### PR TITLE
feat(m1b/phase-104): CDP proxy routing integration (D661)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.34.0] — 2026-04-21
+
+M1b / Phase 104 — CDP proxy routing integration. Completes the M1 story split from 2026-04-20: on RN < 0.85, `cdp_open_devtools` now starts the multiplexer proxy automatically and re-routes the MCP's own CDP WebSocket through it, so React Native DevTools can connect to the same proxy as a second consumer. Both coexist on single-debugger Hermes without evicting each other. MCP server bumped to 0.29.0.
+
+### Added
+- **`CDPClient.startProxy(opts?)` / `stopProxy()`**. Lifecycle methods that create/dispose the multiplexer and soft-reconnect the MCP's CDP WebSocket to route through it. Idempotent when already active.
+- **`cdp_status.proxy` block**. Reports `{ active, port, url, consumerCount }`. `consumerCount` observes the 1 → 2 transition when DevTools connects.
+- **`cdp_open_devtools` proxy-active mode**. New fields: `hermesWsUrl` (direct Hermes URL, upstream of proxy) and `proxyPort` (bound loopback port). `devtoolsUrl` now always non-null and points DevTools at `ws=127.0.0.1:PROXY_PORT` when proxy-active.
+- **`CDPMultiplexer` bounded resources**. `hermesBufferMaxSize` option (default 1000) with drop-oldest enforcement in `sendToHermes()`; `routingTimeoutMs` option (default 60s) with periodic sweeper. Test-only getters `hermesBufferSize` / `routingTableSize` for regression assertions.
+
+### Changed (behavioral, forward-compatible)
+- **`cdp_open_devtools` mode rename**: `'proxy-required'` → `'proxy-active'` when RN < 0.85 is detected (or version probe fails — conservative default). Previously: returned workaround guidance + null `devtoolsUrl`. Now: proxy auto-starts, `devtoolsUrl` populated, DevTools is usable immediately. The old `'proxy-required'` mode no longer exists.
+- **`CDPClient.disconnect()` tears down multiplexer** if one is active. The only reliable SIGTERM hook for the proxy; matches the precedent set by `MetroEventsClient` cleanup in the same path.
+- **`CDPMultiplexer.start()` failure cleanup** sets `state='stopping'` during cleanup (matching `stop()`), not `'stopped'` before. Closes a concurrent-start race where a second caller would observe "stopped" and allocate on top of in-flight teardown.
+
+### Fixed
+- **Unbounded `hermesBuffer` during CONNECTING window** — messages from fast/misbehaving consumers could pile up between `new WebSocket(hermesUrl)` and the `open` event. Cap + drop-oldest now enforced.
+- **`routingTable` leaks when Hermes goes partial-death** — entries allocated per consumer→upstream request were only cleaned up on close events. Unresponsive-but-not-closed upstreams leaked routing entries indefinitely. Periodic sweeper evicts entries past `routingTimeoutMs`.
+
+### Testing
+- 451 → 462 tests passing (+11): 3 prereq regression tests (hermesBuffer drop-oldest, routing sweeper, failed-start cleanup) + 1 open-devtools startProxy-error path + 10 CDPClient lifecycle tests. 2 existing cdp_open_devtools tests rewritten for `proxy-active` mode. Shared helper `test/helpers/mock-hermes.js` extracted for reuse across proxy tests.
+
+### Multi-review fixes (applied pre-commit)
+- **`CDPClient.startProxy` concurrency guard** (flagged by both Gemini + Codex at 92-95% confidence). Two parallel callers would each allocate a `CDPMultiplexer`; the second overwrote `_multiplexer` and orphaned the first (port bound, sweeper running, unreferenced). Fixed with an `_startProxyInFlight` promise cache that serializes concurrent callers on the same in-flight promise and clears in a `finally` so failed attempts don't poison retries.
+- **Rollback-path test coverage** (flagged by both at 85-90% confidence). The catch block tearing the multiplexer back down when `softReconnect` throws post-allocation was unreachable by the existing mock-client tests (`softReconnect` never rejected). Added 3 tests using a real mock Hermes that exercise the rollback, the concurrency guard, and the in-flight-cache-clears-on-failure behavior.
+
+### Known limitation logged (B132)
+Stale `hermesUrl` after target change or bundle reload — multiplexer captures the URL once at `startProxy` time. If Hermes regenerates the URL (reload, eviction, Metro restart), the proxy forwards to a dead upstream until `cdp_disconnect` + re-run `cdp_open_devtools`. Pre-existing M1a design limit, not introduced by M1b. Filed as B132 in BUGS.md for follow-up (requires multiplexer upstream-refresh API or client-level teardown-and-restart on target change).
+
+### Refs
+- D661 in DECISIONS.md. Phase 104 in ROADMAP.md. Parent: M1a / D654 (Phase 100, 2026-04-20). Branch: `feat/m1b-cdp-proxy-routing`.
+
+---
+
 ## [0.33.0] — 2026-04-21
 
 Phase 90 metro-mcp pattern adoption (Tier 1 + Tier 2) plus story-driven bug sweep. MCP server bumped to 0.28.0. Seven PRs merged on main since v0.25.0 without intermediate public releases; v0.33.0 is the first public-release checkpoint for all of it.

--- a/scripts/cdp-bridge/dist/cdp-client.js
+++ b/scripts/cdp-bridge/dist/cdp-client.js
@@ -2,6 +2,7 @@ import WebSocket from 'ws';
 import { RingBuffer, makeDeviceKey } from './ring-buffer.js';
 import { getNetworkBufferManager } from './cdp/network-buffer-manager.js';
 import { MetroEventsClient } from './metro/events-client.js';
+import { CDPMultiplexer } from './cdp/multiplexer.js';
 import { detectBridge } from './bridge-detector.js';
 import { logger } from './logger.js';
 import { performSetup, reinjectHelpers as reinjectHelpersFn } from './cdp/setup.js';
