### PR TITLE
fix(#251,#252): atomic project-lock acquire + bounded SessionStart

### DIFF
--- a/.changeset/gh-251-252-lock-atomicity-bounded-start.md
+++ b/.changeset/gh-251-252-lock-atomicity-bounded-start.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-cdp": patch
+"rn-dev-agent-plugin": patch
+---
+
+fix(#251,#252): startup hardening. The project single-instance lock (`Lockfile.acquire`) now uses the same atomic `openSync('wx')` exclusive-create pattern as `DeviceLock` — the previous read-then-write let two bridges starting in the same instant both "acquire" the lock, with the second silently truncating the first; the loser now gets a structured conflict, stale-holder reclaim narrows the steal window with a re-read before unlink, and fs infra errors fail open (`degraded: true`) instead of crashing the bridge at boot. Separately, SessionStart is now bounded: the hook declares an explicit 120s timeout and the maestro-runner installer's `curl | bash` carries `--connect-timeout 10 --max-time 90`, so a stalled CDN can no longer block session start indefinitely; a CI guard (`session-start-bounded.test.sh`) pins both.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
       - name: Changeset-guard unit test
         run: bash scripts/test/require-changeset.test.sh
 
+      # GH#252/B196: SessionStart must stay bounded (hook timeout + curl time limits).
+      - name: SessionStart bounded-startup guard
+        run: bash scripts/test/session-start-bounded.test.sh
+
   version-sync:
     name: Version sync check
     runs-on: ubuntu-latest

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/detect-rn-project.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/detect-rn-project.sh",
+            "timeout": 120
           }
         ]
       }

--- a/scripts/cdp-bridge/dist/lifecycle/lockfile.js
+++ b/scripts/cdp-bridge/dist/lifecycle/lockfile.js
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, statSync, unlinkSync, writeFileSync, writeSync } from 'node:fs';
 import { tmpdir, userInfo } from 'node:os';
 import { join, resolve } from 'node:path';
 const DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
@@ -120,22 +120,67 @@ export class Lockfile {
         };
         this.lockPath = join(tmpDir, `rn-dev-agent-cdp-${uid}-${hash}.lock`);
     }
