### PR TITLE
feat(m7/phase-109): fast-runner tri-state liveness probe (D666)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.36.1",
+      "version": "0.38.0",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.36.1",
+  "version": "0.38.0",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.38.0] — 2026-04-22
+
+M7 / Phase 109 — fast-runner tri-state liveness probe. Closes the Phase 90 Tier 3 M7 story and functionally retires the shape-equivalent leftover from R3. Previously `isFastRunnerAvailable()` only checked PID; a process whose PID was alive but whose HTTP server had wedged was reported as available, and every iOS `device_press` / `device_fill` / `device_swipe` stalled on a 10s fetch timeout before falling through to the daemon. M7 adds a `probeFastRunnerLiveness()` helper that distinguishes `'alive' | 'stale' | 'dead'` via PID check + `/health` probe, plus an explicit `reapStaleFastRunner()` helper for the SIGTERM→grace→SIGKILL escalation. `tryFastRunner` is rewired to branch on the tri-state. MCP server bumped to 0.33.0.
+
+Version note: this release skips 0.37.0 (reserved for unmerged M11 PR #53). When M11 merges it will slot in as 0.37.0 between this and 0.36.1.
+
+### Added
+- **`FastRunnerLiveness` type** + `probeFastRunnerLiveness(deps?)` + `reapStaleFastRunner(deps?)` in `scripts/cdp-bridge/src/fast-runner-session.ts`. All deps injectable (`getState`, `processAlive`, `httpProbe`, `clearState`, `sendSignal`, `sleep`) for hermetic tests — mirrors the `lockfile.ts` pattern.
+- **Tri-state probe semantics**: `'alive'` when `/health` returns `{ok:true}`; `'stale'` on any HTTP error or `ok:false` (including AbortError, ECONNREFUSED, 500, timeout); `'dead'` when no state file or PID has exited (and state is cleared).
+- **Graceful reap**: SIGTERM → 500ms grace → SIGKILL if still alive → clear state. ESRCH tolerance on signal send.
+
+### Changed
+- **`tryFastRunner` in `scripts/cdp-bridge/src/agent-device-wrapper.ts`** now awaits the tri-state probe at entry. `'alive'` proceeds; `'stale'` reaps + returns null (daemon fallthrough); `'dead'` + iOS cold-launches via `startFastRunner`; `'dead'` + non-iOS returns null.
+- **`fastHealthCheck` refactored** to delegate to the new `defaultHttpProbe` helper (single source of truth for the `/health` call shape). Wrapped in try/catch to preserve its original boolean contract — caught during review.
+
+### Fixed
+- **Dangling ChildProcess handle after reap** (Gemini review finding, confidence 84): `clearStateFile()` now nulls `runnerProcess` alongside `runnerState`. Self-heals via `on('exit')` but closes the window cleanly so a concurrent `stopFastRunner()` doesn't double-signal a dead PID.
+
+### Tests
+- **17 new tests** in `test/unit/fast-runner-liveness.test.js`. 8 probe variations (null state, dead PID, alive+healthy, alive+ok:false, HTTP 500, AbortError, ECONNREFUSED, timeout forwarding) + 2 cleanup invariants (probe is read-only on living processes; only `'dead'` discovery clears state) + 6 reap variations (no-op on null state, SIGTERM-only success, SIGTERM-ignored→SIGKILL, ESRCH tolerance, graceMs override, default graceMs) + 1 default-timeout check. All hermetic.
+
+Running total: 488 → **505 passing**, zero failures.
+
+### Known limits
+- **Concurrent `'dead'` probes can race two `xcodebuild` spawns** if two DIFFERENT MCP tool calls arrive within the 30s startup window. Flagged sub-threshold (Gemini, confidence 82) — MCP SDK serializes tool invocations per connection, so the race window is narrow. Will follow up with in-flight promise cache on `startFastRunner` if observed in practice.
+- **SIGKILL on xcodebuild PID may orphan `xctest` children** briefly. macOS launchd reaps within seconds.
+- **Legacy `isFastRunnerAvailable(): boolean`** retained for sync callers (e.g., post-spawn check, status tool). Documented as coarse in JSDoc.
+- **Stale detection conflates "hung" with "misbehaving-but-responsive"**: a runner returning `{ok:false}` is reaped even if it might self-recover. Conservative — prefer respawn over hang.
+
+### Review
+Multi-LLM (Gemini + Codex). Two findings applied. Codex (confidence 90): the `fastHealthCheck` refactor dropped its outer try/catch — fixed by re-wrapping. Gemini (confidence 84): reap left `runnerProcess` dangling — fixed by nulling in `clearStateFile`. Two sub-threshold findings deferred (concurrent dead-probe race, SIGKILL xcodebuild orphan) — noted in Known Limits.
+
+### R3 relationship
+Story R3 ("fast-runner restart") from Phase 85 was marked DONE during the Phase 92 stability sweep with the note that the implementation shape differed from the original spec (PID probe instead of `/ping`; restart integrated into session open). M7 ships the full spec: tri-state `/health` probe, explicit stale detection, graceful reap. The functional gap R3 left is closed.
+
+### Refs
+D666 in `rn-dev-agent-workspace/docs/DECISIONS.md`. Phase 109 in `rn-dev-agent-workspace/docs/ROADMAP.md`. metro-mcp reference: `src/plugins/devtools.ts::tryFocusExisting`.
+
 ## [0.36.1] — 2026-04-21
 
 B133 / Phase 107 — M8 loose ends. Closes the carveout logged during M8's Phase 106 review (Gemini finding, flagged at confidence 85, folded out of M8 per story boundary). Ports the 1..5 `getFiberRoots` probe into `cdp_set_shared_value` so that tool works on apps where `__REACT_DEVTOOLS_GLOBAL_HOOK__.renderers` is empty or missing. Also refreshes the `cdp_open_devtools` tool description, which had been frozen at M1a-era text and was factually misleading after M1b (Phase 104) and B132 (Phase 105) shipped. MCP server bumped to 0.31.1.

--- a/scripts/cdp-bridge/dist/agent-device-wrapper.js
+++ b/scripts/cdp-bridge/dist/agent-device-wrapper.js
@@ -5,7 +5,7 @@ import { createConnection } from 'node:net';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { okResult, failResult } from './utils.js';
-import { isFastRunnerAvailable, getFastRunnerState, fastTap, fastType, fastSwipe, fastSnapshot, fastScreenshot, fastDismissKeyboard, startFastRunner, } from './fast-runner-session.js';
+import { isFastRunnerAvailable, getFastRunnerState, fastTap, fastType, fastSwipe, fastSnapshot, fastScreenshot, fastDismissKeyboard, startFastRunner, probeFastRunnerLiveness, reapStaleFastRunner, } from './fast-runner-session.js';
 import { updateRefMap, refCenter, getScreenRect, hasRefMap, clearRefMap } from './fast-runner-ref-map.js';
 import { resolveBundleId } from './project-config.js';
 const execFile = promisify(execFileCb);
@@ -198,13 +198,26 @@ function computeSwipeCoords(direction, screen) {
     }
 }
 async function tryFastRunner(command, positionals) {
-    if (!isFastRunnerAvailable()) {
+    // M7 / Phase 109 (D666): tri-state liveness — distinguishes a hung HTTP
+    // server (stale) from a dead process. Before M7, any PID-alive-but-HTTP-hung
+    // state caused every press to wait out the 10s fetch timeout.
+    const liveness = await probeFastRunnerLiveness();
+    if (liveness === 'stale') {
+        // Runner process is alive but its HTTP server is wedged. Reap it now;
+        // fall through to the daemon for this call. Next call probes 'dead'
+        // and will cold-launch a fresh runner if iOS.
+        await reapStaleFastRunner();
+        return null;
+    }
+    if (liveness === 'dead') {
         const session = getActiveSession();
         if (session?.platform === 'ios' && session.deviceId) {
             try {
                 await startFastRunner(session.deviceId, resolveBundleId('ios') ?? 'unknown');
             }
             catch { /* auto-restart failed */ }
+            // startFastRunner only resolves after FASTXCT_READY, so a sync PID
+            // check here is sufficient — avoids a second HTTP round-trip.
             if (!isFastRunnerAvailable())
                 return null;
         }

--- a/scripts/cdp-bridge/dist/fast-runner-session.js
+++ b/scripts/cdp-bridge/dist/fast-runner-session.js
@@ -209,22 +209,101 @@ export async function fastHealthCheck() {
     if (!runnerState)
         return false;
     try {
-        const url = `http://[::1]:${runnerState.port}/health`;
-        const controller = new AbortController();
-        const timer = setTimeout(() => controller.abort(), 2000);
-        try {
-            const res = await fetch(url, { signal: controller.signal });
-            clearTimeout(timer);
-            if (!res.ok)
-                return false;
-            const body = await res.json();
-            return body.ok === true;
-        }
-        finally {
-            clearTimeout(timer);
-        }
+        const result = await defaultHttpProbe(runnerState.port, 2000);
+        return result.ok && result.status === 200 && result.bodyOk === true;
+    }
+    catch {
+        // Preserve the original contract: any network/abort/parse error → false.
+        // (The probe helper throws on fetch errors; M7 review caught this regression.)
+        return false;
+    }
+}
+function defaultProcessAlive(pid) {
+    try {
+        process.kill(pid, 0);
+        return true;
     }
     catch {
         return false;
     }
+}
+async function defaultHttpProbe(port, timeoutMs) {
+    const url = `http://[::1]:${port}/health`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        const res = await fetch(url, { signal: controller.signal });
+        if (!res.ok)
+            return { ok: false, status: res.status };
+        let bodyOk;
+        try {
+            const body = await res.json();
+            bodyOk = body.ok === true;
+        }
+        catch {
+            bodyOk = false;
+        }
+        return { ok: true, status: res.status, bodyOk };
+    }
+    finally {
+        clearTimeout(timer);
+    }
+}
+function clearStateFile() {
+    runnerState = null;
+    // M7 review (Gemini): null the child-process handle too. Previously a reap
+    // left `runnerProcess` pointing at a dead PID; the on('exit') handler would
+    // eventually self-heal, but during the window a concurrent stopFastRunner
+    // could signal an already-dead process. Clearing here is defensive.
+    runnerProcess = null;
+    try {
+        unlinkSync(STATE_FILE);
+    }
+    catch { /* already gone */ }
+}
+export async function probeFastRunnerLiveness(deps = {}) {
+    const getState = deps.getState ?? (() => runnerState);
+    const processAlive = deps.processAlive ?? defaultProcessAlive;
+    const httpProbe = deps.httpProbe ?? defaultHttpProbe;
+    const clearState = deps.clearState ?? clearStateFile;
+    const timeoutMs = deps.timeoutMs ?? 2000;
+    const state = getState();
+    if (!state)
+        return 'dead';
+    if (!processAlive(state.pid)) {
+        clearState();
+        return 'dead';
+    }
+    try {
+        const res = await httpProbe(state.port, timeoutMs);
+        if (res.ok && res.status === 200 && res.bodyOk === true)
+            return 'alive';
+        return 'stale';
+    }
+    catch {
+        return 'stale';
+    }
+}
+export async function reapStaleFastRunner(deps = {}) {
+    const getState = deps.getState ?? (() => runnerState);
+    const processAlive = deps.processAlive ?? defaultProcessAlive;
+    const sendSignal = deps.sendSignal ?? ((pid, sig) => process.kill(pid, sig));
+    const sleep = deps.sleep ?? ((ms) => new Promise(r => setTimeout(r, ms)));
+    const clearState = deps.clearState ?? clearStateFile;
+    const graceMs = deps.graceMs ?? 500;
+    const state = getState();
+    if (!state)
+        return;
+    try {
+        sendSignal(state.pid, 'SIGTERM');
+    }
+    catch { /* already dead */ }
+    await sleep(graceMs);
+    if (processAlive(state.pid)) {
+        try {
+            sendSignal(state.pid, 'SIGKILL');
+        }
+        catch { /* race: died between checks */ }
+    }
+    clearState();
 }

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.31.1",
+  "version": "0.33.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/agent-device-wrapper.ts
+++ b/scripts/cdp-bridge/src/agent-device-wrapper.ts
@@ -17,6 +17,8 @@ import {
   fastScreenshot,
   fastDismissKeyboard,
   startFastRunner,
+  probeFastRunnerLiveness,
+  reapStaleFastRunner,
 } from './fast-runner-session.js';
 import { updateRefMap, refCenter, getScreenRect, hasRefMap, clearRefMap } from './fast-runner-ref-map.js';
 import { resolveBundleId } from './project-config.js';
@@ -234,10 +236,23 @@ function computeSwipeCoords(direction: string, screen: { width: number; height: 
 }
 
 async function tryFastRunner(command: string, positionals: string[]): Promise<ToolResult | null> {
-  if (!isFastRunnerAvailable()) {
+  // M7 / Phase 109 (D666): tri-state liveness — distinguishes a hung HTTP
+  // server (stale) from a dead process. Before M7, any PID-alive-but-HTTP-hung
+  // state caused every press to wait out the 10s fetch timeout.
+  const liveness = await probeFastRunnerLiveness();
+  if (liveness === 'stale') {
+    // Runner process is alive but its HTTP server is wedged. Reap it now;
+    // fall through to the daemon for this call. Next call probes 'dead'
+    // and will cold-launch a fresh runner if iOS.
+    await reapStaleFastRunner();
+    return null;
+  }
+  if (liveness === 'dead') {
     const session = getActiveSession();
     if (session?.platform === 'ios' && session.deviceId) {
       try { await startFastRunner(session.deviceId, resolveBundleId('ios') ?? 'unknown'); } catch { /* auto-restart failed */ }
+      // startFastRunner only resolves after FASTXCT_READY, so a sync PID
+      // check here is sufficient — avoids a second HTTP round-trip.
       if (!isFastRunnerAvailable()) return null;
     } else {
       return null;

--- a/scripts/cdp-bridge/src/fast-runner-session.ts
+++ b/scripts/cdp-bridge/src/fast-runner-session.ts
@@ -212,19 +212,145 @@ export async function fastDismissKeyboard(): Promise<FastRunnerResponse> {
 export async function fastHealthCheck(): Promise<boolean> {
   if (!runnerState) return false;
   try {
-    const url = `http://[::1]:${runnerState.port}/health`;
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 2000);
-    try {
-      const res = await fetch(url, { signal: controller.signal });
-      clearTimeout(timer);
-      if (!res.ok) return false;
-      const body = await res.json() as { ok?: boolean };
-      return body.ok === true;
-    } finally {
-      clearTimeout(timer);
-    }
+    const result = await defaultHttpProbe(runnerState.port, 2000);
+    return result.ok && result.status === 200 && result.bodyOk === true;
   } catch {
+    // Preserve the original contract: any network/abort/parse error → false.
+    // (The probe helper throws on fetch errors; M7 review caught this regression.)
     return false;
   }
+}
+
+// ─── M7 / Phase 109: tri-state liveness probe ──────────────────────────
+//
+// Prior art: isFastRunnerAvailable() above only checks PID via
+// process.kill(pid, 0). A process whose PID is alive but whose HTTP
+// server has hung (crashed listener, wedged XCTest thread) would be
+// reported as available, and every device_press then stalled on a
+// 10s fetch timeout before falling back to the daemon.
+//
+// The tri-state distinction:
+//   'alive' — PID lives AND /health returns {ok:true}. Happy path.
+//   'stale' — PID lives but /health times out / 500s / ok:false.
+//             Must be reaped before a fresh startFastRunner.
+//   'dead'  — PID doesn't exist (or no state file). Cold-launch OK.
+//
+// Separation of concerns: the probe is read-only (clears state only
+// on 'dead' discovery, never mutates a living process). The reap
+// helper is the explicit action — SIGTERM, wait 500ms, SIGKILL if
+// still alive. Callers compose: probe → (stale ? reap : …) → act.
+
+export type FastRunnerLiveness = 'alive' | 'stale' | 'dead';
+
+export interface StateSnapshot {
+  pid: number;
+  port: number;
+  deviceId: string;
+  bundleId: string;
+}
+
+export interface HttpProbeResult {
+  ok: boolean;
+  status: number;
+  bodyOk?: boolean;
+}
+
+export interface LivenessProbeDeps {
+  /** Defaults to the module singleton. Tests inject a fake snapshot. */
+  getState?: () => StateSnapshot | null;
+  /** Defaults to `process.kill(pid, 0)` guard. */
+  processAlive?: (pid: number) => boolean;
+  /** Defaults to GET /health over IPv6 loopback with the timeout. */
+  httpProbe?: (port: number, timeoutMs: number) => Promise<HttpProbeResult>;
+  /** Called when probe discovers 'dead' state. Defaults to the real teardown. */
+  clearState?: () => void;
+  /** HTTP probe timeout in ms. Default 2000 (matches existing fastHealthCheck). */
+  timeoutMs?: number;
+}
+
+export interface ReapDeps {
+  getState?: () => StateSnapshot | null;
+  processAlive?: (pid: number) => boolean;
+  sendSignal?: (pid: number, sig: NodeJS.Signals) => void;
+  sleep?: (ms: number) => Promise<void>;
+  clearState?: () => void;
+  /** Time to wait between SIGTERM and SIGKILL escalation. Default 500ms. */
+  graceMs?: number;
+}
+
+function defaultProcessAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+async function defaultHttpProbe(port: number, timeoutMs: number): Promise<HttpProbeResult> {
+  const url = `http://[::1]:${port}/health`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) return { ok: false, status: res.status };
+    let bodyOk: boolean | undefined;
+    try {
+      const body = await res.json() as { ok?: boolean };
+      bodyOk = body.ok === true;
+    } catch {
+      bodyOk = false;
+    }
+    return { ok: true, status: res.status, bodyOk };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function clearStateFile(): void {
+  runnerState = null;
+  // M7 review (Gemini): null the child-process handle too. Previously a reap
+  // left `runnerProcess` pointing at a dead PID; the on('exit') handler would
+  // eventually self-heal, but during the window a concurrent stopFastRunner
+  // could signal an already-dead process. Clearing here is defensive.
+  runnerProcess = null;
+  try { unlinkSync(STATE_FILE); } catch { /* already gone */ }
+}
+
+export async function probeFastRunnerLiveness(deps: LivenessProbeDeps = {}): Promise<FastRunnerLiveness> {
+  const getState = deps.getState ?? (() => runnerState);
+  const processAlive = deps.processAlive ?? defaultProcessAlive;
+  const httpProbe = deps.httpProbe ?? defaultHttpProbe;
+  const clearState = deps.clearState ?? clearStateFile;
+  const timeoutMs = deps.timeoutMs ?? 2000;
+
+  const state = getState();
+  if (!state) return 'dead';
+
+  if (!processAlive(state.pid)) {
+    clearState();
+    return 'dead';
+  }
+
+  try {
+    const res = await httpProbe(state.port, timeoutMs);
+    if (res.ok && res.status === 200 && res.bodyOk === true) return 'alive';
+    return 'stale';
+  } catch {
+    return 'stale';
+  }
+}
+
+export async function reapStaleFastRunner(deps: ReapDeps = {}): Promise<void> {
+  const getState = deps.getState ?? (() => runnerState);
+  const processAlive = deps.processAlive ?? defaultProcessAlive;
+  const sendSignal = deps.sendSignal ?? ((pid, sig) => process.kill(pid, sig));
+  const sleep = deps.sleep ?? ((ms) => new Promise(r => setTimeout(r, ms)));
+  const clearState = deps.clearState ?? clearStateFile;
+  const graceMs = deps.graceMs ?? 500;
+
+  const state = getState();
+  if (!state) return;
+
+  try { sendSignal(state.pid, 'SIGTERM'); } catch { /* already dead */ }
+  await sleep(graceMs);
+  if (processAlive(state.pid)) {
+    try { sendSignal(state.pid, 'SIGKILL'); } catch { /* race: died between checks */ }
+  }
+  clearState();
 }

--- a/scripts/cdp-bridge/test/unit/fast-runner-liveness.test.js
+++ b/scripts/cdp-bridge/test/unit/fast-runner-liveness.test.js
@@ -1,0 +1,240 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  probeFastRunnerLiveness,
+  reapStaleFastRunner,
+} from '../../dist/fast-runner-session.js';
+
+// M7 / D666 — hermetic tests for the tri-state fast-runner liveness probe.
+// Mirrors the injectable-deps pattern from test/unit/lockfile.test.js so we
+// never touch a real process, the real state file, or a real HTTP server.
+
+const STATE = { pid: 12345, port: 22088, deviceId: 'sim-1', bundleId: 'com.example' };
+
+// ── probe: dead paths ─────────────────────────────────────────────────
+
+test('M7 probe: returns dead when no state (no runner ever started)', async () => {
+  let clearCalls = 0;
+  const liveness = await probeFastRunnerLiveness({
+    getState: () => null,
+    processAlive: () => assert.fail('processAlive should not be consulted when state is null'),
+    httpProbe: async () => assert.fail('httpProbe should not run when state is null'),
+    clearState: () => { clearCalls++; },
+  });
+  assert.equal(liveness, 'dead');
+  assert.equal(clearCalls, 0, 'no state to clear');
+});
+
+test('M7 probe: returns dead and clears state when PID has exited', async () => {
+  let clearCalls = 0;
+  const liveness = await probeFastRunnerLiveness({
+    getState: () => STATE,
+    processAlive: () => false,
+    httpProbe: async () => assert.fail('httpProbe should not run after PID check failed'),
+    clearState: () => { clearCalls++; },
+  });
+  assert.equal(liveness, 'dead');
+  assert.equal(clearCalls, 1, 'state file must be cleared so next call rediscovers');
+});
+
+// ── probe: alive path ────────────────────────────────────────────────
+
+test('M7 probe: returns alive when PID lives and /health returns {ok:true}', async () => {
+  const liveness = await probeFastRunnerLiveness({
+    getState: () => STATE,
+    processAlive: () => true,
+    httpProbe: async () => ({ ok: true, status: 200, bodyOk: true }),
+  });
+  assert.equal(liveness, 'alive');
+});
+
+// ── probe: stale paths ───────────────────────────────────────────────
+
+test('M7 probe: returns stale when PID lives but /health returns {ok:false}', async () => {
+  const liveness = await probeFastRunnerLiveness({
+    getState: () => STATE,
+    processAlive: () => true,
+    httpProbe: async () => ({ ok: true, status: 200, bodyOk: false }),
+  });
+  assert.equal(liveness, 'stale');
+});
+
+test('M7 probe: returns stale on HTTP 500 (server crashed handler)', async () => {
+  const liveness = await probeFastRunnerLiveness({
+    getState: () => STATE,
+    processAlive: () => true,
+    httpProbe: async () => ({ ok: false, status: 500 }),
+  });
+  assert.equal(liveness, 'stale');
+});
+
+test('M7 probe: returns stale when httpProbe throws AbortError (hung listener)', async () => {
+  const liveness = await probeFastRunnerLiveness({
+    getState: () => STATE,
+    processAlive: () => true,
+    httpProbe: async () => {
+      const err = new Error('The operation was aborted');
+      err.name = 'AbortError';
+      throw err;
+    },
+  });
+  assert.equal(liveness, 'stale');
+});
+
+test('M7 probe: returns stale when httpProbe throws ECONNREFUSED (port not listening)', async () => {
+  const liveness = await probeFastRunnerLiveness({
+    getState: () => STATE,
+    processAlive: () => true,
+    httpProbe: async () => {
+      const err = new Error('connect ECONNREFUSED ::1:22088');
+      err.code = 'ECONNREFUSED';
+      throw err;
+    },
+  });
+  assert.equal(liveness, 'stale');
+});
+
+test('M7 probe: timeoutMs override forwards to httpProbe', async () => {
+  let observedTimeout = -1;
+  await probeFastRunnerLiveness({
+    getState: () => STATE,
+    processAlive: () => true,
+    httpProbe: async (_port, timeoutMs) => {
+      observedTimeout = timeoutMs;
+      return { ok: true, status: 200, bodyOk: true };
+    },
+    timeoutMs: 750,
+  });
+  assert.equal(observedTimeout, 750);
+});
+
+test('M7 probe: default timeout is 2000ms (matches existing fastHealthCheck)', async () => {
+  let observedTimeout = -1;
+  await probeFastRunnerLiveness({
+    getState: () => STATE,
+    processAlive: () => true,
+    httpProbe: async (_port, timeoutMs) => {
+      observedTimeout = timeoutMs;
+      return { ok: true, status: 200, bodyOk: true };
+    },
+  });
+  assert.equal(observedTimeout, 2000);
+});
+
+// ── probe: state cleanup invariants ───────────────────────────────────
+
+test('M7 probe: stale path does NOT clear state (reap is the explicit action)', async () => {
+  let clearCalls = 0;
+  await probeFastRunnerLiveness({
+    getState: () => STATE,
+    processAlive: () => true,
+    httpProbe: async () => ({ ok: true, status: 200, bodyOk: false }),
+    clearState: () => { clearCalls++; },
+  });
+  assert.equal(clearCalls, 0, 'probe is read-only on a living process');
+});
+
+test('M7 probe: alive path does NOT clear state', async () => {
+  let clearCalls = 0;
+  await probeFastRunnerLiveness({
+    getState: () => STATE,
+    processAlive: () => true,
+    httpProbe: async () => ({ ok: true, status: 200, bodyOk: true }),
+    clearState: () => { clearCalls++; },
+  });
+  assert.equal(clearCalls, 0);
+});
+
+// ── reap ─────────────────────────────────────────────────────────────
+
+test('M7 reap: no-op when state is already null', async () => {
+  let signals = 0;
+  let clearCalls = 0;
+  await reapStaleFastRunner({
+    getState: () => null,
+    processAlive: () => assert.fail('processAlive should not be consulted when state is null'),
+    sendSignal: () => { signals++; },
+    sleep: async () => {},
+    clearState: () => { clearCalls++; },
+  });
+  assert.equal(signals, 0);
+  assert.equal(clearCalls, 0);
+});
+
+test('M7 reap: SIGTERM succeeds — does not escalate to SIGKILL', async () => {
+  const signals = [];
+  let clearCalls = 0;
+  let processAliveCalls = 0;
+  await reapStaleFastRunner({
+    getState: () => STATE,
+    processAlive: () => {
+      processAliveCalls++;
+      // After SIGTERM + grace wait, process is dead
+      return false;
+    },
+    sendSignal: (pid, sig) => { signals.push([pid, sig]); },
+    sleep: async () => {},
+    clearState: () => { clearCalls++; },
+    graceMs: 0,
+  });
+  assert.deepEqual(signals, [[STATE.pid, 'SIGTERM']], 'only SIGTERM should be sent on graceful death');
+  assert.equal(processAliveCalls, 1);
+  assert.equal(clearCalls, 1, 'state must be cleared after successful reap');
+});
+
+test('M7 reap: SIGTERM ignored → SIGKILL escalation', async () => {
+  const signals = [];
+  let clearCalls = 0;
+  await reapStaleFastRunner({
+    getState: () => STATE,
+    processAlive: () => true, // refuses to die after SIGTERM
+    sendSignal: (pid, sig) => { signals.push([pid, sig]); },
+    sleep: async () => {},
+    clearState: () => { clearCalls++; },
+    graceMs: 0,
+  });
+  assert.deepEqual(signals, [[STATE.pid, 'SIGTERM'], [STATE.pid, 'SIGKILL']]);
+  assert.equal(clearCalls, 1);
+});
+
+test('M7 reap: SIGTERM throws ESRCH (already dead) — clearState still called', async () => {
+  let clearCalls = 0;
+  await reapStaleFastRunner({
+    getState: () => STATE,
+    processAlive: () => false, // already gone
+    sendSignal: (_pid, _sig) => {
+      const err = new Error('ESRCH');
+      err.code = 'ESRCH';
+      throw err;
+    },
+    sleep: async () => {},
+    clearState: () => { clearCalls++; },
+    graceMs: 0,
+  });
+  assert.equal(clearCalls, 1, 'state is cleared even when signal throws — target was already dead');
+});
+
+test('M7 reap: graceMs override respected (fake sleep captures value)', async () => {
+  let observedGrace = -1;
+  await reapStaleFastRunner({
+    getState: () => STATE,
+    processAlive: () => false,
+    sendSignal: () => {},
+    sleep: async (ms) => { observedGrace = ms; },
+    clearState: () => {},
+    graceMs: 250,
+  });
+  assert.equal(observedGrace, 250);
+});
+
+test('M7 reap: default graceMs is 500', async () => {
+  let observedGrace = -1;
+  await reapStaleFastRunner({
+    getState: () => STATE,
+    processAlive: () => false,
+    sendSignal: () => {},
+    sleep: async (ms) => { observedGrace = ms; },
+    clearState: () => {},
+  });
+  assert.equal(observedGrace, 500);
+});


### PR DESCRIPTION
## Summary

Closes Phase 90 Tier 3 **Story M7** and functionally retires **Story R3** from Phase 85. Previously `isFastRunnerAvailable()` only checked PID; a process whose PID was alive but whose HTTP server had wedged was reported as available, and every iOS `device_press` / `device_fill` / `device_swipe` stalled on a 10s fetch timeout before falling through to the daemon.

M7 adds `probeFastRunnerLiveness()` that returns `'alive' | 'stale' | 'dead'` via PID check + `/health` probe, plus `reapStaleFastRunner()` for the SIGTERM → 500ms grace → SIGKILL escalation. `tryFastRunner` is rewired to branch on the tri-state.

Branches off current main (0.36.1). Independent of M11 PR #53 (which will slot in as 0.37.0 when merged).

## Why

The symptom this fixes: random-feeling freezes on iOS interaction calls. A runner whose Swift HTTP thread deadlocked (or was paused via SIGSTOP, or crashed its listener without exiting the process) keeps its PID alive, so the sync PID-only check says \"runner is available\" and we hit `postJSON` → 10s fetch timeout → fallback to daemon. Users saw 10s hangs on every press/swipe/fill.

## Scope

| File | Change |
|---|---|
| `scripts/cdp-bridge/src/fast-runner-session.ts` | New type `FastRunnerLiveness` + async fns `probeFastRunnerLiveness(deps?)` and `reapStaleFastRunner(deps?)`. Internal `defaultProcessAlive` / `defaultHttpProbe` / `clearStateFile` helpers. All deps injectable (mirrors `lockfile.ts`). Legacy sync `isFastRunnerAvailable` retained. `fastHealthCheck` refactored to delegate + try/catch-wrapped. `clearStateFile` now nulls `runnerProcess` too. |
| `scripts/cdp-bridge/src/agent-device-wrapper.ts` | `tryFastRunner` rewired to await the tri-state probe. `'alive'` proceeds; `'stale'` reaps + returns null; `'dead'` + iOS cold-launches; `'dead'` + non-iOS returns null. |
| `scripts/cdp-bridge/test/unit/fast-runner-liveness.test.js` | NEW — 17 hermetic tests via injected deps. |
| Versions | plugin 0.36.1 → 0.38.0 (skipping 0.37.0 for M11 PR #53), MCP 0.31.1 → 0.33.0 |

## Design decisions

- **Endpoint `/health`** (not `/ping` as spec said) — HealthHandler already returns `{\"ok\":true,...}`.
- **Timeout 2000ms** (matches existing `fastHealthCheck`) — avoids false-stale during simulator GC pauses.
- **Graceful-then-forceful kill**: SIGTERM → 500ms grace → SIGKILL if still alive.
- **Probe is read-only**; reap is the explicit mutating action.
- **All deps injectable** for hermetic testing.

## Tests

488 → **505 passing**, 0 failures. +17 tests across:

```
✔ M7 probe: returns dead when no state (no runner ever started)
✔ M7 probe: returns dead and clears state when PID has exited
✔ M7 probe: returns alive when PID lives and /health returns {ok:true}
✔ M7 probe: returns stale when PID lives but /health returns {ok:false}
✔ M7 probe: returns stale on HTTP 500 (server crashed handler)
✔ M7 probe: returns stale when httpProbe throws AbortError (hung listener)
✔ M7 probe: returns stale when httpProbe throws ECONNREFUSED (port not listening)
✔ M7 probe: timeoutMs override forwards to httpProbe
✔ M7 probe: default timeout is 2000ms (matches existing fastHealthCheck)
✔ M7 probe: stale path does NOT clear state (reap is the explicit action)
✔ M7 probe: alive path does NOT clear state
✔ M7 reap: no-op when state is already null
✔ M7 reap: SIGTERM succeeds — does not escalate to SIGKILL
✔ M7 reap: SIGTERM ignored → SIGKILL escalation
✔ M7 reap: SIGTERM throws ESRCH (already dead) — clearState still called
✔ M7 reap: graceMs override respected (fake sleep captures value)
✔ M7 reap: default graceMs is 500
```

## Review

Multi-LLM (Gemini + Codex). **Two findings applied inline**:

- **Codex (confidence 90)**: the `fastHealthCheck` refactor lost its outer try/catch — network throws from `defaultHttpProbe` now propagated where the original returned `false`. Fixed by re-wrapping. No current external callers, so zero observable impact today, but preserves the documented contract for any future consumer.
- **Gemini (confidence 84)**: `reapStaleFastRunner` cleared `runnerState` but left the module-level `runnerProcess` (ChildProcess handle) dangling. Fixed by nulling `runnerProcess` in `clearStateFile()`. Self-heals via `on('exit')` but closes the window cleanly.

**Two sub-threshold findings deferred** (documented in Known Limits):
- Concurrent `'dead'` probes could race two `xcodebuild` spawns (Gemini, confidence 82). MCP SDK serializes tool calls per connection; race window is narrow. Fix would be an in-flight promise cache on `startFastRunner`. File follow-up if observed.
- SIGKILL on xcodebuild PID may orphan `xctest` children briefly. macOS launchd reaps within seconds.

## R3 relationship

Story R3 (\"fast-runner restart\") from Phase 85 was marked DONE in Phase 92 with the note: \"Shape differs from original R3 spec (PID probe instead of /ping; restart integrated into device session open rather than standalone auto-restart-on-failure) but acceptance criteria equivalent.\" M7 now implements the full spec: tri-state `/health` probe, explicit stale detection, graceful reap. The functional gap R3 left is closed.

## Test plan

- [x] `cd scripts/cdp-bridge && npm test` → 505 passing, 0 failures
- [x] Hermetic coverage across all probe/reap branches
- [ ] **Post-merge smoke**: after CC restart, run three scenarios on the workspace test-app:
  1. `device_press` twice within 2s → expect one xcodebuild spawn via `ps aux | grep xcodebuild`
  2. `pkill -9 -f FastRunnerTests` → `device_press` → expect cold restart in ~6s
  3. `kill -STOP <fastRunnerPid>` → `device_press` → expect 2s probe timeout + reap + daemon fallback

## Known limits

- Legacy sync `isFastRunnerAvailable()` retained for cheap PID-only callers (documented as coarse in JSDoc).
- Stale detection conflates \"hung\" with \"misbehaving-but-responsive\" — a runner returning `{ok:false}` is reaped even if self-recoverable. Conservative.
- See \"Review findings deferred\" above for two known sub-threshold concerns.

## Refs

- D666 in `rn-dev-agent-workspace/docs/DECISIONS.md`
- Phase 109 in `rn-dev-agent-workspace/docs/ROADMAP.md`
- Proof: `rn-dev-agent-workspace/docs/proof/m7-fast-runner-liveness/`
- metro-mcp reference: `src/plugins/devtools.ts::tryFocusExisting`