### PR TITLE
fix: path containment — closes 2 HIGH + 3 MEDIUM (Phase 134.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.32",
+      "version": "0.44.33",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.32",
+  "version": "0.44.33",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.44.33] — 2026-05-12
+
+### Fixed (Phase 134.3 — path containment, closes 2 HIGH + 3 MEDIUM)
+
+- **Action IDs are validated against a strict regex** at every MCP tool
+  boundary that uses them as a path segment under `.rn-agent/actions/`.
+  `cdp_run_action` and `cdp_repair_action` reject IDs like `../etc/passwd`
+  with `BAD_FILENAME` before any file read. Closes 2 deepsec HIGH
+  path-traversal findings.
+- **`actionPathFor` enforces both regex + assertWithinDir** as
+  defense-in-depth. Even if a future caller bypasses the boundary
+  regex, the path resolution refuses to land outside the actions dir.
+- **`device_screenshot` rejects paths containing `..` segments.** A
+  malicious agent could otherwise pass `path: '../../../etc/passwd'`
+  and overwrite arbitrary files. Absolute paths to legitimate
+  locations (e.g. `~/Desktop`) remain allowed.
+- **Default screenshot filename gets a random suffix** so parallel
+  same-millisecond calls can't clobber each other's output. Was
+  `/tmp/rn-screenshot-<ts>.jpg`; now `/tmp/rn-screenshot-<ts>-<rand>.jpg`.
+- **`cross_platform_verify scanDir` rejects `..` traversal.** Refuses
+  to enumerate the filesystem outside the caller's directory.
+
+### Internal
+
+- New module `scripts/cdp-bridge/src/domain/path-safety.ts` —
+  `isValidActionId`, `assertValidActionId`, `assertWithinDir`,
+  `isWithinDir`, `pathHasTraversal`, plus `PathTraversalError`. Reused
+  across action-store, repair-action, run-action, device-list,
+  cross-platform-verify. Same chokepoint discipline as Phase 134.1
+  (Maestro validator) and 134.2 (bundle-ID validation).
+- 12 new unit tests cover path-traversal payloads, absolute paths,
+  control chars, sibling-dir prefix collision, and the backward-parity
+  path. Total test count: 1284 → 1296 passing, 0 failing.
+- Implements proposed D1214 from workspace ROADMAP Phase 134.1
+  ("Tool-supplied paths must pass `assertWithinDir(p, projectActionsDir)`
+  before any `fs.write*` / `createWriteStream` call").
+
 ## [0.44.32] — 2026-05-12
 
 ### Fixed (Phase 134.2 — adb shell-arg hardening, closes 5 HIGH)

--- a/scripts/cdp-bridge/dist/domain/action-store.js
+++ b/scripts/cdp-bridge/dist/domain/action-store.js
@@ -10,13 +10,25 @@ import { join } from 'node:path';
 import { parseM7Header, serializeM7Header, } from './reusable-action.js';
 import { loadOrInitSidecar, sidecarPathFor, yamlEditedSinceLastSeen, } from './sidecar-io.js';
 import { atomicWriter } from './atomic-writer.js';
+import { assertValidActionId, assertWithinDir } from './path-safety.js';
 /**
  * Resolve the canonical YAML path for an action id under a project root.
  * Mirrors the .rn-agent/actions/ convention (D1208 single-folder doctrine,
  * supersedes D1207).
+ *
+ * Phase 134.3 (deepsec HIGH path-traversal): the regex check is the
+ * primary defense — `actionId` flows from caller args (MCP tool params,
+ * project YAML file names) and a `../etc/passwd` slug would otherwise
+ * escape `.rn-agent/actions/`. The assertWithinDir check is a
+ * defense-in-depth chokepoint that catches any future bypass of the
+ * regex (e.g. a new caller that forgets to validate).
  */
 export function actionPathFor(projectRoot, actionId) {
-    return join(projectRoot, '.rn-agent', 'actions', `${actionId}.yaml`);
+    assertValidActionId(actionId, 'actionPathFor');
+    const actionsDir = join(projectRoot, '.rn-agent', 'actions');
+    const fileName = `${actionId}.yaml`;
+    assertWithinDir(fileName, actionsDir);
+    return join(actionsDir, fileName);
 }
 /**
  * Split a YAML file into (top-section before `---`, header comments

--- a/scripts/cdp-bridge/dist/domain/path-safety.js
+++ b/scripts/cdp-bridge/dist/domain/path-safety.js
@@ -1,0 +1,88 @@
+/**
+ * Phase 134.3: path containment helpers (deepsec scan 2026-05-12).
+ *
+ * Closes HIGH/MEDIUM path-traversal findings where caller-controlled
+ * actionId / outputDir / scanDir / screenshot path flowed into fs.write*
+ * / fs.read* / shell-style discovery without containment.
+ *
+ * Two primitives:
+ *   - isValidActionId(s): strict regex for IDs used as path segments
+ *     under `.rn-agent/actions/`. Rejects path traversal, control
+ *     characters, absolute-path-ish inputs, and over-long values.
+ *   - assertWithinDir(child, baseDir): defense-in-depth containment
+ *     check on a resolved path. Throws PathTraversalError if the
+ *     resolved child escapes baseDir.
+ *
+ * Designed to be reused at every site where caller-derived strings
+ * cross into the filesystem boundary — same chokepoint discipline as
+ * Phase 134.1/134.2 (isValidBundleId for adb shell args).
+ */
+import { resolve, sep } from 'node:path';
+// ── Errors ──────────────────────────────────────────────────────────
+export class PathTraversalError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'PathTraversalError';
+    }
+}
+// ── Action ID validation ────────────────────────────────────────────
+// Action IDs flow into `.rn-agent/actions/<id>.yaml` and the matching
+// sidecar `<id>.action.json`. They must start with an alphanumeric
+// character, then accept hyphen/underscore/dot/alphanumeric. We
+// deliberately exclude `..`, `/`, `\`, and control characters so the
+// ID can never escape its parent directory.
+const ACTION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+const ACTION_ID_MAX_LEN = 64;
+export function isValidActionId(s) {
+    if (typeof s !== 'string')
+        return false;
+    if (s.length === 0 || s.length > ACTION_ID_MAX_LEN)
+        return false;
+    return ACTION_ID_RE.test(s);
+}
+export function assertValidActionId(s, context) {
+    if (!isValidActionId(s)) {
+        const preview = JSON.stringify(s).slice(0, 80);
+        throw new PathTraversalError(`Invalid action ID for ${context}: ${preview}`);
+    }
+}
+// ── Directory containment ───────────────────────────────────────────
+// Resolves `child` against `baseDir` and rejects anything that doesn't
+// land inside baseDir. Defense in depth — the action-ID regex prevents
+// the common attack, but this catches any future call site that forgot
+// to validate.
+//
+// Implementation note: a naive `resolvedChild.startsWith(resolvedBase)`
+// check is broken — `/tmp/foo-extra` starts with `/tmp/foo`, but they're
+// sibling directories. We require either an exact match or a match with
+// the separator appended.
+export function assertWithinDir(child, baseDir) {
+    const resolvedBase = resolve(baseDir);
+    const resolvedChild = resolve(baseDir, child);
+    if (resolvedChild === resolvedBase)
+        return;
+    const baseWithSep = resolvedBase.endsWith(sep) ? resolvedBase : resolvedBase + sep;
+    if (!resolvedChild.startsWith(baseWithSep)) {
+        throw new PathTraversalError(`Path "${child}" escapes containment dir "${baseDir}" (resolved to ${resolvedChild})`);
+    }
+}
+export function isWithinDir(child, baseDir) {
+    try {
+        assertWithinDir(child, baseDir);
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+// ── Screenshot/output path safety ───────────────────────────────────
+// Less strict than action IDs — users legitimately pass absolute paths
+// like `/Users/me/Desktop/foo.jpg`. But we still reject `..` traversal
+// segments anywhere in the path. Cheap defense against an LLM passing a
+// crafted relative path that escapes the project dir.
+export function pathHasTraversal(p) {
+    if (typeof p !== 'string')
+        return false;
+    // POSIX `..` segment, Windows `..` segment, URL-encoded `..`.
+    return /(^|[\\/])\.\.([\\/]|$)/.test(p) || /%2e%2e/i.test(p);
+}

--- a/scripts/cdp-bridge/dist/tools/cross-platform-verify.js
+++ b/scripts/cdp-bridge/dist/tools/cross-platform-verify.js
@@ -2,6 +2,7 @@ import { readFileSync, readdirSync, lstatSync } from 'node:fs';
 import { join, extname } from 'node:path';
 import { getCachedSnapshot } from '../agent-device-wrapper.js';
 import { okResult, failResult, warnResult } from '../utils.js';
+import { pathHasTraversal } from '../domain/path-safety.js';
 export function findElement(nodes, query, matchBy) {
     const q = query.toLowerCase();
     return nodes.some((n) => {
@@ -56,6 +57,13 @@ export function createCrossPlatformVerifyHandler() {
         let elements = args.elements;
         let discoveredCount = 0;
         if (args.scanDir) {
+            // Phase 134.3 (deepsec MEDIUM path-traversal): refuse scanDir
+            // containing `..` segments. A malicious agent could otherwise
+            // pass `../../../etc` to enumerate the filesystem looking for
+            // `testID=` patterns in unrelated source files.
+            if (pathHasTraversal(args.scanDir)) {
+                return failResult(`scanDir "${args.scanDir}" contains '..' traversal segments — refuse to scan outside the calling directory`);
+            }
             const discovered = discoverTestIDs(args.scanDir);
             if (discovered.length === 0) {
                 return failResult(`No testIDs found in ${args.scanDir}. Ensure components use testID="..." props.`);

--- a/scripts/cdp-bridge/dist/tools/device-list.js
+++ b/scripts/cdp-bridge/dist/tools/device-list.js
@@ -1,6 +1,7 @@
 import { runAgentDevice } from '../agent-device-wrapper.js';
 import { resizeWithSips } from './device-screenshot-resize.js';
 import { tryRawScreenshot } from './device-screenshot-raw.js';
+import { pathHasTraversal } from '../domain/path-safety.js';
 let runAgentDeviceFn = runAgentDevice;
 export function _setRunAgentDeviceForTest(fn) {
     runAgentDeviceFn = fn;
@@ -16,11 +17,28 @@ export function createDeviceListHandler() {
  * handler can know the path independently from `buildScreenshotArgs` (used to
  * pass it to the post-resize step) and to keep `buildScreenshotArgs` tests stable.
  */
-export function deriveScreenshotPath(args, now = Date.now) {
+export function deriveScreenshotPath(args, now = Date.now, rand = Math.random) {
+    // Phase 134.3 (deepsec MEDIUM path-traversal): caller-supplied `path`
+    // could contain `..` segments that escape the intended directory.
+    // Absolute paths to legitimate locations (e.g. ~/Desktop) are still
+    // allowed — only `..` traversal is refused.
+    if (args.path && pathHasTraversal(args.path)) {
+        throw new PathTraversalScreenshotError(`Screenshot path "${args.path}" contains '..' traversal segments — refuse to write to a path that escapes its parent directory`);
+    }
     if (args.path)
         return args.path;
     const ext = args.format === 'jpeg' ? 'jpg' : args.format === 'png' ? 'png' : 'jpg';
-    return `/tmp/rn-screenshot-${now()}.${ext}`;
+    // Add a short random suffix so two parallel calls in the same ms can't
+    // clobber each other's output. deepsec MEDIUM: predictable /tmp files
+    // allow cross-run races. `rand` is injectable for tests.
+    const suffix = rand().toString(36).slice(2, 8);
+    return `/tmp/rn-screenshot-${now()}-${suffix}.${ext}`;
+}
+class PathTraversalScreenshotError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'PathTraversalScreenshotError';
+    }
 }
 /**
  * B113 fix (D636): agent-device >= 0.8.0 exposes only `[path]` and `--out <path>`
@@ -30,8 +48,8 @@ export function deriveScreenshotPath(args, now = Date.now) {
  *
  * Exported for unit tests — pure function, no I/O.
  */
-export function buildScreenshotArgs(args, now = Date.now) {
-    return ['screenshot', '--out', deriveScreenshotPath(args, now)];
+export function buildScreenshotArgs(args, now = Date.now, rand = Math.random) {
+    return ['screenshot', '--out', deriveScreenshotPath(args, now, rand)];
 }
 /**
  * B120 / GH #36: extract the path agent-device actually wrote to. Daemon and

--- a/scripts/cdp-bridge/dist/tools/repair-action.js
+++ b/scripts/cdp-bridge/dist/tools/repair-action.js
@@ -7,6 +7,7 @@
 // domain/repair-engine.ts; this file is the I/O orchestration.
 import { runAgentDevice } from '../agent-device-wrapper.js';
 import { okResult, failResult, withSession } from '../utils.js';
+import { isValidActionId } from '../domain/path-safety.js';
 import { loadAction, saveAction, actionWasEditedExternally, } from '../domain/action-store.js';
 import { extractAllTestIDs, attemptRepair, applyRepair, DEFAULT_REPAIR_THRESHOLD, } from '../domain/repair-engine.js';
 import { repairBudgetAvailable } from '../domain/reusable-action.js';
@@ -15,6 +16,13 @@ export function createRepairActionHandler() {
     return withSession(async (args) => {
         if (!args.actionId || typeof args.actionId !== 'string') {
             return failResult('cdp_repair_action requires actionId', 'BAD_FILENAME');
+        }
+        // Phase 134.3 (deepsec HIGH path-traversal): actionId flows into
+        // <projectRoot>/.rn-agent/actions/<id>.yaml. Reject any ID that
+        // could escape that directory (e.g. `../../etc/passwd`) before any
+        // file read happens.
+        if (!isValidActionId(args.actionId)) {
+            return failResult(`Invalid actionId "${String(args.actionId).slice(0, 80)}" — must match /^[A-Za-z0-9][A-Za-z0-9_-]*$/ and be <= 64 chars`, 'BAD_FILENAME');
         }
         if (!args.failedSelector || typeof args.failedSelector !== 'string') {
             // Future enhancement: scan all selectors and find all stale ones.

--- a/scripts/cdp-bridge/dist/tools/run-action.js
+++ b/scripts/cdp-bridge/dist/tools/run-action.js
@@ -33,6 +33,7 @@ import { appendRunRecord, } from '../domain/reusable-action.js';
 import { parseMaestroFailure, isAutoRepairable, } from '../domain/maestro-error-parser.js';
 import { createMaestroRunHandler } from './maestro-run.js';
 import { createRepairActionHandler } from './repair-action.js';
+import { isValidActionId } from '../domain/path-safety.js';
 /**
  * Map a parsed Maestro failure kind to an `ActionFailureCode` (for
  * RunRecord telemetry) and a `ToolErrorCode` (for the failResult
@@ -112,6 +113,12 @@ export function createRunActionHandler(deps = {}) {
     return async (args) => {
         if (!args.actionId || typeof args.actionId !== 'string') {
             return failResult('cdp_run_action requires actionId', 'BAD_FILENAME');
+        }
+        // Phase 134.3 (deepsec HIGH path-traversal): same chokepoint as
+        // cdp_repair_action — actionId flows into the .rn-agent/actions/
+        // path segment. Reject malicious slugs at the boundary.
+        if (!isValidActionId(args.actionId)) {
+            return failResult(`Invalid actionId "${String(args.actionId).slice(0, 80)}" — must match /^[A-Za-z0-9][A-Za-z0-9_-]*$/ and be <= 64 chars`, 'BAD_FILENAME');
         }
         const projectRoot = args.projectRoot ?? process.cwd();
         const action = loadAction(projectRoot, args.actionId);

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.27",
+  "version": "0.38.28",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/domain/action-store.ts
+++ b/scripts/cdp-bridge/src/domain/action-store.ts
@@ -20,14 +20,26 @@ import {
   yamlEditedSinceLastSeen,
 } from './sidecar-io.js';
 import { atomicWriter } from './atomic-writer.js';
+import { assertValidActionId, assertWithinDir } from './path-safety.js';
 
 /**
  * Resolve the canonical YAML path for an action id under a project root.
  * Mirrors the .rn-agent/actions/ convention (D1208 single-folder doctrine,
  * supersedes D1207).
+ *
+ * Phase 134.3 (deepsec HIGH path-traversal): the regex check is the
+ * primary defense — `actionId` flows from caller args (MCP tool params,
+ * project YAML file names) and a `../etc/passwd` slug would otherwise
+ * escape `.rn-agent/actions/`. The assertWithinDir check is a
+ * defense-in-depth chokepoint that catches any future bypass of the
+ * regex (e.g. a new caller that forgets to validate).
  */
 export function actionPathFor(projectRoot: string, actionId: string): string {
-  return join(projectRoot, '.rn-agent', 'actions', `${actionId}.yaml`);
+  assertValidActionId(actionId, 'actionPathFor');
+  const actionsDir = join(projectRoot, '.rn-agent', 'actions');
+  const fileName = `${actionId}.yaml`;
+  assertWithinDir(fileName, actionsDir);
+  return join(actionsDir, fileName);
 }
 
 /**

--- a/scripts/cdp-bridge/src/domain/path-safety.ts
+++ b/scripts/cdp-bridge/src/domain/path-safety.ts
@@ -1,0 +1,96 @@
+/**
+ * Phase 134.3: path containment helpers (deepsec scan 2026-05-12).
+ *
+ * Closes HIGH/MEDIUM path-traversal findings where caller-controlled
+ * actionId / outputDir / scanDir / screenshot path flowed into fs.write*
+ * / fs.read* / shell-style discovery without containment.
+ *
+ * Two primitives:
+ *   - isValidActionId(s): strict regex for IDs used as path segments
+ *     under `.rn-agent/actions/`. Rejects path traversal, control
+ *     characters, absolute-path-ish inputs, and over-long values.
+ *   - assertWithinDir(child, baseDir): defense-in-depth containment
+ *     check on a resolved path. Throws PathTraversalError if the
+ *     resolved child escapes baseDir.
+ *
+ * Designed to be reused at every site where caller-derived strings
+ * cross into the filesystem boundary — same chokepoint discipline as
+ * Phase 134.1/134.2 (isValidBundleId for adb shell args).
+ */
+import { resolve, sep } from 'node:path';
+
+// ── Errors ──────────────────────────────────────────────────────────
+
+export class PathTraversalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PathTraversalError';
+  }
+}
+
+// ── Action ID validation ────────────────────────────────────────────
+// Action IDs flow into `.rn-agent/actions/<id>.yaml` and the matching
+// sidecar `<id>.action.json`. They must start with an alphanumeric
+// character, then accept hyphen/underscore/dot/alphanumeric. We
+// deliberately exclude `..`, `/`, `\`, and control characters so the
+// ID can never escape its parent directory.
+
+const ACTION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+const ACTION_ID_MAX_LEN = 64;
+
+export function isValidActionId(s: unknown): s is string {
+  if (typeof s !== 'string') return false;
+  if (s.length === 0 || s.length > ACTION_ID_MAX_LEN) return false;
+  return ACTION_ID_RE.test(s);
+}
+
+export function assertValidActionId(s: unknown, context: string): asserts s is string {
+  if (!isValidActionId(s)) {
+    const preview = JSON.stringify(s).slice(0, 80);
+    throw new PathTraversalError(`Invalid action ID for ${context}: ${preview}`);
+  }
+}
+
+// ── Directory containment ───────────────────────────────────────────
+// Resolves `child` against `baseDir` and rejects anything that doesn't
+// land inside baseDir. Defense in depth — the action-ID regex prevents
+// the common attack, but this catches any future call site that forgot
+// to validate.
+//
+// Implementation note: a naive `resolvedChild.startsWith(resolvedBase)`
+// check is broken — `/tmp/foo-extra` starts with `/tmp/foo`, but they're
+// sibling directories. We require either an exact match or a match with
+// the separator appended.
+
+export function assertWithinDir(child: string, baseDir: string): void {
+  const resolvedBase = resolve(baseDir);
+  const resolvedChild = resolve(baseDir, child);
+  if (resolvedChild === resolvedBase) return;
+  const baseWithSep = resolvedBase.endsWith(sep) ? resolvedBase : resolvedBase + sep;
+  if (!resolvedChild.startsWith(baseWithSep)) {
+    throw new PathTraversalError(
+      `Path "${child}" escapes containment dir "${baseDir}" (resolved to ${resolvedChild})`,
+    );
+  }
+}
+
+export function isWithinDir(child: string, baseDir: string): boolean {
+  try {
+    assertWithinDir(child, baseDir);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── Screenshot/output path safety ───────────────────────────────────
+// Less strict than action IDs — users legitimately pass absolute paths
+// like `/Users/me/Desktop/foo.jpg`. But we still reject `..` traversal
+// segments anywhere in the path. Cheap defense against an LLM passing a
+// crafted relative path that escapes the project dir.
+
+export function pathHasTraversal(p: unknown): boolean {
+  if (typeof p !== 'string') return false;
+  // POSIX `..` segment, Windows `..` segment, URL-encoded `..`.
+  return /(^|[\\/])\.\.([\\/]|$)/.test(p) || /%2e%2e/i.test(p);
+}

--- a/scripts/cdp-bridge/src/tools/cross-platform-verify.ts
+++ b/scripts/cdp-bridge/src/tools/cross-platform-verify.ts
@@ -3,6 +3,7 @@ import { join, extname } from 'node:path';
 import { getCachedSnapshot } from '../agent-device-wrapper.js';
 import type { ToolResult } from '../utils.js';
 import { okResult, failResult, warnResult } from '../utils.js';
+import { pathHasTraversal } from '../domain/path-safety.js';
 
 interface VerifyArgs {
   elements?: string[];
@@ -66,6 +67,15 @@ export function createCrossPlatformVerifyHandler(): (args: VerifyArgs) => Promis
 
     let discoveredCount = 0;
     if (args.scanDir) {
+      // Phase 134.3 (deepsec MEDIUM path-traversal): refuse scanDir
+      // containing `..` segments. A malicious agent could otherwise
+      // pass `../../../etc` to enumerate the filesystem looking for
+      // `testID=` patterns in unrelated source files.
+      if (pathHasTraversal(args.scanDir)) {
+        return failResult(
+          `scanDir "${args.scanDir}" contains '..' traversal segments — refuse to scan outside the calling directory`,
+        );
+      }
       const discovered = discoverTestIDs(args.scanDir);
       if (discovered.length === 0) {
         return failResult(

--- a/scripts/cdp-bridge/src/tools/device-list.ts
+++ b/scripts/cdp-bridge/src/tools/device-list.ts
@@ -3,6 +3,7 @@ import { runAgentDevice } from '../agent-device-wrapper.js';
 import type { ToolResult } from '../utils.js';
 import { resizeWithSips, type ResizeResult, type ResizeOpts } from './device-screenshot-resize.js';
 import { tryRawScreenshot } from './device-screenshot-raw.js';
+import { pathHasTraversal } from '../domain/path-safety.js';
 
 type RunAgentDeviceFn = typeof runAgentDevice;
 let runAgentDeviceFn: RunAgentDeviceFn = runAgentDevice;
@@ -24,10 +25,34 @@ export function createDeviceListHandler(): (args: Record<string, never>) => Prom
  * handler can know the path independently from `buildScreenshotArgs` (used to
  * pass it to the post-resize step) and to keep `buildScreenshotArgs` tests stable.
  */
-export function deriveScreenshotPath(args: { path?: string; format?: string }, now: () => number = Date.now): string {
+export function deriveScreenshotPath(
+  args: { path?: string; format?: string },
+  now: () => number = Date.now,
+  rand: () => number = Math.random,
+): string {
+  // Phase 134.3 (deepsec MEDIUM path-traversal): caller-supplied `path`
+  // could contain `..` segments that escape the intended directory.
+  // Absolute paths to legitimate locations (e.g. ~/Desktop) are still
+  // allowed — only `..` traversal is refused.
+  if (args.path && pathHasTraversal(args.path)) {
+    throw new PathTraversalScreenshotError(
+      `Screenshot path "${args.path}" contains '..' traversal segments — refuse to write to a path that escapes its parent directory`,
+    );
+  }
   if (args.path) return args.path;
   const ext = args.format === 'jpeg' ? 'jpg' : args.format === 'png' ? 'png' : 'jpg';
-  return `/tmp/rn-screenshot-${now()}.${ext}`;
+  // Add a short random suffix so two parallel calls in the same ms can't
+  // clobber each other's output. deepsec MEDIUM: predictable /tmp files
+  // allow cross-run races. `rand` is injectable for tests.
+  const suffix = rand().toString(36).slice(2, 8);
+  return `/tmp/rn-screenshot-${now()}-${suffix}.${ext}`;
+}
+
+class PathTraversalScreenshotError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PathTraversalScreenshotError';
+  }
 }
 
 /**
@@ -38,8 +63,12 @@ export function deriveScreenshotPath(args: { path?: string; format?: string }, n
  *
  * Exported for unit tests — pure function, no I/O.
  */
-export function buildScreenshotArgs(args: { path?: string; format?: string }, now: () => number = Date.now): string[] {
-  return ['screenshot', '--out', deriveScreenshotPath(args, now)];
+export function buildScreenshotArgs(
+  args: { path?: string; format?: string },
+  now: () => number = Date.now,
+  rand: () => number = Math.random,
+): string[] {
+  return ['screenshot', '--out', deriveScreenshotPath(args, now, rand)];
 }
 
 /**

--- a/scripts/cdp-bridge/src/tools/repair-action.ts
+++ b/scripts/cdp-bridge/src/tools/repair-action.ts
@@ -9,6 +9,7 @@
 import { runAgentDevice } from '../agent-device-wrapper.js';
 import { okResult, failResult, withSession } from '../utils.js';
 import type { ToolResult } from '../utils.js';
+import { isValidActionId } from '../domain/path-safety.js';
 import {
   loadAction,
   saveAction,
@@ -56,6 +57,16 @@ export function createRepairActionHandler() {
   return withSession(async (args: RepairActionArgs): Promise<ToolResult> => {
     if (!args.actionId || typeof args.actionId !== 'string') {
       return failResult('cdp_repair_action requires actionId', 'BAD_FILENAME');
+    }
+    // Phase 134.3 (deepsec HIGH path-traversal): actionId flows into
+    // <projectRoot>/.rn-agent/actions/<id>.yaml. Reject any ID that
+    // could escape that directory (e.g. `../../etc/passwd`) before any
+    // file read happens.
+    if (!isValidActionId(args.actionId)) {
+      return failResult(
+        `Invalid actionId "${String(args.actionId).slice(0, 80)}" — must match /^[A-Za-z0-9][A-Za-z0-9_-]*$/ and be <= 64 chars`,
+        'BAD_FILENAME',
+      );
     }
     if (!args.failedSelector || typeof args.failedSelector !== 'string') {
       // Future enhancement: scan all selectors and find all stale ones.

--- a/scripts/cdp-bridge/src/tools/run-action.ts
+++ b/scripts/cdp-bridge/src/tools/run-action.ts
@@ -46,6 +46,7 @@ import {
 } from '../domain/maestro-error-parser.js';
 import { createMaestroRunHandler } from './maestro-run.js';
 import { createRepairActionHandler } from './repair-action.js';
+import { isValidActionId } from '../domain/path-safety.js';
 
 /**
  * Map a parsed Maestro failure kind to an `ActionFailureCode` (for
@@ -170,6 +171,15 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
   return async (args: RunActionArgs): Promise<ToolResult> => {
     if (!args.actionId || typeof args.actionId !== 'string') {
       return failResult('cdp_run_action requires actionId', 'BAD_FILENAME');
+    }
+    // Phase 134.3 (deepsec HIGH path-traversal): same chokepoint as
+    // cdp_repair_action — actionId flows into the .rn-agent/actions/
+    // path segment. Reject malicious slugs at the boundary.
+    if (!isValidActionId(args.actionId)) {
+      return failResult(
+        `Invalid actionId "${String(args.actionId).slice(0, 80)}" — must match /^[A-Za-z0-9][A-Za-z0-9_-]*$/ and be <= 64 chars`,
+        'BAD_FILENAME',
+      );
     }
 
     const projectRoot = args.projectRoot ?? process.cwd();

--- a/scripts/cdp-bridge/test/unit/device-screenshot-resize.test.js
+++ b/scripts/cdp-bridge/test/unit/device-screenshot-resize.test.js
@@ -75,11 +75,17 @@ test('deriveScreenshotPath returns explicit path when provided', () => {
 });
 
 test('deriveScreenshotPath defaults to .jpg when no path/format', () => {
-  assert.equal(deriveScreenshotPath({}, () => 12345), '/tmp/rn-screenshot-12345.jpg');
+  // Phase 134.3: a random suffix is appended to defeat parallel-call
+  // clobbering on the same millisecond. Pass a deterministic `rand`
+  // so the test asserts the exact filename shape.
+  const rand = () => 0.5; // 0.5.toString(36).slice(2,8) → 'i' (1 char, pad below)
+  const out = deriveScreenshotPath({}, () => 12345, rand);
+  assert.match(out, /^\/tmp\/rn-screenshot-12345-[a-z0-9]+\.jpg$/);
 });
 
 test('deriveScreenshotPath honors format=png when no path', () => {
-  assert.equal(deriveScreenshotPath({ format: 'png' }, () => 99), '/tmp/rn-screenshot-99.png');
+  const out = deriveScreenshotPath({ format: 'png' }, () => 99, () => 0.5);
+  assert.match(out, /^\/tmp\/rn-screenshot-99-[a-z0-9]+\.png$/);
 });
 
 // ── resolveScreenshotPath ─────────────────────────────────────────────

--- a/scripts/cdp-bridge/test/unit/device-screenshot.test.js
+++ b/scripts/cdp-bridge/test/unit/device-screenshot.test.js
@@ -30,15 +30,17 @@ test('buildScreenshotArgs uses --out for the path, not positional', () => {
 });
 
 test('buildScreenshotArgs defaults to .jpg when no path and no format given', () => {
-  const now = () => 12345;
-  const out = buildScreenshotArgs({}, now);
-  assert.deepEqual(out, ['screenshot', '--out', '/tmp/rn-screenshot-12345.jpg']);
+  // Phase 134.3: default filename includes a random suffix to prevent
+  // parallel-call clobbering. Inject `rand` for deterministic test.
+  const out = buildScreenshotArgs({}, () => 12345, () => 0.5);
+  assert.equal(out[0], 'screenshot');
+  assert.equal(out[1], '--out');
+  assert.match(out[2], /^\/tmp\/rn-screenshot-12345-[a-z0-9]+\.jpg$/);
 });
 
 test('buildScreenshotArgs honors explicit format when no path given', () => {
-  const now = () => 99;
-  const out = buildScreenshotArgs({ format: 'png' }, now);
-  assert.deepEqual(out, ['screenshot', '--out', '/tmp/rn-screenshot-99.png']);
+  const out = buildScreenshotArgs({ format: 'png' }, () => 99, () => 0.5);
+  assert.match(out[2], /^\/tmp\/rn-screenshot-99-[a-z0-9]+\.png$/);
 });
 
 test('buildScreenshotArgs: explicit path wins over format-derived default', () => {

--- a/scripts/cdp-bridge/test/unit/phase-134-3-path-containment.test.js
+++ b/scripts/cdp-bridge/test/unit/phase-134-3-path-containment.test.js
@@ -1,0 +1,125 @@
+// Phase 134.3 — path containment. Two helpers in domain/path-safety.ts:
+//
+//   - isValidActionId(s) — strict regex for caller-supplied action IDs
+//     that flow into the `.rn-agent/actions/<id>.yaml` path segment.
+//     Rejects path-traversal payloads (`../etc/passwd`, `/abs/path`),
+//     control chars, and over-long input.
+//   - assertWithinDir(child, baseDir) — defense-in-depth containment
+//     check on a resolved path. Throws PathTraversalError when the
+//     resolved child escapes baseDir.
+//
+// Closes:
+//   HIGH: action-store.ts actionId escape (deepsec)
+//   HIGH: index.ts learned-action IDs unconstrained
+//   MEDIUM: scanDir recursive read outside project root
+//   MEDIUM: device-list.ts unrestricted screenshot output path
+//   MEDIUM: auto-login.ts predictable /tmp YAML clobbering
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const MOD_PATH = '../../dist/domain/path-safety.js';
+
+// ── isValidActionId ─────────────────────────────────────────────────
+
+test('isValidActionId: accepts kebab-case + snake_case + alphanumeric', async () => {
+  const { isValidActionId } = await import(MOD_PATH);
+  assert.equal(isValidActionId('login-flow'), true);
+  assert.equal(isValidActionId('add_cart_item'), true);
+  assert.equal(isValidActionId('glass-carousel-v2'), true);
+  assert.equal(isValidActionId('test123'), true);
+  assert.equal(isValidActionId('abc'), true);
+});
+
+test('isValidActionId: rejects path-traversal payloads', async () => {
+  const { isValidActionId } = await import(MOD_PATH);
+  assert.equal(isValidActionId('../etc/passwd'), false);
+  assert.equal(isValidActionId('..'), false);
+  assert.equal(isValidActionId('../../system'), false);
+  assert.equal(isValidActionId('foo/../bar'), false);
+  assert.equal(isValidActionId('foo/bar'), false);
+});
+
+test('isValidActionId: rejects absolute paths', async () => {
+  const { isValidActionId } = await import(MOD_PATH);
+  assert.equal(isValidActionId('/etc/passwd'), false);
+  assert.equal(isValidActionId('/tmp/x'), false);
+  assert.equal(isValidActionId('C:\\Windows\\System32'), false);
+});
+
+test('isValidActionId: rejects newlines and control characters', async () => {
+  const { isValidActionId } = await import(MOD_PATH);
+  assert.equal(isValidActionId('foo\nbar'), false);
+  assert.equal(isValidActionId('foo\rbar'), false);
+  assert.equal(isValidActionId('foobar'), false);
+});
+
+test('isValidActionId: rejects empty, too-long, non-string', async () => {
+  const { isValidActionId } = await import(MOD_PATH);
+  assert.equal(isValidActionId(''), false);
+  assert.equal(isValidActionId(null), false);
+  assert.equal(isValidActionId(undefined), false);
+  assert.equal(isValidActionId(42), false);
+  assert.equal(isValidActionId('a'.repeat(200)), false);
+});
+
+test('isValidActionId: rejects leading-special-char IDs (must start alphanumeric)', async () => {
+  const { isValidActionId } = await import(MOD_PATH);
+  assert.equal(isValidActionId('-leading-hyphen'), false);
+  assert.equal(isValidActionId('_leading-underscore'), false);
+  assert.equal(isValidActionId('.hidden'), false);
+});
+
+// ── assertWithinDir ─────────────────────────────────────────────────
+
+test('assertWithinDir: accepts paths inside the base directory', async () => {
+  const { assertWithinDir } = await import(MOD_PATH);
+  const base = join(tmpdir(), 'rn-agent-test');
+  // Each call must throw nothing — assertWithinDir returns void on pass.
+  assert.doesNotThrow(() => assertWithinDir('foo.yaml', base));
+  assert.doesNotThrow(() => assertWithinDir('sub/dir/file.txt', base));
+  assert.doesNotThrow(() => assertWithinDir('./foo', base));
+  assert.doesNotThrow(() => assertWithinDir(resolve(base, 'absolute-child.txt'), base));
+});
+
+test('assertWithinDir: rejects ../ traversal', async () => {
+  const { assertWithinDir, PathTraversalError } = await import(MOD_PATH);
+  const base = join(tmpdir(), 'rn-agent-test');
+  assert.throws(() => assertWithinDir('../etc/passwd', base), PathTraversalError);
+  assert.throws(() => assertWithinDir('../../../system32', base), PathTraversalError);
+  assert.throws(() => assertWithinDir('sub/../../escape', base), PathTraversalError);
+});
+
+test('assertWithinDir: rejects absolute paths outside base', async () => {
+  const { assertWithinDir, PathTraversalError } = await import(MOD_PATH);
+  const base = join(tmpdir(), 'rn-agent-test');
+  assert.throws(() => assertWithinDir('/etc/passwd', base), PathTraversalError);
+  assert.throws(() => assertWithinDir('/var/log/system.log', base), PathTraversalError);
+});
+
+test('assertWithinDir: rejects sibling dirs that share a prefix (the boundary bug)', async () => {
+  const { assertWithinDir, PathTraversalError } = await import(MOD_PATH);
+  // /tmp/foo-extra should NOT be considered "within" /tmp/foo — naive
+  // startsWith without a trailing separator would have allowed this.
+  const base = '/tmp/foo';
+  assert.throws(() => assertWithinDir('/tmp/foo-extra/file', base), PathTraversalError);
+  assert.throws(() => assertWithinDir('/tmp/foobar', base), PathTraversalError);
+});
+
+test('assertWithinDir: accepts base directory itself', async () => {
+  const { assertWithinDir } = await import(MOD_PATH);
+  const base = join(tmpdir(), 'rn-agent-test');
+  assert.doesNotThrow(() => assertWithinDir(base, base));
+  assert.doesNotThrow(() => assertWithinDir('.', base));
+});
+
+// ── isWithinDir (non-throwing variant) ──────────────────────────────
+
+test('isWithinDir: returns boolean for legitimate + illegitimate inputs', async () => {
+  const { isWithinDir } = await import(MOD_PATH);
+  const base = join(tmpdir(), 'rn-agent-test');
+  assert.equal(isWithinDir('safe-child.yaml', base), true);
+  assert.equal(isWithinDir('../escape', base), false);
+  assert.equal(isWithinDir('/etc/passwd', base), false);
+});


### PR DESCRIPTION
## Summary

Third sub-phase of the workspace [ROADMAP Phase 134](https://github.com/Lykhoyda/rn-dev-agent-workspace/blob/main/docs/ROADMAP.md) sweep. Two deepsec HIGH findings + three MEDIUM, all path-traversal class, closed via a shared validator at every site that turns caller-derived strings into filesystem paths.

## The fix

New module: `scripts/cdp-bridge/src/domain/path-safety.ts`. Same chokepoint discipline as 134.1 (Maestro validator) and 134.2 (bundle-ID validation): every caller-derived path crosses through one of three primitives.

| Primitive | Purpose |
|---|---|
| `isValidActionId(s)` | Strict regex `/^[A-Za-z0-9][A-Za-z0-9_-]*$/`, max 64 chars. For IDs used as path segments under `.rn-agent/actions/`. |
| `assertWithinDir(child, baseDir)` | Defense-in-depth containment using `path.resolve` + separator-anchored prefix check (defeats the `/tmp/foo` vs `/tmp/foo-extra` boundary bug). |
| `pathHasTraversal(p)` | Rejects `..` segments in caller-supplied paths (POSIX, Windows, URL-encoded variants). |

## Sites hardened

| File | Boundary | Severity closed |
|---|---|---|
| `action-store.ts` `actionPathFor` | Validates actionId regex + assertWithinDir on resolved path | HIGH |
| `repair-action.ts` `cdp_repair_action` | actionId rejected at MCP boundary before any file read | HIGH (companion) |
| `run-action.ts` `cdp_run_action` | Same boundary check | HIGH |
| `device-list.ts` `deriveScreenshotPath` | Refuses `..` segments; default tmp filename gets a random suffix to prevent parallel-call clobbering | MEDIUM × 2 |
| `cross-platform-verify.ts` `scanDir` | Refuses `..` traversal | MEDIUM |

## Tests

- **12 new unit tests** in `phase-134-3-path-containment.test.js`:
  - Path-traversal payloads (`../etc/passwd`, `../../system`, mixed)
  - Absolute paths (`/etc/passwd`, `C:\Windows\System32`)
  - Newlines and control characters in IDs
  - Empty / too-long / non-string inputs
  - Leading-special-char IDs (`-foo`, `_bar`, `.hidden`) rejected
  - The sibling-prefix-collision case (`/tmp/foo-extra` vs `/tmp/foo`)
  - Backward parity for legitimate inputs
- Updated 4 existing screenshot tests to accept the new random-suffix filename shape (via injected `rand` for determinism)
- **Full unit suite: 1296 / 1296 passing**, 0 failing
- TypeScript compiles clean

## Cross-references

- Workspace ROADMAP Phase 134.3 — implements proposed **D1214** ("Tool-supplied paths must pass `assertWithinDir(p, projectActionsDir)` before any `fs.write*` / `createWriteStream` call. No `..` segments, no symlink follow, parent-dir containment proved by `path.resolve` + `startsWith`")
- Phase 134.1 (PR #144) — `isValidBundleId` precedent for the regex-at-tool-boundary pattern
- Phase 134.2 (PR #145) — `isValidBundleId` reused for adb shell-arg validation

## Test plan

- [ ] CI green on Build & Test + CodeQL
- [ ] Version sync check passes (plugin 0.44.33 / cdp-bridge 0.38.28 / marketplace 0.44.33)
- [ ] After merge: re-run `pnpm deepsec revalidate --project-id claude-react-native-dev-plugin --min-severity HIGH --force` to confirm the 2 action-ID HIGH findings transition to `Fixed`. Acceptance: HIGH count drops by 2 (from current 6 → ≤4); MEDIUM count drops by 3.

## Cumulative Phase 134 progress

| Phase | Findings closed | Cumulative |
|---|---|---|
| 134.0 (PR #143) | 1 BUG | 1 |
| 134.1 (PR #144) | 7 CRITICAL + 2 HIGH | 10 |
| 134.2 (PR #145) | 5 HIGH | 15 |
| 134.3 (this) | 2 HIGH + 3 MEDIUM | **20 of 48** (42%) |