### PR TITLE
fix(cdp-bridge): use 127.0.0.1 Origin for Expo SDK 56's second origin gate (B178)

### DIFF
--- a/.changeset/rn-085-expo-origin-host-match.md
+++ b/.changeset/rn-085-expo-origin-host-match.md
@@ -1,0 +1,5 @@
+---
+"rn-dev-agent-plugin": patch
+---
+
+Fix B178: CDP introspection returning zero frames on Expo SDK 56 / RN 0.85. The B177 Origin fix used `localhost`, which clears `@react-native/dev-middleware`'s loopback gate (no 401) but trips Expo SDK 56's **second** origin gate in `createDebugMiddleware` (`isMatchingOrigin`): it requires the `Origin` host to equal the dev server's `serverBaseUrl` host (`127.0.0.1`), and a mismatch is force-closed via `socket.terminate()` → a **1006 abnormal close right after connect, before any CDP frame relays**. Switching `metroOrigin` to emit `127.0.0.1` clears **both** gates (and bare RN's single gate), fully restoring `cdp_status` / `cdp_component_tree` / `cdp_store_state` / `cdp_evaluate` on RN 0.85. Verified end-to-end against a live RN 0.85 app: `Runtime.evaluate` plus Redux / Zustand / navigation reads now relay. (B178 / D1242)

--- a/scripts/cdp-bridge/dist/ws-origin.js
+++ b/scripts/cdp-bridge/dist/ws-origin.js
@@ -1,14 +1,22 @@
-// RN 0.85+ / @react-native/dev-middleware guards the Metro inspector proxy with
-// an Origin check (WebSocket CSRF defense): handshakes whose Origin hostname is
-// not loopback get a 401. Node's `ws` sends no Origin by default, so synthesize
-// a loopback Origin matching the dev-server port to satisfy the allowlist
-// (localhost / 127.0.0.1 / 0.0.0.0 / [::]).
+// The Metro inspector proxy guards WebSocket upgrades with TWO origin gates, and
+// Node's `ws` sends no Origin by default:
+//   1. @react-native/dev-middleware (RN 0.85+) — a CSRF defense that 401s any
+//      handshake whose Origin hostname is not loopback (localhost / 127.0.0.1 /
+//      0.0.0.0 / [::]).
+//   2. Expo SDK 56 createDebugMiddleware — a SECOND check (`isMatchingOrigin`)
+//      requiring the Origin host to equal the dev server's serverBaseUrl host,
+//      which resolves to `127.0.0.1` (from server.address()). A mismatch is
+//      force-closed via socket.terminate() → a 1006 abnormal close right after
+//      connect, before any CDP frame is relayed (the B178 "zero frames" wedge).
+// `127.0.0.1` clears BOTH gates (loopback AND host-match), and also bare RN
+// (which has only gate 1). `localhost` clears gate 1 but trips Expo's gate 2, so
+// we must spell loopback as 127.0.0.1 here. (B177 + B178)
 export function metroOrigin(wsUrl) {
     try {
         const { port } = new URL(wsUrl);
-        return `http://localhost:${port || '8081'}`;
+        return `http://127.0.0.1:${port || '8081'}`;
     }
     catch {
-        return 'http://localhost:8081';
+        return 'http://127.0.0.1:8081';
     }
 }

--- a/scripts/cdp-bridge/src/ws-origin.ts
+++ b/scripts/cdp-bridge/src/ws-origin.ts
@@ -1,13 +1,21 @@
-// RN 0.85+ / @react-native/dev-middleware guards the Metro inspector proxy with
-// an Origin check (WebSocket CSRF defense): handshakes whose Origin hostname is
-// not loopback get a 401. Node's `ws` sends no Origin by default, so synthesize
-// a loopback Origin matching the dev-server port to satisfy the allowlist
-// (localhost / 127.0.0.1 / 0.0.0.0 / [::]).
+// The Metro inspector proxy guards WebSocket upgrades with TWO origin gates, and
+// Node's `ws` sends no Origin by default:
+//   1. @react-native/dev-middleware (RN 0.85+) — a CSRF defense that 401s any
+//      handshake whose Origin hostname is not loopback (localhost / 127.0.0.1 /
+//      0.0.0.0 / [::]).
+//   2. Expo SDK 56 createDebugMiddleware — a SECOND check (`isMatchingOrigin`)
+//      requiring the Origin host to equal the dev server's serverBaseUrl host,
+//      which resolves to `127.0.0.1` (from server.address()). A mismatch is
+//      force-closed via socket.terminate() → a 1006 abnormal close right after
+//      connect, before any CDP frame is relayed (the B178 "zero frames" wedge).
+// `127.0.0.1` clears BOTH gates (loopback AND host-match), and also bare RN
+// (which has only gate 1). `localhost` clears gate 1 but trips Expo's gate 2, so
+// we must spell loopback as 127.0.0.1 here. (B177 + B178)
 export function metroOrigin(wsUrl: string): string {
   try {
     const { port } = new URL(wsUrl);
-    return `http://localhost:${port || '8081'}`;
+    return `http://127.0.0.1:${port || '8081'}`;
   } catch {
-    return 'http://localhost:8081';
+    return 'http://127.0.0.1:8081';
   }
 }

