### PR TITLE
docs: refresh README, docs-site, CLAUDE-MD-TEMPLATE for actions concept + .rn-agent/ doctrine

### DIFF
--- a/CLAUDE-MD-TEMPLATE.md
+++ b/CLAUDE-MD-TEMPLATE.md
@@ -38,6 +38,42 @@ Manual walks are a fallback, not a default. Codified in
 `/rn-dev-agent:test-feature` and Step 0a of the `rn-tester` / `rn-debugger`
 agent protocols.
 
+### 🧩 Hybrid composition — actions are skill primitives, not just full replays
+
+Use deterministic actions wherever they fit, and walk only the parts that
+don't have a saved action. The all-or-nothing "match → replay; else fully
+manual" rule is gone — most real tasks share *partial* overlap with existing
+actions (login, onboarding, locale, subscription gate). Compose action +
+manual when state mismatches; never re-walk a flow you already have.
+
+**Three rules:**
+
+1. **State-detection prologue.** Before any goal-state task, read current
+   state — `cdp_navigation_state` for the route, `cdp_store_state` for the
+   relevant slice. Note any mismatch with the expected starting state.
+2. **Compose action + manual.** If current state ≠ expected start, scan
+   `list-learned-actions` for an action whose `produces` covers the gap.
+   Replay via `cdp_run_action`. Re-verify state. Then continue
+   interactively for the novel part.
+3. **No fully-manual fallback when partial replay would cover half the work.**
+   Login is the cardinal example — if a saved login action exists, use it
+   as a prologue, never re-walk login interactively.
+
+**Worked example.** User: "tap the cart badge."
+
+- Agent: `cdp_navigation_state` → `LoginScreen` (mismatch with home)
+- Agent: `list-learned-actions` → finds `user-login` with
+  `produces: { authenticated: true, route: home }`
+- Agent: `cdp_run_action({ id: "user-login", params: { EMAIL, PASSWORD } })`
+- Agent: `cdp_navigation_state` → `HomeScreen` (state delta closed)
+- Agent: `cdp_component_tree({ filter: "cart" })` → finds `cart-badge` ref
+- Agent: `device_press({ ref: "cart-badge" })`
+
+**The `produces:` field is optional metadata in the M7 action header.** Existing
+actions without `produces` fall back to today's intent-string matching.
+Recorders are encouraged to populate it from observed end-of-flow state when
+saving via `cdp_record_test_save_as_action`.
+
 ---
 
 ### 🚨 Tool Routing — STRICT RULES (read this second)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin that turns Claude into a React Native development partner. It explores your codebase, designs architecture, implements features, then **verifies everything live on the simulator** — reading the component tree, store state, and navigation stack through Chrome DevTools Protocol.
 
