### PR TITLE
chore(end-session): backlog→GitHub-issue sync + Kano refinement steps

### DIFF
--- a/.claude/commands/end-session.md
+++ b/.claude/commands/end-session.md
@@ -1,8 +1,8 @@
 ---
 command: end-session
-description: Wrap up the work session — log decisions to DECISIONS.md, bugs to BUGS.md, findings + a dated narrative to ROADMAP.md (in the sibling rn-dev-agent-workspace), then run a git/changeset hygiene check. Appends only; never deletes or rewrites existing entries; never commits.
+description: Wrap up the work session — log decisions to DECISIONS.md, bugs to BUGS.md, findings + a dated narrative to ROADMAP.md (in the sibling rn-dev-agent-workspace), sync un-filed ROADMAP/BUGS follow-ups to GitHub issues, run Kano backlog refinement, then a git/changeset hygiene check. Docs are append-only and never committed; GitHub issue creation + labels happen only after maintainer confirmation.
 argument-hint: [optional focus or extra notes to weave in]
-allowed-tools: Bash, Read, Edit, Grep, Glob
+allowed-tools: Bash, Read, Edit, Grep, Glob, Skill
 ---
 
 # /end-session — session wrap-up
@@ -38,6 +38,11 @@ it does not replace your own reconstruction of the session.
    before writing and increment from there — do not reuse or guess.
 5. **Match the house format** of each doc exactly (see the templates below). Use today's
    date from `date +%F`, never a guessed date.
+6. **GitHub mutation is gated.** Creating issues (Step 4.5) and applying Kano labels
+   (Step 4.6) are the ONLY outward-facing writes this command makes, and they happen ONLY
+   after you present the proposed set and the maintainer confirms. Never auto-create issues
+   or relabel without that explicit yes. The "never commit" rule still governs the workspace
+   docs — those remain the maintainer's to commit.
 
 ## Procedure
 
@@ -123,6 +128,38 @@ entry's Forward block that are still open.>
 **Refs.** <Dxxxx/Bxxxx created this session, GH #, PR #.>
 ```
 
+### Step 4.5 — Sync un-filed follow-ups to GitHub issues (propose, then apply)
+
+The ROADMAP **Forward.** blocks and open `BUGS.md` entries accumulate "potential issues"
+that were described but never filed. Turn the genuinely-unfiled ones into GitHub issues —
+but **propose first, create only on the maintainer's yes** (this is outward mutation; Iron rule 6).
+
+1. **Collect candidates** from:
+   - the **Forward.** block you just wrote in Step 4, PLUS any still-open carried-forward
+     items from the previous entry's Forward block;
+   - open `BUGS.md` entries (`### B<n> … (Open …)`) that cite no GH issue number.
+2. **Dedup against what's already filed:** `gh issue list --state all --limit 200`. Drop any
+   candidate that (a) already cites a `#N` in the ROADMAP/BUGS text, or (b) matches an existing
+   issue's title/keywords. A duplicate is worse than not filing.
+3. **Draft** each remaining candidate: a clear title, a body quoting the ROADMAP/`Bxxxx`
+   context + this session's date, and suggested labels (`bug`/`enhancement`; a `kano:*`/`effort:*`
+   guess is optional — Step 4.6 finalizes labels).
+4. **Present the proposed issue set** (titles + one-line bodies + labels) and **WAIT** for the
+   maintainer to confirm / edit / drop. Create nothing before the yes.
+5. **On confirmation:** `gh issue create` each, capture the new `#`s, and **append those `#`s
+   into the ROADMAP Forward block** you wrote (so the doc records what got filed). On decline:
+   leave the drafts in the Step 6 report only.
+
+### Step 4.6 — Kano backlog refinement
+
+After the sync, refine the whole open backlog so the new issues are categorized too.
+**Invoke the `kano-backlog` skill** — do not re-implement Kano logic here; it is the single
+source of truth (categorizes every open issue as Must-be / Performance / Attractive /
+Indifferent / Reverse, applies `kano:*` + `priority:*` (+ `effort:*`) labels via `gh`, and
+recommends the single best next issue). Run it AFTER Step 4.5 so it sees the issues just
+created. Its label writes are GitHub mutation — gated by the skill's own flow; if it would
+relabel, surface the plan and apply on the maintainer's yes (Iron rule 6).
+
 ### Step 5 — Hygiene check (report, don't fix)
 - Uncommitted work: surface `git status --short` for **both** repos (the plugin repo and
   the workspace, including the docs you just wrote). **Separate three buckets explicitly:**
