### PR TITLE
feat(gh-60-c): add device_reset_state composite preflight tool

### DIFF
--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -32,6 +32,7 @@ import { createDeviceListHandler, createDeviceScreenshotHandler } from './tools/
 import { createDeviceSnapshotHandler } from './tools/device-session.js';
 import { createDeviceFindHandler, createDevicePressHandler, createDeviceFillHandler, createDeviceSwipeHandler, createDeviceScrollHandler, createDeviceScrollIntoViewHandler, createDeviceLongPressHandler, createDevicePinchHandler, createDeviceBackHandler, createDeviceFocusNextHandler, } from './tools/device-interact.js';
 import { createDevicePermissionHandler } from './tools/device-permission.js';
+import { createDeviceResetStateHandler } from './tools/device-reset-state.js';
 import { createDeviceDeeplinkHandler } from './tools/device-deeplink.js';
 import { createDeviceRecordHandler } from './tools/device-record.js';
 import { createDeviceAcceptSystemDialogHandler, createDeviceDismissSystemDialogHandler, } from './tools/device-system-dialog.js';
@@ -397,6 +398,19 @@ trackedTool('device_permission', 'Grant, revoke, reset, or query app permissions
     appId: z.string().describe('App bundle ID (e.g. "com.example.app")'),
     platform: z.string().optional().describe('Force platform: "ios" or "android". Auto-detected if omitted.'),
 }, createDevicePermissionHandler());
