### PR TITLE
fix(cdp-bridge): send loopback Origin to RN 0.85 Metro inspector (B177)

### DIFF
--- a/.changeset/rn-085-metro-inspector-origin.md
+++ b/.changeset/rn-085-metro-inspector-origin.md
@@ -1,0 +1,5 @@
+---
+"rn-dev-agent-plugin": patch
+---
+
+Fix CDP-bridge connection failure on React Native 0.85 / Expo SDK 56. RN 0.85's Metro inspector proxy (`@react-native/dev-middleware`) now enforces a WebSocket `Origin` allowlist (loopback hostnames only) as a CSRF defense and returns **HTTP 401** to the bridge's header-less `ws` clients — breaking `cdp_status` and all CDP introspection on the newest RN. A new `metroOrigin()` helper (`scripts/cdp-bridge/src/ws-origin.ts`) synthesizes a loopback `Origin` matching the dev-server port; it is now sent on all three Metro WebSocket clients (`cdp/connect.ts`, `cdp/multiplexer.ts`, `metro/events-client.ts`). Verified end-to-end: the handshake now succeeds against an RN 0.85 / SDK 56 app (proven: no-Origin → 401, loopback Origin → OPEN). (B177 / D1240)

--- a/scripts/cdp-bridge/dist/cdp/connect.js
+++ b/scripts/cdp-bridge/dist/cdp/connect.js
@@ -1,5 +1,6 @@
 import WebSocket from 'ws';
 import { logger } from '../logger.js';
+import { metroOrigin } from '../ws-origin.js';
 import { resolveBundleId } from '../project-config.js';
 import { discover } from './discovery.js';
 import { sleep } from './state.js';
