### PR TITLE
fix(setup): correct Anti-pattern #4 — bridge handles __DEV__ guard internally

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -194,7 +194,7 @@ Tell the user up-front when nothing needs to be injected.
 1. Modify any file without showing the diff first.
 2. Inject without checking for the existing marker — duplicating the template would bloat the user's CLAUDE.md.
 3. Skip the user-confirmation prompt — they may have customized their `NavigationContainer` setup in a way the auto-injection would clobber.
-4. Inject the nav-ref or store-exposure snippets without the `if (__DEV__)` guard — exposing nav refs / store hooks in production is a real footgun.
+4. Wrap the `getBridge()?.registerNavRef(...)` / `registerStores(...)` call sites in a `if (__DEV__)` block. The dev-bridge file (Step D scaffolds `.rn-agent/dev-bridge.ts`) handles the `__DEV__` gate internally and returns `null` in production — wrapping again at the call site makes the `getBridge()?.` optional chain a dead branch in dev and breaks the documented Steps B.3 / C.4 examples. Trust the bridge's internal guard.
 5. Use `xcrun simctl` / `adb` for diagnostics — Phase 1 delegates to the `rn-setup` skill, which uses the proper detection commands.
 6. Overwrite any file inside `<cwd>/.rn-agent/` during partial-add. The user may have hand-edited `skeleton.yaml`, `actions/*.yaml`, or `nav-graph.yaml` between scaffolds — only add files that don't already exist.
 7. Use `cp -r src/* dst/` for the scaffold copy. The glob skips dotfiles on some shells; `.gitignore` and `.scaffold-version` would silently disappear. Use `cp -RL src/. dst/` (note the trailing `/.`) or Node's `fs.cpSync(src, dst, { recursive: true })`.


### PR DESCRIPTION
## Summary

`commands/setup.md` Anti-pattern #4 contradicted the prescribed code shape in Steps B.3 (line 77) and C.4 (line 111). Steps B/C deliberately omit the call-site \`if (__DEV__)\` guard because the dev-bridge file (\`.rn-agent/dev-bridge.ts\`, scaffolded by Step D) implements the \`__DEV__\` gate internally — \`getBridge()\` returns \`null\` in production, making the \`getBridge()?.registerNavRef(...)\` optional chain the right pattern.

## Why this matters

Following the old anti-pattern would make an agent:
- Flag its own prescribed code as wrong, or
- Wrap call sites in \`__DEV__\`, which turns the documented optional chain into a dead branch in dev (the bridge is non-null there)

## How it was caught

Phase 6 quality-review reviewer-3 found this while reading \`setup.md\` end-to-end during the \`feat/vercel-skills-integration-spec\` review. Pre-existing in setup.md before the Vercel work; surfaced because the reviewer's scope happened to include this file.

## Test plan

- [x] Anti-pattern #4 wording now aligns with Steps B.3 / C.4 prescribed code
- [ ] Reviewer reads the diff and confirms the new wording matches the bridge's internal \`__DEV__\` semantics