### PR TITLE
feat(m1a): CDP multiplexer module + DevTools detection — Phase 90 Tier 1 (D654)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/scripts/cdp-bridge/dist/cdp/multiplexer.js
+++ b/scripts/cdp-bridge/dist/cdp/multiplexer.js
@@ -1,0 +1,277 @@
+import { createServer } from 'node:http';
+import WebSocket, { WebSocketServer } from 'ws';
+import { logger } from '../logger.js';
+export class CDPMultiplexer {
+    opts;
+    httpServer = null;
+    wss = null;
+    hermesWs = null;
+    consumers = new Map();
+    nextConsumerId = 1;
+    upstreamSeq = 1;
+    routingTable = new Map();
+    hermesBuffer = [];
+    state = 'stopped';
+    boundPort = null;
+    constructor(opts) {
+        this.opts = {
+            hermesUrl: opts.hermesUrl,
+            host: opts.host ?? '127.0.0.1',
+            port: opts.port ?? 0,
+            logTag: opts.logTag ?? 'CDP.proxy',
+        };
+    }
+    get port() {
+        return this.boundPort;
+    }
+    get isRunning() {
+        return this.state === 'running';
+    }
+    get consumerCount() {
+        return this.consumers.size;
+    }
+    async start() {
+        if (this.state !== 'stopped') {
+            throw new Error(`CDPMultiplexer cannot start from state '${this.state}'`);
+        }
+        this.state = 'starting';
+        try {
+            const port = await this.startConsumerServer();
+            await this.connectHermes();
+            this.state = 'running';
+            logger.info(this.opts.logTag, `multiplexer running on ${this.opts.host}:${port}`);
+            return port;
+        }
+        catch (err) {
+            this.state = 'stopped';
+            await this.cleanup();
+            throw err;
+        }
+    }
+    async stop() {
+        if (this.state === 'stopped' || this.state === 'stopping')
+            return;
+        this.state = 'stopping';
+        await this.cleanup();
+        this.state = 'stopped';
+        logger.info(this.opts.logTag, 'multiplexer stopped');
+    }
+    startConsumerServer() {
+        return new Promise((resolve, reject) => {
+            this.httpServer = createServer();
+            this.wss = new WebSocketServer({ server: this.httpServer });
+            this.wss.on('connection', (ws) => this.onConsumerConnect(ws));
+            this.wss.on('error', (err) => {
+                logger.warn(this.opts.logTag, `WebSocketServer error: ${err instanceof Error ? err.message : err}`);
+            });
+            this.httpServer.once('error', reject);
+            this.httpServer.listen(this.opts.port, this.opts.host, () => {
+                const addr = this.httpServer?.address();
+                if (!addr) {
+                    reject(new Error('httpServer.address() returned null after listen'));
+                    return;
+                }
+                this.boundPort = addr.port;
+                resolve(addr.port);
+            });
+        });
+    }
+    connectHermes() {
+        return new Promise((resolve, reject) => {
+            const ws = new WebSocket(this.opts.hermesUrl);
+            this.hermesWs = ws;
+            const onOpen = () => {
+                ws.off('error', onError);
+                for (const msg of this.hermesBuffer)
+                    ws.send(msg);
+                this.hermesBuffer = [];
+                logger.info(this.opts.logTag, `connected to upstream Hermes at ${this.opts.hermesUrl}`);
+                resolve();
+            };
+            const onError = (err) => {
+                ws.off('open', onOpen);
+                reject(err);
+            };
+            ws.once('open', onOpen);
+            ws.once('error', onError);
+            ws.on('message', (data) => this.onHermesMessage(data));
+            ws.on('close', (code, reason) => this.onHermesClose(code, reason.toString()));
+            ws.on('error', (err) => {
+                logger.warn(this.opts.logTag, `upstream WS error: ${err.message}`);
+            });
+        });
+    }
+    onConsumerConnect(ws) {
+        const consumerId = this.nextConsumerId++;
+        this.consumers.set(consumerId, ws);
+        logger.info(this.opts.logTag, `consumer ${consumerId} connected (total: ${this.consumers.size})`);
+        ws.on('message', (data) => this.onConsumerMessage(consumerId, data));
+        ws.on('close', () => {
+            this.consumers.delete(consumerId);
+            for (const [upstreamId, entry] of this.routingTable) {
+                if (entry.consumerId === consumerId)
+                    this.routingTable.delete(upstreamId);
+            }
+            logger.info(this.opts.logTag, `consumer ${consumerId} disconnected (remaining: ${this.consumers.size})`);
+        });
+        ws.on('error', (err) => {
+            logger.warn(this.opts.logTag, `consumer ${consumerId} WS error: ${err.message}`);
+        });
+    }
+    onConsumerMessage(consumerId, data) {
+        const raw = data.toString();
+        let msg;
+        try {
+            msg = JSON.parse(raw);
+        }
+        catch {
+            logger.warn(this.opts.logTag, `consumer ${consumerId} sent non-JSON, dropping`);
+            return;
+        }
+        if (typeof msg !== 'object' || msg === null || Array.isArray(msg)) {
+            logger.warn(this.opts.logTag, `consumer ${consumerId} sent non-object, dropping`);
+            return;
+        }
+        const m = msg;
+        const consumerOriginalId = typeof m.id === 'number' ? m.id : null;
+        if (consumerOriginalId !== null) {
+            const upstreamId = this.upstreamSeq++;
+            this.routingTable.set(upstreamId, { consumerId, consumerOriginalId });
+            m.id = upstreamId;
+        }
+        this.sendToHermes(JSON.stringify(m));
+    }
+    onHermesMessage(data) {
+        const raw = data.toString();
+        let msg;
+        try {
+            msg = JSON.parse(raw);
+        }
+        catch {
+            logger.warn(this.opts.logTag, 'upstream sent non-JSON, dropping');
+            return;
+        }
+        if (typeof msg !== 'object' || msg === null || Array.isArray(msg)) {
+            logger.warn(this.opts.logTag, 'upstream sent non-object, dropping');
+            return;
+        }
+        const m = msg;
+        const upstreamId = typeof m.id === 'number' ? m.id : null;
+        if (upstreamId === null) {
+            this.broadcastToConsumers(raw);
+            return;
+        }
+        const route = this.routingTable.get(upstreamId);
+        if (!route)
+            return;
+        this.routingTable.delete(upstreamId);
+        m.id = route.consumerOriginalId;
+        const rewritten = JSON.stringify(m);
+        const consumerWs = this.consumers.get(route.consumerId);
+        if (consumerWs && consumerWs.readyState === WebSocket.OPEN) {
+            consumerWs.send(rewritten);
+        }
+    }
+    onHermesClose(code, reason) {
+        logger.warn(this.opts.logTag, `upstream Hermes closed (code=${code}, reason='${reason}')`);
+        for (const ws of this.consumers.values()) {
+            try {
+                ws.close(1011, 'upstream closed');
+            }
+            catch { /* ignore */ }
+        }
+        this.consumers.clear();
+        this.routingTable.clear();
+    }
+    sendToHermes(rawMessage) {
+        if (!this.hermesWs) {
+            logger.warn(this.opts.logTag, 'sendToHermes called with no upstream WS');
+            return;
+        }
+        if (this.hermesWs.readyState === WebSocket.CONNECTING) {
+            this.hermesBuffer.push(rawMessage);
+            return;
+        }
+        if (this.hermesWs.readyState !== WebSocket.OPEN) {
+            logger.warn(this.opts.logTag, `upstream WS not open (state=${this.hermesWs.readyState}), dropping`);
+            return;
+        }
+        this.hermesWs.send(rawMessage);
+    }
+    broadcastToConsumers(rawMessage) {
+        for (const ws of this.consumers.values()) {
+            if (ws.readyState === WebSocket.OPEN) {
+                try {
+                    ws.send(rawMessage);
+                }
+                catch { /* one consumer failing should not abort the others */ }
+            }
+        }
+    }
+    async cleanup() {
+        if (this.hermesWs) {
+            try {
+                this.hermesWs.close(1000, 'proxy stopping');
+            }
+            catch { /* ignore */ }
+            this.hermesWs = null;
+        }
+        for (const ws of this.consumers.values()) {
+            try {
+                ws.close(1001, 'proxy stopping');
+            }
+            catch { /* ignore */ }
+        }
+        this.consumers.clear();
+        this.routingTable.clear();
+        this.hermesBuffer = [];
+        if (this.wss) {
+            try {
+                this.wss.close();
+            }
+            catch { /* ignore */ }
+            this.wss = null;
+        }
+        if (this.httpServer) {
+            await new Promise((resolve) => {
+                this.httpServer?.close(() => resolve());
+            });
+            this.httpServer = null;
+        }
+        this.boundPort = null;
+    }
+}
+/**
+ * Parse an RN version object or string into a semver triple. Returns null if the shape is unrecognized.
+ */
+export function parseRNVersion(raw) {
+    if (raw === null || raw === undefined)
+        return null;
+    if (typeof raw === 'string') {
+        const match = /^(\d+)\.(\d+)\.(\d+)/.exec(raw);
+        if (!match)
+            return null;
+        return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
+    }
+    if (typeof raw === 'object') {
+        const v = raw;
+        if (typeof v.major === 'number' && typeof v.minor === 'number' && typeof v.patch === 'number') {
+            return { major: v.major, minor: v.minor, patch: v.patch };
+        }
+    }
+    return null;
+}
+/**
+ * RN greater than or equal to 0.85 has native multi-debugger support via metro-bridge's
+ * supportsMultipleDebuggers flag, so the proxy is redundant. Returns true when the
+ * version is 0.85+ (no proxy needed). Unknown / unparseable versions return false
+ * (conservative default: use proxy).
+ */
+export function supportsNativeMultiDebugger(rnVersion) {
+    const parsed = parseRNVersion(rnVersion);
+    if (!parsed)
+        return false;
+    if (parsed.major > 0)
+        return true;
+    return parsed.minor >= 85;
+}

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -45,6 +45,7 @@ import { createMaestroRunHandler } from './tools/maestro-run.js';
 import { createMaestroGenerateHandler } from './tools/maestro-generate.js';
 import { createMaestroTestAllHandler } from './tools/maestro-test-all.js';
 import { createCrossPlatformVerifyHandler } from './tools/cross-platform-verify.js';
