### PR TITLE
feat(m8/phase-106): renderer 1..5 probe for fiber root resolution (D663)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.36.0] — 2026-04-21
+
+M8 / Phase 106 — renderer 1..5 probe for fiber root resolution. Closes the Tier 3 story from the Phase 90 metro-mcp pattern adoption audit. Two places in the plugin gated React introspection on `__REACT_DEVTOOLS_GLOBAL_HOOK__.renderers.size > 0` — `injected-helpers.ts::findActiveRenderer` (used by 9 downstream consumers) and `cdp/setup.ts::waitForReact` (the 30s readiness gate before helper injection). Both now brute-probe `getFiberRoots(i)` for i in 1..5, mirroring metro-mcp's `FIBER_ROOT_JS` pattern. Apps where `hook.renderers` is empty or missing (React Native macros, Reanimated worklets, React DevTools loaded ahead of first render) now return live fiber trees instead of silent empties. MCP server bumped to 0.31.0.
+
+### Added
+- **`REACT_READY_PROBE_JS` exported constant** in `scripts/cdp-bridge/src/injected-helpers.ts`. Eval-ready IIFE string with the same 1..5 `getFiberRoots` probe as `findActiveRenderer`. Single source of truth for the cross-file readiness invariant — `setup.ts` now imports and awaits it directly instead of reconstructing a narrower inline check.
+
+### Changed (behavioral, forward-compatible)
+- **`findActiveRenderer()` in the injected helper bundle** now brute-probes `getFiberRoots(1..5)` instead of iterating `hook.renderers.entries()`. Dropped the early-return guard `!hook.renderers || hook.renderers.size === 0` that caused silent empty-tree returns on affected apps. `__HELPERS_VERSION__` bumped 13 → 14 so in-flight sessions pick up the new helper on next connect.
+- **`waitForReact` in `cdp/setup.ts`** now awaits `REACT_READY_PROBE_JS` instead of `__REACT_DEVTOOLS_GLOBAL_HOOK__.renderers?.size > 0`. Without this companion fix M8's helper change was blunted — `waitForReact` would time out 30s on exactly the apps M8 was meant to help before injection began. Side benefit: the new probe refuses to declare "ready" until a fiber root actually exists, tightening the gate's semantic correctness.
+
+### Tests
+- **10 new tests** in `scripts/cdp-bridge/test/unit/injected-helpers.test.js`. 5 for `findActiveRenderer` (happy-path, skip-to-renderer-4, renderers-map-empty, all-empty, missing-getFiberRoots) and 5 for `REACT_READY_PROBE_JS` (run in isolated `vm` sandboxes — pin the probe's public behavior so helper + probe can't silently diverge). Running total: 475 → **485**, zero failures.
+
+### Known limits
+- **Renderer IDs 6+ unreachable** — matches metro-mcp's identical bound. Never observed in practice.
+- **`cdp_set_shared_value` in `src/index.ts:359-363`** still uses the `hook.renderers.keys()` pattern. Out-of-scope for M8; filed as **B133** for a separate PR. Low-severity since `cdp_set_shared_value` is a niche proof-capture tool.
+
+### Review
+Multi-LLM (Gemini + Codex). Codex clean. Gemini flagged `setup.ts`'s sibling readiness gate at confidence 85 — originally scoped out of M8, folded in on user direction to preserve end-to-end benefit. Would have shipped as half-a-fix otherwise.
+
+### Refs
+D663 in `rn-dev-agent-workspace/docs/DECISIONS.md`. Phase 106 in `rn-dev-agent-workspace/docs/ROADMAP.md`. metro-mcp reference pattern: `src/utils/fiber.ts` FIBER_ROOT_JS.
+
 ## [0.35.0] — 2026-04-21
 
 B132 / Phase 105 — proxy auto-resume across reconnect. Closes the known limitation logged during M1b review: the multiplexer captured `hermesUrl` once at `startProxy` time, so any event that invalidated the target URL (hot reload, target eviction, Metro restart) left the proxy routing to a dead upstream with every MCP call silently timing out. This release auto-suspends the proxy when the MCP's CDP WebSocket closes, runs the normal reconnect loop directly against Hermes, then auto-resumes the proxy against the refreshed target URL. MCP server bumped to 0.30.0.

