### PR TITLE
feat(skills): creating-actions — guided authoring of reusable Maestro actions

### DIFF
--- a/.changeset/creating-actions-skill.md
+++ b/.changeset/creating-actions-skill.md
@@ -1,0 +1,7 @@
+---
+"rn-dev-agent-plugin": minor
+---
+
+New `creating-actions` skill — guided authoring of reusable Maestro actions.
+
+Walks the agent through the full authoring contract: inventory-dedup scan before authoring (via `learned-actions.mjs`), creation-path choice (recorder vs direct YAML vs `maestro_generate`), selector grounding (never invent a testID), a **required ASCII flow diagram** of screens/transitions annotated with exact testIDs and `${PARAMS}` (embedded in the YAML header — glyph-first lines so the M7 parser can't misread a diagram line as metadata, which would otherwise silently overwrite fields like `status`), the M7 header contract, pre-replay validation (header round-trip through the inventory parser, placeholder↔params coverage, selector audit), and replay-to-promote via `cdp_run_action` (never hand-set `active`). Ships with a full M7 field reference (`references/m7-header-reference.md`) and a toolchain-validated worked example (`examples/add-product-to-cart.yaml` — verified against `parseM7Header`, `learned-actions.mjs`, and Maestro's syntax checker). Routed from `using-rn-dev-agent` (decision tree + skill map) and cross-linked from `rn-testing`'s M7 section.

--- a/.changeset/run-action-params-schema.md
+++ b/.changeset/run-action-params-schema.md
@@ -1,0 +1,7 @@
+---
+"rn-dev-agent-cdp": minor
+---
+
+Expose `params` in the `maestro_run` and `cdp_run_action` MCP tool schemas.
+
+Both handlers have accepted `params` since GH #116 (forwarded to maestro as `-e KEY=VALUE` on the first attempt AND the post-repair retry), but the zod registrations omitted the field — and zod strips unknown keys by default, so a caller's parameter bindings were **silently dropped** at the tool-call layer and a parameterised action failed at runtime with unset `${VAR}` placeholders. Found by Codex review on PR #272 (the new `creating-actions` skill recommends `cdp_run_action({ actionId, params, trigger })`, which was un-callable as advertised; `commands/run-action.md` documented the same call shape). Key-format validation (`/^[A-Z_][A-Z0-9_]*$/`) stays in the handler. Wiring test pins both registrations.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -26,7 +26,8 @@
     "./skills/rn-testing",
     "./skills/rn-debugging",
     "./skills/rn-best-practices",
