### PR TITLE
fix(b59): tiered Maestro dispatch — runner → CLI fallback for iOS+no-adb

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.1",
+      "version": "0.44.2",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.1",
+  "version": "0.44.2",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",
@@ -74,7 +74,9 @@
   "mcpServers": {
     "cdp": {
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/cdp-bridge/dist/index.js"]
+      "args": [
+        "${CLAUDE_PLUGIN_ROOT}/scripts/cdp-bridge/dist/index.js"
+      ]
     }
   }
 }

--- a/scripts/cdp-bridge/dist/tools/maestro-dispatch.js
+++ b/scripts/cdp-bridge/dist/tools/maestro-dispatch.js
@@ -1,0 +1,120 @@
+// B59: tiered dispatch between maestro-runner (preferred, 3× faster) and the
+// upstream Maestro CLI (slower JVM-based fallback). The reason both paths
+// exist: maestro-runner v1.0.9 has an upstream bug — it requires `adb` in
+// PATH even when `--platform ios` is specified. On iOS-only dev machines
+// (no Android SDK installed) every maestro-runner invocation fails. The
+// fallback to `maestro` CLI keeps iOS-only users productive while we wait
+// for the upstream fix.
+//
+// Decision tree:
+//   1. platform === 'android' OR adb in PATH → maestro-runner (fast path)
+//   2. platform === 'ios' AND adb missing AND `maestro` in PATH → Maestro CLI
+//   3. neither viable → fail with a short install hint listing both options
+//
+// Same shape pattern as agent-device's 3-tier dispatch (fast-runner →
+// daemon → CLI) — keeps the codebase architecturally consistent.
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+// Process-wide cache. PATH doesn't change mid-process under normal use,
+// so probing `which` once per binary is enough. Tests pass injected
+// resolvers, which bypass the cache (each call computes fresh).
+const cache = {};
+function defaultWhichAdb() {
+    if (cache.adb !== undefined)
+        return cache.adb;
+    const r = spawnSync('which', ['adb'], { encoding: 'utf8' });
+    cache.adb = r.status === 0 && r.stdout.trim() ? r.stdout.trim() : null;
+    return cache.adb;
+}
+function defaultWhichMaestro() {
+    if (cache.maestro !== undefined)
+        return cache.maestro;
+    const r = spawnSync('which', ['maestro'], { encoding: 'utf8' });
+    cache.maestro = r.status === 0 && r.stdout.trim() ? r.stdout.trim() : null;
+    return cache.maestro;
+}
+function defaultMaestroRunnerPath() {
+    const path = join(homedir(), '.maestro-runner', 'bin', 'maestro-runner');
+    return existsSync(path) ? path : null;
+}
+/**
+ * Test-only: clear the cached `which` results. Production code never calls
+ * this; tests reset between cases to avoid leakage.
+ */
+export function _resetMaestroDispatchCache() {
+    delete cache.adb;
+    delete cache.maestro;
+    warnedFallbackReasons.clear();
+}
+// Per-process set of fallback reasons we've already surfaced to the user.
+// Used by shouldWarnFallback() so a session running 100 flows via the
+// fallback doesn't get 100 identical warnings — the first one is enough,
+// subsequent successes carry the reason silently in meta. Failures still
+// surface the reason because the user is already paying attention.
+const warnedFallbackReasons = new Set();
+/**
+ * Returns true on the FIRST call for a given reason in this process,
+ * false on subsequent calls. Callers use this to decide whether to wrap
+ * an otherwise-successful result in warnResult() (loud) or okResult()
+ * with the reason in meta (quiet). Failures should warn unconditionally.
+ */
+export function shouldWarnFallback(reason) {
+    if (warnedFallbackReasons.has(reason))
+        return false;
+    warnedFallbackReasons.add(reason);
+    return true;
+}
+export function chooseMaestroDispatch(inputs) {
+    const whichAdb = inputs.whichAdb ?? defaultWhichAdb;
+    const whichMaestro = inputs.whichMaestro ?? defaultWhichMaestro;
+    const runnerPath = (inputs.maestroRunnerPath ?? defaultMaestroRunnerPath)();
+    // Tier 1: maestro-runner. Viable when (a) the binary is installed and
+    // (b) we're on android OR adb is reachable (so the upstream bug doesn't bite).
+    const runnerViable = runnerPath !== null && (inputs.platform === 'android' || whichAdb() !== null);
+    if (runnerViable && runnerPath) {
+        return {
+            runner: 'maestro-runner',
+            binPath: runnerPath,
+            buildArgs: (platform, flowFile) => ['--platform', platform, 'test', flowFile],
+        };
+    }
+    // Tier 2: Maestro CLI fallback. Slower JVM cold start (~2s) but works on
+    // iOS-only machines. Use when maestro-runner can't run AND `maestro` is
+    // installed.
+    const maestroPath = whichMaestro();
+    if (maestroPath) {
+        const reason = runnerPath === null
+            ? 'maestro-runner not installed'
+            : 'maestro-runner v1.0.9 requires adb in PATH (upstream bug — see B59); falling back to Maestro CLI';
+        return {
+            runner: 'maestro',
+            binPath: maestroPath,
+            // Maestro CLI: `maestro test --platform <platform> <flow.yaml>`. The
+            // `--platform`/`-p` selector is the only platform flag v2.x exposes
+            // (per `maestro test --help`: [-p=<platform>]). Both reviewers
+            // (Gemini conf 97, Codex conf 98) caught the earlier draft using a
+            // non-existent --device-type flag — would have silently broken the
+            // entire B59 fallback on its target machines.
+            buildArgs: (platform, flowFile) => ['test', '--platform', platform, flowFile],
+            fallbackReason: reason,
+        };
+    }
+    // Tier 3: nothing usable. Fail-fast with both install instructions —
+    // far better than letting maestro-runner timeout opaquely.
+    return {
+        error: 'Neither maestro-runner nor maestro CLI is usable. ' +
+            (runnerPath === null ? 'maestro-runner not installed. ' : '') +
+            (inputs.platform === 'ios' && whichAdb() === null
+                ? 'maestro-runner v1.0.9 needs adb in PATH (upstream B59) but adb is not installed. '
+                : '') +
+            'Install Maestro CLI (`brew install maestro`) for iOS-only setups, ' +
+            'or install Android SDK (`brew install android-platform-tools`) plus ' +
+            '`curl -fsSL https://open.devicelab.dev/install/maestro-runner | bash` ' +
+            'for the faster maestro-runner path.',
+        hint: inputs.platform === 'ios'
+            ? 'iOS-only quickstart: brew install maestro'
+            : 'install Android SDK + maestro-runner for fastest path',
+    };
+}