+trackedTool('device_reset_state', 'One-shot preflight: revoke/reset permissions, clear MMKV storage keys, force-stop the app, then relaunch + reconnect CDP. Composes device_permission + cdp_mmkv + simctl/adb terminate+launch in one atomic call. Best-effort with per-step status — never silently rolls back. Sequence: permission → storage → terminate → launch → reconnect → helpers (→ optional nav_ready). On iOS, permission state is not queryable post-revoke (simctl limitation) — `ok: true` only means the shell-out exited 0. Returns { summary: {ok, failed, skipped}, steps: [...], reconnected, helpersInjected }.', {
+    appId: z.string().describe('App bundle ID, e.g. "com.example.app".'),
+    platform: z.enum(['ios', 'android']).optional().describe('Force platform. Auto-detected from booted devices if omitted.'),
+    permissions: z.array(z.union([
+        z.string(),
+        z.object({ name: z.string(), action: z.enum(['revoke', 'reset']).optional() }),
+    ])).optional().describe('Permissions to revoke/reset before relaunch. String shorthand defaults to revoke. Each entry is processed via device_permission.'),
+    storageKeys: z.array(z.string()).optional().describe('MMKV keys to delete before terminate (so the app reads cleared values on next launch). Skipped if CDP is not connected.'),
+    mmkvInstanceId: z.string().optional().describe('Forwarded to cdp_mmkv. Defaults to mmkv.default.'),
+    relaunch: z.boolean().optional().describe('Launch the app after terminate. Default true.'),
+    waitForReady: z.boolean().optional().describe('After relaunch, wait for CDP reconnect + helpers injection. Default true. Set false to return immediately and let the caller poll.'),
+    waitForNavReady: z.boolean().optional().describe('After helpers, also wait for globalThis.__NAV_REF__ to expose a non-empty navigation state. Default false.'),
+}, createDeviceResetStateHandler(getClient));
 trackedTool('device_deeplink', 'Open a deep link or universal URL on the booted simulator/emulator. Cross-platform: wraps xcrun simctl openurl (iOS) and adb shell am start -a VIEW -d (Android). Session-less — no need to call device_snapshot action=open first. Use to enter the app at a specific route when cdp_navigate is unavailable (RN 0.83 Bridgeless mode) or for universal-link testing.', {
     url: z.string().describe('URL to open, e.g. "myapp://claims/new" or "https://example.com/page".'),
     platform: z.enum(['ios', 'android']).optional().describe('Force platform. Auto-detected from the active session or booted devices if omitted.'),

--- a/scripts/cdp-bridge/dist/tools/app-lifecycle.js
+++ b/scripts/cdp-bridge/dist/tools/app-lifecycle.js
@@ -1,0 +1,42 @@
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+// Safe by construction: argv arrays only, never shell strings.
+// Shared lifecycle ops extracted from startup-replay.ts so device_reset_state
+// can report per-step status (terminate vs launch) instead of one combined call.
+const execFile = promisify(execFileCb);
+const TERMINATE_TIMEOUT_MS = 10_000;
+const LAUNCH_TIMEOUT_MS = 15_000;
+/**
+ * Force-stop the app. Idempotent on both platforms — exits 0 even if the app
+ * wasn't running. iOS: `xcrun simctl terminate booted <bundleId>`. Android:
+ * `adb shell am force-stop <bundleId>`. Errors are propagated so callers can
+ * decide whether to abort or continue (a hung adb is more interesting than
+ * an iOS app that wasn't running).
+ */
+export async function terminateApp(bundleId, platform) {
+    if (platform === 'ios') {
+        await execFile('xcrun', ['simctl', 'terminate', 'booted', bundleId], {
+            timeout: TERMINATE_TIMEOUT_MS, encoding: 'utf8',
+        });
+    }
+    else {
+        await execFile('adb', ['shell', 'am', 'force-stop', bundleId], {
+            timeout: TERMINATE_TIMEOUT_MS, encoding: 'utf8',
+        });
+    }
+}
+/**
+ * Launch the app. iOS: `xcrun simctl launch booted <bundleId>`. Android:
+ * the standard MAIN/LAUNCHER intent (NOT `monkey`, which the brainstorm
+ * flagged as flakier on Android 13+). Throws on failure.
+ */
+export async function launchApp(bundleId, platform) {
+    if (platform === 'ios') {
+        await execFile('xcrun', ['simctl', 'launch', 'booted', bundleId], {
+            timeout: LAUNCH_TIMEOUT_MS, encoding: 'utf8',
+        });
+    }
+    else {
+        await execFile('adb', ['shell', 'am', 'start', '-a', 'android.intent.action.MAIN', '-c', 'android.intent.category.LAUNCHER', bundleId], { timeout: LAUNCH_TIMEOUT_MS, encoding: 'utf8' });
+    }
+}

--- a/scripts/cdp-bridge/dist/tools/device-reset-state.js
+++ b/scripts/cdp-bridge/dist/tools/device-reset-state.js
@@ -1,0 +1,285 @@
+import { okResult, failResult, warnResult } from '../utils.js';
+import { detectPlatform } from './platform-utils.js';
+import { createDevicePermissionHandler } from './device-permission.js';
+import { buildMmkvExpression } from './mmkv.js';
+import { terminateApp, launchApp } from './app-lifecycle.js';
+import { handleDevClientPicker } from './dev-client-picker.js';
+import { waitForNavigationReady } from './startup-replay.js';
+const RECONNECT_ATTEMPTS = 4;
+const RECONNECT_BACKOFF_MS = 2_000;
+const POST_LAUNCH_SETTLE_MS = 1_000;
+const HELPERS_DEADLINE_MS = 15_000;
+const NAV_READY_TIMEOUT_MS = 12_000;
+function normalizePermissions(input) {
+    if (!input || input.length === 0)
+        return [];
+    return input.map((p) => typeof p === 'string' ? { name: p, action: 'revoke' } : { name: p.name, action: p.action ?? 'revoke' });
+}
+async function runPermissionSteps(permissions, appId, platform) {
+    const handler = createDevicePermissionHandler();
+    const results = [];
+    for (const perm of permissions) {
+        const start = Date.now();
+        try {
+            const r = await handler({
+                action: perm.action ?? 'revoke',
+                permission: perm.name,
+                appId,
+                platform,
+            });
+            const failed = r.isError === true;
+            const parsed = failed ? safeParseError(r) : undefined;
+            results.push({
+                step: 'permission',
+                target: perm.name,
+                action: perm.action ?? 'revoke',
+                ok: !failed,
+                durationMs: Date.now() - start,
+                ...(failed ? { code: parsed?.code, error: parsed?.error } : {}),
+            });
+        }
+        catch (e) {
+            results.push({
+                step: 'permission',
+                target: perm.name,
+                action: perm.action ?? 'revoke',
+                ok: false,
+                durationMs: Date.now() - start,
+                error: e instanceof Error ? e.message : String(e),
+            });
+        }
+    }
+    return results;
+}
+async function runStorageSteps(client, keys, instanceId) {
+    const results = [];
+    for (const key of keys) {
+        const start = Date.now();
+        try {
+            const expr = buildMmkvExpression({ action: 'delete', key, instanceId });
+            const evalResult = await client.evaluate(expr);
+            if (evalResult.error) {
+                results.push({
+                    step: 'storage', target: key, action: 'delete', ok: false,
+                    durationMs: Date.now() - start, error: evalResult.error,
+                });
+                continue;
+            }
+            // Expression returns JSON; check for __agent_error sentinel.
+            const raw = typeof evalResult.value === 'string' ? evalResult.value : JSON.stringify(evalResult.value);
+            let parsed;
+            try {
+                parsed = JSON.parse(raw);
+            }
+            catch {
+                parsed = null;
+            }
+            const obj = (parsed && typeof parsed === 'object') ? parsed : null;
+            if (obj && typeof obj.__agent_error === 'string') {
+                results.push({
+                    step: 'storage', target: key, action: 'delete', ok: false,
+                    durationMs: Date.now() - start, error: obj.__agent_error,
+                });
+                continue;
+            }
+            results.push({ step: 'storage', target: key, action: 'delete', ok: true, durationMs: Date.now() - start });
+        }
+        catch (e) {
+            results.push({
+                step: 'storage', target: key, action: 'delete', ok: false,
+                durationMs: Date.now() - start, error: e instanceof Error ? e.message : String(e),
+            });
+        }
+    }
+    return results;
+}
+async function runTerminateStep(appId, platform) {
+    const start = Date.now();
+    try {
+        await terminateApp(appId, platform);
+        return { step: 'terminate', target: appId, ok: true, durationMs: Date.now() - start };
+    }
+    catch (e) {
+        return {
+            step: 'terminate', target: appId, ok: false, durationMs: Date.now() - start,
+            error: e instanceof Error ? e.message : String(e),
+        };
+    }
+}
+async function runLaunchStep(appId, platform) {
+    const start = Date.now();
+    try {
+        await launchApp(appId, platform);
+        return { step: 'launch', target: appId, ok: true, durationMs: Date.now() - start };
+    }
+    catch (e) {
+        return {
+            step: 'launch', target: appId, ok: false, durationMs: Date.now() - start,
+            error: e instanceof Error ? e.message : String(e),
+        };
+    }
+}
+async function runReconnectStep(client) {
+    const start = Date.now();
+    await new Promise((r) => setTimeout(r, POST_LAUNCH_SETTLE_MS));
+    await handleDevClientPicker().catch(() => undefined);
+    for (let attempt = 0; attempt < RECONNECT_ATTEMPTS; attempt++) {
+        try {
+            await client.softReconnect();
+            return {
+                step: { step: 'reconnect', ok: true, durationMs: Date.now() - start },
+                reconnected: true,
+            };
+        }
+        catch (err) {
+            if (attempt < RECONNECT_ATTEMPTS - 1) {
+                await new Promise((r) => setTimeout(r, RECONNECT_BACKOFF_MS));
+            }
+            else {
+                return {
+                    step: {
+                        step: 'reconnect', ok: false, durationMs: Date.now() - start,
+                        error: err instanceof Error ? err.message : String(err),
+                    },
+                    reconnected: false,
+                };
+            }
+        }
+    }
+    return {
+        step: { step: 'reconnect', ok: false, durationMs: Date.now() - start, error: 'reconnect attempts exhausted' },
+        reconnected: false,
+    };
+}
+async function runHelpersStep(client) {
+    const start = Date.now();
+    const deadline = Date.now() + HELPERS_DEADLINE_MS;
+    while (!client.helpersInjected && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 500));
+    }
+    const ok = client.helpersInjected;
+    return {
+        step: {
+            step: 'helpers', ok, durationMs: Date.now() - start,
+            ...(ok ? {} : { error: `helpers not injected within ${HELPERS_DEADLINE_MS}ms` }),
+        },
+        helpersInjected: ok,
+    };
+}
+async function runNavReadyStep(client) {
+    const start = Date.now();
+    const ready = await waitForNavigationReady(client, NAV_READY_TIMEOUT_MS);
+    return {
+        step: 'nav_ready', ok: ready, durationMs: Date.now() - start,
+        ...(ready ? {} : { error: `nav ref not ready within ${NAV_READY_TIMEOUT_MS}ms` }),
+    };
+}
+function safeParseError(r) {
+    try {
+        const text = r.content[0]?.text;
+        if (!text)
+            return {};
+        const parsed = JSON.parse(text);
+        return { code: parsed.code, error: parsed.error };
+    }
+    catch {
+        return {};
+    }
+}
+export function createDeviceResetStateHandler(getClient) {
+    return async (args) => {
+        if (!args.appId || typeof args.appId !== 'string') {
+            return failResult('appId is required.', 'DEVICE_RESET_INVALID_ARGS');
+        }
+        const platform = args.platform ?? (await detectPlatform());
+        if (platform !== 'ios' && platform !== 'android') {
+            return failResult('No iOS simulator or Android device detected. Pass platform explicitly.', 'DEVICE_RESET_INVALID_ARGS');
+        }
+        const permissions = normalizePermissions(args.permissions);
+        const storageKeys = args.storageKeys ?? [];
+        const relaunch = args.relaunch ?? true;
+        const waitForReady = args.waitForReady ?? true;
+        const waitForNavReady = args.waitForNavReady ?? false;
+        const steps = [];
+        let reconnected = false;
+        let helpersInjected = false;
+        let reconnectAttempted = false;
+        // Step 1: permissions (no CDP needed).
+        if (permissions.length > 0) {
+            const permResults = await runPermissionSteps(permissions, args.appId, platform);
+            steps.push(...permResults);
+        }
+        // Step 2: storage (CDP required — best-effort if disconnected).
+        if (storageKeys.length > 0) {
+            const client = getClient();
+            if (!client.isConnected) {
+                for (const key of storageKeys) {
+                    steps.push({
+                        step: 'storage', target: key, action: 'delete', ok: false, durationMs: 0,
+                        code: 'CDP_NOT_CONNECTED',
+                        error: 'CDP not connected — storage keys skipped. Connect first to clear MMKV before terminate.',
+                    });
+                }
+            }
+            else {
+                const storageResults = await runStorageSteps(client, storageKeys, args.mmkvInstanceId);
+                steps.push(...storageResults);
+            }
+        }
+        // Step 3: terminate.
+        steps.push(await runTerminateStep(args.appId, platform));
+        // Step 4: launch + reconnect (gated by relaunch / waitForReady).
+        if (relaunch) {
+            const launchResult = await runLaunchStep(args.appId, platform);
+            steps.push(launchResult);
+            if (launchResult.ok && waitForReady) {
+                // Re-fetch client AFTER launch in case anything swapped it. (No swap
+                // currently happens in this orchestrator, but defensive against
+                // future changes — see B132/B145 territory.)
+                const client = getClient();
+                reconnectAttempted = true;
+                const reconnectStep = await runReconnectStep(client);
+                steps.push(reconnectStep.step);
+                reconnected = reconnectStep.reconnected;
+                if (reconnected) {
+                    const helpersStep = await runHelpersStep(getClient());
+                    steps.push(helpersStep.step);
+                    helpersInjected = helpersStep.helpersInjected;
+                    if (waitForNavReady && helpersInjected) {
+                        steps.push(await runNavReadyStep(getClient()));
+                    }
+                }
+            }
+        }
+        const skipped = steps.filter((s) => s.code === 'CDP_NOT_CONNECTED').length;
+        const okCount = steps.filter((s) => s.ok).length;
+        const failed = steps.filter((s) => !s.ok).length - skipped;
+        const summary = {
+            ok: okCount,
+            failed,
+            skipped,
+        };
+        const data = {
+            appId: args.appId,
+            platform,
+            relaunch,
+            waitForReady,
+            summary,
+            steps,
+            reconnectAttempted,
+            reconnected,
+            helpersInjected,
+        };
+        if (failed === 0 && skipped === 0)
+            return okResult(data);
+        // Only fire RECONNECT_FAILED when reconnect was actually attempted and
+        // failed — not when launch itself failed or reconnect was never reached.
+        if (reconnectAttempted && !reconnected) {
+            return failResult('Reset state ran but CDP reconnect failed. Device IS reset; call cdp_status to retry the connection.', 'DEVICE_RESET_RECONNECT_FAILED', { steps, summary, appId: args.appId, platform });
+        }
+        // All-skipped (only CDP-not-connected entries) is fine — return ok.
+        if (failed === 0)
+            return okResult(data);
+        return warnResult(data, `Reset completed with ${failed} failed step(s). See steps[] for per-step diagnostics.`, { code: 'DEVICE_RESET_STATE_PARTIAL' });
+    };
+}

