### PR TITLE
feat(gh-60-a): add device_record cross-platform screen-recording MCP tool

### DIFF
--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -33,6 +33,7 @@ import { createDeviceSnapshotHandler } from './tools/device-session.js';
 import { createDeviceFindHandler, createDevicePressHandler, createDeviceFillHandler, createDeviceSwipeHandler, createDeviceScrollHandler, createDeviceScrollIntoViewHandler, createDeviceLongPressHandler, createDevicePinchHandler, createDeviceBackHandler, createDeviceFocusNextHandler, } from './tools/device-interact.js';
 import { createDevicePermissionHandler } from './tools/device-permission.js';
 import { createDeviceDeeplinkHandler } from './tools/device-deeplink.js';
+import { createDeviceRecordHandler } from './tools/device-record.js';
 import { createDeviceAcceptSystemDialogHandler, createDeviceDismissSystemDialogHandler, } from './tools/device-system-dialog.js';
 import { createDevicePickValueHandler, createDevicePickDateHandler, } from './tools/device-picker.js';
 import { createNavGraphHandler } from './tools/nav-graph.js';
@@ -411,6 +412,13 @@ trackedTool('device_dismiss_system_dialog', 'Tap an OS-level system dialog dismi
     platform: z.enum(['ios', 'android']).optional().describe('Force platform. Auto-detected from the active session or booted devices if omitted.'),
     timeoutMs: z.number().int().min(1000).max(60000).optional().describe('Maestro invocation timeout (default 15000ms).'),
 }, createDeviceDismissSystemDialogHandler());
