### PR TITLE
feat(gh-65-p3): add cdp_wait_for_network composite tool to eliminate …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,9 +97,9 @@ Fallback: `xcrun simctl` (iOS) + `adb` (Android) for device lifecycle when agent
 
 ### MCP Server (cdp-bridge)
 
-52 tools exposed via MCP:
+64 tools exposed via MCP (count last audited 2026-04-28; per-category breakdown below predates several additions and is approximate):
 
-**CDP tools** (25 — React internals via Chrome DevTools Protocol over WebSocket):
+**CDP tools** (React internals via Chrome DevTools Protocol over WebSocket):
 - `cdp_status` — health check with domain capabilities + reconnect state
 - `cdp_connect` / `cdp_disconnect` / `cdp_targets` — connection management
 - `cdp_evaluate` — arbitrary JS execution in Hermes
@@ -109,6 +109,7 @@ Fallback: `xcrun simctl` (iOS) + `adb` (Android) for device lifecycle when agent
 - `cdp_navigation_state` / `cdp_nav_graph` / `cdp_navigate` — navigation
 - `cdp_store_state` / `cdp_dispatch` — Redux/Zustand/React Query state
 - `cdp_network_log` / `cdp_network_body` / `cdp_console_log` / `cdp_error_log` — buffered events
+- `cdp_wait_for_network` — block until a network request matching url_pattern + method completes (D682, GH #65 P3) — collapses "tap → check → tap" into a single deterministic call
 - `cdp_interact` — press/type/scroll by testID via fiber tree
 - `cdp_heap_usage` — JS memory usage
 - `cdp_cpu_profile` — CPU profiling with hot function ranking

--- a/scripts/cdp-bridge/bench/wait-for-network.bench.mjs
+++ b/scripts/cdp-bridge/bench/wait-for-network.bench.mjs
@@ -1,0 +1,296 @@
+// Benchmark for cdp_wait_for_network — GH #65 P3 / D682.
+//
+// Three layers of measurement:
+//   A. Helper microbenchmarks — pure JS, deterministic
+//   B. Buffer scan latency vs buffer size — Phase 1 retroactive scan
+//   C. End-to-end handler timing — Phase 1 hit, poll hit, timeout
+//
+// Run from scripts/cdp-bridge:
+//   node bench/wait-for-network.bench.mjs
+//
+// Output: stdout summary + benchmark.json (machine-readable for trend tracking
+// per feedback_always_record_timing.md).
+
+import { performance } from 'node:perf_hooks';
+import { writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import {
+  normalizeSince,
+  buildMatchPredicate,
+  isComplete,
+  createWaitForNetworkHandler,
+} from '../dist/tools/wait-for-network.js';
+import { DeviceBufferManager } from '../dist/ring-buffer.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Shared fixtures ─────────────────────────────────────────────────────────
+
+function makeEntry(i, opts = {}) {
+  return {
+    id: `req-${i}`,
+    method: opts.method ?? (i % 5 === 0 ? 'POST' : 'GET'),
+    url: opts.url ?? (i % 7 === 0 ? '/api/cart/add' : `/api/items/${i}`),
+    timestamp: opts.timestamp ?? new Date(Date.now() - (1000 - i)).toISOString(),
+    status: opts.status ?? 200,
+    duration_ms: opts.duration_ms ?? 50,
+  };
+}
+
+function makeBuffer(entryCount, opts = {}) {
+  const buf = new DeviceBufferManager({
+    capacityPerDevice: 100,
+    maxDevices: 10,
+    indexKey: (e) => e.id,
+    timestampOf: (e) => new Date(e.timestamp).getTime(),
+  });
+  const deviceCount = opts.devices ?? 1;
+  for (let i = 0; i < entryCount; i++) {
+    const deviceKey = `8081-page${(i % deviceCount) + 1}`;
+    buf.push(deviceKey, makeEntry(i, opts.entryOpts));
+  }
+  return buf;
+}
+
+function makeFakeClient(buffer, deviceKey = '8081-page1') {
+  return {
+    isConnected: true,
+    helpersInjected: true,
+    connectionGeneration: 1,
+    activeDeviceKey: deviceKey,
+    networkBufferManager: buffer,
+    async evaluate() { return { value: 13 }; },
+    async reinjectHelpers() { return true; },
+  };
+}
+
+function timeIt(fn, iterations) {
+  // Warm up JIT
+  for (let i = 0; i < Math.min(iterations, 1000); i++) fn();
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) fn();
+  const elapsed = performance.now() - start;
+  return {
+    iterations,
+    total_ms: +elapsed.toFixed(3),
+    ns_per_op: Math.round((elapsed * 1e6) / iterations),
+    ops_per_sec: Math.round(iterations / (elapsed / 1000)),
+  };
+}
+
+async function timeAsync(fn, iterations) {
+  // Warm up
+  for (let i = 0; i < Math.min(iterations, 3); i++) await fn();
+  const samples = [];
+  for (let i = 0; i < iterations; i++) {
+    const start = performance.now();
+    await fn();
+    samples.push(performance.now() - start);
+  }
+  samples.sort((a, b) => a - b);
+  return {
+    iterations,
+    min_ms: +samples[0].toFixed(3),
+    p50_ms: +samples[Math.floor(samples.length / 2)].toFixed(3),
+    p95_ms: +samples[Math.floor(samples.length * 0.95)].toFixed(3),
+    max_ms: +samples[samples.length - 1].toFixed(3),
+    mean_ms: +(samples.reduce((s, x) => s + x, 0) / samples.length).toFixed(3),
+  };
+}
+
+// ── A. Helper microbenchmarks ──────────────────────────────────────────────
+
+console.log('\n=== A. Helper microbenchmarks (1M iterations each) ===\n');
+
+const helperResults = {
+  normalizeSince_alreadyZ: timeIt(
+    () => normalizeSince('2026-04-27T08:00:00.000Z'),
+    1_000_000,
+  ),
+  normalizeSince_withOffset: timeIt(
+    () => normalizeSince('2026-04-27T10:00:00+02:00'),
+    1_000_000,
+  ),
+  normalizeSince_unparseable: timeIt(
+    () => normalizeSince('not-a-date'),
+    1_000_000,
+  ),
+  buildMatchPredicate_construction: timeIt(
+    () => buildMatchPredicate('/api/cart', 'POST', '2026-04-27T08:00:00.000Z'),
+    1_000_000,
+  ),
+};
+
+const sampleEntry = makeEntry(0);
+const samplePredicate = buildMatchPredicate('/api/cart', 'POST', '2020-01-01T00:00:00.000Z');
+helperResults.predicate_eval_match = timeIt(
+  () => samplePredicate({ ...sampleEntry, url: '/api/cart/add', method: 'POST' }),
+  1_000_000,
+);
+helperResults.predicate_eval_miss_url = timeIt(
+  () => samplePredicate(sampleEntry),
+  1_000_000,
+);
+helperResults.isComplete_true = timeIt(() => isComplete(sampleEntry), 1_000_000);
+const inflightEntry = { ...sampleEntry };
+delete inflightEntry.status;
+helperResults.isComplete_false = timeIt(() => isComplete(inflightEntry), 1_000_000);
+
+for (const [name, r] of Object.entries(helperResults)) {
+  console.log(`  ${name.padEnd(38)} ${String(r.ns_per_op).padStart(6)} ns/op  (${r.ops_per_sec.toLocaleString()} ops/s)`);
+}
+
+// ── B. Buffer scan latency vs buffer size ──────────────────────────────────
+
+console.log('\n=== B. Buffer scan latency (Phase 1 retroactive scan) ===\n');
+
+const bufferScanResults = {};
+const sizes = [
+  { name: 'empty', entries: 0, devices: 1 },
+  { name: 'small_10', entries: 10, devices: 1 },
+  { name: 'full_100', entries: 100, devices: 1 },
+  { name: 'cross_device_all_500', entries: 500, devices: 5 },
+];
+
+for (const { name, entries, devices } of sizes) {
+  const buf = makeBuffer(entries, { devices });
+  const scope = devices === 1 ? '8081-page1' : 'all';
+  const predicate = buildMatchPredicate('/api/cart', 'POST', undefined);
+
+  const r = timeIt(() => buf.filter(scope, predicate), 10_000);
+  bufferScanResults[name] = { entries, devices, ...r };
+  console.log(
+    `  scope=${scope.padEnd(13)} entries=${String(entries).padStart(3)} devices=${devices}  →  ${r.ns_per_op.toLocaleString().padStart(8)} ns/op  (${(r.ns_per_op / 1000).toFixed(2)} µs/op)`,
+  );
+}
+
+// ── C. End-to-end handler timing ───────────────────────────────────────────
+
+console.log('\n=== C. End-to-end handler timing ===\n');
+
+const handlerResults = {};
+
+// C1. Phase 1 retroactive hit — completed entry already in buffer
+{
+  const buf = makeBuffer(50);
+  // Ensure at least one entry matches our pattern: '/api/cart/add' with POST
+  buf.push('8081-page1', makeEntry(999, { url: '/api/cart/add', method: 'POST', status: 201 }));
+  const client = makeFakeClient(buf);
+  const handler = createWaitForNetworkHandler(() => client);
+
+  handlerResults.retroactive_hit = await timeAsync(
+    () => handler({ url_pattern: '/api/cart/add', method: 'POST' }),
+    50,
+  );
+  console.log(`  C1. Phase 1 hit (50-entry buf, completed match present)`);
+  console.log(`      min=${handlerResults.retroactive_hit.min_ms}ms  p50=${handlerResults.retroactive_hit.p50_ms}ms  p95=${handlerResults.retroactive_hit.p95_ms}ms  max=${handlerResults.retroactive_hit.max_ms}ms`);
+}
+
+// C2. Poll hit — entry mutates from in-flight to complete during poll window
+{
+  // Each iteration needs a fresh in-flight entry that we mutate to complete
+  // mid-poll. Track elapsed time per iteration and compute stats.
+  const iterations = 10;
+  const samples = [];
+  for (let i = 0; i < iterations; i++) {
+    const buf = makeBuffer(10);
+    const inflight = makeEntry(1000 + i, { url: '/api/profile/save', method: 'PUT' });
+    delete inflight.status;
+    buf.push('8081-page1', inflight);
+    const client = makeFakeClient(buf);
+    const handler = createWaitForNetworkHandler(() => client);
+
+    // Mutate the entry to complete after ~75ms (one poll tick at default 100ms,
+    // so the second tick should catch it).
+    setTimeout(() => { inflight.status = 200; inflight.duration_ms = 60; }, 75);
+
+    const start = performance.now();
+    await handler({ url_pattern: '/api/profile/save', method: 'PUT', timeout_ms: 1000, poll_interval_ms: 50 });
+    samples.push(performance.now() - start);
+  }
+  samples.sort((a, b) => a - b);
+  handlerResults.poll_hit_50ms = {
+    iterations,
+    min_ms: +samples[0].toFixed(3),
+    p50_ms: +samples[Math.floor(iterations / 2)].toFixed(3),
+    p95_ms: +samples[Math.floor(iterations * 0.95)].toFixed(3),
+    max_ms: +samples[samples.length - 1].toFixed(3),
+    mean_ms: +(samples.reduce((s, x) => s + x, 0) / samples.length).toFixed(3),
+    note: 'entry completes at +75ms; poll cadence 50ms',
+  };
+  console.log(`  C2. Poll hit (entry completes mid-poll, cadence=50ms)`);
+  console.log(`      min=${handlerResults.poll_hit_50ms.min_ms}ms  p50=${handlerResults.poll_hit_50ms.p50_ms}ms  p95=${handlerResults.poll_hit_50ms.p95_ms}ms  max=${handlerResults.poll_hit_50ms.max_ms}ms`);
+}
+
+// C3. Timeout — no match, full timeout window
+{
+  const buf = makeBuffer(50);
+  const client = makeFakeClient(buf);
+  const handler = createWaitForNetworkHandler(() => client);
+
+  handlerResults.timeout_500ms = await timeAsync(
+    () => handler({ url_pattern: '/never-fires-' + Math.random(), timeout_ms: 500, poll_interval_ms: 100 }),
+    5,
+  );
+  console.log(`  C3. Timeout (no match, 500ms timeout, 100ms poll)`);
+  console.log(`      min=${handlerResults.timeout_500ms.min_ms}ms  p50=${handlerResults.timeout_500ms.p50_ms}ms  p95=${handlerResults.timeout_500ms.p95_ms}ms  max=${handlerResults.timeout_500ms.max_ms}ms`);
+}
+
+// C4. Disconnect mid-poll — connection drops, handler should bail early
+{
+  const iterations = 5;
+  const samples = [];
+  for (let i = 0; i < iterations; i++) {
+    const buf = makeBuffer(10);
+    const client = makeFakeClient(buf);
+    let connected = true;
+    Object.defineProperty(client, 'isConnected', { get() { return connected; } });
+    const handler = createWaitForNetworkHandler(() => client);
+
+    setTimeout(() => { connected = false; }, 75);
+
+    const start = performance.now();
+    await handler({ url_pattern: '/never-fires', timeout_ms: 5000, poll_interval_ms: 50 });
+    samples.push(performance.now() - start);
+  }
+  samples.sort((a, b) => a - b);
+  handlerResults.disconnect_bail = {
+    iterations,
+    min_ms: +samples[0].toFixed(3),
+    p50_ms: +samples[Math.floor(iterations / 2)].toFixed(3),
+    max_ms: +samples[samples.length - 1].toFixed(3),
+    mean_ms: +(samples.reduce((s, x) => s + x, 0) / samples.length).toFixed(3),
+    note: 'connection drops at +75ms; timeout was 5000ms — should short-circuit',
+  };
+  console.log(`  C4. Disconnect bail-out (timeout=5000ms, connection drops at +75ms)`);
+  console.log(`      min=${handlerResults.disconnect_bail.min_ms}ms  p50=${handlerResults.disconnect_bail.p50_ms}ms  max=${handlerResults.disconnect_bail.max_ms}ms`);
+}
+
+// ── Persist machine-readable results ───────────────────────────────────────
+
+const benchmark = {
+  tool: 'cdp_wait_for_network',
+  issue: '#65 P3',
+  decision: 'D682',
+  date: new Date().toISOString(),
+  node_version: process.version,
+  platform: `${process.platform} ${process.arch}`,
+  timings: {
+    helpers: helperResults,
+    buffer_scan: bufferScanResults,
+    handler: handlerResults,
+  },
+  notes: [
+    'Benchmark imports compiled tool from dist/, exercising real DeviceBufferManager and helpers.',
+    'No live MCP transport in scope — envelope serialization adds <100us per call (well below poll cadence).',
+    'C2 (poll_hit_50ms) timing dominated by setTimeout granularity; expect mean ≈ entry-mutation-delay + poll cadence.',
+    'C3 (timeout_500ms) target = 500ms exact; mean reflects setTimeout drift on the test runner.',
+    'C4 (disconnect_bail) verifies the in-poll isConnected guard short-circuits well before timeout.',
+  ],
+};
+
+const outPath = resolve(__dirname, 'wait-for-network.benchmark.json');
+await writeFile(outPath, JSON.stringify(benchmark, null, 2));
+console.log(`\n→ Wrote ${outPath}\n`);

--- a/scripts/cdp-bridge/bench/wait-for-network.benchmark.json
+++ b/scripts/cdp-bridge/bench/wait-for-network.benchmark.json
@@ -1,0 +1,136 @@
+{
+  "tool": "cdp_wait_for_network",
+  "issue": "#65 P3",
+  "decision": "D682",
+  "date": "2026-04-28T12:23:01.796Z",
+  "node_version": "v24.13.0",
+  "platform": "darwin arm64",
+  "timings": {
+    "helpers": {
+      "normalizeSince_alreadyZ": {
+        "iterations": 1000000,
+        "total_ms": 608.144,
+        "ns_per_op": 608,
+        "ops_per_sec": 1644348
+      },
+      "normalizeSince_withOffset": {
+        "iterations": 1000000,
+        "total_ms": 630.643,
+        "ns_per_op": 631,
+        "ops_per_sec": 1585683
+      },
+      "normalizeSince_unparseable": {
+        "iterations": 1000000,
+        "total_ms": 124.936,
+        "ns_per_op": 125,
+        "ops_per_sec": 8004095
+      },
+      "buildMatchPredicate_construction": {
+        "iterations": 1000000,
+        "total_ms": 24.64,
+        "ns_per_op": 25,
+        "ops_per_sec": 40584416
+      },
+      "predicate_eval_match": {
+        "iterations": 1000000,
+        "total_ms": 56.109,
+        "ns_per_op": 56,
+        "ops_per_sec": 17822307
+      },
+      "predicate_eval_miss_url": {
+        "iterations": 1000000,
+        "total_ms": 40.503,
+        "ns_per_op": 41,
+        "ops_per_sec": 24689630
+      },
+      "isComplete_true": {
+        "iterations": 1000000,
+        "total_ms": 3.959,
+        "ns_per_op": 4,
+        "ops_per_sec": 252602309
+      },
+      "isComplete_false": {
+        "iterations": 1000000,
+        "total_ms": 8.615,
+        "ns_per_op": 9,
+        "ops_per_sec": 116078847
+      }
+    },
+    "buffer_scan": {
+      "empty": {
+        "entries": 0,
+        "devices": 1,
+        "iterations": 10000,
+        "total_ms": 0.396,
+        "ns_per_op": 40,
+        "ops_per_sec": 25241880
+      },
+      "small_10": {
+        "entries": 10,
+        "devices": 1,
+        "iterations": 10000,
+        "total_ms": 3.684,
+        "ns_per_op": 368,
+        "ops_per_sec": 2714257
+      },
+      "full_100": {
+        "entries": 100,
+        "devices": 1,
+        "iterations": 10000,
+        "total_ms": 30.718,
+        "ns_per_op": 3072,
+        "ops_per_sec": 325546
+      },
+      "cross_device_all_500": {
+        "entries": 500,
+        "devices": 5,
+        "iterations": 10000,
+        "total_ms": 208.484,
+        "ns_per_op": 20848,
+        "ops_per_sec": 47965
+      }
+    },
+    "handler": {
+      "retroactive_hit": {
+        "iterations": 50,
+        "min_ms": 0.003,
+        "p50_ms": 0.003,
+        "p95_ms": 0.013,
+        "max_ms": 0.035,
+        "mean_ms": 0.005
+      },
+      "poll_hit_50ms": {
+        "iterations": 10,
+        "min_ms": 101.33,
+        "p50_ms": 101.99,
+        "p95_ms": 102.49,
+        "max_ms": 102.49,
+        "mean_ms": 101.902,
+        "note": "entry completes at +75ms; poll cadence 50ms"
+      },
+      "timeout_500ms": {
+        "iterations": 5,
+        "min_ms": 504.543,
+        "p50_ms": 505.562,
+        "p95_ms": 505.627,
+        "max_ms": 505.627,
+        "mean_ms": 505.188
+      },
+      "disconnect_bail": {
+        "iterations": 5,
+        "min_ms": 101.527,
+        "p50_ms": 102.518,
+        "max_ms": 102.58,
+        "mean_ms": 102.302,
+        "note": "connection drops at +75ms; timeout was 5000ms — should short-circuit"
+      }
+    }
+  },
+  "notes": [
+    "Benchmark imports compiled tool from dist/, exercising real DeviceBufferManager and helpers.",
+    "No live MCP transport in scope — envelope serialization adds <100us per call (well below poll cadence).",
+    "C2 (poll_hit_50ms) timing dominated by setTimeout granularity; expect mean ≈ entry-mutation-delay + poll cadence.",
+    "C3 (timeout_500ms) target = 500ms exact; mean reflects setTimeout drift on the test runner.",
+    "C4 (disconnect_bail) verifies the in-poll isConnected guard short-circuits well before timeout."
+  ]
+}

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -16,6 +16,7 @@ import { createNavigationStateHandler } from './tools/navigation-state.js';
 import { createErrorLogHandler } from './tools/error-log.js';
 import { createNativeErrorsHandler } from './tools/native-errors.js';
 import { createNetworkLogHandler } from './tools/network-log.js';
+import { createWaitForNetworkHandler } from './tools/wait-for-network.js';
 import { createNetworkBodyHandler } from './tools/network-body.js';
 import { createHeapUsageHandler, createCpuProfileHandler } from './tools/profiling.js';
 import { createObjectInspectHandler } from './tools/object-inspect.js';
@@ -144,6 +145,14 @@ trackedTool('cdp_network_body', 'Get the actual response body for a network requ
         .describe('Max body length to return (default 10000 chars). Truncated if longer.'),
     device: z.string().optional().describe('Device key to scope the lookup ("all" to search every device buffer). Defaults to the active device.'),
 }, createNetworkBodyHandler(getClient));
