### PR TITLE
fix(b136-b142): M6 QA batch — 6 bug fixes, 27 new tests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/scripts/cdp-bridge/dist/cdp/test-recorder-helpers.js
+++ b/scripts/cdp-bridge/dist/cdp/test-recorder-helpers.js
@@ -131,6 +131,24 @@ export const START_RECORDING_JS = `(function() {
         };
         wrapped = true;
       }
+      // B141: TextInput components fire onFocus (not onPress) on first tap —
+      // emit as 'tap' so Maestro replay (which uses tapOn) focuses the field.
+      // Skip the focus hook if the same props object already has an onPress
+      // handler (Gemini review 2026-04-23, confidence 85): same element firing
+      // both onPress and onFocus would double-emit on every tap, and the
+      // existing same-testID dedup only collapses when testIDs match exactly —
+      // it would NOT protect a Pressable-wraps-TextInput where the wrapper
+      // and field carry different testIDs.
+      if (typeof obj.onFocus === 'function' && typeof obj.onPress !== 'function') {
+        var ofn = obj.onFocus;
+        obj.onFocus = function(e) {
+          if (globalThis.__METRO_MCP_REC_ACTIVE__ && globalThis.__METRO_MCP_REC_SESSION__ === sessionId) {
+            pushEvent({ type: 'tap', testID: tid, label: lbl, route: __currentRoute, t: Date.now() });
+          }
+          return ofn.call(this, e);
+        };
+        wrapped = true;
+      }
       if (typeof obj.onLongPress === 'function') {
         var olp = obj.onLongPress;
         obj.onLongPress = function(e) {

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -253,7 +253,9 @@ trackedTool('cdp_set_shared_value', 'Set a Reanimated SharedValue on a component
       }
       if (!sv || typeof sv !== 'object' || !('value' in sv)) return JSON.stringify({ __agent_error: 'SharedValue prop found but not accessible on the resolved fiber' });
       sv.value = ${args.value};
-      return JSON.stringify({ ok: true, testID: ${JSON.stringify(args.testID)}, prop: ${JSON.stringify(args.prop)}, value: ${args.value} });
+      var observed = sv.value;
+      var drift = observed !== ${args.value};
+      return JSON.stringify({ ok: true, testID: ${JSON.stringify(args.testID)}, prop: ${JSON.stringify(args.prop)}, written: ${args.value}, observed: observed, drift: drift });
     })()`;
     const result = await client.evaluate(expression);
     if (result.error)
