### PR TITLE
feat(m11/phase-108): Metro --clear hint on empty buffers (D665)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,42 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.39.0] — 2026-04-22
+
+M11 / Phase 108 — Metro `--clear` hint on empty buffers. Closes the Phase 90 Tier 4 UX story from the metro-mcp pattern adoption audit. When `cdp_console_log` or `cdp_network_log` return empty results AND the CDP session has been idle for more than 60s (measured as `max(connectedAt, lastEventAt)`), the tool result now includes `meta.hint` suggesting `npx expo start --clear` / `npx react-native start --reset-cache`. This surfaces a failure mode (stale Metro bundle cache) that previously required users to find it in a troubleshooting doc. MCP server bumped to 0.34.0.
+
+Version note: M11 was originally tagged 0.37.0 (reserved before M7 shipped). Main moved to 0.38.0 before this PR merged, so M11 rebased to 0.39.0 above M7. The 0.37.0 reservation was abandoned; no `## [0.37.0]` entry exists.
+
+### Added
+- **`scripts/cdp-bridge/src/tools/metro-clear-hint.ts`** — pure helper. Exports `METRO_CLEAR_HINT_THRESHOLD_MS = 60_000`, `METRO_CLEAR_HINT_TEXT`, and `shouldShowMetroClearHint(deps, resultIsEmpty): boolean` where `deps = { connectedAt, lastEventAt?, now }`. Idle reference is `max(connectedAt, lastEventAt ?? connectedAt)` — any activity resets the clock.
+- **`CDPClient._connectedAt`** — timestamp of the current connection; null when disconnected. Reset via `buildResettableState` so every reconnect (including B132 proxy auto-resume) re-stamps correctly.
+- **`CDPClient._timeNowFn`** — injectable clock. Constructor now accepts `new CDPClient(port?, timeNowFn?)` (backwards compat). Defaults to `Date.now`.
+- **`DeviceBufferManager.getLastPush(deviceKey): number | undefined`** — public accessor over the existing internal `lastPush` map. Used by `cdp_network_log` to gauge per-device idle time.
+
+### Changed (forward-compatible)
+- **`cdp_console_log`** — on empty `entries`, wraps the result with `{ meta: { hint: METRO_CLEAR_HINT_TEXT } }` when the connection has been idle for > 60s. Console has no per-buffer `lastPush` today (it queries in-app `__RN_AGENT.getConsole()` rather than our ring buffer), so the idle reference falls back to `connectedAt` only.
+- **`cdp_network_log`** — same pattern as console, but passes `lastEventAt = client.networkBufferManager.getLastPush(scope)`. For `scope === 'all'` (cross-device query), falls back to `connectedAt` only since there's no single-device `lastPush` to consult.
+
+### Tests
+- **20 new tests**: 10 pure-helper at `test/unit/metro-clear-hint.test.js` (threshold boundaries, null-connectedAt, both-timestamp-max permutations, exactly-at-threshold, undefined-lastEventAt fallback, hint-text content); 10 integration at `test/unit/metro-clear-hint-integration.test.js` (CDPClient surface: null-on-fresh, injected fn returned, Date.now default; console-log handler: present / below / above threshold; network-log handler: present / recent-push / stale-both / scope='all').
+- **Mock helper extended** — `test/helpers/mock-cdp-client.js` gained `connectedAt` + `now` getters with sane defaults that suppress the hint unless explicitly overridden.
+
+Running total after rebase onto M7-included main: 505 → **525 passing**, zero failures.
+
+### Review
+Multi-LLM (Gemini + Codex) on original PR. Both clean. Gemini verified the B132 auto-resume path correctly re-stamps `_connectedAt` via the existing `handleClose → resetState → reconnect → connectToTarget` chain. Codex flagged one sub-threshold observation (clock-skew between `DeviceBufferManager.push` using real `Date.now()` vs. CDPClient using the injected `_timeNowFn`) — moot in production where both are `Date.now`.
+
+### Known limits
+- **Stateless — fires every call past threshold** on genuinely idle apps. Accepted per design; LLM context usually absorbs repeated hints.
+
+### Refs
+D665 in `rn-dev-agent-workspace/docs/DECISIONS.md`. Phase 108 in `rn-dev-agent-workspace/docs/ROADMAP.md`. metro-mcp reference: troubleshooting "Empty Results or Stale Data" (top-3 user issue).
+
 ## [0.38.0] — 2026-04-22
 
 M7 / Phase 109 — fast-runner tri-state liveness probe. Closes the Phase 90 Tier 3 M7 story and functionally retires the shape-equivalent leftover from R3. Previously `isFastRunnerAvailable()` only checked PID; a process whose PID was alive but whose HTTP server had wedged was reported as available, and every iOS `device_press` / `device_fill` / `device_swipe` stalled on a 10s fetch timeout before falling through to the daemon. M7 adds a `probeFastRunnerLiveness()` helper that distinguishes `'alive' | 'stale' | 'dead'` via PID check + `/health` probe, plus an explicit `reapStaleFastRunner()` helper for the SIGTERM→grace→SIGKILL escalation. `tryFastRunner` is rewired to branch on the tri-state. MCP server bumped to 0.33.0.
 
