### PR TITLE
fix: android capturer exit-code race (Phase 134.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.29",
+      "version": "0.44.30",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.29",
+  "version": "0.44.30",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ scripts/fast-runner/build/
 
 # Local worktrees for isolated feature work
 .worktrees/
+
+# deepsec scanner workspace (local-only — config, data/<id>/INFO.md, scan output)
+.deepsec/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.44.30] — 2026-05-12
+
+### Fixed (Phase 134.0 — Android capturer exit-code race, deepsec follow-up)
+
+- **`defaultAndroidCapturer` no longer reports success on adb non-zero exit
+  when the stream finished first.** The prior implementation settled on
+  whichever of `out.on('finish')` or `proc.on('close', code)` fired first.
+  Node doesn't order these events, so a truncated/corrupt screenshot
+  could be reported as `ok: true` when adb exited non-zero AFTER the
+  WriteStream drained. The new two-track settle requires BOTH
+  `streamFinished === true` AND `procCode === 0` before reporting
+  success; on any failure path the partial file is unlinked so
+  `resizeWithSips` never reads a corrupt artifact.
+- The decision logic is extracted as a pure
+  `resolveCaptureOutcome(streamFinished, procCode)` helper exported for
+  unit testing; the event-wiring stays small enough to read at a glance.
+- Caught by the first deepsec full-repo scan (run
+  `20260512130956-afb409ef9132fae2`) — a class of race that neither the
+  PR-A multi-LLM review (Codex + Gemini) flagged because their attention
+  was on the stream-flush race, not the exit-code race. Phase 134 of the
+  workspace ROADMAP sequences the remaining 7 CRITICAL + 11 HIGH
+  findings from the same scan.
+
+### Internal
+
+- 3 new unit tests in `gh-136-screenshot-raw-platform.test.js` cover the
+  `resolveCaptureOutcome` truth table (pending / success / failure
+  including the exact deepsec scenario: `streamFinished=true,
+  procCode=non-zero`). Full unit suite: 1245 passing, 0 failing.
+
 ## [0.44.29] — 2026-05-12
 
 ### Fixed (GH #136 — PR-A: Multi-Device Screenshot Routing)

--- a/scripts/cdp-bridge/dist/tools/device-screenshot-raw.js
+++ b/scripts/cdp-bridge/dist/tools/device-screenshot-raw.js
@@ -17,7 +17,7 @@
  * spawning real `xcrun`/`adb` subprocesses.
  */
 import { execFile, spawn } from 'node:child_process';
-import { createWriteStream } from 'node:fs';
+import { createWriteStream, unlinkSync } from 'node:fs';
 import { promisify } from 'node:util';
 const execFileAsync = promisify(execFile);
 export function parseSimctlBootedUDID(jsonText) {
@@ -93,23 +93,42 @@ const defaultIosCapturer = async (udid, path) => {
         return false;
     }
 };
+export function resolveCaptureOutcome(streamFinished, procCode) {
+    if (!streamFinished)
+        return 'pending';
+    if (procCode === null)
+        return 'pending';
+    return procCode === 0 ? 'success' : 'failure';
+}
 // Android needs the binary screen bytes piped to a file. execFile can't redirect
 // stdout, so spawn directly and pipe to a write stream — no shell, so the path
 // is safely passed as a literal filename, not interpolated into a command string.
 //
