### PR TITLE
fix(cdp): B111 — zombie target selection hardening (D643)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.23.1",
+      "version": "0.24.0",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ drivers/
 
 # Workspace symlinks (local dev only)
 scripts/fast-runner/build/
+
+# Local worktrees for isolated feature work
+.worktrees/

--- a/scripts/cdp-bridge/dist/cdp/connect.js
+++ b/scripts/cdp-bridge/dist/cdp/connect.js
@@ -1,5 +1,6 @@
 import WebSocket from 'ws';
 import { logger } from '../logger.js';
+import { resolveBundleId } from '../project-config.js';
 import { discover } from './discovery.js';
 import { sleep } from './state.js';
 import { CDP_TIMEOUT_FAST } from './timeout-config.js';
@@ -16,14 +17,28 @@ export async function autoConnect(ctx, portHint, filters) {
         if (envPlatform && envPlatform !== 'auto')
             effective.platform = envPlatform;
     }
+    // B111 (D643): auto-populate preferredBundleId from project-config so the
+    // smart auto-selection in selectTarget fires for callers that didn't pass
+    // explicit filters. resolveBundleId returns null when no app.json — graceful no-op.
+    if (!effective.preferredBundleId) {
+        const resolved = resolveBundleId(effective.platform ?? 'ios');
+        if (resolved)
+            effective.preferredBundleId = resolved;
+    }
     return discoverAndConnect(ctx, portHint, effective);
 }
