### PR TITLE
fix(gh-110): one-way fuse for _setRunAgentDeviceForTest test seam

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.36",
+      "version": "0.44.37",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.36",
+  "version": "0.44.37",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.44.37] — 2026-05-13
+
+### Hardened (GH #110 — agent-device test seam fuse)
+
+- **`_setRunAgentDeviceForTest` is now one-way fused.** Once any production
+  `runAgentDevice` call has dispatched in this process, attempting to install
+  a new override throws with `blown fuse — a production runAgentDevice call
+  (cliArgs[0]="...") already dispatched in this process. ... (GH #110
+  hardening)`. The fuse fires BEFORE any tier selection (Codex review
+  conf 90), so a production call that throws downstream still seals the
+  seam.
+- **No reset escape hatch.** A reset seam would be functionally equivalent
+  to no fuse — any code that could call reset is the same code that could
+  leak the override (Codex review conf 90). Tests that genuinely need both
+  production and override paths should use Node 22's
+  `node --test --test-isolation=process` to get a fresh worker per file.
+- **Throw, not no-op** (Codex review conf 95). Silent no-op would let a
+  forgotten `afterEach(() => _setRunAgentDeviceForTest(null))` route a
+  test through the real `agent-device` CLI, producing `ENOENT` errors that
+  look nothing like a test-seam bug. The fuse error message includes the
+  `cliArgs[0]` that blew it, so post-mortem debugging can identify which
+  production call leaked first — that's the test missing its cleanup.
+- 5 new subprocess-isolated regression tests cover: override is honored
+  pre-fuse; setting null pre-fuse re-arms cleanly; production dispatch
+  blows the fuse before tier completion; error message carries GH #110 +
+  remediation hint; standard afterEach `null` cleanup remains legal.
+  Suite: 1312 → 1317 passing.
+
 ## [0.44.36] — 2026-05-12
 
 ### Fixed (Phase 134.2-followup — device_deeplink url injection)

--- a/scripts/cdp-bridge/dist/agent-device-wrapper.js
+++ b/scripts/cdp-bridge/dist/agent-device-wrapper.js
@@ -435,12 +435,39 @@ function cacheRefMapFromResult(result) {
     catch { /* not a snapshot response — ignore */ }
 }
 let _runAgentDeviceOverrideForTest = null;
