### PR TITLE
feat(m2): exponential reconnect with jitter — Phase 90 Tier 1 (D653)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/scripts/cdp-bridge/dist/cdp/reconnection.js
+++ b/scripts/cdp-bridge/dist/cdp/reconnection.js
@@ -1,8 +1,40 @@
 import { logger } from '../logger.js';
 import { resetState, clearActiveFlag, sleep } from './state.js';
-const RECONNECT_DELAY_MS = 1500;
 const RECONNECT_ATTEMPTS = 30;
-const RECONNECT_RETRY_MS = 1500;
+/**
+ * Exponential reconnect delay with jitter (M2 / Phase 90 Tier 1).
+ *
+ * Replaces the old linear 1.5s × 30 retry loop. The curve keeps attempt 0 at 0ms
+ * so hot-reload reconnects are instant, then grows to cap at 30s:
+ *
+ *   attempt 0  → 0ms        (hot-reload happy path)
+ *   attempt 1  → 500ms     ±jitter
+ *   attempt 2  → 1_000ms   ±jitter
+ *   attempt 3  → 2_000ms   ±jitter
+ *   attempt 4  → 4_000ms   ±jitter
+ *   attempt 5  → 8_000ms   ±jitter
+ *   attempt 6  → 16_000ms  ±jitter
+ *   attempt 7+ → 30_000ms  ±jitter (capped)
+ *
+ * Why the jitter: when two MCPs reconnect in lockstep after a Metro restart,
+ * linear retries hammer Metro synchronously. ±500ms of jitter breaks the lockstep
+ * within a few attempts. The cap prevents a 30-minute Metro outage from tripling
+ * into an hour of reconnect attempts.
+ *
+ * `rng` is injectable so tests can assert exact values without flakiness.
+ */
+export function computeReconnectDelay(attempt, opts = {}) {
+    if (attempt <= 0)
+        return 0;
+    const baseMs = opts.baseMs ?? 500;
+    const capMs = opts.capMs ?? 30_000;
+    const jitterMs = opts.jitterMs ?? 500;
+    const rng = opts.rng ?? Math.random;
+    const exponential = baseMs * Math.pow(2, attempt - 1);
+    const capped = Math.min(exponential, capMs);
+    const jitter = Math.floor(rng() * jitterMs);
+    return capped + jitter;
+}
 export function handleClose(ctx, code) {
     resetState(ctx.getResettableState());
     if (ctx.isDisposed() || ctx.isReconnecting())
@@ -21,9 +53,40 @@ export function handleClose(ctx, code) {
         ctx.setReconnecting(false);
     });
 }
