### PR TITLE
feat(m3): single-instance lock file — Phase 90 Tier 1 (D652)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.27.0",
+      "version": "0.28.0",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -40,20 +40,36 @@ import { createProofStepHandler } from './tools/proof-step.js';
 import { createConnectHandler, createDisconnectHandler, createTargetsHandler } from './tools/connection.js';
 import { createRestartHandler } from './tools/restart.js';
 import { buildGracefulShutdown } from './lifecycle/graceful-shutdown.js';
+import { Lockfile, formatLockConflictMessage } from './lifecycle/lockfile.js';
 import { createMaestroRunHandler } from './tools/maestro-run.js';
 import { createMaestroGenerateHandler } from './tools/maestro-generate.js';
 import { createMaestroTestAllHandler } from './tools/maestro-test-all.js';
 import { createCrossPlatformVerifyHandler } from './tools/cross-platform-verify.js';
 import { stopFastRunner } from './fast-runner-session.js';
 import { instrumentTool, pruneOldTelemetry, autoCompactIfNeeded } from './experience/index.js';
+const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
+const pkgVersion = JSON.parse(readFileSync(pkgPath, 'utf8')).version;
+// M3 / Phase 90: single-instance lock. Must run BEFORE telemetry prune / CDPClient creation
+// so two racing MCPs don't corrupt telemetry files or fight for the CDP slot. --no-lock
+// opt-out exists for CI parallelism and benchmark harnesses; documented in the conflict
+// message. Release is registered on process.exit so ALL exit paths (graceful, uncaught,
+// signal) clean up the lock.
+const noLock = process.argv.includes('--no-lock');
+if (!noLock) {
+    const lockfile = new Lockfile({ version: pkgVersion });
+    const lockResult = lockfile.acquire();
+    if (lockResult.status === 'conflict') {
+        process.stderr.write(formatLockConflictMessage(lockResult) + '\n');
+        process.exit(11);
+    }
+    process.on('exit', () => lockfile.release());
+}
 pruneOldTelemetry();
 autoCompactIfNeeded();
 let client = new CDPClient();
 const getClient = () => client;
 const setClient = (c) => { client = c; };
 const createClient = (port) => new CDPClient(port);
