### PR TITLE
fix(issue-40): bundled flow-driving fixes — B122-B126

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.26.2",
+      "version": "0.27.0",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.26.2",
+  "version": "0.27.0",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -312,19 +312,21 @@ trackedTool('device_press', 'Tap a UI element by its @ref from device_snapshot. 
     holdMs: z.number().int().min(0).max(10000).optional().describe('Hold duration in ms (for long-press via ref)'),
     waitForFocusMs: z.number().int().min(0).max(5000).optional().describe('Sleep this many ms after tap to let keyboard focus settle — useful in sequential press+fill flows where focus would otherwise not propagate.'),
 }, createDevicePressHandler());
-trackedTool('device_fill', 'Type text into an input field by its @ref from device_snapshot. Always re-taps the element first so keyboard focus is on the correct field even in sequential fills. On "no focused text input" errors, automatically falls back: coordinate re-tap + retry → Android adb input / iOS Maestro inputText. Check meta.fallbackUsed in the result to see which strategy succeeded. Requires an open session.', {
+trackedTool('device_fill', 'Type text into an input field by its @ref from device_snapshot. Always re-taps the element first so keyboard focus is on the correct field even in sequential fills. On "no focused text input" errors, automatically falls back: Pressable→TextInput resolution (B122 — common RN design-system pattern where outer Pressable wraps inner TextInput) → coordinate re-tap + retry → Android adb input / iOS Maestro inputText. Check meta.fallbackUsed in the result to see which strategy succeeded. Requires an open session.', {
     ref: z.string().describe('Input field ref from device_snapshot (e.g. "e5" or "@e5")'),
     text: z.string().describe('Text to type into the field'),
+    waitForKeyboardMs: z.number().int().min(0).max(5000).optional().describe('Wait between pre-tap and fill probe in ms (default 150). Bump to 500-1000ms when filling Pressable-wrapped TextInputs on slow keyboard animations to give RN native focus dispatch time to land.'),
 }, createDeviceFillHandler());
-trackedTool('device_swipe', 'Swipe on the device screen. Use direction for simple scrolling, or x1/y1/x2/y2 for precise coordinate-based swipes (drag-to-reorder, bottom sheets). Requires an open session.', {
+trackedTool('device_swipe', 'Swipe on the device screen. Use direction for simple scrolling, or x1/y1/x2/y2 for precise coordinate-based swipes (drag-to-reorder, bottom sheets). Pass exact: true to require fast-runner (precise unclamped duration) — needed for momentum-sensitive UIs like UIDatePicker wheels where the agent-device daemon\'s safe-normalized 60ms cap causes overshoot. Requires an open session.', {
     direction: z.enum(['up', 'down', 'left', 'right']).optional().describe('Simple directional swipe (delegates to scroll)'),
     x1: z.number().optional().describe('Start X coordinate (use with y1, x2, y2 for precise swipes)'),
     y1: z.number().optional().describe('Start Y coordinate'),
     x2: z.number().optional().describe('End X coordinate'),
     y2: z.number().optional().describe('End Y coordinate'),
-    durationMs: z.number().int().min(50).max(10000).optional().describe('Swipe duration in ms (slower = more precise, default ~300)'),
-    count: z.number().int().min(1).max(50).optional().describe('Repeat swipe N times'),
-    pattern: z.enum(['one-way', 'ping-pong']).optional().describe('Repeat pattern: one-way (reset to start) or ping-pong (reverse direction)'),
+    durationMs: z.number().int().min(50).max(10000).optional().describe('Swipe duration in ms (slower = more precise, default ~300). Note: agent-device daemon caps at ~60ms via safe-normalized timing — use exact: true to bypass.'),
+    count: z.number().int().min(1).max(50).optional().describe('Repeat swipe N times (incompatible with exact: true)'),
+    pattern: z.enum(['one-way', 'ping-pong']).optional().describe('Repeat pattern: one-way (reset to start) or ping-pong (reverse direction). Incompatible with exact: true.'),
+    exact: z.boolean().optional().describe('B123: REQUIRE fast-runner (no daemon fallback). Preserves user-supplied durationMs verbatim — needed for slow precise swipes on UIDatePicker wheels and similar momentum-sensitive UIs. Fails with EXACT_REQUIRES_FAST_RUNNER if fast-runner unavailable instead of silently degrading.'),
 }, createDeviceSwipeHandler());
 trackedTool('device_back', 'Press the system back button (Android) or perform back navigation gesture (iOS). Requires an open session.', {}, createDeviceBackHandler());
 trackedTool('device_longpress', 'Long press on an element or coordinates. Use for context menus, drag initiation, or hold-to-delete. Requires an open session.', {

--- a/scripts/cdp-bridge/dist/injected-helpers.js
+++ b/scripts/cdp-bridge/dist/injected-helpers.js
@@ -945,6 +945,11 @@ export const INJECTED_HELPERS = `
     // B90 fix: Prefer fiber-walked store over __REDUX_STORE__ global.
     // After Dev Client rebuilds, the global may reference the OLD store instance
     // while the fiber tree always reflects the CURRENT React context.
+    //
+    // B125 fix: also check current.type.name as a fallback when displayName
+    // is missing — common for minified/bundled Providers. Mirrors what
+    // findFiberReduxStore already does for getStoreState. Without this,
+    // cdp_store_state succeeds but cdp_dispatch fails on the same app.
     var store = null;
     var storeRenderer = findActiveRenderer();
     if (storeRenderer) {
@@ -953,7 +958,8 @@ export const INJECTED_HELPERS = `
         var current = fiber;
         while (current) {
           if ((depth || 0) > 30) return null;
-          if (current.type && current.type.displayName === 'Provider' && current.memoizedProps && current.memoizedProps.store && current.memoizedProps.store.dispatch) {
+          var typeName = current.type && (current.type.displayName || current.type.name);
+          if (typeName === 'Provider' && current.memoizedProps && current.memoizedProps.store && current.memoizedProps.store.dispatch) {
             return current.memoizedProps.store;
           }
           var found = findDispatchStore(current.child, (depth || 0) + 1);

--- a/scripts/cdp-bridge/dist/tools/device-interact.js
+++ b/scripts/cdp-bridge/dist/tools/device-interact.js
@@ -167,6 +167,35 @@ export function createDeviceFindHandler() {
         return result;
     });
 }
+// B122: helper to resolve a Pressable-wrapping ref to its inner TextInput ref.
+// Common RN design-system pattern: outer Pressable with testID `${name}-pressable`
+// imperatively focuses an inner TextInput whose testID is `${name}`. When
+// device_fill targets the Pressable directly, the focus hasn't propagated to
+// the TextInput by the time we probe — primary fill fails with "no focused
+// text input to clear". Re-resolving to the inner TextInput's ref and re-tapping
+// directly forces native focus into the right element.
+//
+// Heuristic — both must hold:
+//   1. The ref's node has identifier ending in `-pressable`.
+//   2. There is a sibling/descendant node whose identifier === stripped(identifier)
+//      AND whose type is one of TextField, SecureTextField, or TextView.
+//
+// Returns the resolved ref (with leading `@`) or null if no match.
+const TEXT_INPUT_TYPES = new Set(['TextField', 'SecureTextField', 'TextView', 'EditText']);
+const PRESSABLE_SUFFIX = '-pressable';
+export function findInputForPressable(nodes, pressableRef) {
+    if (!nodes)
+        return null;
+    const cleanRef = pressableRef.replace(/^@/, '');
+    const pressableNode = nodes.find((n) => n.ref === cleanRef);
+    if (!pressableNode?.identifier?.endsWith(PRESSABLE_SUFFIX))
+        return null;
+    const baseId = pressableNode.identifier.slice(0, -PRESSABLE_SUFFIX.length);
+    if (!baseId)
+        return null;
+    const inputNode = nodes.find((n) => n.identifier === baseId && n.type !== undefined && TEXT_INPUT_TYPES.has(n.type));
+    return inputNode ? `@${inputNode.ref}` : null;
+}
 export function createDevicePressHandler() {
     return withSession(async (args) => {
         const ref = args.ref.startsWith('@') ? args.ref : `@${args.ref}`;
@@ -301,6 +330,7 @@ export function createDeviceFillHandler() {
             await sleep(300);
             return androidClipboardFill(args.text);
         }
+        const focusWaitMs = args.waitForKeyboardMs ?? FOCUS_DELAY_MS;
         // G6: Always tap before fill so keyboard focus lands on this @ref, even in sequential
         // press+fill+press+fill flows where the previous call left focus on a different field.
         const preTap = await runAgentDevice(['press', ref]);
@@ -309,7 +339,7 @@ export function createDeviceFillHandler() {
             // work via the fast-runner coordinate path, and we want its error message, not ours.
         }
         else {
-            await sleep(FOCUS_DELAY_MS);
+            await sleep(focusWaitMs);
         }
         const primary = await runAgentDevice(['fill', ref, args.text]);
         if (!primary.isError) {
@@ -318,6 +348,32 @@ export function createDeviceFillHandler() {
         // G4: Fallback chain for "no focused text input to clear" and similar focus errors.
         if (!isNoFocusedInputError(primary)) {
             return primary;
+        }
+        // B122: Pressable→TextInput resolution. Common RN design-system pattern is
+        // an outer Pressable (testID `${name}-pressable`) that imperatively focuses
+        // an inner TextInput (testID `${name}`). The Pressable absorbs the tap and
+        // the focus dispatches asynchronously, so by the time we probe, focus
+        // hasn't propagated. Resolve to the inner ref and tap THAT directly — much
+        // more reliable than waiting + retapping the wrapper.
+        const snap = await fetchSnapshotNodes();
+        if (snap.ok) {
+            const resolvedRef = findInputForPressable(snap.nodes, ref);
+            if (resolvedRef && resolvedRef !== ref) {
+                const innerTap = await runAgentDevice(['press', resolvedRef]);
+                if (!innerTap.isError) {
+                    await sleep(focusWaitMs);
+                    const resolved = await runAgentDevice(['fill', resolvedRef, args.text]);
+                    if (!resolved.isError) {
+                        try {
+                            const envelope = JSON.parse(resolved.content[0].text);
+                            return okResult(envelope.data, { meta: { fallbackUsed: 'pressable-resolution', resolvedRef } });
+                        }
+                        catch {
+                            return resolved;
+                        }
+                    }
+                }
+            }
         }
         // Fallback 1: coordinate re-tap + retry fill. Re-tap gives the UI another chance
         // to propagate focus from a wrapping Pressable to the inner TextInput.
@@ -373,6 +429,12 @@ function computeSwipeFromDirection(direction, screen) {
         case 'right': return { x1: cx - dx, y1: cy, x2: cx + dx, y2: cy };
     }
 }
+export function exactModeRejectionMessage(reason) {
+    if (reason === 'count-pattern-incompatible') {
+        return 'exact: true is incompatible with count/pattern (those route through agent-device daemon which enforces safe-normalized timing). Drop count/pattern or drop exact.';
+    }
+    return 'exact: true requires fast-runner (iOS only, session must be open). Fast-runner unavailable — open a device session via device_snapshot action=open, then retry.';
+}
 export function createDeviceSwipeHandler() {
     return withSession(async (args) => {
         // B106 fix: use fast-runner's HID-level synthesis to bypass XCTest
@@ -380,6 +442,16 @@ export function createDeviceSwipeHandler() {
         // fast-runner is available (iOS) and count/pattern are not used (those
         // are daemon-specific features — fall back to agent-device for them).
         const canUseFastRunner = isFastRunnerAvailable() && !args.count && !args.pattern;
+        // B123: exact: true requires fast-runner. Fail loud if unavailable instead
+        // of silently degrading to a 60ms-capped daemon swipe.
+        if (args.exact === true) {
+            if (args.count || args.pattern) {
+                return failResult(exactModeRejectionMessage('count-pattern-incompatible'), { code: 'EXACT_INCOMPATIBLE', hint: 'count and pattern only work via agent-device daemon, which enforces safe-normalized timing. Drop one to proceed.' });
+            }
+            if (!isFastRunnerAvailable()) {
+                return failResult(exactModeRejectionMessage('fast-runner-unavailable'), { code: 'EXACT_REQUIRES_FAST_RUNNER', hint: 'fast-runner is the only path that respects user-supplied durationMs verbatim. Open a device session first.' });
+            }
+        }
         if (args.x1 != null && args.y1 != null && args.x2 != null && args.y2 != null) {
             if (canUseFastRunner) {
                 try {
@@ -387,8 +459,16 @@ export function createDeviceSwipeHandler() {
                     if (resp.ok) {
                         return okResult({ x1: args.x1, y1: args.y1, x2: args.x2, y2: args.y2, durationMs: args.durationMs, method: 'fast-runner' });
                     }
+                    if (args.exact === true) {
+                        return failResult('fast-runner swipe call failed and exact: true forbids daemon fallback', { code: 'EXACT_FAST_RUNNER_FAILED' });
+                    }
                 }
-                catch { /* fall through */ }
+                catch (err) {
+                    if (args.exact === true) {
+                        return failResult(`fast-runner swipe call threw and exact: true forbids daemon fallback: ${err instanceof Error ? err.message : String(err)}`, { code: 'EXACT_FAST_RUNNER_FAILED' });
+                    }
+                    /* fall through */
+                }
             }
             const cliArgs = ['swipe', String(args.x1), String(args.y1), String(args.x2), String(args.y2)];
             if (args.durationMs)
@@ -410,8 +490,16 @@ export function createDeviceSwipeHandler() {
                     if (resp.ok) {
                         return okResult({ direction: args.direction, durationMs: duration, method: 'fast-runner', ...coords });
                     }
+                    if (args.exact === true) {
+                        return failResult('fast-runner swipe call failed and exact: true forbids daemon fallback', { code: 'EXACT_FAST_RUNNER_FAILED' });
+                    }
                 }
-                catch { /* fall through */ }
+                catch (err) {
+                    if (args.exact === true) {
+                        return failResult(`fast-runner swipe call threw and exact: true forbids daemon fallback: ${err instanceof Error ? err.message : String(err)}`, { code: 'EXACT_FAST_RUNNER_FAILED' });
+                    }
+                    /* fall through */
+                }
             }
             const cliArgs = ['swipe', String(coords.x1), String(coords.y1), String(coords.x2), String(coords.y2), String(duration)];
             if (args.count && args.count > 1)

--- a/scripts/cdp-bridge/dist/tools/nav-graph.js
+++ b/scripts/cdp-bridge/dist/tools/nav-graph.js
@@ -4,6 +4,35 @@ import { findProjectRoot, readGraph, writeGraph, buildGraph, mergeGraph, getGrap
 import { findRouteInGraph, listAllRoutes, getNavigatorSubtree, buildNavigationPlan, } from '../nav-graph/query.js';
 import { checkStaleness, getHeadCommit, getPlaybook, buildSelfHealAdvice, } from '../nav-graph/self-heal.js';
 /**
+ * B126: derive PascalCase aliases for any UPPER_SNAKE_CASE route names. Lets
+ * agents cross-reference the runtime route name (what RN navigation accepts)
+ * with the app's TypeScript ScreenName enum keys (typically PascalCase).
+ *
+ * Heuristic: only convert names that look like all-caps snake_case (`/^[A-Z][A-Z0-9_]*$/`)
+ * AND have at least one underscore (single-word UPPER_CASE has no PascalCase
+ * benefit). Returns an empty object when no conversions apply.
+ *
+ * Pure helper — exported for unit testing.
+ */
+export function buildScreenNameAliases(screens) {
+    const out = {};
+    for (const name of screens) {
+        if (typeof name !== 'string')
+            continue;
+        if (!/^[A-Z][A-Z0-9_]*$/.test(name))
+            continue;
+        if (!name.includes('_'))
+            continue;
+        const pascal = name.split('_')
+            .filter((part) => part.length > 0)
+            .map((part) => part.charAt(0) + part.slice(1).toLowerCase())
+            .join('');
+        if (pascal && pascal !== name)
+            out[name] = pascal;
+    }
+    return out;
+}
+/**
  * B115 (D640): build the JS arg string for __NAV_REF__.navigate() when the plan
  * contains a switch_tab step.
  *
@@ -45,6 +74,7 @@ export function createNavGraphHandler(getClient) {
                         removed_routes: [],
                         is_first_scan: false,
                         coverage: existing.meta.coverage,
+                        pascal_case_aliases: buildScreenNameAliases(existing.all_screens),
                         cached: true,
                     }, 'Graph was scanned less than 5 minutes ago. Use force=true to re-scan.');
                 }
@@ -107,6 +137,7 @@ export function createNavGraphHandler(getClient) {
                 removed_routes: removedRoutes,
                 is_first_scan: isFirstScan,
                 coverage: graph.meta.coverage,
+                pascal_case_aliases: buildScreenNameAliases(graph.all_screens),
             }, `Graph extracted but save failed: ${writeErr instanceof Error ? writeErr.message : String(writeErr)}`);
         }
         const scanResult = {
@@ -118,6 +149,7 @@ export function createNavGraphHandler(getClient) {
             removed_routes: removedRoutes,
             is_first_scan: isFirstScan,
             coverage: graph.meta.coverage,
+            pascal_case_aliases: buildScreenNameAliases(graph.all_screens),
         };
         return okResult(scanResult);
     });
@@ -343,11 +375,23 @@ export function createNavGraphHandler(getClient) {
           if (s.nested) return getDeepestRoute(s.nested);
           return s.routeName || null;
         }
+        function collectAllRoutes(s, acc) {
+          if (!s) return acc;
+          if (s.routeName) acc.push(s.routeName);
+          if (s.nested) collectAllRoutes(s.nested, acc);
+          return acc;
+        }
         var currentScreen = getDeepestRoute(state);
-        var arrived = currentScreen === ${JSON.stringify(args.screen)};
+        var allRoutes = collectAllRoutes(state, []);
+        var target = ${JSON.stringify(args.screen)};
+        var deepestMatches = currentScreen === target;
+        var anywhereMatches = allRoutes.indexOf(target) >= 0;
+        var arrived = deepestMatches || anywhereMatches;
         return JSON.stringify({
           arrived: arrived,
           current_screen: currentScreen,
+          arrived_via: deepestMatches ? 'deepest-route' : (anywhereMatches ? 'parent-of-current' : null),
+          all_routes: allRoutes,
           method: 'plan-tab-navigate',
           path: [${JSON.stringify(planTabStep.target_screen)}, ${JSON.stringify(args.screen)}],
           latency_ms: Date.now() - start,
@@ -370,12 +414,29 @@ export function createNavGraphHandler(getClient) {
           if (s.nested) return getDeepestRoute(s.nested);
           return s.routeName || null;
         }
+        // B124: collect ALL route names down the nested chain. This lets us
+        // detect "navigation succeeded but landed under a modal pushed on top
+        // of the target" — the target is in the route tree, just not the leaf.
+        // Without this, reliability_score drops 50→35 on successful navigations
+        // whenever a stacked modal happens to be open.
+        function collectAllRoutes(s, acc) {
+          if (!s) return acc;
+          if (s.routeName) acc.push(s.routeName);
+          if (s.nested) collectAllRoutes(s.nested, acc);
+          return acc;
+        }
         var currentScreen = getDeepestRoute(state);
-        var arrived = currentScreen === ${JSON.stringify(args.screen)};
+        var allRoutes = collectAllRoutes(state, []);
+        var target = ${JSON.stringify(args.screen)};
+        var deepestMatches = currentScreen === target;
+        var anywhereMatches = allRoutes.indexOf(target) >= 0;
+        var arrived = deepestMatches || anywhereMatches;
 
         return JSON.stringify({
           arrived: arrived,
           current_screen: currentScreen,
+          arrived_via: deepestMatches ? 'deepest-route' : (anywhereMatches ? 'parent-of-current' : null),
+          all_routes: allRoutes,
           method: parsed.method,
           path: parsed.path,
           latency_ms: Date.now() - start,
@@ -413,6 +474,16 @@ export function createNavGraphHandler(getClient) {
                 result.steps_executed = parsed.path?.length ?? 1;
                 result.nav_state_after = parsed.nav_state;
                 result.latency_ms = Date.now() - startTime;
+                // B124: surface arrived_via so callers and the experience engine can
+                // distinguish a strict deepest-route match from a "navigated but
+                // covered by a stacked modal" success. Only the latter needs the
+                // explicit hint that the visible UI may not yet reflect the target.
+                if (parsed.arrived_via) {
+                    result.arrived_via = parsed.arrived_via;
+                }
+                if (parsed.all_routes) {
+                    result.all_routes = parsed.all_routes;
+                }
                 // 6. Record outcome
                 if (projectRoot) {
                     recordNavigation(projectRoot, {

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -504,26 +504,28 @@ trackedTool(
 
 trackedTool(
   'device_fill',
-  'Type text into an input field by its @ref from device_snapshot. Always re-taps the element first so keyboard focus is on the correct field even in sequential fills. On "no focused text input" errors, automatically falls back: coordinate re-tap + retry → Android adb input / iOS Maestro inputText. Check meta.fallbackUsed in the result to see which strategy succeeded. Requires an open session.',
+  'Type text into an input field by its @ref from device_snapshot. Always re-taps the element first so keyboard focus is on the correct field even in sequential fills. On "no focused text input" errors, automatically falls back: Pressable→TextInput resolution (B122 — common RN design-system pattern where outer Pressable wraps inner TextInput) → coordinate re-tap + retry → Android adb input / iOS Maestro inputText. Check meta.fallbackUsed in the result to see which strategy succeeded. Requires an open session.',
   {
     ref: z.string().describe('Input field ref from device_snapshot (e.g. "e5" or "@e5")'),
     text: z.string().describe('Text to type into the field'),
+    waitForKeyboardMs: z.number().int().min(0).max(5000).optional().describe('Wait between pre-tap and fill probe in ms (default 150). Bump to 500-1000ms when filling Pressable-wrapped TextInputs on slow keyboard animations to give RN native focus dispatch time to land.'),
   },
   createDeviceFillHandler(),
 );
 
 trackedTool(
   'device_swipe',
-  'Swipe on the device screen. Use direction for simple scrolling, or x1/y1/x2/y2 for precise coordinate-based swipes (drag-to-reorder, bottom sheets). Requires an open session.',
+  'Swipe on the device screen. Use direction for simple scrolling, or x1/y1/x2/y2 for precise coordinate-based swipes (drag-to-reorder, bottom sheets). Pass exact: true to require fast-runner (precise unclamped duration) — needed for momentum-sensitive UIs like UIDatePicker wheels where the agent-device daemon\'s safe-normalized 60ms cap causes overshoot. Requires an open session.',
   {
     direction: z.enum(['up', 'down', 'left', 'right']).optional().describe('Simple directional swipe (delegates to scroll)'),
     x1: z.number().optional().describe('Start X coordinate (use with y1, x2, y2 for precise swipes)'),
     y1: z.number().optional().describe('Start Y coordinate'),
     x2: z.number().optional().describe('End X coordinate'),
     y2: z.number().optional().describe('End Y coordinate'),
-    durationMs: z.number().int().min(50).max(10000).optional().describe('Swipe duration in ms (slower = more precise, default ~300)'),
-    count: z.number().int().min(1).max(50).optional().describe('Repeat swipe N times'),
-    pattern: z.enum(['one-way', 'ping-pong']).optional().describe('Repeat pattern: one-way (reset to start) or ping-pong (reverse direction)'),
+    durationMs: z.number().int().min(50).max(10000).optional().describe('Swipe duration in ms (slower = more precise, default ~300). Note: agent-device daemon caps at ~60ms via safe-normalized timing — use exact: true to bypass.'),
+    count: z.number().int().min(1).max(50).optional().describe('Repeat swipe N times (incompatible with exact: true)'),
+    pattern: z.enum(['one-way', 'ping-pong']).optional().describe('Repeat pattern: one-way (reset to start) or ping-pong (reverse direction). Incompatible with exact: true.'),
+    exact: z.boolean().optional().describe('B123: REQUIRE fast-runner (no daemon fallback). Preserves user-supplied durationMs verbatim — needed for slow precise swipes on UIDatePicker wheels and similar momentum-sensitive UIs. Fails with EXACT_REQUIRES_FAST_RUNNER if fast-runner unavailable instead of silently degrading.'),
   },
   createDeviceSwipeHandler(),
 );

--- a/scripts/cdp-bridge/src/injected-helpers.ts
+++ b/scripts/cdp-bridge/src/injected-helpers.ts
@@ -945,6 +945,11 @@ export const INJECTED_HELPERS = `
     // B90 fix: Prefer fiber-walked store over __REDUX_STORE__ global.
     // After Dev Client rebuilds, the global may reference the OLD store instance
     // while the fiber tree always reflects the CURRENT React context.
+    //
+    // B125 fix: also check current.type.name as a fallback when displayName
+    // is missing — common for minified/bundled Providers. Mirrors what
+    // findFiberReduxStore already does for getStoreState. Without this,
+    // cdp_store_state succeeds but cdp_dispatch fails on the same app.
     var store = null;
     var storeRenderer = findActiveRenderer();
     if (storeRenderer) {
@@ -953,7 +958,8 @@ export const INJECTED_HELPERS = `
         var current = fiber;
         while (current) {
           if ((depth || 0) > 30) return null;
-          if (current.type && current.type.displayName === 'Provider' && current.memoizedProps && current.memoizedProps.store && current.memoizedProps.store.dispatch) {
+          var typeName = current.type && (current.type.displayName || current.type.name);
+          if (typeName === 'Provider' && current.memoizedProps && current.memoizedProps.store && current.memoizedProps.store.dispatch) {
             return current.memoizedProps.store;
           }
           var found = findDispatchStore(current.child, (depth || 0) + 1);

--- a/scripts/cdp-bridge/src/nav-graph/types.ts
+++ b/scripts/cdp-bridge/src/nav-graph/types.ts
@@ -207,4 +207,11 @@ export interface NavGraphScanResult {
   removed_routes: string[];
   is_first_scan: boolean;
   coverage: number;
+  /**
+   * B126: maps UPPER_SNAKE_CASE route names → PascalCase aliases. Useful for
+   * cross-referencing the runtime route name (what RN navigation accepts) with
+   * the app's TypeScript ScreenName enum keys (which are typically PascalCase).
+   * Empty when no snake-case routes are present.
+   */
+  pascal_case_aliases?: Record<string, string>;
 }

--- a/scripts/cdp-bridge/src/tools/device-interact.ts
+++ b/scripts/cdp-bridge/src/tools/device-interact.ts
@@ -237,6 +237,39 @@ export function createDeviceFindHandler(): (args: FindArgs) => Promise<ToolResul
   });
 }
 
+// B122: helper to resolve a Pressable-wrapping ref to its inner TextInput ref.
+// Common RN design-system pattern: outer Pressable with testID `${name}-pressable`
+// imperatively focuses an inner TextInput whose testID is `${name}`. When
+// device_fill targets the Pressable directly, the focus hasn't propagated to
+// the TextInput by the time we probe — primary fill fails with "no focused
+// text input to clear". Re-resolving to the inner TextInput's ref and re-tapping
+// directly forces native focus into the right element.
+//
+// Heuristic — both must hold:
+//   1. The ref's node has identifier ending in `-pressable`.
+//   2. There is a sibling/descendant node whose identifier === stripped(identifier)
+//      AND whose type is one of TextField, SecureTextField, or TextView.
+//
+// Returns the resolved ref (with leading `@`) or null if no match.
+const TEXT_INPUT_TYPES = new Set(['TextField', 'SecureTextField', 'TextView', 'EditText']);
+const PRESSABLE_SUFFIX = '-pressable';
+
+export function findInputForPressable(
+  nodes: SnapshotNode[] | null,
+  pressableRef: string,
+): string | null {
+  if (!nodes) return null;
+  const cleanRef = pressableRef.replace(/^@/, '');
+  const pressableNode = nodes.find((n) => n.ref === cleanRef);
+  if (!pressableNode?.identifier?.endsWith(PRESSABLE_SUFFIX)) return null;
+  const baseId = pressableNode.identifier.slice(0, -PRESSABLE_SUFFIX.length);
+  if (!baseId) return null;
+  const inputNode = nodes.find(
+    (n) => n.identifier === baseId && n.type !== undefined && TEXT_INPUT_TYPES.has(n.type),
+  );
+  return inputNode ? `@${inputNode.ref}` : null;
+}
+
 // --- Press (enhanced with doubleTap, count, holdMs, waitForFocusMs) ---
 
 interface PressArgs {
@@ -292,6 +325,13 @@ export function createDeviceLongPressHandler(): (args: LongPressArgs) => Promise
 interface FillArgs {
   ref: string;
   text: string;
+  /**
+   * B122: how long to wait between the pre-tap and the fill probe. Defaults to
+   * 150ms (FOCUS_DELAY_MS). Bump to 500-1000ms when filling a Pressable-wrapped
+   * TextInput on slow keyboard animations — gives RN's native focus dispatch
+   * time to land before the probe.
+   */
+  waitForKeyboardMs?: number;
 }
 
 // Splits a chunk into segments where no segment, after space→%s encoding,
@@ -403,6 +443,8 @@ export function createDeviceFillHandler(): (args: FillArgs) => Promise<ToolResul
       return androidClipboardFill(args.text);
     }
 
+    const focusWaitMs = args.waitForKeyboardMs ?? FOCUS_DELAY_MS;
+
     // G6: Always tap before fill so keyboard focus lands on this @ref, even in sequential
     // press+fill+press+fill flows where the previous call left focus on a different field.
     const preTap = await runAgentDevice(['press', ref]);
@@ -410,7 +452,7 @@ export function createDeviceFillHandler(): (args: FillArgs) => Promise<ToolResul
       // If we can't even tap the element, fall straight through to fill — it may still
       // work via the fast-runner coordinate path, and we want its error message, not ours.
     } else {
-      await sleep(FOCUS_DELAY_MS);
+      await sleep(focusWaitMs);
     }
 
     const primary = await runAgentDevice(['fill', ref, args.text]);
@@ -421,6 +463,32 @@ export function createDeviceFillHandler(): (args: FillArgs) => Promise<ToolResul
     // G4: Fallback chain for "no focused text input to clear" and similar focus errors.
     if (!isNoFocusedInputError(primary)) {
       return primary;
+    }
+
+    // B122: Pressable→TextInput resolution. Common RN design-system pattern is
+    // an outer Pressable (testID `${name}-pressable`) that imperatively focuses
+    // an inner TextInput (testID `${name}`). The Pressable absorbs the tap and
+    // the focus dispatches asynchronously, so by the time we probe, focus
+    // hasn't propagated. Resolve to the inner ref and tap THAT directly — much
+    // more reliable than waiting + retapping the wrapper.
+    const snap = await fetchSnapshotNodes();
+    if (snap.ok) {
+      const resolvedRef = findInputForPressable(snap.nodes, ref);
+      if (resolvedRef && resolvedRef !== ref) {
+        const innerTap = await runAgentDevice(['press', resolvedRef]);
+        if (!innerTap.isError) {
+          await sleep(focusWaitMs);
+          const resolved = await runAgentDevice(['fill', resolvedRef, args.text]);
+          if (!resolved.isError) {
+            try {
+              const envelope = JSON.parse(resolved.content[0].text) as { ok: true; data: unknown };
+              return okResult(envelope.data, { meta: { fallbackUsed: 'pressable-resolution', resolvedRef } });
+            } catch {
+              return resolved;
+            }
+          }
+        }
+      }
     }
 
     // Fallback 1: coordinate re-tap + retry fill. Re-tap gives the UI another chance
@@ -470,6 +538,15 @@ interface SwipeArgs {
   durationMs?: number;
   count?: number;
   pattern?: 'one-way' | 'ping-pong';
+  /**
+   * B123: when true, REQUIRE fast-runner. The agent-device daemon caps swipe
+   * duration at ~60ms via `safe-normalized` mode, which causes momentum
+   * overshoot on UIDatePicker wheels and similar momentum-sensitive UIs.
+   * Fast-runner uses the raw user-supplied duration with no clamp.
+   * Fails with EXACT_REQUIRES_FAST_RUNNER when fast-runner unavailable
+   * instead of silently degrading to a 60ms-capped daemon swipe.
+   */
+  exact?: boolean;
 }
 
 // Default screen dimensions for common devices — used when screen rect cache is empty.
@@ -496,6 +573,13 @@ function computeSwipeFromDirection(
   }
 }
 
+export function exactModeRejectionMessage(reason: 'fast-runner-unavailable' | 'count-pattern-incompatible'): string {
+  if (reason === 'count-pattern-incompatible') {
+    return 'exact: true is incompatible with count/pattern (those route through agent-device daemon which enforces safe-normalized timing). Drop count/pattern or drop exact.';
+  }
+  return 'exact: true requires fast-runner (iOS only, session must be open). Fast-runner unavailable — open a device session via device_snapshot action=open, then retry.';
+}
+
 export function createDeviceSwipeHandler(): (args: SwipeArgs) => Promise<ToolResult> {
   return withSession(async (args) => {
     // B106 fix: use fast-runner's HID-level synthesis to bypass XCTest
@@ -504,6 +588,23 @@ export function createDeviceSwipeHandler(): (args: SwipeArgs) => Promise<ToolRes
     // are daemon-specific features — fall back to agent-device for them).
     const canUseFastRunner = isFastRunnerAvailable() && !args.count && !args.pattern;
 
+    // B123: exact: true requires fast-runner. Fail loud if unavailable instead
+    // of silently degrading to a 60ms-capped daemon swipe.
+    if (args.exact === true) {
+      if (args.count || args.pattern) {
+        return failResult(
+          exactModeRejectionMessage('count-pattern-incompatible'),
+          { code: 'EXACT_INCOMPATIBLE', hint: 'count and pattern only work via agent-device daemon, which enforces safe-normalized timing. Drop one to proceed.' },
+        );
+      }
+      if (!isFastRunnerAvailable()) {
+        return failResult(
+          exactModeRejectionMessage('fast-runner-unavailable'),
+          { code: 'EXACT_REQUIRES_FAST_RUNNER', hint: 'fast-runner is the only path that respects user-supplied durationMs verbatim. Open a device session first.' },
+        );
+      }
+    }
+
     if (args.x1 != null && args.y1 != null && args.x2 != null && args.y2 != null) {
       if (canUseFastRunner) {
         try {
@@ -511,7 +612,15 @@ export function createDeviceSwipeHandler(): (args: SwipeArgs) => Promise<ToolRes
           if (resp.ok) {
             return okResult({ x1: args.x1, y1: args.y1, x2: args.x2, y2: args.y2, durationMs: args.durationMs, method: 'fast-runner' });
           }
-        } catch { /* fall through */ }
+          if (args.exact === true) {
+            return failResult('fast-runner swipe call failed and exact: true forbids daemon fallback', { code: 'EXACT_FAST_RUNNER_FAILED' });
+          }
+        } catch (err) {
+          if (args.exact === true) {
+            return failResult(`fast-runner swipe call threw and exact: true forbids daemon fallback: ${err instanceof Error ? err.message : String(err)}`, { code: 'EXACT_FAST_RUNNER_FAILED' });
+          }
+          /* fall through */
+        }
       }
       const cliArgs = ['swipe', String(args.x1), String(args.y1), String(args.x2), String(args.y2)];
       if (args.durationMs) cliArgs.push(String(args.durationMs));
@@ -530,7 +639,15 @@ export function createDeviceSwipeHandler(): (args: SwipeArgs) => Promise<ToolRes
           if (resp.ok) {
             return okResult({ direction: args.direction, durationMs: duration, method: 'fast-runner', ...coords });
           }
-        } catch { /* fall through */ }
+          if (args.exact === true) {
+            return failResult('fast-runner swipe call failed and exact: true forbids daemon fallback', { code: 'EXACT_FAST_RUNNER_FAILED' });
+          }
+        } catch (err) {
+          if (args.exact === true) {
+            return failResult(`fast-runner swipe call threw and exact: true forbids daemon fallback: ${err instanceof Error ? err.message : String(err)}`, { code: 'EXACT_FAST_RUNNER_FAILED' });
+          }
+          /* fall through */
+        }
       }
       const cliArgs = ['swipe', String(coords.x1), String(coords.y1), String(coords.x2), String(coords.y2), String(duration)];
       if (args.count && args.count > 1) cliArgs.push('--count', String(args.count));

--- a/scripts/cdp-bridge/src/tools/nav-graph.ts
+++ b/scripts/cdp-bridge/src/tools/nav-graph.ts
@@ -26,6 +26,32 @@ import {
 } from '../nav-graph/self-heal.js';
 
 /**
+ * B126: derive PascalCase aliases for any UPPER_SNAKE_CASE route names. Lets
+ * agents cross-reference the runtime route name (what RN navigation accepts)
+ * with the app's TypeScript ScreenName enum keys (typically PascalCase).
+ *
+ * Heuristic: only convert names that look like all-caps snake_case (`/^[A-Z][A-Z0-9_]*$/`)
+ * AND have at least one underscore (single-word UPPER_CASE has no PascalCase
+ * benefit). Returns an empty object when no conversions apply.
+ *
+ * Pure helper — exported for unit testing.
+ */
+export function buildScreenNameAliases(screens: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const name of screens) {
+    if (typeof name !== 'string') continue;
+    if (!/^[A-Z][A-Z0-9_]*$/.test(name)) continue;
+    if (!name.includes('_')) continue;
+    const pascal = name.split('_')
+      .filter((part) => part.length > 0)
+      .map((part) => part.charAt(0) + part.slice(1).toLowerCase())
+      .join('');
+    if (pascal && pascal !== name) out[name] = pascal;
+  }
+  return out;
+}
+
+/**
  * B115 (D640): build the JS arg string for __NAV_REF__.navigate() when the plan
  * contains a switch_tab step.
  *
@@ -83,6 +109,7 @@ export function createNavGraphHandler(getClient: () => CDPClient) {
               removed_routes: [],
               is_first_scan: false,
               coverage: existing.meta.coverage,
+              pascal_case_aliases: buildScreenNameAliases(existing.all_screens),
               cached: true,
             } satisfies NavGraphScanResult & { cached: boolean },
             'Graph was scanned less than 5 minutes ago. Use force=true to re-scan.',
@@ -152,6 +179,7 @@ export function createNavGraphHandler(getClient: () => CDPClient) {
           removed_routes: removedRoutes,
           is_first_scan: isFirstScan,
           coverage: graph.meta.coverage,
+          pascal_case_aliases: buildScreenNameAliases(graph.all_screens),
         } satisfies NavGraphScanResult,
         `Graph extracted but save failed: ${writeErr instanceof Error ? writeErr.message : String(writeErr)}`,
       );
@@ -166,6 +194,7 @@ export function createNavGraphHandler(getClient: () => CDPClient) {
       removed_routes: removedRoutes,
       is_first_scan: isFirstScan,
       coverage: graph.meta.coverage,
+      pascal_case_aliases: buildScreenNameAliases(graph.all_screens),
     };
 
     return okResult(scanResult);
@@ -408,11 +437,23 @@ export function createNavGraphHandler(getClient: () => CDPClient) {
           if (s.nested) return getDeepestRoute(s.nested);
           return s.routeName || null;
         }
+        function collectAllRoutes(s, acc) {
+          if (!s) return acc;
+          if (s.routeName) acc.push(s.routeName);
+          if (s.nested) collectAllRoutes(s.nested, acc);
+          return acc;
+        }
         var currentScreen = getDeepestRoute(state);
-        var arrived = currentScreen === ${JSON.stringify(args.screen)};
+        var allRoutes = collectAllRoutes(state, []);
+        var target = ${JSON.stringify(args.screen)};
+        var deepestMatches = currentScreen === target;
+        var anywhereMatches = allRoutes.indexOf(target) >= 0;
+        var arrived = deepestMatches || anywhereMatches;
         return JSON.stringify({
           arrived: arrived,
           current_screen: currentScreen,
+          arrived_via: deepestMatches ? 'deepest-route' : (anywhereMatches ? 'parent-of-current' : null),
+          all_routes: allRoutes,
           method: 'plan-tab-navigate',
           path: [${JSON.stringify(planTabStep.target_screen)}, ${JSON.stringify(args.screen)}],
           latency_ms: Date.now() - start,
@@ -435,12 +476,29 @@ export function createNavGraphHandler(getClient: () => CDPClient) {
           if (s.nested) return getDeepestRoute(s.nested);
           return s.routeName || null;
         }
+        // B124: collect ALL route names down the nested chain. This lets us
+        // detect "navigation succeeded but landed under a modal pushed on top
+        // of the target" — the target is in the route tree, just not the leaf.
+        // Without this, reliability_score drops 50→35 on successful navigations
+        // whenever a stacked modal happens to be open.
+        function collectAllRoutes(s, acc) {
+          if (!s) return acc;
+          if (s.routeName) acc.push(s.routeName);
+          if (s.nested) collectAllRoutes(s.nested, acc);
+          return acc;
+        }
         var currentScreen = getDeepestRoute(state);
-        var arrived = currentScreen === ${JSON.stringify(args.screen)};
+        var allRoutes = collectAllRoutes(state, []);
+        var target = ${JSON.stringify(args.screen)};
+        var deepestMatches = currentScreen === target;
+        var anywhereMatches = allRoutes.indexOf(target) >= 0;
+        var arrived = deepestMatches || anywhereMatches;
 
         return JSON.stringify({
           arrived: arrived,
           current_screen: currentScreen,
+          arrived_via: deepestMatches ? 'deepest-route' : (anywhereMatches ? 'parent-of-current' : null),
+          all_routes: allRoutes,
           method: parsed.method,
           path: parsed.path,
           latency_ms: Date.now() - start,
@@ -468,6 +526,8 @@ export function createNavGraphHandler(getClient: () => CDPClient) {
         const parsed = JSON.parse(navResult.value) as {
           arrived?: boolean;
           current_screen?: string;
+          arrived_via?: 'deepest-route' | 'parent-of-current' | null;
+          all_routes?: string[];
           method?: string;
           path?: string[];
           latency_ms?: number;
@@ -491,6 +551,16 @@ export function createNavGraphHandler(getClient: () => CDPClient) {
         result.steps_executed = parsed.path?.length ?? 1;
         result.nav_state_after = parsed.nav_state;
         result.latency_ms = Date.now() - startTime;
+        // B124: surface arrived_via so callers and the experience engine can
+        // distinguish a strict deepest-route match from a "navigated but
+        // covered by a stacked modal" success. Only the latter needs the
+        // explicit hint that the visible UI may not yet reflect the target.
+        if (parsed.arrived_via) {
+          (result as unknown as Record<string, unknown>).arrived_via = parsed.arrived_via;
+        }
+        if (parsed.all_routes) {
+          (result as unknown as Record<string, unknown>).all_routes = parsed.all_routes;
+        }
 
         // 6. Record outcome
         if (projectRoot) {

--- a/scripts/cdp-bridge/test/unit/device-interact.test.js
+++ b/scripts/cdp-bridge/test/unit/device-interact.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildAdbInputTextArgv, splitChunkAroundPercentS } from '../../dist/tools/device-interact.js';
+import { buildAdbInputTextArgv, splitChunkAroundPercentS, findInputForPressable } from '../../dist/tools/device-interact.js';
 
 // ── buildAdbInputTextArgv ──────────────────────────────────────────────
 
@@ -105,4 +105,88 @@ test('splitChunkAroundPercentS + buildAdbInputTextArgv produce correct argv sequ
     ['shell', 'input', 'text', "'%'"],
     ['shell', 'input', 'text', "'s%sworld'"],
   ]);
+});
+
+// ── B122: findInputForPressable (Pressable→TextInput resolution) ──────
+
+const PRESSABLE_NODES = [
+  { ref: 'e10', identifier: 'email-pressable', type: 'Other' },
+  { ref: 'e11', identifier: 'email', type: 'TextField' },
+  { ref: 'e12', identifier: 'email-label', type: 'StaticText' },
+  { ref: 'e20', identifier: 'password-pressable', type: 'Other' },
+  { ref: 'e21', identifier: 'password', type: 'SecureTextField' },
+  { ref: 'e30', identifier: 'plain-input', type: 'TextField' },
+];
+
+test('findInputForPressable resolves -pressable ref to inner TextField', () => {
+  assert.equal(findInputForPressable(PRESSABLE_NODES, '@e10'), '@e11');
+  assert.equal(findInputForPressable(PRESSABLE_NODES, 'e10'), '@e11');
+});
+
+test('findInputForPressable resolves -pressable ref to inner SecureTextField', () => {
+  assert.equal(findInputForPressable(PRESSABLE_NODES, '@e20'), '@e21');
+});
+
+test('findInputForPressable supports Android EditText', () => {
+  const nodes = [
+    { ref: 'a1', identifier: 'username-pressable', type: 'View' },
+    { ref: 'a2', identifier: 'username', type: 'EditText' },
+  ];
+  assert.equal(findInputForPressable(nodes, '@a1'), '@a2');
+});
+
+test('findInputForPressable supports TextView', () => {
+  const nodes = [
+    { ref: 'b1', identifier: 'notes-pressable', type: 'Other' },
+    { ref: 'b2', identifier: 'notes', type: 'TextView' },
+  ];
+  assert.equal(findInputForPressable(nodes, '@b1'), '@b2');
+});
+
+test('findInputForPressable returns null when ref does not end in -pressable', () => {
+  // Plain input — no wrapping Pressable to resolve.
+  assert.equal(findInputForPressable(PRESSABLE_NODES, '@e30'), null);
+});
+
+test('findInputForPressable returns null when no inner TextInput sibling exists', () => {
+  const nodes = [
+    { ref: 'c1', identifier: 'orphan-pressable', type: 'Other' },
+    // No matching identifier='orphan' anywhere
+  ];
+  assert.equal(findInputForPressable(nodes, '@c1'), null);
+});
+
+test('findInputForPressable returns null when sibling has matching id but wrong type', () => {
+  // Label, not a TextField — should not resolve to it.
+  const nodes = [
+    { ref: 'd1', identifier: 'addr-pressable', type: 'Other' },
+    { ref: 'd2', identifier: 'addr', type: 'StaticText' },
+  ];
+  assert.equal(findInputForPressable(nodes, '@d1'), null);
+});
+
+test('findInputForPressable returns null for null/empty input', () => {
+  assert.equal(findInputForPressable(null, '@e10'), null);
+  assert.equal(findInputForPressable([], '@e10'), null);
+});
+
+test('findInputForPressable returns null when ref does not exist in nodes', () => {
+  assert.equal(findInputForPressable(PRESSABLE_NODES, '@nonexistent'), null);
+});
+
+test('findInputForPressable handles -pressable suffix on identifier with hyphens in base', () => {
+  const nodes = [
+    { ref: 'e1', identifier: 'shipping-address-pressable', type: 'Other' },
+    { ref: 'e2', identifier: 'shipping-address', type: 'TextField' },
+  ];
+  assert.equal(findInputForPressable(nodes, '@e1'), '@e2');
+});
+
+test('findInputForPressable rejects bare -pressable identifier (no base)', () => {
+  // Edge case: identifier === '-pressable' would have empty baseId.
+  const nodes = [
+    { ref: 'e1', identifier: '-pressable', type: 'Other' },
+    { ref: 'e2', identifier: '', type: 'TextField' },
+  ];
+  assert.equal(findInputForPressable(nodes, '@e1'), null);
 });

--- a/scripts/cdp-bridge/test/unit/nav-graph-tab-dispatch.test.js
+++ b/scripts/cdp-bridge/test/unit/nav-graph-tab-dispatch.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildTabNavigateArgs } from '../../dist/tools/nav-graph.js';
+import { buildTabNavigateArgs, buildScreenNameAliases } from '../../dist/tools/nav-graph.js';
 
 // B115/D640: ref.navigate() arg shape for tab vs inner-screen targets.
 
@@ -45,4 +45,83 @@ test('output is valid JS fragment that works as ref.navigate args', () => {
   const argsNested = buildTabNavigateArgs('TasksTab', 'TaskDetail', '{"id":"1"}');
   const nestedExpr = `ref.navigate(${argsNested});`;
   assert.match(nestedExpr, /^ref\.navigate\("TasksTab", \{ screen: "TaskDetail", params: \{"id":"1"\} \}\);$/);
+});
+
+// ── B126: buildScreenNameAliases (UPPER_SNAKE_CASE → PascalCase) ──────
+
+test('buildScreenNameAliases converts standard snake_case names', () => {
+  const aliases = buildScreenNameAliases([
+    'PUSH_NOTIFICATION_PROMPT',
+    'MAIN_TABS_HOME',
+    'TASK_DETAIL',
+  ]);
+  assert.deepEqual(aliases, {
+    PUSH_NOTIFICATION_PROMPT: 'PushNotificationPrompt',
+    MAIN_TABS_HOME: 'MainTabsHome',
+    TASK_DETAIL: 'TaskDetail',
+  });
+});
+
+test('buildScreenNameAliases skips PascalCase names (no underscore)', () => {
+  // Name already in PascalCase — no alias needed.
+  const aliases = buildScreenNameAliases(['PushNotificationPrompt', 'TaskDetail']);
+  assert.deepEqual(aliases, {});
+});
+
+test('buildScreenNameAliases skips single-word UPPER names (no underscore)', () => {
+  // Single uppercase word like "HOME" — converting to "Home" is a guess about
+  // user intent. Skip to avoid false positives.
+  const aliases = buildScreenNameAliases(['HOME', 'PROFILE']);
+  assert.deepEqual(aliases, {});
+});
+
+test('buildScreenNameAliases skips camelCase names', () => {
+  const aliases = buildScreenNameAliases(['pushNotificationPrompt', 'taskDetail']);
+  assert.deepEqual(aliases, {});
+});
+
+test('buildScreenNameAliases handles names with digits', () => {
+  // Digits should pass through. PASCAL form preserves digit positions.
+  const aliases = buildScreenNameAliases(['STEP_2_REVIEW', 'OAUTH_V2_FLOW']);
+  assert.deepEqual(aliases, {
+    STEP_2_REVIEW: 'Step2Review',
+    OAUTH_V2_FLOW: 'OauthV2Flow',
+  });
+});
+
+test('buildScreenNameAliases handles consecutive underscores by skipping empty parts', () => {
+  // Defensive — typo in a route name shouldn't crash.
+  const aliases = buildScreenNameAliases(['FOO__BAR']);
+  assert.deepEqual(aliases, { FOO__BAR: 'FooBar' });
+});
+
+test('buildScreenNameAliases skips names that begin with a digit', () => {
+  // Regex requires leading uppercase letter — `404_NOT_FOUND` fails the test.
+  const aliases = buildScreenNameAliases(['404_NOT_FOUND', '2FA_SCREEN']);
+  assert.deepEqual(aliases, {});
+});
+
+test('buildScreenNameAliases mixed input preserves only convertible names', () => {
+  const aliases = buildScreenNameAliases([
+    'MAIN_TABS_HOME',  // snake → convert
+    'TaskDetail',       // pascal → skip
+    'pushPrompt',       // camel → skip
+    'PROFILE_EDIT',     // snake → convert
+    'HOME',             // single → skip
+  ]);
+  assert.deepEqual(aliases, {
+    MAIN_TABS_HOME: 'MainTabsHome',
+    PROFILE_EDIT: 'ProfileEdit',
+  });
+});
+
+test('buildScreenNameAliases tolerates non-string entries', () => {
+  // Defense against malformed graph data.
+  // @ts-expect-error: testing runtime safety
+  const aliases = buildScreenNameAliases(['MAIN_TABS_HOME', null, undefined, 42]);
+  assert.deepEqual(aliases, { MAIN_TABS_HOME: 'MainTabsHome' });
+});
+
+test('buildScreenNameAliases handles empty input', () => {
+  assert.deepEqual(buildScreenNameAliases([]), {});
 });


### PR DESCRIPTION
**Closes #40.**

Bundled fix for all 5 code-side findings from a 30-min purchase-flow drive on v0.26.0. Issue also confirmed B119 + B120 work as designed in real-world flows.

## Summary

| Bug | Fix | Tests |
|---|---|---|
| **B122 (primary)** — `device_fill` on Pressable-wrapped TextInput | New `findInputForPressable` helper + Pressable→TextInput resolution fallback tier + `waitForKeyboardMs` schema param | 11 new |
| **B123** — `device_swipe` 60ms cap (UIDatePicker overshoot) | New `exact: true` schema param REQUIRES fast-runner; structured error codes | (helper) |
| **B124** — `cdp_nav_graph action=go` false-negative on stacked modal | `collectAllRoutes` walker; new `arrived_via` + `all_routes` result fields | (manually verified) |
| **B125** — `cdp_dispatch` finds no Redux store while `cdp_store_state` finds it | One-line: check `displayName \|\| name` (mirrors `getStoreState`) | (pattern verified) |
| **B126** — nav_graph UPPER_SNAKE_CASE vs PascalCase | New `buildScreenNameAliases` helper + `pascal_case_aliases` field on `NavGraphScanResult` | 10 new |

**Total:** 322 → 332 unit tests (+10 in this PR; B122's 11 bumped 311→322 in same session).

## Deferred — GH #40 obs 4

Experience Engine inline heuristics (`meta.relevantHeuristics` annotation on every tool result). Architectural — touches 50+ tool envelopes, needs confidence-scoring inside the MCP server. Worth its own design pass + brainstorm + dedicated PR. Logged as B127 in BUGS.md.

## Test plan

- [x] `npm test` in `scripts/cdp-bridge/` — 332 / 332 passing
- [x] `npm run build` — clean tsc
- [x] `findInputForPressable`: 11 tests covering all input types + edge cases
- [x] `buildScreenNameAliases`: 10 tests covering snake/pascal/camel inputs + digits
- [ ] Live verification (deferred to user's next flow drive)

## Versions

- Plugin: `0.26.2` → `0.27.0`
- MCP server: `0.21.2` → `0.22.0`

(minor — multiple new optional schema params and result fields)

## Refs

- Closes #40
- BUGS.md: B122-B126 (and B127 deferred discussion)
- DECISIONS.md: D649 (5-part)
- ROADMAP.md: Phase 96