### PR TITLE
fix(gh-113): runtime soft-assertion on saveAction's external-edit precondition

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.36",
+      "version": "0.44.37",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.36",
+  "version": "0.44.37",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.44.37] — 2026-05-13
+
+### Hardened (GH #113 — saveAction precondition becomes a runtime soft-assertion)
+
+- **`saveAction` now throws `SaveActionPreconditionError`** when the
+  on-disk YAML has been edited externally since the in-memory action was
+  loaded. Previously the "caller already gated actionWasEditedExternally"
+  contract was implicit, surfaced only in a comment block. A future caller
+  (e.g. the planned #104 auto-repair-on-failure wiring) could silently
+  clobber a real human edit if it missed the contract.
+- **Bypassed on first write** (file doesn't exist yet) since there's no
+  prior state to protect.
+- Both current callers (`cdp_repair_action`, `cdp_record_test_save_as_action`)
+  gate correctly, so the new guard fires only for misbehaving new callers.
+- Error message references `GH #113`, the offending YAML path, and points
+  the developer at `actionWasEditedExternally` / `saveActionWithCAS`.
+- 3 new regression tests; suite: 1312 → 1315 passing.
+- One `stat()` per save on the happy path — negligible cost.
+
 ## [0.44.36] — 2026-05-12
 
 ### Fixed (Phase 134.2-followup — device_deeplink url injection)

--- a/scripts/cdp-bridge/dist/domain/action-store.js
+++ b/scripts/cdp-bridge/dist/domain/action-store.js
@@ -170,7 +170,29 @@ export function loadAction(projectRoot, actionId) {
  * `cdp_repair_action`, which checks `actionWasEditedExternally` before
  * patching).
  */
+export class SaveActionPreconditionError extends Error {
+    constructor(filePath) {
+        super(`saveAction precondition violated: yaml at ${filePath} has been ` +
+            `edited externally since the in-memory action was loaded. The caller ` +
+            `must invoke actionWasEditedExternally() first and abort on true ` +
+            `(or use saveActionWithCAS for atomic detection). GH #113 contract ` +
+            `enforcement.`);
+        this.name = 'SaveActionPreconditionError';
+    }
+}
 export function saveAction(action) {
+    // GH #113: soft-assertion contract enforcement. Both current callers
+    // (cdp_repair_action, cdp_record_test_save_as_action) gate this check
+    // correctly, but a future caller (e.g. the planned issue-#104
+    // auto-repair-on-failure wiring) could silently clobber a real human
+    // edit if it forgot. One stat() per save is cheap defense.
+    //
+    // Skip the guard when the file doesn't exist yet (first write — there's
+    // no external edit to detect, and actionWasEditedExternally returns
+    // false in that case anyway via its statSync catch).
+    if (existsSync(action.filePath) && actionWasEditedExternally(action)) {
+        throw new SaveActionPreconditionError(action.filePath);
+    }
     // Read existing top section so we don't lose the `appId:` line.
     let topSection = '';
     if (existsSync(action.filePath)) {

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.31",
+  "version": "0.38.32",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/domain/action-store.ts
+++ b/scripts/cdp-bridge/src/domain/action-store.ts
@@ -199,7 +199,33 @@ export type SaveActionCASResult =
  * `cdp_repair_action`, which checks `actionWasEditedExternally` before
  * patching).
  */
+export class SaveActionPreconditionError extends Error {
+  constructor(filePath: string) {
+    super(
+      `saveAction precondition violated: yaml at ${filePath} has been ` +
+      `edited externally since the in-memory action was loaded. The caller ` +
+      `must invoke actionWasEditedExternally() first and abort on true ` +
+      `(or use saveActionWithCAS for atomic detection). GH #113 contract ` +
+      `enforcement.`,
+    );
+    this.name = 'SaveActionPreconditionError';
+  }
+}
+
 export function saveAction(action: ReusableAction): { filePath: string; sidecarPath: string } {
+  // GH #113: soft-assertion contract enforcement. Both current callers
+  // (cdp_repair_action, cdp_record_test_save_as_action) gate this check
+  // correctly, but a future caller (e.g. the planned issue-#104
+  // auto-repair-on-failure wiring) could silently clobber a real human
+  // edit if it forgot. One stat() per save is cheap defense.
+  //
+  // Skip the guard when the file doesn't exist yet (first write — there's
+  // no external edit to detect, and actionWasEditedExternally returns
+  // false in that case anyway via its statSync catch).
+  if (existsSync(action.filePath) && actionWasEditedExternally(action)) {
+    throw new SaveActionPreconditionError(action.filePath);
+  }
+
   // Read existing top section so we don't lose the `appId:` line.
   let topSection = '';
   if (existsSync(action.filePath)) {

--- a/scripts/cdp-bridge/test/unit/gh-113-saveaction-precondition.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-113-saveaction-precondition.test.js
@@ -1,0 +1,123 @@
+// GH #113: saveAction's implicit "caller already gated actionWasEditedExternally"
+// precondition is now a runtime soft-assertion. A caller that forgets to
+// gate gets a clear SaveActionPreconditionError instead of silently
+// clobbering a human edit.
+//
+// Both existing callers (cdp_repair_action, cdp_record_test_save_as_action)
+// gate correctly, so the new guard fires only for new callers that
+// miss the contract — exactly the threat model the issue describes
+// (e.g. the planned #104 auto-repair-on-failure wiring).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, utimesSync, mkdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const STORE_PATH = '../../dist/domain/action-store.js';
+const ACTION_PATH = '../../dist/domain/reusable-action.js';
+
+function makeProject() {
+  const root = mkdtempSync(join(tmpdir(), 'gh113-'));
+  mkdirSync(join(root, '.rn-agent', 'actions'), { recursive: true });
+  return root;
+}
+
+function writeAction(root, id, body, metadata = {}) {
+  const filePath = join(root, '.rn-agent', 'actions', `${id}.yaml`);
+  const meta = {
+    id,
+    intent: metadata.intent ?? `intent ${id}`,
+    tags: metadata.tags ?? [],
+    mutates: metadata.mutates ?? false,
+    status: metadata.status ?? 'experimental',
+    appId: metadata.appId ?? 'com.test.app',
+    ...metadata,
+  };
+  // Build the YAML the way serializeM7Header does (caller doesn't need it
+  // to be perfect for tests — loadAction parses it back).
+  const yaml = [
+    `appId: ${meta.appId}`,
+    '---',
+    `# id: ${meta.id}`,
+    `# intent: ${meta.intent}`,
+    `# status: ${meta.status}`,
+    ...body,
+  ].join('\n');
+  writeFileSync(filePath, yaml);
+  return filePath;
+}
+
+test('saveAction: succeeds when no external edit between load and save', async () => {
+  const { loadAction, saveAction, withBody } = await import(STORE_PATH);
+  const root = makeProject();
+  writeAction(root, 'happy-path', ['- launchApp']);
+  const action = loadAction(root, 'happy-path');
+  assert.ok(action, 'action should load');
+  const modified = withBody(action, '- launchApp\n- tapOn:\n    id: "btn"');
+  const result = saveAction(modified);
+  assert.ok(result.filePath.endsWith('happy-path.yaml'));
+});
+
+test('saveAction: throws SaveActionPreconditionError when YAML was edited externally', async () => {
+  const { loadAction, saveAction, withBody, SaveActionPreconditionError } = await import(STORE_PATH);
+  const root = makeProject();
+  const filePath = writeAction(root, 'edited-mid-flight', ['- launchApp']);
+  const action = loadAction(root, 'edited-mid-flight');
+  assert.ok(action);
+
+  // Simulate an external write: bump the file's mtime forward AFTER the
+  // load (which already snapshotted the mtime into state.lastSeenMtimeMs).
+  const future = (Date.now() + 10_000) / 1000;
+  utimesSync(filePath, future, future);
+
+  const modified = withBody(action, '- launchApp\n- tapOn: { id: "btn" }');
+  assert.throws(
+    () => saveAction(modified),
+    (e) => e instanceof SaveActionPreconditionError && /edited externally/.test(e.message),
+    'must throw a SaveActionPreconditionError',
+  );
+
+  // The error should reference the file path so a developer can identify
+  // which action triggered the guard.
+  try { saveAction(modified); } catch (e) {
+    assert.match(e.message, /edited-mid-flight\.yaml/);
+    assert.match(e.message, /GH #113/);
+    assert.match(e.message, /actionWasEditedExternally/);
+  }
+});
+
+test('saveAction: first write (file does not exist yet) bypasses the guard', async () => {
+  // The guard only fires when the file already exists and has been
+  // edited externally. A brand-new action (first save) has no prior
+  // state to protect.
+  const { saveAction } = await import(STORE_PATH);
+  const root = makeProject();
+  const targetPath = join(root, '.rn-agent', 'actions', 'never-existed.yaml');
+  // Hand-craft a ReusableAction-shaped object (we can't use loadAction
+  // because the file doesn't exist).
+  const action = {
+    filePath: targetPath,
+    metadata: {
+      id: 'never-existed',
+      intent: 'first-write smoke',
+      tags: [],
+      mutates: false,
+      status: 'experimental',
+      appId: 'com.test.app',
+    },
+    body: '- launchApp',
+    state: {
+      schemaVersion: 1,
+      revision: 0,
+      updatedAt: new Date().toISOString(),
+      lastSeenMtimeMs: 0,
+      runHistory: [],
+      repairHistory: [],
+      stats: {},
+    },
+  };
+  const result = saveAction(action);
+  assert.ok(result.filePath.endsWith('never-existed.yaml'));
+  // Verify the file actually landed
+  assert.ok(readFileSync(result.filePath, 'utf-8').includes('id: never-existed'));
+});


### PR DESCRIPTION
Closes #113

## Summary

The "caller already gated `actionWasEditedExternally`" contract on `saveAction` was implicit — surfaced only in a comment block. Both current callers (`cdp_repair_action`, `cdp_record_test_save_as_action`) gate correctly, but a future caller (e.g. the planned #104 auto-repair-on-failure wiring) could silently clobber a real human edit if it missed the contract. Codex flagged at conf 85 in PR #109 review.

## What's in the diff

At the top of `saveAction`, when the YAML file already exists, check `actionWasEditedExternally(action)` and throw a `SaveActionPreconditionError` if true. First-write case (file doesn't exist) bypasses the guard since there's no prior state to protect.

Error message references `GH #113`, the offending YAML path, and points the developer at `actionWasEditedExternally` / `saveActionWithCAS` for the right fix.

One `stat()` per save on the happy path — negligible cost for a runtime guarantee against silent file clobber.

## Multi-review (Codex)

Zero HIGH-conf findings. Verified:
- False-positive risk walked through both production flows — clean
- TOCTOU between `existsSync` and `actionWasEditedExternally` is benign — `stat` failure falls through to existing `existsSync` checks
- JS hoisting of named function declarations works cleanly (forward reference to `actionWasEditedExternally` declared below)
- APFS mtime resolution is sub-millisecond so the 10-second future-bump test is reliable
- `SaveActionPreconditionError` correctly exported for downstream `instanceof` checks

## Test plan

- [x] 3 new regression tests: happy path, external-edit throw (uses `utimesSync` to bump mtime), first-write bypass.
- [x] Suite: 1312 → 1315 passing.
- [x] `npm run build`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)