### PR TITLE
fix: CDP multiplexer trust boundary — closes 1 HIGH (Phase 134.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.33",
+      "version": "0.44.34",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.33",
+  "version": "0.44.34",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.44.34] — 2026-05-12
+
+### Fixed (Phase 134.4 — CDP multiplexer trust boundary, closes 1 HIGH)
+
+- **CDP multiplexer now requires a per-instance capability token** in
+  the WebSocket upgrade path. Previously any process that could
+  discover the ephemeral loopback port could connect and send
+  arbitrary CDP commands (`Runtime.evaluate`, `Page.navigate`, etc.)
+  to the running Hermes runtime, **bypassing Claude Code's
+  tool-permission prompts entirely**. This included a browser tab
+  scanning local ports, a sibling shell, or any malicious process
+  with loopback access.
+- The token is 32 bytes of `crypto.randomBytes` (43 char base64url),
+  unique per multiplexer instance, included in the WebSocket URL
+  path as `ws://127.0.0.1:<port>/<token>`. The `verifyClient`
+  handler uses `timingSafeEqual` on equal-length buffers to compare
+  — no timing side channel leaks the token.
+- The exposed `proxyUrl` (from `client.startProxy()`) and the
+  DevTools URL (from `cdp_open_devtools`) automatically include the
+  token. Without the token in the path, the multiplexer returns
+  `401 Unauthorized` at upgrade time.
+- **Token never appears in logs** — log lines reference
+  `ws://127.0.0.1:<port>/<token>` literally, not the actual value.
+
+### Internal
+
+- New exports from `cdp/multiplexer.ts`: `generateCapabilityToken()`
+  and `verifyConsumerPath(reqUrl, expectedToken)`. Both pure
+  functions for unit testing. `CDPMultiplexer.token` getter for
+  callers building DevTools URLs.
+- 9 new unit tests cover the token verification truth table:
+  legitimate token accepted; wrong token / missing token / empty
+  token / length mismatch / query-style appendage / non-string
+  inputs all rejected. Plus uniqueness across instances.
+- Implements the deepsec recommendation: per-proxy high-entropy
+  capability token required during WebSocket upgrade, rejection
+  before consumer registration.
+
 ## [0.44.33] — 2026-05-12
 
 ### Fixed (Phase 134.3 — path containment, closes 2 HIGH + 3 MEDIUM)

