### PR TITLE
fix(gh-106): bundle .rn-agent/actions + skeleton in experience export/import

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.36",
+      "version": "0.44.38",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.36",
+  "version": "0.44.38",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.44.38] — 2026-05-13
+
+### Added (GH #106 — flow + skeleton bundling in experience export/import)
+
+- **`exportExperience()` now bundles `.rn-agent/actions/*.yaml` flows and
+  `.rn-agent/skeleton.yaml`** alongside heuristics + failure stats —
+  matching what the `rn-agent-export` / `rn-agent-import` command docs
+  have advertised since D1204. Until now the underlying script handled
+  only heuristics, so a teammate exporting + importing got the muscle
+  memory metadata but not the actual reusable actions that ARE the L3
+  corpus.
+- New `src/experience/flow-bundle.ts` exposes pure anonymize/restore
+  helpers: rewrites `appId:` between `com.example.<slug>` (export) and
+  the local project's bundleId (import), truncates author-prose comment
+  lines longer than 200 chars while preserving M7 fields verbatim, and
+  extracts `${VAR}` placeholders so the importer can surface them.
+- **Placeholder manifest comments** (Codex review A, HIGH conf): on
+  import, if a flow contains `${UPPER_CASE_VARS}`, prepend a
+  `# placeholders: VAR1, VAR2 — supply via -e KEY=VALUE on replay` line
+  above the M7 header. Codex's call: don't suffix every placeholder flow
+  with `.needs-review.yaml` (that punishes correctly-authored flows);
+  don't go silent (violates spirit of acceptance criterion); use a
+  grep-able comment instead.
+- **`appId:` rewrite is line-wise** (Codex review B, HIGH conf), so
+  legitimate multi-line top sections (a `# shared across envs` comment
+  above `appId:`) round-trip cleanly. Hard-fails only when zero `appId:`
+  lines exist.
+- **Conflict semantics**: an imported flow whose `id` already exists
+  locally lands at `<id>.imported.yaml` so the user can diff and merge
+  manually. Same pattern for skeleton (`skeleton.imported.yaml`).
+- **Status forced to `experimental`** on import — keeps imported flows
+  from claiming `active` before a local replay proves they work.
+- **Sidecars are not bundled.** Per-developer runtime state (`runHistory`,
+  `repairHistory`, `stats`) is exactly what shouldn't travel; on import
+  the local `loadOrInitSidecar` seeds a fresh sidecar on first replay.
+- **`--no-flows` / `--no-skeleton` opt-outs** on both `ExportOptions`
+  and `ImportOptions` (default both true).
+- **Defense in depth**: import-side flow `id` is re-validated against
+  `^[A-Za-z0-9_-]+$` so a hand-crafted bundle with a path-traversal id
+  can't escape `.rn-agent/actions/`. Malformed flows are skipped with a
+  one-line stderr log.
+- 29 new tests — 18 pure-helper tests on `flow-bundle.ts` + 11
+  integration tests with real temp dirs covering export, import,
+  opt-outs, conflict-rename, malformed-bundle defense in depth, and
+  no-app.json fallback. Suite: 1312 → 1341 passing.
+
 ## [0.44.36] — 2026-05-12
 
 ### Fixed (Phase 134.2-followup — device_deeplink url injection)

