### PR TITLE
fix(plugin.json): remove invalid manifest keys blocking install — v0.44.26

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.22",
+      "version": "0.44.26",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.22",
+  "version": "0.44.26",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",
@@ -9,7 +9,6 @@
   "homepage": "https://github.com/Lykhoyda/rn-dev-agent",
   "repository": "https://github.com/Lykhoyda/rn-dev-agent",
   "license": "MIT",
-  "category": "development",
   "keywords": [
     "react-native",
     "expo",
@@ -54,26 +53,6 @@
     "./commands/list-learned-actions.md",
     "./commands/run-action.md"
   ],
-  "userConfig": {
-    "RN_METRO_PORT": {
-      "title": "Metro Port",
-      "description": "Default Metro bundler port (leave empty for auto-detect: 8081, 8082, 19000, 19006)",
-      "type": "string",
-      "required": false
-    },
-    "RN_PREFERRED_PLATFORM": {
-      "title": "Preferred Platform",
-      "description": "Preferred target platform for CDP connection (auto, ios, or android)",
-      "type": "string",
-      "required": false
-    },
-    "RN_DEV_AGENT_LOG_LEVEL": {
-      "title": "Log Level",
-      "description": "MCP server log verbosity (warn, info, debug, or error)",
-      "type": "string",
-      "required": false
-    }
-  },
   "mcpServers": {
     "cdp": {
       "command": "node",


### PR DESCRIPTION
## Summary

- Removes two invalid keys from `.claude-plugin/plugin.json` that broke fresh installs once the Claude Code plugin manifest validator tightened.
- Bumps to **v0.44.26** (skips ahead of the open stack #127–#130 so this fix can ship independently).
- No runtime change — the three env vars (`RN_METRO_PORT`, `RN_PREFERRED_PLATFORM`, `RN_DEV_AGENT_LOG_LEVEL`) consumed by the MCP server still work; only the (already non-functional) manifest UI declaration is removed.

## Symptom (reported by user)

```
Error: Failed to install: Plugin has an invalid manifest file at
/Users/<user>/.claude/plugins/cache/temp_local_*/.claude-plugin/plugin.json.
Validation errors: : Unrecognized keys: "category", "userConfig"
```

Reproduces on every fresh `/plugin install` against `main` at v0.44.22.

## Root cause

Both keys were added in commit `ade6593` (Phase 75 modernization, v0.14.0) and have been silently invalid against current Claude Code plugin schema:

| Key | Why invalid | Fix |
|---|---|---|
| `category` (top-level) | Not in plugin manifest schema. The marketplace schema accepts it (and `marketplace.json` already declares `"category": "mobile-development"` correctly). | Removed from `plugin.json` only. |
| `userConfig` | Not in current plugin manifest schema. The UI it was meant to expose was already non-functional under the stricter validator. | Removed. |

## Test plan

- [x] `node -e "JSON.parse(...)"` parses both manifests
- [x] `./scripts/sync-versions.sh` confirms `plugin.json` ↔ `marketplace.json` versions match (0.44.26)
- [x] `grep userConfig src/` — manifest declaration was UI-only; runtime env vars still consumed by `scripts/cdp-bridge/src/{logger.ts,connect.ts,discovery.ts}`
- [ ] Reviewer: install plugin via `/plugin install ./` from this branch and confirm the validator accepts the manifest

## Stack interaction

Open stack #127→#128→#129→#130 are all based on v0.44.22 and inherit this bug. After this PR merges, the stack should be rebased onto new `main` so the fix propagates. Versioning leaves room: stack uses `.22 .23 .24 .25`; this PR jumps to `.26`.