### PR TITLE
chore: recover orphaned PRs #128/#129/#130 + unify to v0.44.27

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.26",
+      "version": "0.44.27",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.26",
+  "version": "0.44.27",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CLAUDE-MD-TEMPLATE.md
+++ b/CLAUDE-MD-TEMPLATE.md
@@ -76,6 +76,112 @@ saving via `cdp_record_test_save_as_action`.
 
 ---
 
+### Reusable Actions (the L3 corpus)
+
+An "action" is a Maestro YAML flow stored at `<project>/.rn-agent/actions/<id>.yaml`
+paired with a runtime sidecar at `<project>/.rn-agent/state/<id>.state.json`.
+The YAML is the executable test; the sidecar tracks `revision`, `status`
+(`experimental` / `active` / `deprecated`), `runHistory[]`, and `repairHistory[]`.
+The plugin records, replays, and self-heals these flows so an identical user
+flow that took ~13 minutes the first time costs ~4 seconds on every replay
+afterward — discovery is a one-time cost, replay is the steady state.
+
+**Lifecycle and tooling:**
+
+| Stage | Tool / command | What it does |
+|---|---|---|
+| **Discover** (record) | `cdp_record_test_start` → walk the app → `cdp_record_test_stop` | Buffers events to `.rn-agent/recordings/<id>.json` (pre-save) |
+| **Save** | `cdp_record_test_save_as_action` | Promotes a recording into a paired YAML + sidecar at `.rn-agent/actions/` + `.rn-agent/state/`. Auto-writes the M7 metadata header (`id`, `intent`, `tags`, `mutates`, `status`, optional `produces`) |
+| **List** | `/rn-dev-agent:list-learned-actions [keyword]` | Browse the corpus by intent / tags / appId. Section B of the output shows actions, Section C shows the UI skeleton, Section A surfaces feedback memories |
+| **Run** | `/rn-dev-agent:run-action <id> [-e KEY=VALUE …]` (calls `cdp_run_action`) | Replays with safety pre-flights (mutates flag, appId match, parameter coverage) and auto-repair on `SELECTOR_NOT_FOUND` |
+| **Self-heal** | `cdp_repair_action <id>` | Fuzzy-matches the stale testID against the live snapshot, patches the YAML in place, bumps `revision`, demotes `status` to `experimental` until next clean replay. Bounded: max 3 attempts/24h, refuses on human edits (mtime check) |
+| **Assert state** | `expect_redux`, `expect_route`, `expect_visible_by_testid`, `expect_text` | Macro-Asserts — embed internal-state assertions inside replays. Maestro asserts pixels; these assert what the app actually believes |
+| **Compact** | `/rn-dev-agent:rn-agent-compact` | Periodic corpus health report — flags cold (90+ day), flaky (>50% failure), or high-churn (5+ repairs/30d) actions. Deletion is human-in-the-loop |
+
+**Canonical loop.** Record a verified walk once → save as an action → in the
+next session, `list-learned-actions` surfaces it for the agent → `run-action`
+replays it in ~4 seconds → if a testID drifted, `cdp_run_action` auto-invokes
+`cdp_repair_action`, patches the YAML, retries once, and persists the result
+to the sidecar's `runHistory[]` with auto-repair telemetry.
+
+**Status maturity.** New actions ship as `experimental`. The first clean
+replay auto-promotes them to `active`. Self-repair demotes back to
+`experimental` until the next clean replay re-validates. `deprecated` is a
+manual gesture for actions you want to retain for history but no longer run.
+
+#### Hybrid composition (D1209)
+
+Treat actions as **composable skill primitives**, not just self-contained
+tests. Many tasks share *partial* overlap with existing actions — login is
+the cardinal example: every test that needs an authenticated session
+benefits from replaying a saved login action as a deterministic prologue
+(~4s) instead of re-walking it (~30s+ with LLM-in-the-loop).
+
+The artifact-first rule generalizes from "replay if exact match" to
+**"use deterministic actions wherever they fit, walk only the gaps"**.
+
+**Three rules for any goal-state task:**
+
+1. **Detect current state first.** Before navigating to the requested
+   feature, read `cdp_navigation_state` (current route) and
+   `cdp_store_state(path=…)` (relevant slices, e.g. `auth.user`). Note
+   any mismatch with the expected starting state — login screen vs home,
+   wrong tab, missing onboarding step, etc.
+
+2. **Match the gap, not just the intent.** When you scan
+   `/rn-dev-agent:list-learned-actions` output, check the `Produces`
+   column alongside `Purpose`. An action with
+   `produces: { authenticated: true, route: home }` is the right
+   prologue when current state is `LoginScreen` and the user wants
+   anything that requires auth — even if the user's task isn't "log in"
+   per se. Replay that action via `cdp_run_action`. Re-verify state.
+   Then continue with interactive `cdp_*` / `device_*` tools for the
+   novel part.
+
+3. **No false-binary fallbacks.** Never fall back to a fully-manual
+   walk when a partial replay (login prologue, onboarding skip, locale
+   set) covers half the work. The cost of one failed replay attempt is
+   `cdp_run_action`'s auto-repair budget (3/24h); the cost of a fully
+   manual walk is 30s+ of context-burning device interaction.
+
+**Example — user says "go to home and tap the cart badge":**
+
+```
+1. cdp_navigation_state             → returns "LoginScreen" (mismatch)
+2. /rn-dev-agent:list-learned-actions  (or read .rn-agent/actions/ directly)
+                                    → finds `user-login` with
+                                      produces: { authenticated: true, route: home }
+3. cdp_run_action({                 (deterministic prologue, ~4s)
+     id: "user-login",
+     params: { EMAIL, PASSWORD }
+   })
+4. cdp_navigation_state             → returns "HomeScreen" (state delta closed)
+5. cdp_component_tree({             (interactive discovery for the novel part)
+     filter: "cart"
+   })                               → finds `cart-badge` ref
+6. device_press({ ref: "cart-badge" })
+```
+
+**When persisting a new action**, populate `produces` if the flow
+establishes any reusable state — auth, route, feature flag, locale,
+seeded data. Schema: flat map of primitives.
+
+```
+cdp_record_test_save_as_action({
+  id: "user-login",
+  intent: "Log in via email + password",
+  tags: ["auth", "login"],
+  mutates: false,
+  produces: { authenticated: true, route: "home" }
+})
+```
+
+Optional — actions without `produces` keep working; the LLM falls back
+to intent-string matching for them. The field is purely additive
+metadata.
+
+---
+
 ### 🚨 Tool Routing — STRICT RULES (read this second)
 
 All app interaction MUST go through plugin MCP tools — never raw shell. The plugin's tools

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ A saved, replayable flow through your app — login, navigate to settings, reach
 | Command | Purpose |
 |---------|---------|
 | `/rn-dev-agent:setup` | Inject CLAUDE.md tool-routing rules + nav-ref + Zustand exposure |
-| `/rn-dev-agent:doctor` | 11-row diagnostic table — Node, CDP, agent-device, maestro-runner, simulators, Metro, helpers freshness |
+| `/rn-dev-agent:doctor` | 12-row diagnostic table — Node, CDP, agent-device, maestro-runner, simulators, Metro, helpers freshness, plugin version |
 | `/rn-dev-agent:check-env` | Quick environment-readiness check |
 | `/rn-dev-agent:nav-graph` | Extract and inspect the app navigation graph |
 | `/rn-dev-agent:send-feedback` | Open a GitHub issue with sanitized environment context |

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -1,13 +1,13 @@
 ---
 command: doctor
-description: Diagnose installation health. Check Node, CDP bridge, agent-device, maestro-runner, simulators, Metro, CDP, injected helpers, ffmpeg, physical devices, Vercel rules sync. Reports what's missing — does NOT modify your project.
+description: Diagnose installation health. Check Node, CDP bridge, agent-device, maestro-runner, simulators, Metro, CDP, injected helpers, ffmpeg, physical devices, plugin version, Vercel rules sync. Reports what's missing — does NOT modify your project.
 argument-hint: 
 ---
 
-Run the environment-diagnostic checklist from the `rn-setup` skill. Walk all 12 prerequisite checks (Node.js version, CDP bridge dependencies, agent-device CLI, maestro-runner, iOS simulator, Android emulator, Metro dev server, CDP connection, **injected `__RN_AGENT` helpers**, ffmpeg, physical-device prerequisites, **Vercel rules sync freshness**) and surface install commands for any missing dependencies.
+Run the environment-diagnostic checklist from the `rn-setup` skill. Walk all 13 prerequisite checks (Node.js version, CDP bridge dependencies, agent-device CLI, maestro-runner, iOS simulator, Android emulator, Metro dev server, CDP connection, **injected `__RN_AGENT` helpers**, ffmpeg, physical-device prerequisites, **plugin version freshness**, **Vercel rules sync freshness**) and surface install commands for any missing dependencies.
 
 **This command is read-only.** It diagnoses the current environment and recommends fixes. It does NOT modify any files in the user's project, inject documentation, or instrument source code.
 
-Present results as a 12-row table. For any RED rows, give the user the exact install command (with `nvm` / `sudo` / `brew` flag selection based on their environment). For the helpers row specifically, do NOT suggest retrying `cdp_status` — the bridge already auto-retried injection. If MISSING, recommend `device_*` fallbacks or `cdp_reload`. For the **Vercel rules sync** row: if STALE (>30 days since last sync) or MISSING (no `third_party/vercel-labs/agent-skills/UPSTREAM.lock.json`), surface the resync command — do NOT auto-run; the user runs `node ${CLAUDE_PLUGIN_ROOT}/scripts/sync-vercel-skills.mjs --ref <sha>` themselves.
+Present results as a 13-row table. For any RED rows, give the user the exact install command (with `nvm` / `sudo` / `brew` flag selection based on their environment). For the helpers row specifically, do NOT suggest retrying `cdp_status` — the bridge already auto-retried injection. If MISSING, recommend `device_*` fallbacks or `cdp_reload`. For the **plugin version** row: if BEHIND, surface `/plugin update rn-dev-agent` and let the user decide whether to update before continuing. If OFFLINE (GitHub unreachable), skip without failing — plugin works fine without the upstream check. For the **Vercel rules sync** row: if STALE (>30 days since last sync) or MISSING (no `third_party/vercel-labs/agent-skills/UPSTREAM.lock.json`), surface the resync command — do NOT auto-run; the user runs `node ${CLAUDE_PLUGIN_ROOT}/scripts/sync-vercel-skills.mjs --ref <sha>` themselves.
 
 If the user wants the plugin to also inject project instructions (CLAUDE.md template, nav-ref, store exposure) — point them at `/rn-dev-agent:setup` instead.

--- a/commands/test-feature.md
+++ b/commands/test-feature.md
@@ -24,18 +24,35 @@ Load the `rn-testing` skill and follow this 8-step protocol in this session:
    feature by:
    - filename keyword overlap with `$ARGUMENTS`
    - first-comment-block intent overlap with `$ARGUMENTS`
-   If a match exists, **REPLAY IT FIRST** via:
+   - **`produces:` overlap with the goal state** (D1209) — an action whose
+     `produces` includes the state your task requires (e.g.
+     `authenticated: true` when the task needs an authenticated session)
+     is a useful **prologue** even if its intent doesn't match the full
+     task. See "Hybrid composition" in CLAUDE-MD-TEMPLATE for the loop.
+   If a **full match** exists, **REPLAY IT FIRST** via:
    ```bash
    maestro-runner --platform <ios|android> test -e KEY=VAL <flow-path>
    ```
    If the replay passes, you have your evidence — proceed to step 7
    (verification + generate-or-refresh artifact). If the replay fails with a
    concrete error (`Element not found`, `assertion failed`), fix the flow
-   rather than abandoning to manual primitives. Falling back to `device_*`
-   walks WITHOUT having tried the existing flow is a captured anti-pattern
-   (see `feedback_execute_artifacts_before_manual.md` in auto-memory). Run
+   rather than abandoning to manual primitives.
+
+   If only a **partial match** exists (an action whose `produces` covers
+   part of your task's required state — e.g. login → authenticated, but
+   the rest of the task is novel), use the action as a prologue: replay
+   it via `cdp_run_action({ id, params })`, re-verify state with
+   `cdp_navigation_state` + `cdp_store_state`, then continue with steps
+   1–7 below for the novel part. Save the *new* action covering the full
+   task at step 7. This is the hybrid-composition path — it's the
+   default, not an escape hatch.
+
+   Falling back to `device_*` walks WITHOUT having tried existing flows
+   (full or partial) is a captured anti-pattern (see
+   `feedback_execute_artifacts_before_manual.md` in auto-memory). Run
    `/rn-dev-agent:list-learned-actions` if you want to inspect the
-   inventory.
+   inventory — the `Produces` column shows what state each action
+   establishes.
 1. **Environment check** — call `cdp_status`. If it fails, stop and tell the
    user to run `/rn-dev-agent:setup`.
 2. **Understand the feature** — read implementation files, find testIDs, routes,