+    // GH#251: acquire via atomic exclusive-create (same pattern as DeviceLock).
+    // The previous read-then-writeFileSync let two bridges starting in the same
+    // instant both see no live lock and both "acquire" — the second silently
+    // truncating the first. With 'wx' the loser gets EEXIST and evaluates the
+    // winner's lock as a conflict. Infra errors (not contention) fail OPEN with
+    // `degraded` so an fs hiccup never blocks a legitimate session.
     acquire() {
+        try {
+            this.writeLock();
+            this.acquired = true;
+            return { status: 'acquired', lockPath: this.lockPath };
+        }
+        catch (err) {
+            if (!isEexist(err)) {
+                return { status: 'acquired', lockPath: this.lockPath, degraded: true };
+            }
+        }
         const existing = this.readExisting();
         if (existing && this.isLockLive(existing)) {
-            return {
-                status: 'conflict',
-                lockPath: this.lockPath,
-                pid: existing.pid,
-                projectRoot: existing.projectRoot,
-                startedAt: existing.startedAt,
-                ageMs: this.opts.clock() - existing.startedAt,
-                version: existing.version,
-            };
+            return this.conflictOf(existing);
         }
-        this.writeLock();
-        this.acquired = true;
-        return { status: 'acquired', lockPath: this.lockPath };
+        // Stale/dead/unreadable holder → reclaim. Narrow the steal-a-fresh-lock
+        // window: re-read immediately before unlink and bail if a DIFFERENT,
+        // now-live holder appeared since the staleness judgment. The post-unlink
+        // race is still caught atomically — 'wx' throws EEXIST if another bridge
+        // created a fresh lock in the gap.
+        const before = this.readExisting();
+        if (before &&
+            (existing === null || before.pid !== existing.pid || before.startedAt !== existing.startedAt) &&
+            this.isLockLive(before)) {
+            return this.conflictOf(before);
+        }
+        try {
+            unlinkSync(this.lockPath);
+        }
+        catch { /* already gone */ }
+        try {
+            this.writeLock();
+            this.acquired = true;
+            return { status: 'acquired', lockPath: this.lockPath };
+        }
+        catch (err) {
+            if (!isEexist(err)) {
+                return { status: 'acquired', lockPath: this.lockPath, degraded: true };
+            }
+            const raced = this.readExisting();
+            return raced
+                ? this.conflictOf(raced)
+                : { status: 'acquired', lockPath: this.lockPath, degraded: true };
+        }
+    }
+    conflictOf(body) {
+        return {
+            status: 'conflict',
+            lockPath: this.lockPath,
+            pid: body.pid,
+            projectRoot: body.projectRoot,
+            startedAt: body.startedAt,
+            ageMs: this.opts.clock() - body.startedAt,
+            version: body.version,
+        };
     }
     release() {
         if (!this.acquired)
@@ -253,8 +298,18 @@ export class Lockfile {
         if (!existsSync(dir)) {
             mkdirSync(dir, { recursive: true });
         }
-        writeFileSync(this.lockPath, JSON.stringify(body, null, 2), { encoding: 'utf8' });
+        // GH#251: atomic exclusive create — throws EEXIST if another bridge won the race.
+        const fd = openSync(this.lockPath, 'wx');
+        try {
+            writeSync(fd, JSON.stringify(body, null, 2));
+        }
+        finally {
+            closeSync(fd);
+        }
     }
+}
+function isEexist(err) {
+    return typeof err === 'object' && err !== null && err.code === 'EEXIST';
 }
 function isValidLockBody(obj) {
     if (typeof obj !== 'object' || obj === null)

--- a/scripts/cdp-bridge/src/lifecycle/lockfile.ts
+++ b/scripts/cdp-bridge/src/lifecycle/lockfile.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, statSync, unlinkSync, writeFileSync, writeSync } from 'node:fs';
 import { tmpdir, userInfo } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -33,6 +33,8 @@ export interface LockfileOptions {
 export interface LockAcquired {
   status: 'acquired';
   lockPath: string;
+  /** GH#251: an fs infra error (not contention) made the exclusive create impossible — single-instance protection is off this session, but the bridge still starts (fail-open, mirrors DeviceLock). */
+  degraded?: boolean;
 }
 
 export interface LockConflict {
@@ -176,23 +178,67 @@ export class Lockfile {
     this.lockPath = join(tmpDir, `rn-dev-agent-cdp-${uid}-${hash}.lock`);
   }
 
+  // GH#251: acquire via atomic exclusive-create (same pattern as DeviceLock).
+  // The previous read-then-writeFileSync let two bridges starting in the same
+  // instant both see no live lock and both "acquire" — the second silently
+  // truncating the first. With 'wx' the loser gets EEXIST and evaluates the
+  // winner's lock as a conflict. Infra errors (not contention) fail OPEN with
+  // `degraded` so an fs hiccup never blocks a legitimate session.
   acquire(): LockAcquireResult {
-    const existing = this.readExisting();
-    if (existing && this.isLockLive(existing)) {
-      return {
-        status: 'conflict',
-        lockPath: this.lockPath,
-        pid: existing.pid,
-        projectRoot: existing.projectRoot,
-        startedAt: existing.startedAt,
-        ageMs: this.opts.clock() - existing.startedAt,
-        version: existing.version,
-      };
+    try {
+      this.writeLock();
+      this.acquired = true;
+      return { status: 'acquired', lockPath: this.lockPath };
+    } catch (err) {
+      if (!isEexist(err)) {
+        return { status: 'acquired', lockPath: this.lockPath, degraded: true };
+      }
     }
 
-    this.writeLock();
-    this.acquired = true;
-    return { status: 'acquired', lockPath: this.lockPath };
+    const existing = this.readExisting();
+    if (existing && this.isLockLive(existing)) {
+      return this.conflictOf(existing);
+    }
+
+    // Stale/dead/unreadable holder → reclaim. Narrow the steal-a-fresh-lock
+    // window: re-read immediately before unlink and bail if a DIFFERENT,
+    // now-live holder appeared since the staleness judgment. The post-unlink
+    // race is still caught atomically — 'wx' throws EEXIST if another bridge
+    // created a fresh lock in the gap.
+    const before = this.readExisting();
+    if (
+      before &&
+      (existing === null || before.pid !== existing.pid || before.startedAt !== existing.startedAt) &&
+      this.isLockLive(before)
+    ) {
+      return this.conflictOf(before);
+    }
+    try { unlinkSync(this.lockPath); } catch { /* already gone */ }
+    try {
+      this.writeLock();
+      this.acquired = true;
+      return { status: 'acquired', lockPath: this.lockPath };
+    } catch (err) {
+      if (!isEexist(err)) {
+        return { status: 'acquired', lockPath: this.lockPath, degraded: true };
+      }
+      const raced = this.readExisting();
+      return raced
+        ? this.conflictOf(raced)
+        : { status: 'acquired', lockPath: this.lockPath, degraded: true };
+    }
+  }
+
+  private conflictOf(body: LockFileBody): LockConflict {
+    return {
+      status: 'conflict',
+      lockPath: this.lockPath,
+      pid: body.pid,
+      projectRoot: body.projectRoot,
+      startedAt: body.startedAt,
+      ageMs: this.opts.clock() - body.startedAt,
+      version: body.version,
+    };
   }
 
   release(): void {
@@ -311,8 +357,18 @@ export class Lockfile {
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
     }
-    writeFileSync(this.lockPath, JSON.stringify(body, null, 2), { encoding: 'utf8' });
+    // GH#251: atomic exclusive create — throws EEXIST if another bridge won the race.
+    const fd = openSync(this.lockPath, 'wx');
+    try {
+      writeSync(fd, JSON.stringify(body, null, 2));
+    } finally {
+      closeSync(fd);
+    }
   }
+}
+
+function isEexist(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: string }).code === 'EEXIST';
 }
 
 function isValidLockBody(obj: unknown): obj is LockFileBody {

--- a/scripts/cdp-bridge/test/unit/gh-251-lockfile-atomic-acquire.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-251-lockfile-atomic-acquire.test.js
@@ -1,0 +1,123 @@
+// GH#251/B195: Lockfile.acquire was a non-atomic read-then-write — readExisting()
+// → live-check → writeFileSync (O_TRUNC). Two bridges starting for the same project
+// in the same instant could both see no live lock and both "acquire", the second
+// silently truncating the first — defeating the single-bridge-per-project guarantee.
+// Fix: the same openSync('wx') atomic exclusive-create pattern as DeviceLock.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Lockfile } from '../../dist/lifecycle/lockfile.js';
+
+function makeTmpDir() {
+  return mkdtempSync(join(tmpdir(), 'lockfile-race-test-'));
+}
+
+const NOW = 1_700_000_000_000;
+const FOREIGN_PID = 99999;
+
+function foreignLiveBody() {
+  return {
+    pid: FOREIGN_PID,
+    projectRoot: '/fake/project/root',
+    startedAt: NOW - 5_000,
+    lastHeartbeat: NOW - 1_000,
+    ppid: 4242,
+    version: '0.99.0-foreign',
+  };
+}
+
+function makeLockfile(tmpDir, overrides = {}) {
+  return new Lockfile({
+    projectRoot: '/fake/project/root',
+    pid: 12345,
+    tmpDir,
+    uid: 501,
+    version: '0.23.0-test',
+    clock: () => NOW,
+    processAlive: () => true,
+    processName: () => 'node cdp-bridge',
+    processParent: () => 4242,
+    selfPpid: () => 777,
+    ...overrides,
+  });
+}
+
+test('#251 a foreign lock that lands mid-acquire is never silently overwritten', () => {
+  const tmpDir = makeTmpDir();
+  try {
+    const lockPath = join(tmpDir, 'rn-dev-agent-cdp-501-' + hashOf('/fake/project/root') + '.lock');
+    // Simulate the race deterministically: the injected selfPpid (called while
+    // acquire() builds the lock body) plays the part of a second bridge whose
+    // exclusive create wins the gap between our liveness check and our write.
+    // Conditional on !existsSync, exactly like a real wx create would be.
+    let foreignWrote = false;
+    const lockfile = makeLockfile(tmpDir, {
+      selfPpid: () => {
+        if (!existsSync(lockPath)) {
+          writeFileSync(lockPath, JSON.stringify(foreignLiveBody(), null, 2), 'utf8');
+          foreignWrote = true;
+        }
+        return 777;
+      },
+    });
+    assert.equal(lockfile.lockPath, lockPath, 'test must target the real lock path');
+
+    const result = lockfile.acquire();
+
+    if (foreignWrote) {
+      // The foreign bridge won the race: we must report conflict and leave its lock intact.
+      assert.equal(result.status, 'conflict');
+      assert.equal(result.pid, FOREIGN_PID);
+      const body = JSON.parse(readFileSync(lockPath, 'utf8'));
+      assert.equal(body.pid, FOREIGN_PID, 'foreign lock must not be truncated/overwritten');
+    } else {
+      // We created the file first (exclusive create won): we own it.
+      assert.equal(result.status, 'acquired');
+      const body = JSON.parse(readFileSync(lockPath, 'utf8'));
+      assert.equal(body.pid, 12345);
+    }
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('#251 stale-holder reclaim still works through the exclusive-create path', () => {
+  const tmpDir = makeTmpDir();
+  try {
+    const lockfile = makeLockfile(tmpDir, {
+      processAlive: () => false, // holder pid is dead → reclaimable
+    });
+    writeFileSync(lockfile.lockPath, JSON.stringify(foreignLiveBody(), null, 2), 'utf8');
+
+    const result = lockfile.acquire();
+    assert.equal(result.status, 'acquired');
+    const body = JSON.parse(readFileSync(lockfile.lockPath, 'utf8'));
+    assert.equal(body.pid, 12345, 'reclaimed lock is rewritten with our pid');
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('#251 live-holder conflict still reported with holder details', () => {
+  const tmpDir = makeTmpDir();
+  try {
+    const lockfile = makeLockfile(tmpDir);
+    writeFileSync(lockfile.lockPath, JSON.stringify(foreignLiveBody(), null, 2), 'utf8');
+
+    const result = lockfile.acquire();
+    assert.equal(result.status, 'conflict');
+    assert.equal(result.pid, FOREIGN_PID);
+    assert.equal(result.projectRoot, '/fake/project/root');
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// Mirror of lockfile.ts's path derivation so the race test can pre-compute lockPath.
+import { createHash } from 'node:crypto';
+import { resolve } from 'node:path';
+function hashOf(projectRoot) {
+  return createHash('md5').update(resolve(projectRoot)).digest('hex').slice(0, 8);
+}

--- a/scripts/ensure-maestro-runner.sh
+++ b/scripts/ensure-maestro-runner.sh
@@ -31,7 +31,7 @@ echo "  - Generate CI-ready Maestro YAML test files"
 echo ""
 echo "Installing maestro-runner (~24MB)..."
 
-if curl -fsSL https://open.devicelab.dev/install/maestro-runner | bash 2>&1; then
+if curl -fsSL --connect-timeout 10 --max-time 90 https://open.devicelab.dev/install/maestro-runner | bash 2>&1; then
   echo ""
   echo "maestro-runner installed successfully."
   # Verify

--- a/scripts/test/session-start-bounded.test.sh
+++ b/scripts/test/session-start-bounded.test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Regression test for GH#252/B196 — SessionStart must be bounded. The hook runs
+# installers (npm install, curl | bash) on fresh machines; without an explicit
+# hook timeout and curl time limits, a stalled CDN blocks every session start
+# and the install is silently re-attempted each session.
+#
+# Run: bash scripts/test/session-start-bounded.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+fail=0
+ok() { echo "ok: $1"; }
+bad() { echo "FAIL: $1"; fail=1; }
+
+# 1. Every SessionStart hook entry declares an explicit timeout.
+if python3 - "$REPO_ROOT/hooks/hooks.json" << 'EOF'
+import json, sys
+h = json.load(open(sys.argv[1]))["hooks"]
+entries = [hh for e in h.get("SessionStart", []) for hh in e["hooks"]]
+sys.exit(0 if entries and all(isinstance(hh.get("timeout"), (int, float)) and hh["timeout"] > 0 for hh in entries) else 1)
+EOF
+then ok "hooks.json: SessionStart entries declare a timeout"
+else bad "hooks.json: SessionStart entry missing an explicit timeout"; fi
+
+# 2. The network installer the SessionStart path reaches must bound its curl.
+CURL_LINE="$(grep -E '^\s*if curl .*open\.devicelab\.dev' "$REPO_ROOT/scripts/ensure-maestro-runner.sh" || true)"
+if [ -z "$CURL_LINE" ]; then
+  bad "ensure-maestro-runner.sh: expected install curl line not found (pattern drift?)"
+else
+  case "$CURL_LINE" in
+    *--max-time*) ok "ensure-maestro-runner.sh: curl bounded with --max-time" ;;
+    *) bad "ensure-maestro-runner.sh: install curl has no --max-time (can hang on a stalled CDN)" ;;
+  esac
+  case "$CURL_LINE" in
+    *--connect-timeout*) ok "ensure-maestro-runner.sh: curl bounded with --connect-timeout" ;;
+    *) bad "ensure-maestro-runner.sh: install curl has no --connect-timeout" ;;
+  esac
+fi
+
+exit $fail


### PR DESCRIPTION
Closes #251 (B195) and #252 (B196) from the 2026-06-09 repo-wide bug hunt — the two small startup-hardening fixes, one commit each.

## #251 / B195 — `Lockfile.acquire` was a non-atomic read-then-write

`readExisting()` → live-check → `writeFileSync` (O_TRUNC, not exclusive): two bridges starting for the same project in the same instant could both see no live lock and both "acquire" — the second silently truncating the first, defeating the single-bridge-per-project guarantee the lock exists for.

Now mirrors `DeviceLock`'s proven pattern:
- `openSync(path, 'wx')` atomic exclusive create — the loser gets EEXIST and evaluates the winner's lock as a structured conflict
- stale-holder reclaim re-reads immediately before unlink and bails if a different, now-live holder appeared (narrowed steal window); the post-unlink race is still caught atomically by the second 'wx' create
- fs infra errors (not contention) **fail open** with `degraded: true` instead of throwing — `acquire()` runs unguarded at boot in `index.ts`, so a throw would have crashed the bridge; this also matches the documented DeviceLock fail-open philosophy

All GH#182 orphan-reclaim/heartbeat semantics are untouched (`isLockLive` unchanged); the full existing lockfile suite passes unmodified.

## #252 / B196 — SessionStart could block indefinitely

The SessionStart hook runs installers (`npm install`, `curl | bash`) on fresh machines, but was the only hook entry with **no timeout**, and the maestro-runner installer's curl had no `--max-time`/`--connect-timeout` — a stalled CDN blocked every session start.

- `hooks.json` SessionStart now declares `timeout: 120` (first-run installs get a fair window, but bounded)
- the installer curl carries `--connect-timeout 10 --max-time 90`
- new `scripts/test/session-start-bounded.test.sh` pins both invariants and runs in CI next to the changeset guard

## Test plan

- TDD red-first on both: the lockfile race test deterministically simulates a foreign lock landing mid-acquire via the injected `selfPpid` (watched failing: old code returned `acquired` and truncated the foreign lock); the shell test watched failing on all three checks
- New lockfile tests also pin stale-reclaim and live-conflict through the new path
- Full cdp-bridge unit suite: **1852/1852**; `dist/` rebuilt and staged; changeset added

🤖 Generated with [Claude Code](https://claude.com/claude-code)