### PR TITLE
feat(rn-device): rn-android-runner self-installs on first use (parity with iOS)

### DIFF
--- a/.changeset/android-runner-self-install.md
+++ b/.changeset/android-runner-self-install.md
@@ -1,0 +1,5 @@
+---
+"rn-dev-agent": minor
+---
+
+Android `rn-android-runner` now self-installs on first use (parity with the iOS `rn-fast-runner` cold build): `startAndroidRunner` installs the prebuilt APKs — and cold-builds them via Gradle if absent — when the instrumentation isn't on the device yet. No external CLI or manual `gradlew + adb install` step is required; this makes the `/setup` and `/doctor` "builds/installs on first use" promise true on Android.

--- a/scripts/cdp-bridge/dist/runners/rn-android-runner-client.js
+++ b/scripts/cdp-bridge/dist/runners/rn-android-runner-client.js
@@ -8,6 +8,7 @@ import { writeFileSync, unlinkSync, readFileSync, existsSync } from 'node:fs';
 import { okResult, failResult } from '../utils.js';
 import { updateRefMapFromFlat, getCachedMetadata } from '../fast-runner-ref-map.js';
 import { findFreePort } from './free-port.js';
+import { join } from 'node:path';
 const execFileAsync = promisify(execFile);
 const DEFAULT_PORT = 22089;
 const READY_TIMEOUT_MS = 30_000;
@@ -16,6 +17,15 @@ const INSTRUMENTATION = 'dev.lykhoyda.rndevagent.androidrunner.test/androidx.tes
 const MAIN_LOOP_CLASS = 'dev.lykhoyda.rndevagent.androidrunner.RnAndroidRunnerInstrumentedTest#mainLoop';
 const HEALTH_POLL_INTERVAL_MS = 150;
 const HEALTH_PROBE_TIMEOUT_MS = 1_000;
+// Self-install (parity with the iOS rn-fast-runner cold build): the in-tree runner
+// ships as a Gradle project; its APKs build/install on first use so there's no
+// external CLI to install (matches the /setup + /doctor docs).
+const RN_ANDROID_RUNNER_DIR = join(import.meta.dirname, '..', '..', '..', 'rn-android-runner');
+const GRADLEW = join(RN_ANDROID_RUNNER_DIR, 'gradlew');
+const APK_APP = join(RN_ANDROID_RUNNER_DIR, 'app', 'build', 'outputs', 'apk', 'debug', 'app-debug.apk');
+const APK_TEST = join(RN_ANDROID_RUNNER_DIR, 'app', 'build', 'outputs', 'apk', 'androidTest', 'debug', 'app-debug-androidTest.apk');
+const GRADLE_BUILD_TIMEOUT_MS = 600_000; // cold assembleDebug can take minutes on a fresh machine
+const ADB_INSTALL_TIMEOUT_MS = 120_000;
 let runnerProcess = null;
 let runnerState = null;
 let fetchImpl = globalThis.fetch;