--- a/scripts/cdp-bridge/dist/domain/reusable-action.js
+++ b/scripts/cdp-bridge/dist/domain/reusable-action.js
@@ -159,6 +159,9 @@ export function parseM7Header(yamlText, fallbackId) {
             else if (key === 'params') {
                 meta.params = raw.replace(/^\[|\]$/g, '').split(',').map((t) => t.trim()).filter(Boolean);
             }
+            else if (key === 'produces') {
+                meta.produces = parseProducesMap(raw);
+            }
             else if (key === 'id' || key === 'intent' || key === 'status' || key === 'appId' || key === 'createdAt' || key === 'author') {
                 meta[key] = raw;
             }
@@ -187,7 +190,40 @@ export function parseM7Header(yamlText, fallbackId) {
         appId: meta.appId,
         createdAt: meta.createdAt,
         author: meta.author,
+        produces: meta.produces,
     };
+}
+/**
+ * D1209 — parse the inline `produces` map: `{ key: value, key: value }`.
+ * Values are typed as boolean (`true`/`false`), number (digits + optional
+ * dot + optional sign), or string (everything else, with surrounding
+ * single/double quotes stripped). Returns undefined when the input is
+ * empty or unparseable so the caller can omit the field rather than
+ * carry a half-parsed object. Single-line only; commas + newlines
+ * inside values are not supported in v1.
+ */
+function parseProducesMap(raw) {
+    const inner = raw.trim().replace(/^\{|\}$/g, '').trim();
+    if (!inner)
+        return undefined;
+    const result = {};
+    for (const part of inner.split(',')) {
+        const kv = part.match(/^\s*([a-zA-Z_][\w.-]*)\s*:\s*(.+?)\s*$/);
+        if (!kv)
+            continue;
+        const key = kv[1];
+        const valueRaw = kv[2].trim();
+        if (/^(true|false)$/i.test(valueRaw)) {
+            result[key] = /^true$/i.test(valueRaw);
+        }
+        else if (/^-?\d+(\.\d+)?$/.test(valueRaw)) {
+            result[key] = Number(valueRaw);
+        }
+        else {
+            result[key] = valueRaw.replace(/^['"]|['"]$/g, '');
+        }
+    }
+    return Object.keys(result).length ? result : undefined;
 }
 /**
  * Serialize an M7Metadata object as YAML comment lines. Output is
@@ -214,5 +250,15 @@ export function serializeM7Header(metadata) {
         lines.push(`# createdAt: ${stripNewlines(metadata.createdAt)}`);
     if (metadata.author)
         lines.push(`# author: ${stripNewlines(metadata.author)}`);
+    if (metadata.produces && Object.keys(metadata.produces).length > 0) {
+        const pairs = Object.keys(metadata.produces)
+            .sort()
+            .map((k) => {
+            const v = metadata.produces[k];
+            const formatted = typeof v === 'string' ? stripNewlines(v) : String(v);
+            return `${k}: ${formatted}`;
+        });
+        lines.push(`# produces: { ${pairs.join(', ')} }`);
+    }
     return lines.join('\n');
 }

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -24,6 +24,7 @@ import { createObjectInspectHandler } from './tools/object-inspect.js';
 import { createExceptionBreakpointHandler } from './tools/exception-breakpoint.js';
 import { createConsoleLogHandler } from './tools/console-log.js';
 import { createStoreStateHandler } from './tools/store-state.js';
+import { createDiagnosticRenderersHandler } from './tools/diagnostic-renderers.js';
 import { createExpectReduxHandler, createExpectRouteHandler, createExpectVisibleByTestIDHandler, createExpectTextHandler, } from './tools/macro-asserts.js';
 import { createRepairActionHandler } from './tools/repair-action.js';
 import { createSaveAsActionHandler } from './tools/save-as-action.js';
@@ -95,6 +96,9 @@ trackedTool('cdp_status', 'Get full environment status. Auto-connects if not con
     metroPort: z.number().optional().describe('Override Metro port (default: auto-detect 8081/8082/19000/19006)'),
     platform: z.string().optional().describe('Filter target by platform (e.g. "ios", "android") to avoid connecting to the wrong device in multi-simulator setups'),
 }, createStatusHandler(getClient, setClient, createClient));
+trackedTool('cdp_diagnostic_renderers', 'Diagnostic helper for "fiber root invisibility" bug reports (issue #126 follow-up). Enumerates every registered React renderer and its root count via __REACT_DEVTOOLS_GLOBAL_HOOK__. Returns hook keys, renderer Map keys, per-renderer-id root summaries (top fiber type + first child + testID), and notes when renderers are registered but unscanned. Use this when cdp_component_tree returns empty for a component you know is mounted (modals, portals, sub-apps), or when bug-reporting fiber-walk failures.', {
+    maxRendererId: z.number().int().min(1).max(100).optional().describe('How many renderer IDs to scan. Default 20 (matches IIFE MAX_RENDERER_IDS).'),
+}, createDiagnosticRenderersHandler(getClient));
 trackedTool('cdp_connect', 'Explicitly connect to a Hermes debug target. Use when you need to target a specific platform, port, or bundle, or reconnect after a manual disconnect. When multiple Hermes targets exist (common after app restarts on Expo Dev Client — zombie `host.exp.Exponent` pages linger alongside fresh app pages), pass `targetId` (exact id from cdp_targets) or `bundleId` (e.g. "com.myapp") to disambiguate. Use force=true to always reconnect regardless of current state.', {
     metroPort: z.number().optional().describe('Metro port to connect to (default: auto-detect 8081/8082/19000/19006)'),
     platform: z.string().optional().describe('Filter target by platform (e.g. "ios", "android"). If already connected to a different platform, forces reconnection to the correct target.'),

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -604,7 +604,7 @@ trackedTool('expect_text', 'Assert that visible text is (or is not) currently re
 // first-class L3 reusable action: emits Maestro YAML with full M7
 // metadata header at <project>/.rn-agent/actions/<id>.yaml AND
 // initialises the sidecar runtime state. Closes the L2→L3 loop.
-trackedTool('cdp_record_test_save_as_action', 'Promote the in-memory recording (started via cdp_record_test_start) into a first-class L3 reusable action. Writes Maestro YAML with full M7 metadata header (id, intent, tags, mutates, status) to <project>/.rn-agent/actions/<id>.yaml and initialises the sidecar runtime state. Status defaults to "experimental" — first clean /run-action replay auto-promotes to "active". Refuses if the id already exists unless overwrite=true. Distinct from cdp_record_test_save (which writes JSON to .rn-agent/recordings/) — that is for raw event archival; this is for shipping the recording as a replayable action.', {
+trackedTool('cdp_record_test_save_as_action', 'Promote the in-memory recording (started via cdp_record_test_start) into a first-class L3 reusable action. Writes Maestro YAML with full M7 metadata header (id, intent, tags, mutates, status, produces) to <project>/.rn-agent/actions/<id>.yaml and initialises the sidecar runtime state. Status defaults to "experimental" — first clean /run-action replay auto-promotes to "active". Refuses if the id already exists unless overwrite=true. Distinct from cdp_record_test_save (which writes JSON to .rn-agent/recordings/) — that is for raw event archival; this is for shipping the recording as a replayable action. The optional `produces` field (D1209) records state postconditions — what state the action establishes when it runs cleanly — so downstream tasks can use it as a deterministic prologue.', {
     id: z.string().describe('Stable slug; becomes the filename and the M7 id field. Lower-case kebab-case (a-z, 0-9, hyphen).'),
     intent: z.string().describe('One-line goal — surfaced verbatim by /list-learned-actions. Required.'),
     tags: z.array(z.string()).optional().describe('Lower-case kebab-case keywords for filtering (e.g. ["tasks", "create", "regression"]).'),
@@ -614,6 +614,7 @@ trackedTool('cdp_record_test_save_as_action', 'Promote the in-memory recording (
     projectRoot: z.string().optional().describe('Override project root (default: process.cwd()).'),
     overwrite: z.boolean().optional().describe('If an action with this id already exists, replace it. Default false (refuse with hint).'),
     testName: z.string().optional().describe('Optional one-line description shown as a comment above the M7 header. Falls back to intent.'),
+    produces: z.record(z.union([z.string(), z.number(), z.boolean()])).optional().describe('D1209 — state postconditions this action establishes when it runs cleanly. Flat map of primitive values for hybrid composition (e.g. { authenticated: true, route: "home" }). Optional. Values containing commas or newlines are not supported; use multiple keys instead.'),
 }, createSaveAsActionHandler());
 // D1206 Tier 2 Sprint D / Phase 129 — L3→L2 self-repair. When a Maestro
 // flow fails with "element not found", this tool patches the YAML in place

--- a/scripts/cdp-bridge/dist/injected-helpers.js
+++ b/scripts/cdp-bridge/dist/injected-helpers.js
@@ -1,15 +1,33 @@
 export const INJECTED_HELPERS = `
 (function() {
-  var __HELPERS_VERSION__ = 20;
+  var __HELPERS_VERSION__ = 21;
   if (globalThis.__RN_AGENT && globalThis.__RN_AGENT.__v === __HELPERS_VERSION__) return;
   if (globalThis.__RN_AGENT) delete globalThis.__RN_AGENT;
+
+  // Issue #126 — renderer iteration cap. Was hard-coded 5; bumped to 20
+  // with an early-exit-after-3-empty heuristic so the common case (1-3
+  // renderers) still exits fast. Each getFiberRoots(N) call is a Map
+  // lookup so iteration cost is negligible. Kept as a single constant
+  // so all call sites stay in sync (multi-LLM review of issue #126
+  // identified 5 hard-coded sites that previously drifted).
+  var MAX_RENDERER_IDS = 20;
+  var EARLY_EXIT_EMPTY_STREAK = 3;
 
   function findActiveRenderer() {
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
-    for (var i = 1; i <= 5; i++) {
-      var roots = hook.getFiberRoots(i);
-      if (roots && roots.size > 0) return { rendererId: i, roots: roots };
+    var emptyStreak = 0;
+    for (var i = 1; i <= MAX_RENDERER_IDS; i++) {
+      try {
+        var roots = hook.getFiberRoots(i);
+        if (roots && roots.size > 0) {
+          return { rendererId: i, roots: roots };
+        }
+        emptyStreak++;
+        if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && i >= 5) return null;
+      } catch (_) {
+        emptyStreak++;
+      }
     }
     return null;
   }
@@ -23,10 +41,12 @@ export const INJECTED_HELPERS = `
   function forEachRootFiber(cb) {
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
-    for (var ri = 1; ri <= 5; ri++) {
+    var emptyStreak = 0;
+    for (var ri = 1; ri <= MAX_RENDERER_IDS; ri++) {
       try {
         var roots = hook.getFiberRoots(ri);
         if (roots && roots.size) {
+          emptyStreak = 0;
           var it = roots.values();
           var v;
           while (!(v = it.next()).done) {
@@ -35,8 +55,13 @@ export const INJECTED_HELPERS = `
               if (result) return result;
             }
           }
+        } else {
+          emptyStreak++;
+          if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && ri >= 5) return null;
         }
-      } catch (_) { /* skip bad renderer, keep searching */ }
+      } catch (_) {
+        emptyStreak++;
+      }
     }
     return null;
   }
@@ -54,10 +79,12 @@ export const INJECTED_HELPERS = `
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return [];
     var out = [];
-    for (var ri = 1; ri <= 5; ri++) {
+    var emptyStreak = 0;
+    for (var ri = 1; ri <= MAX_RENDERER_IDS; ri++) {
       try {
         var roots = hook.getFiberRoots(ri);
         if (roots && roots.size) {
+          emptyStreak = 0;
           var it = roots.values();
           var v;
           while (!(v = it.next()).done) {
@@ -65,8 +92,13 @@ export const INJECTED_HELPERS = `
               out.push({ rendererId: ri, fiber: v.value.current });
             }
           }
+        } else {
+          emptyStreak++;
+          if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && ri >= 5) return out;
         }
-      } catch (_) { /* skip bad renderer, keep going */ }
+      } catch (_) {
+        emptyStreak++;
+      }
     }
     return out;
   }
@@ -1038,16 +1070,139 @@ export const INJECTED_HELPERS = `
 
       if (action === 'typeText') {
         var text = opts.text !== undefined ? opts.text : '';
-        if (typeof props.onChangeText === 'function') {
-          props.onChangeText(text);
+
+        // Issue #126 Fix A — typeText handler resolution.
+        //
+        // Path 1 (preserved for backwards compatibility): when the matched
+        // fiber itself has onChangeText / onChange, fire them (existing
+        // behavior fires both if both exist — kept to avoid silent
+        // regressions on consumers depending on the order/double-fire).
+        //
+        // Path 2 (new): when neither handler is on the matched fiber,
+        // walk descendants for a typeable child. Common case: design-system
+        // TextField wraps TextInput in an outer Pressable/View; the wrapper
+        // testID resolves to the wrapper fiber whose props don't carry
+        // onChangeText. Walking down finds the inner TextInput. Bounds:
+        // depth ≤ 16, visit cap 200 across both passes. Two-pass: pass 1
+        // considers only onChangeText; pass 2 falls back to onChange (the
+        // overloaded RN/web handler) only if no onChangeText descendant
+        // exists. Within each pass: prefer fibers whose type matches a
+        // TextInput-family fingerprint; if multiple typed candidates
+        // match, return Ambiguous error rather than guess.
+        if (typeof props.onChangeText === 'function' || typeof props.onChange === 'function') {
+          if (typeof props.onChangeText === 'function') props.onChangeText(text);
+          if (typeof props.onChange === 'function') props.onChange({ nativeEvent: { text: text } });
+          return JSON.stringify({
+            success: true,
+            action: 'typeText',
+            component: typeName,
+            testID: selector,
+            text: text,
+            handlerCalled: typeof props.onChangeText === 'function' ? 'onChangeText' : 'onChange',
+            resolvedFrom: 'matched-fiber'
+          });
         }
-        if (typeof props.onChange === 'function') {
-          props.onChange({ nativeEvent: { text: text } });
+
+        var TYPEABLE_TYPE_RE = /(TextInput|Input|Field|TextField|EditText)/;
+        var visited = 0;
+        var DESCENDANT_DEPTH_CAP = 16;
+        var DESCENDANT_VISIT_CAP = 200;
+
+        function findHandlerDescendants(handlerName) {
+          var matches = [];
+          function walk(node, depth) {
+            if (!node || depth > DESCENDANT_DEPTH_CAP || visited > DESCENDANT_VISIT_CAP) return;
+            visited++;
+            var nProps = node.memoizedProps || {};
+            if (typeof nProps[handlerName] === 'function') {
+              var nName = (node.type && (node.type.displayName || node.type.name)) || '';
+              matches.push({
+                fiber: node,
+                props: nProps,
+                name: nName,
+                typeFingerprint: TYPEABLE_TYPE_RE.test(nName)
+              });
+            }
+            if (node.child) walk(node.child, depth + 1);
+            if (node.sibling) walk(node.sibling, depth);
+          }
+          if (found.child) walk(found.child, 1);
+          return matches;
         }
-        if (typeof props.onChangeText !== 'function' && typeof props.onChange !== 'function') {
-          return JSON.stringify({ error: 'Component has no onChangeText or onChange handler', component: typeName, testID: selector });
+
+        function pickFromMatches(matches, handlerName) {
+          if (matches.length === 0) return { kind: 'none' };
+          var typed = [];
+          for (var i = 0; i < matches.length; i++) if (matches[i].typeFingerprint) typed.push(matches[i]);
+          if (typed.length === 1) return { kind: 'one', match: typed[0], handler: handlerName };
+          if (typed.length > 1) return { kind: 'ambiguous', matches: typed, handler: handlerName };
+          if (matches.length === 1) return { kind: 'one', match: matches[0], handler: handlerName };
+          return { kind: 'ambiguous', matches: matches, handler: handlerName };
         }
-        return JSON.stringify({ success: true, action: 'typeText', component: typeName, testID: selector, text: text });
+
+        var pass1 = pickFromMatches(findHandlerDescendants('onChangeText'), 'onChangeText');
+        var picked = null;
+        if (pass1.kind === 'one') {
+          picked = pass1;
+        } else if (pass1.kind === 'ambiguous') {
+          return JSON.stringify({
+            error: 'Ambiguous typeText resolution',
+            testID: selector,
+            handler: 'onChangeText',
+            count: pass1.matches.length,
+            candidates: pass1.matches.slice(0, 5).map(function(m) {
+              return { component: m.name, testID: m.props.testID, typeFingerprint: m.typeFingerprint };
+            }),
+            hint: 'Multiple onChangeText descendants under testID "' + selector + '". Pass a more specific testID — ideally the inner TextInput itself.'
+          });
+        } else {
+          // pass 2 — onChange fallback
+          var pass2 = pickFromMatches(findHandlerDescendants('onChange'), 'onChange');
+          if (pass2.kind === 'one') {
+            picked = pass2;
+          } else if (pass2.kind === 'ambiguous') {
+            return JSON.stringify({
+              error: 'Ambiguous typeText resolution',
+              testID: selector,
+              handler: 'onChange',
+              count: pass2.matches.length,
+              candidates: pass2.matches.slice(0, 5).map(function(m) {
+                return { component: m.name, testID: m.props.testID, typeFingerprint: m.typeFingerprint };
+              }),
+              hint: 'Multiple onChange descendants under testID "' + selector + '". Pass a more specific testID — ideally the inner TextInput itself.'
+            });
+          }
+        }
+
+        if (!picked) {
+          return JSON.stringify({
+            error: 'Component has no onChangeText or onChange handler',
+            component: typeName,
+            testID: selector,
+            hint: 'Walked up to ' + DESCENDANT_DEPTH_CAP + ' levels (' + visited + ' fibers) — no descendant has a typeable handler. The matched fiber may not contain a TextInput. Use cdp_component_tree to inspect, or pass the inner field testID directly.'
+          });
+        }
+
+        // Single-fire — call only the picked handler. Avoids the
+        // double-fire bug on RHF Controllers where field.onChange wired
+        // to onChangeText + RN HostComponent onChange would each run
+        // with different argument shapes.
+        if (picked.handler === 'onChangeText') {
+          picked.match.props.onChangeText(text);
+        } else {
+          picked.match.props.onChange({ nativeEvent: { text: text } });
+        }
+
+        return JSON.stringify({
+          success: true,
+          action: 'typeText',
+          component: typeName,
+          testID: selector,
+          text: text,
+          handlerCalled: picked.handler,
+          resolvedFrom: picked.match.name + (picked.match.props.testID ? ' [testID="' + picked.match.props.testID + '"]' : ''),
+          visitedFibers: visited
+        });
       }
 
       if (action === 'scroll') {
@@ -1631,21 +1786,35 @@ export const REACT_READY_PROBE_JS = `(function() {
   }
   return false;
 })()`;
+export const MAX_RENDERER_IDS = 20;
+export const EARLY_EXIT_EMPTY_STREAK = 3;
 export function findAllRootFibersForTest(hook) {
     if (!hook || typeof hook.getFiberRoots !== 'function')
         return [];
     const out = [];
-    for (let ri = 1; ri <= 5; ri++) {
-        const roots = hook.getFiberRoots(ri);
-        if (roots && roots.size) {
-            const it = roots.values();
-            let step = it.next();
-            while (!step.done) {
-                const r = step.value;
-                if (r && r.current)
-                    out.push({ rendererId: ri, fiber: r.current });
-                step = it.next();
+    let emptyStreak = 0;
+    for (let ri = 1; ri <= MAX_RENDERER_IDS; ri++) {
+        try {
+            const roots = hook.getFiberRoots(ri);
+            if (roots && roots.size) {
+                emptyStreak = 0;
+                const it = roots.values();
+                let step = it.next();
+                while (!step.done) {
+                    const r = step.value;
+                    if (r && r.current)
+                        out.push({ rendererId: ri, fiber: r.current });
+                    step = it.next();
+                }
             }
+            else {
+                emptyStreak++;
+                if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && ri >= 5)
+                    return out;
+            }
+        }
+        catch {
+            emptyStreak++;
         }
     }
     return out;

--- a/scripts/cdp-bridge/dist/injected-helpers.js
+++ b/scripts/cdp-bridge/dist/injected-helpers.js
@@ -1073,37 +1073,52 @@ export const INJECTED_HELPERS = `
 
         // Issue #126 Fix A — typeText handler resolution.
         //
