### PR TITLE
feat(#262): APP_NOT_INSTALLED detection in recovery paths + strict hardReset bundleId chain

### DIFF
--- a/.changeset/gh-262-app-not-installed.md
+++ b/.changeset/gh-262-app-not-installed.md
@@ -1,0 +1,9 @@
+---
+"rn-dev-agent-cdp": patch
+"rn-dev-agent-plugin": patch
+---
+
+Recovery paths now detect "app not installed" and resolve their relaunch target truthfully (GH #262, absorbs #194 BUG 2).
+
+- `cdp_status` APP_DETACHED auto-relaunch: when `simctl launch` fails AND `get_app_container`'s stderr carries the `NSPOSIXErrorDomain code=2` marker (allowlist-only, stderr-only — argv-spoof-proof), the tool returns a distinct `APP_NOT_INSTALLED` code with install advice — including a shell-quoted `simctl install` line for the newest matching `.app` snapshot from the last clearState (GH #201 dir, mtime-sorted budgeted scan). Ambiguous probe verdicts fail open to the existing `APP_DETACHED` behavior. Concurrent recoveries are serialized, and a confirmed missing bundle is cached (with a cheap re-probe) so the diagnosis is never masked by `budget-exhausted`.
+- `cdp_restart hardReset=true`: the relaunch target resolves through `explicit arg > connectedTarget > cache > active-session appId > strict per-platform app.json` (no iOS←Android fallback), simctl targets the active session's UDID when one exists, failed launches are classified the same way in `hardResetSteps`, and a successful hard reset resets the detached-recovery budget.

--- a/docs/superpowers/plans/2026-06-11-262-app-not-installed-recovery.md
+++ b/docs/superpowers/plans/2026-06-11-262-app-not-installed-recovery.md
@@ -43,11 +43,11 @@ Create `test/unit/gh-262-app-installed-probe.test.js`:
 
 ```js
 // GH #262: ground-truth probe for "is the app bundle installed on the sim?".
-// Classification is ALLOWLIST-only (codex-pair spec review): `false` (not
-// installed) requires the documented app-missing signal (NSPOSIXErrorDomain
-// code=2 / "No such file or directory"); every other failure shape — device
-// errors, unknown stderr, timeouts — returns `null` (verdict unknown).
-// Never claim not-installed without proof.
+// Classification is ALLOWLIST-only (codex-pair spec + plan reviews): `false`
+// (not installed) requires the documented app-missing signal — the
+// NSPOSIXErrorDomain code=2 marker. Every other failure shape — bare ENOENT
+// text, device errors, unknown stderr, timeouts — returns `null` (verdict
+// unknown). Never claim not-installed without proof.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
@@ -79,8 +79,10 @@ test('probeAppInstalled: NSPOSIXErrorDomain code=2 → false (not installed)', a
   assert.equal(await probeAppInstalled('U', 'a', execFailing(stderr)), false);
 });
 
-test('probeAppInstalled: bare "No such file or directory" → false', async () => {
-  assert.equal(await probeAppInstalled('U', 'a', execFailing('No such file or directory')), false);
+test('probeAppInstalled: bare "No such file or directory" WITHOUT the domain marker → null', async () => {
+  // codex-pair plan review: generic ENOENT text can appear in unrelated simctl
+  // failures — only the NSPOSIXErrorDomain code=2 marker is proof.
+  assert.equal(await probeAppInstalled('U', 'a', execFailing('No such file or directory')), null);
 });
 
 test('probeAppInstalled: device-level error → null (fail open)', async () => {
@@ -142,14 +144,15 @@ type Exec = (
   opts?: { timeout?: number },
 ) => Promise<{ stdout: string; stderr: string }>;
 
-// Allowlist classification (codex-pair spec review): `false` requires the
-// documented app-missing signal — issue #262's manual diagnosis was exactly
-// `get_app_container` failing with NSPOSIXErrorDomain code=2. Device-level
+// Allowlist classification (codex-pair spec + plan reviews): `false` requires
+// the documented app-missing signal — issue #262's manual diagnosis was exactly
+// `get_app_container` failing with NSPOSIXErrorDomain code=2, and the domain
+// marker is always present in that message. Bare "No such file or directory"
+// text is NOT sufficient (it can appear in unrelated failures). Device-level
 // errors and unrecognized shapes return null: never claim "not installed"
 // without proof.
 const DEVICE_ERROR = /Invalid device|No devices/i;
 const APP_MISSING_POSIX = /NSPOSIXErrorDomain[\s\S]{0,40}code[^\d]{0,3}2\b/;
-const APP_MISSING_ENOENT = /No such file or directory/i;
 
 /**
  * GH #262: ground-truth "is this bundle installed?" probe.
@@ -169,7 +172,7 @@ export async function probeAppInstalled(
     const stderr = (e as { stderr?: string }).stderr ?? '';
     const detail = `${stderr}\n${e instanceof Error ? e.message : String(e)}`;
     if (DEVICE_ERROR.test(detail)) return null;
-    if (APP_MISSING_POSIX.test(detail) || APP_MISSING_ENOENT.test(detail)) return false;
+    if (APP_MISSING_POSIX.test(detail)) return false;
     return null;
   }
 }

--- a/docs/superpowers/plans/2026-06-11-262-app-not-installed-recovery.md
+++ b/docs/superpowers/plans/2026-06-11-262-app-not-installed-recovery.md
@@ -2,13 +2,15 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Recovery paths (`cdp_status` APP_DETACHED auto-relaunch, `cdp_restart hardReset`) detect a missing app bundle via ground truth (`simctl get_app_container`), report a distinct `APP_NOT_INSTALLED` code with shell-safe install advice (incl. a #201 snapshot hint), and `hardReset` falls back to app.json for its bundleId (closes the #194 BUG 2 residual).
+**Goal:** Recovery paths (`cdp_status` APP_DETACHED auto-relaunch, `cdp_restart hardReset`) detect a missing app bundle via ground truth (`simctl get_app_container`), report a distinct `APP_NOT_INSTALLED` code with shell-safe install advice (incl. a #201 snapshot hint), and `hardReset` resolves its relaunch target through a strict chain ending at app.json (closes the #194 BUG 2 residual).
 
-**Architecture:** A new shared probe module (`cdp/app-installed-probe.ts`) classifies launch failures allowlist-only (`false` requires the documented `NSPOSIXErrorDomain code=2` signal; everything else is `null` — fail open). A snapshot finder in `tools/resolve-ios-app-file.ts` (which owns the #201 snapshot dir) supplies a best-effort reinstall hint under an explicit time/candidate budget. `recover-detached.ts` short-circuits on a confirmed missing bundle; `status.ts` and `restart.ts` render the advice.
+**Architecture:** A new probe module (`cdp/app-installed-probe.ts`) classifies launch failures from **simctl stderr only**, allowlist-style (`false` requires the `NSPOSIXErrorDomain` + `code=2` marker; everything else is `null` — fail open). A snapshot finder in `tools/resolve-ios-app-file.ts` (which owns the #201 snapshot dir) supplies a best-effort reinstall hint (mtime-sorted before capping, budgeted). `recover-detached.ts` serializes concurrent recoveries, short-circuits on a confirmed missing bundle, and caches that terminal diagnosis (with a cheap re-probe so reinstalls self-heal). The snapshot hint is **injected by the tool layer** (`status.ts`/`restart.ts`) — `cdp/` never imports from `tools/`.
 
 **Tech Stack:** TypeScript (Node >= 22), `node:test` + `assert/strict` unit tests importing from `dist/`, injectable-deps pattern throughout.
 
-**Spec:** `docs/superpowers/specs/2026-06-11-262-app-not-installed-recovery-design.md` (approved; codex-pair amendments applied).
+**Spec:** `docs/superpowers/specs/2026-06-11-262-app-not-installed-recovery-design.md` (approved; codex-pair + multi-LLM review amendments applied).
+
+**Multi-LLM review amendments (Antigravity + Codex, 2026-06-11):** stderr-only classification (argv-spoof defense) with case-insensitive, `code=-2`-proof regex; mtime-sort before candidate cap; deadline-clamped plutil timeouts; tool-layer hint injection (no `cdp → tools` import); in-flight serialization of concurrent recoveries; terminal not-installed cache with re-probe self-heal; strict per-platform bundleId resolver (no iOS←Android fallback) + active-session appId in the restart chain; session-UDID targeting in restart; detached-budget reset on successful hardReset; existing gh-208 throwing tests get `isAppInstalled: async () => null` so unit tests never shell out.
 
 ---
 
@@ -18,16 +20,18 @@ All paths relative to `scripts/cdp-bridge/` unless noted.
 
 | File | Action | Responsibility |
 |---|---|---|
-| `src/cdp/app-installed-probe.ts` | Create | `probeAppInstalled` (ground-truth tri-state probe), `posixSingleQuote`, `buildNotInstalledAdvice`, `SnapshotHint` type |
-| `src/tools/resolve-ios-app-file.ts` | Modify | Add `findSnapshotForBundleId` + `snapshotHintForBundleId` (budgeted scan of `$TMPDIR/rn-appfile-snapshots`) |
-| `src/cdp/recover-detached.ts` | Modify | New reason `'app-not-installed'`, short-circuit, `udid`/`appId`/`snapshotHint` on the result |
-| `src/tools/status.ts` | Modify | Map `'app-not-installed'` → `APP_NOT_INSTALLED` failResult with advice |
-| `src/tools/restart.ts` | Modify | bundleId chain gains `resolveBundleId()` fallback; `launch:err` step classified via the probe |
+| `src/cdp/app-installed-probe.ts` | Create | `probeAppInstalled` (stderr-only tri-state probe), `posixSingleQuote`, `buildNotInstalledAdvice`, `SnapshotHint` type |
+| `src/tools/resolve-ios-app-file.ts` | Modify | Add `findSnapshotForBundleId` + `snapshotHintForBundleId` (mtime-sorted, budgeted scan of `$TMPDIR/rn-appfile-snapshots`) |
+| `src/cdp/recover-detached.ts` | Modify | New reason `'app-not-installed'`, in-flight serialization, terminal-diagnosis cache, short-circuit, `udid`/`appId`/`snapshotHint` on the result |
+| `src/tools/status.ts` | Modify | Inject `snapshotHintForBundleId` into recovery; map `'app-not-installed'` → `APP_NOT_INSTALLED` failResult with advice |
+| `src/tools/restart.ts` | Modify | Strict bundleId chain (`arg > connectedTarget > cache > session appId > strict app.json`); session-UDID targeting; `launch:err` classification; budget reset on success |
+| `src/project-config.ts` | Modify | Add `readAppIdStrict` / `resolveBundleIdStrict` (no cross-platform fallback) |
 | `src/types.ts` | Modify | Add `'APP_NOT_INSTALLED'` to `ToolErrorCode` |
 | `test/unit/gh-262-*.test.js` | Create | One test file per task (5 files) |
+| `test/unit/gh-208-*.test.js` | Modify | Inject `isAppInstalled: async () => null` where `relaunchApp` throws (no shell-outs from unit tests) |
 | `.changeset/gh-262-app-not-installed.md` | Create | patch changeset |
 
-Working directory for all commands: `scripts/cdp-bridge/`. Branch: `feat/262-app-not-installed-recovery` (already created; spec committed).
+Working directory for all commands: `scripts/cdp-bridge/`. Branch: `feat/262-app-not-installed-recovery` (already created; spec + plan committed).
 
 ---
 
@@ -43,20 +47,21 @@ Create `test/unit/gh-262-app-installed-probe.test.js`:
 
 ```js
 // GH #262: ground-truth probe for "is the app bundle installed on the sim?".
-// Classification is ALLOWLIST-only (codex-pair spec + plan reviews): `false`
-// (not installed) requires the documented app-missing signal — the
-// NSPOSIXErrorDomain code=2 marker. Every other failure shape — bare ENOENT
-// text, device errors, unknown stderr, timeouts — returns `null` (verdict
-// unknown). Never claim not-installed without proof.
+// Classification is ALLOWLIST-only and reads simctl STDERR ONLY (never
+// Error.message, which embeds command argv — a crafted bundleId containing
+// the marker text must not force a false "not installed"). `false` requires
+// the NSPOSIXErrorDomain + code=2 marker (verified live: "(domain=
+// NSPOSIXErrorDomain, code=2)"); every other failure shape — bare ENOENT
+// text, device errors, unknown stderr, no stderr, timeouts — returns `null`.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   probeAppInstalled, buildNotInstalledAdvice, posixSingleQuote,
 } from '../../dist/cdp/app-installed-probe.js';
 
-function execFailing(stderr) {
+function execFailing(stderr, message) {
   return async () => {
-    const err = new Error(`Command failed: xcrun simctl get_app_container ...\n${stderr}`);
+    const err = new Error(message ?? `Command failed: xcrun simctl get_app_container ...\n${stderr}`);
     err.stderr = stderr;
     throw err;
   };
@@ -72,17 +77,28 @@ test('probeAppInstalled: container resolves → true', async () => {
   assert.equal(await probeAppInstalled('UDID-A', 'com.example.app', exec), true);
 });
 
-test('probeAppInstalled: NSPOSIXErrorDomain code=2 → false (not installed)', async () => {
+test('probeAppInstalled: real missing-app stderr (domain + code=2) → false', async () => {
+  // Exact shape captured live on this machine (Xcode 26):
   const stderr =
     'An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=2):\n'
+    + 'The operation couldn’t be completed. No such file or directory\n'
     + 'No such file or directory';
   assert.equal(await probeAppInstalled('U', 'a', execFailing(stderr)), false);
 });
 
-test('probeAppInstalled: bare "No such file or directory" WITHOUT the domain marker → null', async () => {
-  // codex-pair plan review: generic ENOENT text can appear in unrelated simctl
-  // failures — only the NSPOSIXErrorDomain code=2 marker is proof.
+test('probeAppInstalled: marker is case-insensitive and separator-flexible', async () => {
+  assert.equal(await probeAppInstalled('U', 'a', execFailing('nsposixerrordomain Code: 2 oops')), false);
+});
+
+test('probeAppInstalled: code=-2 / code=20 / missing domain → null (never false)', async () => {
+  assert.equal(await probeAppInstalled('U', 'a', execFailing('domain=NSPOSIXErrorDomain, code=-2')), null);
+  assert.equal(await probeAppInstalled('U', 'a', execFailing('domain=NSPOSIXErrorDomain, code=20')), null);
   assert.equal(await probeAppInstalled('U', 'a', execFailing('No such file or directory')), null);
+});
+
+test('probeAppInstalled: marker in Error.message but NOT stderr → null (argv-spoof defense)', async () => {
+  const spoof = execFailing('', 'Command failed: xcrun simctl get_app_container U NSPOSIXErrorDomain-code=2-trap app');
+  assert.equal(await probeAppInstalled('U', 'NSPOSIXErrorDomain-code=2-trap', spoof), null);
 });
 
 test('probeAppInstalled: device-level error → null (fail open)', async () => {
@@ -90,9 +106,7 @@ test('probeAppInstalled: device-level error → null (fail open)', async () => {
   assert.equal(await probeAppInstalled('U', 'a', execFailing('No devices are booted.')), null);
 });
 
-test('probeAppInstalled: unrecognized failure shape → null (allowlist, fail open)', async () => {
-  assert.equal(await probeAppInstalled('U', 'a', execFailing('Some new simctl error nobody has seen')), null);
-  // Timeout-style error without stderr:
+test('probeAppInstalled: no stderr at all (spawn error / timeout) → null', async () => {
   assert.equal(await probeAppInstalled('U', 'a', async () => { throw new Error('ETIMEDOUT'); }), null);
 });
 
@@ -144,21 +158,26 @@ type Exec = (
   opts?: { timeout?: number },
 ) => Promise<{ stdout: string; stderr: string }>;
 
-// Allowlist classification (codex-pair spec + plan reviews): `false` requires
-// the documented app-missing signal — issue #262's manual diagnosis was exactly
-// `get_app_container` failing with NSPOSIXErrorDomain code=2, and the domain
-// marker is always present in that message. Bare "No such file or directory"
-// text is NOT sufficient (it can appear in unrelated failures). Device-level
-// errors and unrecognized shapes return null: never claim "not installed"
-// without proof.
 const DEVICE_ERROR = /Invalid device|No devices/i;
-const APP_MISSING_POSIX = /NSPOSIXErrorDomain[\s\S]{0,40}code[^\d]{0,3}2\b/;
+
+// Allowlist (codex-pair + multi-LLM plan reviews): `false` requires the
+// documented app-missing signal — verified live as
+// "(domain=NSPOSIXErrorDomain, code=2)". Case-insensitive and
+// distance-independent (Xcode formatting may drift), but `2\b` after an
+// optional '='/':'/space separator so `code=-2` / `code=20` never match.
+function isAppMissingSignal(stderr: string): boolean {
+  return /nsposixerrordomain/i.test(stderr) && /\bcode\s*[=:]?\s*2\b/i.test(stderr);
+}
 
 /**
  * GH #262: ground-truth "is this bundle installed?" probe.
  * true = container resolves; false = confirmed missing; null = unknown
- * (device error / unrecognized failure / timeout) — callers must treat
- * null exactly like "installed" (fail open).
+ * (device error / unrecognized failure / no stderr / timeout) — callers must
+ * treat null exactly like "installed" (fail open).
+ *
+ * Classifies ONLY simctl's own stderr — never Error.message, which embeds the
+ * command argv: a crafted bundleId containing the marker text must not be
+ * able to force a false "not installed".
  */
 export async function probeAppInstalled(
   udid: string,
@@ -170,9 +189,9 @@ export async function probeAppInstalled(
     return true;
   } catch (e) {
     const stderr = (e as { stderr?: string }).stderr ?? '';
-    const detail = `${stderr}\n${e instanceof Error ? e.message : String(e)}`;
-    if (DEVICE_ERROR.test(detail)) return null;
-    if (APP_MISSING_POSIX.test(detail)) return false;
+    if (!stderr) return null;
+    if (DEVICE_ERROR.test(stderr)) return null;
+    if (isAppMissingSignal(stderr)) return false;
     return null;
   }
 }
@@ -206,13 +225,13 @@ export function buildNotInstalledAdvice(
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `npm run build && node --test test/unit/gh-262-app-installed-probe.test.js`
-Expected: PASS (7 tests)
+Expected: PASS (10 tests)
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add src/cdp/app-installed-probe.ts test/unit/gh-262-app-installed-probe.test.js
-git commit -S -m "feat(#262): ground-truth app-installed probe + shell-safe advice builder"
+git commit -S -m "feat(#262): stderr-only app-installed probe + shell-safe advice builder"
 ```
 
 ---
@@ -229,9 +248,12 @@ Create `test/unit/gh-262-find-snapshot.test.js`:
 
 ```js
 // GH #262: best-effort lookup of a reinstallable .app snapshot in the GH #201
-// bounded dir ($TMPDIR/rn-appfile-snapshots). Budgeted (≤10 candidates, ~3s
-// total) and never throws — the hint may add at most the bounded scan budget
-// to an already-failed path and must never FAIL the report it rides on.
+// bounded dir ($TMPDIR/rn-appfile-snapshots). Candidates are mtime-sorted
+// NEWEST-FIRST BEFORE the ≤10 cap (readdir order is arbitrary — capping first
+// could drop the newest match), then plutil-matched under a ~3s budget with
+// deadline-clamped per-read timeouts. Never throws — the hint may add at most
+// the bounded scan budget to an already-failed path and must never FAIL the
+// report it rides on.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
@@ -251,27 +273,45 @@ test('findSnapshotForBundleId: matches CFBundleIdentifier; newest mtime wins', (
   assert.deepEqual(findSnapshotForBundleId('com.example.app', deps), { path: B, mtimeMs: 2000 });
 });
 
-test('findSnapshotForBundleId: no bundle-id match → null', () => {
+test('findSnapshotForBundleId: sorts newest-first BEFORE the cap — newest survives a >10 dir', () => {
+  // 12 decoys older than the target; readdir lists the target LAST.
+  const decoys = Array.from({ length: 12 }, (_, i) => `/tmp/rn-appfile-snapshots/Decoy${i}.app`);
+  const target = '/tmp/rn-appfile-snapshots/Target.app';
+  const reads = [];
   const deps = {
-    listSnapshots: () => [A],
-    readBundleId: () => 'com.other.app',
+    listSnapshots: () => [...decoys, target],
+    readBundleId: (p) => { reads.push(p); return p === target ? 'com.example.app' : 'com.decoy'; },
+    mtimeMs: (p) => (p === target ? 99_000 : 1000),
+    now: () => 0,
+  };
+  assert.deepEqual(findSnapshotForBundleId('com.example.app', deps), { path: target, mtimeMs: 99_000 });
+  assert.equal(reads[0], target, 'newest candidate is plutil-read first');
+  assert.equal(reads.length, 1, 'first (newest) match short-circuits the scan');
+});
+
+test('findSnapshotForBundleId: no bundle-id match → null; at most 10 plutil reads', () => {
+  let reads = 0;
+  const deps = {
+    listSnapshots: () => Array.from({ length: 25 }, (_, i) => `/tmp/rn-appfile-snapshots/App${i}.app`),
+    readBundleId: () => { reads += 1; return 'com.nomatch'; },
     mtimeMs: () => 1000,
     now: () => 0,
   };
   assert.equal(findSnapshotForBundleId('com.example.app', deps), null);
+  assert.equal(reads, 10);
 });
 
 test('findSnapshotForBundleId: unreadable Info.plist (readBundleId null) → candidate skipped', () => {
   const deps = {
     listSnapshots: () => [A, B],
-    readBundleId: (p) => (p === A ? null : 'com.example.app'),
-    mtimeMs: () => 5000,
+    readBundleId: (p) => (p === B ? null : 'com.example.app'),
+    mtimeMs: (p) => (p === A ? 1000 : 2000), // B newer but unreadable
     now: () => 0,
   };
-  assert.deepEqual(findSnapshotForBundleId('com.example.app', deps), { path: B, mtimeMs: 5000 });
+  assert.deepEqual(findSnapshotForBundleId('com.example.app', deps), { path: A, mtimeMs: 1000 });
 });
 
-test('findSnapshotForBundleId: budget overrun → stops scanning, returns best so far', () => {
+test('findSnapshotForBundleId: budget overrun → stops before further plutil reads', () => {
   let reads = 0;
   const deps = {
     listSnapshots: () => [A, B],
@@ -281,19 +321,21 @@ test('findSnapshotForBundleId: budget overrun → stops scanning, returns best s
     now: (() => { let calls = 0; return () => (calls++ === 0 ? 0 : 10_000); })(),
   };
   assert.equal(findSnapshotForBundleId('com.example.app', deps), null);
-  assert.equal(reads, 0, 'no candidate read after budget exceeded');
+  assert.equal(reads, 0, 'no plutil read after budget exceeded');
 });
 
-test('findSnapshotForBundleId: candidate cap — at most 10 scanned', () => {
-  let reads = 0;
+test('findSnapshotForBundleId: per-read timeout is clamped to the remaining deadline', () => {
+  const timeouts = [];
+  let t = 0;
   const deps = {
-    listSnapshots: () => Array.from({ length: 25 }, (_, i) => `/tmp/rn-appfile-snapshots/App${i}.app`),
-    readBundleId: () => { reads += 1; return 'com.nomatch'; },
+    listSnapshots: () => [A, B],
+    readBundleId: (p, timeoutMs) => { timeouts.push(timeoutMs); t += 1500; return 'com.nomatch'; },
     mtimeMs: () => 1000,
-    now: () => 0,
+    now: () => t,
   };
   findSnapshotForBundleId('com.example.app', deps);
-  assert.equal(reads, 10);
+  assert.equal(timeouts[0], 2000, 'full per-read timeout while budget is fresh');
+  assert.ok(timeouts[1] < 2000, `second read clamped to remaining budget, got ${timeouts[1]}`);
 });
 
 test('snapshotHintForBundleId: converts mtime to ageMinutes (rounded, never negative)', () => {
@@ -310,8 +352,8 @@ test('snapshotHintForBundleId: converts mtime to ageMinutes (rounded, never nega
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `node --test test/unit/gh-262-find-snapshot.test.js`
-Expected: FAIL — `findSnapshotForBundleId` is not exported from dist (SyntaxError on import)
+Run: `npm run build && node --test test/unit/gh-262-find-snapshot.test.js`
+Expected: build PASSES, test FAILS — `findSnapshotForBundleId` is not exported from dist (SyntaxError on import)
 
 - [ ] **Step 3: Write the implementation**
 
@@ -332,16 +374,18 @@ Append at the end of the file:
 export interface FindSnapshotDeps {
   /** Absolute paths of candidate .app dirs in the snapshot dir. */
   listSnapshots?: () => string[];
-  /** CFBundleIdentifier of a candidate, or null if unreadable. */
-  readBundleId?: (appPath: string) => string | null;
+  /** CFBundleIdentifier of a candidate (within timeoutMs), or null if unreadable. */
+  readBundleId?: (appPath: string, timeoutMs: number) => string | null;
   /** mtime (ms) of a candidate, or null. */
   mtimeMs?: (appPath: string) => number | null;
   now?: () => number;
 }
 
-// Budget (codex-pair spec review): the hint rides on an ALREADY-FAILED
-// recovery path — it must never add meaningful latency. The dir is bounded
-// by design (one snapshot per app basename), so these are insurance caps.
+// Budget (codex-pair + multi-LLM plan reviews): the hint rides on an
+// ALREADY-FAILED recovery path — it must never add meaningful latency. The
+// dir is bounded by design (one snapshot per app basename), so these are
+// insurance caps. Per-read timeouts are clamped to the remaining deadline so
+// one slow plutil cannot blow the total budget.
 const SNAPSHOT_SCAN_CAP = 10;
 const SNAPSHOT_SCAN_BUDGET_MS = 3000;
 const PLUTIL_TIMEOUT_MS = 2000;
@@ -357,12 +401,12 @@ function defaultListSnapshots(): string[] {
   }
 }
 
-function defaultReadBundleId(appPath: string): string | null {
+function defaultReadBundleId(appPath: string, timeoutMs: number): string | null {
   try {
     const out = execFileSync(
       'plutil',
       ['-extract', 'CFBundleIdentifier', 'raw', join(appPath, 'Info.plist')],
-      { timeout: PLUTIL_TIMEOUT_MS, encoding: 'utf8' },
+      { timeout: timeoutMs, encoding: 'utf8' },
     );
     return out.trim() || null;
   } catch {
@@ -380,11 +424,13 @@ function defaultMtimeMs(appPath: string): number | null {
 
 /**
  * GH #262: find a reinstallable .app snapshot for a bundle id in the GH #201
- * snapshot dir. Best-effort under an explicit budget; returns null on any
- * error or budget overrun. Latency contract: the lookup IS awaited on the
- * already-failed error path, so it may add up to the budget (~3s worst case;
- * typically a few ms — the dir holds one snapshot per app). It can never
- * fail or abort the report it rides on.
+ * snapshot dir. Cheap stat pass first, NEWEST-FIRST sort, THEN the cap —
+ * readdir order is arbitrary, so capping before sorting could drop the newest
+ * match. plutil (the expensive read) runs only on the capped, ordered list,
+ * so the first match is the newest. Latency contract: the lookup IS awaited
+ * on the already-failed error path, so it may add up to the budget (~3s worst
+ * case; typically a few ms — the dir holds one snapshot per app). It can
+ * never fail or abort the report it rides on (all errors → null).
  */
 export function findSnapshotForBundleId(
   bundleId: string,
@@ -395,16 +441,20 @@ export function findSnapshotForBundleId(
   const mtimeMs = deps.mtimeMs ?? defaultMtimeMs;
   const now = deps.now ?? Date.now;
   const deadline = now() + SNAPSHOT_SCAN_BUDGET_MS;
-  let best: { path: string; mtimeMs: number } | null = null;
   try {
-    for (const candidate of listSnapshots().slice(0, SNAPSHOT_SCAN_CAP)) {
-      if (now() > deadline) return best;
-      if (readBundleId(candidate) !== bundleId) continue;
-      const m = mtimeMs(candidate);
-      if (m === null) continue;
-      if (!best || m > best.mtimeMs) best = { path: candidate, mtimeMs: m };
+    const candidates = listSnapshots()
+      .map((path) => ({ path, m: mtimeMs(path) }))
+      .filter((c): c is { path: string; m: number } => c.m !== null)
+      .sort((a, b) => b.m - a.m)
+      .slice(0, SNAPSHOT_SCAN_CAP);
+    for (const { path, m } of candidates) {
+      const remaining = deadline - now();
+      if (remaining <= 0) return null;
+      if (readBundleId(path, Math.min(PLUTIL_TIMEOUT_MS, remaining)) === bundleId) {
+        return { path, mtimeMs: m };
+      }
     }
-    return best;
+    return null;
   } catch {
     return null;
   }
@@ -428,7 +478,7 @@ export function snapshotHintForBundleId(
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `npm run build && node --test test/unit/gh-262-find-snapshot.test.js`
-Expected: PASS (6 tests)
+Expected: PASS (7 tests)
 
 Also run the existing suite for this file to catch regressions:
 Run: `node --test test/unit/gh-201-resolve-ios-app-file.test.js`
@@ -438,16 +488,19 @@ Expected: PASS (unchanged behavior)
 
 ```bash
 git add src/tools/resolve-ios-app-file.ts test/unit/gh-262-find-snapshot.test.js
-git commit -S -m "feat(#262): budgeted snapshot-hint lookup in the GH#201 snapshot dir"
+git commit -S -m "feat(#262): mtime-sorted budgeted snapshot-hint lookup in the GH#201 snapshot dir"
 ```
 
 ---
 
-### Task 3: `recover-detached.ts` — `'app-not-installed'` short-circuit
+### Task 3: `recover-detached.ts` — `'app-not-installed'` short-circuit, serialization, terminal cache
 
 **Files:**
-- Modify: `scripts/cdp-bridge/src/cdp/recover-detached.ts` (reason union ~line 13, result interface ~line 22, deps interface ~line 60, relaunch catch ~line 125)
+- Modify: `scripts/cdp-bridge/src/cdp/recover-detached.ts`
+- Modify: `scripts/cdp-bridge/test/unit/gh-208-recover-detached.test.js` and `scripts/cdp-bridge/test/unit/gh-208-review-fixes.test.js` — every deps object whose `relaunchApp` THROWS gains `isAppInstalled: async () => null` (find them with `grep -n "relaunchApp" test/unit/gh-208-*.test.js`); without it the new default probe would shell out to real `xcrun` from unit tests
 - Test: `scripts/cdp-bridge/test/unit/gh-262-recover-not-installed.test.js`
+
+**Layering rule (multi-LLM review consensus):** `recover-detached.ts` imports ONLY from `./app-installed-probe.js` (same `cdp/` layer). It does NOT import from `tools/` — `deps.snapshotHint` has NO default and stays `undefined` unless the tool layer injects it (Task 4 wires `status.ts`; `restart.ts` uses its own).
 
 - [ ] **Step 1: Write the failing test**
 
@@ -455,10 +508,13 @@ Create `test/unit/gh-262-recover-not-installed.test.js`:
 
 ```js
 // GH #262: when the cold-relaunch fails AND simctl confirms the bundle is not
-// installed, recovery short-circuits with reason 'app-not-installed' (carrying
-// udid/appId for advice + a best-effort snapshot hint) instead of looping on
-// reconnect attempts that can never succeed. Probe verdicts true/null keep the
-// existing still-detached behavior (fail open).
+// installed, recovery short-circuits with reason 'app-not-installed'
+// (carrying udid/appId for advice + a best-effort injected snapshot hint)
+// instead of looping on reconnect attempts that can never succeed. Probe
+// verdicts true/null keep the existing still-detached behavior (fail open).
+// Concurrent recoveries are serialized (followers share the leader's
+// verdict); a confirmed not-installed is cached per (udid, appId) and
+// re-probed cheaply so a user reinstall self-heals.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
@@ -473,7 +529,7 @@ function baseDeps(over = {}) {
       getSession: () => ({ deviceId: 'UDID-A', appId: 'com.example.app', platform: 'ios' }),
       isFlowActive: () => false,
       isOptedOut: () => false,
-      relaunchApp: async () => { throw new Error('FBSOpenApplicationServiceErrorDomain, code=4'); },
+      relaunchApp: async () => { calls.push('relaunch'); throw new Error('FBSOpenApplicationServiceErrorDomain, code=4'); },
       stopFastRunner: () => calls.push('stop'),
       reconnect: async () => { calls.push('reconnect'); },
       probeAlive: async () => false,
@@ -506,6 +562,14 @@ test('launch fails + probe FALSE → app-not-installed, short-circuits settle/re
   assert.ok(!calls.includes('reconnect'), 'short-circuit: no reconnect attempt');
 });
 
+test('no snapshotHint dep injected → app-not-installed without hint (cdp layer has no default)', async () => {
+  resetDetachedRecoveryCounter();
+  const { deps } = baseDeps({ isAppInstalled: async () => false });
+  const r = await recoverDetached({}, deps);
+  assert.equal(r.reason, 'app-not-installed');
+  assert.equal(r.snapshotHint, undefined);
+});
+
 test('launch fails + probe NULL (ambiguous) → still-detached with raw error (fail open)', async () => {
   resetDetachedRecoveryCounter();
   const { calls, deps } = baseDeps({ isAppInstalled: async () => null });
@@ -535,11 +599,50 @@ test('snapshot hint THROWS → app-not-installed without hint (hint is best-effo
   assert.equal(r.snapshotHint, undefined);
 });
 
-test('app-not-installed consumes its attempt (side effects happened)', async () => {
+test('terminal cache: second call re-probes cheaply, NO relaunch side effects, NO budget burn', async () => {
   resetDetachedRecoveryCounter();
-  const mk = () => baseDeps({ isAppInstalled: async () => false, snapshotHint: () => null }).deps;
-  assert.equal((await recoverDetached({}, mk())).attempt, 1);
-  assert.equal((await recoverDetached({}, mk())).attempt, 2);
+  const first = baseDeps({ isAppInstalled: async () => false });
+  assert.equal((await recoverDetached({}, first.deps)).reason, 'app-not-installed');
+
+  const second = baseDeps({ isAppInstalled: async () => false });
+  const r2 = await recoverDetached({}, second.deps);
+  assert.equal(r2.reason, 'app-not-installed');
+  assert.equal(r2.attempt, 1, 'cached diagnosis does not burn budget');
+  assert.ok(!second.calls.includes('relaunch'), 'no terminate/launch on a cached diagnosis');
+});
+
+test('terminal cache self-heals: re-probe TRUE clears the cache and recovery proceeds', async () => {
+  resetDetachedRecoveryCounter();
+  const first = baseDeps({ isAppInstalled: async () => false });
+  await recoverDetached({}, first.deps);
+
+  const second = baseDeps({
+    isAppInstalled: async () => true, // user reinstalled
+    relaunchApp: async () => { second.calls.push('relaunch'); },
+    probeAlive: async () => true,
+  });
+  const r2 = await recoverDetached({}, second.deps);
+  assert.equal(r2.reason, 'recovered');
+  assert.ok(second.calls.includes('relaunch'), 'normal recovery resumed after reinstall');
+});
+
+test('concurrent recoveries are serialized: followers share the leader verdict, one relaunch total', async () => {
+  resetDetachedRecoveryCounter();
+  let release;
+  const gate = new Promise((r) => { release = r; });
+  let relaunches = 0;
+  const { deps } = baseDeps({
+    relaunchApp: async () => { relaunches += 1; await gate; throw new Error('code=4'); },
+    isAppInstalled: async () => false,
+    snapshotHint: () => null,
+  });
+  const p1 = recoverDetached({}, deps);
+  const p2 = recoverDetached({}, deps);
+  release();
+  const [r1, r2] = await Promise.all([p1, p2]);
+  assert.equal(relaunches, 1, 'follower must not run its own terminate/launch');
+  assert.equal(r1.reason, 'app-not-installed');
+  assert.deepEqual(r2, r1, 'follower shares the leader verdict');
 });
 
 test('relaunch SUCCEEDS → probe never called (cost lands only on the failed path)', async () => {
@@ -558,19 +661,18 @@ test('relaunch SUCCEEDS → probe never called (cost lands only on the failed pa
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `node --test test/unit/gh-262-recover-not-installed.test.js`
-Expected: FAIL — first test gets `reason: 'still-detached'` instead of `'app-not-installed'`
+Run: `npm run build && node --test test/unit/gh-262-recover-not-installed.test.js`
+Expected: build PASSES, first test gets `reason: 'still-detached'` instead of `'app-not-installed'`
 
 - [ ] **Step 3: Write the implementation**
 
 In `src/cdp/recover-detached.ts`:
 
-(a) Add imports after the existing ones:
+(a) Add the import (same `cdp/` layer only — NOT from `tools/`):
 
 ```typescript
 import { probeAppInstalled } from './app-installed-probe.js';
 import type { SnapshotHint } from './app-installed-probe.js';
-import { snapshotHintForBundleId } from '../tools/resolve-ios-app-file.js';
 ```
 
 (b) Extend the reason union:
@@ -618,12 +720,89 @@ export interface RecoverDetachedDeps {
   maxPerSession?: number;
   /** GH #262: tri-state install probe (true/false/null=unknown). */
   isAppInstalled?: (udid: string, appId: string) => Promise<boolean | null>;
-  /** GH #262: best-effort reinstallable-snapshot hint. */
+  /**
+   * GH #262: best-effort reinstallable-snapshot hint. NO default — the
+   * implementation lives in the tools layer (resolve-ios-app-file.ts) and
+   * cdp/ must not import from tools/; status.ts/restart.ts inject it.
+   */
   snapshotHint?: (appId: string) => SnapshotHint | null;
 }
 ```
 
-(e) Replace the relaunch try/catch block (currently `let relaunchError ... }` around lines 125–133) with:
+(e) Replace the module-state block (`let attempts = 0; ... export function resetDetachedRecoveryCounter ...`) with:
+
+```typescript
+let attempts = 0;
+/** GH #262: a CONFIRMED missing bundle, cached so follow-up recoveries
+ * short-circuit (no pointless terminate/launch, no budget burn) until a
+ * cheap re-probe sees it reinstalled. */
+let confirmedNotInstalled: { udid: string; appId: string } | null = null;
+/** GH #262: serialize concurrent recoveries — agent workflows fire cdp_status
+ * in bursts; followers share the leader's verdict instead of racing their own
+ * simctl terminate/launch and burning the consecutive-attempt budget. */
+let inflight: Promise<DetachedRecoveryResult> | null = null;
+
+/** Reset the per-session recovery budget (on device_snapshot open AND on a successful recovery). */
+export function resetDetachedRecoveryCounter(): void {
+  attempts = 0;
+  confirmedNotInstalled = null;
+}
+```
+
+(f) Rename the existing exported `recoverDetached` body to a private `recoverDetachedInner` and add the serializing wrapper:
+
+```typescript
+export async function recoverDetached(
+  client: CDPClient,
+  deps: RecoverDetachedDeps = {},
+): Promise<DetachedRecoveryResult> {
+  if (inflight) return inflight;
+  inflight = recoverDetachedInner(client, deps);
+  try {
+    return await inflight;
+  } finally {
+    inflight = null;
+  }
+}
+
+async function recoverDetachedInner(
+  client: CDPClient,
+  deps: RecoverDetachedDeps = {},
+): Promise<DetachedRecoveryResult> {
+  // ... existing body, with the additions below ...
+}
+```
+
+(g) Inside `recoverDetachedInner`, AFTER the session/platform early-returns and BEFORE the budget check, insert the terminal-cache gate (note `udid`/`appId` are already in scope there — move their `const` declarations up if needed):
+
+```typescript
+  const isAppInstalled = deps.isAppInstalled ?? probeAppInstalled;
+  const buildHint = (): SnapshotHint | undefined => {
+    if (!deps.snapshotHint) return undefined;
+    try { return deps.snapshotHint(appId) ?? undefined; } catch { return undefined; }
+  };
+
+  // GH #262: a previously CONFIRMED missing bundle short-circuits the whole
+  // attempt — but a cheap re-probe first, so a user reinstall self-heals.
+  if (confirmedNotInstalled
+      && confirmedNotInstalled.udid === udid
+      && confirmedNotInstalled.appId === appId) {
+    if ((await isAppInstalled(udid, appId)) === false) {
+      const snapshotHint = buildHint();
+      return {
+        recovered: false,
+        reason: 'app-not-installed',
+        attempt: attempts,
+        udid,
+        appId,
+        ...(snapshotHint ? { snapshotHint } : {}),
+      };
+    }
+    confirmedNotInstalled = null;
+  }
+```
+
+(h) Replace the relaunch try/catch block with:
 
 ```typescript
   let relaunchError: string | undefined;
@@ -639,11 +818,9 @@ export interface RecoverDetachedDeps {
     // "relaunch manually" advice) pointless. Ask simctl for ground truth; on a
     // CONFIRMED missing bundle, short-circuit — settle/reconnect/liveness below
     // cannot succeed. Probe verdict null = unknown → fall through (fail open).
-    const isAppInstalled = deps.isAppInstalled ?? probeAppInstalled;
     if ((await isAppInstalled(udid, appId)) === false) {
-      const hintFor = deps.snapshotHint ?? snapshotHintForBundleId;
-      let snapshotHint: SnapshotHint | null = null;
-      try { snapshotHint = hintFor(appId); } catch { /* hint is best-effort */ }
+      confirmedNotInstalled = { udid, appId };
+      const snapshotHint = buildHint();
       return {
         recovered: false,
         reason: 'app-not-installed',
@@ -657,37 +834,40 @@ export interface RecoverDetachedDeps {
   }
 ```
 
+(i) Update the existing gh-208 tests: in `test/unit/gh-208-recover-detached.test.js` and `test/unit/gh-208-review-fixes.test.js`, find every deps object whose `relaunchApp` throws and add `isAppInstalled: async () => null` to it (keeps their still-detached semantics AND prevents the default probe shelling out to real `xcrun` from unit tests).
+
 - [ ] **Step 4: Run tests to verify they pass (new + existing)**
 
-Run: `npm run build && node --test test/unit/gh-262-recover-not-installed.test.js test/unit/gh-208-recover-detached.test.js`
-Expected: PASS — all tests in both files
+Run: `npm run build && node --test test/unit/gh-262-recover-not-installed.test.js test/unit/gh-208-recover-detached.test.js test/unit/gh-208-review-fixes.test.js`
+Expected: PASS — all tests in all three files
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add src/cdp/recover-detached.ts test/unit/gh-262-recover-not-installed.test.js
-git commit -S -m "feat(#262): recover-detached short-circuits on confirmed app-not-installed"
+git add src/cdp/recover-detached.ts test/unit/gh-262-recover-not-installed.test.js test/unit/gh-208-recover-detached.test.js test/unit/gh-208-review-fixes.test.js
+git commit -S -m "feat(#262): recover-detached app-not-installed short-circuit + serialization + terminal cache"
 ```
 
 ---
 
-### Task 4: `APP_NOT_INSTALLED` error code + `cdp_status` mapping
+### Task 4: `APP_NOT_INSTALLED` error code + `cdp_status` mapping + hint injection
 
 **Files:**
 - Modify: `scripts/cdp-bridge/src/types.ts` (ToolErrorCode union, ~line 190)
-- Modify: `scripts/cdp-bridge/src/tools/status.ts` (APP_DETACHED catch, before the `detachedHint` chain ~line 331)
+- Modify: `scripts/cdp-bridge/src/tools/status.ts` (deps type ~line 123, recovery call site ~line 315, APP_DETACHED catch before the `detachedHint` chain ~line 331)
 - Test: `scripts/cdp-bridge/test/unit/gh-262-status-not-installed.test.js`
 
 - [ ] **Step 1: Write the failing test**
 
-Create `test/unit/gh-262-status-not-installed.test.js` (harness mirrors `gh-208-status-detached-recovery.test.js` — if envelope field names differ, align assertions with the APP_DETACHED refusal tests in that file):
+Create `test/unit/gh-262-status-not-installed.test.js` (harness mirrors `gh-208-status-detached-recovery.test.js`; envelope fields verified: `env.code` / `env.error`):
 
 ```js
 // GH #262: when detached-recovery reports 'app-not-installed', cdp_status
 // returns the distinct APP_NOT_INSTALLED code with install advice (incl. a
 // shell-quoted snapshot reinstall line when a hint exists) — instead of the
 // generic APP_DETACHED "relaunch manually / hardReset" advice that can never
-// work for a missing bundle.
+// work for a missing bundle. status.ts also injects the tools-layer
+// snapshotHint implementation into the recovery deps (layering rule).
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createMockClient } from '../helpers/mock-cdp-client.js';
@@ -708,10 +888,10 @@ function makeDetachedClient() {
   });
 }
 
-function makeHandler(recovery) {
+function makeHandler(recovery, capture) {
   const client = makeDetachedClient();
   return createStatusHandler(() => client, () => {}, () => client, {
-    recoverDetached: async () => recovery,
+    recoverDetached: async (c, rdeps) => { if (capture) capture(rdeps); return recovery; },
   });
 }
 
@@ -758,6 +938,21 @@ test('cdp_status: app-not-installed without hint → rebuild advice, no install 
   }
 });
 
+test('cdp_status: injects a tools-layer snapshotHint fn into the recovery deps', async () => {
+  _setHasSessionForTest(false);
+  try {
+    let rdeps;
+    const handler = makeHandler(
+      { recovered: false, reason: 'still-detached', attempt: 1 },
+      (d) => { rdeps = d; },
+    );
+    await handler({});
+    assert.equal(typeof rdeps?.snapshotHint, 'function', 'status.ts must inject snapshotHint (layering rule)');
+  } finally {
+    _resetHasSessionForTest();
+  }
+});
+
 test('cdp_status: still-detached keeps the existing APP_DETACHED code (no regression)', async () => {
   _setHasSessionForTest(false);
   try {
@@ -772,8 +967,8 @@ test('cdp_status: still-detached keeps the existing APP_DETACHED code (no regres
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `node --test test/unit/gh-262-status-not-installed.test.js`
-Expected: FAIL — first two tests get code `APP_DETACHED` instead of `APP_NOT_INSTALLED`
+Run: `npm run build && node --test test/unit/gh-262-status-not-installed.test.js`
+Expected: build PASSES; first two tests get code `APP_DETACHED` instead of `APP_NOT_INSTALLED`; the injection test fails on `rdeps?.snapshotHint`
 
 - [ ] **Step 3: Write the implementation**
 
@@ -784,13 +979,29 @@ Expected: FAIL — first two tests get code `APP_DETACHED` instead of `APP_NOT_I
   | 'APP_NOT_INSTALLED'         // GH #262: relaunch failed and get_app_container confirms the bundle is missing
 ```
 
-(b) `src/tools/status.ts` — add the import:
+(b) `src/tools/status.ts` — add imports:
 
 ```typescript
 import { buildNotInstalledAdvice } from '../cdp/app-installed-probe.js';
+import type { RecoverDetachedDeps } from '../cdp/recover-detached.js';
+import { snapshotHintForBundleId } from './resolve-ios-app-file.js';
 ```
 
-(c) `src/tools/status.ts` — inside the `AppDetachedError` branch, immediately BEFORE the `const detachedHint =` chain, insert:
+(c) `src/tools/status.ts` — widen the injectable's type in the handler deps (where `recoverDetached` is declared, ~line 123-129) to accept the deps argument:
+
+```typescript
+  recoverDetached?: (client: CDPClient, rdeps?: RecoverDetachedDeps) => Promise<DetachedRecoveryResult>;
+```
+
+(d) `src/tools/status.ts` — at the recovery call site (~line 315), inject the tools-layer hint (layering rule: cdp/ has no default for it):
+
+```typescript
+        const recovery: DetachedRecoveryResult = callerPinnedNonIos
+          ? { recovered: false, reason: 'unsupported-platform', attempt: 0 }
+          : await recoverDetachedFn(getClient(), { snapshotHint: snapshotHintForBundleId });
+```
+
+(e) `src/tools/status.ts` — inside the `AppDetachedError` branch, immediately BEFORE the `const detachedHint =` chain, insert:
 
 ```typescript
         // GH #262: the bundle is CONFIRMED missing (e.g. simulator erased) —
@@ -816,22 +1027,23 @@ import { buildNotInstalledAdvice } from '../cdp/app-installed-probe.js';
 
 - [ ] **Step 4: Run tests to verify they pass (new + existing)**
 
-Run: `npm run build && node --test test/unit/gh-262-status-not-installed.test.js test/unit/gh-208-status-detached-recovery.test.js`
-Expected: PASS — all tests in both files
+Run: `npm run build && node --test test/unit/gh-262-status-not-installed.test.js test/unit/gh-208-status-detached-recovery.test.js test/unit/gh-208-status-storm-preempt.test.js`
+Expected: PASS — all tests in all three files
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add src/types.ts src/tools/status.ts test/unit/gh-262-status-not-installed.test.js
-git commit -S -m "feat(#262): cdp_status maps app-not-installed to APP_NOT_INSTALLED with install advice"
+git commit -S -m "feat(#262): cdp_status maps app-not-installed to APP_NOT_INSTALLED + injects tools-layer hint"
 ```
 
 ---
 
-### Task 5: `cdp_restart` — app.json bundleId fallback + launch:err classification
+### Task 5: `cdp_restart` — strict bundleId chain, session-UDID targeting, launch classification
 
 **Files:**
-- Modify: `scripts/cdp-bridge/src/tools/restart.ts` (deps interface ~line 12, handler header ~line 114, bundleId chain ~lines 125–129, launch catch ~lines 155–162)
+- Modify: `scripts/cdp-bridge/src/project-config.ts` (add strict resolver)
+- Modify: `scripts/cdp-bridge/src/tools/restart.ts` (deps interface ~line 12, handler header ~line 114, bundleId chain ~lines 125–130, simctl targets, launch catch ~lines 155–162, budget reset)
 - Test: `scripts/cdp-bridge/test/unit/gh-262-restart-fallback.test.js`
 
 - [ ] **Step 1: Write the failing test**
@@ -840,10 +1052,13 @@ Create `test/unit/gh-262-restart-fallback.test.js` (mock-client harness copied f
 
 ```js
 // GH #262 (+ #194 BUG 2 residual): hardReset must not silently degrade to a
-// soft reset when the bundleId cache is empty — it now falls back to app.json
-// (resolveBundleId). And a failed `simctl launch` is classified: a CONFIRMED
-// missing bundle yields an APP_NOT_INSTALLED step with install advice instead
-// of a raw OS error.
+// soft reset when the bundleId cache is empty — the chain is now
+// explicit arg > connectedTarget > cache > active-session appId > STRICT
+// app.json (per-platform, NO iOS←Android fallback: feeding an Android
+// package to iOS simctl would misreport APP_NOT_INSTALLED). simctl targets
+// the active session's UDID when one exists ('booted' otherwise), failed
+// launches are probe-classified, and a successful hardReset resets the
+// detached-recovery budget.
 import { test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import {
@@ -870,22 +1085,21 @@ function harness(deps) {
   const oldClient = makeMockClient();
   const newClient = makeMockClient();
   let current = oldClient;
-  const handler = createRestartHandler(
+  return createRestartHandler(
     () => current,
     (c) => { current = c; },
     () => newClient,
-    deps,
+    { getSession: () => null, ...deps },
   );
-  return handler;
 }
 
-test('hardReset: empty cache + no connectedTarget → falls back to resolveBundleId (app.json)', async () => {
+test('hardReset: empty cache + no session → strict app.json fallback, simctl on booted', async () => {
   const simctl = [];
   const handler = harness({
     execFile: async (cmd, args) => { simctl.push(args.join(' ')); return { stdout: '', stderr: '' }; },
     stopFastRunner: () => {},
     sleep: async () => {},
-    resolveBundleId: (platform) => {
+    resolveBundleIdStrict: (platform) => {
       assert.equal(platform, 'ios');
       return 'com.fallback.app';
     },
@@ -897,12 +1111,26 @@ test('hardReset: empty cache + no connectedTarget → falls back to resolveBundl
   assert.ok(!data.hardResetSteps.some((s) => s.startsWith('skip-simctl')));
 });
 
-test('hardReset: app.json also unresolvable → existing skip-simctl step (unchanged)', async () => {
+test('hardReset: active iOS session appId outranks app.json; simctl targets the session UDID', async () => {
+  const simctl = [];
+  const handler = harness({
+    execFile: async (cmd, args) => { simctl.push(args.join(' ')); return { stdout: '', stderr: '' }; },
+    stopFastRunner: () => {},
+    sleep: async () => {},
+    getSession: () => ({ deviceId: 'UDID-S', appId: 'com.session.app', platform: 'ios' }),
+    resolveBundleIdStrict: () => 'com.fallback.app',
+  });
+  expectOk(await handler({ hardReset: true }));
+  assert.ok(simctl.some((c) => c === 'simctl terminate UDID-S com.session.app'), `got: ${simctl}`);
+  assert.ok(simctl.some((c) => c === 'simctl launch UDID-S com.session.app'));
+});
+
+test('hardReset: strict resolver also unresolvable → existing skip-simctl step (unchanged)', async () => {
   const handler = harness({
     execFile: async () => ({ stdout: '', stderr: '' }),
     stopFastRunner: () => {},
     sleep: async () => {},
-    resolveBundleId: () => null,
+    resolveBundleIdStrict: () => null,
   });
   const data = expectOk(await handler({ hardReset: true }));
   assert.ok(data.hardResetSteps.includes('skip-simctl:no-bundleId-on-connectedTarget-or-cache'));
@@ -916,7 +1144,7 @@ test('hardReset: launch fails + probe FALSE → APP_NOT_INSTALLED step with quot
     },
     stopFastRunner: () => {},
     sleep: async () => {},
-    resolveBundleId: () => 'com.fallback.app',
+    resolveBundleIdStrict: () => 'com.fallback.app',
     probeAppInstalled: async (udid, appId) => {
       assert.equal(udid, 'booted');
       assert.equal(appId, 'com.fallback.app');
@@ -939,65 +1167,127 @@ test('hardReset: launch fails + probe NULL → raw launch:err step (fail open, u
     },
     stopFastRunner: () => {},
     sleep: async () => {},
-    resolveBundleId: () => 'com.fallback.app',
+    resolveBundleIdStrict: () => 'com.fallback.app',
     probeAppInstalled: async () => null,
   });
   const data = expectOk(await handler({ hardReset: true }));
   assert.ok(data.hardResetSteps.some((s) => s.startsWith('simctl launch:err(') && !s.includes('APP_NOT_INSTALLED')));
 });
+
+test('hardReset success resets the detached-recovery budget', async () => {
+  let resets = 0;
+  const handler = harness({
+    execFile: async () => ({ stdout: '', stderr: '' }),
+    stopFastRunner: () => {},
+    sleep: async () => {},
+    resolveBundleIdStrict: () => 'com.fallback.app',
+    resetDetachedBudget: () => { resets += 1; },
+  });
+  expectOk(await handler({ hardReset: true }));
+  assert.equal(resets, 1, 'a successful manual hard reset is a working recovery — budget must reset');
+});
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `node --test test/unit/gh-262-restart-fallback.test.js`
-Expected: FAIL — first test finds `skip-simctl:no-bundleId-on-connectedTarget-or-cache` (no fallback yet)
+Run: `npm run build && node --test test/unit/gh-262-restart-fallback.test.js`
+Expected: build PASSES; first test finds `skip-simctl:no-bundleId-on-connectedTarget-or-cache` (no fallback yet)
 
 - [ ] **Step 3: Write the implementation**
 
-In `src/tools/restart.ts`:
-
-(a) Add imports:
+(a) `src/project-config.ts` — append the strict resolver (NO cross-platform fallback; multi-LLM review: feeding an Android package to iOS simctl would misreport `APP_NOT_INSTALLED`):
 
 ```typescript
-import { resolveBundleId } from '../project-config.js';
+/**
+ * GH #262: strict per-platform app id — NO cross-platform fallback. Used by
+ * recovery paths where a wrong-platform id would produce a confidently wrong
+ * diagnosis (an Android package fed to iOS simctl "is not installed").
+ */
+export function readAppIdStrict(projectRoot: string, platform: string): string | null {
+  for (const filename of ['app.json', 'app.config.json']) {
+    const p = join(projectRoot, filename);
+    if (!existsSync(p)) continue;
+    try {
+      const raw = JSON.parse(readFileSync(p, 'utf-8')) as AppConfig;
+      const expo = (raw.expo ?? raw) as AppConfig['expo'];
+      if (platform === 'android') return expo?.android?.package ?? null;
+      return expo?.ios?.bundleIdentifier ?? null;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+export function resolveBundleIdStrict(platform: string): string | null {
+  const projectRoot = findProjectRoot();
+  if (!projectRoot) return null;
+  return readAppIdStrict(projectRoot, platform);
+}
+```
+
+(b) `src/tools/restart.ts` — add imports:
+
+```typescript
+import { resolveBundleIdStrict } from '../project-config.js';
+import { getActiveSession } from '../agent-device-wrapper.js';
 import { probeAppInstalled, buildNotInstalledAdvice } from '../cdp/app-installed-probe.js';
 import type { SnapshotHint } from '../cdp/app-installed-probe.js';
+import { resetDetachedRecoveryCounter } from '../cdp/recover-detached.js';
 import { snapshotHintForBundleId } from './resolve-ios-app-file.js';
 ```
 
-(b) Extend `RestartHandlerDeps`:
+(c) Extend `RestartHandlerDeps`:
 
 ```typescript
-  /** GH #262 (#194 BUG 2 residual): app.json fallback for the relaunch target. */
-  resolveBundleId?: (platform: string) => string | null;
+  /** GH #262 (#194 BUG 2 residual): strict per-platform app.json fallback. */
+  resolveBundleIdStrict?: (platform: string) => string | null;
+  /** GH #262: active device session (appId outranks app.json; UDID targets simctl). */
+  getSession?: () => { deviceId?: string; appId?: string; platform?: string } | null;
   /** GH #262: tri-state install probe for classifying launch failures. */
   probeAppInstalled?: (udid: string, appId: string) => Promise<boolean | null>;
   /** GH #262: best-effort reinstallable-snapshot hint. */
   snapshotHint?: (appId: string) => SnapshotHint | null;
+  /** GH #262: a successful manual hard reset is a working recovery — reset the detached budget. */
+  resetDetachedBudget?: () => void;
 ```
 
-(c) Resolve the deps in the handler header (next to the existing three):
+(d) Resolve the deps in the handler header (next to the existing three):
 
 ```typescript
-  const resolveBundleIdFn = deps.resolveBundleId ?? resolveBundleId;
+  const resolveBundleIdStrictFn = deps.resolveBundleIdStrict ?? resolveBundleIdStrict;
+  const getSessionFn = deps.getSession ?? getActiveSession;
   const probeAppInstalledFn = deps.probeAppInstalled ?? probeAppInstalled;
   const snapshotHintFn = deps.snapshotHint ?? snapshotHintForBundleId;
+  const resetDetachedBudgetFn = deps.resetDetachedBudget ?? resetDetachedRecoveryCounter;
 ```
 
-(d) Replace the bundleId/platform resolution block (currently `const observedBundleId ... .toLowerCase();`, ~lines 125–130) — `targetPlatform` must now be computed BEFORE `bundleId`:
+(e) Replace the bundleId/platform resolution block (currently `const observedBundleId ... .toLowerCase();`, ~lines 125–130) — `targetPlatform` must now be computed BEFORE `bundleId`, and the simctl target honors the active session's UDID:
 
 ```typescript
       const observedBundleId = oldClient.connectedTarget?.description ?? null;
       if (observedBundleId) lastSeenBundleId = observedBundleId;
       const targetPlatform = (oldClient.connectedTarget?.platform ?? args.platform ?? 'ios').toLowerCase();
-      // Resolution priority: explicit arg > current connectedTarget > cache >
-      // app.json (GH #262 / #194 BUG 2: a fresh bridge process has no cache —
-      // without the app.json fallback, hardReset silently degraded to a soft
-      // reset exactly when the hard path was needed).
-      const bundleId = args.bundleId ?? observedBundleId ?? lastSeenBundleId ?? resolveBundleIdFn(targetPlatform);
+      const session = getSessionFn();
+      const sessionMatches = !!session && (session.platform ?? 'ios') === targetPlatform;
+      // Resolution priority (GH #262 / #194 BUG 2): explicit arg > current
+      // connectedTarget > cache > active-session appId > STRICT app.json.
+      // A fresh bridge process has no cache — without the fallbacks, hardReset
+      // silently degraded to a soft reset exactly when the hard path was
+      // needed. STRICT: an Android package must never be fed to iOS simctl.
+      const bundleId = args.bundleId
+        ?? observedBundleId
+        ?? lastSeenBundleId
+        ?? (sessionMatches ? session?.appId ?? null : null)
+        ?? resolveBundleIdStrictFn(targetPlatform);
+      // simctl targets the session's simulator when one is open — 'booted' is
+      // ambiguous with multiple booted sims (multi-LLM review).
+      const targetUdid = (sessionMatches ? session?.deviceId : undefined) ?? 'booted';
 ```
 
-(e) Replace the `simctl launch` catch block (currently pushes `simctl launch:err(...)`, ~lines 155–162):
+(f) In the hardReset simctl block, replace the literal `'booted'` in BOTH `simctl terminate` and `simctl launch` argv with `targetUdid` (step strings keep their existing shapes).
+
+(g) Replace the `simctl launch` catch block (currently pushes `simctl launch:err(...)`):
 
 ```typescript
           } catch (err) {
@@ -1005,11 +1295,11 @@ import { snapshotHintForBundleId } from './resolve-ios-app-file.js';
             // GH #262: distinguish "launch hiccup" from "bundle not installed" —
             // the latter needs install advice, not the soft-reset retry below.
             // Probe verdict null = unknown → keep the raw error (fail open).
-            if ((await probeAppInstalledFn('booted', bundleId)) === false) {
+            if ((await probeAppInstalledFn(targetUdid, bundleId)) === false) {
               let hint: SnapshotHint | null = null;
               try { hint = snapshotHintFn(bundleId); } catch { /* best-effort */ }
               hardResetSteps.push(
-                `simctl launch:err(APP_NOT_INSTALLED — ${buildNotInstalledAdvice('booted', bundleId, hint)})`,
+                `simctl launch:err(APP_NOT_INSTALLED — ${buildNotInstalledAdvice(targetUdid, bundleId, hint)})`,
               );
             } else {
               // Fatal-ish: if launch fails, the soft reset below will likely
@@ -1020,16 +1310,24 @@ import { snapshotHintForBundleId } from './resolve-ios-app-file.js';
           }
 ```
 
+(h) In the SUCCESS return path (after the soft-reset reconnect succeeds), reset the detached budget when this was a hard reset (Antigravity review: a working manual recovery must not leave auto-recovery reporting `budget-exhausted`):
+
+```typescript
+      if (args.hardReset && connected) resetDetachedBudgetFn();
+```
+
+(place it where `connected` (the post-autoConnect success flag, whatever it is named in the existing success path) is known, immediately before building the success result).
+
 - [ ] **Step 4: Run tests to verify they pass (new + existing)**
 
 Run: `npm run build && node --test test/unit/gh-262-restart-fallback.test.js test/unit/cdp-restart.test.js`
-Expected: PASS — all tests in both files. (If an existing `cdp-restart.test.js` case asserted the old skip-simctl behavior while app.json IS resolvable in the test env, inject `resolveBundleId: () => null` into that case to preserve its intent — the real default reads the project's app.json.)
+Expected: PASS — all tests in both files. (Existing `cdp-restart.test.js` cases run without a session — `getSession` defaults to the real `getActiveSession`, which returns null in unit tests, so `'booted'` behavior is preserved. If any existing hardReset case starts resolving a bundleId from THIS repo's app.json via the new strict fallback, inject `resolveBundleIdStrict: () => null` into that case to preserve its intent.)
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add src/tools/restart.ts test/unit/gh-262-restart-fallback.test.js
-git commit -S -m "feat(#262): hardReset app.json bundleId fallback + APP_NOT_INSTALLED launch classification"
+git add src/project-config.ts src/tools/restart.ts test/unit/gh-262-restart-fallback.test.js
+git commit -S -m "feat(#262): hardReset strict bundleId chain + session-UDID targeting + APP_NOT_INSTALLED classification"
 ```
 
 ---
@@ -1043,7 +1341,7 @@ git commit -S -m "feat(#262): hardReset app.json bundleId fallback + APP_NOT_INS
 - [ ] **Step 1: Run the full suite**
 
 Run: `cd scripts/cdp-bridge && npm run test:all`
-Expected: ALL PASS (1966 baseline + ~22 new). Zero failures — fix anything red before proceeding.
+Expected: ALL PASS (1966 baseline + ~35 new). Zero failures — fix anything red before proceeding.
 
 - [ ] **Step 2: Lint (if configured)**
 
@@ -1069,10 +1367,10 @@ Create `.changeset/gh-262-app-not-installed.md` (repo root):
 "rn-dev-agent-plugin": patch
 ---
 
-Recovery paths now detect "app not installed" and resolve their relaunch target (GH #262, absorbs #194 BUG 2).
+Recovery paths now detect "app not installed" and resolve their relaunch target truthfully (GH #262, absorbs #194 BUG 2).
 
-- `cdp_status` APP_DETACHED auto-relaunch: when `simctl launch` fails AND `get_app_container` confirms the bundle is missing (allowlist: `NSPOSIXErrorDomain code=2`), the tool returns a distinct `APP_NOT_INSTALLED` code with install advice — including a shell-quoted `simctl install` line for the reinstallable `.app` snapshot from the last clearState (GH #201 dir) when one matches. Ambiguous probe verdicts fail open to the existing `APP_DETACHED` behavior.
-- `cdp_restart hardReset=true`: the bundleId resolution chain gains an app.json fallback (`resolveBundleId`), so a fresh bridge process no longer silently degrades to a soft reset; failed launches are classified the same way in `hardResetSteps`.
+- `cdp_status` APP_DETACHED auto-relaunch: when `simctl launch` fails AND `get_app_container`'s stderr carries the `NSPOSIXErrorDomain code=2` marker (allowlist-only, stderr-only — argv-spoof-proof), the tool returns a distinct `APP_NOT_INSTALLED` code with install advice — including a shell-quoted `simctl install` line for the newest matching `.app` snapshot from the last clearState (GH #201 dir, mtime-sorted budgeted scan). Ambiguous probe verdicts fail open to the existing `APP_DETACHED` behavior. Concurrent recoveries are serialized, and a confirmed missing bundle is cached (with a cheap re-probe) so the diagnosis is never masked by `budget-exhausted`.
+- `cdp_restart hardReset=true`: the relaunch target resolves through `explicit arg > connectedTarget > cache > active-session appId > strict per-platform app.json` (no iOS←Android fallback), simctl targets the active session's UDID when one exists, failed launches are classified the same way in `hardResetSteps`, and a successful hard reset resets the detached-recovery budget.
 ```
 
 - [ ] **Step 5: Commit**
@@ -1084,9 +1382,10 @@ git commit -S -m "chore(#262): rebuilt dist + changeset"
 
 - [ ] **Step 6: Post-implementation gates (per project workflow)**
 
-1. `/multi-review` (Gemini + Codex) on the branch diff; address findings.
+1. `/multi-review` (Antigravity + Codex) on the branch diff; address findings.
 2. Live verification on the booted iOS simulator — the real escape-hatch gate:
-   - Erase a booted sim (`xcrun simctl erase <udid>` while booted requires shutdown first: `xcrun simctl shutdown <udid> && xcrun simctl erase <udid> && xcrun simctl boot <udid>`), start Metro, call `cdp_status platform=ios` → expect `APP_NOT_INSTALLED` with advice (NOT generic APP_DETACHED), in line with the issue's repro.
+   - Erase a booted sim (`xcrun simctl shutdown <udid> && xcrun simctl erase <udid> && xcrun simctl boot <udid>`), start Metro, call `cdp_status platform=ios` → expect `APP_NOT_INSTALLED` with advice (NOT generic APP_DETACHED), in line with the issue's repro.
+   - Call `cdp_status` again → expect the cached diagnosis (fast, no relaunch attempt) — then reinstall the app and confirm recovery proceeds (cache self-heals).
    - Confirm no snapshot hint appears if `$TMPDIR/rn-appfile-snapshots` has no matching bundle; populate via a clearState flow and confirm the hint appears with a quoted path.
 3. PR via `superpowers:finishing-a-development-branch`; body cites #262 with `Closes #262` and notes the #194 BUG 2 residual closure.
 

--- a/docs/superpowers/plans/2026-06-11-262-app-not-installed-recovery.md
+++ b/docs/superpowers/plans/2026-06-11-262-app-not-installed-recovery.md
@@ -1,0 +1,1086 @@
+# GH #262 — APP_NOT_INSTALLED Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recovery paths (`cdp_status` APP_DETACHED auto-relaunch, `cdp_restart hardReset`) detect a missing app bundle via ground truth (`simctl get_app_container`), report a distinct `APP_NOT_INSTALLED` code with shell-safe install advice (incl. a #201 snapshot hint), and `hardReset` falls back to app.json for its bundleId (closes the #194 BUG 2 residual).
+
+**Architecture:** A new shared probe module (`cdp/app-installed-probe.ts`) classifies launch failures allowlist-only (`false` requires the documented `NSPOSIXErrorDomain code=2` signal; everything else is `null` — fail open). A snapshot finder in `tools/resolve-ios-app-file.ts` (which owns the #201 snapshot dir) supplies a best-effort reinstall hint under an explicit time/candidate budget. `recover-detached.ts` short-circuits on a confirmed missing bundle; `status.ts` and `restart.ts` render the advice.
+
+**Tech Stack:** TypeScript (Node >= 22), `node:test` + `assert/strict` unit tests importing from `dist/`, injectable-deps pattern throughout.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-262-app-not-installed-recovery-design.md` (approved; codex-pair amendments applied).
+
+---
+
+## File Structure
+
+All paths relative to `scripts/cdp-bridge/` unless noted.
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/cdp/app-installed-probe.ts` | Create | `probeAppInstalled` (ground-truth tri-state probe), `posixSingleQuote`, `buildNotInstalledAdvice`, `SnapshotHint` type |
+| `src/tools/resolve-ios-app-file.ts` | Modify | Add `findSnapshotForBundleId` + `snapshotHintForBundleId` (budgeted scan of `$TMPDIR/rn-appfile-snapshots`) |
+| `src/cdp/recover-detached.ts` | Modify | New reason `'app-not-installed'`, short-circuit, `udid`/`appId`/`snapshotHint` on the result |
+| `src/tools/status.ts` | Modify | Map `'app-not-installed'` → `APP_NOT_INSTALLED` failResult with advice |
+| `src/tools/restart.ts` | Modify | bundleId chain gains `resolveBundleId()` fallback; `launch:err` step classified via the probe |
+| `src/types.ts` | Modify | Add `'APP_NOT_INSTALLED'` to `ToolErrorCode` |
+| `test/unit/gh-262-*.test.js` | Create | One test file per task (5 files) |
+| `.changeset/gh-262-app-not-installed.md` | Create | patch changeset |
+
+Working directory for all commands: `scripts/cdp-bridge/`. Branch: `feat/262-app-not-installed-recovery` (already created; spec committed).
+
+---
+
+### Task 1: Ground-truth probe module (`app-installed-probe.ts`)
+
+**Files:**
+- Create: `scripts/cdp-bridge/src/cdp/app-installed-probe.ts`
+- Test: `scripts/cdp-bridge/test/unit/gh-262-app-installed-probe.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/gh-262-app-installed-probe.test.js`:
+
+```js
+// GH #262: ground-truth probe for "is the app bundle installed on the sim?".
+// Classification is ALLOWLIST-only (codex-pair spec review): `false` (not
+// installed) requires the documented app-missing signal (NSPOSIXErrorDomain
+// code=2 / "No such file or directory"); every other failure shape — device
+// errors, unknown stderr, timeouts — returns `null` (verdict unknown).
+// Never claim not-installed without proof.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  probeAppInstalled, buildNotInstalledAdvice, posixSingleQuote,
+} from '../../dist/cdp/app-installed-probe.js';
+
+function execFailing(stderr) {
+  return async () => {
+    const err = new Error(`Command failed: xcrun simctl get_app_container ...\n${stderr}`);
+    err.stderr = stderr;
+    throw err;
+  };
+}
+
+test('probeAppInstalled: container resolves → true', async () => {
+  const exec = async (cmd, args, opts) => {
+    assert.equal(cmd, 'xcrun');
+    assert.deepEqual(args, ['simctl', 'get_app_container', 'UDID-A', 'com.example.app', 'app']);
+    assert.equal(opts.timeout, 5000);
+    return { stdout: '/path/Example.app\n', stderr: '' };
+  };
+  assert.equal(await probeAppInstalled('UDID-A', 'com.example.app', exec), true);
+});
+
+test('probeAppInstalled: NSPOSIXErrorDomain code=2 → false (not installed)', async () => {
+  const stderr =
+    'An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=2):\n'
+    + 'No such file or directory';
+  assert.equal(await probeAppInstalled('U', 'a', execFailing(stderr)), false);
+});
+
+test('probeAppInstalled: bare "No such file or directory" → false', async () => {
+  assert.equal(await probeAppInstalled('U', 'a', execFailing('No such file or directory')), false);
+});
+
+test('probeAppInstalled: device-level error → null (fail open)', async () => {
+  assert.equal(await probeAppInstalled('U', 'a', execFailing('Invalid device: U')), null);
+  assert.equal(await probeAppInstalled('U', 'a', execFailing('No devices are booted.')), null);
+});
+
+test('probeAppInstalled: unrecognized failure shape → null (allowlist, fail open)', async () => {
+  assert.equal(await probeAppInstalled('U', 'a', execFailing('Some new simctl error nobody has seen')), null);
+  // Timeout-style error without stderr:
+  assert.equal(await probeAppInstalled('U', 'a', async () => { throw new Error('ETIMEDOUT'); }), null);
+});
+
+test('posixSingleQuote: inert metacharacters and embedded quotes', () => {
+  assert.equal(posixSingleQuote('plain'), `'plain'`);
+  assert.equal(posixSingleQuote("My App's.app"), `'My App'\\''s.app'`);
+});
+
+test('buildNotInstalledAdvice: base advice without hint; shell-quoted install line with hint', () => {
+  const base = buildNotInstalledAdvice('UDID-A', 'com.example.app', null);
+  assert.match(base, /com\.example\.app is not installed on simulator UDID-A/);
+  assert.match(base, /npx expo run:ios/);
+  assert.doesNotMatch(base, /simctl install/);
+
+  const withHint = buildNotInstalledAdvice('UDID-A', 'com.example.app', {
+    path: '/tmp/rn-appfile-snapshots/My App.app',
+    ageMinutes: 42,
+  });
+  assert.match(withHint, /42 min ago/);
+  assert.match(withHint, /may be stale/);
+  assert.match(withHint, /xcrun simctl install 'UDID-A' '\/tmp\/rn-appfile-snapshots\/My App\.app'/);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/cdp-bridge && npm run build 2>/dev/null; node --test test/unit/gh-262-app-installed-probe.test.js`
+Expected: FAIL — `Cannot find module .../dist/cdp/app-installed-probe.js`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/cdp/app-installed-probe.ts`:
+
+```typescript
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCb);
+
+/** GH #262: a reinstallable .app snapshot (from the GH #201 bounded dir). */
+export interface SnapshotHint {
+  path: string;
+  ageMinutes: number;
+}
+
+type Exec = (
+  cmd: string,
+  args: string[],
+  opts?: { timeout?: number },
+) => Promise<{ stdout: string; stderr: string }>;
+
+// Allowlist classification (codex-pair spec review): `false` requires the
+// documented app-missing signal — issue #262's manual diagnosis was exactly
+// `get_app_container` failing with NSPOSIXErrorDomain code=2. Device-level
+// errors and unrecognized shapes return null: never claim "not installed"
+// without proof.
+const DEVICE_ERROR = /Invalid device|No devices/i;
+const APP_MISSING_POSIX = /NSPOSIXErrorDomain[\s\S]{0,40}code[^\d]{0,3}2\b/;
+const APP_MISSING_ENOENT = /No such file or directory/i;
+
+/**
+ * GH #262: ground-truth "is this bundle installed?" probe.
+ * true = container resolves; false = confirmed missing; null = unknown
+ * (device error / unrecognized failure / timeout) — callers must treat
+ * null exactly like "installed" (fail open).
+ */
+export async function probeAppInstalled(
+  udid: string,
+  appId: string,
+  exec: Exec = execFile as unknown as Exec,
+): Promise<boolean | null> {
+  try {
+    await exec('xcrun', ['simctl', 'get_app_container', udid, appId, 'app'], { timeout: 5000 });
+    return true;
+  } catch (e) {
+    const stderr = (e as { stderr?: string }).stderr ?? '';
+    const detail = `${stderr}\n${e instanceof Error ? e.message : String(e)}`;
+    if (DEVICE_ERROR.test(detail)) return null;
+    if (APP_MISSING_POSIX.test(detail) || APP_MISSING_ENOENT.test(detail)) return false;
+    return null;
+  }
+}
+
+/**
+ * POSIX single-quote (same pattern as device-deeplink.ts / device-interact.ts).
+ * The advice built below is designed to be copy-pasted into a shell, and .app
+ * names can contain spaces/metacharacters.
+ */
+export function posixSingleQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+export function buildNotInstalledAdvice(
+  udid: string,
+  appId: string,
+  hint: SnapshotHint | null,
+): string {
+  const base =
+    `App ${appId} is not installed on simulator ${udid} — rebuild and install ` +
+    '(npx expo run:ios / pnpm ios).';
+  if (!hint) return base;
+  return (
+    `${base} Or reinstall the snapshot taken at the last clearState, ` +
+    `${hint.ageMinutes} min ago (may be stale): ` +
+    `xcrun simctl install ${posixSingleQuote(udid)} ${posixSingleQuote(hint.path)}`
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run build && node --test test/unit/gh-262-app-installed-probe.test.js`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cdp/app-installed-probe.ts test/unit/gh-262-app-installed-probe.test.js
+git commit -S -m "feat(#262): ground-truth app-installed probe + shell-safe advice builder"
+```
+
+---
+
+### Task 2: Snapshot finder (`findSnapshotForBundleId` / `snapshotHintForBundleId`)
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/tools/resolve-ios-app-file.ts` (add to end of file; extend the fs import on line 2)
+- Test: `scripts/cdp-bridge/test/unit/gh-262-find-snapshot.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/gh-262-find-snapshot.test.js`:
+
+```js
+// GH #262: best-effort lookup of a reinstallable .app snapshot in the GH #201
+// bounded dir ($TMPDIR/rn-appfile-snapshots). Budgeted (≤10 candidates, ~3s
+// total) and never throws — the hint must never block or delay an error report.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  findSnapshotForBundleId, snapshotHintForBundleId,
+} from '../../dist/tools/resolve-ios-app-file.js';
+
+const A = '/tmp/rn-appfile-snapshots/AppA.app';
+const B = '/tmp/rn-appfile-snapshots/AppB.app';
+
+test('findSnapshotForBundleId: matches CFBundleIdentifier; newest mtime wins', () => {
+  const deps = {
+    listSnapshots: () => [A, B],
+    readBundleId: () => 'com.example.app',
+    mtimeMs: (p) => (p === A ? 1000 : 2000),
+    now: () => 10_000,
+  };
+  assert.deepEqual(findSnapshotForBundleId('com.example.app', deps), { path: B, mtimeMs: 2000 });
+});
+
+test('findSnapshotForBundleId: no bundle-id match → null', () => {
+  const deps = {
+    listSnapshots: () => [A],
+    readBundleId: () => 'com.other.app',
+    mtimeMs: () => 1000,
+    now: () => 0,
+  };
+  assert.equal(findSnapshotForBundleId('com.example.app', deps), null);
+});
+
+test('findSnapshotForBundleId: unreadable Info.plist (readBundleId null) → candidate skipped', () => {
+  const deps = {
+    listSnapshots: () => [A, B],
+    readBundleId: (p) => (p === A ? null : 'com.example.app'),
+    mtimeMs: () => 5000,
+    now: () => 0,
+  };
+  assert.deepEqual(findSnapshotForBundleId('com.example.app', deps), { path: B, mtimeMs: 5000 });
+});
+
+test('findSnapshotForBundleId: budget overrun → stops scanning, returns best so far', () => {
+  let reads = 0;
+  const deps = {
+    listSnapshots: () => [A, B],
+    readBundleId: () => { reads += 1; return 'com.example.app'; },
+    mtimeMs: () => 1000,
+    // First call (deadline calc) t=0; every later call is past the 3s budget.
+    now: (() => { let calls = 0; return () => (calls++ === 0 ? 0 : 10_000); })(),
+  };
+  assert.equal(findSnapshotForBundleId('com.example.app', deps), null);
+  assert.equal(reads, 0, 'no candidate read after budget exceeded');
+});
+
+test('findSnapshotForBundleId: candidate cap — at most 10 scanned', () => {
+  let reads = 0;
+  const deps = {
+    listSnapshots: () => Array.from({ length: 25 }, (_, i) => `/tmp/rn-appfile-snapshots/App${i}.app`),
+    readBundleId: () => { reads += 1; return 'com.nomatch'; },
+    mtimeMs: () => 1000,
+    now: () => 0,
+  };
+  findSnapshotForBundleId('com.example.app', deps);
+  assert.equal(reads, 10);
+});
+
+test('snapshotHintForBundleId: converts mtime to ageMinutes (rounded, never negative)', () => {
+  const deps = {
+    listSnapshots: () => [A],
+    readBundleId: () => 'com.example.app',
+    mtimeMs: () => 0,
+    now: () => 300_000, // 5 min later
+  };
+  assert.deepEqual(snapshotHintForBundleId('com.example.app', deps), { path: A, ageMinutes: 5 });
+  assert.equal(snapshotHintForBundleId('com.missing', deps), null);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test test/unit/gh-262-find-snapshot.test.js`
+Expected: FAIL — `findSnapshotForBundleId` is not exported from dist (SyntaxError on import)
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/tools/resolve-ios-app-file.ts`, extend the imports (top of file):
+
+```typescript
+import { execFileSync } from 'node:child_process';
+import { existsSync, cpSync, rmSync, mkdirSync, readdirSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, basename } from 'node:path';
+import type { SnapshotHint } from '../cdp/app-installed-probe.js';
+```
+
+Append at the end of the file:
+
+```typescript
+/** GH #262: injectable deps for the snapshot-hint lookup. */
+export interface FindSnapshotDeps {
+  /** Absolute paths of candidate .app dirs in the snapshot dir. */
+  listSnapshots?: () => string[];
+  /** CFBundleIdentifier of a candidate, or null if unreadable. */
+  readBundleId?: (appPath: string) => string | null;
+  /** mtime (ms) of a candidate, or null. */
+  mtimeMs?: (appPath: string) => number | null;
+  now?: () => number;
+}
+
+// Budget (codex-pair spec review): the hint rides on an ALREADY-FAILED
+// recovery path — it must never add meaningful latency. The dir is bounded
+// by design (one snapshot per app basename), so these are insurance caps.
+const SNAPSHOT_SCAN_CAP = 10;
+const SNAPSHOT_SCAN_BUDGET_MS = 3000;
+const PLUTIL_TIMEOUT_MS = 2000;
+
+function defaultListSnapshots(): string[] {
+  const dir = join(tmpdir(), 'rn-appfile-snapshots');
+  try {
+    return readdirSync(dir)
+      .filter((name) => name.endsWith('.app'))
+      .map((name) => join(dir, name));
+  } catch {
+    return [];
+  }
+}
+
+function defaultReadBundleId(appPath: string): string | null {
+  try {
+    const out = execFileSync(
+      'plutil',
+      ['-extract', 'CFBundleIdentifier', 'raw', join(appPath, 'Info.plist')],
+      { timeout: PLUTIL_TIMEOUT_MS, encoding: 'utf8' },
+    );
+    return out.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultMtimeMs(appPath: string): number | null {
+  try {
+    return statSync(appPath).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * GH #262: find a reinstallable .app snapshot for a bundle id in the GH #201
+ * snapshot dir. Best-effort under an explicit budget; returns null on any
+ * error or budget overrun — the hint never blocks the error report it rides on.
+ */
+export function findSnapshotForBundleId(
+  bundleId: string,
+  deps: FindSnapshotDeps = {},
+): { path: string; mtimeMs: number } | null {
+  const listSnapshots = deps.listSnapshots ?? defaultListSnapshots;
+  const readBundleId = deps.readBundleId ?? defaultReadBundleId;
+  const mtimeMs = deps.mtimeMs ?? defaultMtimeMs;
+  const now = deps.now ?? Date.now;
+  const deadline = now() + SNAPSHOT_SCAN_BUDGET_MS;
+  let best: { path: string; mtimeMs: number } | null = null;
+  try {
+    for (const candidate of listSnapshots().slice(0, SNAPSHOT_SCAN_CAP)) {
+      if (now() > deadline) return best;
+      if (readBundleId(candidate) !== bundleId) continue;
+      const m = mtimeMs(candidate);
+      if (m === null) continue;
+      if (!best || m > best.mtimeMs) best = { path: candidate, mtimeMs: m };
+    }
+    return best;
+  } catch {
+    return null;
+  }
+}
+
+/** GH #262: `findSnapshotForBundleId` formatted as advice input. */
+export function snapshotHintForBundleId(
+  bundleId: string,
+  deps: FindSnapshotDeps = {},
+): SnapshotHint | null {
+  const now = deps.now ?? Date.now;
+  const snap = findSnapshotForBundleId(bundleId, deps);
+  if (!snap) return null;
+  return {
+    path: snap.path,
+    ageMinutes: Math.max(0, Math.round((now() - snap.mtimeMs) / 60_000)),
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run build && node --test test/unit/gh-262-find-snapshot.test.js`
+Expected: PASS (6 tests)
+
+Also run the existing suite for this file to catch regressions:
+Run: `node --test test/unit/gh-201-resolve-ios-app-file.test.js`
+Expected: PASS (unchanged behavior)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tools/resolve-ios-app-file.ts test/unit/gh-262-find-snapshot.test.js
+git commit -S -m "feat(#262): budgeted snapshot-hint lookup in the GH#201 snapshot dir"
+```
+
+---
+
+### Task 3: `recover-detached.ts` — `'app-not-installed'` short-circuit
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/cdp/recover-detached.ts` (reason union ~line 13, result interface ~line 22, deps interface ~line 60, relaunch catch ~line 125)
+- Test: `scripts/cdp-bridge/test/unit/gh-262-recover-not-installed.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/gh-262-recover-not-installed.test.js`:
+
+```js
+// GH #262: when the cold-relaunch fails AND simctl confirms the bundle is not
+// installed, recovery short-circuits with reason 'app-not-installed' (carrying
+// udid/appId for advice + a best-effort snapshot hint) instead of looping on
+// reconnect attempts that can never succeed. Probe verdicts true/null keep the
+// existing still-detached behavior (fail open).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  recoverDetached, resetDetachedRecoveryCounter,
+} from '../../dist/cdp/recover-detached.js';
+
+function baseDeps(over = {}) {
+  const calls = [];
+  return {
+    calls,
+    deps: {
+      getSession: () => ({ deviceId: 'UDID-A', appId: 'com.example.app', platform: 'ios' }),
+      isFlowActive: () => false,
+      isOptedOut: () => false,
+      relaunchApp: async () => { throw new Error('FBSOpenApplicationServiceErrorDomain, code=4'); },
+      stopFastRunner: () => calls.push('stop'),
+      reconnect: async () => { calls.push('reconnect'); },
+      probeAlive: async () => false,
+      sleep: async () => { calls.push('sleep'); },
+      maxPerSession: 3,
+      ...over,
+    },
+  };
+}
+
+test('launch fails + probe FALSE → app-not-installed, short-circuits settle/reconnect', async () => {
+  resetDetachedRecoveryCounter();
+  const { calls, deps } = baseDeps({
+    isAppInstalled: async (udid, appId) => {
+      calls.push(`probe:${udid}:${appId}`);
+      return false;
+    },
+    snapshotHint: () => ({ path: '/tmp/rn-appfile-snapshots/My App.app', ageMinutes: 7 }),
+  });
+  const r = await recoverDetached({}, deps);
+  assert.equal(r.recovered, false);
+  assert.equal(r.reason, 'app-not-installed');
+  assert.equal(r.attempt, 1);
+  assert.equal(r.udid, 'UDID-A');
+  assert.equal(r.appId, 'com.example.app');
+  assert.match(r.error, /code=4/);
+  assert.deepEqual(r.snapshotHint, { path: '/tmp/rn-appfile-snapshots/My App.app', ageMinutes: 7 });
+  assert.ok(calls.includes('probe:UDID-A:com.example.app'));
+  assert.ok(!calls.includes('sleep'), 'short-circuit: no settle wait');
+  assert.ok(!calls.includes('reconnect'), 'short-circuit: no reconnect attempt');
+});
+
+test('launch fails + probe NULL (ambiguous) → still-detached with raw error (fail open)', async () => {
+  resetDetachedRecoveryCounter();
+  const { calls, deps } = baseDeps({ isAppInstalled: async () => null });
+  const r = await recoverDetached({}, deps);
+  assert.equal(r.reason, 'still-detached');
+  assert.match(r.error, /code=4/);
+  assert.equal(r.snapshotHint, undefined);
+  assert.ok(calls.includes('reconnect'), 'normal path still attempts reconnect');
+});
+
+test('launch fails + probe TRUE (installed) → existing behavior unchanged', async () => {
+  resetDetachedRecoveryCounter();
+  const { calls, deps } = baseDeps({ isAppInstalled: async () => true });
+  const r = await recoverDetached({}, deps);
+  assert.equal(r.reason, 'still-detached');
+  assert.ok(calls.includes('reconnect'));
+});
+
+test('snapshot hint THROWS → app-not-installed without hint (hint is best-effort)', async () => {
+  resetDetachedRecoveryCounter();
+  const { deps } = baseDeps({
+    isAppInstalled: async () => false,
+    snapshotHint: () => { throw new Error('plist exploded'); },
+  });
+  const r = await recoverDetached({}, deps);
+  assert.equal(r.reason, 'app-not-installed');
+  assert.equal(r.snapshotHint, undefined);
+});
+
+test('app-not-installed consumes its attempt (side effects happened)', async () => {
+  resetDetachedRecoveryCounter();
+  const mk = () => baseDeps({ isAppInstalled: async () => false, snapshotHint: () => null }).deps;
+  assert.equal((await recoverDetached({}, mk())).attempt, 1);
+  assert.equal((await recoverDetached({}, mk())).attempt, 2);
+});
+
+test('relaunch SUCCEEDS → probe never called (cost lands only on the failed path)', async () => {
+  resetDetachedRecoveryCounter();
+  let probed = false;
+  const { deps } = baseDeps({
+    relaunchApp: async () => {},
+    probeAlive: async () => true,
+    isAppInstalled: async () => { probed = true; return false; },
+  });
+  const r = await recoverDetached({}, deps);
+  assert.equal(r.reason, 'recovered');
+  assert.equal(probed, false);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test test/unit/gh-262-recover-not-installed.test.js`
+Expected: FAIL — first test gets `reason: 'still-detached'` instead of `'app-not-installed'`
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/cdp/recover-detached.ts`:
+
+(a) Add imports after the existing ones:
+
+```typescript
+import { probeAppInstalled } from './app-installed-probe.js';
+import type { SnapshotHint } from './app-installed-probe.js';
+import { snapshotHintForBundleId } from '../tools/resolve-ios-app-file.js';
+```
+
+(b) Extend the reason union:
+
+```typescript
+export type DetachedReason =
+  | 'recovered'
+  | 'still-detached'
+  | 'app-not-installed'
+  | 'no-session'
+  | 'flow-active'
+  | 'opted-out'
+  | 'unsupported-platform'
+  | 'budget-exhausted';
+```
+
+(c) Extend the result interface:
+
+```typescript
+export interface DetachedRecoveryResult {
+  recovered: boolean;
+  reason: DetachedReason;
+  attempt: number;
+  /** GH #208 review (Codex F3): a `simctl launch` failure message, surfaced instead of hidden. */
+  error?: string;
+  /** GH #262: set on 'app-not-installed' so the caller can build install advice. */
+  udid?: string;
+  appId?: string;
+  snapshotHint?: SnapshotHint;
+}
+```
+
+(d) Extend the deps interface:
+
+```typescript
+export interface RecoverDetachedDeps {
+  getSession?: () => { deviceId?: string; appId?: string; platform?: string } | null;
+  isFlowActive?: () => boolean;
+  isOptedOut?: () => boolean;
+  relaunchApp?: (udid: string, appId: string) => Promise<void>;
+  stopFastRunner?: () => void;
+  reconnect?: () => Promise<void>;
+  probeAlive?: () => Promise<boolean>;
+  sleep?: (ms: number) => Promise<void>;
+  maxPerSession?: number;
+  /** GH #262: tri-state install probe (true/false/null=unknown). */
+  isAppInstalled?: (udid: string, appId: string) => Promise<boolean | null>;
+  /** GH #262: best-effort reinstallable-snapshot hint. */
+  snapshotHint?: (appId: string) => SnapshotHint | null;
+}
+```
+
+(e) Replace the relaunch try/catch block (currently `let relaunchError ... }` around lines 125–133) with:
+
+```typescript
+  let relaunchError: string | undefined;
+  try {
+    await relaunchApp(udid, appId);
+  } catch (e) {
+    // The terminate step is already swallowed inside defaultRelaunchApp, so a throw
+    // here is a real `simctl launch` failure (bad UDID/bundleId, sim unavailable).
+    // Capture it (Codex F3) so the verdict is actionable, not a bare "still-detached".
+    relaunchError = e instanceof Error ? e.message : String(e);
+    // GH #262: a failed launch is ambiguous — a transient hiccup and a missing
+    // bundle look identical here, but the second makes every retry (and the
+    // "relaunch manually" advice) pointless. Ask simctl for ground truth; on a
+    // CONFIRMED missing bundle, short-circuit — settle/reconnect/liveness below
+    // cannot succeed. Probe verdict null = unknown → fall through (fail open).
+    const isAppInstalled = deps.isAppInstalled ?? probeAppInstalled;
+    if ((await isAppInstalled(udid, appId)) === false) {
+      const hintFor = deps.snapshotHint ?? snapshotHintForBundleId;
+      let snapshotHint: SnapshotHint | null = null;
+      try { snapshotHint = hintFor(appId); } catch { /* hint is best-effort */ }
+      return {
+        recovered: false,
+        reason: 'app-not-installed',
+        attempt,
+        error: relaunchError,
+        udid,
+        appId,
+        ...(snapshotHint ? { snapshotHint } : {}),
+      };
+    }
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass (new + existing)**
+
+Run: `npm run build && node --test test/unit/gh-262-recover-not-installed.test.js test/unit/gh-208-recover-detached.test.js`
+Expected: PASS — all tests in both files
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cdp/recover-detached.ts test/unit/gh-262-recover-not-installed.test.js
+git commit -S -m "feat(#262): recover-detached short-circuits on confirmed app-not-installed"
+```
+
+---
+
+### Task 4: `APP_NOT_INSTALLED` error code + `cdp_status` mapping
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/types.ts` (ToolErrorCode union, ~line 190)
+- Modify: `scripts/cdp-bridge/src/tools/status.ts` (APP_DETACHED catch, before the `detachedHint` chain ~line 331)
+- Test: `scripts/cdp-bridge/test/unit/gh-262-status-not-installed.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/gh-262-status-not-installed.test.js` (harness mirrors `gh-208-status-detached-recovery.test.js` — if envelope field names differ, align assertions with the APP_DETACHED refusal tests in that file):
+
+```js
+// GH #262: when detached-recovery reports 'app-not-installed', cdp_status
+// returns the distinct APP_NOT_INSTALLED code with install advice (incl. a
+// shell-quoted snapshot reinstall line when a hint exists) — instead of the
+// generic APP_DETACHED "relaunch manually / hardReset" advice that can never
+// work for a missing bundle.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createMockClient } from '../helpers/mock-cdp-client.js';
+import { parseEnvelope } from '../helpers/result-helpers.js';
+import { createStatusHandler } from '../../dist/tools/status.js';
+import { AppDetachedError } from '../../dist/cdp/discovery.js';
+import {
+  _setHasSessionForTest,
+  _resetHasSessionForTest,
+} from '../../dist/tools/dev-client-picker.js';
+
+function makeDetachedClient() {
+  return createMockClient({
+    _isConnected: false,
+    _helpersInjected: true,
+    reconnectState: { active: false, lastAttempt: null, attemptCount: 0 },
+    autoConnect: async () => { throw new AppDetachedError(8081); },
+  });
+}
+
+function makeHandler(recovery) {
+  const client = makeDetachedClient();
+  return createStatusHandler(() => client, () => {}, () => client, {
+    recoverDetached: async () => recovery,
+  });
+}
+
+test('cdp_status: app-not-installed → APP_NOT_INSTALLED with quoted snapshot advice', async () => {
+  _setHasSessionForTest(false);
+  try {
+    const handler = makeHandler({
+      recovered: false,
+      reason: 'app-not-installed',
+      attempt: 1,
+      error: 'FBSOpenApplicationServiceErrorDomain, code=4',
+      udid: 'UDID-A',
+      appId: 'com.example.app',
+      snapshotHint: { path: '/tmp/rn-appfile-snapshots/My App.app', ageMinutes: 7 },
+    });
+    const env = parseEnvelope(await handler({}));
+    assert.equal(env.ok, false);
+    assert.equal(env.code, 'APP_NOT_INSTALLED');
+    assert.match(env.error, /com\.example\.app is not installed on simulator UDID-A/);
+    assert.match(env.error, /7 min ago/);
+    assert.match(env.error, /xcrun simctl install 'UDID-A' '\/tmp\/rn-appfile-snapshots\/My App\.app'/);
+    assert.equal(env.meta.recovery.reason, 'app-not-installed');
+  } finally {
+    _resetHasSessionForTest();
+  }
+});
+
+test('cdp_status: app-not-installed without hint → rebuild advice, no install line', async () => {
+  _setHasSessionForTest(false);
+  try {
+    const handler = makeHandler({
+      recovered: false,
+      reason: 'app-not-installed',
+      attempt: 1,
+      udid: 'UDID-A',
+      appId: 'com.example.app',
+    });
+    const env = parseEnvelope(await handler({}));
+    assert.equal(env.code, 'APP_NOT_INSTALLED');
+    assert.match(env.error, /npx expo run:ios/);
+    assert.doesNotMatch(env.error, /simctl install/);
+  } finally {
+    _resetHasSessionForTest();
+  }
+});
+
+test('cdp_status: still-detached keeps the existing APP_DETACHED code (no regression)', async () => {
+  _setHasSessionForTest(false);
+  try {
+    const handler = makeHandler({ recovered: false, reason: 'still-detached', attempt: 1 });
+    const env = parseEnvelope(await handler({}));
+    assert.equal(env.code, 'APP_DETACHED');
+  } finally {
+    _resetHasSessionForTest();
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test test/unit/gh-262-status-not-installed.test.js`
+Expected: FAIL — first two tests get code `APP_DETACHED` instead of `APP_NOT_INSTALLED`
+
+- [ ] **Step 3: Write the implementation**
+
+(a) `src/types.ts` — extend the union directly under the `APP_DETACHED` member:
+
+```typescript
+  | 'APP_DETACHED'              // GH #208 (RC2/RC3): Metro up but 0 Hermes targets (app detached)
+  | 'APP_NOT_INSTALLED'         // GH #262: relaunch failed and get_app_container confirms the bundle is missing
+```
+
+(b) `src/tools/status.ts` — add the import:
+
+```typescript
+import { buildNotInstalledAdvice } from '../cdp/app-installed-probe.js';
+```
+
+(c) `src/tools/status.ts` — inside the `AppDetachedError` branch, immediately BEFORE the `const detachedHint =` chain, insert:
+
+```typescript
+        // GH #262: the bundle is CONFIRMED missing (e.g. simulator erased) —
+        // the generic "relaunch manually / hardReset" hints below can never
+        // work. Return the distinct code with install advice instead.
+        if (recovery.reason === 'app-not-installed') {
+          return failResult(
+            `${message} ${buildNotInstalledAdvice(
+              recovery.udid ?? 'booted',
+              recovery.appId ?? 'the app',
+              recovery.snapshotHint ?? null,
+            )}`,
+            'APP_NOT_INSTALLED',
+            {
+              reconnect: getClient().reconnectState,
+              autoConnect: getClient().autoConnectState,
+              bridge: bridgeEnvState(process.env),
+              recovery,
+            },
+          );
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass (new + existing)**
+
+Run: `npm run build && node --test test/unit/gh-262-status-not-installed.test.js test/unit/gh-208-status-detached-recovery.test.js`
+Expected: PASS — all tests in both files
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types.ts src/tools/status.ts test/unit/gh-262-status-not-installed.test.js
+git commit -S -m "feat(#262): cdp_status maps app-not-installed to APP_NOT_INSTALLED with install advice"
+```
+
+---
+
+### Task 5: `cdp_restart` — app.json bundleId fallback + launch:err classification
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/tools/restart.ts` (deps interface ~line 12, handler header ~line 114, bundleId chain ~lines 125–129, launch catch ~lines 155–162)
+- Test: `scripts/cdp-bridge/test/unit/gh-262-restart-fallback.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/gh-262-restart-fallback.test.js` (mock-client harness copied from `cdp-restart.test.js`):
+
+```js
+// GH #262 (+ #194 BUG 2 residual): hardReset must not silently degrade to a
+// soft reset when the bundleId cache is empty — it now falls back to app.json
+// (resolveBundleId). And a failed `simctl launch` is classified: a CONFIRMED
+// missing bundle yields an APP_NOT_INSTALLED step with install advice instead
+// of a raw OS error.
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createRestartHandler, _resetRestartHandlerStateForTest,
+} from '../../dist/tools/restart.js';
+import { expectOk } from '../helpers/result-helpers.js';
+
+beforeEach(() => {
+  _resetRestartHandlerStateForTest();
+});
+
+function makeMockClient({ port = 8081 } = {}) {
+  let connected = false;
+  return {
+    get metroPort() { return port; },
+    get isConnected() { return connected; },
+    // connectedTarget intentionally undefined: the fresh-process case.
+    disconnect: async () => {},
+    autoConnect: async () => { connected = true; return 'Connected to test'; },
+  };
+}
+
+function harness(deps) {
+  const oldClient = makeMockClient();
+  const newClient = makeMockClient();
+  let current = oldClient;
+  const handler = createRestartHandler(
+    () => current,
+    (c) => { current = c; },
+    () => newClient,
+    deps,
+  );
+  return handler;
+}
+
+test('hardReset: empty cache + no connectedTarget → falls back to resolveBundleId (app.json)', async () => {
+  const simctl = [];
+  const handler = harness({
+    execFile: async (cmd, args) => { simctl.push(args.join(' ')); return { stdout: '', stderr: '' }; },
+    stopFastRunner: () => {},
+    sleep: async () => {},
+    resolveBundleId: (platform) => {
+      assert.equal(platform, 'ios');
+      return 'com.fallback.app';
+    },
+  });
+  const data = expectOk(await handler({ hardReset: true }));
+  assert.ok(simctl.some((c) => c === 'simctl terminate booted com.fallback.app'));
+  assert.ok(simctl.some((c) => c === 'simctl launch booted com.fallback.app'));
+  assert.ok(data.hardResetSteps.includes('simctl launch com.fallback.app:ok'));
+  assert.ok(!data.hardResetSteps.some((s) => s.startsWith('skip-simctl')));
+});
+
+test('hardReset: app.json also unresolvable → existing skip-simctl step (unchanged)', async () => {
+  const handler = harness({
+    execFile: async () => ({ stdout: '', stderr: '' }),
+    stopFastRunner: () => {},
+    sleep: async () => {},
+    resolveBundleId: () => null,
+  });
+  const data = expectOk(await handler({ hardReset: true }));
+  assert.ok(data.hardResetSteps.includes('skip-simctl:no-bundleId-on-connectedTarget-or-cache'));
+});
+
+test('hardReset: launch fails + probe FALSE → APP_NOT_INSTALLED step with quoted advice', async () => {
+  const handler = harness({
+    execFile: async (cmd, args) => {
+      if (args.includes('launch')) throw new Error('FBSOpenApplicationServiceErrorDomain, code=4');
+      return { stdout: '', stderr: '' };
+    },
+    stopFastRunner: () => {},
+    sleep: async () => {},
+    resolveBundleId: () => 'com.fallback.app',
+    probeAppInstalled: async (udid, appId) => {
+      assert.equal(udid, 'booted');
+      assert.equal(appId, 'com.fallback.app');
+      return false;
+    },
+    snapshotHint: () => ({ path: '/tmp/rn-appfile-snapshots/My App.app', ageMinutes: 3 }),
+  });
+  const data = expectOk(await handler({ hardReset: true }));
+  const step = data.hardResetSteps.find((s) => s.includes('APP_NOT_INSTALLED'));
+  assert.ok(step, `expected an APP_NOT_INSTALLED step, got: ${JSON.stringify(data.hardResetSteps)}`);
+  assert.match(step, /com\.fallback\.app is not installed/);
+  assert.match(step, /xcrun simctl install 'booted' '\/tmp\/rn-appfile-snapshots\/My App\.app'/);
+});
+
+test('hardReset: launch fails + probe NULL → raw launch:err step (fail open, unchanged)', async () => {
+  const handler = harness({
+    execFile: async (cmd, args) => {
+      if (args.includes('launch')) throw new Error('some transient failure');
+      return { stdout: '', stderr: '' };
+    },
+    stopFastRunner: () => {},
+    sleep: async () => {},
+    resolveBundleId: () => 'com.fallback.app',
+    probeAppInstalled: async () => null,
+  });
+  const data = expectOk(await handler({ hardReset: true }));
+  assert.ok(data.hardResetSteps.some((s) => s.startsWith('simctl launch:err(') && !s.includes('APP_NOT_INSTALLED')));
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test test/unit/gh-262-restart-fallback.test.js`
+Expected: FAIL — first test finds `skip-simctl:no-bundleId-on-connectedTarget-or-cache` (no fallback yet)
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/tools/restart.ts`:
+
+(a) Add imports:
+
+```typescript
+import { resolveBundleId } from '../project-config.js';
+import { probeAppInstalled, buildNotInstalledAdvice } from '../cdp/app-installed-probe.js';
+import type { SnapshotHint } from '../cdp/app-installed-probe.js';
+import { snapshotHintForBundleId } from './resolve-ios-app-file.js';
+```
+
+(b) Extend `RestartHandlerDeps`:
+
+```typescript
+  /** GH #262 (#194 BUG 2 residual): app.json fallback for the relaunch target. */
+  resolveBundleId?: (platform: string) => string | null;
+  /** GH #262: tri-state install probe for classifying launch failures. */
+  probeAppInstalled?: (udid: string, appId: string) => Promise<boolean | null>;
+  /** GH #262: best-effort reinstallable-snapshot hint. */
+  snapshotHint?: (appId: string) => SnapshotHint | null;
+```
+
+(c) Resolve the deps in the handler header (next to the existing three):
+
+```typescript
+  const resolveBundleIdFn = deps.resolveBundleId ?? resolveBundleId;
+  const probeAppInstalledFn = deps.probeAppInstalled ?? probeAppInstalled;
+  const snapshotHintFn = deps.snapshotHint ?? snapshotHintForBundleId;
+```
+
+(d) Replace the bundleId/platform resolution block (currently `const observedBundleId ... .toLowerCase();`, ~lines 125–130) — `targetPlatform` must now be computed BEFORE `bundleId`:
+
+```typescript
+      const observedBundleId = oldClient.connectedTarget?.description ?? null;
+      if (observedBundleId) lastSeenBundleId = observedBundleId;
+      const targetPlatform = (oldClient.connectedTarget?.platform ?? args.platform ?? 'ios').toLowerCase();
+      // Resolution priority: explicit arg > current connectedTarget > cache >
+      // app.json (GH #262 / #194 BUG 2: a fresh bridge process has no cache —
+      // without the app.json fallback, hardReset silently degraded to a soft
+      // reset exactly when the hard path was needed).
+      const bundleId = args.bundleId ?? observedBundleId ?? lastSeenBundleId ?? resolveBundleIdFn(targetPlatform);
+```
+
+(e) Replace the `simctl launch` catch block (currently pushes `simctl launch:err(...)`, ~lines 155–162):
+
+```typescript
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            // GH #262: distinguish "launch hiccup" from "bundle not installed" —
+            // the latter needs install advice, not the soft-reset retry below.
+            // Probe verdict null = unknown → keep the raw error (fail open).
+            if ((await probeAppInstalledFn('booted', bundleId)) === false) {
+              let hint: SnapshotHint | null = null;
+              try { hint = snapshotHintFn(bundleId); } catch { /* best-effort */ }
+              hardResetSteps.push(
+                `simctl launch:err(APP_NOT_INSTALLED — ${buildNotInstalledAdvice('booted', bundleId, hint)})`,
+              );
+            } else {
+              // Fatal-ish: if launch fails, the soft reset below will likely
+              // fail too. Still continue — caller sees the launch error in
+              // hardResetSteps and the connectError from the autoConnect.
+              hardResetSteps.push(`simctl launch:err(${msg})`);
+            }
+          }
+```
+
+- [ ] **Step 4: Run tests to verify they pass (new + existing)**
+
+Run: `npm run build && node --test test/unit/gh-262-restart-fallback.test.js test/unit/cdp-restart.test.js`
+Expected: PASS — all tests in both files. (If an existing `cdp-restart.test.js` case asserted the old skip-simctl behavior while app.json IS resolvable in the test env, inject `resolveBundleId: () => null` into that case to preserve its intent — the real default reads the project's app.json.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tools/restart.ts test/unit/gh-262-restart-fallback.test.js
+git commit -S -m "feat(#262): hardReset app.json bundleId fallback + APP_NOT_INSTALLED launch classification"
+```
+
+---
+
+### Task 6: Full verification, dist rebuild, changeset
+
+**Files:**
+- Create: `.changeset/gh-262-app-not-installed.md` (repo root)
+- Modify: `scripts/cdp-bridge/dist/**` (tracked build output)
+
+- [ ] **Step 1: Run the full suite**
+
+Run: `cd scripts/cdp-bridge && npm run test:all`
+Expected: ALL PASS (1966 baseline + ~22 new). Zero failures — fix anything red before proceeding.
+
+- [ ] **Step 2: Lint (if configured)**
+
+Run: `npm run lint --if-present`
+Expected: clean (or script absent — fine).
+
+- [ ] **Step 3: Stage rebuilt dist**
+
+`npm run test:all` already ran `tsc`. Stage the tracked outputs:
+
+```bash
+git add dist
+git status --short  # expect: new dist/cdp/app-installed-probe.js + modified dist files only
+```
+
+- [ ] **Step 4: Write the changeset**
+
+Create `.changeset/gh-262-app-not-installed.md` (repo root):
+
+```markdown
+---
+"rn-dev-agent-cdp": patch
+"rn-dev-agent-plugin": patch
+---
+
+Recovery paths now detect "app not installed" and resolve their relaunch target (GH #262, absorbs #194 BUG 2).
+
+- `cdp_status` APP_DETACHED auto-relaunch: when `simctl launch` fails AND `get_app_container` confirms the bundle is missing (allowlist: `NSPOSIXErrorDomain code=2`), the tool returns a distinct `APP_NOT_INSTALLED` code with install advice — including a shell-quoted `simctl install` line for the reinstallable `.app` snapshot from the last clearState (GH #201 dir) when one matches. Ambiguous probe verdicts fail open to the existing `APP_DETACHED` behavior.
+- `cdp_restart hardReset=true`: the bundleId resolution chain gains an app.json fallback (`resolveBundleId`), so a fresh bridge process no longer silently degrades to a soft reset; failed launches are classified the same way in `hardResetSteps`.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .changeset/gh-262-app-not-installed.md dist
+git commit -S -m "chore(#262): rebuilt dist + changeset"
+```
+
+- [ ] **Step 6: Post-implementation gates (per project workflow)**
+
+1. `/multi-review` (Gemini + Codex) on the branch diff; address findings.
+2. Live verification on the booted iOS simulator — the real escape-hatch gate:
+   - Erase a booted sim (`xcrun simctl erase <udid>` while booted requires shutdown first: `xcrun simctl shutdown <udid> && xcrun simctl erase <udid> && xcrun simctl boot <udid>`), start Metro, call `cdp_status platform=ios` → expect `APP_NOT_INSTALLED` with advice (NOT generic APP_DETACHED), in line with the issue's repro.
+   - Confirm no snapshot hint appears if `$TMPDIR/rn-appfile-snapshots` has no matching bundle; populate via a clearState flow and confirm the hint appears with a quoted path.
+3. PR via `superpowers:finishing-a-development-branch`; body cites #262 with `Closes #262` and notes the #194 BUG 2 residual closure.
+
+**No MCP tool-docs regeneration needed:** no tool was added and no input schema changed — only result codes/messages.

--- a/docs/superpowers/plans/2026-06-11-262-app-not-installed-recovery.md
+++ b/docs/superpowers/plans/2026-06-11-262-app-not-installed-recovery.md
@@ -119,8 +119,8 @@ test('buildNotInstalledAdvice: base advice without hint; shell-quoted install li
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cd scripts/cdp-bridge && npm run build 2>/dev/null; node --test test/unit/gh-262-app-installed-probe.test.js`
-Expected: FAIL — `Cannot find module .../dist/cdp/app-installed-probe.js`
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/gh-262-app-installed-probe.test.js`
+Expected: the build PASSES (no source changes yet — if it fails, stop and fix the build first), then the test FAILS with `Cannot find module .../dist/cdp/app-installed-probe.js`
 
 - [ ] **Step 3: Write the implementation**
 
@@ -230,7 +230,8 @@ Create `test/unit/gh-262-find-snapshot.test.js`:
 ```js
 // GH #262: best-effort lookup of a reinstallable .app snapshot in the GH #201
 // bounded dir ($TMPDIR/rn-appfile-snapshots). Budgeted (≤10 candidates, ~3s
-// total) and never throws — the hint must never block or delay an error report.
+// total) and never throws — the hint may add at most the bounded scan budget
+// to an already-failed path and must never FAIL the report it rides on.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
@@ -380,7 +381,10 @@ function defaultMtimeMs(appPath: string): number | null {
 /**
  * GH #262: find a reinstallable .app snapshot for a bundle id in the GH #201
  * snapshot dir. Best-effort under an explicit budget; returns null on any
- * error or budget overrun — the hint never blocks the error report it rides on.
+ * error or budget overrun. Latency contract: the lookup IS awaited on the
+ * already-failed error path, so it may add up to the budget (~3s worst case;
+ * typically a few ms — the dir holds one snapshot per app). It can never
+ * fail or abort the report it rides on.
  */
 export function findSnapshotForBundleId(
   bundleId: string,

--- a/docs/superpowers/specs/2026-06-11-262-app-not-installed-recovery-design.md
+++ b/docs/superpowers/specs/2026-06-11-262-app-not-installed-recovery-design.md
@@ -23,7 +23,7 @@ Theme (shared with the rest of the #262 family): **recovery must resolve the app
 
 ### 1. `cdp/recover-detached.ts`
 
-- New injectable dep `isAppInstalled(udid: string, appId: string): Promise<boolean | null>` — default impl runs `xcrun simctl get_app_container <udid> <appId> app` (timeout ~5 s). Returns `true` when the container resolves; `false` **only on the known app-missing signal** (stderr matching `NSPOSIXErrorDomain` + `code=2` / `No such file or directory` — the signal issue #262 documents); `null` for **every other** failure shape (device-level errors, unrecognized stderr, timeout). Allowlist classification: unknown failures must never be reported as not-installed.
+- New injectable dep `isAppInstalled(udid: string, appId: string): Promise<boolean | null>` — default impl runs `xcrun simctl get_app_container <udid> <appId> app` (timeout ~5 s). Returns `true` when the container resolves; `false` **only on the known app-missing signal** (stderr matching the `NSPOSIXErrorDomain` + `code=2` marker — the signal issue #262 documents; bare `No such file or directory` text is NOT sufficient, it can appear in unrelated failures); `null` for **every other** failure shape (device-level errors, unrecognized stderr, timeout). Allowlist classification: unknown failures must never be reported as not-installed.
 - When `relaunchApp` throws: run the probe. On `false` → **short-circuit** (skip the 1.2 s settle, reconnect, and liveness probe — they cannot succeed) and return:
   - `DetachedReason` union gains `'app-not-installed'`.
   - `DetachedRecoveryResult` gains optional `snapshotHint?: { path: string; ageMinutes: number }`.

--- a/docs/superpowers/specs/2026-06-11-262-app-not-installed-recovery-design.md
+++ b/docs/superpowers/specs/2026-06-11-262-app-not-installed-recovery-design.md
@@ -18,22 +18,26 @@ Theme (shared with the rest of the #262 family): **recovery must resolve the app
 
 - **Scope: detect + advise with snapshot hint** (option B). No auto-reinstall: silently resurrecting a possibly stale build right after a deliberate simulator erase violates the no-surprising-side-effects theme. The advice names the snapshot so the fix is one copy-paste away.
 - **Detection: probe on launch failure** (approach 1). Ground truth (`simctl get_app_container` existence) over error-string parsing; cost lands only on the already-failed path. Preflight probing (every attempt pays ~100–150 ms) and `FBSOpenApplicationServiceErrorDomain code=4` string-matching (brittle across Xcode versions, ambiguous) were rejected.
+- **Multi-LLM plan review amendments (Antigravity + Codex, 2026-06-11):** stderr-only classification (argv-spoof defense); case-insensitive, `code=-2`-proof marker match; mtime-sort before the snapshot cap with deadline-clamped plutil timeouts; tool-layer hint injection (no `cdp → tools` import); in-flight serialization of concurrent recoveries; terminal not-installed cache with re-probe self-heal; strict per-platform bundleId resolver + active-session appId in the restart chain; session-UDID simctl targeting in restart; detached-budget reset on successful hardReset.
 
 ## Design
 
 ### 1. `cdp/recover-detached.ts`
 
-- New injectable dep `isAppInstalled(udid: string, appId: string): Promise<boolean | null>` — default impl runs `xcrun simctl get_app_container <udid> <appId> app` (timeout ~5 s). Returns `true` when the container resolves; `false` **only on the known app-missing signal** (stderr matching the `NSPOSIXErrorDomain` + `code=2` marker — the signal issue #262 documents; bare `No such file or directory` text is NOT sufficient, it can appear in unrelated failures); `null` for **every other** failure shape (device-level errors, unrecognized stderr, timeout). Allowlist classification: unknown failures must never be reported as not-installed.
+- New injectable dep `isAppInstalled(udid: string, appId: string): Promise<boolean | null>` — default impl runs `xcrun simctl get_app_container <udid> <appId> app` (timeout ~5 s). Returns `true` when the container resolves; `false` **only on the known app-missing signal** (stderr matching the `NSPOSIXErrorDomain` + `code=2` marker — verified live as `(domain=NSPOSIXErrorDomain, code=2)`; bare `No such file or directory` text is NOT sufficient, it can appear in unrelated failures); `null` for **every other** failure shape (device-level errors, unrecognized stderr, no stderr, timeout). Allowlist classification: unknown failures must never be reported as not-installed. Classification reads **simctl stderr only** — never `Error.message`, which embeds the command argv (a crafted bundleId containing the marker text must not be able to force a false "not installed"). The marker match is case-insensitive and separator-flexible, but `code=-2` / `code=20` never match.
 - When `relaunchApp` throws: run the probe. On `false` → **short-circuit** (skip the 1.2 s settle, reconnect, and liveness probe — they cannot succeed) and return:
   - `DetachedReason` union gains `'app-not-installed'`.
   - `DetachedRecoveryResult` gains optional `snapshotHint?: { path: string; ageMinutes: number }`.
   - The original launch error stays in `error`.
 - On `true`/`null` → existing behavior unchanged (`still-detached` + raw error). **Fail open: never claim not-installed without proof.**
-- Budget: the attempt that discovers not-installed counts (its side effects happened). No change to reset semantics.
+- Budget: the attempt that discovers not-installed counts (its side effects happened).
+- **Layering (review consensus):** `deps.snapshotHint` has **no default** inside `cdp/` — the implementation lives in the tools layer and `cdp/` must not import from `tools/`; `status.ts` and `restart.ts` inject it.
+- **Serialization (review):** concurrent `recoverDetached` calls share one in-flight attempt (module-scoped promise) — agent workflows fire `cdp_status` in bursts, and unserialized recoveries would race `simctl terminate/launch` and burn the budget.
+- **Terminal cache (review):** a confirmed missing bundle is cached per `(udid, appId)`; subsequent recoveries re-probe cheaply (~100 ms) and, while still missing, return `app-not-installed` without side effects or budget burn — so the true diagnosis is never masked by `budget-exhausted`. A `true`/`null` re-probe clears the cache and recovery proceeds (a user reinstall self-heals). Cache clears with the budget reset.
 
 ### 2. `tools/resolve-ios-app-file.ts` — `findSnapshotForBundleId(bundleId)`
 
-Scans `$TMPDIR/rn-appfile-snapshots/*.app` (the GH #201 bounded snapshot dir this file owns), matches `CFBundleIdentifier` via `plutil -extract CFBundleIdentifier raw <app>/Info.plist`, returns the newest match as `{ path, mtimeMs }` or `null`. Best-effort with an explicit budget: ≤ 10 candidates scanned, ~2 s timeout per `plutil` read, ~3 s total; any error or budget overrun → `null`. **Latency contract:** the lookup is awaited on the (already-failed) error path, so it may add up to the ~3 s budget in the worst case — typically a few ms, since the #201 dir holds one snapshot per app. It can never fail or abort the error report (all errors → no hint). Deps (fs scan, plist read) injectable for tests.
+Scans `$TMPDIR/rn-appfile-snapshots/*.app` (the GH #201 bounded snapshot dir this file owns), matches `CFBundleIdentifier` via `plutil -extract CFBundleIdentifier raw <app>/Info.plist`, returns the newest match as `{ path, mtimeMs }` or `null`. **Candidates are mtime-sorted newest-first BEFORE the cap** (review consensus: readdir order is arbitrary — capping first could drop the newest match), so the first plutil match is the newest. Best-effort with an explicit budget: ≤ 10 candidates plutil-read, per-read timeout clamped to the remaining deadline (≤ 2 s each, ~3 s total); any error or budget overrun → `null`. **Latency contract:** the lookup is awaited on the (already-failed) error path, so it may add up to the ~3 s budget in the worst case — typically a few ms, since the #201 dir holds one snapshot per app. It can never fail or abort the error report (all errors → no hint). Deps (fs scan, plist read) injectable for tests.
 
 ### 3. `tools/status.ts` — mapping
 
@@ -44,10 +48,12 @@ Scans `$TMPDIR/rn-appfile-snapshots/*.app` (the GH #201 bounded snapshot dir thi
 
 The embedded `udid` and snapshot `path` are **shell-quoted** (single-quoted with internal `'` escaped) before interpolation — `.app` names can contain spaces/metacharacters, and the advice is designed to be copy-pasted into a shell.
 
-### 4. `tools/restart.ts` — two touches
+### 4. `tools/restart.ts` — strict chain, session targeting, classification
 
-- Resolution chain gains a final fallback: `args.bundleId ?? observedBundleId ?? lastSeenBundleId ?? resolveBundleId(targetPlatform)` (`project-config.ts:42`, app.json). Closes #194 BUG 2 with no disk persistence.
-- On `simctl launch` failure inside hardReset: same `isAppInstalled` probe; on `false` the step string becomes `simctl launch:err(APP_NOT_INSTALLED — app not installed on simulator; rebuild or simctl install <snapshot>)`.
+- Resolution chain (closes #194 BUG 2 with no disk persistence): `args.bundleId ?? connectedTarget ?? lastSeenBundleId ?? active-session appId (platform-matched) ?? resolveBundleIdStrict(targetPlatform)`. **Strict** per-platform resolver (new in `project-config.ts`, no iOS←Android fallback — `resolveBundleId('ios')` falls back to the Android package, which fed to iOS simctl would produce a confidently wrong `APP_NOT_INSTALLED`).
+- simctl terminate/launch/probe/advice target the **active session's UDID** when one exists (`'booted'` is ambiguous with multiple booted sims); `'booted'` otherwise.
+- On `simctl launch` failure inside hardReset: same `isAppInstalled` probe; on `false` the step string becomes `simctl launch:err(APP_NOT_INSTALLED — <advice>)`.
+- A **successful** hardReset (relaunch + reconnect) resets the detached-recovery budget — a working manual recovery must not leave auto-recovery reporting `budget-exhausted`.
 
 ### 5. `types.ts`
 
@@ -69,9 +75,10 @@ Add `APP_NOT_INSTALLED` to the tool error-code union.
 - **status.ts:** `'app-not-installed'` → `APP_NOT_INSTALLED` code; advice includes `simctl install` line iff hint present.
 - **restart.ts:** chain falls back to `resolveBundleId()` when connectedTarget+cache are empty (the #194 BUG 2 repro); `launch:err` step classified on probe `false`.
 
-## Out of scope
+## Out of scope / accepted residual risks
 
 - Android — `recoverDetached` is iOS-only by design (GH #208 review).
 - Auto-reinstall from snapshot (rejected option C).
 - Persisting `lastSeenBundleId` to disk — the app.json fallback makes it unnecessary.
 - `device_*` open-path not-installed detection — different surface, file separately if observed.
+- **Snapshot-advice TOCTOU (accepted):** the hinted `.app` path can be replaced between hint generation and the user pasting the install command. The replacement is almost always the same app's newer build (the #201 dir keys snapshots by app basename and replaces in place) — benign. A cross-project basename collision installing the wrong app is rare, non-destructive to other apps, and recoverable; the "may be stale" caveat plus the named bundle id in the advice are the mitigation. Engineering immutability here would unbound the #201 dir.

--- a/docs/superpowers/specs/2026-06-11-262-app-not-installed-recovery-design.md
+++ b/docs/superpowers/specs/2026-06-11-262-app-not-installed-recovery-design.md
@@ -33,7 +33,7 @@ Theme (shared with the rest of the #262 family): **recovery must resolve the app
 
 ### 2. `tools/resolve-ios-app-file.ts` — `findSnapshotForBundleId(bundleId)`
 
-Scans `$TMPDIR/rn-appfile-snapshots/*.app` (the GH #201 bounded snapshot dir this file owns), matches `CFBundleIdentifier` via `plutil -extract CFBundleIdentifier raw <app>/Info.plist`, returns the newest match as `{ path, mtimeMs }` or `null`. Best-effort with an explicit budget: ≤ 10 candidates scanned, ~2 s timeout per `plutil` read, ~3 s total; any error or budget overrun → `null`. The hint never blocks or delays the error report. Deps (fs scan, plist read) injectable for tests.
+Scans `$TMPDIR/rn-appfile-snapshots/*.app` (the GH #201 bounded snapshot dir this file owns), matches `CFBundleIdentifier` via `plutil -extract CFBundleIdentifier raw <app>/Info.plist`, returns the newest match as `{ path, mtimeMs }` or `null`. Best-effort with an explicit budget: ≤ 10 candidates scanned, ~2 s timeout per `plutil` read, ~3 s total; any error or budget overrun → `null`. **Latency contract:** the lookup is awaited on the (already-failed) error path, so it may add up to the ~3 s budget in the worst case — typically a few ms, since the #201 dir holds one snapshot per app. It can never fail or abort the error report (all errors → no hint). Deps (fs scan, plist read) injectable for tests.
 
 ### 3. `tools/status.ts` — mapping
 

--- a/docs/superpowers/specs/2026-06-11-262-app-not-installed-recovery-design.md
+++ b/docs/superpowers/specs/2026-06-11-262-app-not-installed-recovery-design.md
@@ -1,0 +1,77 @@
+# GH #262 — APP_NOT_INSTALLED detection in recovery paths + bundleId fallback (design)
+
+**Issue:** [#262](https://github.com/Lykhoyda/rn-dev-agent/issues/262) — `cdp_status` APP_DETACHED recovery doesn't detect "app not installed"
+**Absorbed residual:** #194 BUG 2 — `cdp_restart hardReset=true` loses its bundleId when the bridge process is fresh
+**Kano class:** must-be (diagnostic truthfulness) · effort: s
+**Date:** 2026-06-11 · **Status:** approved
+
+## Problem
+
+Two recovery paths give advice that cannot work:
+
+1. **APP_DETACHED auto-relaunch** (`cdp/recover-detached.ts`, GH #208/RC3): when the app bundle is not installed at all (e.g. the user erased the simulator), `simctl launch` fails with the raw `FBSOpenApplicationServiceErrorDomain code=4` error and the tool tells the agent to "relaunch manually or call cdp_restart(hardReset=true)" — advice that can never succeed. The agent burns recovery attempts and has to discover not-installed via a manual `get_app_container` probe.
+2. **hardReset bundleId resolution** (`tools/restart.ts:128`): the chain is `explicit arg > connectedTarget > in-memory lastSeenBundleId`. A fresh bridge process (or a #264 supervisor worker respawn) has no cache, so hardReset silently degrades to a soft reset (`skip-simctl:no-bundleId-on-connectedTarget-or-cache`) exactly when the hard path is needed.
+
+Theme (shared with the rest of the #262 family): **recovery must resolve the app's identity and report its true install state** — never loop on advice that cannot work.
+
+## Decisions
+
+- **Scope: detect + advise with snapshot hint** (option B). No auto-reinstall: silently resurrecting a possibly stale build right after a deliberate simulator erase violates the no-surprising-side-effects theme. The advice names the snapshot so the fix is one copy-paste away.
+- **Detection: probe on launch failure** (approach 1). Ground truth (`simctl get_app_container` existence) over error-string parsing; cost lands only on the already-failed path. Preflight probing (every attempt pays ~100–150 ms) and `FBSOpenApplicationServiceErrorDomain code=4` string-matching (brittle across Xcode versions, ambiguous) were rejected.
+
+## Design
+
+### 1. `cdp/recover-detached.ts`
+
+- New injectable dep `isAppInstalled(udid: string, appId: string): Promise<boolean | null>` — default impl runs `xcrun simctl get_app_container <udid> <appId> app` (timeout ~5 s). Returns `true` when the container resolves; `false` **only on the known app-missing signal** (stderr matching `NSPOSIXErrorDomain` + `code=2` / `No such file or directory` — the signal issue #262 documents); `null` for **every other** failure shape (device-level errors, unrecognized stderr, timeout). Allowlist classification: unknown failures must never be reported as not-installed.
+- When `relaunchApp` throws: run the probe. On `false` → **short-circuit** (skip the 1.2 s settle, reconnect, and liveness probe — they cannot succeed) and return:
+  - `DetachedReason` union gains `'app-not-installed'`.
+  - `DetachedRecoveryResult` gains optional `snapshotHint?: { path: string; ageMinutes: number }`.
+  - The original launch error stays in `error`.
+- On `true`/`null` → existing behavior unchanged (`still-detached` + raw error). **Fail open: never claim not-installed without proof.**
+- Budget: the attempt that discovers not-installed counts (its side effects happened). No change to reset semantics.
+
+### 2. `tools/resolve-ios-app-file.ts` — `findSnapshotForBundleId(bundleId)`
+
+Scans `$TMPDIR/rn-appfile-snapshots/*.app` (the GH #201 bounded snapshot dir this file owns), matches `CFBundleIdentifier` via `plutil -extract CFBundleIdentifier raw <app>/Info.plist`, returns the newest match as `{ path, mtimeMs }` or `null`. Best-effort with an explicit budget: ≤ 10 candidates scanned, ~2 s timeout per `plutil` read, ~3 s total; any error or budget overrun → `null`. The hint never blocks or delays the error report. Deps (fs scan, plist read) injectable for tests.
+
+### 3. `tools/status.ts` — mapping
+
+`recovery.reason === 'app-not-installed'` → `failResult` with new code `APP_NOT_INSTALLED`:
+
+> App `<bundleId>` is not installed on simulator `<udid>` — rebuild and install (`npx expo run:ios` / `pnpm ios`).
+> *(when hint present)* Or reinstall the snapshot taken at the last clearState, N min ago (may be stale): `xcrun simctl install <udid> '<path>'`.
+
+The embedded `udid` and snapshot `path` are **shell-quoted** (single-quoted with internal `'` escaped) before interpolation — `.app` names can contain spaces/metacharacters, and the advice is designed to be copy-pasted into a shell.
+
+### 4. `tools/restart.ts` — two touches
+
+- Resolution chain gains a final fallback: `args.bundleId ?? observedBundleId ?? lastSeenBundleId ?? resolveBundleId(targetPlatform)` (`project-config.ts:42`, app.json). Closes #194 BUG 2 with no disk persistence.
+- On `simctl launch` failure inside hardReset: same `isAppInstalled` probe; on `false` the step string becomes `simctl launch:err(APP_NOT_INSTALLED — app not installed on simulator; rebuild or simctl install <snapshot>)`.
+
+### 5. `types.ts`
+
+Add `APP_NOT_INSTALLED` to the tool error-code union.
+
+## Error handling
+
+| Situation | Behavior |
+|---|---|
+| Probe says container exists | `still-detached` + raw launch error (unchanged) |
+| Probe fails with device-level stderr / times out | `still-detached` + raw launch error (**fail open**) |
+| Probe says app missing | `app-not-installed`, short-circuit, snapshot hint best-effort |
+| Snapshot lookup errors | Hint omitted; error report unaffected |
+
+## Testing (TDD, existing injectable-deps pattern)
+
+- **recover-detached:** launch fails + probe `false` → `'app-not-installed'`, reconnect/liveness skipped, hint attached when finder matches; probe `null`/`true` → `'still-detached'` fail-open; budget consumption unchanged.
+- **findSnapshotForBundleId:** match, no match, unreadable/missing Info.plist, multiple snapshots → newest wins.
+- **status.ts:** `'app-not-installed'` → `APP_NOT_INSTALLED` code; advice includes `simctl install` line iff hint present.
+- **restart.ts:** chain falls back to `resolveBundleId()` when connectedTarget+cache are empty (the #194 BUG 2 repro); `launch:err` step classified on probe `false`.
+
+## Out of scope
+
+- Android — `recoverDetached` is iOS-only by design (GH #208 review).
+- Auto-reinstall from snapshot (rejected option C).
+- Persisting `lastSeenBundleId` to disk — the app.json fallback makes it unnecessary.
+- `device_*` open-path not-installed detection — different surface, file separately if observed.

--- a/scripts/cdp-bridge/dist/cdp/app-installed-probe.js
+++ b/scripts/cdp-bridge/dist/cdp/app-installed-probe.js
@@ -1,0 +1,54 @@
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+const execFile = promisify(execFileCb);
+const DEVICE_ERROR = /Invalid device|No devices/i;
+// Allowlist: `false` requires the documented app-missing signal — verified
+// live as "(domain=NSPOSIXErrorDomain, code=2)". Case-insensitive and
+// distance-independent (Xcode formatting may drift), but `2\b` after an
+// optional '='/':'/space separator so `code=-2` / `code=20` never match.
+function isAppMissingSignal(stderr) {
+    return /nsposixerrordomain/i.test(stderr) && /\bcode\s*[=:]?\s*2\b/i.test(stderr);
+}
+/**
+ * GH #262: ground-truth "is this bundle installed?" probe.
+ * true = container resolves; false = confirmed missing; null = unknown
+ * (device error / unrecognized failure / no stderr / timeout) — callers must
+ * treat null exactly like "installed" (fail open).
+ *
+ * Classifies ONLY simctl's own stderr — never Error.message, which embeds the
+ * command argv: a crafted bundleId containing the marker text must not be
+ * able to force a false "not installed".
+ */
+export async function probeAppInstalled(udid, appId, exec = execFile) {
+    try {
+        await exec('xcrun', ['simctl', 'get_app_container', udid, appId, 'app'], { timeout: 5000 });
+        return true;
+    }
+    catch (e) {
+        const stderr = e.stderr ?? '';
+        if (!stderr)
+            return null;
+        if (DEVICE_ERROR.test(stderr))
+            return null;
+        if (isAppMissingSignal(stderr))
+            return false;
+        return null;
+    }
+}
+/**
+ * POSIX single-quote (same pattern as device-deeplink.ts / device-interact.ts).
+ * The advice built below is designed to be copy-pasted into a shell, and .app
+ * names can contain spaces/metacharacters.
+ */
+export function posixSingleQuote(s) {
+    return `'${s.replace(/'/g, "'\\''")}'`;
+}
+export function buildNotInstalledAdvice(udid, appId, hint) {
+    const base = `App ${appId} is not installed on simulator ${udid} — rebuild and install ` +
+        '(npx expo run:ios / pnpm ios).';
+    if (!hint)
+        return base;
+    return (`${base} Or reinstall the snapshot taken at the last clearState, ` +
+        `${hint.ageMinutes} min ago (may be stale): ` +
+        `xcrun simctl install ${posixSingleQuote(udid)} ${posixSingleQuote(hint.path)}`);
+}

--- a/scripts/cdp-bridge/dist/cdp/recover-detached.js
+++ b/scripts/cdp-bridge/dist/cdp/recover-detached.js
@@ -4,12 +4,24 @@ import { getActiveSession } from '../agent-device-wrapper.js';
 import { stopFastRunner as defaultStopFastRunner } from '../runners/rn-fast-runner-client.js';
 import { arbiter } from '../lifecycle/device-arbiter.js';
 import { probeFreshness } from './recovery.js';
+import { probeAppInstalled } from './app-installed-probe.js';
 const execFile = promisify(execFileCb);
 const DEFAULT_MAX_PER_SESSION = 3;
 const RELAUNCH_SETTLE_MS = 1200;
 let attempts = 0;
+/** GH #262: a CONFIRMED missing bundle, cached so follow-up recoveries
+ * short-circuit (no pointless terminate/launch, no budget burn) until a
+ * cheap re-probe sees it reinstalled. */
+let confirmedNotInstalled = null;
+/** GH #262: serialize concurrent recoveries — agent workflows fire cdp_status
+ * in bursts; followers share the leader's verdict instead of racing their own
+ * simctl terminate/launch and burning the consecutive-attempt budget. */
+let inflight = null;
 /** Reset the per-session recovery budget (on device_snapshot open AND on a successful recovery). */
-export function resetDetachedRecoveryCounter() { attempts = 0; }
+export function resetDetachedRecoveryCounter() {
+    attempts = 0;
+    confirmedNotInstalled = null;
+}
 /**
  * GH #208 (RC3): cold-restart the target app on the booted simulator — terminate
  * THEN launch. Unlike recover-wedge's bare `simctl launch` (which re-foregrounds
@@ -45,6 +57,19 @@ export async function defaultRelaunchApp(udid, appId, exec = execFile) {
  * who'd rather recover manually.
  */
 export async function recoverDetached(client, deps = {}) {
+    // Followers inherit the leader's deps and verdict by design — all real
+    // callers pass equivalent deps, and a shared verdict is the point.
+    if (inflight)
+        return inflight;
+    inflight = recoverDetachedInner(client, deps);
+    try {
+        return await inflight;
+    }
+    finally {
+        inflight = null;
+    }
+}
+async function recoverDetachedInner(client, deps = {}) {
     const max = deps.maxPerSession ?? DEFAULT_MAX_PER_SESSION;
     const isFlowActive = deps.isFlowActive ?? (() => arbiter.snapshot.flowLeaseHeldBy !== null);
     const isOptedOut = deps.isOptedOut ?? (() => process.env.RN_AUTO_RELAUNCH_ON_DETACH === '0');
@@ -62,14 +87,43 @@ export async function recoverDetached(client, deps = {}) {
     if ((session.platform ?? 'ios') !== 'ios') {
         return { recovered: false, reason: 'unsupported-platform', attempt: attempts };
     }
+    const udid = session.deviceId;
+    const appId = session.appId;
+    const isAppInstalled = deps.isAppInstalled ?? probeAppInstalled;
+    const buildHint = () => {
+        if (!deps.snapshotHint)
+            return undefined;
+        try {
+            return deps.snapshotHint(appId) ?? undefined;
+        }
+        catch {
+            return undefined;
+        }
+    };
+    // GH #262: a previously CONFIRMED missing bundle short-circuits the whole
+    // attempt — but a cheap re-probe first, so a user reinstall self-heals.
+    if (confirmedNotInstalled
+        && confirmedNotInstalled.udid === udid
+        && confirmedNotInstalled.appId === appId) {
+        if ((await isAppInstalled(udid, appId)) === false) {
+            const snapshotHint = buildHint();
+            return {
+                recovered: false,
+                reason: 'app-not-installed',
+                attempt: attempts,
+                udid,
+                appId,
+                ...(snapshotHint ? { snapshotHint } : {}),
+            };
+        }
+        confirmedNotInstalled = null;
+    }
     if (attempts >= max) {
         return { recovered: false, reason: 'budget-exhausted', attempt: attempts };
     }
     // A real, side-effecting attempt.
     attempts += 1;
     const attempt = attempts;
-    const udid = session.deviceId;
-    const appId = session.appId;
     const stopFastRunner = deps.stopFastRunner ?? defaultStopFastRunner;
     const relaunchApp = deps.relaunchApp ?? defaultRelaunchApp;
     const reconnect = deps.reconnect ?? (() => client.softReconnect());
@@ -85,6 +139,24 @@ export async function recoverDetached(client, deps = {}) {
         // here is a real `simctl launch` failure (bad UDID/bundleId, sim unavailable).
         // Capture it (Codex F3) so the verdict is actionable, not a bare "still-detached".
         relaunchError = e instanceof Error ? e.message : String(e);
+        // GH #262: a failed launch is ambiguous — a transient hiccup and a missing
+        // bundle look identical here, but the second makes every retry (and the
+        // "relaunch manually" advice) pointless. Ask simctl for ground truth; on a
+        // CONFIRMED missing bundle, short-circuit — settle/reconnect/liveness below
+        // cannot succeed. Probe verdict null = unknown → fall through (fail open).
+        if ((await isAppInstalled(udid, appId)) === false) {
+            confirmedNotInstalled = { udid, appId };
+            const snapshotHint = buildHint();
+            return {
+                recovered: false,
+                reason: 'app-not-installed',
+                attempt,
+                error: relaunchError,
+                udid,
+                appId,
+                ...(snapshotHint ? { snapshotHint } : {}),
+            };
+        }
     }
     await sleep(RELAUNCH_SETTLE_MS);
     try {

--- a/scripts/cdp-bridge/dist/cdp/recover-detached.js
+++ b/scripts/cdp-bridge/dist/cdp/recover-detached.js
@@ -119,6 +119,20 @@ async function recoverDetachedInner(client, deps = {}) {
         confirmedNotInstalled = null;
     }
     if (attempts >= max) {
+        // GH #262 (PR #280 review): an exhausted budget must not mask a freshly
+        // missing bundle — probe (side-effect-free) before reporting exhaustion.
+        if ((await isAppInstalled(udid, appId)) === false) {
+            confirmedNotInstalled = { udid, appId };
+            const snapshotHint = buildHint();
+            return {
+                recovered: false,
+                reason: 'app-not-installed',
+                attempt: attempts,
+                udid,
+                appId,
+                ...(snapshotHint ? { snapshotHint } : {}),
+            };
+        }
         return { recovered: false, reason: 'budget-exhausted', attempt: attempts };
     }
     // A real, side-effecting attempt.

--- a/scripts/cdp-bridge/dist/cdp/recover-detached.js
+++ b/scripts/cdp-bridge/dist/cdp/recover-detached.js
@@ -113,7 +113,8 @@ async function recoverDetachedInner(client, deps = {}) {
     if (confirmedNotInstalled
         && confirmedNotInstalled.udid === udid
         && confirmedNotInstalled.appId === appId) {
-        if ((await isAppInstalled(udid, appId)) === false) {
+        const verdict = await isAppInstalled(udid, appId);
+        if (verdict === false) {
             const snapshotHint = buildHint();
             return {
                 recovered: false,
@@ -123,6 +124,12 @@ async function recoverDetachedInner(client, deps = {}) {
                 appId,
                 ...(snapshotHint ? { snapshotHint } : {}),
             };
+        }
+        if (verdict === true) {
+            // GH #262 (PR #280 review): a confirmed reinstall invalidates the
+            // consecutive-failure budget along with the cached diagnosis —
+            // otherwise recovery stays budget-exhausted against a healthy app.
+            attempts = 0;
         }
         confirmedNotInstalled = null;
     }

--- a/scripts/cdp-bridge/dist/cdp/recover-detached.js
+++ b/scripts/cdp-bridge/dist/cdp/recover-detached.js
@@ -5,9 +5,12 @@ import { stopFastRunner as defaultStopFastRunner } from '../runners/rn-fast-runn
 import { arbiter } from '../lifecycle/device-arbiter.js';
 import { probeFreshness } from './recovery.js';
 import { probeAppInstalled } from './app-installed-probe.js';
+import { isValidBundleId } from '../domain/maestro-validator.js';
 const execFile = promisify(execFileCb);
 const DEFAULT_MAX_PER_SESSION = 3;
 const RELAUNCH_SETTLE_MS = 1200;
+/** Strict iOS simulator UDID shape (matches `xcrun simctl list` output). */
+const SIMULATOR_UDID_RE = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
 let attempts = 0;
 /** GH #262: a CONFIRMED missing bundle, cached so follow-up recoveries
  * short-circuit (no pointless terminate/launch, no budget burn) until a
@@ -89,6 +92,11 @@ async function recoverDetachedInner(client, deps = {}) {
     }
     const udid = session.deviceId;
     const appId = session.appId;
+    // GH #262 (codex-pair): session values come from a file on disk — validate
+    // before they reach simctl argv. An unusable session is the same as none.
+    if (!SIMULATOR_UDID_RE.test(udid) || !isValidBundleId(appId)) {
+        return { recovered: false, reason: 'no-session', attempt: attempts };
+    }
     const isAppInstalled = deps.isAppInstalled ?? probeAppInstalled;
     const buildHint = () => {
         if (!deps.snapshotHint)

--- a/scripts/cdp-bridge/dist/project-config.js
+++ b/scripts/cdp-bridge/dist/project-config.js
@@ -37,6 +37,35 @@ export function resolveBundleId(platform) {
     return readAppId(projectRoot, platform);
 }
 /**
+ * GH #262: strict per-platform app id — NO cross-platform fallback. Used by
+ * recovery paths where a wrong-platform id would produce a confidently wrong
+ * diagnosis (an Android package fed to iOS simctl "is not installed").
+ */
+export function readAppIdStrict(projectRoot, platform) {
+    for (const filename of ['app.json', 'app.config.json']) {
+        const p = join(projectRoot, filename);
+        if (!existsSync(p))
+            continue;
+        try {
+            const raw = JSON.parse(readFileSync(p, 'utf-8'));
+            const expo = (raw.expo ?? raw);
+            if (platform === 'android')
+                return expo?.android?.package ?? null;
+            return expo?.ios?.bundleIdentifier ?? null;
+        }
+        catch {
+            continue;
+        }
+    }
+    return null;
+}
+export function resolveBundleIdStrict(platform) {
+    const projectRoot = findProjectRoot();
+    if (!projectRoot)
+        return null;
+    return readAppIdStrict(projectRoot, platform);
+}
+/**
  * Read the Expo slug from app.json (used for Maestro app ID resolution).
  */
 export function readExpoSlug() {

--- a/scripts/cdp-bridge/dist/tools/resolve-ios-app-file.js
+++ b/scripts/cdp-bridge/dist/tools/resolve-ios-app-file.js
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, cpSync, rmSync, mkdirSync } from 'node:fs';
+import { existsSync, cpSync, rmSync, mkdirSync, readdirSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, basename } from 'node:path';
 /**
@@ -93,6 +93,90 @@ function defaultGetAppContainer(bundleId) {
     try {
         const out = execFileSync('xcrun', ['simctl', 'get_app_container', 'booted', bundleId, 'app'], { encoding: 'utf8', timeout: 5_000 }).trim();
         return out || null;
+    }
+    catch {
+        return null;
+    }
+}
+// Insurance caps: the lookup rides on an already-failed recovery path and
+// must stay bounded — per-read timeouts are clamped to the remaining
+// deadline so one slow plutil cannot blow the total budget.
+const SNAPSHOT_SCAN_CAP = 10;
+const SNAPSHOT_SCAN_BUDGET_MS = 3000;
+const PLUTIL_TIMEOUT_MS = 2000;
+function defaultListSnapshots() {
+    const dir = join(tmpdir(), 'rn-appfile-snapshots');
+    try {
+        return readdirSync(dir)
+            .filter((name) => name.endsWith('.app'))
+            .map((name) => join(dir, name));
+    }
+    catch {
+        return [];
+    }
+}
+function defaultReadBundleId(appPath, timeoutMs) {
+    try {
+        const out = execFileSync('plutil', ['-extract', 'CFBundleIdentifier', 'raw', join(appPath, 'Info.plist')], { timeout: timeoutMs, encoding: 'utf8' });
+        return out.trim() || null;
+    }
+    catch {
+        return null;
+    }
+}
+function defaultMtimeMs(appPath) {
+    try {
+        return statSync(appPath).mtimeMs;
+    }
+    catch {
+        return null;
+    }
+}
+/**
+ * GH #262: find a reinstallable .app snapshot for a bundle id in the GH #201
+ * snapshot dir. Stat pass → newest-first sort → cap (readdir order is
+ * arbitrary; capping first could drop the newest match), so plutil only runs
+ * on the newest candidates and the first match is the newest. Bounded and
+ * best-effort: any error or budget overrun returns null — the hint never
+ * fails the report it rides on.
+ */
+export function findSnapshotForBundleId(bundleId, deps = {}) {
+    const listSnapshots = deps.listSnapshots ?? defaultListSnapshots;
+    const readBundleId = deps.readBundleId ?? defaultReadBundleId;
+    const mtimeMs = deps.mtimeMs ?? defaultMtimeMs;
+    const now = deps.now ?? Date.now;
+    try {
+        const deadline = now() + SNAPSHOT_SCAN_BUDGET_MS;
+        const candidates = listSnapshots()
+            .map((path) => ({ path, m: mtimeMs(path) }))
+            .filter((c) => c.m !== null)
+            .sort((a, b) => b.m - a.m)
+            .slice(0, SNAPSHOT_SCAN_CAP);
+        for (const { path, m } of candidates) {
+            const remaining = deadline - now();
+            if (remaining <= 0)
+                return null;
+            if (readBundleId(path, Math.min(PLUTIL_TIMEOUT_MS, remaining)) === bundleId) {
+                return { path, mtimeMs: m };
+            }
+        }
+        return null;
+    }
+    catch {
+        return null;
+    }
+}
+/** GH #262: `findSnapshotForBundleId` formatted as advice input. */
+export function snapshotHintForBundleId(bundleId, deps = {}) {
+    try {
+        const now = deps.now ?? Date.now;
+        const snap = findSnapshotForBundleId(bundleId, deps);
+        if (!snap)
+            return null;
+        return {
+            path: snap.path,
+            ageMinutes: Math.max(0, Math.round((now() - snap.mtimeMs) / 60_000)),
+        };
     }
     catch {
         return null;

--- a/scripts/cdp-bridge/dist/tools/restart.js
+++ b/scripts/cdp-bridge/dist/tools/restart.js
@@ -3,6 +3,11 @@ import { promisify } from 'node:util';
 import { logger } from '../logger.js';
 import { okResult, failResult } from '../utils.js';
 import { stopFastRunner as defaultStopFastRunner } from '../runners/rn-fast-runner-client.js';
+import { resolveBundleIdStrict } from '../project-config.js';
+import { getActiveSession } from '../agent-device-wrapper.js';
+import { probeAppInstalled, buildNotInstalledAdvice } from '../cdp/app-installed-probe.js';
+import { resetDetachedRecoveryCounter } from '../cdp/recover-detached.js';
+import { snapshotHintForBundleId } from './resolve-ios-app-file.js';
 const defaultExecFile = promisify(execFileCb);
 /**
  * Module-scoped last-known bundle id (Codex review finding #1, conf 92).
@@ -61,6 +66,11 @@ export function createRestartHandler(getClient, setClient, createClient, deps = 
     const execFile = deps.execFile ?? defaultExecFile;
     const stopFastRunner = deps.stopFastRunner ?? defaultStopFastRunner;
     const sleep = deps.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+    const resolveBundleIdStrictFn = deps.resolveBundleIdStrict ?? resolveBundleIdStrict;
+    const getSessionFn = deps.getSession ?? getActiveSession;
+    const probeAppInstalledFn = deps.probeAppInstalled ?? probeAppInstalled;
+    const snapshotHintFn = deps.snapshotHint ?? snapshotHintForBundleId;
+    const resetDetachedBudgetFn = deps.resetDetachedBudget ?? resetDetachedRecoveryCounter;
     async function doRestart(args) {
         try {
             logger.info('MCP', `cdp_restart: in-process state reset requested (hardReset=${!!args.hardReset})`);
@@ -71,9 +81,22 @@ export function createRestartHandler(getClient, setClient, createClient, deps = 
             const observedBundleId = oldClient.connectedTarget?.description ?? null;
             if (observedBundleId)
                 lastSeenBundleId = observedBundleId;
-            // Resolution priority: explicit arg > current connectedTarget > cache.
-            const bundleId = args.bundleId ?? observedBundleId ?? lastSeenBundleId;
             const targetPlatform = (oldClient.connectedTarget?.platform ?? args.platform ?? 'ios').toLowerCase();
+            const session = getSessionFn();
+            const sessionMatches = !!session && (session.platform ?? 'ios') === targetPlatform;
+            // Resolution priority (GH #262 / #194 BUG 2): explicit arg > current
+            // connectedTarget > cache > active-session appId > STRICT app.json.
+            // A fresh bridge process has no cache — without the fallbacks, hardReset
+            // silently degraded to a soft reset exactly when the hard path was
+            // needed. STRICT: an Android package must never be fed to iOS simctl.
+            const bundleId = args.bundleId
+                ?? observedBundleId
+                ?? lastSeenBundleId
+                ?? (sessionMatches ? session?.appId ?? null : null)
+                ?? resolveBundleIdStrictFn(targetPlatform);
+            // simctl targets the session's simulator when one is open — 'booted' is
+            // ambiguous with multiple booted sims.
+            const targetUdid = (sessionMatches ? session?.deviceId : undefined) ?? 'booted';
             const hardResetSteps = [];
             if (args.hardReset) {
                 // Step 1: kill the fast-runner xcodebuild process. This is the
@@ -90,7 +113,7 @@ export function createRestartHandler(getClient, setClient, createClient, deps = 
                 // android branch is a follow-up.
                 if (bundleId && targetPlatform === 'ios') {
                     try {
-                        await execFile('xcrun', ['simctl', 'terminate', 'booted', bundleId], { timeout: 5000 });
+                        await execFile('xcrun', ['simctl', 'terminate', targetUdid, bundleId], { timeout: 5000 });
                         hardResetSteps.push(`simctl terminate ${bundleId}:ok`);
                     }
                     catch (err) {
@@ -98,14 +121,28 @@ export function createRestartHandler(getClient, setClient, createClient, deps = 
                         hardResetSteps.push(`simctl terminate:warn(${err instanceof Error ? err.message : err})`);
                     }
                     try {
-                        await execFile('xcrun', ['simctl', 'launch', 'booted', bundleId], { timeout: 8000 });
+                        await execFile('xcrun', ['simctl', 'launch', targetUdid, bundleId], { timeout: 8000 });
                         hardResetSteps.push(`simctl launch ${bundleId}:ok`);
                     }
                     catch (err) {
-                        // Fatal-ish: if launch fails, the soft reset below will likely
-                        // fail too. Still continue — caller sees the launch error in
-                        // hardResetSteps and the connectError from the autoConnect.
-                        hardResetSteps.push(`simctl launch:err(${err instanceof Error ? err.message : err})`);
+                        const msg = err instanceof Error ? err.message : String(err);
+                        // GH #262: distinguish "launch hiccup" from "bundle not installed" —
+                        // the latter needs install advice, not the soft-reset retry below.
+                        // Probe verdict null = unknown → keep the raw error (fail open).
+                        if ((await probeAppInstalledFn(targetUdid, bundleId)) === false) {
+                            let hint = null;
+                            try {
+                                hint = snapshotHintFn(bundleId);
+                            }
+                            catch { /* best-effort */ }
+                            hardResetSteps.push(`simctl launch:err(APP_NOT_INSTALLED — ${buildNotInstalledAdvice(targetUdid, bundleId, hint)})`);
+                        }
+                        else {
+                            // Fatal-ish: if launch fails, the soft reset below will likely
+                            // fail too. Still continue — caller sees the launch error in
+                            // hardResetSteps and the connectError from the autoConnect.
+                            hardResetSteps.push(`simctl launch:err(${msg})`);
+                        }
                     }
                     // Step 4: give Hermes time to re-register on Metro before we try
                     // to connect. Empirically 2-3s is enough on iPhone 16 Pro sim.
@@ -142,6 +179,11 @@ export function createRestartHandler(getClient, setClient, createClient, deps = 
                 connectError = err instanceof Error ? err.message : String(err);
                 logger.warn('MCP', `cdp_restart: autoConnect failed (best-effort): ${connectError}`);
             }
+            // GH #262: a successful manual hard reset is a working recovery — clear
+            // the detached-recovery budget so the auto-recovery path gets a fresh
+            // attempt allowance after the user fixes the wedge by hand.
+            if (args.hardReset && connected)
+                resetDetachedBudgetFn();
             return okResult({
                 restarted: true,
                 connected,

--- a/scripts/cdp-bridge/dist/tools/restart.js
+++ b/scripts/cdp-bridge/dist/tools/restart.js
@@ -22,8 +22,12 @@ const defaultExecFile = promisify(execFileCb);
  *
  * Cache the bundleId at module scope so subsequent calls keep working.
  * Updated every time we observe a non-null `connectedTarget.description`.
+ *
+ * GH #262 multi-review: keyed by platform — a single bridge process can
+ * switch platform between connects, and a cross-platform cache hit would
+ * feed an Android package to iOS simctl (then misreport APP_NOT_INSTALLED).
  */
-let lastSeenBundleId = null;
+const lastSeenBundleIds = new Map();
 /**
  * Module-scoped in-flight guard (Codex review finding #2, conf 82).
  *
@@ -37,11 +41,11 @@ let lastSeenBundleId = null;
  */
 let inflightRestart = null;
 /**
- * Test-only: reset module state between tests. The lastSeenBundleId
+ * Test-only: reset module state between tests. The lastSeenBundleIds
  * cache and inflight guard would otherwise leak across test files.
  */
 export function _resetRestartHandlerStateForTest() {
-    lastSeenBundleId = null;
+    lastSeenBundleIds.clear();
     inflightRestart = null;
 }
 /**
@@ -79,9 +83,9 @@ export function createRestartHandler(getClient, setClient, createClient, deps = 
             // Capture the bundle id BEFORE we disconnect — the connectedTarget
             // is cleared on disconnect, and we need it to issue simctl commands.
             const observedBundleId = oldClient.connectedTarget?.description ?? null;
-            if (observedBundleId)
-                lastSeenBundleId = observedBundleId;
             const targetPlatform = (oldClient.connectedTarget?.platform ?? args.platform ?? 'ios').toLowerCase();
+            if (observedBundleId)
+                lastSeenBundleIds.set(targetPlatform, observedBundleId);
             const session = getSessionFn();
             const sessionMatches = !!session && (session.platform ?? 'ios') === targetPlatform;
             // Resolution priority (GH #262 / #194 BUG 2): explicit arg > current
@@ -91,7 +95,7 @@ export function createRestartHandler(getClient, setClient, createClient, deps = 
             // needed. STRICT: an Android package must never be fed to iOS simctl.
             const bundleId = args.bundleId
                 ?? observedBundleId
-                ?? lastSeenBundleId
+                ?? (lastSeenBundleIds.get(targetPlatform) ?? null)
                 ?? (sessionMatches ? session?.appId ?? null : null)
                 ?? resolveBundleIdStrictFn(targetPlatform);
             // simctl targets the session's simulator when one is open — 'booted' is
@@ -172,8 +176,10 @@ export function createRestartHandler(getClient, setClient, createClient, deps = 
                 // Refresh the cache from the freshly-connected target so a
                 // subsequent recovery cycle keeps a valid bundleId. (Codex #1.)
                 const postConnectBundle = newClient.connectedTarget?.description;
-                if (postConnectBundle)
-                    lastSeenBundleId = postConnectBundle;
+                if (postConnectBundle) {
+                    const postConnectPlatform = (newClient.connectedTarget?.platform ?? args.platform ?? 'ios').toLowerCase();
+                    lastSeenBundleIds.set(postConnectPlatform, postConnectBundle);
+                }
             }
             catch (err) {
                 connectError = err instanceof Error ? err.message : String(err);

--- a/scripts/cdp-bridge/dist/tools/restart.js
+++ b/scripts/cdp-bridge/dist/tools/restart.js
@@ -11,24 +11,33 @@ import { snapshotHintForBundleId } from './resolve-ios-app-file.js';
 import { isValidBundleId } from '../domain/maestro-validator.js';
 const defaultExecFile = promisify(execFileCb);
 /**
- * Module-scoped last-known bundle id (Codex review finding #1, conf 92).
+ * Module-scoped last-known bundle id, keyed by platform (GH #262 / #194 BUG 2).
  *
- * After a first `hardReset=true` call, a NEW CDPClient is set via
- * `setClient(createClient(...))`. Its `connectedTarget` starts as `null`
- * until `autoConnect` succeeds. If `autoConnect` fails (very plausible —
- * Hermes hasn't re-registered on Metro yet within our 3s window), a
- * second `cdp_restart hardReset=true` would read `null` as bundleId and
- * skip the simctl path — degrading to a useless soft reset exactly when
- * the user needs the hard path most.
- *
+ * After a first `hardReset=true` call, a NEW CDPClient is set whose
+ * `connectedTarget` is `null` until `autoConnect` succeeds. If autoConnect
+ * fails (Hermes hasn't re-registered within our window), a second
+ * `hardReset=true` would read `null` as bundleId and degrade to a soft reset.
  * Cache the bundleId at module scope so subsequent calls keep working.
- * Updated every time we observe a non-null `connectedTarget.description`.
  *
- * GH #262 multi-review: keyed by platform — a single bridge process can
- * switch platform between connects, and a cross-platform cache hit would
- * feed an Android package to iOS simctl (then misreport APP_NOT_INSTALLED).
+ * Keyed by platform because a single bridge process can switch platform
+ * between connects, and a cross-platform cache hit would feed an Android
+ * package to iOS simctl (then misreport APP_NOT_INSTALLED).
  */
 const lastSeenBundleIds = new Map();
+/** Strict iOS simulator UDID shape (matches `xcrun simctl list` output). */
+const SIMULATOR_UDID_RE = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
+/**
+ * GH #262: `session.deviceId` is persisted, untrusted state that reaches
+ * `xcrun simctl` argv. Accept only the literal `'booted'` or a strict UDID;
+ * anything else falls back to `'booted'` rather than shelling out with it.
+ */
+function safeSimctlTarget(deviceId) {
+    if (deviceId === 'booted')
+        return 'booted';
+    if (deviceId && SIMULATOR_UDID_RE.test(deviceId))
+        return deviceId;
+    return 'booted';
+}
 /**
  * Module-scoped in-flight guard (Codex review finding #2, conf 82).
  *
@@ -85,36 +94,46 @@ export function createRestartHandler(getClient, setClient, createClient, deps = 
             // is cleared on disconnect, and we need it to issue simctl commands.
             const observedBundleId = oldClient.connectedTarget?.description ?? null;
             const targetPlatform = (oldClient.connectedTarget?.platform ?? args.platform ?? 'ios').toLowerCase();
+            // The cache write must happen on every restart (incl. soft) so a later
+            // hardReset still has a bundleId after autoConnect clears connectedTarget.
             if (observedBundleId)
                 lastSeenBundleIds.set(targetPlatform, observedBundleId);
-            const session = getSessionFn();
-            const sessionMatches = !!session && (session.platform ?? 'ios') === targetPlatform;
-            // Resolution priority (GH #262 / #194 BUG 2): explicit arg > current
-            // connectedTarget > cache > active-session appId > STRICT app.json.
-            // A fresh bridge process has no cache — without the fallbacks, hardReset
-            // silently degraded to a soft reset exactly when the hard path was
-            // needed. STRICT: an Android package must never be fed to iOS simctl.
-            let bundleId = args.bundleId
-                ?? observedBundleId
-                ?? (lastSeenBundleIds.get(targetPlatform) ?? null)
-                ?? (sessionMatches ? session?.appId ?? null : null)
-                ?? resolveBundleIdStrictFn(targetPlatform);
-            // simctl targets the session's simulator when one is open — 'booted' is
-            // ambiguous with multiple booted sims.
-            const targetUdid = (sessionMatches ? session?.deviceId : undefined) ?? 'booted';
             const hardResetSteps = [];
-            // Phase 134.2 precedent (see device-session.ts): never let an
-            // unvalidated string reach `xcrun simctl terminate/launch` argv. An
-            // explicit bad arg fails fast; a bad value resolved from cache/config
-            // is dropped (treated as no-bundleId) rather than shelling out with it.
-            if (bundleId !== null && !isValidBundleId(bundleId)) {
-                if (args.bundleId !== undefined) {
-                    return failResult(`cdp_restart: invalid bundleId argument "${String(args.bundleId).slice(0, 80)}" — expected reverse-DNS app id like com.example.app`, 'INVALID_BUNDLE_ID');
-                }
-                hardResetSteps.push('skip-simctl:invalid-bundleId-from-cache-or-config');
-                bundleId = null;
-            }
+            let bundleId = null;
+            // Session lookup, the bundleId resolution chain, and UDID targeting only
+            // matter for the hardReset simctl path — a soft reset must do zero
+            // session/app.json I/O and must never fail on bundleId state.
             if (args.hardReset) {
+                const session = getSessionFn();
+                const sessionMatches = !!session && (session.platform ?? 'ios') === targetPlatform;
+                // Resolution priority (GH #262 / #194 BUG 2): explicit arg > current
+                // connectedTarget > active-session appId > cache > STRICT app.json.
+                // The open device session is current user intent; the cache is
+                // connect-time state that can be stale after switching apps in the
+                // same bridge process — so the session outranks the cache. A fresh
+                // bridge process has no cache, so without the fallbacks hardReset
+                // silently degraded to a soft reset. STRICT: an Android package must
+                // never be fed to iOS simctl.
+                bundleId = args.bundleId
+                    ?? observedBundleId
+                    ?? (sessionMatches ? session?.appId ?? null : null)
+                    ?? (lastSeenBundleIds.get(targetPlatform) ?? null)
+                    ?? resolveBundleIdStrictFn(targetPlatform);
+                // simctl targets the session's simulator when one is open — 'booted' is
+                // ambiguous with multiple booted sims. deviceId is persisted/untrusted,
+                // so validate before it reaches argv (invalid → 'booted').
+                const targetUdid = safeSimctlTarget(sessionMatches ? session?.deviceId : undefined);
+                // Phase 134.2 precedent (see device-session.ts): never let an
+                // unvalidated string reach `xcrun simctl terminate/launch` argv. An
+                // explicit bad arg fails fast; a bad value resolved from cache/config
+                // is dropped (treated as no-bundleId) rather than shelling out with it.
+                if (bundleId !== null && !isValidBundleId(bundleId)) {
+                    if (args.bundleId !== undefined) {
+                        return failResult(`cdp_restart: invalid bundleId argument "${String(args.bundleId).slice(0, 80)}" — expected reverse-DNS app id like com.example.app`, 'INVALID_BUNDLE_ID');
+                    }
+                    hardResetSteps.push('skip-simctl:invalid-bundleId-from-cache-or-config');
+                    bundleId = null;
+                }
                 // Step 1: kill the fast-runner xcodebuild process. This is the
                 // agent-device XCTest test rig — if it's foreground, iOS treats
                 // the test-app as backgrounded and pauses its JS thread.
@@ -151,7 +170,14 @@ export function createRestartHandler(getClient, setClient, createClient, deps = 
                                 hint = snapshotHintFn(bundleId);
                             }
                             catch { /* best-effort */ }
-                            hardResetSteps.push(`simctl launch:err(APP_NOT_INSTALLED — ${buildNotInstalledAdvice(targetUdid, bundleId, hint)})`);
+                            const advice = buildNotInstalledAdvice(targetUdid, bundleId, hint);
+                            // Record the step BEFORE returning so hardResetSteps in meta stays
+                            // complete, then return a typed failure: a confirmed-missing bundle
+                            // is the primary error, not a buried step the caller has to fish
+                            // out. The soft reset below cannot help — nothing connects to a
+                            // missing app — so we skip it and leave the existing client.
+                            hardResetSteps.push(`simctl launch:err(APP_NOT_INSTALLED — ${advice})`);
+                            return failResult(advice, 'APP_NOT_INSTALLED', { hardResetSteps });
                         }
                         else {
                             // Fatal-ish: if launch fails, the soft reset below will likely

--- a/scripts/cdp-bridge/dist/tools/restart.js
+++ b/scripts/cdp-bridge/dist/tools/restart.js
@@ -8,6 +8,7 @@ import { getActiveSession } from '../agent-device-wrapper.js';
 import { probeAppInstalled, buildNotInstalledAdvice } from '../cdp/app-installed-probe.js';
 import { resetDetachedRecoveryCounter } from '../cdp/recover-detached.js';
 import { snapshotHintForBundleId } from './resolve-ios-app-file.js';
+import { isValidBundleId } from '../domain/maestro-validator.js';
 const defaultExecFile = promisify(execFileCb);
 /**
  * Module-scoped last-known bundle id (Codex review finding #1, conf 92).
@@ -93,7 +94,7 @@ export function createRestartHandler(getClient, setClient, createClient, deps = 
             // A fresh bridge process has no cache — without the fallbacks, hardReset
             // silently degraded to a soft reset exactly when the hard path was
             // needed. STRICT: an Android package must never be fed to iOS simctl.
-            const bundleId = args.bundleId
+            let bundleId = args.bundleId
                 ?? observedBundleId
                 ?? (lastSeenBundleIds.get(targetPlatform) ?? null)
                 ?? (sessionMatches ? session?.appId ?? null : null)
@@ -102,6 +103,17 @@ export function createRestartHandler(getClient, setClient, createClient, deps = 
             // ambiguous with multiple booted sims.
             const targetUdid = (sessionMatches ? session?.deviceId : undefined) ?? 'booted';
             const hardResetSteps = [];
+            // Phase 134.2 precedent (see device-session.ts): never let an
+            // unvalidated string reach `xcrun simctl terminate/launch` argv. An
+            // explicit bad arg fails fast; a bad value resolved from cache/config
+            // is dropped (treated as no-bundleId) rather than shelling out with it.
+            if (bundleId !== null && !isValidBundleId(bundleId)) {
+                if (args.bundleId !== undefined) {
+                    return failResult(`cdp_restart: invalid bundleId argument "${String(args.bundleId).slice(0, 80)}" — expected reverse-DNS app id like com.example.app`, 'INVALID_BUNDLE_ID');
+                }
+                hardResetSteps.push('skip-simctl:invalid-bundleId-from-cache-or-config');
+                bundleId = null;
+            }
             if (args.hardReset) {
                 // Step 1: kill the fast-runner xcodebuild process. This is the
                 // agent-device XCTest test rig — if it's foreground, iOS treats

--- a/scripts/cdp-bridge/dist/tools/status.js
+++ b/scripts/cdp-bridge/dist/tools/status.js
@@ -6,6 +6,8 @@ import { supportsNativeMultiDebugger } from '../cdp/multiplexer.js';
 import { arbiter } from '../lifecycle/device-arbiter.js';
 import { recoverWedge } from '../cdp/recover-wedge.js';
 import { recoverDetached } from '../cdp/recover-detached.js';
+import { buildNotInstalledAdvice } from '../cdp/app-installed-probe.js';
+import { snapshotHintForBundleId } from './resolve-ios-app-file.js';
 import { AppDetachedError } from '../cdp/discovery.js';
 import { getDeviceSessionHealth } from './device-session-health.js';
 import { detectIosExternalRunner } from '../runners/external-runner-detect.js';
@@ -278,7 +280,7 @@ export function createStatusHandler(getClient, setClient, createClient, deps = {
                 const callerPinnedNonIos = !!args.platform && args.platform.toLowerCase() !== 'ios';
                 const recovery = callerPinnedNonIos
                     ? { recovered: false, reason: 'unsupported-platform', attempt: 0 }
-                    : await recoverDetachedFn(getClient());
+                    : await recoverDetachedFn(getClient(), { snapshotHint: snapshotHintForBundleId });
                 if (recovery.recovered) {
                     // GH #208 review (Gemini F2): never let a post-reconnect status read throw
                     // out of the catch — degrade to a minimal warn instead of crashing the tool.
@@ -288,6 +290,17 @@ export function createStatusHandler(getClient, setClient, createClient, deps = {
                     catch {
                         return warnResult({ recovered: true }, `App had detached (Metro up, 0 Hermes targets) — auto-relaunched and reconnected (attempt ${recovery.attempt}), but reading the full status failed; retry cdp_status.`);
                     }
+                }
+                // GH #262: the bundle is CONFIRMED missing (e.g. simulator erased) —
+                // the generic "relaunch manually / hardReset" hints below can never
+                // work. Return the distinct code with install advice instead.
+                if (recovery.reason === 'app-not-installed') {
+                    return failResult(`${message} ${buildNotInstalledAdvice(recovery.udid ?? 'booted', recovery.appId ?? 'the app', recovery.snapshotHint ?? null)}`, 'APP_NOT_INSTALLED', {
+                        reconnect: getClient().reconnectState,
+                        autoConnect: getClient().autoConnectState,
+                        bridge: bridgeEnvState(process.env),
+                        recovery,
+                    });
                 }
                 const detachedHint = recovery.reason === 'flow-active'
                     ? 'A Maestro flow is running — skipped auto-relaunch. Wait for the flow to finish, then retry cdp_status.'

--- a/scripts/cdp-bridge/src/cdp/app-installed-probe.ts
+++ b/scripts/cdp-bridge/src/cdp/app-installed-probe.ts
@@ -1,0 +1,79 @@
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCb);
+
+/** GH #262: a reinstallable .app snapshot (from the GH #201 bounded dir). */
+export interface SnapshotHint {
+  path: string;
+  ageMinutes: number;
+}
+
+type Exec = (
+  cmd: string,
+  args: string[],
+  opts?: { timeout?: number },
+) => Promise<{ stdout: string; stderr: string }>;
+
+const DEVICE_ERROR = /Invalid device|No devices/i;
+
+// Allowlist (codex-pair + multi-LLM plan reviews): `false` requires the
+// documented app-missing signal — verified live as
+// "(domain=NSPOSIXErrorDomain, code=2)". Case-insensitive and
+// distance-independent (Xcode formatting may drift), but `2\b` after an
+// optional '='/':'/space separator so `code=-2` / `code=20` never match.
+function isAppMissingSignal(stderr: string): boolean {
+  return /nsposixerrordomain/i.test(stderr) && /\bcode\s*[=:]?\s*2\b/i.test(stderr);
+}
+
+/**
+ * GH #262: ground-truth "is this bundle installed?" probe.
+ * true = container resolves; false = confirmed missing; null = unknown
+ * (device error / unrecognized failure / no stderr / timeout) — callers must
+ * treat null exactly like "installed" (fail open).
+ *
+ * Classifies ONLY simctl's own stderr — never Error.message, which embeds the
+ * command argv: a crafted bundleId containing the marker text must not be
+ * able to force a false "not installed".
+ */
+export async function probeAppInstalled(
+  udid: string,
+  appId: string,
+  exec: Exec = execFile as unknown as Exec,
+): Promise<boolean | null> {
+  try {
+    await exec('xcrun', ['simctl', 'get_app_container', udid, appId, 'app'], { timeout: 5000 });
+    return true;
+  } catch (e) {
+    const stderr = (e as { stderr?: string }).stderr ?? '';
+    if (!stderr) return null;
+    if (DEVICE_ERROR.test(stderr)) return null;
+    if (isAppMissingSignal(stderr)) return false;
+    return null;
+  }
+}
+
+/**
+ * POSIX single-quote (same pattern as device-deeplink.ts / device-interact.ts).
+ * The advice built below is designed to be copy-pasted into a shell, and .app
+ * names can contain spaces/metacharacters.
+ */
+export function posixSingleQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+export function buildNotInstalledAdvice(
+  udid: string,
+  appId: string,
+  hint: SnapshotHint | null,
+): string {
+  const base =
+    `App ${appId} is not installed on simulator ${udid} — rebuild and install ` +
+    '(npx expo run:ios / pnpm ios).';
+  if (!hint) return base;
+  return (
+    `${base} Or reinstall the snapshot taken at the last clearState, ` +
+    `${hint.ageMinutes} min ago (may be stale): ` +
+    `xcrun simctl install ${posixSingleQuote(udid)} ${posixSingleQuote(hint.path)}`
+  );
+}

--- a/scripts/cdp-bridge/src/cdp/app-installed-probe.ts
+++ b/scripts/cdp-bridge/src/cdp/app-installed-probe.ts
@@ -17,9 +17,8 @@ type Exec = (
 
 const DEVICE_ERROR = /Invalid device|No devices/i;
 
-// Allowlist (codex-pair + multi-LLM plan reviews): `false` requires the
-// documented app-missing signal — verified live as
-// "(domain=NSPOSIXErrorDomain, code=2)". Case-insensitive and
+// Allowlist: `false` requires the documented app-missing signal — verified
+// live as "(domain=NSPOSIXErrorDomain, code=2)". Case-insensitive and
 // distance-independent (Xcode formatting may drift), but `2\b` after an
 // optional '='/':'/space separator so `code=-2` / `code=20` never match.
 function isAppMissingSignal(stderr: string): boolean {

--- a/scripts/cdp-bridge/src/cdp/recover-detached.ts
+++ b/scripts/cdp-bridge/src/cdp/recover-detached.ts
@@ -172,7 +172,8 @@ async function recoverDetachedInner(
   if (confirmedNotInstalled
       && confirmedNotInstalled.udid === udid
       && confirmedNotInstalled.appId === appId) {
-    if ((await isAppInstalled(udid, appId)) === false) {
+    const verdict = await isAppInstalled(udid, appId);
+    if (verdict === false) {
       const snapshotHint = buildHint();
       return {
         recovered: false,
@@ -182,6 +183,12 @@ async function recoverDetachedInner(
         appId,
         ...(snapshotHint ? { snapshotHint } : {}),
       };
+    }
+    if (verdict === true) {
+      // GH #262 (PR #280 review): a confirmed reinstall invalidates the
+      // consecutive-failure budget along with the cached diagnosis —
+      // otherwise recovery stays budget-exhausted against a healthy app.
+      attempts = 0;
     }
     confirmedNotInstalled = null;
   }

--- a/scripts/cdp-bridge/src/cdp/recover-detached.ts
+++ b/scripts/cdp-bridge/src/cdp/recover-detached.ts
@@ -7,10 +7,14 @@ import { arbiter } from '../lifecycle/device-arbiter.js';
 import { probeFreshness } from './recovery.js';
 import { probeAppInstalled } from './app-installed-probe.js';
 import type { SnapshotHint } from './app-installed-probe.js';
+import { isValidBundleId } from '../domain/maestro-validator.js';
 
 const execFile = promisify(execFileCb);
 const DEFAULT_MAX_PER_SESSION = 3;
 const RELAUNCH_SETTLE_MS = 1200;
+
+/** Strict iOS simulator UDID shape (matches `xcrun simctl list` output). */
+const SIMULATOR_UDID_RE = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
 
 export type DetachedReason =
   | 'recovered'
@@ -150,6 +154,13 @@ async function recoverDetachedInner(
 
   const udid = session.deviceId;
   const appId = session.appId;
+
+  // GH #262 (codex-pair): session values come from a file on disk — validate
+  // before they reach simctl argv. An unusable session is the same as none.
+  if (!SIMULATOR_UDID_RE.test(udid) || !isValidBundleId(appId)) {
+    return { recovered: false, reason: 'no-session', attempt: attempts };
+  }
+
   const isAppInstalled = deps.isAppInstalled ?? probeAppInstalled;
   const buildHint = (): SnapshotHint | undefined => {
     if (!deps.snapshotHint) return undefined;

--- a/scripts/cdp-bridge/src/cdp/recover-detached.ts
+++ b/scripts/cdp-bridge/src/cdp/recover-detached.ts
@@ -114,6 +114,8 @@ export async function recoverDetached(
   client: CDPClient,
   deps: RecoverDetachedDeps = {},
 ): Promise<DetachedRecoveryResult> {
+  // Followers inherit the leader's deps and verdict by design — all real
+  // callers pass equivalent deps, and a shared verdict is the point.
   if (inflight) return inflight;
   inflight = recoverDetachedInner(client, deps);
   try {

--- a/scripts/cdp-bridge/src/cdp/recover-detached.ts
+++ b/scripts/cdp-bridge/src/cdp/recover-detached.ts
@@ -5,6 +5,8 @@ import { getActiveSession } from '../agent-device-wrapper.js';
 import { stopFastRunner as defaultStopFastRunner } from '../runners/rn-fast-runner-client.js';
 import { arbiter } from '../lifecycle/device-arbiter.js';
 import { probeFreshness } from './recovery.js';
+import { probeAppInstalled } from './app-installed-probe.js';
+import type { SnapshotHint } from './app-installed-probe.js';
 
 const execFile = promisify(execFileCb);
 const DEFAULT_MAX_PER_SESSION = 3;
@@ -13,6 +15,7 @@ const RELAUNCH_SETTLE_MS = 1200;
 export type DetachedReason =
   | 'recovered'
   | 'still-detached'
+  | 'app-not-installed'
   | 'no-session'
   | 'flow-active'
   | 'opted-out'
@@ -25,11 +28,27 @@ export interface DetachedRecoveryResult {
   attempt: number;
   /** GH #208 review (Codex F3): a `simctl launch` failure message, surfaced instead of hidden. */
   error?: string;
+  /** GH #262: set on 'app-not-installed' so the caller can build install advice. */
+  udid?: string;
+  appId?: string;
+  snapshotHint?: SnapshotHint;
 }
 
 let attempts = 0;
+/** GH #262: a CONFIRMED missing bundle, cached so follow-up recoveries
+ * short-circuit (no pointless terminate/launch, no budget burn) until a
+ * cheap re-probe sees it reinstalled. */
+let confirmedNotInstalled: { udid: string; appId: string } | null = null;
+/** GH #262: serialize concurrent recoveries — agent workflows fire cdp_status
+ * in bursts; followers share the leader's verdict instead of racing their own
+ * simctl terminate/launch and burning the consecutive-attempt budget. */
+let inflight: Promise<DetachedRecoveryResult> | null = null;
+
 /** Reset the per-session recovery budget (on device_snapshot open AND on a successful recovery). */
-export function resetDetachedRecoveryCounter(): void { attempts = 0; }
+export function resetDetachedRecoveryCounter(): void {
+  attempts = 0;
+  confirmedNotInstalled = null;
+}
 
 type Exec = (cmd: string, args: string[], opts?: { timeout?: number }) => Promise<{ stdout: string; stderr: string }>;
 
@@ -67,6 +86,14 @@ export interface RecoverDetachedDeps {
   probeAlive?: () => Promise<boolean>;
   sleep?: (ms: number) => Promise<void>;
   maxPerSession?: number;
+  /** GH #262: tri-state install probe (true/false/null=unknown). */
+  isAppInstalled?: (udid: string, appId: string) => Promise<boolean | null>;
+  /**
+   * GH #262: best-effort reinstallable-snapshot hint. NO default — the
+   * implementation lives in the tools layer (resolve-ios-app-file.ts) and
+   * cdp/ must not import from tools/; status.ts/restart.ts inject it.
+   */
+  snapshotHint?: (appId: string) => SnapshotHint | null;
 }
 
 /**
@@ -84,6 +111,19 @@ export interface RecoverDetachedDeps {
  * who'd rather recover manually.
  */
 export async function recoverDetached(
+  client: CDPClient,
+  deps: RecoverDetachedDeps = {},
+): Promise<DetachedRecoveryResult> {
+  if (inflight) return inflight;
+  inflight = recoverDetachedInner(client, deps);
+  try {
+    return await inflight;
+  } finally {
+    inflight = null;
+  }
+}
+
+async function recoverDetachedInner(
   client: CDPClient,
   deps: RecoverDetachedDeps = {},
 ): Promise<DetachedRecoveryResult> {
@@ -105,6 +145,34 @@ export async function recoverDetached(
   if ((session.platform ?? 'ios') !== 'ios') {
     return { recovered: false, reason: 'unsupported-platform', attempt: attempts };
   }
+
+  const udid = session.deviceId;
+  const appId = session.appId;
+  const isAppInstalled = deps.isAppInstalled ?? probeAppInstalled;
+  const buildHint = (): SnapshotHint | undefined => {
+    if (!deps.snapshotHint) return undefined;
+    try { return deps.snapshotHint(appId) ?? undefined; } catch { return undefined; }
+  };
+
+  // GH #262: a previously CONFIRMED missing bundle short-circuits the whole
+  // attempt — but a cheap re-probe first, so a user reinstall self-heals.
+  if (confirmedNotInstalled
+      && confirmedNotInstalled.udid === udid
+      && confirmedNotInstalled.appId === appId) {
+    if ((await isAppInstalled(udid, appId)) === false) {
+      const snapshotHint = buildHint();
+      return {
+        recovered: false,
+        reason: 'app-not-installed',
+        attempt: attempts,
+        udid,
+        appId,
+        ...(snapshotHint ? { snapshotHint } : {}),
+      };
+    }
+    confirmedNotInstalled = null;
+  }
+
   if (attempts >= max) {
     return { recovered: false, reason: 'budget-exhausted', attempt: attempts };
   }
@@ -112,8 +180,6 @@ export async function recoverDetached(
   // A real, side-effecting attempt.
   attempts += 1;
   const attempt = attempts;
-  const udid = session.deviceId;
-  const appId = session.appId;
 
   const stopFastRunner = deps.stopFastRunner ?? defaultStopFastRunner;
   const relaunchApp = deps.relaunchApp ?? defaultRelaunchApp;
@@ -130,6 +196,24 @@ export async function recoverDetached(
     // here is a real `simctl launch` failure (bad UDID/bundleId, sim unavailable).
     // Capture it (Codex F3) so the verdict is actionable, not a bare "still-detached".
     relaunchError = e instanceof Error ? e.message : String(e);
+    // GH #262: a failed launch is ambiguous — a transient hiccup and a missing
+    // bundle look identical here, but the second makes every retry (and the
+    // "relaunch manually" advice) pointless. Ask simctl for ground truth; on a
+    // CONFIRMED missing bundle, short-circuit — settle/reconnect/liveness below
+    // cannot succeed. Probe verdict null = unknown → fall through (fail open).
+    if ((await isAppInstalled(udid, appId)) === false) {
+      confirmedNotInstalled = { udid, appId };
+      const snapshotHint = buildHint();
+      return {
+        recovered: false,
+        reason: 'app-not-installed',
+        attempt,
+        error: relaunchError,
+        udid,
+        appId,
+        ...(snapshotHint ? { snapshotHint } : {}),
+      };
+    }
   }
   await sleep(RELAUNCH_SETTLE_MS);
   try { await reconnect(); } catch { /* best-effort; the liveness probe is the verdict */ }

--- a/scripts/cdp-bridge/src/cdp/recover-detached.ts
+++ b/scripts/cdp-bridge/src/cdp/recover-detached.ts
@@ -176,6 +176,20 @@ async function recoverDetachedInner(
   }
 
   if (attempts >= max) {
+    // GH #262 (PR #280 review): an exhausted budget must not mask a freshly
+    // missing bundle — probe (side-effect-free) before reporting exhaustion.
+    if ((await isAppInstalled(udid, appId)) === false) {
+      confirmedNotInstalled = { udid, appId };
+      const snapshotHint = buildHint();
+      return {
+        recovered: false,
+        reason: 'app-not-installed',
+        attempt: attempts,
+        udid,
+        appId,
+        ...(snapshotHint ? { snapshotHint } : {}),
+      };
+    }
     return { recovered: false, reason: 'budget-exhausted', attempt: attempts };
   }
 

--- a/scripts/cdp-bridge/src/project-config.ts
+++ b/scripts/cdp-bridge/src/project-config.ts
@@ -46,6 +46,33 @@ export function resolveBundleId(platform: string): string | null {
 }
 
 /**
+ * GH #262: strict per-platform app id — NO cross-platform fallback. Used by
+ * recovery paths where a wrong-platform id would produce a confidently wrong
+ * diagnosis (an Android package fed to iOS simctl "is not installed").
+ */
+export function readAppIdStrict(projectRoot: string, platform: string): string | null {
+  for (const filename of ['app.json', 'app.config.json']) {
+    const p = join(projectRoot, filename);
+    if (!existsSync(p)) continue;
+    try {
+      const raw = JSON.parse(readFileSync(p, 'utf-8')) as AppConfig;
+      const expo = (raw.expo ?? raw) as AppConfig['expo'];
+      if (platform === 'android') return expo?.android?.package ?? null;
+      return expo?.ios?.bundleIdentifier ?? null;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+export function resolveBundleIdStrict(platform: string): string | null {
+  const projectRoot = findProjectRoot();
+  if (!projectRoot) return null;
+  return readAppIdStrict(projectRoot, platform);
+}
+
+/**
  * Read the Expo slug from app.json (used for Maestro app ID resolution).
  */
 export function readExpoSlug(): string | null {

--- a/scripts/cdp-bridge/src/tools/resolve-ios-app-file.ts
+++ b/scripts/cdp-bridge/src/tools/resolve-ios-app-file.ts
@@ -136,11 +136,9 @@ export interface FindSnapshotDeps {
   now?: () => number;
 }
 
-// Budget (codex-pair + multi-LLM plan reviews): the hint rides on an
-// ALREADY-FAILED recovery path — it must never add meaningful latency. The
-// dir is bounded by design (one snapshot per app basename), so these are
-// insurance caps. Per-read timeouts are clamped to the remaining deadline so
-// one slow plutil cannot blow the total budget.
+// Insurance caps: the lookup rides on an already-failed recovery path and
+// must stay bounded — per-read timeouts are clamped to the remaining
+// deadline so one slow plutil cannot blow the total budget.
 const SNAPSHOT_SCAN_CAP = 10;
 const SNAPSHOT_SCAN_BUDGET_MS = 3000;
 const PLUTIL_TIMEOUT_MS = 2000;
@@ -179,13 +177,11 @@ function defaultMtimeMs(appPath: string): number | null {
 
 /**
  * GH #262: find a reinstallable .app snapshot for a bundle id in the GH #201
- * snapshot dir. Cheap stat pass first, NEWEST-FIRST sort, THEN the cap —
- * readdir order is arbitrary, so capping before sorting could drop the newest
- * match. plutil (the expensive read) runs only on the capped, ordered list,
- * so the first match is the newest. Latency contract: the lookup IS awaited
- * on the already-failed error path, so it may add up to the budget (~3s worst
- * case; typically a few ms — the dir holds one snapshot per app). It can
- * never fail or abort the report it rides on (all errors → null).
+ * snapshot dir. Stat pass → newest-first sort → cap (readdir order is
+ * arbitrary; capping first could drop the newest match), so plutil only runs
+ * on the newest candidates and the first match is the newest. Bounded and
+ * best-effort: any error or budget overrun returns null — the hint never
+ * fails the report it rides on.
  */
 export function findSnapshotForBundleId(
   bundleId: string,
@@ -195,8 +191,8 @@ export function findSnapshotForBundleId(
   const readBundleId = deps.readBundleId ?? defaultReadBundleId;
   const mtimeMs = deps.mtimeMs ?? defaultMtimeMs;
   const now = deps.now ?? Date.now;
-  const deadline = now() + SNAPSHOT_SCAN_BUDGET_MS;
   try {
+    const deadline = now() + SNAPSHOT_SCAN_BUDGET_MS;
     const candidates = listSnapshots()
       .map((path) => ({ path, m: mtimeMs(path) }))
       .filter((c): c is { path: string; m: number } => c.m !== null)
@@ -220,11 +216,15 @@ export function snapshotHintForBundleId(
   bundleId: string,
   deps: FindSnapshotDeps = {},
 ): SnapshotHint | null {
-  const now = deps.now ?? Date.now;
-  const snap = findSnapshotForBundleId(bundleId, deps);
-  if (!snap) return null;
-  return {
-    path: snap.path,
-    ageMinutes: Math.max(0, Math.round((now() - snap.mtimeMs) / 60_000)),
-  };
+  try {
+    const now = deps.now ?? Date.now;
+    const snap = findSnapshotForBundleId(bundleId, deps);
+    if (!snap) return null;
+    return {
+      path: snap.path,
+      ageMinutes: Math.max(0, Math.round((now() - snap.mtimeMs) / 60_000)),
+    };
+  } catch {
+    return null;
+  }
 }

--- a/scripts/cdp-bridge/src/tools/resolve-ios-app-file.ts
+++ b/scripts/cdp-bridge/src/tools/resolve-ios-app-file.ts
@@ -1,7 +1,8 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, cpSync, rmSync, mkdirSync } from 'node:fs';
+import { existsSync, cpSync, rmSync, mkdirSync, readdirSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, basename } from 'node:path';
+import type { SnapshotHint } from '../cdp/app-installed-probe.js';
 
 /**
  * GH#201: true when the flow clears app state. Two Maestro forms both uninstall
@@ -122,4 +123,108 @@ function defaultGetAppContainer(bundleId: string): string | null {
   } catch {
     return null;
   }
+}
+
+/** GH #262: injectable deps for the snapshot-hint lookup. */
+export interface FindSnapshotDeps {
+  /** Absolute paths of candidate .app dirs in the snapshot dir. */
+  listSnapshots?: () => string[];
+  /** CFBundleIdentifier of a candidate (within timeoutMs), or null if unreadable. */
+  readBundleId?: (appPath: string, timeoutMs: number) => string | null;
+  /** mtime (ms) of a candidate, or null. */
+  mtimeMs?: (appPath: string) => number | null;
+  now?: () => number;
+}
+
+// Budget (codex-pair + multi-LLM plan reviews): the hint rides on an
+// ALREADY-FAILED recovery path — it must never add meaningful latency. The
+// dir is bounded by design (one snapshot per app basename), so these are
+// insurance caps. Per-read timeouts are clamped to the remaining deadline so
+// one slow plutil cannot blow the total budget.
+const SNAPSHOT_SCAN_CAP = 10;
+const SNAPSHOT_SCAN_BUDGET_MS = 3000;
+const PLUTIL_TIMEOUT_MS = 2000;
+
+function defaultListSnapshots(): string[] {
+  const dir = join(tmpdir(), 'rn-appfile-snapshots');
+  try {
+    return readdirSync(dir)
+      .filter((name) => name.endsWith('.app'))
+      .map((name) => join(dir, name));
+  } catch {
+    return [];
+  }
+}
+
+function defaultReadBundleId(appPath: string, timeoutMs: number): string | null {
+  try {
+    const out = execFileSync(
+      'plutil',
+      ['-extract', 'CFBundleIdentifier', 'raw', join(appPath, 'Info.plist')],
+      { timeout: timeoutMs, encoding: 'utf8' },
+    );
+    return out.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultMtimeMs(appPath: string): number | null {
+  try {
+    return statSync(appPath).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * GH #262: find a reinstallable .app snapshot for a bundle id in the GH #201
+ * snapshot dir. Cheap stat pass first, NEWEST-FIRST sort, THEN the cap —
+ * readdir order is arbitrary, so capping before sorting could drop the newest
+ * match. plutil (the expensive read) runs only on the capped, ordered list,
+ * so the first match is the newest. Latency contract: the lookup IS awaited
+ * on the already-failed error path, so it may add up to the budget (~3s worst
+ * case; typically a few ms — the dir holds one snapshot per app). It can
+ * never fail or abort the report it rides on (all errors → null).
+ */
+export function findSnapshotForBundleId(
+  bundleId: string,
+  deps: FindSnapshotDeps = {},
+): { path: string; mtimeMs: number } | null {
+  const listSnapshots = deps.listSnapshots ?? defaultListSnapshots;
+  const readBundleId = deps.readBundleId ?? defaultReadBundleId;
+  const mtimeMs = deps.mtimeMs ?? defaultMtimeMs;
+  const now = deps.now ?? Date.now;
+  const deadline = now() + SNAPSHOT_SCAN_BUDGET_MS;
+  try {
+    const candidates = listSnapshots()
+      .map((path) => ({ path, m: mtimeMs(path) }))
+      .filter((c): c is { path: string; m: number } => c.m !== null)
+      .sort((a, b) => b.m - a.m)
+      .slice(0, SNAPSHOT_SCAN_CAP);
+    for (const { path, m } of candidates) {
+      const remaining = deadline - now();
+      if (remaining <= 0) return null;
+      if (readBundleId(path, Math.min(PLUTIL_TIMEOUT_MS, remaining)) === bundleId) {
+        return { path, mtimeMs: m };
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** GH #262: `findSnapshotForBundleId` formatted as advice input. */
+export function snapshotHintForBundleId(
+  bundleId: string,
+  deps: FindSnapshotDeps = {},
+): SnapshotHint | null {
+  const now = deps.now ?? Date.now;
+  const snap = findSnapshotForBundleId(bundleId, deps);
+  if (!snap) return null;
+  return {
+    path: snap.path,
+    ageMinutes: Math.max(0, Math.round((now() - snap.mtimeMs) / 60_000)),
+  };
 }

--- a/scripts/cdp-bridge/src/tools/restart.ts
+++ b/scripts/cdp-bridge/src/tools/restart.ts
@@ -4,6 +4,12 @@ import type { CDPClient } from '../cdp-client.js';
 import { logger } from '../logger.js';
 import { okResult, failResult } from '../utils.js';
 import { stopFastRunner as defaultStopFastRunner } from '../runners/rn-fast-runner-client.js';
+import { resolveBundleIdStrict } from '../project-config.js';
+import { getActiveSession } from '../agent-device-wrapper.js';
+import { probeAppInstalled, buildNotInstalledAdvice } from '../cdp/app-installed-probe.js';
+import type { SnapshotHint } from '../cdp/app-installed-probe.js';
+import { resetDetachedRecoveryCounter } from '../cdp/recover-detached.js';
+import { snapshotHintForBundleId } from './resolve-ios-app-file.js';
 import type { ToolResult } from '../utils.js';
 
 const defaultExecFile = promisify(execFileCb);
@@ -18,6 +24,16 @@ export interface RestartHandlerDeps {
   execFile?: (cmd: string, args: string[], opts?: { timeout?: number }) => Promise<{ stdout: string; stderr: string }>;
   stopFastRunner?: () => void;
   sleep?: (ms: number) => Promise<void>;
+  /** GH #262 (#194 BUG 2 residual): strict per-platform app.json fallback. */
+  resolveBundleIdStrict?: (platform: string) => string | null;
+  /** GH #262: active device session (appId outranks app.json; UDID targets simctl). */
+  getSession?: () => { deviceId?: string; appId?: string; platform?: string } | null;
+  /** GH #262: tri-state install probe for classifying launch failures. */
+  probeAppInstalled?: (udid: string, appId: string) => Promise<boolean | null>;
+  /** GH #262: best-effort reinstallable-snapshot hint. */
+  snapshotHint?: (appId: string) => SnapshotHint | null;
+  /** GH #262: a successful manual hard reset is a working recovery — reset the detached budget. */
+  resetDetachedBudget?: () => void;
 }
 
 export interface RestartArgs {
@@ -114,6 +130,11 @@ export function createRestartHandler(
   const execFile = deps.execFile ?? defaultExecFile;
   const stopFastRunner = deps.stopFastRunner ?? defaultStopFastRunner;
   const sleep = deps.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+  const resolveBundleIdStrictFn = deps.resolveBundleIdStrict ?? resolveBundleIdStrict;
+  const getSessionFn = deps.getSession ?? getActiveSession;
+  const probeAppInstalledFn = deps.probeAppInstalled ?? probeAppInstalled;
+  const snapshotHintFn = deps.snapshotHint ?? snapshotHintForBundleId;
+  const resetDetachedBudgetFn = deps.resetDetachedBudget ?? resetDetachedRecoveryCounter;
 
   async function doRestart(args: RestartArgs): Promise<ToolResult> {
     try {
@@ -124,9 +145,22 @@ export function createRestartHandler(
       // is cleared on disconnect, and we need it to issue simctl commands.
       const observedBundleId = oldClient.connectedTarget?.description ?? null;
       if (observedBundleId) lastSeenBundleId = observedBundleId;
-      // Resolution priority: explicit arg > current connectedTarget > cache.
-      const bundleId = args.bundleId ?? observedBundleId ?? lastSeenBundleId;
       const targetPlatform = (oldClient.connectedTarget?.platform ?? args.platform ?? 'ios').toLowerCase();
+      const session = getSessionFn();
+      const sessionMatches = !!session && (session.platform ?? 'ios') === targetPlatform;
+      // Resolution priority (GH #262 / #194 BUG 2): explicit arg > current
+      // connectedTarget > cache > active-session appId > STRICT app.json.
+      // A fresh bridge process has no cache — without the fallbacks, hardReset
+      // silently degraded to a soft reset exactly when the hard path was
+      // needed. STRICT: an Android package must never be fed to iOS simctl.
+      const bundleId = args.bundleId
+        ?? observedBundleId
+        ?? lastSeenBundleId
+        ?? (sessionMatches ? session?.appId ?? null : null)
+        ?? resolveBundleIdStrictFn(targetPlatform);
+      // simctl targets the session's simulator when one is open — 'booted' is
+      // ambiguous with multiple booted sims.
+      const targetUdid = (sessionMatches ? session?.deviceId : undefined) ?? 'booted';
 
       const hardResetSteps: string[] = [];
 
@@ -145,20 +179,32 @@ export function createRestartHandler(
         // android branch is a follow-up.
         if (bundleId && targetPlatform === 'ios') {
           try {
-            await execFile('xcrun', ['simctl', 'terminate', 'booted', bundleId], { timeout: 5000 });
+            await execFile('xcrun', ['simctl', 'terminate', targetUdid, bundleId], { timeout: 5000 });
             hardResetSteps.push(`simctl terminate ${bundleId}:ok`);
           } catch (err) {
             // Non-fatal: app may already be dead. Log + continue.
             hardResetSteps.push(`simctl terminate:warn(${err instanceof Error ? err.message : err})`);
           }
           try {
-            await execFile('xcrun', ['simctl', 'launch', 'booted', bundleId], { timeout: 8000 });
+            await execFile('xcrun', ['simctl', 'launch', targetUdid, bundleId], { timeout: 8000 });
             hardResetSteps.push(`simctl launch ${bundleId}:ok`);
           } catch (err) {
-            // Fatal-ish: if launch fails, the soft reset below will likely
-            // fail too. Still continue — caller sees the launch error in
-            // hardResetSteps and the connectError from the autoConnect.
-            hardResetSteps.push(`simctl launch:err(${err instanceof Error ? err.message : err})`);
+            const msg = err instanceof Error ? err.message : String(err);
+            // GH #262: distinguish "launch hiccup" from "bundle not installed" —
+            // the latter needs install advice, not the soft-reset retry below.
+            // Probe verdict null = unknown → keep the raw error (fail open).
+            if ((await probeAppInstalledFn(targetUdid, bundleId)) === false) {
+              let hint: SnapshotHint | null = null;
+              try { hint = snapshotHintFn(bundleId); } catch { /* best-effort */ }
+              hardResetSteps.push(
+                `simctl launch:err(APP_NOT_INSTALLED — ${buildNotInstalledAdvice(targetUdid, bundleId, hint)})`,
+              );
+            } else {
+              // Fatal-ish: if launch fails, the soft reset below will likely
+              // fail too. Still continue — caller sees the launch error in
+              // hardResetSteps and the connectError from the autoConnect.
+              hardResetSteps.push(`simctl launch:err(${msg})`);
+            }
           }
           // Step 4: give Hermes time to re-register on Metro before we try
           // to connect. Empirically 2-3s is enough on iPhone 16 Pro sim.
@@ -193,6 +239,11 @@ export function createRestartHandler(
         connectError = err instanceof Error ? err.message : String(err);
         logger.warn('MCP', `cdp_restart: autoConnect failed (best-effort): ${connectError}`);
       }
+
+      // GH #262: a successful manual hard reset is a working recovery — clear
+      // the detached-recovery budget so the auto-recovery path gets a fresh
+      // attempt allowance after the user fixes the wedge by hand.
+      if (args.hardReset && connected) resetDetachedBudgetFn();
 
       return okResult({
         restarted: true,

--- a/scripts/cdp-bridge/src/tools/restart.ts
+++ b/scripts/cdp-bridge/src/tools/restart.ts
@@ -78,8 +78,12 @@ export interface RestartArgs {
  *
  * Cache the bundleId at module scope so subsequent calls keep working.
  * Updated every time we observe a non-null `connectedTarget.description`.
+ *
+ * GH #262 multi-review: keyed by platform — a single bridge process can
+ * switch platform between connects, and a cross-platform cache hit would
+ * feed an Android package to iOS simctl (then misreport APP_NOT_INSTALLED).
  */
-let lastSeenBundleId: string | null = null;
+const lastSeenBundleIds = new Map<string, string>();
 
 /**
  * Module-scoped in-flight guard (Codex review finding #2, conf 82).
@@ -95,11 +99,11 @@ let lastSeenBundleId: string | null = null;
 let inflightRestart: Promise<ToolResult> | null = null;
 
 /**
- * Test-only: reset module state between tests. The lastSeenBundleId
+ * Test-only: reset module state between tests. The lastSeenBundleIds
  * cache and inflight guard would otherwise leak across test files.
  */
 export function _resetRestartHandlerStateForTest(): void {
-  lastSeenBundleId = null;
+  lastSeenBundleIds.clear();
   inflightRestart = null;
 }
 
@@ -144,8 +148,8 @@ export function createRestartHandler(
       // Capture the bundle id BEFORE we disconnect — the connectedTarget
       // is cleared on disconnect, and we need it to issue simctl commands.
       const observedBundleId = oldClient.connectedTarget?.description ?? null;
-      if (observedBundleId) lastSeenBundleId = observedBundleId;
       const targetPlatform = (oldClient.connectedTarget?.platform ?? args.platform ?? 'ios').toLowerCase();
+      if (observedBundleId) lastSeenBundleIds.set(targetPlatform, observedBundleId);
       const session = getSessionFn();
       const sessionMatches = !!session && (session.platform ?? 'ios') === targetPlatform;
       // Resolution priority (GH #262 / #194 BUG 2): explicit arg > current
@@ -155,7 +159,7 @@ export function createRestartHandler(
       // needed. STRICT: an Android package must never be fed to iOS simctl.
       const bundleId = args.bundleId
         ?? observedBundleId
-        ?? lastSeenBundleId
+        ?? (lastSeenBundleIds.get(targetPlatform) ?? null)
         ?? (sessionMatches ? session?.appId ?? null : null)
         ?? resolveBundleIdStrictFn(targetPlatform);
       // simctl targets the session's simulator when one is open — 'booted' is
@@ -234,7 +238,10 @@ export function createRestartHandler(
         // Refresh the cache from the freshly-connected target so a
         // subsequent recovery cycle keeps a valid bundleId. (Codex #1.)
         const postConnectBundle = newClient.connectedTarget?.description;
-        if (postConnectBundle) lastSeenBundleId = postConnectBundle;
+        if (postConnectBundle) {
+          const postConnectPlatform = (newClient.connectedTarget?.platform ?? args.platform ?? 'ios').toLowerCase();
+          lastSeenBundleIds.set(postConnectPlatform, postConnectBundle);
+        }
       } catch (err) {
         connectError = err instanceof Error ? err.message : String(err);
         logger.warn('MCP', `cdp_restart: autoConnect failed (best-effort): ${connectError}`);

--- a/scripts/cdp-bridge/src/tools/restart.ts
+++ b/scripts/cdp-bridge/src/tools/restart.ts
@@ -10,6 +10,7 @@ import { probeAppInstalled, buildNotInstalledAdvice } from '../cdp/app-installed
 import type { SnapshotHint } from '../cdp/app-installed-probe.js';
 import { resetDetachedRecoveryCounter } from '../cdp/recover-detached.js';
 import { snapshotHintForBundleId } from './resolve-ios-app-file.js';
+import { isValidBundleId } from '../domain/maestro-validator.js';
 import type { ToolResult } from '../utils.js';
 
 const defaultExecFile = promisify(execFileCb);
@@ -157,7 +158,7 @@ export function createRestartHandler(
       // A fresh bridge process has no cache — without the fallbacks, hardReset
       // silently degraded to a soft reset exactly when the hard path was
       // needed. STRICT: an Android package must never be fed to iOS simctl.
-      const bundleId = args.bundleId
+      let bundleId = args.bundleId
         ?? observedBundleId
         ?? (lastSeenBundleIds.get(targetPlatform) ?? null)
         ?? (sessionMatches ? session?.appId ?? null : null)
@@ -167,6 +168,21 @@ export function createRestartHandler(
       const targetUdid = (sessionMatches ? session?.deviceId : undefined) ?? 'booted';
 
       const hardResetSteps: string[] = [];
+
+      // Phase 134.2 precedent (see device-session.ts): never let an
+      // unvalidated string reach `xcrun simctl terminate/launch` argv. An
+      // explicit bad arg fails fast; a bad value resolved from cache/config
+      // is dropped (treated as no-bundleId) rather than shelling out with it.
+      if (bundleId !== null && !isValidBundleId(bundleId)) {
+        if (args.bundleId !== undefined) {
+          return failResult(
+            `cdp_restart: invalid bundleId argument "${String(args.bundleId).slice(0, 80)}" — expected reverse-DNS app id like com.example.app`,
+            'INVALID_BUNDLE_ID',
+          );
+        }
+        hardResetSteps.push('skip-simctl:invalid-bundleId-from-cache-or-config');
+        bundleId = null;
+      }
 
       if (args.hardReset) {
         // Step 1: kill the fast-runner xcodebuild process. This is the

--- a/scripts/cdp-bridge/src/tools/restart.ts
+++ b/scripts/cdp-bridge/src/tools/restart.ts
@@ -67,24 +67,33 @@ export interface RestartArgs {
 }
 
 /**
- * Module-scoped last-known bundle id (Codex review finding #1, conf 92).
+ * Module-scoped last-known bundle id, keyed by platform (GH #262 / #194 BUG 2).
  *
- * After a first `hardReset=true` call, a NEW CDPClient is set via
- * `setClient(createClient(...))`. Its `connectedTarget` starts as `null`
- * until `autoConnect` succeeds. If `autoConnect` fails (very plausible —
- * Hermes hasn't re-registered on Metro yet within our 3s window), a
- * second `cdp_restart hardReset=true` would read `null` as bundleId and
- * skip the simctl path — degrading to a useless soft reset exactly when
- * the user needs the hard path most.
- *
+ * After a first `hardReset=true` call, a NEW CDPClient is set whose
+ * `connectedTarget` is `null` until `autoConnect` succeeds. If autoConnect
+ * fails (Hermes hasn't re-registered within our window), a second
+ * `hardReset=true` would read `null` as bundleId and degrade to a soft reset.
  * Cache the bundleId at module scope so subsequent calls keep working.
- * Updated every time we observe a non-null `connectedTarget.description`.
  *
- * GH #262 multi-review: keyed by platform — a single bridge process can
- * switch platform between connects, and a cross-platform cache hit would
- * feed an Android package to iOS simctl (then misreport APP_NOT_INSTALLED).
+ * Keyed by platform because a single bridge process can switch platform
+ * between connects, and a cross-platform cache hit would feed an Android
+ * package to iOS simctl (then misreport APP_NOT_INSTALLED).
  */
 const lastSeenBundleIds = new Map<string, string>();
+
+/** Strict iOS simulator UDID shape (matches `xcrun simctl list` output). */
+const SIMULATOR_UDID_RE = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
+
+/**
+ * GH #262: `session.deviceId` is persisted, untrusted state that reaches
+ * `xcrun simctl` argv. Accept only the literal `'booted'` or a strict UDID;
+ * anything else falls back to `'booted'` rather than shelling out with it.
+ */
+function safeSimctlTarget(deviceId: string | undefined): string {
+  if (deviceId === 'booted') return 'booted';
+  if (deviceId && SIMULATOR_UDID_RE.test(deviceId)) return deviceId;
+  return 'booted';
+}
 
 /**
  * Module-scoped in-flight guard (Codex review finding #2, conf 82).
@@ -150,41 +159,52 @@ export function createRestartHandler(
       // is cleared on disconnect, and we need it to issue simctl commands.
       const observedBundleId = oldClient.connectedTarget?.description ?? null;
       const targetPlatform = (oldClient.connectedTarget?.platform ?? args.platform ?? 'ios').toLowerCase();
+      // The cache write must happen on every restart (incl. soft) so a later
+      // hardReset still has a bundleId after autoConnect clears connectedTarget.
       if (observedBundleId) lastSeenBundleIds.set(targetPlatform, observedBundleId);
-      const session = getSessionFn();
-      const sessionMatches = !!session && (session.platform ?? 'ios') === targetPlatform;
-      // Resolution priority (GH #262 / #194 BUG 2): explicit arg > current
-      // connectedTarget > cache > active-session appId > STRICT app.json.
-      // A fresh bridge process has no cache — without the fallbacks, hardReset
-      // silently degraded to a soft reset exactly when the hard path was
-      // needed. STRICT: an Android package must never be fed to iOS simctl.
-      let bundleId = args.bundleId
-        ?? observedBundleId
-        ?? (lastSeenBundleIds.get(targetPlatform) ?? null)
-        ?? (sessionMatches ? session?.appId ?? null : null)
-        ?? resolveBundleIdStrictFn(targetPlatform);
-      // simctl targets the session's simulator when one is open — 'booted' is
-      // ambiguous with multiple booted sims.
-      const targetUdid = (sessionMatches ? session?.deviceId : undefined) ?? 'booted';
 
       const hardResetSteps: string[] = [];
+      let bundleId: string | null = null;
 
-      // Phase 134.2 precedent (see device-session.ts): never let an
-      // unvalidated string reach `xcrun simctl terminate/launch` argv. An
-      // explicit bad arg fails fast; a bad value resolved from cache/config
-      // is dropped (treated as no-bundleId) rather than shelling out with it.
-      if (bundleId !== null && !isValidBundleId(bundleId)) {
-        if (args.bundleId !== undefined) {
-          return failResult(
-            `cdp_restart: invalid bundleId argument "${String(args.bundleId).slice(0, 80)}" — expected reverse-DNS app id like com.example.app`,
-            'INVALID_BUNDLE_ID',
-          );
-        }
-        hardResetSteps.push('skip-simctl:invalid-bundleId-from-cache-or-config');
-        bundleId = null;
-      }
-
+      // Session lookup, the bundleId resolution chain, and UDID targeting only
+      // matter for the hardReset simctl path — a soft reset must do zero
+      // session/app.json I/O and must never fail on bundleId state.
       if (args.hardReset) {
+        const session = getSessionFn();
+        const sessionMatches = !!session && (session.platform ?? 'ios') === targetPlatform;
+        // Resolution priority (GH #262 / #194 BUG 2): explicit arg > current
+        // connectedTarget > active-session appId > cache > STRICT app.json.
+        // The open device session is current user intent; the cache is
+        // connect-time state that can be stale after switching apps in the
+        // same bridge process — so the session outranks the cache. A fresh
+        // bridge process has no cache, so without the fallbacks hardReset
+        // silently degraded to a soft reset. STRICT: an Android package must
+        // never be fed to iOS simctl.
+        bundleId = args.bundleId
+          ?? observedBundleId
+          ?? (sessionMatches ? session?.appId ?? null : null)
+          ?? (lastSeenBundleIds.get(targetPlatform) ?? null)
+          ?? resolveBundleIdStrictFn(targetPlatform);
+        // simctl targets the session's simulator when one is open — 'booted' is
+        // ambiguous with multiple booted sims. deviceId is persisted/untrusted,
+        // so validate before it reaches argv (invalid → 'booted').
+        const targetUdid = safeSimctlTarget(sessionMatches ? session?.deviceId : undefined);
+
+        // Phase 134.2 precedent (see device-session.ts): never let an
+        // unvalidated string reach `xcrun simctl terminate/launch` argv. An
+        // explicit bad arg fails fast; a bad value resolved from cache/config
+        // is dropped (treated as no-bundleId) rather than shelling out with it.
+        if (bundleId !== null && !isValidBundleId(bundleId)) {
+          if (args.bundleId !== undefined) {
+            return failResult(
+              `cdp_restart: invalid bundleId argument "${String(args.bundleId).slice(0, 80)}" — expected reverse-DNS app id like com.example.app`,
+              'INVALID_BUNDLE_ID',
+            );
+          }
+          hardResetSteps.push('skip-simctl:invalid-bundleId-from-cache-or-config');
+          bundleId = null;
+        }
+
         // Step 1: kill the fast-runner xcodebuild process. This is the
         // agent-device XCTest test rig — if it's foreground, iOS treats
         // the test-app as backgrounded and pauses its JS thread.
@@ -216,9 +236,14 @@ export function createRestartHandler(
             if ((await probeAppInstalledFn(targetUdid, bundleId)) === false) {
               let hint: SnapshotHint | null = null;
               try { hint = snapshotHintFn(bundleId); } catch { /* best-effort */ }
-              hardResetSteps.push(
-                `simctl launch:err(APP_NOT_INSTALLED — ${buildNotInstalledAdvice(targetUdid, bundleId, hint)})`,
-              );
+              const advice = buildNotInstalledAdvice(targetUdid, bundleId, hint);
+              // Record the step BEFORE returning so hardResetSteps in meta stays
+              // complete, then return a typed failure: a confirmed-missing bundle
+              // is the primary error, not a buried step the caller has to fish
+              // out. The soft reset below cannot help — nothing connects to a
+              // missing app — so we skip it and leave the existing client.
+              hardResetSteps.push(`simctl launch:err(APP_NOT_INSTALLED — ${advice})`);
+              return failResult(advice, 'APP_NOT_INSTALLED', { hardResetSteps });
             } else {
               // Fatal-ish: if launch fails, the soft reset below will likely
               // fail too. Still continue — caller sees the launch error in

--- a/scripts/cdp-bridge/src/tools/status.ts
+++ b/scripts/cdp-bridge/src/tools/status.ts
@@ -8,7 +8,9 @@ import { supportsNativeMultiDebugger } from '../cdp/multiplexer.js';
 import { arbiter } from '../lifecycle/device-arbiter.js';
 import { recoverWedge } from '../cdp/recover-wedge.js';
 import { recoverDetached } from '../cdp/recover-detached.js';
-import type { DetachedRecoveryResult } from '../cdp/recover-detached.js';
+import type { DetachedRecoveryResult, RecoverDetachedDeps } from '../cdp/recover-detached.js';
+import { buildNotInstalledAdvice } from '../cdp/app-installed-probe.js';
+import { snapshotHintForBundleId } from './resolve-ios-app-file.js';
 import { AppDetachedError } from '../cdp/discovery.js';
 import { getDeviceSessionHealth } from './device-session-health.js';
 import { detectIosExternalRunner } from '../runners/external-runner-detect.js';
@@ -124,7 +126,7 @@ export function createStatusHandler(
   getClient: () => CDPClient,
   setClient: (c: CDPClient) => void,
   createClient: (port: number) => CDPClient,
-  deps: { recoverDetached?: typeof recoverDetached } = {},
+  deps: { recoverDetached?: (client: CDPClient, rdeps?: RecoverDetachedDeps) => Promise<DetachedRecoveryResult> } = {},
 ) {
   const recoverDetachedFn = deps.recoverDetached ?? recoverDetached;
   return async (args: { metroPort?: number; platform?: string; resetArbiter?: boolean }) => {
@@ -312,7 +314,7 @@ export function createStatusHandler(
         const callerPinnedNonIos = !!args.platform && args.platform.toLowerCase() !== 'ios';
         const recovery: DetachedRecoveryResult = callerPinnedNonIos
           ? { recovered: false, reason: 'unsupported-platform', attempt: 0 }
-          : await recoverDetachedFn(getClient());
+          : await recoverDetachedFn(getClient(), { snapshotHint: snapshotHintForBundleId });
         if (recovery.recovered) {
           // GH #208 review (Gemini F2): never let a post-reconnect status read throw
           // out of the catch — degrade to a minimal warn instead of crashing the tool.
@@ -327,6 +329,25 @@ export function createStatusHandler(
               `App had detached (Metro up, 0 Hermes targets) — auto-relaunched and reconnected (attempt ${recovery.attempt}), but reading the full status failed; retry cdp_status.`,
             );
           }
+        }
+        // GH #262: the bundle is CONFIRMED missing (e.g. simulator erased) —
+        // the generic "relaunch manually / hardReset" hints below can never
+        // work. Return the distinct code with install advice instead.
+        if (recovery.reason === 'app-not-installed') {
+          return failResult(
+            `${message} ${buildNotInstalledAdvice(
+              recovery.udid ?? 'booted',
+              recovery.appId ?? 'the app',
+              recovery.snapshotHint ?? null,
+            )}`,
+            'APP_NOT_INSTALLED',
+            {
+              reconnect: getClient().reconnectState,
+              autoConnect: getClient().autoConnectState,
+              bridge: bridgeEnvState(process.env),
+              recovery,
+            },
+          );
         }
         const detachedHint =
           recovery.reason === 'flow-active'

--- a/scripts/cdp-bridge/src/types.ts
+++ b/scripts/cdp-bridge/src/types.ts
@@ -188,6 +188,7 @@ export type ToolErrorCode =
   | 'HELPERS_STALE'
   | 'RECONNECT_TIMEOUT'
   | 'APP_DETACHED'              // GH #208 (RC2/RC3): Metro up but 0 Hermes targets (app detached)
+  | 'APP_NOT_INSTALLED'         // GH #262: relaunch failed and get_app_container confirms the bundle is missing
   | 'NOT_CONNECTED'
   | 'HELPERS_NOT_INJECTED'
   // M6 / Phase 112 (D669): cdp_record_test_* tool family.

--- a/scripts/cdp-bridge/src/types.ts
+++ b/scripts/cdp-bridge/src/types.ts
@@ -226,6 +226,7 @@ export type ToolErrorCode =
   | 'INVALID_APPID'             // device_permission
   | 'DEVICE_RESET_INVALID_APPID' // device_reset_state
   | 'INVALID_PACKAGE_NAME'      // device_deeplink
+  | 'INVALID_BUNDLE_ID'         // GH #262 codex-pair: cdp_restart explicit bundleId arg failed strict validation
   // GH #105 / B153: cdp_repair_action's snapshot landed on Agent Device Runner.
   | 'RUNNER_LEAK'
   // GH #105 / iOS-MVP §3.1: runIOS press/fill with a @ref no longer in the

--- a/scripts/cdp-bridge/test/unit/cdp-restart.test.js
+++ b/scripts/cdp-bridge/test/unit/cdp-restart.test.js
@@ -203,6 +203,11 @@ test('cdp_restart hardReset:true skips simctl when bundleId unknown (no connecte
       execFile,
       stopFastRunner: () => { stopFastRunnerCalls += 1; },
       sleep: async () => {},
+      // GH #262: pin the new strict-app.json fallback + active-session lookups
+      // off so this case keeps asserting the genuine no-bundleId skip path —
+      // a developer's open session or RN-project cwd must not resolve a real id.
+      resolveBundleIdStrict: () => null,
+      getSession: () => null,
     },
   );
 

--- a/scripts/cdp-bridge/test/unit/gh-208-recover-detached.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-208-recover-detached.test.js
@@ -93,7 +93,7 @@ test('recoverDetached: caps CONSECUTIVE failures; a success resets the budget', 
 
 test('recoverDetached: relaunch throws + probe FALSE → still-detached (no false positive)', async () => {
   resetDetachedRecoveryCounter();
-  const { deps } = baseDeps({ relaunchApp: async () => { throw new Error('simctl boom'); }, probeAlive: async () => false });
+  const { deps } = baseDeps({ relaunchApp: async () => { throw new Error('simctl boom'); }, probeAlive: async () => false, isAppInstalled: async () => null });
   const r = await recoverDetached({}, deps);
   assert.equal(r.recovered, false);
   assert.equal(r.reason, 'still-detached');

--- a/scripts/cdp-bridge/test/unit/gh-208-recover-detached.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-208-recover-detached.test.js
@@ -16,7 +16,7 @@ function baseDeps(over = {}) {
   return {
     calls,
     deps: {
-      getSession: () => ({ deviceId: 'UDID-A', appId: 'com.example.app', platform: 'ios' }),
+      getSession: () => ({ deviceId: 'AAAAAAAA-0000-0000-0000-000000000001', appId: 'com.example.app', platform: 'ios' }),
       isFlowActive: () => false,
       isOptedOut: () => false,
       relaunchApp: async (udid, appId) => { calls.push(`relaunch:${udid}:${appId}`); },
@@ -37,7 +37,7 @@ test('recoverDetached: parks runner, cold-restarts, reconnects, recovers (happy 
   assert.equal(r.recovered, true);
   assert.equal(r.reason, 'recovered');
   assert.equal(r.attempt, 1);
-  assert.deepEqual(calls, ['stop', 'relaunch:UDID-A:com.example.app', 'reconnect']);
+  assert.deepEqual(calls, ['stop', 'relaunch:AAAAAAAA-0000-0000-0000-000000000001:com.example.app', 'reconnect']);
 });
 
 test('recoverDetached: liveness probe FALSE after relaunch → still-detached', async () => {

--- a/scripts/cdp-bridge/test/unit/gh-208-recover-detached.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-208-recover-detached.test.js
@@ -97,6 +97,8 @@ test('recoverDetached: relaunch throws + probe FALSE → still-detached (no fals
   const r = await recoverDetached({}, deps);
   assert.equal(r.recovered, false);
   assert.equal(r.reason, 'still-detached');
+  // Codex F3 contract: the launch failure is surfaced, never swallowed.
+  assert.match(r.error ?? '', /simctl boom/);
 });
 
 // The distinguishing behavior vs recover-wedge: a COLD restart (terminate THEN

--- a/scripts/cdp-bridge/test/unit/gh-208-review-fixes.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-208-review-fixes.test.js
@@ -74,6 +74,7 @@ test('recoverDetached surfaces a simctl launch error instead of hiding it behind
     reconnect: async () => {},
     probeAlive: async () => false,
     sleep: async () => {},
+    isAppInstalled: async () => null,
   });
   assert.equal(r.recovered, false);
   assert.equal(r.reason, 'still-detached');

--- a/scripts/cdp-bridge/test/unit/gh-208-review-fixes.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-208-review-fixes.test.js
@@ -66,7 +66,7 @@ test('AppDetachedError does NOT auto-relaunch when the caller pinned a non-iOS p
 test('recoverDetached surfaces a simctl launch error instead of hiding it behind still-detached', async () => {
   resetDetachedRecoveryCounter();
   const r = await recoverDetached({}, {
-    getSession: () => ({ deviceId: 'U', appId: 'a', platform: 'ios' }),
+    getSession: () => ({ deviceId: 'AAAAAAAA-0000-0000-0000-000000000001', appId: 'com.example.app', platform: 'ios' }),
     isFlowActive: () => false,
     isOptedOut: () => false,
     stopFastRunner: () => {},

--- a/scripts/cdp-bridge/test/unit/gh-262-app-installed-probe.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-262-app-installed-probe.test.js
@@ -1,0 +1,83 @@
+// GH #262: ground-truth probe for "is the app bundle installed on the sim?".
+// Classification is ALLOWLIST-only and reads simctl STDERR ONLY (never
+// Error.message, which embeds command argv — a crafted bundleId containing
+// the marker text must not force a false "not installed"). `false` requires
+// the NSPOSIXErrorDomain + code=2 marker (verified live: "(domain=
+// NSPOSIXErrorDomain, code=2)"); every other failure shape — bare ENOENT
+// text, device errors, unknown stderr, no stderr, timeouts — returns `null`.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  probeAppInstalled, buildNotInstalledAdvice, posixSingleQuote,
+} from '../../dist/cdp/app-installed-probe.js';
+
+function execFailing(stderr, message) {
+  return async () => {
+    const err = new Error(message ?? `Command failed: xcrun simctl get_app_container ...\n${stderr}`);
+    err.stderr = stderr;
+    throw err;
+  };
+}
+
+test('probeAppInstalled: container resolves → true', async () => {
+  const exec = async (cmd, args, opts) => {
+    assert.equal(cmd, 'xcrun');
+    assert.deepEqual(args, ['simctl', 'get_app_container', 'UDID-A', 'com.example.app', 'app']);
+    assert.equal(opts.timeout, 5000);
+    return { stdout: '/path/Example.app\n', stderr: '' };
+  };
+  assert.equal(await probeAppInstalled('UDID-A', 'com.example.app', exec), true);
+});
+
+test('probeAppInstalled: real missing-app stderr (domain + code=2) → false', async () => {
+  // Exact shape captured live on this machine (Xcode 26):
+  const stderr =
+    'An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=2):\n'
+    + 'The operation couldn’t be completed. No such file or directory\n'
+    + 'No such file or directory';
+  assert.equal(await probeAppInstalled('U', 'a', execFailing(stderr)), false);
+});
+
+test('probeAppInstalled: marker is case-insensitive and separator-flexible', async () => {
+  assert.equal(await probeAppInstalled('U', 'a', execFailing('nsposixerrordomain Code: 2 oops')), false);
+});
+
+test('probeAppInstalled: code=-2 / code=20 / missing domain → null (never false)', async () => {
+  assert.equal(await probeAppInstalled('U', 'a', execFailing('domain=NSPOSIXErrorDomain, code=-2')), null);
+  assert.equal(await probeAppInstalled('U', 'a', execFailing('domain=NSPOSIXErrorDomain, code=20')), null);
+  assert.equal(await probeAppInstalled('U', 'a', execFailing('No such file or directory')), null);
+});
+
+test('probeAppInstalled: marker in Error.message but NOT stderr → null (argv-spoof defense)', async () => {
+  const spoof = execFailing('', 'Command failed: xcrun simctl get_app_container U NSPOSIXErrorDomain-code=2-trap app');
+  assert.equal(await probeAppInstalled('U', 'NSPOSIXErrorDomain-code=2-trap', spoof), null);
+});
+
+test('probeAppInstalled: device-level error → null (fail open)', async () => {
+  assert.equal(await probeAppInstalled('U', 'a', execFailing('Invalid device: U')), null);
+  assert.equal(await probeAppInstalled('U', 'a', execFailing('No devices are booted.')), null);
+});
+
+test('probeAppInstalled: no stderr at all (spawn error / timeout) → null', async () => {
+  assert.equal(await probeAppInstalled('U', 'a', async () => { throw new Error('ETIMEDOUT'); }), null);
+});
+
+test('posixSingleQuote: inert metacharacters and embedded quotes', () => {
+  assert.equal(posixSingleQuote('plain'), `'plain'`);
+  assert.equal(posixSingleQuote("My App's.app"), `'My App'\\''s.app'`);
+});
+
+test('buildNotInstalledAdvice: base advice without hint; shell-quoted install line with hint', () => {
+  const base = buildNotInstalledAdvice('UDID-A', 'com.example.app', null);
+  assert.match(base, /com\.example\.app is not installed on simulator UDID-A/);
+  assert.match(base, /npx expo run:ios/);
+  assert.doesNotMatch(base, /simctl install/);
+
+  const withHint = buildNotInstalledAdvice('UDID-A', 'com.example.app', {
+    path: '/tmp/rn-appfile-snapshots/My App.app',
+    ageMinutes: 42,
+  });
+  assert.match(withHint, /42 min ago/);
+  assert.match(withHint, /may be stale/);
+  assert.match(withHint, /xcrun simctl install 'UDID-A' '\/tmp\/rn-appfile-snapshots\/My App\.app'/);
+});

--- a/scripts/cdp-bridge/test/unit/gh-262-find-snapshot.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-262-find-snapshot.test.js
@@ -99,3 +99,22 @@ test('snapshotHintForBundleId: converts mtime to ageMinutes (rounded, never nega
   assert.deepEqual(snapshotHintForBundleId('com.example.app', deps), { path: A, ageMinutes: 5 });
   assert.equal(snapshotHintForBundleId('com.missing', deps), null);
 });
+
+test('snapshotHintForBundleId: future mtime (clock skew) clamps to ageMinutes 0', () => {
+  const deps = {
+    listSnapshots: () => [A],
+    readBundleId: () => 'com.example.app',
+    mtimeMs: () => 600_000,
+    now: () => 300_000,
+  };
+  assert.deepEqual(snapshotHintForBundleId('com.example.app', deps), { path: A, ageMinutes: 0 });
+});
+
+test('never throws: throwing deps → null from both functions', () => {
+  const boom = () => { throw new Error('boom'); };
+  assert.equal(findSnapshotForBundleId('com.x', { listSnapshots: boom }), null);
+  assert.equal(findSnapshotForBundleId('com.x', { listSnapshots: () => [A], mtimeMs: boom }), null);
+  assert.equal(findSnapshotForBundleId('com.x', { listSnapshots: () => [A], mtimeMs: () => 1, readBundleId: boom }), null);
+  assert.equal(findSnapshotForBundleId('com.x', { listSnapshots: () => [A], mtimeMs: () => 1, now: boom }), null);
+  assert.equal(snapshotHintForBundleId('com.x', { listSnapshots: boom }), null);
+});

--- a/scripts/cdp-bridge/test/unit/gh-262-find-snapshot.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-262-find-snapshot.test.js
@@ -1,0 +1,101 @@
+// GH #262: best-effort lookup of a reinstallable .app snapshot in the GH #201
+// bounded dir ($TMPDIR/rn-appfile-snapshots). Candidates are mtime-sorted
+// NEWEST-FIRST BEFORE the ≤10 cap (readdir order is arbitrary — capping first
+// could drop the newest match), then plutil-matched under a ~3s budget with
+// deadline-clamped per-read timeouts. Never throws — the hint may add at most
+// the bounded scan budget to an already-failed path and must never FAIL the
+// report it rides on.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  findSnapshotForBundleId, snapshotHintForBundleId,
+} from '../../dist/tools/resolve-ios-app-file.js';
+
+const A = '/tmp/rn-appfile-snapshots/AppA.app';
+const B = '/tmp/rn-appfile-snapshots/AppB.app';
+
+test('findSnapshotForBundleId: matches CFBundleIdentifier; newest mtime wins', () => {
+  const deps = {
+    listSnapshots: () => [A, B],
+    readBundleId: () => 'com.example.app',
+    mtimeMs: (p) => (p === A ? 1000 : 2000),
+    now: () => 10_000,
+  };
+  assert.deepEqual(findSnapshotForBundleId('com.example.app', deps), { path: B, mtimeMs: 2000 });
+});
+
+test('findSnapshotForBundleId: sorts newest-first BEFORE the cap — newest survives a >10 dir', () => {
+  // 12 decoys older than the target; readdir lists the target LAST.
+  const decoys = Array.from({ length: 12 }, (_, i) => `/tmp/rn-appfile-snapshots/Decoy${i}.app`);
+  const target = '/tmp/rn-appfile-snapshots/Target.app';
+  const reads = [];
+  const deps = {
+    listSnapshots: () => [...decoys, target],
+    readBundleId: (p) => { reads.push(p); return p === target ? 'com.example.app' : 'com.decoy'; },
+    mtimeMs: (p) => (p === target ? 99_000 : 1000),
+    now: () => 0,
+  };
+  assert.deepEqual(findSnapshotForBundleId('com.example.app', deps), { path: target, mtimeMs: 99_000 });
+  assert.equal(reads[0], target, 'newest candidate is plutil-read first');
+  assert.equal(reads.length, 1, 'first (newest) match short-circuits the scan');
+});
+
+test('findSnapshotForBundleId: no bundle-id match → null; at most 10 plutil reads', () => {
+  let reads = 0;
+  const deps = {
+    listSnapshots: () => Array.from({ length: 25 }, (_, i) => `/tmp/rn-appfile-snapshots/App${i}.app`),
+    readBundleId: () => { reads += 1; return 'com.nomatch'; },
+    mtimeMs: () => 1000,
+    now: () => 0,
+  };
+  assert.equal(findSnapshotForBundleId('com.example.app', deps), null);
+  assert.equal(reads, 10);
+});
+
+test('findSnapshotForBundleId: unreadable Info.plist (readBundleId null) → candidate skipped', () => {
+  const deps = {
+    listSnapshots: () => [A, B],
+    readBundleId: (p) => (p === B ? null : 'com.example.app'),
+    mtimeMs: (p) => (p === A ? 1000 : 2000), // B newer but unreadable
+    now: () => 0,
+  };
+  assert.deepEqual(findSnapshotForBundleId('com.example.app', deps), { path: A, mtimeMs: 1000 });
+});
+
+test('findSnapshotForBundleId: budget overrun → stops before further plutil reads', () => {
+  let reads = 0;
+  const deps = {
+    listSnapshots: () => [A, B],
+    readBundleId: () => { reads += 1; return 'com.example.app'; },
+    mtimeMs: () => 1000,
+    // First call (deadline calc) t=0; every later call is past the 3s budget.
+    now: (() => { let calls = 0; return () => (calls++ === 0 ? 0 : 10_000); })(),
+  };
+  assert.equal(findSnapshotForBundleId('com.example.app', deps), null);
+  assert.equal(reads, 0, 'no plutil read after budget exceeded');
+});
+
+test('findSnapshotForBundleId: per-read timeout is clamped to the remaining deadline', () => {
+  const timeouts = [];
+  let t = 0;
+  const deps = {
+    listSnapshots: () => [A, B],
+    readBundleId: (p, timeoutMs) => { timeouts.push(timeoutMs); t += 1500; return 'com.nomatch'; },
+    mtimeMs: () => 1000,
+    now: () => t,
+  };
+  findSnapshotForBundleId('com.example.app', deps);
+  assert.equal(timeouts[0], 2000, 'full per-read timeout while budget is fresh');
+  assert.ok(timeouts[1] < 2000, `second read clamped to remaining budget, got ${timeouts[1]}`);
+});
+
+test('snapshotHintForBundleId: converts mtime to ageMinutes (rounded, never negative)', () => {
+  const deps = {
+    listSnapshots: () => [A],
+    readBundleId: () => 'com.example.app',
+    mtimeMs: () => 0,
+    now: () => 300_000, // 5 min later
+  };
+  assert.deepEqual(snapshotHintForBundleId('com.example.app', deps), { path: A, ageMinutes: 5 });
+  assert.equal(snapshotHintForBundleId('com.missing', deps), null);
+});

--- a/scripts/cdp-bridge/test/unit/gh-262-recover-not-installed.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-262-recover-not-installed.test.js
@@ -1,0 +1,151 @@
+// GH #262: when the cold-relaunch fails AND simctl confirms the bundle is not
+// installed, recovery short-circuits with reason 'app-not-installed'
+// (carrying udid/appId for advice + a best-effort injected snapshot hint)
+// instead of looping on reconnect attempts that can never succeed. Probe
+// verdicts true/null keep the existing still-detached behavior (fail open).
+// Concurrent recoveries are serialized (followers share the leader's
+// verdict); a confirmed not-installed is cached per (udid, appId) and
+// re-probed cheaply so a user reinstall self-heals.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  recoverDetached, resetDetachedRecoveryCounter,
+} from '../../dist/cdp/recover-detached.js';
+
+function baseDeps(over = {}) {
+  const calls = [];
+  return {
+    calls,
+    deps: {
+      getSession: () => ({ deviceId: 'UDID-A', appId: 'com.example.app', platform: 'ios' }),
+      isFlowActive: () => false,
+      isOptedOut: () => false,
+      relaunchApp: async () => { calls.push('relaunch'); throw new Error('FBSOpenApplicationServiceErrorDomain, code=4'); },
+      stopFastRunner: () => calls.push('stop'),
+      reconnect: async () => { calls.push('reconnect'); },
+      probeAlive: async () => false,
+      sleep: async () => { calls.push('sleep'); },
+      maxPerSession: 3,
+      ...over,
+    },
+  };
+}
+
+test('launch fails + probe FALSE → app-not-installed, short-circuits settle/reconnect', async () => {
+  resetDetachedRecoveryCounter();
+  const { calls, deps } = baseDeps({
+    isAppInstalled: async (udid, appId) => {
+      calls.push(`probe:${udid}:${appId}`);
+      return false;
+    },
+    snapshotHint: () => ({ path: '/tmp/rn-appfile-snapshots/My App.app', ageMinutes: 7 }),
+  });
+  const r = await recoverDetached({}, deps);
+  assert.equal(r.recovered, false);
+  assert.equal(r.reason, 'app-not-installed');
+  assert.equal(r.attempt, 1);
+  assert.equal(r.udid, 'UDID-A');
+  assert.equal(r.appId, 'com.example.app');
+  assert.match(r.error, /code=4/);
+  assert.deepEqual(r.snapshotHint, { path: '/tmp/rn-appfile-snapshots/My App.app', ageMinutes: 7 });
+  assert.ok(calls.includes('probe:UDID-A:com.example.app'));
+  assert.ok(!calls.includes('sleep'), 'short-circuit: no settle wait');
+  assert.ok(!calls.includes('reconnect'), 'short-circuit: no reconnect attempt');
+});
+
+test('no snapshotHint dep injected → app-not-installed without hint (cdp layer has no default)', async () => {
+  resetDetachedRecoveryCounter();
+  const { deps } = baseDeps({ isAppInstalled: async () => false });
+  const r = await recoverDetached({}, deps);
+  assert.equal(r.reason, 'app-not-installed');
+  assert.equal(r.snapshotHint, undefined);
+});
+
+test('launch fails + probe NULL (ambiguous) → still-detached with raw error (fail open)', async () => {
+  resetDetachedRecoveryCounter();
+  const { calls, deps } = baseDeps({ isAppInstalled: async () => null });
+  const r = await recoverDetached({}, deps);
+  assert.equal(r.reason, 'still-detached');
+  assert.match(r.error, /code=4/);
+  assert.equal(r.snapshotHint, undefined);
+  assert.ok(calls.includes('reconnect'), 'normal path still attempts reconnect');
+});
+
+test('launch fails + probe TRUE (installed) → existing behavior unchanged', async () => {
+  resetDetachedRecoveryCounter();
+  const { calls, deps } = baseDeps({ isAppInstalled: async () => true });
+  const r = await recoverDetached({}, deps);
+  assert.equal(r.reason, 'still-detached');
+  assert.ok(calls.includes('reconnect'));
+});
+
+test('snapshot hint THROWS → app-not-installed without hint (hint is best-effort)', async () => {
+  resetDetachedRecoveryCounter();
+  const { deps } = baseDeps({
+    isAppInstalled: async () => false,
+    snapshotHint: () => { throw new Error('plist exploded'); },
+  });
+  const r = await recoverDetached({}, deps);
+  assert.equal(r.reason, 'app-not-installed');
+  assert.equal(r.snapshotHint, undefined);
+});
+
+test('terminal cache: second call re-probes cheaply, NO relaunch side effects, NO budget burn', async () => {
+  resetDetachedRecoveryCounter();
+  const first = baseDeps({ isAppInstalled: async () => false });
+  assert.equal((await recoverDetached({}, first.deps)).reason, 'app-not-installed');
+
+  const second = baseDeps({ isAppInstalled: async () => false });
+  const r2 = await recoverDetached({}, second.deps);
+  assert.equal(r2.reason, 'app-not-installed');
+  assert.equal(r2.attempt, 1, 'cached diagnosis does not burn budget');
+  assert.ok(!second.calls.includes('relaunch'), 'no terminate/launch on a cached diagnosis');
+});
+
+test('terminal cache self-heals: re-probe TRUE clears the cache and recovery proceeds', async () => {
+  resetDetachedRecoveryCounter();
+  const first = baseDeps({ isAppInstalled: async () => false });
+  await recoverDetached({}, first.deps);
+
+  const calls = [];
+  const deps = baseDeps({
+    isAppInstalled: async () => true, // user reinstalled
+    relaunchApp: async () => { calls.push('relaunch'); },
+    probeAlive: async () => true,
+  }).deps;
+  const r2 = await recoverDetached({}, { ...deps, relaunchApp: async () => { calls.push('relaunch'); } });
+  assert.equal(r2.reason, 'recovered');
+  assert.ok(calls.includes('relaunch'), 'normal recovery resumed after reinstall');
+});
+
+test('concurrent recoveries are serialized: followers share the leader verdict, one relaunch total', async () => {
+  resetDetachedRecoveryCounter();
+  let release;
+  const gate = new Promise((r) => { release = r; });
+  let relaunches = 0;
+  const { deps } = baseDeps({
+    relaunchApp: async () => { relaunches += 1; await gate; throw new Error('code=4'); },
+    isAppInstalled: async () => false,
+    snapshotHint: () => null,
+  });
+  const p1 = recoverDetached({}, deps);
+  const p2 = recoverDetached({}, deps);
+  release();
+  const [r1, r2] = await Promise.all([p1, p2]);
+  assert.equal(relaunches, 1, 'follower must not run its own terminate/launch');
+  assert.equal(r1.reason, 'app-not-installed');
+  assert.deepEqual(r2, r1, 'follower shares the leader verdict');
+});
+
+test('relaunch SUCCEEDS → probe never called (cost lands only on the failed path)', async () => {
+  resetDetachedRecoveryCounter();
+  let probed = false;
+  const { deps } = baseDeps({
+    relaunchApp: async () => {},
+    probeAlive: async () => true,
+    isAppInstalled: async () => { probed = true; return false; },
+  });
+  const r = await recoverDetached({}, deps);
+  assert.equal(r.reason, 'recovered');
+  assert.equal(probed, false);
+});

--- a/scripts/cdp-bridge/test/unit/gh-262-recover-not-installed.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-262-recover-not-installed.test.js
@@ -17,7 +17,7 @@ function baseDeps(over = {}) {
   return {
     calls,
     deps: {
-      getSession: () => ({ deviceId: 'UDID-A', appId: 'com.example.app', platform: 'ios' }),
+      getSession: () => ({ deviceId: 'AAAAAAAA-0000-0000-0000-000000000001', appId: 'com.example.app', platform: 'ios' }),
       isFlowActive: () => false,
       isOptedOut: () => false,
       relaunchApp: async () => { calls.push('relaunch'); throw new Error('FBSOpenApplicationServiceErrorDomain, code=4'); },
@@ -44,11 +44,11 @@ test('launch fails + probe FALSE → app-not-installed, short-circuits settle/re
   assert.equal(r.recovered, false);
   assert.equal(r.reason, 'app-not-installed');
   assert.equal(r.attempt, 1);
-  assert.equal(r.udid, 'UDID-A');
+  assert.equal(r.udid, 'AAAAAAAA-0000-0000-0000-000000000001');
   assert.equal(r.appId, 'com.example.app');
   assert.match(r.error, /code=4/);
   assert.deepEqual(r.snapshotHint, { path: '/tmp/rn-appfile-snapshots/My App.app', ageMinutes: 7 });
-  assert.ok(calls.includes('probe:UDID-A:com.example.app'));
+  assert.ok(calls.includes('probe:AAAAAAAA-0000-0000-0000-000000000001:com.example.app'));
   assert.ok(!calls.includes('sleep'), 'short-circuit: no settle wait');
   assert.ok(!calls.includes('reconnect'), 'short-circuit: no reconnect attempt');
 });
@@ -164,7 +164,7 @@ test('exhausted budget does not mask a freshly missing bundle (PR #280 P2)', asy
   });
   const r4 = await recoverDetached({}, deps);
   assert.equal(r4.reason, 'app-not-installed');
-  assert.equal(r4.udid, 'UDID-A');
+  assert.equal(r4.udid, 'AAAAAAAA-0000-0000-0000-000000000001');
   assert.deepEqual(r4.snapshotHint, { path: '/tmp/rn-appfile-snapshots/My App.app', ageMinutes: 1 });
   assert.ok(!calls.includes('relaunch'), 'no side effects on the exhausted path');
   // And it cached: the next call short-circuits the same way.
@@ -181,4 +181,27 @@ test('exhausted budget + probe true/null → budget-exhausted unchanged (fail op
   assert.equal(rTrue.reason, 'budget-exhausted');
   const rNull = await recoverDetached({}, baseDeps({ isAppInstalled: async () => null }).deps);
   assert.equal(rNull.reason, 'budget-exhausted');
+});
+
+test('malformed session identifiers → no-session, nothing reaches simctl (codex-pair)', async () => {
+  resetDetachedRecoveryCounter();
+  const evilUdid = baseDeps({
+    getSession: () => ({ deviceId: 'evil; rm -rf /', appId: 'com.example.app', platform: 'ios' }),
+    isAppInstalled: async () => { throw new Error('probe must not run'); },
+  });
+  const r1 = await recoverDetached({}, evilUdid.deps);
+  assert.equal(r1.reason, 'no-session');
+  assert.ok(!evilUdid.calls.includes('relaunch'), 'no simctl side effects');
+
+  const evilAppId = baseDeps({
+    getSession: () => ({ deviceId: 'F1A2B3C4-1111-2222-3333-444455556666', appId: 'not a bundle id!', platform: 'ios' }),
+    isAppInstalled: async () => { throw new Error('probe must not run'); },
+  });
+  const r2 = await recoverDetached({}, evilAppId.deps);
+  assert.equal(r2.reason, 'no-session');
+  assert.ok(!evilAppId.calls.includes('relaunch'));
+
+  // Budget untouched by the rejections: a real attempt is still attempt 1.
+  const real = await recoverDetached({}, baseDeps({ isAppInstalled: async () => null }).deps);
+  assert.equal(real.attempt, 1);
 });

--- a/scripts/cdp-bridge/test/unit/gh-262-recover-not-installed.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-262-recover-not-installed.test.js
@@ -149,3 +149,36 @@ test('relaunch SUCCEEDS → probe never called (cost lands only on the failed pa
   assert.equal(r.reason, 'recovered');
   assert.equal(probed, false);
 });
+
+test('exhausted budget does not mask a freshly missing bundle (PR #280 P2)', async () => {
+  resetDetachedRecoveryCounter();
+  // Exhaust the budget with still-detached attempts (app installed, just wedged).
+  for (let i = 0; i < 3; i += 1) {
+    const r = await recoverDetached({}, baseDeps({ isAppInstalled: async () => true }).deps);
+    assert.equal(r.reason, 'still-detached');
+  }
+  // App now uninstalled: the 4th call must diagnose, not surrender.
+  const { calls, deps } = baseDeps({
+    isAppInstalled: async () => false,
+    snapshotHint: () => ({ path: '/tmp/rn-appfile-snapshots/My App.app', ageMinutes: 1 }),
+  });
+  const r4 = await recoverDetached({}, deps);
+  assert.equal(r4.reason, 'app-not-installed');
+  assert.equal(r4.udid, 'UDID-A');
+  assert.deepEqual(r4.snapshotHint, { path: '/tmp/rn-appfile-snapshots/My App.app', ageMinutes: 1 });
+  assert.ok(!calls.includes('relaunch'), 'no side effects on the exhausted path');
+  // And it cached: the next call short-circuits the same way.
+  const r5 = await recoverDetached({}, baseDeps({ isAppInstalled: async () => false }).deps);
+  assert.equal(r5.reason, 'app-not-installed');
+});
+
+test('exhausted budget + probe true/null → budget-exhausted unchanged (fail open)', async () => {
+  resetDetachedRecoveryCounter();
+  for (let i = 0; i < 3; i += 1) {
+    await recoverDetached({}, baseDeps({ isAppInstalled: async () => true }).deps);
+  }
+  const rTrue = await recoverDetached({}, baseDeps({ isAppInstalled: async () => true }).deps);
+  assert.equal(rTrue.reason, 'budget-exhausted');
+  const rNull = await recoverDetached({}, baseDeps({ isAppInstalled: async () => null }).deps);
+  assert.equal(rNull.reason, 'budget-exhausted');
+});

--- a/scripts/cdp-bridge/test/unit/gh-262-recover-not-installed.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-262-recover-not-installed.test.js
@@ -118,6 +118,40 @@ test('terminal cache self-heals: re-probe TRUE clears the cache and recovery pro
   assert.ok(calls.includes('relaunch'), 'normal recovery resumed after reinstall');
 });
 
+test('self-heal after exhausted-budget diagnosis also resets the budget (PR #280 P2)', async () => {
+  resetDetachedRecoveryCounter();
+  // Exhaust the budget (app installed, just wedged).
+  for (let i = 0; i < 3; i += 1) {
+    await recoverDetached({}, baseDeps({ isAppInstalled: async () => true }).deps);
+  }
+  // App uninstalled: exhausted-path probe diagnoses + caches.
+  assert.equal(
+    (await recoverDetached({}, baseDeps({ isAppInstalled: async () => false }).deps)).reason,
+    'app-not-installed',
+  );
+  // User reinstalls: recovery must actually RETRY (not budget-exhausted).
+  const calls = [];
+  const { deps } = baseDeps({
+    isAppInstalled: async () => true,
+    probeAlive: async () => true,
+  });
+  deps.relaunchApp = async () => { calls.push('relaunch'); };
+  const r = await recoverDetached({}, deps);
+  assert.equal(r.reason, 'recovered');
+  assert.equal(r.attempt, 1, 'budget restarted fresh after confirmed reinstall');
+  assert.ok(calls.includes('relaunch'));
+});
+
+test('self-heal re-probe NULL clears the cache but keeps the exhausted budget (fail open)', async () => {
+  resetDetachedRecoveryCounter();
+  for (let i = 0; i < 3; i += 1) {
+    await recoverDetached({}, baseDeps({ isAppInstalled: async () => true }).deps);
+  }
+  await recoverDetached({}, baseDeps({ isAppInstalled: async () => false }).deps); // cache it
+  const r = await recoverDetached({}, baseDeps({ isAppInstalled: async () => null }).deps);
+  assert.equal(r.reason, 'budget-exhausted', 'null verdict is not evidence of reinstall');
+});
+
 test('concurrent recoveries are serialized: followers share the leader verdict, one relaunch total', async () => {
   resetDetachedRecoveryCounter();
   let release;

--- a/scripts/cdp-bridge/test/unit/gh-262-restart-fallback.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-262-restart-fallback.test.js
@@ -11,7 +11,7 @@ import assert from 'node:assert/strict';
 import {
   createRestartHandler, _resetRestartHandlerStateForTest,
 } from '../../dist/tools/restart.js';
-import { expectOk } from '../helpers/result-helpers.js';
+import { expectOk, expectFail, parseEnvelope } from '../helpers/result-helpers.js';
 
 beforeEach(() => {
   _resetRestartHandlerStateForTest();
@@ -150,14 +150,65 @@ test('hardReset: android-cached bundleId is NOT used for an iOS target (platform
       resolveBundleIdStrict: () => null,
     },
   );
-  await handler({}); // android-flavored soft restart populates the cache
+  expectOk(await handler({})); // android-flavored soft restart populates the cache
   current = plainClient; // fresh-process-like state: no connectedTarget
+
+  // Same-platform control: an android-targeted hardReset (current client has
+  // NO connectedTarget) must FIND the android cache entry and proceed to the
+  // 'android-not-yet-supported' skip — NOT the 'no-bundleId' skip. This proves
+  // the android entry was actually populated (and would fail if the
+  // platform-keyed Map were reverted to a single shared slot: the later
+  // iOS lookup below would then evict/overwrite it — see note in report).
+  const androidData = expectOk(await handler({ hardReset: true, platform: 'android' }));
+  assert.ok(
+    !androidData.hardResetSteps.includes('skip-simctl:no-bundleId-on-connectedTarget-or-cache'),
+    `android cache entry should have been found — got: ${JSON.stringify(androidData.hardResetSteps)}`,
+  );
+  assert.ok(
+    androidData.hardResetSteps.includes('skip-simctl:platform=android-not-yet-supported'),
+    `android cache hit should fall through to the android-not-supported skip — got: ${JSON.stringify(androidData.hardResetSteps)}`,
+  );
+
   const data = expectOk(await handler({ hardReset: true, platform: 'ios' }));
   assert.ok(
     !simctl.some((c) => c.includes('com.android.pkg')),
     `android package must never reach iOS simctl — got: ${JSON.stringify(simctl)}`,
   );
   assert.ok(data.hardResetSteps.includes('skip-simctl:no-bundleId-on-connectedTarget-or-cache'));
+});
+
+test('codex-pair Fix 1: explicit invalid bundleId arg fails fast, simctl never called', async () => {
+  const simctl = [];
+  const handler = harness({
+    execFile: async (cmd, args) => { simctl.push(args.join(' ')); return { stdout: '', stderr: '' }; },
+    stopFastRunner: () => {},
+    sleep: async () => {},
+    resolveBundleIdStrict: () => 'com.fallback.app',
+  });
+  const err = expectFail(await handler({ hardReset: true, bundleId: 'rm -rf /; echo pwned' }));
+  assert.match(err, /invalid bundleId argument/);
+  const env = parseEnvelope(await handler({ hardReset: true, bundleId: 'not a bundle' }));
+  assert.equal(env.code, 'INVALID_BUNDLE_ID');
+  assert.equal(simctl.length, 0, `simctl must never run with an invalid explicit bundleId — got: ${JSON.stringify(simctl)}`);
+});
+
+test('codex-pair Fix 1: invalid cached/config bundleId → skip-simctl step, never reaches simctl argv', async () => {
+  const simctl = [];
+  const handler = harness({
+    execFile: async (cmd, args) => { simctl.push(args.join(' ')); return { stdout: '', stderr: '' }; },
+    stopFastRunner: () => {},
+    sleep: async () => {},
+    // A corrupted app.json / config value resolved from a NON-arg source.
+    resolveBundleIdStrict: () => 'com.evil.app; rm -rf /',
+  });
+  const data = expectOk(await handler({ hardReset: true }));
+  assert.ok(
+    data.hardResetSteps.includes('skip-simctl:invalid-bundleId-from-cache-or-config'),
+    `expected the invalid-from-cache skip step — got: ${JSON.stringify(data.hardResetSteps)}`,
+  );
+  assert.equal(simctl.length, 0, `simctl must never run with an invalid resolved bundleId — got: ${JSON.stringify(simctl)}`);
+  // bundleId nulled out → omitted from the envelope (never echoed back as valid).
+  assert.equal(data.bundleId, undefined);
 });
 
 test('hardReset success resets the detached-recovery budget', async () => {

--- a/scripts/cdp-bridge/test/unit/gh-262-restart-fallback.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-262-restart-fallback.test.js
@@ -1,0 +1,135 @@
+// GH #262 (+ #194 BUG 2 residual): hardReset must not silently degrade to a
+// soft reset when the bundleId cache is empty — the chain is now
+// explicit arg > connectedTarget > cache > active-session appId > STRICT
+// app.json (per-platform, NO iOS←Android fallback: feeding an Android
+// package to iOS simctl would misreport APP_NOT_INSTALLED). simctl targets
+// the active session's UDID when one exists ('booted' otherwise), failed
+// launches are probe-classified, and a successful hardReset resets the
+// detached-recovery budget.
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createRestartHandler, _resetRestartHandlerStateForTest,
+} from '../../dist/tools/restart.js';
+import { expectOk } from '../helpers/result-helpers.js';
+
+beforeEach(() => {
+  _resetRestartHandlerStateForTest();
+});
+
+function makeMockClient({ port = 8081 } = {}) {
+  let connected = false;
+  return {
+    get metroPort() { return port; },
+    get isConnected() { return connected; },
+    // connectedTarget intentionally undefined: the fresh-process case.
+    disconnect: async () => {},
+    autoConnect: async () => { connected = true; return 'Connected to test'; },
+  };
+}
+
+function harness(deps) {
+  const oldClient = makeMockClient();
+  const newClient = makeMockClient();
+  let current = oldClient;
+  return createRestartHandler(
+    () => current,
+    (c) => { current = c; },
+    () => newClient,
+    { getSession: () => null, ...deps },
+  );
+}
+
+test('hardReset: empty cache + no session → strict app.json fallback, simctl on booted', async () => {
+  const simctl = [];
+  const handler = harness({
+    execFile: async (cmd, args) => { simctl.push(args.join(' ')); return { stdout: '', stderr: '' }; },
+    stopFastRunner: () => {},
+    sleep: async () => {},
+    resolveBundleIdStrict: (platform) => {
+      assert.equal(platform, 'ios');
+      return 'com.fallback.app';
+    },
+  });
+  const data = expectOk(await handler({ hardReset: true }));
+  assert.ok(simctl.some((c) => c === 'simctl terminate booted com.fallback.app'));
+  assert.ok(simctl.some((c) => c === 'simctl launch booted com.fallback.app'));
+  assert.ok(data.hardResetSteps.includes('simctl launch com.fallback.app:ok'));
+  assert.ok(!data.hardResetSteps.some((s) => s.startsWith('skip-simctl')));
+});
+
+test('hardReset: active iOS session appId outranks app.json; simctl targets the session UDID', async () => {
+  const simctl = [];
+  const handler = harness({
+    execFile: async (cmd, args) => { simctl.push(args.join(' ')); return { stdout: '', stderr: '' }; },
+    stopFastRunner: () => {},
+    sleep: async () => {},
+    getSession: () => ({ deviceId: 'UDID-S', appId: 'com.session.app', platform: 'ios' }),
+    resolveBundleIdStrict: () => 'com.fallback.app',
+  });
+  expectOk(await handler({ hardReset: true }));
+  assert.ok(simctl.some((c) => c === 'simctl terminate UDID-S com.session.app'), `got: ${simctl}`);
+  assert.ok(simctl.some((c) => c === 'simctl launch UDID-S com.session.app'));
+});
+
+test('hardReset: strict resolver also unresolvable → existing skip-simctl step (unchanged)', async () => {
+  const handler = harness({
+    execFile: async () => ({ stdout: '', stderr: '' }),
+    stopFastRunner: () => {},
+    sleep: async () => {},
+    resolveBundleIdStrict: () => null,
+  });
+  const data = expectOk(await handler({ hardReset: true }));
+  assert.ok(data.hardResetSteps.includes('skip-simctl:no-bundleId-on-connectedTarget-or-cache'));
+});
+
+test('hardReset: launch fails + probe FALSE → APP_NOT_INSTALLED step with quoted advice', async () => {
+  const handler = harness({
+    execFile: async (cmd, args) => {
+      if (args.includes('launch')) throw new Error('FBSOpenApplicationServiceErrorDomain, code=4');
+      return { stdout: '', stderr: '' };
+    },
+    stopFastRunner: () => {},
+    sleep: async () => {},
+    resolveBundleIdStrict: () => 'com.fallback.app',
+    probeAppInstalled: async (udid, appId) => {
+      assert.equal(udid, 'booted');
+      assert.equal(appId, 'com.fallback.app');
+      return false;
+    },
+    snapshotHint: () => ({ path: '/tmp/rn-appfile-snapshots/My App.app', ageMinutes: 3 }),
+  });
+  const data = expectOk(await handler({ hardReset: true }));
+  const step = data.hardResetSteps.find((s) => s.includes('APP_NOT_INSTALLED'));
+  assert.ok(step, `expected an APP_NOT_INSTALLED step, got: ${JSON.stringify(data.hardResetSteps)}`);
+  assert.match(step, /com\.fallback\.app is not installed/);
+  assert.match(step, /xcrun simctl install 'booted' '\/tmp\/rn-appfile-snapshots\/My App\.app'/);
+});
+
+test('hardReset: launch fails + probe NULL → raw launch:err step (fail open, unchanged)', async () => {
+  const handler = harness({
+    execFile: async (cmd, args) => {
+      if (args.includes('launch')) throw new Error('some transient failure');
+      return { stdout: '', stderr: '' };
+    },
+    stopFastRunner: () => {},
+    sleep: async () => {},
+    resolveBundleIdStrict: () => 'com.fallback.app',
+    probeAppInstalled: async () => null,
+  });
+  const data = expectOk(await handler({ hardReset: true }));
+  assert.ok(data.hardResetSteps.some((s) => s.startsWith('simctl launch:err(') && !s.includes('APP_NOT_INSTALLED')));
+});
+
+test('hardReset success resets the detached-recovery budget', async () => {
+  let resets = 0;
+  const handler = harness({
+    execFile: async () => ({ stdout: '', stderr: '' }),
+    stopFastRunner: () => {},
+    sleep: async () => {},
+    resolveBundleIdStrict: () => 'com.fallback.app',
+    resetDetachedBudget: () => { resets += 1; },
+  });
+  expectOk(await handler({ hardReset: true }));
+  assert.equal(resets, 1, 'a successful manual hard reset is a working recovery — budget must reset');
+});

--- a/scripts/cdp-bridge/test/unit/gh-262-restart-fallback.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-262-restart-fallback.test.js
@@ -121,6 +121,45 @@ test('hardReset: launch fails + probe NULL → raw launch:err step (fail open, u
   assert.ok(data.hardResetSteps.some((s) => s.startsWith('simctl launch:err(') && !s.includes('APP_NOT_INSTALLED')));
 });
 
+test('hardReset: android-cached bundleId is NOT used for an iOS target (platform-keyed cache)', async () => {
+  // 1st restart: android connectedTarget populates the cache.
+  const androidClient = {
+    get metroPort() { return 8081; },
+    get isConnected() { return false; },
+    connectedTarget: { description: 'com.android.pkg', platform: 'android' },
+    disconnect: async () => {},
+    autoConnect: async () => 'Connected',
+  };
+  const plainClient = {
+    get metroPort() { return 8081; },
+    get isConnected() { return false; },
+    disconnect: async () => {},
+    autoConnect: async () => 'Connected',
+  };
+  let current = androidClient;
+  const simctl = [];
+  const handler = createRestartHandler(
+    () => current,
+    (c) => {},
+    () => plainClient,
+    {
+      getSession: () => null,
+      execFile: async (cmd, args) => { simctl.push(args.join(' ')); return { stdout: '', stderr: '' }; },
+      stopFastRunner: () => {},
+      sleep: async () => {},
+      resolveBundleIdStrict: () => null,
+    },
+  );
+  await handler({}); // android-flavored soft restart populates the cache
+  current = plainClient; // fresh-process-like state: no connectedTarget
+  const data = expectOk(await handler({ hardReset: true, platform: 'ios' }));
+  assert.ok(
+    !simctl.some((c) => c.includes('com.android.pkg')),
+    `android package must never reach iOS simctl — got: ${JSON.stringify(simctl)}`,
+  );
+  assert.ok(data.hardResetSteps.includes('skip-simctl:no-bundleId-on-connectedTarget-or-cache'));
+});
+
 test('hardReset success resets the detached-recovery budget', async () => {
   let resets = 0;
   const handler = harness({

--- a/scripts/cdp-bridge/test/unit/gh-262-restart-fallback.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-262-restart-fallback.test.js
@@ -64,12 +64,78 @@ test('hardReset: active iOS session appId outranks app.json; simctl targets the 
     execFile: async (cmd, args) => { simctl.push(args.join(' ')); return { stdout: '', stderr: '' }; },
     stopFastRunner: () => {},
     sleep: async () => {},
-    getSession: () => ({ deviceId: 'UDID-S', appId: 'com.session.app', platform: 'ios' }),
+    getSession: () => ({ deviceId: 'F1A2B3C4-1111-2222-3333-444455556666', appId: 'com.session.app', platform: 'ios' }),
     resolveBundleIdStrict: () => 'com.fallback.app',
   });
   expectOk(await handler({ hardReset: true }));
-  assert.ok(simctl.some((c) => c === 'simctl terminate UDID-S com.session.app'), `got: ${simctl}`);
-  assert.ok(simctl.some((c) => c === 'simctl launch UDID-S com.session.app'));
+  assert.ok(simctl.some((c) => c === 'simctl terminate F1A2B3C4-1111-2222-3333-444455556666 com.session.app'), `got: ${simctl}`);
+  assert.ok(simctl.some((c) => c === 'simctl launch F1A2B3C4-1111-2222-3333-444455556666 com.session.app'));
+});
+
+test('codex-pair Fix 1: active session appId outranks the (stale) cache', async () => {
+  // 1st restart: an iOS connectedTarget populates the cache with the OLD app.
+  const oldAppClient = {
+    get metroPort() { return 8081; },
+    get isConnected() { return false; },
+    connectedTarget: { description: 'com.old.app', platform: 'ios' },
+    disconnect: async () => {},
+    autoConnect: async () => 'Connected',
+  };
+  const plainClient = {
+    get metroPort() { return 8081; },
+    get isConnected() { return false; },
+    disconnect: async () => {},
+    autoConnect: async () => 'Connected',
+  };
+  let current = oldAppClient;
+  const simctl = [];
+  let session = null;
+  const handler = createRestartHandler(
+    () => current,
+    () => {},
+    () => plainClient,
+    {
+      getSession: () => session,
+      execFile: async (cmd, args) => { simctl.push(args.join(' ')); return { stdout: '', stderr: '' }; },
+      stopFastRunner: () => {},
+      sleep: async () => {},
+      resolveBundleIdStrict: () => null,
+    },
+  );
+  // Soft restart through the old-app client → cache now holds com.old.app (ios).
+  expectOk(await handler({}));
+  // Switch apps in the same bridge process: no connectedTarget, but a live
+  // session pointing at the CURRENT app.
+  current = plainClient;
+  session = { deviceId: 'F1A2B3C4-1111-2222-3333-444455556666', appId: 'com.current.app', platform: 'ios' };
+
+  expectOk(await handler({ hardReset: true }));
+  assert.ok(
+    simctl.some((c) => c === 'simctl launch F1A2B3C4-1111-2222-3333-444455556666 com.current.app'),
+    `session appId must outrank the stale cache — got: ${JSON.stringify(simctl)}`,
+  );
+  assert.ok(
+    !simctl.some((c) => c.includes('com.old.app')),
+    `stale cached app.id must NOT reach simctl — got: ${JSON.stringify(simctl)}`,
+  );
+});
+
+test('codex-pair Fix 2: malformed session deviceId falls back to booted (never reaches simctl argv)', async () => {
+  const simctl = [];
+  const handler = harness({
+    execFile: async (cmd, args) => { simctl.push(args.join(' ')); return { stdout: '', stderr: '' }; },
+    stopFastRunner: () => {},
+    sleep: async () => {},
+    getSession: () => ({ deviceId: 'evil; rm -rf /', appId: 'com.session.app', platform: 'ios' }),
+    resolveBundleIdStrict: () => 'com.fallback.app',
+  });
+  expectOk(await handler({ hardReset: true }));
+  // bundleId from the session is still trusted; only the deviceId is rejected.
+  assert.ok(simctl.some((c) => c === 'simctl launch booted com.session.app'), `got: ${JSON.stringify(simctl)}`);
+  assert.ok(
+    !simctl.some((c) => c.includes('evil')),
+    `malformed deviceId must never reach simctl argv — got: ${JSON.stringify(simctl)}`,
+  );
 });
 
 test('hardReset: strict resolver also unresolvable → existing skip-simctl step (unchanged)', async () => {
@@ -83,7 +149,7 @@ test('hardReset: strict resolver also unresolvable → existing skip-simctl step
   assert.ok(data.hardResetSteps.includes('skip-simctl:no-bundleId-on-connectedTarget-or-cache'));
 });
 
-test('hardReset: launch fails + probe FALSE → APP_NOT_INSTALLED step with quoted advice', async () => {
+test('hardReset: launch fails + probe FALSE → typed APP_NOT_INSTALLED failure (advice as error, steps in meta)', async () => {
   const handler = harness({
     execFile: async (cmd, args) => {
       if (args.includes('launch')) throw new Error('FBSOpenApplicationServiceErrorDomain, code=4');
@@ -99,11 +165,18 @@ test('hardReset: launch fails + probe FALSE → APP_NOT_INSTALLED step with quot
     },
     snapshotHint: () => ({ path: '/tmp/rn-appfile-snapshots/My App.app', ageMinutes: 3 }),
   });
-  const data = expectOk(await handler({ hardReset: true }));
-  const step = data.hardResetSteps.find((s) => s.includes('APP_NOT_INSTALLED'));
-  assert.ok(step, `expected an APP_NOT_INSTALLED step, got: ${JSON.stringify(data.hardResetSteps)}`);
-  assert.match(step, /com\.fallback\.app is not installed/);
-  assert.match(step, /xcrun simctl install 'booted' '\/tmp\/rn-appfile-snapshots\/My App\.app'/);
+  const result = await handler({ hardReset: true });
+  // A confirmed-missing bundle is the primary error, not a buried step.
+  const error = expectFail(result);
+  assert.match(error, /com\.fallback\.app is not installed/);
+  assert.match(error, /xcrun simctl install 'booted' '\/tmp\/rn-appfile-snapshots\/My App\.app'/);
+  const env = parseEnvelope(result);
+  assert.equal(env.code, 'APP_NOT_INSTALLED');
+  // hardResetSteps stays complete in meta — the launch:err step is recorded
+  // before we return.
+  const steps = env.meta?.hardResetSteps;
+  assert.ok(Array.isArray(steps), `expected hardResetSteps in meta, got: ${JSON.stringify(env.meta)}`);
+  assert.ok(steps.some((s) => s.includes('APP_NOT_INSTALLED')), `got: ${JSON.stringify(steps)}`);
 });
 
 test('hardReset: launch fails + probe NULL → raw launch:err step (fail open, unchanged)', async () => {

--- a/scripts/cdp-bridge/test/unit/gh-262-status-not-installed.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-262-status-not-installed.test.js
@@ -1,0 +1,101 @@
+// GH #262: when detached-recovery reports 'app-not-installed', cdp_status
+// returns the distinct APP_NOT_INSTALLED code with install advice (incl. a
+// shell-quoted snapshot reinstall line when a hint exists) — instead of the
+// generic APP_DETACHED "relaunch manually / hardReset" advice that can never
+// work for a missing bundle. status.ts also injects the tools-layer
+// snapshotHint implementation into the recovery deps (layering rule).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createMockClient } from '../helpers/mock-cdp-client.js';
+import { parseEnvelope } from '../helpers/result-helpers.js';
+import { createStatusHandler } from '../../dist/tools/status.js';
+import { AppDetachedError } from '../../dist/cdp/discovery.js';
+import {
+  _setHasSessionForTest,
+  _resetHasSessionForTest,
+} from '../../dist/tools/dev-client-picker.js';
+
+function makeDetachedClient() {
+  return createMockClient({
+    _isConnected: false,
+    _helpersInjected: true,
+    reconnectState: { active: false, lastAttempt: null, attemptCount: 0 },
+    autoConnect: async () => { throw new AppDetachedError(8081); },
+  });
+}
+
+function makeHandler(recovery, capture) {
+  const client = makeDetachedClient();
+  return createStatusHandler(() => client, () => {}, () => client, {
+    recoverDetached: async (c, rdeps) => { if (capture) capture(rdeps); return recovery; },
+  });
+}
+
+test('cdp_status: app-not-installed → APP_NOT_INSTALLED with quoted snapshot advice', async () => {
+  _setHasSessionForTest(false);
+  try {
+    const handler = makeHandler({
+      recovered: false,
+      reason: 'app-not-installed',
+      attempt: 1,
+      error: 'FBSOpenApplicationServiceErrorDomain, code=4',
+      udid: 'UDID-A',
+      appId: 'com.example.app',
+      snapshotHint: { path: '/tmp/rn-appfile-snapshots/My App.app', ageMinutes: 7 },
+    });
+    const env = parseEnvelope(await handler({}));
+    assert.equal(env.ok, false);
+    assert.equal(env.code, 'APP_NOT_INSTALLED');
+    assert.match(env.error, /com\.example\.app is not installed on simulator UDID-A/);
+    assert.match(env.error, /7 min ago/);
+    assert.match(env.error, /xcrun simctl install 'UDID-A' '\/tmp\/rn-appfile-snapshots\/My App\.app'/);
+    assert.equal(env.meta.recovery.reason, 'app-not-installed');
+  } finally {
+    _resetHasSessionForTest();
+  }
+});
+
+test('cdp_status: app-not-installed without hint → rebuild advice, no install line', async () => {
+  _setHasSessionForTest(false);
+  try {
+    const handler = makeHandler({
+      recovered: false,
+      reason: 'app-not-installed',
+      attempt: 1,
+      udid: 'UDID-A',
+      appId: 'com.example.app',
+    });
+    const env = parseEnvelope(await handler({}));
+    assert.equal(env.code, 'APP_NOT_INSTALLED');
+    assert.match(env.error, /npx expo run:ios/);
+    assert.doesNotMatch(env.error, /simctl install/);
+  } finally {
+    _resetHasSessionForTest();
+  }
+});
+
+test('cdp_status: injects a tools-layer snapshotHint fn into the recovery deps', async () => {
+  _setHasSessionForTest(false);
+  try {
+    let rdeps;
+    const handler = makeHandler(
+      { recovered: false, reason: 'still-detached', attempt: 1 },
+      (d) => { rdeps = d; },
+    );
+    await handler({});
+    assert.equal(typeof rdeps?.snapshotHint, 'function', 'status.ts must inject snapshotHint (layering rule)');
+  } finally {
+    _resetHasSessionForTest();
+  }
+});
+
+test('cdp_status: still-detached keeps the existing APP_DETACHED code (no regression)', async () => {
+  _setHasSessionForTest(false);
+  try {
+    const handler = makeHandler({ recovered: false, reason: 'still-detached', attempt: 1 });
+    const env = parseEnvelope(await handler({}));
+    assert.equal(env.code, 'APP_DETACHED');
+  } finally {
+    _resetHasSessionForTest();
+  }
+});


### PR DESCRIPTION
## Summary

Recovery paths now tell the truth when the app bundle is missing, instead of looping on advice that cannot work (the issue's reporter "burned several recovery attempts" on it).

- **`cdp_status` APP_DETACHED auto-relaunch:** when `simctl launch` fails AND `get_app_container`'s stderr carries the `NSPOSIXErrorDomain code=2` marker (allowlist-only, **stderr-only** — argv-spoof-proof), the tool returns a distinct **`APP_NOT_INSTALLED`** code with install advice, including a shell-quoted `simctl install` line for the newest matching `.app` snapshot from the last clearState (#201 dir, mtime-sorted budgeted scan). Ambiguous probe verdicts **fail open** to the existing `APP_DETACHED` behavior — a wrong "not installed" is never reachable without proof.
- **Recovery robustness:** concurrent recoveries are serialized (followers share the leader's verdict); a confirmed missing bundle is cached per `(udid, appId)` with a cheap re-probe self-heal, so the diagnosis is never masked by `budget-exhausted` and a user reinstall resumes normal recovery.
- **`cdp_restart hardReset=true`** (closes the #194 BUG 2 residual): the relaunch target resolves through `explicit arg > connectedTarget > platform-keyed cache > active-session appId > strict per-platform app.json` (no iOS←Android fallback), every resolved id is validated by the central bundle-ID validator before reaching simctl, simctl targets the active session's UDID when one exists, failed launches are probe-classified into `hardResetSteps`, and a successful hard reset resets the detached-recovery budget.

## Live gate (real simulator, new dist — iPhone 17 Pro)

```
PASS: probe(missing bundle) === false
PASS: probe(installed com.apple.Bridge) === true
PASS: probe(invalid udid) === null
PASS: recoverDetached → 'app-not-installed' — FBSOpenApplicationServiceErrorDomain code=4 repro resolved in 372ms
PASS: cached second call → app-not-installed, no relaunch — 147ms
PASS: advice names bundle + sim + rebuild path
GATE: ALL PASS
```

## Review trail

- Spec + TDD plan multi-LLM-reviewed before code (Antigravity + Codex; FIX-FIRST findings applied: stderr-only classification, strict resolver, mtime-sort-before-cap, serialization, terminal cache, tool-layer hint injection).
- Per-task spec-compliance + quality reviews (subagent-driven), final holistic review: ready.
- Post-implementation `/multi-review`: both providers **SHIP**; the one surviving IMPORTANT (platform-agnostic `lastSeenBundleId` cache) fixed in `ae79cc0` with a failing-first regression test.
- codex-pair per-edit findings across 6 rounds all addressed (incl. strict bundleId validation, `INVALID_BUNDLE_ID` code).
- Tests: **2025/2025** (`test:all`), +~30 new.

## Noted follow-ups (pre-existing behavior, deliberately not changed here)

- `targetPlatform` precedence: `connectedTarget` still outranks an explicit `args.platform` (pre-existing semantics; changing it interacts with cache-write keying).
- `stopFastRunner()` runs for Android-targeted hardResets too (pre-existing; harmless iOS-runner teardown).
- Session-UDID liveness: a lingering session pointing at a shutdown sim wastes two simctl calls before the truthful raw error (degrades gracefully; probe correctly returns `null` for `code=405`).
- Probe marker tokens match independently across multi-line stderr (no real repro constructible; fail-open + re-probe bound the risk; anchoring is optional hardening).

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)