### PR TITLE
fix(gh-59-5): pin resolved platform after auto-detect connect for sti…

### DIFF
--- a/scripts/cdp-bridge/dist/cdp/connect.js
+++ b/scripts/cdp-bridge/dist/cdp/connect.js
@@ -94,8 +94,33 @@ discoverFn = discover) {
     }
     const generation = ctx.incrementConnectionGeneration();
     logger.info('CDP', `Connected to target ${connectedTarget.id} (${connectedTarget.title}) on port ${metroPort}, generation=${generation}`);
+    // GH #59 #5: persist the resolved platform into _connectFilters when the
+    // caller didn't pin one explicitly. Without this, softReconnect after
+    // cdp_reload has nothing to filter on and may pick the wrong simulator
+    // (e.g. iOS user reloads, sortTargets returns Android first, reconnect
+    // lands on Android). Explicit filters from the caller already survive
+    // (B111/D643/G7); this closes the auto-detect gap.
+    const stickyFilters = stickyPlatformFilters(ctx.getConnectFilters(), connectedTarget.platform);
+    if (stickyFilters)
+        ctx.setConnectFilters(stickyFilters);
     const msg = `Connected to ${connectedTarget.title} on port ${metroPort}`;
     return selectionWarning ? `${msg}. WARNING: ${selectionWarning}` : msg;