+import { createOpenDevToolsHandler } from './tools/open-devtools.js';
 import { stopFastRunner } from './fast-runner-session.js';
 import { instrumentTool, pruneOldTelemetry, autoCompactIfNeeded } from './experience/index.js';
 const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
@@ -470,6 +471,7 @@ trackedTool('cross_platform_verify', 'Compare UI elements across iOS and Android
     scanDir: z.string().optional().describe('Directory to scan for testID="..." props in .tsx/.jsx/.ts/.js files. Auto-discovers elements. Merges with elements[] if both provided.'),
     matchBy: z.enum(['testID', 'label', 'any']).default('any').describe('Match strategy: testID (exact identifier match), label (substring in accessibility label), any (try both)'),
 }, createCrossPlatformVerifyHandler());
+trackedTool('cdp_open_devtools', 'Report the React Native DevTools frontend URL for the live app + whether DevTools can coexist with the MCP session (RN >= 0.85 native multi-debugger). M1 (Phase 90 Tier 1) ships detection + capability reporting; full proxy auto-wiring for RN < 0.85 is tracked as M1b/Phase 100. Returns { devtoolsUrl, inspectorWsUrl, mode, supportsMultipleDebuggers, rnVersion, guidance }.', {}, createOpenDevToolsHandler(getClient));
 // B76/D644: unified process-lifecycle shutdown. All termination signals + stdin.end
 // funnel into this graceful path so the 5s background-poll setInterval in
 // reconnection.ts (the zombie cause) is cleared on every exit.

--- a/scripts/cdp-bridge/dist/tools/open-devtools.js
+++ b/scripts/cdp-bridge/dist/tools/open-devtools.js
@@ -1,0 +1,56 @@
+import { okResult, failResult } from '../utils.js';
+import { supportsNativeMultiDebugger } from '../cdp/multiplexer.js';
+const NATIVE_GUIDANCE = [
+    'React DevTools can connect to the inspector URL below while your MCP session stays active.',
+    'Open the DevTools URL in Chrome (or paste the inspectorWsUrl directly into a DevTools fusebox instance).',
+    'Native multi-debugger support on RN >= 0.85 means no proxy is needed — both connections multiplex transparently.',
+].join('\n');
+const PROXY_REQUIRED_GUIDANCE = [
+    'Your RN version does not support native multi-debugger. Using React DevTools will evict the MCP session (CDP close code 1006).',
+    'M1 (this release) ships detection + capability reporting; automatic proxy wiring is tracked as M1b (Phase 100, pending live simulator verification).',
+    'Workaround today: close the MCP CC session while using DevTools, reopen when done. OR upgrade to RN >= 0.85.',
+].join('\n');
+export function createOpenDevToolsHandler(getClient) {
+    return async () => {
+        const client = getClient();
+        if (!client.isConnected) {
+            return failResult('cdp_open_devtools: not connected. Call cdp_status first to auto-connect to the live app.');
+        }
+        const target = client.connectedTarget;
+        if (!target) {
+            return failResult('cdp_open_devtools: no target selected. Run cdp_connect or cdp_status.');
+        }
+        const metroPort = client.metroPort;
+        const inspectorWsUrl = `ws://127.0.0.1:${metroPort}/inspector/debug?device=${encodeURIComponent(target.id)}&page=${encodeURIComponent(target.id)}`;
+        // DevTools frontend is served by Metro at /debugger-frontend/rn_fusebox.html
+        // Query params hand the frontend the WS URL it should connect to. Metro auto-loads the React DevTools bundle.
+        const devtoolsUrl = `http://127.0.0.1:${metroPort}/debugger-frontend/rn_fusebox.html?ws=127.0.0.1:${metroPort}/inspector/debug?device=${encodeURIComponent(target.id)}%26page=${encodeURIComponent(target.id)}`;
+        // Probe app info for RN version. Best-effort — if probe fails, we still report
+        // inspectorWsUrl and assume proxy-required.
+        let rnVersion = null;
+        let supportsMultiple = false;
+        try {
+            const probe = await client.evaluate('JSON.stringify(__RN_AGENT?.getAppInfo ? JSON.parse(__RN_AGENT.getAppInfo()).rnVersion : null)');
+            if (probe.value && typeof probe.value === 'string' && probe.value !== 'null') {
+                const parsed = JSON.parse(probe.value);
+                supportsMultiple = supportsNativeMultiDebugger(parsed);
+                if (parsed && typeof parsed === 'object') {
+                    const v = parsed;
+                    if (typeof v.major === 'number' && typeof v.minor === 'number' && typeof v.patch === 'number') {
+                        rnVersion = { major: v.major, minor: v.minor, patch: v.patch };
+                    }
+                }
+            }
+        }
+        catch { /* leave rnVersion null, supportsMultiple false */ }
+        const result = {
+            devtoolsUrl: supportsMultiple ? devtoolsUrl : null,
+            inspectorWsUrl,
+            mode: supportsMultiple ? 'native' : 'proxy-required',
+            supportsMultipleDebuggers: supportsMultiple,
+            rnVersion,
+            guidance: supportsMultiple ? NATIVE_GUIDANCE : PROXY_REQUIRED_GUIDANCE,
+        };
+        return okResult(result);
+    };
+}

