### PR TITLE
feat(gh-59-7): add cdp_mmkv tool for direct MMKV storage access from …

### DIFF
--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -23,6 +23,7 @@ import { createExceptionBreakpointHandler } from './tools/exception-breakpoint.j
 import { createConsoleLogHandler } from './tools/console-log.js';
 import { createStoreStateHandler } from './tools/store-state.js';
 import { createDispatchHandler } from './tools/dispatch.js';
+import { createMmkvHandler } from './tools/mmkv.js';
 import { createDevSettingsHandler } from './tools/dev-settings.js';
 import { createInteractHandler } from './tools/interact.js';
 import { createCollectLogsHandler } from './tools/collect-logs.js';
@@ -282,6 +283,13 @@ trackedTool('cdp_dispatch', 'Dispatch a Redux action and optionally read state a
     payloadJson: z.string().optional().describe('Stringified JSON payload with guaranteed type preservation. Takes precedence over `payload` when provided. Example: payloadJson=\'"42"\' dispatches the STRING "42"; payloadJson=\'42\' dispatches the NUMBER 42; payloadJson=\'{"id":"42","qty":5}\' dispatches an object.'),
     readPath: z.string().optional().describe('Dot-path to read from store after dispatch (e.g. "tasks.pendingDelete")'),
 }, createDispatchHandler(getClient));
