### PR TITLE
fix(gh-60-5): tier accessibilityLabel matching + expand component_tree filter

### DIFF
--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -107,7 +107,7 @@ trackedTool('cdp_reload', 'Trigger a full reload of the app. Auto-reconnects to 
     full: z.boolean().default(true).describe('Always performs a full reload via DevSettings.reload()'),
 }, createReloadHandler(getClient, setClient, createClient));
 trackedTool('cdp_component_tree', 'Get React component tree. Returns components with props, state, testIDs. Use filter to scope to a specific subtree — NEVER request full tree unless necessary (saves tokens). Detects RedBox and warns.', {
-    filter: z.string().optional().describe('Component name or testID to scope query (e.g. "CartBadge", "product-list")'),
+    filter: z.string().optional().describe('Case-insensitive substring match against component name, testID/nativeID, or accessibilityLabel (e.g. "CartBadge", "product-list", "Continue")'),
     depth: z.number().int().min(1).max(12).default(4).describe('Max depth (default 4, max 12)'),
 }, createComponentTreeHandler(getClient));
 trackedTool('cdp_navigation_state', 'Get current navigation state: active route, params, stack history, nested navigators, active tab. Works with React Navigation and Expo Router.', {}, createNavigationStateHandler(getClient));
@@ -303,10 +303,10 @@ trackedTool('cdp_dev_settings', 'Control React Native dev settings programmatica
     action: z.enum(['reload', 'toggleInspector', 'togglePerfMonitor', 'dismissRedBox', 'disableDevMenu'])
         .describe('Dev menu action to execute'),
 }, createDevSettingsHandler(getClient));
