### PR TITLE
fix(action-store): atomic YAML+sidecar pair-write + handler integration tests — v0.44.15

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.14",
+      "version": "0.44.15",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.15",
+      "version": "0.44.16",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.15",
+  "version": "0.44.16",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.14",
+  "version": "0.44.15",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/scripts/cdp-bridge/dist/agent-device-wrapper.js
+++ b/scripts/cdp-bridge/dist/agent-device-wrapper.js
@@ -434,7 +434,14 @@ function cacheRefMapFromResult(result) {
     }
     catch { /* not a snapshot response — ignore */ }
 }
+let _runAgentDeviceOverrideForTest = null;
+export function _setRunAgentDeviceForTest(fn) {
+    _runAgentDeviceOverrideForTest = fn;
+}
 export async function runAgentDevice(cliArgs, opts = {}) {
+    if (_runAgentDeviceOverrideForTest) {
+        return _runAgentDeviceOverrideForTest(cliArgs, opts);
+    }
     // GH #60: when an explicit platform is requested AND it doesn't match the
     // active session's platform (e.g. user asks for android while an iOS
     // session is active from prior work), skip the session-bound dispatch

--- a/scripts/cdp-bridge/dist/domain/action-store.js
+++ b/scripts/cdp-bridge/dist/domain/action-store.js
@@ -5,10 +5,11 @@
 // composite. Underpins /run-action, self-repair, and auto-emission —
 // they all read/write through this single chokepoint so schema
 // invariants stay enforced.
-import { existsSync, readFileSync, writeFileSync, statSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { parseM7Header, serializeM7Header, } from './reusable-action.js';
-import { loadOrInitSidecar, saveSidecar, yamlEditedSinceLastSeen, } from './sidecar-io.js';
+import { loadOrInitSidecar, sidecarPathFor, yamlEditedSinceLastSeen, } from './sidecar-io.js';
+import { atomicWriter } from './atomic-writer.js';
 /**
  * Resolve the canonical YAML path for an action id under a project root.
  * Mirrors the .rn-agent/actions/ convention (D1207).
@@ -146,13 +147,15 @@ export function saveAction(action) {
     const headerLines = serializeM7Header(action.metadata).split('\n');
     const bodyLines = action.body.split('\n');
     const yamlText = joinYaml({ topSection, headerLines, bodyLines });
-    writeFileSync(action.filePath, yamlText, 'utf8');
-    // After write, mtime changes — refresh state.lastSeenMtimeMs so the
-    // next yamlEditedSinceLastSeen() call doesn't think a human edited it.
-    const newMtimeMs = statSync(action.filePath).mtimeMs;
-    const stateToWrite = { ...action.state, lastSeenMtimeMs: newMtimeMs };
-    const { path: sidecarPath } = saveSidecar(action.filePath, stateToWrite);
-    // Also reflect in-memory.
+    // Issue #101: sidecar-first atomic pair-write. The atomicWriter owns
+    // `lastSeenMtimeMs` correctness — even on partial failure, the
+    // persisted sidecar will have lastSeenMtimeMs ≥ the YAML's actual
+    // mtime, so the next yamlEditedSinceLastSeen() check returns false
+    // (no false-positive alarm).
+    const sidecarPath = sidecarPathFor(action.filePath);
+    const result = atomicWriter.pairWrite(action.filePath, yamlText, sidecarPath, action.state);
+    const stateToWrite = { ...action.state, lastSeenMtimeMs: result.finalMtimeMs };
+    // Reflect in-memory so subsequent calls share the just-written mtime.
     action.state = stateToWrite;
     return { filePath: action.filePath, sidecarPath };
 }

--- a/scripts/cdp-bridge/dist/domain/atomic-writer.js
+++ b/scripts/cdp-bridge/dist/domain/atomic-writer.js
@@ -36,6 +36,17 @@
 // `mock.method(atomicWriter, '_writeFile', ...)` to inject failures.
 import { writeFileSync, renameSync, statSync, mkdirSync, existsSync, unlinkSync, } from 'node:fs';
 import { dirname } from 'node:path';
+// Multi-LLM review of PR #109 findings 1+2: `finalMtimeMs = _stat(yaml)`
+// breaks the safety invariant in two scenarios — (a) slow writes where
+// the actual YAML mtime exceeds `projectedMtimeMs` and step 5 happens
+// to swallow a follow-on error, leaving the persisted sidecar at the
+// stale projected value; (b) clock-skew on networked filesystems where
+// the server-side mtime is *behind* `projectedMtimeMs`, regressing
+// `lastSeenMtimeMs` and hiding real human edits within the skew window.
+// Both are fixed by (i) using `Math.max(actual, projected)` so the
+// recorded value never goes backwards, and (ii) dropping the step-5
+// try/catch — the action isn't safely written without it, so a caller
+// that retries on failure produces the correct behaviour.
 /**
  * Number of milliseconds the projected `lastSeenMtimeMs` is set ahead of
  * `Date.now()` during the sidecar-first phase. Must be:
@@ -78,42 +89,53 @@ function pairWriteImpl(yamlPath, yamlContent, sidecarPath, state) {
     // Step 3+4: YAML, atomic rename.
     atomicWriter._writeFile(yamlTmp, yamlContent);
     atomicWriter._rename(yamlTmp, yamlPath);
-    // Step 5 (optional): resync sidecar to actual mtime. Wrapped in a
-    // try so that an error here doesn't poison the result — partial
-    // failure leaves sidecar with the projected future mtime, which is
-    // already safe per the crash analysis above.
-    let refreshedSidecar = false;
-    let finalMtimeMs = projectedMtimeMs;
-    try {
-        finalMtimeMs = atomicWriter._statMtimeMs(yamlPath);
-        const finalState = {
-            ...state,
-            lastSeenMtimeMs: finalMtimeMs,
-        };
-        atomicWriter._writeFile(sidecarTmp, JSON.stringify(finalState, null, 2) + '\n');
-        atomicWriter._rename(sidecarTmp, sidecarPath);
-        refreshedSidecar = true;
-    }
-    catch {
-        // Step 5 failed but the sidecar still holds projectedMtimeMs which
-        // is ≥ any real YAML mtime — no false-positive alarm possible.
-    }
-    return { yamlPath, sidecarPath, finalMtimeMs, refreshedSidecar };
+    // Step 5 (mandatory after PR #109 review): resync sidecar to the
+    // ACTUAL YAML mtime, but never let the recorded value regress below
+    // `projectedMtimeMs`. This handles two failure modes the original
+    // try/catch silently allowed:
+    //
+    //   - Slow writes (CI fsync queue saturation, antivirus stalls):
+    //     actual_yaml_mtime > projectedMtimeMs. Math.max picks actual,
+    //     so the sidecar ends up with a value ≥ what's on disk.
+    //
+    //   - Clock skew on NFS / Docker bind mounts: actual_yaml_mtime <
+    //     projectedMtimeMs. Math.max keeps projectedMtimeMs, so the
+    //     recorded value doesn't regress and a future legitimate edit
+    //     within the skew window still produces mtime > recorded.
+    //
+    // Errors are NOT swallowed — if step 5 fails, the operation is not
+    // safely complete. Caller should retry; the on-disk sidecar already
+    // holds `projectedMtimeMs` (from step 1+2), so a retry won't see a
+    // false-positive alarm.
+    const actualMtimeMs = atomicWriter._statMtimeMs(yamlPath);
+    const finalMtimeMs = Math.max(actualMtimeMs, projectedMtimeMs);
+    const finalState = {
+        ...state,
+        lastSeenMtimeMs: finalMtimeMs,
+    };
+    atomicWriter._writeFile(sidecarTmp, JSON.stringify(finalState, null, 2) + '\n');
+    atomicWriter._rename(sidecarTmp, sidecarPath);
+    return { yamlPath, sidecarPath, finalMtimeMs, refreshedSidecar: true };
 }
 function ensureDir(filePath) {
     const dir = dirname(filePath);
-    if (!existsSync(dir))
-        mkdirSync(dir, { recursive: true });
+    if (!atomicWriter._exists(dir))
+        atomicWriter._mkdir(dir);
 }
 /**
  * Best-effort cleanup of orphaned `.tmp` files left by a crashed previous
  * call. Called by `pairWrite` before each operation. Idempotent.
+ *
+ * Routes through `atomicWriter._unlink` / `_exists` so PR #109 review
+ * finding (E) — "tests can't simulate mkdir/unlink failures" — is
+ * resolved: the seam is now complete across all fs operations the
+ * writer performs.
  */
 function cleanupOrphans(yamlPath, sidecarPath) {
     for (const orphan of [`${yamlPath}.tmp`, `${sidecarPath}.tmp`]) {
-        if (existsSync(orphan)) {
+        if (atomicWriter._exists(orphan)) {
             try {
-                unlinkSync(orphan);
+                atomicWriter._unlink(orphan);
             }
             catch { /* ignore */ }
         }
@@ -135,6 +157,20 @@ export const atomicWriter = {
     /** Underlying `fs.statSync(path).mtimeMs`. */
     _statMtimeMs(path) {
         return statSync(path).mtimeMs;
+    },
+    /** Underlying `fs.existsSync(path)`. Routed through the seam so test
+     *  cases for ensureDir / cleanupOrphans can simulate exotic failures
+     *  (PR #109 review). */
+    _exists(path) {
+        return existsSync(path);
+    },
+    /** Underlying `fs.mkdirSync(path, { recursive: true })`. */
+    _mkdir(path) {
+        mkdirSync(path, { recursive: true });
+    },
+    /** Underlying `fs.unlinkSync(path)`. Used by orphan-cleanup. */
+    _unlink(path) {
+        unlinkSync(path);
     },
     /**
      * Atomic pair-write. Cleans up any orphaned `.tmp` files before

--- a/scripts/cdp-bridge/dist/domain/atomic-writer.js
+++ b/scripts/cdp-bridge/dist/domain/atomic-writer.js
@@ -1,0 +1,148 @@
+// Issue #101 fix — atomic YAML+sidecar writes for ReusableAction.
+//
+// The naive ordering "write YAML, then update sidecar with the new
+// mtime" has a silent failure mode: if the YAML write succeeds and the
+// sidecar write fails (disk full, permission denied, ENOSPC, …), the
+// on-disk YAML mtime advances but the sidecar still records the OLD
+// mtime as `lastSeenMtimeMs`. Next call to `yamlEditedSinceLastSeen`
+// reports a human edit that didn't happen, and self-repair refuses to
+// operate.
+//
+// This module fixes that with **sidecar-first ordering plus a future
+// mtime buffer**:
+//
+//   1. Write sidecar.tmp with `lastSeenMtimeMs = Date.now() + 1_000`
+//      (one second in the future — bigger than any plausible YAML write
+//      duration, smaller than any plausible human edit interval).
+//   2. Atomic-rename sidecar.tmp → sidecar.
+//   3. Write yaml.tmp with the new content.
+//   4. Atomic-rename yaml.tmp → yaml.
+//   5. (Optimistic) re-stat the YAML, write sidecar.tmp with the actual
+//      mtime, atomic-rename. Brings `lastSeenMtimeMs` back to the precise
+//      value but is not load-bearing for safety.
+//
+// Crash analysis:
+//
+//   - Crash before step 2 → no on-disk change. Safe.
+//   - Crash between 2 and 4 → sidecar has future mtime, YAML still old.
+//     `yamlEditedSinceLastSeen` returns false (current_mtime <
+//     lastSeenMtimeMs). No false-positive alarm. Safe.
+//   - Crash between 4 and 5 → YAML new, sidecar has future mtime ≥
+//     YAML's actual mtime. `yamlEditedSinceLastSeen` returns false. Safe.
+//   - Crash during 5 → as previous case (sidecar's lastSeenMtimeMs is
+//     slightly imprecise but still ≥ actual YAML mtime). Safe.
+//
+// Test seam: the public API is on a single exported object so tests can
+// `mock.method(atomicWriter, '_writeFile', ...)` to inject failures.
+import { writeFileSync, renameSync, statSync, mkdirSync, existsSync, unlinkSync, } from 'node:fs';
+import { dirname } from 'node:path';
+/**
+ * Number of milliseconds the projected `lastSeenMtimeMs` is set ahead of
+ * `Date.now()` during the sidecar-first phase. Must be:
+ * - LARGER than any plausible YAML write duration (~10 ms typical).
+ * - SMALLER than any plausible human-edit interval (multiple seconds).
+ *
+ * 1 second satisfies both with a safe margin.
+ */
+export const FUTURE_MTIME_BUFFER_MS = 1_000;
+/**
+ * Atomic write of a (YAML, sidecar) pair using sidecar-first ordering.
+ * Returns the resolved paths plus the final on-disk mtime. Throws if any
+ * intermediate step fails — caller decides whether to surface the error
+ * or recover.
+ *
+ * Side effects: creates parent directories for both paths, writes/renames
+ * the two files, may leave behind `.tmp` files on hard crash (next call
+ * overwrites them — they're not load-bearing).
+ *
+ * @param yamlPath  Absolute path of the target YAML file.
+ * @param yamlContent  Final YAML text to persist.
+ * @param sidecarPath  Absolute path of the target sidecar JSON file.
+ * @param state  ActionRuntimeState to persist; `lastSeenMtimeMs` is
+ *               overridden by the writer (caller's value is ignored —
+ *               the writer owns this field's timing-correctness).
+ */
+function pairWriteImpl(yamlPath, yamlContent, sidecarPath, state) {
+    ensureDir(yamlPath);
+    ensureDir(sidecarPath);
+    const yamlTmp = `${yamlPath}.tmp`;
+    const sidecarTmp = `${sidecarPath}.tmp`;
+    // Step 1+2: sidecar with projected future mtime, atomic rename.
+    const projectedMtimeMs = Date.now() + FUTURE_MTIME_BUFFER_MS;
+    const projectedState = {
+        ...state,
+        lastSeenMtimeMs: projectedMtimeMs,
+    };
+    atomicWriter._writeFile(sidecarTmp, JSON.stringify(projectedState, null, 2) + '\n');
+    atomicWriter._rename(sidecarTmp, sidecarPath);
+    // Step 3+4: YAML, atomic rename.
+    atomicWriter._writeFile(yamlTmp, yamlContent);
+    atomicWriter._rename(yamlTmp, yamlPath);
+    // Step 5 (optional): resync sidecar to actual mtime. Wrapped in a
+    // try so that an error here doesn't poison the result — partial
+    // failure leaves sidecar with the projected future mtime, which is
+    // already safe per the crash analysis above.
+    let refreshedSidecar = false;
+    let finalMtimeMs = projectedMtimeMs;
+    try {
+        finalMtimeMs = atomicWriter._statMtimeMs(yamlPath);
+        const finalState = {
+            ...state,
+            lastSeenMtimeMs: finalMtimeMs,
+        };
+        atomicWriter._writeFile(sidecarTmp, JSON.stringify(finalState, null, 2) + '\n');
+        atomicWriter._rename(sidecarTmp, sidecarPath);
+        refreshedSidecar = true;
+    }
+    catch {
+        // Step 5 failed but the sidecar still holds projectedMtimeMs which
+        // is ≥ any real YAML mtime — no false-positive alarm possible.
+    }
+    return { yamlPath, sidecarPath, finalMtimeMs, refreshedSidecar };
+}
+function ensureDir(filePath) {
+    const dir = dirname(filePath);
+    if (!existsSync(dir))
+        mkdirSync(dir, { recursive: true });
+}
+/**
+ * Best-effort cleanup of orphaned `.tmp` files left by a crashed previous
+ * call. Called by `pairWrite` before each operation. Idempotent.
+ */
+function cleanupOrphans(yamlPath, sidecarPath) {
+    for (const orphan of [`${yamlPath}.tmp`, `${sidecarPath}.tmp`]) {
+        if (existsSync(orphan)) {
+            try {
+                unlinkSync(orphan);
+            }
+            catch { /* ignore */ }
+        }
+    }
+}
+/**
+ * Public API. Tests can mock the underscore-prefixed methods to inject
+ * filesystem failures for atomicity assertions.
+ */
+export const atomicWriter = {
+    /** Underlying `fs.writeFileSync(path, content, 'utf8')`. */
+    _writeFile(path, content) {
+        writeFileSync(path, content, 'utf8');
+    },
+    /** Underlying `fs.renameSync(from, to)`. */
+    _rename(from, to) {
+        renameSync(from, to);
+    },
+    /** Underlying `fs.statSync(path).mtimeMs`. */
+    _statMtimeMs(path) {
+        return statSync(path).mtimeMs;
+    },
+    /**
+     * Atomic pair-write. Cleans up any orphaned `.tmp` files before
+     * starting. Throws on the first failed step — caller decides whether
+     * to surface or recover.
+     */
+    pairWrite(yamlPath, yamlContent, sidecarPath, state) {
+        cleanupOrphans(yamlPath, sidecarPath);
+        return pairWriteImpl(yamlPath, yamlContent, sidecarPath, state);
+    },
+};

--- a/scripts/cdp-bridge/dist/tools/save-as-action.js
+++ b/scripts/cdp-bridge/dist/tools/save-as-action.js
@@ -12,14 +12,14 @@
 // Those come from the agent's understanding of the user's goal, not the
 // recorder. Keeping emission explicit means the agent has to make the
 // classification decision (which is the right place for it).
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { dirname } from 'node:path';
+import { existsSync } from 'node:fs';
 import { okResult, failResult } from '../utils.js';
 import { getStoredEvents, getRecordingStartRoute } from './test-recorder.js';
 import { generateMaestro } from './test-recorder-generators.js';
 import { freshRuntimeState, } from '../domain/reusable-action.js';
 import { actionPathFor } from '../domain/action-store.js';
-import { saveSidecar } from '../domain/sidecar-io.js';
+import { sidecarPathFor } from '../domain/sidecar-io.js';
+import { atomicWriter } from '../domain/atomic-writer.js';
 export function createSaveAsActionHandler() {
     return async (args) => {
         if (!args.id || typeof args.id !== 'string') {
@@ -66,18 +66,14 @@ export function createSaveAsActionHandler() {
             mutates: args.mutates,
             status,
         });
-        // Write the YAML file (mkdirp the actions/ dir).
-        const actionsDir = dirname(filePath);
-        if (!existsSync(actionsDir))
-            mkdirSync(actionsDir, { recursive: true });
-        writeFileSync(filePath, yamlText, 'utf8');
-        // Initialise the sidecar — fresh state with mtime seeded from the
-        // file we just wrote, so future yamlEditedSinceLastSeen() checks
-        // don't false-alarm on the agent's own write.
-        const fs = await import('node:fs');
-        const mtimeMs = fs.statSync(filePath).mtimeMs;
-        const state = freshRuntimeState(() => new Date(), mtimeMs);
-        const { path: sidecarPath } = saveSidecar(filePath, state);
+        // Issue #101: sidecar-first atomic pair-write. The atomicWriter
+        // owns `lastSeenMtimeMs` correctness (overrides whatever we seed in
+        // `freshRuntimeState`) so even partial-write failures can't leave
+        // the next yamlEditedSinceLastSeen() check returning a false-
+        // positive "human edited" alarm.
+        const sidecarPath = sidecarPathFor(filePath);
+        const initialState = freshRuntimeState(() => new Date(), 0);
+        atomicWriter.pairWrite(filePath, yamlText, sidecarPath, initialState);
         return okResult({
             // Phase 130 (post-review): use captured pre-existence, not the
             // post-write existsSync (always true) and not args.overwrite

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.14",
+  "version": "0.38.15",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.15",
+  "version": "0.38.16",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/agent-device-wrapper.ts
+++ b/scripts/cdp-bridge/src/agent-device-wrapper.ts
@@ -465,10 +465,27 @@ function cacheRefMapFromResult(result: ToolResult): void {
   } catch { /* not a snapshot response — ignore */ }
 }
 
+// Issue #103 — test-only override hook. Tests that exercise handlers
+// orchestrating agent-device snapshots (e.g. cdp_repair_action) can
+// inject a fake CLI response without booting a device. Production code
+// path is untouched when the override is null.
+type RunAgentDeviceFn = (
+  cliArgs: string[],
+  opts?: { skipSession?: boolean; platform?: 'ios' | 'android' | null },
+) => Promise<ToolResult>;
+let _runAgentDeviceOverrideForTest: RunAgentDeviceFn | null = null;
+
+export function _setRunAgentDeviceForTest(fn: RunAgentDeviceFn | null): void {
+  _runAgentDeviceOverrideForTest = fn;
+}
+
 export async function runAgentDevice(
   cliArgs: string[],
   opts: { skipSession?: boolean; platform?: 'ios' | 'android' | null } = {},
 ): Promise<ToolResult> {
+  if (_runAgentDeviceOverrideForTest) {
+    return _runAgentDeviceOverrideForTest(cliArgs, opts);
+  }
   // GH #60: when an explicit platform is requested AND it doesn't match the
   // active session's platform (e.g. user asks for android while an iOS
   // session is active from prior work), skip the session-bound dispatch

--- a/scripts/cdp-bridge/src/domain/action-store.ts
+++ b/scripts/cdp-bridge/src/domain/action-store.ts
@@ -6,7 +6,7 @@
 // they all read/write through this single chokepoint so schema
 // invariants stay enforced.
 
-import { existsSync, readFileSync, writeFileSync, statSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   type ReusableAction,
@@ -16,9 +16,10 @@ import {
 } from './reusable-action.js';
 import {
   loadOrInitSidecar,
-  saveSidecar,
+  sidecarPathFor,
   yamlEditedSinceLastSeen,
 } from './sidecar-io.js';
+import { atomicWriter } from './atomic-writer.js';
 
 /**
  * Resolve the canonical YAML path for an action id under a project root.
@@ -162,14 +163,16 @@ export function saveAction(action: ReusableAction): { filePath: string; sidecarP
   const headerLines = serializeM7Header(action.metadata).split('\n');
   const bodyLines = action.body.split('\n');
   const yamlText = joinYaml({ topSection, headerLines, bodyLines });
-  writeFileSync(action.filePath, yamlText, 'utf8');
 
-  // After write, mtime changes — refresh state.lastSeenMtimeMs so the
-  // next yamlEditedSinceLastSeen() call doesn't think a human edited it.
-  const newMtimeMs = statSync(action.filePath).mtimeMs;
-  const stateToWrite = { ...action.state, lastSeenMtimeMs: newMtimeMs };
-  const { path: sidecarPath } = saveSidecar(action.filePath, stateToWrite);
-  // Also reflect in-memory.
+  // Issue #101: sidecar-first atomic pair-write. The atomicWriter owns
+  // `lastSeenMtimeMs` correctness — even on partial failure, the
+  // persisted sidecar will have lastSeenMtimeMs ≥ the YAML's actual
+  // mtime, so the next yamlEditedSinceLastSeen() check returns false
+  // (no false-positive alarm).
+  const sidecarPath = sidecarPathFor(action.filePath);
+  const result = atomicWriter.pairWrite(action.filePath, yamlText, sidecarPath, action.state);
+  const stateToWrite = { ...action.state, lastSeenMtimeMs: result.finalMtimeMs };
+  // Reflect in-memory so subsequent calls share the just-written mtime.
   action.state = stateToWrite;
   return { filePath: action.filePath, sidecarPath };
 }

--- a/scripts/cdp-bridge/src/domain/atomic-writer.ts
+++ b/scripts/cdp-bridge/src/domain/atomic-writer.ts
@@ -1,0 +1,182 @@
+// Issue #101 fix — atomic YAML+sidecar writes for ReusableAction.
+//
+// The naive ordering "write YAML, then update sidecar with the new
+// mtime" has a silent failure mode: if the YAML write succeeds and the
+// sidecar write fails (disk full, permission denied, ENOSPC, …), the
+// on-disk YAML mtime advances but the sidecar still records the OLD
+// mtime as `lastSeenMtimeMs`. Next call to `yamlEditedSinceLastSeen`
+// reports a human edit that didn't happen, and self-repair refuses to
+// operate.
+//
+// This module fixes that with **sidecar-first ordering plus a future
+// mtime buffer**:
+//
+//   1. Write sidecar.tmp with `lastSeenMtimeMs = Date.now() + 1_000`
+//      (one second in the future — bigger than any plausible YAML write
+//      duration, smaller than any plausible human edit interval).
+//   2. Atomic-rename sidecar.tmp → sidecar.
+//   3. Write yaml.tmp with the new content.
+//   4. Atomic-rename yaml.tmp → yaml.
+//   5. (Optimistic) re-stat the YAML, write sidecar.tmp with the actual
+//      mtime, atomic-rename. Brings `lastSeenMtimeMs` back to the precise
+//      value but is not load-bearing for safety.
+//
+// Crash analysis:
+//
+//   - Crash before step 2 → no on-disk change. Safe.
+//   - Crash between 2 and 4 → sidecar has future mtime, YAML still old.
+//     `yamlEditedSinceLastSeen` returns false (current_mtime <
+//     lastSeenMtimeMs). No false-positive alarm. Safe.
+//   - Crash between 4 and 5 → YAML new, sidecar has future mtime ≥
+//     YAML's actual mtime. `yamlEditedSinceLastSeen` returns false. Safe.
+//   - Crash during 5 → as previous case (sidecar's lastSeenMtimeMs is
+//     slightly imprecise but still ≥ actual YAML mtime). Safe.
+//
+// Test seam: the public API is on a single exported object so tests can
+// `mock.method(atomicWriter, '_writeFile', ...)` to inject failures.
+
+import {
+  writeFileSync,
+  renameSync,
+  statSync,
+  mkdirSync,
+  existsSync,
+  unlinkSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+import type { ActionRuntimeState } from './reusable-action.js';
+
+/**
+ * Number of milliseconds the projected `lastSeenMtimeMs` is set ahead of
+ * `Date.now()` during the sidecar-first phase. Must be:
+ * - LARGER than any plausible YAML write duration (~10 ms typical).
+ * - SMALLER than any plausible human-edit interval (multiple seconds).
+ *
+ * 1 second satisfies both with a safe margin.
+ */
+export const FUTURE_MTIME_BUFFER_MS = 1_000;
+
+export interface PairWriteResult {
+  yamlPath: string;
+  sidecarPath: string;
+  /** Actual YAML mtime after both writes succeed. */
+  finalMtimeMs: number;
+  /** True iff the optimistic step-5 sidecar refresh ran. */
+  refreshedSidecar: boolean;
+}
+
+/**
+ * Atomic write of a (YAML, sidecar) pair using sidecar-first ordering.
+ * Returns the resolved paths plus the final on-disk mtime. Throws if any
+ * intermediate step fails — caller decides whether to surface the error
+ * or recover.
+ *
+ * Side effects: creates parent directories for both paths, writes/renames
+ * the two files, may leave behind `.tmp` files on hard crash (next call
+ * overwrites them — they're not load-bearing).
+ *
+ * @param yamlPath  Absolute path of the target YAML file.
+ * @param yamlContent  Final YAML text to persist.
+ * @param sidecarPath  Absolute path of the target sidecar JSON file.
+ * @param state  ActionRuntimeState to persist; `lastSeenMtimeMs` is
+ *               overridden by the writer (caller's value is ignored —
+ *               the writer owns this field's timing-correctness).
+ */
+function pairWriteImpl(
+  yamlPath: string,
+  yamlContent: string,
+  sidecarPath: string,
+  state: ActionRuntimeState,
+): PairWriteResult {
+  ensureDir(yamlPath);
+  ensureDir(sidecarPath);
+
+  const yamlTmp = `${yamlPath}.tmp`;
+  const sidecarTmp = `${sidecarPath}.tmp`;
+
+  // Step 1+2: sidecar with projected future mtime, atomic rename.
+  const projectedMtimeMs = Date.now() + FUTURE_MTIME_BUFFER_MS;
+  const projectedState: ActionRuntimeState = {
+    ...state,
+    lastSeenMtimeMs: projectedMtimeMs,
+  };
+  atomicWriter._writeFile(sidecarTmp, JSON.stringify(projectedState, null, 2) + '\n');
+  atomicWriter._rename(sidecarTmp, sidecarPath);
+
+  // Step 3+4: YAML, atomic rename.
+  atomicWriter._writeFile(yamlTmp, yamlContent);
+  atomicWriter._rename(yamlTmp, yamlPath);
+
+  // Step 5 (optional): resync sidecar to actual mtime. Wrapped in a
+  // try so that an error here doesn't poison the result — partial
+  // failure leaves sidecar with the projected future mtime, which is
+  // already safe per the crash analysis above.
+  let refreshedSidecar = false;
+  let finalMtimeMs = projectedMtimeMs;
+  try {
+    finalMtimeMs = atomicWriter._statMtimeMs(yamlPath);
+    const finalState: ActionRuntimeState = {
+      ...state,
+      lastSeenMtimeMs: finalMtimeMs,
+    };
+    atomicWriter._writeFile(sidecarTmp, JSON.stringify(finalState, null, 2) + '\n');
+    atomicWriter._rename(sidecarTmp, sidecarPath);
+    refreshedSidecar = true;
+  } catch {
+    // Step 5 failed but the sidecar still holds projectedMtimeMs which
+    // is ≥ any real YAML mtime — no false-positive alarm possible.
+  }
+
+  return { yamlPath, sidecarPath, finalMtimeMs, refreshedSidecar };
+}
+
+function ensureDir(filePath: string): void {
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+/**
+ * Best-effort cleanup of orphaned `.tmp` files left by a crashed previous
+ * call. Called by `pairWrite` before each operation. Idempotent.
+ */
+function cleanupOrphans(yamlPath: string, sidecarPath: string): void {
+  for (const orphan of [`${yamlPath}.tmp`, `${sidecarPath}.tmp`]) {
+    if (existsSync(orphan)) {
+      try { unlinkSync(orphan); } catch { /* ignore */ }
+    }
+  }
+}
+
+/**
+ * Public API. Tests can mock the underscore-prefixed methods to inject
+ * filesystem failures for atomicity assertions.
+ */
+export const atomicWriter = {
+  /** Underlying `fs.writeFileSync(path, content, 'utf8')`. */
+  _writeFile(path: string, content: string): void {
+    writeFileSync(path, content, 'utf8');
+  },
+  /** Underlying `fs.renameSync(from, to)`. */
+  _rename(from: string, to: string): void {
+    renameSync(from, to);
+  },
+  /** Underlying `fs.statSync(path).mtimeMs`. */
+  _statMtimeMs(path: string): number {
+    return statSync(path).mtimeMs;
+  },
+
+  /**
+   * Atomic pair-write. Cleans up any orphaned `.tmp` files before
+   * starting. Throws on the first failed step — caller decides whether
+   * to surface or recover.
+   */
+  pairWrite(
+    yamlPath: string,
+    yamlContent: string,
+    sidecarPath: string,
+    state: ActionRuntimeState,
+  ): PairWriteResult {
+    cleanupOrphans(yamlPath, sidecarPath);
+    return pairWriteImpl(yamlPath, yamlContent, sidecarPath, state);
+  },
+};

--- a/scripts/cdp-bridge/src/domain/atomic-writer.ts
+++ b/scripts/cdp-bridge/src/domain/atomic-writer.ts
@@ -46,6 +46,18 @@ import {
 import { dirname } from 'node:path';
 import type { ActionRuntimeState } from './reusable-action.js';
 
+// Multi-LLM review of PR #109 findings 1+2: `finalMtimeMs = _stat(yaml)`
+// breaks the safety invariant in two scenarios — (a) slow writes where
+// the actual YAML mtime exceeds `projectedMtimeMs` and step 5 happens
+// to swallow a follow-on error, leaving the persisted sidecar at the
+// stale projected value; (b) clock-skew on networked filesystems where
+// the server-side mtime is *behind* `projectedMtimeMs`, regressing
+// `lastSeenMtimeMs` and hiding real human edits within the skew window.
+// Both are fixed by (i) using `Math.max(actual, projected)` so the
+// recorded value never goes backwards, and (ii) dropping the step-5
+// try/catch — the action isn't safely written without it, so a caller
+// that retries on failure produces the correct behaviour.
+
 /**
  * Number of milliseconds the projected `lastSeenMtimeMs` is set ahead of
  * `Date.now()` during the sidecar-first phase. Must be:
@@ -107,42 +119,54 @@ function pairWriteImpl(
   atomicWriter._writeFile(yamlTmp, yamlContent);
   atomicWriter._rename(yamlTmp, yamlPath);
 
-  // Step 5 (optional): resync sidecar to actual mtime. Wrapped in a
-  // try so that an error here doesn't poison the result — partial
-  // failure leaves sidecar with the projected future mtime, which is
-  // already safe per the crash analysis above.
-  let refreshedSidecar = false;
-  let finalMtimeMs = projectedMtimeMs;
-  try {
-    finalMtimeMs = atomicWriter._statMtimeMs(yamlPath);
-    const finalState: ActionRuntimeState = {
-      ...state,
-      lastSeenMtimeMs: finalMtimeMs,
-    };
-    atomicWriter._writeFile(sidecarTmp, JSON.stringify(finalState, null, 2) + '\n');
-    atomicWriter._rename(sidecarTmp, sidecarPath);
-    refreshedSidecar = true;
-  } catch {
-    // Step 5 failed but the sidecar still holds projectedMtimeMs which
-    // is ≥ any real YAML mtime — no false-positive alarm possible.
-  }
+  // Step 5 (mandatory after PR #109 review): resync sidecar to the
+  // ACTUAL YAML mtime, but never let the recorded value regress below
+  // `projectedMtimeMs`. This handles two failure modes the original
+  // try/catch silently allowed:
+  //
+  //   - Slow writes (CI fsync queue saturation, antivirus stalls):
+  //     actual_yaml_mtime > projectedMtimeMs. Math.max picks actual,
+  //     so the sidecar ends up with a value ≥ what's on disk.
+  //
+  //   - Clock skew on NFS / Docker bind mounts: actual_yaml_mtime <
+  //     projectedMtimeMs. Math.max keeps projectedMtimeMs, so the
+  //     recorded value doesn't regress and a future legitimate edit
+  //     within the skew window still produces mtime > recorded.
+  //
+  // Errors are NOT swallowed — if step 5 fails, the operation is not
+  // safely complete. Caller should retry; the on-disk sidecar already
+  // holds `projectedMtimeMs` (from step 1+2), so a retry won't see a
+  // false-positive alarm.
+  const actualMtimeMs = atomicWriter._statMtimeMs(yamlPath);
+  const finalMtimeMs = Math.max(actualMtimeMs, projectedMtimeMs);
+  const finalState: ActionRuntimeState = {
+    ...state,
+    lastSeenMtimeMs: finalMtimeMs,
+  };
+  atomicWriter._writeFile(sidecarTmp, JSON.stringify(finalState, null, 2) + '\n');
+  atomicWriter._rename(sidecarTmp, sidecarPath);
 
-  return { yamlPath, sidecarPath, finalMtimeMs, refreshedSidecar };
+  return { yamlPath, sidecarPath, finalMtimeMs, refreshedSidecar: true };
 }
 
 function ensureDir(filePath: string): void {
   const dir = dirname(filePath);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  if (!atomicWriter._exists(dir)) atomicWriter._mkdir(dir);
 }
 
 /**
  * Best-effort cleanup of orphaned `.tmp` files left by a crashed previous
  * call. Called by `pairWrite` before each operation. Idempotent.
+ *
+ * Routes through `atomicWriter._unlink` / `_exists` so PR #109 review
+ * finding (E) — "tests can't simulate mkdir/unlink failures" — is
+ * resolved: the seam is now complete across all fs operations the
+ * writer performs.
  */
 function cleanupOrphans(yamlPath: string, sidecarPath: string): void {
   for (const orphan of [`${yamlPath}.tmp`, `${sidecarPath}.tmp`]) {
-    if (existsSync(orphan)) {
-      try { unlinkSync(orphan); } catch { /* ignore */ }
+    if (atomicWriter._exists(orphan)) {
+      try { atomicWriter._unlink(orphan); } catch { /* ignore */ }
     }
   }
 }
@@ -163,6 +187,20 @@ export const atomicWriter = {
   /** Underlying `fs.statSync(path).mtimeMs`. */
   _statMtimeMs(path: string): number {
     return statSync(path).mtimeMs;
+  },
+  /** Underlying `fs.existsSync(path)`. Routed through the seam so test
+   *  cases for ensureDir / cleanupOrphans can simulate exotic failures
+   *  (PR #109 review). */
+  _exists(path: string): boolean {
+    return existsSync(path);
+  },
+  /** Underlying `fs.mkdirSync(path, { recursive: true })`. */
+  _mkdir(path: string): void {
+    mkdirSync(path, { recursive: true });
+  },
+  /** Underlying `fs.unlinkSync(path)`. Used by orphan-cleanup. */
+  _unlink(path: string): void {
+    unlinkSync(path);
   },
 
   /**

--- a/scripts/cdp-bridge/src/tools/save-as-action.ts
+++ b/scripts/cdp-bridge/src/tools/save-as-action.ts
@@ -13,8 +13,7 @@
 // recorder. Keeping emission explicit means the agent has to make the
 // classification decision (which is the right place for it).
 
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { dirname } from 'node:path';
+import { existsSync } from 'node:fs';
 import { okResult, failResult } from '../utils.js';
 import type { ToolResult } from '../utils.js';
 import { getStoredEvents, getRecordingStartRoute } from './test-recorder.js';
@@ -24,7 +23,8 @@ import {
   freshRuntimeState,
 } from '../domain/reusable-action.js';
 import { actionPathFor } from '../domain/action-store.js';
-import { saveSidecar } from '../domain/sidecar-io.js';
+import { sidecarPathFor } from '../domain/sidecar-io.js';
+import { atomicWriter } from '../domain/atomic-writer.js';
 
 export interface SaveAsActionArgs {
   /**
@@ -134,18 +134,14 @@ export function createSaveAsActionHandler() {
       status,
     });
 
-    // Write the YAML file (mkdirp the actions/ dir).
-    const actionsDir = dirname(filePath);
-    if (!existsSync(actionsDir)) mkdirSync(actionsDir, { recursive: true });
-    writeFileSync(filePath, yamlText, 'utf8');
-
-    // Initialise the sidecar — fresh state with mtime seeded from the
-    // file we just wrote, so future yamlEditedSinceLastSeen() checks
-    // don't false-alarm on the agent's own write.
-    const fs = await import('node:fs');
-    const mtimeMs = fs.statSync(filePath).mtimeMs;
-    const state = freshRuntimeState(() => new Date(), mtimeMs);
-    const { path: sidecarPath } = saveSidecar(filePath, state);
+    // Issue #101: sidecar-first atomic pair-write. The atomicWriter
+    // owns `lastSeenMtimeMs` correctness (overrides whatever we seed in
+    // `freshRuntimeState`) so even partial-write failures can't leave
+    // the next yamlEditedSinceLastSeen() check returning a false-
+    // positive "human edited" alarm.
+    const sidecarPath = sidecarPathFor(filePath);
+    const initialState = freshRuntimeState(() => new Date(), 0);
+    atomicWriter.pairWrite(filePath, yamlText, sidecarPath, initialState);
 
     return okResult({
       // Phase 130 (post-review): use captured pre-existence, not the

--- a/scripts/cdp-bridge/test/helpers/tmp-project.js
+++ b/scripts/cdp-bridge/test/helpers/tmp-project.js
@@ -1,0 +1,158 @@
+// Issue #103 — tmp project root fixture for handler integration tests.
+//
+// Spins up a disposable directory under os.tmpdir() laid out the way a
+// real RN project under cdp-bridge expects:
+//
+//   <tmpRoot>/
+//     .rn-agent/
+//       actions/   ← YAML files for ReusableAction
+//       state/     ← <id>.state.json sidecar files
+//
+// Tests build a tmp project, drop fixture YAML/state files in, invoke a
+// handler with `projectRoot: <tmpRoot>`, assert on disk + envelope, then
+// dispose of the tmp tree.
+
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, statSync, utimesSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export function createTmpProject() {
+  const root = mkdtempSync(join(tmpdir(), 'rn-agent-test-'));
+  const actionsDir = join(root, '.rn-agent', 'actions');
+  const stateDir = join(root, '.rn-agent', 'state');
+  mkdirSync(actionsDir, { recursive: true });
+  mkdirSync(stateDir, { recursive: true });
+
+  return {
+    root,
+    actionsDir,
+    stateDir,
+
+    /** Resolve absolute path for a fixture YAML by id. */
+    yamlPath(id) {
+      return join(actionsDir, `${id}.yaml`);
+    },
+
+    /** Resolve absolute path for the sidecar JSON by id. */
+    sidecarPath(id) {
+      return join(stateDir, `${id}.state.json`);
+    },
+
+    /**
+     * Write a fixture YAML + sidecar pair atomically (no atomicity bug,
+     * since we're seeding the test, not exercising the production write).
+     * `state` may include lastSeenMtimeMs sentinel — pass null to seed
+     * with the YAML's actual mtime AFTER write.
+     */
+    seedAction(id, yamlText, state) {
+      const yamlPath = join(actionsDir, `${id}.yaml`);
+      const statePath = join(stateDir, `${id}.state.json`);
+      writeFileSync(yamlPath, yamlText, 'utf8');
+      const yamlMtimeMs = statSync(yamlPath).mtimeMs;
+      const stateBlob = state ?? freshFixtureState(yamlMtimeMs);
+      // If caller passed state without an explicit lastSeenMtimeMs (or
+      // with the placeholder 0), align it to the YAML's actual mtime so
+      // `yamlEditedSinceLastSeen` returns false by default. Tests that
+      // want to simulate a human edit should call simulateHumanEdit().
+      if (!stateBlob.lastSeenMtimeMs) {
+        stateBlob.lastSeenMtimeMs = yamlMtimeMs;
+      }
+      writeFileSync(statePath, JSON.stringify(stateBlob, null, 2) + '\n', 'utf8');
+      return { yamlPath, statePath, mtimeMs: yamlMtimeMs };
+    },
+
+    /**
+     * Rewrite the YAML on disk WITHOUT touching the sidecar — simulates
+     * a human edit. Bumps mtime explicitly via utimesSync so the test
+     * doesn't race the filesystem's coarse mtime resolution.
+     */
+    simulateHumanEdit(id, newYaml) {
+      const yamlPath = join(actionsDir, `${id}.yaml`);
+      writeFileSync(yamlPath, newYaml, 'utf8');
+      // Force mtime forward by 5 seconds — defeats fs mtime granularity.
+      const future = new Date(Date.now() + 5_000);
+      utimesSync(yamlPath, future, future);
+    },
+
+    readYaml(id) {
+      return readFileSync(join(actionsDir, `${id}.yaml`), 'utf8');
+    },
+
+    readSidecar(id) {
+      const path = join(stateDir, `${id}.state.json`);
+      if (!existsSync(path)) return null;
+      return JSON.parse(readFileSync(path, 'utf8'));
+    },
+
+    yamlExists(id) {
+      return existsSync(join(actionsDir, `${id}.yaml`));
+    },
+
+    sidecarExists(id) {
+      return existsSync(join(stateDir, `${id}.state.json`));
+    },
+
+    /** Tear down the entire tmp tree. Idempotent. */
+    cleanup() {
+      try {
+        rmSync(root, { recursive: true, force: true });
+      } catch {
+        // Already gone or in use — best-effort.
+      }
+    },
+  };
+}
+
+/**
+ * Minimal valid M7 YAML body — appId top section, --- separator, M7
+ * header comment block, then a tiny tap action. Used as the "before"
+ * fixture for repair tests; callers pick which selectors to embed.
+ */
+export function fixtureYaml({
+  id = 'test-action',
+  intent = 'test fixture',
+  bundleId = 'com.test.app',
+  status = 'experimental',
+  selectors = ['fab-create-task'],
+  tags = ['fixture'],
+} = {}) {
+  const tapLines = selectors.map((sel) =>
+    `  - tapOn:\n      id: "${sel}"`,
+  ).join('\n');
+  return [
+    `appId: ${bundleId}`,
+    '---',
+    `# id: ${id}`,
+    `# intent: ${intent}`,
+    `# tags: [${tags.join(', ')}]`,
+    '# mutates: false',
+    `# status: ${status}`,
+    '',
+    '- launchApp',
+    tapLines,
+    '',
+  ].join('\n');
+}
+
+/**
+ * Fresh sidecar JSON shape matching reusable-action.ts schemaVersion 1.
+ * Tests can override fields after the fact.
+ */
+export function freshFixtureState(lastSeenMtimeMs = 0) {
+  return {
+    schemaVersion: 1,
+    revision: 1,
+    updatedAt: '2026-05-04T00:00:00.000Z',
+    lastSeenMtimeMs,
+    runHistory: [],
+    repairHistory: [],
+    stats: {
+      totalRuns: 0,
+      successCount: 0,
+      failureCount: 0,
+      avgDurationMs: 0,
+      lastSuccessAt: null,
+      lastFailureAt: null,
+    },
+  };
+}

--- a/scripts/cdp-bridge/test/unit/repair-action-handler.test.js
+++ b/scripts/cdp-bridge/test/unit/repair-action-handler.test.js
@@ -1,0 +1,381 @@
+// Issue #103 — handler integration tests for cdp_repair_action.
+//
+// Covers the orchestration that pure repair-engine helpers can't reach:
+// guardrail short-circuits (external edit, budget exhausted, snapshot
+// failure), the on-disk YAML+sidecar round-trip after a successful
+// repair, and the dryRun preview path.
+//
+// The handler reads a real fixture YAML from disk, calls a stubbed
+// `runAgentDevice` to obtain a fake device snapshot, then writes back
+// the patched YAML through the same atomic-pair-writer that
+// `save-as-action` uses — so the atomicity invariant is exercised end-
+// to-end.
+
+import { test, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRepairActionHandler } from '../../dist/tools/repair-action.js';
+import {
+  setActiveSession,
+  resetActiveSessionInMemoryForTest,
+  _setRunAgentDeviceForTest,
+} from '../../dist/agent-device-wrapper.js';
+import { atomicWriter } from '../../dist/domain/atomic-writer.js';
+import { yamlEditedSinceLastSeen } from '../../dist/domain/sidecar-io.js';
+import { loadAction } from '../../dist/domain/action-store.js';
+import { createTmpProject, fixtureYaml, freshFixtureState } from '../helpers/tmp-project.js';
+
+const FAKE_SESSION = {
+  name: 'test-session-rep',
+  platform: 'ios',
+  deviceId: 'TEST-DEVICE-ID',
+  openedAt: '2026-05-04T00:00:00.000Z',
+  appId: 'com.test.app',
+};
+
+/** Build a fake snapshot envelope text shaped like agent-device's `snapshot -i`. */
+function fakeSnapshot(testIDs) {
+  const nodes = testIDs.map((id, i) => ({
+    ref: `e${i}`,
+    identifier: id,
+    rect: { x: 0, y: 0, width: 100, height: 50 },
+  }));
+  return JSON.stringify({ ok: true, data: { nodes } });
+}
+
+/** Build a failed snapshot envelope (ok:false). */
+function failedSnapshot() {
+  return JSON.stringify({ ok: false, error: 'simulated agent-device unreachable' });
+}
+
+let project;
+
+beforeEach(() => {
+  project = createTmpProject();
+  setActiveSession(FAKE_SESSION);
+});
+
+afterEach(() => {
+  _setRunAgentDeviceForTest(null);
+  resetActiveSessionInMemoryForTest();
+  mock.reset();
+  project.cleanup();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Happy path
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('repair-action: happy path patches stale selector with fuzzy match', async () => {
+  // Action references "fab-create-task" but the screen now has
+  // "fab-create-task-btn" (a common rename pattern).
+  project.seedAction(
+    'wizard-create-task',
+    fixtureYaml({ id: 'wizard-create-task', selectors: ['fab-create-task'] }),
+  );
+
+  _setRunAgentDeviceForTest(async (cliArgs) => ({
+    content: [{ type: 'text', text: fakeSnapshot(['fab-create-task-btn', 'btn-cancel', 'header-home']) }],
+  }));
+
+  const handler = createRepairActionHandler();
+  const result = await handler({
+    actionId: 'wizard-create-task',
+    failedSelector: 'fab-create-task',
+    projectRoot: project.root,
+    agentReasoning: 'maestro_run reported missing fab-create-task',
+  });
+
+  assert.equal(result.isError, undefined, `expected ok, got ${result.content[0].text}`);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.ok, true);
+  assert.equal(env.data.patched, true);
+  assert.equal(env.data.oldSelector, 'fab-create-task');
+  assert.equal(env.data.newSelector, 'fab-create-task-btn');
+  assert.equal(env.data.replacements, 1);
+
+  // YAML on disk contains the new selector, not the old one.
+  const yaml = project.readYaml('wizard-create-task');
+  assert.match(yaml, /id:\s+"fab-create-task-btn"/);
+  assert.doesNotMatch(yaml, /id:\s+"fab-create-task"$/m);
+
+  // Sidecar reflects the repair: revision bumped, repairHistory populated.
+  // RepairRecord schema is { timestamp, failureCode, diff: { selector: { from, to } }, ... }
+  const sidecar = project.readSidecar('wizard-create-task');
+  assert.ok(sidecar.revision > 1, 'revision should bump after repair');
+  assert.equal(sidecar.repairHistory.length, 1);
+  assert.equal(sidecar.repairHistory[0].failureCode, 'SELECTOR_NOT_FOUND');
+  assert.equal(sidecar.repairHistory[0].diff.selector.from, 'fab-create-task');
+  assert.equal(sidecar.repairHistory[0].diff.selector.to, 'fab-create-task-btn');
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Validation paths
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('repair-action: missing actionId returns BAD_FILENAME', async () => {
+  const handler = createRepairActionHandler();
+  const result = await handler({ failedSelector: 'foo', projectRoot: project.root });
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'BAD_FILENAME');
+});
+
+test('repair-action: missing failedSelector returns BAD_FILENAME', async () => {
+  const handler = createRepairActionHandler();
+  const result = await handler({ actionId: 'foo', projectRoot: project.root });
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'BAD_FILENAME');
+});
+
+test('repair-action: action not found returns NO_PROJECT_ROOT', async () => {
+  const handler = createRepairActionHandler();
+  const result = await handler({
+    actionId: 'does-not-exist',
+    failedSelector: 'foo',
+    projectRoot: project.root,
+  });
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'NO_PROJECT_ROOT');
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Guardrails
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('repair-action: refuses when YAML was edited externally (mtime newer than lastSeenMtimeMs)', async () => {
+  project.seedAction(
+    'edited-externally',
+    fixtureYaml({ id: 'edited-externally', selectors: ['fab-create-task'] }),
+  );
+  // Simulate human edit AFTER the sidecar was last refreshed.
+  project.simulateHumanEdit(
+    'edited-externally',
+    fixtureYaml({ id: 'edited-externally', selectors: ['user-renamed-this'] }),
+  );
+
+  _setRunAgentDeviceForTest(async () => ({
+    content: [{ type: 'text', text: fakeSnapshot(['anything']) }],
+  }));
+
+  const handler = createRepairActionHandler();
+  const result = await handler({
+    actionId: 'edited-externally',
+    failedSelector: 'fab-create-task',
+    projectRoot: project.root,
+  });
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'STALE_TARGET');
+  assert.match(env.error, /mtime is newer/);
+
+  // YAML must NOT be modified by the handler.
+  const yaml = project.readYaml('edited-externally');
+  assert.match(yaml, /id:\s+"user-renamed-this"/);
+});
+
+test('repair-action: refuses when 24h repair budget is exhausted (3 recent repairs)', async () => {
+  // Pre-seed sidecar with 3 RepairRecord entries inside the 24h window.
+  // (RepairRecord schema: { timestamp, failureCode, diff: { selector: { from, to } }, durationMs }.)
+  const nowIso = new Date().toISOString();
+  const stateWithBudgetExhausted = freshFixtureState(0);
+  const fakeRepair = (from, to) => ({
+    timestamp: nowIso,
+    failureCode: 'SELECTOR_NOT_FOUND',
+    diff: { selector: { from, to } },
+    durationMs: 0,
+  });
+  stateWithBudgetExhausted.repairHistory = [
+    fakeRepair('a', 'a1'),
+    fakeRepair('b', 'b1'),
+    fakeRepair('c', 'c1'),
+  ];
+
+  project.seedAction(
+    'budget-exhausted',
+    fixtureYaml({ id: 'budget-exhausted', selectors: ['fab-create-task'] }),
+    stateWithBudgetExhausted,
+  );
+
+  _setRunAgentDeviceForTest(async () => ({
+    content: [{ type: 'text', text: fakeSnapshot(['fab-create-task-btn']) }],
+  }));
+
+  const handler = createRepairActionHandler();
+  const result = await handler({
+    actionId: 'budget-exhausted',
+    failedSelector: 'fab-create-task',
+    projectRoot: project.root,
+  });
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'STALE_TARGET');
+  assert.match(env.error, /repair budget/);
+});
+
+test('repair-action: SNAPSHOT_FAILED when agent-device snapshot returns ok:false', async () => {
+  project.seedAction(
+    'snap-fail',
+    fixtureYaml({ id: 'snap-fail', selectors: ['fab-create-task'] }),
+  );
+
+  _setRunAgentDeviceForTest(async () => ({
+    content: [{ type: 'text', text: failedSnapshot() }],
+  }));
+
+  const handler = createRepairActionHandler();
+  const result = await handler({
+    actionId: 'snap-fail',
+    failedSelector: 'fab-create-task',
+    projectRoot: project.root,
+  });
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'SNAPSHOT_FAILED');
+});
+
+test('repair-action: snapshot returns 0 testIDs → TESTID_NOT_FOUND', async () => {
+  project.seedAction(
+    'empty-snap',
+    fixtureYaml({ id: 'empty-snap', selectors: ['fab-create-task'] }),
+  );
+
+  _setRunAgentDeviceForTest(async () => ({
+    content: [{ type: 'text', text: fakeSnapshot([]) }],
+  }));
+
+  const handler = createRepairActionHandler();
+  const result = await handler({
+    actionId: 'empty-snap',
+    failedSelector: 'fab-create-task',
+    projectRoot: project.root,
+  });
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'TESTID_NOT_FOUND');
+});
+
+test('repair-action: no candidate clears threshold → TESTID_NOT_FOUND', async () => {
+  project.seedAction(
+    'no-match',
+    fixtureYaml({ id: 'no-match', selectors: ['fab-create-task'] }),
+  );
+
+  // All candidates are wildly different — none clears the default 0.6 threshold.
+  _setRunAgentDeviceForTest(async () => ({
+    content: [{ type: 'text', text: fakeSnapshot(['totally-unrelated', 'header-x', 'menu-y']) }],
+  }));
+
+  const handler = createRepairActionHandler();
+  const result = await handler({
+    actionId: 'no-match',
+    failedSelector: 'fab-create-task',
+    projectRoot: project.root,
+  });
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'TESTID_NOT_FOUND');
+  assert.match(env.error, /no confident replacement/);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// dryRun
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('repair-action: dryRun returns diff without writing to disk', async () => {
+  project.seedAction(
+    'dry-run',
+    fixtureYaml({ id: 'dry-run', selectors: ['fab-create-task'] }),
+  );
+
+  const yamlBefore = project.readYaml('dry-run');
+  const sidecarBefore = JSON.parse(JSON.stringify(project.readSidecar('dry-run')));
+
+  _setRunAgentDeviceForTest(async () => ({
+    content: [{ type: 'text', text: fakeSnapshot(['fab-create-task-btn']) }],
+  }));
+
+  const handler = createRepairActionHandler();
+  const result = await handler({
+    actionId: 'dry-run',
+    failedSelector: 'fab-create-task',
+    projectRoot: project.root,
+    dryRun: true,
+  });
+
+  assert.equal(result.isError, undefined);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.data.dryRun, true);
+  assert.equal(env.data.oldSelector, 'fab-create-task');
+  assert.equal(env.data.newSelector, 'fab-create-task-btn');
+  assert.ok(env.data.diff?.before);
+  assert.ok(env.data.diff?.after);
+
+  // Files unchanged.
+  assert.equal(project.readYaml('dry-run'), yamlBefore, 'YAML must be untouched in dryRun');
+  assert.deepEqual(project.readSidecar('dry-run'), sidecarBefore, 'sidecar must be untouched in dryRun');
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Atomicity (#101 regression test) — even if the YAML write fails after
+// a successful sidecar write, a subsequent yamlEditedSinceLastSeen() must
+// NOT report a false-positive external edit.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('repair-action: when YAML write fails after sidecar succeeds, no false-positive external-edit alarm', async () => {
+  project.seedAction(
+    'partial-fail',
+    fixtureYaml({ id: 'partial-fail', selectors: ['fab-create-task'] }),
+  );
+
+  _setRunAgentDeviceForTest(async () => ({
+    content: [{ type: 'text', text: fakeSnapshot(['fab-create-task-btn']) }],
+  }));
+
+  const realWriteFile = atomicWriter._writeFile.bind(atomicWriter);
+  const stub = mock.method(atomicWriter, '_writeFile', (path, content) => {
+    if (path.endsWith('.yaml.tmp')) {
+      throw new Error('SIMULATED_DISK_FULL: yaml write failed');
+    }
+    return realWriteFile(path, content);
+  });
+
+  const handler = createRepairActionHandler();
+  // The handler currently doesn't try/catch around saveAction, so the
+  // error surfaces through the withSession→handler boundary as a
+  // failResult (utils.ts wraps thrown errors). Either path is fine here
+  // — what matters is the on-disk state afterwards.
+  let didThrow = false;
+  let envelope = null;
+  try {
+    const result = await handler({
+      actionId: 'partial-fail',
+      failedSelector: 'fab-create-task',
+      projectRoot: project.root,
+    });
+    envelope = JSON.parse(result.content[0].text);
+  } catch (err) {
+    didThrow = true;
+    assert.match(String(err), /SIMULATED_DISK_FULL/);
+  }
+  if (!didThrow) {
+    assert.equal(envelope?.ok, false, 'expected failure envelope when write fails');
+  }
+
+  stub.mock.restore();
+
+  // Critical invariant: the persisted sidecar's lastSeenMtimeMs must be
+  // ≥ the on-disk YAML mtime, so yamlEditedSinceLastSeen returns false.
+  const action = loadAction(project.root, 'partial-fail');
+  assert.ok(action, 'action should still load after partial failure');
+  assert.equal(
+    yamlEditedSinceLastSeen(action.filePath, action.state),
+    false,
+    'no false-positive external-edit alarm after partial failure',
+  );
+
+  // The YAML body should still be the ORIGINAL — partial failure must
+  // not advertise a successful patch.
+  assert.match(action.body, /id:\s+"fab-create-task"/);
+});

--- a/scripts/cdp-bridge/test/unit/repair-action-handler.test.js
+++ b/scripts/cdp-bridge/test/unit/repair-action-handler.test.js
@@ -324,10 +324,11 @@ test('repair-action: dryRun returns diff without writing to disk', async () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 test('repair-action: when YAML write fails after sidecar succeeds, no false-positive external-edit alarm', async () => {
-  project.seedAction(
+  const seeded = project.seedAction(
     'partial-fail',
     fixtureYaml({ id: 'partial-fail', selectors: ['fab-create-task'] }),
   );
+  const originalMtimeMs = seeded.mtimeMs;
 
   _setRunAgentDeviceForTest(async () => ({
     content: [{ type: 'text', text: fakeSnapshot(['fab-create-task-btn']) }],
@@ -365,14 +366,30 @@ test('repair-action: when YAML write fails after sidecar succeeds, no false-posi
 
   stub.mock.restore();
 
-  // Critical invariant: the persisted sidecar's lastSeenMtimeMs must be
-  // ≥ the on-disk YAML mtime, so yamlEditedSinceLastSeen returns false.
+  // Critical invariant #1: the persisted sidecar's lastSeenMtimeMs must
+  // be ≥ the on-disk YAML mtime, so yamlEditedSinceLastSeen returns
+  // false (no false-positive alarm).
   const action = loadAction(project.root, 'partial-fail');
   assert.ok(action, 'action should still load after partial failure');
   assert.equal(
     yamlEditedSinceLastSeen(action.filePath, action.state),
     false,
     'no false-positive external-edit alarm after partial failure',
+  );
+
+  // Critical invariant #2 (PR #109 review finding C): the test must
+  // strongly distinguish sidecar-first from a hypothetical YAML-first
+  // implementation. Under sidecar-first, step 1+2 successfully overwrite
+  // the seeded sidecar with `lastSeenMtimeMs = Date.now() + buffer`
+  // BEFORE the YAML write throws. The persisted sidecar therefore has
+  // a strictly LARGER mtime than the original seed — a YAML-first
+  // implementation would leave the sidecar untouched (still equal to
+  // `originalMtimeMs`), so this assertion would fail under that ordering.
+  assert.ok(
+    action.state.lastSeenMtimeMs > originalMtimeMs,
+    `sidecar-first ordering must overwrite the sidecar with a future mtime ` +
+    `before failing on the YAML write; got ${action.state.lastSeenMtimeMs} ` +
+    `vs original ${originalMtimeMs}`,
   );
 
   // The YAML body should still be the ORIGINAL — partial failure must

--- a/scripts/cdp-bridge/test/unit/save-as-action-handler.test.js
+++ b/scripts/cdp-bridge/test/unit/save-as-action-handler.test.js
@@ -262,14 +262,18 @@ test('save-as-action: when YAML write fails after sidecar succeeds, no false-pos
   assert.equal(project.yamlExists('partial-fail'), false, 'YAML should not be present after partial failure');
 
   // Sidecar exists (step 1+2 succeeded). Its lastSeenMtimeMs is the
-  // projected future mtime (≥ Date.now()) — so a subsequent
-  // yamlEditedSinceLastSeen() call against any future YAML creation
-  // would see lastSeenMtimeMs ahead, suppressing a false alarm.
+  // projected future mtime — strictly ≥ Date.now() at the moment of
+  // step 1's `Date.now() + FUTURE_MTIME_BUFFER_MS`. PR #109 review
+  // finding (D): the previous `>= Date.now() - 1_000` bound was too
+  // loose and would have permitted a buggy implementation that wrote
+  // `Date.now() - 500`. Tightened to `> Date.now() - 100` (small slack
+  // covers wall-clock advance during the test, but rules out values in
+  // the pre-test past).
   assert.equal(project.sidecarExists('partial-fail'), true, 'sidecar should exist with projected mtime');
   const sidecar = project.readSidecar('partial-fail');
   assert.ok(
-    sidecar.lastSeenMtimeMs >= Date.now() - 1_000,
-    `expected projected lastSeenMtimeMs near now or future, got ${sidecar.lastSeenMtimeMs}`,
+    sidecar.lastSeenMtimeMs > Date.now() - 100,
+    `expected projected lastSeenMtimeMs near now or future, got ${sidecar.lastSeenMtimeMs} vs now=${Date.now()}`,
   );
 
   // Restore writer, reset mocks, simulate recovery: a subsequent call

--- a/scripts/cdp-bridge/test/unit/save-as-action-handler.test.js
+++ b/scripts/cdp-bridge/test/unit/save-as-action-handler.test.js
@@ -1,0 +1,342 @@
+// Issue #103 — handler integration tests for cdp_record_test_save_as_action.
+//
+// Covers the I/O orchestration that pure-helper unit tests can't reach:
+// real filesystem fixtures, the M7 metadata round-trip, the
+// pre-existing-file refusal path, and the #101 atomicity guarantee
+// (sidecar-first ordering + future-mtime buffer).
+
+import { test, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { createSaveAsActionHandler } from '../../dist/tools/save-as-action.js';
+import {
+  _setStoredEvents,
+  _setRecordingStartRoute,
+  _resetState,
+} from '../../dist/tools/test-recorder.js';
+import { atomicWriter } from '../../dist/domain/atomic-writer.js';
+import { yamlEditedSinceLastSeen } from '../../dist/domain/sidecar-io.js';
+import { loadAction } from '../../dist/domain/action-store.js';
+import { parseM7Header } from '../../dist/domain/reusable-action.js';
+import { createTmpProject } from '../helpers/tmp-project.js';
+
+const SAMPLE_EVENTS = [
+  { type: 'tap', testID: 'fab-create-task', label: null, route: 'home', t: 0 },
+  { type: 'type', testID: 'input-title', label: null, value: 'My task', route: 'wizard', t: 100 },
+  { type: 'tap', testID: 'btn-save', label: null, route: 'wizard', t: 200 },
+];
+
+let project;
+let mockTracker;
+
+beforeEach(() => {
+  project = createTmpProject();
+  _resetState();
+  mockTracker = { restore: () => {} };
+});
+
+afterEach(() => {
+  mockTracker.restore();
+  mock.reset();
+  _resetState();
+  project.cleanup();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Happy path
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('save-as-action: happy path emits YAML + sidecar with M7 metadata', async () => {
+  _setStoredEvents(SAMPLE_EVENTS);
+  _setRecordingStartRoute('home');
+
+  const handler = createSaveAsActionHandler();
+  const result = await handler({
+    id: 'create-task-flow',
+    intent: 'create a new task via the wizard',
+    tags: ['wizard', 'tasks'],
+    mutates: true,
+    bundleId: 'com.test.app',
+    projectRoot: project.root,
+  });
+
+  assert.equal(result.isError, undefined, `expected ok result, got ${result.content[0].text}`);
+  const envelope = JSON.parse(result.content[0].text);
+  assert.equal(envelope.ok, true);
+  assert.equal(envelope.data.created, true);
+  assert.equal(envelope.data.overwritten, false);
+  assert.equal(envelope.data.actionId, 'create-task-flow');
+  assert.equal(envelope.data.eventCount, 3);
+
+  // Files exist on disk.
+  assert.ok(project.yamlExists('create-task-flow'), 'YAML should exist');
+  assert.ok(project.sidecarExists('create-task-flow'), 'sidecar should exist');
+
+  // M7 header round-trips. (appId lives in the Maestro top section
+  // before `---`, not in the M7 comment block, so check it separately.)
+  const yaml = project.readYaml('create-task-flow');
+  assert.match(yaml, /^appId:\s+com\.test\.app/m, 'top-level appId should be present');
+  const parsed = parseM7Header(yaml);
+  assert.ok(parsed, 'M7 header should parse');
+  assert.equal(parsed.id, 'create-task-flow');
+  assert.equal(parsed.intent, 'create a new task via the wizard');
+  assert.deepEqual(parsed.tags, ['wizard', 'tasks']);
+  assert.equal(parsed.mutates, true);
+  assert.equal(parsed.status, 'experimental');
+
+  // Sidecar shape is valid.
+  const sidecar = project.readSidecar('create-task-flow');
+  assert.equal(sidecar.schemaVersion, 1);
+  assert.equal(sidecar.revision, 1);
+  assert.ok(sidecar.lastSeenMtimeMs > 0, 'lastSeenMtimeMs should be seeded');
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Validation paths
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('save-as-action: missing id returns BAD_FILENAME', async () => {
+  _setStoredEvents(SAMPLE_EVENTS);
+  const handler = createSaveAsActionHandler();
+  const result = await handler({
+    intent: 'no id supplied',
+    projectRoot: project.root,
+  });
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'BAD_FILENAME');
+  assert.match(env.error, /requires id/);
+});
+
+test('save-as-action: missing intent returns BAD_FILENAME', async () => {
+  _setStoredEvents(SAMPLE_EVENTS);
+  const handler = createSaveAsActionHandler();
+  const result = await handler({
+    id: 'no-intent',
+    projectRoot: project.root,
+  });
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'BAD_FILENAME');
+  assert.match(env.error, /requires intent/);
+});
+
+test('save-as-action: id regex rejects path-traversal vectors', async () => {
+  _setStoredEvents(SAMPLE_EVENTS);
+  const handler = createSaveAsActionHandler();
+  const malicious = ['../escape', 'with/slash', 'with.dot', 'UPPER', 'with_under', '-leading-hyphen'];
+  for (const id of malicious) {
+    const result = await handler({
+      id,
+      intent: 'attempt traversal',
+      projectRoot: project.root,
+    });
+    assert.equal(result.isError, true, `id "${id}" should be rejected`);
+    const env = JSON.parse(result.content[0].text);
+    assert.equal(env.code, 'BAD_FILENAME');
+    assert.match(env.error, /must be lower-case kebab-case/);
+  }
+});
+
+test('save-as-action: empty buffer returns NO_EVENTS', async () => {
+  _setStoredEvents([]); // explicit empty
+  const handler = createSaveAsActionHandler();
+  const result = await handler({
+    id: 'no-events',
+    intent: 'try with empty buffer',
+    projectRoot: project.root,
+  });
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'NO_EVENTS');
+});
+
+test('save-as-action: null buffer (recorder never started) returns NO_EVENTS', async () => {
+  // _resetState() in beforeEach leaves storedEvents = null
+  const handler = createSaveAsActionHandler();
+  const result = await handler({
+    id: 'no-events',
+    intent: 'try with null buffer',
+    projectRoot: project.root,
+  });
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'NO_EVENTS');
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Overwrite semantics
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('save-as-action: duplicate id without overwrite refuses', async () => {
+  _setStoredEvents(SAMPLE_EVENTS);
+  _setRecordingStartRoute('home');
+  const handler = createSaveAsActionHandler();
+
+  const args = {
+    id: 'duplicate-id',
+    intent: 'first call wins',
+    bundleId: 'com.test.app',
+    projectRoot: project.root,
+  };
+  const first = await handler(args);
+  assert.equal(first.isError, undefined, 'first call should succeed');
+
+  const second = await handler(args);
+  assert.equal(second.isError, true, 'second call without overwrite should fail');
+  const env = JSON.parse(second.content[0].text);
+  assert.equal(env.code, 'BAD_FILENAME');
+  assert.match(env.error, /already exists/);
+});
+
+test('save-as-action: duplicate id with overwrite=true succeeds and reports overwritten:true', async () => {
+  _setStoredEvents(SAMPLE_EVENTS);
+  _setRecordingStartRoute('home');
+  const handler = createSaveAsActionHandler();
+
+  await handler({
+    id: 'overwrite-me',
+    intent: 'first version',
+    bundleId: 'com.test.app',
+    projectRoot: project.root,
+  });
+
+  const second = await handler({
+    id: 'overwrite-me',
+    intent: 'second version',
+    bundleId: 'com.test.app',
+    projectRoot: project.root,
+    overwrite: true,
+  });
+  assert.equal(second.isError, undefined, 'overwrite=true should succeed');
+  const env = JSON.parse(second.content[0].text);
+  assert.equal(env.ok, true);
+  assert.equal(env.data.created, false);
+  assert.equal(env.data.overwritten, true);
+
+  // Verify the YAML now reflects the second intent.
+  const yaml = project.readYaml('overwrite-me');
+  assert.match(yaml, /intent:\s+second version/);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Atomicity (#101 regression test) — sidecar-first ordering must keep
+// `actionWasEditedExternally` returning false even when the second
+// (YAML) write fails after the (sidecar) first one succeeded.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('save-as-action: when YAML write fails after sidecar succeeds, no false-positive external-edit alarm', async () => {
+  _setStoredEvents(SAMPLE_EVENTS);
+  _setRecordingStartRoute('home');
+
+  // Stub the writer to fail when writing the YAML's .tmp file. The
+  // sidecar write happens first (sidecar-first ordering) and should
+  // succeed; the YAML write then fails. Per #101's required invariant,
+  // the persisted sidecar should hold a `lastSeenMtimeMs` ≥ the (still
+  // pre-existing or absent) YAML mtime, so a follow-up edit-detection
+  // call returns false.
+  const realWriteFile = atomicWriter._writeFile.bind(atomicWriter);
+  const stub = mock.method(atomicWriter, '_writeFile', (path, content) => {
+    if (path.endsWith('.yaml.tmp')) {
+      throw new Error('SIMULATED_DISK_FULL: yaml write failed');
+    }
+    return realWriteFile(path, content);
+  });
+
+  const handler = createSaveAsActionHandler();
+
+  // Handler will throw because pairWrite throws — that's OK, the test
+  // is about post-failure state, not graceful error handling here
+  // (the issue's explicit goal is "verify recovery", not "verify the
+  // failure is wrapped in failResult").
+  await assert.rejects(
+    handler({
+      id: 'partial-fail',
+      intent: 'verify atomicity',
+      bundleId: 'com.test.app',
+      projectRoot: project.root,
+    }),
+    /SIMULATED_DISK_FULL/,
+  );
+
+  // YAML must NOT exist on disk — the .tmp write failed before rename.
+  assert.equal(project.yamlExists('partial-fail'), false, 'YAML should not be present after partial failure');
+
+  // Sidecar exists (step 1+2 succeeded). Its lastSeenMtimeMs is the
+  // projected future mtime (≥ Date.now()) — so a subsequent
+  // yamlEditedSinceLastSeen() call against any future YAML creation
+  // would see lastSeenMtimeMs ahead, suppressing a false alarm.
+  assert.equal(project.sidecarExists('partial-fail'), true, 'sidecar should exist with projected mtime');
+  const sidecar = project.readSidecar('partial-fail');
+  assert.ok(
+    sidecar.lastSeenMtimeMs >= Date.now() - 1_000,
+    `expected projected lastSeenMtimeMs near now or future, got ${sidecar.lastSeenMtimeMs}`,
+  );
+
+  // Restore writer, reset mocks, simulate recovery: a subsequent call
+  // with the same id should succeed cleanly (action correctly considered
+  // absent and creatable).
+  stub.mock.restore();
+
+  const handler2 = createSaveAsActionHandler();
+  const recovery = await handler2({
+    id: 'partial-fail',
+    intent: 'verify atomicity',
+    bundleId: 'com.test.app',
+    projectRoot: project.root,
+  });
+  assert.equal(recovery.isError, undefined, 'recovery call should succeed');
+  const recEnv = JSON.parse(recovery.content[0].text);
+  assert.equal(recEnv.data.created, true, 'recovery should report created:true (YAML was absent)');
+  assert.ok(project.yamlExists('partial-fail'));
+
+  // The fresh action loaded back must NOT be considered externally edited.
+  const action = loadAction(project.root, 'partial-fail');
+  assert.ok(action, 'recovered action should load');
+  assert.equal(
+    yamlEditedSinceLastSeen(action.filePath, action.state),
+    false,
+    'no false-positive external-edit alarm after partial failure + recovery',
+  );
+});
+
+test('save-as-action: when sidecar write fails first, nothing is persisted and a retry can succeed', async () => {
+  _setStoredEvents(SAMPLE_EVENTS);
+  _setRecordingStartRoute('home');
+
+  // Fail on the very first write — the sidecar.tmp.
+  let failedOnce = false;
+  const realWriteFile = atomicWriter._writeFile.bind(atomicWriter);
+  const stub = mock.method(atomicWriter, '_writeFile', (path, content) => {
+    if (!failedOnce && path.endsWith('.state.json.tmp')) {
+      failedOnce = true;
+      throw new Error('SIMULATED_DISK_FULL: sidecar write failed');
+    }
+    return realWriteFile(path, content);
+  });
+
+  const handler = createSaveAsActionHandler();
+  await assert.rejects(
+    handler({
+      id: 'sidecar-fail',
+      intent: 'verify atomicity',
+      bundleId: 'com.test.app',
+      projectRoot: project.root,
+    }),
+    /SIMULATED_DISK_FULL/,
+  );
+
+  // Neither file should exist — the operation aborted before either rename.
+  assert.equal(project.yamlExists('sidecar-fail'), false);
+  assert.equal(project.sidecarExists('sidecar-fail'), false);
+
+  // Retry succeeds (the stub has already let `failedOnce` flip, so subsequent
+  // calls fall through to the real writer).
+  stub.mock.restore();
+  const recovery = await handler({
+    id: 'sidecar-fail',
+    intent: 'verify atomicity',
+    bundleId: 'com.test.app',
+    projectRoot: project.root,
+  });
+  assert.equal(recovery.isError, undefined, 'retry should succeed cleanly');
+});


### PR DESCRIPTION
Closes #103, fixes #101.

## Summary

* New `domain/atomic-writer.ts` with `pairWrite()` using **sidecar-first ordering + 1-second future-mtime buffer** — the design that actually fixes #101 (the "write both .tmp + rename both" approach still leaves you exposed if the second rename fails).
* `action-store.saveAction` and `tools/save-as-action.ts` now route their (YAML, sidecar) writes through the atomic writer.
* New `_setRunAgentDeviceForTest` hook on `agent-device-wrapper.ts` so handler tests can stub the device snapshot.
* 21 new tests across two files exercising the I/O orchestration that pure-helper suites (`repair-engine.test.js`, `reusable-action.test.js`) couldn't reach. Suite is now 1140 pass / 0 fail (was 1119).

## Why sidecar-first ordering

The naive "YAML first, sidecar second" ordering has a silent failure mode (#101): if the YAML succeeds and the sidecar update fails, the on-disk YAML mtime advances but `lastSeenMtimeMs` does not — and `yamlEditedSinceLastSeen` then reports a phantom human edit, blocking self-repair.

The fix writes the sidecar FIRST with `lastSeenMtimeMs = Date.now() + 1_000` (longer than any plausible YAML write, shorter than any plausible human edit), atomic-renames it, then writes/renames the YAML. **Any** partial failure leaves the persisted sidecar's mtime ≥ current YAML mtime, so the next `yamlEditedSinceLastSeen` call returns `false`. An optimistic step-5 resync brings the recorded mtime back to the precise value on the happy path.

Crash-window analysis is documented in the module docstring.

## What's in the new test files

`test/unit/save-as-action-handler.test.js` (10 tests):
* happy path emits YAML + sidecar with M7 metadata
* missing id / missing intent / id regex rejection (path-traversal vectors)
* empty buffer + null buffer → `NO_EVENTS`
* duplicate id without overwrite refuses
* duplicate id with `overwrite=true` succeeds and reports `overwritten:true`
* atomicity: stub `atomicWriter._writeFile` to throw on `.yaml.tmp`, assert recovery is sane
* atomicity: stub to throw on `.state.json.tmp`, assert nothing persisted and retry succeeds

`test/unit/repair-action-handler.test.js` (11 tests):
* happy path patches stale selector with fuzzy match (asserts YAML on disk + sidecar `repairHistory[0].diff.selector.{from,to}`)
* missing actionId / missing failedSelector / action not found
* `STALE_TARGET` when YAML is edited externally (mtime > lastSeenMtimeMs)
* `STALE_TARGET` when 24h repair budget is exhausted
* `SNAPSHOT_FAILED` when agent-device returns `ok:false`
* `TESTID_NOT_FOUND` on empty snapshot / no candidate clears threshold
* `dryRun` returns diff but doesn't write
* atomicity: stub YAML write to fail after sidecar succeeds, assert no false-positive external-edit alarm + body unchanged

## Test plan

- [x] `node --test 'test/unit/*.test.js'` — 1140 pass, 0 fail
- [x] `node --test 'test/integration/*.test.js'` — 11 pass, 0 fail
- [x] Version sync: `plugin.json` 0.44.14→0.44.15, `marketplace.json` synced via hook, `package.json` 0.38.14→0.38.15
- [x] `tsc` build clean
- [x] Pre-commit hook runs (version sync check passes)
- [ ] Live smoke once a Dev Client is attached: invoke `cdp_record_test_save_as_action` with the new id-regex vectors, then trigger a `cdp_repair_action` against a known-stale selector to confirm the new atomic writer behaves end-to-end