+// GH #110: test-seam fuse. Once any production runAgentDevice call has
+// dispatched in this process, refuse to install a new override —
+// makes test-pollution-into-prod impossible by construction. The fuse
+// is intentionally one-way: tests that need both production and override
+// paths in the same suite should use `node --test --test-isolation=process`
+// (Node 22 LTS supports this) to get a fresh worker per file. A reset
+// seam here would defeat the entire guarantee — any code that could call
+// the reset is the same code that could leak the override (Codex review
+// conf 90).
+let _testSeamFused = false;
+let _testSeamFuseBlownBy = null;
 export function _setRunAgentDeviceForTest(fn) {
+    if (_testSeamFused) {
+        throw new Error(`_setRunAgentDeviceForTest: blown fuse — a production runAgentDevice ` +
+            `call (cliArgs[0]=${JSON.stringify(_testSeamFuseBlownBy)}) already ` +
+            `dispatched in this process. The test seam cannot be re-armed at runtime ` +
+            `(GH #110 hardening). The most likely cause is a prior test forgot to ` +
+            `clear its override in afterEach. Spawn a fresh Node process — e.g. ` +
+            `\`node --test --test-isolation=process\` — if you genuinely need to ` +
+            `mix production and override paths.`);
+    }
     _runAgentDeviceOverrideForTest = fn;
 }
 export async function runAgentDevice(cliArgs, opts = {}) {
     if (_runAgentDeviceOverrideForTest) {
         return _runAgentDeviceOverrideForTest(cliArgs, opts);
+    }
+    // GH #110: production dispatch reached. Lock the fuse BEFORE any tier
+    // selection so a production call that throws downstream still seals
+    // the seam (Codex review conf 90).
+    if (!_testSeamFused) {
+        _testSeamFused = true;
+        _testSeamFuseBlownBy = cliArgs[0] ?? '<empty>';
     }
     // GH #60: when an explicit platform is requested AND it doesn't match the
     // active session's platform (e.g. user asks for android while an iOS

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.31",
+  "version": "0.38.32",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/agent-device-wrapper.ts
+++ b/scripts/cdp-bridge/src/agent-device-wrapper.ts
@@ -475,7 +475,30 @@ type RunAgentDeviceFn = (
 ) => Promise<ToolResult>;
 let _runAgentDeviceOverrideForTest: RunAgentDeviceFn | null = null;
 
+// GH #110: test-seam fuse. Once any production runAgentDevice call has
+// dispatched in this process, refuse to install a new override —
+// makes test-pollution-into-prod impossible by construction. The fuse
+// is intentionally one-way: tests that need both production and override
+// paths in the same suite should use `node --test --test-isolation=process`
+// (Node 22 LTS supports this) to get a fresh worker per file. A reset
+// seam here would defeat the entire guarantee — any code that could call
+// the reset is the same code that could leak the override (Codex review
+// conf 90).
+let _testSeamFused = false;
+let _testSeamFuseBlownBy: string | null = null;
+
 export function _setRunAgentDeviceForTest(fn: RunAgentDeviceFn | null): void {
+  if (_testSeamFused) {
+    throw new Error(
+      `_setRunAgentDeviceForTest: blown fuse — a production runAgentDevice ` +
+      `call (cliArgs[0]=${JSON.stringify(_testSeamFuseBlownBy)}) already ` +
+      `dispatched in this process. The test seam cannot be re-armed at runtime ` +
+      `(GH #110 hardening). The most likely cause is a prior test forgot to ` +
+      `clear its override in afterEach. Spawn a fresh Node process — e.g. ` +
+      `\`node --test --test-isolation=process\` — if you genuinely need to ` +
+      `mix production and override paths.`,
+    );
+  }
   _runAgentDeviceOverrideForTest = fn;
 }
 
@@ -485,6 +508,13 @@ export async function runAgentDevice(
 ): Promise<ToolResult> {
   if (_runAgentDeviceOverrideForTest) {
     return _runAgentDeviceOverrideForTest(cliArgs, opts);
+  }
+  // GH #110: production dispatch reached. Lock the fuse BEFORE any tier
+  // selection so a production call that throws downstream still seals
+  // the seam (Codex review conf 90).
+  if (!_testSeamFused) {
+    _testSeamFused = true;
+    _testSeamFuseBlownBy = cliArgs[0] ?? '<empty>';
   }
   // GH #60: when an explicit platform is requested AND it doesn't match the
   // active session's platform (e.g. user asks for android while an iOS

--- a/scripts/cdp-bridge/test/unit/gh-110-test-seam-fuse.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-110-test-seam-fuse.test.js
@@ -1,0 +1,131 @@
+// GH #110: regression tests for the agent-device-wrapper test-seam fuse.
+//
+// The fuse is process-global by design (Codex review conf 90/90/95 —
+// adding a reset seam would defeat the guarantee, since any code that
+// could call reset is the same code that could leak the override). Each
+// scenario therefore runs in a freshly-spawned Node subprocess so the
+// fuse state is isolated.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MOD_ABS_PATH = resolve(__dirname, '../../dist/agent-device-wrapper.js');
+
+function runScenario(scenarioCode) {
+  // Use the modern dynamic-import form to avoid CJS/ESM confusion.
+  const wrapped = `
+    (async () => {
+      try {
+        const mod = await import(${JSON.stringify(MOD_ABS_PATH)});
+        ${scenarioCode}
+        console.log('SCENARIO_OK');
+      } catch (e) {
+        console.log('SCENARIO_THREW:' + (e && e.message ? e.message : String(e)));
+      }
+    })().catch(e => { console.log('SCENARIO_REJECTED:' + (e && e.message ? e.message : String(e))); process.exit(1); });
+  `;
+  const result = spawnSync('node', ['--input-type=module', '-e', wrapped], {
+    encoding: 'utf-8',
+    timeout: 20_000,
+  });
+  return { stdout: result.stdout ?? '', stderr: result.stderr ?? '', status: result.status };
+}
+
+test('fuse: override fn is honored when set before any production dispatch', () => {
+  const { stdout } = runScenario(`
+    let captured = null;
+    mod._setRunAgentDeviceForTest(async (args, opts) => {
+      captured = { args, opts };
+      return { content: [{ type: 'text', text: '{"ok":true,"data":"stubbed"}' }] };
+    });
+    const r = await mod.runAgentDevice(['snapshot'], {});
+    if (!r.content[0].text.includes('stubbed')) throw new Error('override not invoked');
+    if (captured.args[0] !== 'snapshot') throw new Error('args not threaded through');
+  `);
+  assert.match(stdout, /SCENARIO_OK/, `expected SCENARIO_OK, got: ${stdout}`);
+});
+
+test('fuse: setting override to null re-enables production tier as long as fuse has not blown', () => {
+  const { stdout } = runScenario(`
+    let called = 0;
+    mod._setRunAgentDeviceForTest(async () => { called++; return { content: [{ type: 'text', text: '{"ok":true}' }] }; });
+    await mod.runAgentDevice(['snapshot'], {});
+    if (called !== 1) throw new Error('override not invoked on first call');
+
+    // Set back to null — fuse has NOT blown (no production dispatch occurred).
+    mod._setRunAgentDeviceForTest(null);
+    // Subsequent installs should still work
+    let called2 = 0;
+    mod._setRunAgentDeviceForTest(async () => { called2++; return { content: [{ type: 'text', text: '{"ok":true}' }] }; });
+    await mod.runAgentDevice(['tap'], {});
+    if (called2 !== 1) throw new Error('second override not invoked');
+  `);
+  assert.match(stdout, /SCENARIO_OK/, `expected SCENARIO_OK, got: ${stdout}`);
+});
+
+test('fuse: a production runAgentDevice call (no override) blows the fuse', () => {
+  // The production tiers will fail (no booted device / fast-runner) but
+  // the fuse must still be sealed regardless of the dispatch outcome.
+  const { stdout } = runScenario(`
+    // Direct call with no override installed → production dispatch
+    // begins → fuse blows immediately (before any tier returns).
+    let prodThrew = false;
+    try {
+      await mod.runAgentDevice(['list-devices'], { skipSession: true });
+    } catch {
+      prodThrew = true;
+    }
+    // Whether the production tier returned cleanly or threw, the fuse
+    // is locked. Attempting to install an override now must throw.
+    let fuseThrew = false;
+    try {
+      mod._setRunAgentDeviceForTest(async () => ({ content: [{ type: 'text', text: '{"ok":true}' }] }));
+    } catch (e) {
+      fuseThrew = true;
+      if (!String(e.message).includes('blown fuse')) throw new Error('wrong error: ' + e.message);
+      if (!String(e.message).includes('list-devices')) throw new Error('error should mention the trigger cliArgs[0]');
+    }
+    if (!fuseThrew) throw new Error('expected fuse to throw on re-arm');
+  `);
+  assert.match(stdout, /SCENARIO_OK/, `expected SCENARIO_OK, got: ${stdout}`);
+});
+
+test('fuse: error message includes GH #110 reference and remediation hint', () => {
+  const { stdout, stderr, status } = runScenario(`
+    // Production tier may throw (no booted device in test env) — that's
+    // fine, the fuse must still seal. Use list-devices because it dodges
+    // the slow fast-runner path that snapshot would take.
+    try { await mod.runAgentDevice(['list-devices'], { skipSession: true }); } catch {}
+    let threw = false;
+    try {
+      mod._setRunAgentDeviceForTest(null);
+    } catch (e) {
+      threw = true;
+      if (!String(e.message).includes('GH #110')) throw new Error('error must reference GH #110');
+      if (!String(e.message).includes('--test-isolation=process')) throw new Error('error must include remediation hint');
+      console.log('GOOD_ERROR');
+    }
+    if (!threw) throw new Error('expected fuse to throw on re-arm');
+  `);
+  assert.match(stdout, /GOOD_ERROR[\s\S]*SCENARIO_OK/, `expected GOOD_ERROR then SCENARIO_OK\nstdout: ${stdout}\nstderr: ${stderr}\nstatus: ${status}`);
+});
+
+test('fuse: setting null to clear override does not block when fuse has NOT blown', () => {
+  // Edge: install an override, run it, then clear it back to null
+  // BEFORE any production dispatch. This is the normal afterEach
+  // cleanup case — must not throw.
+  const { stdout } = runScenario(`
+    mod._setRunAgentDeviceForTest(async () => ({ content: [{ type: 'text', text: '{"ok":true}' }] }));
+    await mod.runAgentDevice(['snapshot'], {});
+    // Standard cleanup — must not throw because no production dispatch happened.
+    mod._setRunAgentDeviceForTest(null);
+    // Installing a new override after clean cleanup must still work.
+    mod._setRunAgentDeviceForTest(async () => ({ content: [{ type: 'text', text: '{"ok":true,"data":"second"}' }] }));
+    const r = await mod.runAgentDevice(['snapshot'], {});
+    if (!r.content[0].text.includes('second')) throw new Error('second override not active');
+  `);
+  assert.match(stdout, /SCENARIO_OK/, `expected SCENARIO_OK, got: ${stdout}`);
+});


### PR DESCRIPTION
Closes #110

## Summary

PR #109 introduced `_setRunAgentDeviceForTest` so handler integration tests could stub `runAgentDevice`, but the unguarded seam let a forgotten `afterEach` poison subsequent tests in the same Node process — or worse, let a downstream caller silently redirect every production `runAgentDevice` call. Both Gemini and Codex flagged this at conf 80 in PR #109's multi-LLM review.

## What's in the diff

Once any production `runAgentDevice` call has dispatched in the process, a module-level `_testSeamFused` boolean locks to `true`. The fuse fires BEFORE any tier selection (fast-runner / daemon / CLI), so a production call that throws downstream still seals the seam. Subsequent `_setRunAgentDeviceForTest()` calls throw with `blown fuse — a production runAgentDevice call (cliArgs[0]="snapshot") already dispatched in this process. ... (GH #110 hardening)`. Includes the `cliArgs[0]` of the trigger so post-mortem debugging can identify which production call leaked first.

## Codex pre-implementation review (3 HIGH-conf calls, all adopted)

- **A (conf 90):** Fire fuse at dispatch entry, not on success. A production call that throws inside `tryFastRunner` / daemon / CLI fallback must still seal the seam.
- **B (conf 90):** No `_resetFuseForTests()` escape hatch. Any code that could call reset is the same code that could leak the override. Tests needing both production AND override paths in the same suite use `node --test --test-isolation=process` (Node 22 LTS supports this).
- **C (conf 95):** Throw on re-arm, not silent no-op. A silent no-op would route a test through the real `agent-device` CLI, producing ENOENT errors on CI that look nothing like a test-seam bug.

## Multi-review (Gemini + Codex on the diff)

Zero HIGH-conf defects flagged. Codex pointed out two scope-extension targets — `dev-client-picker.ts:10` and `device-list.ts:11` share the same vulnerability shape (both expose `_setRunAgentDeviceForTest` + `_resetRunAgentDeviceForTest` swappable module-level fn refs). Filed as a follow-up rather than expanding this PR; keeps the diff bounded to issue #110's stated scope (`agent-device-wrapper.ts`).

## Test plan

- [x] 5 new subprocess-isolated regression tests in `test/unit/gh-110-test-seam-fuse.test.js`. Each scenario runs in a fresh `node -e` subprocess because the fuse is process-global by design.
- [x] Suite: 1312 → 1317 passing.
- [x] `npm run build`: clean TypeScript compile.
- [x] Coverage: override-honored pre-fuse, install→null→re-install pre-fuse, production-blows-fuse-before-tier-completion, error-message-contents (GH #110 + remediation hint), standard `afterEach` `null` cleanup remains legal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)