### PR TITLE
fix(#266): report telemetry staleness honestly in /send-feedback collector

### DIFF
--- a/.changeset/gh-266-feedback-telemetry-staleness.md
+++ b/.changeset/gh-266-feedback-telemetry-staleness.md
@@ -1,0 +1,7 @@
+---
+"rn-dev-agent-plugin": patch
+---
+
+`/send-feedback` no longer presents weeks-old telemetry as "recent" (GH #266).
+
+Root cause: the per-tool-call telemetry writer was removed with the Experience Engine (GH #200, v0.49 era), but `collect-feedback.sh` kept reading the orphaned `~/.claude/rn-agent/telemetry/*.jsonl` files and shipped their tail as "Recent Tool Activity" in filed issues. The collector now cross-checks the newest event's age: fresh events (<24h, legacy plugin versions still writing) ship as before with `telemetry_status: "ok"`; otherwise events are omitted and `telemetry_status` reports `stale (last event N days ago — …)` or `none` explicitly. The `/send-feedback` issue template renders the status line instead of an empty/misleading activity table, and the empty-telemetry edge no longer emits a single bogus `{}` event.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
       - name: SessionStart bounded-startup guard
         run: bash scripts/test/session-start-bounded.test.sh
 
+      # GH#266: feedback collector must not present stale/orphaned telemetry as recent.
+      - name: Feedback telemetry staleness guard
+        run: bash scripts/test/telemetry-staleness.test.sh
+
   version-sync:
     name: Version sync check
     runs-on: ubuntu-latest

--- a/commands/send-feedback.md
+++ b/commands/send-feedback.md
@@ -46,7 +46,7 @@ This collects (all redacted):
 - OS, Node.js, npm versions
 - Simulator/emulator status, Metro status
 - agent-device and maestro-runner versions
-- Last 20 telemetry events (tool name, result, latency — no params or paths)
+- Last 20 telemetry events ONLY when fresh (<24h; tool name, result, latency — no params or paths), plus `telemetry_status` (`ok` / `stale (...)` / `none`). On current plugin versions `stale`/`none` is expected — per-tool-call telemetry capture was removed with the Experience Engine (GH #200); only legacy versions still write it.
 
 Also call `cdp_status` to get current CDP connection state (if available).
 
@@ -116,7 +116,7 @@ gh issue create \
 
 ## Recent Tool Activity
 
-<table of last 5 tool calls with result and latency>
+<ONLY if recent_telemetry_lines is non-empty: table of last 5 tool calls with result and latency. Otherwise render the telemetry_status value verbatim on one line (e.g. "Telemetry: none" or the stale explanation) — never present old events as recent (GH #266).>
 
 ## CDP State at Time of Report
 

--- a/scripts/collect-feedback.sh
+++ b/scripts/collect-feedback.sh
@@ -96,17 +96,25 @@ fi
 recent_telemetry="[]"
 telemetry_status="none"
 if [ -d "$TELEMETRY_DIR" ]; then
-  latest_log=$(ls -t "$TELEMETRY_DIR"/*.jsonl 2>/dev/null | head -1)
+  # `|| true`: an empty dir makes the unmatched glob fail `ls`, and under
+  # `set -euo pipefail` that used to kill the WHOLE collector (zero JSON).
+  latest_log=$(ls -t "$TELEMETRY_DIR"/*.jsonl 2>/dev/null | head -1 || true)
   if [ -n "$latest_log" ]; then
     age_days=$(python3 -c "import os,sys,time; print(int((time.time()-os.path.getmtime(sys.argv[1]))//86400))" "$latest_log" 2>/dev/null || echo "")
-    if [ -n "$age_days" ] && [ "$age_days" -lt 1 ] 2>/dev/null; then
+    # `-ge 0`: a future mtime (clock skew, fs restore) yields a negative age
+    # and must not count as fresh.
+    if [ -n "$age_days" ] && [ "$age_days" -ge 0 ] 2>/dev/null && [ "$age_days" -lt 1 ] 2>/dev/null; then
       telemetry_status="ok"
       raw=$(tail -20 "$latest_log" 2>/dev/null || echo "")
       if [ -n "$raw" ]; then
         recent_telemetry=$(redact "$raw")
       fi
     else
-      telemetry_status="stale (last event ${age_days:-unknown} days ago — telemetry capture is not active in this plugin version; it was removed with the Experience Engine, GH #200. Old events omitted.)"
+      case "$age_days" in
+        ''|-*) age_label="unknown";;
+        *) age_label="$age_days";;
+      esac
+      telemetry_status="stale (last event ${age_label} day(s) ago — telemetry capture is not active in this plugin version; it was removed with the Experience Engine, GH #200. Old events omitted.)"
     fi
   fi
 fi

--- a/scripts/collect-feedback.sh
+++ b/scripts/collect-feedback.sh
@@ -87,14 +87,26 @@ elif curl -s --max-time 2 http://localhost:8082/status 2>/dev/null | grep -q "pa
 fi
 
 # --- Collect recent telemetry (last 20 events, redacted) ---
+# GH #266: the per-tool-call telemetry writer was removed with the Experience
+# Engine (GH #200), so on current plugin versions these files stop updating.
+# Cross-check the newest event's age against now and only ship events that are
+# actually recent (<24h, e.g. a legacy plugin version still writing); report
+# staleness explicitly instead of presenting weeks-old events as current.
 
 recent_telemetry="[]"
+telemetry_status="none"
 if [ -d "$TELEMETRY_DIR" ]; then
   latest_log=$(ls -t "$TELEMETRY_DIR"/*.jsonl 2>/dev/null | head -1)
   if [ -n "$latest_log" ]; then
-    raw=$(tail -20 "$latest_log" 2>/dev/null || echo "")
-    if [ -n "$raw" ]; then
-      recent_telemetry=$(redact "$raw")
+    age_days=$(python3 -c "import os,sys,time; print(int((time.time()-os.path.getmtime(sys.argv[1]))//86400))" "$latest_log" 2>/dev/null || echo "")
+    if [ -n "$age_days" ] && [ "$age_days" -lt 1 ] 2>/dev/null; then
+      telemetry_status="ok"
+      raw=$(tail -20 "$latest_log" 2>/dev/null || echo "")
+      if [ -n "$raw" ]; then
+        recent_telemetry=$(redact "$raw")
+      fi
+    else
+      telemetry_status="stale (last event ${age_days:-unknown} days ago — telemetry capture is not active in this plugin version; it was removed with the Experience Engine, GH #200. Old events omitted.)"
     fi
   fi
 fi
@@ -147,6 +159,8 @@ for line in lines:
         continue
     try:
         e = json.loads(line)
+        if not isinstance(e, dict):
+            continue
         safe = {k: e[k] for k in ['ts','event','tool','result','latency_ms','phase'] if k in e}
         events.append(safe)
     except:
@@ -171,6 +185,7 @@ data = {
         'maestro_runner': sys.argv[11],
     },
     'recent_telemetry_lines': json.loads(sys.argv[12]),
+    'telemetry_status': sys.argv[14],
 }
 log_tail = sys.argv[13].strip()
 if log_tail:
@@ -189,4 +204,5 @@ print(json.dumps(data, indent=2))
   "$agent_device_version" \
   "$maestro_runner_version" \
   "$telemetry_json" \
-  "$cdp_log_tail"
+  "$cdp_log_tail" \
+  "$telemetry_status"

--- a/scripts/test/telemetry-staleness.test.sh
+++ b/scripts/test/telemetry-staleness.test.sh
@@ -31,6 +31,11 @@ run_collect() { # $1=fake home
   HOME="$1" CLAUDE_PLUGIN_DATA="$1/plugin-data" bash "$COLLECT" 2>/dev/null
 }
 
+# make_home runs inside $(...) subshells, so cleanup state can't be
+# accumulated there — the trap references the parent-scope home vars instead
+# (":-" keeps `set -u` happy for homes not yet created at failure time).
+trap 'rm -rf "${home1:-}" "${home2:-}" "${home3:-}" "${home4:-}" "${home5:-}"' EXIT
+
 make_home() {
   local h
   h="$(mktemp -d)"
@@ -85,7 +90,30 @@ count3="$(get_field "$out3" "len(d.get('recent_telemetry_lines',[]))")"
 check "fresh: telemetry_status ok" "$status3" "ok"
 check "fresh: events ARE shipped" "$count3" "1"
 
-rm -rf "$home1" "$home2" "$home3"
+# ── Case 4: telemetry dir exists but is EMPTY (manual cleanup) ──────
+# Pre-existing hazard surfaced in the #266 review: the unmatched glob made
+# `ls` fail and, under `set -euo pipefail`, killed the WHOLE collector —
+# /send-feedback got zero JSON. Must degrade to status "none" instead.
+home4="$(make_home)"
+mkdir -p "$home4/.claude/rn-agent/telemetry"
+out4="$(run_collect "$home4")"
+status4="$(get_field "$out4" "d.get('telemetry_status','<missing>')")"
+check "empty dir: collector survives and reports none" "$status4" "none"
+
+# ── Case 5: future mtime (clock skew / filesystem restore) ──────────
+# A negative age must never count as fresh (it would ship stale events).
+home5="$(make_home)"
+tdir5="$home5/.claude/rn-agent/telemetry"
+mkdir -p "$tdir5"
+cat > "$tdir5/skewed-session.jsonl" <<'EOF'
+{"ts":"2031-01-01T00:00:00.000Z","event":"tool_call","tool":"cdp_status","result":"PASS","latency_ms":3,"phase":"tool"}
+EOF
+touch -t 203101010000 "$tdir5/skewed-session.jsonl"
+out5="$(run_collect "$home5")"
+status5="$(get_field "$out5" "d.get('telemetry_status','<missing>')")"
+count5="$(get_field "$out5" "len(d.get('recent_telemetry_lines',['sentinel']))")"
+check "future mtime: not treated as fresh" "$status5" "stale"
+check "future mtime: no events shipped" "$count5" "0"
 
 if [ "$fail" -ne 0 ]; then
   echo "telemetry-staleness.test.sh: FAILURES"

--- a/scripts/test/telemetry-staleness.test.sh
+++ b/scripts/test/telemetry-staleness.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Regression test for collect-feedback.sh telemetry staleness (GH #266).
+#
+# The per-tool-call telemetry writer was removed with the Experience Engine
+# (GH #200, commit 3beb8e52, 2026-06-01), but collect-feedback.sh kept reading
+# the orphaned ~/.claude/rn-agent/telemetry/*.jsonl files and presented
+# weeks-old events as "recent" in filed feedback issues. The collector must
+# cross-check the newest event's age against now and report honestly:
+#   - fresh (<24h, legacy writer still active) → telemetry_status "ok" + events
+#   - stale (>=24h)                            → "stale (...)" + NO events
+#   - absent (no dir / no files)               → "none" + NO events
+#
+# End-to-end: fake $HOME with planted telemetry files, run the real script,
+# assert on the emitted JSON.
+#
+# Run: bash scripts/test/telemetry-staleness.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+COLLECT="$SCRIPT_DIR/collect-feedback.sh"
+
+fail=0
+
+# jq-free JSON assertions via python3 (already a hard dependency of the script).
+get_field() { # $1=json $2=python expr over `d`
+  printf '%s' "$1" | python3 -c "import json,sys; d=json.load(sys.stdin); print($2)" 2>/dev/null
+}
+
+run_collect() { # $1=fake home
+  HOME="$1" CLAUDE_PLUGIN_DATA="$1/plugin-data" bash "$COLLECT" 2>/dev/null
+}
+
+make_home() {
+  local h
+  h="$(mktemp -d)"
+  mkdir -p "$h/plugin-data"
+  printf '%s' "$h"
+}
+
+check() { # $1=label $2=actual $3=expected-prefix
+  case "$2" in
+    "$3"*) echo "ok: $1 ($2)";;
+    *) echo "FAIL: $1 — expected prefix '$3', got '$2'"; fail=1;;
+  esac
+}
+
+# ── Case 1: stale telemetry (the GH #266 repro) ─────────────────────
+home1="$(make_home)"
+tdir1="$home1/.claude/rn-agent/telemetry"
+mkdir -p "$tdir1"
+cat > "$tdir1/2026-05-31-session-1234.jsonl" <<'EOF'
+{"ts":"2026-05-31T18:44:32.560Z","event":"tool_call","tool":"cdp_status","result":"PASS","latency_ms":1,"phase":"tool"}
+EOF
+# Backdate mtime far past the 24h threshold (portable across BSD/GNU touch).
+touch -t 202605311844 "$tdir1/2026-05-31-session-1234.jsonl"
+
+out1="$(run_collect "$home1")"
+status1="$(get_field "$out1" "d.get('telemetry_status','<missing>')")"
+count1="$(get_field "$out1" "len(d.get('recent_telemetry_lines',['sentinel']))")"
+check "stale: telemetry_status flags staleness" "$status1" "stale"
+check "stale: status names the age in days" "$status1" "stale (last event"
+check "stale: old events are NOT shipped as recent" "$count1" "0"
+
+# ── Case 2: no telemetry at all (fresh install post-#200) ───────────
+home2="$(make_home)"
+out2="$(run_collect "$home2")"
+status2="$(get_field "$out2" "d.get('telemetry_status','<missing>')")"
+count2="$(get_field "$out2" "len(d.get('recent_telemetry_lines',['sentinel']))")"
+check "none: telemetry_status reports none" "$status2" "none"
+check "none: no events shipped" "$count2" "0"
+
+# ── Case 3: fresh telemetry (legacy writer still active) ────────────
+home3="$(make_home)"
+tdir3="$home3/.claude/rn-agent/telemetry"
+mkdir -p "$tdir3"
+cat > "$tdir3/current-session.jsonl" <<'EOF'
+{"ts":"2026-06-12T12:00:00.000Z","event":"tool_call","tool":"cdp_status","result":"PASS","latency_ms":2,"phase":"tool"}
+EOF
+# mtime = now (just written) → fresh.
+
+out3="$(run_collect "$home3")"
+status3="$(get_field "$out3" "d.get('telemetry_status','<missing>')")"
+count3="$(get_field "$out3" "len(d.get('recent_telemetry_lines',[]))")"
+check "fresh: telemetry_status ok" "$status3" "ok"
+check "fresh: events ARE shipped" "$count3" "1"
+
+rm -rf "$home1" "$home2" "$home3"
+
+if [ "$fail" -ne 0 ]; then
+  echo "telemetry-staleness.test.sh: FAILURES"
+  exit 1
+fi
+echo "telemetry-staleness.test.sh: all assertions passed"


### PR DESCRIPTION
## Summary

`rn-collect-feedback` presented telemetry events from **2026-05-31** as "Recent Tool Activity" despite weeks of heavy plugin usage since (GH #266).

**Root cause** — telemetry capture didn't break, it was **removed by design**: commit `3beb8e52` (PR #203, closes #200) deleted the Experience Engine including `src/experience/telemetry.ts`, the per-tool-call writer of `~/.claude/rn-agent/telemetry/*.jsonl`. The collector was never updated and kept tailing the orphaned files. Disk evidence matches exactly: newest file is May 31 20:44 — the writer's last day alive.

## Fix — collector honesty, not writer resurrection

Re-adding per-call telemetry would silently reverse the #200 architecture decision under cover of a bugfix, so the scope is the consumer:

- `collect-feedback.sh` cross-checks the newest event's age. Fresh (`0 <= age < 1 day`, e.g. a legacy plugin version still writing) → `telemetry_status: "ok"` + events as before. Otherwise events are **omitted** and `telemetry_status` reports `stale (last event N day(s) ago — …)` or `none` explicitly — exactly what the issue requested.
- `/send-feedback` template renders the status line when no fresh events exist — never an empty or misleading activity table.
- Empty-telemetry edge no longer emits a bogus `[{}]` event (the `"[]"` placeholder passed through the dict filter).

Hardening from the multi-LLM review round (both verdicts SHIP):
- An **empty** telemetry dir used to kill the whole collector under `set -euo pipefail` (unmatched glob → `ls` fails → zero JSON; verified live). Now degrades to `"none"`.
- A **future mtime** (clock skew / fs restore) yielded a negative age that counted as fresh; fresh now requires `age >= 0`.

## Verification

- TDD throughout: `scripts/test/telemetry-staleness.test.sh` (10 assertions: stale / none / fresh / empty-dir / future-mtime), each watched fail first; registered as a CI step.
- Live repro on the reporting machine's real orphaned files: collector now emits `stale (last event 11 day(s) ago — …)` with 0 events.
- `redact.test.sh` (collector security regression) still passes.
- Changeset bumps `rn-dev-agent-plugin` only — no cdp-bridge code touched.

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)