+trackedTool('cdp_mmkv', 'Read/write the app\'s MMKV storage from Hermes. Closes the iteration-loop gap where tests had to xcrun simctl uninstall + reinstall to clear cooldowns/timestamps/feature flags. Requires react-native-mmkv v3+ (Nitro-based) — older versions exposed via TurboModule are not reachable. Returns __agent_error if MMKV / NitroModulesProxy is unavailable in the runtime. Actions: get|set|delete|has|keys|clear. Use sparingly: writing to MMKV bypasses the real user flow, so only use during test setup/teardown, not as a substitute for UI interaction (see "Verification Fidelity" rule).', {
+    action: z.enum(['get', 'set', 'delete', 'has', 'keys', 'clear']).describe('MMKV action: get/set/delete/has by key, keys (list all), clear (wipe instance)'),
+    key: z.string().optional().describe('Required for get/set/delete/has actions'),
+    value: z.union([z.string(), z.number(), z.boolean()]).optional().describe('Required for set action. Combine with `type` to disambiguate (default: string)'),
+    type: z.enum(['string', 'number', 'boolean']).optional().describe('Value type for get/set (default: string)'),
+    instanceId: z.string().optional().describe('MMKV instance id (default: "mmkv.default")'),
+}, createMmkvHandler(getClient));
 trackedTool('cdp_dev_settings', 'Control React Native dev settings programmatically (no visual dev menu needed). dismissRedBox clears LogBox overlays and RedBox errors via a 4-tier fallback chain. disableDevMenu suppresses shake-to-show dev menu (use before proof recordings). For reload with auto-reconnect, use cdp_reload instead.', {
     action: z.enum(['reload', 'toggleInspector', 'togglePerfMonitor', 'dismissRedBox', 'disableDevMenu'])
         .describe('Dev menu action to execute'),

--- a/scripts/cdp-bridge/dist/tools/mmkv.js
+++ b/scripts/cdp-bridge/dist/tools/mmkv.js
@@ -1,0 +1,124 @@
+import { okResult, failResult, withConnection } from '../utils.js';
+/**
+ * Pure builder — returns a JS expression that, when evaluated in Hermes,
+ * performs the MMKV action and returns a JSON-stringified result.
+ *
+ * Extracted from the handler so tests can verify the expression shape
+ * without spinning up Hermes. Format follows the existing pattern in
+ * other CDP tools: an IIFE that catches all error paths and emits a
+ * `__agent_error` sentinel for the handler to surface as failResult.
+ *
+ * The JS template is plain ES5 — Hermes supports more, but ES5 keeps
+ * this readable and matches the style of injected-helpers.ts.
+ */
+export function buildMmkvExpression(args) {
+    const instanceId = args.instanceId ?? 'mmkv.default';
+    const valueType = args.type ?? 'string';
+    let actionBody;
+    switch (args.action) {
+        case 'get': {
+            if (typeof args.key !== 'string' || args.key.length === 0) {
+                return `JSON.stringify({ __agent_error: 'get requires non-empty key' })`;
+            }
+            const getMethod = valueType === 'number' ? 'getNumber' :
+                valueType === 'boolean' ? 'getBool' : 'getString';
+            actionBody = `var v = mmkv.${getMethod}(${JSON.stringify(args.key)}); return JSON.stringify({ value: v === undefined ? null : v });`;
+            break;
+        }
+        case 'set': {
+            if (typeof args.key !== 'string' || args.key.length === 0) {
+                return `JSON.stringify({ __agent_error: 'set requires non-empty key' })`;
+            }
+            if (args.value === undefined || args.value === null) {
+                return `JSON.stringify({ __agent_error: 'set requires value' })`;
+            }
+            // MMKV's `set` is overloaded by JS-side type inference; pass the
+            // raw literal cast to the requested type.
+            let valueLiteral;
+            if (valueType === 'number') {
+                valueLiteral = String(Number(args.value));
+            }
+            else if (valueType === 'boolean') {
+                valueLiteral = args.value === true || args.value === 'true' ? 'true' : 'false';
+            }
+            else {
+                valueLiteral = JSON.stringify(String(args.value));
+            }
+            actionBody = `mmkv.set(${JSON.stringify(args.key)}, ${valueLiteral}); return JSON.stringify({ ok: true });`;
+            break;
+        }
+        case 'delete': {
+            if (typeof args.key !== 'string' || args.key.length === 0) {
+                return `JSON.stringify({ __agent_error: 'delete requires non-empty key' })`;
+            }
+            actionBody = `mmkv.delete(${JSON.stringify(args.key)}); return JSON.stringify({ ok: true });`;
+            break;
+        }
+        case 'has': {
+            if (typeof args.key !== 'string' || args.key.length === 0) {
+                return `JSON.stringify({ __agent_error: 'has requires non-empty key' })`;
+            }
+            actionBody = `var present = mmkv.contains(${JSON.stringify(args.key)}); return JSON.stringify({ present: !!present });`;
+            break;
+        }
+        case 'keys': {
+            actionBody = `var ks = mmkv.getAllKeys(); return JSON.stringify({ keys: ks || [] });`;
+            break;
+        }
+        case 'clear': {
+            actionBody = `mmkv.clearAll(); return JSON.stringify({ cleared: true });`;
+            break;
+        }
+        default: {
+            // Use JSON.stringify to safely embed user-supplied action — even though
+            // zod gates this at the tool boundary, the helper is exported and could
+            // be invoked from internal callers that bypass schema validation.
+            return `JSON.stringify({ __agent_error: 'unknown action: ' + ${JSON.stringify(String(args.action))} })`;
+        }
+    }
+    return `(function() {
+    try {
+      var nitro = globalThis.NitroModulesProxy;
+      if (typeof nitro !== 'object' || !nitro || typeof nitro.createHybridObject !== 'function') {
+        return JSON.stringify({ __agent_error: 'NitroModulesProxy not available — requires react-native-mmkv v3+ (Nitro-based). For older MMKV versions, expose globalThis.__MMKV__ in your app entry.' });
+      }
+      var factory = nitro.createHybridObject('MMKVFactory');
+      if (!factory || typeof factory.createMMKV !== 'function') {
+        return JSON.stringify({ __agent_error: 'MMKVFactory not registered — is react-native-mmkv installed?' });
+      }
+      var mmkv = factory.createMMKV({ id: ${JSON.stringify(instanceId)} });
+      if (!mmkv) {
+        return JSON.stringify({ __agent_error: 'createMMKV returned no instance for id=' + ${JSON.stringify(instanceId)} });
+      }
+      ${actionBody}
+    } catch (e) {
+      return JSON.stringify({ __agent_error: 'MMKV op threw: ' + (e && e.message ? e.message : String(e)) });
+    }
+  })()`;
+}
+export function createMmkvHandler(getClient) {
+    return withConnection(getClient, async (args, client) => {
+        const expr = buildMmkvExpression(args);
+        const result = await client.evaluate(expr);
+        if (result.error) {
+            return failResult(`MMKV evaluate error: ${result.error}`);
+        }
+        if (typeof result.value !== 'string') {
+            return failResult('Unexpected response from MMKV expression (not a string)');
+        }
+        let parsed;
+        try {
+            parsed = JSON.parse(result.value);
+        }
+        catch {
+            return failResult(`Could not parse MMKV response: ${result.value.slice(0, 200)}`);
+        }
+        if (parsed !== null && typeof parsed === 'object') {
+            const obj = parsed;
+            if ('__agent_error' in obj) {
+                return failResult(String(obj.__agent_error));
+            }
+        }
+        return okResult(parsed);
+    });
+}

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -23,6 +23,7 @@ import { createExceptionBreakpointHandler } from './tools/exception-breakpoint.j
 import { createConsoleLogHandler } from './tools/console-log.js';
 import { createStoreStateHandler } from './tools/store-state.js';
 import { createDispatchHandler } from './tools/dispatch.js';
+import { createMmkvHandler } from './tools/mmkv.js';
 import { createDevSettingsHandler } from './tools/dev-settings.js';
 import { createInteractHandler } from './tools/interact.js';
 import { createCollectLogsHandler } from './tools/collect-logs.js';
@@ -430,6 +431,19 @@ trackedTool(
     readPath: z.string().optional().describe('Dot-path to read from store after dispatch (e.g. "tasks.pendingDelete")'),
   },
   createDispatchHandler(getClient),
+);
+
+trackedTool(
+  'cdp_mmkv',
+  'Read/write the app\'s MMKV storage from Hermes. Closes the iteration-loop gap where tests had to xcrun simctl uninstall + reinstall to clear cooldowns/timestamps/feature flags. Requires react-native-mmkv v3+ (Nitro-based) — older versions exposed via TurboModule are not reachable. Returns __agent_error if MMKV / NitroModulesProxy is unavailable in the runtime. Actions: get|set|delete|has|keys|clear. Use sparingly: writing to MMKV bypasses the real user flow, so only use during test setup/teardown, not as a substitute for UI interaction (see "Verification Fidelity" rule).',
+  {
+    action: z.enum(['get', 'set', 'delete', 'has', 'keys', 'clear']).describe('MMKV action: get/set/delete/has by key, keys (list all), clear (wipe instance)'),
+    key: z.string().optional().describe('Required for get/set/delete/has actions'),
+    value: z.union([z.string(), z.number(), z.boolean()]).optional().describe('Required for set action. Combine with `type` to disambiguate (default: string)'),
+    type: z.enum(['string', 'number', 'boolean']).optional().describe('Value type for get/set (default: string)'),
+    instanceId: z.string().optional().describe('MMKV instance id (default: "mmkv.default")'),
+  },
+  createMmkvHandler(getClient),
 );
 
 trackedTool(

--- a/scripts/cdp-bridge/src/tools/mmkv.ts
+++ b/scripts/cdp-bridge/src/tools/mmkv.ts
@@ -1,0 +1,153 @@
+import type { CDPClient } from '../cdp-client.js';
+import { okResult, failResult, withConnection } from '../utils.js';
+
+// GH #59 #7 + #60 feature-b: cdp_mmkv tool. Reads/writes the app's MMKV
+// storage from Hermes via NitroModulesProxy, without requiring app-side
+// cooperation. Closes the iteration-loop gap where tests had to
+// xcrun simctl uninstall + reinstall + re-login just to clear one key
+// (cooldowns, prompt timestamps, etc.).
+//
+// Requires react-native-mmkv v3+ (Nitro-based). Earlier MMKV versions
+// used TurboModule which is not exposed via NitroModulesProxy. The
+// expression returns a clear error envelope when Nitro / MMKVFactory
+// isn't available, so callers know the runtime requirement.
+
+export type MmkvAction = 'get' | 'set' | 'delete' | 'keys' | 'has' | 'clear';
+export type MmkvValueType = 'string' | 'number' | 'boolean';
+
+export interface MmkvArgs {
+  action: MmkvAction;
+  key?: string;
+  value?: string | number | boolean;
+  type?: MmkvValueType;
+  instanceId?: string;
+}
+
+/**
+ * Pure builder — returns a JS expression that, when evaluated in Hermes,
+ * performs the MMKV action and returns a JSON-stringified result.
+ *
+ * Extracted from the handler so tests can verify the expression shape
+ * without spinning up Hermes. Format follows the existing pattern in
+ * other CDP tools: an IIFE that catches all error paths and emits a
+ * `__agent_error` sentinel for the handler to surface as failResult.
+ *
+ * The JS template is plain ES5 — Hermes supports more, but ES5 keeps
+ * this readable and matches the style of injected-helpers.ts.
+ */
+export function buildMmkvExpression(args: MmkvArgs): string {
+  const instanceId = args.instanceId ?? 'mmkv.default';
+  const valueType: MmkvValueType = args.type ?? 'string';
+
+  let actionBody: string;
+  switch (args.action) {
+    case 'get': {
+      if (typeof args.key !== 'string' || args.key.length === 0) {
+        return `JSON.stringify({ __agent_error: 'get requires non-empty key' })`;
+      }
+      const getMethod =
+        valueType === 'number' ? 'getNumber' :
+        valueType === 'boolean' ? 'getBool' : 'getString';
+      actionBody = `var v = mmkv.${getMethod}(${JSON.stringify(args.key)}); return JSON.stringify({ value: v === undefined ? null : v });`;
+      break;
+    }
+    case 'set': {
+      if (typeof args.key !== 'string' || args.key.length === 0) {
+        return `JSON.stringify({ __agent_error: 'set requires non-empty key' })`;
+      }
+      if (args.value === undefined || args.value === null) {
+        return `JSON.stringify({ __agent_error: 'set requires value' })`;
+      }
+      // MMKV's `set` is overloaded by JS-side type inference; pass the
+      // raw literal cast to the requested type.
+      let valueLiteral: string;
+      if (valueType === 'number') {
+        valueLiteral = String(Number(args.value));
+      } else if (valueType === 'boolean') {
+        valueLiteral = args.value === true || args.value === 'true' ? 'true' : 'false';
+      } else {
+        valueLiteral = JSON.stringify(String(args.value));
+      }
+      actionBody = `mmkv.set(${JSON.stringify(args.key)}, ${valueLiteral}); return JSON.stringify({ ok: true });`;
+      break;
+    }
+    case 'delete': {
+      if (typeof args.key !== 'string' || args.key.length === 0) {
+        return `JSON.stringify({ __agent_error: 'delete requires non-empty key' })`;
+      }
+      actionBody = `mmkv.delete(${JSON.stringify(args.key)}); return JSON.stringify({ ok: true });`;
+      break;
+    }
+    case 'has': {
+      if (typeof args.key !== 'string' || args.key.length === 0) {
+        return `JSON.stringify({ __agent_error: 'has requires non-empty key' })`;
+      }
+      actionBody = `var present = mmkv.contains(${JSON.stringify(args.key)}); return JSON.stringify({ present: !!present });`;
+      break;
+    }
+    case 'keys': {
+      actionBody = `var ks = mmkv.getAllKeys(); return JSON.stringify({ keys: ks || [] });`;
+      break;
+    }
+    case 'clear': {
+      actionBody = `mmkv.clearAll(); return JSON.stringify({ cleared: true });`;
+      break;
+    }
+    default: {
+      // Use JSON.stringify to safely embed user-supplied action — even though
+      // zod gates this at the tool boundary, the helper is exported and could
+      // be invoked from internal callers that bypass schema validation.
+      return `JSON.stringify({ __agent_error: 'unknown action: ' + ${JSON.stringify(String(args.action))} })`;
+    }
+  }
+
+  return `(function() {
+    try {
+      var nitro = globalThis.NitroModulesProxy;
+      if (typeof nitro !== 'object' || !nitro || typeof nitro.createHybridObject !== 'function') {
+        return JSON.stringify({ __agent_error: 'NitroModulesProxy not available — requires react-native-mmkv v3+ (Nitro-based). For older MMKV versions, expose globalThis.__MMKV__ in your app entry.' });
+      }
+      var factory = nitro.createHybridObject('MMKVFactory');
+      if (!factory || typeof factory.createMMKV !== 'function') {
+        return JSON.stringify({ __agent_error: 'MMKVFactory not registered — is react-native-mmkv installed?' });
+      }
+      var mmkv = factory.createMMKV({ id: ${JSON.stringify(instanceId)} });
+      if (!mmkv) {
+        return JSON.stringify({ __agent_error: 'createMMKV returned no instance for id=' + ${JSON.stringify(instanceId)} });
+      }
+      ${actionBody}
+    } catch (e) {
+      return JSON.stringify({ __agent_error: 'MMKV op threw: ' + (e && e.message ? e.message : String(e)) });
+    }
+  })()`;
+}
+
+export function createMmkvHandler(getClient: () => CDPClient) {
+  return withConnection(getClient, async (args: MmkvArgs, client) => {
+    const expr = buildMmkvExpression(args);
+    const result = await client.evaluate(expr);
+
+    if (result.error) {
+      return failResult(`MMKV evaluate error: ${result.error}`);
+    }
+    if (typeof result.value !== 'string') {
+      return failResult('Unexpected response from MMKV expression (not a string)');
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(result.value);
+    } catch {
+      return failResult(`Could not parse MMKV response: ${result.value.slice(0, 200)}`);
+    }
+
+    if (parsed !== null && typeof parsed === 'object') {
+      const obj = parsed as Record<string, unknown>;
+      if ('__agent_error' in obj) {
+        return failResult(String(obj.__agent_error));
+      }
+    }
+
+    return okResult(parsed);
+  });
+}

--- a/scripts/cdp-bridge/test/unit/gh-59-7-cdp-mmkv.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-59-7-cdp-mmkv.test.js
@@ -1,0 +1,247 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import vm from 'node:vm';
+import { buildMmkvExpression, createMmkvHandler } from '../../dist/tools/mmkv.js';
+import { createMockClient } from '../helpers/mock-cdp-client.js';
+import { expectOk, expectFail } from '../helpers/result-helpers.js';
+
+// GH #59 #7 / #60 feature-b: cdp_mmkv tool reads/writes MMKV via
+// NitroModulesProxy from Hermes. Tests:
+//   1. buildMmkvExpression returns valid JS for each action shape
+//   2. The expression run in a VM with a mock NitroModulesProxy
+//      produces correct results
+//   3. The expression returns __agent_error when Nitro / MMKVFactory
+//      / instance is missing
+//   4. Argument validation surfaces clear errors
+
+// ── 1. Pure expression-builder tests ──
+
+test('buildMmkvExpression: get action produces an executable expression', () => {
+  const expr = buildMmkvExpression({ action: 'get', key: 'foo' });
+  assert.match(expr, /createHybridObject\('MMKVFactory'\)/);
+  assert.match(expr, /createMMKV\(\{ id: "mmkv\.default" \}\)/);
+  assert.match(expr, /getString\("foo"\)/);
+});
+
+test('buildMmkvExpression: get with type=number uses getNumber', () => {
+  const expr = buildMmkvExpression({ action: 'get', key: 'count', type: 'number' });
+  assert.match(expr, /getNumber\("count"\)/);
+});
+
+test('buildMmkvExpression: get with type=boolean uses getBool', () => {
+  const expr = buildMmkvExpression({ action: 'get', key: 'flag', type: 'boolean' });
+  assert.match(expr, /getBool\("flag"\)/);
+});
+
+test('buildMmkvExpression: get without key returns __agent_error literal', () => {
+  const expr = buildMmkvExpression({ action: 'get' });
+  assert.match(expr, /__agent_error.*requires non-empty key/);
+});
+
+test('buildMmkvExpression: set action with string value', () => {
+  const expr = buildMmkvExpression({ action: 'set', key: 'name', value: 'alice' });
+  assert.match(expr, /\.set\("name", "alice"\)/);
+});
+
+test('buildMmkvExpression: set with type=number coerces value', () => {
+  const expr = buildMmkvExpression({ action: 'set', key: 'count', value: '42', type: 'number' });
+  assert.match(expr, /\.set\("count", 42\)/);
+});
+
+test('buildMmkvExpression: set with type=boolean accepts true and "true"', () => {
+  const exprTrue = buildMmkvExpression({ action: 'set', key: 'flag', value: true, type: 'boolean' });
+  assert.match(exprTrue, /\.set\("flag", true\)/);
+  const exprStrTrue = buildMmkvExpression({ action: 'set', key: 'flag', value: 'true', type: 'boolean' });
+  assert.match(exprStrTrue, /\.set\("flag", true\)/);
+  const exprFalse = buildMmkvExpression({ action: 'set', key: 'flag', value: false, type: 'boolean' });
+  assert.match(exprFalse, /\.set\("flag", false\)/);
+});
+
+test('buildMmkvExpression: set without value returns __agent_error', () => {
+  const expr = buildMmkvExpression({ action: 'set', key: 'foo' });
+  assert.match(expr, /__agent_error.*set requires value/);
+});
+
+test('buildMmkvExpression: delete includes the key literal', () => {
+  const expr = buildMmkvExpression({ action: 'delete', key: 'foo' });
+  assert.match(expr, /\.delete\("foo"\)/);
+});
+
+test('buildMmkvExpression: has uses contains()', () => {
+  const expr = buildMmkvExpression({ action: 'has', key: 'foo' });
+  assert.match(expr, /\.contains\("foo"\)/);
+});
+
+test('buildMmkvExpression: keys uses getAllKeys()', () => {
+  const expr = buildMmkvExpression({ action: 'keys' });
+  assert.match(expr, /\.getAllKeys\(\)/);
+});
+
+test('buildMmkvExpression: clear uses clearAll()', () => {
+  const expr = buildMmkvExpression({ action: 'clear' });
+  assert.match(expr, /\.clearAll\(\)/);
+});
+
+test('buildMmkvExpression: instanceId is forwarded into createMMKV', () => {
+  const expr = buildMmkvExpression({ action: 'keys', instanceId: 'cart-store' });
+  assert.match(expr, /createMMKV\(\{ id: "cart-store" \}\)/);
+});
+
+test('buildMmkvExpression: special chars in key are JSON-escaped', () => {
+  // A key containing a quote must not break out of the JS string literal.
+  const expr = buildMmkvExpression({ action: 'get', key: 'a"b' });
+  // JSON.stringify('a"b') → "a\"b"
+  assert.match(expr, /getString\("a\\"b"\)/);
+});
+
+test('buildMmkvExpression: malicious instanceId expression executes safely (no JS injection)', () => {
+  // Stronger regression guard: actually parse and run the generated
+  // expression. If injection persists, the throw runs and we never
+  // reach the createMMKV-failure return.
+  const evil = 'x"; throw new Error("INJECTED"); //';
+  const expr = buildMmkvExpression({ action: 'keys', instanceId: evil });
+  const sandbox = {
+    globalThis: {},
+    Array, Object, JSON, String, Number, Boolean, Error,
+  };
+  sandbox.globalThis = sandbox;
+  // Force the createMMKV-failure branch by returning null from createMMKV.
+  sandbox.NitroModulesProxy = {
+    createHybridObject: () => ({ createMMKV: () => null }),
+  };
+  vm.createContext(sandbox);
+  // If the injection were active, the IIFE's outer try/catch would
+  // catch the thrown Error and surface it as MMKV op threw with the
+  // INJECTED message — confirming code executed. With proper escaping,
+  // the IIFE returns the createMMKV-failure envelope and the literal
+  // payload appears as data inside __agent_error, not as executed code.
+  const raw = vm.runInContext(expr, sandbox);
+  const result = JSON.parse(raw);
+  assert.match(result.__agent_error, /createMMKV returned no instance/, 'must reach the failure-branch return');
+  assert.doesNotMatch(result.__agent_error, /MMKV op threw/, 'injection would surface as a thrown error envelope');
+});
+
+// ── 2. End-to-end: run the expression in a VM with a mock NitroModulesProxy ──
+
+function runExpr(expr, mmkvImpl) {
+  const sandbox = {
+    globalThis: {},
+    Array, Object, JSON,
+    String, Number, Boolean,
+  };
+  sandbox.globalThis = sandbox;
+  if (mmkvImpl !== null) {
+    sandbox.NitroModulesProxy = {
+      createHybridObject: (name) => {
+        if (name === 'MMKVFactory') {
+          return {
+            createMMKV: (opts) => mmkvImpl(opts.id),
+          };
+        }
+        return null;
+      },
+    };
+  }
+  vm.createContext(sandbox);
+  const raw = vm.runInContext(expr, sandbox);
+  return JSON.parse(raw);
+}
+
+test('expression runs against a mock instance: get returns stored value', () => {
+  const instance = { getString: (k) => k === 'foo' ? 'bar' : undefined };
+  const result = runExpr(
+    buildMmkvExpression({ action: 'get', key: 'foo' }),
+    () => instance,
+  );
+  assert.deepEqual(result, { value: 'bar' });
+});
+
+test('expression runs against a mock: get returns null when key missing', () => {
+  const instance = { getString: () => undefined };
+  const result = runExpr(buildMmkvExpression({ action: 'get', key: 'absent' }), () => instance);
+  assert.deepEqual(result, { value: null });
+});
+
+test('expression runs against a mock: set + delete are wired', () => {
+  const store = new Map();
+  const instance = {
+    set: (k, v) => store.set(k, v),
+    delete: (k) => store.delete(k),
+  };
+  runExpr(buildMmkvExpression({ action: 'set', key: 'cooldown', value: '12345' }), () => instance);
+  assert.equal(store.get('cooldown'), '12345');
+  runExpr(buildMmkvExpression({ action: 'delete', key: 'cooldown' }), () => instance);
+  assert.equal(store.has('cooldown'), false);
+});
+
+test('expression runs against a mock: keys returns array', () => {
+  const instance = { getAllKeys: () => ['a', 'b', 'c'] };
+  const result = runExpr(buildMmkvExpression({ action: 'keys' }), () => instance);
+  assert.deepEqual(result, { keys: ['a', 'b', 'c'] });
+});
+
+test('expression runs against a mock: has returns boolean', () => {
+  const instance = { contains: (k) => k === 'present' };
+  const yes = runExpr(buildMmkvExpression({ action: 'has', key: 'present' }), () => instance);
+  assert.deepEqual(yes, { present: true });
+  const no = runExpr(buildMmkvExpression({ action: 'has', key: 'absent' }), () => instance);
+  assert.deepEqual(no, { present: false });
+});
+
+// ── 3. Failure envelopes ──
+
+test('expression returns __agent_error when NitroModulesProxy is missing', () => {
+  const result = runExpr(buildMmkvExpression({ action: 'keys' }), null);
+  assert.ok(result.__agent_error, 'should surface __agent_error sentinel');
+  assert.match(result.__agent_error, /NitroModulesProxy not available/);
+});
+
+test('expression returns __agent_error when MMKVFactory is not registered', () => {
+  const sandbox = {
+    globalThis: {},
+    Array, Object, JSON, String, Number, Boolean,
+  };
+  sandbox.globalThis = sandbox;
+  sandbox.NitroModulesProxy = {
+    createHybridObject: () => null,
+  };
+  vm.createContext(sandbox);
+  const raw = vm.runInContext(buildMmkvExpression({ action: 'keys' }), sandbox);
+  const result = JSON.parse(raw);
+  assert.match(result.__agent_error, /MMKVFactory not registered/);
+});
+
+test('expression returns __agent_error when MMKV op throws', () => {
+  const instance = { getString: () => { throw new Error('disk error'); } };
+  const result = runExpr(buildMmkvExpression({ action: 'get', key: 'foo' }), () => instance);
+  assert.match(result.__agent_error, /MMKV op threw.*disk error/);
+});
+
+// ── 4. Handler integration: parsed envelope → ToolResult ──
+
+test('createMmkvHandler: returns failResult on __agent_error sentinel', async () => {
+  const client = createMockClient({
+    evaluate: async () => ({ value: JSON.stringify({ __agent_error: 'NitroModulesProxy not available' }) }),
+  });
+  const handler = createMmkvHandler(() => client);
+  const error = expectFail(await handler({ action: 'keys' }));
+  assert.match(error, /NitroModulesProxy not available/);
+});
+
+test('createMmkvHandler: parses successful response', async () => {
+  const client = createMockClient({
+    evaluate: async () => ({ value: JSON.stringify({ value: 'hello' }) }),
+  });
+  const handler = createMmkvHandler(() => client);
+  const data = expectOk(await handler({ action: 'get', key: 'greeting' }));
+  assert.deepEqual(data, { value: 'hello' });
+});
+
+test('createMmkvHandler: surfaces evaluate-level error', async () => {
+  const client = createMockClient({
+    evaluate: async () => ({ error: 'WebSocket closed' }),
+  });
+  const handler = createMmkvHandler(() => client);
+  const error = expectFail(await handler({ action: 'keys' }));
+  assert.match(error, /MMKV evaluate error.*WebSocket closed/);
+});


### PR DESCRIPTION
…Hermes

Closes #59 sub-item #7 and #60 feature-b. Without this, tests that needed to clear cooldown timestamps, prompt-shown flags, or feature- flag overrides had to xcrun simctl uninstall + reinstall + re-login — a full restart cycle per iteration.

The `cdp_mmkv` MCP tool wraps `globalThis.NitroModulesProxy .createHybridObject('MMKVFactory').createMMKV({ id })` from Hermes, exposing get/set/delete/has/keys/clear actions over a single MCP call. Returns clear `__agent_error` envelopes when NitroModulesProxy or MMKVFactory aren't reachable (e.g. older MMKV versions, or apps without react-native-mmkv installed).

Architecture in scripts/cdp-bridge/src/tools/mmkv.ts:

- `buildMmkvExpression(args)` — pure function returning a JS expression. Extracted for testability — same pattern as stickyPlatformFilters (#59 #5), probeNetworkDomain (#59 #9), rankSnapshotNodes (#59 #4). All user inputs (key, value, instanceId) are interpolated via JSON.stringify so embedded quotes/backslashes can't break out of JS string literals.
- `createMmkvHandler(getClient)` — wraps the expression in withConnection, calls client.evaluate, parses the JSON result, surfaces __agent_error as failResult.

Tool registration in src/index.ts includes a deliberate guardrail in the description: "Use sparingly: writing to MMKV bypasses the real user flow, so only use during test setup/teardown, not as a substitute for UI interaction (see Verification Fidelity rule)." This references the verification-fidelity rules shipped in #61 that explicitly call out MMKV writes as one of the 5 shortcut categories that invalidate verification.

26 new tests in test/unit/gh-59-7-cdp-mmkv.test.js cover:
  - Pure expression-builder tests for each action shape
  - VM sandbox runs the expression with a mock NitroModulesProxy to verify get/set/delete/has/keys behavior
  - Failure envelopes (Nitro missing, factory missing, op throws)
  - Handler integration via createMockClient/expectOk/expectFail
  - Injection-safety regression test: malicious instanceId containing a double quote + throw payload is run through VM, asserting the expression returns the createMMKV-failure envelope (proving the throw never executed).

Multi-provider review (Gemini + gpt-5.5 xhigh) caught a real critical bug: lines 113 and 97 originally interpolated user input unescaped via TS template literals, while every other line used JSON.stringify. Both reviewers independently flagged at confidence 85-95. Fix applied to both lines + injection-safety test added to lock the fix in.