--- a/scripts/cdp-bridge/dist/cdp-client.js
+++ b/scripts/cdp-bridge/dist/cdp-client.js
@@ -197,8 +197,13 @@ export class CDPClient {
         const multiplexer = new CDPMultiplexer({ hermesUrl, ...opts });
         const port = await multiplexer.start();
         this._multiplexer = multiplexer;
-        this._proxyUrl = `ws://127.0.0.1:${port}`;
-        logger.info('CDP', `Proxy started on ${this._proxyUrl}, soft-reconnecting current session`);
+        // Phase 134.4: include the per-instance capability token in the
+        // exposed URL. DevTools (or any other consumer the user authorizes)
+        // connects to `ws://127.0.0.1:<port>/<token>`. Without the token
+        // in the path, the multiplexer rejects the WebSocket upgrade.
+        // The token itself never appears in logs.
+        this._proxyUrl = `ws://127.0.0.1:${port}/${multiplexer.token}`;
+        logger.info('CDP', `Proxy started on ws://127.0.0.1:${port}/<token>, soft-reconnecting current session`);
         try {
             // B132: call `_softReconnectDirect` instead of `this.softReconnect()`. The
             // wrapper would observe _proxyUrl just set above and try to suspend the

--- a/scripts/cdp-bridge/dist/cdp/multiplexer.js
+++ b/scripts/cdp-bridge/dist/cdp/multiplexer.js
@@ -1,6 +1,40 @@
 import { createServer } from 'node:http';
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+import { Buffer } from 'node:buffer';
 import WebSocket, { WebSocketServer } from 'ws';
 import { logger } from '../logger.js';
+/**
+ * Phase 134.4 (deepsec HIGH): generate a per-multiplexer capability
+ * token that consumers must include in the WebSocket upgrade path.
+ * 32 bytes of crypto.randomBytes → 43 char base64url string. Never
+ * logged, never exposed in error messages.
+ */
+export function generateCapabilityToken() {
+    return randomBytes(32).toString('base64url');
+}
+/**
+ * Pure verification helper. Returns true iff the request path is
+ * exactly `/<expectedToken>`. Uses timingSafeEqual on equal-length
+ * buffers to avoid leaking the token via response-timing side
+ * channels. Fails closed on missing/empty/non-string inputs and on
+ * empty expectedToken (never accept an unauthenticated multiplexer).
+ */
+export function verifyConsumerPath(reqUrl, expectedToken) {
+    if (typeof expectedToken !== 'string' || expectedToken.length === 0)
+        return false;
+    if (typeof reqUrl !== 'string' || reqUrl.length === 0)
+        return false;
+    if (!reqUrl.startsWith('/'))
+        return false;
+    const submitted = reqUrl.slice(1);
+    if (submitted.length !== expectedToken.length)
+        return false;
+    const a = Buffer.from(submitted);
+    const b = Buffer.from(expectedToken);
+    if (a.length !== b.length)
+        return false;
+    return timingSafeEqual(a, b);
+}
 const HERMES_BUFFER_MAX_DEFAULT = 1000;
 const ROUTING_TIMEOUT_MS_DEFAULT = 60_000;
 export class CDPMultiplexer {
@@ -15,6 +49,14 @@ export class CDPMultiplexer {
     hermesBuffer = [];
     state = 'stopped';
     boundPort = null;
+    /**
+     * Phase 134.4: per-instance capability token. Required in the
+     * WebSocket upgrade path. Never logged. Exposed via `token` getter
+     * so the caller can include it in the URL it hands to DevTools.
+     */
+    capabilityToken = generateCapabilityToken();
+    /** Phase 134.4: the capability token for this multiplexer instance. */
+    get token() { return this.capabilityToken; }
     routingSweeper = null;
     constructor(opts) {
         this.opts = {
@@ -74,7 +116,24 @@ export class CDPMultiplexer {
     startConsumerServer() {
         return new Promise((resolve, reject) => {
             this.httpServer = createServer();
-            this.wss = new WebSocketServer({ server: this.httpServer });
+            this.wss = new WebSocketServer({
+                server: this.httpServer,
+                // Phase 134.4 (deepsec HIGH): reject any upgrade that doesn't
+                // include the capability token in the path. Any sibling
+                // process that learned the loopback port (or a browser tab
+                // scanning local ports) is refused before reaching
+                // onConsumerConnect / onConsumerMessage. Token comparison
+                // uses timingSafeEqual to avoid leaking the secret via
+                // timing side channels.
+                verifyClient: (info, callback) => {
+                    if (verifyConsumerPath(info.req.url, this.capabilityToken)) {
+                        callback(true);
+                        return;
+                    }
+                    logger.warn(this.opts.logTag, 'rejected upgrade: missing or invalid capability token');
+                    callback(false, 401, 'Unauthorized');
+                },
+            });
             this.wss.on('connection', (ws) => this.onConsumerConnect(ws));
             this.wss.on('error', (err) => {
                 logger.warn(this.opts.logTag, `WebSocketServer error: ${err instanceof Error ? err.message : err}`);

--- a/scripts/cdp-bridge/dist/tools/open-devtools.js
+++ b/scripts/cdp-bridge/dist/tools/open-devtools.js
@@ -70,9 +70,17 @@ export function createOpenDevToolsHandler(getClient) {
             // internal state drift — fail loudly rather than return a half-working URL.
             return failResult('cdp_open_devtools: multiplexer started but has no bound port');
         }
+        const proxyToken = client.proxyMultiplexer?.token ?? null;
+        if (proxyToken === null) {
+            return failResult('cdp_open_devtools: multiplexer started but capability token is missing');
+        }
         // DevTools frontend still lives on Metro (it's static HTML + JS served over HTTP).
         // Only the WS destination changes: DevTools → proxy (loopback); proxy → Hermes.
-        const devtoolsUrl = `http://127.0.0.1:${metroPort}/debugger-frontend/rn_fusebox.html?ws=127.0.0.1:${proxyPort}`;
+        // Phase 134.4: the proxy now requires a per-instance capability token in
+        // the WebSocket path. DevTools includes it via the `ws=` query value;
+        // any browser tab that learns the loopback port without the token gets
+        // a 401 upgrade rejection from verifyClient.
+        const devtoolsUrl = `http://127.0.0.1:${metroPort}/debugger-frontend/rn_fusebox.html?ws=127.0.0.1:${proxyPort}/${proxyToken}`;
         return okResult({
             devtoolsUrl,
             inspectorWsUrl: proxyUrl,

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.28",
+  "version": "0.38.29",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/cdp-client.ts
+++ b/scripts/cdp-bridge/src/cdp-client.ts
@@ -237,8 +237,13 @@ export class CDPClient {
     const multiplexer = new CDPMultiplexer({ hermesUrl, ...opts });
     const port = await multiplexer.start();
     this._multiplexer = multiplexer;
-    this._proxyUrl = `ws://127.0.0.1:${port}`;
-    logger.info('CDP', `Proxy started on ${this._proxyUrl}, soft-reconnecting current session`);
+    // Phase 134.4: include the per-instance capability token in the
+    // exposed URL. DevTools (or any other consumer the user authorizes)
+    // connects to `ws://127.0.0.1:<port>/<token>`. Without the token
+    // in the path, the multiplexer rejects the WebSocket upgrade.
+    // The token itself never appears in logs.
+    this._proxyUrl = `ws://127.0.0.1:${port}/${multiplexer.token}`;
+    logger.info('CDP', `Proxy started on ws://127.0.0.1:${port}/<token>, soft-reconnecting current session`);
     try {
       // B132: call `_softReconnectDirect` instead of `this.softReconnect()`. The
       // wrapper would observe _proxyUrl just set above and try to suspend the

--- a/scripts/cdp-bridge/src/cdp/multiplexer.ts
+++ b/scripts/cdp-bridge/src/cdp/multiplexer.ts
@@ -1,8 +1,39 @@
 import { createServer, type Server } from 'node:http';
 import { type AddressInfo } from 'node:net';
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+import { Buffer } from 'node:buffer';
 import WebSocket, { WebSocketServer } from 'ws';
 
 import { logger } from '../logger.js';
+
+/**
+ * Phase 134.4 (deepsec HIGH): generate a per-multiplexer capability
+ * token that consumers must include in the WebSocket upgrade path.
+ * 32 bytes of crypto.randomBytes → 43 char base64url string. Never
+ * logged, never exposed in error messages.
+ */
+export function generateCapabilityToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+/**
+ * Pure verification helper. Returns true iff the request path is
+ * exactly `/<expectedToken>`. Uses timingSafeEqual on equal-length
+ * buffers to avoid leaking the token via response-timing side
+ * channels. Fails closed on missing/empty/non-string inputs and on
+ * empty expectedToken (never accept an unauthenticated multiplexer).
+ */
+export function verifyConsumerPath(reqUrl: unknown, expectedToken: string): boolean {
+  if (typeof expectedToken !== 'string' || expectedToken.length === 0) return false;
+  if (typeof reqUrl !== 'string' || reqUrl.length === 0) return false;
+  if (!reqUrl.startsWith('/')) return false;
+  const submitted = reqUrl.slice(1);
+  if (submitted.length !== expectedToken.length) return false;
+  const a = Buffer.from(submitted);
+  const b = Buffer.from(expectedToken);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
 
 /**
  * CDP Multiplexer proxy (M1 / Phase 90 Tier 1).
@@ -53,6 +84,15 @@ export class CDPMultiplexer {
   private hermesBuffer: string[] = [];
   private state: 'stopped' | 'starting' | 'running' | 'stopping' = 'stopped';
   private boundPort: number | null = null;
+  /**
+   * Phase 134.4: per-instance capability token. Required in the
+   * WebSocket upgrade path. Never logged. Exposed via `token` getter
+   * so the caller can include it in the URL it hands to DevTools.
+   */
+  private readonly capabilityToken: string = generateCapabilityToken();
+
+  /** Phase 134.4: the capability token for this multiplexer instance. */
+  get token(): string { return this.capabilityToken; }
   private routingSweeper: NodeJS.Timeout | null = null;
 
   constructor(opts: MultiplexerOptions) {
@@ -120,7 +160,24 @@ export class CDPMultiplexer {
   private startConsumerServer(): Promise<number> {
     return new Promise((resolve, reject) => {
       this.httpServer = createServer();
-      this.wss = new WebSocketServer({ server: this.httpServer });
+      this.wss = new WebSocketServer({
+        server: this.httpServer,
+        // Phase 134.4 (deepsec HIGH): reject any upgrade that doesn't
+        // include the capability token in the path. Any sibling
+        // process that learned the loopback port (or a browser tab
+        // scanning local ports) is refused before reaching
+        // onConsumerConnect / onConsumerMessage. Token comparison
+        // uses timingSafeEqual to avoid leaking the secret via
+        // timing side channels.
+        verifyClient: (info, callback) => {
+          if (verifyConsumerPath(info.req.url, this.capabilityToken)) {
+            callback(true);
+            return;
+          }
+          logger.warn(this.opts.logTag, 'rejected upgrade: missing or invalid capability token');
+          callback(false, 401, 'Unauthorized');
+        },
+      });
 
       this.wss.on('connection', (ws) => this.onConsumerConnect(ws));
       this.wss.on('error', (err) => {

--- a/scripts/cdp-bridge/src/tools/open-devtools.ts
+++ b/scripts/cdp-bridge/src/tools/open-devtools.ts
@@ -110,9 +110,17 @@ export function createOpenDevToolsHandler(getClient: () => CDPClient) {
       // internal state drift — fail loudly rather than return a half-working URL.
       return failResult('cdp_open_devtools: multiplexer started but has no bound port');
     }
+    const proxyToken = client.proxyMultiplexer?.token ?? null;
+    if (proxyToken === null) {
+      return failResult('cdp_open_devtools: multiplexer started but capability token is missing');
+    }
     // DevTools frontend still lives on Metro (it's static HTML + JS served over HTTP).
     // Only the WS destination changes: DevTools → proxy (loopback); proxy → Hermes.
-    const devtoolsUrl = `http://127.0.0.1:${metroPort}/debugger-frontend/rn_fusebox.html?ws=127.0.0.1:${proxyPort}`;
+    // Phase 134.4: the proxy now requires a per-instance capability token in
+    // the WebSocket path. DevTools includes it via the `ws=` query value;
+    // any browser tab that learns the loopback port without the token gets
+    // a 401 upgrade rejection from verifyClient.
+    const devtoolsUrl = `http://127.0.0.1:${metroPort}/debugger-frontend/rn_fusebox.html?ws=127.0.0.1:${proxyPort}/${proxyToken}`;
 
     return okResult({
       devtoolsUrl,

--- a/scripts/cdp-bridge/test/helpers/mock-cdp-client.js
+++ b/scripts/cdp-bridge/test/helpers/mock-cdp-client.js
@@ -107,10 +107,13 @@ export function createMockClient(overrides = {}) {
 
     async startProxy() {
       // Mock mirrors real behavior: idempotent, sets URL + multiplexer-like stub,
-      // returns URL. Tests that want failure override this.
+      // returns URL. Tests that want failure override this. Phase 134.4: the
+      // mock multiplexer now exposes a `token` field so open-devtools.ts can
+      // build the token-bearing DevTools URL.
       if (client._proxyUrl) return client._proxyUrl;
-      client._proxyUrl = 'ws://127.0.0.1:45678';
-      client._proxyMultiplexer = { port: 45678, isRunning: true, consumerCount: 0 };
+      const mockToken = 'mock-test-token-AbCdEf1234567890_dashOk';
+      client._proxyUrl = `ws://127.0.0.1:45678/${mockToken}`;
+      client._proxyMultiplexer = { port: 45678, token: mockToken, isRunning: true, consumerCount: 0 };
       return client._proxyUrl;
     },
 

--- a/scripts/cdp-bridge/test/unit/cdp-client-proxy.test.js
+++ b/scripts/cdp-bridge/test/unit/cdp-client-proxy.test.js
@@ -139,7 +139,7 @@ test('CDPClient.startProxy rolls back multiplexer when softReconnect throws (D66
   let reconnects = 0;
   client._softReconnectDirect = async () => { reconnects++; };
   const url = await client.startProxy();
-  assert.match(url, /^ws:\/\/127\.0\.0\.1:\d+$/, 'fresh startProxy succeeds after rollback');
+  assert.match(url, /^ws:\/\/127\.0\.0\.1:\d+\/[A-Za-z0-9_-]+$/, 'fresh startProxy succeeds after rollback');
   assert.equal(reconnects, 1);
 
   await client.disconnect();
@@ -165,7 +165,7 @@ test('CDPClient.startProxy is concurrency-safe — parallel callers share one mu
 
   assert.equal(u1, u2, 'first and second callers get identical URL');
   assert.equal(u2, u3, 'third caller also joins the same in-flight');
-  assert.match(u1, /^ws:\/\/127\.0\.0\.1:\d+$/);
+  assert.match(u1, /^ws:\/\/127\.0\.0\.1:\d+\/[A-Za-z0-9_-]+$/);
   assert.ok(client.proxyMultiplexer, 'exactly one multiplexer stored');
   assert.equal(client.proxyUrl, u1);
 
@@ -193,7 +193,7 @@ test('CDPClient.startProxy: after failed start, in-flight guard clears so next c
 
   // Second call must create a NEW multiplexer (previous one was torn down).
   const url = await client.startProxy();
-  assert.match(url, /^ws:\/\/127\.0\.0\.1:\d+$/);
+  assert.match(url, /^ws:\/\/127\.0\.0\.1:\d+\/[A-Za-z0-9_-]+$/);
   assert.equal(attempts, 2, 'second attempt ran (in-flight cache did not poison retry)');
 
   await client.disconnect();

--- a/scripts/cdp-bridge/test/unit/multiplexer.test.js
+++ b/scripts/cdp-bridge/test/unit/multiplexer.test.js
@@ -59,9 +59,13 @@ test('supportsNativeMultiDebugger: unknown shapes fall back to false (conservati
 // ── CDPMultiplexer: full integration tests with real WS ──
 // (makeMockHermes lives in ../helpers/mock-hermes.js — shared across proxy tests.)
 
-function connectConsumer(port) {
+function connectConsumer(port, token) {
+  // Phase 134.4: WebSocket upgrade requires the per-instance capability
+  // token in the URL path. Callers pass `mux.token` from the
+  // CDPMultiplexer instance under test.
   return new Promise((resolve, reject) => {
-    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    const url = token ? `ws://127.0.0.1:${port}/${token}` : `ws://127.0.0.1:${port}`;
+    const ws = new WebSocket(url);
     ws.once('open', () => resolve(ws));
     ws.once('error', reject);
   });
@@ -100,7 +104,7 @@ test('CDPMultiplexer: forwards a request and routes the response back with origi
   const proxy = new CDPMultiplexer({ hermesUrl: hermes.url });
   try {
     const port = await proxy.start();
-    const consumer = await connectConsumer(port);
+    const consumer = await connectConsumer(port, proxy.token);
 
     const waitForResponse = waitForMessage(consumer, (m) => m.id === 42);
     consumer.send(JSON.stringify({ id: 42, method: 'Runtime.evaluate', params: { expression: '1+1' } }));
@@ -127,8 +131,8 @@ test('CDPMultiplexer: two consumers with same id do not collide — responses ro
   const proxy = new CDPMultiplexer({ hermesUrl: hermes.url });
   try {
     const port = await proxy.start();
-    const c1 = await connectConsumer(port);
-    const c2 = await connectConsumer(port);
+    const c1 = await connectConsumer(port, proxy.token);
+    const c2 = await connectConsumer(port, proxy.token);
 
     const w1 = waitForMessage(c1, (m) => m.id === 7);
     const w2 = waitForMessage(c2, (m) => m.id === 7);
@@ -156,8 +160,8 @@ test('CDPMultiplexer: events (no id) broadcast to all consumers', async () => {
   const proxy = new CDPMultiplexer({ hermesUrl: hermes.url });
   try {
     const port = await proxy.start();
-    const c1 = await connectConsumer(port);
-    const c2 = await connectConsumer(port);
+    const c1 = await connectConsumer(port, proxy.token);
+    const c2 = await connectConsumer(port, proxy.token);
 
     // Give the proxy a beat to register both consumers
     await new Promise((r) => setTimeout(r, 50));
@@ -187,11 +191,11 @@ test('CDPMultiplexer: consumer count increments on connect, decrements on discon
     const port = await proxy.start();
     assert.equal(proxy.consumerCount, 0);
 
-    const c1 = await connectConsumer(port);
+    const c1 = await connectConsumer(port, proxy.token);
     await new Promise((r) => setTimeout(r, 30));
     assert.equal(proxy.consumerCount, 1);
 
-    const c2 = await connectConsumer(port);
+    const c2 = await connectConsumer(port, proxy.token);
     await new Promise((r) => setTimeout(r, 30));
     assert.equal(proxy.consumerCount, 2);
 
@@ -243,7 +247,7 @@ test('CDPMultiplexer: drops messages with non-numeric ids without crashing', asy
   const proxy = new CDPMultiplexer({ hermesUrl: hermes.url });
   try {
     const port = await proxy.start();
-    const consumer = await connectConsumer(port);
+    const consumer = await connectConsumer(port, proxy.token);
 
     consumer.send('this is not json');
     consumer.send(JSON.stringify({ method: 'Runtime.somePing' })); // no id — forwarded as-is
@@ -298,8 +302,10 @@ test('cdp_open_devtools: mode=proxy-active when RN < 0.85 (M1b — proxy auto-st
   assert.equal(data.mode, 'proxy-active', 'proxy started automatically on RN < 0.85');
   assert.equal(data.supportsMultipleDebuggers, false);
   assert.ok(data.devtoolsUrl, 'devtoolsUrl populated (points at proxy port)');
-  assert.match(data.devtoolsUrl, /ws=127\.0\.0\.1:\d+$/, 'devtoolsUrl ws= targets the proxy (no /inspector path)');
-  assert.match(data.inspectorWsUrl, /^ws:\/\/127\.0\.0\.1:\d+$/, 'inspectorWsUrl is the proxy URL');
+  // Phase 134.4: devtoolsUrl now includes the capability token in the
+  // WebSocket path. `?ws=127.0.0.1:PORT/TOKEN` form.
+  assert.match(data.devtoolsUrl, /ws=127\.0\.0\.1:\d+\/[A-Za-z0-9_-]+$/, 'devtoolsUrl ws= targets the proxy with token');
+  assert.match(data.inspectorWsUrl, /^ws:\/\/127\.0\.0\.1:\d+\/[A-Za-z0-9_-]+$/, 'inspectorWsUrl includes the capability token');
   assert.match(data.hermesWsUrl, /\/inspector\/debug\?device=/, 'hermesWsUrl is still the direct Hermes URL');
   assert.equal(typeof data.proxyPort, 'number', 'proxyPort is a bound port');
   assert.match(data.guidance, /proxy has been started|coexist/i, 'guidance reflects active-proxy state');
@@ -412,7 +418,7 @@ test('CDPMultiplexer: M1b prereq — hermesBuffer drops oldest when cap exceeded
     }
     assert.ok(port, 'consumer server should bind before Hermes upgrade delay expires');
 
-    const consumer = await connectConsumer(port);
+    const consumer = await connectConsumer(port, proxy.token);
 
     // Flood 5 messages while hermesWs is still CONNECTING.
     for (let i = 1; i <= 5; i++) {
@@ -445,7 +451,7 @@ test('CDPMultiplexer: M1b prereq — routing sweeper evicts entries past routing
   const proxy = new CDPMultiplexer({ hermesUrl: hermes.url, routingTimeoutMs: 150 });
   try {
     const port = await proxy.start();
-    const consumer = await connectConsumer(port);
+    const consumer = await connectConsumer(port, proxy.token);
     await new Promise((r) => setTimeout(r, 30));
 
     // Send 3 requests; Hermes swallows, so all 3 routes persist.
@@ -485,8 +491,8 @@ test('CDPMultiplexer: consumer disconnect clears its pending routes (no response
   const proxy = new CDPMultiplexer({ hermesUrl: hermes.url });
   try {
     const port = await proxy.start();
-    const c1 = await connectConsumer(port);
-    const c2 = await connectConsumer(port);
+    const c1 = await connectConsumer(port, proxy.token);
+    const c2 = await connectConsumer(port, proxy.token);
     await new Promise((r) => setTimeout(r, 30));
 
     // c1 sends a request, then immediately disconnects.

--- a/scripts/cdp-bridge/test/unit/phase-134-4-multiplexer-auth.test.js
+++ b/scripts/cdp-bridge/test/unit/phase-134-4-multiplexer-auth.test.js
@@ -1,0 +1,90 @@
+// Phase 134.4 — CDP multiplexer trust boundary. Tests the
+// capability-token check that gates WebSocket upgrades against the
+// CDP multiplexer.
+//
+// The deepsec HIGH finding: the multiplexer accepted any localhost
+// connection and forwarded `Runtime.evaluate` (and every other CDP
+// command) straight to the Hermes runtime, bypassing Claude Code's
+// tool-permission prompts entirely. Any process that could discover
+// the ephemeral port could read AsyncStorage, navigate, mutate
+// store state, etc.
+//
+// The fix: per-multiplexer high-entropy token in the WebSocket URL
+// path. verifyConsumerPath enforces the token at upgrade time using
+// timingSafeEqual to avoid leaking the token via timing.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const MOD_PATH = '../../dist/cdp/multiplexer.js';
+
+test('verifyConsumerPath: accepts exact /<token> path', async () => {
+  const { verifyConsumerPath } = await import(MOD_PATH);
+  assert.equal(verifyConsumerPath('/AbCdEf123456_token_value', 'AbCdEf123456_token_value'), true);
+});
+
+test('verifyConsumerPath: rejects wrong token', async () => {
+  const { verifyConsumerPath } = await import(MOD_PATH);
+  assert.equal(verifyConsumerPath('/wrong-token', 'right-token'), false);
+});
+
+test('verifyConsumerPath: rejects missing token (root path)', async () => {
+  const { verifyConsumerPath } = await import(MOD_PATH);
+  assert.equal(verifyConsumerPath('/', 'right-token'), false);
+  assert.equal(verifyConsumerPath('', 'right-token'), false);
+});
+
+test('verifyConsumerPath: rejects length-mismatch tokens (prevents prefix-extension attacks)', async () => {
+  const { verifyConsumerPath } = await import(MOD_PATH);
+  // The legitimate token is "right-token" (11 chars). An attacker
+  // appending extra characters must NOT pass — same defense as the
+  // /tmp/foo vs /tmp/foo-extra prefix bug from 134.3.
+  assert.equal(verifyConsumerPath('/right-token-extra', 'right-token'), false);
+  assert.equal(verifyConsumerPath('/right', 'right-token'), false);
+});
+
+test('verifyConsumerPath: rejects query-style appendage', async () => {
+  const { verifyConsumerPath } = await import(MOD_PATH);
+  // The token is path-based; a query-style appendage means the request
+  // didn't structure the path correctly. Reject defensively.
+  assert.equal(verifyConsumerPath('/right-token?extra=foo', 'right-token'), false);
+});
+
+test('verifyConsumerPath: rejects undefined / non-string inputs', async () => {
+  const { verifyConsumerPath } = await import(MOD_PATH);
+  assert.equal(verifyConsumerPath(undefined, 'right-token'), false);
+  assert.equal(verifyConsumerPath(null, 'right-token'), false);
+  assert.equal(verifyConsumerPath(42, 'right-token'), false);
+});
+
+test('verifyConsumerPath: rejects empty expected token (sanity check)', async () => {
+  const { verifyConsumerPath } = await import(MOD_PATH);
+  // If we somehow ended up with an empty expected token, fail closed
+  // — never accept a wide-open multiplexer.
+  assert.equal(verifyConsumerPath('/', ''), false);
+  assert.equal(verifyConsumerPath('/anything', ''), false);
+});
+
+test('generateCapabilityToken: produces a unique high-entropy token each call', async () => {
+  const { generateCapabilityToken } = await import(MOD_PATH);
+  const a = generateCapabilityToken();
+  const b = generateCapabilityToken();
+  // High-entropy: base64url-encoded 32 bytes → 43 characters, no
+  // padding. Two calls should never collide.
+  assert.notEqual(a, b);
+  assert.equal(typeof a, 'string');
+  assert.match(a, /^[A-Za-z0-9_-]+$/);
+  assert.ok(a.length >= 32, `token too short: ${a.length} chars`);
+});
+
+// ── Multiplexer instance integration ────────────────────────────────
+
+test('CDPMultiplexer.token: per-instance unique token exposed via getter', async () => {
+  const { CDPMultiplexer } = await import(MOD_PATH);
+  const mux1 = new CDPMultiplexer({ hermesUrl: 'ws://127.0.0.1:0', logTag: 'test1' });
+  const mux2 = new CDPMultiplexer({ hermesUrl: 'ws://127.0.0.1:0', logTag: 'test2' });
+  const t1 = mux1.token;
+  const t2 = mux2.token;
+  assert.equal(typeof t1, 'string');
+  assert.ok(t1.length >= 32);
+  assert.notEqual(t1, t2, 'tokens must be unique across instances');
+});


### PR DESCRIPTION
## Summary

Fourth sub-phase of the workspace [ROADMAP Phase 134](https://github.com/Lykhoyda/rn-dev-agent-workspace/blob/main/docs/ROADMAP.md) sweep. One deepsec HIGH finding closed: the CDP multiplexer accepted any localhost connection and forwarded arbitrary CDP commands (`Runtime.evaluate`, `Page.navigate`, etc.) straight to Hermes — **bypassing Claude Code's tool-permission prompts entirely**.

In the prompt-injection threat model: any process with loopback access (a browser tab scanning local ports, a sibling shell, a co-resident process) could read AsyncStorage, mutate store state, exfiltrate in-memory tokens. The fix is per-multiplexer capability-token authentication on the WebSocket upgrade.

## The fix

| Primitive | Role |
|---|---|
| `generateCapabilityToken()` | `crypto.randomBytes(32).toString('base64url')` → 43-char unguessable token, unique per multiplexer instance |
| `verifyConsumerPath(reqUrl, expectedToken)` | Pure helper for `WebSocketServer.verifyClient`. Uses `timingSafeEqual` on equal-length buffers — no timing side channel. Fails closed on missing / empty / length-mismatch / query-decorated / non-string inputs |
| `CDPMultiplexer.token` getter | Caller reads the token to build the URL handed to DevTools |
| URL shape | `ws://127.0.0.1:<port>/<token>` — token in path; never logged |

## Sites wired

- **`cdp/multiplexer.ts`** — `verifyClient` rejects upgrades without `/<token>` in the path with `401 Unauthorized` before consumer registration
- **`cdp-client.ts startProxy`** — `_proxyUrl` includes `/<token>`
- **`tools/open-devtools.ts`** — DevTools URL passes the token via `?ws=PORT/TOKEN`

## Defense against the prefix-extension attack

Same family as Phase 134.3's `/tmp/foo` vs `/tmp/foo-extra` sibling-dir bug. A naive `path === '/' + token` check passes; a naive `path.startsWith('/' + token)` would let `/token-extra` through. The length-equality check before `timingSafeEqual` rejects this. Tested explicitly.

## Tests

- **9 new unit tests** in `phase-134-4-multiplexer-auth.test.js`:
  - Legitimate `/<token>` accepted
  - Wrong / missing / empty / length-mismatch / query-decorated paths rejected
  - Non-string `reqUrl` rejected
  - Empty `expectedToken` fails closed (never accept an unauthenticated multiplexer)
  - `generateCapabilityToken` produces high-entropy unique tokens
  - Per-instance token uniqueness verified
- **4 existing test files updated** for the new URL shape:
  - `cdp-client-proxy.test.js` — regex now accepts `/[A-Za-z0-9_-]+$` suffix
  - `multiplexer.test.js` — `connectConsumer(port, token)` helper; devtoolsUrl/inspectorWsUrl regexes
  - `test/helpers/mock-cdp-client.js` — mock `_proxyMultiplexer` exposes `token` field
- **Full unit suite: 1305 / 1305 passing**, 0 failing
- TypeScript compiles clean

## Cross-references

- Workspace ROADMAP Phase 134.4 — implements the deepsec recommendation: "per-proxy high-entropy capability token required during the WebSocket upgrade, for example in a query parameter or path segment included only in the returned DevTools URL"
- Phase 134.1–134.3 — established the chokepoint-validator pattern this PR extends

## Test plan

- [ ] CI green on Build & Test + CodeQL
- [ ] Version sync check passes (plugin 0.44.34 / cdp-bridge 0.38.29 / marketplace 0.44.34)
- [ ] After merge: re-run `pnpm deepsec revalidate --project-id claude-react-native-dev-plugin --min-severity HIGH --force` to confirm the multiplexer finding transitions to `Fixed`. Acceptance: HIGH count drops by 1 (from current 4 → 3).

## Cumulative Phase 134 progress

| Phase | PR | Findings | Cumulative |
|---|---|---|---|
| 134.0 | #143 | 1 BUG | 1 |
| 134.1 | #144 | 7 CRITICAL + 2 HIGH | 10 |
| 134.2 | #145 | 5 HIGH | 15 |
| 134.3 | #146 | 2 HIGH + 3 MEDIUM | 20 |
| **134.4** | this | 1 HIGH | **21 of 48 (44%)** |
| 134.5 | pending | 3 MEDIUM + 11 BUG | final sweep |