### PR TITLE
feat(gh-61-b1): deep-link depth verification-fidelity detector

### DIFF
--- a/scripts/cdp-bridge/dist/tools/device-deeplink.js
+++ b/scripts/cdp-bridge/dist/tools/device-deeplink.js
@@ -3,6 +3,7 @@ import { promisify } from 'node:util';
 import { okResult, failResult } from '../utils.js';
 import { detectPlatform } from './platform-utils.js';
 import { getAdbSerial } from '../agent-device-wrapper.js';
+import { annotateDeepLinkDepth } from '../verification/deep-link-depth.js';
 const execFile = promisify(execFileCb);
 const EXEC_TIMEOUT_MS = 10_000;
 async function openIosDeeplink(url) {
@@ -64,8 +65,11 @@ export function createDeviceDeeplinkHandler() {
         if (!platform) {
             return failResult('No iOS simulator or Android device detected. Pass platform explicitly or boot a device.', { code: 'NO_DEVICE' });
         }
-        if (platform === 'ios')
-            return openIosDeeplink(args.url);
-        return openAndroidDeeplink(args.url, args.packageName);
+        const result = platform === 'ios'
+            ? await openIosDeeplink(args.url)
+            : await openAndroidDeeplink(args.url, args.packageName);
+        // GH #61 B.1: warn on suspicious-looking deep links (3+ segments OR
+        // success-state suffix). Stateless heuristic; no overhead on short URLs.
+        return annotateDeepLinkDepth(result, { url: args.url });
     };
 }

--- a/scripts/cdp-bridge/dist/verification/deep-link-depth.js
+++ b/scripts/cdp-bridge/dist/verification/deep-link-depth.js
@@ -1,0 +1,93 @@
+import { attachVerificationWarning } from './envelope.js';
+// GH #61 Option B.1 / D689: deep-link depth heuristic. The IX-2950 narrative
+// in #61 was the agent reaching a "policy added" success sheet via a deep
+// link with 3 path segments AND ending in a success-state word
+// (`gtsf://main/wallet/policy-details/<id>/true`). Both signals are weak
+// individually but together they reliably mark "you bypassed the user flow"
+// in practice — at minimum worth a warning so a reviewer can see what was
+// shortcut.
+//
+// Stateless detector — no rolling window or per-device state. Just inspects
+// the URL the caller passed to device_deeplink. Composable with other
+// verification detectors via the same `meta.verification_warning` envelope
+// slot.
+const SUCCESS_SUFFIX_REGEX = /(success|done|added|complete|completed|confirmation)$/i;
+const DEPTH_THRESHOLD = 3;
+/**
+ * Pure: parse a deep-link URL and report path segments + success-suffix flag.
+ * Strips scheme, host, query, and fragment so only the path counts.
+ *
+ * Examples (depth threshold = 3):
+ *   gtsf://main/wallet/policy-details/abc-123 → segments=4, exceeds=true
+ *   gtsf://main/cart                          → segments=2, exceeds=false
+ *   myapp://orders/123/confirmation           → segments=3, suffix=true
+ *   /wallet/policy-details/abc/true           → segments=4, exceeds=true (path-only OK)
+ */
+export function analyzeDeepLinkUrl(url) {
+    if (typeof url !== 'string' || url.length === 0) {
+        return { segments: 0, endsWithSuccessWord: false, exceedsThreshold: false };
+    }
+    // Strip scheme, query, and fragment. Count ALL remaining segments — for
+    // app-scheme deep links (gtsf://main/wallet/...) the part the URL parser
+    // would call "host" is actually a meaningful navigation segment in the
+    // user's mental model. The reporter's bypass URL (gtsf://main/wallet/
+    // policy-details/<id>/true) is meant to be a 5-segment deep link, not a
+    // 4-segment one with "main" stripped as host. For https universal links
+    // the same rule applies — example.com counts as a segment, but in practice
+    // legitimate https deep links rarely deep-link past 3 segments either.
+    let path = url;
+    const hashIdx = path.indexOf('#');
+    if (hashIdx >= 0)
+        path = path.slice(0, hashIdx);
+    const qIdx = path.indexOf('?');
+    if (qIdx >= 0)
+        path = path.slice(0, qIdx);
+    const schemeMatch = path.match(/^[a-zA-Z][a-zA-Z0-9+.-]*:(\/\/)?/);
+    if (schemeMatch) {
+        path = path.slice(schemeMatch[0].length);
+    }
+    const segments = path.split('/').filter((seg) => seg.length > 0);
+    const last = segments.length > 0 ? segments[segments.length - 1] : '';
+    const endsWithSuccessWord = SUCCESS_SUFFIX_REGEX.test(last);
+    const exceedsThreshold = segments.length >= DEPTH_THRESHOLD;
+    return { segments: segments.length, endsWithSuccessWord, exceedsThreshold };
+}
+/**
+ * Annotate a successful device_deeplink result with `meta.verification_warning`
+ * when the URL is suspiciously deep or ends with a success-state word.
+ *
+ * The `device_deeplink` tool's response already carries `data.url`, but we
+ * pass it explicitly so callers can detect bypasses even when the response
+ * shape changes.
+ */
+export function annotateDeepLinkDepth(result, ctx) {
+    const analysis = analyzeDeepLinkUrl(ctx.url);
+    if (!analysis.exceedsThreshold && !analysis.endsWithSuccessWord)
+        return result;
+    const trigger = analysis.exceedsThreshold && analysis.endsWithSuccessWord
+        ? 'depth_and_success_suffix'
+        : analysis.exceedsThreshold
+            ? 'depth'
+            : 'success_suffix';
+    const reasons = [];
+    if (analysis.exceedsThreshold) {
+        reasons.push(`${analysis.segments} path segments (threshold: ${DEPTH_THRESHOLD}+)`);
+    }
+    if (analysis.endsWithSuccessWord) {
+        reasons.push('ends with a success-state word');
+    }
+    const hint = `Deep link "${ctx.url}" matches a bypass-shape pattern (${reasons.join('; ')}). ` +
+        `If this is meant to verify a user-flow, the tap-through path was likely skipped — the user does not ` +
+        `manually navigate 3+ levels deep, and only post-mutation success screens use these route names. ` +
+        `Use cdp_navigate sparingly here; prefer device_press + cdp_interact to drive the actual flow.`;
+    const warning = {
+        code: 'DEEP_LINK_DEPTH',
+        source: 'device_deeplink',
+        url: ctx.url,
+        segments: analysis.segments,
+        ends_with_success_word: analysis.endsWithSuccessWord,
+        trigger,
+        hint,
+    };
+    return attachVerificationWarning(result, warning);
+}