@@ -81,6 +91,83 @@ export function buildAdbForwardRemoveArgs(deviceId, hostPort) {
 }
 export function buildInstrumentPortArgs(devicePort) {
     return ['-e', 'RN_ANDROID_RUNNER_PORT', String(devicePort)];
+}
+export function buildAdbInstallArgs(deviceId, apkPath) {
+    return [...adbSerialArgs(deviceId), 'install', '-r', apkPath];
+}
+export function buildGradleAssembleArgs() {
+    return [':app:assembleDebug', ':app:assembleDebugAndroidTest'];
+}
+/**
+ * True when `adb shell pm list instrumentation` names our exact `<pkg>/<runner>` id.
+ * Anchored to the full id (not the bare package) so a superstring package
+ * (`…androidrunner.testfoo`) or a `(target=…)` mention can't false-positive.
+ */
+export function isInstrumentationRegistered(pmListStdout, instrumentation) {
+    const escaped = instrumentation.replace(/[.$*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`(^|:)${escaped}(\\s|$)`, 'm').test(pmListStdout);
+}
+/** Decide how to provision the runner: reuse (already on device), install the prebuilt
+ *  APKs, or cold-build then install (fresh machine — mirrors the iOS cold xcodebuild). */
+export function resolveAndroidInstallAction(opts) {
+    if (opts.instrumentationRegistered)
+        return 'reuse';
+    if (opts.apksExist)
+        return 'install';
+    return 'build-then-install';
+}
+/**
+ * Self-install the in-tree runner on first use (parity with rn-fast-runner's cold build):
+ * if the instrumentation isn't registered on the device, install the prebuilt APKs — and
+ * if those don't exist yet, cold-build them via Gradle first. Throws an actionable error
+ * (surfaced as RN_ANDROID_RUNNER_DOWN by the caller) when the SDK/Gradle/adb step fails.
+ */
+async function ensureAndroidRunnerInstalled(deviceId) {
+    // Fail fast if the target isn't online — never start a multi-minute cold build (or an
+    // install) against an offline/absent device. (Codex review: avoid the build-then-fail trap.)
+    try {
+        const { stdout } = await execFileAsync('adb', [...adbSerialArgs(deviceId), 'get-state'], { timeout: 5_000 });
+        if (stdout.trim() !== 'device')
+            throw new Error(`adb state is "${stdout.trim()}"`);
+    }
+    catch (err) {
+        throw new Error(`rn-android-runner: target device not online (adb get-state) — boot the emulator / connect the device. ` +
+            `${err instanceof Error ? err.message : String(err)}`);
+    }
+    let pmOut = '';
+    try {
+        pmOut = (await execFileAsync('adb', [...adbSerialArgs(deviceId), 'shell', 'pm', 'list', 'instrumentation'])).stdout;
+    }
+    catch {
+        // adb/pm unavailable → treat as not registered; the install/adb step below surfaces the real error.
+    }
+    const action = resolveAndroidInstallAction({
+        instrumentationRegistered: isInstrumentationRegistered(pmOut, INSTRUMENTATION),
+        apksExist: existsSync(APK_APP) && existsSync(APK_TEST),
+    });
+    if (action === 'reuse')
+        return;
+    if (action === 'build-then-install') {
+        try {
+            await execFileAsync(GRADLEW, buildGradleAssembleArgs(), {
+                cwd: RN_ANDROID_RUNNER_DIR,
+                timeout: GRADLE_BUILD_TIMEOUT_MS,
+                maxBuffer: 10 * 1024 * 1024,
+            });
+        }
+        catch (err) {
+            throw new Error(`rn-android-runner cold build failed (gradlew assembleDebug assembleDebugAndroidTest in ${RN_ANDROID_RUNNER_DIR}). ` +
+                `Ensure the Android SDK + a JDK are installed and on PATH. ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    try {
+        await execFileAsync('adb', buildAdbInstallArgs(deviceId, APK_APP), { timeout: ADB_INSTALL_TIMEOUT_MS });
+        await execFileAsync('adb', buildAdbInstallArgs(deviceId, APK_TEST), { timeout: ADB_INSTALL_TIMEOUT_MS });
+    }
+    catch (err) {
+        throw new Error(`rn-android-runner APK install failed (adb install -r). Is the emulator/device online? ` +
+            `${err instanceof Error ? err.message : String(err)}`);
+    }
 }
 export function isAndroidRunnerAvailable() {
     if (!runnerState)
@@ -149,6 +236,9 @@ export async function waitForAndroidRunnerHealth(port, opts = {}) {
 export async function startAndroidRunner(deviceId, bundleId, devicePort = DEFAULT_PORT) {
     if (isAndroidRunnerAvailable() && shouldReuseAndroidRunner(runnerState, deviceId))
         return runnerState;
+    // Self-install on first use (no external CLI) — build/install the in-tree runner APKs
+    // if the instrumentation isn't on the device yet. Mirrors rn-fast-runner's cold build.
+    await ensureAndroidRunnerInstalled(deviceId);
     let hostPort = await findFreePort(devicePort);
     try {
         await execFileAsync('adb', buildAdbForwardArgs(deviceId, hostPort, devicePort));

--- a/scripts/cdp-bridge/src/runners/rn-android-runner-client.ts
+++ b/scripts/cdp-bridge/src/runners/rn-android-runner-client.ts
@@ -10,6 +10,7 @@ import type { ToolResult } from '../utils.js';
 import { okResult, failResult } from '../utils.js';
 import { updateRefMapFromFlat, getCachedMetadata, type FlatNode } from '../fast-runner-ref-map.js';
 import { findFreePort } from './free-port.js';
+import { join } from 'node:path';
 
 const execFileAsync = promisify(execFile);
 
@@ -20,6 +21,16 @@ const INSTRUMENTATION = 'dev.lykhoyda.rndevagent.androidrunner.test/androidx.tes
 const MAIN_LOOP_CLASS = 'dev.lykhoyda.rndevagent.androidrunner.RnAndroidRunnerInstrumentedTest#mainLoop';
 const HEALTH_POLL_INTERVAL_MS = 150;
 const HEALTH_PROBE_TIMEOUT_MS = 1_000;
+
+// Self-install (parity with the iOS rn-fast-runner cold build): the in-tree runner
+// ships as a Gradle project; its APKs build/install on first use so there's no
+// external CLI to install (matches the /setup + /doctor docs).
+const RN_ANDROID_RUNNER_DIR = join(import.meta.dirname, '..', '..', '..', 'rn-android-runner');
+const GRADLEW = join(RN_ANDROID_RUNNER_DIR, 'gradlew');
+const APK_APP = join(RN_ANDROID_RUNNER_DIR, 'app', 'build', 'outputs', 'apk', 'debug', 'app-debug.apk');
+const APK_TEST = join(RN_ANDROID_RUNNER_DIR, 'app', 'build', 'outputs', 'apk', 'androidTest', 'debug', 'app-debug-androidTest.apk');
+const GRADLE_BUILD_TIMEOUT_MS = 600_000; // cold assembleDebug can take minutes on a fresh machine
+const ADB_INSTALL_TIMEOUT_MS = 120_000;
 
 interface AndroidRunnerState {
   hostPort: number;   // 127.0.0.1 port the TS client connects to (probed; globally contended)
@@ -144,6 +155,94 @@ export function buildInstrumentPortArgs(devicePort: number): string[] {
   return ['-e', 'RN_ANDROID_RUNNER_PORT', String(devicePort)];
 }
 
+export function buildAdbInstallArgs(deviceId: string | undefined, apkPath: string): string[] {
+  return [...adbSerialArgs(deviceId), 'install', '-r', apkPath];
+}
+
+export function buildGradleAssembleArgs(): string[] {
+  return [':app:assembleDebug', ':app:assembleDebugAndroidTest'];
+}
+
+/**
+ * True when `adb shell pm list instrumentation` names our exact `<pkg>/<runner>` id.
+ * Anchored to the full id (not the bare package) so a superstring package
+ * (`…androidrunner.testfoo`) or a `(target=…)` mention can't false-positive.
+ */
+export function isInstrumentationRegistered(pmListStdout: string, instrumentation: string): boolean {
+  const escaped = instrumentation.replace(/[.$*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(^|:)${escaped}(\\s|$)`, 'm').test(pmListStdout);
+}
+
+export type AndroidInstallAction = 'reuse' | 'install' | 'build-then-install';
+
+/** Decide how to provision the runner: reuse (already on device), install the prebuilt
+ *  APKs, or cold-build then install (fresh machine — mirrors the iOS cold xcodebuild). */
+export function resolveAndroidInstallAction(opts: {
+  instrumentationRegistered: boolean;
+  apksExist: boolean;
+}): AndroidInstallAction {
+  if (opts.instrumentationRegistered) return 'reuse';
+  if (opts.apksExist) return 'install';
+  return 'build-then-install';
+}
+
+/**
+ * Self-install the in-tree runner on first use (parity with rn-fast-runner's cold build):
+ * if the instrumentation isn't registered on the device, install the prebuilt APKs — and
+ * if those don't exist yet, cold-build them via Gradle first. Throws an actionable error
+ * (surfaced as RN_ANDROID_RUNNER_DOWN by the caller) when the SDK/Gradle/adb step fails.
+ */
+async function ensureAndroidRunnerInstalled(deviceId?: string): Promise<void> {
+  // Fail fast if the target isn't online — never start a multi-minute cold build (or an
+  // install) against an offline/absent device. (Codex review: avoid the build-then-fail trap.)
+  try {
+    const { stdout } = await execFileAsync('adb', [...adbSerialArgs(deviceId), 'get-state'], { timeout: 5_000 });
+    if (stdout.trim() !== 'device') throw new Error(`adb state is "${stdout.trim()}"`);
+  } catch (err) {
+    throw new Error(
+      `rn-android-runner: target device not online (adb get-state) — boot the emulator / connect the device. ` +
+      `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  let pmOut = '';
+  try {
+    pmOut = (await execFileAsync('adb', [...adbSerialArgs(deviceId), 'shell', 'pm', 'list', 'instrumentation'])).stdout;
+  } catch {
+    // adb/pm unavailable → treat as not registered; the install/adb step below surfaces the real error.
+  }
+  const action = resolveAndroidInstallAction({
+    instrumentationRegistered: isInstrumentationRegistered(pmOut, INSTRUMENTATION),
+    apksExist: existsSync(APK_APP) && existsSync(APK_TEST),
+  });
+  if (action === 'reuse') return;
+
+  if (action === 'build-then-install') {
+    try {
+      await execFileAsync(GRADLEW, buildGradleAssembleArgs(), {
+        cwd: RN_ANDROID_RUNNER_DIR,
+        timeout: GRADLE_BUILD_TIMEOUT_MS,
+        maxBuffer: 10 * 1024 * 1024,
+      });
+    } catch (err) {
+      throw new Error(
+        `rn-android-runner cold build failed (gradlew assembleDebug assembleDebugAndroidTest in ${RN_ANDROID_RUNNER_DIR}). ` +
+        `Ensure the Android SDK + a JDK are installed and on PATH. ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  try {
+    await execFileAsync('adb', buildAdbInstallArgs(deviceId, APK_APP), { timeout: ADB_INSTALL_TIMEOUT_MS });
+    await execFileAsync('adb', buildAdbInstallArgs(deviceId, APK_TEST), { timeout: ADB_INSTALL_TIMEOUT_MS });
+  } catch (err) {
+    throw new Error(
+      `rn-android-runner APK install failed (adb install -r). Is the emulator/device online? ` +
+      `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 export function isAndroidRunnerAvailable(): boolean {
   if (!runnerState) return false;
   try {
@@ -206,6 +305,10 @@ export async function waitForAndroidRunnerHealth(
 
 export async function startAndroidRunner(deviceId?: string, bundleId?: string, devicePort = DEFAULT_PORT): Promise<AndroidRunnerState> {
   if (isAndroidRunnerAvailable() && shouldReuseAndroidRunner(runnerState, deviceId)) return runnerState!;
+
+  // Self-install on first use (no external CLI) — build/install the in-tree runner APKs
+  // if the instrumentation isn't on the device yet. Mirrors rn-fast-runner's cold build.
+  await ensureAndroidRunnerInstalled(deviceId);
 
   let hostPort = await findFreePort(devicePort);
   try {

--- a/scripts/cdp-bridge/test/unit/android-runner-install.test.js
+++ b/scripts/cdp-bridge/test/unit/android-runner-install.test.js
@@ -1,0 +1,56 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isInstrumentationRegistered,
+  resolveAndroidInstallAction,
+  buildAdbInstallArgs,
+  buildGradleAssembleArgs,
+} from '../../dist/runners/rn-android-runner-client.js';
+
+const INSTR = 'dev.lykhoyda.rndevagent.androidrunner.test/androidx.test.runner.AndroidJUnitRunner';
+
+test('isInstrumentationRegistered: true when pm list contains the test package', () => {
+  const out = 'instrumentation:dev.lykhoyda.rndevagent.androidrunner.test/androidx.test.runner.AndroidJUnitRunner (target=dev.lykhoyda.rndevagent.androidrunner)\n';
+  assert.equal(isInstrumentationRegistered(out, INSTR), true);
+});
+
+test('isInstrumentationRegistered: false when absent or empty', () => {
+  assert.equal(isInstrumentationRegistered('instrumentation:com.other/Runner (target=com.other)\n', INSTR), false);
+  assert.equal(isInstrumentationRegistered('', INSTR), false);
+});
+
+test('resolveAndroidInstallAction: reuse when already registered', () => {
+  assert.equal(resolveAndroidInstallAction({ instrumentationRegistered: true, apksExist: false }), 'reuse');
+  assert.equal(resolveAndroidInstallAction({ instrumentationRegistered: true, apksExist: true }), 'reuse');
+});
+
+test('resolveAndroidInstallAction: install when not registered but APKs exist', () => {
+  assert.equal(resolveAndroidInstallAction({ instrumentationRegistered: false, apksExist: true }), 'install');
+});
+
+test('resolveAndroidInstallAction: build-then-install when nothing present (fresh machine)', () => {
+  assert.equal(resolveAndroidInstallAction({ instrumentationRegistered: false, apksExist: false }), 'build-then-install');
+});
+
+test('buildAdbInstallArgs: serial + install -r + apk path', () => {
+  assert.deepEqual(buildAdbInstallArgs('emulator-5554', '/x/app-debug.apk'), ['-s', 'emulator-5554', 'install', '-r', '/x/app-debug.apk']);
+});
+
+test('buildAdbInstallArgs: no serial → bare install', () => {
+  // (no deviceId, no ANDROID_SERIAL) — adbSerialArgs returns []
+  const prev = process.env.ANDROID_SERIAL; delete process.env.ANDROID_SERIAL;
+  try { assert.deepEqual(buildAdbInstallArgs(undefined, '/x/a.apk'), ['install', '-r', '/x/a.apk']); }
+  finally { if (prev !== undefined) process.env.ANDROID_SERIAL = prev; }
+});
+
+test('buildGradleAssembleArgs: assembles both app + androidTest', () => {
+  assert.deepEqual(buildGradleAssembleArgs(), [':app:assembleDebug', ':app:assembleDebugAndroidTest']);
+});
+
+test('isInstrumentationRegistered: false on a superstring package (anchored, not substring)', () => {
+  assert.equal(isInstrumentationRegistered('instrumentation:dev.lykhoyda.rndevagent.androidrunner.testfoo/X (target=y)\n', INSTR), false);
+});
+
+test('isInstrumentationRegistered: false when our id appears only inside a foreign (target=...) mention', () => {
+  assert.equal(isInstrumentationRegistered('instrumentation:com.foreign/Runner (target=dev.lykhoyda.rndevagent.androidrunner.test)\n', INSTR), false);
+});


### PR DESCRIPTION
## Android `rn-android-runner` self-installs on first use

Closes the last gap from the eradicate-agent-device work: the in-tree Android runner now **builds + installs itself on first use**, matching the iOS `rn-fast-runner` cold-build and making the `/setup` + `/doctor` "builds/installs on first use, no external CLI" promise true on Android.

### Before
`startAndroidRunner` went straight to `adb forward` + `am instrument` — if the runner APKs weren't already built **and** installed (a manual `./gradlew … && adb install`), it just failed. The merged docs already claimed auto-install; the code didn't deliver it.

### After
`startAndroidRunner` calls a new `ensureAndroidRunnerInstalled(deviceId)` after the in-memory reuse check, before `adb forward`:
1. **Fail-fast** if the device is offline (`adb get-state`) — never start a multi-minute build against a dead device.
2. **Probe** `adb shell pm list instrumentation` (anchored full-`pkg/runner`-id match — no substring false-positives).
3. If not registered → **install** the prebuilt APKs (`app-debug.apk` then `app-debug-androidTest.apk`), or **cold-build** them via `./gradlew :app:assembleDebug :app:assembleDebugAndroidTest` first if absent (the Android analogue of the iOS cold `xcodebuild`).
4. Failures throw actionable errors surfaced as `RN_ANDROID_RUNNER_DOWN`.

Warm reuse short-circuits before any probe, so steady-state calls pay nothing.

### Testing
- **Unit: 2172/2172** (+10 new: `isInstrumentationRegistered` incl. anchored false-positive cases, `resolveAndroidInstallAction` reuse/install/build matrix, the adb/gradle arg builders).
- **Device-verified on a real emulator** (twice): uninstall the runner → `startAndroidRunner` auto-installed the APKs (`pm list` registered after) → `runAndroid` snapshot `ok=true`.
- Multi-LLM reviewed (Codex + Antigravity): both confirmed sound; 2 Codex fixes folded in (anchored probe + `get-state` precheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
