### PR TITLE
fix(cdp-bridge): resolve CDP connection wedge — storm-preempt + AppDetachedError + auto-relaunch (#208)

### DIFF
--- a/.changeset/gh-208-cdp-connection-wedge.md
+++ b/.changeset/gh-208-cdp-connection-wedge.md
@@ -1,0 +1,14 @@
+---
+"rn-dev-agent-cdp": patch
+"rn-dev-agent-plugin": patch
+---
+
+Fix the CDP connection wedge (GH #208): `cdp_status` no longer dead-locks on "Already connecting to Metro..." and no longer misreports a detached app as "Metro not found". Three root causes were addressed:
+
+- **RC1 — reconnect-storm wedge.** When the app detaches but Metro stays up, the WS-close reconnect loop holds `isReconnecting()` true for up to ~12 min (30 attempts × 30s cap, then re-armed indefinitely by the background poll). `autoConnect`'s guard threw "Already connecting" for every `cdp_status`/`cdp_*` call in that window. `cdp_status` now **preempts** an active reconnect storm via `softReconnect()` (the existing 3s `softReconnectRequested` handshake) for one fresh attempt instead of refusing, and surfaces the live `reconnectState` (attempt N/30) on any connect failure so it reads as progress, not a dead end.
+- **RC2 — misleading error.** "Metro up but 0 Hermes targets" now throws a typed `AppDetachedError` ("Metro is up … advertises 0 Hermes debug targets — the app isn't attached") instead of being conflated with the genuine "Metro not found" (now reserved for `discoverMetroPort` returning null).
+- **RC3 — no auto-recovery.** New `recoverDetached()` cold-restarts a detached iOS app (`simctl terminate` + `launch`) → reconnects → confirms with a real CDP liveness probe. Bounded to 3 consecutive attempts/session, skips while a Maestro flow holds the arbiter lease, iOS-only, opt-out via `RN_AUTO_RELAUNCH_ON_DETACH=0`. Cold-restart (vs recover-wedge's bare launch) is acceptable because it only fires when the app is ALREADY detached — never against a working app.
+
+Hardened via a Codex + Gemini multi-review: `cdp_status` now honors an explicit `args.platform` during a storm (tears down + reconnects rather than reusing the storm's target), auto-relaunch is skipped when the caller pinned a non-iOS platform (never cold-restarts an unrelated iOS session), `simctl launch` failures are surfaced instead of hidden behind "still detached", and the post-recovery status read can no longer throw out of the handler.
+
+19 new unit tests; full suite 1729/1729; `tsc --noEmit` clean. Live false-positive guard verified: the real `discover()` against Metro does not fire `AppDetachedError` while a target is present. Scoping: the literal-0-targets case is fixed; the RN-0.85 "C++ target present, 0 Hermes" flavor remains B156/B184 territory (recover-wedge path). (GH #208, B181, D1245)

--- a/scripts/cdp-bridge/dist/cdp/discovery.js
+++ b/scripts/cdp-bridge/dist/cdp/discovery.js
@@ -1,5 +1,23 @@
 import { execFileSync } from 'node:child_process';
 import { logger } from '../logger.js';
+/**
+ * GH #208 (RC2): thrown by `discover()` when Metro IS reachable but advertises
+ * zero Hermes debug targets — the app has detached (Expo dev launcher,
+ * backgrounded, or crashed). Distinct from the "Metro not found" case so
+ * callers (cdp_status) can trigger the bounded auto-relaunch recovery
+ * (recover-detached.ts) instead of misreporting Metro as down. Carries the
+ * resolved Metro port for the recovery + diagnostics.
+ */
+export class AppDetachedError extends Error {
+    port;
+    constructor(port) {
+        super(`Metro is up on port ${port} but advertises 0 Hermes debug targets — the app isn't attached ` +
+            `(it may be on the Expo dev launcher, backgrounded, or crashed). Relaunch the app, ` +
+            `or call cdp_status to auto-relaunch and reconnect.`);
+        this.name = 'AppDetachedError';
+        this.port = port;
+    }
+}
 export const DISCOVERY_TIMEOUT_MS = 1500;
 export const USER_METRO_PORT = process.env.RN_METRO_PORT ? parseInt(process.env.RN_METRO_PORT, 10) : null;
 export const DEFAULT_PORTS = [
@@ -280,7 +298,7 @@ export async function discover(currentPort, platformFilterOrFilters) {
         }
     });
     if (validTargets.length === 0) {
-        throw new Error('No Hermes debug target found. Is the app running? Is Hermes enabled?');
+        throw new AppDetachedError(metroPort);
     }
     inferPlatforms(validTargets);
     const { targets: sorted, warning } = selectTarget(validTargets, filters);

--- a/scripts/cdp-bridge/dist/cdp/recover-detached.js
+++ b/scripts/cdp-bridge/dist/cdp/recover-detached.js
@@ -1,0 +1,99 @@
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+import { getActiveSession } from '../agent-device-wrapper.js';
+import { stopFastRunner as defaultStopFastRunner } from '../runners/rn-fast-runner-client.js';
+import { arbiter } from '../lifecycle/device-arbiter.js';
+import { probeFreshness } from './recovery.js';
+const execFile = promisify(execFileCb);
+const DEFAULT_MAX_PER_SESSION = 3;
+const RELAUNCH_SETTLE_MS = 1200;
+let attempts = 0;
+/** Reset the per-session recovery budget (on device_snapshot open AND on a successful recovery). */
+export function resetDetachedRecoveryCounter() { attempts = 0; }
+/**
+ * GH #208 (RC3): cold-restart the target app on the booted simulator — terminate
+ * THEN launch. Unlike recover-wedge's bare `simctl launch` (which re-foregrounds
+ * a still-running backgrounded app with the same pid, preserving JS state), a
+ * DETACHED app isn't running at all (dev launcher / crashed), so we force a clean
+ * cold start. The terminate is best-effort: it errors with "found no matching
+ * processes" when the app isn't running — the normal detached case — so swallow it.
+ *
+ * `exec` is injectable so the terminate-then-launch sequence is unit-testable
+ * without spawning simctl.
+ */
+export async function defaultRelaunchApp(udid, appId, exec = execFile) {
+    try {
+        await exec('xcrun', ['simctl', 'terminate', udid, appId], { timeout: 10_000 });
+    }
+    catch {
+        // App wasn't running (the detached case) — terminate is a no-op; proceed to launch.
+    }
+    await exec('xcrun', ['simctl', 'launch', udid, appId], { timeout: 10_000 });
+}
+/**
+ * GH #208 (RC3): bounded recovery for the DETACHED-app wedge — Metro is up but
+ * advertises 0 Hermes targets (AppDetachedError), so there's no target to connect
+ * to. Cold-restart the app (terminate+launch) → reconnect → confirm via a REAL CDP
+ * liveness probe. Bounded to maxPerSession CONSECUTIVE failures (default 3; resets
+ * on success and on device_snapshot action=open). SKIPS when a Maestro flow holds
+ * the arbiter flow lease (don't yank the app from a flow) and when opted out via
+ * RN_AUTO_RELAUNCH_ON_DETACH=0.
+ *
+ * Reverse-risk note: a cold restart destroys in-progress JS state. That's
+ * acceptable ONLY because this fires when the app is ALREADY detached (the session
+ * is already broken) — never against a working app. The opt-out exists for users
+ * who'd rather recover manually.
+ */
+export async function recoverDetached(client, deps = {}) {
+    const max = deps.maxPerSession ?? DEFAULT_MAX_PER_SESSION;
+    const isFlowActive = deps.isFlowActive ?? (() => arbiter.snapshot.flowLeaseHeldBy !== null);
+    const isOptedOut = deps.isOptedOut ?? (() => process.env.RN_AUTO_RELAUNCH_ON_DETACH === '0');
+    // No-op early returns — these must NOT consume the budget.
+    if (isOptedOut()) {
+        return { recovered: false, reason: 'opted-out', attempt: attempts };
+    }
+    if (isFlowActive()) {
+        return { recovered: false, reason: 'flow-active', attempt: attempts };
+    }
+    const session = (deps.getSession ?? getActiveSession)();
+    if (!session?.deviceId || !session?.appId) {
+        return { recovered: false, reason: 'no-session', attempt: attempts };
+    }
+    if ((session.platform ?? 'ios') !== 'ios') {
+        return { recovered: false, reason: 'unsupported-platform', attempt: attempts };
+    }
+    if (attempts >= max) {
+        return { recovered: false, reason: 'budget-exhausted', attempt: attempts };
+    }
+    // A real, side-effecting attempt.
+    attempts += 1;
+    const attempt = attempts;
+    const udid = session.deviceId;
+    const appId = session.appId;
+    const stopFastRunner = deps.stopFastRunner ?? defaultStopFastRunner;
+    const relaunchApp = deps.relaunchApp ?? defaultRelaunchApp;
+    const reconnect = deps.reconnect ?? (() => client.softReconnect());
+    const probeAlive = deps.probeAlive ?? (async () => (await probeFreshness(client)).fresh);
+    const sleep = deps.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+    stopFastRunner();
+    let relaunchError;
+    try {
+        await relaunchApp(udid, appId);
+    }
+    catch (e) {
+        // The terminate step is already swallowed inside defaultRelaunchApp, so a throw
+        // here is a real `simctl launch` failure (bad UDID/bundleId, sim unavailable).
+        // Capture it (Codex F3) so the verdict is actionable, not a bare "still-detached".
+        relaunchError = e instanceof Error ? e.message : String(e);
+    }
+    await sleep(RELAUNCH_SETTLE_MS);
+    try {
+        await reconnect();
+    }
+    catch { /* best-effort; the liveness probe is the verdict */ }
+    if (await probeAlive()) {
+        attempts = 0; // success bounds CONSECUTIVE detaches, not lifetime
+        return { recovered: true, reason: 'recovered', attempt };
+    }
+    return { recovered: false, reason: 'still-detached', attempt, ...(relaunchError ? { error: relaunchError } : {}) };
+}

--- a/scripts/cdp-bridge/dist/tools/device-session.js
+++ b/scripts/cdp-bridge/dist/tools/device-session.js
@@ -6,6 +6,7 @@ import { markCdpStale } from '../cdp/recovery.js';
 import { detectAndroidExternalRunner, detectIosExternalRunner, foreignRunnerNotice } from '../runners/external-runner-detect.js';
 import { ensureSingleRunner } from '../runners/ensure-single-runner.js';
 import { resetWedgeRecoveryCounter } from '../cdp/recover-wedge.js';
+import { resetDetachedRecoveryCounter } from '../cdp/recover-detached.js';
 import { okResult, failResult, warnResult } from '../utils.js';
 import { resolveBundleId } from '../project-config.js';
 import { isValidBundleId } from '../domain/maestro-validator.js';
@@ -187,6 +188,7 @@ export function createDeviceSnapshotHandler() {
                 // the wedge-recovery budget. Placed AFTER the device-lock conflict
                 // early-return so a refused DEVICE_BUSY open does NOT reset it.
                 resetWedgeRecoveryCounter();
+                resetDetachedRecoveryCounter(); // GH #208 (RC3): fresh session clears the auto-relaunch budget too
                 // GH#202 Phase 1: enforce a single iOS interaction runner. The UDID is
                 // known here (device-open), so scope-kill any stale AgentDeviceRunner
                 // targeting THIS simulator and clear orphaned daemon lock files.

--- a/scripts/cdp-bridge/dist/tools/status.js
+++ b/scripts/cdp-bridge/dist/tools/status.js
@@ -5,6 +5,8 @@ import { getSessionReloadCount } from './reload.js';
 import { supportsNativeMultiDebugger } from '../cdp/multiplexer.js';
 import { arbiter } from '../lifecycle/device-arbiter.js';
 import { recoverWedge } from '../cdp/recover-wedge.js';
+import { recoverDetached } from '../cdp/recover-detached.js';
+import { AppDetachedError } from '../cdp/discovery.js';
 // M10 / Phase 110: narrow `appInfo.architecture` to the StatusResult union.
 // Any unexpected value collapses to 'unknown' — defensive against future
 // helper versions that might emit new tokens we don't recognize yet.
@@ -92,7 +94,8 @@ async function buildStatusResult(client) {
         },
     };
 }
-export function createStatusHandler(getClient, setClient, createClient) {
+export function createStatusHandler(getClient, setClient, createClient, deps = {}) {
+    const recoverDetachedFn = deps.recoverDetached ?? recoverDetached;
     return async (args) => {
         if (args?.resetArbiter) {
             const arbiterReset = arbiter.reset('manual via cdp_status');
@@ -125,7 +128,27 @@ export function createStatusHandler(getClient, setClient, createClient) {
                     }
                 }
                 catch { /* fall through to autoConnect */ }
-                await client.autoConnect(args.metroPort, args.platform, 'status');
+                // GH #208 (RC1): when a reconnect storm is in flight, bare autoConnect
+                // throws "Already connecting to Metro..." (connect.ts guard) and dead-ends
+                // cdp_status — the one tool meant to diagnose+recover. Preempt the storm
+                // via softReconnect (the existing 3s softReconnectRequested handshake) for
+                // one fresh, real connection attempt instead of refusing.
+                // GH #208 review (Codex/Gemini F1): softReconnect reuses the storm's
+                // existing target/filters, so only preempt in place when the caller hasn't
+                // pinned a different target. If they pinned an explicit platform, tear the
+                // storm down first (mirrors the metroPort-change path above) so autoConnect
+                // honors it instead of returning wrong-platform data.
+                if (client.reconnectState.active && !args.platform) {
+                    await client.softReconnect();
+                }
+                else {
+                    if (client.reconnectState.active) {
+                        await client.disconnect();
+                        client = createClient(client.metroPort);
+                        setClient(client);
+                    }
+                    await client.autoConnect(args.metroPort, args.platform, 'status');
+                }
             }
             else if (args.platform) {
                 // GH #21: Already connected — check if the current target matches the requested platform
@@ -234,6 +257,46 @@ export function createStatusHandler(getClient, setClient, createClient) {
         }
         catch (err) {
             const message = err instanceof Error ? err.message : String(err);
+            // GH #208 (RC3): Metro is up but the app detached (0 Hermes targets). Auto
+            // cold-restart it (bounded, arbiter-aware, opt-out RN_AUTO_RELAUNCH_ON_DETACH=0),
+            // then reconnect and return a fresh status. On failure, surface a legible
+            // state (reconnect attempt count + escape hatch) rather than a misleading error.
+            if (err instanceof AppDetachedError) {
+                // GH #208 review (Codex F2): RC3 auto-relaunch is iOS-only and acts on the
+                // active device session. If the caller explicitly pinned a non-iOS platform,
+                // do NOT cold-restart the iOS session they didn't ask about — surface the
+                // detached state instead.
+                const callerPinnedNonIos = !!args.platform && args.platform.toLowerCase() !== 'ios';
+                const recovery = callerPinnedNonIos
+                    ? { recovered: false, reason: 'unsupported-platform', attempt: 0 }
+                    : await recoverDetachedFn(getClient());
+                if (recovery.recovered) {
+                    // GH #208 review (Gemini F2): never let a post-reconnect status read throw
+                    // out of the catch — degrade to a minimal warn instead of crashing the tool.
+                    try {
+                        return warnResult(await buildStatusResult(getClient()), `App had detached (Metro up, 0 Hermes targets) — auto-relaunched and reconnected (attempt ${recovery.attempt}).`);
+                    }
+                    catch {
+                        return warnResult({ recovered: true }, `App had detached (Metro up, 0 Hermes targets) — auto-relaunched and reconnected (attempt ${recovery.attempt}), but reading the full status failed; retry cdp_status.`);
+                    }
+                }
+                const detachedHint = recovery.reason === 'flow-active'
+                    ? 'A Maestro flow is running — skipped auto-relaunch. Wait for the flow to finish, then retry cdp_status.'
+                    : recovery.reason === 'opted-out'
+                        ? 'Auto-relaunch is disabled (RN_AUTO_RELAUNCH_ON_DETACH=0). Relaunch the app manually, or call cdp_restart(hardReset=true).'
+                        : recovery.reason === 'budget-exhausted'
+                            ? 'Auto-relaunch budget exhausted this session. Relaunch the app manually, or call cdp_restart(hardReset=true).'
+                            : recovery.reason === 'no-session'
+                                ? 'No active device session to relaunch from. Relaunch the app on the simulator, or call cdp_restart(hardReset=true).'
+                                : recovery.reason === 'unsupported-platform'
+                                    ? 'Auto-relaunch is iOS-only here. Relaunch the app on the device, then retry cdp_status.'
+                                    : 'Auto-relaunch did not restore the app. Relaunch it manually, or call cdp_restart(hardReset=true).';
+                const errSuffix = recovery.error ? ` (relaunch error: ${recovery.error})` : '';
+                return failResult(`${message} ${detachedHint}${errSuffix}`, 'APP_DETACHED', {
+                    reconnect: getClient().reconnectState,
+                    recovery,
+                });
+            }
             // GH #184: the status-scoped connect aborted fast because React was
             // unreachable on a non-Hermes target (picker blocking the bundle, or it's
             // still building). The message is already actionable; still attempt the
@@ -264,7 +327,11 @@ export function createStatusHandler(getClient, setClient, createClient) {
                 }
             }
             catch { /* picker check failed, return original error */ }
-            return pickerBlocking ? failResult(message, 'PICKER_BLOCKING') : failResult(message);
+            // GH #208 (RC1): carry the reconnect attempt count so a connect failure
+            // during a reconnect storm reads as "attempt N/30", not a dead end.
+            return pickerBlocking
+                ? failResult(message, 'PICKER_BLOCKING')
+                : failResult(message, { reconnect: getClient().reconnectState });
         }
     };
 }

--- a/scripts/cdp-bridge/src/cdp/discovery.ts
+++ b/scripts/cdp-bridge/src/cdp/discovery.ts
@@ -2,6 +2,27 @@ import { execFileSync } from 'node:child_process';
 import { logger } from '../logger.js';
 import type { HermesTarget } from '../types.js';
 
+/**
+ * GH #208 (RC2): thrown by `discover()` when Metro IS reachable but advertises
+ * zero Hermes debug targets — the app has detached (Expo dev launcher,
+ * backgrounded, or crashed). Distinct from the "Metro not found" case so
+ * callers (cdp_status) can trigger the bounded auto-relaunch recovery
+ * (recover-detached.ts) instead of misreporting Metro as down. Carries the
+ * resolved Metro port for the recovery + diagnostics.
+ */
+export class AppDetachedError extends Error {
+  readonly port: number;
+  constructor(port: number) {
+    super(
+      `Metro is up on port ${port} but advertises 0 Hermes debug targets — the app isn't attached ` +
+      `(it may be on the Expo dev launcher, backgrounded, or crashed). Relaunch the app, ` +
+      `or call cdp_status to auto-relaunch and reconnect.`,
+    );
+    this.name = 'AppDetachedError';
+    this.port = port;
+  }
+}
+
 export const DISCOVERY_TIMEOUT_MS = 1500;
 export const USER_METRO_PORT = process.env.RN_METRO_PORT ? parseInt(process.env.RN_METRO_PORT, 10) : null;
 export const DEFAULT_PORTS = [
@@ -330,9 +351,7 @@ export async function discover(
   });
 
   if (validTargets.length === 0) {
-    throw new Error(
-      'No Hermes debug target found. Is the app running? Is Hermes enabled?',
-    );
+    throw new AppDetachedError(metroPort);
   }
 
   inferPlatforms(validTargets);

--- a/scripts/cdp-bridge/src/cdp/recover-detached.ts
+++ b/scripts/cdp-bridge/src/cdp/recover-detached.ts
@@ -1,0 +1,142 @@
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { CDPClient } from '../cdp-client.js';
+import { getActiveSession } from '../agent-device-wrapper.js';
+import { stopFastRunner as defaultStopFastRunner } from '../runners/rn-fast-runner-client.js';
+import { arbiter } from '../lifecycle/device-arbiter.js';
+import { probeFreshness } from './recovery.js';
+
+const execFile = promisify(execFileCb);
+const DEFAULT_MAX_PER_SESSION = 3;
+const RELAUNCH_SETTLE_MS = 1200;
+
+export type DetachedReason =
+  | 'recovered'
+  | 'still-detached'
+  | 'no-session'
+  | 'flow-active'
+  | 'opted-out'
+  | 'unsupported-platform'
+  | 'budget-exhausted';
+
+export interface DetachedRecoveryResult {
+  recovered: boolean;
+  reason: DetachedReason;
+  attempt: number;
+  /** GH #208 review (Codex F3): a `simctl launch` failure message, surfaced instead of hidden. */
+  error?: string;
+}
+
+let attempts = 0;
+/** Reset the per-session recovery budget (on device_snapshot open AND on a successful recovery). */
+export function resetDetachedRecoveryCounter(): void { attempts = 0; }
+
+type Exec = (cmd: string, args: string[], opts?: { timeout?: number }) => Promise<{ stdout: string; stderr: string }>;
+
+/**
+ * GH #208 (RC3): cold-restart the target app on the booted simulator — terminate
+ * THEN launch. Unlike recover-wedge's bare `simctl launch` (which re-foregrounds
+ * a still-running backgrounded app with the same pid, preserving JS state), a
+ * DETACHED app isn't running at all (dev launcher / crashed), so we force a clean
+ * cold start. The terminate is best-effort: it errors with "found no matching
+ * processes" when the app isn't running — the normal detached case — so swallow it.
+ *
+ * `exec` is injectable so the terminate-then-launch sequence is unit-testable
+ * without spawning simctl.
+ */
+export async function defaultRelaunchApp(
+  udid: string,
+  appId: string,
+  exec: Exec = execFile as unknown as Exec,
+): Promise<void> {
+  try {
+    await exec('xcrun', ['simctl', 'terminate', udid, appId], { timeout: 10_000 });
+  } catch {
+    // App wasn't running (the detached case) — terminate is a no-op; proceed to launch.
+  }
+  await exec('xcrun', ['simctl', 'launch', udid, appId], { timeout: 10_000 });
+}
+
+export interface RecoverDetachedDeps {
+  getSession?: () => { deviceId?: string; appId?: string; platform?: string } | null;
+  isFlowActive?: () => boolean;
+  isOptedOut?: () => boolean;
+  relaunchApp?: (udid: string, appId: string) => Promise<void>;
+  stopFastRunner?: () => void;
+  reconnect?: () => Promise<void>;
+  probeAlive?: () => Promise<boolean>;
+  sleep?: (ms: number) => Promise<void>;
+  maxPerSession?: number;
+}
+
+/**
+ * GH #208 (RC3): bounded recovery for the DETACHED-app wedge — Metro is up but
+ * advertises 0 Hermes targets (AppDetachedError), so there's no target to connect
+ * to. Cold-restart the app (terminate+launch) → reconnect → confirm via a REAL CDP
+ * liveness probe. Bounded to maxPerSession CONSECUTIVE failures (default 3; resets
+ * on success and on device_snapshot action=open). SKIPS when a Maestro flow holds
+ * the arbiter flow lease (don't yank the app from a flow) and when opted out via
+ * RN_AUTO_RELAUNCH_ON_DETACH=0.
+ *
+ * Reverse-risk note: a cold restart destroys in-progress JS state. That's
+ * acceptable ONLY because this fires when the app is ALREADY detached (the session
+ * is already broken) — never against a working app. The opt-out exists for users
+ * who'd rather recover manually.
+ */
+export async function recoverDetached(
+  client: CDPClient,
+  deps: RecoverDetachedDeps = {},
+): Promise<DetachedRecoveryResult> {
+  const max = deps.maxPerSession ?? DEFAULT_MAX_PER_SESSION;
+  const isFlowActive = deps.isFlowActive ?? (() => arbiter.snapshot.flowLeaseHeldBy !== null);
+  const isOptedOut = deps.isOptedOut ?? (() => process.env.RN_AUTO_RELAUNCH_ON_DETACH === '0');
+
+  // No-op early returns — these must NOT consume the budget.
+  if (isOptedOut()) {
+    return { recovered: false, reason: 'opted-out', attempt: attempts };
+  }
+  if (isFlowActive()) {
+    return { recovered: false, reason: 'flow-active', attempt: attempts };
+  }
+  const session = (deps.getSession ?? getActiveSession)();
+  if (!session?.deviceId || !session?.appId) {
+    return { recovered: false, reason: 'no-session', attempt: attempts };
+  }
+  if ((session.platform ?? 'ios') !== 'ios') {
+    return { recovered: false, reason: 'unsupported-platform', attempt: attempts };
+  }
+  if (attempts >= max) {
+    return { recovered: false, reason: 'budget-exhausted', attempt: attempts };
+  }
+
+  // A real, side-effecting attempt.
+  attempts += 1;
+  const attempt = attempts;
+  const udid = session.deviceId;
+  const appId = session.appId;
+
+  const stopFastRunner = deps.stopFastRunner ?? defaultStopFastRunner;
+  const relaunchApp = deps.relaunchApp ?? defaultRelaunchApp;
+  const reconnect = deps.reconnect ?? (() => client.softReconnect());
+  const probeAlive = deps.probeAlive ?? (async () => (await probeFreshness(client)).fresh);
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+
+  stopFastRunner();
+  let relaunchError: string | undefined;
+  try {
+    await relaunchApp(udid, appId);
+  } catch (e) {
+    // The terminate step is already swallowed inside defaultRelaunchApp, so a throw
+    // here is a real `simctl launch` failure (bad UDID/bundleId, sim unavailable).
+    // Capture it (Codex F3) so the verdict is actionable, not a bare "still-detached".
+    relaunchError = e instanceof Error ? e.message : String(e);
+  }
+  await sleep(RELAUNCH_SETTLE_MS);
+  try { await reconnect(); } catch { /* best-effort; the liveness probe is the verdict */ }
+
+  if (await probeAlive()) {
+    attempts = 0; // success bounds CONSECUTIVE detaches, not lifetime
+    return { recovered: true, reason: 'recovered', attempt };
+  }
+  return { recovered: false, reason: 'still-detached', attempt, ...(relaunchError ? { error: relaunchError } : {}) };
+}

--- a/scripts/cdp-bridge/src/tools/device-session.ts
+++ b/scripts/cdp-bridge/src/tools/device-session.ts
@@ -14,6 +14,7 @@ import { markCdpStale } from '../cdp/recovery.js';
 import { detectAndroidExternalRunner, detectIosExternalRunner, foreignRunnerNotice } from '../runners/external-runner-detect.js';
 import { ensureSingleRunner } from '../runners/ensure-single-runner.js';
 import { resetWedgeRecoveryCounter } from '../cdp/recover-wedge.js';
+import { resetDetachedRecoveryCounter } from '../cdp/recover-detached.js';
 import type { ToolResult } from '../utils.js';
 import { okResult, failResult, warnResult } from '../utils.js';
 import { resolveBundleId } from '../project-config.js';
@@ -256,6 +257,7 @@ export function createDeviceSnapshotHandler(): (args: SnapshotArgs) => Promise<T
         // the wedge-recovery budget. Placed AFTER the device-lock conflict
         // early-return so a refused DEVICE_BUSY open does NOT reset it.
         resetWedgeRecoveryCounter();
+        resetDetachedRecoveryCounter(); // GH #208 (RC3): fresh session clears the auto-relaunch budget too
 
         // GH#202 Phase 1: enforce a single iOS interaction runner. The UDID is
         // known here (device-open), so scope-kill any stale AgentDeviceRunner

--- a/scripts/cdp-bridge/src/tools/status.ts
+++ b/scripts/cdp-bridge/src/tools/status.ts
@@ -7,6 +7,9 @@ import { getSessionReloadCount } from './reload.js';
 import { supportsNativeMultiDebugger } from '../cdp/multiplexer.js';
 import { arbiter } from '../lifecycle/device-arbiter.js';
 import { recoverWedge } from '../cdp/recover-wedge.js';
+import { recoverDetached } from '../cdp/recover-detached.js';
+import type { DetachedRecoveryResult } from '../cdp/recover-detached.js';
+import { AppDetachedError } from '../cdp/discovery.js';
 
 // M10 / Phase 110: narrow `appInfo.architecture` to the StatusResult union.
 // Any unexpected value collapses to 'unknown' — defensive against future
@@ -110,7 +113,9 @@ export function createStatusHandler(
   getClient: () => CDPClient,
   setClient: (c: CDPClient) => void,
   createClient: (port: number) => CDPClient,
+  deps: { recoverDetached?: typeof recoverDetached } = {},
 ) {
+  const recoverDetachedFn = deps.recoverDetached ?? recoverDetached;
   return async (args: { metroPort?: number; platform?: string; resetArbiter?: boolean }) => {
     if (args?.resetArbiter) {
       const arbiterReset = arbiter.reset('manual via cdp_status');
@@ -143,7 +148,26 @@ export function createStatusHandler(
             await handleDevClientPicker();
           }
         } catch { /* fall through to autoConnect */ }
-        await client.autoConnect(args.metroPort, args.platform, 'status');
+        // GH #208 (RC1): when a reconnect storm is in flight, bare autoConnect
+        // throws "Already connecting to Metro..." (connect.ts guard) and dead-ends
+        // cdp_status — the one tool meant to diagnose+recover. Preempt the storm
+        // via softReconnect (the existing 3s softReconnectRequested handshake) for
+        // one fresh, real connection attempt instead of refusing.
+        // GH #208 review (Codex/Gemini F1): softReconnect reuses the storm's
+        // existing target/filters, so only preempt in place when the caller hasn't
+        // pinned a different target. If they pinned an explicit platform, tear the
+        // storm down first (mirrors the metroPort-change path above) so autoConnect
+        // honors it instead of returning wrong-platform data.
+        if (client.reconnectState.active && !args.platform) {
+          await client.softReconnect();
+        } else {
+          if (client.reconnectState.active) {
+            await client.disconnect();
+            client = createClient(client.metroPort);
+            setClient(client);
+          }
+          await client.autoConnect(args.metroPort, args.platform, 'status');
+        }
       } else if (args.platform) {
         // GH #21: Already connected — check if the current target matches the requested platform
         const currentTarget = client.connectedTarget;
@@ -264,6 +288,54 @@ export function createStatusHandler(
       return okResult(status, autoRecoveredMessage ? { meta: { autoRecovered: autoRecoveredMessage } } : undefined);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+
+      // GH #208 (RC3): Metro is up but the app detached (0 Hermes targets). Auto
+      // cold-restart it (bounded, arbiter-aware, opt-out RN_AUTO_RELAUNCH_ON_DETACH=0),
+      // then reconnect and return a fresh status. On failure, surface a legible
+      // state (reconnect attempt count + escape hatch) rather than a misleading error.
+      if (err instanceof AppDetachedError) {
+        // GH #208 review (Codex F2): RC3 auto-relaunch is iOS-only and acts on the
+        // active device session. If the caller explicitly pinned a non-iOS platform,
+        // do NOT cold-restart the iOS session they didn't ask about — surface the
+        // detached state instead.
+        const callerPinnedNonIos = !!args.platform && args.platform.toLowerCase() !== 'ios';
+        const recovery: DetachedRecoveryResult = callerPinnedNonIos
+          ? { recovered: false, reason: 'unsupported-platform', attempt: 0 }
+          : await recoverDetachedFn(getClient());
+        if (recovery.recovered) {
+          // GH #208 review (Gemini F2): never let a post-reconnect status read throw
+          // out of the catch — degrade to a minimal warn instead of crashing the tool.
+          try {
+            return warnResult(
+              await buildStatusResult(getClient()),
+              `App had detached (Metro up, 0 Hermes targets) — auto-relaunched and reconnected (attempt ${recovery.attempt}).`,
+            );
+          } catch {
+            return warnResult(
+              { recovered: true },
+              `App had detached (Metro up, 0 Hermes targets) — auto-relaunched and reconnected (attempt ${recovery.attempt}), but reading the full status failed; retry cdp_status.`,
+            );
+          }
+        }
+        const detachedHint =
+          recovery.reason === 'flow-active'
+            ? 'A Maestro flow is running — skipped auto-relaunch. Wait for the flow to finish, then retry cdp_status.'
+            : recovery.reason === 'opted-out'
+              ? 'Auto-relaunch is disabled (RN_AUTO_RELAUNCH_ON_DETACH=0). Relaunch the app manually, or call cdp_restart(hardReset=true).'
+              : recovery.reason === 'budget-exhausted'
+                ? 'Auto-relaunch budget exhausted this session. Relaunch the app manually, or call cdp_restart(hardReset=true).'
+                : recovery.reason === 'no-session'
+                  ? 'No active device session to relaunch from. Relaunch the app on the simulator, or call cdp_restart(hardReset=true).'
+                  : recovery.reason === 'unsupported-platform'
+                    ? 'Auto-relaunch is iOS-only here. Relaunch the app on the device, then retry cdp_status.'
+                    : 'Auto-relaunch did not restore the app. Relaunch it manually, or call cdp_restart(hardReset=true).';
+        const errSuffix = recovery.error ? ` (relaunch error: ${recovery.error})` : '';
+        return failResult(`${message} ${detachedHint}${errSuffix}`, 'APP_DETACHED', {
+          reconnect: getClient().reconnectState,
+          recovery,
+        });
+      }
+
       // GH #184: the status-scoped connect aborted fast because React was
       // unreachable on a non-Hermes target (picker blocking the bundle, or it's
       // still building). The message is already actionable; still attempt the
@@ -297,7 +369,11 @@ export function createStatusHandler(
         }
       } catch { /* picker check failed, return original error */ }
 
-      return pickerBlocking ? failResult(message, 'PICKER_BLOCKING') : failResult(message);
+      // GH #208 (RC1): carry the reconnect attempt count so a connect failure
+      // during a reconnect storm reads as "attempt N/30", not a dead end.
+      return pickerBlocking
+        ? failResult(message, 'PICKER_BLOCKING')
+        : failResult(message, { reconnect: getClient().reconnectState });
     }
   };
 }

--- a/scripts/cdp-bridge/src/types.ts
+++ b/scripts/cdp-bridge/src/types.ts
@@ -160,6 +160,7 @@ export type ToolErrorCode =
   | 'STALE_TARGET'
   | 'HELPERS_STALE'
   | 'RECONNECT_TIMEOUT'
+  | 'APP_DETACHED'              // GH #208 (RC2/RC3): Metro up but 0 Hermes targets (app detached)
   | 'NOT_CONNECTED'
   | 'HELPERS_NOT_INJECTED'
   // M6 / Phase 112 (D669): cdp_record_test_* tool family.

--- a/scripts/cdp-bridge/test/integration/cdp-client-lifecycle.test.js
+++ b/scripts/cdp-bridge/test/integration/cdp-client-lifecycle.test.js
@@ -123,8 +123,11 @@ describe('CDPClient lifecycle', () => {
         () => client.autoConnect(emptyPort),
         (err) => {
           assert.ok(err instanceof Error);
+          // GH #208 (RC2): a Metro-up-but-0-targets autoConnect now rejects with the
+          // typed AppDetachedError ("…advertises 0 Hermes debug targets…"); the
+          // genuine no-Metro case still surfaces "Metro not found".
           assert.ok(
-            err.message.includes('No Hermes') || err.message.includes('Metro not found'),
+            err.name === 'AppDetachedError' || err.message.includes('Metro not found'),
             `Unexpected error: ${err.message}`,
           );
           return true;

--- a/scripts/cdp-bridge/test/unit/gh-208-app-detached-error.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-208-app-detached-error.test.js
@@ -1,0 +1,47 @@
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { discover, AppDetachedError } from '../../dist/cdp/discovery.js';
+
+const realFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = realFetch; });
+
+// metroPort: the port whose /status returns `packager-status:running` (null = none).
+// targets: the array returned by that port's /json/list.
+function mockFetch({ metroPort, targets }) {
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.endsWith('/status')) {
+      const isMetro = metroPort != null && u.includes(`:${metroPort}/`);
+      return { ok: true, text: async () => (isMetro ? 'packager-status:running' : '') };
+    }
+    if (u.endsWith('/json/list')) {
+      return { ok: true, json: async () => targets };
+    }
+    throw new Error('unexpected fetch url: ' + u);
+  };
+}
+
+// RC2 (GH #208): Metro up but 0 Hermes targets must throw a distinct, typed
+// AppDetachedError — NOT the generic "No Hermes debug target found" and
+// crucially NOT "Metro not found" (the reporter's misleading symptom: the
+// real cause was a detached app, while the error claimed Metro was missing).
+test('discover throws AppDetachedError when Metro is up but advertises 0 targets', async () => {
+  mockFetch({ metroPort: 8081, targets: [] });
+  await assert.rejects(
+    () => discover(8081),
+    (err) => {
+      assert.ok(err instanceof AppDetachedError, 'error should be an AppDetachedError instance');
+      assert.equal(err.name, 'AppDetachedError', 'error name should be AppDetachedError');
+      assert.equal(err.port, 8081, 'should carry the Metro port it found');
+      assert.match(err.message, /0 Hermes|not attached|detached/i);
+      assert.doesNotMatch(err.message, /Metro not found/i, 'must NOT claim Metro is missing');
+      return true;
+    },
+  );
+});
+
+// Regression guard: the genuine "no Metro on any port" case keeps its message.
+test('discover still throws "Metro not found" when no port serves Metro', async () => {
+  mockFetch({ metroPort: null, targets: [] });
+  await assert.rejects(() => discover(8081), /Metro not found on ports/);
+});

--- a/scripts/cdp-bridge/test/unit/gh-208-recover-detached.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-208-recover-detached.test.js
@@ -1,0 +1,128 @@
+// GH #208 (RC3): bounded auto-relaunch recovery for the DETACHED-app case
+// (Metro up, 0 Hermes targets). Mirrors recover-wedge's safety scaffolding
+// (consecutive-attempt budget, arbiter flow-lease skip, session resolution,
+// liveness-probe confirmation) BUT cold-restarts (terminate+launch) instead of
+// recover-wedge's bare launch — the app isn't backgrounded, it's gone. Adds an
+// opt-out (RN_AUTO_RELAUNCH_ON_DETACH=0) because a cold restart destroys JS
+// state (acceptable here only because the session is ALREADY broken).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  recoverDetached, resetDetachedRecoveryCounter, defaultRelaunchApp,
+} from '../../dist/cdp/recover-detached.js';
+
+function baseDeps(over = {}) {
+  const calls = [];
+  return {
+    calls,
+    deps: {
+      getSession: () => ({ deviceId: 'UDID-A', appId: 'com.example.app', platform: 'ios' }),
+      isFlowActive: () => false,
+      isOptedOut: () => false,
+      relaunchApp: async (udid, appId) => { calls.push(`relaunch:${udid}:${appId}`); },
+      stopFastRunner: () => calls.push('stop'),
+      reconnect: async () => { calls.push('reconnect'); },
+      probeAlive: async () => true,
+      sleep: async () => {},
+      maxPerSession: 3,
+      ...over,
+    },
+  };
+}
+
+test('recoverDetached: parks runner, cold-restarts, reconnects, recovers (happy path + order)', async () => {
+  resetDetachedRecoveryCounter();
+  const { calls, deps } = baseDeps();
+  const r = await recoverDetached({}, deps);
+  assert.equal(r.recovered, true);
+  assert.equal(r.reason, 'recovered');
+  assert.equal(r.attempt, 1);
+  assert.deepEqual(calls, ['stop', 'relaunch:UDID-A:com.example.app', 'reconnect']);
+});
+
+test('recoverDetached: liveness probe FALSE after relaunch → still-detached', async () => {
+  resetDetachedRecoveryCounter();
+  const { deps } = baseDeps({ probeAlive: async () => false });
+  const r = await recoverDetached({}, deps);
+  assert.equal(r.recovered, false);
+  assert.equal(r.reason, 'still-detached');
+});
+
+test('recoverDetached: SKIPS when a flow lease is held (no device calls, no budget burn)', async () => {
+  resetDetachedRecoveryCounter();
+  const { calls, deps } = baseDeps({ isFlowActive: () => true });
+  const r = await recoverDetached({}, deps);
+  assert.equal(r.reason, 'flow-active');
+  assert.equal(calls.length, 0);
+});
+
+test('recoverDetached: SKIPS when opted out (RN_AUTO_RELAUNCH_ON_DETACH=0) — no device calls, no budget burn', async () => {
+  resetDetachedRecoveryCounter();
+  const { calls, deps } = baseDeps({ isOptedOut: () => true });
+  const r = await recoverDetached({}, deps);
+  assert.equal(r.reason, 'opted-out');
+  assert.equal(calls.length, 0);
+  // Budget intact: the next real attempt is still attempt 1.
+  const real = await recoverDetached({}, baseDeps({ probeAlive: async () => false }).deps);
+  assert.equal(real.attempt, 1);
+});
+
+test('recoverDetached: no session → no-session; Android → unsupported-platform; neither burns budget', async () => {
+  resetDetachedRecoveryCounter();
+  const noSess = await recoverDetached({}, baseDeps({ getSession: () => null }).deps);
+  assert.equal(noSess.reason, 'no-session');
+  const android = await recoverDetached({}, baseDeps({ getSession: () => ({ deviceId: 'X', appId: 'a', platform: 'android' }) }).deps);
+  assert.equal(android.reason, 'unsupported-platform');
+  const real = await recoverDetached({}, baseDeps({ probeAlive: async () => false }).deps);
+  assert.equal(real.attempt, 1);
+});
+
+test('recoverDetached: caps CONSECUTIVE failures; a success resets the budget', async () => {
+  resetDetachedRecoveryCounter();
+  const failing = baseDeps({ probeAlive: async () => false, maxPerSession: 2 }).deps;
+  assert.equal((await recoverDetached({}, failing)).reason, 'still-detached');     // attempt 1
+  assert.equal((await recoverDetached({}, failing)).reason, 'still-detached');     // attempt 2
+  assert.equal((await recoverDetached({}, failing)).reason, 'budget-exhausted');   // refused (2 >= 2)
+
+  resetDetachedRecoveryCounter();
+  assert.equal((await recoverDetached({}, failing)).reason, 'still-detached');     // attempt 1
+  const ok = await recoverDetached({}, baseDeps({ probeAlive: async () => true, maxPerSession: 2 }).deps); // attempt 2 → success
+  assert.equal(ok.recovered, true);
+  assert.equal((await recoverDetached({}, failing)).reason, 'still-detached');     // attempt 1 again → success reset the count
+});
+
+test('recoverDetached: relaunch throws + probe FALSE → still-detached (no false positive)', async () => {
+  resetDetachedRecoveryCounter();
+  const { deps } = baseDeps({ relaunchApp: async () => { throw new Error('simctl boom'); }, probeAlive: async () => false });
+  const r = await recoverDetached({}, deps);
+  assert.equal(r.recovered, false);
+  assert.equal(r.reason, 'still-detached');
+});
+
+// The distinguishing behavior vs recover-wedge: a COLD restart (terminate THEN
+// launch), not a bare launch. terminate may fail when the app isn't running —
+// that's expected for a detached app and must be tolerated.
+test('defaultRelaunchApp: cold-restart issues simctl terminate THEN launch', async () => {
+  const execCalls = [];
+  const fakeExec = async (bin, args) => { execCalls.push([bin, ...args].join(' ')); return { stdout: '', stderr: '' }; };
+  await defaultRelaunchApp('UDID-A', 'com.example.app', fakeExec);
+  assert.deepEqual(execCalls, [
+    'xcrun simctl terminate UDID-A com.example.app',
+    'xcrun simctl launch UDID-A com.example.app',
+  ]);
+});
+
+test('defaultRelaunchApp: tolerates a terminate error (app not running) and still launches', async () => {
+  const execCalls = [];
+  const fakeExec = async (bin, args) => {
+    const cmd = [bin, ...args].join(' ');
+    execCalls.push(cmd);
+    if (cmd.includes('terminate')) throw new Error('found no matching processes');
+    return { stdout: '', stderr: '' };
+  };
+  await defaultRelaunchApp('UDID-A', 'com.example.app', fakeExec);
+  assert.deepEqual(execCalls, [
+    'xcrun simctl terminate UDID-A com.example.app',
+    'xcrun simctl launch UDID-A com.example.app',
+  ]);
+});