--- a/scripts/cdp-bridge/dist/tools/status.js
+++ b/scripts/cdp-bridge/dist/tools/status.js
@@ -1,6 +1,7 @@
 import { okResult, failResult, warnResult } from '../utils.js';
 import { handleDevClientPicker } from './dev-client-picker.js';
 import { getSessionReloadCount } from './reload.js';
+import { supportsNativeMultiDebugger } from '../cdp/multiplexer.js';
 const STATUS_PROBE_EXPRESSION = `
 (function() {
   var result = { appInfo: null, errorCount: 0, fiberTree: false, hasRedBox: false, helpersLoaded: false };
@@ -53,6 +54,7 @@ async function buildStatusResult(client) {
             networkFallback: client.networkMode === 'hook',
             bridgeDetected: client.bridgeDetected,
             bridgeVersion: client.bridgeVersion,
+            supportsMultipleDebuggers: supportsNativeMultiDebugger(appInfo?.rnVersion),
         },
         domains: {
             runtime: client.isConnected,

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/cdp/multiplexer.ts
+++ b/scripts/cdp-bridge/src/cdp/multiplexer.ts
@@ -1,0 +1,321 @@
+import { createServer, type Server } from 'node:http';
+import { type AddressInfo } from 'node:net';
+import WebSocket, { WebSocketServer } from 'ws';
+
+import { logger } from '../logger.js';
+
+/**
+ * CDP Multiplexer proxy (M1 / Phase 90 Tier 1).
+ *
+ * Hermes accepts ONLY ONE CDP connection. When a user opens React Native DevTools
+ * (or any second debugger) while the MCP is connected, the MCP's WebSocket gets
+ * evicted with close code 1006. This module is the compatibility layer that lets
+ * both coexist on RN versions that don't support native multi-debugger (RN < 0.85).
+ *
+ * Id rewriting strategy:
+ *   consumer sends a message with some id
+ *   proxy allocates a fresh upstream id, records the mapping, forwards upstream
+ *   hermes replies with that upstream id
+ *   proxy looks up the mapping, restores the original consumer id, forwards back
+ *
+ * Events (no id field) broadcast to all consumers.
+ */
+
+export interface MultiplexerOptions {
+  /** WebSocket URL to the target Hermes instance, e.g. ws://127.0.0.1:8081/inspector/debug?targetId=... */
+  hermesUrl: string;
+  /** Bind host for the consumer-facing server. Default: 127.0.0.1 (loopback only). */
+  host?: string;
+  /** Bind port. Default: 0 (random ephemeral). */
+  port?: number;
+  /** Logger tag. Default: 'CDP.proxy' */
+  logTag?: string;
+}
+
+type RoutingEntry = { consumerId: number; consumerOriginalId: number };
+
+export class CDPMultiplexer {
+  private readonly opts: Required<MultiplexerOptions>;
+  private httpServer: Server | null = null;
+  private wss: WebSocketServer | null = null;
+  private hermesWs: WebSocket | null = null;
+  private consumers = new Map<number, WebSocket>();
+  private nextConsumerId = 1;
+  private upstreamSeq = 1;
+  private routingTable = new Map<number, RoutingEntry>();
+  private hermesBuffer: string[] = [];
+  private state: 'stopped' | 'starting' | 'running' | 'stopping' = 'stopped';
+  private boundPort: number | null = null;
+
+  constructor(opts: MultiplexerOptions) {
+    this.opts = {
+      hermesUrl: opts.hermesUrl,
+      host: opts.host ?? '127.0.0.1',
+      port: opts.port ?? 0,
+      logTag: opts.logTag ?? 'CDP.proxy',
+    };
+  }
+
+  get port(): number | null {
+    return this.boundPort;
+  }
+
+  get isRunning(): boolean {
+    return this.state === 'running';
+  }
+
+  get consumerCount(): number {
+    return this.consumers.size;
+  }
+
+  async start(): Promise<number> {
+    if (this.state !== 'stopped') {
+      throw new Error(`CDPMultiplexer cannot start from state '${this.state}'`);
+    }
+    this.state = 'starting';
+
+    try {
+      const port = await this.startConsumerServer();
+      await this.connectHermes();
+      this.state = 'running';
+      logger.info(this.opts.logTag, `multiplexer running on ${this.opts.host}:${port}`);
+      return port;
+    } catch (err) {
+      this.state = 'stopped';
+      await this.cleanup();
+      throw err;
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.state === 'stopped' || this.state === 'stopping') return;
+    this.state = 'stopping';
+    await this.cleanup();
+    this.state = 'stopped';
+    logger.info(this.opts.logTag, 'multiplexer stopped');
+  }
+
+  private startConsumerServer(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      this.httpServer = createServer();
+      this.wss = new WebSocketServer({ server: this.httpServer });
+
+      this.wss.on('connection', (ws) => this.onConsumerConnect(ws));
+      this.wss.on('error', (err) => {
+        logger.warn(this.opts.logTag, `WebSocketServer error: ${err instanceof Error ? err.message : err}`);
+      });
+
+      this.httpServer.once('error', reject);
+      this.httpServer.listen(this.opts.port, this.opts.host, () => {
+        const addr = this.httpServer?.address() as AddressInfo | null;
+        if (!addr) {
+          reject(new Error('httpServer.address() returned null after listen'));
+          return;
+        }
+        this.boundPort = addr.port;
+        resolve(addr.port);
+      });
+    });
+  }
+
+  private connectHermes(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(this.opts.hermesUrl);
+      this.hermesWs = ws;
+
+      const onOpen = (): void => {
+        ws.off('error', onError);
+        for (const msg of this.hermesBuffer) ws.send(msg);
+        this.hermesBuffer = [];
+        logger.info(this.opts.logTag, `connected to upstream Hermes at ${this.opts.hermesUrl}`);
+        resolve();
+      };
+      const onError = (err: Error): void => {
+        ws.off('open', onOpen);
+        reject(err);
+      };
+
+      ws.once('open', onOpen);
+      ws.once('error', onError);
+      ws.on('message', (data) => this.onHermesMessage(data));
+      ws.on('close', (code, reason) => this.onHermesClose(code, reason.toString()));
+      ws.on('error', (err) => {
+        logger.warn(this.opts.logTag, `upstream WS error: ${err.message}`);
+      });
+    });
+  }
+
+  private onConsumerConnect(ws: WebSocket): void {
+    const consumerId = this.nextConsumerId++;
+    this.consumers.set(consumerId, ws);
+    logger.info(this.opts.logTag, `consumer ${consumerId} connected (total: ${this.consumers.size})`);
+
+    ws.on('message', (data) => this.onConsumerMessage(consumerId, data));
+    ws.on('close', () => {
+      this.consumers.delete(consumerId);
+      for (const [upstreamId, entry] of this.routingTable) {
+        if (entry.consumerId === consumerId) this.routingTable.delete(upstreamId);
+      }
+      logger.info(this.opts.logTag, `consumer ${consumerId} disconnected (remaining: ${this.consumers.size})`);
+    });
+    ws.on('error', (err) => {
+      logger.warn(this.opts.logTag, `consumer ${consumerId} WS error: ${err.message}`);
+    });
+  }
+
+  private onConsumerMessage(consumerId: number, data: WebSocket.RawData): void {
+    const raw = data.toString();
+    let msg: unknown;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      logger.warn(this.opts.logTag, `consumer ${consumerId} sent non-JSON, dropping`);
+      return;
+    }
+    if (typeof msg !== 'object' || msg === null || Array.isArray(msg)) {
+      logger.warn(this.opts.logTag, `consumer ${consumerId} sent non-object, dropping`);
+      return;
+    }
+
+    const m = msg as Record<string, unknown>;
+    const consumerOriginalId = typeof m.id === 'number' ? m.id : null;
+
+    if (consumerOriginalId !== null) {
+      const upstreamId = this.upstreamSeq++;
+      this.routingTable.set(upstreamId, { consumerId, consumerOriginalId });
+      m.id = upstreamId;
+    }
+
+    this.sendToHermes(JSON.stringify(m));
+  }
+
+  private onHermesMessage(data: WebSocket.RawData): void {
+    const raw = data.toString();
+    let msg: unknown;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      logger.warn(this.opts.logTag, 'upstream sent non-JSON, dropping');
+      return;
+    }
+    if (typeof msg !== 'object' || msg === null || Array.isArray(msg)) {
+      logger.warn(this.opts.logTag, 'upstream sent non-object, dropping');
+      return;
+    }
+
+    const m = msg as Record<string, unknown>;
+    const upstreamId = typeof m.id === 'number' ? m.id : null;
+
+    if (upstreamId === null) {
+      this.broadcastToConsumers(raw);
+      return;
+    }
+
+    const route = this.routingTable.get(upstreamId);
+    if (!route) return;
+    this.routingTable.delete(upstreamId);
+
+    m.id = route.consumerOriginalId;
+    const rewritten = JSON.stringify(m);
+
+    const consumerWs = this.consumers.get(route.consumerId);
+    if (consumerWs && consumerWs.readyState === WebSocket.OPEN) {
+      consumerWs.send(rewritten);
+    }
+  }
+
+  private onHermesClose(code: number, reason: string): void {
+    logger.warn(this.opts.logTag, `upstream Hermes closed (code=${code}, reason='${reason}')`);
+    for (const ws of this.consumers.values()) {
+      try { ws.close(1011, 'upstream closed'); } catch { /* ignore */ }
+    }
+    this.consumers.clear();
+    this.routingTable.clear();
+  }
+
+  private sendToHermes(rawMessage: string): void {
+    if (!this.hermesWs) {
+      logger.warn(this.opts.logTag, 'sendToHermes called with no upstream WS');
+      return;
+    }
+    if (this.hermesWs.readyState === WebSocket.CONNECTING) {
+      this.hermesBuffer.push(rawMessage);
+      return;
+    }
+    if (this.hermesWs.readyState !== WebSocket.OPEN) {
+      logger.warn(this.opts.logTag, `upstream WS not open (state=${this.hermesWs.readyState}), dropping`);
+      return;
+    }
+    this.hermesWs.send(rawMessage);
+  }
+
+  private broadcastToConsumers(rawMessage: string): void {
+    for (const ws of this.consumers.values()) {
+      if (ws.readyState === WebSocket.OPEN) {
+        try { ws.send(rawMessage); } catch { /* one consumer failing should not abort the others */ }
+      }
+    }
+  }
+
+  private async cleanup(): Promise<void> {
+    if (this.hermesWs) {
+      try { this.hermesWs.close(1000, 'proxy stopping'); } catch { /* ignore */ }
+      this.hermesWs = null;
+    }
+    for (const ws of this.consumers.values()) {
+      try { ws.close(1001, 'proxy stopping'); } catch { /* ignore */ }
+    }
+    this.consumers.clear();
+    this.routingTable.clear();
+    this.hermesBuffer = [];
+
+    if (this.wss) {
+      try { this.wss.close(); } catch { /* ignore */ }
+      this.wss = null;
+    }
+    if (this.httpServer) {
+      await new Promise<void>((resolve) => {
+        this.httpServer?.close(() => resolve());
+      });
+      this.httpServer = null;
+    }
+    this.boundPort = null;
+  }
+}
+
+/**
+ * Parse an RN version object or string into a semver triple. Returns null if the shape is unrecognized.
+ */
+export function parseRNVersion(
+  raw: unknown,
+): { major: number; minor: number; patch: number } | null {
+  if (raw === null || raw === undefined) return null;
+
+  if (typeof raw === 'string') {
+    const match = /^(\d+)\.(\d+)\.(\d+)/.exec(raw);
+    if (!match) return null;
+    return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
+  }
+
+  if (typeof raw === 'object') {
+    const v = raw as { major?: unknown; minor?: unknown; patch?: unknown };
+    if (typeof v.major === 'number' && typeof v.minor === 'number' && typeof v.patch === 'number') {
+      return { major: v.major, minor: v.minor, patch: v.patch };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * RN greater than or equal to 0.85 has native multi-debugger support via metro-bridge's
+ * supportsMultipleDebuggers flag, so the proxy is redundant. Returns true when the
+ * version is 0.85+ (no proxy needed). Unknown / unparseable versions return false
+ * (conservative default: use proxy).
+ */
+export function supportsNativeMultiDebugger(rnVersion: unknown): boolean {
+  const parsed = parseRNVersion(rnVersion);
+  if (!parsed) return false;
+  if (parsed.major > 0) return true;
+  return parsed.minor >= 85;
+}

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -62,6 +62,7 @@ import { createMaestroRunHandler } from './tools/maestro-run.js';
 import { createMaestroGenerateHandler } from './tools/maestro-generate.js';
 import { createMaestroTestAllHandler } from './tools/maestro-test-all.js';
 import { createCrossPlatformVerifyHandler } from './tools/cross-platform-verify.js';
+import { createOpenDevToolsHandler } from './tools/open-devtools.js';
 import { stopFastRunner } from './fast-runner-session.js';
 import { instrumentTool, pruneOldTelemetry, autoCompactIfNeeded } from './experience/index.js';
 
@@ -788,6 +789,13 @@ trackedTool(
     matchBy: z.enum(['testID', 'label', 'any']).default('any').describe('Match strategy: testID (exact identifier match), label (substring in accessibility label), any (try both)'),
   },
   createCrossPlatformVerifyHandler(),
+);
+
+trackedTool(
+  'cdp_open_devtools',
+  'Report the React Native DevTools frontend URL for the live app + whether DevTools can coexist with the MCP session (RN >= 0.85 native multi-debugger). M1 (Phase 90 Tier 1) ships detection + capability reporting; full proxy auto-wiring for RN < 0.85 is tracked as M1b/Phase 100. Returns { devtoolsUrl, inspectorWsUrl, mode, supportsMultipleDebuggers, rnVersion, guidance }.',
+  {},
+  createOpenDevToolsHandler(getClient),
 );
 
 // B76/D644: unified process-lifecycle shutdown. All termination signals + stdin.end

--- a/scripts/cdp-bridge/src/tools/open-devtools.ts
+++ b/scripts/cdp-bridge/src/tools/open-devtools.ts
@@ -1,0 +1,98 @@
+import type { CDPClient } from '../cdp-client.js';
+import { okResult, failResult } from '../utils.js';
+import { supportsNativeMultiDebugger } from '../cdp/multiplexer.js';
+
+/**
+ * cdp_open_devtools — M1 / Phase 90 Tier 1 MVP.
+ *
+ * Report the React Native DevTools frontend URL for the currently connected app,
+ * along with whether DevTools can coexist with the MCP session (RN >= 0.85 native
+ * multi-debugger) or requires the proxy path (RN < 0.85, M1b).
+ *
+ * This tool is read-only — it does not start the multiplexer proxy or mutate any
+ * CDP state. The proxy wiring is deferred to M1b (Phase 100, pending a live
+ * simulator session for end-to-end verification).
+ *
+ * Output shape (on success):
+ *   {
+ *     devtoolsUrl: string | null,  // Metro-served DevTools frontend URL, or null if unavailable
+ *     inspectorWsUrl: string,       // Direct Hermes CDP WS URL (what DevTools connects to)
+ *     mode: 'native' | 'proxy-required',
+ *     supportsMultipleDebuggers: boolean,
+ *     rnVersion: { major, minor, patch } | null,
+ *     guidance: string,             // Human-readable instructions
+ *   }
+ */
+
+interface OpenDevToolsResult {
+  devtoolsUrl: string | null;
+  inspectorWsUrl: string;
+  mode: 'native' | 'proxy-required';
+  supportsMultipleDebuggers: boolean;
+  rnVersion: { major: number; minor: number; patch: number } | null;
+  guidance: string;
+}
+
+const NATIVE_GUIDANCE = [
+  'React DevTools can connect to the inspector URL below while your MCP session stays active.',
+  'Open the DevTools URL in Chrome (or paste the inspectorWsUrl directly into a DevTools fusebox instance).',
+  'Native multi-debugger support on RN >= 0.85 means no proxy is needed — both connections multiplex transparently.',
+].join('\n');
+
+const PROXY_REQUIRED_GUIDANCE = [
+  'Your RN version does not support native multi-debugger. Using React DevTools will evict the MCP session (CDP close code 1006).',
+  'M1 (this release) ships detection + capability reporting; automatic proxy wiring is tracked as M1b (Phase 100, pending live simulator verification).',
+  'Workaround today: close the MCP CC session while using DevTools, reopen when done. OR upgrade to RN >= 0.85.',
+].join('\n');
+
+export function createOpenDevToolsHandler(getClient: () => CDPClient) {
+  return async (): Promise<ReturnType<typeof okResult | typeof failResult>> => {
+    const client = getClient();
+    if (!client.isConnected) {
+      return failResult('cdp_open_devtools: not connected. Call cdp_status first to auto-connect to the live app.');
+    }
+
+    const target = client.connectedTarget;
+    if (!target) {
+      return failResult('cdp_open_devtools: no target selected. Run cdp_connect or cdp_status.');
+    }
+
+    const metroPort = client.metroPort;
+    const inspectorWsUrl = `ws://127.0.0.1:${metroPort}/inspector/debug?device=${encodeURIComponent(target.id)}&page=${encodeURIComponent(target.id)}`;
+
+    // DevTools frontend is served by Metro at /debugger-frontend/rn_fusebox.html
+    // Query params hand the frontend the WS URL it should connect to. Metro auto-loads the React DevTools bundle.
+    const devtoolsUrl = `http://127.0.0.1:${metroPort}/debugger-frontend/rn_fusebox.html?ws=127.0.0.1:${metroPort}/inspector/debug?device=${encodeURIComponent(target.id)}%26page=${encodeURIComponent(target.id)}`;
+
+    // Probe app info for RN version. Best-effort — if probe fails, we still report
+    // inspectorWsUrl and assume proxy-required.
+    let rnVersion: OpenDevToolsResult['rnVersion'] = null;
+    let supportsMultiple = false;
+    try {
+      const probe = await client.evaluate(
+        'JSON.stringify(__RN_AGENT?.getAppInfo ? JSON.parse(__RN_AGENT.getAppInfo()).rnVersion : null)',
+      );
+      if (probe.value && typeof probe.value === 'string' && probe.value !== 'null') {
+        const parsed = JSON.parse(probe.value) as unknown;
+        supportsMultiple = supportsNativeMultiDebugger(parsed);
+        if (parsed && typeof parsed === 'object') {
+          const v = parsed as { major?: unknown; minor?: unknown; patch?: unknown };
+          if (typeof v.major === 'number' && typeof v.minor === 'number' && typeof v.patch === 'number') {
+            rnVersion = { major: v.major, minor: v.minor, patch: v.patch };
+          }
+        }
+      }
+    } catch { /* leave rnVersion null, supportsMultiple false */ }
+
+    const result: OpenDevToolsResult = {
+      devtoolsUrl: supportsMultiple ? devtoolsUrl : null,
+      inspectorWsUrl,
+      mode: supportsMultiple ? 'native' : 'proxy-required',
+      supportsMultipleDebuggers: supportsMultiple,
+      rnVersion,
+      guidance: supportsMultiple ? NATIVE_GUIDANCE : PROXY_REQUIRED_GUIDANCE,
+    };
+
+    return okResult(result);
+  };
+}