+trackedTool('cdp_wait_for_network', 'Block until a network request matching url_pattern (URL substring) and optional method completes (response received), or timeout_ms elapses. Two-phase: scans the existing buffer first (retroactive match), then polls every poll_interval_ms until deadline. Returns {matched:true, mutation, network_log_since} on success or {matched:false, timeout_ms, candidates_seen} (capped at 10) on timeout — never errors on timeout; agents should check `data.matched`. Use after triggering an action that fires a request to deterministically confirm it landed without buffer-churn races. Pin `since` to a timestamp captured BEFORE the trigger (Date.now() ISO) to also catch mutations that land in the MCP transport window.', {
+    url_pattern: z.string().describe('URL substring to match (e.g. "/api/cart/add", "checkout"). Same matching semantics as cdp_network_log filter.'),
+    method: z.union([z.string(), z.array(z.string())]).optional().describe('HTTP method filter, case-insensitive (e.g. "POST" or ["POST","PUT"]). Omit to match any method.'),
+    timeout_ms: z.number().int().min(100).max(60000).default(5000).optional().describe('Max wait in ms (default 5000, range 100-60000)'),
+    poll_interval_ms: z.number().int().min(50).max(500).default(100).optional().describe('Buffer poll cadence in ms (default 100, range 50-500)'),
+    since: z.string().optional().describe('ISO timestamp checkpoint — ignore entries older than this. Defaults to the moment the tool is called. Capture `new Date().toISOString()` before the trigger action to avoid missing the mutation in the transport window.'),
+    device: z.string().optional().describe('Device key OR "all". Defaults to the active device.'),
+}, createWaitForNetworkHandler(getClient));
 trackedTool('cdp_heap_usage', 'Get current JS heap memory usage. Single fast CDP call — useful before/after operations to detect memory leaks. Returns used/total in bytes and MB.', {}, createHeapUsageHandler(getClient));
 trackedTool('cdp_cpu_profile', 'Record a CPU profile for a specified duration. Returns the top hot functions sorted by hit count. Requires Profiler domain (check cdp_status domains.profiler).', {
     durationMs: z.number().int().min(500).max(30000).default(3000).optional()

--- a/scripts/cdp-bridge/dist/tools/wait-for-network.js
+++ b/scripts/cdp-bridge/dist/tools/wait-for-network.js
@@ -1,0 +1,100 @@
+import { okResult, withConnection } from '../utils.js';
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_POLL_INTERVAL_MS = 100;
+const CANDIDATES_CAP = 10;
+/**
+ * Normalize a user-supplied ISO-ish timestamp to the UTC Z-form that
+ * NetworkEntry.timestamp uses. Returns the input unchanged when not
+ * parseable, matching cdp_network_log's leniency (network-log.ts:31-35).
+ */
+export function normalizeSince(since) {
+    const parsed = new Date(since);
+    return Number.isNaN(parsed.getTime()) ? since : parsed.toISOString();
+}
+/**
+ * Build the URL-pattern + method + since match predicate. Does NOT
+ * include the completion gate — pair with isComplete to find fully-arrived
+ * responses, or use alone to also surface in-flight candidates.
+ *
+ * `since` must already be normalized via normalizeSince so lex-comparison
+ * against entry timestamps is correct.
+ */
+export function buildMatchPredicate(urlPattern, method, since) {
+    const wantedMethods = method === undefined
+        ? null
+        : (Array.isArray(method) ? method : [method]).map((m) => m.toUpperCase());
+    return (entry) => {
+        if (!entry.url.includes(urlPattern))
+            return false;
+        if (since !== undefined && entry.timestamp < since)
+            return false;
+        if (wantedMethods !== null && !wantedMethods.includes(entry.method.toUpperCase()))
+            return false;
+        return true;
+    };
+}
+/**
+ * Completion gate: the response (or terminal failure with status=0) has
+ * arrived. Separate from the match predicate so callers can differentiate
+ * "fully arrived" from "matched but still in-flight" in the timeout
+ * diagnostic payload.
+ */
+export function isComplete(entry) {
+    return entry.status !== undefined;
+}
+export function createWaitForNetworkHandler(getClient) {
+    // requireHelpers: false — this tool only reads the in-process network
+    // buffer (mutated by event-handlers.ts on Network.* CDP events). It never
+    // evaluates JS in Hermes, so the freshness probe is unnecessary work.
+    return withConnection(getClient, async (args, client) => {
+        const timeoutMs = args.timeout_ms ?? DEFAULT_TIMEOUT_MS;
+        const pollIntervalMs = args.poll_interval_ms ?? DEFAULT_POLL_INTERVAL_MS;
+        const since = args.since !== undefined ? normalizeSince(args.since) : undefined;
+        const scope = args.device ?? client.activeDeviceKey;
+        const predicate = buildMatchPredicate(args.url_pattern, args.method, since);
+        // Phase 1: retroactive scan — catches mutations already in the buffer
+        // (the common case when no `since` is set, or when `since` predates
+        // buffer entries that arrived during the MCP transport window).
+        const existing = client.networkBufferManager.filter(scope, predicate);
+        const found = existing.find(isComplete);
+        if (found) {
+            return okResult({ matched: true, mutation: found, network_log_since: existing, device: scope });
+        }
+        // Phase 2: poll the buffer until a completed match arrives or deadline.
+        // Buffer entries are mutated in-place by Network.responseReceived
+        // (event-handlers.ts:43), so polling the buffer is functionally
+        // equivalent to subscribing to the event stream.
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            // Bail early if the connection died mid-wait — otherwise we'd poll a
+            // frozen buffer for the full timeout duration. Match the convention
+            // from withConnection's reconnect loops (utils.ts:83, 96, 161, 167).
+            if (!client.isConnected) {
+                const partials = client.networkBufferManager.filter(scope, predicate);
+                return okResult({
+                    matched: false,
+                    timeout_ms: timeoutMs,
+                    candidates_seen: partials.slice(-CANDIDATES_CAP),
+                    device: scope,
+                    disconnected: true,
+                });
+            }
+            await new Promise((r) => setTimeout(r, pollIntervalMs));
+            const matches = client.networkBufferManager.filter(scope, predicate);
+            const hit = matches.find(isComplete);
+            if (hit) {
+                return okResult({ matched: true, mutation: hit, network_log_since: matches, device: scope });
+            }
+        }
+        // Timeout: surface up to CANDIDATES_CAP matched entries (completed or
+        // in-flight) so the agent can self-correct (e.g., wrong url_pattern →
+        // see what DID fire) without another tool roundtrip.
+        const finalMatches = client.networkBufferManager.filter(scope, predicate);
+        return okResult({
+            matched: false,
+            timeout_ms: timeoutMs,
+            candidates_seen: finalMatches.slice(-CANDIDATES_CAP),
+            device: scope,
+        });
+    }, { requireHelpers: false });
+}

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -16,6 +16,7 @@ import { createNavigationStateHandler } from './tools/navigation-state.js';
 import { createErrorLogHandler } from './tools/error-log.js';
 import { createNativeErrorsHandler } from './tools/native-errors.js';
 import { createNetworkLogHandler } from './tools/network-log.js';
+import { createWaitForNetworkHandler } from './tools/wait-for-network.js';
 import { createNetworkBodyHandler } from './tools/network-body.js';
 import { createHeapUsageHandler, createCpuProfileHandler } from './tools/profiling.js';
 import { createObjectInspectHandler } from './tools/object-inspect.js';
@@ -253,6 +254,20 @@ trackedTool(
     device: z.string().optional().describe('Device key to scope the lookup ("all" to search every device buffer). Defaults to the active device.'),
   },
   createNetworkBodyHandler(getClient),
+);
+
+trackedTool(
+  'cdp_wait_for_network',
+  'Block until a network request matching url_pattern (URL substring) and optional method completes (response received), or timeout_ms elapses. Two-phase: scans the existing buffer first (retroactive match), then polls every poll_interval_ms until deadline. Returns {matched:true, mutation, network_log_since} on success or {matched:false, timeout_ms, candidates_seen} (capped at 10) on timeout — never errors on timeout; agents should check `data.matched`. Use after triggering an action that fires a request to deterministically confirm it landed without buffer-churn races. Pin `since` to a timestamp captured BEFORE the trigger (Date.now() ISO) to also catch mutations that land in the MCP transport window.',
+  {
+    url_pattern: z.string().describe('URL substring to match (e.g. "/api/cart/add", "checkout"). Same matching semantics as cdp_network_log filter.'),
+    method: z.union([z.string(), z.array(z.string())]).optional().describe('HTTP method filter, case-insensitive (e.g. "POST" or ["POST","PUT"]). Omit to match any method.'),
+    timeout_ms: z.number().int().min(100).max(60000).default(5000).optional().describe('Max wait in ms (default 5000, range 100-60000)'),
+    poll_interval_ms: z.number().int().min(50).max(500).default(100).optional().describe('Buffer poll cadence in ms (default 100, range 50-500)'),
+    since: z.string().optional().describe('ISO timestamp checkpoint — ignore entries older than this. Defaults to the moment the tool is called. Capture `new Date().toISOString()` before the trigger action to avoid missing the mutation in the transport window.'),
+    device: z.string().optional().describe('Device key OR "all". Defaults to the active device.'),
+  },
+  createWaitForNetworkHandler(getClient),
 );
 
 trackedTool(

--- a/scripts/cdp-bridge/src/tools/wait-for-network.ts
+++ b/scripts/cdp-bridge/src/tools/wait-for-network.ts
@@ -1,0 +1,120 @@
+import type { CDPClient } from '../cdp-client.js';
+import type { NetworkEntry } from '../types.js';
+import { okResult, withConnection } from '../utils.js';
+
+export interface WaitForNetworkArgs {
+  url_pattern: string;
+  method?: string | string[];
+  timeout_ms?: number;
+  poll_interval_ms?: number;
+  since?: string;
+  device?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_POLL_INTERVAL_MS = 100;
+const CANDIDATES_CAP = 10;
+
+/**
+ * Normalize a user-supplied ISO-ish timestamp to the UTC Z-form that
+ * NetworkEntry.timestamp uses. Returns the input unchanged when not
+ * parseable, matching cdp_network_log's leniency (network-log.ts:31-35).
+ */
+export function normalizeSince(since: string): string {
+  const parsed = new Date(since);
+  return Number.isNaN(parsed.getTime()) ? since : parsed.toISOString();
+}
+
+/**
+ * Build the URL-pattern + method + since match predicate. Does NOT
+ * include the completion gate — pair with isComplete to find fully-arrived
+ * responses, or use alone to also surface in-flight candidates.
+ *
+ * `since` must already be normalized via normalizeSince so lex-comparison
+ * against entry timestamps is correct.
+ */
+export function buildMatchPredicate(
+  urlPattern: string,
+  method: string | string[] | undefined,
+  since: string | undefined,
+): (entry: NetworkEntry) => boolean {
+  const wantedMethods = method === undefined
+    ? null
+    : (Array.isArray(method) ? method : [method]).map((m) => m.toUpperCase());
+  return (entry) => {
+    if (!entry.url.includes(urlPattern)) return false;
+    if (since !== undefined && entry.timestamp < since) return false;
+    if (wantedMethods !== null && !wantedMethods.includes(entry.method.toUpperCase())) return false;
+    return true;
+  };
+}
+
+/**
+ * Completion gate: the response (or terminal failure with status=0) has
+ * arrived. Separate from the match predicate so callers can differentiate
+ * "fully arrived" from "matched but still in-flight" in the timeout
+ * diagnostic payload.
+ */
+export function isComplete(entry: NetworkEntry): boolean {
+  return entry.status !== undefined;
+}
+
+export function createWaitForNetworkHandler(getClient: () => CDPClient) {
+  // requireHelpers: false — this tool only reads the in-process network
+  // buffer (mutated by event-handlers.ts on Network.* CDP events). It never
+  // evaluates JS in Hermes, so the freshness probe is unnecessary work.
+  return withConnection(getClient, async (args: WaitForNetworkArgs, client) => {
+    const timeoutMs = args.timeout_ms ?? DEFAULT_TIMEOUT_MS;
+    const pollIntervalMs = args.poll_interval_ms ?? DEFAULT_POLL_INTERVAL_MS;
+    const since = args.since !== undefined ? normalizeSince(args.since) : undefined;
+    const scope = args.device ?? client.activeDeviceKey;
+    const predicate = buildMatchPredicate(args.url_pattern, args.method, since);
+
+    // Phase 1: retroactive scan — catches mutations already in the buffer
+    // (the common case when no `since` is set, or when `since` predates
+    // buffer entries that arrived during the MCP transport window).
+    const existing = client.networkBufferManager.filter(scope, predicate);
+    const found = existing.find(isComplete);
+    if (found) {
+      return okResult({ matched: true, mutation: found, network_log_since: existing, device: scope });
+    }
+
+    // Phase 2: poll the buffer until a completed match arrives or deadline.
+    // Buffer entries are mutated in-place by Network.responseReceived
+    // (event-handlers.ts:43), so polling the buffer is functionally
+    // equivalent to subscribing to the event stream.
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      // Bail early if the connection died mid-wait — otherwise we'd poll a
+      // frozen buffer for the full timeout duration. Match the convention
+      // from withConnection's reconnect loops (utils.ts:83, 96, 161, 167).
+      if (!client.isConnected) {
+        const partials = client.networkBufferManager.filter(scope, predicate);
+        return okResult({
+          matched: false,
+          timeout_ms: timeoutMs,
+          candidates_seen: partials.slice(-CANDIDATES_CAP),
+          device: scope,
+          disconnected: true,
+        });
+      }
+      await new Promise((r) => setTimeout(r, pollIntervalMs));
+      const matches = client.networkBufferManager.filter(scope, predicate);
+      const hit = matches.find(isComplete);
+      if (hit) {
+        return okResult({ matched: true, mutation: hit, network_log_since: matches, device: scope });
+      }
+    }
+
+    // Timeout: surface up to CANDIDATES_CAP matched entries (completed or
+    // in-flight) so the agent can self-correct (e.g., wrong url_pattern →
+    // see what DID fire) without another tool roundtrip.
+    const finalMatches = client.networkBufferManager.filter(scope, predicate);
+    return okResult({
+      matched: false,
+      timeout_ms: timeoutMs,
+      candidates_seen: finalMatches.slice(-CANDIDATES_CAP),
+      device: scope,
+    });
+  }, { requireHelpers: false });
+}

--- a/scripts/cdp-bridge/test/unit/wait-for-network.test.js
+++ b/scripts/cdp-bridge/test/unit/wait-for-network.test.js
@@ -1,0 +1,410 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  normalizeSince,
+  buildMatchPredicate,
+  isComplete,
+  createWaitForNetworkHandler,
+} from '../../dist/tools/wait-for-network.js';
+import { createMockClient } from '../helpers/mock-cdp-client.js';
+import { expectOk } from '../helpers/result-helpers.js';
+
+// GH #65 P3: cdp_wait_for_network — composite primitive that collapses the
+// "fire mutation -> confirm it landed" pattern into a single tool call.
+// Two-phase: retroactive buffer scan + bounded polling. Solves the
+// buffer-churn trap described in IX-2950 (where 4-5 follow-up GETs pushed
+// a POST out of a small filter window).
+//
+// Test coverage:
+//   1. Pure helpers (normalizeSince, buildMatchPredicate, isComplete) — exercise
+//      branch logic without spinning up withConnection.
+//   2. Handler integration — verify two-phase logic against a seeded mock buffer.
+
+// ── 1. normalizeSince ──
+
+test('normalizeSince: ISO with offset is normalised to UTC Z-form', () => {
+  const result = normalizeSince('2026-04-27T10:00:00+02:00');
+  assert.equal(result, '2026-04-27T08:00:00.000Z');
+});
+
+test('normalizeSince: already-Z string is unchanged', () => {
+  const iso = '2026-04-27T08:00:00.000Z';
+  assert.equal(normalizeSince(iso), iso);
+});
+
+test('normalizeSince: unparseable string returned as-is (matches network-log leniency)', () => {
+  assert.equal(normalizeSince('not-a-date'), 'not-a-date');
+});
+
+test('normalizeSince: numeric ms-string is unparseable (callers must pass ISO) — documents the gotcha', () => {
+  // new Date('1777284000000') returns Invalid Date because Date string parser
+  // does not accept bare numeric strings. Callers wanting ms-since-epoch must
+  // use `new Date(ms).toISOString()` instead. Same behaviour as network-log.ts.
+  const numericMs = String(Date.UTC(2026, 3, 27, 10, 0, 0));
+  assert.equal(normalizeSince(numericMs), numericMs, 'returned unchanged');
+  assert.equal(
+    normalizeSince(new Date(Number(numericMs)).toISOString()),
+    '2026-04-27T10:00:00.000Z',
+    'ISO form works correctly',
+  );
+});
+
+// ── 2. buildMatchPredicate ──
+
+function makeEntry(overrides = {}) {
+  return {
+    id: 'req-default',
+    method: 'GET',
+    url: '/api/users',
+    timestamp: '2026-04-27T08:00:00.000Z',
+    status: 200,
+    ...overrides,
+  };
+}
+
+test('buildMatchPredicate: matches on url_pattern substring', () => {
+  const pred = buildMatchPredicate('/api', undefined, undefined);
+  assert.ok(pred(makeEntry({ url: '/api/users' })));
+  assert.ok(!pred(makeEntry({ url: '/auth/login' })));
+});
+
+test('buildMatchPredicate: method filter is case-insensitive', () => {
+  const pred = buildMatchPredicate('/api', 'post', undefined);
+  assert.ok(pred(makeEntry({ url: '/api/cart', method: 'POST' })));
+  assert.ok(!pred(makeEntry({ url: '/api/cart', method: 'GET' })));
+});
+
+test('buildMatchPredicate: method as array allows multiple verbs', () => {
+  const pred = buildMatchPredicate('/api', ['POST', 'put'], undefined);
+  assert.ok(pred(makeEntry({ method: 'POST' })));
+  assert.ok(pred(makeEntry({ method: 'PUT' })));
+  assert.ok(!pred(makeEntry({ method: 'GET' })));
+});
+
+test('buildMatchPredicate: since cutoff drops earlier entries', () => {
+  const pred = buildMatchPredicate('/api', undefined, '2026-04-27T09:00:00.000Z');
+  assert.ok(pred(makeEntry({ timestamp: '2026-04-27T10:00:00.000Z' })));
+  assert.ok(!pred(makeEntry({ timestamp: '2026-04-27T08:00:00.000Z' })));
+});
+
+test('buildMatchPredicate: AND-combines all filters', () => {
+  const pred = buildMatchPredicate('/cart', 'POST', '2026-04-27T09:00:00.000Z');
+  const match = makeEntry({ url: '/api/cart', method: 'POST', timestamp: '2026-04-27T10:00:00.000Z' });
+  assert.ok(pred(match));
+  assert.ok(!pred({ ...match, method: 'GET' }), 'wrong method fails');
+  assert.ok(!pred({ ...match, url: '/api/users' }), 'wrong url fails');
+  assert.ok(!pred({ ...match, timestamp: '2026-04-27T08:00:00.000Z' }), 'pre-since fails');
+});
+
+test('buildMatchPredicate: undefined method matches any HTTP verb', () => {
+  const pred = buildMatchPredicate('/api', undefined, undefined);
+  assert.ok(pred(makeEntry({ method: 'DELETE' })));
+  assert.ok(pred(makeEntry({ method: 'PATCH' })));
+});
+
+test('buildMatchPredicate: undefined since allows any age', () => {
+  const pred = buildMatchPredicate('/api', undefined, undefined);
+  assert.ok(pred(makeEntry({ timestamp: '1970-01-01T00:00:00.000Z' })));
+});
+
+test('buildMatchPredicate: in-flight entry (status undefined) still matches — gate is separate', () => {
+  // Predicate intentionally does NOT include the completion gate. Pair with
+  // isComplete to find completed responses; use predicate alone to also
+  // surface in-flight candidates on timeout.
+  const pred = buildMatchPredicate('/api', undefined, undefined);
+  const inflight = { ...makeEntry({ url: '/api/slow' }), status: undefined };
+  delete inflight.status;
+  assert.ok(pred(inflight));
+});
+
+// ── 3. isComplete ──
+
+test('isComplete: status defined (success) → true', () => {
+  assert.ok(isComplete(makeEntry({ status: 200 })));
+  assert.ok(isComplete(makeEntry({ status: 404 })));
+});
+
+test('isComplete: status=0 (Network.loadingFailed) → true (terminal failure is complete)', () => {
+  assert.ok(isComplete(makeEntry({ status: 0 })));
+});
+
+test('isComplete: status undefined (request still in-flight) → false', () => {
+  const inflight = { ...makeEntry() };
+  delete inflight.status;
+  assert.ok(!isComplete(inflight));
+});
+
+// ── 4. Handler integration tests ──
+
+function pushEntry(client, overrides = {}) {
+  const entry = makeEntry({
+    id: `req-${Math.random().toString(36).slice(2, 9)}`,
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  });
+  client.networkBufferManager.push(client.activeDeviceKey, entry);
+  return entry;
+}
+
+test('handler: retroactive match — completed entry already in buffer returns immediately', async () => {
+  const client = createMockClient();
+  const past = new Date(Date.now() - 60_000).toISOString();
+  pushEntry(client, { url: '/api/cart/add', method: 'POST', status: 201 });
+
+  const handler = createWaitForNetworkHandler(() => client);
+  const data = expectOk(await handler({
+    url_pattern: '/api/cart',
+    method: 'POST',
+    since: past,
+    timeout_ms: 500,
+    poll_interval_ms: 50,
+  }));
+
+  assert.equal(data.matched, true);
+  assert.equal(data.mutation.url, '/api/cart/add');
+  assert.equal(data.mutation.status, 201);
+  assert.ok(Array.isArray(data.network_log_since));
+});
+
+test('handler: timeout with no matching entries — matched:false, empty candidates_seen', async () => {
+  const client = createMockClient();
+  const handler = createWaitForNetworkHandler(() => client);
+  const data = expectOk(await handler({
+    url_pattern: '/api/never',
+    timeout_ms: 150,
+    poll_interval_ms: 50,
+  }));
+
+  assert.equal(data.matched, false);
+  assert.equal(data.timeout_ms, 150);
+  assert.deepEqual(data.candidates_seen, []);
+});
+
+test('handler: timeout with in-flight match — surfaces in-flight in candidates_seen', async () => {
+  const client = createMockClient();
+  const past = new Date(Date.now() - 60_000).toISOString();
+  // Push an entry that matches url+method+since but lacks status (in-flight)
+  const inflight = makeEntry({ id: 'req-pending', url: '/api/checkout', method: 'POST', timestamp: new Date().toISOString() });
+  delete inflight.status;
+  client.networkBufferManager.push(client.activeDeviceKey, inflight);
+
+  const handler = createWaitForNetworkHandler(() => client);
+  const data = expectOk(await handler({
+    url_pattern: '/api/checkout',
+    method: 'POST',
+    since: past,
+    timeout_ms: 150,
+    poll_interval_ms: 50,
+  }));
+
+  assert.equal(data.matched, false);
+  assert.ok(data.candidates_seen.some((e) => e.id === 'req-pending'),
+    'in-flight match should appear in candidates_seen for agent self-correction');
+});
+
+test('handler: method filter excludes non-matching verbs', async () => {
+  const client = createMockClient();
+  const past = new Date(Date.now() - 60_000).toISOString();
+  pushEntry(client, { url: '/api/cart', method: 'GET', status: 200 });
+
+  const handler = createWaitForNetworkHandler(() => client);
+  const data = expectOk(await handler({
+    url_pattern: '/api/cart',
+    method: 'POST',
+    since: past,
+    timeout_ms: 150,
+    poll_interval_ms: 50,
+  }));
+
+  assert.equal(data.matched, false, 'GET should not satisfy POST filter');
+});
+
+test('handler: explicit since cutoff excludes entries older than the timestamp', async () => {
+  const client = createMockClient();
+  pushEntry(client, {
+    url: '/api/cart',
+    method: 'POST',
+    status: 201,
+    timestamp: '2020-01-01T00:00:00.000Z',
+  });
+
+  const handler = createWaitForNetworkHandler(() => client);
+  const data = expectOk(await handler({
+    url_pattern: '/api/cart',
+    since: '2025-01-01T00:00:00.000Z',
+    timeout_ms: 150,
+    poll_interval_ms: 50,
+  }));
+
+  assert.equal(data.matched, false);
+});
+
+test('handler: omitting since means no cutoff — retroactive scan finds completed entries', async () => {
+  // The Phase 1 scan needs to work without forcing the agent to capture
+  // a timestamp before every trigger action. With `since` undefined, the
+  // predicate has no cutoff and any matching completed entry in the
+  // buffer is found immediately.
+  const client = createMockClient();
+  pushEntry(client, {
+    url: '/api/profile/save',
+    method: 'PUT',
+    status: 200,
+    timestamp: new Date(Date.now() - 5000).toISOString(),
+  });
+
+  const handler = createWaitForNetworkHandler(() => client);
+  const data = expectOk(await handler({
+    url_pattern: '/api/profile',
+    method: 'PUT',
+    timeout_ms: 150,
+    poll_interval_ms: 50,
+  }));
+
+  assert.equal(data.matched, true);
+  assert.equal(data.mutation.status, 200);
+});
+
+test('handler: candidates_seen capped at 10 even with many in-flight matches', async () => {
+  const client = createMockClient();
+  const past = new Date(Date.now() - 60_000).toISOString();
+  for (let i = 0; i < 15; i++) {
+    const inflight = makeEntry({
+      id: `req-pending-${i}`,
+      url: '/api/data',
+      method: 'GET',
+      timestamp: new Date().toISOString(),
+    });
+    delete inflight.status;
+    client.networkBufferManager.push(client.activeDeviceKey, inflight);
+  }
+
+  const handler = createWaitForNetworkHandler(() => client);
+  const data = expectOk(await handler({
+    url_pattern: '/api/data',
+    since: past,
+    timeout_ms: 150,
+    poll_interval_ms: 50,
+  }));
+
+  assert.equal(data.matched, false);
+  assert.equal(data.candidates_seen.length, 10);
+});
+
+test('handler: poll match — entry completes during polling window', async () => {
+  const client = createMockClient();
+  const past = new Date(Date.now() - 60_000).toISOString();
+
+  // Seed an in-flight entry that we'll mutate to "complete" mid-poll.
+  const entry = makeEntry({
+    id: 'req-async',
+    url: '/api/profile',
+    method: 'PUT',
+    timestamp: new Date().toISOString(),
+  });
+  delete entry.status;
+  client.networkBufferManager.push(client.activeDeviceKey, entry);
+
+  // After the first poll tick, simulate Network.responseReceived by
+  // mutating the entry in place — same pattern as event-handlers.ts:40.
+  setTimeout(() => {
+    entry.status = 200;
+    entry.duration_ms = 35;
+  }, 75);
+
+  const handler = createWaitForNetworkHandler(() => client);
+  const data = expectOk(await handler({
+    url_pattern: '/api/profile',
+    method: 'PUT',
+    since: past,
+    timeout_ms: 1000,
+    poll_interval_ms: 50,
+  }));
+
+  assert.equal(data.matched, true);
+  assert.equal(data.mutation.id, 'req-async');
+  assert.equal(data.mutation.status, 200);
+});
+
+test('handler: status=0 (loadingFailed) is treated as completed and matches', async () => {
+  const client = createMockClient();
+  const past = new Date(Date.now() - 60_000).toISOString();
+  pushEntry(client, {
+    url: '/api/network-error',
+    method: 'POST',
+    status: 0, // Network.loadingFailed sets status=0
+    duration_ms: 100,
+  });
+
+  const handler = createWaitForNetworkHandler(() => client);
+  const data = expectOk(await handler({
+    url_pattern: '/api/network-error',
+    since: past,
+    timeout_ms: 150,
+    poll_interval_ms: 50,
+  }));
+
+  assert.equal(data.matched, true);
+  assert.equal(data.mutation.status, 0);
+});
+
+test('handler: response payload includes device scope for multi-device disambiguation', async () => {
+  // Sibling cdp_network_log returns `device: scope` in its envelope so
+  // multi-device sessions can attribute results. Match that contract.
+  const client = createMockClient();
+  pushEntry(client, { url: '/api/cart', method: 'POST', status: 201 });
+
+  const handler = createWaitForNetworkHandler(() => client);
+  const data = expectOk(await handler({
+    url_pattern: '/api/cart',
+    timeout_ms: 150,
+    poll_interval_ms: 50,
+  }));
+
+  assert.equal(data.matched, true);
+  assert.equal(data.device, '8081-page1', 'matches mock client activeDeviceKey');
+});
+
+test('handler: explicit device override is reflected in payload', async () => {
+  const client = createMockClient();
+  // Push to a non-default device bucket
+  client.networkBufferManager.push('9000-other-target', {
+    id: 'req-other',
+    method: 'POST',
+    url: '/api/cart',
+    timestamp: new Date().toISOString(),
+    status: 201,
+  });
+
+  const handler = createWaitForNetworkHandler(() => client);
+  const data = expectOk(await handler({
+    url_pattern: '/api/cart',
+    device: '9000-other-target',
+    timeout_ms: 150,
+    poll_interval_ms: 50,
+  }));
+
+  assert.equal(data.matched, true);
+  assert.equal(data.device, '9000-other-target');
+});
+
+test('handler: connection lost mid-poll returns matched:false with disconnected:true', async () => {
+  const client = createMockClient();
+
+  // Drop the connection after the first poll tick. Without the in-loop
+  // isConnected guard, the handler would wait the full timeout against a
+  // frozen buffer.
+  setTimeout(() => { client._isConnected = false; }, 75);
+
+  const handler = createWaitForNetworkHandler(() => client);
+  const t0 = Date.now();
+  const data = expectOk(await handler({
+    url_pattern: '/api/never',
+    timeout_ms: 2000,
+    poll_interval_ms: 50,
+  }));
+  const elapsed = Date.now() - t0;
+
+  assert.equal(data.matched, false);
+  assert.equal(data.disconnected, true);
+  assert.ok(elapsed < 500, `disconnect should short-circuit, got ${elapsed}ms`);
+});


