### PR TITLE
fix(deps): close 5 high-severity Dependabot alerts (fast-uri + devalue)

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -1979,7 +1979,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2066,7 +2065,6 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.5.tgz",
       "integrity": "sha512-AJVw/JlssxUCBFi3Hp4djL8Pt7wUQqStBBawCd8cNGBBM2lBzp/rXGguzt4OcMfW+86fs0hpFwMyopHM2r6d3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^3.0.1",
         "@astrojs/internal-helpers": "0.8.0",
@@ -2519,9 +2517,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
-      "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -4950,7 +4948,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5403,7 +5400,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6081,7 +6077,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -561,6 +561,22 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -1244,14 +1260,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/undici-types": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
-      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -1600,7 +1608,6 @@
     "scripts/cdp-bridge/node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1658,20 +1665,6 @@
     "scripts/cdp-bridge/node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
-    },
-    "scripts/cdp-bridge/node_modules/fast-uri": {
-      "version": "3.1.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "scripts/cdp-bridge/node_modules/finalhandler": {
       "version": "2.1.1",
@@ -1779,7 +1772,6 @@
     "scripts/cdp-bridge/node_modules/hono": {
       "version": "4.12.14",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2221,7 +2213,6 @@
     "scripts/cdp-bridge/node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/scripts/cdp-bridge/package-lock.json
+++ b/scripts/cdp-bridge/package-lock.json
@@ -463,9 +463,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -25,6 +25,7 @@
     "node": ">=22"
   },
   "overrides": {
-    "@hono/node-server": ">=1.19.13"
+    "@hono/node-server": ">=1.19.13",
+    "fast-uri": ">=3.1.2"
   }
 }


### PR DESCRIPTION
## Summary

Closes all 5 open **high-severity** Dependabot alerts on `main`:

| # | Package | Manifest | Vulnerable → Patched | CVE / Advisory |
|---|---------|----------|-----|-----|
| 11 | `fast-uri` | `scripts/cdp-bridge/package-lock.json` | 3.1.0 → 3.1.2 | path traversal via percent-encoded dot segments |
| 15 | `fast-uri` | `scripts/cdp-bridge/package-lock.json` | 3.1.0 → 3.1.2 | host confusion via percent-encoded authority delimiters |
| 20 | `fast-uri` | `package-lock.json` | 3.1.0 → 3.1.2 | path traversal |
| 21 | `fast-uri` | `package-lock.json` | 3.1.0 → 3.1.2 | host confusion |
| 25 | `devalue` | `docs-site/package-lock.json` | 5.7.1 → 5.8.1 | DoS via sparse array deserialization |

## How

Both packages reach us transitively — patches sit inside the parent's existing semver range, so no `package.json` API change is required.

- **`fast-uri`**: pulled in via `@modelcontextprotocol/sdk → ajv@8.18.0` (`^3.0.1`). 3.1.2 already satisfies that range.
  - Root lockfile bumped via `npm update fast-uri --package-lock-only`.
  - `scripts/cdp-bridge/package-lock.json` is a published lockfile (shipped to npm consumers); it can't be re-resolved through the workspace root, so I patched its `node_modules/fast-uri` entry directly (version + resolved + integrity sha512). I also added a defensive `"fast-uri": ">=3.1.2"` override in `scripts/cdp-bridge/package.json` so a fresh `npm install rn-dev-agent-cdp` on a future ajv release that pins an older fast-uri can't regress.
- **`devalue`**: pulled in via `astro@6.1.5`. `npm update devalue --package-lock-only` in `docs-site/` handled it cleanly.

## Test plan

- [x] cdp-bridge unit suite: **1464/1464 passing** locally with patched lockfile
- [x] Lockfile internally consistent (`npm install` in cdp-bridge clean, no integrity errors)
- [ ] CI green (CodeQL + Build & Test) on this PR
- [ ] Dependabot auto-closes the 5 alerts once merged to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)