### PR TITLE
docs: README Security section for cdp_evaluate (B5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,17 @@ Claude Code
 
 [Full troubleshooting guide](https://lykhoyda.github.io/rn-dev-agent/troubleshooting/)
 
+## Security
+
+The `cdp_evaluate` tool runs arbitrary JavaScript in your app's Hermes runtime with full access to component tree, store state, AsyncStorage, and any in-memory secrets. This is **intentional** — runtime introspection is what makes the plugin useful for debugging — but it means **only run this plugin against apps where you trust the agent's prompts**.
+
+Recommended usage:
+- **Local dev environments only.** Do not point the plugin at production builds, store-signed apps, or any app holding real user data.
+- **Treat the agent like a developer with shell access to your laptop.** Any prompt that reaches `cdp_evaluate` (directly or through another tool that calls it) can read or mutate your app's runtime state.
+- **Don't connect to CDP targets you didn't intentionally launch.** The plugin filters Metro endpoints to `127.0.0.1` / `localhost`, but if you're running multiple Hermes targets on your machine, double-check `cdp_targets` before relying on tool output.
+
+The plugin makes no attempt to sandbox `cdp_evaluate` calls. If you need that, gate the agent's tool access through Claude Code's permission prompts rather than trusting the tool layer to enforce safety.
+
 ## Keeping up to date
 
 Enable auto-update in the plugin manager (Marketplaces tab), or update manually:


### PR DESCRIPTION
## Summary

- **B5** (Accepted risk, doc pending since logged): adds a brief Security section to README documenting that `cdp_evaluate` runs unrestricted JS in the app's Hermes runtime.
- One README addition, no code changes.

## What changed

New `## Security` section between `## Troubleshooting` and `## Keeping up to date`:

- States the design intent (runtime introspection is the point of the tool)
- Three practical guidance bullets:
  - Local dev only — never against production / signed / real-user-data builds
  - Treat the agent like a developer with shell access
  - Confirm `cdp_targets` before trusting tool output if multiple Hermes targets are running
- Closing note that sandboxing isn't attempted — point readers at Claude Code's permission prompts as the real enforcement layer

## Test plan

- [x] No code changes — nothing to unit-test or smoke
- [x] Markdown renders correctly (verified locally)
- [x] Section placement: between Troubleshooting and Keeping up to date — operational concerns cluster

## Why this completes B5

BUGS.md B5 was logged with status `Accepted risk — document clearly`. The body claimed "Documented in README troubleshooting", but as of yesterday's verification sweep the README only listed `cdp_evaluate` in the tools table without any security context. This PR makes the actual documentation match the claim.

This is the **one remaining doc-side item** from yesterday's 14-for-15 stability sweep — every other entry was already implemented elsewhere and just needed status updates in BUGS.md/ROADMAP.md.

Workspace doc updates (R1/R6/R8 ROADMAP closures + B5 BUGS update) follow in a separate local commit on the workspace repo, matching today's pattern.