### PR TITLE
feat(m6/phase-112): Object.freeze test recorder (D669)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.41.0",
+      "version": "0.42.0",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.42.0] — 2026-04-22
+
+M6 / Phase 112 — Object.freeze test recorder. Closes the **last remaining Phase 90 metro-mcp pattern-adoption story**. Adds a new `cdp_record_test_*` tool family (7 tools) that records real user interactions on the running app and emits replayable Maestro YAML or Detox JS — without any app code changes. Bumps MCP server to 0.36.0 (new tools). All Phase 90 Tier 3 + Tier 4 (M6-M11) now shipped.
+
+### How it works
+React's `createElement` calls `Object.freeze(props)` in dev mode before sealing them. `cdp_record_test_start` monkey-patches `Object.freeze` inside Hermes — when React asks to freeze a props object that has `onPress`/`onLongPress`/`onChangeText`/`onSubmitEditing`/`onScroll*`, we wrap each handler with event-emission BEFORE letting the freeze proceed. Already-mounted scroll containers are caught via a fiber re-render walk (`stateNode.forceUpdate()` for class, `renderer.overrideProps(fiber, ['__mcpInit'], 1)` for function). Route is captured via the `onCommitFiberRoot` hook reading `__RN_AGENT.getNavState()`, cached into a closure variable so the Object.freeze hot-path stays synchronous.
+
+### Three deliberate deviations from metro-mcp's reference
+1. **Finger-direction swipe semantics** — `dy > 0` (contentOffset increased; finger went UP) emits `direction: 'up'`, matching Maestro's `swipeUp` and Detox's `.swipe('up')`. metro-mcp emits the inverted content-delta direction, producing YAML that replays in the wrong direction.
+2. **500-event cap with priority eviction** — long sessions are capped; on overflow, oldest `swipe`/`type` events are dropped first (taps + navigates carry higher information value). `truncated: true` bubbles up to the `stop` envelope.
+3. **Route caching via the commit hook** — eliminates per-event CDP round-trips. metro-mcp expects the user app to install `globalThis.__METRO_MCP_NAV_REF__`; we instead read our existing `__RN_AGENT.getNavState()` once per React commit and cache the active route name in the IIFE closure.
+
+### Added
+- **NEW `scripts/cdp-bridge/src/cdp/test-recorder-helpers.ts`** — five injected JS string constants (`DEV_CHECK_JS`, `START_RECORDING_JS`, `STOP_RECORDING_JS`, `READ_EVENTS_JS`, `buildAnnotationJs(note)` template). The Object.freeze interceptor IIFE is ~250 lines, mirrors metro-mcp's structure with the deviations above. Includes the M8 1..5 renderer-loop port for fiber root resolution and a session-token (`__METRO_MCP_REC_SESSION__`) so stale wrappers from a prior start-stop cycle gracefully no-op when a new session begins.
+- **NEW `scripts/cdp-bridge/src/tools/test-recorder.ts`** — 7 handler factories (`createRecordTestStartHandler`, `createRecordTestStopHandler`, `createRecordTestGenerateHandler`, `createRecordTestAnnotateHandler`, `createRecordTestSaveHandler`, `createRecordTestLoadHandler`, `createRecordTestListHandler`), the `RecordedEvent` discriminated union, module-level `storedEvents` state, and pure helpers (`deduplicateEvents`, `sanitizeFilename`, `getRecordingsDir`, `typeCounts`). Test-only DI hooks (`_resetState`, `_setStoredEvents`, `_getStoredEvents`) for hermetic integration tests.
+- **NEW `scripts/cdp-bridge/src/tools/test-recorder-generators.ts`** — `generateMaestro` + `generateDetox` + selector helpers (`maestroSelector`, `detoxSelector`, `nextSelector`). All user-controlled string interpolation (annotations, testName, bundleId, route names) goes through `stripNewlines()` to prevent comment-context escape (Gemini/Codex review).
+- **7 new tools registered in `src/index.ts`**: `cdp_record_test_start`, `cdp_record_test_stop`, `cdp_record_test_generate`, `cdp_record_test_annotate`, `cdp_record_test_save`, `cdp_record_test_load`, `cdp_record_test_list`. Storage location: `<projectRoot>/.rn-agent/recordings/<sanitized>.json`. Appium format accepted in zod schema but returns `NOT_IMPLEMENTED` at runtime — Maestro + Detox cover our use cases.
+- **11 new error codes** in `ToolErrorCode` (`DEV_MODE_REQUIRED`, `EVAL_FAILED`, `BAD_RESPONSE`, `START_FAILED`, `NO_EVENTS`, `NOT_IMPLEMENTED`, `NOT_RECORDING`, `NO_PROJECT_ROOT`, `BAD_FILENAME`, `LOAD_FAILED`, `BAD_RECORDING`).
+- **`__HELPERS_VERSION__` 15 → 16** in `injected-helpers.ts` to invalidate cached helpers on devices that connected before this release.
+
+### Tests
+Running total: 549 → **605 passing**, zero failures. **+56 M6 tests** across 5 files:
+- `test-recorder-deduplicate.test.js` (6) — type/tap collision rules
+- `test-recorder-storage.test.js` (5) — sanitizeFilename, getRecordingsDir
+- `test-recorder-generators.test.js` (15) — Maestro YAML + Detox JS output snapshots, swipe direction semantic, newline sanitization regression
+- `test-recorder-js-guard.test.js` (14) — structural invariants of the injected JS strings (Object.freeze override, cleanup, session token, 1..5 renderer loop, eviction policy, all 7 handler names, fiber re-render walk, finger-direction comment)
+- `test-recorder-integration.test.js` (15) — handler-level mock-CDP round-trips including DEV gate, start→stop→generate flow, save→load round-trip, NO_EVENTS / NOT_IMPLEMENTED / LOAD_FAILED error paths
+
+### Review
+Multi-LLM (Gemini + Codex). Three high-confidence findings, all applied inline before commit:
+- **Codex (conf 95) + Gemini (conf 90)** — newline injection in generators. Annotation `note`, `testName`, `bundleId`, and route names are user-controlled strings interpolated into single-line YAML/JS comments. A multi-line note (`"reached checkout\nstep:malicious"`) escapes the comment context and either corrupts Maestro YAML (stray top-level mapping) or executes arbitrary JS in Detox tests. Fix: `stripNewlines()` helper in generators applied at every interpolation site, plus regression tests asserting attack strings stay inside comments.
+- **Codex (conf 85)** — Detox `submit` fallback used `device.pressBack()` which is Android-only and semantically wrong (back button vs return key). Fix: replaced with `// submit: missing testID/label — replay manually` comment.
+- **Gemini (conf 80)** — start-stop-start within a single MCP process leaves stale wrappers on already-frozen props from session 1. Their captured `__currentRoute` closure is stale in session 2 and they emit events with wrong route. Fix: session token (`globalThis.__METRO_MCP_REC_SESSION__` + closure-captured `sessionId`); each wrapper checks the current global token against its captured token before emitting. Stale wrappers from prior sessions silently call through to the original handler without recording.
+
+### Notes for users
+- This is a Dev Client / dev-mode feature only. Calling `cdp_record_test_start` on a release build returns `DEV_MODE_REQUIRED` (release builds pre-freeze props at Metro bundling time, so the interceptor can never fire).
+- Recordings are stored project-locally (`<projectRoot>/.rn-agent/recordings/`) — commit them with feature branches or `.gitignore` the directory if you prefer ephemeral recording.
+- The existing `maestro_generate` (replay-based, no recording required) stays available for the case where you already know the steps.
+
 ## [0.41.0] — 2026-04-22
 
 M9 / Phase 111 — `/rn-dev-agent:setup` now detects USB-connected physical devices and applies (or hints at) the required prerequisites. Closes the Phase 90 Tier 4 M9 story. Auto-runs `adb reverse tcp:8081 tcp:8081` on each physical Android so the device can reach Metro. Checks for `idb-companion` on physical iOS and prints `brew install idb-companion` when missing. Documents WiFi-debugging as unsupported (matching metro-mcp's stance).

--- a/scripts/cdp-bridge/dist/cdp/test-recorder-helpers.js
+++ b/scripts/cdp-bridge/dist/cdp/test-recorder-helpers.js
@@ -1,0 +1,335 @@
+// M6 / Phase 112 (D669): test-recorder injected JS strings.
+//
+// Object.freeze interceptor that captures user-invoked handlers (onPress,
+// onLongPress, onChangeText, onSubmitEditing, onScroll*) at the moment React
+// freezes their props inside createElement. Adapted from metro-mcp
+// (src/plugins/test-recorder.ts) with three deliberate deviations:
+//
+//   1. Finger-direction swipes (NOT metro-mcp's content-delta semantic).
+//      contentOffset.y INCREASING means the user's finger swiped UP (content
+//      scrolled UP through the viewport) — this is what Maestro's `swipeUp`
+//      and Detox's `.swipe('up')` mean. metro-mcp emits the content-delta
+//      direction which produces inverted YAML when replayed.
+//
+//   2. 500-event cap with priority eviction. Long sessions on scroll-heavy
+//      screens can produce tens of thousands of events. We cap at 500 and
+//      drop the oldest scroll/type pair on overflow (taps + navigates carry
+//      higher information value). The `globalThis.__METRO_MCP_REC_TRUNCATED__`
+//      flag bubbles up to `cdp_record_test_stop`'s envelope.
+//
+//   3. Route caching via the commit hook closure. metro-mcp expects the user
+//      app to install `globalThis.__METRO_MCP_NAV_REF__`. We instead read
+//      `__RN_AGENT.getNavState()` inside our `onCommitFiberRoot` patch (which
+//      we install for navigate-event tracking anyway) and cache the active
+//      route into a closure variable. The Object.freeze hot-path reads the
+//      cached variable synchronously — zero CDP round-trips per event.
+//      Mirrored to `globalThis.__METRO_MCP_NAV_REF_CACHE__` so the annotation
+//      JS can reference the same value from a separate IIFE.
+//
+// Gating: cdp_record_test_start probes `__DEV__` first via DEV_CHECK_JS.
+// Release builds pre-freeze props at Metro bundling time so the interceptor
+// can never fire — better to fail fast than silently record nothing.
+export const DEV_CHECK_JS = `(typeof __DEV__ !== 'undefined' && __DEV__ === true)`;
+export const READ_EVENTS_JS = `JSON.stringify({
+  active: !!globalThis.__METRO_MCP_REC_ACTIVE__,
+  truncated: !!globalThis.__METRO_MCP_REC_TRUNCATED__,
+  events: globalThis.__METRO_MCP_REC_EVENTS__ || []
+})`;
+export const START_RECORDING_JS = `(function() {
+  var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  if (!hook || !hook.getFiberRoots) {
+    return JSON.stringify({ ok: false, error: 'React DevTools hook not present' });
+  }
+
+  if (globalThis.__METRO_MCP_REC_ACTIVE__) {
+    return JSON.stringify({ ok: true, alreadyRunning: true, activeRoute: globalThis.__METRO_MCP_NAV_REF_CACHE__ || null });
+  }
+
+  globalThis.__METRO_MCP_REC_EVENTS__ = [];
+  globalThis.__METRO_MCP_REC_ACTIVE__ = true;
+  globalThis.__METRO_MCP_REC_TRUNCATED__ = false;
+  globalThis.__METRO_MCP_NAV_REF_CACHE__ = null;
+
+  // Session token: protects against stale wrappers from a previous start-stop
+  // cycle. Frozen props can't be mutated to clear obj.__mcpRecSession after
+  // cleanup, so wrappers from session 1 still call when session 2 begins.
+  // Each wrapper checks this token against the current global before pushing.
+  var sessionId = String(Date.now()) + '_' + Math.random().toString(36).slice(2);
+  globalThis.__METRO_MCP_REC_SESSION__ = sessionId;
+
+  var MAX_EVENTS = 500;
+  var __currentRoute = null;
+
+  // Cap-with-eviction: drop oldest scroll/type pair before pushing #501.
+  // Falls back to FIFO if no evictable event exists (all taps + navigates).
+  function pushEvent(ev) {
+    var evts = globalThis.__METRO_MCP_REC_EVENTS__;
+    if (evts.length >= MAX_EVENTS) {
+      var evicted = false;
+      for (var i = 0; i < evts.length; i++) {
+        if (evts[i].type === 'swipe' || evts[i].type === 'type') {
+          evts.splice(i, 1);
+          evicted = true;
+          break;
+        }
+      }
+      if (!evicted) evts.shift();
+      globalThis.__METRO_MCP_REC_TRUNCATED__ = true;
+    }
+    evts.push(ev);
+  }
+
+  // Walk a React Navigation state object to its leaf route.
+  function extractActiveRoute(state) {
+    try {
+      var s = state;
+      var depth = 0;
+      while (s && depth < 20) {
+        if (typeof s.index === 'number' && Array.isArray(s.routes)) {
+          var r = s.routes[s.index];
+          if (!r) return null;
+          if (r.state) { s = r.state; depth++; continue; }
+          return r.name || null;
+        }
+        return null;
+      }
+    } catch (e) {}
+    return null;
+  }
+
+  function readCurrentRoute() {
+    try {
+      if (globalThis.__RN_AGENT && globalThis.__RN_AGENT.getNavState) {
+        var raw = globalThis.__RN_AGENT.getNavState();
+        if (typeof raw === 'string') {
+          var parsed = JSON.parse(raw);
+          return extractActiveRoute(parsed);
+        }
+      }
+    } catch (e) {}
+    return null;
+  }
+
+  // --- Object.freeze interceptor (hot path) ---
+  // React's createElement calls Object.freeze on the props object before
+  // returning. We wrap matching handlers BEFORE the freeze so the wrapped
+  // versions become the frozen ones. Idempotent via obj.__mcpRec.
+  var origFreeze = Object.freeze;
+  Object.freeze = function(obj) {
+    if (globalThis.__METRO_MCP_REC_ACTIVE__ && obj && typeof obj === 'object' && !Array.isArray(obj) && !obj.__mcpRec) {
+      var tid = obj.testID || null;
+      var lbl = obj.accessibilityLabel || obj['aria-label'] || null;
+      var wrapped = false;
+
+      if (typeof obj.onPress === 'function') {
+        var op = obj.onPress;
+        obj.onPress = function(e) {
+          if (globalThis.__METRO_MCP_REC_ACTIVE__ && globalThis.__METRO_MCP_REC_SESSION__ === sessionId) {
+            pushEvent({ type: 'tap', testID: tid, label: lbl, route: __currentRoute, t: Date.now() });
+          }
+          return op.call(this, e);
+        };
+        wrapped = true;
+      }
+      if (typeof obj.onLongPress === 'function') {
+        var olp = obj.onLongPress;
+        obj.onLongPress = function(e) {
+          if (globalThis.__METRO_MCP_REC_ACTIVE__ && globalThis.__METRO_MCP_REC_SESSION__ === sessionId) {
+            pushEvent({ type: 'long_press', testID: tid, label: lbl, route: __currentRoute, t: Date.now() });
+          }
+          return olp.call(this, e);
+        };
+        wrapped = true;
+      }
+      if (typeof obj.onChangeText === 'function') {
+        var oct = obj.onChangeText;
+        obj.onChangeText = function(val) {
+          if (globalThis.__METRO_MCP_REC_ACTIVE__ && globalThis.__METRO_MCP_REC_SESSION__ === sessionId) {
+            pushEvent({ type: 'type', testID: tid, label: lbl, value: val, route: __currentRoute, t: Date.now() });
+          }
+          return oct.call(this, val);
+        };
+        wrapped = true;
+      }
+      if (typeof obj.onSubmitEditing === 'function') {
+        var ose = obj.onSubmitEditing;
+        obj.onSubmitEditing = function(e) {
+          if (globalThis.__METRO_MCP_REC_ACTIVE__ && globalThis.__METRO_MCP_REC_SESSION__ === sessionId) {
+            pushEvent({ type: 'submit', testID: tid, label: lbl, route: __currentRoute, t: Date.now() });
+          }
+          return ose.call(this, e);
+        };
+        wrapped = true;
+      }
+
+      // Scroll-container detection: probe for 7 RN ScrollView-specific props.
+      // 'in' (not !== undefined) catches props explicitly set to undefined.
+      var isScrollable =
+        'scrollEventThrottle'            in obj ||
+        'extraScrollHeight'              in obj ||
+        'showsVerticalScrollIndicator'   in obj ||
+        'showsHorizontalScrollIndicator' in obj ||
+        'keyboardShouldPersistTaps'      in obj ||
+        'keyboardDismissMode'            in obj ||
+        'scrollEnabled'                  in obj ||
+        typeof obj.onScrollBeginDrag === 'function' ||
+        typeof obj.onScrollEndDrag   === 'function';
+      if (isScrollable) {
+        var scrollStart = { x: null, y: null };
+        var origBegin       = obj.onScrollBeginDrag   || null;
+        var origEnd         = obj.onScrollEndDrag     || null;
+        var origMomentumEnd = obj.onMomentumScrollEnd || null;
+        obj.onScrollBeginDrag = function(e) {
+          scrollStart.x = e.nativeEvent.contentOffset.x;
+          scrollStart.y = e.nativeEvent.contentOffset.y;
+          if (origBegin) origBegin.call(this, e);
+        };
+        var emitSwipeIfMoved = function(e) {
+          if (scrollStart.x !== null && globalThis.__METRO_MCP_REC_ACTIVE__) {
+            var dx = e.nativeEvent.contentOffset.x - scrollStart.x;
+            var dy = e.nativeEvent.contentOffset.y - scrollStart.y;
+            if (Math.abs(dx) > 5 || Math.abs(dy) > 5) {
+              // Finger-direction (NOT metro-mcp's content-delta — see header).
+              // dy>0: contentOffset increased → finger went UP → 'up'.
+              var dir = Math.abs(dx) > Math.abs(dy)
+                ? (dx > 0 ? 'left'  : 'right')
+                : (dy > 0 ? 'up'    : 'down');
+              var evts = globalThis.__METRO_MCP_REC_EVENTS__;
+              var last = evts[evts.length - 1];
+              if (!(last && last.type === 'swipe' && Date.now() - last.t < 100)) {
+                pushEvent({ type: 'swipe', direction: dir, testID: tid, route: __currentRoute, t: Date.now() });
+              }
+            }
+            scrollStart.x = null;
+          }
+        };
+        obj.onScrollEndDrag = function(e) {
+          emitSwipeIfMoved(e);
+          if (origEnd) origEnd.call(this, e);
+        };
+        obj.onMomentumScrollEnd = function(e) {
+          emitSwipeIfMoved(e);
+          if (origMomentumEnd) origMomentumEnd.call(this, e);
+        };
+        wrapped = true;
+      }
+      if (wrapped) obj.__mcpRec = true;
+    }
+    return origFreeze.call(this, obj);
+  };
+
+  // --- Re-render walk for already-mounted scroll containers ---
+  // Object.freeze only fires on FUTURE renders. Existing ScrollViews missed
+  // the interceptor. Force-render them so their props go through Object.freeze
+  // again. M8 pattern: 1..5 renderer loop for fiber root resolution.
+  (function() {
+    var renderer = null;
+    try {
+      hook.renderers.forEach(function(r) { if (!renderer) renderer = r; });
+    } catch (e) {}
+
+    function isScrollFiber(fiber) {
+      var cn = typeof fiber.type === 'string'
+        ? fiber.type
+        : (fiber.type && (fiber.type.displayName || fiber.type.name)) || '';
+      if (cn === 'ScrollView' || cn === 'FlatList' || cn === 'SectionList' ||
+          cn === 'VirtualizedList' || cn === 'FlashList' || cn === 'BigList' ||
+          cn === 'RecyclerListView' || cn === 'MasonryFlashList') return true;
+      if (/ScrollView|List/i.test(cn)) return true;
+      var p = fiber.memoizedProps;
+      return !!(p && typeof p === 'object' && (
+        'scrollEventThrottle'            in p || 'extraScrollHeight'              in p ||
+        'showsVerticalScrollIndicator'   in p || 'showsHorizontalScrollIndicator' in p ||
+        'keyboardShouldPersistTaps'      in p || 'keyboardDismissMode'            in p ||
+        'scrollEnabled'                  in p ||
+        typeof p.onScrollBeginDrag === 'function' || typeof p.onScrollEndDrag === 'function'
+      ));
+    }
+
+    var stack = [];
+    for (var ri = 1; ri <= 5; ri++) {
+      var roots = hook.getFiberRoots(ri);
+      if (roots && roots.size > 0) {
+        Array.from(roots).forEach(function(r) { stack.push({ f: r.current, d: 0 }); });
+        break;
+      }
+    }
+    while (stack.length) {
+      var item = stack.pop(); var fiber = item.f; var depth = item.d;
+      if (!fiber || depth > 200) continue;
+      if (isScrollFiber(fiber) && fiber.memoizedProps && !fiber.memoizedProps.__mcpRec) {
+        if (fiber.stateNode && typeof fiber.stateNode.forceUpdate === 'function') {
+          try { fiber.stateNode.forceUpdate(); } catch (e) {}
+        } else if (renderer && renderer.overrideProps) {
+          try { renderer.overrideProps(fiber, ['__mcpInit'], 1); } catch (e) {}
+        }
+      }
+      if (fiber.sibling) stack.push({ f: fiber.sibling, d: depth });
+      if (fiber.child)   stack.push({ f: fiber.child,   d: depth + 1 });
+    }
+  })();
+
+  // --- Commit hook: route cache + navigate events ---
+  // Read the current route on every React commit (cheap relative to freeze
+  // frequency), cache it for the freeze hot-path, and emit a navigate event
+  // when it changes.
+  var origCommit = hook.onCommitFiberRoot;
+  var prevRoute = null;
+  hook.onCommitFiberRoot = function(id, root) {
+    if (globalThis.__METRO_MCP_REC_ACTIVE__ && globalThis.__METRO_MCP_REC_SESSION__ === sessionId) {
+      var route = readCurrentRoute();
+      if (route) {
+        __currentRoute = route;
+        globalThis.__METRO_MCP_NAV_REF_CACHE__ = route;
+        if (prevRoute && prevRoute !== route) {
+          pushEvent({ type: 'navigate', from: prevRoute, to: route, route: route, t: Date.now() });
+        }
+        prevRoute = route;
+      }
+    }
+    if (origCommit) return origCommit.apply(this, arguments);
+  };
+
+  // Seed the route cache with one immediate read so events captured before
+  // the first commit have a chance of getting a route attached.
+  __currentRoute = readCurrentRoute();
+  globalThis.__METRO_MCP_NAV_REF_CACHE__ = __currentRoute;
+  prevRoute = __currentRoute;
+
+  globalThis.__METRO_MCP_REC_CLEANUP__ = function() {
+    globalThis.__METRO_MCP_REC_ACTIVE__ = false;
+    hook.onCommitFiberRoot = origCommit;
+    Object.freeze = origFreeze;
+    delete globalThis.__METRO_MCP_REC_CLEANUP__;
+  };
+
+  return JSON.stringify({ ok: true, alreadyRunning: false, activeRoute: __currentRoute });
+})()`;
+export const STOP_RECORDING_JS = `(function() {
+  try {
+    if (globalThis.__METRO_MCP_REC_CLEANUP__) {
+      globalThis.__METRO_MCP_REC_CLEANUP__();
+    }
+  } catch (e) {}
+  var events = globalThis.__METRO_MCP_REC_EVENTS__ || [];
+  var truncated = !!globalThis.__METRO_MCP_REC_TRUNCATED__;
+  return JSON.stringify({ ok: true, events: events, truncated: truncated });
+})()`;
+// ADD_ANNOTATION_JS is a template — the calling handler interpolates the
+// JSON-stringified note via a plain string concat. Keeping the JS as a string
+// (not a function) lets cdp_evaluate execute it directly.
+export function buildAnnotationJs(note) {
+    return `(function() {
+  if (!globalThis.__METRO_MCP_REC_ACTIVE__) {
+    return JSON.stringify({ ok: false, error: 'Recording is not active' });
+  }
+  var route = globalThis.__METRO_MCP_NAV_REF_CACHE__ || null;
+  globalThis.__METRO_MCP_REC_EVENTS__.push({
+    type: 'annotation',
+    note: ${JSON.stringify(note)},
+    route: route,
+    t: Date.now()
+  });
+  return JSON.stringify({ ok: true });
+})()`;
+}

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -44,6 +44,7 @@ import { Lockfile, formatLockConflictMessage } from './lifecycle/lockfile.js';
 import { createMaestroRunHandler } from './tools/maestro-run.js';
 import { createMaestroGenerateHandler } from './tools/maestro-generate.js';
 import { createMaestroTestAllHandler } from './tools/maestro-test-all.js';
+import { createRecordTestStartHandler, createRecordTestStopHandler, createRecordTestGenerateHandler, createRecordTestAnnotateHandler, createRecordTestSaveHandler, createRecordTestLoadHandler, createRecordTestListHandler, } from './tools/test-recorder.js';
 import { createCrossPlatformVerifyHandler } from './tools/cross-platform-verify.js';
 import { createOpenDevToolsHandler } from './tools/open-devtools.js';
 import { createMetroEventsHandler } from './tools/metro-events.js';
@@ -464,6 +465,24 @@ trackedTool('maestro_test_all', 'Discover and run all Maestro flows in .maestro/
     timeoutPerFlow: z.number().int().min(5000).max(300000).default(120000).describe('Timeout per flow in ms'),
     stopOnFailure: z.boolean().default(false).describe('Stop after first failure'),
 }, createMaestroTestAllHandler());
