### PR TITLE
fix(cdp/b134): findProjectRoot sibling-grandchild scan fallback

### DIFF
--- a/scripts/cdp-bridge/dist/nav-graph/storage.js
+++ b/scripts/cdp-bridge/dist/nav-graph/storage.js
@@ -15,6 +15,59 @@ function isRnProject(dir) {
         return false;
     }
 }
+// B134: scan one directory for an RN project, recursing up to maxDepth into
+// subdirectories. Used as the last resort when the standard cwd + walk-up cascade
+// fails — handles the plugin-repo ↔ sibling-workspace/test-app layout where cwd
+// is the plugin repo but the RN project lives as a sibling's child (common when
+// Claude Code is launched from a plugin directory without --plugin-dir override).
+//
+// Traversal is **breadth-first with sorted entries**:
+// - All direct children at each level are checked before any recursion, so a
+//   direct-sibling RN project always wins over a grandchild RN project of
+//   another sibling (per review finding — prevents "aaa-unrelated/demo-rn/"
+//   beating "zzz-real-rn/" when both exist as siblings).
+// - `entries.sort()` makes the pick deterministic across filesystems whose
+//   readdirSync ordering differs (APFS sorts, ext4 doesn't). When multiple RN
+//   projects exist, alphabetical order is a stable default.
+function scanForRnProject(rootDir, maxDepth) {
+    if (maxDepth < 0)
+        return null;
+    let entries;
+    try {
+        entries = readdirSync(rootDir);
+    }
+    catch {
+        return null;
+    }
+    entries.sort();
+    // Pass 1 at this level: check all direct children for an RN project.
+    const subdirs = [];
+    for (const name of entries) {
+        if (name.startsWith('.') || name === 'node_modules')
+            continue;
+        const full = join(rootDir, name);
+        try {
+            const stat = lstatSync(full);
+            if (!(stat.isDirectory() || stat.isSymbolicLink()))
+                continue;
+        }
+        catch {
+            continue;
+        }
+        if (isRnProject(full))
+            return full;
+        subdirs.push(full);
+    }
+    // Pass 2 at this level: recurse into non-matching subdirs (breadth-first).
+    if (maxDepth > 0) {
+        for (const dir of subdirs) {
+            const deeper = scanForRnProject(dir, maxDepth - 1);
+            if (deeper)
+                return deeper;
+        }
+    }
+    return null;
+}
 export function findProjectRoot() {
     const candidates = [
         process.env.RN_PROJECT_ROOT,
@@ -34,21 +87,23 @@ export function findProjectRoot() {
             dir = parent;
         }
     }
-    // Last resort: scan subdirectories of cwd for an RN project (e.g. plugin repo with test-app/ symlink)
+    // Pass 2: scan direct subdirectories of cwd (legacy last resort — handles
+    // old test-app/ symlink layout inside a plugin repo).
     const cwd = process.cwd();
-    try {
-        for (const entry of readdirSync(cwd)) {
-            const full = join(cwd, entry);
-            try {
-                if (lstatSync(full).isDirectory() || lstatSync(full).isSymbolicLink()) {
-                    if (isRnProject(full))
-                        return full;
-                }
-            }
-            catch { /* skip */ }
-        }
+    const cwdScan = scanForRnProject(cwd, 0);
+    if (cwdScan)
+        return cwdScan;
+    // Pass 3 (B134): cwd is not an RN project and has no RN child — walk up one
+    // level and scan siblings + grandchildren. Catches the common sibling-repo
+    // layout: plugin-repo/ and workspace-repo/ as peers with test-app/ nested in
+    // the workspace. Bounded to 1 level of siblings + 1 level of grandchildren to
+    // keep the scan cheap and deterministic (no unbounded recursion).
+    const parentOfCwd = join(cwd, '..');
+    if (parentOfCwd !== cwd) {
+        const siblingScan = scanForRnProject(parentOfCwd, 1);
+        if (siblingScan)
+            return siblingScan;
     }
-    catch { /* skip */ }
     return null;
 }
 function getProjectSlug(projectRoot) {

--- a/scripts/cdp-bridge/src/nav-graph/storage.ts
+++ b/scripts/cdp-bridge/src/nav-graph/storage.ts
@@ -30,6 +30,55 @@ function isRnProject(dir: string): boolean {
   }
 }
 
+// B134: scan one directory for an RN project, recursing up to maxDepth into
+// subdirectories. Used as the last resort when the standard cwd + walk-up cascade
+// fails — handles the plugin-repo ↔ sibling-workspace/test-app layout where cwd
+// is the plugin repo but the RN project lives as a sibling's child (common when
+// Claude Code is launched from a plugin directory without --plugin-dir override).
+//
+// Traversal is **breadth-first with sorted entries**:
+// - All direct children at each level are checked before any recursion, so a
+//   direct-sibling RN project always wins over a grandchild RN project of
+//   another sibling (per review finding — prevents "aaa-unrelated/demo-rn/"
+//   beating "zzz-real-rn/" when both exist as siblings).
+// - `entries.sort()` makes the pick deterministic across filesystems whose
+//   readdirSync ordering differs (APFS sorts, ext4 doesn't). When multiple RN
+//   projects exist, alphabetical order is a stable default.
+function scanForRnProject(rootDir: string, maxDepth: number): string | null {
+  if (maxDepth < 0) return null;
+  let entries: string[];
+  try {
+    entries = readdirSync(rootDir);
+  } catch {
+    return null;
+  }
+  entries.sort();
+
+  // Pass 1 at this level: check all direct children for an RN project.
+  const subdirs: string[] = [];
+  for (const name of entries) {
+    if (name.startsWith('.') || name === 'node_modules') continue;
+    const full = join(rootDir, name);
+    try {
+      const stat = lstatSync(full);
+      if (!(stat.isDirectory() || stat.isSymbolicLink())) continue;
+    } catch {
+      continue;
+    }
+    if (isRnProject(full)) return full;
+    subdirs.push(full);
+  }
+
+  // Pass 2 at this level: recurse into non-matching subdirs (breadth-first).
+  if (maxDepth > 0) {
+    for (const dir of subdirs) {
+      const deeper = scanForRnProject(dir, maxDepth - 1);
+      if (deeper) return deeper;
+    }
+  }
+  return null;
+}
+
 export function findProjectRoot(): string | null {
   const candidates = [
     process.env.RN_PROJECT_ROOT,
@@ -48,18 +97,22 @@ export function findProjectRoot(): string | null {
     }
   }
 
-  // Last resort: scan subdirectories of cwd for an RN project (e.g. plugin repo with test-app/ symlink)
+  // Pass 2: scan direct subdirectories of cwd (legacy last resort — handles
+  // old test-app/ symlink layout inside a plugin repo).
   const cwd = process.cwd();
-  try {
-    for (const entry of readdirSync(cwd)) {
-      const full = join(cwd, entry);
-      try {
-        if (lstatSync(full).isDirectory() || lstatSync(full).isSymbolicLink()) {
-          if (isRnProject(full)) return full;
-        }
-      } catch { /* skip */ }
-    }
-  } catch { /* skip */ }
+  const cwdScan = scanForRnProject(cwd, 0);
+  if (cwdScan) return cwdScan;
+
+  // Pass 3 (B134): cwd is not an RN project and has no RN child — walk up one
+  // level and scan siblings + grandchildren. Catches the common sibling-repo
+  // layout: plugin-repo/ and workspace-repo/ as peers with test-app/ nested in
+  // the workspace. Bounded to 1 level of siblings + 1 level of grandchildren to
+  // keep the scan cheap and deterministic (no unbounded recursion).
+  const parentOfCwd = join(cwd, '..');
+  if (parentOfCwd !== cwd) {
+    const siblingScan = scanForRnProject(parentOfCwd, 1);
+    if (siblingScan) return siblingScan;
+  }
 
   return null;
 }

--- a/scripts/cdp-bridge/test/unit/find-project-root.test.js
+++ b/scripts/cdp-bridge/test/unit/find-project-root.test.js
@@ -1,0 +1,293 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { findProjectRoot } from '../../dist/nav-graph/storage.js';
+
+// B134: findProjectRoot() must find an RN project in these layouts:
+// 1. cwd IS the RN project (direct hit)
+// 2. cwd is inside an RN project (walk-up)
+// 3. cwd is a sibling of the RN project (B134 fix: 1-level sibling scan)
+// 4. cwd is a sibling of a workspace containing the RN project (B134 fix: 1-level grandchild scan)
+// 5. cwd has nothing resembling an RN project → return null
+
+function makeRnProject(dir) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({
+    name: 'test-rn',
+    dependencies: { 'react-native': '0.76.0' }
+  }));
+}
+
+function makeNonRnDir(dir, withPackageJson = false) {
+  mkdirSync(dir, { recursive: true });
+  if (withPackageJson) {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'plain', dependencies: {} }));
+  }
+}
+
+function withCwd(dir, fn) {
+  const original = process.cwd();
+  try {
+    process.chdir(dir);
+    return fn();
+  } finally {
+    process.chdir(original);
+  }
+}
+
+function withEnv(envPatches, fn) {
+  const saved = {};
+  for (const key of Object.keys(envPatches)) {
+    saved[key] = process.env[key];
+    if (envPatches[key] === null) delete process.env[key];
+    else process.env[key] = envPatches[key];
+  }
+  try {
+    return fn();
+  } finally {
+    for (const key of Object.keys(saved)) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  }
+}
+
+test('findProjectRoot: cwd IS an RN project → returns cwd', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'fpr-direct-'));
+  try {
+    makeRnProject(tmp);
+    withEnv({ RN_PROJECT_ROOT: null, CLAUDE_USER_CWD: null }, () => {
+      withCwd(tmp, () => {
+        const result = findProjectRoot();
+        // On macOS /tmp is a symlink to /private/tmp — the resolved path may start
+        // with /private. Either answer is correct as long as it ends with the unique suffix.
+        assert.ok(result && result.endsWith(tmp.split('/').pop()), `expected result to end with tmp suffix, got ${result}`);
+      });
+    });
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('findProjectRoot: cwd is inside an RN project → walks up to find it', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'fpr-walkup-'));
+  try {
+    const rnRoot = tmp;
+    makeRnProject(rnRoot);
+    const nestedCwd = join(rnRoot, 'src', 'components');
+    mkdirSync(nestedCwd, { recursive: true });
+    withEnv({ RN_PROJECT_ROOT: null, CLAUDE_USER_CWD: null }, () => {
+      withCwd(nestedCwd, () => {
+        const result = findProjectRoot();
+        assert.ok(result && result.endsWith(tmp.split('/').pop()), `expected walk-up result to end with tmp suffix, got ${result}`);
+      });
+    });
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('B134: findProjectRoot finds RN project as sibling of cwd (plugin-repo ↔ workspace layout)', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'fpr-sibling-'));
+  try {
+    // tmp/
+    //   plugin-repo/        (cwd — no package.json at root)
+    //   workspace-repo/
+    //     test-app/         (RN project, 2 levels deep from tmp)
+    const pluginRepo = join(tmp, 'plugin-repo');
+    const workspaceRepo = join(tmp, 'workspace-repo');
+    const testApp = join(workspaceRepo, 'test-app');
+    makeNonRnDir(pluginRepo, false);
+    makeNonRnDir(workspaceRepo, false);
+    makeRnProject(testApp);
+
+    withEnv({ RN_PROJECT_ROOT: null, CLAUDE_USER_CWD: null }, () => {
+      withCwd(pluginRepo, () => {
+        const result = findProjectRoot();
+        assert.ok(result, 'expected non-null result from sibling scan');
+        assert.ok(result.endsWith('test-app'), `expected to find test-app, got ${result}`);
+      });
+    });
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('B134: findProjectRoot finds RN project as direct sibling (not nested)', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'fpr-flat-sibling-'));
+  try {
+    // tmp/
+    //   plugin-repo/   (cwd)
+    //   test-app/      (RN project, direct sibling)
+    const pluginRepo = join(tmp, 'plugin-repo');
+    const testApp = join(tmp, 'test-app');
+    makeNonRnDir(pluginRepo, false);
+    makeRnProject(testApp);
+
+    withEnv({ RN_PROJECT_ROOT: null, CLAUDE_USER_CWD: null }, () => {
+      withCwd(pluginRepo, () => {
+        const result = findProjectRoot();
+        assert.ok(result && result.endsWith('test-app'), `expected direct sibling match, got ${result}`);
+      });
+    });
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('findProjectRoot: RN_PROJECT_ROOT env takes precedence over cascade', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'fpr-env-'));
+  try {
+    // Explicit RN project in env; random cwd elsewhere.
+    const rnRoot = join(tmp, 'explicit-root');
+    makeRnProject(rnRoot);
+    const elsewhere = join(tmp, 'elsewhere');
+    mkdirSync(elsewhere);
+
+    withEnv({ RN_PROJECT_ROOT: rnRoot, CLAUDE_USER_CWD: null }, () => {
+      withCwd(elsewhere, () => {
+        const result = findProjectRoot();
+        assert.ok(result && result.endsWith('explicit-root'), `expected env override, got ${result}`);
+      });
+    });
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('findProjectRoot: no false positive inside a controlled RN-free tree', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'fpr-null-'));
+  try {
+    // Controlled layout — nothing under `tmp/` is an RN project:
+    //   tmp/outer/
+    //     inner/      (cwd)
+    // Pass 1 walks up through inner → outer → tmp → /var/folders/... which MAY
+    // contain unrelated RN projects from other mkdtemp dirs in shared /tmp.
+    // So rather than asserting the overall return is null, we assert:
+    // (a) the function does not throw
+    // (b) if it does find a path, that path is NOT inside our controlled tmp
+    //     tree (because we know our tree has no RN project).
+    // This catches real false positives — if Pass 2/3 accidentally matched
+    // a non-RN dir inside our tree, this test would fail.
+    const outer = join(tmp, 'outer');
+    const inner = join(outer, 'inner');
+    mkdirSync(inner, { recursive: true });
+    // Also create some non-RN clutter to exercise the skip logic.
+    makeNonRnDir(join(outer, '.hidden-thing'), true);
+    makeNonRnDir(join(outer, 'node_modules'), false);
+    makeNonRnDir(join(outer, 'plain-non-rn'), true);
+
+    withEnv({ RN_PROJECT_ROOT: null, CLAUDE_USER_CWD: null }, () => {
+      withCwd(inner, () => {
+        const result = findProjectRoot();
+        if (result !== null) {
+          // If we got a path back, it MUST be from outside our tree —
+          // nothing inside tmp/ is an RN project.
+          const resolvedTmp = tmp.replace(/^\/tmp\//, '/private/tmp/');
+          assert.ok(
+            !result.startsWith(tmp) && !result.startsWith(resolvedTmp),
+            `false positive inside controlled tree: ${result}`
+          );
+        }
+      });
+    });
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('B134: sibling-scan is breadth-first — direct sibling RN wins over grandchild RN', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'fpr-bfs-'));
+  try {
+    // tmp/
+    //   plugin-repo/                    (cwd)
+    //   aaa-wrapper/                    (non-RN, alphabetically first sibling)
+    //     nested-rn/                    (RN, grandchild of aaa-wrapper)
+    //   zzz-real/                       (RN, direct sibling, alphabetically later)
+    // Direct-sibling RN (zzz-real) must win over grandchild (aaa-wrapper/nested-rn)
+    // because breadth-first traversal checks all direct siblings before recursing.
+    const pluginRepo = join(tmp, 'plugin-repo');
+    const aaaWrapper = join(tmp, 'aaa-wrapper');
+    const nestedRn = join(aaaWrapper, 'nested-rn');
+    const zzzReal = join(tmp, 'zzz-real');
+    makeNonRnDir(pluginRepo, false);
+    makeNonRnDir(aaaWrapper, false);
+    makeRnProject(nestedRn);
+    makeRnProject(zzzReal);
+
+    withEnv({ RN_PROJECT_ROOT: null, CLAUDE_USER_CWD: null }, () => {
+      withCwd(pluginRepo, () => {
+        const result = findProjectRoot();
+        assert.ok(result, 'expected to find an RN project');
+        assert.ok(
+          result.endsWith('zzz-real'),
+          `breadth-first should pick direct sibling over grandchild, got ${result}`
+        );
+      });
+    });
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('B134: sibling-scan pick is alphabetically deterministic across readdir order', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'fpr-det-'));
+  try {
+    // tmp/
+    //   plugin-repo/     (cwd)
+    //   aaa-rn/          (RN, alphabetically first)
+    //   mmm-rn/          (RN, middle)
+    //   zzz-rn/          (RN, last)
+    // Expected: aaa-rn wins regardless of OS readdir ordering.
+    const pluginRepo = join(tmp, 'plugin-repo');
+    makeNonRnDir(pluginRepo, false);
+    makeRnProject(join(tmp, 'aaa-rn'));
+    makeRnProject(join(tmp, 'mmm-rn'));
+    makeRnProject(join(tmp, 'zzz-rn'));
+
+    withEnv({ RN_PROJECT_ROOT: null, CLAUDE_USER_CWD: null }, () => {
+      withCwd(pluginRepo, () => {
+        const result = findProjectRoot();
+        assert.ok(
+          result && result.endsWith('aaa-rn'),
+          `alphabetical first should win, got ${result}`
+        );
+      });
+    });
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('B134: findProjectRoot skips node_modules and dotfiles during scan (perf + correctness)', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'fpr-skip-'));
+  try {
+    // tmp/
+    //   plugin-repo/   (cwd)
+    //   node_modules/fake-rn-project/  (should be SKIPPED even though it looks like RN)
+    //   .hidden/fake-rn-project/        (should be SKIPPED)
+    //   real-app/                       (RN project, should be FOUND)
+    const pluginRepo = join(tmp, 'plugin-repo');
+    const nodeModulesFake = join(tmp, 'node_modules', 'fake-rn-project');
+    const hiddenFake = join(tmp, '.hidden', 'fake-rn-project');
+    const realApp = join(tmp, 'real-app');
+    makeNonRnDir(pluginRepo, false);
+    makeRnProject(nodeModulesFake);
+    makeRnProject(hiddenFake);
+    makeRnProject(realApp);
+
+    withEnv({ RN_PROJECT_ROOT: null, CLAUDE_USER_CWD: null }, () => {
+      withCwd(pluginRepo, () => {
+        const result = findProjectRoot();
+        assert.ok(result, 'expected to find real-app');
+        assert.ok(!result.includes('node_modules'), `should skip node_modules, got ${result}`);
+        assert.ok(!result.includes('.hidden'), `should skip dotfiles, got ${result}`);
+        assert.ok(result.endsWith('real-app'), `expected real-app, got ${result}`);
+      });
+    });
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Fixes **B134** — `findProjectRoot()` returned `null` when Claude Code launched from the plugin repo, blocking `cdp_record_test_save/load/list` + `cdp_nav_graph` (4 tools)
- Adds a bounded sibling-grandchild scan after the existing cascade, handling the plugin-repo ↔ workspace/test-app layout
- 9 new dedicated tests; 614/614 passing (up from 612)

## Root cause

The plugin repo has no `package.json` at root (only `scripts/cdp-bridge/package.json` deeper). The walk-up cascade searches for a `package.json` ancestor with `react-native` or `expo` deps — never finds one. `findProjectRoot()` returns `null` → 4 tools fail with `NO_PROJECT_ROOT`.

Surfaced during the M6 benchmark QA session (Stories A + D, 2026-04-23). 4 tools share this single root cause — one patch fixes all 4.

## Design

Pass 3 runs AFTER the existing cascade returns null:

1. Walk up one level from `cwd` to `parentOfCwd`
2. Scan siblings + their children (bounded 1+1 = 2 FS levels)
3. First match wins (alphabetically sorted for determinism)
4. Skip `.hidden` dirs + `node_modules`

Breadth-first within the scan: all direct children of each level are checked BEFORE recursing into non-matches. Prevents `aaa-wrapper/demo-rn/` from beating a real `zzz-real-rn/` direct sibling.

Precedence preserved — `RN_PROJECT_ROOT` env, `CLAUDE_USER_CWD`, `process.cwd()` walk-up, and legacy cwd-subdir scan all run BEFORE Pass 3. Users with explicit config see no behavior change.

## Multi-review

Launched Gemini + Codex in parallel. 3 findings applied inline:

| Reviewer | Conf | Finding | Fix |
|---|---|---|---|
| Gemini | 85 | Determinism across filesystems | `entries.sort()` before iteration |
| Gemini | 82 | Depth-first picks wrong project | Breadth-first refactor (2-pass per level) |
| Codex | 85 | Null-test too weak | Strengthened + 2 new determinism tests |

## Test plan

- [x] Unit tests for direct hit, walk-up, sibling layout (B134 scenario), direct sibling, env override, controlled no-false-positive, skip-patterns, breadth-first correctness, alphabetical determinism (9 tests, all new)
- [x] Full suite: 614/614 passing
- [x] Manual verification: from plugin repo cwd, `findProjectRoot()` now returns `/Users/.../rn-dev-agent-workspace/test-app` instead of null
- [ ] Merge and rebuild MCP; re-run QA Story A's save/load/list phase to confirm B134 is genuinely closed

## Refs

- `docs/BUGS.md` B134 (workspace)
- `docs/DECISIONS.md` D670 (workspace)
- `scripts/cdp-bridge/src/nav-graph/storage.ts` `findProjectRoot()` + new `scanForRnProject()`
- `scripts/cdp-bridge/test/unit/find-project-root.test.js` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)