### PR TITLE
ci: require a changeset when shippable src changes (GH #189 post-mortem)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,30 @@ jobs:
         run: node --test 'test/integration/*.test.js'
         working-directory: scripts/cdp-bridge
 
+      # Runs at repo root (no working-directory) — guards the changeset CI gate.
+      - name: Changeset-guard unit test
+        run: bash scripts/test/require-changeset.test.sh
+
   version-sync:
     name: Version sync check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2 — Phase 134.5 SHA pin
       - run: bash scripts/sync-versions.sh
+
+  require-changeset:
+    name: Require changeset
+    runs-on: ubuntu-latest
+    # PR-only: needs a base branch to diff against. Pushes to main are post-merge.
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2 — Phase 134.5 SHA pin
+        with:
+          fetch-depth: 0
+      # base_ref is passed via env (never interpolate ${{ }} directly into run:).
+      - name: Require a changeset when shippable src changes
+        env:
+          BASE_REF_NAME: ${{ github.base_ref }}
+        run: |
+          git fetch origin "$BASE_REF_NAME"
+          BASE_REF="origin/$BASE_REF_NAME" bash scripts/require-changeset.sh

--- a/scripts/require-changeset.sh
+++ b/scripts/require-changeset.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# CI guard (GH #189 / v0.44.45 post-mortem): a PR that changes shippable MCP
+# source MUST include a changeset, so the change earns a version bump + release.
+# Without this, behavior fixes merge to main unversioned and never reach
+# marketplace installs — #188 shipped the runFlow fix with no bump, so users
+# never got it and it was re-reported as #189. Runs on pull_request; see
+# .github/workflows/ci.yml.
+#
+# Test seams (scripts/test/require-changeset.test.sh):
+#   CHANGED_FILES  newline-separated changed paths (overrides git diff)
+#   REPO_ROOT      where to look for .changeset/ (default: repo root)
+#   BASE_REF       git diff base when CHANGED_FILES is unset (default origin/main)
+set -uo pipefail
+
+ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+BASE_REF="${BASE_REF:-origin/main}"
+# Shippable MCP source. Tests, docs, CI, and the .claude-plugin manifest (which
+# IS the changeset output) are intentionally excluded.
+WATCHED='^scripts/cdp-bridge/src/'
+
+if [ -n "${CHANGED_FILES+x}" ]; then
+  changed="$CHANGED_FILES"
+else
+  changed="$(git -C "$ROOT" diff --name-only "${BASE_REF}...HEAD")"
+fi
+
+src_changed="$(printf '%s\n' "$changed" | grep -E "$WATCHED" || true)"
+
+if [ -z "$src_changed" ]; then
+  echo "require-changeset: no shippable src changes — changeset not required."
+  exit 0
+fi
+
+changesets="$(find "$ROOT/.changeset" -maxdepth 1 -type f -name '*.md' ! -name 'README.md' 2>/dev/null || true)"
+
+if [ -z "$changesets" ]; then
+  echo "ERROR: this PR changes shippable source but has NO changeset:" >&2
+  printf '%s\n' "$src_changed" | sed 's/^/  /' >&2
+  cat >&2 <<'MSG'
+
+A behavior change without a changeset ships to main unversioned and is
+undeliverable to marketplace installs (GH #189 / v0.44.45 post-mortem).
+
+Fix: run `npx changeset`, describe the change, and commit the generated
+.changeset/*.md file. Docs / test / CI-only PRs do not need one.
+MSG
+  exit 1
+fi
+
+echo "require-changeset: shippable src changed AND a changeset is present — OK."
+printf '%s\n' "$changesets" | sed 's/^/  /'
+exit 0

--- a/scripts/test/require-changeset.test.sh
+++ b/scripts/test/require-changeset.test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Regression test for require-changeset.sh — the CI guard that fails a PR which
+# changes shippable MCP source (scripts/cdp-bridge/src/) without a changeset.
+# Without this guard a behavior fix merges to main unversioned and is
+# undeliverable to marketplace installs (GH #189 / v0.44.45 post-mortem: #188
+# shipped the runFlow fix with no version bump, so users never got it).
+#
+# Run: bash scripts/test/require-changeset.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+GUARD="$SCRIPT_DIR/require-changeset.sh"
+
+fail=0
+check() { # description expected_exit actual_exit
+  if [ "$2" = "$3" ]; then
+    echo "ok: $1"
+  else
+    echo "FAIL: $1 — expected exit $2, got $3"
+    fail=1
+  fi
+}
+
+# Fake repo root with a .changeset/ dir holding only README (= "no changeset").
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/.changeset"
+echo "# changesets readme" > "$tmp/.changeset/README.md"
+
+# 1. shippable src changed, NO changeset -> MUST fail (the #188/#189 case)
+CHANGED_FILES=$'scripts/cdp-bridge/src/domain/maestro-validator.ts' \
+  REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "src change without changeset fails" 1 $?
+
+# 2. shippable src changed, changeset present -> passes
+printf -- '---\n"rn-dev-agent-cdp": patch\n---\nfix\n' > "$tmp/.changeset/brave-lions.md"
+CHANGED_FILES=$'scripts/cdp-bridge/src/domain/maestro-validator.ts' \
+  REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "src change with changeset passes" 0 $?
+rm -f "$tmp/.changeset/brave-lions.md"
+
+# 3. only non-shippable changes (tests / docs / CI) -> passes without a changeset
+CHANGED_FILES=$'scripts/cdp-bridge/test/unit/x.test.js\ndocs-site/foo.mdx\n.github/workflows/ci.yml' \
+  REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "non-src change without changeset passes" 0 $?
+
+# 4. empty diff -> passes
+CHANGED_FILES="" REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "empty diff passes" 0 $?
+
+if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; exit 1; fi


### PR DESCRIPTION
## What
A **PR-only CI guard** that fails when shippable MCP source (`scripts/cdp-bridge/src/`) changes without a changeset.

## Why
Direct follow-up to the **#189 / v0.44.45 post-mortem**: #188 merged a real behavior fix (the `runFlow` allowlist) to `main` with **no version bump**, so it never reached marketplace installs and was re-reported as #189. The fix existed — it was just undeliverable. This makes that class of mistake **impossible** rather than relying on remembering to bump.

## How
- **`scripts/require-changeset.sh`** — diffs the PR vs base; if any `scripts/cdp-bridge/src/` file changed, requires ≥1 `.changeset/*.md`. Seams: `CHANGED_FILES`, `REPO_ROOT`, `BASE_REF`. Fails-open on infra errors (won't spuriously block).
- **`scripts/test/require-changeset.test.sh`** — 4-case TDD regression test (src+no-changeset → fail; src+changeset → pass; non-src → pass; empty → pass). Run in the `Build & Test` job.
- **`ci.yml`** — new `require-changeset` job (PR-only). `github.base_ref` is passed via `env` + a quoted shell var (no `${{ }}` interpolation into `run:`).

## Scope / notes
- Excludes tests, docs, CI, and the `.claude-plugin` manifest (the manifest *is* the changeset output).
- This PR touches no `cdp-bridge/src/`, so it passes its own gate (verified locally against `main`).
- Does **not** fix the stale root `CHANGELOG.md` (diverged from the changesets per-package logs) — flagged as separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)