### PR TITLE
feat(#202): Phase 3 — 3-layer contract docs + proactive foreign-runner warning (#186)

### DIFF
--- a/.changeset/device-foreign-runner-202-phase3.md
+++ b/.changeset/device-foreign-runner-202-phase3.md
@@ -1,0 +1,5 @@
+---
+"rn-dev-agent-plugin": patch
+---
+
+#202 Phase 3: formalize the three-layer device-control contract (L1 introspection / L2 interaction / L3 flow) in the docs, and add a proactive, informational `FOREIGN_RUNNER_ACTIVE` warning. When `device_snapshot action=open` finds a foreign maestro automation session driving the simulator (UDID-scoped) and rn-dev-agent is not itself running a flow, the open result now carries `meta.foreignRunner` + a heads-up that interleaving `device_*` may trigger a re-foreground (CDP reads are unaffected). Opt out with `RN_IOS_FOREIGN_WARN=0`. The reactive recovery for an actual leak shipped earlier in #188; this is the complementary proactive signal.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,18 @@ Since #202 Phase 2b, `cdp_status` auto-recovers the JS-thread-paused wedge (some
 
 Fallback: `xcrun simctl` (iOS) + `adb` (Android) for device lifecycle (boot / install / launch / terminate) — the runner doesn't manage device state, only interaction.
 
+### Three-layer device-control contract
+
+One mechanism per capability tier. The device-session honors this contract (the L2 coexistence behavior shipped in #188; #202 Phase 3 wrote it down + added a proactive warning).
+
+| Layer | Mechanism | Role | Exclusivity | Toward a foreign runner |
+|---|---|---|---|---|
+| **L1 INTROSPECTION** | CDP / Hermes | read store / network / component-tree / mmkv / native | **shared** | always safe — never touches XCUITest |
+| **L2 INTERACTION** | iOS `RnFastRunner` / Android `agent-device`; `cdp_interact` | primitive taps / types / scrolls | **shared** | re-attach, don't evict (Tier-0 reacquire + CDP re-pin, #188) |
+| **L3 FLOW-REPLAY** | `maestro-runner` (Go + WDA) | whole-`.yaml` E2E flows | **exclusive** | owns the device for the flow's duration |
+
+**Coexistence rule:** L1 reads never conflict with a foreign runner; L2 re-attaches rather than evicts; L3 owns the device. On `device_snapshot action=open`, if a foreign maestro session is detected (UDID-scoped) AND no local flow lease is held, the open result carries an informational `meta.foreignRunner` + `FOREIGN_RUNNER_ACTIVE` warning (`runners/external-runner-detect.ts`; opt out with `RN_IOS_FOREIGN_WARN=0`). See `docs-site` → "Using rn-dev-agent with maestro-mcp".
+
 ### MCP Server (cdp-bridge)
 
 **76 tools** exposed via MCP (re-audited 2026-05-31; counted from `trackedTool()` calls in `scripts/cdp-bridge/src/index.ts`). Five conceptual families:

--- a/docs-site/src/content/docs/architecture.mdx
+++ b/docs-site/src/content/docs/architecture.mdx
@@ -80,6 +80,18 @@ The product layers above are organized; underneath, three implementation layers 
 
 Fallback: `xcrun simctl` (iOS) + `adb` (Android) for device **lifecycle** (boot / install / launch / terminate) — the runner doesn't manage device state, only interaction.
 
+## Three-layer device-control contract
+
+One mechanism per capability tier — **L1 + L2 coexist** (drive with XCTest, assert with CDP in the same per-step loop); **L3 is exclusive** (owns the device for the flow).
+
+| Layer | Mechanism | Role | Exclusivity |
+|---|---|---|---|
+| **L1 INTROSPECTION** | CDP / Hermes | read store / network / component-tree / mmkv / native | shared |
+| **L2 INTERACTION** | iOS `RnFastRunner` / Android `agent-device`; `cdp_interact` | primitive taps / types / scrolls | shared |
+| **L3 FLOW-REPLAY** | `maestro-runner` (Go + WDA) | whole-`.yaml` E2E flows | exclusive |
+
+**Foreign runners** (e.g. the standalone `maestro-mcp`): L1 reads are always safe; on an L2 leak the device-session re-attaches rather than evicts (#188); `device_snapshot action=open` surfaces an informational `FOREIGN_RUNNER_ACTIVE` warning when a foreign session is present and no local flow is running.
+
 ## MCP server (CDP bridge)
 
 The MCP server is a Node.js process that maintains a persistent WebSocket connection to the React Native app's Hermes engine through Metro's CDP endpoint.

--- a/docs-site/src/content/docs/guides/maestro-interop.mdx
+++ b/docs-site/src/content/docs/guides/maestro-interop.mdx
@@ -1,0 +1,25 @@
+---
+title: Using rn-dev-agent with maestro-mcp
+description: How rn-dev-agent coexists with the standalone maestro-mcp server on one iOS simulator.
+---
+
+rn-dev-agent and the standalone **maestro-mcp** server can be used together: maestro *executes* resilient flows, rn-dev-agent *verifies* internal state. They share one iOS simulator, so this page describes how they coexist.
+
+## What is safe to interleave
+
+- **L1 introspection (CDP reads)** — `cdp_navigation_state`, `cdp_store_state`, `cdp_component_tree`, etc. — is **always safe**. It reads Hermes over CDP and never touches the XCUITest automation channel maestro uses.
+- **L2 interaction** (`device_*`) shares the XCUITest channel with maestro's iOS driver. After a maestro run, the next `device_*` may find the channel evicted.
+
+## What happens on handback (already automatic)
+
+When an L2 call sees the runner-leak sentinel after a maestro run, the device-session performs a **state-preserving reacquire** — it re-foregrounds your app (no relaunch) and marks CDP stale so the next read transparently reconnects. You do **not** need a manual `cdp_status` re-pin (shipped in #188).
+
+## The `FOREIGN_RUNNER_ACTIVE` warning
+
+When you `device_snapshot action=open` while a foreign maestro automation session is driving the same simulator (and rn-dev-agent is not itself running a flow), the open result carries an informational `meta.foreignRunner` and a `FOREIGN_RUNNER_ACTIVE` warning. It is a **heads-up only** — it does not block or change the open. It tells you the simulator is contended so you can expect a re-foreground if you interleave `device_*`.
+
+The detection is UDID-scoped (it ignores maestro flows on other simulators and the idle maestro-mcp server). Opt out with `RN_IOS_FOREIGN_WARN=0`. Note: immediately after your *own* `maestro_run`, you may briefly see the warning while maestro's driver is still exiting — that's expected.
+
+## L3 flows own the device
+
+A `maestro_run` / `maestro_test_all` flow (rn-dev-agent's own L3) takes the device exclusively for its duration — `device_*` and CDP reads issued mid-flow refuse fast with `BUSY_FLOW_ACTIVE`.

--- a/docs/superpowers/plans/2026-06-04-device-control-phase3.md
+++ b/docs/superpowers/plans/2026-06-04-device-control-phase3.md
@@ -12,6 +12,16 @@
 
 ---
 
+### Task 0: Live `ps` validation (DONE — 2026-06-04)
+
+Performed before coding (per spec §4, and required by the multi-LLM plan review). Ran a real maestro flow against a booted iPhone 17 Pro (UDID `FC78646A-56D5-4737-9CD0-A360D622F3B3`) and captured `ps ax -o pid=,command=`. Findings that shaped Tasks 1 & 3:
+- maestro's iOS driver is **`maestro-driver-iosUITests-Runner`** (not WebDriverAgent), and its process path **carries the target UDID** (`…/Devices/<UDID>/…`); `xcodebuild … -destination id=<UDID> … maestro-driver-ios-config.xctestrun` carries it too.
+- the **idle** maestro-mcp server (`java … maestro.cli.AppKt mcp`) carries **no UDID**.
+
+Conclusion: the detector is viable; the matcher targets `maestro` (not WebDriverAgent), and **UDID-scoping is mandatory** (it excludes the idle server + other-sim flows). No code in this task — it's the empirical basis for Task 1's matcher + tests.
+
+---
+
 ### Task 1: `detectIosExternalRunner()` — iOS foreign-runner detector
 
 **Files:**
@@ -28,39 +38,47 @@ import { detectIosExternalRunner } from '../../dist/runners/external-runner-dete
 
 const fakePs = (stdout) => async () => ({ stdout });
 
-test('detectIosExternalRunner: flags a foreign WebDriverAgent process', async () => {
-  const ps = fakePs('501 /path/WebDriverAgentRunner-Runner.app/WebDriverAgentRunner-Runner\n502 /usr/bin/login\n');
-  const w = await detectIosExternalRunner(ps);
+// Real signatures captured from a live `ps ax -o command=` during a maestro flow (Task 0).
+const UDID = 'FC78646A-56D5-4737-9CD0-A360D622F3B3';
+const OTHER_UDID = 'AAAAAAAA-1111-2222-3333-BBBBBBBBBBBB';
+const MAESTRO_DRIVER = `18225 /Users/x/Library/Developer/CoreSimulator/Devices/${UDID}/data/Containers/Bundle/Application/155F/maestro-driver-iosUITests-Runner.app/maestro-driver-iosUITests-Runner`;
+const MAESTRO_XCODEBUILD = `17754 /Applications/Xcode.app/.../xcodebuild test-without-building -xctestrun /tmp/${UDID}/maestro-driver-ios-config.xctestrun -destination id=${UDID}`;
+const MAESTRO_MCP_IDLE = '14013 java -classpath /Users/x/.maestro/lib/* maestro.cli.AppKt mcp'; // NB: carries no UDID
+const OUR_RUNNER = `99 /Users/x/Library/Developer/CoreSimulator/Devices/${UDID}/.../RnFastRunnerUITests-Runner.app/RnFastRunnerUITests-Runner`;
+
+test('detectIosExternalRunner: flags a foreign maestro driver on the target UDID', async () => {
+  const ps = fakePs(`${MAESTRO_DRIVER}\n${MAESTRO_XCODEBUILD}\n800 /usr/bin/login\n`);
+  const w = await detectIosExternalRunner(ps, UDID);
   assert.ok(w);
   assert.equal(w.platform, 'ios');
   assert.equal(w.code, 'IOS_XCUITEST_COMPETITOR');
-  assert.equal(w.processLines.length, 1);
-  assert.match(w.processLines[0], /WebDriverAgentRunner/);
+  assert.equal(w.processLines.length, 2);
+  assert.match(w.processLines[0], /maestro-driver-iosUITests-Runner/);
 });
 
-test('detectIosExternalRunner: flags a foreign maestro process', async () => {
-  const ps = fakePs('601 /opt/homebrew/bin/maestro test flow.yaml\n');
-  const w = await detectIosExternalRunner(ps);
-  assert.ok(w);
-  assert.match(w.processLines[0], /maestro/);
+test('detectIosExternalRunner: UDID-scopes — a maestro flow on a DIFFERENT sim is ignored', async () => {
+  const ps = fakePs(MAESTRO_DRIVER + '\n');
+  assert.equal(await detectIosExternalRunner(ps, OTHER_UDID), null);
 });
 
-test('detectIosExternalRunner: excludes our own RnFastRunner host + UITests runner', async () => {
-  const ps = fakePs(
-    '701 /Users/x/Library/Developer/.../RnFastRunner.app/RnFastRunner\n' +
-    '702 /Users/x/Library/Developer/.../RnFastRunnerUITests-Runner.app/RnFastRunnerUITests-Runner\n',
-  );
-  assert.equal(await detectIosExternalRunner(ps), null);
+test('detectIosExternalRunner: ignores the idle maestro-mcp server (no UDID)', async () => {
+  const ps = fakePs(`${MAESTRO_MCP_IDLE}\n800 /usr/bin/login\n`);
+  assert.equal(await detectIosExternalRunner(ps, UDID), null);
+});
+
+test('detectIosExternalRunner: excludes our own RnFastRunner even on the target UDID', async () => {
+  const ps = fakePs(OUR_RUNNER + '\n');
+  assert.equal(await detectIosExternalRunner(ps, UDID), null);
 });
 
 test('detectIosExternalRunner: null when no automation process present', async () => {
   const ps = fakePs('801 /usr/bin/login\n802 /System/Library/Foo\n');
-  assert.equal(await detectIosExternalRunner(ps), null);
+  assert.equal(await detectIosExternalRunner(ps, UDID), null);
 });
 
 test('detectIosExternalRunner: error-safe when ps fails', async () => {
   const ps = async () => { throw new Error('ps blew up'); };
-  assert.equal(await detectIosExternalRunner(ps), null);
+  assert.equal(await detectIosExternalRunner(ps, UDID), null);
 });
 ```
 
@@ -81,15 +99,18 @@ export interface IosExternalRunnerWarning {
   processLines: string[];
 }
 
-// Narrow on purpose: WebDriverAgent is maestro's iOS driver; the `maestro` CLI
-// covers direct invocations. XCTRunner is deliberately NOT matched — it's too
-// generic and would catch our own RnFastRunner UITests host.
-const IOS_FOREIGN_RE = /WebDriverAgent|\bmaestro\b/i;
-// Our own runner shows the app NAME (not the bundle id) in the ps command line.
+// Validated against live `ps` (2026-06-04): maestro's iOS driver is
+// `maestro-driver-iosUITests-Runner` — the `maestro` token catches it, the
+// `.xctestrun`, and the java CLI. `WebDriverAgent` is a harmless secondary for
+// Appium/WDA-style foreign tools. `XCTRunner` is intentionally NOT matched (too
+// generic). The UDID filter is the real defense: the idle maestro-mcp server
+// (`java … maestro.cli.AppKt mcp`) carries NO UDID, so scoping excludes it.
+const IOS_FOREIGN_RE = /maestro|WebDriverAgent/i;
 const RN_FAST_RUNNER_RE = /RnFastRunner/i;
 
 export async function detectIosExternalRunner(
   execFileImpl: typeof execFile = execFile,
+  udid?: string,
 ): Promise<IosExternalRunnerWarning | null> {
   try {
     const opts = { timeout: 2_000, encoding: 'utf8' as const };
@@ -105,6 +126,7 @@ export async function detectIosExternalRunner(
       .split('\n')
       .filter((line) => IOS_FOREIGN_RE.test(line))
       .filter((line) => !RN_FAST_RUNNER_RE.test(line))
+      .filter((line) => (udid ? line.includes(udid) : true))
       .map((line) => line.trim())
       .filter((line) => line.length > 0);
 
@@ -114,7 +136,7 @@ export async function detectIosExternalRunner(
       platform: 'ios',
       code: 'IOS_XCUITEST_COMPETITOR',
       message:
-        'A foreign WebDriverAgent/maestro automation session is running on this simulator. ' +
+        'A foreign maestro/WebDriverAgent automation session is driving this simulator. ' +
         'Interleaving device_* with it may trigger a re-foreground of your app; CDP reads are unaffected. ' +
         '(If this is your own maestro flow, it is expected.)',
       processLines: lines,
@@ -128,7 +150,7 @@ export async function detectIosExternalRunner(
 - [ ] **Step 4: Build + run test to verify it passes**
 
 Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/gh-202-detect-ios-external-runner.test.js`
-Expected: PASS (5/5). (Tests import from `dist/`, so the build must run first.)
+Expected: PASS (6/6). (Tests import from `dist/`, so the build must run first.)
 
 - [ ] **Step 5: Commit**
 
@@ -291,16 +313,22 @@ Replace it with:
           ensureFastRunner(deviceId, appId).catch(() => { /* non-fatal */ });
         }
 
-        // GH#202 Phase 3: proactive foreign-runner heads-up. Gate on the arbiter
-        // flow lease — when WE hold it, a detected WebDriverAgent is our own L3
-        // maestro-runner, not a foreign session (skip the ps-scan entirely).
-        // Informational only and best-effort (the detector never throws), so it
-        // can neither delay nor fail the open.
-        let foreign = null;
-        if (platform === 'ios') {
+        // GH#202 Phase 3: proactive foreign-runner heads-up (informational only).
+        // Skip when opted out, or when WE hold the flow lease (a detected maestro
+        // driver is then our own L3 run — external opens are already refused
+        // BUSY_FLOW_ACTIVE upstream; this guard covers composite/internal callers).
+        // UDID-scoped + best-effort: the detector never throws (can't fail the
+        // open); its ≤2s latency is surfaced in meta.timings_ms.
+        let foreign: ReturnType<typeof foreignRunnerNotice> = null;
+        let foreignDetectMs: number | undefined;
+        if (platform === 'ios' && process.env.RN_IOS_FOREIGN_WARN !== '0') {
           const flowHeld = arbiter.snapshot.flowLeaseHeldBy !== null;
-          const detection = flowHeld ? null : await detectIosExternalRunner();
-          foreign = foreignRunnerNotice(detection, flowHeld);
+          if (!flowHeld) {
+            const t0 = Date.now();
+            const detection = await detectIosExternalRunner(undefined, deviceId);
+            foreignDetectMs = Date.now() - t0;
+            foreign = foreignRunnerNotice(detection, false);
+          }
           if (foreign) {
             logger.warn('rn-device', foreign.warning);
             for (const line of foreign.meta.foreignRunner.processLines) {
@@ -315,7 +343,9 @@ Replace it with:
             autoDetected ? `appId auto-detected from app.json: ${appId}` : null,
             foreign ? foreign.warning : null,
           ].filter(Boolean).join('; ');
-          return warnResult(data, warning, foreign ? foreign.meta : undefined);
+          const meta: Record<string, unknown> = { ...(foreign ? foreign.meta : {}) };
+          if (foreignDetectMs !== undefined) meta.timings_ms = { foreignDetect: foreignDetectMs };
+          return warnResult(data, warning, meta);
         }
       }
 
@@ -483,7 +513,7 @@ Expected: only the already-committed dist files; no unexpected drift. If anythin
 - [ ] **Step 3: Run the full suite**
 
 Run: `cd scripts/cdp-bridge && npm test 2>&1 | grep -E '^ℹ (tests|pass|fail)'`
-Expected: `fail 0`, and the count is up by the 9 new tests (5 + 3 + 1).
+Expected: `fail 0`, and the count is up by the 10 new tests (6 + 3 + 1).
 
 - [ ] **Step 4: Commit**
 
@@ -496,7 +526,7 @@ git commit -S -m "chore(#202): changeset for Phase 3 foreign-runner contract + w
 
 ## Self-review checklist (run before handing off to execution)
 
-- **Spec coverage:** §2 contract → Task 4 (CLAUDE.md + architecture.mdx + handoff page). §3 docs → Task 4. §4 `detectIosExternalRunner` → Task 1. §5 proactive warning + gate → Tasks 2 + 3. §8 tests → Tasks 1/2/4. §0 reconciliation (no recovery rebuild) → respected (no edits to `runner-leak-recovery.ts` / the recovery path).
+- **Spec coverage:** §0 reconciliation (no recovery rebuild) → respected (no edits to `runner-leak-recovery.ts`). §2 contract → Task 4. §3 docs → Task 4. §4 `detectIosExternalRunner` + the live-`ps` validation + UDID-scoping → Task 0 + Task 1. §5 proactive warning + flow-lease gate + opt-out + timings → Tasks 2 + 3. §8 tests → Tasks 1/2/4 (incl. UDID-scope + idle-server + different-sim cases).
 - **Type consistency:** `IosExternalRunnerWarning` (Task 1) is consumed by `foreignRunnerNotice` (Task 2) and the device-session wiring (Task 3). `ForeignRunnerNotice.meta` is passed straight to `warnResult(data, warning, meta)`.
 - **No placeholders:** every code step shows complete code.
 - **Gate correctness:** the flow-lease gate is checked once (Task 3 computes `flowHeld` and skips the ps-scan when held); `foreignRunnerNotice` re-applies it as the single source of truth for the meta decision (and is unit-tested in isolation).

--- a/docs/superpowers/plans/2026-06-04-device-control-phase3.md
+++ b/docs/superpowers/plans/2026-06-04-device-control-phase3.md
@@ -1,0 +1,502 @@
+# Device-Control Phase 3 Implementation Plan — 3-layer contract + proactive foreign-runner warning
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Formalize the three-layer device-control contract in docs, and add a proactive, informational `FOREIGN_RUNNER_ACTIVE` warning when an iOS device session opens while a foreign maestro/WebDriverAgent automation session is present.
+
+**Architecture:** Two new pure functions in `external-runner-detect.ts` (`detectIosExternalRunner` mirroring the existing Android detector, and `foreignRunnerNotice` which applies the arbiter-flow-lease gate + builds the result meta), thin glue in `device-session.ts`'s `action=open` success path, and three documentation edits. The *reactive* recovery (runner-leak reacquire + CDP re-pin) already shipped in #188 — this plan does not touch it.
+
+**Tech Stack:** TypeScript (Node ≥22, ESM), `node --test` (hermetic, tests import compiled JS from `dist/`), Astro Starlight (`docs-site`), changesets.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-device-control-phase3-design.md` (see §0 reconciliation).
+
+---
+
+### Task 1: `detectIosExternalRunner()` — iOS foreign-runner detector
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/runners/external-runner-detect.ts` (append, after `detectAndroidExternalRunner`)
+- Test: `scripts/cdp-bridge/test/unit/gh-202-detect-ios-external-runner.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// scripts/cdp-bridge/test/unit/gh-202-detect-ios-external-runner.test.js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { detectIosExternalRunner } from '../../dist/runners/external-runner-detect.js';
+
+const fakePs = (stdout) => async () => ({ stdout });
+
+test('detectIosExternalRunner: flags a foreign WebDriverAgent process', async () => {
+  const ps = fakePs('501 /path/WebDriverAgentRunner-Runner.app/WebDriverAgentRunner-Runner\n502 /usr/bin/login\n');
+  const w = await detectIosExternalRunner(ps);
+  assert.ok(w);
+  assert.equal(w.platform, 'ios');
+  assert.equal(w.code, 'IOS_XCUITEST_COMPETITOR');
+  assert.equal(w.processLines.length, 1);
+  assert.match(w.processLines[0], /WebDriverAgentRunner/);
+});
+
+test('detectIosExternalRunner: flags a foreign maestro process', async () => {
+  const ps = fakePs('601 /opt/homebrew/bin/maestro test flow.yaml\n');
+  const w = await detectIosExternalRunner(ps);
+  assert.ok(w);
+  assert.match(w.processLines[0], /maestro/);
+});
+
+test('detectIosExternalRunner: excludes our own RnFastRunner host + UITests runner', async () => {
+  const ps = fakePs(
+    '701 /Users/x/Library/Developer/.../RnFastRunner.app/RnFastRunner\n' +
+    '702 /Users/x/Library/Developer/.../RnFastRunnerUITests-Runner.app/RnFastRunnerUITests-Runner\n',
+  );
+  assert.equal(await detectIosExternalRunner(ps), null);
+});
+
+test('detectIosExternalRunner: null when no automation process present', async () => {
+  const ps = fakePs('801 /usr/bin/login\n802 /System/Library/Foo\n');
+  assert.equal(await detectIosExternalRunner(ps), null);
+});
+
+test('detectIosExternalRunner: error-safe when ps fails', async () => {
+  const ps = async () => { throw new Error('ps blew up'); };
+  assert.equal(await detectIosExternalRunner(ps), null);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/cdp-bridge && node --test test/unit/gh-202-detect-ios-external-runner.test.js`
+Expected: FAIL — `detectIosExternalRunner` is not exported (import resolves to `undefined`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `scripts/cdp-bridge/src/runners/external-runner-detect.ts` (the file already imports `execFile` from `node:child_process` and `promisify` from `node:util`):
+
+```ts
+export interface IosExternalRunnerWarning {
+  platform: 'ios';
+  code: 'IOS_XCUITEST_COMPETITOR';
+  message: string;
+  processLines: string[];
+}
+
+// Narrow on purpose: WebDriverAgent is maestro's iOS driver; the `maestro` CLI
+// covers direct invocations. XCTRunner is deliberately NOT matched — it's too
+// generic and would catch our own RnFastRunner UITests host.
+const IOS_FOREIGN_RE = /WebDriverAgent|\bmaestro\b/i;
+// Our own runner shows the app NAME (not the bundle id) in the ps command line.
+const RN_FAST_RUNNER_RE = /RnFastRunner/i;
+
+export async function detectIosExternalRunner(
+  execFileImpl: typeof execFile = execFile,
+): Promise<IosExternalRunnerWarning | null> {
+  try {
+    const opts = { timeout: 2_000, encoding: 'utf8' as const };
+    const run = execFileImpl === execFile
+      ? promisify(execFileImpl)
+      : (execFileImpl as unknown as (
+          b: string,
+          a: string[],
+          o: typeof opts,
+        ) => Promise<{ stdout: string }>);
+    const { stdout } = await run('ps', ['ax', '-o', 'pid=,command='], opts);
+    const lines = stdout
+      .split('\n')
+      .filter((line) => IOS_FOREIGN_RE.test(line))
+      .filter((line) => !RN_FAST_RUNNER_RE.test(line))
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    if (lines.length === 0) return null;
+
+    return {
+      platform: 'ios',
+      code: 'IOS_XCUITEST_COMPETITOR',
+      message:
+        'A foreign WebDriverAgent/maestro automation session is running on this simulator. ' +
+        'Interleaving device_* with it may trigger a re-foreground of your app; CDP reads are unaffected. ' +
+        '(If this is your own maestro flow, it is expected.)',
+      processLines: lines,
+    };
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Build + run test to verify it passes**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/gh-202-detect-ios-external-runner.test.js`
+Expected: PASS (5/5). (Tests import from `dist/`, so the build must run first.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/cdp-bridge/src/runners/external-runner-detect.ts \
+        scripts/cdp-bridge/dist/runners/external-runner-detect.js \
+        scripts/cdp-bridge/test/unit/gh-202-detect-ios-external-runner.test.js
+git commit -S -m "feat(#202): detectIosExternalRunner — iOS foreign maestro/WDA detection (Phase 3)"
+```
+
+---
+
+### Task 2: `foreignRunnerNotice()` — gate + result-meta builder
+
+This pure helper holds the arbiter-flow-lease gate and the meta shape, so the gating logic is unit-tested independently of `device-session.ts`'s hard module imports.
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/runners/external-runner-detect.ts` (append)
+- Test: `scripts/cdp-bridge/test/unit/gh-202-foreign-runner-notice.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// scripts/cdp-bridge/test/unit/gh-202-foreign-runner-notice.test.js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { foreignRunnerNotice } from '../../dist/runners/external-runner-detect.js';
+
+const detection = {
+  platform: 'ios',
+  code: 'IOS_XCUITEST_COMPETITOR',
+  message: 'A foreign WebDriverAgent/maestro automation session is running on this simulator.',
+  processLines: ['601 /opt/homebrew/bin/maestro test flow.yaml'],
+};
+
+test('foreignRunnerNotice: builds notice when foreign present and no flow lease', () => {
+  const n = foreignRunnerNotice(detection, false);
+  assert.ok(n);
+  assert.equal(n.meta.foreignRunner.code, 'IOS_XCUITEST_COMPETITOR');
+  assert.deepEqual(n.meta.foreignRunner.processLines, ['601 /opt/homebrew/bin/maestro test flow.yaml']);
+  assert.match(n.warning, /^FOREIGN_RUNNER_ACTIVE:/);
+});
+
+test('foreignRunnerNotice: null when WE hold the flow lease (the WDA is ours)', () => {
+  assert.equal(foreignRunnerNotice(detection, true), null);
+});
+
+test('foreignRunnerNotice: null when no foreign process detected', () => {
+  assert.equal(foreignRunnerNotice(null, false), null);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/cdp-bridge && node --test test/unit/gh-202-foreign-runner-notice.test.js`
+Expected: FAIL — `foreignRunnerNotice` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `scripts/cdp-bridge/src/runners/external-runner-detect.ts`:
+
+```ts
+export interface ForeignRunnerNotice {
+  meta: { foreignRunner: { code: string; message: string; processLines: string[] } };
+  warning: string;
+}
+
+/**
+ * GH#202 Phase 3: decide whether to surface a proactive foreign-runner heads-up
+ * on an iOS device-session open. Returns null when there's nothing to say:
+ *   - we currently hold the arbiter flow lease (the WebDriverAgent is our OWN
+ *     L3 maestro-runner, not a foreign session), OR
+ *   - no foreign process was detected.
+ * Informational only — the caller never blocks the open on this.
+ */
+export function foreignRunnerNotice(
+  detection: IosExternalRunnerWarning | null,
+  flowLeaseHeld: boolean,
+): ForeignRunnerNotice | null {
+  if (flowLeaseHeld) return null;
+  if (!detection) return null;
+  return {
+    meta: {
+      foreignRunner: {
+        code: detection.code,
+        message: detection.message,
+        processLines: detection.processLines,
+      },
+    },
+    warning: `FOREIGN_RUNNER_ACTIVE: ${detection.message}`,
+  };
+}
+```
+
+- [ ] **Step 4: Build + run test to verify it passes**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/gh-202-foreign-runner-notice.test.js`
+Expected: PASS (3/3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/cdp-bridge/src/runners/external-runner-detect.ts \
+        scripts/cdp-bridge/dist/runners/external-runner-detect.js \
+        scripts/cdp-bridge/test/unit/gh-202-foreign-runner-notice.test.js
+git commit -S -m "feat(#202): foreignRunnerNotice — flow-lease-gated heads-up builder (Phase 3)"
+```
+
+---
+
+### Task 3: Wire the proactive warning into the iOS `action=open` success path
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/tools/device-session.ts` (imports + the `action=open` success tail, ~lines 14, 28, 299–311)
+
+- [ ] **Step 1: Extend the imports**
+
+Change line 14 from:
+
+```ts
+import { detectAndroidExternalRunner } from '../runners/external-runner-detect.js';
+```
+
+to:
+
+```ts
+import { detectAndroidExternalRunner, detectIosExternalRunner, foreignRunnerNotice } from '../runners/external-runner-detect.js';
+```
+
+And add an arbiter import directly after the existing `device-lock` import (line 28, `import type { DeviceLockResult, DeviceLockBody } from '../lifecycle/device-lock.js';`):
+
+```ts
+import { arbiter } from '../lifecycle/device-arbiter.js';
+```
+
+- [ ] **Step 2: Replace the open-success tail**
+
+Find this exact block (the iOS `ensureFastRunner` + `autoDetected` return + the `return result;`):
+
+```ts
+        if (args.platform === 'ios' && deviceId) {
+          ensureFastRunner(deviceId, appId).catch(() => { /* non-fatal */ });
+        }
+
+        if (autoDetected) {
+          return warnResult(
+            JSON.parse(result.content[0].text).data,
+            `appId auto-detected from app.json: ${appId}`,
+          );
+        }
+      }
+
+      return result;
+```
+
+Replace it with:
+
+```ts
+        if (args.platform === 'ios' && deviceId) {
+          ensureFastRunner(deviceId, appId).catch(() => { /* non-fatal */ });
+        }
+
+        // GH#202 Phase 3: proactive foreign-runner heads-up. Gate on the arbiter
+        // flow lease — when WE hold it, a detected WebDriverAgent is our own L3
+        // maestro-runner, not a foreign session (skip the ps-scan entirely).
+        // Informational only and best-effort (the detector never throws), so it
+        // can neither delay nor fail the open.
+        let foreign = null;
+        if (platform === 'ios') {
+          const flowHeld = arbiter.snapshot.flowLeaseHeldBy !== null;
+          const detection = flowHeld ? null : await detectIosExternalRunner();
+          foreign = foreignRunnerNotice(detection, flowHeld);
+          if (foreign) {
+            logger.warn('rn-device', foreign.warning);
+            for (const line of foreign.meta.foreignRunner.processLines) {
+              logger.warn('rn-device', `  ${line}`);
+            }
+          }
+        }
+
+        if (autoDetected || foreign) {
+          const data = JSON.parse(result.content[0].text).data;
+          const warning = [
+            autoDetected ? `appId auto-detected from app.json: ${appId}` : null,
+            foreign ? foreign.warning : null,
+          ].filter(Boolean).join('; ');
+          return warnResult(data, warning, foreign ? foreign.meta : undefined);
+        }
+      }
+
+      return result;
+```
+
+- [ ] **Step 3: Build to verify types**
+
+Run: `cd scripts/cdp-bridge && npm run build`
+Expected: `tsc` exits 0, no errors. (`platform` is already in scope — declared at line 178 as `(args.platform ?? 'ios').toLowerCase()`.)
+
+- [ ] **Step 4: Run the detector + notice tests to confirm no regression**
+
+Run: `cd scripts/cdp-bridge && node --test test/unit/gh-202-detect-ios-external-runner.test.js test/unit/gh-202-foreign-runner-notice.test.js`
+Expected: PASS (8/8).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/cdp-bridge/src/tools/device-session.ts \
+        scripts/cdp-bridge/dist/tools/device-session.js
+git commit -S -m "feat(#202): surface FOREIGN_RUNNER_ACTIVE on iOS device-session open (Phase 3)"
+```
+
+---
+
+### Task 4: Documentation — formalize the three-layer contract + handoff page
+
+**Files:**
+- Modify: `CLAUDE.md` (add a contract subsection in the Architecture section)
+- Modify: `docs-site/src/content/docs/architecture.mdx` (same contract table)
+- Create: `docs-site/src/content/docs/guides/maestro-interop.mdx`
+- Test: `scripts/cdp-bridge/test/unit/gh-202-contract-doc-presence.test.js`
+
+- [ ] **Step 1: Write the failing doc-presence test**
+
+```js
+// scripts/cdp-bridge/test/unit/gh-202-contract-doc-presence.test.js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+
+test('CLAUDE.md documents the three-layer device-control contract', () => {
+  const md = readFileSync(join(repoRoot, 'CLAUDE.md'), 'utf8');
+  assert.match(md, /Three-layer device-control contract/i);
+  assert.match(md, /L1 INTROSPECTION/);
+  assert.match(md, /L2 INTERACTION/);
+  assert.match(md, /L3 FLOW-REPLAY/);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/cdp-bridge && node --test test/unit/gh-202-contract-doc-presence.test.js`
+Expected: FAIL — the heading does not exist in `CLAUDE.md` yet.
+
+- [ ] **Step 3: Add the contract subsection to `CLAUDE.md`**
+
+In `CLAUDE.md`, in the `## Architecture (for contributors)` section, immediately **before** the `### MCP Server (cdp-bridge)` heading, insert:
+
+```markdown
+### Three-layer device-control contract
+
+One mechanism per capability tier. The device-session honors this contract (the L2 coexistence behavior shipped in #188; #202 Phase 3 wrote it down + added a proactive warning).
+
+| Layer | Mechanism | Role | Exclusivity | Toward a foreign runner |
+|---|---|---|---|---|
+| **L1 INTROSPECTION** | CDP / Hermes | read store / network / component-tree / mmkv / native | **shared** | always safe — never touches XCUITest |
+| **L2 INTERACTION** | iOS `RnFastRunner` / Android `agent-device`; `cdp_interact` | primitive taps / types / scrolls | **shared** | re-attach, don't evict (Tier-0 reacquire + CDP re-pin, #188) |
+| **L3 FLOW-REPLAY** | `maestro-runner` (Go + WDA) | whole-`.yaml` E2E flows | **exclusive** | owns the device for the flow's duration |
+
+**Coexistence rule:** L1 reads never conflict with a foreign runner; L2 re-attaches rather than evicts; L3 owns the device. On `device_snapshot action=open`, if a foreign maestro/WDA session is detected AND no local flow lease is held, the open result carries an informational `meta.foreignRunner` + `FOREIGN_RUNNER_ACTIVE` warning (see `runners/external-runner-detect.ts`). See [docs-site › Using rn-dev-agent with maestro-mcp](docs-site/src/content/docs/guides/maestro-interop.mdx).
+
+```
+
+- [ ] **Step 4: Add the same contract table to `architecture.mdx`**
+
+In `docs-site/src/content/docs/architecture.mdx`, after the existing device-tier table (the row block ending with the `Fallback: ...` line), insert a new section:
+
+```markdown
+## Three-layer device-control contract
+
+One mechanism per capability tier — **L1 + L2 coexist** (drive with XCTest, assert with CDP in the same per-step loop); **L3 is exclusive** (owns the device for the flow).
+
+| Layer | Mechanism | Role | Exclusivity |
+|---|---|---|---|
+| **L1 INTROSPECTION** | CDP / Hermes | read store / network / component-tree / mmkv / native | shared |
+| **L2 INTERACTION** | iOS `RnFastRunner` / Android `agent-device`; `cdp_interact` | primitive taps / types / scrolls | shared |
+| **L3 FLOW-REPLAY** | `maestro-runner` (Go + WDA) | whole-`.yaml` E2E flows | exclusive |
+
+**Foreign runners** (e.g. the standalone `maestro-mcp`): L1 reads are always safe; on an L2 leak the device-session re-attaches rather than evicts (#188); `device_snapshot action=open` surfaces an informational `FOREIGN_RUNNER_ACTIVE` warning when a foreign session is present and no local flow is running.
+```
+
+- [ ] **Step 5: Create the handoff guide**
+
+Create `docs-site/src/content/docs/guides/maestro-interop.mdx`:
+
+```mdx
+---
+title: Using rn-dev-agent with maestro-mcp
+description: How rn-dev-agent coexists with the standalone maestro-mcp server on one iOS simulator.
+---
+
+rn-dev-agent and the standalone **maestro-mcp** server can be used together: maestro *executes* resilient flows, rn-dev-agent *verifies* internal state. They share one iOS simulator, so this page describes how they coexist.
+
+## What is safe to interleave
+
+- **L1 introspection (CDP reads)** — `cdp_navigation_state`, `cdp_store_state`, `cdp_component_tree`, etc. — is **always safe**. It reads Hermes over CDP and never touches the XCUITest automation channel maestro uses.
+- **L2 interaction** (`device_*`) shares the XCUITest channel with maestro's WebDriverAgent. After a maestro run, the next `device_*` may find the channel evicted.
+
+## What happens on handback (already automatic)
+
+When an L2 call sees the runner-leak sentinel after a maestro run, the device-session performs a **state-preserving reacquire** — it re-foregrounds your app (no relaunch) and marks CDP stale so the next read transparently reconnects. You do **not** need a manual `cdp_status` re-pin (shipped in #188).
+
+## The `FOREIGN_RUNNER_ACTIVE` warning
+
+When you `device_snapshot action=open` while a foreign maestro/WebDriverAgent session is running (and rn-dev-agent is not itself running a flow), the open result carries an informational `meta.foreignRunner` and a `FOREIGN_RUNNER_ACTIVE` warning. It is a **heads-up only** — it does not block or change the open. It tells you the simulator is contended so you can expect a re-foreground if you interleave `device_*`.
+
+## L3 flows own the device
+
+A `maestro_run` / `maestro_test_all` flow (rn-dev-agent's own L3) takes the device exclusively for its duration — `device_*` and CDP reads issued mid-flow refuse fast with `BUSY_FLOW_ACTIVE`.
+```
+
+- [ ] **Step 6: Run the doc-presence test to verify it passes**
+
+Run: `cd scripts/cdp-bridge && node --test test/unit/gh-202-contract-doc-presence.test.js`
+Expected: PASS (1/1).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add CLAUDE.md \
+        docs-site/src/content/docs/architecture.mdx \
+        docs-site/src/content/docs/guides/maestro-interop.mdx \
+        scripts/cdp-bridge/test/unit/gh-202-contract-doc-presence.test.js
+git commit -S -m "docs(#202): formalize the three-layer device-control contract + maestro-mcp handoff (Phase 3)"
+```
+
+---
+
+### Task 5: Changeset + full suite + dist freshness
+
+**Files:**
+- Create: `.changeset/device-foreign-runner-202-phase3.md`
+
+- [ ] **Step 1: Write the changeset**
+
+```markdown
+---
+"rn-dev-agent-plugin": patch
+---
+
+#202 Phase 3: formalize the three-layer device-control contract (L1 introspection / L2 interaction / L3 flow) in the docs, and add a proactive, informational `FOREIGN_RUNNER_ACTIVE` warning. When `device_snapshot action=open` finds a foreign maestro/WebDriverAgent automation session on the simulator and rn-dev-agent is not itself running a flow, the open result now carries `meta.foreignRunner` + a heads-up that interleaving `device_*` may trigger a re-foreground (CDP reads are unaffected). The reactive recovery for an actual leak shipped earlier in #188; this is the complementary proactive signal.
+```
+
+- [ ] **Step 2: Rebuild dist and confirm no drift**
+
+Run: `cd scripts/cdp-bridge && npm run build && git status --porcelain scripts/cdp-bridge/dist`
+Expected: only the already-committed dist files; no unexpected drift. If anything is unstaged, `git add` it.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `cd scripts/cdp-bridge && npm test 2>&1 | grep -E '^ℹ (tests|pass|fail)'`
+Expected: `fail 0`, and the count is up by the 9 new tests (5 + 3 + 1).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .changeset/device-foreign-runner-202-phase3.md
+git commit -S -m "chore(#202): changeset for Phase 3 foreign-runner contract + warning"
+```
+
+---
+
+## Self-review checklist (run before handing off to execution)
+
+- **Spec coverage:** §2 contract → Task 4 (CLAUDE.md + architecture.mdx + handoff page). §3 docs → Task 4. §4 `detectIosExternalRunner` → Task 1. §5 proactive warning + gate → Tasks 2 + 3. §8 tests → Tasks 1/2/4. §0 reconciliation (no recovery rebuild) → respected (no edits to `runner-leak-recovery.ts` / the recovery path).
+- **Type consistency:** `IosExternalRunnerWarning` (Task 1) is consumed by `foreignRunnerNotice` (Task 2) and the device-session wiring (Task 3). `ForeignRunnerNotice.meta` is passed straight to `warnResult(data, warning, meta)`.
+- **No placeholders:** every code step shows complete code.
+- **Gate correctness:** the flow-lease gate is checked once (Task 3 computes `flowHeld` and skips the ps-scan when held); `foreignRunnerNotice` re-applies it as the single source of truth for the meta decision (and is unit-tested in isolation).

--- a/docs/superpowers/specs/2026-06-04-device-control-phase3-design.md
+++ b/docs/superpowers/specs/2026-06-04-device-control-phase3-design.md
@@ -22,7 +22,9 @@ The brainstorm's "approach B" (detect → don't-evict → auto-settle) was scope
 
 **What Phase 3 actually adds:**
 - **(A)** Formalize the §2 three-layer contract in `CLAUDE.md` + `docs-site`, and document the #188 handoff behavior. *(genuinely missing)*
-- **(B)** A **proactive** `detectIosExternalRunner()` + a non-blocking `FOREIGN_RUNNER_ACTIVE` warning surfaced on `device_snapshot action=open` — a heads-up that a foreign maestro/WDA session is present *before* a leak, complementing #188's *reactive* recovery. *(genuinely missing)*
+- **(B)** A **proactive** `detectIosExternalRunner()` + a non-blocking `FOREIGN_RUNNER_ACTIVE` warning surfaced on `device_snapshot action=open` — a heads-up that a foreign maestro session is present *before* a leak, complementing #188's *reactive* recovery. *(genuinely missing)*
+
+> **Plan reviewed** (Gemini + Codex + Claude, 2026-06-04) and the detector **live-validated** against real `ps` (§4). Corrections applied: UDID-scope the scan (the idle maestro-mcp server has no UDID → would false-positive); match `maestro-driver-iosUITests-Runner` (maestro's actual iOS driver, **not** WebDriverAgent); add opt-out `RN_IOS_FOREIGN_WARN=0` + `meta.timings_ms`; document the teardown race (arbiter suppression deferred).
 
 ## 1. Problem
 
@@ -52,11 +54,12 @@ This contract is currently implicit (scattered across `CLAUDE.md` prose + code).
 
 ## 4. Part B1 — iOS foreign-runner detection
 
-New `detectIosExternalRunner()` in the existing `scripts/cdp-bridge/src/runners/external-runner-detect.ts` (mirrors `detectAndroidExternalRunner`):
+New `detectIosExternalRunner()` in `scripts/cdp-bridge/src/runners/external-runner-detect.ts` (mirrors `detectAndroidExternalRunner`):
 
 ```
 detectIosExternalRunner(
   execFileImpl = execFile,
+  udid?: string,
 ): Promise<IosExternalRunnerWarning | null>
 
 interface IosExternalRunnerWarning {
@@ -67,20 +70,28 @@ interface IosExternalRunnerWarning {
 }
 ```
 
-- `ps`-scan (`ps ax -o pid=,command=`) for foreign maestro/WebDriverAgent automation processes, **excluding our own `RnFastRunner`** host + UITests-runner processes (matched by the `RnFastRunner` app name — the iOS process command shows the app name, not the bundle id; validate against a live `ps` before shipping).
-- Match set (documented, narrow to avoid self-match): `WebDriverAgent` / `WebDriverAgentRunner` (maestro's iOS driver) and the `maestro` CLI. `XCTRunner` is intentionally **left out** — too generic; it would catch our own runner. (`maestro`/WDA can also be rn-dev-agent's *own* L3 driver; §5's gate disambiguates via the arbiter flow lease.)
-- Returns `null` on no match or on any error (error-safe, like the Android detector). Injectable `execFile` → fully `node --test`-mockable.
+**Live-`ps` validation (Task 0, run 2026-06-04 against a booted iPhone 17 Pro while a real maestro flow drove it):**
+- maestro's iOS driver is **`maestro-driver-iosUITests-Runner`** (NOT WebDriverAgent), and its process path **carries the target UDID** (`…/Devices/<UDID>/…/maestro-driver-iosUITests-Runner.app/…`); the companion `xcodebuild … -destination id=<UDID> … maestro-driver-ios-config.xctestrun` carries it too.
+- the **idle maestro-mcp server** (`java … maestro.cli.AppKt mcp`) has **NO UDID** — so an unscoped matcher false-positives whenever maestro-mcp is merely running.
+
+**Therefore:**
+- `ps ax -o pid=,command=` → keep lines matching `/maestro|WebDriverAgent/i` → **UDID-scope** (`udid ? line.includes(udid) : keep`) → drop lines matching `/RnFastRunner/i` (ours). The UDID filter is what excludes the idle mcp server + other-sim flows; it is **essential**, not optional.
+- `maestro` is the primary token (catches `maestro-driver-iosUITests-Runner`, the `.xctestrun`, and the java CLI); `WebDriverAgent` is kept as a harmless secondary for Appium/WDA-style foreign tools. `XCTRunner` is intentionally left out (too generic).
+- Returns `null` on no match or any error (error-safe). Injectable `execFile` → `node --test`-mockable.
 
 ## 5. Part B2 — proactive `FOREIGN_RUNNER_ACTIVE` warning
 
-The *reactive* recovery already exists (#188, §0). Phase 3 adds only a **proactive, non-blocking heads-up**: after a successful iOS `device_snapshot action=open`, detect a foreign session and warn — so the user knows the device is contended *before* hitting a leak.
+The *reactive* recovery already exists (#188, §0). Phase 3 adds only a **proactive, non-blocking heads-up**: after a successful iOS `device_snapshot action=open`, detect a foreign session and warn — so the agent knows the device is contended *before* hitting a leak.
 
 **Wiring** (`device-session.ts`, the iOS `action=open` success path):
-1. Best-effort, timeout-bounded `detectIosExternalRunner()` (never throws; failure → no warning).
-2. **Gate — foreign vs. ours:** treat a hit as foreign only when `arbiter.snapshot.flowLeaseHeldBy === null`. rn-dev-agent's own L3 `maestro-runner` also spawns WDA; if we hold the flow lease the WDA is ours (and an L2 call would already be refused `BUSY_FLOW_ACTIVE` upstream).
-3. On a gated hit, attach to the open result: `meta.foreignRunner = { code: 'IOS_XCUITEST_COMPETITOR', message, processLines }` + a human-readable warning string.
+1. Opt-out: skip entirely when `RN_IOS_FOREIGN_WARN === '0'` (mirrors the file's `RN_DEVICE_KILL_LEGACY` / `RN_ANDROID_RUNNER` convention).
+2. Flow-lease gate: skip the scan when `arbiter.snapshot.flowLeaseHeldBy !== null` — an internal `action=open` reached during our own flow would otherwise scan needlessly (external calls are already refused `BUSY_FLOW_ACTIVE` by `arbiterWrap`, so this only arises for composite/internal callers).
+3. Best-effort `detectIosExternalRunner(execFile, deviceId)` (UDID-scoped; never throws; failure → no warning). Fold its latency into the open's `meta.timings_ms`.
+4. On a hit, attach to the open result: `meta.foreignRunner = { code, message, processLines }` + a `FOREIGN_RUNNER_ACTIVE` warning string (joined with any existing `autoDetected` warning).
 
-**Strictly informational.** It does **not** refuse, evict, or change the open behavior — #188's reacquire tier already handles an actual leak if one occurs. This keeps Phase 3 additive and the arbiter untouched (no cross-process lease coupling).
+**Teardown race (documented, not suppressed in Phase 3):** our *own* L3 `maestro_run` spawns the *same* `maestro-driver-iosUITests-Runner` on the same UDID, so the detector cannot tell our maestro from a foreign one by name. The arbiter lease distinguishes the *in-flight* case (step 2); a brief window remains where our just-finished driver is still dying after the lease released. Because `action=open` is a session-lifecycle event (not a post-flow hot path), this window is rarely hit, and the message self-hedges ("if this is your own maestro flow, it is expected"). A `lastFlowReleasedAtMs` suppression window in the arbiter is a **deferred follow-up** if it proves noisy.
+
+**Strictly informational.** It does **not** refuse, evict, or change the open behavior — #188's reacquire tier already handles an actual leak if one occurs.
 
 ## 6. Data flow
 
@@ -133,9 +144,10 @@ All `node --test`, no live simulator:
 
 | Risk | Mitigation |
 |---|---|
-| Detection signature drift (maestro/WDA process names vary by version) | Validate the matcher against a live `ps aux` before shipping; keep the match set broad + documented; note the Maestro Viewer `:9999` probe as a future augmentation |
-| Over-detection (flagging our own runner) | Exclude `dev.lykhoyda.rndevagent.fastrunner`; gate on `flowLeaseHeldBy === null`; unit tests assert both |
-| Warning noise on every open | Warning is informational + only on a gated hit; detector is best-effort + timeout-bounded so it never delays or fails an open |
+| Detection signature drift (maestro driver name varies by version) | **Validated** against a live `ps` (§4): current driver is `maestro-driver-iosUITests-Runner`. Matcher kept broad (`/maestro|WebDriverAgent/i`); re-validate if maestro renames its runner |
+| Over-detection (idle maestro-mcp server, other-sim flow, our own runner) | **UDID-scope** (primary defense — the idle mcp server carries no UDID); exclude `/RnFastRunner/i`; flow-lease gate; unit tests assert each |
+| Teardown false-positive (our own just-finished maestro) | Documented (§5); message self-hedges; `action=open` is not a post-flow hot path; arbiter suppression-window deferred |
+| Per-open latency (UDID-scoped `ps` scan, 2 s bounded) | Runs only on `action=open` (not per command), skipped when a flow lease is held, opt-out `RN_IOS_FOREIGN_WARN=0`, latency surfaced in `meta.timings_ms` |
 
 ## 11. Conventions
 

--- a/docs/superpowers/specs/2026-06-04-device-control-phase3-design.md
+++ b/docs/superpowers/specs/2026-06-04-device-control-phase3-design.md
@@ -1,0 +1,144 @@
+# Design — Phase 3: formalize the 3-layer contract + foreign-runner coexistence (#202 / #186)
+
+- **Issue:** #202 Phase 3 (final phase) · **Field report:** #186 (rn-dev-agent + maestro-mcp interop)
+- **Builds on:** Phase 1 (`ensureSingleRunner`), Phase 1.5 (`DeviceLock`), Phase 2a (`DeviceSessionArbiter`), Phase 2b (`recoverWedge`) — all merged to `main` via #218.
+- **Platform:** iOS (the contention #186 reports is iOS-only; Android already warns via `detectAndroidExternalRunner`).
+- **Approach:** Formalize the §2 contract in docs + add a **proactive** foreign-runner detection warning. The *reactive* recovery (don't-evict + CDP re-pin) already shipped in **#188** — see §0.
+
+---
+
+## 0. Status reconciliation — what already shipped (#188)
+
+The brainstorm's "approach B" (detect → don't-evict → auto-settle) was scoped before auditing `main`. **PR #188 (`fix(#186): maestro-interop`) already shipped the reactive functional fix**, so Phase 3 does **not** rebuild it:
+
+| #186 item | Status | Where in `main` |
+|---|---|---|
+| 7 — driver eviction (the ~91 s cascade) | ✅ shipped (#188) | `runner-leak-recovery.ts` **Tier-0 `reacquire`** + `device-session.ts:reacquireIosTargetApp` (state-preserving re-foreground, no relaunch) |
+| 2 — silent CDP desync | ✅ shipped (#188) | `markCdpStale()` in the device-session recovery path |
+| 1 — `runFlow` allowlist | ✅ shipped (#188) | — |
+| 3 — route-structure drift | ✅ shipped (#188) | — |
+
+#188's brainstorm explicitly **rejected** an "is-it-foreign?" heuristic for the *recovery* path: field telemetry labels the maestro-eviction case with the same `agent-device-runner-leak` sentinel as the daemon-leak, so a cause-agnostic cheap reacquire tier was chosen. Phase 3 therefore does **not** make the recovery foreign-aware.
+
+**What Phase 3 actually adds:**
+- **(A)** Formalize the §2 three-layer contract in `CLAUDE.md` + `docs-site`, and document the #188 handoff behavior. *(genuinely missing)*
+- **(B)** A **proactive** `detectIosExternalRunner()` + a non-blocking `FOREIGN_RUNNER_ACTIVE` warning surfaced on `device_snapshot action=open` — a heads-up that a foreign maestro/WDA session is present *before* a leak, complementing #188's *reactive* recovery. *(genuinely missing)*
+
+## 1. Problem
+
+Phase 2a's `DeviceSessionArbiter` ended *internal* device-plane contention: the plugin's own L1/L2/L3 tools share one process and one in-memory lease, so the arbiter can serialize them. But #186 is about a **foreign** runner — the standalone **`maestro-mcp`** server (`mcp__maestro__*`), a *separate process* that never calls `tryAcquire` and is therefore structurally invisible to the arbiter.
+
+Observed (#186, item 7): maestro-mcp and rn-dev-agent both drive the same iOS simulator's **XCUITest** automation channel (maestro via WDA, rn-dev-agent via `RnFastRunner`). iOS grants one foreground automation session, so they evict each other. After a sequence of `mcp__maestro__run` calls, the next rn-dev-agent `device_snapshot` triggered a `RUNNER_LEAK → full-relaunch` (~44 s), and the subsequent `cdp_navigation_state` failed `STALE_TARGET` (~47 s) until a manual `cdp_status` re-pinned the CDP target (#186 item 2 — the silent CDP desync).
+
+Key narrowing: rn-dev-agent's *verification* is mostly **L1 (CDP reads)** — `cdp_navigation_state`, `cdp_store_state` — which **do not touch XCUITest**. The interleave #186 wants (maestro executes, rn-dev-agent verifies) only contends when verification reaches **L2 `device_*`**. So the fix is "**re-attach instead of evict** on L2, and auto-re-pin CDP," not "block the interleave." **That reactive fix already shipped in #188 (§0); Phase 3 adds the *proactive* warning + the written contract.**
+
+## 2. North-star: the three-layer contract (written down)
+
+| Layer | Mechanism | Role | Exclusivity | Behavior toward a **foreign** runner |
+|---|---|---|---|---|
+| **L1 INTROSPECTION** | CDP / Hermes (the bridge) | read store / network / component-tree / mmkv / native | **shared** | **always safe** — never touches XCUITest; keeps working during/after a foreign session |
+| **L2 INTERACTION** | iOS `RnFastRunner` / Android `agent-device`; `cdp_interact` (fiber path) | primitive taps / types / scrolls | **shared** | **re-attach, do not evict** — prefer `attach-only` over `full-relaunch` when a foreign session is present |
+| **L3 FLOW-REPLAY** | `maestro-runner` (Go + WDA) | whole-`.yaml` E2E flows only | **exclusive** | owns the device for the flow's duration |
+
+**Coexistence rule:** *L1 reads never conflict with a foreign runner; L2 re-attaches rather than evicts; L3 owns the device.* The device-session **already honors** this rule (via #188's reacquire tier + CDP re-pin); Phase 3 writes it down and adds a proactive heads-up when the contention is present.
+
+This contract is currently implicit (scattered across `CLAUDE.md` prose + code). Phase 3 makes it explicit in `CLAUDE.md` and `docs-site`, and adds a **"Using rn-dev-agent alongside maestro-mcp"** handoff page.
+
+## 3. Part A — documentation
+
+- **`CLAUDE.md`** — a "Three-layer device-control contract" subsection: the table above + the coexistence rule. Cross-reference the existing Architecture section.
+- **`docs-site/src/content/docs/architecture.mdx`** — same contract table + coexistence rule.
+- **`docs-site`** — a new short page **"Using rn-dev-agent with maestro-mcp"**: what is safe to interleave (L1 reads always; L2 self-recovers), what the **#188 reacquire + CDP re-pin** does on handback, that the new `FOREIGN_RUNNER_ACTIVE` warning is informational, and that L3 maestro flows own the device. This is the "documented handoff pattern" #186 asked for.
+
+## 4. Part B1 — iOS foreign-runner detection
+
+New `detectIosExternalRunner()` in the existing `scripts/cdp-bridge/src/runners/external-runner-detect.ts` (mirrors `detectAndroidExternalRunner`):
+
+```
+detectIosExternalRunner(
+  execFileImpl = execFile,
+): Promise<IosExternalRunnerWarning | null>
+
+interface IosExternalRunnerWarning {
+  platform: 'ios';
+  code: 'IOS_XCUITEST_COMPETITOR';
+  message: string;
+  processLines: string[];
+}
+```
+
+- `ps`-scan (`ps ax -o pid=,command=`) for foreign maestro/WebDriverAgent automation processes, **excluding our own `RnFastRunner`** host + UITests-runner processes (matched by the `RnFastRunner` app name — the iOS process command shows the app name, not the bundle id; validate against a live `ps` before shipping).
+- Match set (documented, narrow to avoid self-match): `WebDriverAgent` / `WebDriverAgentRunner` (maestro's iOS driver) and the `maestro` CLI. `XCTRunner` is intentionally **left out** — too generic; it would catch our own runner. (`maestro`/WDA can also be rn-dev-agent's *own* L3 driver; §5's gate disambiguates via the arbiter flow lease.)
+- Returns `null` on no match or on any error (error-safe, like the Android detector). Injectable `execFile` → fully `node --test`-mockable.
+
+## 5. Part B2 — proactive `FOREIGN_RUNNER_ACTIVE` warning
+
+The *reactive* recovery already exists (#188, §0). Phase 3 adds only a **proactive, non-blocking heads-up**: after a successful iOS `device_snapshot action=open`, detect a foreign session and warn — so the user knows the device is contended *before* hitting a leak.
+
+**Wiring** (`device-session.ts`, the iOS `action=open` success path):
+1. Best-effort, timeout-bounded `detectIosExternalRunner()` (never throws; failure → no warning).
+2. **Gate — foreign vs. ours:** treat a hit as foreign only when `arbiter.snapshot.flowLeaseHeldBy === null`. rn-dev-agent's own L3 `maestro-runner` also spawns WDA; if we hold the flow lease the WDA is ours (and an L2 call would already be refused `BUSY_FLOW_ACTIVE` upstream).
+3. On a gated hit, attach to the open result: `meta.foreignRunner = { code: 'IOS_XCUITEST_COMPETITOR', message, processLines }` + a human-readable warning string.
+
+**Strictly informational.** It does **not** refuse, evict, or change the open behavior — #188's reacquire tier already handles an actual leak if one occurs. This keeps Phase 3 additive and the arbiter untouched (no cross-process lease coupling).
+
+## 6. Data flow
+
+**Already in `main` (#188) — reactive recovery on a real leak:**
+```
+mcp__maestro__run (external, L3/WDA)          # maestro owns XCUITest
+        │
+        ▼
+device_snapshot (rn-dev-agent, L2)            # sees the AgentDeviceRunner sentinel
+        │
+        ▼
+Tier-0 reacquire (re-foreground target, no relaunch) → markCdpStale   # #188
+        │
+        ▼
+snapshot returns; the next CDP read reconnects transparently
+```
+
+**Added by Phase 3 — proactive warning on open (no leak required):**
+```
+device_snapshot action=open (iOS, success)
+        │
+        ├── arbiter.flowLeaseHeldBy === null ?  ──no──▶ (WDA is ours; no warning)
+        │                yes
+        ▼
+detectIosExternalRunner() fires → meta.foreignRunner + FOREIGN_RUNNER_ACTIVE warning   # informational only
+```
+Throughout, **L1 CDP reads keep working** — they never touched XCUITest.
+
+## 7. Out of scope (YAGNI)
+
+- **Done in #188 (§0), Phase 3 does not touch:** item 1 (runFlow allowlist), item 2 (CDP re-pin), item 3 (route-drift), item 7 (reacquire / eviction).
+- **Deferred to follow-up issues:** item 4 (shared device handle across the two MCPs), item 5 (unified telemetry — maestro-mcp calls in rn-dev-agent's timeline), item 6 (warm maestro session — avoid per-call driver startup).
+- **No** change to the recovery path, the arbiter, or Android behavior. The new detection is **informational only**.
+
+## 8. Testing strategy
+
+All `node --test`, no live simulator:
+- `detectIosExternalRunner`: matches a foreign WDA/maestro line; **excludes our fastrunner**; `null` on none; error-safe on `ps` failure.
+- proactive-warning wiring (pure helper, injected deps): on a detector hit **with no flow lease**, the open result carries `meta.foreignRunner` + a `FOREIGN_RUNNER_ACTIVE` warning; on a hit **while a flow lease is held**, **no warning** (the WDA is ours); detector error → no warning, open unaffected.
+- a light **doc-presence assertion** that the "Three-layer device-control contract" subsection exists in `CLAUDE.md` (guards doc drift).
+
+## 9. Failure-mode matrix
+
+| Failure (#186) | Status | Detection | Handling |
+|---|---|---|---|
+| Foreign session evicts L2 (the ~91 s cascade) | #188 (existing) | AgentDeviceRunner sentinel | Tier-0 reacquire → `markCdpStale` |
+| Foreign session present, no leak yet | **Phase 3** | `detectIosExternalRunner()` on open, gated on `flowLeaseHeldBy === null` | informational `FOREIGN_RUNNER_ACTIVE` warning (no behavior change) |
+
+## 10. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Detection signature drift (maestro/WDA process names vary by version) | Validate the matcher against a live `ps aux` before shipping; keep the match set broad + documented; note the Maestro Viewer `:9999` probe as a future augmentation |
+| Over-detection (flagging our own runner) | Exclude `dev.lykhoyda.rndevagent.fastrunner`; gate on `flowLeaseHeldBy === null`; unit tests assert both |
+| Warning noise on every open | Warning is informational + only on a gated hit; detector is best-effort + timeout-bounded so it never delays or fails an open |
+
+## 11. Conventions
+
+- Explicit type imports; no unnecessary comments; CDP tree queries always filtered.
+- The `device_snapshot` open result carries `meta.foreignRunner` when a gated detection hit occurs; detection latency folds into the existing open `meta.timings_ms`.
+- `dist/` is tracked — staged rebuilt; one changeset for the increment.

--- a/scripts/cdp-bridge/dist/runners/external-runner-detect.js
+++ b/scripts/cdp-bridge/dist/runners/external-runner-detect.js
@@ -30,3 +30,64 @@ export async function detectAndroidExternalRunner(execFileImpl = execFile, seria
         return null;
     }
 }
+// Validated against live `ps` (2026-06-04): maestro's iOS driver is
+// `maestro-driver-iosUITests-Runner` — the `maestro` token catches it, the
+// `.xctestrun`, and the java CLI. `WebDriverAgent` is a harmless secondary for
+// Appium/WDA-style foreign tools. `XCTRunner` is intentionally NOT matched (too
+// generic). The UDID filter is the real defense: the idle maestro-mcp server
+// (`java … maestro.cli.AppKt mcp`) carries NO UDID, so scoping excludes it.
+const IOS_FOREIGN_RE = /maestro|WebDriverAgent/i;
+const RN_FAST_RUNNER_RE = /RnFastRunner/i;
+export async function detectIosExternalRunner(execFileImpl = execFile, udid) {
+    try {
+        const opts = { timeout: 2_000, encoding: 'utf8' };
+        const run = execFileImpl === execFile
+            ? promisify(execFileImpl)
+            : execFileImpl;
+        const { stdout } = await run('ps', ['ax', '-o', 'pid=,command='], opts);
+        const lines = stdout
+            .split('\n')
+            .filter((line) => IOS_FOREIGN_RE.test(line))
+            .filter((line) => !RN_FAST_RUNNER_RE.test(line))
+            .filter((line) => (udid ? line.includes(udid) : true))
+            .map((line) => line.trim())
+            .filter((line) => line.length > 0);
+        if (lines.length === 0)
+            return null;
+        return {
+            platform: 'ios',
+            code: 'IOS_XCUITEST_COMPETITOR',
+            message: 'A foreign maestro/WebDriverAgent automation session is driving this simulator. ' +
+                'Interleaving device_* with it may trigger a re-foreground of your app; CDP reads are unaffected. ' +
+                '(If this is your own maestro flow, it is expected.)',
+            processLines: lines,
+        };
+    }
+    catch {
+        return null;
+    }
+}
+/**
+ * GH#202 Phase 3: decide whether to surface a proactive foreign-runner heads-up
+ * on an iOS device-session open. Returns null when there's nothing to say:
+ *   - we currently hold the arbiter flow lease (the detected maestro driver is
+ *     then our OWN L3 run, not a foreign session), OR
+ *   - no foreign process was detected.
+ * Informational only — the caller never blocks the open on this.
+ */
+export function foreignRunnerNotice(detection, flowLeaseHeld) {
+    if (flowLeaseHeld)
+        return null;
+    if (!detection)
+        return null;
+    return {
+        meta: {
+            foreignRunner: {
+                code: detection.code,
+                message: detection.message,
+                processLines: detection.processLines,
+            },
+        },
+        warning: `FOREIGN_RUNNER_ACTIVE: ${detection.message}`,
+    };
+}

--- a/scripts/cdp-bridge/dist/tools/device-session.js
+++ b/scripts/cdp-bridge/dist/tools/device-session.js
@@ -3,7 +3,7 @@ import { promisify } from 'node:util';
 import { runAgentDevice, setActiveSession, clearActiveSession, getActiveSession, ensureFastRunner, cacheSnapshot, getAdbSerial, } from '../agent-device-wrapper.js';
 import { stopFastRunner } from '../runners/rn-fast-runner-client.js';
 import { markCdpStale } from '../cdp/recovery.js';
-import { detectAndroidExternalRunner } from '../runners/external-runner-detect.js';
+import { detectAndroidExternalRunner, detectIosExternalRunner, foreignRunnerNotice } from '../runners/external-runner-detect.js';
 import { ensureSingleRunner } from '../runners/ensure-single-runner.js';
 import { resetWedgeRecoveryCounter } from '../cdp/recover-wedge.js';
 import { okResult, failResult, warnResult } from '../utils.js';
@@ -12,6 +12,7 @@ import { isValidBundleId } from '../domain/maestro-validator.js';
 import { logger } from '../logger.js';
 import { isAgentDeviceRunnerSentinel, recoverFromRunnerLeak, } from './runner-leak-recovery.js';
 import { DeviceLock } from '../lifecycle/device-lock.js';
+import { arbiter } from '../lifecycle/device-arbiter.js';
 const execFile = promisify(execFileCb);
 const HEARTBEAT_MS = 30_000;
 let activeDeviceLock = null;
@@ -230,8 +231,39 @@ export function createDeviceSnapshotHandler() {
                 if (args.platform === 'ios' && deviceId) {
                     ensureFastRunner(deviceId, appId).catch(() => { });
                 }
-                if (autoDetected) {
-                    return warnResult(JSON.parse(result.content[0].text).data, `appId auto-detected from app.json: ${appId}`);
+                // GH#202 Phase 3: proactive foreign-runner heads-up (informational only).
+                // Skip when opted out, or when WE hold the flow lease (a detected maestro
+                // driver is then our own L3 run — external opens are already refused
+                // BUSY_FLOW_ACTIVE upstream; this guard covers composite/internal callers).
+                // UDID-scoped + best-effort: the detector never throws (can't fail the
+                // open); its ≤2s latency is surfaced in meta.timings_ms.
+                let foreign = null;
+                let foreignDetectMs;
+                if (platform === 'ios' && process.env.RN_IOS_FOREIGN_WARN !== '0') {
+                    const flowHeld = arbiter.snapshot.flowLeaseHeldBy !== null;
+                    if (!flowHeld) {
+                        const t0 = Date.now();
+                        const detection = await detectIosExternalRunner(undefined, deviceId);
+                        foreignDetectMs = Date.now() - t0;
+                        foreign = foreignRunnerNotice(detection, false);
+                    }
+                    if (foreign) {
+                        logger.warn('rn-device', foreign.warning);
+                        for (const line of foreign.meta.foreignRunner.processLines) {
+                            logger.warn('rn-device', `  ${line}`);
+                        }
+                    }
+                }
+                if (autoDetected || foreign) {
+                    const data = JSON.parse(result.content[0].text).data;
+                    const warning = [
+                        autoDetected ? `appId auto-detected from app.json: ${appId}` : null,
+                        foreign ? foreign.warning : null,
+                    ].filter(Boolean).join('; ');
+                    const meta = { ...(foreign ? foreign.meta : {}) };
+                    if (foreignDetectMs !== undefined)
+                        meta.timings_ms = { foreignDetect: foreignDetectMs };
+                    return warnResult(data, warning, meta);
                 }
             }
             return result;

--- a/scripts/cdp-bridge/src/runners/external-runner-detect.ts
+++ b/scripts/cdp-bridge/src/runners/external-runner-detect.ts
@@ -45,3 +45,88 @@ export async function detectAndroidExternalRunner(
     return null;
   }
 }
+
+export interface IosExternalRunnerWarning {
+  platform: 'ios';
+  code: 'IOS_XCUITEST_COMPETITOR';
+  message: string;
+  processLines: string[];
+}
+
+// Validated against live `ps` (2026-06-04): maestro's iOS driver is
+// `maestro-driver-iosUITests-Runner` — the `maestro` token catches it, the
+// `.xctestrun`, and the java CLI. `WebDriverAgent` is a harmless secondary for
+// Appium/WDA-style foreign tools. `XCTRunner` is intentionally NOT matched (too
+// generic). The UDID filter is the real defense: the idle maestro-mcp server
+// (`java … maestro.cli.AppKt mcp`) carries NO UDID, so scoping excludes it.
+const IOS_FOREIGN_RE = /maestro|WebDriverAgent/i;
+const RN_FAST_RUNNER_RE = /RnFastRunner/i;
+
+export async function detectIosExternalRunner(
+  execFileImpl: typeof execFile = execFile,
+  udid?: string,
+): Promise<IosExternalRunnerWarning | null> {
+  try {
+    const opts = { timeout: 2_000, encoding: 'utf8' as const };
+    const run = execFileImpl === execFile
+      ? promisify(execFileImpl)
+      : (execFileImpl as unknown as (
+          b: string,
+          a: string[],
+          o: typeof opts,
+        ) => Promise<{ stdout: string }>);
+    const { stdout } = await run('ps', ['ax', '-o', 'pid=,command='], opts);
+    const lines = stdout
+      .split('\n')
+      .filter((line) => IOS_FOREIGN_RE.test(line))
+      .filter((line) => !RN_FAST_RUNNER_RE.test(line))
+      .filter((line) => (udid ? line.includes(udid) : true))
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    if (lines.length === 0) return null;
+
+    return {
+      platform: 'ios',
+      code: 'IOS_XCUITEST_COMPETITOR',
+      message:
+        'A foreign maestro/WebDriverAgent automation session is driving this simulator. ' +
+        'Interleaving device_* with it may trigger a re-foreground of your app; CDP reads are unaffected. ' +
+        '(If this is your own maestro flow, it is expected.)',
+      processLines: lines,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export interface ForeignRunnerNotice {
+  meta: { foreignRunner: { code: string; message: string; processLines: string[] } };
+  warning: string;
+}
+
+/**
+ * GH#202 Phase 3: decide whether to surface a proactive foreign-runner heads-up
+ * on an iOS device-session open. Returns null when there's nothing to say:
+ *   - we currently hold the arbiter flow lease (the detected maestro driver is
+ *     then our OWN L3 run, not a foreign session), OR
+ *   - no foreign process was detected.
+ * Informational only — the caller never blocks the open on this.
+ */
+export function foreignRunnerNotice(
+  detection: IosExternalRunnerWarning | null,
+  flowLeaseHeld: boolean,
+): ForeignRunnerNotice | null {
+  if (flowLeaseHeld) return null;
+  if (!detection) return null;
+  return {
+    meta: {
+      foreignRunner: {
+        code: detection.code,
+        message: detection.message,
+        processLines: detection.processLines,
+      },
+    },
+    warning: `FOREIGN_RUNNER_ACTIVE: ${detection.message}`,
+  };
+}

--- a/scripts/cdp-bridge/src/tools/device-session.ts
+++ b/scripts/cdp-bridge/src/tools/device-session.ts
@@ -11,7 +11,7 @@ import {
 } from '../agent-device-wrapper.js';
 import { stopFastRunner } from '../runners/rn-fast-runner-client.js';
 import { markCdpStale } from '../cdp/recovery.js';
-import { detectAndroidExternalRunner } from '../runners/external-runner-detect.js';
+import { detectAndroidExternalRunner, detectIosExternalRunner, foreignRunnerNotice } from '../runners/external-runner-detect.js';
 import { ensureSingleRunner } from '../runners/ensure-single-runner.js';
 import { resetWedgeRecoveryCounter } from '../cdp/recover-wedge.js';
 import type { ToolResult } from '../utils.js';
@@ -26,6 +26,7 @@ import {
 } from './runner-leak-recovery.js';
 import { DeviceLock } from '../lifecycle/device-lock.js';
 import type { DeviceLockResult, DeviceLockBody } from '../lifecycle/device-lock.js';
+import { arbiter } from '../lifecycle/device-arbiter.js';
 
 const execFile = promisify(execFileCb);
 
@@ -300,11 +301,39 @@ export function createDeviceSnapshotHandler(): (args: SnapshotArgs) => Promise<T
           ensureFastRunner(deviceId, appId).catch(() => { /* non-fatal */ });
         }
 
-        if (autoDetected) {
-          return warnResult(
-            JSON.parse(result.content[0].text).data,
-            `appId auto-detected from app.json: ${appId}`,
-          );
+        // GH#202 Phase 3: proactive foreign-runner heads-up (informational only).
+        // Skip when opted out, or when WE hold the flow lease (a detected maestro
+        // driver is then our own L3 run — external opens are already refused
+        // BUSY_FLOW_ACTIVE upstream; this guard covers composite/internal callers).
+        // UDID-scoped + best-effort: the detector never throws (can't fail the
+        // open); its ≤2s latency is surfaced in meta.timings_ms.
+        let foreign: ReturnType<typeof foreignRunnerNotice> = null;
+        let foreignDetectMs: number | undefined;
+        if (platform === 'ios' && process.env.RN_IOS_FOREIGN_WARN !== '0') {
+          const flowHeld = arbiter.snapshot.flowLeaseHeldBy !== null;
+          if (!flowHeld) {
+            const t0 = Date.now();
+            const detection = await detectIosExternalRunner(undefined, deviceId);
+            foreignDetectMs = Date.now() - t0;
+            foreign = foreignRunnerNotice(detection, false);
+          }
+          if (foreign) {
+            logger.warn('rn-device', foreign.warning);
+            for (const line of foreign.meta.foreignRunner.processLines) {
+              logger.warn('rn-device', `  ${line}`);
+            }
+          }
+        }
+
+        if (autoDetected || foreign) {
+          const data = JSON.parse(result.content[0].text).data;
+          const warning = [
+            autoDetected ? `appId auto-detected from app.json: ${appId}` : null,
+            foreign ? foreign.warning : null,
+          ].filter(Boolean).join('; ');
+          const meta: Record<string, unknown> = { ...(foreign ? foreign.meta : {}) };
+          if (foreignDetectMs !== undefined) meta.timings_ms = { foreignDetect: foreignDetectMs };
+          return warnResult(data, warning, meta);
         }
       }
 

--- a/scripts/cdp-bridge/test/unit/gh-202-contract-doc-presence.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-202-contract-doc-presence.test.js
@@ -1,0 +1,15 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+
+test('CLAUDE.md documents the three-layer device-control contract', () => {
+  const md = readFileSync(join(repoRoot, 'CLAUDE.md'), 'utf8');
+  assert.match(md, /Three-layer device-control contract/i);
+  assert.match(md, /L1 INTROSPECTION/);
+  assert.match(md, /L2 INTERACTION/);
+  assert.match(md, /L3 FLOW-REPLAY/);
+});

--- a/scripts/cdp-bridge/test/unit/gh-202-detect-ios-external-runner.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-202-detect-ios-external-runner.test.js
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { detectIosExternalRunner } from '../../dist/runners/external-runner-detect.js';
+
+const fakePs = (stdout) => async () => ({ stdout });
+
+// Real signatures captured from a live `ps ax -o command=` during a maestro flow (Task 0).
+const UDID = 'FC78646A-56D5-4737-9CD0-A360D622F3B3';
+const OTHER_UDID = 'AAAAAAAA-1111-2222-3333-BBBBBBBBBBBB';
+const MAESTRO_DRIVER = `18225 /Users/x/Library/Developer/CoreSimulator/Devices/${UDID}/data/Containers/Bundle/Application/155F/maestro-driver-iosUITests-Runner.app/maestro-driver-iosUITests-Runner`;
+const MAESTRO_XCODEBUILD = `17754 /Applications/Xcode.app/.../xcodebuild test-without-building -xctestrun /tmp/${UDID}/maestro-driver-ios-config.xctestrun -destination id=${UDID}`;
+const MAESTRO_MCP_IDLE = '14013 java -classpath /Users/x/.maestro/lib/* maestro.cli.AppKt mcp'; // NB: carries no UDID
+const OUR_RUNNER = `99 /Users/x/Library/Developer/CoreSimulator/Devices/${UDID}/.../RnFastRunnerUITests-Runner.app/RnFastRunnerUITests-Runner`;
+
+test('detectIosExternalRunner: flags a foreign maestro driver on the target UDID', async () => {
+  const ps = fakePs(`${MAESTRO_DRIVER}\n${MAESTRO_XCODEBUILD}\n800 /usr/bin/login\n`);
+  const w = await detectIosExternalRunner(ps, UDID);
+  assert.ok(w);
+  assert.equal(w.platform, 'ios');
+  assert.equal(w.code, 'IOS_XCUITEST_COMPETITOR');
+  assert.equal(w.processLines.length, 2);
+  assert.match(w.processLines[0], /maestro-driver-iosUITests-Runner/);
+});
+
+test('detectIosExternalRunner: UDID-scopes — a maestro flow on a DIFFERENT sim is ignored', async () => {
+  const ps = fakePs(MAESTRO_DRIVER + '\n');
+  assert.equal(await detectIosExternalRunner(ps, OTHER_UDID), null);
+});
+
+test('detectIosExternalRunner: ignores the idle maestro-mcp server (no UDID)', async () => {
+  const ps = fakePs(`${MAESTRO_MCP_IDLE}\n800 /usr/bin/login\n`);
+  assert.equal(await detectIosExternalRunner(ps, UDID), null);
+});
+
+test('detectIosExternalRunner: excludes our own RnFastRunner even on the target UDID', async () => {
+  const ps = fakePs(OUR_RUNNER + '\n');
+  assert.equal(await detectIosExternalRunner(ps, UDID), null);
+});
+
+test('detectIosExternalRunner: null when no automation process present', async () => {
+  const ps = fakePs('801 /usr/bin/login\n802 /System/Library/Foo\n');
+  assert.equal(await detectIosExternalRunner(ps, UDID), null);
+});
+
+test('detectIosExternalRunner: error-safe when ps fails', async () => {
+  const ps = async () => { throw new Error('ps blew up'); };
+  assert.equal(await detectIosExternalRunner(ps, UDID), null);
+});

--- a/scripts/cdp-bridge/test/unit/gh-202-foreign-runner-notice.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-202-foreign-runner-notice.test.js
@@ -1,0 +1,26 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { foreignRunnerNotice } from '../../dist/runners/external-runner-detect.js';
+
+const detection = {
+  platform: 'ios',
+  code: 'IOS_XCUITEST_COMPETITOR',
+  message: 'A foreign maestro/WebDriverAgent automation session is driving this simulator.',
+  processLines: ['18225 /Devices/FC78.../maestro-driver-iosUITests-Runner'],
+};
+
+test('foreignRunnerNotice: builds notice when foreign present and no flow lease', () => {
+  const n = foreignRunnerNotice(detection, false);
+  assert.ok(n);
+  assert.equal(n.meta.foreignRunner.code, 'IOS_XCUITEST_COMPETITOR');
+  assert.deepEqual(n.meta.foreignRunner.processLines, ['18225 /Devices/FC78.../maestro-driver-iosUITests-Runner']);
+  assert.match(n.warning, /^FOREIGN_RUNNER_ACTIVE:/);
+});
+
+test('foreignRunnerNotice: null when WE hold the flow lease (the driver is ours)', () => {
+  assert.equal(foreignRunnerNotice(detection, true), null);
+});
+
+test('foreignRunnerNotice: null when no foreign process detected', () => {
+  assert.equal(foreignRunnerNotice(null, false), null);
+});


### PR DESCRIPTION
## Summary
The **final phase of #202**. Two deliverables:
- **Formalizes the three-layer device-control contract** (L1 introspection / L2 interaction / L3 flow-replay + the foreign-runner coexistence rule) in `CLAUDE.md` + `docs-site/architecture.mdx` + a new **"Using rn-dev-agent with maestro-mcp"** handoff page.
- **Adds `detectIosExternalRunner`** (UDID-scoped `ps` scan) + an **informational `FOREIGN_RUNNER_ACTIVE` warning** on `device_snapshot action=open` when a foreign maestro session is driving the simulator and rn-dev-agent is not itself running a flow. Strictly a heads-up — never blocks/changes the open. Opt out with `RN_IOS_FOREIGN_WARN=0`.

Scoped against **#188**, which already shipped the *reactive* #186 fix (runner-leak reacquire + CDP re-pin + runFlow allowlist + route-drift). This is the complementary *proactive* signal plus the written contract — it deliberately touches **none** of the recovery path.

## How it was built (design rigor)
brainstorm → spec → **multi-LLM plan review (Gemini + Codex + Claude)** → **live `ps` validation** → TDD implementation. That pipeline caught two issues before any code:
- the original flow-lease gate guarded an **unreachable** case (the arbiter already refuses `device_*` mid-flow), so the real exposure is the post-flow teardown window;
- the live `ps` run **corrected the matcher** — maestro's iOS driver is `maestro-driver-iosUITests-Runner` (not WebDriverAgent) — and **proved UDID-scoping is mandatory** (the idle maestro-mcp server carries no UDID, so an unscoped scan false-positives).

## Test plan
- [x] `detectIosExternalRunner` unit tests (6): foreign-on-target-UDID, different-sim ignored, idle mcp-server ignored, own-RnFastRunner excluded, none, ps-error.
- [x] `foreignRunnerNotice` unit tests (3): builds notice, flow-lease gate skips, no-detection.
- [x] doc-presence test guards the contract subsection in `CLAUDE.md`.
- [x] Full suite **1696 pass / 0 fail**; `tsc` clean; dist tracked + rebuilt.
- [ ] Live device check (manual): warning surfaces when maestro-mcp drives the booted sim; absent on other sims / idle server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)