-// Settle ordering matters: `pipe()` auto-ends `out` when `proc.stdout` ends, but
-// `out.end()` is async — bytes can remain buffered after the child exits. We
-// resolve `true` only on the WriteStream's `'finish'` event (post-flush) so
-// `resizeWithSips` never reads a truncated PNG. Multi-LLM review caught this.
+// Two-track settle: success requires BOTH the WriteStream 'finish' event (all
+// bytes drained to disk) AND adb's 'close' event with exit code 0. Either
+// alone is insufficient: 'finish' before non-zero close = truncated/partial
+// file reported as success (deepsec 2026-05-12 finding); 'close' before
+// 'finish' = success reported before bytes hit disk (earlier multi-LLM
+// review finding). On any failure path, the partial file is unlinked so
+// `resizeWithSips` never sees a corrupt artifact.
 const defaultAndroidCapturer = async (emuId, path) => new Promise((resolve) => {
     let settled = false;
+    let streamFinished = false;
+    let procCode = null;
     const proc = spawn('adb', ['-s', emuId, 'exec-out', 'screencap', '-p'], { stdio: ['ignore', 'pipe', 'pipe'] });
     const out = createWriteStream(path);
+    const cleanupPartial = () => {
+        try {
+            unlinkSync(path);
+        }
+        catch { /* file may not exist yet — ignore */ }
+    };
     const timer = setTimeout(() => {
         if (settled)
             return;
         proc.kill();
         out.destroy();
+        cleanupPartial();
         settle(false);
     }, 15_000);
     const settle = (ok) => {
@@ -119,19 +138,28 @@ const defaultAndroidCapturer = async (emuId, path) => new Promise((resolve) => {
         clearTimeout(timer);
         resolve(ok);
     };
+    const maybeSettle = () => {
+        const outcome = resolveCaptureOutcome(streamFinished, procCode);
+        if (outcome === 'pending')
+            return;
+        if (outcome === 'failure') {
+            out.destroy();
+            cleanupPartial();
+        }
+        settle(outcome === 'success');
+    };
     proc.stdout.pipe(out);
-    out.on('finish', () => settle(true));
-    out.on('error', () => settle(false));
+    out.on('finish', () => { streamFinished = true; maybeSettle(); });
+    out.on('error', () => {
+        cleanupPartial();
+        settle(false);
+    });
     proc.on('error', () => {
         out.destroy();
+        cleanupPartial();
         settle(false);
     });
-    proc.on('close', (code) => {
-        if (code === 0)
-            return; // success path settles via `out.on('finish')`
-        out.destroy();
-        settle(false);
-    });
+    proc.on('close', (code) => { procCode = code; maybeSettle(); });
 });
 let iosResolver = defaultIosResolver;
 let androidResolver = defaultAndroidResolver;

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.24",
+  "version": "0.38.25",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/tools/device-screenshot-raw.ts
+++ b/scripts/cdp-bridge/src/tools/device-screenshot-raw.ts
@@ -17,7 +17,7 @@
  * spawning real `xcrun`/`adb` subprocesses.
  */
 import { execFile, spawn } from 'node:child_process';
-import { createWriteStream } from 'node:fs';
+import { createWriteStream, unlinkSync } from 'node:fs';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
@@ -103,23 +103,47 @@ const defaultIosCapturer: RawCapturer = async (udid, path) => {
   }
 };
 
+/**
+ * Pure decision helper exported for unit tests. Returns the success/failure
+ * verdict only when BOTH the WriteStream finished AND adb's exit code is
+ * known — Node doesn't order `out.on('finish')` and `proc.on('close')`, so
+ * we wait for both before settling. Deepsec scan (2026-05-12) caught the
+ * prior single-track version reporting success on stream-finish even when
+ * adb exited non-zero afterwards.
+ */
+export type CaptureOutcome = 'success' | 'failure' | 'pending';
+export function resolveCaptureOutcome(streamFinished: boolean, procCode: number | null): CaptureOutcome {
+  if (!streamFinished) return 'pending';
+  if (procCode === null) return 'pending';
+  return procCode === 0 ? 'success' : 'failure';
+}
+
 // Android needs the binary screen bytes piped to a file. execFile can't redirect
 // stdout, so spawn directly and pipe to a write stream — no shell, so the path
 // is safely passed as a literal filename, not interpolated into a command string.
 //
-// Settle ordering matters: `pipe()` auto-ends `out` when `proc.stdout` ends, but
-// `out.end()` is async — bytes can remain buffered after the child exits. We
-// resolve `true` only on the WriteStream's `'finish'` event (post-flush) so
-// `resizeWithSips` never reads a truncated PNG. Multi-LLM review caught this.
+// Two-track settle: success requires BOTH the WriteStream 'finish' event (all
+// bytes drained to disk) AND adb's 'close' event with exit code 0. Either
+// alone is insufficient: 'finish' before non-zero close = truncated/partial
+// file reported as success (deepsec 2026-05-12 finding); 'close' before
+// 'finish' = success reported before bytes hit disk (earlier multi-LLM
+// review finding). On any failure path, the partial file is unlinked so
+// `resizeWithSips` never sees a corrupt artifact.
 const defaultAndroidCapturer: RawCapturer = async (emuId, path) =>
   new Promise<boolean>((resolve) => {
     let settled = false;
+    let streamFinished = false;
+    let procCode: number | null = null;
     const proc = spawn('adb', ['-s', emuId, 'exec-out', 'screencap', '-p'], { stdio: ['ignore', 'pipe', 'pipe'] });
     const out = createWriteStream(path);
+    const cleanupPartial = (): void => {
+      try { unlinkSync(path); } catch { /* file may not exist yet — ignore */ }
+    };
     const timer = setTimeout(() => {
       if (settled) return;
       proc.kill();
       out.destroy();
+      cleanupPartial();
       settle(false);
     }, 15_000);
     const settle = (ok: boolean): void => {
@@ -128,18 +152,27 @@ const defaultAndroidCapturer: RawCapturer = async (emuId, path) =>
       clearTimeout(timer);
       resolve(ok);
     };
+    const maybeSettle = (): void => {
+      const outcome = resolveCaptureOutcome(streamFinished, procCode);
+      if (outcome === 'pending') return;
+      if (outcome === 'failure') {
+        out.destroy();
+        cleanupPartial();
+      }
+      settle(outcome === 'success');
+    };
     proc.stdout.pipe(out);
-    out.on('finish', () => settle(true));
-    out.on('error', () => settle(false));
+    out.on('finish', () => { streamFinished = true; maybeSettle(); });
+    out.on('error', () => {
+      cleanupPartial();
+      settle(false);
+    });
     proc.on('error', () => {
       out.destroy();
+      cleanupPartial();
       settle(false);
     });
-    proc.on('close', (code) => {
-      if (code === 0) return; // success path settles via `out.on('finish')`
-      out.destroy();
-      settle(false);
-    });
+    proc.on('close', (code) => { procCode = code; maybeSettle(); });
   });
 
 let iosResolver: RawResolver = defaultIosResolver;

--- a/scripts/cdp-bridge/test/unit/gh-136-screenshot-raw-platform.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-136-screenshot-raw-platform.test.js
@@ -14,6 +14,38 @@ import assert from 'node:assert/strict';
 const RAW_MOD = '../../dist/tools/device-screenshot-raw.js';
 const DEVICE_LIST_MOD = '../../dist/tools/device-list.js';
 
+// ── resolveCaptureOutcome (deepsec 2026-05-12 follow-up) ────────────
+// The Android capturer waits for BOTH the WriteStream's 'finish' event AND
+// adb's exit code before settling. Node doesn't order these two events, so
+// the decision helper must report 'pending' until both have arrived, and
+// only return 'success' when both happened cleanly. The earlier version
+// resolved on whichever fired first — adb exiting non-zero after the
+// stream finished was silently swallowed (deepsec finding "Android
+// screenshot can report success before adb exit status is known").
+
+test('resolveCaptureOutcome: pending until both signals arrive', async () => {
+  const { resolveCaptureOutcome } = await import(RAW_MOD);
+  assert.equal(resolveCaptureOutcome(false, null), 'pending');
+  assert.equal(resolveCaptureOutcome(true, null), 'pending');
+  assert.equal(resolveCaptureOutcome(false, 0), 'pending');
+});
+
+test('resolveCaptureOutcome: success only when stream finished AND exit code 0', async () => {
+  const { resolveCaptureOutcome } = await import(RAW_MOD);
+  assert.equal(resolveCaptureOutcome(true, 0), 'success');
+});
+
+test('resolveCaptureOutcome: stream finished + non-zero exit → failure (the deepsec race)', async () => {
+  const { resolveCaptureOutcome } = await import(RAW_MOD);
+  // This is the exact scenario the deepsec scan caught: WriteStream drained
+  // cleanly, then adb exited with non-zero status. Prior code reported
+  // success on the 'finish' event; the new code must report failure once
+  // both signals are in.
+  assert.equal(resolveCaptureOutcome(true, 1), 'failure');
+  assert.equal(resolveCaptureOutcome(true, 127), 'failure');
+  assert.equal(resolveCaptureOutcome(true, -1), 'failure');
+});
+
 // ── Pure parsers ────────────────────────────────────────────────────
 
 test('parseSimctlBootedUDID: returns first Booted device UDID, skips Shutdown', async () => {


### PR DESCRIPTION
## Summary

First sub-phase of [workspace ROADMAP Phase 134](https://github.com/Lykhoyda/rn-dev-agent-workspace/blob/main/docs/ROADMAP.md) — remediating the [first full deepsec scan](https://github.com/Lykhoyda/rn-dev-agent/issues?q=deepsec) of the plugin repo (48 findings; this PR closes 1 BUG).

**The bug**: `defaultAndroidCapturer` settled on whichever of `out.on('finish')` or `proc.on('close', code)` fired first. Node doesn't order these events. A truncated/corrupt screenshot could be reported as `ok: true` when adb exited non-zero AFTER the WriteStream drained.

**The fix**: two-track settle — track `streamFinished` and `procCode` independently; settle success only when BOTH have arrived clean. Extracted as a pure `resolveCaptureOutcome(streamFinished, procCode)` helper for testability. Failure paths unlink the partial file so the downstream `resizeWithSips` never reads a corrupt artifact.

## Why deepsec caught it but multi-LLM review didn't

PR #142's multi-LLM review (Codex + Gemini) flagged the related **stream-flush race** ('finish' fires before bytes drain) and I fixed that. Both reviewers' attention budgets went on the 'finish' event ordering. The exit-code race is the same shape (two independent event sources) but a different event pair — neither reviewer noticed.

deepsec's 524s investigation budget per batch + the "find security bugs" framing produced the catch. Confidence: high.

## Changes

| File | Change |
|---|---|
| `scripts/cdp-bridge/src/tools/device-screenshot-raw.ts` | Two-track settle. Pure `resolveCaptureOutcome` helper exported. `cleanupPartial()` unlinks on every failure path. Timer also cleans up partial file. |
| `scripts/cdp-bridge/test/unit/gh-136-screenshot-raw-platform.test.js` | 3 new tests covering the `resolveCaptureOutcome` truth table — including the exact deepsec scenario (`streamFinished=true, procCode=non-zero` → `failure`). |
| `CHANGELOG.md` | New `[0.44.30]` section. |
| Version bumps | plugin `0.44.29 → 0.44.30`, cdp-bridge `0.38.24 → 0.38.25`, marketplace synced. |
| `.gitignore` | Bonus chore: ignore `.deepsec/` scanner workspace (separate commit). |

## Tests

- 3 new unit tests for `resolveCaptureOutcome`
- Full unit suite: **1245 / 1245 passing**, 0 failing
- TypeScript compiles cleanly
- The default Android capturer itself isn't unit-tested (would require mocking `spawn` + `createWriteStream` + their event emitters) — the decision logic IS tested via the pure helper, and the wiring is short enough to read at a glance.

## Acceptance

- [x] All paths that settle now go through `resolveCaptureOutcome` or hard-failure handlers that also `cleanupPartial()`
- [x] Truncated/non-zero-exit case unit-tested explicitly
- [x] Timer path also cleans up partial file
- [x] Stream-error / proc-error paths also clean up
- [ ] Live verification against a real Android emulator — deferred (no emulator currently booted; the iOS path is unaffected)

## Out of scope

- Other 47 deepsec findings — sequenced as Phase 134.1–134.5 in the workspace ROADMAP.
- Mocking `spawn`/`createWriteStream` for full event-wiring unit tests — value/cost trade-off doesn't justify it for a 70-line capturer.

## Test plan

- [ ] CI green on Build & Test + CodeQL
- [ ] Version sync check passes (0.44.30 across plugin.json / marketplace.json / cdp-bridge 0.38.25)