+// M6 / Phase 112 (D669): Object.freeze test recorder.
+trackedTool('cdp_record_test_start', 'Start recording UI interactions via Object.freeze interceptor. Captures taps, long-presses, text input, submits, and scroll-derived swipes from the running app — no app changes required. Requires __DEV__=true (release builds pre-freeze props at bundle time). Pair with cdp_record_test_stop and cdp_record_test_generate to produce Maestro YAML or Detox JS.', {}, createRecordTestStartHandler(getClient));
+trackedTool('cdp_record_test_stop', 'Stop recording, deduplicate consecutive type/tap bursts, freeze the buffer, and return event count + per-type breakdown. Sets `truncated: true` when the 500-event cap was hit. Recorded events stay in MCP memory for cdp_record_test_generate / cdp_record_test_save until the next start.', {}, createRecordTestStopHandler(getClient));
+trackedTool('cdp_record_test_generate', 'Render the stored recording as replayable test code. Formats: maestro (YAML, primary), detox (JS). Appium returns NOT_IMPLEMENTED — file an issue if you need it. Requires a recording in memory (call start/stop or load first).', {
+    format: z.enum(['maestro', 'detox', 'appium']).describe('Output format'),
+    testName: z.string().optional().describe('Name shown in describe()/comment header'),
+    bundleId: z.string().optional().describe('App bundle ID for the Maestro appId header'),
+}, createRecordTestGenerateHandler());
+trackedTool('cdp_record_test_annotate', 'Push a human-readable note into the live event stream — appears as a comment in generated tests. Useful for marking flow checkpoints ("reached checkout", "error appeared"). Only valid during an active recording.', {
+    note: z.string().min(1).describe('Annotation text'),
+}, createRecordTestAnnotateHandler(getClient));
+trackedTool('cdp_record_test_save', 'Persist current recording events to <projectRoot>/.rn-agent/recordings/<filename>.json. Filename is sanitized (only [a-zA-Z0-9_-] kept). Use cdp_record_test_load to restore later for re-generation in a different format.', {
+    filename: z.string().min(1).describe('Recording name (without .json — sanitized)'),
+}, createRecordTestSaveHandler());
+trackedTool('cdp_record_test_load', 'Restore a previously-saved recording from <projectRoot>/.rn-agent/recordings/. Replaces any in-memory events. After loading, call cdp_record_test_generate to render in any format.', {
+    filename: z.string().min(1).describe('Recording name (without .json)'),
+}, createRecordTestLoadHandler());
+trackedTool('cdp_record_test_list', 'List saved recordings under <projectRoot>/.rn-agent/recordings/. Returns the directory path and an array of recording names (without .json extension), sorted alphabetically.', {}, createRecordTestListHandler());
 trackedTool('cdp_restart', 'In-process soft state reset (B76/D644). Disconnects the current CDP client, creates a fresh instance, and reconnects. Clears console/network/error ring buffers, background poll, reconnect state, and helpers-injected flag. Does NOT reload the MCP server binary — to load new dist/ after npm run build, fully quit and relaunch Claude Code. Useful for recovering from stuck connection state (target drift, stale helpers after many reloads) without losing the CC session.', {
     metroPort: z.number().optional().describe('Override Metro port for reconnection (default: keep current)'),
     platform: z.string().optional().describe('Platform filter for reconnection (e.g. "ios", "android")'),

--- a/scripts/cdp-bridge/dist/injected-helpers.js
+++ b/scripts/cdp-bridge/dist/injected-helpers.js
@@ -1,6 +1,6 @@
 export const INJECTED_HELPERS = `
 (function() {
-  var __HELPERS_VERSION__ = 15;
+  var __HELPERS_VERSION__ = 16;
   if (globalThis.__RN_AGENT && globalThis.__RN_AGENT.__v === __HELPERS_VERSION__) return;
   if (globalThis.__RN_AGENT) delete globalThis.__RN_AGENT;
 

--- a/scripts/cdp-bridge/dist/tools/test-recorder-generators.js
+++ b/scripts/cdp-bridge/dist/tools/test-recorder-generators.js
@@ -1,0 +1,177 @@
+// M6 / Phase 112 (D669): output generators for cdp_record_test_generate.
+//
+// Maestro YAML and Detox JS only — Appium intentionally deferred (rejected at
+// the handler layer with NOT_IMPLEMENTED). Both generators consume the same
+// RecordedEvent[] shape and emit replayable test code.
+// Strip CR/LF from any user-controlled string before interpolating into a
+// single-line comment or scalar position. Without this an annotation like
+// `"reached checkout\nstep:bad"` escapes the comment in both Maestro YAML
+// (`# NOTE: ...` then a stray top-level mapping) and Detox JS (`// NOTE: ...`
+// then an uncommented identifier). Reported by Gemini + Codex review of M6.
+function stripNewlines(s) {
+    if (s == null)
+        return '';
+    return String(s).replace(/[\r\n]+/g, ' ');
+}
+// --- Selector helpers ---
+export function maestroSelector(ev) {
+    const tid = ev.testID;
+    const lbl = ev.label;
+    if (tid)
+        return `id: "${tid}"`;
+    if (lbl)
+        return `id: "${lbl}"`;
+    return null;
+}
+export function detoxSelector(ev) {
+    const tid = ev.testID;
+    const lbl = ev.label;
+    if (tid)
+        return `element(by.id(${JSON.stringify(tid)}))`;
+    if (lbl)
+        return `element(by.label(${JSON.stringify(lbl)}))`;
+    return null;
+}
+// Lookahead helper: after a navigate event we want to assert the new screen
+// rendered. The first selectable event after the navigate (stopping at the
+// next navigate boundary) is our best signal of "screen has loaded".
+export function nextSelector(events, fromIndex, selectorFn) {
+    for (let j = fromIndex + 1; j < events.length; j++) {
+        const ev = events[j];
+        if (ev.type === 'navigate')
+            return null;
+        const sel = selectorFn(ev);
+        if (sel)
+            return sel;
+    }
+    return null;
+}
+// --- Maestro YAML ---
+export function generateMaestro(events, opts = {}) {
+    const lines = [];
+    if (opts.bundleId) {
+        lines.push(`appId: ${stripNewlines(opts.bundleId)}`);
+        lines.push('---');
+    }
+    lines.push(`# ${stripNewlines(opts.testName ?? 'Recorded flow')}`);
+    lines.push('- launchApp');
+    for (let i = 0; i < events.length; i++) {
+        const ev = events[i];
+        switch (ev.type) {
+            case 'tap': {
+                const sel = maestroSelector(ev);
+                if (sel)
+                    lines.push(`- tapOn:\n    ${sel}`);
+                else
+                    lines.push('# tap: missing testID/label');
+                break;
+            }
+            case 'long_press': {
+                const sel = maestroSelector(ev);
+                if (sel)
+                    lines.push(`- longPressOn:\n    ${sel}`);
+                else
+                    lines.push('# long_press: missing testID/label');
+                break;
+            }
+            case 'type': {
+                const sel = maestroSelector(ev);
+                if (sel) {
+                    lines.push(`- tapOn:\n    ${sel}`);
+                    lines.push(`- inputText: ${JSON.stringify(ev.value)}`);
+                }
+                else {
+                    lines.push(`# type: missing testID/label, value=${JSON.stringify(ev.value)}`);
+                }
+                break;
+            }
+            case 'submit':
+                lines.push('- pressKey: Enter');
+                break;
+            case 'swipe': {
+                const dir = ev.direction.charAt(0).toUpperCase() + ev.direction.slice(1);
+                lines.push(`- swipe${dir}`);
+                break;
+            }
+            case 'navigate': {
+                const next = nextSelector(events, i, maestroSelector);
+                lines.push(`# navigated: ${stripNewlines(ev.from ?? '?')} -> ${stripNewlines(ev.to)}`);
+                if (next)
+                    lines.push(`- assertVisible:\n    ${next}`);
+                break;
+            }
+            case 'annotation':
+                lines.push(`# NOTE: ${stripNewlines(ev.note)}`);
+                break;
+        }
+    }
+    return lines.join('\n') + '\n';
+}
+// --- Detox JS ---
+export function generateDetox(events, opts = {}) {
+    const lines = [];
+    const name = stripNewlines(opts.testName ?? 'Recorded flow');
+    lines.push(`describe(${JSON.stringify(name)}, () => {`);
+    lines.push('  beforeAll(async () => { await device.launchApp(); });');
+    lines.push("  it('replays recorded steps', async () => {");
+    for (let i = 0; i < events.length; i++) {
+        const ev = events[i];
+        switch (ev.type) {
+            case 'tap': {
+                const sel = detoxSelector(ev);
+                if (sel)
+                    lines.push(`    await ${sel}.tap();`);
+                else
+                    lines.push('    // tap: missing testID/label');
+                break;
+            }
+            case 'long_press': {
+                const sel = detoxSelector(ev);
+                if (sel)
+                    lines.push(`    await ${sel}.longPress();`);
+                else
+                    lines.push('    // long_press: missing testID/label');
+                break;
+            }
+            case 'type': {
+                const sel = detoxSelector(ev);
+                if (sel)
+                    lines.push(`    await ${sel}.typeText(${JSON.stringify(ev.value)});`);
+                else
+                    lines.push(`    // type: missing testID/label, value=${JSON.stringify(ev.value)}`);
+                break;
+            }
+            case 'submit': {
+                const sel = detoxSelector(ev);
+                if (sel)
+                    lines.push(`    await ${sel}.tapReturnKey();`);
+                else
+                    lines.push('    // submit: missing testID/label — replay manually');
+                break;
+            }
+            case 'swipe': {
+                const sel = detoxSelector(ev);
+                // Detox's .swipe(direction) uses the same finger-direction semantic
+                // as our recorder, so we pass the direction verbatim.
+                if (sel)
+                    lines.push(`    await ${sel}.swipe(${JSON.stringify(ev.direction)});`);
+                else
+                    lines.push(`    await element(by.type('RCTScrollView')).swipe(${JSON.stringify(ev.direction)});`);
+                break;
+            }
+            case 'navigate': {
+                const next = nextSelector(events, i, detoxSelector);
+                lines.push(`    // navigated: ${stripNewlines(ev.from ?? '?')} -> ${stripNewlines(ev.to)}`);
+                if (next)
+                    lines.push(`    await expect(${next}).toBeVisible();`);
+                break;
+            }
+            case 'annotation':
+                lines.push(`    // NOTE: ${stripNewlines(ev.note)}`);
+                break;
+        }
+    }
+    lines.push('  });');
+    lines.push('});');
+    return lines.join('\n') + '\n';
+}

--- a/scripts/cdp-bridge/dist/tools/test-recorder.js
+++ b/scripts/cdp-bridge/dist/tools/test-recorder.js
@@ -1,0 +1,257 @@
+// M6 / Phase 112 (D669): cdp_record_test_* tool family.
+//
+// Seven tools that wrap the Object.freeze interceptor in test-recorder-helpers
+// and produce replayable test code via test-recorder-generators. State is
+// module-level (storedEvents) — MCP is single-client-per-process so we don't
+// need per-session isolation.
+import { okResult, failResult, withConnection } from '../utils.js';
+import { findProjectRoot } from '../nav-graph/storage.js';
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { DEV_CHECK_JS, START_RECORDING_JS, STOP_RECORDING_JS, buildAnnotationJs, } from '../cdp/test-recorder-helpers.js';
+import { generateMaestro, generateDetox, } from './test-recorder-generators.js';
+// --- Module state ---
+// Shared across the 7 tool handlers — reset on start, written on stop, read by
+// generate / save. Test-only setters exposed at the bottom of this file for
+// hermetic integration tests.
+let storedEvents = null;
+let recordingTruncated = false;
+// --- Pure helpers (easy to unit-test) ---
+// Collapse consecutive duplicates: same-testID type bursts keep the latest
+// value; identical-testID taps within 100ms collapse to one. Mirrors
+// metro-mcp's deduplicateEvents but with explicit type guards.
+export function deduplicateEvents(events) {
+    const out = [];
+    for (let i = 0; i < events.length; i++) {
+        const ev = events[i];
+        if (ev.type === 'type') {
+            const next = events[i + 1];
+            if (next?.type === 'type' &&
+                next.testID === ev.testID) {
+                continue;
+            }
+        }
+        if (ev.type === 'tap') {
+            const last = out[out.length - 1];
+            if (last?.type === 'tap' &&
+                last.testID === ev.testID &&
+                ev.t - last.t < 100) {
+                continue;
+            }
+        }
+        out.push(ev);
+    }
+    return out;
+}
+export function sanitizeFilename(name) {
+    return name.replace(/\.json$/i, '').replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+export function getRecordingsDir(rootResolver = findProjectRoot) {
+    const root = rootResolver();
+    if (!root)
+        return null;
+    return join(root, '.rn-agent', 'recordings');
+}
+export function typeCounts(events) {
+    const counts = {};
+    for (const ev of events)
+        counts[ev.type] = (counts[ev.type] ?? 0) + 1;
+    return counts;
+}
+async function probeDev(client) {
+    const r = (await client.evaluate(DEV_CHECK_JS));
+    return r.value === true;
+}
+const DEV_REQUIRED_MSG = 'Recording requires __DEV__=true — release builds pre-freeze props at bundle time and cannot be intercepted';
+export function createRecordTestStartHandler(getClient) {
+    return withConnection(getClient, async (_args, client) => {
+        if (!(await probeDev(client))) {
+            return failResult(DEV_REQUIRED_MSG, 'DEV_MODE_REQUIRED');
+        }
+        const result = (await client.evaluate(START_RECORDING_JS));
+        if (result.error) {
+            return failResult(`Failed to start recording: ${result.error}`, 'EVAL_FAILED');
+        }
+        if (typeof result.value !== 'string') {
+            return failResult('Unexpected response from START_RECORDING_JS — expected JSON string', 'BAD_RESPONSE');
+        }
+        let parsed;
+        try {
+            parsed = JSON.parse(result.value);
+        }
+        catch {
+            return failResult(`Invalid JSON from start: ${String(result.value).slice(0, 200)}`, 'BAD_RESPONSE');
+        }
+        if (!parsed.ok) {
+            return failResult(parsed.error ?? 'start failed', 'START_FAILED');
+        }
+        storedEvents = null;
+        recordingTruncated = false;
+        return okResult({
+            started: true,
+            alreadyRunning: !!parsed.alreadyRunning,
+            activeRoute: parsed.activeRoute ?? null,
+        });
+    });
+}
+export function createRecordTestStopHandler(getClient) {
+    return withConnection(getClient, async (_args, client) => {
+        const result = (await client.evaluate(STOP_RECORDING_JS));
+        if (result.error) {
+            return failResult(`Failed to stop recording: ${result.error}`, 'EVAL_FAILED');
+        }
+        if (typeof result.value !== 'string') {
+            return failResult('Unexpected response from STOP_RECORDING_JS — expected JSON string', 'BAD_RESPONSE');
+        }
+        let parsed;
+        try {
+            parsed = JSON.parse(result.value);
+        }
+        catch {
+            return failResult(`Invalid JSON from stop: ${String(result.value).slice(0, 200)}`, 'BAD_RESPONSE');
+        }
+        const raw = Array.isArray(parsed.events) ? parsed.events : [];
+        storedEvents = deduplicateEvents(raw);
+        recordingTruncated = !!parsed.truncated;
+        return okResult({
+            stopped: true,
+            eventCount: storedEvents.length,
+            truncated: recordingTruncated,
+            typeCounts: typeCounts(storedEvents),
+        });
+    });
+}
+export function createRecordTestGenerateHandler() {
+    return async (args) => {
+        if (!storedEvents || storedEvents.length === 0) {
+            return failResult('No recorded events — call cdp_record_test_start, interact, then cdp_record_test_stop first', 'NO_EVENTS');
+        }
+        if (args.format === 'appium') {
+            return failResult('Appium generator not implemented in M6 — file a GitHub issue if needed', 'NOT_IMPLEMENTED');
+        }
+        const opts = { testName: args.testName, bundleId: args.bundleId };
+        const text = args.format === 'maestro'
+            ? generateMaestro(storedEvents, opts)
+            : generateDetox(storedEvents, opts);
+        return okResult({ format: args.format, eventCount: storedEvents.length, text });
+    };
+}
+export function createRecordTestAnnotateHandler(getClient) {
+    return withConnection(getClient, async (args, client) => {
+        if (!(await probeDev(client))) {
+            return failResult(DEV_REQUIRED_MSG, 'DEV_MODE_REQUIRED');
+        }
+        const result = (await client.evaluate(buildAnnotationJs(args.note)));
+        if (result.error) {
+            return failResult(`Failed to annotate: ${result.error}`, 'EVAL_FAILED');
+        }
+        if (typeof result.value !== 'string') {
+            return failResult('Unexpected response from annotate — expected JSON string', 'BAD_RESPONSE');
+        }
+        let parsed;
+        try {
+            parsed = JSON.parse(result.value);
+        }
+        catch {
+            return failResult(`Invalid JSON from annotate: ${String(result.value).slice(0, 200)}`, 'BAD_RESPONSE');
+        }
+        if (!parsed.ok) {
+            return failResult(parsed.error ?? 'Annotation failed', 'NOT_RECORDING');
+        }
+        return okResult({ annotated: true });
+    });
+}
+export function createRecordTestSaveHandler() {
+    return async (args) => {
+        if (!storedEvents) {
+            return failResult('No events to save — stop a recording first', 'NO_EVENTS');
+        }
+        const dir = getRecordingsDir();
+        if (!dir) {
+            return failResult('Could not resolve project root (no package.json ancestor). Set RN_PROJECT_ROOT env var.', 'NO_PROJECT_ROOT');
+        }
+        await mkdir(dir, { recursive: true });
+        const safe = sanitizeFilename(args.filename);
+        if (!safe) {
+            return failResult('Filename is empty after sanitization', 'BAD_FILENAME');
+        }
+        const filePath = join(dir, `${safe}.json`);
+        const payload = { savedAt: new Date().toISOString(), events: storedEvents };
+        await writeFile(filePath, JSON.stringify(payload, null, 2), 'utf8');
+        return okResult({
+            saved: true,
+            path: filePath,
+            eventCount: storedEvents.length,
+            truncated: recordingTruncated,
+        });
+    };
+}
+export function createRecordTestLoadHandler() {
+    return async (args) => {
+        const dir = getRecordingsDir();
+        if (!dir) {
+            return failResult('Could not resolve project root', 'NO_PROJECT_ROOT');
+        }
+        const safe = sanitizeFilename(args.filename);
+        if (!safe) {
+            return failResult('Filename is empty after sanitization', 'BAD_FILENAME');
+        }
+        const filePath = join(dir, `${safe}.json`);
+        let raw;
+        try {
+            raw = await readFile(filePath, 'utf8');
+        }
+        catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            return failResult(`Could not load ${filePath}: ${msg}`, 'LOAD_FAILED');
+        }
+        let parsed;
+        try {
+            parsed = JSON.parse(raw);
+        }
+        catch {
+            return failResult(`Recording file is not valid JSON: ${filePath}`, 'BAD_RECORDING');
+        }
+        storedEvents = Array.isArray(parsed.events) ? parsed.events : [];
+        recordingTruncated = false;
+        return okResult({
+            loaded: true,
+            path: filePath,
+            savedAt: parsed.savedAt ?? null,
+            eventCount: storedEvents.length,
+            typeCounts: typeCounts(storedEvents),
+        });
+    };
+}
+export function createRecordTestListHandler() {
+    return async () => {
+        const dir = getRecordingsDir();
+        if (!dir) {
+            return failResult('Could not resolve project root', 'NO_PROJECT_ROOT');
+        }
+        let files;
+        try {
+            files = await readdir(dir);
+        }
+        catch {
+            return okResult({ dir, files: [] });
+        }
+        const recordings = files
+            .filter((f) => f.endsWith('.json'))
+            .map((f) => f.replace(/\.json$/, ''))
+            .sort();
+        return okResult({ dir, files: recordings });
+    };
+}
+// --- Test-only DI hooks (named with leading underscore by convention) ---
+export function _setStoredEvents(events, truncated = false) {
+    storedEvents = events;
+    recordingTruncated = truncated;
+}
+export function _getStoredEvents() {
+    return storedEvents;
+}
+export function _resetState() {
+    storedEvents = null;
+    recordingTruncated = false;
+}

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/cdp/test-recorder-helpers.ts
+++ b/scripts/cdp-bridge/src/cdp/test-recorder-helpers.ts
@@ -1,0 +1,340 @@
+// M6 / Phase 112 (D669): test-recorder injected JS strings.
+//
+// Object.freeze interceptor that captures user-invoked handlers (onPress,
+// onLongPress, onChangeText, onSubmitEditing, onScroll*) at the moment React
+// freezes their props inside createElement. Adapted from metro-mcp
+// (src/plugins/test-recorder.ts) with three deliberate deviations:
+//
+//   1. Finger-direction swipes (NOT metro-mcp's content-delta semantic).
+//      contentOffset.y INCREASING means the user's finger swiped UP (content
+//      scrolled UP through the viewport) — this is what Maestro's `swipeUp`
+//      and Detox's `.swipe('up')` mean. metro-mcp emits the content-delta
+//      direction which produces inverted YAML when replayed.
+//
+//   2. 500-event cap with priority eviction. Long sessions on scroll-heavy
+//      screens can produce tens of thousands of events. We cap at 500 and
+//      drop the oldest scroll/type pair on overflow (taps + navigates carry
+//      higher information value). The `globalThis.__METRO_MCP_REC_TRUNCATED__`
+//      flag bubbles up to `cdp_record_test_stop`'s envelope.
+//
+//   3. Route caching via the commit hook closure. metro-mcp expects the user
+//      app to install `globalThis.__METRO_MCP_NAV_REF__`. We instead read
+//      `__RN_AGENT.getNavState()` inside our `onCommitFiberRoot` patch (which
+//      we install for navigate-event tracking anyway) and cache the active
+//      route into a closure variable. The Object.freeze hot-path reads the
+//      cached variable synchronously — zero CDP round-trips per event.
+//      Mirrored to `globalThis.__METRO_MCP_NAV_REF_CACHE__` so the annotation
+//      JS can reference the same value from a separate IIFE.
+//
+// Gating: cdp_record_test_start probes `__DEV__` first via DEV_CHECK_JS.
+// Release builds pre-freeze props at Metro bundling time so the interceptor
+// can never fire — better to fail fast than silently record nothing.
+
+export const DEV_CHECK_JS = `(typeof __DEV__ !== 'undefined' && __DEV__ === true)`;
+
+export const READ_EVENTS_JS = `JSON.stringify({
+  active: !!globalThis.__METRO_MCP_REC_ACTIVE__,
+  truncated: !!globalThis.__METRO_MCP_REC_TRUNCATED__,
+  events: globalThis.__METRO_MCP_REC_EVENTS__ || []
+})`;
+
+export const START_RECORDING_JS = `(function() {
+  var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  if (!hook || !hook.getFiberRoots) {
+    return JSON.stringify({ ok: false, error: 'React DevTools hook not present' });
+  }
+
+  if (globalThis.__METRO_MCP_REC_ACTIVE__) {
+    return JSON.stringify({ ok: true, alreadyRunning: true, activeRoute: globalThis.__METRO_MCP_NAV_REF_CACHE__ || null });
+  }
+
+  globalThis.__METRO_MCP_REC_EVENTS__ = [];
+  globalThis.__METRO_MCP_REC_ACTIVE__ = true;
+  globalThis.__METRO_MCP_REC_TRUNCATED__ = false;
+  globalThis.__METRO_MCP_NAV_REF_CACHE__ = null;
+
+  // Session token: protects against stale wrappers from a previous start-stop
+  // cycle. Frozen props can't be mutated to clear obj.__mcpRecSession after
+  // cleanup, so wrappers from session 1 still call when session 2 begins.
+  // Each wrapper checks this token against the current global before pushing.
+  var sessionId = String(Date.now()) + '_' + Math.random().toString(36).slice(2);
+  globalThis.__METRO_MCP_REC_SESSION__ = sessionId;
+
+  var MAX_EVENTS = 500;
+  var __currentRoute = null;
+
+  // Cap-with-eviction: drop oldest scroll/type pair before pushing #501.
+  // Falls back to FIFO if no evictable event exists (all taps + navigates).
+  function pushEvent(ev) {
+    var evts = globalThis.__METRO_MCP_REC_EVENTS__;
+    if (evts.length >= MAX_EVENTS) {
+      var evicted = false;
+      for (var i = 0; i < evts.length; i++) {
+        if (evts[i].type === 'swipe' || evts[i].type === 'type') {
+          evts.splice(i, 1);
+          evicted = true;
+          break;
+        }
+      }
+      if (!evicted) evts.shift();
+      globalThis.__METRO_MCP_REC_TRUNCATED__ = true;
+    }
+    evts.push(ev);
+  }
+
+  // Walk a React Navigation state object to its leaf route.
+  function extractActiveRoute(state) {
+    try {
+      var s = state;
+      var depth = 0;
+      while (s && depth < 20) {
+        if (typeof s.index === 'number' && Array.isArray(s.routes)) {
+          var r = s.routes[s.index];
+          if (!r) return null;
+          if (r.state) { s = r.state; depth++; continue; }
+          return r.name || null;
+        }
+        return null;
+      }
+    } catch (e) {}
+    return null;
+  }
+
+  function readCurrentRoute() {
+    try {
+      if (globalThis.__RN_AGENT && globalThis.__RN_AGENT.getNavState) {
+        var raw = globalThis.__RN_AGENT.getNavState();
+        if (typeof raw === 'string') {
+          var parsed = JSON.parse(raw);
+          return extractActiveRoute(parsed);
+        }
+      }
+    } catch (e) {}
+    return null;
+  }
+
+  // --- Object.freeze interceptor (hot path) ---
+  // React's createElement calls Object.freeze on the props object before
+  // returning. We wrap matching handlers BEFORE the freeze so the wrapped
+  // versions become the frozen ones. Idempotent via obj.__mcpRec.
+  var origFreeze = Object.freeze;
+  Object.freeze = function(obj) {
+    if (globalThis.__METRO_MCP_REC_ACTIVE__ && obj && typeof obj === 'object' && !Array.isArray(obj) && !obj.__mcpRec) {
+      var tid = obj.testID || null;
+      var lbl = obj.accessibilityLabel || obj['aria-label'] || null;
+      var wrapped = false;
+
+      if (typeof obj.onPress === 'function') {
+        var op = obj.onPress;
+        obj.onPress = function(e) {
+          if (globalThis.__METRO_MCP_REC_ACTIVE__ && globalThis.__METRO_MCP_REC_SESSION__ === sessionId) {
+            pushEvent({ type: 'tap', testID: tid, label: lbl, route: __currentRoute, t: Date.now() });
+          }
+          return op.call(this, e);
+        };
+        wrapped = true;
+      }
+      if (typeof obj.onLongPress === 'function') {
+        var olp = obj.onLongPress;
+        obj.onLongPress = function(e) {
+          if (globalThis.__METRO_MCP_REC_ACTIVE__ && globalThis.__METRO_MCP_REC_SESSION__ === sessionId) {
+            pushEvent({ type: 'long_press', testID: tid, label: lbl, route: __currentRoute, t: Date.now() });
+          }
+          return olp.call(this, e);
+        };
+        wrapped = true;
+      }
+      if (typeof obj.onChangeText === 'function') {
+        var oct = obj.onChangeText;
+        obj.onChangeText = function(val) {
+          if (globalThis.__METRO_MCP_REC_ACTIVE__ && globalThis.__METRO_MCP_REC_SESSION__ === sessionId) {
+            pushEvent({ type: 'type', testID: tid, label: lbl, value: val, route: __currentRoute, t: Date.now() });
+          }
+          return oct.call(this, val);
+        };
+        wrapped = true;
+      }
+      if (typeof obj.onSubmitEditing === 'function') {
+        var ose = obj.onSubmitEditing;
+        obj.onSubmitEditing = function(e) {
+          if (globalThis.__METRO_MCP_REC_ACTIVE__ && globalThis.__METRO_MCP_REC_SESSION__ === sessionId) {
+            pushEvent({ type: 'submit', testID: tid, label: lbl, route: __currentRoute, t: Date.now() });
+          }
+          return ose.call(this, e);
+        };
+        wrapped = true;
+      }
+
+      // Scroll-container detection: probe for 7 RN ScrollView-specific props.
+      // 'in' (not !== undefined) catches props explicitly set to undefined.
+      var isScrollable =
+        'scrollEventThrottle'            in obj ||
+        'extraScrollHeight'              in obj ||
+        'showsVerticalScrollIndicator'   in obj ||
+        'showsHorizontalScrollIndicator' in obj ||
+        'keyboardShouldPersistTaps'      in obj ||
+        'keyboardDismissMode'            in obj ||
+        'scrollEnabled'                  in obj ||
+        typeof obj.onScrollBeginDrag === 'function' ||
+        typeof obj.onScrollEndDrag   === 'function';
+      if (isScrollable) {
+        var scrollStart = { x: null, y: null };
+        var origBegin       = obj.onScrollBeginDrag   || null;
+        var origEnd         = obj.onScrollEndDrag     || null;
+        var origMomentumEnd = obj.onMomentumScrollEnd || null;
+        obj.onScrollBeginDrag = function(e) {
+          scrollStart.x = e.nativeEvent.contentOffset.x;
+          scrollStart.y = e.nativeEvent.contentOffset.y;
+          if (origBegin) origBegin.call(this, e);
+        };
+        var emitSwipeIfMoved = function(e) {
+          if (scrollStart.x !== null && globalThis.__METRO_MCP_REC_ACTIVE__) {
+            var dx = e.nativeEvent.contentOffset.x - scrollStart.x;
+            var dy = e.nativeEvent.contentOffset.y - scrollStart.y;
+            if (Math.abs(dx) > 5 || Math.abs(dy) > 5) {
+              // Finger-direction (NOT metro-mcp's content-delta — see header).
+              // dy>0: contentOffset increased → finger went UP → 'up'.
+              var dir = Math.abs(dx) > Math.abs(dy)
+                ? (dx > 0 ? 'left'  : 'right')
+                : (dy > 0 ? 'up'    : 'down');
+              var evts = globalThis.__METRO_MCP_REC_EVENTS__;
+              var last = evts[evts.length - 1];
+              if (!(last && last.type === 'swipe' && Date.now() - last.t < 100)) {
+                pushEvent({ type: 'swipe', direction: dir, testID: tid, route: __currentRoute, t: Date.now() });
+              }
+            }
+            scrollStart.x = null;
+          }
+        };
+        obj.onScrollEndDrag = function(e) {
+          emitSwipeIfMoved(e);
+          if (origEnd) origEnd.call(this, e);
+        };
+        obj.onMomentumScrollEnd = function(e) {
+          emitSwipeIfMoved(e);
+          if (origMomentumEnd) origMomentumEnd.call(this, e);
+        };
+        wrapped = true;
+      }
+      if (wrapped) obj.__mcpRec = true;
+    }
+    return origFreeze.call(this, obj);
+  };
+
+  // --- Re-render walk for already-mounted scroll containers ---
+  // Object.freeze only fires on FUTURE renders. Existing ScrollViews missed
+  // the interceptor. Force-render them so their props go through Object.freeze
+  // again. M8 pattern: 1..5 renderer loop for fiber root resolution.
+  (function() {
+    var renderer = null;
+    try {
+      hook.renderers.forEach(function(r) { if (!renderer) renderer = r; });
+    } catch (e) {}
+
+    function isScrollFiber(fiber) {
+      var cn = typeof fiber.type === 'string'
+        ? fiber.type
+        : (fiber.type && (fiber.type.displayName || fiber.type.name)) || '';
+      if (cn === 'ScrollView' || cn === 'FlatList' || cn === 'SectionList' ||
+          cn === 'VirtualizedList' || cn === 'FlashList' || cn === 'BigList' ||
+          cn === 'RecyclerListView' || cn === 'MasonryFlashList') return true;
+      if (/ScrollView|List/i.test(cn)) return true;
+      var p = fiber.memoizedProps;
+      return !!(p && typeof p === 'object' && (
+        'scrollEventThrottle'            in p || 'extraScrollHeight'              in p ||
+        'showsVerticalScrollIndicator'   in p || 'showsHorizontalScrollIndicator' in p ||
+        'keyboardShouldPersistTaps'      in p || 'keyboardDismissMode'            in p ||
+        'scrollEnabled'                  in p ||
+        typeof p.onScrollBeginDrag === 'function' || typeof p.onScrollEndDrag === 'function'
+      ));
+    }
+
+    var stack = [];
+    for (var ri = 1; ri <= 5; ri++) {
+      var roots = hook.getFiberRoots(ri);
+      if (roots && roots.size > 0) {
+        Array.from(roots).forEach(function(r) { stack.push({ f: r.current, d: 0 }); });
+        break;
+      }
+    }
+    while (stack.length) {
+      var item = stack.pop(); var fiber = item.f; var depth = item.d;
+      if (!fiber || depth > 200) continue;
+      if (isScrollFiber(fiber) && fiber.memoizedProps && !fiber.memoizedProps.__mcpRec) {
+        if (fiber.stateNode && typeof fiber.stateNode.forceUpdate === 'function') {
+          try { fiber.stateNode.forceUpdate(); } catch (e) {}
+        } else if (renderer && renderer.overrideProps) {
+          try { renderer.overrideProps(fiber, ['__mcpInit'], 1); } catch (e) {}
+        }
+      }
+      if (fiber.sibling) stack.push({ f: fiber.sibling, d: depth });
+      if (fiber.child)   stack.push({ f: fiber.child,   d: depth + 1 });
+    }
+  })();
+
+  // --- Commit hook: route cache + navigate events ---
+  // Read the current route on every React commit (cheap relative to freeze
+  // frequency), cache it for the freeze hot-path, and emit a navigate event
+  // when it changes.
+  var origCommit = hook.onCommitFiberRoot;
+  var prevRoute = null;
+  hook.onCommitFiberRoot = function(id, root) {
+    if (globalThis.__METRO_MCP_REC_ACTIVE__ && globalThis.__METRO_MCP_REC_SESSION__ === sessionId) {
+      var route = readCurrentRoute();
+      if (route) {
+        __currentRoute = route;
+        globalThis.__METRO_MCP_NAV_REF_CACHE__ = route;
+        if (prevRoute && prevRoute !== route) {
+          pushEvent({ type: 'navigate', from: prevRoute, to: route, route: route, t: Date.now() });
+        }
+        prevRoute = route;
+      }
+    }
+    if (origCommit) return origCommit.apply(this, arguments);
+  };
+
+  // Seed the route cache with one immediate read so events captured before
+  // the first commit have a chance of getting a route attached.
+  __currentRoute = readCurrentRoute();
+  globalThis.__METRO_MCP_NAV_REF_CACHE__ = __currentRoute;
+  prevRoute = __currentRoute;
+
+  globalThis.__METRO_MCP_REC_CLEANUP__ = function() {
+    globalThis.__METRO_MCP_REC_ACTIVE__ = false;
+    hook.onCommitFiberRoot = origCommit;
+    Object.freeze = origFreeze;
+    delete globalThis.__METRO_MCP_REC_CLEANUP__;
+  };
+
+  return JSON.stringify({ ok: true, alreadyRunning: false, activeRoute: __currentRoute });
+})()`;
+
+export const STOP_RECORDING_JS = `(function() {
+  try {
+    if (globalThis.__METRO_MCP_REC_CLEANUP__) {
+      globalThis.__METRO_MCP_REC_CLEANUP__();
+    }
+  } catch (e) {}
+  var events = globalThis.__METRO_MCP_REC_EVENTS__ || [];
+  var truncated = !!globalThis.__METRO_MCP_REC_TRUNCATED__;
+  return JSON.stringify({ ok: true, events: events, truncated: truncated });
+})()`;
+
+// ADD_ANNOTATION_JS is a template — the calling handler interpolates the
+// JSON-stringified note via a plain string concat. Keeping the JS as a string
+// (not a function) lets cdp_evaluate execute it directly.
+export function buildAnnotationJs(note: string): string {
+  return `(function() {
+  if (!globalThis.__METRO_MCP_REC_ACTIVE__) {
+    return JSON.stringify({ ok: false, error: 'Recording is not active' });
+  }
+  var route = globalThis.__METRO_MCP_NAV_REF_CACHE__ || null;
+  globalThis.__METRO_MCP_REC_EVENTS__.push({
+    type: 'annotation',
+    note: ${JSON.stringify(note)},
+    route: route,
+    t: Date.now()
+  });
+  return JSON.stringify({ ok: true });
+})()`;
+}

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -61,6 +61,15 @@ import { Lockfile, formatLockConflictMessage } from './lifecycle/lockfile.js';
 import { createMaestroRunHandler } from './tools/maestro-run.js';
 import { createMaestroGenerateHandler } from './tools/maestro-generate.js';
 import { createMaestroTestAllHandler } from './tools/maestro-test-all.js';
+import {
+  createRecordTestStartHandler,
+  createRecordTestStopHandler,
+  createRecordTestGenerateHandler,
+  createRecordTestAnnotateHandler,
+  createRecordTestSaveHandler,
+  createRecordTestLoadHandler,
+  createRecordTestListHandler,
+} from './tools/test-recorder.js';
 import { createCrossPlatformVerifyHandler } from './tools/cross-platform-verify.js';
 import { createOpenDevToolsHandler } from './tools/open-devtools.js';
 import { createMetroEventsHandler } from './tools/metro-events.js';
@@ -770,6 +779,66 @@ trackedTool(
     stopOnFailure: z.boolean().default(false).describe('Stop after first failure'),
   },
   createMaestroTestAllHandler(),
+);
+
+// M6 / Phase 112 (D669): Object.freeze test recorder.
+trackedTool(
+  'cdp_record_test_start',
+  'Start recording UI interactions via Object.freeze interceptor. Captures taps, long-presses, text input, submits, and scroll-derived swipes from the running app — no app changes required. Requires __DEV__=true (release builds pre-freeze props at bundle time). Pair with cdp_record_test_stop and cdp_record_test_generate to produce Maestro YAML or Detox JS.',
+  {},
+  createRecordTestStartHandler(getClient),
+);
+
+trackedTool(
+  'cdp_record_test_stop',
+  'Stop recording, deduplicate consecutive type/tap bursts, freeze the buffer, and return event count + per-type breakdown. Sets `truncated: true` when the 500-event cap was hit. Recorded events stay in MCP memory for cdp_record_test_generate / cdp_record_test_save until the next start.',
+  {},
+  createRecordTestStopHandler(getClient),
+);
+
+trackedTool(
+  'cdp_record_test_generate',
+  'Render the stored recording as replayable test code. Formats: maestro (YAML, primary), detox (JS). Appium returns NOT_IMPLEMENTED — file an issue if you need it. Requires a recording in memory (call start/stop or load first).',
+  {
+    format: z.enum(['maestro', 'detox', 'appium']).describe('Output format'),
+    testName: z.string().optional().describe('Name shown in describe()/comment header'),
+    bundleId: z.string().optional().describe('App bundle ID for the Maestro appId header'),
+  },
+  createRecordTestGenerateHandler(),
+);
+
+trackedTool(
+  'cdp_record_test_annotate',
+  'Push a human-readable note into the live event stream — appears as a comment in generated tests. Useful for marking flow checkpoints ("reached checkout", "error appeared"). Only valid during an active recording.',
+  {
+    note: z.string().min(1).describe('Annotation text'),
+  },
+  createRecordTestAnnotateHandler(getClient),
+);
+
+trackedTool(
+  'cdp_record_test_save',
+  'Persist current recording events to <projectRoot>/.rn-agent/recordings/<filename>.json. Filename is sanitized (only [a-zA-Z0-9_-] kept). Use cdp_record_test_load to restore later for re-generation in a different format.',
+  {
+    filename: z.string().min(1).describe('Recording name (without .json — sanitized)'),
+  },
+  createRecordTestSaveHandler(),
+);
+
+trackedTool(
+  'cdp_record_test_load',
+  'Restore a previously-saved recording from <projectRoot>/.rn-agent/recordings/. Replaces any in-memory events. After loading, call cdp_record_test_generate to render in any format.',
+  {
+    filename: z.string().min(1).describe('Recording name (without .json)'),
+  },
+  createRecordTestLoadHandler(),
+);
+
+trackedTool(
+  'cdp_record_test_list',
+  'List saved recordings under <projectRoot>/.rn-agent/recordings/. Returns the directory path and an array of recording names (without .json extension), sorted alphabetically.',
+  {},
+  createRecordTestListHandler(),
 );
 
 trackedTool(

--- a/scripts/cdp-bridge/src/injected-helpers.ts
+++ b/scripts/cdp-bridge/src/injected-helpers.ts
@@ -1,6 +1,6 @@
 export const INJECTED_HELPERS = `
 (function() {
-  var __HELPERS_VERSION__ = 15;
+  var __HELPERS_VERSION__ = 16;
   if (globalThis.__RN_AGENT && globalThis.__RN_AGENT.__v === __HELPERS_VERSION__) return;
   if (globalThis.__RN_AGENT) delete globalThis.__RN_AGENT;
 

--- a/scripts/cdp-bridge/src/tools/test-recorder-generators.ts
+++ b/scripts/cdp-bridge/src/tools/test-recorder-generators.ts
@@ -1,0 +1,176 @@
+// M6 / Phase 112 (D669): output generators for cdp_record_test_generate.
+//
+// Maestro YAML and Detox JS only — Appium intentionally deferred (rejected at
+// the handler layer with NOT_IMPLEMENTED). Both generators consume the same
+// RecordedEvent[] shape and emit replayable test code.
+
+import type { RecordedEvent } from './test-recorder.js';
+
+export interface GenerateOpts {
+  testName?: string;
+  bundleId?: string;
+}
+
+// Strip CR/LF from any user-controlled string before interpolating into a
+// single-line comment or scalar position. Without this an annotation like
+// `"reached checkout\nstep:bad"` escapes the comment in both Maestro YAML
+// (`# NOTE: ...` then a stray top-level mapping) and Detox JS (`// NOTE: ...`
+// then an uncommented identifier). Reported by Gemini + Codex review of M6.
+function stripNewlines(s: string | null | undefined): string {
+  if (s == null) return '';
+  return String(s).replace(/[\r\n]+/g, ' ');
+}
+
+// --- Selector helpers ---
+
+export function maestroSelector(ev: RecordedEvent): string | null {
+  const tid = (ev as { testID?: string | null }).testID;
+  const lbl = (ev as { label?: string | null }).label;
+  if (tid) return `id: "${tid}"`;
+  if (lbl) return `id: "${lbl}"`;
+  return null;
+}
+
+export function detoxSelector(ev: RecordedEvent): string | null {
+  const tid = (ev as { testID?: string | null }).testID;
+  const lbl = (ev as { label?: string | null }).label;
+  if (tid) return `element(by.id(${JSON.stringify(tid)}))`;
+  if (lbl) return `element(by.label(${JSON.stringify(lbl)}))`;
+  return null;
+}
+
+// Lookahead helper: after a navigate event we want to assert the new screen
+// rendered. The first selectable event after the navigate (stopping at the
+// next navigate boundary) is our best signal of "screen has loaded".
+export function nextSelector(
+  events: RecordedEvent[],
+  fromIndex: number,
+  selectorFn: (ev: RecordedEvent) => string | null,
+): string | null {
+  for (let j = fromIndex + 1; j < events.length; j++) {
+    const ev = events[j];
+    if (ev.type === 'navigate') return null;
+    const sel = selectorFn(ev);
+    if (sel) return sel;
+  }
+  return null;
+}
+
+// --- Maestro YAML ---
+
+export function generateMaestro(events: RecordedEvent[], opts: GenerateOpts = {}): string {
+  const lines: string[] = [];
+  if (opts.bundleId) {
+    lines.push(`appId: ${stripNewlines(opts.bundleId)}`);
+    lines.push('---');
+  }
+  lines.push(`# ${stripNewlines(opts.testName ?? 'Recorded flow')}`);
+  lines.push('- launchApp');
+
+  for (let i = 0; i < events.length; i++) {
+    const ev = events[i];
+    switch (ev.type) {
+      case 'tap': {
+        const sel = maestroSelector(ev);
+        if (sel) lines.push(`- tapOn:\n    ${sel}`);
+        else lines.push('# tap: missing testID/label');
+        break;
+      }
+      case 'long_press': {
+        const sel = maestroSelector(ev);
+        if (sel) lines.push(`- longPressOn:\n    ${sel}`);
+        else lines.push('# long_press: missing testID/label');
+        break;
+      }
+      case 'type': {
+        const sel = maestroSelector(ev);
+        if (sel) {
+          lines.push(`- tapOn:\n    ${sel}`);
+          lines.push(`- inputText: ${JSON.stringify(ev.value)}`);
+        } else {
+          lines.push(`# type: missing testID/label, value=${JSON.stringify(ev.value)}`);
+        }
+        break;
+      }
+      case 'submit':
+        lines.push('- pressKey: Enter');
+        break;
+      case 'swipe': {
+        const dir = ev.direction.charAt(0).toUpperCase() + ev.direction.slice(1);
+        lines.push(`- swipe${dir}`);
+        break;
+      }
+      case 'navigate': {
+        const next = nextSelector(events, i, maestroSelector);
+        lines.push(`# navigated: ${stripNewlines(ev.from ?? '?')} -> ${stripNewlines(ev.to)}`);
+        if (next) lines.push(`- assertVisible:\n    ${next}`);
+        break;
+      }
+      case 'annotation':
+        lines.push(`# NOTE: ${stripNewlines(ev.note)}`);
+        break;
+    }
+  }
+  return lines.join('\n') + '\n';
+}
+
+// --- Detox JS ---
+
+export function generateDetox(events: RecordedEvent[], opts: GenerateOpts = {}): string {
+  const lines: string[] = [];
+  const name = stripNewlines(opts.testName ?? 'Recorded flow');
+  lines.push(`describe(${JSON.stringify(name)}, () => {`);
+  lines.push('  beforeAll(async () => { await device.launchApp(); });');
+  lines.push("  it('replays recorded steps', async () => {");
+
+  for (let i = 0; i < events.length; i++) {
+    const ev = events[i];
+    switch (ev.type) {
+      case 'tap': {
+        const sel = detoxSelector(ev);
+        if (sel) lines.push(`    await ${sel}.tap();`);
+        else lines.push('    // tap: missing testID/label');
+        break;
+      }
+      case 'long_press': {
+        const sel = detoxSelector(ev);
+        if (sel) lines.push(`    await ${sel}.longPress();`);
+        else lines.push('    // long_press: missing testID/label');
+        break;
+      }
+      case 'type': {
+        const sel = detoxSelector(ev);
+        if (sel) lines.push(`    await ${sel}.typeText(${JSON.stringify(ev.value)});`);
+        else lines.push(`    // type: missing testID/label, value=${JSON.stringify(ev.value)}`);
+        break;
+      }
+      case 'submit': {
+        const sel = detoxSelector(ev);
+        if (sel) lines.push(`    await ${sel}.tapReturnKey();`);
+        else lines.push('    // submit: missing testID/label — replay manually');
+        break;
+      }
+      case 'swipe': {
+        const sel = detoxSelector(ev);
+        // Detox's .swipe(direction) uses the same finger-direction semantic
+        // as our recorder, so we pass the direction verbatim.
+        if (sel) lines.push(`    await ${sel}.swipe(${JSON.stringify(ev.direction)});`);
+        else lines.push(`    await element(by.type('RCTScrollView')).swipe(${JSON.stringify(ev.direction)});`);
+        break;
+      }
+      case 'navigate': {
+        const next = nextSelector(events, i, detoxSelector);
+        lines.push(`    // navigated: ${stripNewlines(ev.from ?? '?')} -> ${stripNewlines(ev.to)}`);
+        if (next) lines.push(`    await expect(${next}).toBeVisible();`);
+        break;
+      }
+      case 'annotation':
+        lines.push(`    // NOTE: ${stripNewlines(ev.note)}`);
+        break;
+    }
+  }
+
+  lines.push('  });');
+  lines.push('});');
+  return lines.join('\n') + '\n';
+}

--- a/scripts/cdp-bridge/src/tools/test-recorder.ts
+++ b/scripts/cdp-bridge/src/tools/test-recorder.ts
@@ -1,0 +1,316 @@
+// M6 / Phase 112 (D669): cdp_record_test_* tool family.
+//
+// Seven tools that wrap the Object.freeze interceptor in test-recorder-helpers
+// and produce replayable test code via test-recorder-generators. State is
+// module-level (storedEvents) — MCP is single-client-per-process so we don't
+// need per-session isolation.
+
+import type { CDPClient } from '../cdp-client.js';
+import { okResult, failResult, withConnection } from '../utils.js';
+import type { ToolResult } from '../utils.js';
+import { findProjectRoot } from '../nav-graph/storage.js';
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  DEV_CHECK_JS,
+  START_RECORDING_JS,
+  STOP_RECORDING_JS,
+  buildAnnotationJs,
+} from '../cdp/test-recorder-helpers.js';
+import {
+  generateMaestro,
+  generateDetox,
+  type GenerateOpts,
+} from './test-recorder-generators.js';
+
+export type RecordedEvent =
+  | { type: 'tap';        testID?: string | null; label?: string | null; route?: string | null; t: number }
+  | { type: 'long_press'; testID?: string | null; label?: string | null; route?: string | null; t: number }
+  | { type: 'type';       testID?: string | null; label?: string | null; value: string;          route?: string | null; t: number }
+  | { type: 'submit';     testID?: string | null; label?: string | null; route?: string | null; t: number }
+  | { type: 'swipe';      direction: 'up' | 'down' | 'left' | 'right'; testID?: string | null; route?: string | null; t: number }
+  | { type: 'navigate';   from?: string | null; to: string; route?: string | null; t: number }
+  | { type: 'annotation'; note: string; route?: string | null; t: number };
+
+// --- Module state ---
+// Shared across the 7 tool handlers — reset on start, written on stop, read by
+// generate / save. Test-only setters exposed at the bottom of this file for
+// hermetic integration tests.
+
+let storedEvents: RecordedEvent[] | null = null;
+let recordingTruncated = false;
+
+// --- Pure helpers (easy to unit-test) ---
+
+// Collapse consecutive duplicates: same-testID type bursts keep the latest
+// value; identical-testID taps within 100ms collapse to one. Mirrors
+// metro-mcp's deduplicateEvents but with explicit type guards.
+export function deduplicateEvents(events: RecordedEvent[]): RecordedEvent[] {
+  const out: RecordedEvent[] = [];
+  for (let i = 0; i < events.length; i++) {
+    const ev = events[i];
+    if (ev.type === 'type') {
+      const next = events[i + 1];
+      if (
+        next?.type === 'type' &&
+        (next as { testID?: string | null }).testID === (ev as { testID?: string | null }).testID
+      ) {
+        continue;
+      }
+    }
+    if (ev.type === 'tap') {
+      const last = out[out.length - 1];
+      if (
+        last?.type === 'tap' &&
+        (last as { testID?: string | null }).testID === (ev as { testID?: string | null }).testID &&
+        ev.t - last.t < 100
+      ) {
+        continue;
+      }
+    }
+    out.push(ev);
+  }
+  return out;
+}
+
+export function sanitizeFilename(name: string): string {
+  return name.replace(/\.json$/i, '').replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
+export function getRecordingsDir(rootResolver: () => string | null = findProjectRoot): string | null {
+  const root = rootResolver();
+  if (!root) return null;
+  return join(root, '.rn-agent', 'recordings');
+}
+
+export function typeCounts(events: RecordedEvent[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const ev of events) counts[ev.type] = (counts[ev.type] ?? 0) + 1;
+  return counts;
+}
+
+// --- Handler factories ---
+
+interface EvalResult {
+  value?: unknown;
+  error?: string;
+}
+
+async function probeDev(client: CDPClient): Promise<boolean> {
+  const r = (await client.evaluate(DEV_CHECK_JS)) as EvalResult;
+  return r.value === true;
+}
+
+const DEV_REQUIRED_MSG =
+  'Recording requires __DEV__=true — release builds pre-freeze props at bundle time and cannot be intercepted';
+
+export function createRecordTestStartHandler(getClient: () => CDPClient): (args: Record<string, never>) => Promise<ToolResult> {
+  return withConnection(getClient, async (_args: Record<string, never>, client) => {
+    if (!(await probeDev(client))) {
+      return failResult(DEV_REQUIRED_MSG, 'DEV_MODE_REQUIRED');
+    }
+    const result = (await client.evaluate(START_RECORDING_JS)) as EvalResult;
+    if (result.error) {
+      return failResult(`Failed to start recording: ${result.error}`, 'EVAL_FAILED');
+    }
+    if (typeof result.value !== 'string') {
+      return failResult('Unexpected response from START_RECORDING_JS — expected JSON string', 'BAD_RESPONSE');
+    }
+    let parsed: { ok?: boolean; error?: string; alreadyRunning?: boolean; activeRoute?: string | null };
+    try {
+      parsed = JSON.parse(result.value);
+    } catch {
+      return failResult(`Invalid JSON from start: ${String(result.value).slice(0, 200)}`, 'BAD_RESPONSE');
+    }
+    if (!parsed.ok) {
+      return failResult(parsed.error ?? 'start failed', 'START_FAILED');
+    }
+    storedEvents = null;
+    recordingTruncated = false;
+    return okResult({
+      started: true,
+      alreadyRunning: !!parsed.alreadyRunning,
+      activeRoute: parsed.activeRoute ?? null,
+    });
+  });
+}
+
+export function createRecordTestStopHandler(getClient: () => CDPClient): (args: Record<string, never>) => Promise<ToolResult> {
+  return withConnection(getClient, async (_args: Record<string, never>, client) => {
+    const result = (await client.evaluate(STOP_RECORDING_JS)) as EvalResult;
+    if (result.error) {
+      return failResult(`Failed to stop recording: ${result.error}`, 'EVAL_FAILED');
+    }
+    if (typeof result.value !== 'string') {
+      return failResult('Unexpected response from STOP_RECORDING_JS — expected JSON string', 'BAD_RESPONSE');
+    }
+    let parsed: { ok?: boolean; events?: RecordedEvent[]; truncated?: boolean };
+    try {
+      parsed = JSON.parse(result.value);
+    } catch {
+      return failResult(`Invalid JSON from stop: ${String(result.value).slice(0, 200)}`, 'BAD_RESPONSE');
+    }
+    const raw = Array.isArray(parsed.events) ? parsed.events : [];
+    storedEvents = deduplicateEvents(raw);
+    recordingTruncated = !!parsed.truncated;
+    return okResult({
+      stopped: true,
+      eventCount: storedEvents.length,
+      truncated: recordingTruncated,
+      typeCounts: typeCounts(storedEvents),
+    });
+  });
+}
+
+interface GenerateArgs extends GenerateOpts {
+  format: 'maestro' | 'detox' | 'appium';
+}
+
+export function createRecordTestGenerateHandler(): (args: GenerateArgs) => Promise<ToolResult> {
+  return async (args) => {
+    if (!storedEvents || storedEvents.length === 0) {
+      return failResult(
+        'No recorded events — call cdp_record_test_start, interact, then cdp_record_test_stop first',
+        'NO_EVENTS',
+      );
+    }
+    if (args.format === 'appium') {
+      return failResult(
+        'Appium generator not implemented in M6 — file a GitHub issue if needed',
+        'NOT_IMPLEMENTED',
+      );
+    }
+    const opts: GenerateOpts = { testName: args.testName, bundleId: args.bundleId };
+    const text =
+      args.format === 'maestro'
+        ? generateMaestro(storedEvents, opts)
+        : generateDetox(storedEvents, opts);
+    return okResult({ format: args.format, eventCount: storedEvents.length, text });
+  };
+}
+
+export function createRecordTestAnnotateHandler(getClient: () => CDPClient): (args: { note: string }) => Promise<ToolResult> {
+  return withConnection(getClient, async (args: { note: string }, client) => {
+    if (!(await probeDev(client))) {
+      return failResult(DEV_REQUIRED_MSG, 'DEV_MODE_REQUIRED');
+    }
+    const result = (await client.evaluate(buildAnnotationJs(args.note))) as EvalResult;
+    if (result.error) {
+      return failResult(`Failed to annotate: ${result.error}`, 'EVAL_FAILED');
+    }
+    if (typeof result.value !== 'string') {
+      return failResult('Unexpected response from annotate — expected JSON string', 'BAD_RESPONSE');
+    }
+    let parsed: { ok?: boolean; error?: string };
+    try {
+      parsed = JSON.parse(result.value);
+    } catch {
+      return failResult(`Invalid JSON from annotate: ${String(result.value).slice(0, 200)}`, 'BAD_RESPONSE');
+    }
+    if (!parsed.ok) {
+      return failResult(parsed.error ?? 'Annotation failed', 'NOT_RECORDING');
+    }
+    return okResult({ annotated: true });
+  });
+}
+
+export function createRecordTestSaveHandler(): (args: { filename: string }) => Promise<ToolResult> {
+  return async (args) => {
+    if (!storedEvents) {
+      return failResult('No events to save — stop a recording first', 'NO_EVENTS');
+    }
+    const dir = getRecordingsDir();
+    if (!dir) {
+      return failResult(
+        'Could not resolve project root (no package.json ancestor). Set RN_PROJECT_ROOT env var.',
+        'NO_PROJECT_ROOT',
+      );
+    }
+    await mkdir(dir, { recursive: true });
+    const safe = sanitizeFilename(args.filename);
+    if (!safe) {
+      return failResult('Filename is empty after sanitization', 'BAD_FILENAME');
+    }
+    const filePath = join(dir, `${safe}.json`);
+    const payload = { savedAt: new Date().toISOString(), events: storedEvents };
+    await writeFile(filePath, JSON.stringify(payload, null, 2), 'utf8');
+    return okResult({
+      saved: true,
+      path: filePath,
+      eventCount: storedEvents.length,
+      truncated: recordingTruncated,
+    });
+  };
+}
+
+export function createRecordTestLoadHandler(): (args: { filename: string }) => Promise<ToolResult> {
+  return async (args) => {
+    const dir = getRecordingsDir();
+    if (!dir) {
+      return failResult('Could not resolve project root', 'NO_PROJECT_ROOT');
+    }
+    const safe = sanitizeFilename(args.filename);
+    if (!safe) {
+      return failResult('Filename is empty after sanitization', 'BAD_FILENAME');
+    }
+    const filePath = join(dir, `${safe}.json`);
+    let raw: string;
+    try {
+      raw = await readFile(filePath, 'utf8');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return failResult(`Could not load ${filePath}: ${msg}`, 'LOAD_FAILED');
+    }
+    let parsed: { savedAt?: string; events?: RecordedEvent[] };
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return failResult(`Recording file is not valid JSON: ${filePath}`, 'BAD_RECORDING');
+    }
+    storedEvents = Array.isArray(parsed.events) ? parsed.events : [];
+    recordingTruncated = false;
+    return okResult({
+      loaded: true,
+      path: filePath,
+      savedAt: parsed.savedAt ?? null,
+      eventCount: storedEvents.length,
+      typeCounts: typeCounts(storedEvents),
+    });
+  };
+}
+
+export function createRecordTestListHandler(): (args: Record<string, never>) => Promise<ToolResult> {
+  return async () => {
+    const dir = getRecordingsDir();
+    if (!dir) {
+      return failResult('Could not resolve project root', 'NO_PROJECT_ROOT');
+    }
+    let files: string[];
+    try {
+      files = await readdir(dir);
+    } catch {
+      return okResult({ dir, files: [] });
+    }
+    const recordings = files
+      .filter((f) => f.endsWith('.json'))
+      .map((f) => f.replace(/\.json$/, ''))
+      .sort();
+    return okResult({ dir, files: recordings });
+  };
+}
+
+// --- Test-only DI hooks (named with leading underscore by convention) ---
+
+export function _setStoredEvents(events: RecordedEvent[] | null, truncated = false): void {
+  storedEvents = events;
+  recordingTruncated = truncated;
+}
+
+export function _getStoredEvents(): RecordedEvent[] | null {
+  return storedEvents;
+}
+
+export function _resetState(): void {
+  storedEvents = null;
+  recordingTruncated = false;
+}

--- a/scripts/cdp-bridge/src/types.ts
+++ b/scripts/cdp-bridge/src/types.ts
@@ -153,7 +153,19 @@ export type ToolErrorCode =
   | 'HELPERS_STALE'
   | 'RECONNECT_TIMEOUT'
   | 'NOT_CONNECTED'
-  | 'HELPERS_NOT_INJECTED';
+  | 'HELPERS_NOT_INJECTED'
+  // M6 / Phase 112 (D669): cdp_record_test_* tool family.
+  | 'DEV_MODE_REQUIRED'
+  | 'EVAL_FAILED'
+  | 'BAD_RESPONSE'
+  | 'START_FAILED'
+  | 'NO_EVENTS'
+  | 'NOT_IMPLEMENTED'
+  | 'NOT_RECORDING'
+  | 'NO_PROJECT_ROOT'
+  | 'BAD_FILENAME'
+  | 'LOAD_FAILED'
+  | 'BAD_RECORDING';
 
 export interface ResultEnvelope<T = unknown> {
   ok: boolean;

--- a/scripts/cdp-bridge/test/unit/injected-helpers.test.js
+++ b/scripts/cdp-bridge/test/unit/injected-helpers.test.js
@@ -317,6 +317,6 @@ test('M10: getAppInfo returns architecture=unknown when nativeFabricUIManager is
   assert.equal(info.architecture, 'unknown');
 });
 
-test('M10: helpers bundle version is 15', () => {
-  assert.match(INJECTED_HELPERS, /__HELPERS_VERSION__\s*=\s*15/);
+test('M6: helpers bundle version is 16 (bumped for test recorder support)', () => {
+  assert.match(INJECTED_HELPERS, /__HELPERS_VERSION__\s*=\s*16/);
 });

--- a/scripts/cdp-bridge/test/unit/test-recorder-deduplicate.test.js
+++ b/scripts/cdp-bridge/test/unit/test-recorder-deduplicate.test.js
@@ -1,0 +1,67 @@
+// M6 / Phase 112: deduplicateEvents tests.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { deduplicateEvents } from '../../dist/tools/test-recorder.js';
+
+test('M6: collapses consecutive type events on the same testID (keeps last)', () => {
+  const events = [
+    { type: 'type', testID: 'email', value: 'a',     t: 1000 },
+    { type: 'type', testID: 'email', value: 'al',    t: 1010 },
+    { type: 'type', testID: 'email', value: 'ali@',  t: 1020 },
+    { type: 'type', testID: 'email', value: 'ali@x', t: 1030 },
+  ];
+  const out = deduplicateEvents(events);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].value, 'ali@x');
+});
+
+test('M6: keeps distinct testID type events', () => {
+  const events = [
+    { type: 'type', testID: 'email', value: 'a@b.c', t: 1000 },
+    { type: 'type', testID: 'pwd',   value: 'sek',   t: 1010 },
+  ];
+  const out = deduplicateEvents(events);
+  assert.equal(out.length, 2);
+});
+
+test('M6: collapses identical taps within 100ms', () => {
+  const events = [
+    { type: 'tap', testID: 'submit', t: 1000 },
+    { type: 'tap', testID: 'submit', t: 1050 },  // <100ms — collapsed
+    { type: 'tap', testID: 'submit', t: 1200 },  // >100ms — kept
+  ];
+  const out = deduplicateEvents(events);
+  assert.equal(out.length, 2);
+  assert.deepEqual(
+    out.map((e) => e.t),
+    [1000, 1200],
+  );
+});
+
+test('M6: keeps taps on different testIDs even within 100ms', () => {
+  const events = [
+    { type: 'tap', testID: 'home',   t: 1000 },
+    { type: 'tap', testID: 'profile', t: 1050 },
+  ];
+  const out = deduplicateEvents(events);
+  assert.equal(out.length, 2);
+});
+
+test('M6: preserves tap → type → swipe → navigate ordering', () => {
+  const events = [
+    { type: 'tap',      testID: 'login',     t: 1000 },
+    { type: 'type',     testID: 'email',     value: 'a@b.c', t: 1100 },
+    { type: 'swipe',    direction: 'up',     t: 1200 },
+    { type: 'navigate', from: 'Login', to: 'Home', t: 1300 },
+  ];
+  const out = deduplicateEvents(events);
+  assert.equal(out.length, 4);
+  assert.deepEqual(
+    out.map((e) => e.type),
+    ['tap', 'type', 'swipe', 'navigate'],
+  );
+});
+
+test('M6: handles empty input', () => {
+  assert.deepEqual(deduplicateEvents([]), []);
+});

--- a/scripts/cdp-bridge/test/unit/test-recorder-generators.test.js
+++ b/scripts/cdp-bridge/test/unit/test-recorder-generators.test.js
@@ -1,0 +1,132 @@
+// M6 / Phase 112: Maestro YAML + Detox JS generator tests.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  generateMaestro,
+  generateDetox,
+  maestroSelector,
+  detoxSelector,
+  nextSelector,
+} from '../../dist/tools/test-recorder-generators.js';
+
+test('M6 Maestro: tap with testID emits tapOn id selector', () => {
+  const out = generateMaestro([{ type: 'tap', testID: 'login-btn', t: 1 }]);
+  assert.match(out, /- tapOn:\s+id: "login-btn"/);
+});
+
+test('M6 Maestro: type emits tapOn + inputText pair', () => {
+  const out = generateMaestro([
+    { type: 'type', testID: 'email-input', value: 'a@b.c', t: 1 },
+  ]);
+  assert.match(out, /- tapOn:\s+id: "email-input"/);
+  assert.match(out, /- inputText: "a@b\.c"/);
+});
+
+test('M6 Maestro: swipeUp uses finger-direction (dy>0 → up)', () => {
+  const out = generateMaestro([{ type: 'swipe', direction: 'up', t: 1 }]);
+  assert.match(out, /- swipeUp/);
+});
+
+test('M6 Maestro: swipeDown / swipeLeft / swipeRight all render', () => {
+  const out = generateMaestro([
+    { type: 'swipe', direction: 'down',  t: 1 },
+    { type: 'swipe', direction: 'left',  t: 2 },
+    { type: 'swipe', direction: 'right', t: 3 },
+  ]);
+  assert.match(out, /- swipeDown/);
+  assert.match(out, /- swipeLeft/);
+  assert.match(out, /- swipeRight/);
+});
+
+test('M6 Maestro: navigate emits assertVisible on next selector', () => {
+  const out = generateMaestro([
+    { type: 'navigate', from: 'Login', to: 'Home', t: 1 },
+    { type: 'tap', testID: 'home-greeting', t: 2 },
+  ]);
+  assert.match(out, /# navigated: Login -> Home/);
+  assert.match(out, /- assertVisible:\s+id: "home-greeting"/);
+});
+
+test('M6 Maestro: annotation becomes YAML comment', () => {
+  const out = generateMaestro([{ type: 'annotation', note: 'reached checkout', t: 1 }]);
+  assert.match(out, /# NOTE: reached checkout/);
+});
+
+test('M6 Maestro: long_press emits longPressOn', () => {
+  const out = generateMaestro([{ type: 'long_press', testID: 'avatar', t: 1 }]);
+  assert.match(out, /- longPressOn:\s+id: "avatar"/);
+});
+
+test('M6 Detox: tap uses by.id selector', () => {
+  const out = generateDetox([{ type: 'tap', testID: 'login-btn', t: 1 }]);
+  assert.match(out, /await element\(by\.id\("login-btn"\)\)\.tap\(\)/);
+});
+
+test('M6 Detox: type uses typeText with JSON-stringified value', () => {
+  const out = generateDetox([
+    { type: 'type', testID: 'email', value: 'with "quotes"', t: 1 },
+  ]);
+  assert.match(out, /await element\(by\.id\("email"\)\)\.typeText\("with \\"quotes\\""\)/);
+});
+
+test('M6 Detox: swipe passes direction verbatim (finger-direction matches Detox)', () => {
+  const out = generateDetox([
+    { type: 'swipe', testID: 'list', direction: 'up', t: 1 },
+  ]);
+  assert.match(out, /await element\(by\.id\("list"\)\)\.swipe\("up"\)/);
+});
+
+test('M6 selectors: maestroSelector falls back to label when no testID', () => {
+  assert.equal(maestroSelector({ type: 'tap', label: 'Submit', t: 1 }), 'id: "Submit"');
+});
+
+test('M6 selectors: detoxSelector returns null when nothing identifies the event', () => {
+  assert.equal(detoxSelector({ type: 'tap', t: 1 }), null);
+});
+
+test('M6 nextSelector: stops at next navigate boundary', () => {
+  const events = [
+    { type: 'navigate', from: 'A', to: 'B', t: 1 },
+    { type: 'navigate', from: 'B', to: 'C', t: 2 },
+    { type: 'tap', testID: 'after-nav', t: 3 },
+  ];
+  const sel = nextSelector(events, 0, maestroSelector);
+  assert.equal(sel, null);
+});
+
+// Review fixes (Gemini conf 90 + Codex conf 95): newline injection in
+// generators. Annotations and other user-controlled strings must not break
+// out of comment context.
+test('M6 Maestro: annotation newlines are stripped (no YAML escape)', () => {
+  const out = generateMaestro([
+    { type: 'annotation', note: 'reached checkout\nstep:malicious', t: 1 },
+  ]);
+  assert.match(out, /# NOTE: reached checkout step:malicious/);
+  assert.doesNotMatch(out, /^step:malicious/m);
+});
+
+test('M6 Detox: annotation newlines are stripped (no JS escape)', () => {
+  const out = generateDetox([
+    { type: 'annotation', note: 'line1\nawait device.uninstallApp();', t: 1 },
+  ]);
+  assert.match(out, /\/\/ NOTE: line1 await device\.uninstallApp\(\);/);
+  // The escaped line MUST appear inside a comment, never as standalone code.
+  assert.doesNotMatch(out, /^\s*await device\.uninstallApp\(\);/m);
+});
+
+test('M6 Maestro: testName / bundleId newlines are stripped', () => {
+  const out = generateMaestro([{ type: 'tap', testID: 'x', t: 1 }], {
+    testName: 'flow\nrm -rf',
+    bundleId: 'com.x\nstep: bad',
+  });
+  assert.match(out, /# flow rm -rf/);
+  assert.match(out, /appId: com\.x step: bad/);
+});
+
+test('M6 Detox: submit fallback is a manual-replay comment, not pressBack()', () => {
+  // No testID/label → fallback path. Old behavior was `device.pressBack()`
+  // which is Android-only and semantically wrong (back-button vs return-key).
+  const out = generateDetox([{ type: 'submit', t: 1 }]);
+  assert.doesNotMatch(out, /device\.pressBack/);
+  assert.match(out, /\/\/ submit: missing testID\/label/);
+});

--- a/scripts/cdp-bridge/test/unit/test-recorder-integration.test.js
+++ b/scripts/cdp-bridge/test/unit/test-recorder-integration.test.js
@@ -1,0 +1,253 @@
+// M6 / Phase 112: integration tests — handler + mock client + envelope.
+//
+// Pattern mirrors metro-clear-hint-integration.test.js: createMockClient with
+// a bespoke `evaluate` stub per test, then run the handler factory and assert
+// the parsed envelope. Module-level storedEvents is reset between tests via
+// _resetState to avoid cross-test contamination.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createMockClient } from '../helpers/mock-cdp-client.js';
+import { expectOk, expectFail, parseEnvelope } from '../helpers/result-helpers.js';
+import {
+  createRecordTestStartHandler,
+  createRecordTestStopHandler,
+  createRecordTestGenerateHandler,
+  createRecordTestAnnotateHandler,
+  createRecordTestSaveHandler,
+  createRecordTestLoadHandler,
+  createRecordTestListHandler,
+  _resetState,
+  _setStoredEvents,
+  _getStoredEvents,
+} from '../../dist/tools/test-recorder.js';
+
+function makeClient(evaluateStub) {
+  const client = createMockClient({});
+  client.evaluate = evaluateStub;
+  return client;
+}
+
+test('M6 start: fails DEV_MODE_REQUIRED when __DEV__ is false', async () => {
+  _resetState();
+  const client = makeClient(async (expr) => {
+    if (expr.includes('__DEV__')) return { value: false };
+    return { value: 'unexpected' };
+  });
+  const handler = createRecordTestStartHandler(() => client);
+  const env = parseEnvelope(await handler({}));
+  assert.equal(env.ok, false);
+  assert.equal(env.code, 'DEV_MODE_REQUIRED');
+  assert.match(env.error, /__DEV__=true/);
+});
+
+test('M6 start: succeeds with activeRoute parsed from JSON envelope', async () => {
+  _resetState();
+  const client = makeClient(async (expr) => {
+    if (expr.includes('__DEV__')) return { value: true };
+    if (expr.includes('Object.freeze')) {
+      return { value: JSON.stringify({ ok: true, alreadyRunning: false, activeRoute: 'Home' }) };
+    }
+    // Freshness probe
+    return { value: 16 };
+  });
+  const handler = createRecordTestStartHandler(() => client);
+  const data = expectOk(await handler({}));
+  assert.equal(data.started, true);
+  assert.equal(data.activeRoute, 'Home');
+  assert.equal(data.alreadyRunning, false);
+});
+
+test('M6 start: surfaces alreadyRunning when interceptor reports it', async () => {
+  _resetState();
+  const client = makeClient(async (expr) => {
+    if (expr.includes('__DEV__')) return { value: true };
+    if (expr.includes('Object.freeze')) {
+      return { value: JSON.stringify({ ok: true, alreadyRunning: true, activeRoute: 'Settings' }) };
+    }
+    return { value: 16 };
+  });
+  const handler = createRecordTestStartHandler(() => client);
+  const data = expectOk(await handler({}));
+  assert.equal(data.alreadyRunning, true);
+  assert.equal(data.activeRoute, 'Settings');
+});
+
+test('M6 stop: deduplicates + populates typeCounts + truncated flag', async () => {
+  _resetState();
+  const fakeEvents = [
+    { type: 'tap', testID: 'btn', t: 1000 },
+    { type: 'tap', testID: 'btn', t: 1050 }, // dedup window
+    { type: 'type', testID: 'email', value: 'a',     t: 1100 },
+    { type: 'type', testID: 'email', value: 'a@b',   t: 1110 },
+    { type: 'type', testID: 'email', value: 'a@b.c', t: 1120 },
+    { type: 'navigate', from: 'Login', to: 'Home',   t: 1200 },
+  ];
+  const client = makeClient(async (expr) => {
+    if (expr.includes('__METRO_MCP_REC_CLEANUP__')) {
+      return { value: JSON.stringify({ ok: true, events: fakeEvents, truncated: true }) };
+    }
+    return { value: 16 };
+  });
+  const handler = createRecordTestStopHandler(() => client);
+  const data = expectOk(await handler({}));
+  assert.equal(data.stopped, true);
+  assert.equal(data.truncated, true);
+  // After dedup: 1 tap (collapsed), 1 type (latest only), 1 navigate
+  assert.equal(data.eventCount, 3);
+  assert.deepEqual(data.typeCounts, { tap: 1, type: 1, navigate: 1 });
+});
+
+test('M6 generate: NO_EVENTS error when buffer is empty', async () => {
+  _resetState();
+  const handler = createRecordTestGenerateHandler();
+  const env = parseEnvelope(await handler({ format: 'maestro' }));
+  assert.equal(env.ok, false);
+  assert.equal(env.code, 'NO_EVENTS');
+});
+
+test('M6 generate: appium returns NOT_IMPLEMENTED', async () => {
+  _setStoredEvents([{ type: 'tap', testID: 'x', t: 1 }]);
+  const handler = createRecordTestGenerateHandler();
+  const env = parseEnvelope(await handler({ format: 'appium' }));
+  assert.equal(env.ok, false);
+  assert.equal(env.code, 'NOT_IMPLEMENTED');
+  _resetState();
+});
+
+test('M6 generate: maestro round-trip produces expected YAML', async () => {
+  _setStoredEvents([
+    { type: 'tap',      testID: 'login-btn', t: 1 },
+    { type: 'type',     testID: 'email',     value: 'a@b.c', t: 2 },
+    { type: 'submit',   testID: 'email',     t: 3 },
+    { type: 'navigate', from: 'Login', to: 'Home', t: 4 },
+    { type: 'tap',      testID: 'home-greeting', t: 5 },
+  ]);
+  const handler = createRecordTestGenerateHandler();
+  const data = expectOk(await handler({ format: 'maestro', testName: 'Login flow', bundleId: 'com.x.app' }));
+  assert.equal(data.format, 'maestro');
+  assert.equal(data.eventCount, 5);
+  assert.match(data.text, /appId: com\.x\.app/);
+  assert.match(data.text, /# Login flow/);
+  assert.match(data.text, /- launchApp/);
+  assert.match(data.text, /- tapOn:\s+id: "login-btn"/);
+  assert.match(data.text, /- inputText: "a@b\.c"/);
+  assert.match(data.text, /- pressKey: Enter/);
+  assert.match(data.text, /- assertVisible:\s+id: "home-greeting"/);
+  _resetState();
+});
+
+test('M6 generate: detox round-trip produces expected JS', async () => {
+  _setStoredEvents([
+    { type: 'tap',  testID: 'login-btn', t: 1 },
+    { type: 'type', testID: 'email',     value: 'a@b.c', t: 2 },
+  ]);
+  const handler = createRecordTestGenerateHandler();
+  const data = expectOk(await handler({ format: 'detox' }));
+  assert.equal(data.format, 'detox');
+  assert.match(data.text, /describe\("Recorded flow"/);
+  assert.match(data.text, /await element\(by\.id\("login-btn"\)\)\.tap\(\)/);
+  assert.match(data.text, /await element\(by\.id\("email"\)\)\.typeText\("a@b\.c"\)/);
+  _resetState();
+});
+
+test('M6 annotate: fails NOT_RECORDING when recording is inactive', async () => {
+  _resetState();
+  const client = makeClient(async (expr) => {
+    if (expr.includes('__DEV__')) return { value: true };
+    if (expr.includes('annotation')) {
+      return { value: JSON.stringify({ ok: false, error: 'Recording is not active' }) };
+    }
+    return { value: 16 };
+  });
+  const handler = createRecordTestAnnotateHandler(() => client);
+  const env = parseEnvelope(await handler({ note: 'reached checkout' }));
+  assert.equal(env.ok, false);
+  assert.equal(env.code, 'NOT_RECORDING');
+});
+
+test('M6 annotate: succeeds during active recording', async () => {
+  _resetState();
+  const client = makeClient(async (expr) => {
+    if (expr.includes('__DEV__')) return { value: true };
+    if (expr.includes('annotation')) {
+      return { value: JSON.stringify({ ok: true }) };
+    }
+    return { value: 16 };
+  });
+  const handler = createRecordTestAnnotateHandler(() => client);
+  const data = expectOk(await handler({ note: 'reached checkout' }));
+  assert.equal(data.annotated, true);
+});
+
+test('M6 save: NO_EVENTS when nothing recorded', async () => {
+  _resetState();
+  const handler = createRecordTestSaveHandler();
+  const env = parseEnvelope(await handler({ filename: 'foo' }));
+  assert.equal(env.ok, false);
+  assert.equal(env.code, 'NO_EVENTS');
+});
+
+test('M6 save → load round-trip restores events', async () => {
+  const tmp = await mkdtemp(join(tmpdir(), 'm6-save-'));
+  process.env.RN_PROJECT_ROOT = tmp;
+  // findProjectRoot() requires an isRnProject signal — fake one cheaply.
+  await writeFile(join(tmp, 'package.json'), JSON.stringify({ name: 'fake', dependencies: { 'react-native': '*' } }));
+  try {
+    _setStoredEvents([
+      { type: 'tap',  testID: 'btn',   t: 1 },
+      { type: 'type', testID: 'email', value: 'a@b.c', t: 2 },
+    ]);
+    const saveData = expectOk(await createRecordTestSaveHandler()({ filename: 'login.json' }));
+    assert.equal(saveData.saved, true);
+    assert.equal(saveData.eventCount, 2);
+    assert.match(saveData.path, /\.rn-agent\/recordings\/login\.json$/);
+
+    _resetState();
+    const loadData = expectOk(await createRecordTestLoadHandler()({ filename: 'login' }));
+    assert.equal(loadData.loaded, true);
+    assert.equal(loadData.eventCount, 2);
+    assert.deepEqual(loadData.typeCounts, { tap: 1, type: 1 });
+    const stored = _getStoredEvents();
+    assert.equal(stored.length, 2);
+    assert.equal(stored[0].testID, 'btn');
+  } finally {
+    delete process.env.RN_PROJECT_ROOT;
+    await rm(tmp, { recursive: true, force: true });
+    _resetState();
+  }
+});
+
+test('M6 list: returns sorted recording names without .json suffix', async () => {
+  const tmp = await mkdtemp(join(tmpdir(), 'm6-list-'));
+  process.env.RN_PROJECT_ROOT = tmp;
+  await writeFile(join(tmp, 'package.json'), JSON.stringify({ name: 'fake', dependencies: { 'react-native': '*' } }));
+  await mkdir(join(tmp, '.rn-agent', 'recordings'), { recursive: true });
+  await writeFile(join(tmp, '.rn-agent', 'recordings', 'zebra.json'), '[]');
+  await writeFile(join(tmp, '.rn-agent', 'recordings', 'alpha.json'), '[]');
+  await writeFile(join(tmp, '.rn-agent', 'recordings', 'ignore.txt'), 'noise');
+  try {
+    const data = expectOk(await createRecordTestListHandler()({}));
+    assert.deepEqual(data.files, ['alpha', 'zebra']);
+  } finally {
+    delete process.env.RN_PROJECT_ROOT;
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('M6 load: LOAD_FAILED when file missing', async () => {
+  const tmp = await mkdtemp(join(tmpdir(), 'm6-loadfail-'));
+  process.env.RN_PROJECT_ROOT = tmp;
+  await writeFile(join(tmp, 'package.json'), JSON.stringify({ name: 'fake', dependencies: { 'react-native': '*' } }));
+  try {
+    const env = parseEnvelope(await createRecordTestLoadHandler()({ filename: 'nope' }));
+    assert.equal(env.ok, false);
+    assert.equal(env.code, 'LOAD_FAILED');
+  } finally {
+    delete process.env.RN_PROJECT_ROOT;
+    await rm(tmp, { recursive: true, force: true });
+  }
+});

--- a/scripts/cdp-bridge/test/unit/test-recorder-js-guard.test.js
+++ b/scripts/cdp-bridge/test/unit/test-recorder-js-guard.test.js
@@ -1,0 +1,112 @@
+// M6 / Phase 112: structural guards on the injected JS strings.
+//
+// These tests can't run the JS — Hermes is required for that. Instead they
+// pin invariants by asserting source-string contents. Catch silent regressions
+// when someone "improves" the IIFE and accidentally drops the eviction policy
+// or the renderer-loop port.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  DEV_CHECK_JS,
+  START_RECORDING_JS,
+  STOP_RECORDING_JS,
+  READ_EVENTS_JS,
+  buildAnnotationJs,
+} from '../../dist/cdp/test-recorder-helpers.js';
+
+test('M6 JS guard: DEV_CHECK_JS probes __DEV__', () => {
+  assert.match(DEV_CHECK_JS, /__DEV__/);
+  assert.match(DEV_CHECK_JS, /=== true/);
+});
+
+test('M6 JS guard: START preserves origFreeze and overrides Object.freeze', () => {
+  assert.match(START_RECORDING_JS, /var origFreeze = Object\.freeze/);
+  assert.match(START_RECORDING_JS, /Object\.freeze = function\(obj\)/);
+  assert.match(START_RECORDING_JS, /return origFreeze\.call\(this, obj\)/);
+});
+
+test('M6 JS guard: START installs __METRO_MCP_REC_CLEANUP__ and restores both hooks', () => {
+  assert.match(START_RECORDING_JS, /globalThis\.__METRO_MCP_REC_CLEANUP__ = function/);
+  assert.match(START_RECORDING_JS, /Object\.freeze = origFreeze/);
+  assert.match(START_RECORDING_JS, /hook\.onCommitFiberRoot = origCommit/);
+});
+
+test('M6 JS guard: START uses obj.__mcpRec idempotency flag', () => {
+  assert.match(START_RECORDING_JS, /!obj\.__mcpRec/);
+  assert.match(START_RECORDING_JS, /obj\.__mcpRec = true/);
+});
+
+test('M6 JS guard: START contains the M8 1..5 renderer loop', () => {
+  assert.match(START_RECORDING_JS, /for \(var ri = 1; ri <= 5; ri\+\+\)/);
+  assert.match(START_RECORDING_JS, /hook\.getFiberRoots\(ri\)/);
+});
+
+test('M6 JS guard: START documents the finger-direction deviation vs metro-mcp', () => {
+  // The deviation comment lives at the top of the file (header) and inline.
+  assert.match(START_RECORDING_JS, /finger went UP/);
+  // Sign convention asserts: dy>0 → up, dx>0 → left
+  assert.match(START_RECORDING_JS, /dy > 0 \? 'up'\s*:\s*'down'/);
+  assert.match(START_RECORDING_JS, /dx > 0 \? 'left'\s*:\s*'right'/);
+});
+
+test('M6 JS guard: START enforces 500-event cap with eviction', () => {
+  assert.match(START_RECORDING_JS, /MAX_EVENTS = 500/);
+  assert.match(START_RECORDING_JS, /__METRO_MCP_REC_TRUNCATED__ = true/);
+  // Eviction prefers swipe/type over taps + navigates
+  assert.match(START_RECORDING_JS, /'swipe' \|\| evts\[i\]\.type === 'type'/);
+});
+
+test('M6 JS guard: START wraps all 7 metro-mcp handlers', () => {
+  for (const handler of [
+    'onPress',
+    'onLongPress',
+    'onChangeText',
+    'onSubmitEditing',
+    'onScrollBeginDrag',
+    'onScrollEndDrag',
+    'onMomentumScrollEnd',
+  ]) {
+    assert.ok(
+      START_RECORDING_JS.includes(handler),
+      `handler ${handler} should appear in START_RECORDING_JS`,
+    );
+  }
+});
+
+test('M6 JS guard: START walks fibers for already-mounted scroll containers', () => {
+  assert.match(START_RECORDING_JS, /isScrollFiber/);
+  assert.match(START_RECORDING_JS, /forceUpdate/);
+  assert.match(START_RECORDING_JS, /overrideProps/);
+  assert.match(START_RECORDING_JS, /__mcpInit/);
+});
+
+test('M6 JS guard: STOP calls cleanup and reads truncated flag', () => {
+  assert.match(STOP_RECORDING_JS, /__METRO_MCP_REC_CLEANUP__/);
+  assert.match(STOP_RECORDING_JS, /__METRO_MCP_REC_TRUNCATED__/);
+});
+
+test('M6 JS guard: READ_EVENTS_JS surfaces active + truncated + events', () => {
+  assert.match(READ_EVENTS_JS, /__METRO_MCP_REC_ACTIVE__/);
+  assert.match(READ_EVENTS_JS, /__METRO_MCP_REC_EVENTS__/);
+});
+
+test('M6 JS guard: buildAnnotationJs gates on REC_ACTIVE and JSON-encodes the note', () => {
+  const js = buildAnnotationJs('hello "world"');
+  assert.match(js, /__METRO_MCP_REC_ACTIVE__/);
+  assert.match(js, /note:\s*"hello \\"world\\""/);
+});
+
+test('M6 JS guard: buildAnnotationJs reads the cached nav ref', () => {
+  const js = buildAnnotationJs('test');
+  assert.match(js, /__METRO_MCP_NAV_REF_CACHE__/);
+});
+
+// Review fix (Gemini, conf 80): session token to prevent stale wrappers from
+// previous start-stop cycles emitting events with stale closure state in the
+// next session. Each wrapper checks its captured sessionId against the
+// current global before firing.
+test('M6 JS guard: START installs a session token + wrappers gate on it', () => {
+  assert.match(START_RECORDING_JS, /__METRO_MCP_REC_SESSION__\s*=\s*sessionId/);
+  assert.match(START_RECORDING_JS, /globalThis\.__METRO_MCP_REC_SESSION__\s*===\s*sessionId/);
+});

--- a/scripts/cdp-bridge/test/unit/test-recorder-storage.test.js
+++ b/scripts/cdp-bridge/test/unit/test-recorder-storage.test.js
@@ -1,0 +1,29 @@
+// M6 / Phase 112: sanitizeFilename + getRecordingsDir tests.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { join } from 'node:path';
+import { sanitizeFilename, getRecordingsDir } from '../../dist/tools/test-recorder.js';
+
+test('M6: sanitizeFilename strips .json extension', () => {
+  assert.equal(sanitizeFilename('login-flow.json'), 'login-flow');
+  assert.equal(sanitizeFilename('login-flow.JSON'), 'login-flow');
+});
+
+test('M6: sanitizeFilename preserves dashes, underscores, alphanumerics', () => {
+  assert.equal(sanitizeFilename('my-Test_Flow_123'), 'my-Test_Flow_123');
+});
+
+test('M6: sanitizeFilename replaces special chars with underscore', () => {
+  assert.equal(sanitizeFilename('foo/bar baz.tmp'), 'foo_bar_baz_tmp');
+  assert.equal(sanitizeFilename('../etc/passwd'), '___etc_passwd');
+});
+
+test('M6: getRecordingsDir returns project-root-relative path when root resolves', () => {
+  const dir = getRecordingsDir(() => '/fake/project');
+  assert.equal(dir, join('/fake/project', '.rn-agent', 'recordings'));
+});
+
+test('M6: getRecordingsDir returns null when project root is missing', () => {
+  const dir = getRecordingsDir(() => null);
+  assert.equal(dir, null);
+});


### PR DESCRIPTION
## Summary

Closes the **last remaining Phase 90 metro-mcp pattern-adoption story**. Adds a new `cdp_record_test_*` tool family (7 tools) that records real user interactions on the running React Native app — without any app code changes — and emits replayable Maestro YAML or Detox JS.

## How it works

React's `createElement` calls `Object.freeze(props)` in dev mode before sealing them. `cdp_record_test_start` monkey-patches `Object.freeze` inside Hermes — when React asks to freeze a props object that has `onPress`/`onLongPress`/`onChangeText`/`onSubmitEditing`/`onScroll*`, we wrap each handler with event-emission BEFORE letting the freeze proceed. Already-mounted scroll containers are caught via a fiber re-render walk. Route is captured via the `onCommitFiberRoot` hook reading `__RN_AGENT.getNavState()`, cached into a closure variable so the Object.freeze hot-path stays synchronous.

## Tools shipped (7)

| Tool | Purpose |
|---|---|
| `cdp_record_test_start` | Install Object.freeze interceptor + commit hook + fiber walk |
| `cdp_record_test_stop` | Restore originals, dedup buffer, return event count |
| `cdp_record_test_generate` | Render events as Maestro YAML / Detox JS (Appium → NOT_IMPLEMENTED) |
| `cdp_record_test_annotate` | Push human-readable note into live event stream |
| `cdp_record_test_save` | Persist to `<projectRoot>/.rn-agent/recordings/<name>.json` |
| `cdp_record_test_load` | Restore previously-saved recording |
| `cdp_record_test_list` | List saved recordings |

## Three deliberate deviations from metro-mcp's reference

1. **Finger-direction swipe semantics** — `dy > 0` (finger went UP, content moved UP) emits `direction: 'up'`, matching Maestro's `swipeUp` / Detox's `.swipe('up')`. metro-mcp emits the inverted content-delta direction → generated YAML replays in the wrong direction.
2. **500-event cap with priority eviction** — long sessions cap; on overflow oldest swipe/type events drop first (preserve taps + navigates).
3. **Route caching via the commit hook** — eliminates per-event CDP round-trips. metro-mcp expects user app to install `globalThis.__METRO_MCP_NAV_REF__`; ours requires no app changes.

## Tests

**549 → 605 passing**, zero failures. **+56 M6 tests** across 5 files:
- `test-recorder-deduplicate.test.js` (6) — type/tap collision rules
- `test-recorder-storage.test.js` (5) — sanitizeFilename, getRecordingsDir
- `test-recorder-generators.test.js` (15) — Maestro YAML + Detox JS output snapshots, swipe direction, newline-injection regression
- `test-recorder-js-guard.test.js` (14) — structural invariants of the injected JS strings
- `test-recorder-integration.test.js` (15) — handler-level mock-CDP round-trips

## Multi-LLM review

Gemini + Codex (parallel). Three high-confidence findings, all applied inline before commit:

| Finding | Source | Conf | Severity | Fix |
|---|---|---|---|---|
| Newline injection in generators escapes YAML/JS comment context. Annotation `note`, `testName`, `bundleId`, route names all flow through single-line comments. Multi-line note → corrupts Maestro YAML or executes JS in Detox tests. | Codex + Gemini | 95 / 90 | HIGH | `stripNewlines()` at every interpolation site + 4 regression tests. |
| Detox `submit` fallback used `device.pressBack()` (Android-only, semantically wrong — back button vs return key). | Codex | 85 | MED | Replaced with manual-replay comment. |
| Stale wrappers from prior start-stop cycle emit events with stale `__currentRoute` in next session. | Gemini | 80 | MED | Session token (`globalThis.__METRO_MCP_REC_SESSION__`); each wrapper checks token match before emit. |

## Sample generator output

10-event fixture (login → first post → long-press → swipe → navigate):

**Maestro YAML**:
```yaml
appId: com.example.app
---
# Login + open first post
- launchApp
- tapOn:
    id: "login-btn"
- tapOn:
    id: "email-input"
- inputText: "alice@example.com"
- tapOn:
    id: "password-input"
- inputText: "hunter2"
- pressKey: Enter
# navigated: Login -> Home
- assertVisible:
    id: "feed-item-1"
# NOTE: reached home — check feed renders
- tapOn:
    id: "feed-item-1"
- longPressOn:
    id: "feed-item-1"
- swipeUp
# navigated: Home -> PostDetail
```

**Detox JS** (same fixture):
```js
describe("Login + open first post", () => {
  beforeAll(async () => { await device.launchApp(); });
  it('replays recorded steps', async () => {
    await element(by.id("login-btn")).tap();
    await element(by.id("email-input")).typeText("alice@example.com");
    await element(by.id("password-input")).typeText("hunter2");
    await element(by.id("password-input")).tapReturnKey();
    // navigated: Login -> Home
    await expect(element(by.id("feed-item-1"))).toBeVisible();
    // NOTE: reached home — check feed renders
    await element(by.id("feed-item-1")).tap();
    await element(by.id("feed-item-1")).longPress();
    await element(by.id("feed-list")).swipe("up");
    // navigated: Home -> PostDetail
  });
});
```

## Versions

- Plugin: **0.41.0 → 0.42.0**
- MCP server: **0.35.0 → 0.36.0** (new tool family)
- `__HELPERS_VERSION__`: **15 → 16** (forces fresh injection on connected devices)

## Notes for users

- Dev Client / dev-mode only. `cdp_record_test_start` on a release build returns `DEV_MODE_REQUIRED` (release builds pre-freeze props at Metro bundling time).
- Recordings stored project-locally — commit them with feature branches or `.gitignore` the directory if you prefer ephemeral.
- Existing `maestro_generate` (replay-based, no recording) stays alongside for the case where you already know the steps.

## Test plan

- [x] Full unit test suite passes (605/605)
- [x] M6 test files isolated (56/56 passing in 100ms)
- [x] TypeScript build clean
- [x] 7 `cdp_record_test_*` tools present in `dist/index.js`
- [x] Multi-LLM review (Gemini + Codex) findings applied inline
- [x] Sample generator output verified for tap/type/submit/navigate/annotation/long_press/swipe
- [ ] **Manual smoke** (deferred — MCP subprocess restart required): record a real 5-tap flow on test-app → stop → generate Maestro → replay via `maestro_run`. Will be done in a follow-up session.

## Refs

- Workspace `docs/ROADMAP.md` — Phase 112 (DONE), Phase 90 epic complete
- Workspace `docs/DECISIONS.md` — D669
- Workspace `docs/proof/m6-object-freeze-test-recorder/` — full proof bundle (PROOF.md, source diff, test output, sample generator output, tools-registered evidence)
- metro-mcp reference: `src/plugins/test-recorder.ts` (931 lines, cached at `/tmp/metro-mcp-ref/test-recorder.ts`)