--- a/scripts/cdp-bridge/test/unit/gh-208-review-fixes.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-208-review-fixes.test.js
@@ -1,0 +1,101 @@
+// GH #208 multi-review (Codex + Gemini) follow-up fixes:
+// F1: storm-preempt must honor an explicit args.platform (tear down + autoConnect, not softReconnect).
+// F2: AppDetachedError must NOT cold-restart iOS when the caller pinned a non-iOS platform.
+// F3: recoverDetached must surface a simctl launch error (not hide it behind "still-detached").
+// F4: the recovery-success path must not throw out of the catch if buildStatusResult fails.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createMockClient } from '../helpers/mock-cdp-client.js';
+import { parseEnvelope } from '../helpers/result-helpers.js';
+import { createStatusHandler } from '../../dist/tools/status.js';
+import { AppDetachedError } from '../../dist/cdp/discovery.js';
+import { recoverDetached, resetDetachedRecoveryCounter } from '../../dist/cdp/recover-detached.js';
+import {
+  _setHasSessionForTest,
+  _resetHasSessionForTest,
+} from '../../dist/tools/dev-client-picker.js';
+
+function makeStatusProbe() {
+  return JSON.stringify({ appInfo: { __DEV__: true }, errorCount: 0, fiberTree: true, hasRedBox: false, helpersLoaded: true });
+}
+
+// F1
+test('RC1 honors an explicit platform during a storm: tears down + autoConnect, not softReconnect', async () => {
+  _setHasSessionForTest(false);
+  const events = [];
+  const client = createMockClient({
+    _isConnected: false,
+    _helpersInjected: true,
+    reconnectState: { active: true, lastAttempt: null, attemptCount: 5 },
+    disconnect: async () => { events.push('disconnect'); client._isConnected = false; },
+    autoConnect: async () => { events.push('autoConnect'); client._isConnected = true; client._helpersInjected = true; return 'connected'; },
+    softReconnect: async () => { events.push('softReconnect'); client._isConnected = true; return 'reconnected'; },
+    evaluate: async () => ({ value: makeStatusProbe() }),
+  });
+  try {
+    const handler = createStatusHandler(() => client, () => {}, () => client);
+    parseEnvelope(await handler({ platform: 'ios' }));
+    assert.ok(!events.includes('softReconnect'), 'must NOT softReconnect when a platform is explicitly pinned during a storm');
+    assert.ok(events.includes('autoConnect'), 'must autoConnect (after teardown) to honor the pinned platform');
+  } finally { _resetHasSessionForTest(); }
+});
+
+// F2
+test('AppDetachedError does NOT auto-relaunch when the caller pinned a non-iOS platform', async () => {
+  _setHasSessionForTest(false);
+  let recoverCalled = 0;
+  const client = createMockClient({
+    _isConnected: false,
+    _helpersInjected: true,
+    reconnectState: { active: false, lastAttempt: null, attemptCount: 0 },
+    autoConnect: async () => { throw new AppDetachedError(8081); },
+  });
+  try {
+    const handler = createStatusHandler(() => client, () => {}, () => client, {
+      recoverDetached: async () => { recoverCalled++; return { recovered: true, reason: 'recovered', attempt: 1 }; },
+    });
+    const env = parseEnvelope(await handler({ platform: 'android' }));
+    assert.equal(recoverCalled, 0, 'must NOT cold-restart the iOS session when android was requested');
+    assert.equal(env.ok, false);
+    assert.equal(env.code, 'APP_DETACHED');
+    assert.match(env.error, /iOS-only|device/i, 'should explain auto-relaunch is iOS-only');
+  } finally { _resetHasSessionForTest(); }
+});
+
+// F3
+test('recoverDetached surfaces a simctl launch error instead of hiding it behind still-detached', async () => {
+  resetDetachedRecoveryCounter();
+  const r = await recoverDetached({}, {
+    getSession: () => ({ deviceId: 'U', appId: 'a', platform: 'ios' }),
+    isFlowActive: () => false,
+    isOptedOut: () => false,
+    stopFastRunner: () => {},
+    relaunchApp: async () => { throw new Error('Invalid device: bad UDID'); },
+    reconnect: async () => {},
+    probeAlive: async () => false,
+    sleep: async () => {},
+  });
+  assert.equal(r.recovered, false);
+  assert.equal(r.reason, 'still-detached');
+  assert.match(r.error ?? '', /bad UDID/, 'the launch error must be surfaced on the result');
+});
+
+// F4
+test('recovery-success path returns a result (not a throw) when buildStatusResult fails', async () => {
+  _setHasSessionForTest(false);
+  const client = createMockClient({
+    _isConnected: false,
+    _helpersInjected: true,
+    reconnectState: { active: false, lastAttempt: null, attemptCount: 0 },
+    autoConnect: async () => { throw new AppDetachedError(8081); },
+    evaluate: async () => { throw new Error('evaluate exploded post-reconnect'); },
+  });
+  try {
+    const handler = createStatusHandler(() => client, () => {}, () => client, {
+      recoverDetached: async (c) => { c._isConnected = true; c._helpersInjected = true; return { recovered: true, reason: 'recovered', attempt: 1 }; },
+    });
+    const env = parseEnvelope(await handler({}));
+    assert.equal(env.ok, true, 'must return a degraded ok/warn result, not throw out of the catch');
+    assert.match(env.meta.warning, /auto-relaunch|retry/i);
+  } finally { _resetHasSessionForTest(); }
+});

