### PR TITLE
fix(mcp): B76 + zombie prevention — unified lifecycle (D644)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.23.0",
+      "version": "0.25.0",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.23.0",
+  "version": "0.25.0",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/scripts/cdp-bridge/dist/cdp-client.js
+++ b/scripts/cdp-bridge/dist/cdp-client.js
@@ -101,6 +101,11 @@ export class CDPClient {
         return softReconnectFn(this.buildReconnectCtx());
     }
     async disconnect() {
+        // B76/D644: idempotent guard — graceful-shutdown may race with a tool-triggered
+        // disconnect (e.g. cdp_restart calling disconnect() while SIGTERM fires). Second
+        // caller sees already-disposed and returns cleanly.
+        if (this.disposed)
+            return;
         this.disposed = true;
         resetState(this.buildResettableState());
         clearActiveFlag();

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -38,6 +38,8 @@ import { createDeviceBatchHandler } from './tools/device-batch.js';
 import { handleAutoLogin } from './tools/auto-login.js';
 import { createProofStepHandler } from './tools/proof-step.js';
 import { createConnectHandler, createDisconnectHandler, createTargetsHandler } from './tools/connection.js';
+import { createRestartHandler } from './tools/restart.js';
+import { buildGracefulShutdown } from './lifecycle/graceful-shutdown.js';
 import { createMaestroRunHandler } from './tools/maestro-run.js';
 import { createMaestroGenerateHandler } from './tools/maestro-generate.js';
 import { createMaestroTestAllHandler } from './tools/maestro-test-all.js';
@@ -439,25 +441,43 @@ trackedTool('maestro_test_all', 'Discover and run all Maestro flows in .maestro/
     timeoutPerFlow: z.number().int().min(5000).max(300000).default(120000).describe('Timeout per flow in ms'),
     stopOnFailure: z.boolean().default(false).describe('Stop after first failure'),
 }, createMaestroTestAllHandler());
+trackedTool('cdp_restart', 'In-process soft state reset (B76/D644). Disconnects the current CDP client, creates a fresh instance, and reconnects. Clears console/network/error ring buffers, background poll, reconnect state, and helpers-injected flag. Does NOT reload the MCP server binary — to load new dist/ after npm run build, fully quit and relaunch Claude Code. Useful for recovering from stuck connection state (target drift, stale helpers after many reloads) without losing the CC session.', {
+    metroPort: z.number().optional().describe('Override Metro port for reconnection (default: keep current)'),
+    platform: z.string().optional().describe('Platform filter for reconnection (e.g. "ios", "android")'),
+}, createRestartHandler(getClient, setClient, createClient));
 trackedTool('cross_platform_verify', 'Compare UI elements across iOS and Android. Reads cached accessibility snapshots from both platforms (populated by device_snapshot) and checks which elements are present on each. Workflow: test on iOS → device_snapshot → switch to Android → device_snapshot → cross_platform_verify. Supports auto-discovery of testIDs from source via scanDir. Returns a per-element comparison table with PASS/FAIL verdict.', {
     elements: z.array(z.string()).optional().describe('List of testIDs or labels to check on both platforms. Optional if scanDir is provided.'),
     scanDir: z.string().optional().describe('Directory to scan for testID="..." props in .tsx/.jsx/.ts/.js files. Auto-discovers elements. Merges with elements[] if both provided.'),
     matchBy: z.enum(['testID', 'label', 'any']).default('any').describe('Match strategy: testID (exact identifier match), label (substring in accessibility label), any (try both)'),
 }, createCrossPlatformVerifyHandler());
+// B76/D644: unified process-lifecycle shutdown. All termination signals + stdin.end
+// funnel into this graceful path so the 5s background-poll setInterval in
+// reconnection.ts (the zombie cause) is cleared on every exit.
+const shutdown = buildGracefulShutdown({ getClient, stopFastRunnerFn: stopFastRunner });
 process.on('uncaughtException', (err) => {
     logger.error('MCP', `Uncaught exception: ${err.message}`);
-    stopFastRunner();
-    process.exit(1);
+    void shutdown(1);
 });
 process.on('unhandledRejection', (reason) => {
     const msg = reason instanceof Error ? reason.message : String(reason);
     logger.warn('MCP', `Unhandled rejection (non-fatal): ${msg}`);
 });
-process.on('SIGTERM', () => {
-    logger.info('MCP', 'SIGTERM received, shutting down');
-    stopFastRunner();
-    process.exit(0);
-});
+process.on('SIGTERM', () => { logger.info('MCP', 'SIGTERM'); void shutdown(0); });
+process.on('SIGINT', () => { logger.info('MCP', 'SIGINT'); void shutdown(0); });
+process.on('SIGHUP', () => { logger.info('MCP', 'SIGHUP'); void shutdown(0); });
+// SIGUSR2: hot-reload intent — exit 1 signals a supervisor to respawn. Today CC
+// doesn't auto-respawn MCP subprocesses (B76 notes) so this is the clean-exit path
+// for future supervisor wiring. Developers should use cdp_restart for in-session reset.
+// NOTE: we deliberately avoid SIGUSR1 here because Node reserves it for the built-in
+// inspector — running the MCP under `node --inspect` would both start the debugger
+// AND trigger our shutdown. SIGUSR2 is collision-free.
+process.on('SIGUSR2', () => { logger.info('MCP', 'SIGUSR2 — hot-reload intent'); void shutdown(1); });
+// stdin.end is the primary zombie-prevention path: CC closes the stdio pipe on quit
+// without sending SIGTERM, and the 5s bgPoll interval would keep the event loop alive
+// forever. Explicitly shut down on stdin EOF. The listener itself is registered early
+// (passive — doesn't flip stdin into flowing mode); StdioServerTransport flips the
+// stream inside transport.start() when server.connect() runs, so 'end' fires reliably.
+process.stdin.on('end', () => { logger.info('MCP', 'stdin closed — host disconnected'); void shutdown(0); });
 async function main() {
     logger.info('MCP', `Starting rn-dev-agent-cdp v0.9.1 (log level: ${logger.level})`);
     if (logger.logFilePath) {

--- a/scripts/cdp-bridge/dist/lifecycle/graceful-shutdown.js
+++ b/scripts/cdp-bridge/dist/lifecycle/graceful-shutdown.js
@@ -35,13 +35,16 @@ export function buildGracefulShutdown(deps) {
                 logger.warn('MCP', `shutdown: stopFastRunner failed: ${err instanceof Error ? err.message : err}`);
             }
         })();
