### PR TITLE
feat(m4): per-device DeviceBufferManager — Phase 90 Tier 2 (D655)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/scripts/cdp-bridge/dist/cdp-client.js
+++ b/scripts/cdp-bridge/dist/cdp-client.js
@@ -1,5 +1,5 @@
 import WebSocket from 'ws';
-import { RingBuffer } from './ring-buffer.js';
+import { RingBuffer, DeviceBufferManager, makeDeviceKey } from './ring-buffer.js';
 import { detectBridge } from './bridge-detector.js';
 import { logger } from './logger.js';
 import { performSetup, reinjectHelpers as reinjectHelpersFn } from './cdp/setup.js';
@@ -18,7 +18,7 @@ export class CDPClient {
     pending = new Map();
     eventHandlers = new Map();
     _consoleBuffer;
-    _networkBuffer;
+    _networkBufferManager;
     _port;
     reconnecting = false;
     disposed = false;
@@ -44,7 +44,12 @@ export class CDPClient {
     constructor(port) {
         this._port = port ?? 8081;
         this._consoleBuffer = new RingBuffer(200);
-        this._networkBuffer = new RingBuffer(100, { indexKey: (e) => e.id });
+        this._networkBufferManager = new DeviceBufferManager({
+            capacityPerDevice: 100,
+            maxDevices: 10,
+            indexKey: (e) => e.id,
+            timestampOf: (e) => new Date(e.timestamp).getTime(),
+        });
         this._logBuffer = new RingBuffer(50);
     }
     get state() { return this._state; }
@@ -55,7 +60,10 @@ export class CDPClient {
     get connectedTarget() { return this._connectedTarget; }
     get networkMode() { return this._networkMode; }
     get consoleBuffer() { return this._consoleBuffer; }
-    get networkBuffer() { return this._networkBuffer; }
+    /** M4 (D655): per-device buffer manager. Use `activeDeviceKey` for single-device queries, `'all'` for cross-device. */
+    get networkBufferManager() { return this._networkBufferManager; }
+    /** M4 (D655): the device key for the currently connected target. Used as the default scope for per-device buffer queries. */
+    get activeDeviceKey() { return makeDeviceKey(this._port, this._connectedTarget?.id); }
     get connectionGeneration() { return this._connectionGeneration; }
     get bridgeDetected() { return this._bridgeDetected; }
     get bridgeVersion() { return this._bridgeVersion; }
@@ -213,7 +221,7 @@ export class CDPClient {
         handleMsg(data, this.pending, this.eventHandlers, (params) => this.parseNetworkHookMessage(params));
     }
     parseNetworkHookMessage(params) {
-        parseNetHook(params, this._networkMode, this._networkBuffer);
+        parseNetHook(params, this._networkMode, this._networkBufferManager, this.activeDeviceKey);
     }
     async setup() {
         const result = await performSetup({
@@ -221,7 +229,8 @@ export class CDPClient {
             evaluate: (expr) => this.evaluate(expr),
             port: this._port,
             connectedTarget: this._connectedTarget,
-            networkBuffer: this._networkBuffer,
+            networkManager: this._networkBufferManager,
+            getDeviceKey: () => this.activeDeviceKey,
             setupEventHandlers: () => this.setupEventHandlers(),
             clearScripts: () => this._scripts.clear(),
             clearEventHandlers: () => this.eventHandlers.clear(),
@@ -236,7 +245,7 @@ export class CDPClient {
         }
     }
     setupEventHandlers() {
-        wireEventHandlers(this.eventHandlers, { console: this._consoleBuffer, network: this._networkBuffer, log: this._logBuffer, scripts: this._scripts }, (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)), () => this._isPaused, (v) => { this._isPaused = v; });
+        wireEventHandlers(this.eventHandlers, { console: this._consoleBuffer, network: this._networkBufferManager, log: this._logBuffer, scripts: this._scripts }, (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)), () => this._isPaused, (v) => { this._isPaused = v; }, () => this.activeDeviceKey);
     }
     handleClose(code) {
         handleCloseFn(this.buildReconnectCtx(), code);

--- a/scripts/cdp-bridge/dist/cdp/event-handlers.js
+++ b/scripts/cdp-bridge/dist/cdp/event-handlers.js
@@ -1,4 +1,4 @@
-export function wireEventHandlers(eventHandlers, buffers, sendFn, getIsPaused, setIsPaused) {
+export function wireEventHandlers(eventHandlers, buffers, sendFn, getIsPaused, setIsPaused, getDeviceKey) {
     eventHandlers.set('Runtime.consoleAPICalled', (params) => {
         const p = params;
         const text = p.args?.map(a => a.value !== undefined ? String(a.value) : (a.description ?? '')).join(' ') ?? '';
@@ -12,7 +12,7 @@ export function wireEventHandlers(eventHandlers, buffers, sendFn, getIsPaused, s
     });
     eventHandlers.set('Network.requestWillBeSent', (params) => {
         const p = params;
-        buffers.network.push({
+        buffers.network.push(getDeviceKey(), {
             id: p.requestId,
             method: p.request?.method ?? 'GET',
             url: p.request?.url ?? '',
@@ -21,7 +21,7 @@ export function wireEventHandlers(eventHandlers, buffers, sendFn, getIsPaused, s
     });
     eventHandlers.set('Network.responseReceived', (params) => {
         const p = params;
-        const entry = buffers.network.getByKey(p.requestId);
+        const entry = buffers.network.getByKey(getDeviceKey(), p.requestId);
         if (entry) {
             entry.status = p.response?.status;
             entry.duration_ms = Date.now() - new Date(entry.timestamp).getTime();
@@ -29,7 +29,7 @@ export function wireEventHandlers(eventHandlers, buffers, sendFn, getIsPaused, s
     });
     eventHandlers.set('Network.loadingFailed', (params) => {
         const p = params;
-        const entry = buffers.network.getByKey(p.requestId);
+        const entry = buffers.network.getByKey(getDeviceKey(), p.requestId);
         if (entry) {
             entry.status = 0;
             entry.duration_ms = Date.now() - new Date(entry.timestamp).getTime();
@@ -62,7 +62,7 @@ export function wireEventHandlers(eventHandlers, buffers, sendFn, getIsPaused, s
     });
     eventHandlers.set('Network.loadingFinished', (params) => {
         const p = params;
-        const entry = buffers.network.getByKey(p.requestId);
+        const entry = buffers.network.getByKey(getDeviceKey(), p.requestId);
         if (entry) {
             entry.bodyAvailable = true;
             entry.bodySize = p.encodedDataLength;
@@ -79,7 +79,7 @@ export function wireEventHandlers(eventHandlers, buffers, sendFn, getIsPaused, s
         setIsPaused(false);
     });
 }
-export function parseNetworkHookMessage(params, networkMode, networkBuffer) {
+export function parseNetworkHookMessage(params, networkMode, networkManager, deviceKey) {
     if (networkMode !== 'hook')
         return;
     const p = params;
@@ -91,7 +91,7 @@ export function parseNetworkHookMessage(params, networkMode, networkBuffer) {
         const type = parts[1];
         const data = JSON.parse(parts.slice(2).join(':'));
         if (type === 'request') {
-            networkBuffer.push({
+            networkManager.push(deviceKey, {
                 id: data.id,
                 method: data.method ?? 'GET',
                 url: data.url ?? '',
@@ -99,7 +99,7 @@ export function parseNetworkHookMessage(params, networkMode, networkBuffer) {
             });
         }
         else if (type === 'response') {
-            const entry = networkBuffer.getByKey(data.id);
+            const entry = networkManager.getByKey(deviceKey, data.id);
             if (entry) {
                 entry.status = data.status;
                 entry.duration_ms = data.duration_ms;

--- a/scripts/cdp-bridge/dist/cdp/setup.js
+++ b/scripts/cdp-bridge/dist/cdp/setup.js
@@ -5,7 +5,7 @@ import { CDP_TIMEOUT_FAST, timeoutForMethod } from './timeout-config.js';
 export const REACT_READY_TIMEOUT_MS = 30_000;
 export const REACT_READY_POLL_MS = 500;
 export async function performSetup(opts) {
-    const { send, evaluate, port, connectedTarget, networkBuffer, setupEventHandlers, clearScripts, clearEventHandlers } = opts;
+    const { send, evaluate, port, connectedTarget, networkManager, getDeviceKey, setupEventHandlers, clearScripts, clearEventHandlers } = opts;
     logger.debug('CDP', 'Running setup: Runtime.enable, Debugger.enable...');
     await send('Runtime.enable', undefined, timeoutForMethod('Runtime.enable'));
     await send('Debugger.enable', undefined, timeoutForMethod('Debugger.enable'));
@@ -53,10 +53,11 @@ export async function performSetup(opts) {
     setActiveFlag(port, connectedTarget);
     // D626 (B1 fix): Probe whether Network.enable actually delivers events.
     if (networkMode === 'cdp') {
-        const bufSizeBefore = networkBuffer.size;
+        const deviceKey = getDeviceKey();
+        const bufSizeBefore = networkManager.size(deviceKey);
         await evaluate(`void fetch('http://localhost:${port}/status').catch(function(){})`);
         await new Promise(r => setTimeout(r, 500));
-        if (networkBuffer.size <= bufSizeBefore) {
+        if (networkManager.size(deviceKey) <= bufSizeBefore) {
             logger.info('CDP', 'Network.enable accepted but no events fired (RN < 0.83) — falling back to hooks');
             networkMode = 'none';
         }

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -127,15 +127,17 @@ trackedTool('cdp_native_errors', 'Read native-level error logs for when JS-layer
     sinceSeconds: z.number().int().min(5).max(3600).optional().describe('How far back to look (default 60s, max 3600)'),
     limit: z.number().int().min(1).max(100).optional().describe('Max entries to return (default 10, max 100)'),
 }, createNativeErrorsHandler(getClient));
-trackedTool('cdp_network_log', 'Get recent network requests. Shows method, URL, status, duration. On RN 0.83+ uses CDP Network domain. On older versions uses injected fetch/XHR hooks (auto-detected).', {
+trackedTool('cdp_network_log', 'Get recent network requests. Shows method, URL, status, duration. On RN 0.83+ uses CDP Network domain. On older versions uses injected fetch/XHR hooks (auto-detected). M4/D655: buffers are per-device, keyed by Metro port + target id — switching simulators no longer bleeds stale traffic. Pass `device: "all"` to merge across every device seen this session.', {
     limit: z.number().int().min(1).max(100).default(20).describe('Max entries to return (default 20, max 100)'),
     filter: z.string().optional().describe('Filter by URL substring (e.g. "/api/cart")'),
     clear: z.boolean().default(false).describe('Clear network buffer instead of reading'),
+    device: z.string().optional().describe('Scope: a specific device key OR the literal "all" for a chronologically-merged view across every device. Defaults to the active device.'),
 }, createNetworkLogHandler(getClient));
-trackedTool('cdp_network_body', 'Get the actual response body for a network request by its requestId. Use cdp_network_log first to find request IDs. Only works in CDP network mode (RN 0.83+). Bodies are fetched on-demand, not cached.', {
+trackedTool('cdp_network_body', 'Get the actual response body for a network request by its requestId. Use cdp_network_log first to find request IDs. Only works in CDP network mode (RN 0.83+). Bodies are fetched on-demand, not cached. M4/D655: pass `device` to look up requestId in a specific device buffer; defaults to the active device.', {
     requestId: z.string().describe('Request ID from cdp_network_log output'),
     maxLength: z.number().int().min(100).max(100000).default(10000).optional()
         .describe('Max body length to return (default 10000 chars). Truncated if longer.'),
+    device: z.string().optional().describe('Device key to scope the lookup ("all" to search every device buffer). Defaults to the active device.'),
 }, createNetworkBodyHandler(getClient));
 trackedTool('cdp_heap_usage', 'Get current JS heap memory usage. Single fast CDP call — useful before/after operations to detect memory leaks. Returns used/total in bytes and MB.', {}, createHeapUsageHandler(getClient));
 trackedTool('cdp_cpu_profile', 'Record a CPU profile for a specified duration. Returns the top hot functions sorted by hit count. Requires Profiler domain (check cdp_status domains.profiler).', {

--- a/scripts/cdp-bridge/dist/ring-buffer.js
+++ b/scripts/cdp-bridge/dist/ring-buffer.js
@@ -66,3 +66,146 @@ export class RingBuffer {
         return this.count;
     }
 }
+export const NO_DEVICE_KEY = 'noport-notarget';
+/**
+ * Build a stable device key from (metroPort, targetId) for `DeviceBufferManager`.
+ * Falls back to a sentinel string when either is null, so events captured before
+ * a target is selected still have a valid bucket.
+ */
+export function makeDeviceKey(port, targetId) {
+    return `${port ?? 'noport'}-${targetId ?? 'notarget'}`;
+}
+/**
+ * Per-device circular buffer manager (M4 / Phase 90 Tier 2).
+ *
+ * Wraps N `RingBuffer`s keyed by `${metroPort}-${targetId}` so console/network/log
+ * events captured while connected to one device don't leak into queries made after
+ * switching to another device. When the active device count exceeds `maxDevices`,
+ * the buffer with the oldest last-push timestamp is evicted whole — bounds memory.
+ *
+ * Supports cross-device aggregation via `device: 'all'`: results are merged across
+ * every live buffer, sorted by `timestampOf(item)` when provided.
+ */
+export class DeviceBufferManager {
+    buffers = new Map();
+    lastPush = new Map();
+    opts;
+    constructor(options) {
+        this.opts = {
+            capacityPerDevice: options.capacityPerDevice,
+            maxDevices: options.maxDevices ?? 10,
+            indexKey: options.indexKey,
+            timestampOf: options.timestampOf,
+        };
+    }
+    /**
+     * Append `item` to the buffer for `deviceKey`. Creates the buffer on first push;
+     * evicts the least-recently-pushed device when `maxDevices` is reached.
+     */
+    push(deviceKey, item) {
+        let buf = this.buffers.get(deviceKey);
+        if (!buf) {
+            if (this.buffers.size >= this.opts.maxDevices) {
+                this.evictOldest();
+            }
+            buf = new RingBuffer(this.opts.capacityPerDevice, this.opts.indexKey ? { indexKey: this.opts.indexKey } : undefined);
+            this.buffers.set(deviceKey, buf);
+        }
+        buf.push(item);
+        this.lastPush.set(deviceKey, Date.now());
+    }
+    /**
+     * Get the last `n` items for `deviceKey`, or `'all'` for a chronologically-merged
+     * view across every device buffer. Cross-device queries require `timestampOf`
+     * (passed at construction) for deterministic ordering; without it, items are
+     * returned in per-device insertion order and then concatenated.
+     */
+    getLast(deviceKey, n) {
+        if (deviceKey !== 'all') {
+            return this.buffers.get(deviceKey)?.getLast(n) ?? [];
+        }
+        const merged = [];
+        for (const buf of this.buffers.values()) {
+            merged.push(...buf.getLast(buf.size));
+        }
+        if (this.opts.timestampOf) {
+            merged.sort((a, b) => this.opts.timestampOf(a) - this.opts.timestampOf(b));
+        }
+        return merged.slice(-n);
+    }
+    /** Filter items (single device or `'all'`) by `predicate`. */
+    filter(deviceKey, predicate) {
+        if (deviceKey !== 'all') {
+            return this.buffers.get(deviceKey)?.filter(predicate) ?? [];
+        }
+        const merged = [];
+        for (const buf of this.buffers.values()) {
+            merged.push(...buf.filter(predicate));
+        }
+        if (this.opts.timestampOf) {
+            merged.sort((a, b) => this.opts.timestampOf(a) - this.opts.timestampOf(b));
+        }
+        return merged;
+    }
+    /**
+     * O(1) key lookup. `'all'` scans every device buffer and returns the first hit;
+     * since callers use unique ids (e.g. network request IDs) collisions are expected
+     * to be extremely rare, but still first-hit wins.
+     */
+    getByKey(deviceKey, key) {
+        if (deviceKey !== 'all') {
+            return this.buffers.get(deviceKey)?.getByKey(key);
+        }
+        for (const buf of this.buffers.values()) {
+            const hit = buf.getByKey(key);
+            if (hit !== undefined)
+                return hit;
+        }
+        return undefined;
+    }
+    /** Clear a single device buffer (or every buffer when called without args). */
+    clear(deviceKey) {
+        if (deviceKey === undefined) {
+            this.buffers.clear();
+            this.lastPush.clear();
+            return;
+        }
+        this.buffers.get(deviceKey)?.clear();
+        this.lastPush.delete(deviceKey);
+    }
+    /** Per-device buffer size. Returns 0 for unknown keys. */
+    size(deviceKey) {
+        return this.buffers.get(deviceKey)?.size ?? 0;
+    }
+    /** Total size across every device (useful for health metrics). */
+    get totalSize() {
+        let total = 0;
+        for (const buf of this.buffers.values())
+            total += buf.size;
+        return total;
+    }
+    /** How many device buffers are currently live. */
+    get deviceCount() {
+        return this.buffers.size;
+    }
+    /** Snapshot of live device keys in last-push order (most recently pushed last). */
+    deviceKeys() {
+        return Array.from(this.lastPush.entries())
+            .sort((a, b) => a[1] - b[1])
+            .map(([key]) => key);
+    }
+    evictOldest() {
+        let oldestKey = null;
+        let oldestTs = Number.POSITIVE_INFINITY;
+        for (const [key, ts] of this.lastPush) {
+            if (ts < oldestTs) {
+                oldestKey = key;
+                oldestTs = ts;
+            }
+        }
+        if (oldestKey !== null) {
+            this.buffers.delete(oldestKey);
+            this.lastPush.delete(oldestKey);
+        }
+    }
+}

--- a/scripts/cdp-bridge/dist/tools/network-body.js
+++ b/scripts/cdp-bridge/dist/tools/network-body.js
@@ -4,7 +4,8 @@ export function createNetworkBodyHandler(getClient) {
         if (!args.requestId) {
             return failResult('requestId is required. Use cdp_network_log to find request IDs.');
         }
-        const entry = client.networkBuffer.getByKey(args.requestId);
+        const scope = args.device ?? client.activeDeviceKey;
+        const entry = client.networkBufferManager.getByKey(scope, args.requestId);
         if (!entry) {
             return failResult(`Request ${args.requestId} not found in network buffer. It may have been evicted (buffer holds last 100 requests).`);
         }

--- a/scripts/cdp-bridge/dist/tools/network-log.js
+++ b/scripts/cdp-bridge/dist/tools/network-log.js
@@ -1,17 +1,18 @@
 import { okResult, withConnection } from '../utils.js';
 export function createNetworkLogHandler(getClient) {
     return withConnection(getClient, async (args, client) => {
+        const scope = args.device ?? client.activeDeviceKey;
         if (args.clear) {
-            client.networkBuffer.clear();
-            return okResult({ cleared: true });
+            client.networkBufferManager.clear(scope === 'all' ? undefined : scope);
+            return okResult({ cleared: true, device: scope });
         }
         const limit = Math.min(Math.max(args.limit ?? 20, 1), 100);
         let entries = args.filter !== undefined
-            ? client.networkBuffer.filter(e => e.url.includes(args.filter))
-            : client.networkBuffer.getLast(limit);
+            ? client.networkBufferManager.filter(scope, (e) => e.url.includes(args.filter))
+            : client.networkBufferManager.getLast(scope, limit);
         if (args.filter !== undefined && entries.length > limit) {
             entries = entries.slice(-limit);
         }
-        return okResult({ mode: client.networkMode, count: entries.length, requests: entries });
+        return okResult({ mode: client.networkMode, device: scope, count: entries.length, requests: entries });
     });
 }

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/cdp-client.ts
+++ b/scripts/cdp-bridge/src/cdp-client.ts
@@ -1,5 +1,5 @@
 import WebSocket from 'ws';
-import { RingBuffer } from './ring-buffer.js';
+import { RingBuffer, DeviceBufferManager, makeDeviceKey } from './ring-buffer.js';
 import { detectBridge } from './bridge-detector.js';
 import { logger } from './logger.js';
 import { performSetup, reinjectHelpers as reinjectHelpersFn } from './cdp/setup.js';
@@ -41,7 +41,7 @@ export class CDPClient {
   private pending = new Map<number, PendingCall>();
   private eventHandlers = new Map<string, (params: unknown) => void>();
   private _consoleBuffer: RingBuffer<ConsoleEntry>;
-  private _networkBuffer: RingBuffer<NetworkEntry, string>;
+  private _networkBufferManager: DeviceBufferManager<NetworkEntry, string>;
   private _port: number;
   private reconnecting = false;
   private disposed = false;
@@ -70,7 +70,12 @@ export class CDPClient {
   constructor(port?: number) {
     this._port = port ?? 8081;
     this._consoleBuffer = new RingBuffer<ConsoleEntry>(200);
-    this._networkBuffer = new RingBuffer<NetworkEntry, string>(100, { indexKey: (e) => e.id });
+    this._networkBufferManager = new DeviceBufferManager<NetworkEntry, string>({
+      capacityPerDevice: 100,
+      maxDevices: 10,
+      indexKey: (e) => e.id,
+      timestampOf: (e) => new Date(e.timestamp).getTime(),
+    });
     this._logBuffer = new RingBuffer<LogEntry>(50);
   }
 
@@ -82,7 +87,10 @@ export class CDPClient {
   get connectedTarget(): HermesTarget | null { return this._connectedTarget; }
   get networkMode(): 'cdp' | 'hook' | 'none' { return this._networkMode; }
   get consoleBuffer(): RingBuffer<ConsoleEntry> { return this._consoleBuffer; }
-  get networkBuffer(): RingBuffer<NetworkEntry, string> { return this._networkBuffer; }
+  /** M4 (D655): per-device buffer manager. Use `activeDeviceKey` for single-device queries, `'all'` for cross-device. */
+  get networkBufferManager(): DeviceBufferManager<NetworkEntry, string> { return this._networkBufferManager; }
+  /** M4 (D655): the device key for the currently connected target. Used as the default scope for per-device buffer queries. */
+  get activeDeviceKey(): string { return makeDeviceKey(this._port, this._connectedTarget?.id); }
   get connectionGeneration(): number { return this._connectionGeneration; }
   get bridgeDetected(): boolean { return this._bridgeDetected; }
   get bridgeVersion(): number | null { return this._bridgeVersion; }
@@ -264,7 +272,7 @@ export class CDPClient {
   }
 
   private parseNetworkHookMessage(params: unknown): void {
-    parseNetHook(params, this._networkMode, this._networkBuffer);
+    parseNetHook(params, this._networkMode, this._networkBufferManager, this.activeDeviceKey);
   }
 
   private async setup(): Promise<void> {
@@ -273,7 +281,8 @@ export class CDPClient {
       evaluate: (expr) => this.evaluate(expr),
       port: this._port,
       connectedTarget: this._connectedTarget,
-      networkBuffer: this._networkBuffer,
+      networkManager: this._networkBufferManager,
+      getDeviceKey: () => this.activeDeviceKey,
       setupEventHandlers: () => this.setupEventHandlers(),
       clearScripts: () => this._scripts.clear(),
       clearEventHandlers: () => this.eventHandlers.clear(),
@@ -291,10 +300,11 @@ export class CDPClient {
   private setupEventHandlers(): void {
     wireEventHandlers(
       this.eventHandlers,
-      { console: this._consoleBuffer, network: this._networkBuffer, log: this._logBuffer, scripts: this._scripts },
+      { console: this._consoleBuffer, network: this._networkBufferManager, log: this._logBuffer, scripts: this._scripts },
       (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)),
       () => this._isPaused,
       (v) => { this._isPaused = v; },
+      () => this.activeDeviceKey,
     );
   }
 

--- a/scripts/cdp-bridge/src/cdp/event-handlers.ts
+++ b/scripts/cdp-bridge/src/cdp/event-handlers.ts
@@ -1,9 +1,9 @@
-import type { RingBuffer } from '../ring-buffer.js';
+import type { RingBuffer, DeviceBufferManager } from '../ring-buffer.js';
 import type { ConsoleEntry, NetworkEntry, LogEntry } from '../types.js';
 
 export interface EventBuffers {
   console: RingBuffer<ConsoleEntry>;
-  network: RingBuffer<NetworkEntry, string>;
+  network: DeviceBufferManager<NetworkEntry, string>;
   log: RingBuffer<LogEntry>;
   scripts: Map<string, { scriptId: string; url: string; startLine: number; endLine: number }>;
 }
@@ -14,6 +14,7 @@ export function wireEventHandlers(
   sendFn: (method: string, params?: unknown, ms?: number) => Promise<unknown>,
   getIsPaused: () => boolean,
   setIsPaused: (v: boolean) => void,
+  getDeviceKey: () => string,
 ): void {
   eventHandlers.set('Runtime.consoleAPICalled', (params: unknown) => {
     const p = params as { type: string; args?: Array<{ value?: unknown; description?: string }> };
@@ -28,7 +29,7 @@ export function wireEventHandlers(
 
   eventHandlers.set('Network.requestWillBeSent', (params: unknown) => {
     const p = params as { requestId: string; request?: { method: string; url: string } };
-    buffers.network.push({
+    buffers.network.push(getDeviceKey(), {
       id: p.requestId,
       method: p.request?.method ?? 'GET',
       url: p.request?.url ?? '',
@@ -38,7 +39,7 @@ export function wireEventHandlers(
 
   eventHandlers.set('Network.responseReceived', (params: unknown) => {
     const p = params as { requestId: string; response?: { status: number } };
-    const entry = buffers.network.getByKey(p.requestId);
+    const entry = buffers.network.getByKey(getDeviceKey(), p.requestId);
     if (entry) {
       entry.status = p.response?.status;
       entry.duration_ms = Date.now() - new Date(entry.timestamp).getTime();
@@ -47,7 +48,7 @@ export function wireEventHandlers(
 
   eventHandlers.set('Network.loadingFailed', (params: unknown) => {
     const p = params as { requestId: string };
-    const entry = buffers.network.getByKey(p.requestId);
+    const entry = buffers.network.getByKey(getDeviceKey(), p.requestId);
     if (entry) {
       entry.status = 0;
       entry.duration_ms = Date.now() - new Date(entry.timestamp).getTime();
@@ -82,7 +83,7 @@ export function wireEventHandlers(
 
   eventHandlers.set('Network.loadingFinished', (params: unknown) => {
     const p = params as { requestId: string; encodedDataLength?: number };
-    const entry = buffers.network.getByKey(p.requestId);
+    const entry = buffers.network.getByKey(getDeviceKey(), p.requestId);
     if (entry) {
       entry.bodyAvailable = true;
       entry.bodySize = p.encodedDataLength;
@@ -103,7 +104,8 @@ export function wireEventHandlers(
 export function parseNetworkHookMessage(
   params: unknown,
   networkMode: 'cdp' | 'hook' | 'none',
-  networkBuffer: RingBuffer<NetworkEntry, string>,
+  networkManager: DeviceBufferManager<NetworkEntry, string>,
+  deviceKey: string,
 ): void {
   if (networkMode !== 'hook') return;
   const p = params as { args?: Array<{ value?: unknown }> };
@@ -116,14 +118,14 @@ export function parseNetworkHookMessage(
     const data = JSON.parse(parts.slice(2).join(':'));
 
     if (type === 'request') {
-      networkBuffer.push({
+      networkManager.push(deviceKey, {
         id: data.id,
         method: data.method ?? 'GET',
         url: data.url ?? '',
         timestamp: new Date().toISOString(),
       });
     } else if (type === 'response') {
-      const entry = networkBuffer.getByKey(data.id);
+      const entry = networkManager.getByKey(deviceKey, data.id);
       if (entry) {
         entry.status = data.status;
         entry.duration_ms = data.duration_ms;

--- a/scripts/cdp-bridge/src/cdp/setup.ts
+++ b/scripts/cdp-bridge/src/cdp/setup.ts
@@ -2,7 +2,7 @@ import { INJECTED_HELPERS, NETWORK_HOOK_SCRIPT } from '../injected-helpers.js';
 import { logger } from '../logger.js';
 import { setActiveFlag, sleep } from './state.js';
 import { CDP_TIMEOUT_FAST, timeoutForMethod } from './timeout-config.js';
-import type { RingBuffer } from '../ring-buffer.js';
+import type { DeviceBufferManager } from '../ring-buffer.js';
 import type { NetworkEntry, EvaluateResult, HermesTarget } from '../types.js';
 
 export const REACT_READY_TIMEOUT_MS = 30_000;
@@ -21,12 +21,13 @@ export async function performSetup(opts: {
   evaluate: (expr: string) => Promise<EvaluateResult>;
   port: number;
   connectedTarget: HermesTarget | null;
-  networkBuffer: RingBuffer<NetworkEntry, string>;
+  networkManager: DeviceBufferManager<NetworkEntry, string>;
+  getDeviceKey: () => string;
   setupEventHandlers: () => void;
   clearScripts: () => void;
   clearEventHandlers: () => void;
 }): Promise<SetupResult> {
-  const { send, evaluate, port, connectedTarget, networkBuffer, setupEventHandlers, clearScripts, clearEventHandlers } = opts;
+  const { send, evaluate, port, connectedTarget, networkManager, getDeviceKey, setupEventHandlers, clearScripts, clearEventHandlers } = opts;
 
   logger.debug('CDP', 'Running setup: Runtime.enable, Debugger.enable...');
   await send('Runtime.enable', undefined, timeoutForMethod('Runtime.enable'));
@@ -82,10 +83,11 @@ export async function performSetup(opts: {
 
   // D626 (B1 fix): Probe whether Network.enable actually delivers events.
   if (networkMode === 'cdp') {
-    const bufSizeBefore = networkBuffer.size;
+    const deviceKey = getDeviceKey();
+    const bufSizeBefore = networkManager.size(deviceKey);
     await evaluate(`void fetch('http://localhost:${port}/status').catch(function(){})`);
     await new Promise(r => setTimeout(r, 500));
-    if (networkBuffer.size <= bufSizeBefore) {
+    if (networkManager.size(deviceKey) <= bufSizeBefore) {
       logger.info('CDP', 'Network.enable accepted but no events fired (RN < 0.83) — falling back to hooks');
       networkMode = 'none';
     }

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -220,22 +220,24 @@ trackedTool(
 
 trackedTool(
   'cdp_network_log',
-  'Get recent network requests. Shows method, URL, status, duration. On RN 0.83+ uses CDP Network domain. On older versions uses injected fetch/XHR hooks (auto-detected).',
+  'Get recent network requests. Shows method, URL, status, duration. On RN 0.83+ uses CDP Network domain. On older versions uses injected fetch/XHR hooks (auto-detected). M4/D655: buffers are per-device, keyed by Metro port + target id — switching simulators no longer bleeds stale traffic. Pass `device: "all"` to merge across every device seen this session.',
   {
     limit: z.number().int().min(1).max(100).default(20).describe('Max entries to return (default 20, max 100)'),
     filter: z.string().optional().describe('Filter by URL substring (e.g. "/api/cart")'),
     clear: z.boolean().default(false).describe('Clear network buffer instead of reading'),
+    device: z.string().optional().describe('Scope: a specific device key OR the literal "all" for a chronologically-merged view across every device. Defaults to the active device.'),
   },
   createNetworkLogHandler(getClient),
 );
 
 trackedTool(
   'cdp_network_body',
-  'Get the actual response body for a network request by its requestId. Use cdp_network_log first to find request IDs. Only works in CDP network mode (RN 0.83+). Bodies are fetched on-demand, not cached.',
+  'Get the actual response body for a network request by its requestId. Use cdp_network_log first to find request IDs. Only works in CDP network mode (RN 0.83+). Bodies are fetched on-demand, not cached. M4/D655: pass `device` to look up requestId in a specific device buffer; defaults to the active device.',
   {
     requestId: z.string().describe('Request ID from cdp_network_log output'),
     maxLength: z.number().int().min(100).max(100000).default(10000).optional()
       .describe('Max body length to return (default 10000 chars). Truncated if longer.'),
+    device: z.string().optional().describe('Device key to scope the lookup ("all" to search every device buffer). Defaults to the active device.'),
   },
   createNetworkBodyHandler(getClient),
 );

--- a/scripts/cdp-bridge/src/ring-buffer.ts
+++ b/scripts/cdp-bridge/src/ring-buffer.ts
@@ -74,3 +74,172 @@ export class RingBuffer<T, K = unknown> {
     return this.count;
   }
 }
+
+export const NO_DEVICE_KEY = 'noport-notarget';
+
+/**
+ * Build a stable device key from (metroPort, targetId) for `DeviceBufferManager`.
+ * Falls back to a sentinel string when either is null, so events captured before
+ * a target is selected still have a valid bucket.
+ */
+export function makeDeviceKey(port: number | null | undefined, targetId: string | null | undefined): string {
+  return `${port ?? 'noport'}-${targetId ?? 'notarget'}`;
+}
+
+export interface DeviceBufferOptions<T, K> extends RingBufferOptions<T, K> {
+  /** Per-device buffer capacity. Each device gets its own `RingBuffer` at this size. */
+  capacityPerDevice: number;
+  /** Maximum number of device buffers held in memory. When exceeded, the device with the oldest last-push timestamp is evicted. Default: 10. */
+  maxDevices?: number;
+  /** Required for cross-device aggregation (`'all'` queries) so results can be merged in chronological order. */
+  timestampOf?: (item: T) => number;
+}
+
+/**
+ * Per-device circular buffer manager (M4 / Phase 90 Tier 2).
+ *
+ * Wraps N `RingBuffer`s keyed by `${metroPort}-${targetId}` so console/network/log
+ * events captured while connected to one device don't leak into queries made after
+ * switching to another device. When the active device count exceeds `maxDevices`,
+ * the buffer with the oldest last-push timestamp is evicted whole — bounds memory.
+ *
+ * Supports cross-device aggregation via `device: 'all'`: results are merged across
+ * every live buffer, sorted by `timestampOf(item)` when provided.
+ */
+export class DeviceBufferManager<T, K = unknown> {
+  private readonly buffers = new Map<string, RingBuffer<T, K>>();
+  private readonly lastPush = new Map<string, number>();
+  private readonly opts: {
+    capacityPerDevice: number;
+    maxDevices: number;
+    indexKey?: (item: T) => K | undefined;
+    timestampOf?: (item: T) => number;
+  };
+
+  constructor(options: DeviceBufferOptions<T, K>) {
+    this.opts = {
+      capacityPerDevice: options.capacityPerDevice,
+      maxDevices: options.maxDevices ?? 10,
+      indexKey: options.indexKey,
+      timestampOf: options.timestampOf,
+    };
+  }
+
+  /**
+   * Append `item` to the buffer for `deviceKey`. Creates the buffer on first push;
+   * evicts the least-recently-pushed device when `maxDevices` is reached.
+   */
+  push(deviceKey: string, item: T): void {
+    let buf = this.buffers.get(deviceKey);
+    if (!buf) {
+      if (this.buffers.size >= this.opts.maxDevices) {
+        this.evictOldest();
+      }
+      buf = new RingBuffer<T, K>(this.opts.capacityPerDevice, this.opts.indexKey ? { indexKey: this.opts.indexKey } : undefined);
+      this.buffers.set(deviceKey, buf);
+    }
+    buf.push(item);
+    this.lastPush.set(deviceKey, Date.now());
+  }
+
+  /**
+   * Get the last `n` items for `deviceKey`, or `'all'` for a chronologically-merged
+   * view across every device buffer. Cross-device queries require `timestampOf`
+   * (passed at construction) for deterministic ordering; without it, items are
+   * returned in per-device insertion order and then concatenated.
+   */
+  getLast(deviceKey: string | 'all', n: number): T[] {
+    if (deviceKey !== 'all') {
+      return this.buffers.get(deviceKey)?.getLast(n) ?? [];
+    }
+    const merged: T[] = [];
+    for (const buf of this.buffers.values()) {
+      merged.push(...buf.getLast(buf.size));
+    }
+    if (this.opts.timestampOf) {
+      merged.sort((a, b) => this.opts.timestampOf!(a) - this.opts.timestampOf!(b));
+    }
+    return merged.slice(-n);
+  }
+
+  /** Filter items (single device or `'all'`) by `predicate`. */
+  filter(deviceKey: string | 'all', predicate: (item: T) => boolean): T[] {
+    if (deviceKey !== 'all') {
+      return this.buffers.get(deviceKey)?.filter(predicate) ?? [];
+    }
+    const merged: T[] = [];
+    for (const buf of this.buffers.values()) {
+      merged.push(...buf.filter(predicate));
+    }
+    if (this.opts.timestampOf) {
+      merged.sort((a, b) => this.opts.timestampOf!(a) - this.opts.timestampOf!(b));
+    }
+    return merged;
+  }
+
+  /**
+   * O(1) key lookup. `'all'` scans every device buffer and returns the first hit;
+   * since callers use unique ids (e.g. network request IDs) collisions are expected
+   * to be extremely rare, but still first-hit wins.
+   */
+  getByKey(deviceKey: string | 'all', key: K): T | undefined {
+    if (deviceKey !== 'all') {
+      return this.buffers.get(deviceKey)?.getByKey(key);
+    }
+    for (const buf of this.buffers.values()) {
+      const hit = buf.getByKey(key);
+      if (hit !== undefined) return hit;
+    }
+    return undefined;
+  }
+
+  /** Clear a single device buffer (or every buffer when called without args). */
+  clear(deviceKey?: string): void {
+    if (deviceKey === undefined) {
+      this.buffers.clear();
+      this.lastPush.clear();
+      return;
+    }
+    this.buffers.get(deviceKey)?.clear();
+    this.lastPush.delete(deviceKey);
+  }
+
+  /** Per-device buffer size. Returns 0 for unknown keys. */
+  size(deviceKey: string): number {
+    return this.buffers.get(deviceKey)?.size ?? 0;
+  }
+
+  /** Total size across every device (useful for health metrics). */
+  get totalSize(): number {
+    let total = 0;
+    for (const buf of this.buffers.values()) total += buf.size;
+    return total;
+  }
+
+  /** How many device buffers are currently live. */
+  get deviceCount(): number {
+    return this.buffers.size;
+  }
+
+  /** Snapshot of live device keys in last-push order (most recently pushed last). */
+  deviceKeys(): string[] {
+    return Array.from(this.lastPush.entries())
+      .sort((a, b) => a[1] - b[1])
+      .map(([key]) => key);
+  }
+
+  private evictOldest(): void {
+    let oldestKey: string | null = null;
+    let oldestTs = Number.POSITIVE_INFINITY;
+    for (const [key, ts] of this.lastPush) {
+      if (ts < oldestTs) {
+        oldestKey = key;
+        oldestTs = ts;
+      }
+    }
+    if (oldestKey !== null) {
+      this.buffers.delete(oldestKey);
+      this.lastPush.delete(oldestKey);
+    }
+  }
+}

--- a/scripts/cdp-bridge/src/tools/network-body.ts
+++ b/scripts/cdp-bridge/src/tools/network-body.ts
@@ -2,12 +2,13 @@ import type { CDPClient } from '../cdp-client.js';
 import { okResult, failResult, withConnection } from '../utils.js';
 
 export function createNetworkBodyHandler(getClient: () => CDPClient) {
-  return withConnection(getClient, async (args: { requestId: string; maxLength?: number }, client) => {
+  return withConnection(getClient, async (args: { requestId: string; maxLength?: number; device?: string }, client) => {
     if (!args.requestId) {
       return failResult('requestId is required. Use cdp_network_log to find request IDs.');
     }
 
-    const entry = client.networkBuffer.getByKey(args.requestId);
+    const scope = args.device ?? client.activeDeviceKey;
+    const entry = client.networkBufferManager.getByKey(scope, args.requestId);
     if (!entry) {
       return failResult(
         `Request ${args.requestId} not found in network buffer. It may have been evicted (buffer holds last 100 requests).`,

--- a/scripts/cdp-bridge/src/tools/network-log.ts
+++ b/scripts/cdp-bridge/src/tools/network-log.ts
@@ -2,22 +2,24 @@ import type { CDPClient } from '../cdp-client.js';
 import { okResult, withConnection } from '../utils.js';
 
 export function createNetworkLogHandler(getClient: () => CDPClient) {
-  return withConnection(getClient, async (args: { limit: number; filter?: string; clear: boolean }, client) => {
+  return withConnection(getClient, async (args: { limit: number; filter?: string; clear: boolean; device?: string }, client) => {
+    const scope = args.device ?? client.activeDeviceKey;
+
     if (args.clear) {
-      client.networkBuffer.clear();
-      return okResult({ cleared: true });
+      client.networkBufferManager.clear(scope === 'all' ? undefined : scope);
+      return okResult({ cleared: true, device: scope });
     }
 
     const limit = Math.min(Math.max(args.limit ?? 20, 1), 100);
 
     let entries = args.filter !== undefined
-      ? client.networkBuffer.filter(e => e.url.includes(args.filter!))
-      : client.networkBuffer.getLast(limit);
+      ? client.networkBufferManager.filter(scope, (e) => e.url.includes(args.filter!))
+      : client.networkBufferManager.getLast(scope, limit);
 
     if (args.filter !== undefined && entries.length > limit) {
       entries = entries.slice(-limit);
     }
 
-    return okResult({ mode: client.networkMode, count: entries.length, requests: entries });
+    return okResult({ mode: client.networkMode, device: scope, count: entries.length, requests: entries });
   });
 }

--- a/scripts/cdp-bridge/test/helpers/mock-cdp-client.js
+++ b/scripts/cdp-bridge/test/helpers/mock-cdp-client.js
@@ -1,4 +1,4 @@
-import { RingBuffer } from '../../dist/ring-buffer.js';
+import { RingBuffer, DeviceBufferManager, makeDeviceKey } from '../../dist/ring-buffer.js';
 
 /**
  * Creates a mock CDPClient that satisfies the interface used by tool handlers
@@ -9,7 +9,12 @@ import { RingBuffer } from '../../dist/ring-buffer.js';
  */
 export function createMockClient(overrides = {}) {
   const consoleBuffer = new RingBuffer(200);
-  const networkBuffer = new RingBuffer(100, { indexKey: (e) => e.id });
+  const networkBufferManager = new DeviceBufferManager({
+    capacityPerDevice: 100,
+    maxDevices: 10,
+    indexKey: (e) => e.id,
+    timestampOf: (e) => new Date(e.timestamp).getTime(),
+  });
   const logBuffer = new RingBuffer(50);
 
   const client = {
@@ -29,7 +34,8 @@ export function createMockClient(overrides = {}) {
     get scripts() { return client._scripts; },
     get connectionGeneration() { return client._connectionGeneration; },
     get consoleBuffer() { return consoleBuffer; },
-    get networkBuffer() { return networkBuffer; },
+    get networkBufferManager() { return networkBufferManager; },
+    get activeDeviceKey() { return makeDeviceKey(client._metroPort, client._connectedTarget?.id); },
     get logBuffer() { return logBuffer; },
     get reconnectState() {
       return { active: false, lastAttempt: null, attemptCount: 0 };

--- a/scripts/cdp-bridge/test/unit/device-buffer-manager.test.js
+++ b/scripts/cdp-bridge/test/unit/device-buffer-manager.test.js
@@ -1,0 +1,262 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DeviceBufferManager, makeDeviceKey, NO_DEVICE_KEY } from '../../dist/ring-buffer.js';
+
+// ── Key helper ──
+
+test('makeDeviceKey: combines port and targetId', () => {
+  assert.equal(makeDeviceKey(8081, 'page1'), '8081-page1');
+});
+
+test('makeDeviceKey: uses sentinels for null/undefined', () => {
+  assert.equal(makeDeviceKey(null, null), NO_DEVICE_KEY);
+  assert.equal(makeDeviceKey(undefined, undefined), NO_DEVICE_KEY);
+  assert.equal(makeDeviceKey(8081, null), '8081-notarget');
+  assert.equal(makeDeviceKey(null, 'page1'), 'noport-page1');
+});
+
+test('NO_DEVICE_KEY matches the double-null form', () => {
+  assert.equal(NO_DEVICE_KEY, makeDeviceKey(null, null));
+});
+
+// ── Basic push + getLast ──
+
+test('DeviceBufferManager: pushes to the correct device bucket', () => {
+  const mgr = new DeviceBufferManager({ capacityPerDevice: 10 });
+  mgr.push('ios-1', { value: 'a' });
+  mgr.push('ios-1', { value: 'b' });
+  mgr.push('android-1', { value: 'x' });
+
+  assert.deepEqual(mgr.getLast('ios-1', 10).map((e) => e.value), ['a', 'b']);
+  assert.deepEqual(mgr.getLast('android-1', 10).map((e) => e.value), ['x']);
+  assert.equal(mgr.deviceCount, 2);
+});
+
+test('DeviceBufferManager: getLast on unknown device returns empty array (not error)', () => {
+  const mgr = new DeviceBufferManager({ capacityPerDevice: 10 });
+  assert.deepEqual(mgr.getLast('never-seen', 10), []);
+});
+
+test('DeviceBufferManager: per-device capacity overflow evicts oldest within THAT device only', () => {
+  const mgr = new DeviceBufferManager({ capacityPerDevice: 3 });
+  for (let i = 0; i < 5; i++) mgr.push('dev-a', { i });
+  mgr.push('dev-b', { x: 1 });
+
+  assert.deepEqual(mgr.getLast('dev-a', 10).map((e) => e.i), [2, 3, 4]);
+  assert.deepEqual(mgr.getLast('dev-b', 10), [{ x: 1 }], 'dev-b unaffected by dev-a overflow');
+});
+
+// ── maxDevices eviction ──
+
+test('DeviceBufferManager: evicts oldest device (by last-push) when maxDevices reached', async () => {
+  const mgr = new DeviceBufferManager({ capacityPerDevice: 10, maxDevices: 3 });
+
+  mgr.push('d1', { x: 1 });
+  await new Promise((r) => setTimeout(r, 5));
+  mgr.push('d2', { x: 2 });
+  await new Promise((r) => setTimeout(r, 5));
+  mgr.push('d3', { x: 3 });
+  await new Promise((r) => setTimeout(r, 5));
+
+  assert.equal(mgr.deviceCount, 3);
+
+  // Add a 4th → d1 (oldest last-push) evicted
+  mgr.push('d4', { x: 4 });
+  assert.equal(mgr.deviceCount, 3);
+  assert.deepEqual(mgr.getLast('d1', 10), [], 'd1 evicted');
+  assert.deepEqual(mgr.getLast('d4', 10), [{ x: 4 }], 'd4 present');
+});
+
+test('DeviceBufferManager: recently-pushed device survives eviction even if old', async () => {
+  const mgr = new DeviceBufferManager({ capacityPerDevice: 10, maxDevices: 3 });
+
+  mgr.push('d1', { x: 1 });
+  mgr.push('d2', { x: 2 });
+  mgr.push('d3', { x: 3 });
+  await new Promise((r) => setTimeout(r, 5));
+
+  // Re-push d1 → now d2 is the oldest by last-push
+  mgr.push('d1', { x: 11 });
+  mgr.push('d4', { x: 4 });
+
+  assert.deepEqual(mgr.getLast('d1', 10).map((e) => e.x), [1, 11], 'd1 survived because of re-push');
+  assert.deepEqual(mgr.getLast('d2', 10), [], 'd2 evicted as new-oldest');
+});
+
+// ── Cross-device 'all' aggregation ──
+
+test('DeviceBufferManager: "all" merges across devices in chronological order (with timestampOf)', () => {
+  const mgr = new DeviceBufferManager({
+    capacityPerDevice: 10,
+    timestampOf: (e) => e.ts,
+  });
+  mgr.push('d1', { ts: 300, label: 'd1-late' });
+  mgr.push('d2', { ts: 100, label: 'd2-early' });
+  mgr.push('d1', { ts: 200, label: 'd1-mid' });
+
+  const all = mgr.getLast('all', 10);
+  assert.deepEqual(
+    all.map((e) => e.label),
+    ['d2-early', 'd1-mid', 'd1-late'],
+    'merged results are timestamp-sorted',
+  );
+});
+
+test('DeviceBufferManager: "all" respects the n limit (tails to most recent)', () => {
+  const mgr = new DeviceBufferManager({
+    capacityPerDevice: 10,
+    timestampOf: (e) => e.ts,
+  });
+  for (let i = 1; i <= 5; i++) mgr.push('d1', { ts: i });
+  for (let i = 6; i <= 10; i++) mgr.push('d2', { ts: i });
+
+  const last3 = mgr.getLast('all', 3);
+  assert.deepEqual(last3.map((e) => e.ts), [8, 9, 10], '"all" limit applied after sorting');
+});
+
+test('DeviceBufferManager: "all" falls back to concatenation when no timestampOf', () => {
+  const mgr = new DeviceBufferManager({ capacityPerDevice: 10 });
+  mgr.push('d1', { v: 1 });
+  mgr.push('d1', { v: 2 });
+  mgr.push('d2', { v: 99 });
+
+  const all = mgr.getLast('all', 10);
+  // Exact order not guaranteed, but all 3 entries must be present.
+  assert.equal(all.length, 3);
+  const values = all.map((e) => e.v).sort((a, b) => a - b);
+  assert.deepEqual(values, [1, 2, 99]);
+});
+
+// ── filter ──
+
+test('DeviceBufferManager: filter scoped to one device', () => {
+  const mgr = new DeviceBufferManager({ capacityPerDevice: 10 });
+  mgr.push('d1', { url: '/users', v: 1 });
+  mgr.push('d1', { url: '/posts', v: 2 });
+  mgr.push('d2', { url: '/users', v: 3 });
+
+  const d1Users = mgr.filter('d1', (e) => e.url === '/users');
+  assert.deepEqual(d1Users.map((e) => e.v), [1]);
+});
+
+test('DeviceBufferManager: filter with "all" merges and sorts', () => {
+  const mgr = new DeviceBufferManager({
+    capacityPerDevice: 10,
+    timestampOf: (e) => e.ts,
+  });
+  mgr.push('d1', { ts: 300, url: '/users', v: 1 });
+  mgr.push('d2', { ts: 100, url: '/users', v: 2 });
+  mgr.push('d1', { ts: 200, url: '/posts', v: 3 });
+
+  const users = mgr.filter('all', (e) => e.url === '/users');
+  assert.deepEqual(users.map((e) => e.v), [2, 1], 'sorted by ts');
+});
+
+// ── getByKey ──
+
+test('DeviceBufferManager: getByKey with indexKey scoped to one device', () => {
+  const mgr = new DeviceBufferManager({
+    capacityPerDevice: 10,
+    indexKey: (e) => e.id,
+  });
+  mgr.push('d1', { id: 'req-1', url: '/users' });
+  mgr.push('d2', { id: 'req-2', url: '/posts' });
+
+  assert.equal(mgr.getByKey('d1', 'req-1')?.url, '/users');
+  assert.equal(mgr.getByKey('d1', 'req-2'), undefined, 'd1 does not see d2\'s req');
+  assert.equal(mgr.getByKey('d2', 'req-2')?.url, '/posts');
+});
+
+test('DeviceBufferManager: getByKey("all") searches all devices', () => {
+  const mgr = new DeviceBufferManager({
+    capacityPerDevice: 10,
+    indexKey: (e) => e.id,
+  });
+  mgr.push('d1', { id: 'req-1', url: '/users' });
+  mgr.push('d2', { id: 'req-2', url: '/posts' });
+
+  assert.equal(mgr.getByKey('all', 'req-1')?.url, '/users');
+  assert.equal(mgr.getByKey('all', 'req-2')?.url, '/posts');
+  assert.equal(mgr.getByKey('all', 'req-missing'), undefined);
+});
+
+// ── clear ──
+
+test('DeviceBufferManager: clear(deviceKey) wipes only that device', () => {
+  const mgr = new DeviceBufferManager({ capacityPerDevice: 10 });
+  mgr.push('d1', { v: 1 });
+  mgr.push('d2', { v: 2 });
+
+  mgr.clear('d1');
+  assert.equal(mgr.size('d1'), 0);
+  assert.equal(mgr.size('d2'), 1);
+});
+
+test('DeviceBufferManager: clear() with no args wipes every device', () => {
+  const mgr = new DeviceBufferManager({ capacityPerDevice: 10 });
+  mgr.push('d1', { v: 1 });
+  mgr.push('d2', { v: 2 });
+
+  mgr.clear();
+  assert.equal(mgr.deviceCount, 0);
+  assert.equal(mgr.totalSize, 0);
+});
+
+// ── Size tracking ──
+
+test('DeviceBufferManager: size/totalSize/deviceCount track correctly', () => {
+  const mgr = new DeviceBufferManager({ capacityPerDevice: 10 });
+  assert.equal(mgr.deviceCount, 0);
+  assert.equal(mgr.totalSize, 0);
+  assert.equal(mgr.size('never-seen'), 0);
+
+  mgr.push('d1', { v: 1 });
+  mgr.push('d1', { v: 2 });
+  mgr.push('d2', { v: 3 });
+
+  assert.equal(mgr.deviceCount, 2);
+  assert.equal(mgr.totalSize, 3);
+  assert.equal(mgr.size('d1'), 2);
+  assert.equal(mgr.size('d2'), 1);
+});
+
+test('DeviceBufferManager: deviceKeys() returns keys in last-push order', async () => {
+  const mgr = new DeviceBufferManager({ capacityPerDevice: 10 });
+  mgr.push('d1', { v: 1 });
+  await new Promise((r) => setTimeout(r, 5));
+  mgr.push('d2', { v: 2 });
+  await new Promise((r) => setTimeout(r, 5));
+  mgr.push('d3', { v: 3 });
+  await new Promise((r) => setTimeout(r, 5));
+  mgr.push('d1', { v: 4 }); // re-push moves d1 to most-recent
+
+  assert.deepEqual(mgr.deviceKeys(), ['d2', 'd3', 'd1']);
+});
+
+// ── Regression: the original stale-logs-across-devices bug ──
+
+test('DeviceBufferManager: switching device no longer leaks stale entries into the new device view', () => {
+  const mgr = new DeviceBufferManager({
+    capacityPerDevice: 10,
+    indexKey: (e) => e.id,
+  });
+
+  // Simulate iOS session
+  const iosKey = makeDeviceKey(8081, 'ios-target-1');
+  mgr.push(iosKey, { id: 'req-old', method: 'GET', url: '/stale', timestamp: '2026-04-01T00:00:00Z' });
+
+  // Switch to Android — different key
+  const androidKey = makeDeviceKey(8081, 'android-target-1');
+  mgr.push(androidKey, { id: 'req-new', method: 'GET', url: '/fresh', timestamp: '2026-04-20T00:00:00Z' });
+
+  assert.deepEqual(
+    mgr.getLast(androidKey, 10).map((e) => e.url),
+    ['/fresh'],
+    'android view contains ONLY android traffic',
+  );
+  assert.equal(
+    mgr.getByKey(androidKey, 'req-old'),
+    undefined,
+    'iOS request id is invisible from android device scope',
+  );
+});

--- a/scripts/cdp-bridge/test/unit/tool-handlers-cdp2.test.js
+++ b/scripts/cdp-bridge/test/unit/tool-handlers-cdp2.test.js
@@ -74,8 +74,8 @@ test('interact: returns warnResult when action_executed with handler_error', asy
 
 test('network_log: returns entries from buffer', async () => {
   const client = createMockClient();
-  client.networkBuffer.push({ id: 'req1', method: 'GET', url: 'https://api.example.com/users', timestamp: '2026-04-13T00:00:00Z', status: 200 });
-  client.networkBuffer.push({ id: 'req2', method: 'POST', url: 'https://api.example.com/login', timestamp: '2026-04-13T00:00:01Z', status: 401 });
+  client.networkBufferManager.push(client.activeDeviceKey,{ id: 'req1', method: 'GET', url: 'https://api.example.com/users', timestamp: '2026-04-13T00:00:00Z', status: 200 });
+  client.networkBufferManager.push(client.activeDeviceKey,{ id: 'req2', method: 'POST', url: 'https://api.example.com/login', timestamp: '2026-04-13T00:00:01Z', status: 401 });
   const handler = createNetworkLogHandler(() => client);
   const data = expectOk(await handler({ limit: 10, clear: false }));
   assert.equal(data.count, 2);
@@ -84,8 +84,8 @@ test('network_log: returns entries from buffer', async () => {
 
 test('network_log: filters entries by URL substring', async () => {
   const client = createMockClient();
-  client.networkBuffer.push({ id: 'req1', method: 'GET', url: 'https://api.example.com/users', timestamp: '2026-04-13T00:00:00Z', status: 200 });
-  client.networkBuffer.push({ id: 'req2', method: 'GET', url: 'https://cdn.example.com/image.png', timestamp: '2026-04-13T00:00:01Z', status: 200 });
+  client.networkBufferManager.push(client.activeDeviceKey,{ id: 'req1', method: 'GET', url: 'https://api.example.com/users', timestamp: '2026-04-13T00:00:00Z', status: 200 });
+  client.networkBufferManager.push(client.activeDeviceKey,{ id: 'req2', method: 'GET', url: 'https://cdn.example.com/image.png', timestamp: '2026-04-13T00:00:01Z', status: 200 });
   const handler = createNetworkLogHandler(() => client);
   const data = expectOk(await handler({ limit: 10, filter: 'api.example', clear: false }));
   assert.equal(data.count, 1);
@@ -94,7 +94,7 @@ test('network_log: filters entries by URL substring', async () => {
 
 test('network_log: clear mode empties buffer', async () => {
   const client = createMockClient();
-  client.networkBuffer.push({ id: 'req1', method: 'GET', url: 'https://api.example.com/users', timestamp: '2026-04-13T00:00:00Z', status: 200 });
+  client.networkBufferManager.push(client.activeDeviceKey,{ id: 'req1', method: 'GET', url: 'https://api.example.com/users', timestamp: '2026-04-13T00:00:00Z', status: 200 });
   const handler = createNetworkLogHandler(() => client);
   const data = expectOk(await handler({ limit: 10, clear: true }));
   assert.equal(data.cleared, true);
@@ -105,7 +105,7 @@ test('network_log: clear mode empties buffer', async () => {
 test('network_log: clamps limit to [1, 100]', async () => {
   const client = createMockClient();
   for (let i = 0; i < 5; i++) {
-    client.networkBuffer.push({ id: `req${i}`, method: 'GET', url: `https://api.example.com/${i}`, timestamp: '2026-04-13T00:00:00Z', status: 200 });
+    client.networkBufferManager.push(client.activeDeviceKey,{ id: `req${i}`, method: 'GET', url: `https://api.example.com/${i}`, timestamp: '2026-04-13T00:00:00Z', status: 200 });
   }
   const handler = createNetworkLogHandler(() => client);
   const dataLow = expectOk(await handler({ limit: 0, clear: false }));
@@ -128,7 +128,7 @@ test('network_body: CDP path success', async () => {
       return {};
     },
   });
-  client.networkBuffer.push({ id: 'req1', method: 'GET', url: 'https://api.example.com/users', timestamp: '2026-04-13T00:00:00Z', status: 200 });
+  client.networkBufferManager.push(client.activeDeviceKey,{ id: 'req1', method: 'GET', url: 'https://api.example.com/users', timestamp: '2026-04-13T00:00:00Z', status: 200 });
   const handler = createNetworkBodyHandler(() => client);
   const data = expectOk(await handler({ requestId: 'req1' }));
   assert.equal(data.source, 'cdp');
@@ -147,7 +147,7 @@ test('network_body: hook path success', async () => {
     _networkMode: 'hook',
     evaluate: async () => ({ value: JSON.stringify({ body: '{"data":"test"}' }) }),
   });
-  client.networkBuffer.push({ id: 'hook-req1', method: 'GET', url: 'https://api.example.com/data', timestamp: '2026-04-13T00:00:00Z', status: 200 });
+  client.networkBufferManager.push(client.activeDeviceKey,{ id: 'hook-req1', method: 'GET', url: 'https://api.example.com/data', timestamp: '2026-04-13T00:00:00Z', status: 200 });
   const handler = createNetworkBodyHandler(() => client);
   const data = expectOk(await handler({ requestId: 'hook-req1' }));
   assert.equal(data.source, 'hook');
@@ -159,7 +159,7 @@ test('network_body: hook path cache miss returns failResult', async () => {
     _networkMode: 'hook',
     evaluate: async () => ({ value: JSON.stringify({ error: 'not_found' }) }),
   });
-  client.networkBuffer.push({ id: 'hook-req2', method: 'GET', url: 'https://api.example.com/other', timestamp: '2026-04-13T00:00:00Z', status: 200 });
+  client.networkBufferManager.push(client.activeDeviceKey,{ id: 'hook-req2', method: 'GET', url: 'https://api.example.com/other', timestamp: '2026-04-13T00:00:00Z', status: 200 });
   const handler = createNetworkBodyHandler(() => client);
   const error = expectFail(await handler({ requestId: 'hook-req2' }));
   assert.match(error, /not in cache/);
@@ -167,7 +167,7 @@ test('network_body: hook path cache miss returns failResult', async () => {
 
 test('network_body: no network mode returns failResult', async () => {
   const client = createMockClient({ _networkMode: 'none' });
-  client.networkBuffer.push({ id: 'req-none', method: 'GET', url: 'https://api.example.com/test', timestamp: '2026-04-13T00:00:00Z', status: 200 });
+  client.networkBufferManager.push(client.activeDeviceKey,{ id: 'req-none', method: 'GET', url: 'https://api.example.com/test', timestamp: '2026-04-13T00:00:00Z', status: 200 });
   const handler = createNetworkBodyHandler(() => client);
   const error = expectFail(await handler({ requestId: 'req-none' }));
   assert.match(error, /not active/);
@@ -191,7 +191,7 @@ test('network_body: truncates body when exceeding maxLength', async () => {
       return {};
     },
   });
-  client.networkBuffer.push({ id: 'big-req', method: 'GET', url: 'https://api.example.com/big', timestamp: '2026-04-13T00:00:00Z', status: 200 });
+  client.networkBufferManager.push(client.activeDeviceKey,{ id: 'big-req', method: 'GET', url: 'https://api.example.com/big', timestamp: '2026-04-13T00:00:00Z', status: 200 });
   const handler = createNetworkBodyHandler(() => client);
   const result = await handler({ requestId: 'big-req', maxLength: 100 });
   const env = parseEnvelope(result);


### PR DESCRIPTION
## Summary

- **M4 (Phase 90 Tier 2 metro-mcp adoption)** — stops stale network traffic from one simulator bleeding into queries made after switching to another simulator.
- New \`DeviceBufferManager<T, K>\` keyed by \`\${metroPort}-\${targetId}\`. Per-device capacity 100, max 10 devices, evict-oldest-by-last-push.
- Cross-device aggregation via \`device: 'all'\` with timestamp-sorted merge.
- \`cdp_network_log\` + \`cdp_network_body\` gain optional \`device\` arg (default active, \`'all'\` for union).

## Scope

**Migrated:** \`_networkBuffer\` (the only MCP-side-consumed buffer today).

**NOT migrated (intentional, not deferral):** \`consoleBuffer\` + \`logBuffer\` — no MCP-side tool reads them; \`cdp_console_log\` pulls from the app's JS context. Migrating would be churn.

## Multi-review

Both reviewers said "ship it". Two informational observations captured in D655:
1. In-flight request across target switch: response lookup misses bucket B if request was in A. Rare; acceptable tradeoff.
2. \`timestampOf\` NaN robustness: low-priority hardening opportunity.

## Test plan

- [x] \`npm run build\` — zero TS errors
- [x] \`npm test\` — 386 → **406 passing** (20 new + 6 updated)
- [x] Multi-review pass 1 (both "ship it")
- [ ] Manual smoke (user): make network requests on iOS, switch simulator to Android, call \`cdp_network_log\` — expect ONLY Android traffic. Call \`cdp_network_log({device: 'all'})\` — expect both sessions merged chronologically.

## Refs

- D655 (DECISIONS.md)
- Phase 101 (ROADMAP.md)
- metro-mcp \`src/utils/buffer.ts\` (reference pattern)