+}
+/**
+ * GH #59 #5: pure helper that pins the resolved platform into a copy of the
+ * current connect filters when (a) no platform filter was explicitly set and
+ * (b) the connect resolved a target whose platform we now know. Returns null
+ * when no update is needed — caller skips the setConnectFilters call.
+ *
+ * Extracted so the auto-detect → reconnect-stays-on-same-platform invariant
+ * can be unit-tested without spinning a real WebSocket connect.
+ */
+export function stickyPlatformFilters(current, resolvedPlatform) {
+    if (current.platform)
+        return null;
+    if (!resolvedPlatform)
+        return null;
+    return { ...current, platform: resolvedPlatform };
 }
 async function connectToTarget(ctx, target, retries = 5) {
     let lastError = null;

--- a/scripts/cdp-bridge/src/cdp/connect.ts
+++ b/scripts/cdp-bridge/src/cdp/connect.ts
@@ -145,8 +145,36 @@ export async function discoverAndConnect(
 
   const generation = ctx.incrementConnectionGeneration();
   logger.info('CDP', `Connected to target ${connectedTarget!.id} (${connectedTarget!.title}) on port ${metroPort}, generation=${generation}`);
+
+  // GH #59 #5: persist the resolved platform into _connectFilters when the
+  // caller didn't pin one explicitly. Without this, softReconnect after
+  // cdp_reload has nothing to filter on and may pick the wrong simulator
+  // (e.g. iOS user reloads, sortTargets returns Android first, reconnect
+  // lands on Android). Explicit filters from the caller already survive
+  // (B111/D643/G7); this closes the auto-detect gap.
+  const stickyFilters = stickyPlatformFilters(ctx.getConnectFilters(), connectedTarget!.platform);
+  if (stickyFilters) ctx.setConnectFilters(stickyFilters);
+
   const msg = `Connected to ${connectedTarget!.title} on port ${metroPort}`;
   return selectionWarning ? `${msg}. WARNING: ${selectionWarning}` : msg;
+}
+
+/**
+ * GH #59 #5: pure helper that pins the resolved platform into a copy of the
+ * current connect filters when (a) no platform filter was explicitly set and
+ * (b) the connect resolved a target whose platform we now know. Returns null
+ * when no update is needed — caller skips the setConnectFilters call.
+ *
+ * Extracted so the auto-detect → reconnect-stays-on-same-platform invariant
+ * can be unit-tested without spinning a real WebSocket connect.
+ */
+export function stickyPlatformFilters(
+  current: ConnectFilters,
+  resolvedPlatform: string | undefined,
+): ConnectFilters | null {
+  if (current.platform) return null;
+  if (!resolvedPlatform) return null;
+  return { ...current, platform: resolvedPlatform };
 }
 
 async function connectToTarget(

--- a/scripts/cdp-bridge/test/unit/gh-59-5-sticky-platform.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-59-5-sticky-platform.test.js
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { stickyPlatformFilters } from '../../dist/cdp/connect.js';
+
+// GH #59 #5: after auto-detect connect resolves to platform X, _connectFilters
+// must be updated so that subsequent softReconnect (cdp_reload) lands on the
+// same platform. Explicit filters from the caller (B111/D643/G7) already
+// survive; this closes the auto-detect gap.
+
+test('stickyPlatformFilters: pins resolved platform when no explicit filter', () => {
+  assert.deepEqual(
+    stickyPlatformFilters({}, 'ios'),
+    { platform: 'ios' },
+    'auto-detect → ios sticks the resolved platform',
+  );
+});
+
+test('stickyPlatformFilters: preserves other filters when pinning platform', () => {
+  assert.deepEqual(
+    stickyPlatformFilters({ bundleId: 'com.example' }, 'android'),
+    { bundleId: 'com.example', platform: 'android' },
+    'must merge with existing filters, not replace',
+  );
+});
+
+test('stickyPlatformFilters: returns null when platform is already set', () => {
+  // Explicit filters take precedence — never overwrite a user-pinned platform.
+  assert.equal(
+    stickyPlatformFilters({ platform: 'android' }, 'ios'),
+    null,
+    'never overwrites a user-supplied platform filter',
+  );
+});
+
+test('stickyPlatformFilters: returns null when resolvedPlatform is missing', () => {
+  // Some discovery paths may not surface platform — skip the update silently.
+  assert.equal(stickyPlatformFilters({}, undefined), null);
+});
+
+test('stickyPlatformFilters: returns null when current has other filters but resolvedPlatform missing', () => {
+  // Don't touch existing filters when there's nothing to sticky.
+  assert.equal(stickyPlatformFilters({ bundleId: 'com.example' }, undefined), null);
+});
+
+test('stickyPlatformFilters: empty resolvedPlatform string is treated as missing', () => {
+  // Defensive: an empty platform shouldn't leak into filters.
+  assert.equal(stickyPlatformFilters({}, ''), null);
+});


### PR DESCRIPTION
…cky reconnect

Closes the cdp_reload-misroute path described in #59 sub-item #5: on a multi-device setup (iOS sim + Android emulator both booted), the auto-reconnect after cdp_reload would land on whichever target sortTargets returned first, often switching the user from iOS to Android. Workaround was `cdp_status platform: "ios"` to force re-bind.

Root cause: when initial connect was auto-detect (no explicit platform: filter), `_connectFilters.platform` stayed undefined. Subsequent softReconnect() then had nothing to filter on. Explicit filters from the caller already survived softReconnect (B111/D643/G7); this closes the auto-detect gap.

Implementation in scripts/cdp-bridge/src/cdp/connect.ts:

- New pure helper stickyPlatformFilters(current, resolvedPlatform) returns updated filters when the platform should be pinned, null otherwise. Guards: never overwrite an existing platform filter (preserves G7), never persist a falsy resolved platform.
- After connectedTarget is resolved in discoverAndConnect, call the helper and persist via ctx.setConnectFilters().

The helper is extracted because the post-connectToTarget code path can't be unit-tested without spinning a real WebSocket. Pulling the rule into a pure function keeps the logic verifiable without adding test infrastructure.

6 new tests in test/unit/gh-59-5-sticky-platform.test.js cover the decision matrix: auto-detect → sticky, preserve other filters, explicit platform takes precedence, missing/empty resolved platform no-ops.

Multi-provider review (Gemini + gpt-5.5 xhigh) returned 0 high-confidence issues. Both reviewers independently verified:
- All three reconnect paths (softReconnect, exponential-backoff reconnect, recovery softReconnect) flow through discoverAndConnect, so one fix point covers all of them.
- Explicit cdp_status platform:"X" still works because that path goes through disconnect() + fresh CDPClient, resetting _connectFilters.
- HermesTarget.platform is typed 'ios' | 'android' | undefined; no garbage strings can leak into filters.