### PR TITLE
fix(gh-59-9): retry network-mode probe to avoid false hook fallback a…

### DIFF
--- a/scripts/cdp-bridge/dist/cdp/setup.js
+++ b/scripts/cdp-bridge/dist/cdp/setup.js
@@ -52,15 +52,12 @@ export async function performSetup(opts) {
     logger.info('CDP', `Helpers injected (v11), network mode: ${networkMode}`);
     setActiveFlag(port, connectedTarget);
     // D626 (B1 fix): Probe whether Network.enable actually delivers events.
+    // GH #59 #9: a single 500ms probe is too tight after platform switches /
+    // reload — the fresh JS context needs time to flush the probe fetch through
+    // its CDP event channel. Retry once at a longer interval before declaring
+    // RN<0.83. Total worst-case wait for legitimate fallback: 500ms + 1500ms.
     if (networkMode === 'cdp') {
-        const deviceKey = getDeviceKey();
-        const bufSizeBefore = networkManager.size(deviceKey);
-        await evaluate(`void fetch('http://localhost:${port}/status').catch(function(){})`);
-        await new Promise(r => setTimeout(r, 500));
-        if (networkManager.size(deviceKey) <= bufSizeBefore) {
-            logger.info('CDP', 'Network.enable accepted but no events fired (RN < 0.83) — falling back to hooks');
-            networkMode = 'none';
-        }
+        networkMode = await probeNetworkDomain({ evaluate, port, networkManager, getDeviceKey });
     }
     if (networkMode === 'none') {
         const hookResult = await evaluate(NETWORK_HOOK_SCRIPT);
@@ -77,6 +74,36 @@ export async function performSetup(opts) {
         }
     }
     return { networkMode, helpersInjected: true, logDomainEnabled, profilerAvailable, heapProfilerAvailable };
+}
+/**
+ * GH #59 #9: probe whether Network.enable actually delivers events on the
+ * current Hermes context. RN >= 0.83 (Bridgeless) accepts Network.enable AND
+ * fires events; older runtimes accept the call but no events flow. The probe
+ * fires a localhost fetch and watches the per-device buffer for growth.
+ *
+ * Two attempts at increasing timeouts (500ms, 1500ms). One-shot 500ms was
+ * the original D626 implementation but produced false negatives after
+ * platform switches and reloads where the fresh context needs longer to
+ * flush the probe fetch through CDP. Total worst-case latency for legitimate
+ * RN<0.83 fallback: ~2 seconds (was 500ms).
+ *
+ * Returns the post-probe network mode: 'cdp' if events fired, 'none'
+ * otherwise (caller will then try hook injection).
+ */
+export async function probeNetworkDomain(opts) {
+    const { evaluate, port, networkManager, getDeviceKey } = opts;
+    const waits = opts.waits ?? [500, 1500];
+    const deviceKey = getDeviceKey();
+    for (let attempt = 0; attempt < waits.length; attempt++) {
+        const bufSizeBefore = networkManager.size(deviceKey);
+        await evaluate(`void fetch('http://localhost:${port}/status').catch(function(){})`);
+        await new Promise(r => setTimeout(r, waits[attempt]));
+        if (networkManager.size(deviceKey) > bufSizeBefore) {
+            return 'cdp';
+        }
+    }
+    logger.info('CDP', `Network.enable accepted but no events fired after ${waits.length} attempt(s) — falling back to hooks`);
+    return 'none';
 }
 export async function reinjectHelpers(evaluate, waitTimeout) {
     await waitForReact(evaluate, waitTimeout ?? REACT_READY_TIMEOUT_MS);

--- a/scripts/cdp-bridge/src/cdp/setup.ts
+++ b/scripts/cdp-bridge/src/cdp/setup.ts
@@ -82,15 +82,12 @@ export async function performSetup(opts: {
   setActiveFlag(port, connectedTarget);
 
   // D626 (B1 fix): Probe whether Network.enable actually delivers events.
+  // GH #59 #9: a single 500ms probe is too tight after platform switches /
+  // reload — the fresh JS context needs time to flush the probe fetch through
+  // its CDP event channel. Retry once at a longer interval before declaring
+  // RN<0.83. Total worst-case wait for legitimate fallback: 500ms + 1500ms.
   if (networkMode === 'cdp') {
-    const deviceKey = getDeviceKey();
-    const bufSizeBefore = networkManager.size(deviceKey);
-    await evaluate(`void fetch('http://localhost:${port}/status').catch(function(){})`);
-    await new Promise(r => setTimeout(r, 500));
-    if (networkManager.size(deviceKey) <= bufSizeBefore) {
-      logger.info('CDP', 'Network.enable accepted but no events fired (RN < 0.83) — falling back to hooks');
-      networkMode = 'none';
-    }
+    networkMode = await probeNetworkDomain({ evaluate, port, networkManager, getDeviceKey });
   }
 
   if (networkMode === 'none') {
@@ -108,6 +105,53 @@ export async function performSetup(opts: {
   }
 
   return { networkMode, helpersInjected: true, logDomainEnabled, profilerAvailable, heapProfilerAvailable };
+}
+
+/**
+ * GH #59 #9: probe whether Network.enable actually delivers events on the
+ * current Hermes context. RN >= 0.83 (Bridgeless) accepts Network.enable AND
+ * fires events; older runtimes accept the call but no events flow. The probe
+ * fires a localhost fetch and watches the per-device buffer for growth.
+ *
+ * Two attempts at increasing timeouts (500ms, 1500ms). One-shot 500ms was
+ * the original D626 implementation but produced false negatives after
+ * platform switches and reloads where the fresh context needs longer to
+ * flush the probe fetch through CDP. Total worst-case latency for legitimate
+ * RN<0.83 fallback: ~2 seconds (was 500ms).
+ *
+ * Returns the post-probe network mode: 'cdp' if events fired, 'none'
+ * otherwise (caller will then try hook injection).
+ */
+export async function probeNetworkDomain(opts: {
+  evaluate: (expr: string) => Promise<EvaluateResult>;
+  port: number;
+  networkManager: DeviceBufferManager<NetworkEntry, string>;
+  getDeviceKey: () => string;
+  /**
+   * Wait intervals between probe fetch and buffer-size check, in ms.
+   * Defaults to [500, 1500]. Exposed for tests to inject deterministic short
+   * waits without changing production behavior.
+   */
+  waits?: number[];
+}): Promise<'cdp' | 'none'> {
+  const { evaluate, port, networkManager, getDeviceKey } = opts;
+  const waits = opts.waits ?? [500, 1500];
+  const deviceKey = getDeviceKey();
+
+  for (let attempt = 0; attempt < waits.length; attempt++) {
+    const bufSizeBefore = networkManager.size(deviceKey);
+    await evaluate(`void fetch('http://localhost:${port}/status').catch(function(){})`);
+    await new Promise(r => setTimeout(r, waits[attempt]));
+    if (networkManager.size(deviceKey) > bufSizeBefore) {
+      return 'cdp';
+    }
+  }
+
+  logger.info(
+    'CDP',
+    `Network.enable accepted but no events fired after ${waits.length} attempt(s) — falling back to hooks`,
+  );
+  return 'none';
 }
 
 export async function reinjectHelpers(

--- a/scripts/cdp-bridge/test/unit/gh-59-9-network-probe.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-59-9-network-probe.test.js
@@ -1,0 +1,154 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { probeNetworkDomain } from '../../dist/cdp/setup.js';
+
+// GH #59 #9: D626 network-mode probe was a single 500ms check — false-negatives
+// happened after platform switches when the fresh Hermes context needed longer
+// to flush the probe fetch. Bug surfaced as cdp_network_log returning
+// mode:'hook' with zero entries despite traffic. Fix: probe twice (500ms then
+// 1500ms) before declaring RN<0.83 fallback.
+
+function createNetworkManager(deviceKey, schedule) {
+  // Schedule: array of { onProbe: (attempt) => grew?: boolean }
+  // simulates the buffer growing in response to the Nth probe.
+  let probeCount = 0;
+  let size = 0;
+  return {
+    size: () => size,
+    // The handler injects an event into the buffer in lock-step with the
+    // attempt counter so the wait completes deterministically.
+    advance: () => {
+      probeCount++;
+      const decision = schedule[probeCount - 1];
+      if (decision?.grew) size += 1;
+    },
+    getProbeCount: () => probeCount,
+    getDeviceKey: () => deviceKey,
+  };
+}
+
+test('probeNetworkDomain: returns cdp when first probe sees a buffer event', async () => {
+  const mgr = createNetworkManager('test-key', [{ grew: true }]);
+  let evalCount = 0;
+  const evaluate = async () => {
+    evalCount++;
+    mgr.advance();
+    return { value: undefined };
+  };
+
+  const mode = await probeNetworkDomain({
+    evaluate,
+    port: 8081,
+    networkManager: { size: mgr.size },
+    getDeviceKey: mgr.getDeviceKey,
+    waits: [1, 1],
+  });
+
+  assert.equal(mode, 'cdp');
+  assert.equal(evalCount, 1, 'should not retry when first probe succeeds');
+});
+
+test('probeNetworkDomain: retries and returns cdp when only second probe sees event', async () => {
+  // First probe: no event. Second probe: event fires. This is the real GH #59 #9
+  // failure mode — fresh context needed extra time after platform switch.
+  const mgr = createNetworkManager('test-key', [{ grew: false }, { grew: true }]);
+  let evalCount = 0;
+  const evaluate = async () => {
+    evalCount++;
+    mgr.advance();
+    return { value: undefined };
+  };
+
+  const mode = await probeNetworkDomain({
+    evaluate,
+    port: 8081,
+    networkManager: { size: mgr.size },
+    getDeviceKey: mgr.getDeviceKey,
+    waits: [1, 1],
+  });
+
+  assert.equal(mode, 'cdp', 'second probe success should keep CDP mode');
+  assert.equal(evalCount, 2, 'should retry exactly once');
+});
+
+test('probeNetworkDomain: returns none after all probes fail', async () => {
+  const mgr = createNetworkManager('test-key', [{ grew: false }, { grew: false }]);
+  let evalCount = 0;
+  const evaluate = async () => {
+    evalCount++;
+    mgr.advance();
+    return { value: undefined };
+  };
+
+  const mode = await probeNetworkDomain({
+    evaluate,
+    port: 8081,
+    networkManager: { size: mgr.size },
+    getDeviceKey: mgr.getDeviceKey,
+    waits: [1, 1],
+  });
+
+  assert.equal(mode, 'none', 'genuine RN<0.83: both probes fail → fallback');
+  assert.equal(evalCount, 2, 'all attempts should be tried before giving up');
+});
+
+test('probeNetworkDomain: respects custom waits length (single attempt)', async () => {
+  const mgr = createNetworkManager('test-key', [{ grew: false }]);
+  let evalCount = 0;
+  const evaluate = async () => {
+    evalCount++;
+    mgr.advance();
+    return { value: undefined };
+  };
+
+  const mode = await probeNetworkDomain({
+    evaluate,
+    port: 8081,
+    networkManager: { size: mgr.size },
+    getDeviceKey: mgr.getDeviceKey,
+    waits: [1],
+  });
+
+  assert.equal(mode, 'none');
+  assert.equal(evalCount, 1, 'waits.length controls attempt count');
+});
+
+test('probeNetworkDomain: uses provided port in fetch URL', async () => {
+  const captured = [];
+  const evaluate = async (expr) => {
+    captured.push(expr);
+    return { value: undefined };
+  };
+
+  await probeNetworkDomain({
+    evaluate,
+    port: 19000,
+    networkManager: { size: () => 0 },
+    getDeviceKey: () => 'k',
+    waits: [1],
+  });
+
+  assert.equal(captured.length, 1);
+  assert.match(captured[0], /http:\/\/localhost:19000\/status/);
+});
+
+test('probeNetworkDomain: defaults waits to [500, 1500] when omitted', async () => {
+  // Smoke test that omitting `waits` doesn't crash. We don't assert exact
+  // timings — just that the call completes without error and returns a valid mode.
+  let evalCount = 0;
+  const evaluate = async () => {
+    evalCount++;
+    return { value: undefined };
+  };
+  const start = Date.now();
+  const mode = await probeNetworkDomain({
+    evaluate,
+    port: 8081,
+    networkManager: { size: () => 0 },
+    getDeviceKey: () => 'k',
+  });
+  const elapsed = Date.now() - start;
+  assert.equal(mode, 'none', 'no events → none');
+  assert.equal(evalCount, 2, 'default schedule has 2 attempts');
+  assert.ok(elapsed >= 1900, `should wait ~2s in default mode, got ${elapsed}ms`);
+});


### PR DESCRIPTION
…fter platform switch

Closes the false-negative path described in #59 sub-item #9: after cycling between iOS and Android via cdp_status platform: ..., the fresh Hermes context needs more than 500ms to flush a probe fetch through CDP. The original D626 single-shot 500ms probe was too tight and would mis-categorize the runtime as RN<0.83, falling back to hook mode unnecessarily. The hook injection then runs against a post-switch context and may not catch all traffic.

Implementation in scripts/cdp-bridge/src/cdp/setup.ts:

- Extracted the probe into a new exported pure function probeNetworkDomain(opts) accepting evaluate, port, networkManager, getDeviceKey, and an optional waits[] schedule.
- Default schedule [500, 1500]: try once at 500ms (matches D626 baseline behavior), retry at 1500ms before declaring fallback. Total worst-case wait for legitimate RN<0.83 fallback: ~2s (was 500ms). Happy path on RN>=0.83 unchanged — first probe succeeds immediately.
- Inline call site in performSetup replaced with a single helper invocation.

The helper extraction also enables proper unit testing — the original inline probe couldn't be exercised without spinning a real Hermes context.

6 new tests in test/unit/gh-59-9-network-probe.test.js cover:
- First-probe success (no retry)
- Retry succeeds (the actual GH #59 #9 failure mode)
- All probes fail (genuine RN<0.83 fallback)
- Custom waits.length controls attempt count
- Probe URL uses provided port
- Default schedule timing smoke test (~2s elapsed)

Multi-provider review (Gemini + gpt-5.5 xhigh) returned 0 high-confidence issues. Both reviewers verified:
- The retry directly addresses the documented race
- Side effects are confined to the legitimate RN<0.83 fallback path (one-time, per setup)
- Network.enable response time is orthogonal — it's awaited before the probe runs (line 38), so slow Network.enable doesn't run concurrently with the probe
- Hook injection failures (a separate concern raised by the reporter) are an independent failure mode this patch does not regress