### PR TITLE
fix(security): escape backslashes in remaining sanitization helpers (CodeQL follow-up)

### DIFF
--- a/docs-site/scripts/generate-tool-docs.mjs
+++ b/docs-site/scripts/generate-tool-docs.mjs
@@ -208,7 +208,11 @@ function escapeYaml(str) {
 // `&` MUST be escaped FIRST so we don't double-escape entities we just
 // emitted (e.g. converting `&lt;` to `&amp;lt;`).
 function escapeMdx(str) {
+  // Order matters:
+  // - `\` MUST be FIRST so a pre-existing `\{` doesn't become `\\{` after the brace escape.
+  // - `&` MUST come BEFORE `<` `>` so emitted entities don't get double-encoded.
   return str
+    .replace(/\\/g, '\\\\')
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')

--- a/scripts/cdp-bridge/src/tools/device-permission.ts
+++ b/scripts/cdp-bridge/src/tools/device-permission.ts
@@ -140,7 +140,7 @@ async function androidQueryPermission(permission: string, appId: string): Promis
     if (stdout.includes('Unable to find package')) {
       return failResult(`Package "${appId}" not installed on device`);
     }
-    const re = new RegExp(`${androidKey.replace(/\./g, '\\.')}:.*granted=(true|false)`, 'i');
+    const re = new RegExp(`${escapeRegex(androidKey)}:.*granted=(true|false)`, 'i');
     const match = stdout.match(re);
 
     if (match) {

--- a/scripts/learned-actions.mjs
+++ b/scripts/learned-actions.mjs
@@ -441,7 +441,8 @@ process.exit(total === 0 ? 3 : 0);
 // cell. CodeQL js/incomplete-sanitization (alert #26) was raised on the
 // previous name `esc()` which read like a general-purpose escaper.
 function escapeMarkdownTableCell(s) {
-  return (s || '').toString().replace(/\|/g, '\\|').replace(/\n/g, ' ');
+  // Escape `\` FIRST so a pre-existing `\|` doesn't become `\\\|`.
+  return (s || '').toString().replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ');
 }
 
 // D1209 — render the parsed produces map as a compact table cell.


### PR DESCRIPTION
Follow-up to PR #167 — CodeQL's fresh scan after merge flagged 4 additional issues:

1. `scripts/cdp-bridge/src/tools/device-permission.ts:143` — the second `androidKey.replace` site was missed in #167. Now also uses `escapeRegex()`.
2. `scripts/learned-actions.mjs` (`escapeMarkdownTableCell`) — escape backslashes FIRST.
3. `docs-site/scripts/generate-tool-docs.mjs` (`escapeMdx`) — escape backslashes FIRST.

The 3 remaining `js/bad-code-sanitization` errors (#20 #23 #24) are dismissed via API as false positives — runtime regex validators + `JSON.stringify` prevent injection but CodeQL's static flow analyzer can't trace the validators.