### PR TITLE
fix(cdp-bridge): recover orphaned single-instance bridge lock (#182)

### DIFF
--- a/.changeset/gh-182-orphaned-bridge-lock.md
+++ b/.changeset/gh-182-orphaned-bridge-lock.md
@@ -1,0 +1,15 @@
+---
+"rn-dev-agent-cdp": patch
+"rn-dev-agent-plugin": patch
+---
+
+Fix #182: the CDP MCP no longer fails with `-32000: Connection closed` when an orphaned bridge from a dead Claude Code session holds the single-instance lock.
+
+Root cause: when CC dies abnormally (SIGKILL/crash/window-close on macOS) without closing the child's stdin or signaling it, the bridge becomes a **live orphan** — still running, still holding the project lock. The existing reclaim (PID-dead / mtime>24h / process-name) can't recover a *live* owner, so the next session hard-failed for up to 24h. Four composing fixes:
+
+- **Parent-death self-exit (prevent).** A `getppid()` poll (`lifecycle/parent-watch.ts`) captures the bridge's PPID at startup and self-exits (releasing the lock) when it *changes* — i.e. the original Claude Code host died and the bridge was reparented. This catches the abnormal-death cases stdin-EOF + signal handlers miss. It compares against the startup PPID rather than testing `=== 1` so a bridge whose host runs as PID 1 (a container with no init system) is never falsely killed.
+- **Orphaned-owner reclaim (recover).** `Lockfile.isLockLive` reclaims a *live* owner whose parent **changed** from the PPID it recorded at acquire (`ps -o ppid=`) — so a new session self-heals past an existing orphan instead of hard-failing. A null PPID lookup fails safe; pre-0.39 locks with no recorded `ppid` fall back to a legacy `PPID===1` reclaim.
+- **Heartbeat (recover wedged).** The lock body carries `lastHeartbeat`, refreshed every ~10s; a live owner whose heartbeat goes stale (>90s) is wedged and reclaimable — mirroring the device-lock's self-healing. Pre-0.39 locks without `lastHeartbeat` fall back to the existing mtime check (back-compat).
+- **Usurp self-terminate (sleep/wake safety).** `Lockfile.touch()` now returns whether we still own the lock. If a contender reclaimed our slot while the laptop slept (heartbeat expired → reclaimed → we wake), the next heartbeat detects the foreign PID and self-terminates instead of running as a second bridge on the same device. This also makes the (pre-existing, non-atomic) reclaim path self-correcting within one tick.
+
+Together these eliminate the manual `kill <pid> && rm <lock>` workaround. 15 #182 unit tests (incl. container-safety, sleep/wake usurp, and a real `ps -o ppid=` check); unit suite 1744/1744; `tsc` clean. (GH #182, B185, D1246)

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -54,6 +54,7 @@ import { createConnectHandler, createDisconnectHandler, createTargetsHandler } f
 import { createRestartHandler } from './tools/restart.js';
 import { buildGracefulShutdown } from './lifecycle/graceful-shutdown.js';
 import { Lockfile, formatLockConflictMessage } from './lifecycle/lockfile.js';
+import { startParentDeathWatch } from './lifecycle/parent-watch.js';
 import { arbiterWrap } from './lifecycle/device-arbiter.js';
 import { createMaestroRunHandler } from './tools/maestro-run.js';
 import { createMaestroGenerateHandler } from './tools/maestro-generate.js';
@@ -74,15 +75,18 @@ const pkgVersion = JSON.parse(readFileSync(pkgPath, 'utf8')).version;
 // opt-out exists for CI parallelism and benchmark harnesses; documented in the conflict
 // message. Release is registered on process.exit so ALL exit paths (graceful, uncaught,
 // signal) clean up the lock.
+// GH #182: module-scoped so the parent-death watch can touch() it (heartbeat) and
+// release() it on orphan-exit. null when --no-lock (touch/release become no-ops).
+let lockfile = null;
 const noLock = process.argv.includes('--no-lock');
 if (!noLock) {
-    const lockfile = new Lockfile({ version: pkgVersion });
+    lockfile = new Lockfile({ version: pkgVersion });
     const lockResult = lockfile.acquire();
     if (lockResult.status === 'conflict') {
         process.stderr.write(formatLockConflictMessage(lockResult) + '\n');
         process.exit(11);
     }
-    process.on('exit', () => lockfile.release());
+    process.on('exit', () => lockfile?.release());
 }
 process.on('exit', () => { try {
     releaseDeviceLockForSession();
@@ -715,6 +719,28 @@ process.on('SIGUSR2', () => { logger.info('MCP', 'SIGUSR2 — hot-reload intent'
 // (passive — doesn't flip stdin into flowing mode); StdioServerTransport flips the
 // stream inside transport.start() when server.connect() runs, so 'end' fires reliably.
 process.stdin.on('end', () => { logger.info('MCP', 'stdin closed — host disconnected'); void shutdown(0); });
+// GH #182: belt-and-suspenders host-death detection + lock heartbeat. stdin-EOF +
+// signals can silently fail to fire when CC dies abnormally (SIGKILL/crash/window
+// close on macOS) without closing the child's stdin — leaving a LIVE orphan that
+// holds the single-instance lock for up to 24h (the PID-alive reclaim can't catch a
+// live process). Poll getppid(): on orphan (PPID changed from startup → parent died
+// + reparented) self-exit + release. On a live parent, refresh the lock heartbeat —
+// and if touch() reports we were usurped (a contender reclaimed our slot while the
+// laptop slept, then we woke), self-terminate so we don't run as a second bridge on
+// the same device. Unref'd timer — never keeps a should-be-dead process alive.
+const stopParentWatch = startParentDeathWatch({
+    onOrphaned: () => { logger.info('MCP', 'parent host gone (PPID changed) — exiting'); void shutdown(0); },
+    onHeartbeat: () => {
+        try {
+            if (lockfile && !lockfile.touch()) {
+                logger.info('MCP', 'single-instance lock was reclaimed by another bridge — exiting');
+                void shutdown(0);
+            }
+        }
+        catch { /* best-effort heartbeat */ }
+    },
+});
+process.on('exit', () => stopParentWatch());
 async function main() {
     logger.info('MCP', `Starting rn-dev-agent-cdp v0.9.1 (log level: ${logger.level})`);
     if (logger.logFilePath) {

--- a/scripts/cdp-bridge/dist/lifecycle/lockfile.js
+++ b/scripts/cdp-bridge/dist/lifecycle/lockfile.js
@@ -5,6 +5,10 @@ import { tmpdir, userInfo } from 'node:os';
 import { join, resolve } from 'node:path';
 const DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_PROCESS_NAME_NEEDLE = 'cdp-bridge';
+// GH #182: heartbeat-staleness window. A healthy bridge refreshes lastHeartbeat
+// well within this (index.ts touches every ~30s); a wedged bridge stops, so its
+// lock becomes reclaimable. Matches device-lock.ts's 90s.
+const DEFAULT_STALE_MS = 90_000;
 function defaultProjectRoot() {
     return process.env.CLAUDE_USER_CWD ?? process.cwd();
 }
@@ -37,6 +41,36 @@ export function defaultProcessName(pid) {
     catch {
         return null;
     }
+}
+/**
+ * GH #182: resolve a PID's parent PID via `ps -p <pid> -o ppid=`. A cdp-bridge
+ * whose PPID is 1 has been reparented to init/launchd — i.e. its Claude Code host
+ * died and it's now a live orphan. Returns null on any failure (caller fails safe:
+ * a null PPID never triggers reclaim). Mirrors defaultProcessName's `ps` usage.
+ */
+export function defaultProcessParent(pid) {
+    try {
+        const out = execFileSync('ps', ['-p', String(pid), '-o', 'ppid='], {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'ignore'],
+            timeout: 1000,
+        });
+        const ppid = parseInt(out.trim(), 10);
+        return Number.isFinite(ppid) ? ppid : null;
+    }
+    catch {
+        return null;
+    }
+}
+/**
+ * GH #182: our own parent PID, recorded at acquire. Compared later against the
+ * owner's *live* PPID — if they differ, the owner's parent (the Claude Code host)
+ * died and it was reparented, so it's a live orphan. `process.getppid` isn't on the
+ * project's `@types/node` Process type, so cast; falls back to 0 if unavailable.
+ */
+export function defaultSelfPpid() {
+    const fn = process.getppid;
+    return typeof fn === 'function' ? fn.call(process) : 0;
 }
 function hashProjectRoot(projectRoot) {
     return createHash('md5').update(resolve(projectRoot)).digest('hex').slice(0, 8);
@@ -78,8 +112,11 @@ export class Lockfile {
             clock: opts.clock ?? Date.now,
             processAlive: opts.processAlive ?? defaultProcessAlive,
             processName: opts.processName ?? defaultProcessName,
+            processParent: opts.processParent ?? defaultProcessParent,
+            selfPpid: opts.selfPpid ?? defaultSelfPpid,
             maxAgeMs: opts.maxAgeMs ?? DEFAULT_MAX_AGE_MS,
             processNameNeedle: opts.processNameNeedle ?? DEFAULT_PROCESS_NAME_NEEDLE,
+            staleMs: opts.staleMs ?? DEFAULT_STALE_MS,
         };
         this.lockPath = join(tmpDir, `rn-dev-agent-cdp-${uid}-${hash}.lock`);
     }
@@ -116,6 +153,31 @@ export class Lockfile {
         }
         this.acquired = false;
     }
+    /**
+     * GH #182: refresh our heartbeat so a healthy bridge's lock never looks stale.
+     *
+     * Returns whether we STILL own the lock. If another bridge usurped our slot — the
+     * sleep/wake case: the laptop slept, our heartbeat went stale, a new session
+     * reclaimed, and we just woke — `body.pid` is now foreign. We must NOT overwrite
+     * (that would resurrect a lock we no longer hold and produce two live bridges on
+     * one device, Gemini HIGH); we return `false` so the caller self-terminates.
+     * Best-effort on I/O (a failed write returns true — we still own it, just stale).
+     */
+    touch() {
+        if (!this.acquired)
+            return false;
+        const body = this.readExisting();
+        if (!body || body.pid !== this.opts.pid)
+            return false; // usurped → caller should exit
+        body.lastHeartbeat = this.opts.clock();
+        try {
+            writeFileSync(this.lockPath, JSON.stringify(body, null, 2), { encoding: 'utf8' });
+        }
+        catch {
+            // Best-effort: a failed heartbeat just means the lock may look stale sooner.
+        }
+        return true;
+    }
     readExisting() {
         if (!existsSync(this.lockPath))
             return null;
@@ -140,6 +202,33 @@ export class Lockfile {
         if (name !== null && !name.toLowerCase().includes(this.opts.processNameNeedle.toLowerCase())) {
             return false;
         }
+        // GH #182: a LIVE owner whose parent CHANGED since it acquired the lock was
+        // orphaned — its Claude Code host died and it was reparented. PID-alive alone
+        // can't catch a live orphan. We compare the owner's *recorded* PPID against its
+        // *live* PPID rather than testing `=== 1`, because in a container where CC runs
+        // as PID 1 (no init system) a healthy bridge legitimately has PPID 1 — testing
+        // `=== 1` would steal a healthy lock and self-exit on every tick (Gemini HIGH).
+        // A null live lookup fails safe (treated as live, never reclaimed).
+        const livePpid = this.opts.processParent(body.pid);
+        if (livePpid !== null) {
+            if (typeof body.ppid === 'number') {
+                if (livePpid !== body.ppid)
+                    return false; // parent changed → orphaned
+            }
+            else if (livePpid === 1) {
+                // Pre-0.39 lock with no recorded PPID: best-effort legacy reclaim. PPID 1
+                // means reparented to init. The container false-positive is bounded to the
+                // upgrade window (the next acquire rewrites a ppid-bearing lock).
+                return false;
+            }
+        }
+        // GH #182: a live owner whose heartbeat went stale is wedged (event loop blocked,
+        // no longer refreshing) — reclaim. Skipped for pre-0.39 locks with no
+        // lastHeartbeat (they fall back to the mtime check above).
+        if (typeof body.lastHeartbeat === 'number' &&
+            this.opts.clock() - body.lastHeartbeat > this.opts.staleMs) {
+            return false;
+        }
         return true;
     }
     ageOfLockFile() {
@@ -156,6 +245,8 @@ export class Lockfile {
             pid: this.opts.pid,
             projectRoot: this.opts.projectRoot,
             startedAt: this.opts.clock(),
+            lastHeartbeat: this.opts.clock(),
+            ppid: this.opts.selfPpid(),
             version: this.opts.version || undefined,
         };
         const dir = this.opts.tmpDir;

--- a/scripts/cdp-bridge/dist/lifecycle/parent-watch.js
+++ b/scripts/cdp-bridge/dist/lifecycle/parent-watch.js
@@ -1,0 +1,57 @@
+import { logger } from '../logger.js';
+const DEFAULT_INTERVAL_MS = 10_000;
+/**
+ * GH #182: one tick of the parent-death watch. Compares the bridge's *current* PPID
+ * against the PPID it observed at startup. If it CHANGED, the original parent (the
+ * Claude Code host) died and the bridge was reparented (to init, launchd, or a
+ * subreaper) — it's now a LIVE orphan still holding the single-instance lock, so
+ * trigger onOrphaned (self-exit). Otherwise onHeartbeat (refresh the lock).
+ *
+ * We compare against the initial PPID rather than testing `=== 1` so a bridge whose
+ * Claude Code host runs as PID 1 (a container with no init system) does NOT
+ * self-exit on every tick — its PPID is legitimately 1 and never changes while CC
+ * is alive (Gemini HIGH). Subreaper reparenting (PPID → some non-1 PID) is caught too.
+ * Pure + injectable so the decision is unit-tested without timers or real PPIDs.
+ */
+export function parentWatchTick(getppid, initialPpid, onOrphaned, onHeartbeat) {
+    if (getppid() !== initialPpid)
+        onOrphaned();
+    else
+        onHeartbeat();
+}
+/**
+ * Read the parent PID. process.getppid() exists at runtime on Node >= 16 (incl. the
+ * Node 22+ this plugin requires) but isn't on this project's @types/node Process type
+ * — the structural cast bridges that gap without an `any`. Returns 0 if unavailable;
+ * since the watch compares current-vs-initial PPID, a constant 0 simply never trips
+ * the orphan signal, so it fails safe to "parent alive".
+ */
+function defaultGetppid() {
+    const fn = process.getppid;
+    return typeof fn === 'function' ? fn.call(process) : 0;
+}
+/**
+ * GH #182: belt-and-suspenders host-death detection. The existing stdin-EOF + signal
+ * handlers can silently fail to fire when CC dies abnormally (SIGKILL/crash/window
+ * close on macOS) without closing the child's stdin — leaving a LIVE orphan that
+ * holds the project lock for up to 24h (the PID-alive reclaim can't catch it). This
+ * polls getppid() and self-exits on orphan; on a live parent it refreshes the lock
+ * heartbeat. The timer is unref'd so it never keeps a should-be-dead process alive.
+ * Returns a stop() that clears the timer (called from the shutdown path).
+ */
+export function startParentDeathWatch(opts) {
+    const getppid = opts.getppid ?? defaultGetppid;
+    // Capture the PPID at startup; "orphaned" means it later changes (parent died →
+    // reparented). This makes a CC-as-PID-1 container safe: initial PPID 1 stays 1.
+    const initialPpid = getppid();
+    const interval = setInterval(() => {
+        try {
+            parentWatchTick(getppid, initialPpid, opts.onOrphaned, opts.onHeartbeat);
+        }
+        catch (err) {
+            logger.warn('MCP', `parent-death watch tick failed: ${err instanceof Error ? err.message : err}`);
+        }
+    }, opts.intervalMs ?? DEFAULT_INTERVAL_MS);
+    interval.unref?.();
+    return () => clearInterval(interval);
+}

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -76,6 +76,7 @@ import { createConnectHandler, createDisconnectHandler, createTargetsHandler } f
 import { createRestartHandler } from './tools/restart.js';
 import { buildGracefulShutdown } from './lifecycle/graceful-shutdown.js';
 import { Lockfile, formatLockConflictMessage } from './lifecycle/lockfile.js';
+import { startParentDeathWatch } from './lifecycle/parent-watch.js';
 import { arbiterWrap } from './lifecycle/device-arbiter.js';
 import { createMaestroRunHandler } from './tools/maestro-run.js';
 import { createMaestroGenerateHandler } from './tools/maestro-generate.js';
@@ -106,15 +107,18 @@ const pkgVersion = (JSON.parse(readFileSync(pkgPath, 'utf8')) as { version: stri
 // opt-out exists for CI parallelism and benchmark harnesses; documented in the conflict
 // message. Release is registered on process.exit so ALL exit paths (graceful, uncaught,
 // signal) clean up the lock.
+// GH #182: module-scoped so the parent-death watch can touch() it (heartbeat) and
+// release() it on orphan-exit. null when --no-lock (touch/release become no-ops).
+let lockfile: Lockfile | null = null;
 const noLock = process.argv.includes('--no-lock');
 if (!noLock) {
-  const lockfile = new Lockfile({ version: pkgVersion });
+  lockfile = new Lockfile({ version: pkgVersion });
   const lockResult = lockfile.acquire();
   if (lockResult.status === 'conflict') {
     process.stderr.write(formatLockConflictMessage(lockResult) + '\n');
     process.exit(11);
   }
-  process.on('exit', () => lockfile.release());
+  process.on('exit', () => lockfile?.release());
 }
 process.on('exit', () => { try { releaseDeviceLockForSession(); } catch { /* never fail exit */ } });
 
@@ -1193,6 +1197,28 @@ process.on('SIGUSR2', () => { logger.info('MCP', 'SIGUSR2 — hot-reload intent'
 // (passive — doesn't flip stdin into flowing mode); StdioServerTransport flips the
 // stream inside transport.start() when server.connect() runs, so 'end' fires reliably.
 process.stdin.on('end', () => { logger.info('MCP', 'stdin closed — host disconnected'); void shutdown(0); });
+
+// GH #182: belt-and-suspenders host-death detection + lock heartbeat. stdin-EOF +
+// signals can silently fail to fire when CC dies abnormally (SIGKILL/crash/window
+// close on macOS) without closing the child's stdin — leaving a LIVE orphan that
+// holds the single-instance lock for up to 24h (the PID-alive reclaim can't catch a
+// live process). Poll getppid(): on orphan (PPID changed from startup → parent died
+// + reparented) self-exit + release. On a live parent, refresh the lock heartbeat —
+// and if touch() reports we were usurped (a contender reclaimed our slot while the
+// laptop slept, then we woke), self-terminate so we don't run as a second bridge on
+// the same device. Unref'd timer — never keeps a should-be-dead process alive.
+const stopParentWatch = startParentDeathWatch({
+  onOrphaned: () => { logger.info('MCP', 'parent host gone (PPID changed) — exiting'); void shutdown(0); },
+  onHeartbeat: () => {
+    try {
+      if (lockfile && !lockfile.touch()) {
+        logger.info('MCP', 'single-instance lock was reclaimed by another bridge — exiting');
+        void shutdown(0);
+      }
+    } catch { /* best-effort heartbeat */ }
+  },
+});
+process.on('exit', () => stopParentWatch());
 
 async function main() {
   logger.info('MCP', `Starting rn-dev-agent-cdp v0.9.1 (log level: ${logger.level})`);

--- a/scripts/cdp-bridge/src/lifecycle/lockfile.ts
+++ b/scripts/cdp-bridge/src/lifecycle/lockfile.ts
@@ -6,6 +6,10 @@ import { join, resolve } from 'node:path';
 
 const DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_PROCESS_NAME_NEEDLE = 'cdp-bridge';
+// GH #182: heartbeat-staleness window. A healthy bridge refreshes lastHeartbeat
+// well within this (index.ts touches every ~30s); a wedged bridge stops, so its
+// lock becomes reclaimable. Matches device-lock.ts's 90s.
+const DEFAULT_STALE_MS = 90_000;
 
 export interface LockfileOptions {
   projectRoot?: string;
@@ -16,8 +20,14 @@ export interface LockfileOptions {
   clock?: () => number;
   processAlive?: (pid: number) => boolean;
   processName?: (pid: number) => string | null;
+  /** GH #182: resolve a PID's parent PID (PPID). A live owner whose PPID *changed* from the one it recorded was orphaned (its CC died). */
+  processParent?: (pid: number) => number | null;
+  /** GH #182: our own PPID, recorded at acquire so a contender can later detect we were orphaned (parent changed). */
+  selfPpid?: () => number;
   maxAgeMs?: number;
   processNameNeedle?: string;
+  /** GH #182: heartbeat-staleness window in ms (a live owner past this is wedged → reclaimable). */
+  staleMs?: number;
 }
 
 export interface LockAcquired {
@@ -42,6 +52,10 @@ interface LockFileBody {
   projectRoot: string;
   startedAt: number;
   version?: string;
+  /** GH #182: refreshed by Lockfile.touch() while the owner is healthy; absent on pre-0.39 locks. */
+  lastHeartbeat?: number;
+  /** GH #182: the owner's PPID at acquire. A contender reclaims if the owner's *live* PPID differs (parent died → reparented). Absent on pre-0.39 locks. */
+  ppid?: number;
 }
 
 function defaultProjectRoot(): string {
@@ -76,6 +90,37 @@ export function defaultProcessName(pid: number): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * GH #182: resolve a PID's parent PID via `ps -p <pid> -o ppid=`. A cdp-bridge
+ * whose PPID is 1 has been reparented to init/launchd — i.e. its Claude Code host
+ * died and it's now a live orphan. Returns null on any failure (caller fails safe:
+ * a null PPID never triggers reclaim). Mirrors defaultProcessName's `ps` usage.
+ */
+export function defaultProcessParent(pid: number): number | null {
+  try {
+    const out = execFileSync('ps', ['-p', String(pid), '-o', 'ppid='], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 1000,
+    });
+    const ppid = parseInt(out.trim(), 10);
+    return Number.isFinite(ppid) ? ppid : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * GH #182: our own parent PID, recorded at acquire. Compared later against the
+ * owner's *live* PPID — if they differ, the owner's parent (the Claude Code host)
+ * died and it was reparented, so it's a live orphan. `process.getppid` isn't on the
+ * project's `@types/node` Process type, so cast; falls back to 0 if unavailable.
+ */
+export function defaultSelfPpid(): number {
+  const fn = (process as { getppid?: () => number }).getppid;
+  return typeof fn === 'function' ? fn.call(process) : 0;
 }
 
 function hashProjectRoot(projectRoot: string): string {
@@ -121,8 +166,11 @@ export class Lockfile {
       clock: opts.clock ?? Date.now,
       processAlive: opts.processAlive ?? defaultProcessAlive,
       processName: opts.processName ?? defaultProcessName,
+      processParent: opts.processParent ?? defaultProcessParent,
+      selfPpid: opts.selfPpid ?? defaultSelfPpid,
       maxAgeMs: opts.maxAgeMs ?? DEFAULT_MAX_AGE_MS,
       processNameNeedle: opts.processNameNeedle ?? DEFAULT_PROCESS_NAME_NEEDLE,
+      staleMs: opts.staleMs ?? DEFAULT_STALE_MS,
     };
 
     this.lockPath = join(tmpDir, `rn-dev-agent-cdp-${uid}-${hash}.lock`);
@@ -162,6 +210,29 @@ export class Lockfile {
     this.acquired = false;
   }
 
+  /**
+   * GH #182: refresh our heartbeat so a healthy bridge's lock never looks stale.
+   *
+   * Returns whether we STILL own the lock. If another bridge usurped our slot — the
+   * sleep/wake case: the laptop slept, our heartbeat went stale, a new session
+   * reclaimed, and we just woke — `body.pid` is now foreign. We must NOT overwrite
+   * (that would resurrect a lock we no longer hold and produce two live bridges on
+   * one device, Gemini HIGH); we return `false` so the caller self-terminates.
+   * Best-effort on I/O (a failed write returns true — we still own it, just stale).
+   */
+  touch(): boolean {
+    if (!this.acquired) return false;
+    const body = this.readExisting();
+    if (!body || body.pid !== this.opts.pid) return false; // usurped → caller should exit
+    body.lastHeartbeat = this.opts.clock();
+    try {
+      writeFileSync(this.lockPath, JSON.stringify(body, null, 2), { encoding: 'utf8' });
+    } catch {
+      // Best-effort: a failed heartbeat just means the lock may look stale sooner.
+    }
+    return true;
+  }
+
   private readExisting(): LockFileBody | null {
     if (!existsSync(this.lockPath)) return null;
     try {
@@ -185,6 +256,35 @@ export class Lockfile {
       return false;
     }
 
+    // GH #182: a LIVE owner whose parent CHANGED since it acquired the lock was
+    // orphaned — its Claude Code host died and it was reparented. PID-alive alone
+    // can't catch a live orphan. We compare the owner's *recorded* PPID against its
+    // *live* PPID rather than testing `=== 1`, because in a container where CC runs
+    // as PID 1 (no init system) a healthy bridge legitimately has PPID 1 — testing
+    // `=== 1` would steal a healthy lock and self-exit on every tick (Gemini HIGH).
+    // A null live lookup fails safe (treated as live, never reclaimed).
+    const livePpid = this.opts.processParent(body.pid);
+    if (livePpid !== null) {
+      if (typeof body.ppid === 'number') {
+        if (livePpid !== body.ppid) return false; // parent changed → orphaned
+      } else if (livePpid === 1) {
+        // Pre-0.39 lock with no recorded PPID: best-effort legacy reclaim. PPID 1
+        // means reparented to init. The container false-positive is bounded to the
+        // upgrade window (the next acquire rewrites a ppid-bearing lock).
+        return false;
+      }
+    }
+
+    // GH #182: a live owner whose heartbeat went stale is wedged (event loop blocked,
+    // no longer refreshing) — reclaim. Skipped for pre-0.39 locks with no
+    // lastHeartbeat (they fall back to the mtime check above).
+    if (
+      typeof body.lastHeartbeat === 'number' &&
+      this.opts.clock() - body.lastHeartbeat > this.opts.staleMs
+    ) {
+      return false;
+    }
+
     return true;
   }
 
@@ -202,6 +302,8 @@ export class Lockfile {
       pid: this.opts.pid,
       projectRoot: this.opts.projectRoot,
       startedAt: this.opts.clock(),
+      lastHeartbeat: this.opts.clock(),
+      ppid: this.opts.selfPpid(),
       version: this.opts.version || undefined,
     };
 

--- a/scripts/cdp-bridge/src/lifecycle/parent-watch.ts
+++ b/scripts/cdp-bridge/src/lifecycle/parent-watch.ts
@@ -1,0 +1,71 @@
+import { logger } from '../logger.js';
+
+const DEFAULT_INTERVAL_MS = 10_000;
+
+/**
+ * GH #182: one tick of the parent-death watch. Compares the bridge's *current* PPID
+ * against the PPID it observed at startup. If it CHANGED, the original parent (the
+ * Claude Code host) died and the bridge was reparented (to init, launchd, or a
+ * subreaper) — it's now a LIVE orphan still holding the single-instance lock, so
+ * trigger onOrphaned (self-exit). Otherwise onHeartbeat (refresh the lock).
+ *
+ * We compare against the initial PPID rather than testing `=== 1` so a bridge whose
+ * Claude Code host runs as PID 1 (a container with no init system) does NOT
+ * self-exit on every tick — its PPID is legitimately 1 and never changes while CC
+ * is alive (Gemini HIGH). Subreaper reparenting (PPID → some non-1 PID) is caught too.
+ * Pure + injectable so the decision is unit-tested without timers or real PPIDs.
+ */
+export function parentWatchTick(
+  getppid: () => number,
+  initialPpid: number,
+  onOrphaned: () => void,
+  onHeartbeat: () => void,
+): void {
+  if (getppid() !== initialPpid) onOrphaned();
+  else onHeartbeat();
+}
+
+export interface ParentDeathWatchOptions {
+  /** Defaults to reading process.getppid(). Injectable for tests. */
+  getppid?: () => number;
+  onOrphaned: () => void;
+  onHeartbeat: () => void;
+  intervalMs?: number;
+}
+
+/**
+ * Read the parent PID. process.getppid() exists at runtime on Node >= 16 (incl. the
+ * Node 22+ this plugin requires) but isn't on this project's @types/node Process type
+ * — the structural cast bridges that gap without an `any`. Returns 0 if unavailable;
+ * since the watch compares current-vs-initial PPID, a constant 0 simply never trips
+ * the orphan signal, so it fails safe to "parent alive".
+ */
+function defaultGetppid(): number {
+  const fn = (process as { getppid?: () => number }).getppid;
+  return typeof fn === 'function' ? fn.call(process) : 0;
+}
+
+/**
+ * GH #182: belt-and-suspenders host-death detection. The existing stdin-EOF + signal
+ * handlers can silently fail to fire when CC dies abnormally (SIGKILL/crash/window
+ * close on macOS) without closing the child's stdin — leaving a LIVE orphan that
+ * holds the project lock for up to 24h (the PID-alive reclaim can't catch it). This
+ * polls getppid() and self-exits on orphan; on a live parent it refreshes the lock
+ * heartbeat. The timer is unref'd so it never keeps a should-be-dead process alive.
+ * Returns a stop() that clears the timer (called from the shutdown path).
+ */
+export function startParentDeathWatch(opts: ParentDeathWatchOptions): () => void {
+  const getppid = opts.getppid ?? defaultGetppid;
+  // Capture the PPID at startup; "orphaned" means it later changes (parent died →
+  // reparented). This makes a CC-as-PID-1 container safe: initial PPID 1 stays 1.
+  const initialPpid = getppid();
+  const interval = setInterval(() => {
+    try {
+      parentWatchTick(getppid, initialPpid, opts.onOrphaned, opts.onHeartbeat);
+    } catch (err) {
+      logger.warn('MCP', `parent-death watch tick failed: ${err instanceof Error ? err.message : err}`);
+    }
+  }, opts.intervalMs ?? DEFAULT_INTERVAL_MS);
+  interval.unref?.();
+  return () => clearInterval(interval);
+}

--- a/scripts/cdp-bridge/test/unit/gh-182-lock-orphan-reclaim.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-182-lock-orphan-reclaim.test.js
@@ -1,0 +1,134 @@
+// GH #182: a LIVE orphaned bridge (its Claude Code parent died, so it's reparented)
+// holds the single-instance lock; PID-dead/mtime/name reclaim can't catch a live owner.
+// Fix: reclaim a live owner whose PARENT CHANGED from the PPID it recorded at creation
+// (orphaned), reclaim a wedged owner via a stale heartbeat, and — for pre-0.39 locks with
+// no recorded ppid — fall back to PPID===1. Container-safe (CC as PID 1 stays PID 1 →
+// unchanged → not stolen). Multi-review hardened (Gemini HIGH / Codex C1/C2).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Lockfile, defaultProcessParent } from '../../dist/lifecycle/lockfile.js';
+
+const NOW = 1_700_000_000_000;
+const tmp = () => mkdtempSync(join(tmpdir(), 'gh182-lock-'));
+
+function prep(tmpDir, ownerBody, contenderOpts = {}) {
+  const contender = new Lockfile({
+    projectRoot: '/p', pid: 12345, tmpDir, uid: 501, clock: () => NOW,
+    processAlive: () => true, processName: () => 'node cdp-bridge',
+    ...contenderOpts,
+  });
+  writeFileSync(contender.lockPath, JSON.stringify(ownerBody, null, 2), 'utf8');
+  return contender;
+}
+
+// ── parent-CHANGED reclaim (new-format lock with recorded ppid) ──
+test('#182: reclaims a LIVE owner whose parent CHANGED (orphaned — CC died)', () => {
+  const tmpDir = tmp();
+  try {
+    const c = prep(tmpDir,
+      { pid: 85744, projectRoot: '/p', startedAt: NOW, lastHeartbeat: NOW, ppid: 4242 },
+      { processAlive: (p) => p === 85744, processParent: () => 1, staleMs: 90_000 });
+    assert.equal(c.acquire().status, 'acquired', 'orphaned (parent changed 4242→1) must be reclaimed');
+  } finally { rmSync(tmpDir, { recursive: true, force: true }); }
+});
+
+test('#182 container-safe: does NOT steal a healthy owner whose PPID is 1 AND was 1 at creation', () => {
+  const tmpDir = tmp();
+  try {
+    // CC runs as PID 1 (devcontainer/no-init): owner recorded ppid 1, live parent still 1 → unchanged → healthy.
+    const c = prep(tmpDir,
+      { pid: 85744, projectRoot: '/p', startedAt: NOW, lastHeartbeat: NOW, ppid: 1 },
+      { processAlive: (p) => p === 85744, processParent: () => 1, staleMs: 90_000 });
+    assert.equal(c.acquire().status, 'conflict', 'PPID 1 unchanged since creation is NOT an orphan (container) — must not steal');
+  } finally { rmSync(tmpDir, { recursive: true, force: true }); }
+});
+
+test('#182 safety: does NOT steal a healthy owner whose parent is unchanged', () => {
+  const tmpDir = tmp();
+  try {
+    const c = prep(tmpDir,
+      { pid: 85744, projectRoot: '/p', startedAt: NOW, lastHeartbeat: NOW, ppid: 4242 },
+      { processAlive: (p) => p === 85744, processParent: () => 4242, staleMs: 90_000 });
+    assert.equal(c.acquire().status, 'conflict', 'unchanged parent → healthy → not stolen');
+  } finally { rmSync(tmpDir, { recursive: true, force: true }); }
+});
+
+test('#182 fail-safe: PPID lookup failure (null) does NOT trigger reclaim', () => {
+  const tmpDir = tmp();
+  try {
+    const c = prep(tmpDir,
+      { pid: 85744, projectRoot: '/p', startedAt: NOW, lastHeartbeat: NOW, ppid: 4242 },
+      { processAlive: (p) => p === 85744, processParent: () => null, staleMs: 90_000 });
+    assert.equal(c.acquire().status, 'conflict', 'null PPID lookup fails safe to conflict');
+  } finally { rmSync(tmpDir, { recursive: true, force: true }); }
+});
+
+// ── pre-0.39 lock (no recorded ppid): PPID===1 fallback ──
+test('#182 legacy: reclaims a no-ppid lock whose live owner PPID is 1', () => {
+  const tmpDir = tmp();
+  try {
+    const c = prep(tmpDir,
+      { pid: 85744, projectRoot: '/p', startedAt: NOW }, // pre-0.39: no ppid, no lastHeartbeat
+      { processAlive: (p) => p === 85744, processParent: () => 1, staleMs: 90_000, clock: () => NOW });
+    assert.equal(c.acquire().status, 'acquired', 'legacy orphan (no ppid, live PPID 1) reclaimed via ===1 fallback');
+  } finally { rmSync(tmpDir, { recursive: true, force: true }); }
+});
+
+test('#182 legacy: does NOT reclaim a no-ppid lock with a real parent + fresh mtime', () => {
+  const tmpDir = tmp();
+  try {
+    const c = prep(tmpDir,
+      { pid: 85744, projectRoot: '/p', startedAt: Date.now() },
+      { processAlive: (p) => p === 85744, processParent: () => 4242, staleMs: 90_000, clock: () => Date.now() });
+    assert.equal(c.acquire().status, 'conflict', 'legacy lock, real parent, fresh mtime → not reclaimed');
+  } finally { rmSync(tmpDir, { recursive: true, force: true }); }
+});
+
+// ── heartbeat (wedged-alive) ──
+test('#182 heartbeat: reclaims a live owner (unchanged parent) whose heartbeat is stale (wedged)', () => {
+  const tmpDir = tmp();
+  try {
+    const c = prep(tmpDir,
+      { pid: 85744, projectRoot: '/p', startedAt: NOW - 200_000, lastHeartbeat: NOW - 120_000, ppid: 4242 },
+      { processAlive: (p) => p === 85744, processParent: () => 4242, staleMs: 90_000, clock: () => NOW });
+    assert.equal(c.acquire().status, 'acquired', 'stale-heartbeat (wedged) owner must be reclaimed');
+  } finally { rmSync(tmpDir, { recursive: true, force: true }); }
+});
+
+// ── real ps -o ppid= reader ──
+test('#182 defaultProcessParent: real PPID for self; null for a bogus PID (fail-safe)', () => {
+  const ppid = defaultProcessParent(process.pid);
+  assert.ok(typeof ppid === 'number' && ppid > 0, `expected real PPID, got ${ppid}`);
+  assert.equal(defaultProcessParent(999999999), null, 'non-existent PID → null');
+});
+
+// ── acquire records the owner ppid (input to parent-changed detection) ──
+test('#182: acquire records the owner PPID in the lock body', () => {
+  const tmpDir = tmp();
+  try {
+    const lf = new Lockfile({ projectRoot: '/p', pid: 12345, tmpDir, uid: 501, clock: () => NOW, selfPpid: () => 4242 });
+    lf.acquire();
+    assert.equal(JSON.parse(readFileSync(lf.lockPath, 'utf8')).ppid, 4242, 'acquire stamps the owner PPID');
+  } finally { rmSync(tmpDir, { recursive: true, force: true }); }
+});
+
+// ── touch(): heartbeat refresh + usurp detection (returns false when stolen) ──
+test('#182 touch(): refreshes + returns true when owned; returns false (no clobber) when usurped', () => {
+  const tmpDir = tmp();
+  try {
+    let t = NOW;
+    const lf = new Lockfile({ projectRoot: '/p', pid: 12345, tmpDir, uid: 501,
+      clock: () => t, processAlive: () => false, processName: () => null, selfPpid: () => 4242 });
+    lf.acquire();
+    t = NOW + 30_000;
+    assert.equal(lf.touch(), true, 'touch returns true while we own the lock');
+    assert.equal(JSON.parse(readFileSync(lf.lockPath, 'utf8')).lastHeartbeat, NOW + 30_000, 'heartbeat refreshed');
+    // A foreign owner usurped our slot (e.g. after a sleep/wake reclaim) → touch reports false + no clobber.
+    writeFileSync(lf.lockPath, JSON.stringify({ pid: 99999, projectRoot: '/p', startedAt: NOW, lastHeartbeat: NOW, ppid: 7 }), 'utf8');
+    assert.equal(lf.touch(), false, 'touch returns false when usurped (signals the bridge to self-terminate)');
+    assert.equal(JSON.parse(readFileSync(lf.lockPath, 'utf8')).pid, 99999, 'did not resurrect a lock we no longer own');
+  } finally { rmSync(tmpDir, { recursive: true, force: true }); }
+});

--- a/scripts/cdp-bridge/test/unit/gh-182-parent-watch.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-182-parent-watch.test.js
@@ -1,0 +1,43 @@
+// GH #182 RC-A: the bridge self-exits when its Claude Code host dies, even when
+// stdin-EOF and signals don't fire. Detection is "parent CHANGED from the PPID
+// observed at startup" — NOT "PPID===1" — so a container where CC runs as PID 1
+// (devcontainer/no-init) never false-self-exits, and subreaper reparenting is caught.
+// (Multi-review: Gemini HIGH / Codex C1.)
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parentWatchTick, startParentDeathWatch } from '../../dist/lifecycle/parent-watch.js';
+
+test('#182 parentWatchTick: parent CHANGED from initial (host died → reparented) → onOrphaned', () => {
+  let orphaned = 0, beat = 0;
+  // initial PPID 4242 (CC), now 1 (reparented to init) → changed → orphaned
+  parentWatchTick(() => 1, 4242, () => { orphaned++; }, () => { beat++; });
+  assert.equal(orphaned, 1, 'PPID changed from 4242→1 means CC died → self-exit');
+  assert.equal(beat, 0);
+});
+
+test('#182 parentWatchTick: parent changed to a subreaper (not 1) → onOrphaned', () => {
+  let orphaned = 0, beat = 0;
+  parentWatchTick(() => 999, 4242, () => { orphaned++; }, () => { beat++; });
+  assert.equal(orphaned, 1, 'reparented to a subreaper (999 != initial 4242) → orphaned');
+});
+
+test('#182 parentWatchTick: parent UNCHANGED → onHeartbeat (no false exit)', () => {
+  let orphaned = 0, beat = 0;
+  parentWatchTick(() => 4242, 4242, () => { orphaned++; }, () => { beat++; });
+  assert.equal(beat, 1, 'parent still alive (PPID unchanged) → heartbeat');
+  assert.equal(orphaned, 0);
+});
+
+test('#182 parentWatchTick: container (initial PPID 1, still 1) → onHeartbeat, NOT orphaned', () => {
+  let orphaned = 0, beat = 0;
+  // CC runs as PID 1 in a container: initial PPID is 1 and stays 1 while CC is alive.
+  parentWatchTick(() => 1, 1, () => { orphaned++; }, () => { beat++; });
+  assert.equal(orphaned, 0, 'PPID 1 that was 1 at startup is NOT an orphan signal (container)');
+  assert.equal(beat, 1);
+});
+
+test('#182 startParentDeathWatch: returns a stop() that clears the interval', () => {
+  const stop = startParentDeathWatch({ getppid: () => 4242, onOrphaned: () => {}, onHeartbeat: () => {}, intervalMs: 60_000 });
+  assert.equal(typeof stop, 'function');
+  stop();
+});

--- a/scripts/cdp-bridge/test/unit/lockfile.test.js
+++ b/scripts/cdp-bridge/test/unit/lockfile.test.js
@@ -55,22 +55,23 @@ test('Lockfile: acquires on clean state and writes lock body', () => {
 test('Lockfile: returns conflict when valid live lock exists (same project)', () => {
   const tmpDir = makeTmpDir();
   try {
-    const preExistingLock = new Lockfile({
-      projectRoot: '/fake/project/root',
-      pid: 99999,
-      tmpDir,
-      uid: 501,
-      clock: () => 1_700_000_000_000,
-      processAlive: () => true,
-      processName: () => 'node cdp-bridge',
-    });
-    preExistingLock.acquire();
-
+    const contenderClock = 1_700_000_000_000 + 5 * 60 * 1000;
     const { lockfile } = makeLockfile({
       tmpDir,
       processAlive: (pid) => pid === 99999,
       processName: (pid) => (pid === 99999 ? 'node cdp-bridge' : null),
-      clock: () => 1_700_000_000_000 + 5 * 60 * 1000, // 5 minutes later
+      processParent: () => 4242, // GH #182: owner has a real parent (not orphaned)
+      clock: () => contenderClock,
+    });
+    // GH #182: a healthy 5-min-old bridge — started 5 min ago (ageMs) but heartbeating,
+    // so lastHeartbeat is fresh (< 90s stale window). A live, parented, freshly-beating
+    // owner must still conflict.
+    writeLockBody(lockfile.lockPath, {
+      pid: 99999,
+      projectRoot: '/fake/project/root',
+      startedAt: 1_700_000_000_000,
+      lastHeartbeat: contenderClock - 10_000,
+      version: '0.23.0-test',
     });
 
     const result = lockfile.acquire();
@@ -400,7 +401,12 @@ test('Lockfile: default processName stale check matches real node scripts (D652 
       tmpDir,
       uid: 501,
       clock: () => Date.now(),
-      // Use the REAL processAlive AND REAL processName — no stubs
+      // Model the child as the lock owner: had the child run acquire(), its getppid()
+      // would be this test process (its real parent), so record that as the lock's
+      // ppid. Otherwise the contender's real PPID lookup (child's parent === us) would
+      // differ from the recorded ppid and the GH #182 parent-changed check would
+      // falsely reclaim. Still exercises the REAL processAlive + processName needle.
+      selfPpid: () => process.pid,
     });
     preLock.acquire();
 


### PR DESCRIPTION
## Problem (#182)

A new Claude Code session fails with **`-32000: Connection closed`** when a *previous* session left a still-running cdp-bridge holding the single-instance project lock. CC died abnormally (SIGKILL / crash / window-close on macOS) without closing the child's stdin or signaling it, so the bridge is a **live orphan** — and the existing reclaim (PID-dead / mtime>24h / process-name) can't recover a *live* owner. The reporter accumulated **two** orphans and had to `kill <pid> && rm <lock>` by hand.

Confirmed the stdin-EOF self-exit + lockfile reclaim already shipped in 0.38.39 → this is a genuine remaining gap, not a missing fix.

## Fix — four composing layers

| Layer | Mechanism |
|---|---|
| **Prevent** | `lifecycle/parent-watch.ts` — a `getppid()` poll (10s, unref'd) captures the PPID at startup and self-exits (`shutdown(0)` → release lock) when it **changes** (parent died → reparented). |
| **Recover orphan** | `Lockfile.isLockLive` reclaims a live owner whose parent **changed** from the PPID it recorded at acquire (`ps -o ppid=`). Null lookup fails safe; pre-0.39 locks with no recorded `ppid` fall back to legacy `PPID===1`. |
| **Recover wedged** | Lock body carries `lastHeartbeat`, refreshed every ~10s; a live owner past 90s is wedged → reclaimable (mirrors `device-lock.ts`). mtime fallback for pre-0.39 locks. |
| **Usurp self-terminate** | `Lockfile.touch()` returns whether we still own the lock; `onHeartbeat` `shutdown(0)`s when it returns false — so a bridge usurped during sleep/wake doesn't run as a second bridge on the same device. |

## Multi-review hardened the design (Codex + Gemini, before merge — like #208)

The first cut used `PPID===1`. Both reviewers flagged it; applying the `receiving-code-review` discipline (verify before implementing), two HIGH findings were real and fixed:

- **Container PID-1 false-positive (Gemini HIGH).** When CC runs as PID 1 (devcontainer / no init), a healthy bridge's PPID is *legitimately* 1 → `===1` self-kills it every tick and lets every other session steal its lock. → Switched to **parent-changed** (capture startup PPID; orphan = it differs). Container-safe (1 stays 1) and strictly stronger (catches subreaper reparenting too).
- **Sleep/wake zombie (Gemini HIGH).** The heartbeat I *added* manufactures a new path: sleep → heartbeat expires → new session reclaims → original wakes → two bridges. → `touch()` now reports loss-of-ownership and the usurped bridge self-terminates. Bonus: this makes the pre-existing **non-atomic `acquire()`** (a known LOW TOCTOU, not `wx`-exclusive like `device-lock.ts`) self-correcting within one tick.
- **Deferred (LOW, pre-existing, now self-healing):** atomic-`wx` acquire. Noted in `DECISIONS.md`.

## Tests

TDD throughout. **15 #182 unit tests** — parent-changed reclaim, container-safety, fail-safe null PPID, legacy `===1` fallback, stale-heartbeat reclaim, `touch()` refresh + usurp, a real `ps -o ppid=` check, and the parent-watch tick (changed / subreaper / unchanged / container). Updated one existing real-child lockfile test to inject `selfPpid` (models the child's true parent — test artifact, not a prod bug).

- Unit suite: **1744/1744**
- `tsc`: clean
- `dist/` rebuilt + committed (tracked in this repo)

Closes #182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