-trackedTool('cdp_interact', 'Interact with React components by testID — press buttons, long-press, type text, scroll. Calls JS handlers directly (not native touch). Reliable for all React-level interactions including elements inside gesture handlers. For native gestures (swipe, drag), use device_swipe/device_press instead.', {
+trackedTool('cdp_interact', 'Interact with React components by testID (preferred) or accessibilityLabel — press buttons, long-press, type text, scroll. Calls JS handlers directly (not native touch). testID matches strictly; accessibilityLabel matches in tiers (exact → trim/case-insensitive → substring) and returns an ambiguity error when >1 component matches. Prefer testID for unambiguous targeting. For native gestures (swipe, drag), use device_swipe/device_press instead.', {
     action: z.enum(['press', 'longPress', 'typeText', 'scroll']).describe('press: calls onPress. longPress: calls onLongPress. typeText: calls onChangeText. scroll: calls scrollTo or onScroll.'),
-    testID: z.string().optional().describe('testID prop of the target component'),
-    accessibilityLabel: z.string().optional().describe('accessibilityLabel prop (used if testID not provided)'),
+    testID: z.string().optional().describe('testID prop of the target component (strict match — preferred)'),
+    accessibilityLabel: z.string().optional().describe('accessibilityLabel prop (used if testID not provided). Tiered match: exact → normalized (trim+lowercase) → substring. Returns Ambiguous error if >1 component matches.'),
     text: z.string().optional().describe('Required for typeText: the text to enter'),
     scrollX: z.number().optional().describe('For scroll: horizontal offset in pixels (default 0)'),
     scrollY: z.number().optional().describe('For scroll: vertical offset in pixels (default 300)'),

--- a/scripts/cdp-bridge/dist/injected-helpers.js
+++ b/scripts/cdp-bridge/dist/injected-helpers.js
@@ -1,6 +1,6 @@
 export const INJECTED_HELPERS = `
 (function() {
-  var __HELPERS_VERSION__ = 19;
+  var __HELPERS_VERSION__ = 20;
   if (globalThis.__RN_AGENT && globalThis.__RN_AGENT.__v === __HELPERS_VERSION__) return;
   if (globalThis.__RN_AGENT) delete globalThis.__RN_AGENT;
 
@@ -304,9 +304,11 @@ export const INJECTED_HELPERS = `
         scanned++;
         var fname = getName(fiber);
         var ftid = fiber.memoizedProps && (fiber.memoizedProps.testID || fiber.memoizedProps.nativeID);
+        var flabel = fiber.memoizedProps && fiber.memoizedProps.accessibilityLabel;
         var matchesName = fname && fname.toLowerCase().indexOf(f) >= 0;
-        var matchesTestID = ftid && ftid.toLowerCase().indexOf(f) >= 0;
-        if ((matchesName || matchesTestID) && !hasMatchedAncestor(fiber)) {
+        var matchesTestID = ftid && String(ftid).toLowerCase().indexOf(f) >= 0;
+        var matchesLabel = flabel && String(flabel).toLowerCase().indexOf(f) >= 0;
+        if ((matchesName || matchesTestID || matchesLabel) && !hasMatchedAncestor(fiber)) {
           matchFibers.push(fiber);
           matchFiberSet.add(fiber);
         }
@@ -914,6 +916,7 @@ export const INJECTED_HELPERS = `
     var action = opts.action;
     var selector = opts.testID || opts.accessibilityLabel;
     var matchField = opts.testID ? 'testID' : 'accessibilityLabel';
+    var isLabelMatch = matchField === 'accessibilityLabel';
 
     if (!action) return JSON.stringify({ error: 'action is required' });
     if (!selector) return JSON.stringify({ error: 'testID or accessibilityLabel is required' });
@@ -921,29 +924,97 @@ export const INJECTED_HELPERS = `
     var found = null;
     var findCount = 0;
 
+    // B5/D684: testID stays strict + early-return (fast happy path).
+    // accessibilityLabel uses tiered matching: exact === → normalized
+    // (trim+collapse-ws+lowercase) → substring contains. Ambiguity in the
+    // looser tiers surfaces as a structured error so we never silently pick
+    // among multiple "Continue" buttons.
+    function norm(v) {
+      return String(v).replace(/\\s+/g, ' ').replace(/^\\s+|\\s+$/g, '').toLowerCase();
+    }
+    var normSelector = isLabelMatch ? norm(selector) : null;
+    var exactMatches = [];
+    var normMatches = [];
+    var containsMatches = [];
+
     function findFiber(fiber) {
       var current = fiber;
       while (current) {
         findCount++;
         if (findCount > 8000) return;
         var props = current.memoizedProps;
-        if (props && props[matchField] === selector) {
-          found = current;
-          return;
+        if (props) {
+          if (!isLabelMatch) {
+            if (props[matchField] === selector) {
+              found = current;
+              return;
+            }
+          } else {
+            var raw = props.accessibilityLabel;
+            if (raw !== undefined && raw !== null && raw !== '') {
+              if (raw === selector) {
+                exactMatches.push(current);
+              } else {
+                var nv = norm(raw);
+                if (nv === normSelector) {
+                  normMatches.push(current);
+                } else if (nv.indexOf(normSelector) >= 0) {
+                  containsMatches.push(current);
+                }
+              }
+            }
+          }
         }
         if (current.child) findFiber(current.child);
-        if (found) return;
+        if (!isLabelMatch && found) return;
         current = current.sibling;
       }
     }
 
     // B145: walk root.current across every renderer until the testID is
     // found. Previously only the first renderer's roots were searched.
+    // For label matching, walk ALL renderers (no short-circuit) so duplicate
+    // labels split across renderers (LogBox vs Fabric) are detected.
     forEachRootFiber(function(rootFiber) {
-      if (found) return found; // short-circuit forEachRootFiber
+      if (!isLabelMatch && found) return found;
       findFiber(rootFiber);
-      return found;
+      return isLabelMatch ? null : found;
     });
+
+    if (isLabelMatch) {
+      var tier = exactMatches.length > 0
+        ? exactMatches
+        : (normMatches.length > 0 ? normMatches : containsMatches);
+      if (tier.length === 0) {
+        return JSON.stringify({
+          error: 'Component not found',
+          selector: selector,
+          matchField: matchField,
+          hint: 'Tried exact, case/whitespace-normalized, and substring match. Use cdp_component_tree filter:"' + selector + '" to verify the label is mounted, or pass a testID instead.'
+        });
+      }
+      if (tier.length > 1) {
+        var descriptors = [];
+        for (var di = 0; di < tier.length && di < 10; di++) {
+          var dp = tier[di].memoizedProps || {};
+          var dt = (tier[di].type && (tier[di].type.displayName || tier[di].type.name)) || 'Unknown';
+          descriptors.push({
+            component: dt,
+            testID: dp.testID,
+            accessibilityLabel: dp.accessibilityLabel,
+          });
+        }
+        return JSON.stringify({
+          error: 'Ambiguous component match',
+          selector: selector,
+          matchField: matchField,
+          count: tier.length,
+          matches: descriptors,
+          hint: 'Multiple components match this accessibilityLabel. Add a testID to the target component for unambiguous matching.'
+        });
+      }
+      found = tier[0];
+    }
 
     if (!found) {
       return JSON.stringify({

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -179,7 +179,7 @@ trackedTool(
   'cdp_component_tree',
   'Get React component tree. Returns components with props, state, testIDs. Use filter to scope to a specific subtree — NEVER request full tree unless necessary (saves tokens). Detects RedBox and warns.',
   {
-    filter: z.string().optional().describe('Component name or testID to scope query (e.g. "CartBadge", "product-list")'),
+    filter: z.string().optional().describe('Case-insensitive substring match against component name, testID/nativeID, or accessibilityLabel (e.g. "CartBadge", "product-list", "Continue")'),
     depth: z.number().int().min(1).max(12).default(4).describe('Max depth (default 4, max 12)'),
   },
   createComponentTreeHandler(getClient),
@@ -473,11 +473,11 @@ trackedTool(
 
 trackedTool(
   'cdp_interact',
-  'Interact with React components by testID — press buttons, long-press, type text, scroll. Calls JS handlers directly (not native touch). Reliable for all React-level interactions including elements inside gesture handlers. For native gestures (swipe, drag), use device_swipe/device_press instead.',
+  'Interact with React components by testID (preferred) or accessibilityLabel — press buttons, long-press, type text, scroll. Calls JS handlers directly (not native touch). testID matches strictly; accessibilityLabel matches in tiers (exact → trim/case-insensitive → substring) and returns an ambiguity error when >1 component matches. Prefer testID for unambiguous targeting. For native gestures (swipe, drag), use device_swipe/device_press instead.',
   {
     action: z.enum(['press', 'longPress', 'typeText', 'scroll']).describe('press: calls onPress. longPress: calls onLongPress. typeText: calls onChangeText. scroll: calls scrollTo or onScroll.'),
-    testID: z.string().optional().describe('testID prop of the target component'),
-    accessibilityLabel: z.string().optional().describe('accessibilityLabel prop (used if testID not provided)'),
+    testID: z.string().optional().describe('testID prop of the target component (strict match — preferred)'),
+    accessibilityLabel: z.string().optional().describe('accessibilityLabel prop (used if testID not provided). Tiered match: exact → normalized (trim+lowercase) → substring. Returns Ambiguous error if >1 component matches.'),
     text: z.string().optional().describe('Required for typeText: the text to enter'),
     scrollX: z.number().optional().describe('For scroll: horizontal offset in pixels (default 0)'),
     scrollY: z.number().optional().describe('For scroll: vertical offset in pixels (default 300)'),

--- a/scripts/cdp-bridge/src/injected-helpers.ts
+++ b/scripts/cdp-bridge/src/injected-helpers.ts
@@ -1,6 +1,6 @@
 export const INJECTED_HELPERS = `
 (function() {
-  var __HELPERS_VERSION__ = 19;
+  var __HELPERS_VERSION__ = 20;
   if (globalThis.__RN_AGENT && globalThis.__RN_AGENT.__v === __HELPERS_VERSION__) return;
   if (globalThis.__RN_AGENT) delete globalThis.__RN_AGENT;
 
@@ -304,9 +304,11 @@ export const INJECTED_HELPERS = `
         scanned++;
         var fname = getName(fiber);
         var ftid = fiber.memoizedProps && (fiber.memoizedProps.testID || fiber.memoizedProps.nativeID);
+        var flabel = fiber.memoizedProps && fiber.memoizedProps.accessibilityLabel;
         var matchesName = fname && fname.toLowerCase().indexOf(f) >= 0;
-        var matchesTestID = ftid && ftid.toLowerCase().indexOf(f) >= 0;
-        if ((matchesName || matchesTestID) && !hasMatchedAncestor(fiber)) {
+        var matchesTestID = ftid && String(ftid).toLowerCase().indexOf(f) >= 0;
+        var matchesLabel = flabel && String(flabel).toLowerCase().indexOf(f) >= 0;
+        if ((matchesName || matchesTestID || matchesLabel) && !hasMatchedAncestor(fiber)) {
           matchFibers.push(fiber);
           matchFiberSet.add(fiber);
         }
@@ -914,6 +916,7 @@ export const INJECTED_HELPERS = `
     var action = opts.action;
     var selector = opts.testID || opts.accessibilityLabel;
     var matchField = opts.testID ? 'testID' : 'accessibilityLabel';
+    var isLabelMatch = matchField === 'accessibilityLabel';
 
     if (!action) return JSON.stringify({ error: 'action is required' });
     if (!selector) return JSON.stringify({ error: 'testID or accessibilityLabel is required' });
@@ -921,29 +924,97 @@ export const INJECTED_HELPERS = `
     var found = null;
     var findCount = 0;
 
+    // B5/D684: testID stays strict + early-return (fast happy path).
+    // accessibilityLabel uses tiered matching: exact === → normalized
+    // (trim+collapse-ws+lowercase) → substring contains. Ambiguity in the
+    // looser tiers surfaces as a structured error so we never silently pick
+    // among multiple "Continue" buttons.
+    function norm(v) {
+      return String(v).replace(/\\s+/g, ' ').replace(/^\\s+|\\s+$/g, '').toLowerCase();
+    }
+    var normSelector = isLabelMatch ? norm(selector) : null;
+    var exactMatches = [];
+    var normMatches = [];
+    var containsMatches = [];
+
     function findFiber(fiber) {
       var current = fiber;
       while (current) {
         findCount++;
         if (findCount > 8000) return;
         var props = current.memoizedProps;
-        if (props && props[matchField] === selector) {
-          found = current;
-          return;
+        if (props) {
+          if (!isLabelMatch) {
+            if (props[matchField] === selector) {
+              found = current;
+              return;
+            }
+          } else {
+            var raw = props.accessibilityLabel;
+            if (raw !== undefined && raw !== null && raw !== '') {
+              if (raw === selector) {
+                exactMatches.push(current);
+              } else {
+                var nv = norm(raw);
+                if (nv === normSelector) {
+                  normMatches.push(current);
+                } else if (nv.indexOf(normSelector) >= 0) {
+                  containsMatches.push(current);
+                }
+              }
+            }
+          }
         }
         if (current.child) findFiber(current.child);
-        if (found) return;
+        if (!isLabelMatch && found) return;
         current = current.sibling;
       }
     }
 
     // B145: walk root.current across every renderer until the testID is
     // found. Previously only the first renderer's roots were searched.
+    // For label matching, walk ALL renderers (no short-circuit) so duplicate
+    // labels split across renderers (LogBox vs Fabric) are detected.
     forEachRootFiber(function(rootFiber) {
-      if (found) return found; // short-circuit forEachRootFiber
+      if (!isLabelMatch && found) return found;
       findFiber(rootFiber);
-      return found;
+      return isLabelMatch ? null : found;
     });
+
+    if (isLabelMatch) {
+      var tier = exactMatches.length > 0
+        ? exactMatches
+        : (normMatches.length > 0 ? normMatches : containsMatches);
+      if (tier.length === 0) {
+        return JSON.stringify({
+          error: 'Component not found',
+          selector: selector,
+          matchField: matchField,
+          hint: 'Tried exact, case/whitespace-normalized, and substring match. Use cdp_component_tree filter:"' + selector + '" to verify the label is mounted, or pass a testID instead.'
+        });
+      }
+      if (tier.length > 1) {
+        var descriptors = [];
+        for (var di = 0; di < tier.length && di < 10; di++) {
+          var dp = tier[di].memoizedProps || {};
+          var dt = (tier[di].type && (tier[di].type.displayName || tier[di].type.name)) || 'Unknown';
+          descriptors.push({
+            component: dt,
+            testID: dp.testID,
+            accessibilityLabel: dp.accessibilityLabel,
+          });
+        }
+        return JSON.stringify({
+          error: 'Ambiguous component match',
+          selector: selector,
+          matchField: matchField,
+          count: tier.length,
+          matches: descriptors,
+          hint: 'Multiple components match this accessibilityLabel. Add a testID to the target component for unambiguous matching.'
+        });
+      }
+      found = tier[0];
+    }
 
     if (!found) {
       return JSON.stringify({

--- a/scripts/cdp-bridge/test/unit/find-active-renderer-migration.test.js
+++ b/scripts/cdp-bridge/test/unit/find-active-renderer-migration.test.js
@@ -55,12 +55,15 @@ test('B145: findNavRef walks all renderers for NavigationContainer ref', () => {
 });
 
 test('B145: interact tool walks all renderers for the testID', () => {
-  // The pattern is: forEachRootFiber(fn => { findFiber(rootFiber); return found; })
+  // GH #60-5: testID early-returns `found`; accessibilityLabel walks every
+  // renderer and collects matches across them, so the callback can return
+  // null to keep iterating. We assert the callback uses both findFiber and
+  // forEachRootFiber, without pinning the exact return statement.
   const src = INJECTED_HELPERS;
   const idx = src.indexOf('function interact');
   assert.ok(idx >= 0, 'interact definition missing');
   const slice = src.slice(idx, idx + 3000);
-  assert.match(slice, /forEachRootFiber\(function\(rootFiber\)\s*\{[\s\S]*?findFiber\(rootFiber\);[\s\S]*?return found;/, 'interact did not migrate to forEachRootFiber');
+  assert.match(slice, /forEachRootFiber\(function\(rootFiber\)\s*\{[\s\S]*?findFiber\(rootFiber\);/, 'interact did not call findFiber inside forEachRootFiber');
 });
 
 test('B145: getComponentState walks all renderers for the testID', () => {

--- a/scripts/cdp-bridge/test/unit/gh-60-bug-5-label-matching.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-60-bug-5-label-matching.test.js
@@ -1,0 +1,329 @@
+// GH #60 Bug 5 / D684: cdp_interact accessibilityLabel matching was strict-equal
+// only — case/whitespace differences (and non-exact strings like "Continue" vs
+// "Continue button") returned "Component not found" on visible buttons.
+// cdp_component_tree filter only matched component name + testID/nativeID, so
+// "Home" against a tab labeled accessibilityLabel="Home" returned tree:null.
+//
+// Fix: tiered match for the accessibilityLabel branch of interact() (exact →
+// trim+lowercase → substring) with a structured Ambiguous error when the
+// chosen tier has >1 hit. testID stays strict + early-return. getTree filter
+// gains accessibilityLabel as a third matched field.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import vm from 'node:vm';
+import { INJECTED_HELPERS } from '../../dist/injected-helpers.js';
+
+function createSandbox(opts = {}) {
+  const sandbox = {
+    Array, Object, JSON, Map, WeakSet, Error, Date, parseInt, parseFloat,
+    console: { log() {}, error() {}, warn() {}, info() {}, debug() {} },
+    String, Number, Boolean, RegExp, Symbol, Set, Promise, setTimeout, clearTimeout,
+  };
+  sandbox.globalThis = sandbox;
+
+  if (opts.fiberRoot) {
+    sandbox.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+      renderers: new Map([[1, {}]]),
+      getFiberRoots: (id) => id === 1 ? new Set([{ current: opts.fiberRoot }]) : new Set(),
+    };
+  }
+
+  vm.createContext(sandbox);
+  vm.runInContext(INJECTED_HELPERS, sandbox);
+  return sandbox;
+}
+
+// Build a simple fiber tree: parent → child → sibling chain
+// Each spec is { name, props, children?, sibling? }
+function buildFiber(spec, parent = null) {
+  const fiber = {
+    type: spec.name ? { displayName: spec.name } : null,
+    memoizedProps: spec.props || {},
+    return: parent,
+    child: null,
+    sibling: null,
+    stateNode: spec.stateNode || null,
+  };
+  if (spec.children && spec.children.length > 0) {
+    let prev = null;
+    for (const c of spec.children) {
+      const child = buildFiber(c, fiber);
+      if (!fiber.child) fiber.child = child;
+      else prev.sibling = child;
+      prev = child;
+    }
+  }
+  return fiber;
+}
+
+// ── interact() — testID strict equality (regression guard) ──────────────
+
+test('interact: testID exact match still works (strict ===)', () => {
+  const root = buildFiber({
+    name: 'App',
+    children: [
+      { name: 'Pressable', props: { testID: 'continue-btn', onPress: () => {} } },
+    ],
+  });
+  const sandbox = createSandbox({ fiberRoot: root });
+  const result = JSON.parse(sandbox.__RN_AGENT.interact({ action: 'press', testID: 'continue-btn' }));
+  assert.equal(result.success, true);
+  assert.equal(result.testID, 'continue-btn');
+});
+
+test('interact: testID case-mismatch still fails (testID stays strict)', () => {
+  const root = buildFiber({
+    name: 'App',
+    children: [
+      { name: 'Pressable', props: { testID: 'Continue-Btn', onPress: () => {} } },
+    ],
+  });
+  const sandbox = createSandbox({ fiberRoot: root });
+  const result = JSON.parse(sandbox.__RN_AGENT.interact({ action: 'press', testID: 'continue-btn' }));
+  assert.equal(result.error, 'Component not found');
+});
+
+// ── interact() — accessibilityLabel tier 1: exact match ─────────────────
+
+test('interact: accessibilityLabel exact === match presses', () => {
+  let pressed = false;
+  const root = buildFiber({
+    name: 'App',
+    children: [
+      { name: 'Pressable', props: { accessibilityLabel: 'Continue', onPress: () => { pressed = true; } } },
+    ],
+  });
+  const sandbox = createSandbox({ fiberRoot: root });
+  const result = JSON.parse(sandbox.__RN_AGENT.interact({ action: 'press', accessibilityLabel: 'Continue' }));
+  assert.equal(result.success, true);
+  assert.equal(pressed, true);
+});
+
+// ── interact() — tier 2: normalized match (trim + collapse-ws + lowercase) ──
+
+test('interact: accessibilityLabel matches across trailing whitespace', () => {
+  let pressed = false;
+  const root = buildFiber({
+    name: 'App',
+    children: [
+      { name: 'Pressable', props: { accessibilityLabel: 'Continue ', onPress: () => { pressed = true; } } },
+    ],
+  });
+  const sandbox = createSandbox({ fiberRoot: root });
+  const result = JSON.parse(sandbox.__RN_AGENT.interact({ action: 'press', accessibilityLabel: 'Continue' }));
+  assert.equal(result.success, true);
+  assert.equal(pressed, true);
+});
+
+test('interact: accessibilityLabel matches case-insensitively', () => {
+  let pressed = false;
+  const root = buildFiber({
+    name: 'App',
+    children: [
+      { name: 'Pressable', props: { accessibilityLabel: 'Continue', onPress: () => { pressed = true; } } },
+    ],
+  });
+  const sandbox = createSandbox({ fiberRoot: root });
+  const result = JSON.parse(sandbox.__RN_AGENT.interact({ action: 'press', accessibilityLabel: 'continue' }));
+  assert.equal(result.success, true);
+  assert.equal(pressed, true);
+});
+
+test('interact: accessibilityLabel matches across collapsed inner whitespace', () => {
+  let pressed = false;
+  const root = buildFiber({
+    name: 'App',
+    children: [
+      { name: 'Pressable', props: { accessibilityLabel: 'Sign  In', onPress: () => { pressed = true; } } },
+    ],
+  });
+  const sandbox = createSandbox({ fiberRoot: root });
+  const result = JSON.parse(sandbox.__RN_AGENT.interact({ action: 'press', accessibilityLabel: 'sign in' }));
+  assert.equal(result.success, true);
+  assert.equal(pressed, true);
+});
+
+// ── interact() — tier 3: substring contains ─────────────────────────────
+
+test('interact: accessibilityLabel substring fallback presses single match', () => {
+  let pressed = false;
+  const root = buildFiber({
+    name: 'App',
+    children: [
+      { name: 'Pressable', props: { accessibilityLabel: 'Continue button', onPress: () => { pressed = true; } } },
+    ],
+  });
+  const sandbox = createSandbox({ fiberRoot: root });
+  const result = JSON.parse(sandbox.__RN_AGENT.interact({ action: 'press', accessibilityLabel: 'Continue' }));
+  assert.equal(result.success, true);
+  assert.equal(pressed, true);
+});
+
+// ── interact() — tier-priority: exact wins over later tiers (no false ambiguity) ──
+
+test('interact: exact match wins over substring sibling — no ambiguity', () => {
+  let pressedExact = false;
+  let pressedSubstring = false;
+  const root = buildFiber({
+    name: 'App',
+    children: [
+      { name: 'Pressable', props: { accessibilityLabel: 'Continue', onPress: () => { pressedExact = true; } } },
+      { name: 'Pressable', props: { accessibilityLabel: 'Continue button', onPress: () => { pressedSubstring = true; } } },
+    ],
+  });
+  const sandbox = createSandbox({ fiberRoot: root });
+  const result = JSON.parse(sandbox.__RN_AGENT.interact({ action: 'press', accessibilityLabel: 'Continue' }));
+  assert.equal(result.success, true, result.error || 'should succeed');
+  assert.equal(pressedExact, true, 'exact tier should take priority');
+  assert.equal(pressedSubstring, false, 'substring sibling must not fire');
+});
+
+// ── interact() — ambiguity error when chosen tier has >1 match ──────────
+
+test('interact: two exact matches return Ambiguous error with both descriptors', () => {
+  const root = buildFiber({
+    name: 'App',
+    children: [
+      { name: 'Pressable', props: { accessibilityLabel: 'Continue', testID: 'a', onPress: () => {} } },
+      { name: 'Pressable', props: { accessibilityLabel: 'Continue', testID: 'b', onPress: () => {} } },
+    ],
+  });
+  const sandbox = createSandbox({ fiberRoot: root });
+  const result = JSON.parse(sandbox.__RN_AGENT.interact({ action: 'press', accessibilityLabel: 'Continue' }));
+  assert.equal(result.error, 'Ambiguous component match');
+  assert.equal(result.count, 2);
+  assert.equal(result.matches.length, 2);
+  assert.deepEqual(
+    result.matches.map((m) => m.testID).sort(),
+    ['a', 'b'],
+  );
+  assert.match(result.hint, /Add a testID/);
+});
+
+test('interact: substring tier ambiguity returns error (does not silently pick first)', () => {
+  let firstPressed = false;
+  let secondPressed = false;
+  const root = buildFiber({
+    name: 'App',
+    children: [
+      { name: 'Pressable', props: { accessibilityLabel: 'Continue button', onPress: () => { firstPressed = true; } } },
+      { name: 'Pressable', props: { accessibilityLabel: 'Continue link', onPress: () => { secondPressed = true; } } },
+    ],
+  });
+  const sandbox = createSandbox({ fiberRoot: root });
+  const result = JSON.parse(sandbox.__RN_AGENT.interact({ action: 'press', accessibilityLabel: 'Continue' }));
+  assert.equal(result.error, 'Ambiguous component match');
+  assert.equal(firstPressed, false);
+  assert.equal(secondPressed, false);
+});
+
+// ── interact() — not-found shape includes new hint ──────────────────────
+
+test('interact: accessibilityLabel no match returns Component not found with tiered hint', () => {
+  const root = buildFiber({
+    name: 'App',
+    children: [
+      { name: 'Pressable', props: { accessibilityLabel: 'Cancel', onPress: () => {} } },
+    ],
+  });
+  const sandbox = createSandbox({ fiberRoot: root });
+  const result = JSON.parse(sandbox.__RN_AGENT.interact({ action: 'press', accessibilityLabel: 'Continue' }));
+  assert.equal(result.error, 'Component not found');
+  assert.match(result.hint, /exact, case\/whitespace-normalized, and substring/);
+  assert.match(result.hint, /cdp_component_tree/);
+});
+
+// ── interact() — non-string accessibilityLabel values must not crash ────
+
+test('interact: handles falsy/non-string accessibilityLabel values without crashing', () => {
+  const root = buildFiber({
+    name: 'App',
+    children: [
+      { name: 'Pressable', props: { accessibilityLabel: false, onPress: () => {} } },
+      { name: 'Pressable', props: { accessibilityLabel: null, onPress: () => {} } },
+      { name: 'Pressable', props: { accessibilityLabel: '', onPress: () => {} } },
+      { name: 'Pressable', props: { accessibilityLabel: 'Continue', onPress: () => {} } },
+    ],
+  });
+  const sandbox = createSandbox({ fiberRoot: root });
+  const result = JSON.parse(sandbox.__RN_AGENT.interact({ action: 'press', accessibilityLabel: 'Continue' }));
+  assert.equal(result.success, true);
+});
+
+// ── getTree() — filter now matches accessibilityLabel ───────────────────
+
+test('getTree: filter matches accessibilityLabel (the Home tab case)', () => {
+  const root = buildFiber({
+    name: 'NavigationContainer',
+    children: [
+      {
+        name: 'BottomTabItem',
+        props: { accessibilityLabel: 'Home' },
+      },
+      {
+        name: 'BottomTabItem',
+        props: { accessibilityLabel: 'Settings' },
+      },
+    ],
+  });
+  const sandbox = createSandbox({ fiberRoot: root });
+  const result = JSON.parse(sandbox.__RN_AGENT.getTree({ filter: 'Home', maxDepth: 4 }));
+  assert.notEqual(result.tree, null, 'filter "Home" should now find the BottomTabItem with accessibilityLabel:"Home"');
+});
+
+test('getTree: filter against name + testID still works (regression)', () => {
+  const root = buildFiber({
+    name: 'App',
+    children: [
+      { name: 'CartBadge', props: { testID: 'cart-badge' } },
+    ],
+  });
+  const sandbox = createSandbox({ fiberRoot: root });
+  const byName = JSON.parse(sandbox.__RN_AGENT.getTree({ filter: 'CartBadge', maxDepth: 4 }));
+  assert.notEqual(byName.tree, null);
+  const byTestID = JSON.parse(sandbox.__RN_AGENT.getTree({ filter: 'cart-badge', maxDepth: 4 }));
+  assert.notEqual(byTestID.tree, null);
+});
+
+test('getTree: filter is case-insensitive on accessibilityLabel', () => {
+  const root = buildFiber({
+    name: 'App',
+    children: [
+      { name: 'Pressable', props: { accessibilityLabel: 'Submit Form' } },
+    ],
+  });
+  const sandbox = createSandbox({ fiberRoot: root });
+  const result = JSON.parse(sandbox.__RN_AGENT.getTree({ filter: 'submit', maxDepth: 4 }));
+  assert.notEqual(result.tree, null);
+});
+
+test('getTree: filter with no match returns tree:null with rootsSeeded count', () => {
+  const root = buildFiber({
+    name: 'App',
+    children: [
+      { name: 'Pressable', props: { accessibilityLabel: 'Cancel' } },
+    ],
+  });
+  const sandbox = createSandbox({ fiberRoot: root });
+  const result = JSON.parse(sandbox.__RN_AGENT.getTree({ filter: 'NotPresent', maxDepth: 4 }));
+  assert.equal(result.tree, null);
+  assert.ok(typeof result.rootsSeeded === 'number');
+});
+
+// ── source-grep regression guard: ensure helper code doesn't drift ──────
+
+test('source guard: interact() has tiered match scaffolding', () => {
+  assert.match(INJECTED_HELPERS, /var exactMatches = \[\];/);
+  assert.match(INJECTED_HELPERS, /var normMatches = \[\];/);
+  assert.match(INJECTED_HELPERS, /var containsMatches = \[\];/);
+  assert.match(INJECTED_HELPERS, /Ambiguous component match/);
+});
+
+test('source guard: getTree filter checks accessibilityLabel', () => {
+  assert.match(INJECTED_HELPERS, /matchesLabel/);
+  assert.match(INJECTED_HELPERS, /matchesName \|\| matchesTestID \|\| matchesLabel/);
+});
+
+test('source guard: helpers version bumped to 20', () => {
+  assert.match(INJECTED_HELPERS, /__HELPERS_VERSION__ = 20;/);
+});

--- a/scripts/cdp-bridge/test/unit/injected-helpers.test.js
+++ b/scripts/cdp-bridge/test/unit/injected-helpers.test.js
@@ -317,6 +317,6 @@ test('M10: getAppInfo returns architecture=unknown when nativeFabricUIManager is
   assert.equal(info.architecture, 'unknown');
 });
 
-test('GH #72: helpers bundle version is 19 (bumped for findNavRef hooks-chain walker)', () => {
-  assert.match(INJECTED_HELPERS, /__HELPERS_VERSION__\s*=\s*19/);
+test('GH #60-5: helpers bundle version is 20 (bumped for tiered accessibilityLabel matching)', () => {
+  assert.match(INJECTED_HELPERS, /__HELPERS_VERSION__\s*=\s*20/);
 });


### PR DESCRIPTION
Closes GH #60 sub-item 5.

## Summary
- `cdp_interact` accessibilityLabel matching is now **tiered**: exact `===` → normalized exact (trim + collapse-ws + lowercase) → substring contains. First non-empty tier wins; >1 hit in that tier returns a structured `Ambiguous component match` error with up to 10 descriptors. testID stays strict + early-return.
- `cdp_component_tree` filter now matches `accessibilityLabel` (case-insensitive substring) in addition to component name + testID/nativeID.
- Multi-renderer collection in label mode — duplicate "Continue" buttons split across LogBox/Fabric correctly produce Ambiguous instead of silent first-pick.
- Helpers version bumped 19 → 20; tool descriptions updated.

## Why
Reporter (IX-2950) saw `cdp_interact action: "press" accessibilityLabel: "Continue"` returning "Component not found" on a clearly-visible button, and `cdp_component_tree filter: "Home"` returning `tree: null` despite a Home tab being mounted with `accessibilityLabel="Home"`. Tool descriptions implied `accessibilityLabel` was equivalent to testID; reality was strict-equal `===` plus a filter that ignored the field entirely.

## Test plan
- [x] 19 new unit tests in `gh-60-bug-5-label-matching.test.js`:
  - testID regression (strict, case-mismatch fails)
  - accessibilityLabel exact + tier 2 (whitespace/case/collapsed-ws) + tier 3 (substring)
  - Tier priority — exact wins over substring sibling
  - Ambiguity — Ambiguous error returned, no fiber pressed
  - Falsy/non-string accessibilityLabel safety
  - getTree filter — label match (Home tab), name+testID regression, case-insensitive, no-match
  - Source-grep regression guards (tier scaffolding, label field, version=20)
- [x] Pre-existing regression guards updated: `injected-helpers.test.js:320` v19 → v20; `find-active-renderer-migration.test.js:57` relaxed to verify `findFiber` inside `forEachRootFiber` (not the exact return-statement shape).
- [x] Full suite 842 passing, zero regressions.
- [x] Multi-LLM review (Gemini + Codex gpt-5.5 xhigh, parallel/isolated): 0 high-confidence issues. Both verified ES5 compat, regex-escape correctness against dist output, testID hot path preservation, ambiguity safety, and Hermes-vs-Node-VM equivalence.

## Subtle gotcha
`\s` inside the JS template literal is consumed as just `s`. Source uses `\\s+` so the runtime regex is `/\s+/g`. Caught by a `"Sign  In"` vs `"sign in"` collapsed-inner-whitespace test (18/19 of the new tests passed before the escape fix).

## Smoke (post-merge, requires CC restart)
1. Press a button by accessibilityLabel with whitespace/case mismatch — should now succeed instead of "Component not found".
2. Filter component tree by an accessibilityLabel-only label — should return the subtree instead of `tree: null`.
3. Two buttons with the same accessibilityLabel — should now return structured Ambiguous, not silently press one.

Workspace docs (D684, Phase 115, B146): committed as `1e66869` on `rn-dev-agent-workspace` main.