### PR TITLE
ci: monorepo-aware CodeQL advanced setup (fixes Swift + Java-Kotlin scans)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read
@@ -56,12 +56,6 @@ jobs:
           distribution: temurin
           java-version: '17'
 
-      - name: Set up Xcode (Swift)
-        if: matrix.language == 'swift'
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
@@ -73,18 +67,26 @@ jobs:
         working-directory: scripts/rn-android-runner
         run: ./gradlew :app:assembleDebugAndroidTest --no-daemon
 
+      # Use the macos-15 runner's preinstalled Xcode (16.x); skip the slow
+      # `maxim-lobanov/setup-xcode` action. Build for the iphonesimulator SDK
+      # without requiring a specific device — CodeQL only needs the compile
+      # commands traced, not a runnable test bundle.
       - name: Build rn-fast-runner
         if: matrix.language == 'swift'
         working-directory: scripts/rn-fast-runner/RnFastRunner
         run: |
-          xcodebuild build-for-testing \
+          set -euo pipefail
+          xcodebuild -version
+          xcodebuild build \
             -project RnFastRunner.xcodeproj \
             -scheme RnFastRunner \
-            -destination 'generic/platform=iOS Simulator' \
+            -sdk iphonesimulator \
+            -configuration Debug \
             -derivedDataPath ../build/DerivedData \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGN_IDENTITY="" \
-            CODE_SIGNING_REQUIRED=NO
+            CODE_SIGNING_REQUIRED=NO \
+            ONLY_ACTIVE_ARCH=YES
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,92 @@
+name: CodeQL
+
+# Advanced CodeQL setup. Replaces the repo's previous "default setup" because
+# autobuild can't locate our nested Swift Xcode project at
+# scripts/rn-fast-runner/RnFastRunner/RnFastRunner.xcodeproj or our nested
+# Android Gradle project at scripts/rn-android-runner/. This workflow runs
+# each language's correct build command and lets CodeQL trace the resulting
+# artifacts.
+#
+# All ${{ }} interpolations here read from matrix.* (workflow-defined values)
+# and do not consume untrusted github.event.* input — safe per
+# https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '20 12 * * 4'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            os: ubuntu-latest
+            build-mode: none
+          - language: actions
+            os: ubuntu-latest
+            build-mode: none
+          - language: java-kotlin
+            os: ubuntu-latest
+            build-mode: manual
+          - language: swift
+            os: macos-15
+            build-mode: manual
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java (Android Gradle)
+        if: matrix.language == 'java-kotlin'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Xcode (Swift)
+        if: matrix.language == 'swift'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Build rn-android-runner
+        if: matrix.language == 'java-kotlin'
+        working-directory: scripts/rn-android-runner
+        run: ./gradlew :app:assembleDebugAndroidTest --no-daemon
+
+      - name: Build rn-fast-runner
+        if: matrix.language == 'swift'
+        working-directory: scripts/rn-fast-runner/RnFastRunner
+        run: |
+          xcodebuild build-for-testing \
+            -project RnFastRunner.xcodeproj \
+            -scheme RnFastRunner \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath ../build/DerivedData \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

CodeQL's default setup was failing both \`language:swift\` and \`language:java-kotlin\` on every scan because autobuild can't locate our nested projects:

- Swift Xcode project at \`scripts/rn-fast-runner/RnFastRunner/RnFastRunner.xcodeproj\`
- Android Gradle project at \`scripts/rn-android-runner/\`

Default-setup error for Swift: *\"No Xcode project or workspace found. autobuild detected neither an Xcode project or workspace, nor a Swift package. Set up a manual build command.\"*

## What this PR does

Replace default setup with an advanced workflow that runs the correct build per language:

| Language | Build mode | Build step |
|---|---|---|
| javascript-typescript | none | source-only scan |
| actions | none | source-only scan |
| java-kotlin | manual | \`./gradlew :app:assembleDebugAndroidTest\` under JDK 17 in \`scripts/rn-android-runner\` |
| swift | manual | \`xcodebuild build-for-testing\` on \`RnFastRunner.xcodeproj\` on macos-15 with code-signing disabled |

All \`\${{ }}\` interpolations read from \`matrix.*\` (workflow-defined values) — no \`github.event.*\` untrusted input — safe per [github.blog workflow-injection guidance](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/).

## Required manual step after merge

GitHub does not auto-disable default setup when an advanced workflow appears (advanced setup must be explicitly opted into for each language). After this PR merges:

1. Repo → **Settings** → **Code security and analysis** → **Code scanning**
2. Find the **CodeQL** configuration
3. Switch from **Default setup** to **Advanced**

Once switched, the workflow added here takes over. Default-setup runs will stop and the existing red X marks for swift / java-kotlin will be replaced by results from this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)