@@ -274,7 +276,8 @@ trackedTool('cdp_set_shared_value', 'Set a Reanimated SharedValue on a component
 }));
 trackedTool('cdp_dispatch', 'Dispatch a Redux action and optionally read state afterward — all in a single synchronous JS execution. Use for atomic dispatch+verify operations (e.g. dispatch "tasks/softDelete" then read "tasks.pendingDelete"). NOTE: Best used for state verification, not UI interaction testing — React components may not re-render immediately after CDP-dispatched actions. For UI testing, use device_press/device_find to trigger the action through the UI instead.', {
     action: z.string().describe('Redux action type (e.g. "tasks/softDelete", "cart/addItem")'),
-    payload: z.any().optional().describe('Action payload'),
+    payload: z.any().optional().describe('Action payload. WARNING: JSON-RPC between LLM and MCP does not preserve the distinction between string "42" and number 42 — the LLM\'s JSON encoder may serialize either way. For type-critical payloads (e.g. a string that happens to be numeric), use payloadJson instead.'),
+    payloadJson: z.string().optional().describe('Stringified JSON payload with guaranteed type preservation. Takes precedence over `payload` when provided. Example: payloadJson=\'"42"\' dispatches the STRING "42"; payloadJson=\'42\' dispatches the NUMBER 42; payloadJson=\'{"id":"42","qty":5}\' dispatches an object.'),
     readPath: z.string().optional().describe('Dot-path to read from store after dispatch (e.g. "tasks.pendingDelete")'),
 }, createDispatchHandler(getClient));
 trackedTool('cdp_dev_settings', 'Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses shake-to-show dev menu (use before proof recordings). For reload with auto-reconnect, use cdp_reload instead.', {

--- a/scripts/cdp-bridge/dist/injected-helpers.js
+++ b/scripts/cdp-bridge/dist/injected-helpers.js
@@ -205,10 +205,19 @@ export const INJECTED_HELPERS = `
     if (filter) {
       var f = String(filter).toLowerCase();
       var matchFibers = [];
+      var matchFiberSet = new WeakSet();
       var queue = [root.current];
       var seen = new WeakSet();
       var scanned = 0;
       var bfsStart = Date.now();
+      function hasMatchedAncestor(f2) {
+        var cur = f2.return;
+        while (cur) {
+          if (matchFiberSet.has(cur)) return true;
+          cur = cur.return;
+        }
+        return false;
+      }
       while (queue.length > 0 && scanned < 2000 && (Date.now() - bfsStart) < 3000) {
         var fiber = queue.shift();
         if (!fiber || seen.has(fiber)) continue;
@@ -218,7 +227,10 @@ export const INJECTED_HELPERS = `
         var ftid = fiber.memoizedProps && (fiber.memoizedProps.testID || fiber.memoizedProps.nativeID);
         var matchesName = fname && fname.toLowerCase().indexOf(f) >= 0;
         var matchesTestID = ftid && ftid.toLowerCase().indexOf(f) >= 0;
-        if (matchesName || matchesTestID) matchFibers.push(fiber);
+        if ((matchesName || matchesTestID) && !hasMatchedAncestor(fiber)) {
+          matchFibers.push(fiber);
+          matchFiberSet.add(fiber);
+        }
         var ch = fiber.child;
         while (ch) {
           queue.push(ch);

--- a/scripts/cdp-bridge/dist/tools/dispatch.js
+++ b/scripts/cdp-bridge/dist/tools/dispatch.js
@@ -1,9 +1,18 @@
 import { okResult, failResult, withConnection } from '../utils.js';
 export function createDispatchHandler(getClient) {
     return withConnection(getClient, async (args, client) => {
+        let payload = args.payload;
+        if (typeof args.payloadJson === 'string') {
+            try {
+                payload = JSON.parse(args.payloadJson);
+            }
+            catch (e) {
+                return failResult(`Invalid payloadJson — must be valid JSON literal (e.g. '"42"' for the string "42"): ${e.message}`);
+            }
+        }
         const opts = JSON.stringify({
             action: args.action,
-            payload: args.payload,
+            payload: payload,
             readPath: args.readPath,
         });
         const result = await client.evaluate(client.helperExpr(`dispatchAction(${opts})`));

--- a/scripts/cdp-bridge/dist/tools/test-recorder-generators.js
+++ b/scripts/cdp-bridge/dist/tools/test-recorder-generators.js
@@ -3,6 +3,33 @@
 // Maestro YAML and Detox JS only — Appium intentionally deferred (rejected at
 // the handler layer with NOT_IMPLEMENTED). Both generators consume the same
 // RecordedEvent[] shape and emit replayable test code.
+// B137: window (ms) after a tap in which a subsequent `navigate` event is
+// considered to be caused by the tap. 1000ms handles human-pace UI transitions
+// plus async navigator resolution without false-positives spanning unrelated
+// user pauses.
+const TAP_TO_NAV_WINDOW_MS = 1000;
+// B137: look forward from a tap for the next navigate event. If it lies within
+// the correlation window AND no other tap/swipe/submit event precedes it, the
+// tap is treated as the navigation trigger. Returns the navigate event index
+// so the caller can (a) emit a `# navigated:` comment and (b) mark the event
+// as consumed so the navigate branch doesn't double-emit.
+export function lookaheadNavigate(events, fromIndex, windowMs = TAP_TO_NAV_WINDOW_MS) {
+    const source = events[fromIndex];
+    if (!source || (source.type !== 'tap' && source.type !== 'long_press'))
+        return null;
+    for (let j = fromIndex + 1; j < events.length; j++) {
+        const ev = events[j];
+        if (ev.type === 'navigate') {
+            if (ev.t - source.t <= windowMs)
+                return { event: ev, index: j };
+            return null;
+        }
+        if (ev.type === 'tap' || ev.type === 'long_press' || ev.type === 'swipe' || ev.type === 'submit') {
+            return null;
+        }
+    }
+    return null;
+}
 // Strip CR/LF from any user-controlled string before interpolating into a
 // single-line comment or scalar position. Without this an annotation like
 // `"reached checkout\nstep:bad"` escapes the comment in both Maestro YAML
@@ -54,7 +81,14 @@ export function generateMaestro(events, opts = {}) {
         lines.push('---');
     }
     lines.push(`# ${stripNewlines(opts.testName ?? 'Recorded flow')}`);
+    if (opts.startRoute) {
+        lines.push(`# startRoute: ${stripNewlines(opts.startRoute)}`);
+        lines.push('# NOTE: replay requires the app to be on this route before `- launchApp` finishes. If your app does not default to it, insert a navigation step here (e.g. deep link or tab tap).');
+    }
     lines.push('- launchApp');
+    // B137: navigate events reached via tap lookahead are emitted inline with the
+    // tap; skip them here to avoid double-emission.
+    const consumedNavIndices = new Set();
     for (let i = 0; i < events.length; i++) {
         const ev = events[i];
         switch (ev.type) {
@@ -64,6 +98,14 @@ export function generateMaestro(events, opts = {}) {
                     lines.push(`- tapOn:\n    ${sel}`);
                 else
                     lines.push('# tap: missing testID/label');
+                const hit = lookaheadNavigate(events, i);
+                if (hit) {
+                    lines.push(`# navigated: ${stripNewlines(hit.event.from ?? '?')} -> ${stripNewlines(hit.event.to)}`);
+                    const next = nextSelector(events, hit.index, maestroSelector);
+                    if (next)
+                        lines.push(`- assertVisible:\n    ${next}`);
+                    consumedNavIndices.add(hit.index);
+                }
                 break;
             }
             case 'long_press': {
@@ -72,6 +114,14 @@ export function generateMaestro(events, opts = {}) {
                     lines.push(`- longPressOn:\n    ${sel}`);
                 else
                     lines.push('# long_press: missing testID/label');
+                const hit = lookaheadNavigate(events, i);
+                if (hit) {
+                    lines.push(`# navigated: ${stripNewlines(hit.event.from ?? '?')} -> ${stripNewlines(hit.event.to)}`);
+                    const next = nextSelector(events, hit.index, maestroSelector);
+                    if (next)
+                        lines.push(`- assertVisible:\n    ${next}`);
+                    consumedNavIndices.add(hit.index);
+                }
                 break;
             }
             case 'type': {
@@ -94,6 +144,8 @@ export function generateMaestro(events, opts = {}) {
                 break;
             }
             case 'navigate': {
+                if (consumedNavIndices.has(i))
+                    break;
                 const next = nextSelector(events, i, maestroSelector);
                 lines.push(`# navigated: ${stripNewlines(ev.from ?? '?')} -> ${stripNewlines(ev.to)}`);
                 if (next)
@@ -112,8 +164,12 @@ export function generateDetox(events, opts = {}) {
     const lines = [];
     const name = stripNewlines(opts.testName ?? 'Recorded flow');
     lines.push(`describe(${JSON.stringify(name)}, () => {`);
+    if (opts.startRoute) {
+        lines.push(`  // startRoute: ${stripNewlines(opts.startRoute)} — ensure app is on this route before running`);
+    }
     lines.push('  beforeAll(async () => { await device.launchApp(); });');
     lines.push("  it('replays recorded steps', async () => {");
+    const consumedNavIndices = new Set();
     for (let i = 0; i < events.length; i++) {
         const ev = events[i];
         switch (ev.type) {
@@ -123,6 +179,14 @@ export function generateDetox(events, opts = {}) {
                     lines.push(`    await ${sel}.tap();`);
                 else
                     lines.push('    // tap: missing testID/label');
+                const hit = lookaheadNavigate(events, i);
+                if (hit) {
+                    lines.push(`    // navigated: ${stripNewlines(hit.event.from ?? '?')} -> ${stripNewlines(hit.event.to)}`);
+                    const next = nextSelector(events, hit.index, detoxSelector);
+                    if (next)
+                        lines.push(`    await expect(${next}).toBeVisible();`);
+                    consumedNavIndices.add(hit.index);
+                }
                 break;
             }
             case 'long_press': {
@@ -131,6 +195,14 @@ export function generateDetox(events, opts = {}) {
                     lines.push(`    await ${sel}.longPress();`);
                 else
                     lines.push('    // long_press: missing testID/label');
+                const hit = lookaheadNavigate(events, i);
+                if (hit) {
+                    lines.push(`    // navigated: ${stripNewlines(hit.event.from ?? '?')} -> ${stripNewlines(hit.event.to)}`);
+                    const next = nextSelector(events, hit.index, detoxSelector);
+                    if (next)
+                        lines.push(`    await expect(${next}).toBeVisible();`);
+                    consumedNavIndices.add(hit.index);
+                }
                 break;
             }
             case 'type': {
@@ -160,6 +232,8 @@ export function generateDetox(events, opts = {}) {
                 break;
             }
             case 'navigate': {
+                if (consumedNavIndices.has(i))
+                    break;
                 const next = nextSelector(events, i, detoxSelector);
                 lines.push(`    // navigated: ${stripNewlines(ev.from ?? '?')} -> ${stripNewlines(ev.to)}`);
                 if (next)

--- a/scripts/cdp-bridge/dist/tools/test-recorder.js
+++ b/scripts/cdp-bridge/dist/tools/test-recorder.js
@@ -16,6 +16,11 @@ import { generateMaestro, generateDetox, } from './test-recorder-generators.js';
 // hermetic integration tests.
 let storedEvents = null;
 let recordingTruncated = false;
+// B136: route captured at record_start — used by the generator to emit a
+// `# startRoute: <name>` preamble so replay users know where the recorded
+// flow assumes the app is. Null when the recorder couldn't resolve a route
+// (no __NAV_REF__ yet, or app is on its default/landing route).
+let recordingStartRoute = null;
 // --- Pure helpers (easy to unit-test) ---
 // Collapse consecutive duplicates: same-testID type bursts keep the latest
 // value; identical-testID taps within 100ms collapse to one. Mirrors
@@ -87,6 +92,7 @@ export function createRecordTestStartHandler(getClient) {
         }
         storedEvents = null;
         recordingTruncated = false;
+        recordingStartRoute = parsed.activeRoute ?? null;
         return okResult({
             started: true,
             alreadyRunning: !!parsed.alreadyRunning,
@@ -129,11 +135,15 @@ export function createRecordTestGenerateHandler() {
         if (args.format === 'appium') {
             return failResult('Appium generator not implemented in M6 — file a GitHub issue if needed', 'NOT_IMPLEMENTED');
         }
-        const opts = { testName: args.testName, bundleId: args.bundleId };
+        const opts = {
+            testName: args.testName,
+            bundleId: args.bundleId,
+            startRoute: recordingStartRoute ?? undefined,
+        };
         const text = args.format === 'maestro'
             ? generateMaestro(storedEvents, opts)
             : generateDetox(storedEvents, opts);
-        return okResult({ format: args.format, eventCount: storedEvents.length, text });
+        return okResult({ format: args.format, eventCount: storedEvents.length, text, startRoute: recordingStartRoute });
     };
 }
 export function createRecordTestAnnotateHandler(getClient) {
@@ -254,4 +264,8 @@ export function _getStoredEvents() {
 export function _resetState() {
     storedEvents = null;
     recordingTruncated = false;
+    recordingStartRoute = null;
+}
+export function _setRecordingStartRoute(route) {
+    recordingStartRoute = route;
 }

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/cdp/test-recorder-helpers.ts
+++ b/scripts/cdp-bridge/src/cdp/test-recorder-helpers.ts
@@ -134,6 +134,24 @@ export const START_RECORDING_JS = `(function() {
         };
         wrapped = true;
       }
+      // B141: TextInput components fire onFocus (not onPress) on first tap —
+      // emit as 'tap' so Maestro replay (which uses tapOn) focuses the field.
+      // Skip the focus hook if the same props object already has an onPress
+      // handler (Gemini review 2026-04-23, confidence 85): same element firing
+      // both onPress and onFocus would double-emit on every tap, and the
+      // existing same-testID dedup only collapses when testIDs match exactly —
+      // it would NOT protect a Pressable-wraps-TextInput where the wrapper
+      // and field carry different testIDs.
+      if (typeof obj.onFocus === 'function' && typeof obj.onPress !== 'function') {
+        var ofn = obj.onFocus;
+        obj.onFocus = function(e) {
+          if (globalThis.__METRO_MCP_REC_ACTIVE__ && globalThis.__METRO_MCP_REC_SESSION__ === sessionId) {
+            pushEvent({ type: 'tap', testID: tid, label: lbl, route: __currentRoute, t: Date.now() });
+          }
+          return ofn.call(this, e);
+        };
+        wrapped = true;
+      }
       if (typeof obj.onLongPress === 'function') {
         var olp = obj.onLongPress;
         obj.onLongPress = function(e) {

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -402,7 +402,9 @@ trackedTool(
       }
       if (!sv || typeof sv !== 'object' || !('value' in sv)) return JSON.stringify({ __agent_error: 'SharedValue prop found but not accessible on the resolved fiber' });
       sv.value = ${args.value};
-      return JSON.stringify({ ok: true, testID: ${JSON.stringify(args.testID)}, prop: ${JSON.stringify(args.prop)}, value: ${args.value} });
+      var observed = sv.value;
+      var drift = observed !== ${args.value};
+      return JSON.stringify({ ok: true, testID: ${JSON.stringify(args.testID)}, prop: ${JSON.stringify(args.prop)}, written: ${args.value}, observed: observed, drift: drift });
     })()`;
     const result = await client.evaluate(expression);
     if (result.error) return failResult(`SharedValue error: ${result.error}`);
@@ -421,7 +423,8 @@ trackedTool(
   'Dispatch a Redux action and optionally read state afterward — all in a single synchronous JS execution. Use for atomic dispatch+verify operations (e.g. dispatch "tasks/softDelete" then read "tasks.pendingDelete"). NOTE: Best used for state verification, not UI interaction testing — React components may not re-render immediately after CDP-dispatched actions. For UI testing, use device_press/device_find to trigger the action through the UI instead.',
   {
     action: z.string().describe('Redux action type (e.g. "tasks/softDelete", "cart/addItem")'),
-    payload: z.any().optional().describe('Action payload'),
+    payload: z.any().optional().describe('Action payload. WARNING: JSON-RPC between LLM and MCP does not preserve the distinction between string "42" and number 42 — the LLM\'s JSON encoder may serialize either way. For type-critical payloads (e.g. a string that happens to be numeric), use payloadJson instead.'),
+    payloadJson: z.string().optional().describe('Stringified JSON payload with guaranteed type preservation. Takes precedence over `payload` when provided. Example: payloadJson=\'"42"\' dispatches the STRING "42"; payloadJson=\'42\' dispatches the NUMBER 42; payloadJson=\'{"id":"42","qty":5}\' dispatches an object.'),
     readPath: z.string().optional().describe('Dot-path to read from store after dispatch (e.g. "tasks.pendingDelete")'),
   },
   createDispatchHandler(getClient),

--- a/scripts/cdp-bridge/src/injected-helpers.ts
+++ b/scripts/cdp-bridge/src/injected-helpers.ts
@@ -205,10 +205,19 @@ export const INJECTED_HELPERS = `
     if (filter) {
       var f = String(filter).toLowerCase();
       var matchFibers = [];
+      var matchFiberSet = new WeakSet();
       var queue = [root.current];
       var seen = new WeakSet();
       var scanned = 0;
       var bfsStart = Date.now();
+      function hasMatchedAncestor(f2) {
+        var cur = f2.return;
+        while (cur) {
+          if (matchFiberSet.has(cur)) return true;
+          cur = cur.return;
+        }
+        return false;
+      }
       while (queue.length > 0 && scanned < 2000 && (Date.now() - bfsStart) < 3000) {
         var fiber = queue.shift();
         if (!fiber || seen.has(fiber)) continue;
@@ -218,7 +227,10 @@ export const INJECTED_HELPERS = `
         var ftid = fiber.memoizedProps && (fiber.memoizedProps.testID || fiber.memoizedProps.nativeID);
         var matchesName = fname && fname.toLowerCase().indexOf(f) >= 0;
         var matchesTestID = ftid && ftid.toLowerCase().indexOf(f) >= 0;
-        if (matchesName || matchesTestID) matchFibers.push(fiber);
+        if ((matchesName || matchesTestID) && !hasMatchedAncestor(fiber)) {
+          matchFibers.push(fiber);
+          matchFiberSet.add(fiber);
+        }
         var ch = fiber.child;
         while (ch) {
           queue.push(ch);

--- a/scripts/cdp-bridge/src/tools/dispatch.ts
+++ b/scripts/cdp-bridge/src/tools/dispatch.ts
@@ -2,10 +2,18 @@ import type { CDPClient } from '../cdp-client.js';
 import { okResult, failResult, withConnection } from '../utils.js';
 
 export function createDispatchHandler(getClient: () => CDPClient) {
-  return withConnection(getClient, async (args: { action: string; payload?: unknown; readPath?: string }, client) => {
+  return withConnection(getClient, async (args: { action: string; payload?: unknown; payloadJson?: string; readPath?: string }, client) => {
+    let payload: unknown = args.payload;
+    if (typeof args.payloadJson === 'string') {
+      try {
+        payload = JSON.parse(args.payloadJson);
+      } catch (e) {
+        return failResult(`Invalid payloadJson — must be valid JSON literal (e.g. '"42"' for the string "42"): ${(e as Error).message}`);
+      }
+    }
     const opts = JSON.stringify({
       action: args.action,
-      payload: args.payload,
+      payload: payload,
       readPath: args.readPath,
     });
     const result = await client.evaluate(client.helperExpr(`dispatchAction(${opts})`));

--- a/scripts/cdp-bridge/src/tools/test-recorder-generators.ts
+++ b/scripts/cdp-bridge/src/tools/test-recorder-generators.ts
@@ -9,6 +9,41 @@ import type { RecordedEvent } from './test-recorder.js';
 export interface GenerateOpts {
   testName?: string;
   bundleId?: string;
+  // B136: route captured at record_test_start. Emitted as a `# startRoute: X`
+  // comment after the header so replay users know the flow assumes the app is
+  // already on <X>. When unset, flows assume the app's default landing route.
+  startRoute?: string | null;
+}
+
+// B137: window (ms) after a tap in which a subsequent `navigate` event is
+// considered to be caused by the tap. 1000ms handles human-pace UI transitions
+// plus async navigator resolution without false-positives spanning unrelated
+// user pauses.
+const TAP_TO_NAV_WINDOW_MS = 1000;
+
+// B137: look forward from a tap for the next navigate event. If it lies within
+// the correlation window AND no other tap/swipe/submit event precedes it, the
+// tap is treated as the navigation trigger. Returns the navigate event index
+// so the caller can (a) emit a `# navigated:` comment and (b) mark the event
+// as consumed so the navigate branch doesn't double-emit.
+export function lookaheadNavigate(
+  events: RecordedEvent[],
+  fromIndex: number,
+  windowMs: number = TAP_TO_NAV_WINDOW_MS,
+): { event: Extract<RecordedEvent, { type: 'navigate' }>; index: number } | null {
+  const source = events[fromIndex];
+  if (!source || (source.type !== 'tap' && source.type !== 'long_press')) return null;
+  for (let j = fromIndex + 1; j < events.length; j++) {
+    const ev = events[j];
+    if (ev.type === 'navigate') {
+      if (ev.t - source.t <= windowMs) return { event: ev, index: j };
+      return null;
+    }
+    if (ev.type === 'tap' || ev.type === 'long_press' || ev.type === 'swipe' || ev.type === 'submit') {
+      return null;
+    }
+  }
+  return null;
 }
 
 // Strip CR/LF from any user-controlled string before interpolating into a
@@ -65,7 +100,15 @@ export function generateMaestro(events: RecordedEvent[], opts: GenerateOpts = {}
     lines.push('---');
   }
   lines.push(`# ${stripNewlines(opts.testName ?? 'Recorded flow')}`);
+  if (opts.startRoute) {
+    lines.push(`# startRoute: ${stripNewlines(opts.startRoute)}`);
+    lines.push('# NOTE: replay requires the app to be on this route before `- launchApp` finishes. If your app does not default to it, insert a navigation step here (e.g. deep link or tab tap).');
+  }
   lines.push('- launchApp');
+
+  // B137: navigate events reached via tap lookahead are emitted inline with the
+  // tap; skip them here to avoid double-emission.
+  const consumedNavIndices = new Set<number>();
 
   for (let i = 0; i < events.length; i++) {
     const ev = events[i];
@@ -74,12 +117,26 @@ export function generateMaestro(events: RecordedEvent[], opts: GenerateOpts = {}
         const sel = maestroSelector(ev);
         if (sel) lines.push(`- tapOn:\n    ${sel}`);
         else lines.push('# tap: missing testID/label');
+        const hit = lookaheadNavigate(events, i);
+        if (hit) {
+          lines.push(`# navigated: ${stripNewlines(hit.event.from ?? '?')} -> ${stripNewlines(hit.event.to)}`);
+          const next = nextSelector(events, hit.index, maestroSelector);
+          if (next) lines.push(`- assertVisible:\n    ${next}`);
+          consumedNavIndices.add(hit.index);
+        }
         break;
       }
       case 'long_press': {
         const sel = maestroSelector(ev);
         if (sel) lines.push(`- longPressOn:\n    ${sel}`);
         else lines.push('# long_press: missing testID/label');
+        const hit = lookaheadNavigate(events, i);
+        if (hit) {
+          lines.push(`# navigated: ${stripNewlines(hit.event.from ?? '?')} -> ${stripNewlines(hit.event.to)}`);
+          const next = nextSelector(events, hit.index, maestroSelector);
+          if (next) lines.push(`- assertVisible:\n    ${next}`);
+          consumedNavIndices.add(hit.index);
+        }
         break;
       }
       case 'type': {
@@ -101,6 +158,7 @@ export function generateMaestro(events: RecordedEvent[], opts: GenerateOpts = {}
         break;
       }
       case 'navigate': {
+        if (consumedNavIndices.has(i)) break;
         const next = nextSelector(events, i, maestroSelector);
         lines.push(`# navigated: ${stripNewlines(ev.from ?? '?')} -> ${stripNewlines(ev.to)}`);
         if (next) lines.push(`- assertVisible:\n    ${next}`);
@@ -120,8 +178,13 @@ export function generateDetox(events: RecordedEvent[], opts: GenerateOpts = {}):
   const lines: string[] = [];
   const name = stripNewlines(opts.testName ?? 'Recorded flow');
   lines.push(`describe(${JSON.stringify(name)}, () => {`);
+  if (opts.startRoute) {
+    lines.push(`  // startRoute: ${stripNewlines(opts.startRoute)} — ensure app is on this route before running`);
+  }
   lines.push('  beforeAll(async () => { await device.launchApp(); });');
   lines.push("  it('replays recorded steps', async () => {");
+
+  const consumedNavIndices = new Set<number>();
 
   for (let i = 0; i < events.length; i++) {
     const ev = events[i];
@@ -130,12 +193,26 @@ export function generateDetox(events: RecordedEvent[], opts: GenerateOpts = {}):
         const sel = detoxSelector(ev);
         if (sel) lines.push(`    await ${sel}.tap();`);
         else lines.push('    // tap: missing testID/label');
+        const hit = lookaheadNavigate(events, i);
+        if (hit) {
+          lines.push(`    // navigated: ${stripNewlines(hit.event.from ?? '?')} -> ${stripNewlines(hit.event.to)}`);
+          const next = nextSelector(events, hit.index, detoxSelector);
+          if (next) lines.push(`    await expect(${next}).toBeVisible();`);
+          consumedNavIndices.add(hit.index);
+        }
         break;
       }
       case 'long_press': {
         const sel = detoxSelector(ev);
         if (sel) lines.push(`    await ${sel}.longPress();`);
         else lines.push('    // long_press: missing testID/label');
+        const hit = lookaheadNavigate(events, i);
+        if (hit) {
+          lines.push(`    // navigated: ${stripNewlines(hit.event.from ?? '?')} -> ${stripNewlines(hit.event.to)}`);
+          const next = nextSelector(events, hit.index, detoxSelector);
+          if (next) lines.push(`    await expect(${next}).toBeVisible();`);
+          consumedNavIndices.add(hit.index);
+        }
         break;
       }
       case 'type': {
@@ -159,6 +236,7 @@ export function generateDetox(events: RecordedEvent[], opts: GenerateOpts = {}):
         break;
       }
       case 'navigate': {
+        if (consumedNavIndices.has(i)) break;
         const next = nextSelector(events, i, detoxSelector);
         lines.push(`    // navigated: ${stripNewlines(ev.from ?? '?')} -> ${stripNewlines(ev.to)}`);
         if (next) lines.push(`    await expect(${next}).toBeVisible();`);

--- a/scripts/cdp-bridge/src/tools/test-recorder.ts
+++ b/scripts/cdp-bridge/src/tools/test-recorder.ts
@@ -39,6 +39,11 @@ export type RecordedEvent =
 
 let storedEvents: RecordedEvent[] | null = null;
 let recordingTruncated = false;
+// B136: route captured at record_start — used by the generator to emit a
+// `# startRoute: <name>` preamble so replay users know where the recorded
+// flow assumes the app is. Null when the recorder couldn't resolve a route
+// (no __NAV_REF__ yet, or app is on its default/landing route).
+let recordingStartRoute: string | null = null;
 
 // --- Pure helpers (easy to unit-test) ---
 
@@ -127,6 +132,7 @@ export function createRecordTestStartHandler(getClient: () => CDPClient): (args:
     }
     storedEvents = null;
     recordingTruncated = false;
+    recordingStartRoute = parsed.activeRoute ?? null;
     return okResult({
       started: true,
       alreadyRunning: !!parsed.alreadyRunning,
@@ -180,12 +186,16 @@ export function createRecordTestGenerateHandler(): (args: GenerateArgs) => Promi
         'NOT_IMPLEMENTED',
       );
     }
-    const opts: GenerateOpts = { testName: args.testName, bundleId: args.bundleId };
+    const opts: GenerateOpts = {
+      testName: args.testName,
+      bundleId: args.bundleId,
+      startRoute: recordingStartRoute ?? undefined,
+    };
     const text =
       args.format === 'maestro'
         ? generateMaestro(storedEvents, opts)
         : generateDetox(storedEvents, opts);
-    return okResult({ format: args.format, eventCount: storedEvents.length, text });
+    return okResult({ format: args.format, eventCount: storedEvents.length, text, startRoute: recordingStartRoute });
   };
 }
 
@@ -313,4 +323,9 @@ export function _getStoredEvents(): RecordedEvent[] | null {
 export function _resetState(): void {
   storedEvents = null;
   recordingTruncated = false;
+  recordingStartRoute = null;
+}
+
+export function _setRecordingStartRoute(route: string | null): void {
+  recordingStartRoute = route;
 }

--- a/scripts/cdp-bridge/test/unit/dispatch-payload-types.test.js
+++ b/scripts/cdp-bridge/test/unit/dispatch-payload-types.test.js
@@ -1,0 +1,92 @@
+// B139: cdp_dispatch must preserve payload types across the LLM↔MCP JSON-RPC
+// boundary. The fix adds an optional `payloadJson` field that, when set, is
+// parsed to a JS value with the original JSON types intact and used as the
+// dispatch payload. Without `payloadJson`, the LLM's JSON encoder may coerce
+// numeric-looking strings to numbers (e.g. "42" → 42), which silently breaks
+// Redux actions that type-check their payload.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createDispatchHandler } from '../../dist/tools/dispatch.js';
+import { createMockClient } from '../helpers/mock-cdp-client.js';
+import { parseEnvelope } from '../helpers/result-helpers.js';
+
+function invoke(args) {
+  const capture = { expressionSeen: null };
+  const client = createMockClient({
+    evaluate: async (expr) => {
+      // Let probeFreshness's typeof __RN_AGENT probe return a number; capture
+      // only the real dispatch call (identified by dispatchAction substring).
+      if (typeof expr === 'string' && expr.includes('dispatchAction(')) {
+        capture.expressionSeen = expr;
+        return { value: JSON.stringify({ ok: true }) };
+      }
+      return { value: 13 };
+    },
+  });
+  const handler = createDispatchHandler(() => client);
+  return handler(args).then((result) => ({ result, captured: capture }));
+}
+
+test('B139: payloadJson "42" dispatches the STRING "42" (types preserved)', async () => {
+  const { captured } = await invoke({ action: 'tasks/setDescription', payloadJson: '"42"' });
+  assert.match(captured.expressionSeen, /"payload":"42"/);
+});
+
+test('B139: payloadJson 42 dispatches the NUMBER 42', async () => {
+  const { captured } = await invoke({ action: 'counter/set', payloadJson: '42' });
+  assert.match(captured.expressionSeen, /"payload":42[^"]/);
+});
+
+test('B139: payloadJson object round-trips through JSON.parse + JSON.stringify', async () => {
+  const { captured } = await invoke({ action: 'cart/addItem', payloadJson: '{"id":"7","qty":3}' });
+  assert.match(captured.expressionSeen, /"payload":\{"id":"7","qty":3\}/);
+});
+
+test('B139: payloadJson array preserves element types', async () => {
+  const { captured } = await invoke({ action: 'tags/set', payloadJson: '["42","hello"]' });
+  assert.match(captured.expressionSeen, /"payload":\["42","hello"\]/);
+});
+
+test('B139: payloadJson boolean preserved', async () => {
+  const { captured } = await invoke({ action: 'flags/enable', payloadJson: 'true' });
+  assert.match(captured.expressionSeen, /"payload":true/);
+});
+
+test('B139: payloadJson null preserved', async () => {
+  const { captured } = await invoke({ action: 'session/clear', payloadJson: 'null' });
+  assert.match(captured.expressionSeen, /"payload":null/);
+});
+
+test('B139: invalid payloadJson returns failResult', async () => {
+  const { result } = await invoke({ action: 'anything', payloadJson: 'not-json' });
+  const env = parseEnvelope(result);
+  assert.equal(env.ok, false);
+  assert.match(env.error, /Invalid payloadJson/);
+});
+
+test('B139: plain `payload` still works when payloadJson omitted (backward compat)', async () => {
+  const { captured } = await invoke({ action: 'items/add', payload: { sku: 'abc' } });
+  assert.match(captured.expressionSeen, /"payload":\{"sku":"abc"\}/);
+});
+
+test('B139: payloadJson takes precedence over payload when both set', async () => {
+  const { captured } = await invoke({
+    action: 'value/set',
+    payload: 999,
+    payloadJson: '"999"',
+  });
+  // payloadJson parses to string "999"; that wins.
+  assert.match(captured.expressionSeen, /"payload":"999"/);
+});
+
+test('B139: dispatch without any payload omits the key (JSON.stringify drops undefined)', async () => {
+  const { captured } = await invoke({ action: 'noop' });
+  // With both payload and payloadJson omitted, the key is dropped by JSON.stringify.
+  assert.ok(captured.expressionSeen.includes('"action":"noop"'));
+  assert.ok(!captured.expressionSeen.includes('"payload"'));
+});
+
+test('B139: readPath propagates through to helperExpr', async () => {
+  const { captured } = await invoke({ action: 'x', payloadJson: '{}', readPath: 'a.b.c' });
+  assert.match(captured.expressionSeen, /"readPath":"a\.b\.c"/);
+});

--- a/scripts/cdp-bridge/test/unit/test-recorder-tap-nav-and-preamble.test.js
+++ b/scripts/cdp-bridge/test/unit/test-recorder-tap-nav-and-preamble.test.js
@@ -1,0 +1,149 @@
+// B136 + B137: generator improvements for M6 recorder.
+// B136 — emit `# startRoute:` preamble when opts.startRoute is set.
+// B137 — correlate tap events with following navigate events, emit
+//        `# navigated:` + assertVisible inline, consume the navigate so it
+//        isn't double-emitted by the navigate branch.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  generateMaestro,
+  generateDetox,
+  lookaheadNavigate,
+} from '../../dist/tools/test-recorder-generators.js';
+
+test('B136: Maestro emits `# startRoute:` preamble when set', () => {
+  const out = generateMaestro([{ type: 'annotation', note: 'first', t: 1 }], { startRoute: 'ProfileTab' });
+  assert.match(out, /# startRoute: ProfileTab/);
+});
+
+test('B136: Maestro preamble includes replay note about navigation setup', () => {
+  const out = generateMaestro([], { startRoute: 'SettingsScreen' });
+  assert.match(out, /replay requires the app to be on this route/);
+});
+
+test('B136: Maestro emits NO preamble when startRoute not set', () => {
+  const out = generateMaestro([{ type: 'tap', testID: 'x', t: 1 }]);
+  assert.doesNotMatch(out, /# startRoute/);
+});
+
+test('B136: Maestro emits NO preamble when startRoute is null', () => {
+  const out = generateMaestro([{ type: 'tap', testID: 'x', t: 1 }], { startRoute: null });
+  assert.doesNotMatch(out, /# startRoute/);
+});
+
+test('B136: Detox emits startRoute comment inside describe block', () => {
+  const out = generateDetox([], { startRoute: 'Home' });
+  assert.match(out, /\/\/ startRoute: Home/);
+});
+
+test('B137: lookaheadNavigate finds next navigate within window', () => {
+  const events = [
+    { type: 'tap', testID: 'tab-home', t: 1000 },
+    { type: 'navigate', from: 'X', to: 'Home', t: 1100 },
+  ];
+  const hit = lookaheadNavigate(events, 0, 1000);
+  assert.ok(hit);
+  assert.equal(hit.event.to, 'Home');
+  assert.equal(hit.index, 1);
+});
+
+test('B137: lookaheadNavigate returns null when navigate is outside window', () => {
+  const events = [
+    { type: 'tap', testID: 'tab-home', t: 1000 },
+    { type: 'navigate', from: 'X', to: 'Home', t: 3000 },
+  ];
+  assert.equal(lookaheadNavigate(events, 0, 1000), null);
+});
+
+test('B137: lookaheadNavigate returns null when another tap intervenes', () => {
+  const events = [
+    { type: 'tap', testID: 'a', t: 1000 },
+    { type: 'tap', testID: 'b', t: 1050 },
+    { type: 'navigate', from: 'X', to: 'Y', t: 1100 },
+  ];
+  assert.equal(lookaheadNavigate(events, 0, 1000), null);
+});
+
+test('B137: lookaheadNavigate returns null when called on a non-tap event', () => {
+  const events = [
+    { type: 'annotation', note: 'x', t: 1 },
+    { type: 'navigate', from: 'A', to: 'B', t: 50 },
+  ];
+  assert.equal(lookaheadNavigate(events, 0, 1000), null);
+});
+
+test('B137: lookaheadNavigate works for long_press too', () => {
+  const events = [
+    { type: 'long_press', testID: 'row', t: 1000 },
+    { type: 'navigate', from: 'List', to: 'Detail', t: 1100 },
+  ];
+  const hit = lookaheadNavigate(events, 0, 1000);
+  assert.ok(hit);
+  assert.equal(hit.event.to, 'Detail');
+});
+
+test('B137: Maestro tap + nav emits navigated comment inline', () => {
+  const events = [
+    { type: 'tap', testID: 'tab-tasks', t: 1000 },
+    { type: 'navigate', from: 'Home', to: 'Tasks', t: 1100 },
+    { type: 'tap', testID: 'task-row-1', t: 1500 },
+  ];
+  const out = generateMaestro(events);
+  assert.match(out, /- tapOn:\s+id: "tab-tasks"\s+# navigated: Home -> Tasks/);
+  // lookahead assertVisible should point at task-row-1 (next selector after navigate)
+  assert.match(out, /- assertVisible:\s+id: "task-row-1"/);
+});
+
+test('B137: Maestro does NOT double-emit navigate — only once, not from both branches', () => {
+  const events = [
+    { type: 'tap', testID: 'cta', t: 1000 },
+    { type: 'navigate', from: 'Start', to: 'End', t: 1100 },
+  ];
+  const out = generateMaestro(events);
+  const navComments = (out.match(/# navigated: Start -> End/g) ?? []).length;
+  assert.equal(navComments, 1, 'navigate comment must appear exactly once');
+});
+
+test('B137: Maestro falls back to navigate branch when tap is NOT followed by navigate within window', () => {
+  const events = [
+    { type: 'tap', testID: 'lonely', t: 1000 },
+    { type: 'annotation', note: 'wait', t: 1500 },
+    { type: 'navigate', from: 'A', to: 'B', t: 3000 },
+    { type: 'tap', testID: 'on-b', t: 3100 },
+  ];
+  const out = generateMaestro(events);
+  assert.match(out, /# navigated: A -> B/);
+  assert.match(out, /- assertVisible:\s+id: "on-b"/);
+});
+
+test('B137: Maestro emits navigate branch when no preceding tap exists', () => {
+  const events = [
+    { type: 'navigate', from: 'Splash', to: 'Login', t: 1 },
+    { type: 'tap', testID: 'username', t: 2 },
+  ];
+  const out = generateMaestro(events);
+  assert.match(out, /# navigated: Splash -> Login/);
+  assert.match(out, /- assertVisible:\s+id: "username"/);
+});
+
+test('B137: Detox tap + nav emits navigated comment + toBeVisible inline', () => {
+  const events = [
+    { type: 'tap', testID: 'tab-tasks', t: 1000 },
+    { type: 'navigate', from: 'Home', to: 'Tasks', t: 1050 },
+    { type: 'tap', testID: 'row', t: 2000 },
+  ];
+  const out = generateDetox(events);
+  assert.match(out, /await element\(by\.id\("tab-tasks"\)\)\.tap\(\);/);
+  assert.match(out, /\/\/ navigated: Home -> Tasks/);
+  assert.match(out, /await expect\(element\(by\.id\("row"\)\)\)\.toBeVisible\(\)/);
+});
+
+test('B137: Detox does NOT double-emit navigate comment', () => {
+  const events = [
+    { type: 'tap', testID: 'cta', t: 1000 },
+    { type: 'navigate', from: 'Start', to: 'End', t: 1100 },
+  ];
+  const out = generateDetox(events);
+  const navComments = (out.match(/\/\/ navigated: Start -> End/g) ?? []).length;
+  assert.equal(navComments, 1);
+});


### PR DESCRIPTION
## Summary

Batch fix for six bugs surfaced during the M6 benchmark QA session (docs/qa/m6-benchmark-stories/). All validated via parallel Gemini + Codex multi-review. 632 unit tests pass (+27 new).

| Bug | Severity | Fix | Files |
|---|---|---|---|
| B136 | MEDIUM | Generator emits `# startRoute:` preamble | `test-recorder.ts`, `test-recorder-generators.ts` |
| B137 | MEDIUM | Generator tap→nav classifier (1000ms lookahead, consume-nav) | `test-recorder-generators.ts` |
| B139 | MEDIUM | `cdp_dispatch` adds optional `payloadJson` for type preservation | `dispatch.ts`, `index.ts` |
| B140 | LOW-MED | `cdp_set_shared_value` reads back `.value`, returns `{written, observed, drift}` | `index.ts` |
| B141 | LOW | Recorder hooks `onFocus` for TextInput focus-taps (guarded against Pressable overlap) | `test-recorder-helpers.ts` |
| B142 | LOW | `cdp_component_tree({filter})` dedups by fiber ancestry (WeakSet + `fiber.return`) | `injected-helpers.ts` |

B138 closed as NOT-A-BUG — React Navigation swallows `onPress` on already-active tab, not a plugin defect (see BUGS.md entry).

## Versions

- plugin: **0.42.0 → 0.43.0**
- MCP: **0.36.0 → 0.37.0**

## Multi-review summary

- **Gemini**: 1 actionable at confidence 85 — applied inline. B141 `onFocus` hook now skips when `onPress` is present on the same props object (prevents double-emit on Pressable-wraps-TextInput with distinct testIDs).
- **Codex**: approved all 6 fixes. Explicitly verified B142 ancestor scan is sound (BFS only traverses committed tree via child/sibling, never `.alternate` WIP fibers).

## Test plan

- [x] `npm run build` clean (tsc no errors)
- [x] `npm test` — 632 passing (605 previous + 27 new: 11 B139 + 16 B136/B137)
- [ ] Post-merge live verification on iOS + Android:
  - B139: `cdp_dispatch({action:"tasks/setDescription", payloadJson:'"42"'})` → reducer receives string "42"
  - B140: `cdp_set_shared_value({testID, prop, value: 200})` → response has `written: 200, observed: 200, drift: false`
  - B141: focus a TextInput first, type → `typeCounts` includes tap for the focus
  - B136: record a flow starting on ProfileTab → generated YAML has `# startRoute: ProfileTab`
  - B137: record `tap tab-tasks → nav Home→Tasks` → YAML emits `# navigated: Home -> Tasks` + `assertVisible` after `tapOn`
  - B142: `cdp_component_tree({filter:"tab-tasks"})` returns ONE match (not 2-4)

## Follow-ups (not in this PR)

- **B137 swipe-to-nav correlation**: Gemini at confidence 80 noted `lookaheadNavigate` doesn't accept swipe as source. Swipe-navigates still work (standalone `# navigated:` branch covers them), but inline correlation for swipe-to-route-change is a v2 opportunity. Logged as deferred.
- **B134 / B135 merges**: PRs #63 and #64 are still OPEN, MERGEABLE, CI green. This PR does NOT depend on them — but Story D and any other flow exercising `cdp_nav_graph` / `cdp_record_test_save` will keep repro'ing until those merge + Claude Code restart.