-Version note: this release skips 0.37.0 (reserved for unmerged M11 PR #53). When M11 merges it will slot in as 0.37.0 between this and 0.36.1.
+Version note: this release skipped 0.37.0 (reserved for M11 PR #53 at the time). Main moved past 0.37.0 before M11 merged, so M11 shipped as 0.39.0 above this entry instead of slotting in below.
 
 ### Added
 - **`FastRunnerLiveness` type** + `probeFastRunnerLiveness(deps?)` + `reapStaleFastRunner(deps?)` in `scripts/cdp-bridge/src/fast-runner-session.ts`. All deps injectable (`getState`, `processAlive`, `httpProbe`, `clearState`, `sendSignal`, `sleep`) for hermetic tests — mirrors the `lockfile.ts` pattern.

--- a/scripts/cdp-bridge/dist/cdp-client.js
+++ b/scripts/cdp-bridge/dist/cdp-client.js
@@ -33,6 +33,11 @@ export class CDPClient {
     _networkMode = 'none';
     _isPaused = false;
     _connectedTarget = null;
+    // M11 / Phase 108: timestamp (ms) of the current CDP connection; null when disconnected.
+    // Used by cdp_console_log / cdp_network_log to surface the Metro --clear hint after
+    // prolonged empty results. Reset alongside _connectedTarget via buildResettableState.
+    _connectedAt = null;
+    _timeNowFn;
     _state = 'disconnected';
     _connectionGeneration = 0;
     _softReconnectRequested = false;
@@ -64,8 +69,10 @@ export class CDPClient {
     // or disconnect(). Preserved across _suspendProxy() so post-reconnect auto-resume
     // can rehydrate the proxy against the fresh target URL.
     _proxyDesired = false;
-    constructor(port) {
+    constructor(port, timeNowFn) {
         this._port = port ?? 8081;
+        // M11: optional injectable clock for deterministic tests. Production default: Date.now.
+        this._timeNowFn = timeNowFn ?? Date.now;
         this._consoleBuffer = new RingBuffer(200);
         // B128 (D657): use process-scoped singleton instead of per-client instance
         this._networkBufferManager = getNetworkBufferManager();
@@ -77,6 +84,10 @@ export class CDPClient {
     get helpersInjected() { return this._helpersInjected; }
     get metroPort() { return this._port; }
     get connectedTarget() { return this._connectedTarget; }
+    /** M11: timestamp of the current CDP connection (ms since epoch); null when disconnected. */
+    get connectedAt() { return this._connectedAt; }
+    /** M11: clock source for this client (injectable; defaults to Date.now). */
+    get now() { return this._timeNowFn; }
     get networkMode() { return this._networkMode; }
     get consoleBuffer() { return this._consoleBuffer; }
     /** M4 (D655): per-device buffer manager. Use `activeDeviceKey` for single-device queries, `'all'` for cross-device. */
@@ -541,6 +552,8 @@ export class CDPClient {
             setWs: (ws) => { this.ws = ws; },
             setHelpersInjected: (v) => { this._helpersInjected = v; },
             setConnectedTarget: (t) => { this._connectedTarget = t; },
+            setConnectedAt: (ms) => { this._connectedAt = ms; },
+            now: () => this._timeNowFn(),
             incrementConnectionGeneration: () => ++this._connectionGeneration,
             evaluate: (expr) => this.evaluate(expr),
             sendWithTimeout: (method, params, ms) => this.sendWithTimeout(method, params, ms),
@@ -558,6 +571,7 @@ export class CDPClient {
             setBridgeDetected: (v) => { this._bridgeDetected = v; },
             setBridgeVersion: (v) => { this._bridgeVersion = v; },
             setConnectedTarget: (v) => { this._connectedTarget = v; },
+            setConnectedAt: (v) => { this._connectedAt = v; },
             setLogDomainEnabled: (v) => { this._logDomainEnabled = v; },
             setProfilerAvailable: (v) => { this._profilerAvailable = v; },
             setHeapProfilerAvailable: (v) => { this._heapProfilerAvailable = v; },

--- a/scripts/cdp-bridge/dist/cdp/connect.js
+++ b/scripts/cdp-bridge/dist/cdp/connect.js
@@ -123,6 +123,9 @@ async function connectToTarget(ctx, target, retries = 5) {
                 throw new Error('Target failed pre-flight probe (1+1) — likely a dead JS context');
             }
             ctx.setConnectedTarget(target);
+            // M11: stamp connection time so cdp_console_log / cdp_network_log can reason
+            // about "how long have we been connected with nothing happening?"
+            ctx.setConnectedAt(ctx.now());
             await ctx.setup();
             return;
         }

--- a/scripts/cdp-bridge/dist/cdp/state.js
+++ b/scripts/cdp-bridge/dist/cdp/state.js
@@ -9,6 +9,7 @@ export function resetState(s) {
     s.setBridgeDetected(false);
     s.setBridgeVersion(null);
     s.setConnectedTarget(null);
+    s.setConnectedAt(null);
     s.setLogDomainEnabled(false);
     s.setProfilerAvailable(false);
     s.setHeapProfilerAvailable(false);

--- a/scripts/cdp-bridge/dist/ring-buffer.js
+++ b/scripts/cdp-bridge/dist/ring-buffer.js
@@ -194,6 +194,14 @@ export class DeviceBufferManager {
             .sort((a, b) => a[1] - b[1])
             .map(([key]) => key);
     }
+    /**
+     * M11 (D665): timestamp (ms since epoch) of the most recent push to `deviceKey`,
+     * or undefined if this device has never pushed. Used to gauge idle time for
+     * the Metro --clear hint in cdp_network_log.
+     */
+    getLastPush(deviceKey) {
+        return this.lastPush.get(deviceKey);
+    }
     evictOldest() {
         let oldestKey = null;
         let oldestTs = Number.POSITIVE_INFINITY;

--- a/scripts/cdp-bridge/dist/tools/console-log.js
+++ b/scripts/cdp-bridge/dist/tools/console-log.js
@@ -1,4 +1,5 @@
 import { okResult, failResult, withConnection } from '../utils.js';
+import { shouldShowMetroClearHint, METRO_CLEAR_HINT_TEXT } from './metro-clear-hint.js';
 export function createConsoleLogHandler(getClient) {
     return withConnection(getClient, async (args, client) => {
         if (args.clear) {
@@ -35,6 +36,11 @@ export function createConsoleLogHandler(getClient) {
         else {
             return failResult('Unexpected response from getConsole — expected array or { entries }');
         }
-        return okResult({ count: entries.length, entries });
+        // M11: include hint when buffer has stayed empty for >60s since connect.
+        // Console has no per-buffer lastPush (queries in-app __RN_AGENT.getConsole),
+        // so connectedAt is the only reference point.
+        const hint = shouldShowMetroClearHint({ connectedAt: client.connectedAt, now: client.now }, entries.length === 0) ? METRO_CLEAR_HINT_TEXT : undefined;
+        const resultOpts = hint ? { meta: { hint } } : undefined;
+        return okResult({ count: entries.length, entries }, resultOpts);
     });
 }

--- a/scripts/cdp-bridge/dist/tools/metro-clear-hint.js
+++ b/scripts/cdp-bridge/dist/tools/metro-clear-hint.js
@@ -1,0 +1,27 @@
+// M11 / Phase 90 Tier 3: Metro --clear / --reset-cache hint.
+//
+// When the MCP's buffers return empty while the session has been active
+// for more than METRO_CLEAR_HINT_THRESHOLD_MS, suggest restarting Metro
+// with a cache clear. The common failure mode this targets is a stale
+// bundle cache — app logs/requests happen but never reach the MCP because
+// a mismatched bundle is running. Source: metro-mcp troubleshooting
+// "Empty Results or Stale Data" (top-3 issue).
+export const METRO_CLEAR_HINT_THRESHOLD_MS = 60_000;
+export const METRO_CLEAR_HINT_TEXT = 'If results stay empty, try restarting Metro with `npx expo start --clear` ' +
+    'or `npx react-native start --reset-cache`. The MCP will reconnect automatically.';
+/**
+ * Decide whether to include the Metro --clear hint in a tool result.
+ *
+ * Semantics: the idle-clock reference is the MORE RECENT of `connectedAt`
+ * and `lastEventAt`. Any activity (connecting OR receiving an event)
+ * resets the clock. Both must be older than the threshold for the hint
+ * to fire.
+ */
+export function shouldShowMetroClearHint(deps, resultIsEmpty) {
+    if (!resultIsEmpty)
+        return false;
+    if (deps.connectedAt == null)
+        return false;
+    const ref = Math.max(deps.connectedAt, deps.lastEventAt ?? deps.connectedAt);
+    return deps.now() - ref >= METRO_CLEAR_HINT_THRESHOLD_MS;
+}

--- a/scripts/cdp-bridge/dist/tools/network-log.js
+++ b/scripts/cdp-bridge/dist/tools/network-log.js
@@ -1,4 +1,5 @@
 import { okResult, withConnection } from '../utils.js';
+import { shouldShowMetroClearHint, METRO_CLEAR_HINT_TEXT } from './metro-clear-hint.js';
 export function createNetworkLogHandler(getClient) {
     return withConnection(getClient, async (args, client) => {
         const scope = args.device ?? client.activeDeviceKey;
@@ -13,6 +14,13 @@ export function createNetworkLogHandler(getClient) {
         if (args.filter !== undefined && entries.length > limit) {
             entries = entries.slice(-limit);
         }
-        return okResult({ mode: client.networkMode, device: scope, count: entries.length, requests: entries });
+        // M11: include hint when buffer has stayed empty for >60s. The network
+        // manager tracks per-device lastPush, so the idle reference is
+        // max(connectedAt, lastPush[scope]). 'all' scope has no single lastPush,
+        // so fall back to connectedAt only.
+        const lastEventAt = scope === 'all' ? null : client.networkBufferManager.getLastPush(scope);
+        const hint = shouldShowMetroClearHint({ connectedAt: client.connectedAt, lastEventAt: lastEventAt ?? null, now: client.now }, entries.length === 0) ? METRO_CLEAR_HINT_TEXT : undefined;
+        const resultOpts = hint ? { meta: { hint } } : undefined;
+        return okResult({ mode: client.networkMode, device: scope, count: entries.length, requests: entries }, resultOpts);
     });
 }

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/cdp-client.ts
+++ b/scripts/cdp-bridge/src/cdp-client.ts
@@ -57,6 +57,11 @@ export class CDPClient {
   private _networkMode: 'cdp' | 'hook' | 'none' = 'none';
   private _isPaused = false;
   private _connectedTarget: HermesTarget | null = null;
+  // M11 / Phase 108: timestamp (ms) of the current CDP connection; null when disconnected.
+  // Used by cdp_console_log / cdp_network_log to surface the Metro --clear hint after
+  // prolonged empty results. Reset alongside _connectedTarget via buildResettableState.
+  private _connectedAt: number | null = null;
+  private _timeNowFn: () => number;
   private _state: CDPClientState = 'disconnected';
   private _connectionGeneration = 0;
   private _softReconnectRequested = false;
@@ -92,8 +97,10 @@ export class CDPClient {
   // can rehydrate the proxy against the fresh target URL.
   private _proxyDesired = false;
 
-  constructor(port?: number) {
+  constructor(port?: number, timeNowFn?: () => number) {
     this._port = port ?? 8081;
+    // M11: optional injectable clock for deterministic tests. Production default: Date.now.
+    this._timeNowFn = timeNowFn ?? Date.now;
     this._consoleBuffer = new RingBuffer<ConsoleEntry>(200);
     // B128 (D657): use process-scoped singleton instead of per-client instance
     this._networkBufferManager = getNetworkBufferManager();
@@ -106,6 +113,10 @@ export class CDPClient {
   get helpersInjected(): boolean { return this._helpersInjected; }
   get metroPort(): number { return this._port; }
   get connectedTarget(): HermesTarget | null { return this._connectedTarget; }
+  /** M11: timestamp of the current CDP connection (ms since epoch); null when disconnected. */
+  get connectedAt(): number | null { return this._connectedAt; }
+  /** M11: clock source for this client (injectable; defaults to Date.now). */
+  get now(): () => number { return this._timeNowFn; }
   get networkMode(): 'cdp' | 'hook' | 'none' { return this._networkMode; }
   get consoleBuffer(): RingBuffer<ConsoleEntry> { return this._consoleBuffer; }
   /** M4 (D655): per-device buffer manager. Use `activeDeviceKey` for single-device queries, `'all'` for cross-device. */
@@ -593,6 +604,8 @@ export class CDPClient {
       setWs: (ws) => { this.ws = ws; },
       setHelpersInjected: (v) => { this._helpersInjected = v; },
       setConnectedTarget: (t) => { this._connectedTarget = t; },
+      setConnectedAt: (ms) => { this._connectedAt = ms; },
+      now: () => this._timeNowFn(),
       incrementConnectionGeneration: () => ++this._connectionGeneration,
       evaluate: (expr) => this.evaluate(expr),
       sendWithTimeout: (method, params, ms) => this.sendWithTimeout(method, params, ms),
@@ -611,6 +624,7 @@ export class CDPClient {
       setBridgeDetected: (v) => { this._bridgeDetected = v; },
       setBridgeVersion: (v) => { this._bridgeVersion = v; },
       setConnectedTarget: (v) => { this._connectedTarget = v; },
+      setConnectedAt: (v) => { this._connectedAt = v; },
       setLogDomainEnabled: (v) => { this._logDomainEnabled = v; },
       setProfilerAvailable: (v) => { this._profilerAvailable = v; },
       setHeapProfilerAvailable: (v) => { this._heapProfilerAvailable = v; },

--- a/scripts/cdp-bridge/src/cdp/connect.ts
+++ b/scripts/cdp-bridge/src/cdp/connect.ts
@@ -28,6 +28,8 @@ export interface ConnectContext {
   setWs(ws: WebSocket | null): void;
   setHelpersInjected(v: boolean): void;
   setConnectedTarget(t: HermesTarget | null): void;
+  setConnectedAt(ms: number | null): void;
+  now(): number;
   incrementConnectionGeneration(): number;
   evaluate(expr: string): Promise<EvaluateResult>;
   sendWithTimeout(method: string, params: unknown, ms: number): Promise<unknown>;
@@ -176,6 +178,9 @@ async function connectToTarget(
         throw new Error('Target failed pre-flight probe (1+1) — likely a dead JS context');
       }
       ctx.setConnectedTarget(target);
+      // M11: stamp connection time so cdp_console_log / cdp_network_log can reason
+      // about "how long have we been connected with nothing happening?"
+      ctx.setConnectedAt(ctx.now());
       await ctx.setup();
       return;
     } catch (err) {

--- a/scripts/cdp-bridge/src/cdp/state.ts
+++ b/scripts/cdp-bridge/src/cdp/state.ts
@@ -12,6 +12,7 @@ export interface ResettableState {
   setBridgeDetected(v: boolean): void;
   setBridgeVersion(v: number | null): void;
   setConnectedTarget(v: HermesTarget | null): void;
+  setConnectedAt(v: number | null): void;
   setLogDomainEnabled(v: boolean): void;
   setProfilerAvailable(v: boolean): void;
   setHeapProfilerAvailable(v: boolean): void;
@@ -24,6 +25,7 @@ export function resetState(s: ResettableState): void {
   s.setBridgeDetected(false);
   s.setBridgeVersion(null);
   s.setConnectedTarget(null);
+  s.setConnectedAt(null);
   s.setLogDomainEnabled(false);
   s.setProfilerAvailable(false);
   s.setHeapProfilerAvailable(false);

--- a/scripts/cdp-bridge/src/ring-buffer.ts
+++ b/scripts/cdp-bridge/src/ring-buffer.ts
@@ -228,6 +228,15 @@ export class DeviceBufferManager<T, K = unknown> {
       .map(([key]) => key);
   }
 
+  /**
+   * M11 (D665): timestamp (ms since epoch) of the most recent push to `deviceKey`,
+   * or undefined if this device has never pushed. Used to gauge idle time for
+   * the Metro --clear hint in cdp_network_log.
+   */
+  getLastPush(deviceKey: string): number | undefined {
+    return this.lastPush.get(deviceKey);
+  }
+
   private evictOldest(): void {
     let oldestKey: string | null = null;
     let oldestTs = Number.POSITIVE_INFINITY;

--- a/scripts/cdp-bridge/src/tools/console-log.ts
+++ b/scripts/cdp-bridge/src/tools/console-log.ts
@@ -1,5 +1,6 @@
 import type { CDPClient } from '../cdp-client.js';
 import { okResult, failResult, withConnection } from '../utils.js';
+import { shouldShowMetroClearHint, METRO_CLEAR_HINT_TEXT } from './metro-clear-hint.js';
 
 export function createConsoleLogHandler(getClient: () => CDPClient) {
   return withConnection(getClient, async (args: { level: string; limit: number; clear: boolean }, client) => {
@@ -41,6 +42,15 @@ export function createConsoleLogHandler(getClient: () => CDPClient) {
       return failResult('Unexpected response from getConsole — expected array or { entries }');
     }
 
-    return okResult({ count: entries.length, entries });
+    // M11: include hint when buffer has stayed empty for >60s since connect.
+    // Console has no per-buffer lastPush (queries in-app __RN_AGENT.getConsole),
+    // so connectedAt is the only reference point.
+    const hint = shouldShowMetroClearHint(
+      { connectedAt: client.connectedAt, now: client.now },
+      entries.length === 0,
+    ) ? METRO_CLEAR_HINT_TEXT : undefined;
+    const resultOpts = hint ? { meta: { hint } } : undefined;
+
+    return okResult({ count: entries.length, entries }, resultOpts);
   });
 }

--- a/scripts/cdp-bridge/src/tools/metro-clear-hint.ts
+++ b/scripts/cdp-bridge/src/tools/metro-clear-hint.ts
@@ -1,0 +1,41 @@
+// M11 / Phase 90 Tier 3: Metro --clear / --reset-cache hint.
+//
+// When the MCP's buffers return empty while the session has been active
+// for more than METRO_CLEAR_HINT_THRESHOLD_MS, suggest restarting Metro
+// with a cache clear. The common failure mode this targets is a stale
+// bundle cache — app logs/requests happen but never reach the MCP because
+// a mismatched bundle is running. Source: metro-mcp troubleshooting
+// "Empty Results or Stale Data" (top-3 issue).
+
+export const METRO_CLEAR_HINT_THRESHOLD_MS = 60_000;
+
+export const METRO_CLEAR_HINT_TEXT =
+  'If results stay empty, try restarting Metro with `npx expo start --clear` ' +
+  'or `npx react-native start --reset-cache`. The MCP will reconnect automatically.';
+
+export interface HintDeps {
+  /** Timestamp (ms since epoch) of the CDP connection. Null when disconnected. */
+  connectedAt: number | null;
+  /** Most recent per-scope push timestamp from a DeviceBufferManager. Undefined/null when no events have been observed (or no buffer backs this tool). */
+  lastEventAt?: number | null;
+  /** Clock source — injectable for tests. */
+  now: () => number;
+}
+
+/**
+ * Decide whether to include the Metro --clear hint in a tool result.
+ *
+ * Semantics: the idle-clock reference is the MORE RECENT of `connectedAt`
+ * and `lastEventAt`. Any activity (connecting OR receiving an event)
+ * resets the clock. Both must be older than the threshold for the hint
+ * to fire.
+ */
+export function shouldShowMetroClearHint(
+  deps: HintDeps,
+  resultIsEmpty: boolean,
+): boolean {
+  if (!resultIsEmpty) return false;
+  if (deps.connectedAt == null) return false;
+  const ref = Math.max(deps.connectedAt, deps.lastEventAt ?? deps.connectedAt);
+  return deps.now() - ref >= METRO_CLEAR_HINT_THRESHOLD_MS;
+}

--- a/scripts/cdp-bridge/src/tools/network-log.ts
+++ b/scripts/cdp-bridge/src/tools/network-log.ts
@@ -1,5 +1,6 @@
 import type { CDPClient } from '../cdp-client.js';
 import { okResult, withConnection } from '../utils.js';
+import { shouldShowMetroClearHint, METRO_CLEAR_HINT_TEXT } from './metro-clear-hint.js';
 
 export function createNetworkLogHandler(getClient: () => CDPClient) {
   return withConnection(getClient, async (args: { limit: number; filter?: string; clear: boolean; device?: string }, client) => {
@@ -20,6 +21,17 @@ export function createNetworkLogHandler(getClient: () => CDPClient) {
       entries = entries.slice(-limit);
     }
 
-    return okResult({ mode: client.networkMode, device: scope, count: entries.length, requests: entries });
+    // M11: include hint when buffer has stayed empty for >60s. The network
+    // manager tracks per-device lastPush, so the idle reference is
+    // max(connectedAt, lastPush[scope]). 'all' scope has no single lastPush,
+    // so fall back to connectedAt only.
+    const lastEventAt = scope === 'all' ? null : client.networkBufferManager.getLastPush(scope);
+    const hint = shouldShowMetroClearHint(
+      { connectedAt: client.connectedAt, lastEventAt: lastEventAt ?? null, now: client.now },
+      entries.length === 0,
+    ) ? METRO_CLEAR_HINT_TEXT : undefined;
+    const resultOpts = hint ? { meta: { hint } } : undefined;
+
+    return okResult({ mode: client.networkMode, device: scope, count: entries.length, requests: entries }, resultOpts);
   });
 }

--- a/scripts/cdp-bridge/test/helpers/mock-cdp-client.js
+++ b/scripts/cdp-bridge/test/helpers/mock-cdp-client.js
@@ -46,6 +46,9 @@ export function createMockClient(overrides = {}) {
     get proxyUrl() { return client._proxyUrl; },
     get isProxyActive() { return client._proxyUrl !== null; },
     get proxyMultiplexer() { return client._proxyMultiplexer; },
+    /** M11: connection timestamp + injectable clock. Override _connectedAt / _timeNowFn. */
+    get connectedAt() { return client._connectedAt; },
+    get now() { return client._timeNowFn; },
 
     // --- Mutable state (set in overrides or mutated in tests) ---
     _isConnected: true,
@@ -70,6 +73,11 @@ export function createMockClient(overrides = {}) {
     _heapProfilerAvailable: true,
     _scripts: new Map(),
     _connectionGeneration: 1,
+    // M11 defaults: connectedAt=1_000_000 and timeNowFn returning 1_000_000
+    // means "just connected, 0ms elapsed" — hint should NOT fire by default.
+    // Tests that want the hint to fire override _timeNowFn to a later value.
+    _connectedAt: 1_000_000,
+    _timeNowFn: () => 1_000_000,
 
     // D502 freshness probe needs this — withConnection checks `typeof globalThis.__RN_AGENT`
     // and expects a number. Returning 13 (helpers version) satisfies the probe so tests

--- a/scripts/cdp-bridge/test/unit/cdp-connect.test.js
+++ b/scripts/cdp-bridge/test/unit/cdp-connect.test.js
@@ -28,6 +28,8 @@ function createMockContext({ initialFilters = {}, port = 8081 } = {}) {
     setWs: () => {},
     setHelpersInjected: () => {},
     setConnectedTarget: () => {},
+    setConnectedAt: () => {},
+    now: () => 1_000_000,
     incrementConnectionGeneration: () => 1,
     evaluate: async () => ({ value: undefined }),
     sendWithTimeout: async () => null,

--- a/scripts/cdp-bridge/test/unit/cdp-state.test.js
+++ b/scripts/cdp-bridge/test/unit/cdp-state.test.js
@@ -23,6 +23,7 @@ function makeTarget() {
     setBridgeDetected: (v) => { calls.push(['bridgeDetected', v]); state.bridgeDetected = v; },
     setBridgeVersion: (v) => { calls.push(['bridgeVersion', v]); state.bridgeVersion = v; },
     setConnectedTarget: (v) => { calls.push(['target', v]); state.connectedTarget = v; },
+    setConnectedAt: (v) => { calls.push(['connectedAt', v]); state.connectedAt = v; },
     setLogDomainEnabled: (v) => { calls.push(['logDomain', v]); state.logDomainEnabled = v; },
     setProfilerAvailable: (v) => { calls.push(['profiler', v]); state.profilerAvailable = v; },
     setHeapProfilerAvailable: (v) => { calls.push(['heapProfiler', v]); state.heapProfilerAvailable = v; },
@@ -65,7 +66,7 @@ test('resetState calls every setter exactly once', () => {
   const names = t.calls.map(c => c[0]);
   assert.deepEqual(names, [
     'state', 'helpers', 'bridgeDetected', 'bridgeVersion',
-    'target', 'logDomain', 'profiler', 'heapProfiler', 'clearScripts',
+    'target', 'connectedAt', 'logDomain', 'profiler', 'heapProfiler', 'clearScripts',
   ]);
 });
 

--- a/scripts/cdp-bridge/test/unit/metro-clear-hint-integration.test.js
+++ b/scripts/cdp-bridge/test/unit/metro-clear-hint-integration.test.js
@@ -1,0 +1,153 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { CDPClient } from '../../dist/cdp-client.js';
+import { createMockClient } from '../helpers/mock-cdp-client.js';
+import { parseEnvelope } from '../helpers/result-helpers.js';
+import { createConsoleLogHandler } from '../../dist/tools/console-log.js';
+import { createNetworkLogHandler } from '../../dist/tools/network-log.js';
+import { METRO_CLEAR_HINT_TEXT } from '../../dist/tools/metro-clear-hint.js';
+
+// M11 / D665 — integration tests. Cover (a) CDPClient's connectedAt/now surface
+// and (b) console-log + network-log handlers emitting meta.hint when the idle
+// threshold is crossed.
+
+// ── CDPClient lifecycle surface ──
+
+test('M11: CDPClient.connectedAt is null on a fresh instance', () => {
+  const client = new CDPClient();
+  assert.equal(client.connectedAt, null);
+});
+
+test('M11: CDPClient.now returns the injected timeNowFn', () => {
+  const stubNow = () => 42;
+  const client = new CDPClient(8081, stubNow);
+  assert.equal(client.now, stubNow);
+  assert.equal(client.now(), 42);
+});
+
+test('M11: CDPClient.now defaults to Date.now when no fn injected', () => {
+  const client = new CDPClient();
+  // Sanity: close to Date.now() at call time (within 100ms window)
+  const delta = Math.abs(client.now() - Date.now());
+  assert.ok(delta < 100, `expected now() near Date.now(), delta=${delta}`);
+});
+
+// ── console_log handler: hint wiring ──
+
+function buildEntriesResponse(entries) {
+  return { value: JSON.stringify({ entries }) };
+}
+
+test('M11 console_log: no hint when entries present', async () => {
+  const client = createMockClient({
+    evaluate: async () => buildEntriesResponse([{ level: 'log', message: 'hello' }]),
+    _connectedAt: 1_000_000,
+    _timeNowFn: () => 1_000_000 + 120_000, // 120s elapsed
+  });
+  const handler = createConsoleLogHandler(() => client);
+  const result = await handler({ level: 'all', limit: 50, clear: false });
+  const envelope = parseEnvelope(result);
+  assert.equal(envelope.ok, true);
+  assert.equal(envelope.meta, undefined, 'no meta when entries non-empty');
+});
+
+test('M11 console_log: no hint when entries empty but < 60s since connect', async () => {
+  const client = createMockClient({
+    evaluate: async () => buildEntriesResponse([]),
+    _connectedAt: 1_000_000,
+    _timeNowFn: () => 1_000_000 + 30_000, // 30s elapsed, below threshold
+  });
+  const handler = createConsoleLogHandler(() => client);
+  const result = await handler({ level: 'all', limit: 50, clear: false });
+  const envelope = parseEnvelope(result);
+  assert.equal(envelope.ok, true);
+  assert.equal(envelope.meta, undefined, 'no meta when below threshold');
+});
+
+test('M11 console_log: emits meta.hint when empty AND >60s since connect', async () => {
+  const client = createMockClient({
+    evaluate: async () => buildEntriesResponse([]),
+    _connectedAt: 1_000_000,
+    _timeNowFn: () => 1_000_000 + 90_000, // 90s elapsed, above threshold
+  });
+  const handler = createConsoleLogHandler(() => client);
+  const result = await handler({ level: 'all', limit: 50, clear: false });
+  const envelope = parseEnvelope(result);
+  assert.equal(envelope.ok, true);
+  assert.ok(envelope.meta, 'meta should be present');
+  assert.equal(envelope.meta.hint, METRO_CLEAR_HINT_TEXT);
+});
+
+// ── network_log handler: hint wiring ──
+
+test('M11 network_log: no hint when requests present', async () => {
+  const client = createMockClient({
+    _connectedAt: 1_000_000,
+    _timeNowFn: () => 1_000_000 + 120_000,
+  });
+  // Push a fake request so buffer is non-empty
+  client.networkBufferManager.push(client.activeDeviceKey, {
+    id: 'req1', url: 'https://example.com', method: 'GET', timestamp: new Date().toISOString(),
+  });
+  const handler = createNetworkLogHandler(() => client);
+  const result = await handler({ limit: 20, clear: false });
+  const envelope = parseEnvelope(result);
+  assert.equal(envelope.ok, true);
+  assert.equal(envelope.meta, undefined, 'no meta when requests non-empty');
+});
+
+test('M11 network_log: no hint when empty but recent push (lastEventAt within window)', async () => {
+  const client = createMockClient({
+    _connectedAt: 1_000_000,
+    _timeNowFn: () => 1_000_000 + 120_000, // connectedAt is old
+  });
+  // Push then clear — so buffer is empty but lastPush is recent (Date.now() at push)
+  // Mock the manager's internal lastPush by pushing then directly overwriting.
+  client.networkBufferManager.push(client.activeDeviceKey, {
+    id: 'req1', url: 'https://ex.com', method: 'GET', timestamp: new Date().toISOString(),
+  });
+  client.networkBufferManager.clear(client.activeDeviceKey);
+  // After clear, the buffer is empty BUT the manager's lastPush map may still hold an entry.
+  // The test's real purpose: if getLastPush returns undefined after clear, hint-fire depends
+  // on connectedAt alone; if it returns a ts, hint-fire depends on max(connectedAt, lastPush).
+  // Explicitly simulate "recent event observed" by spying on getLastPush.
+  const originalGetLastPush = client.networkBufferManager.getLastPush.bind(client.networkBufferManager);
+  client.networkBufferManager.getLastPush = (key) => {
+    // Override: pretend we saw an event recently (now - 5s)
+    return 1_000_000 + 115_000;
+  };
+
+  const handler = createNetworkLogHandler(() => client);
+  const result = await handler({ limit: 20, clear: false });
+  const envelope = parseEnvelope(result);
+  assert.equal(envelope.ok, true);
+  assert.equal(envelope.meta, undefined, 'recent event should suppress hint');
+  client.networkBufferManager.getLastPush = originalGetLastPush;
+});
+
+test('M11 network_log: emits meta.hint when empty AND both connectedAt + lastPush are stale', async () => {
+  const client = createMockClient({
+    _connectedAt: 1_000_000,
+    _timeNowFn: () => 1_000_000 + 120_000, // 120s elapsed
+  });
+  // getLastPush returns undefined (no events ever) — fallback to connectedAt, which is old
+  const handler = createNetworkLogHandler(() => client);
+  const result = await handler({ limit: 20, clear: false });
+  const envelope = parseEnvelope(result);
+  assert.equal(envelope.ok, true);
+  assert.ok(envelope.meta, 'meta should be present');
+  assert.equal(envelope.meta.hint, METRO_CLEAR_HINT_TEXT);
+});
+
+test('M11 network_log: scope="all" uses connectedAt alone (no per-scope lastPush)', async () => {
+  const client = createMockClient({
+    _connectedAt: 1_000_000,
+    _timeNowFn: () => 1_000_000 + 90_000, // 90s elapsed
+  });
+  const handler = createNetworkLogHandler(() => client);
+  const result = await handler({ limit: 20, clear: false, device: 'all' });
+  const envelope = parseEnvelope(result);
+  assert.equal(envelope.ok, true);
+  assert.ok(envelope.meta, 'meta should be present on empty all-scope after threshold');
+  assert.equal(envelope.meta.hint, METRO_CLEAR_HINT_TEXT);
+});

--- a/scripts/cdp-bridge/test/unit/metro-clear-hint.test.js
+++ b/scripts/cdp-bridge/test/unit/metro-clear-hint.test.js
@@ -1,0 +1,110 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  shouldShowMetroClearHint,
+  METRO_CLEAR_HINT_THRESHOLD_MS,
+  METRO_CLEAR_HINT_TEXT,
+} from '../../dist/tools/metro-clear-hint.js';
+
+// M11 / D665 — pure helper tests. Mirrors metro-mcp's troubleshooting
+// "Empty Results or Stale Data" signal but surfaces it inline in tool
+// results when the buffer has been empty for > threshold.
+
+const NOW = 10_000_000;
+const stub = (nowValue) => () => nowValue;
+
+test('M11 probe: non-empty result returns false regardless of timing', () => {
+  assert.equal(
+    shouldShowMetroClearHint(
+      { connectedAt: NOW - 120_000, now: stub(NOW) },
+      false,
+    ),
+    false,
+  );
+});
+
+test('M11 probe: null connectedAt returns false (not connected yet)', () => {
+  assert.equal(
+    shouldShowMetroClearHint(
+      { connectedAt: null, now: stub(NOW) },
+      true,
+    ),
+    false,
+  );
+});
+
+test('M11 probe: empty + connected 30s ago returns false (below threshold)', () => {
+  assert.equal(
+    shouldShowMetroClearHint(
+      { connectedAt: NOW - 30_000, now: stub(NOW) },
+      true,
+    ),
+    false,
+  );
+});
+
+test('M11 probe: empty + connected 61s ago returns true', () => {
+  assert.equal(
+    shouldShowMetroClearHint(
+      { connectedAt: NOW - 61_000, now: stub(NOW) },
+      true,
+    ),
+    true,
+  );
+});
+
+test('M11 probe: empty + old connectedAt + recent lastEventAt returns false (recent event resets clock)', () => {
+  assert.equal(
+    shouldShowMetroClearHint(
+      { connectedAt: NOW - 120_000, lastEventAt: NOW - 10_000, now: stub(NOW) },
+      true,
+    ),
+    false,
+  );
+});
+
+test('M11 probe: empty + recent connectedAt + old lastEventAt returns false (recent connect resets clock)', () => {
+  assert.equal(
+    shouldShowMetroClearHint(
+      { connectedAt: NOW - 10_000, lastEventAt: NOW - 120_000, now: stub(NOW) },
+      true,
+    ),
+    false,
+  );
+});
+
+test('M11 probe: empty + both old returns true', () => {
+  assert.equal(
+    shouldShowMetroClearHint(
+      { connectedAt: NOW - 120_000, lastEventAt: NOW - 120_000, now: stub(NOW) },
+      true,
+    ),
+    true,
+  );
+});
+
+test('M11 probe: exactly at threshold fires (>=, not strict >)', () => {
+  assert.equal(
+    shouldShowMetroClearHint(
+      { connectedAt: NOW - METRO_CLEAR_HINT_THRESHOLD_MS, now: stub(NOW) },
+      true,
+    ),
+    true,
+  );
+});
+
+test('M11 probe: undefined lastEventAt falls back to connectedAt', () => {
+  // lastEventAt undefined; connectedAt old → should fire
+  assert.equal(
+    shouldShowMetroClearHint(
+      { connectedAt: NOW - 120_000, lastEventAt: undefined, now: stub(NOW) },
+      true,
+    ),
+    true,
+  );
+});
+
+test('M11 hint text contains both expo and react-native commands', () => {
+  assert.match(METRO_CLEAR_HINT_TEXT, /npx expo start --clear/);
+  assert.match(METRO_CLEAR_HINT_TEXT, /npx react-native start --reset-cache/);
+});


### PR DESCRIPTION
## Summary

Closes Phase 90 Tier 4 **Story M11** — the last metro-mcp pattern adoption story at the Tier 4 polish level. When `cdp_console_log` or `cdp_network_log` return empty results AND the CDP session has been idle for >60s, the tool result now includes `meta.hint` suggesting `npx expo start --clear` / `npx react-native start --reset-cache`.

## Why

metro-mcp's troubleshooting doc lists \"Empty Results or Stale Data\" as a top-3 user issue — Metro's bundle cache can go stale, the app keeps running, but our MCP sees empty buffers. Previously the fix (`--clear`) lived only in that doc. Surfacing it inline closes the knowledge gap at the moment the user notices the symptom.

Stacked-independent: branches off current main (not stacked on #52 / B133, which is a separate PR in flight).

## Scope

| File | Change |
|---|---|
| `scripts/cdp-bridge/src/tools/metro-clear-hint.ts` | NEW — pure helper. Exports `METRO_CLEAR_HINT_THRESHOLD_MS`, `METRO_CLEAR_HINT_TEXT`, `shouldShowMetroClearHint(deps, resultIsEmpty)`. Idle reference = `max(connectedAt, lastEventAt ?? connectedAt)`. |
| `scripts/cdp-bridge/src/cdp-client.ts` | Added `_connectedAt: number \| null`, `_timeNowFn: () => number`, getters `connectedAt` + `now`. Constructor `new CDPClient(port?, timeNowFn?)` — backwards compat. Wired into ConnectContext + ResettableState. |
| `scripts/cdp-bridge/src/cdp/connect.ts` + `state.ts` | Interfaces gained `setConnectedAt` + `now`. `connectToTarget` calls `ctx.setConnectedAt(ctx.now())`. `resetState` clears it. |
| `scripts/cdp-bridge/src/ring-buffer.ts` | `DeviceBufferManager.getLastPush(deviceKey): number \| undefined` — public accessor over existing internal `lastPush`. |
| `scripts/cdp-bridge/src/tools/console-log.ts` | Wires hint on empty `entries`. Uses `connectedAt` only (console queries in-app `__RN_AGENT.getConsole`). |
| `scripts/cdp-bridge/src/tools/network-log.ts` | Wires hint on empty `requests`. Uses `max(connectedAt, networkBufferManager.getLastPush(scope))`; for `scope='all'` falls back to `connectedAt` only. |
| Versions | plugin 0.36.0 → 0.37.0, MCP 0.31.0 → 0.32.0 |

## Design decisions

- **Scope to `cdp_console_log` + `cdp_network_log` only.** Not `cdp_status` (called too often; becomes noise). Not `cdp_error_log` (empty errors is the desired state).
- **Stateless — fires every call past threshold.** Simpler than session-scoped one-shot; LLM context usually absorbs repeated hints. Revisit if false-positive data warrants.
- **\`max()\` semantics for idle reference.** Any activity — connecting OR receiving an event — resets the clock. Both must be old for the hint to fire.
- **Injectable `timeNowFn` for test determinism.** Constructor-level addition; defaults to `Date.now`.

## Tests

488 → **505 passing**, 0 failures. +17 tests across:

```
✔ M11 probe: non-empty result returns false regardless of timing
✔ M11 probe: null connectedAt returns false (not connected yet)
✔ M11 probe: empty + connected 30s ago returns false (below threshold)
✔ M11 probe: empty + connected 61s ago returns true
✔ M11 probe: empty + old connectedAt + recent lastEventAt returns false (recent event resets clock)
✔ M11 probe: empty + recent connectedAt + old lastEventAt returns false (recent connect resets clock)
✔ M11 probe: empty + both old returns true
✔ M11 probe: exactly at threshold fires (>=, not strict >)
✔ M11 probe: undefined lastEventAt falls back to connectedAt
✔ M11 hint text contains both expo and react-native commands
✔ M11: CDPClient.connectedAt is null on a fresh instance
✔ M11: CDPClient.now returns the injected timeNowFn
✔ M11: CDPClient.now defaults to Date.now when no fn injected
✔ M11 console_log: no hint when entries present
✔ M11 console_log: no hint when entries empty but < 60s since connect
✔ M11 console_log: emits meta.hint when empty AND >60s since connect
✔ M11 network_log: no hint when requests present
✔ M11 network_log: no hint when empty but recent push (lastEventAt within window)
✔ M11 network_log: emits meta.hint when empty AND both connectedAt + lastPush are stale
✔ M11 network_log: scope=\"all\" uses connectedAt alone (no per-scope lastPush)
```

## Review

Multi-LLM (Gemini + Codex). Both **clean** — 0 high-confidence findings.

- **Gemini**: verified `max()` semantics, B132 auto-resume re-stamps `_connectedAt` via the standard `handleClose → resetState → reconnect → connectToTarget` chain (no bypass), backwards-compat constructor, `okResult(data, opts)` signature pre-existed so no handler regression.
- **Codex**: verified false-positive surface matches the <1% acceptance envelope. Flagged one sub-threshold clock-skew observation (`DeviceBufferManager.push` uses real `Date.now()` while CDPClient uses injected `_timeNowFn`) — moot in production where both are `Date.now`; tests sidestep with mock-only `getLastPush` overrides.

## Test plan

- [x] `cd scripts/cdp-bridge && npm test` → 505 passing, 0 failures
- [x] Baseline captured under pre-M11 MCP — `cdp_network_log` returns 0 requests, no `meta` field (confirms the hint is truly new, not a pre-existing envelope field)
- [ ] **Post-merge smoke**: after CC restart, call `cdp_network_log` on the test-app. If session age > 60s, expect `meta.hint` to equal `METRO_CLEAR_HINT_TEXT`. If < 60s, expect no `meta` field.

## Known limits

- Hint fires on every call past threshold on genuinely idle apps (stateless, no cooldown). Accepted per design; LLM absorbs repeats.
- Console has no per-buffer `lastPushAt` today — uses `connectedAt` alone.
- `scope='all'` network path falls back to `connectedAt` only (no single-device `lastPush`).

## Refs

- D665 in `rn-dev-agent-workspace/docs/DECISIONS.md`
- Phase 108 in `rn-dev-agent-workspace/docs/ROADMAP.md`
- Proof: `rn-dev-agent-workspace/docs/proof/m11-metro-clear-hint/`
- metro-mcp reference: troubleshooting \"Empty Results or Stale Data\"