--- a/scripts/cdp-bridge/dist/verification/envelope.js
+++ b/scripts/cdp-bridge/dist/verification/envelope.js
@@ -1,0 +1,15 @@
+export function attachVerificationWarning(result, warning) {
+    if (result.isError)
+        return result;
+    try {
+        const text = result.content[0]?.text;
+        if (!text)
+            return result;
+        const env = JSON.parse(text);
+        env.meta = { ...env.meta, verification_warning: warning };
+        return { content: [{ type: 'text', text: JSON.stringify(env) }] };
+    }
+    catch {
+        return result;
+    }
+}

--- a/scripts/cdp-bridge/dist/verification/mutation-absence.js
+++ b/scripts/cdp-bridge/dist/verification/mutation-absence.js
@@ -1,3 +1,4 @@
+import { attachVerificationWarning } from './envelope.js';
 // GH #91 / D688: mutation-absence detector. Catches the IX-2950 verification-
 // fidelity failure where an agent reaches a "success-shape" screen
 // (OrderConfirmation, AddPolicySuccess, ...) via deep-link or state-injection
@@ -138,20 +139,7 @@ export function annotateMutationAbsence(result, ctx) {
         last_mutation_age_ms: lastMutationAgeMs,
         hint,
     };
-    return augmentMeta(result, { verification_warning: warning });
-}
-function augmentMeta(result, extra) {
-    try {
-        const text = result.content[0]?.text;
-        if (!text)
-            return result;
-        const env = JSON.parse(text);
-        env.meta = { ...env.meta, ...extra };
-        return { content: [{ type: 'text', text: JSON.stringify(env) }] };
-    }
-    catch {
-        return result;
-    }
+    return attachVerificationWarning(result, warning);
 }
 /** Test seam: clear the per-device state map. Not exported via index.ts. */
 export function _resetForTests() {

--- a/scripts/cdp-bridge/src/tools/device-deeplink.ts
+++ b/scripts/cdp-bridge/src/tools/device-deeplink.ts
@@ -4,6 +4,7 @@ import type { ToolResult } from '../utils.js';
 import { okResult, failResult } from '../utils.js';
 import { detectPlatform } from './platform-utils.js';
 import { getAdbSerial } from '../agent-device-wrapper.js';
+import { annotateDeepLinkDepth } from '../verification/deep-link-depth.js';
 
 const execFile = promisify(execFileCb);
 const EXEC_TIMEOUT_MS = 10_000;
@@ -79,7 +80,11 @@ export function createDeviceDeeplinkHandler(): (args: DeeplinkArgs) => Promise<T
         { code: 'NO_DEVICE' },
       );
     }
