### PR TITLE
ci(release): direct-merge fallback when Version PR is already clean

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,31 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable auto-merge on the Version Packages PR
+      # Prefer auto-merge (it gates on any pending checks). `gh pr merge --auto`
+      # ERRORS only when auto-merge can't be enabled — most commonly because the
+      # PR is already in a clean/mergeable state: the changeset-release/main
+      # branch has no required status checks, so the Version PR is usually
+      # immediately mergeable and there is no gate to attach to. Fall back to a
+      # direct merge ONLY for that specific benign error. Any OTHER auto-merge
+      # failure (e.g. "Allow auto-merge" disabled, missing permission) must fail
+      # the job loudly rather than silently direct-merging — a failing/pending
+      # check never lands here, because --auto succeeds at *enabling* in that
+      # case and simply waits.
+      - name: Merge the Version Packages PR (auto-merge, or direct only if already clean)
         if: steps.changesets.outputs.pullRequestNumber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
-        run: gh pr merge --squash --auto "$PR_NUMBER"
+        run: |
+          if out=$(gh pr merge --squash --auto "$PR_NUMBER" 2>&1); then
+            echo "$out"
+          else
+            echo "$out"
+            if printf '%s' "$out" | grep -q "Pull request is in clean status"; then
+              echo "auto-merge not applicable (PR already mergeable) — merging directly"
+              gh pr merge --squash "$PR_NUMBER"
+            else
+              echo "auto-merge failed for an unexpected reason — not falling back" >&2
+              exit 1
+            fi
+          fi


### PR DESCRIPTION
## Summary

The Release workflow's "enable auto-merge" step fails intermittently with:

```
GraphQL: Pull request is in clean status (enablePullRequestAutoMerge)
```

— most recently leaving the v0.54.3 Version Packages PR (#290) open and unmerged after the #214 release (also observed earlier on `bc577e9`).

**Root cause:** the `changeset-release/main` branch has **no required status checks** (`gh pr checks` reports "no checks reported"), so the Version Packages PR is frequently *immediately* mergeable. `gh pr merge --auto` then errors, because `enablePullRequestAutoMerge` needs a pending gate to attach to — there's nothing to wait for.

## Fix

```diff
- run: gh pr merge --squash --auto "$PR_NUMBER"
+ run: gh pr merge --squash --auto "$PR_NUMBER" || gh pr merge --squash "$PR_NUMBER"
```

The direct-merge fallback fires **only** when enabling auto-merge fails — i.e. the already-mergeable case. If checks were genuinely pending, `--auto` would succeed at *enabling* and the fallback would never run, so this can't bypass a real pending/failing check. Safe under Actions' default `bash -e` (failure on the left of `||` doesn't trip `set -e`).

## Notes

- CI-only change — `require-changeset` watches only `^scripts/cdp-bridge/src/` and excludes `.github/`, so no changeset is needed.
- #290 itself was already merged manually (the release shipped); this prevents the recurrence on future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)