### PR TITLE
fix(gh-60-3): add cdp_reload force-reconnect fallback after soft-loop…

### DIFF
--- a/scripts/cdp-bridge/dist/cdp-client.js
+++ b/scripts/cdp-bridge/dist/cdp-client.js
@@ -84,6 +84,8 @@ export class CDPClient {
     get helpersInjected() { return this._helpersInjected; }
     get metroPort() { return this._port; }
     get connectedTarget() { return this._connectedTarget; }
+    /** B132: whether DevTools attachment was requested. Survives soft reconnect (auto-resumes via afterReconnect). Lost on `disconnect()` — caller must re-run cdp_open_devtools after a force-recreate. */
+    get proxyDesired() { return this._proxyDesired; }
     /** M11: timestamp of the current CDP connection (ms since epoch); null when disconnected. */
     get connectedAt() { return this._connectedAt; }
     /** M11: clock source for this client (injectable; defaults to Date.now). */

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -102,9 +102,9 @@ trackedTool('cdp_evaluate', 'CAUTION: Executes arbitrary JavaScript directly in 
     expression: z.string().describe('JavaScript expression to evaluate'),
     awaitPromise: z.boolean().default(false).describe('Wait for promise resolution'),
 }, createEvaluateHandler(getClient));
-trackedTool('cdp_reload', 'Trigger a full reload of the app. Auto-reconnects to the new Hermes target (waits up to 30s with 5 retries). After Dev Client rebuilds, the app may need a manual restart (xcrun simctl terminate + launch) if reconnect fails.', {
+trackedTool('cdp_reload', 'Trigger a full reload of the app. Auto-reconnects to the new Hermes target (waits up to 30s with 5 soft retries; on failure, falls back once to a 10s force-recreate that mirrors `cdp_connect force=true`). After Dev Client rebuilds, the app may need a manual restart (xcrun simctl terminate + launch) if both paths fail. When the force fallback recovers, `meta.recovered_via` is "force_reconnect" and `meta.proxy_was_active` indicates whether DevTools was attached (re-run cdp_open_devtools to re-attach).', {
     full: z.boolean().default(true).describe('Always performs a full reload via DevSettings.reload()'),
-}, createReloadHandler(getClient));
+}, createReloadHandler(getClient, setClient, createClient));
 trackedTool('cdp_component_tree', 'Get React component tree. Returns components with props, state, testIDs. Use filter to scope to a specific subtree — NEVER request full tree unless necessary (saves tokens). Detects RedBox and warns.', {
     filter: z.string().optional().describe('Component name or testID to scope query (e.g. "CartBadge", "product-list")'),
     depth: z.number().int().min(1).max(12).default(4).describe('Max depth (default 4, max 12)'),

--- a/scripts/cdp-bridge/dist/tools/reload.js
+++ b/scripts/cdp-bridge/dist/tools/reload.js
@@ -1,9 +1,58 @@
 import { okResult, failResult, warnResult, withConnection } from '../utils.js';
 let sessionReloadCount = 0;
 export function getSessionReloadCount() { return sessionReloadCount; }
-export function createReloadHandler(getClient) {
+const SOFT_RECONNECT_DEADLINE_MS = 30_000;
+const SOFT_RECONNECT_ATTEMPTS = 5;
+const FORCE_FALLBACK_TIMEOUT_MS = 10_000;
+const DISCONNECT_TIMEOUT_MS = 2_000;
+export function captureClientState(client) {
+    const target = client.connectedTarget;
+    return {
+        port: client.metroPort,
+        platform: target?.platform,
+        bundleId: target?.description ?? undefined,
+        proxyWasActive: client.proxyDesired,
+    };
+}
+async function raceWithTimeout(promise, timeoutMs, errorLabel) {
+    let timer;
+    try {
+        return await Promise.race([
+            promise,
+            new Promise((_, reject) => {
+                timer = setTimeout(() => reject(new Error(`${errorLabel} timeout (${timeoutMs}ms)`)), timeoutMs);
+            }),
+        ]);
+    }
+    finally {
+        if (timer)
+            clearTimeout(timer);
+    }
+}
+export async function forceReconnect(oldClient, setClient, createClient, captured) {
+    const swallow = () => undefined;
+    const disconnectPromise = oldClient.disconnect().catch(swallow);
+    await raceWithTimeout(disconnectPromise, DISCONNECT_TIMEOUT_MS, 'disconnect').catch(swallow);
+    const newClient = createClient(captured.port);
+    setClient(newClient);
+    const filters = {
+        platform: captured.platform,
+        bundleId: captured.bundleId,
+    };
+    try {
+        await raceWithTimeout(newClient.autoConnect(captured.port, filters), FORCE_FALLBACK_TIMEOUT_MS, 'force_reconnect');
+    }
+    catch (err) {
+        newClient.disconnect().catch(swallow);
+        setClient(createClient(captured.port));
+        return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+    }
+    const finalPlatform = newClient.connectedTarget?.platform ?? null;
+    const platformMatched = !captured.platform || captured.platform === finalPlatform;
+    return { ok: true, platformMatched, finalPlatform };
+}
+export function createReloadHandler(getClient, setClient, createClient) {
     return withConnection(getClient, async (_args, client) => {
-        // Step 1: Trigger reload — expected to disconnect the WS
         try {
             const result = await client.evaluate('(function() {' +
                 '  var ds = null;' +
@@ -27,61 +76,87 @@ export function createReloadHandler(getClient) {
                 return failResult(`Reload failed unexpectedly: ${msg}`);
             }
         }
-        // Step 2: Wait for WS to close (normal mode) or settle (Bridgeless: WS stays open)
         const wsDownDeadline = Date.now() + 3_000;
         while (client.isConnected && Date.now() < wsDownDeadline) {
             await new Promise(r => setTimeout(r, 200));
         }
-        // Step 3 (B61 fix, B89 fix): Always do full target re-discovery after reload.
-        // Retry up to 5 times with 30s absolute deadline — Dev Client rebuilds need
-        // extra time for the new Hermes target to become discoverable via Metro /json.
         let reconnected = false;
         let lastReconnErr = '';
-        const reconnectDeadline = Date.now() + 30_000;
-        for (let attempt = 0; attempt < 5; attempt++) {
+        let softAttemptsRun = 0;
+        const reconnectDeadline = Date.now() + SOFT_RECONNECT_DEADLINE_MS;
+        for (let attempt = 0; attempt < SOFT_RECONNECT_ATTEMPTS; attempt++) {
             if (Date.now() > reconnectDeadline) {
-                lastReconnErr = 'Reconnect deadline exceeded (30s)';
+                lastReconnErr = `Reconnect deadline exceeded (${SOFT_RECONNECT_DEADLINE_MS / 1000}s)`;
                 break;
             }
+            softAttemptsRun = attempt + 1;
+            let reconnTimer;
             try {
-                let reconnTimer;
                 await Promise.race([
                     client.softReconnect(),
                     new Promise((_, reject) => {
                         reconnTimer = setTimeout(() => reject(new Error('softReconnect timeout')), Math.max(reconnectDeadline - Date.now(), 2000));
                     }),
                 ]);
-                if (reconnTimer)
-                    clearTimeout(reconnTimer);
                 reconnected = true;
                 break;
             }
             catch (reconnErr) {
                 lastReconnErr = reconnErr instanceof Error ? reconnErr.message : String(reconnErr);
-                // Progressive delay: 2s, 3s, 4s, 5s between retries
-                if (attempt < 4)
+                if (attempt < SOFT_RECONNECT_ATTEMPTS - 1) {
                     await new Promise(r => setTimeout(r, 2000 + attempt * 1000));
+                }
+            }
+            finally {
+                if (reconnTimer)
+                    clearTimeout(reconnTimer);
             }
         }
+        let forceMeta = {};
         if (!reconnected) {
-            return okResult({ reloaded: true, type: 'full', reconnected: false }, { meta: { warning: `Reload triggered but re-discovery failed after 3 attempts: ${lastReconnErr}` } });
+            const captured = captureClientState(getClient());
+            const forceResult = await forceReconnect(getClient(), setClient, createClient, captured);
+            if (forceResult.ok) {
+                reconnected = true;
+                client = getClient();
+                const notes = [];
+                if (captured.proxyWasActive) {
+                    notes.push('DevTools detached — run cdp_open_devtools to re-attach.');
+                }
+                notes.push('Network/console buffers reset for new target.');
+                forceMeta = {
+                    recovered_via: 'force_reconnect',
+                    proxy_was_active: captured.proxyWasActive,
+                    note: notes.join(' '),
+                };
+                if (!forceResult.platformMatched) {
+                    forceMeta.warning = `Recovered onto ${forceResult.finalPlatform ?? 'unknown'} but pre-reload session was on ${captured.platform ?? 'unknown'}. Run cdp_connect platform: "${captured.platform}" force: true to re-bind.`;
+                }
+            }
+            else {
+                return okResult({ reloaded: true, type: 'full', reconnected: false }, {
+                    meta: {
+                        warning: `Reload triggered but re-discovery failed after ${softAttemptsRun} soft attempts: ${lastReconnErr}; force_reconnect also failed (10s budget): ${forceResult.reason}`,
+                        force_reconnect_attempted: true,
+                        proxy_was_active: captured.proxyWasActive,
+                    },
+                });
+            }
         }
-        // Step 4: Wait for helpers injection (up to 12s)
         const helperDeadline = Date.now() + 12_000;
         while (!client.helpersInjected && Date.now() < helperDeadline) {
             await new Promise(r => setTimeout(r, 400));
         }
         if (!client.isConnected) {
-            return okResult({ reloaded: true, type: 'full', reconnected: false }, { meta: { warning: 'Reload triggered but connection dropped after re-discovery.' } });
+            return okResult({ reloaded: true, type: 'full', reconnected: false }, { meta: { warning: 'Reload triggered but connection dropped after re-discovery.', ...forceMeta } });
         }
         if (!client.helpersInjected) {
-            // B43 fix: pass tighter timeout (10s) to avoid exceeding reload's overall budget
             const injected = await client.reinjectHelpers(10_000);
             if (!injected) {
-                return warnResult({ reloaded: true, type: 'full', reconnected: true }, 'Reload succeeded but helper injection failed. App may still be loading — retry cdp_status.');
+                return warnResult({ reloaded: true, type: 'full', reconnected: true }, 'Reload succeeded but helper injection failed. App may still be loading — retry cdp_status.', forceMeta);
             }
         }
         sessionReloadCount++;
-        return okResult({ reloaded: true, type: 'full', reconnected: true });
+        return okResult({ reloaded: true, type: 'full', reconnected: true }, Object.keys(forceMeta).length > 0 ? { meta: forceMeta } : undefined);
     });
 }

--- a/scripts/cdp-bridge/src/cdp-client.ts
+++ b/scripts/cdp-bridge/src/cdp-client.ts
@@ -113,6 +113,8 @@ export class CDPClient {
   get helpersInjected(): boolean { return this._helpersInjected; }
   get metroPort(): number { return this._port; }
   get connectedTarget(): HermesTarget | null { return this._connectedTarget; }
+  /** B132: whether DevTools attachment was requested. Survives soft reconnect (auto-resumes via afterReconnect). Lost on `disconnect()` — caller must re-run cdp_open_devtools after a force-recreate. */
+  get proxyDesired(): boolean { return this._proxyDesired; }
   /** M11: timestamp of the current CDP connection (ms since epoch); null when disconnected. */
   get connectedAt(): number | null { return this._connectedAt; }
   /** M11: clock source for this client (injectable; defaults to Date.now). */

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -167,11 +167,11 @@ trackedTool(
 
 trackedTool(
   'cdp_reload',
-  'Trigger a full reload of the app. Auto-reconnects to the new Hermes target (waits up to 30s with 5 retries). After Dev Client rebuilds, the app may need a manual restart (xcrun simctl terminate + launch) if reconnect fails.',
+  'Trigger a full reload of the app. Auto-reconnects to the new Hermes target (waits up to 30s with 5 soft retries; on failure, falls back once to a 10s force-recreate that mirrors `cdp_connect force=true`). After Dev Client rebuilds, the app may need a manual restart (xcrun simctl terminate + launch) if both paths fail. When the force fallback recovers, `meta.recovered_via` is "force_reconnect" and `meta.proxy_was_active` indicates whether DevTools was attached (re-run cdp_open_devtools to re-attach).',
   {
     full: z.boolean().default(true).describe('Always performs a full reload via DevSettings.reload()'),
   },
-  createReloadHandler(getClient),
+  createReloadHandler(getClient, setClient, createClient),
 );
 
 trackedTool(

--- a/scripts/cdp-bridge/src/tools/reload.ts
+++ b/scripts/cdp-bridge/src/tools/reload.ts
@@ -4,9 +4,98 @@ import { okResult, failResult, warnResult, withConnection } from '../utils.js';
 let sessionReloadCount = 0;
 export function getSessionReloadCount(): number { return sessionReloadCount; }
 
-export function createReloadHandler(getClient: () => CDPClient) {
+const SOFT_RECONNECT_DEADLINE_MS = 30_000;
+const SOFT_RECONNECT_ATTEMPTS = 5;
+const FORCE_FALLBACK_TIMEOUT_MS = 10_000;
+const DISCONNECT_TIMEOUT_MS = 2_000;
+
+interface CapturedClientState {
+  port: number;
+  platform: 'ios' | 'android' | undefined;
+  bundleId: string | undefined;
+  proxyWasActive: boolean;
+}
+
+export function captureClientState(client: CDPClient): CapturedClientState {
+  const target = client.connectedTarget;
+  return {
+    port: client.metroPort,
+    platform: target?.platform,
+    bundleId: target?.description ?? undefined,
+    proxyWasActive: client.proxyDesired,
+  };
+}
+
+async function raceWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  errorLabel: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`${errorLabel} timeout (${timeoutMs}ms)`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export interface ForceReconnectResult {
+  ok: boolean;
+  reason?: string;
+  platformMatched?: boolean;
+  finalPlatform?: 'ios' | 'android' | null;
+}
+
+export async function forceReconnect(
+  oldClient: CDPClient,
+  setClient: (c: CDPClient) => void,
+  createClient: (port: number) => CDPClient,
+  captured: CapturedClientState,
+): Promise<ForceReconnectResult> {
+  const swallow = (): undefined => undefined;
+
+  const disconnectPromise = oldClient.disconnect().catch(swallow);
+  await raceWithTimeout(disconnectPromise, DISCONNECT_TIMEOUT_MS, 'disconnect').catch(swallow);
+
+  const newClient = createClient(captured.port);
+  setClient(newClient);
+
+  const filters = {
+    platform: captured.platform,
+    bundleId: captured.bundleId,
+  };
+
+  try {
+    await raceWithTimeout(
+      newClient.autoConnect(captured.port, filters),
+      FORCE_FALLBACK_TIMEOUT_MS,
+      'force_reconnect',
+    );
+  } catch (err) {
+    newClient.disconnect().catch(swallow);
+    setClient(createClient(captured.port));
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+
+  const finalPlatform = newClient.connectedTarget?.platform ?? null;
+  const platformMatched = !captured.platform || captured.platform === finalPlatform;
+  return { ok: true, platformMatched, finalPlatform };
+}
+
+export function createReloadHandler(
+  getClient: () => CDPClient,
+  setClient: (c: CDPClient) => void,
+  createClient: (port: number) => CDPClient,
+) {
   return withConnection(getClient, async (_args: { full: boolean }, client) => {
-    // Step 1: Trigger reload — expected to disconnect the WS
     try {
       const result = await client.evaluate(
         '(function() {' +
@@ -33,48 +122,78 @@ export function createReloadHandler(getClient: () => CDPClient) {
       }
     }
 
-    // Step 2: Wait for WS to close (normal mode) or settle (Bridgeless: WS stays open)
     const wsDownDeadline = Date.now() + 3_000;
     while (client.isConnected && Date.now() < wsDownDeadline) {
       await new Promise(r => setTimeout(r, 200));
     }
 
-    // Step 3 (B61 fix, B89 fix): Always do full target re-discovery after reload.
-    // Retry up to 5 times with 30s absolute deadline — Dev Client rebuilds need
-    // extra time for the new Hermes target to become discoverable via Metro /json.
     let reconnected = false;
     let lastReconnErr = '';
-    const reconnectDeadline = Date.now() + 30_000;
-    for (let attempt = 0; attempt < 5; attempt++) {
+    let softAttemptsRun = 0;
+    const reconnectDeadline = Date.now() + SOFT_RECONNECT_DEADLINE_MS;
+    for (let attempt = 0; attempt < SOFT_RECONNECT_ATTEMPTS; attempt++) {
       if (Date.now() > reconnectDeadline) {
-        lastReconnErr = 'Reconnect deadline exceeded (30s)';
+        lastReconnErr = `Reconnect deadline exceeded (${SOFT_RECONNECT_DEADLINE_MS / 1000}s)`;
         break;
       }
+      softAttemptsRun = attempt + 1;
+      let reconnTimer: ReturnType<typeof setTimeout> | undefined;
       try {
-        let reconnTimer: ReturnType<typeof setTimeout> | undefined;
         await Promise.race([
           client.softReconnect(),
           new Promise<never>((_, reject) => {
-            reconnTimer = setTimeout(() => reject(new Error('softReconnect timeout')), Math.max(reconnectDeadline - Date.now(), 2000));
+            reconnTimer = setTimeout(
+              () => reject(new Error('softReconnect timeout')),
+              Math.max(reconnectDeadline - Date.now(), 2000),
+            );
           }),
         ]);
-        if (reconnTimer) clearTimeout(reconnTimer);
         reconnected = true;
         break;
       } catch (reconnErr) {
         lastReconnErr = reconnErr instanceof Error ? reconnErr.message : String(reconnErr);
-        // Progressive delay: 2s, 3s, 4s, 5s between retries
-        if (attempt < 4) await new Promise(r => setTimeout(r, 2000 + attempt * 1000));
+        if (attempt < SOFT_RECONNECT_ATTEMPTS - 1) {
+          await new Promise(r => setTimeout(r, 2000 + attempt * 1000));
+        }
+      } finally {
+        if (reconnTimer) clearTimeout(reconnTimer);
       }
     }
+
+    let forceMeta: Record<string, unknown> = {};
     if (!reconnected) {
-      return okResult(
-        { reloaded: true, type: 'full', reconnected: false },
-        { meta: { warning: `Reload triggered but re-discovery failed after 3 attempts: ${lastReconnErr}` } },
-      );
+      const captured = captureClientState(getClient());
+      const forceResult = await forceReconnect(getClient(), setClient, createClient, captured);
+      if (forceResult.ok) {
+        reconnected = true;
+        client = getClient();
+        const notes: string[] = [];
+        if (captured.proxyWasActive) {
+          notes.push('DevTools detached — run cdp_open_devtools to re-attach.');
+        }
+        notes.push('Network/console buffers reset for new target.');
+        forceMeta = {
+          recovered_via: 'force_reconnect',
+          proxy_was_active: captured.proxyWasActive,
+          note: notes.join(' '),
+        };
+        if (!forceResult.platformMatched) {
+          forceMeta.warning = `Recovered onto ${forceResult.finalPlatform ?? 'unknown'} but pre-reload session was on ${captured.platform ?? 'unknown'}. Run cdp_connect platform: "${captured.platform}" force: true to re-bind.`;
+        }
+      } else {
+        return okResult(
+          { reloaded: true, type: 'full', reconnected: false },
+          {
+            meta: {
+              warning: `Reload triggered but re-discovery failed after ${softAttemptsRun} soft attempts: ${lastReconnErr}; force_reconnect also failed (10s budget): ${forceResult.reason}`,
+              force_reconnect_attempted: true,
+              proxy_was_active: captured.proxyWasActive,
+            },
+          },
+        );
+      }
     }
 
-    // Step 4: Wait for helpers injection (up to 12s)
     const helperDeadline = Date.now() + 12_000;
     while (!client.helpersInjected && Date.now() < helperDeadline) {
       await new Promise(r => setTimeout(r, 400));
@@ -83,22 +202,25 @@ export function createReloadHandler(getClient: () => CDPClient) {
     if (!client.isConnected) {
       return okResult(
         { reloaded: true, type: 'full', reconnected: false },
-        { meta: { warning: 'Reload triggered but connection dropped after re-discovery.' } },
+        { meta: { warning: 'Reload triggered but connection dropped after re-discovery.', ...forceMeta } },
       );
     }
 
     if (!client.helpersInjected) {
-      // B43 fix: pass tighter timeout (10s) to avoid exceeding reload's overall budget
       const injected = await client.reinjectHelpers(10_000);
       if (!injected) {
         return warnResult(
           { reloaded: true, type: 'full', reconnected: true },
           'Reload succeeded but helper injection failed. App may still be loading — retry cdp_status.',
+          forceMeta,
         );
       }
     }
 
     sessionReloadCount++;
-    return okResult({ reloaded: true, type: 'full', reconnected: true });
+    return okResult(
+      { reloaded: true, type: 'full', reconnected: true },
+      Object.keys(forceMeta).length > 0 ? { meta: forceMeta } : undefined,
+    );
   });
 }

--- a/scripts/cdp-bridge/test/unit/reload-force-retry.test.js
+++ b/scripts/cdp-bridge/test/unit/reload-force-retry.test.js
@@ -1,0 +1,276 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { captureClientState, forceReconnect } from '../../dist/tools/reload.js';
+
+// Mock CDPClient with the surface forceReconnect / captureClientState consume.
+// `autoConnectImpl` runs on the NEW client created via createClient() — not the old one.
+function makeMockClient(opts = {}) {
+  const {
+    port = 8081,
+    target = null,
+    proxyDesired = false,
+    disconnectImpl,
+    autoConnectImpl,
+  } = opts;
+
+  const calls = { disconnect: 0, autoConnect: 0, lastFilters: undefined };
+  let connectedTarget = target;
+
+  const client = {
+    get metroPort() { return port; },
+    get connectedTarget() { return connectedTarget; },
+    get proxyDesired() { return proxyDesired; },
+    disconnect: async () => {
+      calls.disconnect += 1;
+      if (disconnectImpl) return disconnectImpl();
+    },
+    autoConnect: async (portHint, filters) => {
+      calls.autoConnect += 1;
+      calls.lastFilters = filters;
+      if (autoConnectImpl) {
+        const result = await autoConnectImpl(portHint, filters);
+        if (result && result.connectedTarget !== undefined) {
+          connectedTarget = result.connectedTarget;
+        }
+        return result?.message ?? 'connected';
+      }
+      return 'connected';
+    },
+  };
+
+  return { client, calls };
+}
+
+// ── captureClientState ─────────────────────────────────────────────────
+
+test('captureClientState: captures port, platform, bundleId from connectedTarget', () => {
+  const { client } = makeMockClient({
+    port: 19000,
+    target: { id: 'page-1', platform: 'android', description: 'com.example.app' },
+    proxyDesired: true,
+  });
+  const captured = captureClientState(client);
+  assert.equal(captured.port, 19000);
+  assert.equal(captured.platform, 'android');
+  assert.equal(captured.bundleId, 'com.example.app');
+  assert.equal(captured.proxyWasActive, true);
+});
+
+test('captureClientState: handles null connectedTarget', () => {
+  const { client } = makeMockClient({ port: 8081, target: null });
+  const captured = captureClientState(client);
+  assert.equal(captured.port, 8081);
+  assert.equal(captured.platform, undefined);
+  assert.equal(captured.bundleId, undefined);
+  assert.equal(captured.proxyWasActive, false);
+});
+
+test('captureClientState: target without description yields undefined bundleId', () => {
+  const { client } = makeMockClient({
+    target: { id: 'page-1', platform: 'ios' },
+  });
+  const captured = captureClientState(client);
+  assert.equal(captured.platform, 'ios');
+  assert.equal(captured.bundleId, undefined);
+});
+
+// ── forceReconnect helper ──────────────────────────────────────────────
+
+test('forceReconnect: happy path — disposes old, creates fresh, autoConnects, returns ok', async () => {
+  const { client: oldClient, calls: oldCalls } = makeMockClient({
+    port: 8081,
+    target: { id: 'old-1', platform: 'ios', description: 'com.app' },
+    proxyDesired: false,
+  });
+  const { client: newClient, calls: newCalls } = makeMockClient({
+    port: 8081,
+    autoConnectImpl: async () => ({
+      connectedTarget: { id: 'new-1', platform: 'ios', description: 'com.app' },
+    }),
+  });
+
+  let current = oldClient;
+  const setClient = (c) => { current = c; };
+  const createClient = () => newClient;
+
+  const captured = captureClientState(oldClient);
+  const result = await forceReconnect(oldClient, setClient, createClient, captured);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.platformMatched, true);
+  assert.equal(result.finalPlatform, 'ios');
+  assert.equal(oldCalls.disconnect, 1, 'old client disconnected once');
+  assert.equal(newCalls.autoConnect, 1, 'new client autoConnect called once');
+  assert.equal(current, newClient, 'setClient swapped to new instance');
+});
+
+test('forceReconnect: passes { platform, bundleId } and NO targetId to autoConnect', async () => {
+  const { client: oldClient } = makeMockClient({
+    port: 8081,
+    target: { id: 'stale-target-id', platform: 'android', description: 'com.example' },
+  });
+  const { client: newClient, calls: newCalls } = makeMockClient({
+    autoConnectImpl: async () => ({
+      connectedTarget: { id: 'fresh-id', platform: 'android', description: 'com.example' },
+    }),
+  });
+
+  let current = oldClient;
+  const captured = captureClientState(oldClient);
+  await forceReconnect(oldClient, (c) => { current = c; }, () => newClient, captured);
+
+  const filters = newCalls.lastFilters;
+  assert.equal(filters.platform, 'android');
+  assert.equal(filters.bundleId, 'com.example');
+  assert.equal(filters.targetId, undefined, 'targetId must NOT be forwarded — changes after rebuild');
+});
+
+test('forceReconnect: autoConnect rejects → returns ok:false with reason and orphan-replaces', async () => {
+  const { client: oldClient } = makeMockClient({
+    port: 8081,
+    target: { id: 'p', platform: 'ios' },
+  });
+  // First instance rejects on autoConnect; second is the orphan-replacement.
+  const instances = [
+    makeMockClient({ autoConnectImpl: async () => { throw new Error('discovery failed'); } }).client,
+    makeMockClient({ port: 8081 }).client,
+  ];
+  let createIdx = 0;
+  let current = oldClient;
+  const captured = captureClientState(oldClient);
+
+  const result = await forceReconnect(
+    oldClient,
+    (c) => { current = c; },
+    () => instances[createIdx++],
+    captured,
+  );
+
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /discovery failed/);
+  assert.equal(createIdx, 2, 'createClient called twice — attempt + orphan-replace');
+  assert.equal(current, instances[1], 'setClient installed the replacement instance');
+});
+
+// tick() is synchronous in node:test MockTimers (no tickAsync until 22.6+);
+// we drain microtasks explicitly so awaited timer rejections settle.
+async function drainMicrotasks(rounds = 5) {
+  for (let i = 0; i < rounds; i++) await Promise.resolve();
+}
+
+test('forceReconnect: autoConnect hangs → 10s timeout fires, orphan disposed, fresh client installed', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+
+  const { client: oldClient } = makeMockClient({
+    port: 8081,
+    target: { id: 'p', platform: 'ios' },
+  });
+
+  const hangingInstance = makeMockClient({
+    autoConnectImpl: () => new Promise(() => {}),
+  });
+  const replacementInstance = makeMockClient({ port: 8081 });
+
+  let current = oldClient;
+  const instances = [hangingInstance.client, replacementInstance.client];
+  let createIdx = 0;
+  const captured = captureClientState(oldClient);
+
+  const promise = forceReconnect(
+    oldClient,
+    (c) => { current = c; },
+    () => instances[createIdx++],
+    captured,
+  );
+
+  // Disconnect race (2s) — old client's disconnect returns immediately so it resolves on its own,
+  // but the timer needs to be cleared. Tick past it to be safe.
+  t.mock.timers.tick(2_001);
+  await drainMicrotasks();
+  // Force-reconnect timeout (10s) — fires the rejection that orphan-handles.
+  t.mock.timers.tick(10_001);
+  await drainMicrotasks();
+
+  const result = await promise;
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /force_reconnect timeout/);
+  assert.equal(hangingInstance.calls.disconnect, 1, 'orphan (hung) instance was disposed');
+  assert.equal(createIdx, 2, 'createClient called twice — attempt + orphan-replace');
+  assert.equal(current, replacementInstance.client, 'final installed client is the replacement, not the orphan');
+
+  t.mock.timers.reset();
+});
+
+test('forceReconnect: disconnect() hangs >2s → still proceeds to install fresh client', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+
+  const { client: oldClient } = makeMockClient({
+    port: 8081,
+    target: { id: 'p', platform: 'ios' },
+    disconnectImpl: () => new Promise(() => {}),
+  });
+  const { client: newClient } = makeMockClient({
+    autoConnectImpl: async () => ({
+      connectedTarget: { id: 'new', platform: 'ios' },
+    }),
+  });
+
+  let current = oldClient;
+  const captured = captureClientState(oldClient);
+  const promise = forceReconnect(
+    oldClient,
+    (c) => { current = c; },
+    () => newClient,
+    captured,
+  );
+
+  // Disconnect race fires its 2s timeout — the .catch(swallow) absorbs it,
+  // and forceReconnect proceeds to createClient + autoConnect (which resolves immediately).
+  t.mock.timers.tick(2_001);
+  await drainMicrotasks();
+
+  const result = await promise;
+  assert.equal(result.ok, true, 'force-reconnect proceeded despite hanging disconnect');
+  assert.equal(current, newClient, 'fresh client installed');
+
+  t.mock.timers.reset();
+});
+
+test('forceReconnect: platform mismatch surfaces in result (recovered to wrong platform)', async () => {
+  const { client: oldClient } = makeMockClient({
+    port: 8081,
+    target: { id: 'p', platform: 'ios', description: 'com.app' },
+  });
+  const { client: newClient } = makeMockClient({
+    autoConnectImpl: async () => ({
+      connectedTarget: { id: 'q', platform: 'android', description: 'com.app' },
+    }),
+  });
+
+  let current = oldClient;
+  const captured = captureClientState(oldClient);
+  const result = await forceReconnect(oldClient, (c) => { current = c; }, () => newClient, captured);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.platformMatched, false, 'iOS captured but recovered onto Android');
+  assert.equal(result.finalPlatform, 'android');
+});
+
+test('forceReconnect: captured platform=undefined → platformMatched=true regardless', async () => {
+  const { client: oldClient } = makeMockClient({
+    port: 8081,
+    target: null,
+  });
+  const { client: newClient } = makeMockClient({
+    autoConnectImpl: async () => ({
+      connectedTarget: { id: 'q', platform: 'android' },
+    }),
+  });
+
+  const captured = captureClientState(oldClient);
+  const result = await forceReconnect(oldClient, () => {}, () => newClient, captured);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.platformMatched, true, 'no captured platform → no constraint to match');
+  assert.equal(result.finalPlatform, 'android');
+});


### PR DESCRIPTION
… deadline

When cdp_reload's existing 5-attempt 30s soft-reconnect loop fails, the user previously had to manually call cdp_connect platform: X force: true to recover (IX-2950, 2026-04-23). This makes cdp_reload perform that recovery automatically — Option Y (post-loop fallback, not escalation within the loop).

Mechanics:
- Capture {port, platform, bundleId, proxyWasActive} from old client BEFORE disconnect. Skip targetId — it changes after a Dev Client rebuild, and discovery.ts hard-filters on it (would defeat recovery).
- Race disconnect() with a 2s timeout (defensive against a hanging multiplexer.stop()), then createClient + setClient + autoConnect with a 10s timeout.
- On force-fallback timeout, dispose the orphaned new client AND install another fresh createClient() — Promise.race does NOT cancel the loser, so the racing autoConnect could otherwise mutate state on a client we still hold a reference to. Same finally { clearTimeout } pattern applied to the existing soft-reconnect race (latent leak).

Meta contract:
- meta.recovered_via: "force_reconnect" ONLY on actual success.
- meta.force_reconnect_attempted: true on failure (no false success signal).
- meta.proxy_was_active surfaces DevTools-detached state (lost across client swap; user should re-run cdp_open_devtools).
- Post-condition platform check: if force-recreate lands on a different platform than captured, surface meta.warning so the user knows to rebind. Guards against re-introducing PR #76's bug class.

Wiring:
- createReloadHandler signature now (getClient, setClient, createClient) matching createConnectHandler / createRestartHandler.
- Closure-captured client reassigned via client = getClient() after force-success, since withConnection only reads the client once at handler entry.
- Public proxyDesired getter on CDPClient with JSDoc on its survives-soft-reconnect / lost-on-disconnect lifecycle.

Other:
- Off-by-two warning text fixed: "after 3 attempts" was wrong (loop ran 5); now reports computed softAttemptsRun, incremented after the deadline check so the count reflects attempts that actually ran.
- 10 new unit tests on captureClientState (3) and forceReconnect (7): happy path, no-targetId-leak, autoConnect rejection + orphan replace, 10s autoConnect hang via mock timers, 2s disconnect hang via mock timers, platform mismatch surfaces, undefined platform → matched.
- 796 tests passing (+10 new, zero regressions).

Multi-LLM brainstorm (Codex gpt-5.5 xhigh) cross-checked clean against source and caught two pre-ship issues (Promise.race orphan-leak, recovered_via vs force_reconnect_attempted distinction). Multi-review (Gemini + Codex) caught the softAttemptsRun off-by-one regression and test-file dead-setup before merge — both fixed.

Refs: GH #60 (sub-item 3), D683, Phase 114.