-        // Path 1 (preserved for backwards compatibility): when the matched
-        // fiber itself has onChangeText / onChange, fire them (existing
-        // behavior fires both if both exist — kept to avoid silent
-        // regressions on consumers depending on the order/double-fire).
+        // Path 1: matched fiber itself has onChangeText / onChange. SINGLE-
+        // fire — pick onChangeText if present, else onChange. Avoids the
+        // double-fire bug: when an RHF Controller wraps a TextInput via
+        // <TextInput {...field} />, both onChangeText and onChange are bound
+        // to field.onChange. Firing both ran field.onChange twice with
+        // different argument shapes (string then {nativeEvent}), corrupting
+        // the form state and double-triggering validators.
         //
-        // Path 2 (new): when neither handler is on the matched fiber,
-        // walk descendants for a typeable child. Common case: design-system
+        // Path 2: when matched fiber has no typeable handler, walk
+        // descendants for a typeable child. Common case: design-system
         // TextField wraps TextInput in an outer Pressable/View; the wrapper
         // testID resolves to the wrapper fiber whose props don't carry
         // onChangeText. Walking down finds the inner TextInput. Bounds:
         // depth ≤ 16, visit cap 200 across both passes. Two-pass: pass 1
         // considers only onChangeText; pass 2 falls back to onChange (the
-        // overloaded RN/web handler) only if no onChangeText descendant
+        // overloaded RN handler) only if no onChangeText descendant
         // exists. Within each pass: prefer fibers whose type matches a
-        // TextInput-family fingerprint; if multiple typed candidates
-        // match, return Ambiguous error rather than guess.
+        // TextInput-family fingerprint, then dedupe candidates that share
+        // the same handler function reference (react-native-paper wraps
+        // TextInputOutlined → TextInput → InternalTextInput each forwarding
+        // the same onChangeText — pick the deepest leaf), and return
+        // Ambiguous only when truly distinct typed handlers compete.
         if (typeof props.onChangeText === 'function' || typeof props.onChange === 'function') {
-          if (typeof props.onChangeText === 'function') props.onChangeText(text);
-          if (typeof props.onChange === 'function') props.onChange({ nativeEvent: { text: text } });
+          var p1Handler;
+          if (typeof props.onChangeText === 'function') {
+            p1Handler = 'onChangeText';
+            props.onChangeText(text);
+          } else {
+            p1Handler = 'onChange';
+            props.onChange({ nativeEvent: { text: text } });
+          }
           return JSON.stringify({
             success: true,
             action: 'typeText',
             component: typeName,
             testID: selector,
             text: text,
-            handlerCalled: typeof props.onChangeText === 'function' ? 'onChangeText' : 'onChange',
+            handlerCalled: p1Handler,
             resolvedFrom: 'matched-fiber'
           });
         }
 
-        var TYPEABLE_TYPE_RE = /(TextInput|Input|Field|TextField|EditText)/;
+        // Anchored on TextInput-family names. Drops bare Input/Field
+        // substrings to avoid false-positives on RadioGroupField,
+        // InputAccessoryView, BottomSheetTextInput's wrapper, etc.
+        var TYPEABLE_TYPE_RE = /(TextInput|TextField|EditText)/;
         var visited = 0;
         var DESCENDANT_DEPTH_CAP = 16;
         var DESCENDANT_VISIT_CAP = 200;
@@ -1120,6 +1135,7 @@ export const INJECTED_HELPERS = `
                 fiber: node,
                 props: nProps,
                 name: nName,
+                depth: depth,
                 typeFingerprint: TYPEABLE_TYPE_RE.test(nName)
               });
             }
@@ -1130,14 +1146,40 @@ export const INJECTED_HELPERS = `
           return matches;
         }
 
+        // Dedupe candidates that share the same handler function reference.
+        // react-native-paper's TextInputOutlined → TextInput → InternalTextInput
+        // chain each forwards the SAME onChangeText down — they're the same
+        // logical handler, not three independent typeable fields. Keep the
+        // deepest leaf so the call lands on the host-component fiber that
+        // actually owns the input. (Codex M4 / multi-LLM review of issue #126.)
+        function dedupeByHandlerIdentity(matches, handlerName) {
+          var byFn = [];
+          for (var i = 0; i < matches.length; i++) {
+            var m = matches[i];
+            var fn = m.props[handlerName];
+            var existingIdx = -1;
+            for (var j = 0; j < byFn.length; j++) {
+              if (byFn[j].props[handlerName] === fn) { existingIdx = j; break; }
+            }
+            if (existingIdx === -1) {
+              byFn.push(m);
+            } else if (m.depth > byFn[existingIdx].depth) {
+              // Same handler, deeper fiber — replace with the leaf.
+              byFn[existingIdx] = m;
+            }
+          }
+          return byFn;
+        }
+
         function pickFromMatches(matches, handlerName) {
           if (matches.length === 0) return { kind: 'none' };
+          var deduped = dedupeByHandlerIdentity(matches, handlerName);
           var typed = [];
-          for (var i = 0; i < matches.length; i++) if (matches[i].typeFingerprint) typed.push(matches[i]);
+          for (var i = 0; i < deduped.length; i++) if (deduped[i].typeFingerprint) typed.push(deduped[i]);
           if (typed.length === 1) return { kind: 'one', match: typed[0], handler: handlerName };
           if (typed.length > 1) return { kind: 'ambiguous', matches: typed, handler: handlerName };
-          if (matches.length === 1) return { kind: 'one', match: matches[0], handler: handlerName };
-          return { kind: 'ambiguous', matches: matches, handler: handlerName };
+          if (deduped.length === 1) return { kind: 'one', match: deduped[0], handler: handlerName };
+          return { kind: 'ambiguous', matches: deduped, handler: handlerName };
         }
 
         var pass1 = pickFromMatches(findHandlerDescendants('onChangeText'), 'onChangeText');

--- a/scripts/cdp-bridge/dist/tools/diagnostic-renderers.js
+++ b/scripts/cdp-bridge/dist/tools/diagnostic-renderers.js
@@ -21,11 +21,17 @@ const DIAGNOSTIC_RENDERERS_JS = `(function(opts) {
     });
   }
 
-  var max = (opts && opts.maxRendererId) ? opts.maxRendererId : 20;
+  var max = (opts && typeof opts.maxRendererId === 'number') ? opts.maxRendererId : 20;
   var notes = [];
+  // Use getOwnPropertyNames so non-enumerable hook properties (e.g. those
+  // installed by React DevTools backend via Object.defineProperty with
+  // enumerable:false — renderers, getFiberRoots, inject on some
+  // versions) are surfaced. for...in / Object.keys would miss them.
   var hookKeys = [];
-  for (var k in hook) {
-    if (Object.prototype.hasOwnProperty.call(hook, k)) hookKeys.push(k);
+  try {
+    hookKeys = Object.getOwnPropertyNames(hook);
+  } catch (_) {
+    hookKeys = [];
   }
 
   var rendererKeys = [];
@@ -95,15 +101,28 @@ const DIAGNOSTIC_RENDERERS_JS = `(function(opts) {
     }
   }
 
+  // Single consolidated "registered but unscanned" note (Gemini H3 +
+  // Codex M1 from PR #130 review): list ALL unscanned IDs once with a
+  // single re-run suggestion at the max needed value. Avoids N misleading
+  // "+5 buffer" notes that confused the user about the actual cause.
   if (earlyExited) {
+    var unscanned = [];
     for (var rk = 0; rk < rendererKeys.length; rk++) {
       var matched = false;
       for (var rr = 0; rr < rows.length; rr++) {
         if (rows[rr].rendererId === rendererKeys[rk]) { matched = true; break; }
       }
-      if (!matched) {
-        notes.push('Renderer ID ' + rendererKeys[rk] + ' was registered but not scanned (early-exit). Pass maxRendererId=' + (rendererKeys[rk] + 5) + ' to include it.');
-      }
+      if (!matched) unscanned.push(rendererKeys[rk]);
+    }
+    if (unscanned.length > 0) {
+      var needed = unscanned[0];
+      for (var ui = 1; ui < unscanned.length; ui++) if (unscanned[ui] > needed) needed = unscanned[ui];
+      notes.push('Renderer ID' + (unscanned.length > 1 ? 's' : '') + ' ' + unscanned.join(', ') + ' ' + (unscanned.length > 1 ? 'were' : 'was') + ' registered but not scanned (early-exit). Re-run with maxRendererId=' + needed + ' to include ' + (unscanned.length > 1 ? 'them' : 'it') + '.');
+    } else if (rendererKeys.length === 0) {
+      // hook.renderers was missing — we can't tell which IDs were skipped.
+      // Surface the gap explicitly so the user knows to re-run wider.
+      var lastScanned = rows.length ? rows[rows.length - 1].rendererId : 0;
+      notes.push('Early-exited at renderer ' + lastScanned + '. hook.renderers is unavailable so we cannot detect skipped renderers. Re-run with maxRendererId=' + (lastScanned + 10) + ' if you suspect a renderer at id ' + (lastScanned + 1) + '+.');
     }
   }
 

--- a/scripts/cdp-bridge/dist/tools/diagnostic-renderers.js
+++ b/scripts/cdp-bridge/dist/tools/diagnostic-renderers.js
@@ -1,0 +1,143 @@
+// Issue #126 follow-up — diagnostic helper for "fiber root invisibility"
+// bug reports. Returns a complete enumeration of registered React renderers
+// + their root counts so users can self-serve diagnose Gap-B-style failures
+// (modal/portal mounted but cdp_component_tree returns empty).
+//
+// Read-only: makes no mutations. Surfaces the raw shape of
+// __REACT_DEVTOOLS_GLOBAL_HOOK__ in a single round-trip.
+import { okResult, failResult, withConnection } from '../utils.js';
+const DIAGNOSTIC_RENDERERS_JS = `(function(opts) {
+  var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  if (!hook) {
+    return JSON.stringify({
+      hookPresent: false,
+      hookKeys: [],
+      rendererCount: 0,
+      rendererKeys: [],
+      rows: [],
+      scannedRange: { from: 0, to: 0 },
+      earlyExited: false,
+      notes: ['__REACT_DEVTOOLS_GLOBAL_HOOK__ is not defined — DevTools backend has not loaded. Verify you are on a Dev Client / dev-mode bundle.']
+    });
+  }
+
+  var max = (opts && opts.maxRendererId) ? opts.maxRendererId : 20;
+  var notes = [];
+  var hookKeys = [];
+  for (var k in hook) {
+    if (Object.prototype.hasOwnProperty.call(hook, k)) hookKeys.push(k);
+  }
+
+  var rendererKeys = [];
+  if (hook.renderers && typeof hook.renderers.forEach === 'function') {
+    hook.renderers.forEach(function(_v, key) {
+      if (typeof key === 'number') rendererKeys.push(key);
+    });
+    rendererKeys.sort(function(a, b) { return a - b; });
+  } else {
+    notes.push('hook.renderers is not a Map — falling back to iteration only.');
+  }
+
+  if (typeof hook.getFiberRoots !== 'function') {
+    return JSON.stringify({
+      hookPresent: true,
+      hookKeys: hookKeys,
+      rendererCount: rendererKeys.length,
+      rendererKeys: rendererKeys,
+      rows: [],
+      scannedRange: { from: 0, to: 0 },
+      earlyExited: false,
+      notes: notes.concat(['hook.getFiberRoots is missing. Cannot enumerate fiber roots — DevTools backend may be a stub.'])
+    });
+  }
+
+  function summarize(rootCurrent) {
+    if (!rootCurrent || typeof rootCurrent !== 'object') return null;
+    var typeName = (rootCurrent.type && (rootCurrent.type.displayName || rootCurrent.type.name)) || null;
+    var childTypeName = null;
+    var testID = null;
+    if (rootCurrent.child) {
+      var c = rootCurrent.child;
+      childTypeName = (c.type && (c.type.displayName || c.type.name)) || null;
+      var props = c.memoizedProps;
+      if (props && typeof props === 'object' && props.testID) testID = String(props.testID);
+    }
+    return { typeName: typeName, childTypeName: childTypeName, testID: testID };
+  }
+
+  var rows = [];
+  var emptyStreak = 0;
+  var earlyExited = false;
+  for (var ri = 1; ri <= max; ri++) {
+    try {
+      var roots = hook.getFiberRoots(ri);
+      if (roots && roots.size) {
+        emptyStreak = 0;
+        var rootInfo = [];
+        var it = roots.values();
+        var step = it.next();
+        while (!step.done) {
+          if (step.value && step.value.current) {
+            var s = summarize(step.value.current);
+            if (s) rootInfo.push(s);
+          }
+          step = it.next();
+        }
+        rows.push({ rendererId: ri, rootCount: roots.size, roots: rootInfo });
+      } else {
+        rows.push({ rendererId: ri, rootCount: 0 });
+        emptyStreak++;
+        if (emptyStreak >= 3 && ri >= 5) { earlyExited = true; break; }
+      }
+    } catch (err) {
+      rows.push({ rendererId: ri, rootCount: null, error: String(err && err.message || err) });
+      emptyStreak++;
+    }
+  }
+
+  if (earlyExited) {
+    for (var rk = 0; rk < rendererKeys.length; rk++) {
+      var matched = false;
+      for (var rr = 0; rr < rows.length; rr++) {
+        if (rows[rr].rendererId === rendererKeys[rk]) { matched = true; break; }
+      }
+      if (!matched) {
+        notes.push('Renderer ID ' + rendererKeys[rk] + ' was registered but not scanned (early-exit). Pass maxRendererId=' + (rendererKeys[rk] + 5) + ' to include it.');
+      }
+    }
+  }
+
+  return JSON.stringify({
+    hookPresent: true,
+    hookKeys: hookKeys,
+    rendererCount: rendererKeys.length || rows.filter(function(r) { return r.rootCount && r.rootCount > 0; }).length,
+    rendererKeys: rendererKeys,
+    rows: rows,
+    scannedRange: { from: 1, to: rows.length ? rows[rows.length - 1].rendererId : 0 },
+    earlyExited: earlyExited,
+    notes: notes
+  });
+})`;
+export function createDiagnosticRenderersHandler(getClient) {
+    return withConnection(getClient, async (args, client) => {
+        const max = args.maxRendererId ?? 20;
+        if (max < 1 || max > 100) {
+            return failResult(`cdp_diagnostic_renderers: maxRendererId must be 1..100 (got ${max})`);
+        }
+        const expression = `${DIAGNOSTIC_RENDERERS_JS}({maxRendererId: ${JSON.stringify(max)}})`;
+        const result = await client.evaluate(expression);
+        if (result.error) {
+            return failResult(`cdp_diagnostic_renderers: ${result.error}`);
+        }
+        if (typeof result.value !== 'string') {
+            return failResult('cdp_diagnostic_renderers: hook probe returned non-string');
+        }
+        try {
+            const parsed = JSON.parse(result.value);
+            return okResult(parsed);
+        }
+        catch (err) {
+            return failResult(`cdp_diagnostic_renderers: failed to parse hook probe response: ${String(err)}`);
+        }
+    });
+}

