### PR TITLE
fix(gh-105): MTTR experiment surfaces & fixes maestro-error-parser regression

### DIFF
--- a/scripts/cdp-bridge/dist/domain/maestro-error-parser.js
+++ b/scripts/cdp-bridge/dist/domain/maestro-error-parser.js
@@ -6,13 +6,14 @@
 // raw output text, no I/O, fully unit-testable.
 //
 // Maestro emits failures in a few canonical shapes (verified against
-// Maestro 1.40+ output and maestro-runner 0.x):
+// Maestro 1.40+ output, maestro-runner 0.x, and maestro-runner 1.0.9):
 //
 //   - "Element with id 'X' not found"
 //   - "Element with text 'X' not found"
 //   - 'Assertion failed: "X" not visible'
 //   - "Timed out waiting for element 'X'"
 //   - "Element 'X' is not visible"  (assertion variant)
+//   - "Element not found: id='X'"   (maestro-runner 1.0.x shape — issue #105)
 //
 // The parser tries each known shape in order and returns the first
 // match. If none match, returns `{ kind: 'UNKNOWN', raw }` so the caller
@@ -38,6 +39,16 @@ const PATTERNS = [
     },
     {
         re: /Element with text (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
+        build: (m, raw) => ({ kind: 'SELECTOR_NOT_FOUND', selectorKind: 'text', selector: m[2], raw }),
+    },
+    // maestro-runner 1.0.x shape — issue #105.
+    // "Element not found: id='X'" or "Element not found: text='X'".
+    {
+        re: /Element not found:\s*id=(['"])((?:(?!\1).)+)\1/i,
+        build: (m, raw) => ({ kind: 'SELECTOR_NOT_FOUND', selectorKind: 'id', selector: m[2], raw }),
+    },
+    {
+        re: /Element not found:\s*text=(['"])((?:(?!\1).)+)\1/i,
         build: (m, raw) => ({ kind: 'SELECTOR_NOT_FOUND', selectorKind: 'text', selector: m[2], raw }),
     },
     {

--- a/scripts/cdp-bridge/src/domain/maestro-error-parser.ts
+++ b/scripts/cdp-bridge/src/domain/maestro-error-parser.ts
@@ -6,13 +6,14 @@
 // raw output text, no I/O, fully unit-testable.
 //
 // Maestro emits failures in a few canonical shapes (verified against
-// Maestro 1.40+ output and maestro-runner 0.x):
+// Maestro 1.40+ output, maestro-runner 0.x, and maestro-runner 1.0.9):
 //
 //   - "Element with id 'X' not found"
 //   - "Element with text 'X' not found"
 //   - 'Assertion failed: "X" not visible'
 //   - "Timed out waiting for element 'X'"
 //   - "Element 'X' is not visible"  (assertion variant)
+//   - "Element not found: id='X'"   (maestro-runner 1.0.x shape — issue #105)
 //
 // The parser tries each known shape in order and returns the first
 // match. If none match, returns `{ kind: 'UNKNOWN', raw }` so the caller
@@ -50,6 +51,16 @@ const PATTERNS: Pattern[] = [
   },
   {
     re: /Element with text (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
+    build: (m, raw) => ({ kind: 'SELECTOR_NOT_FOUND', selectorKind: 'text', selector: m[2], raw }),
+  },
+  // maestro-runner 1.0.x shape — issue #105.
+  // "Element not found: id='X'" or "Element not found: text='X'".
+  {
+    re: /Element not found:\s*id=(['"])((?:(?!\1).)+)\1/i,
+    build: (m, raw) => ({ kind: 'SELECTOR_NOT_FOUND', selectorKind: 'id', selector: m[2], raw }),
+  },
+  {
+    re: /Element not found:\s*text=(['"])((?:(?!\1).)+)\1/i,
     build: (m, raw) => ({ kind: 'SELECTOR_NOT_FOUND', selectorKind: 'text', selector: m[2], raw }),
   },
   {


### PR DESCRIPTION
Closes #105.

## Summary

The #105 MTTR experiment was designed to settle whether the L3 self-healing loop (`cdp_repair_action` + `/run-action` auto-repair, Sprint D / D1206) repairs realistic UI drift fast enough to justify the "self-healing compiler" pitch. Methodology: 5 representative flows × 3 drift kinds (selector rename / layout change / element replaced) on iOS, comparing agent vs. Claude-naive paths.

What landed in this PR:

- **Parser fix (the headline bug the experiment caught)** — `scripts/cdp-bridge/src/domain/maestro-error-parser.ts` only matched the classic Maestro stderr shape (`Element with id 'X' not found`). `maestro-runner 1.0.9` emits `Element not found: id='X'`, which fell through to `UNKNOWN`, so `isAutoRepairable` returned `false` and **the L3 self-healing loop has been silently dead-on-arrival in production** since `maestro-runner 1.0.9` shipped. Added two patterns covering the 1.0.9 shape (`id=` and `text=` variants), ordered before the catch-all so they win on specificity.
- **dist build** committed alongside source — keeps the deployed MCP server in sync.

What's in the companion workspace PR (`Lykhoyda/rn-dev-agent-workspace#?`):

- `docs/superpowers/specs/2026-05-13-mttr-experiment-design.md` — full design spec (methodology, scenario matrix, drift mechanics, metric definitions, threats-to-validity)
- `dev/mttr/scenarios.yaml` — 15-row reusable scenario manifest
- `dev/mttr/drift.mjs` — idempotent drift injector (rename / wrap / replace), reverts via `git checkout`
- `dev/mttr/record.mjs` — append-only JSONL recorder so partial runs aren't lost
- 4 new learned actions in `test-app/.rn-agent/actions/` (`toggle-theme`, `add-feed-comment`, `add-task-quick`, `cycle-task-priority`), all baseline-pass tested via `cdp_run_action`
- `docs/proof/mttr-experiment/REPORT.md` — empirical writeup, partial results, full findings section
- `docs/BUGS.md` — B152 (this PR fixes), B153 (cdp_repair_action snapshot-empty), B154 (CDP stale lock)

## Why this is partial

Two more L3 bugs surfaced during runtime (filed as B153/B154 in workspace BUGS.md):

- **B153** — `cdp_repair_action` returns `TESTID_NOT_FOUND` ("snapshot contained 0 testIDs") immediately after a `maestro_run` failure, even when the target screen is fully rendered with all testIDs (confirmed via `cdp_component_tree` just before the maestro_run). Hypotheses around stale fiber cache, foreground-app switching to the agent-device runner, or bridge re-injection silently producing an empty helper.
- **B154** — After B153 fires, the CDP bridge wedges into "Failed to connect after 5 attempts" for every subsequent call. `cdp_disconnect` doesn't recover. Direct `ws://` probes work; the MCP server is alive; non-CDP tools (`device_list`, `device_screenshot`) work fine. Recovery requires Claude Code restart.

Both block running the agent path end-to-end. The experiment's harness, manifest, and 5-action corpus are intact and re-runnable; once B153/B154 land, the remaining 13 scenarios are a 30-45 min batch.

## Test plan

- [x] `npm run build` in `scripts/cdp-bridge/` — clean
- [x] Parser fix verified against real maestro-runner 1.0.9 stderr captured in this session: `Element not found: id='task-mark-all-done'` → `SELECTOR_NOT_FOUND, selectorKind: 'id', selector: 'task-mark-all-done'`
- [ ] Unit tests for the two new patterns — deferred to a follow-up PR to keep this one experiment-scoped (existing parser unit tests still pass; new shapes covered by integration testing during the experiment)
- [ ] End-to-end `/run-action` retry on a selector-rename drift — requires Claude Code restart so the MCP server picks up the new dist (the running MCP process still has the old parser cached in module state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)