### PR TITLE
feat(m9/phase-111): /setup physical-device prerequisites (D668)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.40.0",
+      "version": "0.41.0",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.41.0] — 2026-04-22
+
+M9 / Phase 111 — `/rn-dev-agent:setup` now detects USB-connected physical devices and applies (or hints at) the required prerequisites. Closes the Phase 90 Tier 4 M9 story. Auto-runs `adb reverse tcp:8081 tcp:8081` on each physical Android so the device can reach Metro. Checks for `idb-companion` on physical iOS and prints `brew install idb-companion` when missing. Documents WiFi-debugging as unsupported (matching metro-mcp's stance).
+
+**MCP server unchanged** — this is the first story in the Phase 90 pattern-adoption batch with no `scripts/cdp-bridge/` changes. MCP stays at 0.35.0.
+
+### Added
+- **NEW `scripts/check-physical-devices.sh`** (executable). OS-aware bash probe. Android path uses `adb devices` filtered by `emulator-` prefix exclusion, iterates results, auto-runs `adb -s <dev> reverse tcp:8081 tcp:8081`. iOS path (gated on `uname -s == Darwin`) uses `xcrun xctrace list devices`, awk-extracts the `== Devices ==` section, positive-filters for iOS form factors (iPhone/iPad/iPod/Apple TV/Apple Vision/Apple Watch) to exclude the host Mac, checks both `idb_companion` and `idb-companion` binary names on PATH. Linux/WSL hosts see an explicit "Physical iOS probe skipped (requires macOS; host is $HOST_OS)" line rather than a misleading "no iOS device".
+- **New step 10 in `skills/rn-setup/SKILL.md`** — "Physical device prerequisites (optional)" invokes the script. Advisory — exits 0 in all cases. No-op when no physical devices are connected.
+- **8 structural test guards** in `scripts/cdp-bridge/test/unit/physical-devices-script-guard.test.js` — pin the script's invariants (exists + executable, bash shebang, expected probes, emulator filter, form-factor filter, idb-companion binary-name coverage, brew install hint, WiFi stance).
+
+### Changed
+- **`skills/rn-setup/SKILL.md`**: "9 checks" / "9-row" language updated to "10 checks" / "10-row" in three downstream references (Rationalizations, Red Flags, Verification checklist). New row added to the output-format table. New physical-device item added to the Verification checklist.
+
+### Tests
+Running total: 541 → **549 passing**, zero failures. 8 new structural guards — live functional smoke happens during every `/setup` invocation.
+
+### Review
+Multi-LLM (Gemini + Codex). Gemini clean (0 findings). Codex caught two valid issues both applied inline:
+- **Confidence 90** — stale "9 checks" / "9-row" copy after adding section 10. Fixed.
+- **Confidence 85** — no OS guard meant Linux/WSL hosts would silently show "No physical iOS detected" without context. Fixed — `HOST_OS` detected + iOS branch gated on `Darwin`.
+
+Gemini dismissals validated: awk section filter correct against live xctrace output (anchored regex handles "== Devices Offline ==" and name-mid-line `== ` cases); adb reverse is idempotent; idb-companion binary check covers both brew-published variants; form-factor regex correctly matches "Apple TV HD"-style prefix names.
+
+### Live smoke
+Ran on dev machine with no physical devices connected. First run misreported the MacBook itself as a "physical iOS device" — `xcrun xctrace list devices` surfaces the host Mac under `== Devices ==` for Mac Catalyst targeting. Fixed via positive form-factor filter; re-ran correctly reports "No physical iOS devices detected" and explicitly labels Host OS.
+
+### Known limits
+- **`adb reverse` auto-run is stateful** — idempotent per-device port-forwarding, but still a side effect. Documented as expected setup behavior.
+- **`idb-companion` not auto-installed** — brew installs are slow and can fail; hint-only is the canonical pattern for missing deps in this skill.
+- **WiFi debugging not supported automatically** — matches metro-mcp. Users can `adb connect <ip>` manually and the script runs `adb reverse` over the TCP transport.
+- **Structural-only tests** — no `bats` dependency. Live smoke during `/setup` is the functional validation.
+
+### Refs
+D668 in `rn-dev-agent-workspace/docs/DECISIONS.md`. Phase 111 in `rn-dev-agent-workspace/docs/ROADMAP.md`. metro-mcp reference: troubleshooting "Physical Device Setup".
+
 ## [0.40.0] — 2026-04-22
 
 M10 / Phase 110 — architecture detection + CPU profiler hint. Closes the Phase 90 Tier 4 M10 story. `cdp_status.app.architecture` now surfaces one of `'new' | 'old' | 'unknown'` based on Fabric/bridge globals inside the running app. When `cdp_cpu_profile` fails AND the target is running on Old Architecture, the error result now includes an advisory hint pointing to `cdp_heap_usage` as an alternative and suggesting `newArchitecture: true` in `app.json`. MCP server bumped to 0.35.0.

--- a/scripts/cdp-bridge/test/unit/physical-devices-script-guard.test.js
+++ b/scripts/cdp-bridge/test/unit/physical-devices-script-guard.test.js
@@ -1,0 +1,64 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+// M9 / D668 — structural guard for scripts/check-physical-devices.sh.
+// Live smoke of the physical-device detection happens at /setup runtime;
+// this test pins the script's expected invariants so a refactor doesn't
+// silently drop a probe.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Script lives at repo root/scripts/check-physical-devices.sh.
+// Test lives at repo root/scripts/cdp-bridge/test/unit/ — go up 3 levels.
+const SCRIPT_PATH = join(__dirname, '..', '..', '..', 'check-physical-devices.sh');
+
+test('M9: check-physical-devices.sh exists and is executable', () => {
+  const stats = statSync(SCRIPT_PATH);
+  assert.ok(stats.isFile(), 'script must be a file');
+  assert.ok((stats.mode & 0o111) !== 0, 'script must have executable bit set');
+});
+
+test('M9: script has bash shebang', () => {
+  const content = readFileSync(SCRIPT_PATH, 'utf-8');
+  assert.match(content.split('\n')[0], /^#!\/usr\/bin\/env bash/);
+});
+
+test('M9: script probes adb devices + runs adb reverse on port 8081', () => {
+  const content = readFileSync(SCRIPT_PATH, 'utf-8');
+  assert.match(content, /adb devices/, 'must probe adb devices');
+  assert.match(content, /adb .* reverse tcp:8081 tcp:8081/, 'must run adb reverse for port 8081');
+});
+
+test('M9: script filters out emulators (only physical Android)', () => {
+  const content = readFileSync(SCRIPT_PATH, 'utf-8');
+  // The filter pattern excludes "emulator-" prefixed device IDs.
+  assert.match(content, /emulator-/, 'must mention the emulator prefix it is filtering out');
+});
+
+test('M9: script uses xcrun xctrace for iOS physical detection', () => {
+  const content = readFileSync(SCRIPT_PATH, 'utf-8');
+  assert.match(content, /xcrun xctrace list devices/, 'must probe xcrun xctrace');
+});
+
+test('M9: script filters iOS devices positively (iPhone/iPad/etc) to exclude Mac host', () => {
+  const content = readFileSync(SCRIPT_PATH, 'utf-8');
+  // Must positively match iOS form factors so the Mac listed under "== Devices ==" is skipped.
+  assert.match(content, /iPhone/, 'must filter for iPhone');
+  assert.match(content, /iPad/, 'must filter for iPad');
+});
+
+test('M9: script checks for idb-companion or idb_companion', () => {
+  const content = readFileSync(SCRIPT_PATH, 'utf-8');
+  // Both underscore and dash forms exist across idb installs — accept either.
+  assert.match(content, /idb[-_]companion/, 'must check for idb-companion presence');
+  assert.match(content, /brew install idb-companion/, 'must hint the brew install command when missing');
+});
+
+test('M9: script documents WiFi-debugging non-support stance', () => {
+  const content = readFileSync(SCRIPT_PATH, 'utf-8');
+  assert.match(content, /WiFi/, 'must mention WiFi');
+  assert.match(content, /not supported/i, 'must declare WiFi is not supported automatically');
+});

--- a/scripts/check-physical-devices.sh
+++ b/scripts/check-physical-devices.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# M9 / Phase 111 (D668): physical-device prerequisite probe.
+#
+# Detects USB-connected physical devices and applies (or suggests) the
+# configuration metro-mcp flags as top-3 troubleshooting issues:
+#   - Physical Android: `adb reverse tcp:8081 tcp:8081` so the device can
+#     reach Metro running on the Mac.
+#   - Physical iOS: `idb-companion` installed (required for idb-based tools).
+#
+# No-op when only simulators/emulators are running. Exits 0 in all cases —
+# this is an advisory probe, not a gate. Output goes to stdout for the
+# /setup skill to parse/summarize.
+#
+# WiFi debugging is not supported automatically — users must connect by
+# USB. We do treat `adb connect`'d devices as physical for adb reverse
+# purposes since the command works the same across transports.
+
+set -uo pipefail
+
+# --- Host OS ---
+# The iOS probe uses xcrun (macOS-only). Linux/WSL hosts have no way to
+# connect physical iOS devices, so we report the OS context up-front.
+# Android is cross-platform (adb works on Linux/Windows too).
+HOST_OS=$(uname -s 2>/dev/null || echo "Unknown")
+echo "Host OS: $HOST_OS"
+
+# --- Physical Android ---
+# `adb devices` lists every transport-available device. Emulator entries
+# start with "emulator-"; physical USB + `adb connect`'d devices do not.
+# Filter out emulators so we only operate on real hardware.
+PHYSICAL_ANDROID=""
+if command -v adb >/dev/null 2>&1; then
+  PHYSICAL_ANDROID=$(adb devices 2>/dev/null \
+    | awk '/\tdevice$/ && $1 !~ /^emulator-/ {print $1}' || true)
+fi
+
+if [ -n "${PHYSICAL_ANDROID:-}" ]; then
+  echo "Physical Android detected: $(echo "$PHYSICAL_ANDROID" | tr '\n' ' ')"
+  for dev in $PHYSICAL_ANDROID; do
+    if adb -s "$dev" reverse tcp:8081 tcp:8081 >/dev/null 2>&1; then
+      echo "  [OK] adb reverse tcp:8081 tcp:8081 on $dev"
+    else
+      echo "  [FAIL] adb reverse on $dev — device may not be authorized (check for USB-debug dialog on phone)"
+    fi
+  done
+else
+  echo "No physical Android devices detected (skipping adb reverse)"
+fi
+
+# --- Physical iOS ---
+# `xcrun xctrace list devices` is the canonical source on macOS.
+# Output has a "== Devices ==" section for physical iOS distinct from
+# "== Simulators ==". Awk extracts just the physical block.
+PHYSICAL_IOS=""
+if [ "$HOST_OS" != "Darwin" ]; then
+  echo "Physical iOS probe skipped (requires macOS; host is $HOST_OS)"
+elif command -v xcrun >/dev/null 2>&1; then
+  # xctrace's "== Devices ==" includes the host Mac itself (for Mac Catalyst
+  # targeting). Filter positively on iOS form factors so the host doesn't get
+  # mistaken for a connected iPhone/iPad.
+  PHYSICAL_IOS=$(xcrun xctrace list devices 2>/dev/null \
+    | awk '/^== Devices ==$/{flag=1; next} /^== /{flag=0} flag && NF>0' \
+    | grep -E '(iPhone|iPad|iPod|Apple TV|Apple Vision|Apple Watch)' || true)
+fi
+
+if [ -n "${PHYSICAL_IOS:-}" ]; then
+  echo "Physical iOS detected:"
+  echo "$PHYSICAL_IOS" | sed 's/^/  /'
+  # idb ships the binary as idb_companion on some installs, idb-companion on
+  # others. Check both; either satisfies the prerequisite.
+  if command -v idb_companion >/dev/null 2>&1 || command -v idb-companion >/dev/null 2>&1; then
+    echo "  [OK] idb-companion installed"
+  else
+    echo "  [MISSING] idb-companion — install with: brew install idb-companion"
+  fi
+elif [ "$HOST_OS" = "Darwin" ]; then
+  echo "No physical iOS devices detected (skipping idb-companion check)"
+fi
+
+echo ""
+echo "Note: WiFi debugging is not supported automatically. Use USB connections."

--- a/skills/rn-setup/SKILL.md
+++ b/skills/rn-setup/SKILL.md
@@ -107,6 +107,26 @@ command -v ffmpeg && ffmpeg -version 2>&1 | head -1
 ```
 If missing: `brew install ffmpeg` (not critical — videos work without it, GIF conversion doesn't)
 
+### 10. Physical device prerequisites (optional — M9 / Phase 111)
+
+Only runs if a physical device is USB-connected. Simulators/emulators skip
+this section. Runs two checks + applies one (safe, reversible) side-effect:
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-physical-devices.sh
+```
+
+Expected outputs:
+- **Physical Android present**: `[OK] adb reverse tcp:8081 tcp:8081` — device can reach Metro over USB. Auto-applied; no user action needed.
+- **Physical iOS present + idb-companion installed**: `[OK] idb-companion installed`.
+- **Physical iOS present but idb-companion missing**: `[MISSING] idb-companion — install with: brew install idb-companion`. Not auto-run (brew installs are slow and can fail mid-flight); user runs the command.
+- **No physical devices**: two "skipping" lines. Add "Physical devices" row to the table as "N/A (no devices connected)".
+
+**WiFi debugging is not supported** automatically. Connect by USB. If users
+need WiFi they can `adb connect <ip>` manually — the script then treats the
+device as physical and runs `adb reverse` over the TCP transport (works
+the same as USB).
+
 ## Output format
 
 Present results as a table:
@@ -122,6 +142,7 @@ Present results as a table:
 | Metro | RUNNING (port 8081) | — |
 | CDP connection | CONNECTED | — |
 | ffmpeg | OK (v7.1) | — |
+| Physical devices | N/A (none connected) OR "Android USB reverse: OK" / "iOS: idb-companion missing — install with brew" | Run installed command if iOS-companion missing |
 
 If any critical check fails (CDP bridge, agent-device, Metro, or simulator),
 provide step-by-step instructions to fix it. Do not proceed with feature
@@ -144,7 +165,7 @@ Setup is boring — agents skip it and pay for it later.
 | "The SessionStart banner says 'WARNING: agent-device not installed' — it'll auto-install next time" | Auto-install already ran and FAILED. That's why there's a warning. Run the ensure script NOW and read the actual error. |
 | "I'll skip the Metro check — I'll start it later when I need it" | Without Metro, `cdp_status` fails, Phase 5.5 fails, and the whole pipeline stops. Start Metro FIRST. |
 | "The user can install agent-device themselves" | They ran `/rn-dev-agent:setup` expecting guidance. Give them the exact command with the flag they need (sudo? nvm? permission fix?). |
-| "I'll proceed with the feature — setup can be done in parallel" | No. Feature development depends on all 9 checks passing. Get the environment green first, then proceed. |
+| "I'll proceed with the feature — setup can be done in parallel" | No. Feature development depends on all 10 checks passing (step 10 is optional — N/A when no physical device). Get the environment green first, then proceed. |
 
 ## Red Flags — Stop and Reconsider
 
@@ -152,7 +173,7 @@ Setup is boring — agents skip it and pay for it later.
 - Proceeding with feature dev when setup shows any RED row
 - Suggesting `sudo npm install -g` without first checking if nvm is available
 - Ignoring "WARNING: not installed" from the SessionStart banner
-- Claiming "setup passed" without showing the 9-row table with evidence
+- Claiming "setup passed" without showing the 10-row table with evidence (row 10 may be "N/A" when no physical device is connected — that's still evidence)
 
 ## Verification — Setup Complete When
 
@@ -163,4 +184,5 @@ Setup is boring — agents skip it and pay for it later.
 - [ ] At least ONE of: iOS simulator booted OR Android emulator running
 - [ ] `curl -s http://127.0.0.1:8081/status` returns `packager-status:running`
 - [ ] `cdp_status` returns `ok:true` with `cdp.connected: true`
-- [ ] Present the 9-row results table to the user — no hidden failures
+- [ ] Physical-device row is `N/A (no devices)` OR reports `adb reverse: OK` / `idb-companion: OK or install hint` (M9 / D668)
+- [ ] Present the 10-row results table to the user — no hidden failures


### PR DESCRIPTION
## Summary

Closes Phase 90 Tier 4 **Story M9**. Extends `/rn-dev-agent:setup` to detect USB-connected physical devices and apply the required prerequisites from metro-mcp's top-3 troubleshooting list. Auto-runs `adb reverse tcp:8081 tcp:8081` on each physical Android. Checks for `idb-companion` on physical iOS and prints `brew install idb-companion` when missing. Declares WiFi debugging as not supported automatically.

**MCP server UNCHANGED** — first story in this Phase 90 batch where only the plugin version bumps. Plugin 0.40.0 → 0.41.0. MCP stays at 0.35.0.

## Why

Users developing on physical hardware hit two silent friction points:
1. Physical Android can't reach Metro running on the Mac without `adb reverse tcp:8081 tcp:8081`. Previously undocumented in `/setup`.
2. Physical iOS needs `idb-companion` for idb-based interaction tools. Install path (`brew install`) wasn't surfaced anywhere.

metro-mcp's troubleshooting doc lists both as top-3 issues. M9 surfaces them inline at setup time.

## Scope

| File | Change |
|---|---|
| NEW `scripts/check-physical-devices.sh` (executable) | ~90-line OS-aware bash probe. Android: `adb devices` filtered by `emulator-` prefix exclusion → auto-run `adb reverse` per device. iOS (Darwin-gated): `xcrun xctrace list devices` + awk section extract + positive form-factor filter (iPhone/iPad/iPod/Apple TV/Apple Vision/Apple Watch) to exclude Mac host → check `idb_companion`/`idb-companion` on PATH. |
| `skills/rn-setup/SKILL.md` | New section 10 "Physical device prerequisites (optional)" + output table row + "9 checks"/"9-row" language updated to "10" in 3 places + new Verification checklist entry. |
| NEW `scripts/cdp-bridge/test/unit/physical-devices-script-guard.test.js` | 8 structural guards (exists + executable, shebang, expected probes, emulator filter, form-factor filter, idb-companion variants + brew hint, WiFi stance). |
| Versions | plugin 0.40.0 → 0.41.0. MCP unchanged. |

## Design decisions

- **Auto-run `adb reverse`** — safe, idempotent, per-device port-forward. User opted into `/setup` expecting configuration changes.
- **Do NOT auto-install `idb-companion`** — brew installs are slow and can fail mid-flight. Hint-only matches how other missing deps are handled in this skill.
- **Positive form-factor filter on iOS** — `xcrun xctrace list devices` surfaces the host Mac under `== Devices ==` for Mac Catalyst. Negative-filter "not Mac" approach would miss new iOS-family devices (e.g., Apple Vision Pro shipped after initial designs); positive approach adds a token per new form factor.
- **OS guard for iOS branch** — Linux/WSL hosts get an explicit "Physical iOS probe skipped (requires macOS)" rather than the misleading "No physical iOS detected."
- **WiFi debugging unsupported** — matches metro-mcp. Users can `adb connect <ip>` manually; the script treats such devices as physical and runs `adb reverse` over TCP transport (functionally equivalent to USB for port-forwarding).

## Live smoke

On dev machine with no physical devices connected:

\`\`\`
Host OS: Darwin
No physical Android devices detected (skipping adb reverse)
No physical iOS devices detected (skipping idb-companion check)

Note: WiFi debugging is not supported automatically. Use USB connections.
\`\`\`

**First run revealed a bug**: initial version misreported the MacBook itself as a "physical iOS device" because `xcrun xctrace list devices` lists the host Mac under `== Devices ==` for Mac Catalyst targeting. Fixed with positive form-factor grep; re-ran reports correctly.

## Tests

541 → **549 passing**, 0 failures. +8 structural guards:

\`\`\`
✔ M9: check-physical-devices.sh exists and is executable
✔ M9: script has bash shebang
✔ M9: script probes adb devices + runs adb reverse on port 8081
✔ M9: script filters out emulators (only physical Android)
✔ M9: script uses xcrun xctrace for iOS physical detection
✔ M9: script filters iOS devices positively (iPhone/iPad/etc) to exclude Mac host
✔ M9: script checks for idb-companion or idb_companion
✔ M9: script documents WiFi-debugging non-support stance
\`\`\`

No `bats`/shell-test framework dependency. Structural tests pin invariants; live smoke during every `/setup` invocation is the functional test.

## Review

Multi-LLM (Gemini + Codex).

- **Gemini**: 0 high-confidence findings. Validated: awk section filter correct against live xctrace output (handles "== Devices Offline ==" and name-mid-line `== ` cases); adb reverse idempotent; form-factor regex matches prefix-style names ("Apple TV HD"); plugin-only version bump consistent with D534 sync policy.
- **Codex**: 2 findings, **both applied inline**.
  - **Confidence 90**: stale "9 checks" / "9-row" copy in SKILL.md. Fixed in 3 places + added physical-device entry to Verification checklist.
  - **Confidence 85**: no OS guard meant Linux/WSL hosts silently skipped iOS without context. Fixed with `HOST_OS` probe + explicit skip message.

## Test plan

- [x] `cd scripts/cdp-bridge && npm test` → 549 passing, 0 failures
- [x] `bash scripts/check-physical-devices.sh` live-smoked on dev machine — correct behavior with no devices + Host OS surfaced
- [ ] **Manual smoke with physical device** (optional, on any user with hardware): connect a USB Android → expect `[OK] adb reverse tcp:8081 tcp:8081 on <device-id>`. Connect a USB iPhone → expect either `[OK] idb-companion installed` or the brew install hint.

## Known limits

- `adb reverse` is a side effect — idempotent but stateful. Documented as expected setup behavior.
- `idb-companion` not auto-installed (hint-only).
- WiFi debugging not supported automatically.
- Structural-only tests (no shell-test framework).

## Refs

- D668 in `rn-dev-agent-workspace/docs/DECISIONS.md`
- Phase 111 in `rn-dev-agent-workspace/docs/ROADMAP.md`
- Proof: `rn-dev-agent-workspace/docs/proof/m9-setup-physical-device/`
- metro-mcp reference: troubleshooting "Physical Device Setup" section