@@ -142,5 +179,7 @@ Print a compact report:
 - The hygiene flags (uncommitted files, missing changeset, branch state).
 - An explicit reminder that **nothing was committed** — list the exact files the
   maintainer should review and commit, in both repos.
+- **Backlog:** issues created this run (with `#`s), or proposed-but-declined; the Kano
+  next-pick recommendation from Step 4.6.
 
 Keep the final report short; the value is in the doc updates, not the recap.

--- a/.claude/commands/end-session.md
+++ b/.claude/commands/end-session.md
@@ -153,7 +153,8 @@ but **propose first, create only on the maintainer's yes** (this is outward muta
 ### Step 4.6 — Kano backlog refinement
 
 After the sync, refine the whole open backlog so the new issues are categorized too.
-**Invoke the `kano-backlog` skill** — do not re-implement Kano logic here; it is the single
+**Invoke the `kano-backlog` skill** (vendored maintainer tooling at `.claude/skills/kano-backlog/`,
+so this command is self-contained on any checkout) — do not re-implement Kano logic here; it is the single
 source of truth (categorizes every open issue as Must-be / Performance / Attractive /
 Indifferent / Reverse, applies `kano:*` + `priority:*` (+ `effort:*`) labels via `gh`, and
 recommends the single best next issue). Run it AFTER Step 4.5 so it sees the issues just

