### PR TITLE
fix(b119): detect + auto-recover from agent-device runner leak (GH #35)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/scripts/cdp-bridge/dist/tools/device-interact.js
+++ b/scripts/cdp-bridge/dist/tools/device-interact.js
@@ -5,6 +5,8 @@ import { isFastRunnerAvailable, fastSwipe } from '../fast-runner-session.js';
 import { withSession } from '../utils.js';
 import { okResult, failResult } from '../utils.js';
 import { runMaestroInline, yamlEscape } from '../maestro-invoke.js';
+import { isAgentDeviceRunnerSentinel, recoverFromRunnerLeak } from './runner-leak-recovery.js';
+import { reopenSessionForRecovery } from './device-session.js';
 const execFile = promisify(execFileCb);
 const ANDROID_UNSAFE_CHARS = /[+@#$%^&*(){}|\\<>~`[\]?*]/;
 const ANDROID_FILL_MAX_SAFE_LEN = 30;
@@ -18,30 +20,54 @@ function candidateFromNode(n) {
         position: n.rect ? { x: n.rect.x, y: n.rect.y } : undefined,
     };
 }
-async function fetchSnapshotNodes() {
+function parseSnapshotEnvelope(result) {
+    if (result.isError)
+        return null;
     try {
-        const snapshotResult = await runAgentDevice(['snapshot', '-i']);
-        if (snapshotResult.isError)
-            return null;
-        const envelope = JSON.parse(snapshotResult.content[0].text);
+        const envelope = JSON.parse(result.content[0].text);
         if (!envelope.ok || !envelope.data?.nodes)
             return null;
-        const nodes = envelope.data.nodes;
-        const platform = getActiveSession()?.platform;
-        if (platform)
-            cacheSnapshot(platform, nodes);
-        return nodes;
+        return envelope.data.nodes;
     }
     catch {
         return null;
     }
 }
+async function fetchSnapshotNodes() {
+    const first = await runAgentDevice(['snapshot', '-i']);
+    const initialNodes = parseSnapshotEnvelope(first);
+    if (initialNodes === null)
+        return { ok: false, reason: 'fetch-failed' };
+    if (!isAgentDeviceRunnerSentinel(initialNodes)) {
+        const platform = getActiveSession()?.platform;
+        if (platform)
+            cacheSnapshot(platform, initialNodes);
+        return { ok: true, nodes: initialNodes };
+    }
+    const session = getActiveSession();
+    const recovery = await recoverFromRunnerLeak({ platform: session?.platform, appId: session?.appId, sessionName: session?.name }, {
+        closeSession: () => runAgentDevice(['close']),
+        openSession: ({ appId, platform, attachOnly }) => reopenSessionForRecovery(appId, platform, attachOnly),
+        resnapshot: () => runAgentDevice(['snapshot', '-i']),
+        parseNodes: parseSnapshotEnvelope,
+    });
+    if (!recovery.recovered) {
+        return { ok: false, reason: 'runner-leak-unrecovered', recoveryReason: recovery.reason };
+    }
+    const recoveredNodes = parseSnapshotEnvelope(recovery.result);
+    if (recoveredNodes === null)
+        return { ok: false, reason: 'fetch-failed' };
+    const platform = getActiveSession()?.platform;
+    if (platform)
+        cacheSnapshot(platform, recoveredNodes);
+    return { ok: true, nodes: recoveredNodes, recoveredTier: recovery.tier };
+}
 async function fetchFindCandidates(query, exact) {
-    const nodes = await fetchSnapshotNodes();
-    if (!nodes)
-        return null;
+    const snap = await fetchSnapshotNodes();
+    if (!snap.ok)
+        return snap;
     const needle = query.toLowerCase();
-    return nodes
+    const candidates = snap.nodes
         .filter((n) => {
         const label = n.label ?? '';
         const id = n.identifier ?? '';
@@ -51,6 +77,15 @@ async function fetchFindCandidates(query, exact) {
     })
         .slice(0, 10)
         .map(candidateFromNode);
+    return { ok: true, candidates, recoveredTier: snap.recoveredTier };
+}
+function runnerLeakFailResult(query, recoveryReason) {
+    const queryHint = query ? ` (while resolving "${query}")` : '';
+    return failResult(`device_find/snapshot returned AgentDeviceRunner's own UI tree instead of the target app${queryHint} (B119 / GH #35 — agent-device daemon dropped appBundleId on dispatch). Auto-recovery did not restore the target.`, {
+        code: 'RUNNER_LEAK',
+        recoveryReason,
+        hint: 'Manually close + reopen the session with device_snapshot action=open appId=<your.bundle.id> platform=ios (full launch, not attachOnly). The recovery may have killed the JS context — re-establish CDP via cdp_connect before reading state. Upstream: Callstack/agent-device, see B119/GH#35.',
+    });
 }
 async function pressCandidate(candidate, action) {
     const ref = candidate.ref.startsWith('@') ? candidate.ref : `@${candidate.ref}`;
@@ -59,19 +94,38 @@ async function pressCandidate(candidate, action) {
     }
     return okResult({ ref: candidate.ref, label: candidate.label, testID: candidate.testID });
 }
+// B119: when an underlying snapshot triggered runner-leak recovery, surface
+// that side-effect on the wrapping result so callers (LLM agents) know the
+// app may have been relaunched and CDP/state may have been invalidated.
+function tagPressIfRecovered(result, tier) {
+    if (!tier || result.isError)
+        return result;
+    try {
+        const envelope = JSON.parse(result.content[0].text);
+        envelope.meta = { ...envelope.meta, recovered: 'agent-device-runner-leak', recoveryTier: tier };
+        return { content: [{ type: 'text', text: JSON.stringify(envelope) }] };
+    }
+    catch {
+        return result;
+    }
+}
 export function createDeviceFindHandler() {
     return withSession(async (args) => {
         // Fast path when caller already knows they want exact or a specific index:
         // go straight to a snapshot-based client-side match so we never roll the dice
         // on agent-device's fuzzy matcher returning AMBIGUOUS_MATCH.
         if (args.exact === true || args.index !== undefined) {
-            const candidates = await fetchFindCandidates(args.text, args.exact === true);
-            if (candidates === null) {
+            const find = await fetchFindCandidates(args.text, args.exact === true);
+            if (!find.ok) {
+                if (find.reason === 'runner-leak-unrecovered') {
+                    return runnerLeakFailResult(args.text, find.recoveryReason);
+                }
                 // Snapshot failed and caller has strict requirements — do NOT fall through
                 // to the fuzzy agent-device path because it cannot honor exact/index. Fail
                 // cleanly so the caller knows exact/index semantics aren't reachable.
                 return failResult(`Snapshot unavailable — cannot resolve ${args.exact ? 'exact' : 'index-based'} match for "${args.text}". Retry after device_snapshot action=open/snapshot.`, { code: 'SNAPSHOT_UNAVAILABLE', query: args.text });
             }
+            const { candidates, recoveredTier } = find;
             if (candidates.length === 0) {
                 return failResult(`No element matches "${args.text}" (exact=${args.exact === true})`, { code: 'NOT_FOUND', query: args.text });
             }
@@ -79,11 +133,11 @@ export function createDeviceFindHandler() {
                 if (args.index < 0 || args.index >= candidates.length) {
                     return failResult(`index ${args.index} out of range (got ${candidates.length} candidates)`, { code: 'INDEX_OUT_OF_RANGE', count: candidates.length, candidates });
                 }
-                return pressCandidate(candidates[args.index], args.action);
+                return tagPressIfRecovered(await pressCandidate(candidates[args.index], args.action), recoveredTier);
             }
             // exact=true, no index: require single match
             if (candidates.length === 1) {
-                return pressCandidate(candidates[0], args.action);
+                return tagPressIfRecovered(await pressCandidate(candidates[0], args.action), recoveredTier);
             }
             return failResult(`AMBIGUOUS_MATCH: exact "${args.text}" matched ${candidates.length} elements`, { code: 'AMBIGUOUS_MATCH', query: args.text, candidates, hint: 'Add index: N to pick one.' });
         }
@@ -95,8 +149,12 @@ export function createDeviceFindHandler() {
         if (result.isError) {
             const text = result.content?.[0]?.text ?? '';
             if (text.includes('AMBIGUOUS_MATCH') || (text.includes('matched') && text.includes('elements'))) {
-                const candidates = await fetchFindCandidates(args.text, false);
-                if (candidates) {
+                const find = await fetchFindCandidates(args.text, false);
+                if (!find.ok && find.reason === 'runner-leak-unrecovered') {
+                    return runnerLeakFailResult(args.text, find.recoveryReason);
+                }
+                if (find.ok) {
+                    const candidates = find.candidates;
                     return failResult(`AMBIGUOUS_MATCH: "${args.text}" matched ${candidates.length} elements. Use device_press with one of these refs, or retry with index: N.`, {
                         code: 'AMBIGUOUS_MATCH',
                         query: args.text,
@@ -455,10 +513,14 @@ export function createDeviceFocusNextHandler() {
         // Benchmark data: 4 serial finds = 10-22s on no-keyboard case; single
         // snapshot = 3-5s on the same case. Also more reliable — one accessibility
         // query races keyboard animations less than four sequential queries.
-        const nodes = await fetchSnapshotNodes();
-        if (!nodes) {
+        const snap = await fetchSnapshotNodes();
+        if (!snap.ok) {
+            if (snap.reason === 'runner-leak-unrecovered') {
+                return runnerLeakFailResult(undefined, snap.recoveryReason);
+            }
             return failResult('Snapshot unavailable — cannot look for keyboard key. Retry after device_snapshot action=open/snapshot.', { code: 'SNAPSHOT_UNAVAILABLE' });
         }
+        const { nodes, recoveredTier } = snap;
         for (const label of NEXT_KEY_LABELS) {
             const match = nodes.find((n) => n.label === label);
             if (!match)
@@ -468,7 +530,12 @@ export function createDeviceFocusNextHandler() {
                 continue; // Match found but tap failed — try next label
             try {
                 const envelope = JSON.parse(pressResult.content[0].text);
-                return okResult(envelope.data, { meta: { keyUsed: label, ref: match.ref } });
+                const meta = { keyUsed: label, ref: match.ref };
+                if (recoveredTier) {
+                    meta.recovered = 'agent-device-runner-leak';
+                    meta.recoveryTier = recoveredTier;
+                }
+                return okResult(envelope.data, { meta });
             }
             catch {
                 return pressResult;

--- a/scripts/cdp-bridge/dist/tools/device-session.js
+++ b/scripts/cdp-bridge/dist/tools/device-session.js
@@ -4,6 +4,7 @@ import { runAgentDevice, setActiveSession, clearActiveSession, getActiveSession,
 import { stopFastRunner } from '../fast-runner-session.js';
 import { okResult, failResult, warnResult } from '../utils.js';
 import { resolveBundleId } from '../project-config.js';
+import { isAgentDeviceRunnerSentinel, recoverFromRunnerLeak, } from './runner-leak-recovery.js';
 const execFile = promisify(execFileCb);
 /**
  * B112 (D641): check whether a given bundleId is currently running on the
@@ -103,6 +104,7 @@ export function createDeviceSnapshotHandler() {
                     platform: args.platform,
                     deviceId,
                     openedAt: new Date().toISOString(),
+                    appId,
                 });
                 if (args.platform === 'ios' && deviceId) {
                     ensureFastRunner(deviceId, appId).catch(() => { });
@@ -129,17 +131,125 @@ export function createDeviceSnapshotHandler() {
         if (!getActiveSession()) {
             return failResult('No device session open. Call device_snapshot with action="open" first.', { hint: 'Provide appId and platform to start a session.' });
         }
-        const result = await runAgentDevice(['snapshot', '-i']);
-        if (!result.isError) {
-            try {
-                const envelope = JSON.parse(result.content[0].text);
-                const platform = getActiveSession()?.platform;
-                if (platform && envelope.ok && envelope.data?.nodes) {
-                    cacheSnapshot(platform, envelope.data.nodes);
-                }
+        const result = await rawSnapshot();
+        const nodes = parseSnapshotNodes(result);
+        if (!result.isError && nodes && isAgentDeviceRunnerSentinel(nodes)) {
+            const session = getActiveSession();
+            const recovery = await recoverFromRunnerLeak({ platform: session?.platform, appId: session?.appId, sessionName: session?.name }, {
+                closeSession: () => runAgentDevice(['close']),
+                openSession: ({ appId, platform, attachOnly }) => reopenSessionForRecovery(appId, platform, attachOnly),
+                resnapshot: () => rawSnapshot(),
+                parseNodes: parseSnapshotNodes,
+            });
+            if (recovery.recovered) {
+                cacheSnapshotIfPossible(recovery.result);
+                return wrapWithMeta(recovery.result, {
+                    recovered: 'agent-device-runner-leak',
+                    recoveryTier: recovery.tier,
+                });
             }
-            catch { /* best-effort cache */ }
+            return failResult(runnerLeakFailureMessage(recovery.reason, session), {
+                code: 'RUNNER_LEAK',
+                recoveryReason: recovery.reason,
+                hint: runnerLeakFailureHint(recovery.reason, session),
+            });
         }
+        cacheSnapshotIfPossible(result);
         return result;
     };
+}
+export function runnerLeakFailureMessage(reason, session) {
+    if (reason === 'no-session-context' && session && !session.appId) {
+        return 'device_snapshot returned AgentDeviceRunner\'s own UI tree, but auto-recovery cannot run because the active session has no stored appId. This usually means the session was opened by a plugin version from before B119 / GH #35 landed.';
+    }
+    return 'device_snapshot returned AgentDeviceRunner\'s own UI tree instead of the target app (B119 / GH #35 — agent-device daemon dropped appBundleId on dispatch). Auto-recovery did not restore the target.';
+}
+export function runnerLeakFailureHint(reason, session) {
+    if (reason === 'no-session-context' && session && !session.appId) {
+        return 'Run device_snapshot action=close, then action=open appId=<your.bundle.id> platform=ios to start a session that supports auto-recovery.';
+    }
+    return 'Manually close + reopen the session with action=open appId=<your.bundle.id> platform=ios (full launch, not attachOnly). Upstream: Callstack/agent-device, see B119/GH#35.';
+}
+async function rawSnapshot() {
+    return runAgentDevice(['snapshot', '-i']);
+}
+function parseSnapshotNodes(result) {
+    if (result.isError)
+        return null;
+    try {
+        const envelope = JSON.parse(result.content[0].text);
+        if (!envelope.ok || !envelope.data?.nodes)
+            return null;
+        return envelope.data.nodes;
+    }
+    catch {
+        return null;
+    }
+}
+function cacheSnapshotIfPossible(result) {
+    if (result.isError)
+        return;
+    try {
+        const envelope = JSON.parse(result.content[0].text);
+        const platform = getActiveSession()?.platform;
+        if (platform && envelope.ok && envelope.data?.nodes) {
+            cacheSnapshot(platform, envelope.data.nodes);
+        }
+    }
+    catch { /* best-effort cache */ }
+}
+function wrapWithMeta(result, meta) {
+    if (result.isError)
+        return result;
+    try {
+        const envelope = JSON.parse(result.content[0].text);
+        envelope.meta = { ...envelope.meta, ...meta };
+        return { content: [{ type: 'text', text: JSON.stringify(envelope) }] };
+    }
+    catch {
+        return result;
+    }
+}
+export async function reopenSessionForRecovery(appId, platform, attachOnly) {
+    // Always mint a fresh recovery name (Gemini G3): reusing the original
+    // session name risks the daemon either rejecting as "already exists" or
+    // silently re-attaching to the corrupted session, defeating the rebuild.
+    const recoveryName = `rn-agent-recovery-${Date.now()}`;
+    let cliArgs;
+    if (attachOnly) {
+        // attachOnly only makes sense if the target app is already running.
+        // Otherwise there's nothing to attach to and we should let the caller
+        // escalate (typically to the full-relaunch tier).
+        const running = await isAppRunning(platform, appId);
+        if (!running) {
+            return failResult(`attachOnly recovery aborted: ${appId} is not running on ${platform}.`, { code: 'NOT_CONNECTED', recoveryAbort: true });
+        }
+        cliArgs = ['open', '--session', recoveryName, '--platform', platform];
+    }
+    else {
+        cliArgs = ['open', appId, '--session', recoveryName, '--platform', platform];
+    }
+    const result = await runAgentDevice(cliArgs, { skipSession: true });
+    if (result.isError)
+        return result;
+    let deviceId;
+    try {
+        const envelope = JSON.parse(result.content[0].text);
+        const data = envelope?.data;
+        const rawId = data?.deviceId
+            ?? data?.device_udid
+            ?? data?.id
+            ?? (typeof data?.device === 'object' ? data?.device?.id : undefined);
+        const UDID_RE = /^[0-9A-Fa-f-]{25,}$/;
+        deviceId = typeof rawId === 'string' && UDID_RE.test(rawId) ? rawId : undefined;
+    }
+    catch { /* best-effort */ }
+    setActiveSession({
+        name: recoveryName,
+        platform,
+        deviceId,
+        openedAt: new Date().toISOString(),
+        appId,
+    });
+    return result;
 }

--- a/scripts/cdp-bridge/dist/tools/runner-leak-recovery.js
+++ b/scripts/cdp-bridge/dist/tools/runner-leak-recovery.js
@@ -1,0 +1,105 @@
+const RUNNER_APP_LABEL = 'AgentDeviceRunner';
+const RUNNER_VISIBLE_TEXT = 'Agent Device Runner';
+const RUNNER_FINGERPRINT_IDENTIFIERS = new Set(['Logo', 'PoweredBy']);
+const SMALL_TREE_THRESHOLD = 12;
+/**
+ * B119/GH#35: detect when an iOS snapshot returned AgentDeviceRunner's own UI
+ * tree instead of the session's target app. This happens when the agent-device
+ * daemon dispatches a command to the Swift runner without `appBundleId`,
+ * causing RunnerTests+CommandExecution.swift:111-122 to clear `currentApp`
+ * and activate the runner itself. Snapshot succeeds but returns the wrong
+ * tree (~6 nodes including the runner's splash UI).
+ *
+ * Heuristic — both must hold:
+ *   1. Tree is small (<= 12 nodes) — real app trees are larger.
+ *   2. Either: any node label === "AgentDeviceRunner" (the Application node),
+ *      OR (visible "Agent Device Runner" text AND a fingerprint identifier).
+ *
+ * The double-check guards against rare false positives where a real app
+ * happens to contain the literal string "AgentDeviceRunner" but has many
+ * other elements.
+ */
+export function isAgentDeviceRunnerSentinel(nodes) {
+    if (!nodes || nodes.length === 0)
+        return false;
+    if (nodes.length > SMALL_TREE_THRESHOLD)
+        return false;
+    const hasRunnerAppLabel = nodes.some((n) => n.label === RUNNER_APP_LABEL);
+    if (hasRunnerAppLabel)
+        return true;
+    const hasVisibleText = nodes.some((n) => n.label === RUNNER_VISIBLE_TEXT);
+    const hasFingerprintId = nodes.some((n) => n.identifier !== undefined && RUNNER_FINGERPRINT_IDENTIFIERS.has(n.identifier));
+    return hasVisibleText && hasFingerprintId;
+}
+const DAEMON_SETTLE_MS = 600;
+const defaultSleep = (ms) => new Promise((r) => setTimeout(r, ms));
+/**
+ * B119: attempt to recover from the runner-leak failure mode in two tiers.
+ *
+ *   Tier 1 — attachOnly reopen. Preserves the user's app state (JS heap,
+ *   Hermes context, navigation stack, store state, form input). LIMITATION:
+ *   agent-device's attachOnly mode opens a session WITHOUT passing the
+ *   bundleId positional, so the daemon's SessionState.appBundleId stays
+ *   unset — meaning the very condition that triggers the leak persists. In
+ *   practice tier-1 will usually fail for this specific bug, but it's a
+ *   cheap try and would help in any adjacent failure mode where attaching
+ *   is enough.
+ *
+ *   Tier 2 — full app relaunch. Destructive (kills CDP context, drops
+ *   in-memory state, resets navigation, wipes ring buffers) but gives the
+ *   daemon a clean SessionState with appBundleId set.
+ *
+ * Returns { recovered: false } when prerequisites aren't met (no stored
+ * appId, non-iOS, or already-attempted). Caller decides whether to map
+ * that to a hard failure or a softer null/undefined sentinel.
+ */
+export async function recoverFromRunnerLeak(ctx, deps) {
+    if (ctx.alreadyRecovered) {
+        return { recovered: false, result: emptyResult(), reason: 'already-attempted' };
+    }
+    if ((ctx.platform ?? 'ios').toLowerCase() !== 'ios') {
+        return { recovered: false, result: emptyResult(), reason: 'wrong-platform' };
+    }
+    if (!ctx.appId) {
+        return { recovered: false, result: emptyResult(), reason: 'no-session-context' };
+    }
+    const sleep = deps.sleep ?? defaultSleep;
+    // Tier 1: attachOnly reopen — preserves app state when it works.
+    const tier1 = await attemptRecoveryCycle(ctx, deps, true, sleep);
+    if (tier1.phase === 'success') {
+        return { recovered: true, result: tier1.result, tier: 'attach-only' };
+    }
+    // Tier 2: full app relaunch — destructive but resets daemon state cleanly.
+    const tier2 = await attemptRecoveryCycle(ctx, deps, false, sleep);
+    if (tier2.phase === 'success') {
+        return { recovered: true, result: tier2.result, tier: 'full-relaunch' };
+    }
+    if (tier2.phase === 'sentinel') {
+        return { recovered: false, result: tier2.result, reason: 'still-sentinel' };
+    }
+    return { recovered: false, result: tier2.result, reason: 'reopen-failed' };
+}
+async function attemptRecoveryCycle(ctx, deps, attachOnly, sleep) {
+    await deps.closeSession();
+    await sleep(DAEMON_SETTLE_MS);
+    const reopenResult = await deps.openSession({
+        appId: ctx.appId,
+        platform: 'ios',
+        sessionName: ctx.sessionName,
+        attachOnly,
+    });
+    if (reopenResult.isError) {
+        return { phase: 'reopen-failed', result: reopenResult };
+    }
+    const retryResult = await deps.resnapshot();
+    if (retryResult.isError) {
+        return { phase: 'snapshot-failed', result: retryResult };
+    }
+    if (isAgentDeviceRunnerSentinel(deps.parseNodes(retryResult))) {
+        return { phase: 'sentinel', result: retryResult };
+    }
+    return { phase: 'success', result: retryResult };
+}
+function emptyResult() {
+    return { content: [{ type: 'text', text: '' }] };
+}

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/tools/device-interact.ts
+++ b/scripts/cdp-bridge/src/tools/device-interact.ts
@@ -6,6 +6,8 @@ import { withSession } from '../utils.js';
 import type { ToolResult } from '../utils.js';
 import { okResult, failResult } from '../utils.js';
 import { runMaestroInline, yamlEscape } from '../maestro-invoke.js';
+import { isAgentDeviceRunnerSentinel, recoverFromRunnerLeak } from './runner-leak-recovery.js';
+import { reopenSessionForRecovery } from './device-session.js';
 
 const execFile = promisify(execFileCb);
 
@@ -41,29 +43,71 @@ function candidateFromNode(n: SnapshotNode): FindCandidate {
   };
 }
 
-async function fetchSnapshotNodes(): Promise<SnapshotNode[] | null> {
+function parseSnapshotEnvelope(result: ToolResult): SnapshotNode[] | null {
+  if (result.isError) return null;
   try {
-    const snapshotResult = await runAgentDevice(['snapshot', '-i']);
-    if (snapshotResult.isError) return null;
-    const envelope = JSON.parse(snapshotResult.content[0].text) as {
+    const envelope = JSON.parse(result.content[0].text) as {
       ok?: boolean;
       data?: { nodes?: SnapshotNode[] };
     };
     if (!envelope.ok || !envelope.data?.nodes) return null;
-    const nodes = envelope.data.nodes;
-    const platform = getActiveSession()?.platform;
-    if (platform) cacheSnapshot(platform, nodes);
-    return nodes;
+    return envelope.data.nodes;
   } catch {
     return null;
   }
 }
 
-async function fetchFindCandidates(query: string, exact: boolean): Promise<FindCandidate[] | null> {
-  const nodes = await fetchSnapshotNodes();
-  if (!nodes) return null;
+export type SnapshotFetchResult =
+  | { ok: true; nodes: SnapshotNode[]; recoveredTier?: 'attach-only' | 'full-relaunch' }
+  | { ok: false; reason: 'fetch-failed' }
+  | { ok: false; reason: 'runner-leak-unrecovered'; recoveryReason?: string };
+
+async function fetchSnapshotNodes(): Promise<SnapshotFetchResult> {
+  const first = await runAgentDevice(['snapshot', '-i']);
+  const initialNodes = parseSnapshotEnvelope(first);
+  if (initialNodes === null) return { ok: false, reason: 'fetch-failed' };
+
+  if (!isAgentDeviceRunnerSentinel(initialNodes)) {
+    const platform = getActiveSession()?.platform;
+    if (platform) cacheSnapshot(platform, initialNodes);
+    return { ok: true, nodes: initialNodes };
+  }
+
+  const session = getActiveSession();
+  const recovery = await recoverFromRunnerLeak(
+    { platform: session?.platform, appId: session?.appId, sessionName: session?.name },
+    {
+      closeSession: () => runAgentDevice(['close']),
+      openSession: ({ appId, platform, attachOnly }) =>
+        reopenSessionForRecovery(appId, platform, attachOnly),
+      resnapshot: () => runAgentDevice(['snapshot', '-i']),
+      parseNodes: parseSnapshotEnvelope,
+    },
+  );
+
+  if (!recovery.recovered) {
+    return { ok: false, reason: 'runner-leak-unrecovered', recoveryReason: recovery.reason };
+  }
+
+  const recoveredNodes = parseSnapshotEnvelope(recovery.result);
+  if (recoveredNodes === null) return { ok: false, reason: 'fetch-failed' };
+
+  const platform = getActiveSession()?.platform;
+  if (platform) cacheSnapshot(platform, recoveredNodes);
+  return { ok: true, nodes: recoveredNodes, recoveredTier: recovery.tier };
+}
+
+export type FindCandidatesResult =
+  | { ok: true; candidates: FindCandidate[]; recoveredTier?: 'attach-only' | 'full-relaunch' }
+  | { ok: false; reason: 'fetch-failed' }
+  | { ok: false; reason: 'runner-leak-unrecovered'; recoveryReason?: string };
+
+async function fetchFindCandidates(query: string, exact: boolean): Promise<FindCandidatesResult> {
+  const snap = await fetchSnapshotNodes();
+  if (!snap.ok) return snap;
+
   const needle = query.toLowerCase();
-  return nodes
+  const candidates = snap.nodes
     .filter((n) => {
       const label = n.label ?? '';
       const id = n.identifier ?? '';
@@ -72,6 +116,19 @@ async function fetchFindCandidates(query: string, exact: boolean): Promise<FindC
     })
     .slice(0, 10)
     .map(candidateFromNode);
+  return { ok: true, candidates, recoveredTier: snap.recoveredTier };
+}
+
+function runnerLeakFailResult(query: string | undefined, recoveryReason?: string): ToolResult {
+  const queryHint = query ? ` (while resolving "${query}")` : '';
+  return failResult(
+    `device_find/snapshot returned AgentDeviceRunner's own UI tree instead of the target app${queryHint} (B119 / GH #35 — agent-device daemon dropped appBundleId on dispatch). Auto-recovery did not restore the target.`,
+    {
+      code: 'RUNNER_LEAK',
+      recoveryReason,
+      hint: 'Manually close + reopen the session with device_snapshot action=open appId=<your.bundle.id> platform=ios (full launch, not attachOnly). The recovery may have killed the JS context — re-establish CDP via cdp_connect before reading state. Upstream: Callstack/agent-device, see B119/GH#35.',
+    },
+  );
 }
 
 async function pressCandidate(candidate: FindCandidate, action?: string): Promise<ToolResult> {
@@ -80,6 +137,20 @@ async function pressCandidate(candidate: FindCandidate, action?: string): Promis
     return runAgentDevice(['press', ref]);
   }
   return okResult({ ref: candidate.ref, label: candidate.label, testID: candidate.testID });
+}
+
+// B119: when an underlying snapshot triggered runner-leak recovery, surface
+// that side-effect on the wrapping result so callers (LLM agents) know the
+// app may have been relaunched and CDP/state may have been invalidated.
+function tagPressIfRecovered(result: ToolResult, tier?: 'attach-only' | 'full-relaunch'): ToolResult {
+  if (!tier || result.isError) return result;
+  try {
+    const envelope = JSON.parse(result.content[0].text) as { ok?: boolean; data?: unknown; meta?: Record<string, unknown> };
+    envelope.meta = { ...envelope.meta, recovered: 'agent-device-runner-leak', recoveryTier: tier };
+    return { content: [{ type: 'text' as const, text: JSON.stringify(envelope) }] };
+  } catch {
+    return result;
+  }
 }
 
 // --- Find ---
@@ -97,8 +168,11 @@ export function createDeviceFindHandler(): (args: FindArgs) => Promise<ToolResul
     // go straight to a snapshot-based client-side match so we never roll the dice
     // on agent-device's fuzzy matcher returning AMBIGUOUS_MATCH.
     if (args.exact === true || args.index !== undefined) {
-      const candidates = await fetchFindCandidates(args.text, args.exact === true);
-      if (candidates === null) {
+      const find = await fetchFindCandidates(args.text, args.exact === true);
+      if (!find.ok) {
+        if (find.reason === 'runner-leak-unrecovered') {
+          return runnerLeakFailResult(args.text, find.recoveryReason);
+        }
         // Snapshot failed and caller has strict requirements — do NOT fall through
         // to the fuzzy agent-device path because it cannot honor exact/index. Fail
         // cleanly so the caller knows exact/index semantics aren't reachable.
@@ -107,6 +181,7 @@ export function createDeviceFindHandler(): (args: FindArgs) => Promise<ToolResul
           { code: 'SNAPSHOT_UNAVAILABLE', query: args.text },
         );
       }
+      const { candidates, recoveredTier } = find;
       if (candidates.length === 0) {
         return failResult(
           `No element matches "${args.text}" (exact=${args.exact === true})`,
@@ -120,11 +195,11 @@ export function createDeviceFindHandler(): (args: FindArgs) => Promise<ToolResul
             { code: 'INDEX_OUT_OF_RANGE', count: candidates.length, candidates },
           );
         }
-        return pressCandidate(candidates[args.index], args.action);
+        return tagPressIfRecovered(await pressCandidate(candidates[args.index], args.action), recoveredTier);
       }
       // exact=true, no index: require single match
       if (candidates.length === 1) {
-        return pressCandidate(candidates[0], args.action);
+        return tagPressIfRecovered(await pressCandidate(candidates[0], args.action), recoveredTier);
       }
       return failResult(
         `AMBIGUOUS_MATCH: exact "${args.text}" matched ${candidates.length} elements`,
@@ -140,8 +215,12 @@ export function createDeviceFindHandler(): (args: FindArgs) => Promise<ToolResul
     if (result.isError) {
       const text = result.content?.[0]?.text ?? '';
       if (text.includes('AMBIGUOUS_MATCH') || (text.includes('matched') && text.includes('elements'))) {
-        const candidates = await fetchFindCandidates(args.text, false);
-        if (candidates) {
+        const find = await fetchFindCandidates(args.text, false);
+        if (!find.ok && find.reason === 'runner-leak-unrecovered') {
+          return runnerLeakFailResult(args.text, find.recoveryReason);
+        }
+        if (find.ok) {
+          const candidates = find.candidates;
           return failResult(
             `AMBIGUOUS_MATCH: "${args.text}" matched ${candidates.length} elements. Use device_press with one of these refs, or retry with index: N.`,
             {
@@ -567,14 +646,18 @@ export function createDeviceFocusNextHandler(): (args: Record<string, never>) =>
     // Benchmark data: 4 serial finds = 10-22s on no-keyboard case; single
     // snapshot = 3-5s on the same case. Also more reliable — one accessibility
     // query races keyboard animations less than four sequential queries.
-    const nodes = await fetchSnapshotNodes();
-    if (!nodes) {
+    const snap = await fetchSnapshotNodes();
+    if (!snap.ok) {
+      if (snap.reason === 'runner-leak-unrecovered') {
+        return runnerLeakFailResult(undefined, snap.recoveryReason);
+      }
       return failResult(
         'Snapshot unavailable — cannot look for keyboard key. Retry after device_snapshot action=open/snapshot.',
         { code: 'SNAPSHOT_UNAVAILABLE' },
       );
     }
 
+    const { nodes, recoveredTier } = snap;
     for (const label of NEXT_KEY_LABELS) {
       const match = nodes.find((n) => n.label === label);
       if (!match) continue;
@@ -582,7 +665,12 @@ export function createDeviceFocusNextHandler(): (args: Record<string, never>) =>
       if (pressResult.isError) continue; // Match found but tap failed — try next label
       try {
         const envelope = JSON.parse(pressResult.content[0].text) as { ok: true; data: unknown };
-        return okResult(envelope.data, { meta: { keyUsed: label, ref: match.ref } });
+        const meta: Record<string, unknown> = { keyUsed: label, ref: match.ref };
+        if (recoveredTier) {
+          meta.recovered = 'agent-device-runner-leak';
+          meta.recoveryTier = recoveredTier;
+        }
+        return okResult(envelope.data, { meta });
       } catch {
         return pressResult;
       }

--- a/scripts/cdp-bridge/src/tools/device-session.ts
+++ b/scripts/cdp-bridge/src/tools/device-session.ts
@@ -12,6 +12,11 @@ import { stopFastRunner } from '../fast-runner-session.js';
 import type { ToolResult } from '../utils.js';
 import { okResult, failResult, warnResult } from '../utils.js';
 import { resolveBundleId } from '../project-config.js';
+import {
+  isAgentDeviceRunnerSentinel,
+  recoverFromRunnerLeak,
+  type RunnerLeakNode,
+} from './runner-leak-recovery.js';
 
 const execFile = promisify(execFileCb);
 
@@ -153,6 +158,7 @@ export function createDeviceSnapshotHandler(): (args: SnapshotArgs) => Promise<T
           platform: args.platform,
           deviceId,
           openedAt: new Date().toISOString(),
+          appId,
         });
 
         if (args.platform === 'ios' && deviceId) {
@@ -192,19 +198,153 @@ export function createDeviceSnapshotHandler(): (args: SnapshotArgs) => Promise<T
       );
     }
 
-    const result = await runAgentDevice(['snapshot', '-i']);
-    if (!result.isError) {
-      try {
-        const envelope = JSON.parse(result.content[0].text) as {
-          ok?: boolean;
-          data?: { nodes?: { ref: string; label?: string; identifier?: string; type?: string; hittable?: boolean }[] };
-        };
-        const platform = getActiveSession()?.platform;
-        if (platform && envelope.ok && envelope.data?.nodes) {
-          cacheSnapshot(platform, envelope.data.nodes);
-        }
-      } catch { /* best-effort cache */ }
+    const result = await rawSnapshot();
+    const nodes = parseSnapshotNodes(result);
+
+    if (!result.isError && nodes && isAgentDeviceRunnerSentinel(nodes)) {
+      const session = getActiveSession();
+      const recovery = await recoverFromRunnerLeak(
+        { platform: session?.platform, appId: session?.appId, sessionName: session?.name },
+        {
+          closeSession: () => runAgentDevice(['close']),
+          openSession: ({ appId, platform, attachOnly }) =>
+            reopenSessionForRecovery(appId, platform, attachOnly),
+          resnapshot: () => rawSnapshot(),
+          parseNodes: parseSnapshotNodes,
+        },
+      );
+
+      if (recovery.recovered) {
+        cacheSnapshotIfPossible(recovery.result);
+        return wrapWithMeta(recovery.result, {
+          recovered: 'agent-device-runner-leak',
+          recoveryTier: recovery.tier,
+        });
+      }
+
+      return failResult(runnerLeakFailureMessage(recovery.reason, session), {
+        code: 'RUNNER_LEAK',
+        recoveryReason: recovery.reason,
+        hint: runnerLeakFailureHint(recovery.reason, session),
+      });
     }
+
+    cacheSnapshotIfPossible(result);
     return result;
   };
+}
+
+export function runnerLeakFailureMessage(
+  reason: string | undefined,
+  session: { appId?: string } | null,
+): string {
+  if (reason === 'no-session-context' && session && !session.appId) {
+    return 'device_snapshot returned AgentDeviceRunner\'s own UI tree, but auto-recovery cannot run because the active session has no stored appId. This usually means the session was opened by a plugin version from before B119 / GH #35 landed.';
+  }
+  return 'device_snapshot returned AgentDeviceRunner\'s own UI tree instead of the target app (B119 / GH #35 — agent-device daemon dropped appBundleId on dispatch). Auto-recovery did not restore the target.';
+}
+
+export function runnerLeakFailureHint(
+  reason: string | undefined,
+  session: { appId?: string } | null,
+): string {
+  if (reason === 'no-session-context' && session && !session.appId) {
+    return 'Run device_snapshot action=close, then action=open appId=<your.bundle.id> platform=ios to start a session that supports auto-recovery.';
+  }
+  return 'Manually close + reopen the session with action=open appId=<your.bundle.id> platform=ios (full launch, not attachOnly). Upstream: Callstack/agent-device, see B119/GH#35.';
+}
+
+async function rawSnapshot(): Promise<ToolResult> {
+  return runAgentDevice(['snapshot', '-i']);
+}
+
+function parseSnapshotNodes(result: ToolResult): RunnerLeakNode[] | null {
+  if (result.isError) return null;
+  try {
+    const envelope = JSON.parse(result.content[0].text) as {
+      ok?: boolean;
+      data?: { nodes?: RunnerLeakNode[] };
+    };
+    if (!envelope.ok || !envelope.data?.nodes) return null;
+    return envelope.data.nodes;
+  } catch {
+    return null;
+  }
+}
+
+function cacheSnapshotIfPossible(result: ToolResult): void {
+  if (result.isError) return;
+  try {
+    const envelope = JSON.parse(result.content[0].text) as {
+      ok?: boolean;
+      data?: { nodes?: { ref: string; label?: string; identifier?: string; type?: string; hittable?: boolean }[] };
+    };
+    const platform = getActiveSession()?.platform;
+    if (platform && envelope.ok && envelope.data?.nodes) {
+      cacheSnapshot(platform, envelope.data.nodes);
+    }
+  } catch { /* best-effort cache */ }
+}
+
+function wrapWithMeta(result: ToolResult, meta: Record<string, unknown>): ToolResult {
+  if (result.isError) return result;
+  try {
+    const envelope = JSON.parse(result.content[0].text) as { ok?: boolean; data?: unknown; meta?: Record<string, unknown> };
+    envelope.meta = { ...envelope.meta, ...meta };
+    return { content: [{ type: 'text' as const, text: JSON.stringify(envelope) }] };
+  } catch {
+    return result;
+  }
+}
+
+export async function reopenSessionForRecovery(
+  appId: string,
+  platform: string,
+  attachOnly: boolean,
+): Promise<ToolResult> {
+  // Always mint a fresh recovery name (Gemini G3): reusing the original
+  // session name risks the daemon either rejecting as "already exists" or
+  // silently re-attaching to the corrupted session, defeating the rebuild.
+  const recoveryName = `rn-agent-recovery-${Date.now()}`;
+
+  let cliArgs: string[];
+  if (attachOnly) {
+    // attachOnly only makes sense if the target app is already running.
+    // Otherwise there's nothing to attach to and we should let the caller
+    // escalate (typically to the full-relaunch tier).
+    const running = await isAppRunning(platform, appId);
+    if (!running) {
+      return failResult(
+        `attachOnly recovery aborted: ${appId} is not running on ${platform}.`,
+        { code: 'NOT_CONNECTED', recoveryAbort: true },
+      );
+    }
+    cliArgs = ['open', '--session', recoveryName, '--platform', platform];
+  } else {
+    cliArgs = ['open', appId, '--session', recoveryName, '--platform', platform];
+  }
+
+  const result = await runAgentDevice(cliArgs, { skipSession: true });
+  if (result.isError) return result;
+
+  let deviceId: string | undefined;
+  try {
+    const envelope = JSON.parse(result.content[0].text);
+    const data = envelope?.data;
+    const rawId = data?.deviceId
+      ?? data?.device_udid
+      ?? data?.id
+      ?? (typeof data?.device === 'object' ? data?.device?.id : undefined);
+    const UDID_RE = /^[0-9A-Fa-f-]{25,}$/;
+    deviceId = typeof rawId === 'string' && UDID_RE.test(rawId) ? rawId : undefined;
+  } catch { /* best-effort */ }
+
+  setActiveSession({
+    name: recoveryName,
+    platform,
+    deviceId,
+    openedAt: new Date().toISOString(),
+    appId,
+  });
+  return result;
 }

--- a/scripts/cdp-bridge/src/tools/runner-leak-recovery.ts
+++ b/scripts/cdp-bridge/src/tools/runner-leak-recovery.ts
@@ -1,0 +1,172 @@
+import type { ToolResult } from '../utils.js';
+
+export interface RunnerLeakNode {
+  ref?: string;
+  label?: string;
+  identifier?: string;
+  type?: string;
+}
+
+const RUNNER_APP_LABEL = 'AgentDeviceRunner';
+const RUNNER_VISIBLE_TEXT = 'Agent Device Runner';
+const RUNNER_FINGERPRINT_IDENTIFIERS = new Set(['Logo', 'PoweredBy']);
+const SMALL_TREE_THRESHOLD = 12;
+
+/**
+ * B119/GH#35: detect when an iOS snapshot returned AgentDeviceRunner's own UI
+ * tree instead of the session's target app. This happens when the agent-device
+ * daemon dispatches a command to the Swift runner without `appBundleId`,
+ * causing RunnerTests+CommandExecution.swift:111-122 to clear `currentApp`
+ * and activate the runner itself. Snapshot succeeds but returns the wrong
+ * tree (~6 nodes including the runner's splash UI).
+ *
+ * Heuristic — both must hold:
+ *   1. Tree is small (<= 12 nodes) — real app trees are larger.
+ *   2. Either: any node label === "AgentDeviceRunner" (the Application node),
+ *      OR (visible "Agent Device Runner" text AND a fingerprint identifier).
+ *
+ * The double-check guards against rare false positives where a real app
+ * happens to contain the literal string "AgentDeviceRunner" but has many
+ * other elements.
+ */
+export function isAgentDeviceRunnerSentinel(nodes: RunnerLeakNode[] | null | undefined): boolean {
+  if (!nodes || nodes.length === 0) return false;
+  if (nodes.length > SMALL_TREE_THRESHOLD) return false;
+
+  const hasRunnerAppLabel = nodes.some((n) => n.label === RUNNER_APP_LABEL);
+  if (hasRunnerAppLabel) return true;
+
+  const hasVisibleText = nodes.some((n) => n.label === RUNNER_VISIBLE_TEXT);
+  const hasFingerprintId = nodes.some(
+    (n) => n.identifier !== undefined && RUNNER_FINGERPRINT_IDENTIFIERS.has(n.identifier),
+  );
+  return hasVisibleText && hasFingerprintId;
+}
+
+export interface RecoveryContext {
+  platform?: string;
+  appId?: string;
+  sessionName?: string;
+  alreadyRecovered?: boolean;
+}
+
+export interface OpenSessionArgs {
+  appId: string;
+  platform: string;
+  sessionName?: string;
+  attachOnly: boolean;
+}
+
+export interface RecoveryDeps {
+  closeSession: () => Promise<ToolResult>;
+  openSession: (args: OpenSessionArgs) => Promise<ToolResult>;
+  resnapshot: () => Promise<ToolResult>;
+  parseNodes: (result: ToolResult) => RunnerLeakNode[] | null;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const DAEMON_SETTLE_MS = 600;
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+export type RecoveryTier = 'attach-only' | 'full-relaunch';
+
+export interface RecoveryOutcome {
+  recovered: boolean;
+  result: ToolResult;
+  tier?: RecoveryTier;
+  reason?: 'no-session-context' | 'wrong-platform' | 'already-attempted' | 'still-sentinel' | 'reopen-failed';
+}
+
+/**
+ * B119: attempt to recover from the runner-leak failure mode in two tiers.
+ *
+ *   Tier 1 — attachOnly reopen. Preserves the user's app state (JS heap,
+ *   Hermes context, navigation stack, store state, form input). LIMITATION:
+ *   agent-device's attachOnly mode opens a session WITHOUT passing the
+ *   bundleId positional, so the daemon's SessionState.appBundleId stays
+ *   unset — meaning the very condition that triggers the leak persists. In
+ *   practice tier-1 will usually fail for this specific bug, but it's a
+ *   cheap try and would help in any adjacent failure mode where attaching
+ *   is enough.
+ *
+ *   Tier 2 — full app relaunch. Destructive (kills CDP context, drops
+ *   in-memory state, resets navigation, wipes ring buffers) but gives the
+ *   daemon a clean SessionState with appBundleId set.
+ *
+ * Returns { recovered: false } when prerequisites aren't met (no stored
+ * appId, non-iOS, or already-attempted). Caller decides whether to map
+ * that to a hard failure or a softer null/undefined sentinel.
+ */
+export async function recoverFromRunnerLeak(
+  ctx: RecoveryContext,
+  deps: RecoveryDeps,
+): Promise<RecoveryOutcome> {
+  if (ctx.alreadyRecovered) {
+    return { recovered: false, result: emptyResult(), reason: 'already-attempted' };
+  }
+  if ((ctx.platform ?? 'ios').toLowerCase() !== 'ios') {
+    return { recovered: false, result: emptyResult(), reason: 'wrong-platform' };
+  }
+  if (!ctx.appId) {
+    return { recovered: false, result: emptyResult(), reason: 'no-session-context' };
+  }
+
+  const sleep = deps.sleep ?? defaultSleep;
+
+  // Tier 1: attachOnly reopen — preserves app state when it works.
+  const tier1 = await attemptRecoveryCycle(ctx, deps, true, sleep);
+  if (tier1.phase === 'success') {
+    return { recovered: true, result: tier1.result, tier: 'attach-only' };
+  }
+
+  // Tier 2: full app relaunch — destructive but resets daemon state cleanly.
+  const tier2 = await attemptRecoveryCycle(ctx, deps, false, sleep);
+  if (tier2.phase === 'success') {
+    return { recovered: true, result: tier2.result, tier: 'full-relaunch' };
+  }
+
+  if (tier2.phase === 'sentinel') {
+    return { recovered: false, result: tier2.result, reason: 'still-sentinel' };
+  }
+  return { recovered: false, result: tier2.result, reason: 'reopen-failed' };
+}
+
+interface RecoveryCycleResult {
+  phase: 'reopen-failed' | 'snapshot-failed' | 'sentinel' | 'success';
+  result: ToolResult;
+}
+
+async function attemptRecoveryCycle(
+  ctx: RecoveryContext,
+  deps: RecoveryDeps,
+  attachOnly: boolean,
+  sleep: (ms: number) => Promise<void>,
+): Promise<RecoveryCycleResult> {
+  await deps.closeSession();
+  await sleep(DAEMON_SETTLE_MS);
+
+  const reopenResult = await deps.openSession({
+    appId: ctx.appId!,
+    platform: 'ios',
+    sessionName: ctx.sessionName,
+    attachOnly,
+  });
+  if (reopenResult.isError) {
+    return { phase: 'reopen-failed', result: reopenResult };
+  }
+
+  const retryResult = await deps.resnapshot();
+  if (retryResult.isError) {
+    return { phase: 'snapshot-failed', result: retryResult };
+  }
+
+  if (isAgentDeviceRunnerSentinel(deps.parseNodes(retryResult))) {
+    return { phase: 'sentinel', result: retryResult };
+  }
+  return { phase: 'success', result: retryResult };
+}
+
+function emptyResult(): ToolResult {
+  return { content: [{ type: 'text' as const, text: '' }] };
+}

--- a/scripts/cdp-bridge/src/types.ts
+++ b/scripts/cdp-bridge/src/types.ts
@@ -135,6 +135,12 @@ export interface SessionState {
   platform?: string;
   deviceId?: string;
   openedAt: string;
+  /**
+   * B35: bundleId saved at session-open time. Used by runner-leak-recovery to
+   * close+reopen the session when the agent-device daemon misroutes commands
+   * to AgentDeviceRunner instead of the target app on iOS.
+   */
+  appId?: string;
 }
 
 export interface FastRunnerState {

--- a/scripts/cdp-bridge/test/unit/runner-leak-recovery.test.js
+++ b/scripts/cdp-bridge/test/unit/runner-leak-recovery.test.js
@@ -1,0 +1,229 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isAgentDeviceRunnerSentinel,
+  recoverFromRunnerLeak,
+} from '../../dist/tools/runner-leak-recovery.js';
+
+const RUNNER_TREE = [
+  { ref: 'a', label: 'AgentDeviceRunner', type: 'Application' },
+  { ref: 'b', type: 'Window' },
+  { ref: 'c', identifier: 'Logo', type: 'Image' },
+  { ref: 'd', label: 'Agent Device Runner', type: 'StaticText' },
+  { ref: 'e', identifier: 'PoweredBy', type: 'Image' },
+  { ref: 'f', type: 'Other' },
+];
+
+const REAL_APP_TREE_SMALL = [
+  { ref: 'a', label: 'MyAwesomeApp', type: 'Application' },
+  { ref: 'b', type: 'Window' },
+  { ref: 'c', label: 'Welcome', type: 'StaticText' },
+];
+
+const REAL_APP_TREE_LARGE = Array.from({ length: 25 }, (_, i) => ({
+  ref: `r${i}`,
+  label: i === 0 ? 'AgentDeviceRunner' : `item-${i}`,
+  type: i === 0 ? 'Application' : 'Other',
+}));
+
+// ── isAgentDeviceRunnerSentinel ───────────────────────────────────────
+
+test('detects sentinel via Application label', () => {
+  assert.equal(isAgentDeviceRunnerSentinel(RUNNER_TREE), true);
+});
+
+test('detects sentinel via fingerprint identifier + visible text', () => {
+  const tree = [
+    { ref: 'b', type: 'Window' },
+    { ref: 'c', identifier: 'Logo', type: 'Image' },
+    { ref: 'd', label: 'Agent Device Runner', type: 'StaticText' },
+    { ref: 'e', identifier: 'PoweredBy', type: 'Image' },
+  ];
+  assert.equal(isAgentDeviceRunnerSentinel(tree), true);
+});
+
+test('does not detect on real app tree (different label)', () => {
+  assert.equal(isAgentDeviceRunnerSentinel(REAL_APP_TREE_SMALL), false);
+});
+
+test('does not detect on large tree even with matching label (size guard)', () => {
+  assert.equal(isAgentDeviceRunnerSentinel(REAL_APP_TREE_LARGE), false);
+});
+
+test('returns false for null/empty input', () => {
+  assert.equal(isAgentDeviceRunnerSentinel(null), false);
+  assert.equal(isAgentDeviceRunnerSentinel(undefined), false);
+  assert.equal(isAgentDeviceRunnerSentinel([]), false);
+});
+
+test('does not detect when only one fingerprint signal present', () => {
+  const onlyText = [
+    { ref: 'a', label: 'Some App', type: 'Application' },
+    { ref: 'b', label: 'Agent Device Runner', type: 'StaticText' },
+  ];
+  assert.equal(isAgentDeviceRunnerSentinel(onlyText), false);
+
+  const onlyId = [
+    { ref: 'a', label: 'Some App', type: 'Application' },
+    { ref: 'b', identifier: 'Logo', type: 'Image' },
+  ];
+  assert.equal(isAgentDeviceRunnerSentinel(onlyId), false);
+});
+
+// ── recoverFromRunnerLeak: precondition gates ─────────────────────────
+
+test('skips recovery when no appId in session context', async () => {
+  const ctx = { platform: 'ios', appId: undefined };
+  const deps = makeDepsRecording([]);
+  const out = await recoverFromRunnerLeak(ctx, deps);
+  assert.equal(out.recovered, false);
+  assert.equal(out.reason, 'no-session-context');
+  assert.equal(deps.calls.length, 0);
+});
+
+test('skips recovery on non-iOS platforms', async () => {
+  const ctx = { platform: 'android', appId: 'com.x' };
+  const deps = makeDepsRecording([]);
+  const out = await recoverFromRunnerLeak(ctx, deps);
+  assert.equal(out.recovered, false);
+  assert.equal(out.reason, 'wrong-platform');
+});
+
+test('skips recovery when alreadyRecovered=true', async () => {
+  const ctx = { platform: 'ios', appId: 'com.x', alreadyRecovered: true };
+  const deps = makeDepsRecording([]);
+  const out = await recoverFromRunnerLeak(ctx, deps);
+  assert.equal(out.recovered, false);
+  assert.equal(out.reason, 'already-attempted');
+});
+
+// ── recoverFromRunnerLeak: tier-1 attachOnly recovery ─────────────────
+
+test('tier-1 attachOnly success: returns recovered + tier=attach-only without escalating', async () => {
+  const cleanNodes = [{ ref: 'a', label: 'MyApp', type: 'Application' }];
+  const ctx = { platform: 'ios', appId: 'com.example.app', sessionName: 's1' };
+  const deps = makeDepsRecording([
+    { kind: 'close', result: okResult({}) },
+    { kind: 'open', result: okResult({ id: 'sim-udid' }), assertAttachOnly: true },
+    { kind: 'snapshot', result: okResult({ nodes: cleanNodes }) },
+  ]);
+
+  const out = await recoverFromRunnerLeak(ctx, deps);
+  assert.equal(out.recovered, true);
+  assert.equal(out.tier, 'attach-only');
+  assert.deepEqual(deps.calls.map(c => c.kind), ['close', 'open', 'snapshot']);
+  const openArgs = deps.calls.find(c => c.kind === 'open').args;
+  assert.equal(openArgs.appId, 'com.example.app');
+  assert.equal(openArgs.platform, 'ios');
+  assert.equal(openArgs.attachOnly, true);
+});
+
+// ── recoverFromRunnerLeak: tier-1 fails → tier-2 escalation ───────────
+
+test('tier-1 sentinel + tier-2 success: returns recovered + tier=full-relaunch', async () => {
+  const cleanNodes = [{ ref: 'a', label: 'MyApp', type: 'Application' }];
+  const ctx = { platform: 'ios', appId: 'com.example.app' };
+  const deps = makeDepsRecording([
+    // Tier 1 (attachOnly) — comes back with sentinel
+    { kind: 'close', result: okResult({}) },
+    { kind: 'open', result: okResult({ id: 'udid' }), assertAttachOnly: true },
+    { kind: 'snapshot', result: okResult({ nodes: RUNNER_TREE }) },
+    // Tier 2 (full relaunch) — returns clean nodes
+    { kind: 'close', result: okResult({}) },
+    { kind: 'open', result: okResult({ id: 'udid' }), assertAttachOnly: false },
+    { kind: 'snapshot', result: okResult({ nodes: cleanNodes }) },
+  ]);
+
+  const out = await recoverFromRunnerLeak(ctx, deps);
+  assert.equal(out.recovered, true);
+  assert.equal(out.tier, 'full-relaunch');
+  assert.equal(deps.calls.length, 6);
+});
+
+test('tier-1 reopen failure escalates to tier-2', async () => {
+  const cleanNodes = [{ ref: 'a', label: 'MyApp', type: 'Application' }];
+  const ctx = { platform: 'ios', appId: 'com.example.app' };
+  const deps = makeDepsRecording([
+    // Tier 1 — reopen fails (e.g., app not running so attachOnly aborts)
+    { kind: 'close', result: okResult({}) },
+    { kind: 'open', result: errResult('attachOnly recovery aborted'), assertAttachOnly: true },
+    // Tier 2 — full relaunch succeeds
+    { kind: 'close', result: okResult({}) },
+    { kind: 'open', result: okResult({ id: 'udid' }), assertAttachOnly: false },
+    { kind: 'snapshot', result: okResult({ nodes: cleanNodes }) },
+  ]);
+
+  const out = await recoverFromRunnerLeak(ctx, deps);
+  assert.equal(out.recovered, true);
+  assert.equal(out.tier, 'full-relaunch');
+});
+
+// ── recoverFromRunnerLeak: both tiers fail ────────────────────────────
+
+test('both tiers return sentinel: recovered=false with reason=still-sentinel', async () => {
+  const ctx = { platform: 'ios', appId: 'com.example.app' };
+  const deps = makeDepsRecording([
+    { kind: 'close', result: okResult({}) },
+    { kind: 'open', result: okResult({ id: 'udid' }), assertAttachOnly: true },
+    { kind: 'snapshot', result: okResult({ nodes: RUNNER_TREE }) },
+    { kind: 'close', result: okResult({}) },
+    { kind: 'open', result: okResult({ id: 'udid' }), assertAttachOnly: false },
+    { kind: 'snapshot', result: okResult({ nodes: RUNNER_TREE }) },
+  ]);
+
+  const out = await recoverFromRunnerLeak(ctx, deps);
+  assert.equal(out.recovered, false);
+  assert.equal(out.reason, 'still-sentinel');
+});
+
+test('both tiers reopen-fail: recovered=false with reason=reopen-failed', async () => {
+  const ctx = { platform: 'ios', appId: 'com.example.app' };
+  const deps = makeDepsRecording([
+    { kind: 'close', result: okResult({}) },
+    { kind: 'open', result: errResult('attachOnly aborted'), assertAttachOnly: true },
+    { kind: 'close', result: okResult({}) },
+    { kind: 'open', result: errResult('simulator not booted'), assertAttachOnly: false },
+  ]);
+
+  const out = await recoverFromRunnerLeak(ctx, deps);
+  assert.equal(out.recovered, false);
+  assert.equal(out.reason, 'reopen-failed');
+  assert.equal(out.result.isError, true);
+});
+
+// ── helpers ───────────────────────────────────────────────────────────
+
+function okResult(data) {
+  return { content: [{ type: 'text', text: JSON.stringify({ ok: true, data }) }] };
+}
+
+function errResult(msg) {
+  return { content: [{ type: 'text', text: JSON.stringify({ ok: false, error: msg }) }], isError: true };
+}
+
+function makeDepsRecording(scripted) {
+  const calls = [];
+  let i = 0;
+  const next = (kind, args) => {
+    calls.push({ kind, args });
+    const step = scripted[i++];
+    if (!step) throw new Error(`unexpected ${kind} call (no scripted step)`);
+    if (step.kind && step.kind !== kind) throw new Error(`expected ${step.kind} got ${kind}`);
+    if (kind === 'open' && step.assertAttachOnly !== undefined) {
+      assert.equal(args.attachOnly, step.assertAttachOnly, `open call ${i} attachOnly mismatch`);
+    }
+    return Promise.resolve(step.result);
+  };
+  return {
+    calls,
+    closeSession: () => next('close'),
+    openSession: (args) => next('open', args),
+    resnapshot: () => next('snapshot'),
+    parseNodes: (result) => {
+      try {
+        return JSON.parse(result.content[0].text).data?.nodes ?? null;
+      } catch { return null; }
+    },
+    sleep: () => Promise.resolve(),
+  };
+}


### PR DESCRIPTION
**Closes #35** (B119).

On iOS, `device_snapshot` / `device_find` / `device_press` silently returned AgentDeviceRunner's own UI tree instead of the session's target app. Root cause is upstream in `agent-device@0.8.0` (Callstack, third-party): when the daemon dispatches commands without `appBundleId`, the Swift runner clears its target reference and activates AgentDeviceRunner itself. The plugin cannot patch the dispatch layer — no per-command CLI flag, no protocol slot — so this PR ships a plugin-side **detection + two-tier auto-recovery + actionable failure** with full signal propagation.

## What this ships

- **Sentinel detector** (`runner-leak-recovery.ts::isAgentDeviceRunnerSentinel`): tree size ≤12 AND (Application label = `"AgentDeviceRunner"` OR (visible "Agent Device Runner" + fingerprint identifier "Logo"/"PoweredBy")). Two-signal AND-gate avoids false-positives on real RN apps.
- **Two-tier recovery**: tier 1 = `attachOnly` reopen (preserves app state when it works); tier 2 = full relaunch (destructive but resets daemon state). `RecoveryOutcome.tier` surfaced.
- **Discriminated result type** for `fetchSnapshotNodes` / `fetchFindCandidates` — `device_find` (exact/index + AMBIGUOUS_MATCH branches) and `device_focus_next` now surface a `RUNNER_LEAK` failResult instead of generic `SNAPSHOT_UNAVAILABLE`.
- **`meta.recovered` + `meta.recoveryTier`** wrapped on every successful caller path so LLM agents see the destructive side-effect and can re-establish CDP.
- **Pre-upgrade session hint** when the active session has no `appId` — points users at close + reopen rather than the generic post-recovery error.
- `SessionState.appId` saved at open time so recovery has a re-launch target.
- `reopenSessionForRecovery` always mints a fresh session name (avoid daemon "session already exists" collision).

## Honest caveat about tier-1

Because `agent-device`'s `attachOnly` mode opens a session WITHOUT passing the bundleId positional, the daemon's `SessionState.appBundleId` stays unset — meaning the very condition that triggers B119 persists. So tier-1 will usually fall through to tier-2 for this specific bug. Kept because (a) ~2-3s extra on a rare recovery is cheap, (b) preserves state in adjacent failure modes where attaching is enough, (c) `meta.recoveryTier` makes it observable so we can rip it out if production shows it never helps.

## Multi-provider review

Reviewed in parallel by Gemini and Codex via `/ask-llm:multi-review`. Both flagged the silent-side-effect on find/focus-next paths (consensus C1). Gemini also caught the pre-upgrade session compatibility (G1) and sessionName reuse risk (G3). All addressed in this PR; G2 (lifecycle symmetry — `closeSession` bypasses `clearActiveSession()`/`stopFastRunner()`) deferred — impact bounded, logged in D646.

## Test plan

- [x] `npm test` in `scripts/cdp-bridge/` — **286 / 286 passing** (was 273 pre-PR; +13 net for new sentinel + two-tier + edge case coverage)
- [x] `npm run build` — clean tsc
- [x] Sentinel detector — false-positive coverage on 25-node real-app tree, single-signal rejection, null/empty input
- [x] Recovery — tier-1 success path, tier-1→tier-2 escalation (sentinel and reopen-failure variants), both-tier failure paths
- [x] Precondition gates — no-appId, non-iOS, alreadyRecovered
- [ ] Live smoke on iOS sim (next session) — verify `meta.recoveryTier` surfaces and the `RUNNER_LEAK` error message renders cleanly

## Versions

- Plugin: `0.25.0` → `0.25.1`
- MCP server: `0.20.0` → `0.20.1`

## Refs

- Closes #35
- BUGS.md: B119
- DECISIONS.md: D645 (initial design), D646 (multi-review hardening)
- ROADMAP.md: Phase 93