### PR TITLE
chore(release): v0.44.45 — deliver #186/#188 maestro-interop fixes (re #189)

### DIFF
--- a/.claude-plugin/CHANGELOG.md
+++ b/.claude-plugin/CHANGELOG.md
@@ -1,0 +1,13 @@
+# rn-dev-agent-plugin
+
+## 0.44.45
+
+### Patch Changes
+
+- Deliver the GH #186 maestro-interop fixes that merged in #188 without a version bump (closes #189).
+
+  - `cdp_run_action` now allows `runFlow` (including `when:` conditionals and `{file}` sub-flows) through the Maestro command allowlist, so actions with conditional dialog-handling (Expo dev-server picker, iOS "Open in" dialog) replay through the canonical runner instead of hard-failing with `Command not in allowlist: runFlow (Phase 134.1)`.
+  - Non-destructive runner-leak `reacquire` recovery tier + cross-tool CDP re-pin, avoiding the ~44s relaunch / ~47s STALE_TARGET when maestro-mcp and rn-dev-agent contend for the same iOS device.
+  - Structural route-drift detection: a stale-selector failure on an inserted screen is classified `ROUTE_DRIFT` instead of triggering a wasted fuzzy-repair.
+
+  #188 shipped these to `main` with no version bump, leaving them undeliverable to marketplace installs; this patch publishes them.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "rn-dev-agent",
       "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
-      "version": "0.44.44",
+      "version": "0.44.45",
       "source": "./",
       "category": "mobile-development",
       "homepage": "https://github.com/Lykhoyda/rn-dev-agent"

--- a/.claude-plugin/package.json
+++ b/.claude-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-plugin",
-  "version": "0.44.44",
+  "version": "0.44.45",
   "private": true,
   "description": "Synthetic package — changesets uses this as the version source of truth for the Claude Code plugin manifest. Bumps here are mirrored into plugin.json + marketplace.json by scripts/sync-plugin-manifest.mjs (run automatically by `npm run version-packages`).",
   "license": "MIT"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent",
-  "version": "0.44.44",
+  "version": "0.44.45",
   "description": "AI agent that fully tests React Native features on simulator/emulator — navigates the app, verifies UI, walks user flows, and confirms internal state.",
   "author": {
     "name": "Anton Lykhoyda",

--- a/scripts/cdp-bridge/CHANGELOG.md
+++ b/scripts/cdp-bridge/CHANGELOG.md
@@ -1,0 +1,13 @@
+# rn-dev-agent-cdp
+
+## 0.38.40
+
+### Patch Changes
+
+- Deliver the GH #186 maestro-interop fixes that merged in #188 without a version bump (closes #189).
+
+  - `cdp_run_action` now allows `runFlow` (including `when:` conditionals and `{file}` sub-flows) through the Maestro command allowlist, so actions with conditional dialog-handling (Expo dev-server picker, iOS "Open in" dialog) replay through the canonical runner instead of hard-failing with `Command not in allowlist: runFlow (Phase 134.1)`.
+  - Non-destructive runner-leak `reacquire` recovery tier + cross-tool CDP re-pin, avoiding the ~44s relaunch / ~47s STALE_TARGET when maestro-mcp and rn-dev-agent contend for the same iOS device.
+  - Structural route-drift detection: a stale-selector failure on an inserted screen is classified `ROUTE_DRIFT` instead of triggering a wasted fuzzy-repair.
+
+  #188 shipped these to `main` with no version bump, leaving them undeliverable to marketplace installs; this patch publishes them.

--- a/scripts/cdp-bridge/package.json
+++ b/scripts/cdp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-dev-agent-cdp",
-  "version": "0.38.39",
+  "version": "0.38.40",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## What
Release **v0.44.45** (cdp-bridge 0.38.40) — delivers the GH #186 maestro-interop fixes that merged in #188 **without a version bump**.

| package | before | after |
|---|---|---|
| rn-dev-agent-plugin | 0.44.44 | 0.44.45 |
| rn-dev-agent-cdp | 0.38.39 | 0.38.40 |

## Why
#188 shipped these to `main` with no version bump, so plugin/cdp-bridge stayed at 0.44.44 / 0.38.39 — leaving the fix **undeliverable to marketplace installs**. It was re-reported as **#189** on 0.44.44 (filed ~3.5h *after* #188 merged). This bump publishes it.

## What's delivered (from #188)
- `cdp_run_action` allows `runFlow` (incl. `when:` conditionals + `{file}` sub-flows) — conditional dialog-handling actions replay through the canonical runner (the #189 primary).
- Non-destructive runner-leak `reacquire` recovery tier + cross-tool CDP re-pin.
- Structural route-drift detection (`ROUTE_DRIFT` vs a wasted fuzzy-repair).

## Notes
- Made via changesets (`npm run version-packages`); `Version sync check` passes (3 `.claude-plugin` manifests synced at 0.44.45).
- **References #189 (primary only).** The two *secondary* text-input issues in #189 (`inputText` email corruption; `device_fill` fallthrough while `cdp_interact` typing worked) are **not** in this release and remain tracked separately — intentionally not auto-closing #189.
- The bump commit was authored unsigned (1Password agent locked); a squash-merge will be GitHub-signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)