### PR TITLE
fix(gh-136): explicit-platform raw screenshot path (PR-A)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.28",
+      "version": "0.44.29",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.28",
+  "version": "0.44.29",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - New `_setRunAgentDeviceForTest` / `_resetRunAgentDeviceForTest` seams on
   `device-list.ts` for integration tests, mirroring the GH #136 PR-B picker
   convention.
-- 12 new unit tests in `gh-136-screenshot-raw-platform.test.js` cover the
-  pure parsers, orchestrator branches, raw-vs-fallback dispatch, and that
-  the resize pipeline + EPHEMERAL_PATH advisory still wrap the raw result
-  identically. Full unit suite at 1240 passing, 0 failing.
+- 14 new unit tests in `gh-136-screenshot-raw-platform.test.js` cover the
+  pure parsers, orchestrator branches (both iOS and Android arms,
+  success + capturer-failure for each), raw-vs-fallback dispatch, and
+  that the resize pipeline + EPHEMERAL_PATH advisory still wrap the raw
+  result identically. Full unit suite at 1242 passing, 0 failing.
+- Multi-LLM review (Codex + Gemini, parallel) flagged an Android
+  `WriteStream` flush race in the default capturer: `out.end()` returns
+  before bytes drain, so the promise could resolve `ok: true` while
+  `resizeWithSips` reads a truncated PNG (>64KB pipe buffer = real risk
+  for high-res emulators). Fixed by waiting on the `'finish'` event and
+  destroying the stream on timeout / proc-error paths. The fix is to
+  `defaultAndroidCapturer` only — iOS uses `execFile`-completion
+  ordering which doesn't have this race.
 
 ## [0.44.28] — 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.44.29] — 2026-05-12
+
+### Fixed (GH #136 — PR-A: Multi-Device Screenshot Routing)
+
+- **`device_screenshot platform: "ios" | "android"` now disambiguates reliably
+  when both an iOS sim and an Android emu are booted.** Previously the call
+  routed through `agent-device --platform`, which silently fell back to the
+  active session and returned a wrong-platform image (iPhone-resolution JPEG
+  when `platform: "android"` was requested). The explicit-platform path now
+  resolves the booted device directly via `xcrun simctl list -j devices
+  booted` (iOS) or `adb devices` (Android), then captures via
+  `xcrun simctl io <UDID> screenshot --type=jpeg <path>` or
+  `adb -s <emu-id> exec-out screencap -p` — bypassing agent-device entirely.
+- **Backward-safe by design.** The raw path fires only when the caller passes
+  `platform` explicitly. Calls that omit the field (the common single-device
+  case) keep the existing `runAgentDevice` flow exactly. Any failure in the
+  raw path (resolver miss, command error, missing `xcrun`/`adb`) gracefully
+  degrades to `runAgentDevice` — no new error surface for users.
+
+### Internal
+
+- New module `scripts/cdp-bridge/src/tools/device-screenshot-raw.ts` —
+  pure parsers (`parseSimctlBootedUDID`, `parseAdbDevicesEmu`) plus the
+  `tryRawScreenshot` orchestrator, with test seams (`_setForTest`,
+  `_resetForTest`) for resolver/capturer injection.
+- New `_setRunAgentDeviceForTest` / `_resetRunAgentDeviceForTest` seams on
+  `device-list.ts` for integration tests, mirroring the GH #136 PR-B picker
+  convention.
+- 12 new unit tests in `gh-136-screenshot-raw-platform.test.js` cover the
+  pure parsers, orchestrator branches, raw-vs-fallback dispatch, and that
+  the resize pipeline + EPHEMERAL_PATH advisory still wrap the raw result
+  identically. Full unit suite at 1240 passing, 0 failing.
+
 ## [0.44.28] — 2026-05-07
 
 ### Fixed (GH #136 — PR-B: Dev-Client Picker Reliability)

--- a/scripts/cdp-bridge/dist/tools/device-list.js
+++ b/scripts/cdp-bridge/dist/tools/device-list.js
@@ -1,7 +1,15 @@
 import { runAgentDevice } from '../agent-device-wrapper.js';
 import { resizeWithSips } from './device-screenshot-resize.js';
+import { tryRawScreenshot } from './device-screenshot-raw.js';
+let runAgentDeviceFn = runAgentDevice;
+export function _setRunAgentDeviceForTest(fn) {
+    runAgentDeviceFn = fn;
+}
+export function _resetRunAgentDeviceForTest() {
+    runAgentDeviceFn = runAgentDevice;
+}
 export function createDeviceListHandler() {
-    return async () => runAgentDevice(['devices'], { skipSession: true });
+    return async () => runAgentDeviceFn(['devices'], { skipSession: true });
 }
 /**
  * Pure derivation of the output path for a screenshot call. Extracted so the
@@ -120,7 +128,22 @@ export async function captureAndResizeScreenshot(args) {
     // regardless of which dispatch tier (fast-runner / daemon / CLI) responded.
     const argsWithPath = { ...args, path: requestedPath };
     const advisories = computeScreenshotAdvisories(args, requestedPath);
-    const result = await runAgentDevice(buildScreenshotArgs(argsWithPath), { platform: args.platform ?? null });
+    // GH #136 PR-A: explicit-platform raw path bypasses agent-device's --platform
+    // routing when both iOS sim and Android emu are booted. Falls through to
+    // runAgentDevice on any failure (resolution miss, command error) — graceful
+    // degradation preserves single-device behavior identically.
+    let result;
+    if (args.platformExplicit && (args.platform === 'ios' || args.platform === 'android')) {
+        const raw = await tryRawScreenshot(args.platform, requestedPath);
+        if (raw) {
+            result = {
+                content: [{ type: 'text', text: JSON.stringify({ ok: true, data: { path: raw.path } }) }],
+            };
+        }
+    }
+    if (!result) {
+        result = await runAgentDeviceFn(buildScreenshotArgs(argsWithPath), { platform: args.platform ?? null });
+    }
     if (result.isError)
         return result;
     const actualPath = resolveScreenshotPath(result, requestedPath);
@@ -148,7 +171,8 @@ export async function captureAndResizeScreenshot(args) {
  */
 export function createDeviceScreenshotHandler(getClient) {
     return async (args) => {
+        const platformExplicit = args.platform === 'ios' || args.platform === 'android';
         const platform = args.platform ?? getClient?.()?.connectedTarget?.platform ?? null;
-        return captureAndResizeScreenshot({ ...args, platform });
+        return captureAndResizeScreenshot({ ...args, platform, platformExplicit });
     };
 }