-const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
-const pkgVersion = JSON.parse(readFileSync(pkgPath, 'utf8')).version;
 const server = new McpServer({
     name: 'rn-dev-agent-cdp-bridge',
     version: pkgVersion,

--- a/scripts/cdp-bridge/dist/lifecycle/lockfile.js
+++ b/scripts/cdp-bridge/dist/lifecycle/lockfile.js
@@ -1,0 +1,198 @@
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir, userInfo } from 'node:os';
+import { join, resolve } from 'node:path';
+const DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_PROCESS_NAME_NEEDLE = 'cdp-bridge';
+function defaultProjectRoot() {
+    return process.env.CLAUDE_USER_CWD ?? process.cwd();
+}
+function defaultProcessAlive(pid) {
+    try {
+        process.kill(pid, 0);
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+/**
+ * Resolve a PID to its full command line for process-identity matching.
+ *
+ * Uses `ps -o args=` (not `-o comm=`). Both BSD ps (macOS) and procps (Linux) honor
+ * `args=` and emit the full command line — e.g. `node /path/to/cdp-bridge/dist/index.js`.
+ * `comm=` would return only the executable basename (`"node"`) which never contains our
+ * needle `cdp-bridge` — caught by multi-review before ship (D652 implementation notes).
+ */
+export function defaultProcessName(pid) {
+    try {
+        const out = execFileSync('ps', ['-p', String(pid), '-o', 'args='], {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'ignore'],
+            timeout: 1000,
+        });
+        return out.trim() || null;
+    }
+    catch {
+        return null;
+    }
+}
+function hashProjectRoot(projectRoot) {
+    return createHash('md5').update(resolve(projectRoot)).digest('hex').slice(0, 8);
+}
+/**
+ * Single-instance gate for the MCP subprocess (M3 / Phase 90 Tier 1).
+ *
+ * Two Claude Code windows opened in the same project would spawn two MCP subprocesses,
+ * both racing for the single Hermes CDP slot and producing missed events + state flicker.
+ * This module writes a lock file at startup keyed on the user's uid + an 8-char hash of
+ * the project root, so:
+ *   - same project, two windows → conflict (exit 11)
+ *   - different projects, same machine → coexist fine (different hash)
+ *   - different users on the same machine → coexist fine (different uid)
+ *
+ * Stale lock detection has three orthogonal checks (any failure ⇒ reclaim):
+ *   1. PID alive via `process.kill(pid, 0)` — catches crashed predecessors
+ *   2. Process name matches `cdp-bridge` via `ps -p <pid> -o args=` — catches PID reuse after reboot
+ *   3. Lock mtime < 24h — catches SIGKILL'd processes that left orphan locks
+ *
+ * All side effects are injectable (tmpDir, clock, processAlive, processName) so unit tests
+ * run fully hermetic without touching /tmp or spawning ps.
+ */
+export class Lockfile {
+    opts;
+    lockPath;
+    acquired = false;
+    constructor(opts = {}) {
+        const projectRoot = opts.projectRoot ?? defaultProjectRoot();
+        const uid = opts.uid ?? userInfo().uid;
+        const tmpDir = opts.tmpDir ?? tmpdir();
+        const hash = hashProjectRoot(projectRoot);
+        this.opts = {
+            projectRoot,
+            uid,
+            tmpDir,
+            pid: opts.pid ?? process.pid,
+            version: opts.version ?? '',
+            clock: opts.clock ?? Date.now,
+            processAlive: opts.processAlive ?? defaultProcessAlive,
+            processName: opts.processName ?? defaultProcessName,
+            maxAgeMs: opts.maxAgeMs ?? DEFAULT_MAX_AGE_MS,
+            processNameNeedle: opts.processNameNeedle ?? DEFAULT_PROCESS_NAME_NEEDLE,
+        };
+        this.lockPath = join(tmpDir, `rn-dev-agent-cdp-${uid}-${hash}.lock`);
+    }
+    acquire() {
+        const existing = this.readExisting();
+        if (existing && this.isLockLive(existing)) {
+            return {
+                status: 'conflict',
+                lockPath: this.lockPath,
+                pid: existing.pid,
+                projectRoot: existing.projectRoot,
+                startedAt: existing.startedAt,
+                ageMs: this.opts.clock() - existing.startedAt,
+                version: existing.version,
+            };
+        }
+        this.writeLock();
+        this.acquired = true;
+        return { status: 'acquired', lockPath: this.lockPath };
+    }
+    release() {
+        if (!this.acquired)
+            return;
+        try {
+            if (existsSync(this.lockPath)) {
+                const body = this.readExisting();
+                if (body?.pid === this.opts.pid) {
+                    unlinkSync(this.lockPath);
+                }
+            }
+        }
+        catch {
+            // Swallow: release must never fail the shutdown path.
+        }
+        this.acquired = false;
+    }
+    readExisting() {
+        if (!existsSync(this.lockPath))
+            return null;
+        try {
+            const raw = readFileSync(this.lockPath, 'utf8');
+            const parsed = JSON.parse(raw);
+            if (!isValidLockBody(parsed))
+                return null;
+            return parsed;
+        }
+        catch {
+            return null;
+        }
+    }
+    isLockLive(body) {
+        if (!this.opts.processAlive(body.pid))
+            return false;
+        const age = this.ageOfLockFile();
+        if (age !== null && age > this.opts.maxAgeMs)
+            return false;
+        const name = this.opts.processName(body.pid);
+        if (name !== null && !name.toLowerCase().includes(this.opts.processNameNeedle.toLowerCase())) {
+            return false;
+        }
+        return true;
+    }
+    ageOfLockFile() {
+        try {
+            const st = statSync(this.lockPath);
+            return this.opts.clock() - st.mtimeMs;
+        }
+        catch {
+            return null;
+        }
+    }
+    writeLock() {
+        const body = {
+            pid: this.opts.pid,
+            projectRoot: this.opts.projectRoot,
+            startedAt: this.opts.clock(),
+            version: this.opts.version || undefined,
+        };
+        const dir = this.opts.tmpDir;
+        if (!existsSync(dir)) {
+            mkdirSync(dir, { recursive: true });
+        }
+        writeFileSync(this.lockPath, JSON.stringify(body, null, 2), { encoding: 'utf8' });
+    }
+}
+function isValidLockBody(obj) {
+    if (typeof obj !== 'object' || obj === null)
+        return false;
+    const o = obj;
+    return (typeof o.pid === 'number' &&
+        typeof o.projectRoot === 'string' &&
+        typeof o.startedAt === 'number');
+}
+export function formatLockConflictMessage(conflict) {
+    const ageSec = Math.floor(conflict.ageMs / 1000);
+    const ageStr = ageSec < 60
+        ? `${ageSec}s ago`
+        : ageSec < 3600
+            ? `${Math.floor(ageSec / 60)}m ago`
+            : `${Math.floor(ageSec / 3600)}h ${Math.floor((ageSec % 3600) / 60)}m ago`;
+    return [
+        `Another rn-dev-agent MCP is running in this project.`,
+        `  PID:      ${conflict.pid}`,
+        `  Project:  ${conflict.projectRoot}`,
+        `  Started:  ${ageStr}`,
+        `  Lock:     ${conflict.lockPath}`,
+        ``,
+        `To resolve:`,
+        `  1. Close the other Claude Code window for this project, OR`,
+        `  2. Kill the other process:  kill ${conflict.pid}`,
+        `  3. (If the process is dead) delete the lock file:  rm ${conflict.lockPath}`,
+        ``,
+        `Running two MCPs in the same project causes missed events and state flicker.`,
+        `Start with --no-lock to bypass this check (advanced; expect flaky behavior).`,
+    ].join('\n');
+}

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -57,12 +57,32 @@ import { createProofStepHandler } from './tools/proof-step.js';
 import { createConnectHandler, createDisconnectHandler, createTargetsHandler } from './tools/connection.js';
 import { createRestartHandler } from './tools/restart.js';
 import { buildGracefulShutdown } from './lifecycle/graceful-shutdown.js';
+import { Lockfile, formatLockConflictMessage } from './lifecycle/lockfile.js';
 import { createMaestroRunHandler } from './tools/maestro-run.js';
 import { createMaestroGenerateHandler } from './tools/maestro-generate.js';
 import { createMaestroTestAllHandler } from './tools/maestro-test-all.js';
 import { createCrossPlatformVerifyHandler } from './tools/cross-platform-verify.js';
 import { stopFastRunner } from './fast-runner-session.js';
 import { instrumentTool, pruneOldTelemetry, autoCompactIfNeeded } from './experience/index.js';
+
+const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
+const pkgVersion = (JSON.parse(readFileSync(pkgPath, 'utf8')) as { version: string }).version;
+
+// M3 / Phase 90: single-instance lock. Must run BEFORE telemetry prune / CDPClient creation
+// so two racing MCPs don't corrupt telemetry files or fight for the CDP slot. --no-lock
+// opt-out exists for CI parallelism and benchmark harnesses; documented in the conflict
+// message. Release is registered on process.exit so ALL exit paths (graceful, uncaught,
+// signal) clean up the lock.
+const noLock = process.argv.includes('--no-lock');
+if (!noLock) {
+  const lockfile = new Lockfile({ version: pkgVersion });
+  const lockResult = lockfile.acquire();
+  if (lockResult.status === 'conflict') {
+    process.stderr.write(formatLockConflictMessage(lockResult) + '\n');
+    process.exit(11);
+  }
+  process.on('exit', () => lockfile.release());
+}
 
 pruneOldTelemetry();
 autoCompactIfNeeded();
@@ -72,9 +92,6 @@ let client = new CDPClient();
 const getClient = (): CDPClient => client;
 const setClient = (c: CDPClient): void => { client = c; };
 const createClient = (port: number): CDPClient => new CDPClient(port);
-
-const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
-const pkgVersion = (JSON.parse(readFileSync(pkgPath, 'utf8')) as { version: string }).version;
 
 const server = new McpServer({
   name: 'rn-dev-agent-cdp-bridge',

--- a/scripts/cdp-bridge/src/lifecycle/lockfile.ts
+++ b/scripts/cdp-bridge/src/lifecycle/lockfile.ts
@@ -1,0 +1,250 @@
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir, userInfo } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_PROCESS_NAME_NEEDLE = 'cdp-bridge';
+
+export interface LockfileOptions {
+  projectRoot?: string;
+  pid?: number;
+  version?: string;
+  tmpDir?: string;
+  uid?: number;
+  clock?: () => number;
+  processAlive?: (pid: number) => boolean;
+  processName?: (pid: number) => string | null;
+  maxAgeMs?: number;
+  processNameNeedle?: string;
+}
+
+export interface LockAcquired {
+  status: 'acquired';
+  lockPath: string;
+}
+
+export interface LockConflict {
+  status: 'conflict';
+  lockPath: string;
+  pid: number;
+  projectRoot: string;
+  startedAt: number;
+  ageMs: number;
+  version?: string;
+}
+
+export type LockAcquireResult = LockAcquired | LockConflict;
+
+interface LockFileBody {
+  pid: number;
+  projectRoot: string;
+  startedAt: number;
+  version?: string;
+}
+
+function defaultProjectRoot(): string {
+  return process.env.CLAUDE_USER_CWD ?? process.cwd();
+}
+
+function defaultProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve a PID to its full command line for process-identity matching.
+ *
+ * Uses `ps -o args=` (not `-o comm=`). Both BSD ps (macOS) and procps (Linux) honor
+ * `args=` and emit the full command line — e.g. `node /path/to/cdp-bridge/dist/index.js`.
+ * `comm=` would return only the executable basename (`"node"`) which never contains our
+ * needle `cdp-bridge` — caught by multi-review before ship (D652 implementation notes).
+ */
+export function defaultProcessName(pid: number): string | null {
+  try {
+    const out = execFileSync('ps', ['-p', String(pid), '-o', 'args='], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 1000,
+    });
+    return out.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function hashProjectRoot(projectRoot: string): string {
+  return createHash('md5').update(resolve(projectRoot)).digest('hex').slice(0, 8);
+}
+
+/**
+ * Single-instance gate for the MCP subprocess (M3 / Phase 90 Tier 1).
+ *
+ * Two Claude Code windows opened in the same project would spawn two MCP subprocesses,
+ * both racing for the single Hermes CDP slot and producing missed events + state flicker.
+ * This module writes a lock file at startup keyed on the user's uid + an 8-char hash of
+ * the project root, so:
+ *   - same project, two windows → conflict (exit 11)
+ *   - different projects, same machine → coexist fine (different hash)
+ *   - different users on the same machine → coexist fine (different uid)
+ *
+ * Stale lock detection has three orthogonal checks (any failure ⇒ reclaim):
+ *   1. PID alive via `process.kill(pid, 0)` — catches crashed predecessors
+ *   2. Process name matches `cdp-bridge` via `ps -p <pid> -o args=` — catches PID reuse after reboot
+ *   3. Lock mtime < 24h — catches SIGKILL'd processes that left orphan locks
+ *
+ * All side effects are injectable (tmpDir, clock, processAlive, processName) so unit tests
+ * run fully hermetic without touching /tmp or spawning ps.
+ */
+export class Lockfile {
+  private readonly opts: Required<LockfileOptions>;
+  readonly lockPath: string;
+  private acquired = false;
+
+  constructor(opts: LockfileOptions = {}) {
+    const projectRoot = opts.projectRoot ?? defaultProjectRoot();
+    const uid = opts.uid ?? userInfo().uid;
+    const tmpDir = opts.tmpDir ?? tmpdir();
+    const hash = hashProjectRoot(projectRoot);
+
+    this.opts = {
+      projectRoot,
+      uid,
+      tmpDir,
+      pid: opts.pid ?? process.pid,
+      version: opts.version ?? '',
+      clock: opts.clock ?? Date.now,
+      processAlive: opts.processAlive ?? defaultProcessAlive,
+      processName: opts.processName ?? defaultProcessName,
+      maxAgeMs: opts.maxAgeMs ?? DEFAULT_MAX_AGE_MS,
+      processNameNeedle: opts.processNameNeedle ?? DEFAULT_PROCESS_NAME_NEEDLE,
+    };
+
+    this.lockPath = join(tmpDir, `rn-dev-agent-cdp-${uid}-${hash}.lock`);
+  }
+
+  acquire(): LockAcquireResult {
+    const existing = this.readExisting();
+    if (existing && this.isLockLive(existing)) {
+      return {
+        status: 'conflict',
+        lockPath: this.lockPath,
+        pid: existing.pid,
+        projectRoot: existing.projectRoot,
+        startedAt: existing.startedAt,
+        ageMs: this.opts.clock() - existing.startedAt,
+        version: existing.version,
+      };
+    }
+
+    this.writeLock();
+    this.acquired = true;
+    return { status: 'acquired', lockPath: this.lockPath };
+  }
+
+  release(): void {
+    if (!this.acquired) return;
+    try {
+      if (existsSync(this.lockPath)) {
+        const body = this.readExisting();
+        if (body?.pid === this.opts.pid) {
+          unlinkSync(this.lockPath);
+        }
+      }
+    } catch {
+      // Swallow: release must never fail the shutdown path.
+    }
+    this.acquired = false;
+  }
+
+  private readExisting(): LockFileBody | null {
+    if (!existsSync(this.lockPath)) return null;
+    try {
+      const raw = readFileSync(this.lockPath, 'utf8');
+      const parsed = JSON.parse(raw) as unknown;
+      if (!isValidLockBody(parsed)) return null;
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  private isLockLive(body: LockFileBody): boolean {
+    if (!this.opts.processAlive(body.pid)) return false;
+
+    const age = this.ageOfLockFile();
+    if (age !== null && age > this.opts.maxAgeMs) return false;
+
+    const name = this.opts.processName(body.pid);
+    if (name !== null && !name.toLowerCase().includes(this.opts.processNameNeedle.toLowerCase())) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private ageOfLockFile(): number | null {
+    try {
+      const st = statSync(this.lockPath);
+      return this.opts.clock() - st.mtimeMs;
+    } catch {
+      return null;
+    }
+  }
+
+  private writeLock(): void {
+    const body: LockFileBody = {
+      pid: this.opts.pid,
+      projectRoot: this.opts.projectRoot,
+      startedAt: this.opts.clock(),
+      version: this.opts.version || undefined,
+    };
+
+    const dir = this.opts.tmpDir;
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    writeFileSync(this.lockPath, JSON.stringify(body, null, 2), { encoding: 'utf8' });
+  }
+}
+
+function isValidLockBody(obj: unknown): obj is LockFileBody {
+  if (typeof obj !== 'object' || obj === null) return false;
+  const o = obj as Record<string, unknown>;
+  return (
+    typeof o.pid === 'number' &&
+    typeof o.projectRoot === 'string' &&
+    typeof o.startedAt === 'number'
+  );
+}
+
+export function formatLockConflictMessage(conflict: LockConflict): string {
+  const ageSec = Math.floor(conflict.ageMs / 1000);
+  const ageStr =
+    ageSec < 60
+      ? `${ageSec}s ago`
+      : ageSec < 3600
+        ? `${Math.floor(ageSec / 60)}m ago`
+        : `${Math.floor(ageSec / 3600)}h ${Math.floor((ageSec % 3600) / 60)}m ago`;
+
+  return [
+    `Another rn-dev-agent MCP is running in this project.`,
+    `  PID:      ${conflict.pid}`,
+    `  Project:  ${conflict.projectRoot}`,
+    `  Started:  ${ageStr}`,
+    `  Lock:     ${conflict.lockPath}`,
+    ``,
+    `To resolve:`,
+    `  1. Close the other Claude Code window for this project, OR`,
+    `  2. Kill the other process:  kill ${conflict.pid}`,
+    `  3. (If the process is dead) delete the lock file:  rm ${conflict.lockPath}`,
+    ``,
+    `Running two MCPs in the same project causes missed events and state flicker.`,
+    `Start with --no-lock to bypass this check (advanced; expect flaky behavior).`,
+  ].join('\n');
+}

--- a/scripts/cdp-bridge/test/unit/lockfile.test.js
+++ b/scripts/cdp-bridge/test/unit/lockfile.test.js
@@ -1,0 +1,428 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, existsSync, readFileSync, writeFileSync, rmSync, utimesSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { Lockfile, formatLockConflictMessage, defaultProcessName } from '../../dist/lifecycle/lockfile.js';
+
+function makeTmpDir() {
+  return mkdtempSync(join(tmpdir(), 'lockfile-test-'));
+}
+
+function writeLockBody(lockPath, body) {
+  writeFileSync(lockPath, JSON.stringify(body, null, 2), 'utf8');
+}
+
+function makeLockfile(overrides = {}) {
+  const tmpDir = overrides.tmpDir ?? makeTmpDir();
+  return {
+    tmpDir,
+    lockfile: new Lockfile({
+      projectRoot: '/fake/project/root',
+      pid: 12345,
+      tmpDir,
+      uid: 501,
+      version: '0.23.0-test',
+      clock: overrides.clock ?? (() => 1_700_000_000_000),
+      processAlive: overrides.processAlive ?? (() => false),
+      processName: overrides.processName ?? (() => null),
+      maxAgeMs: overrides.maxAgeMs ?? 24 * 60 * 60 * 1000,
+      processNameNeedle: overrides.processNameNeedle ?? 'cdp-bridge',
+      ...overrides,
+    }),
+  };
+}
+
+test('Lockfile: acquires on clean state and writes lock body', () => {
+  const { tmpDir, lockfile } = makeLockfile();
+  try {
+    const result = lockfile.acquire();
+    assert.equal(result.status, 'acquired');
+    assert.equal(result.lockPath, lockfile.lockPath);
+    assert.ok(existsSync(lockfile.lockPath), 'lock file exists on disk');
+
+    const body = JSON.parse(readFileSync(lockfile.lockPath, 'utf8'));
+    assert.equal(body.pid, 12345);
+    assert.equal(body.projectRoot, '/fake/project/root');
+    assert.equal(body.startedAt, 1_700_000_000_000);
+    assert.equal(body.version, '0.23.0-test');
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('Lockfile: returns conflict when valid live lock exists (same project)', () => {
+  const tmpDir = makeTmpDir();
+  try {
+    const preExistingLock = new Lockfile({
+      projectRoot: '/fake/project/root',
+      pid: 99999,
+      tmpDir,
+      uid: 501,
+      clock: () => 1_700_000_000_000,
+      processAlive: () => true,
+      processName: () => 'node cdp-bridge',
+    });
+    preExistingLock.acquire();
+
+    const { lockfile } = makeLockfile({
+      tmpDir,
+      processAlive: (pid) => pid === 99999,
+      processName: (pid) => (pid === 99999 ? 'node cdp-bridge' : null),
+      clock: () => 1_700_000_000_000 + 5 * 60 * 1000, // 5 minutes later
+    });
+
+    const result = lockfile.acquire();
+    assert.equal(result.status, 'conflict');
+    assert.equal(result.pid, 99999);
+    assert.equal(result.projectRoot, '/fake/project/root');
+    assert.equal(result.startedAt, 1_700_000_000_000);
+    assert.equal(result.ageMs, 5 * 60 * 1000);
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('Lockfile: reclaims stale lock when PID is dead', () => {
+  const tmpDir = makeTmpDir();
+  try {
+    writeLockBody(join(tmpDir, 'rn-dev-agent-cdp-501-bb3fe5be.lock'), {
+      pid: 88888,
+      projectRoot: '/fake/project/root',
+      startedAt: 1_700_000_000_000,
+      version: '0.20.0',
+    });
+
+    const { lockfile } = makeLockfile({
+      tmpDir,
+      processAlive: () => false, // dead PID
+    });
+
+    const result = lockfile.acquire();
+    assert.equal(result.status, 'acquired', 'reclaimed when PID is dead');
+
+    const body = JSON.parse(readFileSync(lockfile.lockPath, 'utf8'));
+    assert.equal(body.pid, 12345, 'new lock body has our PID');
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('Lockfile: reclaims stale lock when process name does not match cdp-bridge', () => {
+  const tmpDir = makeTmpDir();
+  try {
+    const { lockfile: first } = makeLockfile({
+      tmpDir,
+      processAlive: () => true,
+      processName: () => 'some-random-other-process',
+    });
+    // Pre-populate with a "live PID but wrong process name" scenario — as if the PID was reused.
+    writeLockBody(first.lockPath, {
+      pid: 77777,
+      projectRoot: '/fake/project/root',
+      startedAt: 1_700_000_000_000,
+    });
+
+    const { lockfile } = makeLockfile({
+      tmpDir,
+      processAlive: (pid) => pid === 77777,
+      processName: () => 'bash', // PID reused by unrelated process
+    });
+
+    const result = lockfile.acquire();
+    assert.equal(result.status, 'acquired', 'reclaimed when process name mismatch');
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('Lockfile: reclaims lock older than maxAgeMs (SIGKILL orphan)', () => {
+  const tmpDir = makeTmpDir();
+  try {
+    const lockPath = join(tmpDir, 'rn-dev-agent-cdp-501-bb3fe5be.lock');
+    writeLockBody(lockPath, {
+      pid: 66666,
+      projectRoot: '/fake/project/root',
+      startedAt: 1_700_000_000_000 - 48 * 60 * 60 * 1000, // 48h old
+    });
+    // Backdate mtime to 48h ago so the age check trips.
+    const past = new Date(1_700_000_000_000 - 48 * 60 * 60 * 1000);
+    utimesSync(lockPath, past, past);
+
+    const { lockfile } = makeLockfile({
+      tmpDir,
+      clock: () => 1_700_000_000_000,
+      processAlive: () => true, // pretend PID is alive (OS recycled it)
+      processName: () => 'node cdp-bridge', // pretend name matches
+      maxAgeMs: 24 * 60 * 60 * 1000,
+    });
+
+    const result = lockfile.acquire();
+    assert.equal(result.status, 'acquired', 'reclaimed stale (48h) lock despite live PID and matching name');
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('Lockfile: different project roots coexist (different hash ⇒ different file)', () => {
+  const tmpDir = makeTmpDir();
+  try {
+    const lockA = new Lockfile({
+      projectRoot: '/fake/project/alpha',
+      pid: 11111,
+      tmpDir,
+      uid: 501,
+      clock: () => 1_700_000_000_000,
+      processAlive: () => true,
+      processName: () => 'cdp-bridge',
+    });
+    const lockB = new Lockfile({
+      projectRoot: '/fake/project/beta',
+      pid: 22222,
+      tmpDir,
+      uid: 501,
+      clock: () => 1_700_000_000_000,
+      processAlive: () => true,
+      processName: () => 'cdp-bridge',
+    });
+
+    assert.notEqual(lockA.lockPath, lockB.lockPath, 'distinct lock paths for distinct projects');
+
+    const rA = lockA.acquire();
+    const rB = lockB.acquire();
+    assert.equal(rA.status, 'acquired');
+    assert.equal(rB.status, 'acquired', 'second project acquires independently');
+    assert.ok(existsSync(lockA.lockPath));
+    assert.ok(existsSync(lockB.lockPath));
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('Lockfile: release() unlinks lock file when we own it', () => {
+  const { tmpDir, lockfile } = makeLockfile();
+  try {
+    lockfile.acquire();
+    assert.ok(existsSync(lockfile.lockPath), 'lock exists after acquire');
+
+    lockfile.release();
+    assert.ok(!existsSync(lockfile.lockPath), 'lock removed after release');
+
+    // Second release is a no-op, not an error.
+    lockfile.release();
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('Lockfile: release() is a no-op when acquire was never called', () => {
+  const { tmpDir, lockfile } = makeLockfile();
+  try {
+    // No acquire. Release should not throw or try to unlink anything.
+    lockfile.release();
+    assert.ok(!existsSync(lockfile.lockPath), 'no lock file was ever created');
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('Lockfile: release() does NOT unlink if another process took over our lock slot', () => {
+  const tmpDir = makeTmpDir();
+  try {
+    const { lockfile } = makeLockfile({ tmpDir });
+    lockfile.acquire();
+
+    // Simulate another process overwriting the lock file (e.g. after we stall, another
+    // MCP reclaims our slot via the stale-check). Our release() must not clobber their lock.
+    writeLockBody(lockfile.lockPath, {
+      pid: 99999,
+      projectRoot: '/fake/project/root',
+      startedAt: 1_700_000_000_500,
+    });
+    const replacementMtime = statSync(lockfile.lockPath).mtimeMs;
+
+    lockfile.release();
+
+    assert.ok(existsSync(lockfile.lockPath), 'replacement lock preserved — we did not clobber it');
+    const body = JSON.parse(readFileSync(lockfile.lockPath, 'utf8'));
+    assert.equal(body.pid, 99999, 'replacement pid still in file');
+    assert.equal(statSync(lockfile.lockPath).mtimeMs, replacementMtime, 'file untouched');
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('Lockfile: lock filename includes uid and project hash (collision-safe shape)', () => {
+  const { tmpDir, lockfile } = makeLockfile();
+  try {
+    assert.match(
+      lockfile.lockPath,
+      /\/rn-dev-agent-cdp-501-[0-9a-f]{8}\.lock$/,
+      'filename pattern: ${uid}-${8-char-hex}',
+    );
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('Lockfile: ignores malformed lock file body and reclaims', () => {
+  const tmpDir = makeTmpDir();
+  try {
+    const { lockfile } = makeLockfile({ tmpDir });
+    writeFileSync(lockfile.lockPath, '{this is not valid json', 'utf8');
+
+    const result = lockfile.acquire();
+    assert.equal(result.status, 'acquired', 'malformed body treated as no-lock');
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('formatLockConflictMessage: renders all fields for human diagnosis', () => {
+  const msg = formatLockConflictMessage({
+    status: 'conflict',
+    lockPath: '/tmp/rn-dev-agent-cdp-501-abcd1234.lock',
+    pid: 54321,
+    projectRoot: '/Users/anton/GitHub/my-app',
+    startedAt: 1_700_000_000_000,
+    ageMs: 5 * 60 * 1000,
+  });
+
+  assert.match(msg, /Another rn-dev-agent MCP is running/);
+  assert.match(msg, /PID:\s+54321/);
+  assert.match(msg, /Project:\s+\/Users\/anton\/GitHub\/my-app/);
+  assert.match(msg, /Started:\s+5m ago/);
+  assert.match(msg, /Lock:\s+\/tmp\/rn-dev-agent-cdp-501-abcd1234\.lock/);
+  assert.match(msg, /kill 54321/);
+  assert.match(msg, /--no-lock/);
+});
+
+test('formatLockConflictMessage: seconds age rendering for young locks', () => {
+  const msg = formatLockConflictMessage({
+    status: 'conflict',
+    lockPath: '/tmp/fake.lock',
+    pid: 1,
+    projectRoot: '/x',
+    startedAt: 0,
+    ageMs: 42 * 1000,
+  });
+  assert.match(msg, /Started:\s+42s ago/);
+});
+
+test('formatLockConflictMessage: hours+minutes age rendering for old locks', () => {
+  const msg = formatLockConflictMessage({
+    status: 'conflict',
+    lockPath: '/tmp/fake.lock',
+    pid: 1,
+    projectRoot: '/x',
+    startedAt: 0,
+    ageMs: (3 * 60 * 60 + 12 * 60) * 1000,
+  });
+  assert.match(msg, /Started:\s+3h 12m ago/);
+});
+
+// ── D652 multi-review fix: real-process verification for defaultProcessName ──
+//
+// The original implementation used `ps -o comm=` which returns only the executable
+// basename ("node") for Node-launched scripts. That meant our needle match against
+// "cdp-bridge" could NEVER succeed in production — every live MCP would be flagged
+// stale and reclaimed, defeating the single-instance gate. Switched to `-o args=`
+// which returns the full command line on both BSD (macOS) and procps (Linux).
+//
+// This test exercises the REAL `defaultProcessName` against a REAL spawned child
+// process. It would have failed with the original `-o comm=` implementation because
+// the uniqueToken we pass via `-e` appears ONLY in the command-line args, never in
+// the executable basename. Keeps the hermetic-unit-tests spirit (no reliance on
+// anything about the cdp-bridge path on this machine) while proving the args-style
+// output that the needle match depends on.
+
+test('defaultProcessName: returns non-null for live PID', () => {
+  const name = defaultProcessName(process.pid);
+  assert.ok(name !== null, 'ps -p <self> returned non-null');
+  assert.ok(name.length > 0, `expected non-empty output, got: ${JSON.stringify(name)}`);
+});
+
+test('defaultProcessName: returns null for non-existent PID', () => {
+  // PID 1 is almost always init — call with a wildly invalid PID instead
+  const name = defaultProcessName(999999999);
+  assert.equal(name, null, 'non-existent PID should return null');
+});
+
+test('defaultProcessName: returns full command line (args=), not just basename (comm=)', async () => {
+  // Spawn a Node child with a unique token in its -e script body. With `-o args=`
+  // the token appears in the output; with `-o comm=` it would NOT (comm= is just
+  // "node"). This test fails loudly on the original bug and passes after the fix.
+  const uniqueToken = `M3_TEST_TOKEN_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  const child = spawn(
+    process.execPath,
+    ['-e', `/* ${uniqueToken} */ setTimeout(() => {}, 10000)`],
+    { stdio: 'ignore', detached: false },
+  );
+
+  try {
+    // Give the OS a moment to materialize the process so ps can find it
+    await new Promise((r) => setTimeout(r, 150));
+    const name = defaultProcessName(child.pid);
+    assert.ok(name !== null, `ps returned null for live child PID ${child.pid}`);
+    assert.ok(
+      name.includes(uniqueToken),
+      `expected args= output containing ${uniqueToken}, got: ${JSON.stringify(name)}`,
+    );
+  } finally {
+    child.kill('SIGKILL');
+    // Don't leave zombie children
+    await new Promise((r) => setTimeout(r, 50));
+  }
+});
+
+test('Lockfile: default processName stale check matches real node scripts (D652 regression guard)', async () => {
+  // End-to-end: spawn a child whose command line contains "cdp-bridge", write its PID
+  // to a lock file, then call acquire() using the REAL defaultProcessName. If the
+  // needle match works against `ps -o args=`, isLockLive returns true and acquire
+  // returns 'conflict'. With the original `-o comm=` bug, this test would incorrectly
+  // return 'acquired' because "node" doesn't contain "cdp-bridge".
+  const uniqueToken = 'cdp-bridge'; // the actual needle we match on
+  const child = spawn(
+    process.execPath,
+    ['-e', `/* ${uniqueToken} marker */ setTimeout(() => {}, 10000)`],
+    { stdio: 'ignore', detached: false },
+  );
+
+  const tmpDir = makeTmpDir();
+  try {
+    await new Promise((r) => setTimeout(r, 150));
+
+    // Pre-write a lock body claiming the live child owns the lock
+    const preLock = new Lockfile({
+      projectRoot: '/fake/project/root',
+      pid: child.pid,
+      tmpDir,
+      uid: 501,
+      clock: () => Date.now(),
+      // Use the REAL processAlive AND REAL processName — no stubs
+    });
+    preLock.acquire();
+
+    // New Lockfile instance with different PID tries to acquire — should conflict
+    const contender = new Lockfile({
+      projectRoot: '/fake/project/root',
+      pid: 99999, // different PID than the child
+      tmpDir,
+      uid: 501,
+      clock: () => Date.now(),
+      // No processAlive/processName overrides — exercises the real defaults
+    });
+
+    const result = contender.acquire();
+    assert.equal(
+      result.status,
+      'conflict',
+      `expected conflict (live child PID ${child.pid} owns lock, real processName should match "cdp-bridge"), got: ${JSON.stringify(result)}`,
+    );
+  } finally {
+    child.kill('SIGKILL');
+    await new Promise((r) => setTimeout(r, 50));
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- **M3 (Phase 90 Tier 1 metro-mcp adoption)**: new lockfile gate at MCP startup prevents two Claude Code windows in the same project from spawning colliding MCP subprocesses that fight over the single Hermes CDP slot.
- Exit code 11 + actionable stderr message on conflict; `--no-lock` CLI opt-out for CI parallelism.
- **Three-tier stale-lock reclaim**: dead PID (`process.kill(pid, 0)`) OR mismatched process name (`ps -p <pid> -o args=`) OR mtime >24h → reclaim.
- Lock path `/tmp/rn-dev-agent-cdp-${uid}-${md5(projectRoot).slice(0,8)}.lock` → distinct projects coexist, same project conflicts.

## Multi-review iteration

First-pass multi-review caught a ship-blocker: `ps -p <pid> -o comm=` returns only `"node"` for Node-launched scripts, so the `"cdp-bridge"` needle could never match a live MCP. Swapped to `-o args=`. Added 4 real-process regression tests. Second pass: both agents said "ship it".

## Test plan

- [x] `npm run build` zero errors
- [x] `npm test` — 350/350 passing (18 new)
- [x] Multi-review pass 2 clean
- [ ] **Manual smoke (user)**: after CC restart, two windows in same project → second exits 11