### PR TITLE
feat(gh-73): add method/since filters and truncated warning to cdp_ne…

### DIFF
--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -129,9 +129,11 @@ trackedTool('cdp_native_errors', 'Read native-level error logs for when JS-layer
     sinceSeconds: z.number().int().min(5).max(3600).optional().describe('How far back to look (default 60s, max 3600)'),
     limit: z.number().int().min(1).max(100).optional().describe('Max entries to return (default 10, max 100)'),
 }, createNativeErrorsHandler(getClient));
-trackedTool('cdp_network_log', 'Get recent network requests. Shows method, URL, status, duration. On RN 0.83+ uses CDP Network domain. On older versions uses injected fetch/XHR hooks (auto-detected). M4/D655: buffers are per-device, keyed by Metro port + target id — switching simulators no longer bleeds stale traffic. Pass `device: "all"` to merge across every device seen this session.', {
+trackedTool('cdp_network_log', 'Get recent network requests. Shows method, URL, status, duration. On RN 0.83+ uses CDP Network domain. On older versions uses injected fetch/XHR hooks (auto-detected). M4/D655: buffers are per-device, keyed by Metro port + target id — switching simulators no longer bleeds stale traffic. Pass `device: "all"` to merge across every device seen this session. Filters AND-combine: `filter` (URL substring), `method` (HTTP verb), `since` (ISO timestamp). When more entries match than `limit` allows, response includes `truncated:true` + `total_matches`.', {
     limit: z.number().int().min(1).max(100).default(20).describe('Max entries to return (default 20, max 100)'),
     filter: z.string().optional().describe('Filter by URL substring (e.g. "/api/cart")'),
+    method: z.union([z.string(), z.array(z.string())]).optional().describe('Filter by HTTP method, case-insensitive (e.g. "POST" or ["POST","PUT"]). AND-combined with `filter`. Use to isolate mutations from follow-up GETs.'),
+    since: z.string().optional().describe('ISO timestamp — drop entries with timestamp < since before applying limit. Use to pin a checkpoint before an action and ask for everything since.'),
     clear: z.boolean().default(false).describe('Clear network buffer instead of reading'),
     device: z.string().optional().describe('Scope: a specific device key OR the literal "all" for a chronologically-merged view across every device. Defaults to the active device.'),
 }, createNetworkLogHandler(getClient));

--- a/scripts/cdp-bridge/dist/tools/network-log.js
+++ b/scripts/cdp-bridge/dist/tools/network-log.js
@@ -8,19 +8,42 @@ export function createNetworkLogHandler(getClient) {
             return okResult({ cleared: true, device: scope });
         }
         const limit = Math.min(Math.max(args.limit ?? 20, 1), 100);
-        let entries = args.filter !== undefined
-            ? client.networkBufferManager.filter(scope, (e) => e.url.includes(args.filter))
-            : client.networkBufferManager.getLast(scope, limit);
-        if (args.filter !== undefined && entries.length > limit) {
-            entries = entries.slice(-limit);
+        const wantedMethods = args.method
+            ? (Array.isArray(args.method) ? args.method : [args.method]).map((m) => m.toUpperCase())
+            : null;
+        // Normalize since to UTC Z-form. Entry timestamps come from
+        // `new Date().toISOString()` (always Z), so a user-supplied offset like
+        // `+02:00` would mis-compare under naive lexicographic order.
+        let since;
+        if (args.since !== undefined) {
+            const parsed = new Date(args.since);
+            since = Number.isNaN(parsed.getTime()) ? args.since : parsed.toISOString();
         }
-        // M11: include hint when buffer has stayed empty for >60s. The network
-        // manager tracks per-device lastPush, so the idle reference is
-        // max(connectedAt, lastPush[scope]). 'all' scope has no single lastPush,
-        // so fall back to connectedAt only.
+        const urlNeedle = args.filter;
+        const hasFilters = urlNeedle !== undefined || wantedMethods !== null || since !== undefined;
+        let matches = hasFilters
+            ? client.networkBufferManager.filter(scope, (e) => {
+                if (urlNeedle !== undefined && !e.url.includes(urlNeedle))
+                    return false;
+                if (since !== undefined && e.timestamp < since)
+                    return false;
+                if (wantedMethods !== null && !wantedMethods.includes(e.method.toUpperCase()))
+                    return false;
+                return true;
+            })
+            : client.networkBufferManager.getLast(scope, limit);
+        const totalMatches = matches.length;
+        const sliced = hasFilters && matches.length > limit ? matches.slice(-limit) : matches;
+        const truncated = totalMatches > sliced.length;
         const lastEventAt = scope === 'all' ? null : client.networkBufferManager.getLastPush(scope);
-        const hint = shouldShowMetroClearHint({ connectedAt: client.connectedAt, lastEventAt: lastEventAt ?? null, now: client.now }, entries.length === 0) ? METRO_CLEAR_HINT_TEXT : undefined;
+        const hint = shouldShowMetroClearHint({ connectedAt: client.connectedAt, lastEventAt: lastEventAt ?? null, now: client.now }, sliced.length === 0) ? METRO_CLEAR_HINT_TEXT : undefined;
         const resultOpts = hint ? { meta: { hint } } : undefined;
-        return okResult({ mode: client.networkMode, device: scope, count: entries.length, requests: entries }, resultOpts);
+        return okResult({
+            mode: client.networkMode,
+            device: scope,
+            count: sliced.length,
+            requests: sliced,
+            ...(truncated ? { truncated: true, total_matches: totalMatches } : {}),
+        }, resultOpts);
     });
 }

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -230,10 +230,12 @@ trackedTool(
 
 trackedTool(
   'cdp_network_log',
-  'Get recent network requests. Shows method, URL, status, duration. On RN 0.83+ uses CDP Network domain. On older versions uses injected fetch/XHR hooks (auto-detected). M4/D655: buffers are per-device, keyed by Metro port + target id — switching simulators no longer bleeds stale traffic. Pass `device: "all"` to merge across every device seen this session.',
+  'Get recent network requests. Shows method, URL, status, duration. On RN 0.83+ uses CDP Network domain. On older versions uses injected fetch/XHR hooks (auto-detected). M4/D655: buffers are per-device, keyed by Metro port + target id — switching simulators no longer bleeds stale traffic. Pass `device: "all"` to merge across every device seen this session. Filters AND-combine: `filter` (URL substring), `method` (HTTP verb), `since` (ISO timestamp). When more entries match than `limit` allows, response includes `truncated:true` + `total_matches`.',
   {
     limit: z.number().int().min(1).max(100).default(20).describe('Max entries to return (default 20, max 100)'),
     filter: z.string().optional().describe('Filter by URL substring (e.g. "/api/cart")'),
+    method: z.union([z.string(), z.array(z.string())]).optional().describe('Filter by HTTP method, case-insensitive (e.g. "POST" or ["POST","PUT"]). AND-combined with `filter`. Use to isolate mutations from follow-up GETs.'),
+    since: z.string().optional().describe('ISO timestamp — drop entries with timestamp < since before applying limit. Use to pin a checkpoint before an action and ask for everything since.'),
     clear: z.boolean().default(false).describe('Clear network buffer instead of reading'),
     device: z.string().optional().describe('Scope: a specific device key OR the literal "all" for a chronologically-merged view across every device. Defaults to the active device.'),
   },

--- a/scripts/cdp-bridge/src/tools/network-log.ts
+++ b/scripts/cdp-bridge/src/tools/network-log.ts
@@ -2,8 +2,17 @@ import type { CDPClient } from '../cdp-client.js';
 import { okResult, withConnection } from '../utils.js';
 import { shouldShowMetroClearHint, METRO_CLEAR_HINT_TEXT } from './metro-clear-hint.js';
 
+export interface NetworkLogArgs {
+  limit: number;
+  filter?: string;
+  method?: string | string[];
+  since?: string;
+  clear: boolean;
+  device?: string;
+}
+
 export function createNetworkLogHandler(getClient: () => CDPClient) {
-  return withConnection(getClient, async (args: { limit: number; filter?: string; clear: boolean; device?: string }, client) => {
+  return withConnection(getClient, async (args: NetworkLogArgs, client) => {
     const scope = args.device ?? client.activeDeviceKey;
 
     if (args.clear) {
@@ -13,25 +22,50 @@ export function createNetworkLogHandler(getClient: () => CDPClient) {
 
     const limit = Math.min(Math.max(args.limit ?? 20, 1), 100);
 
-    let entries = args.filter !== undefined
-      ? client.networkBufferManager.filter(scope, (e) => e.url.includes(args.filter!))
+    const wantedMethods = args.method
+      ? (Array.isArray(args.method) ? args.method : [args.method]).map((m) => m.toUpperCase())
+      : null;
+    // Normalize since to UTC Z-form. Entry timestamps come from
+    // `new Date().toISOString()` (always Z), so a user-supplied offset like
+    // `+02:00` would mis-compare under naive lexicographic order.
+    let since: string | undefined;
+    if (args.since !== undefined) {
+      const parsed = new Date(args.since);
+      since = Number.isNaN(parsed.getTime()) ? args.since : parsed.toISOString();
+    }
+    const urlNeedle = args.filter;
+
+    const hasFilters = urlNeedle !== undefined || wantedMethods !== null || since !== undefined;
+
+    let matches = hasFilters
+      ? client.networkBufferManager.filter(scope, (e) => {
+          if (urlNeedle !== undefined && !e.url.includes(urlNeedle)) return false;
+          if (since !== undefined && e.timestamp < since) return false;
+          if (wantedMethods !== null && !wantedMethods.includes(e.method.toUpperCase())) return false;
+          return true;
+        })
       : client.networkBufferManager.getLast(scope, limit);
 
-    if (args.filter !== undefined && entries.length > limit) {
-      entries = entries.slice(-limit);
-    }
+    const totalMatches = matches.length;
+    const sliced = hasFilters && matches.length > limit ? matches.slice(-limit) : matches;
+    const truncated = totalMatches > sliced.length;
 
-    // M11: include hint when buffer has stayed empty for >60s. The network
-    // manager tracks per-device lastPush, so the idle reference is
-    // max(connectedAt, lastPush[scope]). 'all' scope has no single lastPush,
-    // so fall back to connectedAt only.
     const lastEventAt = scope === 'all' ? null : client.networkBufferManager.getLastPush(scope);
     const hint = shouldShowMetroClearHint(
       { connectedAt: client.connectedAt, lastEventAt: lastEventAt ?? null, now: client.now },
-      entries.length === 0,
+      sliced.length === 0,
     ) ? METRO_CLEAR_HINT_TEXT : undefined;
     const resultOpts = hint ? { meta: { hint } } : undefined;
 
-    return okResult({ mode: client.networkMode, device: scope, count: entries.length, requests: entries }, resultOpts);
+    return okResult(
+      {
+        mode: client.networkMode,
+        device: scope,
+        count: sliced.length,
+        requests: sliced,
+        ...(truncated ? { truncated: true, total_matches: totalMatches } : {}),
+      },
+      resultOpts,
+    );
   });
 }

--- a/scripts/cdp-bridge/test/unit/tool-handlers-cdp2.test.js
+++ b/scripts/cdp-bridge/test/unit/tool-handlers-cdp2.test.js
@@ -114,6 +114,93 @@ test('network_log: clamps limit to [1, 100]', async () => {
   assert.equal(dataHigh.requests.length, 5, 'limit:200 clamps to 100, but only 5 entries exist');
 });
 
+// ── #73: method: filter, since: filter, truncated: warning ─────────────
+
+test('network_log: method filter (string) isolates POST from GET noise', async () => {
+  const client = createMockClient();
+  const ts = (i) => `2026-04-23T16:56:${String(i).padStart(2, '0')}Z`;
+  client.networkBufferManager.push(client.activeDeviceKey, { id: 'r1', method: 'POST', url: '/external_coverages', timestamp: ts(26), status: 201 });
+  client.networkBufferManager.push(client.activeDeviceKey, { id: 'r2', method: 'GET',  url: '/external_coverages', timestamp: ts(27), status: 200 });
+  client.networkBufferManager.push(client.activeDeviceKey, { id: 'r3', method: 'GET',  url: '/external_coverages', timestamp: ts(28), status: 200 });
+  const handler = createNetworkLogHandler(() => client);
+  const data = expectOk(await handler({ limit: 5, filter: 'external_coverages', method: 'POST', clear: false }));
+  assert.equal(data.count, 1);
+  assert.equal(data.requests[0].id, 'r1');
+});
+
+test('network_log: method filter (array) accepts multiple verbs case-insensitively', async () => {
+  const client = createMockClient();
+  client.networkBufferManager.push(client.activeDeviceKey, { id: 'r1', method: 'POST',   url: '/a', timestamp: '2026-04-23T16:56:26Z' });
+  client.networkBufferManager.push(client.activeDeviceKey, { id: 'r2', method: 'GET',    url: '/a', timestamp: '2026-04-23T16:56:27Z' });
+  client.networkBufferManager.push(client.activeDeviceKey, { id: 'r3', method: 'PATCH',  url: '/a', timestamp: '2026-04-23T16:56:28Z' });
+  client.networkBufferManager.push(client.activeDeviceKey, { id: 'r4', method: 'PUT',    url: '/a', timestamp: '2026-04-23T16:56:29Z' });
+  const handler = createNetworkLogHandler(() => client);
+  const data = expectOk(await handler({ limit: 10, method: ['post', 'patch'], clear: false }));
+  assert.equal(data.count, 2);
+  assert.deepEqual(data.requests.map((r) => r.id), ['r1', 'r3']);
+});
+
+test('network_log: since filter drops entries with timestamp < since', async () => {
+  const client = createMockClient();
+  client.networkBufferManager.push(client.activeDeviceKey, { id: 'r1', method: 'GET', url: '/a', timestamp: '2026-04-23T16:55:00Z' });
+  client.networkBufferManager.push(client.activeDeviceKey, { id: 'r2', method: 'GET', url: '/a', timestamp: '2026-04-23T16:56:30Z' });
+  client.networkBufferManager.push(client.activeDeviceKey, { id: 'r3', method: 'GET', url: '/a', timestamp: '2026-04-23T16:57:00Z' });
+  const handler = createNetworkLogHandler(() => client);
+  const data = expectOk(await handler({ limit: 10, since: '2026-04-23T16:56:00Z', clear: false }));
+  assert.equal(data.count, 2);
+  assert.deepEqual(data.requests.map((r) => r.id), ['r2', 'r3']);
+});
+
+test('network_log: since filter normalizes non-Z offset ISO to UTC for safe compare', async () => {
+  const client = createMockClient();
+  // Entry timestamps are always Z-form (per Date.toISOString())
+  client.networkBufferManager.push(client.activeDeviceKey, { id: 'r1', method: 'GET', url: '/a', timestamp: '2026-04-23T14:55:00Z' });
+  client.networkBufferManager.push(client.activeDeviceKey, { id: 'r2', method: 'GET', url: '/a', timestamp: '2026-04-23T14:56:30Z' });
+  client.networkBufferManager.push(client.activeDeviceKey, { id: 'r3', method: 'GET', url: '/a', timestamp: '2026-04-23T14:57:00Z' });
+  const handler = createNetworkLogHandler(() => client);
+  // User passes since in +02:00 offset; 16:56:00+02:00 == 14:56:00Z
+  // Naive string compare would treat "2026-04-23T16:56:00+02:00" > "2026-04-23T14:57:00Z" → 0 results
+  // After normalization, it correctly drops only r1.
+  const data = expectOk(await handler({ limit: 10, since: '2026-04-23T16:56:00+02:00', clear: false }));
+  assert.equal(data.count, 2);
+  assert.deepEqual(data.requests.map((r) => r.id), ['r2', 'r3']);
+});
+
+test('network_log: filter + method + since AND-combine', async () => {
+  const client = createMockClient();
+  client.networkBufferManager.push(client.activeDeviceKey, { id: 'r1', method: 'POST', url: '/users',   timestamp: '2026-04-23T16:55:00Z' });
+  client.networkBufferManager.push(client.activeDeviceKey, { id: 'r2', method: 'POST', url: '/orders',  timestamp: '2026-04-23T16:56:00Z' });
+  client.networkBufferManager.push(client.activeDeviceKey, { id: 'r3', method: 'GET',  url: '/orders',  timestamp: '2026-04-23T16:57:00Z' });
+  client.networkBufferManager.push(client.activeDeviceKey, { id: 'r4', method: 'POST', url: '/orders',  timestamp: '2026-04-23T16:58:00Z' });
+  const handler = createNetworkLogHandler(() => client);
+  const data = expectOk(await handler({ limit: 10, filter: '/orders', method: 'POST', since: '2026-04-23T16:57:00Z', clear: false }));
+  assert.equal(data.count, 1);
+  assert.equal(data.requests[0].id, 'r4');
+});
+
+test('network_log: truncated flag set when matches > limit', async () => {
+  const client = createMockClient();
+  for (let i = 0; i < 12; i++) {
+    client.networkBufferManager.push(client.activeDeviceKey, { id: `r${i}`, method: 'POST', url: '/orders', timestamp: `2026-04-23T16:56:${String(i).padStart(2, '0')}Z` });
+  }
+  const handler = createNetworkLogHandler(() => client);
+  const data = expectOk(await handler({ limit: 5, filter: '/orders', clear: false }));
+  assert.equal(data.count, 5);
+  assert.equal(data.truncated, true);
+  assert.equal(data.total_matches, 12);
+  assert.deepEqual(data.requests.map((r) => r.id), ['r7', 'r8', 'r9', 'r10', 'r11'], 'returns the most recent 5');
+});
+
+test('network_log: truncated absent when matches fit within limit', async () => {
+  const client = createMockClient();
+  client.networkBufferManager.push(client.activeDeviceKey, { id: 'r1', method: 'POST', url: '/orders', timestamp: '2026-04-23T16:56:00Z' });
+  const handler = createNetworkLogHandler(() => client);
+  const data = expectOk(await handler({ limit: 5, filter: '/orders', clear: false }));
+  assert.equal(data.count, 1);
+  assert.equal(data.truncated, undefined);
+  assert.equal(data.total_matches, undefined);
+});
+
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 // cdp_network_body
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### PR DESCRIPTION
…twork_log

Three additive opt-in parameters that target the verification pain documented in #73 — agents thrashing on cdp_network_log when one user action triggers many same-URL requests:

- method: string | string[] — case-insensitive HTTP verb filter, AND-combined with the existing URL substring `filter`. Lets a query like `filter:"external_coverages" method:"POST"` isolate the mutation from its follow-up GETs in one call.
- since: ISO timestamp — drops entries with timestamp < since before applying limit. Eliminates the "stale vs fresh" ambiguity for multi-mutation flows. Input is normalized via new Date(since).toISOString() so non-Z offsets (e.g. +02:00) compare correctly against the always-Z entry timestamps.
- truncated: true + total_matches: N — emitted only when the filtered match count exceeds the requested limit. Tells the agent to widen the limit instead of changing the filter.

Implementation collapses three predicates into a single buffer filter pass; no manager changes. Existing callers see identical output (no filter -> getLast path, count + requests keys unchanged).

7 new tests in test/unit/tool-handlers-cdp2.test.js: string-form method, array-form case-insensitive, since-only, three-way AND, truncated:true with most-recent-N slicing, truncated absent in fit-within-limit case, and offset normalization for since.

Multi-provider review (Gemini + gpt-5.5 xhigh) returned 0 high-confidence issues; both flagged the timestamp lex-compare as sub-threshold which the offset normalization addresses.