### PR TITLE
fix: device_deeplink url injection (Phase 134.2-followup) — closes last HIGH

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.35",
+      "version": "0.44.36",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.35",
+  "version": "0.44.36",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.44.36] — 2026-05-12
+
+### Fixed (Phase 134.2-followup — device_deeplink url injection)
+
+- **`device_deeplink` now POSIX-quotes the caller-supplied `url`** before
+  passing it through `adb shell am start -d <url>`. The Phase 134.2 fix
+  validated `packageName` but missed `url`. Deepsec revalidation
+  (run `20260512193352`) re-flagged the deeplink as HIGH because the
+  `url` arg still flowed unescaped into the Android remote shell, where
+  argv is joined with spaces and re-interpreted as a raw command line.
+  A URL like `myapp://path;reboot` would have executed `reboot` after
+  the `am start` completed.
+- Two-layer defense:
+  1. **Validation at the handler boundary**: reject any `url` that
+     contains control characters or newlines (which would break out of
+     the POSIX-quoted string itself), or exceeds 4096 chars.
+  2. **POSIX single-quote wrap**: every shell metacharacter inside the
+     URL (`;`, `|`, `$`, `` ` ``, `&`) becomes inert. Same pattern as
+     `device-interact.ts:524` (`buildAdbInputTextArgv`).
+- Legitimate URLs with `&`, `?`, `=`, `#` continue to work — the quote
+  wrap makes those literal arguments to `am start -d`, not shell
+  expansion targets.
+
+### Internal
+
+- 4 new unit tests in `phase-134-2-adb-shell-arg-hardening.test.js`:
+  - newline-injected URL rejected
+  - control-char-bearing URL rejected
+  - oversized URL (>4096 chars) rejected
+  - legitimate URL with query+fragment passes validation
+- Full unit suite: 1308 → 1312 passing, 0 failing.
+- Closes the **last HIGH-severity** finding from the original deepsec
+  scan. Post-merge: **CRITICAL = 0, HIGH = 0** (100% security-class
+  findings closed).
+
 ## [0.44.35] — 2026-05-12
 
 ### Fixed (Phase 134.5 — workflow + correctness sweep, closes 3 MEDIUM + 2 BUG)

--- a/scripts/cdp-bridge/dist/tools/device-deeplink.js
+++ b/scripts/cdp-bridge/dist/tools/device-deeplink.js
@@ -22,9 +22,27 @@ async function openIosDeeplink(url) {
         return failResult(`xcrun simctl openurl failed: ${msg}`, { code: 'DEEPLINK_FAILED', platform: 'ios', url });
     }
 }
