### PR TITLE
chore(gitignore): collapse codex-pair entries to single .codex-pair/ line (ADR-092)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,8 @@ scripts/rn-fast-runner/**/DerivedData/
 # deepsec scanner workspace (local-only — config, data/<id>/INFO.md, scan output)
 .deepsec/
 
-# codex-pair (per-developer opt-in; marker presence enables the hook)
-.codex-pair-context.md
-.codex-pair-log.jsonl
-.codex-pair-cache/
-.codex-pair-state/
+# codex-pair (per-developer opt-in; marker presence enables the hook).
+# Per ADR-092, every state artifact (marker, log, cache, ignore globs,
+# pause sentinel, inflight locks) nests under a single directory so one
+# line covers everything including future additions.
+.codex-pair/


### PR DESCRIPTION
## Summary

`ask-llm` plugin v0.7.1 moved every codex-pair state artifact (marker, log, cache, ignore globs, pause sentinel, inflight locks) under a single `.codex-pair/` directory per ADR-092. The old four-line gitignore block no longer matches the layout — those exact paths never get created by the new hook, so the entries are dead.

| Old (dead) | New (replaces all four) |
|---|---|
| `.codex-pair-context.md` | `.codex-pair/` |
| `.codex-pair-log.jsonl` | (covers context.md, log.jsonl, cache/, state/, ignore, inflight) |
| `.codex-pair-cache/` | |
| `.codex-pair-state/` | |

## Why this matters

Plugin v0.7.1's hook self-gates on `.codex-pair/context.md`. The old marker at `.codex-pair-context.md` is no longer recognized — so contributors who set up codex-pair under v0.6.x see the hook go silent after the plugin update (the log goes ~6 days without entries — that's how I noticed). New contributors enabling codex-pair only need the single `.codex-pair/` gitignore entry; the entire opt-in state directory is per-developer and never committed.

## Verified locally

- Migrated `.codex-pair-context.md` → `.codex-pair/context.md` (marker preserved verbatim)
- Migrated `.codex-pair-log.jsonl` → `.codex-pair/log.jsonl`
- Migrated `.codex-pair-cache/` → `.codex-pair/cache/`
- Migrated `.codex-pair-state/` → `.codex-pair/state/`
- New hook fires on the next Edit — smoke test caught both planted issues (regex-injection HIGH + non-`import type` MED) in 19s
- `git check-ignore -v` confirms all three new paths are covered by the single `.codex-pair/` line

## Test plan

- [x] gitignore patterns verified via `git check-ignore`
- [x] codex-pair hook fires correctly with new layout (smoke test)
- [ ] CI green (gitignore-only change; should be quick)

## Refs

- ADR-092 — single-directory layout for codex-pair state
- `ask-llm` plugin v0.7.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)