--- a/scripts/cdp-bridge/test/unit/ws-origin.test.js
+++ b/scripts/cdp-bridge/test/unit/ws-origin.test.js
@@ -4,30 +4,31 @@ import assert from 'node:assert/strict';
 import { metroOrigin } from '../../dist/ws-origin.js';
 
 /**
- * B177 (D1240): RN 0.85 / @react-native/dev-middleware 401s WebSocket
- * handshakes whose Origin hostname is not loopback. metroOrigin synthesizes a
- * loopback Origin matching the dev-server port so the header-less `ws` client
- * is accepted by the inspector proxy.
+ * B177 + B178: the Metro inspector proxy has two origin gates and Node's `ws`
+ * sends no Origin by default. (1) @react-native/dev-middleware 401s non-loopback
+ * origins; (2) Expo SDK 56 createDebugMiddleware force-closes (1006) any origin
+ * whose host != serverBaseUrl host (127.0.0.1). metroOrigin must emit 127.0.0.1
+ * (not localhost) so it clears BOTH gates.
  */
 
-test('metroOrigin: derives a loopback origin carrying the ws URL port', () => {
+test('metroOrigin: emits a 127.0.0.1 loopback origin carrying the ws URL port', () => {
   assert.equal(
     metroOrigin('ws://localhost:8081/inspector/debug?device=abc&page=2'),
-    'http://localhost:8081',
+    'http://127.0.0.1:8081',
   );
 });
 
-test('metroOrigin: forces the localhost hostname even when the ws URL is a LAN IP', () => {
+test('metroOrigin: forces the 127.0.0.1 host even when the ws URL is a LAN IP', () => {
   assert.equal(
     metroOrigin('ws://192.168.18.51:8082/inspector/debug?device=abc&page=1'),
-    'http://localhost:8082',
+    'http://127.0.0.1:8082',
   );
 });
 
 test('metroOrigin: falls back to :8081 when the ws URL has no explicit port', () => {
-  assert.equal(metroOrigin('ws://localhost/inspector/debug'), 'http://localhost:8081');
+  assert.equal(metroOrigin('ws://localhost/inspector/debug'), 'http://127.0.0.1:8081');
 });
 
 test('metroOrigin: falls back to a safe default on an unparseable input', () => {
-  assert.equal(metroOrigin('not a url'), 'http://localhost:8081');
+  assert.equal(metroOrigin('not a url'), 'http://127.0.0.1:8081');
 });


### PR DESCRIPTION
## Problem (B178)

After #224 (B177) restored the WebSocket **handshake** on RN 0.85, CDP introspection still returned **zero frames** — `cdp_status` reported "handshake succeeded but Runtime.evaluate('1+1') timed out — JS thread paused", and `cdp_component_tree` / `cdp_store_state` / `cdp_evaluate` were unusable on Expo SDK 56 / RN 0.85.

## Root cause — a *second* origin gate

The Metro inspector proxy has **two** origin checks, and B177's `localhost` Origin cleared the first but tripped the second:

1. **`@react-native/dev-middleware`** (RN 0.85) — a CSRF defense that `401`s any non-loopback Origin. *(B177 fixed this with a loopback Origin.)*
2. **Expo SDK 56 `createDebugMiddleware`** — a **second** check, `isMatchingOrigin`, requiring `Origin.host === serverBaseUrl.host`. Expo's `serverBaseUrl` resolves to **`127.0.0.1`** (from `server.address()`). On mismatch it calls **`socket.terminate()`** → a **1006 abnormal close right after `connect`, before any CDP frame is relayed**.

`Origin: http://localhost:8081` clears gate #1 but **fails gate #2** (`localhost` ≠ `127.0.0.1`) → terminated → zero frames.

Confirmed via the proxy's own frame log (`DEBUG=Metro:InspectorProxyCDPMessages`):
```
Got new debugger connection for page 2 ... sessionId f6e28040
(Proxy)->(Device): {"event":"connect", ...}
Debugger ... disconnected (sessionId f6e28040)        ← socket dies, our frame never delivered
Connection closed ... code='1006'
```
And an Origin sweep against the live RN 0.85 app:

| Origin | Result |
|---|---|
| `http://localhost:8081` | 1006 terminate (Expo gate #2) |
| **`http://127.0.0.1:8081`** | **RELAYED ✅** |
| `http://192.168.18.51:8081` | 401 (gate #1, non-loopback) |
| _(none)_ | 401 (gate #1) |

## Fix

`metroOrigin()` now emits **`127.0.0.1`** instead of `localhost`. It clears **both** Expo gates (loopback allowlist *and* `serverBaseUrl` host-match) and bare RN's single gate. One-line behavioral change; the plugin's existing connect sequence (the `Runtime.evaluate('1+1')`-first probe) works unchanged.

## Verification (end-to-end against a live RN 0.85 / SDK 56 app)

Through the rebuilt `dist` (the actual shipped `metroOrigin`):
```
dist metroOrigin -> http://127.0.0.1:8081
Runtime.evaluate(1+1) -> 2
FULL CDP -> {"route":"Tabs","sum":2,"tasks":3}        ← evaluate + nav route + Redux read
APP STATE -> redux:[user,feed,notifications,settings,tasks,network,categories,_persist]
             zustand:[preferences,bookmarks,searchHistory,inputForm]
```
Plus the plugin's exact evaluate-first probe returns `2` with no prior `Runtime.enable`. `tsc` clean; `ws-origin` unit tests updated (4/4 pass).

## Notes
- `dist/` rebuilt and committed per repo convention.
- Follow-up to #224. Together these two fix **L1 CDP introspection on RN 0.85 / Expo SDK 56** end-to-end (handshake + relay).
- Optional future polish (not in this PR): `connect.ts` mislabels this wedge as "JS thread paused" — with this fix it no longer occurs on SDK 56, but the diagnostic could be made more specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)