-export async function discoverAndConnect(ctx, portHint, filters) {
+export async function discoverAndConnect(ctx, portHint, filters, 
+// B111 (D643): injectable for unit tests — defaults to real discover. Production
+// call sites pass nothing, so behavior is unchanged. Tests pass a stub.
+discoverFn = discover) {
     if (ctx.isDisposed()) {
         throw new Error('Client is disposed. Create a new CDPClient instance.');
     }
     if (portHint)
         ctx.setPort(portHint);
+    // B111 (D643/G7): preserve _connectFilters across softReconnect — only overwrite
+    // when caller explicitly passes filters. softReconnect calls with filters=undefined
+    // so the previously-set targetId/bundleId/preferredBundleId survive the reload.
     if (filters !== undefined)
         ctx.setConnectFilters(filters);
     ctx.setState('connecting');
@@ -36,14 +51,21 @@ export async function discoverAndConnect(ctx, portHint, filters) {
     };
     let result;
     try {
-        result = await discover(ctx.getPort(), filtersForDiscover);
+        result = await discoverFn(ctx.getPort(), filtersForDiscover);
     }
     catch (err) {
         ctx.setState('disconnected');
         throw err;
     }
-    const { port: metroPort, targets: sorted, warning: platformFilterWarning } = result;
+    const { port: metroPort, targets: sorted, warning: selectionWarning } = result;
     ctx.setPort(metroPort);
+    // B111 (D643/G9): selectTarget hard-fails (returns []) on explicit filter
+    // mismatch — surface that as a connect error rather than crashing on the
+    // candidate loop's connectedTarget! non-null assertion below.
+    if (sorted.length === 0) {
+        ctx.setState('disconnected');
+        throw new Error(selectionWarning ?? 'No matching CDP targets found.');
+    }
     let connectedTarget = null;
     for (const candidate of sorted) {
         try {
@@ -73,7 +95,7 @@ export async function discoverAndConnect(ctx, portHint, filters) {
     const generation = ctx.incrementConnectionGeneration();
     logger.info('CDP', `Connected to target ${connectedTarget.id} (${connectedTarget.title}) on port ${metroPort}, generation=${generation}`);
     const msg = `Connected to ${connectedTarget.title} on port ${metroPort}`;
-    return platformFilterWarning ? `${msg}. WARNING: ${platformFilterWarning}` : msg;
+    return selectionWarning ? `${msg}. WARNING: ${selectionWarning}` : msg;
 }
 async function connectToTarget(ctx, target, retries = 5) {
     let lastError = null;

--- a/scripts/cdp-bridge/dist/cdp/discovery.js
+++ b/scripts/cdp-bridge/dist/cdp/discovery.js
@@ -139,25 +139,30 @@ export function selectTarget(validTargets, filtersOrPlatform) {
         : (filtersOrPlatform ?? {});
     let filteredTargets = validTargets;
     const warnings = [];
-    // B111 (D635): targetId is an exact-id filter — highest precedence.
+    // B111 (D643): explicit targetId hard-fails on no match — silent fallthrough
+    // would silently connect the caller to a different target than requested.
     if (filters.targetId) {
         const idMatched = validTargets.filter(t => t.id === filters.targetId);
-        if (idMatched.length > 0) {
-            filteredTargets = idMatched;
+        if (idMatched.length === 0) {
+            return {
+                targets: [],
+                warning: `targetId "${filters.targetId}" not found. Available ids: ${validTargets.map(t => t.id).join(', ')}`,
+            };
         }
-        else {
-            warnings.push(`targetId "${filters.targetId}" matched no targets; ignoring filter. Available ids: ${validTargets.map(t => t.id).join(', ')}`);
-        }
+        filteredTargets = idMatched;
     }
-    // B111 (D635): bundleId matches target.description exactly.
-    if (filters.bundleId && filteredTargets.length > 1) {
-        const bundleMatched = filteredTargets.filter(t => t.description === filters.bundleId);
-        if (bundleMatched.length > 0) {
-            filteredTargets = bundleMatched;
+    // B111 (D643): explicit bundleId hard-fails on no match (case-insensitive).
+    // Runs even with 1 target — single non-matching target is still wrong.
+    if (filters.bundleId) {
+        const bundleLower = filters.bundleId.toLowerCase();
+        const bundleMatched = filteredTargets.filter(t => (t.description ?? '').toLowerCase() === bundleLower);
+        if (bundleMatched.length === 0) {
+            return {
+                targets: [],
+                warning: `bundleId "${filters.bundleId}" not found. Available descriptions: ${filteredTargets.map(t => t.description ?? '?').join(', ')}`,
+            };
         }
-        else {
-            warnings.push(`bundleId "${filters.bundleId}" matched no targets (available descriptions: ${filteredTargets.map(t => t.description ?? '?').join(', ')}); falling through.`);
-        }
+        filteredTargets = bundleMatched;
     }
     if (filters.platform && filteredTargets.length > 1) {
         const pf = filters.platform.toLowerCase();
@@ -175,19 +180,32 @@ export function selectTarget(validTargets, filtersOrPlatform) {
             warnings.push(`Platform filter "${filters.platform}" matched no targets (available: ${filteredTargets.map(t => `${t.description || t.id} [${t.platform ?? '?'}]`).join(', ')}). Connecting to best available target.`);
         }
     }
-    // B111 (D635): smarter auto-selection — when a preferred bundleId exists (e.g. from
-    // project-config.ts), prefer targets whose description matches it. This is a soft
-    // filter: only applied when it narrows without eliminating all candidates.
-    if (filters.preferredBundleId && filteredTargets.length > 1) {
-        const preferred = filteredTargets.filter(t => t.description === filters.preferredBundleId);
+    // B111 (D643): preferredBundleId is a SOFT filter — auto-selection hint
+    // (case-insensitive). Only applied when it narrows without eliminating
+    // all candidates. Auto-populated from project-config.ts in connect.ts.
+    const prefLower = filters.preferredBundleId?.toLowerCase();
+    if (prefLower && filteredTargets.length > 1) {
+        const preferred = filteredTargets.filter(t => (t.description ?? '').toLowerCase() === prefLower);
         if (preferred.length > 0 && preferred.length < filteredTargets.length) {
+            logger.info('CDP', `Auto-selected target by preferredBundleId "${filters.preferredBundleId}" (${preferred.length} of ${filteredTargets.length})`);
             filteredTargets = preferred;
         }
     }
+    // B111 (D643): deterministic sort. Primary: page-id desc (newer first).
+    // Tie-break 1: preferredBundleId-matched targets win.
+    // Tie-break 2: lexicographic by full id (eliminates JS sort stability dependency).
     const sorted = [...filteredTargets].sort((a, b) => {
         const aPage = parseInt(a.id?.split('-')[1] ?? '0', 10);
         const bPage = parseInt(b.id?.split('-')[1] ?? '0', 10);
-        return bPage - aPage;
+        if (aPage !== bPage)
+            return bPage - aPage;
+        if (prefLower) {
+            const aPref = (a.description ?? '').toLowerCase() === prefLower ? 1 : 0;
+            const bPref = (b.description ?? '').toLowerCase() === prefLower ? 1 : 0;
+            if (aPref !== bPref)
+                return bPref - aPref;
+        }
+        return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
     });
     return { targets: sorted, warning: warnings.length > 0 ? warnings.join(' | ') : undefined };
 }

--- a/scripts/cdp-bridge/dist/tools/status.js
+++ b/scripts/cdp-bridge/dist/tools/status.js
@@ -36,7 +36,7 @@ async function buildStatusResult(client) {
     }
     return {
         metro: { running: true, port: client.metroPort },
-        cdp: { connected: client.isConnected, device: client.connectedTarget?.title ?? null, pageId: client.connectedTarget?.id ?? null, platform: client.connectedTarget?.platform ?? null },
+        cdp: { connected: client.isConnected, device: client.connectedTarget?.title ?? null, pageId: client.connectedTarget?.id ?? null, platform: client.connectedTarget?.platform ?? null, bundleId: client.connectedTarget?.description ?? null },
         app: {
             platform: appInfo?.platform ?? null,
             dev: appInfo?.__DEV__ ?? null,
@@ -113,6 +113,7 @@ export function createStatusHandler(getClient, setClient, createClient) {
                                     status.app.isPaused = client.isPaused;
                                     status.cdp.device = client.connectedTarget?.title ?? null;
                                     status.cdp.pageId = client.connectedTarget?.id ?? null;
+                                    status.cdp.bundleId = client.connectedTarget?.description ?? null;
                                     status.capabilities.fiberTree = retryProbe.fiberTree;
                                     devRecovered = true;
                                     autoRecoveredMessage = 'Reconnected to correct JS context';
@@ -138,6 +139,7 @@ export function createStatusHandler(getClient, setClient, createClient) {
                     status.app.isPaused = client.isPaused;
                     status.cdp.device = client.connectedTarget?.title ?? null;
                     status.cdp.pageId = client.connectedTarget?.id ?? null;
+                    status.cdp.bundleId = client.connectedTarget?.description ?? null;
                     if (status.app.isPaused) {
                         return warnResult(status, 'Debugger is still paused after auto-recovery. Try cdp_reload(full=true).');
                     }

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/cdp/connect.ts
+++ b/scripts/cdp-bridge/src/cdp/connect.ts
@@ -1,5 +1,6 @@
 import WebSocket from 'ws';
 import { logger } from '../logger.js';
+import { resolveBundleId } from '../project-config.js';
 import { discover } from './discovery.js';
 import type { SelectTargetFilters } from './discovery.js';
 import { sleep } from './state.js';
@@ -52,6 +53,13 @@ export async function autoConnect(
     const envPlatform = process.env.RN_PREFERRED_PLATFORM;
     if (envPlatform && envPlatform !== 'auto') effective.platform = envPlatform;
   }
+  // B111 (D643): auto-populate preferredBundleId from project-config so the
+  // smart auto-selection in selectTarget fires for callers that didn't pass
+  // explicit filters. resolveBundleId returns null when no app.json — graceful no-op.
+  if (!effective.preferredBundleId) {
+    const resolved = resolveBundleId(effective.platform ?? 'ios');
+    if (resolved) effective.preferredBundleId = resolved;
+  }
   return discoverAndConnect(ctx, portHint, effective);
 }
 
@@ -59,12 +67,18 @@ export async function discoverAndConnect(
   ctx: ConnectContext,
   portHint?: number,
   filters?: ConnectFilters,
+  // B111 (D643): injectable for unit tests — defaults to real discover. Production
+  // call sites pass nothing, so behavior is unchanged. Tests pass a stub.
+  discoverFn: typeof discover = discover,
 ): Promise<string> {
   if (ctx.isDisposed()) {
     throw new Error('Client is disposed. Create a new CDPClient instance.');
   }
 
   if (portHint) ctx.setPort(portHint);
+  // B111 (D643/G7): preserve _connectFilters across softReconnect — only overwrite
+  // when caller explicitly passes filters. softReconnect calls with filters=undefined
+  // so the previously-set targetId/bundleId/preferredBundleId survive the reload.
   if (filters !== undefined) ctx.setConnectFilters(filters);
   ctx.setState('connecting');
 
@@ -78,14 +92,22 @@ export async function discoverAndConnect(
 
   let result;
   try {
-    result = await discover(ctx.getPort(), filtersForDiscover);
+    result = await discoverFn(ctx.getPort(), filtersForDiscover);
   } catch (err) {
     ctx.setState('disconnected');
     throw err;
   }
 
-  const { port: metroPort, targets: sorted, warning: platformFilterWarning } = result;
+  const { port: metroPort, targets: sorted, warning: selectionWarning } = result;
   ctx.setPort(metroPort);
+
+  // B111 (D643/G9): selectTarget hard-fails (returns []) on explicit filter
+  // mismatch — surface that as a connect error rather than crashing on the
+  // candidate loop's connectedTarget! non-null assertion below.
+  if (sorted.length === 0) {
+    ctx.setState('disconnected');
+    throw new Error(selectionWarning ?? 'No matching CDP targets found.');
+  }
 
   let connectedTarget: HermesTarget | null = null;
   for (const candidate of sorted) {
@@ -115,7 +137,7 @@ export async function discoverAndConnect(
   const generation = ctx.incrementConnectionGeneration();
   logger.info('CDP', `Connected to target ${connectedTarget!.id} (${connectedTarget!.title}) on port ${metroPort}, generation=${generation}`);
   const msg = `Connected to ${connectedTarget!.title} on port ${metroPort}`;
-  return platformFilterWarning ? `${msg}. WARNING: ${platformFilterWarning}` : msg;
+  return selectionWarning ? `${msg}. WARNING: ${selectionWarning}` : msg;
 }
 
 async function connectToTarget(

--- a/scripts/cdp-bridge/src/cdp/discovery.ts
+++ b/scripts/cdp-bridge/src/cdp/discovery.ts
@@ -171,24 +171,33 @@ export function selectTarget(
   let filteredTargets = validTargets;
   const warnings: string[] = [];
 
-  // B111 (D635): targetId is an exact-id filter — highest precedence.
+  // B111 (D643): explicit targetId hard-fails on no match — silent fallthrough
+  // would silently connect the caller to a different target than requested.
   if (filters.targetId) {
     const idMatched = validTargets.filter(t => t.id === filters.targetId);
-    if (idMatched.length > 0) {
-      filteredTargets = idMatched;
-    } else {
-      warnings.push(`targetId "${filters.targetId}" matched no targets; ignoring filter. Available ids: ${validTargets.map(t => t.id).join(', ')}`);
+    if (idMatched.length === 0) {
+      return {
+        targets: [],
+        warning: `targetId "${filters.targetId}" not found. Available ids: ${validTargets.map(t => t.id).join(', ')}`,
+      };
     }
+    filteredTargets = idMatched;
   }
 
-  // B111 (D635): bundleId matches target.description exactly.
-  if (filters.bundleId && filteredTargets.length > 1) {
-    const bundleMatched = filteredTargets.filter(t => t.description === filters.bundleId);
-    if (bundleMatched.length > 0) {
-      filteredTargets = bundleMatched;
-    } else {
-      warnings.push(`bundleId "${filters.bundleId}" matched no targets (available descriptions: ${filteredTargets.map(t => t.description ?? '?').join(', ')}); falling through.`);
+  // B111 (D643): explicit bundleId hard-fails on no match (case-insensitive).
+  // Runs even with 1 target — single non-matching target is still wrong.
+  if (filters.bundleId) {
+    const bundleLower = filters.bundleId.toLowerCase();
+    const bundleMatched = filteredTargets.filter(
+      t => (t.description ?? '').toLowerCase() === bundleLower,
+    );
+    if (bundleMatched.length === 0) {
+      return {
+        targets: [],
+        warning: `bundleId "${filters.bundleId}" not found. Available descriptions: ${filteredTargets.map(t => t.description ?? '?').join(', ')}`,
+      };
     }
+    filteredTargets = bundleMatched;
   }
 
   if (filters.platform && filteredTargets.length > 1) {
@@ -207,20 +216,33 @@ export function selectTarget(
     }
   }
 
-  // B111 (D635): smarter auto-selection — when a preferred bundleId exists (e.g. from
-  // project-config.ts), prefer targets whose description matches it. This is a soft
-  // filter: only applied when it narrows without eliminating all candidates.
-  if (filters.preferredBundleId && filteredTargets.length > 1) {
-    const preferred = filteredTargets.filter(t => t.description === filters.preferredBundleId);
+  // B111 (D643): preferredBundleId is a SOFT filter — auto-selection hint
+  // (case-insensitive). Only applied when it narrows without eliminating
+  // all candidates. Auto-populated from project-config.ts in connect.ts.
+  const prefLower = filters.preferredBundleId?.toLowerCase();
+  if (prefLower && filteredTargets.length > 1) {
+    const preferred = filteredTargets.filter(
+      t => (t.description ?? '').toLowerCase() === prefLower,
+    );
     if (preferred.length > 0 && preferred.length < filteredTargets.length) {
+      logger.info('CDP', `Auto-selected target by preferredBundleId "${filters.preferredBundleId}" (${preferred.length} of ${filteredTargets.length})`);
       filteredTargets = preferred;
     }
   }
 
+  // B111 (D643): deterministic sort. Primary: page-id desc (newer first).
+  // Tie-break 1: preferredBundleId-matched targets win.
+  // Tie-break 2: lexicographic by full id (eliminates JS sort stability dependency).
   const sorted = [...filteredTargets].sort((a, b) => {
     const aPage = parseInt(a.id?.split('-')[1] ?? '0', 10);
     const bPage = parseInt(b.id?.split('-')[1] ?? '0', 10);
-    return bPage - aPage;
+    if (aPage !== bPage) return bPage - aPage;
+    if (prefLower) {
+      const aPref = (a.description ?? '').toLowerCase() === prefLower ? 1 : 0;
+      const bPref = (b.description ?? '').toLowerCase() === prefLower ? 1 : 0;
+      if (aPref !== bPref) return bPref - aPref;
+    }
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
   });
 
   return { targets: sorted, warning: warnings.length > 0 ? warnings.join(' | ') : undefined };

--- a/scripts/cdp-bridge/src/tools/status.ts
+++ b/scripts/cdp-bridge/src/tools/status.ts
@@ -47,7 +47,7 @@ async function buildStatusResult(client: CDPClient): Promise<StatusResult> {
 
   return {
     metro: { running: true, port: client.metroPort },
-    cdp: { connected: client.isConnected, device: client.connectedTarget?.title ?? null, pageId: client.connectedTarget?.id ?? null, platform: client.connectedTarget?.platform ?? null },
+    cdp: { connected: client.isConnected, device: client.connectedTarget?.title ?? null, pageId: client.connectedTarget?.id ?? null, platform: client.connectedTarget?.platform ?? null, bundleId: client.connectedTarget?.description ?? null },
     app: {
       platform: (appInfo?.platform as string) ?? null,
       dev: (appInfo?.__DEV__ as boolean) ?? null,
@@ -138,6 +138,7 @@ export function createStatusHandler(
                   status.app.isPaused = client.isPaused;
                   status.cdp.device = client.connectedTarget?.title ?? null;
                   status.cdp.pageId = client.connectedTarget?.id ?? null;
+                  status.cdp.bundleId = client.connectedTarget?.description ?? null;
                   status.capabilities.fiberTree = retryProbe.fiberTree;
                   devRecovered = true;
                   autoRecoveredMessage = 'Reconnected to correct JS context';
@@ -162,6 +163,7 @@ export function createStatusHandler(
           status.app.isPaused = client.isPaused;
           status.cdp.device = client.connectedTarget?.title ?? null;
           status.cdp.pageId = client.connectedTarget?.id ?? null;
+          status.cdp.bundleId = client.connectedTarget?.description ?? null;
           if (status.app.isPaused) {
             return warnResult(status, 'Debugger is still paused after auto-recovery. Try cdp_reload(full=true).');
           }

--- a/scripts/cdp-bridge/src/types.ts
+++ b/scripts/cdp-bridge/src/types.ts
@@ -74,6 +74,8 @@ export interface StatusResult {
     device: string | null;
     pageId: string | null;
     platform: string | null;
+    /** B111 (D643): target.description (bundleId from Metro) — surfaces which app the MCP attached to. */
+    bundleId: string | null;
   };
   app: {
     platform: string | null;

--- a/scripts/cdp-bridge/test/unit/cdp-connect.test.js
+++ b/scripts/cdp-bridge/test/unit/cdp-connect.test.js
@@ -1,0 +1,102 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { discoverAndConnect } from '../../dist/cdp/connect.js';
+
+// Minimal ConnectContext stub — only the methods discoverAndConnect calls
+// before the connectToTarget loop are exercised by these tests. The G9
+// throw exits early on empty `sorted`, so we don't need a real WebSocket.
+function createMockContext({ initialFilters = {}, port = 8081 } = {}) {
+  const state = {
+    disposed: false,
+    port,
+    connectFilters: { ...initialFilters },
+    currentState: 'disconnected',
+    setConnectFiltersCalled: false,
+    setStateCalls: [],
+  };
+  const ctx = {
+    isDisposed: () => state.disposed,
+    isReconnecting: () => false,
+    isSoftReconnectRequested: () => false,
+    getState: () => state.currentState,
+    setState: (s) => { state.currentState = s; state.setStateCalls.push(s); },
+    getPort: () => state.port,
+    setPort: (v) => { state.port = v; },
+    getConnectFilters: () => state.connectFilters,
+    setConnectFilters: (v) => { state.connectFilters = v; state.setConnectFiltersCalled = true; },
+    getWs: () => null,
+    setWs: () => {},
+    setHelpersInjected: () => {},
+    setConnectedTarget: () => {},
+    incrementConnectionGeneration: () => 1,
+    evaluate: async () => ({ value: undefined }),
+    sendWithTimeout: async () => null,
+    handleMessage: () => {},
+    handleClose: () => {},
+    rejectAllPending: () => {},
+    setup: async () => {},
+  };
+  return { state, ctx };
+}
+
+// ── B111 / D643 / G9: discoverAndConnect throws on empty target list ──
+
+test('discoverAndConnect: throws with selectionWarning when discover returns [] (B111/D643/G9)', async () => {
+  const { state, ctx } = createMockContext({ port: 8081 });
+  const mockDiscover = async () => ({
+    port: 8081,
+    targets: [],
+    warning: 'targetId "phantom-99" not found. Available ids: real-1, real-2',
+  });
+  await assert.rejects(
+    () => discoverAndConnect(ctx, undefined, undefined, mockDiscover),
+    /targetId "phantom-99" not found/,
+  );
+  // State must be left clean for the reconnect loop / caller error handling
+  assert.equal(state.currentState, 'disconnected');
+  assert.ok(state.setStateCalls.includes('disconnected'), 'setState("disconnected") must be called before throw');
+});
+
+test('discoverAndConnect: throws with default message when discover returns [] without warning (B111/D643/G9)', async () => {
+  const { ctx } = createMockContext();
+  const mockDiscover = async () => ({ port: 8081, targets: [], warning: undefined });
+  await assert.rejects(
+    () => discoverAndConnect(ctx, undefined, undefined, mockDiscover),
+    /No matching CDP targets found/,
+  );
+});
+
+// ── B111 / D643 / G7: filters preserved across no-filters call (softReconnect path) ──
+
+test('discoverAndConnect: filters=undefined preserves stored _connectFilters (B111/D643/G7)', async () => {
+  // Simulates softReconnect — previously-set filters must survive a no-args reconnect call.
+  const { state, ctx } = createMockContext({
+    initialFilters: { bundleId: 'com.persisted', targetId: 'page-1' },
+  });
+  let observedFilters;
+  const mockDiscover = async (_port, filters) => {
+    observedFilters = filters;
+    return { port: 8081, targets: [], warning: 'observable-stop' };
+  };
+  await assert.rejects(
+    () => discoverAndConnect(ctx, undefined, undefined, mockDiscover),
+    /observable-stop/,
+  );
+  // The stored bundleId+targetId must have been forwarded to discover via getConnectFilters
+  assert.equal(observedFilters.bundleId, 'com.persisted');
+  assert.equal(observedFilters.targetId, 'page-1');
+  // setConnectFilters must NOT have been called — undefined is the "preserve" signal
+  assert.equal(state.setConnectFiltersCalled, false);
+});
+
+test('discoverAndConnect: explicit filters overwrite _connectFilters (B111/D643/G7)', async () => {
+  const { state, ctx } = createMockContext({ initialFilters: { bundleId: 'com.old' } });
+  const newFilters = { bundleId: 'com.new', targetId: 'page-9' };
+  const mockDiscover = async () => ({ port: 8081, targets: [], warning: 'observable-stop' });
+  await assert.rejects(
+    () => discoverAndConnect(ctx, undefined, newFilters, mockDiscover),
+    /observable-stop/,
+  );
+  assert.equal(state.setConnectFiltersCalled, true);
+  assert.deepEqual(state.connectFilters, newFilters);
+});

--- a/scripts/cdp-bridge/test/unit/cdp-discovery.test.js
+++ b/scripts/cdp-bridge/test/unit/cdp-discovery.test.js
@@ -108,15 +108,17 @@ test('selectTarget with targetId returns only the exact-id match', () => {
   assert.equal(warning, undefined);
 });
 
-test('selectTarget with unknown targetId falls through with warning', () => {
+test('selectTarget with unknown targetId hard-fails (B111/D643: was silent fallthrough)', () => {
   const targets = [
     { id: '008aba-1', platform: 'ios', description: 'host.exp.Exponent' },
     { id: '6f8d21-2', platform: 'ios', description: 'com.rndevagent.testapp' },
   ];
   const { targets: sorted, warning } = selectTarget(targets, { targetId: 'does-not-exist' });
-  assert.equal(sorted.length, 2); // fell back to all
+  assert.equal(sorted.length, 0);
   assert.ok(warning);
-  assert.match(warning, /targetId "does-not-exist" matched no targets/);
+  assert.match(warning, /targetId "does-not-exist" not found/);
+  assert.match(warning, /008aba-1/);
+  assert.match(warning, /6f8d21-2/);
 });
 
 test('selectTarget with bundleId filters zombie targets out', () => {
@@ -133,15 +135,16 @@ test('selectTarget with bundleId filters zombie targets out', () => {
   assert.equal(sorted[0].id, '6f8d21-2');
 });
 
-test('selectTarget with unknown bundleId falls through with warning', () => {
+test('selectTarget with unknown bundleId hard-fails (B111/D643: was silent fallthrough)', () => {
   const targets = [
     { id: '6f8d21-1', platform: 'ios', description: 'com.rndevagent.testapp' },
     { id: '6f8d21-2', platform: 'ios', description: 'com.rndevagent.testapp' },
   ];
   const { targets: sorted, warning } = selectTarget(targets, { bundleId: 'com.different.app' });
-  assert.equal(sorted.length, 2);
+  assert.equal(sorted.length, 0);
   assert.ok(warning);
-  assert.match(warning, /bundleId "com.different.app" matched no targets/);
+  assert.match(warning, /bundleId "com.different.app" not found/);
+  assert.match(warning, /com.rndevagent.testapp/);
 });
 
 test('selectTarget preferredBundleId is soft filter — only applies when it narrows', () => {
@@ -180,6 +183,81 @@ test('selectTarget: legacy string signature still works', () => {
   const { targets: sorted } = selectTarget(targets, 'ios');
   assert.equal(sorted.length, 1);
   assert.equal(sorted[0].id, '1');
+});
+
+// ── B111 / D643: zombie target hardening (Phase 91) ───────────────────
+
+test('selectTarget: bundleId hard-fails on single-target mismatch (B111/D643)', () => {
+  // Pre-D643, the bundleId check was guarded by `length > 1` and silently
+  // skipped this case — connecting to the wrong app. Now hard-fails.
+  const targets = [
+    { id: 'aaa-1', platform: 'ios', description: 'com.zombie.app' },
+  ];
+  const { targets: sorted, warning } = selectTarget(targets, { bundleId: 'com.realapp' });
+  assert.equal(sorted.length, 0);
+  assert.match(warning, /bundleId "com.realapp" not found/);
+  assert.match(warning, /com.zombie.app/);
+});
+
+test('selectTarget: bundleId match is case-insensitive (B111/D643/G4)', () => {
+  const targets = [
+    { id: 'aaa-1', platform: 'ios', description: 'host.exp.Exponent' },
+    { id: 'bbb-1', platform: 'ios', description: 'host.exp.exponent' },
+  ];
+  const { targets: sorted } = selectTarget(targets, { bundleId: 'HOST.EXP.EXPONENT' });
+  assert.equal(sorted.length, 2);
+  assert.ok(sorted.every(t => t.description?.toLowerCase() === 'host.exp.exponent'));
+});
+
+test('selectTarget: preferredBundleId match is case-insensitive (B111/D643/G4)', () => {
+  const targets = [
+    { id: 'aaa-1', platform: 'ios', description: 'HOST.EXP.EXPONENT' },
+    { id: 'bbb-1', platform: 'ios', description: 'com.myapp' },
+  ];
+  const { targets: sorted } = selectTarget(targets, { preferredBundleId: 'host.exp.exponent' });
+  assert.equal(sorted.length, 1);
+  assert.equal(sorted[0].id, 'aaa-1');
+});
+
+test('selectTarget: zombie tie-break — preferredBundleId picks fresh over zombie at equal page (B111/D643/G3)', () => {
+  // Core B111 regression. Both targets have page-id `1` so the numeric sort
+  // is a tie. Without preferredBundleId, JS sort stability dictates which wins —
+  // a flake. With preferredBundleId pointing at the real app, fresh always wins.
+  const targets = [
+    { id: 'aaaaaaa-1', platform: 'ios', description: 'host.exp.Exponent', title: 'Hermes' },
+    { id: 'bbbbbbb-1', platform: 'ios', description: 'com.myapp', title: 'Hermes' },
+  ];
+  const { targets: sorted } = selectTarget(targets, { preferredBundleId: 'com.myapp' });
+  assert.equal(sorted[0].description, 'com.myapp');
+  // narrowed via soft filter — only matching target survives
+  assert.equal(sorted.length, 1);
+});
+
+test('selectTarget: lexicographic id tie-break is deterministic when no preferredBundleId (B111/D643/G5)', () => {
+  // Same page-id, no preferredBundleId — fall back to ascending lex by full id
+  // for a stable, repeatable result. This is determinism, not zombie-avoidance
+  // (zombie-avoidance is preferredBundleId's job — see G3 above).
+  const targets = [
+    { id: 'zzz-5', platform: 'ios', description: 'com.appA' },
+    { id: 'aaa-5', platform: 'ios', description: 'com.appB' },
+  ];
+  const { targets: sorted } = selectTarget(targets);
+  assert.equal(sorted.length, 2);
+  // ascending lex by id: 'aaa-5' before 'zzz-5'
+  assert.equal(sorted[0].id, 'aaa-5');
+  assert.equal(sorted[1].id, 'zzz-5');
+});
+
+test('selectTarget: warning includes available ids when targetId not found (B111/D643/G9)', () => {
+  const targets = [
+    { id: 'real-1', platform: 'ios', description: 'com.app' },
+    { id: 'real-2', platform: 'ios', description: 'com.app' },
+  ];
+  const { targets: sorted, warning } = selectTarget(targets, { targetId: 'phantom-99' });
+  assert.equal(sorted.length, 0);
+  assert.ok(warning);
+  // Caller-actionable: tells them what's actually available
+  assert.match(warning, /Available ids: real-1, real-2/);
 });
 
 // ── B116 / D639: platform inference via simctl listapps + adb pm list ──


### PR DESCRIPTION
## Summary

- **B111** (critical, silent data corruption): `selectTarget` silently picked zombie Hermes targets over the live app when multiple targets shared the same page-id and platform — common with Expo Dev Client where `host.exp.Exponent` zombies linger alongside live `com.<bundleId>` targets. Every CDP tool returned plausible-but-stale data while the visible UI was on a different app.
- **Six surgical changes** to `selectTarget` + `autoConnect` + `discoverAndConnect` + `cdp_status` (G1, G2, G4, G5, G6, G7, G9 — see commit body for the breakdown).
- **Tests**: 249 → 259 passing, 0 failing. Multi-review (Gemini + Codex) found 0 high-confidence issues.
- **Versions**: plugin `0.23.0` → `0.24.0`, MCP server `0.18.0` → `0.19.0` (MINOR — adds `cdp.bundleId` field + behavior change on explicit filter mismatch).

## What changed

| Gap | Change | File |
|---|---|---|
| G1 | Hard-fail on explicit `targetId`/`bundleId` mismatch — returns `targets:[]` + actionable warning listing available ids/descriptions. Removed `length>1` guard so single-target zombie cases also fail loud. | `discovery.ts` |
| G2 | `autoConnect` auto-populates `preferredBundleId` from `resolveBundleId(platform)`. Graceful no-op when no app.json. | `connect.ts` |
| G4 | Case-insensitive bundleId/preferredBundleId match (fixes Expo Go `host.exp.exponent` variance). | `discovery.ts` |
| G5 | Deterministic sort tie-break: page-id desc → preferredBundleId-matched first → ascending lex by full id. Eliminates JS sort-stability dependency. | `discovery.ts` |
| G6 | `cdp.bundleId` (target.description) added to `cdp_status` output. Populated in initial build + 2 recovery branches. | `types.ts`, `tools/status.ts` |
| G7 | Confirmed `_connectFilters` survives `softReconnect` via existing `if(filters!==undefined)` guard. Inline comment + 2 dedicated tests. | `connect.ts`, `cdp-connect.test.js` |
| G9 | `discoverAndConnect` throws cleanly on `selectTarget` returning empty. `setState('disconnected')` runs first. Variable rename `platformFilterWarning` → `selectionWarning`. | `connect.ts` |

Added optional `discoverFn` parameter to `discoverAndConnect` (defaults to `discover`) for unit-testability of the throw-on-empty path. Zero behavior change at production call sites.

## Test plan

- [x] `npm run test` — 259 / 259 passing (was 249 baseline; +10 new tests, 2 updated assertions). `npm run build` — 0 TypeScript errors.
- [x] **Live smoke** on iOS Simulator with Expo Dev Client zombie+live scenario:
  - [x] Gate 1: `cdp_status` exposes `cdp.bundleId: "com.rndevagent.testapp"` ✅
  - [x] Gate 2: `cdp_connect({targetId: "phantom-99"})` rejected with `targetId "phantom-99" not found. Available ids: ...` listing real targets ✅
  - [x] Gate 3: `cdp_connect({bundleId: "com.fake.app"})` rejected with `bundleId "com.fake.app" not found. Available descriptions: ...` ✅
  - [x] Gate 4: `cdp_connect()` (no filters) consistently picks the live target via auto-populated `preferredBundleId`; live-verified via `cdp_evaluate` (Hermes + `__RN_AGENT` injected) ✅
- [x] Multi-review (Gemini + Codex, parallel) — 0 high-confidence issues, both reviewers explicitly said "ship it"
- [x] Sort tie-break is deterministic (lex ascending by full id when page-id and preferredBundleId match) — covered by `T-G5`
- [x] Single-target zombie scenario hard-fails (the most subtle pre-existing bug surface) — covered by `T-G1c`

## Behavioral change (non-breaking in practice, MINOR semver)

Callers of `cdp_connect` that previously passed an `targetId` or `bundleId` that did NOT match any live target now see an explicit error instead of silently connecting to whatever target sorted first. This is the intended fix for B111 — the silent fallthrough was the bug. Any caller relying on the old behavior was already getting wrong data.

## Proof

Detailed proof artifacts at `rn-dev-agent-workspace/docs/proof/b111-zombie-target-selection/` (separate workspace repo): `PROOF.md`, `test-output.txt` (full 259-test pass output), `before-after-trace.json` (8-scenario `selectTarget` trace on the zombie fixture).