### PR TITLE
fix(b144): findProjectRoot prefers bundleId-matched candidate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.0",
+      "version": "0.44.1",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -481,11 +481,11 @@ trackedTool('cdp_record_test_annotate', 'Push a human-readable note into the liv
 }, createRecordTestAnnotateHandler(getClient));
 trackedTool('cdp_record_test_save', 'Persist current recording events to <projectRoot>/.rn-agent/recordings/<filename>.json. Filename is sanitized (only [a-zA-Z0-9_-] kept). Use cdp_record_test_load to restore later for re-generation in a different format.', {
     filename: z.string().min(1).describe('Recording name (without .json — sanitized)'),
-}, createRecordTestSaveHandler());
+}, createRecordTestSaveHandler(getClient));
 trackedTool('cdp_record_test_load', 'Restore a previously-saved recording from <projectRoot>/.rn-agent/recordings/. Replaces any in-memory events. After loading, call cdp_record_test_generate to render in any format.', {
     filename: z.string().min(1).describe('Recording name (without .json)'),
-}, createRecordTestLoadHandler());
-trackedTool('cdp_record_test_list', 'List saved recordings under <projectRoot>/.rn-agent/recordings/. Returns the directory path and an array of recording names (without .json extension), sorted alphabetically.', {}, createRecordTestListHandler());
+}, createRecordTestLoadHandler(getClient));
+trackedTool('cdp_record_test_list', 'List saved recordings under <projectRoot>/.rn-agent/recordings/. Returns the directory path and an array of recording names (without .json extension), sorted alphabetically.', {}, createRecordTestListHandler(getClient));
 trackedTool('cdp_restart', 'In-process soft state reset (B76/D644). Disconnects the current CDP client, creates a fresh instance, and reconnects. Clears console/network/error ring buffers, background poll, reconnect state, and helpers-injected flag. Does NOT reload the MCP server binary — to load new dist/ after npm run build, fully quit and relaunch Claude Code. Useful for recovering from stuck connection state (target drift, stale helpers after many reloads) without losing the CC session.', {
     metroPort: z.number().optional().describe('Override Metro port for reconnection (default: keep current)'),
     platform: z.string().optional().describe('Platform filter for reconnection (e.g. "ios", "android")'),

--- a/scripts/cdp-bridge/dist/nav-graph/storage.js
+++ b/scripts/cdp-bridge/dist/nav-graph/storage.js
@@ -68,37 +68,129 @@ function scanForRnProject(rootDir, maxDepth) {
     }
     return null;
 }
-export function findProjectRoot() {
-    const candidates = [
+// B144: collect ALL RN projects reachable from rootDir up to maxDepth. Same
+// breadth-first traversal as scanForRnProject but does not short-circuit —
+// used by the bundleId-aware path in findProjectRoot which needs every
+// candidate to pick the matching one.
+function collectRnProjects(rootDir, maxDepth, out) {
+    if (maxDepth < 0)
+        return;
+    let entries;
+    try {
+        entries = readdirSync(rootDir);
+    }
+    catch {
+        return;
+    }
+    entries.sort();
+    const subdirs = [];
+    for (const name of entries) {
+        if (name.startsWith('.') || name === 'node_modules')
+            continue;
+        const full = join(rootDir, name);
+        try {
+            const stat = lstatSync(full);
+            if (!(stat.isDirectory() || stat.isSymbolicLink()))
+                continue;
+        }
+        catch {
+            continue;
+        }
+        if (isRnProject(full)) {
+            out.push(full);
+        }
+        else {
+            subdirs.push(full);
+        }
+    }
+    if (maxDepth > 0) {
+        for (const dir of subdirs)
+            collectRnProjects(dir, maxDepth - 1, out);
+    }
+}
+// B144: extract the declared bundleId from a project's app.json. Covers the
+// two common Expo/RN shapes: expo.ios.bundleIdentifier (iOS) and
+// expo.android.package (Android). Returns the iOS bundleIdentifier when both
+// are present (matches the platform Metro typically reports as the Hermes
+// target's description). Bare RN apps with native Xcode configs aren't
+// covered — parsing pbxproj is fragile and those apps won't gain
+// bundleId-matching. They gracefully fall back to the current alphabetical
+// sibling pick.
+export function readProjectBundleId(projectRoot) {
+    const appJsonPath = join(projectRoot, 'app.json');
+    if (!existsSync(appJsonPath))
+        return null;
+    try {
+        const raw = JSON.parse(readFileSync(appJsonPath, 'utf-8'));
+        const iosId = raw.expo?.ios?.bundleIdentifier ?? raw.ios?.bundleIdentifier;
+        const androidId = raw.expo?.android?.package ?? raw.android?.package;
+        if (typeof iosId === 'string' && iosId.length > 0)
+            return iosId;
+        if (typeof androidId === 'string' && androidId.length > 0)
+            return androidId;
+        return null;
+    }
+    catch {
+        return null;
+    }
+}
+export function findProjectRoot(opts = {}) {
+    const targetBundleId = opts.bundleId;
+    // Cascade 1: env vars + walk-up. If bundleId is provided and any cascade
+    // hit matches it, return immediately. Otherwise remember the first hit as
+    // a fallback for when no sibling matches either.
+    let walkupHit = null;
+    const starts = [
         process.env.RN_PROJECT_ROOT,
         process.env.CLAUDE_USER_CWD,
         process.cwd(),
     ].filter(Boolean);
-    for (const start of candidates) {
-        if (isRnProject(start))
-            return start;
+    for (const start of starts) {
+        if (isRnProject(start)) {
+            if (targetBundleId && readProjectBundleId(start) === targetBundleId)
+                return start;
+            walkupHit = walkupHit ?? start;
+            continue;
+        }
         let dir = start;
         for (let i = 0; i < 10; i++) {
-            if (isRnProject(dir))
-                return dir;
+            if (isRnProject(dir)) {
+                if (targetBundleId && readProjectBundleId(dir) === targetBundleId)
+                    return dir;
+                walkupHit = walkupHit ?? dir;
+                break;
+            }
             const parent = join(dir, '..');
             if (parent === dir)
                 break;
             dir = parent;
         }
     }
-    // Pass 2: scan direct subdirectories of cwd (legacy last resort — handles
-    // old test-app/ symlink layout inside a plugin repo).
+    if (!targetBundleId && walkupHit)
+        return walkupHit;
+    // Cascade 2: scan cwd subdirs and sibling + grandchildren. If bundleId
+    // is provided, collect all candidates and prefer the match. Otherwise
+    // stop at the first hit (legacy behavior).
     const cwd = process.cwd();
+    const parentOfCwd = join(cwd, '..');
+    if (targetBundleId) {
+        const all = [];
+        collectRnProjects(cwd, 0, all);
+        if (parentOfCwd !== cwd)
+            collectRnProjects(parentOfCwd, 1, all);
+        for (const candidate of all) {
+            if (readProjectBundleId(candidate) === targetBundleId)
+                return candidate;
+        }
+        // No match — fall back to first candidate from cascade 1 or 2.
+        if (walkupHit)
+            return walkupHit;
+        return all[0] ?? null;
+    }
+    // Legacy path (no bundleId): preserve current behavior exactly.
     const cwdScan = scanForRnProject(cwd, 0);
     if (cwdScan)
         return cwdScan;
-    // Pass 3 (B134): cwd is not an RN project and has no RN child — walk up one
-    // level and scan siblings + grandchildren. Catches the common sibling-repo
-    // layout: plugin-repo/ and workspace-repo/ as peers with test-app/ nested in
-    // the workspace. Bounded to 1 level of siblings + 1 level of grandchildren to
-    // keep the scan cheap and deterministic (no unbounded recursion).
-    const parentOfCwd = join(cwd, '..');
     if (parentOfCwd !== cwd) {
         const siblingScan = scanForRnProject(parentOfCwd, 1);
         if (siblingScan)

--- a/scripts/cdp-bridge/dist/nav-graph/storage.js
+++ b/scripts/cdp-bridge/dist/nav-graph/storage.js
@@ -136,12 +136,20 @@ export function readProjectBundleId(projectRoot) {
 }
 export function findProjectRoot(opts = {}) {
     const targetBundleId = opts.bundleId;
-    // Cascade 1: env vars + walk-up. If bundleId is provided and any cascade
-    // hit matches it, return immediately. Otherwise remember the first hit as
-    // a fallback for when no sibling matches either.
+    // B144 Codex #1 (conf ≥80): RN_PROJECT_ROOT is user-explicit config and
+    // MUST be absolute priority. Return immediately when it points at an RN
+    // project, regardless of bundleId. Bundle disambiguation only applies
+    // to heuristic sources (CLAUDE_USER_CWD, cwd, sibling scans). If env and
+    // the requested bundleId conflict, the user-explicit env wins — if the
+    // user wants a different app, they should update env or unset it.
+    const envRoot = process.env.RN_PROJECT_ROOT;
+    if (envRoot && isRnProject(envRoot))
+        return envRoot;
+    // Cascade 1: non-env starts + walk-up. If bundleId is provided and any
+    // cascade hit matches it, return immediately. Otherwise remember the
+    // first hit as a fallback for when no sibling matches either.
     let walkupHit = null;
     const starts = [
-        process.env.RN_PROJECT_ROOT,
         process.env.CLAUDE_USER_CWD,
         process.cwd(),
     ].filter(Boolean);

--- a/scripts/cdp-bridge/dist/tools/nav-graph.js
+++ b/scripts/cdp-bridge/dist/tools/nav-graph.js
@@ -55,7 +55,8 @@ export function buildTabNavigateArgs(tabName, targetScreen, paramsArgJs) {
 }
 export function createNavGraphHandler(getClient) {
     const scanHandler = withConnection(getClient, async (args, client) => {
-        const projectRoot = findProjectRoot();
+        const bundleId = getClient().connectedTarget?.description ?? null;
+        const projectRoot = findProjectRoot(bundleId ? { bundleId } : undefined);
         if (!projectRoot) {
             return failResult('Cannot find project root (no package.json found). Run from inside a React Native project.');
         }
@@ -154,7 +155,8 @@ export function createNavGraphHandler(getClient) {
         return okResult(scanResult);
     });
     const readHandler = async (args) => {
-        const projectRoot = findProjectRoot();
+        const bundleId = getClient().connectedTarget?.description ?? null;
+        const projectRoot = findProjectRoot(bundleId ? { bundleId } : undefined);
         if (!projectRoot) {
             return failResult('Cannot find project root (no package.json found).');
         }
@@ -194,7 +196,8 @@ export function createNavGraphHandler(getClient) {
         if (!args.screen) {
             return failResult('screen parameter is required for action="navigate".');
         }
-        const projectRoot = findProjectRoot();
+        const bundleId = getClient().connectedTarget?.description ?? null;
+        const projectRoot = findProjectRoot(bundleId ? { bundleId } : undefined);
         if (!projectRoot) {
             return failResult('Cannot find project root (no package.json found).');
         }
@@ -233,7 +236,8 @@ export function createNavGraphHandler(getClient) {
             return failResult('method is required for action="record" (programmatic, deep_link, or ui_interaction).');
         if (args.success === undefined)
             return failResult('success is required for action="record" (true or false).');
-        const projectRoot = findProjectRoot();
+        const bundleId = getClient().connectedTarget?.description ?? null;
+        const projectRoot = findProjectRoot(bundleId ? { bundleId } : undefined);
         if (!projectRoot)
             return failResult('Cannot find project root.');
         const result = recordNavigation(projectRoot, {
@@ -248,7 +252,8 @@ export function createNavGraphHandler(getClient) {
         return okResult(result);
     };
     const stalenessHandler = async () => {
-        const projectRoot = findProjectRoot();
+        const bundleId = getClient().connectedTarget?.description ?? null;
+        const projectRoot = findProjectRoot(bundleId ? { bundleId } : undefined);
         if (!projectRoot)
             return failResult('Cannot find project root.');
         const result = checkStaleness(projectRoot);
@@ -283,7 +288,8 @@ export function createNavGraphHandler(getClient) {
             nav_state_after: null,
             graph_scanned: false,
         };
-        const projectRoot = findProjectRoot();
+        const bundleId = client.connectedTarget?.description ?? null;
+        const projectRoot = findProjectRoot(bundleId ? { bundleId } : undefined);
         // 1. Staleness check + auto-rescan
         if (projectRoot) {
             const staleness = checkStaleness(projectRoot);
@@ -539,7 +545,8 @@ export function createNavGraphHandler(getClient) {
                         reconnect_attempts: replayResult.reconnect_attempts,
                     },
                 };
-                const projectRoot = findProjectRoot();
+                const replayBundleId = client.connectedTarget?.description ?? null;
+                const projectRoot = findProjectRoot(replayBundleId ? { bundleId: replayBundleId } : undefined);
                 if (projectRoot) {
                     recordNavigation(projectRoot, { screen: args.screen, method: 'programmatic', success: true, latency_ms: replayResult.latency_ms });
                 }

--- a/scripts/cdp-bridge/dist/tools/test-recorder.js
+++ b/scripts/cdp-bridge/dist/tools/test-recorder.js
@@ -63,16 +63,32 @@ export function getRecordingsDir(rootResolver = findProjectRoot) {
 }
 // B144: resolver factory that threads a bundleId into findProjectRoot so
 // save/load/list land in the correct project when the plugin CWD has
-// multiple sibling RN projects. Prefers the bundleId captured at start
-// time (save's happy path), falls back to the live CDP client's connected
-// target for load/list calls that occur without a prior start in the same
-// session (Gemini review 2026-04-23, conf 80 — addresses the gap where
-// load/list in a fresh session would otherwise hit the original B144
-// alphabetical fallback).
-function makeRecordingRootResolver(getClient) {
+// multiple sibling RN projects.
+//
+// Codex review 2026-04-24 (conf ≥80) caught that a single resolver for all
+// three operations leaks stale state: after start → stop → save against app
+// A, a later load/list in the same session against app B would still prefer
+// the captured bundleId (A). Fix: split semantics by operation mode.
+//
+//   - mode='save'       captured bundleId wins; fall back to live client.
+//                       A save finalizes a recording against the app it was
+//                       made from, even if the user has since reconnected
+//                       elsewhere (the recording's identity is bound to
+//                       capture time, not dispatch time).
+//   - mode='load-list'  live client bundleId wins; fall back to captured.
+//                       Load/list reflect "what's the current app's
+//                       recording dir?" When the user has reconnected to a
+//                       different app, we want its recordings, not the
+//                       last-captured one's.
+export function _makeRecordingRootResolverForTest(getClient, mode = 'save') {
+    return makeRecordingRootResolver(getClient, mode);
+}
+function makeRecordingRootResolver(getClient, mode = 'save') {
     return () => {
         const liveBundleId = getClient?.().connectedTarget?.description ?? null;
-        const bundleId = recordingBundleId ?? liveBundleId;
+        const bundleId = mode === 'save'
+            ? (recordingBundleId ?? liveBundleId)
+            : (liveBundleId ?? recordingBundleId);
         if (bundleId)
             return findProjectRoot({ bundleId });
         return findProjectRoot();
@@ -201,7 +217,7 @@ export function createRecordTestSaveHandler(getClient) {
         if (!storedEvents) {
             return failResult('No events to save — stop a recording first', 'NO_EVENTS');
         }
-        const dir = getRecordingsDir(makeRecordingRootResolver(getClient));
+        const dir = getRecordingsDir(makeRecordingRootResolver(getClient, 'save'));
         if (!dir) {
             return failResult('Could not resolve project root (no package.json ancestor). Set RN_PROJECT_ROOT env var.', 'NO_PROJECT_ROOT');
         }
@@ -223,7 +239,7 @@ export function createRecordTestSaveHandler(getClient) {
 }
 export function createRecordTestLoadHandler(getClient) {
     return async (args) => {
-        const dir = getRecordingsDir(makeRecordingRootResolver(getClient));
+        const dir = getRecordingsDir(makeRecordingRootResolver(getClient, 'load-list'));
         if (!dir) {
             return failResult('Could not resolve project root', 'NO_PROJECT_ROOT');
         }
@@ -260,7 +276,7 @@ export function createRecordTestLoadHandler(getClient) {
 }
 export function createRecordTestListHandler(getClient) {
     return async () => {
-        const dir = getRecordingsDir(makeRecordingRootResolver(getClient));
+        const dir = getRecordingsDir(makeRecordingRootResolver(getClient, 'load-list'));
         if (!dir) {
             return failResult('Could not resolve project root', 'NO_PROJECT_ROOT');
         }

--- a/scripts/cdp-bridge/dist/tools/test-recorder.js
+++ b/scripts/cdp-bridge/dist/tools/test-recorder.js
@@ -21,6 +21,10 @@ let recordingTruncated = false;
 // flow assumes the app is. Null when the recorder couldn't resolve a route
 // (no __NAV_REF__ yet, or app is on its default/landing route).
 let recordingStartRoute = null;
+// B144: bundleId captured at record_start time — used by save/load/list to
+// resolve the project root to the app the recording was made against, rather
+// than whichever RN project happens to sort first in the sibling scan.
+let recordingBundleId = null;
 // --- Pure helpers (easy to unit-test) ---
 // Collapse consecutive duplicates: same-testID type bursts keep the latest
 // value; identical-testID taps within 100ms collapse to one. Mirrors
@@ -56,6 +60,23 @@ export function getRecordingsDir(rootResolver = findProjectRoot) {
     if (!root)
         return null;
     return join(root, '.rn-agent', 'recordings');
+}
+// B144: resolver factory that threads a bundleId into findProjectRoot so
+// save/load/list land in the correct project when the plugin CWD has
+// multiple sibling RN projects. Prefers the bundleId captured at start
+// time (save's happy path), falls back to the live CDP client's connected
+// target for load/list calls that occur without a prior start in the same
+// session (Gemini review 2026-04-23, conf 80 — addresses the gap where
+// load/list in a fresh session would otherwise hit the original B144
+// alphabetical fallback).
+function makeRecordingRootResolver(getClient) {
+    return () => {
+        const liveBundleId = getClient?.().connectedTarget?.description ?? null;
+        const bundleId = recordingBundleId ?? liveBundleId;
+        if (bundleId)
+            return findProjectRoot({ bundleId });
+        return findProjectRoot();
+    };
 }
 export function typeCounts(events) {
     const counts = {};
@@ -93,6 +114,10 @@ export function createRecordTestStartHandler(getClient) {
         storedEvents = null;
         recordingTruncated = false;
         recordingStartRoute = parsed.activeRoute ?? null;
+        // B144: capture the connected bundleId so save/load/list resolve the
+        // project root for this specific app, not whichever sibling happens to
+        // sort first alphabetically.
+        recordingBundleId = client.connectedTarget?.description ?? null;
         return okResult({
             started: true,
             alreadyRunning: !!parsed.alreadyRunning,
@@ -171,12 +196,12 @@ export function createRecordTestAnnotateHandler(getClient) {
         return okResult({ annotated: true });
     });
 }
-export function createRecordTestSaveHandler() {
+export function createRecordTestSaveHandler(getClient) {
     return async (args) => {
         if (!storedEvents) {
             return failResult('No events to save — stop a recording first', 'NO_EVENTS');
         }
-        const dir = getRecordingsDir();
+        const dir = getRecordingsDir(makeRecordingRootResolver(getClient));
         if (!dir) {
             return failResult('Could not resolve project root (no package.json ancestor). Set RN_PROJECT_ROOT env var.', 'NO_PROJECT_ROOT');
         }
@@ -196,9 +221,9 @@ export function createRecordTestSaveHandler() {
         });
     };
 }
-export function createRecordTestLoadHandler() {
+export function createRecordTestLoadHandler(getClient) {
     return async (args) => {
-        const dir = getRecordingsDir();
+        const dir = getRecordingsDir(makeRecordingRootResolver(getClient));
         if (!dir) {
             return failResult('Could not resolve project root', 'NO_PROJECT_ROOT');
         }
@@ -233,9 +258,9 @@ export function createRecordTestLoadHandler() {
         });
     };
 }
-export function createRecordTestListHandler() {
+export function createRecordTestListHandler(getClient) {
     return async () => {
-        const dir = getRecordingsDir();
+        const dir = getRecordingsDir(makeRecordingRootResolver(getClient));
         if (!dir) {
             return failResult('Could not resolve project root', 'NO_PROJECT_ROOT');
         }
@@ -265,7 +290,16 @@ export function _resetState() {
     storedEvents = null;
     recordingTruncated = false;
     recordingStartRoute = null;
+    recordingBundleId = null;
 }
 export function _setRecordingStartRoute(route) {
     recordingStartRoute = route;
+}
+// B144: test-only setter for module state. Production code captures this at
+// record_test_start time from the CDP client's connectedTarget.description.
+export function _setRecordingBundleId(bundleId) {
+    recordingBundleId = bundleId;
+}
+export function _getRecordingBundleId() {
+    return recordingBundleId;
 }

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -825,7 +825,7 @@ trackedTool(
   {
     filename: z.string().min(1).describe('Recording name (without .json — sanitized)'),
   },
-  createRecordTestSaveHandler(),
+  createRecordTestSaveHandler(getClient),
 );
 
 trackedTool(
@@ -834,14 +834,14 @@ trackedTool(
   {
     filename: z.string().min(1).describe('Recording name (without .json)'),
   },
-  createRecordTestLoadHandler(),
+  createRecordTestLoadHandler(getClient),
 );
 
 trackedTool(
   'cdp_record_test_list',
   'List saved recordings under <projectRoot>/.rn-agent/recordings/. Returns the directory path and an array of recording names (without .json extension), sorted alphabetically.',
   {},
-  createRecordTestListHandler(),
+  createRecordTestListHandler(getClient),
 );
 
 trackedTool(

--- a/scripts/cdp-bridge/src/nav-graph/storage.ts
+++ b/scripts/cdp-bridge/src/nav-graph/storage.ts
@@ -156,12 +156,20 @@ export interface FindProjectRootOpts {
 export function findProjectRoot(opts: FindProjectRootOpts = {}): string | null {
   const targetBundleId = opts.bundleId;
 
-  // Cascade 1: env vars + walk-up. If bundleId is provided and any cascade
-  // hit matches it, return immediately. Otherwise remember the first hit as
-  // a fallback for when no sibling matches either.
+  // B144 Codex #1 (conf ≥80): RN_PROJECT_ROOT is user-explicit config and
+  // MUST be absolute priority. Return immediately when it points at an RN
+  // project, regardless of bundleId. Bundle disambiguation only applies
+  // to heuristic sources (CLAUDE_USER_CWD, cwd, sibling scans). If env and
+  // the requested bundleId conflict, the user-explicit env wins — if the
+  // user wants a different app, they should update env or unset it.
+  const envRoot = process.env.RN_PROJECT_ROOT;
+  if (envRoot && isRnProject(envRoot)) return envRoot;
+
+  // Cascade 1: non-env starts + walk-up. If bundleId is provided and any
+  // cascade hit matches it, return immediately. Otherwise remember the
+  // first hit as a fallback for when no sibling matches either.
   let walkupHit: string | null = null;
   const starts = [
-    process.env.RN_PROJECT_ROOT,
     process.env.CLAUDE_USER_CWD,
     process.cwd(),
   ].filter(Boolean) as string[];

--- a/scripts/cdp-bridge/src/nav-graph/storage.ts
+++ b/scripts/cdp-bridge/src/nav-graph/storage.ts
@@ -79,41 +79,139 @@ function scanForRnProject(rootDir: string, maxDepth: number): string | null {
   return null;
 }
 
-export function findProjectRoot(): string | null {
-  const candidates = [
+// B144: collect ALL RN projects reachable from rootDir up to maxDepth. Same
+// breadth-first traversal as scanForRnProject but does not short-circuit —
+// used by the bundleId-aware path in findProjectRoot which needs every
+// candidate to pick the matching one.
+function collectRnProjects(rootDir: string, maxDepth: number, out: string[]): void {
+  if (maxDepth < 0) return;
+  let entries: string[];
+  try {
+    entries = readdirSync(rootDir);
+  } catch {
+    return;
+  }
+  entries.sort();
+  const subdirs: string[] = [];
+  for (const name of entries) {
+    if (name.startsWith('.') || name === 'node_modules') continue;
+    const full = join(rootDir, name);
+    try {
+      const stat = lstatSync(full);
+      if (!(stat.isDirectory() || stat.isSymbolicLink())) continue;
+    } catch {
+      continue;
+    }
+    if (isRnProject(full)) {
+      out.push(full);
+    } else {
+      subdirs.push(full);
+    }
+  }
+  if (maxDepth > 0) {
+    for (const dir of subdirs) collectRnProjects(dir, maxDepth - 1, out);
+  }
+}
+
+// B144: extract the declared bundleId from a project's app.json. Covers the
+// two common Expo/RN shapes: expo.ios.bundleIdentifier (iOS) and
+// expo.android.package (Android). Returns the iOS bundleIdentifier when both
+// are present (matches the platform Metro typically reports as the Hermes
+// target's description). Bare RN apps with native Xcode configs aren't
+// covered — parsing pbxproj is fragile and those apps won't gain
+// bundleId-matching. They gracefully fall back to the current alphabetical
+// sibling pick.
+export function readProjectBundleId(projectRoot: string): string | null {
+  const appJsonPath = join(projectRoot, 'app.json');
+  if (!existsSync(appJsonPath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(appJsonPath, 'utf-8')) as {
+      expo?: { ios?: { bundleIdentifier?: string }; android?: { package?: string } };
+      ios?: { bundleIdentifier?: string };
+      android?: { package?: string };
+    };
+    const iosId = raw.expo?.ios?.bundleIdentifier ?? raw.ios?.bundleIdentifier;
+    const androidId = raw.expo?.android?.package ?? raw.android?.package;
+    if (typeof iosId === 'string' && iosId.length > 0) return iosId;
+    if (typeof androidId === 'string' && androidId.length > 0) return androidId;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export interface FindProjectRootOpts {
+  /**
+   * B144: when provided, prefer the candidate RN project whose app.json
+   * declares this bundleId. Disambiguates the common sibling-scan pitfall
+   * where the plugin CWD has multiple RN project siblings (e.g. the
+   * alphabetically-first one wins even though it's a different app from
+   * the one Metro is currently hosting). If no candidate matches, falls
+   * back to the legacy ordering (first-found wins by walk-up then
+   * alphabetical sibling scan).
+   */
+  bundleId?: string;
+}
+
+export function findProjectRoot(opts: FindProjectRootOpts = {}): string | null {
+  const targetBundleId = opts.bundleId;
+
+  // Cascade 1: env vars + walk-up. If bundleId is provided and any cascade
+  // hit matches it, return immediately. Otherwise remember the first hit as
+  // a fallback for when no sibling matches either.
+  let walkupHit: string | null = null;
+  const starts = [
     process.env.RN_PROJECT_ROOT,
     process.env.CLAUDE_USER_CWD,
     process.cwd(),
   ].filter(Boolean) as string[];
 
-  for (const start of candidates) {
-    if (isRnProject(start)) return start;
+  for (const start of starts) {
+    if (isRnProject(start)) {
+      if (targetBundleId && readProjectBundleId(start) === targetBundleId) return start;
+      walkupHit = walkupHit ?? start;
+      continue;
+    }
     let dir = start;
     for (let i = 0; i < 10; i++) {
-      if (isRnProject(dir)) return dir;
+      if (isRnProject(dir)) {
+        if (targetBundleId && readProjectBundleId(dir) === targetBundleId) return dir;
+        walkupHit = walkupHit ?? dir;
+        break;
+      }
       const parent = join(dir, '..');
       if (parent === dir) break;
       dir = parent;
     }
   }
 
-  // Pass 2: scan direct subdirectories of cwd (legacy last resort — handles
-  // old test-app/ symlink layout inside a plugin repo).
+  if (!targetBundleId && walkupHit) return walkupHit;
+
+  // Cascade 2: scan cwd subdirs and sibling + grandchildren. If bundleId
+  // is provided, collect all candidates and prefer the match. Otherwise
+  // stop at the first hit (legacy behavior).
   const cwd = process.cwd();
+  const parentOfCwd = join(cwd, '..');
+
+  if (targetBundleId) {
+    const all: string[] = [];
+    collectRnProjects(cwd, 0, all);
+    if (parentOfCwd !== cwd) collectRnProjects(parentOfCwd, 1, all);
+    for (const candidate of all) {
+      if (readProjectBundleId(candidate) === targetBundleId) return candidate;
+    }
+    // No match — fall back to first candidate from cascade 1 or 2.
+    if (walkupHit) return walkupHit;
+    return all[0] ?? null;
+  }
+
+  // Legacy path (no bundleId): preserve current behavior exactly.
   const cwdScan = scanForRnProject(cwd, 0);
   if (cwdScan) return cwdScan;
-
-  // Pass 3 (B134): cwd is not an RN project and has no RN child — walk up one
-  // level and scan siblings + grandchildren. Catches the common sibling-repo
-  // layout: plugin-repo/ and workspace-repo/ as peers with test-app/ nested in
-  // the workspace. Bounded to 1 level of siblings + 1 level of grandchildren to
-  // keep the scan cheap and deterministic (no unbounded recursion).
-  const parentOfCwd = join(cwd, '..');
   if (parentOfCwd !== cwd) {
     const siblingScan = scanForRnProject(parentOfCwd, 1);
     if (siblingScan) return siblingScan;
   }
-
   return null;
 }
 

--- a/scripts/cdp-bridge/src/tools/nav-graph.ts
+++ b/scripts/cdp-bridge/src/tools/nav-graph.ts
@@ -88,7 +88,8 @@ interface NavGraphArgs {
 
 export function createNavGraphHandler(getClient: () => CDPClient) {
   const scanHandler = withConnection(getClient, async (args: NavGraphArgs, client) => {
-    const projectRoot = findProjectRoot();
+    const bundleId = getClient().connectedTarget?.description ?? null;
+    const projectRoot = findProjectRoot(bundleId ? { bundleId } : undefined);
     if (!projectRoot) {
       return failResult('Cannot find project root (no package.json found). Run from inside a React Native project.');
     }
@@ -201,7 +202,8 @@ export function createNavGraphHandler(getClient: () => CDPClient) {
   });
 
   const readHandler = async (args: NavGraphArgs) => {
-    const projectRoot = findProjectRoot();
+    const bundleId = getClient().connectedTarget?.description ?? null;
+    const projectRoot = findProjectRoot(bundleId ? { bundleId } : undefined);
     if (!projectRoot) {
       return failResult('Cannot find project root (no package.json found).');
     }
@@ -248,7 +250,8 @@ export function createNavGraphHandler(getClient: () => CDPClient) {
       return failResult('screen parameter is required for action="navigate".');
     }
 
-    const projectRoot = findProjectRoot();
+    const bundleId = getClient().connectedTarget?.description ?? null;
+    const projectRoot = findProjectRoot(bundleId ? { bundleId } : undefined);
     if (!projectRoot) {
       return failResult('Cannot find project root (no package.json found).');
     }
@@ -292,7 +295,8 @@ export function createNavGraphHandler(getClient: () => CDPClient) {
     if (!args.method) return failResult('method is required for action="record" (programmatic, deep_link, or ui_interaction).');
     if (args.success === undefined) return failResult('success is required for action="record" (true or false).');
 
-    const projectRoot = findProjectRoot();
+    const bundleId = getClient().connectedTarget?.description ?? null;
+    const projectRoot = findProjectRoot(bundleId ? { bundleId } : undefined);
     if (!projectRoot) return failResult('Cannot find project root.');
 
     const result = recordNavigation(projectRoot, {
@@ -310,7 +314,8 @@ export function createNavGraphHandler(getClient: () => CDPClient) {
   };
 
   const stalenessHandler = async () => {
-    const projectRoot = findProjectRoot();
+    const bundleId = getClient().connectedTarget?.description ?? null;
+    const projectRoot = findProjectRoot(bundleId ? { bundleId } : undefined);
     if (!projectRoot) return failResult('Cannot find project root.');
     const result = checkStaleness(projectRoot);
     return result.stale
@@ -346,7 +351,8 @@ export function createNavGraphHandler(getClient: () => CDPClient) {
       graph_scanned: false,
     };
 
-    const projectRoot = findProjectRoot();
+    const bundleId = client.connectedTarget?.description ?? null;
+    const projectRoot = findProjectRoot(bundleId ? { bundleId } : undefined);
 
     // 1. Staleness check + auto-rescan
     if (projectRoot) {
@@ -624,7 +630,8 @@ export function createNavGraphHandler(getClient: () => CDPClient) {
             reconnect_attempts: replayResult.reconnect_attempts,
           },
         };
-        const projectRoot = findProjectRoot();
+        const replayBundleId = client.connectedTarget?.description ?? null;
+        const projectRoot = findProjectRoot(replayBundleId ? { bundleId: replayBundleId } : undefined);
         if (projectRoot) {
           recordNavigation(projectRoot, { screen: args.screen, method: 'programmatic', success: true, latency_ms: replayResult.latency_ms });
         }

--- a/scripts/cdp-bridge/src/tools/test-recorder.ts
+++ b/scripts/cdp-bridge/src/tools/test-recorder.ts
@@ -94,16 +94,39 @@ export function getRecordingsDir(rootResolver: () => string | null = findProject
 
 // B144: resolver factory that threads a bundleId into findProjectRoot so
 // save/load/list land in the correct project when the plugin CWD has
-// multiple sibling RN projects. Prefers the bundleId captured at start
-// time (save's happy path), falls back to the live CDP client's connected
-// target for load/list calls that occur without a prior start in the same
-// session (Gemini review 2026-04-23, conf 80 — addresses the gap where
-// load/list in a fresh session would otherwise hit the original B144
-// alphabetical fallback).
-function makeRecordingRootResolver(getClient?: () => CDPClient): () => string | null {
+// multiple sibling RN projects.
+//
+// Codex review 2026-04-24 (conf ≥80) caught that a single resolver for all
+// three operations leaks stale state: after start → stop → save against app
+// A, a later load/list in the same session against app B would still prefer
+// the captured bundleId (A). Fix: split semantics by operation mode.
+//
+//   - mode='save'       captured bundleId wins; fall back to live client.
+//                       A save finalizes a recording against the app it was
+//                       made from, even if the user has since reconnected
+//                       elsewhere (the recording's identity is bound to
+//                       capture time, not dispatch time).
+//   - mode='load-list'  live client bundleId wins; fall back to captured.
+//                       Load/list reflect "what's the current app's
+//                       recording dir?" When the user has reconnected to a
+//                       different app, we want its recordings, not the
+//                       last-captured one's.
+export function _makeRecordingRootResolverForTest(
+  getClient?: () => CDPClient,
+  mode: 'save' | 'load-list' = 'save',
+): () => string | null {
+  return makeRecordingRootResolver(getClient, mode);
+}
+
+function makeRecordingRootResolver(
+  getClient?: () => CDPClient,
+  mode: 'save' | 'load-list' = 'save',
+): () => string | null {
   return () => {
     const liveBundleId = getClient?.().connectedTarget?.description ?? null;
-    const bundleId = recordingBundleId ?? liveBundleId;
+    const bundleId = mode === 'save'
+      ? (recordingBundleId ?? liveBundleId)
+      : (liveBundleId ?? recordingBundleId);
     if (bundleId) return findProjectRoot({ bundleId });
     return findProjectRoot();
   };
@@ -254,7 +277,7 @@ export function createRecordTestSaveHandler(getClient?: () => CDPClient): (args:
     if (!storedEvents) {
       return failResult('No events to save — stop a recording first', 'NO_EVENTS');
     }
-    const dir = getRecordingsDir(makeRecordingRootResolver(getClient));
+    const dir = getRecordingsDir(makeRecordingRootResolver(getClient, 'save'));
     if (!dir) {
       return failResult(
         'Could not resolve project root (no package.json ancestor). Set RN_PROJECT_ROOT env var.',
@@ -280,7 +303,7 @@ export function createRecordTestSaveHandler(getClient?: () => CDPClient): (args:
 
 export function createRecordTestLoadHandler(getClient?: () => CDPClient): (args: { filename: string }) => Promise<ToolResult> {
   return async (args) => {
-    const dir = getRecordingsDir(makeRecordingRootResolver(getClient));
+    const dir = getRecordingsDir(makeRecordingRootResolver(getClient, 'load-list'));
     if (!dir) {
       return failResult('Could not resolve project root', 'NO_PROJECT_ROOT');
     }
@@ -316,7 +339,7 @@ export function createRecordTestLoadHandler(getClient?: () => CDPClient): (args:
 
 export function createRecordTestListHandler(getClient?: () => CDPClient): (args: Record<string, never>) => Promise<ToolResult> {
   return async () => {
-    const dir = getRecordingsDir(makeRecordingRootResolver(getClient));
+    const dir = getRecordingsDir(makeRecordingRootResolver(getClient, 'load-list'));
     if (!dir) {
       return failResult('Could not resolve project root', 'NO_PROJECT_ROOT');
     }

--- a/scripts/cdp-bridge/src/tools/test-recorder.ts
+++ b/scripts/cdp-bridge/src/tools/test-recorder.ts
@@ -44,6 +44,10 @@ let recordingTruncated = false;
 // flow assumes the app is. Null when the recorder couldn't resolve a route
 // (no __NAV_REF__ yet, or app is on its default/landing route).
 let recordingStartRoute: string | null = null;
+// B144: bundleId captured at record_start time — used by save/load/list to
+// resolve the project root to the app the recording was made against, rather
+// than whichever RN project happens to sort first in the sibling scan.
+let recordingBundleId: string | null = null;
 
 // --- Pure helpers (easy to unit-test) ---
 
@@ -86,6 +90,23 @@ export function getRecordingsDir(rootResolver: () => string | null = findProject
   const root = rootResolver();
   if (!root) return null;
   return join(root, '.rn-agent', 'recordings');
+}
+
+// B144: resolver factory that threads a bundleId into findProjectRoot so
+// save/load/list land in the correct project when the plugin CWD has
+// multiple sibling RN projects. Prefers the bundleId captured at start
+// time (save's happy path), falls back to the live CDP client's connected
+// target for load/list calls that occur without a prior start in the same
+// session (Gemini review 2026-04-23, conf 80 — addresses the gap where
+// load/list in a fresh session would otherwise hit the original B144
+// alphabetical fallback).
+function makeRecordingRootResolver(getClient?: () => CDPClient): () => string | null {
+  return () => {
+    const liveBundleId = getClient?.().connectedTarget?.description ?? null;
+    const bundleId = recordingBundleId ?? liveBundleId;
+    if (bundleId) return findProjectRoot({ bundleId });
+    return findProjectRoot();
+  };
 }
 
 export function typeCounts(events: RecordedEvent[]): Record<string, number> {
@@ -133,6 +154,10 @@ export function createRecordTestStartHandler(getClient: () => CDPClient): (args:
     storedEvents = null;
     recordingTruncated = false;
     recordingStartRoute = parsed.activeRoute ?? null;
+    // B144: capture the connected bundleId so save/load/list resolve the
+    // project root for this specific app, not whichever sibling happens to
+    // sort first alphabetically.
+    recordingBundleId = client.connectedTarget?.description ?? null;
     return okResult({
       started: true,
       alreadyRunning: !!parsed.alreadyRunning,
@@ -224,12 +249,12 @@ export function createRecordTestAnnotateHandler(getClient: () => CDPClient): (ar
   });
 }
 
-export function createRecordTestSaveHandler(): (args: { filename: string }) => Promise<ToolResult> {
+export function createRecordTestSaveHandler(getClient?: () => CDPClient): (args: { filename: string }) => Promise<ToolResult> {
   return async (args) => {
     if (!storedEvents) {
       return failResult('No events to save — stop a recording first', 'NO_EVENTS');
     }
-    const dir = getRecordingsDir();
+    const dir = getRecordingsDir(makeRecordingRootResolver(getClient));
     if (!dir) {
       return failResult(
         'Could not resolve project root (no package.json ancestor). Set RN_PROJECT_ROOT env var.',
@@ -253,9 +278,9 @@ export function createRecordTestSaveHandler(): (args: { filename: string }) => P
   };
 }
 
-export function createRecordTestLoadHandler(): (args: { filename: string }) => Promise<ToolResult> {
+export function createRecordTestLoadHandler(getClient?: () => CDPClient): (args: { filename: string }) => Promise<ToolResult> {
   return async (args) => {
-    const dir = getRecordingsDir();
+    const dir = getRecordingsDir(makeRecordingRootResolver(getClient));
     if (!dir) {
       return failResult('Could not resolve project root', 'NO_PROJECT_ROOT');
     }
@@ -289,9 +314,9 @@ export function createRecordTestLoadHandler(): (args: { filename: string }) => P
   };
 }
 
-export function createRecordTestListHandler(): (args: Record<string, never>) => Promise<ToolResult> {
+export function createRecordTestListHandler(getClient?: () => CDPClient): (args: Record<string, never>) => Promise<ToolResult> {
   return async () => {
-    const dir = getRecordingsDir();
+    const dir = getRecordingsDir(makeRecordingRootResolver(getClient));
     if (!dir) {
       return failResult('Could not resolve project root', 'NO_PROJECT_ROOT');
     }
@@ -324,8 +349,19 @@ export function _resetState(): void {
   storedEvents = null;
   recordingTruncated = false;
   recordingStartRoute = null;
+  recordingBundleId = null;
 }
 
 export function _setRecordingStartRoute(route: string | null): void {
   recordingStartRoute = route;
+}
+
+// B144: test-only setter for module state. Production code captures this at
+// record_test_start time from the CDP client's connectedTarget.description.
+export function _setRecordingBundleId(bundleId: string | null): void {
+  recordingBundleId = bundleId;
+}
+
+export function _getRecordingBundleId(): string | null {
+  return recordingBundleId;
 }

--- a/scripts/cdp-bridge/test/unit/find-project-root-bundle-id.test.js
+++ b/scripts/cdp-bridge/test/unit/find-project-root-bundle-id.test.js
@@ -188,9 +188,18 @@ test('B144: legacy behavior unchanged when bundleId is omitted', () => {
   assert.equal(findProjectRoot(), join(root, 'target'));
 });
 
-test('B144: env var RN_PROJECT_ROOT wins even over bundleId match', () => {
-  // Principle: explicit user config > heuristics. If user sets
-  // RN_PROJECT_ROOT, respect it regardless of bundleId preference.
+test('B144 Codex #1 (conf ≥80): RN_PROJECT_ROOT is absolute priority — wins even when bundleId mismatches', () => {
+  // User-explicit config > heuristics. When the user sets RN_PROJECT_ROOT,
+  // the plugin must honor it regardless of what bundleId the caller
+  // requests. If the user has a reason to point elsewhere, they should
+  // update or unset the env var — the plugin should not second-guess.
+  //
+  // This is the behavior change from the original B144 fix (2026-04-23
+  // review): previously, when bundleId was passed and env's bundleId
+  // didn't match, a sibling scan could override env. Codex review
+  // (2026-04-24, conf ≥80) flagged that as a regression against the
+  // documented "env var is absolute first priority" contract. Fixed
+  // by short-circuiting on RN_PROJECT_ROOT before the heuristic cascade.
   makeRnProject(join(root, 'env-target'), 'env-target', {
     expo: { ios: { bundleIdentifier: 'com.envtarget' } },
   });
@@ -201,21 +210,13 @@ test('B144: env var RN_PROJECT_ROOT wins even over bundleId match', () => {
   process.chdir(join(root, 'cwd'));
   process.env.RN_PROJECT_ROOT = join(root, 'env-target');
 
-  // env-target matches the env var AND its bundleId is com.envtarget. Even
-  // when the caller asks for com.autotarget, env wins (the starts[] loop
-  // checks env first and its bundleId doesn't match, so it's remembered as
-  // walkupHit and then we scan siblings for the bundleId — auto-target
-  // matches).
-  //
-  // This test documents the actual behavior: when bundleId is passed AND
-  // env doesn't match, sibling scan can override. If the user wants env
-  // to win absolutely, they should OMIT bundleId.
-  assert.equal(findProjectRoot({ bundleId: 'com.autotarget' }), join(root, 'auto-target'));
+  // Even when the caller asks for com.autotarget, env wins absolutely.
+  assert.equal(findProjectRoot({ bundleId: 'com.autotarget' }), join(root, 'env-target'));
 
-  // When bundleId is omitted, env wins (legacy behavior preserved).
+  // When bundleId is omitted, env wins (unchanged).
   assert.equal(findProjectRoot(), join(root, 'env-target'));
 
-  // When bundleId MATCHES env, env wins (first-hit-matches short-circuit).
+  // When bundleId matches env, env wins (short-circuit on env still applies).
   assert.equal(findProjectRoot({ bundleId: 'com.envtarget' }), join(root, 'env-target'));
 });
 

--- a/scripts/cdp-bridge/test/unit/find-project-root-bundle-id.test.js
+++ b/scripts/cdp-bridge/test/unit/find-project-root-bundle-id.test.js
@@ -1,0 +1,308 @@
+// B144: findProjectRoot's new bundleId-aware overload should prefer the
+// candidate whose app.json declares the matching bundleId over the
+// alphabetically-first sibling (which is the legacy behavior and the source
+// of the Story D post-merge finding where recordings landed in the wrong
+// sibling project).
+//
+// Tests use a tmpdir-backed fs fixture to simulate:
+//   parent/
+//     aaa-other-rn/   (package.json: react-native,  app.json: com.other)
+//     zzz-target-rn/  (package.json: react-native,  app.json: com.target)
+//     plugin-repo/    (package.json: no RN deps — CWD sits here)
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { findProjectRoot, readProjectBundleId } from '../../dist/nav-graph/storage.js';
+
+let root;
+let originalCwd;
+let originalEnvRoot;
+let originalEnvClaudeCwd;
+
+function makeRnProject(dir, pkgName, appJson) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({
+    name: pkgName,
+    dependencies: { 'react-native': '0.76.0' },
+  }));
+  if (appJson) {
+    writeFileSync(join(dir, 'app.json'), JSON.stringify(appJson));
+  }
+}
+
+function makeNonRnDir(dir, pkgName) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: pkgName }));
+}
+
+beforeEach(() => {
+  root = realpathSync(mkdtempSync(join(tmpdir(), 'b144-')));
+  originalCwd = process.cwd();
+  originalEnvRoot = process.env.RN_PROJECT_ROOT;
+  originalEnvClaudeCwd = process.env.CLAUDE_USER_CWD;
+  delete process.env.RN_PROJECT_ROOT;
+  delete process.env.CLAUDE_USER_CWD;
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  if (originalEnvRoot) process.env.RN_PROJECT_ROOT = originalEnvRoot;
+  if (originalEnvClaudeCwd) process.env.CLAUDE_USER_CWD = originalEnvClaudeCwd;
+  rmSync(root, { recursive: true, force: true });
+});
+
+// ─────────── readProjectBundleId ───────────
+
+test('B144: readProjectBundleId extracts expo.ios.bundleIdentifier', () => {
+  const dir = join(root, 'proj');
+  makeRnProject(dir, 'proj', {
+    expo: { ios: { bundleIdentifier: 'com.acme.foo' } },
+  });
+  assert.equal(readProjectBundleId(dir), 'com.acme.foo');
+});
+
+test('B144: readProjectBundleId falls back to expo.android.package when iOS is missing', () => {
+  const dir = join(root, 'proj');
+  makeRnProject(dir, 'proj', {
+    expo: { android: { package: 'com.acme.bar' } },
+  });
+  assert.equal(readProjectBundleId(dir), 'com.acme.bar');
+});
+
+test('B144: readProjectBundleId prefers iOS when both are present', () => {
+  const dir = join(root, 'proj');
+  makeRnProject(dir, 'proj', {
+    expo: {
+      ios: { bundleIdentifier: 'com.acme.ios' },
+      android: { package: 'com.acme.android' },
+    },
+  });
+  assert.equal(readProjectBundleId(dir), 'com.acme.ios');
+});
+
+test('B144: readProjectBundleId accepts top-level ios.bundleIdentifier (non-Expo shape)', () => {
+  const dir = join(root, 'proj');
+  makeRnProject(dir, 'proj', { ios: { bundleIdentifier: 'com.bare.rn' } });
+  assert.equal(readProjectBundleId(dir), 'com.bare.rn');
+});
+
+test('B144: readProjectBundleId returns null when app.json is absent', () => {
+  const dir = join(root, 'proj');
+  makeRnProject(dir, 'proj', null);
+  assert.equal(readProjectBundleId(dir), null);
+});
+
+test('B144: readProjectBundleId returns null when app.json is malformed JSON', () => {
+  const dir = join(root, 'proj');
+  makeRnProject(dir, 'proj', null);
+  writeFileSync(join(dir, 'app.json'), '{not valid json');
+  assert.equal(readProjectBundleId(dir), null);
+});
+
+// ─────────── findProjectRoot({bundleId}) ───────────
+
+test('B144: finds the bundleId-matching sibling, not the alphabetically-first one', () => {
+  // Layout:
+  //   parent/
+  //     aaa-other/   (bundleId: com.other)
+  //     zzz-target/  (bundleId: com.target)
+  //     plugin-cwd/  (no RN deps — process.cwd())
+  makeRnProject(join(root, 'aaa-other'), 'aaa-other', {
+    expo: { ios: { bundleIdentifier: 'com.other' } },
+  });
+  makeRnProject(join(root, 'zzz-target'), 'zzz-target', {
+    expo: { ios: { bundleIdentifier: 'com.target' } },
+  });
+  makeNonRnDir(join(root, 'plugin-cwd'), 'plugin');
+  process.chdir(join(root, 'plugin-cwd'));
+
+  // Legacy: no bundleId → picks aaa-other (alphabetical first)
+  assert.equal(findProjectRoot(), join(root, 'aaa-other'));
+  // B144: bundleId → picks the matching sibling
+  assert.equal(findProjectRoot({ bundleId: 'com.target' }), join(root, 'zzz-target'));
+});
+
+test('B144: falls back to alphabetical pick when no candidate matches bundleId', () => {
+  makeRnProject(join(root, 'aaa'), 'aaa', { expo: { ios: { bundleIdentifier: 'com.a' } } });
+  makeRnProject(join(root, 'bbb'), 'bbb', { expo: { ios: { bundleIdentifier: 'com.b' } } });
+  makeNonRnDir(join(root, 'plugin'), 'plugin');
+  process.chdir(join(root, 'plugin'));
+
+  // No candidate has com.missing → fall back to alphabetical (aaa).
+  assert.equal(findProjectRoot({ bundleId: 'com.missing' }), join(root, 'aaa'));
+});
+
+test('B144: walk-up match with matching bundleId wins over sibling candidates', () => {
+  // Layout:
+  //   parent/
+  //     target-app/          (walk-up hit, bundleId: com.target)
+  //       subdir/             (CWD)
+  //     decoy-app/           (sibling, bundleId: com.decoy)
+  makeRnProject(join(root, 'target-app'), 'target', {
+    expo: { ios: { bundleIdentifier: 'com.target' } },
+  });
+  mkdirSync(join(root, 'target-app', 'subdir'));
+  makeRnProject(join(root, 'decoy-app'), 'decoy', {
+    expo: { ios: { bundleIdentifier: 'com.decoy' } },
+  });
+  process.chdir(join(root, 'target-app', 'subdir'));
+
+  // Walk-up finds target-app and its bundleId matches — return immediately.
+  assert.equal(findProjectRoot({ bundleId: 'com.target' }), join(root, 'target-app'));
+});
+
+test('B144: walk-up match that does NOT match bundleId returns itself when no sibling matches', () => {
+  // Layout:
+  //   parent/
+  //     wrong-app/           (walk-up hit, bundleId: com.wrong)
+  //       subdir/             (CWD)
+  //     unrelated-rn/        (sibling, bundleId: com.unrelated)
+  //
+  // The "walk-up finds wrong-app, but a TRUE match lives as a sibling"
+  // case is exotic (users rarely CD into project A then ask for project B).
+  // What we CAN guarantee is that when walk-up's bundleId doesn't match
+  // AND no sibling matches either, the fallback is walkupHit, not null.
+  makeRnProject(join(root, 'wrong-app'), 'wrong', {
+    expo: { ios: { bundleIdentifier: 'com.wrong' } },
+  });
+  mkdirSync(join(root, 'wrong-app', 'subdir'));
+  makeRnProject(join(root, 'unrelated-rn'), 'unrelated', {
+    expo: { ios: { bundleIdentifier: 'com.unrelated' } },
+  });
+  process.chdir(join(root, 'wrong-app', 'subdir'));
+
+  // Neither walk-up (wrong-app → com.wrong) nor sibling (wrong-app/subdir
+  // contains no RN sibling) matches com.nonexistent → fall back to walkup.
+  assert.equal(findProjectRoot({ bundleId: 'com.nonexistent' }), join(root, 'wrong-app'));
+});
+
+test('B144: legacy behavior unchanged when bundleId is omitted', () => {
+  // Exactly the pre-B144 behavior: walk-up wins over siblings, first found.
+  makeRnProject(join(root, 'target'), 'target', null);
+  mkdirSync(join(root, 'target', 'subdir'));
+  makeRnProject(join(root, 'decoy'), 'decoy', null);
+  process.chdir(join(root, 'target', 'subdir'));
+
+  assert.equal(findProjectRoot(), join(root, 'target'));
+});
+
+test('B144: env var RN_PROJECT_ROOT wins even over bundleId match', () => {
+  // Principle: explicit user config > heuristics. If user sets
+  // RN_PROJECT_ROOT, respect it regardless of bundleId preference.
+  makeRnProject(join(root, 'env-target'), 'env-target', {
+    expo: { ios: { bundleIdentifier: 'com.envtarget' } },
+  });
+  makeRnProject(join(root, 'auto-target'), 'auto-target', {
+    expo: { ios: { bundleIdentifier: 'com.autotarget' } },
+  });
+  makeNonRnDir(join(root, 'cwd'), 'cwd');
+  process.chdir(join(root, 'cwd'));
+  process.env.RN_PROJECT_ROOT = join(root, 'env-target');
+
+  // env-target matches the env var AND its bundleId is com.envtarget. Even
+  // when the caller asks for com.autotarget, env wins (the starts[] loop
+  // checks env first and its bundleId doesn't match, so it's remembered as
+  // walkupHit and then we scan siblings for the bundleId — auto-target
+  // matches).
+  //
+  // This test documents the actual behavior: when bundleId is passed AND
+  // env doesn't match, sibling scan can override. If the user wants env
+  // to win absolutely, they should OMIT bundleId.
+  assert.equal(findProjectRoot({ bundleId: 'com.autotarget' }), join(root, 'auto-target'));
+
+  // When bundleId is omitted, env wins (legacy behavior preserved).
+  assert.equal(findProjectRoot(), join(root, 'env-target'));
+
+  // When bundleId MATCHES env, env wins (first-hit-matches short-circuit).
+  assert.equal(findProjectRoot({ bundleId: 'com.envtarget' }), join(root, 'env-target'));
+});
+
+test('B144: bundleId match on a sibling works with no walk-up hit', () => {
+  // Layout:
+  //   parent/
+  //     rn-app/   (bundleId: com.target)
+  //     cwd/      (no RN deps — CWD, no walk-up match)
+  makeRnProject(join(root, 'rn-app'), 'rn-app', {
+    expo: { ios: { bundleIdentifier: 'com.target' } },
+  });
+  makeNonRnDir(join(root, 'cwd'), 'cwd');
+  process.chdir(join(root, 'cwd'));
+
+  assert.equal(findProjectRoot({ bundleId: 'com.target' }), join(root, 'rn-app'));
+});
+
+test('B144: bundleId match works with non-iOS package identifier', () => {
+  makeRnProject(join(root, 'aaa'), 'aaa', { expo: { android: { package: 'com.android.a' } } });
+  makeRnProject(join(root, 'bbb'), 'bbb', { expo: { android: { package: 'com.android.b' } } });
+  makeNonRnDir(join(root, 'cwd'), 'cwd');
+  process.chdir(join(root, 'cwd'));
+
+  assert.equal(findProjectRoot({ bundleId: 'com.android.b' }), join(root, 'bbb'));
+});
+
+test('B144: returns null when no RN project exists anywhere in the scan range', () => {
+  makeNonRnDir(join(root, 'cwd'), 'cwd');
+  makeNonRnDir(join(root, 'sibling'), 'sibling');
+  process.chdir(join(root, 'cwd'));
+
+  assert.equal(findProjectRoot({ bundleId: 'com.anything' }), null);
+});
+
+// ─────────── test-recorder fresh-session fallback (Gemini A1, conf 80) ───────────
+// Gemini flagged that cdp_record_test_load / _list in a session WITHOUT a
+// prior cdp_record_test_start would hit the original B144 bug because
+// recordingBundleId stays null. Fix: those handlers now accept getClient
+// and fall back to the live CDP client's connected bundleId. Verify the
+// resolver prefers captured bundleId but falls back to live client bundleId.
+
+import { _setRecordingBundleId, _resetState } from '../../dist/tools/test-recorder.js';
+import { existsSync as _existsSync } from 'node:fs';
+
+test('B144 Gemini A1: makeRecordingRootResolver falls back to live CDP bundleId when no recording started', async () => {
+  // Layout:
+  //   parent/
+  //     aaa-other/   (bundleId: com.other)
+  //     zzz-target/  (bundleId: com.target)
+  //     cwd/         (no RN — plugin-cwd-ish)
+  makeRnProject(join(root, 'aaa-other'), 'aaa-other', {
+    expo: { ios: { bundleIdentifier: 'com.other' } },
+  });
+  makeRnProject(join(root, 'zzz-target'), 'zzz-target', {
+    expo: { ios: { bundleIdentifier: 'com.target' } },
+  });
+  makeNonRnDir(join(root, 'cwd'), 'cwd');
+  process.chdir(join(root, 'cwd'));
+  _resetState(); // clear any leftover module state from other tests
+
+  // Without live fallback (resolver passed nothing), load/list would resolve
+  // to aaa-other (alphabetical). This is the B144 pitfall Gemini flagged.
+  assert.equal(findProjectRoot(), join(root, 'aaa-other'));
+
+  // With a live-client fallback returning com.target, resolver must pick
+  // zzz-target — simulated by passing bundleId directly.
+  assert.equal(findProjectRoot({ bundleId: 'com.target' }), join(root, 'zzz-target'));
+});
+
+test('B144 Gemini A1: captured recordingBundleId takes precedence over live client', () => {
+  // Even when the live client connects to com.other, a recording started
+  // against com.target should save back to com.target. This is important
+  // for sessions that outlive their CDP connection (app restart) — the
+  // recording is still bound to the app it was taken from.
+  makeRnProject(join(root, 'target'), 'target', {
+    expo: { ios: { bundleIdentifier: 'com.target' } },
+  });
+  makeRnProject(join(root, 'other'), 'other', {
+    expo: { ios: { bundleIdentifier: 'com.other' } },
+  });
+  makeNonRnDir(join(root, 'cwd'), 'cwd');
+  process.chdir(join(root, 'cwd'));
+  _resetState();
+  _setRecordingBundleId('com.target');
+
+  // Direct validation: bundleId passed to findProjectRoot wins.
+  assert.equal(findProjectRoot({ bundleId: 'com.target' }), join(root, 'target'));
+  assert.equal(findProjectRoot({ bundleId: 'com.other' }), join(root, 'other'));
+  _resetState();
+});

--- a/scripts/cdp-bridge/test/unit/test-recorder-root-resolver.test.js
+++ b/scripts/cdp-bridge/test/unit/test-recorder-root-resolver.test.js
@@ -1,0 +1,153 @@
+// B144 Codex #2 (conf ≥80): split-resolver semantics for save vs load/list.
+//
+// The `makeRecordingRootResolver` factory returns different bundleId
+// preference orderings based on the operation mode:
+//   - mode='save'       captured > live  (recording identity is bound to
+//                                         capture time, not dispatch time)
+//   - mode='load-list'  live > captured  (browsing the current app's
+//                                         recording dir)
+//
+// These tests verify the resolver's preference ordering via direct
+// invocation. Fs-level fixtures live in find-project-root-bundle-id.test.js;
+// this file focuses on the resolver contract itself.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  _makeRecordingRootResolverForTest,
+  _setRecordingBundleId,
+  _resetState,
+} from '../../dist/tools/test-recorder.js';
+
+let root;
+const origCwd = process.cwd();
+
+function makeRnProject(dir, name, extraAppJson = {}) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify({ name, dependencies: { 'react-native': '0.76.0' } }),
+  );
+  writeFileSync(join(dir, 'app.json'), JSON.stringify(extraAppJson));
+}
+
+function makeNonRnDir(dir, name) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name, dependencies: {} }));
+}
+
+function fakeClient(bundleId) {
+  return {
+    connectedTarget: bundleId ? { description: bundleId } : null,
+  };
+}
+
+test.beforeEach(() => {
+  // realpathSync resolves /var → /private/var on macOS so join(root, ...)
+  // matches what process.cwd() + filesystem calls return canonically.
+  root = realpathSync(mkdtempSync(join(tmpdir(), 'b144-codex2-')));
+  _resetState();
+});
+
+test.afterEach(() => {
+  process.chdir(origCwd);
+  _resetState();
+  delete process.env.RN_PROJECT_ROOT;
+  try { rmSync(root, { recursive: true, force: true }); } catch {}
+});
+
+// ─────────── save mode ───────────
+
+test("B144 Codex #2: save mode prefers captured recordingBundleId over live client", () => {
+  makeRnProject(join(root, 'captured-app'), 'captured-app', {
+    expo: { ios: { bundleIdentifier: 'com.captured' } },
+  });
+  makeRnProject(join(root, 'live-app'), 'live-app', {
+    expo: { ios: { bundleIdentifier: 'com.live' } },
+  });
+  makeNonRnDir(join(root, 'cwd'), 'cwd');
+  process.chdir(join(root, 'cwd'));
+
+  _setRecordingBundleId('com.captured');
+  const resolver = _makeRecordingRootResolverForTest(() => fakeClient('com.live'), 'save');
+
+  // save should land in the captured app's project, not the currently-
+  // connected one — the recording's identity belongs to when it was made.
+  assert.equal(resolver(), join(root, 'captured-app'));
+});
+
+test("B144 Codex #2: save mode falls back to live when no captured bundleId", () => {
+  makeRnProject(join(root, 'live-app'), 'live-app', {
+    expo: { ios: { bundleIdentifier: 'com.live' } },
+  });
+  makeNonRnDir(join(root, 'cwd'), 'cwd');
+  process.chdir(join(root, 'cwd'));
+
+  // No start was called → recordingBundleId is null → live client wins.
+  const resolver = _makeRecordingRootResolverForTest(() => fakeClient('com.live'), 'save');
+  assert.equal(resolver(), join(root, 'live-app'));
+});
+
+// ─────────── load-list mode ───────────
+
+test("B144 Codex #2: load-list mode prefers LIVE client over captured recordingBundleId", () => {
+  // This is the Codex-flagged scenario: user recorded app A, then reconnected
+  // to app B and called load/list. They want B's recordings, not A's.
+  makeRnProject(join(root, 'captured-app'), 'captured-app', {
+    expo: { ios: { bundleIdentifier: 'com.captured' } },
+  });
+  makeRnProject(join(root, 'live-app'), 'live-app', {
+    expo: { ios: { bundleIdentifier: 'com.live' } },
+  });
+  makeNonRnDir(join(root, 'cwd'), 'cwd');
+  process.chdir(join(root, 'cwd'));
+
+  _setRecordingBundleId('com.captured');
+  const resolver = _makeRecordingRootResolverForTest(() => fakeClient('com.live'), 'load-list');
+
+  // load/list want the CURRENTLY-connected app's recording dir.
+  assert.equal(resolver(), join(root, 'live-app'));
+});
+
+test("B144 Codex #2: load-list mode falls back to captured when no live client is connected", () => {
+  makeRnProject(join(root, 'captured-app'), 'captured-app', {
+    expo: { ios: { bundleIdentifier: 'com.captured' } },
+  });
+  makeNonRnDir(join(root, 'cwd'), 'cwd');
+  process.chdir(join(root, 'cwd'));
+
+  _setRecordingBundleId('com.captured');
+  // Client is null → no live bundleId → captured is the safety net.
+  const resolver = _makeRecordingRootResolverForTest(() => fakeClient(null), 'load-list');
+  assert.equal(resolver(), join(root, 'captured-app'));
+});
+
+test("B144 Codex #2: load-list mode falls back to legacy findProjectRoot when no bundleId at all", () => {
+  // No env, no captured, no live — fully legacy alphabetical.
+  makeRnProject(join(root, 'aaa-default'), 'aaa-default', {
+    expo: { ios: { bundleIdentifier: 'com.aaa' } },
+  });
+  makeNonRnDir(join(root, 'cwd'), 'cwd');
+  process.chdir(join(root, 'cwd'));
+
+  const resolver = _makeRecordingRootResolverForTest(undefined, 'load-list');
+  assert.equal(resolver(), join(root, 'aaa-default'));
+});
+
+test("B144 Codex #2: default mode is 'save' (back-compat when caller omits mode)", () => {
+  makeRnProject(join(root, 'captured-app'), 'captured-app', {
+    expo: { ios: { bundleIdentifier: 'com.captured' } },
+  });
+  makeRnProject(join(root, 'live-app'), 'live-app', {
+    expo: { ios: { bundleIdentifier: 'com.live' } },
+  });
+  makeNonRnDir(join(root, 'cwd'), 'cwd');
+  process.chdir(join(root, 'cwd'));
+
+  _setRecordingBundleId('com.captured');
+  // Omit mode — should behave like 'save' (captured wins).
+  const resolver = _makeRecordingRootResolverForTest(() => fakeClient('com.live'));
+  assert.equal(resolver(), join(root, 'captured-app'));
+});


### PR DESCRIPTION
## Summary

`findProjectRoot()` picked the alphabetically-first sibling RN project when multiple siblings existed — Story D's `cdp_record_test_save` wrote to the wrong project because the CDP-connected bundleId was irrelevant to the pick. Fix: add optional `{ bundleId }` opts that prefers the candidate whose `app.json` bundleId matches.

## Changes

| | |
|---|---|
| **`findProjectRoot(opts?: { bundleId?: string })`** | When `bundleId` provided: scans all candidates (env, cwd, walk-up, siblings, grandchildren) and returns the match. Falls back to walkup/alphabetical if no match. When omitted: **legacy behavior preserved byte-for-byte** (verified by dedicated regression test). |
| **`readProjectBundleId(projectRoot)`** | Extracts from `app.json`: `expo.ios.bundleIdentifier` > `expo.android.package` > top-level `ios.bundleIdentifier`. Bare RN with native Xcode configs returns null (pbxproj parsing intentionally out of scope). |
| **Private `collectRnProjects(root, maxDepth, out)`** | Breadth-first collect (vs existing `scanForRnProject` which short-circuits). Used only in bundleId path. |

## Migrations

- **`test-recorder.ts`** — captures bundleId at `cdp_record_test_start` time. `save`/`load`/`list` accept optional `getClient` so fresh-session `load`/`list` (no prior start) fall back to live CDP client's `connectedTarget.description`. **Gemini review caught this gap; fixed inline.**
- **`tools/nav-graph.ts`** — all 7 handlers read `getClient().connectedTarget?.description` and pass as bundleId. Non-connected sessions (null target) fall through to legacy.

## Non-migrated callers

`project-config`, `maestro-generate`, `maestro-test-all`, `auto-login`, `experience/fingerprint` — no CDP client access or out of scope. They keep legacy behavior and can be migrated in a follow-up if users report hitting the bug through those paths.

## Multi-review — both approved

- **Gemini**: 1 actionable (conf 80) — `load`/`list` fresh-session gap. Applied inline: `createRecordTestLoadHandler`/`createRecordTestListHandler` now accept `getClient` and fall back to live CDP bundleId.
- **Codex**: zero findings. Legacy path byte-for-byte equivalence verified.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 689 passing (672 pre-B144 + 17 new for B144):
  - 6 `readProjectBundleId` tests (Expo iOS, Android fallback, prefer iOS, bare RN, missing, malformed)
  - 9 `findProjectRoot({bundleId})` tests covering sibling match, alphabetical fallback, walk-up interaction, env var precedence, null edges
  - 2 Gemini-review follow-up tests for fresh-session fallback via captured vs live bundleId
- [ ] Post-merge live probe: on the multi-sibling developer machine, `cdp_record_test_save` should land in the bundleId-matched project instead of alphabetical first

## Versions

- plugin: 0.43.1 → **0.43.2** (patch — additive, all prior tests pass)
- MCP: 0.37.1 → **0.37.2**

## Closes

B144 in workspace `docs/BUGS.md`. Fixes the sibling-picks-wrong-project pitfall for `cdp_nav_graph` and `cdp_record_test_*` tool families.