### PR TITLE
fix(cdp-bridge): cdp_console_log — accept JSON object args in helper-expr guard (B180)

### DIFF
--- a/.changeset/cdp-console-log-helper-expr.md
+++ b/.changeset/cdp-console-log-helper-expr.md
@@ -1,0 +1,5 @@
+---
+"rn-dev-agent-plugin": patch
+---
+
+Fix `cdp_console_log` and harden the helper-expr injection guard. The guard that validates injected-helper calls before `Runtime.evaluate` banned any call containing `{}`, which broke `cdp_console_log` — it passes a JSON object argument (`getConsole({"level":"all","limit":50})`) and was refused with "helper-expr: refusing to interpolate untrusted call". The guard now validates that the argument list is **pure JSON data** (object/array literals included) instead of banning `{}` characters. This fixes `cdp_console_log` (and any object-arg helper call, e.g. `dispatchAction`) **and tightens security**: the old `[^;{}]*` regex let nested calls such as `getConsole(stealSecrets())` through; those are now rejected. The one non-JSON token a call site emits — `undefined` (store-state's absent path/type) — is normalized to `null` for validation only; the original call is interpolated unchanged. Verified: 1710/1710 unit tests pass (incl. 10 new helper-expr tests) and live `cdp_console_log` returns the console buffer (69 entries). (B180)

--- a/scripts/cdp-bridge/dist/cdp/helper-expr.js
+++ b/scripts/cdp-bridge/dist/cdp/helper-expr.js
@@ -1,17 +1,39 @@
 // CodeQL js/bad-code-sanitization (alerts #23 #24):
 // `call` is interpolated into a JavaScript expression that the MCP server
-// sends to Hermes via Runtime.evaluate. All production call sites use
-// hardcoded method names + JSON.stringify'd arguments (e.g. `getStoreState(${pathArg}, ${typeArg})`
-// where pathArg/typeArg come from JSON.stringify), so injection is not
-// reachable in practice. The validator below adds defense in depth by
-// rejecting any `call` containing characters that could escape the
-// surrounding function-call boundary.
-const SAFE_CALL_RE = /^[A-Za-z_$][A-Za-z0-9_$]*\([^;{}]*\)$/;
+// sends to Hermes via Runtime.evaluate. All production call sites use hardcoded
+// method names + JSON.stringify'd arguments (e.g. `getStoreState(${pathArg}, ${typeArg})`,
+// `getConsole(${JSON.stringify(opts)})`), so injection is not reachable in
+// practice. validateCall adds defense in depth: it requires `call` to be
+// `identifier(<args>)` where <args> is empty or a comma-separated list of pure
+// JSON DATA values. JSON data cannot carry executable code (no calls, no
+// statements), so an object/array-literal argument — getConsole({...}),
+// dispatchAction({...}) — is accepted, while a nested call such as
+// `getConsole(stealSecrets())` or any `;`-statement injection is rejected.
+// (The previous `[^;{}]*` regex was both too strict — it banned legitimate JSON
+// object args, breaking cdp_console_log — and too loose — it let nested calls
+// through.)
+const CALL_RE = /^[A-Za-z_$][A-Za-z0-9_$]*\(([\s\S]*)\)$/;
 function validateCall(call) {
-    if (!SAFE_CALL_RE.test(call)) {
-        throw new Error(`helper-expr: refusing to interpolate untrusted call "${call.slice(0, 80)}"; ` +
-            `expected identifier-prefixed parenthesized expression with no ;{} characters.`);
+    const match = CALL_RE.exec(call);
+    if (match) {
+        const args = match[1].trim();
+        if (args === '')
+            return;
+        // `undefined` is the one non-JSON token a call site may emit (store-state's
+        // absent path/type, e.g. `getStoreState(undefined, undefined)`). Normalize
+        // it to `null` FOR VALIDATION ONLY — both are inert literals; the original
+        // (unmodified) `call` is what actually gets interpolated.
+        const forJson = args.replace(/\bundefined\b/g, 'null');
+        try {
+            JSON.parse(`[${forJson}]`);
+            return;
+        }
+        catch {
+            /* not pure JSON data — fall through to reject */
+        }
     }
+    throw new Error(`helper-expr: refusing to interpolate untrusted call "${call.slice(0, 80)}"; ` +
+        `expected identifier(<args>) where <args> are pure JSON data values.`);
 }
 export function helperExpr(call, bridgeDetected) {
     validateCall(call);

--- a/scripts/cdp-bridge/src/cdp/helper-expr.ts
+++ b/scripts/cdp-bridge/src/cdp/helper-expr.ts
@@ -1,20 +1,40 @@
 // CodeQL js/bad-code-sanitization (alerts #23 #24):
 // `call` is interpolated into a JavaScript expression that the MCP server
-// sends to Hermes via Runtime.evaluate. All production call sites use
-// hardcoded method names + JSON.stringify'd arguments (e.g. `getStoreState(${pathArg}, ${typeArg})`
-// where pathArg/typeArg come from JSON.stringify), so injection is not
-// reachable in practice. The validator below adds defense in depth by
-// rejecting any `call` containing characters that could escape the
-// surrounding function-call boundary.
-const SAFE_CALL_RE = /^[A-Za-z_$][A-Za-z0-9_$]*\([^;{}]*\)$/;
+// sends to Hermes via Runtime.evaluate. All production call sites use hardcoded
+// method names + JSON.stringify'd arguments (e.g. `getStoreState(${pathArg}, ${typeArg})`,
+// `getConsole(${JSON.stringify(opts)})`), so injection is not reachable in
+// practice. validateCall adds defense in depth: it requires `call` to be
+// `identifier(<args>)` where <args> is empty or a comma-separated list of pure
+// JSON DATA values. JSON data cannot carry executable code (no calls, no
+// statements), so an object/array-literal argument — getConsole({...}),
+// dispatchAction({...}) — is accepted, while a nested call such as
+// `getConsole(stealSecrets())` or any `;`-statement injection is rejected.
+// (The previous `[^;{}]*` regex was both too strict — it banned legitimate JSON
+// object args, breaking cdp_console_log — and too loose — it let nested calls
+// through.)
+const CALL_RE = /^[A-Za-z_$][A-Za-z0-9_$]*\(([\s\S]*)\)$/;
 
 function validateCall(call: string): void {
-  if (!SAFE_CALL_RE.test(call)) {
-    throw new Error(
-      `helper-expr: refusing to interpolate untrusted call "${call.slice(0, 80)}"; ` +
-      `expected identifier-prefixed parenthesized expression with no ;{} characters.`,
-    );
+  const match = CALL_RE.exec(call);
+  if (match) {
+    const args = match[1].trim();
+    if (args === '') return;
+    // `undefined` is the one non-JSON token a call site may emit (store-state's
+    // absent path/type, e.g. `getStoreState(undefined, undefined)`). Normalize
+    // it to `null` FOR VALIDATION ONLY — both are inert literals; the original
+    // (unmodified) `call` is what actually gets interpolated.
+    const forJson = args.replace(/\bundefined\b/g, 'null');
+    try {
+      JSON.parse(`[${forJson}]`);
+      return;
+    } catch {
+      /* not pure JSON data — fall through to reject */
+    }
   }
+  throw new Error(
+    `helper-expr: refusing to interpolate untrusted call "${call.slice(0, 80)}"; ` +
+    `expected identifier(<args>) where <args> are pure JSON data values.`,
+  );
 }
 
 export function helperExpr(call: string, bridgeDetected: boolean): string {

--- a/scripts/cdp-bridge/test/unit/helper-expr.test.js
+++ b/scripts/cdp-bridge/test/unit/helper-expr.test.js
@@ -1,0 +1,75 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { helperExpr, bridgeWithFallback } from '../../dist/cdp/helper-expr.js';
+
+/**
+ * Regression: the helper-expr injection guard must accept JSON object/array
+ * arguments — getConsole({...}), dispatchAction({...}) — not just quoted-string
+ * args, while still rejecting injection. The original guard banned `{}` outright,
+ * which broke cdp_console_log (handshake OK, but the helper call was refused).
+ * The guard now validates the argument list is pure JSON *data* (which cannot
+ * carry executable code), so it is both more permissive (object literals) AND
+ * stricter (rejects nested calls the old `[^;{}]*` regex let through).
+ */
+
+// ── Accepts every legitimate production call shape ──
+
+test('accepts a JSON object-literal argument (getConsole) — the regression', () => {
+  assert.equal(
+    helperExpr('getConsole({"level":"all","limit":50})', true),
+    '__RN_DEV_BRIDGE__.getConsole({"level":"all","limit":50})',
+  );
+});
+
+test('accepts a nested-object argument (dispatchAction)', () => {
+  const call = 'dispatchAction({"action":"tasks/add","payload":{"title":"x"},"readPath":"tasks.items"})';
+  assert.equal(helperExpr(call, false), `__RN_AGENT.${call}`);
+});
+
+test('accepts the bare `undefined` token (store-state absent path/type)', () => {
+  assert.equal(
+    helperExpr('getStoreState(undefined, undefined)', true),
+    '__RN_DEV_BRIDGE__.getStoreState(undefined, undefined)',
+  );
+});
+
+test('accepts JSON string args (getStoreState path/type)', () => {
+  assert.equal(
+    helperExpr('getStoreState("cart.items", "redux")', true),
+    '__RN_DEV_BRIDGE__.getStoreState("cart.items", "redux")',
+  );
+});
+
+test('accepts no-arg calls on either bridge', () => {
+  assert.equal(helperExpr('getNavState()', true), '__RN_DEV_BRIDGE__.getNavState()');
+  assert.equal(helperExpr('clearConsole()', false), '__RN_AGENT.clearConsole()');
+});
+
+test('does NOT corrupt a JSON string value of "undefined" (validation-only normalization)', () => {
+  const call = 'dispatchAction({"action":"x","payload":"undefined"})';
+  // accepted, and the interpolated call keeps the original string intact
+  assert.equal(helperExpr(call, true), `__RN_DEV_BRIDGE__.${call}`);
+});
+
+// ── Still rejects injection (defense in depth) ──
+
+test('REJECTS statement-injection via `;`', () => {
+  assert.throws(() => helperExpr('getConsole(); stealSecrets()', true), /refusing to interpolate/);
+});
+
+test('REJECTS a nested function-call argument (not JSON data) — tightened vs old guard', () => {
+  assert.throws(() => helperExpr('getConsole(stealSecrets())', true), /refusing to interpolate/);
+});
+
+test('REJECTS a non-identifier / member-access method name', () => {
+  assert.throws(() => helperExpr('1evil()', true), /refusing to interpolate/);
+  assert.throws(() => helperExpr('a.b()', true), /refusing to interpolate/);
+});
+
+test('bridgeWithFallback validates the same way and wraps both bridges', () => {
+  const out = bridgeWithFallback('getStoreState("x", undefined)', true);
+  assert.match(out, /__RN_DEV_BRIDGE__\.getStoreState\("x", undefined\)/);
+  assert.match(out, /__RN_AGENT\.getStoreState\("x", undefined\)/);
+  assert.throws(() => bridgeWithFallback('getConsole(evil())', true), /refusing to interpolate/);
+});


### PR DESCRIPTION
## Problem

`cdp_console_log` fails on every call:
```
helper-expr: refusing to interpolate untrusted call "getConsole({"level":"all","limit":50})";
expected identifier-prefixed parenthesized expression with no ;{} characters.
```

The `helper-expr` injection guard (`src/cdp/helper-expr.ts`) validates injected-helper calls before they're interpolated into a `Runtime.evaluate` expression. Its regex `^[A-Za-z_$][A-Za-z0-9_$]*\([^;{}]*\)$` **bans `{}`** — but `console-log.ts` passes a JSON **object** argument (`getConsole({"level":...,"limit":...})`), so the call is refused. (`collect_logs` works only because it builds the expression directly, bypassing the guard.)

The old regex was also **too loose**: `[^;{}]*` permits a nested call like `getConsole(stealSecrets())` — a real (if not-yet-reachable) injection vector.

## Fix

Validate that the argument list is **pure JSON data** rather than banning brace characters:

```ts
const CALL_RE = /^[A-Za-z_$][A-Za-z0-9_$]*\(([\s\S]*)\)$/;
// args === '' → ok; else JSON.parse(`[${args}]`) must succeed
```

JSON data cannot carry executable code (no calls, no statements), so:
- ✅ object/array literals are **accepted** → fixes `cdp_console_log` (and `dispatchAction({...})`)
- ✅ nested calls / statement injection are **rejected** → `getConsole(stealSecrets())`, `getConsole(); evil()`, `1evil()`, `a.b()` all throw (the first was previously *allowed*)

The one non-JSON token a call site emits — `undefined` (store-state's absent `path`/`type`, e.g. `getStoreState(undefined, undefined)`) — is normalized to `null` **for validation only**; the original `call` is interpolated unchanged (so a JSON string value of `"undefined"` is never corrupted).

## Verification

- **TDD**: 10 new tests in `test/unit/helper-expr.test.js` (written red-first — object-arg cases failed, and the "rejects nested call" case exposed the old guard's gap).
- **No regression**: full unit suite **1710/1710 pass** (`helperExpr` has many consumers — dispatch, store-state, macro-asserts, nav, errors).
- **Live**: against a running RN 0.85 app, `cdp_console_log` now returns the console buffer (**69 entries**, incl. `__RN_NET__` request/response logs) instead of the guard error; `getConsole(stealSecrets())` is rejected.

## Notes
- `dist/` rebuilt and committed per repo convention.
- Independent of B177/B178 (this is an MCP-server-side guard bug, not RN-version-specific) — discovered during the RN 0.85 introspection sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)