--- a/scripts/cdp-bridge/test/unit/gh-208-status-detached-recovery.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-208-status-detached-recovery.test.js
@@ -1,0 +1,70 @@
+// GH #208 (RC2+RC3 wiring): when connect throws AppDetachedError (Metro up, 0
+// Hermes targets), cdp_status routes into the bounded auto-relaunch recovery.
+// On success it returns a fresh status (warn); on refusal it returns a legible
+// APP_DETACHED failure carrying the reconnect attempt count + an escape hatch —
+// never a misleading "Metro not found".
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createMockClient } from '../helpers/mock-cdp-client.js';
+import { parseEnvelope } from '../helpers/result-helpers.js';
+import { createStatusHandler } from '../../dist/tools/status.js';
+import { AppDetachedError } from '../../dist/cdp/discovery.js';
+import {
+  _setHasSessionForTest,
+  _resetHasSessionForTest,
+} from '../../dist/tools/dev-client-picker.js';
+
+function makeStatusProbe() {
+  return JSON.stringify({
+    appInfo: { __DEV__: true },
+    errorCount: 0,
+    fiberTree: true,
+    hasRedBox: false,
+    helpersLoaded: true,
+  });
+}
+
+test('cdp_status: AppDetachedError → auto-relaunch recovers → fresh status (warn)', async () => {
+  _setHasSessionForTest(false);
+  const client = createMockClient({
+    _isConnected: false,
+    _helpersInjected: true,
+    reconnectState: { active: false, lastAttempt: null, attemptCount: 0 },
+    autoConnect: async () => { throw new AppDetachedError(8081); },
+    evaluate: async () => ({ value: makeStatusProbe() }),
+  });
+  try {
+    const handler = createStatusHandler(() => client, () => {}, () => client, {
+      recoverDetached: async (c) => { c._isConnected = true; c._helpersInjected = true; return { recovered: true, reason: 'recovered', attempt: 1 }; },
+    });
+    const env = parseEnvelope(await handler({}));
+    assert.equal(env.ok, true, 'recovered detach should be a successful (warn) status');
+    assert.match(env.meta.warning, /auto-relaunched|detached/i);
+  } finally {
+    _resetHasSessionForTest();
+  }
+});
+
+test('cdp_status: AppDetachedError → recovery refused (opted-out) → legible APP_DETACHED failure with reconnect context', async () => {
+  _setHasSessionForTest(false);
+  const client = createMockClient({
+    _isConnected: false,
+    _helpersInjected: true,
+    reconnectState: { active: true, lastAttempt: '2026-06-07T00:00:00.000Z', attemptCount: 7 },
+    // active storm → cdp_status uses softReconnect (RC1); it throws the detached error.
+    softReconnect: async () => { throw new AppDetachedError(8081); },
+  });
+  try {
+    const handler = createStatusHandler(() => client, () => {}, () => client, {
+      recoverDetached: async () => ({ recovered: false, reason: 'opted-out', attempt: 0 }),
+    });
+    const env = parseEnvelope(await handler({}));
+    assert.equal(env.ok, false);
+    assert.equal(env.code, 'APP_DETACHED');
+    assert.match(env.error, /0 Hermes|detached/i, 'must explain the real cause');
+    assert.match(env.error, /RN_AUTO_RELAUNCH_ON_DETACH|manually|cdp_restart/i, 'must offer an escape hatch');
+    assert.equal(env.meta.reconnect.attemptCount, 7, 'must surface the reconnect attempt count for legibility');
+  } finally {
+    _resetHasSessionForTest();
+  }
+});

