### PR TITLE
feat(agents,skills): opus/fable model tiers + skill efficiency pass

### DIFF
--- a/.changeset/agent-models-skill-efficiency.md
+++ b/.changeset/agent-models-skill-efficiency.md
@@ -1,0 +1,15 @@
+---
+"rn-dev-agent-plugin": minor
+---
+
+Agent model upgrades + skill efficiency pass.
+
+**Agents**: all agents now run on `opus` (rn-tester, rn-code-explorer, rn-code-reviewer up from sonnet; rn-debugger unchanged); `rn-code-architect` moves to `fable` — the top model tier for the pipeline's single deep-reasoning blueprint step. Model-tier prose synced in the router skill and docs-site.
+
+**Skills** (token efficiency + correctness, verified by a confined-subagent retrieval test):
+
+- `rn-feature-development` 5,076 → ~3,960 words (−22%): Phase 8 no longer duplicates the proof protocol — `commands/proof-capture.md` is the single source of truth, with pipeline deltas (architect's flow table as source, persist-as-action via creating-actions Steps 3–6, `cdp_run_action` smoke-test, Deviations section) listed on top; 8 repeated per-phase evaluator lines collapsed into one core principle; description rewritten trigger-only (a workflow-summarizing description makes the body get skipped).
+- `using-rn-dev-agent` (always loaded at session start) 2,065 → ~1,825 words: HELPERS_NOT_INJECTED recovery protocol moved to `rn-debugging` (its natural home) with a routing pointer left behind; stale surface counts fixed (76 MCP tools / 14 commands).
+- `rn-testing`: M7 header section slimmed to a 5-key table + creating-actions pointer (the full glossary lives there) — same heading kept for existing citations.
+- `rn-best-practices` / `rn-setup`: descriptions rewritten trigger-only (dropped the rot-prone rule-count inventory; added concrete failure-phrase triggers).
+- Stale claims fixed everywhere: `maestro_run`/`cdp_run_action` DO forward `params` since #272 (proof-capture + feature-dev said otherwise); broken section citation in `run-action.md`; dangling "Step 1.4" cross-references from the old inline Phase 8; smoke-test now consistently `cdp_run_action` (RunRecord + auto-promotion) with plain `maestro_run` reserved for the on-camera replay.

--- a/agents/rn-code-architect.md
+++ b/agents/rn-code-architect.md
@@ -25,7 +25,7 @@ description: |
   </commentary>
   </example>
 tools: Glob, Grep, LS, Read
-model: opus
+model: fable
 effort: high
 skills: rn-testing, rn-best-practices
 color: green

--- a/agents/rn-code-explorer.md
+++ b/agents/rn-code-explorer.md
@@ -26,7 +26,7 @@ description: |
   </commentary>
   </example>
 tools: Glob, Grep, LS, Read
-model: sonnet
+model: opus
 skills: rn-testing
 color: yellow
 ---

--- a/agents/rn-code-reviewer.md
+++ b/agents/rn-code-reviewer.md
@@ -25,7 +25,7 @@ description: |
   </commentary>
   </example>
 tools: Glob, Grep, LS, Read
-model: sonnet
+model: opus
 skills: rn-testing, rn-best-practices
 color: magenta
 ---

--- a/agents/rn-tester.md
+++ b/agents/rn-tester.md
@@ -36,7 +36,7 @@ description: |
   </commentary>
   </example>
 tools: Bash, Read, Write, Edit, Glob, Grep
-model: sonnet
+model: opus
 memory: true
 color: cyan
 skills: rn-device-control, rn-testing, rn-debugging

--- a/commands/proof-capture.md
+++ b/commands/proof-capture.md
@@ -64,7 +64,8 @@ without the camera capturing the search.
    continuing.
 2. Fix any discovered drift (wrong testID, missing route, store-path typo).
 3. **Generate a Maestro flow** capturing the verified sequence at
-   `<test-app>/.rn-agent/actions/<slug>.yaml`. Two authoring paths:
+   `<test-app>/.rn-agent/actions/<slug>.yaml` (`<test-app>` = the RN
+   project's root). Two authoring paths:
    - `maestro_generate(name="<slug>", steps=[...], appId="...")` — writes
      the YAML from structured steps; does NOT emit the M7 metadata header.
    - `cdp_record_test_generate(format="maestro")` — converts the recorder
@@ -72,18 +73,19 @@ without the camera capturing the search.
      schema, so the header is not auto-populated.
    In both paths, the agent MUST then PREPEND the 5-key M7 metadata header
    by hand (`id`, `intent`, `tags`, `mutates`, `status`) — see
-   `skills/rn-testing/SKILL.md` § "Reusable Action Metadata Schema".
+   `skills/rn-testing/SKILL.md` § "Reusable Action Metadata Schema", and the
+   creating-actions skill for the full authoring contract (header validation,
+   replay-to-promote).
 4. Reset the app state to the same starting screen the recording will use
    (close modals, navigate back, clear in-memory residue if `mutates: true`).
-5. Smoke-test the flow once. For flows with `${VAR}` placeholders, use the
-   Bash CLI (which supports `-e`):
-   ```bash
-   maestro-runner --platform <ios|android> test \
-     <test-app>/.rn-agent/actions/<slug>.yaml -e KEY=VALUE
-   ```
-   For env-free flows, the MCP tool also works:
-   `maestro_run(flowPath="<test-app>/.rn-agent/actions/<slug>.yaml")`.
-   The replay must pass end-to-end without a single failure.
+5. Smoke-test the flow once via
+   `cdp_run_action({actionId: "<slug>", params: {KEY: "VALUE"}})` — it
+   records a RunRecord and a clean pass auto-promotes the action
+   `experimental` → `active`. `params` covers `${VAR}` placeholders
+   (forwarded as `-e KEY=VALUE`); plain `maestro_run(flowPath=...,
+   params={...})` or the `maestro-runner` CLI are equivalent replays
+   without the telemetry. The replay must pass end-to-end without a
+   single failure.
 6. **Retry budget: max 3 fix-and-replay loops.** If the rehearsal still
    fails after 3 attempts, escalate to the user with the failing step,
    the failing assertion, and snapshots from `cdp_navigation_state` /
@@ -122,17 +124,13 @@ If recording fails to start, warn but continue — screenshots are the primary a
 **Preferred path:** with recording running, invoke the Maestro flow generated
 in Step 2.5.
 
-For flows with `${VAR}` placeholders (need env substitution):
-```bash
-maestro-runner --platform <ios|android> test \
-  <test-app>/.rn-agent/actions/<slug>.yaml -e KEY=VALUE
+```
+maestro_run(flowPath="<test-app>/.rn-agent/actions/<slug>.yaml", params={KEY: "VALUE"})
 ```
 
-For env-free flows, the MCP tool also works:
-- `maestro_run(flowPath="<test-app>/.rn-agent/actions/<slug>.yaml")`
-
-(The MCP `maestro_run` tool schema does not forward `-e` env vars; for
-substitution use the `maestro-runner` Bash CLI.)
+`params` covers `${VAR}` placeholders (forwarded to maestro as `-e KEY=VALUE`;
+keys match `[A-Z_][A-Z0-9_]*`). Omit it for env-free flows. The
+`maestro-runner` CLI with `-e` flags is an equivalent Bash path.
 
 While the flow runs, take numbered screenshots at meaningful state changes:
 

--- a/commands/run-action.md
+++ b/commands/run-action.md
@@ -67,7 +67,7 @@ Example calls:
 3. **Pre-flight safety checks** before replay:
    - **Read the flow file** and look for a `mutates: true` or
      `destructive: true` line in the metadata header (per the schema in
-     `skills/rn-testing/SKILL.md` "Maestro Flow Standards"). If present,
+     `skills/rn-testing/SKILL.md` § "Reusable Action Metadata Schema (M7)"). If present,
      **warn the user explicitly** and ask for confirmation before running.
      Mention that destructive flows can create duplicate backend rows when
      replayed multiple times — suggest using a timestamp-suffixed TITLE

--- a/docs-site/src/content/docs/agents/index.mdx
+++ b/docs-site/src/content/docs/agents/index.mdx
@@ -11,9 +11,9 @@ These use only `Glob, Grep, LS, Read` — safe to spawn via the Task tool, typic
 
 | Agent | Model | Purpose |
 |-------|-------|---------|
-| [`rn-code-explorer`](/rn-dev-agent/agents/rn-code-explorer/) | Sonnet | Codebase mapping: screens, store, navigation, testIDs |
-| [`rn-code-architect`](/rn-dev-agent/agents/rn-code-architect/) | Opus | Architecture design with E2E proof flow |
-| [`rn-code-reviewer`](/rn-dev-agent/agents/rn-code-reviewer/) | Sonnet | Correctness, RN conventions, project patterns |
+| [`rn-code-explorer`](/rn-dev-agent/agents/rn-code-explorer/) | Opus | Codebase mapping: screens, store, navigation, testIDs |
+| [`rn-code-architect`](/rn-dev-agent/agents/rn-code-architect/) | Fable | Architecture design with E2E proof flow |
+| [`rn-code-reviewer`](/rn-dev-agent/agents/rn-code-reviewer/) | Opus | Correctness, RN conventions, project patterns |
 
 ## Parent-session-only agents (protocol playbooks)
 
@@ -21,7 +21,7 @@ These agents' protocols require `cdp_*` / `device_*` MCP tools. **Do NOT spawn t
 
 | Agent | Model | Purpose | How to invoke |
 |-------|-------|---------|---------------|
-| [`rn-tester`](/rn-dev-agent/agents/rn-tester/) | Sonnet | 7-step test verification protocol | `/rn-dev-agent:test-feature` — runs inline |
+| [`rn-tester`](/rn-dev-agent/agents/rn-tester/) | Opus | 7-step test verification protocol | `/rn-dev-agent:test-feature` — runs inline |
 | [`rn-debugger`](/rn-dev-agent/agents/rn-debugger/) | Opus | Parallel evidence gathering + targeted fix | `/rn-dev-agent:debug-screen` — runs inline |
 
 ## When agents are used

--- a/docs-site/src/content/docs/agents/rn-code-architect.mdx
+++ b/docs-site/src/content/docs/agents/rn-code-architect.mdx
@@ -9,7 +9,7 @@ The architect agent produces decisive, actionable implementation blueprints for 
 
 | Property | Value |
 |----------|-------|
-| **Model** | Opus |
+| **Model** | Fable |
 | **Color** | Green |
 | **Skills** | rn-testing, rn-best-practices |
 | **Tools** | Glob, Grep, LS, Read |

--- a/docs-site/src/content/docs/agents/rn-code-explorer.mdx
+++ b/docs-site/src/content/docs/agents/rn-code-explorer.mdx
@@ -9,7 +9,7 @@ The explorer agent analyzes React Native codebases to produce a complete map of 
 
 | Property | Value |
 |----------|-------|
-| **Model** | Sonnet |
+| **Model** | Opus |
 | **Color** | Yellow |
 | **Skills** | rn-testing |
 | **Tools** | Glob, Grep, LS, Read |

--- a/docs-site/src/content/docs/agents/rn-code-reviewer.mdx
+++ b/docs-site/src/content/docs/agents/rn-code-reviewer.mdx
@@ -9,7 +9,7 @@ The reviewer agent checks implemented code for real issues with high precision. 
 
 | Property | Value |
 |----------|-------|
-| **Model** | Sonnet |
+| **Model** | Opus |
 | **Color** | Magenta |
 | **Skills** | rn-testing, rn-best-practices |
 | **Tools** | Glob, Grep, LS, Read |

--- a/docs-site/src/content/docs/agents/rn-tester.mdx
+++ b/docs-site/src/content/docs/agents/rn-tester.mdx
@@ -9,7 +9,7 @@ The tester agent verifies that an implemented feature works correctly on a live 
 
 | Property | Value |
 |----------|-------|
-| **Model** | Sonnet |
+| **Model** | Opus |
 | **Color** | Cyan |
 | **Skills** | rn-device-control, rn-testing, rn-debugging |
 | **Tools** | Bash, Read, Write, Edit, Glob, Grep, all MCP CDP/device tools |

--- a/skills/rn-best-practices/SKILL.md
+++ b/skills/rn-best-practices/SKILL.md
@@ -5,17 +5,13 @@ paths:
   - "**/*.{ts,tsx,js,jsx}"
   - "**/package.json"
 description: >
-  React Native and Expo best practices. Routes through rules.index.json (118
-  rules: 70 from vercel-labs/agent-skills react-best-practices + 36 from
-  react-native-skills + 8 from composition-patterns + 4 rn-dev-agent custom).
-  Use when reviewing React Native code, designing component architecture,
-  implementing features, optimizing list performance, implementing animations,
-  designing component APIs, working with navigation, auditing UI components,
-  reviewing state management, checking production readiness. Triggers on
-  "review best practices", "check performance", "optimize renders", "review
-  list rendering", "check animation patterns", "review state management",
-  "audit UI", "review composition", "review for production readiness", "check
-  React Native conventions", "performance audit".
+  This skill should be used when writing or reviewing React Native / Expo
+  code — before writing list rendering, animations, data fetching, component
+  APIs, navigation, or image/media UI — and when asked to "review best
+  practices", "check performance", "optimize renders", "review list
+  rendering", "check animation patterns", "review state management",
+  "audit UI", "review composition", "review for production readiness",
+  "check React Native conventions", "performance audit".
 ---
 
 # React Native Best Practices — Procedural Adapter

--- a/skills/rn-debugging/SKILL.md
+++ b/skills/rn-debugging/SKILL.md
@@ -108,6 +108,26 @@ Decision tree:
 
 ---
 
+## Recovering from HELPERS_NOT_INJECTED
+
+When a `cdp_*` tool returns `code: HELPERS_NOT_INJECTED`, the bridge has already done all of this:
+
+1. Waited up to 5s for the connect-time injection to flip the flag
+2. Actively re-injected `__RN_AGENT` once with a 3s React-ready timeout
+3. Attempted a Dev Client picker dismissal (in case a native overlay was blocking React)
+4. Waited up to another 30s if the picker was dismissed
+
+So when this error appears, **the JS world is genuinely hung** — Hermes is up but `__RN_AGENT` won't land. Two recovery paths, in order:
+
+| Step | Action | Why |
+|------|--------|-----|
+| 1 | Switch the immediate task to `device_*` tools (`device_press`, `device_fill`, `device_snapshot`, `device_screenshot`) | These run through XCTest / adb and don't depend on injected JS at all. The task usually doesn't need React fiber introspection — it just needs to interact with the visible UI. |
+| 2 | If React state is specifically needed (`cdp_component_tree`, `cdp_store_state`, `cdp_navigation_state`), call `cdp_reload` once | Forces a clean bundle reload + reconnect, which re-runs the full injection handshake. Note: open modals, in-progress forms, or unsaved screen state are wiped — confirm with the user before reloading if their work is at risk. |
+
+**Anti-pattern**: retrying `cdp_status` in a loop. The connection is up; status calls don't re-trigger injection in this state — they return immediately and let you spin. The error code is the signal to change strategy, not to wait longer.
+
+---
+
 ## Post-Reload Readiness
 
 After `cdp_reload`, the server auto-reconnects and waits up to 30 seconds for

--- a/skills/rn-feature-development/SKILL.md
+++ b/skills/rn-feature-development/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: rn-feature-development
 description: >
-  Full 8-phase React Native feature development pipeline — discovery, codebase
-  exploration, clarifying questions, architecture, implementation, live
-  verification, quality review, and E2E proof. Use when building any new
-  feature in a React Native or Expo app. Triggers on "build a feature",
-  "add X to the app", "implement Y", "create a new screen", "rn-feature-dev",
-  "feature development", "build me X".
+  This skill should be used when building any new feature in a React Native
+  or Expo app, or when the /rn-dev-agent:rn-feature-dev command runs.
+  Triggers on "build a feature", "add X to the app", "implement Y",
+  "create a new screen", "rn-feature-dev", "feature development",
+  "build me X", "add a screen", "wire up this flow".
 ---
 
 # React Native Feature Development (8-Phase Pipeline)
@@ -34,6 +33,10 @@ the simulator, review quality, and produce E2E proof with screenshots.
 - **Cross-platform visual verification**: When both iOS and Android are
   available, compare screenshots element-by-element. A screen that renders
   without crashing but has missing icons/images is a FAIL, not a PASS.
+- **Evaluator hook**: if `dev/evaluator.md` exists in the plugin root, log
+  every phase's events per its matching Phase section there (it defines what
+  each phase records; re-verification logs as Phase 5.5-retry); Phase 7
+  finalizes the report and appends high-confidence bugs to `docs/BUGS.md`.
 
 ---
 
@@ -49,8 +52,6 @@ the simulator, review quality, and produce E2E proof with screenshots.
    - Does this touch the store — if so which slice?
    - Are there API calls involved?
 3. Summarize your understanding and confirm with the user
-
-**Evaluator**: If `dev/evaluator.md` exists in the plugin root, initialize report — record feature name, slug, start time per `dev/evaluator.md` Phase 1.
 
 ---
 
@@ -71,8 +72,6 @@ the simulator, review quality, and produce E2E proof with screenshots.
    - Include a list of 5–10 key files to read
 2. Once agents return, read all files they identified
 3. Present a comprehensive summary of findings
-
-**Evaluator**: If `dev/evaluator.md` exists in the plugin root, log agent launches and files identified per `dev/evaluator.md` Phase 2.
 
 ---
 
@@ -98,8 +97,6 @@ the simulator, review quality, and produce E2E proof with screenshots.
 
 If the user says "whatever you think is best", provide your recommendation
 and get explicit confirmation.
-
-**Evaluator**: If `dev/evaluator.md` exists in the plugin root, log question counts per `dev/evaluator.md` Phase 3.
 
 ---
 
@@ -138,8 +135,6 @@ and get explicit confirmation.
 6. **Ask: "Proceed with implementation?"**
 7. **Do NOT start Phase 5 without explicit user approval**
 
-**Evaluator**: If `dev/evaluator.md` exists in the plugin root, log agent launches and blueprint completeness per `dev/evaluator.md` Phase 4.
-
 ---
 
 ## Phase 5: Implementation
@@ -159,8 +154,6 @@ and get explicit confirmation.
    - If `requiresFullReload` is true: call `cdp_reload(full=true)` and wait
      for reconnection
    - Otherwise: wait 2 seconds for Fast Refresh to apply
-
-**Evaluator**: If `dev/evaluator.md` exists in the plugin root, log files changed, reload type, and cdp_reload result per `dev/evaluator.md` Phase 5.
 
 ---
 
@@ -371,8 +364,6 @@ verification as complete. This catches platform-specific rendering failures
 A screen that loads without crashing but has missing icons is a FAIL, not
 a PASS.
 
-**Evaluator**: If `dev/evaluator.md` exists in the plugin root, log every CDP tool call, recovery action, and fix-retry loop per `dev/evaluator.md` Phase 5.5.
-
 ---
 
 ## Phase 6: Quality Review
@@ -406,8 +397,6 @@ a PASS.
 6. Apply approved fixes
 7. If fixes were applied, re-run Phase 5.5 verification to confirm nothing broke
 
-**Evaluator**: If `dev/evaluator.md` exists in the plugin root, log agent launches, findings, and re-verification per `dev/evaluator.md` Phase 6. If re-verification ran, log as Phase 5.5-retry.
-
 ---
 
 ## Phase 7: Summary
@@ -422,262 +411,65 @@ a PASS.
    - **Verification results** (the Phase 5.5 table)
    - **Review findings** (count fixed / count deferred)
 
-**Evaluator**: If `dev/evaluator.md` exists in the plugin root, finalize and write the evaluation report per `dev/evaluator.md` Phase 7. Append high-confidence bugs to `docs/BUGS.md`.
-
 ---
 
 ## Phase 8: E2E Proof
 
-**Goal**: Produce a permanent proof artifact showing the feature works end-to-end,
-with screenshots of each step of the user flow.
+**Goal**: A permanent proof artifact — `docs/proof/<feature-slug>/` with
+numbered screenshots, `PROOF.md`, `PR-BODY.md`, and the rehearsed flow
+persisted as a replayable action.
 
-**CRITICAL**: This phase executes the **E2E Proof Flow** designed by the architect
-in Phase 4 — step by step, mechanically. Do NOT improvise the flow, skip steps,
-or simplify the sequence. The architect (Opus) designed this flow with full feature
-context. Your job is to execute it faithfully and capture the evidence.
+**Protocol — single source of truth**: execute the `/rn-dev-agent:proof-capture`
+protocol (read `${CLAUDE_PLUGIN_ROOT}/commands/proof-capture.md` and run its
+Protocol steps with `<feature-slug>`). The pipeline adds these deltas:
 
-The output is a `docs/proof/<feature-slug>/` directory with numbered screenshots
-and a `PROOF.md` summary.
+1. **The flow source is the architect's E2E Proof Flow table** from Phase 4 —
+   execute it mechanically. Do NOT improvise, skip, or simplify steps; the
+   architect designed it with full feature context. If rehearsal reveals drift
+   (wrong testID, renamed route, store-path typo), reconcile reality and
+   update the blueprint table.
+2. **Persist the rehearsed flow as a reusable action** at
+   `<project-root>/.rn-agent/actions/<feature-slug>.yaml` (the RN app's root —
+   written `<test-app>` in the command docs) — follow the creating-actions
+   skill Steps 3–6 (flow diagram, M7 header, pre-replay validation,
+   replay-to-promote; the architect's proof-flow table maps nearly 1:1 onto
+   the diagram). `maestro_generate` and `cdp_record_test_generate` emit the
+   YAML body but NOT the M7 header — prepend it per creating-actions.
+3. **Smoke-test before recording** via
+   `cdp_run_action({actionId: "<feature-slug>", params: {...}})` — it records
+   the RunRecord and a clean pass auto-promotes `experimental` → `active`,
+   which the Gate below requires. Plain `maestro_run(flowPath=...,
+   params={KEY: "VALUE"})` is for the ON-CAMERA replay only (no auto-repair
+   mid-recording — a repair would mutate the flow on camera).
+4. **PROOF.md carries a "Deviations from Plan" section** — every step where
+   the actual result differed from the architect's expected state, or
+   "None — all steps matched the architect's E2E Proof Flow."
 
-**Actions**:
+**Hard gates (from the protocol — enforced here too):**
 
-### Step 1: Prepare proof directory
+- **Rehearsal BEFORE recording.** Discovery happens OFF camera; recording
+  captures a verified replay, never exploration. Max 3 rehearsal fix-loops,
+  then escalate with the failing step/assertion plus `cdp_navigation_state`
+  and `cdp_store_state` snapshots.
+- **Maestro-inexpressible carve-out**: only when a step genuinely cannot be
+  expressed in Maestro (custom gestures, native-module side-effects,
+  Reanimated captures via `cdp_set_shared_value`, JS introspection mid-flow)
+  may the rehearsed `device_*`/`cdp_*` sequence be the on-camera artifact —
+  and the missing Maestro primitive MUST be named in PROOF.md "Deviations".
+- **A flow failure ON camera = stop, rebase to clean state, re-rehearse.**
+  It means drift between rehearsal and recording (timing, residue from a
+  `mutates: true` flow) — never "fix it on camera."
+- **Validate artifacts before presenting** (video exists and > 10KB, final
+  screenshot shows the expected end state, `cdp_error_log` clean, every
+  numbered screenshot non-zero). Report invalid proof — never present it as
+  complete.
 
-```bash
-mkdir -p docs/proof/<feature-slug>
-```
-
-Use the feature slug from Phase 1 (e.g., `s4-notification-snooze`, `profile-edit-modal`).
-
-### Step 1.4: Rehearsal pass — discovery happens OFF camera (MANDATORY)
-
-**Rule.** The video must capture a known-good replay of the feature, NOT
-the LLM figuring out how to navigate. Recording during discovery produces
-multi-minute videos full of dead-ends, wrong screens, and "let me check the
-testID" pauses — nobody wants that in a PR. Discovery is cheap; re-recording
-is expensive.
-
-**Protocol — perform every step BEFORE pressing record:**
-
-1. **Dry-run the architect's E2E Proof Flow once with NO video.** Use
-   `device_*` / `cdp_*` calls to walk every row of the blueprint table from
-   start to end. Verify each interaction lands and each assertion holds.
-2. **Fix discovered drift.** The blueprint is the contract, but the live app
-   is reality — wrong testID, renamed route, store-path typo, late-mounted
-   component. Reconcile both. Update the blueprint table if the rehearsal
-   reveals a missing step.
-3. **Persist the verified sequence as a Maestro flow.** Once the rehearsal
-   completes clean end-to-end, write the flow to
-   `<test-app>/.rn-agent/actions/<feature-slug>.yaml`. Two authoring paths:
-   - `maestro_generate(name="<feature-slug>", steps=[...], appId="...")` —
-     structured-step authoring; the MCP tool writes the YAML but does NOT
-     emit the M7 metadata header.
-   - `cdp_record_test_generate(format="maestro")` — converts the recorder
-     buffer (started via `cdp_record_test_start` during rehearsal) into
-     YAML text returned in the response; the MCP tool schema does not
-     forward the M7 fields, so the header is not auto-populated.
-   In both cases, the agent MUST then read the file (or capture the
-   returned text) and PREPEND the 5-key M7 metadata header by hand
-   (`id`, `intent`, `tags`, `mutates`, `status`) — see
-   `skills/rn-testing/SKILL.md` § "Reusable Action Metadata Schema".
-4. **Smoke-test the flow.** Replay it once before recording. For flows
-   with `${VAR}` placeholders, use the Bash CLI (which supports `-e`
-   substitution):
-   ```bash
-   maestro-runner --platform <ios|android> test \
-     <test-app>/.rn-agent/actions/<feature-slug>.yaml \
-     -e KEY=VALUE
-   ```
-   For env-free flows, the MCP tool also works:
-   `maestro_run(flowPath="<test-app>/.rn-agent/actions/<feature-slug>.yaml")`.
-   The replay must pass end-to-end without a single failure.
-5. **Retry budget: max 3 fix-and-replay loops.** If the rehearsal still
-   fails after 3 attempts, escalate to the user with (a) the failing
-   step, (b) the failing assertion, and (c) snapshots from
-   `cdp_navigation_state` and `cdp_store_state`. Do NOT loop indefinitely.
-
-**Maestro-inexpressible carve-out.** If the flow genuinely cannot be
-expressed in Maestro (custom gestures, native-module side-effects,
-Reanimated proof captures via `cdp_set_shared_value`, JS-introspection
-mid-flow), the rehearsal walk itself via `device_*` / `cdp_*` becomes the
-artifact. Document the specific Maestro primitive that is missing in
-PROOF.md "Deviations" — naming the inexpressibility is mandatory; without
-it you must keep trying to express the flow.
-
-**Hard gate.** Do not proceed to Step 1.5 until either step 4 passes
-cleanly OR the inexpressibility carve-out has been written into PROOF.md.
-If you catch yourself thinking "I'll just record while I work out the
-last step," stop — that's the failure mode this gate exists to prevent.
-
-### Step 1.5: Pre-recording setup and start video
-
-**Pre-recording readiness (GH #8, #9):**
-1. Call `cdp_status` — auto-detects and dismisses the Dev Client picker if
-   an agent-device session is open (GH #9). If warning returned, retry.
-2. Call `cdp_navigation_state` — verify a valid route (not Dev Client picker).
-   If still stuck, ask the user to select the Metro server.
-3. Call `cdp_dev_settings(action="disableDevMenu")` — suppress dev menu popups
-   during recording.
-4. Take a baseline screenshot to confirm app is on an actual screen.
-
-Then start recording:
-
-```bash
-# Detect platform
-PLATFORM="ios"  # or "android" based on booted devices
-
-# Start recording
-rn-record-proof start $PLATFORM docs/proof/<feature-slug>/flow-$PLATFORM.mp4
-```
-
-If recording fails to start (no simulator, permissions), log a warning and
-continue — video is a nice-to-have, not a gate. Screenshots remain primary.
-
-### Step 2: Replay the rehearsed flow ON CAMERA
-
-**Preferred path: replay the Maestro flow generated in Step 1.4.** With
-recording running, invoke the rehearsed flow.
-
-For flows with `${VAR}` placeholders (need env substitution):
-```bash
-maestro-runner --platform <ios|android> test \
-  <test-app>/.rn-agent/actions/<feature-slug>.yaml \
-  -e KEY=VALUE
-```
-
-For env-free flows, use the MCP tool:
-- `maestro_run(flowPath="<test-app>/.rn-agent/actions/<feature-slug>.yaml")`
-
-(The MCP `maestro_run` tool schema accepts `flowPath`, `inlineYaml`,
-`platform`, `appId`, `timeoutMs` — there is no `-e` env-var pass-through.
-For substitution you need the `maestro-runner` CLI via Bash.)
-
-Either path produces a deterministic, hesitation-free recording. The LLM
-is NOT in the loop during the actual replay — Maestro drives the device
-at native speed. While the flow runs, take numbered screenshots at meaningful state
-changes via `device_screenshot(path="docs/proof/<feature-slug>/<NN-stepname>.jpg")`.
-
-**Flow assertion failure during recording = stop and re-rehearse.** A
-failure here means the flow drifted between rehearsal and recording (timing,
-state, leftover residue from a `mutates: true` flow). Stop the recording,
-rebase to a clean app state, redo Step 1.4. Do not "fix it on camera."
-
-**Fallback: only when Maestro cannot express the flow** — custom gestures,
-native-module side-effects, Reanimated proof captures via
-`cdp_set_shared_value`, or anything that needs JS-level introspection
-mid-flow. In that case, execute the rehearsed sequence step-by-step using
-the same `device_*` / `cdp_*` calls you ran in Step 1.4. Every action must
-be one you already executed cleanly during rehearsal — do NOT debug,
-explore, or improvise on camera.
-
-For each meaningful state change (whether driven by Maestro or by the
-fallback path), capture:
-
-1. **Screenshot** with the exact filename from the blueprint table:
-   `device_screenshot(path="docs/proof/<feature-slug>/<filename>")`
-2. **State assertion** matching what the table specified:
-   - Store assertion → `cdp_store_state` value matches
-   - Navigation assertion → `cdp_navigation_state`
-   - Visual assertion → verified via the screenshot
-3. **Record the actual value** for PROOF.md — the rehearsal already proved
-   this works, so deviations here are recording-environment bugs, not
-   feature bugs.
-
-### Step 2.5: Stop recording and convert
-
-Stop the background video recording:
-
-```bash
-rn-record-proof stop
-```
-
-Attempt GIF conversion for inline PR display:
-
-```bash
-rn-record-proof convert-gif \
-  docs/proof/<feature-slug>/flow-$PLATFORM.mp4 \
-  docs/proof/<feature-slug>/flow-$PLATFORM.gif
-```
-
-If ffmpeg is not available, skip GIF conversion — the raw .mp4 is still useful.
-
-### Step 3: Write PROOF.md
-
-Create `docs/proof/<feature-slug>/PROOF.md` with this structure:
-
-```markdown
-# <Feature Name> — E2E Proof
-
-**Date:** <YYYY-MM-DD>
-**Device:** <device name> (<OS version>, Simulator/Emulator)
-**Method:** CDP interactions + screenshots (flow designed by architect in Phase 4)
-
-## Flow
-
-| Step | Screenshot | Action | Verification |
-|------|-----------|--------|--------------|
-| 1 | 01-initial.jpg | Navigate to <screen> | Route confirmed via cdp_navigation_state |
-| 2 | 02-action.jpg | <interaction description> | <state or visual confirmation> |
-| 3 | 03-result.jpg | <interaction description> | <state or visual confirmation> |
-
-## Key State Snapshots
-
-- After step 2: `store.path = <value>`
-- After step 3: `store.path = <value>`
-
-## Deviations from Plan
-
-List any steps where the actual result differed from the architect's expected
-state, or any steps that required retries. If none, write "None — all steps
-matched the architect's E2E Proof Flow."
-
-## Files
-
-- `01-initial.jpg` — <description>
-- `02-action.jpg` — <description>
-- `03-result.jpg` — <description>
-```
-
-### Step 4: Validate proof artifacts (CRITICAL)
-
-**Before presenting proof to the user, verify the recording and screenshots
-actually show the expected feature.** This prevents presenting invalid proof.
-
-Validation checklist:
-1. **Video file exists and has reasonable size** (> 10KB):
-   ```bash
-   ls -la docs/proof/<feature-slug>/flow-*.mp4 2>/dev/null
-   ```
-2. **Final screenshot shows the expected end state** — verify via
-   `cdp_component_tree` or `cdp_navigation_state` that the app is on the
-   expected screen with expected data visible.
-3. **No errors during recording** — call `cdp_error_log` and confirm no
-   new errors appeared during the proof flow.
-4. **All numbered screenshots exist** with non-zero size.
-
-If validation fails: report what went wrong and ask the user if they want
-to re-record. Do NOT present invalid proof as complete.
-
-### Step 5: Generate PR body
-
-```bash
-rn-generate-pr-body docs/proof/<feature-slug>/
-```
-
-This produces `docs/proof/<feature-slug>/PR-BODY.md` — a ready-to-paste PR
-description with embedded screenshots, video upload placeholders, device
-info, and a files-changed summary.
-
-### Step 6: Mark complete
-
-Mark all todos complete. The feature is done — implemented, verified, reviewed,
-and proven with screenshots and video.
-
-**Gate**: PROOF.md exists, contains screenshots for ALL steps in the architect's
-E2E Proof Flow, all state assertions match, and PR-BODY.md is generated.
-If screenshot capture fails (e.g., no simulator), log the failure in PROOF.md
-and note it in the Phase 7 summary. If a state assertion doesn't match,
-this is a bug — fix it before completing.
+**Gate**: PROOF.md exists with screenshots for ALL steps of the architect's
+flow, all state assertions match, PR-BODY.md is generated, and the action
+file exists and has replayed clean at least once. If screenshot capture
+fails (e.g., no simulator), log it in PROOF.md and note it in the Phase 7
+summary. If a state assertion doesn't match, that is a bug — fix it before
+completing. Mark all todos complete.
 
 ---
 
@@ -726,7 +518,7 @@ Each phase has shortcuts agents reach for. Don't.
 | "I tested iOS — Android works the same" | Wrong ~40% of the time. Keyboard, permissions, back button, text input, safe-area all differ. `cross_platform_verify` is mandatory unless explicitly single-platform. |
 | "Phase 6 found 1 issue — ship it" | Review agents already filter by confidence. If ONE flags an issue, read it fully. |
 | "Phase 8 (E2E Proof) is just for PR theater" | Proof flows become the permanent Maestro test file. Skip them and you pay in manual testing every sprint. |
-| "I'll record while I figure out the flow — saves a pass" | The video then shows you stuck on a wrong testID for 90 seconds. Rehearsal (Step 1.4) is the cheap pass; re-recording is the expensive one. Discovery happens off camera, replay happens on camera. |
+| "I'll record while I figure out the flow — saves a pass" | The video then shows you stuck on a wrong testID for 90 seconds. The rehearsal pass is the cheap one; re-recording is the expensive one. Discovery happens off camera, replay happens on camera. |
 
 ## Red Flags — Stop and Reconsider
 
@@ -736,10 +528,10 @@ Each phase has shortcuts agents reach for. Don't.
 - About to skip a phase "because the feature is small"
 - About to add a dependency without asking the user first
 - Editing files outside the architect's blueprint "while I'm here"
-- About to call `rn-record-proof start` before the Step 1.4 rehearsal flow has replayed clean (via `maestro-runner` CLI or `maestro_run`)
+- About to call `rn-record-proof start` before the rehearsed flow has replayed clean (proof-capture protocol Step 2.5)
 - About to use `device_*` exploratory calls during recording to "find the right testID"
-- About to take the `device_*` / `cdp_*` fallback path in Phase 8 Step 2 without naming the specific Maestro primitive that cannot express the step in PROOF.md "Deviations"
-- About to enter a fourth rehearsal-fix loop in Step 1.4 without escalating to the user
+- About to take the `device_*` / `cdp_*` fallback path for the on-camera replay without naming the specific Maestro primitive that cannot express the step in PROOF.md "Deviations"
+- About to enter a fourth rehearsal-fix loop without escalating to the user
 
 ## Boundaries
 
@@ -749,7 +541,7 @@ Each phase has shortcuts agents reach for. Don't.
 - Use MCP tools (cdp_*, device_*) for app state reads
 - Present the Phase 5.5 verification table with concrete Evidence
 - Gate Phase 5 on user approval of the architecture
-- Run the Phase 8 Step 1.4 rehearsal pass and confirm `maestro_run` replays the generated flow cleanly BEFORE starting any video recording
+- Run the Phase 8 rehearsal pass and confirm the persisted flow replays cleanly (`cdp_run_action`) BEFORE starting any video recording
 
 ### Ask First
 - Adding any new dependency to the user's project

--- a/skills/rn-setup/SKILL.md
+++ b/skills/rn-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 skill: setup
-description: Check and install all rn-dev-agent prerequisites — Node.js, Metro, simulators, rn-fast-runner (iOS), agent-device (Android), maestro-runner, CDP bridge. Run this when tools fail or on first setup.
+description: This skill should be used when the user runs /rn-dev-agent:setup, on first use of the plugin in a project, or when tooling fails — "set up rn-dev-agent", "check prerequisites", "cdp_status fails", "CDP connection failed", "agent-device not installed", "maestro-runner not found", "rn-fast-runner did not become ready", "Metro not running", "no booted simulator", "plugin tools not working", "wrong Node version".
 ---
 
 # Environment Setup & Dependency Check

--- a/skills/rn-testing/SKILL.md
+++ b/skills/rn-testing/SKILL.md
@@ -233,51 +233,30 @@ maestro-runner --platform <ios|android> test /tmp/step.yaml
 
 ## Reusable Action Metadata Schema (M7)
 
-Every reusable Maestro flow MUST declare a 5-field metadata header so
-`/rn-dev-agent:list-learned-actions` and `/rn-dev-agent:run-action` can
-filter, replay, and reason about it without parsing the YAML body. The
-header lives in YAML comments above (or just below) the `---` separator
-so Maestro itself ignores it.
+Every reusable Maestro flow MUST declare an M7 metadata header — `# key: value`
+comment lines above the body (Maestro ignores them; the inventory and the
+`/run-action` pre-flight parse them). The 5 inventory keys:
 
-```yaml
-appId: com.example.app
----
-# id: <stable-slug>           # Stable identifier. Defaults to the filename
-                              # without `.yaml`. Set explicitly only when you
-                              # want to rename the file later without breaking
-                              # references.
-# intent: <one-line goal>     # Human-readable goal. Surfaced verbatim by the
-                              # `list-learned-actions` inventory; replaces the
-                              # older "first comment block = purpose" heuristic.
-# tags: [a, b, c]             # Filterable keywords (lower-case kebab-case).
-                              # Conventions: feature area (tasks, auth,
-                              # profile), operation (create, update, delete),
-                              # markers (smoke, regression).
-# mutates: true|false         # `true` if the flow leaves persistent residue
-                              # (created/deleted rows, toggled settings,
-                              # anything a subsequent test would need to clean
-                              # up). Read-only flows are `false`. Consumed by
-                              # `/run-action` to require explicit confirmation
-                              # before replay.
-# status: active|deprecated|experimental
-                              # `active` = production-quality, replay anytime.
-                              # `experimental` = under construction, may break.
-                              # `deprecated` = kept for history, do NOT replay.
-- launchApp
-```
+| Key | Value | Notes |
+|---|---|---|
+| `id` | kebab-case slug | defaults to filename without `.yaml` |
+| `intent` | one-line goal | surfaced verbatim by `/list-learned-actions`; the routing key |
+| `tags` | `[a, b, c]` lower-case kebab | feature area (auth, tasks), operation (create, delete), markers (smoke, regression) |
+| `mutates` | `true`/`false` | persistent residue? drives the `/run-action` confirmation gate; missing parses as `null` and renders as `?` |
+| `status` | `experimental` \| `active` \| `deprecated` | start `experimental`; first clean replay promotes; `deprecated` = never replay |
 
 **Auto-generated flows** from `cdp_record_test_generate` populate these fields
 when supplied via `GenerateOpts.id|intent|tags|mutates|status` (see
-`tools/test-recorder-generators.ts`). **Hand-written flows** must add the
-header manually before the flow is considered reusable.
+`tools/test-recorder-generators.ts`). `maestro_generate` and **hand-written
+flows** must add the header manually before the flow is considered reusable.
 
-For the full end-to-end authoring workflow (inventory dedup, selector
-grounding, the ASCII flow diagram, validation, replay-to-promote), load the
+**Verification rule:** before approving a new flow for the artifact-first
+inventory, confirm the header carries all 5 keys.
+
+For the full authoring workflow (inventory dedup, selector grounding, the
+ASCII flow diagram, optional fields — `params`, `appId`, `produces`,
+`expectedRouteSequence` — validation, and replay-to-promote), load the
 **creating-actions** skill.
-
-**Verification rule:** Before approving a new flow for the artifact-first
-inventory, confirm the header carries all 5 keys. A flow missing `mutates:` is
-parsed as `mutates: null` and `list-learned-actions` renders it as `?`.
 
 ---
 

--- a/skills/using-rn-dev-agent/SKILL.md
+++ b/skills/using-rn-dev-agent/SKILL.md
@@ -71,7 +71,7 @@ What is the user asking for?
 │
 ├── Design architecture before implementing
 │   └─► Spawn rn-code-architect via Task tool (read-only, safe to spawn)
-│       (Opus-powered blueprint with testID placement + proof flow)
+│       (Fable-powered blueprint with testID placement + proof flow)
 │
 ├── Review code before merging
 │   └─► Spawn rn-code-reviewer via Task tool (read-only, safe to spawn)
@@ -145,7 +145,7 @@ read them as reference, execute the steps INLINE in the parent session.
 
 | Agent | Model | Purpose | How to invoke |
 |-------|-------|---------|-----------|
-| `rn-tester` | sonnet | Verify feature works live on device | Run `/test-feature` — protocol executes inline in parent session |
+| `rn-tester` | opus | Verify feature works live on device | Run `/test-feature` — protocol executes inline in parent session |
 | `rn-debugger` | opus | Diagnose broken screen, apply fix | Run `/debug-screen` — protocol executes inline in parent session |
 
 ### Spawnable agents (read-only — safe to use via Task tool)
@@ -155,9 +155,9 @@ in parallel via the Task tool for concurrent codebase analysis.
 
 | Agent | Model | Purpose | How to invoke |
 |-------|-------|---------|-----------|
-| `rn-code-explorer` | sonnet | Map feature implementation across layers | `Task(subagent_type='rn-dev-agent:rn-code-explorer', ...)` — typically × 2-3 in parallel during `/rn-feature-dev` Phase 2 |
-| `rn-code-architect` | opus | Design blueprint with proof flow | `Task(subagent_type='rn-dev-agent:rn-code-architect', ...)` — typically × 1-2 during `/rn-feature-dev` Phase 4 |
-| `rn-code-reviewer` | sonnet | Review for bugs + RN convention violations | `Task(subagent_type='rn-dev-agent:rn-code-reviewer', ...)` — typically × 2-3 in parallel during `/rn-feature-dev` Phase 6 |
+| `rn-code-explorer` | opus | Map feature implementation across layers | `Task(subagent_type='rn-dev-agent:rn-code-explorer', ...)` — typically × 2-3 in parallel during `/rn-feature-dev` Phase 2 |
+| `rn-code-architect` | fable | Design blueprint with proof flow | `Task(subagent_type='rn-dev-agent:rn-code-architect', ...)` — typically × 1-2 during `/rn-feature-dev` Phase 4 |
+| `rn-code-reviewer` | opus | Review for bugs + RN convention violations | `Task(subagent_type='rn-dev-agent:rn-code-reviewer', ...)` — typically × 2-3 in parallel during `/rn-feature-dev` Phase 6 |
 
 ---
 

--- a/skills/using-rn-dev-agent/SKILL.md
+++ b/skills/using-rn-dev-agent/SKILL.md
@@ -10,7 +10,7 @@ description: >
 
 # Using rn-dev-agent
 
-The React Native development plugin for Claude Code. **64 MCP tools**, **5 agents**, **16 commands**, **8 skills**.
+The React Native development plugin for Claude Code. **76 MCP tools**, **5 agents**, **14 commands**, **8 skills**.
 
 This skill is your front door. Before starting any RN work, use the decision tree below to route the user's intent to the right tool.
 
@@ -172,7 +172,7 @@ Agents skip this skill at the start of conversations. Don't.
 | "The user said 'fix the bug' — I'll just edit the file directly" | Route to `/rn-dev-agent:debug-screen` which runs the rn-debugger protocol inline in the parent session. Enforces reproduce → diagnose → fix → verify. Never spawn `rn-debugger` via Task tool — MCP tools won't work (GH #31). |
 | "I'll spawn `rn-tester` via Task to verify while I work on something else" | You can't — MCP stdio doesn't propagate to Task-spawned subagents (GH #31). rn-tester and rn-debugger are parent-session-only protocol playbooks. Only `rn-code-explorer`, `rn-code-architect`, `rn-code-reviewer` are safe to spawn (they're read-only, no MCP). |
 | "This is a trivial change — I'll skip Phase 5.5 verification" | Trivial changes are where verification gates matter most. They're the ones you tell yourself don't need testing. They do. |
-| "I got `HELPERS_NOT_INJECTED` — let me retry `cdp_status`" | Retrying `cdp_status` does NOT re-run helper injection if the bridge thinks it's connected; it just returns status. The plugin auto-retries injection internally on every gated call (see "Recovering from HELPERS_NOT_INJECTED" below). If the auto-retry exhausted, switch to `device_*` tools (XCTest path — no helpers required) or call `cdp_reload`. Don't spin on `cdp_status`. |
+| "I got `HELPERS_NOT_INJECTED` — let me retry `cdp_status`" | Retrying `cdp_status` does NOT re-run helper injection if the bridge thinks it's connected; it just returns status. The plugin auto-retries injection internally on every gated call (see "Recovering from HELPERS_NOT_INJECTED" in the rn-debugging skill). If the auto-retry exhausted, switch to `device_*` tools (XCTest path — no helpers required) or call `cdp_reload`. Don't spin on `cdp_status`. |
 
 ---
 
@@ -204,27 +204,7 @@ Things that repeatedly go wrong, cataloged for prevention:
 | Wasted 10K tokens on component tree | Called `cdp_component_tree()` without filter | Always filter by testID or component name |
 | Tests silently broken after refactor | No Maestro flow exists | `/rn-dev-agent:proof-capture` generates one; use it |
 | CDP session lost mid-task | Another debugger (DevTools, Flipper) connected | Close all other debuggers before starting |
-| Stuck on `HELPERS_NOT_INJECTED` for minutes | Retrying `cdp_status` instead of letting the auto-retry surface a final answer, or instead of falling back to device tools | The bridge auto-retries injection once before failing. When the error finally returns, it's authoritative — switch to `device_*` tools or call `cdp_reload`. Never sit in a `cdp_status` retry loop. |
-
----
-
-## Recovering from HELPERS_NOT_INJECTED
-
-When a `cdp_*` tool returns `code: HELPERS_NOT_INJECTED`, the bridge has already done all of this for you:
-
-1. Waited up to 5s for the connect-time injection to flip the flag
-2. Actively re-injected `__RN_AGENT` once with a 3s React-ready timeout
-3. Attempted a Dev Client picker dismissal (in case a native overlay was blocking React)
-4. Waited up to another 30s if the picker was dismissed
-
-So when you see this error, **the JS world is genuinely hung** — Hermes is up but `__RN_AGENT` won't land. Two recovery paths, in order:
-
-| Step | Action | Why |
-|------|--------|-----|
-| 1 | Switch the immediate task to `device_*` tools (`device_press`, `device_fill`, `device_snapshot`, `device_screenshot`) | These run through XCTest / adb and don't depend on injected JS at all. The user's task usually doesn't need React fiber introspection — it just needs to interact with the visible UI. |
-| 2 | If you specifically need React state (`cdp_component_tree`, `cdp_store_state`, `cdp_navigation_state`), call `cdp_reload` once | Forces a clean bundle reload + reconnect, which re-runs the full injection handshake. Note: any open modals, in-progress forms, or unsaved screen state are wiped — confirm with the user before reloading if their work is at risk. |
-
-**Anti-pattern**: retrying `cdp_status` in a loop. The connection is up; status calls don't re-trigger injection in this state. They just return immediately and let you spin. The error code is your signal to change strategy, not to wait longer.
+| Stuck on `HELPERS_NOT_INJECTED` for minutes | Retrying `cdp_status` instead of letting the auto-retry surface a final answer, or instead of falling back to device tools | The error is authoritative (the bridge already auto-retried injection) — switch to `device_*` tools or call `cdp_reload`; never sit in a `cdp_status` retry loop. Full recovery protocol: rn-debugging skill § "Recovering from HELPERS_NOT_INJECTED". |
 
 ---
 


### PR DESCRIPTION
## Summary

Two commits: agent model upgrades, then a skill efficiency pass driven by a duplication/staleness audit.

> Note: the Conductor-prefilled PR description referenced the `creating-actions` skill — that work already merged as #272 this morning; this body describes the actual branch content.

## 1. Agent models (`5211903`)

| Agent | Was | Now |
|---|---|---|
| rn-tester | sonnet | **opus** |
| rn-code-explorer | sonnet | **opus** |
| rn-code-reviewer | sonnet | **opus** |
| rn-debugger | opus | opus |
| rn-code-architect | opus | **fable** |

The architect gets the top tier (`fable` → claude-fable-5): it is the pipeline's single 1–2× deep-reasoning blueprint step, vs the others' 2–3× parallel fan-outs. Model-tier prose synced in `using-rn-dev-agent` (agent-map tables + decision tree) and the six docs-site agent pages.

## 2. Skill efficiency pass (`1eb5e65`)

The audit found the real inefficiencies were **drifting duplication** and **stale claims**, not just word counts:

- **`rn-feature-development` 5,076 → 3,962 words (−22%)**: Phase 8 was a ~1,800-word copy of the `/proof-capture` protocol that had already diverged from it (the command gained video-labeling the skill lacked; both carried a claim falsified by #272). Phase 8 now defers to `commands/proof-capture.md` as the single protocol source and lists only the pipeline deltas (architect's flow table as source, persist-as-action via creating-actions Steps 3–6, `cdp_run_action` smoke-test, Deviations section). Eight repeated per-phase evaluator lines collapsed into one core principle. Description rewritten **trigger-only** per the CSO rule — a workflow-summarizing description makes the body get skipped.
- **`using-rn-dev-agent` 2,065 → 1,825 (−12%)** — loads at the start of every RN conversation, so highest leverage: HELPERS_NOT_INJECTED recovery protocol moved to `rn-debugging` (its owner) with routing pointers; stale surface counts fixed (64→76 MCP tools, 16→14 commands).
- **`rn-testing`**: M7 section slimmed to a 5-key table + creating-actions pointer (the full glossary lives there); heading preserved so existing citations resolve.
- **`rn-best-practices` / `rn-setup`**: trigger-only descriptions (dropped the rot-prone 118-rule inventory; added concrete failure-phrase triggers).
- **Correctness**: two files still claimed `maestro_run` has "no `-e` pass-through" (false since #272 — now show `params={KEY: "VALUE"}`); broken citation in `run-action.md` ("Maestro Flow Standards" → real heading); smoke-test standardized on `cdp_run_action` (RunRecord + auto-promotion) with plain `maestro_run` reserved for the on-camera replay (auto-repair must not mutate a flow mid-recording); `<test-app>` placeholder defined.

## Verification

- Deterministic sweeps: all 8 skill frontmatters parse; zero stale-claim greps; all cross-references/citations resolve; M7 table escapes render.
- **Confined-subagent retrieval test** on the restructured Phase 8 chain (skill → proof-capture → creating-actions): answered every execution question concretely from the new text, and surfaced 4 real defects — stale "Step 1.4" cross-references, the smoke-test tool contradiction, a Steps-range that skipped the diagram, the undefined `<test-app>` placeholder — **all fixed in this PR before commit**.

## Wiring

- Changeset: `rn-dev-agent-plugin` minor (covers both commits)
- No bridge/source changes; docs/skills/agents only

🤖 Generated with [Claude Code](https://claude.com/claude-code)