### PR TITLE
fix(b132/phase-105): proxy auto-resume across reconnect (D662)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.35.0] — 2026-04-21
+
+B132 / Phase 105 — proxy auto-resume across reconnect. Closes the known limitation logged during M1b review: the multiplexer captured `hermesUrl` once at `startProxy` time, so any event that invalidated the target URL (hot reload, target eviction, Metro restart) left the proxy routing to a dead upstream with every MCP call silently timing out. This release auto-suspends the proxy when the MCP's CDP WebSocket closes, runs the normal reconnect loop directly against Hermes, then auto-resumes the proxy against the refreshed target URL. MCP server bumped to 0.30.0.
+
+### Added
+- **`CDPClient._proxyDesired` intent flag**. Tracks user's standing wish for a proxy separately from the live `_proxyUrl`. Set by successful `startProxy()`, cleared by `stopProxy()` / `disconnect()`. Preserved across internal `_suspendProxy()` so auto-resume knows to re-allocate.
+- **`CDPClient._suspendProxy()` / `_resumeProxy()` internal lifecycle**. `_suspendProxy` clears `_proxyUrl` synchronously (so the reconnect loop observes cleared state before the multiplexer's HTTP server finishes its async shutdown) and tears down the old multiplexer best-effort. `_resumeProxy` rehydrates a fresh multiplexer against the CURRENT `_connectedTarget.webSocketDebuggerUrl`.
+- **`ReconnectContext.afterReconnect?: () => Promise<void>`**. New optional callback fired inside `reconnect()` after `discoverAndConnect` resolves successfully. Used by CDPClient to auto-resume the proxy. Hook failures are caught + logged, never propagated — a post-reconnect hook cannot undo a successful reconnect.
+- **`CDPClient._softReconnectDirect()`**. Bypasses the new `softReconnect` wrapper for internal callers like `_doStartProxy`, avoiding infinite-rollback where the wrapper would suspend the just-allocated multiplexer. Named method (not inline call) so tests can stub the direct path independently of the public `softReconnect`.
+
+### Changed (behavioral, forward-compatible)
+- **`CDPClient.softReconnect()` now wraps with suspend→reconnect→resume** when a proxy is active. Covers all auto-recovery paths (e.g., `cdp_status`'s `__DEV__=false` recovery). When no proxy is active, behavior is unchanged.
+- **`CDPClient.handleClose()` now fires-and-forgets `_suspendProxy()` before delegating to the reconnect machinery**. `_suspendProxy` is ordered so its synchronous preamble (clearing `_proxyUrl`) runs before `handleCloseFn` returns control — guaranteeing the reconnect loop's `discoverAndConnect → connectToTarget → ctx.getProxyUrl()` sees `null`. Multiplexer HTTP server shutdown runs concurrently but harmlessly (no one still routes to it).
+
+### Fixed
+- **B132: stale `hermesUrl` in multiplexer after target change or Metro reload** — see Added. The multiplexer now rehydrates against the fresh target URL on every reconnect, eliminating the silent "proxy routes to dead upstream" failure mode.
+
+### Testing
+- 462 → 475 tests passing (+13): 10 CDPClient proxy-lifecycle tests (`_suspendProxy` sync behavior, `_resumeProxy` guards + one-shot failure policy, `softReconnect` wrapper suspend+resume, `stopProxy`/`disconnect` clearing desired flag, end-to-end URL rehydration via both `softReconnect` wrapper and `afterReconnect` callback trigger paths) + 3 reconnect-loop tests (`afterReconnect` fires exactly once on success, undefined-callback backwards compat, hook failure doesn't propagate).
+
+### Multi-review outcome
+Gemini + Codex both returned clean (no high-confidence issues). Six critical race-condition questions verified: suspend-before-reconnect ordering, double-resume hazard on preemption, `_doStartProxy` rollback correctness, `_resumeProxy` failure policy, `_startProxyInFlight` concurrency sharing, end-to-end test soundness. One below-threshold observation from Gemini (the end-to-end test exercised the softReconnect-wrapper path but not the `afterReconnect` trigger specifically) closed with an additional focused test.
+
+### Policy choices documented
+- **`_resumeProxy` failure → clear `_proxyDesired`** (predictable over resilient). Silent-retry-on-every-reconnect would mask structural bugs. User sees the log warning once and can re-run `cdp_open_devtools` to retry manually.
+- **`handleClose` uses `void this._suspendProxy()`** (fire-and-forget). The synchronous preamble is sufficient to redirect the reconnect; awaiting `mux.stop()` would block the `handleClose` path unnecessarily.
+
+### Refs
+- D662 in DECISIONS.md. Phase 105 in ROADMAP.md. B132 closed in BUGS.md. Parent: D661 / Phase 104 (M1b, 2026-04-21). Branch: `fix/b132-proxy-auto-resume`.
+
+---
+
 ## [0.34.0] — 2026-04-21
 
 M1b / Phase 104 — CDP proxy routing integration. Completes the M1 story split from 2026-04-20: on RN < 0.85, `cdp_open_devtools` now starts the multiplexer proxy automatically and re-routes the MCP's own CDP WebSocket through it, so React Native DevTools can connect to the same proxy as a second consumer. Both coexist on single-debugger Hermes without evicting each other. MCP server bumped to 0.29.0.

--- a/scripts/cdp-bridge/dist/cdp-client.js
+++ b/scripts/cdp-bridge/dist/cdp-client.js
@@ -58,6 +58,12 @@ export class CDPClient {
     // multiplexer, with the second overwriting _multiplexer and orphaning the first.
     // In-flight promise cache serializes concurrent callers on the same startup.
     _startProxyInFlight = null;
+    // B132 (M1b follow-up): separate user intent from live proxy state. `_proxyUrl`
+    // is the live state (null between suspend and resume). `_proxyDesired` is the
+    // user's standing wish — set by successful startProxy(), cleared by stopProxy()
+    // or disconnect(). Preserved across _suspendProxy() so post-reconnect auto-resume
+    // can rehydrate the proxy against the fresh target URL.
+    _proxyDesired = false;
     constructor(port) {
         this._port = port ?? 8081;
         this._consoleBuffer = new RingBuffer(200);
@@ -127,6 +133,27 @@ export class CDPClient {
         return discoverAndConnectFn(this.buildConnectCtx(), portHint, filters);
     }
     async softReconnect() {
+        // B132: if the proxy is active, suspend it first so the reconnect goes
+        // DIRECT to Hermes (not through the potentially-stale proxy), then resume
+        // on success so DevTools can reconnect. This covers auto-recovery paths
+        // like `cdp_status` __DEV__=false recovery.
+        const wasProxyActive = this._proxyUrl !== null;
+        if (wasProxyActive) {
+            await this._suspendProxy();
+        }
+        const result = await this._softReconnectDirect();
+        if (wasProxyActive) {
+            await this._resumeProxy();
+        }
+        return result;
+    }
+    /**
+     * B132: softReconnect that BYPASSES the suspend/resume wrapper. Used only
+     * by `_doStartProxy` — we must not suspend the multiplexer we just allocated.
+     * Kept as a named private method (not an inline call) so tests can stub it
+     * independently of the public `softReconnect`.
+     */
+    async _softReconnectDirect() {
         return softReconnectFn(this.buildReconnectCtx());
     }
     /**
@@ -160,7 +187,12 @@ export class CDPClient {
         this._proxyUrl = `ws://127.0.0.1:${port}`;
         logger.info('CDP', `Proxy started on ${this._proxyUrl}, soft-reconnecting current session`);
         try {
-            await this.softReconnect();
+            // B132: call `_softReconnectDirect` instead of `this.softReconnect()`. The
+            // wrapper would observe _proxyUrl just set above and try to suspend the
+            // multiplexer we just allocated — infinite rollback. `_softReconnectDirect`
+            // is also testable in isolation (tests can stub it to simulate failure
+            // without the full softReconnectFn machinery).
+            await this._softReconnectDirect();
         }
         catch (err) {
             // Soft-reconnect failed — tear the proxy back down so we don't leave a
@@ -173,6 +205,10 @@ export class CDPClient {
             this._proxyUrl = null;
             throw err;
         }
+        // B132: set intent ONLY after the full startup+softReconnect succeeds.
+        // If any step failed, _proxyDesired stays false — no surprise auto-resume
+        // on the next reconnect.
+        this._proxyDesired = true;
         return this._proxyUrl;
     }
     /**
@@ -180,6 +216,10 @@ export class CDPClient {
      * No-op if the proxy isn't active.
      */
     async stopProxy() {
+        // B132: clear intent FIRST so the softReconnect wrapper's auto-resume hook
+        // (and any in-flight afterReconnect hook from a concurrent reconnect) sees
+        // _proxyDesired=false and skips re-allocating a new proxy.
+        this._proxyDesired = false;
         if (!this._proxyUrl)
             return;
         logger.info('CDP', `Stopping proxy at ${this._proxyUrl}`);
@@ -199,6 +239,56 @@ export class CDPClient {
                 }
                 catch { /* best-effort */ }
             }
+        }
+    }
+    /**
+     * B132: stop the multiplexer without reconnecting the MCP. Called from
+     * `handleClose` and the `softReconnect` wrapper BEFORE a reconnect fires, so
+     * the reconnect attempts go DIRECT to Hermes. Preserves `_proxyDesired` so
+     * `_resumeProxy` can rehydrate the proxy against the fresh target URL after
+     * the reconnect succeeds.
+     */
+    async _suspendProxy() {
+        if (!this._proxyUrl)
+            return;
+        const mux = this._multiplexer;
+        // Clear _proxyUrl SYNCHRONOUSLY so any concurrent reconnect observes it
+        // cleared before the multiplexer's HTTP server is actually torn down.
+        this._proxyUrl = null;
+        this._multiplexer = null;
+        if (mux) {
+            try {
+                await mux.stop();
+            }
+            catch { /* best-effort */ }
+        }
+    }
+    /**
+     * B132: if `_proxyDesired` is set and no proxy is currently active, restart
+     * the multiplexer against the CURRENT `_connectedTarget` (which may have a
+     * different `webSocketDebuggerUrl` after reconnect — that's the whole point).
+     *
+     * Failure policy: log a warning and CLEAR `_proxyDesired` so we don't
+     * silently loop on every subsequent reconnect. User can re-run
+     * `cdp_open_devtools` to retry manually. This is "predictable over resilient"
+     * — noisy failures are easier to debug than silent retries.
+     */
+    async _resumeProxy() {
+        if (!this._proxyDesired)
+            return;
+        if (this.disposed)
+            return;
+        if (!this._connectedTarget)
+            return;
+        if (this._proxyUrl)
+            return;
+        try {
+            await this.startProxy();
+            logger.info('CDP', 'Proxy auto-resumed after reconnect');
+        }
+        catch (err) {
+            logger.warn('CDP', `Proxy auto-resume failed — clearing desired flag. Run cdp_open_devtools to retry: ${err instanceof Error ? err.message : err}`);
+            this._proxyDesired = false;
         }
     }
     async disconnect() {
@@ -229,6 +319,9 @@ export class CDPClient {
             this._multiplexer = null;
             this._proxyUrl = null;
         }
+        // B132: clear intent on disposal — a fresh CDPClient must not inherit
+        // desired=true from a previous session.
+        this._proxyDesired = false;
         if (this.ws) {
             this.ws.removeAllListeners();
             if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {
@@ -378,6 +471,15 @@ export class CDPClient {
         wireEventHandlers(this.eventHandlers, { console: this._consoleBuffer, network: this._networkBufferManager, log: this._logBuffer, scripts: this._scripts }, (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)), () => this._isPaused, (v) => { this._isPaused = v; }, () => this.activeDeviceKey);
     }
     handleClose(code) {
+        // B132: if the proxy is active when the upstream closes, suspend it BEFORE
+        // the reconnect loop fires. `_suspendProxy` clears `_proxyUrl` synchronously
+        // at its start (before the first await), so by the time `reconnect()` calls
+        // `discoverAndConnect` → `connectToTarget` → `ctx.getProxyUrl()`, the URL
+        // is already null and reconnect goes direct. Fire-and-forget is fine — the
+        // multiplexer's HTTP server shutdown is bounded and doesn't gate reconnect.
+        if (this._proxyUrl) {
+            void this._suspendProxy();
+        }
         handleCloseFn(this.buildReconnectCtx(), code);
     }
     async reconnect() {
@@ -417,6 +519,11 @@ export class CDPClient {
             getPort: () => this._port,
             setBgPollTimer: (timer) => { this._bgPollTimer = timer; },
             getBgPollTimer: () => this._bgPollTimer,
+            // B132: after the exponential-backoff reconnect loop succeeds, rehydrate
+            // the proxy if one was desired. This is the "auto-resume" half of the
+            // suspend→reconnect→resume sequence. softReconnect has its own wrapper
+            // and does NOT go through this hook — would double-fire the resume.
+            afterReconnect: () => this._resumeProxy(),
         };
     }
     buildConnectCtx() {

--- a/scripts/cdp-bridge/dist/cdp/reconnection.js
+++ b/scripts/cdp-bridge/dist/cdp/reconnection.js
@@ -96,6 +96,14 @@ export async function reconnect(ctx) {
             await ctx.discoverAndConnect();
             ctx.setReconnecting(false);
             console.error('CDP: reconnected successfully');
+            if (ctx.afterReconnect) {
+                try {
+                    await ctx.afterReconnect();
+                }
+                catch (err) {
+                    logger.warn('CDP', `afterReconnect hook failed: ${err instanceof Error ? err.message : err}`);
+                }
+            }
             return;
         }
         catch {

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/cdp-client.ts
+++ b/scripts/cdp-bridge/src/cdp-client.ts
@@ -85,6 +85,12 @@ export class CDPClient {
   // multiplexer, with the second overwriting _multiplexer and orphaning the first.
   // In-flight promise cache serializes concurrent callers on the same startup.
   private _startProxyInFlight: Promise<string> | null = null;
+  // B132 (M1b follow-up): separate user intent from live proxy state. `_proxyUrl`
+  // is the live state (null between suspend and resume). `_proxyDesired` is the
+  // user's standing wish — set by successful startProxy(), cleared by stopProxy()
+  // or disconnect(). Preserved across _suspendProxy() so post-reconnect auto-resume
+  // can rehydrate the proxy against the fresh target URL.
+  private _proxyDesired = false;
 
   constructor(port?: number) {
     this._port = port ?? 8081;
@@ -166,6 +172,28 @@ export class CDPClient {
   }
 
   async softReconnect(): Promise<string> {
+    // B132: if the proxy is active, suspend it first so the reconnect goes
+    // DIRECT to Hermes (not through the potentially-stale proxy), then resume
+    // on success so DevTools can reconnect. This covers auto-recovery paths
+    // like `cdp_status` __DEV__=false recovery.
+    const wasProxyActive = this._proxyUrl !== null;
+    if (wasProxyActive) {
+      await this._suspendProxy();
+    }
+    const result = await this._softReconnectDirect();
+    if (wasProxyActive) {
+      await this._resumeProxy();
+    }
+    return result;
+  }
+
+  /**
+   * B132: softReconnect that BYPASSES the suspend/resume wrapper. Used only
+   * by `_doStartProxy` — we must not suspend the multiplexer we just allocated.
+   * Kept as a named private method (not an inline call) so tests can stub it
+   * independently of the public `softReconnect`.
+   */
+  private async _softReconnectDirect(): Promise<string> {
     return softReconnectFn(this.buildReconnectCtx());
   }
 
@@ -199,7 +227,12 @@ export class CDPClient {
     this._proxyUrl = `ws://127.0.0.1:${port}`;
     logger.info('CDP', `Proxy started on ${this._proxyUrl}, soft-reconnecting current session`);
     try {
-      await this.softReconnect();
+      // B132: call `_softReconnectDirect` instead of `this.softReconnect()`. The
+      // wrapper would observe _proxyUrl just set above and try to suspend the
+      // multiplexer we just allocated — infinite rollback. `_softReconnectDirect`
+      // is also testable in isolation (tests can stub it to simulate failure
+      // without the full softReconnectFn machinery).
+      await this._softReconnectDirect();
     } catch (err) {
       // Soft-reconnect failed — tear the proxy back down so we don't leave a
       // half-switched state (proxy running but CDPClient disconnected).
@@ -208,6 +241,10 @@ export class CDPClient {
       this._proxyUrl = null;
       throw err;
     }
+    // B132: set intent ONLY after the full startup+softReconnect succeeds.
+    // If any step failed, _proxyDesired stays false — no surprise auto-resume
+    // on the next reconnect.
+    this._proxyDesired = true;
     return this._proxyUrl;
   }
 
@@ -216,6 +253,10 @@ export class CDPClient {
    * No-op if the proxy isn't active.
    */
   async stopProxy(): Promise<void> {
+    // B132: clear intent FIRST so the softReconnect wrapper's auto-resume hook
+    // (and any in-flight afterReconnect hook from a concurrent reconnect) sees
+    // _proxyDesired=false and skips re-allocating a new proxy.
+    this._proxyDesired = false;
     if (!this._proxyUrl) return;
     logger.info('CDP', `Stopping proxy at ${this._proxyUrl}`);
     const mux = this._multiplexer;
@@ -230,6 +271,49 @@ export class CDPClient {
       if (mux) {
         try { await mux.stop(); } catch { /* best-effort */ }
       }
+    }
+  }
+
+  /**
+   * B132: stop the multiplexer without reconnecting the MCP. Called from
+   * `handleClose` and the `softReconnect` wrapper BEFORE a reconnect fires, so
+   * the reconnect attempts go DIRECT to Hermes. Preserves `_proxyDesired` so
+   * `_resumeProxy` can rehydrate the proxy against the fresh target URL after
+   * the reconnect succeeds.
+   */
+  private async _suspendProxy(): Promise<void> {
+    if (!this._proxyUrl) return;
+    const mux = this._multiplexer;
+    // Clear _proxyUrl SYNCHRONOUSLY so any concurrent reconnect observes it
+    // cleared before the multiplexer's HTTP server is actually torn down.
+    this._proxyUrl = null;
+    this._multiplexer = null;
+    if (mux) {
+      try { await mux.stop(); } catch { /* best-effort */ }
+    }
+  }
+
+  /**
+   * B132: if `_proxyDesired` is set and no proxy is currently active, restart
+   * the multiplexer against the CURRENT `_connectedTarget` (which may have a
+   * different `webSocketDebuggerUrl` after reconnect — that's the whole point).
+   *
+   * Failure policy: log a warning and CLEAR `_proxyDesired` so we don't
+   * silently loop on every subsequent reconnect. User can re-run
+   * `cdp_open_devtools` to retry manually. This is "predictable over resilient"
+   * — noisy failures are easier to debug than silent retries.
+   */
+  private async _resumeProxy(): Promise<void> {
+    if (!this._proxyDesired) return;
+    if (this.disposed) return;
+    if (!this._connectedTarget) return;
+    if (this._proxyUrl) return;
+    try {
+      await this.startProxy();
+      logger.info('CDP', 'Proxy auto-resumed after reconnect');
+    } catch (err) {
+      logger.warn('CDP', `Proxy auto-resume failed — clearing desired flag. Run cdp_open_devtools to retry: ${err instanceof Error ? err.message : err}`);
+      this._proxyDesired = false;
     }
   }
 
@@ -256,6 +340,9 @@ export class CDPClient {
       this._multiplexer = null;
       this._proxyUrl = null;
     }
+    // B132: clear intent on disposal — a fresh CDPClient must not inherit
+    // desired=true from a previous session.
+    this._proxyDesired = false;
 
     if (this.ws) {
       this.ws.removeAllListeners();
@@ -431,6 +518,15 @@ export class CDPClient {
   }
 
   private handleClose(code: number): void {
+    // B132: if the proxy is active when the upstream closes, suspend it BEFORE
+    // the reconnect loop fires. `_suspendProxy` clears `_proxyUrl` synchronously
+    // at its start (before the first await), so by the time `reconnect()` calls
+    // `discoverAndConnect` → `connectToTarget` → `ctx.getProxyUrl()`, the URL
+    // is already null and reconnect goes direct. Fire-and-forget is fine — the
+    // multiplexer's HTTP server shutdown is bounded and doesn't gate reconnect.
+    if (this._proxyUrl) {
+      void this._suspendProxy();
+    }
     handleCloseFn(this.buildReconnectCtx(), code);
   }
 
@@ -474,6 +570,11 @@ export class CDPClient {
       getPort: () => this._port,
       setBgPollTimer: (timer) => { this._bgPollTimer = timer; },
       getBgPollTimer: () => this._bgPollTimer,
+      // B132: after the exponential-backoff reconnect loop succeeds, rehydrate
+      // the proxy if one was desired. This is the "auto-resume" half of the
+      // suspend→reconnect→resume sequence. softReconnect has its own wrapper
+      // and does NOT go through this hook — would double-fire the resume.
+      afterReconnect: () => this._resumeProxy(),
     };
   }
 

--- a/scripts/cdp-bridge/src/cdp/reconnection.ts
+++ b/scripts/cdp-bridge/src/cdp/reconnection.ts
@@ -62,6 +62,15 @@ export interface ReconnectContext {
   setBgPollTimer: (timer: ReturnType<typeof setInterval> | null) => void;
   getBgPollTimer: () => ReturnType<typeof setInterval> | null;
   isConnected: () => boolean;
+  /**
+   * B132 (M1b follow-up): invoked after a successful reconnect inside the
+   * exponential-backoff `reconnect()` loop. Used by CDPClient to auto-resume
+   * the multiplexer proxy after reconnecting directly to Hermes. NOT fired
+   * by `softReconnect()` — that path has its own wrapper on the CDPClient.
+   * Failures are logged, never propagated — post-reconnect hooks must not
+   * undo a successful reconnect.
+   */
+  afterReconnect?: () => Promise<void>;
 }
 
 export function handleClose(ctx: ReconnectContext, code: number): void {
@@ -133,6 +142,13 @@ export async function reconnect(ctx: ReconnectContext): Promise<void> {
       await ctx.discoverAndConnect();
       ctx.setReconnecting(false);
       console.error('CDP: reconnected successfully');
+      if (ctx.afterReconnect) {
+        try {
+          await ctx.afterReconnect();
+        } catch (err) {
+          logger.warn('CDP', `afterReconnect hook failed: ${err instanceof Error ? err.message : err}`);
+        }
+      }
       return;
     } catch {
       // Fall through to next iteration — delay for attempt i+1 applied at top of loop.

--- a/scripts/cdp-bridge/test/unit/cdp-client-proxy.test.js
+++ b/scripts/cdp-bridge/test/unit/cdp-client-proxy.test.js
@@ -126,7 +126,7 @@ test('CDPClient.startProxy rolls back multiplexer when softReconnect throws (D66
 
   // Stub softReconnect to simulate the "connection landed, but the full session
   // re-setup failed" path. This is the only branch that triggers rollback.
-  client.softReconnect = async () => { throw new Error('simulated reconnect failure'); };
+  client._softReconnectDirect = async () => { throw new Error('simulated reconnect failure'); };
 
   await assert.rejects(() => client.startProxy(), /simulated reconnect failure/);
 
@@ -137,7 +137,7 @@ test('CDPClient.startProxy rolls back multiplexer when softReconnect throws (D66
 
   // A fresh startProxy must succeed (state genuinely reset, not just nulled out).
   let reconnects = 0;
-  client.softReconnect = async () => { reconnects++; };
+  client._softReconnectDirect = async () => { reconnects++; };
   const url = await client.startProxy();
   assert.match(url, /^ws:\/\/127\.0\.0\.1:\d+$/, 'fresh startProxy succeeds after rollback');
   assert.equal(reconnects, 1);
@@ -153,7 +153,7 @@ test('CDPClient.startProxy is concurrency-safe — parallel callers share one mu
 
   // Stub softReconnect with a small delay so both callers definitely race through
   // the guard during the multiplexer.start() await window.
-  client.softReconnect = async () => {
+  client._softReconnectDirect = async () => {
     await new Promise((r) => setTimeout(r, 30));
   };
 
@@ -183,7 +183,7 @@ test('CDPClient.startProxy: after failed start, in-flight guard clears so next c
   plantConnectedTarget(client, hermes.url);
 
   let attempts = 0;
-  client.softReconnect = async () => {
+  client._softReconnectDirect = async () => {
     attempts++;
     if (attempts === 1) throw new Error('first attempt fails');
   };
@@ -198,4 +198,235 @@ test('CDPClient.startProxy: after failed start, in-flight guard clears so next c
 
   await client.disconnect();
   await hermes.stop();
+});
+
+// ── B132 auto-suspend / auto-resume across reconnect ──
+
+test('B132: _suspendProxy clears _proxyUrl synchronously, preserves _proxyDesired', async () => {
+  const client = new CDPClient();
+
+  // Plant active-proxy state.
+  client._proxyUrl = 'ws://127.0.0.1:45678';
+  client._multiplexer = {
+    port: 45678, isRunning: true, consumerCount: 0,
+    stop: async () => {},
+  };
+  client._proxyDesired = true;
+
+  const suspendPromise = client._suspendProxy();
+
+  // Synchronous post-condition: _proxyUrl and _multiplexer cleared BEFORE the await.
+  // This is critical — the handleClose hook relies on this so the reconnect loop
+  // observes cleared state without waiting for multiplexer.stop() to complete.
+  assert.equal(client._proxyUrl, null, '_proxyUrl cleared synchronously');
+  assert.equal(client._multiplexer, null, '_multiplexer cleared synchronously');
+  assert.equal(client._proxyDesired, true, '_proxyDesired preserved — resume hook should re-allocate');
+
+  await suspendPromise;
+});
+
+test('B132: _resumeProxy no-ops when _proxyDesired=false', async () => {
+  const client = new CDPClient();
+  // Plant a target so the "no connected target" guard doesn't trigger.
+  plantConnectedTarget(client, 'ws://127.0.0.1:99999/will-not-use');
+
+  assert.equal(client._proxyDesired, false, 'default desired=false');
+
+  // Track whether startProxy fires.
+  let startCalls = 0;
+  const originalStartProxy = client.startProxy.bind(client);
+  client.startProxy = async (...args) => { startCalls++; return originalStartProxy(...args); };
+
+  await client._resumeProxy();
+  assert.equal(startCalls, 0, '_resumeProxy skipped — no desired intent');
+});
+
+test('B132: _resumeProxy no-ops when _proxyUrl already set (already active)', async () => {
+  const client = new CDPClient();
+  plantConnectedTarget(client, 'ws://127.0.0.1:99999/existing');
+  client._proxyDesired = true;
+  client._proxyUrl = 'ws://127.0.0.1:45678';  // Already active
+
+  let startCalls = 0;
+  const originalStartProxy = client.startProxy.bind(client);
+  client.startProxy = async (...args) => { startCalls++; return originalStartProxy(...args); };
+
+  await client._resumeProxy();
+  assert.equal(startCalls, 0, '_resumeProxy skipped — proxy already active');
+});
+
+test('B132: _resumeProxy failure clears _proxyDesired (predictable one-shot policy)', async () => {
+  const hermes = await makeMockHermes();
+  const client = new CDPClient();
+  plantConnectedTarget(client, hermes.url);
+  client._proxyDesired = true;
+
+  // Stub _softReconnectDirect to fail — startProxy rollback fires, resume fails.
+  client._softReconnectDirect = async () => { throw new Error('resume softReconnect failed'); };
+
+  await client._resumeProxy();
+
+  // Failure policy: clear desired so we don't silently retry on every subsequent
+  // reconnect. User sees the log warning + can re-invoke cdp_open_devtools.
+  assert.equal(client._proxyDesired, false, '_proxyDesired cleared after resume failure');
+  assert.equal(client._proxyUrl, null, 'no live proxy after failed resume');
+
+  await hermes.stop();
+});
+
+test('B132: softReconnect wrapper suspends + resumes the proxy across reconnect', async () => {
+  const hermes = await makeMockHermes();
+  const client = new CDPClient();
+  plantConnectedTarget(client, hermes.url);
+
+  // First startProxy via the direct path — plants _proxyUrl + _proxyDesired=true.
+  client._softReconnectDirect = async () => {};  // no-op reconnect
+  const originalUrl = await client.startProxy();
+  assert.ok(client._proxyDesired, '_proxyDesired set after successful startProxy');
+
+  const firstMux = client._multiplexer;
+
+  // Now invoke the PUBLIC softReconnect — which should wrap with suspend→resume.
+  // After this returns, _proxyUrl should be populated with a FRESH URL (new mux),
+  // and the old mux should have been stopped.
+  let firstMuxStopped = false;
+  const origStop = firstMux.stop.bind(firstMux);
+  firstMux.stop = async () => { firstMuxStopped = true; return origStop(); };
+
+  await client.softReconnect();
+
+  assert.equal(firstMuxStopped, true, 'suspend stopped the original multiplexer');
+  assert.ok(client._proxyUrl, 'resume allocated a new proxy URL');
+  assert.notEqual(client._multiplexer, firstMux, 'new multiplexer allocated');
+
+  await client.disconnect();
+  await hermes.stop();
+});
+
+test('B132: softReconnect wrapper does NOT suspend/resume when proxy was inactive', async () => {
+  const hermes = await makeMockHermes();
+  const client = new CDPClient();
+  plantConnectedTarget(client, hermes.url);
+
+  assert.equal(client._proxyUrl, null, 'precondition: proxy inactive');
+
+  let directCalls = 0;
+  client._softReconnectDirect = async () => { directCalls++; };
+
+  await client.softReconnect();
+
+  assert.equal(directCalls, 1, 'softReconnect ran exactly once — no suspend/resume path');
+  assert.equal(client._proxyUrl, null, 'proxy still inactive');
+  assert.equal(client._proxyDesired, false, 'desired stays false');
+
+  await hermes.stop();
+});
+
+test('B132: stopProxy clears _proxyDesired so post-stop reconnect does not re-allocate', async () => {
+  const hermes = await makeMockHermes();
+  const client = new CDPClient();
+  plantConnectedTarget(client, hermes.url);
+
+  client._softReconnectDirect = async () => {};
+  await client.startProxy();
+  assert.equal(client._proxyDesired, true);
+
+  await client.stopProxy();
+  assert.equal(client._proxyDesired, false, 'stopProxy cleared desired intent');
+  assert.equal(client._proxyUrl, null);
+
+  // A subsequent softReconnect should NOT re-allocate a proxy.
+  await client.softReconnect();
+  assert.equal(client._proxyUrl, null, 'no proxy after explicit stop + reconnect');
+
+  await client.disconnect();
+  await hermes.stop();
+});
+
+test('B132: disconnect clears _proxyDesired (no zombie desired-flag across sessions)', async () => {
+  const client = new CDPClient();
+  client._proxyDesired = true;
+
+  await client.disconnect();
+  assert.equal(client._proxyDesired, false, 'disconnect clears desired flag');
+});
+
+test('B132: afterReconnect path — _resumeProxy picks up the new target URL (reconnect-loop trigger)', async () => {
+  // This test complements the softReconnect-wrapper end-to-end below by exercising
+  // the OTHER production trigger: the `handleClose → reconnect() → afterReconnect`
+  // path. Instead of wiring up a fake WS close event, we directly simulate the
+  // post-reconnect state: proxy suspended, _connectedTarget mutated to a new URL,
+  // then `_resumeProxy()` invoked (which is what buildReconnectCtx's afterReconnect
+  // callback does).
+  const hermesA = await makeMockHermes();
+  const hermesB = await makeMockHermes();
+  const client = new CDPClient();
+  plantConnectedTarget(client, hermesA.url);
+
+  // Initial proxy start against hermesA.
+  client._softReconnectDirect = async () => {};
+  await client.startProxy();
+  const muxA = client._multiplexer;
+  assert.equal(muxA.opts ? muxA.opts.hermesUrl : undefined, hermesA.url);
+
+  // Simulate handleClose fire-and-forget: suspend the proxy synchronously.
+  // (handleClose itself does this via `void this._suspendProxy()`.)
+  await client._suspendProxy();
+  assert.equal(client.proxyUrl, null);
+  assert.equal(client.proxyMultiplexer, null);
+  assert.equal(client._proxyDesired, true, 'desired flag preserved across suspend');
+
+  // Simulate reconnect loop: discoverAndConnect picked a refreshed target.
+  client._connectedTarget = {
+    id: 'page1', title: 'Mock', vm: 'Hermes',
+    webSocketDebuggerUrl: hermesB.url,
+    platform: 'ios',
+  };
+
+  // afterReconnect hook fires → _resumeProxy() (this is what buildReconnectCtx wires up).
+  await client._resumeProxy();
+
+  const muxB = client._multiplexer;
+  assert.notEqual(muxB, muxA, 'fresh multiplexer allocated via afterReconnect path');
+  assert.equal(muxB.opts ? muxB.opts.hermesUrl : undefined, hermesB.url, 'new proxy points at hermes B');
+
+  await client.disconnect();
+  await hermesA.stop();
+  await hermesB.stop();
+});
+
+test('B132: end-to-end — proxy rehydrates against a NEW target URL after reconnect', async () => {
+  // Two mock Hermes instances simulate "target got a new URL after reload".
+  const hermesA = await makeMockHermes();
+  const hermesB = await makeMockHermes();
+  const client = new CDPClient();
+  plantConnectedTarget(client, hermesA.url);
+
+  client._softReconnectDirect = async () => {};
+  const urlA = await client.startProxy();
+  const muxA = client._multiplexer;
+  assert.equal(muxA.opts ? muxA.opts.hermesUrl : undefined, hermesA.url, 'proxy A points at hermes A');
+
+  // Simulate a reconnect where the target's URL changed. In production, the
+  // reconnect loop would update _connectedTarget via discoverAndConnect; here
+  // we simulate that by mutating the target before softReconnect.
+  client._softReconnectDirect = async () => {
+    // Discovery picked a "refreshed" target with the same ID but a new URL.
+    client._connectedTarget = {
+      id: 'page1', title: 'Mock', vm: 'Hermes',
+      webSocketDebuggerUrl: hermesB.url,
+      platform: 'ios',
+    };
+  };
+
+  await client.softReconnect();
+
+  const muxB = client._multiplexer;
+  assert.notEqual(muxB, muxA, 'new multiplexer allocated on resume');
+  assert.equal(muxB.opts ? muxB.opts.hermesUrl : undefined, hermesB.url, 'new proxy points at hermes B — this is the B132 fix');
+  assert.notEqual(client._proxyUrl, urlA, 'proxy URL changed (new ephemeral port)');
+
+  await client.disconnect();
+  await hermesA.stop();
+  await hermesB.stop();
 });

--- a/scripts/cdp-bridge/test/unit/reconnect-delay.test.js
+++ b/scripts/cdp-bridge/test/unit/reconnect-delay.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { computeReconnectDelay, interruptibleSleep } from '../../dist/cdp/reconnection.js';
+import { computeReconnectDelay, interruptibleSleep, reconnect } from '../../dist/cdp/reconnection.js';
 
 // Minimal mock ReconnectContext — interruptibleSleep only touches isDisposed / isSoftReconnectRequested
 function makeMockCtx(overrides = {}) {
@@ -219,4 +219,84 @@ test('computeReconnectDelay: cumulative delay over 30 attempts vs old linear (re
     attemptsIn60s < 40,
     `new curve must be well under old linear ~40 attempts/60s, got ${attemptsIn60s}`,
   );
+});
+
+// ── B132: afterReconnect callback fires once on successful reconnect ──
+
+function makeReconnectCtx({ succeedOnAttempt = 0, afterReconnect } = {}) {
+  let attempt = 0;
+  const state = {
+    reconnecting: true,
+    disposed: false,
+    softReconnectRequested: false,
+    state: 'reconnecting',
+    attempts: [],
+    afterReconnectCalls: 0,
+    discoverCalls: 0,
+  };
+  const ctx = {
+    isDisposed: () => state.disposed,
+    isSoftReconnectRequested: () => state.softReconnectRequested,
+    isReconnecting: () => state.reconnecting,
+    setReconnecting: (v) => { state.reconnecting = v; },
+    setSoftReconnectRequested: (v) => { state.softReconnectRequested = v; },
+    setState: (s) => { state.state = s; },
+    setReconnectAttempt: (count, ts) => { state.attempts.push({ count, ts }); },
+    closeWs: () => {},
+    rejectAllPending: () => {},
+    discoverAndConnect: async () => {
+      state.discoverCalls++;
+      if (attempt < succeedOnAttempt) {
+        attempt++;
+        throw new Error('mock discover failure');
+      }
+      return 'connected';
+    },
+    getResettableState: () => ({}),
+    getPort: () => 8081,
+    setBgPollTimer: () => {},
+    getBgPollTimer: () => null,
+    isConnected: () => false,
+    afterReconnect: afterReconnect
+      ? async () => { state.afterReconnectCalls++; await afterReconnect(); }
+      : undefined,
+  };
+  return { state, ctx };
+}
+
+test('B132: reconnect() calls afterReconnect exactly once after successful attempt', async () => {
+  let hookCalls = 0;
+  const { state, ctx } = makeReconnectCtx({
+    succeedOnAttempt: 0,  // first attempt succeeds — no backoff waits
+    afterReconnect: async () => { hookCalls++; },
+  });
+
+  await reconnect(ctx);
+
+  assert.equal(state.discoverCalls, 1);
+  assert.equal(hookCalls, 1, 'afterReconnect fired exactly once');
+  assert.equal(state.reconnecting, false, 'reconnecting flag cleared');
+});
+
+test('B132: reconnect() does NOT call afterReconnect when callback is not provided (backwards compat)', async () => {
+  const { state, ctx } = makeReconnectCtx({ succeedOnAttempt: 0 });
+  // ctx.afterReconnect is undefined — reconnect must not throw.
+
+  await reconnect(ctx);
+
+  assert.equal(state.discoverCalls, 1);
+  assert.equal(state.reconnecting, false);
+});
+
+test('B132: afterReconnect failure is caught + logged, never propagates (reconnect success preserved)', async () => {
+  const { state, ctx } = makeReconnectCtx({
+    succeedOnAttempt: 0,
+    afterReconnect: async () => { throw new Error('hook boom'); },
+  });
+
+  // reconnect() must still resolve cleanly — hook failure cannot undo a successful reconnect.
+  await reconnect(ctx);
+
+  assert.equal(state.discoverCalls, 1);
+  assert.equal(state.reconnecting, false, 'reconnect still succeeded despite hook failure');
 });


### PR DESCRIPTION
## Summary

Closes the known limitation logged during M1b review (PR #49). When Hermes regenerates the target URL (hot reload, target eviction, Metro restart), the multiplexer captured `hermesUrl` once at `startProxy` time and was left routing to a dead upstream. Every MCP tool call through the proxy silently timed out.

## Design — Option B (auto-suspend / auto-resume)

Five options evaluated; B chosen as the best code-complexity vs DevTools-UX trade-off. Dismissed alternatives:
- **A** (manual re-invocation) — too much friction for RN's frequent hot reloads
- **C** (multiplexer `refreshUpstream` API) — seamless UX was illusory since Hermes CDP state is per-instance
- **D** (Metro `/events` proactive restart) — blocked by Expo `/events` incompatibility (B129/D658)
- **E** (port-stable rebind) — complexity for small UX win

## What changed

### `CDPClient` additions
- **`_proxyDesired` flag**: user intent, separate from live `_proxyUrl`. Set by successful `startProxy`, cleared by `stopProxy` + `disconnect`. Preserved across `_suspendProxy` so resume knows to rehydrate.
- **`_suspendProxy()`**: clears `_proxyUrl` + `_multiplexer` SYNCHRONOUSLY (before first `await`), then awaits `multiplexer.stop()` best-effort. Synchronous-clear invariant is load-bearing — `handleClose` fires-and-forgets and immediately delegates to `handleCloseFn`; by the time `reconnect()` calls `ctx.getProxyUrl()`, null is guaranteed.
- **`_resumeProxy()`**: if desired + connected + no active proxy, calls `startProxy()` to rehydrate against current `_connectedTarget`. Failure policy: clear `_proxyDesired` (predictable over resilient).
- **`_softReconnectDirect()`**: bypasses the new `softReconnect` wrapper; used by `_doStartProxy` to avoid infinite rollback. Named method for testability.
- **`softReconnect()`** now wraps with suspend→reconnect→resume when a proxy is active. Covers `cdp_status` `__DEV__=false` auto-recovery.

### `ReconnectContext`
- New optional `afterReconnect?: () => Promise<void>` callback. Invoked inside `reconnect()` after `discoverAndConnect` resolves. Hook failures caught + logged, never propagated.

## Multi-review outcome

**Gemini + Codex both clean** — zero high-confidence issues. Six critical race-condition questions verified:
1. Suspend vs reconnect ordering (synchronous-clear invariant holds)
2. Double-resume hazard on preemption (reconnect() preemption gates bail before afterReconnect)
3. `_doStartProxy` rollback via `_softReconnectDirect` (catch path correctly tears down)
4. `_resumeProxy` failure policy (predictable over resilient, documented)
5. `_startProxyInFlight` concurrency sharing (cached promise coalesces user + resume callers)
6. End-to-end test soundness (covered by both softReconnect wrapper path AND afterReconnect callback path)

One below-threshold observation from Gemini closed with an additional focused test.

## Versions

- Plugin `0.34.0 → 0.35.0`
- MCP `0.29.0 → 0.30.0`
- Tests `462 → 475` (+13: 10 CDPClient lifecycle + 3 reconnect-loop callback)

## Test plan

- [x] `npm test` — 475/475 passing
- [x] `npm run build` — TypeScript compile clean
- [x] Multi-review (Gemini + Codex) — clean
- [ ] Live smoke: with proxy active, trigger a simulator reload (Cmd+R), confirm `cdp_evaluate` still works post-reload (proving the proxy rehydrated against new target URL)
- [ ] Verify `cdp_status.proxy.url` changes across a reload cycle (new ephemeral port per resume)
- [ ] Regression: confirm no-proxy path still works unchanged through reconnects

## Known intentional caveat

Each resume allocates a new ephemeral loopback port, so `devtoolsUrl` changes per reload. DevTools users refresh the tab with the updated URL from a fresh `cdp_open_devtools` call. This is the Option-B trade-off we accepted (Option E would have rebound the same port but adds complexity for a small UX gain).

## Refs

- D662 (`../rn-dev-agent-workspace/docs/DECISIONS.md`)
- Phase 105 (`../rn-dev-agent-workspace/docs/ROADMAP.md`)
- B132 FIXED (`../rn-dev-agent-workspace/docs/BUGS.md`)
- Parent: D661 / Phase 104 (M1b, merged as PR #49)