### PR TITLE
feat(#263): detect wedged simulator runtime → RUNTIME_DEGRADED hint

### DIFF
--- a/.changeset/gh-263-runtime-degraded.md
+++ b/.changeset/gh-263-runtime-degraded.md
@@ -1,0 +1,8 @@
+---
+"rn-dev-agent-cdp": patch
+"rn-dev-agent-plugin": patch
+---
+
+`maestro_run` now flags a wedged simulator runtime (GH #263).
+
+When a flow fails AND the median latency of its successful `tapOn` steps exceeds a floor (default 1500ms, `RN_RUNTIME_DEGRADED_FLOOR_MS`), the result gains a `RUNTIME_DEGRADED` hint and `meta.runtimeDegraded` — "the simulator test runtime is likely wedged; reboot it (xcrun simctl shutdown/boot), relaunch, and retry." This replaces the misleading "Element not found" that previously sent the agent chasing app code when the real cause was a degraded simulator (taps reported success but `onPress` never fired). Detection is purely additive — it never changes a pass/fail verdict, never fires on a passing run, and only counts successful taps (a failed tap's duration is the step timeout, which would otherwise false-positive an ordinary element-not-found failure). Fail-open: unparseable output → no hint.

--- a/docs/superpowers/plans/2026-06-14-263-runtime-degraded-detection.md
+++ b/docs/superpowers/plans/2026-06-14-263-runtime-degraded-detection.md
@@ -1,0 +1,373 @@
+# Wedged-simulator detection → `RUNTIME_DEGRADED` hint (GH #263) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a `maestro_run` flow fails with degraded tap latency, append a `RUNTIME_DEGRADED` hint pointing at a simulator reboot, instead of the misleading "Element not found".
+
+**Architecture:** A new pure module `src/domain/tap-latency.ts` parses the median of successful (`✓`) `tapOn` latencies from maestro-runner output (already captured by `maestro_run`), classifies degradation against a fixed floor (1500ms, env-overridable), and builds the hint. `maestro-run.ts` calls a pure `augmentFailureWithDegradation` helper at its two failure return sites; it's purely additive and never runs on a passing flow.
+
+**Tech Stack:** TypeScript (Node ≥22, ESM), `node:test`.
+
+**Spec:** `docs/superpowers/specs/2026-06-14-263-runtime-degraded-detection-design.md`
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/domain/tap-latency.ts` | parse ✓ tapOn latencies, median, classify, resolve floor, format hint, augment-failure helper | **create** (pure, no I/O) |
+| `src/tools/maestro-run.ts` | call `augmentFailureWithDegradation` at the two failure returns | **modify** (2 sites + import) |
+| `test/unit/gh-263-tap-latency.test.js` | unit tests for the whole module incl. the augment helper | **create** |
+
+Real maestro-runner output format (from existing `test/unit/maestro-error-parser.test.js` fixtures — actual output):
+```
+  ✓ launchApp (2.3s)
+  ✓ tapOn: id="tab-tasks" (2.8s)
+  ✓ assertVisible: text="Tasks" (1.3s)
+  ✗ tapOn: id="task-mark-all-done" (12.7s)
+✗ rn-maestro-run 23.8s
+```
+
+---
+
+## Task 1: Pure `tap-latency.ts` module
+
+**Files:**
+- Create: `src/domain/tap-latency.ts`
+- Test: `test/unit/gh-263-tap-latency.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/unit/gh-263-tap-latency.test.js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseTapLatencies, median, resolveFloorMs, classifyRuntimeDegradation,
+  formatRuntimeDegradedHint, augmentFailureWithDegradation, DEFAULT_FLOOR_MS,
+} from '../../dist/domain/tap-latency.js';
+
+const DEGRADED = `  ✓ launchApp (2.3s)
+  ✓ tapOn: id="a" (2.8s)
+  ✓ tapOn: id="b" (3.0s)
+  ✓ assertVisible: text="x" (1.1s)
+  ✗ tapOn: id="c" (12.7s)
+✗ rn-maestro-run 23.8s`;
+
+const NORMAL = `  ✓ launchApp (1.0s)
+  ✓ tapOn: id="a" (0.7s)
+  ✓ tapOn: id="b" (0.9s)
+  ✗ assertVisible: text="x" (10.0s)
+✗ rn-maestro-run 12.0s`;
+
+// A genuine "element not found" failure with ONE tap that timed out — the ✗
+// duration must NOT be counted, else this false-positives as degraded.
+const SINGLE_FAILED_TAP = `  ✓ launchApp (1.1s)
+  ✗ tapOn: id="missing" (12.7s)
+✗ rn-maestro-run 14.0s`;
+
+test('parseTapLatencies: only successful (✓) tapOn lines, seconds→ms', () => {
+  assert.deepEqual(parseTapLatencies(DEGRADED), [2800, 3000]);
+});
+
+test('parseTapLatencies: a single failed (✗) tap yields no samples (no false positive)', () => {
+  assert.deepEqual(parseTapLatencies(SINGLE_FAILED_TAP), []);
+});
+
+test('parseTapLatencies: output with no tapOn lines → []', () => {
+  assert.deepEqual(parseTapLatencies('  ✓ launchApp (2.0s)\n✓ rn-maestro-run 2.0s'), []);
+  assert.deepEqual(parseTapLatencies(''), []);
+});
+
+test('median: odd, even, single, empty', () => {
+  assert.equal(median([3000, 2800, 1000]), 2800);  // sorted 1000,2800,3000
+  assert.equal(median([2800, 3000]), 2900);        // average of two middle
+  assert.equal(median([1500]), 1500);
+  assert.equal(median([]), null);
+});
+
+test('resolveFloorMs: default, valid override, invalid → default', () => {
+  assert.equal(resolveFloorMs(undefined), DEFAULT_FLOOR_MS);
+  assert.equal(DEFAULT_FLOOR_MS, 1500);
+  assert.equal(resolveFloorMs('2000'), 2000);
+  assert.equal(resolveFloorMs('abc'), DEFAULT_FLOOR_MS);
+  assert.equal(resolveFloorMs('0'), DEFAULT_FLOOR_MS);
+  assert.equal(resolveFloorMs('-5'), DEFAULT_FLOOR_MS);
+});
+
+test('classifyRuntimeDegradation: degraded when median ≥ floor', () => {
+  const d = classifyRuntimeDegradation(DEGRADED, 1500);
+  assert.equal(d.degraded, true);
+  assert.equal(d.medianMs, 2900);   // median of [2800,3000]
+  assert.equal(d.sampleCount, 2);
+  assert.equal(d.floorMs, 1500);
+});
+
+test('classifyRuntimeDegradation: normal latency is not degraded', () => {
+  const d = classifyRuntimeDegradation(NORMAL, 1500);
+  assert.equal(d.degraded, false);
+  assert.equal(d.medianMs, 800);    // median of [700,900]
+});
+
+test('classifyRuntimeDegradation: no tap samples → not degraded, medianMs null', () => {
+  const d = classifyRuntimeDegradation(SINGLE_FAILED_TAP, 1500);
+  assert.equal(d.degraded, false);
+  assert.equal(d.medianMs, null);
+  assert.equal(d.sampleCount, 0);
+});
+
+test('formatRuntimeDegradedHint: names the code, median, floor, and reboot', () => {
+  const hint = formatRuntimeDegradedHint(classifyRuntimeDegradation(DEGRADED, 1500));
+  assert.match(hint, /RUNTIME_DEGRADED/);
+  assert.match(hint, /2900ms/);
+  assert.match(hint, /1500ms/);
+  assert.match(hint, /simctl shutdown/);
+});
+
+test('augmentFailureWithDegradation: degraded → hint appended + meta.runtimeDegraded', () => {
+  const { message, meta } = augmentFailureWithDegradation(DEGRADED, 1500, 'Flow failed', { passed: false });
+  assert.match(message, /Flow failed — RUNTIME_DEGRADED:/);
+  assert.deepEqual(meta.runtimeDegraded, { medianTapMs: 2900, floorMs: 1500, sampleCount: 2 });
+  assert.equal(meta.passed, false); // base meta preserved
+});
+
+test('augmentFailureWithDegradation: not degraded → message + meta unchanged', () => {
+  const base = { passed: false, output: 'x' };
+  const { message, meta } = augmentFailureWithDegradation(NORMAL, 1500, 'Flow failed', base);
+  assert.equal(message, 'Flow failed');
+  assert.equal(meta.runtimeDegraded, undefined);
+  assert.deepEqual(meta, base);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run build && node --test test/unit/gh-263-tap-latency.test.js`
+Expected: FAIL — cannot find module `dist/domain/tap-latency.js`.
+
+- [ ] **Step 3: Implement `src/domain/tap-latency.ts`**
+
+```ts
+// src/domain/tap-latency.ts
+// GH #263: detect a wedged simulator test-runtime from maestro-runner output.
+// Pure, no I/O. Fail-open: unparseable output yields no samples → no hint.
+
+export const DEFAULT_FLOOR_MS = 1500;
+
+/**
+ * Extract latencies (ms) of SUCCESSFUL tapOn steps from maestro-runner output.
+ * maestro-runner prints each step as `  ✓ tapOn: id="x" (2.8s)` (seconds, in
+ * parens at end). Only ✓ lines count: a ✗ line's duration is the step TIMEOUT
+ * (~12.7s), which would false-positive an ordinary element-not-found failure.
+ */
+export function parseTapLatencies(output: string): number[] {
+  const out: number[] = [];
+  for (const raw of output.split('\n')) {
+    const line = raw.trim();
+    if (!line.startsWith('✓')) continue;       // successful steps only
+    if (!/\btapOn\b/.test(line)) continue;     // tap steps only
+    const m = line.match(/\(([\d.]+)s\)\s*$/); // trailing (N.Ns)
+    if (!m) continue;
+    const seconds = Number(m[1]);
+    if (Number.isFinite(seconds)) out.push(Math.round(seconds * 1000));
+  }
+  return out;
+}
+
+export function median(samples: number[]): number | null {
+  if (samples.length === 0) return null;
+  const s = [...samples].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 === 0 ? Math.round((s[mid - 1] + s[mid]) / 2) : s[mid];
+}
+
+export function resolveFloorMs(envVal?: string): number {
+  if (envVal === undefined) return DEFAULT_FLOOR_MS;
+  const n = Number(envVal);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_FLOOR_MS;
+}
+
+export interface RuntimeDegradation {
+  degraded: boolean;
+  medianMs: number | null;
+  floorMs: number;
+  sampleCount: number;
+}
+
+export function classifyRuntimeDegradation(output: string, floorMs: number): RuntimeDegradation {
+  const samples = parseTapLatencies(output);
+  const medianMs = median(samples);
+  return {
+    degraded: medianMs != null && medianMs >= floorMs,
+    medianMs,
+    floorMs,
+    sampleCount: samples.length,
+  };
+}
+
+export function formatRuntimeDegradedHint(d: RuntimeDegradation): string {
+  return `RUNTIME_DEGRADED: median tapOn latency ${d.medianMs}ms (>= ${d.floorMs}ms) — `
+    + `the simulator test runtime is likely wedged; reboot it `
+    + `(xcrun simctl shutdown <udid> && xcrun simctl boot <udid>), relaunch the app, and retry.`;
+}
+
+/**
+ * Integration helper: given the runner output and an already-built failure
+ * (message + meta), append the RUNTIME_DEGRADED hint + meta.runtimeDegraded
+ * IFF degraded. Returns the base unchanged otherwise. Call ONLY on a failure
+ * path — never on a passing flow (a passing-but-slow run must not be hinted).
+ */
+export function augmentFailureWithDegradation(
+  output: string,
+  floorMs: number,
+  baseMessage: string,
+  baseMeta: Record<string, unknown>,
+): { message: string; meta: Record<string, unknown> } {
+  const d = classifyRuntimeDegradation(output, floorMs);
+  if (!d.degraded) return { message: baseMessage, meta: baseMeta };
+  return {
+    message: `${baseMessage} — ${formatRuntimeDegradedHint(d)}`,
+    meta: { ...baseMeta, runtimeDegraded: { medianTapMs: d.medianMs, floorMs: d.floorMs, sampleCount: d.sampleCount } },
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run build && node --test test/unit/gh-263-tap-latency.test.js`
+Expected: PASS (11/11).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/domain/tap-latency.ts test/unit/gh-263-tap-latency.test.js dist/domain/tap-latency.js
+git commit -m "feat(#263): tap-latency domain module — parse/median/classify/augment (pure)"
+```
+
+---
+
+## Task 2: Wire into `maestro-run.ts` failure paths + changeset
+
+**Files:**
+- Modify: `src/tools/maestro-run.ts` (import + the two failure returns)
+- Create: `.changeset/gh-263-runtime-degraded.md`
+
+- [ ] **Step 1: Add the import**
+
+Near the other domain imports in `src/tools/maestro-run.ts` (it already imports `outputIndicatesFlowFailure` from `../domain/maestro-error-parser.js`), add:
+
+```ts
+import { augmentFailureWithDegradation, resolveFloorMs } from '../domain/tap-latency.js';
+```
+
+- [ ] **Step 2: Wire the "completed with failures" path**
+
+Current code (the failing branch of the success path):
+```ts
+      return warnResult(
+        meta,
+        dispatch.fallbackReason
+          ? `${dispatch.fallbackReason}; flow completed with warnings or failures`
+          : 'Flow completed with warnings or failures',
+      );
+```
+Replace with (classify on the FULL `output` var, not the sliced `meta.output`):
+```ts
+      const baseWarnMsg = dispatch.fallbackReason
+        ? `${dispatch.fallbackReason}; flow completed with warnings or failures`
+        : 'Flow completed with warnings or failures';
+      const warnAug = augmentFailureWithDegradation(
+        output,
+        resolveFloorMs(process.env.RN_RUNTIME_DEGRADED_FLOOR_MS),
+        baseWarnMsg,
+        meta,
+      );
+      return warnResult(warnAug.meta, warnAug.message);
+```
+
+- [ ] **Step 3: Wire the catch (timeout/non-zero exit) path**
+
+Current code:
+```ts
+      const combined = (stdout + '\n' + stderr).trim();
+      return failResult(`Maestro flow failed: ${msg.slice(0, 500)}`, {
+        flowFile,
+        platform,
+        runner: dispatch.runner,
+        passed: false,
+        output: combined.slice(0, 4000),
+      });
+```
+Replace with:
+```ts
+      const combined = (stdout + '\n' + stderr).trim();
+      const failAug = augmentFailureWithDegradation(
+        combined,
+        resolveFloorMs(process.env.RN_RUNTIME_DEGRADED_FLOOR_MS),
+        `Maestro flow failed: ${msg.slice(0, 500)}`,
+        { flowFile, platform, runner: dispatch.runner, passed: false, output: combined.slice(0, 4000) },
+      );
+      return failResult(failAug.message, failAug.meta);
+```
+
+- [ ] **Step 4: Verify the passing path is untouched (no hint on success)**
+
+Run: `grep -n "augmentFailureWithDegradation" src/tools/maestro-run.ts`
+Expected: exactly TWO matches — the warn (completed-with-failures) path and the catch path. Confirm NEITHER is inside the `if (passed)` block (the `okResult`/success-with-fallback returns must remain unchanged). This is the structural guarantee that a passing flow never gets a hint.
+
+- [ ] **Step 5: Build + full suite**
+
+Run: `npm test 2>&1 | grep -E "ℹ (tests|pass|fail) "`
+Expected: 0 fail; count = prior baseline + 11.
+
+- [ ] **Step 6: Add changeset**
+
+Create `.changeset/gh-263-runtime-degraded.md`:
+```markdown
+---
+"rn-dev-agent-cdp": patch
+"rn-dev-agent-plugin": patch
+---
+
+`maestro_run` now flags a wedged simulator runtime (GH #263).
+
+When a flow fails AND the median latency of its successful `tapOn` steps exceeds a floor (default 1500ms, `RN_RUNTIME_DEGRADED_FLOOR_MS`), the result gains a `RUNTIME_DEGRADED` hint and `meta.runtimeDegraded` — "the simulator test runtime is likely wedged; reboot it (xcrun simctl shutdown/boot), relaunch, and retry." This replaces the misleading "Element not found" that previously sent the agent chasing app code when the real cause was a degraded simulator (taps reported success but `onPress` never fired). Detection is purely additive — it never changes a pass/fail verdict, never fires on a passing run, and only counts successful taps (a failed tap's duration is the step timeout, which would otherwise false-positive an ordinary element-not-found failure). Fail-open: unparseable output → no hint.
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/tools/maestro-run.ts dist/tools/maestro-run.js .changeset/gh-263-runtime-degraded.md
+git commit -m "feat(#263): maestro_run appends RUNTIME_DEGRADED hint on degraded-latency failure"
+```
+
+---
+
+## Task 3: Verify + finish
+
+- [ ] **Step 1: Full suite green**
+
+Run: `npm test 2>&1 | grep -E "ℹ (tests|pass|fail) "`
+Expected: 0 fail.
+
+- [ ] **Step 2: dist parity**
+
+Run: `npm run build && git status --short scripts/cdp-bridge/dist/ | grep -v "^??" || echo "dist in sync"`
+Expected: `dist in sync` (the committed dist matches a fresh build).
+
+- [ ] **Step 3: Finish the branch**
+
+Use `superpowers:finishing-a-development-branch` → push `feat/263-runtime-degraded-detection`, open PR `Closes #263`, multi-LLM review (Codex + Antigravity) on the diff, address findings, merge on green.
+
+Note: no live device gate is required — the detector is pure string analysis over already-captured output, fully covered by the fixture-based unit tests (the real format is pinned from existing maestro-error-parser fixtures). A live wedge is non-deterministic to reproduce on demand.
+
+---
+
+## Self-review
+
+**Spec coverage:** signal = median ✓-tapOn latency parsed from captured output (T1 `parseTapLatencies`/`classifyRuntimeDegradation`) ✓; floor 1500 + env override (T1 `resolveFloorMs`) ✓; failure-only + additive hint (T2 two failure sites, Step 4 verifies not in the passed branch) ✓; meta.runtimeDegraded `{medianTapMs,floorMs,sampleCount}` (T1 `augmentFailureWithDegradation`, asserted in test) ✓; fail-open (parse returns [] → not degraded) ✓; ✗-tap false-positive guard (T1 SINGLE_FAILED_TAP test) ✓; tests for parser/median/classify/resolveFloor/integration (T1) ✓.
+
+**Placeholders:** none — every step has concrete code/commands.
+
+**Type consistency:** `RuntimeDegradation` shape (T1) consumed by `formatRuntimeDegradedHint`/`augmentFailureWithDegradation` (T1) and the meta key `runtimeDegraded.medianTapMs` matches the spec and the test assertion; `augmentFailureWithDegradation(output, floorMs, baseMessage, baseMeta)` signature identical at both T2 call sites; `resolveFloorMs` used with `process.env.RN_RUNTIME_DEGRADED_FLOOR_MS` consistently.

--- a/docs/superpowers/specs/2026-06-14-263-runtime-degraded-detection-design.md
+++ b/docs/superpowers/specs/2026-06-14-263-runtime-degraded-detection-design.md
@@ -1,0 +1,74 @@
+# GH #263 — Detect wedged simulator runtime → `RUNTIME_DEGRADED` hint
+
+**Status:** Approved (2026-06-14)
+**Issue:** [#263](https://github.com/Lykhoyda/rn-dev-agent/issues/263) — detect wedged simulator test-runtime (degraded tap latency) and recommend reboot (`kano:performance`, `effort:m`)
+
+## Problem
+
+A recurring iOS failure mode: tap latencies degrade 3–4× (~0.7s → ~2.6–3.0s), taps report success but `onPress` never fires, and learned-action replays fail at random steps. A `simctl shutdown && boot` restores normal latency every time. The wedged state is **invisible in the failure report** — maestro-runner shows a step timeout ("Element not found"), so the agent investigates app code / staging APIs before recalling the documented reboot fix. We want the failure surface to *name* the likely cause.
+
+## Scope (chosen)
+
+**Detect + hint only.** On a failed `maestro_run` whose median `tapOn` latency is degraded, append a structured `RUNTIME_DEGRADED` hint pointing at a reboot. No new device-lifecycle tool, no auto-reboot — those add disruptive actions (reboot is ~30s and could mask real failures) for marginal gain over a clear hint. The hint alone fixes the core problem: the misleading "Element not found" that misdirects the agent.
+
+## Signal & threshold
+
+- **Source:** the per-`tapOn` latencies maestro-runner already prints in the output `maestro_run` already captures (`stdout+stderr`). No dependency on #211. Real format (from existing `maestro-error-parser.test.js` fixtures, i.e. actual maestro-runner output):
+  ```
+    ✓ tapOn: id="tab-tasks" (2.8s)
+    ✗ tapOn: id="task-mark-all-done" (12.7s)
+  ```
+  Each `tapOn` step line ends with a parenthesized duration in **seconds**.
+- **Only `✓` (successful) tapOn lines count.** A `✗` line's duration is the step *timeout* (e.g. 12.7s), not a tap latency — including it would false-positive on an ordinary "element not found" failure (one timed-out tap → median ≥ floor → bogus hint). The wedge signal is in the *successful* taps being slow (the reporter's 2.6–3.0s were completed taps). So the parser ignores `✗` lines.
+- **Statistic:** **median** of the successful `tapOn` durations (robust to a single slow tap), in ms.
+- **Threshold:** degraded when `median ≥ floorMs`, default **1500** (1.5s), overridable via `RN_RUNTIME_DEGRADED_FLOOR_MS` (parsed defensively; invalid → default).
+- **Gate:** evaluated **only on a failed flow** — never nag on a passing-but-slow run.
+
+## Architecture
+
+```
+maestro_run failure branch (maestro-run.ts)
+  └─ classifyRuntimeDegradation(output, floorMs)        [domain/tap-latency.ts — pure, no I/O]
+       ├─ parseTapLatencies(output): number[] (ms)      regex over `tapOn ... (<N>s)` lines
+       └─ median ≥ floor ? { degraded:true, medianMs, floorMs, sampleCount } : { degraded:false, ... }
+  └─ if degraded: augment the failResult with meta.runtimeDegraded + a RUNTIME_DEGRADED hint line
+```
+
+### Component: `src/domain/tap-latency.ts` (new, pure)
+
+- `parseTapLatencies(output: string): number[]` — scan lines, match **successful** `tapOn` step lines (the `✓` marker) with a trailing `(<float>s)`, convert seconds→ms, return all samples (order preserved). Tolerant: ignores `✗` (failed/timed-out) tap lines, non-`tapOn` step lines (launchApp/assertVisible/etc.), the final `rn-maestro-run` summary line, and any line without a parseable duration. Returns `[]` when nothing matches.
+- `median(samples: number[]): number | null` — null on empty; average of the two middle values for even counts.
+- `classifyRuntimeDegradation(output: string, floorMs: number): { degraded: boolean; medianMs: number | null; floorMs: number; sampleCount: number }` — `degraded = medianMs != null && medianMs >= floorMs`.
+- `resolveFloorMs(env?: string): number` — parse `RN_RUNTIME_DEGRADED_FLOOR_MS`; positive finite integer wins, else `DEFAULT_FLOOR_MS = 1500`.
+
+### Integration: `maestro-run.ts`
+
+In the existing failure path (after `outputIndicatesFlowFailure` determines failure), call `classifyRuntimeDegradation(output, resolveFloorMs(process.env.RN_RUNTIME_DEGRADED_FLOOR_MS))`. If `degraded`:
+- add `meta.runtimeDegraded = { medianTapMs, floorMs, sampleCount }` to the failResult, and
+- append to the error message:
+  `RUNTIME_DEGRADED: median tapOn latency <medianTapMs>ms (≥ <floorMs>ms) — the simulator test runtime is likely wedged; reboot it (xcrun simctl shutdown <udid> && xcrun simctl boot <udid>), relaunch the app, and retry.`
+
+The hint is **purely additive** — it never changes the pass/fail verdict, never alters a passing result, and is appended only to an already-failing `maestro_run` result.
+
+## Error handling — fail-open
+
+`parseTapLatencies`/`classifyRuntimeDegradation` never throw. If the output has no parseable `tapOn` durations (format drift, a flow with no taps), `medianMs` is null → not degraded → no hint → original failResult unchanged. Format drift degrades to "no hint," never a crash or a false alarm.
+
+## Testing
+
+- **`tap-latency.test.js`** (pure unit):
+  - `parseTapLatencies`: real-format fixture with mixed `✓/✗ tapOn (Ns)` + non-tap lines + summary line → only the `✓` tapOn durations in ms (the `✗` timeout excluded); no-tap output → `[]`; malformed/no-paren lines skipped. Critical case: a single-tap flow that fails with one `✗ tapOn (12.7s)` → `[]` (no `✓` samples) → NOT degraded (guards the normal-failure false-positive).
+  - `median`: odd, even, single, empty(→null).
+  - `classifyRuntimeDegradation`: degraded fixture (median ≥ 1500 → degraded with correct medianMs/sampleCount); normal fixture (< 1500 → not degraded); no-timings (→ not degraded, medianMs null).
+  - `resolveFloorMs`: default 1500; valid env override; invalid env (`abc`, `0`, negative) → default.
+- **`maestro-run` integration:** failed flow + degraded-latency output → result carries the `RUNTIME_DEGRADED` hint + `meta.runtimeDegraded`; failed flow + normal latency → no hint; **passing flow → never a hint** (assert even with high latencies in a passing run).
+
+## Out of scope
+
+- A `device_reboot` MCP tool and auto-reboot-and-retry (deferred; the hint is the v1 deliverable).
+- Degradation detection on the `device_*` (L2) tap path — this targets `maestro_run`/learned-action replays where the reporter hit it. A `device_*` extension can reuse `tap-latency` later.
+- A per-action RunRecord latency baseline — RunRecord stores only whole-flow `durationMs`; a fixed floor is simpler and stateless. (Revisit if the fixed floor proves noisy across machines.)
+
+## Refs
+
+`src/tools/maestro-run.ts` (failure branch, already captures `output`), new `src/domain/tap-latency.ts`; real output format from `test/unit/maestro-error-parser.test.js` fixtures. Related #202 (runner contention — possible root cause), #211 (structured step results), #194 (recovery loops). Issue #263.

--- a/docs/superpowers/specs/2026-06-14-263-runtime-degraded-detection-design.md
+++ b/docs/superpowers/specs/2026-06-14-263-runtime-degraded-detection-design.md
@@ -20,8 +20,9 @@ A recurring iOS failure mode: tap latencies degrade 3–4× (~0.7s → ~2.6–3.
   ```
   Each `tapOn` step line ends with a parenthesized duration in **seconds**.
 - **Only `✓` (successful) tapOn lines count.** A `✗` line's duration is the step *timeout* (e.g. 12.7s), not a tap latency — including it would false-positive on an ordinary "element not found" failure (one timed-out tap → median ≥ floor → bogus hint). The wedge signal is in the *successful* taps being slow (the reporter's 2.6–3.0s were completed taps). So the parser ignores `✗` lines.
-- **Statistic:** **median** of the successful `tapOn` durations (robust to a single slow tap), in ms.
-- **Threshold:** degraded when `median ≥ floorMs`, default **1500** (1.5s), overridable via `RN_RUNTIME_DEGRADED_FLOOR_MS` (parsed defensively; invalid → default).
+- **Statistic:** **median** of the successful `tapOn` durations, in ms.
+- **Minimum samples:** require **≥2** successful-tap samples before flagging degraded. A single slow tap (e.g. a cold-start navigation tap > 1.5s) is normal variance — `median` of one sample is just that value, so without this guard an ordinary element-not-found failure that happened after one slow nav tap would mis-fire "reboot" (the exact misdirection this feature fights; caught in multi-LLM review against the canonical #105 fixture). A real wedge degrades *multiple* taps (the reporter saw 2.6–3.0s across the replay), so ≥2 preserves true-positive detection.
+- **Threshold:** degraded when `sampleCount ≥ 2 && median ≥ floorMs`, default floor **1500** (1.5s), overridable via `RN_RUNTIME_DEGRADED_FLOOR_MS` (parsed defensively; invalid → default).
 - **Gate:** evaluated **only on a failed flow** — never nag on a passing-but-slow run.
 
 ## Architecture

--- a/scripts/cdp-bridge/dist/domain/tap-latency.js
+++ b/scripts/cdp-bridge/dist/domain/tap-latency.js
@@ -12,10 +12,11 @@ export function parseTapLatencies(output) {
     const out = [];
     for (const raw of output.split('\n')) {
         const line = raw.trim();
-        if (!line.startsWith('✓'))
-            continue; // successful steps only
-        if (!/\btapOn\b/.test(line))
-            continue; // tap steps only
+        // Anchor on the step verb (`✓ tapOn:`) so "tapOn" inside another step's
+        // text/selector value (e.g. `✓ assertVisible: text="tapOn …"`) is not
+        // counted. Successful (✓) steps only — a ✗ duration is the step timeout.
+        if (!/^✓\s+tapOn\b/.test(line))
+            continue;
         const m = line.match(/\(([\d.]+)s\)\s*$/); // trailing (N.Ns)
         if (!m)
             continue;
@@ -38,11 +39,16 @@ export function resolveFloorMs(envVal) {
     const n = Number(envVal);
     return Number.isFinite(n) && n > 0 ? n : DEFAULT_FLOOR_MS;
 }
+// Require at least this many successful-tap samples before attributing slowness
+// to a wedge. A single slow tap (e.g. a cold-start navigation tap) is normal
+// variance — flagging it would mis-hint "reboot" on an ordinary element-not-found
+// failure, the exact misdirection this feature fights (review finding #1).
+const MIN_SAMPLES_FOR_DEGRADED = 2;
 export function classifyRuntimeDegradation(output, floorMs) {
     const samples = parseTapLatencies(output);
     const medianMs = median(samples);
     return {
-        degraded: medianMs != null && medianMs >= floorMs,
+        degraded: medianMs != null && samples.length >= MIN_SAMPLES_FOR_DEGRADED && medianMs >= floorMs,
         medianMs,
         floorMs,
         sampleCount: samples.length,

--- a/scripts/cdp-bridge/dist/domain/tap-latency.js
+++ b/scripts/cdp-bridge/dist/domain/tap-latency.js
@@ -1,0 +1,70 @@
+// src/domain/tap-latency.ts
+// GH #263: detect a wedged simulator test-runtime from maestro-runner output.
+// Pure, no I/O. Fail-open: unparseable output yields no samples → no hint.
+export const DEFAULT_FLOOR_MS = 1500;
+/**
+ * Extract latencies (ms) of SUCCESSFUL tapOn steps from maestro-runner output.
+ * maestro-runner prints each step as `  ✓ tapOn: id="x" (2.8s)` (seconds, in
+ * parens at end). Only ✓ lines count: a ✗ line's duration is the step TIMEOUT
+ * (~12.7s), which would false-positive an ordinary element-not-found failure.
+ */
+export function parseTapLatencies(output) {
+    const out = [];
+    for (const raw of output.split('\n')) {
+        const line = raw.trim();
+        if (!line.startsWith('✓'))
+            continue; // successful steps only
+        if (!/\btapOn\b/.test(line))
+            continue; // tap steps only
+        const m = line.match(/\(([\d.]+)s\)\s*$/); // trailing (N.Ns)
+        if (!m)
+            continue;
+        const seconds = Number(m[1]);
+        if (Number.isFinite(seconds))
+            out.push(Math.round(seconds * 1000));
+    }
+    return out;
+}
+export function median(samples) {
+    if (samples.length === 0)
+        return null;
+    const s = [...samples].sort((a, b) => a - b);
+    const mid = Math.floor(s.length / 2);
+    return s.length % 2 === 0 ? Math.round((s[mid - 1] + s[mid]) / 2) : s[mid];
+}
+export function resolveFloorMs(envVal) {
+    if (envVal === undefined)
+        return DEFAULT_FLOOR_MS;
+    const n = Number(envVal);
+    return Number.isFinite(n) && n > 0 ? n : DEFAULT_FLOOR_MS;
+}
+export function classifyRuntimeDegradation(output, floorMs) {
+    const samples = parseTapLatencies(output);
+    const medianMs = median(samples);
+    return {
+        degraded: medianMs != null && medianMs >= floorMs,
+        medianMs,
+        floorMs,
+        sampleCount: samples.length,
+    };
+}
+export function formatRuntimeDegradedHint(d) {
+    return `RUNTIME_DEGRADED: median tapOn latency ${d.medianMs}ms (>= ${d.floorMs}ms) — `
+        + `the simulator test runtime is likely wedged; reboot it `
+        + `(xcrun simctl shutdown <udid> && xcrun simctl boot <udid>), relaunch the app, and retry.`;
+}
+/**
+ * Integration helper: given the runner output and an already-built failure
+ * (message + meta), append the RUNTIME_DEGRADED hint + meta.runtimeDegraded
+ * IFF degraded. Returns the base unchanged otherwise. Call ONLY on a failure
+ * path — never on a passing flow (a passing-but-slow run must not be hinted).
+ */
+export function augmentFailureWithDegradation(output, floorMs, baseMessage, baseMeta) {
+    const d = classifyRuntimeDegradation(output, floorMs);
+    if (!d.degraded)
+        return { message: baseMessage, meta: baseMeta };
+    return {
+        message: `${baseMessage} — ${formatRuntimeDegradedHint(d)}`,
+        meta: { ...baseMeta, runtimeDegraded: { medianTapMs: d.medianMs, floorMs: d.floorMs, sampleCount: d.sampleCount } },
+    };
+}

--- a/scripts/cdp-bridge/dist/tools/maestro-run.js
+++ b/scripts/cdp-bridge/dist/tools/maestro-run.js
@@ -10,6 +10,7 @@ import { chooseMaestroDispatch, shouldWarnFallback } from './maestro-dispatch.js
 import { resolveAppFileForClearState } from './resolve-ios-app-file.js';
 import { buildMaestroFlow, parseAndValidateFlow, isValidBundleId, MaestroValidationError, } from '../domain/maestro-validator.js';
 import { outputIndicatesFlowFailure } from '../domain/maestro-error-parser.js';
+import { augmentFailureWithDegradation, resolveFloorMs } from '../domain/tap-latency.js';
 import { stopFastRunner as defaultStopFastRunner } from '../runners/rn-fast-runner-client.js';
 import { releaseAndroidInteractionSlot as defaultReleaseAndroidSlot } from '../runners/release-android-slot.js';
 import { markCdpStale as defaultMarkCdpStale } from '../cdp/recovery.js';
@@ -188,9 +189,12 @@ export function createMaestroRunHandler() {
                 }
                 return okResult(meta);
             }
-            return warnResult(meta, dispatch.fallbackReason
+            const baseWarnMsg = dispatch.fallbackReason
                 ? `${dispatch.fallbackReason}; flow completed with warnings or failures`
-                : 'Flow completed with warnings or failures');
+                : 'Flow completed with warnings or failures';
+            // GH #263: classify on the FULL output (not the sliced meta.output).
+            const warnAug = augmentFailureWithDegradation(output, resolveFloorMs(process.env.RN_RUNTIME_DEGRADED_FLOOR_MS), baseWarnMsg, meta);
+            return warnResult(warnAug.meta, warnAug.message);
         }
         catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
@@ -206,7 +210,9 @@ export function createMaestroRunHandler() {
             const stdout = typeof errAny?.stdout === 'string' ? errAny.stdout : '';
             const stderr = typeof errAny?.stderr === 'string' ? errAny.stderr : '';
             const combined = (stdout + '\n' + stderr).trim();
-            return failResult(`Maestro flow failed: ${msg.slice(0, 500)}`, {
+            // GH #263: a timeout/non-zero exit is also a failure surface — flag a
+            // wedged runtime here too if the successful taps were degraded.
+            const failAug = augmentFailureWithDegradation(combined, resolveFloorMs(process.env.RN_RUNTIME_DEGRADED_FLOOR_MS), `Maestro flow failed: ${msg.slice(0, 500)}`, {
                 flowFile,
                 platform,
                 runner: dispatch.runner,
@@ -215,6 +221,7 @@ export function createMaestroRunHandler() {
                 // it the same way regardless of which path they hit.
                 output: combined.slice(0, 4000),
             });
+            return failResult(failAug.message, failAug.meta);
         }
     };
 }

--- a/scripts/cdp-bridge/src/domain/tap-latency.ts
+++ b/scripts/cdp-bridge/src/domain/tap-latency.ts
@@ -14,8 +14,10 @@ export function parseTapLatencies(output: string): number[] {
   const out: number[] = [];
   for (const raw of output.split('\n')) {
     const line = raw.trim();
-    if (!line.startsWith('✓')) continue;       // successful steps only
-    if (!/\btapOn\b/.test(line)) continue;     // tap steps only
+    // Anchor on the step verb (`✓ tapOn:`) so "tapOn" inside another step's
+    // text/selector value (e.g. `✓ assertVisible: text="tapOn …"`) is not
+    // counted. Successful (✓) steps only — a ✗ duration is the step timeout.
+    if (!/^✓\s+tapOn\b/.test(line)) continue;
     const m = line.match(/\(([\d.]+)s\)\s*$/); // trailing (N.Ns)
     if (!m) continue;
     const seconds = Number(m[1]);
@@ -44,11 +46,17 @@ export interface RuntimeDegradation {
   sampleCount: number;
 }
 
+// Require at least this many successful-tap samples before attributing slowness
+// to a wedge. A single slow tap (e.g. a cold-start navigation tap) is normal
+// variance — flagging it would mis-hint "reboot" on an ordinary element-not-found
+// failure, the exact misdirection this feature fights (review finding #1).
+const MIN_SAMPLES_FOR_DEGRADED = 2;
+
 export function classifyRuntimeDegradation(output: string, floorMs: number): RuntimeDegradation {
   const samples = parseTapLatencies(output);
   const medianMs = median(samples);
   return {
-    degraded: medianMs != null && medianMs >= floorMs,
+    degraded: medianMs != null && samples.length >= MIN_SAMPLES_FOR_DEGRADED && medianMs >= floorMs,
     medianMs,
     floorMs,
     sampleCount: samples.length,

--- a/scripts/cdp-bridge/src/domain/tap-latency.ts
+++ b/scripts/cdp-bridge/src/domain/tap-latency.ts
@@ -1,0 +1,82 @@
+// src/domain/tap-latency.ts
+// GH #263: detect a wedged simulator test-runtime from maestro-runner output.
+// Pure, no I/O. Fail-open: unparseable output yields no samples → no hint.
+
+export const DEFAULT_FLOOR_MS = 1500;
+
+/**
+ * Extract latencies (ms) of SUCCESSFUL tapOn steps from maestro-runner output.
+ * maestro-runner prints each step as `  ✓ tapOn: id="x" (2.8s)` (seconds, in
+ * parens at end). Only ✓ lines count: a ✗ line's duration is the step TIMEOUT
+ * (~12.7s), which would false-positive an ordinary element-not-found failure.
+ */
+export function parseTapLatencies(output: string): number[] {
+  const out: number[] = [];
+  for (const raw of output.split('\n')) {
+    const line = raw.trim();
+    if (!line.startsWith('✓')) continue;       // successful steps only
+    if (!/\btapOn\b/.test(line)) continue;     // tap steps only
+    const m = line.match(/\(([\d.]+)s\)\s*$/); // trailing (N.Ns)
+    if (!m) continue;
+    const seconds = Number(m[1]);
+    if (Number.isFinite(seconds)) out.push(Math.round(seconds * 1000));
+  }
+  return out;
+}
+
+export function median(samples: number[]): number | null {
+  if (samples.length === 0) return null;
+  const s = [...samples].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 === 0 ? Math.round((s[mid - 1] + s[mid]) / 2) : s[mid];
+}
+
+export function resolveFloorMs(envVal?: string): number {
+  if (envVal === undefined) return DEFAULT_FLOOR_MS;
+  const n = Number(envVal);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_FLOOR_MS;
+}
+
+export interface RuntimeDegradation {
+  degraded: boolean;
+  medianMs: number | null;
+  floorMs: number;
+  sampleCount: number;
+}
+
+export function classifyRuntimeDegradation(output: string, floorMs: number): RuntimeDegradation {
+  const samples = parseTapLatencies(output);
+  const medianMs = median(samples);
+  return {
+    degraded: medianMs != null && medianMs >= floorMs,
+    medianMs,
+    floorMs,
+    sampleCount: samples.length,
+  };
+}
+
+export function formatRuntimeDegradedHint(d: RuntimeDegradation): string {
+  return `RUNTIME_DEGRADED: median tapOn latency ${d.medianMs}ms (>= ${d.floorMs}ms) — `
+    + `the simulator test runtime is likely wedged; reboot it `
+    + `(xcrun simctl shutdown <udid> && xcrun simctl boot <udid>), relaunch the app, and retry.`;
+}
+
+/**
+ * Integration helper: given the runner output and an already-built failure
+ * (message + meta), append the RUNTIME_DEGRADED hint + meta.runtimeDegraded
+ * IFF degraded. Returns the base unchanged otherwise. Call ONLY on a failure
+ * path — never on a passing flow (a passing-but-slow run must not be hinted).
+ */
+export function augmentFailureWithDegradation(
+  output: string,
+  floorMs: number,
+  baseMessage: string,
+  baseMeta: Record<string, unknown>,
+): { message: string; meta: Record<string, unknown> } {
+  const d = classifyRuntimeDegradation(output, floorMs);
+  if (!d.degraded) return { message: baseMessage, meta: baseMeta };
+  return {
+    message: `${baseMessage} — ${formatRuntimeDegradedHint(d)}`,
+    meta: { ...baseMeta, runtimeDegraded: { medianTapMs: d.medianMs, floorMs: d.floorMs, sampleCount: d.sampleCount } },
+  };
+}

--- a/scripts/cdp-bridge/src/tools/maestro-run.ts
+++ b/scripts/cdp-bridge/src/tools/maestro-run.ts
@@ -16,6 +16,7 @@ import {
   MaestroValidationError,
 } from '../domain/maestro-validator.js';
 import { outputIndicatesFlowFailure } from '../domain/maestro-error-parser.js';
+import { augmentFailureWithDegradation, resolveFloorMs } from '../domain/tap-latency.js';
 import { stopFastRunner as defaultStopFastRunner } from '../runners/rn-fast-runner-client.js';
 import { releaseAndroidInteractionSlot as defaultReleaseAndroidSlot } from '../runners/release-android-slot.js';
 import { markCdpStale as defaultMarkCdpStale } from '../cdp/recovery.js';
@@ -241,12 +242,17 @@ export function createMaestroRunHandler(): (args: MaestroRunArgs) => Promise<Too
         }
         return okResult(meta);
       }
-      return warnResult(
+      const baseWarnMsg = dispatch.fallbackReason
+        ? `${dispatch.fallbackReason}; flow completed with warnings or failures`
+        : 'Flow completed with warnings or failures';
+      // GH #263: classify on the FULL output (not the sliced meta.output).
+      const warnAug = augmentFailureWithDegradation(
+        output,
+        resolveFloorMs(process.env.RN_RUNTIME_DEGRADED_FLOOR_MS),
+        baseWarnMsg,
         meta,
-        dispatch.fallbackReason
-          ? `${dispatch.fallbackReason}; flow completed with warnings or failures`
-          : 'Flow completed with warnings or failures',
       );
+      return warnResult(warnAug.meta, warnAug.message);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       // Multi-LLM review of PR #115 (Codex conf 95): when execFile
@@ -261,15 +267,23 @@ export function createMaestroRunHandler(): (args: MaestroRunArgs) => Promise<Too
       const stdout = typeof errAny?.stdout === 'string' ? errAny.stdout : '';
       const stderr = typeof errAny?.stderr === 'string' ? errAny.stderr : '';
       const combined = (stdout + '\n' + stderr).trim();
-      return failResult(`Maestro flow failed: ${msg.slice(0, 500)}`, {
-        flowFile,
-        platform,
-        runner: dispatch.runner,
-        passed: false,
-        // `output` mirrors the success/warn shape so callers can read
-        // it the same way regardless of which path they hit.
-        output: combined.slice(0, 4000),
-      });
+      // GH #263: a timeout/non-zero exit is also a failure surface — flag a
+      // wedged runtime here too if the successful taps were degraded.
+      const failAug = augmentFailureWithDegradation(
+        combined,
+        resolveFloorMs(process.env.RN_RUNTIME_DEGRADED_FLOOR_MS),
+        `Maestro flow failed: ${msg.slice(0, 500)}`,
+        {
+          flowFile,
+          platform,
+          runner: dispatch.runner,
+          passed: false,
+          // `output` mirrors the success/warn shape so callers can read
+          // it the same way regardless of which path they hit.
+          output: combined.slice(0, 4000),
+        },
+      );
+      return failResult(failAug.message, failAug.meta);
     }
   };
 }

--- a/scripts/cdp-bridge/test/unit/gh-263-tap-latency.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-263-tap-latency.test.js
@@ -38,6 +38,30 @@ test('parseTapLatencies: output with no tapOn lines → []', () => {
   assert.deepEqual(parseTapLatencies(''), []);
 });
 
+// Review finding #2: a non-tap step whose text VALUE contains "tapOn" must not
+// be counted (anchor on the step verb, not a substring match).
+test('parseTapLatencies: "tapOn" inside another step\'s text value is not a tap sample', () => {
+  assert.deepEqual(parseTapLatencies('  ✓ assertVisible: text="tapOn the button" (3.0s)'), []);
+});
+
+// Review finding #1 (both reviewers, verified vs the canonical #105 fixture):
+// one successful tap before an element-not-found failure must NOT be flagged
+// degraded — a single slow cold-start tap is normal, and hinting "reboot" on an
+// ordinary missing-element failure is the exact misdirection this feature fights.
+const SINGLE_SUCCESS_THEN_NOTFOUND = `  ✓ launchApp (2.3s)
+  ✓ tapOn: id="tab-tasks" (2.8s)
+  ✓ assertVisible: text="Tasks" (1.3s)
+  ✗ tapOn: id="task-mark-all-done" (12.7s)
+      ╰─ Element not found: id='task-mark-all-done'
+✗ rn-maestro-run 23.8s`;
+
+test('classifyRuntimeDegradation: a single successful slow tap is NOT degraded (needs ≥2 samples)', () => {
+  const d = classifyRuntimeDegradation(SINGLE_SUCCESS_THEN_NOTFOUND, 1500);
+  assert.equal(d.sampleCount, 1);
+  assert.equal(d.medianMs, 2800);
+  assert.equal(d.degraded, false, 'one slow tap is not enough evidence of a wedge');
+});
+
 test('median: odd, even, single, empty', () => {
   assert.equal(median([3000, 2800, 1000]), 2800);  // sorted 1000,2800,3000
   assert.equal(median([2800, 3000]), 2900);        // average of two middle

--- a/scripts/cdp-bridge/test/unit/gh-263-tap-latency.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-263-tap-latency.test.js
@@ -1,0 +1,99 @@
+// test/unit/gh-263-tap-latency.test.js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseTapLatencies, median, resolveFloorMs, classifyRuntimeDegradation,
+  formatRuntimeDegradedHint, augmentFailureWithDegradation, DEFAULT_FLOOR_MS,
+} from '../../dist/domain/tap-latency.js';
+
+const DEGRADED = `  ✓ launchApp (2.3s)
+  ✓ tapOn: id="a" (2.8s)
+  ✓ tapOn: id="b" (3.0s)
+  ✓ assertVisible: text="x" (1.1s)
+  ✗ tapOn: id="c" (12.7s)
+✗ rn-maestro-run 23.8s`;
+
+const NORMAL = `  ✓ launchApp (1.0s)
+  ✓ tapOn: id="a" (0.7s)
+  ✓ tapOn: id="b" (0.9s)
+  ✗ assertVisible: text="x" (10.0s)
+✗ rn-maestro-run 12.0s`;
+
+// A genuine "element not found" failure with ONE tap that timed out — the ✗
+// duration must NOT be counted, else this false-positives as degraded.
+const SINGLE_FAILED_TAP = `  ✓ launchApp (1.1s)
+  ✗ tapOn: id="missing" (12.7s)
+✗ rn-maestro-run 14.0s`;
+
+test('parseTapLatencies: only successful (✓) tapOn lines, seconds→ms', () => {
+  assert.deepEqual(parseTapLatencies(DEGRADED), [2800, 3000]);
+});
+
+test('parseTapLatencies: a single failed (✗) tap yields no samples (no false positive)', () => {
+  assert.deepEqual(parseTapLatencies(SINGLE_FAILED_TAP), []);
+});
+
+test('parseTapLatencies: output with no tapOn lines → []', () => {
+  assert.deepEqual(parseTapLatencies('  ✓ launchApp (2.0s)\n✓ rn-maestro-run 2.0s'), []);
+  assert.deepEqual(parseTapLatencies(''), []);
+});
+
+test('median: odd, even, single, empty', () => {
+  assert.equal(median([3000, 2800, 1000]), 2800);  // sorted 1000,2800,3000
+  assert.equal(median([2800, 3000]), 2900);        // average of two middle
+  assert.equal(median([1500]), 1500);
+  assert.equal(median([]), null);
+});
+
+test('resolveFloorMs: default, valid override, invalid → default', () => {
+  assert.equal(resolveFloorMs(undefined), DEFAULT_FLOOR_MS);
+  assert.equal(DEFAULT_FLOOR_MS, 1500);
+  assert.equal(resolveFloorMs('2000'), 2000);
+  assert.equal(resolveFloorMs('abc'), DEFAULT_FLOOR_MS);
+  assert.equal(resolveFloorMs('0'), DEFAULT_FLOOR_MS);
+  assert.equal(resolveFloorMs('-5'), DEFAULT_FLOOR_MS);
+});
+
+test('classifyRuntimeDegradation: degraded when median ≥ floor', () => {
+  const d = classifyRuntimeDegradation(DEGRADED, 1500);
+  assert.equal(d.degraded, true);
+  assert.equal(d.medianMs, 2900);   // median of [2800,3000]
+  assert.equal(d.sampleCount, 2);
+  assert.equal(d.floorMs, 1500);
+});
+
+test('classifyRuntimeDegradation: normal latency is not degraded', () => {
+  const d = classifyRuntimeDegradation(NORMAL, 1500);
+  assert.equal(d.degraded, false);
+  assert.equal(d.medianMs, 800);    // median of [700,900]
+});
+
+test('classifyRuntimeDegradation: no tap samples → not degraded, medianMs null', () => {
+  const d = classifyRuntimeDegradation(SINGLE_FAILED_TAP, 1500);
+  assert.equal(d.degraded, false);
+  assert.equal(d.medianMs, null);
+  assert.equal(d.sampleCount, 0);
+});
+
+test('formatRuntimeDegradedHint: names the code, median, floor, and reboot', () => {
+  const hint = formatRuntimeDegradedHint(classifyRuntimeDegradation(DEGRADED, 1500));
+  assert.match(hint, /RUNTIME_DEGRADED/);
+  assert.match(hint, /2900ms/);
+  assert.match(hint, /1500ms/);
+  assert.match(hint, /simctl shutdown/);
+});
+
+test('augmentFailureWithDegradation: degraded → hint appended + meta.runtimeDegraded', () => {
+  const { message, meta } = augmentFailureWithDegradation(DEGRADED, 1500, 'Flow failed', { passed: false });
+  assert.match(message, /Flow failed — RUNTIME_DEGRADED:/);
+  assert.deepEqual(meta.runtimeDegraded, { medianTapMs: 2900, floorMs: 1500, sampleCount: 2 });
+  assert.equal(meta.passed, false); // base meta preserved
+});
+
+test('augmentFailureWithDegradation: not degraded → message + meta unchanged', () => {
+  const base = { passed: false, output: 'x' };
+  const { message, meta } = augmentFailureWithDegradation(NORMAL, 1500, 'Flow failed', base);
+  assert.equal(message, 'Flow failed');
+  assert.equal(meta.runtimeDegraded, undefined);
+  assert.deepEqual(meta, base);
+});


### PR DESCRIPTION
## Summary

When the iOS simulator test-runtime wedges, tap latency degrades 3–4× (~0.7s → ~2.6–3.0s), taps report success but `onPress` never fires, and learned-action replays fail at random steps — but the failure surfaces as a misleading "Element not found", so the agent chases app code instead of the documented `simctl shutdown && boot` fix (GH #263).

This makes the failure name its likely cause: on a **failed** `maestro_run` whose successful taps were degraded, the result gains a structured `RUNTIME_DEGRADED` hint + `meta.runtimeDegraded`.

## How

- **Signal:** parse the median latency of **successful (`✓`) `tapOn`** steps from the output `maestro_run` already captures (real maestro-runner format, pinned from existing parser-test fixtures — no live capture, no #211 dependency). `✓`-only because a `✗` line's duration is the step *timeout*.
- **Threshold:** degraded when `sampleCount ≥ 2 && median ≥ floor` (default **1500ms**, `RN_RUNTIME_DEGRADED_FLOOR_MS`). The ≥2-sample guard prevents a single slow cold-start tap from mis-firing on an ordinary element-not-found failure.
- **Additive & failure-only:** wired into both failure returns (the "completed with failures" `warnResult` and the catch-path `failResult`); never alters a pass/fail verdict, never fires on a passing flow. Fail-open: unparseable output → no hint.
- New pure module `src/domain/tap-latency.ts` (parse / median / classify / format / augment), fully unit-tested.

## Verification

- TDD, 13 unit tests (parser ✓-only incl. the single-`✗`-tap and `tapOn`-in-text guards, median, classify, floor-resolve, the integration helper). Full suite **2063/2063**; dist tracked + in sync.
- **Multi-LLM final review (Codex + Antigravity):** both independently caught a single-sample false-positive against the project's canonical #105 fixture (one slow nav tap + element-not-found → bogus "reboot" hint). Fixed pre-merge with the `≥2`-sample guard + a regression test; the misleading-parse nit (`tapOn` inside a text value) fixed by anchoring the regex.

No live device gate: the detector is pure string analysis over already-captured output (a live wedge isn't deterministically reproducible). Scope deliberately excludes a `device_reboot` tool / auto-retry (deferred).

Spec: `docs/superpowers/specs/2026-06-14-263-runtime-degraded-detection-design.md` · Plan: `docs/superpowers/plans/2026-06-14-263-runtime-degraded-detection.md`

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)