-    "./skills/rn-setup"
+    "./skills/rn-setup",
+    "./skills/creating-actions"
   ],
   "agents": [
     "./agents/rn-tester.md",

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -549,6 +549,7 @@ trackedTool('maestro_run', 'Execute a Maestro flow via maestro-runner. Pass flow
     appId: z.string().optional().describe('App bundle ID (auto-detected from app.json)'),
     appFile: z.string().optional().describe('iOS only — path to a built .app/.ipa for maestro-runner to reinstall on clearState. Auto-resolved from the flow appId when omitted (GH#201).'),
     timeoutMs: z.number().int().min(5000).max(300000).default(120000).describe('Execution timeout in ms'),
+    params: z.record(z.string(), z.string()).optional().describe('GH #116: parameter bindings forwarded as -e KEY=VALUE for ${KEY} placeholders in the flow. Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in the handler).'),
 }, createMaestroRunHandler());
 trackedTool('maestro_generate', 'Generate a persistent Maestro YAML flow file from structured steps. Writes to .rn-agent/actions/<name>.yaml in the project root. Use after live verification to create reusable actions.', {
     name: z.string().describe('Flow name (e.g. "add-to-cart", "profile-edit"). Becomes filename.'),
@@ -686,6 +687,7 @@ trackedTool('cdp_run_action', 'Replay a learned action by id with end-to-end aut
     timeoutMs: z.number().optional().describe('Maestro execution timeout per attempt (ms). Default 120_000.'),
     trigger: z.enum(['agent', 'ci', 'human']).optional().describe('RunRecord trigger annotation. Default "agent". CI calls should pass "ci".'),
     forceReload: z.boolean().optional().describe('GH #173: when true (default), acknowledge any human edit to the YAML as the new baseline before running so downstream repair does not abort with STALE_TARGET. Pass false for the strict Phase 129 "respect external edits" behavior (useful for CI replays of fixed baselines).'),
+    params: z.record(z.string(), z.string()).optional().describe('Parameter bindings for the action\'s ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).'),
 }, 
 // GH #186: supply a CDP-backed live-route reader so the route-drift guard is
 // actually active. Without this the handler defaulted getLiveRoute to a no-op

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -898,6 +898,7 @@ trackedTool(
     appId: z.string().optional().describe('App bundle ID (auto-detected from app.json)'),
     appFile: z.string().optional().describe('iOS only — path to a built .app/.ipa for maestro-runner to reinstall on clearState. Auto-resolved from the flow appId when omitted (GH#201).'),
     timeoutMs: z.number().int().min(5000).max(300000).default(120000).describe('Execution timeout in ms'),
+    params: z.record(z.string(), z.string()).optional().describe('GH #116: parameter bindings forwarded as -e KEY=VALUE for ${KEY} placeholders in the flow. Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in the handler).'),
   },
   createMaestroRunHandler(),
 );
@@ -1158,6 +1159,7 @@ trackedTool(
     timeoutMs: z.number().optional().describe('Maestro execution timeout per attempt (ms). Default 120_000.'),
     trigger: z.enum(['agent', 'ci', 'human']).optional().describe('RunRecord trigger annotation. Default "agent". CI calls should pass "ci".'),
     forceReload: z.boolean().optional().describe('GH #173: when true (default), acknowledge any human edit to the YAML as the new baseline before running so downstream repair does not abort with STALE_TARGET. Pass false for the strict Phase 129 "respect external edits" behavior (useful for CI replays of fixed baselines).'),
+    params: z.record(z.string(), z.string()).optional().describe('Parameter bindings for the action\'s ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).'),
   },
   // GH #186: supply a CDP-backed live-route reader so the route-drift guard is
   // actually active. Without this the handler defaulted getLiveRoute to a no-op

--- a/scripts/cdp-bridge/test/unit/pr-272-params-schema-wiring.test.js
+++ b/scripts/cdp-bridge/test/unit/pr-272-params-schema-wiring.test.js
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const indexSrc = readFileSync(resolve(__dirname, '../../src/index.ts'), 'utf8');
+
+// PR #272 review (Codex P2): both handlers accept `params` (GH #116 — forwarded
+// as -e KEY=VALUE on first attempt AND post-repair retry), but the MCP zod
+// registrations omitted the field. zod strips unknown keys by default, so a
+// caller's params were SILENTLY DROPPED at the tool-call layer and a
+// parameterised action failed with unset placeholders. These tests pin the
+// schema exposure so the registration can't regress behind the handlers again.
+
+/** Slice the trackedTool('<name>', ...) registration block out of index.ts. */
+function registrationBlock(toolName) {
+  const start = indexSrc.indexOf(`'${toolName}',`);
+  assert.notEqual(start, -1, `registration for ${toolName} not found`);
+  const rest = indexSrc.slice(start);
+  const next = rest.indexOf('trackedTool(', 1);
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+test('PR#272 maestro_run registration exposes params as a string record', () => {
+  assert.match(registrationBlock('maestro_run'), /params:\s*z\.record\(z\.string\(\), z\.string\(\)\)\.optional\(\)/);
+});
+
+test('PR#272 cdp_run_action registration exposes params as a string record', () => {
+  assert.match(registrationBlock('cdp_run_action'), /params:\s*z\.record\(z\.string\(\), z\.string\(\)\)\.optional\(\)/);
+});

--- a/skills/creating-actions/SKILL.md
+++ b/skills/creating-actions/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: creating-actions
+description: This skill should be used when the user asks to "create an action", "save this flow as an action", "make this replayable", "record a reusable action", "author a Maestro flow as an action", "add a login/setup action", or when a verified UI walk should be persisted under .rn-agent/actions/ so future sessions can replay it with maestro.
+---
+
+# creating-actions — Author a Reusable Maestro Action
+
+An **action** is a parameterised Maestro flow at `<project>/.rn-agent/actions/<id>.yaml` with an M7 metadata header, replayable via `/rn-dev-agent:run-action` or `cdp_run_action` (auto-repair-aware). A well-authored action turns a ~minutes interactive walk into a ~seconds deterministic replay. Authoring one well means: **dedup first, ground every selector in evidence, design the flow as an ASCII diagram before writing YAML, validate, then replay to promote.**
+
+## When to Use
+
+- A verified flow is worth replaying: login, navigation prologue, multi-step setup, locale/theme switching, data seeding.
+- `/rn-dev-agent:test-feature` verification passed and the walk should be persisted.
+- The user asks to make a flow replayable / save an action.
+
+**When NOT to author an action:**
+- A one-off check — use `maestro_run` with `inlineYaml` and throw it away.
+- An existing action already covers the flow — extend or parameterise it instead of forking a near-duplicate.
+- The flow spans two apps — actions are single-`appId` by contract.
+
+## Step 0 — Scan the Inventory First (dedup)
+
+Before authoring anything, check what already exists:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/learned-actions.mjs" --json --section b \
+  --workspace-root "$PWD" --memory-cwd "$PWD" --filter <keyword>
+```
+
+(or `/rn-dev-agent:list-learned-actions <keyword>`). If a match covers the goal, replay it. If a near-match exists (same flow, hardcoded values), parameterise THAT action with `${VAR}` placeholders rather than creating a sibling — duplicate actions rot independently and split the repair history.
+
+## Step 1 — Pick the Creation Path
+
+| Situation | Path |
+|---|---|
+| About to walk the flow live on a device anyway | **Recorder**: `cdp_record_test_start` → drive UI (`cdp_interact` / `device_*`) → `cdp_record_test_stop` → `cdp_record_test_save_as_action` (writes header + sidecar; pass `intent`/`tags`/`mutates`/`produces` yourself — the recorder cannot infer them) |
+| Flow and selectors already known (prior exploration, existing test) | **Direct authoring** — Steps 2–6 below |
+| Structured steps in hand, want generated YAML | `maestro_generate` — then verify the M7 header per Step 4 and continue with Steps 5–6 |
+
+The recorder path still benefits from Steps 3 (diagram) and 5–6 (validate, replay to promote): add the diagram to the generated YAML's header before first replay.
+
+## Step 2 — Ground Every Selector (never invent a testID)
+
+Collect evidence for every element the flow will touch:
+
+- `cdp_component_tree(filter="<screen-or-component>")` per screen — filtered, never the full tree
+- `device_snapshot` for what is actually on the native screen
+- `grep -r 'testID=' src/` for static discovery
+- `cdp_nav_graph` / `cdp_navigation_state` for exact route names (used in `expectedRouteSequence`)
+
+If an element the flow needs has **no testID, stop and add one to the app source first** (see the rn-testing skill for testID conventions). Text-based selectors break on i18n and copy edits; an action built on them generates repair churn.
+
+## Step 3 — Draw the ASCII Flow Diagram (required, before any YAML)
+
+Map the flow screen-by-screen with the exact selectors. This is the design-review artifact: parameter gaps, missing assertion anchors, and wrong start-state assumptions are cheap to fix here and expensive to fix after the YAML exists.
+
+Canonical format — one `[RouteName]` box line per screen, `│`-arrow lines for interactions, each labelled with the exact selector; one **anchor** (the `assertVisible` proving arrival) per screen; `${PARAMS}` marked where caller data flows in:
+
+```
+[any screen]
+     │ launchApp (stopApp: false)
+     │ tapOn tab-home
+     ▼
+[Home]  anchor: product-list
+     │ scrollUntilVisible product-card-${PRODUCT_ID}   (if off-screen)
+     │ tapOn product-add-btn-${PRODUCT_ID}
+     ▼
+[Home]  cart-badge increments
+     │ tapOn tab-cart
+     ▼
+[Cart]  anchor: cart-list
+        verify: cart-item-${PRODUCT_ID}
+```
+
+Review the diagram against Step-2 evidence before continuing:
+- [ ] Every selector in the diagram exists in the gathered tree/snapshot
+- [ ] Every transition has an anchor on the destination screen
+- [ ] Everything caller-variable is a `${PARAM}`; everything else is fixed
+- [ ] The entry assumption is explicit (works from any screen? requires login?)
+
+**Embed the diagram in the YAML header** (below the M7 block) so the action documents itself and repair reviews can see intended structure. Safety rules for embedding — the M7 parser trims each comment line and treats a leading `word: value` as metadata:
+
+1. Every line starts with `#` — a fully blank line ends the header block.
+2. Every diagram line's content starts with a **non-letter glyph** (`[`, `│`, `▼`, `(`, indentation is NOT enough). A line like `# status: shows spinner` would silently **overwrite the action's `status` metadata**.
+
+## Step 4 — Write the YAML
+
+```yaml
+appId: com.example.shop
+---
+# id: add-product-to-cart
+# intent: From any screen, add product PRODUCT_ID to the cart and verify it landed.
+# tags: [cart, add, smoke]
+# mutates: true
+# status: experimental
+# params: [PRODUCT_ID]
+# appId: com.example.shop
+#
+# [diagram from Step 3 — every line #-prefixed, glyph-first]
+- launchApp:
+    stopApp: false
+- tapOn:
+    id: "tab-home"
+- assertVisible:
+    id: "product-list"
+# ... steps mirror the diagram 1:1
+```
+
+Contract rules (violations break replay, repair, or inventory):
+
+- **id / filename**: lower-case kebab-case `^[a-z0-9][a-z0-9-]*$`; file is `.rn-agent/actions/<id>.yaml`.
+- **Header**: `id`, `intent`, `tags`, `mutates`, `status` are the 5 inventory keys — a missing `mutates` renders as `?` in `/list-learned-actions`. Always `status: experimental` at creation; promotion to `active` is earned by a clean replay, never hand-set. Full field glossary (incl. `produces`, `expectedRouteSequence`, `author`): `references/m7-header-reference.md`.
+- **Params**: keys match `[A-Z_][A-Z0-9_]*`; every `${VAR}` in the steps is listed in `# params`, and vice versa. The inventory scanner counts `${...}` occurrences **anywhere in the file, comments included** — so the diagram may mark real step params as `${PRODUCT_ID}`, but prose (e.g. the `intent` line) uses bare names, and no comment may mention a `${VAR}` the steps don't use.
+- **Body**: `launchApp: { stopApp: false }` self-bootstrap (works cold or warm, preserves login); conditional prologues via `runFlow: { when: { visible: ... } }`; `waitForAnimationToEnd` after transitions; the diagram's anchor `assertVisible` after each screen change; `scrollUntilVisible` for potentially off-screen targets.
+- **Never `clearState: true`** on an Expo Dev Client build — it wipes the Metro URL and strands the launcher (GH #8).
+- Do **not** hand-write the sidecar (`.rn-agent/state/<id>.state.json`) — it is created lazily on first load/replay.
+
+Copy-adapt the complete worked example: `examples/add-product-to-cart.yaml`.
+
+## Step 5 — Validate Before First Replay
+
+1. **Header parses + inventory lists it**: re-run the Step-0 command with `--filter <id>` — confirm `intent`, `tags`, `mutates`, `status` come back exactly as written (not `?`). This also proves the embedded diagram didn't corrupt the header.
+2. **Placeholder coverage**: `grep -o '\${[A-Z_]*}' <file>` over the steps ↔ `# params` list, both directions.
+3. **Selector audit**: every `id:` in the YAML appears in the Step-2 evidence.
+4. **Syntax**: if the maestro MCP server is connected, `check_flow_syntax` on the body; otherwise the first replay doubles as the syntax check.
+
+## Step 6 — Replay to Promote
+
+Replay through the orchestrator — not raw `maestro_run` — so the run is recorded and auto-repair-aware:
+
+```
+cdp_run_action({ actionId: "<id>", params: { PRODUCT_ID: "7" }, trigger: "agent" })
+```
+
+- First clean pass auto-promotes `experimental → active` and materialises the sidecar.
+- Verify the outcome by **state, not pixels**: `cdp_store_state`, `expect_redux` / `expect_route` / `expect_visible_by_testid`.
+- `mutates: true` actions leave residue — clean up between runs or use timestamp-suffixed param values so repeated replays stay deterministic.
+- Exercise the variable branch (e.g. one on-screen and one off-screen `PRODUCT_ID`) before trusting the action.
+- **No device available?** Leave `status: experimental` and say so explicitly — never hand-promote.
+
+After any later auto-repair or manual selector edit, **update the embedded diagram** to match — a stale diagram misleads the next repair review.
+
+## Quick Reference
+
+| What | Where / Rule |
+|---|---|
+| Action file | `<project>/.rn-agent/actions/<id>.yaml` |
+| Sidecar (auto-created) | `<project>/.rn-agent/state/<id>.state.json` |
+| id regex | `^[a-z0-9][a-z0-9-]*$` |
+| param key regex | `[A-Z_][A-Z0-9_]*` |
+| Inventory / dedup | `scripts/learned-actions.mjs` or `/rn-dev-agent:list-learned-actions` |
+| Replay | `cdp_run_action` / `/rn-dev-agent:run-action <id> -e KEY=VAL` |
+| Lifecycle | `experimental` → (clean replay) → `active`; repair demotes back to `experimental`; `deprecated` = never replay |
+| Repair budget | 3 auto-repairs per rolling 24h per action |
+
+## Common Mistakes
+
+| Mistake | Consequence |
+|---|---|
+| Skipping the Step-0 inventory scan | Duplicate actions that drift apart; repair history split |
+| Inventing a testID that "should" exist | `SELECTOR_NOT_FOUND` on first replay; wasted repair budget |
+| Hardcoding values instead of `${PARAMS}` | Action only replays one scenario; near-duplicates multiply |
+| `status: active` at creation | Unvalidated flow treated as production-quality by replay-first routing |
+| Diagram line starting with a bare `word:` | Silently overwrites M7 metadata (e.g. `status`) |
+| Blank (non-`#`) line inside the header | Parser stops early; later M7 keys ignored |
+| `${VAR}` in a comment that no step uses | Inventory synthesizes a phantom `-e VAR=...`; replay pre-flight demands a param the flow ignores |
+| `clearState: true` on Dev Client | App strands on the Dev Client launcher (GH #8) |
+| Raw `maestro_run` for a saved action | No RunRecord, no auto-repair, no promotion |
+| Hand-writing the sidecar | Stale `lastSeenMtimeMs` → false `EXTERNAL_EDIT` repair refusals |
+
+## Related
+
+- **rn-testing skill** — Maestro step patterns, timing rules, testID conventions, auth/permission pre-flights
+- **`references/m7-header-reference.md`** — every M7 field with semantics, parser behavior, lifecycle transitions
+- **`examples/add-product-to-cart.yaml`** — complete worked example with embedded diagram
+- **`/rn-dev-agent:run-action`** — replay-side pre-flight (mutates confirmation, appId match, param coverage)

--- a/skills/creating-actions/examples/add-product-to-cart.yaml
+++ b/skills/creating-actions/examples/add-product-to-cart.yaml
@@ -1,0 +1,58 @@
+appId: com.example.shop
+---
+# id: add-product-to-cart
+# intent: From any screen, add product PRODUCT_ID to the cart and verify it landed in the cart list.
+# tags: [cart, add, smoke]
+# mutates: true
+# status: experimental
+# params: [PRODUCT_ID]
+# appId: com.example.shop
+# author: human
+# produces: { route: Cart, cartItemAdded: true }
+# expectedRouteSequence: [Home, Cart]
+#
+# Flow diagram (selectors grounded in cdp_component_tree on 2026-06-11):
+#
+#   [any screen]
+#        │ launchApp (stopApp: false)
+#        │ tapOn tab-home
+#        ▼
+#   [Home]  anchor: product-list
+#        │ scrollUntilVisible product-card-${PRODUCT_ID}   (runFlow when notVisible)
+#        │ tapOn product-add-btn-${PRODUCT_ID}
+#        ▼
+#   [Home]  cart-badge increments
+#        │ tapOn tab-cart
+#        ▼
+#   [Cart]  anchor: cart-list
+#           (assert cart-item-${PRODUCT_ID} present)
+#
+# Replay:
+#   /rn-dev-agent:run-action add-product-to-cart -e PRODUCT_ID=7
+#   PRODUCT_ID is required — there is no default, so the run-action
+#   placeholder-coverage gate refuses a parameterless replay.
+- launchApp:
+    stopApp: false
+- tapOn:
+    id: "tab-home"
+- assertVisible:
+    id: "product-list"
+- runFlow:
+    when:
+      notVisible:
+        id: "product-card-${PRODUCT_ID}"
+    commands:
+      - scrollUntilVisible:
+          element:
+            id: "product-card-${PRODUCT_ID}"
+          direction: DOWN
+          centerElement: true
+- tapOn:
+    id: "product-add-btn-${PRODUCT_ID}"
+- tapOn:
+    id: "tab-cart"
+- waitForAnimationToEnd
+- assertVisible:
+    id: "cart-list"
+- assertVisible:
+    id: "cart-item-${PRODUCT_ID}"

--- a/skills/creating-actions/references/m7-header-reference.md
+++ b/skills/creating-actions/references/m7-header-reference.md
@@ -1,0 +1,58 @@
+# M7 Metadata Header — Field Reference
+
+The M7 header lives as `# key: value` comment lines above the Maestro YAML body. Maestro ignores comments; `scripts/learned-actions.mjs` (inventory), `cdp_run_action` (replay pre-flight), and `cdp_repair_action` (self-repair) parse them. Single source of truth for the schema: `scripts/cdp-bridge/src/domain/reusable-action.ts` (`M7Metadata`, `parseM7Header`, `serializeM7Header`).
+
+## Parser behavior (what the header may and may not contain)
+
+`parseM7Header` walks the file line by line:
+
+- Only `#`-prefixed lines are considered. Each is stripped of `# ` and **trimmed**, then matched against `^([a-zA-Z][\w-]*)\s*:\s*(.+)$`.
+- A matching line whose key is **recognized** (table below) sets that field — **later occurrences overwrite earlier ones**. This is why embedded diagram/prose lines must never begin with a bare recognized key: `# status: shows spinner` would overwrite `status`.
+- A matching line with an unrecognized key (e.g. `verify: cart-list`) is ignored — harmless but avoid relying on it.
+- Lines whose content starts with a non-letter glyph (`[`, `│`, `▼`, `(`, `-`) can never match — the safe shape for diagram lines.
+- A **fully blank line** (no `#`) after any metadata has been read ends the header. Keep the M7 block + diagram contiguous `#` lines.
+- A non-comment line (the first flow step) also ends the header.
+- `id` and `intent` are required — if either is missing the whole file fails to load as an action (`loadAction` returns null; the inventory and `cdp_run_action` won't see it). `id` falls back to the filename without `.yaml`.
+
+The `appId: <bundle>` + `---` **top section** above the comments is Maestro's own header, not part of M7 — both are needed.
+
+## Fields
+
+| Key | Required | Type / format | Semantics |
+|---|---|---|---|
+| `id` | yes | kebab-case slug `^[a-z0-9][a-z0-9-]*$` | Stable identifier; defaults to filename without `.yaml`. Set explicitly only to allow renaming the file later without breaking references. |
+| `intent` | yes | one line of prose | The routing key: `/list-learned-actions` surfaces it verbatim; agents match tasks against it. Write it as the goal, not the mechanics. Use bare param names (`PRODUCT_ID`), never `${...}`. |
+| `tags` | recommended | `[a, b, c]` lower-case kebab | Filter keywords. Conventions: feature area (`tasks`, `auth`, `cart`), operation (`create`, `update`, `delete`), markers (`smoke`, `regression`). |
+| `mutates` | recommended | `true` / `false` | `true` if the flow leaves persistent residue (created rows, toggled settings). Drives the `/run-action` confirmation gate. Missing → rendered as `?` in the inventory. |
+| `status` | yes (defaults `experimental`) | `experimental` \| `active` \| `deprecated` | Lifecycle. See transitions below. |
+| `params` | when the body has `${VAR}` | `[KEY_A, KEY_B]`, keys `[A-Z_][A-Z0-9_]*` | The `-e KEY=VAL` surface. Auto-extracted from the body if absent, but declare explicitly so the replay pre-flight reports gaps clearly. |
+| `appId` | strongly recommended | bundle id | Replay pre-flight refuses cross-app replays when the connected target's bundle differs. Duplicate of the top-section value on purpose. |
+| `createdAt` | optional | ISO timestamp | Falls back to file ctime when absent. |
+| `author` | optional | `auto` \| `human` \| `imported` | Provenance: `auto` = emitted by the recorder pipeline (`cdp_record_test_save_as_action`); `human` = hand-authored YAML (including agent-direct-authored); `imported` = landed via import. Drives diff-noise expectations and trust. |
+| `produces` | optional | `{ key: value, ... }` single line, primitive values, no commas/newlines inside values | State postconditions a clean run establishes (e.g. `{ authenticated: true, route: home }`). Enables hybrid composition: an agent needing that state replays this action as a prologue. |
+| `expectedRouteSequence` | optional | `[Route1, Route2]` | Ordered route names the flow walks (from `cdp_nav_graph` / nav events). Enables structural drift detection: a live route off this sequence reclassifies `SELECTOR_NOT_FOUND` as `ROUTE_DRIFT`, which correctly refuses fuzzy selector repair. |
+
+## Lifecycle transitions (enforced in code — do not hand-set)
+
+```
+experimental ──(first clean cdp_run_action replay)──▶ active
+active ──(auto-repair patches the YAML)──▶ experimental   (re-validation required)
+any ──(manual archival)──▶ deprecated                      (never auto-routed or replayed)
+```
+
+- Promotion happens inside `cdp_run_action` (`shouldAutoPromoteToActive`); hand-setting `active` skips the validation the status claims.
+- Demotion after repair is intentional: a patched selector is a hypothesis until a replay proves it.
+
+## Sidecar (`.rn-agent/state/<id>.state.json`) — never hand-write
+
+Created lazily by `loadOrInitSidecar` on first load. Holds `runHistory` (cap 50), `repairHistory` (cap 25), `stats`, `revision`, and `lastSeenMtimeMs`. That last field powers external-edit detection: hand-writing or pre-creating the sidecar desynchronizes it and triggers false `EXTERNAL_EDIT` repair refusals. Repair budget: 3 successful auto-repairs per rolling 24h per action; exceeding it returns `BUDGET_EXHAUSTED` and escalates to the user.
+
+## Failure codes seen at replay (what they mean for the author)
+
+| Code | Authoring implication |
+|---|---|
+| `SELECTOR_NOT_FOUND` | A testID in the YAML isn't on screen — stale selector (repairable) or wrong anchor assumption |
+| `ROUTE_DRIFT` | Live navigation diverged from `expectedRouteSequence` — structural change; repair is refused on purpose |
+| `STATE_MISMATCH` | Flow ran but produced wrong state — real regression, not an authoring bug |
+| `MUTATE_PRECONDITION_FAILED` | Entry assumption violated (e.g. not logged in) — make the prologue conditional or compose with a login action |
+| `TIMEOUT` | Flaky timing — add `waitForAnimationToEnd` / anchor asserts instead of sleeps |

--- a/skills/rn-testing/SKILL.md
+++ b/skills/rn-testing/SKILL.md
@@ -271,6 +271,10 @@ when supplied via `GenerateOpts.id|intent|tags|mutates|status` (see
 `tools/test-recorder-generators.ts`). **Hand-written flows** must add the
 header manually before the flow is considered reusable.
 
+For the full end-to-end authoring workflow (inventory dedup, selector
+grounding, the ASCII flow diagram, validation, replay-to-promote), load the
+**creating-actions** skill.
+
 **Verification rule:** Before approving a new flow for the artifact-first
 inventory, confirm the header carries all 5 keys. A flow missing `mutates:` is
 parsed as `mutates: null` and `list-learned-actions` renders it as `?`.

--- a/skills/using-rn-dev-agent/SKILL.md
+++ b/skills/using-rn-dev-agent/SKILL.md
@@ -10,7 +10,7 @@ description: >
 
 # Using rn-dev-agent
 
-The React Native development plugin for Claude Code. **64 MCP tools**, **5 agents**, **16 commands**, **7 skills**.
+The React Native development plugin for Claude Code. **64 MCP tools**, **5 agents**, **16 commands**, **8 skills**.
 
 This skill is your front door. Before starting any RN work, use the decision tree below to route the user's intent to the right tool.
 
@@ -33,6 +33,12 @@ What is the user asking for?
 │       (Counterpart to list-learned-actions: list discovers, run executes.
 │        Pre-flights mutates flag, appId match, parameter coverage. Use to
 │        skip a 7-min manual walk when a 23-sec flow already exists.)
+│
+├── CREATE a new reusable action ("save this flow", "make this replayable")
+│   └─► Load the creating-actions skill
+│       (Inventory-dedup first, ground selectors in evidence, ASCII flow
+│        diagram, M7 header, validate, then replay to promote. Covers both
+│        the recorder path and direct YAML authoring.)
 │
 ├── BUILD a new feature / "add X to the app"
 │   └─► /rn-dev-agent:rn-feature-dev <description>
@@ -120,6 +126,7 @@ These apply to every RN task:
 | `rn-setup` | Process | User runs `/rn-dev-agent:setup` or tools fail |
 | `rn-feature-development` | Process | Inside `/rn-dev-agent:rn-feature-dev` — 8-phase pipeline |
 | `rn-testing` | Reference + process | Test writing, Maestro flows, E2E verification |
+| `creating-actions` | Process + reference | Authoring a new reusable action (save / replay a flow) |
 | `rn-debugging` | Reference + process | Diagnosing crashes, errors, blank screens |
 | `rn-device-control` | Reference | Simulator / emulator commands, screenshots |
 | `rn-best-practices` | Reference | 46 RN rules for architecture + review |


### PR DESCRIPTION
## Summary

New `creating-actions` skill (the plugin's 8th) that facilitates creating new **actions** — replayable Maestro flows under `.rn-agent/actions/` — with a required **ASCII flow-diagram design step** mapping screens/transitions to exact testIDs/selectors before any YAML is written.

The skill codifies the full authoring contract that previously lived scattered across `rn-testing`, `run-action.md`, and the bridge source:

1. **Step 0 — inventory dedup**: scan `learned-actions.mjs` before authoring; extend a near-duplicate instead of forking it
2. **Step 1 — creation-path choice**: recorder (`cdp_record_test_*`) vs direct YAML vs `maestro_generate`
3. **Step 2 — selector grounding**: every testID from `cdp_component_tree` / `device_snapshot` / source grep — never invented
4. **Step 3 — ASCII flow diagram (required)**: `[RouteName]` boxes, `│`-arrows labeled with exact selectors and `${PARAMS}`, one assertion anchor per screen; embedded in the YAML header so each action documents itself
5. **Step 4 — M7 header contract** (id regex, 5 inventory keys, params rules, `status: experimental` at creation)
6. **Step 5 — pre-replay validation**: header round-trip via the inventory parser, placeholder↔params coverage both directions, selector audit
7. **Step 6 — replay-to-promote** via `cdp_run_action` (never hand-set `active`; sidecar is never hand-written)

Ships with `references/m7-header-reference.md` (full field glossary, parser behavior, lifecycle transitions, failure codes) and `examples/add-product-to-cart.yaml` (worked example with embedded diagram).

## Why the diagram rules are strict (grounded in parser reality, not style)

- `parseM7Header` trims each comment line and **last-wins** kv-parses it: an adversarial probe confirmed a diagram line `# status: shows spinner` silently **overwrites the action's `status`**. Hence: every diagram line's content starts with a non-letter glyph (`[`, `│`, `▼`).
- `learned-actions.mjs` extracts `${VAR}` params from the **whole file text, comments included** (`learned-actions.mjs:115`) — so the skill pins down exactly where `${...}` may appear (steps + diagram mirroring steps; bare names in prose).

## Verification

- **RED→GREEN subagent test**: baseline agent (best case, full repo access) authored a valid action but skipped flow design (no diagram) and the pre-authoring dedup scan; with the skill loaded, a confined agent on an **unseen flow** followed every step and produced a toolchain-clean action.
- **Toolchain validation of the shipped example**: real `parseM7Header` round-trips all 11 M7 fields with the diagram embedded (incl. `produces` + `expectedRouteSequence`); `learned-actions.mjs` lists exact metadata and synthesizes the replay command with exactly one `-e`; Maestro `check_flow_syntax` → valid.
- Adversarial probe demonstrating the `status`-overwrite hazard the skill guards against.

## Wiring

- Registered in `plugin.json` (`skills` 7→8)
- Routed from `using-rn-dev-agent` (new decision-tree branch + skill-map row, count bump)
- Cross-linked from `rn-testing`'s M7 section
- Changeset: `rn-dev-agent-plugin` minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)