### PR TITLE
feat(rn-device): eradicate agent-device — Phase 1: port/conflict hardening

### DIFF
--- a/.changeset/android-device-lock-port-hardening.md
+++ b/.changeset/android-device-lock-port-hardening.md
@@ -1,0 +1,5 @@
+---
+"rn-dev-agent": minor
+---
+
+Harden device-control conflicts: add an Android serial-scoped device lock (parity with iOS) that engages on a normal emulator, separate the Android runner's probed host port from its fixed device-listener port (`adb forward`), and let the iOS runner self-assign a free port when 22088 is taken.

--- a/docs/superpowers/plans/2026-06-15-eradicate-agent-device-plan.md
+++ b/docs/superpowers/plans/2026-06-15-eradicate-agent-device-plan.md
@@ -1,0 +1,560 @@
+# Eradicate agent-device — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the third-party `agent-device` CLI dependency entirely (iOS + Android), making the in-tree `rn-fast-runner` / `rn-android-runner` the sole device-interaction backend — proven faster + more reliable than agent-device, with hardened port-lock / conflict handling.
+
+**Architecture:** `device_*` verbs dispatch through a platform router (`runIOS` / `runAndroid`) to in-tree HTTP `/command` runners. No daemon, no CLI, no silent fallback. A device session = runner-readiness + a state file + a serial/UDID-scoped device lock. iOS uses one host-loopback port (the runner self-assigns when the default is taken); Android separates a fixed device-listener port from a probed host port bridged by `adb forward`.
+
+**Tech Stack:** TypeScript (Node ≥22, `tsc` build, `node:test`), Swift/XCTest (`rn-fast-runner`), Kotlin/UIAutomator2 + NanoHTTPD (`rn-android-runner`), `xcrun simctl` / `adb`.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-eradicate-agent-device-design.md`
+
+> **Amendments applied from the multi-LLM plan review (Codex + Gemini, 2026-06-15):** fixed the Android-lock no-op (UDID_RE gates out adb serials → added `resolveAndroidSerial`); rewrote the Task 5 test to match the file's actual static source-regex style; fixed the Task 1 breakage of `gh-202-device-lock-wiring.test.js:12`; corrected/completed the Task 3 test-file list (real `runners/` path + `gh-243` + `audit-h4`) and added state-file migration; replaced the racy iOS TS-probe with "pass 0 on collision" (runner self-assigns); made `findFreePort` tests race-tolerant + guarded against resolving port 0.
+
+---
+
+## Phase Roadmap (stacked PRs)
+
+This plan details **Phase 1** in full TDD. Phases 0/2/3/4 get their own plans authored when reached (each depends on the prior phase's concrete API/outcomes). Dependency graph:
+
+```
+Phase 1 (hardening) ─┐
+                     ├─► Phase 2 (cutover) ─► Phase 3 (cleanup/docs) ─► Phase 4 (verify)
+Phase 0 (benchmark) ─┘
+```
+
+| Phase | Title | Shape | Depends on | Status |
+|---|---|---|---|---|
+| **1** | Port/conflict hardening | Pure TS, unit-TDD | — | **DETAILED BELOW** |
+| **0** | Head-to-head benchmark (both sims) | Device session + harness | — (must finish before Phase 2) | Own plan |
+| **2** | Hard cutover (remove daemon+CLI tiers, residual verbs → native, lock-before-side-effects) | TS + device verify | Phase 1 API, Phase 0 data | Own plan |
+| **3** | Cleanup + docs (install script, hook, ~522 refs, /setup, /doctor) | TS + docs | Phase 2 | Own plan |
+| **4** | Final dual-platform verification + ours-only re-benchmark | Device session | Phases 1–3 | Own plan |
+
+**Execution order:** Phase 1 first (pure code, no device gating, de-risks everything). Phase 0 (benchmark) runs as a device session before the Phase 2 cutover. Phases 0 and 1 have no interdependency.
+
+**Per-task workflow (all tasks):** edit `src/*.ts` → **build** → **run test**. Tests import compiled `dist/`, so the build is mandatory:
+```bash
+cd scripts/cdp-bridge && npm run build            # tsc → dist/
+node --test test/unit/<file>.test.js              # run one test file (after build)
+```
+> **`.js` tests are NOT type-checked** (`tsconfig.json` includes only `src`). A renamed required field on `AndroidRunnerState` therefore produces NO compile error — stale fixtures fail only at runtime under the phase-end full-suite `**` glob. Migrate every fixture in the same task that renames the field.
+
+Full suite gate at phase end: `cd scripts/cdp-bridge && npm test` (builds + all unit files, including the `test/unit/**` subdirs). Commits are signed, per-task; add a changeset for user-facing behavior.
+
+---
+
+## Phase 1 — Port/Conflict Hardening
+
+**Outcome of this PR:** an Android serial-scoped device lock that **actually engages on a normal single emulator** (parity with the iOS UDID lock), collision-tolerant runner ports (probed host port on Android via `adb forward`; runner self-assigns on iOS when 22088 is taken), and robust forward/cleanup — with no behavior change for the common single-simulator case.
+
+### File Structure (Phase 1)
+
+| File | Responsibility | Change |
+|---|---|---|
+| `scripts/cdp-bridge/src/lifecycle/device-lock.ts` | Persisted per-device ownership lock | **Modify** — widen `'ios'`-only → `'ios' \| 'android'`, rename `udid`→`deviceId` |
+| `scripts/cdp-bridge/src/runners/free-port.ts` | Port probing (`findFreePort`, `isPortFree`) | **Create** |
+| `scripts/cdp-bridge/src/runners/rn-android-runner-client.ts` | Android runner lifecycle + HTTP client | **Modify** — split `hostPort`/`devicePort`, probe host port, add `resolveAndroidSerial`/`parseAdbDevicesSerials`, state-file migration |
+| `scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts` | iOS runner lifecycle | **Modify** — pass `0` (runner self-assigns) when 22088 is taken |
+| `scripts/cdp-bridge/src/tools/device-session.ts` | Session open/close + lock wiring | **Modify** — generalize `acquireDeviceLockForSession`, wire Android lock on the resolved serial |
+| `test/unit/gh-202-device-lock.test.js` | Lock unit tests | **Modify** — cover both platforms |
+| `test/unit/gh-202-device-lock-wiring.test.js` | Lock wiring (static source-regex) | **Modify** — fix line 12 + add Android-branch assertions |
+| `test/unit/free-port.test.js` | Port-probe unit tests | **Create** |
+| `test/unit/android-runner-ports.test.js` | Android port-split + serial-parse tests | **Create** |
+| `test/unit/runners/rn-android-runner-client.test.js`, `gh-243-android-runner-health.test.js`, `audit-h4-android-runner-deviceid.test.js` | Existing state fixtures | **Modify** — `{ port }` → `{ hostPort, devicePort }` |
+
+---
+
+### Task 1: Generalize `DeviceLock` to iOS + Android
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/lifecycle/device-lock.ts`
+- Modify: `scripts/cdp-bridge/src/tools/device-session.ts:40-60` (`acquireDeviceLockForSession`) + its iOS call site (`:235`)
+- Test: `test/unit/gh-202-device-lock.test.js`, and **fix** `test/unit/gh-202-device-lock-wiring.test.js:12`
+
+- [ ] **Step 1: Update the lock test to the generalized API + add Android cases (failing).**
+
+In `test/unit/gh-202-device-lock.test.js`, change `makeLock` to pass `platform` + `deviceId` (replacing `udid`), update body/path assertions (`body.udid`→`body.deviceId`, `r.holder.udid`→`r.holder.deviceId`, and the inline `isDeviceLockStale` fixture `udid:`→`deviceId:`; keep the iOS path assertion `device-501-ios-${UDID}` — format is `${platform}-${deviceId}`). Then add:
+
+```js
+function makeLock(dir, over = {}) {
+  return new DeviceLock({
+    platform: over.platform ?? 'ios',
+    deviceId: over.deviceId ?? UDID,
+    projectRoot: over.projectRoot ?? '/proj/a',
+    appId: over.appId ?? 'com.example.app',
+    pid: over.pid ?? 4242,
+    uid: 501, tmpDir: dir, version: '0-test',
+    clock: over.clock ?? (() => FIXED),
+    processAlive: over.processAlive ?? (() => true),
+    staleMs: over.staleMs ?? 90_000,
+  });
+}
+
+test('GH#202 DeviceLock: Android serial-scoped lock keys path + body on platform+serial', () => {
+  const dir = tmp();
+  try {
+    const r = makeLock(dir, { platform: 'android', deviceId: 'emulator-5554' }).acquire();
+    assert.equal(r.status, 'acquired');
+    const lock = makeLock(dir, { platform: 'android', deviceId: 'emulator-5554' });
+    assert.ok(lock.lockPath.includes('device-501-android-emulator-5554'));
+    const body = JSON.parse(readFileSync(lock.lockPath, 'utf8'));
+    assert.equal(body.platform, 'android');
+    assert.equal(body.deviceId, 'emulator-5554');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('GH#202 DeviceLock: same id on different platforms do NOT collide', () => {
+  const dir = tmp();
+  try {
+    const ios = makeLock(dir, { platform: 'ios', deviceId: 'shared-id', pid: 1 }).acquire();
+    const and = makeLock(dir, { platform: 'android', deviceId: 'shared-id', pid: 2 }).acquire();
+    assert.equal(ios.status, 'acquired');
+    assert.equal(and.status, 'acquired');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+```
+
+- [ ] **Step 2: Build + run to verify failure.**
+
+```bash
+cd scripts/cdp-bridge && npm run build && node --test test/unit/gh-202-device-lock.test.js
+```
+Expected: FAIL — constructor still expects `udid`; `body.deviceId`/`platform`/path assertions fail.
+
+- [ ] **Step 3: Generalize `device-lock.ts`.** Replace the body interface, options, path, body writer, foreign-body guard, and validity check:
+
+```ts
+export interface DeviceLockBody {
+  pid: number; projectRoot: string;
+  platform: 'ios' | 'android';
+  deviceId: string;            // iOS UDID or Android adb serial
+  appId?: string; startedAt: number; lastHeartbeat: number; version?: string;
+}
+export interface DeviceLockOptions {
+  platform: 'ios' | 'android';
+  deviceId: string;
+  projectRoot?: string; appId?: string; pid?: number; uid?: number;
+  tmpDir?: string; version?: string; clock?: () => number;
+  processAlive?: (pid: number) => boolean; staleMs?: number;
+}
+```
+Constructor (replace the `udid` field + path):
+```ts
+    this.platform = opts.platform;
+    this.deviceId = opts.deviceId;
+    this.lockPath = join(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
+```
+(declare `private readonly platform: 'ios' | 'android';` + `private readonly deviceId: string;`; remove `udid`.) In `create()` the body uses `platform: this.platform, deviceId: this.deviceId`. In `readExisting()`:
+```ts
+      if (parsed.deviceId !== this.deviceId || parsed.platform !== this.platform) return null;
+```
+In `isValidBody()` (replace the two iOS-specific lines):
+```ts
+    (b.platform === 'ios' || b.platform === 'android') &&
+    typeof b.deviceId === 'string' && b.deviceId.length > 0 &&
+```
+
+- [ ] **Step 4: Update the caller + fix the wiring-test regex.**
+
+In `device-session.ts`, change `acquireDeviceLockForSession` to `(platform: 'ios' | 'android', deviceId: string, appId: string)` and `new DeviceLock({ platform, deviceId, appId })`; update its iOS call site to `acquireDeviceLockForSession('ios', deviceId, appId)`.
+
+Then fix `test/unit/gh-202-device-lock-wiring.test.js:12` — it asserts the OLD signature and would go red:
+```js
+  assert.match(sessionSrc, /acquireDeviceLockForSession\('ios', deviceId, appId\)/);
+```
+(Leave lines 16-27 as-is; the close→clear→DEVICE_BUSY and `releaseDeviceLockForSession() … new DeviceLock` orderings are preserved by the edits below in Task 5.)
+
+- [ ] **Step 5: Build + run to verify pass.**
+
+```bash
+cd scripts/cdp-bridge && npm run build && node --test test/unit/gh-202-device-lock.test.js test/unit/gh-202-device-lock-wiring.test.js
+```
+Expected: PASS (iOS cases + the two new Android cases; wiring regex now matches).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add scripts/cdp-bridge/src/lifecycle/device-lock.ts scripts/cdp-bridge/src/tools/device-session.ts scripts/cdp-bridge/test/unit/gh-202-device-lock.test.js scripts/cdp-bridge/test/unit/gh-202-device-lock-wiring.test.js scripts/cdp-bridge/dist
+git commit -m "feat(rn-device): generalize DeviceLock to iOS+Android (deviceId/platform)"
+```
+
+---
+
+### Task 2: `free-port.ts` (`findFreePort` + `isPortFree`)
+
+**Files:**
+- Create: `scripts/cdp-bridge/src/runners/free-port.ts`
+- Test: `scripts/cdp-bridge/test/unit/free-port.test.js`
+
+- [ ] **Step 1: Write the failing test (race-tolerant — no hard-coded ports).**
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:net';
+import { findFreePort, isPortFree } from '../../dist/runners/free-port.js';
+
+// Bind :0 to obtain a guaranteed-free port number, then close it.
+function knownFreePort() {
+  return new Promise((resolve) => {
+    const s = createServer();
+    s.listen({ port: 0, host: '127.0.0.1' }, () => {
+      const p = s.address().port;
+      s.close(() => resolve(p));
+    });
+  });
+}
+
+test('findFreePort: returns the preferred port when it is free', async () => {
+  const p = await knownFreePort();
+  assert.equal(await findFreePort(p), p);
+});
+
+test('findFreePort: returns a different, valid port when preferred is occupied', async () => {
+  const blocker = createServer();
+  const held = await new Promise((r) => blocker.listen({ port: 0, host: '127.0.0.1' }, () => r(blocker.address().port)));
+  try {
+    const p = await findFreePort(held);
+    assert.notEqual(p, held);
+    assert.ok(p > 0 && p < 65536);
+  } finally { await new Promise((r) => blocker.close(r)); }
+});
+
+test('isPortFree: true for a free port, false for an occupied one', async () => {
+  const blocker = createServer();
+  const held = await new Promise((r) => blocker.listen({ port: 0, host: '127.0.0.1' }, () => r(blocker.address().port)));
+  try { assert.equal(await isPortFree(held), false); }
+  finally { await new Promise((r) => blocker.close(r)); }
+});
+```
+
+- [ ] **Step 2: Build + run to verify failure.**
+
+```bash
+cd scripts/cdp-bridge && npm run build && node --test test/unit/free-port.test.js
+```
+Expected: FAIL — `Cannot find module '../../dist/runners/free-port.js'`.
+
+- [ ] **Step 3: Implement `free-port.ts`.**
+
+```ts
+import { createServer } from 'node:net';
+
+export function isPortFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const srv = createServer();
+    srv.once('error', () => resolve(false));
+    srv.listen({ port, host: '127.0.0.1' }, () => srv.close(() => resolve(true)));
+  });
+}
+
+/**
+ * Resolve a bindable TCP port on 127.0.0.1: `preferred` if free, else an
+ * OS-assigned ephemeral free port. Rejects on unexpected bind errors or if the
+ * OS hands back an unusable port 0. Note: there is an inherent TOCTOU window
+ * between this probe and the caller's real bind — callers that bind a SPECIFIC
+ * number (e.g. adb forward) must handle a late EADDRINUSE; the iOS runner avoids
+ * the window entirely by self-assigning (port 0).
+ */
+export function findFreePort(preferred: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const tryListen = (port: number, fallbackToAny: boolean): void => {
+      const srv = createServer();
+      srv.once('error', (err: NodeJS.ErrnoException) => {
+        if (fallbackToAny && err.code === 'EADDRINUSE') tryListen(0, false);
+        else reject(err);
+      });
+      srv.listen({ port, host: '127.0.0.1' }, () => {
+        const addr = srv.address();
+        const chosen = typeof addr === 'object' && addr ? addr.port : 0;
+        if (!chosen) { srv.close(() => reject(new Error('findFreePort: OS returned port 0'))); return; }
+        srv.close(() => resolve(chosen));
+      });
+    };
+    tryListen(preferred, true);
+  });
+}
+```
+
+- [ ] **Step 4: Build + run to verify pass.**
+
+```bash
+cd scripts/cdp-bridge && npm run build && node --test test/unit/free-port.test.js
+```
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add scripts/cdp-bridge/src/runners/free-port.ts scripts/cdp-bridge/test/unit/free-port.test.js scripts/cdp-bridge/dist
+git commit -m "feat(rn-device): add findFreePort/isPortFree port-probe helpers"
+```
+
+---
+
+### Task 3: Split Android runner host/device ports (+ state migration)
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/runners/rn-android-runner-client.ts`
+- Test: create `test/unit/android-runner-ports.test.js`; migrate fixtures in `test/unit/runners/rn-android-runner-client.test.js`, `test/unit/gh-243-android-runner-health.test.js`, `test/unit/audit-h4-android-runner-deviceid.test.js`
+
+- [ ] **Step 1: Write the failing test (all three builders imported up front).**
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildAdbForwardArgs, buildAdbForwardRemoveArgs, buildInstrumentPortArgs,
+} from '../../dist/runners/rn-android-runner-client.js';
+
+test('Android ports: adb forward maps probed hostPort → fixed devicePort', () => {
+  assert.deepEqual(buildAdbForwardArgs('emulator-5554', 41001, 22089),
+    ['-s', 'emulator-5554', 'forward', 'tcp:41001', 'tcp:22089']);
+});
+test('Android ports: instrumentation receives the DEVICE port, not the host port', () => {
+  assert.deepEqual(buildInstrumentPortArgs(22089), ['-e', 'RN_ANDROID_RUNNER_PORT', '22089']);
+});
+test('Android ports: forward --remove targets the host port', () => {
+  assert.deepEqual(buildAdbForwardRemoveArgs('emulator-5554', 41001),
+    ['-s', 'emulator-5554', 'forward', '--remove', 'tcp:41001']);
+});
+```
+
+- [ ] **Step 2: Build + run to verify failure.**
+
+```bash
+cd scripts/cdp-bridge && npm run build && node --test test/unit/android-runner-ports.test.js
+```
+Expected: FAIL — builders not exported.
+
+- [ ] **Step 3: Implement the port split + state migration.**
+
+Replace `AndroidRunnerState`:
+```ts
+interface AndroidRunnerState {
+  hostPort: number;   // 127.0.0.1 port the TS client connects to (probed; globally contended)
+  devicePort: number; // NanoHTTPD listener inside the emulator (fixed; emulator-namespaced)
+  pid: number; deviceId?: string; bundleId?: string; startedAt: string;
+}
+```
+Harden the state-file rehydration block (currently ~lines 83-95) so a stale old-shape file (`{ port }`, no `hostPort`) is discarded, not adopted:
+```ts
+    const raw = JSON.parse(readFileSync(STATE_FILE, 'utf-8')) as Partial<AndroidRunnerState>;
+    if (typeof raw.hostPort !== 'number' || typeof raw.devicePort !== 'number') {
+      unlinkSync(STATE_FILE);                 // pre-split state shape → ignore + clear
+    } else {
+      try { process.kill(raw.pid, 0); runnerState = raw as AndroidRunnerState; }
+      catch { unlinkSync(STATE_FILE); }
+    }
+```
+Add pure, testable builders near `adbSerialArgs`:
+```ts
+export function buildAdbForwardArgs(deviceId: string | undefined, hostPort: number, devicePort: number): string[] {
+  return [...adbSerialArgs(deviceId), 'forward', `tcp:${hostPort}`, `tcp:${devicePort}`];
+}
+export function buildAdbForwardRemoveArgs(deviceId: string | undefined, hostPort: number): string[] {
+  return [...adbSerialArgs(deviceId), 'forward', '--remove', `tcp:${hostPort}`];
+}
+export function buildInstrumentPortArgs(devicePort: number): string[] {
+  return ['-e', 'RN_ANDROID_RUNNER_PORT', String(devicePort)];
+}
+```
+Rewrite `startAndroidRunner` to probe the host port (import `findFreePort` from `./free-port.js`), keep `devicePort` fixed, and retry the forward once if the probed host port raced:
+```ts
+export async function startAndroidRunner(deviceId?: string, bundleId?: string, devicePort = DEFAULT_PORT): Promise<AndroidRunnerState> {
+  if (isAndroidRunnerAvailable() && shouldReuseAndroidRunner(runnerState, deviceId)) return runnerState!;
+
+  let hostPort = await findFreePort(devicePort);
+  try {
+    await execFileAsync('adb', buildAdbForwardArgs(deviceId, hostPort, devicePort));
+  } catch {
+    hostPort = await findFreePort(0);          // host port raced between probe and forward → re-probe once
+    await execFileAsync('adb', buildAdbForwardArgs(deviceId, hostPort, devicePort));
+  }
+  // spawn: ...am instrument args use buildInstrumentPortArgs(devicePort)...
+  // readiness: await waitForAndroidRunnerHealth(hostPort, ...)
+  // state: runnerState = { hostPort, devicePort, pid: child.pid, deviceId, bundleId, startedAt: new Date().toISOString() }
+}
+```
+Replace every remaining `runnerState.port` / `state.port` read with `runnerState.hostPort` (the `/command` + `/health` URLs become `http://127.0.0.1:${hostPort}`). In `stopAndroidRunner`, change the forward removal to `buildAdbForwardRemoveArgs(state.deviceId, state.hostPort)`.
+
+- [ ] **Step 4: Build + run new test; then migrate the existing fixtures.**
+
+```bash
+cd scripts/cdp-bridge && npm run build && node --test test/unit/android-runner-ports.test.js
+```
+Expected: PASS (3). Then migrate every `_setAndroidRunnerStateForTest({ port: N, ... })` and `stateFor` fixture to `{ hostPort: N, devicePort: 22089, ... }`, and any `state.port` assertion to `state.hostPort`, in **exactly these files** (verified to set the old shape):
+- `test/unit/runners/rn-android-runner-client.test.js`  ← note the `runners/` subdir
+- `test/unit/gh-243-android-runner-health.test.js`
+- `test/unit/audit-h4-android-runner-deviceid.test.js`
+
+```bash
+node --test test/unit/runners/rn-android-runner-client.test.js test/unit/gh-243-android-runner-health.test.js test/unit/audit-h4-android-runner-deviceid.test.js
+```
+Expected: PASS after the rename. (Do NOT touch `android-runner-short-circuit.test.js` — it is a static source-regex test that sets no state.)
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add scripts/cdp-bridge/src/runners/rn-android-runner-client.ts scripts/cdp-bridge/test/unit scripts/cdp-bridge/dist
+git commit -m "feat(rn-device): separate Android host vs device ports (probe host, fix device) + migrate stale state"
+```
+
+---
+
+### Task 4: iOS — runner self-assigns when 22088 is taken
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts` (`startFastRunner`)
+
+> No Swift change needed: `makeRunnerListener` already binds an OS-assigned port via `NWListener(using: .tcp)` when `desiredPort == 0`, and echoes the actual port back as `RN_FAST_RUNNER_PORT=<n>` (the TS parser already reads `result.port`). So we just pass `0` instead of a contended fixed number — eliminating the probe→bind TOCTOU.
+
+- [ ] **Step 1: Implement the fallback.**
+
+`startFastRunner` currently always uses `port = DEFAULT_PORT` (22088). Use 22088 when free, else `0` (import `isPortFree` from `./free-port.js`):
+```ts
+export async function startFastRunner(deviceId: string, bundleId: string, port?: number): Promise<FastRunnerState> {
+  const desired = port ?? (await isPortFree(DEFAULT_PORT) ? DEFAULT_PORT : 0);
+  // ...existing body, using `desired` where `port` was used:
+  //   env: { ...process.env, RN_FAST_RUNNER_PORT: String(desired) }
+  //   the runner binds 22088 (or OS-assigns when desired===0) and echoes the actual
+  //   port; result.port stays authoritative and flows into FastRunnerState.port.
+}
+```
+Reuse is unaffected: `shouldReuseRunner` keys on `deviceId`, and the cached-state early-return happens before this computes a port. Residual risk: the narrow 22088-freed-then-retaken window is the SAME as today (today blindly binds 22088); the collision case is now graceful instead of `LISTENER_FAILED`.
+
+- [ ] **Step 2: Build + verify the full unit suite stays green.**
+
+```bash
+cd scripts/cdp-bridge && npm test 2>&1 | tail -20
+```
+Expected: all unit tests pass (additive; fast-runner tests passing an explicit `port` are unaffected). The spawn path is device-verified in Phase 4.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts scripts/cdp-bridge/dist
+git commit -m "feat(rn-device): iOS runner self-assigns a free port when 22088 is taken"
+```
+
+---
+
+### Task 5: Resolve the Android serial + wire the device lock at open
+
+This is the fix for the review's #1 blocker: the open path derives `deviceId` via `UDID_RE = /^[0-9A-Fa-f-]{25,}$/`, which an adb serial (`emulator-5554`) never matches — so the lock must key on a **separately-resolved adb serial**, not on `deviceId`.
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/runners/rn-android-runner-client.ts` (add `parseAdbDevicesSerials` + `resolveAndroidSerial`)
+- Modify: `scripts/cdp-bridge/src/tools/device-session.ts` (Android lock branch in the `action==='open'` success path)
+- Test: extend `test/unit/android-runner-ports.test.js` (serial parse) + `test/unit/gh-202-device-lock-wiring.test.js` (source-regex)
+
+- [ ] **Step 1: Write the failing tests.**
+
+Serial-parse (pure, in `android-runner-ports.test.js`):
+```js
+import { parseAdbDevicesSerials } from '../../dist/runners/rn-android-runner-client.js';
+
+test('parseAdbDevicesSerials: extracts only online device serials', () => {
+  const out = 'List of devices attached\nemulator-5554\tdevice\nemulator-5556\toffline\n\n';
+  assert.deepEqual(parseAdbDevicesSerials(out), ['emulator-5554']);
+});
+```
+Wiring (source-regex, matching this file's existing style — it `readFileSync`s `device-session.ts` and runs `assert.match`):
+```js
+test('GH#202 Android open resolves the adb serial and acquires the device lock', () => {
+  assert.match(sessionSrc, /resolveAndroidSerial/);
+  assert.match(sessionSrc, /acquireDeviceLockForSession\('android', /);
+});
+test('GH#202 Android conflict teardown stops the android runner', () => {
+  assert.match(sessionSrc, /stopAndroidRunner\(\)/);
+});
+```
+
+- [ ] **Step 2: Build + run to verify failure.**
+
+```bash
+cd scripts/cdp-bridge && npm run build && node --test test/unit/android-runner-ports.test.js test/unit/gh-202-device-lock-wiring.test.js
+```
+Expected: FAIL — `parseAdbDevicesSerials` not exported; the Android wiring regexes don't match.
+
+- [ ] **Step 3: Implement serial resolution + the Android lock branch.**
+
+In `rn-android-runner-client.ts`:
+```ts
+export function parseAdbDevicesSerials(stdout: string): string[] {
+  return stdout.split('\n').slice(1)
+    .map((l) => l.trim())
+    .filter((l) => l.endsWith('\tdevice'))
+    .map((l) => l.split('\t')[0]);
+}
+export async function resolveAndroidSerial(explicit?: string): Promise<string | undefined> {
+  if (explicit) return explicit;
+  if (process.env.ANDROID_SERIAL) return process.env.ANDROID_SERIAL;
+  try {
+    const { stdout } = await execFileAsync('adb', ['devices']);
+    const serials = parseAdbDevicesSerials(stdout);
+    return serials.length === 1 ? serials[0] : undefined; // ambiguous if 0 or >1 → fail-open
+  } catch { return undefined; }
+}
+```
+In `device-session.ts` `action==='open'` success branch, generalize the iOS-only lock block to cover both platforms (import `stopAndroidRunner`, `resolveAndroidSerial`):
+```ts
+        const lockPlatform: 'ios' | 'android' = platform === 'android' ? 'android' : 'ios';
+        const lockDeviceId = lockPlatform === 'android'
+          ? await resolveAndroidSerial(deviceId)         // adb serial, NOT the UDID_RE-gated deviceId
+          : deviceId;
+        if (lockDeviceId) {
+          const lockResult = acquireDeviceLockForSession(lockPlatform, lockDeviceId, appId);
+          if (lockResult.status === 'conflict') {
+            await runAgentDevice(['close']).catch(() => { /* best-effort teardown */ });
+            clearActiveSession();
+            if (lockPlatform === 'ios') stopFastRunner(); else stopAndroidRunner();
+            return failResult(deviceBusyMessage(lockDeviceId, lockResult.holder), { code: 'DEVICE_BUSY', holder: lockResult.holder });
+          }
+          if (lockResult.degraded) {
+            logger.warn('rn-device', `Device-ownership lock unavailable (fs error) for ${lockDeviceId} — cross-bridge contention protection is off this session.`);
+          }
+        }
+```
+(Replace the old `if (platform === 'ios' && deviceId)` lock block. Add a `// TODO(phase2): acquire the lock BEFORE the open side-effect once 'open' is resolved via simctl/adb instead of agent-device — spec D-e.`)
+
+> **Scope honesty:** when `resolveAndroidSerial` returns `undefined` (no device / multiple ambiguous devices), the lock fails open — no regression, but no protection that session. The common single-emulator case now resolves one serial and DOES acquire the lock — this is the fix for the no-op the review caught. Multi-emulator serial disambiguation is finished in Phase 2 (explicit device targeting).
+
+- [ ] **Step 4: Build + run to verify pass.**
+
+```bash
+cd scripts/cdp-bridge && npm run build && node --test test/unit/android-runner-ports.test.js test/unit/gh-202-device-lock-wiring.test.js
+```
+Expected: PASS (serial parse + both Android wiring regexes match; iOS wiring still green).
+
+- [ ] **Step 5: Phase gate — full suite + changeset, then commit.**
+
+```bash
+cd scripts/cdp-bridge && npm test 2>&1 | tail -20
+```
+Expected: all unit files green (including `test/unit/**`).
+```bash
+cat > .changeset/android-device-lock-port-hardening.md <<'EOF'
+---
+"rn-dev-agent": minor
+---
+
+Harden device-control conflicts: add an Android serial-scoped device lock (parity with iOS) that engages on a normal emulator, separate the Android runner's probed host port from its fixed device-listener port (`adb forward`), and let the iOS runner self-assign a free port when 22088 is taken.
+EOF
+git add scripts/cdp-bridge/src/runners/rn-android-runner-client.ts scripts/cdp-bridge/src/tools/device-session.ts scripts/cdp-bridge/test/unit scripts/cdp-bridge/dist .changeset/android-device-lock-port-hardening.md
+git commit -m "feat(rn-device): resolve adb serial + acquire Android device lock at session open"
+```
+
+---
+
+## Self-Review (Phase 1)
+
+**1. Spec coverage:** G4 (conflict hardening) → Tasks 1 (lock), 3 (Android ports), 4 (iOS port), 5 (serial + wiring). D-d (host/device split) → Task 3. D-e (Android lock) → Tasks 1+5; the **lock-before-side-effects ordering** is explicitly deferred to Phase 2 (marked `TODO(phase2)`) because `open` still uses agent-device here — recorded, not lost.
+
+**2. Placeholder scan:** `startAndroidRunner` / `startFastRunner` bodies show the changed lines with `// ...existing...` markers for the unchanged spawn/readiness scaffolding (the executor edits in place, not rewrites). All new code (builders, helpers, lock branch, tests) is complete.
+
+**3. Type consistency:** `DeviceLock({platform, deviceId})` ↔ `acquireDeviceLockForSession(platform, deviceId, appId)` ↔ tests. `AndroidRunnerState.{hostPort,devicePort}` ↔ builders ↔ migrated fixtures ↔ `stopAndroidRunner`. `findFreePort(preferred)`/`isPortFree(port)` ↔ callers (Tasks 3, 4). `resolveAndroidSerial(explicit?)`/`parseAdbDevicesSerials(stdout)` ↔ Task 5 wiring + test.
+
+**4. Review findings closed:** Android lock no-op → `resolveAndroidSerial` (Task 5); Task 5 dynamic-harness mismatch → source-regex test; Task 1 wiring line-12 breakage → fixed in Task 1 Step 4; Task 3 wrong/incomplete test list → corrected to the 3 real files; state-file migration → Task 3 Step 3; iOS TOCTOU → "pass 0" via the runner's existing self-assign; `findFreePort` flake/port-0 → race-tolerant tests + guard.

--- a/docs/superpowers/specs/2026-06-15-eradicate-agent-device-design.md
+++ b/docs/superpowers/specs/2026-06-15-eradicate-agent-device-design.md
@@ -1,0 +1,159 @@
+# Eradicate agent-device — In-tree Native Runners as Sole Backend — Design
+
+**Date:** 2026-06-15
+**Status:** Approved (design) — ready for implementation plan
+**Author:** brainstormed with the user (plugin maintainer)
+**Scope:** Remove the third-party `agent-device` CLI dependency entirely (iOS + Android), making the in-tree native runners (`rn-fast-runner` for iOS, `rn-android-runner` for Android) the only device-interaction backend; prove they beat agent-device on speed + reliability; harden port-lock / conflict handling on both platforms.
+
+## 1. Problem & Context
+
+The plugin's L2 device-interaction layer ("INTERACTION" in the three-layer contract) historically dispatched through the upstream Callstack **`agent-device`** CLI (package `agent-device`, bundle `com.callstack.agentdevice.runner`). Two migrations have already replaced most of it with in-tree native runners — but the dependency is not gone, and the state is **asymmetric**:
+
+- **iOS** — fully migrated (GH #105). `runAgentDevice()` short-circuits every interaction verb to `rn-fast-runner` (Swift/XCTest rig, `POST /command` HTTP server @ **22088**) via `runIOS()`. agent-device's iOS in-bridge path was deleted (~200 LOC).
+- **Android** — the in-tree **`rn-android-runner` already exists and is default-on** (`scripts/rn-android-runner/`, Kotlin/UIAutomator2, NanoHTTPD `POST /command` @ **22089**, TS client `rn-android-runner-client.ts` with `adb forward` + `/health`-gated readiness from GH #243). It routes the interaction verbs when `RN_ANDROID_RUNNER !== '0'`.
+
+What still depends on agent-device (the real surface area of this work):
+
+| Surviving usage | Location |
+|---|---|
+| Android **daemon-socket tier** (Tier 1) | `agent-device-wrapper.ts:779–788` |
+| Android **CLI tier** (Tier 3, `execFile('agent-device', …)`) | `agent-device-wrapper.ts:800–859` |
+| `RN_ANDROID_RUNNER=0` **restores** the agent-device tiers | `agent-device-wrapper.ts:760–768` |
+| Residual verb `device_list`/`devices` → `runAgentDevice(['devices'])` | `tools/device-list.ts:5,26` |
+| Residual verb session **`open`** → `runAgentDevice(['open', appId, …])` | `tools/device-session.ts:196–202` |
+| Residual verb session **`close`** → `runAgentDevice(['close'])` | `tools/device-session.ts:237,240,394` |
+| Auto-install script, invoked on **every SessionStart** | `scripts/ensure-agent-device.sh`, `hooks/detect-rn-project.sh:67` |
+| Legacy-runner eradication (kill `AgentDeviceRunner`, clean `~/.agent-device/*`, uninstall `com.callstack.agentdevice.*`) | `runners/ensure-single-runner.ts` |
+| Runner-leak sentinel detection | `tools/runner-leak-recovery.ts` (`isAgentDeviceRunnerSentinel`) |
+| ~**522** `agent-device` string references (code + tests + docs) | repo-wide |
+
+> Note: verbs **not** in `RN_FAST_RUNNER_COMMANDS` (`agent-device-wrapper.ts:308`) — notably `open`/`close`/`devices` — fall through to the agent-device path on **both** platforms today, because the iOS short-circuit only fires for that command set and only when `!opts.skipSession`. The deepest entanglement is therefore **session lifecycle**, not taps.
+
+The user's intent: get rid of agent-device **completely**, on both platforms, with the in-tree runners as the sole backend; benchmark to prove ours is faster + more reliable than the 3rd party; pay special attention to **port locks and conflicts**; verify it works seamlessly on iOS simulator and Android emulator.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- G1. No code path spawns, installs, or requires `agent-device` after this work. No silent fallback can ever resurrect it.
+- G2. The in-tree runners handle **all** device verbs, including the residual lifecycle verbs (`open`/`close`/`list`).
+- G3. Head-to-head benchmark data (latency + reliability) proving ours ≥ agent-device, captured **before** removal, committed as proof.
+- G4. Hardened port-lock / conflict handling: Android serial-scoped device lock (parity with iOS), collision-tolerant runner ports, robust `adb forward`/slot cleanup.
+- G5. Seamless `device_*` operation verified live on **both** iOS simulator and Android emulator; zero agent-device process spawns confirmed.
+
+**Non-goals**
+- N1. No change to the L1 CDP introspection layer or the L3 Maestro flow layer beyond what conflict-hardening requires.
+- N2. No new device capabilities (WebView DOM, real physical devices) — purely backend substitution + hardening.
+- N3. Not removing the *defensive cleanup* of a foreign/stale upstream `AgentDeviceRunner` (see D-b) — that protects users with old installs and is not a dependency.
+
+## 3. Resolved decisions (from brainstorming)
+
+1. **Removal depth → Hard cutover.** Delete the daemon + CLI tiers, the install script, and its SessionStart hook. In-tree runners become the only backend. `RN_ANDROID_RUNNER=0` no longer restores agent-device — it errors with guidance. No silent fallback.
+2. **Benchmark → Head-to-head on both simulators.** Keep agent-device installed temporarily; benchmark identical flows (ours vs agent-device) for per-op latency + reliability on iOS sim AND Android emulator; record a results table; then remove.
+3. **Conflict hardening → In scope.** Add an Android serial-scoped device lock, make runner ports collision-tolerant, harden adb forward/reverse + slot cleanup.
+
+## 4. End-state architecture
+
+One mechanism per platform; no third party; no silent fallback:
+
+```
+device_* / cdp_interact
+        │
+   runNative(platform, cmd)         ← renamed from runAgentDevice; zero agent-device knowledge
+        ├── ios     → runIOS()      → rn-fast-runner    POST /command @ probed port (default 22088)
+        └── android → runAndroid()  → rn-android-runner POST /command @ probed port (default 22089, via adb forward)
+
+device_list   → xcrun simctl list devices --json   /   adb devices -l        (native enumeration)
+session open  → resolve target device → acquire device-lock (DEVICE_BUSY if held)
+                → ensure runner ready → launch/foreground app (simctl launch / adb am start)
+                → write session state                                        (no agent-device 'open')
+session close → shutdown runner + release locks + clear session state        (no agent-device 'close')
+find          → pure-TS orchestrator (snapshot → match → tap)                [already native]
+```
+
+A "device session" becomes purely *our* concept: runner readiness + a per-project session-state file + the device lock. There is no external session daemon to open/close.
+
+## 5. Phased plan (stacked PRs, `#202`-style)
+
+### Phase 0 — Benchmark harness + head-to-head data (agent-device still installed)
+- Extend the existing harness at `rn-dev-agent-workspace/docs/proof/issue-3-benchmark/` (it already records `agent-device --version`).
+- **Metrics per op:** latency p50/p95 over N≈25 iterations; reliability (success rate over repeats); cold-start.
+- **Ops:** `snapshot`, `tap`, `find+tap`, `fill`/`type`, `swipe`/`scroll`, `screenshot`.
+- **Android = true A/B in-bridge:** same flows with `RN_ANDROID_RUNNER` unset (ours) vs `=0` (agent-device daemon/CLI).
+- **iOS = asymmetric (see §6):** agent-device's in-bridge iOS path was already deleted (#105), so compare our `runIOS` against **agent-device standalone CLI** for identical ops; if its iOS CLI is broken on the current Xcode/runtime, fall back to the recorded `v0.21.1-baseline` numbers and state so explicitly.
+- **Output:** committed results table under `rn-dev-agent-workspace/docs/proof/` (proof artifacts live in the sibling workspace). **Gate:** removal proceeds only once this exists and shows ours ≥ agent-device.
+
+### Phase 1 — Port/conflict hardening (independently valuable; de-risks the cutover)
+- **Android device lock**: add `android` support to `lifecycle/device-lock.ts`, keyed on adb serial — `${TMPDIR}/rn-dev-agent-device-<uid>-android-<serial>.lock` — mirroring the iOS UDID lock (atomic `wx`, PID-liveness + 30s heartbeat self-heal, fail-open on fs error). Acquired at session open.
+- **Collision-tolerant ports** (probe-on-collision; default to current ports when free → zero behavior change for the single-sim case):
+  - **iOS** — a single host-loopback port (`RN_FAST_RUNNER_PORT`, default 22088). The XCUITest runner binds it on the Mac's loopback, so two simulators would collide; probe a free port and pass it to the runner.
+  - **Android** — **two distinct ports**, never conflated: a fixed **`devicePort`** (the NanoHTTPD listener inside the emulator via `RN_ANDROID_RUNNER_PORT`, default 22089 — emulator-namespaced, so it needn't move) and a probed **`hostPort`** (what the TS client connects to on `127.0.0.1`). Bridge them with `adb forward tcp:<hostPort> tcp:<devicePort>`. The host port is the globally-contended one (two bridges share one host `adb`), so it is what gets probed; health checks and `adb forward --remove` use **`hostPort`**.
+  - Persist `hostPort`/`devicePort` in the runner state file; reconnects reuse them.
+- **adb cleanup + slot handoff**: ensure `adb forward --remove` always runs on stop; verify `release-android-slot.ts` UIAutomator single-slot handoff is robust under the new lock.
+
+### Phase 2 — Hard cutover (the removal)
+- Delete the Android **daemon-socket** + **CLI** tiers from `agent-device-wrapper.ts`; rename the export `runAgentDevice` → `runNative` with a thin temporary re-export so the ~20 importers don't all churn at once (D-a).
+- Replace residual verbs:
+  - `device_list`/`devices` → `xcrun simctl list devices --json` (iOS) + `adb devices -l` (Android).
+  - session `open` → resolve target device → **acquire device lock first** (`DEVICE_BUSY` if held) → ensure runner ready (`ensureFastRunner` / `startAndroidRunner`) → launch/foreground app via simctl/adb → write session state.
+  - session `close` → shutdown runner + release locks + clear session state.
+- `RN_ANDROID_RUNNER=0` (and any iOS "disable" intent) → **error with actionable guidance** (D-c) instead of restoring agent-device.
+
+### Phase 3 — Cleanup + docs
+- Remove `scripts/ensure-agent-device.sh` and its `hooks/detect-rn-project.sh:67` SessionStart call.
+- Reconcile the ~522 references: dead code/tests, `/setup` + `/doctor` rows, `CLAUDE.md`, `docs-site`, troubleshooting notes. Update the prerequisites ("agent-device required for Android") and the architecture tables.
+- **Retain** foreign-runner cleanup in `ensure-single-runner.ts` (D-b) — but reframe it from "kill our legacy dependency" to "defend against a foreign/stale upstream runner stealing focus."
+
+### Phase 4 — Final dual-platform verification + ours-only re-benchmark
+- Full `device_*` smoke on iOS sim **and** Android emulator until seamless.
+- Assert **zero** agent-device process spawns during a full session (grep `ps`/no `~/.agent-device` writes).
+- Re-run the benchmark (ours-only) to confirm targets still hold post-removal.
+
+## 6. Benchmark methodology (the asymmetry, explicitly)
+
+The comparison is asymmetric *by construction* and the proof must say so honestly:
+
+- **Android** — clean in-bridge A/B: a single env flip (`RN_ANDROID_RUNNER`) routes the same MCP `device_*` calls through ours vs agent-device's daemon/CLI. Same device, same flows, same harness → directly comparable.
+- **iOS** — agent-device's in-bridge path is already gone (#105), so we cannot A/B inside the bridge. Two honest options, in order of preference:
+  1. Drive `agent-device` **standalone CLI** for the same ops against the same booted simulator, vs our `runIOS`. Fresh, comparable numbers.
+  2. If agent-device's iOS CLI no longer works on the current Xcode/runtime, compare ours against the **recorded baseline** (`v0.21.1-baseline/PROOF.md`, e.g. `device_snapshot` open ≈533 ms via agent-device) and label it a historical baseline, not a same-day A/B.
+
+Acceptance: ours ≤ agent-device on median latency for the common verbs and ≥ on reliability, on both platforms (with the iOS caveat documented).
+
+## 7. Key technical decisions
+
+- **D-a (dispatcher rename):** `runAgentDevice` → `runNative(cliArgs, {platform})`, no agent-device branches. Keep a one-line `export const runAgentDevice = runNative` shim during Phase 2 to avoid a 20-file churn in a single commit; drop the shim in Phase 3.
+- **D-b (retain foreign-runner defense):** Keep killing stale `com.callstack.agentdevice.*` processes/apps and cleaning `~/.agent-device/*` in `ensure-single-runner.ts`, and keep `isAgentDeviceRunnerSentinel`. Rationale: this removes a *dependency*, not the *defense* against a third party's stale runner capturing simulator focus. It must never re-spawn agent-device — only clean it up.
+- **D-c (disable = error, never fallback):** Setting `RN_ANDROID_RUNNER=0` (or any iOS equivalent) makes `device_*` return an actionable error ("in-tree runner is the only backend; the agent-device fallback was removed in <version>"), never a silent degrade. Symmetric iOS/Android behavior.
+- **D-d (port strategy):** Stable-by-default, probe-on-collision. iOS uses a single host-loopback port. **Android separates a fixed device-listener port (`RN_ANDROID_RUNNER_PORT`, emulator-namespaced) from a probed host port** used for `adb forward`, `127.0.0.1` health checks, and `adb forward --remove` — never conflate the two. The (project, device) pair gets deterministic ports unless taken; only then probe upward. Persisted in the runner state file (Android stores both `hostPort` and `devicePort`) so reconnects are stable.
+- **D-e (Android device lock + lock-before-side-effects):** Serial-scoped, same shape/semantics as the iOS UDID lock, so two different projects' bridges can't drive one emulator (`DEVICE_BUSY`), with PID + heartbeat self-heal (no orphaned-lock regression). **Critically, session open acquires the device lock immediately after resolving the target device and *before* starting any runner, launching/foregrounding the app, or writing session state** — otherwise a competing bridge could start a runner or steal focus before the conflict is detected. This ordering applies to iOS too.
+
+## 8. Testing & verification
+
+- **TDD throughout:** failing test → minimal impl → pass → signed per-task commit; a changeset per change; `dist/` rebuilt + staged.
+- **Unit baseline:** the full `scripts/cdp-bridge` unit suite (≈2087 tests as of #211) stays green and grows — new tests for: the Android device lock, port-probe/collision, `runNative` (no agent-device branch), residual-verb native replacements, and `RN_ANDROID_RUNNER=0` error semantics.
+- **Plan review BEFORE code:** `/brainstorm gemini,codex <plan + key files>`; apply findings; amend the plan commit.
+- **Multi-review AFTER code:** `/multi-review` on the diff per phase.
+- **Device verification:** the acceptance bar — `device_*` smoke on iOS sim AND Android emulator, plus the zero-agent-device-spawn assertion.
+
+## 9. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Hard cutover removes the safety net on the plugin's core capability | Phase 0 proof + Phase 1 hardening land first; device-verify between every phase; phased stacked PRs keep blast radius small |
+| iOS head-to-head limited (agent-device iOS path already deleted) | Standalone-CLI comparison; cite recorded baseline if broken — stated honestly in the proof |
+| Port probing regresses the existing single-sim flow | Default to current ports when free; probe only on collision; unit-test both branches |
+| A live agent-device code path slips through 522 refs | grep-gate (a CI-style check that no `execFile('agent-device'` / install remains); Phase 4 asserts zero spawns at runtime |
+| Session lifecycle (`open`/`close`) is the riskiest edit | Isolated to Phase 2, behind the Phase 1 lock/port safety net; covered by new unit tests + device smoke |
+| Android UIAutomator single-slot contention with Maestro L3 | Reuse `release-android-slot.ts` handoff; verify under the new serial lock |
+
+## 10. References
+
+- **devicelab-dev** org (user-suggested): `maestro-runner` (Go flow engine this plugin already prefers) and `maestro-ios-device` (Obj-C real-device driver) — reference patterns for native iOS/Android driving and the "fast, no-JVM" framing; `maestro-complete-reports` for results formatting.
+- Prior art in-repo: `2026-05-15-rn-device-ios-first-mvp-design.md` (iOS #105 cutover), `2026-05-16-rn-android-runner-mvp-plan.md` (Android runner build), `2026-06-09-237-android-instrumentation-slot-handoff-design.md`, `2026-06-09-gh-243-244-android-post-flow-lifecycle-design.md`.
+- Benchmark harness: `rn-dev-agent-workspace/docs/proof/issue-3-benchmark/`, `…/v0.21.1-baseline/PROOF.md`.
+
+## 11. Out of scope / follow-ups
+
+- WebView DOM inspection from the Android runner.
+- Real physical-device support.
+- Any rename of the `device_*` MCP tool surface (kept stable for users).

--- a/scripts/cdp-bridge/dist/lifecycle/device-lock.js
+++ b/scripts/cdp-bridge/dist/lifecycle/device-lock.js
@@ -33,7 +33,8 @@ export class DeviceLock {
     lockPath;
     acquired = false;
     pid;
-    udid;
+    platform;
+    deviceId;
     projectRoot;
     appId;
     version;
@@ -42,7 +43,8 @@ export class DeviceLock {
     staleMs;
     tmpDir;
     constructor(opts) {
-        this.udid = opts.udid;
+        this.platform = opts.platform;
+        this.deviceId = opts.deviceId;
         this.projectRoot = opts.projectRoot ?? (process.env.CLAUDE_USER_CWD ?? process.cwd());
         const uid = opts.uid ?? userInfo().uid;
         this.tmpDir = opts.tmpDir ?? tmpdir();
@@ -52,7 +54,7 @@ export class DeviceLock {
         this.clock = opts.clock ?? Date.now;
         this.processAlive = opts.processAlive ?? defaultProcessAlive;
         this.staleMs = opts.staleMs ?? DEFAULT_STALE_MS;
-        this.lockPath = join(this.tmpDir, `rn-dev-agent-device-${uid}-ios-${this.udid}.lock`);
+        this.lockPath = join(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
     }
     acquire() {
         try {
@@ -134,8 +136,8 @@ export class DeviceLock {
             const body = {
                 pid: this.pid,
                 projectRoot: this.projectRoot,
-                platform: 'ios',
-                udid: this.udid,
+                platform: this.platform,
+                deviceId: this.deviceId,
                 appId: this.appId,
                 startedAt: now,
                 lastHeartbeat: now,
@@ -153,8 +155,7 @@ export class DeviceLock {
             const parsed = JSON.parse(readFileSync(this.lockPath, 'utf8'));
             if (!isValidBody(parsed))
                 return null;
-            // A body for a different UDID on our path is foreign/corrupt → reclaimable.
-            if (parsed.udid !== this.udid)
+            if (parsed.deviceId !== this.deviceId || parsed.platform !== this.platform)
                 return null;
             return parsed;
         }
@@ -171,9 +172,9 @@ function isValidBody(o) {
         return false;
     const b = o;
     return (typeof b.pid === 'number' && Number.isFinite(b.pid) &&
-        typeof b.udid === 'string' && b.udid.length > 0 &&
+        (b.platform === 'ios' || b.platform === 'android') &&
+        typeof b.deviceId === 'string' && b.deviceId.length > 0 &&
         typeof b.projectRoot === 'string' &&
-        b.platform === 'ios' &&
         typeof b.startedAt === 'number' && Number.isFinite(b.startedAt) &&
         typeof b.lastHeartbeat === 'number' && Number.isFinite(b.lastHeartbeat));
 }

--- a/scripts/cdp-bridge/dist/runners/free-port.js
+++ b/scripts/cdp-bridge/dist/runners/free-port.js
@@ -1,0 +1,39 @@
+import { createServer } from 'node:net';
+export function isPortFree(port) {
+    return new Promise((resolve) => {
+        const srv = createServer();
+        srv.once('error', () => resolve(false));
+        srv.listen({ port, host: '127.0.0.1' }, () => srv.close(() => resolve(true)));
+    });
+}
+/**
+ * Resolve a bindable TCP port on 127.0.0.1: `preferred` if free, else an
+ * OS-assigned ephemeral free port. Rejects on unexpected bind errors or if the
+ * OS hands back an unusable port 0. Note: there is an inherent TOCTOU window
+ * between this probe and the caller's real bind — callers that bind a SPECIFIC
+ * number (e.g. adb forward) must handle a late EADDRINUSE; the iOS runner avoids
+ * the window entirely by self-assigning (port 0).
+ */
+export function findFreePort(preferred) {
+    return new Promise((resolve, reject) => {
+        const tryListen = (port, fallbackToAny) => {
+            const srv = createServer();
+            srv.once('error', (err) => {
+                if (fallbackToAny && err.code === 'EADDRINUSE')
+                    tryListen(0, false);
+                else
+                    reject(err);
+            });
+            srv.listen({ port, host: '127.0.0.1' }, () => {
+                const addr = srv.address();
+                const chosen = typeof addr === 'object' && addr ? addr.port : 0;
+                if (!chosen) {
+                    srv.close(() => reject(new Error('findFreePort: OS returned port 0')));
+                    return;
+                }
+                srv.close(() => resolve(chosen));
+            });
+        };
+        tryListen(preferred, true);
+    });
+}

--- a/scripts/cdp-bridge/dist/runners/rn-android-runner-client.js
+++ b/scripts/cdp-bridge/dist/runners/rn-android-runner-client.js
@@ -48,8 +48,9 @@ export function _setAndroidRunnerStateForTest(state) {
 export function parseAdbDevicesSerials(stdout) {
     return stdout.split('\n').slice(1)
         .map((l) => l.trim())
-        .filter((l) => l.endsWith('\tdevice'))
-        .map((l) => l.split('\t')[0]);
+        .map((l) => /^(\S+)\s+device\b/.exec(l))
+        .filter((m) => m !== null)
+        .map((m) => m[1]);
 }
 export async function resolveAndroidSerial(explicit) {
     if (explicit)
@@ -209,12 +210,17 @@ export async function startAndroidRunner(deviceId, bundleId, devicePort = DEFAUL
         });
         child.on('exit', (code) => {
             if (runnerProcess === child) {
+                const exitState = runnerState;
                 runnerProcess = null;
                 runnerState = null;
                 try {
                     unlinkSync(STATE_FILE);
                 }
                 catch { /* already removed */ }
+                if (typeof exitState?.hostPort === 'number') {
+                    execFileAsync('adb', buildAdbForwardRemoveArgs(exitState.deviceId, exitState.hostPort))
+                        .catch(() => { });
+                }
             }
             if (!resolved) {
                 resolved = true;
@@ -245,12 +251,13 @@ export async function stopAndroidRunner(deviceId) {
         unlinkSync(STATE_FILE);
     }
     catch { /* already removed */ }
-    const hostPort = stoppedState?.hostPort ?? DEFAULT_PORT;
-    const resolvedDeviceId = deviceId ?? stoppedState?.deviceId;
-    try {
-        await execFileAsync('adb', buildAdbForwardRemoveArgs(resolvedDeviceId, hostPort));
+    if (typeof stoppedState?.hostPort === 'number') {
+        const resolvedDeviceId = deviceId ?? stoppedState.deviceId;
+        try {
+            await execFileAsync('adb', buildAdbForwardRemoveArgs(resolvedDeviceId, stoppedState.hostPort));
+        }
+        catch { /* non-fatal */ }
     }
-    catch { /* non-fatal */ }
 }
 async function postCommand(body) {
     const state = runnerState;

--- a/scripts/cdp-bridge/dist/runners/rn-android-runner-client.js
+++ b/scripts/cdp-bridge/dist/runners/rn-android-runner-client.js
@@ -45,6 +45,26 @@ export function _setFetchForTest(fn) {
 export function _setAndroidRunnerStateForTest(state) {
     runnerState = state;
 }
+export function parseAdbDevicesSerials(stdout) {
+    return stdout.split('\n').slice(1)
+        .map((l) => l.trim())
+        .filter((l) => l.endsWith('\tdevice'))
+        .map((l) => l.split('\t')[0]);
+}
+export async function resolveAndroidSerial(explicit) {
+    if (explicit)
+        return explicit;
+    if (process.env.ANDROID_SERIAL)
+        return process.env.ANDROID_SERIAL;
+    try {
+        const { stdout } = await execFileAsync('adb', ['devices']);
+        const serials = parseAdbDevicesSerials(stdout);
+        return serials.length === 1 ? serials[0] : undefined;
+    }
+    catch {
+        return undefined;
+    }
+}
 function adbSerialArgs(deviceId) {
     if (deviceId)
         return ['-s', deviceId];

--- a/scripts/cdp-bridge/dist/runners/rn-android-runner-client.js
+++ b/scripts/cdp-bridge/dist/runners/rn-android-runner-client.js
@@ -7,6 +7,7 @@ import { promisify } from 'node:util';
 import { writeFileSync, unlinkSync, readFileSync, existsSync } from 'node:fs';
 import { okResult, failResult } from '../utils.js';
 import { updateRefMapFromFlat, getCachedMetadata } from '../fast-runner-ref-map.js';
+import { findFreePort } from './free-port.js';
 const execFileAsync = promisify(execFile);
 const DEFAULT_PORT = 22089;
 const READY_TIMEOUT_MS = 30_000;
@@ -21,12 +22,17 @@ let fetchImpl = globalThis.fetch;
 try {
     if (existsSync(STATE_FILE)) {
         const raw = JSON.parse(readFileSync(STATE_FILE, 'utf-8'));
-        try {
-            process.kill(raw.pid, 0);
-            runnerState = raw;
+        if (typeof raw.hostPort !== 'number' || typeof raw.devicePort !== 'number') {
+            unlinkSync(STATE_FILE); // pre-split state shape → ignore + clear
         }
-        catch {
-            unlinkSync(STATE_FILE);
+        else {
+            try {
+                process.kill(raw.pid, 0);
+                runnerState = raw;
+            }
+            catch {
+                unlinkSync(STATE_FILE);
+            }
         }
     }
 }
@@ -45,6 +51,15 @@ function adbSerialArgs(deviceId) {
     if (process.env.ANDROID_SERIAL)
         return ['-s', process.env.ANDROID_SERIAL];
     return [];
+}
+export function buildAdbForwardArgs(deviceId, hostPort, devicePort) {
+    return [...adbSerialArgs(deviceId), 'forward', `tcp:${hostPort}`, `tcp:${devicePort}`];
+}
+export function buildAdbForwardRemoveArgs(deviceId, hostPort) {
+    return [...adbSerialArgs(deviceId), 'forward', '--remove', `tcp:${hostPort}`];
+}
+export function buildInstrumentPortArgs(devicePort) {
+    return ['-e', 'RN_ANDROID_RUNNER_PORT', String(devicePort)];
 }
 export function isAndroidRunnerAvailable() {
     if (!runnerState)
@@ -110,23 +125,28 @@ export async function waitForAndroidRunnerHealth(port, opts = {}) {
     }
     return false;
 }
-export async function startAndroidRunner(deviceId, bundleId, port = DEFAULT_PORT) {
+export async function startAndroidRunner(deviceId, bundleId, devicePort = DEFAULT_PORT) {
     if (isAndroidRunnerAvailable() && shouldReuseAndroidRunner(runnerState, deviceId))
         return runnerState;
-    const serial = adbSerialArgs(deviceId);
-    await execFileAsync('adb', [...serial, 'forward', `tcp:${port}`, `tcp:${port}`]);
+    let hostPort = await findFreePort(devicePort);
+    try {
+        await execFileAsync('adb', buildAdbForwardArgs(deviceId, hostPort, devicePort));
+    }
+    catch {
+        // host port raced between probe and forward → re-probe once with any free port
+        hostPort = await findFreePort(0);
+        await execFileAsync('adb', buildAdbForwardArgs(deviceId, hostPort, devicePort));
+    }
     return new Promise((resolve, reject) => {
         let resolved = false;
         const child = spawn('adb', [
-            ...serial,
+            ...adbSerialArgs(deviceId),
             'shell',
             'am',
             'instrument',
             '-w',
             '-r',
-            '-e',
-            'RN_ANDROID_RUNNER_PORT',
-            String(port),
+            ...buildInstrumentPortArgs(devicePort),
             '-e',
             'class',
             MAIN_LOOP_CLASS,
@@ -147,7 +167,8 @@ export async function startAndroidRunner(deviceId, bundleId, port = DEFAULT_PORT
                 return;
             resolved = true;
             const state = {
-                port,
+                hostPort,
+                devicePort,
                 pid: child.pid,
                 ...(deviceId ? { deviceId } : {}),
                 ...(bundleId ? { bundleId } : {}),
@@ -182,7 +203,7 @@ export async function startAndroidRunner(deviceId, bundleId, port = DEFAULT_PORT
         });
         // GH#243: readiness is the runner's own /health, not the (stale-prone) logcat
         // ring buffer. /health is true only once the ServerSocket is actually accepting.
-        void waitForAndroidRunnerHealth(port).then((healthy) => {
+        void waitForAndroidRunnerHealth(hostPort).then((healthy) => {
             if (resolved)
                 return;
             if (healthy) {
@@ -191,12 +212,12 @@ export async function startAndroidRunner(deviceId, bundleId, port = DEFAULT_PORT
             }
             resolved = true;
             child.kill('SIGTERM');
-            reject(new Error(`Android runner did not become ready within ${READY_TIMEOUT_MS / 1000}s (no /health on port ${port})${diag ? `\n${diag.trim()}` : ''}`));
+            reject(new Error(`Android runner did not become ready within ${READY_TIMEOUT_MS / 1000}s (no /health on port ${hostPort})${diag ? `\n${diag.trim()}` : ''}`));
         });
     });
 }
 export async function stopAndroidRunner(deviceId) {
-    const serial = adbSerialArgs(deviceId ?? runnerState?.deviceId);
+    const stoppedState = runnerState;
     runnerProcess?.kill('SIGTERM');
     runnerProcess = null;
     runnerState = null;
@@ -204,8 +225,10 @@ export async function stopAndroidRunner(deviceId) {
         unlinkSync(STATE_FILE);
     }
     catch { /* already removed */ }
+    const hostPort = stoppedState?.hostPort ?? DEFAULT_PORT;
+    const resolvedDeviceId = deviceId ?? stoppedState?.deviceId;
     try {
-        await execFileAsync('adb', [...serial, 'forward', '--remove', `tcp:${DEFAULT_PORT}`]);
+        await execFileAsync('adb', buildAdbForwardRemoveArgs(resolvedDeviceId, hostPort));
     }
     catch { /* non-fatal */ }
 }
@@ -221,7 +244,7 @@ async function postCommand(body) {
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     let resp;
     try {
-        resp = await fetchImpl(`http://127.0.0.1:${state.port}/command`, {
+        resp = await fetchImpl(`http://127.0.0.1:${state.hostPort}/command`, {
             method: 'POST',
             headers: { 'content-type': 'application/json' },
             body: JSON.stringify(body),

--- a/scripts/cdp-bridge/dist/runners/rn-fast-runner-client.js
+++ b/scripts/cdp-bridge/dist/runners/rn-fast-runner-client.js
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { writeFileSync, unlinkSync, readFileSync, existsSync, readdirSync } from 'node:fs';
 import { okResult, failResult } from '../utils.js';
 import { updateRefMapFromFlat, getCachedMetadata } from '../fast-runner-ref-map.js';
+import { isPortFree } from './free-port.js';
 const DEFAULT_PORT = 22088;
 const READY_TIMEOUT_MS = 30_000;
 // A cold `xcodebuild test` compiles the runner project before launching it; on a
@@ -145,9 +146,10 @@ export function derivedDataPathForRunner() {
 export function shouldReuseRunner(state, deviceId) {
     return state !== null && state.deviceId === deviceId;
 }
-export function startFastRunner(deviceId, bundleId, port = DEFAULT_PORT) {
+export async function startFastRunner(deviceId, bundleId, port) {
     if (shouldReuseRunner(runnerState, deviceId))
-        return Promise.resolve(runnerState);
+        return runnerState;
+    const desired = port ?? (await isPortFree(DEFAULT_PORT) ? DEFAULT_PORT : 0);
     return new Promise((resolve, reject) => {
         const projectPath = join(FAST_RUNNER_PROJECT, 'RnFastRunner', 'RnFastRunner.xcodeproj');
         if (!existsSync(projectPath)) {
@@ -167,7 +169,7 @@ export function startFastRunner(deviceId, bundleId, port = DEFAULT_PORT) {
         const child = spawn('xcodebuild', args, {
             env: {
                 ...process.env,
-                RN_FAST_RUNNER_PORT: String(port),
+                RN_FAST_RUNNER_PORT: String(desired),
             },
             stdio: ['ignore', 'pipe', 'pipe'],
         });

--- a/scripts/cdp-bridge/dist/tools/device-session-close.js
+++ b/scripts/cdp-bridge/dist/tools/device-session-close.js
@@ -36,12 +36,14 @@ export async function closeDeviceSession(deps) {
     if (!result.isError) {
         deps.clearActiveSession();
         deps.stopFastRunner();
+        await deps.stopAndroidRunner();
         deps.releaseDeviceLock();
         return result;
     }
     if (isBenignSessionGoneError(result)) {
         deps.clearActiveSession();
         deps.stopFastRunner();
+        await deps.stopAndroidRunner();
         deps.releaseDeviceLock();
         return okResult({
             closed: true,

--- a/scripts/cdp-bridge/dist/tools/device-session.js
+++ b/scripts/cdp-bridge/dist/tools/device-session.js
@@ -189,7 +189,7 @@ export function createDeviceSnapshotHandler() {
                         if (lockPlatform === 'ios')
                             stopFastRunner();
                         else
-                            await stopAndroidRunner();
+                            await stopAndroidRunner(lockDeviceId);
                         return failResult(deviceBusyMessage(lockDeviceId, lockResult.holder), { code: 'DEVICE_BUSY', holder: lockResult.holder });
                     }
                     if (lockResult.degraded) {
@@ -302,6 +302,7 @@ export function createDeviceSnapshotHandler() {
                 closeUnderlyingSession: () => runAgentDevice(['close']),
                 clearActiveSession,
                 stopFastRunner,
+                stopAndroidRunner,
                 releaseDeviceLock: releaseDeviceLockForSession,
             });
         }

--- a/scripts/cdp-bridge/dist/tools/device-session.js
+++ b/scripts/cdp-bridge/dist/tools/device-session.js
@@ -20,11 +20,11 @@ const execFile = promisify(execFileCb);
 const HEARTBEAT_MS = 30_000;
 let activeDeviceLock = null;
 let heartbeatTimer = null;
-function acquireDeviceLockForSession(udid, appId) {
+function acquireDeviceLockForSession(platform, deviceId, appId) {
     // Single-owner: drop any prior lock + heartbeat first (release is null-safe)
     // so a re-open can't leak a timer or orphan a lock. (#202 review — blocker.)
     releaseDeviceLockForSession();
-    const lock = new DeviceLock({ udid, appId });
+    const lock = new DeviceLock({ platform, deviceId, appId });
     const result = lock.acquire();
     // Only manage a heartbeat for a REAL exclusive lock — a degraded (fs-error)
     // acquire is unmanaged, so there is nothing to refresh or release.
@@ -170,7 +170,7 @@ export function createDeviceSnapshotHandler() {
                 // another project's bridge owns the sim — tear our just-opened session
                 // back down and refuse, rather than fight for foreground.
                 if (platform === 'ios' && deviceId) {
-                    const lockResult = acquireDeviceLockForSession(deviceId, appId);
+                    const lockResult = acquireDeviceLockForSession('ios', deviceId, appId);
                     if (lockResult.status === 'conflict') {
                         // Close FIRST — runAgentDevice derives `--session` from the active
                         // session, so clearing before closing would close the wrong (or no)

--- a/scripts/cdp-bridge/dist/tools/device-session.js
+++ b/scripts/cdp-bridge/dist/tools/device-session.js
@@ -2,6 +2,7 @@ import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
 import { runAgentDevice, setActiveSession, clearActiveSession, getActiveSession, ensureFastRunner, cacheSnapshot, getAdbSerial, } from '../agent-device-wrapper.js';
 import { stopFastRunner } from '../runners/rn-fast-runner-client.js';
+import { stopAndroidRunner, resolveAndroidSerial } from '../runners/rn-android-runner-client.js';
 import { markCdpStale } from '../cdp/recovery.js';
 import { detectAndroidExternalRunner, detectIosExternalRunner, foreignRunnerNotice } from '../runners/external-runner-detect.js';
 import { ensureSingleRunner } from '../runners/ensure-single-runner.js';
@@ -47,7 +48,8 @@ export function releaseDeviceLockForSession() {
     }
 }
 export function deviceBusyMessage(deviceId, holder) {
-    return (`Simulator ${deviceId} is already owned by another rn-dev-agent bridge ` +
+    const label = holder.platform === 'android' ? 'Emulator/device' : 'Simulator';
+    return (`${label} ${deviceId} is already owned by another rn-dev-agent bridge ` +
         `(PID ${holder.pid}, project ${holder.projectRoot}` +
         `${holder.appId ? `, app ${holder.appId}` : ''}). ` +
         `Close that session or target a different simulator.`);
@@ -165,24 +167,33 @@ export function createDeviceSnapshotHandler() {
                     openedAt: new Date().toISOString(),
                     appId,
                 });
-                // GH#202 Phase 1.5: claim exclusive ownership of THIS simulator across
-                // bridge processes. The UDID is only known now (post-open). On conflict
-                // another project's bridge owns the sim — tear our just-opened session
-                // back down and refuse, rather than fight for foreground.
-                if (platform === 'ios' && deviceId) {
-                    const lockResult = acquireDeviceLockForSession('ios', deviceId, appId);
+                // GH#202 Phase 1.5 (iOS) + Task 5 (Android): claim exclusive ownership
+                // of THIS device across bridge processes. On conflict another project's
+                // bridge owns it — tear our just-opened session back down and refuse.
+                // Android: deviceId is filtered through UDID_RE and is always undefined
+                // for adb serials like "emulator-5554", so we resolve the serial
+                // independently via `adb devices` rather than keying on deviceId.
+                const lockPlatform = platform === 'android' ? 'android' : 'ios';
+                const lockDeviceId = lockPlatform === 'android'
+                    ? await resolveAndroidSerial(deviceId)
+                    : deviceId;
+                if (lockDeviceId) {
+                    // TODO(phase2): acquire the lock BEFORE the open side-effect once 'open' is resolved via simctl/adb instead of agent-device — spec D-e.
+                    const lockResult = acquireDeviceLockForSession(lockPlatform, lockDeviceId, appId);
                     if (lockResult.status === 'conflict') {
                         // Close FIRST — runAgentDevice derives `--session` from the active
                         // session, so clearing before closing would close the wrong (or no)
                         // session and leak the one we just opened (#202 review — blocker).
                         await runAgentDevice(['close']).catch(() => { });
                         clearActiveSession();
-                        stopFastRunner();
-                        const h = lockResult.holder;
-                        return failResult(deviceBusyMessage(deviceId, h), { code: 'DEVICE_BUSY', holder: h });
+                        if (lockPlatform === 'ios')
+                            stopFastRunner();
+                        else
+                            await stopAndroidRunner();
+                        return failResult(deviceBusyMessage(lockDeviceId, lockResult.holder), { code: 'DEVICE_BUSY', holder: lockResult.holder });
                     }
                     if (lockResult.degraded) {
-                        logger.warn('rn-device', `Device-ownership lock unavailable (fs error) for ${deviceId} — ` +
+                        logger.warn('rn-device', `Device-ownership lock unavailable (fs error) for ${lockDeviceId} — ` +
                             `cross-bridge contention protection is off this session.`);
                     }
                 }

--- a/scripts/cdp-bridge/src/lifecycle/device-lock.ts
+++ b/scripts/cdp-bridge/src/lifecycle/device-lock.ts
@@ -10,8 +10,8 @@ const DEFAULT_STALE_MS = 90_000;
 export interface DeviceLockBody {
   pid: number;
   projectRoot: string;
-  platform: 'ios';
-  udid: string;
+  platform: 'ios' | 'android';
+  deviceId: string;  // iOS UDID or Android adb serial
   appId?: string;
   startedAt: number;
   lastHeartbeat: number;
@@ -32,7 +32,8 @@ export interface DeviceLockConflict { status: 'conflict'; lockPath: string; hold
 export type DeviceLockResult = DeviceLockAcquired | DeviceLockConflict;
 
 export interface DeviceLockOptions {
-  udid: string;
+  platform: 'ios' | 'android';
+  deviceId: string;
   projectRoot?: string;
   appId?: string;
   pid?: number;
@@ -75,7 +76,8 @@ export class DeviceLock {
   readonly lockPath: string;
   private acquired = false;
   private readonly pid: number;
-  private readonly udid: string;
+  private readonly platform: 'ios' | 'android';
+  private readonly deviceId: string;
   private readonly projectRoot: string;
   private readonly appId?: string;
   private readonly version?: string;
@@ -85,7 +87,8 @@ export class DeviceLock {
   private readonly tmpDir: string;
 
   constructor(opts: DeviceLockOptions) {
-    this.udid = opts.udid;
+    this.platform = opts.platform;
+    this.deviceId = opts.deviceId;
     this.projectRoot = opts.projectRoot ?? (process.env.CLAUDE_USER_CWD ?? process.cwd());
     const uid = opts.uid ?? userInfo().uid;
     this.tmpDir = opts.tmpDir ?? tmpdir();
@@ -95,7 +98,7 @@ export class DeviceLock {
     this.clock = opts.clock ?? Date.now;
     this.processAlive = opts.processAlive ?? defaultProcessAlive;
     this.staleMs = opts.staleMs ?? DEFAULT_STALE_MS;
-    this.lockPath = join(this.tmpDir, `rn-dev-agent-device-${uid}-ios-${this.udid}.lock`);
+    this.lockPath = join(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
   }
 
   acquire(): DeviceLockResult {
@@ -169,8 +172,8 @@ export class DeviceLock {
       const body: DeviceLockBody = {
         pid: this.pid,
         projectRoot: this.projectRoot,
-        platform: 'ios',
-        udid: this.udid,
+        platform: this.platform,
+        deviceId: this.deviceId,
         appId: this.appId,
         startedAt: now,
         lastHeartbeat: now,
@@ -187,8 +190,7 @@ export class DeviceLock {
     try {
       const parsed = JSON.parse(readFileSync(this.lockPath, 'utf8')) as unknown;
       if (!isValidBody(parsed)) return null;
-      // A body for a different UDID on our path is foreign/corrupt → reclaimable.
-      if (parsed.udid !== this.udid) return null;
+      if (parsed.deviceId !== this.deviceId || parsed.platform !== this.platform) return null;
       return parsed;
     } catch {
       return null;
@@ -205,9 +207,9 @@ function isValidBody(o: unknown): o is DeviceLockBody {
   const b = o as Record<string, unknown>;
   return (
     typeof b.pid === 'number' && Number.isFinite(b.pid) &&
-    typeof b.udid === 'string' && b.udid.length > 0 &&
+    (b.platform === 'ios' || b.platform === 'android') &&
+    typeof b.deviceId === 'string' && b.deviceId.length > 0 &&
     typeof b.projectRoot === 'string' &&
-    b.platform === 'ios' &&
     typeof b.startedAt === 'number' && Number.isFinite(b.startedAt) &&
     typeof b.lastHeartbeat === 'number' && Number.isFinite(b.lastHeartbeat)
   );

--- a/scripts/cdp-bridge/src/runners/free-port.ts
+++ b/scripts/cdp-bridge/src/runners/free-port.ts
@@ -1,0 +1,36 @@
+import { createServer } from 'node:net';
+
+export function isPortFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const srv = createServer();
+    srv.once('error', () => resolve(false));
+    srv.listen({ port, host: '127.0.0.1' }, () => srv.close(() => resolve(true)));
+  });
+}
+
+/**
+ * Resolve a bindable TCP port on 127.0.0.1: `preferred` if free, else an
+ * OS-assigned ephemeral free port. Rejects on unexpected bind errors or if the
+ * OS hands back an unusable port 0. Note: there is an inherent TOCTOU window
+ * between this probe and the caller's real bind — callers that bind a SPECIFIC
+ * number (e.g. adb forward) must handle a late EADDRINUSE; the iOS runner avoids
+ * the window entirely by self-assigning (port 0).
+ */
+export function findFreePort(preferred: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const tryListen = (port: number, fallbackToAny: boolean): void => {
+      const srv = createServer();
+      srv.once('error', (err: NodeJS.ErrnoException) => {
+        if (fallbackToAny && err.code === 'EADDRINUSE') tryListen(0, false);
+        else reject(err);
+      });
+      srv.listen({ port, host: '127.0.0.1' }, () => {
+        const addr = srv.address();
+        const chosen = typeof addr === 'object' && addr ? addr.port : 0;
+        if (!chosen) { srv.close(() => reject(new Error('findFreePort: OS returned port 0'))); return; }
+        srv.close(() => resolve(chosen));
+      });
+    };
+    tryListen(preferred, true);
+  });
+}

--- a/scripts/cdp-bridge/src/runners/rn-android-runner-client.ts
+++ b/scripts/cdp-bridge/src/runners/rn-android-runner-client.ts
@@ -111,8 +111,9 @@ export function _setAndroidRunnerStateForTest(state: AndroidRunnerState | null):
 export function parseAdbDevicesSerials(stdout: string): string[] {
   return stdout.split('\n').slice(1)
     .map((l) => l.trim())
-    .filter((l) => l.endsWith('\tdevice'))
-    .map((l) => l.split('\t')[0]);
+    .map((l) => /^(\S+)\s+device\b/.exec(l))
+    .filter((m): m is RegExpExecArray => m !== null)
+    .map((m) => m[1]);
 }
 
 export async function resolveAndroidSerial(explicit?: string): Promise<string | undefined> {
@@ -268,9 +269,14 @@ export async function startAndroidRunner(deviceId?: string, bundleId?: string, d
 
     child.on('exit', (code) => {
       if (runnerProcess === child) {
+        const exitState = runnerState;
         runnerProcess = null;
         runnerState = null;
         try { unlinkSync(STATE_FILE); } catch { /* already removed */ }
+        if (typeof exitState?.hostPort === 'number') {
+          execFileAsync('adb', buildAdbForwardRemoveArgs(exitState.deviceId, exitState.hostPort))
+            .catch(() => { /* best-effort: must never throw from exit handler */ });
+        }
       }
       if (!resolved) {
         resolved = true;
@@ -299,9 +305,10 @@ export async function stopAndroidRunner(deviceId?: string): Promise<void> {
   runnerProcess = null;
   runnerState = null;
   try { unlinkSync(STATE_FILE); } catch { /* already removed */ }
-  const hostPort = stoppedState?.hostPort ?? DEFAULT_PORT;
-  const resolvedDeviceId = deviceId ?? stoppedState?.deviceId;
-  try { await execFileAsync('adb', buildAdbForwardRemoveArgs(resolvedDeviceId, hostPort)); } catch { /* non-fatal */ }
+  if (typeof stoppedState?.hostPort === 'number') {
+    const resolvedDeviceId = deviceId ?? stoppedState.deviceId;
+    try { await execFileAsync('adb', buildAdbForwardRemoveArgs(resolvedDeviceId, stoppedState.hostPort)); } catch { /* non-fatal */ }
+  }
 }
 
 async function postCommand(body: { command?: unknown }): Promise<RunnerResponse> {

--- a/scripts/cdp-bridge/src/runners/rn-android-runner-client.ts
+++ b/scripts/cdp-bridge/src/runners/rn-android-runner-client.ts
@@ -108,6 +108,23 @@ export function _setAndroidRunnerStateForTest(state: AndroidRunnerState | null):
   runnerState = state;
 }
 
+export function parseAdbDevicesSerials(stdout: string): string[] {
+  return stdout.split('\n').slice(1)
+    .map((l) => l.trim())
+    .filter((l) => l.endsWith('\tdevice'))
+    .map((l) => l.split('\t')[0]);
+}
+
+export async function resolveAndroidSerial(explicit?: string): Promise<string | undefined> {
+  if (explicit) return explicit;
+  if (process.env.ANDROID_SERIAL) return process.env.ANDROID_SERIAL;
+  try {
+    const { stdout } = await execFileAsync('adb', ['devices']);
+    const serials = parseAdbDevicesSerials(stdout);
+    return serials.length === 1 ? serials[0] : undefined;
+  } catch { return undefined; }
+}
+
 function adbSerialArgs(deviceId?: string): string[] {
   if (deviceId) return ['-s', deviceId];
   if (process.env.ANDROID_SERIAL) return ['-s', process.env.ANDROID_SERIAL];

--- a/scripts/cdp-bridge/src/runners/rn-android-runner-client.ts
+++ b/scripts/cdp-bridge/src/runners/rn-android-runner-client.ts
@@ -9,6 +9,7 @@ import { writeFileSync, unlinkSync, readFileSync, existsSync } from 'node:fs';
 import type { ToolResult } from '../utils.js';
 import { okResult, failResult } from '../utils.js';
 import { updateRefMapFromFlat, getCachedMetadata, type FlatNode } from '../fast-runner-ref-map.js';
+import { findFreePort } from './free-port.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -21,7 +22,8 @@ const HEALTH_POLL_INTERVAL_MS = 150;
 const HEALTH_PROBE_TIMEOUT_MS = 1_000;
 
 interface AndroidRunnerState {
-  port: number;
+  hostPort: number;   // 127.0.0.1 port the TS client connects to (probed; globally contended)
+  devicePort: number; // NanoHTTPD listener inside the emulator (fixed; emulator-namespaced)
   pid: number;
   deviceId?: string;
   bundleId?: string;
@@ -82,12 +84,16 @@ let fetchImpl: typeof fetch = globalThis.fetch;
 
 try {
   if (existsSync(STATE_FILE)) {
-    const raw = JSON.parse(readFileSync(STATE_FILE, 'utf-8')) as AndroidRunnerState;
-    try {
-      process.kill(raw.pid, 0);
-      runnerState = raw;
-    } catch {
-      unlinkSync(STATE_FILE);
+    const raw = JSON.parse(readFileSync(STATE_FILE, 'utf-8')) as Partial<AndroidRunnerState>;
+    if (typeof raw.hostPort !== 'number' || typeof raw.devicePort !== 'number') {
+      unlinkSync(STATE_FILE); // pre-split state shape → ignore + clear
+    } else {
+      try {
+        process.kill(raw.pid!, 0);
+        runnerState = raw as AndroidRunnerState;
+      } catch {
+        unlinkSync(STATE_FILE);
+      }
     }
   }
 } catch {
@@ -106,6 +112,18 @@ function adbSerialArgs(deviceId?: string): string[] {
   if (deviceId) return ['-s', deviceId];
   if (process.env.ANDROID_SERIAL) return ['-s', process.env.ANDROID_SERIAL];
   return [];
+}
+
+export function buildAdbForwardArgs(deviceId: string | undefined, hostPort: number, devicePort: number): string[] {
+  return [...adbSerialArgs(deviceId), 'forward', `tcp:${hostPort}`, `tcp:${devicePort}`];
+}
+
+export function buildAdbForwardRemoveArgs(deviceId: string | undefined, hostPort: number): string[] {
+  return [...adbSerialArgs(deviceId), 'forward', '--remove', `tcp:${hostPort}`];
+}
+
+export function buildInstrumentPortArgs(devicePort: number): string[] {
+  return ['-e', 'RN_ANDROID_RUNNER_PORT', String(devicePort)];
 }
 
 export function isAndroidRunnerAvailable(): boolean {
@@ -168,25 +186,29 @@ export async function waitForAndroidRunnerHealth(
   return false;
 }
 
-export async function startAndroidRunner(deviceId?: string, bundleId?: string, port = DEFAULT_PORT): Promise<AndroidRunnerState> {
+export async function startAndroidRunner(deviceId?: string, bundleId?: string, devicePort = DEFAULT_PORT): Promise<AndroidRunnerState> {
   if (isAndroidRunnerAvailable() && shouldReuseAndroidRunner(runnerState, deviceId)) return runnerState!;
 
-  const serial = adbSerialArgs(deviceId);
-  await execFileAsync('adb', [...serial, 'forward', `tcp:${port}`, `tcp:${port}`]);
+  let hostPort = await findFreePort(devicePort);
+  try {
+    await execFileAsync('adb', buildAdbForwardArgs(deviceId, hostPort, devicePort));
+  } catch {
+    // host port raced between probe and forward → re-probe once with any free port
+    hostPort = await findFreePort(0);
+    await execFileAsync('adb', buildAdbForwardArgs(deviceId, hostPort, devicePort));
+  }
 
   return new Promise((resolve, reject) => {
     let resolved = false;
 
     const child = spawn('adb', [
-      ...serial,
+      ...adbSerialArgs(deviceId),
       'shell',
       'am',
       'instrument',
       '-w',
       '-r',
-      '-e',
-      'RN_ANDROID_RUNNER_PORT',
-      String(port),
+      ...buildInstrumentPortArgs(devicePort),
       '-e',
       'class',
       MAIN_LOOP_CLASS,
@@ -209,7 +231,8 @@ export async function startAndroidRunner(deviceId?: string, bundleId?: string, p
       if (resolved) return;
       resolved = true;
       const state: AndroidRunnerState = {
-        port,
+        hostPort,
+        devicePort,
         pid: child.pid!,
         ...(deviceId ? { deviceId } : {}),
         ...(bundleId ? { bundleId } : {}),
@@ -240,7 +263,7 @@ export async function startAndroidRunner(deviceId?: string, bundleId?: string, p
 
     // GH#243: readiness is the runner's own /health, not the (stale-prone) logcat
     // ring buffer. /health is true only once the ServerSocket is actually accepting.
-    void waitForAndroidRunnerHealth(port).then((healthy) => {
+    void waitForAndroidRunnerHealth(hostPort).then((healthy) => {
       if (resolved) return;
       if (healthy) {
         finishReady();
@@ -248,18 +271,20 @@ export async function startAndroidRunner(deviceId?: string, bundleId?: string, p
       }
       resolved = true;
       child.kill('SIGTERM');
-      reject(new Error(`Android runner did not become ready within ${READY_TIMEOUT_MS / 1000}s (no /health on port ${port})${diag ? `\n${diag.trim()}` : ''}`));
+      reject(new Error(`Android runner did not become ready within ${READY_TIMEOUT_MS / 1000}s (no /health on port ${hostPort})${diag ? `\n${diag.trim()}` : ''}`));
     });
   });
 }
 
 export async function stopAndroidRunner(deviceId?: string): Promise<void> {
-  const serial = adbSerialArgs(deviceId ?? runnerState?.deviceId);
+  const stoppedState = runnerState;
   runnerProcess?.kill('SIGTERM');
   runnerProcess = null;
   runnerState = null;
   try { unlinkSync(STATE_FILE); } catch { /* already removed */ }
-  try { await execFileAsync('adb', [...serial, 'forward', '--remove', `tcp:${DEFAULT_PORT}`]); } catch { /* non-fatal */ }
+  const hostPort = stoppedState?.hostPort ?? DEFAULT_PORT;
+  const resolvedDeviceId = deviceId ?? stoppedState?.deviceId;
+  try { await execFileAsync('adb', buildAdbForwardRemoveArgs(resolvedDeviceId, hostPort)); } catch { /* non-fatal */ }
 }
 
 async function postCommand(body: { command?: unknown }): Promise<RunnerResponse> {
@@ -273,7 +298,7 @@ async function postCommand(body: { command?: unknown }): Promise<RunnerResponse>
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   let resp: Response;
   try {
-    resp = await fetchImpl(`http://127.0.0.1:${state.port}/command`, {
+    resp = await fetchImpl(`http://127.0.0.1:${state.hostPort}/command`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body),

--- a/scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts
+++ b/scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts
@@ -6,6 +6,7 @@ import type { ToolResult } from '../utils.js';
 import { okResult, failResult } from '../utils.js';
 import type { FastRunnerState } from '../types.js';
 import { updateRefMapFromFlat, getCachedMetadata, type FlatNode } from '../fast-runner-ref-map.js';
+import { isPortFree } from './free-port.js';
 
 const DEFAULT_PORT = 22088;
 const READY_TIMEOUT_MS = 30_000;
@@ -185,8 +186,10 @@ export function shouldReuseRunner(state: FastRunnerState | null, deviceId: strin
   return state !== null && state.deviceId === deviceId;
 }
 
-export function startFastRunner(deviceId: string, bundleId: string, port = DEFAULT_PORT): Promise<FastRunnerState> {
-  if (shouldReuseRunner(runnerState, deviceId)) return Promise.resolve(runnerState!);
+export async function startFastRunner(deviceId: string, bundleId: string, port?: number): Promise<FastRunnerState> {
+  if (shouldReuseRunner(runnerState, deviceId)) return runnerState!;
+
+  const desired = port ?? (await isPortFree(DEFAULT_PORT) ? DEFAULT_PORT : 0);
 
   return new Promise((resolve, reject) => {
     const projectPath = join(FAST_RUNNER_PROJECT, 'RnFastRunner', 'RnFastRunner.xcodeproj');
@@ -210,7 +213,7 @@ export function startFastRunner(deviceId: string, bundleId: string, port = DEFAU
     const child = spawn('xcodebuild', args, {
       env: {
         ...process.env,
-        RN_FAST_RUNNER_PORT: String(port),
+        RN_FAST_RUNNER_PORT: String(desired),
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     });

--- a/scripts/cdp-bridge/src/tools/device-session-close.ts
+++ b/scripts/cdp-bridge/src/tools/device-session-close.ts
@@ -6,6 +6,7 @@ export interface CloseDeviceSessionDeps {
   closeUnderlyingSession: () => Promise<ToolResult>;
   clearActiveSession: () => void;
   stopFastRunner: () => void;
+  stopAndroidRunner: () => Promise<void>;
   releaseDeviceLock: () => void;
 }
 
@@ -46,6 +47,7 @@ export async function closeDeviceSession(deps: CloseDeviceSessionDeps): Promise<
   if (!result.isError) {
     deps.clearActiveSession();
     deps.stopFastRunner();
+    await deps.stopAndroidRunner();
     deps.releaseDeviceLock();
     return result;
   }
@@ -53,6 +55,7 @@ export async function closeDeviceSession(deps: CloseDeviceSessionDeps): Promise<
   if (isBenignSessionGoneError(result)) {
     deps.clearActiveSession();
     deps.stopFastRunner();
+    await deps.stopAndroidRunner();
     deps.releaseDeviceLock();
     return okResult({
       closed: true,

--- a/scripts/cdp-bridge/src/tools/device-session.ts
+++ b/scripts/cdp-bridge/src/tools/device-session.ts
@@ -37,11 +37,11 @@ const HEARTBEAT_MS = 30_000;
 let activeDeviceLock: DeviceLock | null = null;
 let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 
-function acquireDeviceLockForSession(udid: string, appId: string): DeviceLockResult {
+function acquireDeviceLockForSession(platform: 'ios' | 'android', deviceId: string, appId: string): DeviceLockResult {
   // Single-owner: drop any prior lock + heartbeat first (release is null-safe)
   // so a re-open can't leak a timer or orphan a lock. (#202 review — blocker.)
   releaseDeviceLockForSession();
-  const lock = new DeviceLock({ udid, appId });
+  const lock = new DeviceLock({ platform, deviceId, appId });
   const result = lock.acquire();
   // Only manage a heartbeat for a REAL exclusive lock — a degraded (fs-error)
   // acquire is unmanaged, so there is nothing to refresh or release.
@@ -232,7 +232,7 @@ export function createDeviceSnapshotHandler(): (args: SnapshotArgs) => Promise<T
         // another project's bridge owns the sim — tear our just-opened session
         // back down and refuse, rather than fight for foreground.
         if (platform === 'ios' && deviceId) {
-          const lockResult = acquireDeviceLockForSession(deviceId, appId);
+          const lockResult = acquireDeviceLockForSession('ios', deviceId, appId);
           if (lockResult.status === 'conflict') {
             // Close FIRST — runAgentDevice derives `--session` from the active
             // session, so clearing before closing would close the wrong (or no)

--- a/scripts/cdp-bridge/src/tools/device-session.ts
+++ b/scripts/cdp-bridge/src/tools/device-session.ts
@@ -10,6 +10,7 @@ import {
   getAdbSerial,
 } from '../agent-device-wrapper.js';
 import { stopFastRunner } from '../runners/rn-fast-runner-client.js';
+import { stopAndroidRunner, resolveAndroidSerial } from '../runners/rn-android-runner-client.js';
 import { markCdpStale } from '../cdp/recovery.js';
 import { detectAndroidExternalRunner, detectIosExternalRunner, foreignRunnerNotice } from '../runners/external-runner-detect.js';
 import { ensureSingleRunner } from '../runners/ensure-single-runner.js';
@@ -60,8 +61,9 @@ export function releaseDeviceLockForSession(): void {
 }
 
 export function deviceBusyMessage(deviceId: string, holder: DeviceLockBody): string {
+  const label = holder.platform === 'android' ? 'Emulator/device' : 'Simulator';
   return (
-    `Simulator ${deviceId} is already owned by another rn-dev-agent bridge ` +
+    `${label} ${deviceId} is already owned by another rn-dev-agent bridge ` +
     `(PID ${holder.pid}, project ${holder.projectRoot}` +
     `${holder.appId ? `, app ${holder.appId}` : ''}). ` +
     `Close that session or target a different simulator.`
@@ -227,29 +229,35 @@ export function createDeviceSnapshotHandler(): (args: SnapshotArgs) => Promise<T
           appId,
         });
 
-        // GH#202 Phase 1.5: claim exclusive ownership of THIS simulator across
-        // bridge processes. The UDID is only known now (post-open). On conflict
-        // another project's bridge owns the sim — tear our just-opened session
-        // back down and refuse, rather than fight for foreground.
-        if (platform === 'ios' && deviceId) {
-          const lockResult = acquireDeviceLockForSession('ios', deviceId, appId);
+        // GH#202 Phase 1.5 (iOS) + Task 5 (Android): claim exclusive ownership
+        // of THIS device across bridge processes. On conflict another project's
+        // bridge owns it — tear our just-opened session back down and refuse.
+        // Android: deviceId is filtered through UDID_RE and is always undefined
+        // for adb serials like "emulator-5554", so we resolve the serial
+        // independently via `adb devices` rather than keying on deviceId.
+        const lockPlatform: 'ios' | 'android' = platform === 'android' ? 'android' : 'ios';
+        const lockDeviceId = lockPlatform === 'android'
+          ? await resolveAndroidSerial(deviceId)
+          : deviceId;
+        if (lockDeviceId) {
+          // TODO(phase2): acquire the lock BEFORE the open side-effect once 'open' is resolved via simctl/adb instead of agent-device — spec D-e.
+          const lockResult = acquireDeviceLockForSession(lockPlatform, lockDeviceId, appId);
           if (lockResult.status === 'conflict') {
             // Close FIRST — runAgentDevice derives `--session` from the active
             // session, so clearing before closing would close the wrong (or no)
             // session and leak the one we just opened (#202 review — blocker).
             await runAgentDevice(['close']).catch(() => { /* best-effort teardown */ });
             clearActiveSession();
-            stopFastRunner();
-            const h = lockResult.holder;
+            if (lockPlatform === 'ios') stopFastRunner(); else await stopAndroidRunner();
             return failResult(
-              deviceBusyMessage(deviceId, h),
-              { code: 'DEVICE_BUSY', holder: h },
+              deviceBusyMessage(lockDeviceId, lockResult.holder),
+              { code: 'DEVICE_BUSY', holder: lockResult.holder },
             );
           }
           if (lockResult.degraded) {
             logger.warn(
               'rn-device',
-              `Device-ownership lock unavailable (fs error) for ${deviceId} — ` +
+              `Device-ownership lock unavailable (fs error) for ${lockDeviceId} — ` +
               `cross-bridge contention protection is off this session.`,
             );
           }

--- a/scripts/cdp-bridge/src/tools/device-session.ts
+++ b/scripts/cdp-bridge/src/tools/device-session.ts
@@ -248,7 +248,7 @@ export function createDeviceSnapshotHandler(): (args: SnapshotArgs) => Promise<T
             // session and leak the one we just opened (#202 review — blocker).
             await runAgentDevice(['close']).catch(() => { /* best-effort teardown */ });
             clearActiveSession();
-            if (lockPlatform === 'ios') stopFastRunner(); else await stopAndroidRunner();
+            if (lockPlatform === 'ios') stopFastRunner(); else await stopAndroidRunner(lockDeviceId);
             return failResult(
               deviceBusyMessage(lockDeviceId, lockResult.holder),
               { code: 'DEVICE_BUSY', holder: lockResult.holder },
@@ -370,6 +370,7 @@ export function createDeviceSnapshotHandler(): (args: SnapshotArgs) => Promise<T
         closeUnderlyingSession: () => runAgentDevice(['close']),
         clearActiveSession,
         stopFastRunner,
+        stopAndroidRunner,
         releaseDeviceLock: releaseDeviceLockForSession,
       });
     }

--- a/scripts/cdp-bridge/test/unit/android-runner-ports.test.js
+++ b/scripts/cdp-bridge/test/unit/android-runner-ports.test.js
@@ -20,3 +20,7 @@ test('parseAdbDevicesSerials: extracts only online device serials', () => {
   const out = 'List of devices attached\nemulator-5554\tdevice\nemulator-5556\toffline\n\n';
   assert.deepEqual(parseAdbDevicesSerials(out), ['emulator-5554']);
 });
+test('parseAdbDevicesSerials: tolerates trailing attributes (transport_id/product)', () => {
+  const out = 'List of devices attached\nemulator-5554\tdevice product:sdk_gphone64 transport_id:1\nemulator-5556\toffline\n\n';
+  assert.deepEqual(parseAdbDevicesSerials(out), ['emulator-5554']);
+});

--- a/scripts/cdp-bridge/test/unit/android-runner-ports.test.js
+++ b/scripts/cdp-bridge/test/unit/android-runner-ports.test.js
@@ -1,0 +1,17 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildAdbForwardArgs, buildAdbForwardRemoveArgs, buildInstrumentPortArgs,
+} from '../../dist/runners/rn-android-runner-client.js';
+
+test('Android ports: adb forward maps probed hostPort → fixed devicePort', () => {
+  assert.deepEqual(buildAdbForwardArgs('emulator-5554', 41001, 22089),
+    ['-s', 'emulator-5554', 'forward', 'tcp:41001', 'tcp:22089']);
+});
+test('Android ports: instrumentation receives the DEVICE port, not the host port', () => {
+  assert.deepEqual(buildInstrumentPortArgs(22089), ['-e', 'RN_ANDROID_RUNNER_PORT', '22089']);
+});
+test('Android ports: forward --remove targets the host port', () => {
+  assert.deepEqual(buildAdbForwardRemoveArgs('emulator-5554', 41001),
+    ['-s', 'emulator-5554', 'forward', '--remove', 'tcp:41001']);
+});

--- a/scripts/cdp-bridge/test/unit/android-runner-ports.test.js
+++ b/scripts/cdp-bridge/test/unit/android-runner-ports.test.js
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   buildAdbForwardArgs, buildAdbForwardRemoveArgs, buildInstrumentPortArgs,
+  parseAdbDevicesSerials,
 } from '../../dist/runners/rn-android-runner-client.js';
 
 test('Android ports: adb forward maps probed hostPort → fixed devicePort', () => {
@@ -14,4 +15,8 @@ test('Android ports: instrumentation receives the DEVICE port, not the host port
 test('Android ports: forward --remove targets the host port', () => {
   assert.deepEqual(buildAdbForwardRemoveArgs('emulator-5554', 41001),
     ['-s', 'emulator-5554', 'forward', '--remove', 'tcp:41001']);
+});
+test('parseAdbDevicesSerials: extracts only online device serials', () => {
+  const out = 'List of devices attached\nemulator-5554\tdevice\nemulator-5556\toffline\n\n';
+  assert.deepEqual(parseAdbDevicesSerials(out), ['emulator-5554']);
 });

--- a/scripts/cdp-bridge/test/unit/audit-h4-android-runner-deviceid.test.js
+++ b/scripts/cdp-bridge/test/unit/audit-h4-android-runner-deviceid.test.js
@@ -6,7 +6,7 @@ import { shouldReuseAndroidRunner } from '../../dist/runners/rn-android-runner-c
 // emulator-A must NOT be reused to drive emulator-B (its adb forward + port
 // still target A — every device_* would silently hit the wrong emulator).
 
-const stateFor = (deviceId) => ({ port: 22089, pid: 4242, deviceId, startedAt: 'now' });
+const stateFor = (deviceId) => ({ hostPort: 22089, devicePort: 22089, pid: 4242, deviceId, startedAt: 'now' });
 
 test('H4: same emulator → reuse', () => {
   assert.equal(shouldReuseAndroidRunner(stateFor('emulator-5554'), 'emulator-5554'), true);

--- a/scripts/cdp-bridge/test/unit/free-port.test.js
+++ b/scripts/cdp-bridge/test/unit/free-port.test.js
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:net';
+import { findFreePort, isPortFree } from '../../dist/runners/free-port.js';
+
+function knownFreePort() {
+  return new Promise((resolve) => {
+    const s = createServer();
+    s.listen({ port: 0, host: '127.0.0.1' }, () => {
+      const p = s.address().port;
+      s.close(() => resolve(p));
+    });
+  });
+}
+
+test('findFreePort: returns the preferred port when it is free', async () => {
+  const p = await knownFreePort();
+  assert.equal(await findFreePort(p), p);
+});
+
+test('findFreePort: returns a different, valid port when preferred is occupied', async () => {
+  const blocker = createServer();
+  const held = await new Promise((r) => blocker.listen({ port: 0, host: '127.0.0.1' }, () => r(blocker.address().port)));
+  try {
+    const p = await findFreePort(held);
+    assert.notEqual(p, held);
+    assert.ok(p > 0 && p < 65536);
+  } finally { await new Promise((r) => blocker.close(r)); }
+});
+
+test('isPortFree: true for a free port, false for an occupied one', async () => {
+  const blocker = createServer();
+  const held = await new Promise((r) => blocker.listen({ port: 0, host: '127.0.0.1' }, () => r(blocker.address().port)));
+  try { assert.equal(await isPortFree(held), false); }
+  finally { await new Promise((r) => blocker.close(r)); }
+});

--- a/scripts/cdp-bridge/test/unit/gh-202-device-lock-wiring.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-202-device-lock-wiring.test.js
@@ -43,6 +43,6 @@ test('GH#202 Android open resolves the adb serial and acquires the device lock',
   assert.match(sessionSrc, /resolveAndroidSerial\(/);
   assert.match(sessionSrc, /acquireDeviceLockForSession\(lockPlatform, lockDeviceId, appId\)/);
 });
-test('GH#202 Android conflict teardown stops the android runner', () => {
-  assert.match(sessionSrc, /stopAndroidRunner\(\)/);
+test('GH#202 Android conflict teardown stops the android runner with the locked serial', () => {
+  assert.match(sessionSrc, /stopAndroidRunner\(lockDeviceId\)/);
 });

--- a/scripts/cdp-bridge/test/unit/gh-202-device-lock-wiring.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-202-device-lock-wiring.test.js
@@ -9,7 +9,7 @@ const sessionSrc = readFileSync(resolve(__dirname, '../../src/tools/device-sessi
 const indexSrc = readFileSync(resolve(__dirname, '../../src/index.ts'), 'utf8');
 
 test('GH#202 device-open acquires the UDID lock and refuses on conflict', () => {
-  assert.match(sessionSrc, /acquireDeviceLockForSession\('ios', deviceId, appId\)/);
+  assert.match(sessionSrc, /acquireDeviceLockForSession\(lockPlatform, lockDeviceId, appId\)/);
   assert.match(sessionSrc, /DEVICE_BUSY/);
 });
 
@@ -37,4 +37,12 @@ test('GH#202 device-close releases the UDID lock', () => {
 
 test('GH#202 process exit releases the UDID lock', () => {
   assert.match(indexSrc, /releaseDeviceLockForSession/);
+});
+
+test('GH#202 Android open resolves the adb serial and acquires the device lock', () => {
+  assert.match(sessionSrc, /resolveAndroidSerial\(/);
+  assert.match(sessionSrc, /acquireDeviceLockForSession\(lockPlatform, lockDeviceId, appId\)/);
+});
+test('GH#202 Android conflict teardown stops the android runner', () => {
+  assert.match(sessionSrc, /stopAndroidRunner\(\)/);
 });

--- a/scripts/cdp-bridge/test/unit/gh-202-device-lock-wiring.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-202-device-lock-wiring.test.js
@@ -9,7 +9,7 @@ const sessionSrc = readFileSync(resolve(__dirname, '../../src/tools/device-sessi
 const indexSrc = readFileSync(resolve(__dirname, '../../src/index.ts'), 'utf8');
 
 test('GH#202 device-open acquires the UDID lock and refuses on conflict', () => {
-  assert.match(sessionSrc, /acquireDeviceLockForSession\(deviceId, appId\)/);
+  assert.match(sessionSrc, /acquireDeviceLockForSession\('ios', deviceId, appId\)/);
   assert.match(sessionSrc, /DEVICE_BUSY/);
 });
 

--- a/scripts/cdp-bridge/test/unit/gh-202-device-lock.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-202-device-lock.test.js
@@ -14,13 +14,12 @@ function tmp() {
 
 function makeLock(dir, over = {}) {
   return new DeviceLock({
-    udid: UDID,
+    platform: over.platform ?? 'ios',
+    deviceId: over.deviceId ?? UDID,
     projectRoot: over.projectRoot ?? '/proj/a',
     appId: over.appId ?? 'com.example.app',
     pid: over.pid ?? 4242,
-    uid: 501,
-    tmpDir: dir,
-    version: '0-test',
+    uid: 501, tmpDir: dir, version: '0-test',
     clock: over.clock ?? (() => FIXED),
     processAlive: over.processAlive ?? (() => true),
     staleMs: over.staleMs ?? 90_000,
@@ -28,7 +27,7 @@ function makeLock(dir, over = {}) {
 }
 
 test('GH#202 isDeviceLockStale: stale when PID dead OR heartbeat too old, fresh otherwise', () => {
-  const body = { pid: 1, projectRoot: '/p', platform: 'ios', udid: UDID, startedAt: FIXED, lastHeartbeat: FIXED };
+  const body = { pid: 1, projectRoot: '/p', platform: 'ios', deviceId: UDID, startedAt: FIXED, lastHeartbeat: FIXED };
   assert.equal(isDeviceLockStale(body, FIXED, () => false, 90_000), true);            // dead PID
   assert.equal(isDeviceLockStale(body, FIXED + 91_000, () => true, 90_000), true);    // stale heartbeat
   assert.equal(isDeviceLockStale(body, FIXED + 1_000, () => true, 90_000), false);    // alive + fresh
@@ -43,7 +42,7 @@ test('GH#202 DeviceLock.acquire: clean state → acquired, writes body keyed on 
     assert.ok(lock.lockPath.includes(`device-501-ios-${UDID}`));
     assert.ok(existsSync(lock.lockPath));
     const body = JSON.parse(readFileSync(lock.lockPath, 'utf8'));
-    assert.equal(body.udid, UDID);
+    assert.equal(body.deviceId, UDID);
     assert.equal(body.pid, 4242);
     assert.equal(body.platform, 'ios');
     assert.equal(body.startedAt, FIXED);
@@ -58,7 +57,7 @@ test('GH#202 DeviceLock.acquire: conflict when a LIVE holder owns the UDID', () 
     const r = makeLock(dir, { pid: 2222, processAlive: () => true, clock: () => FIXED + 1_000 }).acquire();
     assert.equal(r.status, 'conflict');
     assert.equal(r.holder.pid, 1111);
-    assert.equal(r.holder.udid, UDID);
+    assert.equal(r.holder.deviceId, UDID);
   } finally { rmSync(dir, { recursive: true, force: true }); }
 });
 
@@ -103,7 +102,7 @@ test('GH#202 DeviceLock.release: unlinks only when we are the owner', () => {
     assert.ok(!existsSync(owner.lockPath));
 
     writeFileSync(join(dir, `rn-dev-agent-device-501-ios-${UDID}.lock`),
-      JSON.stringify({ pid: 999, projectRoot: '/p', platform: 'ios', udid: UDID, startedAt: FIXED, lastHeartbeat: FIXED }), 'utf8');
+      JSON.stringify({ pid: 999, projectRoot: '/p', platform: 'ios', deviceId: UDID, startedAt: FIXED, lastHeartbeat: FIXED }), 'utf8');
     makeLock(dir, { pid: 8 }).release();   // never acquired → no-op
     assert.ok(existsSync(join(dir, `rn-dev-agent-device-501-ios-${UDID}.lock`)));
   } finally { rmSync(dir, { recursive: true, force: true }); }
@@ -115,7 +114,7 @@ test('GH#202 DeviceLock.touch: does NOT resurrect a lock another bridge reclaime
     const owner = makeLock(dir, { pid: 7 });
     owner.acquire();
     writeFileSync(owner.lockPath,
-      JSON.stringify({ pid: 999, projectRoot: '/proj/b', platform: 'ios', udid: UDID, startedAt: 1, lastHeartbeat: 1 }), 'utf8');
+      JSON.stringify({ pid: 999, projectRoot: '/proj/b', platform: 'ios', deviceId: UDID, startedAt: 1, lastHeartbeat: 1 }), 'utf8');
     owner.touch();   // we no longer own it → must NOT overwrite
     assert.equal(JSON.parse(readFileSync(owner.lockPath, 'utf8')).pid, 999);
   } finally { rmSync(dir, { recursive: true, force: true }); }
@@ -125,8 +124,31 @@ test('GH#202 DeviceLock: a foreign/corrupt body is treated as reclaimable', () =
   const dir = tmp();
   try {
     const lockPath = join(dir, `rn-dev-agent-device-501-ios-${UDID}.lock`);
-    writeFileSync(lockPath, JSON.stringify({ pid: 1, projectRoot: '/p', platform: 'android', udid: UDID, startedAt: 1, lastHeartbeat: 9_999_999_999_999 }), 'utf8');
+    writeFileSync(lockPath, JSON.stringify({ pid: 1, projectRoot: '/p', platform: 'android', deviceId: UDID, startedAt: 1, lastHeartbeat: 9_999_999_999_999 }), 'utf8');
     const r = makeLock(dir, { pid: 2222, processAlive: () => true }).acquire();
     assert.equal(r.status, 'acquired');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('GH#202 DeviceLock: Android serial-scoped lock keys path + body on platform+serial', () => {
+  const dir = tmp();
+  try {
+    const r = makeLock(dir, { platform: 'android', deviceId: 'emulator-5554' }).acquire();
+    assert.equal(r.status, 'acquired');
+    const lock = makeLock(dir, { platform: 'android', deviceId: 'emulator-5554' });
+    assert.ok(lock.lockPath.includes('device-501-android-emulator-5554'));
+    const body = JSON.parse(readFileSync(lock.lockPath, 'utf8'));
+    assert.equal(body.platform, 'android');
+    assert.equal(body.deviceId, 'emulator-5554');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('GH#202 DeviceLock: same id on different platforms do NOT collide', () => {
+  const dir = tmp();
+  try {
+    const ios = makeLock(dir, { platform: 'ios', deviceId: 'shared-id', pid: 1 }).acquire();
+    const and = makeLock(dir, { platform: 'android', deviceId: 'shared-id', pid: 2 }).acquire();
+    assert.equal(ios.status, 'acquired');
+    assert.equal(and.status, 'acquired');
   } finally { rmSync(dir, { recursive: true, force: true }); }
 });

--- a/scripts/cdp-bridge/test/unit/gh-243-android-runner-health.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-243-android-runner-health.test.js
@@ -64,7 +64,8 @@ test('#243/B191 isAndroidConnectionFailure matches startAndroidRunner startup-fa
 
 test('#243 runAndroid returns RN_ANDROID_RUNNER_DOWN (not bare "fetch failed") on connection failure', async () => {
   _setAndroidRunnerStateForTest({
-    port: 22089,
+    hostPort: 22089,
+    devicePort: 22089,
     pid: process.pid, // alive → startAndroidRunner short-circuits, no real adb spawn
     deviceId: 'emulator-5554',
     bundleId: 'com.example',

--- a/scripts/cdp-bridge/test/unit/gh-244-close-session-gone.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-244-close-session-gone.test.js
@@ -13,60 +13,67 @@ const errClose = (error, code) => ({
   isError: true,
 });
 
-test('#244 no in-memory session → ok no-op; underlying close NOT called', async () => {
-  const calls = { clear: 0, stop: 0, release: 0, close: 0 };
-  const r = await closeDeviceSession({
-    hasActiveSession: () => false,
+// Base deps factory: stopAndroidRunner is a no-op async spy by default.
+function makeDeps(overrides = {}) {
+  const calls = { clear: 0, stop: 0, stopAndroid: 0, release: 0, close: 0 };
+  const deps = {
+    hasActiveSession: () => true,
     closeUnderlyingSession: async () => { calls.close++; return okClose(); },
     clearActiveSession: () => { calls.clear++; },
     stopFastRunner: () => { calls.stop++; },
+    stopAndroidRunner: async () => { calls.stopAndroid++; },
     releaseDeviceLock: () => { calls.release++; },
-  });
+    ...overrides,
+  };
+  return { deps, calls };
+}
+
+test('#244 no in-memory session → ok no-op; underlying close NOT called', async () => {
+  const { deps, calls } = makeDeps({ hasActiveSession: () => false });
+  const r = await closeDeviceSession(deps);
   assert.equal(r.isError, undefined);
   assert.match(r.content[0].text, /No active session to close/);
   assert.equal(calls.close, 0);
 });
 
 test('#244 close succeeds → ok; cleanup all called once', async () => {
-  const calls = { clear: 0, stop: 0, release: 0, close: 0 };
-  const r = await closeDeviceSession({
-    hasActiveSession: () => true,
-    closeUnderlyingSession: async () => { calls.close++; return okClose(); },
-    clearActiveSession: () => { calls.clear++; },
-    stopFastRunner: () => { calls.stop++; },
-    releaseDeviceLock: () => { calls.release++; },
-  });
+  const { deps, calls } = makeDeps();
+  const r = await closeDeviceSession(deps);
   assert.equal(r.isError, undefined);
-  assert.deepEqual(calls, { clear: 1, stop: 1, release: 1, close: 1 });
+  assert.equal(calls.clear, 1);
+  assert.equal(calls.stop, 1);
+  assert.equal(calls.stopAndroid, 1);
+  assert.equal(calls.release, 1);
+  assert.equal(calls.close, 1);
 });
 
 test('#244 SESSION_NOT_FOUND after a flow → ok with sessionAlreadyGone; cleanup all called', async () => {
-  const calls = { clear: 0, stop: 0, release: 0, close: 0 };
-  const r = await closeDeviceSession({
-    hasActiveSession: () => true,
+  const { deps, calls } = makeDeps({
     closeUnderlyingSession: async () => { calls.close++; return errClose('No active session', 'SESSION_NOT_FOUND'); },
-    clearActiveSession: () => { calls.clear++; },
-    stopFastRunner: () => { calls.stop++; },
-    releaseDeviceLock: () => { calls.release++; },
   });
+  const r = await closeDeviceSession(deps);
   assert.equal(r.isError, undefined);
   const env = JSON.parse(r.content[0].text);
   assert.equal(env.data.sessionAlreadyGone, true);
-  assert.deepEqual(calls, { clear: 1, stop: 1, release: 1, close: 1 });
+  assert.equal(calls.clear, 1);
+  assert.equal(calls.stop, 1);
+  assert.equal(calls.stopAndroid, 1);
+  assert.equal(calls.release, 1);
+  assert.equal(calls.close, 1);
 });
 
 test('#244 unrelated close error → surfaced as-is; cleanup NOT called', async () => {
-  const calls = { clear: 0, stop: 0, release: 0, close: 0 };
-  const r = await closeDeviceSession({
-    hasActiveSession: () => true,
+  const { deps, calls } = makeDeps({
     closeUnderlyingSession: async () => { calls.close++; return errClose('adb: device offline', 'BAD_RESPONSE'); },
-    clearActiveSession: () => { calls.clear++; },
-    stopFastRunner: () => { calls.stop++; },
-    releaseDeviceLock: () => { calls.release++; },
   });
+  const r = await closeDeviceSession(deps);
   assert.equal(r.isError, true);
   assert.match(r.content[0].text, /device offline/);
-  assert.deepEqual(calls, { clear: 0, stop: 0, release: 0, close: 1 });
+  assert.equal(calls.clear, 0);
+  assert.equal(calls.stop, 0);
+  assert.equal(calls.stopAndroid, 0);
+  assert.equal(calls.release, 0);
+  assert.equal(calls.close, 1);
 });
 
 test('#244 isBenignSessionGoneError matches only gone-session shapes', () => {
@@ -93,14 +100,36 @@ test('#244/B192 non-JSON payload mentioning the phrase is NOT benign', async () 
   assert.equal(isBenignSessionGoneError(plainText), false);
 
   // and closeDeviceSession must surface it unchanged, leaving local state intact
-  const calls = { clear: 0, stop: 0, release: 0 };
-  const r = await closeDeviceSession({
-    hasActiveSession: () => true,
+  const { deps, calls } = makeDeps({
     closeUnderlyingSession: async () => plainText,
-    clearActiveSession: () => { calls.clear++; },
-    stopFastRunner: () => { calls.stop++; },
-    releaseDeviceLock: () => { calls.release++; },
   });
+  const r = await closeDeviceSession(deps);
   assert.equal(r.isError, true);
-  assert.deepEqual(calls, { clear: 0, stop: 0, release: 0 });
+  assert.equal(calls.clear, 0);
+  assert.equal(calls.stop, 0);
+  assert.equal(calls.stopAndroid, 0);
+  assert.equal(calls.release, 0);
+});
+
+// Finding 1a: stopAndroidRunner must be called on a normal successful close (dep-injection proof).
+test('android close teardown: stopAndroidRunner is called on successful close', async () => {
+  let androidStopCalled = false;
+  const { deps } = makeDeps({
+    stopAndroidRunner: async () => { androidStopCalled = true; },
+  });
+  const r = await closeDeviceSession(deps);
+  assert.equal(r.isError, undefined);
+  assert.equal(androidStopCalled, true, 'stopAndroidRunner must be called on a normal close');
+});
+
+// Finding 1a: stopAndroidRunner must also be called when the session is already gone (benign path).
+test('android close teardown: stopAndroidRunner is called on SESSION_NOT_FOUND (benign gone path)', async () => {
+  let androidStopCalled = false;
+  const { deps } = makeDeps({
+    closeUnderlyingSession: async () => errClose('No active session', 'SESSION_NOT_FOUND'),
+    stopAndroidRunner: async () => { androidStopCalled = true; },
+  });
+  const r = await closeDeviceSession(deps);
+  assert.equal(r.isError, undefined);
+  assert.equal(androidStopCalled, true, 'stopAndroidRunner must be called even when the underlying session was already gone');
 });

--- a/scripts/cdp-bridge/test/unit/runners/rn-android-runner-client.test.js
+++ b/scripts/cdp-bridge/test/unit/runners/rn-android-runner-client.test.js
@@ -8,7 +8,8 @@ import {
 import { refCenter, clearRefMap } from '../../../dist/fast-runner-ref-map.js';
 
 _setAndroidRunnerStateForTest({
-  port: 22089,
+  hostPort: 22089,
+  devicePort: 22089,
   pid: process.pid,
   deviceId: 'emulator-5554',
   bundleId: 'com.example',


### PR DESCRIPTION
## Eradicate agent-device — Phase 1: Port/Conflict Hardening

**Phase 1 of 5** in removing the third-party `agent-device` CLI entirely and making the in-tree native runners (`rn-fast-runner` iOS, `rn-android-runner` Android) the sole device-interaction backend.

- **Spec:** `docs/superpowers/specs/2026-06-15-eradicate-agent-device-design.md`
- **Plan:** `docs/superpowers/plans/2026-06-15-eradicate-agent-device-plan.md`

This PR delivers the **port-lock / conflict hardening** that de-risks the later hard-cutover phase. No interaction-path behavior change for the common single-simulator case.

### What's in this PR
| Change | Commit |
|---|---|
| Generalize `DeviceLock` iOS→iOS+Android (`platform`+`deviceId`, path keyed per platform) | `53d9d540` |
| `findFreePort` / `isPortFree` port-probe helpers | `6e64642d` |
| Android runner host/device port split (probe host, fix device, `adb forward`, state-file migration, forward retry) | `067780fa` |
| iOS runner self-assigns a free port when 22088 is taken (passes `0` → Swift OS-assign) | `a5d03537` |
| `resolveAndroidSerial` / `parseAdbDevicesSerials` + Android device lock wired at session open (keyed on the resolved adb serial) | `40beaa5a` |
| Final-review fixes: `adb forward` cleanup on close/crash, lenient serial parser, teardown serial, platform-aware `DEVICE_BUSY` message | `60334be5` |

### Why
Device control is asymmetric today: iOS already uses `rn-fast-runner`, Android already has `rn-android-runner` (default-on), but `agent-device` survives as the Android daemon/CLI fallback + install scaffolding. Before the Phase 2 cutover removes that safety net, Phase 1 hardens the conflict surface flagged as the #1 risk:
- **No Android device lock existed** (iOS had a UDID-scoped one) → two bridges could fight over one emulator. Now there's a serial-scoped lock with parity.
- **Ports were hardcoded** (22088/22089) with no collision tolerance → fragile for multi-sim / multi-bridge. Now host ports are probed (Android) / self-assigned (iOS) while the device-listener port stays fixed.

### Review trail (adversarial, multi-gate)
- **codex-pair** caught 2 bugs in the spec (lock-before-side-effects ordering; host/device port conflation) — fixed pre-commit.
- **Codex + Gemini** plan review caught 4 blockers *before any code* — notably the **Android lock no-op** (a UDID regex silently gating out every adb serial) and the host/device port conflation — fixed in the plan.
- **Codex + Antigravity** final review caught the **`adb forward` leak** introduced by the now-dynamic host port (close + crash paths) + a too-strict serial parser — fixed (`60334be5`).

### Testing
- **Unit:** full cdp-bridge suite **2102/2102 green** (added: DeviceLock both-platform, free-port, Android port-split builders, serial parse, lock wiring; migrated 3 Android state fixtures).
- **Device-smoked on real iOS sim + Android emulator** (direct `dist/` tests against booted devices):
  - iOS `DeviceLock` (real UDID): acquire → conflict-refusal → release → re-acquire ✓
  - Android serial resolution against **real** `adb devices -l` output (with `transport_id:`/`product:` attributes) — confirms the lenient parser is load-bearing; the pre-fix `.endsWith('\tdevice')` parser returned `[]` on this exact output ✓
  - Android `DeviceLock` (real serial) ✓
  - Android runner port-split: `adb forward tcp:host tcp:device` → `/health` ok → snapshot (86 nodes) → `stopAndroidRunner` removes the forward ✓

### Migration notes
- On-disk lock body field renamed `udid`→`deviceId`; pre-rename iOS lock files are treated as reclaimable (transient `${TMPDIR}` locks, heartbeat self-healing — at most one stale reclaim post-upgrade).
- Pre-split `/tmp/rn-android-runner-state.json` (`{ port }` shape) is discarded on load (prevents `fetch …/undefined/command`).

### Deferred / follow-ups (not blockers)
- **Lock-before-side-effects** ordering (spec D-e) is `TODO(phase2)` — `open` still uses agent-device here, so the lock is acquired post-open (parity with today's iOS); Phase 2 rewrites `open` off agent-device and moves the lock first.
- Observed during smoke: a transient `UiAutomation DeadObjectException` on the runner's first connect after a snapshot boot (force-stop + retry cleared it) — candidate runner-startup-resilience follow-up.
- `stopAndroidRunner` removes the host forward but not the device-side app process (handled by `release-android-slot.ts` before flows / on reuse) — candidate cleanup-symmetry follow-up.

### Roadmap
Phase 1 (this PR) → **Phase 0** head-to-head benchmark (data gate) → **Phase 2** hard cutover → **Phase 3** cleanup/docs → **Phase 4** final dual-platform verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
