### PR TITLE
fix(#214): disable CDP Network domain on hook fallback — stop double-capturing requests

### DIFF
--- a/.changeset/gh-214-network-double-capture.md
+++ b/.changeset/gh-214-network-double-capture.md
@@ -1,0 +1,10 @@
+---
+"rn-dev-agent-cdp": patch
+"rn-dev-agent-plugin": patch
+---
+
+`cdp_network_log` no longer returns two entries per request (GH #214).
+
+Root cause: setup sends `Network.enable` (mode `cdp`), then `probeNetworkDomain` fires a probe fetch and watches the buffer. On RN ≥ 0.83 the CDP Network domain *does* deliver events, but when they don't flush within the probe window — a false negative documented after platform switches / reloads (GH #59 #9) — the probe returns `none` and setup injects the fetch/XHR hook **without disabling the still-enabled Network domain**. Both paths then capture every request (CDP numeric-id entries + hook UUID-id entries), and the existing exact-id dedup can't collapse them because the two id schemes never collide.
+
+Fix: when setup falls back to the hook, it now disables the CDP Network domain first, so the hook is the single capture source. This also makes `cdp_status`'s `networkDomain: false` truthful instead of a label over a still-running domain — the "capability flag out of sync" symptom in the report was the same root cause. Read-time fuzzy dedup was deliberately rejected: it would collapse legitimately-identical rapid requests (a real double-mutation) and hide bugs — the opposite of what the reporter needed.

--- a/scripts/cdp-bridge/dist/cdp/setup.js
+++ b/scripts/cdp-bridge/dist/cdp/setup.js
@@ -5,14 +5,18 @@ import { CDP_TIMEOUT_FAST, timeoutForMethod } from './timeout-config.js';
 export const REACT_READY_TIMEOUT_MS = 30_000;
 export const REACT_READY_POLL_MS = 500;
 export async function performSetup(opts) {
-    const { send, evaluate, port, connectedTarget, networkManager, getDeviceKey, setupEventHandlers, clearScripts, clearEventHandlers } = opts;
+    const { send, evaluate, port, connectedTarget, networkManager, getDeviceKey, setupEventHandlers, clearScripts, clearEventHandlers, probeWaits } = opts;
     logger.debug('CDP', 'Running setup: Runtime.enable, Debugger.enable...');
     await send('Runtime.enable', undefined, timeoutForMethod('Runtime.enable'));
     await send('Debugger.enable', undefined, timeoutForMethod('Debugger.enable'));
     let networkMode;
+    // GH #214: track whether the CDP Network domain is actually enabled, so the
+    // hook fallback can disable it and avoid double-feeding the buffer.
+    let networkDomainEnabled = false;
     try {
         await send('Network.enable', undefined, timeoutForMethod('Network.enable'));
         networkMode = 'cdp';
+        networkDomainEnabled = true;
     }
     catch {
         networkMode = 'none';
@@ -59,6 +63,7 @@ export async function performSetup(opts) {
             await send('Network.disable', undefined, CDP_TIMEOUT_FAST);
         }
         catch { /* best-effort */ }
+        networkDomainEnabled = false;
     }
     logger.info('CDP', `Helpers injected (v${HELPERS_VERSION}), network mode: ${networkMode}`);
     setActiveFlag(port, connectedTarget);
@@ -68,9 +73,25 @@ export async function performSetup(opts) {
     // its CDP event channel. Retry once at a longer interval before declaring
     // RN<0.83. Total worst-case wait for legitimate fallback: 500ms + 1500ms.
     if (networkMode === 'cdp') {
-        networkMode = await probeNetworkDomain({ evaluate, port, networkManager, getDeviceKey });
+        networkMode = await probeNetworkDomain({ evaluate, port, networkManager, getDeviceKey, waits: probeWaits });
     }
     if (networkMode === 'none') {
+        // GH #214: if the CDP Network domain is still enabled here, the probe fell
+        // back to the hook despite Network.enable succeeding — a false negative on
+        // RN >= 0.83 where the probe fetch's events flush after the probe window.
+        // Disable the domain so the injected hook is the SINGLE capture source.
+        // Leaving it on double-feeds the buffer (CDP numeric-id entries + hook
+        // UUID-id entries for the same request); the getByKey dedup can't collapse
+        // them because the two id schemes never collide. This also makes
+        // cdp_status's networkDomain:false truthful instead of a label over a
+        // still-running domain.
+        if (networkDomainEnabled) {
+            try {
+                await send('Network.disable', undefined, CDP_TIMEOUT_FAST);
+            }
+            catch { /* best-effort */ }
+            networkDomainEnabled = false;
+        }
         const hookResult = await evaluate(NETWORK_HOOK_SCRIPT);
         if (hookResult.error) {
             console.error('CDP: failed to inject network hooks:', hookResult.error);

--- a/scripts/cdp-bridge/src/cdp/setup.ts
+++ b/scripts/cdp-bridge/src/cdp/setup.ts
@@ -26,17 +26,27 @@ export async function performSetup(opts: {
   setupEventHandlers: () => void;
   clearScripts: () => void;
   clearEventHandlers: () => void;
+  /**
+   * Test seam: probe wait intervals forwarded to probeNetworkDomain. Defaults
+   * to its production [500, 1500]. Lets tests drive the fallback path without
+   * paying the ~2s real probe wait. Mirrors the existing `waits` seam.
+   */
+  probeWaits?: number[];
 }): Promise<SetupResult> {
-  const { send, evaluate, port, connectedTarget, networkManager, getDeviceKey, setupEventHandlers, clearScripts, clearEventHandlers } = opts;
+  const { send, evaluate, port, connectedTarget, networkManager, getDeviceKey, setupEventHandlers, clearScripts, clearEventHandlers, probeWaits } = opts;
 
   logger.debug('CDP', 'Running setup: Runtime.enable, Debugger.enable...');
   await send('Runtime.enable', undefined, timeoutForMethod('Runtime.enable'));
   await send('Debugger.enable', undefined, timeoutForMethod('Debugger.enable'));
 
   let networkMode: 'cdp' | 'hook' | 'none';
+  // GH #214: track whether the CDP Network domain is actually enabled, so the
+  // hook fallback can disable it and avoid double-feeding the buffer.
+  let networkDomainEnabled = false;
   try {
     await send('Network.enable', undefined, timeoutForMethod('Network.enable'));
     networkMode = 'cdp';
+    networkDomainEnabled = true;
   } catch {
     networkMode = 'none';
   }
@@ -85,6 +95,7 @@ export async function performSetup(opts: {
   if (process.env.RN_FORCE_NETWORK_HOOK === '1') {
     networkMode = 'none';
     try { await send('Network.disable', undefined, CDP_TIMEOUT_FAST); } catch { /* best-effort */ }
+    networkDomainEnabled = false;
   }
 
   logger.info('CDP', `Helpers injected (v${HELPERS_VERSION}), network mode: ${networkMode}`);
@@ -96,10 +107,23 @@ export async function performSetup(opts: {
   // its CDP event channel. Retry once at a longer interval before declaring
   // RN<0.83. Total worst-case wait for legitimate fallback: 500ms + 1500ms.
   if (networkMode === 'cdp') {
-    networkMode = await probeNetworkDomain({ evaluate, port, networkManager, getDeviceKey });
+    networkMode = await probeNetworkDomain({ evaluate, port, networkManager, getDeviceKey, waits: probeWaits });
   }
 
   if (networkMode === 'none') {
+    // GH #214: if the CDP Network domain is still enabled here, the probe fell
+    // back to the hook despite Network.enable succeeding — a false negative on
+    // RN >= 0.83 where the probe fetch's events flush after the probe window.
+    // Disable the domain so the injected hook is the SINGLE capture source.
+    // Leaving it on double-feeds the buffer (CDP numeric-id entries + hook
+    // UUID-id entries for the same request); the getByKey dedup can't collapse
+    // them because the two id schemes never collide. This also makes
+    // cdp_status's networkDomain:false truthful instead of a label over a
+    // still-running domain.
+    if (networkDomainEnabled) {
+      try { await send('Network.disable', undefined, CDP_TIMEOUT_FAST); } catch { /* best-effort */ }
+      networkDomainEnabled = false;
+    }
     const hookResult = await evaluate(NETWORK_HOOK_SCRIPT);
     if (hookResult.error) {
       console.error('CDP: failed to inject network hooks:', hookResult.error);

--- a/scripts/cdp-bridge/test/unit/gh-214-network-double-capture.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-214-network-double-capture.test.js
@@ -1,0 +1,99 @@
+// GH #214: cdp_network_log returned TWO entries per request — one with a
+// numeric id (CDP Network domain) and one with a UUID id (injected fetch/XHR
+// hook). Root cause: performSetup sends Network.enable (mode='cdp'), then
+// probeNetworkDomain fires a probe fetch and watches the buffer. On RN >= 0.83
+// the domain DOES deliver events, but when they don't flush within the probe
+// window (false negative — documented after platform switches / reloads, GH
+// #59 #9), the probe returns 'none' and the fallback injects the hook and sets
+// mode='hook' WITHOUT disabling the still-enabled CDP Network domain. Both
+// paths then capture every request; the getByKey dedup can't catch the dupes
+// because numeric and UUID id schemes never collide.
+//
+// This is also the capability "desync" the reporter saw: cdp_status labels the
+// mode 'hook' (networkDomain:false) while numeric CDP ids keep appearing,
+// because the domain was never turned off.
+//
+// Fix: when setup falls back to the hook, it must Network.disable first so the
+// hook is the single capture source.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { performSetup } from '../../dist/cdp/setup.js';
+import {
+  INJECTED_HELPERS,
+  NETWORK_HOOK_SCRIPT,
+  NETWORK_CB_BUFFERED_SCRIPT,
+  REACT_READY_PROBE_JS,
+} from '../../dist/injected-helpers.js';
+
+// Minimal performSetup harness. `send` records every CDP method; `evaluate`
+// answers the fixed expressions setup issues. `bufferGrowsOnProbe` controls
+// whether the probe fetch appears to deliver a CDP event (true = RN<0.83-style
+// real CDP, stays 'cdp'; false = false-negative / genuine fallback → 'hook').
+function makeHarness({ enableThrows = false, bufferGrowsOnProbe = false } = {}) {
+  const sent = [];
+  const send = async (method) => {
+    sent.push(method);
+    if (method === 'Network.enable' && enableThrows) throw new Error('not supported');
+    return {};
+  };
+  let size = 0;
+  const evaluate = async (expr) => {
+    if (expr === REACT_READY_PROBE_JS) return { value: true };
+    if (expr === INJECTED_HELPERS) return { value: undefined };
+    if (expr === 'typeof globalThis.__RN_AGENT === "object"') return { value: true };
+    if (expr === NETWORK_HOOK_SCRIPT || expr === NETWORK_CB_BUFFERED_SCRIPT) return { value: undefined };
+    // probe fetch (`void fetch(...)`) — optionally simulate a delivered event.
+    if (typeof expr === 'string' && expr.includes('fetch(') && bufferGrowsOnProbe) size += 1;
+    return { value: undefined };
+  };
+  const networkManager = { size: () => size, push: () => {}, getByKey: () => undefined };
+  return {
+    sent,
+    opts: {
+      send,
+      evaluate,
+      port: 8081,
+      connectedTarget: null,
+      networkManager,
+      getDeviceKey: () => 'k',
+      setupEventHandlers: () => {},
+      clearScripts: () => {},
+      clearEventHandlers: () => {},
+      probeWaits: [1, 1], // test seam: fast probe
+    },
+  };
+}
+
+test('fallback to hook disables the CDP Network domain (the #214 double-capture fix)', async () => {
+  const h = makeHarness({ enableThrows: false, bufferGrowsOnProbe: false });
+  const result = await performSetup(h.opts);
+
+  assert.equal(result.networkMode, 'hook', 'false-negative probe must fall back to hook');
+  assert.ok(h.sent.includes('Network.enable'), 'Network.enable was attempted');
+  assert.ok(
+    h.sent.includes('Network.disable'),
+    `must disable the still-enabled CDP domain before hook capture — sent: ${h.sent.join(', ')}`,
+  );
+  // Ordering: the domain must be disabled, not re-enabled afterward.
+  assert.ok(
+    h.sent.lastIndexOf('Network.disable') > h.sent.lastIndexOf('Network.enable'),
+    'Network.disable must come after the Network.enable it cancels',
+  );
+});
+
+test('CDP mode (probe succeeds) keeps the domain — does NOT disable it', async () => {
+  const h = makeHarness({ enableThrows: false, bufferGrowsOnProbe: true });
+  const result = await performSetup(h.opts);
+
+  assert.equal(result.networkMode, 'cdp', 'a delivered probe event keeps CDP mode');
+  assert.ok(!h.sent.includes('Network.disable'), 'must not disable the domain that is the sole capture source');
+});
+
+test('Network.enable unsupported (genuine RN<0.83): reaches hook mode without crashing', async () => {
+  const h = makeHarness({ enableThrows: true, bufferGrowsOnProbe: false });
+  const result = await performSetup(h.opts);
+
+  assert.equal(result.networkMode, 'hook', 'enable threw → never cdp → hook fallback');
+  // The domain was never enabled, so a disable here is a harmless no-op; the
+  // single-source contract is satisfied either way. No assertion on disable.
+});


### PR DESCRIPTION
## Summary

`cdp_network_log` returned **two entries for every request** — a numeric-id one (CDP Network domain) and a UUID-id one (injected fetch/XHR hook). In a real session this read as a double-`PUT` / double-`DELETE` and cost the reporter investigation time chasing an app-side double-mutation that didn't exist (GH #214).

**Root cause** (`performSetup`, `scripts/cdp-bridge/src/cdp/setup.ts`): setup sends `Network.enable` (`networkMode='cdp'`), then `probeNetworkDomain` fires a probe fetch and watches the buffer. On RN ≥ 0.83 the domain *does* deliver events, but when they don't flush within the 500ms+1500ms probe window — a false negative documented after platform switches/reloads (GH #59 #9) — the probe returns `'none'` and the fallback injects the hook and sets `networkMode='hook'` **without disabling the still-enabled Network domain**. Both paths then capture every request; the existing exact-id `getByKey` dedup can't collapse them because numeric and UUID id schemes never collide.

This is also the reporter's **capability "desync"**: `cdp_status` labels the mode `hook` (`networkDomain:false`) while numeric CDP ids keep appearing — same root cause, because the domain was never turned off. The author already knew leaving it on "double-feed[s] the buffer"; they guarded only the `RN_FORCE_NETWORK_HOOK` test seam, not the real probe-fallback path.

## Fix

Track whether `Network.enable` succeeded; when setup falls back to the hook, `Network.disable` first (best-effort) so the hook is the **single** capture source. Precise bookkeeping: the disable is skipped when `enable` threw (domain never on) and when the test seam already disabled it.

**Deliberately rejected** the issue's read-time fuzzy-dedup suggestion (`method,url,status,timestamp±50ms`): it would collapse legitimately-identical rapid requests and hide real double-mutations — the opposite of what the reporter needed. Source-level single-source capture means a "double PUT" in the log is now *trustworthy* evidence of a real problem.

## Verification

- TDD: 3 new tests driving the **real** `performSetup` through all three paths (fallback-disables / cdp-success-does-NOT-over-disable / enable-threw-still-reaches-hook), watched fail first. A `probeWaits` test seam (mirroring the existing probe `waits` seam) keeps them fast.
- Full suite: **2026/2026**.
- Multi-LLM review (Codex + Antigravity): both **SHIP** — and both independently restored the pre-fix `dist` and confirmed the fallback test fails pre-fix / passes post-fix, verified no CDP capability is lost (hook-mode bodies flow through the `__RN_AGENT_RESPONSE_BODIES__` cache), and confirmed reconnect/persisted-context paths can't resurrect the double-feed (both hook-drain paths gate on `networkMode==='hook'`).
- **No live device run**: the double-capture only manifests under the probe false-negative (timing-dependent on RN ≥ 0.83), not deterministically reproducible on a healthy app — the unit test drives that exact path deterministically. A connected-app run was attempted but the workspace dev client wasn't attached to Metro.

A defense-in-depth follow-up (gate the CDP `Network.*` handlers on `networkMode`, with a documented trap about probe timing) is filed as **#288**.

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)