### PR TITLE
fix(#250): report handler throws as failures, not successes, in cdp_interact

### DIFF
--- a/.changeset/gh-250-interact-handler-throw.md
+++ b/.changeset/gh-250-interact-handler-throw.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-cdp": patch
+"rn-dev-agent-plugin": patch
+---
+
+fix(#250): `cdp_interact` no longer reports success when the app's own handler throws. The injected interact dispatch caught handler exceptions (`onPress`/`onChangeText`/`setValue` raising — unmounted component, missing context, thrown validation) and returned `success: true, action_executed: true`, which the tool layer surfaced as a non-error warning — so agents proceeded against a screen that may be in an error state. The helper now reports `success: false` (keeping `action_executed: true` to distinguish "dispatched but handler threw" from "couldn't dispatch"), and the tool layer maps it to a structured error with `meta.actionExecuted`, `meta.handlerError`, and a check-`cdp_error_log` hint. HELPERS_VERSION bumped to 25 so connected sessions re-inject.

--- a/scripts/cdp-bridge/dist/injected-helpers.js
+++ b/scripts/cdp-bridge/dist/injected-helpers.js
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 24;
+export const HELPERS_VERSION = 25;
 export const INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -1418,10 +1418,10 @@ export const INJECTED_HELPERS = `
       return JSON.stringify({ error: 'Unknown action: ' + action });
     } catch(e) {
       return JSON.stringify({
-        success: true, action_executed: true,
+        success: false, action_executed: true,
         handler_error: (e && e.message || String(e)),
         component: typeName, testID: selector,
-        hint: 'The action was dispatched but the handler threw. This may be intentional (e.g., error testing).'
+        hint: 'The action was dispatched but the app handler threw — the screen may now be in an error state. Check cdp_error_log before continuing.'
       });
     }
   }

--- a/scripts/cdp-bridge/dist/tools/interact.js
+++ b/scripts/cdp-bridge/dist/tools/interact.js
@@ -1,4 +1,4 @@
-import { okResult, failResult, warnResult, withConnection } from '../utils.js';
+import { okResult, failResult, withConnection } from '../utils.js';
 export function createInteractHandler(getClient) {
     return withConnection(getClient, async (args, client) => {
         if (!args.testID && !args.accessibilityLabel) {
@@ -52,8 +52,15 @@ export function createInteractHandler(getClient) {
         if (parsed.error) {
             return failResult(`Interact failed: ${parsed.error}`, parsed.hint ? { hint: parsed.hint } : undefined);
         }
+        // GH#250: a handler throw is an app-side failure, not a warning — the action
+        // dispatched but its effect likely didn't happen. actionExecuted in meta keeps
+        // the "dispatched but threw" / "couldn't dispatch" distinction.
         if (parsed.action_executed && parsed.handler_error) {
-            return warnResult(parsed, `Action executed but handler threw: ${parsed.handler_error}`);
+            return failResult(`Action executed but handler threw: ${parsed.handler_error}`, {
+                actionExecuted: true,
+                handlerError: parsed.handler_error,
+                hint: 'The app handler raised an exception — the screen may be in an error state. Check cdp_error_log before continuing.',
+            });
         }
         return okResult(parsed);
     });

--- a/scripts/cdp-bridge/src/injected-helpers.ts
+++ b/scripts/cdp-bridge/src/injected-helpers.ts
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 24;
+export const HELPERS_VERSION = 25;
 
 export const INJECTED_HELPERS = `
 (function() {
@@ -1419,10 +1419,10 @@ export const INJECTED_HELPERS = `
       return JSON.stringify({ error: 'Unknown action: ' + action });
     } catch(e) {
       return JSON.stringify({
-        success: true, action_executed: true,
+        success: false, action_executed: true,
         handler_error: (e && e.message || String(e)),
         component: typeName, testID: selector,
-        hint: 'The action was dispatched but the handler threw. This may be intentional (e.g., error testing).'
+        hint: 'The action was dispatched but the app handler threw — the screen may now be in an error state. Check cdp_error_log before continuing.'
       });
     }
   }

--- a/scripts/cdp-bridge/src/tools/interact.ts
+++ b/scripts/cdp-bridge/src/tools/interact.ts
@@ -1,5 +1,5 @@
 import type { CDPClient } from '../cdp-client.js';
-import { okResult, failResult, warnResult, withConnection } from '../utils.js';
+import { okResult, failResult, withConnection } from '../utils.js';
 
 type InteractAction = 'press' | 'longPress' | 'typeText' | 'scroll' | 'setFieldValue';
 
@@ -73,8 +73,18 @@ export function createInteractHandler(getClient: () => CDPClient) {
       );
     }
 
+    // GH#250: a handler throw is an app-side failure, not a warning — the action
+    // dispatched but its effect likely didn't happen. actionExecuted in meta keeps
+    // the "dispatched but threw" / "couldn't dispatch" distinction.
     if (parsed.action_executed && parsed.handler_error) {
-      return warnResult(parsed, `Action executed but handler threw: ${parsed.handler_error}`);
+      return failResult(
+        `Action executed but handler threw: ${parsed.handler_error}`,
+        {
+          actionExecuted: true,
+          handlerError: parsed.handler_error,
+          hint: 'The app handler raised an exception — the screen may be in an error state. Check cdp_error_log before continuing.',
+        },
+      );
     }
 
     return okResult(parsed);

--- a/scripts/cdp-bridge/test/unit/gh-250-interact-handler-throw.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-250-interact-handler-throw.test.js
@@ -1,0 +1,106 @@
+// GH#250/B194: when the app's own handler (onPress/onChangeText/...) THROWS, the
+// interact dispatch catch returned { success: true, action_executed: true } and the
+// TS layer mapped it to warnResult (envelope ok: true) — a real app-side exception
+// read as a successful interaction, so agents proceeded against a screen that may
+// be in an error state. Truthful contract: success: false at the helper layer,
+// failResult (isError) at the tool layer, with action_executed kept to distinguish
+// "dispatched but handler threw" from "couldn't dispatch".
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import vm from 'node:vm';
+import { INJECTED_HELPERS } from '../../dist/injected-helpers.js';
+import { createMockClient } from '../helpers/mock-cdp-client.js';
+import { expectFail } from '../helpers/result-helpers.js';
+import { createInteractHandler } from '../../dist/tools/interact.js';
+
+function createSandbox(opts = {}) {
+  const sandbox = {
+    Array, Object, JSON, Map, WeakSet, Error, Date, parseInt, parseFloat,
+    console: { log() {}, error() {}, warn() {}, info() {}, debug() {} },
+    String, Number, Boolean, RegExp, Symbol, Set, Promise, setTimeout, clearTimeout,
+  };
+  sandbox.globalThis = sandbox;
+  if (opts.fiberRoot) {
+    sandbox.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+      renderers: new Map([[1, {}]]),
+      getFiberRoots: (id) => id === 1 ? new Set([{ current: opts.fiberRoot }]) : new Set(),
+    };
+  }
+  vm.createContext(sandbox);
+  vm.runInContext(INJECTED_HELPERS, sandbox);
+  return sandbox;
+}
+
+function buildFiber(spec, parent = null) {
+  const fiber = {
+    type: spec.name ? { displayName: spec.name } : null,
+    memoizedProps: spec.props || {},
+    return: parent,
+    child: null,
+    sibling: null,
+    stateNode: spec.stateNode || null,
+  };
+  if (spec.children && spec.children.length > 0) {
+    let prev = null;
+    for (const c of spec.children) {
+      const child = buildFiber(c, fiber);
+      if (!fiber.child) fiber.child = child;
+      else prev.sibling = child;
+      prev = child;
+    }
+  }
+  return fiber;
+}
+
+test('#250 helper: a throwing onPress reports success:false with action_executed + handler_error', () => {
+  const root = buildFiber({
+    name: 'App',
+    children: [
+      {
+        name: 'Pressable',
+        props: {
+          testID: 'crash-btn',
+          onPress: () => { throw new Error('Cannot update unmounted component'); },
+        },
+      },
+    ],
+  });
+  const sandbox = createSandbox({ fiberRoot: root });
+  const result = JSON.parse(sandbox.__RN_AGENT.interact({ action: 'press', testID: 'crash-btn' }));
+  assert.equal(result.success, false);
+  assert.equal(result.action_executed, true);
+  assert.match(result.handler_error, /unmounted component/);
+});
+
+test('#250 helper: a non-throwing onPress still reports success:true (regression guard)', () => {
+  const root = buildFiber({
+    name: 'App',
+    children: [
+      { name: 'Pressable', props: { testID: 'ok-btn', onPress: () => {} } },
+    ],
+  });
+  const sandbox = createSandbox({ fiberRoot: root });
+  const result = JSON.parse(sandbox.__RN_AGENT.interact({ action: 'press', testID: 'ok-btn' }));
+  assert.equal(result.success, true);
+});
+
+test('#250 tool layer: action_executed + handler_error maps to failResult, not warnResult', async () => {
+  const client = createMockClient({
+    evaluate: async () => ({
+      value: JSON.stringify({
+        success: false,
+        action_executed: true,
+        handler_error: 'onPress threw an error',
+        testID: 'crash-btn',
+      }),
+    }),
+  });
+  const handler = createInteractHandler(() => client);
+  const result = await handler({ action: 'press', testID: 'crash-btn', animated: false });
+  assert.equal(result.isError, true);
+  const error = expectFail(result);
+  assert.match(error, /handler threw/);
+  // the envelope must still carry the "it DID dispatch" distinction
+  const envelope = JSON.parse(result.content[0].text);
+  assert.equal(envelope.meta?.actionExecuted, true);
+});

--- a/scripts/cdp-bridge/test/unit/injected-helpers.test.js
+++ b/scripts/cdp-bridge/test/unit/injected-helpers.test.js
@@ -317,6 +317,6 @@ test('M10: getAppInfo returns architecture=unknown when nativeFabricUIManager is
   assert.equal(info.architecture, 'unknown');
 });
 
-test('#191: helpers bundle version is 24 (bumped for typeText verify-mode + readInputValue)', () => {
-  assert.match(INJECTED_HELPERS, /__HELPERS_VERSION__\s*=\s*24/);
+test('#250: helpers bundle version is 25 (bumped for handler-throw success:false)', () => {
+  assert.match(INJECTED_HELPERS, /__HELPERS_VERSION__\s*=\s*25/);
 });

--- a/scripts/cdp-bridge/test/unit/injected-typetext-verify.test.js
+++ b/scripts/cdp-bridge/test/unit/injected-typetext-verify.test.js
@@ -15,8 +15,8 @@ function verifyNoHandlerSlice() {
   return s.slice(open, open + 400);
 }
 
-test('#191: HELPERS_VERSION bumped to 24', () => {
-  assert.equal(HELPERS_VERSION, 24);
+test('#250: HELPERS_VERSION bumped to 25 (handler-throw success:false)', () => {
+  assert.equal(HELPERS_VERSION, 25);
 });
 test('#191: verify mode reads opts.verify', () => {
   assert.match(typeTextSlice(), /opts\.verify/);

--- a/scripts/cdp-bridge/test/unit/tool-handlers-cdp2.test.js
+++ b/scripts/cdp-bridge/test/unit/tool-handlers-cdp2.test.js
@@ -57,15 +57,15 @@ test('interact: returns failResult when parsed response has error', async () => 
   assert.match(error, /Element not found/);
 });
 
-test('interact: returns warnResult when action_executed with handler_error', async () => {
+test('interact: returns failResult when action_executed with handler_error (GH#250)', async () => {
   const client = createMockClient({
     evaluate: async () => ({
       value: JSON.stringify({ action_executed: 'press', handler_error: 'onPress threw an error' }),
     }),
   });
   const handler = createInteractHandler(() => client);
-  const { warning } = expectWarn(await handler({ action: 'press', testID: 'btn', animated: false }));
-  assert.match(warning, /handler threw/);
+  const error = expectFail(await handler({ action: 'press', testID: 'btn', animated: false }));
+  assert.match(error, /handler threw/);
 });
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### PR DESCRIPTION
Closes #250 (B194 from the 2026-06-09 repo-wide bug hunt). **Stacked on #254** (shared rebuilt `dist/`); merge #254 first, then this.

## Problem

The injected `interact` dispatch wrapped handler invocation in a catch that returned `{ success: true, action_executed: true, handler_error }` when the app's own handler threw (`onPress`/`onChangeText`/`setValue` raising — unmounted component, missing context, thrown validation). `tools/interact.ts` then mapped that shape to `warnResult`, whose envelope is literally `ok: true`.

Net effect: a real app-side exception read as a successful interaction. Agents key on `success`/`ok` and proceeded against a screen that may be in an error state — for an agent-driven tool, a wrong success signal is the most corrosive bug class.

## Fix

Two layers, keeping the "dispatched but threw" vs "couldn't dispatch" distinction:

- **Injected helper**: catch now returns `success: false, action_executed: true, handler_error`, with a hint pointing at `cdp_error_log`. `HELPERS_VERSION` 24 → 25 so connected sessions re-inject the fixed bundle.
- **Tool layer**: the `action_executed + handler_error` shape maps to `failResult` (envelope `ok: false`, `isError: true`) with `meta.actionExecuted`, `meta.handlerError`, and the same hint. The now-unused `warnResult` import is dropped.

## Test plan

- TDD red-first (`gh-250-interact-handler-throw.test.js`): VM-sandbox test drives the real injected bundle with a fiber whose `onPress` throws → asserts `success: false` + `action_executed: true`; a non-throwing `onPress` still returns `success: true` (regression guard); tool-layer test asserts `isError: true` + `meta.actionExecuted`
- Existing pin updated: `tool-handlers-cdp2.test.js` warn-pin → fail-pin; the two `HELPERS_VERSION` pin tests updated 24 → 25 (they exist to force exactly this acknowledgment)
- Full cdp-bridge unit suite: **1849/1849**; `dist/` rebuilt and staged; changeset added

🤖 Generated with [Claude Code](https://claude.com/claude-code)