-    if (platform === 'ios') return openIosDeeplink(args.url);
-    return openAndroidDeeplink(args.url, args.packageName);
+    const result = platform === 'ios'
+      ? await openIosDeeplink(args.url)
+      : await openAndroidDeeplink(args.url, args.packageName);
+    // GH #61 B.1: warn on suspicious-looking deep links (3+ segments OR
+    // success-state suffix). Stateless heuristic; no overhead on short URLs.
+    return annotateDeepLinkDepth(result, { url: args.url });
   };
 }

--- a/scripts/cdp-bridge/src/verification/deep-link-depth.ts
+++ b/scripts/cdp-bridge/src/verification/deep-link-depth.ts
@@ -1,0 +1,123 @@
+import type { ToolResult } from '../utils.js';
+import { attachVerificationWarning, type BaseVerificationWarning } from './envelope.js';
+
+// GH #61 Option B.1 / D689: deep-link depth heuristic. The IX-2950 narrative
+// in #61 was the agent reaching a "policy added" success sheet via a deep
+// link with 3 path segments AND ending in a success-state word
+// (`gtsf://main/wallet/policy-details/<id>/true`). Both signals are weak
+// individually but together they reliably mark "you bypassed the user flow"
+// in practice — at minimum worth a warning so a reviewer can see what was
+// shortcut.
+//
+// Stateless detector — no rolling window or per-device state. Just inspects
+// the URL the caller passed to device_deeplink. Composable with other
+// verification detectors via the same `meta.verification_warning` envelope
+// slot.
+
+const SUCCESS_SUFFIX_REGEX = /(success|done|added|complete|completed|confirmation)$/i;
+
+const DEPTH_THRESHOLD = 3;
+
+export interface DeepLinkDepthWarning extends BaseVerificationWarning {
+  code: 'DEEP_LINK_DEPTH';
+  source: 'device_deeplink';
+  url: string;
+  segments: number;
+  ends_with_success_word: boolean;
+  trigger: 'depth' | 'success_suffix' | 'depth_and_success_suffix';
+  hint: string;
+}
+
+export interface DeepLinkAnalysis {
+  segments: number;
+  endsWithSuccessWord: boolean;
+  exceedsThreshold: boolean;
+}
+
+/**
+ * Pure: parse a deep-link URL and report path segments + success-suffix flag.
+ * Strips scheme, host, query, and fragment so only the path counts.
+ *
+ * Examples (depth threshold = 3):
+ *   gtsf://main/wallet/policy-details/abc-123 → segments=4, exceeds=true
+ *   gtsf://main/cart                          → segments=2, exceeds=false
+ *   myapp://orders/123/confirmation           → segments=3, suffix=true
+ *   /wallet/policy-details/abc/true           → segments=4, exceeds=true (path-only OK)
+ */
+export function analyzeDeepLinkUrl(url: string): DeepLinkAnalysis {
+  if (typeof url !== 'string' || url.length === 0) {
+    return { segments: 0, endsWithSuccessWord: false, exceedsThreshold: false };
+  }
+
+  // Strip scheme, query, and fragment. Count ALL remaining segments — for
+  // app-scheme deep links (gtsf://main/wallet/...) the part the URL parser
+  // would call "host" is actually a meaningful navigation segment in the
+  // user's mental model. The reporter's bypass URL (gtsf://main/wallet/
+  // policy-details/<id>/true) is meant to be a 5-segment deep link, not a
+  // 4-segment one with "main" stripped as host. For https universal links
+  // the same rule applies — example.com counts as a segment, but in practice
+  // legitimate https deep links rarely deep-link past 3 segments either.
+  let path = url;
+  const hashIdx = path.indexOf('#');
+  if (hashIdx >= 0) path = path.slice(0, hashIdx);
+  const qIdx = path.indexOf('?');
+  if (qIdx >= 0) path = path.slice(0, qIdx);
+  const schemeMatch = path.match(/^[a-zA-Z][a-zA-Z0-9+.-]*:(\/\/)?/);
+  if (schemeMatch) {
+    path = path.slice(schemeMatch[0].length);
+  }
+
+  const segments = path.split('/').filter((seg) => seg.length > 0);
+  const last = segments.length > 0 ? segments[segments.length - 1] : '';
+  const endsWithSuccessWord = SUCCESS_SUFFIX_REGEX.test(last);
+  const exceedsThreshold = segments.length >= DEPTH_THRESHOLD;
+  return { segments: segments.length, endsWithSuccessWord, exceedsThreshold };
+}
+
+/**
+ * Annotate a successful device_deeplink result with `meta.verification_warning`
+ * when the URL is suspiciously deep or ends with a success-state word.
+ *
+ * The `device_deeplink` tool's response already carries `data.url`, but we
+ * pass it explicitly so callers can detect bypasses even when the response
+ * shape changes.
+ */
+export function annotateDeepLinkDepth(
+  result: ToolResult,
+  ctx: { url: string },
+): ToolResult {
+  const analysis = analyzeDeepLinkUrl(ctx.url);
+  if (!analysis.exceedsThreshold && !analysis.endsWithSuccessWord) return result;
+
+  const trigger: DeepLinkDepthWarning['trigger'] = analysis.exceedsThreshold && analysis.endsWithSuccessWord
+    ? 'depth_and_success_suffix'
+    : analysis.exceedsThreshold
+      ? 'depth'
+      : 'success_suffix';
+
+  const reasons: string[] = [];
+  if (analysis.exceedsThreshold) {
+    reasons.push(`${analysis.segments} path segments (threshold: ${DEPTH_THRESHOLD}+)`);
+  }
+  if (analysis.endsWithSuccessWord) {
+    reasons.push('ends with a success-state word');
+  }
+
+  const hint =
+    `Deep link "${ctx.url}" matches a bypass-shape pattern (${reasons.join('; ')}). ` +
+    `If this is meant to verify a user-flow, the tap-through path was likely skipped — the user does not ` +
+    `manually navigate 3+ levels deep, and only post-mutation success screens use these route names. ` +
+    `Use cdp_navigate sparingly here; prefer device_press + cdp_interact to drive the actual flow.`;
+
+  const warning: DeepLinkDepthWarning = {
+    code: 'DEEP_LINK_DEPTH',
+    source: 'device_deeplink',
+    url: ctx.url,
+    segments: analysis.segments,
+    ends_with_success_word: analysis.endsWithSuccessWord,
+    trigger,
+    hint,
+  };
+
+  return attachVerificationWarning(result, warning);
+}

