### PR TITLE
fix: resolve confirmed bugs/regressions/reliability findings from multi-agent audit

### DIFF
--- a/.changeset/audit-fixes-batch.md
+++ b/.changeset/audit-fixes-batch.md
@@ -1,0 +1,37 @@
+---
+"rn-dev-agent-cdp": patch
+"rn-dev-agent-plugin": patch
+---
+
+Fix a batch of bugs, regressions, and reliability issues surfaced by a multi-agent repo audit.
+
+**Security**
+- Redaction no longer leaks private-key material. `redactString` now applies secret patterns BEFORE truncating (a >2000-char PEM previously had its `-----END-----` marker severed by truncation so the key body passed through), and the PEM rule now matches multi-word labels like `RSA PRIVATE KEY` / `OPENSSH PRIVATE KEY` (the old single-word pattern never matched the most common headers).
+
+**Device interaction**
+- `device_scroll` no longer throws on Android (and on the iOS fast-runner fallback): a direction-form scroll is now converted to coordinates before dispatch, matching `device_swipe`.
+- `device_batch` scroll steps no longer crash the whole batch on either platform (same root cause).
+- A coordinate `device_swipe` with `--count`/`--pattern` but no `durationMs` no longer mis-parses the flag value as a 3 ms duration on iOS (the positional extractor now strips flag values, matching Android).
+- The Android runner is no longer reused across emulators: `shouldReuseAndroidRunner` checks the bound `deviceId` (parity with iOS `shouldReuseRunner`), so a runner bound to one emulator can't silently drive another.
+- A wedged-but-alive fast-runner is now reaped: `ensureFastRunner` probes tri-state liveness instead of PID-only, so a hung HTTP listener no longer makes every subsequent command burn the full timeout.
+- `ensureSingleRunner` is now awaited at session-open so the stale-runner kill completes before the first interaction, and its `ps` failure surfaces as a warning instead of a silent no-op.
+
+**Actions / Maestro**
+- Actions now auto-promote `experimental → active` on the first clean replay (the documented lifecycle was defined + tested but never wired).
+- The GH#186 route-drift guard is now active in production (`cdp_run_action` is wired with a CDP-backed live-route reader; it previously defaulted to a no-op).
+- `maestro_test_all` and the inline Maestro fallback no longer mark passing flows as failed when app/console output merely contains `Error:`, and both now auto-resolve `--app-file` for iOS `clearState` flows (previously only `maestro_run` did). `clearState` detection also recognises the standalone `- clearState` command.
+- All Maestro `execFile` calls raise `maxBuffer` to 10 MB so a large flow log can't kill the child and mask a passing run.
+- `cdp_repair_action` `RUNNER_LEAK` refusals are now bucketed as `SNAPSHOT_FAILED` in MTTR telemetry instead of `INTERNAL_ERROR`.
+- A bare-form `id:` repair now emits a quoted scalar, so a testID containing YAML-special characters can't corrupt the action.
+
+**Reliability / correctness**
+- `collect_logs` no longer double-shifts Android logcat timestamps by the host UTC offset (which corrupted both the time and the cross-source merge order).
+- CDP freshness/dev probes attach a no-op catch to the raced `evaluate()` promise so a mid-probe WebSocket close can't surface as an unhandledRejection.
+- The observability server keeps a small `headersTimeout` (slow-loris guard), broadcasts a `shutdown` event so the browser stops auto-reconnecting after stop, and `Recorder.clear()` notifies subscribers instead of orphaning live SSE streams.
+- Action IDs now accept dots (`v2.0-login`) per their documented contract while still rejecting `..`.
+- The post-edit health-check hook's "app not installed → skip" guard works again (`grep -c || echo "0"` produced a two-line `0\n0`).
+- `learned-actions` resolves the project memory dir correctly for paths containing a dot, and its `${VAR}` extractor accepts digit-bearing keys.
+- The injected-helpers version is a single source of truth (the post-injection log no longer reports a stale `v11`).
+- `sync-versions.sh` drops a dead, misleading variable and documents that `rn-dev-agent-cdp` is independently versioned.
+
+Hardened the previously flaky `proof_step` unit tests (they depended on a machine-global session file) with a dependency-injection seam, making the suite deterministic.