@@ -271,6 +272,7 @@ function connectWs(ctx, url) {
         const ws = new WebSocket(url, {
             handshakeTimeout: 5000,
             maxPayload: 100 * 1024 * 1024,
+            headers: { Origin: metroOrigin(url) },
         });
         let settled = false;
         // Backstop: handshakeTimeout should emit 'error', but if the socket ever

--- a/scripts/cdp-bridge/dist/cdp/multiplexer.js
+++ b/scripts/cdp-bridge/dist/cdp/multiplexer.js
@@ -2,6 +2,7 @@ import { createServer } from 'node:http';
 import { randomBytes, timingSafeEqual } from 'node:crypto';
 import { Buffer } from 'node:buffer';
 import WebSocket, { WebSocketServer } from 'ws';
+import { metroOrigin } from '../ws-origin.js';
 import { logger } from '../logger.js';
 /**
  * Phase 134.4 (deepsec HIGH): generate a per-multiplexer capability
@@ -152,7 +153,9 @@ export class CDPMultiplexer {
     }
     connectHermes() {
         return new Promise((resolve, reject) => {
-            const ws = new WebSocket(this.opts.hermesUrl);
+            const ws = new WebSocket(this.opts.hermesUrl, {
+                headers: { Origin: metroOrigin(this.opts.hermesUrl) },
+            });
             this.hermesWs = ws;
             const onOpen = () => {
                 ws.off('error', onError);

--- a/scripts/cdp-bridge/dist/metro/events-client.js
+++ b/scripts/cdp-bridge/dist/metro/events-client.js
@@ -1,4 +1,5 @@
 import WebSocket from 'ws';
+import { metroOrigin } from '../ws-origin.js';
 import { logger } from '../logger.js';
 import { computeReconnectDelay } from '../cdp/reconnection.js';
 import { RingBuffer } from '../ring-buffer.js';
@@ -209,7 +210,9 @@ export class MetroEventsClient {
         this.state = 'connecting';
         const url = `ws://${this.opts.host}:${this.opts.port}/events`;
         return new Promise((resolve) => {
-            const ws = new WebSocket(url);
+            const ws = new WebSocket(url, {
+                headers: { Origin: metroOrigin(url) },
+            });
             this.ws = ws;
             // Multi-review catch: on ECONNREFUSED / handshake failures, the `ws` library
             // fires BOTH `error` and `close` for the same failure. Without this `outcome`

--- a/scripts/cdp-bridge/dist/ws-origin.js
+++ b/scripts/cdp-bridge/dist/ws-origin.js
@@ -1,0 +1,14 @@
+// RN 0.85+ / @react-native/dev-middleware guards the Metro inspector proxy with
+// an Origin check (WebSocket CSRF defense): handshakes whose Origin hostname is
+// not loopback get a 401. Node's `ws` sends no Origin by default, so synthesize
+// a loopback Origin matching the dev-server port to satisfy the allowlist
+// (localhost / 127.0.0.1 / 0.0.0.0 / [::]).
+export function metroOrigin(wsUrl) {
+    try {
+        const { port } = new URL(wsUrl);
+        return `http://localhost:${port || '8081'}`;
+    }
+    catch {
+        return 'http://localhost:8081';
+    }
+}

--- a/scripts/cdp-bridge/src/cdp/connect.ts
+++ b/scripts/cdp-bridge/src/cdp/connect.ts
@@ -1,5 +1,6 @@
 import WebSocket from 'ws';
 import { logger } from '../logger.js';
+import { metroOrigin } from '../ws-origin.js';
 import { resolveBundleId } from '../project-config.js';
 import { discover } from './discovery.js';
 import type { SelectTargetFilters } from './discovery.js';
@@ -349,6 +350,7 @@ function connectWs(ctx: ConnectContext, url: string): Promise<void> {
     const ws = new WebSocket(url, {
       handshakeTimeout: 5000,
       maxPayload: 100 * 1024 * 1024,
+      headers: { Origin: metroOrigin(url) },
     });
     let settled = false;
     // Backstop: handshakeTimeout should emit 'error', but if the socket ever

--- a/scripts/cdp-bridge/src/cdp/multiplexer.ts
+++ b/scripts/cdp-bridge/src/cdp/multiplexer.ts
@@ -3,6 +3,7 @@ import { type AddressInfo } from 'node:net';
 import { randomBytes, timingSafeEqual } from 'node:crypto';
 import { Buffer } from 'node:buffer';
 import WebSocket, { WebSocketServer } from 'ws';
+import { metroOrigin } from '../ws-origin.js';
 
 import { logger } from '../logger.js';
 
@@ -199,7 +200,9 @@ export class CDPMultiplexer {
 
   private connectHermes(): Promise<void> {
     return new Promise((resolve, reject) => {
-      const ws = new WebSocket(this.opts.hermesUrl);
+      const ws = new WebSocket(this.opts.hermesUrl, {
+        headers: { Origin: metroOrigin(this.opts.hermesUrl) },
+      });
       this.hermesWs = ws;
 
       const onOpen = (): void => {

--- a/scripts/cdp-bridge/src/metro/events-client.ts
+++ b/scripts/cdp-bridge/src/metro/events-client.ts
@@ -1,4 +1,5 @@
 import WebSocket from 'ws';
+import { metroOrigin } from '../ws-origin.js';
 
 import { logger } from '../logger.js';
 import { computeReconnectDelay } from '../cdp/reconnection.js';
@@ -279,7 +280,9 @@ export class MetroEventsClient {
     const url = `ws://${this.opts.host}:${this.opts.port}/events`;
 
     return new Promise<void>((resolve) => {
-      const ws = new WebSocket(url);
+      const ws = new WebSocket(url, {
+        headers: { Origin: metroOrigin(url) },
+      });
       this.ws = ws;
 
       // Multi-review catch: on ECONNREFUSED / handshake failures, the `ws` library

--- a/scripts/cdp-bridge/src/ws-origin.ts
+++ b/scripts/cdp-bridge/src/ws-origin.ts
@@ -1,0 +1,13 @@
+// RN 0.85+ / @react-native/dev-middleware guards the Metro inspector proxy with
+// an Origin check (WebSocket CSRF defense): handshakes whose Origin hostname is
+// not loopback get a 401. Node's `ws` sends no Origin by default, so synthesize
+// a loopback Origin matching the dev-server port to satisfy the allowlist
+// (localhost / 127.0.0.1 / 0.0.0.0 / [::]).
+export function metroOrigin(wsUrl: string): string {
+  try {
+    const { port } = new URL(wsUrl);
+    return `http://localhost:${port || '8081'}`;
+  } catch {
+    return 'http://localhost:8081';
+  }
+}

--- a/scripts/cdp-bridge/test/unit/ws-origin.test.js
+++ b/scripts/cdp-bridge/test/unit/ws-origin.test.js
@@ -1,0 +1,33 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { metroOrigin } from '../../dist/ws-origin.js';
+
+/**
+ * B177 (D1240): RN 0.85 / @react-native/dev-middleware 401s WebSocket
+ * handshakes whose Origin hostname is not loopback. metroOrigin synthesizes a
+ * loopback Origin matching the dev-server port so the header-less `ws` client
+ * is accepted by the inspector proxy.
+ */
+
+test('metroOrigin: derives a loopback origin carrying the ws URL port', () => {
+  assert.equal(
+    metroOrigin('ws://localhost:8081/inspector/debug?device=abc&page=2'),
+    'http://localhost:8081',
+  );
+});
+
+test('metroOrigin: forces the localhost hostname even when the ws URL is a LAN IP', () => {
+  assert.equal(
+    metroOrigin('ws://192.168.18.51:8082/inspector/debug?device=abc&page=1'),
+    'http://localhost:8082',
+  );
+});
+
+test('metroOrigin: falls back to :8081 when the ws URL has no explicit port', () => {
+  assert.equal(metroOrigin('ws://localhost/inspector/debug'), 'http://localhost:8081');
+});
+
+test('metroOrigin: falls back to a safe default on an unparseable input', () => {
+  assert.equal(metroOrigin('not a url'), 'http://localhost:8081');
+});


### PR DESCRIPTION
## Problem

On **React Native 0.85 / Expo SDK 56**, `cdp_status` (and therefore all CDP introspection) fails to connect:

```
Failed to connect after 5 attempts
```

Metro logs the real cause:

```
Connection from DevTools failed to be established for origin 'undefined' and
path '/inspector/debug?device=…&page=…'. Was expecting origin
'http://127.0.0.1:8081', or origin hostname to be one of:
localhost, 127.0.0.1, 0.0.0.0, [::]
```

RN 0.85's Metro inspector proxy (`@react-native/dev-middleware`) added a **WebSocket `Origin` allowlist** (a CSRF defense) on `/inspector/debug`. Node's `ws` library sends **no `Origin` header** by default, so the proxy treats the bridge's handshake as cross-origin and returns **HTTP 401**. This breaks the bridge for every RN 0.85 / SDK 56 user.

Proven with a direct `ws` test against a live RN 0.85 app:

| Origin header | Result |
|---|---|
| _(none)_ | **HTTP 401** |
| `http://localhost:8081` | **OPEN ✅** |

## Fix

A new `metroOrigin(wsUrl)` helper (`scripts/cdp-bridge/src/ws-origin.ts`) returns `http://localhost:<port>` — deriving the port from the ws URL but **forcing the `localhost` hostname** so it always lands in Metro's loopback allowlist (even if the ws URL uses a LAN IP). It is passed as the `Origin` header on all three `ws` clients that connect to Metro:

- `cdp/connect.ts` — the primary CDP connection (`cdp_status`, all introspection)
- `cdp/multiplexer.ts` — the observability fan-out to the Hermes inspector
- `metro/events-client.ts` — the Metro `/events` client

## Verification

- End-to-end: `cdp_status` handshake now **succeeds** against a live RN 0.85 / SDK 56 app (previously 401).
- New unit tests: `test/unit/ws-origin.test.js` (4 cases — port carry-over, LAN-IP→localhost coercion, no-port fallback, unparseable fallback).
- `122/122` existing tests for the touched modules (connect / multiplexer / events-client) still pass — the change is purely additive (`headers` option).

## Notes

- `dist/` is rebuilt and committed per repo convention.
- Surfaced while upgrading the test-app to SDK 56 / RN 0.85. A **separate, still-open** issue (B178) blocks CDP `Runtime.evaluate` on RN 0.85's bridgeless **Fusebox** inspector (the device side returns no frames even after the handshake) — that needs its own investigation and is **not** addressed here; this PR restores the handshake that B178 builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)