@@ -48,6 +49,15 @@ export class CDPClient {
     // Tier 3: reconnection state visibility (D596)
     _lastReconnectAttempt = null;
     _reconnectAttemptCount = 0;
+    // M1b (Phase 100+): multiplexer proxy state. When `_proxyUrl` is non-null, the
+    // CDP WebSocket routes through `_multiplexer` instead of connecting directly to
+    // Hermes. Lets React Native DevTools share the same Hermes target on RN < 0.85.
+    _proxyUrl = null;
+    _multiplexer = null;
+    // D661 review finding: concurrent startProxy() callers would each allocate a
+    // multiplexer, with the second overwriting _multiplexer and orphaning the first.
+    // In-flight promise cache serializes concurrent callers on the same startup.
+    _startProxyInFlight = null;
     constructor(port) {
         this._port = port ?? 8081;
         this._consoleBuffer = new RingBuffer(200);
@@ -80,6 +90,12 @@ export class CDPClient {
     get reconnectState() {
         return { active: this.reconnecting, lastAttempt: this._lastReconnectAttempt, attemptCount: this._reconnectAttemptCount };
     }
+    /** M1b: URL the CDPClient routes through (null when connected directly). */
+    get proxyUrl() { return this._proxyUrl; }
+    /** M1b: true when the multiplexer is owned by this client and routing traffic. */
+    get isProxyActive() { return this._proxyUrl !== null; }
+    /** M1b: the multiplexer instance (null when no proxy is active). */
+    get proxyMultiplexer() { return this._multiplexer; }
     helperExpr(call) {
         return helperExprFn(call, this._bridgeDetected);
     }
@@ -113,6 +129,78 @@ export class CDPClient {
     async softReconnect() {
         return softReconnectFn(this.buildReconnectCtx());
     }
+    /**
+     * M1b (Phase 100+): start the multiplexer proxy and switch this client's CDP
+     * WebSocket to ride through it. After this resolves, React Native DevTools
+     * (or any other WS consumer) can connect to the same port and coexist with
+     * the MCP. Requires an already-connected target — call `autoConnect` first.
+     *
+     * No-op if the proxy is already active (returns existing URL). Concurrent
+     * callers share a single in-flight promise — the multiplexer is allocated
+     * exactly once per successful `(connected → active)` transition.
+     */
+    async startProxy(opts) {
+        if (this._proxyUrl)
+            return this._proxyUrl;
+        if (this._startProxyInFlight)
+            return this._startProxyInFlight;
+        this._startProxyInFlight = this._doStartProxy(opts).finally(() => {
+            this._startProxyInFlight = null;
+        });
+        return this._startProxyInFlight;
+    }
+    async _doStartProxy(opts) {
+        if (!this._connectedTarget) {
+            throw new Error('startProxy requires an active CDP connection — call autoConnect first');
+        }
+        const hermesUrl = this._connectedTarget.webSocketDebuggerUrl;
+        const multiplexer = new CDPMultiplexer({ hermesUrl, ...opts });
+        const port = await multiplexer.start();
+        this._multiplexer = multiplexer;
+        this._proxyUrl = `ws://127.0.0.1:${port}`;
+        logger.info('CDP', `Proxy started on ${this._proxyUrl}, soft-reconnecting current session`);
+        try {
+            await this.softReconnect();
+        }
+        catch (err) {
+            // Soft-reconnect failed — tear the proxy back down so we don't leave a
+            // half-switched state (proxy running but CDPClient disconnected).
+            try {
+                await multiplexer.stop();
+            }
+            catch { /* best-effort */ }
+            this._multiplexer = null;
+            this._proxyUrl = null;
+            throw err;
+        }
+        return this._proxyUrl;
+    }
+    /**
+     * M1b: stop the multiplexer and reconnect this client directly to Hermes.
+     * No-op if the proxy isn't active.
+     */
+    async stopProxy() {
+        if (!this._proxyUrl)
+            return;
+        logger.info('CDP', `Stopping proxy at ${this._proxyUrl}`);
+        const mux = this._multiplexer;
+        this._proxyUrl = null;
+        this._multiplexer = null;
+        // Reconnect first (uses direct target URL now that _proxyUrl is null), then
+        // stop the old proxy. Reverse order would briefly leave the client trying
+        // to route through an already-stopped proxy.
+        try {
+            await this.softReconnect();
+        }
+        finally {
+            if (mux) {
+                try {
+                    await mux.stop();
+                }
+                catch { /* best-effort */ }
+            }
+        }
+    }
     async disconnect() {
         // B76/D644: idempotent guard — graceful-shutdown may race with a tool-triggered
         // disconnect (e.g. cdp_restart calling disconnect() while SIGTERM fires). Second
@@ -130,6 +218,16 @@ export class CDPClient {
             }
             catch { /* best-effort */ }
             this._metroEventsClient = null;
+        }
+        // M1b: tear down multiplexer if one is active. This is the only reliable
+        // end-of-session cleanup hook for the proxy (SIGTERM → disconnect → here).
+        if (this._multiplexer) {
+            try {
+                await this._multiplexer.stop();
+            }
+            catch { /* best-effort */ }
+            this._multiplexer = null;
+            this._proxyUrl = null;
         }
         if (this.ws) {
             this.ws.removeAllListeners();
@@ -343,6 +441,7 @@ export class CDPClient {
             handleClose: (code) => this.handleClose(code),
             rejectAllPending: (reason) => this.rejectAllPending(reason),
             setup: () => this.setup(),
+            getProxyUrl: () => this._proxyUrl,
         };
     }
     buildResettableState() {

--- a/scripts/cdp-bridge/dist/cdp/connect.js
+++ b/scripts/cdp-bridge/dist/cdp/connect.js
@@ -104,7 +104,14 @@ async function connectToTarget(ctx, target, retries = 5) {
             throw new Error('Client disposed or preempted during connection');
         }
         try {
-            await connectWs(ctx, target.webSocketDebuggerUrl);
+            // M1b: ride the multiplexer when _proxyUrl is set (from CDPClient.startProxy).
+            // Falls back to the target's direct webSocketDebuggerUrl when no proxy is active.
+            const proxyUrl = ctx.getProxyUrl();
+            const url = proxyUrl ?? target.webSocketDebuggerUrl;
+            if (proxyUrl) {
+                logger.info('CDP', `Routing via multiplexer proxy: ${proxyUrl}`);
+            }
+            await connectWs(ctx, url);
             // D594: Early stale-target detection — quick probe before full setup
             try {
                 await ctx.sendWithTimeout('Runtime.evaluate', {

--- a/scripts/cdp-bridge/dist/cdp/multiplexer.js
+++ b/scripts/cdp-bridge/dist/cdp/multiplexer.js
@@ -1,6 +1,8 @@
 import { createServer } from 'node:http';
 import WebSocket, { WebSocketServer } from 'ws';
 import { logger } from '../logger.js';
+const HERMES_BUFFER_MAX_DEFAULT = 1000;
+const ROUTING_TIMEOUT_MS_DEFAULT = 60_000;
 export class CDPMultiplexer {
     opts;
     httpServer = null;
@@ -13,12 +15,15 @@ export class CDPMultiplexer {
     hermesBuffer = [];
     state = 'stopped';
     boundPort = null;
+    routingSweeper = null;
     constructor(opts) {
         this.opts = {
             hermesUrl: opts.hermesUrl,
             host: opts.host ?? '127.0.0.1',
             port: opts.port ?? 0,
             logTag: opts.logTag ?? 'CDP.proxy',
+            hermesBufferMaxSize: opts.hermesBufferMaxSize ?? HERMES_BUFFER_MAX_DEFAULT,
+            routingTimeoutMs: opts.routingTimeoutMs ?? ROUTING_TIMEOUT_MS_DEFAULT,
         };
     }
     get port() {
@@ -30,6 +35,14 @@ export class CDPMultiplexer {
     get consumerCount() {
         return this.consumers.size;
     }
+    /** Test-only: current size of the routing table (how many pending upstream requests). */
+    get routingTableSize() {
+        return this.routingTable.size;
+    }
+    /** Test-only: current size of the CONNECTING-window buffer. */
+    get hermesBufferSize() {
+        return this.hermesBuffer.length;
+    }
     async start() {
         if (this.state !== 'stopped') {
             throw new Error(`CDPMultiplexer cannot start from state '${this.state}'`);
@@ -38,13 +51,15 @@ export class CDPMultiplexer {
         try {
             const port = await this.startConsumerServer();
             await this.connectHermes();
+            this.startRoutingSweeper();
             this.state = 'running';
             logger.info(this.opts.logTag, `multiplexer running on ${this.opts.host}:${port}`);
             return port;
         }
         catch (err) {
-            this.state = 'stopped';
+            this.state = 'stopping';
             await this.cleanup();
+            this.state = 'stopped';
             throw err;
         }
     }
@@ -136,7 +151,7 @@ export class CDPMultiplexer {
         const consumerOriginalId = typeof m.id === 'number' ? m.id : null;
         if (consumerOriginalId !== null) {
             const upstreamId = this.upstreamSeq++;
-            this.routingTable.set(upstreamId, { consumerId, consumerOriginalId });
+            this.routingTable.set(upstreamId, { consumerId, consumerOriginalId, createdAt: Date.now() });
             m.id = upstreamId;
         }
         this.sendToHermes(JSON.stringify(m));
@@ -189,6 +204,10 @@ export class CDPMultiplexer {
             return;
         }
         if (this.hermesWs.readyState === WebSocket.CONNECTING) {
+            if (this.hermesBuffer.length >= this.opts.hermesBufferMaxSize) {
+                this.hermesBuffer.shift();
+                logger.warn(this.opts.logTag, `hermesBuffer exceeded cap (${this.opts.hermesBufferMaxSize}), dropping oldest`);
+            }
             this.hermesBuffer.push(rawMessage);
             return;
         }
@@ -197,6 +216,32 @@ export class CDPMultiplexer {
             return;
         }
         this.hermesWs.send(rawMessage);
+    }
+    startRoutingSweeper() {
+        if (this.routingSweeper)
+            return;
+        const timeoutMs = this.opts.routingTimeoutMs;
+        const sweepMs = Math.max(500, Math.floor(timeoutMs / 2));
+        this.routingSweeper = setInterval(() => {
+            const cutoff = Date.now() - timeoutMs;
+            let dropped = 0;
+            for (const [upstreamId, entry] of this.routingTable) {
+                if (entry.createdAt < cutoff) {
+                    this.routingTable.delete(upstreamId);
+                    dropped++;
+                }
+            }
+            if (dropped > 0) {
+                logger.warn(this.opts.logTag, `routing sweeper dropped ${dropped} expired entries`);
+            }
+        }, sweepMs);
+        this.routingSweeper.unref?.();
+    }
+    stopRoutingSweeper() {
+        if (this.routingSweeper) {
+            clearInterval(this.routingSweeper);
+            this.routingSweeper = null;
+        }
     }
     broadcastToConsumers(rawMessage) {
         for (const ws of this.consumers.values()) {
@@ -209,6 +254,7 @@ export class CDPMultiplexer {
         }
     }
     async cleanup() {
+        this.stopRoutingSweeper();
         if (this.hermesWs) {
             try {
                 this.hermesWs.close(1000, 'proxy stopping');

--- a/scripts/cdp-bridge/dist/tools/open-devtools.js
+++ b/scripts/cdp-bridge/dist/tools/open-devtools.js
@@ -2,13 +2,13 @@ import { okResult, failResult } from '../utils.js';
 import { supportsNativeMultiDebugger } from '../cdp/multiplexer.js';
 const NATIVE_GUIDANCE = [
     'React DevTools can connect to the inspector URL below while your MCP session stays active.',
-    'Open the DevTools URL in Chrome (or paste the inspectorWsUrl directly into a DevTools fusebox instance).',
+    'Open the devtoolsUrl in Chrome (or paste the inspectorWsUrl directly into a DevTools fusebox instance).',
     'Native multi-debugger support on RN >= 0.85 means no proxy is needed — both connections multiplex transparently.',
 ].join('\n');
-const PROXY_REQUIRED_GUIDANCE = [
-    'Your RN version does not support native multi-debugger. Using React DevTools will evict the MCP session (CDP close code 1006).',
-    'M1 (this release) ships detection + capability reporting; automatic proxy wiring is tracked as M1b (Phase 100, pending live simulator verification).',
-    'Workaround today: close the MCP CC session while using DevTools, reopen when done. OR upgrade to RN >= 0.85.',
+const PROXY_ACTIVE_GUIDANCE = [
+    'Your RN version does not support native multi-debugger; the multiplexer proxy has been started so React DevTools can coexist with the MCP.',
+    'Open the devtoolsUrl in Chrome. DevTools will connect to the proxy (inspectorWsUrl); the MCP is already routing through it.',
+    'The proxy stops automatically when the MCP disconnects, or explicitly via cdp_disconnect.',
 ].join('\n');
 export function createOpenDevToolsHandler(getClient) {
     return async () => {
@@ -21,12 +21,9 @@ export function createOpenDevToolsHandler(getClient) {
             return failResult('cdp_open_devtools: no target selected. Run cdp_connect or cdp_status.');
         }
         const metroPort = client.metroPort;
-        const inspectorWsUrl = `ws://127.0.0.1:${metroPort}/inspector/debug?device=${encodeURIComponent(target.id)}&page=${encodeURIComponent(target.id)}`;
-        // DevTools frontend is served by Metro at /debugger-frontend/rn_fusebox.html
-        // Query params hand the frontend the WS URL it should connect to. Metro auto-loads the React DevTools bundle.
-        const devtoolsUrl = `http://127.0.0.1:${metroPort}/debugger-frontend/rn_fusebox.html?ws=127.0.0.1:${metroPort}/inspector/debug?device=${encodeURIComponent(target.id)}%26page=${encodeURIComponent(target.id)}`;
-        // Probe app info for RN version. Best-effort — if probe fails, we still report
-        // inspectorWsUrl and assume proxy-required.
+        const hermesWsUrl = `ws://127.0.0.1:${metroPort}/inspector/debug?device=${encodeURIComponent(target.id)}&page=${encodeURIComponent(target.id)}`;
+        // Probe app info for RN version. Best-effort — if probe fails, treat as
+        // proxy-required (conservative default: use the proxy so DevTools doesn't evict the MCP).
         let rnVersion = null;
         let supportsMultiple = false;
         try {
@@ -43,14 +40,48 @@ export function createOpenDevToolsHandler(getClient) {
             }
         }
         catch { /* leave rnVersion null, supportsMultiple false */ }
-        const result = {
-            devtoolsUrl: supportsMultiple ? devtoolsUrl : null,
-            inspectorWsUrl,
-            mode: supportsMultiple ? 'native' : 'proxy-required',
-            supportsMultipleDebuggers: supportsMultiple,
+        if (supportsMultiple) {
+            // Native multi-debugger: DevTools connects directly to Hermes via Metro's
+            // /inspector/debug endpoint. No proxy needed.
+            const devtoolsUrl = `http://127.0.0.1:${metroPort}/debugger-frontend/rn_fusebox.html?ws=127.0.0.1:${metroPort}/inspector/debug?device=${encodeURIComponent(target.id)}%26page=${encodeURIComponent(target.id)}`;
+            return okResult({
+                devtoolsUrl,
+                inspectorWsUrl: hermesWsUrl,
+                hermesWsUrl,
+                mode: 'native',
+                supportsMultipleDebuggers: true,
+                rnVersion,
+                proxyPort: null,
+                guidance: NATIVE_GUIDANCE,
+            });
+        }
+        // Proxy path: start (or reuse) the multiplexer so DevTools and MCP coexist.
+        let proxyUrl;
+        try {
+            proxyUrl = await client.startProxy();
+        }
+        catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            return failResult(`cdp_open_devtools: failed to start multiplexer proxy: ${message}`);
+        }
+        const proxyPort = client.proxyMultiplexer?.port ?? null;
+        if (proxyPort === null) {
+            // Defensive: startProxy resolved but the multiplexer has no port. Indicates an
+            // internal state drift — fail loudly rather than return a half-working URL.
+            return failResult('cdp_open_devtools: multiplexer started but has no bound port');
+        }
+        // DevTools frontend still lives on Metro (it's static HTML + JS served over HTTP).
+        // Only the WS destination changes: DevTools → proxy (loopback); proxy → Hermes.
+        const devtoolsUrl = `http://127.0.0.1:${metroPort}/debugger-frontend/rn_fusebox.html?ws=127.0.0.1:${proxyPort}`;
+        return okResult({
+            devtoolsUrl,
+            inspectorWsUrl: proxyUrl,
+            hermesWsUrl,
+            mode: 'proxy-active',
+            supportsMultipleDebuggers: false,
             rnVersion,
-            guidance: supportsMultiple ? NATIVE_GUIDANCE : PROXY_REQUIRED_GUIDANCE,
-        };
-        return okResult(result);
+            proxyPort,
+            guidance: PROXY_ACTIVE_GUIDANCE,
+        });
     };
 }

--- a/scripts/cdp-bridge/dist/tools/status.js
+++ b/scripts/cdp-bridge/dist/tools/status.js
@@ -73,6 +73,12 @@ async function buildStatusResult(client) {
             heapProfiler: client.heapProfilerAvailable,
         },
         reconnect: client.reconnectState,
+        proxy: {
+            active: client.isProxyActive,
+            port: client.proxyMultiplexer?.port ?? null,
+            url: client.proxyUrl,
+            consumerCount: client.proxyMultiplexer?.consumerCount ?? 0,
+        },
     };
 }
 export function createStatusHandler(getClient, setClient, createClient) {

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/cdp-client.ts
+++ b/scripts/cdp-bridge/src/cdp-client.ts
@@ -2,6 +2,8 @@ import WebSocket from 'ws';
 import { RingBuffer, DeviceBufferManager, makeDeviceKey } from './ring-buffer.js';
 import { getNetworkBufferManager } from './cdp/network-buffer-manager.js';
 import { MetroEventsClient } from './metro/events-client.js';
+import { CDPMultiplexer } from './cdp/multiplexer.js';
+import type { MultiplexerOptions } from './cdp/multiplexer.js';
 import { detectBridge } from './bridge-detector.js';
 import { logger } from './logger.js';
 import { performSetup, reinjectHelpers as reinjectHelpersFn } from './cdp/setup.js';
@@ -74,6 +76,16 @@ export class CDPClient {
   private _lastReconnectAttempt: string | null = null;
   private _reconnectAttemptCount = 0;
 
+  // M1b (Phase 100+): multiplexer proxy state. When `_proxyUrl` is non-null, the
+  // CDP WebSocket routes through `_multiplexer` instead of connecting directly to
+  // Hermes. Lets React Native DevTools share the same Hermes target on RN < 0.85.
+  private _proxyUrl: string | null = null;
+  private _multiplexer: CDPMultiplexer | null = null;
+  // D661 review finding: concurrent startProxy() callers would each allocate a
+  // multiplexer, with the second overwriting _multiplexer and orphaning the first.
+  // In-flight promise cache serializes concurrent callers on the same startup.
+  private _startProxyInFlight: Promise<string> | null = null;
+
   constructor(port?: number) {
     this._port = port ?? 8081;
     this._consoleBuffer = new RingBuffer<ConsoleEntry>(200);
@@ -107,6 +119,12 @@ export class CDPClient {
   get reconnectState(): { active: boolean; lastAttempt: string | null; attemptCount: number } {
     return { active: this.reconnecting, lastAttempt: this._lastReconnectAttempt, attemptCount: this._reconnectAttemptCount };
   }
+  /** M1b: URL the CDPClient routes through (null when connected directly). */
+  get proxyUrl(): string | null { return this._proxyUrl; }
+  /** M1b: true when the multiplexer is owned by this client and routing traffic. */
+  get isProxyActive(): boolean { return this._proxyUrl !== null; }
+  /** M1b: the multiplexer instance (null when no proxy is active). */
+  get proxyMultiplexer(): CDPMultiplexer | null { return this._multiplexer; }
 
   helperExpr(call: string): string {
     return helperExprFn(call, this._bridgeDetected);
@@ -151,6 +169,70 @@ export class CDPClient {
     return softReconnectFn(this.buildReconnectCtx());
   }
 
+  /**
+   * M1b (Phase 100+): start the multiplexer proxy and switch this client's CDP
+   * WebSocket to ride through it. After this resolves, React Native DevTools
+   * (or any other WS consumer) can connect to the same port and coexist with
+   * the MCP. Requires an already-connected target — call `autoConnect` first.
+   *
+   * No-op if the proxy is already active (returns existing URL). Concurrent
+   * callers share a single in-flight promise — the multiplexer is allocated
+   * exactly once per successful `(connected → active)` transition.
+   */
+  async startProxy(opts?: Partial<Omit<MultiplexerOptions, 'hermesUrl'>>): Promise<string> {
+    if (this._proxyUrl) return this._proxyUrl;
+    if (this._startProxyInFlight) return this._startProxyInFlight;
+    this._startProxyInFlight = this._doStartProxy(opts).finally(() => {
+      this._startProxyInFlight = null;
+    });
+    return this._startProxyInFlight;
+  }
+
+  private async _doStartProxy(opts?: Partial<Omit<MultiplexerOptions, 'hermesUrl'>>): Promise<string> {
+    if (!this._connectedTarget) {
+      throw new Error('startProxy requires an active CDP connection — call autoConnect first');
+    }
+    const hermesUrl = this._connectedTarget.webSocketDebuggerUrl;
+    const multiplexer = new CDPMultiplexer({ hermesUrl, ...opts });
+    const port = await multiplexer.start();
+    this._multiplexer = multiplexer;
+    this._proxyUrl = `ws://127.0.0.1:${port}`;
+    logger.info('CDP', `Proxy started on ${this._proxyUrl}, soft-reconnecting current session`);
+    try {
+      await this.softReconnect();
+    } catch (err) {
+      // Soft-reconnect failed — tear the proxy back down so we don't leave a
+      // half-switched state (proxy running but CDPClient disconnected).
+      try { await multiplexer.stop(); } catch { /* best-effort */ }
+      this._multiplexer = null;
+      this._proxyUrl = null;
+      throw err;
+    }
+    return this._proxyUrl;
+  }
+
+  /**
+   * M1b: stop the multiplexer and reconnect this client directly to Hermes.
+   * No-op if the proxy isn't active.
+   */
+  async stopProxy(): Promise<void> {
+    if (!this._proxyUrl) return;
+    logger.info('CDP', `Stopping proxy at ${this._proxyUrl}`);
+    const mux = this._multiplexer;
+    this._proxyUrl = null;
+    this._multiplexer = null;
+    // Reconnect first (uses direct target URL now that _proxyUrl is null), then
+    // stop the old proxy. Reverse order would briefly leave the client trying
+    // to route through an already-stopped proxy.
+    try {
+      await this.softReconnect();
+    } finally {
+      if (mux) {
+        try { await mux.stop(); } catch { /* best-effort */ }
+      }
+    }
+  }
+
   async disconnect(): Promise<void> {
     // B76/D644: idempotent guard — graceful-shutdown may race with a tool-triggered
     // disconnect (e.g. cdp_restart calling disconnect() while SIGTERM fires). Second
@@ -165,6 +247,14 @@ export class CDPClient {
     if (this._metroEventsClient) {
       try { this._metroEventsClient.stop(); } catch { /* best-effort */ }
       this._metroEventsClient = null;
+    }
+
+    // M1b: tear down multiplexer if one is active. This is the only reliable
+    // end-of-session cleanup hook for the proxy (SIGTERM → disconnect → here).
+    if (this._multiplexer) {
+      try { await this._multiplexer.stop(); } catch { /* best-effort */ }
+      this._multiplexer = null;
+      this._proxyUrl = null;
     }
 
     if (this.ws) {
@@ -409,6 +499,7 @@ export class CDPClient {
       handleClose: (code) => this.handleClose(code),
       rejectAllPending: (reason) => this.rejectAllPending(reason),
       setup: () => this.setup(),
+      getProxyUrl: () => this._proxyUrl,
     };
   }
 

--- a/scripts/cdp-bridge/src/cdp/connect.ts
+++ b/scripts/cdp-bridge/src/cdp/connect.ts
@@ -35,6 +35,13 @@ export interface ConnectContext {
   handleClose(code: number): void;
   rejectAllPending(reason: Error): void;
   setup(): Promise<void>;
+  /**
+   * M1b (Phase 100+): when non-null, connectToTarget routes through this URL
+   * instead of the target's direct `webSocketDebuggerUrl`. This is how the
+   * CDPClient rides the local multiplexer proxy, allowing React Native DevTools
+   * (or any second consumer) to coexist on RN < 0.85.
+   */
+  getProxyUrl(): string | null;
 }
 
 export async function autoConnect(
@@ -151,7 +158,14 @@ async function connectToTarget(
       throw new Error('Client disposed or preempted during connection');
     }
     try {
-      await connectWs(ctx, target.webSocketDebuggerUrl);
+      // M1b: ride the multiplexer when _proxyUrl is set (from CDPClient.startProxy).
+      // Falls back to the target's direct webSocketDebuggerUrl when no proxy is active.
+      const proxyUrl = ctx.getProxyUrl();
+      const url = proxyUrl ?? target.webSocketDebuggerUrl;
+      if (proxyUrl) {
+        logger.info('CDP', `Routing via multiplexer proxy: ${proxyUrl}`);
+      }
+      await connectWs(ctx, url);
       // D594: Early stale-target detection — quick probe before full setup
       try {
         await ctx.sendWithTimeout('Runtime.evaluate', {

--- a/scripts/cdp-bridge/src/cdp/multiplexer.ts
+++ b/scripts/cdp-bridge/src/cdp/multiplexer.ts
@@ -30,9 +30,16 @@ export interface MultiplexerOptions {
   port?: number;
   /** Logger tag. Default: 'CDP.proxy' */
   logTag?: string;
+  /** Max size of the hermesBuffer (messages enqueued during CONNECTING). Default: 1000. Drop-oldest on overflow. */
+  hermesBufferMaxSize?: number;
+  /** Max age for routing entries before the sweeper drops them. Default: 60000 ms. */
+  routingTimeoutMs?: number;
 }
 
-type RoutingEntry = { consumerId: number; consumerOriginalId: number };
+type RoutingEntry = { consumerId: number; consumerOriginalId: number; createdAt: number };
+
+const HERMES_BUFFER_MAX_DEFAULT = 1000;
+const ROUTING_TIMEOUT_MS_DEFAULT = 60_000;
 
 export class CDPMultiplexer {
   private readonly opts: Required<MultiplexerOptions>;
@@ -46,6 +53,7 @@ export class CDPMultiplexer {
   private hermesBuffer: string[] = [];
   private state: 'stopped' | 'starting' | 'running' | 'stopping' = 'stopped';
   private boundPort: number | null = null;
+  private routingSweeper: NodeJS.Timeout | null = null;
 
   constructor(opts: MultiplexerOptions) {
     this.opts = {
@@ -53,6 +61,8 @@ export class CDPMultiplexer {
       host: opts.host ?? '127.0.0.1',
       port: opts.port ?? 0,
       logTag: opts.logTag ?? 'CDP.proxy',
+      hermesBufferMaxSize: opts.hermesBufferMaxSize ?? HERMES_BUFFER_MAX_DEFAULT,
+      routingTimeoutMs: opts.routingTimeoutMs ?? ROUTING_TIMEOUT_MS_DEFAULT,
     };
   }
 
@@ -68,6 +78,16 @@ export class CDPMultiplexer {
     return this.consumers.size;
   }
 
+  /** Test-only: current size of the routing table (how many pending upstream requests). */
+  get routingTableSize(): number {
+    return this.routingTable.size;
+  }
+
+  /** Test-only: current size of the CONNECTING-window buffer. */
+  get hermesBufferSize(): number {
+    return this.hermesBuffer.length;
+  }
+
   async start(): Promise<number> {
     if (this.state !== 'stopped') {
       throw new Error(`CDPMultiplexer cannot start from state '${this.state}'`);
@@ -77,12 +97,14 @@ export class CDPMultiplexer {
     try {
       const port = await this.startConsumerServer();
       await this.connectHermes();
+      this.startRoutingSweeper();
       this.state = 'running';
       logger.info(this.opts.logTag, `multiplexer running on ${this.opts.host}:${port}`);
       return port;
     } catch (err) {
-      this.state = 'stopped';
+      this.state = 'stopping';
       await this.cleanup();
+      this.state = 'stopped';
       throw err;
     }
   }
@@ -182,7 +204,7 @@ export class CDPMultiplexer {
 
     if (consumerOriginalId !== null) {
       const upstreamId = this.upstreamSeq++;
-      this.routingTable.set(upstreamId, { consumerId, consumerOriginalId });
+      this.routingTable.set(upstreamId, { consumerId, consumerOriginalId, createdAt: Date.now() });
       m.id = upstreamId;
     }
 
@@ -239,6 +261,13 @@ export class CDPMultiplexer {
       return;
     }
     if (this.hermesWs.readyState === WebSocket.CONNECTING) {
+      if (this.hermesBuffer.length >= this.opts.hermesBufferMaxSize) {
+        this.hermesBuffer.shift();
+        logger.warn(
+          this.opts.logTag,
+          `hermesBuffer exceeded cap (${this.opts.hermesBufferMaxSize}), dropping oldest`,
+        );
+      }
       this.hermesBuffer.push(rawMessage);
       return;
     }
@@ -247,6 +276,33 @@ export class CDPMultiplexer {
       return;
     }
     this.hermesWs.send(rawMessage);
+  }
+
+  private startRoutingSweeper(): void {
+    if (this.routingSweeper) return;
+    const timeoutMs = this.opts.routingTimeoutMs;
+    const sweepMs = Math.max(500, Math.floor(timeoutMs / 2));
+    this.routingSweeper = setInterval(() => {
+      const cutoff = Date.now() - timeoutMs;
+      let dropped = 0;
+      for (const [upstreamId, entry] of this.routingTable) {
+        if (entry.createdAt < cutoff) {
+          this.routingTable.delete(upstreamId);
+          dropped++;
+        }
+      }
+      if (dropped > 0) {
+        logger.warn(this.opts.logTag, `routing sweeper dropped ${dropped} expired entries`);
+      }
+    }, sweepMs);
+    this.routingSweeper.unref?.();
+  }
+
+  private stopRoutingSweeper(): void {
+    if (this.routingSweeper) {
+      clearInterval(this.routingSweeper);
+      this.routingSweeper = null;
+    }
   }
 
   private broadcastToConsumers(rawMessage: string): void {
@@ -258,6 +314,7 @@ export class CDPMultiplexer {
   }
 
   private async cleanup(): Promise<void> {
+    this.stopRoutingSweeper();
     if (this.hermesWs) {
       try { this.hermesWs.close(1000, 'proxy stopping'); } catch { /* ignore */ }
       this.hermesWs = null;

--- a/scripts/cdp-bridge/src/tools/open-devtools.ts
+++ b/scripts/cdp-bridge/src/tools/open-devtools.ts
@@ -3,46 +3,46 @@ import { okResult, failResult } from '../utils.js';
 import { supportsNativeMultiDebugger } from '../cdp/multiplexer.js';
 
 /**
- * cdp_open_devtools — M1 / Phase 90 Tier 1 MVP.
+ * cdp_open_devtools — M1 / Phase 90 Tier 1 + M1b (Phase 100).
  *
  * Report the React Native DevTools frontend URL for the currently connected app,
- * along with whether DevTools can coexist with the MCP session (RN >= 0.85 native
- * multi-debugger) or requires the proxy path (RN < 0.85, M1b).
- *
- * This tool is read-only — it does not start the multiplexer proxy or mutate any
- * CDP state. The proxy wiring is deferred to M1b (Phase 100, pending a live
- * simulator session for end-to-end verification).
+ * and on RN < 0.85 automatically start the multiplexer proxy so DevTools can
+ * coexist with the MCP session (native multi-debugger kicks in on RN >= 0.85).
  *
  * Output shape (on success):
  *   {
- *     devtoolsUrl: string | null,  // Metro-served DevTools frontend URL, or null if unavailable
- *     inspectorWsUrl: string,       // Direct Hermes CDP WS URL (what DevTools connects to)
- *     mode: 'native' | 'proxy-required',
+ *     devtoolsUrl: string,          // DevTools frontend URL (points at proxy when proxy-active)
+ *     inspectorWsUrl: string,        // WS URL to connect DevTools to (proxy port in proxy-active mode)
+ *     hermesWsUrl: string,           // Direct Hermes WS URL (what the proxy talks to upstream)
+ *     mode: 'native' | 'proxy-active',
  *     supportsMultipleDebuggers: boolean,
  *     rnVersion: { major, minor, patch } | null,
- *     guidance: string,             // Human-readable instructions
+ *     proxyPort: number | null,      // proxy port when mode='proxy-active'
+ *     guidance: string,              // Human-readable instructions
  *   }
  */
 
 interface OpenDevToolsResult {
-  devtoolsUrl: string | null;
+  devtoolsUrl: string;
   inspectorWsUrl: string;
-  mode: 'native' | 'proxy-required';
+  hermesWsUrl: string;
+  mode: 'native' | 'proxy-active';
   supportsMultipleDebuggers: boolean;
   rnVersion: { major: number; minor: number; patch: number } | null;
+  proxyPort: number | null;
   guidance: string;
 }
 
 const NATIVE_GUIDANCE = [
   'React DevTools can connect to the inspector URL below while your MCP session stays active.',
-  'Open the DevTools URL in Chrome (or paste the inspectorWsUrl directly into a DevTools fusebox instance).',
+  'Open the devtoolsUrl in Chrome (or paste the inspectorWsUrl directly into a DevTools fusebox instance).',
   'Native multi-debugger support on RN >= 0.85 means no proxy is needed — both connections multiplex transparently.',
 ].join('\n');
 
-const PROXY_REQUIRED_GUIDANCE = [
-  'Your RN version does not support native multi-debugger. Using React DevTools will evict the MCP session (CDP close code 1006).',
-  'M1 (this release) ships detection + capability reporting; automatic proxy wiring is tracked as M1b (Phase 100, pending live simulator verification).',
-  'Workaround today: close the MCP CC session while using DevTools, reopen when done. OR upgrade to RN >= 0.85.',
+const PROXY_ACTIVE_GUIDANCE = [
+  'Your RN version does not support native multi-debugger; the multiplexer proxy has been started so React DevTools can coexist with the MCP.',
+  'Open the devtoolsUrl in Chrome. DevTools will connect to the proxy (inspectorWsUrl); the MCP is already routing through it.',
+  'The proxy stops automatically when the MCP disconnects, or explicitly via cdp_disconnect.',
 ].join('\n');
 
 export function createOpenDevToolsHandler(getClient: () => CDPClient) {
@@ -58,14 +58,10 @@ export function createOpenDevToolsHandler(getClient: () => CDPClient) {
     }
 
     const metroPort = client.metroPort;
-    const inspectorWsUrl = `ws://127.0.0.1:${metroPort}/inspector/debug?device=${encodeURIComponent(target.id)}&page=${encodeURIComponent(target.id)}`;
+    const hermesWsUrl = `ws://127.0.0.1:${metroPort}/inspector/debug?device=${encodeURIComponent(target.id)}&page=${encodeURIComponent(target.id)}`;
 
-    // DevTools frontend is served by Metro at /debugger-frontend/rn_fusebox.html
-    // Query params hand the frontend the WS URL it should connect to. Metro auto-loads the React DevTools bundle.
-    const devtoolsUrl = `http://127.0.0.1:${metroPort}/debugger-frontend/rn_fusebox.html?ws=127.0.0.1:${metroPort}/inspector/debug?device=${encodeURIComponent(target.id)}%26page=${encodeURIComponent(target.id)}`;
-
-    // Probe app info for RN version. Best-effort — if probe fails, we still report
-    // inspectorWsUrl and assume proxy-required.
+    // Probe app info for RN version. Best-effort — if probe fails, treat as
+    // proxy-required (conservative default: use the proxy so DevTools doesn't evict the MCP).
     let rnVersion: OpenDevToolsResult['rnVersion'] = null;
     let supportsMultiple = false;
     try {
@@ -84,15 +80,49 @@ export function createOpenDevToolsHandler(getClient: () => CDPClient) {
       }
     } catch { /* leave rnVersion null, supportsMultiple false */ }
 
-    const result: OpenDevToolsResult = {
-      devtoolsUrl: supportsMultiple ? devtoolsUrl : null,
-      inspectorWsUrl,
-      mode: supportsMultiple ? 'native' : 'proxy-required',
-      supportsMultipleDebuggers: supportsMultiple,
-      rnVersion,
-      guidance: supportsMultiple ? NATIVE_GUIDANCE : PROXY_REQUIRED_GUIDANCE,
-    };
+    if (supportsMultiple) {
+      // Native multi-debugger: DevTools connects directly to Hermes via Metro's
+      // /inspector/debug endpoint. No proxy needed.
+      const devtoolsUrl = `http://127.0.0.1:${metroPort}/debugger-frontend/rn_fusebox.html?ws=127.0.0.1:${metroPort}/inspector/debug?device=${encodeURIComponent(target.id)}%26page=${encodeURIComponent(target.id)}`;
+      return okResult({
+        devtoolsUrl,
+        inspectorWsUrl: hermesWsUrl,
+        hermesWsUrl,
+        mode: 'native',
+        supportsMultipleDebuggers: true,
+        rnVersion,
+        proxyPort: null,
+        guidance: NATIVE_GUIDANCE,
+      } satisfies OpenDevToolsResult);
+    }
 
-    return okResult(result);
+    // Proxy path: start (or reuse) the multiplexer so DevTools and MCP coexist.
+    let proxyUrl: string;
+    try {
+      proxyUrl = await client.startProxy();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return failResult(`cdp_open_devtools: failed to start multiplexer proxy: ${message}`);
+    }
+    const proxyPort = client.proxyMultiplexer?.port ?? null;
+    if (proxyPort === null) {
+      // Defensive: startProxy resolved but the multiplexer has no port. Indicates an
+      // internal state drift — fail loudly rather than return a half-working URL.
+      return failResult('cdp_open_devtools: multiplexer started but has no bound port');
+    }
+    // DevTools frontend still lives on Metro (it's static HTML + JS served over HTTP).
+    // Only the WS destination changes: DevTools → proxy (loopback); proxy → Hermes.
+    const devtoolsUrl = `http://127.0.0.1:${metroPort}/debugger-frontend/rn_fusebox.html?ws=127.0.0.1:${proxyPort}`;
+
+    return okResult({
+      devtoolsUrl,
+      inspectorWsUrl: proxyUrl,
+      hermesWsUrl,
+      mode: 'proxy-active',
+      supportsMultipleDebuggers: false,
+      rnVersion,
+      proxyPort,
+      guidance: PROXY_ACTIVE_GUIDANCE,
+    } satisfies OpenDevToolsResult);
   };
 }

--- a/scripts/cdp-bridge/src/tools/status.ts
+++ b/scripts/cdp-bridge/src/tools/status.ts
@@ -85,6 +85,12 @@ async function buildStatusResult(client: CDPClient): Promise<StatusResult> {
       heapProfiler: client.heapProfilerAvailable,
     },
     reconnect: client.reconnectState,
+    proxy: {
+      active: client.isProxyActive,
+      port: client.proxyMultiplexer?.port ?? null,
+      url: client.proxyUrl,
+      consumerCount: client.proxyMultiplexer?.consumerCount ?? 0,
+    },
   };
 }
 

--- a/scripts/cdp-bridge/src/types.ts
+++ b/scripts/cdp-bridge/src/types.ts
@@ -127,6 +127,18 @@ export interface StatusResult {
     lastAttempt: string | null;
     attemptCount: number;
   };
+  /**
+   * M1b (Phase 100+): multiplexer proxy state. `active: true` means React Native
+   * DevTools can coexist with the MCP by connecting to `port` on localhost.
+   * `consumerCount` is the number of DevTools/other-debugger instances connected
+   * to the proxy (excluding the MCP itself).
+   */
+  proxy: {
+    active: boolean;
+    port: number | null;
+    url: string | null;
+    consumerCount: number;
+  };
 }
 
 export interface EvaluateResult {

--- a/scripts/cdp-bridge/test/helpers/mock-cdp-client.js
+++ b/scripts/cdp-bridge/test/helpers/mock-cdp-client.js
@@ -42,6 +42,10 @@ export function createMockClient(overrides = {}) {
     get reconnectState() {
       return { active: false, lastAttempt: null, attemptCount: 0 };
     },
+    /** M1b: proxy getters — default "no proxy active", override via _proxyUrl/_proxyMultiplexer. */
+    get proxyUrl() { return client._proxyUrl; },
+    get isProxyActive() { return client._proxyUrl !== null; },
+    get proxyMultiplexer() { return client._proxyMultiplexer; },
 
     // --- Mutable state (set in overrides or mutated in tests) ---
     _isConnected: true,
@@ -57,6 +61,8 @@ export function createMockClient(overrides = {}) {
     },
     _networkMode: 'cdp',
     _metroEventsClient: null,
+    _proxyUrl: null,
+    _proxyMultiplexer: null,
     _bridgeDetected: false,
     _bridgeVersion: null,
     _logDomainEnabled: true,
@@ -89,6 +95,20 @@ export function createMockClient(overrides = {}) {
     async softReconnect() {
       client._isConnected = true;
       client._helpersInjected = true;
+    },
+
+    async startProxy() {
+      // Mock mirrors real behavior: idempotent, sets URL + multiplexer-like stub,
+      // returns URL. Tests that want failure override this.
+      if (client._proxyUrl) return client._proxyUrl;
+      client._proxyUrl = 'ws://127.0.0.1:45678';
+      client._proxyMultiplexer = { port: 45678, isRunning: true, consumerCount: 0 };
+      return client._proxyUrl;
+    },
+
+    async stopProxy() {
+      client._proxyUrl = null;
+      client._proxyMultiplexer = null;
     },
 
     async reinjectHelpers() {

--- a/scripts/cdp-bridge/test/helpers/mock-hermes.js
+++ b/scripts/cdp-bridge/test/helpers/mock-hermes.js
@@ -1,0 +1,53 @@
+import { createServer } from 'node:http';
+import WebSocket, { WebSocketServer } from 'ws';
+
+/**
+ * Minimal Hermes stand-in used by multiplexer and CDPClient proxy tests.
+ * Accepts a single WS, echoes request ids back as responses, can emit events
+ * on demand, and tracks the raw messages it received for assertion.
+ *
+ * Returns:
+ *   { port, url, received, emit(event), stop() }
+ */
+export function makeMockHermes() {
+  const server = createServer();
+  const wss = new WebSocketServer({ server });
+  let activeWs = null;
+  const received = [];
+
+  wss.on('connection', (ws) => {
+    if (activeWs) {
+      // Real Hermes would evict the older connection; for tests we just reject.
+      ws.close(4000, 'only-one-allowed');
+      return;
+    }
+    activeWs = ws;
+    ws.on('message', (data) => {
+      const raw = data.toString();
+      received.push(raw);
+      const parsed = JSON.parse(raw);
+      if (typeof parsed.id === 'number') {
+        ws.send(
+          JSON.stringify({
+            id: parsed.id,
+            result: { echo: parsed.method, params: parsed.params ?? null },
+          }),
+        );
+      }
+    });
+    ws.on('close', () => { activeWs = null; });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const port = server.address().port;
+      resolve({
+        port,
+        url: `ws://127.0.0.1:${port}`,
+        received,
+        emit: (event) => { if (activeWs) activeWs.send(JSON.stringify(event)); },
+        stop: () => new Promise((r) => { wss.close(() => server.close(() => r())); }),
+      });
+    });
+  });
+}

--- a/scripts/cdp-bridge/test/unit/cdp-client-proxy.test.js
+++ b/scripts/cdp-bridge/test/unit/cdp-client-proxy.test.js
@@ -1,0 +1,201 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { CDPClient } from '../../dist/cdp-client.js';
+import { makeMockHermes } from '../helpers/mock-hermes.js';
+
+// M1b (Phase 100+): CDPClient proxy lifecycle tests.
+//
+// The guard-path tests (throws, idempotency, disconnect cleanup) use planted
+// state and do not spin up real sockets. The softReconnect rollback and
+// concurrency tests use a real mock Hermes so the multiplexer actually starts
+// against a live WS endpoint, and stub only `softReconnect` to control the
+// success/failure of the post-allocation step.
+
+test('CDPClient.isProxyActive defaults to false before startProxy is called', () => {
+  const client = new CDPClient();
+  assert.equal(client.isProxyActive, false);
+  assert.equal(client.proxyUrl, null);
+  assert.equal(client.proxyMultiplexer, null);
+});
+
+test('CDPClient.startProxy throws when no target is connected', async () => {
+  const client = new CDPClient();
+  await assert.rejects(
+    () => client.startProxy(),
+    /startProxy requires an active CDP connection/,
+  );
+  // No state drift after failed guard
+  assert.equal(client.isProxyActive, false);
+  assert.equal(client.proxyUrl, null);
+});
+
+test('CDPClient.stopProxy is a no-op when no proxy is active', async () => {
+  const client = new CDPClient();
+  // Should resolve cleanly without reaching softReconnect (guarded by _proxyUrl null)
+  await client.stopProxy();
+  assert.equal(client.isProxyActive, false);
+});
+
+test('CDPClient.startProxy is idempotent — second call returns existing URL without double-starting', async () => {
+  const client = new CDPClient();
+
+  // Plant a fake already-active state. Skips the multiplexer-start path entirely,
+  // exercising the idempotent early-return.
+  // Private-field access is intentional in tests — JS sees all fields as public.
+  client._proxyUrl = 'ws://127.0.0.1:45678';
+  client._multiplexer = { port: 45678, stop: async () => {}, isRunning: true, consumerCount: 0 };
+
+  const returned = await client.startProxy();
+  assert.equal(returned, 'ws://127.0.0.1:45678', 'returns existing URL, does not allocate new port');
+  assert.equal(client.proxyUrl, 'ws://127.0.0.1:45678', 'state unchanged');
+});
+
+test('CDPClient.disconnect tears down the multiplexer and clears proxy state (graceful shutdown)', async () => {
+  const client = new CDPClient();
+
+  let stopCalled = false;
+  // Plant a fake active multiplexer. disconnect() must invoke stop() on it AND
+  // clear _proxyUrl/_multiplexer — this is the SIGTERM → disconnect path.
+  client._proxyUrl = 'ws://127.0.0.1:45999';
+  client._multiplexer = {
+    port: 45999,
+    isRunning: true,
+    consumerCount: 0,
+    stop: async () => { stopCalled = true; },
+  };
+
+  await client.disconnect();
+
+  assert.equal(stopCalled, true, 'multiplexer.stop was called during disconnect');
+  assert.equal(client.isProxyActive, false, 'proxy state cleared');
+  assert.equal(client.proxyUrl, null);
+  assert.equal(client.proxyMultiplexer, null);
+});
+
+test('CDPClient.disconnect is idempotent — safe to call twice (graceful shutdown race)', async () => {
+  const client = new CDPClient();
+
+  let stopCalls = 0;
+  client._proxyUrl = 'ws://127.0.0.1:45000';
+  client._multiplexer = {
+    port: 45000,
+    isRunning: true,
+    consumerCount: 0,
+    stop: async () => { stopCalls++; },
+  };
+
+  await client.disconnect();
+  await client.disconnect(); // Second call — must not re-stop
+
+  assert.equal(stopCalls, 1, 'multiplexer.stop called exactly once across two disconnects');
+});
+
+test('CDPClient.disconnect tolerates multiplexer.stop() rejecting (best-effort cleanup)', async () => {
+  const client = new CDPClient();
+
+  client._proxyUrl = 'ws://127.0.0.1:45111';
+  client._multiplexer = {
+    port: 45111,
+    isRunning: true,
+    consumerCount: 0,
+    stop: async () => { throw new Error('multiplexer cleanup failed'); },
+  };
+
+  // disconnect() must still complete — proxy cleanup is best-effort, not a hard requirement.
+  await client.disconnect();
+
+  assert.equal(client.isProxyActive, false, 'proxy state cleared despite stop() rejecting');
+});
+
+// ── D661 review-driven regression tests (concurrency guard + rollback path) ──
+
+function plantConnectedTarget(client, hermesUrl) {
+  client._connectedTarget = {
+    id: 'page1',
+    title: 'Mock',
+    vm: 'Hermes',
+    webSocketDebuggerUrl: hermesUrl,
+    platform: 'ios',
+  };
+}
+
+test('CDPClient.startProxy rolls back multiplexer when softReconnect throws (D661 rollback path)', async () => {
+  const hermes = await makeMockHermes();
+  const client = new CDPClient();
+  plantConnectedTarget(client, hermes.url);
+
+  // Stub softReconnect to simulate the "connection landed, but the full session
+  // re-setup failed" path. This is the only branch that triggers rollback.
+  client.softReconnect = async () => { throw new Error('simulated reconnect failure'); };
+
+  await assert.rejects(() => client.startProxy(), /simulated reconnect failure/);
+
+  // Rollback assertions: both fields null, multiplexer stopped (its port freed).
+  assert.equal(client.isProxyActive, false, 'proxy state rolled back after softReconnect failure');
+  assert.equal(client.proxyUrl, null, '_proxyUrl cleared');
+  assert.equal(client.proxyMultiplexer, null, '_multiplexer cleared');
+
+  // A fresh startProxy must succeed (state genuinely reset, not just nulled out).
+  let reconnects = 0;
+  client.softReconnect = async () => { reconnects++; };
+  const url = await client.startProxy();
+  assert.match(url, /^ws:\/\/127\.0\.0\.1:\d+$/, 'fresh startProxy succeeds after rollback');
+  assert.equal(reconnects, 1);
+
+  await client.disconnect();
+  await hermes.stop();
+});
+
+test('CDPClient.startProxy is concurrency-safe — parallel callers share one multiplexer (D661 in-flight guard)', async () => {
+  const hermes = await makeMockHermes();
+  const client = new CDPClient();
+  plantConnectedTarget(client, hermes.url);
+
+  // Stub softReconnect with a small delay so both callers definitely race through
+  // the guard during the multiplexer.start() await window.
+  client.softReconnect = async () => {
+    await new Promise((r) => setTimeout(r, 30));
+  };
+
+  const [u1, u2, u3] = await Promise.all([
+    client.startProxy(),
+    client.startProxy(),
+    client.startProxy(),
+  ]);
+
+  assert.equal(u1, u2, 'first and second callers get identical URL');
+  assert.equal(u2, u3, 'third caller also joins the same in-flight');
+  assert.match(u1, /^ws:\/\/127\.0\.0\.1:\d+$/);
+  assert.ok(client.proxyMultiplexer, 'exactly one multiplexer stored');
+  assert.equal(client.proxyUrl, u1);
+
+  // Second (post-resolved) call takes the already-active early return.
+  const u4 = await client.startProxy();
+  assert.equal(u4, u1, 'post-resolved calls return existing URL without re-allocating');
+
+  await client.disconnect();
+  await hermes.stop();
+});
+
+test('CDPClient.startProxy: after failed start, in-flight guard clears so next call retries cleanly (D661)', async () => {
+  const hermes = await makeMockHermes();
+  const client = new CDPClient();
+  plantConnectedTarget(client, hermes.url);
+
+  let attempts = 0;
+  client.softReconnect = async () => {
+    attempts++;
+    if (attempts === 1) throw new Error('first attempt fails');
+  };
+
+  // First call rejects → rollback path → _startProxyInFlight cleared.
+  await assert.rejects(() => client.startProxy(), /first attempt fails/);
+
+  // Second call must create a NEW multiplexer (previous one was torn down).
+  const url = await client.startProxy();
+  assert.match(url, /^ws:\/\/127\.0\.0\.1:\d+$/);
+  assert.equal(attempts, 2, 'second attempt ran (in-flight cache did not poison retry)');
+
+  await client.disconnect();
+  await hermes.stop();
+});

--- a/scripts/cdp-bridge/test/unit/cdp-connect.test.js
+++ b/scripts/cdp-bridge/test/unit/cdp-connect.test.js
@@ -35,6 +35,7 @@ function createMockContext({ initialFilters = {}, port = 8081 } = {}) {
     handleClose: () => {},
     rejectAllPending: () => {},
     setup: async () => {},
+    getProxyUrl: () => null,
   };
   return { state, ctx };
 }

--- a/scripts/cdp-bridge/test/unit/multiplexer.test.js
+++ b/scripts/cdp-bridge/test/unit/multiplexer.test.js
@@ -9,6 +9,7 @@ import {
 } from '../../dist/cdp/multiplexer.js';
 import { createOpenDevToolsHandler } from '../../dist/tools/open-devtools.js';
 import { createMockClient } from '../helpers/mock-cdp-client.js';
+import { makeMockHermes } from '../helpers/mock-hermes.js';
 import { expectOk, expectFail } from '../helpers/result-helpers.js';
 
 // ── Pure helpers: parseRNVersion / supportsNativeMultiDebugger ──
@@ -56,48 +57,7 @@ test('supportsNativeMultiDebugger: unknown shapes fall back to false (conservati
 });
 
 // ── CDPMultiplexer: full integration tests with real WS ──
-
-function makeMockHermes() {
-  // A tiny Hermes stand-in: echoes request ids back as responses, and can emit events on demand.
-  const server = createServer();
-  const wss = new WebSocketServer({ server });
-  let activeWs = null;
-  const received = [];
-
-  wss.on('connection', (ws) => {
-    if (activeWs) {
-      // Real Hermes would evict; for tests we just ignore
-      ws.close(4000, 'only-one-allowed');
-      return;
-    }
-    activeWs = ws;
-    ws.on('message', (data) => {
-      const raw = data.toString();
-      received.push(raw);
-      const parsed = JSON.parse(raw);
-      if (typeof parsed.id === 'number') {
-        // Echo back a response keyed on the same id
-        ws.send(JSON.stringify({ id: parsed.id, result: { echo: parsed.method, params: parsed.params ?? null } }));
-      }
-    });
-    ws.on('close', () => { activeWs = null; });
-  });
-
-  return new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', () => {
-      const port = server.address().port;
-      resolve({
-        port,
-        url: `ws://127.0.0.1:${port}`,
-        received,
-        emit: (event) => { if (activeWs) activeWs.send(JSON.stringify(event)); },
-        stop: () => new Promise((r) => {
-          wss.close(() => server.close(() => r()));
-        }),
-      });
-    });
-  });
-}
+// (makeMockHermes lives in ../helpers/mock-hermes.js — shared across proxy tests.)
 
 function connectConsumer(port) {
   return new Promise((resolve, reject) => {
@@ -309,7 +269,7 @@ test('cdp_open_devtools: fails when not connected', async () => {
   assert.match(err, /not connected/i);
 });
 
-test('cdp_open_devtools: mode=native when RN >= 0.85', async () => {
+test('cdp_open_devtools: mode=native when RN >= 0.85 (no proxy started)', async () => {
   const client = createMockClient({
     async evaluate() {
       return { value: JSON.stringify({ major: 0, minor: 85, patch: 0 }) };
@@ -321,10 +281,13 @@ test('cdp_open_devtools: mode=native when RN >= 0.85', async () => {
   assert.equal(data.supportsMultipleDebuggers, true);
   assert.ok(data.devtoolsUrl !== null, 'devtoolsUrl populated in native mode');
   assert.match(data.inspectorWsUrl, /^ws:\/\/127\.0\.0\.1:8081/);
+  assert.equal(data.inspectorWsUrl, data.hermesWsUrl, 'native mode: inspector and hermes URLs identical');
+  assert.equal(data.proxyPort, null, 'native mode: no proxy port');
+  assert.equal(client.proxyUrl, null, 'native mode does not call startProxy');
   assert.deepEqual(data.rnVersion, { major: 0, minor: 85, patch: 0 });
 });
 
-test('cdp_open_devtools: mode=proxy-required when RN < 0.85', async () => {
+test('cdp_open_devtools: mode=proxy-active when RN < 0.85 (M1b — proxy auto-starts)', async () => {
   const client = createMockClient({
     async evaluate() {
       return { value: JSON.stringify({ major: 0, minor: 76, patch: 7 }) };
@@ -332,14 +295,17 @@ test('cdp_open_devtools: mode=proxy-required when RN < 0.85', async () => {
   });
   const handler = createOpenDevToolsHandler(() => client);
   const data = expectOk(await handler({}));
-  assert.equal(data.mode, 'proxy-required');
+  assert.equal(data.mode, 'proxy-active', 'proxy started automatically on RN < 0.85');
   assert.equal(data.supportsMultipleDebuggers, false);
-  assert.equal(data.devtoolsUrl, null, 'devtoolsUrl null in proxy-required mode');
-  assert.ok(data.inspectorWsUrl, 'inspectorWsUrl still reported even when proxy-required');
-  assert.match(data.guidance, /M1b|Phase 100|evict/i, 'guidance mentions the M1b deferral or eviction risk');
+  assert.ok(data.devtoolsUrl, 'devtoolsUrl populated (points at proxy port)');
+  assert.match(data.devtoolsUrl, /ws=127\.0\.0\.1:\d+$/, 'devtoolsUrl ws= targets the proxy (no /inspector path)');
+  assert.match(data.inspectorWsUrl, /^ws:\/\/127\.0\.0\.1:\d+$/, 'inspectorWsUrl is the proxy URL');
+  assert.match(data.hermesWsUrl, /\/inspector\/debug\?device=/, 'hermesWsUrl is still the direct Hermes URL');
+  assert.equal(typeof data.proxyPort, 'number', 'proxyPort is a bound port');
+  assert.match(data.guidance, /proxy has been started|coexist/i, 'guidance reflects active-proxy state');
 });
 
-test('cdp_open_devtools: mode=proxy-required when rnVersion probe fails (conservative default)', async () => {
+test('cdp_open_devtools: mode=proxy-active when rnVersion probe fails (conservative default)', async () => {
   const client = createMockClient({
     async evaluate() {
       return { value: 'null' }; // probe returned null — version unknown
@@ -347,9 +313,25 @@ test('cdp_open_devtools: mode=proxy-required when rnVersion probe fails (conserv
   });
   const handler = createOpenDevToolsHandler(() => client);
   const data = expectOk(await handler({}));
-  assert.equal(data.mode, 'proxy-required');
+  assert.equal(data.mode, 'proxy-active', 'unknown version → conservative: use proxy');
   assert.equal(data.supportsMultipleDebuggers, false);
   assert.equal(data.rnVersion, null);
+  assert.ok(data.devtoolsUrl, 'devtoolsUrl populated in conservative-proxy fallback');
+});
+
+test('cdp_open_devtools: failResult when startProxy throws (M1b error path)', async () => {
+  const client = createMockClient({
+    async evaluate() {
+      return { value: JSON.stringify({ major: 0, minor: 76, patch: 7 }) };
+    },
+    async startProxy() {
+      throw new Error('multiplexer start failed: port already in use');
+    },
+  });
+  const handler = createOpenDevToolsHandler(() => client);
+  const err = expectFail(await handler({}));
+  assert.match(err, /failed to start multiplexer proxy/i);
+  assert.match(err, /port already in use/i, 'underlying error is surfaced');
 });
 
 test('cdp_open_devtools: fails gracefully when no target selected', async () => {
@@ -357,6 +339,145 @@ test('cdp_open_devtools: fails gracefully when no target selected', async () => 
   const handler = createOpenDevToolsHandler(() => client);
   const err = expectFail(await handler({}));
   assert.match(err, /no target/i);
+});
+
+// ── M1b prerequisites: buffer cap, routing sweeper, failed-start cleanup ──
+
+function makeSilentHermes() {
+  // Accepts WS, receives messages, NEVER responds. Lets us accumulate routing entries
+  // that the sweeper should later evict.
+  const server = createServer();
+  const wss = new WebSocketServer({ server });
+  const received = [];
+  wss.on('connection', (ws) => {
+    ws.on('message', (data) => received.push(data.toString()));
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({
+        port: server.address().port,
+        url: `ws://127.0.0.1:${server.address().port}`,
+        received,
+        stop: () => new Promise((r) => { wss.close(() => server.close(() => r())); }),
+      });
+    });
+  });
+}
+
+function makeDelayedHermes(openDelayMs) {
+  // Accepts the TCP connection but delays the WS upgrade by openDelayMs.
+  // This keeps the proxy's upstream hermesWs in the CONNECTING state, forcing
+  // any consumer messages in that window into hermesBuffer.
+  const server = createServer();
+  const wss = new WebSocketServer({ noServer: true });
+  const received = [];
+
+  server.on('upgrade', (req, socket, head) => {
+    setTimeout(() => {
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        wss.emit('connection', ws, req);
+      });
+    }, openDelayMs);
+  });
+
+  wss.on('connection', (ws) => {
+    ws.on('message', (data) => received.push(data.toString()));
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({
+        port: server.address().port,
+        url: `ws://127.0.0.1:${server.address().port}`,
+        received,
+        stop: () => new Promise((r) => { wss.close(() => server.close(() => r())); }),
+      });
+    });
+  });
+}
+
+test('CDPMultiplexer: M1b prereq — hermesBuffer drops oldest when cap exceeded during CONNECTING window', async () => {
+  const hermes = await makeDelayedHermes(250);
+  const proxy = new CDPMultiplexer({ hermesUrl: hermes.url, hermesBufferMaxSize: 3 });
+  try {
+    // Kick off start WITHOUT awaiting; the consumer server binds synchronously once
+    // startConsumerServer's listen fires, but connectHermes stays pending on upgrade.
+    const startPromise = proxy.start();
+
+    // Poll for the bound port — available as soon as httpServer.listen completes.
+    let port = null;
+    for (let i = 0; i < 30; i++) {
+      if (proxy.port !== null) { port = proxy.port; break; }
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    assert.ok(port, 'consumer server should bind before Hermes upgrade delay expires');
+
+    const consumer = await connectConsumer(port);
+
+    // Flood 5 messages while hermesWs is still CONNECTING.
+    for (let i = 1; i <= 5; i++) {
+      consumer.send(JSON.stringify({ id: i, method: `Flood.m${i}` }));
+    }
+
+    // Buffer should be capped at 3 (oldest two dropped).
+    // Small wait to let the consumer's on('message') handlers fire.
+    await new Promise((r) => setTimeout(r, 30));
+    assert.equal(proxy.hermesBufferSize, 3, 'buffer size capped at hermesBufferMaxSize');
+
+    // Wait for Hermes to open and drain the buffer.
+    await startPromise;
+    await new Promise((r) => setTimeout(r, 150));
+
+    assert.equal(hermes.received.length, 3, 'exactly hermesBufferMaxSize messages reach Hermes');
+    const methods = hermes.received.map((raw) => JSON.parse(raw).method);
+    assert.deepEqual(methods, ['Flood.m3', 'Flood.m4', 'Flood.m5'], 'drop-oldest preserves newest');
+
+    consumer.close();
+  } finally {
+    await proxy.stop();
+    await hermes.stop();
+  }
+});
+
+test('CDPMultiplexer: M1b prereq — routing sweeper evicts entries past routingTimeoutMs', async () => {
+  const hermes = await makeSilentHermes();
+  // 150ms timeout → sweeper interval = max(500, 75) = 500ms. Use slightly longer waits.
+  const proxy = new CDPMultiplexer({ hermesUrl: hermes.url, routingTimeoutMs: 150 });
+  try {
+    const port = await proxy.start();
+    const consumer = await connectConsumer(port);
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Send 3 requests; Hermes swallows, so all 3 routes persist.
+    for (let i = 1; i <= 3; i++) {
+      consumer.send(JSON.stringify({ id: i, method: `Silent.m${i}` }));
+    }
+    await new Promise((r) => setTimeout(r, 50));
+    assert.equal(proxy.routingTableSize, 3, 'routes accumulate while upstream is silent');
+
+    // Wait past timeout + one sweeper cycle. Sweeper interval is 500ms for a 150ms timeout,
+    // so wait ~700ms to guarantee eviction.
+    await new Promise((r) => setTimeout(r, 700));
+
+    assert.equal(proxy.routingTableSize, 0, 'sweeper cleared all expired routes');
+
+    consumer.close();
+  } finally {
+    await proxy.stop();
+    await hermes.stop();
+  }
+});
+
+test('CDPMultiplexer: M1b prereq — failed start cleans up fully (port released, state=stopped)', async () => {
+  const proxy = new CDPMultiplexer({ hermesUrl: 'ws://127.0.0.1:59994/nope' });
+  await assert.rejects(() => proxy.start(), /ECONNREFUSED|connect/);
+
+  assert.equal(proxy.isRunning, false, 'not running after failure');
+  assert.equal(proxy.port, null, 'boundPort cleared — httpServer was closed in cleanup');
+
+  // Follow-up stop() must be a safe no-op (state === 'stopped').
+  await proxy.stop();
+  assert.equal(proxy.port, null);
 });
 
 test('CDPMultiplexer: consumer disconnect clears its pending routes (no response leak)', async () => {


### PR DESCRIPTION
## Summary

Completes the M1 story split from 2026-04-20 (D654). On RN < 0.85, `cdp_open_devtools` now starts the multiplexer proxy automatically and re-routes the MCP's own CDP WebSocket through it. React Native DevTools connects to the same proxy as a second consumer — both coexist on single-debugger Hermes without evicting each other.

## What changed

### Multiplexer prereq hardening (3 fixes, required before new traffic lands)
- `hermesBufferMaxSize` option (default 1000) + drop-oldest in `sendToHermes()`. Prevents CONNECTING-window flood from OOM'ing the MCP.
- `routingTimeoutMs` option (default 60s) + periodic sweeper. Evicts orphaned routing entries on partial-death upstreams.
- `start()` failure path matches `stop()` ordering: `state='stopping'` during cleanup, `state='stopped'` only after. Closes a concurrent-start race under SIGTERM.

### CDPClient lifecycle
- `startProxy(opts?)` / `stopProxy()` — owned by CDPClient (same pattern as `_metroEventsClient`). `disconnect()` tears down the multiplexer when active — only reliable SIGTERM hook.
- `ConnectContext.getProxyUrl()` threads URL override into `connectToTarget`. Single-point override; reconnect state machine unchanged.

### Tool surface
- `cdp_open_devtools` mode rename: `'proxy-required'` → `'proxy-active'` when RN < 0.85 (auto-starts proxy). New fields: `hermesWsUrl`, `proxyPort`.
- `cdp_status.proxy` block: `{ active, port, url, consumerCount }`.

### Multi-review fixes (Gemini + Codex, applied pre-commit)
- **Concurrency guard**: `_startProxyInFlight` promise cache serializes parallel `startProxy()` callers. Without this, two concurrent `cdp_open_devtools` calls each allocated a multiplexer; the second overwrote `_multiplexer`, and the first was orphaned (port bound, sweeper running, unreferenced).
- **Rollback-path tests**: 3 new tests using a real mock Hermes + stubbed `softReconnect` exercise the catch-block teardown. Previously unreachable because mock-client `softReconnect` never threw.

### B132 logged as known limitation
Multiplexer captures `hermesUrl` once at `startProxy` time; Hermes may regenerate URL on reload/eviction, leaving proxy routing to dead upstream. Pre-existing M1a design limit, not introduced by M1b. Workaround: `cdp_disconnect` + `cdp_open_devtools`. Follow-up requires multiplexer upstream-refresh API or client-level teardown-and-restart on target change.

## Versions

- Plugin `0.33.0 → 0.34.0`
- MCP `0.28.0 → 0.29.0`
- Tests `451 → 462` (+11)

## Test plan

- [x] `npm test` — 462/462 passing (all unit)
- [x] `npm run build` — TypeScript compile clean
- [x] Multi-review (Gemini + Codex) on full diff — 2 findings flagged, both addressed pre-commit
- [ ] Live simulator smoke: `cdp_status` → `cdp_open_devtools` on iOS 26.0 + Android API 37, confirm `devtoolsUrl` loads in Chrome and `cdp_status.proxy.consumerCount` observes 1 → 2 transition when DevTools connects
- [ ] Verify `disconnect()` releases proxy port (no lingering loopback listener after session end)
- [ ] Regression: confirm RN 0.85+ path still returns `mode: 'native'` without starting proxy

## Refs

- D661 (`../rn-dev-agent-workspace/docs/DECISIONS.md`)
- Phase 104 (`../rn-dev-agent-workspace/docs/ROADMAP.md`)
- B132 follow-up (`../rn-dev-agent-workspace/docs/BUGS.md`)
- Parent: D654 / M1a (Phase 100, 2026-04-20)