--- a/scripts/cdp-bridge/src/verification/envelope.ts
+++ b/scripts/cdp-bridge/src/verification/envelope.ts
@@ -1,0 +1,35 @@
+import type { ToolResult } from '../utils.js';
+
+// GH #61 / D688+: shared envelope-augmentation helper for verification-fidelity
+// detectors. Mutates the JSON-stringified envelope inside `result.content[0]`
+// to add `meta.verification_warning`. Pure: returns the original result on
+// parse failure, malformed shape, or isError envelope so detectors can never
+// break tools.
+//
+// v1: single-warning slot. When a future detector composes onto a tool that
+// already carries a warning (e.g. B.2 suspect route-param + B.4 mutation-absence
+// on cdp_navigate), this will need to migrate to a `verification_warnings`
+// array. Keeping it singular for now since the active detectors (B.1
+// device_deeplink + B.4 cdp_navigate/nav_state/proof_step) hit disjoint tools.
+
+export interface BaseVerificationWarning {
+  code: string;
+  source: string;
+  hint: string;
+}
+
+export function attachVerificationWarning<T extends BaseVerificationWarning>(
+  result: ToolResult,
+  warning: T,
+): ToolResult {
+  if (result.isError) return result;
+  try {
+    const text = result.content[0]?.text;
+    if (!text) return result;
+    const env = JSON.parse(text) as { ok?: boolean; data?: unknown; meta?: Record<string, unknown> };
+    env.meta = { ...env.meta, verification_warning: warning };
+    return { content: [{ type: 'text' as const, text: JSON.stringify(env) }] };
+  } catch {
+    return result;
+  }
+}