+/**
+ * Phase 134.2-followup (deepsec HIGH revalidation 20260512193352): the
+ * Phase 134.2 fix validated `packageName` but missed `url`. `adb shell
+ * <argv...>` joins argv with spaces and sends the result to the Android
+ * remote shell as a raw command line — it does NOT per-argument escape.
+ * Without quoting, `url='myapp://path;reboot'` produces a shell command
+ * `am start ... -d myapp://path;reboot` where `;reboot` runs after
+ * `am start` completes.
+ *
+ * Two-layer defense: validate URL shape first (reject newlines / control
+ * chars), then POSIX single-quote the resolved URL so any remaining shell
+ * metacharacters are inert. Same quoting pattern as
+ * device-interact.ts:524 (`buildAdbInputTextArgv`).
+ */
+function posixSingleQuote(s) {
+    return `'${s.replace(/'/g, "'\\''")}'`;
+}
 async function openAndroidDeeplink(url, packageName) {
     const serial = getAdbSerial();
-    const args = [...serial, 'shell', 'am', 'start', '-a', 'android.intent.action.VIEW', '-d', url];
+    const quotedUrl = posixSingleQuote(url);
+    const args = [...serial, 'shell', 'am', 'start', '-a', 'android.intent.action.VIEW', '-d', quotedUrl];
     if (packageName)
         args.push('-n', packageName);
     try {
@@ -61,6 +79,17 @@ export function createDeviceDeeplinkHandler() {
     return async (args) => {
         if (!args.url || args.url.length === 0) {
             return failResult('url is required', { code: 'INVALID_ARGS' });
+        }
+        // Phase 134.2-followup (deepsec HIGH revalidation 20260512193352):
+        // `url` flows into the adb shell command line. POSIX-quoting in
+        // openAndroidDeeplink covers the shell-metachar layer, but a URL
+        // containing a newline or control char would break out of the
+        // quoted string entirely. Reject those at the boundary.
+        if (typeof args.url !== 'string' || /[\u0000-\u001F\u0085\u2028\u2029]/.test(args.url)) {
+            return failResult(`url contains control characters or newlines — refuse to pass to adb shell (Phase 134.2-followup)`, { code: 'INVALID_ARGS' });
+        }
+        if (args.url.length > 4096) {
+            return failResult('url too long (max 4096 chars)', { code: 'INVALID_ARGS' });
         }
         // Phase 134.2 (deepsec HIGH): `packageName` reaches `adb shell am start
         // -n <packageName>`, where the remote Android shell re-interprets argv.

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.30",
+  "version": "0.38.31",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/tools/device-deeplink.ts
+++ b/scripts/cdp-bridge/src/tools/device-deeplink.ts
@@ -35,9 +35,28 @@ async function openIosDeeplink(url: string): Promise<ToolResult> {
   }
 }
 
+/**
+ * Phase 134.2-followup (deepsec HIGH revalidation 20260512193352): the
+ * Phase 134.2 fix validated `packageName` but missed `url`. `adb shell
+ * <argv...>` joins argv with spaces and sends the result to the Android
+ * remote shell as a raw command line — it does NOT per-argument escape.
+ * Without quoting, `url='myapp://path;reboot'` produces a shell command
+ * `am start ... -d myapp://path;reboot` where `;reboot` runs after
+ * `am start` completes.
+ *
+ * Two-layer defense: validate URL shape first (reject newlines / control
+ * chars), then POSIX single-quote the resolved URL so any remaining shell
+ * metacharacters are inert. Same quoting pattern as
+ * device-interact.ts:524 (`buildAdbInputTextArgv`).
+ */
+function posixSingleQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
 async function openAndroidDeeplink(url: string, packageName?: string): Promise<ToolResult> {
   const serial = getAdbSerial();
-  const args = [...serial, 'shell', 'am', 'start', '-a', 'android.intent.action.VIEW', '-d', url];
+  const quotedUrl = posixSingleQuote(url);
+  const args = [...serial, 'shell', 'am', 'start', '-a', 'android.intent.action.VIEW', '-d', quotedUrl];
   if (packageName) args.push('-n', packageName);
   try {
     const { stdout, stderr } = await execFile('adb', args, { timeout: EXEC_TIMEOUT_MS });
@@ -73,6 +92,20 @@ export function createDeviceDeeplinkHandler(): (args: DeeplinkArgs) => Promise<T
   return async (args) => {
     if (!args.url || args.url.length === 0) {
       return failResult('url is required', { code: 'INVALID_ARGS' });
+    }
+    // Phase 134.2-followup (deepsec HIGH revalidation 20260512193352):
+    // `url` flows into the adb shell command line. POSIX-quoting in
+    // openAndroidDeeplink covers the shell-metachar layer, but a URL
+    // containing a newline or control char would break out of the
+    // quoted string entirely. Reject those at the boundary.
+    if (typeof args.url !== 'string' || /[\u0000-\u001F\u0085\u2028\u2029]/.test(args.url)) {
+      return failResult(
+        `url contains control characters or newlines — refuse to pass to adb shell (Phase 134.2-followup)`,
+        { code: 'INVALID_ARGS' },
+      );
+    }
+    if (args.url.length > 4096) {
+      return failResult('url too long (max 4096 chars)', { code: 'INVALID_ARGS' });
     }
     // Phase 134.2 (deepsec HIGH): `packageName` reaches `adb shell am start
     // -n <packageName>`, where the remote Android shell re-interprets argv.

--- a/scripts/cdp-bridge/test/unit/phase-134-2-adb-shell-arg-hardening.test.js
+++ b/scripts/cdp-bridge/test/unit/phase-134-2-adb-shell-arg-hardening.test.js
@@ -215,7 +215,64 @@ test('Phase 134.2: device_snapshot action=open rejects shell-metachar appId', as
   assert.equal(r.isError, true);
 });
 
-test('Phase 134.2: device_deeplink without packageName works (optional arg unchanged)', async () => {
+// ── Phase 134.2-followup: device_deeplink URL injection ─────────────
+// The original 134.2 fix validated packageName but missed `url`.
+// Deepsec revalidation 20260512193352 flagged `url` as a separate
+// injection vector: a URL like 'myapp://path;reboot' would break out
+// of the adb shell command after `am start` completes. Fix: validate
+// + POSIX single-quote the url.
+
+test('Phase 134.2-followup: device_deeplink rejects url with newline-injection', async () => {
+  const { createDeviceDeeplinkHandler } = await import('../../dist/tools/device-deeplink.js');
+  const handler = createDeviceDeeplinkHandler();
+  const r = await handler({
+    url: 'myapp://path\nreboot',
+    platform: 'android',
+  });
+  assert.equal(r.isError, true);
+  const env = parseEnvelope(r);
+  assert.match(env.error, /control characters|newlines/i);
+});
+
+test('Phase 134.2-followup: device_deeplink rejects url with control characters', async () => {
+  const { createDeviceDeeplinkHandler } = await import('../../dist/tools/device-deeplink.js');
+  const handler = createDeviceDeeplinkHandler();
+  const r = await handler({
+    url: 'myapp://pathevil',
+    platform: 'android',
+  });
+  assert.equal(r.isError, true);
+});
+
+test('Phase 134.2-followup: device_deeplink rejects oversized url', async () => {
+  const { createDeviceDeeplinkHandler } = await import('../../dist/tools/device-deeplink.js');
+  const handler = createDeviceDeeplinkHandler();
+  const r = await handler({
+    url: 'myapp://' + 'a'.repeat(5000),
+    platform: 'android',
+  });
+  assert.equal(r.isError, true);
+  const env = parseEnvelope(r);
+  assert.match(env.error, /too long/i);
+});
+
+test('Phase 134.2-followup: device_deeplink accepts urls with legitimate special chars (& ? = #)', async () => {
+  // URL query params with & and = are legitimate; POSIX-quoting keeps them inert.
+  const { createDeviceDeeplinkHandler } = await import('../../dist/tools/device-deeplink.js');
+  const handler = createDeviceDeeplinkHandler();
+  const r = await handler({
+    url: 'myapp://path?key=value&other=thing#fragment',
+    platform: 'android',
+  });
+  // May error from adb-not-installed but NOT from input validation.
+  if (r.isError) {
+    const env = parseEnvelope(r);
+    assert.doesNotMatch(env.error ?? '', /control characters|newlines|too long/i,
+      'Legitimate URL with query/fragment must pass input validation');
+  }
+});
+
+test('Phase 134.2-followup: device_deeplink without packageName works (optional arg unchanged)', async () => {
   // packageName is optional — when omitted, no validation is needed.
   const { createDeviceDeeplinkHandler } = await import('../../dist/tools/device-deeplink.js');
   const handler = createDeviceDeeplinkHandler();


### PR DESCRIPTION
## Summary

Followup to [PR #145](https://github.com/Lykhoyda/rn-dev-agent/pull/145) (Phase 134.2). Deepsec revalidation run `20260512193352` re-flagged `device-deeplink.ts` as HIGH because the original 134.2 fix validated `packageName` but missed the **`url`** argument. The `url` flowed unescaped into `adb shell am start -d <url>`, where the Android remote shell joins argv with spaces and re-interprets the result as a raw command line. A URL like `myapp://path;reboot` would execute `reboot` after `am start` completed.

## The fix

Two-layer defense at `tools/device-deeplink.ts`:

**Layer 1 — validate at the boundary**: reject URLs that contain control characters, newlines, or exceed 4096 chars. Those would break out of the POSIX-quoted string itself.

**Layer 2 — POSIX single-quote**: wrap the URL with `'...'` before passing to `adb` argv. Same pattern as `device-interact.ts:524` (`buildAdbInputTextArgv`). Every shell metacharacter (`;`, `|`, `$`, backtick, `&`) becomes inert.

Legitimate URLs with `&`, `?`, `=`, `#` continue to work — the quote wrap makes those literal arguments to `am start`, not shell expansion targets.

## Tests

4 new unit tests in `phase-134-2-adb-shell-arg-hardening.test.js`:
- Newline-injected URL rejected
- Control-char-bearing URL rejected
- Oversized URL (>4096 chars) rejected
- Legitimate URL with `?key=value&other=thing#fragment` passes validation

**Full unit suite: 1308 → 1312 passing**, 0 failing.

## Cumulative Phase 134 — post-merge state

| Severity | Closed | Remaining | % |
|---|---|---|---|
| 🔴 **CRITICAL** | 7 / 7 | 0 | **100%** ✅ |
| 🟠 **HIGH** | 11 / 11 | 0 | **100%** ✅ |
| 🟡 MEDIUM | ~8 / 16 | 8 | 50% |
| 🟣 HIGH_BUG | 0 / 3 | 3 | 0% |
| 🔵 BUG | 3+ / 11 | 8 | 27% |

After this lands: **0 CRITICAL + 0 HIGH** — all attacker-capability findings closed.

## Test plan

- [ ] CI green on Build & Test + CodeQL
- [ ] Version sync check passes (plugin 0.44.36 / cdp-bridge 0.38.31 / marketplace 0.44.36)
- [ ] After merge: re-run `pnpm deepsec revalidate --project-id claude-react-native-dev-plugin --min-severity HIGH --force --agent claude` to confirm HIGH drops to 0.