--- a/docs-site/src/content/docs/actions/index.mdx
+++ b/docs-site/src/content/docs/actions/index.mdx
@@ -61,7 +61,7 @@ The hybrid is implemented across **four MCP tools** (one conceptual family, "Act
 | Tool | Role |
 |---|---|
 | `cdp_record_test_save_as_action` | Convert a recorded interactive walk into a first-class `.rn-agent/actions/<id>.yaml` with metadata header and sidecar state file. Auto-promotes to `status: active` after the first clean replay. |
-| `cdp_run_action` | Replay an action by id with `params`. Orchestrates `maestro_run` + optional `cdp_repair_action` retry. Persists a `RunRecord` with `autoRepair` telemetry (passed / failed / refused / skipped, phase timings) so the experience engine can learn which flows are stable. |
+| `cdp_run_action` | Replay an action by id with `params`. Orchestrates `maestro_run` + optional `cdp_repair_action` retry. Persists a `RunRecord` with `autoRepair` telemetry (passed / failed / refused / skipped, phase timings) so MTTR analysis can see which flows are stable. |
 | `cdp_repair_action` | When a run fails with `SELECTOR_NOT_FOUND`, fuzzy-match the stale selector against the live snapshot, patch the YAML, retry. Refuses on human-edited files (`mtime` check), >3 repairs/24h, or snapshot infrastructure failure. |
 | `cdp_record_test_*` (start / stop / generate / annotate / save / load / list) | The recorder upstream of actions — captures device taps + CDP state assertions during interactive walks, before they get promoted to actions. |
 

--- a/hooks/post-edit-health-check.sh
+++ b/hooks/post-edit-health-check.sh
@@ -107,7 +107,10 @@ if [[ "$ios_booted" == "true" ]]; then
   if [[ -f "$app_json" ]]; then
     bundle_id=$(jq -r '.expo.ios.bundleIdentifier // empty' "$app_json" 2>/dev/null)
     if [[ -n "$bundle_id" ]]; then
-      installed=$(xcrun simctl listapps booted 2>/dev/null | grep -cF "\"$bundle_id\"" || echo "0")
+      # `grep -c` already prints `0` on no match (and exits 1); use `|| true` to
+      # swallow that exit code. A prior `|| echo "0"` appended a SECOND `0`,
+      # yielding the two-line string "0\n0" so the `== "0"` skip guard never fired.
+      installed=$(xcrun simctl listapps booted 2>/dev/null | grep -cF "\"$bundle_id\"" || true)
       if [[ "$installed" == "0" ]]; then
         exit 0  # App not installed on simulator — skip
       fi
@@ -121,7 +124,8 @@ elif [[ "$android_booted" == "true" ]]; then
       android_pkg=$(jq -r '.android.package // empty' "$app_json" 2>/dev/null)
     fi
     if [[ -n "$android_pkg" ]]; then
-      installed=$(adb shell pm list packages 2>/dev/null | grep -cxF "package:$android_pkg" || echo "0")
+      # See iOS note above: `|| true` (not `|| echo "0"`) avoids the "0\n0" bug.
+      installed=$(adb shell pm list packages 2>/dev/null | grep -cxF "package:$android_pkg" || true)
       if [[ "$installed" == "0" ]]; then
         exit 0  # App not installed on emulator — skip
       fi

--- a/scripts/cdp-bridge/dist/agent-device-wrapper.js
+++ b/scripts/cdp-bridge/dist/agent-device-wrapper.js
@@ -6,7 +6,7 @@ import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { okResult, failResult } from './utils.js';
-import { isFastRunnerAvailable, startFastRunner, } from './runners/rn-fast-runner-client.js';
+import { startFastRunner, probeFastRunnerLiveness, reapStaleFastRunner, } from './runners/rn-fast-runner-client.js';
 import { refCenter, getScreenRect, clearRefMap, isRefMapFresh } from './fast-runner-ref-map.js';
 import { resolveBundleId } from './project-config.js';
 const execFile = promisify(execFileCb);
@@ -286,7 +286,7 @@ export function getCachedScreenRect() {
 }
 export function buildRunIOSArgs(cliArgs, bundleId) {
     const cmd = cliArgs[0];
-    const positionals = cliArgs.slice(1).filter((a) => !a.startsWith('--'));
+    const positionals = positionalArgs(cliArgs);
     switch (cmd) {
         case 'press':
         case 'tap': {
@@ -404,7 +404,11 @@ function optionValue(cliArgs, flag) {
     const value = cliArgs[i + 1];
     return value && !value.startsWith('-') ? value : undefined;
 }
-function androidPositionals(cliArgs) {
+// Extract positional args, dropping flag tokens AND their values (`--count 3`,
+// `--pattern xy`). A naive `filter(a => !a.startsWith('--'))` strips the flag
+// token but keeps its value, which then mis-parses as a trailing positional
+// (e.g. count's `3` landing in the swipe duration slot → a 3ms flick).
+function positionalArgs(cliArgs) {
     const out = [];
     for (let i = 1; i < cliArgs.length; i++) {
         const a = cliArgs[i];
@@ -420,7 +424,7 @@ function androidPositionals(cliArgs) {
 }
 export function buildRunAndroidArgs(cliArgs, bundleId) {
     const cmd = cliArgs[0];
-    const positionals = androidPositionals(cliArgs);
+    const positionals = positionalArgs(cliArgs);
     const withBundle = bundleId ? { bundleId } : {};
     switch (cmd) {
         case 'press':
@@ -526,8 +530,18 @@ export function buildRunAndroidArgs(cliArgs, bundleId) {
     }
 }
 export async function ensureFastRunner(deviceId, bundleId) {
-    if (isFastRunnerAvailable())
+    // M7/Phase-109: probe tri-state liveness instead of the PID-only
+    // isFastRunnerAvailable(). A runner whose PID is alive but whose HTTP server
+    // has wedged ('stale') must be reaped before a fresh start — otherwise it is
+    // reused and every subsequent device_* command burns the full HTTP timeout
+    // before failing. /health responds in ms when healthy, so the happy path is
+    // cheap; only a wedged runner pays the 2s probe timeout (vs. 10s per command).
+    const liveness = await probeFastRunnerLiveness();
+    if (liveness === 'alive')
         return;
+    if (liveness === 'stale') {
+        await reapStaleFastRunner();
+    }
     try {
         await startFastRunner(deviceId, bundleId);
     }

--- a/scripts/cdp-bridge/dist/cdp/recovery.js
+++ b/scripts/cdp-bridge/dist/cdp/recovery.js
@@ -22,8 +22,13 @@ export async function probeFreshness(client, timeoutMs = FRESHNESS_PROBE_MS) {
     }
     let probeTimer;
     try {
+        // If the timeout wins the race, this evaluate() promise is orphaned; attach
+        // a no-op catch so a later rejection (e.g. a mid-probe WebSocket close)
+        // can't surface as an unhandledRejection and crash the MCP process.
+        const evalPromise = client.evaluate('typeof globalThis.__RN_AGENT === "object" && globalThis.__RN_AGENT.__v');
+        evalPromise.catch(() => { });
         const result = await Promise.race([
-            client.evaluate('typeof globalThis.__RN_AGENT === "object" && globalThis.__RN_AGENT.__v'),
+            evalPromise,
             new Promise((resolve) => {
                 probeTimer = setTimeout(() => resolve({ error: 'timeout' }), timeoutMs);
             }),
@@ -68,8 +73,12 @@ export async function recoverFromStaleTarget(client) {
 async function probeDev(client, timeoutMs) {
     let timer;
     try {
+        // No-op catch on the orphaned promise if the timeout wins the race (see
+        // probeFreshness) — prevents an unhandledRejection on a mid-probe WS close.
+        const evalPromise = client.evaluate('typeof __DEV__ !== "undefined" && __DEV__ === true');
+        evalPromise.catch(() => { });
         const result = await Promise.race([
-            client.evaluate('typeof __DEV__ !== "undefined" && __DEV__ === true'),
+            evalPromise,
             new Promise((resolve) => {
                 timer = setTimeout(() => resolve({ error: 'probe timeout' }), timeoutMs);
             }),

--- a/scripts/cdp-bridge/dist/cdp/setup.js
+++ b/scripts/cdp-bridge/dist/cdp/setup.js
@@ -1,4 +1,4 @@
-import { INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, REACT_READY_PROBE_JS } from '../injected-helpers.js';
+import { HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, REACT_READY_PROBE_JS } from '../injected-helpers.js';
 import { logger } from '../logger.js';
 import { setActiveFlag, sleep } from './state.js';
 import { CDP_TIMEOUT_FAST, timeoutForMethod } from './timeout-config.js';
@@ -49,7 +49,7 @@ export async function performSetup(opts) {
         console.error('CDP: helper injection succeeded but __RN_AGENT not found');
         return { networkMode, helpersInjected: false, logDomainEnabled, profilerAvailable, heapProfilerAvailable };
     }
-    logger.info('CDP', `Helpers injected (v11), network mode: ${networkMode}`);
+    logger.info('CDP', `Helpers injected (v${HELPERS_VERSION}), network mode: ${networkMode}`);
     setActiveFlag(port, connectedTarget);
     // D626 (B1 fix): Probe whether Network.enable actually delivers events.
     // GH #59 #9: a single 500ms probe is too tight after platform switches /

--- a/scripts/cdp-bridge/dist/domain/action-store.js
+++ b/scripts/cdp-bridge/dist/domain/action-store.js
@@ -307,6 +307,15 @@ export function saveActionWithCAS(action) {
             // Corrupted sidecar — treat as no prior state, proceed to write.
         }
     }
+    // NOTE on the SaveActionPreconditionError that saveAction can throw here:
+    // this throw is LOAD-BEARING, not a contract bug. When forceReload=false and
+    // the YAML was edited externally, the throw propagates to cdp_run_action's
+    // top-level catch and becomes the correct strict-mode (Phase 129) refusal —
+    // see gh-173-run-action-force-reload. Converting it to a structured conflict
+    // makes persistRun treat it as a transient CAS race and retry-then-succeed,
+    // silently dropping the refusal. The RunRecord can't be persisted in that
+    // case anyway (the sidecar is pair-written with the YAML, which strict mode
+    // is deliberately refusing to clobber), so there is nothing to recover.
     const { filePath, sidecarPath: writtenSidecarPath } = saveAction(action);
     return { ok: true, filePath, sidecarPath: writtenSidecarPath };
 }

--- a/scripts/cdp-bridge/dist/domain/path-safety.js
+++ b/scripts/cdp-bridge/dist/domain/path-safety.js
@@ -28,15 +28,20 @@ export class PathTraversalError extends Error {
 // ── Action ID validation ────────────────────────────────────────────
 // Action IDs flow into `.rn-agent/actions/<id>.yaml` and the matching
 // sidecar `.rn-agent/state/<id>.state.json`. They must start with an alphanumeric
-// character, then accept hyphen/underscore/dot/alphanumeric. We
-// deliberately exclude `..`, `/`, `\`, and control characters so the
-// ID can never escape its parent directory.
-const ACTION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+// character, then accept hyphen/underscore/dot/alphanumeric (dots support
+// versioned flow names like `v2.0-login`). We deliberately exclude `..`, `/`,
+// `\`, and control characters so the ID can never escape its parent directory.
+const ACTION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.-]*$/;
 const ACTION_ID_MAX_LEN = 64;
 export function isValidActionId(s) {
     if (typeof s !== 'string')
         return false;
     if (s.length === 0 || s.length > ACTION_ID_MAX_LEN)
+        return false;
+    // Belt-and-suspenders: even though `<id>.yaml` has no path separator, never
+    // allow a `..` segment in the slug — keeps the "deliberately exclude `..`"
+    // contract literally true regardless of how the id is later joined.
+    if (s.includes('..'))
         return false;
     return ACTION_ID_RE.test(s);
 }

--- a/scripts/cdp-bridge/dist/domain/repair-engine.js
+++ b/scripts/cdp-bridge/dist/domain/repair-engine.js
@@ -160,7 +160,19 @@ export function replaceIdSelector(body, oldId, newId) {
         }
         m = line.match(bare);
         if (m) {
-            out.push(`${m[1]}id: ${newId}${m[2]}`);
+            // D3: the bare form has no original quote style to preserve, so emit a
+            // SAFELY-quoted scalar. isSafeMaestroScalar only rejects control chars /
+            // line separators — it lets `:`, `{`, `[`, `#`, `"` through — so an
+            // unquoted `id: ${newId}` produced invalid YAML for a testID like
+            // `button: submit` or `{fab}`, permanently breaking the action after a
+            // repair. Matched-quote grammar (same as maestro-error-parser): prefer the
+            // quote the value lacks; escape only when it contains both.
+            const quoted = !newId.includes('"')
+                ? `"${newId}"`
+                : !newId.includes("'")
+                    ? `'${newId}'`
+                    : `"${newId.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+            out.push(`${m[1]}id: ${quoted}${m[2]}`);
             replacements++;
             continue;
         }

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -14,7 +14,7 @@ import { createStatusHandler } from './tools/status.js';
 import { createEvaluateHandler } from './tools/evaluate.js';
 import { createReloadHandler } from './tools/reload.js';
 import { createComponentTreeHandler } from './tools/component-tree.js';
-import { createNavigationStateHandler } from './tools/navigation-state.js';
+import { createNavigationStateHandler, readLiveRoute } from './tools/navigation-state.js';
 import { createErrorLogHandler } from './tools/error-log.js';
 import { createNativeErrorsHandler } from './tools/native-errors.js';
 import { createNetworkLogHandler } from './tools/network-log.js';
@@ -674,7 +674,12 @@ trackedTool('cdp_run_action', 'Replay a learned action by id with end-to-end aut
     timeoutMs: z.number().optional().describe('Maestro execution timeout per attempt (ms). Default 120_000.'),
     trigger: z.enum(['agent', 'ci', 'human']).optional().describe('RunRecord trigger annotation. Default "agent". CI calls should pass "ci".'),
     forceReload: z.boolean().optional().describe('GH #173: when true (default), acknowledge any human edit to the YAML as the new baseline before running so downstream repair does not abort with STALE_TARGET. Pass false for the strict Phase 129 "respect external edits" behavior (useful for CI replays of fixed baselines).'),
-}, createRunActionHandler());
+}, 
+// GH #186: supply a CDP-backed live-route reader so the route-drift guard is
+// actually active. Without this the handler defaulted getLiveRoute to a no-op
+// and the drift branch could never fire, silently routing screen-change
+// failures into fuzzy selector repair.
+createRunActionHandler({ getLiveRoute: () => readLiveRoute(getClient()) }));
 // B76/D644: unified process-lifecycle shutdown. All termination signals + stdin.end
 // funnel into this graceful path so the 5s background-poll setInterval in
 // reconnection.ts (the zombie cause) is cleared on every exit.

--- a/scripts/cdp-bridge/dist/injected-helpers.js
+++ b/scripts/cdp-bridge/dist/injected-helpers.js
@@ -1,6 +1,11 @@
+// Single source of truth for the injected-helpers protocol version. Bump this
+// whenever the injected surface changes; it flows into the IIFE's freshness
+// check (__RN_AGENT.__v) AND the post-injection log line, so they can never
+// drift (the log previously hard-coded a stale "v11").
+export const HELPERS_VERSION = 23;
 export const INJECTED_HELPERS = `
 (function() {
-  var __HELPERS_VERSION__ = 23;
+  var __HELPERS_VERSION__ = ${HELPERS_VERSION};
   if (globalThis.__RN_AGENT && globalThis.__RN_AGENT.__v === __HELPERS_VERSION__) return;
   if (globalThis.__RN_AGENT) delete globalThis.__RN_AGENT;
 

--- a/scripts/cdp-bridge/dist/maestro-invoke.js
+++ b/scripts/cdp-bridge/dist/maestro-invoke.js
@@ -6,6 +6,7 @@ import { homedir, tmpdir } from 'node:os';
 import { resolveBundleId, readExpoSlug } from './project-config.js';
 import { buildMaestroFlow, parseAndValidateFlow, isValidBundleId, MaestroValidationError, } from './domain/maestro-validator.js';
 import { chooseMaestroDispatch } from './tools/maestro-dispatch.js';
+import { resolveAppFileForClearState } from './tools/resolve-ios-app-file.js';
 const execFile = promisify(execFileCb);
 // Escape a user-supplied string for safe embedding inside a double-quoted YAML scalar.
 // Handles backslash, double quote, and control characters that would break the scalar.
@@ -44,11 +45,13 @@ export async function runMaestroInline(yaml, opts) {
     const rawAppId = opts.appId ?? resolveBundleId(opts.platform) ?? readExpoSlug() ?? '';
     const flowFile = join(tmpdir(), `rn-maestro-invoke-${opts.slug ?? 'flow'}-${Date.now()}.yaml`);
     let content;
+    let headerAppId;
     try {
         const parsed = parseAndValidateFlow(yaml, { rejectHeader: true });
         const appIdOpts = {};
         if (rawAppId && isValidBundleId(rawAppId)) {
             appIdOpts.appId = rawAppId;
+            headerAppId = rawAppId;
         }
         else if (rawAppId) {
             return {
@@ -83,10 +86,20 @@ export async function runMaestroInline(yaml, opts) {
         };
     }
     const timeout = opts.timeoutMs ?? 30_000;
+    // GH#201 parity with maestro_run: resolve --app-file so an iOS clearState flow
+    // run through this inline path (device_fill/picker/dialog fallbacks) can
+    // reinstall the app instead of failing after uninstall.
+    const appFileResolution = resolveAppFileForClearState(opts.platform, content, headerAppId, undefined);
+    if (!appFileResolution.ok) {
+        return { passed: false, output: '', flowFile, error: appFileResolution.error };
+    }
     try {
-        const { stdout, stderr } = await execFile(dispatch.binPath, dispatch.buildArgs(opts.platform, flowFile), { timeout, encoding: 'utf8' });
+        const { stdout, stderr } = await execFile(dispatch.binPath, dispatch.buildArgs(opts.platform, flowFile, appFileResolution.appFile), { timeout, encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 });
         const output = (stdout + '\n' + stderr).trim();
-        const passed = !output.includes('FAILED') && !output.includes('Error:');
+        // Runner exited 0 → authoritative pass. Key the secondary scan on maestro's
+        // `FAILED` token only; a broad `Error:` match false-flagged passing runs
+        // whose app/console output merely contained "Error:" (mirrors maestro_run).
+        const passed = !output.includes('FAILED');
         return { passed, output, flowFile };
     }
     catch (err) {

--- a/scripts/cdp-bridge/dist/observability/recorder.js
+++ b/scripts/cdp-bridge/dist/observability/recorder.js
@@ -41,7 +41,22 @@ export class Recorder {
         return { snapshot, detach: () => { this.subs.delete(fn); } };
     }
     getScreenshot(seq) { return this.shots.get(seq); }
-    clear() { this.buf.clear(); this.subs.clear(); this.shots.clear(); this.seq = 0; }
+    clear() {
+        this.buf.clear();
+        // Notify live subscribers with a terminal sentinel BEFORE dropping them, so
+        // a clear() (e.g. a future "reset session") can't silently orphan an open
+        // SSE stream + its heartbeat interval. The server's stream subscriber ends
+        // the response on this event.
+        for (const fn of this.subs) {
+            try {
+                fn({ type: 'cleared' });
+            }
+            catch { /* per-subscriber swallow */ }
+        }
+        this.subs.clear();
+        this.shots.clear();
+        this.seq = 0;
+    }
     captureScreenshot(ev, o) {
         if (ev.tool !== 'device_screenshot' || !ev.ok)
             return;

--- a/scripts/cdp-bridge/dist/observability/server.js
+++ b/scripts/cdp-bridge/dist/observability/server.js
@@ -8,6 +8,7 @@ export class ObservabilityServer {
     recorder;
     server = null;
     port = 0;
+    streams = new Set();
     constructor(recorder) {
         this.recorder = recorder;
     }
@@ -15,8 +16,12 @@ export class ObservabilityServer {
         if (this.server)
             return { url: this.url(), port: this.port };
         const server = createServer((req, res) => this.handle(req, res));
+        // SSE responses are long-lived, so disable the body timeout. But keep a
+        // small headersTimeout so a connection that stalls mid-request-headers
+        // (slow-loris) is closed instead of held open forever — SSE clients send
+        // their headers immediately, so 5s is ample.
         server.requestTimeout = 0;
-        server.headersTimeout = 0;
+        server.headersTimeout = 5_000;
         try {
             this.port = await listen(server, preferredPort ?? 0);
         }
@@ -34,6 +39,18 @@ export class ObservabilityServer {
     async stop() {
         const s = this.server;
         this.server = null;
+        // Tell live SSE clients we're shutting down BEFORE yanking the sockets, so
+        // the browser's EventSource closes instead of entering its auto-reconnect
+        // loop (which would otherwise hammer the dead port, or silently reattach to
+        // a different session started later on the same port).
+        for (const res of this.streams) {
+            try {
+                res.write('data: {"type":"shutdown"}\n\n');
+                res.end();
+            }
+            catch { /* already closed */ }
+        }
+        this.streams.clear();
         if (s) {
             s.closeAllConnections?.();
             await new Promise((r) => s.close(() => r()));
@@ -66,17 +83,26 @@ export class ObservabilityServer {
                 return false;
             }
         };
-        const { snapshot, detach } = this.recorder.attach((ev) => { if (!write(ev)) {
-            detach();
-            res.end();
-        } });
+        this.streams.add(res);
+        const { snapshot, detach } = this.recorder.attach((ev) => {
+            // Recorder.clear() emits a terminal sentinel — end the stream cleanly.
+            if (ev.type === 'cleared') {
+                detach();
+                res.end();
+                return;
+            }
+            if (!write(ev)) {
+                detach();
+                res.end();
+            }
+        });
         write({ type: 'snapshot', events: snapshot });
         const hb = setInterval(() => { try {
             res.write(': hb\n\n');
         }
         catch { /* closed */ } }, 15_000);
         hb.unref?.();
-        res.on('close', () => { clearInterval(hb); detach(); });
+        res.on('close', () => { clearInterval(hb); detach(); this.streams.delete(res); });
     }
     guard(req, res) {
         const host = (req.headers.host ?? '').toLowerCase();

--- a/scripts/cdp-bridge/dist/runners/ensure-single-runner.js
+++ b/scripts/cdp-bridge/dist/runners/ensure-single-runner.js
@@ -36,14 +36,11 @@ export function shouldRemoveDaemonFiles(daemonPid, isAlive) {
 }
 function defaultDeps() {
     return {
-        listProcesses: () => {
-            try {
-                return execFileSync('ps', ['-A', '-o', 'pid=,args='], { encoding: 'utf8', timeout: 3_000 });
-            }
-            catch {
-                return '';
-            }
-        },
+        // Let a `ps` failure (timeout / EAGAIN under load) PROPAGATE to the
+        // caller's try/catch, which records a warning. Swallowing it here and
+        // returning '' made single-runner enforcement degrade to a silent no-op
+        // with no operator signal — exactly when the machine is busy.
+        listProcesses: () => execFileSync('ps', ['-A', '-o', 'pid=,args='], { encoding: 'utf8', timeout: 3_000 }),
         kill: (pid, signal) => process.kill(pid, signal),
         isAlive: (pid) => {
             try {

--- a/scripts/cdp-bridge/dist/runners/rn-android-runner-client.js
+++ b/scripts/cdp-bridge/dist/runners/rn-android-runner-client.js
@@ -61,8 +61,23 @@ export function isAndroidRunnerAvailable() {
         return false;
     }
 }
+/**
+ * GH#202 parity with iOS shouldReuseRunner: only adopt a live runner when it is
+ * bound to the SAME emulator. The state file path is a fixed constant shared
+ * across projects/sessions, so a runner bound to emulator-A must never be reused
+ * to drive emulator-B (its adb forward + port still point at A — every command
+ * would silently hit the wrong device). When no specific deviceId is requested
+ * (single-device flow), any live runner is acceptable.
+ */
+export function shouldReuseAndroidRunner(state, deviceId) {
+    if (state === null)
+        return false;
+    if (!deviceId)
+        return true;
+    return state.deviceId === deviceId;
+}
 export async function startAndroidRunner(deviceId, bundleId, port = DEFAULT_PORT) {
-    if (isAndroidRunnerAvailable())
+    if (isAndroidRunnerAvailable() && shouldReuseAndroidRunner(runnerState, deviceId))
         return runnerState;
     const serial = adbSerialArgs(deviceId);
     await execFileAsync('adb', [...serial, 'forward', `tcp:${port}`, `tcp:${port}`]);

--- a/scripts/cdp-bridge/dist/tools/collect-logs.js
+++ b/scripts/cdp-bridge/dist/tools/collect-logs.js
@@ -167,7 +167,6 @@ function collectNativeAndroid(durationMs, signal) {
     return new Promise((resolve, reject) => {
         const entries = [];
         const year = new Date().getFullYear();
-        const tzOffsetMs = new Date().getTimezoneOffset() * 60_000;
         const killMs = durationMs > 0 ? durationMs : 100;
         let killed = false;
         let killedByUs = false;
@@ -213,7 +212,7 @@ function collectNativeAndroid(durationMs, signal) {
             const lines = buf.split('\n');
             buf = lines.pop() ?? '';
             for (const line of lines) {
-                const entry = parseLogcatLine(line, year, tzOffsetMs);
+                const entry = parseLogcatLine(line, year);
                 if (entry)
                     entries.push(entry);
             }
@@ -227,7 +226,7 @@ function collectNativeAndroid(durationMs, signal) {
                 clearTimeout(sigkillTimer);
             signal.removeEventListener('abort', onAbort);
             if (buf.trim()) {
-                const entry = parseLogcatLine(buf, year, tzOffsetMs);
+                const entry = parseLogcatLine(buf, year);
                 if (entry)
                     entries.push(entry);
             }
@@ -259,13 +258,17 @@ const LOGCAT_RE = /^(\d{2}-\d{2})\s+(\d{2}:\d{2}:\d{2}\.\d{3})\s+(\d+)\s+\d+\s+(
 const ANDROID_LEVEL_MAP = {
     V: 'debug', D: 'debug', I: 'info', W: 'warn', E: 'error', F: 'error', S: 'log',
 };
-function parseLogcatLine(line, year, tzOffsetMs) {
+export function parseLogcatLine(line, year) {
     const m = LOGCAT_RE.exec(line);
     if (!m)
         return null;
     const [, date, time, pidStr, priority, tag, message] = m;
-    const localDate = new Date(`${year}-${date}T${time}`);
-    const utcDate = new Date(localDate.getTime() + tzOffsetMs);
+    // logcat emits device-LOCAL wall-clock with no offset. `new Date("...T...")`
+    // (no trailing Z) already parses in the local zone, so getTime() is already
+    // the correct UTC epoch — the previous `+ tzOffsetMs` double-shifted every
+    // entry by the host's UTC offset, corrupting both the reported time and the
+    // cross-source merge-sort ordering.
+    const utcDate = new Date(`${year}-${date}T${time}`);
     return {
         source: 'native_android',
         level: ANDROID_LEVEL_MAP[priority] ?? 'log',

--- a/scripts/cdp-bridge/dist/tools/device-batch.js
+++ b/scripts/cdp-bridge/dist/tools/device-batch.js
@@ -1,5 +1,5 @@
 import { runAgentDevice } from '../agent-device-wrapper.js';
-import { buildDirectionalSwipeCliArgs } from './device-interact.js';
+import { buildDirectionalScrollCliArgs, buildDirectionalSwipeCliArgs } from './device-interact.js';
 import { withSession, okResult, failResult } from '../utils.js';
 import { captureAndResizeScreenshot } from './device-list.js';
 /**
@@ -156,7 +156,9 @@ async function executeStep(step) {
         case 'scroll': {
             if (!step.direction)
                 return failResult('scroll requires direction');
-            return runAgentDevice(['scroll', step.direction]);
+            // Coordinate form — the raw ['scroll', direction] shape throws in the
+            // iOS/Android arg builders and aborted the whole batch.
+            return runAgentDevice(buildDirectionalScrollCliArgs(step.direction));
         }
         case 'back': {
             return runAgentDevice(['back']);

--- a/scripts/cdp-bridge/dist/tools/device-interact.js
+++ b/scripts/cdp-bridge/dist/tools/device-interact.js
@@ -610,6 +610,34 @@ export function buildDirectionalSwipeCliArgs(direction, durationMs) {
     const duration = durationMs ?? DEFAULT_SWIPE_DURATION_MS;
     return ['swipe', String(coords.x1), String(coords.y1), String(coords.x2), String(coords.y2), String(duration)];
 }
+// Scroll direction → finger gesture is INVERTED vs swipe ("scroll down" = content
+// moves up = finger moves up) and scaled by `amount` (0..1). Centred half-spans
+// keep the gesture inside the viewport.
+function computeScrollFromDirection(direction, amount, screen) {
+    const cx = Math.round(screen.width / 2);
+    const cy = Math.round(screen.height / 2);
+    const dy = Math.round(screen.height * SWIPE_FRACTION * amount);
+    const dx = Math.round(screen.width * SWIPE_FRACTION * amount);
+    switch (direction) {
+        case 'down': return { x1: cx, y1: cy + Math.round(dy / 2), x2: cx, y2: cy - Math.round(dy / 2) };
+        case 'up': return { x1: cx, y1: cy - Math.round(dy / 2), x2: cx, y2: cy + Math.round(dy / 2) };
+        case 'left': return { x1: cx + Math.round(dx / 2), y1: cy, x2: cx - Math.round(dx / 2), y2: cy };
+        case 'right': return { x1: cx - Math.round(dx / 2), y1: cy, x2: cx + Math.round(dx / 2), y2: cy };
+    }
+}
+// Shared by the standalone scroll handler's daemon fallthrough and device_batch
+// so a "scroll" step always dispatches the COORDINATE form. The arg builders
+// (buildRunIOSArgs / buildRunAndroidArgs) map scroll → a 4-coordinate drag and
+// throw on the direction form — so the raw ['scroll', direction] shape that used
+// to be dispatched here crashed on Android (always) and on the iOS fast-runner
+// fallback path.
+export function buildDirectionalScrollCliArgs(direction, amount, durationMs) {
+    const screen = getCachedScreenRect() ?? DEFAULT_SCREEN;
+    const clamped = Math.min(Math.max(amount ?? 0.5, 0), 1);
+    const coords = computeScrollFromDirection(direction, clamped, screen);
+    const duration = durationMs ?? DEFAULT_SWIPE_DURATION_MS;
+    return ['scroll', String(coords.x1), String(coords.y1), String(coords.x2), String(coords.y2), String(duration)];
+}
 export function exactModeRejectionMessage(reason) {
     if (reason === 'count-pattern-incompatible') {
         return 'exact: true is incompatible with count/pattern (those route through agent-device daemon which enforces safe-normalized timing). Drop count/pattern or drop exact.';
@@ -701,33 +729,10 @@ export function createDeviceScrollHandler() {
         // because the UI thread is never "idle" between scroll events. Fast-runner
         // uses `RunnerDaemonProxy.synthesize(eventRecord)` which is raw HID event
         // injection and returns as soon as events are delivered.
+        const screen = getCachedScreenRect() ?? DEFAULT_SCREEN;
+        const amount = Math.min(Math.max(args.amount ?? 0.5, 0), 1);
+        const { x1, y1, x2, y2 } = computeScrollFromDirection(args.direction, amount, screen);
         if (isFastRunnerAvailable()) {
-            const screen = getCachedScreenRect() ?? DEFAULT_SCREEN;
-            const amount = Math.min(Math.max(args.amount ?? 0.5, 0), 1);
-            const cx = Math.round(screen.width / 2);
-            const cy = Math.round(screen.height / 2);
-            const dy = Math.round(screen.height * SWIPE_FRACTION * amount);
-            const dx = Math.round(screen.width * SWIPE_FRACTION * amount);
-            let x1 = cx, y1 = cy, x2 = cx, y2 = cy;
-            switch (args.direction) {
-                // "scroll down" = content moves up = finger moves up (swipe up)
-                case 'down':
-                    y1 = cy + Math.round(dy / 2);
-                    y2 = cy - Math.round(dy / 2);
-                    break;
-                case 'up':
-                    y1 = cy - Math.round(dy / 2);
-                    y2 = cy + Math.round(dy / 2);
-                    break;
-                case 'left':
-                    x1 = cx + Math.round(dx / 2);
-                    x2 = cx - Math.round(dx / 2);
-                    break;
-                case 'right':
-                    x1 = cx - Math.round(dx / 2);
-                    x2 = cx + Math.round(dx / 2);
-                    break;
-            }
             try {
                 const resp = await fastSwipe(x1, y1, x2, y2, DEFAULT_SWIPE_DURATION_MS);
                 if (resp.ok) {
@@ -739,10 +744,10 @@ export function createDeviceScrollHandler() {
                 // Fall through to daemon on fast-runner error
             }
         }
-        const cliArgs = ['scroll', args.direction];
-        if (args.amount != null)
-            cliArgs.push(String(args.amount));
-        return runAgentDevice(cliArgs);
+        // Daemon / Android fallthrough: dispatch the COORDINATE form. The arg
+        // builders throw on the raw direction form, so this previously crashed on
+        // Android (always) and on the iOS fast-runner fallback.
+        return runAgentDevice(buildDirectionalScrollCliArgs(args.direction, args.amount));
     });
 }
 export function createDeviceScrollIntoViewHandler() {

--- a/scripts/cdp-bridge/dist/tools/device-session.js
+++ b/scripts/cdp-bridge/dist/tools/device-session.js
@@ -125,8 +125,13 @@ export function createDeviceSnapshotHandler() {
                 // targeting THIS simulator and clear orphaned daemon lock files.
                 // Default-on; opt out with RN_DEVICE_KILL_LEGACY=0.
                 if (process.env.RN_DEVICE_KILL_LEGACY !== '0' && args.platform === 'ios' && deviceId) {
-                    ensureSingleRunner({ udid: deviceId })
-                        .then((r) => {
+                    // Await: the stale-runner kill (SIGTERM → 500ms grace → SIGKILL) must
+                    // finish BEFORE the session is usable, or the first device_* command
+                    // races it and a stale AgentDeviceRunner can still steal focus —
+                    // which is exactly the single-runner guarantee #202 promises. The
+                    // added latency lands on an already-slow session-open, not per-command.
+                    try {
+                        const r = await ensureSingleRunner({ udid: deviceId });
                         if (r.killedPids.length) {
                             logger.info('rn-device', `ensureSingleRunner: killed stale runner PID(s) ${r.killedPids.join(', ')} on ${deviceId}`);
                         }
@@ -135,10 +140,10 @@ export function createDeviceSnapshotHandler() {
                         }
                         for (const w of r.warnings)
                             logger.warn('rn-device', w);
-                    })
-                        .catch((err) => {
+                    }
+                    catch (err) {
                         logger.warn('rn-device', `ensureSingleRunner failed: ${err instanceof Error ? err.message : String(err)}`);
-                    });
+                    }
                 }
                 // Task 9 of Android-MVP: warn on competing Android UIAutomator /
                 // agent-device processes that would contend for input + focus with

--- a/scripts/cdp-bridge/dist/tools/maestro-run.js
+++ b/scripts/cdp-bridge/dist/tools/maestro-run.js
@@ -7,7 +7,7 @@ import { okResult, failResult, warnResult } from '../utils.js';
 import { getActiveSession } from '../agent-device-wrapper.js';
 import { resolveBundleId, readExpoSlug } from '../project-config.js';
 import { chooseMaestroDispatch, shouldWarnFallback } from './maestro-dispatch.js';
-import { flowUsesClearState, resolveIosAppFile } from './resolve-ios-app-file.js';
+import { resolveAppFileForClearState } from './resolve-ios-app-file.js';
 import { buildMaestroFlow, parseAndValidateFlow, isValidBundleId, MaestroValidationError, } from '../domain/maestro-validator.js';
 const execFile = promisify(execFileCb);
 /** GH #116: Maestro env-style key pattern. Refuses anything that could
@@ -116,19 +116,11 @@ export function createMaestroRunHandler() {
         // params. Validation already ran at the top of the handler so by
         // this point every key matches PARAM_KEY_RE and every value is a
         // string — no need to re-check.
-        let appFile = args.appFile;
-        if (!appFile && platform === 'ios' && flowUsesClearState(validatedContent)) {
-            if (!headerAppId) {
-                return failResult('Flow uses clearState on iOS but no appId is known to locate the .app. ' +
-                    'Add `appId:` to the flow header or pass appFile=<path-to-.app>.');
-            }
-            appFile = resolveIosAppFile(headerAppId) ?? undefined;
-            if (!appFile) {
-                return failResult(`Flow uses clearState on iOS but no built .app could be located for ${headerAppId}. ` +
-                    'Pass appFile=<path-to-.app> (e.g. <DerivedData>/Build/Products/Debug-iphonesimulator/<App>.app).');
-            }
+        const appFileResolution = resolveAppFileForClearState(platform, validatedContent, headerAppId, args.appFile);
+        if (!appFileResolution.ok) {
+            return failResult(appFileResolution.error);
         }
-        const baseArgs = dispatch.buildArgs(platform, flowFile, appFile);
+        const baseArgs = dispatch.buildArgs(platform, flowFile, appFileResolution.appFile);
         const paramArgs = [];
         if (args.params) {
             for (const [key, value] of Object.entries(args.params)) {
@@ -137,7 +129,12 @@ export function createMaestroRunHandler() {
         }
         const finalArgs = [...baseArgs, ...paramArgs];
         try {
-            const { stdout, stderr } = await execFile(dispatch.binPath, finalArgs, { timeout, encoding: 'utf8' });
+            const { stdout, stderr } = await execFile(dispatch.binPath, finalArgs, 
+            // 10MB buffer: a multi-step flow with screenshots + app console/network
+            // logs routinely exceeds Node's 1MB execFile default, which would kill
+            // the child with ERR_CHILD_PROCESS_STDIO_MAXBUFFER and mask a passing
+            // run as a failure.
+            { timeout, encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 });
             const output = (stdout + '\n' + stderr).trim();
             // Reaching here means the runner exited 0 — that exit code is the
             // authoritative pass signal (a real flow failure exits non-zero and is

--- a/scripts/cdp-bridge/dist/tools/maestro-test-all.js
+++ b/scripts/cdp-bridge/dist/tools/maestro-test-all.js
@@ -8,6 +8,7 @@ import { getActiveSession } from '../agent-device-wrapper.js';
 import { findProjectRoot } from '../nav-graph/storage.js';
 import { chooseMaestroDispatch, shouldWarnFallback } from './maestro-dispatch.js';
 import { buildMaestroFlow, parseAndValidateFlow, MaestroValidationError, } from '../domain/maestro-validator.js';
+import { resolveAppFileForClearState } from './resolve-ios-app-file.js';
 const execFile = promisify(execFileCb);
 function discoverFlows(dir, pattern) {
     if (!existsSync(dir))
@@ -73,12 +74,24 @@ export function createMaestroTestAllHandler() {
             // file and execute that — never the on-disk YAML directly, so
             // any inert metadata or duplicated headers can't sneak through.
             let safeFlowFile;
+            let appFile;
             try {
                 const yamlText = readFileSync(flow, 'utf-8');
                 const parsed = parseAndValidateFlow(yamlText);
                 const canonical = buildMaestroFlow(parsed.appId !== undefined ? { appId: parsed.appId } : {}, parsed.commands);
                 safeFlowFile = join(tmpdir(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
                 writeFileSync(safeFlowFile, canonical, 'utf-8');
+                // GH#201 parity with maestro_run: an iOS clearState flow must reinstall
+                // the app, which maestro-runner can only do given --app-file.
+                const appFileResolution = resolveAppFileForClearState(platform, canonical, parsed.appId, undefined);
+                if (!appFileResolution.ok) {
+                    results.push({ name, passed: false, durationMs: Date.now() - start, error: appFileResolution.error.slice(0, 300) });
+                    failed++;
+                    if (args.stopOnFailure)
+                        break;
+                    continue;
+                }
+                appFile = appFileResolution.appFile;
             }
             catch (err) {
                 const reason = err instanceof MaestroValidationError
@@ -96,9 +109,14 @@ export function createMaestroTestAllHandler() {
                 continue;
             }
             try {
-                const { stdout, stderr } = await execFile(dispatch.binPath, dispatch.buildArgs(platform, safeFlowFile), { timeout, encoding: 'utf8' });
+                const { stdout, stderr } = await execFile(dispatch.binPath, dispatch.buildArgs(platform, safeFlowFile, appFile), { timeout, encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 });
                 const output = (stdout + '\n' + stderr).trim();
-                const ok = !output.includes('FAILED') && !output.includes('Error:');
+                // The runner already exited 0 here, so that exit code is the
+                // authoritative pass signal. Key the secondary scan on maestro's own
+                // `FAILED` token only — a broad `Error:` match false-flagged passing
+                // runs whose app/console logs merely contained "Error:" (mirrors the
+                // maestro_run fix).
+                const ok = !output.includes('FAILED');
                 results.push({
                     name,
                     passed: ok,

--- a/scripts/cdp-bridge/dist/tools/navigation-state.js
+++ b/scripts/cdp-bridge/dist/tools/navigation-state.js
@@ -7,7 +7,7 @@ import { loadVerificationConfig, getCachedProjectRoot } from '../verification/co
  * stack form) are accepted — Expo Router and React Navigation produce slightly
  * different shapes via the helper.
  */
-function extractActiveScreen(parsed) {
+export function extractActiveScreen(parsed) {
     const direct = parsed.routeName;
     if (typeof direct === 'string' && direct.length > 0)
         return direct;
@@ -23,6 +23,26 @@ function extractActiveScreen(parsed) {
             return path;
     }
     return null;
+}
+/**
+ * Best-effort live-route reader for the GH#186 route-drift guard. Returns the
+ * active route name via getNavState(), or null on any failure (CDP not
+ * connected, helpers absent, malformed payload) — callers treat null as
+ * "couldn't determine, skip drift detection". Never throws.
+ */
+export async function readLiveRoute(client) {
+    try {
+        const result = await client.evaluate(client.helperExpr('getNavState()'));
+        if (typeof result.value !== 'string')
+            return null;
+        const parsed = JSON.parse(result.value);
+        if (parsed.error)
+            return null;
+        return extractActiveScreen(parsed);
+    }
+    catch {
+        return null;
+    }
 }
 export function createNavigationStateHandler(getClient) {
     return withConnection(getClient, async (_args, client) => {

--- a/scripts/cdp-bridge/dist/tools/proof-step.js
+++ b/scripts/cdp-bridge/dist/tools/proof-step.js
@@ -3,7 +3,9 @@ import { runAgentDevice, hasActiveSession } from '../agent-device-wrapper.js';
 import { captureAndResizeScreenshot } from './device-list.js';
 import { annotateMutationAbsence } from '../verification/mutation-absence.js';
 import { loadVerificationConfig, getCachedProjectRoot } from '../verification/config.js';
-export function createProofStepHandler(getClient) {
+export function createProofStepHandler(getClient, deps = {}) {
+    const hasSession = deps.hasSession ?? hasActiveSession;
+    const captureScreenshot = deps.captureScreenshot ?? captureAndResizeScreenshot;
     return withConnection(getClient, async (args, client) => {
         const result = {
             screenshotPath: '',
@@ -102,8 +104,8 @@ export function createProofStepHandler(getClient) {
         // Step 4: Screenshot — B121: route through resize wrapper so per-phase
         // proof captures pay the B120 budget (default maxWidth=800) instead of
         // emitting native-resolution images that bloat proof bundles.
-        if (hasActiveSession()) {
-            const ssResult = await captureAndResizeScreenshot({ path: args.screenshotPath });
+        if (hasSession()) {
+            const ssResult = await captureScreenshot({ path: args.screenshotPath });
             if (ssResult.isError) {
                 errors.push('Screenshot failed');
             }

--- a/scripts/cdp-bridge/dist/tools/repair-action.js
+++ b/scripts/cdp-bridge/dist/tools/repair-action.js
@@ -110,7 +110,7 @@ export function createRepairActionHandler() {
         // could escape that directory (e.g. `../../etc/passwd`) before any
         // file read happens.
         if (!isValidActionId(args.actionId)) {
-            return failResult(`Invalid actionId "${String(args.actionId).slice(0, 80)}" — must match /^[A-Za-z0-9][A-Za-z0-9_-]*$/ and be <= 64 chars`, 'BAD_FILENAME');
+            return failResult(`Invalid actionId "${String(args.actionId).slice(0, 80)}" — must match /^[A-Za-z0-9][A-Za-z0-9_.-]*$/ (no "..") and be <= 64 chars`, 'BAD_FILENAME');
         }
         if (!args.failedSelector || typeof args.failedSelector !== 'string') {
             // Future enhancement: scan all selectors and find all stale ones.

--- a/scripts/cdp-bridge/dist/tools/resolve-ios-app-file.js
+++ b/scripts/cdp-bridge/dist/tools/resolve-ios-app-file.js
@@ -1,8 +1,14 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-/** GH#201: true when the flow text contains a `clearState: true` directive. */
+/**
+ * GH#201: true when the flow clears app state. Two Maestro forms both uninstall
+ * (and so need `--app-file` to reinstall on maestro-runner):
+ *   - `launchApp: { clearState: true }`
+ *   - the standalone `- clearState` command (in the validator allowlist)
+ */
 export function flowUsesClearState(flowText) {
-    return /clearState:\s*true\b/.test(flowText);
+    return /clearState:\s*true\b/.test(flowText)
+        || /^[ \t]*-[ \t]*clearState[ \t]*$/m.test(flowText);
 }
 /**
  * GH#201: locate a built `.app` to pass to `maestro-runner --app-file` so an
@@ -20,6 +26,36 @@ export function resolveIosAppFile(bundleId, deps = {}) {
     if (fromDerived && exists(fromDerived))
         return fromDerived;
     return null;
+}
+/**
+ * GH#201: decide the `--app-file` value for a single flow. Returns the explicit
+ * override untouched; otherwise only an iOS `clearState` flow needs one (so it
+ * can reinstall after uninstall). Shared by maestro_run, maestro_test_all, and
+ * runMaestroInline so all three reinstall on clearState — previously only
+ * maestro_run resolved the app file, leaving the other two to hit the exact
+ * uninstall-without-reinstall failure #201 fixed.
+ */
+export function resolveAppFileForClearState(platform, flowText, headerAppId, explicitAppFile, deps) {
+    if (explicitAppFile)
+        return { ok: true, appFile: explicitAppFile };
+    if (platform !== 'ios' || !flowUsesClearState(flowText))
+        return { ok: true };
+    if (!headerAppId) {
+        return {
+            ok: false,
+            error: 'Flow uses clearState on iOS but no appId is known to locate the .app. ' +
+                'Add `appId:` to the flow header or pass appFile=<path-to-.app>.',
+        };
+    }
+    const appFile = resolveIosAppFile(headerAppId, deps) ?? undefined;
+    if (!appFile) {
+        return {
+            ok: false,
+            error: `Flow uses clearState on iOS but no built .app could be located for ${headerAppId}. ` +
+                'Pass appFile=<path-to-.app> (e.g. <DerivedData>/Build/Products/Debug-iphonesimulator/<App>.app).',
+        };
+    }
+    return { ok: true, appFile };
 }
 function defaultGetAppContainer(bundleId) {
     try {

--- a/scripts/cdp-bridge/dist/tools/run-action.js
+++ b/scripts/cdp-bridge/dist/tools/run-action.js
@@ -29,7 +29,7 @@
 //     mask underlying screen churn).
 import { okResult, failResult } from '../utils.js';
 import { acknowledgeExternalEdit, loadAction, saveActionWithCAS } from '../domain/action-store.js';
-import { appendRunRecord, } from '../domain/reusable-action.js';
+import { appendRunRecord, shouldAutoPromoteToActive, } from '../domain/reusable-action.js';
 import { parseMaestroFailure, isAutoRepairable, } from '../domain/maestro-error-parser.js';
 import { createMaestroRunHandler } from './maestro-run.js';
 import { createRepairActionHandler } from './repair-action.js';
@@ -96,6 +96,13 @@ function readMaestroOutput(env) {
 function mapRefusedReason(repairCode, repairError) {
     if (repairCode === 'SNAPSHOT_FAILED')
         return 'SNAPSHOT_FAILED';
+    // RUNNER_LEAK = the snapshot returned the Agent Device Runner's own UI rather
+    // than the target app. That is structurally a snapshot-infra failure (a known,
+    // actionable focus-stealing condition), NOT a transport/contract bug — bucket
+    // it with SNAPSHOT_FAILED so MTTR analytics surface it instead of hiding it
+    // under INTERNAL_ERROR.
+    if (repairCode === 'RUNNER_LEAK')
+        return 'SNAPSHOT_FAILED';
     if (repairCode === 'TESTID_NOT_FOUND')
         return 'NO_MATCH';
     if (repairCode === 'STALE_TARGET') {
@@ -120,7 +127,7 @@ export function createRunActionHandler(deps = {}) {
         // cdp_repair_action — actionId flows into the .rn-agent/actions/
         // path segment. Reject malicious slugs at the boundary.
         if (!isValidActionId(args.actionId)) {
-            return failResult(`Invalid actionId "${String(args.actionId).slice(0, 80)}" — must match /^[A-Za-z0-9][A-Za-z0-9_-]*$/ and be <= 64 chars`, 'BAD_FILENAME');
+            return failResult(`Invalid actionId "${String(args.actionId).slice(0, 80)}" — must match /^[A-Za-z0-9][A-Za-z0-9_.-]*$/ (no "..") and be <= 64 chars`, 'BAD_FILENAME');
         }
         const projectRoot = args.projectRoot ?? process.cwd();
         const loaded = loadAction(projectRoot, args.actionId);
@@ -450,7 +457,15 @@ async function persistRun(actionId, projectRoot, record) {
             console.error(`cdp_run_action: persistRun could not reload action "${actionId}" — RunRecord dropped (status=${record.status}, autoRepair.outcome=${record.autoRepair?.outcome ?? 'n/a'})`);
             return;
         }
-        const next = { ...fresh, state: appendRunRecord(fresh.state, record) };
+        // H5: promote experimental → active on a clean replay. This is the
+        // documented lifecycle ("first clean /run-action replay auto-promotes to
+        // active") that was defined + unit-tested but never wired into a call site.
+        // persistRun is the single chokepoint both success paths reach, so the
+        // promotion rides the same atomic CAS write as the RunRecord append.
+        const promotedMetadata = shouldAutoPromoteToActive(fresh.metadata, record)
+            ? { ...fresh.metadata, status: 'active' }
+            : fresh.metadata;
+        const next = { ...fresh, metadata: promotedMetadata, state: appendRunRecord(fresh.state, record) };
         const result = saveActionWithCAS(next);
         if (result.ok)
             return;

--- a/scripts/cdp-bridge/dist/util/redact.js
+++ b/scripts/cdp-bridge/dist/util/redact.js
@@ -9,7 +9,11 @@ const SECRET_PATTERNS = [
     /\bAKIA[0-9A-Z]{16}\b/g,
     /\bxox[baprs]-[A-Za-z0-9\-]+\b/g,
     /\bAIza[0-9A-Za-z\-_]{35}\b/g,
-    /-----BEGIN (?:RSA |OPENSSH |PRIVATE )?KEY-----[\s\S]*?-----END (?:RSA |OPENSSH |PRIVATE )?KEY-----/g,
+    // Any private-key label variant: PRIVATE KEY, RSA PRIVATE KEY,
+    // OPENSSH PRIVATE KEY, EC/DSA/ENCRYPTED PRIVATE KEY, ... The old single-word
+    // `(?:RSA |OPENSSH |PRIVATE )?KEY` form never matched multi-word labels like
+    // "RSA PRIVATE KEY" — the most common ssh-keygen header — so keys leaked.
+    /-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----/g,
 ];
 // Value-side secret capture: redacts the VALUE when a secret-ish key is glued
 // to it via `:` or `=` (quoted JSON / kv-pairs in error strings), preserving
@@ -28,10 +32,11 @@ const PII_PATTERNS = [
 const AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
 const MAX_STRING_LENGTH = 2000;
 function redactString(value) {
-    let result = value.length > MAX_STRING_LENGTH
-        ? value.slice(0, MAX_STRING_LENGTH) + `[TRUNCATED:${value.length}]`
-        : value;
-    result = result.replace(HOME_RE, '~');
+    // Redact BEFORE truncating. Truncation can sever a paired-delimiter secret —
+    // e.g. a PEM private key's -----END----- marker — so the pattern would never
+    // match and the key body would leak through. Apply every pattern to the full
+    // string first, then clip what remains.
+    let result = value.replace(HOME_RE, '~');
     KEYED_SECRET_RE.lastIndex = 0;
     result = result.replace(KEYED_SECRET_RE, '$1[REDACTED_SECRET]');
     for (const pattern of SECRET_PATTERNS) {
@@ -41,6 +46,9 @@ function redactString(value) {
     for (const pattern of PII_PATTERNS) {
         pattern.lastIndex = 0;
         result = result.replace(pattern, '[PII_REDACTED]');
+    }
+    if (result.length > MAX_STRING_LENGTH) {
+        result = result.slice(0, MAX_STRING_LENGTH) + `[TRUNCATED:${result.length}]`;
     }
     return result;
 }

--- a/scripts/cdp-bridge/src/agent-device-wrapper.ts
+++ b/scripts/cdp-bridge/src/agent-device-wrapper.ts
@@ -11,6 +11,8 @@ import { okResult, failResult } from './utils.js';
 import {
   isFastRunnerAvailable,
   startFastRunner,
+  probeFastRunnerLiveness,
+  reapStaleFastRunner,
 } from './runners/rn-fast-runner-client.js';
 import { refCenter, getScreenRect, clearRefMap, isRefMapFresh } from './fast-runner-ref-map.js';
 import { resolveBundleId } from './project-config.js';
@@ -323,7 +325,7 @@ export function buildRunIOSArgs(
   bundleId?: string,
 ): import('./runners/rn-fast-runner-client.js').RunIOSArgs {
   const cmd = cliArgs[0];
-  const positionals = cliArgs.slice(1).filter((a) => !a.startsWith('--'));
+  const positionals = positionalArgs(cliArgs);
   switch (cmd) {
     case 'press':
     case 'tap': {
@@ -438,7 +440,11 @@ function optionValue(cliArgs: string[], flag: string): string | undefined {
   return value && !value.startsWith('-') ? value : undefined;
 }
 
-function androidPositionals(cliArgs: string[]): string[] {
+// Extract positional args, dropping flag tokens AND their values (`--count 3`,
+// `--pattern xy`). A naive `filter(a => !a.startsWith('--'))` strips the flag
+// token but keeps its value, which then mis-parses as a trailing positional
+// (e.g. count's `3` landing in the swipe duration slot → a 3ms flick).
+function positionalArgs(cliArgs: string[]): string[] {
   const out: string[] = [];
   for (let i = 1; i < cliArgs.length; i++) {
     const a = cliArgs[i];
@@ -458,7 +464,7 @@ export function buildRunAndroidArgs(
 ): import('./runners/rn-android-runner-client.js').RunAndroidArgs {
   type RunAndroidArgs = import('./runners/rn-android-runner-client.js').RunAndroidArgs;
   const cmd = cliArgs[0];
-  const positionals = androidPositionals(cliArgs);
+  const positionals = positionalArgs(cliArgs);
   const withBundle = bundleId ? { bundleId } : {};
 
   switch (cmd) {
@@ -569,7 +575,17 @@ export function buildRunAndroidArgs(
 }
 
 export async function ensureFastRunner(deviceId: string, bundleId: string): Promise<void> {
-  if (isFastRunnerAvailable()) return;
+  // M7/Phase-109: probe tri-state liveness instead of the PID-only
+  // isFastRunnerAvailable(). A runner whose PID is alive but whose HTTP server
+  // has wedged ('stale') must be reaped before a fresh start — otherwise it is
+  // reused and every subsequent device_* command burns the full HTTP timeout
+  // before failing. /health responds in ms when healthy, so the happy path is
+  // cheap; only a wedged runner pays the 2s probe timeout (vs. 10s per command).
+  const liveness = await probeFastRunnerLiveness();
+  if (liveness === 'alive') return;
+  if (liveness === 'stale') {
+    await reapStaleFastRunner();
+  }
   try {
     await startFastRunner(deviceId, bundleId);
   } catch (err) {

--- a/scripts/cdp-bridge/src/cdp/recovery.ts
+++ b/scripts/cdp-bridge/src/cdp/recovery.ts
@@ -36,8 +36,13 @@ export async function probeFreshness(
   }
   let probeTimer: ReturnType<typeof setTimeout> | undefined;
   try {
+    // If the timeout wins the race, this evaluate() promise is orphaned; attach
+    // a no-op catch so a later rejection (e.g. a mid-probe WebSocket close)
+    // can't surface as an unhandledRejection and crash the MCP process.
+    const evalPromise = client.evaluate('typeof globalThis.__RN_AGENT === "object" && globalThis.__RN_AGENT.__v');
+    evalPromise.catch(() => { /* swallowed if the timeout already settled the race */ });
     const result = await Promise.race([
-      client.evaluate('typeof globalThis.__RN_AGENT === "object" && globalThis.__RN_AGENT.__v'),
+      evalPromise,
       new Promise<EvaluateResult>((resolve) => {
         probeTimer = setTimeout(() => resolve({ error: 'timeout' }), timeoutMs);
       }),
@@ -93,8 +98,12 @@ async function probeDev(
 ): Promise<{ ok: boolean; timedOut: boolean }> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
+    // No-op catch on the orphaned promise if the timeout wins the race (see
+    // probeFreshness) — prevents an unhandledRejection on a mid-probe WS close.
+    const evalPromise = client.evaluate('typeof __DEV__ !== "undefined" && __DEV__ === true');
+    evalPromise.catch(() => { /* swallowed if the timeout already settled the race */ });
     const result = await Promise.race([
-      client.evaluate('typeof __DEV__ !== "undefined" && __DEV__ === true'),
+      evalPromise,
       new Promise<EvaluateResult>((resolve) => {
         timer = setTimeout(() => resolve({ error: 'probe timeout' }), timeoutMs);
       }),

--- a/scripts/cdp-bridge/src/cdp/setup.ts
+++ b/scripts/cdp-bridge/src/cdp/setup.ts
@@ -1,4 +1,4 @@
-import { INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, REACT_READY_PROBE_JS } from '../injected-helpers.js';
+import { HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, REACT_READY_PROBE_JS } from '../injected-helpers.js';
 import { logger } from '../logger.js';
 import { setActiveFlag, sleep } from './state.js';
 import { CDP_TIMEOUT_FAST, timeoutForMethod } from './timeout-config.js';
@@ -78,7 +78,7 @@ export async function performSetup(opts: {
     return { networkMode, helpersInjected: false, logDomainEnabled, profilerAvailable, heapProfilerAvailable };
   }
 
-  logger.info('CDP', `Helpers injected (v11), network mode: ${networkMode}`);
+  logger.info('CDP', `Helpers injected (v${HELPERS_VERSION}), network mode: ${networkMode}`);
   setActiveFlag(port, connectedTarget);
 
   // D626 (B1 fix): Probe whether Network.enable actually delivers events.

--- a/scripts/cdp-bridge/src/domain/action-store.ts
+++ b/scripts/cdp-bridge/src/domain/action-store.ts
@@ -347,6 +347,15 @@ export function saveActionWithCAS(action: ReusableAction): SaveActionCASResult {
     }
   }
 
+  // NOTE on the SaveActionPreconditionError that saveAction can throw here:
+  // this throw is LOAD-BEARING, not a contract bug. When forceReload=false and
+  // the YAML was edited externally, the throw propagates to cdp_run_action's
+  // top-level catch and becomes the correct strict-mode (Phase 129) refusal —
+  // see gh-173-run-action-force-reload. Converting it to a structured conflict
+  // makes persistRun treat it as a transient CAS race and retry-then-succeed,
+  // silently dropping the refusal. The RunRecord can't be persisted in that
+  // case anyway (the sidecar is pair-written with the YAML, which strict mode
+  // is deliberately refusing to clobber), so there is nothing to recover.
   const { filePath, sidecarPath: writtenSidecarPath } = saveAction(action);
   return { ok: true, filePath, sidecarPath: writtenSidecarPath };
 }

--- a/scripts/cdp-bridge/src/domain/path-safety.ts
+++ b/scripts/cdp-bridge/src/domain/path-safety.ts
@@ -31,16 +31,20 @@ export class PathTraversalError extends Error {
 // ── Action ID validation ────────────────────────────────────────────
 // Action IDs flow into `.rn-agent/actions/<id>.yaml` and the matching
 // sidecar `.rn-agent/state/<id>.state.json`. They must start with an alphanumeric
-// character, then accept hyphen/underscore/dot/alphanumeric. We
-// deliberately exclude `..`, `/`, `\`, and control characters so the
-// ID can never escape its parent directory.
+// character, then accept hyphen/underscore/dot/alphanumeric (dots support
+// versioned flow names like `v2.0-login`). We deliberately exclude `..`, `/`,
+// `\`, and control characters so the ID can never escape its parent directory.
 
-const ACTION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+const ACTION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.-]*$/;
 const ACTION_ID_MAX_LEN = 64;
 
 export function isValidActionId(s: unknown): s is string {
   if (typeof s !== 'string') return false;
   if (s.length === 0 || s.length > ACTION_ID_MAX_LEN) return false;
+  // Belt-and-suspenders: even though `<id>.yaml` has no path separator, never
+  // allow a `..` segment in the slug — keeps the "deliberately exclude `..`"
+  // contract literally true regardless of how the id is later joined.
+  if (s.includes('..')) return false;
   return ACTION_ID_RE.test(s);
 }
 

--- a/scripts/cdp-bridge/src/domain/repair-engine.ts
+++ b/scripts/cdp-bridge/src/domain/repair-engine.ts
@@ -176,7 +176,23 @@ export function replaceIdSelector(body: string, oldId: string, newId: string): {
     m = line.match(sq);
     if (m) { out.push(`${m[1]}id: '${newId}'${m[2]}`); replacements++; continue; }
     m = line.match(bare);
-    if (m) { out.push(`${m[1]}id: ${newId}${m[2]}`); replacements++; continue; }
+    if (m) {
+      // D3: the bare form has no original quote style to preserve, so emit a
+      // SAFELY-quoted scalar. isSafeMaestroScalar only rejects control chars /
+      // line separators — it lets `:`, `{`, `[`, `#`, `"` through — so an
+      // unquoted `id: ${newId}` produced invalid YAML for a testID like
+      // `button: submit` or `{fab}`, permanently breaking the action after a
+      // repair. Matched-quote grammar (same as maestro-error-parser): prefer the
+      // quote the value lacks; escape only when it contains both.
+      const quoted = !newId.includes('"')
+        ? `"${newId}"`
+        : !newId.includes("'")
+          ? `'${newId}'`
+          : `"${newId.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+      out.push(`${m[1]}id: ${quoted}${m[2]}`);
+      replacements++;
+      continue;
+    }
     out.push(line);
   }
   return { body: out.join('\n'), replacements };

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -14,7 +14,7 @@ import { createStatusHandler } from './tools/status.js';
 import { createEvaluateHandler } from './tools/evaluate.js';
 import { createReloadHandler } from './tools/reload.js';
 import { createComponentTreeHandler } from './tools/component-tree.js';
-import { createNavigationStateHandler } from './tools/navigation-state.js';
+import { createNavigationStateHandler, readLiveRoute } from './tools/navigation-state.js';
 import { createErrorLogHandler } from './tools/error-log.js';
 import { createNativeErrorsHandler } from './tools/native-errors.js';
 import { createNetworkLogHandler } from './tools/network-log.js';
@@ -1147,7 +1147,11 @@ trackedTool(
     trigger: z.enum(['agent', 'ci', 'human']).optional().describe('RunRecord trigger annotation. Default "agent". CI calls should pass "ci".'),
     forceReload: z.boolean().optional().describe('GH #173: when true (default), acknowledge any human edit to the YAML as the new baseline before running so downstream repair does not abort with STALE_TARGET. Pass false for the strict Phase 129 "respect external edits" behavior (useful for CI replays of fixed baselines).'),
   },
-  createRunActionHandler(),
+  // GH #186: supply a CDP-backed live-route reader so the route-drift guard is
+  // actually active. Without this the handler defaulted getLiveRoute to a no-op
+  // and the drift branch could never fire, silently routing screen-change
+  // failures into fuzzy selector repair.
+  createRunActionHandler({ getLiveRoute: () => readLiveRoute(getClient()) }),
 );
 
 // B76/D644: unified process-lifecycle shutdown. All termination signals + stdin.end

--- a/scripts/cdp-bridge/src/injected-helpers.ts
+++ b/scripts/cdp-bridge/src/injected-helpers.ts
@@ -1,6 +1,12 @@
+// Single source of truth for the injected-helpers protocol version. Bump this
+// whenever the injected surface changes; it flows into the IIFE's freshness
+// check (__RN_AGENT.__v) AND the post-injection log line, so they can never
+// drift (the log previously hard-coded a stale "v11").
+export const HELPERS_VERSION = 23;
+
 export const INJECTED_HELPERS = `
 (function() {
-  var __HELPERS_VERSION__ = 23;
+  var __HELPERS_VERSION__ = ${HELPERS_VERSION};
   if (globalThis.__RN_AGENT && globalThis.__RN_AGENT.__v === __HELPERS_VERSION__) return;
   if (globalThis.__RN_AGENT) delete globalThis.__RN_AGENT;
 

--- a/scripts/cdp-bridge/src/maestro-invoke.ts
+++ b/scripts/cdp-bridge/src/maestro-invoke.ts
@@ -11,6 +11,7 @@ import {
   MaestroValidationError,
 } from './domain/maestro-validator.js';
 import { chooseMaestroDispatch } from './tools/maestro-dispatch.js';
+import { resolveAppFileForClearState } from './tools/resolve-ios-app-file.js';
 
 const execFile = promisify(execFileCb);
 
@@ -72,11 +73,13 @@ export async function runMaestroInline(
   const flowFile = join(tmpdir(), `rn-maestro-invoke-${opts.slug ?? 'flow'}-${Date.now()}.yaml`);
 
   let content: string;
+  let headerAppId: string | undefined;
   try {
     const parsed = parseAndValidateFlow(yaml, { rejectHeader: true });
     const appIdOpts: { appId?: string } = {};
     if (rawAppId && isValidBundleId(rawAppId)) {
       appIdOpts.appId = rawAppId;
+      headerAppId = rawAppId;
     } else if (rawAppId) {
       return {
         passed: false,
@@ -111,14 +114,25 @@ export async function runMaestroInline(
 
   const timeout = opts.timeoutMs ?? 30_000;
 
+  // GH#201 parity with maestro_run: resolve --app-file so an iOS clearState flow
+  // run through this inline path (device_fill/picker/dialog fallbacks) can
+  // reinstall the app instead of failing after uninstall.
+  const appFileResolution = resolveAppFileForClearState(opts.platform, content, headerAppId, undefined);
+  if (!appFileResolution.ok) {
+    return { passed: false, output: '', flowFile, error: appFileResolution.error };
+  }
+
   try {
     const { stdout, stderr } = await execFile(
       dispatch.binPath,
-      dispatch.buildArgs(opts.platform, flowFile),
-      { timeout, encoding: 'utf8' },
+      dispatch.buildArgs(opts.platform, flowFile, appFileResolution.appFile),
+      { timeout, encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 },
     );
     const output = (stdout + '\n' + stderr).trim();
-    const passed = !output.includes('FAILED') && !output.includes('Error:');
+    // Runner exited 0 → authoritative pass. Key the secondary scan on maestro's
+    // `FAILED` token only; a broad `Error:` match false-flagged passing runs
+    // whose app/console output merely contained "Error:" (mirrors maestro_run).
+    const passed = !output.includes('FAILED');
     return { passed, output, flowFile };
   } catch (err) {
     // execFile errors carry stdout/stderr from the failed child process. When

--- a/scripts/cdp-bridge/src/observability/recorder.ts
+++ b/scripts/cdp-bridge/src/observability/recorder.ts
@@ -40,7 +40,19 @@ export class Recorder {
     return { snapshot, detach: () => { this.subs.delete(fn); } };
   }
   getScreenshot(seq: number): ScreenshotBytes | undefined { return this.shots.get(seq); }
-  clear(): void { this.buf.clear(); this.subs.clear(); this.shots.clear(); this.seq = 0; }
+  clear(): void {
+    this.buf.clear();
+    // Notify live subscribers with a terminal sentinel BEFORE dropping them, so
+    // a clear() (e.g. a future "reset session") can't silently orphan an open
+    // SSE stream + its heartbeat interval. The server's stream subscriber ends
+    // the response on this event.
+    for (const fn of this.subs) {
+      try { fn({ type: 'cleared' } as unknown as AgentEvent); } catch { /* per-subscriber swallow */ }
+    }
+    this.subs.clear();
+    this.shots.clear();
+    this.seq = 0;
+  }
   protected captureScreenshot(ev: AgentEvent, o: ToolObservation): void {
     if (ev.tool !== 'device_screenshot' || !ev.ok) return;
     const p = screenshotPath(o.result);

--- a/scripts/cdp-bridge/src/observability/server.ts
+++ b/scripts/cdp-bridge/src/observability/server.ts
@@ -10,13 +10,18 @@ const __dir = dirname(fileURLToPath(import.meta.url));
 export class ObservabilityServer {
   private server: Server | null = null;
   private port = 0;
+  private streams = new Set<ServerResponse>();
   constructor(private readonly recorder: Recorder) {}
 
   async start(preferredPort?: number): Promise<{ url: string; port: number }> {
     if (this.server) return { url: this.url(), port: this.port };
     const server = createServer((req, res) => this.handle(req, res));
+    // SSE responses are long-lived, so disable the body timeout. But keep a
+    // small headersTimeout so a connection that stalls mid-request-headers
+    // (slow-loris) is closed instead of held open forever — SSE clients send
+    // their headers immediately, so 5s is ample.
     server.requestTimeout = 0;
-    server.headersTimeout = 0;
+    server.headersTimeout = 5_000;
     try {
       this.port = await listen(server, preferredPort ?? 0);
     } catch (e) {
@@ -30,6 +35,14 @@ export class ObservabilityServer {
 
   async stop(): Promise<void> {
     const s = this.server; this.server = null;
+    // Tell live SSE clients we're shutting down BEFORE yanking the sockets, so
+    // the browser's EventSource closes instead of entering its auto-reconnect
+    // loop (which would otherwise hammer the dead port, or silently reattach to
+    // a different session started later on the same port).
+    for (const res of this.streams) {
+      try { res.write('data: {"type":"shutdown"}\n\n'); res.end(); } catch { /* already closed */ }
+    }
+    this.streams.clear();
     if (s) {
       s.closeAllConnections?.();
       await new Promise<void>((r) => s.close(() => r()));
@@ -56,11 +69,16 @@ export class ObservabilityServer {
       try { return res.write(`data: ${JSON.stringify(ev)}\n\n`); }
       catch { return false; }
     };
-    const { snapshot, detach } = this.recorder.attach((ev) => { if (!write(ev)) { detach(); res.end(); } });
+    this.streams.add(res);
+    const { snapshot, detach } = this.recorder.attach((ev) => {
+      // Recorder.clear() emits a terminal sentinel — end the stream cleanly.
+      if ((ev as { type?: string }).type === 'cleared') { detach(); res.end(); return; }
+      if (!write(ev)) { detach(); res.end(); }
+    });
     write({ type: 'snapshot', events: snapshot });
     const hb = setInterval(() => { try { res.write(': hb\n\n'); } catch { /* closed */ } }, 15_000);
     hb.unref?.();
-    res.on('close', () => { clearInterval(hb); detach(); });
+    res.on('close', () => { clearInterval(hb); detach(); this.streams.delete(res); });
   }
 
   private guard(req: IncomingMessage, res: ServerResponse): boolean {

--- a/scripts/cdp-bridge/src/observability/web/src/main.tsx
+++ b/scripts/cdp-bridge/src/observability/web/src/main.tsx
@@ -99,7 +99,12 @@ function App(): JSX.Element {
       } catch {
         return;
       }
-      if (parsed && typeof parsed === 'object' && (parsed as { type?: string }).type === 'snapshot') {
+      const type = (parsed && typeof parsed === 'object') ? (parsed as { type?: string }).type : undefined;
+      // The server sends this right before it stops. Close the EventSource so
+      // the browser does NOT auto-reconnect (which would hammer the dead port,
+      // or silently reattach to a different session reusing the same port).
+      if (type === 'shutdown') { es.close(); setConn('error'); return; }
+      if (type === 'snapshot') {
         merge(((parsed as { events?: AgentEvent[] }).events) ?? []);
       } else {
         merge([parsed as AgentEvent]);

--- a/scripts/cdp-bridge/src/runners/ensure-single-runner.ts
+++ b/scripts/cdp-bridge/src/runners/ensure-single-runner.ts
@@ -55,13 +55,12 @@ export interface EnsureSingleRunnerDeps {
 
 function defaultDeps(): EnsureSingleRunnerDeps {
   return {
-    listProcesses: () => {
-      try {
-        return execFileSync('ps', ['-A', '-o', 'pid=,args='], { encoding: 'utf8', timeout: 3_000 });
-      } catch {
-        return '';
-      }
-    },
+    // Let a `ps` failure (timeout / EAGAIN under load) PROPAGATE to the
+    // caller's try/catch, which records a warning. Swallowing it here and
+    // returning '' made single-runner enforcement degrade to a silent no-op
+    // with no operator signal — exactly when the machine is busy.
+    listProcesses: () =>
+      execFileSync('ps', ['-A', '-o', 'pid=,args='], { encoding: 'utf8', timeout: 3_000 }),
     kill: (pid, signal) => process.kill(pid, signal),
     isAlive: (pid) => {
       try { process.kill(pid, 0); return true; } catch { return false; }

--- a/scripts/cdp-bridge/src/runners/rn-android-runner-client.ts
+++ b/scripts/cdp-bridge/src/runners/rn-android-runner-client.ts
@@ -119,8 +119,22 @@ export function isAndroidRunnerAvailable(): boolean {
   }
 }
 
+/**
+ * GH#202 parity with iOS shouldReuseRunner: only adopt a live runner when it is
+ * bound to the SAME emulator. The state file path is a fixed constant shared
+ * across projects/sessions, so a runner bound to emulator-A must never be reused
+ * to drive emulator-B (its adb forward + port still point at A — every command
+ * would silently hit the wrong device). When no specific deviceId is requested
+ * (single-device flow), any live runner is acceptable.
+ */
+export function shouldReuseAndroidRunner(state: AndroidRunnerState | null, deviceId?: string): boolean {
+  if (state === null) return false;
+  if (!deviceId) return true;
+  return state.deviceId === deviceId;
+}
+
 export async function startAndroidRunner(deviceId?: string, bundleId?: string, port = DEFAULT_PORT): Promise<AndroidRunnerState> {
-  if (isAndroidRunnerAvailable()) return runnerState!;
+  if (isAndroidRunnerAvailable() && shouldReuseAndroidRunner(runnerState, deviceId)) return runnerState!;
 
   const serial = adbSerialArgs(deviceId);
   await execFileAsync('adb', [...serial, 'forward', `tcp:${port}`, `tcp:${port}`]);

--- a/scripts/cdp-bridge/src/tools/collect-logs.ts
+++ b/scripts/cdp-bridge/src/tools/collect-logs.ts
@@ -180,7 +180,6 @@ function collectNativeAndroid(durationMs: number, signal: AbortSignal): Promise<
   return new Promise<LogEntry[]>((resolve, reject) => {
     const entries: LogEntry[] = [];
     const year = new Date().getFullYear();
-    const tzOffsetMs = new Date().getTimezoneOffset() * 60_000;
     const killMs = durationMs > 0 ? durationMs : 100;
     let killed = false;
     let killedByUs = false;
@@ -225,7 +224,7 @@ function collectNativeAndroid(durationMs: number, signal: AbortSignal): Promise<
       const lines = buf.split('\n');
       buf = lines.pop() ?? '';
       for (const line of lines) {
-        const entry = parseLogcatLine(line, year, tzOffsetMs);
+        const entry = parseLogcatLine(line, year);
         if (entry) entries.push(entry);
       }
     });
@@ -237,7 +236,7 @@ function collectNativeAndroid(durationMs: number, signal: AbortSignal): Promise<
       if (sigkillTimer) clearTimeout(sigkillTimer);
       signal.removeEventListener('abort', onAbort);
       if (buf.trim()) {
-        const entry = parseLogcatLine(buf, year, tzOffsetMs);
+        const entry = parseLogcatLine(buf, year);
         if (entry) entries.push(entry);
       }
       if (!killedByUs && code !== 0 && entries.length === 0) {
@@ -266,13 +265,17 @@ const ANDROID_LEVEL_MAP: Record<string, string> = {
   V: 'debug', D: 'debug', I: 'info', W: 'warn', E: 'error', F: 'error', S: 'log',
 };
 
-function parseLogcatLine(line: string, year: number, tzOffsetMs: number): LogEntry | null {
+export function parseLogcatLine(line: string, year: number): LogEntry | null {
   const m = LOGCAT_RE.exec(line);
   if (!m) return null;
 
   const [, date, time, pidStr, priority, tag, message] = m;
-  const localDate = new Date(`${year}-${date}T${time}`);
-  const utcDate = new Date(localDate.getTime() + tzOffsetMs);
+  // logcat emits device-LOCAL wall-clock with no offset. `new Date("...T...")`
+  // (no trailing Z) already parses in the local zone, so getTime() is already
+  // the correct UTC epoch — the previous `+ tzOffsetMs` double-shifted every
+  // entry by the host's UTC offset, corrupting both the reported time and the
+  // cross-source merge-sort ordering.
+  const utcDate = new Date(`${year}-${date}T${time}`);
 
   return {
     source: 'native_android',

--- a/scripts/cdp-bridge/src/tools/device-batch.ts
+++ b/scripts/cdp-bridge/src/tools/device-batch.ts
@@ -1,5 +1,5 @@
 import { runAgentDevice } from '../agent-device-wrapper.js';
-import { buildDirectionalSwipeCliArgs } from './device-interact.js';
+import { buildDirectionalScrollCliArgs, buildDirectionalSwipeCliArgs } from './device-interact.js';
 import { withSession, okResult, failResult } from '../utils.js';
 import type { ToolResult } from '../utils.js';
 import { captureAndResizeScreenshot } from './device-list.js';
@@ -226,7 +226,9 @@ async function executeStep(step: BatchStep): Promise<ToolResult> {
     }
     case 'scroll': {
       if (!step.direction) return failResult('scroll requires direction');
-      return runAgentDevice(['scroll', step.direction]);
+      // Coordinate form — the raw ['scroll', direction] shape throws in the
+      // iOS/Android arg builders and aborted the whole batch.
+      return runAgentDevice(buildDirectionalScrollCliArgs(step.direction));
     }
     case 'back': {
       return runAgentDevice(['back']);

--- a/scripts/cdp-bridge/src/tools/device-interact.ts
+++ b/scripts/cdp-bridge/src/tools/device-interact.ts
@@ -789,6 +789,44 @@ export function buildDirectionalSwipeCliArgs(
   return ['swipe', String(coords.x1), String(coords.y1), String(coords.x2), String(coords.y2), String(duration)];
 }
 
+// Scroll direction → finger gesture is INVERTED vs swipe ("scroll down" = content
+// moves up = finger moves up) and scaled by `amount` (0..1). Centred half-spans
+// keep the gesture inside the viewport.
+function computeScrollFromDirection(
+  direction: 'up' | 'down' | 'left' | 'right',
+  amount: number,
+  screen: { width: number; height: number },
+): { x1: number; y1: number; x2: number; y2: number } {
+  const cx = Math.round(screen.width / 2);
+  const cy = Math.round(screen.height / 2);
+  const dy = Math.round(screen.height * SWIPE_FRACTION * amount);
+  const dx = Math.round(screen.width * SWIPE_FRACTION * amount);
+  switch (direction) {
+    case 'down': return { x1: cx, y1: cy + Math.round(dy / 2), x2: cx, y2: cy - Math.round(dy / 2) };
+    case 'up': return { x1: cx, y1: cy - Math.round(dy / 2), x2: cx, y2: cy + Math.round(dy / 2) };
+    case 'left': return { x1: cx + Math.round(dx / 2), y1: cy, x2: cx - Math.round(dx / 2), y2: cy };
+    case 'right': return { x1: cx - Math.round(dx / 2), y1: cy, x2: cx + Math.round(dx / 2), y2: cy };
+  }
+}
+
+// Shared by the standalone scroll handler's daemon fallthrough and device_batch
+// so a "scroll" step always dispatches the COORDINATE form. The arg builders
+// (buildRunIOSArgs / buildRunAndroidArgs) map scroll → a 4-coordinate drag and
+// throw on the direction form — so the raw ['scroll', direction] shape that used
+// to be dispatched here crashed on Android (always) and on the iOS fast-runner
+// fallback path.
+export function buildDirectionalScrollCliArgs(
+  direction: 'up' | 'down' | 'left' | 'right',
+  amount?: number,
+  durationMs?: number,
+): string[] {
+  const screen = getCachedScreenRect() ?? DEFAULT_SCREEN;
+  const clamped = Math.min(Math.max(amount ?? 0.5, 0), 1);
+  const coords = computeScrollFromDirection(direction, clamped, screen);
+  const duration = durationMs ?? DEFAULT_SWIPE_DURATION_MS;
+  return ['scroll', String(coords.x1), String(coords.y1), String(coords.x2), String(coords.y2), String(duration)];
+}
+
 export function exactModeRejectionMessage(reason: 'fast-runner-unavailable' | 'count-pattern-incompatible'): string {
   if (reason === 'count-pattern-incompatible') {
     return 'exact: true is incompatible with count/pattern (those route through agent-device daemon which enforces safe-normalized timing). Drop count/pattern or drop exact.';
@@ -890,21 +928,10 @@ export function createDeviceScrollHandler(): (args: ScrollArgs) => Promise<ToolR
     // because the UI thread is never "idle" between scroll events. Fast-runner
     // uses `RunnerDaemonProxy.synthesize(eventRecord)` which is raw HID event
     // injection and returns as soon as events are delivered.
+    const screen = getCachedScreenRect() ?? DEFAULT_SCREEN;
+    const amount = Math.min(Math.max(args.amount ?? 0.5, 0), 1);
+    const { x1, y1, x2, y2 } = computeScrollFromDirection(args.direction, amount, screen);
     if (isFastRunnerAvailable()) {
-      const screen = getCachedScreenRect() ?? DEFAULT_SCREEN;
-      const amount = Math.min(Math.max(args.amount ?? 0.5, 0), 1);
-      const cx = Math.round(screen.width / 2);
-      const cy = Math.round(screen.height / 2);
-      const dy = Math.round(screen.height * SWIPE_FRACTION * amount);
-      const dx = Math.round(screen.width * SWIPE_FRACTION * amount);
-      let x1 = cx, y1 = cy, x2 = cx, y2 = cy;
-      switch (args.direction) {
-        // "scroll down" = content moves up = finger moves up (swipe up)
-        case 'down': y1 = cy + Math.round(dy / 2); y2 = cy - Math.round(dy / 2); break;
-        case 'up': y1 = cy - Math.round(dy / 2); y2 = cy + Math.round(dy / 2); break;
-        case 'left': x1 = cx + Math.round(dx / 2); x2 = cx - Math.round(dx / 2); break;
-        case 'right': x1 = cx - Math.round(dx / 2); x2 = cx + Math.round(dx / 2); break;
-      }
       try {
         const resp = await fastSwipe(x1, y1, x2, y2, DEFAULT_SWIPE_DURATION_MS);
         if (resp.ok) {
@@ -915,9 +942,10 @@ export function createDeviceScrollHandler(): (args: ScrollArgs) => Promise<ToolR
         // Fall through to daemon on fast-runner error
       }
     }
-    const cliArgs = ['scroll', args.direction];
-    if (args.amount != null) cliArgs.push(String(args.amount));
-    return runAgentDevice(cliArgs);
+    // Daemon / Android fallthrough: dispatch the COORDINATE form. The arg
+    // builders throw on the raw direction form, so this previously crashed on
+    // Android (always) and on the iOS fast-runner fallback.
+    return runAgentDevice(buildDirectionalScrollCliArgs(args.direction, args.amount));
   });
 }
 

--- a/scripts/cdp-bridge/src/tools/device-session.ts
+++ b/scripts/cdp-bridge/src/tools/device-session.ts
@@ -185,19 +185,23 @@ export function createDeviceSnapshotHandler(): (args: SnapshotArgs) => Promise<T
         // targeting THIS simulator and clear orphaned daemon lock files.
         // Default-on; opt out with RN_DEVICE_KILL_LEGACY=0.
         if (process.env.RN_DEVICE_KILL_LEGACY !== '0' && args.platform === 'ios' && deviceId) {
-          ensureSingleRunner({ udid: deviceId })
-            .then((r) => {
-              if (r.killedPids.length) {
-                logger.info('rn-device', `ensureSingleRunner: killed stale runner PID(s) ${r.killedPids.join(', ')} on ${deviceId}`);
-              }
-              if (r.removedFiles.length) {
-                logger.info('rn-device', `ensureSingleRunner: removed ${r.removedFiles.join(', ')}`);
-              }
-              for (const w of r.warnings) logger.warn('rn-device', w);
-            })
-            .catch((err) => {
-              logger.warn('rn-device', `ensureSingleRunner failed: ${err instanceof Error ? err.message : String(err)}`);
-            });
+          // Await: the stale-runner kill (SIGTERM → 500ms grace → SIGKILL) must
+          // finish BEFORE the session is usable, or the first device_* command
+          // races it and a stale AgentDeviceRunner can still steal focus —
+          // which is exactly the single-runner guarantee #202 promises. The
+          // added latency lands on an already-slow session-open, not per-command.
+          try {
+            const r = await ensureSingleRunner({ udid: deviceId });
+            if (r.killedPids.length) {
+              logger.info('rn-device', `ensureSingleRunner: killed stale runner PID(s) ${r.killedPids.join(', ')} on ${deviceId}`);
+            }
+            if (r.removedFiles.length) {
+              logger.info('rn-device', `ensureSingleRunner: removed ${r.removedFiles.join(', ')}`);
+            }
+            for (const w of r.warnings) logger.warn('rn-device', w);
+          } catch (err) {
+            logger.warn('rn-device', `ensureSingleRunner failed: ${err instanceof Error ? err.message : String(err)}`);
+          }
         }
 
         // Task 9 of Android-MVP: warn on competing Android UIAutomator /

--- a/scripts/cdp-bridge/src/tools/maestro-run.ts
+++ b/scripts/cdp-bridge/src/tools/maestro-run.ts
@@ -8,7 +8,7 @@ import { okResult, failResult, warnResult } from '../utils.js';
 import { getActiveSession } from '../agent-device-wrapper.js';
 import { resolveBundleId, readExpoSlug } from '../project-config.js';
 import { chooseMaestroDispatch, shouldWarnFallback } from './maestro-dispatch.js';
-import { flowUsesClearState, resolveIosAppFile } from './resolve-ios-app-file.js';
+import { resolveAppFileForClearState } from './resolve-ios-app-file.js';
 import {
   buildMaestroFlow,
   parseAndValidateFlow,
@@ -152,23 +152,11 @@ export function createMaestroRunHandler(): (args: MaestroRunArgs) => Promise<Too
     // params. Validation already ran at the top of the handler so by
     // this point every key matches PARAM_KEY_RE and every value is a
     // string — no need to re-check.
-    let appFile = args.appFile;
-    if (!appFile && platform === 'ios' && flowUsesClearState(validatedContent)) {
-      if (!headerAppId) {
-        return failResult(
-          'Flow uses clearState on iOS but no appId is known to locate the .app. ' +
-          'Add `appId:` to the flow header or pass appFile=<path-to-.app>.',
-        );
-      }
-      appFile = resolveIosAppFile(headerAppId) ?? undefined;
-      if (!appFile) {
-        return failResult(
-          `Flow uses clearState on iOS but no built .app could be located for ${headerAppId}. ` +
-          'Pass appFile=<path-to-.app> (e.g. <DerivedData>/Build/Products/Debug-iphonesimulator/<App>.app).',
-        );
-      }
+    const appFileResolution = resolveAppFileForClearState(platform, validatedContent, headerAppId, args.appFile);
+    if (!appFileResolution.ok) {
+      return failResult(appFileResolution.error);
     }
-    const baseArgs = dispatch.buildArgs(platform, flowFile, appFile);
+    const baseArgs = dispatch.buildArgs(platform, flowFile, appFileResolution.appFile);
     const paramArgs: string[] = [];
     if (args.params) {
       for (const [key, value] of Object.entries(args.params)) {
@@ -181,7 +169,11 @@ export function createMaestroRunHandler(): (args: MaestroRunArgs) => Promise<Too
       const { stdout, stderr } = await execFile(
         dispatch.binPath,
         finalArgs,
-        { timeout, encoding: 'utf8' },
+        // 10MB buffer: a multi-step flow with screenshots + app console/network
+        // logs routinely exceeds Node's 1MB execFile default, which would kill
+        // the child with ERR_CHILD_PROCESS_STDIO_MAXBUFFER and mask a passing
+        // run as a failure.
+        { timeout, encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 },
       );
 
       const output = (stdout + '\n' + stderr).trim();

--- a/scripts/cdp-bridge/src/tools/maestro-test-all.ts
+++ b/scripts/cdp-bridge/src/tools/maestro-test-all.ts
@@ -13,6 +13,7 @@ import {
   parseAndValidateFlow,
   MaestroValidationError,
 } from '../domain/maestro-validator.js';
+import { resolveAppFileForClearState } from './resolve-ios-app-file.js';
 
 const execFile = promisify(execFileCb);
 
@@ -101,6 +102,7 @@ export function createMaestroTestAllHandler(): (args: MaestroTestAllArgs) => Pro
       // file and execute that — never the on-disk YAML directly, so
       // any inert metadata or duplicated headers can't sneak through.
       let safeFlowFile: string;
+      let appFile: string | undefined;
       try {
         const yamlText = readFileSync(flow, 'utf-8');
         const parsed = parseAndValidateFlow(yamlText);
@@ -110,6 +112,16 @@ export function createMaestroTestAllHandler(): (args: MaestroTestAllArgs) => Pro
         );
         safeFlowFile = join(tmpdir(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
         writeFileSync(safeFlowFile, canonical, 'utf-8');
+        // GH#201 parity with maestro_run: an iOS clearState flow must reinstall
+        // the app, which maestro-runner can only do given --app-file.
+        const appFileResolution = resolveAppFileForClearState(platform, canonical, parsed.appId, undefined);
+        if (!appFileResolution.ok) {
+          results.push({ name, passed: false, durationMs: Date.now() - start, error: appFileResolution.error.slice(0, 300) });
+          failed++;
+          if (args.stopOnFailure) break;
+          continue;
+        }
+        appFile = appFileResolution.appFile;
       } catch (err) {
         const reason =
           err instanceof MaestroValidationError
@@ -129,11 +141,16 @@ export function createMaestroTestAllHandler(): (args: MaestroTestAllArgs) => Pro
       try {
         const { stdout, stderr } = await execFile(
           dispatch.binPath,
-          dispatch.buildArgs(platform, safeFlowFile),
-          { timeout, encoding: 'utf8' },
+          dispatch.buildArgs(platform, safeFlowFile, appFile),
+          { timeout, encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 },
         );
         const output = (stdout + '\n' + stderr).trim();
-        const ok = !output.includes('FAILED') && !output.includes('Error:');
+        // The runner already exited 0 here, so that exit code is the
+        // authoritative pass signal. Key the secondary scan on maestro's own
+        // `FAILED` token only — a broad `Error:` match false-flagged passing
+        // runs whose app/console logs merely contained "Error:" (mirrors the
+        // maestro_run fix).
+        const ok = !output.includes('FAILED');
 
         results.push({
           name,

--- a/scripts/cdp-bridge/src/tools/navigation-state.ts
+++ b/scripts/cdp-bridge/src/tools/navigation-state.ts
@@ -9,7 +9,7 @@ import { loadVerificationConfig, getCachedProjectRoot } from '../verification/co
  * stack form) are accepted — Expo Router and React Navigation produce slightly
  * different shapes via the helper.
  */
-function extractActiveScreen(parsed: Record<string, unknown>): string | null {
+export function extractActiveScreen(parsed: Record<string, unknown>): string | null {
   const direct = parsed.routeName;
   if (typeof direct === 'string' && direct.length > 0) return direct;
   const routes = parsed.routes;
@@ -22,6 +22,24 @@ function extractActiveScreen(parsed: Record<string, unknown>): string | null {
     if (typeof path === 'string') return path;
   }
   return null;
+}
+
+/**
+ * Best-effort live-route reader for the GH#186 route-drift guard. Returns the
+ * active route name via getNavState(), or null on any failure (CDP not
+ * connected, helpers absent, malformed payload) — callers treat null as
+ * "couldn't determine, skip drift detection". Never throws.
+ */
+export async function readLiveRoute(client: CDPClient): Promise<string | null> {
+  try {
+    const result = await client.evaluate(client.helperExpr('getNavState()'));
+    if (typeof result.value !== 'string') return null;
+    const parsed = JSON.parse(result.value) as Record<string, unknown>;
+    if (parsed.error) return null;
+    return extractActiveScreen(parsed);
+  } catch {
+    return null;
+  }
 }
 
 export function createNavigationStateHandler(getClient: () => CDPClient) {

--- a/scripts/cdp-bridge/src/tools/proof-step.ts
+++ b/scripts/cdp-bridge/src/tools/proof-step.ts
@@ -26,7 +26,17 @@ interface ProofStepResult {
   errors?: string[];
 }
 
-export function createProofStepHandler(getClient: () => CDPClient) {
+export interface ProofStepDeps {
+  /** Defaults to the module-level session check. Injected false in tests so the
+   *  screenshot subprocess is never spawned (keeps tests hermetic + fast). */
+  hasSession?: () => boolean;
+  /** Defaults to the real resize-wrapped capture. Injectable for tests. */
+  captureScreenshot?: (opts: { path?: string }) => Promise<ToolResult>;
+}
+
+export function createProofStepHandler(getClient: () => CDPClient, deps: ProofStepDeps = {}) {
+  const hasSession = deps.hasSession ?? hasActiveSession;
+  const captureScreenshot = deps.captureScreenshot ?? captureAndResizeScreenshot;
   return withConnection(getClient, async (args: ProofStepArgs, client) => {
     const result: ProofStepResult = {
       screenshotPath: '',
@@ -119,8 +129,8 @@ export function createProofStepHandler(getClient: () => CDPClient) {
     // Step 4: Screenshot — B121: route through resize wrapper so per-phase
     // proof captures pay the B120 budget (default maxWidth=800) instead of
     // emitting native-resolution images that bloat proof bundles.
-    if (hasActiveSession()) {
-      const ssResult = await captureAndResizeScreenshot({ path: args.screenshotPath });
+    if (hasSession()) {
+      const ssResult = await captureScreenshot({ path: args.screenshotPath });
       if (ssResult.isError) {
         errors.push('Screenshot failed');
       } else {

--- a/scripts/cdp-bridge/src/tools/repair-action.ts
+++ b/scripts/cdp-bridge/src/tools/repair-action.ts
@@ -163,7 +163,7 @@ export function createRepairActionHandler() {
     // file read happens.
     if (!isValidActionId(args.actionId)) {
       return failResult(
-        `Invalid actionId "${String(args.actionId).slice(0, 80)}" — must match /^[A-Za-z0-9][A-Za-z0-9_-]*$/ and be <= 64 chars`,
+        `Invalid actionId "${String(args.actionId).slice(0, 80)}" — must match /^[A-Za-z0-9][A-Za-z0-9_.-]*$/ (no "..") and be <= 64 chars`,
         'BAD_FILENAME',
       );
     }

--- a/scripts/cdp-bridge/src/tools/resolve-ios-app-file.ts
+++ b/scripts/cdp-bridge/src/tools/resolve-ios-app-file.ts
@@ -1,9 +1,15 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 
-/** GH#201: true when the flow text contains a `clearState: true` directive. */
+/**
+ * GH#201: true when the flow clears app state. Two Maestro forms both uninstall
+ * (and so need `--app-file` to reinstall on maestro-runner):
+ *   - `launchApp: { clearState: true }`
+ *   - the standalone `- clearState` command (in the validator allowlist)
+ */
 export function flowUsesClearState(flowText: string): boolean {
-  return /clearState:\s*true\b/.test(flowText);
+  return /clearState:\s*true\b/.test(flowText)
+    || /^[ \t]*-[ \t]*clearState[ \t]*$/m.test(flowText);
 }
 
 export interface ResolveAppFileDeps {
@@ -29,6 +35,47 @@ export function resolveIosAppFile(bundleId: string, deps: ResolveAppFileDeps = {
   const fromDerived = (deps.newestDerivedDataApp ?? (() => null))();
   if (fromDerived && exists(fromDerived)) return fromDerived;
   return null;
+}
+
+export type AppFileResolution =
+  | { ok: true; appFile?: string }
+  | { ok: false; error: string };
+
+/**
+ * GH#201: decide the `--app-file` value for a single flow. Returns the explicit
+ * override untouched; otherwise only an iOS `clearState` flow needs one (so it
+ * can reinstall after uninstall). Shared by maestro_run, maestro_test_all, and
+ * runMaestroInline so all three reinstall on clearState — previously only
+ * maestro_run resolved the app file, leaving the other two to hit the exact
+ * uninstall-without-reinstall failure #201 fixed.
+ */
+export function resolveAppFileForClearState(
+  platform: 'ios' | 'android',
+  flowText: string,
+  headerAppId: string | undefined,
+  explicitAppFile?: string,
+  deps?: ResolveAppFileDeps,
+): AppFileResolution {
+  if (explicitAppFile) return { ok: true, appFile: explicitAppFile };
+  if (platform !== 'ios' || !flowUsesClearState(flowText)) return { ok: true };
+  if (!headerAppId) {
+    return {
+      ok: false,
+      error:
+        'Flow uses clearState on iOS but no appId is known to locate the .app. ' +
+        'Add `appId:` to the flow header or pass appFile=<path-to-.app>.',
+    };
+  }
+  const appFile = resolveIosAppFile(headerAppId, deps) ?? undefined;
+  if (!appFile) {
+    return {
+      ok: false,
+      error:
+        `Flow uses clearState on iOS but no built .app could be located for ${headerAppId}. ` +
+        'Pass appFile=<path-to-.app> (e.g. <DerivedData>/Build/Products/Debug-iphonesimulator/<App>.app).',
+    };
+  }
+  return { ok: true, appFile };
 }
 
 function defaultGetAppContainer(bundleId: string): string | null {

--- a/scripts/cdp-bridge/src/tools/run-action.ts
+++ b/scripts/cdp-bridge/src/tools/run-action.ts
@@ -38,6 +38,7 @@ import {
   type AutoRepairRefusedReason,
   type ActionFailureCode,
   appendRunRecord,
+  shouldAutoPromoteToActive,
 } from '../domain/reusable-action.js';
 import {
   parseMaestroFailure,
@@ -164,6 +165,12 @@ function readMaestroOutput(env: MaestroEnvelope): string {
  */
 function mapRefusedReason(repairCode: string | undefined, repairError: string): AutoRepairRefusedReason {
   if (repairCode === 'SNAPSHOT_FAILED') return 'SNAPSHOT_FAILED';
+  // RUNNER_LEAK = the snapshot returned the Agent Device Runner's own UI rather
+  // than the target app. That is structurally a snapshot-infra failure (a known,
+  // actionable focus-stealing condition), NOT a transport/contract bug — bucket
+  // it with SNAPSHOT_FAILED so MTTR analytics surface it instead of hiding it
+  // under INTERNAL_ERROR.
+  if (repairCode === 'RUNNER_LEAK') return 'SNAPSHOT_FAILED';
   if (repairCode === 'TESTID_NOT_FOUND') return 'NO_MATCH';
   if (repairCode === 'STALE_TARGET') {
     if (/repair budget/i.test(repairError)) return 'BUDGET_EXHAUSTED';
@@ -206,7 +213,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
     // path segment. Reject malicious slugs at the boundary.
     if (!isValidActionId(args.actionId)) {
       return failResult(
-        `Invalid actionId "${String(args.actionId).slice(0, 80)}" — must match /^[A-Za-z0-9][A-Za-z0-9_-]*$/ and be <= 64 chars`,
+        `Invalid actionId "${String(args.actionId).slice(0, 80)}" — must match /^[A-Za-z0-9][A-Za-z0-9_.-]*$/ (no "..") and be <= 64 chars`,
         'BAD_FILENAME',
       );
     }
@@ -591,7 +598,15 @@ async function persistRun(
       );
       return;
     }
-    const next = { ...fresh, state: appendRunRecord(fresh.state, record) };
+    // H5: promote experimental → active on a clean replay. This is the
+    // documented lifecycle ("first clean /run-action replay auto-promotes to
+    // active") that was defined + unit-tested but never wired into a call site.
+    // persistRun is the single chokepoint both success paths reach, so the
+    // promotion rides the same atomic CAS write as the RunRecord append.
+    const promotedMetadata = shouldAutoPromoteToActive(fresh.metadata, record)
+      ? { ...fresh.metadata, status: 'active' as const }
+      : fresh.metadata;
+    const next = { ...fresh, metadata: promotedMetadata, state: appendRunRecord(fresh.state, record) };
     const result = saveActionWithCAS(next);
     if (result.ok) return;
     // CAS conflict — another writer raced us. Reload and retry.

--- a/scripts/cdp-bridge/src/util/redact.ts
+++ b/scripts/cdp-bridge/src/util/redact.ts
@@ -11,7 +11,11 @@ const SECRET_PATTERNS = [
   /\bAKIA[0-9A-Z]{16}\b/g,
   /\bxox[baprs]-[A-Za-z0-9\-]+\b/g,
   /\bAIza[0-9A-Za-z\-_]{35}\b/g,
-  /-----BEGIN (?:RSA |OPENSSH |PRIVATE )?KEY-----[\s\S]*?-----END (?:RSA |OPENSSH |PRIVATE )?KEY-----/g,
+  // Any private-key label variant: PRIVATE KEY, RSA PRIVATE KEY,
+  // OPENSSH PRIVATE KEY, EC/DSA/ENCRYPTED PRIVATE KEY, ... The old single-word
+  // `(?:RSA |OPENSSH |PRIVATE )?KEY` form never matched multi-word labels like
+  // "RSA PRIVATE KEY" — the most common ssh-keygen header — so keys leaked.
+  /-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----/g,
 ];
 
 // Value-side secret capture: redacts the VALUE when a secret-ish key is glued
@@ -35,10 +39,11 @@ const AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken
 const MAX_STRING_LENGTH = 2000;
 
 function redactString(value: string): string {
-  let result = value.length > MAX_STRING_LENGTH
-    ? value.slice(0, MAX_STRING_LENGTH) + `[TRUNCATED:${value.length}]`
-    : value;
-  result = result.replace(HOME_RE, '~');
+  // Redact BEFORE truncating. Truncation can sever a paired-delimiter secret —
+  // e.g. a PEM private key's -----END----- marker — so the pattern would never
+  // match and the key body would leak through. Apply every pattern to the full
+  // string first, then clip what remains.
+  let result = value.replace(HOME_RE, '~');
   KEYED_SECRET_RE.lastIndex = 0;
   result = result.replace(KEYED_SECRET_RE, '$1[REDACTED_SECRET]');
   for (const pattern of SECRET_PATTERNS) {
@@ -48,6 +53,9 @@ function redactString(value: string): string {
   for (const pattern of PII_PATTERNS) {
     pattern.lastIndex = 0;
     result = result.replace(pattern, '[PII_REDACTED]');
+  }
+  if (result.length > MAX_STRING_LENGTH) {
+    result = result.slice(0, MAX_STRING_LENGTH) + `[TRUNCATED:${result.length}]`;
   }
   return result;
 }

--- a/scripts/cdp-bridge/test/unit/audit-clearstate-standalone.test.js
+++ b/scripts/cdp-bridge/test/unit/audit-clearstate-standalone.test.js
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { flowUsesClearState } from '../../dist/tools/resolve-ios-app-file.js';
+
+// Audit (needs-runtime bucket): flowUsesClearState only matched
+// `launchApp: { clearState: true }`, missing the standalone `- clearState`
+// command (also in the validator allowlist), which uninstalls + needs reinstall.
+
+test('clearState: launchApp object form is detected', () => {
+  assert.equal(flowUsesClearState('- launchApp:\n    clearState: true\n'), true);
+});
+
+test('clearState: standalone command form is now detected', () => {
+  assert.equal(flowUsesClearState('- launchApp\n- clearState\n- tapOn:\n    id: x\n'), true);
+});
+
+test('clearState: a flow without it is not flagged', () => {
+  assert.equal(flowUsesClearState('- launchApp\n- tapOn:\n    id: x\n'), false);
+});
+
+test('clearState: a comment mentioning clearState does not false-trigger the standalone form', () => {
+  // The standalone matcher anchors on a list item, so prose/comment mentions
+  // (no leading `- `) do not match.
+  assert.equal(flowUsesClearState('# we used to clearState here\n- launchApp\n'), false);
+});

--- a/scripts/cdp-bridge/test/unit/audit-d3-repair-bare-quoting.test.js
+++ b/scripts/cdp-bridge/test/unit/audit-d3-repair-bare-quoting.test.js
@@ -1,0 +1,42 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parse as parseYaml } from 'yaml';
+import { replaceIdSelector } from '../../dist/domain/repair-engine.js';
+
+// Audit D3: a bare-form `id:` repair wrote the new id unquoted. isSafeMaestroScalar
+// permits `:`, `{`, `#`, `"`, so a testID like `button: submit` produced invalid
+// YAML that broke the action permanently. The bare form must emit a quoted scalar.
+
+function idOf(body) {
+  // Parse the repaired single-step flow and pull the tapOn id back out.
+  const doc = parseYaml(body);
+  return doc[0].tapOn.id;
+}
+
+test('D3: a colon-bearing new id is quoted so the YAML stays valid', () => {
+  const body = '- tapOn:\n    id: old-btn';
+  const { body: out, replacements } = replaceIdSelector(body, 'old-btn', 'button: submit');
+  assert.equal(replacements, 1);
+  assert.doesNotThrow(() => parseYaml(out), 'repaired YAML must still parse');
+  assert.equal(idOf(out), 'button: submit', 'the id round-trips exactly');
+});
+
+test('D3: a brace/hash new id is quoted', () => {
+  const body = '- tapOn:\n    id: old';
+  const { body: out } = replaceIdSelector(body, 'old', '{fab}#1');
+  assert.doesNotThrow(() => parseYaml(out));
+  assert.equal(idOf(out), '{fab}#1');
+});
+
+test('D3: a plain new id from a bare source is still emitted (now quoted, same meaning)', () => {
+  const body = '- tapOn:\n    id: old';
+  const { body: out } = replaceIdSelector(body, 'old', 'new-btn');
+  assert.equal(idOf(out), 'new-btn');
+});
+
+test('D3: a new id containing a double-quote uses single quotes (matched-quote grammar)', () => {
+  const body = '- tapOn:\n    id: old';
+  const { body: out } = replaceIdSelector(body, 'old', 'say-"hi"');
+  assert.doesNotThrow(() => parseYaml(out));
+  assert.equal(idOf(out), 'say-"hi"');
+});

--- a/scripts/cdp-bridge/test/unit/audit-h1-redact-before-truncate.test.js
+++ b/scripts/cdp-bridge/test/unit/audit-h1-redact-before-truncate.test.js
@@ -1,0 +1,41 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { redact } from '../../dist/util/redact.js';
+
+// Audit H1: redactString must apply SECRET_PATTERNS BEFORE truncating. The PEM
+// rule is a paired-delimiter regex needing both BEGIN and END markers; a real
+// private key (1700-3200+ chars) exceeds MAX_STRING_LENGTH (2000), so truncating
+// first severs the END marker and the key body leaks through unredacted.
+
+function bigPem() {
+  // ~2940-char base64 body -> total > 3000 chars, comfortably over the 2000 cap.
+  const body = 'MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQ'.repeat(60);
+  return '-----BEGIN RSA PRIVATE KEY-----\n' + body + '\n-----END RSA PRIVATE KEY-----';
+}
+
+test('H1: a >2000-char PEM private key is redacted, not leaked', () => {
+  const pem = bigPem();
+  assert.ok(pem.length > 2000, 'precondition: PEM exceeds MAX_STRING_LENGTH');
+
+  const out = redact({ note: pem });
+  const s = out.note;
+
+  assert.equal(typeof s, 'string');
+  assert.ok(!s.includes('MIIEvQIBADANBgkqhkiG'), 'raw key body must NOT survive redaction');
+  assert.ok(s.includes('[REDACTED_SECRET]'), 'the PEM must be replaced with the redaction marker');
+});
+
+test('H1: OPENSSH private key over the cap is also redacted', () => {
+  const body = 'b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAAB'.repeat(50);
+  const key = '-----BEGIN OPENSSH PRIVATE KEY-----\n' + body + '\n-----END OPENSSH PRIVATE KEY-----';
+  const out = redact({ k: key });
+  assert.ok(!out.k.includes('b3BlbnNzaC1rZXktdjEA'), 'OPENSSH key body must not leak');
+  assert.ok(out.k.includes('[REDACTED_SECRET]'));
+});
+
+test('H1: a long non-secret string is still truncated (ordering preserved)', () => {
+  const long = 'x'.repeat(5000);
+  const out = redact({ blob: long });
+  assert.ok(out.blob.includes('[TRUNCATED:'), 'long benign strings still get a truncation marker');
+  assert.ok(out.blob.length < 5000, 'output is clipped');
+});

--- a/scripts/cdp-bridge/test/unit/audit-h2-h3-m7-scroll-swipe-coords.test.js
+++ b/scripts/cdp-bridge/test/unit/audit-h2-h3-m7-scroll-swipe-coords.test.js
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildDirectionalScrollCliArgs } from '../../dist/tools/device-interact.js';
+import { buildRunIOSArgs, buildRunAndroidArgs } from '../../dist/agent-device-wrapper.js';
+
+// Audit H2/H3: a direction-form scroll must be dispatched as the COORDINATE
+// form. The arg builders map scroll → a 4-coordinate drag and throw on the
+// direction form, so the old ['scroll', direction] shape crashed device_scroll
+// on Android and device_batch scroll on both platforms.
+
+test('H2/H3: buildDirectionalScrollCliArgs emits the coordinate form', () => {
+  const args = buildDirectionalScrollCliArgs('down');
+  assert.equal(args[0], 'scroll');
+  assert.equal(args.length, 6, "['scroll', x1, y1, x2, y2, duration]");
+  for (const n of args.slice(1)) {
+    assert.ok(/^\d+$/.test(n), `expected numeric coordinate, got "${n}"`);
+  }
+});
+
+test('H2/H3: the emitted scroll args pass through buildRunAndroidArgs without throwing', () => {
+  const args = buildDirectionalScrollCliArgs('up');
+  const out = buildRunAndroidArgs(args, 'com.example.app');
+  assert.equal(out.command, 'drag');
+  assert.equal(typeof out.x1, 'number');
+});
+
+test('H2/H3: the emitted scroll args pass through buildRunIOSArgs without throwing', () => {
+  const args = buildDirectionalScrollCliArgs('left');
+  const out = buildRunIOSArgs(args, 'com.example.app');
+  assert.equal(out.command, 'drag');
+  assert.equal(typeof out.x, 'number');
+});
+
+test('H2/H3 regression: the OLD direction form still throws (proves the builders reject it)', () => {
+  assert.throws(() => buildRunAndroidArgs(['scroll', 'down'], 'app'), /four numeric coordinates/);
+  assert.throws(() => buildRunIOSArgs(['scroll', 'down'], 'app'), /four numeric coordinates/);
+});
+
+test('H2/H3: scroll direction is inverted vs swipe (scroll down = finger up)', () => {
+  const down = buildDirectionalScrollCliArgs('down'); // [scroll, x1, y1, x2, y2, dur]
+  const y1 = Number(down[2]);
+  const y2 = Number(down[4]);
+  assert.ok(y1 > y2, 'scroll down should move the finger upward (y1 > y2)');
+});
+
+// Audit M7: a coordinate swipe with --count but no durationMs must not let the
+// count value leak into the duration slot on iOS.
+test('M7: --count value does not corrupt iOS swipe durationMs', () => {
+  // canUseFastRunner is false when count is set, so this argv reaches buildRunIOSArgs.
+  const cli = ['swipe', '100', '200', '100', '400', '--count', '3'];
+  const out = buildRunIOSArgs(cli, 'com.example.app');
+  assert.equal(out.command, 'drag');
+  assert.equal(out.x, 100);
+  assert.equal(out.y, 200);
+  assert.equal(out.x2, 100);
+  assert.equal(out.y2, 400);
+  // The '3' from --count must NOT have been parsed as a 3ms duration.
+  assert.notEqual(out.durationMs, 3, '--count value leaked into durationMs (3ms flick)');
+  assert.equal(out.durationMs, undefined, 'no durationMs was supplied, so none should be set');
+});
+
+test('M7: an explicit durationMs IS still honored alongside --count', () => {
+  const cli = ['swipe', '100', '200', '100', '400', '500', '--count', '3'];
+  const out = buildRunIOSArgs(cli, 'com.example.app');
+  assert.equal(out.durationMs, 500, 'the real duration positional must survive flag stripping');
+});

--- a/scripts/cdp-bridge/test/unit/audit-h4-android-runner-deviceid.test.js
+++ b/scripts/cdp-bridge/test/unit/audit-h4-android-runner-deviceid.test.js
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { shouldReuseAndroidRunner } from '../../dist/runners/rn-android-runner-client.js';
+
+// Audit H4: parity with iOS shouldReuseRunner. A live Android runner bound to
+// emulator-A must NOT be reused to drive emulator-B (its adb forward + port
+// still target A — every device_* would silently hit the wrong emulator).
+
+const stateFor = (deviceId) => ({ port: 22089, pid: 4242, deviceId, startedAt: 'now' });
+
+test('H4: same emulator → reuse', () => {
+  assert.equal(shouldReuseAndroidRunner(stateFor('emulator-5554'), 'emulator-5554'), true);
+});
+
+test('H4: different emulator → do NOT reuse (the wrong-device bug)', () => {
+  assert.equal(shouldReuseAndroidRunner(stateFor('emulator-5554'), 'emulator-5556'), false);
+});
+
+test('H4: no live runner → cannot reuse', () => {
+  assert.equal(shouldReuseAndroidRunner(null, 'emulator-5554'), false);
+});
+
+test('H4: no target requested (single-device flow) → any live runner is acceptable', () => {
+  assert.equal(shouldReuseAndroidRunner(stateFor('emulator-5554'), undefined), true);
+});
+
+test('H4: runner with no recorded device + a specific target requested → do not reuse', () => {
+  assert.equal(shouldReuseAndroidRunner(stateFor(undefined), 'emulator-5556'), false);
+});

--- a/scripts/cdp-bridge/test/unit/audit-h5-m1-run-action-promote-drift.test.js
+++ b/scripts/cdp-bridge/test/unit/audit-h5-m1-run-action-promote-drift.test.js
@@ -1,0 +1,83 @@
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRunActionHandler } from '../../dist/tools/run-action.js';
+import { loadAction } from '../../dist/domain/action-store.js';
+import { createTmpProject, fixtureYaml } from '../helpers/tmp-project.js';
+
+let project;
+beforeEach(() => { project = createTmpProject(); });
+afterEach(() => { project.cleanup(); });
+
+function fakeMaestroRun(envelopes) {
+  let i = 0;
+  return async () => {
+    const env = envelopes[Math.min(i, envelopes.length - 1)];
+    i++;
+    return {
+      content: [{ type: 'text', text: JSON.stringify(env) }],
+      ...(env.ok === false ? { isError: true } : {}),
+    };
+  };
+}
+
+const PASS_ENV = { ok: true, data: { passed: true, output: 'Flow passed', flowFile: 'x', platform: 'ios' } };
+
+// Audit H5: the documented "first clean replay auto-promotes experimental →
+// active" lifecycle was never wired into a call site. A clean run must flip the
+// on-disk status.
+test('H5: a clean replay promotes an experimental action to active', async () => {
+  project.seedAction('demo', fixtureYaml({ id: 'demo', status: 'experimental' }));
+
+  const handler = createRunActionHandler({ maestroRun: fakeMaestroRun([PASS_ENV]) });
+  const res = await handler({ actionId: 'demo', projectRoot: project.root, platform: 'ios' });
+  assert.equal(res.isError, undefined, 'the run should succeed');
+
+  const reloaded = loadAction(project.root, 'demo');
+  assert.equal(reloaded.metadata.status, 'active', 'experimental must be promoted to active after a clean replay');
+});
+
+test('H5: an already-active action stays active (no spurious churn)', async () => {
+  project.seedAction('demo', fixtureYaml({ id: 'demo', status: 'active' }));
+  const handler = createRunActionHandler({ maestroRun: fakeMaestroRun([PASS_ENV]) });
+  await handler({ actionId: 'demo', projectRoot: project.root, platform: 'ios' });
+  assert.equal(loadAction(project.root, 'demo').metadata.status, 'active');
+});
+
+// Audit M1: the ROUTE_DRIFT guard only fires when a CDP-backed getLiveRoute is
+// supplied. The default no-op leaves it inert — so the DI seam must, when wired,
+// actually reclassify a selector failure on an off-sequence screen as drift.
+const FAIL_SELECTOR_ENV = {
+  ok: false,
+  data: { passed: false, output: "Element with id 'fab-create-task' not found", flowFile: 'x', platform: 'ios' },
+};
+
+test('M1: a wired getLiveRoute reclassifies an off-sequence selector failure as ROUTE_DRIFT', async () => {
+  // Seed an action whose recorded route sequence expects [Home, Detail] but the
+  // live route is an unexpected screen → drift, not a stale selector.
+  const yaml = [
+    'appId: com.test.app',
+    '---',
+    '# id: demo',
+    '# intent: drift fixture',
+    '# tags: [fixture]',
+    '# mutates: false',
+    '# status: active',
+    '# expectedRouteSequence: [Home, Detail]',
+    '',
+    '- launchApp',
+    '  - tapOn:',
+    '      id: "fab-create-task"',
+    '',
+  ].join('\n');
+  project.seedAction('demo', yaml);
+
+  const handler = createRunActionHandler({
+    maestroRun: fakeMaestroRun([FAIL_SELECTOR_ENV]),
+    getLiveRoute: async () => 'CouponCode', // an unexpected, off-sequence screen
+  });
+  const res = await handler({ actionId: 'demo', projectRoot: project.root, platform: 'ios', autoRepair: true });
+
+  assert.equal(res.isError, true, 'an off-sequence failure should not silently pass');
+  const text = res.content?.[0]?.text ?? '';
+  assert.match(text, /ROUTE_DRIFT|route-drift/i, 'failure should be classified as route drift, not routed into selector repair');
+});

--- a/scripts/cdp-bridge/test/unit/audit-l6-action-id-dot.test.js
+++ b/scripts/cdp-bridge/test/unit/audit-l6-action-id-dot.test.js
@@ -1,0 +1,28 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isValidActionId } from '../../dist/domain/path-safety.js';
+
+// Audit L6: the comment documented "hyphen/underscore/dot/alphanumeric" but the
+// regex excluded dots, so versioned ids (v2.0-login) were rejected with an
+// opaque error. Dots are now accepted; `..` stays rejected for traversal safety.
+
+test('L6: dotted (versioned) action ids are accepted', () => {
+  assert.equal(isValidActionId('v2.0-login'), true);
+  assert.equal(isValidActionId('auth.flow'), true);
+  assert.equal(isValidActionId('checkout.v1.2'), true);
+});
+
+test('L6: existing non-dotted ids still accepted', () => {
+  assert.equal(isValidActionId('login-flow'), true);
+  assert.equal(isValidActionId('add_cart_item'), true);
+  assert.equal(isValidActionId('test123'), true);
+});
+
+test('L6: `..` and traversal payloads stay rejected', () => {
+  assert.equal(isValidActionId('..'), false);
+  assert.equal(isValidActionId('a..b'), false, 'a `..` segment is rejected even without a slash');
+  assert.equal(isValidActionId('../etc/passwd'), false);
+  assert.equal(isValidActionId('foo/../bar'), false);
+  assert.equal(isValidActionId('foo/bar'), false);
+  assert.equal(isValidActionId('.hidden'), false, 'must still start with an alphanumeric');
+});

--- a/scripts/cdp-bridge/test/unit/audit-m3-ensure-fast-runner-liveness.test.js
+++ b/scripts/cdp-bridge/test/unit/audit-m3-ensure-fast-runner-liveness.test.js
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+// Audit M3: the tri-state liveness probe (probeFastRunnerLiveness /
+// reapStaleFastRunner) existed + was unit-tested but had ZERO production
+// callers, so a PID-alive-but-HTTP-wedged runner was still reused and hung
+// every command on the full HTTP timeout. ensureFastRunner must now compose
+// probe → (stale ? reap) → start instead of the PID-only check.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const wrapperSrc = readFileSync(resolve(__dirname, '../../src/agent-device-wrapper.ts'), 'utf8');
+
+// Isolate the ensureFastRunner function body.
+const fnMatch = wrapperSrc.match(/export async function ensureFastRunner[\s\S]*?\n}/);
+assert.ok(fnMatch, 'ensureFastRunner should be present');
+const fnBody = fnMatch[0];
+
+test('M3: ensureFastRunner probes tri-state liveness, not just the PID', () => {
+  assert.match(fnBody, /probeFastRunnerLiveness\(/, 'must probe liveness');
+  assert.ok(!/if \(isFastRunnerAvailable\(\)\) return;/.test(fnBody), 'must NOT gate solely on the PID-only check');
+});
+
+test('M3: ensureFastRunner reaps a stale (wedged) runner before starting fresh', () => {
+  assert.match(fnBody, /reapStaleFastRunner\(/, 'must reap a stale runner');
+  assert.match(fnBody, /startFastRunner\(/, 'must still start a fresh runner');
+});
+
+test('M3: liveness/reap helpers are imported into the wrapper', () => {
+  assert.match(wrapperSrc, /probeFastRunnerLiveness/, 'probe imported');
+  assert.match(wrapperSrc, /reapStaleFastRunner/, 'reap imported');
+});

--- a/scripts/cdp-bridge/test/unit/audit-m4-logcat-timestamp.test.js
+++ b/scripts/cdp-bridge/test/unit/audit-m4-logcat-timestamp.test.js
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseLogcatLine } from '../../dist/tools/collect-logs.js';
+
+// Audit M4: a logcat line carries device-LOCAL wall-clock with no offset.
+// `new Date("YYYY-MM-DDThh:mm:ss")` already parses as local, so getTime() is
+// already the correct UTC epoch. The old code then ADDED the host UTC offset,
+// double-shifting every Android entry by that offset and corrupting merge-sort
+// ordering. The timestamp must equal the local-parsed instant, with no extra
+// offset applied.
+
+test('M4: logcat timestamp is not double-shifted by the host UTC offset', () => {
+  // Format mirrors LOGCAT_RE: "MM-DD hh:mm:ss.mmm  PID  TID PRIO TAG: message"
+  const line = '04-16 22:15:00.123  1234  1234 I MyTag: hello world';
+  const year = 2026;
+
+  const entry = parseLogcatLine(line, year);
+  assert.ok(entry, 'a well-formed logcat line should parse');
+
+  // The single correct interpretation: the same wall-clock, parsed as local.
+  const expected = new Date(`${year}-04-16T22:15:00.123`).toISOString();
+  assert.equal(entry.timestamp, expected);
+});
+
+test('M4: two adjacent log lines preserve monotonic ordering (no offset skew)', () => {
+  const a = parseLogcatLine('04-16 22:15:00.000  1 1 I T: a', 2026);
+  const b = parseLogcatLine('04-16 22:15:01.000  1 1 I T: b', 2026);
+  assert.ok(new Date(a.timestamp).getTime() < new Date(b.timestamp).getTime());
+});

--- a/scripts/cdp-bridge/test/unit/audit-m5-shared-appfile-resolution.test.js
+++ b/scripts/cdp-bridge/test/unit/audit-m5-shared-appfile-resolution.test.js
@@ -1,0 +1,49 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveAppFileForClearState } from '../../dist/tools/resolve-ios-app-file.js';
+
+// Audit M5: the iOS clearState --app-file resolution (#201) must be shared by
+// maestro_run, maestro_test_all, and runMaestroInline. This locks the shared
+// helper's contract that all three now call.
+
+const IOS_CLEARSTATE = '- launchApp:\n    clearState: true\n';
+const NO_CLEARSTATE = '- launchApp\n';
+
+test('M5: an explicit appFile is passed through untouched', () => {
+  const r = resolveAppFileForClearState('ios', IOS_CLEARSTATE, 'com.app', '/built/My.app');
+  assert.deepEqual(r, { ok: true, appFile: '/built/My.app' });
+});
+
+test('M5: a non-clearState flow needs no appFile', () => {
+  const r = resolveAppFileForClearState('ios', NO_CLEARSTATE, 'com.app', undefined);
+  assert.deepEqual(r, { ok: true });
+});
+
+test('M5: Android never needs an appFile even with clearState', () => {
+  const r = resolveAppFileForClearState('android', IOS_CLEARSTATE, 'com.app', undefined);
+  assert.deepEqual(r, { ok: true });
+});
+
+test('M5: iOS clearState with no appId is a structured error (not a silent miss)', () => {
+  const r = resolveAppFileForClearState('ios', IOS_CLEARSTATE, undefined, undefined);
+  assert.equal(r.ok, false);
+  assert.match(r.error, /no appId is known/);
+});
+
+test('M5: iOS clearState resolves via the injected container lookup', () => {
+  const r = resolveAppFileForClearState('ios', IOS_CLEARSTATE, 'com.app', undefined, {
+    getAppContainer: () => '/Containers/My.app',
+    exists: () => true,
+  });
+  assert.deepEqual(r, { ok: true, appFile: '/Containers/My.app' });
+});
+
+test('M5: iOS clearState with no locatable .app is a structured error', () => {
+  const r = resolveAppFileForClearState('ios', IOS_CLEARSTATE, 'com.app', undefined, {
+    getAppContainer: () => null,
+    newestDerivedDataApp: () => null,
+    exists: () => false,
+  });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /no built \.app could be located/);
+});

--- a/scripts/cdp-bridge/test/unit/audit-obs1-recorder-clear-notify.test.js
+++ b/scripts/cdp-bridge/test/unit/audit-obs1-recorder-clear-notify.test.js
@@ -1,0 +1,25 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Recorder } from '../../dist/observability/recorder.js';
+
+// Audit OBS-1: Recorder.clear() used to empty the subscriber set silently,
+// orphaning any live SSE connection (its res + heartbeat interval stayed open
+// forever). clear() must now emit a terminal sentinel so subscribers can close.
+
+test('OBS-1: clear() notifies live subscribers with a terminal sentinel before dropping them', () => {
+  const rec = new Recorder();
+  const received = [];
+  const { detach } = rec.attach((ev) => received.push(ev));
+
+  rec.clear();
+
+  assert.equal(received.length, 1, 'subscriber should get exactly one terminal event');
+  assert.equal(received[0].type, 'cleared', 'the sentinel must be the {type:"cleared"} terminal event');
+
+  // After clear(), the subscriber set is empty — a subsequent record() reaches
+  // no one (no lingering reference).
+  rec.record({ tool: 'device_screenshot', ok: true, result: {} });
+  assert.equal(received.length, 1, 'dropped subscriber must not receive post-clear events');
+
+  detach(); // idempotent no-op now
+});

--- a/scripts/cdp-bridge/test/unit/cdp-002-proof-step-null-tree.test.js
+++ b/scripts/cdp-bridge/test/unit/cdp-002-proof-step-null-tree.test.js
@@ -14,7 +14,7 @@ function buildHandler(treeResponse) {
     if (expr.includes('getTree')) return { value: JSON.stringify(treeResponse) };
     return { value: undefined };
   };
-  return createProofStepHandler(() => client);
+  return createProofStepHandler(() => client, { hasSession: () => false });
 }
 
 function parseResult(toolResult) {
@@ -48,7 +48,7 @@ test('CDP-002: __agent_error envelope → verified:false', async () => {
 test('CDP-002: malformed JSON → verified:false (was true before)', async () => {
   const client = createMockClient();
   client.evaluate = async () => ({ value: 'not-json{{{' });
-  const handler = createProofStepHandler(() => client);
+  const handler = createProofStepHandler(() => client, { hasSession: () => false });
   const r = await handler({ verifyTestID: 'x', waitMs: 0 });
   const parsed = parseResult(r);
   assert.equal(parsed.data.verified, false, 'unparseable response must NOT pass verification');

--- a/scripts/cdp-bridge/test/unit/cdp-005-proof-step-screenshot-failure.test.js
+++ b/scripts/cdp-bridge/test/unit/cdp-005-proof-step-screenshot-failure.test.js
@@ -27,7 +27,7 @@ test('CDP-005: errors accumulated (e.g. navigation error) → warn metadata is s
     if (expr.includes('getTree')) return { value: JSON.stringify({ tree: { component: 'View' } }) };
     return { value: undefined };
   };
-  const handler = createProofStepHandler(() => client);
+  const handler = createProofStepHandler(() => client, { hasSession: () => false });
   const r = await handler({ screen: 'X', verifyTestID: 'something', waitMs: 0 });
   const env = parseEnvelope(r);
   assert.ok(typeof env.meta?.warning === 'string' && env.meta.warning.length > 0,
@@ -38,7 +38,7 @@ test('CDP-005: errors accumulated (e.g. navigation error) → warn metadata is s
 test('CDP-005: verification requested + verified=false alone triggers warning', async () => {
   const client = createMockClient();
   client.evaluate = async () => ({ value: JSON.stringify({ tree: null }) });
-  const handler = createProofStepHandler(() => client);
+  const handler = createProofStepHandler(() => client, { hasSession: () => false });
   const r = await handler({ verifyTestID: 'missing', waitMs: 0 });
   const env = parseEnvelope(r);
   assert.ok(typeof env.meta?.warning === 'string' && env.meta.warning.length > 0);
@@ -48,7 +48,7 @@ test('CDP-005: verification requested + verified=false alone triggers warning', 
 test('CDP-005: clean verification stays verified=true (warn may still fire from screenshot if no session — that\'s the expected CDP-005 behaviour)', async () => {
   const client = createMockClient();
   client.evaluate = async () => ({ value: JSON.stringify({ tree: { component: 'View', testID: 'real' } }) });
-  const handler = createProofStepHandler(() => client);
+  const handler = createProofStepHandler(() => client, { hasSession: () => false });
   const r = await handler({ verifyTestID: 'real', waitMs: 0 });
   const env = parseEnvelope(r);
   // Verification succeeded — that's the regression-preserving check.

--- a/scripts/cdp-bridge/test/unit/gh-201-maestro-run-app-file-wiring.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-201-maestro-run-app-file-wiring.test.js
@@ -9,9 +9,11 @@ const runSrc = readFileSync(resolve(__dirname, '../../src/tools/maestro-run.ts')
 const indexSrc = readFileSync(resolve(__dirname, '../../src/index.ts'), 'utf8');
 
 test('GH#201 maestro-run auto-resolves appFile for iOS clearState flows', () => {
-  assert.match(runSrc, /flowUsesClearState\(/);
-  assert.match(runSrc, /resolveIosAppFile\(headerAppId\)/);
-  assert.match(runSrc, /dispatch\.buildArgs\(platform, flowFile, appFile\)/);
+  // The clearState→appFile resolution was extracted into the shared
+  // resolveAppFileForClearState helper (so maestro_test_all + runMaestroInline
+  // reuse it too); maestro-run delegates to it and threads the result into buildArgs.
+  assert.match(runSrc, /resolveAppFileForClearState\(/);
+  assert.match(runSrc, /dispatch\.buildArgs\(platform, flowFile, appFileResolution\.appFile\)/);
 });
 
 test('GH#201 maestro_run exposes an appFile param', () => {

--- a/scripts/learned-actions.mjs
+++ b/scripts/learned-actions.mjs
@@ -67,9 +67,13 @@ const matchKw = (...fields) =>
 // A. Feedback memories
 // ─────────────────────────────────────────────────────────────────────────────
 function scanMemories() {
-  // Claude Code encodes the project cwd by replacing both `/` and `_` with `-`
-  // (verified: /Users/anton_personal/GitHub/foo → -Users-anton-personal-GitHub-foo).
-  const encoded = flags.memoryCwd.replace(/[\/_]/g, '-');
+  // Claude Code encodes the project cwd by replacing every non-alphanumeric
+  // character with `-` — that includes `/`, `_`, AND `.` (verified:
+  // /Users/x/.claude-mem → -Users-x--claude-mem). The previous `[\/_]` regex
+  // left dots intact, so any cwd containing a dot (a dotted dir name, a dotfile
+  // dir, or a dotted username) computed a memDir that did not exist on disk and
+  // silently dropped the entire feedback-memory section.
+  const encoded = flags.memoryCwd.replace(/[^a-zA-Z0-9]/g, '-');
   const memDir = path.join(os.homedir(), '.claude', 'projects', encoded, 'memory');
   if (!fs.existsSync(memDir)) return { exists: false, dir: memDir, items: [] };
 
@@ -108,7 +112,7 @@ function scanFlows() {
       if (flags.appId && meta.appId !== flags.appId) continue;
       const tagsStr = (meta.tags || []).join(',');
       if (!matchKw(meta.purpose, meta.appId, meta.intent, tagsStr, f, fp)) continue;
-      const params = (text.match(/\$\{([A-Z_]+)\}/g) || []).map((s) => s.slice(2, -1));
+      const params = (text.match(/\$\{([A-Z_][A-Z0-9_]*)\}/g) || []).map((s) => s.slice(2, -1));
       const uniqParams = Array.from(new Set(params));
       const replay = uniqParams.length
         ? `maestro-runner --platform ios test ${uniqParams.map((p) => `-e ${p}=...`).join(' ')} ${fp}`

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -8,8 +8,14 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PLUGIN_JSON="$REPO_ROOT/.claude-plugin/plugin.json"
 MARKETPLACE_JSON="$REPO_ROOT/.claude-plugin/marketplace.json"
 SYNTHETIC_PKG_JSON="$REPO_ROOT/.claude-plugin/package.json"
-MCP_PACKAGE_JSON="$REPO_ROOT/scripts/cdp-bridge/package.json"
 MCP_SRC_DIR="$REPO_ROOT/scripts/cdp-bridge/src"
+# NOTE: scripts/cdp-bridge/package.json (rn-dev-agent-cdp) is NOT synced here.
+# It is an INDEPENDENTLY-versioned changeset package (changeset config has
+# fixed:[]/linked:[]), so its version legitimately differs from the plugin's.
+# A prior MCP_PACKAGE_JSON variable here was declared but never used and implied
+# a sync that must not happen — removed to avoid that false impression. The MCP
+# server reads its own version from this file at runtime; keep it bumped via a
+# `rn-dev-agent-cdp` changeset entry whenever cdp-bridge/src changes.
 
 plugin_version=$(grep '"version"' "$PLUGIN_JSON" | head -1 | sed 's/.*"version": *"\([^"]*\)".*/\1/')
 marketplace_version=$(grep '"version"' "$MARKETPLACE_JSON" | head -1 | sed 's/.*"version": *"\([^"]*\)".*/\1/')


### PR DESCRIPTION
## Summary

A multi-agent audit of the repo surfaced a set of bugs, regressions, and reliability issues. This PR fixes every **independently-verified** finding (High → Low) with regression tests, and hardens the flaky `proof_step` unit tests. Stacked on `feat/202-phase1.5-device-lock`; the diff is just the audit fixes.

**Verification:** unit suite **1659/1659** (was 1618), deterministic across repeated runs; integration tests green; `tsc --noEmit` clean. 41 new regression tests; `dist` rebuilt.

## Security
- **redact.ts** — private keys no longer leak. Secret patterns now run **before** truncation (a >2000-char PEM had its `-----END-----` severed so the body passed through), and the PEM rule now matches multi-word labels like `RSA PRIVATE KEY` / `OPENSSH PRIVATE KEY` (the old single-word pattern never matched the most common headers).

## Device interaction
- `device_scroll` / `device_batch` scroll **no longer throw** on Android (and the iOS fast-runner fallback) — direction is converted to coordinates before dispatch, mirroring `device_swipe`.
- iOS coordinate swipe with `--count`/`--pattern` but no `durationMs` no longer mis-parses the flag value as a 3 ms duration (flag-aware positional extraction).
- Android runner won't drive the wrong emulator — `shouldReuseAndroidRunner` checks the bound `deviceId` (iOS `shouldReuseRunner` parity, #202).
- `ensureFastRunner` probes **tri-state liveness** + reaps a wedged-but-alive runner (previously every command burned the full HTTP timeout).
- `ensureSingleRunner` is awaited at session-open (kill precedes first interaction) and surfaces `ps` failure as a warning instead of a silent no-op.

## Actions / Maestro
- Actions **auto-promote** `experimental → active` on first clean replay (documented + tested but never wired).
- The #186 **route-drift guard** is active in production (`cdp_run_action` wired with a CDP-backed live-route reader; previously a no-op default).
- `maestro_test_all` + inline fallback drop the `Error:` false-fail, share the #201 `--app-file` resolution, and recognise standalone `- clearState`; all Maestro `execFile` calls use `maxBuffer: 10 MB`.
- `cdp_repair_action` `RUNNER_LEAK` refusals bucket as `SNAPSHOT_FAILED` (not `INTERNAL_ERROR`) in MTTR telemetry; bare-form `id:` repair emits a quoted scalar.

## Reliability / correctness
- `collect_logs` stops double-shifting Android logcat timestamps by the host UTC offset.
- CDP freshness/dev probes attach a no-op catch to the raced `evaluate()` promise (no `unhandledRejection` on mid-probe WS close).
- Observability server: `headersTimeout` slow-loris guard, `shutdown` broadcast (browser stops auto-reconnecting), and `Recorder.clear()` notifies subscribers instead of orphaning SSE streams.
- Action IDs accept dots (`v2.0-login`) per their documented contract, still reject `..`.
- post-edit hook's "app not installed → skip" guard works again (`grep -c || echo "0"` produced `0\n0`).
- `learned-actions` resolves dotted project paths + accepts digit-bearing `${VAR}` keys.
- Single-source `HELPERS_VERSION` (log no longer reports a stale `v11`); `sync-versions.sh` drops a dead var and documents that `rn-dev-agent-cdp` is independently versioned.

## Deliberately NOT changed (flagged for a runtime pass)
- **D2** (`saveActionWithCAS` throws): investigation showed the throw is **load-bearing** — it enforces the strict-mode (forceReload=false) refusal and is correctly caught by the handler. Reverted my initial "fix" after it regressed `gh-173-run-action-force-reload`; documented inline.
- Nested-navigator `extractActiveScreen` and the `softReconnect` double-connect race — unconfirmed (runtime-dependent), carry regression risk; left for a device-backed verification pass.

## Test-suite hardening
The previously **flaky** `cdp-002`/`cdp-005` proof-step tests read a machine-global session file, so on a dev machine they hit a real screenshot subprocess that flaked under parallel load. Added a DI seam (`hasSession`/`captureScreenshot`) → deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)