### PR TITLE
fix(#249): key the exit-0 Maestro failure guard on status lines, not a FAILED substring

### DIFF
--- a/.changeset/gh-249-maestro-failed-token.md
+++ b/.changeset/gh-249-maestro-failed-token.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-cdp": patch
+"rn-dev-agent-plugin": patch
+---
+
+fix(#249): Maestro pass detection no longer flips passing flows to failed when app logs contain the substring `FAILED`. The exit-0 secondary guard in `maestro_run`, `maestro_test_all`, and the inline maestro fallback used a bare `output.includes('FAILED')` over combined stdout+stderr — app/console output like a `FETCH_FAILED` Redux action or a `LOGIN_FAILED` analytics event marked a genuinely passing flow as failed and triggered pointless auto-repair. All three call sites now share `outputIndicatesFlowFailure`, which keys on Maestro's own terminal status lines (`Test FAILED` / `Flow FAILED` / a `[FAILED]` step marker / a bare `FAILED` line) instead of a substring.

--- a/scripts/cdp-bridge/dist/domain/maestro-error-parser.js
+++ b/scripts/cdp-bridge/dist/domain/maestro-error-parser.js
@@ -128,3 +128,17 @@ export function parseMaestroFailure(output) {
 export function isAutoRepairable(failure) {
     return failure.kind === 'SELECTOR_NOT_FOUND';
 }
+/**
+ * GH#249/B193: exit-0 secondary guard for "flow failed despite a zero exit".
+ * The previous bare `output.includes('FAILED')` scanned combined stdout+stderr
+ * — which carries app/console logs — so a passing flow whose app logged
+ * FETCH_FAILED (or any *_FAILED token) was flagged failed and triggered
+ * pointless auto-repair. Key on Maestro's own terminal status LINES instead:
+ * `Test FAILED` / `Flow FAILED` (JVM Maestro), a `[FAILED]` step marker, or a
+ * line that IS the bare token. maestro-runner emits no uppercase FAILED at all
+ * (verified against the binary), so app-log content is the only thing a
+ * substring match could ever catch there.
+ */
+export function outputIndicatesFlowFailure(output) {
+    return /^\s*(?:\[FAILED\]|(?:Test|Flow) FAILED\b|FAILED\s*$)/m.test(output);
+}

--- a/scripts/cdp-bridge/dist/maestro-invoke.js
+++ b/scripts/cdp-bridge/dist/maestro-invoke.js
@@ -6,6 +6,7 @@ import { homedir, tmpdir } from 'node:os';
 import { resolveBundleId, readExpoSlug } from './project-config.js';
 import { buildMaestroFlow, parseAndValidateFlow, isValidBundleId, MaestroValidationError, } from './domain/maestro-validator.js';
 import { chooseMaestroDispatch } from './tools/maestro-dispatch.js';
+import { outputIndicatesFlowFailure } from './domain/maestro-error-parser.js';
 import { resolveAppFileForClearState } from './tools/resolve-ios-app-file.js';
 const execFile = promisify(execFileCb);
 // Escape a user-supplied string for safe embedding inside a double-quoted YAML scalar.
@@ -96,10 +97,10 @@ export async function runMaestroInline(yaml, opts) {
     try {
         const { stdout, stderr } = await execFile(dispatch.binPath, dispatch.buildArgs(opts.platform, flowFile, appFileResolution.appFile), { timeout, encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 });
         const output = (stdout + '\n' + stderr).trim();
-        // Runner exited 0 → authoritative pass. Key the secondary scan on maestro's
-        // `FAILED` token only; a broad `Error:` match false-flagged passing runs
-        // whose app/console output merely contained "Error:" (mirrors maestro_run).
-        const passed = !output.includes('FAILED');
+        // Runner exited 0 → authoritative pass. The secondary scan keys on Maestro's
+        // own status LINES (GH#249: a bare `FAILED` substring false-flagged passing
+        // runs whose app logs contained the token; mirrors maestro_run).
+        const passed = !outputIndicatesFlowFailure(output);
         return { passed, output, flowFile };
     }
     catch (err) {

--- a/scripts/cdp-bridge/dist/tools/maestro-run.js
+++ b/scripts/cdp-bridge/dist/tools/maestro-run.js
@@ -9,6 +9,7 @@ import { resolveBundleId, readExpoSlug } from '../project-config.js';
 import { chooseMaestroDispatch, shouldWarnFallback } from './maestro-dispatch.js';
 import { resolveAppFileForClearState } from './resolve-ios-app-file.js';
 import { buildMaestroFlow, parseAndValidateFlow, isValidBundleId, MaestroValidationError, } from '../domain/maestro-validator.js';
+import { outputIndicatesFlowFailure } from '../domain/maestro-error-parser.js';
 import { stopFastRunner as defaultStopFastRunner } from '../runners/rn-fast-runner-client.js';
 import { releaseAndroidInteractionSlot as defaultReleaseAndroidSlot } from '../runners/release-android-slot.js';
 import { markCdpStale as defaultMarkCdpStale } from '../cdp/recovery.js';
@@ -165,11 +166,10 @@ export function createMaestroRunHandler() {
             const output = (stdout + '\n' + stderr).trim();
             // Reaching here means the runner exited 0 — that exit code is the
             // authoritative pass signal (a real flow failure exits non-zero and is
-            // handled in the catch below). The output scan is only a secondary guard;
-            // it keys on maestro's own `FAILED` status token rather than the previous
-            // broad `Error:` match, which false-flagged passing runs whose app/console
-            // logs merely contained "Error:".
-            const passed = !output.includes('FAILED');
+            // handled in the catch below). The output scan is only a secondary guard,
+            // keyed on Maestro's own status LINES (GH#249: the prior bare `FAILED`
+            // substring false-flagged passing runs whose app logs contained the token).
+            const passed = !outputIndicatesFlowFailure(output);
             const meta = {
                 passed,
                 flowFile,

--- a/scripts/cdp-bridge/dist/tools/maestro-test-all.js
+++ b/scripts/cdp-bridge/dist/tools/maestro-test-all.js
@@ -9,6 +9,7 @@ import { findProjectRoot } from '../nav-graph/storage.js';
 import { chooseMaestroDispatch, shouldWarnFallback } from './maestro-dispatch.js';
 import { buildMaestroFlow, parseAndValidateFlow, MaestroValidationError, } from '../domain/maestro-validator.js';
 import { runFlowParked } from './maestro-run.js';
+import { outputIndicatesFlowFailure } from '../domain/maestro-error-parser.js';
 import { resolveAppFileForClearState } from './resolve-ios-app-file.js';
 const execFile = promisify(execFileCb);
 function discoverFlows(dir, pattern) {
@@ -113,11 +114,10 @@ export function createMaestroTestAllHandler() {
                 const { stdout, stderr } = await runFlowParked(() => execFile(dispatch.binPath, dispatch.buildArgs(platform, safeFlowFile, appFile), { timeout, encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 }), { platform, deviceId: getActiveSession()?.deviceId });
                 const output = (stdout + '\n' + stderr).trim();
                 // The runner already exited 0 here, so that exit code is the
-                // authoritative pass signal. Key the secondary scan on maestro's own
-                // `FAILED` token only — a broad `Error:` match false-flagged passing
-                // runs whose app/console logs merely contained "Error:" (mirrors the
-                // maestro_run fix).
-                const ok = !output.includes('FAILED');
+                // authoritative pass signal. The secondary scan keys on Maestro's own
+                // status LINES (GH#249: a bare `FAILED` substring false-flagged passing
+                // runs whose app logs contained the token; mirrors the maestro_run fix).
+                const ok = !outputIndicatesFlowFailure(output);
                 results.push({
                     name,
                     passed: ok,

--- a/scripts/cdp-bridge/src/domain/maestro-error-parser.ts
+++ b/scripts/cdp-bridge/src/domain/maestro-error-parser.ts
@@ -139,3 +139,18 @@ export function parseMaestroFailure(output: string): MaestroFailure {
 export function isAutoRepairable(failure: MaestroFailure): boolean {
   return failure.kind === 'SELECTOR_NOT_FOUND';
 }
+
+/**
+ * GH#249/B193: exit-0 secondary guard for "flow failed despite a zero exit".
+ * The previous bare `output.includes('FAILED')` scanned combined stdout+stderr
+ * — which carries app/console logs — so a passing flow whose app logged
+ * FETCH_FAILED (or any *_FAILED token) was flagged failed and triggered
+ * pointless auto-repair. Key on Maestro's own terminal status LINES instead:
+ * `Test FAILED` / `Flow FAILED` (JVM Maestro), a `[FAILED]` step marker, or a
+ * line that IS the bare token. maestro-runner emits no uppercase FAILED at all
+ * (verified against the binary), so app-log content is the only thing a
+ * substring match could ever catch there.
+ */
+export function outputIndicatesFlowFailure(output: string): boolean {
+  return /^\s*(?:\[FAILED\]|(?:Test|Flow) FAILED\b|FAILED\s*$)/m.test(output);
+}

--- a/scripts/cdp-bridge/src/maestro-invoke.ts
+++ b/scripts/cdp-bridge/src/maestro-invoke.ts
@@ -11,6 +11,7 @@ import {
   MaestroValidationError,
 } from './domain/maestro-validator.js';
 import { chooseMaestroDispatch } from './tools/maestro-dispatch.js';
+import { outputIndicatesFlowFailure } from './domain/maestro-error-parser.js';
 import { resolveAppFileForClearState } from './tools/resolve-ios-app-file.js';
 
 const execFile = promisify(execFileCb);
@@ -129,10 +130,10 @@ export async function runMaestroInline(
       { timeout, encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 },
     );
     const output = (stdout + '\n' + stderr).trim();
-    // Runner exited 0 → authoritative pass. Key the secondary scan on maestro's
-    // `FAILED` token only; a broad `Error:` match false-flagged passing runs
-    // whose app/console output merely contained "Error:" (mirrors maestro_run).
-    const passed = !output.includes('FAILED');
+    // Runner exited 0 → authoritative pass. The secondary scan keys on Maestro's
+    // own status LINES (GH#249: a bare `FAILED` substring false-flagged passing
+    // runs whose app logs contained the token; mirrors maestro_run).
+    const passed = !outputIndicatesFlowFailure(output);
     return { passed, output, flowFile };
   } catch (err) {
     // execFile errors carry stdout/stderr from the failed child process. When

--- a/scripts/cdp-bridge/src/tools/maestro-run.ts
+++ b/scripts/cdp-bridge/src/tools/maestro-run.ts
@@ -15,6 +15,7 @@ import {
   isValidBundleId,
   MaestroValidationError,
 } from '../domain/maestro-validator.js';
+import { outputIndicatesFlowFailure } from '../domain/maestro-error-parser.js';
 import { stopFastRunner as defaultStopFastRunner } from '../runners/rn-fast-runner-client.js';
 import { releaseAndroidInteractionSlot as defaultReleaseAndroidSlot } from '../runners/release-android-slot.js';
 import { markCdpStale as defaultMarkCdpStale } from '../cdp/recovery.js';
@@ -217,11 +218,10 @@ export function createMaestroRunHandler(): (args: MaestroRunArgs) => Promise<Too
       const output = (stdout + '\n' + stderr).trim();
       // Reaching here means the runner exited 0 — that exit code is the
       // authoritative pass signal (a real flow failure exits non-zero and is
-      // handled in the catch below). The output scan is only a secondary guard;
-      // it keys on maestro's own `FAILED` status token rather than the previous
-      // broad `Error:` match, which false-flagged passing runs whose app/console
-      // logs merely contained "Error:".
-      const passed = !output.includes('FAILED');
+      // handled in the catch below). The output scan is only a secondary guard,
+      // keyed on Maestro's own status LINES (GH#249: the prior bare `FAILED`
+      // substring false-flagged passing runs whose app logs contained the token).
+      const passed = !outputIndicatesFlowFailure(output);
       const meta = {
         passed,
         flowFile,

--- a/scripts/cdp-bridge/src/tools/maestro-test-all.ts
+++ b/scripts/cdp-bridge/src/tools/maestro-test-all.ts
@@ -14,6 +14,7 @@ import {
   MaestroValidationError,
 } from '../domain/maestro-validator.js';
 import { runFlowParked } from './maestro-run.js';
+import { outputIndicatesFlowFailure } from '../domain/maestro-error-parser.js';
 import { resolveAppFileForClearState } from './resolve-ios-app-file.js';
 
 const execFile = promisify(execFileCb);
@@ -151,11 +152,10 @@ export function createMaestroTestAllHandler(): (args: MaestroTestAllArgs) => Pro
         );
         const output = (stdout + '\n' + stderr).trim();
         // The runner already exited 0 here, so that exit code is the
-        // authoritative pass signal. Key the secondary scan on maestro's own
-        // `FAILED` token only — a broad `Error:` match false-flagged passing
-        // runs whose app/console logs merely contained "Error:" (mirrors the
-        // maestro_run fix).
-        const ok = !output.includes('FAILED');
+        // authoritative pass signal. The secondary scan keys on Maestro's own
+        // status LINES (GH#249: a bare `FAILED` substring false-flagged passing
+        // runs whose app logs contained the token; mirrors the maestro_run fix).
+        const ok = !outputIndicatesFlowFailure(output);
 
         results.push({
           name,

--- a/scripts/cdp-bridge/test/unit/gh-249-maestro-failed-token.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-249-maestro-failed-token.test.js
@@ -1,0 +1,28 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { outputIndicatesFlowFailure } from '../../dist/domain/maestro-error-parser.js';
+
+// GH#249/B193: the exit-0 secondary guard was `output.includes('FAILED')` over combined
+// stdout+stderr — which contains app/console logs, so a passing flow whose app merely
+// logged the substring (FETCH_FAILED, LOGIN_FAILED, ...) was flagged failed and kicked
+// off pointless auto-repair. The guard must key on Maestro's own terminal status LINES.
+// (maestro-runner emits no uppercase FAILED at all — verified against the binary — so
+// the token only ever comes from the JVM Maestro fallback, e.g. the 'Test FAILED' line
+// already pinned in maestro-error-parser.test.js.)
+
+test('#249 matches Maestro terminal status lines', () => {
+  assert.equal(outputIndicatesFlowFailure('Test FAILED'), true);
+  assert.equal(outputIndicatesFlowFailure('[INFO] Tapping on "ok"\nTest FAILED\n'), true);
+  assert.equal(outputIndicatesFlowFailure('Flow FAILED'), true);
+  assert.equal(outputIndicatesFlowFailure('[FAILED] Tap on element with id "submit"'), true);
+  assert.equal(outputIndicatesFlowFailure('  FAILED  '), true); // bare status line, indented
+});
+
+test('#249 does NOT match app/console log content that merely contains the substring', () => {
+  assert.equal(outputIndicatesFlowFailure('[INFO] dispatching action FETCH_FAILED'), false);
+  assert.equal(outputIndicatesFlowFailure('console.log: USER_REGISTRATION_FAILED event sent'), false);
+  assert.equal(outputIndicatesFlowFailure('2026-06-10 12:00:01 upload FAILED midway, retrying'), false);
+  assert.equal(outputIndicatesFlowFailure('FAILED to fetch user profile'), false); // line-leading but prose, not a status line
+  assert.equal(outputIndicatesFlowFailure('All steps passed'), false);
+  assert.equal(outputIndicatesFlowFailure(''), false);
+});


### PR DESCRIPTION
Closes #249 (B193 from the 2026-06-09 repo-wide bug hunt).

## Problem

After a Maestro runner exits 0 — documented at all three call sites as "the authoritative pass signal" — a secondary guard scanned the combined stdout+stderr with a bare `output.includes('FAILED')`. That buffer carries app/console logs, so a passing flow whose app merely logged the substring (`FETCH_FAILED` Redux action, `LOGIN_FAILED` analytics event, any user-facing error string) was flagged failed:

- `cdp_run_action` then triggered pointless auto-repair (30s+ per run), looping if the app always logs the token
- pass/fail telemetry was corrupted
- the same bug class was fixed once before for the broad `Error:` match — this was the residual

## Fix

New shared `outputIndicatesFlowFailure` in `domain/maestro-error-parser.ts`, wired at all three call sites (`maestro_run`, `maestro_test_all`, the inline `maestro-invoke` fallback). It matches only Maestro's terminal status **lines**: `Test FAILED` / `Flow FAILED` (the JVM Maestro shape already pinned in `maestro-error-parser.test.js` fixtures), a `[FAILED]` step marker, or a line that IS the bare token.

**Grounding:** `strings` on the installed maestro-runner binary shows it emits no uppercase `FAILED` at all — so on the preferred runner path the old substring scan could *only* ever match app-log content. The token only comes from the JVM Maestro fallback, where a real failure also exits non-zero (handled in the catch).

## Test plan

- TDD red-first: `gh-249-maestro-failed-token.test.js` watched failing (missing export), then green
- Positive pins: `Test FAILED`, `Flow FAILED`, `[FAILED] Tap on …`, bare/indented `FAILED` line
- Negative pins: `FETCH_FAILED`/`USER_REGISTRATION_FAILED` log lines, timestamped `upload FAILED midway`, line-leading prose `FAILED to fetch user profile`
- Full cdp-bridge unit suite green; `dist/` rebuilt and staged; changeset added

🤖 Generated with [Claude Code](https://claude.com/claude-code)