--- a/scripts/cdp-bridge/dist/tools/device-screenshot-raw.js
+++ b/scripts/cdp-bridge/dist/tools/device-screenshot-raw.js
@@ -1,0 +1,151 @@
+/**
+ * GH #136 PR-A: raw-command screenshot path for explicit-platform disambiguation.
+ *
+ * When `device_screenshot` is called with explicit `platform: 'ios' | 'android'`
+ * (i.e., the caller actually passed the field, not inferred from CDP target),
+ * we bypass agent-device entirely and shell out to `xcrun simctl io` or
+ * `adb -s <emu> exec-out screencap -p`. This sidesteps the agent-device CLI's
+ * `--platform` routing issue when both an iOS sim and an Android emu are
+ * booted simultaneously (the field-reported bug from issue #136 #1).
+ *
+ * On any failure (resolution fails, command errors), the caller falls through
+ * to the existing `runAgentDevice` path — no behavior change for users who
+ * don't pass `platform` or who run a single device.
+ *
+ * Test seams (`_setForTest`, `_resetForTest`) follow the GH #136 picker
+ * precedent — allow unit tests to inject resolver/capturer fakes without
+ * spawning real `xcrun`/`adb` subprocesses.
+ */
+import { execFile, spawn } from 'node:child_process';
+import { createWriteStream } from 'node:fs';
+import { promisify } from 'node:util';
+const execFileAsync = promisify(execFile);
+export function parseSimctlBootedUDID(jsonText) {
+    let data;
+    try {
+        data = JSON.parse(jsonText);
+    }
+    catch {
+        return null;
+    }
+    const runtimes = data?.devices;
+    if (!runtimes || typeof runtimes !== 'object')
+        return null;
+    for (const list of Object.values(runtimes)) {
+        if (!Array.isArray(list))
+            continue;
+        for (const device of list) {
+            if (device && device.state === 'Booted' && typeof device.udid === 'string' && device.udid.length > 0) {
+                return device.udid;
+            }
+        }
+    }
+    return null;
+}
+const EMU_LINE = /^(emulator-\d+)\s+device\b/;
+export function parseAdbDevicesEmu(stdout) {
+    const lines = stdout.split('\n');
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed)
+            continue;
+        if (trimmed.startsWith('List of devices'))
+            continue;
+        const match = trimmed.match(EMU_LINE);
+        if (match)
+            return match[1];
+    }
+    return null;
+}
+const defaultIosResolver = async () => {
+    try {
+        const { stdout } = await execFileAsync('xcrun', ['simctl', 'list', '-j', 'devices', 'booted'], {
+            timeout: 5000,
+            maxBuffer: 1024 * 1024,
+        });
+        return parseSimctlBootedUDID(stdout);
+    }
+    catch {
+        return null;
+    }
+};
+const defaultAndroidResolver = async () => {
+    try {
+        const { stdout } = await execFileAsync('adb', ['devices'], {
+            timeout: 5000,
+            maxBuffer: 1024 * 1024,
+        });
+        return parseAdbDevicesEmu(stdout);
+    }
+    catch {
+        return null;
+    }
+};
+const defaultIosCapturer = async (udid, path) => {
+    try {
+        await execFileAsync('xcrun', ['simctl', 'io', udid, 'screenshot', '--type=jpeg', path], {
+            timeout: 15_000,
+            maxBuffer: 1024 * 1024,
+        });
+        return true;
+    }
+    catch {
+        return false;
+    }
+};
+// Android needs the binary screen bytes piped to a file. execFile can't redirect
+// stdout, so spawn directly and pipe to a write stream — no shell, so the path
+// is safely passed as a literal filename, not interpolated into a command string.
+const defaultAndroidCapturer = async (emuId, path) => new Promise((resolve) => {
+    let settled = false;
+    const settle = (ok) => {
+        if (settled)
+            return;
+        settled = true;
+        resolve(ok);
+    };
+    const proc = spawn('adb', ['-s', emuId, 'exec-out', 'screencap', '-p'], { stdio: ['ignore', 'pipe', 'pipe'] });
+    const out = createWriteStream(path);
+    proc.stdout.pipe(out);
+    out.on('error', () => settle(false));
+    proc.on('error', () => settle(false));
+    proc.on('close', (code) => {
+        out.end();
+        settle(code === 0);
+    });
+    setTimeout(() => {
+        if (!settled) {
+            proc.kill();
+            settle(false);
+        }
+    }, 15_000);
+});
+let iosResolver = defaultIosResolver;
+let androidResolver = defaultAndroidResolver;
+let iosCapturer = defaultIosCapturer;
+let androidCapturer = defaultAndroidCapturer;
+export function _setForTest(overrides) {
+    if (overrides.iosResolver)
+        iosResolver = overrides.iosResolver;
+    if (overrides.androidResolver)
+        androidResolver = overrides.androidResolver;
+    if (overrides.iosCapturer)
+        iosCapturer = overrides.iosCapturer;
+    if (overrides.androidCapturer)
+        androidCapturer = overrides.androidCapturer;
+}
+export function _resetForTest() {
+    iosResolver = defaultIosResolver;
+    androidResolver = defaultAndroidResolver;
+    iosCapturer = defaultIosCapturer;
+    androidCapturer = defaultAndroidCapturer;
+}
+export async function tryRawScreenshot(platform, path) {
+    const resolver = platform === 'ios' ? iosResolver : androidResolver;
+    const capturer = platform === 'ios' ? iosCapturer : androidCapturer;
+    const id = await resolver();
+    if (!id)
+        return null;
+    const ok = await capturer(id, path);
+    return ok ? { ok: true, path } : null;
+}