--- a/scripts/cdp-bridge/dist/experience/flow-bundle.js
+++ b/scripts/cdp-bridge/dist/experience/flow-bundle.js
@@ -1,0 +1,219 @@
+// GH #106 / D1204 follow-up — flow + skeleton bundling helpers for the
+// experience export/import pipeline. The detector / existing exporter in
+// sharing.ts already handles heuristics + failure stats; this module adds
+// the missing pieces so the bundle actually carries the .rn-agent/actions/
+// corpus and the skeleton.yaml lookup table.
+//
+// Pure functions only — no I/O. Caller (sharing.ts) walks the filesystem
+// and feeds raw YAML text in. Returns transformed YAML text. Keeps the
+// I/O surface auditable and the helpers testable without temp dirs.
+//
+// Design calls (Codex pre-implementation review, both HIGH conf):
+// - `${VAR}` placeholders → prepend "# placeholders: VAR1, VAR2" comment
+//   above the M7 header on restore. Do NOT suffix with .needs-review.yaml
+//   — that punishes correctly-authored flows. (Codex A)
+// - `appId:` rewrite is line-wise, not whole-string. Preserves multi-line
+//   top sections (a human-edited "# shared across envs" comment above
+//   appId is legitimate per saveAction's topSection contract). Hard-fail
+//   only when zero `appId:` lines exist; warn on multiple. (Codex B)
+const APPID_LINE_RE = /^appId:\s*(.+)$/;
+const PLACEHOLDER_RE = /\$\{([A-Z_][A-Z0-9_]*)\}/g;
+const M7_HEADER_LINE_RE = /^#\s*(id|intent|tags|mutates|status|requires|produces|preconditions|placeholders):/i;
+const STATUS_LINE_RE = /^(#\s*status:\s*).+$/;
+const MAX_PROSE_LINE_LENGTH = 200; // bytes per prose comment before truncation
+/** Anonymize a project's appId into a stable export slug (lowercase, no dots). */
+export function sanitizeAppIdSlug(appId) {
+    if (!appId || typeof appId !== 'string')
+        return 'app';
+    const slug = appId
+        .toLowerCase()
+        .replace(/^com\./, '')
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 64);
+    return slug || 'app';
+}
+function splitFlowYaml(text) {
+    const lines = text.split('\n');
+    const sepIdx = lines.findIndex((l) => l.trim() === '---');
+    if (sepIdx < 0) {
+        return { topSection: [], m7HeaderAndProse: [], body: lines, hasSeparator: false };
+    }
+    const topSection = lines.slice(0, sepIdx);
+    const afterSep = lines.slice(sepIdx + 1);
+    const headerAndProse = [];
+    const body = [];
+    let stillHeader = true;
+    for (const line of afterSep) {
+        if (stillHeader && (line.startsWith('#') || line.trim() === '')) {
+            headerAndProse.push(line);
+        }
+        else {
+            stillHeader = false;
+            body.push(line);
+        }
+    }
+    return { topSection, m7HeaderAndProse: headerAndProse, body, hasSeparator: true };
+}
+function joinFlowYaml(parts) {
+    const out = [];
+    if (parts.hasSeparator) {
+        for (const l of parts.topSection)
+            out.push(l);
+        out.push('---');
+    }
+    for (const l of parts.m7HeaderAndProse)
+        out.push(l);
+    for (const l of parts.body)
+        out.push(l);
+    return out.join('\n');
+}
+function rewriteAppIdLine(topSection, newAppId) {
+    let foundIdx = -1;
+    for (let i = 0; i < topSection.length; i++) {
+        if (APPID_LINE_RE.test(topSection[i])) {
+            foundIdx = i;
+            break;
+        }
+    }
+    if (foundIdx < 0) {
+        throw new Error('FlowBundleError: top section missing appId: line');
+    }
+    // Codex B: replace the first match; if there are duplicates, the second
+    // is left alone. Maestro itself honors the first appId, so this matches
+    // runtime semantics. A warning here would just spam logs since the
+    // export side runs through every project's flows.
+    const next = [...topSection];
+    next[foundIdx] = `appId: ${newAppId}`;
+    return next;
+}
+/**
+ * Anonymize a flow YAML for export:
+ *   - rewrite `appId:` to `com.example.<slug>`
+ *   - truncate any prose comment line longer than 200 chars in the
+ *     header-and-prose section (preserves M7 fields verbatim)
+ *   - leave body verbatim (testIDs are semantic; ${VAR} placeholders stay)
+ *
+ * Throws FlowBundleError when the YAML has no `appId:` line — surfaces
+ * malformed input rather than silently producing a broken export.
+ */
+export function anonymizeFlowYaml(text) {
+    const parts = splitFlowYaml(text);
+    if (!parts.hasSeparator) {
+        throw new Error('FlowBundleError: flow YAML missing --- separator');
+    }
+    const sourceMatch = parts.topSection
+        .map((l) => l.match(APPID_LINE_RE))
+        .find((m) => m !== null);
+    if (!sourceMatch) {
+        throw new Error('FlowBundleError: top section missing appId: line');
+    }
+    const slug = sanitizeAppIdSlug(sourceMatch[1].trim());
+    const newTop = rewriteAppIdLine(parts.topSection, `com.example.${slug}`);
+    // Multi-review fix (Codex 92 + Gemini 95): strip any `# placeholders:`
+    // line on export so a bundle round-trip (A→B→C) doesn't accumulate
+    // copies. The manifest is a local-import-only annotation; the bundle
+    // itself should never carry it.
+    const newHeader = parts.m7HeaderAndProse
+        .filter((line) => !/^#\s*placeholders:/i.test(line))
+        .map((line) => {
+        if (!line.startsWith('#'))
+            return line;
+        if (M7_HEADER_LINE_RE.test(line))
+            return line; // keep M7 fields verbatim
+        if (line.length <= MAX_PROSE_LINE_LENGTH + 2)
+            return line; // 2 == '# ' prefix
+        return line.slice(0, MAX_PROSE_LINE_LENGTH + 2 - 3) + '...';
+    });
+    return joinFlowYaml({ ...parts, topSection: newTop, m7HeaderAndProse: newHeader });
+}
+/** Read the first uppercase-only `${VAR}` placeholder names in the YAML body. */
+export function extractPlaceholders(text) {
+    const seen = new Set();
+    const iter = text.matchAll(PLACEHOLDER_RE);
+    for (const m of iter) {
+        seen.add(m[1]);
+    }
+    return [...seen].sort();
+}
+/** Pull the `id` from a flow's M7 header. Returns null when missing. */
+export function extractActionId(text) {
+    const parts = splitFlowYaml(text);
+    for (const line of parts.m7HeaderAndProse) {
+        const m = line.match(/^#\s*id:\s*(.+)$/);
+        if (m) {
+            const id = m[1].trim();
+            if (/^[A-Za-z0-9_-]+$/.test(id))
+                return id;
+        }
+    }
+    return null;
+}
+/**
+ * Restore an anonymized flow YAML for import:
+ *   - rewrite `appId:` from `com.example.<slug>` to the local project's
+ *     actual appId
+ *   - force `# status: <anything>` to `# status: experimental` so the
+ *     imported flow can't claim active status before a local replay
+ *     proves it works
+ *   - if `${VAR}` placeholders exist, prepend a `# placeholders: …`
+ *     comment so the user sees what `-e KEY=VAL` args to supply at replay
+ */
+export function restoreFlowYaml(text, localAppId) {
+    const parts = splitFlowYaml(text);
+    if (!parts.hasSeparator) {
+        throw new Error('FlowBundleError: flow YAML missing --- separator');
+    }
+    const newTop = rewriteAppIdLine(parts.topSection, localAppId);
+    // Multi-review fix (Codex 92 + Gemini 95): drop any existing
+    // `# placeholders:` line BEFORE we decide to prepend a fresh one, so a
+    // file imported multiple times (manual re-import, or a renamed
+    // `.imported.yaml` that was promoted to the canonical name) doesn't
+    // stack duplicate manifest comments.
+    const newHeader = parts.m7HeaderAndProse
+        .filter((line) => !/^#\s*placeholders:/i.test(line))
+        .map((line) => {
+        const m = line.match(STATUS_LINE_RE);
+        if (m)
+            return `${m[1]}experimental`;
+        return line;
+    });
+    const placeholders = extractPlaceholders(parts.body.join('\n'));
+    let header = newHeader;
+    if (placeholders.length > 0) {
+        const manifest = `# placeholders: ${placeholders.join(', ')} — supply via -e KEY=VALUE on replay`;
+        header = [manifest, ...newHeader];
+    }
+    return joinFlowYaml({ ...parts, topSection: newTop, m7HeaderAndProse: header });
+}
+// ── skeleton helpers ────────────────────────────────────────────────────
+//
+// Skeleton uses a structured YAML where `appId:` lives at top-level (not
+// inside a topSection-before-`---` block). Same rewrite logic via a
+// line-wise scan over the full document.
+function rewriteSkeletonAppId(text, newAppId) {
+    const lines = text.split('\n');
+    let foundIdx = -1;
+    for (let i = 0; i < lines.length; i++) {
+        if (APPID_LINE_RE.test(lines[i])) {
+            foundIdx = i;
+            break;
+        }
+    }
+    if (foundIdx < 0) {
+        throw new Error('FlowBundleError: skeleton missing appId: field');
+    }
+    lines[foundIdx] = `appId: ${newAppId}`;
+    return lines.join('\n');
+}
+export function anonymizeSkeleton(text) {
+    const lines = text.split('\n');
+    const m = lines.map((l) => l.match(APPID_LINE_RE)).find((x) => x !== null);
+    if (!m)
+        throw new Error('FlowBundleError: skeleton missing appId: field');
+    const slug = sanitizeAppIdSlug(m[1].trim());
+    return rewriteSkeletonAppId(text, `com.example.${slug}`);
+}
+export function restoreSkeleton(text, localAppId) {
+    return rewriteSkeletonAppId(text, localAppId);
+}

--- a/scripts/cdp-bridge/dist/experience/sharing.js
+++ b/scripts/cdp-bridge/dist/experience/sharing.js
@@ -6,6 +6,9 @@ import { redact } from './redact.js';
 import { captureFingerprint } from './fingerprint.js';
 import { loadExperience } from './retrieve.js';
 import { scanTelemetry, groupFailures } from './compact.js';
+import { anonymizeFlowYaml, restoreFlowYaml, anonymizeSkeleton, restoreSkeleton, extractActionId, } from './flow-bundle.js';
+import { findProjectRoot } from '../nav-graph/storage.js';
+import { readAppId } from '../project-config.js';
 const AGENT_DIR = join(homedir(), '.claude', 'rn-agent');
 const EXPORTS_DIR = join(AGENT_DIR, 'exports');
 const EXPERIENCE_PATH = join(AGENT_DIR, 'experience.md');
@@ -46,7 +49,51 @@ function anonymizeStats(s) {
         run_count: s.runs.size,
     };
 }
-export function exportExperience() {
+/**
+ * GH #106: walk `<projectRoot>/.rn-agent/actions/*.yaml` and return
+ * anonymized flow entries. Skips files that throw FlowBundleError
+ * (malformed actions) and logs them — one bad file shouldn't kill the
+ * whole export. Returns empty array when the dir doesn't exist.
+ */
+function collectFlows(projectRoot) {
+    const actionsDir = join(projectRoot, '.rn-agent', 'actions');
+    if (!existsSync(actionsDir))
+        return [];
+    let files;
+    try {
+        files = readdirSync(actionsDir).filter(f => f.endsWith('.yaml'));
+    }
+    catch {
+        return [];
+    }
+    const out = [];
+    for (const f of files) {
+        try {
+            const text = readFileSync(join(actionsDir, f), 'utf-8');
+            const anonymized = anonymizeFlowYaml(text);
+            const id = extractActionId(anonymized) ?? f.replace(/\.yaml$/, '');
+            out.push({ id, yaml: anonymized });
+        }
+        catch (e) {
+            process.stderr.write(`[export] skipping ${f}: ${e.message}\n`);
+        }
+    }
+    return out;
+}
+function collectSkeleton(projectRoot) {
+    const path = join(projectRoot, '.rn-agent', 'skeleton.yaml');
+    if (!existsSync(path))
+        return null;
+    try {
+        const text = readFileSync(path, 'utf-8');
+        return { yaml: anonymizeSkeleton(text) };
+    }
+    catch (e) {
+        process.stderr.write(`[export] skipping skeleton: ${e.message}\n`);
+        return null;
+    }
+}
+export function exportExperience(opts = {}) {
     if (!existsSync(EXPORTS_DIR)) {
         mkdirSync(EXPORTS_DIR, { recursive: true });
     }
@@ -61,13 +108,104 @@ export function exportExperience() {
         heuristics: experience.heuristics.map(anonymizeHeuristic),
         failure_stats: stats.filter(s => s.total >= 2).map(anonymizeStats),
     };
+    // GH #106: optionally bundle .rn-agent/actions/ and .rn-agent/skeleton.yaml.
+    const includeFlows = opts.flows !== false;
+    const includeSkeleton = opts.skeleton !== false;
+    const projectRoot = opts.projectRoot !== undefined ? opts.projectRoot : findProjectRoot();
+    if (projectRoot && (includeFlows || includeSkeleton)) {
+        if (includeFlows)
+            bundle.flows = collectFlows(projectRoot);
+        if (includeSkeleton)
+            bundle.skeleton = collectSkeleton(projectRoot);
+    }
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
     const filename = `export-${timestamp}.yaml`;
     const path = join(EXPORTS_DIR, filename);
     writeFileSync(path, yamlStringify(bundle), 'utf-8');
     return { path, bundle };
 }
-export function importExperience(filePath) {
+/**
+ * GH #106: write a single bundled flow into <projectRoot>/.rn-agent/actions/.
+ * On id collision, write `<id>.imported.yaml` so the user can diff and
+ * merge manually. Forces `status: experimental` (handled by
+ * restoreFlowYaml) and rewrites the placeholder appId to the local one.
+ */
+function writeImportedFlow(projectRoot, flow, localAppId, renamed) {
+    const actionsDir = join(projectRoot, '.rn-agent', 'actions');
+    if (!existsSync(actionsDir))
+        mkdirSync(actionsDir, { recursive: true });
+    // Defense in depth: id must be a plain slug; reject anything else so we
+    // can't be tricked into writing outside the actions dir via a malformed
+    // bundle. (extractActionId already enforces this on export but
+    // re-validate at the import boundary.)
+    if (!/^[A-Za-z0-9_-]+$/.test(flow.id)) {
+        process.stderr.write(`[import] skipping flow with invalid id: ${JSON.stringify(flow.id)}\n`);
+        return false;
+    }
+    const targetPath = join(actionsDir, `${flow.id}.yaml`);
+    let restored;
+    try {
+        restored = restoreFlowYaml(flow.yaml, localAppId);
+    }
+    catch (e) {
+        process.stderr.write(`[import] skipping flow ${flow.id}: ${e.message}\n`);
+        return false;
+    }
+    if (existsSync(targetPath)) {
+        // Gemini multi-review (conf 90): the first collision goes to
+        // `<id>.imported.yaml`. The SECOND collision must not silently
+        // overwrite the first imported variant — the user may be mid-merge
+        // on that file. Numbered suffix preserves every prior import for
+        // diff-and-merge.
+        let altPath = join(actionsDir, `${flow.id}.imported.yaml`);
+        let altName = `${flow.id}.imported.yaml`;
+        let n = 2;
+        while (existsSync(altPath)) {
+            altName = `${flow.id}.imported.${n}.yaml`;
+            altPath = join(actionsDir, altName);
+            n++;
+            if (n > 100) {
+                // Bound the climb at 100 — at that point the user has bigger
+                // problems and we should fail loudly rather than write 1000
+                // suffixed files.
+                process.stderr.write(`[import] too many imported variants of ${flow.id}; skipping\n`);
+                return false;
+            }
+        }
+        writeFileSync(altPath, restored, 'utf-8');
+        renamed.push(altName);
+        return true;
+    }
+    writeFileSync(targetPath, restored, 'utf-8');
+    return true;
+}
+function writeImportedSkeleton(projectRoot, skeleton, localAppId) {
+    const rnAgentDir = join(projectRoot, '.rn-agent');
+    if (!existsSync(rnAgentDir))
+        mkdirSync(rnAgentDir, { recursive: true });
+    const targetPath = join(rnAgentDir, 'skeleton.yaml');
+    // Don't overwrite an existing skeleton silently — write side-by-side.
+    // Same numbered-suffix rule as flows so a second import doesn't
+    // clobber a first-imported variant that's mid-merge.
+    const restored = restoreSkeleton(skeleton.yaml, localAppId);
+    if (existsSync(targetPath)) {
+        let altPath = join(rnAgentDir, 'skeleton.imported.yaml');
+        let n = 2;
+        while (existsSync(altPath)) {
+            altPath = join(rnAgentDir, `skeleton.imported.${n}.yaml`);
+            n++;
+            if (n > 100) {
+                process.stderr.write('[import] too many imported skeleton variants; skipping\n');
+                return false;
+            }
+        }
+        writeFileSync(altPath, restored, 'utf-8');
+        return true;
+    }
+    writeFileSync(targetPath, restored, 'utf-8');
+    return true;
+}
+export function importExperience(filePath, opts = {}) {
     if (!existsSync(filePath)) {
         throw new Error(`File not found: ${filePath}`);
     }
@@ -134,6 +272,38 @@ export function importExperience(filePath) {
             writeFileSync(EXPERIENCE_PATH, content, 'utf-8');
         }
         catch { /* best-effort */ }
+    }
+    // GH #106: import flows + skeleton when present in the bundle and not
+    // opted out. Resolves the local appId via project-config.readAppId, so
+    // the bundle's com.example.<slug> stub gets rewritten to the real
+    // bundleId of the receiving test-app.
+    const includeFlows = opts.flows !== false;
+    const includeSkeleton = opts.skeleton !== false;
+    const hasFlows = Array.isArray(bundle.flows) && bundle.flows.length > 0;
+    const hasSkeleton = bundle.skeleton != null;
+    if ((includeFlows && hasFlows) || (includeSkeleton && hasSkeleton)) {
+        const projectRoot = opts.projectRoot !== undefined ? opts.projectRoot : findProjectRoot();
+        if (projectRoot) {
+            const platform = opts.appPlatform ?? 'ios';
+            const localAppId = readAppId(projectRoot, platform) ?? 'com.example.unknownapp';
+            const renamed = [];
+            let flowCount = 0;
+            if (includeFlows && hasFlows) {
+                for (const flow of bundle.flows) {
+                    if (writeImportedFlow(projectRoot, flow, localAppId, renamed))
+                        flowCount++;
+                }
+                result.flows_imported = flowCount;
+                if (renamed.length > 0)
+                    result.flows_renamed = renamed;
+            }
+            if (includeSkeleton && hasSkeleton) {
+                result.skeleton_imported = writeImportedSkeleton(projectRoot, bundle.skeleton, localAppId);
+            }
+        }
+        else {
+            process.stderr.write('[import] no project root found — skipping flow/skeleton import\n');
+        }
     }
     return result;
 }

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.31",
+  "version": "0.38.33",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/experience/flow-bundle.ts
+++ b/scripts/cdp-bridge/src/experience/flow-bundle.ts
@@ -1,0 +1,229 @@
+// GH #106 / D1204 follow-up — flow + skeleton bundling helpers for the
+// experience export/import pipeline. The detector / existing exporter in
+// sharing.ts already handles heuristics + failure stats; this module adds
+// the missing pieces so the bundle actually carries the .rn-agent/actions/
+// corpus and the skeleton.yaml lookup table.
+//
+// Pure functions only — no I/O. Caller (sharing.ts) walks the filesystem
+// and feeds raw YAML text in. Returns transformed YAML text. Keeps the
+// I/O surface auditable and the helpers testable without temp dirs.
+//
+// Design calls (Codex pre-implementation review, both HIGH conf):
+// - `${VAR}` placeholders → prepend "# placeholders: VAR1, VAR2" comment
+//   above the M7 header on restore. Do NOT suffix with .needs-review.yaml
+//   — that punishes correctly-authored flows. (Codex A)
+// - `appId:` rewrite is line-wise, not whole-string. Preserves multi-line
+//   top sections (a human-edited "# shared across envs" comment above
+//   appId is legitimate per saveAction's topSection contract). Hard-fail
+//   only when zero `appId:` lines exist; warn on multiple. (Codex B)
+
+const APPID_LINE_RE = /^appId:\s*(.+)$/;
+const PLACEHOLDER_RE = /\$\{([A-Z_][A-Z0-9_]*)\}/g;
+const M7_HEADER_LINE_RE = /^#\s*(id|intent|tags|mutates|status|requires|produces|preconditions|placeholders):/i;
+const STATUS_LINE_RE = /^(#\s*status:\s*).+$/;
+
+const MAX_PROSE_LINE_LENGTH = 200; // bytes per prose comment before truncation
+
+/** Anonymize a project's appId into a stable export slug (lowercase, no dots). */
+export function sanitizeAppIdSlug(appId: string): string {
+  if (!appId || typeof appId !== 'string') return 'app';
+  const slug = appId
+    .toLowerCase()
+    .replace(/^com\./, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+  return slug || 'app';
+}
+
+interface SplitYaml {
+  topSection: string[];
+  m7HeaderAndProse: string[];
+  body: string[];
+  hasSeparator: boolean;
+}
+
+function splitFlowYaml(text: string): SplitYaml {
+  const lines = text.split('\n');
+  const sepIdx = lines.findIndex((l) => l.trim() === '---');
+  if (sepIdx < 0) {
+    return { topSection: [], m7HeaderAndProse: [], body: lines, hasSeparator: false };
+  }
+  const topSection = lines.slice(0, sepIdx);
+  const afterSep = lines.slice(sepIdx + 1);
+  const headerAndProse: string[] = [];
+  const body: string[] = [];
+  let stillHeader = true;
+  for (const line of afterSep) {
+    if (stillHeader && (line.startsWith('#') || line.trim() === '')) {
+      headerAndProse.push(line);
+    } else {
+      stillHeader = false;
+      body.push(line);
+    }
+  }
+  return { topSection, m7HeaderAndProse: headerAndProse, body, hasSeparator: true };
+}
+
+function joinFlowYaml(parts: SplitYaml): string {
+  const out: string[] = [];
+  if (parts.hasSeparator) {
+    for (const l of parts.topSection) out.push(l);
+    out.push('---');
+  }
+  for (const l of parts.m7HeaderAndProse) out.push(l);
+  for (const l of parts.body) out.push(l);
+  return out.join('\n');
+}
+
+function rewriteAppIdLine(topSection: string[], newAppId: string): string[] {
+  let foundIdx = -1;
+  for (let i = 0; i < topSection.length; i++) {
+    if (APPID_LINE_RE.test(topSection[i])) {
+      foundIdx = i;
+      break;
+    }
+  }
+  if (foundIdx < 0) {
+    throw new Error('FlowBundleError: top section missing appId: line');
+  }
+  // Codex B: replace the first match; if there are duplicates, the second
+  // is left alone. Maestro itself honors the first appId, so this matches
+  // runtime semantics. A warning here would just spam logs since the
+  // export side runs through every project's flows.
+  const next = [...topSection];
+  next[foundIdx] = `appId: ${newAppId}`;
+  return next;
+}
+
+/**
+ * Anonymize a flow YAML for export:
+ *   - rewrite `appId:` to `com.example.<slug>`
+ *   - truncate any prose comment line longer than 200 chars in the
+ *     header-and-prose section (preserves M7 fields verbatim)
+ *   - leave body verbatim (testIDs are semantic; ${VAR} placeholders stay)
+ *
+ * Throws FlowBundleError when the YAML has no `appId:` line — surfaces
+ * malformed input rather than silently producing a broken export.
+ */
+export function anonymizeFlowYaml(text: string): string {
+  const parts = splitFlowYaml(text);
+  if (!parts.hasSeparator) {
+    throw new Error('FlowBundleError: flow YAML missing --- separator');
+  }
+  const sourceMatch = parts.topSection
+    .map((l) => l.match(APPID_LINE_RE))
+    .find((m) => m !== null);
+  if (!sourceMatch) {
+    throw new Error('FlowBundleError: top section missing appId: line');
+  }
+  const slug = sanitizeAppIdSlug(sourceMatch[1].trim());
+  const newTop = rewriteAppIdLine(parts.topSection, `com.example.${slug}`);
+  // Multi-review fix (Codex 92 + Gemini 95): strip any `# placeholders:`
+  // line on export so a bundle round-trip (A→B→C) doesn't accumulate
+  // copies. The manifest is a local-import-only annotation; the bundle
+  // itself should never carry it.
+  const newHeader = parts.m7HeaderAndProse
+    .filter((line) => !/^#\s*placeholders:/i.test(line))
+    .map((line) => {
+      if (!line.startsWith('#')) return line;
+      if (M7_HEADER_LINE_RE.test(line)) return line; // keep M7 fields verbatim
+      if (line.length <= MAX_PROSE_LINE_LENGTH + 2) return line; // 2 == '# ' prefix
+      return line.slice(0, MAX_PROSE_LINE_LENGTH + 2 - 3) + '...';
+    });
+  return joinFlowYaml({ ...parts, topSection: newTop, m7HeaderAndProse: newHeader });
+}
+
+/** Read the first uppercase-only `${VAR}` placeholder names in the YAML body. */
+export function extractPlaceholders(text: string): string[] {
+  const seen = new Set<string>();
+  const iter = text.matchAll(PLACEHOLDER_RE);
+  for (const m of iter) {
+    seen.add(m[1]);
+  }
+  return [...seen].sort();
+}
+
+/** Pull the `id` from a flow's M7 header. Returns null when missing. */
+export function extractActionId(text: string): string | null {
+  const parts = splitFlowYaml(text);
+  for (const line of parts.m7HeaderAndProse) {
+    const m = line.match(/^#\s*id:\s*(.+)$/);
+    if (m) {
+      const id = m[1].trim();
+      if (/^[A-Za-z0-9_-]+$/.test(id)) return id;
+    }
+  }
+  return null;
+}
+
+/**
+ * Restore an anonymized flow YAML for import:
+ *   - rewrite `appId:` from `com.example.<slug>` to the local project's
+ *     actual appId
+ *   - force `# status: <anything>` to `# status: experimental` so the
+ *     imported flow can't claim active status before a local replay
+ *     proves it works
+ *   - if `${VAR}` placeholders exist, prepend a `# placeholders: …`
+ *     comment so the user sees what `-e KEY=VAL` args to supply at replay
+ */
+export function restoreFlowYaml(text: string, localAppId: string): string {
+  const parts = splitFlowYaml(text);
+  if (!parts.hasSeparator) {
+    throw new Error('FlowBundleError: flow YAML missing --- separator');
+  }
+  const newTop = rewriteAppIdLine(parts.topSection, localAppId);
+  // Multi-review fix (Codex 92 + Gemini 95): drop any existing
+  // `# placeholders:` line BEFORE we decide to prepend a fresh one, so a
+  // file imported multiple times (manual re-import, or a renamed
+  // `.imported.yaml` that was promoted to the canonical name) doesn't
+  // stack duplicate manifest comments.
+  const newHeader = parts.m7HeaderAndProse
+    .filter((line) => !/^#\s*placeholders:/i.test(line))
+    .map((line) => {
+      const m = line.match(STATUS_LINE_RE);
+      if (m) return `${m[1]}experimental`;
+      return line;
+    });
+  const placeholders = extractPlaceholders(parts.body.join('\n'));
+  let header = newHeader;
+  if (placeholders.length > 0) {
+    const manifest = `# placeholders: ${placeholders.join(', ')} — supply via -e KEY=VALUE on replay`;
+    header = [manifest, ...newHeader];
+  }
+  return joinFlowYaml({ ...parts, topSection: newTop, m7HeaderAndProse: header });
+}
+
+// ── skeleton helpers ────────────────────────────────────────────────────
+//
+// Skeleton uses a structured YAML where `appId:` lives at top-level (not
+// inside a topSection-before-`---` block). Same rewrite logic via a
+// line-wise scan over the full document.
+
+function rewriteSkeletonAppId(text: string, newAppId: string): string {
+  const lines = text.split('\n');
+  let foundIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (APPID_LINE_RE.test(lines[i])) {
+      foundIdx = i;
+      break;
+    }
+  }
+  if (foundIdx < 0) {
+    throw new Error('FlowBundleError: skeleton missing appId: field');
+  }
+  lines[foundIdx] = `appId: ${newAppId}`;
+  return lines.join('\n');
+}
+
+export function anonymizeSkeleton(text: string): string {
+  const lines = text.split('\n');
+  const m = lines.map((l) => l.match(APPID_LINE_RE)).find((x) => x !== null);
+  if (!m) throw new Error('FlowBundleError: skeleton missing appId: field');
+  const slug = sanitizeAppIdSlug(m[1].trim());
+  return rewriteSkeletonAppId(text, `com.example.${slug}`);
+}
+
+export function restoreSkeleton(text: string, localAppId: string): string {
+  return rewriteSkeletonAppId(text, localAppId);
+}

--- a/scripts/cdp-bridge/src/experience/sharing.ts
+++ b/scripts/cdp-bridge/src/experience/sharing.ts
@@ -11,6 +11,15 @@ import type {
   EnvironmentFingerprint,
   FailureStats,
 } from './types.js';
+import {
+  anonymizeFlowYaml,
+  restoreFlowYaml,
+  anonymizeSkeleton,
+  restoreSkeleton,
+  extractActionId,
+} from './flow-bundle.js';
+import { findProjectRoot } from '../nav-graph/storage.js';
+import { readAppId } from '../project-config.js';
 
 const AGENT_DIR = join(homedir(), '.claude', 'rn-agent');
 const EXPORTS_DIR = join(AGENT_DIR, 'exports');
@@ -37,12 +46,48 @@ interface ExportedFailureGroup {
   run_count: number;
 }
 
+/** GH #106: one anonymized flow inside the export bundle. */
+interface ExportedFlow {
+  id: string;            // M7 `id` from the flow header — used for conflict detection on import
+  yaml: string;          // anonymized YAML (appId rewritten, prose truncated, body verbatim)
+}
+
+/** GH #106: anonymized skeleton inside the export bundle. */
+interface ExportedSkeleton {
+  yaml: string;
+}
+
 interface ExportBundle {
   version: 1;
   exported_at: string;
   env: Partial<EnvironmentFingerprint>;
   heuristics: ExportedHeuristic[];
   failure_stats: ExportedFailureGroup[];
+  flows?: ExportedFlow[];           // GH #106 — present unless --no-flows
+  skeleton?: ExportedSkeleton | null; // GH #106 — present unless --no-skeleton
+}
+
+export interface ExportOptions {
+  /** GH #106: bundle .rn-agent/actions/*.yaml (default true). */
+  flows?: boolean;
+  /** GH #106: bundle .rn-agent/skeleton.yaml (default true). */
+  skeleton?: boolean;
+  /**
+   * Override project root for tests. Defaults to findProjectRoot() result.
+   * When null, flows + skeleton bundling is silently skipped.
+   */
+  projectRoot?: string | null;
+}
+
+export interface ImportOptions {
+  /** GH #106: write bundled flows into local .rn-agent/actions/ (default true). */
+  flows?: boolean;
+  /** GH #106: write bundled skeleton into local .rn-agent/skeleton.yaml (default true). */
+  skeleton?: boolean;
+  /** Override project root for tests. Defaults to findProjectRoot() result. */
+  projectRoot?: string | null;
+  /** Override local app platform for appId resolution. Defaults to 'ios'. */
+  appPlatform?: 'ios' | 'android';
 }
 
 function coarsenEnv(env: EnvironmentFingerprint): Partial<EnvironmentFingerprint> {
@@ -81,7 +126,48 @@ function anonymizeStats(s: FailureStats): ExportedFailureGroup {
   };
 }
 
-export function exportExperience(): { path: string; bundle: ExportBundle } {
+/**
+ * GH #106: walk `<projectRoot>/.rn-agent/actions/*.yaml` and return
+ * anonymized flow entries. Skips files that throw FlowBundleError
+ * (malformed actions) and logs them — one bad file shouldn't kill the
+ * whole export. Returns empty array when the dir doesn't exist.
+ */
+function collectFlows(projectRoot: string): ExportedFlow[] {
+  const actionsDir = join(projectRoot, '.rn-agent', 'actions');
+  if (!existsSync(actionsDir)) return [];
+  let files: string[];
+  try {
+    files = readdirSync(actionsDir).filter(f => f.endsWith('.yaml'));
+  } catch {
+    return [];
+  }
+  const out: ExportedFlow[] = [];
+  for (const f of files) {
+    try {
+      const text = readFileSync(join(actionsDir, f), 'utf-8');
+      const anonymized = anonymizeFlowYaml(text);
+      const id = extractActionId(anonymized) ?? f.replace(/\.yaml$/, '');
+      out.push({ id, yaml: anonymized });
+    } catch (e) {
+      process.stderr.write(`[export] skipping ${f}: ${(e as Error).message}\n`);
+    }
+  }
+  return out;
+}
+
+function collectSkeleton(projectRoot: string): ExportedSkeleton | null {
+  const path = join(projectRoot, '.rn-agent', 'skeleton.yaml');
+  if (!existsSync(path)) return null;
+  try {
+    const text = readFileSync(path, 'utf-8');
+    return { yaml: anonymizeSkeleton(text) };
+  } catch (e) {
+    process.stderr.write(`[export] skipping skeleton: ${(e as Error).message}\n`);
+    return null;
+  }
+}
+
+export function exportExperience(opts: ExportOptions = {}): { path: string; bundle: ExportBundle } {
   if (!existsSync(EXPORTS_DIR)) {
     mkdirSync(EXPORTS_DIR, { recursive: true });
   }
@@ -99,6 +185,15 @@ export function exportExperience(): { path: string; bundle: ExportBundle } {
     failure_stats: stats.filter(s => s.total >= 2).map(anonymizeStats),
   };
 
+  // GH #106: optionally bundle .rn-agent/actions/ and .rn-agent/skeleton.yaml.
+  const includeFlows = opts.flows !== false;
+  const includeSkeleton = opts.skeleton !== false;
+  const projectRoot = opts.projectRoot !== undefined ? opts.projectRoot : findProjectRoot();
+  if (projectRoot && (includeFlows || includeSkeleton)) {
+    if (includeFlows) bundle.flows = collectFlows(projectRoot);
+    if (includeSkeleton) bundle.skeleton = collectSkeleton(projectRoot);
+  }
+
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
   const filename = `export-${timestamp}.yaml`;
   const path = join(EXPORTS_DIR, filename);
@@ -113,9 +208,104 @@ interface ImportResult {
   imported: number;
   skipped: number;
   contradictions: string[];
+  /** GH #106 — count of flow YAMLs written into `.rn-agent/actions/`. */
+  flows_imported?: number;
+  /** GH #106 — flow files written with `.imported.yaml` suffix because their `id` collided. */
+  flows_renamed?: string[];
+  /** GH #106 — skeleton write outcome. */
+  skeleton_imported?: boolean;
 }
 
-export function importExperience(filePath: string): ImportResult {
+/**
+ * GH #106: write a single bundled flow into <projectRoot>/.rn-agent/actions/.
+ * On id collision, write `<id>.imported.yaml` so the user can diff and
+ * merge manually. Forces `status: experimental` (handled by
+ * restoreFlowYaml) and rewrites the placeholder appId to the local one.
+ */
+function writeImportedFlow(
+  projectRoot: string,
+  flow: ExportedFlow,
+  localAppId: string,
+  renamed: string[],
+): boolean {
+  const actionsDir = join(projectRoot, '.rn-agent', 'actions');
+  if (!existsSync(actionsDir)) mkdirSync(actionsDir, { recursive: true });
+  // Defense in depth: id must be a plain slug; reject anything else so we
+  // can't be tricked into writing outside the actions dir via a malformed
+  // bundle. (extractActionId already enforces this on export but
+  // re-validate at the import boundary.)
+  if (!/^[A-Za-z0-9_-]+$/.test(flow.id)) {
+    process.stderr.write(`[import] skipping flow with invalid id: ${JSON.stringify(flow.id)}\n`);
+    return false;
+  }
+  const targetPath = join(actionsDir, `${flow.id}.yaml`);
+  let restored: string;
+  try {
+    restored = restoreFlowYaml(flow.yaml, localAppId);
+  } catch (e) {
+    process.stderr.write(`[import] skipping flow ${flow.id}: ${(e as Error).message}\n`);
+    return false;
+  }
+  if (existsSync(targetPath)) {
+    // Gemini multi-review (conf 90): the first collision goes to
+    // `<id>.imported.yaml`. The SECOND collision must not silently
+    // overwrite the first imported variant — the user may be mid-merge
+    // on that file. Numbered suffix preserves every prior import for
+    // diff-and-merge.
+    let altPath = join(actionsDir, `${flow.id}.imported.yaml`);
+    let altName = `${flow.id}.imported.yaml`;
+    let n = 2;
+    while (existsSync(altPath)) {
+      altName = `${flow.id}.imported.${n}.yaml`;
+      altPath = join(actionsDir, altName);
+      n++;
+      if (n > 100) {
+        // Bound the climb at 100 — at that point the user has bigger
+        // problems and we should fail loudly rather than write 1000
+        // suffixed files.
+        process.stderr.write(`[import] too many imported variants of ${flow.id}; skipping\n`);
+        return false;
+      }
+    }
+    writeFileSync(altPath, restored, 'utf-8');
+    renamed.push(altName);
+    return true;
+  }
+  writeFileSync(targetPath, restored, 'utf-8');
+  return true;
+}
+
+function writeImportedSkeleton(
+  projectRoot: string,
+  skeleton: ExportedSkeleton,
+  localAppId: string,
+): boolean {
+  const rnAgentDir = join(projectRoot, '.rn-agent');
+  if (!existsSync(rnAgentDir)) mkdirSync(rnAgentDir, { recursive: true });
+  const targetPath = join(rnAgentDir, 'skeleton.yaml');
+  // Don't overwrite an existing skeleton silently — write side-by-side.
+  // Same numbered-suffix rule as flows so a second import doesn't
+  // clobber a first-imported variant that's mid-merge.
+  const restored = restoreSkeleton(skeleton.yaml, localAppId);
+  if (existsSync(targetPath)) {
+    let altPath = join(rnAgentDir, 'skeleton.imported.yaml');
+    let n = 2;
+    while (existsSync(altPath)) {
+      altPath = join(rnAgentDir, `skeleton.imported.${n}.yaml`);
+      n++;
+      if (n > 100) {
+        process.stderr.write('[import] too many imported skeleton variants; skipping\n');
+        return false;
+      }
+    }
+    writeFileSync(altPath, restored, 'utf-8');
+    return true;
+  }
+  writeFileSync(targetPath, restored, 'utf-8');
+  return true;
+}
+
+export function importExperience(filePath: string, opts: ImportOptions = {}): ImportResult {
   if (!existsSync(filePath)) {
     throw new Error(`File not found: ${filePath}`);
   }
@@ -183,6 +373,36 @@ export function importExperience(filePath: string): ImportResult {
 
   if (result.imported > 0) {
     try { writeFileSync(EXPERIENCE_PATH, content, 'utf-8'); } catch { /* best-effort */ }
+  }
+
+  // GH #106: import flows + skeleton when present in the bundle and not
+  // opted out. Resolves the local appId via project-config.readAppId, so
+  // the bundle's com.example.<slug> stub gets rewritten to the real
+  // bundleId of the receiving test-app.
+  const includeFlows = opts.flows !== false;
+  const includeSkeleton = opts.skeleton !== false;
+  const hasFlows = Array.isArray(bundle.flows) && bundle.flows.length > 0;
+  const hasSkeleton = bundle.skeleton != null;
+  if ((includeFlows && hasFlows) || (includeSkeleton && hasSkeleton)) {
+    const projectRoot = opts.projectRoot !== undefined ? opts.projectRoot : findProjectRoot();
+    if (projectRoot) {
+      const platform = opts.appPlatform ?? 'ios';
+      const localAppId = readAppId(projectRoot, platform) ?? 'com.example.unknownapp';
+      const renamed: string[] = [];
+      let flowCount = 0;
+      if (includeFlows && hasFlows) {
+        for (const flow of bundle.flows!) {
+          if (writeImportedFlow(projectRoot, flow, localAppId, renamed)) flowCount++;
+        }
+        result.flows_imported = flowCount;
+        if (renamed.length > 0) result.flows_renamed = renamed;
+      }
+      if (includeSkeleton && hasSkeleton) {
+        result.skeleton_imported = writeImportedSkeleton(projectRoot, bundle.skeleton!, localAppId);
+      }
+    } else {
+      process.stderr.write('[import] no project root found — skipping flow/skeleton import\n');
+    }
   }
 
   return result;

--- a/scripts/cdp-bridge/test/unit/gh-106-flow-bundle.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-106-flow-bundle.test.js
@@ -1,0 +1,302 @@
+// GH #106: pure-helper tests for flow + skeleton bundling. Covers
+// anonymize/restore appId, M7 header prose truncation, placeholder
+// extraction, and the manifest-comment prepend that Codex review locked
+// in as the right interpretation of the spec's "unknown placeholder"
+// language.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const MOD_PATH = '../../dist/experience/flow-bundle.js';
+
+// ── slug sanitization ───────────────────────────────────────────────────
+
+test('sanitizeAppIdSlug: lowercases, replaces unsafe chars with hyphens, trims length', async () => {
+  const { sanitizeAppIdSlug } = await import(MOD_PATH);
+  assert.equal(sanitizeAppIdSlug('com.rndevagent.testapp'), 'rndevagent-testapp');
+  assert.equal(sanitizeAppIdSlug('com.Foo.Bar'), 'foo-bar');
+  assert.equal(sanitizeAppIdSlug('com.foo'), 'foo');
+  assert.equal(sanitizeAppIdSlug(''), 'app');
+  // Pathological inputs are squashed safely.
+  assert.equal(sanitizeAppIdSlug('com.../../weird/$%^app'), 'weird-app');
+});
+
+// ── anonymizeFlowYaml ────────────────────────────────────────────────────
+
+test('anonymizeFlowYaml: rewrites appId line to com.example.<slug>', async () => {
+  const { anonymizeFlowYaml } = await import(MOD_PATH);
+  const input = [
+    'appId: com.rndevagent.testapp',
+    '---',
+    '# id: foo',
+    '# intent: do thing',
+    '- launchApp',
+  ].join('\n');
+  const out = anonymizeFlowYaml(input);
+  assert.match(out, /^appId: com\.example\.rndevagent-testapp$/m);
+  // M7 header preserved verbatim
+  assert.match(out, /^# id: foo$/m);
+  assert.match(out, /^# intent: do thing$/m);
+  // Body preserved verbatim
+  assert.match(out, /^- launchApp$/m);
+});
+
+test('anonymizeFlowYaml: preserves multi-line top section (leading comments above appId)', async () => {
+  // Codex review B (HIGH conf): line-wise rewrite must preserve any
+  // pre-existing comments above the appId line.
+  const { anonymizeFlowYaml } = await import(MOD_PATH);
+  const input = [
+    '# shared across envs',
+    'appId: com.foo.bar',
+    '---',
+    '# id: zap',
+    '- launchApp',
+  ].join('\n');
+  const out = anonymizeFlowYaml(input);
+  // Leading comment preserved
+  assert.match(out, /^# shared across envs$/m);
+  // appId rewritten
+  assert.match(out, /^appId: com\.example\.foo-bar$/m);
+});
+
+test('anonymizeFlowYaml: truncates author-prose comments above the M7 header to 200 chars', async () => {
+  const { anonymizeFlowYaml } = await import(MOD_PATH);
+  const longProse = '# ' + 'A'.repeat(500);
+  const input = [
+    'appId: com.foo.app',
+    '---',
+    longProse,
+    '# id: foo',
+    '# intent: do thing',
+    '- launchApp',
+  ].join('\n');
+  const out = anonymizeFlowYaml(input);
+  // M7 header lines untouched
+  assert.match(out, /^# id: foo$/m);
+  assert.match(out, /^# intent: do thing$/m);
+  // Long prose is truncated — find the line and check its length
+  const proseLine = out.split('\n').find(l => l.startsWith('# A'));
+  assert.ok(proseLine, 'truncated prose line should still exist');
+  assert.ok(proseLine.length <= 202, `prose line should be <= 202 chars (# + 200), got ${proseLine.length}`);
+  assert.match(proseLine, /\.\.\.$/, 'should end with ellipsis');
+});
+
+test('anonymizeFlowYaml: throws ExportError when topSection lacks appId line', async () => {
+  // Codex review B (HIGH conf): the only legitimate hard-fail is "no
+  // appId: at all". Surface a clear error rather than silently dropping
+  // the flow or producing a malformed export.
+  const { anonymizeFlowYaml } = await import(MOD_PATH);
+  const input = [
+    '# orphan comment only',
+    '---',
+    '# id: foo',
+    '- launchApp',
+  ].join('\n');
+  assert.throws(() => anonymizeFlowYaml(input), /missing appId:/);
+});
+
+test('anonymizeFlowYaml: throws when there is no --- separator at all', async () => {
+  const { anonymizeFlowYaml } = await import(MOD_PATH);
+  assert.throws(() => anonymizeFlowYaml('- launchApp\n- tapOn: foo'), /missing.*---|missing appId:/);
+});
+
+// ── restoreFlowYaml ──────────────────────────────────────────────────────
+
+test('restoreFlowYaml: rewrites com.example.<slug> back to the local appId', async () => {
+  const { restoreFlowYaml } = await import(MOD_PATH);
+  const input = [
+    'appId: com.example.rndevagent-testapp',
+    '---',
+    '# id: foo',
+    '# status: active',
+    '- launchApp',
+  ].join('\n');
+  const out = restoreFlowYaml(input, 'com.myorg.actualapp');
+  assert.match(out, /^appId: com\.myorg\.actualapp$/m);
+  // M7 header preserved
+  assert.match(out, /^# id: foo$/m);
+});
+
+test('restoreFlowYaml: forces status: active to status: experimental in M7 header', async () => {
+  // Issue acceptance: "Force imported actions to status: experimental
+  // until first clean replay locally"
+  const { restoreFlowYaml } = await import(MOD_PATH);
+  const input = [
+    'appId: com.example.foo',
+    '---',
+    '# id: foo',
+    '# status: active',
+    '- launchApp',
+  ].join('\n');
+  const out = restoreFlowYaml(input, 'com.myorg.app');
+  assert.match(out, /^#\s*status:\s*experimental$/m);
+  assert.doesNotMatch(out, /^#\s*status:\s*active$/m);
+});
+
+test('restoreFlowYaml: leaves status: experimental untouched', async () => {
+  const { restoreFlowYaml } = await import(MOD_PATH);
+  const input = [
+    'appId: com.example.foo',
+    '---',
+    '# id: foo',
+    '# status: experimental',
+    '- launchApp',
+  ].join('\n');
+  const out = restoreFlowYaml(input, 'com.myorg.app');
+  assert.match(out, /^#\s*status:\s*experimental$/m);
+});
+
+test('restoreFlowYaml: prepends placeholder manifest when ${VAR} usages exist', async () => {
+  // Codex review A (HIGH conf): prepend a "# placeholders: ..." comment
+  // above the M7 header rather than suffix with .needs-review.yaml.
+  // Visible, doesn't lie about flow status, grep-able.
+  const { restoreFlowYaml } = await import(MOD_PATH);
+  const input = [
+    'appId: com.example.foo',
+    '---',
+    '# id: foo',
+    '- launchApp',
+    '- inputText: ${TITLE}',
+    '- inputText: ${DESC}',
+    '- tapOn: { id: ${TITLE} }',
+  ].join('\n');
+  const out = restoreFlowYaml(input, 'com.myorg.app');
+  const placeholderLine = out.split('\n').find(l => l.startsWith('# placeholders:'));
+  assert.ok(placeholderLine, 'should prepend a # placeholders: comment');
+  assert.match(placeholderLine, /TITLE/);
+  assert.match(placeholderLine, /DESC/);
+  // Dedup: TITLE should appear only once in the manifest line
+  const titleCount = (placeholderLine.match(/TITLE/g) || []).length;
+  assert.equal(titleCount, 1, 'placeholders should be deduped');
+});
+
+test('restoreFlowYaml: deduplicates existing # placeholders: line on re-import (round-trip idempotence)', async () => {
+  // Multi-review regression (Codex 92 + Gemini 95): a flow already
+  // carrying a "# placeholders:" line from a prior import must NOT get
+  // a second one stacked above. After N round-trips there should still
+  // be exactly ONE manifest line.
+  const { restoreFlowYaml } = await import(MOD_PATH);
+  let yaml = [
+    'appId: com.example.foo',
+    '---',
+    '# placeholders: TITLE — supply via -e KEY=VALUE on replay',
+    '# id: foo',
+    '# status: experimental',
+    '- inputText: ${TITLE}',
+  ].join('\n');
+  yaml = restoreFlowYaml(yaml, 'com.myorg.app');
+  yaml = restoreFlowYaml(yaml, 'com.myorg.app');
+  yaml = restoreFlowYaml(yaml, 'com.myorg.app');
+  const manifestLines = yaml.split('\n').filter(l => /^#\s*placeholders:/i.test(l));
+  assert.equal(manifestLines.length, 1, 'should have exactly one manifest line after 3 imports');
+});
+
+test('anonymizeFlowYaml: strips # placeholders: line so the bundle never carries it (defense)', async () => {
+  // Bundle round-trip A→B→C must not accumulate manifests across
+  // machines. The manifest is a local-import annotation — the bundle
+  // itself should be clean.
+  const { anonymizeFlowYaml } = await import(MOD_PATH);
+  const input = [
+    'appId: com.foo.bar',
+    '---',
+    '# placeholders: TITLE — supply via -e KEY=VALUE on replay',
+    '# id: foo',
+    '- inputText: ${TITLE}',
+  ].join('\n');
+  const out = anonymizeFlowYaml(input);
+  assert.doesNotMatch(out, /^#\s*placeholders:/m);
+});
+
+test('restoreFlowYaml: no placeholder manifest when ${VAR} usages are absent', async () => {
+  const { restoreFlowYaml } = await import(MOD_PATH);
+  const input = [
+    'appId: com.example.foo',
+    '---',
+    '# id: foo',
+    '- launchApp',
+    '- tapOn: { id: "static-id" }',
+  ].join('\n');
+  const out = restoreFlowYaml(input, 'com.myorg.app');
+  assert.doesNotMatch(out, /^# placeholders:/m);
+});
+
+// ── extractActionId ──────────────────────────────────────────────────────
+
+test('extractActionId: reads "# id: <name>" from the M7 header', async () => {
+  const { extractActionId } = await import(MOD_PATH);
+  assert.equal(extractActionId('appId: x\n---\n# id: wizard-create-task\n- launchApp'), 'wizard-create-task');
+  assert.equal(extractActionId('appId: x\n---\n#id:trim-test\n- launchApp'), 'trim-test');
+  assert.equal(extractActionId('appId: x\n---\n# intent: missing id\n- launchApp'), null);
+});
+
+// ── extractPlaceholders ──────────────────────────────────────────────────
+
+test('extractPlaceholders: returns sorted dedup placeholder names', async () => {
+  const { extractPlaceholders } = await import(MOD_PATH);
+  const yaml = [
+    'appId: com.foo.x',
+    '---',
+    '- inputText: ${TITLE}',
+    '- inputText: ${DESC}',
+    '- inputText: ${TITLE}',
+    '- assertVisible: ${PRIORITY}',
+  ].join('\n');
+  assert.deepEqual(extractPlaceholders(yaml), ['DESC', 'PRIORITY', 'TITLE']);
+});
+
+test('extractPlaceholders: returns empty array when no placeholders are present', async () => {
+  const { extractPlaceholders } = await import(MOD_PATH);
+  assert.deepEqual(extractPlaceholders('appId: x\n---\n- launchApp'), []);
+});
+
+test('extractPlaceholders: ignores lower-case ${var} and shell-style $VAR (Maestro uses ${UPPER})', async () => {
+  // The Maestro convention is uppercase env vars passed via `-e KEY=value`.
+  // Lower-case interpolations are uncommon in flows; we match the
+  // documented pattern only.
+  const { extractPlaceholders } = await import(MOD_PATH);
+  const yaml = [
+    'appId: com.foo.x',
+    '---',
+    '- inputText: ${TITLE}',
+    '- inputText: ${lowercase}',
+    '- inputText: $BARE',
+  ].join('\n');
+  assert.deepEqual(extractPlaceholders(yaml), ['TITLE']);
+});
+
+// ── anonymizeSkeleton / restoreSkeleton ─────────────────────────────────
+
+test('anonymizeSkeleton: rewrites appId field, preserves screens map', async () => {
+  const { anonymizeSkeleton } = await import(MOD_PATH);
+  const input = [
+    'schemaVersion: 1',
+    'appId: com.rndevagent.testapp',
+    'generatedFrom: "session 2026-04-29"',
+    'screens:',
+    '  home:',
+    '    welcome-title: home-welcome',
+    '    search-button: home-search-btn',
+  ].join('\n');
+  const out = anonymizeSkeleton(input);
+  assert.match(out, /^appId: com\.example\.rndevagent-testapp$/m);
+  // Screens block preserved verbatim
+  assert.match(out, /welcome-title: home-welcome/);
+  assert.match(out, /search-button: home-search-btn/);
+});
+
+test('restoreSkeleton: rewrites appId back to local value', async () => {
+  const { restoreSkeleton } = await import(MOD_PATH);
+  const input = [
+    'schemaVersion: 1',
+    'appId: com.example.foo-bar',
+    'screens:',
+    '  home:',
+    '    welcome: home-welcome',
+  ].join('\n');
+  const out = restoreSkeleton(input, 'com.myorg.app');
+  assert.match(out, /^appId: com\.myorg\.app$/m);
+});
+
+test('anonymizeSkeleton: throws when appId is missing entirely', async () => {
+  const { anonymizeSkeleton } = await import(MOD_PATH);
+  assert.throws(() => anonymizeSkeleton('schemaVersion: 1\nscreens: {}'), /missing appId/);
+});

--- a/scripts/cdp-bridge/test/unit/gh-106-sharing-flows.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-106-sharing-flows.test.js
@@ -1,0 +1,331 @@
+// GH #106: integration tests for the flow + skeleton bundling path
+// through sharing.ts. Uses real temp dirs so the readdirSync /
+// writeFileSync I/O is exercised end-to-end. Verifies:
+//   - export walks .rn-agent/actions/ and includes flows by default
+//   - --no-flows / --no-skeleton opt-outs work
+//   - import writes flows back, rewriting appId to the local value
+//   - conflicting flow ids are suffixed `.imported.yaml`
+//   - skeleton bundling + restore works end-to-end
+//   - missing project root cleanly skips the flow bundling (no throw)
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const MOD_PATH = '../../dist/experience/sharing.js';
+
+function makeWorkspace(opts = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'gh106-'));
+  const actionsDir = join(root, '.rn-agent', 'actions');
+  mkdirSync(actionsDir, { recursive: true });
+  if (opts.appJson) {
+    writeFileSync(join(root, 'app.json'), JSON.stringify(opts.appJson), 'utf-8');
+  }
+  // Plausible package.json so findProjectRoot is happy if pointed here.
+  writeFileSync(join(root, 'package.json'), JSON.stringify({
+    name: 'temp-test-app',
+    dependencies: { 'react-native': '0.79.0' },
+  }), 'utf-8');
+  for (const [name, contents] of Object.entries(opts.flows ?? {})) {
+    writeFileSync(join(actionsDir, name), contents, 'utf-8');
+  }
+  if (opts.skeleton !== undefined) {
+    writeFileSync(join(root, '.rn-agent', 'skeleton.yaml'), opts.skeleton, 'utf-8');
+  }
+  return root;
+}
+
+function makeFlow(id, appId = 'com.foo.bar', extra = '') {
+  return [
+    `appId: ${appId}`,
+    '---',
+    `# id: ${id}`,
+    `# intent: do a thing`,
+    `# status: active`,
+    ...(extra ? [extra] : []),
+    '- launchApp',
+    '- tapOn:',
+    '    id: "foo-btn"',
+  ].join('\n');
+}
+
+function makeSkeleton(appId = 'com.foo.bar') {
+  return [
+    'schemaVersion: 1',
+    `appId: ${appId}`,
+    'screens:',
+    '  home:',
+    '    welcome: home-welcome',
+  ].join('\n');
+}
+
+test('exportExperience: bundles flows + skeleton by default', async () => {
+  const { exportExperience } = await import(MOD_PATH);
+  const root = makeWorkspace({
+    appJson: { expo: { ios: { bundleIdentifier: 'com.foo.bar' } } },
+    flows: {
+      'alpha.yaml': makeFlow('alpha'),
+      'beta.yaml': makeFlow('beta', 'com.foo.bar', '- inputText: ${TITLE}'),
+    },
+    skeleton: makeSkeleton(),
+  });
+  try {
+    const { bundle } = exportExperience({ projectRoot: root });
+    assert.ok(Array.isArray(bundle.flows), 'flows array should be present');
+    assert.equal(bundle.flows.length, 2);
+    const ids = bundle.flows.map(f => f.id).sort();
+    assert.deepEqual(ids, ['alpha', 'beta']);
+    // Anonymized appId in each
+    for (const f of bundle.flows) {
+      assert.match(f.yaml, /^appId: com\.example\.foo-bar$/m);
+      // Body preserved verbatim — testID still there
+      assert.match(f.yaml, /id: "foo-btn"/);
+    }
+    assert.ok(bundle.skeleton, 'skeleton present');
+    assert.match(bundle.skeleton.yaml, /^appId: com\.example\.foo-bar$/m);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('exportExperience: --no-flows opts out of flow bundling', async () => {
+  const { exportExperience } = await import(MOD_PATH);
+  const root = makeWorkspace({
+    appJson: { expo: { ios: { bundleIdentifier: 'com.foo.bar' } } },
+    flows: { 'alpha.yaml': makeFlow('alpha') },
+    skeleton: makeSkeleton(),
+  });
+  try {
+    const { bundle } = exportExperience({ projectRoot: root, flows: false });
+    assert.equal(bundle.flows, undefined);
+    assert.ok(bundle.skeleton, 'skeleton still bundled');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('exportExperience: --no-skeleton opts out of skeleton bundling', async () => {
+  const { exportExperience } = await import(MOD_PATH);
+  const root = makeWorkspace({
+    appJson: { expo: { ios: { bundleIdentifier: 'com.foo.bar' } } },
+    flows: { 'alpha.yaml': makeFlow('alpha') },
+    skeleton: makeSkeleton(),
+  });
+  try {
+    const { bundle } = exportExperience({ projectRoot: root, skeleton: false });
+    assert.ok(Array.isArray(bundle.flows));
+    assert.equal(bundle.skeleton, undefined);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('exportExperience: missing project root cleanly skips flow bundling', async () => {
+  const { exportExperience } = await import(MOD_PATH);
+  // projectRoot: null means "no rooted project found"
+  const { bundle } = exportExperience({ projectRoot: null });
+  assert.equal(bundle.flows, undefined);
+  assert.equal(bundle.skeleton, undefined);
+});
+
+test('exportExperience: skips malformed flow files (one bad file does not kill the export)', async () => {
+  const { exportExperience } = await import(MOD_PATH);
+  const root = makeWorkspace({
+    flows: {
+      'good.yaml': makeFlow('good'),
+      'bad.yaml': '- this has no appId line\n- launchApp',
+    },
+  });
+  try {
+    const { bundle } = exportExperience({ projectRoot: root });
+    assert.equal(bundle.flows.length, 1);
+    assert.equal(bundle.flows[0].id, 'good');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('importExperience: writes flows to .rn-agent/actions/, rewrites appId to local', async () => {
+  const { exportExperience, importExperience } = await import(MOD_PATH);
+  const sourceRoot = makeWorkspace({
+    appJson: { expo: { ios: { bundleIdentifier: 'com.original.app' } } },
+    flows: { 'alpha.yaml': makeFlow('alpha', 'com.original.app') },
+  });
+  const targetRoot = makeWorkspace({
+    appJson: { expo: { ios: { bundleIdentifier: 'com.target.testapp' } } },
+  });
+  try {
+    const { path: bundlePath } = exportExperience({ projectRoot: sourceRoot, skeleton: false });
+    const result = importExperience(bundlePath, { projectRoot: targetRoot });
+    assert.equal(result.flows_imported, 1);
+    const imported = readFileSync(join(targetRoot, '.rn-agent', 'actions', 'alpha.yaml'), 'utf-8');
+    // appId rewritten to TARGET's bundleId
+    assert.match(imported, /^appId: com\.target\.testapp$/m);
+    // status forced to experimental
+    assert.match(imported, /^#\s*status:\s*experimental$/m);
+    // Body preserved
+    assert.match(imported, /id: "foo-btn"/);
+  } finally {
+    rmSync(sourceRoot, { recursive: true, force: true });
+    rmSync(targetRoot, { recursive: true, force: true });
+  }
+});
+
+test('importExperience: conflicting flow id lands at <id>.imported.yaml', async () => {
+  const { exportExperience, importExperience } = await import(MOD_PATH);
+  const sourceRoot = makeWorkspace({
+    flows: { 'alpha.yaml': makeFlow('alpha', 'com.source.app') },
+  });
+  // Pre-populate target with an existing alpha.yaml
+  const targetRoot = makeWorkspace({
+    appJson: { expo: { ios: { bundleIdentifier: 'com.target.app' } } },
+    flows: { 'alpha.yaml': makeFlow('alpha', 'com.target.app') },
+  });
+  try {
+    const { path: bundlePath } = exportExperience({ projectRoot: sourceRoot, skeleton: false });
+    const result = importExperience(bundlePath, { projectRoot: targetRoot });
+    assert.equal(result.flows_imported, 1);
+    assert.deepEqual(result.flows_renamed, ['alpha.imported.yaml']);
+    // Original alpha.yaml unchanged
+    const original = readFileSync(join(targetRoot, '.rn-agent', 'actions', 'alpha.yaml'), 'utf-8');
+    assert.match(original, /^appId: com\.target\.app$/m); // unchanged
+    // Imported variant exists side-by-side
+    const importedPath = join(targetRoot, '.rn-agent', 'actions', 'alpha.imported.yaml');
+    assert.ok(existsSync(importedPath));
+    const imported = readFileSync(importedPath, 'utf-8');
+    assert.match(imported, /^appId: com\.target\.app$/m);
+  } finally {
+    rmSync(sourceRoot, { recursive: true, force: true });
+    rmSync(targetRoot, { recursive: true, force: true });
+  }
+});
+
+test('importExperience: second collision lands at <id>.imported.2.yaml (no silent overwrite)', async () => {
+  // Gemini multi-review (conf 90): when both <id>.yaml AND
+  // <id>.imported.yaml already exist, the next import MUST not clobber
+  // the first imported variant — the user may be mid-merge on it. Use a
+  // numbered suffix instead.
+  const { exportExperience, importExperience } = await import(MOD_PATH);
+  const sourceRoot = makeWorkspace({
+    flows: { 'alpha.yaml': makeFlow('alpha', 'com.source.app') },
+  });
+  const targetRoot = makeWorkspace({
+    appJson: { expo: { ios: { bundleIdentifier: 'com.target.app' } } },
+    flows: {
+      'alpha.yaml': makeFlow('alpha', 'com.target.app', '# version: original'),
+      'alpha.imported.yaml': makeFlow('alpha', 'com.target.app', '# version: first-import-being-merged'),
+    },
+  });
+  try {
+    const { path: bundlePath } = exportExperience({ projectRoot: sourceRoot, skeleton: false });
+    const result = importExperience(bundlePath, { projectRoot: targetRoot });
+    assert.equal(result.flows_imported, 1);
+    assert.deepEqual(result.flows_renamed, ['alpha.imported.2.yaml']);
+    // Original alpha.imported.yaml UNCHANGED (the merge-in-progress)
+    const firstImport = readFileSync(join(targetRoot, '.rn-agent', 'actions', 'alpha.imported.yaml'), 'utf-8');
+    assert.match(firstImport, /# version: first-import-being-merged/);
+    // New variant exists at the numbered path
+    const secondImport = readFileSync(join(targetRoot, '.rn-agent', 'actions', 'alpha.imported.2.yaml'), 'utf-8');
+    assert.match(secondImport, /^appId: com\.target\.app$/m);
+  } finally {
+    rmSync(sourceRoot, { recursive: true, force: true });
+    rmSync(targetRoot, { recursive: true, force: true });
+  }
+});
+
+test('importExperience: skeleton written to .rn-agent/skeleton.yaml with rewritten appId', async () => {
+  const { exportExperience, importExperience } = await import(MOD_PATH);
+  const sourceRoot = makeWorkspace({
+    flows: {},
+    skeleton: makeSkeleton('com.source.app'),
+  });
+  const targetRoot = makeWorkspace({
+    appJson: { expo: { ios: { bundleIdentifier: 'com.target.app' } } },
+  });
+  try {
+    const { path: bundlePath } = exportExperience({ projectRoot: sourceRoot });
+    const result = importExperience(bundlePath, { projectRoot: targetRoot });
+    assert.equal(result.skeleton_imported, true);
+    const imported = readFileSync(join(targetRoot, '.rn-agent', 'skeleton.yaml'), 'utf-8');
+    assert.match(imported, /^appId: com\.target\.app$/m);
+  } finally {
+    rmSync(sourceRoot, { recursive: true, force: true });
+    rmSync(targetRoot, { recursive: true, force: true });
+  }
+});
+
+test('importExperience: --no-flows opts out of flow restoration', async () => {
+  const { exportExperience, importExperience } = await import(MOD_PATH);
+  const sourceRoot = makeWorkspace({
+    flows: { 'alpha.yaml': makeFlow('alpha') },
+  });
+  const targetRoot = makeWorkspace({
+    appJson: { expo: { ios: { bundleIdentifier: 'com.target.app' } } },
+  });
+  try {
+    const { path: bundlePath } = exportExperience({ projectRoot: sourceRoot, skeleton: false });
+    const result = importExperience(bundlePath, { projectRoot: targetRoot, flows: false });
+    assert.equal(result.flows_imported, undefined);
+    assert.ok(!existsSync(join(targetRoot, '.rn-agent', 'actions', 'alpha.yaml')));
+  } finally {
+    rmSync(sourceRoot, { recursive: true, force: true });
+    rmSync(targetRoot, { recursive: true, force: true });
+  }
+});
+
+test('importExperience: target with no app.json falls back to com.example.unknownapp', async () => {
+  // Edge case: target project has no app.json, so readAppId returns null.
+  // Importer should still write the flow with a sentinel appId so the
+  // user can see what landed and edit the appId line.
+  const { exportExperience, importExperience } = await import(MOD_PATH);
+  const sourceRoot = makeWorkspace({
+    flows: { 'alpha.yaml': makeFlow('alpha') },
+  });
+  const targetRoot = makeWorkspace({ /* no appJson */ });
+  try {
+    const { path: bundlePath } = exportExperience({ projectRoot: sourceRoot, skeleton: false });
+    const result = importExperience(bundlePath, { projectRoot: targetRoot });
+    assert.equal(result.flows_imported, 1);
+    const imported = readFileSync(join(targetRoot, '.rn-agent', 'actions', 'alpha.yaml'), 'utf-8');
+    assert.match(imported, /^appId: com\.example\.unknownapp$/m);
+  } finally {
+    rmSync(sourceRoot, { recursive: true, force: true });
+    rmSync(targetRoot, { recursive: true, force: true });
+  }
+});
+
+test('importExperience: malformed bundle flow id is skipped (defense in depth)', async () => {
+  // The export path validates ids, but a hand-crafted/tampered bundle
+  // could carry a malicious id. The writeImportedFlow guard rejects
+  // anything not matching ^[A-Za-z0-9_-]+$.
+  const { importExperience } = await import(MOD_PATH);
+  const bundlesDir = mkdtempSync(join(tmpdir(), 'gh106-bundle-'));
+  const targetRoot = makeWorkspace({
+    appJson: { expo: { ios: { bundleIdentifier: 'com.target.app' } } },
+  });
+  const bundlePath = join(bundlesDir, 'bad.yaml');
+  // Hand-craft a bundle with a path-traversal id
+  const bundle = {
+    version: 1,
+    exported_at: '2026-04-01T00:00:00Z',
+    env: {},
+    heuristics: [],
+    failure_stats: [],
+    flows: [{
+      id: '../../../etc/passwd',
+      yaml: makeFlow('safe-id', 'com.example.foo'),
+    }],
+  };
+  const { stringify } = await import('yaml');
+  writeFileSync(bundlePath, stringify(bundle), 'utf-8');
+  try {
+    const result = importExperience(bundlePath, { projectRoot: targetRoot });
+    assert.equal(result.flows_imported ?? 0, 0);
+    // No file written under any traversal-like path
+    assert.ok(!existsSync(join(targetRoot, '.rn-agent', 'actions', '..', '..', '..', 'etc', 'passwd')));
+  } finally {
+    rmSync(bundlesDir, { recursive: true, force: true });
+    rmSync(targetRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #106

## Summary

The `rn-agent-export` / `rn-agent-import` command docs have advertised flow + skeleton bundling since D1204, but the underlying script handled only heuristics + failure stats. A teammate sharing the bundle got the muscle memory metadata but not the actual reusable actions that ARE the L3 corpus. This PR ships the missing piece.

## What's in the diff

- **New `src/experience/flow-bundle.ts`** — pure anonymize/restore helpers (no I/O). `anonymizeFlowYaml` rewrites `appId:` to `com.example.<slug>`, truncates author-prose comments above the M7 header to 200 chars, preserves M7 fields verbatim. `restoreFlowYaml` rewrites back to the target's local `appId`, forces `status: experimental`, and prepends `# placeholders: VAR1, VAR2 — supply via -e KEY=VALUE on replay` when the body contains `${VAR}` placeholders. Same anonymize/restore for `skeleton.yaml`.
- **Extended `src/experience/sharing.ts`** — `ExportOptions` / `ImportOptions` with `flows?: boolean`, `skeleton?: boolean`, `projectRoot?: string | null`. Export walks `<projectRoot>/.rn-agent/actions/*.yaml`, anonymizes each, packs into `bundle.flows[]`. Import writes restored flows back, rewriting appId via `project-config.readAppId`, suffixing with `.imported.yaml` on conflict (then `.imported.2.yaml`, etc. on further collisions), and forcing `status: experimental`.
- **Sidecars are intentionally not bundled** — `runHistory` / `repairHistory` / `stats` are by definition per-developer state; the importer's `loadOrInitSidecar` seeds a fresh sidecar on first replay.
- **Defense in depth**: import-side flow id re-validated against `^[A-Za-z0-9_-]+$` so a tampered bundle can't escape `.rn-agent/actions/` via a path-traversal id.

## Codex pre-implementation review (2 HIGH-conf design calls, both adopted)

- **A: `${VAR}` placeholders** → prepend a `# placeholders: ...` comment above the M7 header rather than suffix the flow with `.needs-review.yaml`. The importer has no oracle for "known variables" (Maestro takes them via `-e` at replay time), so the literal spec interpretation would punish correctly-authored flows. Grep-able, doesn't lie about flow status.
- **B: `appId:` rewrite** is line-wise, preserving multi-line top sections (a `# shared across envs` comment above `appId:` is legitimate per `saveAction`'s topSection contract). Hard-fail only when zero `appId:` lines exist; warn on duplicates (Maestro itself honors the first).

## Multi-review caught two HIGH-conf bugs, both fixed

- **Placeholder manifest accumulation on round-trips** (Codex 92 + Gemini 95, reproduced empirically by both). A flow that already carries a `# placeholders:` line from a prior import would get a SECOND one prepended on re-import. After 3 round-trips: 3 identical manifest lines. Fixed: strip any existing manifest in BOTH `anonymizeFlowYaml` (so bundle never carries it) AND `restoreFlowYaml` (so re-imports stay idempotent).
- **Second-collision silent overwrite** (Gemini 90). First collision wrote to `<id>.imported.yaml`. Second collision: `writeFileSync` clobbered the prior imported variant — silent data loss for a user mid-merge. Fixed: numbered suffix climb (`.imported.2.yaml`, `.imported.3.yaml`, ...) up to a sane cap of 100 before failing loudly.

## Lower-confidence findings noted but not addressed

- Gemini ~60: `findProjectRoot()` returns symlinked vs canonicalized paths on macOS — could double-log the "loaded config" line. Functionally benign; would need `realpathSync`. Not worth the dep for this PR.
- Codex ~55: `writeImportedSkeleton` doesn't `try/catch` around `restoreSkeleton` (unlike `writeImportedFlow`). Malformed skeleton in a bundle would throw out of the import loop after flows were already written. Low likelihood; bundles are produced by our own exporter.

## Test plan

- [x] `npm test` from `scripts/cdp-bridge/`: 1312 → 1344 passing (+32 new: 18 pure helpers + 11 integration + 3 regression).
- [x] `npm run build`: clean TypeScript compile.
- [x] Pre-commit `sync-versions.sh`: plugin.json + marketplace.json + cdp-bridge/package.json all at 0.44.38 / 0.38.33.
- [x] Defense-in-depth path-traversal test verifies a hand-crafted bundle with id `../../../etc/passwd` is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)