### PR TITLE
fix(gh-119): record nextFailedSelector on cascading-selector failures

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.36",
+      "version": "0.44.37",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.36",
+  "version": "0.44.37",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to rn-dev-agent will be documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.44.37] — 2026-05-13
+
+### Fixed (GH #119 — AutoRepairOutcome cascading-selector clarification)
+
+- **`AutoRepairOutcome.nextFailedSelector`**: new optional field, populated
+  when auto-repair succeeded but the post-repair retry failed on a DIFFERENT
+  selector. Lets MTTR analysis distinguish "patch didn't work" from
+  "cascading failure — patch worked, next selector broke." Without this,
+  the telemetry made every cascading failure look like a failed patch.
+- Absent when retry passed (happy path) OR when retry failed on the
+  SAME selector as the patch (= patch didn't actually fix it). Codex
+  flagged the misclassification at conf 85 in the PR #115 review.
+- 3 new regression tests cover the three cases. Suite 1312 → 1315 passing.
+
 ## [0.44.36] — 2026-05-12
 
 ### Fixed (Phase 134.2-followup — device_deeplink url injection)

--- a/scripts/cdp-bridge/dist/tools/run-action.js
+++ b/scripts/cdp-bridge/dist/tools/run-action.js
@@ -290,6 +290,24 @@ export function createRunActionHandler(deps = {}) {
             const repairTimestamp = reloadedAction.state.repairHistory.length > 0
                 ? reloadedAction.state.repairHistory[reloadedAction.state.repairHistory.length - 1].timestamp
                 : undefined;
+            // GH #119: when the retry fails on a DIFFERENT selector than the
+            // one just patched, capture it as `nextFailedSelector` so MTTR
+            // analysis can distinguish "patch didn't work" from "cascading
+            // failure — patch worked, next selector broke." Only meaningful
+            // when retry failed; same-selector failures (= patch didn't work)
+            // are implicit in the existing diff.
+            let nextFailedSelector;
+            if (!retryPassed) {
+                try {
+                    const retryFailure = parseMaestroFailure(retryOutput);
+                    if (retryFailure.kind === 'SELECTOR_NOT_FOUND' &&
+                        retryFailure.selector &&
+                        retryFailure.selector !== repairData.newSelector) {
+                        nextFailedSelector = retryFailure.selector;
+                    }
+                }
+                catch { /* best-effort — don't fail the run because the parser hiccuped */ }
+            }
             const autoRepair = {
                 attempted: true,
                 outcome: retryPassed ? 'passed' : 'failed',
@@ -302,6 +320,7 @@ export function createRunActionHandler(deps = {}) {
                 },
                 phases: { firstAttemptMs, repairMs, retryMs },
                 repairTimestamp,
+                ...(nextFailedSelector ? { nextFailedSelector } : {}),
             };
             await persistRun(args.actionId, projectRoot, {
                 timestamp: new Date().toISOString(),

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.31",
+  "version": "0.38.32",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/scripts/cdp-bridge/src/domain/reusable-action.ts
+++ b/scripts/cdp-bridge/src/domain/reusable-action.ts
@@ -209,6 +209,14 @@ export interface AutoRepairOutcome {
    * and emitted a RepairRecord).
    */
   repairTimestamp?: string;
+  /**
+   * GH #119: when outcome === 'failed' AND the post-repair retry failed
+   * on a DIFFERENT selector than the one just patched, record it here
+   * so MTTR analysis can distinguish "patch didn't work" from
+   * "cascading failure — patch worked, next selector broke." Absent
+   * when the retry failed on the same selector or didn't run.
+   */
+  nextFailedSelector?: string;
 }
 
 /** A single replay attempt's outcome. Append-only; oldest dropped at limit. */

--- a/scripts/cdp-bridge/src/tools/run-action.ts
+++ b/scripts/cdp-bridge/src/tools/run-action.ts
@@ -382,6 +382,26 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
         ? reloadedAction.state.repairHistory[reloadedAction.state.repairHistory.length - 1].timestamp
         : undefined;
 
+      // GH #119: when the retry fails on a DIFFERENT selector than the
+      // one just patched, capture it as `nextFailedSelector` so MTTR
+      // analysis can distinguish "patch didn't work" from "cascading
+      // failure — patch worked, next selector broke." Only meaningful
+      // when retry failed; same-selector failures (= patch didn't work)
+      // are implicit in the existing diff.
+      let nextFailedSelector: string | undefined;
+      if (!retryPassed) {
+        try {
+          const retryFailure = parseMaestroFailure(retryOutput);
+          if (
+            retryFailure.kind === 'SELECTOR_NOT_FOUND' &&
+            retryFailure.selector &&
+            retryFailure.selector !== repairData.newSelector
+          ) {
+            nextFailedSelector = retryFailure.selector;
+          }
+        } catch { /* best-effort — don't fail the run because the parser hiccuped */ }
+      }
+
       const autoRepair: AutoRepairOutcome = {
         attempted: true,
         outcome: retryPassed ? 'passed' : 'failed',
@@ -394,6 +414,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
         },
         phases: { firstAttemptMs, repairMs, retryMs },
         repairTimestamp,
+        ...(nextFailedSelector ? { nextFailedSelector } : {}),
       };
 
       await persistRun(args.actionId, projectRoot, {

--- a/scripts/cdp-bridge/test/unit/gh-119-cascading-selector.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-119-cascading-selector.test.js
@@ -1,0 +1,185 @@
+// GH #119: cascading-selector hardening. When auto-repair patches
+// selector A→A' and the retry then fails on a DIFFERENT selector B,
+// AutoRepairOutcome.nextFailedSelector captures B so MTTR can
+// distinguish "patch didn't work" from "patch worked, next selector
+// broke."
+import { test, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const RUN_ACTION_PATH = '../../dist/tools/run-action.js';
+
+function makeProject() {
+  const root = mkdtempSync(join(tmpdir(), 'gh119-'));
+  mkdirSync(join(root, '.rn-agent', 'actions'), { recursive: true });
+  writeFileSync(join(root, '.rn-agent', 'actions', 'sample.yaml'), [
+    'appId: com.test.app',
+    '---',
+    '# id: sample',
+    '# intent: a sample',
+    '# status: experimental',
+    '# mutates: false',
+    '- launchApp',
+    '- tapOn:',
+    '    id: "btn-A"',
+  ].join('\n'));
+  return root;
+}
+
+test('AutoRepairOutcome.nextFailedSelector populated when retry fails on a different selector', async () => {
+  const { createRunActionHandler } = await import(RUN_ACTION_PATH);
+  const root = makeProject();
+
+  // First call: maestro fails with SELECTOR_NOT_FOUND on selector "btn-A".
+  // Second call (post-repair retry): maestro fails on a DIFFERENT selector
+  // "btn-B" → cascading failure.
+  let mCount = 0;
+  const fakeMaestroRun = mock.fn(async () => {
+    mCount++;
+    if (mCount === 1) {
+      return {
+        content: [{ type: 'text', text: JSON.stringify({
+          ok: true,
+          data: { passed: false, output: '== Element with id "btn-A" not found ==' },
+        }) }],
+      };
+    }
+    // Retry: also fails, but on a different selector
+    return {
+      content: [{ type: 'text', text: JSON.stringify({
+        ok: true,
+        data: { passed: false, output: '== Element with id "btn-B" not found ==' },
+      }) }],
+    };
+  });
+
+  const fakeRepairAction = mock.fn(async () => ({
+    content: [{ type: 'text', text: JSON.stringify({
+      ok: true,
+      data: { patched: true, oldSelector: 'btn-A', newSelector: 'btn-A-new', score: 0.9 },
+      meta: { repairTimestamp: new Date().toISOString() },
+    }) }],
+  }));
+
+  const handler = createRunActionHandler({ maestroRun: fakeMaestroRun, repairAction: fakeRepairAction });
+  const result = await handler({
+    actionId: 'sample',
+    projectRoot: root,
+    platform: 'ios',
+    autoRepair: true,
+  });
+
+  // Result should be a failResult with the autoRepair meta
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  // The autoRepair payload is in meta (failResult shape)
+  const autoRepair = env.meta?.autoRepair ?? env.data?.autoRepair;
+  assert.ok(autoRepair, `expected autoRepair in envelope; got ${result.content[0].text.slice(0, 300)}`);
+  assert.equal(autoRepair.outcome, 'failed');
+  // The fix's contract: when retry fails on a different selector, capture it
+  assert.equal(autoRepair.nextFailedSelector, 'btn-B',
+    `nextFailedSelector should be the retry's failed selector; got ${autoRepair.nextFailedSelector}`);
+  // The original diff stays unchanged
+  assert.equal(autoRepair.diff?.selector?.from, 'btn-A');
+  assert.equal(autoRepair.diff?.selector?.to, 'btn-A-new');
+
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('AutoRepairOutcome.nextFailedSelector NOT populated when retry fails on the SAME selector (patch did not work)', async () => {
+  const { createRunActionHandler } = await import(RUN_ACTION_PATH);
+  const root = makeProject();
+
+  let mCount = 0;
+  const fakeMaestroRun = mock.fn(async () => {
+    mCount++;
+    if (mCount === 1) {
+      return {
+        content: [{ type: 'text', text: JSON.stringify({
+          ok: true,
+          data: { passed: false, output: '== Element with id "btn-A" not found ==' },
+        }) }],
+      };
+    }
+    // Retry fails on the SAME (newly patched) selector — patch didn't work
+    return {
+      content: [{ type: 'text', text: JSON.stringify({
+        ok: true,
+        data: { passed: false, output: '== Element with id "btn-A-new" not found ==' },
+      }) }],
+    };
+  });
+
+  const fakeRepairAction = mock.fn(async () => ({
+    content: [{ type: 'text', text: JSON.stringify({
+      ok: true,
+      data: { patched: true, oldSelector: 'btn-A', newSelector: 'btn-A-new' },
+      meta: { repairTimestamp: new Date().toISOString() },
+    }) }],
+  }));
+
+  const handler = createRunActionHandler({ maestroRun: fakeMaestroRun, repairAction: fakeRepairAction });
+  const result = await handler({
+    actionId: 'sample',
+    projectRoot: root,
+    platform: 'ios',
+    autoRepair: true,
+  });
+
+  const env = JSON.parse(result.content[0].text);
+  const autoRepair = env.meta?.autoRepair ?? env.data?.autoRepair;
+  assert.ok(autoRepair);
+  assert.equal(autoRepair.outcome, 'failed');
+  // No cascading selector — should be absent
+  assert.equal(autoRepair.nextFailedSelector, undefined,
+    `nextFailedSelector should NOT be present when same selector failed; got ${autoRepair.nextFailedSelector}`);
+
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('AutoRepairOutcome.nextFailedSelector NOT populated when retry passed (happy repair path)', async () => {
+  const { createRunActionHandler } = await import(RUN_ACTION_PATH);
+  const root = makeProject();
+
+  let mCount = 0;
+  const fakeMaestroRun = mock.fn(async () => {
+    mCount++;
+    if (mCount === 1) {
+      return {
+        content: [{ type: 'text', text: JSON.stringify({
+          ok: true,
+          data: { passed: false, output: '== Element with id "btn-A" not found ==' },
+        }) }],
+      };
+    }
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ ok: true, data: { passed: true, output: 'pass' } }) }],
+    };
+  });
+
+  const fakeRepairAction = mock.fn(async () => ({
+    content: [{ type: 'text', text: JSON.stringify({
+      ok: true,
+      data: { patched: true, oldSelector: 'btn-A', newSelector: 'btn-A-new' },
+      meta: { repairTimestamp: new Date().toISOString() },
+    }) }],
+  }));
+
+  const handler = createRunActionHandler({ maestroRun: fakeMaestroRun, repairAction: fakeRepairAction });
+  const result = await handler({
+    actionId: 'sample',
+    projectRoot: root,
+    platform: 'ios',
+    autoRepair: true,
+  });
+
+  assert.equal(result.isError, undefined);
+  const env = JSON.parse(result.content[0].text);
+  const autoRepair = env.data.autoRepair;
+  assert.equal(autoRepair.outcome, 'passed');
+  assert.equal(autoRepair.nextFailedSelector, undefined);
+
+  rmSync(root, { recursive: true, force: true });
+});


### PR DESCRIPTION
Closes #119

## Summary

When auto-repair patches selector A→A' and the retry then fails on a DIFFERENT selector B, the RunRecord previously showed:
- `failureCode: SELECTOR_NOT_FOUND` ✓ correct
- `failureDetail`: mentions the new failed selector ✓ correct
- `autoRepair.diff.selector: { from: 'A', to: 'A\\'' }` ✗ misleading — looks like the patch didn't work
- `autoRepair.outcome: 'failed'` ✓ correct

Reading the telemetry standalone suggested "we patched A but the patch didn't work" when reality is "the patch worked AND a different selector failed next." MTTR analysis would mis-attribute the failure to the just-applied patch.

Codex flagged at conf 85 in PR #115 review.

## What's in the diff

- New `AutoRepairOutcome.nextFailedSelector?: string` field (`src/domain/reusable-action.ts`)
- In `src/tools/run-action.ts`, after the retry fails, parse `retryOutput` for the failed selector. If it differs from `repairData.newSelector`, capture it as `nextFailedSelector`. Absent when retry passed (happy path) or when retry failed on the same selector (= patch truly didn't fix it).

## Test plan

- [x] 3 new regression tests covering all 3 cases (cascading → `nextFailedSelector` present; same-selector → absent; happy retry → absent).
- [x] Suite: 1312 → 1315 passing.
- [x] `npm run build`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)