--- a/scripts/cdp-bridge/dist/tools/device-screenshot-raw.js
+++ b/scripts/cdp-bridge/dist/tools/device-screenshot-raw.js
@@ -96,29 +96,42 @@ const defaultIosCapturer = async (udid, path) => {
 // Android needs the binary screen bytes piped to a file. execFile can't redirect
 // stdout, so spawn directly and pipe to a write stream — no shell, so the path
 // is safely passed as a literal filename, not interpolated into a command string.
+//
+// Settle ordering matters: `pipe()` auto-ends `out` when `proc.stdout` ends, but
+// `out.end()` is async — bytes can remain buffered after the child exits. We
+// resolve `true` only on the WriteStream's `'finish'` event (post-flush) so
+// `resizeWithSips` never reads a truncated PNG. Multi-LLM review caught this.
 const defaultAndroidCapturer = async (emuId, path) => new Promise((resolve) => {
     let settled = false;
+    const proc = spawn('adb', ['-s', emuId, 'exec-out', 'screencap', '-p'], { stdio: ['ignore', 'pipe', 'pipe'] });
+    const out = createWriteStream(path);
+    const timer = setTimeout(() => {
+        if (settled)
+            return;
+        proc.kill();
+        out.destroy();
+        settle(false);
+    }, 15_000);
     const settle = (ok) => {
         if (settled)
             return;
         settled = true;
+        clearTimeout(timer);
         resolve(ok);
     };
-    const proc = spawn('adb', ['-s', emuId, 'exec-out', 'screencap', '-p'], { stdio: ['ignore', 'pipe', 'pipe'] });
-    const out = createWriteStream(path);
     proc.stdout.pipe(out);
+    out.on('finish', () => settle(true));
     out.on('error', () => settle(false));
-    proc.on('error', () => settle(false));
-    proc.on('close', (code) => {
-        out.end();
-        settle(code === 0);
+    proc.on('error', () => {
+        out.destroy();
+        settle(false);
     });
-    setTimeout(() => {
-        if (!settled) {
-            proc.kill();
-            settle(false);
-        }
-    }, 15_000);
+    proc.on('close', (code) => {
+        if (code === 0)
+            return; // success path settles via `out.on('finish')`
+        out.destroy();
+        settle(false);
+    });
 });
 let iosResolver = defaultIosResolver;
 let androidResolver = defaultAndroidResolver;

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.23",
+  "version": "0.38.24",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/tools/device-list.ts
+++ b/scripts/cdp-bridge/src/tools/device-list.ts
@@ -2,9 +2,21 @@ import type { CDPClient } from '../cdp-client.js';
 import { runAgentDevice } from '../agent-device-wrapper.js';
 import type { ToolResult } from '../utils.js';
 import { resizeWithSips, type ResizeResult, type ResizeOpts } from './device-screenshot-resize.js';
+import { tryRawScreenshot } from './device-screenshot-raw.js';
+
+type RunAgentDeviceFn = typeof runAgentDevice;
+let runAgentDeviceFn: RunAgentDeviceFn = runAgentDevice;
+
+export function _setRunAgentDeviceForTest(fn: RunAgentDeviceFn): void {
+  runAgentDeviceFn = fn;
+}
+
+export function _resetRunAgentDeviceForTest(): void {
+  runAgentDeviceFn = runAgentDevice;
+}
 
 export function createDeviceListHandler(): (args: Record<string, never>) => Promise<ToolResult> {
-  return async () => runAgentDevice(['devices'], { skipSession: true });
+  return async () => runAgentDeviceFn(['devices'], { skipSession: true });
 }
 
 /**
@@ -141,6 +153,13 @@ export interface ScreenshotArgs {
   path?: string;
   format?: string;
   platform?: 'ios' | 'android' | null;
+  /**
+   * GH #136 PR-A internal signal: did the caller pass `platform` explicitly,
+   * or was it inferred from the connected CDP target? Only explicit calls
+   * take the raw `xcrun simctl` / `adb` path; inferred ones use the existing
+   * `runAgentDevice` flow so behavior is unchanged for single-device users.
+   */
+  platformExplicit?: boolean;
   maxWidth?: number;
   quality?: number;
 }
@@ -162,7 +181,22 @@ export async function captureAndResizeScreenshot(
   // regardless of which dispatch tier (fast-runner / daemon / CLI) responded.
   const argsWithPath = { ...args, path: requestedPath };
   const advisories = computeScreenshotAdvisories(args, requestedPath);
-  const result = await runAgentDevice(buildScreenshotArgs(argsWithPath), { platform: args.platform ?? null });
+  // GH #136 PR-A: explicit-platform raw path bypasses agent-device's --platform
+  // routing when both iOS sim and Android emu are booted. Falls through to
+  // runAgentDevice on any failure (resolution miss, command error) — graceful
+  // degradation preserves single-device behavior identically.
+  let result: ToolResult | undefined;
+  if (args.platformExplicit && (args.platform === 'ios' || args.platform === 'android')) {
+    const raw = await tryRawScreenshot(args.platform, requestedPath);
+    if (raw) {
+      result = {
+        content: [{ type: 'text' as const, text: JSON.stringify({ ok: true, data: { path: raw.path } }) }],
+      };
+    }
+  }
+  if (!result) {
+    result = await runAgentDeviceFn(buildScreenshotArgs(argsWithPath), { platform: args.platform ?? null });
+  }
   if (result.isError) return result;
 
   const actualPath = resolveScreenshotPath(result, requestedPath);
@@ -191,8 +225,9 @@ export function createDeviceScreenshotHandler(
   getClient?: () => CDPClient,
 ): (args: ScreenshotArgs) => Promise<ToolResult> {
   return async (args) => {
+    const platformExplicit = args.platform === 'ios' || args.platform === 'android';
     const platform: 'ios' | 'android' | null =
       args.platform ?? (getClient?.()?.connectedTarget?.platform as 'ios' | 'android' | undefined) ?? null;
-    return captureAndResizeScreenshot({ ...args, platform });
+    return captureAndResizeScreenshot({ ...args, platform, platformExplicit });
   };
 }

--- a/scripts/cdp-bridge/src/tools/device-screenshot-raw.ts
+++ b/scripts/cdp-bridge/src/tools/device-screenshot-raw.ts
@@ -106,29 +106,40 @@ const defaultIosCapturer: RawCapturer = async (udid, path) => {
 // Android needs the binary screen bytes piped to a file. execFile can't redirect
 // stdout, so spawn directly and pipe to a write stream — no shell, so the path
 // is safely passed as a literal filename, not interpolated into a command string.
+//
+// Settle ordering matters: `pipe()` auto-ends `out` when `proc.stdout` ends, but
+// `out.end()` is async — bytes can remain buffered after the child exits. We
+// resolve `true` only on the WriteStream's `'finish'` event (post-flush) so
+// `resizeWithSips` never reads a truncated PNG. Multi-LLM review caught this.
 const defaultAndroidCapturer: RawCapturer = async (emuId, path) =>
   new Promise<boolean>((resolve) => {
     let settled = false;
+    const proc = spawn('adb', ['-s', emuId, 'exec-out', 'screencap', '-p'], { stdio: ['ignore', 'pipe', 'pipe'] });
+    const out = createWriteStream(path);
+    const timer = setTimeout(() => {
+      if (settled) return;
+      proc.kill();
+      out.destroy();
+      settle(false);
+    }, 15_000);
     const settle = (ok: boolean): void => {
       if (settled) return;
       settled = true;
+      clearTimeout(timer);
       resolve(ok);
     };
-    const proc = spawn('adb', ['-s', emuId, 'exec-out', 'screencap', '-p'], { stdio: ['ignore', 'pipe', 'pipe'] });
-    const out = createWriteStream(path);
     proc.stdout.pipe(out);
+    out.on('finish', () => settle(true));
     out.on('error', () => settle(false));
-    proc.on('error', () => settle(false));
-    proc.on('close', (code) => {
-      out.end();
-      settle(code === 0);
+    proc.on('error', () => {
+      out.destroy();
+      settle(false);
     });
-    setTimeout(() => {
-      if (!settled) {
-        proc.kill();
-        settle(false);
-      }
-    }, 15_000);
+    proc.on('close', (code) => {
+      if (code === 0) return; // success path settles via `out.on('finish')`
+      out.destroy();
+      settle(false);
+    });
   });
 
 let iosResolver: RawResolver = defaultIosResolver;

--- a/scripts/cdp-bridge/src/tools/device-screenshot-raw.ts
+++ b/scripts/cdp-bridge/src/tools/device-screenshot-raw.ts
@@ -1,0 +1,175 @@
+/**
+ * GH #136 PR-A: raw-command screenshot path for explicit-platform disambiguation.
+ *
+ * When `device_screenshot` is called with explicit `platform: 'ios' | 'android'`
+ * (i.e., the caller actually passed the field, not inferred from CDP target),
+ * we bypass agent-device entirely and shell out to `xcrun simctl io` or
+ * `adb -s <emu> exec-out screencap -p`. This sidesteps the agent-device CLI's
+ * `--platform` routing issue when both an iOS sim and an Android emu are
+ * booted simultaneously (the field-reported bug from issue #136 #1).
+ *
+ * On any failure (resolution fails, command errors), the caller falls through
+ * to the existing `runAgentDevice` path — no behavior change for users who
+ * don't pass `platform` or who run a single device.
+ *
+ * Test seams (`_setForTest`, `_resetForTest`) follow the GH #136 picker
+ * precedent — allow unit tests to inject resolver/capturer fakes without
+ * spawning real `xcrun`/`adb` subprocesses.
+ */
+import { execFile, spawn } from 'node:child_process';
+import { createWriteStream } from 'node:fs';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export type RawResolver = () => Promise<string | null>;
+export type RawCapturer = (idOrUdid: string, path: string) => Promise<boolean>;
+
+interface SimctlDevice {
+  udid: string;
+  state: string;
+}
+interface SimctlListPayload {
+  devices?: Record<string, SimctlDevice[]>;
+}
+
+export function parseSimctlBootedUDID(jsonText: string): string | null {
+  let data: SimctlListPayload;
+  try {
+    data = JSON.parse(jsonText) as SimctlListPayload;
+  } catch {
+    return null;
+  }
+  const runtimes = data?.devices;
+  if (!runtimes || typeof runtimes !== 'object') return null;
+  for (const list of Object.values(runtimes)) {
+    if (!Array.isArray(list)) continue;
+    for (const device of list) {
+      if (device && device.state === 'Booted' && typeof device.udid === 'string' && device.udid.length > 0) {
+        return device.udid;
+      }
+    }
+  }
+  return null;
+}
+
+const EMU_LINE = /^(emulator-\d+)\s+device\b/;
+
+export function parseAdbDevicesEmu(stdout: string): string | null {
+  const lines = stdout.split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (trimmed.startsWith('List of devices')) continue;
+    const match = trimmed.match(EMU_LINE);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+const defaultIosResolver: RawResolver = async () => {
+  try {
+    const { stdout } = await execFileAsync('xcrun', ['simctl', 'list', '-j', 'devices', 'booted'], {
+      timeout: 5000,
+      maxBuffer: 1024 * 1024,
+    });
+    return parseSimctlBootedUDID(stdout);
+  } catch {
+    return null;
+  }
+};
+
+const defaultAndroidResolver: RawResolver = async () => {
+  try {
+    const { stdout } = await execFileAsync('adb', ['devices'], {
+      timeout: 5000,
+      maxBuffer: 1024 * 1024,
+    });
+    return parseAdbDevicesEmu(stdout);
+  } catch {
+    return null;
+  }
+};
+
+const defaultIosCapturer: RawCapturer = async (udid, path) => {
+  try {
+    await execFileAsync('xcrun', ['simctl', 'io', udid, 'screenshot', '--type=jpeg', path], {
+      timeout: 15_000,
+      maxBuffer: 1024 * 1024,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+// Android needs the binary screen bytes piped to a file. execFile can't redirect
+// stdout, so spawn directly and pipe to a write stream — no shell, so the path
+// is safely passed as a literal filename, not interpolated into a command string.
+const defaultAndroidCapturer: RawCapturer = async (emuId, path) =>
+  new Promise<boolean>((resolve) => {
+    let settled = false;
+    const settle = (ok: boolean): void => {
+      if (settled) return;
+      settled = true;
+      resolve(ok);
+    };
+    const proc = spawn('adb', ['-s', emuId, 'exec-out', 'screencap', '-p'], { stdio: ['ignore', 'pipe', 'pipe'] });
+    const out = createWriteStream(path);
+    proc.stdout.pipe(out);
+    out.on('error', () => settle(false));
+    proc.on('error', () => settle(false));
+    proc.on('close', (code) => {
+      out.end();
+      settle(code === 0);
+    });
+    setTimeout(() => {
+      if (!settled) {
+        proc.kill();
+        settle(false);
+      }
+    }, 15_000);
+  });
+
+let iosResolver: RawResolver = defaultIosResolver;
+let androidResolver: RawResolver = defaultAndroidResolver;
+let iosCapturer: RawCapturer = defaultIosCapturer;
+let androidCapturer: RawCapturer = defaultAndroidCapturer;
+
+export interface TestOverrides {
+  iosResolver?: RawResolver;
+  androidResolver?: RawResolver;
+  iosCapturer?: RawCapturer;
+  androidCapturer?: RawCapturer;
+}
+
+export function _setForTest(overrides: TestOverrides): void {
+  if (overrides.iosResolver) iosResolver = overrides.iosResolver;
+  if (overrides.androidResolver) androidResolver = overrides.androidResolver;
+  if (overrides.iosCapturer) iosCapturer = overrides.iosCapturer;
+  if (overrides.androidCapturer) androidCapturer = overrides.androidCapturer;
+}
+
+export function _resetForTest(): void {
+  iosResolver = defaultIosResolver;
+  androidResolver = defaultAndroidResolver;
+  iosCapturer = defaultIosCapturer;
+  androidCapturer = defaultAndroidCapturer;
+}
+
+export interface RawScreenshotResult {
+  ok: true;
+  path: string;
+}
+
+export async function tryRawScreenshot(
+  platform: 'ios' | 'android',
+  path: string,
+): Promise<RawScreenshotResult | null> {
+  const resolver = platform === 'ios' ? iosResolver : androidResolver;
+  const capturer = platform === 'ios' ? iosCapturer : androidCapturer;
+  const id = await resolver();
+  if (!id) return null;
+  const ok = await capturer(id, path);
+  return ok ? { ok: true, path } : null;
+}

--- a/scripts/cdp-bridge/test/unit/gh-136-screenshot-raw-platform.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-136-screenshot-raw-platform.test.js
@@ -1,0 +1,258 @@
+// GH #136 PR-A: explicit-platform raw screenshot path. When the caller passes
+// `platform: 'ios' | 'android'` explicitly (not inferred from CDP target),
+// device_screenshot bypasses `runAgentDevice` and uses xcrun simctl / adb
+// directly to disambiguate when both an iOS sim and an Android emu are booted.
+//
+// Tests cover (1) pure parsers for `xcrun simctl list -j devices booted` JSON
+// and `adb devices` stdout, (2) the `tryRawScreenshot` orchestrator branches,
+// and (3) the device-list `captureAndResizeScreenshot` plumbing — that the
+// raw path is taken iff `platformExplicit` is true, and falls through to
+// `runAgentDevice` on any failure (graceful degradation per spec).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const RAW_MOD = '../../dist/tools/device-screenshot-raw.js';
+const DEVICE_LIST_MOD = '../../dist/tools/device-list.js';
+
+// ── Pure parsers ────────────────────────────────────────────────────
+
+test('parseSimctlBootedUDID: returns first Booted device UDID, skips Shutdown', async () => {
+  const { parseSimctlBootedUDID } = await import(RAW_MOD);
+  // `xcrun simctl list -j devices booted` actually only returns booted devices,
+  // but the parser should still tolerate mixed state in case the caller passes
+  // unfiltered output.
+  const json = JSON.stringify({
+    devices: {
+      'com.apple.CoreSimulator.SimRuntime.iOS-18-0': [
+        { udid: 'ABC-SHUTDOWN', state: 'Shutdown', name: 'iPhone 16' },
+        { udid: 'DEF-BOOTED-IOS', state: 'Booted', name: 'iPhone 17 Pro' },
+      ],
+    },
+  });
+  assert.equal(parseSimctlBootedUDID(json), 'DEF-BOOTED-IOS');
+});
+
+test('parseSimctlBootedUDID: returns null on no Booted device or malformed JSON', async () => {
+  const { parseSimctlBootedUDID } = await import(RAW_MOD);
+  // No booted device
+  const noBootedJson = JSON.stringify({
+    devices: {
+      'com.apple.CoreSimulator.SimRuntime.iOS-18-0': [
+        { udid: 'X', state: 'Shutdown', name: 'iPhone 16' },
+      ],
+    },
+  });
+  assert.equal(parseSimctlBootedUDID(noBootedJson), null);
+  // Empty devices object
+  assert.equal(parseSimctlBootedUDID(JSON.stringify({ devices: {} })), null);
+  // Malformed JSON
+  assert.equal(parseSimctlBootedUDID('not-json'), null);
+  // Missing devices key
+  assert.equal(parseSimctlBootedUDID('{}'), null);
+});
+
+test('parseAdbDevicesEmu: returns first emulator-N device, skips offline/unauthorized', async () => {
+  const { parseAdbDevicesEmu } = await import(RAW_MOD);
+  // adb devices output format. Note: physical device IDs are typically
+  // alphanumeric without the emulator- prefix, so they're skipped.
+  const stdout =
+    'List of devices attached\n' +
+    'emulator-5554\toffline\n' +
+    'physical-abc-123\tdevice\n' +
+    'emulator-5556\tdevice\n' +
+    'emulator-5558\tunauthorized\n';
+  assert.equal(parseAdbDevicesEmu(stdout), 'emulator-5556');
+});
+
+test('parseAdbDevicesEmu: returns null when no online emulator', async () => {
+  const { parseAdbDevicesEmu } = await import(RAW_MOD);
+  assert.equal(parseAdbDevicesEmu(''), null);
+  assert.equal(parseAdbDevicesEmu('List of devices attached\n'), null);
+  assert.equal(parseAdbDevicesEmu('List of devices attached\nemulator-5554\toffline\n'), null);
+});
+
+// ── tryRawScreenshot orchestrator ───────────────────────────────────
+
+test('tryRawScreenshot(ios): resolver returns UDID, capturer succeeds → envelope returned', async () => {
+  const mod = await import(RAW_MOD);
+  const { tryRawScreenshot, _setForTest, _resetForTest } = mod;
+  const captures = [];
+  _setForTest({
+    iosResolver: async () => 'DEF-UDID',
+    iosCapturer: async (udid, path) => { captures.push({ udid, path }); return true; },
+  });
+  try {
+    const result = await tryRawScreenshot('ios', '/tmp/shot.jpg');
+    assert.deepEqual(result, { ok: true, path: '/tmp/shot.jpg' });
+    assert.deepEqual(captures, [{ udid: 'DEF-UDID', path: '/tmp/shot.jpg' }]);
+  } finally {
+    _resetForTest();
+  }
+});
+
+test('tryRawScreenshot(ios): resolver returns null → returns null (no capture attempt)', async () => {
+  const mod = await import(RAW_MOD);
+  const { tryRawScreenshot, _setForTest, _resetForTest } = mod;
+  let capturerCalled = false;
+  _setForTest({
+    iosResolver: async () => null,
+    iosCapturer: async () => { capturerCalled = true; return true; },
+  });
+  try {
+    const result = await tryRawScreenshot('ios', '/tmp/shot.jpg');
+    assert.equal(result, null);
+    assert.equal(capturerCalled, false);
+  } finally {
+    _resetForTest();
+  }
+});
+
+test('tryRawScreenshot(ios): capturer fails → returns null', async () => {
+  const mod = await import(RAW_MOD);
+  const { tryRawScreenshot, _setForTest, _resetForTest } = mod;
+  _setForTest({
+    iosResolver: async () => 'UDID-X',
+    iosCapturer: async () => false,
+  });
+  try {
+    const result = await tryRawScreenshot('ios', '/tmp/shot.jpg');
+    assert.equal(result, null);
+  } finally {
+    _resetForTest();
+  }
+});
+
+test('tryRawScreenshot(android): resolver returns emu-id, capturer succeeds → envelope returned', async () => {
+  const mod = await import(RAW_MOD);
+  const { tryRawScreenshot, _setForTest, _resetForTest } = mod;
+  const captures = [];
+  _setForTest({
+    androidResolver: async () => 'emulator-5556',
+    androidCapturer: async (emuId, path) => { captures.push({ emuId, path }); return true; },
+  });
+  try {
+    const result = await tryRawScreenshot('android', '/tmp/shot.png');
+    assert.deepEqual(result, { ok: true, path: '/tmp/shot.png' });
+    assert.deepEqual(captures, [{ emuId: 'emulator-5556', path: '/tmp/shot.png' }]);
+  } finally {
+    _resetForTest();
+  }
+});
+
+// ── device-list integration ─────────────────────────────────────────
+
+test('captureAndResizeScreenshot: platformExplicit + ios resolved → raw path taken (no runAgentDevice)', async () => {
+  const raw = await import(RAW_MOD);
+  const dl = await import(DEVICE_LIST_MOD);
+  const { captureAndResizeScreenshot, _setRunAgentDeviceForTest, _resetRunAgentDeviceForTest } = dl;
+  let runAgentDeviceCalled = false;
+  _setRunAgentDeviceForTest(async () => {
+    runAgentDeviceCalled = true;
+    return { content: [{ type: 'text', text: JSON.stringify({ ok: false }) }], isError: true };
+  });
+  raw._setForTest({
+    iosResolver: async () => 'IOS-UDID',
+    iosCapturer: async () => true,
+  });
+  try {
+    const result = await captureAndResizeScreenshot({
+      platform: 'ios',
+      platformExplicit: true,
+      path: '/tmp/raw-ios.jpg',
+      maxWidth: 0, // skip resize so we don't need sips
+    });
+    assert.equal(runAgentDeviceCalled, false, 'runAgentDevice should NOT have been called');
+    const envelope = JSON.parse(result.content[0].text);
+    assert.equal(envelope.ok, true);
+    assert.equal(envelope.data.path, '/tmp/raw-ios.jpg');
+  } finally {
+    _resetRunAgentDeviceForTest();
+    raw._resetForTest();
+  }
+});
+
+test('captureAndResizeScreenshot: platformExplicit + resolver fails → falls through to runAgentDevice', async () => {
+  const raw = await import(RAW_MOD);
+  const dl = await import(DEVICE_LIST_MOD);
+  const { captureAndResizeScreenshot, _setRunAgentDeviceForTest, _resetRunAgentDeviceForTest } = dl;
+  let runAgentDeviceCalled = false;
+  _setRunAgentDeviceForTest(async (args, opts) => {
+    runAgentDeviceCalled = true;
+    // Mimic agent-device success envelope shape.
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ ok: true, data: { path: '/tmp/fallback.jpg' } }) }],
+    };
+  });
+  raw._setForTest({
+    iosResolver: async () => null, // resolver fails — should fall through
+  });
+  try {
+    const result = await captureAndResizeScreenshot({
+      platform: 'ios',
+      platformExplicit: true,
+      path: '/tmp/fallback.jpg',
+      maxWidth: 0,
+    });
+    assert.equal(runAgentDeviceCalled, true, 'runAgentDevice should be the fallback');
+    const envelope = JSON.parse(result.content[0].text);
+    assert.equal(envelope.ok, true);
+  } finally {
+    _resetRunAgentDeviceForTest();
+    raw._resetForTest();
+  }
+});
+
+test('captureAndResizeScreenshot: platformExplicit=false → uses runAgentDevice (backward parity)', async () => {
+  const raw = await import(RAW_MOD);
+  const dl = await import(DEVICE_LIST_MOD);
+  const { captureAndResizeScreenshot, _setRunAgentDeviceForTest, _resetRunAgentDeviceForTest } = dl;
+  let runAgentDeviceCalled = false;
+  let resolverCalled = false;
+  _setRunAgentDeviceForTest(async () => {
+    runAgentDeviceCalled = true;
+    return { content: [{ type: 'text', text: JSON.stringify({ ok: true, data: { path: '/tmp/x.jpg' } }) }] };
+  });
+  raw._setForTest({
+    iosResolver: async () => { resolverCalled = true; return 'X'; },
+  });
+  try {
+    // No platformExplicit field (or false) — even with platform set,
+    // we must NOT attempt raw path (only client-inferred platforms here).
+    await captureAndResizeScreenshot({
+      platform: 'ios',
+      // platformExplicit deliberately omitted
+      path: '/tmp/x.jpg',
+      maxWidth: 0,
+    });
+    assert.equal(runAgentDeviceCalled, true);
+    assert.equal(resolverCalled, false, 'resolver MUST NOT be called when platformExplicit is falsy');
+  } finally {
+    _resetRunAgentDeviceForTest();
+    raw._resetForTest();
+  }
+});
+
+test('captureAndResizeScreenshot: raw path still gets EPHEMERAL_PATH advisory for /tmp paths', async () => {
+  const raw = await import(RAW_MOD);
+  const dl = await import(DEVICE_LIST_MOD);
+  const { captureAndResizeScreenshot, _setRunAgentDeviceForTest, _resetRunAgentDeviceForTest } = dl;
+  _setRunAgentDeviceForTest(async () => ({ content: [{ type: 'text', text: '{}' }], isError: true }));
+  raw._setForTest({
+    iosResolver: async () => 'UDID',
+    iosCapturer: async () => true,
+  });
+  try {
+    const result = await captureAndResizeScreenshot({
+      platform: 'ios',
+      platformExplicit: true,
+      path: '/tmp/ephemeral.jpg',
+      maxWidth: 0,
+    });
+    const envelope = JSON.parse(result.content[0].text);
+    const codes = (envelope.meta?.advisories ?? []).map((a) => a.code);
+    assert.ok(codes.includes('EPHEMERAL_PATH'), `expected EPHEMERAL_PATH advisory, got ${JSON.stringify(codes)}`);
+  } finally {
+    _resetRunAgentDeviceForTest();
+    raw._resetForTest();
+  }
+});

--- a/scripts/cdp-bridge/test/unit/gh-136-screenshot-raw-platform.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-136-screenshot-raw-platform.test.js
@@ -139,6 +139,21 @@ test('tryRawScreenshot(android): resolver returns emu-id, capturer succeeds → 
   }
 });
 
+test('tryRawScreenshot(android): capturer fails → returns null (mirrors iOS test for symmetry)', async () => {
+  const mod = await import(RAW_MOD);
+  const { tryRawScreenshot, _setForTest, _resetForTest } = mod;
+  _setForTest({
+    androidResolver: async () => 'emulator-5556',
+    androidCapturer: async () => false,
+  });
+  try {
+    const result = await tryRawScreenshot('android', '/tmp/shot.png');
+    assert.equal(result, null);
+  } finally {
+    _resetForTest();
+  }
+});
+
 // ── device-list integration ─────────────────────────────────────────
 
 test('captureAndResizeScreenshot: platformExplicit + ios resolved → raw path taken (no runAgentDevice)', async () => {
@@ -165,6 +180,42 @@ test('captureAndResizeScreenshot: platformExplicit + ios resolved → raw path t
     const envelope = JSON.parse(result.content[0].text);
     assert.equal(envelope.ok, true);
     assert.equal(envelope.data.path, '/tmp/raw-ios.jpg');
+  } finally {
+    _resetRunAgentDeviceForTest();
+    raw._resetForTest();
+  }
+});
+
+test('captureAndResizeScreenshot: platformExplicit + android resolved → raw path taken (no runAgentDevice)', async () => {
+  // Mirrors the iOS-explicit test — covers the other arm of the
+  // `platform === 'ios' ? iosResolver : androidResolver` dispatch in
+  // tryRawScreenshot. Without this, a branch inversion in device-list.ts
+  // (e.g., calling iosResolver for android) would land green.
+  const raw = await import(RAW_MOD);
+  const dl = await import(DEVICE_LIST_MOD);
+  const { captureAndResizeScreenshot, _setRunAgentDeviceForTest, _resetRunAgentDeviceForTest } = dl;
+  let runAgentDeviceCalled = false;
+  const captures = [];
+  _setRunAgentDeviceForTest(async () => {
+    runAgentDeviceCalled = true;
+    return { content: [{ type: 'text', text: JSON.stringify({ ok: false }) }], isError: true };
+  });
+  raw._setForTest({
+    androidResolver: async () => 'emulator-5556',
+    androidCapturer: async (id, p) => { captures.push({ id, p }); return true; },
+  });
+  try {
+    const result = await captureAndResizeScreenshot({
+      platform: 'android',
+      platformExplicit: true,
+      path: '/tmp/raw-android.png',
+      maxWidth: 0,
+    });
+    assert.equal(runAgentDeviceCalled, false, 'runAgentDevice should NOT have been called for android explicit path');
+    assert.deepEqual(captures, [{ id: 'emulator-5556', p: '/tmp/raw-android.png' }]);
+    const envelope = JSON.parse(result.content[0].text);
+    assert.equal(envelope.ok, true);
+    assert.equal(envelope.data.path, '/tmp/raw-android.png');
   } finally {
     _resetRunAgentDeviceForTest();
     raw._resetForTest();


### PR DESCRIPTION
## Summary

Closes the multi-device routing half of [GH #136](https://github.com/Lykhoyda/rn-dev-agent/issues/136). PR-B (dev-client picker reliability) shipped in v0.44.28 (#139); this is the independent PR-A described in the same design spec.

**Problem (issue #136 #1):** with both an iOS sim and an Android emu booted, `device_screenshot platform: "android"` returned an iPhone-resolution JPEG. Root cause: `agent-device --platform` silently falls back to the active CDP session, ignoring the request.

**Fix:** when `device_screenshot` is called with **explicit** `platform: 'ios' | 'android'`, bypass agent-device and shell out to `xcrun simctl io` (iOS) or `adb -s <emu-id> exec-out screencap -p` (Android) directly. Backward-safe: omitted-platform calls (the common single-device case) use the existing `runAgentDevice` path identically. On any raw-path failure (resolver miss, command error, missing toolchain), gracefully falls through to `runAgentDevice`.

## Changes

| File | Purpose |
|---|---|
| `scripts/cdp-bridge/src/tools/device-screenshot-raw.ts` (new) | Pure parsers (`parseSimctlBootedUDID`, `parseAdbDevicesEmu`), default resolvers via `execFile` (no shell), Android capturer via `spawn` + `createWriteStream` (no shell redirect), `tryRawScreenshot` orchestrator, test seams (`_setForTest` / `_resetForTest`) |
| `scripts/cdp-bridge/src/tools/device-list.ts` | Added `platformExplicit?: boolean` to `ScreenshotArgs`. `captureAndResizeScreenshot` tries the raw path only when `platformExplicit`; `createDeviceScreenshotHandler` sets it based on whether the user passed `platform` (not inferred). New `_setRunAgentDeviceForTest` / `_resetRunAgentDeviceForTest` seams mirror the PR-B picker convention. |
| `scripts/cdp-bridge/test/unit/gh-136-screenshot-raw-platform.test.js` (new) | 14 unit tests: pure parsers (real + adversarial JSON / adb shapes), orchestrator branches (both iOS and Android arms, success + capturer-failure for each), raw-vs-fallback dispatch, advisory passthrough, backward parity |

## Multi-LLM review (Codex + Gemini, parallel)

Both reviewers converged on one real bug:

- **Android `WriteStream` flush race** (Codex 82%, Gemini 85%): `out.end()` is async — the promise could resolve `ok: true` while bytes remained buffered. For >64KB pipe buffers (any high-res emulator screenshot is ~1MB+) `resizeWithSips` could read a truncated PNG. Fixed in `9af8c80` by waiting on the `'finish'` event and destroying the stream on timeout / proc-error paths.
- **Test symmetry gaps** (Gemini 80%): added Android capturer-fails and Android raw-path integration tests to mirror the iOS coverage.

All other concerns (shell injection, module-scope seams, `platformExplicit` scope vs batch/proof_step, MCP schema safety, partial-file corruption, parser edge cases, JSDoc accuracy, Linux/CI resilience) verified clean and dropped during validation.

## Live verification (iOS smoke test)

Smoke-tested against a real booted iPhone 16 Pro on iOS 18.5:

\`\`\`
parseSimctlBootedUDID against real output → D704DA00-EF0D-44D0-B9C2-E73231C5F2E6
tryRawScreenshot('ios', ...) → {"ok":true,"path":"/tmp/pr-a-smoke-1778587007281.jpg"} in 331ms
File: /tmp/pr-a-smoke-1778587007281.jpg → 414038 bytes
JPEG magic bytes verified: FF D8 FF
Image dimensions: 1206 × 2622  (iPhone 16 Pro native — proves the iOS branch is platform-correct)
\`\`\`

Android half stays under unit-test + multi-LLM review coverage (no Android emulator available for live test this session — graceful fallback path means worst case is identical behavior to today).

## Tests

- 14 new PR-A unit tests, all passing
- Full unit suite: 1242 / 1242 passing, 0 failing
- TypeScript compiles clean
- Live iOS end-to-end smoke test against real `xcrun simctl`

## Acceptance (from spec)

- [x] Reproducer #136 #1: explicit-platform raw path bypasses agent-device entirely (verified via integration tests asserting `runAgentDevice` is not called)
- [x] Backward parity: no `platform` arg → existing path unchanged (test #13, asserts resolver never invoked)
- [x] Resize integration: raw screenshot still goes through `resizeWithSips` (test #14 asserts `EPHEMERAL_PATH` advisory fires identically)
- [ ] **Deferred to follow-up**: live multi-device test (iOS sim + Android emu booted, real `device_screenshot {platform: "android"}` returns Pixel-resolution image). Documented as smoke test of unit-tested code path for this PR.

## Test plan

- [ ] CI green on Build & Test + CodeQL
- [ ] Reviewer to optionally run the multi-device live repro from issue #136 against the merged build
- [ ] Version sync check passes (plugin 0.44.29 / cdp-bridge 0.38.24 / marketplace 0.44.29)