### PR TITLE
feat(gh-91): mutation-absence verification-fidelity detector

### DIFF
--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -7,6 +7,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import { CDPClient } from './cdp-client.js';
 import { okResult, failResult, warnResult, withConnection } from './utils.js';
+import { annotateMutationAbsence } from './verification/mutation-absence.js';
 import { logger } from './logger.js';
 import { createStatusHandler } from './tools/status.js';
 import { createEvaluateHandler } from './tools/evaluate.js';
@@ -200,7 +201,15 @@ trackedTool('cdp_navigate', 'Navigate to any screen by name, including nested st
     if (parsed !== null && typeof parsed === 'object' && '__agent_error' in parsed) {
         return failResult(String(parsed.__agent_error));
     }
-    return okResult(parsed);
+    // GH #91: surface verification_warning when the requested screen matches
+    // the success-shape regex AND the 5s rolling window has no qualifying
+    // mutation. Uses args.screen as the signal — the user asked to navigate
+    // there, so even if the actual landing route differs we capture intent.
+    return annotateMutationAbsence(okResult(parsed), {
+        client,
+        screenName: args.screen,
+        source: 'cdp_navigate',
+    });
 }));
 trackedTool('cdp_component_state', 'Inspect a specific component\'s full hook state by testID. Returns props, all hook values (useState, useRef, useForm, etc.), and auto-detects react-hook-form control objects. Use when cdp_store_state misses non-Redux state (forms, local state, atoms).', {
     testID: z.string().describe('testID of the target component'),

--- a/scripts/cdp-bridge/dist/tools/navigation-state.js
+++ b/scripts/cdp-bridge/dist/tools/navigation-state.js
@@ -1,4 +1,28 @@
 import { okResult, failResult, withConnection } from '../utils.js';
+import { annotateMutationAbsence } from '../verification/mutation-absence.js';
+/**
+ * GH #91: extract the topmost active route name from a getNavState() payload.
+ * Both `routeName` (top-level convenience) and `routes[index].name` (full
+ * stack form) are accepted — Expo Router and React Navigation produce slightly
+ * different shapes via the helper.
+ */
+function extractActiveScreen(parsed) {
+    const direct = parsed.routeName;
+    if (typeof direct === 'string' && direct.length > 0)
+        return direct;
+    const routes = parsed.routes;
+    if (Array.isArray(routes) && routes.length > 0) {
+        const idx = typeof parsed.index === 'number' ? parsed.index : routes.length - 1;
+        const active = routes[Math.max(0, Math.min(idx, routes.length - 1))];
+        const name = active?.name;
+        if (typeof name === 'string')
+            return name;
+        const path = active?.path;
+        if (typeof path === 'string')
+            return path;
+    }
+    return null;
+}
 export function createNavigationStateHandler(getClient) {
     return withConnection(getClient, async (_args, client) => {
         const result = await client.evaluate(client.helperExpr('getNavState()'));
@@ -12,6 +36,10 @@ export function createNavigationStateHandler(getClient) {
         if (parsed.error) {
             return failResult(`Navigation state error: ${parsed.error}`);
         }
-        return okResult(parsed);
+        return annotateMutationAbsence(okResult(parsed), {
+            client,
+            screenName: extractActiveScreen(parsed),
+            source: 'cdp_navigation_state',
+        });
     });
 }

--- a/scripts/cdp-bridge/dist/tools/proof-step.js
+++ b/scripts/cdp-bridge/dist/tools/proof-step.js
@@ -1,6 +1,7 @@
 import { okResult, warnResult, withConnection } from '../utils.js';
 import { runAgentDevice, hasActiveSession } from '../agent-device-wrapper.js';
 import { captureAndResizeScreenshot } from './device-list.js';
+import { annotateMutationAbsence } from '../verification/mutation-absence.js';
 export function createProofStepHandler(getClient) {
     return withConnection(getClient, async (args, client) => {
         const result = {
@@ -93,9 +94,15 @@ export function createProofStepHandler(getClient) {
         if (errors.length > 0)
             result.errors = errors;
         const hasFailure = errors.length > 0 && !result.verified && args.verifyText || args.verifyTestID;
+        // GH #91: derive a screen-name signal from whichever input is freshest.
+        // Prefer the screen we navigated to (driving signal), then the verified
+        // testID (success-shape testIDs like "AddPolicySuccessSheet" trigger too),
+        // then the verified text. nul allowed — annotateMutationAbsence handles it.
+        const screenName = args.screen ?? args.verifyTestID ?? args.verifyText ?? null;
+        const ctx = { client, screenName, source: 'proof_step' };
         if (hasFailure && result.verified === false) {
-            return warnResult(result, errors.join('; '));
+            return annotateMutationAbsence(warnResult(result, errors.join('; ')), ctx);
         }
-        return okResult(result);
+        return annotateMutationAbsence(okResult(result), ctx);
     });
 }

--- a/scripts/cdp-bridge/dist/verification/mutation-absence.js
+++ b/scripts/cdp-bridge/dist/verification/mutation-absence.js
@@ -1,0 +1,159 @@
+// GH #91 / D688: mutation-absence detector. Catches the IX-2950 verification-
+// fidelity failure where an agent reaches a "success-shape" screen
+// (OrderConfirmation, AddPolicySuccess, ...) via deep-link or state-injection
+// without the user-flow's underlying server mutation actually firing.
+//
+// Reads from the existing CDP network buffer (no new event handlers). Wires
+// into 3 nav-aware tools (cdp_navigate, cdp_navigation_state, proof_step) and
+// attaches a `meta.verification_warning` field when:
+//   1. The currently-active screen name matches the success-shape regex.
+//   2. This is a TRANSITION (different from the previous observation for this
+//      device) — never warn on first observation.
+//   3. The 5-second rolling window of mutation network calls is empty.
+//
+// Multi-LLM brainstorm consensus (Codex + Gemini + Claude verified):
+// - State lives in a module-level Map keyed by `${metroPort}-${targetId}`,
+//   matching the existing NetworkBufferManager pattern (D657/B128). Survives
+//   soft-reconnect; resets naturally on force-reconnect (deviceKey changes).
+// - Mutation count uses `client.networkBufferManager.filter(...)` so we get
+//   per-device scoping for free.
+// - Filter status: include pending (`status === undefined`) AND 2xx/3xx so
+//   failed mutations (5xx) don't silence the detector — Gemini's catch.
+// - Edge-trigger only; first observation primes the signature without warning.
+const DEFAULT_WINDOW_MS = 5_000;
+// Gemini review (conf 85): pending mutations (status === undefined) are
+// captured at requestWillBeSent and only get their final status at
+// responseReceived. Counting ALL pending entries as success would silence
+// warnings for in-flight requests that are about to 5xx. Mitigation: only
+// recently-fired pending entries count as in-flight success (the optimistic-UI
+// case where the screen renders ~100-300ms after the POST starts). Older
+// pendings are suspect — likely hung or silently failed — and don't count.
+const MAX_PENDING_AGE_MS = 2_000;
+// Suffix-match against the LAST path segment so both Expo Router
+// (/orders/[id]/confirmation) and React Navigation (OrderConfirmation) work.
+const SUCCESS_SHAPE_REGEX = /(success|done|added|complete|completed|confirmation)$/i;
+const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+const stateByDevice = new Map();
+/**
+ * Pure helper: normalize an arbitrary route name string for success-shape
+ * matching. For Expo Router path-style strings, take the last non-empty
+ * segment. For React Navigation name-style strings, return as-is. Returns
+ * lowercase already so the regex stays simple.
+ */
+export function normalizeRouteName(raw) {
+    if (!raw || typeof raw !== 'string')
+        return null;
+    const trimmed = raw.trim();
+    if (!trimmed)
+        return null;
+    const segments = trimmed.split('/').filter(Boolean);
+    return (segments.length > 0 ? segments[segments.length - 1] : trimmed).toLowerCase();
+}
+export function isSuccessShape(rawName) {
+    const normalized = normalizeRouteName(rawName);
+    if (!normalized)
+        return false;
+    return SUCCESS_SHAPE_REGEX.test(normalized);
+}
+/**
+ * Pure: check the current device's mutation buffer against the window. Returns
+ * the in-window count and (when zero) the age of the most-recent mutation
+ * regardless of window — useful diagnostic so callers can tell "I missed by
+ * 0.5s" from "I never had a mutation in this session at all".
+ */
+export function countWindowedMutations(client, windowMs, now) {
+    const deviceKey = client.activeDeviceKey;
+    const sinceISO = new Date(now - windowMs).toISOString();
+    // Filter by the broader "is mutation" predicate first so we can also
+    // compute last_mutation_age_ms from the same scan.
+    const allMutations = client.networkBufferManager.filter(deviceKey, (entry) => {
+        const method = (entry.method ?? '').toUpperCase();
+        if (!MUTATION_METHODS.has(method))
+            return false;
+        // Skip failed mutations (>= 400). For pending entries (status === undefined),
+        // only count if recently-fired — older pendings are suspect (likely hung
+        // or silently failed) and shouldn't be treated as in-flight success.
+        const status = entry.status;
+        if (status === undefined) {
+            const t = Date.parse(entry.timestamp);
+            return Number.isFinite(t) && (now - t) <= MAX_PENDING_AGE_MS;
+        }
+        return status >= 200 && status < 400;
+    });
+    const inWindow = allMutations.filter((e) => e.timestamp >= sinceISO).length;
+    if (inWindow > 0)
+        return { inWindow, lastMutationAgeMs: 0 };
+    let lastMutationAgeMs = null;
+    if (allMutations.length > 0) {
+        const mostRecent = allMutations[allMutations.length - 1];
+        const t = Date.parse(mostRecent.timestamp);
+        lastMutationAgeMs = Number.isFinite(t) ? Math.max(0, now - t) : null;
+    }
+    return { inWindow: 0, lastMutationAgeMs };
+}
+/**
+ * Augment a tool result with `meta.verification_warning` if the conditions
+ * fire. Returns the result unchanged on first observation (priming) or when
+ * the screen isn't a success shape or the window has any qualifying mutation.
+ *
+ * Never throws; on parse failure returns the original result so a buggy
+ * envelope shape can't break tools.
+ */
+export function annotateMutationAbsence(result, ctx) {
+    if (result.isError)
+        return result;
+    const deviceKey = ctx.client.activeDeviceKey;
+    // Edge-trigger using ONLY the active screen name. Stack-hash signatures
+    // were considered (Codex) but the spec only cares about the topmost route
+    // for the success-shape match — keeping signature == name is simpler and
+    // dodges param-only-rerender false positives.
+    const signature = ctx.screenName ?? '';
+    const prev = stateByDevice.get(deviceKey);
+    if (!prev) {
+        // First observation primes; never warns. (Reduces the "user navigates
+        // to OrderConfirmation because they're VIEWING an existing order"
+        // false-positive class.)
+        stateByDevice.set(deviceKey, { lastSignature: signature });
+        return result;
+    }
+    if (prev.lastSignature === signature)
+        return result;
+    prev.lastSignature = signature;
+    if (!isSuccessShape(ctx.screenName))
+        return result;
+    const windowMs = ctx.windowMs ?? DEFAULT_WINDOW_MS;
+    const now = (ctx.now ?? Date.now)();
+    const { inWindow, lastMutationAgeMs } = countWindowedMutations(ctx.client, windowMs, now);
+    if (inWindow > 0)
+        return result;
+    const hint = lastMutationAgeMs !== null && lastMutationAgeMs < windowMs * 3
+        ? `Most recent mutation was ${lastMutationAgeMs}ms ago — outside the ${windowMs}ms window. If this is an optimistic UI flow, the mutation may have completed before the screen change observation; consider running the verification immediately after navigation.`
+        : `Success-shape screen reached without a preceding write request in the last ${windowMs}ms. If the path under verification involves a server-side mutation, the user-flow may not have actually executed (deep-link bypass, state injection, or pre-existing state matching the success shape). Use cdp_network_log to confirm whether the expected mutation actually fired.`;
+    const warning = {
+        code: 'MUTATION_ABSENCE',
+        screen: ctx.screenName ?? 'unknown',
+        source: ctx.source,
+        window_ms: windowMs,
+        mutations_observed: 0,
+        last_mutation_age_ms: lastMutationAgeMs,
+        hint,
+    };
+    return augmentMeta(result, { verification_warning: warning });
+}
+function augmentMeta(result, extra) {
+    try {
+        const text = result.content[0]?.text;
+        if (!text)
+            return result;
+        const env = JSON.parse(text);
+        env.meta = { ...env.meta, ...extra };
+        return { content: [{ type: 'text', text: JSON.stringify(env) }] };
+    }
+    catch {
+        return result;
+    }
+}
+/** Test seam: clear the per-device state map. Not exported via index.ts. */
+export function _resetForTests() {
+    stateByDevice.clear();
+}

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -7,6 +7,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import { CDPClient } from './cdp-client.js';
 import { okResult, failResult, warnResult, withConnection } from './utils.js';
+import { annotateMutationAbsence } from './verification/mutation-absence.js';
 import { logger } from './logger.js';
 import { createStatusHandler } from './tools/status.js';
 import { createEvaluateHandler } from './tools/evaluate.js';
@@ -350,7 +351,15 @@ trackedTool(
     if (parsed !== null && typeof parsed === 'object' && '__agent_error' in (parsed as Record<string, unknown>)) {
       return failResult(String((parsed as Record<string, unknown>).__agent_error));
     }
-    return okResult(parsed);
+    // GH #91: surface verification_warning when the requested screen matches
+    // the success-shape regex AND the 5s rolling window has no qualifying
+    // mutation. Uses args.screen as the signal — the user asked to navigate
+    // there, so even if the actual landing route differs we capture intent.
+    return annotateMutationAbsence(okResult(parsed), {
+      client,
+      screenName: args.screen,
+      source: 'cdp_navigate',
+    });
   }),
 );
 

--- a/scripts/cdp-bridge/src/tools/navigation-state.ts
+++ b/scripts/cdp-bridge/src/tools/navigation-state.ts
@@ -1,5 +1,27 @@
 import type { CDPClient } from '../cdp-client.js';
 import { okResult, failResult, withConnection } from '../utils.js';
+import { annotateMutationAbsence } from '../verification/mutation-absence.js';
+
+/**
+ * GH #91: extract the topmost active route name from a getNavState() payload.
+ * Both `routeName` (top-level convenience) and `routes[index].name` (full
+ * stack form) are accepted — Expo Router and React Navigation produce slightly
+ * different shapes via the helper.
+ */
+function extractActiveScreen(parsed: Record<string, unknown>): string | null {
+  const direct = parsed.routeName;
+  if (typeof direct === 'string' && direct.length > 0) return direct;
+  const routes = parsed.routes;
+  if (Array.isArray(routes) && routes.length > 0) {
+    const idx = typeof parsed.index === 'number' ? parsed.index : routes.length - 1;
+    const active = routes[Math.max(0, Math.min(idx, routes.length - 1))] as Record<string, unknown> | undefined;
+    const name = active?.name;
+    if (typeof name === 'string') return name;
+    const path = active?.path;
+    if (typeof path === 'string') return path;
+  }
+  return null;
+}
 
 export function createNavigationStateHandler(getClient: () => CDPClient) {
   return withConnection(getClient, async (_args: Record<string, never>, client) => {
@@ -19,6 +41,10 @@ export function createNavigationStateHandler(getClient: () => CDPClient) {
       return failResult(`Navigation state error: ${parsed.error}`);
     }
 
-    return okResult(parsed);
+    return annotateMutationAbsence(okResult(parsed), {
+      client,
+      screenName: extractActiveScreen(parsed),
+      source: 'cdp_navigation_state',
+    });
   });
 }

--- a/scripts/cdp-bridge/src/tools/proof-step.ts
+++ b/scripts/cdp-bridge/src/tools/proof-step.ts
@@ -3,6 +3,7 @@ import type { ToolResult } from '../utils.js';
 import { okResult, failResult, warnResult, withConnection } from '../utils.js';
 import { runAgentDevice, hasActiveSession } from '../agent-device-wrapper.js';
 import { captureAndResizeScreenshot } from './device-list.js';
+import { annotateMutationAbsence } from '../verification/mutation-absence.js';
 
 interface ProofStepArgs {
   screen?: string;
@@ -111,9 +112,15 @@ export function createProofStepHandler(getClient: () => CDPClient) {
     if (errors.length > 0) result.errors = errors;
 
     const hasFailure = errors.length > 0 && !result.verified && args.verifyText || args.verifyTestID;
+    // GH #91: derive a screen-name signal from whichever input is freshest.
+    // Prefer the screen we navigated to (driving signal), then the verified
+    // testID (success-shape testIDs like "AddPolicySuccessSheet" trigger too),
+    // then the verified text. nul allowed — annotateMutationAbsence handles it.
+    const screenName = args.screen ?? args.verifyTestID ?? args.verifyText ?? null;
+    const ctx = { client, screenName, source: 'proof_step' as const };
     if (hasFailure && result.verified === false) {
-      return warnResult(result, errors.join('; '));
+      return annotateMutationAbsence(warnResult(result, errors.join('; ')), ctx);
     }
-    return okResult(result);
+    return annotateMutationAbsence(okResult(result), ctx);
   });
 }

--- a/scripts/cdp-bridge/src/verification/mutation-absence.ts
+++ b/scripts/cdp-bridge/src/verification/mutation-absence.ts
@@ -1,0 +1,199 @@
+import type { CDPClient } from '../cdp-client.js';
+import type { ToolResult } from '../utils.js';
+
+// GH #91 / D688: mutation-absence detector. Catches the IX-2950 verification-
+// fidelity failure where an agent reaches a "success-shape" screen
+// (OrderConfirmation, AddPolicySuccess, ...) via deep-link or state-injection
+// without the user-flow's underlying server mutation actually firing.
+//
+// Reads from the existing CDP network buffer (no new event handlers). Wires
+// into 3 nav-aware tools (cdp_navigate, cdp_navigation_state, proof_step) and
+// attaches a `meta.verification_warning` field when:
+//   1. The currently-active screen name matches the success-shape regex.
+//   2. This is a TRANSITION (different from the previous observation for this
+//      device) — never warn on first observation.
+//   3. The 5-second rolling window of mutation network calls is empty.
+//
+// Multi-LLM brainstorm consensus (Codex + Gemini + Claude verified):
+// - State lives in a module-level Map keyed by `${metroPort}-${targetId}`,
+//   matching the existing NetworkBufferManager pattern (D657/B128). Survives
+//   soft-reconnect; resets naturally on force-reconnect (deviceKey changes).
+// - Mutation count uses `client.networkBufferManager.filter(...)` so we get
+//   per-device scoping for free.
+// - Filter status: include pending (`status === undefined`) AND 2xx/3xx so
+//   failed mutations (5xx) don't silence the detector — Gemini's catch.
+// - Edge-trigger only; first observation primes the signature without warning.
+
+const DEFAULT_WINDOW_MS = 5_000;
+
+// Gemini review (conf 85): pending mutations (status === undefined) are
+// captured at requestWillBeSent and only get their final status at
+// responseReceived. Counting ALL pending entries as success would silence
+// warnings for in-flight requests that are about to 5xx. Mitigation: only
+// recently-fired pending entries count as in-flight success (the optimistic-UI
+// case where the screen renders ~100-300ms after the POST starts). Older
+// pendings are suspect — likely hung or silently failed — and don't count.
+const MAX_PENDING_AGE_MS = 2_000;
+
+// Suffix-match against the LAST path segment so both Expo Router
+// (/orders/[id]/confirmation) and React Navigation (OrderConfirmation) work.
+const SUCCESS_SHAPE_REGEX = /(success|done|added|complete|completed|confirmation)$/i;
+
+const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+interface DetectorState {
+  lastSignature: string | null;
+}
+
+const stateByDevice = new Map<string, DetectorState>();
+
+export interface VerificationWarning {
+  code: 'MUTATION_ABSENCE';
+  screen: string;
+  source: string;
+  window_ms: number;
+  mutations_observed: number;
+  last_mutation_age_ms: number | null;
+  hint: string;
+}
+
+export interface AnnotateContext {
+  client: CDPClient;
+  /** The currently-active screen name (topmost route or last path segment). */
+  screenName: string | null;
+  /** Which tool produced this observation (for the warning's `source` field). */
+  source: 'cdp_navigate' | 'cdp_navigation_state' | 'proof_step';
+  /** Override the default 5_000ms window for tests / future per-project config. */
+  windowMs?: number;
+  /** Inject a clock for deterministic tests. */
+  now?: () => number;
+}
+
+/**
+ * Pure helper: normalize an arbitrary route name string for success-shape
+ * matching. For Expo Router path-style strings, take the last non-empty
+ * segment. For React Navigation name-style strings, return as-is. Returns
+ * lowercase already so the regex stays simple.
+ */
+export function normalizeRouteName(raw: string | null | undefined): string | null {
+  if (!raw || typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const segments = trimmed.split('/').filter(Boolean);
+  return (segments.length > 0 ? segments[segments.length - 1] : trimmed).toLowerCase();
+}
+
+export function isSuccessShape(rawName: string | null | undefined): boolean {
+  const normalized = normalizeRouteName(rawName);
+  if (!normalized) return false;
+  return SUCCESS_SHAPE_REGEX.test(normalized);
+}
+
+/**
+ * Pure: check the current device's mutation buffer against the window. Returns
+ * the in-window count and (when zero) the age of the most-recent mutation
+ * regardless of window — useful diagnostic so callers can tell "I missed by
+ * 0.5s" from "I never had a mutation in this session at all".
+ */
+export function countWindowedMutations(
+  client: CDPClient,
+  windowMs: number,
+  now: number,
+): { inWindow: number; lastMutationAgeMs: number | null } {
+  const deviceKey = client.activeDeviceKey;
+  const sinceISO = new Date(now - windowMs).toISOString();
+  // Filter by the broader "is mutation" predicate first so we can also
+  // compute last_mutation_age_ms from the same scan.
+  const allMutations = client.networkBufferManager.filter(deviceKey, (entry) => {
+    const method = (entry.method ?? '').toUpperCase();
+    if (!MUTATION_METHODS.has(method)) return false;
+    // Skip failed mutations (>= 400). For pending entries (status === undefined),
+    // only count if recently-fired — older pendings are suspect (likely hung
+    // or silently failed) and shouldn't be treated as in-flight success.
+    const status = entry.status;
+    if (status === undefined) {
+      const t = Date.parse(entry.timestamp);
+      return Number.isFinite(t) && (now - t) <= MAX_PENDING_AGE_MS;
+    }
+    return status >= 200 && status < 400;
+  });
+  const inWindow = allMutations.filter((e) => e.timestamp >= sinceISO).length;
+  if (inWindow > 0) return { inWindow, lastMutationAgeMs: 0 };
+  let lastMutationAgeMs: number | null = null;
+  if (allMutations.length > 0) {
+    const mostRecent = allMutations[allMutations.length - 1];
+    const t = Date.parse(mostRecent.timestamp);
+    lastMutationAgeMs = Number.isFinite(t) ? Math.max(0, now - t) : null;
+  }
+  return { inWindow: 0, lastMutationAgeMs };
+}
+
+/**
+ * Augment a tool result with `meta.verification_warning` if the conditions
+ * fire. Returns the result unchanged on first observation (priming) or when
+ * the screen isn't a success shape or the window has any qualifying mutation.
+ *
+ * Never throws; on parse failure returns the original result so a buggy
+ * envelope shape can't break tools.
+ */
+export function annotateMutationAbsence(result: ToolResult, ctx: AnnotateContext): ToolResult {
+  if (result.isError) return result;
+
+  const deviceKey = ctx.client.activeDeviceKey;
+  // Edge-trigger using ONLY the active screen name. Stack-hash signatures
+  // were considered (Codex) but the spec only cares about the topmost route
+  // for the success-shape match — keeping signature == name is simpler and
+  // dodges param-only-rerender false positives.
+  const signature = ctx.screenName ?? '';
+  const prev = stateByDevice.get(deviceKey);
+  if (!prev) {
+    // First observation primes; never warns. (Reduces the "user navigates
+    // to OrderConfirmation because they're VIEWING an existing order"
+    // false-positive class.)
+    stateByDevice.set(deviceKey, { lastSignature: signature });
+    return result;
+  }
+  if (prev.lastSignature === signature) return result;
+  prev.lastSignature = signature;
+
+  if (!isSuccessShape(ctx.screenName)) return result;
+
+  const windowMs = ctx.windowMs ?? DEFAULT_WINDOW_MS;
+  const now = (ctx.now ?? Date.now)();
+  const { inWindow, lastMutationAgeMs } = countWindowedMutations(ctx.client, windowMs, now);
+  if (inWindow > 0) return result;
+
+  const hint =
+    lastMutationAgeMs !== null && lastMutationAgeMs < windowMs * 3
+      ? `Most recent mutation was ${lastMutationAgeMs}ms ago — outside the ${windowMs}ms window. If this is an optimistic UI flow, the mutation may have completed before the screen change observation; consider running the verification immediately after navigation.`
+      : `Success-shape screen reached without a preceding write request in the last ${windowMs}ms. If the path under verification involves a server-side mutation, the user-flow may not have actually executed (deep-link bypass, state injection, or pre-existing state matching the success shape). Use cdp_network_log to confirm whether the expected mutation actually fired.`;
+
+  const warning: VerificationWarning = {
+    code: 'MUTATION_ABSENCE',
+    screen: ctx.screenName ?? 'unknown',
+    source: ctx.source,
+    window_ms: windowMs,
+    mutations_observed: 0,
+    last_mutation_age_ms: lastMutationAgeMs,
+    hint,
+  };
+
+  return augmentMeta(result, { verification_warning: warning });
+}
+
+function augmentMeta(result: ToolResult, extra: Record<string, unknown>): ToolResult {
+  try {
+    const text = result.content[0]?.text;
+    if (!text) return result;
+    const env = JSON.parse(text) as { ok?: boolean; data?: unknown; meta?: Record<string, unknown> };
+    env.meta = { ...env.meta, ...extra };
+    return { content: [{ type: 'text' as const, text: JSON.stringify(env) }] };
+  } catch {
+    return result;
+  }
+}
+
+/** Test seam: clear the per-device state map. Not exported via index.ts. */
+export function _resetForTests(): void {
+  stateByDevice.clear();
+}

--- a/scripts/cdp-bridge/test/unit/gh-91-mutation-absence.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-91-mutation-absence.test.js
@@ -1,0 +1,385 @@
+// GH #91 / D688: mutation-absence detector. Catches the IX-2950 verification-
+// fidelity failure where an agent reaches a "success-shape" screen via
+// deep-link without the underlying server mutation actually firing.
+//
+// Tests cover: pure helpers (normalizeRouteName, isSuccessShape,
+// countWindowedMutations), the annotateMutationAbsence integration logic
+// (edge-trigger, success-shape gating, mutation status filter, last-mutation
+// age diagnostic), and source-grep guards on the 3 wire-in tools.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const MOD_PATH = '../../dist/verification/mutation-absence.js';
+
+function makeMockClient(opts = {}) {
+  const entries = opts.entries ?? [];
+  return {
+    activeDeviceKey: opts.deviceKey ?? '8081-target-1',
+    networkBufferManager: {
+      filter: (_key, predicate) => entries.filter(predicate),
+    },
+  };
+}
+
+function envelope(data, meta) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ ok: true, data, ...(meta ? { meta } : {}) }) }],
+  };
+}
+
+function parse(result) {
+  return JSON.parse(result.content[0].text);
+}
+
+// ── normalizeRouteName ──────────────────────────────────────────────────
+
+test('normalizeRouteName: returns null for empty/null/undefined', async () => {
+  const { normalizeRouteName } = await import(MOD_PATH);
+  assert.equal(normalizeRouteName(null), null);
+  assert.equal(normalizeRouteName(undefined), null);
+  assert.equal(normalizeRouteName(''), null);
+  assert.equal(normalizeRouteName('   '), null);
+});
+
+test('normalizeRouteName: lowercases and returns React Navigation name as-is', async () => {
+  const { normalizeRouteName } = await import(MOD_PATH);
+  assert.equal(normalizeRouteName('OrderConfirmation'), 'orderconfirmation');
+});
+
+test('normalizeRouteName: strips path segments for Expo Router routes', async () => {
+  const { normalizeRouteName } = await import(MOD_PATH);
+  assert.equal(normalizeRouteName('/orders/[id]/confirmation'), 'confirmation');
+  assert.equal(normalizeRouteName('orders/123/success'), 'success');
+});
+
+// ── isSuccessShape ──────────────────────────────────────────────────────
+
+test('isSuccessShape: matches React Navigation success-style names', async () => {
+  const { isSuccessShape } = await import(MOD_PATH);
+  for (const name of ['OrderSuccess', 'AddPolicySuccess', 'PaymentDone', 'TaskAdded', 'JobComplete', 'PaymentCompleted', 'OrderConfirmation']) {
+    assert.equal(isSuccessShape(name), true, `${name} should match success shape`);
+  }
+});
+
+test('isSuccessShape: matches Expo Router path-style routes', async () => {
+  const { isSuccessShape } = await import(MOD_PATH);
+  assert.equal(isSuccessShape('/orders/[id]/confirmation'), true);
+  assert.equal(isSuccessShape('/checkout/done'), true);
+});
+
+test('isSuccessShape: rejects non-success names', async () => {
+  const { isSuccessShape } = await import(MOD_PATH);
+  for (const name of ['Home', 'OrderList', 'CheckoutFlow', 'CartScreen', null, undefined, '']) {
+    assert.equal(isSuccessShape(name), false, `${name} should NOT match success shape`);
+  }
+});
+
+test('isSuccessShape: case-insensitive suffix match', async () => {
+  const { isSuccessShape } = await import(MOD_PATH);
+  // The regex anchors to end-of-string with case-insensitive flag, so any
+  // form of "success" suffix matches. Trailing punctuation/separators are
+  // not stripped — the match is purely on the path's last segment ending in
+  // a success-shape word.
+  assert.equal(isSuccessShape('ORDER_SUCCESS'), true);
+  assert.equal(isSuccessShape('OrderSUCCESS'), true);
+  assert.equal(isSuccessShape('ordersuccess'), true);
+});
+
+// ── countWindowedMutations ──────────────────────────────────────────────
+
+test('countWindowedMutations: counts only POST/PUT/PATCH/DELETE', async () => {
+  const { countWindowedMutations } = await import(MOD_PATH);
+  const now = Date.parse('2026-04-28T12:00:00.000Z');
+  const ago = (sec) => new Date(now - sec * 1000).toISOString();
+  const client = makeMockClient({
+    entries: [
+      { method: 'GET', url: '/api/users', timestamp: ago(1), status: 200 },
+      { method: 'POST', url: '/api/orders', timestamp: ago(2), status: 200 },
+      { method: 'PUT', url: '/api/profile', timestamp: ago(3), status: 200 },
+      { method: 'PATCH', url: '/api/settings', timestamp: ago(4), status: 204 },
+      { method: 'DELETE', url: '/api/items/1', timestamp: ago(4.5), status: 204 },
+      { method: 'OPTIONS', url: '/api/cors', timestamp: ago(0.5), status: 200 },
+    ],
+  });
+  const { inWindow } = countWindowedMutations(client, 5_000, now);
+  assert.equal(inWindow, 4, 'POST + PUT + PATCH + DELETE = 4');
+});
+
+test('countWindowedMutations: filters by 5s window', async () => {
+  const { countWindowedMutations } = await import(MOD_PATH);
+  const now = Date.parse('2026-04-28T12:00:00.000Z');
+  const ago = (sec) => new Date(now - sec * 1000).toISOString();
+  const client = makeMockClient({
+    entries: [
+      { method: 'POST', url: '/api/a', timestamp: ago(2), status: 201 },
+      { method: 'POST', url: '/api/b', timestamp: ago(8), status: 201 }, // outside 5s
+      { method: 'POST', url: '/api/c', timestamp: ago(12), status: 201 }, // outside
+    ],
+  });
+  const { inWindow, lastMutationAgeMs } = countWindowedMutations(client, 5_000, now);
+  assert.equal(inWindow, 1, 'only the 2s-ago entry is in-window');
+  // lastMutationAgeMs is 0 when in-window count > 0 — diagnostic only matters when zero.
+  assert.equal(lastMutationAgeMs, 0);
+});
+
+test('countWindowedMutations: skips failed mutations (>= 400)', async () => {
+  // Gemini's catch: a POST that 500s should NOT silence the detector.
+  const { countWindowedMutations } = await import(MOD_PATH);
+  const now = Date.parse('2026-04-28T12:00:00.000Z');
+  const ago = (sec) => new Date(now - sec * 1000).toISOString();
+  const client = makeMockClient({
+    entries: [
+      { method: 'POST', url: '/api/orders', timestamp: ago(2), status: 500 },
+      { method: 'POST', url: '/api/items', timestamp: ago(3), status: 404 },
+    ],
+  });
+  const { inWindow } = countWindowedMutations(client, 5_000, now);
+  assert.equal(inWindow, 0, 'failed mutations must not count as success');
+});
+
+test('countWindowedMutations: FRESH pending entries (status undefined, < 2s old) count as in-progress success', async () => {
+  // Optimistic UI: screen renders before response lands; the request is
+  // captured at requestWillBeSent and gets `status` set later.
+  const { countWindowedMutations } = await import(MOD_PATH);
+  const now = Date.parse('2026-04-28T12:00:00.000Z');
+  const ago = (sec) => new Date(now - sec * 1000).toISOString();
+  const client = makeMockClient({
+    entries: [
+      { method: 'POST', url: '/api/orders', timestamp: ago(0.3), status: undefined },
+    ],
+  });
+  const { inWindow } = countWindowedMutations(client, 5_000, now);
+  assert.equal(inWindow, 1, 'fresh pending mutation should count');
+});
+
+test('countWindowedMutations: STALE pending entries (>2s old) do NOT count (Gemini review fix)', async () => {
+  // Gemini's race-condition catch: a pending entry that's been "in flight"
+  // for 3+ seconds is suspect — likely hung, silently failed, or a long-running
+  // background fetch. Treating it as success-so-far would silence warnings for
+  // mutations that are about to 5xx. The freshness gate (MAX_PENDING_AGE_MS=2000ms)
+  // limits the optimistic-UI window so only recently-fired pendings count.
+  const { countWindowedMutations } = await import(MOD_PATH);
+  const now = Date.parse('2026-04-28T12:00:00.000Z');
+  const ago = (sec) => new Date(now - sec * 1000).toISOString();
+  const client = makeMockClient({
+    entries: [
+      { method: 'POST', url: '/api/orders', timestamp: ago(3.5), status: undefined },
+    ],
+  });
+  const { inWindow } = countWindowedMutations(client, 5_000, now);
+  assert.equal(inWindow, 0, 'stale pending must not silence the detector');
+});
+
+test('countWindowedMutations: freshness boundary (exactly 2s) counts as success', async () => {
+  // The boundary itself is inclusive (<= MAX_PENDING_AGE_MS).
+  const { countWindowedMutations } = await import(MOD_PATH);
+  const now = Date.parse('2026-04-28T12:00:00.000Z');
+  const at = (sec) => new Date(now - sec * 1000).toISOString();
+  const client = makeMockClient({
+    entries: [
+      { method: 'POST', url: '/api/orders', timestamp: at(2), status: undefined },
+    ],
+  });
+  const { inWindow } = countWindowedMutations(client, 5_000, now);
+  assert.equal(inWindow, 1, 'exactly 2s old pending mutation should still count');
+});
+
+test('countWindowedMutations: reports last_mutation_age_ms when window is empty', async () => {
+  const { countWindowedMutations } = await import(MOD_PATH);
+  const now = Date.parse('2026-04-28T12:00:00.000Z');
+  const ago = (sec) => new Date(now - sec * 1000).toISOString();
+  const client = makeMockClient({
+    entries: [
+      { method: 'POST', url: '/api/old', timestamp: ago(7.3), status: 201 },
+    ],
+  });
+  const { inWindow, lastMutationAgeMs } = countWindowedMutations(client, 5_000, now);
+  assert.equal(inWindow, 0);
+  assert.equal(lastMutationAgeMs, 7300);
+});
+
+test('countWindowedMutations: lastMutationAgeMs is null when no mutations ever', async () => {
+  const { countWindowedMutations } = await import(MOD_PATH);
+  const now = Date.parse('2026-04-28T12:00:00.000Z');
+  const client = makeMockClient({ entries: [] });
+  const { inWindow, lastMutationAgeMs } = countWindowedMutations(client, 5_000, now);
+  assert.equal(inWindow, 0);
+  assert.equal(lastMutationAgeMs, null);
+});
+
+// ── annotateMutationAbsence — edge-trigger semantics ────────────────────
+
+test('annotateMutationAbsence: first observation primes, never warns', async () => {
+  const { annotateMutationAbsence, _resetForTests } = await import(MOD_PATH);
+  _resetForTests();
+  const client = makeMockClient(); // no mutations
+  const result = annotateMutationAbsence(envelope({ ok: true }), {
+    client, screenName: 'OrderSuccess', source: 'cdp_navigate',
+  });
+  const env = parse(result);
+  assert.equal(env.meta?.verification_warning, undefined, 'first observation must not warn');
+});
+
+test('annotateMutationAbsence: same-screen second observation does not warn', async () => {
+  const { annotateMutationAbsence, _resetForTests } = await import(MOD_PATH);
+  _resetForTests();
+  const client = makeMockClient();
+  // Prime
+  annotateMutationAbsence(envelope({}), { client, screenName: 'OrderSuccess', source: 'cdp_navigate' });
+  // Second observation, same screen, no transition.
+  const r2 = annotateMutationAbsence(envelope({}), { client, screenName: 'OrderSuccess', source: 'cdp_navigation_state' });
+  assert.equal(parse(r2).meta?.verification_warning, undefined);
+});
+
+test('annotateMutationAbsence: transition to success shape with no mutation -> warns', async () => {
+  const { annotateMutationAbsence, _resetForTests } = await import(MOD_PATH);
+  _resetForTests();
+  const client = makeMockClient(); // no mutations
+  // Prime on a non-success screen
+  annotateMutationAbsence(envelope({}), { client, screenName: 'CheckoutFlow', source: 'cdp_navigation_state' });
+  // Transition to OrderSuccess
+  const result = annotateMutationAbsence(envelope({ navigated: true }), {
+    client, screenName: 'OrderSuccess', source: 'cdp_navigate',
+  });
+  const env = parse(result);
+  assert.ok(env.meta?.verification_warning, 'should warn on transition to success shape');
+  assert.equal(env.meta.verification_warning.code, 'MUTATION_ABSENCE');
+  assert.equal(env.meta.verification_warning.screen, 'OrderSuccess');
+  assert.equal(env.meta.verification_warning.source, 'cdp_navigate');
+  assert.equal(env.meta.verification_warning.window_ms, 5000);
+  assert.equal(env.meta.verification_warning.mutations_observed, 0);
+  assert.equal(env.meta.verification_warning.last_mutation_age_ms, null);
+  assert.match(env.meta.verification_warning.hint, /5000ms|deep-link|user-flow/);
+});
+
+test('annotateMutationAbsence: transition to non-success screen does NOT warn', async () => {
+  const { annotateMutationAbsence, _resetForTests } = await import(MOD_PATH);
+  _resetForTests();
+  const client = makeMockClient();
+  annotateMutationAbsence(envelope({}), { client, screenName: 'Home', source: 'cdp_navigate' });
+  const result = annotateMutationAbsence(envelope({}), {
+    client, screenName: 'CartScreen', source: 'cdp_navigate',
+  });
+  assert.equal(parse(result).meta?.verification_warning, undefined);
+});
+
+test('annotateMutationAbsence: success transition WITH in-window mutation does NOT warn', async () => {
+  const { annotateMutationAbsence, _resetForTests } = await import(MOD_PATH);
+  _resetForTests();
+  const now = Date.parse('2026-04-28T12:00:00.000Z');
+  const client = makeMockClient({
+    entries: [
+      { method: 'POST', url: '/api/orders', timestamp: new Date(now - 1500).toISOString(), status: 201 },
+    ],
+  });
+  // Prime
+  annotateMutationAbsence(envelope({}), { client, screenName: 'CheckoutFlow', source: 'cdp_navigate', now: () => now });
+  // Transition with mutation in window
+  const result = annotateMutationAbsence(envelope({}), {
+    client, screenName: 'OrderSuccess', source: 'cdp_navigate', now: () => now,
+  });
+  assert.equal(parse(result).meta?.verification_warning, undefined, 'real flow should not be flagged');
+});
+
+test('annotateMutationAbsence: emits last_mutation_age_ms diagnostic when out-of-window mutation exists', async () => {
+  const { annotateMutationAbsence, _resetForTests } = await import(MOD_PATH);
+  _resetForTests();
+  const now = Date.parse('2026-04-28T12:00:00.000Z');
+  const client = makeMockClient({
+    entries: [
+      { method: 'POST', url: '/api/orders', timestamp: new Date(now - 7500).toISOString(), status: 201 },
+    ],
+  });
+  annotateMutationAbsence(envelope({}), { client, screenName: 'CheckoutFlow', source: 'cdp_navigate', now: () => now });
+  const result = annotateMutationAbsence(envelope({}), {
+    client, screenName: 'OrderSuccess', source: 'cdp_navigate', now: () => now,
+  });
+  const w = parse(result).meta.verification_warning;
+  assert.equal(w.last_mutation_age_ms, 7500);
+  assert.match(w.hint, /Most recent mutation was 7500ms ago/);
+});
+
+test('annotateMutationAbsence: skips on isError result', async () => {
+  const { annotateMutationAbsence, _resetForTests } = await import(MOD_PATH);
+  _resetForTests();
+  const client = makeMockClient();
+  const errorResult = {
+    content: [{ type: 'text', text: JSON.stringify({ ok: false, error: 'fail' }) }],
+    isError: true,
+  };
+  const result = annotateMutationAbsence(errorResult, { client, screenName: 'OrderSuccess', source: 'cdp_navigate' });
+  assert.equal(result, errorResult, 'isError results pass through unchanged');
+});
+
+test('annotateMutationAbsence: per-device state isolation', async () => {
+  const { annotateMutationAbsence, _resetForTests } = await import(MOD_PATH);
+  _resetForTests();
+  const ios = makeMockClient({ deviceKey: '8081-ios-1' });
+  const android = makeMockClient({ deviceKey: '8081-android-1' });
+  // Prime both on different screens
+  annotateMutationAbsence(envelope({}), { client: ios, screenName: 'Home', source: 'cdp_navigate' });
+  annotateMutationAbsence(envelope({}), { client: android, screenName: 'Home', source: 'cdp_navigate' });
+  // iOS transitions to success → warns
+  const iosResult = annotateMutationAbsence(envelope({}), { client: ios, screenName: 'OrderSuccess', source: 'cdp_navigate' });
+  // Android stays on Home — same observation, no transition, no warning
+  const androidResult = annotateMutationAbsence(envelope({}), { client: android, screenName: 'Home', source: 'cdp_navigate' });
+  assert.ok(parse(iosResult).meta?.verification_warning);
+  assert.equal(parse(androidResult).meta?.verification_warning, undefined);
+});
+
+test('annotateMutationAbsence: preserves existing meta fields', async () => {
+  const { annotateMutationAbsence, _resetForTests } = await import(MOD_PATH);
+  _resetForTests();
+  const client = makeMockClient();
+  // Prime
+  annotateMutationAbsence(envelope({}), { client, screenName: 'Home', source: 'cdp_navigate' });
+  // Observation with pre-existing meta
+  const r = envelope({}, { recovered_via: 'force_reconnect' });
+  const result = annotateMutationAbsence(r, { client, screenName: 'OrderSuccess', source: 'cdp_navigate' });
+  const env = parse(result);
+  assert.equal(env.meta.recovered_via, 'force_reconnect', 'pre-existing meta preserved');
+  assert.equal(env.meta.verification_warning.code, 'MUTATION_ABSENCE');
+});
+
+test('annotateMutationAbsence: malformed envelope passes through unchanged', async () => {
+  const { annotateMutationAbsence, _resetForTests } = await import(MOD_PATH);
+  _resetForTests();
+  const client = makeMockClient();
+  const malformed = { content: [{ type: 'text', text: 'not json' }] };
+  // Prime + transition
+  annotateMutationAbsence(envelope({}), { client, screenName: 'Home', source: 'cdp_navigate' });
+  const result = annotateMutationAbsence(malformed, { client, screenName: 'OrderSuccess', source: 'cdp_navigate' });
+  assert.equal(result, malformed);
+});
+
+// ── Source guards ───────────────────────────────────────────────────────
+
+test('source guard: cdp_navigate handler invokes annotateMutationAbsence', async () => {
+  const { readFileSync } = await import('node:fs');
+  const { fileURLToPath } = await import('node:url');
+  const { dirname, join } = await import('node:path');
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(join(__dirname, '../../dist/index.js'), 'utf-8');
+  // The cdp_navigate inline handler must annotate.
+  assert.match(src, /annotateMutationAbsence\(okResult\(parsed\),\s*\{[\s\S]*?source:\s*['"]cdp_navigate['"]/);
+});
+
+test('source guard: cdp_navigation_state handler invokes annotateMutationAbsence', async () => {
+  const { readFileSync } = await import('node:fs');
+  const { fileURLToPath } = await import('node:url');
+  const { dirname, join } = await import('node:path');
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(join(__dirname, '../../dist/tools/navigation-state.js'), 'utf-8');
+  assert.match(src, /annotateMutationAbsence/);
+  assert.match(src, /source:\s*['"]cdp_navigation_state['"]/);
+});
+
+test('source guard: proof_step handler invokes annotateMutationAbsence', async () => {
+  const { readFileSync } = await import('node:fs');
+  const { fileURLToPath } = await import('node:url');
+  const { dirname, join } = await import('node:path');
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(join(__dirname, '../../dist/tools/proof-step.js'), 'utf-8');
+  assert.match(src, /annotateMutationAbsence/);
+  assert.match(src, /source:\s*['"]proof_step['"]/);
+});


### PR DESCRIPTION
Closes GH #91. Partial progress on #61 (Option B.4 specifically; B.1-3/B.5/C/D remain on #61 as the umbrella).

## Summary
- **New module** `verification/mutation-absence.ts` — pure consumer-side detector reading from the existing CDP network buffer (no new event handlers). Singleton state map keyed by `${metroPort}-${targetId}`, mirroring the `NetworkBufferManager` pattern.
- **Detection rule**: emit `meta.verification_warning: { code: 'MUTATION_ABSENCE', screen, source, window_ms, mutations_observed: 0, last_mutation_age_ms, hint }` when:
  1. The active screen name suffix-matches `(success|done|added|complete|completed|confirmation)$/i` (last path segment, case-insensitive — works for both React Navigation `OrderConfirmation` and Expo Router `/orders/[id]/confirmation`).
  2. This is a transition (signature differs from last observation for this device — first observation primes, never warns).
  3. The 5-second rolling window has zero qualifying mutations: POST/PUT/PATCH/DELETE with status 2xx/3xx OR fresh-pending (`status === undefined && timestamp >= now - 2000ms`).
- **3 wire-in sites**: `cdp_navigate` (intent signal via `args.screen`), `cdp_navigation_state` (extracts active route from parsed nav state), `proof_step` (derives signal from `args.screen ?? args.verifyTestID ?? args.verifyText`).
- **Visibility, not enforcement.** Doesn't block. Per #61's framing: agents are more allergic to ignoring visible warnings than to breaking invisible rules.

## Why
IX-2950 (#60, now closed) had an agent reach a "policy added" success sheet via deep-linking past the `createExternalCoverage` mutation. Screenshots looked identical to a real flow; only the absent network call would have revealed the bypass. #61 proposed a verification-fidelity framework; B.4 was the highest-impact concrete piece. This implements it.

## Test plan
- [x] **28 new unit tests** in `gh-91-mutation-absence.test.js`:
  - Pure helpers (8): `normalizeRouteName` for null/empty/whitespace/RN/Expo; `isSuccessShape` for RN style/Expo path style/non-success/case-insensitive.
  - `countWindowedMutations` (7): method filter, 5s window, failed mutations excluded (Gemini's correctness catch — regression guard), fresh-pending counts, **stale-pending does NOT count** (closes the race window — Gemini conf 85), freshness boundary at exactly 2s, last_mutation_age_ms reporting.
  - `annotateMutationAbsence` (10): first observation primes / never warns, same-screen no-transition does not warn, transition to success-shape with empty window emits warning, transition to non-success does not warn, mutation in window suppresses warning, last_mutation_age_ms diagnostic, isError pass-through, per-device isolation, pre-existing meta preserved, malformed envelope safety.
  - Source guards (3): each wire-in must call `annotateMutationAbsence` with the right `source` tag.
- [x] Full suite **919 passing** (was 891, +28), zero regressions.
- [x] Multi-LLM brainstorm (Codex gpt-5.5 xhigh + Gemini + Claude verified, parallel/isolated): converged on singleton-pattern, reuse `networkBufferManager.filter()`, status-filter design, edge-trigger semantics, 3-of-4 wire-in scope for v1.
- [x] Multi-LLM review:
  - **Gemini (conf 85)** caught the in-flight pending race: a `requestWillBeSent` POST with `status === undefined` would silence warnings for what'll be a 5xx. Fixed pre-PR with `MAX_PENDING_AGE_MS = 2000` freshness gate (only recently-fired pendings count as in-flight success). 2 new regression tests verify the boundary.
  - **Codex (gpt-5.5 xhigh)**: 0 high-confidence issues. Verified edge-trigger correctness, status filter (also excludes `loadingFailed`'s `status: 0` sentinel), per-device isolation via `activeDeviceKey`, soft-reconnect resilience via deviceKey invariance, JSON round-trip safety in `augmentMeta`.

## Smoke (post-merge, requires CC restart)
1. Boot iOS simulator; connect via `cdp_status`.
2. Use `cdp_navigate({ screen: 'AnyHomeScreen' })` to prime the detector to a non-success screen.
3. Use `cdp_navigate({ screen: 'OrderSuccess' })` (or any success-shape route name) WITHOUT firing a mutation first.
4. Expect: `meta.verification_warning: { code: 'MUTATION_ABSENCE', screen: 'OrderSuccess', source: 'cdp_navigate', window_ms: 5000, mutations_observed: 0, last_mutation_age_ms: null, hint: '...' }`.
5. Verify the same flow with a mutation fired in the 5s window does NOT emit the warning.

## Out of scope (deferred to v1.1)
- `cdp_interact` / `device_press` wire-in (those tools don't fetch nav state; typical follow-up `cdp_navigation_state` call catches the post-tap transition).
- Per-project config knobs (`verification.windowMs`, `verification.successShapes`, allow-list).
- Push-based listener via `Runtime.addBinding` on `__NAV_REF__.addListener`.
- Cross-source signature normalization (the `cdp_navigate` route-name vs `cdp_navigation_state` path-style edge case Codex flagged sub-threshold — usability nit, not correctness).

Workspace docs (D688, Phase 120): committed as `d2d1b7a` on `rn-dev-agent-workspace` main.