### PR TITLE
feat(m10/phase-110): architecture detection + CPU profiler hint (D667)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.39.0",
+      "version": "0.40.0",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.40.0] — 2026-04-22
+
+M10 / Phase 110 — architecture detection + CPU profiler hint. Closes the Phase 90 Tier 4 M10 story. `cdp_status.app.architecture` now surfaces one of `'new' | 'old' | 'unknown'` based on Fabric/bridge globals inside the running app. When `cdp_cpu_profile` fails AND the target is running on Old Architecture, the error result now includes an advisory hint pointing to `cdp_heap_usage` as an alternative and suggesting `newArchitecture: true` in `app.json`. MCP server bumped to 0.35.0.
+
+### Added
+- **`cdp_status.app.architecture`** — new optional field: `'new'` when `globalThis.nativeFabricUIManager` is present (Fabric loaded), `'old'` when `globalThis.__fbBatchedBridge` is present and Fabric is absent (classic bridge), `'unknown'` when neither signal exists or the probe throws. Fabric wins on transient "both present" interop state.
+- **`OLD_ARCH_PROFILER_HINT` exported constant** in `scripts/cdp-bridge/src/tools/profiling.ts`. Attached as `meta.hint` to `cdp_cpu_profile` failures when the architecture probe returns `'old'`.
+- **`narrowArchitecture` exported helper** in `scripts/cdp-bridge/src/tools/status.ts`. Whitelists the union — any unexpected string or missing value collapses to `'unknown'`, so TypeScript's union guarantee holds at runtime regardless of what future helper bundles emit.
+
+### Changed
+- **`__HELPERS_VERSION__` bumped 14 → 15** in `injected-helpers.ts`. Forces Hermes re-injection on next connect so apps pick up the new `getAppInfo()` shape. Existing freshness check (D502) triggers re-injection automatically.
+- **`getAppInfo()` extended** to compute architecture at probe time (wrapped in try/catch — probe failure defaults to `'unknown'`).
+- **`buildStatusResult()` AND the `__DEV__=false` recovery retry path** both write `status.app.architecture` so consumers see consistent values regardless of whether the recovery branch fired.
+- **`cpuProfile` error catch** now performs a single-shot architecture probe (via new internal `safeProbeArchitecture`) before returning `failResult`. Probe failure → `'unknown'` → no hint.
+
+### Tests
+- **16 new tests**. 6 detection in `test/unit/injected-helpers.test.js` (Fabric-only, bridge-only, neither, both-present → `'new'`, null-Fabric guard, helpers version = 15). 10 in new `test/unit/m10-architecture.test.js` (3 `narrowArchitecture` tests, 4 status-handler integration tests, 3 profiler-hint integration tests including a probe-itself-throws path).
+
+Running total: 525 → **541 passing**, zero failures.
+
+### Review
+Multi-LLM (Gemini + Codex). Both clean — zero high-confidence findings. Independently validated: Fabric is always object-typed in RN (never function); the extra error-path probe adds only ~50-200ms to an already-failed CPU profile call; `narrowArchitecture` whitelist is injection-safe; `__DEV__=false` recovery-path parity is complete; v14 → v15 cache invalidation is clean via the existing `__v` freshness check.
+
+### Known limits
+- **Fabric-wins on "both present"** is a deliberate heuristic for interop-mode transients. Documented.
+- **`'unknown'` is non-actionable** — consumers should treat as "skip arch-specific hints," not as "assume old."
+- **Profiler hint is advisory, not blocking** — `cdp_cpu_profile` still runs on Old Arch; some profiles do succeed. Hint only fires on actual failures.
+
+### Refs
+D667 in `rn-dev-agent-workspace/docs/DECISIONS.md`. Phase 110 in `rn-dev-agent-workspace/docs/ROADMAP.md`. Related: D502 (helper freshness check catches stale v14 caches), M8/D663 (prior `__HELPERS_VERSION__` bump pattern).
+
 ## [0.39.0] — 2026-04-22
 
 M11 / Phase 108 — Metro `--clear` hint on empty buffers. Closes the Phase 90 Tier 4 UX story from the metro-mcp pattern adoption audit. When `cdp_console_log` or `cdp_network_log` return empty results AND the CDP session has been idle for more than 60s (measured as `max(connectedAt, lastEventAt)`), the tool result now includes `meta.hint` suggesting `npx expo start --clear` / `npx react-native start --reset-cache`. This surfaces a failure mode (stale Metro bundle cache) that previously required users to find it in a troubleshooting doc. MCP server bumped to 0.34.0.