--- a/scripts/cdp-bridge/dist/cdp/setup.js
+++ b/scripts/cdp-bridge/dist/cdp/setup.js
@@ -1,4 +1,4 @@
-import { INJECTED_HELPERS, NETWORK_HOOK_SCRIPT } from '../injected-helpers.js';
+import { INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, REACT_READY_PROBE_JS } from '../injected-helpers.js';
 import { logger } from '../logger.js';
 import { setActiveFlag, sleep } from './state.js';
 import { CDP_TIMEOUT_FAST, timeoutForMethod } from './timeout-config.js';
@@ -97,8 +97,7 @@ export async function waitForReact(evaluate, timeout, pollInterval) {
     const start = Date.now();
     while (Date.now() - start < effectiveTimeout) {
         try {
-            const result = await evaluate('typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== "undefined" && ' +
-                '__REACT_DEVTOOLS_GLOBAL_HOOK__.renderers?.size > 0');
+            const result = await evaluate(REACT_READY_PROBE_JS);
             if (result.value === true)
                 return;
         }

--- a/scripts/cdp-bridge/dist/injected-helpers.js
+++ b/scripts/cdp-bridge/dist/injected-helpers.js
@@ -1,16 +1,15 @@
 export const INJECTED_HELPERS = `
 (function() {
-  var __HELPERS_VERSION__ = 13;
+  var __HELPERS_VERSION__ = 14;
   if (globalThis.__RN_AGENT && globalThis.__RN_AGENT.__v === __HELPERS_VERSION__) return;
   if (globalThis.__RN_AGENT) delete globalThis.__RN_AGENT;
 
   function findActiveRenderer() {
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-    if (!hook || !hook.renderers || hook.renderers.size === 0) return null;
-    for (var entry of hook.renderers) {
-      var id = entry[0];
-      var roots = hook.getFiberRoots(id);
-      if (roots && roots.size > 0) return { rendererId: id, roots: roots };
+    if (!hook || typeof hook.getFiberRoots !== 'function') return null;
+    for (var i = 1; i <= 5; i++) {
+      var roots = hook.getFiberRoots(i);
+      if (roots && roots.size > 0) return { rendererId: i, roots: roots };
     }
     return null;
   }
@@ -1384,3 +1383,15 @@ export const NETWORK_HOOK_SCRIPT = `
   }
 })();
 `;
+// M8: readiness probe for waitForReact — must mirror findActiveRenderer's
+// guard shape in INJECTED_HELPERS so setup.ts stops gating on a stale
+// renderers-map check. If either diverges the gate becomes a silent no-op.
+export const REACT_READY_PROBE_JS = `(function() {
+  var h = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  if (!h || typeof h.getFiberRoots !== 'function') return false;
+  for (var i = 1; i <= 5; i++) {
+    var r = h.getFiberRoots(i);
+    if (r && r.size > 0) return true;
+  }
+  return false;
+})()`;

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/cdp/setup.ts
+++ b/scripts/cdp-bridge/src/cdp/setup.ts
@@ -1,4 +1,4 @@
-import { INJECTED_HELPERS, NETWORK_HOOK_SCRIPT } from '../injected-helpers.js';
+import { INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, REACT_READY_PROBE_JS } from '../injected-helpers.js';
 import { logger } from '../logger.js';
 import { setActiveFlag, sleep } from './state.js';
 import { CDP_TIMEOUT_FAST, timeoutForMethod } from './timeout-config.js';
@@ -137,10 +137,7 @@ export async function waitForReact(
   const start = Date.now();
   while (Date.now() - start < effectiveTimeout) {
     try {
-      const result = await evaluate(
-        'typeof __REACT_DEVTOOLS_GLOBAL_HOOK__ !== "undefined" && ' +
-        '__REACT_DEVTOOLS_GLOBAL_HOOK__.renderers?.size > 0'
-      );
+      const result = await evaluate(REACT_READY_PROBE_JS);
       if (result.value === true) return;
     } catch {
       // Not ready yet

--- a/scripts/cdp-bridge/src/injected-helpers.ts
+++ b/scripts/cdp-bridge/src/injected-helpers.ts
@@ -1,16 +1,15 @@
 export const INJECTED_HELPERS = `
 (function() {
-  var __HELPERS_VERSION__ = 13;
+  var __HELPERS_VERSION__ = 14;
   if (globalThis.__RN_AGENT && globalThis.__RN_AGENT.__v === __HELPERS_VERSION__) return;
   if (globalThis.__RN_AGENT) delete globalThis.__RN_AGENT;
 
   function findActiveRenderer() {
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-    if (!hook || !hook.renderers || hook.renderers.size === 0) return null;
-    for (var entry of hook.renderers) {
-      var id = entry[0];
-      var roots = hook.getFiberRoots(id);
-      if (roots && roots.size > 0) return { rendererId: id, roots: roots };
+    if (!hook || typeof hook.getFiberRoots !== 'function') return null;
+    for (var i = 1; i <= 5; i++) {
+      var roots = hook.getFiberRoots(i);
+      if (roots && roots.size > 0) return { rendererId: i, roots: roots };
     }
     return null;
   }
@@ -1385,3 +1384,16 @@ export const NETWORK_HOOK_SCRIPT = `
   }
 })();
 `;
+
+// M8: readiness probe for waitForReact — must mirror findActiveRenderer's
+// guard shape in INJECTED_HELPERS so setup.ts stops gating on a stale
+// renderers-map check. If either diverges the gate becomes a silent no-op.
+export const REACT_READY_PROBE_JS = `(function() {
+  var h = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  if (!h || typeof h.getFiberRoots !== 'function') return false;
+  for (var i = 1; i <= 5; i++) {
+    var r = h.getFiberRoots(i);
+    if (r && r.size > 0) return true;
+  }
+  return false;
+})()`;

--- a/scripts/cdp-bridge/test/unit/injected-helpers.test.js
+++ b/scripts/cdp-bridge/test/unit/injected-helpers.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import vm from 'node:vm';
-import { INJECTED_HELPERS } from '../../dist/injected-helpers.js';
+import { INJECTED_HELPERS, REACT_READY_PROBE_JS } from '../../dist/injected-helpers.js';
 
 /**
  * Create a VM sandbox with mock React DevTools globals.
@@ -28,7 +28,9 @@ function createSandbox(opts = {}) {
   sandbox.globalThis = sandbox;
 
   // Set up React DevTools hook with a mock fiber root
-  if (opts.fiberRoot) {
+  if (opts.hook) {
+    sandbox.__REACT_DEVTOOLS_GLOBAL_HOOK__ = opts.hook;
+  } else if (opts.fiberRoot) {
     sandbox.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
       renderers: new Map([[1, {}]]),
       getFiberRoots: () => new Set([{ current: opts.fiberRoot }]),
@@ -184,4 +186,95 @@ test('getStoreState: no-store error includes Jotai hint', () => {
   const result = JSON.parse(sandbox.__RN_AGENT.getStoreState());
   assert.ok(result.hint3, 'hint3 should exist for Jotai');
   assert.match(result.hint3, /JOTAI_STORE/);
+});
+
+// ── M8: findActiveRenderer 1..5 probe ────────────────────────────────
+// Mirrors metro-mcp src/utils/fiber.ts FIBER_ROOT_JS. Proves the probe
+// finds fiber roots regardless of hook.renderers population state.
+
+test('M8: findActiveRenderer finds root at renderer ID 1 (happy path, no regression)', () => {
+  const fiber = { type: { name: 'App' }, child: null, sibling: null };
+  const hook = {
+    renderers: new Map([[1, {}]]),
+    getFiberRoots: (id) => id === 1 ? new Set([{ current: fiber }]) : new Set(),
+  };
+  const sandbox = createSandbox({ hook });
+  assert.equal(sandbox.__RN_AGENT.isReady(), true);
+});
+
+test('M8: findActiveRenderer probes past empty IDs to renderer 4', () => {
+  const fiber = { type: { name: 'App' }, child: null, sibling: null };
+  const hook = {
+    renderers: new Map(),
+    getFiberRoots: (id) => id === 4 ? new Set([{ current: fiber }]) : new Set(),
+  };
+  const sandbox = createSandbox({ hook });
+  assert.equal(sandbox.__RN_AGENT.isReady(), true);
+});
+
+test('M8: findActiveRenderer succeeds when hook.renderers is empty (story repro)', () => {
+  const fiber = { type: { name: 'App' }, child: null, sibling: null };
+  const hook = {
+    renderers: new Map(),
+    getFiberRoots: (id) => id === 1 ? new Set([{ current: fiber }]) : new Set(),
+  };
+  const sandbox = createSandbox({ hook });
+  assert.equal(sandbox.__RN_AGENT.isReady(), true);
+});
+
+test('M8: findActiveRenderer returns null when no renderer 1..5 has roots', () => {
+  const hook = {
+    renderers: new Map(),
+    getFiberRoots: () => new Set(),
+  };
+  const sandbox = createSandbox({ hook });
+  assert.equal(sandbox.__RN_AGENT.isReady(), false);
+});
+
+test('M8: findActiveRenderer returns null when hook.getFiberRoots is missing', () => {
+  const sandbox = createSandbox({ hook: { renderers: new Map() } });
+  assert.equal(sandbox.__RN_AGENT.isReady(), false);
+});
+
+// ── M8: REACT_READY_PROBE_JS for waitForReact ──────────────────────
+// Mirrors findActiveRenderer's probe shape so setup.ts's readiness gate
+// stops timing out on apps where hook.renderers is empty.
+
+function evalProbe(hook) {
+  const sandbox = { __REACT_DEVTOOLS_GLOBAL_HOOK__: hook };
+  sandbox.globalThis = sandbox;
+  vm.createContext(sandbox);
+  return vm.runInContext(REACT_READY_PROBE_JS, sandbox);
+}
+
+test('M8 probe: returns true when fiber roots exist at renderer ID 1', () => {
+  assert.equal(evalProbe({
+    renderers: new Map(),
+    getFiberRoots: (i) => i === 1 ? new Set([{}]) : new Set(),
+  }), true);
+});
+
+test('M8 probe: returns true when fiber roots only at renderer ID 4 (renderers map empty)', () => {
+  assert.equal(evalProbe({
+    renderers: new Map(),
+    getFiberRoots: (i) => i === 4 ? new Set([{}]) : new Set(),
+  }), true);
+});
+
+test('M8 probe: returns false when no renderer 1..5 has fiber roots', () => {
+  assert.equal(evalProbe({
+    renderers: new Map(),
+    getFiberRoots: () => new Set(),
+  }), false);
+});
+
+test('M8 probe: returns false when hook.getFiberRoots is missing', () => {
+  assert.equal(evalProbe({ renderers: new Map() }), false);
+});
+
+test('M8 probe: returns false when hook itself is absent', () => {
+  const sandbox = {};
+  sandbox.globalThis = sandbox;
+  vm.createContext(sandbox);
+  assert.equal(vm.runInContext(REACT_READY_PROBE_JS, sandbox), false);
 });


### PR DESCRIPTION
## Summary

Closes Phase 90 Tier 3 Story **M8**. Replaces the `hook.renderers`-gated renderer lookup in both the injected helper bundle and the setup-time readiness probe with a 1..5 `getFiberRoots` brute probe, mirroring metro-mcp `src/utils/fiber.ts` FIBER_ROOT_JS.

**Stacked on #50** (B132 proxy auto-resume). Merge #50 first, then rebase this onto `main` for a clean merge.

## Why

Two places gated React introspection on `__REACT_DEVTOOLS_GLOBAL_HOOK__.renderers.size > 0`:
1. `injected-helpers.ts::findActiveRenderer` — used by 9 downstream consumers.
2. `cdp/setup.ts::waitForReact` — the 30s readiness gate BEFORE helper injection.

On apps where the `renderers` map is empty or missing (React Native macros, Reanimated worklets, React DevTools loaded ahead of first render), both paths early-returned / timed out — silent empty trees after a 30s log-spammy wait, even though `getFiberRoots(1..5)` would have resolved populated Sets.

## Scope

| File | Change |
|---|---|
| `scripts/cdp-bridge/src/injected-helpers.ts` | `findActiveRenderer` body: 1..5 brute probe, dropped `!hook.renderers` guard. `__HELPERS_VERSION__` 13 → 14. New exported `REACT_READY_PROBE_JS` constant. |
| `scripts/cdp-bridge/src/cdp/setup.ts` | `waitForReact` awaits `REACT_READY_PROBE_JS` instead of inline `renderers?.size > 0`. |
| `scripts/cdp-bridge/test/unit/injected-helpers.test.js` | +10 tests (5 `findActiveRenderer` + 5 probe). Extended `createSandbox` with `opts.hook` override. |
| Versions | plugin 0.35.0 → 0.36.0, MCP 0.30.0 → 0.31.0 |

## Tests

475 → **485 passing**, 0 failures. M8 tests cover:

```
✔ M8: findActiveRenderer finds root at renderer ID 1 (happy path, no regression)
✔ M8: findActiveRenderer probes past empty IDs to renderer 4
✔ M8: findActiveRenderer succeeds when hook.renderers is empty (story repro)
✔ M8: findActiveRenderer returns null when no renderer 1..5 has roots
✔ M8: findActiveRenderer returns null when hook.getFiberRoots is missing
✔ M8 probe: returns true when fiber roots exist at renderer ID 1
✔ M8 probe: returns true when fiber roots only at renderer ID 4 (renderers map empty)
✔ M8 probe: returns false when no renderer 1..5 has fiber roots
✔ M8 probe: returns false when hook.getFiberRoots is missing
✔ M8 probe: returns false when hook itself is absent
```

## Review

Multi-LLM review (Gemini + Codex). Codex clean. Gemini flagged the `setup.ts` sibling readiness gate at confidence 85 — originally scoped out, folded in per user direction to preserve end-to-end benefit. Would have shipped as half-a-fix otherwise.

## Known limits

- **Renderer IDs 6+ unreachable** — matches metro-mcp's identical bound. Never observed in practice.
- **`cdp_set_shared_value`** in `src/index.ts:359-363` uses the same `hook.renderers.keys()` pattern. Out-of-scope per story boundary; filed as **B133**.

## Test plan

- [x] Unit tests pass (`cd scripts/cdp-bridge && npm test` → 485 passing)
- [x] Baseline: `cdp_status` + `cdp_component_tree` on test-app under v13 confirm happy-path works (no regression surface)
- [ ] **Post-merge smoke:** after CC restart loads new v14, `cdp_component_tree(filter="App", depth=3)` on the Expo test-app returns non-empty tree; no "React not ready" warning in logs

## Refs

- D663 in `rn-dev-agent-workspace/docs/DECISIONS.md`
- Phase 106 in `rn-dev-agent-workspace/docs/ROADMAP.md`
- Proof: `rn-dev-agent-workspace/docs/proof/m8-renderer-id-loop/`
- metro-mcp reference pattern: `src/utils/fiber.ts` FIBER_ROOT_JS