### PR TITLE
fix(gh-105): kill fast-runner before simctl launch in cdp_repair_action — closes the live focus race

### DIFF
--- a/scripts/cdp-bridge/dist/tools/repair-action.js
+++ b/scripts/cdp-bridge/dist/tools/repair-action.js
@@ -16,6 +16,7 @@ import { repairBudgetAvailable } from '../domain/reusable-action.js';
 import { snapshotEnvelopeFailed } from './device-batch.js';
 import { resolveBundleId } from '../project-config.js';
 import { isAgentDeviceRunnerSentinel } from './runner-leak-recovery.js';
+import { stopFastRunner } from '../fast-runner-session.js';
 const execFile = promisify(execFileCb);
 /**
  * GH #105 / B153: bring the target app to foreground BEFORE taking the
@@ -24,12 +25,31 @@ const execFile = promisify(execFileCb);
  * no testIDs of its own. That yields the misleading "snapshot returned 0
  * testIDs" failure on a perfectly healthy app.
  *
+ * **Live-smoke-test discovery (GH #105 follow-up):** `simctl launch` alone
+ * loses the focus race when the agent-device fast-runner (spawned by the
+ * prior `maestro_run`) is still alive — `XCUIApplication.activate()` inside
+ * the runner re-foregrounds the runner before the snapshot lands. The fix
+ * is to `stopFastRunner()` FIRST so there's nothing competing for focus,
+ * THEN `simctl launch` the test-app. The next `runAgentDevice(snapshot)`
+ * will lazily re-spawn the fast-runner, which is fine because by then
+ * agent-device knows which bundle to attach to (it inherits the foreground
+ * app's XCUIApplication).
+ *
  * Best-effort: silent failure means we still fall through to the snapshot,
  * which can still detect the runner-leak sentinel and surface a useful
  * error. iOS uses `simctl launch booted <bundleId>`; Android uses `am start`
  * via adb.
  */
 async function bringTargetAppToForeground(platform, bundleId) {
+    // Kill the fast-runner FIRST so it can't re-grab focus the moment we
+    // simctl-launch the test-app. Equivalent step exists in cdp_restart
+    // hardReset (PR #161); this is its single-tool counterpart inside the
+    // repair path so users don't have to call cdp_restart manually after
+    // a SELECTOR_NOT_FOUND.
+    try {
+        stopFastRunner();
+    }
+    catch { /* best-effort — fast-runner may already be dead */ }
     try {
         if (platform === 'android') {
             await execFile('adb', ['shell', 'monkey', '-p', bundleId, '-c', 'android.intent.category.LAUNCHER', '1'], { timeout: 5000, encoding: 'utf8' });

--- a/scripts/cdp-bridge/src/tools/repair-action.ts
+++ b/scripts/cdp-bridge/src/tools/repair-action.ts
@@ -27,6 +27,7 @@ import { repairBudgetAvailable } from '../domain/reusable-action.js';
 import { snapshotEnvelopeFailed } from './device-batch.js';
 import { resolveBundleId } from '../project-config.js';
 import { isAgentDeviceRunnerSentinel, type RunnerLeakNode } from './runner-leak-recovery.js';
+import { stopFastRunner } from '../fast-runner-session.js';
 
 const execFile = promisify(execFileCb);
 
@@ -37,6 +38,16 @@ const execFile = promisify(execFileCb);
  * no testIDs of its own. That yields the misleading "snapshot returned 0
  * testIDs" failure on a perfectly healthy app.
  *
+ * **Live-smoke-test discovery (GH #105 follow-up):** `simctl launch` alone
+ * loses the focus race when the agent-device fast-runner (spawned by the
+ * prior `maestro_run`) is still alive — `XCUIApplication.activate()` inside
+ * the runner re-foregrounds the runner before the snapshot lands. The fix
+ * is to `stopFastRunner()` FIRST so there's nothing competing for focus,
+ * THEN `simctl launch` the test-app. The next `runAgentDevice(snapshot)`
+ * will lazily re-spawn the fast-runner, which is fine because by then
+ * agent-device knows which bundle to attach to (it inherits the foreground
+ * app's XCUIApplication).
+ *
  * Best-effort: silent failure means we still fall through to the snapshot,
  * which can still detect the runner-leak sentinel and surface a useful
  * error. iOS uses `simctl launch booted <bundleId>`; Android uses `am start`
@@ -46,6 +57,14 @@ async function bringTargetAppToForeground(
   platform: string,
   bundleId: string,
 ): Promise<void> {
+  // Kill the fast-runner FIRST so it can't re-grab focus the moment we
+  // simctl-launch the test-app. Equivalent step exists in cdp_restart
+  // hardReset (PR #161); this is its single-tool counterpart inside the
+  // repair path so users don't have to call cdp_restart manually after
+  // a SELECTOR_NOT_FOUND.
+  try {
+    stopFastRunner();
+  } catch { /* best-effort — fast-runner may already be dead */ }
   try {
     if (platform === 'android') {
       await execFile(


### PR DESCRIPTION
## Discovery

Live smoke-test of #160 in the running session today produced:

```
cdp_run_action mark-all-done
  → SELECTOR_NOT_FOUND (parser fix from #159 ✓)
  → autoRepair.attempted: true (orchestration from #160 ✓)
  → cdp_repair_action invoked
  → bringTargetAppToForeground (simctl launch booted com.rndevagent.testapp)
  → snapshot
  → RUNNER_LEAK (sentinel detection from #160 ✓)
  → repairError: "snapshot returned the Agent Device Runner's own UI"
```

**Diagnosis worked. Recovery didn't.** The `simctl launch` step alone loses the focus race against a live agent-device fast-runner — `XCUIApplication.activate()` inside the runner re-foregrounds the runner the moment `simctl launch` finishes, before the snapshot lands.

## Fix

One-line change in `bringTargetAppToForeground` inside `cdp_repair_action`: call `stopFastRunner()` FIRST, THEN `simctl launch`. With no runner alive to compete, the test-app stays foreground long enough for the snapshot.

Mirrors step 1 of `cdp_restart hardReset` (#161) but scoped to a single repair invocation, so users don't have to manually call `cdp_restart` after every `SELECTOR_NOT_FOUND` — the `/run-action` auto-repair path becomes truly self-sufficient.

## Why no new unit test

The new line is a single `stopFastRunner()` call inside a private helper that's already module-imported. Testing it directly would require refactoring `bringTargetAppToForeground` for dependency injection just to assert one function call. The cost-benefit doesn't favor a refactor here:
- The same `stopFastRunner()` step is already test-covered via `cdp_restart hardReset`'s test suite (PR #161, 5 dedicated tests).
- The 1408-test regression suite is the safety net for unintended side-effects.
- The true verification is the live smoke-test, which is the same path we used for #160 + #161.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 1408/1408 pass
- [ ] **Live smoke-test deferred** to user `/reload-plugins` post-merge — at which point the next `cdp_run_action` on a drifted action should complete the L3 self-healing loop end-to-end. This is the same smoke-test gap as #160 and #161 (running MCP server caches old modules).

## After this PR

The MTTR experiment's 12 remaining scenarios (2-A through 5-C) should run to completion with `autoRepair.outcome: 'passed'` on kind A (selector rename), `'skipped'` on kind B (no testID change), and `'refused'` (or RUNNER_LEAK) on kind C (semantically different replacement). REPORT.md §3 + §4 are finally fillable with empirical data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)