-**74 MCP tools** | **5 agents** | **17 commands** | **1180+ tests** | **46 best-practice rules** | [Full documentation](https://lykhoyda.github.io/rn-dev-agent/)
+**70+ MCP tools** · **5 agents** · **16 commands** · **1180+ tests** · **46 best-practice rules** · [Full documentation](https://lykhoyda.github.io/rn-dev-agent/)
 
 ---
 
@@ -73,12 +73,20 @@ Claude runs an [8-phase pipeline](https://lykhoyda.github.io/rn-dev-agent/comman
 | `/rn-dev-agent:build-and-test <desc>` | Build app (local or EAS), install on device, then test |
 | `/rn-dev-agent:proof-capture <desc>` | Rehearsal-gated video + screenshots + PR body |
 
-**Reusable actions (M7) + L3 self-healing corpus:**
+**Actions: replayable app flows**
 
-| Command | Purpose |
-|---------|---------|
-| `/rn-dev-agent:list-learned-actions` | Browse memories + Maestro flows + UI skeletons + commands available in this project |
-| `/rn-dev-agent:run-action <id>` | Replay a persisted Maestro flow with safety pre-flights (mutates flag, appId match, parameter coverage); auto-repairs SELECTOR_NOT_FOUND failures via `cdp_run_action` |
+A saved, replayable flow through your app — login, navigate to settings, reach a known state. The plugin records actions automatically when verification passes; you replay them in seconds.
+
+| | |
+|---|---|
+| **What** | A saved, replayable flow through your app (login, navigation, multi-step setup). |
+| **Where** | `.rn-agent/actions/<name>.yaml`. The plugin's home in your project is `.rn-agent/`. |
+| **Create one** | Run `/rn-dev-agent:test-feature <description>`. When verification passes, the plugin saves the verified walk as an action. |
+| **Run one** | List with `/rn-dev-agent:list-learned-actions`; replay with `/rn-dev-agent:run-action <name>`. The agent also picks an action automatically when it needs to reach a known state (e.g. logged-in home) before doing new work. |
+| **Self-repair** | If a `testID` changes, the plugin patches the action against the live UI and retries. Small UI drift is absorbed without re-recording; broken product logic is not auto-fixed. |
+| **Why** | Known flows replay in seconds instead of being rediscovered interactively. Repeated setup work like login becomes one fast step. |
+
+[Full actions guide](https://lykhoyda.github.io/rn-dev-agent/actions/)
 
 **Setup & diagnostics:**
 
@@ -122,23 +130,23 @@ if (__DEV__) {
 
 ## MCP Tools
 
-74 tools across three layers. [Full reference](https://lykhoyda.github.io/rn-dev-agent/tools/)
+The plugin exposes a wide surface area of MCP tools across four families. See the [tools reference](https://lykhoyda.github.io/rn-dev-agent/tools/) for the full list.
 
-| Category | Count | Examples | Docs |
-|----------|-------|---------|------|
-| **CDP** (React internals) | 39 | `cdp_component_tree`, `cdp_store_state`, `cdp_evaluate`, `cdp_set_shared_value`, `cdp_native_errors`, `cdp_record_test_*`, `cdp_repair_action` | [CDP tools](https://lykhoyda.github.io/rn-dev-agent/tools/#cdp-tools) |
-| **Device** (native interaction) | 22 | `device_find`, `device_press`, `device_fill`, `device_screenshot`, `device_pick_date`, `device_pick_value` | [Device tools](https://lykhoyda.github.io/rn-dev-agent/tools/#device-tools) |
-| **Testing** (E2E + proof) | 8 | `proof_step`, `cross_platform_verify`, `maestro_run`, `maestro_generate`, `maestro_test_all`, `cdp_run_action` | [Testing tools](https://lykhoyda.github.io/rn-dev-agent/tools/#testing-tools) |
-| **Macro-Asserts** (L3 state checks) | 4 | `expect_redux`, `expect_route`, `expect_visible_by_testid`, `expect_text` | [Macro-Asserts](https://lykhoyda.github.io/rn-dev-agent/tools/#macro-asserts) |
+| Family | What it's for | Examples |
+|---|---|---|
+| **CDP** | React internals via Chrome DevTools Protocol | `cdp_component_tree`, `cdp_store_state`, `cdp_evaluate`, `cdp_native_errors`, `cdp_record_test_*`, `cdp_repair_action` |
+| **Device** | Native interaction with the simulator/emulator | `device_find`, `device_press`, `device_fill`, `device_screenshot`, `device_pick_date` |
+| **Testing** | E2E replay and PR-ready proof | `proof_step`, `cross_platform_verify`, `maestro_run`, `cdp_run_action` |
+| **Macro-Asserts** | State-assertive replays — internal state, not pixels | `expect_redux`, `expect_route`, `expect_visible_by_testid`, `expect_text` |
 
 ### What's new in v0.44.18 (2026-05-05)
 
-- **L3 self-healing corpus** — new `cdp_repair_action` patches a flow's stale testID via fuzzy match against the live snapshot when `/run-action` fails with `SELECTOR_NOT_FOUND`. Guardrails: refuses on human edits (mtime check), refuses past 3 repairs in 24h, refuses on snapshot infrastructure failure.
+- **Self-healing actions** — new `cdp_repair_action` patches a stale `testID` via fuzzy match against the live snapshot when `/run-action` fails with `SELECTOR_NOT_FOUND`. Guardrails: refuses on human edits (mtime check), refuses past 3 repairs in 24h, refuses on snapshot infrastructure failure.
 - **Auto-repair-aware action replay** — new `cdp_run_action` orchestrates `maestro_run` + parser + `cdp_repair_action` + retry, then persists a `RunRecord` with structured `autoRepair` telemetry (passed / failed / refused / skipped, plus phase-level timing for MTTR analysis).
-- **L2→L3 auto-emission** — new `cdp_record_test_save_as_action` turns a recorded walk into a first-class `.rn-agent/actions/<id>.yaml` with full M7 metadata header + initialised sidecar. Auto-promotes to `status: active` on first clean replay.
+- **Auto-emission of recorded walks** — new `cdp_record_test_save_as_action` turns a recorded walk into a first-class `.rn-agent/actions/<id>.yaml` with a full metadata header and initialised sidecar. Auto-promotes to `status: active` on first clean replay.
 - **Macro-Asserts** — `expect_redux`, `expect_route`, `expect_visible_by_testid`, `expect_text` for state-assertive replays. Maestro asserts pixels; these assert internal state. Differentiated capability over Maestro Cloud / KaneAI / BrowserStack.
 - **testID-keyed `device_batch`** — re-resolves via fresh fiber-tree snapshot per call, immune to stale-ref-across-step-transitions failures.
-- **Three-layer architecture** — D1206 codifies L1 Workflow / L2 Discovery / L3 Reproducible Actions as the canonical mental model.
+- **Three-layer architecture** — Workflow (rn-feature-dev) / Discovery (CDP + device tools) / Reproducible Actions is the canonical mental model. See [architecture](https://lykhoyda.github.io/rn-dev-agent/architecture/).
 - **Atomic YAML+sidecar pair-write** — sidecar-first ordering with future-mtime buffer guarantees no false-positive "external edit" alarms even on partial-write failures (D1101 / issue #101).
 - **CAS read-modify-write protection** — `saveActionWithCAS` detects concurrent writer races on the same actionId and retries, so RunRecord history doesn't lose entries under heavy parallel runs (issue #117).
 - **1180+ unit tests** in cdp-bridge (was 994 in v0.44.5, 249 in v0.23.0).

--- a/docs-site/src/content/docs/actions/index.mdx
+++ b/docs-site/src/content/docs/actions/index.mdx
@@ -1,0 +1,106 @@
+---
+title: Actions
+description: Saved, replayable flows through your app — what they are, where they live, and how the agent uses them.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+An **action** is a saved, replayable flow through your app — login, navigating to a screen, completing a multi-step form. The plugin records them automatically when verification passes; you replay them in seconds via `/run-action`, and the agent uses them as prologues when it needs to reach a known state.
+
+| | |
+|---|---|
+| **What** | A saved, replayable flow through your app (login, navigation, multi-step setup). |
+| **Where** | `.rn-agent/actions/<name>.yaml`. The plugin's home in your project is `.rn-agent/`. |
+| **Create one** | Run `/rn-dev-agent:test-feature <description>`. When verification passes, the plugin saves the verified walk as an action. |
+| **Run one** | List with `/rn-dev-agent:list-learned-actions`; replay with `/rn-dev-agent:run-action <name>`. The agent also picks an action automatically when it needs to reach a known state. |
+| **Self-repair** | If a `testID` changes, the plugin patches the action against the live UI and retries. Small UI drift is absorbed; broken product logic is not. |
+| **Why** | Known flows replay in seconds instead of being rediscovered interactively. Repeated setup work like login becomes one fast step. |
+
+## Where actions live
+
+The plugin's home in your project is `.rn-agent/`. Actions live in the `actions/` subdirectory; sibling folders hold supporting state.
+
+```
+.rn-agent/
+├── actions/                ← saved actions (commit)
+│   └── *.yaml
+├── state/                  ← run history, repair history (gitignore)
+├── recordings/             ← raw captures from cdp_record_test (gitignore)
+├── skeleton.yaml           ← UI semantic-name → testID map (commit)
+├── nav-graph.yaml          ← persisted navigation graph (commit, optional)
+├── fixtures/               ← seed data for replay (commit)
+├── proposals/              ← repair proposals queued for review (commit)
+└── README.md
+```
+
+`/rn-dev-agent:setup` scaffolds the entire directory on first onboarding; [`/doctor`](../commands/doctor/) reports on its health.
+
+The plugin's entire footprint is `.rn-agent/`. It does not read or write anywhere else in your project.
+
+## Creating an action
+
+Run `/rn-dev-agent:test-feature <feature description>`. The plugin walks the feature on the live simulator, verifies UI rendering and internal state, then saves the verified walk as `.rn-agent/actions/<feature-slug>.yaml`. Each action carries a small metadata header at the top — its intent, what it tags, whether it mutates data, its lifecycle status.
+
+```yaml
+# id: wizard-create-task
+# intent: Create a task via the 3-step wizard
+# tags: [task, wizard, create]
+# mutates: true
+# status: active
+appId: com.rndevagent.testapp
+---
+# Maestro YAML body...
+```
+
+You can hand-edit actions, but consider that self-repair refuses to touch hand-edited files (`mtime` check) — to keep the plugin's automatic upkeep working, prefer rerecording over hand-editing.
+
+## Listing and running
+
+[`/rn-dev-agent:list-learned-actions`](../commands/list-learned-actions/) shows what's saved in this project (with an optional keyword filter):
+
+```
+/rn-dev-agent:list-learned-actions task
+```
+
+[`/rn-dev-agent:run-action`](../commands/run-action/) replays one by name:
+
+```
+/rn-dev-agent:run-action wizard-create-task -e TITLE="Buy milk" -e PRIORITY=high
+```
+
+`-e KEY=VALUE` fills `${KEY}` placeholders inside the action. `--platform ios|android` targets a specific device when multiple are booted. `--dry-run` prints the resolved replay command without executing it.
+
+## Self-repair, in plain words
+
+When a `testID` gets renamed in your app and the action references the old name, replay fails with `SELECTOR_NOT_FOUND`. The plugin doesn't give up: it looks at the live UI, finds the most likely new `testID` via fuzzy matching, patches the YAML, and retries. The repair gets logged to the action's sidecar file so you can see what changed.
+
+<Aside type="caution" title="Self-repair has limits">
+Self-repair handles **small UI drift** (a renamed `testID`, a moved button), not broken product logic. It refuses to touch files you've hand-edited (`mtime` check). It refuses after 3 repairs on the same action in 24h to avoid runaway patching. Failures escalate to you.
+</Aside>
+
+## The agent picks actions automatically
+
+You don't have to type `/run-action` yourself. When you ask the agent to do something on screen X but the app is on screen Y, the agent will scan saved actions for one that gets you to X and run it as a prologue — then continue with the new work interactively.
+
+**Example.** You ask: "tap the cart badge."
+
+- The agent reads the navigation state. The app is on `LoginScreen`, but the cart badge lives on `HomeScreen`.
+- It finds a saved `user-login` action whose recorded outcome is "logged-in home."
+- It runs `user-login` (~4 seconds), arrives at `HomeScreen`.
+- Then it discovers the cart badge interactively and taps it.
+
+This is the **hybrid composition** pattern. Actions cover the predictable parts (login, onboarding, locale switching, subscription gates) so the agent only spends time on the part that's actually new.
+
+## What actions are NOT
+
+- **Not a magic auto-tester.** Self-repair handles small UI drift; it doesn't fix broken features.
+- **Not a replacement for hand-written E2E tests.** If you maintain a `.maestro/` suite for CI, the plugin doesn't touch it. Actions and your team's E2E suite live separately.
+- **Not isolated from your project.** Actions live in `.rn-agent/actions/`, alongside the skeleton and other plugin-managed files. Commit them — they're as much a part of your project as `__tests__/`.
+
+## See also
+
+- [`/rn-dev-agent:test-feature`](../commands/test-feature/) — the command that records actions
+- [`/rn-dev-agent:list-learned-actions`](../commands/list-learned-actions/) — list saved actions
+- [`/rn-dev-agent:run-action`](../commands/run-action/) — replay an action by name
+- [`/rn-dev-agent:setup`](../commands/setup/) — scaffolds `.rn-agent/` and the dev-bridge
+- [Architecture](../architecture/) — where actions sit in the three-layer model

--- a/docs-site/src/content/docs/architecture.mdx
+++ b/docs-site/src/content/docs/architecture.mdx
@@ -1,9 +1,48 @@
 ---
 title: Architecture
-description: Three-layer architecture — device interaction, app introspection, and E2E testing.
+description: How the plugin is organized — three product layers (workflow, discovery, replayable actions) and the implementation underneath.
 ---
 
-## Three-layer model
+## Three layers — the product model
+
+The plugin is organized into three layers. Each one has a different job and gets used at a different point in the loop.
+
+| Layer | Job | Examples |
+|---|---|---|
+| **Workflow** | Decides what to do; gates quality | `/rn-feature-dev` 8-phase pipeline; the rn-tester / rn-debugger / rn-code-architect agent protocols |
+| **Discovery** | Looks at the running app to know what's there | CDP tools (`cdp_component_tree`, `cdp_store_state`, `cdp_navigation_state`, `cdp_evaluate`); device tools (`device_press`, `device_fill`, `device_snapshot`, `device_screenshot`) |
+| **Reproducible actions** | Replays known flows in seconds; self-repairs on UI drift | `.rn-agent/actions/<name>.yaml`; `cdp_run_action` orchestrator; `cdp_repair_action` selector patcher; [actions guide](actions/) |
+
+```
+        ┌──────────────────────────────────────┐
+        │   Workflow (rn-feature-dev, agents)   │
+        │   Decides WHAT, gates quality         │
+        └────────┬───────────────────┬─────────┘
+                 │ "verify this"     │ "produce/replay flow"
+                 ▼                   ▼
+   ┌─────────────────────┐  ┌──────────────────────┐
+   │      Discovery      │  │       Actions        │
+   │  Empirical reality  │  │  Replay in seconds   │
+   │  CDP + device tools │  │  Self-repair on drift│
+   │  Macro-Asserts      │◄─┤                      │
+   └─────────────────────┘  └──────────────────────┘
+                 ▲                   │
+                 │  Discovery emits  │
+                 └─── new actions ───┘
+                      Actions repair via Discovery
+```
+
+### Why this matters: replay vs. interactive walks
+
+On a known 3-step task-creation wizard, an interactive agent walk took **13 minutes 55 seconds**. The same wizard, replayed as a saved action, finished in **~4 seconds** — a ~210× speedup. That's the load-bearing data point behind the architecture: discovery tools are how the agent finds new ground; actions are how it replays known ground without paying that cost again.
+
+The agent doesn't choose all-or-nothing. If you're on the login screen and need to do something on home, the agent runs the saved login action as a prologue (4 seconds), then discovers the new work interactively. See [actions](actions/) for the full hybrid composition pattern.
+
+---
+
+## Implementation layers — how it's built
+
+The product layers above are organized; underneath, three implementation layers do the work.
 
 ```
 ┌─────────────────────────────────────────────────────┐
@@ -16,7 +55,7 @@ description: Three-layer architecture — device interaction, app introspection,
 │  ┌──────▼───▼────────────▼─────────────────▼──────┐ │
 │  │              MCP Server (CDP Bridge)            │ │
 │  │  WebSocket → Metro → Hermes CDP                 │ │
-│  │  38 tools: CDP + device + testing               │ │
+│  │  70+ tools: CDP + device + testing              │ │
 │  └─────────────────────┬───────────────────────────┘ │
 │                        │                             │
 │  ┌─────────────────────▼───────────────────────────┐ │
@@ -31,11 +70,11 @@ description: Three-layer architecture — device interaction, app introspection,
     └─────────┘                   └───────────┘
 ```
 
-| Layer | Tool | Role |
+| Implementation tier | Tool | Role |
 |-------|------|------|
 | **Device interaction** | agent-device CLI (auto-installed) | Cross-platform native device control: tap, swipe, fill, find, snapshot, screenshot |
 | **App introspection** | Custom MCP server → Hermes CDP via WebSocket | Persistent WebSocket — reads React fiber tree, store state, network, console, errors |
-| **E2E testing** | maestro-runner (preferred) / Maestro (fallback) | YAML-based persistent test files for CI |
+| **E2E testing** | maestro-runner (preferred) / Maestro (fallback) | YAML-based persistent test files; underlying format for actions in `.rn-agent/actions/` |
 
 Fallback: `xcrun simctl` (iOS) + `adb` (Android) for device lifecycle when agent-device is unavailable.
 
@@ -43,10 +82,11 @@ Fallback: `xcrun simctl` (iOS) + `adb` (Android) for device lifecycle when agent
 
 The MCP server is a Node.js process that maintains a persistent WebSocket connection to the React Native app's Hermes engine through Metro's CDP endpoint.
 
-**38 tools** in three categories:
-- **19 CDP tools** — React internals via Chrome DevTools Protocol
-- **14 device tools** — Native interaction via agent-device CLI
-- **5 testing/composite tools** — Maestro flows, proof capture, auto-login
+**70+ tools** across four families:
+- **CDP** — React internals via Chrome DevTools Protocol (component tree, store state, navigation, profiling, network)
+- **Device** — Native interaction via agent-device CLI (tap, swipe, fill, snapshot, screenshot)
+- **Testing** — Action replay, proof capture, auto-login, cross-platform verify
+- **Macro-Asserts** — State-assertive replays (`expect_redux`, `expect_route`, `expect_visible_by_testid`, `expect_text`)
 
 All tools are registered through a single `trackedTool()` wrapper that adds telemetry via the Experience Engine.
 

--- a/docs-site/src/content/docs/commands/doctor.mdx
+++ b/docs-site/src/content/docs/commands/doctor.mdx
@@ -1,0 +1,70 @@
+---
+title: doctor
+description: Read-only environment diagnostic — checks 11 prerequisites and reports what's missing without modifying your project.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+`/doctor` reports; [`/setup`](../setup/) fixes and instruments. Use `/doctor` when you want diagnostics without changing files.
+
+## Usage
+
+```
+/rn-dev-agent:doctor
+```
+
+## What it checks
+
+A dozen prerequisites, presented as a single table:
+
+| # | Check | Required | Auto-install possible (via `/setup`) |
+|---|-------|----------|---------------------------------------|
+| 1 | Node.js >= 22 LTS | Yes | No (user must install) |
+| 2 | CDP bridge dependencies | Yes | Yes |
+| 3 | agent-device CLI | Yes | Yes |
+| 4 | maestro-runner | Yes | Yes |
+| 5 | iOS Simulator booted | One platform | No |
+| 6 | Android Emulator running | One platform | No |
+| 7 | Metro dev server | Yes | No (you start it) |
+| 8 | CDP connection reachable | Yes | Auto via `cdp_status` |
+| 9 | Injected `__RN_AGENT` helpers fresh | Yes | Auto on connect |
+| 10 | ffmpeg | Optional | No |
+| 11 | Physical-device prerequisites | Optional | No |
+| 12 | Vercel rules sync freshness | Optional | Yes (re-sync on stale) |
+
+For every red row, `/doctor` prints the exact install command tailored to your environment (e.g., the right `nvm`/`brew` flag).
+
+<Aside type="note" title="`/doctor` is read-only">
+`/doctor` does not modify your project. It does not append to `CLAUDE.md`, scaffold `.rn-agent/`, or change source code. To do those things, run [`/setup`](../setup/) instead.
+</Aside>
+
+## When to run
+
+- After SessionStart shows WARNING messages
+- When `cdp_status` fails to connect
+- When `device_*` tools start failing
+- Before reporting a plugin bug — paste the table into the issue
+
+## Example output
+
+```
+| Check                  | Status                | Action Needed                          |
+|------------------------|-----------------------|----------------------------------------|
+| Node.js                | OK (v22.15.0)         | —                                      |
+| CDP bridge             | OK                    | —                                      |
+| agent-device           | MISSING               | Run /rn-dev-agent:setup to install     |
+| maestro-runner         | OK (v1.0.9)           | —                                      |
+| iOS Simulator          | BOOTED (iPhone 16)    | —                                      |
+| Android emulator       | NOT RUNNING           | Boot one if you need Android coverage  |
+| Metro                  | RUNNING (port 8081)   | —                                      |
+| CDP connection         | CONNECTED             | —                                      |
+| __RN_AGENT helpers     | FRESH (v16)           | —                                      |
+| ffmpeg                 | OK (v7.1)             | —                                      |
+| Physical device        | NONE CONNECTED        | Skip if testing on simulator only      |
+```
+
+## See also
+
+- [`/setup`](../setup/) — onboarding sibling that fixes what `/doctor` reports
+- [`/check-env`](../check-env/) — quicker, narrower readiness check
+- [Troubleshooting](../../troubleshooting/) — common issues and fixes

--- a/docs-site/src/content/docs/commands/list-learned-actions.mdx
+++ b/docs-site/src/content/docs/commands/list-learned-actions.mdx
@@ -1,0 +1,46 @@
+---
+title: list-learned-actions
+description: List the agent's saved actions, memories, and helpers available in your project.
+---
+
+Show what's available to the agent in this project — saved actions, cross-session memories, the UI skeleton, and plugin commands. Pair with [`/run-action`](../run-action/) to replay one.
+
+## Usage
+
+```
+/rn-dev-agent:list-learned-actions [keyword]
+```
+
+The optional keyword filters all sections by substring match (case-insensitive).
+
+## Examples
+
+```
+/rn-dev-agent:list-learned-actions
+/rn-dev-agent:list-learned-actions login
+/rn-dev-agent:list-learned-actions cart
+```
+
+## What it shows
+
+Four sections, each scoped to the current project:
+
+| Section | What it lists | Source |
+|---|---|---|
+| **A. Memories** | Past feedback the agent persisted across sessions | `~/.claude/projects/<encoded-cwd>/memory/feedback_*.md` |
+| **B. Actions** | Saved replay-ready flows | `.rn-agent/actions/<name>.yaml` |
+| **C. UI skeleton** | Semantic-name → testID map | `.rn-agent/skeleton.yaml` |
+| **D. Plugin commands** | Slash commands the plugin exposes | from the plugin manifest |
+
+## When to run
+
+- At the start of a task, before composing manual `device_*` walks — reuse what's there
+- To find the right action name to pass to `/run-action`
+- When debugging — see what memories the agent has accumulated
+- During onboarding — confirms `/setup` scaffolded the project successfully
+
+## See also
+
+- [`/run-action`](../run-action/) — replay an action by name
+- [Actions](../../actions/) — what saved actions are and how the agent uses them
+- [`/test-feature`](../test-feature/) — record a new action

--- a/docs-site/src/content/docs/commands/run-action.mdx
+++ b/docs-site/src/content/docs/commands/run-action.mdx
@@ -1,0 +1,58 @@
+---
+title: run-action
+description: Replay a saved action by name. Self-repairs small UI drift; doesn't fix broken product logic.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Replay a saved action — login, navigate to a screen, complete a multi-step flow — in seconds. Counterpart to [`/list-learned-actions`](../list-learned-actions/), which discovers what's available.
+
+## Usage
+
+```
+/rn-dev-agent:run-action <name> [-e KEY=VALUE ...] [--platform ios|android] [--dry-run]
+```
+
+## Examples
+
+```
+/rn-dev-agent:run-action wizard-create-task -e TITLE="Buy milk" -e PRIORITY=high
+/rn-dev-agent:run-action user-login --platform android
+/rn-dev-agent:run-action mark-all-done --dry-run
+```
+
+## How match works
+
+The first argument is matched against action filenames in `.rn-agent/actions/` (substring, case-insensitive). If the match is unique, replay starts immediately. If multiple actions match, the plugin prints the candidates and asks for disambiguation. If none match, it offers the closest alternatives.
+
+## Parameters
+
+- `-e KEY=VALUE` — fills `${KEY}` placeholders inside the action body. Repeatable.
+- `--platform ios|android` — picks a target platform when both are booted. Auto-detected if only one is running.
+- `--dry-run` — print the resolved replay command without executing.
+
+## Self-repair
+
+If a step fails because a `testID` was renamed, the plugin uses the live UI to find the new name, patches the action YAML, and retries.
+
+<Aside type="caution" title="What self-repair does — and doesn't">
+- **Handles:** small UI drift (renamed `testID`, slightly moved element).
+- **Does not handle:** broken product logic, missing buttons, removed screens, structurally changed flows.
+- **Refuses on hand-edited files** (`mtime` check) — to keep your edits intact.
+- **Refuses after 3 repairs** on the same action in 24h — to avoid runaway patching.
+
+If repair is refused or fails, the plugin asks before forcing. If the underlying flow has changed structurally, re-record with [`/test-feature`](../test-feature/).
+</Aside>
+
+## When to run
+
+- The agent uses this internally when it detects a known starting state (e.g., logged-in home) is needed before doing new work
+- You can also call it directly to validate an action still works after a code change
+- During development, to skip past login or onboarding when iterating on a downstream screen
+
+## See also
+
+- [Actions](../../actions/) — full guide to what an action is and how the agent uses them
+- [`/list-learned-actions`](../list-learned-actions/) — list available actions in this project
+- [`/test-feature`](../test-feature/) — record a new action
+- [Troubleshooting → Action replay fails](../../troubleshooting/#actions-and-setup) — when self-repair refuses or runs out of attempts

--- a/docs-site/src/content/docs/commands/setup.mdx
+++ b/docs-site/src/content/docs/commands/setup.mdx
@@ -1,6 +1,6 @@
 ---
 title: setup
-description: Check and install all rn-dev-agent prerequisites with automatic retry and manual fallback instructions.
+description: Onboard the plugin into your project — diagnose, then inject the CLAUDE.md template, scaffold .rn-agent/, and add the dev-only bridge.
 ---
 
 ## Usage
@@ -11,28 +11,25 @@ description: Check and install all rn-dev-agent prerequisites with automatic ret
 
 ## What it does
 
-Runs a 9-point environment checklist. For each missing dependency, it attempts automatic installation. If that fails, it provides manual instructions.
+`/setup` does two things in sequence: diagnoses your environment, then proposes the project-side wiring the plugin needs. Each proposed change is shown as a diff and asks for confirmation before writing.
 
-## Checklist
+| Phase | Step | Action |
+|---|---|---|
+| 1. Diagnose | A | Run [`/doctor`](../doctor/) — check Node, CDP bridge, agent-device, maestro-runner, simulators, Metro, ffmpeg |
+| 2. Inject | B | Append the plugin's tool-routing rules to your project `CLAUDE.md` (or create one) |
+| 2. Inject | C | Add a small dev-only bridge call to your app entry — exposes the navigation ref + Zustand stores in `__DEV__` only |
+| 2. Inject | D | Scaffold `.rn-agent/` — the plugin's home in your project (README, `.gitignore`, `dev-bridge.ts`, `globals.d.ts`, starter folders) |
+| 2. Verify | E | Run `cdp_status` to confirm the bridge is reachable |
 
-| # | Check | Required | Auto-install |
-|---|-------|----------|-------------|
-| 1 | Node.js >= 22 LTS | Yes | No (user must install) |
-| 2 | CDP bridge dependencies | Yes | Yes (`npm install`) |
-| 3 | agent-device CLI | Yes | Yes (`npm install -g agent-device`) |
-| 4 | maestro-runner | Yes | Yes (curl installer) |
-| 5 | iOS Simulator booted | One platform | No |
-| 6 | Android Emulator running | One platform | No |
-| 7 | Metro dev server | Yes | No (user starts) |
-| 8 | CDP connection | Yes | Auto via `cdp_status` |
-| 9 | ffmpeg | Optional | No |
+Re-running `/setup` is idempotent. Already-applied blocks are detected and skipped — safe to run any time you want to confirm everything is wired.
 
 ## When to run
 
-- First time using the plugin
+- First time using the plugin in a project
 - After SessionStart shows WARNING messages
 - When `cdp_status` fails to connect
 - When `device_*` tools fail
+- After cloning a project that already had `/setup` run by someone else (will detect existing wiring and skip)
 
 ## Example output
 
@@ -48,4 +45,15 @@ Runs a 9-point environment checklist. For each missing dependency, it attempts a
 | Metro           | RUNNING (port 8081)   | —                                       |
 | CDP connection  | CONNECTED             | —                                       |
 | ffmpeg          | OK (v7.1)             | —                                       |
+
+CLAUDE.md           — append plugin tool-routing rules?    [diff shown] (y/n)
+App entry           — add getBridge()?.registerNavRef(...)? [diff shown] (y/n)
+App entry           — add getBridge()?.registerStores(...)? [diff shown] (y/n)
+.rn-agent/          — scaffold (8 files)?                    [list shown] (y/n)
 ```
+
+## See also
+
+- [`/doctor`](../doctor/) — read-only diagnostic sibling. `/doctor` reports; `/setup` fixes and instruments.
+- [Getting Started](../../getting-started/) — installation and first run
+- [Actions](../../actions/) — what `.rn-agent/` is for after `/setup` scaffolds it

--- a/docs-site/src/content/docs/commands/test-feature.mdx
+++ b/docs-site/src/content/docs/commands/test-feature.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-Test an already-implemented feature on the running simulator or emulator. Verifies UI rendering, user flows, and internal state, then generates a persistent Maestro test file for CI.
+Test an already-implemented feature on the running simulator or emulator. Verifies UI rendering, user flows, and internal state, then saves the verified walk as a replayable [action](../../actions/) under `.rn-agent/actions/`.
 
 ## Usage
 
@@ -31,12 +31,12 @@ Test an already-implemented feature on the running simulator or emulator. Verifi
 | 4 | **Navigate to start** — use deep links or navigation to reach the starting screen |
 | 5 | **Execute and verify** — for each step: act, wait, verify UI via `cdp_component_tree`, verify data via `cdp_store_state` |
 | 6 | **Edge cases** — test empty state, error state, back navigation, rapid interactions |
-| 7 | **Generate persistent test** — write `flows/<feature-name>.yaml` Maestro flow for CI |
+| 7 | **Save the verified walk as an action** — write `.rn-agent/actions/<feature-slug>.yaml` so the next session replays it in seconds via `/run-action` |
 
 ## Output
 
 - Pass/fail summary with evidence (screenshots, component tree snapshots, store state)
-- A `flows/<feature-name>.yaml` Maestro flow file written to the repo
+- A new action at `.rn-agent/actions/<feature-slug>.yaml` — see [Actions](../../actions/) for what to do with it
 
 ## When to Use
 
@@ -49,4 +49,4 @@ Test an already-implemented feature on the running simulator or emulator. Verifi
 - iOS Simulator or Android Emulator running with the app loaded
 - Metro dev server running
 - Maestro or maestro-runner installed
-- For Zustand apps: `if (__DEV__) global.__ZUSTAND_STORES__ = { ... }` in app entry
+- For Zustand apps: `getBridge()?.registerStores({ ... })` in app entry — `/rn-dev-agent:setup` proposes this automatically

--- a/docs-site/src/content/docs/getting-started.mdx
+++ b/docs-site/src/content/docs/getting-started.mdx
@@ -54,19 +54,23 @@ Manual update:
 
 The plugin connects to your running app via Metro's CDP endpoint and reads the React fiber tree directly.
 
-### Zustand stores (one line)
+### Zustand stores (one bridge call)
+
+`/rn-dev-agent:setup` scaffolds `.rn-agent/dev-bridge.ts` and `.rn-agent/globals.d.ts` into your project. Then add a single registration call alongside your store definitions:
 
 ```typescript
 // App.tsx or app/_layout.tsx
-if (__DEV__) {
-  global.__ZUSTAND_STORES__ = {
-    auth: useAuthStore,
-    cart: useCartStore,
-  };
-}
+import { getBridge } from './.rn-agent/dev-bridge';
+
+getBridge()?.registerStores({
+  auth: useAuthStore,
+  cart: useCartStore,
+});
 ```
 
-Zero production cost — stripped in release builds.
+No `__DEV__` guard at the call site — `getBridge()` returns `null` in production and the optional chain is a no-op. Zero production cost. The bridge handles the dev-only global assignment internally.
+
+`/rn-dev-agent:setup` proposes this edit automatically; you don't have to write it by hand.
 
 ### Redux
 
@@ -82,24 +86,19 @@ Add `testID` to interactive elements for reliable component queries:
 </Pressable>
 ```
 
-## Recommended: Add to your CLAUDE.md
+## Project instructions: let `/setup` do it
 
-Copy this into your project's `CLAUDE.md` to ensure Claude uses CDP tools:
+`/rn-dev-agent:setup` injects the plugin's tool-routing rules into your project's `CLAUDE.md` automatically. It also scaffolds the bridge files and the `.rn-agent/` directory in one pass.
 
-```markdown
-## React Native Development (rn-dev-agent)
+The injection is idempotent — re-running `/setup` skips already-applied blocks.
 
-### Tool Usage Rules
-- ALWAYS use CDP MCP tools instead of raw bash commands
-- ALWAYS call cdp_status first before any app interaction
-- NEVER use xcrun simctl openurl for navigation
-- For UI interaction, use device_find/device_press — not simctl or adb input
+If you want to inspect the rules first, see [the CLAUDE.md template](https://github.com/Lykhoyda/rn-dev-agent/blob/main/CLAUDE-MD-TEMPLATE.md) — the body after the `---` separator is what gets appended to your project's `CLAUDE.md`.
 
-### Key Commands
-- /rn-dev-agent:rn-feature-dev <description> — Full 8-phase pipeline
-- /rn-dev-agent:check-env — Verify environment
-- /rn-dev-agent:debug-screen — Diagnose current screen
-```
+## Your agent's saved flows live in `.rn-agent/`
+
+The plugin's home in your project is `.rn-agent/`. Saved actions, the UI skeleton, navigation graph, and runtime state all live there. `/setup` scaffolds the directory; [`/doctor`](commands/doctor/) reports on its health.
+
+See the [Actions guide](actions/) for what an action is, how to record one, and how the agent uses them.
 
 ## First run
 

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -9,7 +9,7 @@ hero:
       link: /rn-dev-agent/getting-started/
       icon: right-arrow
       variant: primary
-    - text: Browse 51 Tools
+    - text: Browse the tool reference
       link: /rn-dev-agent/tools/
       variant: minimal
 ---
@@ -22,8 +22,11 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
   <Card title="Live Verification" icon="approve-check">
     After implementing a feature, Claude connects to your running app via CDP, navigates to the screen, checks the component tree, exercises interactions, and confirms store state — no "trust me it works."
   </Card>
-  <Card title="51 MCP Tools" icon="setting">
-    24 CDP tools for React internals (component tree, store state, navigation, profiling), 14 device tools for native interaction (tap, swipe, type, scroll), and 13 testing/composite tools (Maestro, proof capture, cross-platform verify).
+  <Card title="Live introspection MCP tools" icon="setting">
+    CDP tools for React internals (component tree, store state, navigation, profiling), device tools for native interaction (tap, swipe, type, scroll), testing tools for replay and proof capture, and Macro-Asserts for state-assertive checks.
+  </Card>
+  <Card title="Replayable actions" icon="rocket">
+    Saved app flows in `.rn-agent/actions/` that replay in seconds. The plugin records them automatically when verification passes; the agent uses them as prologues (e.g. login) before doing new work. [Learn more](/rn-dev-agent/actions/).
   </Card>
   <Card title="8-Phase Pipeline" icon="list-format">
     `/rn-feature-dev` runs discovery, exploration, questions, architecture, implementation, live verification, code review, and E2E proof — from description to verified code.

--- a/docs-site/src/content/docs/troubleshooting.mdx
+++ b/docs-site/src/content/docs/troubleshooting.mdx
@@ -26,12 +26,17 @@ This is normal. `cdp_reload` automatically reconnects within 15 seconds. If it f
 ## Store state issues
 
 <Aside type="tip" title="cdp_store_state error for Zustand">
-Add a one-line setup to your app entry:
+Run `/rn-dev-agent:setup` — it scaffolds the dev-bridge and proposes a `getBridge()?.registerStores({ ... })` line in your app entry. The bridge call replaces the older `globalThis.__ZUSTAND_STORES__` pattern.
+
+Manual fallback if you want to wire it yourself:
 
 ```typescript
-if (__DEV__) {
-  global.__ZUSTAND_STORES__ = { auth: useAuthStore, cart: useCartStore };
-}
+import { getBridge } from './.rn-agent/dev-bridge';
+
+getBridge()?.registerStores({
+  auth: useAuthStore,
+  cart: useCartStore,
+});
 ```
 
 Redux is auto-detected — no setup needed.
@@ -91,4 +96,22 @@ Ensure the emulator is booted and `adb devices` shows it. The plugin auto-select
 
 <Aside type="tip" title="Maestro gRPC error on Android">
 Use maestro-runner instead of classic Maestro — it uses HTTP to UIAutomator2 instead of gRPC. The plugin enforces this by default.
+</Aside>
+
+## Actions and setup
+
+<Aside type="tip" title="Action replay fails with SELECTOR_NOT_FOUND">
+The plugin attempts to self-repair small UI drift: it looks at the live UI, finds the renamed `testID` via fuzzy match, patches the action YAML, and retries.
+
+Self-repair refuses if the file has been hand-edited (mtime check), or after 3 repairs in 24h. If repair is refused or fails, the plugin asks before forcing. If the underlying flow has changed structurally (extra step, removed screen), re-record with `/rn-dev-agent:test-feature`.
+
+See the [Actions guide](/rn-dev-agent/actions/) for full details.
+</Aside>
+
+<Aside type="tip" title="`/setup` skipped a step">
+Re-run `/rn-dev-agent:setup`. It's idempotent — already-injected blocks are detected and skipped, so only the missing pieces get applied.
+</Aside>
+
+<Aside type="tip" title=".rn-agent/state/ showing up in git status">
+That directory holds runtime state (run history, repair history) — not config. Check that `.rn-agent/.gitignore` exists and contains `state/`, `recordings/`, `snapshots/`, `diag/`, `index.json`. The `/setup` scaffold ships this file; if it's missing, regenerate via `/setup` (idempotent — only the missing pieces are added).
 </Aside>

--- a/templates/rn-agent/README.md
+++ b/templates/rn-agent/README.md
@@ -1,18 +1,19 @@
 # `.rn-agent/` — `rn-dev-agent` plugin home
 
-This directory is the home for everything the
-[`rn-dev-agent`](https://github.com/Lykhoyda/rn-dev-agent) Claude Code
-plugin reads or writes in your project. One folder, one doctrine.
+This directory is the **plugin's home in your project**. Files here are
+managed by the [`rn-dev-agent`](https://github.com/Lykhoyda/rn-dev-agent)
+Claude Code plugin. One folder, one doctrine — the plugin's entire
+footprint is `.rn-agent/` and it does not read or write anywhere else
+in your project.
 
-If your project has a `.maestro/` folder for hand-authored E2E tests,
-that's yours alone — the plugin treats it as out of scope. The single
-intentional carve-out is `cdp_auto_login`, which reads user-authored
-login subflows from `<project>/.maestro/subflows/login.yaml` (and
-`sign_in.yaml`, `auth.yaml`, `register_user.yaml`, `flow_start.yaml`)
-when the app is on a login screen — that's a *read* of user-managed
-content, not plugin territory. To migrate this carve-out into
-`.rn-agent/`, see issue tracker; until then, login subflows live in
-`.maestro/subflows/`.
+If your project also has a `.maestro/` folder for hand-authored E2E
+tests, that's yours alone. The plugin doesn't read it.
+
+> **One small exception:** if the agent lands on a login screen and
+> finds a `.maestro/subflows/login.yaml` (or `sign_in.yaml`,
+> `auth.yaml`, `register_user.yaml`, `flow_start.yaml`), it can use
+> that subflow to log in. This is a read of *your* content, not plugin
+> territory.
 
 ## Layout
 
@@ -23,8 +24,8 @@ content, not plugin territory. To migrate this carve-out into
 ├── .scaffold-version      ← plugin scaffold version (commit)
 ├── skeleton.yaml          ← semantic-name → testID map (commit)
 ├── nav-graph.yaml         ← cached navigation graph (commit, auto-managed)
-├── actions/               ← reusable Maestro flows (commit)
-│   └── *.yaml               each carries an M7 metadata header + sidecar
+├── actions/               ← saved replayable flows (commit)
+│   └── *.yaml               each has a metadata header + state sidecar
 ├── fixtures/              ← seed data for replay (commit)
 ├── proposals/             ← repair proposals queued for review (commit)
 ├── state/                 ← runtime state per action (gitignore)
@@ -66,12 +67,13 @@ other than `SELECTOR_NOT_FOUND` escalate without auto-fix.
 
 The report is informational; deletion stays a deliberate human gesture.
 
-## Refs
+## Learn more
 
-- Workspace: `docs/DECISIONS.md` — D1208 (single-folder doctrine,
-  supersedes D1207), D1206 (three-layer architecture)
-- Plugin commands: `/rn-dev-agent:list-learned-actions`,
-  `/rn-dev-agent:run-action`, `/rn-dev-agent:rn-agent-compact`,
-  `/rn-dev-agent:rn-agent-export`, `/rn-dev-agent:rn-agent-import`
-- Plugin: `scripts/learned-actions.mjs`,
-  `scripts/cdp-bridge/src/domain/action-store.ts`
+- [Actions guide](https://lykhoyda.github.io/rn-dev-agent/actions/) —
+  what actions are and how the agent uses them
+- [`/rn-dev-agent:list-learned-actions`](https://lykhoyda.github.io/rn-dev-agent/commands/list-learned-actions/) —
+  see what's saved in this project
+- [`/rn-dev-agent:run-action`](https://lykhoyda.github.io/rn-dev-agent/commands/run-action/) —
+  replay a saved action
+- [`/rn-dev-agent:rn-agent-compact`](https://lykhoyda.github.io/rn-dev-agent/commands/rn-agent-compact/) —
+  surface stale or flaky actions for review


### PR DESCRIPTION
## Summary

Brings user-facing docs up to three recent decisions on the workspace side, all framed in plain language for the end-user audience. No D-numbers in user copy; no "L3 corpus" or "M7 metadata" jargon. The user-facing noun is **action**.

- **Three-layer architecture** is now the canonical mental model: Workflow / Discovery / Reproducible Actions.
- **`.rn-agent/` is the plugin's only home in your project.** No second territory; `/promote-action` is gone.
- **Actions are composable skill primitives** — the agent runs a saved login action automatically before doing new work on a downstream screen, instead of re-walking login interactively.

13 files: 5 surgical edits + 1 expanded stub + 4 new docs-site pages + 1 doctrine sub-section + 1 README rewrite + 1 shipping-template rewrite.

## What changed (per file)

### `README.md`
- Strapline tool count `74` → `70+`; command count `17` → `16` (D1208 deleted `/promote-action`)
- New **Actions: replayable app flows** table replaces the M7 / L3 self-healing corpus header
- Line 80 fix: `.maestro/flows` → `.rn-agent/actions/`
- MCP-tool taxonomy table moves to prose with a tools-reference link (counts drift)
- "What's new" entries: rephrase to drop M7 / L3-corpus vocabulary; relegate D-numbers to changelog/architecture only

### `CLAUDE-MD-TEMPLATE.md`
- New **Hybrid composition** sub-section under Mandatory Pre-flight: state-detection prologue → action-as-prologue → walk only the gap
- Worked example: LoginScreen → `user-login` action (`produces: { authenticated: true, route: home }`) → cart-badge tap
- The `produces:` field is documented **here only** — audience is the agent reading the template

### `docs-site` — 6 edits + 4 new pages
**NEW**:
- `actions/index.mdx` — canonical concept page (where actions live, how to create/list/run, self-repair plain-language explanation, hybrid composition walkthrough)
- `commands/doctor.mdx` — 12-row diagnostic table; "/doctor reports, /setup fixes" framing
- `commands/list-learned-actions.mdx` — listing semantics + section taxonomy
- `commands/run-action.mdx` — `<name> [-e KEY=VALUE] [--platform] [--dry-run]`; honest self-repair caveat ("small UI drift, not broken product logic")

**Edits**:
- `getting-started.mdx` — `getBridge()?.registerStores(...)` replaces stale `__ZUSTAND_STORES__`; pointer to `/setup`; new "saved flows live in `.rn-agent/`" section
- `architecture.mdx` — D1206 product layers (Workflow / Discovery / Reproducible Actions) lead; original implementation-layers diagram retained as "How it's built" sub-section. Adds the 13:55 → 4s benchmark callout (the load-bearing data point behind the architecture)
- `commands/test-feature.mdx` — Step 7 path `flows/<name>.yaml` → `.rn-agent/actions/<feature-slug>.yaml`; reword "Generate persistent test" → "Save the verified walk as an action"
- `commands/setup.mdx` — expand from stub to Phase 1 (diagnose) + Phase 2 (inject CLAUDE.md / dev-bridge / `.rn-agent/` scaffold) walkthrough; cross-link to `/doctor`
- `index.mdx` — soften "51 MCP Tools" hero copy; new **Replayable actions** card linking to `/actions/`
- `troubleshooting.mdx` — three new entries (action replay self-repair, `/setup` re-run idempotency, `.rn-agent/state/` accidentally tracked); fix Zustand recipe to use the bridge call

### `templates/rn-agent/README.md` (the shipping per-project README)
- Single-folder doctrine phrased positively ("plugin's home in your project")
- Drop "team territory" framing of `.maestro/`; the plugin doesn't read it
- Drop M7-metadata vocabulary; replace D-number Refs with user-facing links to `lykhoyda.github.io`
- Demote `cdp_auto_login` carve-out from prominent paragraph to a short pull-quote

## Decisions made for end-user copy

| Decision | Reason |
|---|---|
| No D-numbers in user-facing files | They're internal ADR identifiers — meaningless to end users |
| Soften hardcoded counts (`70+ tools`, "the full command list") | Counts drift the moment any tool changes; three pages currently disagree on the number |
| `produces:` schema mentioned only in CLAUDE-MD-TEMPLATE | The agent benefits from the schema; end users don't need to know the field name to use actions |
| Self-repair always paired with the "small UI drift, not broken product logic" caveat | Prevents the "why didn't the agent fix my actually-broken feature" support burden |
| "Maestro" never appears as the user-facing brand for actions | "Action" is the noun; Maestro is the underlying YAML format, mentioned only in `architecture.mdx` |

## Test plan

- [x] `cd docs-site && npm run build` — clean (158 pages built, all 4 new pages rendered)
- [x] `grep -r '/promote-action'` in user-facing files — zero hits
- [x] `grep -rE 'D11[0-9][0-9]|D12[0-9][0-9]'` in `README.md`, `templates/rn-agent/README.md`, user-facing docs-site pages — zero hits (D-numbers remain only in changelog and tool-reference pages, which are appropriate)
- [x] `grep -r '\.maestro/flows'` in user-facing files — zero hits
- [ ] Reviewer: render plugin `README.md` on GitHub preview, confirm Actions table reads cleanly
- [ ] Reviewer: smoke test — fresh `/setup` in a scratch project; confirm scaffolded `.rn-agent/README.md` reads correctly post-rewrite

## Companion PR

The workspace repo (`Lykhoyda/rn-dev-agent-workspace`) gets a parallel docs PR adding a top-level `README.md` (orienting visitors: "this is the dev workspace, plugin source is at the sibling repo"), bringing `test-app/.rn-agent/README.md` up to D1208, and appending a Phase 133 entry to `docs/ROADMAP.md`. Spec for both PRs lives at `docs/superpowers/specs/2026-05-07-docs-update-actions-design.md` in that repo.

## Rebase note

This PR's commit (`a1e11d5`) is a cherry-pick of `12d1a91`, which originally landed on `feat/vercel-skills-integration-spec` due to a parallel-session branch-switch race during the docs work. The cherry-pick is identical content; both copies will collapse to one when this PR merges (whichever lands second is detected as already-applied by git).

🤖 Generated with [Claude Code](https://claude.com/claude-code)