### PR TITLE
feat(m5): Metro /events WS subscriber — Phase 90 Tier 2 (D656)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/scripts/cdp-bridge/dist/cdp-client.js
+++ b/scripts/cdp-bridge/dist/cdp-client.js
@@ -1,5 +1,6 @@
 import WebSocket from 'ws';
 import { RingBuffer, DeviceBufferManager, makeDeviceKey } from './ring-buffer.js';
+import { MetroEventsClient } from './metro/events-client.js';
 import { detectBridge } from './bridge-detector.js';
 import { logger } from './logger.js';
 import { performSetup, reinjectHelpers as reinjectHelpersFn } from './cdp/setup.js';
@@ -36,6 +37,7 @@ export class CDPClient {
     _logDomainEnabled = false;
     _profilerAvailable = false;
     _heapProfilerAvailable = false;
+    _metroEventsClient = null;
     // Tier 3: scriptParsed cache (D592)
     _scripts = new Map();
     // Tier 3: reconnection state visibility (D596)
@@ -64,6 +66,8 @@ export class CDPClient {
     get networkBufferManager() { return this._networkBufferManager; }
     /** M4 (D655): the device key for the currently connected target. Used as the default scope for per-device buffer queries. */
     get activeDeviceKey() { return makeDeviceKey(this._port, this._connectedTarget?.id); }
+    /** M5 (D656): Metro /events subscriber; null until first successful CDP setup attaches it. */
+    get metroEventsClient() { return this._metroEventsClient; }
     get connectionGeneration() { return this._connectionGeneration; }
     get bridgeDetected() { return this._bridgeDetected; }
     get bridgeVersion() { return this._bridgeVersion; }
@@ -118,6 +122,14 @@ export class CDPClient {
         resetState(this.buildResettableState());
         clearActiveFlag();
         this.stopBackgroundPoll();
+        // M5 (D656): tear down Metro /events subscriber alongside CDP shutdown.
+        if (this._metroEventsClient) {
+            try {
+                this._metroEventsClient.stop();
+            }
+            catch { /* best-effort */ }
+            this._metroEventsClient = null;
+        }
         if (this.ws) {
             this.ws.removeAllListeners();
             if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {
@@ -224,6 +236,10 @@ export class CDPClient {
         parseNetHook(params, this._networkMode, this._networkBufferManager, this.activeDeviceKey);
     }
     async setup() {
+        // M5 (D656): attach Metro /events subscriber on every setup. Idempotent for the
+        // common reconnect case (start() is a no-op when already open). Fire-and-forget —
+        // failure to connect events WS must not block CDP setup.
+        this.ensureMetroEventsClient().catch(() => { });
         const result = await performSetup({
             send: (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)),
             evaluate: (expr) => this.evaluate(expr),
@@ -243,6 +259,21 @@ export class CDPClient {
         if (result.helpersInjected) {
             detectBridge(this).then((r) => { this._bridgeDetected = r.present; this._bridgeVersion = r.version; logger.debug('CDP', `Bridge detection: present=${r.present}, version=${r.version}`); }).catch(() => { });
         }
+    }
+    async ensureMetroEventsClient() {
+        // Multi-review catch: if Metro hopped ports (CDPClient's `_port` was updated
+        // via discovery), the existing MetroEventsClient is still bound to the old
+        // port and would silently reconnect-forever to a dead endpoint. Detect the
+        // mismatch and swap in a fresh client. Covers the Metro-restart-on-new-port
+        // scenario this story is supposed to handle gracefully.
+        if (this._metroEventsClient && this._metroEventsClient.port !== this._port) {
+            this._metroEventsClient.stop();
+            this._metroEventsClient = null;
+        }
+        if (!this._metroEventsClient) {
+            this._metroEventsClient = new MetroEventsClient({ port: this._port });
+        }
+        await this._metroEventsClient.start();
     }
     setupEventHandlers() {
         wireEventHandlers(this.eventHandlers, { console: this._consoleBuffer, network: this._networkBufferManager, log: this._logBuffer, scripts: this._scripts }, (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)), () => this._isPaused, (v) => { this._isPaused = v; }, () => this.activeDeviceKey);

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -46,6 +46,7 @@ import { createMaestroGenerateHandler } from './tools/maestro-generate.js';
 import { createMaestroTestAllHandler } from './tools/maestro-test-all.js';
 import { createCrossPlatformVerifyHandler } from './tools/cross-platform-verify.js';
 import { createOpenDevToolsHandler } from './tools/open-devtools.js';
+import { createMetroEventsHandler } from './tools/metro-events.js';
 import { stopFastRunner } from './fast-runner-session.js';
 import { instrumentTool, pruneOldTelemetry, autoCompactIfNeeded } from './experience/index.js';
 const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
@@ -474,6 +475,11 @@ trackedTool('cross_platform_verify', 'Compare UI elements across iOS and Android
     matchBy: z.enum(['testID', 'label', 'any']).default('any').describe('Match strategy: testID (exact identifier match), label (substring in accessibility label), any (try both)'),
 }, createCrossPlatformVerifyHandler());
 trackedTool('cdp_open_devtools', 'Report the React Native DevTools frontend URL for the live app + whether DevTools can coexist with the MCP session (RN >= 0.85 native multi-debugger). M1 (Phase 90 Tier 1) ships detection + capability reporting; full proxy auto-wiring for RN < 0.85 is tracked as M1b/Phase 100. Returns { devtoolsUrl, inspectorWsUrl, mode, supportsMultipleDebuggers, rnVersion, guidance }.', {}, createOpenDevToolsHandler(getClient));
+trackedTool('cdp_metro_events', 'Read Metro reporter events (bundle_build_started, bundle_build_done, bundle_build_failed, reloads) captured since the MCP connected. M5 (Phase 90 Tier 2 / D656): the MetroEventsClient attaches a second WebSocket alongside CDP, giving push-based visibility into bundler state — watch for build errors without having to read console.error. Returns { eventsConnected, lastBuild, buildErrors, events, count }. Pass `clearErrors: true` to reset the build-error counter.', {
+    limit: z.number().int().min(1).max(100).default(20).describe('Max entries to return (default 20, max 100)'),
+    type: z.string().optional().describe('Filter by event type (e.g. "bundle_build_failed")'),
+    clearErrors: z.boolean().default(false).describe('Reset the build-error counter without reading events'),
+}, createMetroEventsHandler(getClient));
 // B76/D644: unified process-lifecycle shutdown. All termination signals + stdin.end
 // funnel into this graceful path so the 5s background-poll setInterval in
 // reconnection.ts (the zombie cause) is cleared on every exit.

--- a/scripts/cdp-bridge/dist/metro/events-client.js
+++ b/scripts/cdp-bridge/dist/metro/events-client.js
@@ -1,0 +1,209 @@
+import WebSocket from 'ws';
+import { logger } from '../logger.js';
+import { computeReconnectDelay } from '../cdp/reconnection.js';
+import { RingBuffer } from '../ring-buffer.js';
+export class MetroEventsClient {
+    opts;
+    ws = null;
+    state = 'stopped';
+    reconnectTimer = null;
+    reconnectAttempt = 0;
+    _lastBuild = null;
+    _buildErrors = 0;
+    events;
+    constructor(options) {
+        this.opts = {
+            host: options.host ?? '127.0.0.1',
+            port: options.port,
+            bufferCapacity: options.bufferCapacity ?? 100,
+            logTag: options.logTag ?? 'Metro.events',
+            maxReconnectAttempts: options.maxReconnectAttempts ?? 0,
+            onEvent: options.onEvent,
+        };
+        this.events = new RingBuffer(this.opts.bufferCapacity);
+    }
+    get isConnected() {
+        return this.state === 'open';
+    }
+    get lastBuild() {
+        return this._lastBuild;
+    }
+    get buildErrors() {
+        return this._buildErrors;
+    }
+    /** Port this client is attached to. Immutable after construction — if Metro hops ports, the caller must stop() and construct a fresh client. */
+    get port() {
+        return this.opts.port;
+    }
+    /**
+     * Open the WS connection. Idempotent — calling while already open is a no-op.
+     * Resolves when the connection is established OR when the initial attempt fails
+     * (auto-reconnect continues in the background). Never throws — failures log and
+     * schedule a retry.
+     *
+     * If a reconnect is already scheduled (state === 'reconnecting'), we pre-empt
+     * the pending timer and attempt immediately. This prevents a parallel
+     * `connectOnce()` race (multi-review catch: without the preempt, the scheduled
+     * timer would fire after our successful open and create a second WebSocket).
+     */
+    async start() {
+        if (this.state === 'open' || this.state === 'connecting')
+            return;
+        if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = null;
+        }
+        await this.connectOnce();
+    }
+    /**
+     * Stop the client and cancel any pending reconnect. Idempotent — safe to call
+     * from shutdown hooks and on disconnect flows. Does not flush the events buffer.
+     *
+     * Edge case (multi-review pass 2 catch): when `ws` is in `CONNECTING` state,
+     * calling `close()` triggers the ws library's `abortHandshake()` which
+     * asynchronously emits an `'error'` event ("WebSocket was closed before the
+     * connection was established"). Because we `removeAllListeners()` first to
+     * prevent our handlers from running after stop, the emitted error has no
+     * listener — Node's EventEmitter contract crashes the process via
+     * `uncaughtException`. Workaround: re-attach a no-op error listener AFTER
+     * removing all listeners, BEFORE calling close. Reachable in practice via
+     * port-swap in `ensureMetroEventsClient`, SIGTERM during initial CDP setup,
+     * or the fire-and-forget race in `CDPClient.setup()`.
+     */
+    stop() {
+        if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = null;
+        }
+        if (this.ws) {
+            try {
+                this.ws.removeAllListeners();
+            }
+            catch { /* ignore */ }
+            // Swallow the handshake-abort error that fires on close() against a
+            // CONNECTING socket. No-op on already-OPEN or already-CLOSED sockets.
+            this.ws.on('error', () => { });
+            try {
+                this.ws.close(1000, 'client stopping');
+            }
+            catch { /* ignore */ }
+            this.ws = null;
+        }
+        this.state = 'stopped';
+        this.reconnectAttempt = 0;
+    }
+    /** Reset the build-error counter. Useful when the user acknowledges errors. */
+    clearBuildErrors() {
+        this._buildErrors = 0;
+    }
+    async connectOnce() {
+        this.state = 'connecting';
+        const url = `ws://${this.opts.host}:${this.opts.port}/events`;
+        return new Promise((resolve) => {
+            const ws = new WebSocket(url);
+            this.ws = ws;
+            // Multi-review catch: on ECONNREFUSED / handshake failures, the `ws` library
+            // fires BOTH `error` and `close` for the same failure. Without this `outcome`
+            // guard, each event scheduled a reconnect independently → 2 timers pending,
+            // `reconnectAttempt` incrementing 2× per real cycle, the M2 backoff curve
+            // effectively doubled.  The guard also covers the win-race between happy-path
+            // open and a stray late `close` (which shouldn't happen in practice but
+            // costs us nothing to defend against).
+            let outcome = null;
+            const onOpen = () => {
+                if (outcome !== null)
+                    return;
+                outcome = 'open';
+                this.state = 'open';
+                this.reconnectAttempt = 0;
+                logger.info(this.opts.logTag, `connected to ${url}`);
+                resolve();
+            };
+            const onFail = (reason) => {
+                if (outcome !== null)
+                    return;
+                outcome = 'failed';
+                logger.debug(this.opts.logTag, `connect failed: ${reason}`);
+                this.scheduleReconnect();
+                resolve();
+            };
+            ws.once('open', onOpen);
+            ws.once('error', (err) => onFail(err instanceof Error ? err.message : String(err)));
+            ws.on('message', (data) => this.onMessage(data));
+            ws.on('close', (code) => {
+                // If the connection never opened, treat close as a connection failure.
+                // Otherwise, route to the long-lived close handler (schedules reconnect
+                // via its own path — which is also guarded by scheduleReconnect's
+                // `reconnectTimer` no-double-schedule check below).
+                if (outcome === null) {
+                    onFail(`close code ${code} before open`);
+                }
+                else {
+                    this.onClose(code);
+                }
+            });
+        });
+    }
+    onMessage(data) {
+        let parsed;
+        try {
+            parsed = JSON.parse(data.toString());
+        }
+        catch {
+            logger.debug(this.opts.logTag, 'dropped non-JSON event message');
+            return;
+        }
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed))
+            return;
+        const raw = parsed;
+        const type = typeof raw.type === 'string' ? raw.type : 'unknown';
+        const event = {
+            type,
+            timestamp: new Date().toISOString(),
+            payload: raw,
+        };
+        this.events.push(event);
+        // Update convenience accessors for build state — these power cdp_status.metro
+        if (type === 'bundle_build_started') {
+            this._lastBuild = { status: 'started', timestamp: event.timestamp };
+        }
+        else if (type === 'bundle_build_done') {
+            this._lastBuild = { status: 'done', timestamp: event.timestamp };
+        }
+        else if (type === 'bundle_build_failed') {
+            this._lastBuild = { status: 'failed', timestamp: event.timestamp };
+            this._buildErrors++;
+        }
+        this.opts.onEvent?.(event);
+    }
+    onClose(code) {
+        if (this.state === 'stopped')
+            return;
+        this.ws = null;
+        logger.debug(this.opts.logTag, `ws closed (code=${code})`);
+        this.scheduleReconnect();
+    }
+    scheduleReconnect() {
+        if (this.state === 'stopped')
+            return;
+        // Defense-in-depth against duplicate schedules. The connectOnce `outcome` flag
+        // handles the initial-connect error+close race; this handles any other duplicate
+        // pathway (e.g. stop()+start() reusing the instance while a timer is mid-flight).
+        if (this.reconnectTimer !== null)
+            return;
+        this.reconnectAttempt++;
+        if (this.opts.maxReconnectAttempts > 0 && this.reconnectAttempt > this.opts.maxReconnectAttempts) {
+            logger.warn(this.opts.logTag, `max reconnect attempts (${this.opts.maxReconnectAttempts}) exceeded, giving up`);
+            this.state = 'stopped';
+            return;
+        }
+        this.state = 'reconnecting';
+        const delayMs = computeReconnectDelay(this.reconnectAttempt);
+        this.reconnectTimer = setTimeout(() => {
+            this.reconnectTimer = null;
+            if (this.state === 'stopped')
+                return;
+            void this.connectOnce();
+        }, delayMs);
+    }
+}

--- a/scripts/cdp-bridge/dist/tools/metro-events.js
+++ b/scripts/cdp-bridge/dist/tools/metro-events.js
@@ -1,0 +1,48 @@
+import { okResult, withConnection } from '../utils.js';
+/**
+ * cdp_metro_events — M5 / Phase 90 Tier 2.
+ *
+ * Read recent Metro reporter events (bundle_build_started, bundle_build_done,
+ * bundle_build_failed, ...) captured by the MetroEventsClient that attaches
+ * alongside every CDP session. Supports filtering by event type and clearing
+ * the build-error counter.
+ */
+export function createMetroEventsHandler(getClient) {
+    return withConnection(getClient, async (args, client) => {
+        const metroEvents = client.metroEventsClient;
+        if (!metroEvents) {
+            return okResult({
+                eventsConnected: false,
+                events: [],
+                count: 0,
+                lastBuild: null,
+                buildErrors: 0,
+                hint: 'Metro events client has not started. This should attach automatically when CDP connects. If you see this, the events WS may have failed to open (port mismatch, Metro not serving /events on this version).',
+            });
+        }
+        if (args.clearErrors) {
+            metroEvents.clearBuildErrors();
+            return okResult({
+                eventsConnected: metroEvents.isConnected,
+                cleared: true,
+                lastBuild: metroEvents.lastBuild,
+                buildErrors: metroEvents.buildErrors,
+            });
+        }
+        const limit = Math.min(Math.max(args.limit ?? 20, 1), 100);
+        let entries = metroEvents.events.getLast(metroEvents.events.size);
+        if (args.type) {
+            entries = entries.filter((e) => e.type === args.type);
+        }
+        if (entries.length > limit) {
+            entries = entries.slice(-limit);
+        }
+        return okResult({
+            eventsConnected: metroEvents.isConnected,
+            lastBuild: metroEvents.lastBuild,
+            buildErrors: metroEvents.buildErrors,
+            count: entries.length,
+            events: entries,
+        });
+    });
+}

--- a/scripts/cdp-bridge/dist/tools/status.js
+++ b/scripts/cdp-bridge/dist/tools/status.js
@@ -35,8 +35,15 @@ async function buildStatusResult(client) {
             catch { /* probe failed */ }
         }
     }
+    const metroEvents = client.metroEventsClient;
     return {
-        metro: { running: true, port: client.metroPort },
+        metro: {
+            running: true,
+            port: client.metroPort,
+            eventsConnected: metroEvents?.isConnected ?? false,
+            lastBuild: metroEvents?.lastBuild ?? null,
+            buildErrors: metroEvents?.buildErrors ?? 0,
+        },
         cdp: { connected: client.isConnected, device: client.connectedTarget?.title ?? null, pageId: client.connectedTarget?.id ?? null, platform: client.connectedTarget?.platform ?? null, bundleId: client.connectedTarget?.description ?? null },
         app: {
             platform: appInfo?.platform ?? null,

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/cdp-client.ts
+++ b/scripts/cdp-bridge/src/cdp-client.ts
@@ -1,5 +1,6 @@
 import WebSocket from 'ws';
 import { RingBuffer, DeviceBufferManager, makeDeviceKey } from './ring-buffer.js';
+import { MetroEventsClient } from './metro/events-client.js';
 import { detectBridge } from './bridge-detector.js';
 import { logger } from './logger.js';
 import { performSetup, reinjectHelpers as reinjectHelpersFn } from './cdp/setup.js';
@@ -60,6 +61,7 @@ export class CDPClient {
   private _logDomainEnabled = false;
   private _profilerAvailable = false;
   private _heapProfilerAvailable = false;
+  private _metroEventsClient: MetroEventsClient | null = null;
 
   // Tier 3: scriptParsed cache (D592)
   private _scripts = new Map<string, { scriptId: string; url: string; startLine: number; endLine: number }>();
@@ -91,6 +93,8 @@ export class CDPClient {
   get networkBufferManager(): DeviceBufferManager<NetworkEntry, string> { return this._networkBufferManager; }
   /** M4 (D655): the device key for the currently connected target. Used as the default scope for per-device buffer queries. */
   get activeDeviceKey(): string { return makeDeviceKey(this._port, this._connectedTarget?.id); }
+  /** M5 (D656): Metro /events subscriber; null until first successful CDP setup attaches it. */
+  get metroEventsClient(): MetroEventsClient | null { return this._metroEventsClient; }
   get connectionGeneration(): number { return this._connectionGeneration; }
   get bridgeDetected(): boolean { return this._bridgeDetected; }
   get bridgeVersion(): number | null { return this._bridgeVersion; }
@@ -155,6 +159,12 @@ export class CDPClient {
     resetState(this.buildResettableState());
     clearActiveFlag();
     this.stopBackgroundPoll();
+
+    // M5 (D656): tear down Metro /events subscriber alongside CDP shutdown.
+    if (this._metroEventsClient) {
+      try { this._metroEventsClient.stop(); } catch { /* best-effort */ }
+      this._metroEventsClient = null;
+    }
 
     if (this.ws) {
       this.ws.removeAllListeners();
@@ -276,6 +286,11 @@ export class CDPClient {
   }
 
   private async setup(): Promise<void> {
+    // M5 (D656): attach Metro /events subscriber on every setup. Idempotent for the
+    // common reconnect case (start() is a no-op when already open). Fire-and-forget —
+    // failure to connect events WS must not block CDP setup.
+    this.ensureMetroEventsClient().catch(() => { /* MetroEventsClient handles its own reconnects */ });
+
     const result = await performSetup({
       send: (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)),
       evaluate: (expr) => this.evaluate(expr),
@@ -295,6 +310,22 @@ export class CDPClient {
     if (result.helpersInjected) {
       detectBridge(this).then((r) => { this._bridgeDetected = r.present; this._bridgeVersion = r.version; logger.debug('CDP', `Bridge detection: present=${r.present}, version=${r.version}`); }).catch(() => {});
     }
+  }
+
+  private async ensureMetroEventsClient(): Promise<void> {
+    // Multi-review catch: if Metro hopped ports (CDPClient's `_port` was updated
+    // via discovery), the existing MetroEventsClient is still bound to the old
+    // port and would silently reconnect-forever to a dead endpoint. Detect the
+    // mismatch and swap in a fresh client. Covers the Metro-restart-on-new-port
+    // scenario this story is supposed to handle gracefully.
+    if (this._metroEventsClient && this._metroEventsClient.port !== this._port) {
+      this._metroEventsClient.stop();
+      this._metroEventsClient = null;
+    }
+    if (!this._metroEventsClient) {
+      this._metroEventsClient = new MetroEventsClient({ port: this._port });
+    }
+    await this._metroEventsClient.start();
   }
 
   private setupEventHandlers(): void {

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -63,6 +63,7 @@ import { createMaestroGenerateHandler } from './tools/maestro-generate.js';
 import { createMaestroTestAllHandler } from './tools/maestro-test-all.js';
 import { createCrossPlatformVerifyHandler } from './tools/cross-platform-verify.js';
 import { createOpenDevToolsHandler } from './tools/open-devtools.js';
+import { createMetroEventsHandler } from './tools/metro-events.js';
 import { stopFastRunner } from './fast-runner-session.js';
 import { instrumentTool, pruneOldTelemetry, autoCompactIfNeeded } from './experience/index.js';
 
@@ -798,6 +799,17 @@ trackedTool(
   'Report the React Native DevTools frontend URL for the live app + whether DevTools can coexist with the MCP session (RN >= 0.85 native multi-debugger). M1 (Phase 90 Tier 1) ships detection + capability reporting; full proxy auto-wiring for RN < 0.85 is tracked as M1b/Phase 100. Returns { devtoolsUrl, inspectorWsUrl, mode, supportsMultipleDebuggers, rnVersion, guidance }.',
   {},
   createOpenDevToolsHandler(getClient),
+);
+
+trackedTool(
+  'cdp_metro_events',
+  'Read Metro reporter events (bundle_build_started, bundle_build_done, bundle_build_failed, reloads) captured since the MCP connected. M5 (Phase 90 Tier 2 / D656): the MetroEventsClient attaches a second WebSocket alongside CDP, giving push-based visibility into bundler state — watch for build errors without having to read console.error. Returns { eventsConnected, lastBuild, buildErrors, events, count }. Pass `clearErrors: true` to reset the build-error counter.',
+  {
+    limit: z.number().int().min(1).max(100).default(20).describe('Max entries to return (default 20, max 100)'),
+    type: z.string().optional().describe('Filter by event type (e.g. "bundle_build_failed")'),
+    clearErrors: z.boolean().default(false).describe('Reset the build-error counter without reading events'),
+  },
+  createMetroEventsHandler(getClient),
 );
 
 // B76/D644: unified process-lifecycle shutdown. All termination signals + stdin.end

--- a/scripts/cdp-bridge/src/metro/events-client.ts
+++ b/scripts/cdp-bridge/src/metro/events-client.ts
@@ -1,0 +1,262 @@
+import WebSocket from 'ws';
+
+import { logger } from '../logger.js';
+import { computeReconnectDelay } from '../cdp/reconnection.js';
+import { RingBuffer } from '../ring-buffer.js';
+
+/**
+ * Metro `/events` WebSocket subscriber (M5 / Phase 90 Tier 2).
+ *
+ * Metro's Dev Server exposes a WebSocket at `ws://${host}:${port}/events` that
+ * broadcasts all reporter events (bundle build_started / build_done / build_failed,
+ * reload signals, and others). No registration required — every client sees
+ * every event. This module connects once on CDP open and keeps the connection
+ * alive across Metro restarts via the same exponential-backoff curve that
+ * reconnection.ts uses for Hermes (M2 / D653).
+ *
+ * Concrete signals surfaced today:
+ *   - `bundle_build_started` — a bundle is being compiled
+ *   - `bundle_build_done` — bundle compiled successfully
+ *   - `bundle_build_failed` — bundle had a build error (syntax, missing dep, etc)
+ *
+ * The client exposes:
+ *   - `lastBuild`: the most recent build status ('started' | 'done' | 'failed' | null)
+ *   - `buildErrors`: count of `bundle_build_failed` events observed since start
+ *   - a `RingBuffer` of recent events queryable via `cdp_metro_events`
+ */
+
+export interface MetroEvent {
+  type: string;
+  timestamp: string;
+  payload: Record<string, unknown>;
+}
+
+export interface MetroEventsClientOptions {
+  host?: string;
+  port: number;
+  /** Ring buffer capacity for captured events. Default: 100. */
+  bufferCapacity?: number;
+  /** Optional callback invoked for every event (useful for tests). */
+  onEvent?: (event: MetroEvent) => void;
+  logTag?: string;
+  /** Max reconnect attempts per stop-start cycle. Default: unlimited (0 = off). */
+  maxReconnectAttempts?: number;
+}
+
+export type BuildStatus = 'started' | 'done' | 'failed';
+
+type State = 'stopped' | 'connecting' | 'open' | 'reconnecting';
+
+export class MetroEventsClient {
+  private readonly opts: Required<Omit<MetroEventsClientOptions, 'onEvent'>> & {
+    onEvent?: (event: MetroEvent) => void;
+  };
+  private ws: WebSocket | null = null;
+  private state: State = 'stopped';
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempt = 0;
+  private _lastBuild: { status: BuildStatus; timestamp: string } | null = null;
+  private _buildErrors = 0;
+  readonly events: RingBuffer<MetroEvent>;
+
+  constructor(options: MetroEventsClientOptions) {
+    this.opts = {
+      host: options.host ?? '127.0.0.1',
+      port: options.port,
+      bufferCapacity: options.bufferCapacity ?? 100,
+      logTag: options.logTag ?? 'Metro.events',
+      maxReconnectAttempts: options.maxReconnectAttempts ?? 0,
+      onEvent: options.onEvent,
+    };
+    this.events = new RingBuffer<MetroEvent>(this.opts.bufferCapacity);
+  }
+
+  get isConnected(): boolean {
+    return this.state === 'open';
+  }
+
+  get lastBuild(): { status: BuildStatus; timestamp: string } | null {
+    return this._lastBuild;
+  }
+
+  get buildErrors(): number {
+    return this._buildErrors;
+  }
+
+  /** Port this client is attached to. Immutable after construction — if Metro hops ports, the caller must stop() and construct a fresh client. */
+  get port(): number {
+    return this.opts.port;
+  }
+
+  /**
+   * Open the WS connection. Idempotent — calling while already open is a no-op.
+   * Resolves when the connection is established OR when the initial attempt fails
+   * (auto-reconnect continues in the background). Never throws — failures log and
+   * schedule a retry.
+   *
+   * If a reconnect is already scheduled (state === 'reconnecting'), we pre-empt
+   * the pending timer and attempt immediately. This prevents a parallel
+   * `connectOnce()` race (multi-review catch: without the preempt, the scheduled
+   * timer would fire after our successful open and create a second WebSocket).
+   */
+  async start(): Promise<void> {
+    if (this.state === 'open' || this.state === 'connecting') return;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    await this.connectOnce();
+  }
+
+  /**
+   * Stop the client and cancel any pending reconnect. Idempotent — safe to call
+   * from shutdown hooks and on disconnect flows. Does not flush the events buffer.
+   *
+   * Edge case (multi-review pass 2 catch): when `ws` is in `CONNECTING` state,
+   * calling `close()` triggers the ws library's `abortHandshake()` which
+   * asynchronously emits an `'error'` event ("WebSocket was closed before the
+   * connection was established"). Because we `removeAllListeners()` first to
+   * prevent our handlers from running after stop, the emitted error has no
+   * listener — Node's EventEmitter contract crashes the process via
+   * `uncaughtException`. Workaround: re-attach a no-op error listener AFTER
+   * removing all listeners, BEFORE calling close. Reachable in practice via
+   * port-swap in `ensureMetroEventsClient`, SIGTERM during initial CDP setup,
+   * or the fire-and-forget race in `CDPClient.setup()`.
+   */
+  stop(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      try { this.ws.removeAllListeners(); } catch { /* ignore */ }
+      // Swallow the handshake-abort error that fires on close() against a
+      // CONNECTING socket. No-op on already-OPEN or already-CLOSED sockets.
+      this.ws.on('error', () => { /* post-stop error: swallow */ });
+      try { this.ws.close(1000, 'client stopping'); } catch { /* ignore */ }
+      this.ws = null;
+    }
+    this.state = 'stopped';
+    this.reconnectAttempt = 0;
+  }
+
+  /** Reset the build-error counter. Useful when the user acknowledges errors. */
+  clearBuildErrors(): void {
+    this._buildErrors = 0;
+  }
+
+  private async connectOnce(): Promise<void> {
+    this.state = 'connecting';
+    const url = `ws://${this.opts.host}:${this.opts.port}/events`;
+
+    return new Promise<void>((resolve) => {
+      const ws = new WebSocket(url);
+      this.ws = ws;
+
+      // Multi-review catch: on ECONNREFUSED / handshake failures, the `ws` library
+      // fires BOTH `error` and `close` for the same failure. Without this `outcome`
+      // guard, each event scheduled a reconnect independently → 2 timers pending,
+      // `reconnectAttempt` incrementing 2× per real cycle, the M2 backoff curve
+      // effectively doubled.  The guard also covers the win-race between happy-path
+      // open and a stray late `close` (which shouldn't happen in practice but
+      // costs us nothing to defend against).
+      let outcome: 'open' | 'failed' | null = null;
+
+      const onOpen = (): void => {
+        if (outcome !== null) return;
+        outcome = 'open';
+        this.state = 'open';
+        this.reconnectAttempt = 0;
+        logger.info(this.opts.logTag, `connected to ${url}`);
+        resolve();
+      };
+
+      const onFail = (reason: string): void => {
+        if (outcome !== null) return;
+        outcome = 'failed';
+        logger.debug(this.opts.logTag, `connect failed: ${reason}`);
+        this.scheduleReconnect();
+        resolve();
+      };
+
+      ws.once('open', onOpen);
+      ws.once('error', (err) => onFail(err instanceof Error ? err.message : String(err)));
+      ws.on('message', (data) => this.onMessage(data));
+      ws.on('close', (code) => {
+        // If the connection never opened, treat close as a connection failure.
+        // Otherwise, route to the long-lived close handler (schedules reconnect
+        // via its own path — which is also guarded by scheduleReconnect's
+        // `reconnectTimer` no-double-schedule check below).
+        if (outcome === null) {
+          onFail(`close code ${code} before open`);
+        } else {
+          this.onClose(code);
+        }
+      });
+    });
+  }
+
+  private onMessage(data: WebSocket.RawData): void {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(data.toString());
+    } catch {
+      logger.debug(this.opts.logTag, 'dropped non-JSON event message');
+      return;
+    }
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return;
+
+    const raw = parsed as Record<string, unknown>;
+    const type = typeof raw.type === 'string' ? raw.type : 'unknown';
+
+    const event: MetroEvent = {
+      type,
+      timestamp: new Date().toISOString(),
+      payload: raw,
+    };
+    this.events.push(event);
+
+    // Update convenience accessors for build state — these power cdp_status.metro
+    if (type === 'bundle_build_started') {
+      this._lastBuild = { status: 'started', timestamp: event.timestamp };
+    } else if (type === 'bundle_build_done') {
+      this._lastBuild = { status: 'done', timestamp: event.timestamp };
+    } else if (type === 'bundle_build_failed') {
+      this._lastBuild = { status: 'failed', timestamp: event.timestamp };
+      this._buildErrors++;
+    }
+
+    this.opts.onEvent?.(event);
+  }
+
+  private onClose(code: number): void {
+    if (this.state === 'stopped') return;
+    this.ws = null;
+    logger.debug(this.opts.logTag, `ws closed (code=${code})`);
+    this.scheduleReconnect();
+  }
+
+  private scheduleReconnect(): void {
+    if (this.state === 'stopped') return;
+    // Defense-in-depth against duplicate schedules. The connectOnce `outcome` flag
+    // handles the initial-connect error+close race; this handles any other duplicate
+    // pathway (e.g. stop()+start() reusing the instance while a timer is mid-flight).
+    if (this.reconnectTimer !== null) return;
+
+    this.reconnectAttempt++;
+
+    if (this.opts.maxReconnectAttempts > 0 && this.reconnectAttempt > this.opts.maxReconnectAttempts) {
+      logger.warn(this.opts.logTag, `max reconnect attempts (${this.opts.maxReconnectAttempts}) exceeded, giving up`);
+      this.state = 'stopped';
+      return;
+    }
+
+    this.state = 'reconnecting';
+    const delayMs = computeReconnectDelay(this.reconnectAttempt);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.state === 'stopped') return;
+      void this.connectOnce();
+    }, delayMs);
+  }
+}

--- a/scripts/cdp-bridge/src/tools/metro-events.ts
+++ b/scripts/cdp-bridge/src/tools/metro-events.ts
@@ -1,0 +1,59 @@
+import type { CDPClient } from '../cdp-client.js';
+import { okResult, withConnection } from '../utils.js';
+
+/**
+ * cdp_metro_events — M5 / Phase 90 Tier 2.
+ *
+ * Read recent Metro reporter events (bundle_build_started, bundle_build_done,
+ * bundle_build_failed, ...) captured by the MetroEventsClient that attaches
+ * alongside every CDP session. Supports filtering by event type and clearing
+ * the build-error counter.
+ */
+export function createMetroEventsHandler(getClient: () => CDPClient) {
+  return withConnection(getClient, async (args: {
+    limit?: number;
+    type?: string;
+    clearErrors?: boolean;
+  }, client) => {
+    const metroEvents = client.metroEventsClient;
+    if (!metroEvents) {
+      return okResult({
+        eventsConnected: false,
+        events: [],
+        count: 0,
+        lastBuild: null,
+        buildErrors: 0,
+        hint: 'Metro events client has not started. This should attach automatically when CDP connects. If you see this, the events WS may have failed to open (port mismatch, Metro not serving /events on this version).',
+      });
+    }
+
+    if (args.clearErrors) {
+      metroEvents.clearBuildErrors();
+      return okResult({
+        eventsConnected: metroEvents.isConnected,
+        cleared: true,
+        lastBuild: metroEvents.lastBuild,
+        buildErrors: metroEvents.buildErrors,
+      });
+    }
+
+    const limit = Math.min(Math.max(args.limit ?? 20, 1), 100);
+    let entries = metroEvents.events.getLast(metroEvents.events.size);
+
+    if (args.type) {
+      entries = entries.filter((e) => e.type === args.type);
+    }
+
+    if (entries.length > limit) {
+      entries = entries.slice(-limit);
+    }
+
+    return okResult({
+      eventsConnected: metroEvents.isConnected,
+      lastBuild: metroEvents.lastBuild,
+      buildErrors: metroEvents.buildErrors,
+      count: entries.length,
+      events: entries,
+    });
+  });
+}

--- a/scripts/cdp-bridge/src/tools/status.ts
+++ b/scripts/cdp-bridge/src/tools/status.ts
@@ -46,8 +46,16 @@ async function buildStatusResult(client: CDPClient): Promise<StatusResult> {
     }
   }
 
+  const metroEvents = client.metroEventsClient;
+
   return {
-    metro: { running: true, port: client.metroPort },
+    metro: {
+      running: true,
+      port: client.metroPort,
+      eventsConnected: metroEvents?.isConnected ?? false,
+      lastBuild: metroEvents?.lastBuild ?? null,
+      buildErrors: metroEvents?.buildErrors ?? 0,
+    },
     cdp: { connected: client.isConnected, device: client.connectedTarget?.title ?? null, pageId: client.connectedTarget?.id ?? null, platform: client.connectedTarget?.platform ?? null, bundleId: client.connectedTarget?.description ?? null },
     app: {
       platform: (appInfo?.platform as string) ?? null,

--- a/scripts/cdp-bridge/src/types.ts
+++ b/scripts/cdp-bridge/src/types.ts
@@ -68,6 +68,12 @@ export interface StatusResult {
   metro: {
     running: boolean;
     port: number | null;
+    /** M5 (D656): true when the MetroEventsClient has an open WS to Metro's /events endpoint. */
+    eventsConnected?: boolean;
+    /** M5 (D656): most recent bundle build status + timestamp (null if no events seen yet). */
+    lastBuild?: { status: 'started' | 'done' | 'failed'; timestamp: string } | null;
+    /** M5 (D656): count of bundle_build_failed events observed since MCP connected. */
+    buildErrors?: number;
   };
   cdp: {
     connected: boolean;

--- a/scripts/cdp-bridge/test/helpers/mock-cdp-client.js
+++ b/scripts/cdp-bridge/test/helpers/mock-cdp-client.js
@@ -36,6 +36,8 @@ export function createMockClient(overrides = {}) {
     get consoleBuffer() { return consoleBuffer; },
     get networkBufferManager() { return networkBufferManager; },
     get activeDeviceKey() { return makeDeviceKey(client._metroPort, client._connectedTarget?.id); },
+    /** M5: mock client defaults to null; tests can override with a stub. */
+    get metroEventsClient() { return client._metroEventsClient; },
     get logBuffer() { return logBuffer; },
     get reconnectState() {
       return { active: false, lastAttempt: null, attemptCount: 0 };
@@ -54,6 +56,7 @@ export function createMockClient(overrides = {}) {
       platform: 'ios',
     },
     _networkMode: 'cdp',
+    _metroEventsClient: null,
     _bridgeDetected: false,
     _bridgeVersion: null,
     _logDomainEnabled: true,

--- a/scripts/cdp-bridge/test/unit/metro-events-client.test.js
+++ b/scripts/cdp-bridge/test/unit/metro-events-client.test.js
@@ -1,0 +1,439 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { WebSocketServer } from 'ws';
+import { MetroEventsClient } from '../../dist/metro/events-client.js';
+import { createMetroEventsHandler } from '../../dist/tools/metro-events.js';
+import { createMockClient } from '../helpers/mock-cdp-client.js';
+import { expectOk } from '../helpers/result-helpers.js';
+
+function makeMockMetroEventsServer() {
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/events' });
+  const connections = [];
+  let totalConnectionsEver = 0;
+
+  wss.on('connection', (ws) => {
+    connections.push(ws);
+    totalConnectionsEver++;
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      resolve({
+        port,
+        url: `ws://127.0.0.1:${port}`,
+        emit: (event) => {
+          const msg = JSON.stringify(event);
+          for (const ws of connections) if (ws.readyState === 1) ws.send(msg);
+        },
+        /** Send raw bytes without JSON.stringify wrapping — for exercising the parse-fail branch. */
+        sendRaw: (text) => {
+          for (const ws of connections) if (ws.readyState === 1) ws.send(text);
+        },
+        /** Currently-open server-side connections. */
+        connectionCount: () => connections.length,
+        /** Total connections the server has EVER accepted (including ones already closed). Use for regression tests. */
+        totalConnectionsEver: () => totalConnectionsEver,
+        closeAllConnections: () => {
+          for (const ws of connections) {
+            try { ws.close(1000); } catch { /* ignore */ }
+          }
+          connections.length = 0;
+        },
+        stop: () => new Promise((r) => {
+          wss.close(() => server.close(() => r()));
+        }),
+      });
+    });
+  });
+}
+
+function waitForCondition(check, timeoutMs = 2000, intervalMs = 25) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const tick = () => {
+      if (check()) return resolve();
+      if (Date.now() - start >= timeoutMs) return reject(new Error(`condition not met within ${timeoutMs}ms`));
+      setTimeout(tick, intervalMs);
+    };
+    tick();
+  });
+}
+
+// ── MetroEventsClient: lifecycle ──
+
+test('MetroEventsClient: connects to /events and reports isConnected', async () => {
+  const server = await makeMockMetroEventsServer();
+  const client = new MetroEventsClient({ port: server.port });
+  try {
+    await client.start();
+    await waitForCondition(() => client.isConnected);
+    assert.equal(client.isConnected, true);
+  } finally {
+    client.stop();
+    await server.stop();
+  }
+});
+
+test('MetroEventsClient: stop is idempotent (safe to call twice)', async () => {
+  const server = await makeMockMetroEventsServer();
+  const client = new MetroEventsClient({ port: server.port });
+  await client.start();
+  await waitForCondition(() => client.isConnected);
+
+  client.stop();
+  client.stop(); // must not throw
+  assert.equal(client.isConnected, false);
+  await server.stop();
+});
+
+test('MetroEventsClient: start is idempotent — second call while open is a no-op', async () => {
+  const server = await makeMockMetroEventsServer();
+  const client = new MetroEventsClient({ port: server.port });
+  try {
+    await client.start();
+    await waitForCondition(() => client.isConnected);
+    await client.start(); // should not open a second connection
+    await new Promise((r) => setTimeout(r, 50));
+    assert.equal(server.connectionCount(), 1, 'only one connection to the server');
+  } finally {
+    client.stop();
+    await server.stop();
+  }
+});
+
+test('MetroEventsClient: start against unreachable port does not throw; schedules reconnect', async () => {
+  const client = new MetroEventsClient({ port: 1, maxReconnectAttempts: 1 });
+  await client.start(); // must resolve without throwing
+  await new Promise((r) => setTimeout(r, 50));
+  assert.equal(client.isConnected, false);
+  client.stop();
+});
+
+// ── MetroEventsClient: event routing + build state tracking ──
+
+test('MetroEventsClient: captures bundle_build_started / done / failed into ring buffer', async () => {
+  const server = await makeMockMetroEventsServer();
+  const client = new MetroEventsClient({ port: server.port });
+  try {
+    await client.start();
+    await waitForCondition(() => client.isConnected);
+
+    server.emit({ type: 'bundle_build_started', bundleOptions: {} });
+    await new Promise((r) => setTimeout(r, 30));
+    assert.equal(client.lastBuild?.status, 'started');
+    assert.equal(client.buildErrors, 0);
+
+    server.emit({ type: 'bundle_build_done', bundleOptions: {} });
+    await new Promise((r) => setTimeout(r, 30));
+    assert.equal(client.lastBuild?.status, 'done');
+    assert.equal(client.buildErrors, 0);
+
+    server.emit({ type: 'bundle_build_failed', error: { message: 'syntax error' } });
+    await new Promise((r) => setTimeout(r, 30));
+    assert.equal(client.lastBuild?.status, 'failed');
+    assert.equal(client.buildErrors, 1);
+
+    server.emit({ type: 'bundle_build_failed', error: { message: 'missing dep' } });
+    await new Promise((r) => setTimeout(r, 30));
+    assert.equal(client.buildErrors, 2, 'errors accumulate');
+
+    const entries = client.events.getLast(10);
+    assert.equal(entries.length, 4);
+    assert.equal(entries[0].type, 'bundle_build_started');
+    assert.equal(entries[3].type, 'bundle_build_failed');
+  } finally {
+    client.stop();
+    await server.stop();
+  }
+});
+
+test('MetroEventsClient: clearBuildErrors resets counter but preserves lastBuild', async () => {
+  const server = await makeMockMetroEventsServer();
+  const client = new MetroEventsClient({ port: server.port });
+  try {
+    await client.start();
+    await waitForCondition(() => client.isConnected);
+
+    server.emit({ type: 'bundle_build_failed', error: {} });
+    await new Promise((r) => setTimeout(r, 30));
+    assert.equal(client.buildErrors, 1);
+
+    client.clearBuildErrors();
+    assert.equal(client.buildErrors, 0);
+    assert.equal(client.lastBuild?.status, 'failed', 'lastBuild unchanged by clearBuildErrors');
+  } finally {
+    client.stop();
+    await server.stop();
+  }
+});
+
+test('MetroEventsClient: invokes onEvent callback for every event', async () => {
+  const server = await makeMockMetroEventsServer();
+  const received = [];
+  const client = new MetroEventsClient({
+    port: server.port,
+    onEvent: (e) => received.push(e),
+  });
+  try {
+    await client.start();
+    await waitForCondition(() => client.isConnected);
+
+    server.emit({ type: 'A' });
+    server.emit({ type: 'B' });
+    await new Promise((r) => setTimeout(r, 30));
+
+    assert.equal(received.length, 2);
+    assert.equal(received[0].type, 'A');
+    assert.equal(received[1].type, 'B');
+  } finally {
+    client.stop();
+    await server.stop();
+  }
+});
+
+test('MetroEventsClient: drops non-object JSON roots (primitives, arrays)', async () => {
+  const server = await makeMockMetroEventsServer();
+  const client = new MetroEventsClient({ port: server.port });
+  try {
+    await client.start();
+    await waitForCondition(() => client.isConnected);
+
+    // Primitive root → valid JSON but fails `typeof !== 'object'` guard
+    server.sendRaw(JSON.stringify('primitive'));
+    // Array root → fails Array.isArray guard
+    server.sendRaw(JSON.stringify(['array']));
+    // Null root → fails null guard
+    server.sendRaw(JSON.stringify(null));
+    await new Promise((r) => setTimeout(r, 30));
+
+    assert.equal(client.isConnected, true);
+    assert.equal(client.events.size, 0, 'none of the three non-object roots accepted');
+  } finally {
+    client.stop();
+    await server.stop();
+  }
+});
+
+test('MetroEventsClient: drops unparseable bytes silently (actual JSON.parse failure)', async () => {
+  const server = await makeMockMetroEventsServer();
+  const client = new MetroEventsClient({ port: server.port });
+  try {
+    await client.start();
+    await waitForCondition(() => client.isConnected);
+
+    // Raw garbage that cannot parse as JSON at all — exercises the catch branch
+    server.sendRaw('{not json at all');
+    server.sendRaw('garbage text');
+    await new Promise((r) => setTimeout(r, 30));
+
+    assert.equal(client.isConnected, true);
+    assert.equal(client.events.size, 0);
+  } finally {
+    client.stop();
+    await server.stop();
+  }
+});
+
+// ── Multi-review regression guards (D656 fixes) ──
+
+test('MetroEventsClient: D656 regression — initial connect failure does NOT double-schedule reconnect', async () => {
+  // Point at an unreachable port. `ws` library fires both `error` and `close` on
+  // ECONNREFUSED. Without the outcome-guard fix in connectOnce, both would call
+  // scheduleReconnect, leaking one timer per cycle and doubling the attempt counter.
+  // With the fix, exactly one schedule should happen per failure.
+  const client = new MetroEventsClient({
+    port: 1, // unreachable (ephemeral root-only on most systems; ECONNREFUSED)
+    maxReconnectAttempts: 1,
+  });
+  await client.start();
+  // Give it long enough to let both `error` and `close` fire
+  await new Promise((r) => setTimeout(r, 300));
+  // With the bug: attempt would be 2 (both handlers schedule). With the fix: attempt = 1.
+  // After maxReconnectAttempts=1, state → 'stopped' exactly once.
+  // We verify indirectly: only ONE reconnect was scheduled → the max-attempts guard
+  // fires at the boundary, not 1 attempt early.
+  // Also verify no double-timer leak: process.getActiveResourcesInfo().
+  const activeTimers = (process.getActiveResourcesInfo?.() ?? []).filter((n) => n === 'Timeout').length;
+  assert.ok(activeTimers <= 1, `expected ≤1 pending Timeout (single-schedule), got ${activeTimers}`);
+  client.stop();
+});
+
+test('MetroEventsClient: D656 regression — start() during reconnecting pre-empts pending timer', async () => {
+  // Scenario: client is mid-backoff (reconnectTimer pending), caller calls start()
+  // again. Without the fix, start() would connectOnce while the timer still fires
+  // later → two parallel connects. With the fix, start() clears the timer first.
+  const server = await makeMockMetroEventsServer();
+  const client = new MetroEventsClient({ port: server.port });
+  try {
+    // Force client into reconnecting by connecting then closing server-side
+    await client.start();
+    await waitForCondition(() => client.isConnected);
+    server.closeAllConnections();
+    await waitForCondition(() => !client.isConnected, 1000);
+    // Now a reconnect timer should be pending (500ms+ exponential delay)
+
+    // Call start() again — must pre-empt the pending timer
+    await client.start();
+    await waitForCondition(() => client.isConnected, 2000);
+
+    // Wait past the delay that the pre-empted timer would have fired at (attempt 1 = ~500-1000ms)
+    // to prove it actually got cleared — if NOT cleared, we'd see a 3rd connection here.
+    await new Promise((r) => setTimeout(r, 1200));
+    assert.equal(
+      server.totalConnectionsEver(),
+      2,
+      'expected exactly 2 total server-side connections (initial + start-preempted reconnect); more would indicate the pending timer was not cleared',
+    );
+  } finally {
+    client.stop();
+    await server.stop();
+  }
+});
+
+test('MetroEventsClient: exposes port getter for integration with CDPClient port-change detection', () => {
+  const client = new MetroEventsClient({ port: 19000 });
+  assert.equal(client.port, 19000);
+  client.stop();
+});
+
+test('MetroEventsClient: D656 regression — stop() during CONNECTING state does not crash the process', async () => {
+  // Multi-review pass 2 (Gemini 90%): ws.close() on a CONNECTING socket emits
+  // 'error' asynchronously via abortHandshake. If stop() strips all listeners
+  // before closing, the unhandled error crashes the process.
+  //
+  // This test creates a scenario where we call stop() while the ws is in
+  // CONNECTING state (point at a port that accepts TCP but hangs the WS handshake),
+  // then waits past the abortHandshake tick. If the fix is missing, Node throws
+  // 'uncaughtException' and this test will fail with an ERR_UNHANDLED_ERROR
+  // propagation into the test runner.
+  //
+  // We can't easily hang a real WS handshake, so we directly exercise the
+  // problem shape: start() against an unreachable port, which puts ws into
+  // CONNECTING briefly, then immediately call stop() and assert the process
+  // is still alive and no 'uncaughtException' was observed.
+  let uncaught = null;
+  const handler = (err) => { uncaught = err; };
+  process.once('uncaughtException', handler);
+
+  try {
+    const client = new MetroEventsClient({ port: 1, maxReconnectAttempts: 0 });
+    // Don't await start() — we want to call stop() while the initial connectOnce
+    // is still in CONNECTING state (start() resolves either on open or fail)
+    const p = client.start();
+    // Tiny delay — just enough to let the ws emit the CONNECTING state
+    await new Promise((r) => setImmediate(r));
+    client.stop();
+    await p; // let the start promise settle
+
+    // Give the event loop a few ticks for any async error to propagate
+    await new Promise((r) => setTimeout(r, 50));
+  } finally {
+    process.off('uncaughtException', handler);
+  }
+
+  assert.equal(uncaught, null, `expected no uncaughtException, got: ${uncaught?.message ?? 'none'}`);
+});
+
+// ── cdp_metro_events tool ──
+
+test('cdp_metro_events: reports not-connected when client is null', async () => {
+  const mock = createMockClient({ _metroEventsClient: null });
+  const handler = createMetroEventsHandler(() => mock);
+  const data = expectOk(await handler({ limit: 20, clearErrors: false }));
+  assert.equal(data.eventsConnected, false);
+  assert.equal(data.count, 0);
+  assert.match(data.hint, /Metro events client/i);
+});
+
+test('cdp_metro_events: returns events from a live client', async () => {
+  const server = await makeMockMetroEventsServer();
+  const events = new MetroEventsClient({ port: server.port });
+  try {
+    await events.start();
+    await waitForCondition(() => events.isConnected);
+    server.emit({ type: 'bundle_build_started' });
+    server.emit({ type: 'bundle_build_done' });
+    await new Promise((r) => setTimeout(r, 40));
+
+    const mock = createMockClient({ _metroEventsClient: events });
+    const handler = createMetroEventsHandler(() => mock);
+    const data = expectOk(await handler({ limit: 10, clearErrors: false }));
+    assert.equal(data.eventsConnected, true);
+    assert.equal(data.count, 2);
+    assert.equal(data.lastBuild?.status, 'done');
+    assert.equal(data.buildErrors, 0);
+  } finally {
+    events.stop();
+    await server.stop();
+  }
+});
+
+test('cdp_metro_events: type filter narrows results', async () => {
+  const server = await makeMockMetroEventsServer();
+  const events = new MetroEventsClient({ port: server.port });
+  try {
+    await events.start();
+    await waitForCondition(() => events.isConnected);
+    server.emit({ type: 'bundle_build_started' });
+    server.emit({ type: 'bundle_build_failed' });
+    server.emit({ type: 'bundle_build_failed' });
+    await new Promise((r) => setTimeout(r, 40));
+
+    const mock = createMockClient({ _metroEventsClient: events });
+    const handler = createMetroEventsHandler(() => mock);
+    const data = expectOk(await handler({ limit: 10, type: 'bundle_build_failed', clearErrors: false }));
+    assert.equal(data.count, 2);
+    assert.ok(data.events.every((e) => e.type === 'bundle_build_failed'));
+    assert.equal(data.buildErrors, 2);
+  } finally {
+    events.stop();
+    await server.stop();
+  }
+});
+
+test('cdp_metro_events: clearErrors resets counter via the tool', async () => {
+  const server = await makeMockMetroEventsServer();
+  const events = new MetroEventsClient({ port: server.port });
+  try {
+    await events.start();
+    await waitForCondition(() => events.isConnected);
+    server.emit({ type: 'bundle_build_failed' });
+    await new Promise((r) => setTimeout(r, 40));
+    assert.equal(events.buildErrors, 1);
+
+    const mock = createMockClient({ _metroEventsClient: events });
+    const handler = createMetroEventsHandler(() => mock);
+    const data = expectOk(await handler({ clearErrors: true }));
+    assert.equal(data.cleared, true);
+    assert.equal(events.buildErrors, 0);
+  } finally {
+    events.stop();
+    await server.stop();
+  }
+});
+
+// ── MetroEventsClient: reconnect on server close ──
+
+test('MetroEventsClient: auto-reconnects after server drops the connection', async () => {
+  const server = await makeMockMetroEventsServer();
+  const client = new MetroEventsClient({ port: server.port });
+  try {
+    await client.start();
+    await waitForCondition(() => client.isConnected);
+
+    // Simulate Metro dropping the connection (not the whole server — just this WS)
+    server.closeAllConnections();
+    await waitForCondition(() => !client.isConnected, 1000);
+    assert.equal(client.isConnected, false);
+
+    // MetroEventsClient should auto-reconnect within a few hundred ms (attempt 1 = ~500ms + jitter)
+    await waitForCondition(() => client.isConnected, 3000);
+    assert.equal(client.isConnected, true);
+  } finally {
+    client.stop();
+    await server.stop();
+  }
+});


### PR DESCRIPTION
M5 ships push-based bundler-state visibility via Metro's /events WebSocket. New cdp_metro_events tool + three cdp_status.metro fields. 17 new tests. 406 → 424 passing. Multi-review caught 4 ship-blockers across 2 passes (all fixed + regression-tested, see D656).