### PR TITLE
feat(#211): maestro_run structured step results + partial progress on timeout

### DIFF
--- a/.changeset/maestro-structured-step-results.md
+++ b/.changeset/maestro-structured-step-results.md
@@ -1,0 +1,8 @@
+---
+"rn-dev-agent-cdp": patch
+"rn-dev-agent-plugin": patch
+---
+
+`maestro_run` now returns structured per-step results and partial progress on timeout (GH #211).
+
+The result gains `steps[]` (`{index,name,verb,status,durationMs}`), `failedStep`, `reason` (sanitized `{kind,selector}` — never the raw runner log), `lastStep` (progress marker), `timedOut`, and `outputTruncated`. On timeout the partial steps are returned instead of a bare failure, and the failure headline names the failing/last step. Parsed from maestro-runner stdout (the JVM Maestro CLI fallback degrades fail-open to empty steps); `tapOn` latencies for #263 now derive from the shared parser. Additive — `output` is preserved for `run-action` consumers.

--- a/docs/superpowers/plans/2026-06-14-211-maestro-structured-results.md
+++ b/docs/superpowers/plans/2026-06-14-211-maestro-structured-results.md
@@ -303,7 +303,7 @@ git commit -m "feat(#211): buildStepSummary + helpers (raw-free reason, terminal
 - [ ] **Step 1: Write the failing test** (append)
 
 ```js
-import { classifyExecError } from '../../dist/domain/maestro-step-parser.js';
+import { classifyExecError, formatFailureHeadline } from '../../dist/domain/maestro-step-parser.js';
 
 test('classifyExecError: timeout (killed, no code) → timedOut, not truncated', () => {
   assert.deepEqual(
@@ -335,6 +335,28 @@ test('catch-path assembly: timeout → timedOut, partial steps, failedStep null'
   assert.equal(summary.failedStep, null);
   assert.equal(summary.lastStep.name, 'tapOn: id="a"');
 });
+
+test('formatFailureHeadline: structured & raw-free; raw fallback only for system errors', () => {
+  const t = buildStepSummary('  ✓ launchApp (2.0s)\n  ✓ tapOn: id="a" (2.5s)', { failed: true });
+  assert.equal(
+    formatFailureHeadline(t, { timedOut: true, outputTruncated: false }, 'Command failed: …'),
+    'Maestro flow timed out after step "tapOn: id="a""',
+  );
+  const f = buildStepSummary('  ✗ tapOn: id="c" (12.7s)\nElement with id \'c\' not found', { failed: true });
+  assert.equal(
+    formatFailureHeadline(f, { timedOut: false, outputTruncated: false }, 'x'),
+    'Maestro flow failed at step "tapOn: id="c"" (SELECTOR_NOT_FOUND: c)',
+  );
+  const empty = { steps: [], failedStep: null, reason: null, lastStep: null };
+  assert.equal(
+    formatFailureHeadline(empty, { timedOut: false, outputTruncated: false }, 'spawn ENOENT'),
+    'Maestro flow failed: spawn ENOENT',
+  );
+  assert.equal(
+    formatFailureHeadline(empty, { timedOut: false, outputTruncated: true }, 'x'),
+    'Maestro flow output exceeded the 10MB buffer',
+  );
+});
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -360,6 +382,30 @@ export function classifyExecError(err: unknown): ExecErrorClass {
   const killed = e?.killed === true;
   const overflow = e?.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER';
   return { timedOut: killed && !overflow, outputTruncated: overflow };
+}
+
+// Headline for a failed maestro_run, built from STRUCTURED data so it never
+// re-embeds raw runner/app output. The raw fallbackMsg (err.message, which
+// execFile populates with stderr) is used ONLY when there is no structured
+// signal — e.g. a spawn/system error with no step output. Raw output still
+// lives in the bounded `output` field.
+export function formatFailureHeadline(
+  summary: StepSummary,
+  cls: ExecErrorClass,
+  fallbackMsg: string,
+): string {
+  if (cls.timedOut) {
+    return `Maestro flow timed out${summary.lastStep ? ` after step "${summary.lastStep.name}"` : ''}`;
+  }
+  if (cls.outputTruncated) {
+    return 'Maestro flow output exceeded the 10MB buffer';
+  }
+  if (summary.failedStep) {
+    const r = summary.reason;
+    const reasonStr = r ? ` (${r.kind}${r.selector ? `: ${r.selector}` : ''})` : '';
+    return `Maestro flow failed at step "${summary.failedStep.name}"${reasonStr}`;
+  }
+  return `Maestro flow failed: ${fallbackMsg.slice(0, 500)}`;
 }
 ```
 
@@ -428,7 +474,7 @@ git commit -m "refactor(#211): parseTapLatencies derives from shared parseSteps 
 - [ ] **Step 1: Add the import** (after line 19, alongside the other domain imports)
 
 ```ts
-import { buildStepSummary, classifyExecError } from '../domain/maestro-step-parser.js';
+import { buildStepSummary, classifyExecError, formatFailureHeadline } from '../domain/maestro-step-parser.js';
 ```
 
 - [ ] **Step 2: Rewrite the success/warn block**
@@ -488,12 +534,15 @@ Replace the catch body (current lines 256-287) with:
       const combined = (stdout + '\n' + stderr).trim();
       const { timedOut, outputTruncated } = classifyExecError(err);
       const summary = buildStepSummary(combined, { failed: true });
+      // Headline from structured data (raw-free); the raw err.message is the
+      // fallback only for system errors with no step output (e.g. spawn ENOENT).
+      const headline = formatFailureHeadline(summary, { timedOut, outputTruncated }, msg);
       // GH #263: a timeout/non-zero exit is also a failure surface — flag a
       // wedged runtime here too if the successful taps were degraded.
       const failAug = augmentFailureWithDegradation(
         combined,
         resolveFloorMs(process.env.RN_RUNTIME_DEGRADED_FLOOR_MS),
-        `Maestro flow failed: ${msg.slice(0, 500)}`,
+        headline,
         {
           flowFile,
           platform,
@@ -525,37 +574,36 @@ git commit -m "feat(#211): maestro_run returns steps/failedStep/reason/lastStep 
 
 ## Task 6: Changeset + final green
 
+> **Working dir for THIS task: repo root** (`/Users/anton_personal/GitHub/claude-react-native-dev-plugin`). Changesets live at repo-root `.changeset/`, NOT under `scripts/cdp-bridge/` (verified: `.changeset/gh-263-runtime-degraded.md`). `git add .changeset/` from the subdir would stage the wrong path and silently drop the changeset (codex-pair MED #2).
+
 **Files:**
-- Create: `scripts/cdp-bridge/.changeset/<run-name>.md` (or repo-root `.changeset/` — match where existing changesets live; check `ls .changeset` from repo root)
+- Create: `.changeset/maestro-structured-step-results.md` (repo root)
 
-- [ ] **Step 1: Locate the changeset dir**
+- [ ] **Step 1: Write the changeset** (two-package frontmatter, mirroring `.changeset/gh-263-runtime-degraded.md`)
 
-Run (from repo root): `ls .changeset/*.md | head` and open one to copy the frontmatter package name (e.g. `"rn-dev-agent"` / the cdp-bridge package name).
-
-- [ ] **Step 2: Write the changeset**
-
-Create `.changeset/maestro-structured-step-results.md` (use the package name from Step 1):
+Create `.changeset/maestro-structured-step-results.md`:
 
 ```markdown
 ---
-"<package-name-from-step-1>": patch
+"rn-dev-agent-cdp": patch
+"rn-dev-agent-plugin": patch
 ---
 
-maestro_run: structured per-step results (steps/failedStep/reason/lastStep) and
-partial progress on timeout. Parsed from maestro-runner stdout; reason is
-sanitized (no raw log); timeout is distinguished from maxBuffer overflow
-(timedOut vs outputTruncated). Fields are additive — output is preserved (#211).
+`maestro_run` now returns structured per-step results and partial progress on timeout (GH #211).
+
+The result gains `steps[]` (`{index,name,verb,status,durationMs}`), `failedStep`, `reason` (sanitized `{kind,selector}` — never the raw runner log), `lastStep` (progress marker), `timedOut`, and `outputTruncated`. On timeout the partial steps are returned instead of a bare failure, and the headline names the failing/last step. Parsed from maestro-runner stdout (the JVM Maestro CLI fallback degrades fail-open to empty steps); `tapOn` latencies for #263 now derive from the shared parser. Additive — `output` is preserved for `run-action` consumers.
 ```
 
-- [ ] **Step 3: Final full suite + typecheck**
+- [ ] **Step 2: Final full suite** (from `scripts/cdp-bridge`)
 
-Run (from `scripts/cdp-bridge`): `npm test`
-Expected: PASS, full suite green.
+Run: `cd scripts/cdp-bridge && npm test`
+Expected: PASS, full suite green (≥ the pre-change baseline of 2063).
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 3: Commit** (from repo root)
 
 ```bash
-git add .changeset/
+cd /Users/anton_personal/GitHub/claude-react-native-dev-plugin
+git add .changeset/maestro-structured-step-results.md
 git commit -m "chore(#211): changeset for maestro_run structured step results"
 ```
 
@@ -566,6 +614,11 @@ git commit -m "chore(#211): changeset for maestro_run structured step results"
 - **/multi-review** the diff (Gemini + Codex).
 - **On-device verify** (`maestro_run` on a real iOS sim flow): assert `data.steps`/`data.failedStep`/`data.lastStep` populate on pass and a forced-fail flow; settle the **ANSI question** empirically — `~/.maestro-runner/bin/maestro-runner --platform ios test <flow> | cat -v | grep -c '\^\['` (or pipe to a file and `grep -c $'\x1b'`); confirm `runFlow` sub-flow step rendering. Repeat one check on Android emulator.
 - Fix findings, re-run suite, finish branch → PR.
+
+## Amendments applied (codex-pair plan review, 2026-06-14)
+
+- **MED #1 — raw-free failure headline:** added pure `formatFailureHeadline(summary, cls, fallbackMsg)` (Task 3) and wired it in Task 5 so the catch-path headline is built from structured data (names the failing/last step) instead of `Maestro flow failed: ${err.message.slice(0,500)}`; the raw `err.message` is kept only as a fallback for system errors with no step output. Raw output stays in the bounded `output` field.
+- **MED #2 — changeset path:** Task 6 now runs from the repo root and stages the repo-root `.changeset/` explicitly (changesets are NOT under `scripts/cdp-bridge/`); two-package frontmatter (`rn-dev-agent-cdp` + `rn-dev-agent-plugin`).
 
 ## Self-Review
 

--- a/docs/superpowers/plans/2026-06-14-211-maestro-structured-results.md
+++ b/docs/superpowers/plans/2026-06-14-211-maestro-structured-results.md
@@ -1,0 +1,574 @@
+# maestro_run Structured Step Results — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `maestro_run` return structured per-step results (`steps`/`failedStep`/`reason`/`lastStep`) and partial progress on timeout, parsed from maestro-runner stdout.
+
+**Architecture:** One new pure module (`maestro-step-parser.ts`) parses the `{✓|✗} verb[: sel] (N.Ns)` step lines maestro-runner already prints; `tap-latency.ts` (#263) is refactored to derive its tap latencies from it; `maestro-run.ts` spreads the structured fields into the result payload on all three return paths (additive — `output` preserved for `run-action.ts`). Fields land in `envelope.data` on pass/warn and `envelope.meta` on fail.
+
+**Tech Stack:** TypeScript (ESM, `type:module`, Node ≥22), `node:test` + `node:assert/strict`, tests import compiled `dist/*.js` (`npm run build` = `tsc`).
+
+**Working dir for ALL commands:** `scripts/cdp-bridge/`
+
+---
+
+## File Structure
+
+- **Create** `scripts/cdp-bridge/src/domain/maestro-step-parser.ts` — pure helpers: `stripAnsi`, `parseSteps`, `findFailedStep`, `lastObservedStep`, `summarizeReason`, `buildStepSummary`, `classifyExecError` + types `MaestroStep`, `ReasonSummary`, `StepSummary`, `ExecErrorClass`.
+- **Modify** `scripts/cdp-bridge/src/domain/tap-latency.ts` — `parseTapLatencies` derives from `parseSteps`.
+- **Modify** `scripts/cdp-bridge/src/tools/maestro-run.ts` — import + spread structured fields on success/warn/catch paths.
+- **Create** `scripts/cdp-bridge/test/unit/gh-211-maestro-step-parser.test.js` — all pure-logic tests (parser, helpers, summary, exec-error, catch-path assembly).
+- **Unchanged guard** `scripts/cdp-bridge/test/unit/gh-263-tap-latency.test.js` — must stay green after Task 3.
+- **Create** `.changeset/<name>.md` — patch changeset.
+
+> Note: the spec mentioned a separate handler-level test file. It collapses to one file here because `createMaestroRunHandler()` has no `execFile` injection seam, and the existing test pattern (`gh-201`/`gh-202`) tests **exported pure helpers**, not the full handler. The handler wiring is covered by the type-checked build + full suite + on-device verification (phase 6).
+
+---
+
+## Task 1: Step parser core (`parseSteps`, `stripAnsi`, `MaestroStep`)
+
+**Files:**
+- Create: `scripts/cdp-bridge/src/domain/maestro-step-parser.ts`
+- Test: `scripts/cdp-bridge/test/unit/gh-211-maestro-step-parser.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/unit/gh-211-maestro-step-parser.test.js`:
+
+```js
+// test/unit/gh-211-maestro-step-parser.test.js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseSteps, stripAnsi } from '../../dist/domain/maestro-step-parser.js';
+
+// Real maestro-runner format (same shape as the gh-263 fixtures).
+const FAILED_RUN = `  ✓ launchApp (2.3s)
+  ✓ tapOn: id="a" (2.8s)
+  ✓ tapOn: id="b" (3.0s)
+  ✓ assertVisible: text="x" (1.1s)
+  ✗ tapOn: id="c" (12.7s)
+✗ rn-maestro-run 23.8s`;
+
+test('parseSteps: verb/status/durationMs/index; summary line excluded', () => {
+  const steps = parseSteps(FAILED_RUN);
+  assert.equal(steps.length, 5);
+  assert.deepEqual(steps[0], { index: 0, name: 'launchApp', verb: 'launchApp', status: 'pass', durationMs: 2300 });
+  assert.deepEqual(steps[1], { index: 1, name: 'tapOn: id="a"', verb: 'tapOn', status: 'pass', durationMs: 2800 });
+  assert.deepEqual(steps[4], { index: 4, name: 'tapOn: id="c"', verb: 'tapOn', status: 'fail', durationMs: 12700 });
+  assert.ok(!steps.some((s) => s.verb === 'rn-maestro-run')); // `✗ rn-maestro-run 23.8s` has no (N.Ns)
+});
+
+test('parseSteps: verb has trailing colon stripped', () => {
+  assert.equal(parseSteps('  ✓ tapOn: id="a" (1.0s)')[0].verb, 'tapOn');
+});
+
+test('parseSteps: verb is first token — verb name inside a selector value is not the verb', () => {
+  assert.equal(parseSteps('  ✓ assertVisible: text="tapOn now" (1.0s)')[0].verb, 'assertVisible');
+});
+
+test('parseSteps: count lines / bare text are not steps', () => {
+  assert.deepEqual(parseSteps('  3 steps passing\n  1 steps failing\nRunning on iPhone'), []);
+});
+
+test('parseSteps: embedded (N.Ns) in a selector — trailing duration wins', () => {
+  const steps = parseSteps('  ✓ assertVisible: text="took (2.0s)" (1.0s)');
+  assert.equal(steps.length, 1);
+  assert.equal(steps[0].durationMs, 1000);
+  assert.equal(steps[0].name, 'assertVisible: text="took (2.0s)"');
+});
+
+test('parseSteps: empty / garbage / non-string → [] (never throws)', () => {
+  assert.deepEqual(parseSteps(''), []);
+  assert.deepEqual(parseSteps('not maestro output'), []);
+  assert.deepEqual(parseSteps(undefined), []);
+});
+
+test('stripAnsi: removes SGR codes; ANSI-wrapped glyph line still parses', () => {
+  const colored = '  [32m✓[0m tapOn: id="a" (1.0s)';
+  assert.equal(stripAnsi(colored).includes(''), false);
+  const steps = parseSteps(colored);
+  assert.equal(steps.length, 1);
+  assert.equal(steps[0].verb, 'tapOn');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run build && node --test test/unit/gh-211-maestro-step-parser.test.js`
+Expected: FAIL — `Cannot find module .../dist/domain/maestro-step-parser.js` (module not yet created).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/domain/maestro-step-parser.ts`:
+
+```ts
+// src/domain/maestro-step-parser.ts
+// GH #211: structure maestro_run results from maestro-runner stdout. Pure, no
+// I/O, fail-open: unparseable output yields []. Generalizes the #263 step-line
+// parser (tap-latency.ts derives from parseSteps).
+
+export interface MaestroStep {
+  index: number;
+  name: string;
+  verb: string;
+  status: 'pass' | 'fail';
+  durationMs: number;
+}
+
+// Strip ANSI SGR/color escape sequences. execFile output is usually un-colored
+// (child stdout is a pipe, not a TTY) but maestro-runner is not guaranteed to
+// honor that, and a glyph-anchored match breaks on `[32m✓[0m`.
+const ANSI_RE = /\[[0-9;]*m/g;
+export function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, '');
+}
+
+// `  {✓|✗} <name> (N.Ns)` — the trailing (N.Ns) is REQUIRED, which excludes the
+// `✗ rn-maestro-run 23.8s` summary line and the `N steps passing` count lines.
+// `.*?` is non-greedy + `$`-anchored so a duration-looking token inside the
+// selector value (`text="took (2.0s)"`) loses to the real trailing duration.
+const STEP_RE = /^([✓✗])\s+(.*?)\s*\(([\d.]+)s\)\s*$/;
+
+export function parseSteps(output: string): MaestroStep[] {
+  if (!output || typeof output !== 'string') return [];
+  const steps: MaestroStep[] = [];
+  let index = 0;
+  for (const raw of stripAnsi(output).split('\n')) {
+    const m = STEP_RE.exec(raw.trim());
+    if (!m) continue;
+    const name = m[2].trim();
+    const verb = name.split(/\s+/)[0].replace(/:$/, '');
+    if (verb === 'rn-maestro-run') continue; // belt-and-suspenders vs a future summary format
+    const seconds = Number(m[3]);
+    if (!Number.isFinite(seconds)) continue;
+    steps.push({
+      index: index++,
+      name,
+      verb,
+      status: m[1] === '✓' ? 'pass' : 'fail',
+      durationMs: Math.round(seconds * 1000),
+    });
+  }
+  return steps;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run build && node --test test/unit/gh-211-maestro-step-parser.test.js`
+Expected: PASS (all `parseSteps` + `stripAnsi` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/domain/maestro-step-parser.ts test/unit/gh-211-maestro-step-parser.test.js
+git commit -m "feat(#211): parseSteps + stripAnsi — structure maestro-runner step lines"
+```
+
+---
+
+## Task 2: Summary helpers (`findFailedStep`, `lastObservedStep`, `summarizeReason`, `buildStepSummary`)
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/domain/maestro-step-parser.ts`
+- Test: `scripts/cdp-bridge/test/unit/gh-211-maestro-step-parser.test.js`
+
+- [ ] **Step 1: Write the failing test** (append to the test file)
+
+```js
+import {
+  findFailedStep, lastObservedStep, summarizeReason, buildStepSummary,
+} from '../../dist/domain/maestro-step-parser.js';
+
+test('findFailedStep: last ✗ step; null when all pass', () => {
+  assert.equal(findFailedStep(parseSteps(FAILED_RUN)).name, 'tapOn: id="c"');
+  assert.equal(findFailedStep(parseSteps('  ✓ launchApp (1.0s)')), null);
+});
+
+test('lastObservedStep: steps.at(-1); null when empty', () => {
+  assert.equal(lastObservedStep(parseSteps(FAILED_RUN)).name, 'tapOn: id="c"');
+  assert.equal(lastObservedStep([]), null);
+});
+
+test('summarizeReason: sanitized {kind, selector}; NEVER carries raw', () => {
+  const r = summarizeReason(`Element with id 'submit' not found`);
+  assert.deepEqual(r, { kind: 'SELECTOR_NOT_FOUND', selector: 'submit' });
+  assert.equal('raw' in r, false);
+});
+
+test('summarizeReason: unrecognized output → null', () => {
+  assert.equal(summarizeReason('some unrecognized output'), null);
+});
+
+test('buildStepSummary: failed=false → failedStep/reason null even with a transient ✗', () => {
+  const s = buildStepSummary(FAILED_RUN, { failed: false });
+  assert.equal(s.failedStep, null);
+  assert.equal(s.reason, null);
+  assert.equal(s.steps.length, 5);
+  assert.equal(s.lastStep.name, 'tapOn: id="c"');
+});
+
+test('buildStepSummary: failed=true → failedStep + reason populated', () => {
+  const out = FAILED_RUN + `\nElement with id 'c' not found`;
+  const s = buildStepSummary(out, { failed: true });
+  assert.equal(s.failedStep.name, 'tapOn: id="c"');
+  assert.deepEqual(s.reason, { kind: 'SELECTOR_NOT_FOUND', selector: 'c' });
+});
+
+test('buildStepSummary: timeout partial (no ✗) → failedStep null, lastStep = last ✓', () => {
+  const partial = `  ✓ launchApp (2.0s)\n  ✓ tapOn: id="a" (2.5s)`;
+  const s = buildStepSummary(partial, { failed: true });
+  assert.equal(s.failedStep, null);
+  assert.equal(s.lastStep.name, 'tapOn: id="a"');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run build && node --test test/unit/gh-211-maestro-step-parser.test.js`
+Expected: FAIL — `findFailedStep`/`lastObservedStep`/`summarizeReason`/`buildStepSummary` are not exported.
+
+- [ ] **Step 3: Write minimal implementation** (append to `src/domain/maestro-step-parser.ts`)
+
+```ts
+import { parseMaestroFailure } from './maestro-error-parser.js';
+
+export function findFailedStep(steps: MaestroStep[]): MaestroStep | null {
+  for (let i = steps.length - 1; i >= 0; i--) {
+    if (steps[i].status === 'fail') return steps[i];
+  }
+  return null;
+}
+
+export function lastObservedStep(steps: MaestroStep[]): MaestroStep | null {
+  return steps.length ? steps[steps.length - 1] : null;
+}
+
+export interface ReasonSummary {
+  kind: 'SELECTOR_NOT_FOUND' | 'TIMEOUT' | 'ASSERTION_FAILED';
+  selector: string | null;
+}
+
+// Project parseMaestroFailure to {kind, selector}, DROPPING its `raw` field —
+// every MaestroFailure variant carries `raw` = the full unsliced output, which
+// must not be re-embedded into the result (it would defeat the output slice).
+export function summarizeReason(output: string): ReasonSummary | null {
+  const f = parseMaestroFailure(output);
+  if (f.kind === 'UNKNOWN') return null;
+  const selector = 'selector' in f ? (f.selector ?? null) : null;
+  return { kind: f.kind, selector };
+}
+
+export interface StepSummary {
+  steps: MaestroStep[];
+  failedStep: MaestroStep | null;
+  reason: ReasonSummary | null;
+  lastStep: MaestroStep | null;
+}
+
+// failedStep/reason are populated ONLY when the run's terminal verdict is fail
+// (opts.failed). maestro-runner logs transient retries; a fail-then-retry-✓ on
+// a PASSED run must not report a failedStep (mirrors parseMaestroFailure GH#118).
+export function buildStepSummary(output: string, opts: { failed: boolean }): StepSummary {
+  const steps = parseSteps(output);
+  return {
+    steps,
+    failedStep: opts.failed ? findFailedStep(steps) : null,
+    reason: opts.failed ? summarizeReason(output) : null,
+    lastStep: lastObservedStep(steps),
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run build && node --test test/unit/gh-211-maestro-step-parser.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/domain/maestro-step-parser.ts test/unit/gh-211-maestro-step-parser.test.js
+git commit -m "feat(#211): buildStepSummary + helpers (raw-free reason, terminal-only failedStep)"
+```
+
+---
+
+## Task 3: Exec-error classifier (`classifyExecError`) + catch-path assembly
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/domain/maestro-step-parser.ts`
+- Test: `scripts/cdp-bridge/test/unit/gh-211-maestro-step-parser.test.js`
+
+- [ ] **Step 1: Write the failing test** (append)
+
+```js
+import { classifyExecError } from '../../dist/domain/maestro-step-parser.js';
+
+test('classifyExecError: timeout (killed, no code) → timedOut, not truncated', () => {
+  assert.deepEqual(
+    classifyExecError({ killed: true, signal: 'SIGTERM', code: null }),
+    { timedOut: true, outputTruncated: false },
+  );
+});
+
+test('classifyExecError: maxBuffer overflow → truncated, not timedOut', () => {
+  assert.deepEqual(
+    classifyExecError({ killed: true, code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' }),
+    { timedOut: false, outputTruncated: true },
+  );
+});
+
+test('classifyExecError: normal non-zero exit → neither; null/undefined safe', () => {
+  assert.deepEqual(classifyExecError({ killed: false, code: 1 }), { timedOut: false, outputTruncated: false });
+  assert.deepEqual(classifyExecError(null), { timedOut: false, outputTruncated: false });
+});
+
+// Documents the maestro-run.ts catch-path assembly using the same functions.
+test('catch-path assembly: timeout → timedOut, partial steps, failedStep null', () => {
+  const err = { killed: true, code: null, stdout: '  ✓ launchApp (2.0s)\n  ✓ tapOn: id="a" (2.5s)', stderr: '' };
+  const combined = (err.stdout + '\n' + err.stderr).trim();
+  const cls = classifyExecError(err);
+  const summary = buildStepSummary(combined, { failed: true });
+  assert.equal(cls.timedOut, true);
+  assert.equal(cls.outputTruncated, false);
+  assert.equal(summary.failedStep, null);
+  assert.equal(summary.lastStep.name, 'tapOn: id="a"');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run build && node --test test/unit/gh-211-maestro-step-parser.test.js`
+Expected: FAIL — `classifyExecError` is not exported.
+
+- [ ] **Step 3: Write minimal implementation** (append to `src/domain/maestro-step-parser.ts`)
+
+```ts
+export interface ExecErrorClass {
+  timedOut: boolean;
+  outputTruncated: boolean;
+}
+
+// execFile timeout kills the child (killed===true, signal 'SIGTERM', code null).
+// A 10MB maxBuffer overflow ALSO rejects with killed===true but code
+// 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' — that's truncation, not a timeout, so it
+// must not be mislabeled. `killed` is authoritative; `code` only subtracts the
+// overflow case (a SIGTERM-trapping child can leave a non-null exit code).
+export function classifyExecError(err: unknown): ExecErrorClass {
+  const e = err as { killed?: unknown; code?: unknown } | null;
+  const killed = e?.killed === true;
+  const overflow = e?.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER';
+  return { timedOut: killed && !overflow, outputTruncated: overflow };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run build && node --test test/unit/gh-211-maestro-step-parser.test.js`
+Expected: PASS (full file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/domain/maestro-step-parser.ts test/unit/gh-211-maestro-step-parser.test.js
+git commit -m "feat(#211): classifyExecError — distinguish timeout from maxBuffer overflow"
+```
+
+---
+
+## Task 4: Refactor `parseTapLatencies` to derive from `parseSteps` (#263 stays green)
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/domain/tap-latency.ts:13-27`
+- Guard test (unchanged): `scripts/cdp-bridge/test/unit/gh-263-tap-latency.test.js`
+
+- [ ] **Step 1: Replace the parser body**
+
+In `src/domain/tap-latency.ts`, replace the `parseTapLatencies` function (lines 13-27) with a derivation over `parseSteps`. Add the import at the top of the file (after the header comment):
+
+```ts
+import { parseSteps } from './maestro-step-parser.js';
+```
+
+Replace the function:
+
+```ts
+/**
+ * Latencies (ms) of SUCCESSFUL tapOn steps. Derived from parseSteps (GH #211):
+ * a ✗ tap's duration is the step timeout (~12.7s) and would false-positive an
+ * ordinary element-not-found failure, so only pass tapOn steps count.
+ */
+export function parseTapLatencies(output: string): number[] {
+  return parseSteps(output)
+    .filter((s) => s.verb === 'tapOn' && s.status === 'pass')
+    .map((s) => s.durationMs);
+}
+```
+
+- [ ] **Step 2: Run the #263 regression guard + #211 tests**
+
+Run: `npm run build && node --test test/unit/gh-263-tap-latency.test.js test/unit/gh-211-maestro-step-parser.test.js`
+Expected: PASS — `parseTapLatencies(DEGRADED)` still `[2800, 3000]`, single-failed-tap still `[]`, verb-in-selector still excluded, `classifyRuntimeDegradation`/`median`/`augmentFailureWithDegradation` unaffected.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/domain/tap-latency.ts
+git commit -m "refactor(#211): parseTapLatencies derives from shared parseSteps (DRY with #263)"
+```
+
+---
+
+## Task 5: Wire structured fields into `maestro_run` (success / warn / catch)
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/tools/maestro-run.ts` (import; success/warn block ~L219-255; catch block ~L256-287)
+
+- [ ] **Step 1: Add the import** (after line 19, alongside the other domain imports)
+
+```ts
+import { buildStepSummary, classifyExecError } from '../domain/maestro-step-parser.js';
+```
+
+- [ ] **Step 2: Rewrite the success/warn block**
+
+Replace the block from `const output = (stdout + '\n' + stderr).trim();` through the `return warnResult(warnAug.meta, warnAug.message);` (current lines 219-255) with:
+
+```ts
+      const output = (stdout + '\n' + stderr).trim();
+      // Exit 0 is the authoritative pass signal; the output scan is the GH#249
+      // secondary guard keyed on Maestro's own status LINES.
+      const passed = !outputIndicatesFlowFailure(output);
+      const summary = buildStepSummary(output, { failed: !passed });
+      const meta = {
+        passed,
+        flowFile,
+        platform,
+        runner: dispatch.runner,
+        output: output.slice(0, 2000),
+        ...summary,
+        timedOut: false,
+        outputTruncated: false,
+        ...(dispatch.fallbackReason ? { fallbackReason: dispatch.fallbackReason } : {}),
+      };
+
+      if (passed) {
+        if (dispatch.fallbackReason && shouldWarnFallback(dispatch.fallbackReason)) {
+          return warnResult(meta, dispatch.fallbackReason);
+        }
+        return okResult(meta);
+      }
+      const baseWarnMsg = dispatch.fallbackReason
+        ? `${dispatch.fallbackReason}; flow completed with warnings or failures`
+        : 'Flow completed with warnings or failures';
+      // GH #263: classify on the FULL output (not the sliced meta.output).
+      const warnAug = augmentFailureWithDegradation(
+        output,
+        resolveFloorMs(process.env.RN_RUNTIME_DEGRADED_FLOOR_MS),
+        baseWarnMsg,
+        meta,
+      );
+      return warnResult(warnAug.meta, warnAug.message);
+```
+
+- [ ] **Step 3: Rewrite the catch block**
+
+Replace the catch body (current lines 256-287) with:
+
+```ts
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // Node attaches partial stdout/stderr to the error on timeout/kill —
+      // preserve them so downstream parsers (run-action parseMaestroFailure)
+      // and the step parser can still classify the partial run.
+      const errAny = err as { stdout?: unknown; stderr?: unknown };
+      const stdout = typeof errAny?.stdout === 'string' ? errAny.stdout : '';
+      const stderr = typeof errAny?.stderr === 'string' ? errAny.stderr : '';
+      const combined = (stdout + '\n' + stderr).trim();
+      const { timedOut, outputTruncated } = classifyExecError(err);
+      const summary = buildStepSummary(combined, { failed: true });
+      // GH #263: a timeout/non-zero exit is also a failure surface — flag a
+      // wedged runtime here too if the successful taps were degraded.
+      const failAug = augmentFailureWithDegradation(
+        combined,
+        resolveFloorMs(process.env.RN_RUNTIME_DEGRADED_FLOOR_MS),
+        `Maestro flow failed: ${msg.slice(0, 500)}`,
+        {
+          flowFile,
+          platform,
+          runner: dispatch.runner,
+          passed: false,
+          output: combined.slice(0, 4000),
+          ...summary,
+          timedOut,
+          outputTruncated,
+        },
+      );
+      return failResult(failAug.message, failAug.meta);
+    }
+```
+
+- [ ] **Step 4: Build + run the FULL suite**
+
+Run: `npm test`
+Expected: PASS — all suites including `gh-211-*`, `gh-263-*`, `gh-201-*`, `gh-202-*`, `gh-249-*`, `maestro-error-parser`, `maestro-dispatch`. Confirm the total count is ≥ the pre-change baseline (was 2063).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tools/maestro-run.ts
+git commit -m "feat(#211): maestro_run returns steps/failedStep/reason/lastStep + partial progress on timeout"
+```
+
+---
+
+## Task 6: Changeset + final green
+
+**Files:**
+- Create: `scripts/cdp-bridge/.changeset/<run-name>.md` (or repo-root `.changeset/` — match where existing changesets live; check `ls .changeset` from repo root)
+
+- [ ] **Step 1: Locate the changeset dir**
+
+Run (from repo root): `ls .changeset/*.md | head` and open one to copy the frontmatter package name (e.g. `"rn-dev-agent"` / the cdp-bridge package name).
+
+- [ ] **Step 2: Write the changeset**
+
+Create `.changeset/maestro-structured-step-results.md` (use the package name from Step 1):
+
+```markdown
+---
+"<package-name-from-step-1>": patch
+---
+
+maestro_run: structured per-step results (steps/failedStep/reason/lastStep) and
+partial progress on timeout. Parsed from maestro-runner stdout; reason is
+sanitized (no raw log); timeout is distinguished from maxBuffer overflow
+(timedOut vs outputTruncated). Fields are additive — output is preserved (#211).
+```
+
+- [ ] **Step 3: Final full suite + typecheck**
+
+Run (from `scripts/cdp-bridge`): `npm test`
+Expected: PASS, full suite green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .changeset/
+git commit -m "chore(#211): changeset for maestro_run structured step results"
+```
+
+---
+
+## Post-implementation (phase 6 — not TDD tasks)
+
+- **/multi-review** the diff (Gemini + Codex).
+- **On-device verify** (`maestro_run` on a real iOS sim flow): assert `data.steps`/`data.failedStep`/`data.lastStep` populate on pass and a forced-fail flow; settle the **ANSI question** empirically — `~/.maestro-runner/bin/maestro-runner --platform ios test <flow> | cat -v | grep -c '\^\['` (or pipe to a file and `grep -c $'\x1b'`); confirm `runFlow` sub-flow step rendering. Repeat one check on Android emulator.
+- Fix findings, re-run suite, finish branch → PR.
+
+## Self-Review
+
+- **Spec coverage:** structured steps (Tasks 1-2,5) ✓; partial-progress-on-timeout (Tasks 3,5) ✓; #263 DRY refactor (Task 4) ✓; raw-free reason (Task 2) ✓; timeout≠overflow (Task 3) ✓; additive `output` preserved (Task 5) ✓; ANSI/runFlow (defensive in Task 1 + device-verify) ✓.
+- **Placeholder scan:** none — every code step has full code; the only `<placeholder>` is the changeset package name, resolved in Task 6 Step 1.
+- **Type consistency:** `MaestroStep`/`ReasonSummary`/`StepSummary`/`ExecErrorClass` defined in Tasks 1-3 and used identically in Tasks 4-5; `buildStepSummary(output,{failed})`, `classifyExecError(err)` signatures match call sites in `maestro-run.ts`.

--- a/docs/superpowers/specs/2026-06-14-211-maestro-structured-results-design.md
+++ b/docs/superpowers/specs/2026-06-14-211-maestro-structured-results-design.md
@@ -1,0 +1,163 @@
+# Design — #211: `maestro_run` structured step results + partial-progress-on-timeout
+
+**Date:** 2026-06-14
+**Issue:** [#211](https://github.com/Lykhoyda/rn-dev-agent/issues/211)
+**Status:** Approved design → ready for plan
+**Branch:** `feat/211-maestro-structured-results` (off `main`; #263 already merged)
+
+## Problem
+
+`maestro_run` works, but verification is harder than it should be:
+
+1. **Output truncated mid-flow** — success is only confirmable via top-level `passed: true` + a separate `cdp_navigation_state`. Per-step pass/fail/durations and terminal assertions aren't visible. The reporter re-ran `grep 'message=' reports/<ts>/junit-report.xml` after *nearly every* failed run (~30/session) to find the failing step.
+2. **Timeout returns a bare failure** — a flow that exceeds the cap yields no verdict and no "how far did it get".
+
+Issue item 3 (iOS `clearState` needing `--app-file`) **already shipped** in #276/#201 (`resolveAppFileForClearState`) — out of scope here.
+
+## Goal
+
+Add **structured, additive** fields to the `maestro_run` result so the failing step, reason, and per-step durations are visible without grepping report files, and so a timeout returns partial progress. The per-step durations also become the clean data source #263's degraded-tap-latency heuristic already wants.
+
+## Scope
+
+- **IN:** structured step results; partial progress on timeout.
+- **OUT:** iOS `clearState` (shipped); JUnit/report-file parsing (chose stdout-only); `screenshots[]` (YAGNI — the reporter's own suggestion had it empty); bumping the default timeout (the partial-progress *return* is the fix, not a bigger cap).
+- **Source:** maestro-runner **stdout** only. The JVM Maestro CLI fallback (iOS-no-adb) emits a different format and degrades **fail-open** to `steps: []` + raw `output`.
+
+## Architecture
+
+Three files; one new pure module. The win is that the per-step data is **already in the stdout** maestro-runner prints — the exact lines #263 parses — so #211's parser is a *generalization* of #263's, and `parseTapLatencies` collapses to a filter over it.
+
+### 1. NEW `src/domain/maestro-step-parser.ts` (pure, no I/O, fail-open)
+
+```ts
+export interface ReasonSummary {
+  kind: 'SELECTOR_NOT_FOUND' | 'TIMEOUT' | 'ASSERTION_FAILED';
+  selector: string | null;
+}
+
+export interface MaestroStep {
+  index: number;                  // 0-based observed order — disambiguates loops / runFlow repeats
+  name: string;                   // full step text minus the trailing (N.Ns), e.g. `tapOn: id="submit"`
+  verb: string;                   // first token after the glyph, trailing ':' stripped, e.g. `tapOn`
+  status: 'pass' | 'fail';
+  durationMs: number;
+}
+
+export function stripAnsi(s: string): string;                 // remove SGR codes before matching
+export function parseSteps(output: string): MaestroStep[];    // completed steps only (those with a (N.Ns))
+export function findFailedStep(steps: MaestroStep[]): MaestroStep | null;     // last status==='fail'
+export function lastObservedStep(steps: MaestroStep[]): MaestroStep | null;   // steps.at(-1)
+export function summarizeReason(output: string): ReasonSummary | null;        // sanitized — NO raw
+
+export interface StepSummary {
+  steps: MaestroStep[];
+  failedStep: MaestroStep | null;   // terminal failure only; null unless opts.failed
+  reason: ReasonSummary | null;     // null unless opts.failed
+  lastStep: MaestroStep | null;     // last observed (completed) step — the progress marker
+}
+export function buildStepSummary(output: string, opts: { failed: boolean }): StepSummary;
+```
+
+**Line grammar (verified against the #263 fixtures):** each step prints as
+`  {✓|✗} {verb}[: {selector}] (N.Ns)`. Parser rules:
+
+- `stripAnsi()` first (belt-and-suspenders; `execFile` is not a TTY so color is *usually* off, but unverified against the real binary — see Risks).
+- Anchor on a leading status glyph `✓`/`✗` after trimming.
+- **Require a trailing `(N.Ns)`** — this excludes the summary line `✗ rn-maestro-run 23.8s` (no parens) and the count lines `3 steps passing` (no glyph). Belt-and-suspenders: also skip a line whose verb is `rn-maestro-run`.
+- `verb` = first whitespace-delimited token after the glyph, **with a trailing `:` stripped** (`tapOn:` → `tapOn`). This is load-bearing for the #263 refactor (filter `verb === 'tapOn'`).
+- `name` = the line minus the glyph and the trailing `(N.Ns)`.
+- `durationMs` = `round(seconds * 1000)`.
+- `verb` is the FIRST token, so a verb-name *inside a selector value* (`✓ assertVisible: text="tapOn …"`) is recorded as `assertVisible` — preserves #263 review-finding #2.
+- Garbage / empty / CLI-fallback format → `[]`. Never throws.
+
+**`failedStep` is terminal-only.** `findFailedStep` returns the last `✗` step, but `buildStepSummary` only populates `failedStep`/`reason` when `opts.failed` is true. maestro-runner logs transient retries; a step that fails-then-retries-✓ on a run that ultimately **passed** must NOT report a `failedStep` (mirrors `parseMaestroFailure`'s END→START terminal-preference, GH#118). The handler passes `failed = !passed`, so on the success path `failedStep` is always null even if a transient `✗` appears in `steps`.
+
+**`reason` is sanitized — never carries `raw`.** `summarizeReason` calls `parseMaestroFailure` but **projects to `{ kind, selector }`**, explicitly dropping the `raw: string` field that every `MaestroFailure` variant carries. Returning the parser's object directly would re-embed the full unsliced runner log into the result, defeating the 2000/4000-char `output` slice. (UNKNOWN → `null`.)
+
+### 2. REFACTOR `src/domain/tap-latency.ts`
+
+```ts
+import { parseSteps } from './maestro-step-parser.js';
+export function parseTapLatencies(output: string): number[] {
+  return parseSteps(output)
+    .filter((s) => s.verb === 'tapOn' && s.status === 'pass')
+    .map((s) => s.durationMs);
+}
+```
+
+`gh-263-tap-latency.test.js` is the regression guard — the `DEGRADED` fixture must still yield `[2800, 3000]` and the single-failed-tap fixture `[]`. `classifyRuntimeDegradation`, `median`, `resolveFloorMs`, `augmentFailureWithDegradation` are unchanged. (The ≥2-sample gate `MIN_SAMPLES_FOR_DEGRADED` is unaffected — it operates on the filtered latency array.)
+
+### 3. WIRE `src/tools/maestro-run.ts`
+
+The current `meta` object (the payload passed to `okResult`/`warnResult`/`failResult`) is extended with the **same field set on all three paths**. Because `okResult(x)`/`warnResult(x,…)` place `x` in `envelope.data` while `failResult(msg,x)` places `x` in `envelope.meta`, the structured fields appear under `data.*` on pass/warn and `meta.*` on fail — and `output` is preserved on every path (`run-action.ts:144` reads `data.output` then `meta.output`).
+
+Added fields (stable set, present on every path):
+
+```ts
+steps: MaestroStep[]
+failedStep: MaestroStep | null
+reason: ReasonSummary | null
+lastStep: MaestroStep | null
+timedOut: boolean
+outputTruncated: boolean
+```
+
+- **success** (exit 0, `passed`): `buildStepSummary(output, { failed: false })` → `steps` + `lastStep`; `failedStep:null, reason:null, timedOut:false, outputTruncated:false`.
+- **warn** (exit 0 but `outputIndicatesFlowFailure`): `buildStepSummary(output, { failed: true })`; `timedOut:false, outputTruncated:false`; existing `augmentFailureWithDegradation` (#263) unchanged.
+- **catch** (non-zero / timeout / overflow): parse the partial `combined` (stdout+stderr Node attaches to the thrown error); `buildStepSummary(combined, { failed: true })`; existing `#263` augmentation unchanged. Timeout vs overflow discrimination:
+  ```ts
+  const killed = (err as any).killed === true;
+  const overflow = (err as any).code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER';
+  const timedOut = killed && !overflow;
+  const outputTruncated = overflow;
+  ```
+  `err.killed` is the authoritative timeout discriminator (empirical Node probe: timeout → `killed:true, signal:'SIGTERM', code:null`; normal non-zero → `killed:false, code:N`; a SIGTERM-trapping child can leave `code` non-null while killed, so `code` is used only to *subtract* the maxBuffer case). On a pure timeout `failedStep` is `null` (nothing asserted-failed) and `lastStep` is the last **completed** step — the progress marker (an in-flight step has no `(N.Ns)` yet, so it isn't parsed).
+
+## Result shape (consumer view)
+
+```jsonc
+// success/warn → envelope.data ; fail/timeout → envelope.meta
+{
+  "passed": false,
+  "flowFile": "/tmp/rn-maestro-run-….yaml",
+  "platform": "ios",
+  "runner": "maestro-runner",
+  "output": "…sliced 2000/4000…",          // unchanged — back-compat
+  "steps": [
+    { "index": 0, "name": "launchApp", "verb": "launchApp", "status": "pass", "durationMs": 2300 },
+    { "index": 1, "name": "tapOn: id=\"submit\"", "verb": "tapOn", "status": "fail", "durationMs": 12700 }
+  ],
+  "failedStep": { "index": 1, "name": "tapOn: id=\"submit\"", "verb": "tapOn", "status": "fail", "durationMs": 12700 },
+  "reason": { "kind": "SELECTOR_NOT_FOUND", "selector": "submit" },
+  "lastStep": { "index": 1, "name": "tapOn: id=\"submit\"", "verb": "tapOn", "status": "fail", "durationMs": 12700 },
+  "timedOut": false,
+  "outputTruncated": false,
+  "runtimeDegraded": { "medianTapMs": 1800, "floorMs": 1500, "sampleCount": 3 }  // #263, only when degraded
+}
+```
+
+## Testing (TDD)
+
+- **NEW `test/unit/gh-211-maestro-step-parser.test.js`** — pure parser + helpers:
+  - verbs/status/durations; verb has NO trailing colon; index is observed order.
+  - excludes `✗ rn-maestro-run 23.8s` summary line and `N steps passing/failing` count lines.
+  - verb-in-selector (`assertVisible: text="tapOn …"`) → verb `assertVisible`.
+  - empty / garbage / CLI-format → `[]`; never throws.
+  - `stripAnsi` removes SGR codes; an ANSI-wrapped glyph line still parses.
+  - `findFailedStep` = last `✗`; `lastObservedStep` = `steps.at(-1)`.
+  - `summarizeReason` returns `{ kind, selector }` and **contains no `raw`** (assert the key is absent); UNKNOWN → null.
+  - `buildStepSummary(out,{failed:false})` → `failedStep:null,reason:null`; fail-then-retry-✓ output with `{failed:false}` → `failedStep:null`.
+- **REGRESSION `test/unit/gh-263-tap-latency.test.js`** stays green (proves `parseTapLatencies` unchanged).
+- **NEW `test/unit/gh-211-maestro-run-structured-results.test.js`** — exercise the pure assembly seam directly (no `execFile` mocking): success/warn metas via `buildStepSummary`; catch-path via a fake error `{ killed:true, code:null, stdout:'…partial…', stderr:'' }` asserting `timedOut:true, failedStep:null, lastStep=<last ✓>`; a maxBuffer fake `{ killed:true, code:'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' }` asserting `timedOut:false, outputTruncated:true`.
+- **Patch changeset.**
+
+## Risks / open items
+
+- **ANSI (unverified against the real binary).** No ANSI handling exists in the repo and `execFile` is not a TTY (color usually off), but not guaranteed. Mitigation: ship `stripAnsi()` + test now; during device-verify run `~/.maestro-runner/bin/maestro-runner --platform ios test <flow> | grep -c $'\x1b'` to settle whether the strip is load-bearing or belt-and-suspenders.
+- **`runFlow` sub-flows.** `runFlow` is allowlisted/used (GH#186). No captured fixture shows how maestro-runner renders sub-flow child glyphs. `steps[]` is documented as a **flat observed list** — no parent/child hierarchy promised; `index` disambiguates repeats. Confirm rendering during device-verify.
+- **CLI fallback** produces no structured steps (different format) → `steps: []`, `output` intact. Acceptable: maestro-runner is the default fast path; fail-open matches #263.
+
+## Provenance
+
+Plan reviewed pre-code via `/brainstorm codex,antigravity` (2026-06-14). Codex + Claude file-grounded research caught: the `reason`-re-embeds-`raw` blocker, the maxBuffer-vs-timeout blocker, the `verb` trailing-colon trap, the `data` vs `meta` envelope placement, terminal-only `failedStep`, and ANSI/`runFlow` edges — all folded into this design. (Antigravity hung with no output.)

--- a/scripts/cdp-bridge/dist/domain/maestro-step-parser.js
+++ b/scripts/cdp-bridge/dist/domain/maestro-step-parser.js
@@ -74,3 +74,33 @@ export function buildStepSummary(output, opts) {
         lastStep: lastObservedStep(steps),
     };
 }
+// execFile timeout kills the child (killed===true, signal 'SIGTERM', code null).
+// A 10MB maxBuffer overflow ALSO rejects with killed===true but code
+// 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' — that's truncation, not a timeout, so it
+// must not be mislabeled. `killed` is authoritative; `code` only subtracts the
+// overflow case (a SIGTERM-trapping child can leave a non-null exit code).
+export function classifyExecError(err) {
+    const e = err;
+    const killed = e?.killed === true;
+    const overflow = e?.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER';
+    return { timedOut: killed && !overflow, outputTruncated: overflow };
+}
+// Headline for a failed maestro_run, built from STRUCTURED data so it never
+// re-embeds raw runner/app output. The raw fallbackMsg (err.message, which
+// execFile populates with stderr) is used ONLY when there is no structured
+// signal — e.g. a spawn/system error with no step output. Raw output still
+// lives in the bounded `output` field.
+export function formatFailureHeadline(summary, cls, fallbackMsg) {
+    if (cls.timedOut) {
+        return `Maestro flow timed out${summary.lastStep ? ` after step "${summary.lastStep.name}"` : ''}`;
+    }
+    if (cls.outputTruncated) {
+        return 'Maestro flow output exceeded the 10MB buffer';
+    }
+    if (summary.failedStep) {
+        const r = summary.reason;
+        const reasonStr = r ? ` (${r.kind}${r.selector ? `: ${r.selector}` : ''})` : '';
+        return `Maestro flow failed at step "${summary.failedStep.name}"${reasonStr}`;
+    }
+    return `Maestro flow failed: ${fallbackMsg.slice(0, 500)}`;
+}

--- a/scripts/cdp-bridge/dist/domain/maestro-step-parser.js
+++ b/scripts/cdp-bridge/dist/domain/maestro-step-parser.js
@@ -16,6 +16,13 @@ export function stripAnsi(s) {
 // `.*?` is non-greedy + `$`-anchored so a duration-looking token inside the
 // selector value (`text="took (2.0s)"`) loses to the real trailing duration.
 const STEP_RE = /^([✓✗])\s+(.*?)\s*\(([\d.]+)s\)\s*$/;
+// Bound any text interpolated into results/headline so a pathological step name
+// or selector (e.g. a multi-KB inputText value) can't balloon the failure
+// message and defeat the sliced `output` field (codex-pair review).
+const MAX_FIELD = 200;
+function cap(s) {
+    return s.length > MAX_FIELD ? s.slice(0, MAX_FIELD) + '…' : s;
+}
 export function parseSteps(output) {
     if (!output || typeof output !== 'string')
         return [];
@@ -34,7 +41,7 @@ export function parseSteps(output) {
             continue;
         steps.push({
             index: index++,
-            name,
+            name: cap(name),
             verb,
             status: m[1] === '✓' ? 'pass' : 'fail',
             durationMs: Math.round(seconds * 1000),
@@ -42,12 +49,13 @@ export function parseSteps(output) {
     }
     return steps;
 }
+// The TERMINAL failed step: the last parsed step iff it failed. maestro-runner
+// stops at the first real failure, so the terminal ✗ is the last parsed step; a
+// transient ✗ that was retried-✓ before a later timeout is NOT reported, because
+// the last parsed step is then the recovery ✓ (codex-pair review).
 export function findFailedStep(steps) {
-    for (let i = steps.length - 1; i >= 0; i--) {
-        if (steps[i].status === 'fail')
-            return steps[i];
-    }
-    return null;
+    const last = steps.length ? steps[steps.length - 1] : null;
+    return last && last.status === 'fail' ? last : null;
 }
 export function lastObservedStep(steps) {
     return steps.length ? steps[steps.length - 1] : null;
@@ -60,7 +68,7 @@ export function summarizeReason(output) {
     if (f.kind === 'UNKNOWN')
         return null;
     const selector = 'selector' in f ? (f.selector ?? null) : null;
-    return { kind: f.kind, selector };
+    return { kind: f.kind, selector: selector === null ? null : cap(selector) };
 }
 // failedStep/reason are populated ONLY when the run's terminal verdict is fail
 // (opts.failed). maestro-runner logs transient retries; a fail-then-retry-✓ on

--- a/scripts/cdp-bridge/dist/domain/maestro-step-parser.js
+++ b/scripts/cdp-bridge/dist/domain/maestro-step-parser.js
@@ -2,6 +2,7 @@
 // GH #211: structure maestro_run results from maestro-runner stdout. Pure, no
 // I/O, fail-open: unparseable output yields []. Generalizes the #263 step-line
 // parser (tap-latency.ts derives parseTapLatencies from parseSteps).
+import { parseMaestroFailure } from './maestro-error-parser.js';
 // Strip ANSI SGR/color escape sequences. execFile output is usually un-colored
 // (child stdout is a pipe, not a TTY) but maestro-runner is not guaranteed to
 // honor that, and a glyph-anchored match breaks on a colored `✓`. Built via
@@ -40,4 +41,36 @@ export function parseSteps(output) {
         });
     }
     return steps;
+}
+export function findFailedStep(steps) {
+    for (let i = steps.length - 1; i >= 0; i--) {
+        if (steps[i].status === 'fail')
+            return steps[i];
+    }
+    return null;
+}
+export function lastObservedStep(steps) {
+    return steps.length ? steps[steps.length - 1] : null;
+}
+// Project parseMaestroFailure to {kind, selector}, DROPPING its `raw` field —
+// every MaestroFailure variant carries `raw` = the full unsliced output, which
+// must not be re-embedded into the result (it would defeat the output slice).
+export function summarizeReason(output) {
+    const f = parseMaestroFailure(output);
+    if (f.kind === 'UNKNOWN')
+        return null;
+    const selector = 'selector' in f ? (f.selector ?? null) : null;
+    return { kind: f.kind, selector };
+}
+// failedStep/reason are populated ONLY when the run's terminal verdict is fail
+// (opts.failed). maestro-runner logs transient retries; a fail-then-retry-✓ on
+// a PASSED run must not report a failedStep (mirrors parseMaestroFailure GH#118).
+export function buildStepSummary(output, opts) {
+    const steps = parseSteps(output);
+    return {
+        steps,
+        failedStep: opts.failed ? findFailedStep(steps) : null,
+        reason: opts.failed ? summarizeReason(output) : null,
+        lastStep: lastObservedStep(steps),
+    };
 }

--- a/scripts/cdp-bridge/dist/domain/maestro-step-parser.js
+++ b/scripts/cdp-bridge/dist/domain/maestro-step-parser.js
@@ -1,0 +1,43 @@
+// src/domain/maestro-step-parser.ts
+// GH #211: structure maestro_run results from maestro-runner stdout. Pure, no
+// I/O, fail-open: unparseable output yields []. Generalizes the #263 step-line
+// parser (tap-latency.ts derives parseTapLatencies from parseSteps).
+// Strip ANSI SGR/color escape sequences. execFile output is usually un-colored
+// (child stdout is a pipe, not a TTY) but maestro-runner is not guaranteed to
+// honor that, and a glyph-anchored match breaks on a colored `✓`. Built via
+// fromCharCode(27) (ESC) to keep a raw control char out of the source/regex.
+const ANSI_RE = new RegExp(String.fromCharCode(27) + '\\[[0-9;]*m', 'g');
+export function stripAnsi(s) {
+    return s.replace(ANSI_RE, '');
+}
+// `  {✓|✗} <name> (N.Ns)` — the trailing (N.Ns) is REQUIRED, which excludes the
+// `✗ rn-maestro-run 23.8s` summary line and the `N steps passing` count lines.
+// `.*?` is non-greedy + `$`-anchored so a duration-looking token inside the
+// selector value (`text="took (2.0s)"`) loses to the real trailing duration.
+const STEP_RE = /^([✓✗])\s+(.*?)\s*\(([\d.]+)s\)\s*$/;
+export function parseSteps(output) {
+    if (!output || typeof output !== 'string')
+        return [];
+    const steps = [];
+    let index = 0;
+    for (const raw of stripAnsi(output).split('\n')) {
+        const m = STEP_RE.exec(raw.trim());
+        if (!m)
+            continue;
+        const name = m[2].trim();
+        const verb = name.split(/\s+/)[0].replace(/:$/, '');
+        if (verb === 'rn-maestro-run')
+            continue; // belt-and-suspenders vs a future summary format
+        const seconds = Number(m[3]);
+        if (!Number.isFinite(seconds))
+            continue;
+        steps.push({
+            index: index++,
+            name,
+            verb,
+            status: m[1] === '✓' ? 'pass' : 'fail',
+            durationMs: Math.round(seconds * 1000),
+        });
+    }
+    return steps;
+}

--- a/scripts/cdp-bridge/dist/domain/maestro-step-parser.js
+++ b/scripts/cdp-bridge/dist/domain/maestro-step-parser.js
@@ -27,6 +27,11 @@ const MAX_FIELD = 200;
 function cap(s) {
     return s.length > MAX_FIELD ? s.slice(0, MAX_FIELD) + '…' : s;
 }
+// Cap the returned steps so a pathological run (a multi-MB stdout/stderr with
+// many step-shaped log lines) can't bloat the MCP response past the `output`
+// slice. Keep the most recent steps — failures and partial-progress live at the
+// tail — with their true `index` preserved (a gap signals truncation).
+const MAX_STEPS = 1000;
 export function parseSteps(output) {
     if (!output || typeof output !== 'string')
         return [];
@@ -51,7 +56,7 @@ export function parseSteps(output) {
             durationMs: Math.round(seconds * 1000),
         });
     }
-    return steps;
+    return steps.length > MAX_STEPS ? steps.slice(-MAX_STEPS) : steps;
 }
 // The TERMINAL failed step: the last parsed step iff it failed. maestro-runner
 // stops at the first real failure, so the terminal ✗ is the last parsed step; a

--- a/scripts/cdp-bridge/dist/domain/maestro-step-parser.js
+++ b/scripts/cdp-bridge/dist/domain/maestro-step-parser.js
@@ -13,9 +13,13 @@ export function stripAnsi(s) {
 }
 // `  {✓|✗} <name> (N.Ns)` — the trailing (N.Ns) is REQUIRED, which excludes the
 // `✗ rn-maestro-run 23.8s` summary line and the `N steps passing` count lines.
-// `.*?` is non-greedy + `$`-anchored so a duration-looking token inside the
-// selector value (`text="took (2.0s)"`) loses to the real trailing duration.
-const STEP_RE = /^([✓✗])\s+(.*?)\s*\(([\d.]+)s\)\s*$/;
+// The name is `\S.*\S|\S` (must start AND end non-whitespace). This keeps a
+// duration-looking token inside the selector value (`text="took (2.0s)"`) losing
+// to the real trailing `$`-anchored duration, AND removes the overlapping
+// whitespace quantifiers (`\s+(.*?)\s*`) that made the prior pattern
+// catastrophically backtrack (ReDoS) on a glyph + long-whitespace line — the
+// combined stdout+stderr carries untrusted multi-MB app logs (multi-LLM review).
+const STEP_RE = /^([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
 // Bound any text interpolated into results/headline so a pathological step name
 // or selector (e.g. a multi-KB inputText value) can't balloon the failure
 // message and defeat the sliced `output` field (codex-pair review).
@@ -109,6 +113,12 @@ export function formatFailureHeadline(summary, cls, fallbackMsg) {
         const r = summary.reason;
         const reasonStr = r ? ` (${r.kind}${r.selector ? `: ${r.selector}` : ''})` : '';
         return `Maestro flow failed at step "${summary.failedStep.name}"${reasonStr}`;
+    }
+    // No terminal ✗ step line (e.g. it was truncated) but a recognizable error
+    // string survived — prefer the structured, raw-free reason over the raw msg.
+    if (summary.reason) {
+        const r = summary.reason;
+        return `Maestro flow failed (${r.kind}${r.selector ? `: ${r.selector}` : ''})`;
     }
     return `Maestro flow failed: ${fallbackMsg.slice(0, 500)}`;
 }

--- a/scripts/cdp-bridge/dist/domain/tap-latency.js
+++ b/scripts/cdp-bridge/dist/domain/tap-latency.js
@@ -1,30 +1,17 @@
 // src/domain/tap-latency.ts
 // GH #263: detect a wedged simulator test-runtime from maestro-runner output.
 // Pure, no I/O. Fail-open: unparseable output yields no samples → no hint.
+import { parseSteps } from './maestro-step-parser.js';
 export const DEFAULT_FLOOR_MS = 1500;
 /**
- * Extract latencies (ms) of SUCCESSFUL tapOn steps from maestro-runner output.
- * maestro-runner prints each step as `  ✓ tapOn: id="x" (2.8s)` (seconds, in
- * parens at end). Only ✓ lines count: a ✗ line's duration is the step TIMEOUT
- * (~12.7s), which would false-positive an ordinary element-not-found failure.
+ * Latencies (ms) of SUCCESSFUL tapOn steps. Derived from parseSteps (GH #211):
+ * a ✗ tap's duration is the step TIMEOUT (~12.7s) and would false-positive an
+ * ordinary element-not-found failure, so only pass tapOn steps count.
  */
 export function parseTapLatencies(output) {
-    const out = [];
-    for (const raw of output.split('\n')) {
-        const line = raw.trim();
-        // Anchor on the step verb (`✓ tapOn:`) so "tapOn" inside another step's
-        // text/selector value (e.g. `✓ assertVisible: text="tapOn …"`) is not
-        // counted. Successful (✓) steps only — a ✗ duration is the step timeout.
-        if (!/^✓\s+tapOn\b/.test(line))
-            continue;
-        const m = line.match(/\(([\d.]+)s\)\s*$/); // trailing (N.Ns)
-        if (!m)
-            continue;
-        const seconds = Number(m[1]);
-        if (Number.isFinite(seconds))
-            out.push(Math.round(seconds * 1000));
-    }
-    return out;
+    return parseSteps(output)
+        .filter((s) => s.verb === 'tapOn' && s.status === 'pass')
+        .map((s) => s.durationMs);
 }
 export function median(samples) {
     if (samples.length === 0)

--- a/scripts/cdp-bridge/dist/tools/maestro-run.js
+++ b/scripts/cdp-bridge/dist/tools/maestro-run.js
@@ -11,6 +11,7 @@ import { resolveAppFileForClearState } from './resolve-ios-app-file.js';
 import { buildMaestroFlow, parseAndValidateFlow, isValidBundleId, MaestroValidationError, } from '../domain/maestro-validator.js';
 import { outputIndicatesFlowFailure } from '../domain/maestro-error-parser.js';
 import { augmentFailureWithDegradation, resolveFloorMs } from '../domain/tap-latency.js';
+import { buildStepSummary, classifyExecError, formatFailureHeadline } from '../domain/maestro-step-parser.js';
 import { stopFastRunner as defaultStopFastRunner } from '../runners/rn-fast-runner-client.js';
 import { releaseAndroidInteractionSlot as defaultReleaseAndroidSlot } from '../runners/release-android-slot.js';
 import { markCdpStale as defaultMarkCdpStale } from '../cdp/recovery.js';
@@ -171,12 +172,16 @@ export function createMaestroRunHandler() {
             // keyed on Maestro's own status LINES (GH#249: the prior bare `FAILED`
             // substring false-flagged passing runs whose app logs contained the token).
             const passed = !outputIndicatesFlowFailure(output);
+            const summary = buildStepSummary(output, { failed: !passed });
             const meta = {
                 passed,
                 flowFile,
                 platform,
                 runner: dispatch.runner,
                 output: output.slice(0, 2000),
+                ...summary,
+                timedOut: false,
+                outputTruncated: false,
                 ...(dispatch.fallbackReason ? { fallbackReason: dispatch.fallbackReason } : {}),
             };
             if (passed) {
@@ -210,9 +215,14 @@ export function createMaestroRunHandler() {
             const stdout = typeof errAny?.stdout === 'string' ? errAny.stdout : '';
             const stderr = typeof errAny?.stderr === 'string' ? errAny.stderr : '';
             const combined = (stdout + '\n' + stderr).trim();
+            const { timedOut, outputTruncated } = classifyExecError(err);
+            const summary = buildStepSummary(combined, { failed: true });
+            // Headline from structured data (raw-free); the raw err.message is the
+            // fallback only for system errors with no step output (e.g. spawn ENOENT).
+            const headline = formatFailureHeadline(summary, { timedOut, outputTruncated }, msg);
             // GH #263: a timeout/non-zero exit is also a failure surface — flag a
             // wedged runtime here too if the successful taps were degraded.
-            const failAug = augmentFailureWithDegradation(combined, resolveFloorMs(process.env.RN_RUNTIME_DEGRADED_FLOOR_MS), `Maestro flow failed: ${msg.slice(0, 500)}`, {
+            const failAug = augmentFailureWithDegradation(combined, resolveFloorMs(process.env.RN_RUNTIME_DEGRADED_FLOOR_MS), headline, {
                 flowFile,
                 platform,
                 runner: dispatch.runner,
@@ -220,6 +230,9 @@ export function createMaestroRunHandler() {
                 // `output` mirrors the success/warn shape so callers can read
                 // it the same way regardless of which path they hit.
                 output: combined.slice(0, 4000),
+                ...summary,
+                timedOut,
+                outputTruncated,
             });
             return failResult(failAug.message, failAug.meta);
         }

--- a/scripts/cdp-bridge/src/domain/maestro-step-parser.ts
+++ b/scripts/cdp-bridge/src/domain/maestro-step-parser.ts
@@ -28,6 +28,14 @@ export function stripAnsi(s: string): string {
 // selector value (`text="took (2.0s)"`) loses to the real trailing duration.
 const STEP_RE = /^([✓✗])\s+(.*?)\s*\(([\d.]+)s\)\s*$/;
 
+// Bound any text interpolated into results/headline so a pathological step name
+// or selector (e.g. a multi-KB inputText value) can't balloon the failure
+// message and defeat the sliced `output` field (codex-pair review).
+const MAX_FIELD = 200;
+function cap(s: string): string {
+  return s.length > MAX_FIELD ? s.slice(0, MAX_FIELD) + '…' : s;
+}
+
 export function parseSteps(output: string): MaestroStep[] {
   if (!output || typeof output !== 'string') return [];
   const steps: MaestroStep[] = [];
@@ -42,7 +50,7 @@ export function parseSteps(output: string): MaestroStep[] {
     if (!Number.isFinite(seconds)) continue;
     steps.push({
       index: index++,
-      name,
+      name: cap(name),
       verb,
       status: m[1] === '✓' ? 'pass' : 'fail',
       durationMs: Math.round(seconds * 1000),
@@ -51,11 +59,13 @@ export function parseSteps(output: string): MaestroStep[] {
   return steps;
 }
 
+// The TERMINAL failed step: the last parsed step iff it failed. maestro-runner
+// stops at the first real failure, so the terminal ✗ is the last parsed step; a
+// transient ✗ that was retried-✓ before a later timeout is NOT reported, because
+// the last parsed step is then the recovery ✓ (codex-pair review).
 export function findFailedStep(steps: MaestroStep[]): MaestroStep | null {
-  for (let i = steps.length - 1; i >= 0; i--) {
-    if (steps[i].status === 'fail') return steps[i];
-  }
-  return null;
+  const last = steps.length ? steps[steps.length - 1] : null;
+  return last && last.status === 'fail' ? last : null;
 }
 
 export function lastObservedStep(steps: MaestroStep[]): MaestroStep | null {
@@ -74,7 +84,7 @@ export function summarizeReason(output: string): ReasonSummary | null {
   const f = parseMaestroFailure(output);
   if (f.kind === 'UNKNOWN') return null;
   const selector = 'selector' in f ? (f.selector ?? null) : null;
-  return { kind: f.kind, selector };
+  return { kind: f.kind, selector: selector === null ? null : cap(selector) };
 }
 
 export interface StepSummary {

--- a/scripts/cdp-bridge/src/domain/maestro-step-parser.ts
+++ b/scripts/cdp-bridge/src/domain/maestro-step-parser.ts
@@ -24,9 +24,13 @@ export function stripAnsi(s: string): string {
 
 // `  {✓|✗} <name> (N.Ns)` — the trailing (N.Ns) is REQUIRED, which excludes the
 // `✗ rn-maestro-run 23.8s` summary line and the `N steps passing` count lines.
-// `.*?` is non-greedy + `$`-anchored so a duration-looking token inside the
-// selector value (`text="took (2.0s)"`) loses to the real trailing duration.
-const STEP_RE = /^([✓✗])\s+(.*?)\s*\(([\d.]+)s\)\s*$/;
+// The name is `\S.*\S|\S` (must start AND end non-whitespace). This keeps a
+// duration-looking token inside the selector value (`text="took (2.0s)"`) losing
+// to the real trailing `$`-anchored duration, AND removes the overlapping
+// whitespace quantifiers (`\s+(.*?)\s*`) that made the prior pattern
+// catastrophically backtrack (ReDoS) on a glyph + long-whitespace line — the
+// combined stdout+stderr carries untrusted multi-MB app logs (multi-LLM review).
+const STEP_RE = /^([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
 
 // Bound any text interpolated into results/headline so a pathological step name
 // or selector (e.g. a multi-KB inputText value) can't balloon the failure
@@ -144,6 +148,12 @@ export function formatFailureHeadline(
     const r = summary.reason;
     const reasonStr = r ? ` (${r.kind}${r.selector ? `: ${r.selector}` : ''})` : '';
     return `Maestro flow failed at step "${summary.failedStep.name}"${reasonStr}`;
+  }
+  // No terminal ✗ step line (e.g. it was truncated) but a recognizable error
+  // string survived — prefer the structured, raw-free reason over the raw msg.
+  if (summary.reason) {
+    const r = summary.reason;
+    return `Maestro flow failed (${r.kind}${r.selector ? `: ${r.selector}` : ''})`;
   }
   return `Maestro flow failed: ${fallbackMsg.slice(0, 500)}`;
 }

--- a/scripts/cdp-bridge/src/domain/maestro-step-parser.ts
+++ b/scripts/cdp-bridge/src/domain/maestro-step-parser.ts
@@ -96,3 +96,44 @@ export function buildStepSummary(output: string, opts: { failed: boolean }): Ste
     lastStep: lastObservedStep(steps),
   };
 }
+
+export interface ExecErrorClass {
+  timedOut: boolean;
+  outputTruncated: boolean;
+}
+
+// execFile timeout kills the child (killed===true, signal 'SIGTERM', code null).
+// A 10MB maxBuffer overflow ALSO rejects with killed===true but code
+// 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' — that's truncation, not a timeout, so it
+// must not be mislabeled. `killed` is authoritative; `code` only subtracts the
+// overflow case (a SIGTERM-trapping child can leave a non-null exit code).
+export function classifyExecError(err: unknown): ExecErrorClass {
+  const e = err as { killed?: unknown; code?: unknown } | null;
+  const killed = e?.killed === true;
+  const overflow = e?.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER';
+  return { timedOut: killed && !overflow, outputTruncated: overflow };
+}
+
+// Headline for a failed maestro_run, built from STRUCTURED data so it never
+// re-embeds raw runner/app output. The raw fallbackMsg (err.message, which
+// execFile populates with stderr) is used ONLY when there is no structured
+// signal — e.g. a spawn/system error with no step output. Raw output still
+// lives in the bounded `output` field.
+export function formatFailureHeadline(
+  summary: StepSummary,
+  cls: ExecErrorClass,
+  fallbackMsg: string,
+): string {
+  if (cls.timedOut) {
+    return `Maestro flow timed out${summary.lastStep ? ` after step "${summary.lastStep.name}"` : ''}`;
+  }
+  if (cls.outputTruncated) {
+    return 'Maestro flow output exceeded the 10MB buffer';
+  }
+  if (summary.failedStep) {
+    const r = summary.reason;
+    const reasonStr = r ? ` (${r.kind}${r.selector ? `: ${r.selector}` : ''})` : '';
+    return `Maestro flow failed at step "${summary.failedStep.name}"${reasonStr}`;
+  }
+  return `Maestro flow failed: ${fallbackMsg.slice(0, 500)}`;
+}

--- a/scripts/cdp-bridge/src/domain/maestro-step-parser.ts
+++ b/scripts/cdp-bridge/src/domain/maestro-step-parser.ts
@@ -40,6 +40,12 @@ function cap(s: string): string {
   return s.length > MAX_FIELD ? s.slice(0, MAX_FIELD) + '…' : s;
 }
 
+// Cap the returned steps so a pathological run (a multi-MB stdout/stderr with
+// many step-shaped log lines) can't bloat the MCP response past the `output`
+// slice. Keep the most recent steps — failures and partial-progress live at the
+// tail — with their true `index` preserved (a gap signals truncation).
+const MAX_STEPS = 1000;
+
 export function parseSteps(output: string): MaestroStep[] {
   if (!output || typeof output !== 'string') return [];
   const steps: MaestroStep[] = [];
@@ -60,7 +66,7 @@ export function parseSteps(output: string): MaestroStep[] {
       durationMs: Math.round(seconds * 1000),
     });
   }
-  return steps;
+  return steps.length > MAX_STEPS ? steps.slice(-MAX_STEPS) : steps;
 }
 
 // The TERMINAL failed step: the last parsed step iff it failed. maestro-runner

--- a/scripts/cdp-bridge/src/domain/maestro-step-parser.ts
+++ b/scripts/cdp-bridge/src/domain/maestro-step-parser.ts
@@ -3,6 +3,8 @@
 // I/O, fail-open: unparseable output yields []. Generalizes the #263 step-line
 // parser (tap-latency.ts derives parseTapLatencies from parseSteps).
 
+import { parseMaestroFailure } from './maestro-error-parser.js';
+
 export interface MaestroStep {
   index: number;
   name: string;
@@ -47,4 +49,50 @@ export function parseSteps(output: string): MaestroStep[] {
     });
   }
   return steps;
+}
+
+export function findFailedStep(steps: MaestroStep[]): MaestroStep | null {
+  for (let i = steps.length - 1; i >= 0; i--) {
+    if (steps[i].status === 'fail') return steps[i];
+  }
+  return null;
+}
+
+export function lastObservedStep(steps: MaestroStep[]): MaestroStep | null {
+  return steps.length ? steps[steps.length - 1] : null;
+}
+
+export interface ReasonSummary {
+  kind: 'SELECTOR_NOT_FOUND' | 'TIMEOUT' | 'ASSERTION_FAILED';
+  selector: string | null;
+}
+
+// Project parseMaestroFailure to {kind, selector}, DROPPING its `raw` field —
+// every MaestroFailure variant carries `raw` = the full unsliced output, which
+// must not be re-embedded into the result (it would defeat the output slice).
+export function summarizeReason(output: string): ReasonSummary | null {
+  const f = parseMaestroFailure(output);
+  if (f.kind === 'UNKNOWN') return null;
+  const selector = 'selector' in f ? (f.selector ?? null) : null;
+  return { kind: f.kind, selector };
+}
+
+export interface StepSummary {
+  steps: MaestroStep[];
+  failedStep: MaestroStep | null;
+  reason: ReasonSummary | null;
+  lastStep: MaestroStep | null;
+}
+
+// failedStep/reason are populated ONLY when the run's terminal verdict is fail
+// (opts.failed). maestro-runner logs transient retries; a fail-then-retry-✓ on
+// a PASSED run must not report a failedStep (mirrors parseMaestroFailure GH#118).
+export function buildStepSummary(output: string, opts: { failed: boolean }): StepSummary {
+  const steps = parseSteps(output);
+  return {
+    steps,
+    failedStep: opts.failed ? findFailedStep(steps) : null,
+    reason: opts.failed ? summarizeReason(output) : null,
+    lastStep: lastObservedStep(steps),
+  };
 }

--- a/scripts/cdp-bridge/src/domain/maestro-step-parser.ts
+++ b/scripts/cdp-bridge/src/domain/maestro-step-parser.ts
@@ -1,0 +1,50 @@
+// src/domain/maestro-step-parser.ts
+// GH #211: structure maestro_run results from maestro-runner stdout. Pure, no
+// I/O, fail-open: unparseable output yields []. Generalizes the #263 step-line
+// parser (tap-latency.ts derives parseTapLatencies from parseSteps).
+
+export interface MaestroStep {
+  index: number;
+  name: string;
+  verb: string;
+  status: 'pass' | 'fail';
+  durationMs: number;
+}
+
+// Strip ANSI SGR/color escape sequences. execFile output is usually un-colored
+// (child stdout is a pipe, not a TTY) but maestro-runner is not guaranteed to
+// honor that, and a glyph-anchored match breaks on a colored `✓`. Built via
+// fromCharCode(27) (ESC) to keep a raw control char out of the source/regex.
+const ANSI_RE = new RegExp(String.fromCharCode(27) + '\\[[0-9;]*m', 'g');
+export function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, '');
+}
+
+// `  {✓|✗} <name> (N.Ns)` — the trailing (N.Ns) is REQUIRED, which excludes the
+// `✗ rn-maestro-run 23.8s` summary line and the `N steps passing` count lines.
+// `.*?` is non-greedy + `$`-anchored so a duration-looking token inside the
+// selector value (`text="took (2.0s)"`) loses to the real trailing duration.
+const STEP_RE = /^([✓✗])\s+(.*?)\s*\(([\d.]+)s\)\s*$/;
+
+export function parseSteps(output: string): MaestroStep[] {
+  if (!output || typeof output !== 'string') return [];
+  const steps: MaestroStep[] = [];
+  let index = 0;
+  for (const raw of stripAnsi(output).split('\n')) {
+    const m = STEP_RE.exec(raw.trim());
+    if (!m) continue;
+    const name = m[2].trim();
+    const verb = name.split(/\s+/)[0].replace(/:$/, '');
+    if (verb === 'rn-maestro-run') continue; // belt-and-suspenders vs a future summary format
+    const seconds = Number(m[3]);
+    if (!Number.isFinite(seconds)) continue;
+    steps.push({
+      index: index++,
+      name,
+      verb,
+      status: m[1] === '✓' ? 'pass' : 'fail',
+      durationMs: Math.round(seconds * 1000),
+    });
+  }
+  return steps;
+}

--- a/scripts/cdp-bridge/src/domain/tap-latency.ts
+++ b/scripts/cdp-bridge/src/domain/tap-latency.ts
@@ -2,28 +2,19 @@
 // GH #263: detect a wedged simulator test-runtime from maestro-runner output.
 // Pure, no I/O. Fail-open: unparseable output yields no samples → no hint.
 
+import { parseSteps } from './maestro-step-parser.js';
+
 export const DEFAULT_FLOOR_MS = 1500;
 
 /**
- * Extract latencies (ms) of SUCCESSFUL tapOn steps from maestro-runner output.
- * maestro-runner prints each step as `  ✓ tapOn: id="x" (2.8s)` (seconds, in
- * parens at end). Only ✓ lines count: a ✗ line's duration is the step TIMEOUT
- * (~12.7s), which would false-positive an ordinary element-not-found failure.
+ * Latencies (ms) of SUCCESSFUL tapOn steps. Derived from parseSteps (GH #211):
+ * a ✗ tap's duration is the step TIMEOUT (~12.7s) and would false-positive an
+ * ordinary element-not-found failure, so only pass tapOn steps count.
  */
 export function parseTapLatencies(output: string): number[] {
-  const out: number[] = [];
-  for (const raw of output.split('\n')) {
-    const line = raw.trim();
-    // Anchor on the step verb (`✓ tapOn:`) so "tapOn" inside another step's
-    // text/selector value (e.g. `✓ assertVisible: text="tapOn …"`) is not
-    // counted. Successful (✓) steps only — a ✗ duration is the step timeout.
-    if (!/^✓\s+tapOn\b/.test(line)) continue;
-    const m = line.match(/\(([\d.]+)s\)\s*$/); // trailing (N.Ns)
-    if (!m) continue;
-    const seconds = Number(m[1]);
-    if (Number.isFinite(seconds)) out.push(Math.round(seconds * 1000));
-  }
-  return out;
+  return parseSteps(output)
+    .filter((s) => s.verb === 'tapOn' && s.status === 'pass')
+    .map((s) => s.durationMs);
 }
 
 export function median(samples: number[]): number | null {

--- a/scripts/cdp-bridge/src/tools/maestro-run.ts
+++ b/scripts/cdp-bridge/src/tools/maestro-run.ts
@@ -17,6 +17,7 @@ import {
 } from '../domain/maestro-validator.js';
 import { outputIndicatesFlowFailure } from '../domain/maestro-error-parser.js';
 import { augmentFailureWithDegradation, resolveFloorMs } from '../domain/tap-latency.js';
+import { buildStepSummary, classifyExecError, formatFailureHeadline } from '../domain/maestro-step-parser.js';
 import { stopFastRunner as defaultStopFastRunner } from '../runners/rn-fast-runner-client.js';
 import { releaseAndroidInteractionSlot as defaultReleaseAndroidSlot } from '../runners/release-android-slot.js';
 import { markCdpStale as defaultMarkCdpStale } from '../cdp/recovery.js';
@@ -223,12 +224,16 @@ export function createMaestroRunHandler(): (args: MaestroRunArgs) => Promise<Too
       // keyed on Maestro's own status LINES (GH#249: the prior bare `FAILED`
       // substring false-flagged passing runs whose app logs contained the token).
       const passed = !outputIndicatesFlowFailure(output);
+      const summary = buildStepSummary(output, { failed: !passed });
       const meta = {
         passed,
         flowFile,
         platform,
         runner: dispatch.runner,
         output: output.slice(0, 2000),
+        ...summary,
+        timedOut: false,
+        outputTruncated: false,
         ...(dispatch.fallbackReason ? { fallbackReason: dispatch.fallbackReason } : {}),
       };
 
@@ -267,12 +272,17 @@ export function createMaestroRunHandler(): (args: MaestroRunArgs) => Promise<Too
       const stdout = typeof errAny?.stdout === 'string' ? errAny.stdout : '';
       const stderr = typeof errAny?.stderr === 'string' ? errAny.stderr : '';
       const combined = (stdout + '\n' + stderr).trim();
+      const { timedOut, outputTruncated } = classifyExecError(err);
+      const summary = buildStepSummary(combined, { failed: true });
+      // Headline from structured data (raw-free); the raw err.message is the
+      // fallback only for system errors with no step output (e.g. spawn ENOENT).
+      const headline = formatFailureHeadline(summary, { timedOut, outputTruncated }, msg);
       // GH #263: a timeout/non-zero exit is also a failure surface — flag a
       // wedged runtime here too if the successful taps were degraded.
       const failAug = augmentFailureWithDegradation(
         combined,
         resolveFloorMs(process.env.RN_RUNTIME_DEGRADED_FLOOR_MS),
-        `Maestro flow failed: ${msg.slice(0, 500)}`,
+        headline,
         {
           flowFile,
           platform,
@@ -281,6 +291,9 @@ export function createMaestroRunHandler(): (args: MaestroRunArgs) => Promise<Too
           // `output` mirrors the success/warn shape so callers can read
           // it the same way regardless of which path they hit.
           output: combined.slice(0, 4000),
+          ...summary,
+          timedOut,
+          outputTruncated,
         },
       );
       return failResult(failAug.message, failAug.meta);

--- a/scripts/cdp-bridge/test/unit/gh-211-maestro-step-parser.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-211-maestro-step-parser.test.js
@@ -150,3 +150,22 @@ test('formatFailureHeadline: structured & raw-free; raw fallback only for system
     'Maestro flow output exceeded the 10MB buffer',
   );
 });
+
+test('findFailedStep: transient ✗ retried-✓ then nothing → null (terminal-fail only)', () => {
+  const out = '  ✗ tapOn: id="a" (12.0s)\n  ✓ tapOn: id="a" (1.0s)\n  ✓ tapOn: id="b" (1.0s)';
+  assert.equal(findFailedStep(parseSteps(out)), null);
+});
+
+test('parseSteps: a pathologically long step name is capped', () => {
+  const steps = parseSteps('  ✓ inputText: "' + 'x'.repeat(500) + '" (1.0s)');
+  assert.equal(steps.length, 1);
+  assert.ok(steps[0].name.length <= 201, `name len ${steps[0].name.length}`);
+  assert.ok(steps[0].name.endsWith('…'));
+  assert.equal(steps[0].verb, 'inputText'); // verb still derived from the uncapped first token
+});
+
+test('formatFailureHeadline: long parsed names stay bounded (no raw blowup)', () => {
+  const s = buildStepSummary('  ✗ tapOn: id="' + 'y'.repeat(500) + '" (3.0s)', { failed: true });
+  const h = formatFailureHeadline(s, { timedOut: false, outputTruncated: false }, 'x');
+  assert.ok(h.length < 300, `headline len ${h.length}`);
+});

--- a/scripts/cdp-bridge/test/unit/gh-211-maestro-step-parser.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-211-maestro-step-parser.test.js
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   parseSteps, stripAnsi, findFailedStep, lastObservedStep, summarizeReason, buildStepSummary,
+  classifyExecError, formatFailureHeadline,
 } from '../../dist/domain/maestro-step-parser.js';
 
 // Real maestro-runner format (same shape as the gh-263 fixtures).
@@ -96,4 +97,56 @@ test('buildStepSummary: timeout partial (no ✗) → failedStep null, lastStep =
   const s = buildStepSummary(partial, { failed: true });
   assert.equal(s.failedStep, null);
   assert.equal(s.lastStep.name, 'tapOn: id="a"');
+});
+
+test('classifyExecError: timeout (killed, no code) → timedOut, not truncated', () => {
+  assert.deepEqual(
+    classifyExecError({ killed: true, signal: 'SIGTERM', code: null }),
+    { timedOut: true, outputTruncated: false },
+  );
+});
+
+test('classifyExecError: maxBuffer overflow → truncated, not timedOut', () => {
+  assert.deepEqual(
+    classifyExecError({ killed: true, code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' }),
+    { timedOut: false, outputTruncated: true },
+  );
+});
+
+test('classifyExecError: normal non-zero exit → neither; null safe', () => {
+  assert.deepEqual(classifyExecError({ killed: false, code: 1 }), { timedOut: false, outputTruncated: false });
+  assert.deepEqual(classifyExecError(null), { timedOut: false, outputTruncated: false });
+});
+
+test('catch-path assembly: timeout → timedOut, partial steps, failedStep null', () => {
+  const err = { killed: true, code: null, stdout: '  ✓ launchApp (2.0s)\n  ✓ tapOn: id="a" (2.5s)', stderr: '' };
+  const combined = (err.stdout + '\n' + err.stderr).trim();
+  const cls = classifyExecError(err);
+  const summary = buildStepSummary(combined, { failed: true });
+  assert.equal(cls.timedOut, true);
+  assert.equal(cls.outputTruncated, false);
+  assert.equal(summary.failedStep, null);
+  assert.equal(summary.lastStep.name, 'tapOn: id="a"');
+});
+
+test('formatFailureHeadline: structured & raw-free; raw fallback only for system errors', () => {
+  const t = buildStepSummary('  ✓ launchApp (2.0s)\n  ✓ tapOn: id="a" (2.5s)', { failed: true });
+  assert.equal(
+    formatFailureHeadline(t, { timedOut: true, outputTruncated: false }, 'Command failed: …'),
+    'Maestro flow timed out after step "tapOn: id="a""',
+  );
+  const f = buildStepSummary('  ✗ tapOn: id="c" (12.7s)\nElement with id \'c\' not found', { failed: true });
+  assert.equal(
+    formatFailureHeadline(f, { timedOut: false, outputTruncated: false }, 'x'),
+    'Maestro flow failed at step "tapOn: id="c"" (SELECTOR_NOT_FOUND: c)',
+  );
+  const empty = { steps: [], failedStep: null, reason: null, lastStep: null };
+  assert.equal(
+    formatFailureHeadline(empty, { timedOut: false, outputTruncated: false }, 'spawn ENOENT'),
+    'Maestro flow failed: spawn ENOENT',
+  );
+  assert.equal(
+    formatFailureHeadline(empty, { timedOut: false, outputTruncated: true }, 'x'),
+    'Maestro flow output exceeded the 10MB buffer',
+  );
 });

--- a/scripts/cdp-bridge/test/unit/gh-211-maestro-step-parser.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-211-maestro-step-parser.test.js
@@ -169,3 +169,25 @@ test('formatFailureHeadline: long parsed names stay bounded (no raw blowup)', ()
   const h = formatFailureHeadline(s, { timedOut: false, outputTruncated: false }, 'x');
   assert.ok(h.length < 300, `headline len ${h.length}`);
 });
+
+test('parseSteps: pathological whitespace lines do not catastrophically backtrack (ReDoS)', () => {
+  const start = process.hrtime.bigint();
+  assert.deepEqual(parseSteps('✓ ' + ' '.repeat(8000) + 'x'), []);     // leading whitespace run
+  assert.deepEqual(parseSteps('✓ step' + ' '.repeat(8000) + 'x'), []); // trailing whitespace run
+  assert.deepEqual(parseSteps('✗ ' + '\t'.repeat(8000) + 'y'), []);    // tabs
+  const ms = Number(process.hrtime.bigint() - start) / 1e6;
+  // Generous ceiling: the fixed (linear) parser runs in <1ms; a catastrophic-
+  // backtracking regression measures 30s+. 2000ms cleanly separates the two
+  // without flaking under CI/system load.
+  assert.ok(ms < 2000, `parseSteps took ${ms.toFixed(1)}ms — possible ReDoS`);
+});
+
+test('formatFailureHeadline: reason without a failed step → structured (raw-free) headline', () => {
+  const s = buildStepSummary("  ✓ launchApp (2.0s)\nElement with id 'missing' not found", { failed: true });
+  assert.equal(s.failedStep, null);
+  assert.deepEqual(s.reason, { kind: 'SELECTOR_NOT_FOUND', selector: 'missing' });
+  assert.equal(
+    formatFailureHeadline(s, { timedOut: false, outputTruncated: false }, 'raw fallback should not appear'),
+    'Maestro flow failed (SELECTOR_NOT_FOUND: missing)',
+  );
+});

--- a/scripts/cdp-bridge/test/unit/gh-211-maestro-step-parser.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-211-maestro-step-parser.test.js
@@ -191,3 +191,13 @@ test('formatFailureHeadline: reason without a failed step → structured (raw-fr
     'Maestro flow failed (SELECTOR_NOT_FOUND: missing)',
   );
 });
+
+test('parseSteps: caps returned steps to the most recent 1000 (tail kept, true index)', () => {
+  const lines = [];
+  for (let i = 0; i < 1500; i++) lines.push(`  ✓ tapOn: id="s${i}" (1.0s)`);
+  const steps = parseSteps(lines.join('\n'));
+  assert.equal(steps.length, 1000);                       // capped
+  assert.equal(steps[steps.length - 1].name, 'tapOn: id="s1499"'); // tail kept
+  assert.equal(steps[steps.length - 1].index, 1499);      // true index preserved
+  assert.equal(steps[0].index, 500);                      // 1500 total → first kept index = 500 (gap = truncation signal)
+});

--- a/scripts/cdp-bridge/test/unit/gh-211-maestro-step-parser.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-211-maestro-step-parser.test.js
@@ -1,7 +1,9 @@
 // test/unit/gh-211-maestro-step-parser.test.js
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseSteps, stripAnsi } from '../../dist/domain/maestro-step-parser.js';
+import {
+  parseSteps, stripAnsi, findFailedStep, lastObservedStep, summarizeReason, buildStepSummary,
+} from '../../dist/domain/maestro-step-parser.js';
 
 // Real maestro-runner format (same shape as the gh-263 fixtures).
 const FAILED_RUN = `  ✓ launchApp (2.3s)
@@ -52,4 +54,46 @@ test('stripAnsi: removes SGR codes; ANSI-wrapped glyph line still parses', () =>
   const steps = parseSteps(colored);
   assert.equal(steps.length, 1);
   assert.equal(steps[0].verb, 'tapOn');
+});
+
+test('findFailedStep: last ✗ step; null when all pass', () => {
+  assert.equal(findFailedStep(parseSteps(FAILED_RUN)).name, 'tapOn: id="c"');
+  assert.equal(findFailedStep(parseSteps('  ✓ launchApp (1.0s)')), null);
+});
+
+test('lastObservedStep: steps.at(-1); null when empty', () => {
+  assert.equal(lastObservedStep(parseSteps(FAILED_RUN)).name, 'tapOn: id="c"');
+  assert.equal(lastObservedStep([]), null);
+});
+
+test('summarizeReason: sanitized {kind, selector}; NEVER carries raw', () => {
+  const r = summarizeReason(`Element with id 'submit' not found`);
+  assert.deepEqual(r, { kind: 'SELECTOR_NOT_FOUND', selector: 'submit' });
+  assert.equal('raw' in r, false);
+});
+
+test('summarizeReason: unrecognized output → null', () => {
+  assert.equal(summarizeReason('some unrecognized output'), null);
+});
+
+test('buildStepSummary: failed=false → failedStep/reason null even with a transient ✗', () => {
+  const s = buildStepSummary(FAILED_RUN, { failed: false });
+  assert.equal(s.failedStep, null);
+  assert.equal(s.reason, null);
+  assert.equal(s.steps.length, 5);
+  assert.equal(s.lastStep.name, 'tapOn: id="c"');
+});
+
+test('buildStepSummary: failed=true → failedStep + reason populated', () => {
+  const out = FAILED_RUN + `\nElement with id 'c' not found`;
+  const s = buildStepSummary(out, { failed: true });
+  assert.equal(s.failedStep.name, 'tapOn: id="c"');
+  assert.deepEqual(s.reason, { kind: 'SELECTOR_NOT_FOUND', selector: 'c' });
+});
+
+test('buildStepSummary: timeout partial (no ✗) → failedStep null, lastStep = last ✓', () => {
+  const partial = `  ✓ launchApp (2.0s)\n  ✓ tapOn: id="a" (2.5s)`;
+  const s = buildStepSummary(partial, { failed: true });
+  assert.equal(s.failedStep, null);
+  assert.equal(s.lastStep.name, 'tapOn: id="a"');
 });

--- a/scripts/cdp-bridge/test/unit/gh-211-maestro-step-parser.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-211-maestro-step-parser.test.js
@@ -1,0 +1,55 @@
+// test/unit/gh-211-maestro-step-parser.test.js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseSteps, stripAnsi } from '../../dist/domain/maestro-step-parser.js';
+
+// Real maestro-runner format (same shape as the gh-263 fixtures).
+const FAILED_RUN = `  ✓ launchApp (2.3s)
+  ✓ tapOn: id="a" (2.8s)
+  ✓ tapOn: id="b" (3.0s)
+  ✓ assertVisible: text="x" (1.1s)
+  ✗ tapOn: id="c" (12.7s)
+✗ rn-maestro-run 23.8s`;
+
+test('parseSteps: verb/status/durationMs/index; summary line excluded', () => {
+  const steps = parseSteps(FAILED_RUN);
+  assert.equal(steps.length, 5);
+  assert.deepEqual(steps[0], { index: 0, name: 'launchApp', verb: 'launchApp', status: 'pass', durationMs: 2300 });
+  assert.deepEqual(steps[1], { index: 1, name: 'tapOn: id="a"', verb: 'tapOn', status: 'pass', durationMs: 2800 });
+  assert.deepEqual(steps[4], { index: 4, name: 'tapOn: id="c"', verb: 'tapOn', status: 'fail', durationMs: 12700 });
+  assert.ok(!steps.some((s) => s.verb === 'rn-maestro-run')); // `✗ rn-maestro-run 23.8s` has no (N.Ns)
+});
+
+test('parseSteps: verb has trailing colon stripped', () => {
+  assert.equal(parseSteps('  ✓ tapOn: id="a" (1.0s)')[0].verb, 'tapOn');
+});
+
+test('parseSteps: verb is first token — verb name inside a selector value is not the verb', () => {
+  assert.equal(parseSteps('  ✓ assertVisible: text="tapOn now" (1.0s)')[0].verb, 'assertVisible');
+});
+
+test('parseSteps: count lines / bare text are not steps', () => {
+  assert.deepEqual(parseSteps('  3 steps passing\n  1 steps failing\nRunning on iPhone'), []);
+});
+
+test('parseSteps: embedded (N.Ns) in a selector — trailing duration wins', () => {
+  const steps = parseSteps('  ✓ assertVisible: text="took (2.0s)" (1.0s)');
+  assert.equal(steps.length, 1);
+  assert.equal(steps[0].durationMs, 1000);
+  assert.equal(steps[0].name, 'assertVisible: text="took (2.0s)"');
+});
+
+test('parseSteps: empty / garbage / non-string → [] (never throws)', () => {
+  assert.deepEqual(parseSteps(''), []);
+  assert.deepEqual(parseSteps('not maestro output'), []);
+  assert.deepEqual(parseSteps(undefined), []);
+});
+
+test('stripAnsi: removes SGR codes; ANSI-wrapped glyph line still parses', () => {
+  const ESC = String.fromCharCode(27); // ANSI escape byte (0x1b)
+  const colored = `  ${ESC}[32m✓${ESC}[0m tapOn: id="a" (1.0s)`;
+  assert.equal(stripAnsi(colored).includes(ESC), false);
+  const steps = parseSteps(colored);
+  assert.equal(steps.length, 1);
+  assert.equal(steps[0].verb, 'tapOn');
+});


### PR DESCRIPTION
## Summary
Makes `maestro_run` return **structured per-step results** and **partial progress on timeout**, parsed from maestro-runner stdout (no new file I/O). Closes #211. (Issue item 3 — iOS `clearState` — already shipped in #276/#201.)

New pure module `maestro-step-parser.ts` parses the `{✓|✗} verb[: sel] (N.Ns)` step lines maestro-runner already prints; `tap-latency.ts` (#263) now derives its tap latencies from the same parser (one regex, not two); `maestro_run` spreads additive fields into the result on all three paths.

### Result shape (additive — `output` preserved for `run-action`)
`data` on pass/warn, `meta` on fail:
```
steps:           {index,name,verb,status:'pass'|'fail',durationMs}[]
failedStep:      MaestroStep | null      // terminal failed step only
reason:          {kind,selector} | null  // sanitized — never the raw runner log
lastStep:        MaestroStep | null      // progress marker
timedOut:        boolean
outputTruncated: boolean                 // maxBuffer overflow, distinct from timeout
```

## Process
- **Plan multi-reviewed pre-code** (Codex + Claude): caught the `reason`-re-embeds-`raw` blocker, maxBuffer-vs-timeout, verb colon-strip, data/meta envelope placement, terminal-only `failedStep`.
- TDD; per-edit **codex-pair** review (→ terminal-fail semantics + bounded fields); then full-diff **multi-review**:
  - **Codex** found a **ReDoS** in the step regex (overlapping `\s+(.*?)\s*` → 30s on a glyph + long-whitespace line in untrusted 10MB stdout). Hardened to `(\S.*\S|\S)\s*\(` — 0ms on all pathological inputs, byte-identical on valid lines.
  - **Antigravity** full-diff review: no material issues; verified envelope placement, raw-free invariant, #263 non-regression, no consumer breaks.

## Test plan
- [x] Unit: full cdp-bridge suite **2087/2087** (gh-211 parser cases incl. ReDoS timing guard, field capping, terminal-fail, timeout-vs-maxBuffer).
- [x] #263 regression: `gh-263-tap-latency.test.js` green — `parseTapLatencies` behavior identical.
- [x] Device: real maestro-runner output (piped) emits **0 ANSI bytes** (`stripAnsi` is defensive-only); `parseSteps` fail-open on real non-step output → `[]`. Step-line format validated by #263's real fixtures (same binary v1.0.9).
- [ ] Pre-merge nicety: live `✓ step (N.Ns)` capture (local WDA startup flaked on a fresh iOS 26.5 sim — environment, not the change) + `runFlow` sub-flow rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)