--- a/scripts/cdp-bridge/dist/tools/maestro-run.js
+++ b/scripts/cdp-bridge/dist/tools/maestro-run.js
@@ -1,18 +1,13 @@
 import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
 import { existsSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { homedir } from 'node:os';
 import { okResult, failResult, warnResult } from '../utils.js';
 import { getActiveSession } from '../agent-device-wrapper.js';
 import { resolveBundleId, readExpoSlug } from '../project-config.js';
+import { chooseMaestroDispatch, shouldWarnFallback } from './maestro-dispatch.js';
 const execFile = promisify(execFileCb);
-function getRunnerPath() {
-    const path = join(homedir(), '.maestro-runner', 'bin', 'maestro-runner');
-    return existsSync(path) ? path : null;
-}
 function resolvePlatform(override) {
-    if (override)
+    if (override === 'ios' || override === 'android')
         return override;
     const session = getActiveSession();
     return session?.platform ?? null;
@@ -26,13 +21,15 @@ function resolveAppId(override, platform) {
 }
 export function createMaestroRunHandler() {
     return async (args) => {
-        const runnerPath = getRunnerPath();
-        if (!runnerPath) {
-            return failResult('maestro-runner not found. Install: curl -fsSL https://open.devicelab.dev/install/maestro-runner | bash');
-        }
         const platform = resolvePlatform(args.platform);
         if (!platform) {
             return failResult('Cannot determine platform. Pass platform or open a device session first.');
+        }
+        // B59: tiered dispatch — maestro-runner when viable, Maestro CLI fallback
+        // when iOS-only and adb is missing, fail-fast with install hints when neither.
+        const dispatch = chooseMaestroDispatch({ platform });
+        if ('error' in dispatch) {
+            return failResult(dispatch.error);
         }
         let flowFile;
         if (args.inlineYaml) {
@@ -53,24 +50,37 @@ export function createMaestroRunHandler() {
         }
         const timeout = args.timeoutMs ?? 120_000;
         try {
-            const { stdout, stderr } = await execFile(runnerPath, ['--platform', platform, 'test', flowFile], { timeout, encoding: 'utf8' });
+            const { stdout, stderr } = await execFile(dispatch.binPath, dispatch.buildArgs(platform, flowFile), { timeout, encoding: 'utf8' });
             const output = (stdout + '\n' + stderr).trim();
             const passed = !output.includes('FAILED') && !output.includes('Error:');
+            const meta = {
+                passed,
+                flowFile,
+                platform,
+                runner: dispatch.runner,
+                output: output.slice(0, 2000),
+                ...(dispatch.fallbackReason ? { fallbackReason: dispatch.fallbackReason } : {}),
+            };
             if (passed) {
-                return okResult({
-                    passed: true,
-                    flowFile,
-                    platform,
-                    output: output.slice(0, 2000),
-                });
+                // B59 (Gemini review, conf 82): on success-with-fallback, only emit
+                // a loud warning the FIRST time per process so a 100-flow loop
+                // doesn't generate 100 identical warnings. Subsequent successes
+                // carry the reason silently in meta.fallbackReason.
+                if (dispatch.fallbackReason && shouldWarnFallback(dispatch.fallbackReason)) {
+                    return warnResult(meta, dispatch.fallbackReason);
+                }
+                return okResult(meta);
             }
-            return warnResult({ passed: false, flowFile, platform, output: output.slice(0, 2000) }, 'Flow completed with warnings or failures');
+            return warnResult(meta, dispatch.fallbackReason
+                ? `${dispatch.fallbackReason}; flow completed with warnings or failures`
+                : 'Flow completed with warnings or failures');
         }
         catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             return failResult(`Maestro flow failed: ${msg.slice(0, 500)}`, {
                 flowFile,
                 platform,
+                runner: dispatch.runner,
             });
         }
     };

--- a/scripts/cdp-bridge/dist/tools/maestro-test-all.js
+++ b/scripts/cdp-bridge/dist/tools/maestro-test-all.js
@@ -2,10 +2,10 @@ import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
 import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { homedir } from 'node:os';
 import { okResult, failResult, warnResult } from '../utils.js';
 import { getActiveSession } from '../agent-device-wrapper.js';
 import { findProjectRoot } from '../nav-graph/storage.js';
+import { chooseMaestroDispatch, shouldWarnFallback } from './maestro-dispatch.js';
 const execFile = promisify(execFileCb);
 function discoverFlows(dir, pattern) {
     if (!existsSync(dir))
@@ -23,13 +23,15 @@ function discoverFlows(dir, pattern) {
 }
 export function createMaestroTestAllHandler() {
     return async (args) => {
-        const runnerPath = join(homedir(), '.maestro-runner', 'bin', 'maestro-runner');
-        if (!existsSync(runnerPath)) {
-            return failResult('maestro-runner not found. Install: curl -fsSL https://open.devicelab.dev/install/maestro-runner | bash');
-        }
-        const platform = args.platform ?? getActiveSession()?.platform;
+        const platform = (args.platform ?? getActiveSession()?.platform);
         if (!platform) {
             return failResult('Cannot determine platform. Pass platform or open a device session first.');
+        }
+        // B59: tiered dispatch (see maestro-dispatch.ts) — picks maestro-runner
+        // when viable, falls back to the Maestro CLI on iOS+no-adb machines.
+        const dispatch = chooseMaestroDispatch({ platform });
+        if ('error' in dispatch) {
+            return failResult(dispatch.error);
         }
         const root = findProjectRoot();
         const flowDir = args.flowDir ?? (root ? join(root, '.maestro', 'flows') : null);
@@ -48,7 +50,7 @@ export function createMaestroTestAllHandler() {
             const name = flow.replace(flowDir + '/', '');
             const start = Date.now();
             try {
-                const { stdout, stderr } = await execFile(runnerPath, ['--platform', platform, 'test', flow], { timeout, encoding: 'utf8' });
+                const { stdout, stderr } = await execFile(dispatch.binPath, dispatch.buildArgs(platform, flow), { timeout, encoding: 'utf8' });
                 const output = (stdout + '\n' + stderr).trim();
                 const ok = !output.includes('FAILED') && !output.includes('Error:');
                 results.push({
@@ -84,10 +86,19 @@ export function createMaestroTestAllHandler() {
             failed,
             platform,
             flowDir,
+            runner: dispatch.runner,
+            ...(dispatch.fallbackReason ? { fallbackReason: dispatch.fallbackReason } : {}),
             results,
         };
         if (failed > 0) {
-            return warnResult(summary, `${failed} of ${results.length} flows failed`);
+            const baseMsg = `${failed} of ${results.length} flows failed`;
+            return warnResult(summary, dispatch.fallbackReason ? `${dispatch.fallbackReason}; ${baseMsg}` : baseMsg);
+        }
+        // B59 (Gemini review, conf 82): suppress repeated success-with-fallback
+        // warnings within the same process — first call surfaces, subsequent
+        // calls keep the reason in meta only.
+        if (dispatch.fallbackReason && shouldWarnFallback(dispatch.fallbackReason)) {
+            return warnResult(summary, dispatch.fallbackReason);
         }
         return okResult(summary);
     };

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.1",
+  "version": "0.38.2",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/tools/maestro-dispatch.ts
+++ b/scripts/cdp-bridge/src/tools/maestro-dispatch.ts
@@ -1,0 +1,168 @@
+// B59: tiered dispatch between maestro-runner (preferred, 3× faster) and the
+// upstream Maestro CLI (slower JVM-based fallback). The reason both paths
+// exist: maestro-runner v1.0.9 has an upstream bug — it requires `adb` in
+// PATH even when `--platform ios` is specified. On iOS-only dev machines
+// (no Android SDK installed) every maestro-runner invocation fails. The
+// fallback to `maestro` CLI keeps iOS-only users productive while we wait
+// for the upstream fix.
+//
+// Decision tree:
+//   1. platform === 'android' OR adb in PATH → maestro-runner (fast path)
+//   2. platform === 'ios' AND adb missing AND `maestro` in PATH → Maestro CLI
+//   3. neither viable → fail with a short install hint listing both options
+//
+// Same shape pattern as agent-device's 3-tier dispatch (fast-runner →
+// daemon → CLI) — keeps the codebase architecturally consistent.
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+export type MaestroRunner = 'maestro-runner' | 'maestro';
+
+export interface MaestroDispatch {
+  runner: MaestroRunner;
+  binPath: string;
+  /**
+   * Builds the argv for `execFile(binPath, argv)` to run a single flow.
+   * Both runners accept `<flow.yaml>` as the last positional but their
+   * platform-targeting flags differ.
+   */
+  buildArgs(platform: 'ios' | 'android', flowFile: string): string[];
+  /**
+   * Present when the fallback runner was chosen — surfaces in caller's
+   * warnResult so users see why the slower path was used.
+   */
+  fallbackReason?: string;
+}
+
+export interface MaestroDispatchInputs {
+  platform: 'ios' | 'android';
+  /** Override for tests. Defaults to `which adb` via spawnSync. */
+  whichAdb?: () => string | null;
+  /** Override for tests. Defaults to `which maestro` via spawnSync. */
+  whichMaestro?: () => string | null;
+  /** Override for tests. Defaults to ~/.maestro-runner/bin/maestro-runner. */
+  maestroRunnerPath?: () => string | null;
+}
+
+// Process-wide cache. PATH doesn't change mid-process under normal use,
+// so probing `which` once per binary is enough. Tests pass injected
+// resolvers, which bypass the cache (each call computes fresh).
+const cache: { adb?: string | null; maestro?: string | null } = {};
+
+function defaultWhichAdb(): string | null {
+  if (cache.adb !== undefined) return cache.adb;
+  const r = spawnSync('which', ['adb'], { encoding: 'utf8' });
+  cache.adb = r.status === 0 && r.stdout.trim() ? r.stdout.trim() : null;
+  return cache.adb;
+}
+
+function defaultWhichMaestro(): string | null {
+  if (cache.maestro !== undefined) return cache.maestro;
+  const r = spawnSync('which', ['maestro'], { encoding: 'utf8' });
+  cache.maestro = r.status === 0 && r.stdout.trim() ? r.stdout.trim() : null;
+  return cache.maestro;
+}
+
+function defaultMaestroRunnerPath(): string | null {
+  const path = join(homedir(), '.maestro-runner', 'bin', 'maestro-runner');
+  return existsSync(path) ? path : null;
+}
+
+/**
+ * Test-only: clear the cached `which` results. Production code never calls
+ * this; tests reset between cases to avoid leakage.
+ */
+export function _resetMaestroDispatchCache(): void {
+  delete cache.adb;
+  delete cache.maestro;
+  warnedFallbackReasons.clear();
+}
+
+// Per-process set of fallback reasons we've already surfaced to the user.
+// Used by shouldWarnFallback() so a session running 100 flows via the
+// fallback doesn't get 100 identical warnings — the first one is enough,
+// subsequent successes carry the reason silently in meta. Failures still
+// surface the reason because the user is already paying attention.
+const warnedFallbackReasons = new Set<string>();
+
+/**
+ * Returns true on the FIRST call for a given reason in this process,
+ * false on subsequent calls. Callers use this to decide whether to wrap
+ * an otherwise-successful result in warnResult() (loud) or okResult()
+ * with the reason in meta (quiet). Failures should warn unconditionally.
+ */
+export function shouldWarnFallback(reason: string): boolean {
+  if (warnedFallbackReasons.has(reason)) return false;
+  warnedFallbackReasons.add(reason);
+  return true;
+}
+
+export interface MaestroDispatchError {
+  error: string;
+  hint: string;
+}
+
+export function chooseMaestroDispatch(
+  inputs: MaestroDispatchInputs,
+): MaestroDispatch | MaestroDispatchError {
+  const whichAdb = inputs.whichAdb ?? defaultWhichAdb;
+  const whichMaestro = inputs.whichMaestro ?? defaultWhichMaestro;
+  const runnerPath = (inputs.maestroRunnerPath ?? defaultMaestroRunnerPath)();
+
+  // Tier 1: maestro-runner. Viable when (a) the binary is installed and
+  // (b) we're on android OR adb is reachable (so the upstream bug doesn't bite).
+  const runnerViable =
+    runnerPath !== null && (inputs.platform === 'android' || whichAdb() !== null);
+  if (runnerViable && runnerPath) {
+    return {
+      runner: 'maestro-runner',
+      binPath: runnerPath,
+      buildArgs: (platform, flowFile) => ['--platform', platform, 'test', flowFile],
+    };
+  }
+
+  // Tier 2: Maestro CLI fallback. Slower JVM cold start (~2s) but works on
+  // iOS-only machines. Use when maestro-runner can't run AND `maestro` is
+  // installed.
+  const maestroPath = whichMaestro();
+  if (maestroPath) {
+    const reason =
+      runnerPath === null
+        ? 'maestro-runner not installed'
+        : 'maestro-runner v1.0.9 requires adb in PATH (upstream bug — see B59); falling back to Maestro CLI';
+    return {
+      runner: 'maestro',
+      binPath: maestroPath,
+      // Maestro CLI: `maestro test --platform <platform> <flow.yaml>`. The
+      // `--platform`/`-p` selector is the only platform flag v2.x exposes
+      // (per `maestro test --help`: [-p=<platform>]). Both reviewers
+      // (Gemini conf 97, Codex conf 98) caught the earlier draft using a
+      // non-existent --device-type flag — would have silently broken the
+      // entire B59 fallback on its target machines.
+      buildArgs: (platform, flowFile) => ['test', '--platform', platform, flowFile],
+      fallbackReason: reason,
+    };
+  }
+
+  // Tier 3: nothing usable. Fail-fast with both install instructions —
+  // far better than letting maestro-runner timeout opaquely.
+  return {
+    error:
+      'Neither maestro-runner nor maestro CLI is usable. ' +
+      (runnerPath === null ? 'maestro-runner not installed. ' : '') +
+      (inputs.platform === 'ios' && whichAdb() === null
+        ? 'maestro-runner v1.0.9 needs adb in PATH (upstream B59) but adb is not installed. '
+        : '') +
+      'Install Maestro CLI (`brew install maestro`) for iOS-only setups, ' +
+      'or install Android SDK (`brew install android-platform-tools`) plus ' +
+      '`curl -fsSL https://open.devicelab.dev/install/maestro-runner | bash` ' +
+      'for the faster maestro-runner path.',
+    hint:
+      inputs.platform === 'ios'
+        ? 'iOS-only quickstart: brew install maestro'
+        : 'install Android SDK + maestro-runner for fastest path',
+  };
+}

--- a/scripts/cdp-bridge/src/tools/maestro-run.ts
+++ b/scripts/cdp-bridge/src/tools/maestro-run.ts
@@ -1,12 +1,11 @@
 import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
 import { existsSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { homedir } from 'node:os';
 import type { ToolResult } from '../utils.js';
 import { okResult, failResult, warnResult } from '../utils.js';
 import { getActiveSession } from '../agent-device-wrapper.js';
 import { resolveBundleId, readExpoSlug } from '../project-config.js';
+import { chooseMaestroDispatch, shouldWarnFallback } from './maestro-dispatch.js';
 
 const execFile = promisify(execFileCb);
 
@@ -18,15 +17,10 @@ interface MaestroRunArgs {
   timeoutMs?: number;
 }
 
-function getRunnerPath(): string | null {
-  const path = join(homedir(), '.maestro-runner', 'bin', 'maestro-runner');
-  return existsSync(path) ? path : null;
-}
-
-function resolvePlatform(override?: string): string | null {
-  if (override) return override;
+function resolvePlatform(override?: string): 'ios' | 'android' | null {
+  if (override === 'ios' || override === 'android') return override;
   const session = getActiveSession();
-  return session?.platform ?? null;
+  return (session?.platform as 'ios' | 'android' | undefined) ?? null;
 }
 
 function resolveAppId(override?: string, platform?: string): string {
@@ -37,18 +31,18 @@ function resolveAppId(override?: string, platform?: string): string {
 
 export function createMaestroRunHandler(): (args: MaestroRunArgs) => Promise<ToolResult> {
   return async (args) => {
-    const runnerPath = getRunnerPath();
-    if (!runnerPath) {
-      return failResult(
-        'maestro-runner not found. Install: curl -fsSL https://open.devicelab.dev/install/maestro-runner | bash',
-      );
-    }
-
     const platform = resolvePlatform(args.platform);
     if (!platform) {
       return failResult(
         'Cannot determine platform. Pass platform or open a device session first.',
       );
+    }
+
+    // B59: tiered dispatch — maestro-runner when viable, Maestro CLI fallback
+    // when iOS-only and adb is missing, fail-fast with install hints when neither.
+    const dispatch = chooseMaestroDispatch({ platform });
+    if ('error' in dispatch) {
+      return failResult(dispatch.error);
     }
 
     let flowFile: string;
@@ -72,31 +66,44 @@ export function createMaestroRunHandler(): (args: MaestroRunArgs) => Promise<Too
 
     try {
       const { stdout, stderr } = await execFile(
-        runnerPath,
-        ['--platform', platform, 'test', flowFile],
+        dispatch.binPath,
+        dispatch.buildArgs(platform, flowFile),
         { timeout, encoding: 'utf8' },
       );
 
       const output = (stdout + '\n' + stderr).trim();
       const passed = !output.includes('FAILED') && !output.includes('Error:');
+      const meta = {
+        passed,
+        flowFile,
+        platform,
+        runner: dispatch.runner,
+        output: output.slice(0, 2000),
+        ...(dispatch.fallbackReason ? { fallbackReason: dispatch.fallbackReason } : {}),
+      };
 
       if (passed) {
-        return okResult({
-          passed: true,
-          flowFile,
-          platform,
-          output: output.slice(0, 2000),
-        });
+        // B59 (Gemini review, conf 82): on success-with-fallback, only emit
+        // a loud warning the FIRST time per process so a 100-flow loop
+        // doesn't generate 100 identical warnings. Subsequent successes
+        // carry the reason silently in meta.fallbackReason.
+        if (dispatch.fallbackReason && shouldWarnFallback(dispatch.fallbackReason)) {
+          return warnResult(meta, dispatch.fallbackReason);
+        }
+        return okResult(meta);
       }
       return warnResult(
-        { passed: false, flowFile, platform, output: output.slice(0, 2000) },
-        'Flow completed with warnings or failures',
+        meta,
+        dispatch.fallbackReason
+          ? `${dispatch.fallbackReason}; flow completed with warnings or failures`
+          : 'Flow completed with warnings or failures',
       );
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       return failResult(`Maestro flow failed: ${msg.slice(0, 500)}`, {
         flowFile,
         platform,
+        runner: dispatch.runner,
       });
     }
   };

--- a/scripts/cdp-bridge/src/tools/maestro-test-all.ts
+++ b/scripts/cdp-bridge/src/tools/maestro-test-all.ts
@@ -2,11 +2,11 @@ import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
 import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { homedir } from 'node:os';
 import type { ToolResult } from '../utils.js';
 import { okResult, failResult, warnResult } from '../utils.js';
 import { getActiveSession } from '../agent-device-wrapper.js';
 import { findProjectRoot } from '../nav-graph/storage.js';
+import { chooseMaestroDispatch, shouldWarnFallback } from './maestro-dispatch.js';
 
 const execFile = promisify(execFileCb);
 
@@ -42,16 +42,16 @@ function discoverFlows(dir: string, pattern?: string): string[] {
 
 export function createMaestroTestAllHandler(): (args: MaestroTestAllArgs) => Promise<ToolResult> {
   return async (args) => {
-    const runnerPath = join(homedir(), '.maestro-runner', 'bin', 'maestro-runner');
-    if (!existsSync(runnerPath)) {
-      return failResult(
-        'maestro-runner not found. Install: curl -fsSL https://open.devicelab.dev/install/maestro-runner | bash',
-      );
-    }
-
-    const platform = args.platform ?? getActiveSession()?.platform;
+    const platform = (args.platform ?? getActiveSession()?.platform) as 'ios' | 'android' | undefined;
     if (!platform) {
       return failResult('Cannot determine platform. Pass platform or open a device session first.');
+    }
+
+    // B59: tiered dispatch (see maestro-dispatch.ts) — picks maestro-runner
+    // when viable, falls back to the Maestro CLI on iOS+no-adb machines.
+    const dispatch = chooseMaestroDispatch({ platform });
+    if ('error' in dispatch) {
+      return failResult(dispatch.error);
     }
 
     const root = findProjectRoot();
@@ -76,8 +76,8 @@ export function createMaestroTestAllHandler(): (args: MaestroTestAllArgs) => Pro
 
       try {
         const { stdout, stderr } = await execFile(
-          runnerPath,
-          ['--platform', platform, 'test', flow],
+          dispatch.binPath,
+          dispatch.buildArgs(platform, flow),
           { timeout, encoding: 'utf8' },
         );
         const output = (stdout + '\n' + stderr).trim();
@@ -114,11 +114,23 @@ export function createMaestroTestAllHandler(): (args: MaestroTestAllArgs) => Pro
       failed,
       platform,
       flowDir,
+      runner: dispatch.runner,
+      ...(dispatch.fallbackReason ? { fallbackReason: dispatch.fallbackReason } : {}),
       results,
     };
 
     if (failed > 0) {
-      return warnResult(summary, `${failed} of ${results.length} flows failed`);
+      const baseMsg = `${failed} of ${results.length} flows failed`;
+      return warnResult(
+        summary,
+        dispatch.fallbackReason ? `${dispatch.fallbackReason}; ${baseMsg}` : baseMsg,
+      );
+    }
+    // B59 (Gemini review, conf 82): suppress repeated success-with-fallback
+    // warnings within the same process — first call surfaces, subsequent
+    // calls keep the reason in meta only.
+    if (dispatch.fallbackReason && shouldWarnFallback(dispatch.fallbackReason)) {
+      return warnResult(summary, dispatch.fallbackReason);
     }
     return okResult(summary);
   };

--- a/scripts/cdp-bridge/test/unit/maestro-dispatch.test.js
+++ b/scripts/cdp-bridge/test/unit/maestro-dispatch.test.js
@@ -1,0 +1,154 @@
+// B59: tiered Maestro dispatch — picks maestro-runner when viable, falls
+// back to Maestro CLI on iOS-only machines without adb in PATH (upstream
+// maestro-runner v1.0.9 bug). Tests inject the `which` resolvers + the
+// runner-binary existence check so we can simulate every PATH topology
+// without touching the real filesystem.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  chooseMaestroDispatch,
+  _resetMaestroDispatchCache,
+} from '../../dist/tools/maestro-dispatch.js';
+
+test.beforeEach(() => _resetMaestroDispatchCache());
+
+// ── Tier 1: maestro-runner happy path ────────────────────────────────
+
+test('B59 Tier 1: ios + adb present + runner installed → maestro-runner', () => {
+  const d = chooseMaestroDispatch({
+    platform: 'ios',
+    whichAdb: () => '/usr/bin/adb',
+    whichMaestro: () => '/opt/homebrew/bin/maestro',
+    maestroRunnerPath: () => '/Users/me/.maestro-runner/bin/maestro-runner',
+  });
+  assert.equal('runner' in d ? d.runner : null, 'maestro-runner');
+  assert.equal('binPath' in d ? d.binPath : null, '/Users/me/.maestro-runner/bin/maestro-runner');
+  // Tier 1 must have NO fallbackReason — the fast path is silent.
+  assert.equal('fallbackReason' in d && d.fallbackReason !== undefined, false);
+});
+
+test('B59 Tier 1: android + runner installed → maestro-runner (adb irrelevant)', () => {
+  const d = chooseMaestroDispatch({
+    platform: 'android',
+    whichAdb: () => null, // no adb but android still routes through maestro-runner
+    whichMaestro: () => null,
+    maestroRunnerPath: () => '/runner',
+  });
+  assert.equal('runner' in d ? d.runner : null, 'maestro-runner');
+});
+
+test('B59 Tier 1: buildArgs emits --platform <p> test <flow>', () => {
+  const d = chooseMaestroDispatch({
+    platform: 'ios',
+    whichAdb: () => '/adb',
+    whichMaestro: () => null,
+    maestroRunnerPath: () => '/runner',
+  });
+  if (!('buildArgs' in d)) throw new Error('expected dispatch');
+  assert.deepEqual(d.buildArgs('ios', '/tmp/flow.yaml'), ['--platform', 'ios', 'test', '/tmp/flow.yaml']);
+  assert.deepEqual(d.buildArgs('android', '/tmp/flow.yaml'), ['--platform', 'android', 'test', '/tmp/flow.yaml']);
+});
+
+// ── Tier 2: Maestro CLI fallback ─────────────────────────────────────
+
+test('B59 Tier 2: ios + no adb + maestro-runner installed → falls back to Maestro CLI with B59 reason', () => {
+  const d = chooseMaestroDispatch({
+    platform: 'ios',
+    whichAdb: () => null,
+    whichMaestro: () => '/opt/homebrew/bin/maestro',
+    maestroRunnerPath: () => '/Users/me/.maestro-runner/bin/maestro-runner',
+  });
+  assert.equal('runner' in d ? d.runner : null, 'maestro');
+  assert.equal('binPath' in d ? d.binPath : null, '/opt/homebrew/bin/maestro');
+  assert.match('fallbackReason' in d ? d.fallbackReason ?? '' : '', /B59|adb in PATH/);
+});
+
+test('B59 Tier 2: ios + no adb + no maestro-runner → falls back to Maestro CLI with installed-msg', () => {
+  const d = chooseMaestroDispatch({
+    platform: 'ios',
+    whichAdb: () => null,
+    whichMaestro: () => '/opt/homebrew/bin/maestro',
+    maestroRunnerPath: () => null,
+  });
+  assert.equal('runner' in d ? d.runner : null, 'maestro');
+  assert.match('fallbackReason' in d ? d.fallbackReason ?? '' : '', /not installed/);
+});
+
+test('B59 Tier 2: Maestro CLI argv uses -p <platform> for iOS (verified against `maestro test --help`)', () => {
+  // The Maestro CLI v2.x `test` subcommand accepts only `-p=<platform>` per
+  // its --help output (no --device-type flag exists). Earlier draft used the
+  // wrong flag — Gemini review (conf 97) caught it before the broken
+  // fallback shipped. Both -p ios and -p=ios are accepted; we use the
+  // separate-token form for execFile array passing.
+  const d = chooseMaestroDispatch({
+    platform: 'ios',
+    whichAdb: () => null,
+    whichMaestro: () => '/maestro',
+    maestroRunnerPath: () => null,
+  });
+  if (!('buildArgs' in d)) throw new Error('expected dispatch');
+  assert.deepEqual(d.buildArgs('ios', '/tmp/f.yaml'), ['test', '--platform', 'ios', '/tmp/f.yaml']);
+});
+
+test('B59 Tier 2: Maestro CLI argv uses -p android for Android', () => {
+  // Synthetic case: imagine a future where Tier 1 isn't available on Android either.
+  // The fallback must still produce coherent argv.
+  const d = chooseMaestroDispatch({
+    platform: 'android',
+    whichAdb: () => null,
+    whichMaestro: () => '/maestro',
+    maestroRunnerPath: () => null,
+  });
+  if (!('buildArgs' in d)) throw new Error('expected dispatch');
+  assert.deepEqual(d.buildArgs('android', '/tmp/f.yaml'), ['test', '--platform', 'android', '/tmp/f.yaml']);
+});
+
+// ── Tier 3: fail-fast with install hint ──────────────────────────────
+
+test('B59 Tier 3: nothing usable → returns error with install hint mentioning both options', () => {
+  const d = chooseMaestroDispatch({
+    platform: 'ios',
+    whichAdb: () => null,
+    whichMaestro: () => null,
+    maestroRunnerPath: () => null,
+  });
+  assert.ok('error' in d, 'expected error');
+  assert.match(d.error, /brew install maestro/);
+  assert.match(d.error, /maestro-runner/);
+  assert.match(d.error, /adb/i);
+  assert.match(d.hint, /iOS-only quickstart/);
+});
+
+test('B59 Tier 3: android with nothing → fail-fast still emits install hint', () => {
+  const d = chooseMaestroDispatch({
+    platform: 'android',
+    whichAdb: () => '/adb',  // adb present but no runner AND no maestro
+    whichMaestro: () => null,
+    maestroRunnerPath: () => null,
+  });
+  assert.ok('error' in d, 'expected error');
+  assert.match(d.hint, /Android SDK \+ maestro-runner/);
+});
+
+// ── Edge: Tier 1 viable beats Tier 2 even when both runners installed ──
+
+test('B59: Tier 1 wins when viable — does NOT use Maestro CLI just because both are installed', () => {
+  const d = chooseMaestroDispatch({
+    platform: 'ios',
+    whichAdb: () => '/adb',
+    whichMaestro: () => '/maestro',
+    maestroRunnerPath: () => '/runner',
+  });
+  assert.equal('runner' in d ? d.runner : null, 'maestro-runner', 'fast path must be preferred');
+});
+
+// ── Cache reset hook ─────────────────────────────────────────────────
+
+test('B59: _resetMaestroDispatchCache clears between tests so each one is hermetic', () => {
+  // Just verifies the function exists and doesn't throw — actual cache usage
+  // is exercised via injected resolvers above (which bypass cache). This test
+  // is the contract that production code calls _resetMaestroDispatchCache via
+  // beforeEach so suite-level state can't leak.
+  assert.equal(typeof _resetMaestroDispatchCache, 'function');
+  _resetMaestroDispatchCache();
+});


### PR DESCRIPTION
## Summary

maestro-runner v1.0.9 has an upstream bug: it requires `adb` in PATH even when `--platform ios` is specified. iOS-only dev machines (no Android SDK installed) hit an opaque timeout or hard failure on every Maestro invocation. This blocked B59 — reported upstream, no ETA on fix.

This PR adds a tiered dispatch that automatically falls back to the Maestro CLI when the fast path is unavailable.

## Decision tree

| Tier | Runner | Gate | Cost |
|---|---|---|---|
| **1** | maestro-runner | `platform === 'android'` OR `adb` in PATH | preferred — 3× faster, no JVM |
| **2** | Maestro CLI (`brew install maestro`) | iOS + no adb + `maestro` in PATH | fallback — JVM cold start ~2s |
| **3** | fail-fast with install hints | neither viable | error |

Same shape as agent-device's existing 3-tier (`fast-runner → daemon → CLI`) — keeps the codebase architecturally consistent.

## Changes

- **NEW** `scripts/cdp-bridge/src/tools/maestro-dispatch.ts` — `chooseMaestroDispatch({platform, ...resolvers})` returns either `{runner, binPath, buildArgs, fallbackReason?}` or `{error, hint}`. Injectable resolvers (`whichAdb`, `whichMaestro`, `maestroRunnerPath`) make every PATH topology testable without filesystem fixtures. Process-wide cache memoizes `spawnSync(which, ...)` results; reset hook for tests.
- **MIGRATED** `maestro-run.ts` + `maestro-test-all.ts` to use the dispatch helper instead of resolving the runner path inline.
- **Warn-once-on-success** semantic: a session running 100 flows via the fallback gets ONE loud warning + 99 quiet successes (with `meta.fallbackReason` for programmatic consumers). Failures still warn unconditionally.

## Multi-review — both flagged the same critical bug

| Reviewer | Severity | Finding | Resolution |
|---|---|---|---|
| **Gemini** | Critical (conf 97) | initial draft used non-existent `--device-type` flag | Fixed argv to `--platform`, updated 2 tests |
| **Codex** | Critical (conf 98) | same finding, verified against `maestro test --help` showing `Unknown option: '--device-type'` | same fix |
| **Gemini** | Actionable (conf 82) | 100 flows via fallback would emit 100 warnings | Added `shouldWarnFallback()` — warn-once per process per reason |

**Critical-bug significance**: without this fix the entire Tier 2 fallback would have failed at flag parsing on every iOS+no-adb machine — the exact target audience for B59. Tests pass'd because they only assert argv shape, never exec the binary. Worth a follow-up: integration test that parses `maestro test --help` to verify our flag still exists.

## Verified live

```
$ maestro test --platform ios /tmp/nonexistent.yaml
Flow path does not exist: /tmp/nonexistent.yaml
```
Flag accepted; error is on the missing flow file (expected), not on the flag.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 706 → **717 passing** (+11 new for B59 covering all 3 tiers + buildArgs + fallback edge cases + cache reset)
- [x] Verified `--platform` against live `maestro 2.x` CLI
- [ ] Post-merge live probe on iOS-only machine (or via temporary PATH manipulation removing adb): `cdp_record_test_save` followed by `maestro_run` should succeed via Tier 2 with first call carrying `warnResult` + `fallbackReason`, subsequent calls quiet

## Versions

- plugin: 0.44.1 → **0.44.2**
- MCP: 0.38.1 → **0.38.2**

## Closes

B59 in workspace `docs/BUGS.md`.