+/**
+ * Sleep for `delayMs` total, but check for `isDisposed()` / `isSoftReconnectRequested()`
+ * every `sliceMs` (default 500ms) so soft-reconnect requests are honored within one slice
+ * instead of waiting out the full exponential backoff window.
+ *
+ * Returns `true` if the full delay elapsed without interruption, `false` if a disposal
+ * or soft-reconnect request was observed. Critical for M2 / D653 — once the backoff
+ * curve hits the 30s cap, a non-interruptible sleep would exceed `softReconnect`'s 3s
+ * bail window, letting both paths race to call `discoverAndConnect()` concurrently.
+ */
+// Exported for unit testing — the `reconnect()` loop is a tight ReconnectContext
+// consumer, so exercising the sleep separately from the loop catches preemption
+// bugs without mocking every context field.
+export async function interruptibleSleep(delayMs, ctx, sliceMs = 500) {
+    const deadline = Date.now() + delayMs;
+    while (Date.now() < deadline) {
+        if (ctx.isDisposed() || ctx.isSoftReconnectRequested())
+            return false;
+        const remaining = deadline - Date.now();
+        await sleep(Math.min(sliceMs, remaining));
+    }
+    return true;
+}
 export async function reconnect(ctx) {
-    await sleep(RECONNECT_DELAY_MS);
     for (let i = 0; i < RECONNECT_ATTEMPTS; i++) {
+        const delayMs = computeReconnectDelay(i);
+        if (delayMs > 0) {
+            logger.info('CDP', `reconnect attempt ${i + 1}/${RECONNECT_ATTEMPTS} in ${delayMs}ms`);
+            const completed = await interruptibleSleep(delayMs, ctx);
+            if (!completed) {
+                ctx.setReconnecting(false);
+                return;
+            }
+        }
         ctx.setReconnectAttempt(i + 1, new Date().toISOString());
         if (ctx.isDisposed() || ctx.isSoftReconnectRequested()) {
             ctx.setReconnecting(false);
@@ -36,13 +99,7 @@ export async function reconnect(ctx) {
             return;
         }
         catch {
-            if (i < RECONNECT_ATTEMPTS - 1) {
-                if (ctx.isSoftReconnectRequested()) {
-                    ctx.setReconnecting(false);
-                    return;
-                }
-                await sleep(RECONNECT_RETRY_MS);
-            }
+            // Fall through to next iteration — delay for attempt i+1 applied at top of loop.
         }
     }
     ctx.setReconnecting(false);

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/cdp/reconnection.ts
+++ b/scripts/cdp-bridge/src/cdp/reconnection.ts
@@ -2,9 +2,49 @@ import { logger } from '../logger.js';
 import { resetState, clearActiveFlag, sleep } from './state.js';
 import type { ResettableState } from './state.js';
 
-const RECONNECT_DELAY_MS = 1500;
 const RECONNECT_ATTEMPTS = 30;
-const RECONNECT_RETRY_MS = 1500;
+
+export interface ReconnectDelayOpts {
+  baseMs?: number;
+  capMs?: number;
+  jitterMs?: number;
+  rng?: () => number;
+}
+
+/**
+ * Exponential reconnect delay with jitter (M2 / Phase 90 Tier 1).
+ *
+ * Replaces the old linear 1.5s × 30 retry loop. The curve keeps attempt 0 at 0ms
+ * so hot-reload reconnects are instant, then grows to cap at 30s:
+ *
+ *   attempt 0  → 0ms        (hot-reload happy path)
+ *   attempt 1  → 500ms     ±jitter
+ *   attempt 2  → 1_000ms   ±jitter
+ *   attempt 3  → 2_000ms   ±jitter
+ *   attempt 4  → 4_000ms   ±jitter
+ *   attempt 5  → 8_000ms   ±jitter
+ *   attempt 6  → 16_000ms  ±jitter
+ *   attempt 7+ → 30_000ms  ±jitter (capped)
+ *
+ * Why the jitter: when two MCPs reconnect in lockstep after a Metro restart,
+ * linear retries hammer Metro synchronously. ±500ms of jitter breaks the lockstep
+ * within a few attempts. The cap prevents a 30-minute Metro outage from tripling
+ * into an hour of reconnect attempts.
+ *
+ * `rng` is injectable so tests can assert exact values without flakiness.
+ */
+export function computeReconnectDelay(attempt: number, opts: ReconnectDelayOpts = {}): number {
+  if (attempt <= 0) return 0;
+  const baseMs = opts.baseMs ?? 500;
+  const capMs = opts.capMs ?? 30_000;
+  const jitterMs = opts.jitterMs ?? 500;
+  const rng = opts.rng ?? Math.random;
+
+  const exponential = baseMs * Math.pow(2, attempt - 1);
+  const capped = Math.min(exponential, capMs);
+  const jitter = Math.floor(rng() * jitterMs);
+  return capped + jitter;
+}
 
 export interface ReconnectContext {
   isDisposed: () => boolean;
@@ -45,10 +85,45 @@ export function handleClose(ctx: ReconnectContext, code: number): void {
   });
 }
 
-export async function reconnect(ctx: ReconnectContext): Promise<void> {
-  await sleep(RECONNECT_DELAY_MS);
+/**
+ * Sleep for `delayMs` total, but check for `isDisposed()` / `isSoftReconnectRequested()`
+ * every `sliceMs` (default 500ms) so soft-reconnect requests are honored within one slice
+ * instead of waiting out the full exponential backoff window.
+ *
+ * Returns `true` if the full delay elapsed without interruption, `false` if a disposal
+ * or soft-reconnect request was observed. Critical for M2 / D653 — once the backoff
+ * curve hits the 30s cap, a non-interruptible sleep would exceed `softReconnect`'s 3s
+ * bail window, letting both paths race to call `discoverAndConnect()` concurrently.
+ */
+// Exported for unit testing — the `reconnect()` loop is a tight ReconnectContext
+// consumer, so exercising the sleep separately from the loop catches preemption
+// bugs without mocking every context field.
+export async function interruptibleSleep(
+  delayMs: number,
+  ctx: ReconnectContext,
+  sliceMs = 500,
+): Promise<boolean> {
+  const deadline = Date.now() + delayMs;
+  while (Date.now() < deadline) {
+    if (ctx.isDisposed() || ctx.isSoftReconnectRequested()) return false;
+    const remaining = deadline - Date.now();
+    await sleep(Math.min(sliceMs, remaining));
+  }
+  return true;
+}
 
+export async function reconnect(ctx: ReconnectContext): Promise<void> {
   for (let i = 0; i < RECONNECT_ATTEMPTS; i++) {
+    const delayMs = computeReconnectDelay(i);
+    if (delayMs > 0) {
+      logger.info('CDP', `reconnect attempt ${i + 1}/${RECONNECT_ATTEMPTS} in ${delayMs}ms`);
+      const completed = await interruptibleSleep(delayMs, ctx);
+      if (!completed) {
+        ctx.setReconnecting(false);
+        return;
+      }
+    }
+
     ctx.setReconnectAttempt(i + 1, new Date().toISOString());
     if (ctx.isDisposed() || ctx.isSoftReconnectRequested()) {
       ctx.setReconnecting(false);
@@ -60,13 +135,7 @@ export async function reconnect(ctx: ReconnectContext): Promise<void> {
       console.error('CDP: reconnected successfully');
       return;
     } catch {
-      if (i < RECONNECT_ATTEMPTS - 1) {
-        if (ctx.isSoftReconnectRequested()) {
-          ctx.setReconnecting(false);
-          return;
-        }
-        await sleep(RECONNECT_RETRY_MS);
-      }
+      // Fall through to next iteration — delay for attempt i+1 applied at top of loop.
     }
   }
   ctx.setReconnecting(false);

--- a/scripts/cdp-bridge/test/unit/reconnect-delay.test.js
+++ b/scripts/cdp-bridge/test/unit/reconnect-delay.test.js
@@ -1,0 +1,222 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeReconnectDelay, interruptibleSleep } from '../../dist/cdp/reconnection.js';
+
+// Minimal mock ReconnectContext — interruptibleSleep only touches isDisposed / isSoftReconnectRequested
+function makeMockCtx(overrides = {}) {
+  const state = {
+    disposed: false,
+    softReconnectRequested: false,
+    ...overrides,
+  };
+  return {
+    state,
+    ctx: {
+      isDisposed: () => state.disposed,
+      isSoftReconnectRequested: () => state.softReconnectRequested,
+      // Unused by interruptibleSleep — stubs kept minimal
+      isReconnecting: () => false,
+      setReconnecting: () => {},
+      setSoftReconnectRequested: (v) => { state.softReconnectRequested = v; },
+      setState: () => {},
+      setReconnectAttempt: () => {},
+      closeWs: () => {},
+      rejectAllPending: () => {},
+      discoverAndConnect: async () => '',
+      getResettableState: () => ({}),
+      getPort: () => 8081,
+      setBgPollTimer: () => {},
+      getBgPollTimer: () => null,
+      isConnected: () => false,
+    },
+  };
+}
+
+// ── M2 / Phase 90 Tier 1: exponential reconnect with jitter ──
+//
+// Replaces the old linear RECONNECT_RETRY_MS = 1500 loop. Curve (with jitterMs=0):
+//   [0, 500, 1000, 2000, 4000, 8000, 16000, 30000, 30000, 30000, ...]
+//
+// Hot-reload responsiveness preserved by attempt 0 returning 0ms (no initial wait).
+// Jitter ±500ms breaks lockstep when two MCPs reconnect simultaneously.
+
+test('computeReconnectDelay: attempt 0 returns 0 (hot-reload happy path, never jittered)', () => {
+  assert.equal(computeReconnectDelay(0), 0);
+  assert.equal(computeReconnectDelay(0, { jitterMs: 10_000 }), 0, 'jitter does not apply to attempt 0');
+  assert.equal(computeReconnectDelay(-1), 0, 'negative attempts clamp to 0');
+});
+
+test('computeReconnectDelay: curve at attempts 0..10 with jitter=0 matches spec', () => {
+  const noJitter = { jitterMs: 0 };
+  const expected = [0, 500, 1000, 2000, 4000, 8000, 16_000, 30_000, 30_000, 30_000, 30_000];
+  for (let i = 0; i <= 10; i++) {
+    assert.equal(
+      computeReconnectDelay(i, noJitter),
+      expected[i],
+      `attempt ${i}: expected ${expected[i]}ms`,
+    );
+  }
+});
+
+test('computeReconnectDelay: jitter bounded within [0, jitterMs) at attempt 5', () => {
+  // With baseMs=500, capMs=30000, attempt=5 → 8000ms base (uncapped), +jitter in [0, 500).
+  // 1000 samples with real Math.random: all should fall in [8000, 8500).
+  const samples = [];
+  for (let i = 0; i < 1000; i++) {
+    samples.push(computeReconnectDelay(5));
+  }
+  const min = Math.min(...samples);
+  const max = Math.max(...samples);
+  assert.ok(min >= 8000, `min delay should be >= 8000, got ${min}`);
+  assert.ok(max < 8500, `max delay should be < 8500, got ${max}`);
+});
+
+test('computeReconnectDelay: cap respected at very high attempt counts', () => {
+  const noJitter = { jitterMs: 0 };
+  // 2^20 = 1M, way past 30s cap. Must still return exactly 30_000.
+  assert.equal(computeReconnectDelay(20, noJitter), 30_000);
+  assert.equal(computeReconnectDelay(50, noJitter), 30_000);
+  // And with jitter on, cap + jitter upper bound holds.
+  const withJitter = computeReconnectDelay(100); // default jitterMs=500
+  assert.ok(
+    withJitter >= 30_000 && withJitter < 30_500,
+    `attempt=100 with default jitter should be in [30000, 30500), got ${withJitter}`,
+  );
+});
+
+test('computeReconnectDelay: rng injectable for deterministic output', () => {
+  // Fixed rng() = 0.5 → jitter = floor(0.5 * 500) = 250
+  const fixed = computeReconnectDelay(3, { rng: () => 0.5 });
+  assert.equal(fixed, 2000 + 250, 'attempt 3 = 2000 base + 250 jitter at rng=0.5');
+
+  // rng() = 0 → no jitter
+  assert.equal(computeReconnectDelay(3, { rng: () => 0 }), 2000);
+
+  // rng() = 0.999... → max jitter (floor(499.5) = 499)
+  assert.equal(computeReconnectDelay(3, { rng: () => 0.999 }), 2000 + Math.floor(0.999 * 500));
+});
+
+test('computeReconnectDelay: custom baseMs/capMs/jitterMs params respected', () => {
+  const opts = { baseMs: 1000, capMs: 10_000, jitterMs: 0 };
+  assert.equal(computeReconnectDelay(0, opts), 0);
+  assert.equal(computeReconnectDelay(1, opts), 1000, 'baseMs respected at attempt 1');
+  assert.equal(computeReconnectDelay(2, opts), 2000);
+  assert.equal(computeReconnectDelay(4, opts), 8000);
+  assert.equal(computeReconnectDelay(5, opts), 10_000, 'capMs respected');
+  assert.equal(computeReconnectDelay(10, opts), 10_000);
+});
+
+test('computeReconnectDelay: jitter=0 disables randomness even with default rng', () => {
+  // Sanity: with jitterMs=0, output is deterministic regardless of rng.
+  for (let i = 1; i <= 5; i++) {
+    const a = computeReconnectDelay(i, { jitterMs: 0 });
+    const b = computeReconnectDelay(i, { jitterMs: 0 });
+    assert.equal(a, b, `attempt ${i} deterministic with jitterMs=0`);
+  }
+});
+
+// ── D653 multi-review fix: interruptibleSleep preserves softReconnect preemption ──
+//
+// The first-pass review surfaced a race: after M2 raised the per-iteration sleep to
+// 30s at attempt 7+, softReconnect's 3s bail window could no longer out-wait the
+// exponential backoff loop, letting both paths race to call discoverAndConnect().
+// Fix: interruptibleSleep polls isDisposed() / isSoftReconnectRequested() every
+// 500ms (default slice) so preemption latency stays bounded regardless of the
+// underlying delay.
+
+test('interruptibleSleep: completes full delay when no interruption requested', async () => {
+  const { ctx } = makeMockCtx();
+  const start = Date.now();
+  const completed = await interruptibleSleep(300, ctx, 100);
+  const elapsed = Date.now() - start;
+  assert.equal(completed, true, 'returns true when full delay elapsed');
+  assert.ok(elapsed >= 290 && elapsed < 500, `elapsed should be ~300ms, got ${elapsed}`);
+});
+
+test('interruptibleSleep: exits within one slice when softReconnect requested mid-sleep', async () => {
+  const { state, ctx } = makeMockCtx();
+  const sliceMs = 100;
+  // Flip the flag after 150ms — between slice 1 and slice 2 of a 1000ms sleep
+  setTimeout(() => { state.softReconnectRequested = true; }, 150);
+
+  const start = Date.now();
+  const completed = await interruptibleSleep(1000, ctx, sliceMs);
+  const elapsed = Date.now() - start;
+
+  assert.equal(completed, false, 'returns false when interrupted');
+  // Flag flipped at ~150ms; next slice boundary checked by ~200ms worst case
+  assert.ok(elapsed < 350, `should exit within ~250ms of flag flip, got ${elapsed}`);
+  assert.ok(elapsed < 1000, `must NOT wait out the full 1000ms delay, got ${elapsed}`);
+});
+
+test('interruptibleSleep: exits within one slice when disposed mid-sleep', async () => {
+  const { state, ctx } = makeMockCtx();
+  const sliceMs = 100;
+  setTimeout(() => { state.disposed = true; }, 150);
+
+  const start = Date.now();
+  const completed = await interruptibleSleep(1000, ctx, sliceMs);
+  const elapsed = Date.now() - start;
+
+  assert.equal(completed, false, 'returns false when disposed');
+  assert.ok(elapsed < 350, `should exit within ~250ms of dispose, got ${elapsed}`);
+});
+
+test('interruptibleSleep: returns false immediately when flag already set before call', async () => {
+  const { ctx } = makeMockCtx({ softReconnectRequested: true });
+  const start = Date.now();
+  const completed = await interruptibleSleep(1000, ctx, 100);
+  const elapsed = Date.now() - start;
+  assert.equal(completed, false);
+  assert.ok(elapsed < 50, `should return almost instantly, got ${elapsed}ms`);
+});
+
+test('interruptibleSleep: zero or negative delay returns true immediately', async () => {
+  const { ctx } = makeMockCtx();
+  assert.equal(await interruptibleSleep(0, ctx), true);
+  assert.equal(await interruptibleSleep(-100, ctx), true);
+});
+
+test('interruptibleSleep: honors D653 worst case — 30s sleep preempted within 500ms slice', async () => {
+  // Simulates M2's worst-case scenario: reconnect at attempt 7+, 30s backoff
+  // sleep, softReconnect arrives 2s in. With default 500ms slices, preemption
+  // latency <= 500ms. We shrink the numbers to keep the test fast but preserve
+  // the proportion (30s:500ms = 60:1).
+  const { state, ctx } = makeMockCtx();
+  setTimeout(() => { state.softReconnectRequested = true; }, 40);
+
+  const start = Date.now();
+  const completed = await interruptibleSleep(3000, ctx, 50); // 60:1 ratio like prod
+  const elapsed = Date.now() - start;
+
+  assert.equal(completed, false, 'preempted');
+  assert.ok(elapsed < 150, `prod-equivalent preemption should be <500ms/prod scaled ~100ms test, got ${elapsed}`);
+});
+
+test('computeReconnectDelay: cumulative delay over 30 attempts vs old linear (reduction proof)', () => {
+  // Old code: 30 × 1500ms = 45_000ms between first and last attempt.
+  // New code: 0 + 500 + 1000 + 2000 + 4000 + 8000 + 16000 + 30000*23 ≈ 720_500ms worst case.
+  // Wait — that's WORSE! But the story isn't cumulative sleep; it's Metro traffic density.
+  // Old: 30 requests in 45s (linear 1 req/1.5s).
+  // New: 30 requests spread over ~720s (1 req/1.5s early, then 1 req/30s late).
+  // Metro load in first minute: old=40 attempts (hammer), new=7 attempts (0,0.5,1,2,4,8,16,30=62s... so 8 in 60s).
+  //
+  // Test this by counting how many attempts fit in the first 60 seconds (jitter-free).
+  let elapsed = 0;
+  let attemptsIn60s = 0;
+  for (let i = 0; i < 30 && elapsed <= 60_000; i++) {
+    const delay = computeReconnectDelay(i, { jitterMs: 0 });
+    elapsed += delay;
+    if (elapsed <= 60_000) attemptsIn60s++;
+  }
+  // Within first 60s: 0 + 500 + 1000 + 2000 + 4000 + 8000 + 16000 = 31500ms cumulative at attempt 6.
+  // Adding attempt 7 (30000ms) puts us at 61500ms — just over 60s, so attempts 0..6 fit (7 attempts).
+  assert.ok(
+    attemptsIn60s >= 6 && attemptsIn60s <= 8,
+    `expected 6-8 attempts in first 60s, got ${attemptsIn60s}`,
+  );
+  assert.ok(
+    attemptsIn60s < 40,
+    `new curve must be well under old linear ~40 attempts/60s, got ${attemptsIn60s}`,
+  );
+});


### PR DESCRIPTION
## Summary

- **M2 (Phase 90 Tier 1)** — replaces linear 1.5s × 30 reconnect loop with exponential backoff + jitter. Metro wake-ups in first 60s of outage: **~40 → 6-8** (~5× reduction). Hot-reload stays instant (attempt 0 = 0ms).
- New exported `computeReconnectDelay(attempt, opts?)` pure helper with curve `[0, 500, 1000, 2000, 4000, 8000, 16_000, 30_000, ...]` ±500ms jitter. All parameters injectable.
- New `interruptibleSleep` helper — preserves `softReconnect`'s fast-takeover UX even at the 30s cap.
- Removed both `RECONNECT_DELAY_MS` and `RECONNECT_RETRY_MS` constants.

## Multi-review iteration

**Pass 1:** Both reviewers converged on a real race at 85% (Codex) / 70% (Gemini): new 30s cap sleep exceeds `softReconnect`'s 3s `bailDeadline`, allowing double `discoverAndConnect()`.

**Fix:** New `interruptibleSleep(delayMs, ctx, sliceMs=500)` polls the dispose / soft-reconnect flags in 500ms slices. Preemption latency bounded by sliceMs regardless of underlying delay. Considered and rejected bumping bailDeadline 3s → 31s (would slow `softReconnect` on all recovery paths).

**Pass 2:** Both "ship it" — no further issues.

## Test plan

- [x] `npm run build` — zero TS errors
- [x] `npm test` — 350 → **364 passing** (8 curve tests + 6 interruptibleSleep tests)
- [x] Multi-review pass 2: both agents say "ship it"
- [ ] Manual verification (user): kill Metro for ~60s, watch logs — should see structured `reconnect attempt N/30 in Mms` lines with exponential pacing instead of the old silent 1.5s loop

## Refs

- D653 (DECISIONS.md) — full rationale + multi-review lessons
- Phase 99 (ROADMAP.md) — standalone DONE entry with behavioral comparison
- Phase 90 Story M2 — marked DONE inline; only M1 (multiplexer) remains in Tier 1