### PR TITLE
fix(gh-111): unique .tmp suffixes + age-bounded cleanupOrphans

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.36",
+      "version": "0.44.37",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.36",
+  "version": "0.44.37",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.44.37] — 2026-05-13
+
+### Hardened (GH #111 — atomic-writer concurrent pairWrite races)
+
+- **`pairWrite` now uses unique `.tmp.<pid>.<time36>.<rand36>` suffixes** so
+  two concurrent writers against the same action don't share a tmp namespace.
+  Without this, `cleanupOrphans` could `unlinkSync` writer A's in-flight tmp
+  file mid-rename, producing an opaque ENOENT for the user. Gemini flagged
+  the failure mode at conf 82 in the PR #109 multi-LLM review.
+- **`cleanupOrphans` is age-bounded**: scans the target directory for files
+  matching the path prefix and only unlinks orphans older than
+  `ORPHAN_MAX_AGE_MS = 5 minutes`. Concurrent writer's fresh tmp file
+  preserved; crashed process's stale tmp file becomes eligible for sweep
+  after 5 minutes.
+- **New `_readdir` test seam** for deterministic cleanup mocking.
+- 7 new regression tests cover unique-stamp generation, stale-orphan sweep,
+  fresh-orphan preservation, prefix anchoring, missing-dir tolerance, the
+  exported constant value, and round-trip orphan-free state across 5
+  repeated `pairWrite` calls. Three existing tests updated to match the
+  new `.tmp.<stamp>` filename shape. Suite: 1312 → 1319 passing.
+
 ## [0.44.36] — 2026-05-12
 
 ### Fixed (Phase 134.2-followup — device_deeplink url injection)

--- a/scripts/cdp-bridge/dist/domain/atomic-writer.js
+++ b/scripts/cdp-bridge/dist/domain/atomic-writer.js
@@ -34,8 +34,8 @@
 //
 // Test seam: the public API is on a single exported object so tests can
 // `mock.method(atomicWriter, '_writeFile', ...)` to inject failures.
-import { writeFileSync, renameSync, statSync, mkdirSync, existsSync, unlinkSync, } from 'node:fs';
-import { dirname } from 'node:path';
+import { writeFileSync, renameSync, statSync, mkdirSync, existsSync, unlinkSync, readdirSync, } from 'node:fs';
+import { dirname, basename } from 'node:path';
 // Multi-LLM review of PR #109 findings 1+2: `finalMtimeMs = _stat(yaml)`
 // breaks the safety invariant in two scenarios — (a) slow writes where
 // the actual YAML mtime exceeds `projectedMtimeMs` and step 5 happens