+        // Timeout is NOT unref'd: it must keep the event loop alive so it can fire
+        // even if no other work is pending (otherwise Node would exit the loop while
+        // cleanup is still pending, and process.exit never runs). The timer is always
+        // cleared on the happy path so it doesn't block shutdown when cleanup wins.
         let timeoutHandle = null;
         const timeout = new Promise((resolve) => {
             timeoutHandle = setTimeout(() => {
                 logger.warn('MCP', `shutdown: cleanup timeout after ${timeoutMs}ms, forcing exit`);
                 resolve();
             }, timeoutMs);
-            timeoutHandle.unref();
         });
         await Promise.race([cleanup, timeout]);
         if (timeoutHandle)

--- a/scripts/cdp-bridge/dist/lifecycle/graceful-shutdown.js
+++ b/scripts/cdp-bridge/dist/lifecycle/graceful-shutdown.js
@@ -1,0 +1,51 @@
+import { logger } from '../logger.js';
+const DEFAULT_TIMEOUT_MS = 3000;
+/**
+ * Factory for the process-lifecycle shutdown path. B73/B76/zombie-cleanup (D644).
+ *
+ * All termination signals + stdin.end funnel into the returned `shutdown(exitCode)`:
+ *   1. Guard against re-entry (idempotent — multiple simultaneous signals collapse to one run).
+ *   2. Disconnect the CDPClient — internally clears the 5s background poll setInterval
+ *      (the root cause of MCP zombies surviving parent CC quit) and closes the WebSocket.
+ *   3. Stop the fast-runner child process (xcodebuild).
+ *   4. Race cleanup against DEFAULT_TIMEOUT_MS — if cleanup hangs, force-exit anyway so
+ *      the parent CC session never waits on a stuck MCP.
+ *
+ * `exitFn` is injectable so tests can observe the exit code without killing the test runner.
+ */
+export function buildGracefulShutdown(deps) {
+    const exitFn = deps.exitFn ?? ((code) => process.exit(code));
+    const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    let shuttingDown = false;
+    return async function shutdown(exitCode) {
+        if (shuttingDown)
+            return;
+        shuttingDown = true;
+        const cleanup = (async () => {
+            try {
+                await deps.getClient().disconnect();
+            }
+            catch (err) {
+                logger.warn('MCP', `shutdown: disconnect failed: ${err instanceof Error ? err.message : err}`);
+            }
+            try {
+                deps.stopFastRunnerFn();
+            }
+            catch (err) {
+                logger.warn('MCP', `shutdown: stopFastRunner failed: ${err instanceof Error ? err.message : err}`);
+            }
+        })();
+        let timeoutHandle = null;
+        const timeout = new Promise((resolve) => {
+            timeoutHandle = setTimeout(() => {
+                logger.warn('MCP', `shutdown: cleanup timeout after ${timeoutMs}ms, forcing exit`);
+                resolve();
+            }, timeoutMs);
+            timeoutHandle.unref();
+        });
+        await Promise.race([cleanup, timeout]);
+        if (timeoutHandle)
+            clearTimeout(timeoutHandle);
+        exitFn(exitCode);
+    };
+}

