### PR TITLE
ci: automate version bumps via changesets (Version-PR + auto-merge)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+# Changesets release automation (Version-PR pattern).
+#
+# On every push to main, this opens/updates a "Version Packages" PR that runs
+# `npm run version-packages` (changeset version -> sync-plugin-manifest -> sync-versions --fix),
+# accumulating all pending changesets into one version bump. Merging that PR
+# bumps plugin.json + marketplace.json + cdp-bridge, updates CHANGELOGs, and
+# consumes the changesets — making the new version installable from the marketplace.
+#
+# No npm publish: the "package" is the plugin manifest the marketplace reads
+# from the repo, so only the version half of changesets/action is used.
+#
+# PREREQUISITES (must be enabled in repo settings — cannot be set from this file):
+#   - Settings > Actions > General > "Allow GitHub Actions to create and approve pull requests"
+#   - Settings > General > "Allow auto-merge"
+#   - Branch protection on main with >=1 required status check (so `gh pr merge --auto`
+#     has a check to gate on; otherwise auto-merge has nothing to wait for).
+
+on:
+  push:
+    branches: [main]
+
+concurrency: release-${{ github.ref }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: npm ci
+
+      - name: Create or update the Version Packages PR
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: npm run version-packages
+          commit: "chore(release): version packages"
+          title: "chore(release): version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge on the Version Packages PR
+        if: steps.changesets.outputs.pullRequestNumber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
+        run: gh pr merge --squash --auto "$PR_NUMBER"


### PR DESCRIPTION
## What

Adds `.github/workflows/release.yml` — the [`changesets/action`](https://github.com/changesets/action) **Version-PR** pattern with auto-merge.

## Flow

1. Feature PRs carry a changeset (already enforced by the `require-changeset` CI gate).
2. On push to `main`, this workflow opens/updates a **"Version Packages"** PR that runs `npm run version-packages` (accumulating all pending changesets).
3. Auto-merge is enabled on that PR, so it lands without a manual click → versions bump on `main` → the new version is installable from the marketplace.

No npm publish step: the plugin's "package" is the manifest the marketplace reads from the repo, so only the *version* half of changesets/action is used.

## Security note

The `gh pr merge` step passes the PR number through an `env:` variable (`PR_NUMBER`) rather than interpolating `${{ steps.changesets.outputs.pullRequestNumber }}` directly into the shell command — eliminating the injection surface even though the value is numeric and action-controlled.

## Required repo settings (enable before this works)

- **Settings → Actions → General →** "Allow GitHub Actions to create and approve pull requests"
- **Settings → General →** "Allow auto-merge"
- **Branch protection on `main`** with ≥1 required status check — `gh pr merge --auto` needs a check to gate on; with none, auto-merge has nothing to wait for.

## Notes

- Why a Version PR (not a direct push to `main`): it keeps the bump reviewable/visible and avoids racing concurrent merges, while auto-merge keeps it hands-off.
- The Version PR changes only version files + CHANGELOG + changeset deletions (no `src`), so `require-changeset` passes on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)