--- a/scripts/cdp-bridge/src/verification/mutation-absence.ts
+++ b/scripts/cdp-bridge/src/verification/mutation-absence.ts
@@ -1,5 +1,6 @@
 import type { CDPClient } from '../cdp-client.js';
 import type { ToolResult } from '../utils.js';
+import { attachVerificationWarning } from './envelope.js';
 
 // GH #91 / D688: mutation-absence detector. Catches the IX-2950 verification-
 // fidelity failure where an agent reaches a "success-shape" screen
@@ -178,19 +179,7 @@ export function annotateMutationAbsence(result: ToolResult, ctx: AnnotateContext
     hint,
   };
 
-  return augmentMeta(result, { verification_warning: warning });
-}
-
-function augmentMeta(result: ToolResult, extra: Record<string, unknown>): ToolResult {
-  try {
-    const text = result.content[0]?.text;
-    if (!text) return result;
-    const env = JSON.parse(text) as { ok?: boolean; data?: unknown; meta?: Record<string, unknown> };
-    env.meta = { ...env.meta, ...extra };
-    return { content: [{ type: 'text' as const, text: JSON.stringify(env) }] };
-  } catch {
-    return result;
-  }
+  return attachVerificationWarning(result, warning);
 }
 
 /** Test seam: clear the per-device state map. Not exported via index.ts. */