--- a/scripts/cdp-bridge/dist/tools/startup-replay.js
+++ b/scripts/cdp-bridge/dist/tools/startup-replay.js
@@ -1,28 +1,8 @@
-import { execFile as execFileCb } from 'node:child_process';
-import { promisify } from 'node:util';
 import { getActiveSession } from '../agent-device-wrapper.js';
 import { handleDevClientPicker } from './dev-client-picker.js';
 import { resolveBundleId } from '../project-config.js';
-const execFile = promisify(execFileCb);
-async function launchApp(bundleId, platform) {
-    if (platform === 'ios') {
-        await execFile('xcrun', ['simctl', 'terminate', 'booted', bundleId], {
-            timeout: 10_000, encoding: 'utf8',
-        }).catch(() => { });
-        await execFile('xcrun', ['simctl', 'launch', 'booted', bundleId], {
-            timeout: 15_000, encoding: 'utf8',
-        });
-    }
-    else {
-        await execFile('adb', ['shell', 'am', 'force-stop', bundleId], {
-            timeout: 10_000, encoding: 'utf8',
-        }).catch(() => { });
-        await execFile('adb', ['shell', 'am', 'start', '-a', 'android.intent.action.MAIN', '-c', 'android.intent.category.LAUNCHER', bundleId], {
-            timeout: 15_000, encoding: 'utf8',
-        });
-    }
-}
-async function waitForNavigationReady(client, timeoutMs = 12_000) {
+import { terminateApp, launchApp } from './app-lifecycle.js';
+export async function waitForNavigationReady(client, timeoutMs = 12_000) {
     const checkExpr = `(function() {
     var ref = globalThis.__NAV_REF__;
     if (ref && typeof ref.getRootState === 'function') {
@@ -65,6 +45,7 @@ export async function launchAndNavigate(client, screen, params, opts = {}) {
     let pickerDismissed = false;
     let reconnectAttempts = 0;
     try {
+        await terminateApp(bundleId, platform).catch(() => { });
         await launchApp(bundleId, platform);
     }
     catch (err) {

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -43,6 +43,7 @@ import {
   createDeviceFocusNextHandler,
 } from './tools/device-interact.js';
 import { createDevicePermissionHandler } from './tools/device-permission.js';
+import { createDeviceResetStateHandler } from './tools/device-reset-state.js';
 import { createDeviceDeeplinkHandler } from './tools/device-deeplink.js';
 import { createDeviceRecordHandler } from './tools/device-record.js';
 import {
@@ -654,6 +655,25 @@ trackedTool(
     platform: z.string().optional().describe('Force platform: "ios" or "android". Auto-detected if omitted.'),
   },
   createDevicePermissionHandler(),
+);
+
+trackedTool(
+  'device_reset_state',
+  'One-shot preflight: revoke/reset permissions, clear MMKV storage keys, force-stop the app, then relaunch + reconnect CDP. Composes device_permission + cdp_mmkv + simctl/adb terminate+launch in one atomic call. Best-effort with per-step status — never silently rolls back. Sequence: permission → storage → terminate → launch → reconnect → helpers (→ optional nav_ready). On iOS, permission state is not queryable post-revoke (simctl limitation) — `ok: true` only means the shell-out exited 0. Returns { summary: {ok, failed, skipped}, steps: [...], reconnected, helpersInjected }.',
+  {
+    appId: z.string().describe('App bundle ID, e.g. "com.example.app".'),
+    platform: z.enum(['ios', 'android']).optional().describe('Force platform. Auto-detected from booted devices if omitted.'),
+    permissions: z.array(z.union([
+      z.string(),
+      z.object({ name: z.string(), action: z.enum(['revoke', 'reset']).optional() }),
+    ])).optional().describe('Permissions to revoke/reset before relaunch. String shorthand defaults to revoke. Each entry is processed via device_permission.'),
+    storageKeys: z.array(z.string()).optional().describe('MMKV keys to delete before terminate (so the app reads cleared values on next launch). Skipped if CDP is not connected.'),
+    mmkvInstanceId: z.string().optional().describe('Forwarded to cdp_mmkv. Defaults to mmkv.default.'),
+    relaunch: z.boolean().optional().describe('Launch the app after terminate. Default true.'),
+    waitForReady: z.boolean().optional().describe('After relaunch, wait for CDP reconnect + helpers injection. Default true. Set false to return immediately and let the caller poll.'),
+    waitForNavReady: z.boolean().optional().describe('After helpers, also wait for globalThis.__NAV_REF__ to expose a non-empty navigation state. Default false.'),
+  },
+  createDeviceResetStateHandler(getClient),
 );
 
 trackedTool(

--- a/scripts/cdp-bridge/src/tools/app-lifecycle.ts
+++ b/scripts/cdp-bridge/src/tools/app-lifecycle.ts
@@ -1,0 +1,48 @@
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+
+// Safe by construction: argv arrays only, never shell strings.
+// Shared lifecycle ops extracted from startup-replay.ts so device_reset_state
+// can report per-step status (terminate vs launch) instead of one combined call.
+const execFile = promisify(execFileCb);
+
+const TERMINATE_TIMEOUT_MS = 10_000;
+const LAUNCH_TIMEOUT_MS = 15_000;
+
+/**
+ * Force-stop the app. Idempotent on both platforms — exits 0 even if the app
+ * wasn't running. iOS: `xcrun simctl terminate booted <bundleId>`. Android:
+ * `adb shell am force-stop <bundleId>`. Errors are propagated so callers can
+ * decide whether to abort or continue (a hung adb is more interesting than
+ * an iOS app that wasn't running).
+ */
+export async function terminateApp(bundleId: string, platform: 'ios' | 'android'): Promise<void> {
+  if (platform === 'ios') {
+    await execFile('xcrun', ['simctl', 'terminate', 'booted', bundleId], {
+      timeout: TERMINATE_TIMEOUT_MS, encoding: 'utf8',
+    });
+  } else {
+    await execFile('adb', ['shell', 'am', 'force-stop', bundleId], {
+      timeout: TERMINATE_TIMEOUT_MS, encoding: 'utf8',
+    });
+  }
+}
+
+/**
+ * Launch the app. iOS: `xcrun simctl launch booted <bundleId>`. Android:
+ * the standard MAIN/LAUNCHER intent (NOT `monkey`, which the brainstorm
+ * flagged as flakier on Android 13+). Throws on failure.
+ */
+export async function launchApp(bundleId: string, platform: 'ios' | 'android'): Promise<void> {
+  if (platform === 'ios') {
+    await execFile('xcrun', ['simctl', 'launch', 'booted', bundleId], {
+      timeout: LAUNCH_TIMEOUT_MS, encoding: 'utf8',
+    });
+  } else {
+    await execFile(
+      'adb',
+      ['shell', 'am', 'start', '-a', 'android.intent.action.MAIN', '-c', 'android.intent.category.LAUNCHER', bundleId],
+      { timeout: LAUNCH_TIMEOUT_MS, encoding: 'utf8' },
+    );
+  }
+}

--- a/scripts/cdp-bridge/src/tools/device-reset-state.ts
+++ b/scripts/cdp-bridge/src/tools/device-reset-state.ts
@@ -1,0 +1,367 @@
+import type { CDPClient } from '../cdp-client.js';
+import { okResult, failResult, warnResult, type ToolResult } from '../utils.js';
+import { detectPlatform } from './platform-utils.js';
+import { createDevicePermissionHandler } from './device-permission.js';
+import { buildMmkvExpression } from './mmkv.js';
+import { terminateApp, launchApp } from './app-lifecycle.js';
+import { handleDevClientPicker } from './dev-client-picker.js';
+import { waitForNavigationReady } from './startup-replay.js';
+
+// GH #60 Feature-c / D687: device_reset_state composes the 4-step preflight
+// (permissions → storage → terminate → launch+reconnect) into a single MCP
+// call. Best-effort with per-step status; never silently rolls back.
+//
+// Sequence rationale (Codex/Claude consensus):
+// 1. Permissions FIRST — changes can trigger app-side observers that write
+//    cooldown keys, which must be deletable by the next step.
+// 2. MMKV BEFORE terminate — cdp_mmkv requires a live CDP target, and MMKV
+//    mmap visibility means writes are observable by the next process.
+// 3. Terminate before launch (idempotent on both platforms).
+// 4. Reconnect only if waitForReady — caller can opt out for faster return.
+
+type PermissionAction = 'revoke' | 'reset';
+
+export interface PermissionSpec {
+  name: string;
+  action?: PermissionAction;
+}
+
+export interface DeviceResetStateArgs {
+  appId: string;
+  platform?: 'ios' | 'android';
+  permissions?: Array<string | PermissionSpec>;
+  storageKeys?: string[];
+  mmkvInstanceId?: string;
+  relaunch?: boolean;
+  waitForReady?: boolean;
+  waitForNavReady?: boolean;
+}
+
+type StepName =
+  | 'permission'
+  | 'storage'
+  | 'terminate'
+  | 'launch'
+  | 'reconnect'
+  | 'helpers'
+  | 'nav_ready';
+
+interface StepResult {
+  step: StepName;
+  target?: string;
+  action?: string;
+  ok: boolean;
+  durationMs: number;
+  code?: string;
+  error?: string;
+}
+
+const RECONNECT_ATTEMPTS = 4;
+const RECONNECT_BACKOFF_MS = 2_000;
+const POST_LAUNCH_SETTLE_MS = 1_000;
+const HELPERS_DEADLINE_MS = 15_000;
+const NAV_READY_TIMEOUT_MS = 12_000;
+
+function normalizePermissions(input: DeviceResetStateArgs['permissions']): PermissionSpec[] {
+  if (!input || input.length === 0) return [];
+  return input.map((p) =>
+    typeof p === 'string' ? { name: p, action: 'revoke' as const } : { name: p.name, action: p.action ?? 'revoke' },
+  );
+}
+
+async function runPermissionSteps(
+  permissions: PermissionSpec[],
+  appId: string,
+  platform: 'ios' | 'android',
+): Promise<StepResult[]> {
+  const handler = createDevicePermissionHandler();
+  const results: StepResult[] = [];
+  for (const perm of permissions) {
+    const start = Date.now();
+    try {
+      const r = await handler({
+        action: perm.action ?? 'revoke',
+        permission: perm.name,
+        appId,
+        platform,
+      });
+      const failed = r.isError === true;
+      const parsed = failed ? safeParseError(r) : undefined;
+      results.push({
+        step: 'permission',
+        target: perm.name,
+        action: perm.action ?? 'revoke',
+        ok: !failed,
+        durationMs: Date.now() - start,
+        ...(failed ? { code: parsed?.code, error: parsed?.error } : {}),
+      });
+    } catch (e: unknown) {
+      results.push({
+        step: 'permission',
+        target: perm.name,
+        action: perm.action ?? 'revoke',
+        ok: false,
+        durationMs: Date.now() - start,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+  return results;
+}
+
+async function runStorageSteps(
+  client: CDPClient,
+  keys: string[],
+  instanceId: string | undefined,
+): Promise<StepResult[]> {
+  const results: StepResult[] = [];
+  for (const key of keys) {
+    const start = Date.now();
+    try {
+      const expr = buildMmkvExpression({ action: 'delete', key, instanceId });
+      const evalResult = await client.evaluate(expr);
+      if (evalResult.error) {
+        results.push({
+          step: 'storage', target: key, action: 'delete', ok: false,
+          durationMs: Date.now() - start, error: evalResult.error,
+        });
+        continue;
+      }
+      // Expression returns JSON; check for __agent_error sentinel.
+      const raw = typeof evalResult.value === 'string' ? evalResult.value : JSON.stringify(evalResult.value);
+      let parsed: unknown;
+      try { parsed = JSON.parse(raw); } catch { parsed = null; }
+      const obj = (parsed && typeof parsed === 'object') ? parsed as Record<string, unknown> : null;
+      if (obj && typeof obj.__agent_error === 'string') {
+        results.push({
+          step: 'storage', target: key, action: 'delete', ok: false,
+          durationMs: Date.now() - start, error: obj.__agent_error,
+        });
+        continue;
+      }
+      results.push({ step: 'storage', target: key, action: 'delete', ok: true, durationMs: Date.now() - start });
+    } catch (e: unknown) {
+      results.push({
+        step: 'storage', target: key, action: 'delete', ok: false,
+        durationMs: Date.now() - start, error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+  return results;
+}
+
+async function runTerminateStep(appId: string, platform: 'ios' | 'android'): Promise<StepResult> {
+  const start = Date.now();
+  try {
+    await terminateApp(appId, platform);
+    return { step: 'terminate', target: appId, ok: true, durationMs: Date.now() - start };
+  } catch (e: unknown) {
+    return {
+      step: 'terminate', target: appId, ok: false, durationMs: Date.now() - start,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+async function runLaunchStep(appId: string, platform: 'ios' | 'android'): Promise<StepResult> {
+  const start = Date.now();
+  try {
+    await launchApp(appId, platform);
+    return { step: 'launch', target: appId, ok: true, durationMs: Date.now() - start };
+  } catch (e: unknown) {
+    return {
+      step: 'launch', target: appId, ok: false, durationMs: Date.now() - start,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+async function runReconnectStep(client: CDPClient): Promise<{ step: StepResult; reconnected: boolean }> {
+  const start = Date.now();
+  await new Promise((r) => setTimeout(r, POST_LAUNCH_SETTLE_MS));
+  await handleDevClientPicker().catch(() => undefined);
+
+  for (let attempt = 0; attempt < RECONNECT_ATTEMPTS; attempt++) {
+    try {
+      await client.softReconnect();
+      return {
+        step: { step: 'reconnect', ok: true, durationMs: Date.now() - start },
+        reconnected: true,
+      };
+    } catch (err) {
+      if (attempt < RECONNECT_ATTEMPTS - 1) {
+        await new Promise((r) => setTimeout(r, RECONNECT_BACKOFF_MS));
+      } else {
+        return {
+          step: {
+            step: 'reconnect', ok: false, durationMs: Date.now() - start,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          reconnected: false,
+        };
+      }
+    }
+  }
+  return {
+    step: { step: 'reconnect', ok: false, durationMs: Date.now() - start, error: 'reconnect attempts exhausted' },
+    reconnected: false,
+  };
+}
+
+async function runHelpersStep(client: CDPClient): Promise<{ step: StepResult; helpersInjected: boolean }> {
+  const start = Date.now();
+  const deadline = Date.now() + HELPERS_DEADLINE_MS;
+  while (!client.helpersInjected && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  const ok = client.helpersInjected;
+  return {
+    step: {
+      step: 'helpers', ok, durationMs: Date.now() - start,
+      ...(ok ? {} : { error: `helpers not injected within ${HELPERS_DEADLINE_MS}ms` }),
+    },
+    helpersInjected: ok,
+  };
+}
+
+async function runNavReadyStep(client: CDPClient): Promise<StepResult> {
+  const start = Date.now();
+  const ready = await waitForNavigationReady(client, NAV_READY_TIMEOUT_MS);
+  return {
+    step: 'nav_ready', ok: ready, durationMs: Date.now() - start,
+    ...(ready ? {} : { error: `nav ref not ready within ${NAV_READY_TIMEOUT_MS}ms` }),
+  };
+}
+
+function safeParseError(r: ToolResult): { code?: string; error?: string } {
+  try {
+    const text = r.content[0]?.text;
+    if (!text) return {};
+    const parsed = JSON.parse(text) as { code?: string; error?: string };
+    return { code: parsed.code, error: parsed.error };
+  } catch {
+    return {};
+  }
+}
+
+export function createDeviceResetStateHandler(
+  getClient: () => CDPClient,
+): (args: DeviceResetStateArgs) => Promise<ToolResult> {
+  return async (args) => {
+    if (!args.appId || typeof args.appId !== 'string') {
+      return failResult('appId is required.', 'DEVICE_RESET_INVALID_ARGS');
+    }
+    const platform = args.platform ?? (await detectPlatform());
+    if (platform !== 'ios' && platform !== 'android') {
+      return failResult(
+        'No iOS simulator or Android device detected. Pass platform explicitly.',
+        'DEVICE_RESET_INVALID_ARGS',
+      );
+    }
+
+    const permissions = normalizePermissions(args.permissions);
+    const storageKeys = args.storageKeys ?? [];
+    const relaunch = args.relaunch ?? true;
+    const waitForReady = args.waitForReady ?? true;
+    const waitForNavReady = args.waitForNavReady ?? false;
+
+    const steps: StepResult[] = [];
+    let reconnected = false;
+    let helpersInjected = false;
+    let reconnectAttempted = false;
+
+    // Step 1: permissions (no CDP needed).
+    if (permissions.length > 0) {
+      const permResults = await runPermissionSteps(permissions, args.appId, platform);
+      steps.push(...permResults);
+    }
+
+    // Step 2: storage (CDP required — best-effort if disconnected).
+    if (storageKeys.length > 0) {
+      const client = getClient();
+      if (!client.isConnected) {
+        for (const key of storageKeys) {
+          steps.push({
+            step: 'storage', target: key, action: 'delete', ok: false, durationMs: 0,
+            code: 'CDP_NOT_CONNECTED',
+            error: 'CDP not connected — storage keys skipped. Connect first to clear MMKV before terminate.',
+          });
+        }
+      } else {
+        const storageResults = await runStorageSteps(client, storageKeys, args.mmkvInstanceId);
+        steps.push(...storageResults);
+      }
+    }
+
+    // Step 3: terminate.
+    steps.push(await runTerminateStep(args.appId, platform));
+
+    // Step 4: launch + reconnect (gated by relaunch / waitForReady).
+    if (relaunch) {
+      const launchResult = await runLaunchStep(args.appId, platform);
+      steps.push(launchResult);
+      if (launchResult.ok && waitForReady) {
+        // Re-fetch client AFTER launch in case anything swapped it. (No swap
+        // currently happens in this orchestrator, but defensive against
+        // future changes — see B132/B145 territory.)
+        const client = getClient();
+        reconnectAttempted = true;
+        const reconnectStep = await runReconnectStep(client);
+        steps.push(reconnectStep.step);
+        reconnected = reconnectStep.reconnected;
+
+        if (reconnected) {
+          const helpersStep = await runHelpersStep(getClient());
+          steps.push(helpersStep.step);
+          helpersInjected = helpersStep.helpersInjected;
+
+          if (waitForNavReady && helpersInjected) {
+            steps.push(await runNavReadyStep(getClient()));
+          }
+        }
+      }
+    }
+
+    const skipped = steps.filter((s) => s.code === 'CDP_NOT_CONNECTED').length;
+    const okCount = steps.filter((s) => s.ok).length;
+    const failed = steps.filter((s) => !s.ok).length - skipped;
+    const summary = {
+      ok: okCount,
+      failed,
+      skipped,
+    };
+
+    const data = {
+      appId: args.appId,
+      platform,
+      relaunch,
+      waitForReady,
+      summary,
+      steps,
+      reconnectAttempted,
+      reconnected,
+      helpersInjected,
+    };
+
+    if (failed === 0 && skipped === 0) return okResult(data);
+
+    // Only fire RECONNECT_FAILED when reconnect was actually attempted and
+    // failed — not when launch itself failed or reconnect was never reached.
+    if (reconnectAttempted && !reconnected) {
+      return failResult(
+        'Reset state ran but CDP reconnect failed. Device IS reset; call cdp_status to retry the connection.',
+        'DEVICE_RESET_RECONNECT_FAILED',
+        { steps, summary, appId: args.appId, platform },
+      );
+    }
+
+    // All-skipped (only CDP-not-connected entries) is fine — return ok.
+    if (failed === 0) return okResult(data);
+
+    return warnResult(
+      data,
+      `Reset completed with ${failed} failed step(s). See steps[] for per-step diagnostics.`,
+      { code: 'DEVICE_RESET_STATE_PARTIAL' },
+    );
+  };
+}

--- a/scripts/cdp-bridge/src/tools/startup-replay.ts
+++ b/scripts/cdp-bridge/src/tools/startup-replay.ts
@@ -1,11 +1,8 @@
-import { execFile as execFileCb } from 'node:child_process';
-import { promisify } from 'node:util';
 import type { CDPClient } from '../cdp-client.js';
 import { getActiveSession } from '../agent-device-wrapper.js';
 import { handleDevClientPicker } from './dev-client-picker.js';
 import { resolveBundleId } from '../project-config.js';
-
-const execFile = promisify(execFileCb);
+import { terminateApp, launchApp } from './app-lifecycle.js';
 
 export interface StartupReplayResult {
   arrived: boolean;
@@ -18,25 +15,7 @@ export interface StartupReplayResult {
   error?: string;
 }
 
-async function launchApp(bundleId: string, platform: string): Promise<void> {
-  if (platform === 'ios') {
-    await execFile('xcrun', ['simctl', 'terminate', 'booted', bundleId], {
-      timeout: 10_000, encoding: 'utf8',
-    }).catch(() => {});
-    await execFile('xcrun', ['simctl', 'launch', 'booted', bundleId], {
-      timeout: 15_000, encoding: 'utf8',
-    });
-  } else {
-    await execFile('adb', ['shell', 'am', 'force-stop', bundleId], {
-      timeout: 10_000, encoding: 'utf8',
-    }).catch(() => {});
-    await execFile('adb', ['shell', 'am', 'start', '-a', 'android.intent.action.MAIN', '-c', 'android.intent.category.LAUNCHER', bundleId], {
-      timeout: 15_000, encoding: 'utf8',
-    });
-  }
-}
-
-async function waitForNavigationReady(client: CDPClient, timeoutMs = 12_000): Promise<boolean> {
+export async function waitForNavigationReady(client: CDPClient, timeoutMs = 12_000): Promise<boolean> {
   const checkExpr = `(function() {
     var ref = globalThis.__NAV_REF__;
     if (ref && typeof ref.getRootState === 'function') {
@@ -87,7 +66,8 @@ export async function launchAndNavigate(
   let reconnectAttempts = 0;
 
   try {
-    await launchApp(bundleId, platform);
+    await terminateApp(bundleId, platform as 'ios' | 'android').catch(() => { /* idempotent */ });
+    await launchApp(bundleId, platform as 'ios' | 'android');
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return {

--- a/scripts/cdp-bridge/src/types.ts
+++ b/scripts/cdp-bridge/src/types.ts
@@ -165,7 +165,12 @@ export type ToolErrorCode =
   | 'NO_PROJECT_ROOT'
   | 'BAD_FILENAME'
   | 'LOAD_FAILED'
-  | 'BAD_RECORDING';
+  | 'BAD_RECORDING'
+  // GH #60 Feature-c (D687): device_reset_state composite tool.
+  | 'DEVICE_RESET_INVALID_ARGS'
+  | 'DEVICE_RESET_STATE_PARTIAL'
+  | 'DEVICE_RESET_RECONNECT_FAILED'
+  | 'CDP_NOT_CONNECTED';
 
 export interface ResultEnvelope<T = unknown> {
   ok: boolean;

--- a/scripts/cdp-bridge/test/unit/gh-60-feature-c-device-reset-state.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-60-feature-c-device-reset-state.test.js
@@ -1,0 +1,326 @@
+// GH #60 Feature-c / D687: device_reset_state orchestrator. Composes
+// device_permission + cdp_mmkv + simctl/adb terminate+launch in one call,
+// best-effort with per-step status. Tests cover the orchestration logic
+// (sequence, partial-failure semantics, response shape) by mocking a
+// CDPClient and observing the response envelope. Spawned subprocess paths
+// (xcrun simctl, adb) may fail in the sandbox — we assert SHAPE rather than
+// running them through.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const MOD_PATH = '../../dist/tools/device-reset-state.js';
+
+function makeMockClient(opts = {}) {
+  const calls = { evaluate: [], softReconnect: 0 };
+  return {
+    isConnected: opts.isConnected ?? true,
+    helpersInjected: opts.helpersInjected ?? true,
+    metroPort: opts.metroPort ?? 8081,
+    connectedTarget: opts.connectedTarget ?? null,
+    proxyDesired: false,
+    evaluate: async (expr) => {
+      calls.evaluate.push(expr);
+      if (opts.evaluateImpl) return opts.evaluateImpl(expr);
+      return { value: JSON.stringify({ deleted: true }) };
+    },
+    softReconnect: async () => {
+      calls.softReconnect += 1;
+      if (opts.softReconnectImpl) return opts.softReconnectImpl();
+    },
+    autoConnect: async () => 'connected',
+    disconnect: async () => undefined,
+    _calls: calls,
+  };
+}
+
+function parseEnvelope(result) {
+  return JSON.parse(result.content[0].text);
+}
+
+// ── Args validation ─────────────────────────────────────────────────────
+
+test('args: missing appId returns DEVICE_RESET_INVALID_ARGS failResult', async () => {
+  const { createDeviceResetStateHandler } = await import(MOD_PATH);
+  const handler = createDeviceResetStateHandler(() => makeMockClient());
+  const result = await handler({});
+  assert.equal(result.isError, true);
+  const env = parseEnvelope(result);
+  assert.equal(env.code, 'DEVICE_RESET_INVALID_ARGS');
+  assert.match(env.error, /appId is required/);
+});
+
+test('args: explicit invalid platform returns DEVICE_RESET_INVALID_ARGS', async () => {
+  const { createDeviceResetStateHandler } = await import(MOD_PATH);
+  const handler = createDeviceResetStateHandler(() => makeMockClient());
+  const result = await handler({ appId: 'com.example.app', platform: 'windows' });
+  assert.equal(result.isError, true);
+  const env = parseEnvelope(result);
+  assert.equal(env.code, 'DEVICE_RESET_INVALID_ARGS');
+});
+
+// ── Empty-input path ────────────────────────────────────────────────────
+
+test('empty permissions + empty storageKeys + relaunch=false: only terminate runs', async () => {
+  const { createDeviceResetStateHandler } = await import(MOD_PATH);
+  const client = makeMockClient();
+  const handler = createDeviceResetStateHandler(() => client);
+  const result = await handler({
+    appId: 'com.example.app',
+    platform: 'ios',
+    relaunch: false,
+  });
+  const env = parseEnvelope(result);
+  assert.ok('content' in result);
+  assert.ok(env.data, 'envelope must carry data');
+  assert.equal(env.data.platform, 'ios');
+  assert.equal(env.data.relaunch, false);
+  assert.ok(Array.isArray(env.data.steps), 'steps[] required');
+  assert.equal(env.data.steps.length, 1, 'only terminate step ran');
+  assert.equal(env.data.steps[0].step, 'terminate');
+});
+
+// ── Storage step: CDP not connected → all keys skipped ──────────────────
+
+test('storageKeys when CDP not connected: each key marked skipped with CDP_NOT_CONNECTED', async () => {
+  const { createDeviceResetStateHandler } = await import(MOD_PATH);
+  const client = makeMockClient({ isConnected: false });
+  const handler = createDeviceResetStateHandler(() => client);
+  const result = await handler({
+    appId: 'com.example.app',
+    platform: 'ios',
+    storageKeys: ['cooldown1', 'cooldown2'],
+    relaunch: false,
+  });
+  const env = parseEnvelope(result);
+  const storageSteps = env.data.steps.filter((s) => s.step === 'storage');
+  assert.equal(storageSteps.length, 2);
+  for (const s of storageSteps) {
+    assert.equal(s.ok, false);
+    assert.equal(s.code, 'CDP_NOT_CONNECTED');
+    assert.match(s.error, /CDP not connected/);
+  }
+  assert.equal(env.data.summary.skipped, 2);
+  // No evaluate() calls when not connected.
+  assert.equal(client._calls.evaluate.length, 0);
+});
+
+// ── Storage step: __agent_error sentinel surfaces as failure ────────────
+
+test('storageKeys when MMKV unavailable: __agent_error surfaces per-key failure', async () => {
+  const { createDeviceResetStateHandler } = await import(MOD_PATH);
+  const client = makeMockClient({
+    evaluateImpl: () => ({
+      value: JSON.stringify({ __agent_error: 'NitroModulesProxy not available — MMKV requires react-native-mmkv v3+' }),
+    }),
+  });
+  const handler = createDeviceResetStateHandler(() => client);
+  const result = await handler({
+    appId: 'com.example.app',
+    platform: 'ios',
+    storageKeys: ['cooldown1'],
+    relaunch: false,
+  });
+  const env = parseEnvelope(result);
+  const storage = env.data.steps.find((s) => s.step === 'storage');
+  assert.ok(storage);
+  assert.equal(storage.ok, false);
+  assert.match(storage.error, /NitroModulesProxy not available/);
+  assert.equal(client._calls.evaluate.length, 1);
+  assert.match(client._calls.evaluate[0], /MMKVFactory|mmkv\.delete|nitro/i);
+});
+
+// ── Storage step: happy path ────────────────────────────────────────────
+
+test('storageKeys success: each key reports ok with action=delete', async () => {
+  const { createDeviceResetStateHandler } = await import(MOD_PATH);
+  const client = makeMockClient({
+    evaluateImpl: () => ({ value: JSON.stringify({ deleted: true }) }),
+  });
+  const handler = createDeviceResetStateHandler(() => client);
+  const result = await handler({
+    appId: 'com.example.app',
+    platform: 'ios',
+    storageKeys: ['k1', 'k2'],
+    relaunch: false,
+  });
+  const env = parseEnvelope(result);
+  const storage = env.data.steps.filter((s) => s.step === 'storage');
+  assert.equal(storage.length, 2);
+  assert.equal(storage[0].ok, true);
+  assert.equal(storage[0].action, 'delete');
+  assert.equal(storage[0].target, 'k1');
+  assert.equal(storage[1].target, 'k2');
+});
+
+// ── Permission shorthand string defaults to revoke ──────────────────────
+
+test('permissions string shorthand normalizes to action=revoke', async () => {
+  const { createDeviceResetStateHandler } = await import(MOD_PATH);
+  const client = makeMockClient({ isConnected: false });
+  const handler = createDeviceResetStateHandler(() => client);
+  const result = await handler({
+    appId: 'com.example.app',
+    platform: 'ios',
+    permissions: ['notifications'],
+    relaunch: false,
+  });
+  const env = parseEnvelope(result);
+  const perm = env.data.steps.find((s) => s.step === 'permission');
+  assert.ok(perm);
+  assert.equal(perm.target, 'notifications');
+  assert.equal(perm.action, 'revoke');
+});
+
+test('permissions object form preserves action=reset', async () => {
+  const { createDeviceResetStateHandler } = await import(MOD_PATH);
+  const handler = createDeviceResetStateHandler(() => makeMockClient({ isConnected: false }));
+  const result = await handler({
+    appId: 'com.example.app',
+    platform: 'ios',
+    permissions: [{ name: 'notifications', action: 'reset' }],
+    relaunch: false,
+  });
+  const env = parseEnvelope(result);
+  const perm = env.data.steps.find((s) => s.step === 'permission');
+  assert.equal(perm.action, 'reset');
+});
+
+// ── Relaunch flag controls launch/reconnect/helpers ─────────────────────
+
+test('relaunch=false: no launch / reconnect / helpers steps in output', async () => {
+  const { createDeviceResetStateHandler } = await import(MOD_PATH);
+  const handler = createDeviceResetStateHandler(() => makeMockClient());
+  const result = await handler({
+    appId: 'com.example.app',
+    platform: 'ios',
+    relaunch: false,
+  });
+  const env = parseEnvelope(result);
+  const stepNames = env.data.steps.map((s) => s.step);
+  assert.ok(!stepNames.includes('launch'));
+  assert.ok(!stepNames.includes('reconnect'));
+  assert.ok(!stepNames.includes('helpers'));
+  assert.equal(env.data.relaunch, false);
+});
+
+test('relaunch=true + waitForReady=false: launch runs, reconnect/helpers do not', async () => {
+  const { createDeviceResetStateHandler } = await import(MOD_PATH);
+  const handler = createDeviceResetStateHandler(() => makeMockClient());
+  const result = await handler({
+    appId: 'com.example.app',
+    platform: 'ios',
+    relaunch: true,
+    waitForReady: false,
+  });
+  const env = parseEnvelope(result);
+  const stepNames = env.data.steps.map((s) => s.step);
+  assert.ok(stepNames.includes('launch'));
+  assert.ok(!stepNames.includes('reconnect'));
+  assert.ok(!stepNames.includes('helpers'));
+  assert.equal(env.data.reconnected, false);
+});
+
+// ── Multi-LLM review fixes (Codex + Gemini) ─────────────────────────────
+
+test('reconnectAttempted flag distinguishes "skipped reconnect" from "failed reconnect"', async () => {
+  // Codex/Gemini: reconnected:false alone is ambiguous — it means both
+  // "reconnect failed" and "reconnect never attempted". We add an explicit
+  // reconnectAttempted boolean and assert both states.
+  const { createDeviceResetStateHandler } = await import(MOD_PATH);
+
+  // Case A: relaunch=false → reconnectAttempted MUST be false.
+  const h1 = createDeviceResetStateHandler(() => makeMockClient());
+  const r1 = await h1({ appId: 'com.example.app', platform: 'ios', relaunch: false });
+  const e1 = parseEnvelope(r1);
+  assert.equal(e1.data.reconnectAttempted, false, 'relaunch=false → reconnect not attempted');
+  assert.equal(e1.data.reconnected, false);
+
+  // Case B: relaunch=true + waitForReady=false → reconnectAttempted MUST be false.
+  const h2 = createDeviceResetStateHandler(() => makeMockClient());
+  const r2 = await h2({ appId: 'com.example.app', platform: 'ios', waitForReady: false });
+  const e2 = parseEnvelope(r2);
+  assert.equal(e2.data.reconnectAttempted, false, 'waitForReady=false → reconnect not attempted');
+});
+
+test('summary.failed does NOT double-count CDP_NOT_CONNECTED skips (Codex review)', async () => {
+  // Codex: previously summary.failed and summary.skipped both counted
+  // CDP_NOT_CONNECTED entries → failed >= skipped always. Fix: failed
+  // is steps-with-ok-false MINUS skipped.
+  const { createDeviceResetStateHandler } = await import(MOD_PATH);
+  const handler = createDeviceResetStateHandler(() => makeMockClient({ isConnected: false }));
+  const result = await handler({
+    appId: 'com.example.app',
+    platform: 'ios',
+    storageKeys: ['k1', 'k2', 'k3'],
+    relaunch: false,
+  });
+  const env = parseEnvelope(result);
+  // 3 storage skips + 1 terminate (terminate may fail in sandbox; that's fine).
+  // Critical: skipped MUST NOT be inflated into failed.
+  assert.equal(env.data.summary.skipped, 3, 'three storage keys skipped');
+  // failed counts only NON-skipped failures (the terminate step's outcome).
+  assert.ok(env.data.summary.failed <= 1, 'failed should not include the 3 skipped entries');
+});
+
+test('all-skipped (CDP down + no relaunch) returns okResult — not failed', async () => {
+  // Codex: when only skipped steps fail, the response should be ok-shape
+  // because the skips were intentional (CDP not connected, partial reset).
+  // We assert this for the storage-only-skip case where terminate succeeds.
+  // (Terminate may fail in sandbox; we only assert the not-isError case
+  // when it does succeed.)
+  const { createDeviceResetStateHandler } = await import(MOD_PATH);
+  const handler = createDeviceResetStateHandler(() => makeMockClient({ isConnected: false }));
+  const result = await handler({
+    appId: 'com.example.app',
+    platform: 'ios',
+    storageKeys: ['k1'],
+    relaunch: false,
+  });
+  const env = parseEnvelope(result);
+  // If terminate succeeded in the sandbox, the only failure is the skip,
+  // so failed === 0 and the envelope is NOT isError.
+  if (env.data.summary.failed === 0) {
+    assert.notEqual(result.isError, true, 'all-skipped + no real failures → not isError');
+  }
+  // If terminate also failed, we get warnResult — still not isError.
+  assert.notEqual(result.isError, true, 'all-skipped paths are never isError');
+});
+
+// ── Source guards ───────────────────────────────────────────────────────
+
+test('source guard: device_reset_state tool registered in built index.js', async () => {
+  const { readFileSync } = await import('node:fs');
+  const { fileURLToPath } = await import('node:url');
+  const { dirname, join } = await import('node:path');
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const indexSrc = readFileSync(join(__dirname, '../../dist/index.js'), 'utf-8');
+  assert.match(indexSrc, /'device_reset_state'/);
+  assert.match(indexSrc, /createDeviceResetStateHandler/);
+});
+
+test('source guard: orchestrator imports buildMmkvExpression + terminateApp + launchApp', async () => {
+  const { readFileSync } = await import('node:fs');
+  const { fileURLToPath } = await import('node:url');
+  const { dirname, join } = await import('node:path');
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(join(__dirname, '../../dist/tools/device-reset-state.js'), 'utf-8');
+  assert.match(src, /buildMmkvExpression/);
+  assert.match(src, /terminateApp/);
+  assert.match(src, /launchApp/);
+});
+
+test('source guard: shared app-lifecycle helpers exported', async () => {
+  const { terminateApp, launchApp } = await import('../../dist/tools/app-lifecycle.js');
+  assert.equal(typeof terminateApp, 'function');
+  assert.equal(typeof launchApp, 'function');
+});
+
+test('source guard: startup-replay reuses extracted helpers (no inline launchApp)', async () => {
+  const { readFileSync } = await import('node:fs');
+  const { fileURLToPath } = await import('node:url');
+  const { dirname, join } = await import('node:path');
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(join(__dirname, '../../dist/tools/startup-replay.js'), 'utf-8');
+  assert.match(src, /from "\.\/app-lifecycle\.js"|from '\.\/app-lifecycle\.js'/);
+  assert.equal(/^function launchApp\b/m.test(src), false, 'private launchApp should have been removed');
+});


### PR DESCRIPTION
Closes GH #60 Feature-c.

## Summary
- New `device_reset_state` MCP tool consolidates the recurring 4-step preflight (revoke permission → clear MMKV cooldown keys → terminate → relaunch+reconnect) into one call.
- Sequence: **permission → storage → terminate → launch → reconnect → helpers** (→ optional nav_ready). MMKV must precede terminate because `cdp_mmkv` requires a live CDP target; mmap visibility means writes are observable by the next process.
- Best-effort with per-step status — never silently rolls back. Returns `{summary: {ok, failed, skipped}, steps: [...], reconnectAttempted, reconnected, helpersInjected}`.
- **Refactor**: extracted `terminateApp` + `launchApp` from `startup-replay.ts` into a new shared `app-lifecycle.ts` so the orchestrator can report per-step status instead of one combined call. `startup-replay.ts` now imports the shared helpers and exports `waitForNavigationReady` for reuse.
- 4 new ToolErrorCode union members: `DEVICE_RESET_INVALID_ARGS`, `DEVICE_RESET_STATE_PARTIAL`, `DEVICE_RESET_RECONNECT_FAILED`, `CDP_NOT_CONNECTED`.

## Why
Issue #60 (IX-2950) described a 4-step preflight that callers always run together, in a specific order, where the SECOND call (`cdp_mmkv delete`) requires CDP to still be connected to the OLD process. Agents would terminate first and then try `cdp_mmkv` against a dead target. This tool encodes the correct sequence + error codes so callers can't get it wrong.

## Test plan
- [x] 17 new unit tests in `gh-60-feature-c-device-reset-state.test.js` (14 original + 3 regression guards from multi-LLM review):
  - Args validation (2): missing appId, invalid platform.
  - Empty-input fast-path (1): only terminate runs when nothing else requested.
  - Storage step (3): CDP_NOT_CONNECTED skip path, `__agent_error` sentinel, happy path.
  - Permission shorthand vs object form (2).
  - Relaunch flag controls steps (2).
  - Multi-LLM regression guards (3): reconnectAttempted flag distinguishes skipped/failed, summary.failed doesn't double-count skipped, all-skipped paths return ok.
  - Source-grep guards (4): tool registered, helper imports, app-lifecycle exports, startup-replay refactored.
- [x] Full suite **880 passing** (was 863, +17), zero regressions.
- [x] Multi-LLM review (Gemini + Codex gpt-5.5 xhigh, parallel/isolated): caught **three real response-shape issues**, all fixed pre-PR:
  1. `DEVICE_RESET_RECONNECT_FAILED` misattributed when launch itself failed (Codex conf 85). Fixed by tracking `reconnectAttempted` flag and gating the error code on `reconnectAttempted && !reconnected`.
  2. `reconnected: false` ambiguous between "skipped" and "failed" (Gemini conf 85). Added explicit `reconnectAttempted: boolean` field.
  3. `summary.failed` double-counted CDP_NOT_CONNECTED skips (Codex conf 80). Fixed to `failed = nonOk - skipped`; all-skipped paths now return `okResult`.

## Smoke (post-merge, requires CC restart)
1. Boot iOS simulator with the test app installed; connect via `cdp_status`.
2. Set a cooldown via `cdp_mmkv set` (e.g. `notification.lastPrompt = "2025-01-01"`).
3. `device_reset_state appId: "com.example.app" permissions: ["notifications"] storageKeys: ["notification.lastPrompt"]` → expect `summary.ok` >= 5 (permission, storage, terminate, launch, reconnect, helpers), `reconnectAttempted: true`, `reconnected: true`, `helpersInjected: true`.
4. Verify cooldown cleared: `cdp_mmkv get notification.lastPrompt` → `value: null`.

## Out of scope (deferred to v2)
- Race window between MMKV delete and terminate where the running app could rewrite the key. Mitigation: orchestrator issues delete-then-terminate back-to-back with no awaits between. v2 candidates: freeze JS thread via CDP `Debugger.pause` before delete, or delete MMKV file from disk after terminate.
- Skill or slash-command wrapper around this tool — the tool is self-contained.

Workspace docs (D687, Phase 118): committed as `a55b25c` on `rn-dev-agent-workspace` main.