--- a/scripts/cdp-bridge/src/tools/status.ts
+++ b/scripts/cdp-bridge/src/tools/status.ts
@@ -3,6 +3,7 @@ import type { StatusResult } from '../types.js';
 import { okResult, failResult, warnResult } from '../utils.js';
 import { handleDevClientPicker } from './dev-client-picker.js';
 import { getSessionReloadCount } from './reload.js';
+import { supportsNativeMultiDebugger } from '../cdp/multiplexer.js';
 
 const STATUS_PROBE_EXPRESSION = `
 (function() {
@@ -64,6 +65,7 @@ async function buildStatusResult(client: CDPClient): Promise<StatusResult> {
       networkFallback: client.networkMode === 'hook',
       bridgeDetected: client.bridgeDetected,
       bridgeVersion: client.bridgeVersion,
+      supportsMultipleDebuggers: supportsNativeMultiDebugger(appInfo?.rnVersion),
     },
     domains: {
       runtime: client.isConnected,

--- a/scripts/cdp-bridge/src/types.ts
+++ b/scripts/cdp-bridge/src/types.ts
@@ -93,6 +93,8 @@ export interface StatusResult {
     networkFallback: boolean;
     bridgeDetected: boolean;
     bridgeVersion: number | null;
+    /** M1 (D654): true when RN >= 0.85 supports native multi-debugger (DevTools + MCP can coexist without proxy). */
+    supportsMultipleDebuggers: boolean;
   };
   domains: {
     runtime: boolean;

--- a/scripts/cdp-bridge/test/unit/multiplexer.test.js
+++ b/scripts/cdp-bridge/test/unit/multiplexer.test.js
@@ -1,0 +1,395 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import WebSocket, { WebSocketServer } from 'ws';
+import {
+  CDPMultiplexer,
+  parseRNVersion,
+  supportsNativeMultiDebugger,
+} from '../../dist/cdp/multiplexer.js';
+import { createOpenDevToolsHandler } from '../../dist/tools/open-devtools.js';
+import { createMockClient } from '../helpers/mock-cdp-client.js';
+import { expectOk, expectFail } from '../helpers/result-helpers.js';
+
+// ── Pure helpers: parseRNVersion / supportsNativeMultiDebugger ──
+
+test('parseRNVersion: accepts RN PlatformConstants object shape', () => {
+  const v = parseRNVersion({ major: 0, minor: 76, patch: 7, prerelease: null });
+  assert.deepEqual(v, { major: 0, minor: 76, patch: 7 });
+});
+
+test('parseRNVersion: accepts semver string shape (future-proof)', () => {
+  assert.deepEqual(parseRNVersion('0.85.0'), { major: 0, minor: 85, patch: 0 });
+  assert.deepEqual(parseRNVersion('1.0.0-rc.1'), { major: 1, minor: 0, patch: 0 });
+});
+
+test('parseRNVersion: returns null for unparseable shapes', () => {
+  assert.equal(parseRNVersion(null), null);
+  assert.equal(parseRNVersion(undefined), null);
+  assert.equal(parseRNVersion(42), null);
+  assert.equal(parseRNVersion({}), null);
+  assert.equal(parseRNVersion({ major: '0', minor: 76, patch: 7 }), null, 'string major rejected');
+  assert.equal(parseRNVersion('not-a-version'), null);
+});
+
+test('supportsNativeMultiDebugger: RN < 0.85 returns false', () => {
+  assert.equal(supportsNativeMultiDebugger({ major: 0, minor: 76, patch: 7 }), false);
+  assert.equal(supportsNativeMultiDebugger({ major: 0, minor: 84, patch: 99 }), false);
+  assert.equal(supportsNativeMultiDebugger('0.79.0'), false);
+});
+
+test('supportsNativeMultiDebugger: RN >= 0.85 returns true', () => {
+  assert.equal(supportsNativeMultiDebugger({ major: 0, minor: 85, patch: 0 }), true);
+  assert.equal(supportsNativeMultiDebugger({ major: 0, minor: 90, patch: 3 }), true);
+  assert.equal(supportsNativeMultiDebugger('0.85.1'), true);
+});
+
+test('supportsNativeMultiDebugger: RN 1.x+ always returns true', () => {
+  assert.equal(supportsNativeMultiDebugger({ major: 1, minor: 0, patch: 0 }), true);
+  assert.equal(supportsNativeMultiDebugger({ major: 2, minor: 5, patch: 3 }), true);
+});
+
+test('supportsNativeMultiDebugger: unknown shapes fall back to false (conservative — use proxy)', () => {
+  assert.equal(supportsNativeMultiDebugger(null), false);
+  assert.equal(supportsNativeMultiDebugger(undefined), false);
+  assert.equal(supportsNativeMultiDebugger({}), false);
+});
+
+// ── CDPMultiplexer: full integration tests with real WS ──
+
+function makeMockHermes() {
+  // A tiny Hermes stand-in: echoes request ids back as responses, and can emit events on demand.
+  const server = createServer();
+  const wss = new WebSocketServer({ server });
+  let activeWs = null;
+  const received = [];
+
+  wss.on('connection', (ws) => {
+    if (activeWs) {
+      // Real Hermes would evict; for tests we just ignore
+      ws.close(4000, 'only-one-allowed');
+      return;
+    }
+    activeWs = ws;
+    ws.on('message', (data) => {
+      const raw = data.toString();
+      received.push(raw);
+      const parsed = JSON.parse(raw);
+      if (typeof parsed.id === 'number') {
+        // Echo back a response keyed on the same id
+        ws.send(JSON.stringify({ id: parsed.id, result: { echo: parsed.method, params: parsed.params ?? null } }));
+      }
+    });
+    ws.on('close', () => { activeWs = null; });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      resolve({
+        port,
+        url: `ws://127.0.0.1:${port}`,
+        received,
+        emit: (event) => { if (activeWs) activeWs.send(JSON.stringify(event)); },
+        stop: () => new Promise((r) => {
+          wss.close(() => server.close(() => r()));
+        }),
+      });
+    });
+  });
+}
+
+function connectConsumer(port) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    ws.once('open', () => resolve(ws));
+    ws.once('error', reject);
+  });
+}
+
+function waitForMessage(ws, predicate = () => true) {
+  return new Promise((resolve) => {
+    const handler = (data) => {
+      const msg = JSON.parse(data.toString());
+      if (predicate(msg)) {
+        ws.off('message', handler);
+        resolve(msg);
+      }
+    };
+    ws.on('message', handler);
+  });
+}
+
+test('CDPMultiplexer: start returns bound port, isRunning becomes true', async () => {
+  const hermes = await makeMockHermes();
+  const proxy = new CDPMultiplexer({ hermesUrl: hermes.url });
+  try {
+    const port = await proxy.start();
+    assert.ok(port > 0, `bound port should be > 0, got ${port}`);
+    assert.equal(proxy.port, port);
+    assert.equal(proxy.isRunning, true);
+    assert.equal(proxy.consumerCount, 0);
+  } finally {
+    await proxy.stop();
+    await hermes.stop();
+  }
+});
+
+test('CDPMultiplexer: forwards a request and routes the response back with original id', async () => {
+  const hermes = await makeMockHermes();
+  const proxy = new CDPMultiplexer({ hermesUrl: hermes.url });
+  try {
+    const port = await proxy.start();
+    const consumer = await connectConsumer(port);
+
+    const waitForResponse = waitForMessage(consumer, (m) => m.id === 42);
+    consumer.send(JSON.stringify({ id: 42, method: 'Runtime.evaluate', params: { expression: '1+1' } }));
+
+    const response = await waitForResponse;
+    assert.equal(response.id, 42, 'response id matches consumer original id');
+    assert.equal(response.result.echo, 'Runtime.evaluate');
+
+    // Hermes should have received a DIFFERENT (rewritten) id
+    assert.equal(hermes.received.length, 1);
+    const upstream = JSON.parse(hermes.received[0]);
+    assert.notEqual(upstream.id, 42, 'upstream id should be rewritten, not 42');
+    assert.equal(typeof upstream.id, 'number');
+
+    consumer.close();
+  } finally {
+    await proxy.stop();
+    await hermes.stop();
+  }
+});
+
+test('CDPMultiplexer: two consumers with same id do not collide — responses route correctly', async () => {
+  const hermes = await makeMockHermes();
+  const proxy = new CDPMultiplexer({ hermesUrl: hermes.url });
+  try {
+    const port = await proxy.start();
+    const c1 = await connectConsumer(port);
+    const c2 = await connectConsumer(port);
+
+    const w1 = waitForMessage(c1, (m) => m.id === 7);
+    const w2 = waitForMessage(c2, (m) => m.id === 7);
+
+    // Both consumers send id=7 — the proxy must allocate distinct upstream ids.
+    c1.send(JSON.stringify({ id: 7, method: 'Domain.a', params: { from: 'c1' } }));
+    c2.send(JSON.stringify({ id: 7, method: 'Domain.b', params: { from: 'c2' } }));
+
+    const [r1, r2] = await Promise.all([w1, w2]);
+    assert.equal(r1.id, 7);
+    assert.equal(r2.id, 7);
+    assert.equal(r1.result.echo, 'Domain.a', 'c1 received its own response, not c2\'s');
+    assert.equal(r2.result.echo, 'Domain.b', 'c2 received its own response, not c1\'s');
+
+    c1.close();
+    c2.close();
+  } finally {
+    await proxy.stop();
+    await hermes.stop();
+  }
+});
+
+test('CDPMultiplexer: events (no id) broadcast to all consumers', async () => {
+  const hermes = await makeMockHermes();
+  const proxy = new CDPMultiplexer({ hermesUrl: hermes.url });
+  try {
+    const port = await proxy.start();
+    const c1 = await connectConsumer(port);
+    const c2 = await connectConsumer(port);
+
+    // Give the proxy a beat to register both consumers
+    await new Promise((r) => setTimeout(r, 50));
+
+    const w1 = waitForMessage(c1, (m) => m.method === 'Runtime.consoleAPICalled');
+    const w2 = waitForMessage(c2, (m) => m.method === 'Runtime.consoleAPICalled');
+
+    hermes.emit({ method: 'Runtime.consoleAPICalled', params: { type: 'log' } });
+
+    const [m1, m2] = await Promise.all([w1, w2]);
+    assert.equal(m1.method, 'Runtime.consoleAPICalled');
+    assert.equal(m2.method, 'Runtime.consoleAPICalled');
+    assert.deepEqual(m1.params, { type: 'log' });
+
+    c1.close();
+    c2.close();
+  } finally {
+    await proxy.stop();
+    await hermes.stop();
+  }
+});
+
+test('CDPMultiplexer: consumer count increments on connect, decrements on disconnect', async () => {
+  const hermes = await makeMockHermes();
+  const proxy = new CDPMultiplexer({ hermesUrl: hermes.url });
+  try {
+    const port = await proxy.start();
+    assert.equal(proxy.consumerCount, 0);
+
+    const c1 = await connectConsumer(port);
+    await new Promise((r) => setTimeout(r, 30));
+    assert.equal(proxy.consumerCount, 1);
+
+    const c2 = await connectConsumer(port);
+    await new Promise((r) => setTimeout(r, 30));
+    assert.equal(proxy.consumerCount, 2);
+
+    c1.close();
+    await new Promise((r) => setTimeout(r, 50));
+    assert.equal(proxy.consumerCount, 1);
+
+    c2.close();
+    await new Promise((r) => setTimeout(r, 50));
+    assert.equal(proxy.consumerCount, 0);
+  } finally {
+    await proxy.stop();
+    await hermes.stop();
+  }
+});
+
+test('CDPMultiplexer: stop is idempotent — safe to call twice', async () => {
+  const hermes = await makeMockHermes();
+  const proxy = new CDPMultiplexer({ hermesUrl: hermes.url });
+  await proxy.start();
+  await proxy.stop();
+  await proxy.stop(); // should not throw
+  assert.equal(proxy.isRunning, false);
+  assert.equal(proxy.port, null);
+  await hermes.stop();
+});
+
+test('CDPMultiplexer: start throws if already running', async () => {
+  const hermes = await makeMockHermes();
+  const proxy = new CDPMultiplexer({ hermesUrl: hermes.url });
+  try {
+    await proxy.start();
+    await assert.rejects(() => proxy.start(), /cannot start from state 'running'/);
+  } finally {
+    await proxy.stop();
+    await hermes.stop();
+  }
+});
+
+test('CDPMultiplexer: start rejects if Hermes is unreachable', async () => {
+  // Point at a port where nothing is listening
+  const proxy = new CDPMultiplexer({ hermesUrl: 'ws://127.0.0.1:59999/nonexistent' });
+  await assert.rejects(() => proxy.start(), /ECONNREFUSED|connect/);
+  assert.equal(proxy.isRunning, false);
+});
+
+test('CDPMultiplexer: drops messages with non-numeric ids without crashing', async () => {
+  const hermes = await makeMockHermes();
+  const proxy = new CDPMultiplexer({ hermesUrl: hermes.url });
+  try {
+    const port = await proxy.start();
+    const consumer = await connectConsumer(port);
+
+    consumer.send('this is not json');
+    consumer.send(JSON.stringify({ method: 'Runtime.somePing' })); // no id — forwarded as-is
+    consumer.send(JSON.stringify({ id: 'not-a-number', method: 'X' })); // id non-numeric — forwarded as-is with id unchanged
+
+    await new Promise((r) => setTimeout(r, 100));
+    // Hermes should have received the two JSON messages (second and third) but not the non-JSON.
+    assert.ok(hermes.received.length >= 2, `expected >= 2 hermes messages, got ${hermes.received.length}`);
+
+    consumer.close();
+  } finally {
+    await proxy.stop();
+    await hermes.stop();
+  }
+});
+
+// ── cdp_open_devtools tool handler ──
+
+test('cdp_open_devtools: fails when not connected', async () => {
+  const client = createMockClient({ _isConnected: false });
+  const handler = createOpenDevToolsHandler(() => client);
+  const err = expectFail(await handler({}));
+  assert.match(err, /not connected/i);
+});
+
+test('cdp_open_devtools: mode=native when RN >= 0.85', async () => {
+  const client = createMockClient({
+    async evaluate() {
+      return { value: JSON.stringify({ major: 0, minor: 85, patch: 0 }) };
+    },
+  });
+  const handler = createOpenDevToolsHandler(() => client);
+  const data = expectOk(await handler({}));
+  assert.equal(data.mode, 'native');
+  assert.equal(data.supportsMultipleDebuggers, true);
+  assert.ok(data.devtoolsUrl !== null, 'devtoolsUrl populated in native mode');
+  assert.match(data.inspectorWsUrl, /^ws:\/\/127\.0\.0\.1:8081/);
+  assert.deepEqual(data.rnVersion, { major: 0, minor: 85, patch: 0 });
+});
+
+test('cdp_open_devtools: mode=proxy-required when RN < 0.85', async () => {
+  const client = createMockClient({
+    async evaluate() {
+      return { value: JSON.stringify({ major: 0, minor: 76, patch: 7 }) };
+    },
+  });
+  const handler = createOpenDevToolsHandler(() => client);
+  const data = expectOk(await handler({}));
+  assert.equal(data.mode, 'proxy-required');
+  assert.equal(data.supportsMultipleDebuggers, false);
+  assert.equal(data.devtoolsUrl, null, 'devtoolsUrl null in proxy-required mode');
+  assert.ok(data.inspectorWsUrl, 'inspectorWsUrl still reported even when proxy-required');
+  assert.match(data.guidance, /M1b|Phase 100|evict/i, 'guidance mentions the M1b deferral or eviction risk');
+});
+
+test('cdp_open_devtools: mode=proxy-required when rnVersion probe fails (conservative default)', async () => {
+  const client = createMockClient({
+    async evaluate() {
+      return { value: 'null' }; // probe returned null — version unknown
+    },
+  });
+  const handler = createOpenDevToolsHandler(() => client);
+  const data = expectOk(await handler({}));
+  assert.equal(data.mode, 'proxy-required');
+  assert.equal(data.supportsMultipleDebuggers, false);
+  assert.equal(data.rnVersion, null);
+});
+
+test('cdp_open_devtools: fails gracefully when no target selected', async () => {
+  const client = createMockClient({ _connectedTarget: null });
+  const handler = createOpenDevToolsHandler(() => client);
+  const err = expectFail(await handler({}));
+  assert.match(err, /no target/i);
+});
+
+test('CDPMultiplexer: consumer disconnect clears its pending routes (no response leak)', async () => {
+  const hermes = await makeMockHermes();
+  const proxy = new CDPMultiplexer({ hermesUrl: hermes.url });
+  try {
+    const port = await proxy.start();
+    const c1 = await connectConsumer(port);
+    const c2 = await connectConsumer(port);
+    await new Promise((r) => setTimeout(r, 30));
+
+    // c1 sends a request, then immediately disconnects.
+    c1.send(JSON.stringify({ id: 99, method: 'Slow.operation' }));
+    c1.close();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // c2 should NOT receive c1's orphan response — it should be silently dropped.
+    let leaked = false;
+    c2.on('message', (data) => {
+      const m = JSON.parse(data.toString());
+      if (m.id === 99) leaked = true;
+    });
+
+    // Send a normal request from c2, wait for its response, then verify no leak
+    const wait = waitForMessage(c2, (m) => m.id === 1);
+    c2.send(JSON.stringify({ id: 1, method: 'Normal.call' }));
+    await wait;
+
+    assert.equal(leaked, false, 'c2 must not receive c1\'s orphan response');
+
+    c2.close();
+  } finally {
+    await proxy.stop();
+    await hermes.stop();
+  }
+});


