### PR TITLE
fix(gh-59-2): add devicectl fallback for modern iOS device detection

### DIFF
--- a/scripts/check-physical-devices.sh
+++ b/scripts/check-physical-devices.sh
@@ -48,10 +48,17 @@ else
 fi
 
 # --- Physical iOS ---
-# `xcrun xctrace list devices` is the canonical source on macOS.
-# Output has a "== Devices ==" section for physical iOS distinct from
-# "== Simulators ==". Awk extracts just the physical block.
+# Two probes — modern Xcode (15+) ships `devicectl` which lists devices
+# missed by the legacy `xctrace` tool, especially iOS 17+ devices that
+# only appear via CoreDevice. GH #59 #2: a paired iPhone 15 Pro Max
+# was visible to `devicectl list devices` but invisible to xctrace,
+# so the script reported "No physical iOS devices detected" despite
+# `available (paired)` state.
+#
+# Strategy: try xctrace first (compatible across older Xcode), then
+# fall back to devicectl. Either tool finding a device counts.
 PHYSICAL_IOS=""
+PHYSICAL_IOS_SOURCE=""
 if [ "$HOST_OS" != "Darwin" ]; then
   echo "Physical iOS probe skipped (requires macOS; host is $HOST_OS)"
 elif command -v xcrun >/dev/null 2>&1; then
@@ -61,10 +68,28 @@ elif command -v xcrun >/dev/null 2>&1; then
   PHYSICAL_IOS=$(xcrun xctrace list devices 2>/dev/null \
     | awk '/^== Devices ==$/{flag=1; next} /^== /{flag=0} flag && NF>0' \
     | grep -E '(iPhone|iPad|iPod|Apple TV|Apple Vision|Apple Watch)' || true)
+  if [ -n "$PHYSICAL_IOS" ]; then
+    PHYSICAL_IOS_SOURCE="xctrace"
+  fi
+
+  # Augment with devicectl when available (Xcode 15+). Catches iOS 17+
+  # devices that xctrace misses. devicectl prints a header banner + table;
+  # filter rows where the State column contains "available" (skips
+  # "unavailable"/"connecting" states) and the Model column starts with
+  # an iOS form factor (skips the host Mac when present).
+  if [ -z "$PHYSICAL_IOS" ] && xcrun --find devicectl >/dev/null 2>&1; then
+    PHYSICAL_IOS=$(xcrun devicectl list devices 2>/dev/null \
+      | grep -E '(iPhone|iPad|iPod|Apple Vision|Apple Watch|Apple TV)' \
+      | grep 'available' \
+      | grep -v 'unavailable' || true)
+    if [ -n "$PHYSICAL_IOS" ]; then
+      PHYSICAL_IOS_SOURCE="devicectl"
+    fi
+  fi
 fi
 
 if [ -n "${PHYSICAL_IOS:-}" ]; then
-  echo "Physical iOS detected:"
+  echo "Physical iOS detected (via $PHYSICAL_IOS_SOURCE):"
   echo "$PHYSICAL_IOS" | sed 's/^/  /'
   # idb ships the binary as idb_companion on some installs, idb-companion on
   # others. Check both; either satisfies the prerequisite.


### PR DESCRIPTION
Closes #59 sub-item #2: paired iPhone 15 Pro Max with state "available (paired)" was visible to `xcrun devicectl list devices` but `check-physical-devices.sh` reported "No physical iOS devices detected." Reporter blamed `idevice_id`/libimobiledevice in the issue body, but the actual probe is `xcrun xctrace list devices` — which on modern Xcode + iOS 17+ devices misses what `devicectl` (CoreDevice framework) sees.

Implementation in scripts/check-physical-devices.sh:

- After the existing xctrace probe, fall back to `xcrun devicectl list devices` when xctrace returned empty AND devicectl is available (`xcrun --find devicectl`).
- Filter rows: must contain an iOS form factor name (iPhone/iPad/iPod/Apple Vision/Apple Watch/Apple TV), must contain "available", must NOT contain "unavailable" (correctly excludes "unavailable" entries).
- Track PHYSICAL_IOS_SOURCE so the user knows which tool found the device. Output reads "Physical iOS detected (via devicectl)" vs "(via xctrace)".
- Existing xctrace happy path completely preserved — devicectl only runs when xctrace returned empty, so no duplicate listings and no behavior change for users on older Xcode.

Live smoke test confirmed on Xcode 26.4 + iPhone 16 Pro Max:
- Pre-fix: "No physical iOS devices detected"
- Post-fix: "Physical iOS detected (via devicectl): iPhone Lykhoyda 15pro max ... available (paired) ... iPhone16,2"
- An "unavailable" iPad is correctly filtered out.

Multi-provider review (Gemini + gpt-5.5 xhigh) returned 0 high-confidence issues. Both reviewers traced the filter pipeline against real `devicectl` output and verified `set -uo pipefail` interaction with `|| true` is safe (no `set -e` in this script, trailing `|| true` correctly absorbs grep's exit-1-on-no-matches). The "duplicate listings" concern was confirmed not to apply: the devicectl branch is gated on `[ -z "$PHYSICAL_IOS" ]`.