### PR TITLE
fix(gh-112): sidecarPathFor handles both POSIX and Windows separators

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.36",
+      "version": "0.44.37",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.36",
+  "version": "0.44.37",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.44.37] — 2026-05-13
+
+### Fixed (GH #112 — sidecar-io Windows path bug)
+
+- **`sidecarPathFor` now extracts the basename via `split(/[\\/]/).pop()`**
+  instead of `split('/').pop()`. The old form returned the entire
+  backslash-containing path as a single segment on Windows, producing
+  absurd deeply-nested directory trees through subsequent
+  `join(parent, 'state', base)`. PR #109's atomic-writer trusted this
+  output and `ensureDir`-ed it, making the pre-existing latent bug more
+  impactful. Gemini flagged at conf 88 in the PR #109 multi-LLM review.
+- 4 new regression tests cover POSIX-style paths, `.yml` extension,
+  Windows-style backslash input, and mixed-separator input. The fix
+  works on both POSIX and Windows runtimes since the separator split
+  is explicit rather than platform-native. Suite: 1312 → 1316 passing.
+
 ## [0.44.36] — 2026-05-12
 
 ### Fixed (Phase 134.2-followup — device_deeplink url injection)

--- a/scripts/cdp-bridge/dist/domain/sidecar-io.js
+++ b/scripts/cdp-bridge/dist/domain/sidecar-io.js
@@ -12,9 +12,19 @@ export function sidecarPathFor(yamlFilePath) {
     // <project>/.rn-agent/actions/<id>.yaml → <project>/.rn-agent/state/<id>.state.json
     // We don't assume the input is under .rn-agent/actions/ — instead derive
     // the sidecar by replacing the YAML's parent dir with sibling `state/`.
+    //
+    // GH #112: split on BOTH POSIX and Windows separators. The original
+    // `split('/').pop()` returned the entire backslash-containing path as a
+    // single segment on Windows, leading `join(parent, 'state', base)` to
+    // produce a deeply-nested broken directory tree. Using `path.basename`
+    // alone isn't enough because on a POSIX runtime `path.basename` doesn't
+    // recognize `\` as a separator, so a Windows-style input passed through
+    // unrelated code (e.g. cross-platform test fixtures) would still
+    // misbehave. Explicit `[/\\]` split is platform-agnostic at the source.
     const dir = dirname(yamlFilePath);
     const parent = dirname(dir);
-    const base = yamlFilePath.replace(/\.ya?ml$/i, '.state.json').split('/').pop();
+    const filename = yamlFilePath.replace(/\.ya?ml$/i, '.state.json');
+    const base = filename.split(/[\\/]/).pop();
     return join(parent, 'state', base);
 }
 /**

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.31",
+  "version": "0.38.32",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/domain/sidecar-io.ts
+++ b/scripts/cdp-bridge/src/domain/sidecar-io.ts
@@ -17,9 +17,19 @@ export function sidecarPathFor(yamlFilePath: string): string {
   // <project>/.rn-agent/actions/<id>.yaml → <project>/.rn-agent/state/<id>.state.json
   // We don't assume the input is under .rn-agent/actions/ — instead derive
   // the sidecar by replacing the YAML's parent dir with sibling `state/`.
+  //
+  // GH #112: split on BOTH POSIX and Windows separators. The original
+  // `split('/').pop()` returned the entire backslash-containing path as a
+  // single segment on Windows, leading `join(parent, 'state', base)` to
+  // produce a deeply-nested broken directory tree. Using `path.basename`
+  // alone isn't enough because on a POSIX runtime `path.basename` doesn't
+  // recognize `\` as a separator, so a Windows-style input passed through
+  // unrelated code (e.g. cross-platform test fixtures) would still
+  // misbehave. Explicit `[/\\]` split is platform-agnostic at the source.
   const dir = dirname(yamlFilePath);
   const parent = dirname(dir);
-  const base = yamlFilePath.replace(/\.ya?ml$/i, '.state.json').split('/').pop()!;
+  const filename = yamlFilePath.replace(/\.ya?ml$/i, '.state.json');
+  const base = filename.split(/[\\/]/).pop()!;
   return join(parent, 'state', base);
 }
 

--- a/scripts/cdp-bridge/test/unit/gh-112-sidecar-windows-path.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-112-sidecar-windows-path.test.js
@@ -1,0 +1,55 @@
+// GH #112: regression test for sidecarPathFor's basename extraction.
+// The original implementation used `split('/').pop()` which returned the
+// entire backslash-containing path as a single segment on Windows,
+// producing absurd `join(parent, 'state', <full-windows-path>)` deep
+// directory trees. The fix splits on both separators explicitly.
+//
+// We run this on a POSIX runtime (darwin/linux) and assert that the
+// EXTRACTED basename is correct for Windows-style input regardless of
+// platform-native path module behavior. Parent-dir resolution on a
+// Windows path is platform-dependent and out of scope — the goal here is
+// only "the basename portion is correctly extracted."
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const MOD_PATH = '../../dist/domain/sidecar-io.js';
+
+test('sidecarPathFor: POSIX-style path produces expected sidecar path', async () => {
+  const { sidecarPathFor } = await import(MOD_PATH);
+  const result = sidecarPathFor('/Users/me/project/.rn-agent/actions/wizard-create-task.yaml');
+  assert.equal(result, '/Users/me/project/.rn-agent/state/wizard-create-task.state.json');
+});
+
+test('sidecarPathFor: .yml extension also handled', async () => {
+  const { sidecarPathFor } = await import(MOD_PATH);
+  const result = sidecarPathFor('/a/b/actions/short.yml');
+  assert.equal(result, '/a/b/state/short.state.json');
+});
+
+test('sidecarPathFor: Windows-style backslash input extracts basename correctly (no embedded path in result)', async () => {
+  // GH #112: this is the regression case. The buggy code produced a base
+  // string containing the entire backslash path, which join() then
+  // embedded into a deeply-nested directory tree. The fix's contract is
+  // that the result's filename portion is just `<id>.state.json`, not
+  // the full path. We assert on the END of the result string so we don't
+  // depend on platform-native dirname/join behavior for Windows inputs
+  // on a POSIX test runtime.
+  const { sidecarPathFor } = await import(MOD_PATH);
+  const result = sidecarPathFor('C:\\Users\\foo\\project\\.rn-agent\\actions\\my-action.yaml');
+  // The trailing segment must be `my-action.state.json`, not the full
+  // backslash-containing path.
+  assert.match(result, /[/\\]my-action\.state\.json$/, `result did not end with clean basename: ${result}`);
+  // The result must NOT contain the entire Windows-style filename glued in.
+  assert.ok(!result.includes('C:\\Users\\foo\\project\\.rn-agent\\actions\\my-action.state.json'),
+    `result still contains the full Windows path: ${result}`);
+});
+
+test('sidecarPathFor: mixed forward+backward slash input extracts basename correctly', async () => {
+  // Defensive: someone hand-builds a path with both separators (e.g.
+  // pre-processing wasn't normalized). Should still extract the trailing
+  // segment cleanly.
+  const { sidecarPathFor } = await import(MOD_PATH);
+  const result = sidecarPathFor('/a/b\\c/d\\my-action.yaml');
+  assert.match(result, /[/\\]my-action\.state\.json$/, `mixed-separator result: ${result}`);
+  assert.ok(!result.includes('a/b\\c/d\\my-action.state.json'));
+});


### PR DESCRIPTION
Closes #112

## Summary

Pre-existing latent bug in `sidecarPathFor` (`scripts/cdp-bridge/src/domain/sidecar-io.ts`). The old form used `split('/').pop()` which on Windows returned the entire backslash-containing path as a single segment, leading `join(parent, 'state', base)` to produce absurdly nested broken directory trees. PR #109's atomic-writer trusted this output and `ensureDir`-ed it, making the latent bug more impactful.

Flagged by Gemini at conf 88 in PR #109 review.

## What's in the diff

2-line change: `split(/[\\\\/]/)` instead of `split('/')`. Explicit cross-platform separator handling rather than relying on `path.basename`'s platform-native behavior (which on POSIX doesn't recognize backslash as a separator — a Windows-style input passed through cross-platform code would still misbehave).

## Multi-review (Gemini)

Zero HIGH-conf findings. One sub-threshold note: trailing-separator inputs (`foo/bar.yaml/`) would split to empty basename and produce a confusing EISDIR downstream. Not reachable from current callers (paths come from `readdirSync` of `.rn-agent/actions/`, which never yield trailing separators). If a real bug surfaces there, add a one-line empty-basename guard at the throw boundary.

## Test plan

- [x] 4 new regression tests: POSIX paths, `.yml` extension, Windows-style backslash input, mixed-separator input.
- [x] Suite: 1312 → 1316 passing.
- [x] `npm run build`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)