--- a/.claude/skills/kano-backlog/SKILL.md
+++ b/.claude/skills/kano-backlog/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: kano-backlog
+description: >-
+  Prioritize and refine a GitHub Issues backlog with the Kano model — categorize
+  every open issue as Must-be, Performance, Attractive, Indifferent, or Reverse,
+  apply Kano + priority labels back to GitHub automatically, and recommend the
+  single best next issue to pick up. Use this whenever the user wants to triage,
+  groom, or refine a backlog, decide what to build/work on next, prioritize
+  issues or features, or run a Kano analysis. Triggers on "refine the backlog",
+  "groom the backlog", "what should I work on next", "what should I build next",
+  "which issue should I pick", "prioritize these issues", "triage my issues",
+  "Kano model", "Kano analysis", "select the next issue" — even if the user
+  never says the word "Kano". This operates on an existing backlog of many open
+  issues; it is not for creating a single issue, closing/commenting on one issue,
+  checking an issue's status, or manually labeling a fixed range of issues.
+---
+
+# Kano Backlog Refinement (GitHub Issues)
+
+Turn a noisy GitHub Issues backlog into a Kano-prioritized plan and a single,
+defensible "do this next" pick. The Kano model is the right lens because backlog
+priority is not one-dimensional: an unmet **Must-be** (a bug, a broken basic)
+quietly burns satisfaction every day, while an **Attractive** delighter costs
+nothing when absent. Sorting by Kano category before sorting by votes or age
+prevents the classic failure of shipping shiny features on top of broken basics.
+
+Read `references/kano-model.md` for the five categories, the functional/
+dysfunctional question pair, the full evaluation table, and the heuristic signals.
+Load it before categorizing — the body below assumes you know the categories.
+
+## When to use
+
+The user wants to know what to work on next, wants the backlog cleaned up /
+groomed / refined / triaged, wants issues prioritized, or names the Kano model.
+You operate on **GitHub Issues** via the `gh` CLI.
+
+## What this skill does and does not change
+
+Write-back is **automatic** (no confirmation prompt) but deliberately scoped to
+**additive, reversible** edits:
+
+- ✅ Auto-applied: `kano:*` category labels and `priority:now|next|later` labels.
+- ⚠️ Recommended, never auto-done: **closing** issues (e.g. Reverse or stale
+  Indifferent items) and editing/deleting issue bodies. Closing is hard to
+  reverse and signals intent to a human audience, so surface it as a recommended
+  action with rationale and let the user run it. This boundary holds even though
+  the user opted into "fully automatic" — automation covers labeling, not
+  destructive or outward-facing actions.
+
+Every label change is logged in the final report so the run is auditable.
+
+## Workflow
+
+### 1. Resolve the target repo
+
+Confirm which repo's backlog you're refining before touching anything — labeling
+the wrong repo is annoying to undo.
+
+- If the user named a repo, use `--repo owner/name` on every `gh` call.
+- Otherwise detect the current one: `gh repo view --json nameWithOwner -q .nameWithOwner`.
+- State the resolved repo in your first message ("Refining the backlog for
+  `owner/name`…") so a wrong target is caught immediately.
+
+Honor any scope the user gives — a label filter, a milestone, "just the bugs",
+a maximum count. Pass it through to the fetch.
+
+### 2. Fetch the backlog
+
+Run the bundled fetch helper (it selects exactly the fields you need):
+
+```bash
+bash scripts/fetch_backlog.sh --repo owner/name --limit 100
+# optional: --label area/api   --search "milestone:v2"
+```
+
+It returns a JSON array of open issues with `number`, `title`, `body`, `labels`,
+`createdAt`, `updatedAt`, `comments`, `reactionGroups`, `assignees`, `milestone`.
+If the backlog is large, agree on a scope (a label, a milestone, top N by recent
+activity) rather than silently truncating — and say what you scoped to.
+
+### 3. Categorize each issue (Kano, heuristic)
+
+For each issue, reason about the **pair** of Kano questions before reaching for
+keywords:
+
+> If this shipped and worked well, how would users feel? → functional answer
+> If this never ships / stays broken, how would users feel? → dysfunctional answer
+
+Map the pair through the evaluation table in `references/kano-model.md` to get the
+category (M / O / A / I / R / Q). Use the heuristic signals there to estimate the
+answers — bugs and broken basics lean Must-be, "faster/more/cheaper" leans
+Performance, novel/unexpected upside leans Attractive, internal-only or
+zero-engagement leans Indifferent, forced/intrusive/option-removing leans Reverse.
+
+Record per issue: **category**, a one-line **rationale** tied to the question
+pair, a **confidence** (high/med/low), and a **demand signal** (reactions +
+comments + age). Flag low-confidence or mixed-scope issues as Questionable rather
+than guessing — those want a clarifying comment, not a confident label.
+
+### 4. Rank into a refined backlog
+
+Kano gives the tier; demand and effort order issues within it. Apply the
+prioritization policy from the reference:
+
+1. **Unmet Must-be** → `priority:now`. Active dissatisfaction; clear first.
+2. **Performance** by value/effort (demand ÷ effort) → top of the list go `now`,
+   the rest `next`.
+3. **1–2 Attractive** bets for differentiation → `next`; the remainder `later`.
+4. **Indifferent** → `later`, or recommend closing if stale and not unblocking
+   anything. If it *does* unblock a higher tier, say so and keep it.
+5. **Reverse** → no priority label; recommend "make optional / scope down / close
+   with rationale".
+
+Use `effort:*` / `size:*` / `SP:*` labels when present; otherwise infer scope
+from the description and say it's an estimate.
+
+### 5. Write back the labels (automatic)
+
+Ensure the label set exists, then apply categories and priorities. The label
+helper is idempotent (`gh label create --force` updates color/description in place):
+
+```bash
+bash scripts/ensure_labels.sh --repo owner/name
+```
+
+Then per issue (additive — swap any prior `kano:*`/`priority:*` so an issue never
+carries two conflicting tiers):
+
+```bash
+gh issue edit <num> --repo owner/name \
+  --add-label "kano:performance" --add-label "priority:next" \
+  --remove-label "priority:later"
+```
+
+Apply in a loop over your ranked list. Keep a running log of `#num → category,
+priority` for the report. If a `gh` call fails (permissions, missing label),
+note it and continue — don't abort the whole run over one issue.
+
+### 6. Select the next issue
+
+Recommend exactly one issue to pick up next, with reasoning. The default winner is
+the **highest-impact unmet Must-be that is unblocked and reasonably sized**. If no
+Must-be is outstanding, take the top Performance item by value/effort. Only lead
+with an Attractive item when basics and performance are genuinely in good shape —
+and say why.
+
+The pick must be **actionable now**: not blocked, not already assigned/in-progress
+(unless the user asked about their own in-flight work), and scoped enough to start.
+If the best-by-Kano item is blocked, name the blocker and pick the best unblocked
+alternative instead.
+
+### 7. Report
+
+Use this structure:
+
+```
+## Backlog refinement — owner/name (N issues)
+
+### 🎯 Next pick: #<num> <title>
+Kano: <category> · Priority: now · Effort: <est> · Demand: <signal>
+Why: <2–3 sentences tying the Kano reasoning + readiness to the recommendation>
+First steps: <1–3 concrete starting actions>
+
+### Refined backlog
+| # | Title | Kano | Conf | Demand | Effort | Priority | Action |
+|---|-------|------|------|--------|--------|----------|--------|
+| … | …     | M/O/A/I/R | H/M/L | 👍12 💬4 | S/M/L | now/next/later | label / recommend-close |
+
+### Labels applied
+- #12 → kano:must-be, priority:now
+- #34 → kano:attractive, priority:later  (…)
+
+### Recommended manual actions (not auto-applied)
+- Close #56 (Reverse: forces a flow users rely on opting out of) — rationale + suggested comment
+- Clarify #78 (Questionable: mixes two features) — suggested clarifying question
+```
+
+Keep rationales tied to *why* a category was chosen (the question pair), not just
+the label. That's what makes the refinement defensible to a human.
+
+## Categorization examples
+
+**Example 1 — Must-be**
+Input: "#101 Login fails with 500 for SSO users since Tuesday's deploy."
+Reasoning: present→users *expect* working login; absent→users *dislike* it
+strongly. Expect × Dislike → **Must-be**. Priority: now. It's a regression on a
+basic — top of the list.
+
+**Example 2 — Performance**
+Input: "#102 Search takes 4–6s; please make results return faster."
+Reasoning: faster is *liked*, slower is *disliked*, and satisfaction scales with
+the metric. Like × Dislike → **Performance (O)**. Rank by latency-pain ÷ effort.
+
+**Example 3 — Attractive**
+Input: "#103 Would be cool to auto-generate a weekly summary email with AI."
+Reasoning: present→*like* (novel, unexpected); absent→*neutral* (nobody expects
+it yet). Like × Neutral → **Attractive (A)**. Worth one bet, not the whole cycle.
+
+**Example 4 — Indifferent / Reverse**
+Input: "#104 Rename internal `UtilHelper` class to `Helpers`." → no user-visible
+effect, no demand → **Indifferent**; `later` or close unless it unblocks work.
+Input: "#105 Force all users into the new onboarding, remove the skip button." →
+removing an option many rely on → **Reverse**; recommend making it skippable
+rather than shipping as written.
+
+## Notes
+
+- This skill never closes, deletes, or edits issue bodies on its own. Those are
+  recommended actions for a human.
+- If `gh` isn't authenticated (`gh auth status` fails), stop and tell the user to
+  run `gh auth login` rather than guessing.
+- Re-running is safe: labels are idempotent and priorities are recomputed each run,
+  so the skill doubles as ongoing grooming, not a one-shot.

--- a/.claude/skills/kano-backlog/references/kano-model.md
+++ b/.claude/skills/kano-backlog/references/kano-model.md
@@ -1,0 +1,118 @@
+# The Kano Model — reference
+
+The Kano model (Noriaki Kano, 1984) classifies product attributes by how their
+presence or absence affects user satisfaction. It is not a linear priority score:
+two features with identical "importance" can demand opposite treatment because
+users react to them asymmetrically.
+
+## The five categories
+
+| Category | Code | If present | If absent | Treat as |
+|----------|------|-----------|-----------|----------|
+| **Must-be** (Basic / Threshold) | M | No extra satisfaction — taken for granted | Strong dissatisfaction | Non-negotiable. Fix/ship before anything else. |
+| **Performance** (One-dimensional / Linear) | O | Satisfaction rises the more/better it is | Dissatisfaction rises the less/worse it is | Invest proportionally to demand. The "more is better" axis. |
+| **Attractive** (Delighter / Exciter) | A | Delight, differentiation | No dissatisfaction — users didn't expect it | Selective bets. A few wins outsized loyalty; don't over-invest. |
+| **Indifferent** | I | No measurable effect | No measurable effect | Deprioritize or drop. Often internal-only or nobody-asked. |
+| **Reverse** | R | Some users actively dislike it | Those users are happier without it | Don't build as-is. Make optional, or reconsider. |
+| **Questionable** | Q | Contradictory signal | Contradictory signal | Data/understanding is inconsistent — re-read the issue, don't classify. |
+
+The critical insight for backlog work: **Must-be items are invisible when present
+but catastrophic when missing**, so an unmet Must-be (a bug, a broken basic) almost
+always outranks a shiny Attractive feature. Conversely, piling Performance effort
+onto an already-satisfied Must-be yields nothing — you can't delight users by making
+the login page "more reliable" past the point where it already works.
+
+## The functional / dysfunctional question pair
+
+Classic Kano derives a category from two mirrored questions about the *same* feature:
+
+- **Functional** (feature is present / works well): *How do you feel?*
+- **Dysfunctional** (feature is absent / works poorly): *How do you feel?*
+
+Each is answered on the same 5-point scale:
+
+1. I like it
+2. I expect it (it must be that way)
+3. I am neutral
+4. I can tolerate it
+5. I dislike it
+
+In heuristic mode you estimate both answers from the issue text and any demand
+signals, then read the category off the table below.
+
+## Kano evaluation table
+
+Rows = the **functional** answer (feature present). Columns = the **dysfunctional**
+answer (feature absent). The cell is the category.
+
+| Functional ↓ \ Dysfunctional → | Like | Expect | Neutral | Tolerate | Dislike |
+|---|---|---|---|---|---|
+| **Like**     | Q | A | A | A | O |
+| **Expect**   | R | I | I | I | M |
+| **Neutral**  | R | I | I | I | M |
+| **Tolerate** | R | I | I | I | M |
+| **Dislike**  | R | R | R | R | Q |
+
+How to read it: "I'd *like* it if present (Like) and I'd *dislike* its absence
+(Dislike)" → **O**, Performance. "I *expect* it if present and I'd *dislike* its
+absence" → **M**, Must-be. "I'd *like* it if present but I'm *neutral* about its
+absence" → **A**, Attractive.
+
+## Heuristic signals (text → estimated answers)
+
+These are *hints*, not rules. Always reason about the pair of questions first;
+use signals to break ties. Read the issue's title, body, labels, comments, and
+reaction/vote counts.
+
+**Lean Must-be (M)** — the absence causes pain users consider unacceptable:
+- Bug reports, regressions, crashes, errors, "doesn't work", "broken", "fails"
+- Security vulnerabilities, data loss, privacy, auth/login/payment broken
+- Legal/compliance/accessibility obligations (the floor, not a delighter)
+- Anything described as "table stakes", "expected", "should already work"
+
+**Lean Performance (O)** — satisfaction scales with the metric:
+- Speed/latency/load-time, throughput, cost/price, capacity/limits/quota
+- "Faster", "more", "reduce steps", "improve accuracy", "increase X"
+- Search relevance, sync reliability, battery/efficiency — graded, not binary
+
+**Lean Attractive (A)** — unexpected upside, no pain if missing:
+- New integrations, novel capabilities, automation, "AI-powered", "magic"
+- "Would be cool", "nice to have", "wishlist", "delight", "wow"
+- Differentiators competitors lack; things users didn't think to ask for
+
+**Lean Indifferent (I)** — no user-visible effect or no demand:
+- Internal refactors, renames, tech-debt cleanup, dependency bumps with no behavior change
+- Cosmetic tweaks nobody requested; zero reactions/comments after a long time
+- (Internal-but-enabling work isn't worthless — it may *unblock* a Must-be/Performance
+  item. Note the dependency rather than dismissing it.)
+
+**Lean Reverse (R)** — adding it would annoy a meaningful set of users:
+- Forced flows, mandatory steps, removing an option users rely on
+- Intrusive notifications/popups, auto-enabled tracking, dark patterns
+- "Make X mandatory", "remove the ability to Y", "force users to Z"
+
+**Confidence.** Note low confidence when the issue is vague, mixes several features,
+or signals conflict (Questionable). Low-confidence items are candidates for a
+clarifying comment, not a confident label.
+
+## Demand signals (for ranking *within* a category)
+
+Kano gives the *tier*; these order issues inside a tier:
+- **Reactions / 👍 / votes** — revealed demand
+- **Comment volume & distinct participants** — breadth of interest
+- **Age** — a long-unmet Must-be is more urgent; a stale Indifferent is a drop candidate
+- **Effort** — from `effort:*`/`size:*`/`SP:*` labels or inferred scope
+- **Dependencies / blockers** — an item that unblocks others rises
+
+## Prioritization policy (Kano → backlog order)
+
+1. **Unmet Must-be first.** Bugs and broken basics produce active dissatisfaction
+   every day they remain. Clear these before adding anything new.
+2. **Performance next, by value/effort.** Order by demand signal ÷ effort so the
+   steepest satisfaction-per-cost work surfaces first.
+3. **A few Attractive bets.** Reserve limited capacity for 1–2 delighters per cycle
+   for differentiation — not the whole backlog, since their absence costs nothing.
+4. **Indifferent: deprioritize or drop.** Keep only if it unblocks a higher tier
+   (say so explicitly).
+5. **Reverse: don't ship as-is.** Recommend making it optional, scoping it down, or
+   closing with rationale. Never silently build it.

--- a/.claude/skills/kano-backlog/scripts/ensure_labels.sh
+++ b/.claude/skills/kano-backlog/scripts/ensure_labels.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Ensure the Kano + priority label set exists on a GitHub repo (idempotent).
+# Usage: ensure_labels.sh [--repo owner/name]
+# Uses `gh label create --force`, which creates the label or updates its
+# color/description if it already exists — safe to run repeatedly.
+set -euo pipefail
+
+REPO_ARG=()
+if [[ "${1:-}" == "--repo" && -n "${2:-}" ]]; then
+  REPO_ARG=(--repo "$2")
+fi
+
+# name|color(hex,no #)|description
+LABELS=(
+  "kano:must-be|b60205|Kano: basic expectation — absence causes strong dissatisfaction"
+  "kano:performance|fbca04|Kano: more/better linearly increases satisfaction"
+  "kano:attractive|0e8a16|Kano: delighter — presence wows, absence costs nothing"
+  "kano:indifferent|cccccc|Kano: no measurable effect on satisfaction"
+  "kano:reverse|5319e7|Kano: some users actively dislike this if added"
+  "priority:now|d93f0b|Pick up now (top of refined backlog)"
+  "priority:next|fbca04|Up next after current 'now' items"
+  "priority:later|0052cc|Valuable but deferred"
+)
+
+for entry in "${LABELS[@]}"; do
+  IFS='|' read -r name color desc <<<"$entry"
+  gh label create "$name" --color "$color" --description "$desc" --force "${REPO_ARG[@]}"
+done
+
+echo "Kano + priority labels ensured."

--- a/.claude/skills/kano-backlog/scripts/fetch_backlog.sh
+++ b/.claude/skills/kano-backlog/scripts/fetch_backlog.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Fetch open backlog issues as JSON for Kano analysis.
+# Usage: fetch_backlog.sh [--repo owner/name] [--limit N] [--label LABEL] [--search QUERY]
+# Emits a JSON array on stdout with the fields the skill needs. Reaction counts
+# arrive under reactionGroups; comment count under `comments`. Pull requests are
+# excluded automatically by `gh issue list`.
+set -euo pipefail
+
+REPO_ARG=()
+LIMIT=100
+EXTRA=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)   REPO_ARG=(--repo "$2"); shift 2 ;;
+    --limit)  LIMIT="$2"; shift 2 ;;
+    --label)  EXTRA+=(--label "$2"); shift 2 ;;
+    --search) EXTRA+=(--search "$2"); shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+gh issue list \
+  "${REPO_ARG[@]}" \
+  --state open \
+  --limit "$LIMIT" \
+  "${EXTRA[@]}" \
+  --json number,title,body,labels,createdAt,updatedAt,comments,reactionGroups,assignees,milestone

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 
 .claude/*
 !.claude/commands/
+!.claude/skills/
 .agents
 .idea
 skills-lock.json


### PR DESCRIPTION
## `/end-session`: backlog→GitHub-issue sync + Kano refinement

Extends the maintainer `/end-session` ritual so session wrap-up also keeps the GitHub backlog current — without changing its append-only / never-commit-docs ethos.

### New steps (after the doc-logging Steps 1–4)
- **Step 4.5 — Sync un-filed follow-ups to GitHub issues (propose, then apply).** Collects "potential issues" from the ROADMAP **Forward.** blocks + open `BUGS.md` entries that cite no GH issue, dedups against `gh issue list`, drafts the genuinely-unfiled ones, **presents them and waits for confirmation**, then `gh issue create`s on approval and writes the new `#`s back into the ROADMAP Forward block.
- **Step 4.6 — Kano refinement.** Invokes the existing **`kano-backlog`** skill (single source of truth) to categorize the full open backlog (`kano:*`/`priority:*`/`effort:*`) and recommend the next pick — run *after* 4.5 so it sees the new issues.

### Guardrails
- New **Iron rule 6**: GitHub issue creation + labels are the only outward writes, and happen **only after maintainer confirmation** (propose-then-apply). The "never commit" rule still governs the workspace docs.
- `allowed-tools` gains `Skill` (to invoke `kano-backlog`); Step 6 summary now reports issues created + the Kano next-pick.

Scope: edits `.claude/commands/end-session.md` only (the local maintainer command — not a shipped plugin command). No `src/` change, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
