### PR TITLE
fix(gh-60): respect explicit platform over active session in agent-de…

### DIFF
--- a/scripts/cdp-bridge/dist/agent-device-wrapper.js
+++ b/scripts/cdp-bridge/dist/agent-device-wrapper.js
@@ -166,12 +166,17 @@ export function listCachedSnapshots() {
     return [...snapshotCache.keys()];
 }
 // Returns the `-s <serial>` args for adb when a specific device/emulator is
-// targeted. Prefers the active session's deviceId, then ANDROID_SERIAL env.
-// Returns an empty array when no target is set (adb will pick the only
-// connected device, or fail with "more than one device" if multiple exist).
+// targeted. Prefers the active session's deviceId IFF that session is Android,
+// then ANDROID_SERIAL env. Returns an empty array when no target is set (adb
+// will pick the only connected device, or fail with "more than one device" if
+// multiple exist).
+//
+// GH #60: prior to this gate, an active iOS session would leak its UDID into
+// adb commands (e.g. `device_deeplink platform:"android"` → `adb -s <iOS-UDID>
+// not found`) when both iOS and Android were booted simultaneously.
 export function getAdbSerial() {
     const session = getActiveSession();
-    if (session?.deviceId)
+    if (session?.platform === 'android' && session.deviceId)
         return ['-s', session.deviceId];
     if (process.env.ANDROID_SERIAL)
         return ['-s', process.env.ANDROID_SERIAL];
@@ -357,7 +362,13 @@ function cacheRefMapFromResult(result) {
     catch { /* not a snapshot response — ignore */ }
 }
 export async function runAgentDevice(cliArgs, opts = {}) {
-    const sessionName = (!opts.skipSession && activeSession) ? activeSession.name : '';
+    // GH #60: when an explicit platform is requested AND it doesn't match the
+    // active session's platform (e.g. user asks for android while an iOS
+    // session is active from prior work), skip the session-bound dispatch
+    // tiers (fast-runner, daemon) — they would otherwise route to the wrong
+    // device. Forcing CLI with `--platform` is correct in this case.
+    const platformMismatch = !!opts.platform && !!activeSession?.platform && opts.platform !== activeSession.platform;
+    const sessionName = (!opts.skipSession && !platformMismatch && activeSession) ? activeSession.name : '';
     const isSnapshotCmd = cliArgs[0] === 'snapshot';
     // Fastest path: XCTest fast-runner HTTP (iOS only, ~5-30ms/op)
     // Note: fast-runner snapshots return { tree: ... } (nested XCUIElement dict), not { nodes: [...] }

--- a/scripts/cdp-bridge/src/agent-device-wrapper.ts
+++ b/scripts/cdp-bridge/src/agent-device-wrapper.ts
@@ -201,12 +201,17 @@ export function listCachedSnapshots(): string[] {
 }
 
 // Returns the `-s <serial>` args for adb when a specific device/emulator is
-// targeted. Prefers the active session's deviceId, then ANDROID_SERIAL env.
-// Returns an empty array when no target is set (adb will pick the only
-// connected device, or fail with "more than one device" if multiple exist).
+// targeted. Prefers the active session's deviceId IFF that session is Android,
+// then ANDROID_SERIAL env. Returns an empty array when no target is set (adb
+// will pick the only connected device, or fail with "more than one device" if
+// multiple exist).
+//
+// GH #60: prior to this gate, an active iOS session would leak its UDID into
+// adb commands (e.g. `device_deeplink platform:"android"` → `adb -s <iOS-UDID>
+// not found`) when both iOS and Android were booted simultaneously.
 export function getAdbSerial(): string[] {
   const session = getActiveSession();
-  if (session?.deviceId) return ['-s', session.deviceId];
+  if (session?.platform === 'android' && session.deviceId) return ['-s', session.deviceId];
   if (process.env.ANDROID_SERIAL) return ['-s', process.env.ANDROID_SERIAL];
   return [];
 }
@@ -385,7 +390,14 @@ export async function runAgentDevice(
   cliArgs: string[],
   opts: { skipSession?: boolean; platform?: 'ios' | 'android' | null } = {},
 ): Promise<ToolResult> {
-  const sessionName = (!opts.skipSession && activeSession) ? activeSession.name : '';
+  // GH #60: when an explicit platform is requested AND it doesn't match the
+  // active session's platform (e.g. user asks for android while an iOS
+  // session is active from prior work), skip the session-bound dispatch
+  // tiers (fast-runner, daemon) — they would otherwise route to the wrong
+  // device. Forcing CLI with `--platform` is correct in this case.
+  const platformMismatch =
+    !!opts.platform && !!activeSession?.platform && opts.platform !== activeSession.platform;
+  const sessionName = (!opts.skipSession && !platformMismatch && activeSession) ? activeSession.name : '';
   const isSnapshotCmd = cliArgs[0] === 'snapshot';
 
   // Fastest path: XCTest fast-runner HTTP (iOS only, ~5-30ms/op)

--- a/scripts/cdp-bridge/test/unit/gh-60-multi-device-routing.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-60-multi-device-routing.test.js
@@ -1,0 +1,93 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getAdbSerial,
+  setActiveSession,
+  clearActiveSession,
+} from '../../dist/agent-device-wrapper.js';
+
+// GH #60: when an iOS session is active and a caller targets Android (e.g. via
+// device_deeplink platform:"android" or any adb-backed flow), the iOS UDID
+// would leak into adb's `-s <serial>` arg and produce "device not found".
+// The fix gates the session-deviceId branch on session.platform === 'android'.
+
+test('getAdbSerial: returns empty when iOS session is active and no ANDROID_SERIAL env', () => {
+  const prevEnv = process.env.ANDROID_SERIAL;
+  delete process.env.ANDROID_SERIAL;
+  try {
+    setActiveSession({ name: 'ios-test', platform: 'ios', deviceId: 'ABCDEF12-1234-5678-9012-IOS-UDID-EXAMPLE' });
+    assert.deepEqual(
+      getAdbSerial(),
+      [],
+      'iOS UDID must not leak into adb args when session is iOS',
+    );
+  } finally {
+    clearActiveSession();
+    if (prevEnv !== undefined) process.env.ANDROID_SERIAL = prevEnv;
+  }
+});
+
+test('getAdbSerial: returns ANDROID_SERIAL when iOS session is active', () => {
+  const prevEnv = process.env.ANDROID_SERIAL;
+  process.env.ANDROID_SERIAL = 'emulator-5554';
+  try {
+    setActiveSession({ name: 'ios-test', platform: 'ios', deviceId: 'ABCDEF12-1234-5678-9012-IOS-UDID-EXAMPLE' });
+    assert.deepEqual(
+      getAdbSerial(),
+      ['-s', 'emulator-5554'],
+      'falls back to ANDROID_SERIAL when iOS session has nothing usable',
+    );
+  } finally {
+    clearActiveSession();
+    if (prevEnv === undefined) delete process.env.ANDROID_SERIAL;
+    else process.env.ANDROID_SERIAL = prevEnv;
+  }
+});
+
+test('getAdbSerial: returns session.deviceId when Android session is active', () => {
+  const prevEnv = process.env.ANDROID_SERIAL;
+  delete process.env.ANDROID_SERIAL;
+  try {
+    setActiveSession({ name: 'android-test', platform: 'android', deviceId: 'emulator-5554' });
+    assert.deepEqual(
+      getAdbSerial(),
+      ['-s', 'emulator-5554'],
+      'Android session deviceId is the correct adb serial',
+    );
+  } finally {
+    clearActiveSession();
+    if (prevEnv !== undefined) process.env.ANDROID_SERIAL = prevEnv;
+  }
+});
+
+test('getAdbSerial: prefers Android session.deviceId over ANDROID_SERIAL env', () => {
+  const prevEnv = process.env.ANDROID_SERIAL;
+  process.env.ANDROID_SERIAL = 'env-serial';
+  try {
+    setActiveSession({ name: 'android-test', platform: 'android', deviceId: 'emulator-5554' });
+    assert.deepEqual(
+      getAdbSerial(),
+      ['-s', 'emulator-5554'],
+      'session takes precedence over env when platform matches',
+    );
+  } finally {
+    clearActiveSession();
+    if (prevEnv === undefined) delete process.env.ANDROID_SERIAL;
+    else process.env.ANDROID_SERIAL = prevEnv;
+  }
+});
+
+test('getAdbSerial: returns empty when no session and no env', () => {
+  const prevEnv = process.env.ANDROID_SERIAL;
+  delete process.env.ANDROID_SERIAL;
+  try {
+    clearActiveSession();
+    assert.deepEqual(
+      getAdbSerial(),
+      [],
+      'empty array → adb picks the only connected device, or errors loudly',
+    );
+  } finally {
+    if (prevEnv !== undefined) process.env.ANDROID_SERIAL = prevEnv;
+  }
+});


### PR DESCRIPTION
…vice routing

Two minimal changes in scripts/cdp-bridge/src/agent-device-wrapper.ts that close both bugs reported in #60:

1. getAdbSerial() now gates session.deviceId on session.platform === 'android'. Previously it would return the active session's deviceId regardless of platform, leaking iOS UDIDs into adb -s commands when both sims were booted (e.g.
   `device_deeplink platform:"android"` -> "adb: device <iOS-UDID>
   not found"). Both call sites (openAndroidDeeplink in device-deeplink.ts:37, androidClipboardFill in device-interact.ts:378) are Android-only paths; the leak was never desired. Falls back to ANDROID_SERIAL env or empty array when session is iOS, preserving the manual-override path.

2. runAgentDevice() now computes a platformMismatch flag and empties sessionName when the caller explicitly passes opts.platform AND it differs from activeSession.platform. With sessionName='', the fast-runner gate (line 407, sessionName && activeSession?.platform === 'ios') and daemon gate (line 417, sessionName && loadDaemonInfo()) both bypass, falling through to CLI with --platform (B117/D638 plumbing already in place). This fixes `device_screenshot platform:"android"` capturing iOS when an iOS session was active from prior work.

The fix is minimal by design — the legacy-session edge case (activeSession.platform undefined) intentionally falls back to old behavior, since an undefined platform means we have no positive evidence of a mismatch. Modern session-open paths always set platform.

5 new tests in test/unit/gh-60-multi-device-routing.test.js cover getAdbSerial across the four state combinations (iOS-no-env, iOS-with-env, Android-no-env, Android-with-env-priority) plus the empty baseline. The runAgentDevice platformMismatch branch is verified by code review; isolated unit testing would require mocking execFile and the daemon socket.

Multi-provider review (Gemini + gpt-5.5 xhigh) returned 0 high-confidence issues; both reviewers verified that no caller of getAdbSerial() depended on the prior iOS-UDID-leak behavior.

Bug 4 from the same issue (cdp_navigate requires global nav ref) is already tracked in #72; remaining items (cdp_reload retry, accessibilityLabel matching, require() docs gap, missing recording/storage/reset/Android-dialog tools) deferred to follow-up issues.