### PR TITLE
feat: M7 reusable-actions metadata + Phase 8 rehearsal gate + helpers auto-reinject (v0.44.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.4",
+      "version": "0.44.5",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.4",
+  "version": "0.44.5",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/commands/proof-capture.md
+++ b/commands/proof-capture.md
@@ -9,13 +9,20 @@ Capture PR proof artifacts for: $ARGUMENTS
 
 ## What This Does
 
-1. Starts video recording on the active simulator/emulator
-2. Executes the described user flow (or asks you to perform it)
-3. Captures numbered screenshots at each step
-4. Stops recording and converts to GIF (if ffmpeg available)
-5. **Labels the video** — adds a text bar below the video with step descriptions (default)
-6. **Validates the recording** — verifies the feature is actually visible
-7. Writes PROOF.md and generates PR-BODY.md
+1. **Rehearses the flow OFF camera** to discover testIDs / navigation / state — recording captures replay, not exploration
+2. **Generates a Maestro flow** capturing the verified sequence (with M7 metadata)
+3. Starts video recording on the active simulator/emulator
+4. **Replays the rehearsed flow** via `maestro_run` (deterministic, hesitation-free)
+5. Captures numbered screenshots at each step
+6. Stops recording and converts to GIF (if ffmpeg available)
+7. **Labels the video** — adds a text bar below the video with step descriptions (default)
+8. **Validates the recording** — verifies the feature is actually visible
+9. Writes PROOF.md and generates PR-BODY.md
+
+**Core principle.** Discovery happens before the camera rolls. The video is
+the replay of a known-good action — never the LLM working out testIDs or
+navigation paths on screen. If you would not show the rehearsal pass to a
+reviewer, do not record it.
 
 ## Protocol
 
@@ -44,9 +51,61 @@ Call `cdp_status` to confirm the app is running and CDP is connected.
 4. Take a baseline screenshot to confirm the starting screen is the actual
    app, not a system dialog or dev client picker.
 
+### Step 2.5: Rehearsal pass (MANDATORY — discovery happens OFF camera)
+
+**Do NOT start recording yet.** First, walk the described flow once with no
+video so you can discover testIDs, navigation paths, and state shapes
+without the camera capturing the search.
+
+**Protocol:**
+
+1. Execute the described flow using `device_*` / `cdp_*` calls. If no flow
+   description was supplied, ask the user to describe the steps before
+   continuing.
+2. Fix any discovered drift (wrong testID, missing route, store-path typo).
+3. **Generate a Maestro flow** capturing the verified sequence at
+   `<test-app>/.maestro/flows/<slug>.yaml`. Two authoring paths:
+   - `maestro_generate(name="<slug>", steps=[...], appId="...")` — writes
+     the YAML from structured steps; does NOT emit the M7 metadata header.
+   - `cdp_record_test_generate(format="maestro")` — converts the recorder
+     buffer to YAML text; M7 fields are not forwarded by the MCP tool
+     schema, so the header is not auto-populated.
+   In both paths, the agent MUST then PREPEND the 5-key M7 metadata header
+   by hand (`id`, `intent`, `tags`, `mutates`, `status`) — see
+   `skills/rn-testing/SKILL.md` § "Reusable Action Metadata Schema".
+4. Reset the app state to the same starting screen the recording will use
+   (close modals, navigate back, clear in-memory residue if `mutates: true`).
+5. Smoke-test the flow once. For flows with `${VAR}` placeholders, use the
+   Bash CLI (which supports `-e`):
+   ```bash
+   maestro-runner --platform <ios|android> test \
+     <test-app>/.maestro/flows/<slug>.yaml -e KEY=VALUE
+   ```
+   For env-free flows, the MCP tool also works:
+   `maestro_run(flowPath="<test-app>/.maestro/flows/<slug>.yaml")`.
+   The replay must pass end-to-end without a single failure.
+6. **Retry budget: max 3 fix-and-replay loops.** If the rehearsal still
+   fails after 3 attempts, escalate to the user with the failing step,
+   the failing assertion, and snapshots from `cdp_navigation_state` /
+   `cdp_store_state` — do NOT loop indefinitely.
+
+**Hard gate.** If step 5 fails, fix the flow and repeat (max 3 attempts).
+Do not move to Step 3 (start recording) until the replay is clean OR the
+inexpressibility carve-out below has been documented.
+
+**Maestro-inexpressibility carve-out.** If the flow genuinely cannot be
+expressed in Maestro (custom gestures, native-module side-effects,
+Reanimated proof captures via `cdp_set_shared_value`, JS-introspection
+mid-flow), document the specific Maestro primitive that is missing in
+PROOF.md "Deviations" and proceed to Step 3 — the rehearsal walk via
+`device_*` / `cdp_*` becomes the artifact. Choosing the fallback without
+naming the inexpressibility is a Red Flag — keep trying to express the
+flow until you can name what's missing.
+
 ### Step 3: Start recording
 
-Detect the platform and start recording:
+After the rehearsal flow has replayed clean, reset the app to the starting
+screen one more time, then start recording:
 
 ```bash
 # iOS
@@ -58,20 +117,41 @@ rn-record-proof start android docs/proof/<slug>/flow-android.mp4
 
 If recording fails to start, warn but continue — screenshots are the primary artifact.
 
-### Step 4: Execute the flow
+### Step 4: Replay the rehearsed flow
 
-If a flow description was provided, navigate and interact through the described
-flow step by step. At each meaningful state change:
+**Preferred path:** with recording running, invoke the Maestro flow generated
+in Step 2.5.
 
-1. Wait 1-2 seconds for the UI to settle
-2. Take a numbered screenshot:
-   ```bash
-   xcrun simctl io booted screenshot --type=jpeg docs/proof/<slug>/01-<description>.jpg
-   ```
-3. Verify the expected state via `cdp_component_tree`, `cdp_store_state`,
-   or `cdp_navigation_state`
+For flows with `${VAR}` placeholders (need env substitution):
+```bash
+maestro-runner --platform <ios|android> test \
+  <test-app>/.maestro/flows/<slug>.yaml -e KEY=VALUE
+```
 
-If no flow description was provided, ask the user to describe the steps.
+For env-free flows, the MCP tool also works:
+- `maestro_run(flowPath="<test-app>/.maestro/flows/<slug>.yaml")`
+
+(The MCP `maestro_run` tool schema does not forward `-e` env vars; for
+substitution use the `maestro-runner` Bash CLI.)
+
+While the flow runs, take numbered screenshots at meaningful state changes:
+
+```bash
+device_screenshot(path="docs/proof/<slug>/<NN-stepname>.jpg")
+```
+
+For each screenshot, verify the expected state via `cdp_component_tree`,
+`cdp_store_state`, or `cdp_navigation_state`.
+
+**Fallback (only if Maestro cannot express the flow):** execute the
+rehearsed sequence step-by-step using the same `device_*` / `cdp_*` calls
+you confirmed in Step 2.5. Every action must be one you already executed
+cleanly during rehearsal — do NOT debug, navigate randomly, or "explore"
+on camera.
+
+**If a step fails on camera:** stop recording, rebase the app state, redo
+Step 2.5. A failure here means the flow drifted between rehearsal and
+recording — that's a flow bug, not a feature bug. Do not "fix it on camera."
 
 ### Step 5: Stop recording
 

--- a/commands/rn-agent-export.md
+++ b/commands/rn-agent-export.md
@@ -16,8 +16,15 @@ Export your accumulated experience as an anonymized YAML bundle.
 | Confidence scores | Yes | As-is |
 | Environment fingerprint | Yes | Coarsened (major.minor only) |
 | Failure statistics | Yes | Normalized errors only |
+| **Maestro flows** (`<test-app>/.maestro/flows/*.yaml`) | **Yes (default)** | **`appId` redacted to `com.example.<slug>`; `${VAR}` placeholders preserved** |
+| **UI skeleton** (`<test-app>/.ui-skeleton.yaml`) | **Yes (default)** | **`appId` redacted; testID strings preserved (they're already semantic)** |
 | Raw telemetry | No | Never exported |
 | Candidate files | No | Not included |
+
+Flows + skeleton are bundled by default because they ARE the reusable
+actions — the artifact-first protocol relies on them, so a fresh teammate
+clone only gets the muscle memory if these travel with the heuristics.
+Pass `--no-flows` / `--no-skeleton` to opt out for sensitive bundles.
 
 ## Output
 
@@ -29,4 +36,9 @@ Share this file with teammates or across projects. Import with `/rn-dev-agent:rn
 
 - All summaries pass through the redaction module (secrets, PII, paths stripped)
 - Environment versions coarsened to major.minor
+- Flows: `appId:` line replaced with `com.example.<sanitized-slug>`; only
+  the metadata header (`id`, `intent`, `tags`, `mutates`, `status`) and
+  YAML body are kept. Long author-prose comments above the body are
+  truncated to 200 chars.
+- Skeleton: same `appId` redaction; testID list preserved verbatim.
 - No raw telemetry, no project names, no file paths

--- a/commands/rn-agent-import.md
+++ b/commands/rn-agent-import.md
@@ -18,11 +18,15 @@ Provide the path to an export YAML file:
 
 ## What Happens
 
-1. **Validates** the bundle format (version, heuristics array)
+1. **Validates** the bundle format (version, heuristics array, optional flows + skeleton sections)
 2. **Checks** for duplicates against existing experience (by summary text)
 3. **Adds** new heuristics with **70% of original confidence** (imported knowledge is less trusted)
 4. **Marks** imported entries with source attribution and original date
 5. **Skips** heuristics below 20% effective confidence
+6. **Imports flows + skeleton** (default ON) into `<test-app>/.maestro/flows/`
+   and `<test-app>/.ui-skeleton.yaml`. Existing flows with the same `id:`
+   are NOT overwritten — they land at `<id>.imported.yaml` so you can diff
+   and merge manually. Pass `--no-flows` / `--no-skeleton` to skip these.
 
 ## Import Rules
 
@@ -30,3 +34,9 @@ Provide the path to an export YAML file:
 - Duplicates (same summary text) are silently skipped
 - Confidence is reduced to 70% of the exported value
 - No heuristics are auto-promoted — all stay in experience.md for review
+- Imported flows keep their metadata header but `status:` is forced to
+  `experimental` until you replay them locally and bump it to `active`.
+- The bundled `appId: com.example.<slug>` line is rewritten to your
+  project's actual `appId` (read from `app.json` / `Info.plist`) on
+  import. If the bundle's `${VAR}` placeholders reference variables
+  unknown to your test-app, the flow lands at `*.needs-review.yaml`.

--- a/commands/test-feature.md
+++ b/commands/test-feature.md
@@ -54,13 +54,16 @@ Load the `rn-testing` skill and follow this 8-step protocol in this session:
    - If step 0 found and replayed an existing flow: re-validate it still
      covers the new edge cases; if you discovered a gap, ADD steps to the
      existing flow (don't fork a new file).
-   - If step 0 found NO matching flow: WRITE one at
-     `<test-app>/.maestro/flows/<feature-slug>.yaml`, parameterised via
-     `${VAR}` placeholders for any input strings. Reference testIDs
-     symbolically — if the test-app has a `.ui-skeleton.yaml`, add the
-     mapping there too. Make the flow self-bootstrapping
-     (`launchApp: { stopApp: false }` plus a conditional `runFlow … when:
-     visible: id: tab-X` to land on the starting screen).
+   - If step 0 found NO matching flow: prefer **auto-emission** over hand-
+     authoring. Wrap the manual walk between `cdp_record_test_start` and
+     `cdp_record_test_stop`, then `cdp_record_test_save` to write
+     `<test-app>/.maestro/flows/<feature-slug>.yaml` with the metadata
+     header pre-populated (`id`, `intent`, `tags`, `mutates`, `status` —
+     see `skills/rn-testing/SKILL.md` "Reusable Action Metadata Schema").
+     Hand-edit the result to parameterise input strings via `${VAR}`
+     placeholders and add a `when: visible: id: tab-X` self-bootstrap if
+     the flow assumes a starting screen. If `<test-app>/.ui-skeleton.yaml`
+     exists, add any new testIDs the flow references there too.
    - If step 0 found a flow that doesn't cleanly extend (different feature
      overlap), still add a NEW flow. Two short flows beat one tangled flow.
 

--- a/scripts/cdp-bridge/dist/tools/test-recorder-generators.js
+++ b/scripts/cdp-bridge/dist/tools/test-recorder-generators.js
@@ -17,6 +17,23 @@ function maestroScalar(value) {
     const safe = stripNewlines(value);
     return yamlStringify(safe).replace(/\n+$/, '');
 }
+function metaPairs(opts) {
+    const out = [];
+    if (opts.id)
+        out.push(['id', stripNewlines(opts.id)]);
+    if (opts.intent)
+        out.push(['intent', stripNewlines(opts.intent)]);
+    if (opts.tags && opts.tags.length) {
+        const cleaned = opts.tags.map((t) => stripNewlines(t)).filter(Boolean);
+        if (cleaned.length)
+            out.push(['tags', `[${cleaned.join(', ')}]`]);
+    }
+    if (typeof opts.mutates === 'boolean')
+        out.push(['mutates', String(opts.mutates)]);
+    if (opts.status)
+        out.push(['status', stripNewlines(opts.status)]);
+    return out;
+}
 // B137: window (ms) after a tap in which a subsequent `navigate` event is
 // considered to be caused by the tap. 1000ms handles human-pace UI transitions
 // plus async navigator resolution without false-positives spanning unrelated
@@ -100,6 +117,9 @@ export function generateMaestro(events, opts = {}) {
         lines.push('---');
     }
     lines.push(`# ${stripNewlines(opts.testName ?? 'Recorded flow')}`);
+    for (const [k, v] of metaPairs(opts)) {
+        lines.push(`# ${k}: ${v}`);
+    }
     if (opts.startRoute) {
         lines.push(`# startRoute: ${stripNewlines(opts.startRoute)}`);
         lines.push('# NOTE: replay requires the app to be on this route before `- launchApp` finishes. If your app does not default to it, insert a navigation step here (e.g. deep link or tab tap).');
@@ -183,6 +203,9 @@ export function generateDetox(events, opts = {}) {
     const lines = [];
     const name = stripNewlines(opts.testName ?? 'Recorded flow');
     lines.push(`describe(${JSON.stringify(name)}, () => {`);
+    for (const [k, v] of metaPairs(opts)) {
+        lines.push(`  // ${k}: ${v}`);
+    }
     if (opts.startRoute) {
         lines.push(`  // startRoute: ${stripNewlines(opts.startRoute)} — ensure app is on this route before running`);
     }

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.4",
+  "version": "0.38.5",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/tools/test-recorder-generators.ts
+++ b/scripts/cdp-bridge/src/tools/test-recorder-generators.ts
@@ -28,6 +28,29 @@ export interface GenerateOpts {
   // comment after the header so replay users know the flow assumes the app is
   // already on <X>. When unset, flows assume the app's default landing route.
   startRoute?: string | null;
+  // Reusable Action Metadata (M7 / Phase 116). Emitted as `# key: value`
+  // comments so Maestro ignores them but `learned-actions.mjs` can parse them
+  // for the artifact-first inventory.
+  id?: string;
+  intent?: string;
+  tags?: string[];
+  mutates?: boolean;
+  status?: 'active' | 'deprecated' | 'experimental';
+}
+
+type MetaPair = [string, string];
+
+function metaPairs(opts: GenerateOpts): MetaPair[] {
+  const out: MetaPair[] = [];
+  if (opts.id) out.push(['id', stripNewlines(opts.id)]);
+  if (opts.intent) out.push(['intent', stripNewlines(opts.intent)]);
+  if (opts.tags && opts.tags.length) {
+    const cleaned = opts.tags.map((t) => stripNewlines(t)).filter(Boolean);
+    if (cleaned.length) out.push(['tags', `[${cleaned.join(', ')}]`]);
+  }
+  if (typeof opts.mutates === 'boolean') out.push(['mutates', String(opts.mutates)]);
+  if (opts.status) out.push(['status', stripNewlines(opts.status)]);
+  return out;
 }
 
 // B137: window (ms) after a tap in which a subsequent `navigate` event is
@@ -120,6 +143,9 @@ export function generateMaestro(events: RecordedEvent[], opts: GenerateOpts = {}
     lines.push('---');
   }
   lines.push(`# ${stripNewlines(opts.testName ?? 'Recorded flow')}`);
+  for (const [k, v] of metaPairs(opts)) {
+    lines.push(`# ${k}: ${v}`);
+  }
   if (opts.startRoute) {
     lines.push(`# startRoute: ${stripNewlines(opts.startRoute)}`);
     lines.push('# NOTE: replay requires the app to be on this route before `- launchApp` finishes. If your app does not default to it, insert a navigation step here (e.g. deep link or tab tap).');
@@ -198,6 +224,9 @@ export function generateDetox(events: RecordedEvent[], opts: GenerateOpts = {}):
   const lines: string[] = [];
   const name = stripNewlines(opts.testName ?? 'Recorded flow');
   lines.push(`describe(${JSON.stringify(name)}, () => {`);
+  for (const [k, v] of metaPairs(opts)) {
+    lines.push(`  // ${k}: ${v}`);
+  }
   if (opts.startRoute) {
     lines.push(`  // startRoute: ${stripNewlines(opts.startRoute)} — ensure app is on this route before running`);
   }

--- a/scripts/cdp-bridge/test/unit/test-recorder-generators.test.js
+++ b/scripts/cdp-bridge/test/unit/test-recorder-generators.test.js
@@ -135,3 +135,65 @@ test('M6 Detox: submit fallback is a manual-replay comment, not pressBack()', ()
   assert.doesNotMatch(out, /device\.pressBack/);
   assert.match(out, /\/\/ submit: missing testID\/label/);
 });
+
+// M7 / Phase 116: Reusable Action Metadata header emission.
+test('M7 Maestro: metadata header emits id/intent/tags/mutates/status', () => {
+  const out = generateMaestro([{ type: 'tap', testID: 'x', t: 1 }], {
+    testName: 'wizard create',
+    id: 'wizard-create-task',
+    intent: 'Create a task via the FAB',
+    tags: ['tasks', 'wizard'],
+    mutates: true,
+    status: 'active',
+  });
+  assert.match(out, /# id: wizard-create-task/);
+  assert.match(out, /# intent: Create a task via the FAB/);
+  assert.match(out, /# tags: \[tasks, wizard\]/);
+  assert.match(out, /# mutates: true/);
+  assert.match(out, /# status: active/);
+});
+
+test('M7 Maestro: omitted metadata fields are not emitted', () => {
+  const out = generateMaestro([{ type: 'tap', testID: 'x', t: 1 }], {
+    intent: 'just intent',
+  });
+  assert.match(out, /# intent: just intent/);
+  assert.doesNotMatch(out, /# id:/);
+  assert.doesNotMatch(out, /# tags:/);
+  assert.doesNotMatch(out, /# mutates:/);
+  assert.doesNotMatch(out, /# status:/);
+});
+
+test('M7 Maestro: mutates=false still emits the line', () => {
+  const out = generateMaestro([{ type: 'tap', testID: 'x', t: 1 }], { mutates: false });
+  assert.match(out, /# mutates: false/);
+});
+
+test('M7 Maestro: metadata strings are newline-stripped', () => {
+  const out = generateMaestro([{ type: 'tap', testID: 'x', t: 1 }], {
+    id: 'evil\nappId: com.bad',
+    intent: 'first\nrm -rf',
+  });
+  assert.match(out, /# id: evil appId: com\.bad/);
+  assert.match(out, /# intent: first rm -rf/);
+});
+
+test('M7 Detox: metadata header emits as // comments inside describe block', () => {
+  const out = generateDetox([{ type: 'tap', testID: 'x', t: 1 }], {
+    id: 'wizard-create-task',
+    intent: 'Create a task',
+    tags: ['tasks'],
+    mutates: true,
+    status: 'active',
+  });
+  assert.match(out, /\/\/ id: wizard-create-task/);
+  assert.match(out, /\/\/ intent: Create a task/);
+  assert.match(out, /\/\/ tags: \[tasks\]/);
+  assert.match(out, /\/\/ mutates: true/);
+  assert.match(out, /\/\/ status: active/);
+});
+
+test('M7 Maestro: empty tags array is treated as omitted', () => {
+  const out = generateMaestro([{ type: 'tap', testID: 'x', t: 1 }], { tags: [] });
+  assert.doesNotMatch(out, /# tags:/);
+});

--- a/scripts/learned-actions.mjs
+++ b/scripts/learned-actions.mjs
@@ -106,7 +106,8 @@ function scanFlows() {
       const text = fs.readFileSync(fp, 'utf8');
       const meta = parseFlowMeta(text);
       if (flags.appId && meta.appId !== flags.appId) continue;
-      if (!matchKw(meta.purpose, meta.appId, f, fp)) continue;
+      const tagsStr = (meta.tags || []).join(',');
+      if (!matchKw(meta.purpose, meta.appId, meta.intent, tagsStr, f, fp)) continue;
       const params = (text.match(/\$\{([A-Z_]+)\}/g) || []).map((s) => s.slice(2, -1));
       const uniqParams = Array.from(new Set(params));
       const replay = uniqParams.length
@@ -117,6 +118,11 @@ function scanFlows() {
         path: fp,
         appId: meta.appId,
         purpose: truncate(meta.purpose, 140),
+        id: meta.id,
+        intent: meta.intent,
+        tags: meta.tags,
+        mutates: meta.mutates,
+        status: meta.status,
         params: uniqParams,
         replay,
       });
@@ -147,23 +153,56 @@ function collectFlowRoots(start) {
 function parseFlowMeta(text) {
   // Maestro YAML has a top section before the `---` separator with appId etc.
   // Grab `appId:` and the first non-blank comment block as purpose.
+  // Reusable Action Metadata (M7): also surface `# id|intent|tags|mutates|status: ...`
+  // lines anywhere in the header so machine-readable filtering is possible
+  // without parsing the full YAML body.
   const appIdMatch = text.match(/^appId:\s*([^\s#]+)/m);
   const lines = text.split('\n');
   const purposeLines = [];
+  const meta = { id: null, intent: null, tags: null, mutates: null, status: null };
+  const META_KEYS = new Set(['id', 'intent', 'tags', 'mutates', 'status']);
   let inComment = false;
   for (const line of lines) {
     if (line.startsWith('#')) {
       inComment = true;
       const stripped = line.replace(/^#\s?/, '').trim();
-      if (stripped) purposeLines.push(stripped);
+      if (!stripped) continue;
+      const kv = stripped.match(/^([a-zA-Z][\w-]*)\s*:\s*(.+)$/);
+      if (kv && META_KEYS.has(kv[1])) {
+        const key = kv[1];
+        const raw = kv[2].trim();
+        if (key === 'tags') {
+          meta.tags = raw
+            .replace(/^\[|\]$/g, '')
+            .split(',')
+            .map((t) => t.trim())
+            .filter(Boolean);
+        } else if (key === 'mutates') {
+          meta.mutates = /^true$/i.test(raw);
+        } else {
+          meta[key] = raw;
+        }
+        continue;
+      }
+      purposeLines.push(stripped);
     } else if (inComment && line.trim() === '') {
       if (purposeLines.length) break; // first comment block
     } else if (inComment) {
       break;
     }
   }
-  const purpose = purposeLines.length ? purposeLines.join(' ') : '(no description comment)';
-  return { appId: appIdMatch ? appIdMatch[1] : null, purpose };
+  const fallbackPurpose = purposeLines.length ? purposeLines.join(' ') : '(no description comment)';
+  // Prefer explicit intent over the heuristic purpose extraction.
+  const purpose = meta.intent || fallbackPurpose;
+  return {
+    appId: appIdMatch ? appIdMatch[1] : null,
+    purpose,
+    id: meta.id,
+    intent: meta.intent,
+    tags: meta.tags,
+    mutates: meta.mutates,
+    status: meta.status,
+  };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -316,10 +355,13 @@ if (want('b')) {
       parts.push(`_Searched: ${flows.roots.map((r) => '`' + r + '`').join(', ')}_`);
     }
   } else {
-    parts.push('| Flow | Purpose | App ID | Replay |');
-    parts.push('|---|---|---|---|');
+    parts.push('| Flow | Purpose | App ID | Mutates | Status | Tags | Replay |');
+    parts.push('|---|---|---|---|---|---|---|');
     for (const f of flows.items) {
-      parts.push(`| \`${f.flow}\` | ${esc(f.purpose)} | \`${f.appId || '?'}\` | \`${f.replay}\` |`);
+      const mut = f.mutates === null || f.mutates === undefined ? '?' : (f.mutates ? 'yes' : 'no');
+      const status = f.status || '?';
+      const tags = (f.tags && f.tags.length) ? f.tags.join(', ') : '?';
+      parts.push(`| \`${f.flow}\` | ${esc(f.purpose)} | \`${f.appId || '?'}\` | ${mut} | ${status} | ${esc(tags)} | \`${f.replay}\` |`);
     }
   }
   parts.push('');

--- a/skills/rn-feature-development/SKILL.md
+++ b/skills/rn-feature-development/SKILL.md
@@ -429,6 +429,66 @@ mkdir -p docs/proof/<feature-slug>
 
 Use the feature slug from Phase 1 (e.g., `s4-notification-snooze`, `profile-edit-modal`).
 
+### Step 1.4: Rehearsal pass — discovery happens OFF camera (MANDATORY)
+
+**Rule.** The video must capture a known-good replay of the feature, NOT
+the LLM figuring out how to navigate. Recording during discovery produces
+multi-minute videos full of dead-ends, wrong screens, and "let me check the
+testID" pauses — nobody wants that in a PR. Discovery is cheap; re-recording
+is expensive.
+
+**Protocol — perform every step BEFORE pressing record:**
+
+1. **Dry-run the architect's E2E Proof Flow once with NO video.** Use
+   `device_*` / `cdp_*` calls to walk every row of the blueprint table from
+   start to end. Verify each interaction lands and each assertion holds.
+2. **Fix discovered drift.** The blueprint is the contract, but the live app
+   is reality — wrong testID, renamed route, store-path typo, late-mounted
+   component. Reconcile both. Update the blueprint table if the rehearsal
+   reveals a missing step.
+3. **Persist the verified sequence as a Maestro flow.** Once the rehearsal
+   completes clean end-to-end, write the flow to
+   `<test-app>/.maestro/flows/<feature-slug>.yaml`. Two authoring paths:
+   - `maestro_generate(name="<feature-slug>", steps=[...], appId="...")` —
+     structured-step authoring; the MCP tool writes the YAML but does NOT
+     emit the M7 metadata header.
+   - `cdp_record_test_generate(format="maestro")` — converts the recorder
+     buffer (started via `cdp_record_test_start` during rehearsal) into
+     YAML text returned in the response; the MCP tool schema does not
+     forward the M7 fields, so the header is not auto-populated.
+   In both cases, the agent MUST then read the file (or capture the
+   returned text) and PREPEND the 5-key M7 metadata header by hand
+   (`id`, `intent`, `tags`, `mutates`, `status`) — see
+   `skills/rn-testing/SKILL.md` § "Reusable Action Metadata Schema".
+4. **Smoke-test the flow.** Replay it once before recording. For flows
+   with `${VAR}` placeholders, use the Bash CLI (which supports `-e`
+   substitution):
+   ```bash
+   maestro-runner --platform <ios|android> test \
+     <test-app>/.maestro/flows/<feature-slug>.yaml \
+     -e KEY=VALUE
+   ```
+   For env-free flows, the MCP tool also works:
+   `maestro_run(flowPath="<test-app>/.maestro/flows/<feature-slug>.yaml")`.
+   The replay must pass end-to-end without a single failure.
+5. **Retry budget: max 3 fix-and-replay loops.** If the rehearsal still
+   fails after 3 attempts, escalate to the user with (a) the failing
+   step, (b) the failing assertion, and (c) snapshots from
+   `cdp_navigation_state` and `cdp_store_state`. Do NOT loop indefinitely.
+
+**Maestro-inexpressible carve-out.** If the flow genuinely cannot be
+expressed in Maestro (custom gestures, native-module side-effects,
+Reanimated proof captures via `cdp_set_shared_value`, JS-introspection
+mid-flow), the rehearsal walk itself via `device_*` / `cdp_*` becomes the
+artifact. Document the specific Maestro primitive that is missing in
+PROOF.md "Deviations" — naming the inexpressibility is mandatory; without
+it you must keep trying to express the flow.
+
+**Hard gate.** Do not proceed to Step 1.5 until either step 4 passes
+cleanly OR the inexpressibility carve-out has been written into PROOF.md.
+If you catch yourself thinking "I'll just record while I work out the
+last step," stop — that's the failure mode this gate exists to prevent.
+
 ### Step 1.5: Pre-recording setup and start video
 
 **Pre-recording readiness (GH #8, #9):**
@@ -453,35 +513,55 @@ rn-record-proof start $PLATFORM docs/proof/<feature-slug>/flow-$PLATFORM.mp4
 If recording fails to start (no simulator, permissions), log a warning and
 continue — video is a nice-to-have, not a gate. Screenshots remain primary.
 
-### Step 2: Execute the E2E Proof Flow from the blueprint
+### Step 2: Replay the rehearsed flow ON CAMERA
 
-Read the **E2E Proof Flow** table from the Phase 4 blueprint. For each row
-in the table, execute in order:
+**Preferred path: replay the Maestro flow generated in Step 1.4.** With
+recording running, invoke the rehearsed flow.
 
-1. **Perform the action** exactly as specified:
-   - Navigation: use `cdp_evaluate` with the expression from the table
-   - Interaction: use `device_find(text="<text>", action="click")`,
-     `device_press(ref="@<ref>")`, or `device_fill(ref="@<ref>", text="<input>")`
-   - Wait 1-2 seconds for state to settle (or use `device_snapshot` to confirm)
+For flows with `${VAR}` placeholders (need env substitution):
+```bash
+maestro-runner --platform <ios|android> test \
+  <test-app>/.maestro/flows/<feature-slug>.yaml \
+  -e KEY=VALUE
+```
 
-2. **Capture the screenshot** using the exact filename from the table:
-   ```
-   device_screenshot(path="docs/proof/<feature-slug>/<filename>")
-   ```
+For env-free flows, use the MCP tool:
+- `maestro_run(flowPath="<test-app>/.maestro/flows/<feature-slug>.yaml")`
 
-3. **Verify the expected state** as specified in the table:
-   - If the table specifies a store assertion: call `cdp_store_state` and
-     verify the value matches
-   - If the table specifies a navigation assertion: call `cdp_navigation_state`
-   - If the table specifies a visual assertion: verify via the screenshot
-   - Record the actual value for the PROOF.md
+(The MCP `maestro_run` tool schema accepts `flowPath`, `inlineYaml`,
+`platform`, `appId`, `timeoutMs` — there is no `-e` env-var pass-through.
+For substitution you need the `maestro-runner` CLI via Bash.)
 
-4. **If a step fails**: fix the issue and retry that step. Do NOT skip steps
-   or proceed with a failing assertion. Maximum 2 retries per step before
-   escalating to the user.
+Either path produces a deterministic, hesitation-free recording. The LLM
+is NOT in the loop during the actual replay — Maestro drives the device
+at native speed. While the flow runs, take numbered screenshots at meaningful state
+changes via `device_screenshot(path="docs/proof/<feature-slug>/<NN-stepname>.jpg")`.
 
-Execute ALL rows in the table. Do not stop early or skip "optional" steps —
-the architect included them for a reason.
+**Flow assertion failure during recording = stop and re-rehearse.** A
+failure here means the flow drifted between rehearsal and recording (timing,
+state, leftover residue from a `mutates: true` flow). Stop the recording,
+rebase to a clean app state, redo Step 1.4. Do not "fix it on camera."
+
+**Fallback: only when Maestro cannot express the flow** — custom gestures,
+native-module side-effects, Reanimated proof captures via
+`cdp_set_shared_value`, or anything that needs JS-level introspection
+mid-flow. In that case, execute the rehearsed sequence step-by-step using
+the same `device_*` / `cdp_*` calls you ran in Step 1.4. Every action must
+be one you already executed cleanly during rehearsal — do NOT debug,
+explore, or improvise on camera.
+
+For each meaningful state change (whether driven by Maestro or by the
+fallback path), capture:
+
+1. **Screenshot** with the exact filename from the blueprint table:
+   `device_screenshot(path="docs/proof/<feature-slug>/<filename>")`
+2. **State assertion** matching what the table specified:
+   - Store assertion → `cdp_store_state` value matches
+   - Navigation assertion → `cdp_navigation_state`
+   - Visual assertion → verified via the screenshot
+3. **Record the actual value** for PROOF.md — the rehearsal already proved
+   this works, so deviations here are recording-environment bugs, not
+   feature bugs.
 
 ### Step 2.5: Stop recording and convert
 
@@ -626,6 +706,7 @@ Each phase has shortcuts agents reach for. Don't.
 | "I tested iOS — Android works the same" | Wrong ~40% of the time. Keyboard, permissions, back button, text input, safe-area all differ. `cross_platform_verify` is mandatory unless explicitly single-platform. |
 | "Phase 6 found 1 issue — ship it" | Review agents already filter by confidence. If ONE flags an issue, read it fully. |
 | "Phase 8 (E2E Proof) is just for PR theater" | Proof flows become the permanent Maestro test file. Skip them and you pay in manual testing every sprint. |
+| "I'll record while I figure out the flow — saves a pass" | The video then shows you stuck on a wrong testID for 90 seconds. Rehearsal (Step 1.4) is the cheap pass; re-recording is the expensive one. Discovery happens off camera, replay happens on camera. |
 
 ## Red Flags — Stop and Reconsider
 
@@ -635,15 +716,20 @@ Each phase has shortcuts agents reach for. Don't.
 - About to skip a phase "because the feature is small"
 - About to add a dependency without asking the user first
 - Editing files outside the architect's blueprint "while I'm here"
+- About to call `rn-record-proof start` before the Step 1.4 rehearsal flow has replayed clean (via `maestro-runner` CLI or `maestro_run`)
+- About to use `device_*` exploratory calls during recording to "find the right testID"
+- About to take the `device_*` / `cdp_*` fallback path in Phase 8 Step 2 without naming the specific Maestro primitive that cannot express the step in PROOF.md "Deviations"
+- About to enter a fourth rehearsal-fix loop in Step 1.4 without escalating to the user
 
 ## Boundaries
 
 ### Always
 - Call `cdp_status` before Phase 5.5 starts
-- Run the architect's proof flow step-by-step in Phase 8
+- Replay the architect's proof flow on camera in Phase 8 — Maestro-driven (`maestro-runner` CLI for env-substituted flows or `maestro_run` MCP tool for env-free flows) when expressible, step-by-step `device_*` / `cdp_*` only when Maestro genuinely cannot capture it AND the inexpressibility is documented in PROOF.md Deviations
 - Use MCP tools (cdp_*, device_*) for app state reads
 - Present the Phase 5.5 verification table with concrete Evidence
 - Gate Phase 5 on user approval of the architecture
+- Run the Phase 8 Step 1.4 rehearsal pass and confirm `maestro_run` replays the generated flow cleanly BEFORE starting any video recording
 
 ### Ask First
 - Adding any new dependency to the user's project
@@ -661,6 +747,7 @@ Each phase has shortcuts agents reach for. Don't.
 - Add `console.log` calls and leave them in committed code
 - Proceed past Phase 4 without user approval on architecture
 - Commit with `cdp_error_log` showing new errors
+- Start `rn-record-proof start` while still discovering testIDs, navigation paths, or state shapes — recording is for verified replay, not exploration
 
 ## Verification — Feature Complete When
 

--- a/skills/rn-testing/SKILL.md
+++ b/skills/rn-testing/SKILL.md
@@ -231,6 +231,52 @@ maestro-runner --platform <ios|android> test /tmp/step.yaml
 
 ---
 
+## Reusable Action Metadata Schema (M7)
+
+Every reusable Maestro flow MUST declare a 5-field metadata header so
+`/rn-dev-agent:list-learned-actions` and `/rn-dev-agent:run-action` can
+filter, replay, and reason about it without parsing the YAML body. The
+header lives in YAML comments above (or just below) the `---` separator
+so Maestro itself ignores it.
+
+```yaml
+appId: com.example.app
+---
+# id: <stable-slug>           # Stable identifier. Defaults to the filename
+                              # without `.yaml`. Set explicitly only when you
+                              # want to rename the file later without breaking
+                              # references.
+# intent: <one-line goal>     # Human-readable goal. Surfaced verbatim by the
+                              # `list-learned-actions` inventory; replaces the
+                              # older "first comment block = purpose" heuristic.
+# tags: [a, b, c]             # Filterable keywords (lower-case kebab-case).
+                              # Conventions: feature area (tasks, auth,
+                              # profile), operation (create, update, delete),
+                              # markers (smoke, regression).
+# mutates: true|false         # `true` if the flow leaves persistent residue
+                              # (created/deleted rows, toggled settings,
+                              # anything a subsequent test would need to clean
+                              # up). Read-only flows are `false`. Consumed by
+                              # `/run-action` to require explicit confirmation
+                              # before replay.
+# status: active|deprecated|experimental
+                              # `active` = production-quality, replay anytime.
+                              # `experimental` = under construction, may break.
+                              # `deprecated` = kept for history, do NOT replay.
+- launchApp
+```
+
+**Auto-generated flows** from `cdp_record_test_generate` populate these fields
+when supplied via `GenerateOpts.id|intent|tags|mutates|status` (see
+`tools/test-recorder-generators.ts`). **Hand-written flows** must add the
+header manually before the flow is considered reusable.
+
+**Verification rule:** Before approving a new flow for the artifact-first
+inventory, confirm the header carries all 5 keys. A flow missing `mutates:` is
+parsed as `mutates: null` and `list-learned-actions` renders it as `?`.
+
+---
+
 ## testID Best Practices
 
 ```tsx


### PR DESCRIPTION
## Summary

Three independent improvements, batched on the `fix/helpers-auto-reinject` branch (whose name no longer reflects the full scope, but the commits are well-isolated). Bumps plugin to **v0.44.5** / cdp-bridge to **v0.38.5**.

### 1. CDP helpers auto-reinject (B149, D1202) — `562e2ad`
Active 1-shot helper reinject in `withConnection` plus `helpersInjected` exposed in `cdp_status.capabilities`. New doctor row 8b. Prevents `HELPERS_NOT_INJECTED` from cascading after silent helper drops.

### 2. M7 reusable-actions system — `d4fd7c7` + `a472d2f` (D1203)
Closes Priority 1 + Priority 2 of the multi-LLM brainstorm on reusable actions:
- Priority 1: artifact-first scan rule propagated across rn-tester / rn-debugger / test-feature; new `/list-learned-actions` and `/run-action` commands; `scripts/learned-actions.mjs` 4-section inventory.
- Priority 2: 5-key metadata schema (`id`, `intent`, `tags`, `mutates`, `status`) emitted by `cdp_record_test_*` generators and parsed by `learned-actions.mjs`. Schema codified in `skills/rn-testing/SKILL.md` § "Reusable Action Metadata Schema". Backfilled `wizard-create-task.yaml` + `mark-all-done.yaml` (workspace test-app). 7 new generator tests.

### 3. Phase 8 rehearsal-before-recording gate — `a556bfc` (D1204)
Discovery happens OFF camera. Recording captures replay of a verified Maestro flow, eliminating multi-minute videos full of LLM testID-hunting. New gates in `skills/rn-feature-development/SKILL.md` Step 1.4 and `commands/proof-capture.md` Step 2.5: rehearsal pass → persist as `.maestro/flows/<slug>.yaml` with M7 metadata → smoke-test via `maestro-runner` CLI or `maestro_run` MCP → max 3 retry budget → record only after gate passes. Maestro-inexpressibility carve-out requires naming the missing primitive in PROOF.md "Deviations".

Multi-provider review (`/multi-review`) caught and fixed 2 critical toolchain bugs in the original draft (`cdp_record_test_save` was misnamed; `maestro_run` had unsupported `-e` syntax) and exposed an MCP-schema gap logged as D1204 follow-up.

## Test plan

- [ ] `cd scripts/cdp-bridge && npm run build` clean (TS compiles)
- [ ] `node --test test/unit/test-recorder-*.test.js` → 100/100 pass
- [ ] `node scripts/learned-actions.mjs --section b --workspace-root ../rn-dev-agent-workspace` → both backfilled flows render with Mutates/Status/Tags columns populated
- [ ] `node scripts/learned-actions.mjs --section b --filter bulk` → matches `mark-all-done` via tag-only (word never appears in body)
- [ ] Manual smoke: `/rn-dev-agent:list-learned-actions` from inside a project surfaces flows + memories + skeletons + commands
- [ ] Manual smoke: `cdp_status` after a reload returns `capabilities.helpersInjected: true` without a manual reinject call

## Decision refs

- D1202 — helpers auto-reinject (workspace `docs/DECISIONS.md`)
- D1203 — Reusable Action Metadata Schema (workspace `docs/DECISIONS.md`)
- D1204 — Phase 8 rehearsal-gate + M7 MCP-schema gap follow-up (workspace `docs/DECISIONS.md`)