### PR TITLE
fix(gh-72): walk hooks chain in findNavRef to discover ref-less Navig…

### DIFF
--- a/scripts/cdp-bridge/dist/injected-helpers.js
+++ b/scripts/cdp-bridge/dist/injected-helpers.js
@@ -1,6 +1,6 @@
 export const INJECTED_HELPERS = `
 (function() {
-  var __HELPERS_VERSION__ = 18;
+  var __HELPERS_VERSION__ = 19;
   if (globalThis.__RN_AGENT && globalThis.__RN_AGENT.__v === __HELPERS_VERSION__) return;
   if (globalThis.__RN_AGENT) delete globalThis.__RN_AGENT;
 
@@ -1096,6 +1096,14 @@ export const INJECTED_HELPERS = `
     // navigate() ref. The fiber ref lives on the same renderer as the
     // container itself, so no cross-renderer lookup is needed — we just
     // have to reach the right renderer.
+    //
+    // GH #72: when the app renders <NavigationContainer> without a ref prop
+    // (common in Expo Router and minimalist setups), neither fiber.ref nor
+    // fiber.stateNode carry a navigate() function. React Navigation's
+    // internal ref from useNavigationContainerRef() lives on the hooks
+    // linked list at fiber.memoizedState. Walk that chain too — strict
+    // match on { navigate, dispatch, getRootState } avoids picking up
+    // unrelated refs in apps with multiple navigation libraries.
     return forEachRootFiber(function(rootFiber) {
       var localFound = null;
       var count = 0;
@@ -1115,6 +1123,22 @@ export const INJECTED_HELPERS = `
             localFound = fiber.stateNode;
             break;
           }
+          // GH #72: walk the hooks linked list for the internal ref.
+          var hook = fiber.memoizedState;
+          var hopGuard = 0;
+          while (hook && hopGuard < 100) {
+            hopGuard++;
+            var hms = hook.memoizedState;
+            if (hms && hms.current
+                && typeof hms.current.navigate === 'function'
+                && typeof hms.current.dispatch === 'function'
+                && typeof hms.current.getRootState === 'function') {
+              localFound = hms.current;
+              break;
+            }
+            hook = hook.next;
+          }
+          if (localFound) break;
         }
         if (fiber.sibling) stack.push(fiber.sibling);
         if (fiber.child) stack.push(fiber.child);
@@ -1125,7 +1149,12 @@ export const INJECTED_HELPERS = `
 
   function navigateTo(screen, params) {
     var ref = findNavRef();
-    if (!ref) return JSON.stringify({ __agent_error: 'Navigation ref not found. Add globalThis.__NAV_REF__ = navigationRef in your app, or ensure NavigationContainer has a ref prop.' });
+    // GH #72: error message updated to reflect the wider discovery surface.
+    // findNavRef() now checks 3 globals + fiber.ref + fiber.stateNode +
+    // fiber.memoizedState hooks chain. If all of those miss, the app is
+    // likely on React Navigation < 6.x (no NavigationContainer fiber name)
+    // or has wrapped the container in something unrecognized.
+    if (!ref) return JSON.stringify({ __agent_error: 'Navigation ref not found. The plugin walks 3 globals (__NAV_REF__, __NAVIGATION_REF__, navigationRef), NavigationContainer fiber.ref + fiber.stateNode, and the useNavigationContainerRef() hooks chain. None matched. If you are on React Navigation 6+, ensure <NavigationContainer> is rendered. As a last resort, expose globalThis.__NAV_REF__ = navigationRef in your app entry.' });
 
     try {
       var state = ref.getRootState();

--- a/scripts/cdp-bridge/src/injected-helpers.ts
+++ b/scripts/cdp-bridge/src/injected-helpers.ts
@@ -1,6 +1,6 @@
 export const INJECTED_HELPERS = `
 (function() {
-  var __HELPERS_VERSION__ = 18;
+  var __HELPERS_VERSION__ = 19;
   if (globalThis.__RN_AGENT && globalThis.__RN_AGENT.__v === __HELPERS_VERSION__) return;
   if (globalThis.__RN_AGENT) delete globalThis.__RN_AGENT;
 
@@ -1096,6 +1096,14 @@ export const INJECTED_HELPERS = `
     // navigate() ref. The fiber ref lives on the same renderer as the
     // container itself, so no cross-renderer lookup is needed — we just
     // have to reach the right renderer.
+    //
+    // GH #72: when the app renders <NavigationContainer> without a ref prop
+    // (common in Expo Router and minimalist setups), neither fiber.ref nor
+    // fiber.stateNode carry a navigate() function. React Navigation's
+    // internal ref from useNavigationContainerRef() lives on the hooks
+    // linked list at fiber.memoizedState. Walk that chain too — strict
+    // match on { navigate, dispatch, getRootState } avoids picking up
+    // unrelated refs in apps with multiple navigation libraries.
     return forEachRootFiber(function(rootFiber) {
       var localFound = null;
       var count = 0;
@@ -1115,6 +1123,22 @@ export const INJECTED_HELPERS = `
             localFound = fiber.stateNode;
             break;
           }
+          // GH #72: walk the hooks linked list for the internal ref.
+          var hook = fiber.memoizedState;
+          var hopGuard = 0;
+          while (hook && hopGuard < 100) {
+            hopGuard++;
+            var hms = hook.memoizedState;
+            if (hms && hms.current
+                && typeof hms.current.navigate === 'function'
+                && typeof hms.current.dispatch === 'function'
+                && typeof hms.current.getRootState === 'function') {
+              localFound = hms.current;
+              break;
+            }
+            hook = hook.next;
+          }
+          if (localFound) break;
         }
         if (fiber.sibling) stack.push(fiber.sibling);
         if (fiber.child) stack.push(fiber.child);
@@ -1125,7 +1149,12 @@ export const INJECTED_HELPERS = `
 
   function navigateTo(screen, params) {
     var ref = findNavRef();
-    if (!ref) return JSON.stringify({ __agent_error: 'Navigation ref not found. Add globalThis.__NAV_REF__ = navigationRef in your app, or ensure NavigationContainer has a ref prop.' });
+    // GH #72: error message updated to reflect the wider discovery surface.
+    // findNavRef() now checks 3 globals + fiber.ref + fiber.stateNode +
+    // fiber.memoizedState hooks chain. If all of those miss, the app is
+    // likely on React Navigation < 6.x (no NavigationContainer fiber name)
+    // or has wrapped the container in something unrecognized.
+    if (!ref) return JSON.stringify({ __agent_error: 'Navigation ref not found. The plugin walks 3 globals (__NAV_REF__, __NAVIGATION_REF__, navigationRef), NavigationContainer fiber.ref + fiber.stateNode, and the useNavigationContainerRef() hooks chain. None matched. If you are on React Navigation 6+, ensure <NavigationContainer> is rendered. As a last resort, expose globalThis.__NAV_REF__ = navigationRef in your app entry.' });
 
     try {
       var state = ref.getRootState();

--- a/scripts/cdp-bridge/test/unit/gh-72-navref-hooks-walk.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-72-navref-hooks-walk.test.js
@@ -1,0 +1,177 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import vm from 'node:vm';
+import { INJECTED_HELPERS } from '../../dist/injected-helpers.js';
+
+// GH #72: findNavRef() must discover React Navigation's internal ref from the
+// useNavigationContainerRef() hook chain when the host app renders
+// <NavigationContainer> without a ref prop. Apps using Expo Router or
+// minimalist setups commonly omit the ref. Without this, cdp_navigate fails
+// with "Navigation ref not found" even though navigation is fully working.
+
+function makeNavRefShape(extra = {}) {
+  // The 3-method match required by the strict guard.
+  return {
+    navigate: () => {},
+    dispatch: () => {},
+    getRootState: () => ({ routes: [{ name: 'Home' }], index: 0, routeNames: ['Home'] }),
+    ...extra,
+  };
+}
+
+function createSandbox(opts = {}) {
+  const sandbox = {
+    globalThis: {},
+    Array, Object, JSON, Map, WeakSet, Error, Date, parseInt, parseFloat,
+    console: { log() {}, error() {}, warn() {}, info() {}, debug() {} },
+    String, Number, Boolean, RegExp, Symbol, Set, Promise, setTimeout, clearTimeout,
+  };
+  sandbox.globalThis = sandbox;
+
+  if (opts.fiberRoot) {
+    sandbox.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+      renderers: new Map([[1, {}]]),
+      getFiberRoots: () => new Set([{ current: opts.fiberRoot }]),
+    };
+  }
+  if (opts.globals) Object.assign(sandbox, opts.globals);
+
+  vm.createContext(sandbox);
+  vm.runInContext(INJECTED_HELPERS, sandbox);
+  return sandbox;
+}
+
+// Helper: invoke __RN_AGENT.navigateTo and parse the JSON response.
+function navigate(sandbox, screen, params) {
+  const result = sandbox.globalThis.__RN_AGENT.navigateTo(screen, params);
+  return JSON.parse(result);
+}
+
+// ── Hooks-chain discovery (GH #72 core fix) ──
+
+test('findNavRef: discovers ref from hooks chain when fiber.ref is absent (GH #72)', () => {
+  const navRef = makeNavRefShape();
+  const fiber = {
+    type: { displayName: 'NavigationContainer' },
+    ref: null,
+    stateNode: null,
+    memoizedState: {
+      // The internal ref from useNavigationContainerRef() lives on the
+      // hooks linked list. RN puts it in a hook with `.memoizedState.current`.
+      memoizedState: { current: navRef },
+      next: null,
+    },
+    child: null,
+    sibling: null,
+  };
+  const sandbox = createSandbox({ fiberRoot: fiber });
+  const result = navigate(sandbox, 'Home');
+  assert.equal(result.navigated, true, 'should successfully navigate via hooks-chain ref');
+  assert.equal(result.__agent_error, undefined, 'no error should surface when ref is found');
+});
+
+test('findNavRef: walks past unrelated hooks to find the nav ref', () => {
+  const navRef = makeNavRefShape();
+  const fiber = {
+    type: { displayName: 'NavigationContainer' },
+    ref: null,
+    stateNode: null,
+    memoizedState: {
+      memoizedState: { value: 0 }, // useState hook
+      next: {
+        memoizedState: { tag: 'effect' }, // useEffect hook
+        next: {
+          memoizedState: { current: navRef }, // the nav ref hook
+          next: null,
+        },
+      },
+    },
+    child: null, sibling: null,
+  };
+  const sandbox = createSandbox({ fiberRoot: fiber });
+  const result = navigate(sandbox, 'Home');
+  assert.equal(result.navigated, true);
+});
+
+test('findNavRef: rejects hook with .current.navigate but missing dispatch (strict match)', () => {
+  // Strict match avoids picking up unrelated refs in apps with multiple
+  // navigation libraries (e.g. react-navigation + react-native-navigation).
+  const partial = { current: { navigate: () => {} } }; // missing dispatch + getRootState
+  const fiber = {
+    type: { displayName: 'NavigationContainer' },
+    ref: null,
+    stateNode: null,
+    memoizedState: { memoizedState: partial, next: null },
+    child: null, sibling: null,
+  };
+  const sandbox = createSandbox({ fiberRoot: fiber });
+  const result = navigate(sandbox, 'Home');
+  assert.equal(result.navigated, undefined);
+  assert.match(result.__agent_error || '', /Navigation ref not found/);
+});
+
+test('findNavRef: existing fiber.ref path still works (no regression)', () => {
+  const navRef = makeNavRefShape();
+  const fiber = {
+    type: { displayName: 'NavigationContainer' },
+    ref: { current: navRef }, // ref-prop path — pre-#72 behavior
+    stateNode: null,
+    memoizedState: null,
+    child: null, sibling: null,
+  };
+  const sandbox = createSandbox({ fiberRoot: fiber });
+  const result = navigate(sandbox, 'Home');
+  assert.equal(result.navigated, true);
+});
+
+test('findNavRef: globals path still wins over fiber walk (no regression)', () => {
+  // __NAV_REF__ takes precedence — fiber walk is the fallback only.
+  const globalRef = makeNavRefShape({
+    getRootState: () => ({ routes: [{ name: 'GLOBAL' }], index: 0, routeNames: ['GLOBAL'] }),
+  });
+  const fiberRef = makeNavRefShape({
+    getRootState: () => ({ routes: [{ name: 'FIBER' }], index: 0, routeNames: ['FIBER'] }),
+  });
+  const fiber = {
+    type: { displayName: 'NavigationContainer' },
+    ref: { current: fiberRef },
+    memoizedState: null,
+    child: null, sibling: null,
+  };
+  let navigatedTo = null;
+  globalRef.navigate = (s) => { navigatedTo = `global:${s}`; };
+  fiberRef.navigate = (s) => { navigatedTo = `fiber:${s}`; };
+  const sandbox = createSandbox({
+    fiberRoot: fiber,
+    globals: { __NAV_REF__: globalRef },
+  });
+  navigate(sandbox, 'GLOBAL');
+  assert.equal(navigatedTo, 'global:GLOBAL', '__NAV_REF__ must beat fiber walk');
+});
+
+test('findNavRef: error message lists all discovery paths (GH #72 step 3)', () => {
+  // No fiber, no globals — error message should be informative.
+  const sandbox = createSandbox({ fiberRoot: null });
+  const result = navigate(sandbox, 'Home');
+  assert.match(result.__agent_error || '', /Navigation ref not found/);
+  assert.match(result.__agent_error || '', /__NAV_REF__/);
+  assert.match(result.__agent_error || '', /useNavigationContainerRef|hooks/i);
+});
+
+test('findNavRef: hopGuard prevents infinite loop on circular hooks chain', () => {
+  // Pathological: a hook whose .next points back to itself. Should not hang.
+  const partial = { current: { unrelated: true } };
+  const hookA = { memoizedState: partial, next: null };
+  hookA.next = hookA; // circular
+  const fiber = {
+    type: { displayName: 'NavigationContainer' },
+    memoizedState: hookA,
+    child: null, sibling: null,
+  };
+  const sandbox = createSandbox({ fiberRoot: fiber });
+  const start = Date.now();
+  const result = navigate(sandbox, 'Home');
+  const elapsed = Date.now() - start;
+  assert.ok(elapsed < 1000, `must terminate quickly, took ${elapsed}ms`);
+  assert.match(result.__agent_error || '', /Navigation ref not found/);
+});

--- a/scripts/cdp-bridge/test/unit/injected-helpers.test.js
+++ b/scripts/cdp-bridge/test/unit/injected-helpers.test.js
@@ -317,6 +317,6 @@ test('M10: getAppInfo returns architecture=unknown when nativeFabricUIManager is
   assert.equal(info.architecture, 'unknown');
 });
 
-test('B145: helpers bundle version is 18 (bumped for forEachRootFiber migration)', () => {
-  assert.match(INJECTED_HELPERS, /__HELPERS_VERSION__\s*=\s*18/);
+test('GH #72: helpers bundle version is 19 (bumped for findNavRef hooks-chain walker)', () => {
+  assert.match(INJECTED_HELPERS, /__HELPERS_VERSION__\s*=\s*19/);
 });


### PR DESCRIPTION
…ationContainer

Closes the navigation-discovery gap reported in #59 sub-items #1 and #6 (now tracked in #72): cdp_navigate fails with "Navigation ref not found" when the host app renders <NavigationContainer> without a ref prop. Common in Expo Router and minimalist setups. The existing fiber walk (B145) only checked fiber.ref.current and fiber.stateNode — both absent for ref-less containers. React Navigation's internal ref from useNavigationContainerRef() lives on the hooks linked list at fiber.memoizedState, which the previous code didn't traverse.

Implementation in scripts/cdp-bridge/src/injected-helpers.ts:

- findNavRef() now walks fiber.memoizedState (hooks linked list) when the existing fiber.ref/stateNode paths miss. Strict 3-method match on { navigate, dispatch, getRootState } avoids picking up unrelated refs in apps with multiple navigation libraries.
- hopGuard (max 100 hops) prevents infinite loops on pathological circular hooks chains. NavigationContainerInner has ~5-15 hooks in practice, so 100 is generous.
- Updated the navigateTo error message to list all discovery surfaces so users understand what was tried before manual __NAV_REF__ exposure is suggested as a last resort.
- Bumped __HELPERS_VERSION__ to 19 (and the corresponding test assertion) so users with stale __RN_AGENT from a prior session pick up the new discovery on next injection — IIFE early-exits when versions match, so the bump is required for the fix to land on long-lived Hermes contexts.

Scope decision: Step 2 from #72's original spec (device_deeplink bypass:"navigation-service" auto-route) was dropped. After this fix, cdp_navigate works for ref-less containers, making it the recommended path on iOS Dev Client (which is what the reporter actually wanted — the "navigation-service" workaround in their issue was just calling cdp_navigate via cdp_evaluate). Wrapping that into device_deeplink would have required reimplementing getStateFromPath in injected JS (non-trivial because Hermes has no require() per #60 #6) for a wrapper that mostly duplicates cdp_navigate's behavior.

7 new tests in test/unit/gh-72-navref-hooks-walk.test.js cover: hooks-chain discovery on ref-less fiber, walking past unrelated hooks, strict-match rejection of partial refs, regression tests for existing fiber.ref and globals paths, error message contents, hopGuard circular-chain protection.

Multi-provider review (Gemini + gpt-5.5 xhigh) caught the missing version bump (the IIFE early-exits at line 4 when stored __v matches, silently skipping the fix on stale contexts). Codex independently verified via BaseNavigationContainer source that the 3-method strict match has zero false-positive risk inside the container's own hooks.