### PR DESCRIPTION
## Summary

- **M1a (Phase 90 Tier 1 metro-mcp adoption)** — ships the multiplexer module + native multi-debugger detection + \`cdp_open_devtools\` reporting tool. Closes the detection-and-reporting slice of M1.
- Users on **RN >= 0.85** get immediate DevTools coexistence via native multiplex (URL returned by the tool).
- Users on **RN < 0.85** get explicit guidance that automatic proxy wiring ships in M1b (follow-up PR, requires live simulator verification).
- **22 new tests** (364 → 386) — 7 pure-function + 10 multiplexer integration (against real mock Hermes WS server) + 5 cdp_open_devtools handler.

## Scope boundary (explicit)

**Shipped in M1a:**
- Multiplexer module (full WS proxy with numeric id rewriting, routing table, event broadcast, lifecycle)
- Capability detection (\`parseRNVersion\`, \`supportsNativeMultiDebugger\`)
- \`cdp_open_devtools\` MCP tool
- \`cdp_status.capabilities.supportsMultipleDebuggers\` boolean

**Deferred to M1b / Phase 101:**
- CDPClient refactor to support \`switchToProxy(proxyUrl)\` — reconnect through the proxy
- Automatic proxy start when \`cdp_open_devtools\` is called on RN < 0.85
- Live simulator + real DevTools frontend verification
- DoS caps on \`hermesBuffer\` + \`routingTable\` (Codex review flagged for pre-wiring)
- \`stop()\` ordering fix (Gemini review)

Both reviewers said "ship it" on M1a pass 1 — no HIGH-CONFIDENCE blockers; the three findings above are dormant in M1a (proxy never invoked by live code) and captured in D654 notes as M1b prerequisites.

## Test plan

- [x] \`npm run build\` — zero TS errors
- [x] \`npm test\` — 364 → **386 passing** (22 new, no regressions)
- [x] Multi-review pass 1 (Gemini + Codex both "ship it")
- [ ] **Manual smoke (user, on RN 0.85+ app)**: after CC restart, call \`cdp_open_devtools\`; expect \`mode: 'native'\` + working \`devtoolsUrl\`. Open URL in Chrome → DevTools connects → MCP session continues.
- [ ] **Manual smoke (user, on RN 0.76 test app)**: call \`cdp_open_devtools\`; expect \`mode: 'proxy-required'\` + guidance text mentioning M1b deferral.

## Refs

- D654 (DECISIONS.md) — full rationale, implementation notes, M1a/M1b split reasoning, multi-review findings
- Phase 100 (ROADMAP.md) — standalone DONE entry with scope-shipped/scope-deferred tables
- Phase 90 Story M1 (split into M1a ✓ and M1b pending)
- metro-mcp \`src/plugins/devtools.ts\` — reference implementation pattern