--- a/scripts/cdp-bridge/test/unit/gh-208-status-storm-preempt.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-208-status-storm-preempt.test.js
@@ -1,0 +1,64 @@
+// GH #208 (RC1): during an in-flight reconnect storm, cdp_status must NOT call
+// bare autoConnect — its guard throws "Already connecting to Metro..." which
+// dead-ends the one tool meant to diagnose+recover. Instead it preempts the
+// storm via softReconnect (the existing 3s softReconnectRequested handshake),
+// getting one fresh, real connection attempt.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createMockClient } from '../helpers/mock-cdp-client.js';
+import { expectOk } from '../helpers/result-helpers.js';
+import { createStatusHandler } from '../../dist/tools/status.js';
+import {
+  _setHasSessionForTest,
+  _resetHasSessionForTest,
+} from '../../dist/tools/dev-client-picker.js';
+
+function makeStatusProbe(extraAppInfo = {}) {
+  return JSON.stringify({
+    appInfo: { __DEV__: true, ...extraAppInfo },
+    errorCount: 0,
+    fiberTree: true,
+    hasRedBox: false,
+    helpersLoaded: true,
+  });
+}
+
+test('cdp_status preempts an active reconnect storm via softReconnect, not bare autoConnect', async () => {
+  _setHasSessionForTest(false); // keep the dev-client picker out of the path
+  const events = [];
+  const client = createMockClient({
+    _isConnected: false,
+    _helpersInjected: true,
+    reconnectState: { active: true, lastAttempt: '2026-06-07T00:00:00.000Z', attemptCount: 12 },
+    autoConnect: async () => { events.push('autoConnect'); client._isConnected = true; client._helpersInjected = true; return 'connected'; },
+    softReconnect: async () => { events.push('softReconnect'); client._isConnected = true; client._helpersInjected = true; return 'reconnected'; },
+    evaluate: async () => ({ value: makeStatusProbe() }),
+  });
+  try {
+    const handler = createStatusHandler(() => client, () => {}, () => client);
+    expectOk(await handler({}));
+    assert.deepEqual(events, ['softReconnect'], 'a reconnect storm must be preempted via softReconnect, never bare autoConnect');
+  } finally {
+    _resetHasSessionForTest();
+  }
+});
+
+test('cdp_status uses autoConnect (not softReconnect) when disconnected with no active storm', async () => {
+  _setHasSessionForTest(false);
+  const events = [];
+  const client = createMockClient({
+    _isConnected: false,
+    _helpersInjected: true,
+    reconnectState: { active: false, lastAttempt: null, attemptCount: 0 },
+    autoConnect: async () => { events.push('autoConnect'); client._isConnected = true; client._helpersInjected = true; return 'connected'; },
+    softReconnect: async () => { events.push('softReconnect'); client._isConnected = true; client._helpersInjected = true; return 'reconnected'; },
+    evaluate: async () => ({ value: makeStatusProbe() }),
+  });
+  try {
+    const handler = createStatusHandler(() => client, () => {}, () => client);
+    expectOk(await handler({}));
+    assert.deepEqual(events, ['autoConnect'], 'a normal disconnected status should use autoConnect');
+  } finally {
+    _resetHasSessionForTest();
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #208 — the "CDP connection wedge". One issue hiding **three root causes** on the tool's core `connect → introspect → interact` path (Kano `kano:must-be`):

- **RC1 — reconnect-storm wedge.** When the app detaches but Metro stays up, the WS-close reconnect loop holds `isReconnecting()` true for up to ~12 min (30 attempts × 30s cap, then re-armed indefinitely by the background poll). `autoConnect`'s guard threw **"Already connecting to Metro..."** for every `cdp_status`/`cdp_*` call in that window. `cdp_status` now **preempts** the storm via `softReconnect()` (the existing 3s `softReconnectRequested` handshake) and surfaces the live `reconnectState` (attempt N/30) on failure.
- **RC2 — misleading error.** "Metro up but 0 Hermes targets" now throws a typed **`AppDetachedError`**, distinct from the genuine "Metro not found" (reserved for `discoverMetroPort === null`).
- **RC3 — no auto-recovery.** New **`recoverDetached()`** cold-restarts a detached iOS app (`simctl terminate` + `launch`) → reconnect → real CDP liveness probe. Bounded to **3 consecutive attempts/session**, **arbiter-aware** (skips while a Maestro flow holds the lease), **iOS-only**, opt-out via **`RN_AUTO_RELAUNCH_ON_DETACH=0`**.

## Why auto-relaunch is safe (Kano *Reverse* check)

A cold restart destroys in-progress JS state — the same shape as the auto-`clearState` *Reverse* signal flagged in the 2026-06-04 Kano categorization. It's acceptable here **only because it fires when the app is already detached** (0 targets — the session is already broken), never against a working app. recover-wedge keeps bare-launch (preserve state) for the paused case; recover-detached cold-restarts because there's nothing to preserve.

## Multi-review hardening (Codex + Gemini)

A pre-merge multi-LLM review caught a consistency gap. **4 findings fixed, 4 refuted** with codebase-grounded reasoning:

- ✅ `cdp_status` honors an explicit `args.platform` during a storm (tears down + reconnects, doesn't reuse the storm's target).
- ✅ Auto-relaunch is **skipped when the caller pinned a non-iOS platform** (never cold-restarts an unrelated iOS session).
- ✅ `simctl launch` failures are **surfaced**, not hidden behind "still detached".
- ✅ The post-recovery status read can no longer throw out of the handler.
- ✋ Refuted: liveness false-positive (`probeFreshness` self-guards on `isConnected` + `terminate` kills the old WS), `softReconnect` stale-URL (it re-discovers via `/json/list`).

## Testing

- **19 new unit tests**, all TDD red-first.
- Full suite **1729/1729**, `tsc --noEmit` clean.
- **Live false-positive guard** on a booted iPhone 17 Pro / RN 0.85: the real `discover()` against Metro does **not** fire `AppDetachedError` while a target is present — it won't cold-restart a working app.

## Scoping

Targets the reporter's **literal-0-targets** case (RN 0.83). The RN-0.85 "1 C++ Bridgeless target, 0 Hermes" flavor still passes `filterValidTargets`, so `AppDetachedError` does **not** fire there — that remains B156/B184 + recover-wedge territory. Deferred.

Closes #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