--- a/scripts/cdp-bridge/dist/tools/save-as-action.js
+++ b/scripts/cdp-bridge/dist/tools/save-as-action.js
@@ -65,6 +65,7 @@ export function createSaveAsActionHandler() {
             tags: args.tags,
             mutates: args.mutates,
             status,
+            produces: args.produces,
         });
         // Issue #101: sidecar-first atomic pair-write. The atomicWriter
         // owns `lastSeenMtimeMs` correctness (overrides whatever we seed in
@@ -91,6 +92,7 @@ export function createSaveAsActionHandler() {
                 mutates: args.mutates,
                 status,
                 appId: args.bundleId,
+                produces: args.produces,
             },
             hint: `Action emitted as experimental. Run /run-action ${args.id} to validate; on first clean replay it auto-promotes to active.`,
         });

--- a/scripts/cdp-bridge/dist/tools/test-recorder-generators.js
+++ b/scripts/cdp-bridge/dist/tools/test-recorder-generators.js
@@ -32,6 +32,16 @@ function metaPairs(opts) {
         out.push(['mutates', String(opts.mutates)]);
     if (opts.status)
         out.push(['status', stripNewlines(opts.status)]);
+    if (opts.produces && Object.keys(opts.produces).length > 0) {
+        const pairs = Object.keys(opts.produces)
+            .sort()
+            .map((k) => {
+            const v = opts.produces[k];
+            const formatted = typeof v === 'string' ? stripNewlines(v) : String(v);
+            return `${k}: ${formatted}`;
+        });
+        out.push(['produces', `{ ${pairs.join(', ')} }`]);
+    }
     return out;
 }
 // B137: window (ms) after a tap in which a subsequent `navigate` event is

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.20",
+  "version": "0.38.21",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.21",
+  "version": "0.38.22",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/domain/reusable-action.ts
+++ b/scripts/cdp-bridge/src/domain/reusable-action.ts
@@ -112,6 +112,24 @@ export interface M7Metadata {
   createdAt?: string;
 
   author?: ActionAuthor;
+
+  /**
+   * D1209 — state postconditions this action establishes when it runs
+   * cleanly. A flat map of primitive-valued state assertions (e.g.
+   * `{ authenticated: true, route: 'home' }`). Used by the agent for
+   * hybrid composition: when the user's task requires a state the
+   * current app doesn't satisfy, the agent scans for an action whose
+   * `produces` covers the gap and replays it as a deterministic
+   * prologue before continuing with interactive tools.
+   *
+   * Optional — actions without `produces` continue to work; the agent
+   * falls back to intent-string matching for them.
+   *
+   * v1 supports primitive values only (string | number | boolean).
+   * The inline YAML serialization rules out commas + newlines inside
+   * values.
+   */
+  produces?: Record<string, string | number | boolean>;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -427,6 +445,8 @@ export function parseM7Header(yamlText: string, fallbackId?: string): M7Metadata
         meta.mutates = /^true$/i.test(raw);
       } else if (key === 'params') {
         meta.params = raw.replace(/^\[|\]$/g, '').split(',').map((t) => t.trim()).filter(Boolean);
+      } else if (key === 'produces') {
+        meta.produces = parseProducesMap(raw);
       } else if (key === 'id' || key === 'intent' || key === 'status' || key === 'appId' || key === 'createdAt' || key === 'author') {
         meta[key] = raw;
       }
@@ -451,7 +471,37 @@ export function parseM7Header(yamlText: string, fallbackId?: string): M7Metadata
     appId: meta.appId as string | undefined,
     createdAt: meta.createdAt as string | undefined,
     author: meta.author as ActionAuthor | undefined,
+    produces: meta.produces as Record<string, string | number | boolean> | undefined,
   };
+}
+
+/**
+ * D1209 — parse the inline `produces` map: `{ key: value, key: value }`.
+ * Values are typed as boolean (`true`/`false`), number (digits + optional
+ * dot + optional sign), or string (everything else, with surrounding
+ * single/double quotes stripped). Returns undefined when the input is
+ * empty or unparseable so the caller can omit the field rather than
+ * carry a half-parsed object. Single-line only; commas + newlines
+ * inside values are not supported in v1.
+ */
+function parseProducesMap(raw: string): Record<string, string | number | boolean> | undefined {
+  const inner = raw.trim().replace(/^\{|\}$/g, '').trim();
+  if (!inner) return undefined;
+  const result: Record<string, string | number | boolean> = {};
+  for (const part of inner.split(',')) {
+    const kv = part.match(/^\s*([a-zA-Z_][\w.-]*)\s*:\s*(.+?)\s*$/);
+    if (!kv) continue;
+    const key = kv[1];
+    const valueRaw = kv[2].trim();
+    if (/^(true|false)$/i.test(valueRaw)) {
+      result[key] = /^true$/i.test(valueRaw);
+    } else if (/^-?\d+(\.\d+)?$/.test(valueRaw)) {
+      result[key] = Number(valueRaw);
+    } else {
+      result[key] = valueRaw.replace(/^['"]|['"]$/g, '');
+    }
+  }
+  return Object.keys(result).length ? result : undefined;
 }
 
 /**
@@ -476,5 +526,15 @@ export function serializeM7Header(metadata: M7Metadata): string {
   if (metadata.appId) lines.push(`# appId: ${stripNewlines(metadata.appId)}`);
   if (metadata.createdAt) lines.push(`# createdAt: ${stripNewlines(metadata.createdAt)}`);
   if (metadata.author) lines.push(`# author: ${stripNewlines(metadata.author)}`);
+  if (metadata.produces && Object.keys(metadata.produces).length > 0) {
+    const pairs = Object.keys(metadata.produces)
+      .sort()
+      .map((k) => {
+        const v = metadata.produces![k];
+        const formatted = typeof v === 'string' ? stripNewlines(v) : String(v);
+        return `${k}: ${formatted}`;
+      });
+    lines.push(`# produces: { ${pairs.join(', ')} }`);
+  }
   return lines.join('\n');
 }

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -1043,7 +1043,7 @@ trackedTool(
 
 trackedTool(
   'cdp_record_test_save_as_action',
-  'Promote the in-memory recording (started via cdp_record_test_start) into a first-class L3 reusable action. Writes Maestro YAML with full M7 metadata header (id, intent, tags, mutates, status) to <project>/.rn-agent/actions/<id>.yaml and initialises the sidecar runtime state. Status defaults to "experimental" — first clean /run-action replay auto-promotes to "active". Refuses if the id already exists unless overwrite=true. Distinct from cdp_record_test_save (which writes JSON to .rn-agent/recordings/) — that is for raw event archival; this is for shipping the recording as a replayable action.',
+  'Promote the in-memory recording (started via cdp_record_test_start) into a first-class L3 reusable action. Writes Maestro YAML with full M7 metadata header (id, intent, tags, mutates, status, produces) to <project>/.rn-agent/actions/<id>.yaml and initialises the sidecar runtime state. Status defaults to "experimental" — first clean /run-action replay auto-promotes to "active". Refuses if the id already exists unless overwrite=true. Distinct from cdp_record_test_save (which writes JSON to .rn-agent/recordings/) — that is for raw event archival; this is for shipping the recording as a replayable action. The optional `produces` field (D1209) records state postconditions — what state the action establishes when it runs cleanly — so downstream tasks can use it as a deterministic prologue.',
   {
     id: z.string().describe('Stable slug; becomes the filename and the M7 id field. Lower-case kebab-case (a-z, 0-9, hyphen).'),
     intent: z.string().describe('One-line goal — surfaced verbatim by /list-learned-actions. Required.'),
@@ -1054,6 +1054,7 @@ trackedTool(
     projectRoot: z.string().optional().describe('Override project root (default: process.cwd()).'),
     overwrite: z.boolean().optional().describe('If an action with this id already exists, replace it. Default false (refuse with hint).'),
     testName: z.string().optional().describe('Optional one-line description shown as a comment above the M7 header. Falls back to intent.'),
+    produces: z.record(z.union([z.string(), z.number(), z.boolean()])).optional().describe('D1209 — state postconditions this action establishes when it runs cleanly. Flat map of primitive values for hybrid composition (e.g. { authenticated: true, route: "home" }). Optional. Values containing commas or newlines are not supported; use multiple keys instead.'),
   },
   createSaveAsActionHandler(),
 );

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -24,6 +24,7 @@ import { createObjectInspectHandler } from './tools/object-inspect.js';
 import { createExceptionBreakpointHandler } from './tools/exception-breakpoint.js';
 import { createConsoleLogHandler } from './tools/console-log.js';
 import { createStoreStateHandler } from './tools/store-state.js';
+import { createDiagnosticRenderersHandler } from './tools/diagnostic-renderers.js';
 import {
   createExpectReduxHandler,
   createExpectRouteHandler,
@@ -137,6 +138,15 @@ trackedTool(
     platform: z.string().optional().describe('Filter target by platform (e.g. "ios", "android") to avoid connecting to the wrong device in multi-simulator setups'),
   },
   createStatusHandler(getClient, setClient, createClient),
+);
+
+trackedTool(
+  'cdp_diagnostic_renderers',
+  'Diagnostic helper for "fiber root invisibility" bug reports (issue #126 follow-up). Enumerates every registered React renderer and its root count via __REACT_DEVTOOLS_GLOBAL_HOOK__. Returns hook keys, renderer Map keys, per-renderer-id root summaries (top fiber type + first child + testID), and notes when renderers are registered but unscanned. Use this when cdp_component_tree returns empty for a component you know is mounted (modals, portals, sub-apps), or when bug-reporting fiber-walk failures.',
+  {
+    maxRendererId: z.number().int().min(1).max(100).optional().describe('How many renderer IDs to scan. Default 20 (matches IIFE MAX_RENDERER_IDS).'),
+  },
+  createDiagnosticRenderersHandler(getClient),
 );
 
 trackedTool(

--- a/scripts/cdp-bridge/src/injected-helpers.ts
+++ b/scripts/cdp-bridge/src/injected-helpers.ts
@@ -1,15 +1,33 @@
 export const INJECTED_HELPERS = `
 (function() {
-  var __HELPERS_VERSION__ = 20;
+  var __HELPERS_VERSION__ = 21;
   if (globalThis.__RN_AGENT && globalThis.__RN_AGENT.__v === __HELPERS_VERSION__) return;
   if (globalThis.__RN_AGENT) delete globalThis.__RN_AGENT;
+
+  // Issue #126 — renderer iteration cap. Was hard-coded 5; bumped to 20
+  // with an early-exit-after-3-empty heuristic so the common case (1-3
+  // renderers) still exits fast. Each getFiberRoots(N) call is a Map
+  // lookup so iteration cost is negligible. Kept as a single constant
+  // so all call sites stay in sync (multi-LLM review of issue #126
+  // identified 5 hard-coded sites that previously drifted).
+  var MAX_RENDERER_IDS = 20;
+  var EARLY_EXIT_EMPTY_STREAK = 3;
 
   function findActiveRenderer() {
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
-    for (var i = 1; i <= 5; i++) {
-      var roots = hook.getFiberRoots(i);
-      if (roots && roots.size > 0) return { rendererId: i, roots: roots };
+    var emptyStreak = 0;
+    for (var i = 1; i <= MAX_RENDERER_IDS; i++) {
+      try {
+        var roots = hook.getFiberRoots(i);
+        if (roots && roots.size > 0) {
+          return { rendererId: i, roots: roots };
+        }
+        emptyStreak++;
+        if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && i >= 5) return null;
+      } catch (_) {
+        emptyStreak++;
+      }
     }
     return null;
   }
@@ -23,10 +41,12 @@ export const INJECTED_HELPERS = `
   function forEachRootFiber(cb) {
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
-    for (var ri = 1; ri <= 5; ri++) {
+    var emptyStreak = 0;
+    for (var ri = 1; ri <= MAX_RENDERER_IDS; ri++) {
       try {
         var roots = hook.getFiberRoots(ri);
         if (roots && roots.size) {
+          emptyStreak = 0;
           var it = roots.values();
           var v;
           while (!(v = it.next()).done) {
@@ -35,8 +55,13 @@ export const INJECTED_HELPERS = `
               if (result) return result;
             }
           }
+        } else {
+          emptyStreak++;
+          if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && ri >= 5) return null;
         }
-      } catch (_) { /* skip bad renderer, keep searching */ }
+      } catch (_) {
+        emptyStreak++;
+      }
     }
     return null;
   }
@@ -54,10 +79,12 @@ export const INJECTED_HELPERS = `
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return [];
     var out = [];
-    for (var ri = 1; ri <= 5; ri++) {
+    var emptyStreak = 0;
+    for (var ri = 1; ri <= MAX_RENDERER_IDS; ri++) {
       try {
         var roots = hook.getFiberRoots(ri);
         if (roots && roots.size) {
+          emptyStreak = 0;
           var it = roots.values();
           var v;
           while (!(v = it.next()).done) {
@@ -65,8 +92,13 @@ export const INJECTED_HELPERS = `
               out.push({ rendererId: ri, fiber: v.value.current });
             }
           }
