### PR TITLE
fix(gh-59-4): rank device_find AMBIGUOUS_MATCH candidates by tap intent

### DIFF
--- a/scripts/cdp-bridge/dist/tools/device-interact.js
+++ b/scripts/cdp-bridge/dist/tools/device-interact.js
@@ -20,6 +20,68 @@ function candidateFromNode(n) {
         position: n.rect ? { x: n.rect.x, y: n.rect.y } : undefined,
     };
 }
+// GH #59 #4: when device_find returns AMBIGUOUS_MATCH, the agent has to
+// pick a candidate by index. Without ranking, the order is arbitrary —
+// in the reporter's iOS share-sheet case, "Copy" matched 5 candidates
+// (ScrollView, Cell, Other, Other, StaticText) and the actual tap target
+// was the Cell, which sat in position 1 by luck. We rank candidates so
+// the most likely tap target sits at index 0.
+//
+// Ranking signals (highest weight first):
+//   1. hittable: true beats hittable: false (XCUITest's hittable flag
+//      means "directly tappable" — the most reliable tap-intent signal).
+//   2. Element-type priority for tap intent: Button/Cell/Switch >
+//      Other/Link > StaticText/Image > ScrollView. Containers like
+//      ScrollView are usually parents of the real tap target.
+//   3. Dedupe by visual rect — when two elements share the same bounds
+//      (e.g. a Cell wrapping a StaticText), keep only the higher-scored
+//      one. The user wants ONE candidate per unique screen position.
+//
+// Pure helper exported for unit testing.
+const TYPE_PRIORITY_FOR_TAP = {
+    Button: 100,
+    Cell: 95,
+    Switch: 90,
+    Link: 80,
+    Other: 60,
+    StaticText: 30,
+    Image: 25,
+    ScrollView: 10,
+};
+function typePriority(type) {
+    if (!type)
+        return 50;
+    return TYPE_PRIORITY_FOR_TAP[type] ?? 50;
+}
+function rectKey(rect) {
+    if (!rect)
+        return null;
+    return `${Math.round(rect.x)},${Math.round(rect.y)},${Math.round(rect.width)},${Math.round(rect.height)}`;
+}
+export function rankSnapshotNodes(nodes) {
+    const withScore = nodes.map((node, originalIndex) => ({
+        node,
+        originalIndex,
+        score: (node.hittable === true ? 1000 : 0) + typePriority(node.type),
+    }));
+    withScore.sort((a, b) => {
+        if (b.score !== a.score)
+            return b.score - a.score;
+        return a.originalIndex - b.originalIndex;
+    });
+    const seenRects = new Set();
+    const ranked = [];
+    for (const s of withScore) {
+        const key = rectKey(s.node.rect);
+        if (key !== null) {
+            if (seenRects.has(key))
+                continue;
+            seenRects.add(key);
+        }
+        ranked.push(s.node);
+    }
+    return ranked;
+}
 function parseSnapshotEnvelope(result) {
     if (result.isError)
         return null;
@@ -67,16 +129,19 @@ async function fetchFindCandidates(query, exact) {
     if (!snap.ok)
         return snap;
     const needle = query.toLowerCase();
-    const candidates = snap.nodes
-        .filter((n) => {
+    const matched = snap.nodes.filter((n) => {
         const label = n.label ?? '';
         const id = n.identifier ?? '';
         if (exact)
             return label === query || id === query;
         return label.toLowerCase().includes(needle) || id.toLowerCase().includes(needle);
-    })
-        .slice(0, 10)
-        .map(candidateFromNode);
+    });
+    // GH #59 #4: rank before slicing so the truncation never drops the
+    // most-likely tap target. Without this, a query that matches 12
+    // elements (10 ScrollViews + 2 Cells) could lose both Cells to the
+    // 10-element cap.
+    const ranked = rankSnapshotNodes(matched);
+    const candidates = ranked.slice(0, 10).map(candidateFromNode);
     return { ok: true, candidates, recoveredTier: snap.recoveredTier };
 }
 function runnerLeakFailResult(query, recoveryReason) {

--- a/scripts/cdp-bridge/src/tools/device-interact.ts
+++ b/scripts/cdp-bridge/src/tools/device-interact.ts
@@ -43,6 +43,70 @@ function candidateFromNode(n: SnapshotNode): FindCandidate {
   };
 }
 
+// GH #59 #4: when device_find returns AMBIGUOUS_MATCH, the agent has to
+// pick a candidate by index. Without ranking, the order is arbitrary —
+// in the reporter's iOS share-sheet case, "Copy" matched 5 candidates
+// (ScrollView, Cell, Other, Other, StaticText) and the actual tap target
+// was the Cell, which sat in position 1 by luck. We rank candidates so
+// the most likely tap target sits at index 0.
+//
+// Ranking signals (highest weight first):
+//   1. hittable: true beats hittable: false (XCUITest's hittable flag
+//      means "directly tappable" — the most reliable tap-intent signal).
+//   2. Element-type priority for tap intent: Button/Cell/Switch >
+//      Other/Link > StaticText/Image > ScrollView. Containers like
+//      ScrollView are usually parents of the real tap target.
+//   3. Dedupe by visual rect — when two elements share the same bounds
+//      (e.g. a Cell wrapping a StaticText), keep only the higher-scored
+//      one. The user wants ONE candidate per unique screen position.
+//
+// Pure helper exported for unit testing.
+const TYPE_PRIORITY_FOR_TAP: Record<string, number> = {
+  Button: 100,
+  Cell: 95,
+  Switch: 90,
+  Link: 80,
+  Other: 60,
+  StaticText: 30,
+  Image: 25,
+  ScrollView: 10,
+};
+
+function typePriority(type: string | undefined): number {
+  if (!type) return 50;
+  return TYPE_PRIORITY_FOR_TAP[type] ?? 50;
+}
+
+function rectKey(rect: SnapshotNode['rect']): string | null {
+  if (!rect) return null;
+  return `${Math.round(rect.x)},${Math.round(rect.y)},${Math.round(rect.width)},${Math.round(rect.height)}`;
+}
+
+export function rankSnapshotNodes(nodes: SnapshotNode[]): SnapshotNode[] {
+  const withScore = nodes.map((node, originalIndex) => ({
+    node,
+    originalIndex,
+    score: (node.hittable === true ? 1000 : 0) + typePriority(node.type),
+  }));
+
+  withScore.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.originalIndex - b.originalIndex;
+  });
+
+  const seenRects = new Set<string>();
+  const ranked: SnapshotNode[] = [];
+  for (const s of withScore) {
+    const key = rectKey(s.node.rect);
+    if (key !== null) {
+      if (seenRects.has(key)) continue;
+      seenRects.add(key);
+    }
+    ranked.push(s.node);
+  }
+  return ranked;
+}
+
 function parseSnapshotEnvelope(result: ToolResult): SnapshotNode[] | null {
   if (result.isError) return null;
   try {
@@ -107,15 +171,18 @@ async function fetchFindCandidates(query: string, exact: boolean): Promise<FindC
   if (!snap.ok) return snap;
 
   const needle = query.toLowerCase();
-  const candidates = snap.nodes
-    .filter((n) => {
-      const label = n.label ?? '';
-      const id = n.identifier ?? '';
-      if (exact) return label === query || id === query;
-      return label.toLowerCase().includes(needle) || id.toLowerCase().includes(needle);
-    })
-    .slice(0, 10)
-    .map(candidateFromNode);
+  const matched = snap.nodes.filter((n) => {
+    const label = n.label ?? '';
+    const id = n.identifier ?? '';
+    if (exact) return label === query || id === query;
+    return label.toLowerCase().includes(needle) || id.toLowerCase().includes(needle);
+  });
+  // GH #59 #4: rank before slicing so the truncation never drops the
+  // most-likely tap target. Without this, a query that matches 12
+  // elements (10 ScrollViews + 2 Cells) could lose both Cells to the
+  // 10-element cap.
+  const ranked = rankSnapshotNodes(matched);
+  const candidates = ranked.slice(0, 10).map(candidateFromNode);
   return { ok: true, candidates, recoveredTier: snap.recoveredTier };
 }
 

--- a/scripts/cdp-bridge/test/unit/gh-59-4-rank-snapshot-nodes.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-59-4-rank-snapshot-nodes.test.js
@@ -1,0 +1,139 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { rankSnapshotNodes } from '../../dist/tools/device-interact.js';
+
+// GH #59 #4: AMBIGUOUS_MATCH from device_find returned candidates in
+// arbitrary order — agents had to trial-and-error pick the right ref.
+// rankSnapshotNodes orders candidates so the most-likely tap target sits
+// at index 0. Reporter's case: iOS share sheet "Copy" matched 5 elements
+// (ScrollView, Cell, Other, Other, StaticText), all hittable: false; the
+// actual tap target was the Cell. Ranking should surface Cell first.
+
+const node = (overrides = {}) => ({
+  ref: 'r1',
+  type: 'Other',
+  hittable: false,
+  ...overrides,
+});
+
+// ── Hittable beats anything else ──
+
+test('hittable: true wins regardless of type', () => {
+  const ranked = rankSnapshotNodes([
+    node({ ref: 'a', type: 'Cell', hittable: false }),
+    node({ ref: 'b', type: 'StaticText', hittable: true }),
+  ]);
+  assert.equal(ranked[0].ref, 'b', 'hittable StaticText beats non-hittable Cell');
+});
+
+test('multiple hittable: tie-broken by type priority', () => {
+  const ranked = rankSnapshotNodes([
+    node({ ref: 'a', type: 'StaticText', hittable: true }),
+    node({ ref: 'b', type: 'Button', hittable: true }),
+    node({ ref: 'c', type: 'Cell', hittable: true }),
+  ]);
+  assert.deepEqual(
+    ranked.map((n) => n.ref),
+    ['b', 'c', 'a'],
+    'Button > Cell > StaticText when all hittable',
+  );
+});
+
+// ── Type priority when nothing is hittable (the reporter's case) ──
+
+test('reporter scenario: iOS share-sheet Copy candidates, none hittable', () => {
+  // Order in input is the same as agent-device returned them.
+  const ranked = rankSnapshotNodes([
+    node({ ref: '1', type: 'ScrollView', hittable: false }),
+    node({ ref: '2', type: 'Cell', hittable: false }),
+    node({ ref: '3', type: 'Other', hittable: false }),
+    node({ ref: '4', type: 'Other', hittable: false }),
+    node({ ref: '5', type: 'StaticText', hittable: false }),
+  ]);
+  // Cell should come first (highest tap-intent score among non-hittable types).
+  assert.equal(ranked[0].ref, '2', 'Cell ranked first among non-hittable mix');
+  assert.equal(ranked[ranked.length - 1].ref, '1', 'ScrollView (lowest priority) ranked last');
+});
+
+test('Other > StaticText > ScrollView', () => {
+  const ranked = rankSnapshotNodes([
+    node({ ref: 'st', type: 'StaticText' }),
+    node({ ref: 'sv', type: 'ScrollView' }),
+    node({ ref: 'o', type: 'Other' }),
+  ]);
+  assert.deepEqual(ranked.map((n) => n.ref), ['o', 'st', 'sv']);
+});
+
+// ── Stable for equal scores ──
+
+test('equal-score nodes preserve original order (stable sort)', () => {
+  const ranked = rankSnapshotNodes([
+    node({ ref: 'a', type: 'Other' }),
+    node({ ref: 'b', type: 'Other' }),
+    node({ ref: 'c', type: 'Other' }),
+  ]);
+  assert.deepEqual(ranked.map((n) => n.ref), ['a', 'b', 'c']);
+});
+
+// ── Rect dedupe ──
+
+test('dedupes by rect — keeps higher-scored node when bounds match', () => {
+  // Cell wrapping a StaticText with identical bounds.
+  const sharedRect = { x: 100, y: 200, width: 80, height: 40 };
+  const ranked = rankSnapshotNodes([
+    node({ ref: 'inner', type: 'StaticText', rect: sharedRect }),
+    node({ ref: 'outer', type: 'Cell', rect: { ...sharedRect } }),
+  ]);
+  assert.equal(ranked.length, 1, 'duplicate-rect collapses to one entry');
+  assert.equal(ranked[0].ref, 'outer', 'higher-scored Cell survives dedupe');
+});
+
+test('dedupe ignores sub-pixel rect drift via Math.round', () => {
+  const ranked = rankSnapshotNodes([
+    node({ ref: 'a', type: 'StaticText', rect: { x: 100.1, y: 200.0, width: 80.4, height: 40.0 } }),
+    node({ ref: 'b', type: 'Cell', rect: { x: 100.0, y: 199.9, width: 80.2, height: 40.4 } }),
+  ]);
+  assert.equal(ranked.length, 1);
+  assert.equal(ranked[0].ref, 'b');
+});
+
+test('different rects are kept separately', () => {
+  const ranked = rankSnapshotNodes([
+    node({ ref: 'a', type: 'Cell', rect: { x: 0, y: 0, width: 100, height: 50 } }),
+    node({ ref: 'b', type: 'Cell', rect: { x: 0, y: 100, width: 100, height: 50 } }),
+  ]);
+  assert.equal(ranked.length, 2);
+});
+
+test('nodes without rect are not deduped against each other', () => {
+  // Without a rect, we cannot tell if two nodes overlap — keep both.
+  const ranked = rankSnapshotNodes([
+    node({ ref: 'a', type: 'Cell' }),
+    node({ ref: 'b', type: 'Cell' }),
+  ]);
+  assert.equal(ranked.length, 2);
+});
+
+// ── Edge cases ──
+
+test('empty input returns empty array', () => {
+  assert.deepEqual(rankSnapshotNodes([]), []);
+});
+
+test('unknown type falls in mid-tier', () => {
+  const ranked = rankSnapshotNodes([
+    node({ ref: 'sv', type: 'ScrollView' }),
+    node({ ref: 'unknown', type: 'WeirdNewType' }),
+    node({ ref: 'st', type: 'StaticText' }),
+  ]);
+  // Unknown gets default 50, StaticText is 30, ScrollView is 10
+  assert.deepEqual(ranked.map((n) => n.ref), ['unknown', 'st', 'sv']);
+});
+
+test('missing type field falls in mid-tier (same as unknown)', () => {
+  const ranked = rankSnapshotNodes([
+    node({ ref: 'noType', type: undefined }),
+    node({ ref: 'sv', type: 'ScrollView' }),
+  ]);
+  assert.equal(ranked[0].ref, 'noType', 'missing type beats explicitly low-priority types');
+});


### PR DESCRIPTION
Closes #59 sub-item #4. Without ranking, device_find candidates were returned in arbitrary snapshot order — agents had to trial-and-error pick the right ref. Reporter's iOS share-sheet case: query "Copy" matched 5 elements (ScrollView, Cell, Other, Other, StaticText), all hittable: false; the actual tap target was the Cell, but it was at arbitrary index in the candidates array.

Implementation in scripts/cdp-bridge/src/tools/device-interact.ts:

- New pure helper rankSnapshotNodes(nodes) reorders by tap-intent priority: score = (hittable ? 1000 : 0) + typePriority(type).
- TYPE_PRIORITY_FOR_TAP table: Button=100, Cell=95, Switch=90, Link=80, Other=60, StaticText=30, Image=25, ScrollView=10. Unknown / missing type = 50 (mid-tier — keeps Android types from collapsing into the lowest-priority bucket where they'd lose to ScrollView).
- After scoring + sort, dedupe by visual rect: round x/y/width/ height to whole pixels and skip duplicates. Keeps higher-scored node when bounds match (e.g. Cell wrapping StaticText with identical rect). Nodes without rect are NOT deduped (cannot determine overlap).
- Stable across equal scores (preserves original snapshot order for tie-breaking — Node 12+ Array.sort is stable).
- Applied in fetchFindCandidates BEFORE the slice(0, 10) cap so a busy snapshot can't drop high-priority candidates via truncation.

12 new tests cover: hittable beats type, type priority among non-hittable (the reporter's exact scenario), stable sort, rect dedupe with sub-pixel rounding tolerance, different-rect preservation, no-rect passthrough, empty input, unknown / missing types.

Multi-provider review (Gemini + gpt-5.5 xhigh) returned 0 high-confidence issues. Both reviewers verified:
- Type priority ordering matches XCUITest tap-intent conventions
- Math.round dedupe is appropriate for logical-pixel layouts
- slice(0, 10) after dedupe is intentional (rank-before-slice)
- Android types fall through to mid-tier default — no behavior regression on Android, just no improvement
- exact=true auto-tap behavior change (rect-collinear duplicates now collapse to a single auto-tap candidate) matches the reporter's preferred semantics

Sub-threshold improvements deferred: text input types (TextField, SecureTextField, EditText, TextView) currently fall to mid-tier 50; could be promoted to ~85 for higher tap-intent. Worth a follow-up if observed mis-ranking in practice.