### PR TITLE
fix(b133/phase-107): cdp_set_shared_value renderer probe + open_devtools description (D664)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.36.0",
+      "version": "0.36.1",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.36.1] — 2026-04-21
+
+B133 / Phase 107 — M8 loose ends. Closes the carveout logged during M8's Phase 106 review (Gemini finding, flagged at confidence 85, folded out of M8 per story boundary). Ports the 1..5 `getFiberRoots` probe into `cdp_set_shared_value` so that tool works on apps where `__REACT_DEVTOOLS_GLOBAL_HOOK__.renderers` is empty or missing. Also refreshes the `cdp_open_devtools` tool description, which had been frozen at M1a-era text and was factually misleading after M1b (Phase 104) and B132 (Phase 105) shipped. MCP server bumped to 0.31.1.
+
+### Fixed
+- **B133**: `cdp_set_shared_value` inline renderer walk in `src/index.ts:356-397`. Replaced the stale `Array.from(hook.renderers.keys())` loop with the 1..5 `getFiberRoots` probe pattern — mirrors M8's `findActiveRenderer` and `REACT_READY_PROBE_JS`. Intentional divergence: the `allRoots` accumulator is preserved (not early-return) because Reanimated worklets can mount in a secondary renderer at a different ID from the React DOM/native renderer, and `cdp_set_shared_value` must tolerate that to locate its target testID.
+
+### Changed
+- **`cdp_open_devtools` tool description** in `src/index.ts:798`. Old text stopped at M1a/Phase 100 detection; new text honestly reflects the Phase 100 (M1a) → Phase 104 (M1b CDPClient proxy wiring) → Phase 105 (B132 auto-resume) chain. Returns shape now documents `hermesWsUrl` + `proxyPort` that the handler has been emitting since M1b.
+
+### Tests
+- **3 new structural guard tests** at `scripts/cdp-bridge/test/unit/shared-value-renderer-probe-guard.test.js`. Walks all `src/*.ts` and fails on any reintroduction of `hook.renderers.keys()`. Pins `index.ts` to contain the 1..5 probe loop + the `typeof getFiberRoots === 'function'` guard. Pattern mirrors the existing `screenshot-bypass-guard.test.js` (B121).
+
+Running total: 485 → **488 passing**, zero failures.
+
+### Review
+Multi-LLM (Gemini + Codex). Both clean. Gemini validated the fix matches what they flagged during M8 review. Codex noted the `allRoots` accumulator divergence from M8's pattern is intentionally correct for worklet-aware fiber walks.
+
+### Refs
+D664 in `rn-dev-agent-workspace/docs/DECISIONS.md`. Phase 107 in `rn-dev-agent-workspace/docs/ROADMAP.md`. Parent: D663 / M8 / Phase 106.
+
 ## [0.36.0] — 2026-04-21
 
 M8 / Phase 106 — renderer 1..5 probe for fiber root resolution. Closes the Tier 3 story from the Phase 90 metro-mcp pattern adoption audit. Two places in the plugin gated React introspection on `__REACT_DEVTOOLS_GLOBAL_HOOK__.renderers.size > 0` — `injected-helpers.ts::findActiveRenderer` (used by 9 downstream consumers) and `cdp/setup.ts::waitForReact` (the 30s readiness gate before helper injection). Both now brute-probe `getFiberRoots(i)` for i in 1..5, mirroring metro-mcp's `FIBER_ROOT_JS` pattern. Apps where `hook.renderers` is empty or missing (React Native macros, Reanimated worklets, React DevTools loaded ahead of first render) now return live fiber trees instead of silent empties. MCP server bumped to 0.31.0.

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -214,11 +214,10 @@ trackedTool('cdp_set_shared_value', 'Set a Reanimated SharedValue on a component
 }, withConnection(getClient, async (args, client) => {
     const expression = `(function() {
       var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-      if (!hook) return JSON.stringify({ __agent_error: 'No React DevTools hook' });
-      var ids = Array.from(hook.renderers.keys());
+      if (!hook || typeof hook.getFiberRoots !== 'function') return JSON.stringify({ __agent_error: 'No React DevTools hook' });
       var allRoots = [];
-      for (var i = 0; i < ids.length; i++) {
-        var r = hook.getFiberRoots(ids[i]);
+      for (var i = 1; i <= 5; i++) {
+        var r = hook.getFiberRoots(i);
         if (r && r.size) { var it = r.values(); var v; while (!(v = it.next()).done) allRoots.push(v.value); }
       }
       if (!allRoots.length) return JSON.stringify({ __agent_error: 'No fiber roots' });
@@ -474,7 +473,7 @@ trackedTool('cross_platform_verify', 'Compare UI elements across iOS and Android
     scanDir: z.string().optional().describe('Directory to scan for testID="..." props in .tsx/.jsx/.ts/.js files. Auto-discovers elements. Merges with elements[] if both provided.'),
     matchBy: z.enum(['testID', 'label', 'any']).default('any').describe('Match strategy: testID (exact identifier match), label (substring in accessibility label), any (try both)'),
 }, createCrossPlatformVerifyHandler());
-trackedTool('cdp_open_devtools', 'Report the React Native DevTools frontend URL for the live app + whether DevTools can coexist with the MCP session (RN >= 0.85 native multi-debugger). M1 (Phase 90 Tier 1) ships detection + capability reporting; full proxy auto-wiring for RN < 0.85 is tracked as M1b/Phase 100. Returns { devtoolsUrl, inspectorWsUrl, mode, supportsMultipleDebuggers, rnVersion, guidance }.', {}, createOpenDevToolsHandler(getClient));
+trackedTool('cdp_open_devtools', 'Report the React Native DevTools frontend URL for the live app + start a multiplexer proxy so DevTools can coexist with the MCP session on RN < 0.85 (RN >= 0.85 uses native multi-debugger). M1a (Phase 100) shipped detection + capability reporting; M1b (Phase 104) wired the proxy into CDPClient; B132 (Phase 105) added proxy auto-resume across reconnect. Returns { devtoolsUrl, inspectorWsUrl, hermesWsUrl, mode: "native" | "proxy-active", proxyPort, supportsMultipleDebuggers, rnVersion, guidance }.', {}, createOpenDevToolsHandler(getClient));
 trackedTool('cdp_metro_events', 'Read Metro reporter events (bundle_build_started, bundle_build_done, bundle_build_failed, reloads) captured since the MCP connected. M5 (Phase 90 Tier 2 / D656): the MetroEventsClient attaches a second WebSocket alongside CDP, giving push-based visibility into bundler state — watch for build errors without having to read console.error. Returns { eventsConnected, lastBuild, buildErrors, events, count }. Pass `clearErrors: true` to reset the build-error counter.', {
     limit: z.number().int().min(1).max(100).default(20).describe('Max entries to return (default 20, max 100)'),
     type: z.string().optional().describe('Filter by event type (e.g. "bundle_build_failed")'),

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -355,11 +355,10 @@ trackedTool(
   withConnection(getClient, async (args: { testID: string; prop: string; value: number }, client) => {
     const expression = `(function() {
       var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-      if (!hook) return JSON.stringify({ __agent_error: 'No React DevTools hook' });
-      var ids = Array.from(hook.renderers.keys());
+      if (!hook || typeof hook.getFiberRoots !== 'function') return JSON.stringify({ __agent_error: 'No React DevTools hook' });
       var allRoots = [];
-      for (var i = 0; i < ids.length; i++) {
-        var r = hook.getFiberRoots(ids[i]);
+      for (var i = 1; i <= 5; i++) {
+        var r = hook.getFiberRoots(i);
         if (r && r.size) { var it = r.values(); var v; while (!(v = it.next()).done) allRoots.push(v.value); }
       }
       if (!allRoots.length) return JSON.stringify({ __agent_error: 'No fiber roots' });
@@ -796,7 +795,7 @@ trackedTool(
 
 trackedTool(
   'cdp_open_devtools',
-  'Report the React Native DevTools frontend URL for the live app + whether DevTools can coexist with the MCP session (RN >= 0.85 native multi-debugger). M1 (Phase 90 Tier 1) ships detection + capability reporting; full proxy auto-wiring for RN < 0.85 is tracked as M1b/Phase 100. Returns { devtoolsUrl, inspectorWsUrl, mode, supportsMultipleDebuggers, rnVersion, guidance }.',
+  'Report the React Native DevTools frontend URL for the live app + start a multiplexer proxy so DevTools can coexist with the MCP session on RN < 0.85 (RN >= 0.85 uses native multi-debugger). M1a (Phase 100) shipped detection + capability reporting; M1b (Phase 104) wired the proxy into CDPClient; B132 (Phase 105) added proxy auto-resume across reconnect. Returns { devtoolsUrl, inspectorWsUrl, hermesWsUrl, mode: "native" | "proxy-active", proxyPort, supportsMultipleDebuggers, rnVersion, guidance }.',
   {},
   createOpenDevToolsHandler(getClient),
 );

--- a/scripts/cdp-bridge/test/unit/shared-value-renderer-probe-guard.test.js
+++ b/scripts/cdp-bridge/test/unit/shared-value-renderer-probe-guard.test.js
@@ -1,0 +1,59 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// B133 / M8 regression guard. M8 (D663) replaced the `hook.renderers.keys()`
+// pattern in injected-helpers.ts::findActiveRenderer with a 1..5 getFiberRoots
+// probe. B133 (D664) ported the same fix into index.ts::cdp_set_shared_value.
+// This test fails if any new source file reintroduces the stale pattern —
+// which would silently break apps where `__REACT_DEVTOOLS_GLOBAL_HOOK__.renderers`
+// is empty or missing (React Native macros, Reanimated worklets, early render).
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC_DIR = join(__dirname, '../../src');
+
+function* walkTs(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkTs(full);
+    } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+      yield full;
+    }
+  }
+}
+
+test('B133: no src file uses stale hook.renderers.keys pattern', () => {
+  const violations = [];
+  for (const file of walkTs(SRC_DIR)) {
+    const content = readFileSync(file, 'utf8');
+    if (/hook\.renderers\.keys\s*\(/.test(content)) {
+      violations.push(relative(SRC_DIR, file));
+    }
+  }
+  assert.deepEqual(
+    violations,
+    [],
+    `Files using stale hook.renderers.keys() pattern — use 1..5 getFiberRoots probe (see injected-helpers.ts::findActiveRenderer or REACT_READY_PROBE_JS). Violations: ${violations.join(', ')}`,
+  );
+});
+
+test('B133: cdp_set_shared_value uses the 1..5 getFiberRoots probe pattern', () => {
+  const content = readFileSync(join(SRC_DIR, 'index.ts'), 'utf8');
+  assert.match(
+    content,
+    /for \(var i = 1; i <= 5; i\+\+\) \{\s*\n\s*var r = hook\.getFiberRoots\(i\);/,
+    'cdp_set_shared_value expression should use the 1..5 probe pattern after B133 fix',
+  );
+});
+
+test('B133: cdp_set_shared_value guards on typeof hook.getFiberRoots === "function"', () => {
+  const content = readFileSync(join(SRC_DIR, 'index.ts'), 'utf8');
+  assert.match(
+    content,
+    /typeof hook\.getFiberRoots !== 'function'/,
+    'cdp_set_shared_value should guard on getFiberRoots being a function (matches findActiveRenderer and REACT_READY_PROBE_JS)',
+  );
+});


### PR DESCRIPTION
## Summary

Closes **B133** (filed during M8 / Phase 106 review as a sibling-carveout). Ports the 1..5 `getFiberRoots` probe pattern into `cdp_set_shared_value` so the tool works on apps where `__REACT_DEVTOOLS_GLOBAL_HOOK__.renderers` is empty or missing — the same fix M8 shipped for `findActiveRenderer` and `waitForReact`.

Bundles a concurrent fix: the `cdp_open_devtools` tool description was frozen at M1a-era text, factually misleading after M1b (Phase 104) and B132 (Phase 105) shipped. Two tiny fixes in the same file + a structural regression guard — one PR, one merge.

## Why

During M8 review, Gemini flagged `src/index.ts:356-398` as using the stale `hook.renderers.keys()` pattern that M8 was dropping elsewhere. Scoped out of M8 per story boundary, filed as B133. Without this fix, `cdp_set_shared_value` silently fails on the exact apps M8 was meant to help.

The description cleanup is cosmetic but misleading if left: users reading the tool listing see "M1b tracked as Phase 100" which hasn't been true since M1b merged in #49.

## Scope

| File | Change |
|---|---|
| `scripts/cdp-bridge/src/index.ts` | B133 fix (lines 356-397): replaced `Array.from(hook.renderers.keys())` loop with `for (var i = 1; i <= 5; i++) getFiberRoots(i)` + `typeof getFiberRoots !== 'function'` guard. Description refresh (line 798): M1a/Phase 100 → M1b/Phase 104 → B132/Phase 105 chain. |
| `scripts/cdp-bridge/test/unit/shared-value-renderer-probe-guard.test.js` | NEW — 3 structural tests. Walks all `src/*.ts` for stale-pattern reintroduction; pins `index.ts` to the new probe shape. |
| Versions | plugin 0.36.0 → 0.36.1, MCP 0.31.0 → 0.31.1 (patch — bugfix + doc fix) |

## Intentional divergence from M8

M8's `findActiveRenderer` returns on the FIRST renderer with populated roots (early-return). `cdp_set_shared_value` accumulates ALL roots across IDs 1..5 into `allRoots` before walking — because Reanimated worklets can mount in a secondary renderer at a different ID from the React DOM/native renderer, and the target testID might live in any of them. Early-return would miss worklet targets. Both reviewers verified this is correct.

## Tests

485 → **488 passing**, 0 failures.

New tests:
```
✔ B133: no src file uses stale hook.renderers.keys pattern
✔ B133: cdp_set_shared_value uses the 1..5 getFiberRoots probe pattern
✔ B133: cdp_set_shared_value guards on typeof hook.getFiberRoots === \"function\"
```

## Review

Multi-LLM (Gemini + Codex). Both clean — 0 high-confidence findings.

- **Gemini** (who originally flagged this): "The 3-line swap faithfully mirrors M8, the description honestly reflects the M1a+M1b+B132 chain, and the guard pins the exact pattern without overreach. Ship it."
- **Codex**: Verified the `allRoots` accumulator divergence is intentionally correct for worklet-aware fiber walks. Scope tight.

## Test plan

- [x] `cd scripts/cdp-bridge && npm test` → 488 passing, 0 failures
- [x] Structural guards added (B133 test file)
- [ ] **Post-merge smoke**: opportunistic — if we hit a Reanimated-worklet app via `cdp_set_shared_value`, confirm it now locates the target on a secondary renderer. Not a blocker for merge since the logic mirrors already-shipped M8 code.

## Refs

- D664 in `rn-dev-agent-workspace/docs/DECISIONS.md`
- Phase 107 in `rn-dev-agent-workspace/docs/ROADMAP.md`
- B133 in `rn-dev-agent-workspace/docs/BUGS.md` (now FIXED)
- Parent: D663 / M8 / Phase 106 (#51)