+        } else {
+          emptyStreak++;
+          if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && ri >= 5) return out;
         }
-      } catch (_) { /* skip bad renderer, keep going */ }
+      } catch (_) {
+        emptyStreak++;
+      }
     }
     return out;
   }
@@ -1038,16 +1070,139 @@ export const INJECTED_HELPERS = `
 
       if (action === 'typeText') {
         var text = opts.text !== undefined ? opts.text : '';
-        if (typeof props.onChangeText === 'function') {
-          props.onChangeText(text);
+
+        // Issue #126 Fix A — typeText handler resolution.
+        //
+        // Path 1 (preserved for backwards compatibility): when the matched
+        // fiber itself has onChangeText / onChange, fire them (existing
+        // behavior fires both if both exist — kept to avoid silent
+        // regressions on consumers depending on the order/double-fire).
+        //
+        // Path 2 (new): when neither handler is on the matched fiber,
+        // walk descendants for a typeable child. Common case: design-system
+        // TextField wraps TextInput in an outer Pressable/View; the wrapper
+        // testID resolves to the wrapper fiber whose props don't carry
+        // onChangeText. Walking down finds the inner TextInput. Bounds:
+        // depth ≤ 16, visit cap 200 across both passes. Two-pass: pass 1
+        // considers only onChangeText; pass 2 falls back to onChange (the
+        // overloaded RN/web handler) only if no onChangeText descendant
+        // exists. Within each pass: prefer fibers whose type matches a
+        // TextInput-family fingerprint; if multiple typed candidates
+        // match, return Ambiguous error rather than guess.
+        if (typeof props.onChangeText === 'function' || typeof props.onChange === 'function') {
+          if (typeof props.onChangeText === 'function') props.onChangeText(text);
+          if (typeof props.onChange === 'function') props.onChange({ nativeEvent: { text: text } });
+          return JSON.stringify({
+            success: true,
+            action: 'typeText',
+            component: typeName,
+            testID: selector,
+            text: text,
+            handlerCalled: typeof props.onChangeText === 'function' ? 'onChangeText' : 'onChange',
+            resolvedFrom: 'matched-fiber'
+          });
         }
-        if (typeof props.onChange === 'function') {
-          props.onChange({ nativeEvent: { text: text } });
+
+        var TYPEABLE_TYPE_RE = /(TextInput|Input|Field|TextField|EditText)/;
+        var visited = 0;
+        var DESCENDANT_DEPTH_CAP = 16;
+        var DESCENDANT_VISIT_CAP = 200;
+
+        function findHandlerDescendants(handlerName) {
+          var matches = [];
+          function walk(node, depth) {
+            if (!node || depth > DESCENDANT_DEPTH_CAP || visited > DESCENDANT_VISIT_CAP) return;
+            visited++;
+            var nProps = node.memoizedProps || {};
+            if (typeof nProps[handlerName] === 'function') {
+              var nName = (node.type && (node.type.displayName || node.type.name)) || '';
+              matches.push({
+                fiber: node,
+                props: nProps,
+                name: nName,
+                typeFingerprint: TYPEABLE_TYPE_RE.test(nName)
+              });
+            }
+            if (node.child) walk(node.child, depth + 1);
+            if (node.sibling) walk(node.sibling, depth);
+          }
+          if (found.child) walk(found.child, 1);
+          return matches;
         }
-        if (typeof props.onChangeText !== 'function' && typeof props.onChange !== 'function') {
-          return JSON.stringify({ error: 'Component has no onChangeText or onChange handler', component: typeName, testID: selector });
+
+        function pickFromMatches(matches, handlerName) {
+          if (matches.length === 0) return { kind: 'none' };
+          var typed = [];
+          for (var i = 0; i < matches.length; i++) if (matches[i].typeFingerprint) typed.push(matches[i]);
+          if (typed.length === 1) return { kind: 'one', match: typed[0], handler: handlerName };
+          if (typed.length > 1) return { kind: 'ambiguous', matches: typed, handler: handlerName };
+          if (matches.length === 1) return { kind: 'one', match: matches[0], handler: handlerName };
+          return { kind: 'ambiguous', matches: matches, handler: handlerName };
         }
-        return JSON.stringify({ success: true, action: 'typeText', component: typeName, testID: selector, text: text });
+
+        var pass1 = pickFromMatches(findHandlerDescendants('onChangeText'), 'onChangeText');
+        var picked = null;
+        if (pass1.kind === 'one') {
+          picked = pass1;
+        } else if (pass1.kind === 'ambiguous') {
+          return JSON.stringify({
+            error: 'Ambiguous typeText resolution',
+            testID: selector,
+            handler: 'onChangeText',
+            count: pass1.matches.length,
+            candidates: pass1.matches.slice(0, 5).map(function(m) {
+              return { component: m.name, testID: m.props.testID, typeFingerprint: m.typeFingerprint };
+            }),
+            hint: 'Multiple onChangeText descendants under testID "' + selector + '". Pass a more specific testID — ideally the inner TextInput itself.'
+          });
+        } else {
+          // pass 2 — onChange fallback
+          var pass2 = pickFromMatches(findHandlerDescendants('onChange'), 'onChange');
+          if (pass2.kind === 'one') {
+            picked = pass2;
+          } else if (pass2.kind === 'ambiguous') {
+            return JSON.stringify({
+              error: 'Ambiguous typeText resolution',
+              testID: selector,
+              handler: 'onChange',
+              count: pass2.matches.length,
+              candidates: pass2.matches.slice(0, 5).map(function(m) {
+                return { component: m.name, testID: m.props.testID, typeFingerprint: m.typeFingerprint };
+              }),
+              hint: 'Multiple onChange descendants under testID "' + selector + '". Pass a more specific testID — ideally the inner TextInput itself.'
+            });
+          }
+        }
+
+        if (!picked) {
+          return JSON.stringify({
+            error: 'Component has no onChangeText or onChange handler',
+            component: typeName,
+            testID: selector,
+            hint: 'Walked up to ' + DESCENDANT_DEPTH_CAP + ' levels (' + visited + ' fibers) — no descendant has a typeable handler. The matched fiber may not contain a TextInput. Use cdp_component_tree to inspect, or pass the inner field testID directly.'
+          });
+        }
+
+        // Single-fire — call only the picked handler. Avoids the
+        // double-fire bug on RHF Controllers where field.onChange wired
+        // to onChangeText + RN HostComponent onChange would each run
+        // with different argument shapes.
+        if (picked.handler === 'onChangeText') {
+          picked.match.props.onChangeText(text);
+        } else {
+          picked.match.props.onChange({ nativeEvent: { text: text } });
+        }
+
+        return JSON.stringify({
+          success: true,
+          action: 'typeText',
+          component: typeName,
+          testID: selector,
+          text: text,
+          handlerCalled: picked.handler,
+          resolvedFrom: picked.match.name + (picked.match.props.testID ? ' [testID="' + picked.match.props.testID + '"]' : ''),
+          visitedFibers: visited
+        });
       }
 
       if (action === 'scroll') {
@@ -1638,6 +1793,9 @@ export const REACT_READY_PROBE_JS = `(function() {
 // INJECTED_HELPERS. The in-IIFE copy MUST be kept in sync with this logic.
 // Tests exercise this mirror; the IIFE version runs in Hermes as pure JS.
 // See test/unit/component-tree-multi-renderer.test.js for the contract.
+//
+// Issue #126: bumped MAX_RENDERER_IDS from 5 → 20 with early-exit-after-3-empty
+// heuristic so apps that register a renderer at id 6+ are no longer invisible.
 export interface FiberLike { current?: unknown }
 export interface RendererRootsLike {
   size: number;
@@ -1647,19 +1805,31 @@ export interface DevToolsHookLike {
   getFiberRoots?: (rendererId: number) => RendererRootsLike | null | undefined;
 }
 
+export const MAX_RENDERER_IDS = 20;
+export const EARLY_EXIT_EMPTY_STREAK = 3;
+
 export function findAllRootFibersForTest(hook: DevToolsHookLike | null | undefined): Array<{ rendererId: number; fiber: unknown }> {
   if (!hook || typeof hook.getFiberRoots !== 'function') return [];
   const out: Array<{ rendererId: number; fiber: unknown }> = [];
-  for (let ri = 1; ri <= 5; ri++) {
-    const roots = hook.getFiberRoots(ri);
-    if (roots && roots.size) {
-      const it = roots.values();
-      let step = it.next();
-      while (!step.done) {
-        const r = step.value;
-        if (r && r.current) out.push({ rendererId: ri, fiber: r.current });
-        step = it.next();
+  let emptyStreak = 0;
+  for (let ri = 1; ri <= MAX_RENDERER_IDS; ri++) {
+    try {
+      const roots = hook.getFiberRoots(ri);
+      if (roots && roots.size) {
+        emptyStreak = 0;
+        const it = roots.values();
+        let step = it.next();
+        while (!step.done) {
+          const r = step.value;
+          if (r && r.current) out.push({ rendererId: ri, fiber: r.current });
+          step = it.next();
+        }
+      } else {
+        emptyStreak++;
+        if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && ri >= 5) return out;
       }
+    } catch {
+      emptyStreak++;
     }
   }
   return out;

--- a/scripts/cdp-bridge/src/injected-helpers.ts
+++ b/scripts/cdp-bridge/src/injected-helpers.ts
@@ -1073,37 +1073,52 @@ export const INJECTED_HELPERS = `
 
         // Issue #126 Fix A — typeText handler resolution.
         //
-        // Path 1 (preserved for backwards compatibility): when the matched
-        // fiber itself has onChangeText / onChange, fire them (existing
-        // behavior fires both if both exist — kept to avoid silent
-        // regressions on consumers depending on the order/double-fire).
+        // Path 1: matched fiber itself has onChangeText / onChange. SINGLE-
+        // fire — pick onChangeText if present, else onChange. Avoids the
+        // double-fire bug: when an RHF Controller wraps a TextInput via
+        // <TextInput {...field} />, both onChangeText and onChange are bound
+        // to field.onChange. Firing both ran field.onChange twice with
+        // different argument shapes (string then {nativeEvent}), corrupting
+        // the form state and double-triggering validators.
         //
-        // Path 2 (new): when neither handler is on the matched fiber,
-        // walk descendants for a typeable child. Common case: design-system
+        // Path 2: when matched fiber has no typeable handler, walk
+        // descendants for a typeable child. Common case: design-system
         // TextField wraps TextInput in an outer Pressable/View; the wrapper
         // testID resolves to the wrapper fiber whose props don't carry
         // onChangeText. Walking down finds the inner TextInput. Bounds:
         // depth ≤ 16, visit cap 200 across both passes. Two-pass: pass 1
         // considers only onChangeText; pass 2 falls back to onChange (the
-        // overloaded RN/web handler) only if no onChangeText descendant
+        // overloaded RN handler) only if no onChangeText descendant
         // exists. Within each pass: prefer fibers whose type matches a
-        // TextInput-family fingerprint; if multiple typed candidates
-        // match, return Ambiguous error rather than guess.
+        // TextInput-family fingerprint, then dedupe candidates that share
+        // the same handler function reference (react-native-paper wraps
+        // TextInputOutlined → TextInput → InternalTextInput each forwarding
+        // the same onChangeText — pick the deepest leaf), and return
+        // Ambiguous only when truly distinct typed handlers compete.
         if (typeof props.onChangeText === 'function' || typeof props.onChange === 'function') {
-          if (typeof props.onChangeText === 'function') props.onChangeText(text);
-          if (typeof props.onChange === 'function') props.onChange({ nativeEvent: { text: text } });
+          var p1Handler;
+          if (typeof props.onChangeText === 'function') {
+            p1Handler = 'onChangeText';
+            props.onChangeText(text);
+          } else {
+            p1Handler = 'onChange';
+            props.onChange({ nativeEvent: { text: text } });
+          }
           return JSON.stringify({
             success: true,
             action: 'typeText',
             component: typeName,
             testID: selector,
             text: text,
-            handlerCalled: typeof props.onChangeText === 'function' ? 'onChangeText' : 'onChange',
+            handlerCalled: p1Handler,
             resolvedFrom: 'matched-fiber'
           });
         }
 
-        var TYPEABLE_TYPE_RE = /(TextInput|Input|Field|TextField|EditText)/;
+        // Anchored on TextInput-family names. Drops bare Input/Field
+        // substrings to avoid false-positives on RadioGroupField,
+        // InputAccessoryView, BottomSheetTextInput's wrapper, etc.
+        var TYPEABLE_TYPE_RE = /(TextInput|TextField|EditText)/;
         var visited = 0;
         var DESCENDANT_DEPTH_CAP = 16;
         var DESCENDANT_VISIT_CAP = 200;
@@ -1120,6 +1135,7 @@ export const INJECTED_HELPERS = `
                 fiber: node,
                 props: nProps,
                 name: nName,
+                depth: depth,
                 typeFingerprint: TYPEABLE_TYPE_RE.test(nName)
               });
             }
@@ -1130,14 +1146,40 @@ export const INJECTED_HELPERS = `
           return matches;
         }
 
+        // Dedupe candidates that share the same handler function reference.
+        // react-native-paper's TextInputOutlined → TextInput → InternalTextInput
+        // chain each forwards the SAME onChangeText down — they're the same
+        // logical handler, not three independent typeable fields. Keep the
+        // deepest leaf so the call lands on the host-component fiber that
+        // actually owns the input. (Codex M4 / multi-LLM review of issue #126.)
+        function dedupeByHandlerIdentity(matches, handlerName) {
+          var byFn = [];
+          for (var i = 0; i < matches.length; i++) {
+            var m = matches[i];
+            var fn = m.props[handlerName];
+            var existingIdx = -1;
+            for (var j = 0; j < byFn.length; j++) {
+              if (byFn[j].props[handlerName] === fn) { existingIdx = j; break; }
+            }
+            if (existingIdx === -1) {
+              byFn.push(m);
+            } else if (m.depth > byFn[existingIdx].depth) {
+              // Same handler, deeper fiber — replace with the leaf.
+              byFn[existingIdx] = m;
+            }
+          }
+          return byFn;
+        }
+
         function pickFromMatches(matches, handlerName) {
           if (matches.length === 0) return { kind: 'none' };
+          var deduped = dedupeByHandlerIdentity(matches, handlerName);
           var typed = [];
-          for (var i = 0; i < matches.length; i++) if (matches[i].typeFingerprint) typed.push(matches[i]);
+          for (var i = 0; i < deduped.length; i++) if (deduped[i].typeFingerprint) typed.push(deduped[i]);
           if (typed.length === 1) return { kind: 'one', match: typed[0], handler: handlerName };
           if (typed.length > 1) return { kind: 'ambiguous', matches: typed, handler: handlerName };
-          if (matches.length === 1) return { kind: 'one', match: matches[0], handler: handlerName };
-          return { kind: 'ambiguous', matches: matches, handler: handlerName };
+          if (deduped.length === 1) return { kind: 'one', match: deduped[0], handler: handlerName };
+          return { kind: 'ambiguous', matches: deduped, handler: handlerName };
         }
 
         var pass1 = pickFromMatches(findHandlerDescendants('onChangeText'), 'onChangeText');

--- a/scripts/cdp-bridge/src/tools/diagnostic-renderers.ts
+++ b/scripts/cdp-bridge/src/tools/diagnostic-renderers.ts
@@ -33,11 +33,17 @@ const DIAGNOSTIC_RENDERERS_JS = `(function(opts) {
     });
   }
 
-  var max = (opts && opts.maxRendererId) ? opts.maxRendererId : 20;
+  var max = (opts && typeof opts.maxRendererId === 'number') ? opts.maxRendererId : 20;
   var notes = [];
+  // Use getOwnPropertyNames so non-enumerable hook properties (e.g. those
+  // installed by React DevTools backend via Object.defineProperty with
+  // enumerable:false — renderers, getFiberRoots, inject on some
+  // versions) are surfaced. for...in / Object.keys would miss them.
   var hookKeys = [];
-  for (var k in hook) {
-    if (Object.prototype.hasOwnProperty.call(hook, k)) hookKeys.push(k);
+  try {
+    hookKeys = Object.getOwnPropertyNames(hook);
+  } catch (_) {
+    hookKeys = [];
   }
 
   var rendererKeys = [];
@@ -107,15 +113,28 @@ const DIAGNOSTIC_RENDERERS_JS = `(function(opts) {
     }
   }
 
+  // Single consolidated "registered but unscanned" note (Gemini H3 +
+  // Codex M1 from PR #130 review): list ALL unscanned IDs once with a
+  // single re-run suggestion at the max needed value. Avoids N misleading
+  // "+5 buffer" notes that confused the user about the actual cause.
   if (earlyExited) {
+    var unscanned = [];
     for (var rk = 0; rk < rendererKeys.length; rk++) {
       var matched = false;
       for (var rr = 0; rr < rows.length; rr++) {
         if (rows[rr].rendererId === rendererKeys[rk]) { matched = true; break; }
       }
-      if (!matched) {
-        notes.push('Renderer ID ' + rendererKeys[rk] + ' was registered but not scanned (early-exit). Pass maxRendererId=' + (rendererKeys[rk] + 5) + ' to include it.');
-      }
+      if (!matched) unscanned.push(rendererKeys[rk]);
+    }
+    if (unscanned.length > 0) {
+      var needed = unscanned[0];
+      for (var ui = 1; ui < unscanned.length; ui++) if (unscanned[ui] > needed) needed = unscanned[ui];
+      notes.push('Renderer ID' + (unscanned.length > 1 ? 's' : '') + ' ' + unscanned.join(', ') + ' ' + (unscanned.length > 1 ? 'were' : 'was') + ' registered but not scanned (early-exit). Re-run with maxRendererId=' + needed + ' to include ' + (unscanned.length > 1 ? 'them' : 'it') + '.');
+    } else if (rendererKeys.length === 0) {
+      // hook.renderers was missing — we can't tell which IDs were skipped.
+      // Surface the gap explicitly so the user knows to re-run wider.
+      var lastScanned = rows.length ? rows[rows.length - 1].rendererId : 0;
+      notes.push('Early-exited at renderer ' + lastScanned + '. hook.renderers is unavailable so we cannot detect skipped renderers. Re-run with maxRendererId=' + (lastScanned + 10) + ' if you suspect a renderer at id ' + (lastScanned + 1) + '+.');
     }
   }
 

--- a/scripts/cdp-bridge/src/tools/diagnostic-renderers.ts
+++ b/scripts/cdp-bridge/src/tools/diagnostic-renderers.ts
@@ -1,0 +1,157 @@
+// Issue #126 follow-up — diagnostic helper for "fiber root invisibility"
+// bug reports. Returns a complete enumeration of registered React renderers
+// + their root counts so users can self-serve diagnose Gap-B-style failures
+// (modal/portal mounted but cdp_component_tree returns empty).
+//
+// Read-only: makes no mutations. Surfaces the raw shape of
+// __REACT_DEVTOOLS_GLOBAL_HOOK__ in a single round-trip.
+
+import type { CDPClient } from '../cdp-client.js';
+import { okResult, failResult, withConnection } from '../utils.js';
+
+interface DiagnosticRenderersArgs {
+  /**
+   * How many renderer IDs to scan. Default 20 (matches the IIFE
+   * MAX_RENDERER_IDS). Set higher only if the standard scan misses
+   * something — most apps register 1-3 renderers.
+   */
+  maxRendererId?: number;
+}
+
+const DIAGNOSTIC_RENDERERS_JS = `(function(opts) {
+  var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  if (!hook) {
+    return JSON.stringify({
+      hookPresent: false,
+      hookKeys: [],
+      rendererCount: 0,
+      rendererKeys: [],
+      rows: [],
+      scannedRange: { from: 0, to: 0 },
+      earlyExited: false,
+      notes: ['__REACT_DEVTOOLS_GLOBAL_HOOK__ is not defined — DevTools backend has not loaded. Verify you are on a Dev Client / dev-mode bundle.']
+    });
+  }
+
+  var max = (opts && opts.maxRendererId) ? opts.maxRendererId : 20;
+  var notes = [];
+  var hookKeys = [];
+  for (var k in hook) {
+    if (Object.prototype.hasOwnProperty.call(hook, k)) hookKeys.push(k);
+  }
+
+  var rendererKeys = [];
+  if (hook.renderers && typeof hook.renderers.forEach === 'function') {
+    hook.renderers.forEach(function(_v, key) {
+      if (typeof key === 'number') rendererKeys.push(key);
+    });
+    rendererKeys.sort(function(a, b) { return a - b; });
+  } else {
+    notes.push('hook.renderers is not a Map — falling back to iteration only.');
+  }
+
+  if (typeof hook.getFiberRoots !== 'function') {
+    return JSON.stringify({
+      hookPresent: true,
+      hookKeys: hookKeys,
+      rendererCount: rendererKeys.length,
+      rendererKeys: rendererKeys,
+      rows: [],
+      scannedRange: { from: 0, to: 0 },
+      earlyExited: false,
+      notes: notes.concat(['hook.getFiberRoots is missing. Cannot enumerate fiber roots — DevTools backend may be a stub.'])
+    });
+  }
+
+  function summarize(rootCurrent) {
+    if (!rootCurrent || typeof rootCurrent !== 'object') return null;
+    var typeName = (rootCurrent.type && (rootCurrent.type.displayName || rootCurrent.type.name)) || null;
+    var childTypeName = null;
+    var testID = null;
+    if (rootCurrent.child) {
+      var c = rootCurrent.child;
+      childTypeName = (c.type && (c.type.displayName || c.type.name)) || null;
+      var props = c.memoizedProps;
+      if (props && typeof props === 'object' && props.testID) testID = String(props.testID);
+    }
+    return { typeName: typeName, childTypeName: childTypeName, testID: testID };
+  }
+
+  var rows = [];
+  var emptyStreak = 0;
+  var earlyExited = false;
+  for (var ri = 1; ri <= max; ri++) {
+    try {
+      var roots = hook.getFiberRoots(ri);
+      if (roots && roots.size) {
+        emptyStreak = 0;
+        var rootInfo = [];
+        var it = roots.values();
+        var step = it.next();
+        while (!step.done) {
+          if (step.value && step.value.current) {
+            var s = summarize(step.value.current);
+            if (s) rootInfo.push(s);
+          }
+          step = it.next();
+        }
+        rows.push({ rendererId: ri, rootCount: roots.size, roots: rootInfo });
+      } else {
+        rows.push({ rendererId: ri, rootCount: 0 });
+        emptyStreak++;
+        if (emptyStreak >= 3 && ri >= 5) { earlyExited = true; break; }
+      }
+    } catch (err) {
+      rows.push({ rendererId: ri, rootCount: null, error: String(err && err.message || err) });
+      emptyStreak++;
+    }
+  }
+
+  if (earlyExited) {
+    for (var rk = 0; rk < rendererKeys.length; rk++) {
+      var matched = false;
+      for (var rr = 0; rr < rows.length; rr++) {
+        if (rows[rr].rendererId === rendererKeys[rk]) { matched = true; break; }
+      }
+      if (!matched) {
+        notes.push('Renderer ID ' + rendererKeys[rk] + ' was registered but not scanned (early-exit). Pass maxRendererId=' + (rendererKeys[rk] + 5) + ' to include it.');
+      }
+    }
+  }
+
+  return JSON.stringify({
+    hookPresent: true,
+    hookKeys: hookKeys,
+    rendererCount: rendererKeys.length || rows.filter(function(r) { return r.rootCount && r.rootCount > 0; }).length,
+    rendererKeys: rendererKeys,
+    rows: rows,
+    scannedRange: { from: 1, to: rows.length ? rows[rows.length - 1].rendererId : 0 },
+    earlyExited: earlyExited,
+    notes: notes
+  });
+})`;
+
+export function createDiagnosticRenderersHandler(getClient: () => CDPClient) {
+  return withConnection(getClient, async (args: DiagnosticRenderersArgs, client) => {
+    const max = args.maxRendererId ?? 20;
+    if (max < 1 || max > 100) {
+      return failResult(`cdp_diagnostic_renderers: maxRendererId must be 1..100 (got ${max})`);
+    }
+    const expression = `${DIAGNOSTIC_RENDERERS_JS}({maxRendererId: ${JSON.stringify(max)}})`;
+    const result = await client.evaluate(expression);
+
+    if (result.error) {
+      return failResult(`cdp_diagnostic_renderers: ${result.error}`);
+    }
+    if (typeof result.value !== 'string') {
+      return failResult('cdp_diagnostic_renderers: hook probe returned non-string');
+    }
+
+    try {
+      const parsed = JSON.parse(result.value);
+      return okResult(parsed);
+    } catch (err) {
+      return failResult(`cdp_diagnostic_renderers: failed to parse hook probe response: ${String(err)}`);
+    }
+  });
+}

--- a/scripts/cdp-bridge/src/tools/save-as-action.ts
+++ b/scripts/cdp-bridge/src/tools/save-as-action.ts
@@ -72,6 +72,16 @@ export interface SaveAsActionArgs {
    * header in the YAML. Falls back to `intent` when absent.
    */
   testName?: string;
+  /**
+   * D1209 — state postconditions this action establishes when it runs
+   * cleanly. Flat map of primitive values (string | number | boolean).
+   * The agent uses this for hybrid composition: when a downstream task
+   * needs a state the current app doesn't satisfy, it scans for an
+   * action whose `produces` covers the gap and replays it as a
+   * deterministic prologue. Optional. Example:
+   * `{ authenticated: true, route: 'home' }`.
+   */
+  produces?: Record<string, string | number | boolean>;
 }
 
 export function createSaveAsActionHandler() {
@@ -132,6 +142,7 @@ export function createSaveAsActionHandler() {
       tags: args.tags,
       mutates: args.mutates,
       status,
+      produces: args.produces,
     });
 
     // Issue #101: sidecar-first atomic pair-write. The atomicWriter
@@ -160,6 +171,7 @@ export function createSaveAsActionHandler() {
         mutates: args.mutates,
         status,
         appId: args.bundleId,
+        produces: args.produces,
       },
       hint: `Action emitted as experimental. Run /run-action ${args.id} to validate; on first clean replay it auto-promotes to active.`,
     });

--- a/scripts/cdp-bridge/src/tools/test-recorder-generators.ts
+++ b/scripts/cdp-bridge/src/tools/test-recorder-generators.ts
@@ -36,6 +36,12 @@ export interface GenerateOpts {
   tags?: string[];
   mutates?: boolean;
   status?: 'active' | 'deprecated' | 'experimental';
+  // D1209 — state postconditions this action establishes when it runs
+  // cleanly. Flat map of primitive values (string | number | boolean).
+  // Emitted as `# produces: { key: value, ... }` so single-line parsers
+  // can pick it up. Values containing commas or newlines are not
+  // supported in v1.
+  produces?: Record<string, string | number | boolean>;
 }
 
 type MetaPair = [string, string];
@@ -50,6 +56,16 @@ function metaPairs(opts: GenerateOpts): MetaPair[] {
   }
   if (typeof opts.mutates === 'boolean') out.push(['mutates', String(opts.mutates)]);
   if (opts.status) out.push(['status', stripNewlines(opts.status)]);
+  if (opts.produces && Object.keys(opts.produces).length > 0) {
+    const pairs = Object.keys(opts.produces)
+      .sort()
+      .map((k) => {
+        const v = opts.produces![k];
+        const formatted = typeof v === 'string' ? stripNewlines(v) : String(v);
+        return `${k}: ${formatted}`;
+      });
+    out.push(['produces', `{ ${pairs.join(', ')} }`]);
+  }
   return out;
 }
 

--- a/scripts/cdp-bridge/test/unit/component-tree-multi-renderer.test.js
+++ b/scripts/cdp-bridge/test/unit/component-tree-multi-renderer.test.js
@@ -160,26 +160,45 @@ test('B143: root without .current is filtered out', () => {
   assert.equal(result[0].fiber.tag, 'real');
 });
 
-test('B143 A3 (Gemini 80): per-renderer throw does NOT poison the union (TS mirror contract)', () => {
-  // Current TS mirror does bubble, but the injected IIFE now has try/catch
-  // guards around each renderer access (see regression guard below).
-  // If the TS mirror is hardened later, update this test to assert partial
-  // results rather than throw.
+test('B143 A3 (Gemini 80) + Issue #126: per-renderer throw does NOT poison the union — TS mirror hardened', () => {
+  // Issue #126: TS mirror was hardened to add per-renderer try/catch
+  // (matching the IIFE behavior, B143 A3). A throwing renderer is treated
+  // as empty for that ID and counts toward the early-exit-after-3-empty
+  // streak. This test now asserts partial-results rather than throw.
   const hook = {
     getFiberRoots(ri) {
       if (ri === 2) throw new Error('boom');
+      if (ri === 1) {
+        return {
+          size: 1,
+          values() {
+            let sent = false;
+            return {
+              next() {
+                if (sent) return { done: true, value: undefined };
+                sent = true;
+                return { done: false, value: { current: { tag: 'real' } } };
+              },
+            };
+          },
+        };
+      }
       return null;
     },
   };
-  assert.throws(() => findAllRootFibersForTest(hook), /boom/);
+  const result = findAllRootFibersForTest(hook);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].rendererId, 1);
 });
 
 // ── Regression guard against IIFE/TS-mirror drift ─────────────────────
 
-test('B143: injected helpers contain findAllRootFibers with 1..5 loop', () => {
+test('B143 + Issue #126: injected helpers contain findAllRootFibers with MAX_RENDERER_IDS loop', () => {
   const src = INJECTED_HELPERS;
   assert.match(src, /function findAllRootFibers\(\)/, 'findAllRootFibers function missing from injected helpers');
-  assert.match(src, /for \(var ri = 1; ri <= 5; ri\+\+\)/, '1..5 renderer loop missing');
+  // Issue #126: cap bumped from 5 → 20. Loop condition uses the constant.
+  assert.match(src, /for \(var ri = 1; ri <= MAX_RENDERER_IDS; ri\+\+\)/, 'renderer loop missing or no longer uses MAX_RENDERER_IDS constant');
+  assert.match(src, /var MAX_RENDERER_IDS = 20;/, 'MAX_RENDERER_IDS constant missing or not 20');
   assert.match(src, /hook\.getFiberRoots\(ri\)/, 'hook.getFiberRoots(ri) iteration missing');
   assert.match(src, /out\.push\(\{ rendererId: ri, fiber: v\.value\.current \}\)/, 'out.push signature drifted from TS mirror');
 });

--- a/scripts/cdp-bridge/test/unit/find-active-renderer-migration.test.js
+++ b/scripts/cdp-bridge/test/unit/find-active-renderer-migration.test.js
@@ -10,15 +10,17 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { INJECTED_HELPERS } from '../../dist/injected-helpers.js';
 
-test('B145: forEachRootFiber helper is defined in the IIFE', () => {
+test('B145 + Issue #126: forEachRootFiber helper is defined in the IIFE', () => {
   assert.match(INJECTED_HELPERS, /function forEachRootFiber\(cb\)/, 'forEachRootFiber helper missing');
-  // Iterates renderers 1..5 with try/catch per renderer
+  // Issue #126: cap bumped from 5 → 20 with early-exit-after-3-empty.
   const slice = INJECTED_HELPERS.split('function forEachRootFiber')[1]?.split('function ')[0] ?? '';
-  assert.match(slice, /for \(var ri = 1; ri <= 5; ri\+\+\)/, 'forEachRootFiber missing renderer loop');
+  assert.match(slice, /for \(var ri = 1; ri <= MAX_RENDERER_IDS; ri\+\+\)/, 'forEachRootFiber missing renderer loop');
   assert.match(slice, /try \{/, 'forEachRootFiber missing try guard');
   assert.match(slice, /catch \(_\)/, 'forEachRootFiber missing per-renderer catch');
   // Short-circuits on truthy callback return
   assert.match(slice, /if \(result\) return result;/, 'forEachRootFiber short-circuit missing');
+  // Cap is 20
+  assert.match(INJECTED_HELPERS, /var MAX_RENDERER_IDS = 20;/, 'MAX_RENDERER_IDS constant missing or not 20');
 });
 
 test('B145: getStoreState redux fiber walk uses forEachRootFiber (not single-renderer)', () => {

--- a/scripts/cdp-bridge/test/unit/gh-60-bug-5-label-matching.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-60-bug-5-label-matching.test.js
@@ -324,6 +324,6 @@ test('source guard: getTree filter checks accessibilityLabel', () => {
   assert.match(INJECTED_HELPERS, /matchesName \|\| matchesTestID \|\| matchesLabel/);
 });
 
-test('source guard: helpers version bumped to 20', () => {
-  assert.match(INJECTED_HELPERS, /__HELPERS_VERSION__ = 20;/);
+test('source guard: helpers version bumped to 21', () => {
+  assert.match(INJECTED_HELPERS, /__HELPERS_VERSION__ = 21;/);
 });

--- a/scripts/cdp-bridge/test/unit/injected-helpers.test.js
+++ b/scripts/cdp-bridge/test/unit/injected-helpers.test.js
@@ -317,6 +317,6 @@ test('M10: getAppInfo returns architecture=unknown when nativeFabricUIManager is
   assert.equal(info.architecture, 'unknown');
 });
 
-test('GH #60-5: helpers bundle version is 20 (bumped for tiered accessibilityLabel matching)', () => {
-  assert.match(INJECTED_HELPERS, /__HELPERS_VERSION__\s*=\s*20/);
+test('Issue #126: helpers bundle version is 21 (bumped for typeText descendant walk + MAX_RENDERER_IDS=20)', () => {
+  assert.match(INJECTED_HELPERS, /__HELPERS_VERSION__\s*=\s*21/);
 });

--- a/scripts/cdp-bridge/test/unit/issue-126-typetext-walkdown.test.js
+++ b/scripts/cdp-bridge/test/unit/issue-126-typetext-walkdown.test.js
@@ -19,17 +19,36 @@ function typeTextSlice() {
   return INJECTED_HELPERS.slice(open, close);
 }
 
-test('Issue #126: typeText branch preserves immediate-fiber path for backwards compat', () => {
+test('Issue #126: typeText Path 1 (matched-fiber) is single-fire — picks onChangeText if present, else onChange', () => {
   const slice = typeTextSlice();
-  // Path 1 still fires both handlers when present on the matched fiber.
+  // Path 1 single-fires after multi-LLM review caught the double-fire
+  // bug on RHF Controllers (Gemini H1 from implementation review).
   assert.match(slice, /typeof props\.onChangeText === 'function' \|\| typeof props\.onChange === 'function'/);
   assert.match(slice, /resolvedFrom: 'matched-fiber'/);
+  // Single-fire structure: if-onChangeText-else-onChange (NOT if-then-if).
+  assert.match(slice, /if \(typeof props\.onChangeText === 'function'\) \{[^}]*p1Handler = 'onChangeText';[^}]*props\.onChangeText\(text\);[^}]*\} else \{[^}]*p1Handler = 'onChange';[^}]*props\.onChange\(/);
 });
 
-test('Issue #126: typeText descendant walk has TextInput-family type fingerprint', () => {
+test('Issue #126: typeText descendant walk has TextInput-family type fingerprint (anchored, no bare Input/Field)', () => {
   const slice = typeTextSlice();
-  // TYPEABLE_TYPE_RE matches the React Native + design-system TextInput component naming.
-  assert.match(slice, /TYPEABLE_TYPE_RE\s*=\s*\/\(TextInput\|Input\|Field\|TextField\|EditText\)\//);
+  // TYPEABLE_TYPE_RE was tightened after multi-LLM review: bare `Input`
+  // and `Field` substrings produced false positives on RadioGroupField,
+  // InputAccessoryView, BottomSheetTextInput's wrapper, etc.
+  assert.match(slice, /TYPEABLE_TYPE_RE\s*=\s*\/\(TextInput\|TextField\|EditText\)\//);
+  // Negative guard — make sure the loose form doesn't sneak back in.
+  assert.doesNotMatch(slice, /\(TextInput\|Input\|Field\|TextField\|EditText\)/);
+});
+
+test('Issue #126: dedupe candidates by handler-function identity (Codex M4 from impl review)', () => {
+  const slice = typeTextSlice();
+  // react-native-paper's TextInputOutlined → TextInput → InternalTextInput
+  // chain forwards the same onChangeText down. Without dedupe, the impl
+  // returns Ambiguous error on a perfectly normal Paper TextField. Fix:
+  // group candidates by handler function reference, keep the deepest leaf.
+  assert.match(slice, /function dedupeByHandlerIdentity/);
+  assert.match(slice, /byFn\[j\]\.props\[handlerName\] === fn/);
+  // Prefer-deepest tiebreak.
+  assert.match(slice, /m\.depth > byFn\[existingIdx\]\.depth/);
 });
 
 test('Issue #126: typeText descendant walk is depth- and visit-bounded', () => {
@@ -83,10 +102,11 @@ test('Issue #126: typeText error message hints at depth + visited count for debu
   assert.match(slice, /cdp_component_tree to inspect/);
 });
 
-test('Issue #126: source guard — typeText branch length sanity (~5KB ± 1KB)', () => {
-  // The new descendant walk is ~5KB. If this assertion fails wildly, a
-  // recent edit may have either removed the new code path or doubled it.
+test('Issue #126: source guard — typeText branch length sanity', () => {
+  // Loose bounds — only catches "code path completely removed" (lower)
+  // or "accidental duplication of the entire branch" (upper). Codex M5
+  // from impl review flagged tight bounds as fragile; widened.
   const slice = typeTextSlice();
   assert.ok(slice.length > 3500, `typeText branch unexpectedly short (${slice.length} bytes); descendant walk may have been removed`);
-  assert.ok(slice.length < 7000, `typeText branch unexpectedly long (${slice.length} bytes); duplicated code or accidental copy?`);
+  assert.ok(slice.length < 15000, `typeText branch unexpectedly long (${slice.length} bytes); accidental copy or runaway code?`);
 });

--- a/scripts/cdp-bridge/test/unit/issue-126-typetext-walkdown.test.js
+++ b/scripts/cdp-bridge/test/unit/issue-126-typetext-walkdown.test.js
@@ -1,0 +1,92 @@
+// Issue #126 Fix A — typeText descendant walk source-guard tests.
+// Validates the IIFE structure for the new typeText handler resolution
+// path: when matched fiber has no onChangeText/onChange, walk descendants
+// for a typeable child. The IIFE runs in Hermes; behavioral tests run
+// against the live device. These guards prevent silent regressions to
+// the old immediate-fiber-only behavior.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { INJECTED_HELPERS } from '../../dist/injected-helpers.js';
+
+// Slice typeText branch from the IIFE — everything between
+// `action === 'typeText'` and the next `action === 'scroll'` block.
+function typeTextSlice() {
+  const open = INJECTED_HELPERS.indexOf("action === 'typeText'");
+  const close = INJECTED_HELPERS.indexOf("action === 'scroll'", open);
+  assert.ok(open >= 0, 'typeText branch not found in IIFE');
+  assert.ok(close > open, 'scroll branch not found after typeText (slice would be unbounded)');
+  return INJECTED_HELPERS.slice(open, close);
+}
+
+test('Issue #126: typeText branch preserves immediate-fiber path for backwards compat', () => {
+  const slice = typeTextSlice();
+  // Path 1 still fires both handlers when present on the matched fiber.
+  assert.match(slice, /typeof props\.onChangeText === 'function' \|\| typeof props\.onChange === 'function'/);
+  assert.match(slice, /resolvedFrom: 'matched-fiber'/);
+});
+
+test('Issue #126: typeText descendant walk has TextInput-family type fingerprint', () => {
+  const slice = typeTextSlice();
+  // TYPEABLE_TYPE_RE matches the React Native + design-system TextInput component naming.
+  assert.match(slice, /TYPEABLE_TYPE_RE\s*=\s*\/\(TextInput\|Input\|Field\|TextField\|EditText\)\//);
+});
+
+test('Issue #126: typeText descendant walk is depth- and visit-bounded', () => {
+  const slice = typeTextSlice();
+  assert.match(slice, /DESCENDANT_DEPTH_CAP\s*=\s*16/);
+  assert.match(slice, /DESCENDANT_VISIT_CAP\s*=\s*200/);
+});
+
+test('Issue #126: typeText is two-pass — onChangeText first, then onChange', () => {
+  const slice = typeTextSlice();
+  const pass1 = slice.indexOf("findHandlerDescendants('onChangeText')");
+  const pass2 = slice.indexOf("findHandlerDescendants('onChange')");
+  assert.ok(pass1 >= 0, 'pass 1 (onChangeText) findHandlerDescendants call missing');
+  assert.ok(pass2 >= 0, 'pass 2 (onChange) findHandlerDescendants call missing');
+  assert.ok(pass1 < pass2, 'onChangeText pass must come before onChange pass (avoids double-fire on RHF Controller-wrapped fields)');
+});
+
+test('Issue #126: typeText descendant walk single-fires (no double-fire bug from descendants)', () => {
+  const slice = typeTextSlice();
+  // The picked-handler dispatch is an if/else, not an if/if. This prevents
+  // the double-fire bug Codex H1 caught: RHF Controller's field.onChange
+  // wired to onChangeText + RN HostComponent onChange would each run with
+  // different argument shapes, double-applying or triggering RHF's
+  // validator twice.
+  assert.match(
+    slice,
+    /if \(picked\.handler === 'onChangeText'\) \{[^}]*picked\.match\.props\.onChangeText\(text\);[^}]*\} else \{[^}]*picked\.match\.props\.onChange\(/,
+  );
+});
+
+test('Issue #126: typeText returns Ambiguous error when multiple type-fingerprint matches', () => {
+  const slice = typeTextSlice();
+  assert.match(slice, /Ambiguous typeText resolution/);
+  // Two distinct ambiguity reports — pass 1 (onChangeText) and pass 2 (onChange).
+  const ambiguousCount = (slice.match(/Ambiguous typeText resolution/g) || []).length;
+  assert.equal(ambiguousCount, 2, 'expected 2 Ambiguous error returns (pass 1 + pass 2)');
+});
+
+test('Issue #126: typeText success payload includes resolvedFrom + handlerCalled + visitedFibers', () => {
+  const slice = typeTextSlice();
+  assert.match(slice, /resolvedFrom: picked\.match\.name/);
+  assert.match(slice, /handlerCalled: picked\.handler/);
+  assert.match(slice, /visitedFibers: visited/);
+});
+
+test('Issue #126: typeText error message hints at depth + visited count for debugging', () => {
+  const slice = typeTextSlice();
+  // The "no descendant has typeable handler" error includes diagnostic
+  // hints — depth cap + visit count + cdp_component_tree pointer.
+  assert.match(slice, /Walked up to ' \+ DESCENDANT_DEPTH_CAP \+ ' levels \(' \+ visited \+ ' fibers\)/);
+  assert.match(slice, /cdp_component_tree to inspect/);
+});
+
+test('Issue #126: source guard — typeText branch length sanity (~5KB ± 1KB)', () => {
+  // The new descendant walk is ~5KB. If this assertion fails wildly, a
+  // recent edit may have either removed the new code path or doubled it.
+  const slice = typeTextSlice();
+  assert.ok(slice.length > 3500, `typeText branch unexpectedly short (${slice.length} bytes); descendant walk may have been removed`);
+  assert.ok(slice.length < 7000, `typeText branch unexpectedly long (${slice.length} bytes); duplicated code or accidental copy?`);
+});

--- a/scripts/cdp-bridge/test/unit/reusable-action.test.js
+++ b/scripts/cdp-bridge/test/unit/reusable-action.test.js
@@ -267,3 +267,65 @@ test('Phase127 serializeM7Header: newlines stripped from VALUES (not between fie
   // Verify count: 3 lines, exactly 2 newlines between them.
   assert.equal(out.split('\n').length, 3);
 });
+
+// D1209 produces field — hybrid composition state postconditions.
+test('D1209 serializeM7Header: produces emits inline map with sorted keys', () => {
+  const meta = {
+    id: 'x',
+    intent: 'y',
+    status: 'active',
+    produces: { route: 'home', authenticated: true, count: 3 },
+  };
+  const out = serializeM7Header(meta);
+  // Sorted alphabetically: authenticated, count, route.
+  assert.match(out, /# produces: \{ authenticated: true, count: 3, route: home \}/);
+});
+
+test('D1209 serializeM7Header: omits produces when undefined or empty', () => {
+  const omitted = serializeM7Header({ id: 'x', intent: 'y', status: 'active' });
+  assert.doesNotMatch(omitted, /# produces:/);
+  const emptyMap = serializeM7Header({ id: 'x', intent: 'y', status: 'active', produces: {} });
+  assert.doesNotMatch(emptyMap, /# produces:/);
+});
+
+test('D1209 parseM7Header: produces map roundtrips with mixed types', () => {
+  const yaml = '# id: foo\n# intent: bar\n# status: active\n# produces: { authenticated: true, route: home, retries: 3 }\n';
+  const meta = parseM7Header(yaml);
+  assert.deepEqual(meta.produces, { authenticated: true, route: 'home', retries: 3 });
+});
+
+test('D1209 parseM7Header: produces handles boolean false + negative + decimal', () => {
+  const yaml = '# id: foo\n# intent: bar\n# status: active\n# produces: { dirty: false, offset: -2, ratio: 0.75 }\n';
+  const meta = parseM7Header(yaml);
+  assert.deepEqual(meta.produces, { dirty: false, offset: -2, ratio: 0.75 });
+});
+
+test('D1209 parseM7Header: produces strips quotes around string values', () => {
+  const yaml = '# id: foo\n# intent: bar\n# status: active\n# produces: { route: "Settings", lang: \'en-US\' }\n';
+  const meta = parseM7Header(yaml);
+  assert.deepEqual(meta.produces, { route: 'Settings', lang: 'en-US' });
+});
+
+test('D1209 parseM7Header: produces empty braces yields undefined', () => {
+  const yaml = '# id: foo\n# intent: bar\n# status: active\n# produces: { }\n';
+  const meta = parseM7Header(yaml);
+  assert.equal(meta.produces, undefined);
+});
+
+test('D1209 parseM7Header: produces missing field stays undefined', () => {
+  const yaml = '# id: foo\n# intent: bar\n# status: active\n';
+  const meta = parseM7Header(yaml);
+  assert.equal(meta.produces, undefined);
+});
+
+test('D1209 serializeM7Header → parseM7Header: full produces roundtrip', () => {
+  const original = {
+    id: 'user-login',
+    intent: 'Log in via email + password',
+    status: 'active',
+    produces: { authenticated: true, route: 'home', userTier: 'premium' },
+  };
+  const out = serializeM7Header(original);
+  const parsed = parseM7Header(out);
+  assert.deepEqual(parsed.produces, original.produces);
+});

--- a/scripts/learned-actions.mjs
+++ b/scripts/learned-actions.mjs
@@ -124,6 +124,7 @@ function scanFlows() {
         mutates: meta.mutates,
         status: meta.status,
         params: uniqParams,
+        produces: meta.produces,
         replay,
       });
     }
@@ -160,8 +161,8 @@ function parseFlowMeta(text) {
   const appIdMatch = text.match(/^appId:\s*([^\s#]+)/m);
   const lines = text.split('\n');
   const purposeLines = [];
-  const meta = { id: null, intent: null, tags: null, mutates: null, status: null };
-  const META_KEYS = new Set(['id', 'intent', 'tags', 'mutates', 'status']);
+  const meta = { id: null, intent: null, tags: null, mutates: null, status: null, produces: null };
+  const META_KEYS = new Set(['id', 'intent', 'tags', 'mutates', 'status', 'produces']);
   let inComment = false;
   for (const line of lines) {
     if (line.startsWith('#')) {
@@ -180,6 +181,8 @@ function parseFlowMeta(text) {
             .filter(Boolean);
         } else if (key === 'mutates') {
           meta.mutates = /^true$/i.test(raw);
+        } else if (key === 'produces') {
+          meta.produces = parseProducesMap(raw);
         } else {
           meta[key] = raw;
         }
@@ -203,7 +206,32 @@ function parseFlowMeta(text) {
     tags: meta.tags,
     mutates: meta.mutates,
     status: meta.status,
+    produces: meta.produces,
   };
+}
+
+// D1209 — parse the inline `produces` map: `{ key: value, key: value }`.
+// Values are typed as boolean (true/false), number, or string. Returns
+// null when empty or unparseable so callers can omit the field. Mirrors
+// parseProducesMap() in scripts/cdp-bridge/src/domain/reusable-action.ts.
+function parseProducesMap(raw) {
+  const inner = raw.trim().replace(/^\{|\}$/g, '').trim();
+  if (!inner) return null;
+  const result = {};
+  for (const part of inner.split(',')) {
+    const kv = part.match(/^\s*([a-zA-Z_][\w.-]*)\s*:\s*(.+?)\s*$/);
+    if (!kv) continue;
+    const key = kv[1];
+    const valueRaw = kv[2].trim();
+    if (/^(true|false)$/i.test(valueRaw)) {
+      result[key] = /^true$/i.test(valueRaw);
+    } else if (/^-?\d+(\.\d+)?$/.test(valueRaw)) {
+      result[key] = Number(valueRaw);
+    } else {
+      result[key] = valueRaw.replace(/^['"]|['"]$/g, '');
+    }
+  }
+  return Object.keys(result).length ? result : null;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -363,13 +391,14 @@ if (want('b')) {
       parts.push(`_Searched: ${flows.roots.map((r) => '`' + r + '`').join(', ')}_`);
     }
   } else {
-    parts.push('| Flow | Purpose | App ID | Mutates | Status | Tags | Replay |');
-    parts.push('|---|---|---|---|---|---|---|');
+    parts.push('| Flow | Purpose | App ID | Mutates | Status | Tags | Produces | Replay |');
+    parts.push('|---|---|---|---|---|---|---|---|');
     for (const f of flows.items) {
       const mut = f.mutates === null || f.mutates === undefined ? '?' : (f.mutates ? 'yes' : 'no');
       const status = f.status || '?';
       const tags = (f.tags && f.tags.length) ? f.tags.join(', ') : '?';
-      parts.push(`| \`${f.flow}\` | ${esc(f.purpose)} | \`${f.appId || '?'}\` | ${mut} | ${status} | ${esc(tags)} | \`${f.replay}\` |`);
+      const produces = formatProducesCell(f.produces);
+      parts.push(`| \`${f.flow}\` | ${esc(f.purpose)} | \`${f.appId || '?'}\` | ${mut} | ${status} | ${esc(tags)} | ${esc(produces)} | \`${f.replay}\` |`);
     }
   }
   parts.push('');
@@ -408,4 +437,13 @@ process.exit(total === 0 ? 3 : 0);
 
 function esc(s) {
   return (s || '').toString().replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+// D1209 — render the parsed produces map as a compact table cell.
+// Empty / null returns '?'.
+function formatProducesCell(produces) {
+  if (!produces || typeof produces !== 'object') return '?';
+  const keys = Object.keys(produces).sort();
+  if (keys.length === 0) return '?';
+  return keys.map((k) => `${k}=${produces[k]}`).join(', ');
 }

--- a/skills/rn-setup/SKILL.md
+++ b/skills/rn-setup/SKILL.md
@@ -135,7 +135,50 @@ need WiFi they can `adb connect <ip>` manually — the script then treats the
 device as physical and runs `adb reverse` over the TCP transport (works
 the same as USB).
 
-### 11. Vercel rules sync freshness
+### 11. Plugin version freshness
+
+Compare the locally installed plugin version against the latest GitHub
+release. Read-only — never auto-updates. The user runs
+`/plugin update rn-dev-agent` themselves if the row reports BEHIND.
+
+```bash
+LOCAL=$(jq -r '.version' "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" 2>/dev/null)
+LATEST=$(curl -fsSL --max-time 3 https://api.github.com/repos/Lykhoyda/rn-dev-agent/releases/latest 2>/dev/null | jq -r '.tag_name // empty' | sed 's/^v//')
+
+if [ -z "$LOCAL" ]; then
+  echo "[?] Plugin version: could not read \${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json"
+elif [ -z "$LATEST" ]; then
+  echo "[OFFLINE] Plugin version: installed $LOCAL — couldn't reach GitHub for upstream check"
+else
+  NEWER=$(printf '%s\n%s\n' "$LOCAL" "$LATEST" | sort -V | tail -1)
+  if [ "$LOCAL" = "$LATEST" ]; then
+    echo "[OK] Plugin version: $LOCAL (latest)"
+  elif [ "$NEWER" = "$LATEST" ]; then
+    echo "[BEHIND] Plugin version: installed $LOCAL, latest $LATEST — run /plugin update rn-dev-agent"
+  else
+    echo "[AHEAD] Plugin version: installed $LOCAL is newer than latest release $LATEST (dev install — fine)"
+  fi
+fi
+```
+
+Expected outputs:
+- **OK**: installed version equals the latest release tag.
+- **BEHIND**: installed version is older than the latest release. Surface the
+  exact `/plugin update rn-dev-agent` command. Common when a user pinned
+  an older version or hasn't updated since their last `claude` install.
+- **AHEAD (dev install)**: local version is newer — typical for plugin
+  contributors running off `main` or a feature branch. Note the discrepancy
+  but don't treat as a failure.
+- **OFFLINE**: GitHub API was unreachable (no network, rate-limited,
+  authentication blocking). Skip without failing — plugin works fine
+  without the upstream check.
+
+GitHub's unauthenticated API allows 60 requests/hour per IP. The `/doctor`
+command is read-only and not expected to run that often per hour, so no
+caching is required for v1. If rate-limit complaints surface, add a 24h
+on-disk cache at `~/.cache/rn-dev-agent/upgrade-check.json`.
+
+### 12. Vercel rules sync freshness
 
 Verify the vendored Vercel agent-skills content is present and not stale.
 Read-only check; does NOT auto-sync (user runs the resync command if BEHIND).
@@ -172,7 +215,8 @@ Present results as a table:
 | Injected helpers | OK / MISSING | If MISSING: fall back to `device_*` tools or call `cdp_reload`. Do not retry `cdp_status` in a loop. |
 | ffmpeg | OK (v7.1) | — |
 | Physical devices | N/A (none connected) OR "Android USB reverse: OK" / "iOS: idb-companion missing — install with brew" | Run installed command if iOS-companion missing |
-| Vercel rules sync | OK (118 rules, fetched X days ago) / STALE (> 30 days) / MISSING / DRIFT | Run: node ${CLAUDE_PLUGIN_ROOT}/scripts/sync-vercel-skills.mjs --fix --ref \<sha\> |
+| Plugin version | OK (latest) / BEHIND (installed X, latest Y) / OFFLINE / AHEAD (dev install) | Run: `/plugin update rn-dev-agent` if BEHIND |
+| Vercel rules sync | OK (N rules, fetched X days ago) / STALE (> 30 days) / MISSING / DRIFT | Run: node ${CLAUDE_PLUGIN_ROOT}/scripts/sync-vercel-skills.mjs --fix --ref \<sha\> |
 
 If any critical check fails (CDP bridge, agent-device, Metro, or simulator),
 provide step-by-step instructions to fix it. Do not proceed with feature
@@ -195,7 +239,7 @@ Setup is boring — agents skip it and pay for it later.
 | "The SessionStart banner says 'WARNING: agent-device not installed' — it'll auto-install next time" | Auto-install already ran and FAILED. That's why there's a warning. Run the ensure script NOW and read the actual error. |
 | "I'll skip the Metro check — I'll start it later when I need it" | Without Metro, `cdp_status` fails, Phase 5.5 fails, and the whole pipeline stops. Start Metro FIRST. |
 | "The user can install agent-device themselves" | They ran `/rn-dev-agent:setup` expecting guidance. Give them the exact command with the flag they need (sudo? nvm? permission fix?). |
-| "I'll proceed with the feature — setup can be done in parallel" | No. Feature development depends on all 10 checks passing (step 10 is optional — N/A when no physical device). Get the environment green first, then proceed. |
+| "I'll proceed with the feature — setup can be done in parallel" | No. Feature development depends on critical checks passing (steps 10 + 11 are optional — N/A when no physical device, OFFLINE acceptable for the version check). Get the environment green first, then proceed. |
 
 ## Red Flags — Stop and Reconsider
 
@@ -203,7 +247,7 @@ Setup is boring — agents skip it and pay for it later.
 - Proceeding with feature dev when setup shows any RED row
 - Suggesting `sudo npm install -g` without first checking if nvm is available
 - Ignoring "WARNING: not installed" from the SessionStart banner
-- Claiming "setup passed" without showing the 10-row table with evidence (row 10 may be "N/A" when no physical device is connected — that's still evidence)
+- Claiming "setup passed" without showing the 11-row table with evidence (row 10 may be "N/A" when no physical device is connected and row 11 may be "OFFLINE" when GitHub is unreachable — both are still evidence)
 
 ## Verification — Setup Complete When
 
@@ -215,4 +259,5 @@ Setup is boring — agents skip it and pay for it later.
 - [ ] `curl -s http://127.0.0.1:8081/status` returns `packager-status:running`
 - [ ] `cdp_status` returns `ok:true` with `cdp.connected: true` AND `capabilities.helpersInjected: true`
 - [ ] Physical-device row is `N/A (no devices)` OR reports `adb reverse: OK` / `idb-companion: OK or install hint` (M9 / D668)
-- [ ] Present the 10-row results table to the user — no hidden failures
+- [ ] Plugin-version row is `OK` (installed = latest) / `OFFLINE` (acceptable) / `AHEAD (dev install)` — if `BEHIND`, surface the `/plugin update rn-dev-agent` instruction; user decides whether to update before continuing
+- [ ] Present the 11-row results table to the user — no hidden failures


### PR DESCRIPTION
## Summary

Recovery PR for the three stacked PRs that merged into their respective feature branches but **never reached `main`**:

| Original PR | Title | Recovered as |
|---|---|---|
| #128 | feat(D1209): hybrid action composition + Reusable Actions doctrine — v0.44.23 | commit `6b68180` |
| #129 | feat(doctor): add plugin-version freshness check (12th row) — v0.44.24 | commit `c39777c` |
| #130 part 1 | fix(issue-126): typeText walks descendants + cdp_diagnostic_renderers — v0.44.25 | commit `0453220` |
| #130 part 2 | fix(issue-126): apply multi-LLM impl-review findings — Path 1 single-fire + dedupe + tighter regex | commit `f08ef49` |
| (this PR) | unify version + resolve doctor-row collision | commit `c867e3f` (v0.44.27) |

## Why this is needed

PRs #128/#129/#130 were stacked PRs whose `baseRefName` pointed at each other (not at `main`). When they "merged" on GitHub, the changes landed on the stacked feature branches but never propagated to `main`. The work was real and merged-in-the-API-sense, but absent from `main`. Confirmed today by reading the live `gh pr view` data and walking origin branch HEADs.

## Conflict resolution

**Doctor row collision** — both #129 (plugin-version freshness, 12th row) and the v1.0 vercel-skills work in PR #132 (Vercel rules sync freshness, also a 12th row) wanted to be \"the 12th row\". Resolved by keeping BOTH:

- **Row 12: Plugin version freshness** (from #129) — surfaces \`/plugin update rn-dev-agent\` when a release is newer than the installed version
- **Row 13: Vercel rules sync freshness** (from PR #132) — surfaces the resync command when \`UPSTREAM.lock.json\` is missing or > 30 days old

Doctor command prose updated to \"13 prerequisite checks\".

**Version conflicts** on `plugin.json` / `marketplace.json` / `.scaffold-version` resolved as \"ours\" (main's existing values) through all 4 cherry-picks, then a final commit bumps to **v0.44.27** as a single unified recovery release above main's v0.44.26 floor.

## What ships in this PR

From #128 (D1209):
- Hybrid action composition design doc + scaffold under `templates/rn-agent/proposals/`
- Reusable Actions doctrine update in CLAUDE-MD-TEMPLATE

From #129 (doctor 12th row):
- Plugin-version freshness check in `skills/rn-setup/SKILL.md` § 11
- Doctor command prose 11 → 12 → 13 rows (combined with PR #132's row)

From #130 (issue-126 typeText fix):
- `typeText` walks descendants when matched wrapper has no handler
- `cdp_diagnostic_renderers` tool (gap-B observability)
- Multi-LLM review fixes: Path-1 single-fire bug, dedupeByHandlerIdentity, tighter `TYPEABLE_TYPE_RE`, hookKeys via `Object.getOwnPropertyNames`, source-guard length bound widened, diagnostic notes consolidated

## Test plan

- [ ] CI passes (build, tests, version-sync check, CodeQL)
- [ ] Reviewer reads the diff, confirms the 13-row doctor table layout
- [ ] Reviewer spot-checks each cherry-picked commit's content matches its origin
- [ ] After merge: clean up the 3 orphan branches (`feat/d1209-hybrid-composition`, `feat/doctor-version-check`, `fix/issue-126-typeText-walk-down`)

## Auto-merge

Setting auto-merge per user directive.