### PR TITLE
chore: gitignore scripts/cdp-bridge/eval/ (local-only live-gate harnesses)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ scripts/rn-fast-runner/**/DerivedData/
 # pause sentinel, inflight locks) nests under a single directory so one
 # line covers everything including future additions.
 .codex-pair/
+
+# cdp-bridge eval harnesses (local-only dev scaffolding — live-gate scripts
+# driven against booted devices, e.g. eval/live-gate-gh253.mjs; not shipped)
+scripts/cdp-bridge/eval/


### PR DESCRIPTION
## Summary
- Adds `scripts/cdp-bridge/eval/` to the root `.gitignore`, following the existing local-only scaffolding pattern (`.worktrees/`, `.deepsec/`, `.codex-pair/`).
- The directory holds dev-machine eval/live-gate harnesses driven against booted devices (e.g. `live-gate-gh253.mjs` from the B197 fix, and the #243/#244 live-verify scripts) — useful locally, not shipped with the plugin.
- No src change → no changeset needed (the `require-changeset` guard only gates shippable MCP source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)