--- a/scripts/cdp-bridge/dist/tools/restart.js
+++ b/scripts/cdp-bridge/dist/tools/restart.js
@@ -1,0 +1,49 @@
+import { logger } from '../logger.js';
+import { okResult, failResult } from '../utils.js';
+/**
+ * cdp_restart — in-process soft state reset (B76/D644).
+ *
+ * Disconnects the current CDPClient (clears WebSocket, ring buffers, background poll,
+ * reconnect state), creates a fresh instance, and attempts to reconnect. The MCP server
+ * process is NOT restarted — for new dist/ code after npm run build, the caller must
+ * fully quit and relaunch Claude Code.
+ *
+ * Useful for recovering from stuck connection state (e.g., target drift, helpers stale
+ * after many reloads) without losing the CC session.
+ */
+export function createRestartHandler(getClient, setClient, createClient) {
+    return async (args) => {
+        try {
+            logger.info('MCP', 'cdp_restart: in-process state reset requested');
+            const oldClient = getClient();
+            const preservedPort = oldClient.metroPort;
+            try {
+                await oldClient.disconnect();
+            }
+            catch (err) {
+                logger.warn('MCP', `cdp_restart: old client disconnect failed (non-fatal): ${err instanceof Error ? err.message : err}`);
+            }
+            const newClient = createClient(args.metroPort ?? preservedPort);
+            setClient(newClient);
+            let connected = false;
+            let connectError;
+            try {
+                await newClient.autoConnect(args.metroPort, args.platform);
+                connected = newClient.isConnected;
+            }
+            catch (err) {
+                connectError = err instanceof Error ? err.message : String(err);
+                logger.warn('MCP', `cdp_restart: autoConnect failed (best-effort): ${connectError}`);
+            }
+            return okResult({
+                restarted: true,
+                connected,
+                port: newClient.metroPort,
+                ...(connectError ? { connectError } : {}),
+            });
+        }
+        catch (err) {
+            return failResult(err instanceof Error ? err.message : String(err));
+        }
+    };
+}

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.18.0",
+  "version": "0.20.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/cdp-client.ts
+++ b/scripts/cdp-bridge/src/cdp-client.ts
@@ -139,6 +139,10 @@ export class CDPClient {
   }
 
   async disconnect(): Promise<void> {
+    // B76/D644: idempotent guard — graceful-shutdown may race with a tool-triggered
+    // disconnect (e.g. cdp_restart calling disconnect() while SIGTERM fires). Second
+    // caller sees already-disposed and returns cleanly.
+    if (this.disposed) return;
     this.disposed = true;
     resetState(this.buildResettableState());
     clearActiveFlag();

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -55,6 +55,8 @@ import { createDeviceBatchHandler } from './tools/device-batch.js';
 import { handleAutoLogin } from './tools/auto-login.js';
 import { createProofStepHandler } from './tools/proof-step.js';
 import { createConnectHandler, createDisconnectHandler, createTargetsHandler } from './tools/connection.js';
+import { createRestartHandler } from './tools/restart.js';
+import { buildGracefulShutdown } from './lifecycle/graceful-shutdown.js';
 import { createMaestroRunHandler } from './tools/maestro-run.js';
 import { createMaestroGenerateHandler } from './tools/maestro-generate.js';
 import { createMaestroTestAllHandler } from './tools/maestro-test-all.js';
@@ -747,6 +749,16 @@ trackedTool(
 );
 
 trackedTool(
+  'cdp_restart',
+  'In-process soft state reset (B76/D644). Disconnects the current CDP client, creates a fresh instance, and reconnects. Clears console/network/error ring buffers, background poll, reconnect state, and helpers-injected flag. Does NOT reload the MCP server binary — to load new dist/ after npm run build, fully quit and relaunch Claude Code. Useful for recovering from stuck connection state (target drift, stale helpers after many reloads) without losing the CC session.',
+  {
+    metroPort: z.number().optional().describe('Override Metro port for reconnection (default: keep current)'),
+    platform: z.string().optional().describe('Platform filter for reconnection (e.g. "ios", "android")'),
+  },
+  createRestartHandler(getClient, setClient, createClient),
+);
+
+trackedTool(
   'cross_platform_verify',
   'Compare UI elements across iOS and Android. Reads cached accessibility snapshots from both platforms (populated by device_snapshot) and checks which elements are present on each. Workflow: test on iOS → device_snapshot → switch to Android → device_snapshot → cross_platform_verify. Supports auto-discovery of testIDs from source via scanDir. Returns a per-element comparison table with PASS/FAIL verdict.',
   {
@@ -757,10 +769,14 @@ trackedTool(
   createCrossPlatformVerifyHandler(),
 );
 
+// B76/D644: unified process-lifecycle shutdown. All termination signals + stdin.end
+// funnel into this graceful path so the 5s background-poll setInterval in
+// reconnection.ts (the zombie cause) is cleared on every exit.
+const shutdown = buildGracefulShutdown({ getClient, stopFastRunnerFn: stopFastRunner });
+
 process.on('uncaughtException', (err: Error) => {
   logger.error('MCP', `Uncaught exception: ${err.message}`);
-  stopFastRunner();
-  process.exit(1);
+  void shutdown(1);
 });
 
 process.on('unhandledRejection', (reason: unknown) => {
@@ -768,11 +784,23 @@ process.on('unhandledRejection', (reason: unknown) => {
   logger.warn('MCP', `Unhandled rejection (non-fatal): ${msg}`);
 });
 
-process.on('SIGTERM', () => {
-  logger.info('MCP', 'SIGTERM received, shutting down');
-  stopFastRunner();
-  process.exit(0);
-});
+process.on('SIGTERM', () => { logger.info('MCP', 'SIGTERM'); void shutdown(0); });
+process.on('SIGINT',  () => { logger.info('MCP', 'SIGINT');  void shutdown(0); });
+process.on('SIGHUP',  () => { logger.info('MCP', 'SIGHUP');  void shutdown(0); });
+// SIGUSR2: hot-reload intent — exit 1 signals a supervisor to respawn. Today CC
+// doesn't auto-respawn MCP subprocesses (B76 notes) so this is the clean-exit path
+// for future supervisor wiring. Developers should use cdp_restart for in-session reset.
+// NOTE: we deliberately avoid SIGUSR1 here because Node reserves it for the built-in
+// inspector — running the MCP under `node --inspect` would both start the debugger
+// AND trigger our shutdown. SIGUSR2 is collision-free.
+process.on('SIGUSR2', () => { logger.info('MCP', 'SIGUSR2 — hot-reload intent'); void shutdown(1); });
+
+// stdin.end is the primary zombie-prevention path: CC closes the stdio pipe on quit
+// without sending SIGTERM, and the 5s bgPoll interval would keep the event loop alive
+// forever. Explicitly shut down on stdin EOF. The listener itself is registered early
+// (passive — doesn't flip stdin into flowing mode); StdioServerTransport flips the
+// stream inside transport.start() when server.connect() runs, so 'end' fires reliably.
+process.stdin.on('end', () => { logger.info('MCP', 'stdin closed — host disconnected'); void shutdown(0); });
 
 async function main() {
   logger.info('MCP', `Starting rn-dev-agent-cdp v0.9.1 (log level: ${logger.level})`);

--- a/scripts/cdp-bridge/src/lifecycle/graceful-shutdown.ts
+++ b/scripts/cdp-bridge/src/lifecycle/graceful-shutdown.ts
@@ -45,13 +45,16 @@ export function buildGracefulShutdown(deps: GracefulShutdownDeps): (exitCode: nu
       }
     })();
 
+    // Timeout is NOT unref'd: it must keep the event loop alive so it can fire
+    // even if no other work is pending (otherwise Node would exit the loop while
+    // cleanup is still pending, and process.exit never runs). The timer is always
+    // cleared on the happy path so it doesn't block shutdown when cleanup wins.
     let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
     const timeout = new Promise<void>((resolve) => {
       timeoutHandle = setTimeout(() => {
         logger.warn('MCP', `shutdown: cleanup timeout after ${timeoutMs}ms, forcing exit`);
         resolve();
       }, timeoutMs);
-      timeoutHandle.unref();
     });
 
     await Promise.race([cleanup, timeout]);

--- a/scripts/cdp-bridge/src/lifecycle/graceful-shutdown.ts
+++ b/scripts/cdp-bridge/src/lifecycle/graceful-shutdown.ts
@@ -1,0 +1,61 @@
+import type { CDPClient } from '../cdp-client.js';
+import { logger } from '../logger.js';
+
+const DEFAULT_TIMEOUT_MS = 3000;
+
+export interface GracefulShutdownDeps {
+  getClient: () => CDPClient;
+  stopFastRunnerFn: () => void;
+  exitFn?: (code: number) => never;
+  timeoutMs?: number;
+}
+
+/**
+ * Factory for the process-lifecycle shutdown path. B73/B76/zombie-cleanup (D644).
+ *
+ * All termination signals + stdin.end funnel into the returned `shutdown(exitCode)`:
+ *   1. Guard against re-entry (idempotent — multiple simultaneous signals collapse to one run).
+ *   2. Disconnect the CDPClient — internally clears the 5s background poll setInterval
+ *      (the root cause of MCP zombies surviving parent CC quit) and closes the WebSocket.
+ *   3. Stop the fast-runner child process (xcodebuild).
+ *   4. Race cleanup against DEFAULT_TIMEOUT_MS — if cleanup hangs, force-exit anyway so
+ *      the parent CC session never waits on a stuck MCP.
+ *
+ * `exitFn` is injectable so tests can observe the exit code without killing the test runner.
+ */
+export function buildGracefulShutdown(deps: GracefulShutdownDeps): (exitCode: number) => Promise<void> {
+  const exitFn = deps.exitFn ?? ((code: number) => process.exit(code));
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  let shuttingDown = false;
+
+  return async function shutdown(exitCode: number): Promise<void> {
+    if (shuttingDown) return;
+    shuttingDown = true;
+
+    const cleanup = (async () => {
+      try {
+        await deps.getClient().disconnect();
+      } catch (err) {
+        logger.warn('MCP', `shutdown: disconnect failed: ${err instanceof Error ? err.message : err}`);
+      }
+      try {
+        deps.stopFastRunnerFn();
+      } catch (err) {
+        logger.warn('MCP', `shutdown: stopFastRunner failed: ${err instanceof Error ? err.message : err}`);
+      }
+    })();
+
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+    const timeout = new Promise<void>((resolve) => {
+      timeoutHandle = setTimeout(() => {
+        logger.warn('MCP', `shutdown: cleanup timeout after ${timeoutMs}ms, forcing exit`);
+        resolve();
+      }, timeoutMs);
+      timeoutHandle.unref();
+    });
+
+    await Promise.race([cleanup, timeout]);
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+    exitFn(exitCode);
+  };
+}

--- a/scripts/cdp-bridge/src/tools/restart.ts
+++ b/scripts/cdp-bridge/src/tools/restart.ts
@@ -1,0 +1,61 @@
+import type { CDPClient } from '../cdp-client.js';
+import { logger } from '../logger.js';
+import { okResult, failResult } from '../utils.js';
+
+export interface RestartArgs {
+  metroPort?: number;
+  platform?: string;
+}
+
+/**
+ * cdp_restart — in-process soft state reset (B76/D644).
+ *
+ * Disconnects the current CDPClient (clears WebSocket, ring buffers, background poll,
+ * reconnect state), creates a fresh instance, and attempts to reconnect. The MCP server
+ * process is NOT restarted — for new dist/ code after npm run build, the caller must
+ * fully quit and relaunch Claude Code.
+ *
+ * Useful for recovering from stuck connection state (e.g., target drift, helpers stale
+ * after many reloads) without losing the CC session.
+ */
+export function createRestartHandler(
+  getClient: () => CDPClient,
+  setClient: (c: CDPClient) => void,
+  createClient: (port: number) => CDPClient,
+) {
+  return async (args: RestartArgs) => {
+    try {
+      logger.info('MCP', 'cdp_restart: in-process state reset requested');
+      const oldClient = getClient();
+      const preservedPort = oldClient.metroPort;
+
+      try {
+        await oldClient.disconnect();
+      } catch (err) {
+        logger.warn('MCP', `cdp_restart: old client disconnect failed (non-fatal): ${err instanceof Error ? err.message : err}`);
+      }
+
+      const newClient = createClient(args.metroPort ?? preservedPort);
+      setClient(newClient);
+
+      let connected = false;
+      let connectError: string | undefined;
+      try {
+        await newClient.autoConnect(args.metroPort, args.platform);
+        connected = newClient.isConnected;
+      } catch (err) {
+        connectError = err instanceof Error ? err.message : String(err);
+        logger.warn('MCP', `cdp_restart: autoConnect failed (best-effort): ${connectError}`);
+      }
+
+      return okResult({
+        restarted: true,
+        connected,
+        port: newClient.metroPort,
+        ...(connectError ? { connectError } : {}),
+      });
+    } catch (err) {
+      return failResult(err instanceof Error ? err.message : String(err));
+    }
+  };
+}

--- a/scripts/cdp-bridge/test/unit/cdp-restart.test.js
+++ b/scripts/cdp-bridge/test/unit/cdp-restart.test.js
@@ -1,0 +1,128 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRestartHandler } from '../../dist/tools/restart.js';
+import { parseEnvelope, expectOk, expectFail } from '../helpers/result-helpers.js';
+
+// Build a mock CDPClient — only the methods cdp_restart calls.
+function makeMockClient({ port = 8081, connected = false, autoConnectImpl, disconnectImpl } = {}) {
+  const calls = { disconnect: 0, autoConnect: 0 };
+  const client = {
+    get metroPort() { return port; },
+    get isConnected() { return connected; },
+    disconnect: async () => {
+      calls.disconnect += 1;
+      if (disconnectImpl) return disconnectImpl();
+    },
+    autoConnect: async (portHint, platform) => {
+      calls.autoConnect += 1;
+      calls.lastAutoConnect = { portHint, platform };
+      if (autoConnectImpl) return autoConnectImpl(portHint, platform);
+      connected = true;
+      return 'Connected to test';
+    },
+  };
+  return { client, calls };
+}
+
+// ── B76 / D644: cdp_restart tool ───────────────────────────────────────
+
+test('cdp_restart: happy path — disconnects old client, creates fresh, reconnects (B76/D644)', async () => {
+  const { client: oldClient, calls: oldCalls } = makeMockClient({ port: 8081 });
+  const { client: newClient, calls: newCalls } = makeMockClient({ port: 8081 });
+
+  let currentClient = oldClient;
+  const getClient = () => currentClient;
+  const setClient = (c) => { currentClient = c; };
+  const createClient = (port) => { newClient.__requestedPort = port; return newClient; };
+
+  const handler = createRestartHandler(getClient, setClient, createClient);
+  const data = expectOk(await handler({}));
+
+  assert.equal(oldCalls.disconnect, 1, 'old client disconnected');
+  assert.equal(newCalls.autoConnect, 1, 'new client autoConnect called');
+  assert.equal(data.restarted, true);
+  assert.equal(data.connected, true);
+  assert.equal(data.port, 8081);
+  assert.equal(currentClient, newClient, 'setClient swapped to new instance');
+});
+
+test('cdp_restart: preserves port when not overridden (B76/D644)', async () => {
+  const { client: oldClient } = makeMockClient({ port: 19000 });
+  const { client: newClient } = makeMockClient({ port: 19000 });
+
+  let currentClient = oldClient;
+  let requestedPort;
+  const createClient = (port) => { requestedPort = port; return newClient; };
+
+  const handler = createRestartHandler(() => currentClient, (c) => { currentClient = c; }, createClient);
+  await handler({});
+
+  assert.equal(requestedPort, 19000, 'new client uses preserved port');
+});
+
+test('cdp_restart: metroPort arg overrides preserved port (B76/D644)', async () => {
+  const { client: oldClient } = makeMockClient({ port: 8081 });
+  const { client: newClient } = makeMockClient({ port: 8082 });
+
+  let currentClient = oldClient;
+  let requestedPort;
+  const createClient = (port) => { requestedPort = port; return newClient; };
+
+  const handler = createRestartHandler(() => currentClient, (c) => { currentClient = c; }, createClient);
+  await handler({ metroPort: 8082 });
+
+  assert.equal(requestedPort, 8082, 'new client uses overridden port');
+});
+
+test('cdp_restart: autoConnect failure returns okResult with connectError + connected:false (B76/D644)', async () => {
+  const { client: oldClient } = makeMockClient();
+  const { client: newClient } = makeMockClient({
+    autoConnectImpl: () => { throw new Error('Metro not found'); },
+  });
+
+  let currentClient = oldClient;
+  const handler = createRestartHandler(
+    () => currentClient,
+    (c) => { currentClient = c; },
+    () => newClient,
+  );
+  const data = expectOk(await handler({}));
+
+  assert.equal(data.restarted, true);
+  assert.equal(data.connected, false);
+  assert.match(data.connectError, /Metro not found/);
+});
+
+test('cdp_restart: old disconnect failure is non-fatal — new client still created (B76/D644)', async () => {
+  const { client: oldClient, calls: oldCalls } = makeMockClient({
+    disconnectImpl: async () => { throw new Error('ws already closed'); },
+  });
+  const { client: newClient, calls: newCalls } = makeMockClient();
+
+  let currentClient = oldClient;
+  const handler = createRestartHandler(
+    () => currentClient,
+    (c) => { currentClient = c; },
+    () => newClient,
+  );
+  const data = expectOk(await handler({}));
+
+  assert.equal(oldCalls.disconnect, 1, 'disconnect was attempted');
+  assert.equal(newCalls.autoConnect, 1, 'new client still created and connected');
+  assert.equal(data.restarted, true);
+});
+
+test('cdp_restart: passes platform filter through to autoConnect (B76/D644)', async () => {
+  const { client: oldClient } = makeMockClient();
+  const { client: newClient, calls: newCalls } = makeMockClient();
+
+  let currentClient = oldClient;
+  const handler = createRestartHandler(
+    () => currentClient,
+    (c) => { currentClient = c; },
+    () => newClient,
+  );
+  await handler({ platform: 'ios' });
+
+  assert.equal(newCalls.lastAutoConnect.platform, 'ios');
+});

--- a/scripts/cdp-bridge/test/unit/graceful-shutdown.test.js
+++ b/scripts/cdp-bridge/test/unit/graceful-shutdown.test.js
@@ -117,11 +117,11 @@ test('gracefulShutdown: stopFastRunner throw is non-fatal (B76/D644)', async () 
 });
 
 test('gracefulShutdown: timeout forces exit if cleanup hangs (B76/D644)', async () => {
-  // disconnect() doesn't resolve until we let it — simulates a stuck cleanup path.
-  // Hold the resolve ref so we can release it after the test asserts; otherwise
-  // node:test in CI cancels the file because the promise is permanently pending.
-  let releaseCleanup;
-  const { client } = mockClient(() => new Promise((r) => { releaseCleanup = r; }));
+  // disconnect() never resolves — simulates a stuck cleanup path. The shutdown's
+  // setTimeout is NOT unref'd in production code, so it keeps the event loop alive
+  // long enough to fire, settle Promise.race, and force exit. This test would have
+  // caught the .unref() bug that slipped through the first CI run.
+  const { client } = mockClient(() => new Promise(() => {}));
   const { exits, exitFn } = captureExit();
 
   const shutdown = buildGracefulShutdown({
@@ -137,10 +137,6 @@ test('gracefulShutdown: timeout forces exit if cleanup hangs (B76/D644)', async 
 
   assert.deepEqual(exits, [0], 'exit forced via timeout');
   assert.ok(elapsed >= 40 && elapsed < 500, `timeout respected: ${elapsed}ms`);
-
-  // Release the dangling cleanup promise so node:test drains cleanly in CI
-  releaseCleanup();
-  await new Promise((r) => setImmediate(r));
 });
 
 test('gracefulShutdown: concurrent calls during slow disconnect share one cleanup (B76/D644 race)', async () => {

--- a/scripts/cdp-bridge/test/unit/graceful-shutdown.test.js
+++ b/scripts/cdp-bridge/test/unit/graceful-shutdown.test.js
@@ -117,8 +117,11 @@ test('gracefulShutdown: stopFastRunner throw is non-fatal (B76/D644)', async () 
 });
 
 test('gracefulShutdown: timeout forces exit if cleanup hangs (B76/D644)', async () => {
-  // disconnect() never resolves — simulates a stuck cleanup path
-  const { client } = mockClient(() => new Promise(() => {}));
+  // disconnect() doesn't resolve until we let it — simulates a stuck cleanup path.
+  // Hold the resolve ref so we can release it after the test asserts; otherwise
+  // node:test in CI cancels the file because the promise is permanently pending.
+  let releaseCleanup;
+  const { client } = mockClient(() => new Promise((r) => { releaseCleanup = r; }));
   const { exits, exitFn } = captureExit();
 
   const shutdown = buildGracefulShutdown({
@@ -134,6 +137,10 @@ test('gracefulShutdown: timeout forces exit if cleanup hangs (B76/D644)', async 
 
   assert.deepEqual(exits, [0], 'exit forced via timeout');
   assert.ok(elapsed >= 40 && elapsed < 500, `timeout respected: ${elapsed}ms`);
+
+  // Release the dangling cleanup promise so node:test drains cleanly in CI
+  releaseCleanup();
+  await new Promise((r) => setImmediate(r));
 });
 
 test('gracefulShutdown: concurrent calls during slow disconnect share one cleanup (B76/D644 race)', async () => {

--- a/scripts/cdp-bridge/test/unit/graceful-shutdown.test.js
+++ b/scripts/cdp-bridge/test/unit/graceful-shutdown.test.js
@@ -1,0 +1,169 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildGracefulShutdown } from '../../dist/lifecycle/graceful-shutdown.js';
+
+// Build a minimal mock client — only disconnect() is called by shutdown.
+function mockClient(disconnectImpl = async () => {}) {
+  const calls = { disconnect: 0 };
+  return {
+    client: {
+      disconnect: async () => {
+        calls.disconnect += 1;
+        return disconnectImpl();
+      },
+    },
+    calls,
+  };
+}
+
+function captureExit() {
+  const exits = [];
+  const exitFn = ((code) => {
+    exits.push(code);
+    // Do NOT actually exit — return undefined cast to never for type compat
+    return undefined;
+  });
+  return { exits, exitFn };
+}
+
+// ── B76 / D644: graceful shutdown factory ──────────────────────────────
+
+test('gracefulShutdown: calls disconnect then stopFastRunner then exit with correct code (B76/D644)', async () => {
+  const { client, calls } = mockClient();
+  let stopFastRunnerCalls = 0;
+  const { exits, exitFn } = captureExit();
+
+  const shutdown = buildGracefulShutdown({
+    getClient: () => client,
+    stopFastRunnerFn: () => { stopFastRunnerCalls += 1; },
+    exitFn,
+    timeoutMs: 1000,
+  });
+
+  await shutdown(0);
+
+  assert.equal(calls.disconnect, 1, 'disconnect called once');
+  assert.equal(stopFastRunnerCalls, 1, 'stopFastRunner called once');
+  assert.deepEqual(exits, [0], 'exit called with code 0');
+});
+
+test('gracefulShutdown: passes through non-zero exit code (B76/D644)', async () => {
+  const { client } = mockClient();
+  const { exits, exitFn } = captureExit();
+
+  const shutdown = buildGracefulShutdown({
+    getClient: () => client,
+    stopFastRunnerFn: () => {},
+    exitFn,
+    timeoutMs: 1000,
+  });
+
+  await shutdown(1);
+  assert.deepEqual(exits, [1], 'exit called with code 1 (SIGUSR1 crash-restart intent)');
+});
+
+test('gracefulShutdown: idempotent — second call is a no-op (B76/D644)', async () => {
+  const { client, calls } = mockClient();
+  let stopFastRunnerCalls = 0;
+  const { exits, exitFn } = captureExit();
+
+  const shutdown = buildGracefulShutdown({
+    getClient: () => client,
+    stopFastRunnerFn: () => { stopFastRunnerCalls += 1; },
+    exitFn,
+    timeoutMs: 1000,
+  });
+
+  await Promise.all([shutdown(0), shutdown(0), shutdown(0)]);
+
+  assert.equal(calls.disconnect, 1, 'disconnect called exactly once despite 3 shutdowns');
+  assert.equal(stopFastRunnerCalls, 1, 'stopFastRunner called exactly once');
+  assert.equal(exits.length, 1, 'exit called exactly once');
+});
+
+test('gracefulShutdown: disconnect throw is non-fatal (B76/D644)', async () => {
+  const { client } = mockClient(async () => { throw new Error('boom'); });
+  let stopFastRunnerCalls = 0;
+  const { exits, exitFn } = captureExit();
+
+  const shutdown = buildGracefulShutdown({
+    getClient: () => client,
+    stopFastRunnerFn: () => { stopFastRunnerCalls += 1; },
+    exitFn,
+    timeoutMs: 1000,
+  });
+
+  await shutdown(0);
+
+  assert.equal(stopFastRunnerCalls, 1, 'stopFastRunner still called after disconnect throws');
+  assert.deepEqual(exits, [0], 'exit still called');
+});
+
+test('gracefulShutdown: stopFastRunner throw is non-fatal (B76/D644)', async () => {
+  const { client, calls } = mockClient();
+  const { exits, exitFn } = captureExit();
+
+  const shutdown = buildGracefulShutdown({
+    getClient: () => client,
+    stopFastRunnerFn: () => { throw new Error('fastrunner boom'); },
+    exitFn,
+    timeoutMs: 1000,
+  });
+
+  await shutdown(0);
+
+  assert.equal(calls.disconnect, 1, 'disconnect was called');
+  assert.deepEqual(exits, [0], 'exit still called despite stopFastRunner throw');
+});
+
+test('gracefulShutdown: timeout forces exit if cleanup hangs (B76/D644)', async () => {
+  // disconnect() never resolves — simulates a stuck cleanup path
+  const { client } = mockClient(() => new Promise(() => {}));
+  const { exits, exitFn } = captureExit();
+
+  const shutdown = buildGracefulShutdown({
+    getClient: () => client,
+    stopFastRunnerFn: () => {},
+    exitFn,
+    timeoutMs: 50,
+  });
+
+  const start = Date.now();
+  await shutdown(0);
+  const elapsed = Date.now() - start;
+
+  assert.deepEqual(exits, [0], 'exit forced via timeout');
+  assert.ok(elapsed >= 40 && elapsed < 500, `timeout respected: ${elapsed}ms`);
+});
+
+test('gracefulShutdown: concurrent calls during slow disconnect share one cleanup (B76/D644 race)', async () => {
+  // Simulates the cdp_restart-mid-flight + SIGTERM race the idempotency guard is for.
+  let disconnectResolve;
+  const { client, calls } = mockClient(() => new Promise((r) => { disconnectResolve = r; }));
+  let stopFastRunnerCalls = 0;
+  const { exits, exitFn } = captureExit();
+
+  const shutdown = buildGracefulShutdown({
+    getClient: () => client,
+    stopFastRunnerFn: () => { stopFastRunnerCalls += 1; },
+    exitFn,
+    timeoutMs: 5000,
+  });
+
+  // Fire 3 parallel shutdowns while disconnect() is pending
+  const p1 = shutdown(0);
+  const p2 = shutdown(0);
+  const p3 = shutdown(1);
+
+  // Give the microtask queue a tick to ensure the first shutdown has entered its body
+  await new Promise((r) => setImmediate(r));
+  assert.equal(calls.disconnect, 1, 'disconnect called exactly once despite 3 concurrent shutdowns');
+
+  // Resolve the slow disconnect → cleanup completes → exit fires
+  disconnectResolve();
+  await Promise.all([p1, p2, p3]);
+
+  assert.equal(stopFastRunnerCalls, 1, 'stopFastRunner called exactly once');
+  assert.equal(exits.length, 1, 'exit called exactly once');
+  assert.deepEqual(exits, [0], 'first shutdown wins — its exit code is used');
+});


### PR DESCRIPTION
## Summary

- **B76** (HIGH, critical dev workflow): MCP server cannot be restarted within a Claude Code session — every `npm run build` required a full CC quit + reopen, losing conversation context.
- **Zombie MCP subprocesses**: 6 orphans observed during Phase 91 B111 session, surviving across CC quits. Root cause: the 5s `setInterval` background Metro poll in `cdp/reconnection.ts:108` held the Node event loop alive indefinitely when Claude Code closed stdin without SIGTERM.
- **B73** (HIGH): empirically verified **already fixed** on main. Kill-Metro test proved the reconnect loop + background poll (historical D622) handle Metro death correctly. BUGS.md update only — no code change.

## What changed

| Layer | Change |
|---|---|
| **New** | `src/lifecycle/graceful-shutdown.ts` — idempotent factory with 3s timeout + injectable `exitFn` |
| **New** | `src/tools/restart.ts` — `cdp_restart` MCP tool for in-process soft state reset |
| **Modified** | `src/index.ts` — all signals (SIGTERM/SIGINT/SIGHUP/SIGUSR2) + `stdin.end` + `uncaughtException` funnel into `shutdown(code)`; new tool registered |
| **Modified** | `src/cdp-client.ts` — 2-line idempotent guard on `disconnect()` for concurrent-shutdown race safety |
| **New** | 13 unit tests (7 graceful-shutdown incl. concurrent-race, 6 cdp_restart) |

### Key design choices

- **SIGUSR2 not SIGUSR1** — Node reserves SIGUSR1 for its built-in inspector (`--inspect`). Using SIGUSR2 avoids the debugger collision that would double-fire both things under `--inspect`.
- **No `stdin.resume()`** — `StdioServerTransport.start()` flips stdin to flowing mode inside `server.connect(transport)`. A passive `'end'` listener is sufficient and avoids a theoretical data-loss window.
- **`cdp_restart` is state reset, not binary reload** — tool description explicitly disclaims this. Loading new `dist/` after `npm run build` still requires full CC restart (CC does not auto-respawn MCP subprocesses on non-zero exit).
- **Injectable `exitFn` + `discoverFn` patterns** — unit tests observe exit behavior without killing the real process, respecting the project's "never kill the MCP" rule.

## Test plan

- [x] `npm run test` — **262 / 262 passing** (was 249 baseline, +13 new). `npm run build` — 0 TypeScript errors.
- [x] **Live smoke verified on macOS** — CC restart loaded the fix dist, all 5 gates passed:
  - [x] Gate 1: `cdp_restart` tool appeared in tool list ✓
  - [x] Gate 2: Baseline `cdp_status` — connected, pageId `bb5160…-1`, MCP PID 11696 ✓
  - [x] Gate 3: `cdp_restart` call returned `{restarted:true, connected:true, port:8081}` ✓
  - [x] Gate 4: Post-restart `cdp_status` — reconnected cleanly ✓
  - [x] Gate 5: **MCP PID 11696 unchanged** across `cdp_restart` — confirms in-process reset, not binary reload ✓
- [x] **B73 empirical verification** (kill Metro → observe MCP survival) — recorded in proof log, MCP auto-reconnected at `attemptCount: 1` when Metro returned.
- [x] Multi-review (Gemini + Codex, parallel) — 0 high-confidence issues remaining after 4 follow-up fixes (SIGUSR1→SIGUSR2, removed stdin.resume(), clearTimeout on happy path, added concurrent-race test).
- [ ] **Passive zombie verification** (will happen organically on next Cmd+Q) — `ps aux | grep cdp-bridge` should show no orphans because the new `stdin.end` handler fires graceful-shutdown → clears bgPoll interval → clean exit.

## Semver + versions

- Plugin: **0.23.0 → 0.25.0** (MINOR: new `cdp_restart` tool + behavior change on signal handling)
- MCP server: **0.18.0 → 0.20.0** (MINOR: same)
- Skipped 0.24.0/0.19.0 to avoid collision with in-flight PR #32 (B111 fix) which takes those versions. Whichever PR merges second will rebase naturally on the other.

## Non-goals (explicit scope limits)

- Does NOT solve the "reload new `dist/` mid-session" workflow. CC does not auto-respawn MCP subprocesses; `cdp_restart` is state-only; real dist reload still needs CC quit+reopen.
- Does NOT add a supervisor wrapper (historical `run.sh` SIGUSR1 pattern at commit `ac4c8d7` was abandoned because `run.sh` is not invoked by `plugin.json` — node called directly per B84/D535/`f423bd8`).

## Behavioral change (MINOR bump rationale)

- New `cdp_restart` tool exposed to callers (additive, but new public surface)
- Signal handling changed: old code only had SIGTERM + uncaughtException. New code adds SIGINT/SIGHUP/SIGUSR2/stdin.end and routes all through a unified graceful shutdown. A caller sending SIGTERM gets identical-looking behavior (cleanup + exit 0), but any caller previously sending SIGINT (e.g., Ctrl+C in a dev tty) now gets graceful cleanup instead of Node's default abrupt exit — strictly better.

## Proof

Detailed artifacts at `rn-dev-agent-workspace/docs/proof/b73-b76-mcp-lifecycle/` (workspace repo): `PROOF.md` full narrative, `test-output.txt` (262-test pass output), `b73-verification.log` (raw kill-Metro + restart trace).

Relates: PR #32 (B111 — in flight on separate branch). No code conflicts expected between the two.