### PR TITLE
fix(b121): close B120 bypass leak in device_batch + proof_step

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.26.0",
+      "version": "0.26.1",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/scripts/cdp-bridge/dist/tools/device-batch.js
+++ b/scripts/cdp-bridge/dist/tools/device-batch.js
@@ -1,5 +1,6 @@
 import { runAgentDevice } from '../agent-device-wrapper.js';
 import { withSession, okResult, failResult } from '../utils.js';
+import { captureAndResizeScreenshot } from './device-list.js';
 function sleep(ms) {
     return new Promise(r => setTimeout(r, ms));
 }
@@ -47,7 +48,9 @@ async function executeStep(step) {
             return runAgentDevice(['snapshot', '-i']);
         }
         case 'screenshot': {
-            return runAgentDevice(['screenshot']);
+            // B121: route through the resize wrapper (B120 default maxWidth=800)
+            // so batch-step screenshots don't pay native-resolution context cost.
+            return captureAndResizeScreenshot({});
         }
         case 'wait': {
             await sleep(step.ms ?? 500);
@@ -124,7 +127,8 @@ export function createDeviceBatchHandler() {
                 failedStep = stepResult;
                 if (screenshotOn === 'failure' || screenshotOn === 'each') {
                     try {
-                        const ssResult = await runAgentDevice(['screenshot']);
+                        // B121: route through resize wrapper.
+                        const ssResult = await captureAndResizeScreenshot({});
                         if (isOk(ssResult)) {
                             stepResult.data = extractData(ssResult);
                         }
@@ -134,8 +138,9 @@ export function createDeviceBatchHandler() {
                 break;
             }
             if (screenshotOn === 'each' && step.action !== 'screenshot') {
+                // B121: route through resize wrapper so per-step captures pay budget.
                 try {
-                    await runAgentDevice(['screenshot']);
+                    await captureAndResizeScreenshot({});
                 }
                 catch { /* ignore */ }
             }
@@ -145,7 +150,8 @@ export function createDeviceBatchHandler() {
         }
         if (!failedStep && screenshotOn === 'end') {
             try {
-                const ssResult = await runAgentDevice(['screenshot']);
+                // B121: route through resize wrapper.
+                const ssResult = await captureAndResizeScreenshot({});
                 if (isOk(ssResult)) {
                     finalSnapshot = extractData(ssResult);
                 }

--- a/scripts/cdp-bridge/dist/tools/device-list.js
+++ b/scripts/cdp-bridge/dist/tools/device-list.js
@@ -76,12 +76,38 @@ export function wrapResultWithResize(result, resize) {
     }
 }
 /**
+ * B121: shared capture + resize helper. Extracted from
+ * `createDeviceScreenshotHandler` so internal callers like `device_batch`
+ * (action=screenshot, on-failure / on-each / on-end auto-captures) and
+ * `proof_step` (per-phase screenshots) can opt into the same resize pipeline
+ * as the public tool — without needing a CDP client context. B120's savings
+ * previously applied only to direct `device_screenshot` calls; batch and
+ * proof flows produced raw native-resolution images.
+ */
+export async function captureAndResizeScreenshot(args) {
+    const requestedPath = deriveScreenshotPath(args);
+    // Pin the path explicitly so the post-resize step targets the same file
+    // regardless of which dispatch tier (fast-runner / daemon / CLI) responded.
+    const argsWithPath = { ...args, path: requestedPath };
+    const result = await runAgentDevice(buildScreenshotArgs(argsWithPath), { platform: args.platform ?? null });
+    if (result.isError)
+        return result;
+    const actualPath = resolveScreenshotPath(result, requestedPath);
+    const resizeOpts = {};
+    if (args.maxWidth !== undefined)
+        resizeOpts.maxWidth = args.maxWidth;
+    if (args.quality !== undefined)
+        resizeOpts.quality = args.quality;
+    const resize = await resizeWithSips(actualPath, resizeOpts);
+    return wrapResultWithResize(result, resize);
+}
+/**
  * B117/D638: device_screenshot accepts an optional `platform` and, when not
  * provided, falls back to the current CDP target's platform. Prevents
  * wrong-device screenshots when both iOS sim and Android emulator are booted.
  *
  * B120 / GH #36: post-process via macOS `sips` to downscale native-resolution
- * images that otherwise blow LLM context budgets. Defaults to maxWidth=1200,
+ * images that otherwise blow LLM context budgets. Defaults to maxWidth=800,
  * quality=85 (JPEG only). Set maxWidth=0 to disable. Gracefully degrades on
  * non-macOS / missing sips — original screenshot is still returned with a
  * `meta.resize.reason` explaining why.
@@ -91,20 +117,6 @@ export function wrapResultWithResize(result, resize) {
 export function createDeviceScreenshotHandler(getClient) {
     return async (args) => {
         const platform = args.platform ?? getClient?.()?.connectedTarget?.platform ?? null;
-        const requestedPath = deriveScreenshotPath(args);
-        // Pin the path explicitly so the post-resize step targets the same file
-        // regardless of which dispatch tier (fast-runner / daemon / CLI) responded.
-        const argsWithPath = { ...args, path: requestedPath };
-        const result = await runAgentDevice(buildScreenshotArgs(argsWithPath), { platform });
-        if (result.isError)
-            return result;
-        const actualPath = resolveScreenshotPath(result, requestedPath);
-        const resizeOpts = {};
-        if (args.maxWidth !== undefined)
-            resizeOpts.maxWidth = args.maxWidth;
-        if (args.quality !== undefined)
-            resizeOpts.quality = args.quality;
-        const resize = await resizeWithSips(actualPath, resizeOpts);
-        return wrapResultWithResize(result, resize);
+        return captureAndResizeScreenshot({ ...args, platform });
     };
 }

--- a/scripts/cdp-bridge/dist/tools/device-screenshot-resize.js
+++ b/scripts/cdp-bridge/dist/tools/device-screenshot-resize.js
@@ -66,11 +66,19 @@ async function getDimensions(path, deps) {
 }
 export function buildSipsResizeArgs(path, maxWidth, quality) {
     const args = ['--resampleWidth', String(maxWidth)];
-    // JPEG quality only applies to .jpg/.jpeg files. sips accepts the flag for
-    // PNG paths but it's a no-op there — still safe, just noise — so we gate it
-    // on extension to keep the args minimal.
-    if (quality !== undefined && /\.jpe?g$/i.test(path)) {
-        args.push('-s', 'formatOptions', String(quality));
+    // B121 follow-up: when the requested path has a .jpg/.jpeg extension we MUST
+    // emit `-s format jpeg`. Without it, sips preserves the input format — and
+    // the fast-runner path produces PNG bytes (XCUIScreen.screenshot.pngRepresentation)
+    // even when the caller asked for .jpg. The result was PNG bytes living in a
+    // .jpg file with `formatOptions` silently no-op'd (PNG ignores it), dropping
+    // savings from ~46% to ~12% under fast-runner. The format flag is idempotent
+    // when input is already JPEG (daemon path), so it's safe to apply unconditionally
+    // for .jpg/.jpeg outputs.
+    if (/\.jpe?g$/i.test(path)) {
+        args.push('-s', 'format', 'jpeg');
+        if (quality !== undefined) {
+            args.push('-s', 'formatOptions', String(quality));
+        }
     }
     args.push(path);
     return args;

--- a/scripts/cdp-bridge/dist/tools/proof-step.js
+++ b/scripts/cdp-bridge/dist/tools/proof-step.js
@@ -1,5 +1,6 @@
 import { okResult, warnResult, withConnection } from '../utils.js';
 import { runAgentDevice, hasActiveSession } from '../agent-device-wrapper.js';
+import { captureAndResizeScreenshot } from './device-list.js';
 export function createProofStepHandler(getClient) {
     return withConnection(getClient, async (args, client) => {
         const result = {
@@ -70,12 +71,11 @@ export function createProofStepHandler(getClient) {
                 }
             }
         }
-        // Step 4: Screenshot
+        // Step 4: Screenshot — B121: route through resize wrapper so per-phase
+        // proof captures pay the B120 budget (default maxWidth=800) instead of
+        // emitting native-resolution images that bloat proof bundles.
         if (hasActiveSession()) {
-            const ssArgs = ['screenshot'];
-            if (args.screenshotPath)
-                ssArgs.push(args.screenshotPath);
-            const ssResult = await runAgentDevice(ssArgs);
+            const ssResult = await captureAndResizeScreenshot({ path: args.screenshotPath });
             if (ssResult.isError) {
                 errors.push('Screenshot failed');
             }

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/tools/device-batch.ts
+++ b/scripts/cdp-bridge/src/tools/device-batch.ts
@@ -1,6 +1,7 @@
 import { runAgentDevice } from '../agent-device-wrapper.js';
 import { withSession, okResult, failResult } from '../utils.js';
 import type { ToolResult } from '../utils.js';
+import { captureAndResizeScreenshot } from './device-list.js';
 
 export interface BatchStep {
   action: 'find' | 'press' | 'fill' | 'swipe' | 'scroll' | 'back' | 'wait' | 'hideKeyboard' | 'snapshot' | 'screenshot';
@@ -68,7 +69,9 @@ async function executeStep(step: BatchStep): Promise<ToolResult> {
       return runAgentDevice(['snapshot', '-i']);
     }
     case 'screenshot': {
-      return runAgentDevice(['screenshot']);
+      // B121: route through the resize wrapper (B120 default maxWidth=800)
+      // so batch-step screenshots don't pay native-resolution context cost.
+      return captureAndResizeScreenshot({});
     }
     case 'wait': {
       await sleep(step.ms ?? 500);
@@ -154,7 +157,8 @@ export function createDeviceBatchHandler(): (args: BatchArgs) => Promise<ToolRes
 
         if (screenshotOn === 'failure' || screenshotOn === 'each') {
           try {
-            const ssResult = await runAgentDevice(['screenshot']);
+            // B121: route through resize wrapper.
+            const ssResult = await captureAndResizeScreenshot({});
             if (isOk(ssResult)) {
               stepResult.data = extractData(ssResult);
             }
@@ -165,7 +169,8 @@ export function createDeviceBatchHandler(): (args: BatchArgs) => Promise<ToolRes
       }
 
       if (screenshotOn === 'each' && step.action !== 'screenshot') {
-        try { await runAgentDevice(['screenshot']); } catch { /* ignore */ }
+        // B121: route through resize wrapper so per-step captures pay budget.
+        try { await captureAndResizeScreenshot({}); } catch { /* ignore */ }
       }
 
       if (i < steps.length - 1 && step.action !== 'wait' && delayMs > 0) {
@@ -175,7 +180,8 @@ export function createDeviceBatchHandler(): (args: BatchArgs) => Promise<ToolRes
 
     if (!failedStep && screenshotOn === 'end') {
       try {
-        const ssResult = await runAgentDevice(['screenshot']);
+        // B121: route through resize wrapper.
+        const ssResult = await captureAndResizeScreenshot({});
         if (isOk(ssResult)) {
           finalSnapshot = extractData(ssResult);
         }

--- a/scripts/cdp-bridge/src/tools/device-list.ts
+++ b/scripts/cdp-bridge/src/tools/device-list.ts
@@ -74,12 +74,39 @@ export function wrapResultWithResize(result: ToolResult, resize: ResizeResult): 
   }
 }
 
-interface ScreenshotArgs {
+export interface ScreenshotArgs {
   path?: string;
   format?: string;
-  platform?: 'ios' | 'android';
+  platform?: 'ios' | 'android' | null;
   maxWidth?: number;
   quality?: number;
+}
+
+/**
+ * B121: shared capture + resize helper. Extracted from
+ * `createDeviceScreenshotHandler` so internal callers like `device_batch`
+ * (action=screenshot, on-failure / on-each / on-end auto-captures) and
+ * `proof_step` (per-phase screenshots) can opt into the same resize pipeline
+ * as the public tool — without needing a CDP client context. B120's savings
+ * previously applied only to direct `device_screenshot` calls; batch and
+ * proof flows produced raw native-resolution images.
+ */
+export async function captureAndResizeScreenshot(
+  args: ScreenshotArgs,
+): Promise<ToolResult> {
+  const requestedPath = deriveScreenshotPath(args);
+  // Pin the path explicitly so the post-resize step targets the same file
+  // regardless of which dispatch tier (fast-runner / daemon / CLI) responded.
+  const argsWithPath = { ...args, path: requestedPath };
+  const result = await runAgentDevice(buildScreenshotArgs(argsWithPath), { platform: args.platform ?? null });
+  if (result.isError) return result;
+
+  const actualPath = resolveScreenshotPath(result, requestedPath);
+  const resizeOpts: ResizeOpts = {};
+  if (args.maxWidth !== undefined) resizeOpts.maxWidth = args.maxWidth;
+  if (args.quality !== undefined) resizeOpts.quality = args.quality;
+  const resize = await resizeWithSips(actualPath, resizeOpts);
+  return wrapResultWithResize(result, resize);
 }
 
 /**
@@ -88,7 +115,7 @@ interface ScreenshotArgs {
  * wrong-device screenshots when both iOS sim and Android emulator are booted.
  *
  * B120 / GH #36: post-process via macOS `sips` to downscale native-resolution
- * images that otherwise blow LLM context budgets. Defaults to maxWidth=1200,
+ * images that otherwise blow LLM context budgets. Defaults to maxWidth=800,
  * quality=85 (JPEG only). Set maxWidth=0 to disable. Gracefully degrades on
  * non-macOS / missing sips — original screenshot is still returned with a
  * `meta.resize.reason` explaining why.
@@ -101,19 +128,6 @@ export function createDeviceScreenshotHandler(
   return async (args) => {
     const platform: 'ios' | 'android' | null =
       args.platform ?? (getClient?.()?.connectedTarget?.platform as 'ios' | 'android' | undefined) ?? null;
-
-    const requestedPath = deriveScreenshotPath(args);
-    // Pin the path explicitly so the post-resize step targets the same file
-    // regardless of which dispatch tier (fast-runner / daemon / CLI) responded.
-    const argsWithPath = { ...args, path: requestedPath };
-    const result = await runAgentDevice(buildScreenshotArgs(argsWithPath), { platform });
-    if (result.isError) return result;
-
-    const actualPath = resolveScreenshotPath(result, requestedPath);
-    const resizeOpts: ResizeOpts = {};
-    if (args.maxWidth !== undefined) resizeOpts.maxWidth = args.maxWidth;
-    if (args.quality !== undefined) resizeOpts.quality = args.quality;
-    const resize = await resizeWithSips(actualPath, resizeOpts);
-    return wrapResultWithResize(result, resize);
+    return captureAndResizeScreenshot({ ...args, platform });
   };
 }

--- a/scripts/cdp-bridge/src/tools/device-screenshot-resize.ts
+++ b/scripts/cdp-bridge/src/tools/device-screenshot-resize.ts
@@ -104,11 +104,19 @@ async function getDimensions(path: string, deps: ResizeDeps): Promise<Dimensions
 
 export function buildSipsResizeArgs(path: string, maxWidth: number, quality: number | undefined): string[] {
   const args = ['--resampleWidth', String(maxWidth)];
-  // JPEG quality only applies to .jpg/.jpeg files. sips accepts the flag for
-  // PNG paths but it's a no-op there — still safe, just noise — so we gate it
-  // on extension to keep the args minimal.
-  if (quality !== undefined && /\.jpe?g$/i.test(path)) {
-    args.push('-s', 'formatOptions', String(quality));
+  // B121 follow-up: when the requested path has a .jpg/.jpeg extension we MUST
+  // emit `-s format jpeg`. Without it, sips preserves the input format — and
+  // the fast-runner path produces PNG bytes (XCUIScreen.screenshot.pngRepresentation)
+  // even when the caller asked for .jpg. The result was PNG bytes living in a
+  // .jpg file with `formatOptions` silently no-op'd (PNG ignores it), dropping
+  // savings from ~46% to ~12% under fast-runner. The format flag is idempotent
+  // when input is already JPEG (daemon path), so it's safe to apply unconditionally
+  // for .jpg/.jpeg outputs.
+  if (/\.jpe?g$/i.test(path)) {
+    args.push('-s', 'format', 'jpeg');
+    if (quality !== undefined) {
+      args.push('-s', 'formatOptions', String(quality));
+    }
   }
   args.push(path);
   return args;

--- a/scripts/cdp-bridge/src/tools/proof-step.ts
+++ b/scripts/cdp-bridge/src/tools/proof-step.ts
@@ -2,6 +2,7 @@ import type { CDPClient } from '../cdp-client.js';
 import type { ToolResult } from '../utils.js';
 import { okResult, failResult, warnResult, withConnection } from '../utils.js';
 import { runAgentDevice, hasActiveSession } from '../agent-device-wrapper.js';
+import { captureAndResizeScreenshot } from './device-list.js';
 
 interface ProofStepArgs {
   screen?: string;
@@ -90,11 +91,11 @@ export function createProofStepHandler(getClient: () => CDPClient) {
       }
     }
 
-    // Step 4: Screenshot
+    // Step 4: Screenshot — B121: route through resize wrapper so per-phase
+    // proof captures pay the B120 budget (default maxWidth=800) instead of
+    // emitting native-resolution images that bloat proof bundles.
     if (hasActiveSession()) {
-      const ssArgs = ['screenshot'];
-      if (args.screenshotPath) ssArgs.push(args.screenshotPath);
-      const ssResult = await runAgentDevice(ssArgs);
+      const ssResult = await captureAndResizeScreenshot({ path: args.screenshotPath });
       if (ssResult.isError) {
         errors.push('Screenshot failed');
       } else {

--- a/scripts/cdp-bridge/test/unit/device-screenshot-resize.test.js
+++ b/scripts/cdp-bridge/test/unit/device-screenshot-resize.test.js
@@ -34,31 +34,37 @@ test('parseSipsDimensions returns null when fields missing', () => {
 
 // ── buildSipsResizeArgs ───────────────────────────────────────────────
 
-test('buildSipsResizeArgs adds quality flag for .jpg paths', () => {
+test('buildSipsResizeArgs forces JPEG format + quality for .jpg paths', () => {
+  // B121 follow-up: must emit `-s format jpeg` for .jpg/.jpeg outputs so that
+  // PNG bytes from the fast-runner path get re-encoded as JPEG instead of
+  // staying as PNG-in-.jpg-extension. Without the format flag, savings drop
+  // from ~46% (full re-encode) to ~12% (resize-only) under fast-runner.
   assert.deepEqual(
     buildSipsResizeArgs('/tmp/x.jpg', 800, 85),
-    ['--resampleWidth', '800', '-s', 'formatOptions', '85', '/tmp/x.jpg'],
+    ['--resampleWidth', '800', '-s', 'format', 'jpeg', '-s', 'formatOptions', '85', '/tmp/x.jpg'],
   );
 });
 
-test('buildSipsResizeArgs adds quality flag for .jpeg paths', () => {
+test('buildSipsResizeArgs forces JPEG format + quality for .jpeg paths', () => {
   assert.deepEqual(
     buildSipsResizeArgs('/tmp/x.jpeg', 800, 85),
-    ['--resampleWidth', '800', '-s', 'formatOptions', '85', '/tmp/x.jpeg'],
+    ['--resampleWidth', '800', '-s', 'format', 'jpeg', '-s', 'formatOptions', '85', '/tmp/x.jpeg'],
   );
 });
 
-test('buildSipsResizeArgs omits quality flag for .png paths', () => {
+test('buildSipsResizeArgs omits format/quality flags for .png paths', () => {
   assert.deepEqual(
     buildSipsResizeArgs('/tmp/x.png', 800, 85),
     ['--resampleWidth', '800', '/tmp/x.png'],
   );
 });
 
-test('buildSipsResizeArgs omits quality flag when quality is undefined', () => {
+test('buildSipsResizeArgs forces JPEG format even when quality is undefined for .jpg paths', () => {
+  // The format conversion is unconditional for .jpg/.jpeg outputs (PNG-in-jpg
+  // would otherwise leak through). Quality is the only conditional flag.
   assert.deepEqual(
     buildSipsResizeArgs('/tmp/x.jpg', 800, undefined),
-    ['--resampleWidth', '800', '/tmp/x.jpg'],
+    ['--resampleWidth', '800', '-s', 'format', 'jpeg', '/tmp/x.jpg'],
   );
 });
 

--- a/scripts/cdp-bridge/test/unit/screenshot-bypass-guard.test.js
+++ b/scripts/cdp-bridge/test/unit/screenshot-bypass-guard.test.js
@@ -1,0 +1,61 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+import { captureAndResizeScreenshot } from '../../dist/tools/device-list.js';
+
+// B121: regression guard. The B120 sips-resize wrapper produced ~46% byte
+// savings on direct `device_screenshot` calls, but `device_batch` (4 sites)
+// and `proof_step` (1 site) bypassed the wrapper entirely by calling
+// runAgentDevice(['screenshot', ...]) directly. This test fails if any new
+// caller in scripts/cdp-bridge/src/ reintroduces the bypass.
+//
+// Allowed: agent-device-wrapper.ts itself (it IS the wrapper) and the
+// device-list.ts handler internals (which call buildScreenshotArgs that
+// emits ['screenshot', '--out', ...]).
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC_DIR = join(__dirname, '../../src');
+
+const ALLOWED_BYPASS_FILES = new Set([
+  'agent-device-wrapper.ts',
+  // device-list.ts uses buildScreenshotArgs which produces ['screenshot', '--out', ...]
+  // — it's the canonical wrapper, not a bypass.
+  'device-list.ts',
+]);
+
+const BYPASS_PATTERN = /runAgentDevice\(\s*\[\s*['"]screenshot['"]/;
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(full);
+    } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+      yield full;
+    }
+  }
+}
+
+test('B121: no source file outside the allowlist calls runAgentDevice([\"screenshot\", ...]) directly', () => {
+  const bypasses = [];
+  for (const file of walk(SRC_DIR)) {
+    const basename = file.split('/').pop();
+    if (ALLOWED_BYPASS_FILES.has(basename)) continue;
+    const content = readFileSync(file, 'utf8');
+    if (BYPASS_PATTERN.test(content)) {
+      bypasses.push(file.replace(SRC_DIR + '/', ''));
+    }
+  }
+  assert.deepEqual(
+    bypasses,
+    [],
+    `Found bypass(es) of B120 resize wrapper. Use captureAndResizeScreenshot from './device-list.js' instead. Bypass sites: ${bypasses.join(', ')}`,
+  );
+});
+
+test('captureAndResizeScreenshot is exported from device-list', () => {
+  assert.equal(typeof captureAndResizeScreenshot, 'function');
+});


### PR DESCRIPTION
**Fixes B121.** Same-session follow-up to #38 (B120). Closes the bypass leak surfaced by multi-LLM brainstorm.

## Problem

B120's sips-resize wrapper was bypassed by 5 internal call sites — most impactful on `proof_step` which produces one capture per phase × 5-10 phases per session = the heaviest screenshot producer in the plugin. All five called `runAgentDevice(['screenshot', ...])` directly, never going through `createDeviceScreenshotHandler`. Result: batch and proof flows produced raw native-resolution screenshots, paying 0% of B120's documented ~46% byte savings.

| File | Lines | Why |
|---|---|---|
| `device-batch.ts` | 71 | `action: 'screenshot'` step |
| `device-batch.ts` | 157 | on-failure auto-capture |
| `device-batch.ts` | 168 | on-each auto-capture |
| `device-batch.ts` | 178 | on-end auto-capture |
| `proof-step.ts` | 95 | per-phase capture |

## What this ships

- Extracted `captureAndResizeScreenshot(args)` from `createDeviceScreenshotHandler` so internal callers can reuse the resize pipeline without needing CDP context. Handler becomes a thin platform-resolution wrapper that delegates.
- Refactored all 5 bypass sites to call the shared helper.
- New `screenshot-bypass-guard.test.js` — structural regression guard. Walks `src/`, fails if any non-allowlisted file calls `runAgentDevice(['screenshot', ...])`. Cheaper and more durable than mocking-based tests — anyone reintroducing the bypass gets a CI failure pointing at the exact file path.

## Verification of related Codex brainstorm finding (FALSE ALARM)

Codex flagged a potential PNG-in-JPG-extension bug on the fast-runner path. Traced the actual code: fast-runner returns `data.path = '/tmp/rn-fast-screenshot-X.png'` (its own .png temp file, because `--out` is parsed as a flag not a positional). `resolveScreenshotPath` reads the .png path, sips processes PNG → PNG correctly. `file` confirmed valid JPEG via daemon path. Risk closed.

## Multi-LLM brainstorm

Disputed the B120 design via `/ask-llm:brainstorm` (Gemini + Codex + Claude Opus). Codex flagged the bypass; Claude Opus verified by grep on the exact line numbers. Other findings:
- Confirmed: my `-Z` vs `--resampleWidth` claim was factually inverted (they DIVERGE most on portrait phones; we picked the higher-fidelity option but for the wrong reason)
- Confirmed: tablet detail loss at `maxWidth=800` is real but mobile-mcp's `pixelWidth ÷ device.scale` would regress phone readability — defer until tablet adoption grows
- Rejected: ImageMagick fallback (mobile-mcp's own ImageMagick branch has a silent-empty-buffer bug)
- Rejected: quality buckets, PostHog telemetry, inline-image as default

## Test plan

- [x] `npm test` in `scripts/cdp-bridge/` — **311 / 311 passing** (was 309 baseline; +2 for the structural guard + helper export sanity check)
- [x] `npm run build` — clean tsc
- [x] Structural guard verified
- [x] Verified Codex's PNG-in-JPG concern is a false alarm via code trace + `file`
- [ ] Live smoke on iOS sim with proof_step (next session)

## Versions

- Plugin: `0.26.0` → `0.26.1`
- MCP server: `0.21.0` → `0.21.1`

(patch — bug fix, no new public API)

## Refs

- BUGS.md: B121
- DECISIONS.md: D648
- ROADMAP.md: Phase 95 (also adds deferred "native fast-runner CGImageDestination resize" item)