--- a/scripts/cdp-bridge/dist/injected-helpers.js
+++ b/scripts/cdp-bridge/dist/injected-helpers.js
@@ -1,6 +1,6 @@
 export const INJECTED_HELPERS = `
 (function() {
-  var __HELPERS_VERSION__ = 14;
+  var __HELPERS_VERSION__ = 15;
   if (globalThis.__RN_AGENT && globalThis.__RN_AGENT.__v === __HELPERS_VERSION__) return;
   if (globalThis.__RN_AGENT) delete globalThis.__RN_AGENT;
 
@@ -1275,6 +1275,18 @@ export const INJECTED_HELPERS = `
               if (dims && dims.window) info.dimensions = dims.window;
             }
           } catch(e) {}
+        }
+        // M10 / Phase 110: architecture detection. Fabric wins on "both present"
+        // (transient interop state); __fbBatchedBridge alone → classic bridge;
+        // neither → unknown. See docs/DECISIONS.md D667.
+        try {
+          var fabric = typeof globalThis.nativeFabricUIManager === 'object'
+            && globalThis.nativeFabricUIManager !== null;
+          var bridge = typeof globalThis.__fbBatchedBridge === 'object'
+            && globalThis.__fbBatchedBridge !== null;
+          info.architecture = fabric ? 'new' : (bridge ? 'old' : 'unknown');
+        } catch (e) {
+          info.architecture = 'unknown';
         }
         return JSON.stringify(info);
       } catch(e) {

--- a/scripts/cdp-bridge/dist/tools/profiling.js
+++ b/scripts/cdp-bridge/dist/tools/profiling.js
@@ -1,4 +1,25 @@
 import { okResult, failResult, withConnection } from '../utils.js';
+// M10 / Phase 110 / D667: advisory hint appended to cpuProfile failures when
+// the target is running on the classic bridge (Fabric absent). CPU profiling
+// via CDP Profiler domain is known to be flaky on Old Arch — this wording
+// points users at the most likely cause + actionable alternatives.
+export const OLD_ARCH_PROFILER_HINT = 'Old architecture detected — CPU profile may be unreliable or incomplete on the classic bridge. ' +
+    'Prefer cdp_heap_usage for memory, or enable New Architecture (newArchitecture: true in app.json) for profiling.';
+// Single-shot probe of app architecture. Used in the error path of cpuProfile
+// so we can surface OLD_ARCH_PROFILER_HINT only when it's actually relevant.
+// Wrapped in try/catch — any failure collapses to 'unknown' so we don't hint.
+async function safeProbeArchitecture(client) {
+    try {
+        const result = await client.evaluate(client.helperExpr('getAppInfo()'));
+        if (typeof result.value !== 'string')
+            return 'unknown';
+        const info = JSON.parse(result.value);
+        return info.architecture === 'new' || info.architecture === 'old' ? info.architecture : 'unknown';
+    }
+    catch {
+        return 'unknown';
+    }
+}
 export function createHeapUsageHandler(getClient) {
     return withConnection(getClient, async (_args, client) => {
         try {
@@ -101,7 +122,13 @@ export function createCpuProfileHandler(getClient) {
                 await client.send('Profiler.disable', undefined);
             }
             catch { /* cleanup */ }
-            return failResult(`CPU profiling failed: ${err instanceof Error ? err.message : err}`);
+            const base = `CPU profiling failed: ${err instanceof Error ? err.message : err}`;
+            // M10: advisory hint when the cause is likely Old Architecture.
+            const arch = await safeProbeArchitecture(client);
+            if (arch === 'old') {
+                return failResult(base, { hint: OLD_ARCH_PROFILER_HINT, architecture: arch });
+            }
+            return failResult(base);
         }
     });
 }

--- a/scripts/cdp-bridge/dist/tools/status.js
+++ b/scripts/cdp-bridge/dist/tools/status.js
@@ -2,6 +2,12 @@ import { okResult, failResult, warnResult } from '../utils.js';
 import { handleDevClientPicker } from './dev-client-picker.js';
 import { getSessionReloadCount } from './reload.js';
 import { supportsNativeMultiDebugger } from '../cdp/multiplexer.js';
+// M10 / Phase 110: narrow `appInfo.architecture` to the StatusResult union.
+// Any unexpected value collapses to 'unknown' — defensive against future
+// helper versions that might emit new tokens we don't recognize yet.
+export function narrowArchitecture(raw) {
+    return raw === 'new' || raw === 'old' ? raw : 'unknown';
+}
 const STATUS_PROBE_EXPRESSION = `
 (function() {
   var result = { appInfo: null, errorCount: 0, fiberTree: false, hasRedBox: false, helpersLoaded: false };
@@ -55,6 +61,7 @@ async function buildStatusResult(client) {
             hasRedBox,
             isPaused: client.isPaused,
             errorCount,
+            architecture: narrowArchitecture(appInfo?.architecture),
         },
         capabilities: {
             networkDomain: client.networkMode === 'cdp',
@@ -127,6 +134,7 @@ export function createStatusHandler(getClient, setClient, createClient) {
                                     status.app.hasRedBox = retryProbe.hasRedBox;
                                     status.app.errorCount = retryProbe.errorCount;
                                     status.app.isPaused = client.isPaused;
+                                    status.app.architecture = narrowArchitecture(retryProbe.appInfo?.architecture);
                                     status.cdp.device = client.connectedTarget?.title ?? null;
                                     status.cdp.pageId = client.connectedTarget?.id ?? null;
                                     status.cdp.bundleId = client.connectedTarget?.description ?? null;

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/injected-helpers.ts
+++ b/scripts/cdp-bridge/src/injected-helpers.ts
@@ -1,6 +1,6 @@
 export const INJECTED_HELPERS = `
 (function() {
-  var __HELPERS_VERSION__ = 14;
+  var __HELPERS_VERSION__ = 15;
   if (globalThis.__RN_AGENT && globalThis.__RN_AGENT.__v === __HELPERS_VERSION__) return;
   if (globalThis.__RN_AGENT) delete globalThis.__RN_AGENT;
 
@@ -1275,6 +1275,18 @@ export const INJECTED_HELPERS = `
               if (dims && dims.window) info.dimensions = dims.window;
             }
           } catch(e) {}
+        }
+        // M10 / Phase 110: architecture detection. Fabric wins on "both present"
+        // (transient interop state); __fbBatchedBridge alone → classic bridge;
+        // neither → unknown. See docs/DECISIONS.md D667.
+        try {
+          var fabric = typeof globalThis.nativeFabricUIManager === 'object'
+            && globalThis.nativeFabricUIManager !== null;
+          var bridge = typeof globalThis.__fbBatchedBridge === 'object'
+            && globalThis.__fbBatchedBridge !== null;
+          info.architecture = fabric ? 'new' : (bridge ? 'old' : 'unknown');
+        } catch (e) {
+          info.architecture = 'unknown';
         }
         return JSON.stringify(info);
       } catch(e) {

--- a/scripts/cdp-bridge/src/tools/profiling.ts
+++ b/scripts/cdp-bridge/src/tools/profiling.ts
@@ -1,6 +1,28 @@
 import type { CDPClient } from '../cdp-client.js';
 import { okResult, failResult, withConnection } from '../utils.js';
 
+// M10 / Phase 110 / D667: advisory hint appended to cpuProfile failures when
+// the target is running on the classic bridge (Fabric absent). CPU profiling
+// via CDP Profiler domain is known to be flaky on Old Arch — this wording
+// points users at the most likely cause + actionable alternatives.
+export const OLD_ARCH_PROFILER_HINT =
+  'Old architecture detected — CPU profile may be unreliable or incomplete on the classic bridge. ' +
+  'Prefer cdp_heap_usage for memory, or enable New Architecture (newArchitecture: true in app.json) for profiling.';
+
+// Single-shot probe of app architecture. Used in the error path of cpuProfile
+// so we can surface OLD_ARCH_PROFILER_HINT only when it's actually relevant.
+// Wrapped in try/catch — any failure collapses to 'unknown' so we don't hint.
+async function safeProbeArchitecture(client: CDPClient): Promise<'new' | 'old' | 'unknown'> {
+  try {
+    const result = await client.evaluate(client.helperExpr('getAppInfo()'));
+    if (typeof result.value !== 'string') return 'unknown';
+    const info = JSON.parse(result.value) as { architecture?: unknown };
+    return info.architecture === 'new' || info.architecture === 'old' ? info.architecture : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
 export function createHeapUsageHandler(getClient: () => CDPClient) {
   return withConnection(getClient, async (_args: Record<string, never>, client) => {
     try {
@@ -115,7 +137,13 @@ export function createCpuProfileHandler(getClient: () => CDPClient) {
       });
     } catch (err) {
       try { await client.send('Profiler.disable', undefined); } catch { /* cleanup */ }
-      return failResult(`CPU profiling failed: ${err instanceof Error ? err.message : err}`);
+      const base = `CPU profiling failed: ${err instanceof Error ? err.message : err}`;
+      // M10: advisory hint when the cause is likely Old Architecture.
+      const arch = await safeProbeArchitecture(client);
+      if (arch === 'old') {
+        return failResult(base, { hint: OLD_ARCH_PROFILER_HINT, architecture: arch });
+      }
+      return failResult(base);
     }
   });
 }

--- a/scripts/cdp-bridge/src/tools/status.ts
+++ b/scripts/cdp-bridge/src/tools/status.ts
@@ -5,6 +5,13 @@ import { handleDevClientPicker } from './dev-client-picker.js';
 import { getSessionReloadCount } from './reload.js';
 import { supportsNativeMultiDebugger } from '../cdp/multiplexer.js';
 
+// M10 / Phase 110: narrow `appInfo.architecture` to the StatusResult union.
+// Any unexpected value collapses to 'unknown' — defensive against future
+// helper versions that might emit new tokens we don't recognize yet.
+export function narrowArchitecture(raw: unknown): 'new' | 'old' | 'unknown' {
+  return raw === 'new' || raw === 'old' ? raw : 'unknown';
+}
+
 const STATUS_PROBE_EXPRESSION = `
 (function() {
   var result = { appInfo: null, errorCount: 0, fiberTree: false, hasRedBox: false, helpersLoaded: false };
@@ -67,6 +74,7 @@ async function buildStatusResult(client: CDPClient): Promise<StatusResult> {
       hasRedBox,
       isPaused: client.isPaused,
       errorCount,
+      architecture: narrowArchitecture(appInfo?.architecture),
     },
     capabilities: {
       networkDomain: client.networkMode === 'cdp',
@@ -153,6 +161,7 @@ export function createStatusHandler(
                   status.app.hasRedBox = retryProbe.hasRedBox;
                   status.app.errorCount = retryProbe.errorCount;
                   status.app.isPaused = client.isPaused;
+                  status.app.architecture = narrowArchitecture(retryProbe.appInfo?.architecture);
                   status.cdp.device = client.connectedTarget?.title ?? null;
                   status.cdp.pageId = client.connectedTarget?.id ?? null;
                   status.cdp.bundleId = client.connectedTarget?.description ?? null;

--- a/scripts/cdp-bridge/src/types.ts
+++ b/scripts/cdp-bridge/src/types.ts
@@ -104,6 +104,8 @@ export interface StatusResult {
     hasRedBox: boolean;
     isPaused: boolean;
     errorCount: number;
+    /** M10 / Phase 110: RN architecture — 'new' (Fabric), 'old' (classic bridge), 'unknown' (probe failed or non-RN). Optional for older callers. */
+    architecture?: 'new' | 'old' | 'unknown';
   };
   capabilities: {
     networkDomain: boolean;

--- a/scripts/cdp-bridge/test/unit/injected-helpers.test.js
+++ b/scripts/cdp-bridge/test/unit/injected-helpers.test.js
@@ -278,3 +278,45 @@ test('M8 probe: returns false when hook itself is absent', () => {
   vm.createContext(sandbox);
   assert.equal(vm.runInContext(REACT_READY_PROBE_JS, sandbox), false);
 });
+
+// ── M10: architecture detection in getAppInfo ─────────────────────────
+// Fabric-wins on "both present" (transient interop state during migration).
+// `__fbBatchedBridge` alone → classic bridge. Neither → unknown.
+
+function appInfoFrom(globals) {
+  const sandbox = createSandbox({ globals });
+  return JSON.parse(sandbox.__RN_AGENT.getAppInfo());
+}
+
+test('M10: getAppInfo returns architecture=new when nativeFabricUIManager present', () => {
+  const info = appInfoFrom({ nativeFabricUIManager: { /* Fabric object */ } });
+  assert.equal(info.architecture, 'new');
+});
+
+test('M10: getAppInfo returns architecture=old when __fbBatchedBridge present and Fabric absent', () => {
+  const info = appInfoFrom({ __fbBatchedBridge: { getCallableModule: () => null } });
+  assert.equal(info.architecture, 'old');
+});
+
+test('M10: getAppInfo returns architecture=unknown when neither signal present', () => {
+  const info = appInfoFrom({});
+  assert.equal(info.architecture, 'unknown');
+});
+
+test('M10: getAppInfo returns architecture=new when BOTH Fabric and bridge present (Fabric wins)', () => {
+  const info = appInfoFrom({
+    nativeFabricUIManager: { /* Fabric */ },
+    __fbBatchedBridge: { getCallableModule: () => null },
+  });
+  assert.equal(info.architecture, 'new');
+});
+
+test('M10: getAppInfo returns architecture=unknown when nativeFabricUIManager is null (guard works)', () => {
+  // Only __fbBatchedBridge falsy too → unknown
+  const info = appInfoFrom({ nativeFabricUIManager: null });
+  assert.equal(info.architecture, 'unknown');
+});
+
+test('M10: helpers bundle version is 15', () => {
+  assert.match(INJECTED_HELPERS, /__HELPERS_VERSION__\s*=\s*15/);
+});

--- a/scripts/cdp-bridge/test/unit/m10-architecture.test.js
+++ b/scripts/cdp-bridge/test/unit/m10-architecture.test.js
@@ -1,0 +1,155 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createMockClient } from '../helpers/mock-cdp-client.js';
+import { parseEnvelope, expectOk, expectFail } from '../helpers/result-helpers.js';
+import { createStatusHandler } from '../../dist/tools/status.js';
+import { narrowArchitecture } from '../../dist/tools/status.js';
+import { createCpuProfileHandler, OLD_ARCH_PROFILER_HINT } from '../../dist/tools/profiling.js';
+
+// M10 / D667 — integration tests for cdp_status.app.architecture wiring
+// plus the cdp_cpu_profile failure hint when architecture is 'old'.
+
+// ── narrowArchitecture helper ────────────────────────────────────────
+
+test('M10 narrow: passes through "new" unchanged', () => {
+  assert.equal(narrowArchitecture('new'), 'new');
+});
+
+test('M10 narrow: passes through "old" unchanged', () => {
+  assert.equal(narrowArchitecture('old'), 'old');
+});
+
+test('M10 narrow: collapses anything else to "unknown"', () => {
+  assert.equal(narrowArchitecture(undefined), 'unknown');
+  assert.equal(narrowArchitecture(null), 'unknown');
+  assert.equal(narrowArchitecture('fabric'), 'unknown');
+  assert.equal(narrowArchitecture(42), 'unknown');
+  assert.equal(narrowArchitecture({}), 'unknown');
+});
+
+// ── cdp_status handler integration ───────────────────────────────────
+
+function buildStatusProbeResult(appInfo) {
+  return JSON.stringify({
+    appInfo,
+    errorCount: 0,
+    fiberTree: true,
+    hasRedBox: false,
+    helpersLoaded: true,
+  });
+}
+
+test('M10 status: app.architecture="new" when probe returns new', async () => {
+  const client = createMockClient({
+    evaluate: async () => ({ value: buildStatusProbeResult({ __DEV__: true, architecture: 'new' }) }),
+  });
+  const handler = createStatusHandler(() => client, () => {}, () => client);
+  const data = expectOk(await handler({}));
+  assert.equal(data.app.architecture, 'new');
+});
+
+test('M10 status: app.architecture="old" when probe returns old', async () => {
+  const client = createMockClient({
+    evaluate: async () => ({ value: buildStatusProbeResult({ __DEV__: true, architecture: 'old' }) }),
+  });
+  const handler = createStatusHandler(() => client, () => {}, () => client);
+  const data = expectOk(await handler({}));
+  assert.equal(data.app.architecture, 'old');
+});
+
+test('M10 status: app.architecture="unknown" when probe omits the field', async () => {
+  const client = createMockClient({
+    evaluate: async () => ({ value: buildStatusProbeResult({ __DEV__: true }) }),
+  });
+  const handler = createStatusHandler(() => client, () => {}, () => client);
+  const data = expectOk(await handler({}));
+  assert.equal(data.app.architecture, 'unknown');
+});
+
+test('M10 status: unexpected architecture string is narrowed to "unknown"', async () => {
+  const client = createMockClient({
+    evaluate: async () => ({ value: buildStatusProbeResult({ __DEV__: true, architecture: 'bridgeless-interop' }) }),
+  });
+  const handler = createStatusHandler(() => client, () => {}, () => client);
+  const data = expectOk(await handler({}));
+  assert.equal(data.app.architecture, 'unknown');
+});
+
+// ── cdp_cpu_profile error-path hint ──────────────────────────────────
+
+test('M10 profiler: failure on old architecture includes meta.hint', async () => {
+  let evaluateCalls = 0;
+  const client = createMockClient({
+    _profilerAvailable: true,
+    async send(method) {
+      if (method === 'Profiler.enable') return {};
+      if (method === 'Profiler.start') throw new Error('Profiler.start timed out');
+      if (method === 'Profiler.disable') return {};
+      return {};
+    },
+    async evaluate(expr) {
+      evaluateCalls++;
+      // safeProbeArchitecture calls helperExpr('getAppInfo()') — return 'old'
+      if (expr.includes('getAppInfo')) {
+        return { value: JSON.stringify({ architecture: 'old' }) };
+      }
+      return { value: 13 };
+    },
+    get profilerAvailable() { return true; },
+  });
+  const handler = createCpuProfileHandler(() => client);
+  const result = await handler({ durationMs: 500 });
+  const envelope = parseEnvelope(result);
+  assert.equal(envelope.ok, false);
+  assert.match(envelope.error, /CPU profiling failed/);
+  assert.ok(envelope.meta, 'meta should be attached when architecture is old');
+  assert.equal(envelope.meta.hint, OLD_ARCH_PROFILER_HINT);
+  assert.equal(envelope.meta.architecture, 'old');
+  assert.ok(evaluateCalls >= 1, 'safeProbeArchitecture should have fired');
+});
+
+test('M10 profiler: failure on new architecture omits meta.hint', async () => {
+  const client = createMockClient({
+    _profilerAvailable: true,
+    async send(method) {
+      if (method === 'Profiler.enable') return {};
+      if (method === 'Profiler.start') throw new Error('Profiler.start timed out');
+      if (method === 'Profiler.disable') return {};
+      return {};
+    },
+    async evaluate(expr) {
+      if (expr.includes('getAppInfo')) {
+        return { value: JSON.stringify({ architecture: 'new' }) };
+      }
+      return { value: 13 };
+    },
+    get profilerAvailable() { return true; },
+  });
+  const handler = createCpuProfileHandler(() => client);
+  const result = await handler({ durationMs: 500 });
+  const envelope = parseEnvelope(result);
+  assert.equal(envelope.ok, false);
+  assert.equal(envelope.meta?.hint, undefined, 'no hint on new architecture');
+});
+
+test('M10 profiler: failure when safeProbeArchitecture itself throws — no hint', async () => {
+  const client = createMockClient({
+    _profilerAvailable: true,
+    async send(method) {
+      if (method === 'Profiler.enable') return {};
+      if (method === 'Profiler.start') throw new Error('Profiler.start timed out');
+      if (method === 'Profiler.disable') return {};
+      return {};
+    },
+    async evaluate(expr) {
+      if (expr.includes('getAppInfo')) throw new Error('evaluate broken');
+      return { value: 13 };
+    },
+    get profilerAvailable() { return true; },
+  });
+  const handler = createCpuProfileHandler(() => client);
+  const result = await handler({ durationMs: 500 });
+  const envelope = parseEnvelope(result);
+  assert.equal(envelope.ok, false);
+  assert.equal(envelope.meta?.hint, undefined, 'probe failure collapses to unknown, no hint');
+});


### PR DESCRIPTION
## Summary

Closes Phase 90 Tier 4 **Story M10**. Adds `cdp_status.app.architecture: 'new' | 'old' | 'unknown'` detection based on in-app Fabric/bridge globals, plus an advisory hint on `cdp_cpu_profile` failures when the target is running on Old Architecture.

Branches off current main (0.39.0 / MCP 0.34.0, with M11 merged).

## Why

Two developer-experience gaps this closes:
1. Agents calling `cdp_status` had no signal about whether the app runs on New Architecture (Fabric/Bridgeless) vs classic bridge. This matters because several tools behave differently across architectures — notably `cdp_cpu_profile`, where the CDP Profiler domain is flaky on Old Arch.
2. `cdp_cpu_profile` failures returned a bare `CPU profiling failed: <timeout>` error. Users on Old Arch had no signal that the architecture itself might be the cause.

## Scope

| File | Change |
|---|---|
| `scripts/cdp-bridge/src/injected-helpers.ts` | `__HELPERS_VERSION__` 14 → 15. `getAppInfo()` extended with architecture probe (wrapped in try/catch, defaults `'unknown'`). |
| `scripts/cdp-bridge/src/types.ts` | Optional `architecture?: 'new' \| 'old' \| 'unknown'` added to `StatusResult.app`. |
| `scripts/cdp-bridge/src/tools/status.ts` | New exported `narrowArchitecture(raw)` whitelist helper. Wired in `buildStatusResult()` happy path AND the `__DEV__=false` recovery retry path for consistency. |
| `scripts/cdp-bridge/src/tools/profiling.ts` | New exported `OLD_ARCH_PROFILER_HINT` constant + internal `safeProbeArchitecture(client)` single-shot probe. `cpuProfile` error catch attaches `{ hint, architecture }` meta only when arch='old'. |
| `scripts/cdp-bridge/test/unit/*.test.js` | +16 tests (6 detection + 10 integration). |
| Versions | plugin 0.39.0 → 0.40.0, MCP 0.34.0 → 0.35.0 |

## Detection rules

\`\`\`js
var fabric = typeof globalThis.nativeFabricUIManager === 'object'
  && globalThis.nativeFabricUIManager !== null;
var bridge = typeof globalThis.__fbBatchedBridge === 'object'
  && globalThis.__fbBatchedBridge !== null;
info.architecture = fabric ? 'new' : (bridge ? 'old' : 'unknown');
\`\`\`

- **`'new'`**: Fabric loaded (non-null `nativeFabricUIManager`).
- **`'old'`**: classic bridge present AND Fabric absent.
- **`'unknown'`**: neither signal (or probe threw).
- **Both present → `'new'`** — Fabric wins on transient interop state; Fabric presence is the more definitive signal.

## Hint text

> \"Old architecture detected — CPU profile may be unreliable or incomplete on the classic bridge. Prefer `cdp_heap_usage` for memory, or enable New Architecture (`newArchitecture: true` in `app.json`) for profiling.\"

## Design decisions

- **Probe lives in `getAppInfo()`** — same shape as existing `platform`/`hermes`/`rnVersion` fields. One round-trip.
- **`narrowArchitecture` whitelist defensiveness** — any unexpected value collapses to `'unknown'`, preserving the TypeScript union invariant at runtime even if a future helper bundle emits new tokens.
- **No `lastKnownArchitecture` cache on client state** — blueprint considered and rejected. Single-shot probe in the error path is simpler, no state mutation, only ~50-200ms on already-failed calls.
- **Hint only fires on error path, only when arch='old'** — probe-failure skips the hint (no false positives). Success never gets a hint (no noise on happy path).

## Tests

525 → **541 passing**, 0 failures. +16 tests:

\`\`\`
Detection (6):
✔ M10: getAppInfo returns architecture=new when nativeFabricUIManager present
✔ M10: getAppInfo returns architecture=old when __fbBatchedBridge present and Fabric absent
✔ M10: getAppInfo returns architecture=unknown when neither signal present
✔ M10: getAppInfo returns architecture=new when BOTH Fabric and bridge present (Fabric wins)
✔ M10: getAppInfo returns architecture=unknown when nativeFabricUIManager is null (guard works)
✔ M10: helpers bundle version is 15

narrowArchitecture whitelist (3):
✔ M10 narrow: passes through \"new\" unchanged
✔ M10 narrow: passes through \"old\" unchanged
✔ M10 narrow: collapses anything else to \"unknown\"

Status handler integration (4):
✔ M10 status: app.architecture=\"new\" when probe returns new
✔ M10 status: app.architecture=\"old\" when probe returns old
✔ M10 status: app.architecture=\"unknown\" when probe omits the field
✔ M10 status: unexpected architecture string is narrowed to \"unknown\"

Profiler hint (3):
✔ M10 profiler: failure on old architecture includes meta.hint
✔ M10 profiler: failure on new architecture omits meta.hint
✔ M10 profiler: failure when safeProbeArchitecture itself throws — no hint
\`\`\`

## Review

Multi-LLM (Gemini + Codex). **Both clean — zero high-confidence findings.**

Five separate dismissal validations independently confirmed by both reviewers:
- Fabric is always object-typed in RN (never callable — FabricUIManager installer confirms)
- Extra evaluate on error path is noise (~50-200ms on already-failed multi-second profile call)
- `narrowArchitecture` whitelist is injection-safe (pure identity check)
- `__DEV__=false` recovery-path parity is complete
- v14 → v15 cache invalidation is clean via existing `__v` freshness check (D502)

Codex additionally verified: consumer-compat for optional field (runtime always populates, never ships undefined); `safeProbeArchitecture` hang risk (routes through standard evaluate timeout — no worse than any other tool call); no resource leaks (no new listeners/timers).

## Test plan

- [x] `cd scripts/cdp-bridge && npm test` → 541 passing, 0 failures
- [x] Pre-M10 baseline captured: current MCP's `cdp_status.app` lacks `architecture` field (confirms truly-new surface, not regression)
- [ ] **Post-merge smoke**: after CC restart, `cdp_status` on test-app (Bridgeless/Fabric) → expect `app.architecture: 'new'`. Forced `cdp_cpu_profile` failure on same test-app (new-arch) → expect NO `meta.hint` (inverse check).

## Known limits

- **Fabric-wins on \"both present\"** is a heuristic for interop-mode transients. Documented.
- **`'unknown'` is non-actionable** — consumers should treat as \"skip arch-specific hints,\" not \"assume old.\"
- **Profiler hint is advisory, not blocking** — `cdp_cpu_profile` still runs on Old Arch; some profiles do succeed. Hint only fires on actual failures.

## Refs

- D667 in `rn-dev-agent-workspace/docs/DECISIONS.md`
- Phase 110 in `rn-dev-agent-workspace/docs/ROADMAP.md`
- Proof: `rn-dev-agent-workspace/docs/proof/m10-architecture-detection/`
- Related: D502 (helper freshness check), M8/D663 (prior `__HELPERS_VERSION__` bump pattern)