### PR TITLE
fix(#209): cdp_mmkv delete + boolean get against the real Nitro hybrid-object API

### DIFF
--- a/.changeset/gh-209-mmkv-nitro-remove.md
+++ b/.changeset/gh-209-mmkv-nitro-remove.md
@@ -1,0 +1,10 @@
+---
+"rn-dev-agent-cdp": patch
+"rn-dev-agent-plugin": patch
+---
+
+`cdp_mmkv` delete and boolean reads now work on the Nitro react-native-mmkv line (GH #209).
+
+- `delete` was calling `mmkv.delete(key)` — a JS-wrapper-class method that doesn't exist on the raw Nitro hybrid object the tool actually talks to (`createHybridObject('MMKVFactory').createMMKV(...)`), whose spec exposes `remove(key)`. The generated expression now prefers `remove()`, falls back to `delete()` for wrapper-shaped objects, and reports a named error (instead of a bare TypeError) when neither exists. This unblocks first-class auth/storage resets for logged-out replays on iOS — previously a raw `cdp_evaluate` escape hatch every time.
+- `get` with `type: 'boolean'` emitted `mmkv.getBool(key)`, which exists on no MMKV surface (hybrid object and wrapper both spell it `getBoolean`) — broken since the tool shipped. Now fixed.
+- The follow-up enhancement from the issue (a `clearKeys:` action-YAML directive for self-contained auth-gated replays) is tracked as GH #286.

--- a/scripts/cdp-bridge/dist/tools/mmkv.js
+++ b/scripts/cdp-bridge/dist/tools/mmkv.js
@@ -20,8 +20,12 @@ export function buildMmkvExpression(args) {
             if (typeof args.key !== 'string' || args.key.length === 0) {
                 return `JSON.stringify({ __agent_error: 'get requires non-empty key' })`;
             }
+            // GH #209: `getBoolean` — the spelling on BOTH the Nitro hybrid object
+            // (MMKV.nitro.ts) and the JS wrapper class. The previous `getBool`
+            // existed on neither; type=boolean reads were broken since the tool
+            // shipped.
             const getMethod = valueType === 'number' ? 'getNumber' :
-                valueType === 'boolean' ? 'getBool' : 'getString';
+                valueType === 'boolean' ? 'getBoolean' : 'getString';
             actionBody = `var v = mmkv.${getMethod}(${JSON.stringify(args.key)}); return JSON.stringify({ value: v === undefined ? null : v });`;
             break;
         }
@@ -51,7 +55,14 @@ export function buildMmkvExpression(args) {
             if (typeof args.key !== 'string' || args.key.length === 0) {
                 return `JSON.stringify({ __agent_error: 'delete requires non-empty key' })`;
             }
-            actionBody = `mmkv.delete(${JSON.stringify(args.key)}); return JSON.stringify({ ok: true });`;
+            // GH #209: the raw Nitro hybrid object (v4 / 3.0-beta line) exposes
+            // `remove(key)` per MMKV.nitro.ts — `delete(key)` only exists on the JS
+            // wrapper class. Prefer the spec name, fall back to the wrapper name,
+            // and fail with a named error instead of a bare TypeError.
+            actionBody = `if (typeof mmkv.remove === 'function') { mmkv.remove(${JSON.stringify(args.key)}); }
+      else if (typeof mmkv.delete === 'function') { mmkv.delete(${JSON.stringify(args.key)}); }
+      else { return JSON.stringify({ __agent_error: 'MMKV instance has neither remove() nor delete() — unexpected API surface; report the react-native-mmkv version' }); }
+      return JSON.stringify({ ok: true });`;
             break;
         }
         case 'has': {

--- a/scripts/cdp-bridge/src/tools/mmkv.ts
+++ b/scripts/cdp-bridge/src/tools/mmkv.ts
@@ -45,9 +45,13 @@ export function buildMmkvExpression(args: MmkvArgs): string {
       if (typeof args.key !== 'string' || args.key.length === 0) {
         return `JSON.stringify({ __agent_error: 'get requires non-empty key' })`;
       }
+      // GH #209: `getBoolean` — the spelling on BOTH the Nitro hybrid object
+      // (MMKV.nitro.ts) and the JS wrapper class. The previous `getBool`
+      // existed on neither; type=boolean reads were broken since the tool
+      // shipped.
       const getMethod =
         valueType === 'number' ? 'getNumber' :
-        valueType === 'boolean' ? 'getBool' : 'getString';
+        valueType === 'boolean' ? 'getBoolean' : 'getString';
       actionBody = `var v = mmkv.${getMethod}(${JSON.stringify(args.key)}); return JSON.stringify({ value: v === undefined ? null : v });`;
       break;
     }
@@ -75,7 +79,14 @@ export function buildMmkvExpression(args: MmkvArgs): string {
       if (typeof args.key !== 'string' || args.key.length === 0) {
         return `JSON.stringify({ __agent_error: 'delete requires non-empty key' })`;
       }
-      actionBody = `mmkv.delete(${JSON.stringify(args.key)}); return JSON.stringify({ ok: true });`;
+      // GH #209: the raw Nitro hybrid object (v4 / 3.0-beta line) exposes
+      // `remove(key)` per MMKV.nitro.ts — `delete(key)` only exists on the JS
+      // wrapper class. Prefer the spec name, fall back to the wrapper name,
+      // and fail with a named error instead of a bare TypeError.
+      actionBody = `if (typeof mmkv.remove === 'function') { mmkv.remove(${JSON.stringify(args.key)}); }
+      else if (typeof mmkv.delete === 'function') { mmkv.delete(${JSON.stringify(args.key)}); }
+      else { return JSON.stringify({ __agent_error: 'MMKV instance has neither remove() nor delete() — unexpected API surface; report the react-native-mmkv version' }); }
+      return JSON.stringify({ ok: true });`;
       break;
     }
     case 'has': {

--- a/scripts/cdp-bridge/test/unit/gh-209-mmkv-nitro-api.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-209-mmkv-nitro-api.test.js
@@ -1,0 +1,100 @@
+// GH #209: cdp_mmkv delete threw "mmkv.delete is not a function" on the Nitro
+// react-native-mmkv line (v4 / 3.0 betas; stable v3 is TurboModule and never
+// reaches NitroModulesProxy).
+//
+// Root cause: buildMmkvExpression was written against the JS wrapper class API
+// (`delete(key)`), but the expression executes against the RAW Nitro hybrid
+// object from createHybridObject('MMKVFactory').createMMKV(...) whose spec
+// (MMKV.nitro.ts, HybridMMKV.cpp) exposes `remove(key): boolean` — no
+// `delete`. Same class of bug, worse: `get type=boolean` emitted
+// `mmkv.getBool(...)`, which exists on NEITHER surface (wrapper and hybrid
+// object both spell it `getBoolean`) — broken since the tool shipped.
+//
+// These tests run the generated expression in a VM against a mock that models
+// the REAL v4 hybrid-object surface (remove/getBoolean present, delete/getBool
+// absent), so wrapper-API regressions fail here instead of on a live device.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import vm from 'node:vm';
+
+const MOD = '../../dist/tools/mmkv.js';
+
+function runExpr(expr, mmkvImpl) {
+  const sandbox = {
+    globalThis: {},
+    Array, Object, JSON,
+    String, Number, Boolean,
+  };
+  sandbox.globalThis = sandbox;
+  sandbox.NitroModulesProxy = {
+    createHybridObject: (name) => {
+      if (name === 'MMKVFactory') {
+        return { createMMKV: (opts) => mmkvImpl(opts.id) };
+      }
+      return null;
+    },
+  };
+  vm.createContext(sandbox);
+  return JSON.parse(vm.runInContext(expr, sandbox));
+}
+
+// Models the v4 Nitro hybrid object: spec-faithful method names ONLY.
+// (remove returns boolean per HybridMMKV.cpp; no delete, no getBool.)
+function makeNitroV4Instance(store) {
+  return {
+    set: (k, v) => store.set(k, v),
+    getString: (k) => store.get(k),
+    getNumber: (k) => store.get(k),
+    getBoolean: (k) => store.get(k),
+    contains: (k) => store.has(k),
+    remove: (k) => store.delete(k),
+    getAllKeys: () => [...store.keys()],
+    clearAll: () => store.clear(),
+  };
+}
+
+test('delete works against the real Nitro v4 surface (remove, no delete) — the #209 repro', async () => {
+  const { buildMmkvExpression } = await import(MOD);
+  const store = new Map([['authAccessToken', 'tok-123']]);
+  const result = runExpr(
+    buildMmkvExpression({ action: 'delete', key: 'authAccessToken' }),
+    () => makeNitroV4Instance(store),
+  );
+  assert.equal(result.__agent_error, undefined, `expected success, got: ${JSON.stringify(result)}`);
+  assert.equal(result.ok, true);
+  assert.equal(store.has('authAccessToken'), false, 'key must actually be removed');
+});
+
+test('delete still works against a legacy wrapper-shaped object (delete, no remove)', async () => {
+  const { buildMmkvExpression } = await import(MOD);
+  const store = new Map([['k', 'v']]);
+  const wrapperShaped = {
+    delete: (k) => store.delete(k),
+  };
+  const result = runExpr(
+    buildMmkvExpression({ action: 'delete', key: 'k' }),
+    () => wrapperShaped,
+  );
+  assert.equal(result.ok, true);
+  assert.equal(store.has('k'), false);
+});
+
+test('delete with neither remove nor delete surfaces a clear error (not a TypeError)', async () => {
+  const { buildMmkvExpression } = await import(MOD);
+  const result = runExpr(
+    buildMmkvExpression({ action: 'delete', key: 'k' }),
+    () => ({}),
+  );
+  assert.match(String(result.__agent_error), /neither remove\(\) nor delete\(\)/i);
+});
+
+test('get type=boolean works against the real Nitro v4 surface (getBoolean, no getBool)', async () => {
+  const { buildMmkvExpression } = await import(MOD);
+  const store = new Map([['flag', true]]);
+  const result = runExpr(
+    buildMmkvExpression({ action: 'get', key: 'flag', type: 'boolean' }),
+    () => makeNitroV4Instance(store),
+  );
+  assert.equal(result.__agent_error, undefined, `expected success, got: ${JSON.stringify(result)}`);
+  assert.equal(result.value, true);
+});

--- a/scripts/cdp-bridge/test/unit/gh-59-7-cdp-mmkv.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-59-7-cdp-mmkv.test.js
@@ -28,9 +28,9 @@ test('buildMmkvExpression: get with type=number uses getNumber', () => {
   assert.match(expr, /getNumber\("count"\)/);
 });
 
-test('buildMmkvExpression: get with type=boolean uses getBool', () => {
+test('buildMmkvExpression: get with type=boolean uses getBoolean (GH #209 — getBool exists on no MMKV surface)', () => {
   const expr = buildMmkvExpression({ action: 'get', key: 'flag', type: 'boolean' });
-  assert.match(expr, /getBool\("flag"\)/);
+  assert.match(expr, /getBoolean\("flag"\)/);
 });
 
 test('buildMmkvExpression: get without key returns __agent_error literal', () => {
@@ -62,9 +62,12 @@ test('buildMmkvExpression: set without value returns __agent_error', () => {
   assert.match(expr, /__agent_error.*set requires value/);
 });
 
-test('buildMmkvExpression: delete includes the key literal', () => {
+test('buildMmkvExpression: delete prefers Nitro remove() with wrapper delete() fallback (GH #209)', () => {
   const expr = buildMmkvExpression({ action: 'delete', key: 'foo' });
-  assert.match(expr, /\.delete\("foo"\)/);
+  assert.match(expr, /mmkv\.remove\("foo"\)/);
+  assert.match(expr, /mmkv\.delete\("foo"\)/);
+  // remove (the hybrid-object spec name) must be tried first.
+  assert.ok(expr.indexOf('mmkv.remove') < expr.indexOf('mmkv.delete'));
 });
 
 test('buildMmkvExpression: has uses contains()', () => {


### PR DESCRIPTION
## Summary

`cdp_mmkv` with `action: delete` threw `mmkv.delete is not a function` on the Nitro react-native-mmkv line (reported 7/8 times in one session, forcing a raw `cdp_evaluate` escape hatch for every iOS auth logout) — GH #209.

**Root cause** (verified against the published package source — `src/specs/MMKV.nitro.ts` + `cpp/HybridMMKV.cpp`): `buildMmkvExpression` was written against react-native-mmkv's **JS wrapper class** API (`delete(key)`), but the generated expression executes against the **raw Nitro hybrid object** returned by `createHybridObject('MMKVFactory').createMMKV(...)`, whose spec exposes `remove(key): boolean` — there is no `delete()`.

**Version-label correction vs the issue:** stable v3 (3.0.0–3.3.3) is TurboModule-based — no Nitro at all — and `defaultMMKVInstanceId` (used in the reporter's working workaround) exists only in the **v4** factory spec. The affected surface is v4 / the 3.0 betas; the fix targets the API surface, not a version number.

**Second latent bug found during verification:** `get` with `type: 'boolean'` emitted `mmkv.getBool(key)`, which exists on **no** MMKV surface — the wrapper, the v3 wrapper, and the v4 hybrid object all spell it `getBoolean`. Broken since the tool shipped (GH #59).

## Fix

In the generated Hermes expression (`scripts/cdp-bridge/src/tools/mmkv.ts`):
- **delete**: prefer `remove()` (the hybrid-object spec name), fall back to `delete()` for wrapper-shaped objects (e.g. a `globalThis.__MMKV__` escape hatch), and return a **named** `__agent_error` ("neither remove() nor delete()") instead of a bare TypeError when neither exists.
- **boolean get**: `getBoolean`.

## Verification

- TDD: 4 new tests in `gh-209-mmkv-nitro-api.test.js` run the generated expression in a `node:vm` sandbox against a **spec-faithful v4 mock** (`remove`/`getBoolean` present, `delete`/`getBool` absent), each watched fail first. 2 stale shape assertions in `gh-59-7` updated (they pinned the buggy method names).
- Full suite: **2023/2023**.
- Multi-LLM review (Codex + Antigravity): both **SHIP**, each independently confirming the API names against published react-native-mmkv v2.12.2 / v3.3.3 / v4.3.1 source, ES5 validity + escaping in all branches, and remove-before-delete unambiguity.
- **No live-device run**: the workspace test-app doesn't bundle react-native-mmkv (a Nitro native module needs a Dev Client rebuild — out of scope). The VM tests model the exact published spec surface.

The issue's second ask — a `clearKeys:` action-YAML directive for self-contained auth-gated replays — is split to follow-up **#286**.

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)