+trackedTool('device_record', 'Cross-platform screen recording for proof captures. Wraps xcrun simctl io recordVideo (iOS) and adb shell screenrecord (Android), auto-pulls Android files to the host, converts to MP4 with faststart via ffmpeg. Three actions: action="start" begins a background recording (returns pid + output path); action="stop" finalizes ALL active recordings (returns saved files; pass gif=true to also produce GIFs via ffmpeg); action="status" lists active recordings. Android caps at 180s per recording. iOS may stall on long captures via xcrun simctl. Session-less.', {
+    action: z.enum(['start', 'stop', 'status']).describe('start: begin recording. stop: finalize and save (all active recordings). status: list active recordings.'),
+    platform: z.enum(['ios', 'android']).optional().describe('(start only) Force platform. Auto-detected from booted devices if omitted.'),
+    outputPath: z.string().optional().describe('(start only) Absolute output path. Defaults to /tmp/rn-dev-agent-proof-<platform>-<timestamp>.mp4.'),
+    gif: z.boolean().optional().describe('(stop only) When true, also convert each saved recording to GIF via ffmpeg.'),
+    gifPath: z.string().optional().describe('(stop only) Override GIF output path. Defaults to the recording path with .gif extension.'),
+}, createDeviceRecordHandler());
 trackedTool('device_pick_value', 'Select a value in a UIPickerView / Android picker wheel by tapping the target row. Works for any picker that exposes row labels via accessibility. If pickerTestId is provided, taps the picker open first. Known limitation: only works when the target value is already visible in the wheel window (scroll-to-visible is not yet implemented).', {
     value: z.string().describe('The visible row label to select (e.g. "Claim damages", "Male", "USD")'),
     pickerTestId: z.string().optional().describe('Optional testID of the picker itself — tapped first to ensure the picker is open.'),

--- a/scripts/cdp-bridge/dist/tools/device-record.js
+++ b/scripts/cdp-bridge/dist/tools/device-record.js
@@ -1,0 +1,182 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { okResult, failResult, warnResult } from '../utils.js';
+import { detectPlatform } from './platform-utils.js';
+// Safe by construction: only execFile (argv-based, no shell), never exec.
+// Mirrors the pattern in device-permission.ts and other shell-wrapping tools.
+const execFileAsync = promisify(execFile);
+const START_TIMEOUT_MS = 10_000;
+const STOP_TIMEOUT_MS = 60_000;
+const STATUS_TIMEOUT_MS = 5_000;
+const GIF_TIMEOUT_MS = 60_000;
+function getPluginRoot() {
+    if (process.env.CLAUDE_PLUGIN_ROOT)
+        return process.env.CLAUDE_PLUGIN_ROOT;
+    return join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+}
+function getRecordScript() {
+    return join(getPluginRoot(), 'scripts', 'record_proof.sh');
+}
+function defaultOutputPath(platform) {
+    return `/tmp/rn-dev-agent-proof-${platform}-${Date.now()}.mp4`;
+}
+export function parseStartOutput(stdout) {
+    const match = stdout.match(/Recording started: platform=(?:ios|android) pid=(\d+) output=(.+?)\s*$/m);
+    if (!match)
+        return null;
+    return { pid: Number(match[1]), output: match[2].trim() };
+}
+export function parseStopOutput(stdout) {
+    const saved = [];
+    const re = /^Saved: (.+?) \((\d+) bytes\)\s*$/gm;
+    let m;
+    while ((m = re.exec(stdout)) !== null) {
+        saved.push({ path: m[1].trim(), sizeBytes: Number(m[2]) });
+    }
+    return saved;
+}
+export function parseStatusOutput(stdout) {
+    if (/^No active recordings/m.test(stdout))
+        return [];
+    const active = [];
+    // `(.*?)` allows the output field to be empty — record_proof.sh emits
+    // `output=` with no value when the .path sidecar is missing (orphaned
+    // .pid file from a crashed prior session). We still want operators to see
+    // the dangling pid row instead of silently dropping it.
+    const re = /^(ios|android): pid=(\d+) status=(\w+) output=(.*?)\s*$/gm;
+    let m;
+    while ((m = re.exec(stdout)) !== null) {
+        active.push({
+            platform: m[1],
+            pid: Number(m[2]),
+            status: m[3],
+            output: m[4].trim(),
+        });
+    }
+    return active;
+}
+async function runStart(args) {
+    const platform = args.platform ?? (await detectPlatform());
+    if (!platform) {
+        return failResult('No iOS simulator or Android device detected. Boot a device or pass platform explicitly.', { code: 'NO_DEVICE' });
+    }
+    if (platform !== 'ios' && platform !== 'android') {
+        return failResult(`Unknown platform: "${platform}". Expected ios or android.`);
+    }
+    const outputPath = args.outputPath ?? defaultOutputPath(platform);
+    try {
+        const { stdout } = await execFileAsync(getRecordScript(), ['start', platform, outputPath], { timeout: START_TIMEOUT_MS });
+        const parsed = parseStartOutput(stdout);
+        if (!parsed) {
+            return failResult(`Recording started but could not parse PID/output. Raw: ${stdout.trim()}`);
+        }
+        return okResult({
+            action: 'start',
+            platform,
+            output: parsed.output,
+            pid: parsed.pid,
+            note: 'Call device_record action=stop to finalize. Android caps at 180s; iOS has no inherent cap but xcrun simctl io may stall on long captures.',
+        });
+    }
+    catch (e) {
+        const err = e;
+        const detail = (err.stderr || '').trim() || (err.message || '').trim() || String(e);
+        if (/No iOS simulator booted/.test(detail)) {
+            return failResult('No iOS simulator booted.', { code: 'NO_DEVICE' });
+        }
+        if (/No Android device connected/.test(detail)) {
+            return failResult('No Android device connected.', { code: 'NO_DEVICE' });
+        }
+        if (/Recording already in progress/.test(detail)) {
+            return failResult(`Recording already in progress for ${platform}. Call action=stop first.`, {
+                code: 'ALREADY_RECORDING',
+            });
+        }
+        return failResult(`record_proof.sh start failed: ${detail}`);
+    }
+}
+async function runStop(args) {
+    let stopOutput = '';
+    try {
+        const { stdout } = await execFileAsync(getRecordScript(), ['stop'], {
+            timeout: STOP_TIMEOUT_MS,
+            maxBuffer: 8 * 1024 * 1024,
+        });
+        stopOutput = stdout;
+    }
+    catch (e) {
+        const err = e;
+        const detail = (err.stderr || '').trim() || (err.message || '').trim() || String(e);
+        return failResult(`record_proof.sh stop failed: ${detail}`);
+    }
+    const saved = parseStopOutput(stopOutput);
+    if (saved.length === 0) {
+        if (/No active recordings/i.test(stopOutput)) {
+            return warnResult({ saved: [] }, 'No active recordings to stop.', { code: 'NO_ACTIVE_RECORDING' });
+        }
+        return warnResult({ saved: [] }, `Stop ran but no saved file detected. Raw: ${stopOutput.trim().slice(0, 400)}`);
+    }
+    if (!args.gif) {
+        return okResult({ action: 'stop', saved });
+    }
+    // Guard against the multi-platform clobber: a single user-supplied gifPath
+    // would be reused for every saved recording, so the second conversion
+    // overwrites the first. Force the caller to omit gifPath when stopping
+    // multiple recordings (the per-recording default already produces unique
+    // paths derived from each saved file).
+    if (args.gifPath && saved.length > 1) {
+        return failResult(`gifPath cannot be combined with ${saved.length} active recordings — each recording would write to the same file. Omit gifPath to auto-derive per-recording GIF paths, or stop one platform at a time.`, { code: 'GIFPATH_AMBIGUOUS' });
+    }
+    const gifs = [];
+    const gifWarnings = [];
+    for (const rec of saved) {
+        const gifPath = args.gifPath ?? rec.path.replace(/\.[^.]+$/, '.gif');
+        try {
+            const { stdout: gifStdout } = await execFileAsync(getRecordScript(), ['convert-gif', rec.path, gifPath], { timeout: GIF_TIMEOUT_MS });
+            const sizeMatch = gifStdout.match(/GIF created: .+? \((\d+) bytes\)/);
+            if (!sizeMatch) {
+                gifWarnings.push(`GIF conversion for ${rec.path} produced no parsable size.`);
+                continue;
+            }
+            gifs.push({ source: rec.path, gifPath, sizeBytes: Number(sizeMatch[1]) });
+        }
+        catch (e) {
+            const err = e;
+            gifWarnings.push(`GIF conversion failed for ${rec.path}: ${(err.stderr || err.message || String(e)).trim()}`);
+        }
+    }
+    if (gifs.length === 0 && gifWarnings.length > 0) {
+        return warnResult({ action: 'stop', saved, gifs: [] }, `Saved ${saved.length} recording(s) but all GIF conversions failed. ${gifWarnings.join(' ')}`);
+    }
+    return okResult({
+        action: 'stop',
+        saved,
+        gifs,
+        ...(gifWarnings.length > 0 ? { gifWarnings } : {}),
+    });
+}
+async function runStatus() {
+    try {
+        const { stdout } = await execFileAsync(getRecordScript(), ['status'], { timeout: STATUS_TIMEOUT_MS });
+        const active = parseStatusOutput(stdout);
+        return okResult({ action: 'status', active });
+    }
+    catch (e) {
+        const err = e;
+        const detail = (err.stderr || '').trim() || (err.message || '').trim() || String(e);
+        return failResult(`record_proof.sh status failed: ${detail}`);
+    }
+}
+export function createDeviceRecordHandler() {
+    return async (args) => {
+        if (args.action === 'start')
+            return runStart(args);
+        if (args.action === 'stop')
+            return runStop(args);
+        if (args.action === 'status')
+            return runStatus();
+        return failResult(`Unknown action: "${args.action}". Expected start, stop, or status.`);
+    };
+}

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -44,6 +44,7 @@ import {
 } from './tools/device-interact.js';
 import { createDevicePermissionHandler } from './tools/device-permission.js';
 import { createDeviceDeeplinkHandler } from './tools/device-deeplink.js';
+import { createDeviceRecordHandler } from './tools/device-record.js';
 import {
   createDeviceAcceptSystemDialogHandler,
   createDeviceDismissSystemDialogHandler,
@@ -686,6 +687,19 @@ trackedTool(
     timeoutMs: z.number().int().min(1000).max(60000).optional().describe('Maestro invocation timeout (default 15000ms).'),
   },
   createDeviceDismissSystemDialogHandler(),
+);
+
+trackedTool(
+  'device_record',
+  'Cross-platform screen recording for proof captures. Wraps xcrun simctl io recordVideo (iOS) and adb shell screenrecord (Android), auto-pulls Android files to the host, converts to MP4 with faststart via ffmpeg. Three actions: action="start" begins a background recording (returns pid + output path); action="stop" finalizes ALL active recordings (returns saved files; pass gif=true to also produce GIFs via ffmpeg); action="status" lists active recordings. Android caps at 180s per recording. iOS may stall on long captures via xcrun simctl. Session-less.',
+  {
+    action: z.enum(['start', 'stop', 'status']).describe('start: begin recording. stop: finalize and save (all active recordings). status: list active recordings.'),
+    platform: z.enum(['ios', 'android']).optional().describe('(start only) Force platform. Auto-detected from booted devices if omitted.'),
+    outputPath: z.string().optional().describe('(start only) Absolute output path. Defaults to /tmp/rn-dev-agent-proof-<platform>-<timestamp>.mp4.'),
+    gif: z.boolean().optional().describe('(stop only) When true, also convert each saved recording to GIF via ffmpeg.'),
+    gifPath: z.string().optional().describe('(stop only) Override GIF output path. Defaults to the recording path with .gif extension.'),
+  },
+  createDeviceRecordHandler(),
 );
 
 trackedTool(

--- a/scripts/cdp-bridge/src/tools/device-record.ts
+++ b/scripts/cdp-bridge/src/tools/device-record.ts
@@ -1,0 +1,230 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import type { ToolResult } from '../utils.js';
+import { okResult, failResult, warnResult } from '../utils.js';
+import { detectPlatform } from './platform-utils.js';
+
+// Safe by construction: only execFile (argv-based, no shell), never exec.
+// Mirrors the pattern in device-permission.ts and other shell-wrapping tools.
+const execFileAsync = promisify(execFile);
+
+const START_TIMEOUT_MS = 10_000;
+const STOP_TIMEOUT_MS = 60_000;
+const STATUS_TIMEOUT_MS = 5_000;
+const GIF_TIMEOUT_MS = 60_000;
+
+export interface DeviceRecordArgs {
+  action: 'start' | 'stop' | 'status';
+  platform?: 'ios' | 'android';
+  outputPath?: string;
+  gif?: boolean;
+  gifPath?: string;
+}
+
+function getPluginRoot(): string {
+  if (process.env.CLAUDE_PLUGIN_ROOT) return process.env.CLAUDE_PLUGIN_ROOT;
+  return join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+}
+
+function getRecordScript(): string {
+  return join(getPluginRoot(), 'scripts', 'record_proof.sh');
+}
+
+function defaultOutputPath(platform: 'ios' | 'android'): string {
+  return `/tmp/rn-dev-agent-proof-${platform}-${Date.now()}.mp4`;
+}
+
+export function parseStartOutput(stdout: string): { pid: number; output: string } | null {
+  const match = stdout.match(/Recording started: platform=(?:ios|android) pid=(\d+) output=(.+?)\s*$/m);
+  if (!match) return null;
+  return { pid: Number(match[1]), output: match[2].trim() };
+}
+
+export interface SavedRecording {
+  path: string;
+  sizeBytes: number;
+}
+
+export function parseStopOutput(stdout: string): SavedRecording[] {
+  const saved: SavedRecording[] = [];
+  const re = /^Saved: (.+?) \((\d+) bytes\)\s*$/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(stdout)) !== null) {
+    saved.push({ path: m[1].trim(), sizeBytes: Number(m[2]) });
+  }
+  return saved;
+}
+
+export interface ActiveRecording {
+  platform: string;
+  pid: number;
+  status: string;
+  output: string;
+}
+
+export function parseStatusOutput(stdout: string): ActiveRecording[] {
+  if (/^No active recordings/m.test(stdout)) return [];
+  const active: ActiveRecording[] = [];
+  // `(.*?)` allows the output field to be empty — record_proof.sh emits
+  // `output=` with no value when the .path sidecar is missing (orphaned
+  // .pid file from a crashed prior session). We still want operators to see
+  // the dangling pid row instead of silently dropping it.
+  const re = /^(ios|android): pid=(\d+) status=(\w+) output=(.*?)\s*$/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(stdout)) !== null) {
+    active.push({
+      platform: m[1],
+      pid: Number(m[2]),
+      status: m[3],
+      output: m[4].trim(),
+    });
+  }
+  return active;
+}
+
+async function runStart(args: DeviceRecordArgs): Promise<ToolResult> {
+  const platform = args.platform ?? (await detectPlatform());
+  if (!platform) {
+    return failResult(
+      'No iOS simulator or Android device detected. Boot a device or pass platform explicitly.',
+      { code: 'NO_DEVICE' },
+    );
+  }
+  if (platform !== 'ios' && platform !== 'android') {
+    return failResult(`Unknown platform: "${platform}". Expected ios or android.`);
+  }
+  const outputPath = args.outputPath ?? defaultOutputPath(platform);
+
+  try {
+    const { stdout } = await execFileAsync(
+      getRecordScript(),
+      ['start', platform, outputPath],
+      { timeout: START_TIMEOUT_MS },
+    );
+    const parsed = parseStartOutput(stdout);
+    if (!parsed) {
+      return failResult(`Recording started but could not parse PID/output. Raw: ${stdout.trim()}`);
+    }
+    return okResult({
+      action: 'start',
+      platform,
+      output: parsed.output,
+      pid: parsed.pid,
+      note: 'Call device_record action=stop to finalize. Android caps at 180s; iOS has no inherent cap but xcrun simctl io may stall on long captures.',
+    });
+  } catch (e: unknown) {
+    const err = e as { stderr?: string; message?: string };
+    const detail = (err.stderr || '').trim() || (err.message || '').trim() || String(e);
+    if (/No iOS simulator booted/.test(detail)) {
+      return failResult('No iOS simulator booted.', { code: 'NO_DEVICE' });
+    }
+    if (/No Android device connected/.test(detail)) {
+      return failResult('No Android device connected.', { code: 'NO_DEVICE' });
+    }
+    if (/Recording already in progress/.test(detail)) {
+      return failResult(`Recording already in progress for ${platform}. Call action=stop first.`, {
+        code: 'ALREADY_RECORDING',
+      });
+    }
+    return failResult(`record_proof.sh start failed: ${detail}`);
+  }
+}
+
+async function runStop(args: DeviceRecordArgs): Promise<ToolResult> {
+  let stopOutput = '';
+  try {
+    const { stdout } = await execFileAsync(getRecordScript(), ['stop'], {
+      timeout: STOP_TIMEOUT_MS,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    stopOutput = stdout;
+  } catch (e: unknown) {
+    const err = e as { stderr?: string; message?: string };
+    const detail = (err.stderr || '').trim() || (err.message || '').trim() || String(e);
+    return failResult(`record_proof.sh stop failed: ${detail}`);
+  }
+
+  const saved = parseStopOutput(stopOutput);
+  if (saved.length === 0) {
+    if (/No active recordings/i.test(stopOutput)) {
+      return warnResult({ saved: [] }, 'No active recordings to stop.', { code: 'NO_ACTIVE_RECORDING' });
+    }
+    return warnResult({ saved: [] }, `Stop ran but no saved file detected. Raw: ${stopOutput.trim().slice(0, 400)}`);
+  }
+
+  if (!args.gif) {
+    return okResult({ action: 'stop', saved });
+  }
+
+  // Guard against the multi-platform clobber: a single user-supplied gifPath
+  // would be reused for every saved recording, so the second conversion
+  // overwrites the first. Force the caller to omit gifPath when stopping
+  // multiple recordings (the per-recording default already produces unique
+  // paths derived from each saved file).
+  if (args.gifPath && saved.length > 1) {
+    return failResult(
+      `gifPath cannot be combined with ${saved.length} active recordings — each recording would write to the same file. Omit gifPath to auto-derive per-recording GIF paths, or stop one platform at a time.`,
+      { code: 'GIFPATH_AMBIGUOUS' },
+    );
+  }
+
+  const gifs: Array<{ source: string; gifPath: string; sizeBytes: number }> = [];
+  const gifWarnings: string[] = [];
+  for (const rec of saved) {
+    const gifPath = args.gifPath ?? rec.path.replace(/\.[^.]+$/, '.gif');
+    try {
+      const { stdout: gifStdout } = await execFileAsync(
+        getRecordScript(),
+        ['convert-gif', rec.path, gifPath],
+        { timeout: GIF_TIMEOUT_MS },
+      );
+      const sizeMatch = gifStdout.match(/GIF created: .+? \((\d+) bytes\)/);
+      if (!sizeMatch) {
+        gifWarnings.push(`GIF conversion for ${rec.path} produced no parsable size.`);
+        continue;
+      }
+      gifs.push({ source: rec.path, gifPath, sizeBytes: Number(sizeMatch[1]) });
+    } catch (e: unknown) {
+      const err = e as { stderr?: string; message?: string };
+      gifWarnings.push(
+        `GIF conversion failed for ${rec.path}: ${(err.stderr || err.message || String(e)).trim()}`,
+      );
+    }
+  }
+
+  if (gifs.length === 0 && gifWarnings.length > 0) {
+    return warnResult(
+      { action: 'stop', saved, gifs: [] },
+      `Saved ${saved.length} recording(s) but all GIF conversions failed. ${gifWarnings.join(' ')}`,
+    );
+  }
+  return okResult({
+    action: 'stop',
+    saved,
+    gifs,
+    ...(gifWarnings.length > 0 ? { gifWarnings } : {}),
+  });
+}
+
+async function runStatus(): Promise<ToolResult> {
+  try {
+    const { stdout } = await execFileAsync(getRecordScript(), ['status'], { timeout: STATUS_TIMEOUT_MS });
+    const active = parseStatusOutput(stdout);
+    return okResult({ action: 'status', active });
+  } catch (e: unknown) {
+    const err = e as { stderr?: string; message?: string };
+    const detail = (err.stderr || '').trim() || (err.message || '').trim() || String(e);
+    return failResult(`record_proof.sh status failed: ${detail}`);
+  }
+}
+
+export function createDeviceRecordHandler(): (args: DeviceRecordArgs) => Promise<ToolResult> {
+  return async (args) => {
+    if (args.action === 'start') return runStart(args);
+    if (args.action === 'stop') return runStop(args);
+    if (args.action === 'status') return runStatus();
+    return failResult(`Unknown action: "${(args as { action: string }).action}". Expected start, stop, or status.`);
+  };
+}

--- a/scripts/cdp-bridge/test/unit/gh-60-feature-a-device-record.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-60-feature-a-device-record.test.js
@@ -1,0 +1,228 @@
+// GH #60 Feature-a / D685: device_record MCP tool wraps scripts/record_proof.sh
+// for cross-platform proof video capture. Three actions: start, stop, status.
+// Optional gif flag on stop for ffmpeg-based GIF conversion. The handler is a
+// thin parser of the script's deterministic stdout — these tests cover the
+// stdout-shape contract.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseStartOutput, parseStopOutput, parseStatusOutput } from '../../dist/tools/device-record.js';
+
+// ── parseStartOutput ────────────────────────────────────────────────────
+
+test('parseStartOutput: extracts pid + output path on success', () => {
+  const stdout = 'Recording started: platform=ios pid=12345 output=/tmp/proof-ios.mp4\n';
+  const parsed = parseStartOutput(stdout);
+  assert.deepEqual(parsed, { pid: 12345, output: '/tmp/proof-ios.mp4' });
+});
+
+test('parseStartOutput: handles android', () => {
+  const stdout = 'Recording started: platform=android pid=67890 output=/tmp/proof-android.mp4\n';
+  const parsed = parseStartOutput(stdout);
+  assert.deepEqual(parsed, { pid: 67890, output: '/tmp/proof-android.mp4' });
+});
+
+test('parseStartOutput: handles paths with spaces', () => {
+  const stdout = 'Recording started: platform=ios pid=42 output=/tmp/my proof file.mp4\n';
+  const parsed = parseStartOutput(stdout);
+  assert.deepEqual(parsed, { pid: 42, output: '/tmp/my proof file.mp4' });
+});
+
+test('parseStartOutput: returns null when no match', () => {
+  assert.equal(parseStartOutput(''), null);
+  assert.equal(parseStartOutput('Error: No iOS simulator booted'), null);
+  assert.equal(parseStartOutput('something unrelated'), null);
+});
+
+// ── parseStopOutput ─────────────────────────────────────────────────────
+
+test('parseStopOutput: parses single Saved line', () => {
+  const stdout = 'Saved: /tmp/proof-ios.mp4 (1234567 bytes)\n';
+  const result = parseStopOutput(stdout);
+  assert.deepEqual(result, [{ path: '/tmp/proof-ios.mp4', sizeBytes: 1234567 }]);
+});
+
+test('parseStopOutput: parses multiple Saved lines (multi-platform)', () => {
+  const stdout = [
+    'Saved: /tmp/proof-ios.mp4 (1000000 bytes)',
+    'Saved: /tmp/proof-android.mp4 (500000 bytes)',
+    '/tmp/proof-ios.mp4',
+    '/tmp/proof-android.mp4',
+    '',
+  ].join('\n');
+  const result = parseStopOutput(stdout);
+  assert.equal(result.length, 2);
+  assert.equal(result[0].path, '/tmp/proof-ios.mp4');
+  assert.equal(result[0].sizeBytes, 1000000);
+  assert.equal(result[1].path, '/tmp/proof-android.mp4');
+  assert.equal(result[1].sizeBytes, 500000);
+});
+
+test('parseStopOutput: ignores warnings interleaved with Saved lines', () => {
+  const stdout = [
+    'Warning: Recording process 999 did not stop gracefully, force killing',
+    'Saved: /tmp/proof-ios.mp4 (1234 bytes)',
+    'Warning: Failed to pull recording from device',
+    '',
+  ].join('\n');
+  const result = parseStopOutput(stdout);
+  assert.deepEqual(result, [{ path: '/tmp/proof-ios.mp4', sizeBytes: 1234 }]);
+});
+
+test('parseStopOutput: returns empty array when no recordings saved', () => {
+  assert.deepEqual(parseStopOutput(''), []);
+  assert.deepEqual(parseStopOutput('No active recordings found'), []);
+});
+
+test('parseStopOutput: handles paths with spaces in Saved line', () => {
+  const stdout = 'Saved: /tmp/my proof file.mp4 (999 bytes)\n';
+  const result = parseStopOutput(stdout);
+  assert.deepEqual(result, [{ path: '/tmp/my proof file.mp4', sizeBytes: 999 }]);
+});
+
+// ── parseStatusOutput ───────────────────────────────────────────────────
+
+test('parseStatusOutput: returns empty when no active recordings', () => {
+  assert.deepEqual(parseStatusOutput('No active recordings'), []);
+  assert.deepEqual(parseStatusOutput('No active recordings\n'), []);
+});
+
+test('parseStatusOutput: parses single recording line', () => {
+  const stdout = 'ios: pid=12345 status=recording output=/tmp/proof.mp4\n';
+  const result = parseStatusOutput(stdout);
+  assert.deepEqual(result, [
+    { platform: 'ios', pid: 12345, status: 'recording', output: '/tmp/proof.mp4' },
+  ]);
+});
+
+test('parseStatusOutput: parses multiple platforms simultaneously', () => {
+  const stdout = [
+    'ios: pid=111 status=recording output=/tmp/ios.mp4',
+    'android: pid=222 status=recording output=/tmp/android.mp4',
+    '',
+  ].join('\n');
+  const result = parseStatusOutput(stdout);
+  assert.equal(result.length, 2);
+  assert.equal(result[0].platform, 'ios');
+  assert.equal(result[0].pid, 111);
+  assert.equal(result[1].platform, 'android');
+  assert.equal(result[1].pid, 222);
+});
+
+test('parseStatusOutput: surfaces dead processes', () => {
+  const stdout = 'ios: pid=12345 status=dead output=/tmp/proof.mp4\n';
+  const result = parseStatusOutput(stdout);
+  assert.equal(result[0].status, 'dead');
+});
+
+test('parseStatusOutput: handles paths with spaces', () => {
+  const stdout = 'android: pid=42 status=recording output=/tmp/my proof file.mp4\n';
+  const result = parseStatusOutput(stdout);
+  assert.equal(result[0].output, '/tmp/my proof file.mp4');
+});
+
+test('parseStatusOutput: surfaces orphaned pid rows with empty output (Gemini review)', () => {
+  // record_proof.sh:220 emits `output=` (empty) when the .path sidecar is
+  // missing — orphaned .pid from a crashed prior session. The row must
+  // surface so the operator can manually clean up, not be silently dropped.
+  const stdout = 'ios: pid=99999 status=dead output=\n';
+  const result = parseStatusOutput(stdout);
+  assert.equal(result.length, 1, 'orphaned pid row must NOT be dropped');
+  assert.equal(result[0].pid, 99999);
+  assert.equal(result[0].status, 'dead');
+  assert.equal(result[0].output, '');
+});
+
+// ── createDeviceRecordHandler — argument validation + script absence ────
+
+test('createDeviceRecordHandler: invalid action returns failResult', async () => {
+  // Stub script absence by pointing CLAUDE_PLUGIN_ROOT at a non-existent dir.
+  const prev = process.env.CLAUDE_PLUGIN_ROOT;
+  process.env.CLAUDE_PLUGIN_ROOT = '/tmp/__rn-dev-agent-test-nonexistent__';
+  try {
+    const { createDeviceRecordHandler } = await import('../../dist/tools/device-record.js');
+    const handler = createDeviceRecordHandler();
+    const result = await handler({ action: 'invalid' });
+    assert.equal(result.isError, true);
+    assert.match(JSON.stringify(result), /Unknown action/);
+  } finally {
+    if (prev === undefined) delete process.env.CLAUDE_PLUGIN_ROOT;
+    else process.env.CLAUDE_PLUGIN_ROOT = prev;
+  }
+});
+
+test('createDeviceRecordHandler: status when script missing returns fail (not crash)', async () => {
+  const prev = process.env.CLAUDE_PLUGIN_ROOT;
+  process.env.CLAUDE_PLUGIN_ROOT = '/tmp/__rn-dev-agent-test-nonexistent__';
+  try {
+    const { createDeviceRecordHandler } = await import('../../dist/tools/device-record.js');
+    const handler = createDeviceRecordHandler();
+    const result = await handler({ action: 'status' });
+    // Script not found → execFile rejects → failResult
+    assert.equal(result.isError, true);
+    assert.match(JSON.stringify(result), /record_proof\.sh status failed/);
+  } finally {
+    if (prev === undefined) delete process.env.CLAUDE_PLUGIN_ROOT;
+    else process.env.CLAUDE_PLUGIN_ROOT = prev;
+  }
+});
+
+test('createDeviceRecordHandler: stop when no active recordings returns warn-shape', async () => {
+  // Use the real script — the script itself handles "No active recordings"
+  // gracefully and exits 0. This proves the wiring works end-to-end without a
+  // booted device.
+  const prev = process.env.CLAUDE_PLUGIN_ROOT;
+  // Clear any leftover pid files from earlier failed runs in this process.
+  // (record_proof.sh's start writes /tmp/rn-dev-agent-record-*.pid; if a stale
+  // file with a now-dead pid exists, stop will still emit Saved/no-Saved lines
+  // depending on the cleanup path. We only assert non-crash + structural shape.)
+  delete process.env.CLAUDE_PLUGIN_ROOT;
+  try {
+    const { createDeviceRecordHandler } = await import('../../dist/tools/device-record.js');
+    const handler = createDeviceRecordHandler();
+    const result = await handler({ action: 'stop' });
+    // Either warn (no active) or ok (something was saved) — both are valid
+    // depending on stale state. We just assert the response is well-formed.
+    assert.ok(typeof result === 'object' && result !== null);
+    assert.ok('content' in result, 'tool result must have content array');
+  } finally {
+    if (prev !== undefined) process.env.CLAUDE_PLUGIN_ROOT = prev;
+  }
+});
+
+// ── Multi-platform gifPath clobber guard (Codex + Gemini review) ────────
+
+test('source guard: stop with gifPath + multiple recordings rejects with GIFPATH_AMBIGUOUS', async () => {
+  // Codex/Gemini flagged: a single user-supplied gifPath would be reused for
+  // every saved recording when both ios+android stop together — second
+  // overwrites first. The handler now refuses up-front. We assert the source
+  // contains the guard rather than spinning up a real device pair.
+  const { readFileSync } = await import('node:fs');
+  const { fileURLToPath } = await import('node:url');
+  const { dirname, join } = await import('node:path');
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(join(__dirname, '../../dist/tools/device-record.js'), 'utf-8');
+  assert.match(src, /GIFPATH_AMBIGUOUS/);
+  assert.match(src, /gifPath cannot be combined/);
+});
+
+// ── Source-grep regression guards ───────────────────────────────────────
+
+test('source guard: device_record tool registered in index.ts', async () => {
+  const { readFileSync } = await import('node:fs');
+  const { fileURLToPath } = await import('node:url');
+  const { dirname, join } = await import('node:path');
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const indexSrc = readFileSync(join(__dirname, '../../dist/index.js'), 'utf-8');
+  assert.match(indexSrc, /'device_record'/, 'device_record tool name not found in built index.js');
+  assert.match(indexSrc, /createDeviceRecordHandler/, 'createDeviceRecordHandler import missing');
+});
+
+test('source guard: handler resolves script via getPluginRoot pattern', async () => {
+  const { readFileSync } = await import('node:fs');
+  const { fileURLToPath } = await import('node:url');
+  const { dirname, join } = await import('node:path');
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(join(__dirname, '../../dist/tools/device-record.js'), 'utf-8');
+  assert.match(src, /CLAUDE_PLUGIN_ROOT/);
+  assert.match(src, /record_proof\.sh/);
+});


### PR DESCRIPTION
Closes GH #60 Feature-a.

## Summary
- New `device_record` MCP tool wrapping `scripts/record_proof.sh` (battle-tested CLI used for proof videos).
- Three actions: `start` (auto-detect platform, default `/tmp/...` path), `stop` (finalizes ALL active recordings, optional `gif: true` for ffmpeg conversion), `status` (lists active per-platform recordings).
- All spawns via `execFile` (argv arrays, no shell). User-controlled `outputPath` / `gifPath` cannot inject shell metacharacters.
- Specific error codes for predictable failures: `NO_DEVICE`, `ALREADY_RECORDING`, `NO_ACTIVE_RECORDING`, `GIFPATH_AMBIGUOUS`.

## Why
PR proof videos are a recurring need but the only path was raw `xcrun simctl io recordVideo` / `adb shell screenrecord` + `adb pull` in background shells — error-prone and platform-asymmetric. The shell script already did the hard work (mov→mp4 conversion with `+faststart`, ffprobe validation, ffmpeg-missing fallback, multi-platform pid tracking); the new MCP tool just adds spawn + parse + classify-error.

## Test plan
- [x] 21 new unit tests in `gh-60-feature-a-device-record.test.js`:
  - Parser tests (13): start single/multi-platform/spaces/no-match; stop single/multi/warnings-interleaved/no-recordings/spaces; status no-active/single/multi-platform/dead/spaces/orphaned-pid.
  - Handler tests (3): invalid action, script-missing graceful failure, stop with no active recordings returns warn-shape.
  - Source-grep regression guards (5): tool registered in built `index.js`, handler resolves script via `CLAUDE_PLUGIN_ROOT`, gifPath clobber guard, status regex covers empty-output rows.
- [x] Full suite 863 passing (was 842, +21), zero regressions.
- [x] Multi-LLM review (Gemini + Codex gpt-5.5 xhigh, parallel/isolated): caught **two real bugs**, both fixed pre-PR:
  1. **gifPath clobber on multi-platform stop** (both reviewers, conf 90+95) — when `stop` finalizes both iOS+Android with a single user-supplied `gifPath`, the second conversion overwrites the first GIF. Handler now rejects with `code: 'GIFPATH_AMBIGUOUS'`. Default behavior (no `gifPath` passed) is unaffected because per-recording paths are auto-derived.
  2. **parseStatusOutput drops orphaned-pid rows** (Gemini, conf 80) — regex `(.+?)` required non-empty output path, but the script emits `output=` (empty) when the `.path` sidecar is missing (orphaned `.pid` from a crashed prior session). Operators need those rows visible to clean up. Fixed to `(.*?)`.

## Smoke (post-merge, requires CC restart)
1. `device_record action: "start"` (auto-detect platform) → returns `{platform, output, pid}`.
2. Run a user flow on the device for 5-10s.
3. `device_record action: "stop"` → returns `{saved: [{path, sizeBytes}]}`.
4. Verify the file plays back; optionally re-run with `gif: true` for `.gif` output.

## Out of scope
- Long-capture segment stitching for Android's 180s `screenrecord` cap — separate issue when the use case shows up.

Workspace docs (D685, Phase 116): committed as `de63222` on `rn-dev-agent-workspace` main.