### PR DESCRIPTION
…buffer-churn races

Closes the "fire mutation -> confirm it landed" agent loop into a single deterministic tool call. Two-phase design: scan existing buffer first (retroactive match), then poll until match or deadline. Buffer entries mutate in-place when Network.responseReceived arrives, so polling the buffer is functionally equivalent to subscribing.

Returns okResult on both success and timeout — agents check data.matched, never result.isError. On timeout, surfaces up to 10 candidates_seen (matching but in-flight) so the agent can self-correct without another tool roundtrip.

Three exported helpers (normalizeSince, buildMatchPredicate, isComplete) matching the mmkv.ts testability precedent. requireHelpers: false skips the freshness probe — this tool reads only the buffer, never evaluates Hermes JS.

Reviewer-caught fixes pre-merge:
- In-loop isConnected guard: bails on disconnect rather than polling a frozen buffer for the full timeout window
- since defaults to undefined (not new Date().toISOString() at entry), so Phase 1 retroactive scan actually finds pre-existing entries
- device: scope in payload — matches sibling cdp_network_log convention

Decision logged as D682. 27 new unit tests; 813 total passing (no regressions). Closes #65 P3; sibling #73 closeable separately (its proposed filters already shipped in cdp_network_log).

Bench: scripts/cdp-bridge/bench/wait-for-network.bench.mjs
- Phase 1 retroactive hit: p50 = 3 us (vs ~60s of agent-loop time this replaces in IX-2950)
- Poll hit at 50ms cadence: p50 = 102 ms (entry-completes + cadence)
- Timeout 500ms: p50 = 506 ms (5ms tail latency)
- Disconnect bail-out: p50 = 102 ms (vs 5000ms wasted polling without the in-loop isConnected guard)