### PR TITLE
fix(#253): derive repair platform from the device session, not hardcoded ios (B197)

### DIFF
--- a/.changeset/gh-253-repair-action-android-platform.md
+++ b/.changeset/gh-253-repair-action-android-platform.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-cdp": patch
+"rn-dev-agent-plugin": patch
+---
+
+fix(#253): `cdp_repair_action` no longer hardcodes `targetPlatform='ios'` — Android auto-repair works against an emulator. The repair orchestrator now derives the platform from the active device session via `detectPlatform()` (booted-device probe fallback when no session is open; `'ios'` only as the final no-session, no-device fallback). Previously an Android repair foregrounded the app via `xcrun simctl`, snapshotted through the iOS short-circuit, and bootstrapped the iOS fast-runner — so Android selector drift always escalated as a hard failure instead of self-healing.

--- a/scripts/cdp-bridge/dist/tools/repair-action.js
+++ b/scripts/cdp-bridge/dist/tools/repair-action.js
@@ -16,6 +16,7 @@ import { repairBudgetAvailable, recentRepairCount } from '../domain/reusable-act
 import { snapshotEnvelopeFailed } from './device-batch.js';
 import { resolveBundleId } from '../project-config.js';
 import { isAgentDeviceRunnerSentinel } from './runner-leak-recovery.js';
+import { detectPlatform } from './platform-utils.js';
 import { stopFastRunner } from '../runners/rn-fast-runner-client.js';
 const execFile = promisify(execFileCb);
 /**
@@ -146,9 +147,12 @@ export function createRepairActionHandler() {
         // GH #105 / B153: bring the target app to foreground before snapshot.
         // Without this, the snapshot lands on whichever app is frontmost — often
         // the Agent Device Runner (XCTest test rig) which has zero app testIDs.
-        // Resolve bundle id from app.json via project-config; fall back to ios
-        // platform if the connected target hasn't told us yet.
-        const targetPlatform = 'ios'; // TODO(gh-105 follow-up): plumb platform from CDP target
+        // GH #253 / B197: platform comes from the active device session (probe
+        // fallback when none is open) — a hardcoded 'ios' made the whole repair
+        // loop foreground via simctl, snapshot via the iOS short-circuit, and
+        // bootstrap the iOS fast-runner against Android emulators. 'ios' remains
+        // the final fallback for the no-session, no-device edge.
+        const targetPlatform = (await detectPlatform()) ?? 'ios';
         const targetBundleId = resolveBundleId(targetPlatform);
         if (targetBundleId) {
             await bringTargetAppToForeground(targetPlatform, targetBundleId);

--- a/scripts/cdp-bridge/src/tools/repair-action.ts
+++ b/scripts/cdp-bridge/src/tools/repair-action.ts
@@ -27,6 +27,7 @@ import { repairBudgetAvailable, recentRepairCount } from '../domain/reusable-act
 import { snapshotEnvelopeFailed } from './device-batch.js';
 import { resolveBundleId } from '../project-config.js';
 import { isAgentDeviceRunnerSentinel, type RunnerLeakNode } from './runner-leak-recovery.js';
+import { detectPlatform } from './platform-utils.js';
 import { stopFastRunner } from '../runners/rn-fast-runner-client.js';
 
 const execFile = promisify(execFileCb);
@@ -221,9 +222,12 @@ export function createRepairActionHandler() {
     // GH #105 / B153: bring the target app to foreground before snapshot.
     // Without this, the snapshot lands on whichever app is frontmost — often
     // the Agent Device Runner (XCTest test rig) which has zero app testIDs.
-    // Resolve bundle id from app.json via project-config; fall back to ios
-    // platform if the connected target hasn't told us yet.
-    const targetPlatform = 'ios'; // TODO(gh-105 follow-up): plumb platform from CDP target
+    // GH #253 / B197: platform comes from the active device session (probe
+    // fallback when none is open) — a hardcoded 'ios' made the whole repair
+    // loop foreground via simctl, snapshot via the iOS short-circuit, and
+    // bootstrap the iOS fast-runner against Android emulators. 'ios' remains
+    // the final fallback for the no-session, no-device edge.
+    const targetPlatform = (await detectPlatform()) ?? 'ios';
     const targetBundleId = resolveBundleId(targetPlatform);
     if (targetBundleId) {
       await bringTargetAppToForeground(targetPlatform, targetBundleId);

--- a/scripts/cdp-bridge/test/unit/repair-action-handler.test.js
+++ b/scripts/cdp-bridge/test/unit/repair-action-handler.test.js
@@ -109,6 +109,75 @@ test('repair-action: happy path patches stale selector with fuzzy match', async 
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Platform plumbing (GH #253 / B197) — the snapshot dispatch must carry the
+// active session's platform, not a hardcoded 'ios'. With 'ios' hardcoded, an
+// Android repair foregrounds via simctl, snapshots via the iOS short-circuit,
+// and bootstraps the iOS fast-runner — none of which work against an emulator.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('GH #253: android session → snapshot dispatched with platform android', async () => {
+  setActiveSession({
+    ...FAKE_SESSION,
+    platform: 'android',
+    deviceId: 'emulator-5554',
+  });
+  project.seedAction(
+    'android-repair',
+    fixtureYaml({ id: 'android-repair', selectors: ['fab-create-task'] }),
+  );
+
+  let capturedOpts;
+  _setRunAgentDeviceForTest(async (cliArgs, opts) => {
+    capturedOpts = opts;
+    return {
+      content: [{ type: 'text', text: fakeSnapshot(['fab-create-task-btn']) }],
+    };
+  });
+
+  const handler = createRepairActionHandler();
+  const result = await handler({
+    actionId: 'android-repair',
+    failedSelector: 'fab-create-task',
+    projectRoot: project.root,
+  });
+
+  assert.equal(result.isError, undefined, `expected ok, got ${result.content[0].text}`);
+  assert.equal(
+    capturedOpts?.platform,
+    'android',
+    `snapshot must dispatch with the session platform; got ${capturedOpts?.platform} — ` +
+    `a hardcoded 'ios' routes the snapshot through the iOS short-circuit on an emulator`,
+  );
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.data.patched, true, 'repair itself must still succeed on android');
+});
+
+test('GH #253: ios session → snapshot dispatched with platform ios (regression guard)', async () => {
+  project.seedAction(
+    'ios-repair',
+    fixtureYaml({ id: 'ios-repair', selectors: ['fab-create-task'] }),
+  );
+
+  let capturedOpts;
+  _setRunAgentDeviceForTest(async (cliArgs, opts) => {
+    capturedOpts = opts;
+    return {
+      content: [{ type: 'text', text: fakeSnapshot(['fab-create-task-btn']) }],
+    };
+  });
+
+  const handler = createRepairActionHandler();
+  const result = await handler({
+    actionId: 'ios-repair',
+    failedSelector: 'fab-create-task',
+    projectRoot: project.root,
+  });
+
+  assert.equal(result.isError, undefined, `expected ok, got ${result.content[0].text}`);
+  assert.equal(capturedOpts?.platform, 'ios');
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Validation paths
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `cdp_repair_action` hardcoded `targetPlatform='ios'` (the gh-105 TODO at `repair-action.ts:226`), so on an Android session the repair loop foregrounded via `xcrun simctl`, snapshotted through the iOS short-circuit, and bootstrapped the iOS fast-runner — Android selector drift always escalated as a hard failure.
- The orchestrator now resolves the platform with `detectPlatform()` (active device session first, booted-device probes after, `'ios'` only as the no-session/no-device fallback) — the same policy used by the seven other platform-resolving tools.
- Everything downstream was already platform-aware (adb foreground branch, `resolveBundleId('android')` → `expo.android.package`, ios-gated fast-runner bootstrap); this was the last hardcoded seam.

## Tests
- New unit test: an Android session must dispatch the snapshot with `platform: 'android'` — red on the old code (`'ios' !== 'android'`), green after.
- New iOS regression guard asserting the dispatch still carries `platform: 'ios'` for iOS sessions.
- Full suite: 1854/1854 pass.

## Live-gate (Android emulator, per the issue's verification requirement)
Ran the built handler directly against booted `emulator-5554` with an Android session active:
1. Snapshot dispatched through the Android runner (error envelope for a non-installed package originated from the on-device instrumentation, not iOS machinery) in ~1.2s.
2. Against the installed Settings app: full pipeline — adb foreground → Android snapshot → 38 real candidate identifiers extracted → fuzzy match → correct guarded `TESTID_NOT_FOUND` refusal (best score 0.28 < 0.6 threshold), no false patch.

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)