--- a/scripts/cdp-bridge/test/unit/gh-61-b1-deep-link-depth.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-61-b1-deep-link-depth.test.js
@@ -1,0 +1,214 @@
+// GH #61 Option B.1 / D689: deep-link depth heuristic. Verification-fidelity
+// detector that warns on `device_deeplink` URLs with 3+ path segments OR
+// ending with a success-state word (success/done/added/complete/completed/
+// confirmation). Stateless — pure URL pattern check, no rolling window.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const MOD_PATH = '../../dist/verification/deep-link-depth.js';
+
+function envelope(data, meta) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ ok: true, data, ...(meta ? { meta } : {}) }) }],
+  };
+}
+
+function parse(result) {
+  return JSON.parse(result.content[0].text);
+}
+
+// ── analyzeDeepLinkUrl: pure URL parsing ───────────────────────────────
+
+test('analyzeDeepLinkUrl: handles RN custom-scheme deep links', async () => {
+  const { analyzeDeepLinkUrl } = await import(MOD_PATH);
+  // The IX-2950 trigger URL: gtsf://main/wallet/policy-details/<id>/true.
+  // For app-scheme deep links, every post-`://` part is a meaningful navigation
+  // segment — "main" is a logical root, not a DNS host.
+  const a = analyzeDeepLinkUrl('gtsf://main/wallet/policy-details/abc-123/true');
+  assert.equal(a.segments, 5);
+  assert.equal(a.exceedsThreshold, true);
+});
+
+test('analyzeDeepLinkUrl: detects success-state suffix', async () => {
+  const { analyzeDeepLinkUrl } = await import(MOD_PATH);
+  for (const suffix of ['success', 'done', 'added', 'complete', 'completed', 'confirmation']) {
+    const a = analyzeDeepLinkUrl(`myapp://orders/${suffix}`);
+    assert.equal(a.endsWithSuccessWord, true, `suffix "${suffix}" should match`);
+  }
+});
+
+test('analyzeDeepLinkUrl: case-insensitive success match', async () => {
+  const { analyzeDeepLinkUrl } = await import(MOD_PATH);
+  assert.equal(analyzeDeepLinkUrl('myapp://orders/SUCCESS').endsWithSuccessWord, true);
+  assert.equal(analyzeDeepLinkUrl('myapp://orders/Confirmation').endsWithSuccessWord, true);
+});
+
+test('analyzeDeepLinkUrl: non-success suffixes do not match', async () => {
+  const { analyzeDeepLinkUrl } = await import(MOD_PATH);
+  for (const tail of ['list', 'detail', 'home', 'cart', 'profile']) {
+    assert.equal(
+      analyzeDeepLinkUrl(`myapp://app/${tail}`).endsWithSuccessWord,
+      false,
+      `tail "${tail}" must not flag as success`,
+    );
+  }
+});
+
+test('analyzeDeepLinkUrl: 1-2 segments do NOT exceed threshold', async () => {
+  const { analyzeDeepLinkUrl } = await import(MOD_PATH);
+  assert.equal(analyzeDeepLinkUrl('myapp://home').exceedsThreshold, false);
+  assert.equal(analyzeDeepLinkUrl('myapp://orders').exceedsThreshold, false);
+});
+
+test('analyzeDeepLinkUrl: 3+ segments exceed threshold', async () => {
+  const { analyzeDeepLinkUrl } = await import(MOD_PATH);
+  // myapp://orders/list = 2 segments (below threshold) — shallow nav.
+  assert.equal(analyzeDeepLinkUrl('myapp://orders/list').exceedsThreshold, false);
+  // myapp://orders/123/edit = 3 segments — meets threshold.
+  assert.equal(analyzeDeepLinkUrl('myapp://orders/123/edit').exceedsThreshold, true);
+  // myapp://wallet/policies/abc/details/edit = 5 segments — clearly deep.
+  assert.equal(analyzeDeepLinkUrl('myapp://wallet/policies/abc/details/edit').exceedsThreshold, true);
+});
+
+test('analyzeDeepLinkUrl: strips query and fragment', async () => {
+  const { analyzeDeepLinkUrl } = await import(MOD_PATH);
+  // Query and fragment must NOT count as segments and must NOT contribute to suffix.
+  const a = analyzeDeepLinkUrl('myapp://orders?confirmation=true&id=123');
+  assert.equal(a.segments, 1, 'orders is 1 segment, query stripped');
+  assert.equal(a.endsWithSuccessWord, false);
+  const b = analyzeDeepLinkUrl('myapp://orders/list#success');
+  assert.equal(b.segments, 2);
+  assert.equal(b.endsWithSuccessWord, false, 'fragment must not contribute to suffix');
+});
+
+test('analyzeDeepLinkUrl: handles path-only inputs', async () => {
+  const { analyzeDeepLinkUrl } = await import(MOD_PATH);
+  // Some callers may pass paths without a scheme.
+  const a = analyzeDeepLinkUrl('/wallet/policy-details/abc/true');
+  assert.equal(a.segments, 4);
+  assert.equal(a.exceedsThreshold, true);
+});
+
+test('analyzeDeepLinkUrl: handles https universal links', async () => {
+  const { analyzeDeepLinkUrl } = await import(MOD_PATH);
+  // example.com counts as a segment too — same uniform treatment as app schemes.
+  const a = analyzeDeepLinkUrl('https://example.com/orders/123/confirmation');
+  assert.equal(a.segments, 4);
+  assert.equal(a.endsWithSuccessWord, true);
+  assert.equal(a.exceedsThreshold, true);
+});
+
+test('analyzeDeepLinkUrl: handles malformed and empty inputs safely', async () => {
+  const { analyzeDeepLinkUrl } = await import(MOD_PATH);
+  assert.deepEqual(analyzeDeepLinkUrl(''), { segments: 0, endsWithSuccessWord: false, exceedsThreshold: false });
+  assert.deepEqual(analyzeDeepLinkUrl(null), { segments: 0, endsWithSuccessWord: false, exceedsThreshold: false });
+  assert.deepEqual(analyzeDeepLinkUrl(undefined), { segments: 0, endsWithSuccessWord: false, exceedsThreshold: false });
+  // Bare scheme with no path
+  assert.deepEqual(analyzeDeepLinkUrl('myapp://'), { segments: 0, endsWithSuccessWord: false, exceedsThreshold: false });
+});
+
+// ── annotateDeepLinkDepth: integration with envelope ─────────────────────
+
+test('annotateDeepLinkDepth: shallow URL with no success suffix passes through unchanged', async () => {
+  const { annotateDeepLinkDepth } = await import(MOD_PATH);
+  const r = envelope({ opened: true, url: 'myapp://home' });
+  const result = annotateDeepLinkDepth(r, { url: 'myapp://home' });
+  assert.equal(parse(result).meta?.verification_warning, undefined);
+});
+
+test('annotateDeepLinkDepth: depth-only trigger emits DEEP_LINK_DEPTH warning', async () => {
+  const { annotateDeepLinkDepth } = await import(MOD_PATH);
+  const url = 'myapp://wallet/policies/abc/details';
+  const result = annotateDeepLinkDepth(envelope({ opened: true, url }), { url });
+  const env = parse(result);
+  assert.ok(env.meta?.verification_warning);
+  assert.equal(env.meta.verification_warning.code, 'DEEP_LINK_DEPTH');
+  assert.equal(env.meta.verification_warning.source, 'device_deeplink');
+  assert.equal(env.meta.verification_warning.trigger, 'depth');
+  assert.equal(env.meta.verification_warning.segments, 4);
+  assert.equal(env.meta.verification_warning.ends_with_success_word, false);
+});
+
+test('annotateDeepLinkDepth: borderline 2-segment URL with non-success suffix passes through', async () => {
+  // Make sure the threshold semantics are right — 2-segment shallow nav
+  // (orders/list, profile/edit) is below threshold and shouldn't warn.
+  const { annotateDeepLinkDepth } = await import(MOD_PATH);
+  const r1 = annotateDeepLinkDepth(envelope({}), { url: 'myapp://orders/list' });
+  assert.equal(parse(r1).meta?.verification_warning, undefined);
+  const r2 = annotateDeepLinkDepth(envelope({}), { url: 'myapp://profile/edit' });
+  assert.equal(parse(r2).meta?.verification_warning, undefined);
+});
+
+test('annotateDeepLinkDepth: success-suffix-only trigger fires below depth threshold', async () => {
+  const { annotateDeepLinkDepth } = await import(MOD_PATH);
+  const url = 'myapp://orders/done';
+  const result = annotateDeepLinkDepth(envelope({}), { url });
+  const w = parse(result).meta.verification_warning;
+  assert.equal(w.trigger, 'success_suffix');
+  assert.equal(w.segments, 2);
+  assert.equal(w.ends_with_success_word, true);
+});
+
+test('annotateDeepLinkDepth: combined trigger (depth + success suffix) reports both', async () => {
+  const { annotateDeepLinkDepth } = await import(MOD_PATH);
+  // The IX-2950 case: 4 segments AND ends with success-shape word
+  const url = 'gtsf://main/wallet/policy-details/abc-123/confirmation';
+  const result = annotateDeepLinkDepth(envelope({}), { url });
+  const w = parse(result).meta.verification_warning;
+  assert.equal(w.trigger, 'depth_and_success_suffix');
+  assert.match(w.hint, /5 path segments/);
+  assert.match(w.hint, /ends with a success-state word/);
+});
+
+test('annotateDeepLinkDepth: does NOT mutate result on isError envelope', async () => {
+  const { annotateDeepLinkDepth } = await import(MOD_PATH);
+  const errored = {
+    content: [{ type: 'text', text: JSON.stringify({ ok: false, error: 'fail' }) }],
+    isError: true,
+  };
+  const result = annotateDeepLinkDepth(errored, { url: 'myapp://orders/123/success' });
+  assert.equal(result, errored);
+});
+
+test('annotateDeepLinkDepth: preserves existing meta fields', async () => {
+  const { annotateDeepLinkDepth } = await import(MOD_PATH);
+  const r = envelope({}, { recovered_via: 'force_reconnect' });
+  const result = annotateDeepLinkDepth(r, { url: 'myapp://orders/123/success' });
+  const env = parse(result);
+  assert.equal(env.meta.recovered_via, 'force_reconnect');
+  assert.equal(env.meta.verification_warning.code, 'DEEP_LINK_DEPTH');
+});
+
+test('annotateDeepLinkDepth: malformed envelope passes through unchanged', async () => {
+  const { annotateDeepLinkDepth } = await import(MOD_PATH);
+  const malformed = { content: [{ type: 'text', text: 'not json' }] };
+  const result = annotateDeepLinkDepth(malformed, { url: 'myapp://orders/123/success' });
+  assert.equal(result, malformed);
+});
+
+// ── Source guards ───────────────────────────────────────────────────────
+
+test('source guard: device_deeplink handler invokes annotateDeepLinkDepth', async () => {
+  const { readFileSync } = await import('node:fs');
+  const { fileURLToPath } = await import('node:url');
+  const { dirname, join } = await import('node:path');
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(join(__dirname, '../../dist/tools/device-deeplink.js'), 'utf-8');
+  assert.match(src, /annotateDeepLinkDepth/);
+});
+
+test('source guard: shared envelope helper attachVerificationWarning is exported', async () => {
+  const { attachVerificationWarning } = await import('../../dist/verification/envelope.js');
+  assert.equal(typeof attachVerificationWarning, 'function');
+});
+
+test('source guard: mutation-absence refactored to use shared envelope helper', async () => {
+  const { readFileSync } = await import('node:fs');
+  const { fileURLToPath } = await import('node:url');
+  const { dirname, join } = await import('node:path');
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(join(__dirname, '../../dist/verification/mutation-absence.js'), 'utf-8');
+  assert.match(src, /attachVerificationWarning/);
+  // Private augmentMeta should be gone now.
+  assert.equal(/^function augmentMeta\b/m.test(src), false, 'private augmentMeta should have been removed');
+});


