### PR TITLE
chore(descriptions): polish 11 tool descriptions; close GH #60 Bug 6

### DIFF
--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -100,7 +100,7 @@ trackedTool('cdp_disconnect', 'Cleanly disconnect from the current Hermes target
 trackedTool('cdp_targets', 'List available Hermes debug targets without connecting. Shows all valid targets from Metro with their IDs, titles, and VM type. Highlights which target is currently connected (if any). Use to inspect what is available before calling cdp_connect.', {
     metroPort: z.number().optional().describe('Metro port to scan (default: auto-detect)'),
 }, createTargetsHandler(getClient));
-trackedTool('cdp_evaluate', 'CAUTION: Executes arbitrary JavaScript directly in the Hermes runtime with no sandboxing. Use only when no specific tool covers the need. Has a 5-second timeout. Prefer cdp_component_tree, cdp_store_state, and other targeted tools over raw evaluate.', {
+trackedTool('cdp_evaluate', 'CAUTION: Executes arbitrary JavaScript directly in the Hermes runtime with no sandboxing. Use only when no specific tool covers the need. Has a 5-second timeout. The Hermes dev runtime has NO Node `require()` — Metro bundles modules internally and only the live React tree is reachable. Use cdp_mmkv for storage R/W, cdp_dispatch for Redux/Zustand state changes, cdp_component_tree / cdp_store_state for introspection. Reach for raw evaluate only when no targeted tool fits.', {
     expression: z.string().describe('JavaScript expression to evaluate'),
     awaitPromise: z.boolean().default(false).describe('Wait for promise resolution'),
 }, createEvaluateHandler(getClient));
@@ -124,7 +124,7 @@ trackedTool('cdp_nav_graph', 'Navigation graph tool. PRIMARY: action="go" — na
     platform: z.enum(['ios', 'android']).optional().describe('(go/playbook/heal) Platform for playbook tips and heal advice'),
     params: z.record(z.unknown()).optional().describe('(go) Screen params to pass (e.g. { id: "1" })'),
 }, createNavGraphHandler(getClient));
-trackedTool('cdp_error_log', 'Get unhandled JS errors and promise rejections. Hooked into ErrorUtils and Hermes rejection tracker. If empty but app crashed, the error is NATIVE — call cdp_native_errors to check native logs (B114/D642).', {
+trackedTool('cdp_error_log', 'Get unhandled JS errors and promise rejections. Hooked into ErrorUtils and Hermes rejection tracker. If empty but app crashed, the error is NATIVE — call cdp_native_errors to check native logs.', {
     clear: z.boolean().default(false).describe('Clear all captured errors instead of reading them'),
 }, createErrorLogHandler(getClient));
 trackedTool('cdp_native_errors', 'Read native-level error logs for when JS-layer tools come up empty. iOS spawns `xcrun simctl log show`, Android uses `adb logcat -d`. Catches errors that fire BEFORE __RN_AGENT injects (missing native module, bundle load failure, native crash). Returns filtered + deduped error/fatal entries. Platform defaults to the CDP-connected target.', {
@@ -132,7 +132,7 @@ trackedTool('cdp_native_errors', 'Read native-level error logs for when JS-layer
     sinceSeconds: z.number().int().min(5).max(3600).optional().describe('How far back to look (default 60s, max 3600)'),
     limit: z.number().int().min(1).max(100).optional().describe('Max entries to return (default 10, max 100)'),
 }, createNativeErrorsHandler(getClient));
-trackedTool('cdp_network_log', 'Get recent network requests. Shows method, URL, status, duration. On RN 0.83+ uses CDP Network domain. On older versions uses injected fetch/XHR hooks (auto-detected). M4/D655: buffers are per-device, keyed by Metro port + target id — switching simulators no longer bleeds stale traffic. Pass `device: "all"` to merge across every device seen this session. Filters AND-combine: `filter` (URL substring), `method` (HTTP verb), `since` (ISO timestamp). When more entries match than `limit` allows, response includes `truncated:true` + `total_matches`.', {
+trackedTool('cdp_network_log', 'Get recent network requests. Shows method, URL, status, duration. On RN 0.83+ uses CDP Network domain. On older versions uses injected fetch/XHR hooks (auto-detected). Buffers are per-device, keyed by Metro port + target id — switching simulators no longer bleeds stale traffic. Pass `device: "all"` to merge across every device seen this session. Filters AND-combine: `filter` (URL substring), `method` (HTTP verb), `since` (ISO timestamp). When more entries match than `limit` allows, response includes `truncated:true` + `total_matches`.', {
     limit: z.number().int().min(1).max(100).default(20).describe('Max entries to return (default 20, max 100)'),
     filter: z.string().optional().describe('Filter by URL substring (e.g. "/api/cart")'),
     method: z.union([z.string(), z.array(z.string())]).optional().describe('Filter by HTTP method, case-insensitive (e.g. "POST" or ["POST","PUT"]). AND-combined with `filter`. Use to isolate mutations from follow-up GETs.'),
@@ -140,7 +140,7 @@ trackedTool('cdp_network_log', 'Get recent network requests. Shows method, URL, 
     clear: z.boolean().default(false).describe('Clear network buffer instead of reading'),
     device: z.string().optional().describe('Scope: a specific device key OR the literal "all" for a chronologically-merged view across every device. Defaults to the active device.'),
 }, createNetworkLogHandler(getClient));
-trackedTool('cdp_network_body', 'Get the actual response body for a network request by its requestId. Use cdp_network_log first to find request IDs. Only works in CDP network mode (RN 0.83+). Bodies are fetched on-demand, not cached. M4/D655: pass `device` to look up requestId in a specific device buffer; defaults to the active device.', {
+trackedTool('cdp_network_body', 'Get the actual response body for a network request by its requestId. Use cdp_network_log first to find request IDs. Only works in CDP network mode (RN 0.83+). Bodies are fetched on-demand, not cached. Pass `device` to look up requestId in a specific device buffer; defaults to the active device.', {
     requestId: z.string().describe('Request ID from cdp_network_log output'),
     maxLength: z.number().int().min(100).max(100000).default(10000).optional()
         .describe('Max body length to return (default 10000 chars). Truncated if longer.'),
@@ -335,12 +335,12 @@ trackedTool('device_screenshot', 'Capture a screenshot of the active device scre
     maxWidth: z.number().int().min(0).optional().describe('Downscale image so width does not exceed this many pixels. 0 disables resize. Default 800 (saves ~46% on iPhone 15/17 Pro screenshots without losing label readability).'),
     quality: z.number().int().min(1).max(100).optional().describe('JPEG compression quality (1-100). Only applied to .jpg/.jpeg files. Default 85.'),
 }, createDeviceScreenshotHandler(getClient));
-trackedTool('device_snapshot', 'Manage device sessions and capture UI snapshots. action=open starts a session (required before other device_ tools). action=snapshot returns the accessibility tree with @ref identifiers for device_press/device_fill. action=close ends the session. Use attachOnly=true on action=open to skip launching the app when it is already running (avoids relaunch-induced bundle races — B112).', {
+trackedTool('device_snapshot', 'Manage device sessions and capture UI snapshots. action=open starts a session (required before other device_ tools). action=snapshot returns the accessibility tree with @ref identifiers for device_press/device_fill. action=close ends the session. Use attachOnly=true on action=open to skip launching the app when it is already running (avoids relaunch-induced bundle races).', {
     action: z.enum(['open', 'close', 'snapshot']).default('snapshot').describe('open: start session for an app. snapshot: capture UI tree with element refs. close: end session.'),
     appId: z.string().optional().describe('App bundle ID — required for action=open (e.g. "com.example.app")'),
     platform: z.enum(['ios', 'android']).optional().describe('Target platform — used with action=open to select device'),
     sessionName: z.string().optional().describe('Session name override (default: auto-generated)'),
-    attachOnly: z.boolean().optional().describe('action=open only: skip launching the app. Requires the app to be already running. Use when connecting to an already-active dev session to avoid bundle-load races (B112/D641).'),
+    attachOnly: z.boolean().optional().describe('action=open only: skip launching the app. Requires the app to be already running. Use when connecting to an already-active dev session to avoid bundle-load races.'),
 }, createDeviceSnapshotHandler());
 trackedTool('device_find', 'Find a UI element by visible text and optionally interact with it. Use action="click" to tap, omit for find-only. Returns element ref for use with device_press/device_fill. Requires an open session. For overlapping labels (e.g. "Property damaged" vs "Property lost"), pass exact=true for strict match or index=N to pick the Nth candidate directly — both short-circuit AMBIGUOUS_MATCH. If AMBIGUOUS_MATCH still occurs, the result includes a candidates[] array with refs you can pass to device_press.', {
     text: z.string().describe('Visible text, accessibility label, or identifier to find'),
@@ -355,7 +355,7 @@ trackedTool('device_press', 'Tap a UI element by its @ref from device_snapshot. 
     holdMs: z.number().int().min(0).max(10000).optional().describe('Hold duration in ms (for long-press via ref)'),
     waitForFocusMs: z.number().int().min(0).max(5000).optional().describe('Sleep this many ms after tap to let keyboard focus settle — useful in sequential press+fill flows where focus would otherwise not propagate.'),
 }, createDevicePressHandler());
-trackedTool('device_fill', 'Type text into an input field by its @ref from device_snapshot. Always re-taps the element first so keyboard focus is on the correct field even in sequential fills. On "no focused text input" errors, automatically falls back: Pressable→TextInput resolution (B122 — common RN design-system pattern where outer Pressable wraps inner TextInput) → coordinate re-tap + retry → Android adb input / iOS Maestro inputText. Check meta.fallbackUsed in the result to see which strategy succeeded. Requires an open session.', {
+trackedTool('device_fill', 'Type text into an input field by its @ref from device_snapshot. Always re-taps the element first so keyboard focus is on the correct field even in sequential fills. On "no focused text input" errors, automatically falls back: Pressable→TextInput resolution (common RN design-system pattern where outer Pressable wraps inner TextInput) → coordinate re-tap + retry → Android adb input / iOS Maestro inputText. Check meta.fallbackUsed in the result to see which strategy succeeded. Requires an open session.', {
     ref: z.string().describe('Input field ref from device_snapshot (e.g. "e5" or "@e5")'),
     text: z.string().describe('Text to type into the field'),
     waitForKeyboardMs: z.number().int().min(0).max(5000).optional().describe('Wait between pre-tap and fill probe in ms (default 150). Bump to 500-1000ms when filling Pressable-wrapped TextInputs on slow keyboard animations to give RN native focus dispatch time to land.'),
@@ -458,7 +458,7 @@ trackedTool('cdp_auto_login', 'Pre-flight check: detect if the app is on a login
         return okResult(result);
     return warnResult(result, result.reason);
 }));
-trackedTool('proof_step', 'Atomic proof capture step: navigate to a screen (optional), wait for settlement, verify an element (optional), and take a screenshot. Combines 3-4 tool calls into one. Use in Phase 8 proof flows to reduce tool-call overhead.', {
+trackedTool('proof_step', 'Atomic proof capture step: navigate to a screen (optional), wait for settlement, verify an element (optional), and take a screenshot. Combines 3-4 tool calls into one. Use in proof flows to reduce tool-call overhead.', {
     screen: z.string().optional().describe('Screen to navigate to (omit to stay on current screen)'),
     params: z.record(z.unknown()).optional().describe('Navigation params (e.g. { id: "1" })'),
     waitMs: z.number().int().min(0).max(10000).default(1500).describe('Settlement wait in ms (default 1500)'),
@@ -474,7 +474,7 @@ trackedTool('maestro_run', 'Execute a Maestro flow via maestro-runner. Pass flow
     appId: z.string().optional().describe('App bundle ID (auto-detected from app.json)'),
     timeoutMs: z.number().int().min(5000).max(300000).default(120000).describe('Execution timeout in ms'),
 }, createMaestroRunHandler());
-trackedTool('maestro_generate', 'Generate a persistent Maestro YAML flow file from structured steps. Writes to .maestro/flows/<name>.yaml in the project root. Use after Phase 5.5 verification to create regression tests.', {
+trackedTool('maestro_generate', 'Generate a persistent Maestro YAML flow file from structured steps. Writes to .maestro/flows/<name>.yaml in the project root. Use after live verification to create regression tests.', {
     name: z.string().describe('Flow name (e.g. "add-to-cart", "profile-edit"). Becomes filename.'),
     steps: z.array(z.object({
         action: z.enum(['tap', 'fill', 'assert', 'scroll', 'navigate', 'back', 'wait', 'swipe', 'launch']).describe('Step action'),
@@ -513,7 +513,7 @@ trackedTool('cdp_record_test_load', 'Restore a previously-saved recording from <
     filename: z.string().min(1).describe('Recording name (without .json)'),
 }, createRecordTestLoadHandler(getClient));
 trackedTool('cdp_record_test_list', 'List saved recordings under <projectRoot>/.rn-agent/recordings/. Returns the directory path and an array of recording names (without .json extension), sorted alphabetically.', {}, createRecordTestListHandler(getClient));
-trackedTool('cdp_restart', 'In-process soft state reset (B76/D644). Disconnects the current CDP client, creates a fresh instance, and reconnects. Clears console/network/error ring buffers, background poll, reconnect state, and helpers-injected flag. Does NOT reload the MCP server binary — to load new dist/ after npm run build, fully quit and relaunch Claude Code. Useful for recovering from stuck connection state (target drift, stale helpers after many reloads) without losing the CC session.', {
+trackedTool('cdp_restart', 'In-process soft state reset. Disconnects the current CDP client, creates a fresh instance, and reconnects. Clears console/network/error ring buffers, background poll, reconnect state, and helpers-injected flag. Does NOT reload the MCP server binary — to load new dist/ after npm run build, fully quit and relaunch Claude Code. Useful for recovering from stuck connection state (target drift, stale helpers after many reloads) without losing the CC session.', {
     metroPort: z.number().optional().describe('Override Metro port for reconnection (default: keep current)'),
     platform: z.string().optional().describe('Platform filter for reconnection (e.g. "ios", "android")'),
 }, createRestartHandler(getClient, setClient, createClient));
@@ -522,8 +522,8 @@ trackedTool('cross_platform_verify', 'Compare UI elements across iOS and Android
     scanDir: z.string().optional().describe('Directory to scan for testID="..." props in .tsx/.jsx/.ts/.js files. Auto-discovers elements. Merges with elements[] if both provided.'),
     matchBy: z.enum(['testID', 'label', 'any']).default('any').describe('Match strategy: testID (exact identifier match), label (substring in accessibility label), any (try both)'),
 }, createCrossPlatformVerifyHandler());
-trackedTool('cdp_open_devtools', 'Report the React Native DevTools frontend URL for the live app + start a multiplexer proxy so DevTools can coexist with the MCP session on RN < 0.85 (RN >= 0.85 uses native multi-debugger). M1a (Phase 100) shipped detection + capability reporting; M1b (Phase 104) wired the proxy into CDPClient; B132 (Phase 105) added proxy auto-resume across reconnect. Returns { devtoolsUrl, inspectorWsUrl, hermesWsUrl, mode: "native" | "proxy-active", proxyPort, supportsMultipleDebuggers, rnVersion, guidance }.', {}, createOpenDevToolsHandler(getClient));
-trackedTool('cdp_metro_events', 'Read Metro reporter events (bundle_build_started, bundle_build_done, bundle_build_failed, reloads) captured since the MCP connected. M5 (Phase 90 Tier 2 / D656): the MetroEventsClient attaches a second WebSocket alongside CDP, giving push-based visibility into bundler state — watch for build errors without having to read console.error. Returns { eventsConnected, lastBuild, buildErrors, events, count }. Pass `clearErrors: true` to reset the build-error counter.', {
+trackedTool('cdp_open_devtools', 'Report the React Native DevTools frontend URL for the live app + start a multiplexer proxy so DevTools can coexist with the MCP session on RN < 0.85 (RN >= 0.85 uses native multi-debugger). The proxy auto-resumes across reconnects. Returns { devtoolsUrl, inspectorWsUrl, hermesWsUrl, mode: "native" | "proxy-active", proxyPort, supportsMultipleDebuggers, rnVersion, guidance }.', {}, createOpenDevToolsHandler(getClient));
+trackedTool('cdp_metro_events', 'Read Metro reporter events (bundle_build_started, bundle_build_done, bundle_build_failed, reloads) captured since the MCP connected. The MetroEventsClient attaches a second WebSocket alongside CDP, giving push-based visibility into bundler state — watch for build errors without having to read console.error. Returns { eventsConnected, lastBuild, buildErrors, events, count }. Pass `clearErrors: true` to reset the build-error counter.', {
     limit: z.number().int().min(1).max(100).default(20).describe('Max entries to return (default 20, max 100)'),
     type: z.string().optional().describe('Filter by event type (e.g. "bundle_build_failed")'),
     clearErrors: z.boolean().default(false).describe('Reset the build-error counter without reading events'),

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -159,7 +159,7 @@ trackedTool(
 
 trackedTool(
   'cdp_evaluate',
-  'CAUTION: Executes arbitrary JavaScript directly in the Hermes runtime with no sandboxing. Use only when no specific tool covers the need. Has a 5-second timeout. Prefer cdp_component_tree, cdp_store_state, and other targeted tools over raw evaluate.',
+  'CAUTION: Executes arbitrary JavaScript directly in the Hermes runtime with no sandboxing. Use only when no specific tool covers the need. Has a 5-second timeout. The Hermes dev runtime has NO Node `require()` — Metro bundles modules internally and only the live React tree is reachable. Use cdp_mmkv for storage R/W, cdp_dispatch for Redux/Zustand state changes, cdp_component_tree / cdp_store_state for introspection. Reach for raw evaluate only when no targeted tool fits.',
   {
     expression: z.string().describe('JavaScript expression to evaluate'),
     awaitPromise: z.boolean().default(false).describe('Wait for promise resolution'),
@@ -213,7 +213,7 @@ trackedTool(
 
 trackedTool(
   'cdp_error_log',
-  'Get unhandled JS errors and promise rejections. Hooked into ErrorUtils and Hermes rejection tracker. If empty but app crashed, the error is NATIVE — call cdp_native_errors to check native logs (B114/D642).',
+  'Get unhandled JS errors and promise rejections. Hooked into ErrorUtils and Hermes rejection tracker. If empty but app crashed, the error is NATIVE — call cdp_native_errors to check native logs.',
   {
     clear: z.boolean().default(false).describe('Clear all captured errors instead of reading them'),
   },
@@ -233,7 +233,7 @@ trackedTool(
 
 trackedTool(
   'cdp_network_log',
-  'Get recent network requests. Shows method, URL, status, duration. On RN 0.83+ uses CDP Network domain. On older versions uses injected fetch/XHR hooks (auto-detected). M4/D655: buffers are per-device, keyed by Metro port + target id — switching simulators no longer bleeds stale traffic. Pass `device: "all"` to merge across every device seen this session. Filters AND-combine: `filter` (URL substring), `method` (HTTP verb), `since` (ISO timestamp). When more entries match than `limit` allows, response includes `truncated:true` + `total_matches`.',
+  'Get recent network requests. Shows method, URL, status, duration. On RN 0.83+ uses CDP Network domain. On older versions uses injected fetch/XHR hooks (auto-detected). Buffers are per-device, keyed by Metro port + target id — switching simulators no longer bleeds stale traffic. Pass `device: "all"` to merge across every device seen this session. Filters AND-combine: `filter` (URL substring), `method` (HTTP verb), `since` (ISO timestamp). When more entries match than `limit` allows, response includes `truncated:true` + `total_matches`.',
   {
     limit: z.number().int().min(1).max(100).default(20).describe('Max entries to return (default 20, max 100)'),
     filter: z.string().optional().describe('Filter by URL substring (e.g. "/api/cart")'),
@@ -247,7 +247,7 @@ trackedTool(
 
 trackedTool(
   'cdp_network_body',
-  'Get the actual response body for a network request by its requestId. Use cdp_network_log first to find request IDs. Only works in CDP network mode (RN 0.83+). Bodies are fetched on-demand, not cached. M4/D655: pass `device` to look up requestId in a specific device buffer; defaults to the active device.',
+  'Get the actual response body for a network request by its requestId. Use cdp_network_log first to find request IDs. Only works in CDP network mode (RN 0.83+). Bodies are fetched on-demand, not cached. Pass `device` to look up requestId in a specific device buffer; defaults to the active device.',
   {
     requestId: z.string().describe('Request ID from cdp_network_log output'),
     maxLength: z.number().int().min(100).max(100000).default(10000).optional()
@@ -530,13 +530,13 @@ trackedTool(
 
 trackedTool(
   'device_snapshot',
-  'Manage device sessions and capture UI snapshots. action=open starts a session (required before other device_ tools). action=snapshot returns the accessibility tree with @ref identifiers for device_press/device_fill. action=close ends the session. Use attachOnly=true on action=open to skip launching the app when it is already running (avoids relaunch-induced bundle races — B112).',
+  'Manage device sessions and capture UI snapshots. action=open starts a session (required before other device_ tools). action=snapshot returns the accessibility tree with @ref identifiers for device_press/device_fill. action=close ends the session. Use attachOnly=true on action=open to skip launching the app when it is already running (avoids relaunch-induced bundle races).',
   {
     action: z.enum(['open', 'close', 'snapshot']).default('snapshot').describe('open: start session for an app. snapshot: capture UI tree with element refs. close: end session.'),
     appId: z.string().optional().describe('App bundle ID — required for action=open (e.g. "com.example.app")'),
     platform: z.enum(['ios', 'android']).optional().describe('Target platform — used with action=open to select device'),
     sessionName: z.string().optional().describe('Session name override (default: auto-generated)'),
-    attachOnly: z.boolean().optional().describe('action=open only: skip launching the app. Requires the app to be already running. Use when connecting to an already-active dev session to avoid bundle-load races (B112/D641).'),
+    attachOnly: z.boolean().optional().describe('action=open only: skip launching the app. Requires the app to be already running. Use when connecting to an already-active dev session to avoid bundle-load races.'),
   },
   createDeviceSnapshotHandler(),
 );
@@ -568,7 +568,7 @@ trackedTool(
 
 trackedTool(
   'device_fill',
-  'Type text into an input field by its @ref from device_snapshot. Always re-taps the element first so keyboard focus is on the correct field even in sequential fills. On "no focused text input" errors, automatically falls back: Pressable→TextInput resolution (B122 — common RN design-system pattern where outer Pressable wraps inner TextInput) → coordinate re-tap + retry → Android adb input / iOS Maestro inputText. Check meta.fallbackUsed in the result to see which strategy succeeded. Requires an open session.',
+  'Type text into an input field by its @ref from device_snapshot. Always re-taps the element first so keyboard focus is on the correct field even in sequential fills. On "no focused text input" errors, automatically falls back: Pressable→TextInput resolution (common RN design-system pattern where outer Pressable wraps inner TextInput) → coordinate re-tap + retry → Android adb input / iOS Maestro inputText. Check meta.fallbackUsed in the result to see which strategy succeeded. Requires an open session.',
   {
     ref: z.string().describe('Input field ref from device_snapshot (e.g. "e5" or "@e5")'),
     text: z.string().describe('Text to type into the field'),
@@ -770,7 +770,7 @@ trackedTool(
 
 trackedTool(
   'proof_step',
-  'Atomic proof capture step: navigate to a screen (optional), wait for settlement, verify an element (optional), and take a screenshot. Combines 3-4 tool calls into one. Use in Phase 8 proof flows to reduce tool-call overhead.',
+  'Atomic proof capture step: navigate to a screen (optional), wait for settlement, verify an element (optional), and take a screenshot. Combines 3-4 tool calls into one. Use in proof flows to reduce tool-call overhead.',
   {
     screen: z.string().optional().describe('Screen to navigate to (omit to stay on current screen)'),
     params: z.record(z.unknown()).optional().describe('Navigation params (e.g. { id: "1" })'),
@@ -798,7 +798,7 @@ trackedTool(
 
 trackedTool(
   'maestro_generate',
-  'Generate a persistent Maestro YAML flow file from structured steps. Writes to .maestro/flows/<name>.yaml in the project root. Use after Phase 5.5 verification to create regression tests.',
+  'Generate a persistent Maestro YAML flow file from structured steps. Writes to .maestro/flows/<name>.yaml in the project root. Use after live verification to create regression tests.',
   {
     name: z.string().describe('Flow name (e.g. "add-to-cart", "profile-edit"). Becomes filename.'),
     steps: z.array(z.object({
@@ -891,7 +891,7 @@ trackedTool(
 
 trackedTool(
   'cdp_restart',
-  'In-process soft state reset (B76/D644). Disconnects the current CDP client, creates a fresh instance, and reconnects. Clears console/network/error ring buffers, background poll, reconnect state, and helpers-injected flag. Does NOT reload the MCP server binary — to load new dist/ after npm run build, fully quit and relaunch Claude Code. Useful for recovering from stuck connection state (target drift, stale helpers after many reloads) without losing the CC session.',
+  'In-process soft state reset. Disconnects the current CDP client, creates a fresh instance, and reconnects. Clears console/network/error ring buffers, background poll, reconnect state, and helpers-injected flag. Does NOT reload the MCP server binary — to load new dist/ after npm run build, fully quit and relaunch Claude Code. Useful for recovering from stuck connection state (target drift, stale helpers after many reloads) without losing the CC session.',
   {
     metroPort: z.number().optional().describe('Override Metro port for reconnection (default: keep current)'),
     platform: z.string().optional().describe('Platform filter for reconnection (e.g. "ios", "android")'),
@@ -912,14 +912,14 @@ trackedTool(
 
 trackedTool(
   'cdp_open_devtools',
-  'Report the React Native DevTools frontend URL for the live app + start a multiplexer proxy so DevTools can coexist with the MCP session on RN < 0.85 (RN >= 0.85 uses native multi-debugger). M1a (Phase 100) shipped detection + capability reporting; M1b (Phase 104) wired the proxy into CDPClient; B132 (Phase 105) added proxy auto-resume across reconnect. Returns { devtoolsUrl, inspectorWsUrl, hermesWsUrl, mode: "native" | "proxy-active", proxyPort, supportsMultipleDebuggers, rnVersion, guidance }.',
+  'Report the React Native DevTools frontend URL for the live app + start a multiplexer proxy so DevTools can coexist with the MCP session on RN < 0.85 (RN >= 0.85 uses native multi-debugger). The proxy auto-resumes across reconnects. Returns { devtoolsUrl, inspectorWsUrl, hermesWsUrl, mode: "native" | "proxy-active", proxyPort, supportsMultipleDebuggers, rnVersion, guidance }.',
   {},
   createOpenDevToolsHandler(getClient),
 );
 
 trackedTool(
   'cdp_metro_events',
-  'Read Metro reporter events (bundle_build_started, bundle_build_done, bundle_build_failed, reloads) captured since the MCP connected. M5 (Phase 90 Tier 2 / D656): the MetroEventsClient attaches a second WebSocket alongside CDP, giving push-based visibility into bundler state — watch for build errors without having to read console.error. Returns { eventsConnected, lastBuild, buildErrors, events, count }. Pass `clearErrors: true` to reset the build-error counter.',
+  'Read Metro reporter events (bundle_build_started, bundle_build_done, bundle_build_failed, reloads) captured since the MCP connected. The MetroEventsClient attaches a second WebSocket alongside CDP, giving push-based visibility into bundler state — watch for build errors without having to read console.error. Returns { eventsConnected, lastBuild, buildErrors, events, count }. Pass `clearErrors: true` to reset the build-error counter.',
   {
     limit: z.number().int().min(1).max(100).default(20).describe('Max entries to return (default 20, max 100)'),
     type: z.string().optional().describe('Filter by event type (e.g. "bundle_build_failed")'),


### PR DESCRIPTION
Closes GH #60 Bug 6.

## Summary
- **Bug 6 fix**: `cdp_evaluate` description now explicitly states the Hermes dev runtime has NO Node `require()` and routes to `cdp_mmkv` (storage R/W), `cdp_dispatch` (Redux/Zustand mutation), `cdp_component_tree` / `cdp_store_state` (introspection).
- **LOOSE cleanup (10 edits)**: strip internal references that mean nothing to end users and bloat upfront MCP token cost — `B114/D642`, `M4/D655`, `B112`, `B122`, Phase numbers, `B76/D644`, `M1a/M1b/B132`, `D656`.

## Why
Reporter (IX-2950) reached for `require('app/services/storage')` inside `cdp_evaluate` and got `ReferenceError: Property 'require' doesn't exist`. Tool description didn't surface the constraint. The LOOSE cleanup removes another class of friction: tool descriptions full of `(B114/D642)` and `M4/D655:` prefixes are noise to anyone outside this repo.

## Test plan
- [x] No code logic changes — descriptions only.
- [x] 863 tests still pass.
- [x] Single-reviewer Codex pass caught a same-tool parity miss (`device_snapshot.attachOnly` param description still had `(B112/D641)` after the tool description had `B112` stripped). Fixed.

## Files
- `scripts/cdp-bridge/src/index.ts` — 11 description edits (10 LOOSE strips + Bug 6 cdp_evaluate rewrite + 1 same-tool parity fix on `device_snapshot.attachOnly`).

## Out of scope
- `B76/D644` references inside SOURCE COMMENTS at lines 931 and 950 are not tool descriptions; not stripped here.
- LOOSE cleanup is partial — there are more descriptions with internal IDs that could be stripped in a future pass.

Workspace docs (Phase 117, B147): committed as `7005ea6` on `rn-dev-agent-workspace` main.