### PR TITLE
fix(cdp): fast-fail cdp_status when the Dev Client picker blocks the bundle (closes #184)

### DIFF
--- a/scripts/cdp-bridge/dist/cdp-client.js
+++ b/scripts/cdp-bridge/dist/cdp-client.js
@@ -132,11 +132,11 @@ export class CDPClient {
         }
         return ok;
     }
-    async autoConnect(portHint, filtersOrPlatform) {
+    async autoConnect(portHint, filtersOrPlatform, intent = 'default') {
         const filters = typeof filtersOrPlatform === 'string'
             ? { platform: filtersOrPlatform }
             : (filtersOrPlatform ?? {});
-        return autoConnectFn(this.buildConnectCtx(), portHint, filters);
+        return autoConnectFn(this.buildConnectCtx(), portHint, filters, intent);
     }
     async listTargets(portHint) {
         return discoverForList(this._port, portHint);

--- a/scripts/cdp-bridge/dist/cdp/connect.js
+++ b/scripts/cdp-bridge/dist/cdp/connect.js
@@ -4,7 +4,41 @@ import { resolveBundleId } from '../project-config.js';
 import { discover } from './discovery.js';
 import { sleep } from './state.js';
 import { CDP_TIMEOUT_FAST } from './timeout-config.js';
-export async function autoConnect(ctx, portHint, filters) {
+import { probeReactReachable } from './setup.js';
+// Budget for the status-scoped React-reachability probe. Generous enough to
+// clear a normal Bridgeless reload (React ready in <~2s) but far below setup()'s
+// 30s waitForReact, so cdp_status fails fast instead of hanging when the Dev
+// Client picker blocks the bundle. Env-overridable for tuning/tests.
+const PICKER_PROBE_BUDGET_MS = (() => {
+    const n = parseInt(process.env.RN_PICKER_PROBE_BUDGET_MS ?? '', 10);
+    return Number.isFinite(n) && n > 0 ? n : 5000;
+})();
+/**
+ * GH #184: thrown when a status-scoped connect can't reach React within the
+ * bounded budget on a non-Hermes target — the signature of the Expo Dev Client
+ * "Development servers" picker leaving stale C++ targets advertised while the
+ * bundle never loads. status.ts maps it to a fast, actionable failResult
+ * instead of letting setup() burn the full 30s waitForReact.
+ */
+export class PickerBlockingBundleError extends Error {
+    target;
+    constructor(target) {
+        super(`Dev Client picker appears to be blocking the bundle: React was not reachable on target ` +
+            `"${target.title}" (vm=${target.vm}). If the Expo "Development servers" picker is showing on ` +
+            `the simulator, select your Metro server, then retry cdp_status. (If the bundle is still building, just retry.)`);
+        this.name = 'PickerBlockingBundleError';
+        this.target = target;
+    }
+}
+/**
+ * GH #184: run the bounded picker probe only for a status-intent connect against
+ * a non-Hermes target. Hermes targets are skipped so a genuinely slow Hermes
+ * first-build keeps the full waitForReact budget rather than being aborted.
+ */
+export function shouldRunPickerProbe(intent, target) {
+    return intent === 'status' && target.vm !== 'Hermes';
+}
+export async function autoConnect(ctx, portHint, filters, intent = 'default') {
     if (ctx.getState() === 'connecting' || ctx.isReconnecting()) {
         throw new Error('Already connecting to Metro...');
     }
@@ -25,12 +59,15 @@ export async function autoConnect(ctx, portHint, filters) {
         if (resolved)
             effective.preferredBundleId = resolved;
     }
-    return discoverAndConnect(ctx, portHint, effective);
+    return discoverAndConnect(ctx, portHint, effective, discover, intent);
 }
 export async function discoverAndConnect(ctx, portHint, filters, 
 // B111 (D643): injectable for unit tests — defaults to real discover. Production
 // call sites pass nothing, so behavior is unchanged. Tests pass a stub.
-discoverFn = discover) {
+discoverFn = discover, 
+// GH #184: connect intent threaded to connectToTarget. Kept last so existing
+// callers (and tests passing discoverFn as the 4th arg) are unaffected.
+intent = 'default') {
     if (ctx.isDisposed()) {
         throw new Error('Client is disposed. Create a new CDPClient instance.');
     }
@@ -71,7 +108,7 @@ discoverFn = discover) {
         const candidate = sorted[idx];
         const isLast = idx === sorted.length - 1;
         try {
-            await connectToTarget(ctx, candidate);
+            await connectToTarget(ctx, candidate, 5, intent);
             const devCheck = await ctx.evaluate('typeof __DEV__ !== "undefined" && __DEV__ === true');
             if (devCheck.value === true) {
                 connectedTarget = candidate;
@@ -89,6 +126,12 @@ discoverFn = discover) {
             connectedTarget = candidate;
         }
         catch (err) {
+            // GH #184: picker-blocking affects the whole bundle — every other
+            // candidate is the same stale C++ target, so don't waste a probe on each.
+            if (err instanceof PickerBlockingBundleError) {
+                ctx.setState('disconnected');
+                throw err;
+            }
             if (!isLast)
                 continue;
             throw err;
@@ -151,7 +194,7 @@ export function formatConnectFailureMessage(retries, attempts, bundleHint, lastE
         : '';
     return `Failed to connect after ${retries} attempts.${hint}`;
 }
-async function connectToTarget(ctx, target, retries = 5) {
+async function connectToTarget(ctx, target, retries = 5, intent = 'default') {
     let lastError = null;
     // GH #105 / B154: track per-attempt outcome (handshake ok vs probe timeout).
     // Fed into formatConnectFailureMessage at the end.
@@ -187,10 +230,28 @@ async function connectToTarget(ctx, target, retries = 5) {
             // M11: stamp connection time so cdp_console_log / cdp_network_log can reason
             // about "how long have we been connected with nothing happening?"
             ctx.setConnectedAt(ctx.now());
+            // GH #184: for a status-scoped connect, bounded-probe React reachability
+            // BEFORE the up-to-30s waitForReact inside setup(). A non-Hermes target
+            // that can't reach React within the budget is a stale C++ connection the
+            // Dev Client picker leaves advertised — abort fast with a typed error
+            // instead of hanging. Hermes targets are skipped (legit slow builds).
+            if (shouldRunPickerProbe(intent, target)) {
+                const reachable = await probeReactReachable((expr) => ctx.evaluate(expr), PICKER_PROBE_BUDGET_MS);
+                if (!reachable)
+                    throw new PickerBlockingBundleError(target);
+            }
             await ctx.setup();
             return;
         }
         catch (err) {
+            // GH #184: the picker-blocking abort is deterministic, not transient —
+            // don't burn the retry budget on it; clean up and surface it immediately.
+            if (err instanceof PickerBlockingBundleError) {
+                closeAndResetWs(ctx);
+                ctx.setConnectedTarget(null);
+                ctx.setState('disconnected');
+                throw err;
+            }
             lastError = err instanceof Error ? err : new Error(String(err));
             attempts.push({ handshakeOk, probeTimedOut });
             closeAndResetWs(ctx);

--- a/scripts/cdp-bridge/dist/cdp/setup.js
+++ b/scripts/cdp-bridge/dist/cdp/setup.js
@@ -118,6 +118,28 @@ export async function reinjectHelpers(evaluate, waitTimeout) {
     }
     return true;
 }
+/**
+ * GH #184: bounded variant of waitForReact that RETURNS whether React became
+ * reachable within `budgetMs` (vs waitForReact which always resolves void after
+ * logging). Used by the status-scoped picker-blocking probe to decide fast,
+ * before the full REACT_READY_TIMEOUT_MS wait in setup(), whether a non-Hermes
+ * target is a stale (picker-blocked) connection.
+ */
+export async function probeReactReachable(evaluate, budgetMs, pollMs = REACT_READY_POLL_MS) {
+    const start = Date.now();
+    while (Date.now() - start < budgetMs) {
+        try {
+            const result = await evaluate(REACT_READY_PROBE_JS);
+            if (result.value === true)
+                return true;
+        }
+        catch {
+            // not ready yet
+        }
+        await sleep(pollMs);
+    }
+    return false;
+}
 export async function waitForReact(evaluate, timeout, pollInterval) {
     const effectiveTimeout = timeout ?? REACT_READY_TIMEOUT_MS;
     const effectivePoll = pollInterval ?? REACT_READY_POLL_MS;

--- a/scripts/cdp-bridge/dist/tools/status.js
+++ b/scripts/cdp-bridge/dist/tools/status.js
@@ -1,5 +1,6 @@
 import { okResult, failResult, warnResult } from '../utils.js';
 import { handleDevClientPicker, isDevClientPickerShowing } from './dev-client-picker.js';
+import { PickerBlockingBundleError } from '../cdp/connect.js';
 import { getSessionReloadCount } from './reload.js';
 import { supportsNativeMultiDebugger } from '../cdp/multiplexer.js';
 // M10 / Phase 110: narrow `appInfo.architecture` to the StatusResult union.
@@ -111,7 +112,7 @@ export function createStatusHandler(getClient, setClient, createClient) {
                     }
                 }
                 catch { /* fall through to autoConnect */ }
-                await client.autoConnect(args.metroPort, args.platform);
+                await client.autoConnect(args.metroPort, args.platform, 'status');
             }
             else if (args.platform) {
                 // GH #21: Already connected — check if the current target matches the requested platform
@@ -123,7 +124,7 @@ export function createStatusHandler(getClient, setClient, createClient) {
                     await client.disconnect();
                     client = createClient(client.metroPort);
                     setClient(client);
-                    await client.autoConnect(args.metroPort, args.platform);
+                    await client.autoConnect(args.metroPort, args.platform, 'status');
                 }
             }
             const status = await buildStatusResult(client);
@@ -203,6 +204,12 @@ export function createStatusHandler(getClient, setClient, createClient) {
         }
         catch (err) {
             const message = err instanceof Error ? err.message : String(err);
+            // GH #184: the status-scoped connect aborted fast because React was
+            // unreachable on a non-Hermes target (picker blocking the bundle, or it's
+            // still building). The message is already actionable; still attempt the
+            // best-effort auto-dismiss below (helps when a device session is open),
+            // then surface it with a typed code instead of a generic failure.
+            const pickerBlocking = err instanceof PickerBlockingBundleError;
             // If connection failed, check if the Dev Client picker is blocking
             try {
                 const pickerResult = await handleDevClientPicker();
@@ -227,7 +234,7 @@ export function createStatusHandler(getClient, setClient, createClient) {
                 }
             }
             catch { /* picker check failed, return original error */ }
-            return failResult(message);
+            return pickerBlocking ? failResult(message, 'PICKER_BLOCKING') : failResult(message);
         }
     };
 }

--- a/scripts/cdp-bridge/src/cdp-client.ts
+++ b/scripts/cdp-bridge/src/cdp-client.ts
@@ -19,7 +19,7 @@ import {
   autoConnect as autoConnectFn,
   discoverAndConnect as discoverAndConnectFn,
 } from './cdp/connect.js';
-import type { ConnectContext, ConnectFilters } from './cdp/connect.js';
+import type { ConnectContext, ConnectFilters, ConnectIntent } from './cdp/connect.js';
 import {
   handleClose as handleCloseFn,
   reconnect as reconnectFn,
@@ -167,11 +167,11 @@ export class CDPClient {
     return ok;
   }
 
-  async autoConnect(portHint?: number, filtersOrPlatform?: string | ConnectFilters): Promise<string> {
+  async autoConnect(portHint?: number, filtersOrPlatform?: string | ConnectFilters, intent: ConnectIntent = 'default'): Promise<string> {
     const filters: ConnectFilters = typeof filtersOrPlatform === 'string'
       ? { platform: filtersOrPlatform }
       : (filtersOrPlatform ?? {});
-    return autoConnectFn(this.buildConnectCtx(), portHint, filters);
+    return autoConnectFn(this.buildConnectCtx(), portHint, filters, intent);
   }
 
   async listTargets(portHint?: number): Promise<{ port: number; targets: HermesTarget[] }> {

--- a/scripts/cdp-bridge/src/cdp/connect.ts
+++ b/scripts/cdp-bridge/src/cdp/connect.ts
@@ -5,7 +5,51 @@ import { discover } from './discovery.js';
 import type { SelectTargetFilters } from './discovery.js';
 import { sleep } from './state.js';
 import { CDP_TIMEOUT_FAST } from './timeout-config.js';
+import { probeReactReachable } from './setup.js';
 import type { CDPClientState, EvaluateResult, HermesTarget } from '../types.js';
+
+// GH #184: distinguishes a quick health-check connect (cdp_status) from every
+// other connect path. Only 'status' connects run the bounded picker probe; all
+// other paths keep the full waitForReact budget for legitimate slow builds.
+export type ConnectIntent = 'default' | 'status';
+
+// Budget for the status-scoped React-reachability probe. Generous enough to
+// clear a normal Bridgeless reload (React ready in <~2s) but far below setup()'s
+// 30s waitForReact, so cdp_status fails fast instead of hanging when the Dev
+// Client picker blocks the bundle. Env-overridable for tuning/tests.
+const PICKER_PROBE_BUDGET_MS = (() => {
+  const n = parseInt(process.env.RN_PICKER_PROBE_BUDGET_MS ?? '', 10);
+  return Number.isFinite(n) && n > 0 ? n : 5000;
+})();
+
+/**
+ * GH #184: thrown when a status-scoped connect can't reach React within the
+ * bounded budget on a non-Hermes target — the signature of the Expo Dev Client
+ * "Development servers" picker leaving stale C++ targets advertised while the
+ * bundle never loads. status.ts maps it to a fast, actionable failResult
+ * instead of letting setup() burn the full 30s waitForReact.
+ */
+export class PickerBlockingBundleError extends Error {
+  readonly target: HermesTarget;
+  constructor(target: HermesTarget) {
+    super(
+      `Dev Client picker appears to be blocking the bundle: React was not reachable on target ` +
+      `"${target.title}" (vm=${target.vm}). If the Expo "Development servers" picker is showing on ` +
+      `the simulator, select your Metro server, then retry cdp_status. (If the bundle is still building, just retry.)`,
+    );
+    this.name = 'PickerBlockingBundleError';
+    this.target = target;
+  }
+}
+
+/**
+ * GH #184: run the bounded picker probe only for a status-intent connect against
+ * a non-Hermes target. Hermes targets are skipped so a genuinely slow Hermes
+ * first-build keeps the full waitForReact budget rather than being aborted.
+ */
+export function shouldRunPickerProbe(intent: ConnectIntent, target: HermesTarget): boolean {
+  return intent === 'status' && target.vm !== 'Hermes';
+}
 
 export interface ConnectFilters {
   platform?: string;
@@ -50,6 +94,7 @@ export async function autoConnect(
   ctx: ConnectContext,
   portHint?: number,
   filters?: ConnectFilters,
+  intent: ConnectIntent = 'default',
 ): Promise<string> {
   if (ctx.getState() === 'connecting' || ctx.isReconnecting()) {
     throw new Error('Already connecting to Metro...');
@@ -69,7 +114,7 @@ export async function autoConnect(
     const resolved = resolveBundleId(effective.platform ?? 'ios');
     if (resolved) effective.preferredBundleId = resolved;
   }
-  return discoverAndConnect(ctx, portHint, effective);
+  return discoverAndConnect(ctx, portHint, effective, discover, intent);
 }
 
 export async function discoverAndConnect(
@@ -79,6 +124,9 @@ export async function discoverAndConnect(
   // B111 (D643): injectable for unit tests — defaults to real discover. Production
   // call sites pass nothing, so behavior is unchanged. Tests pass a stub.
   discoverFn: typeof discover = discover,
+  // GH #184: connect intent threaded to connectToTarget. Kept last so existing
+  // callers (and tests passing discoverFn as the 4th arg) are unaffected.
+  intent: ConnectIntent = 'default',
 ): Promise<string> {
   if (ctx.isDisposed()) {
     throw new Error('Client is disposed. Create a new CDPClient instance.');
@@ -123,7 +171,7 @@ export async function discoverAndConnect(
     const candidate = sorted[idx];
     const isLast = idx === sorted.length - 1;
     try {
-      await connectToTarget(ctx, candidate);
+      await connectToTarget(ctx, candidate, 5, intent);
       const devCheck = await ctx.evaluate('typeof __DEV__ !== "undefined" && __DEV__ === true');
       if (devCheck.value === true) {
         connectedTarget = candidate;
@@ -140,6 +188,12 @@ export async function discoverAndConnect(
       console.error('CDP: no target with __DEV__=true found, using last available target');
       connectedTarget = candidate;
     } catch (err) {
+      // GH #184: picker-blocking affects the whole bundle — every other
+      // candidate is the same stale C++ target, so don't waste a probe on each.
+      if (err instanceof PickerBlockingBundleError) {
+        ctx.setState('disconnected');
+        throw err;
+      }
       if (!isLast) continue;
       throw err;
     }
@@ -218,6 +272,7 @@ async function connectToTarget(
   ctx: ConnectContext,
   target: HermesTarget,
   retries = 5,
+  intent: ConnectIntent = 'default',
 ): Promise<void> {
   let lastError: Error | null = null;
   // GH #105 / B154: track per-attempt outcome (handshake ok vs probe timeout).
@@ -253,9 +308,26 @@ async function connectToTarget(
       // M11: stamp connection time so cdp_console_log / cdp_network_log can reason
       // about "how long have we been connected with nothing happening?"
       ctx.setConnectedAt(ctx.now());
+      // GH #184: for a status-scoped connect, bounded-probe React reachability
+      // BEFORE the up-to-30s waitForReact inside setup(). A non-Hermes target
+      // that can't reach React within the budget is a stale C++ connection the
+      // Dev Client picker leaves advertised — abort fast with a typed error
+      // instead of hanging. Hermes targets are skipped (legit slow builds).
+      if (shouldRunPickerProbe(intent, target)) {
+        const reachable = await probeReactReachable((expr) => ctx.evaluate(expr), PICKER_PROBE_BUDGET_MS);
+        if (!reachable) throw new PickerBlockingBundleError(target);
+      }
       await ctx.setup();
       return;
     } catch (err) {
+      // GH #184: the picker-blocking abort is deterministic, not transient —
+      // don't burn the retry budget on it; clean up and surface it immediately.
+      if (err instanceof PickerBlockingBundleError) {
+        closeAndResetWs(ctx);
+        ctx.setConnectedTarget(null);
+        ctx.setState('disconnected');
+        throw err;
+      }
       lastError = err instanceof Error ? err : new Error(String(err));
       attempts.push({ handshakeOk, probeTimedOut });
       closeAndResetWs(ctx);

--- a/scripts/cdp-bridge/src/cdp/setup.ts
+++ b/scripts/cdp-bridge/src/cdp/setup.ts
@@ -171,6 +171,31 @@ export async function reinjectHelpers(
   return true;
 }
 
+/**
+ * GH #184: bounded variant of waitForReact that RETURNS whether React became
+ * reachable within `budgetMs` (vs waitForReact which always resolves void after
+ * logging). Used by the status-scoped picker-blocking probe to decide fast,
+ * before the full REACT_READY_TIMEOUT_MS wait in setup(), whether a non-Hermes
+ * target is a stale (picker-blocked) connection.
+ */
+export async function probeReactReachable(
+  evaluate: (expr: string) => Promise<EvaluateResult>,
+  budgetMs: number,
+  pollMs: number = REACT_READY_POLL_MS,
+): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < budgetMs) {
+    try {
+      const result = await evaluate(REACT_READY_PROBE_JS);
+      if (result.value === true) return true;
+    } catch {
+      // not ready yet
+    }
+    await sleep(pollMs);
+  }
+  return false;
+}
+
 export async function waitForReact(
   evaluate: (expr: string) => Promise<EvaluateResult>,
   timeout?: number,

--- a/scripts/cdp-bridge/src/tools/status.ts
+++ b/scripts/cdp-bridge/src/tools/status.ts
@@ -2,6 +2,7 @@ import type { CDPClient } from '../cdp-client.js';
 import type { StatusResult } from '../types.js';
 import { okResult, failResult, warnResult } from '../utils.js';
 import { handleDevClientPicker, isDevClientPickerShowing } from './dev-client-picker.js';
+import { PickerBlockingBundleError } from '../cdp/connect.js';
 import { getSessionReloadCount } from './reload.js';
 import { supportsNativeMultiDebugger } from '../cdp/multiplexer.js';
 
@@ -130,7 +131,7 @@ export function createStatusHandler(
             await handleDevClientPicker();
           }
         } catch { /* fall through to autoConnect */ }
-        await client.autoConnect(args.metroPort, args.platform);
+        await client.autoConnect(args.metroPort, args.platform, 'status');
       } else if (args.platform) {
         // GH #21: Already connected — check if the current target matches the requested platform
         const currentTarget = client.connectedTarget;
@@ -141,7 +142,7 @@ export function createStatusHandler(
           await client.disconnect();
           client = createClient(client.metroPort);
           setClient(client);
-          await client.autoConnect(args.metroPort, args.platform);
+          await client.autoConnect(args.metroPort, args.platform, 'status');
         }
       }
 
@@ -234,6 +235,12 @@ export function createStatusHandler(
       return okResult(status, autoRecoveredMessage ? { meta: { autoRecovered: autoRecoveredMessage } } : undefined);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      // GH #184: the status-scoped connect aborted fast because React was
+      // unreachable on a non-Hermes target (picker blocking the bundle, or it's
+      // still building). The message is already actionable; still attempt the
+      // best-effort auto-dismiss below (helps when a device session is open),
+      // then surface it with a typed code instead of a generic failure.
+      const pickerBlocking = err instanceof PickerBlockingBundleError;
 
       // If connection failed, check if the Dev Client picker is blocking
       try {
@@ -261,7 +268,7 @@ export function createStatusHandler(
         }
       } catch { /* picker check failed, return original error */ }
 
-      return failResult(message);
+      return pickerBlocking ? failResult(message, 'PICKER_BLOCKING') : failResult(message);
     }
   };
 }

--- a/scripts/cdp-bridge/src/types.ts
+++ b/scripts/cdp-bridge/src/types.ts
@@ -203,7 +203,10 @@ export type ToolErrorCode =
   | 'STALE_REF'
   // Audit B5: cross_platform_verify verdict FAIL (elements differ across
   // platforms) — distinct from the partial-coverage missing-snapshot warning.
-  | 'CROSS_PLATFORM_MISMATCH';
+  | 'CROSS_PLATFORM_MISMATCH'
+  // GH #184: cdp_status aborted fast because the Dev Client picker was blocking
+  // the bundle (React unreachable on a non-Hermes target within the budget).
+  | 'PICKER_BLOCKING';
 
 export interface ResultEnvelope<T = unknown> {
   ok: boolean;

--- a/scripts/cdp-bridge/test/unit/gh-184-picker-blocking-probe.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-184-picker-blocking-probe.test.js
@@ -1,0 +1,60 @@
+// GH #184: cdp_status must fail fast (not hang ~33.5s) when the Dev Client
+// picker blocks the bundle. A status-scoped bounded React-reachability probe
+// runs before setup()'s 30s waitForReact; on timeout against a non-Hermes
+// (stale C++) target it throws PickerBlockingBundleError.
+//
+// connectToTarget opens a real WebSocket, so — following the repo convention
+// for formatConnectFailureMessage/stickyPlatformFilters — the decision logic is
+// extracted into pure helpers tested here without spinning a socket.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { probeReactReachable } from '../../dist/cdp/setup.js';
+import { shouldRunPickerProbe, PickerBlockingBundleError } from '../../dist/cdp/connect.js';
+
+const hermes = { id: 'a', title: 'X', vm: 'Hermes', webSocketDebuggerUrl: 'ws://x' };
+const cpp = { id: 'b', title: 'React Native Bridgeless [C++ connection]', vm: 'don\'t know', webSocketDebuggerUrl: 'ws://y' };
+
+// ── probeReactReachable ─────────────────────────────────────────────────
+
+test('probeReactReachable returns true as soon as React reports ready', async () => {
+  let calls = 0;
+  const evaluate = async () => { calls++; return { value: calls >= 2 }; };
+  const ok = await probeReactReachable(evaluate, 1000, 5);
+  assert.equal(ok, true);
+  assert.ok(calls >= 2);
+});
+
+test('probeReactReachable returns false when React never readies within budget', async () => {
+  const start = Date.now();
+  const ok = await probeReactReachable(async () => ({ value: false }), 80, 10);
+  assert.equal(ok, false);
+  assert.ok(Date.now() - start >= 80, 'waited at least the budget');
+  assert.ok(Date.now() - start < 2000, 'returned promptly, not after the 30s setup wait');
+});
+
+test('probeReactReachable tolerates a throwing evaluate then success', async () => {
+  let calls = 0;
+  const evaluate = async () => { calls++; if (calls < 2) throw new Error('not ready'); return { value: true }; };
+  assert.equal(await probeReactReachable(evaluate, 1000, 5), true);
+});
+
+// ── shouldRunPickerProbe (the vm/intent gate) ───────────────────────────
+
+test('shouldRunPickerProbe only fires for status intent on a non-Hermes target', () => {
+  assert.equal(shouldRunPickerProbe('status', cpp), true, 'status + non-Hermes → probe');
+  assert.equal(shouldRunPickerProbe('status', hermes), false, 'status + Hermes → skip (legit slow build)');
+  assert.equal(shouldRunPickerProbe('default', cpp), false, 'default intent → never probe');
+  assert.equal(shouldRunPickerProbe('default', hermes), false);
+});
+
+// ── PickerBlockingBundleError shape ─────────────────────────────────────
+
+test('PickerBlockingBundleError is an Error carrying the target + an actionable message', () => {
+  const err = new PickerBlockingBundleError(cpp);
+  assert.ok(err instanceof Error);
+  assert.equal(err.name, 'PickerBlockingBundleError');
+  assert.equal(err.target, cpp);
+  assert.match(err.message, /picker/i);
+  assert.match(err.message, /Metro|select|retry/i);
+});


### PR DESCRIPTION
Closes #184.

## Problem
`cdp_status({platform:'ios'})` with the Expo Dev Client "Development servers" picker up **and Metro running** hung **~33.5s**, logged `React not ready after 30000ms`, then returned a misleading `ok:true`. Root cause: stale C++ targets pass `filterValidTargets`, the `1+1` pre-flight probe passes (the C++ connection answers), and `performSetup`'s `waitForReact(REACT_READY_TIMEOUT_MS=30_000)` then burns its full 30s because the picker blocks the bundle so React never readies.

## Fix
Thread a connect intent (`'default' | 'status'`) through `autoConnect → discoverAndConnect → connectToTarget`. For a **status-scoped** connect against a **non-Hermes** target, run a **bounded React-reachability probe** (default 5s, `RN_PICKER_PROBE_BUDGET_MS`-overridable) *before* `setup()`'s 30s `waitForReact`. If React isn't reachable within the budget, throw the typed **`PickerBlockingBundleError`** — which bypasses both the `connectToTarget` retry loop and the `discoverAndConnect` candidate loop — and `status.ts` maps it to a fast `failResult` with code **`PICKER_BLOCKING`** and an actionable message:

> *Dev Client picker appears to be blocking the bundle … select your Metro server, then retry cdp_status.*

A *working* Bridgeless app's target is also a `[C++ connection]`, but its React **is** reachable, so the probe succeeds and the connect proceeds normally — only a genuinely blocked/never-ready target throws.

## What it deliberately does NOT do (the two regressions #184 called out)
- **Doesn't** shorten the global `REACT_READY_TIMEOUT_MS` — it's shared by every connect path and would regress legitimate slow first-builds.
- **Doesn't** add a pre-`autoConnect` target-shape heuristic — `/json/list` returns 0 Hermes targets transiently during healthy reloads, so that would false-positive.
- **Hermes** targets skip the probe entirely (a slow Hermes first-build keeps the full budget); **non-status** connect paths (cdp_connect, feature-dev, reconnect) are completely unchanged.

## Files (~5, as the issue estimated)
`cdp/connect.ts` (intent threading, `PickerBlockingBundleError`, `shouldRunPickerProbe`, probe + both catch sites), `cdp/setup.ts` (`probeReactReachable`), `cdp-client.ts` (intent param), `tools/status.ts` (`'status'` intent + mapping), `types.ts` (`PICKER_BLOCKING` code).

## Testing
- 5 new unit tests for the extracted pure helpers (`probeReactReachable`, `shouldRunPickerProbe`, `PickerBlockingBundleError`), written failing-first — the connect layer opens a real WebSocket, so the decision logic is extracted into pure helpers per the repo's existing `formatConnectFailureMessage`/`stickyPlatformFilters` convention.
- **Full suite: 1563 pass**; `tsc --noEmit` clean; existing connect tests unaffected.
- The end-to-end picker-up assertion (`cdp_status` returns < ~6s) belongs to the deferred Dev Client harness CI (DC-Task 9 / #136), per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)