### PR DESCRIPTION
Closes #61 Option B.1. Partial progress on the remaining #61 detector queue (B.2, B.3, B.5, C, D still deferred).

## Summary
- **New stateless detector** `verification/deep-link-depth.ts`. Warns on `device_deeplink` URLs with 3+ path segments OR ending with a success-state word (success/done/added/complete/completed/confirmation). The IX-2950 bypass URL `gtsf://main/wallet/policy-details/<id>/true` hits both signals and is the prototypical case the detector flags.
- **New shared helper** `verification/envelope.ts` exporting `attachVerificationWarning(result, warning)`. Extracted from D688's private `augmentMeta` to unblock composition across detectors. Mutation-absence.ts refactored to use it; all 28 existing mutation-absence tests still pass — refactor preserved behavior.
- **Three trigger codes** in the warning: `'depth'`, `'success_suffix'`, `'depth_and_success_suffix'`. Lets callers see which signal(s) fired without re-parsing.

## Why
B.4 mutation-absence (#91, just shipped) catches the success-shape transition but doesn't see the deep-link itself — `device_deeplink` returns immediately, before any nav-state observation. B.1 fills that gap with a synchronous URL pattern check on the deeplink call itself. Same `meta.verification_warning` envelope; different signal.

## Design decisions

- **Count ALL post-scheme segments — no host stripping.** For app-scheme deep links (`gtsf://main/wallet/...`), "main" is a meaningful navigation segment in the user's mental model, not a DNS host. Spec's "3+ segments" threshold tunes for this host-included count. https universal links get the same uniform treatment (`https://example.com/orders/list` = 3 segments).
- **Singular `meta.verification_warning` slot retained.** When B.2 (suspect-route-param) lands and collides with B.4 on `cdp_navigate`, migrate to `verification_warnings: []` array. Deferring until then because B.1 wires into a tool no other detector touches.
- **Run AFTER iOS/Android dispatch.** Failed deeplinks (failResult with isError) pass through unchanged via the `attachVerificationWarning` isError guard. No double-warning on failure paths.

## Test plan
- [x] 21 new unit tests in `gh-61-b1-deep-link-depth.test.js`:
  - `analyzeDeepLinkUrl` (10): RN custom-scheme, all 6 success suffixes, case-insensitive, non-success rejection, threshold boundary, query/fragment stripping, path-only, https universal links, malformed/empty/null/undefined safety.
  - `annotateDeepLinkDepth` (7): shallow URL pass-through, depth-only trigger, success-suffix-only trigger, combined trigger reports both reasons, isError pass-through, meta preservation, malformed envelope safety, borderline 2-segment with non-success suffix.
  - Source guards (3): device_deeplink wires the detector, shared `attachVerificationWarning` exported, mutation-absence refactored.
- [x] Full suite **940 passing** (was 919, +21), zero regressions.
- [x] Multi-LLM review (Gemini + Codex gpt-5.5 xhigh, parallel/isolated): **0 high-confidence issues from either reviewer**. Both independently verified parser edge cases (null/bare-scheme/trailing-slash/double-slash/path-traversal), refactor parity (mutation-absence behavior preserved), isError guard correctness, threshold semantics matching the spec example.

## Smoke (post-merge, requires CC restart)
1. Boot iOS simulator with the test app; connect via `cdp_status`.
2. Call `device_deeplink({ url: 'gtsf://main/wallet/policy-details/abc-123/confirmation' })`.
3. Expect: `meta.verification_warning: { code: 'DEEP_LINK_DEPTH', source: 'device_deeplink', url, segments: 5, ends_with_success_word: true, trigger: 'depth_and_success_suffix', hint: '...' }`.
4. Verify a normal-depth URL (`device_deeplink({ url: 'myapp://home' })`) does NOT emit the warning.

## Out of scope (deferred to follow-up PRs)
- B.2 suspect-route-param detector (when it lands, migrate to `verification_warnings` array because of cdp_navigate collision with B.4).
- B.3 MMKV reset detector.
- B.5 snapshot-before-interact check.
- C snapshot-staleness flag.
- D verify-user-flow skill.

Workspace docs (D689, Phase 121): committed as `7154061` on `rn-dev-agent-workspace` main.