@@ -57,6 +57,23 @@ import { dirname } from 'node:path';
  */
 export const FUTURE_MTIME_BUFFER_MS = 1_000;
 /**
+ * GH #111: orphan .tmp files older than this threshold are eligible for
+ * cleanup. Any process that's been alive for 5 minutes hasn't crashed
+ * mid-pairWrite — the orphan must be from a prior crashed run. Concurrent
+ * pairWrite calls don't collide because each call uses a unique stamp,
+ * but a stale orphan from a crashed process would otherwise stick around
+ * forever. 5 minutes is conservative (allows long fsync queues / CI
+ * antivirus stalls).
+ */
+export const ORPHAN_MAX_AGE_MS = 5 * 60 * 1_000;
+/** Generate a unique tmp-file stamp per pairWrite call. Crash-resistant
+ *  and concurrent-safe — two pairWrites for the same action path won't
+ *  collide because each owns its own tmp namespace. */
+function generateTmpStamp() {
+    const rand = Math.random().toString(36).slice(2, 10);
+    return `${process.pid}.${Date.now().toString(36)}.${rand}`;
+}
+/**
  * Atomic write of a (YAML, sidecar) pair using sidecar-first ordering.
  * Returns the resolved paths plus the final on-disk mtime. Throws if any
  * intermediate step fails — caller decides whether to surface the error
@@ -76,8 +93,13 @@ export const FUTURE_MTIME_BUFFER_MS = 1_000;
 function pairWriteImpl(yamlPath, yamlContent, sidecarPath, state) {
     ensureDir(yamlPath);
     ensureDir(sidecarPath);
-    const yamlTmp = `${yamlPath}.tmp`;
-    const sidecarTmp = `${sidecarPath}.tmp`;
+    // GH #111: unique stamp per call so two concurrent pairWrites against
+    // the same action id never share a tmp namespace. Without this, B's
+    // cleanupOrphans could unlink A's in-flight .tmp file and produce an
+    // opaque ENOENT during A's rename.
+    const stamp = generateTmpStamp();
+    const yamlTmp = `${yamlPath}.tmp.${stamp}`;
+    const sidecarTmp = `${sidecarPath}.tmp.${stamp}`;
     // Step 1+2: sidecar with projected future mtime, atomic rename.
     const projectedMtimeMs = Date.now() + FUTURE_MTIME_BUFFER_MS;
     const projectedState = {
@@ -123,21 +145,41 @@ function ensureDir(filePath) {
         atomicWriter._mkdir(dir);
 }
 /**
- * Best-effort cleanup of orphaned `.tmp` files left by a crashed previous
- * call. Called by `pairWrite` before each operation. Idempotent.
+ * Best-effort cleanup of orphaned `.tmp.<stamp>` files left by a crashed
+ * previous call (GH #111). Called by `pairWrite` before each operation.
+ * Idempotent.
  *
- * Routes through `atomicWriter._unlink` / `_exists` so PR #109 review
- * finding (E) — "tests can't simulate mkdir/unlink failures" — is
- * resolved: the seam is now complete across all fs operations the
- * writer performs.
+ * Only removes `.tmp.<stamp>` files matching the target path's prefix
+ * AND older than ORPHAN_MAX_AGE_MS — concurrent writers' fresh tmp files
+ * are untouched. A crashed process's stale tmp file becomes eligible
+ * after 5 minutes, well past any plausible pairWrite duration.
+ *
+ * Routes through `atomicWriter._readdir` / `_statMtimeMs` / `_unlink`
+ * so tests can mock cleanup behavior deterministically.
  */
 function cleanupOrphans(yamlPath, sidecarPath) {
-    for (const orphan of [`${yamlPath}.tmp`, `${sidecarPath}.tmp`]) {
-        if (atomicWriter._exists(orphan)) {
+    const now = Date.now();
+    for (const targetPath of [yamlPath, sidecarPath]) {
+        const dir = dirname(targetPath);
+        const prefix = `${basename(targetPath)}.tmp.`;
+        let entries;
+        try {
+            entries = atomicWriter._readdir(dir);
+        }
+        catch {
+            continue; // dir doesn't exist yet — no orphans possible
+        }
+        for (const entry of entries) {
+            if (!entry.startsWith(prefix))
+                continue;
+            const orphanPath = `${dir}/${entry}`;
             try {
-                atomicWriter._unlink(orphan);
+                const mtimeMs = atomicWriter._statMtimeMs(orphanPath);
+                if (now - mtimeMs < ORPHAN_MAX_AGE_MS)
+                    continue; // fresh — likely a concurrent writer's
+                atomicWriter._unlink(orphanPath);
             }
-            catch { /* ignore */ }
+            catch { /* best-effort */ }
         }
     }
 }
@@ -171,6 +213,10 @@ export const atomicWriter = {
     /** Underlying `fs.unlinkSync(path)`. Used by orphan-cleanup. */
     _unlink(path) {
         unlinkSync(path);
+    },
+    /** Underlying `fs.readdirSync(path)`. Used by GH #111 prefix-scan cleanup. */
+    _readdir(path) {
+        return readdirSync(path);
     },
     /**
      * Atomic pair-write. Cleans up any orphaned `.tmp` files before

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.31",
+  "version": "0.38.32",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/domain/atomic-writer.ts
+++ b/scripts/cdp-bridge/src/domain/atomic-writer.ts
@@ -42,8 +42,9 @@ import {
   mkdirSync,
   existsSync,
   unlinkSync,
+  readdirSync,
 } from 'node:fs';
-import { dirname } from 'node:path';
+import { dirname, basename } from 'node:path';
 import type { ActionRuntimeState } from './reusable-action.js';
 
 // Multi-LLM review of PR #109 findings 1+2: `finalMtimeMs = _stat(yaml)`
@@ -67,6 +68,25 @@ import type { ActionRuntimeState } from './reusable-action.js';
  * 1 second satisfies both with a safe margin.
  */
 export const FUTURE_MTIME_BUFFER_MS = 1_000;
+
+/**
+ * GH #111: orphan .tmp files older than this threshold are eligible for
+ * cleanup. Any process that's been alive for 5 minutes hasn't crashed
+ * mid-pairWrite — the orphan must be from a prior crashed run. Concurrent
+ * pairWrite calls don't collide because each call uses a unique stamp,
+ * but a stale orphan from a crashed process would otherwise stick around
+ * forever. 5 minutes is conservative (allows long fsync queues / CI
+ * antivirus stalls).
+ */
+export const ORPHAN_MAX_AGE_MS = 5 * 60 * 1_000;
+
+/** Generate a unique tmp-file stamp per pairWrite call. Crash-resistant
+ *  and concurrent-safe — two pairWrites for the same action path won't
+ *  collide because each owns its own tmp namespace. */
+function generateTmpStamp(): string {
+  const rand = Math.random().toString(36).slice(2, 10);
+  return `${process.pid}.${Date.now().toString(36)}.${rand}`;
+}
 
 export interface PairWriteResult {
   yamlPath: string;
@@ -103,8 +123,13 @@ function pairWriteImpl(
   ensureDir(yamlPath);
   ensureDir(sidecarPath);
 
-  const yamlTmp = `${yamlPath}.tmp`;
-  const sidecarTmp = `${sidecarPath}.tmp`;
+  // GH #111: unique stamp per call so two concurrent pairWrites against
+  // the same action id never share a tmp namespace. Without this, B's
+  // cleanupOrphans could unlink A's in-flight .tmp file and produce an
+  // opaque ENOENT during A's rename.
+  const stamp = generateTmpStamp();
+  const yamlTmp = `${yamlPath}.tmp.${stamp}`;
+  const sidecarTmp = `${sidecarPath}.tmp.${stamp}`;
 
   // Step 1+2: sidecar with projected future mtime, atomic rename.
   const projectedMtimeMs = Date.now() + FUTURE_MTIME_BUFFER_MS;
@@ -155,18 +180,37 @@ function ensureDir(filePath: string): void {
 }
 
 /**
- * Best-effort cleanup of orphaned `.tmp` files left by a crashed previous
- * call. Called by `pairWrite` before each operation. Idempotent.
+ * Best-effort cleanup of orphaned `.tmp.<stamp>` files left by a crashed
+ * previous call (GH #111). Called by `pairWrite` before each operation.
+ * Idempotent.
  *
- * Routes through `atomicWriter._unlink` / `_exists` so PR #109 review
- * finding (E) — "tests can't simulate mkdir/unlink failures" — is
- * resolved: the seam is now complete across all fs operations the
- * writer performs.
+ * Only removes `.tmp.<stamp>` files matching the target path's prefix
+ * AND older than ORPHAN_MAX_AGE_MS — concurrent writers' fresh tmp files
+ * are untouched. A crashed process's stale tmp file becomes eligible
+ * after 5 minutes, well past any plausible pairWrite duration.
+ *
+ * Routes through `atomicWriter._readdir` / `_statMtimeMs` / `_unlink`
+ * so tests can mock cleanup behavior deterministically.
  */
 function cleanupOrphans(yamlPath: string, sidecarPath: string): void {
-  for (const orphan of [`${yamlPath}.tmp`, `${sidecarPath}.tmp`]) {
-    if (atomicWriter._exists(orphan)) {
-      try { atomicWriter._unlink(orphan); } catch { /* ignore */ }
+  const now = Date.now();
+  for (const targetPath of [yamlPath, sidecarPath]) {
+    const dir = dirname(targetPath);
+    const prefix = `${basename(targetPath)}.tmp.`;
+    let entries: string[];
+    try {
+      entries = atomicWriter._readdir(dir);
+    } catch {
+      continue; // dir doesn't exist yet — no orphans possible
+    }
+    for (const entry of entries) {
+      if (!entry.startsWith(prefix)) continue;
+      const orphanPath = `${dir}/${entry}`;
+      try {
+        const mtimeMs = atomicWriter._statMtimeMs(orphanPath);
+        if (now - mtimeMs < ORPHAN_MAX_AGE_MS) continue; // fresh — likely a concurrent writer's
+        atomicWriter._unlink(orphanPath);
+      } catch { /* best-effort */ }
     }
   }
 }
@@ -201,6 +245,10 @@ export const atomicWriter = {
   /** Underlying `fs.unlinkSync(path)`. Used by orphan-cleanup. */
   _unlink(path: string): void {
     unlinkSync(path);
+  },
+  /** Underlying `fs.readdirSync(path)`. Used by GH #111 prefix-scan cleanup. */
+  _readdir(path: string): string[] {
+    return readdirSync(path);
   },
 
   /**

--- a/scripts/cdp-bridge/test/unit/gh-111-atomic-writer-unique-tmp.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-111-atomic-writer-unique-tmp.test.js
@@ -1,0 +1,174 @@
+// GH #111: regression tests for the atomic-writer unique-tmp-suffix
+// hardening. The fix replaces fixed `.tmp` suffixes with unique
+// `.tmp.<pid>.<base36-time>.<base36-rand>` stamps so two concurrent
+// pairWrite calls against the same action don't unlink each other's
+// in-flight tmp files. cleanupOrphans now scans the dir for matching
+// prefixes and only deletes files older than ORPHAN_MAX_AGE_MS.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readdirSync, existsSync, rmSync, utimesSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const MOD_PATH = '../../dist/domain/atomic-writer.js';
+
+function makeFreshDir() {
+  return mkdtempSync(join(tmpdir(), 'gh111-'));
+}
+
+function makeSidecarState() {
+  return {
+    schemaVersion: 1,
+    revision: 0,
+    updatedAt: new Date().toISOString(),
+    lastSeenMtimeMs: 0,
+    runHistory: [],
+    repairHistory: [],
+    stats: {},
+  };
+}
+
+test('pairWrite uses unique tmp suffixes — two back-to-back calls have different stamps', async () => {
+  const { atomicWriter } = await import(MOD_PATH);
+  const dir = makeFreshDir();
+  try {
+    // Capture every _writeFile path the writer used
+    const observed = [];
+    const realWrite = atomicWriter._writeFile.bind(atomicWriter);
+    atomicWriter._writeFile = (path, content) => {
+      observed.push(path);
+      return realWrite(path, content);
+    };
+    try {
+      const yamlA = join(dir, 'alpha.yaml');
+      const sidecarA = join(dir, 'state', 'alpha.state.json');
+      atomicWriter.pairWrite(yamlA, 'body: a\n', sidecarA, makeSidecarState());
+
+      const yamlB = join(dir, 'beta.yaml');
+      const sidecarB = join(dir, 'state', 'beta.state.json');
+      atomicWriter.pairWrite(yamlB, 'body: b\n', sidecarB, makeSidecarState());
+
+      const yamlTmps = observed.filter(p => /\.yaml\.tmp\./.test(p));
+      // Two pairWrites × 1 YAML tmp each = 2 distinct paths
+      assert.equal(yamlTmps.length, 2, `expected 2 yaml tmp writes; got ${yamlTmps.length}: ${JSON.stringify(yamlTmps)}`);
+      assert.notEqual(yamlTmps[0], yamlTmps[1], 'two pairWrites must use distinct tmp stamps');
+      // Each tmp path should match the .yaml.tmp.<stamp> shape
+      for (const p of yamlTmps) {
+        assert.match(p, /\.yaml\.tmp\.\d+\.[a-z0-9]+\.[a-z0-9]+$/, `tmp path shape unexpected: ${p}`);
+      }
+    } finally {
+      atomicWriter._writeFile = realWrite;
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('cleanupOrphans deletes stale (>5min) orphans matching prefix', async () => {
+  const { atomicWriter, ORPHAN_MAX_AGE_MS } = await import(MOD_PATH);
+  const dir = makeFreshDir();
+  try {
+    const yamlPath = join(dir, 'target.yaml');
+    // Plant a stale orphan with backdated mtime
+    const staleOrphan = `${yamlPath}.tmp.99999.aged.deadbe`;
+    writeFileSync(staleOrphan, 'stale content');
+    const staleMtime = (Date.now() - ORPHAN_MAX_AGE_MS - 60_000) / 1000; // 6 minutes ago
+    utimesSync(staleOrphan, staleMtime, staleMtime);
+    assert.ok(existsSync(staleOrphan));
+
+    // Trigger cleanup by calling pairWrite (cleanupOrphans runs first)
+    const sidecarPath = join(dir, 'state', 'target.state.json');
+    atomicWriter.pairWrite(yamlPath, 'body: real\n', sidecarPath, makeSidecarState());
+
+    assert.ok(!existsSync(staleOrphan), 'stale orphan should be cleaned up');
+    // Final files exist
+    assert.ok(existsSync(yamlPath));
+    assert.ok(existsSync(sidecarPath));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('cleanupOrphans does NOT delete fresh orphans (< 5min) — concurrent writer protection', async () => {
+  const { atomicWriter } = await import(MOD_PATH);
+  const dir = makeFreshDir();
+  try {
+    const yamlPath = join(dir, 'target.yaml');
+    // Plant a fresh orphan simulating a concurrent writer's in-flight tmp
+    const freshOrphan = `${yamlPath}.tmp.55555.fresh.cafe01`;
+    writeFileSync(freshOrphan, 'concurrent-writer-content');
+
+    // Run a second pairWrite on the same target — must NOT touch freshOrphan
+    const sidecarPath = join(dir, 'state', 'target.state.json');
+    atomicWriter.pairWrite(yamlPath, 'body: B\n', sidecarPath, makeSidecarState());
+
+    assert.ok(existsSync(freshOrphan), 'fresh concurrent-writer orphan must be preserved');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('cleanupOrphans does NOT delete non-matching .tmp files in the same dir', async () => {
+  const { atomicWriter, ORPHAN_MAX_AGE_MS } = await import(MOD_PATH);
+  const dir = makeFreshDir();
+  try {
+    const yamlPath = join(dir, 'target.yaml');
+    // Plant a stale .tmp file for a DIFFERENT action — must NOT be touched
+    const unrelated = join(dir, 'other.yaml.tmp.11111.aged.beef02');
+    writeFileSync(unrelated, 'unrelated content');
+    const staleMtime = (Date.now() - ORPHAN_MAX_AGE_MS - 60_000) / 1000;
+    utimesSync(unrelated, staleMtime, staleMtime);
+
+    const sidecarPath = join(dir, 'state', 'target.state.json');
+    atomicWriter.pairWrite(yamlPath, 'body: x\n', sidecarPath, makeSidecarState());
+
+    assert.ok(existsSync(unrelated), 'non-matching prefix must be preserved');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('cleanupOrphans tolerates missing target directory (no throw)', async () => {
+  const { atomicWriter } = await import(MOD_PATH);
+  const dir = makeFreshDir();
+  try {
+    // Target is in a deeply nested dir that doesn't exist yet — pairWrite
+    // must create it via ensureDir and not bail at cleanupOrphans.
+    const yamlPath = join(dir, 'deeper', 'nested', 'target.yaml');
+    const sidecarPath = join(dir, 'deeper', 'state', 'target.state.json');
+    atomicWriter.pairWrite(yamlPath, 'body: nested\n', sidecarPath, makeSidecarState());
+    assert.ok(existsSync(yamlPath));
+    assert.ok(existsSync(sidecarPath));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('ORPHAN_MAX_AGE_MS is exported and is 5 minutes', async () => {
+  const { ORPHAN_MAX_AGE_MS } = await import(MOD_PATH);
+  assert.equal(ORPHAN_MAX_AGE_MS, 5 * 60 * 1000);
+});
+
+test('pairWrite is idempotent under repeated calls without orphan accumulation', async () => {
+  // Each pairWrite produces a fresh stamp, so the dir doesn't accumulate
+  // stamps across normal (non-crashed) runs — each pairWrite's tmp gets
+  // renamed away cleanly. After 5 calls, the dir contains exactly the
+  // YAML + sidecar (no orphans).
+  const { atomicWriter } = await import(MOD_PATH);
+  const dir = makeFreshDir();
+  try {
+    const yamlPath = join(dir, 'iter.yaml');
+    const sidecarPath = join(dir, 'state', 'iter.state.json');
+    for (let i = 0; i < 5; i++) {
+      atomicWriter.pairWrite(yamlPath, `body: iter${i}\n`, sidecarPath, makeSidecarState());
+    }
+    // YAML dir contains only `iter.yaml`
+    const yamlEntries = readdirSync(dir).filter(e => e.startsWith('iter.'));
+    assert.deepEqual(yamlEntries.sort(), ['iter.yaml']);
+    // Sidecar dir contains only `iter.state.json`
+    const sidecarEntries = readdirSync(join(dir, 'state')).filter(e => e.startsWith('iter.'));
+    assert.deepEqual(sidecarEntries.sort(), ['iter.state.json']);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/cdp-bridge/test/unit/repair-action-handler.test.js
+++ b/scripts/cdp-bridge/test/unit/repair-action-handler.test.js
@@ -371,7 +371,8 @@ test('repair-action: when YAML write fails after sidecar succeeds, no false-posi
 
   const realWriteFile = atomicWriter._writeFile.bind(atomicWriter);
   const stub = mock.method(atomicWriter, '_writeFile', (path, content) => {
-    if (path.endsWith('.yaml.tmp')) {
+    // GH #111: tmp suffix is now `.tmp.<stamp>` rather than fixed `.tmp`.
+    if (/\.yaml\.tmp\./.test(path)) {
       throw new Error('SIMULATED_DISK_FULL: yaml write failed');
     }
     return realWriteFile(path, content);

--- a/scripts/cdp-bridge/test/unit/save-as-action-handler.test.js
+++ b/scripts/cdp-bridge/test/unit/save-as-action-handler.test.js
@@ -236,7 +236,8 @@ test('save-as-action: when YAML write fails after sidecar succeeds, no false-pos
   // call returns false.
   const realWriteFile = atomicWriter._writeFile.bind(atomicWriter);
   const stub = mock.method(atomicWriter, '_writeFile', (path, content) => {
-    if (path.endsWith('.yaml.tmp')) {
+    // GH #111: tmp suffix is now `.tmp.<stamp>` rather than fixed `.tmp`.
+    if (/\.yaml\.tmp\./.test(path)) {
       throw new Error('SIMULATED_DISK_FULL: yaml write failed');
     }
     return realWriteFile(path, content);
@@ -311,7 +312,8 @@ test('save-as-action: when sidecar write fails first, nothing is persisted and a
   let failedOnce = false;
   const realWriteFile = atomicWriter._writeFile.bind(atomicWriter);
   const stub = mock.method(atomicWriter, '_writeFile', (path, content) => {
-    if (!failedOnce && path.endsWith('.state.json.tmp')) {
+    // GH #111: tmp suffix is now `.tmp.<stamp>` rather than fixed `.tmp`.
+    if (!failedOnce && /\.state\.json\.tmp\./.test(path)) {
       failedOnce = true;
       throw new Error('SIMULATED_DISK_FULL: sidecar write failed');
     }


### PR DESCRIPTION
Closes #111

## Summary

PR #109's atomic-writer used fixed `.tmp` suffixes. Gemini flagged at conf 82: two concurrent `pairWrite` calls A and B against the same action id could collide — A writes `<yaml>.tmp` → B's `cleanupOrphans` unlinks A's in-flight tmp → A's rename fails with an opaque ENOENT. Currently moot (single-client MCP) but a real risk for any future feature parallelising writes.

## What's in the diff

- **Unique stamp per call**: `generateTmpStamp()` returns `${pid}.${base36(Date.now())}.${base36(rand,8)}` — ~2.8e12 combinations per (pid, ms) tuple. Two concurrent pairWrites have disjoint tmp namespaces by construction.
- **`cleanupOrphans` is age-bounded**: scans target dir, filters entries by the `basename(target).tmp.` prefix, skips fresh files (<5 min — concurrent-writer protection), unlinks stale orphans (crashed-process recovery). Tolerates missing dir.
- **New `_readdir` test seam** consistent with the existing `_writeFile`/`_rename`/`_unlink`/`_exists`/`_mkdir`/`_statMtimeMs` pattern.
- **3 existing matchers updated** from `path.endsWith('.yaml.tmp')` to `/\.yaml\.tmp\./.test(path)` to match the new `.tmp.<stamp>` shape.

## Multi-review (Gemini + Codex)

**Zero HIGH-confidence findings.** Both reviewers verified:
- Race correctness: unique-stamp + 5-min age threshold eliminates the original race
- Stamp uniqueness: ~2.8e12 combinations is strong enough
- `_readdir` scope: every other `readdirSync` call site is in unrelated modules
- Slug sanitization: no path-traversal artifacts
- Fresh-orphan test mtime reliability on APFS/ext4/HFS+

Codex noted one style nit (`${dir}/${entry}` uses forward-slash where rest of codebase uses `path.join`) — acceptable since the codebase targets darwin/linux only and Node's fs APIs accept mixed separators on Windows anyway.

## Test plan

- [x] 7 new regression tests covering unique-stamp generation, stale-orphan sweep, fresh-orphan preservation, prefix anchoring (won't touch unrelated `.tmp` files), missing-dir tolerance, exported constant value, and round-trip orphan-free state across 5 repeated `pairWrite` calls.
- [x] 3 existing tests updated to match the new `.tmp.<stamp>` filename shape.
- [x] Suite: 1312 → 1319 passing.
- [x] `npm run build`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)