### PR TITLE
chore(audit): raise default --max from 200 to 1000

### DIFF
--- a/scripts/check-vercel-rules.mjs
+++ b/scripts/check-vercel-rules.mjs
@@ -23,7 +23,7 @@
 //   --no-baseline           Disable baseline loading.
 //
 // Other:
-//   --max <n>               Max files to walk in --all/--ci mode (default 200).
+//   --max <n>               Max files to walk in --all/--ci mode (default 1000).
 //   --quiet                 Suppress informational stderr.
 //   --help, -h              Show usage.
 //
@@ -118,7 +118,7 @@ function parseArgs(argv) {
     baselinePath: '.rn-agent/vercel-rules-baseline.json',
     snapshot: false,
     useBaseline: true,
-    max: 200,
+    max: 1000,
     quiet: false,
   };
   let endOfFlags = false;
@@ -175,7 +175,7 @@ Baseline:
   --no-baseline            Disable baseline loading
 
 Other:
-  --max <n>                Max files in --all/--ci (default 200)
+  --max <n>                Max files in --all/--ci (default 1000)
   --quiet                  Less stderr output
 `
   );


### PR DESCRIPTION
## Summary
- Bumps `scripts/check-vercel-rules.mjs` default `--max` from 200 → 1000.
- The old 200 cap silently truncated `--all`/`--ci` audits past the cap, with no warning. Workspace test-app at 104 files happened to fit, but mid-sized RN apps would skip files.
- `--max` remains configurable on the CLI for monorepos.
- PostToolUse hook is unaffected (uses `--changed` mode, no cap).

## Context
Discovered during v0.44.27 sanity check against the workspace test-app — flagged that 200 was suspiciously low for the cap default.

## Test plan
- [x] `node scripts/check-vercel-rules.mjs --help` shows `default 1000`
- [x] `--all` against test-app (104 files) → 0 violations, exit 0