### PR TITLE
fix(#303): correct Metro-port selection + worktree disambiguation

### DIFF
--- a/.changeset/metro-port-selection.md
+++ b/.changeset/metro-port-selection.md
@@ -1,0 +1,5 @@
+---
+"rn-dev-agent": patch
+---
+
+Fix #303: Metro-port discovery now prefers the port with an attached Hermes target over a merely-running one, and when several Metros have an app it auto-selects the one whose serving directory matches this worktree's project root (resolved via `findProjectRoot` + realpath, containment-aware). `cdp_status` surfaces all candidate Metros (`metro.candidates`) plus `projectRoot`/`servingCwd`, and warns when the connected Metro serves a different worktree — catching the silent trap where an agent verifies against the wrong worktree's JS bundle even with a single Metro running. `cdp_targets` (`discoverForList`) prefers the attached port too. Fail-open throughout (macOS `lsof`; degrades to prior behavior off-darwin or when paths can't be resolved).

--- a/docs/superpowers/plans/2026-06-16-303-metro-port-selection.md
+++ b/docs/superpowers/plans/2026-06-16-303-metro-port-selection.md
@@ -1,0 +1,916 @@
+# Metro-Port Selection + Worktree Disambiguation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `cdp_status`/discovery picks the Metro port that actually has the app attached (never a detached sibling-worktree Metro), auto-selects the Metro whose serving directory matches this worktree, and warns when the connected bundle is from a different worktree.
+
+**Architecture:** Replace first-match port discovery with best-match: probe all candidate ports in parallel, prefer one with attached Hermes targets, and when several have apps, pick the one whose `lsof`-resolved serving cwd equals this bridge's project root. A new fail-open `cdp/metro-cwd.ts` does PID→cwd resolution; `cdp_status` independently enumerates candidates + emits a cwd-mismatch warning (decoupled from the connect path so it works even when already connected).
+
+**Tech Stack:** TypeScript (Node ≥22), `node --test` unit tests importing compiled `dist/`, `lsof` (macOS-first, fail-open), Chrome DevTools Protocol over WebSocket.
+
+---
+
+## File Structure
+
+- **Create** `scripts/cdp-bridge/src/cdp/metro-cwd.ts` — PID/cwd resolution from a TCP port (`lsof`), memoized `pid→cwd`, macOS-gated, fail-open; plus `resolveProjectRoot()`.
+- **Modify** `scripts/cdp-bridge/src/cdp/discovery.ts` — add `discoverAllMetroPorts`, `selectMetroPort`, `enumerateMetroCandidates`; rewrite `discover()` selection; extend `AppDetachedError` with running-port list.
+- **Modify** `scripts/cdp-bridge/src/types.ts` — extend `StatusResult.metro` with `candidates`/`projectRoot`/`servingCwd` and add the `MetroCandidate` type.
+- **Modify** `scripts/cdp-bridge/src/tools/status.ts` — populate the new `metro.*` fields and emit the cwd-mismatch warning.
+- **Create** tests: `test/unit/metro-cwd.test.js`, `test/unit/discover-port-selection.test.js`, `test/unit/status-metro-mismatch.test.js`.
+- **Create** `.changeset/metro-port-selection.md`.
+
+All test files import from compiled `../../dist/...` (the `test` script runs `npm run build` first).
+
+---
+
+## Task 1: `metro-cwd.ts` — resolve a Metro's serving cwd from its port
+
+**Files:**
+- Create: `scripts/cdp-bridge/src/cdp/metro-cwd.ts`
+- Test: `scripts/cdp-bridge/test/unit/metro-cwd.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/unit/metro-cwd.test.js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseLsofPid,
+  parseLsofCwd,
+  cwdForPort,
+  pathMatchesRoot,
+  _resetMetroCwdCacheForTest,
+} from '../../dist/cdp/metro-cwd.js';
+
+test('parseLsofPid: first numeric line from `lsof -ti` output', () => {
+  assert.equal(parseLsofPid('12345\n'), 12345);
+  assert.equal(parseLsofPid('12345\n12346\n'), 12345);
+});
+
+test('parseLsofPid: null on empty / non-numeric', () => {
+  assert.equal(parseLsofPid(''), null);
+  assert.equal(parseLsofPid('\n  \n'), null);
+});
+
+test('parseLsofCwd: extracts the n-field from `lsof -Fn` machine output', () => {
+  const out = 'p12345\nfcwd\nn/Users/anton/GitHub/ix3030/test-app\n';
+  assert.equal(parseLsofCwd(out), '/Users/anton/GitHub/ix3030/test-app');
+});
+
+test('parseLsofCwd: null when no n-field present', () => {
+  assert.equal(parseLsofCwd('p12345\nfcwd\n'), null);
+});
+
+test('cwdForPort: composes pid→cwd via injected exec', () => {
+  _resetMetroCwdCacheForTest();
+  const calls = [];
+  const exec = (cmd, args) => {
+    calls.push(args.join(' '));
+    if (args.includes('-ti')) return '777\n';
+    return 'p777\nfcwd\nn/repo/worktreeA\n';
+  };
+  assert.equal(cwdForPort(8081, exec), '/repo/worktreeA');
+});
+
+test('cwdForPort: memoizes pid→cwd but re-resolves port→pid each call', () => {
+  _resetMetroCwdCacheForTest();
+  let pidCalls = 0;
+  let cwdCalls = 0;
+  const exec = (cmd, args) => {
+    if (args.includes('-ti')) { pidCalls++; return '777\n'; }
+    cwdCalls++; return 'p777\nfcwd\nn/repo/worktreeA\n';
+  };
+  cwdForPort(8081, exec);
+  cwdForPort(8081, exec);
+  assert.equal(pidCalls, 2, 'port→pid re-resolved each call (guards port reuse)');
+  assert.equal(cwdCalls, 1, 'pid→cwd memoized');
+});
+
+test('cwdForPort: fail-open — null when exec throws or returns junk', () => {
+  _resetMetroCwdCacheForTest();
+  const throwing = () => { throw new Error('lsof not found'); };
+  assert.equal(cwdForPort(8081, throwing), null);
+  _resetMetroCwdCacheForTest();
+  const noPid = (cmd, args) => (args.includes('-ti') ? '' : '');
+  assert.equal(cwdForPort(8081, noPid), null);
+});
+
+test('pathMatchesRoot: equal paths match', () => {
+  assert.equal(pathMatchesRoot('/repo/worktreeA', '/repo/worktreeA'), true);
+});
+
+test('pathMatchesRoot: serving cwd nested under root matches (monorepo app subdir, both directions)', () => {
+  assert.equal(pathMatchesRoot('/repo/worktreeA/app', '/repo/worktreeA'), true);
+  assert.equal(pathMatchesRoot('/repo/worktreeA', '/repo/worktreeA/app'), true);
+});
+
+test('pathMatchesRoot: sibling worktrees do NOT match (the #303 case)', () => {
+  assert.equal(pathMatchesRoot('/repo/worktreeB', '/repo/worktreeA'), false);
+});
+
+test('pathMatchesRoot: shared prefix without a separator boundary does NOT match', () => {
+  assert.equal(pathMatchesRoot('/repo/worktreeA-2', '/repo/worktreeA'), false);
+});
+
+test('pathMatchesRoot: null/undefined operands → false (fail-open)', () => {
+  assert.equal(pathMatchesRoot(null, '/repo/worktreeA'), false);
+  assert.equal(pathMatchesRoot('/repo/worktreeA', undefined), false);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/metro-cwd.test.js`
+Expected: FAIL — `Cannot find module '../../dist/cdp/metro-cwd.js'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/cdp/metro-cwd.ts
+import { execFileSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import { resolve, sep } from 'node:path';
+import { findProjectRoot } from '../nav-graph/storage.js';
+
+export const CWD_LSOF_TIMEOUT_MS = 800;
+
+export type ExecFn = (cmd: string, args: string[]) => string;
+
+const defaultExec: ExecFn = (cmd, args) =>
+  execFileSync(cmd, args, {
+    timeout: CWD_LSOF_TIMEOUT_MS,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+
+const pidCwdCache = new Map<number, string | null>();
+
+export function _resetMetroCwdCacheForTest(): void {
+  pidCwdCache.clear();
+}
+
+export function parseLsofPid(stdout: string): number | null {
+  for (const line of stdout.split('\n')) {
+    const n = parseInt(line.trim(), 10);
+    if (!isNaN(n) && n > 0) return n;
+  }
+  return null;
+}
+
+export function parseLsofCwd(stdout: string): string | null {
+  for (const line of stdout.split('\n')) {
+    if (line.startsWith('n')) {
+      const path = line.slice(1).trim();
+      if (path) return path;
+    }
+  }
+  return null;
+}
+
+function pidForPort(port: number, exec: ExecFn): number | null {
+  try {
+    return parseLsofPid(exec('lsof', ['-ti', `tcp:${port}`, '-sTCP:LISTEN']));
+  } catch {
+    return null;
+  }
+}
+
+function cwdForPid(pid: number, exec: ExecFn): string | null {
+  if (pidCwdCache.has(pid)) return pidCwdCache.get(pid) ?? null;
+  let cwd: string | null = null;
+  try {
+    cwd = parseLsofCwd(exec('lsof', ['-a', '-p', String(pid), '-d', 'cwd', '-Fn']));
+  } catch {
+    cwd = null;
+  }
+  pidCwdCache.set(pid, cwd);
+  return cwd;
+}
+
+function realpathOrResolve(p: string): string {
+  try {
+    return realpathSync(resolve(p)); // lsof reports realpaths; normalize both sides the same way
+  } catch {
+    return resolve(p); // path may not exist (unit fixtures / race) — fail-open to normalized
+  }
+}
+
+export function cwdForPort(port: number, exec: ExecFn = defaultExec): string | null {
+  // Platform guard only when using the real lsof; injected-exec tests still run on Linux CI.
+  if (exec === defaultExec && process.platform !== 'darwin') return null;
+  const pid = pidForPort(port, exec);
+  if (pid == null) return null;
+  const cwd = cwdForPid(pid, exec);
+  return cwd ? realpathOrResolve(cwd) : null;
+}
+
+/**
+ * Match a Metro's serving cwd against the bridge's project root. `lsof -d cwd`
+ * reports a realpath-resolved cwd, so BOTH sides are realpath-normalized before
+ * comparison (plain `resolve()` does not follow symlinks — a symlinked worktree
+ * or `/tmp`→`/private/tmp` would never `===`). Match = equal OR one contains the
+ * other on a path-separator boundary (Metro launched from a monorepo root serving
+ * an app subdir, or vice versa). Sibling worktrees never match.
+ */
+export function pathMatchesRoot(servingCwd: string | null, projectRoot: string | null | undefined): boolean {
+  if (!servingCwd || !projectRoot) return false;
+  const a = realpathOrResolve(servingCwd);
+  const b = realpathOrResolve(projectRoot);
+  if (a === b) return true;
+  return a.startsWith(b + sep) || b.startsWith(a + sep);
+}
+
+/**
+ * Bridge project root via the CANONICAL resolver (`findProjectRoot`: RN_PROJECT_ROOT
+ * → CLAUDE_USER_CWD → cwd → walk-up → sibling scan), realpath-normalized. Returns
+ * null when no RN project is found → cwd auto-pick + mismatch warning stay silent
+ * (fail-open). NOTE: must NOT re-derive from CLAUDE_USER_CWD/cwd directly — that is
+ * a different value than the rest of the bridge's project-root notion (plan review F1).
+ */
+export function resolveBridgeProjectRoot(): string | null {
+  const root = findProjectRoot();
+  return root ? realpathOrResolve(root) : null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/metro-cwd.test.js`
+Expected: PASS (all 12 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/anton_personal/GitHub/claude-react-native-dev-plugin
+git add scripts/cdp-bridge/src/cdp/metro-cwd.ts scripts/cdp-bridge/test/unit/metro-cwd.test.js
+git commit -S -m "feat(#303): metro-cwd — resolve a Metro's serving cwd from its port (fail-open)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `discoverAllMetroPorts` + `selectMetroPort` (pure selection)
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/cdp/discovery.ts` (add two exports + extend `AppDetachedError`)
+- Test: `scripts/cdp-bridge/test/unit/discover-port-selection.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/unit/discover-port-selection.test.js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { selectMetroPort, AppDetachedError } from '../../dist/cdp/discovery.js';
+
+const T = (description) => ({ id: 'page-1', title: 'RN', vm: 'Hermes', description });
+
+test('selectMetroPort: single attached port wins, no warning', () => {
+  const res = selectMetroPort(
+    [{ port: 8081, targets: [T('com.app')] }],
+    [8081, 8082],
+    { currentPort: 8082, cwdForPort: () => null },
+  );
+  assert.equal(res.port, 8081);
+  assert.equal(res.warning, undefined);
+});
+
+test('selectMetroPort: zero attached → AppDetachedError listing running ports', () => {
+  assert.throws(
+    () => selectMetroPort([], [8081, 8082], { currentPort: 8081, cwdForPort: () => null }),
+    (err) => err instanceof AppDetachedError && err.runningPorts.includes(8082),
+  );
+});
+
+test('selectMetroPort: projectRoot cwd-match beats sticky currentPort', () => {
+  const res = selectMetroPort(
+    [{ port: 8081, targets: [T('com.app')] }, { port: 8082, targets: [T('com.app')] }],
+    [8081, 8082],
+    {
+      currentPort: 8082, // sticky would pick 8082
+      projectRoot: '/repo/worktreeA',
+      cwdForPort: (p) => (p === 8081 ? '/repo/worktreeA' : '/repo/worktreeB'),
+    },
+  );
+  assert.equal(res.port, 8081, 'cwd match wins over stickiness');
+});
+
+test('selectMetroPort: preferredBundleId port-level tie-break when one port matches', () => {
+  const res = selectMetroPort(
+    [{ port: 8081, targets: [T('com.other')] }, { port: 8082, targets: [T('com.app')] }],
+    [8081, 8082],
+    { currentPort: 8081, preferredBundleId: 'com.app', cwdForPort: () => null },
+  );
+  assert.equal(res.port, 8082);
+});
+
+test('selectMetroPort: no cwd match, no pref → sticky currentPort + warning lists candidates', () => {
+  const res = selectMetroPort(
+    [{ port: 8081, targets: [T('com.app')] }, { port: 8082, targets: [T('com.app')] }],
+    [8081, 8082],
+    { currentPort: 8082, projectRoot: '/repo/none', cwdForPort: () => null },
+  );
+  assert.equal(res.port, 8082, 'sticky currentPort chosen');
+  assert.match(res.warning, /8081/);
+  assert.match(res.warning, /metroPort/);
+});
+
+test('selectMetroPort: sticky falls back to lowest attached when currentPort detached', () => {
+  const res = selectMetroPort(
+    [{ port: 8082, targets: [T('com.app')] }, { port: 19000, targets: [T('com.app')] }],
+    [8081, 8082, 19000],
+    { currentPort: 8081, cwdForPort: () => null },
+  );
+  assert.equal(res.port, 8082);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/discover-port-selection.test.js`
+Expected: FAIL — `selectMetroPort` is not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Edit `src/cdp/discovery.ts`. Add the cwd import at the top of the file (used by `selectMetroPort` and, in Task 3, `discover()`):
+
+```ts
+import { cwdForPort, resolveBridgeProjectRoot, pathMatchesRoot } from './metro-cwd.js';
+```
+
+First extend `AppDetachedError` to carry running ports. (`.port` is preserved for the message/back-compat only — verified in plan review: `recover-detached.ts` relaunches by the active *session's* deviceId/appId and never reads `.port`, and `status.ts` only does `err instanceof AppDetachedError`. So `.port` pointing at an arbitrary detached running port is harmless.)
+
+```ts
+export class AppDetachedError extends Error {
+  readonly port: number;
+  readonly runningPorts: number[];
+  constructor(port: number, runningPorts: number[] = [port]) {
+    super(
+      `Metro is up on port ${port}` +
+      (runningPorts.length > 1 ? ` (also running: ${runningPorts.join(', ')})` : '') +
+      ` but no live Metro advertises a Hermes debug target — the app isn't attached ` +
+      `(it may be on the Expo dev launcher, backgrounded, or crashed). Relaunch the app, ` +
+      `or call cdp_status to auto-relaunch and reconnect.`,
+    );
+    this.name = 'AppDetachedError';
+    this.port = port;
+    this.runningPorts = runningPorts;
+  }
+}
+```
+
+Add `discoverAllMetroPorts` (parallel probe) near `discoverMetroPort`:
+
+```ts
+export async function discoverAllMetroPorts(ports: number[], timeout: number): Promise<number[]> {
+  const checks = await Promise.all(
+    ports.map(async (p) => {
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), timeout);
+      try {
+        const resp = await fetch(`http://127.0.0.1:${p}/status`, { signal: ctrl.signal });
+        const text = await resp.text();
+        return text.includes('packager-status:running') ? p : null;
+      } catch {
+        return null;
+      } finally {
+        clearTimeout(timer);
+      }
+    }),
+  );
+  return checks.filter((p): p is number => p !== null);
+}
+```
+
+Add `selectMetroPort` (pure):
+
+```ts
+export interface AttachedPort {
+  port: number;
+  targets: HermesTarget[];
+}
+
+export interface SelectMetroPortCtx {
+  currentPort: number;
+  projectRoot?: string;
+  preferredBundleId?: string;
+  cwdForPort: (port: number) => string | null;
+}
+
+export function selectMetroPort(
+  attached: AttachedPort[],
+  runningPorts: number[],
+  ctx: SelectMetroPortCtx,
+): { port: number; warning?: string } {
+  if (attached.length === 0) {
+    throw new AppDetachedError(runningPorts[0] ?? ctx.currentPort, runningPorts);
+  }
+  if (attached.length === 1) {
+    return { port: attached[0].port };
+  }
+
+  // 1. projectRoot cwd-match (most specific worktree signal). pathMatchesRoot
+  //    realpath-normalizes both sides and allows monorepo subdir containment.
+  if (ctx.projectRoot) {
+    const matches = attached.filter((a) => pathMatchesRoot(ctx.cwdForPort(a.port), ctx.projectRoot));
+    if (matches.length === 1) return { port: matches[0].port };
+  }
+
+  // 2. preferredBundleId port-level tie-break (exactly one port has a target with it).
+  if (ctx.preferredBundleId) {
+    const pref = ctx.preferredBundleId.toLowerCase();
+    const prefPorts = attached.filter((a) =>
+      a.targets.some((t) => (t.description ?? '').toLowerCase() === pref),
+    );
+    if (prefPorts.length === 1) return { port: prefPorts[0].port };
+  }
+
+  // 3. sticky currentPort if attached, else lowest attached port + disambiguation warning.
+  const attachedPortNums = attached.map((a) => a.port).sort((x, y) => x - y);
+  const chosen = attachedPortNums.includes(ctx.currentPort) ? ctx.currentPort : attachedPortNums[0];
+  const list = attached
+    .map((a) => `:${a.port}${ctx.cwdForPort(a.port) ? ` (${ctx.cwdForPort(a.port)})` : ''}`)
+    .join(', ');
+  return {
+    port: chosen,
+    warning: `Multiple live Metros with an attached app: ${list}. Picked :${chosen}. Pass metroPort explicitly to choose a different worktree.`,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/discover-port-selection.test.js`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/cdp-bridge/src/cdp/discovery.ts scripts/cdp-bridge/test/unit/discover-port-selection.test.js
+git commit -S -m "feat(#303): discoverAllMetroPorts + selectMetroPort (prefer attached, cwd auto-pick)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Wire best-match selection into `discover()`
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/cdp/discovery.ts` (`discover()` body)
+- Test: extend `scripts/cdp-bridge/test/unit/discover-port-selection.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `discover-port-selection.test.js`. `discover()` uses module-level `fetch`, so stub `globalThis.fetch`:
+
+```js
+test('discover: skips detached first port for attached second port', async () => {
+  const { discover } = await import('../../dist/cdp/discovery.js');
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.includes('/status')) return { text: async () => 'packager-status:running' };
+    if (u.includes(':8082/json/list')) return { json: async () => [] }; // detached
+    if (u.includes(':8081/json/list')) return {
+      json: async () => [{
+        id: 'page-1', title: 'RN', vm: 'Hermes', description: 'com.app',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:8081/inspector/debug?page=1',
+      }],
+    };
+    return { json: async () => [], text: async () => '' };
+  };
+  try {
+    const res = await discover(8082, {}); // currentPort 8082 is the detached one
+    assert.equal(res.port, 8081, 'discovery chose the attached port, not the running-but-detached one');
+    assert.equal(res.targets.length, 1);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test('discover: all-detached still throws AppDetachedError', async () => {
+  const { discover, AppDetachedError } = await import('../../dist/cdp/discovery.js');
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.includes('/status')) return { text: async () => 'packager-status:running' };
+    return { json: async () => [] };
+  };
+  try {
+    await assert.rejects(discover(8081, {}), (e) => e instanceof AppDetachedError);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/discover-port-selection.test.js`
+Expected: FAIL — current `discover()` returns `:8082` (first running) and throws `AppDetachedError`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the body of `discover()` (the section from `const metroPort = await discoverMetroPort(...)` through `if (validTargets.length === 0) throw new AppDetachedError(metroPort);`) with best-match selection. (The `./metro-cwd.js` import was added at the top of `discovery.ts` in Task 2.)
+
+New `discover()` core (keep the existing `ports`/`hints`/logging prefix and the trailing `inferPlatforms`/`selectTarget`/return):
+
+```ts
+  const runningPorts = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
+  if (runningPorts.length === 0) {
+    throw new Error(
+      'Metro not found on ports ' + ports.join(', ') +
+      '. Is the dev server running? Try: npx expo start or npx react-native start',
+    );
+  }
+
+  const perPort = await Promise.all(
+    runningPorts.map(async (p) => {
+      try {
+        const raw = await fetchTargets(p, DISCOVERY_TIMEOUT_MS * 2);
+        const valid = filterValidTargets(raw).filter((t) => {
+          try {
+            const { hostname } = new URL(t.webSocketDebuggerUrl!);
+            return hostname === '127.0.0.1' || hostname === 'localhost';
+          } catch {
+            return false;
+          }
+        });
+        return { port: p, targets: valid };
+      } catch {
+        return { port: p, targets: [] as HermesTarget[] };
+      }
+    }),
+  );
+
+  const attached = perPort.filter((pp) => pp.targets.length > 0);
+  const { port: metroPort, warning: portWarning } = selectMetroPort(attached, runningPorts, {
+    currentPort,
+    projectRoot: resolveBridgeProjectRoot() ?? undefined,
+    preferredBundleId: filters.preferredBundleId,
+    cwdForPort: (p) => cwdForPort(p),
+  });
+  logger.info('CDP', `Metro selected on port ${metroPort} (running: ${runningPorts.join(', ')})`);
+
+  const validTargets = attached.find((pp) => pp.port === metroPort)!.targets;
+
+  inferPlatforms(validTargets);
+  const { targets: sorted, warning: selectWarning } = selectTarget(validTargets, filters);
+  const warning = [portWarning, selectWarning].filter(Boolean).join(' | ') || undefined;
+
+  logger.debug('CDP', `Found ${sorted.length} valid target(s): ${sorted.map(t => `${t.id} (${t.title}, platform=${t.platform ?? '?'})`).join(', ')}`);
+  return { port: metroPort, targets: sorted, warning };
+```
+
+`selectMetroPort` throws `AppDetachedError` when `attached` is empty, preserving the existing catch in `status.ts`.
+
+Also fix `discoverForList()` (the backing for `cdp_targets`, called from `cdp-client.ts:192`) so it can't disagree with the now-fixed `discover()` about which Metro it inspects (plan review F2). It does not need cwd auto-pick — just prefer a port with an attached target over a merely-running one. Replace its `discoverMetroPort` first-match call:
+
+```ts
+export async function discoverForList(
+  currentPort: number,
+  portHint?: number,
+): Promise<{ port: number; targets: HermesTarget[] }> {
+  const ports = [...new Set([portHint ?? currentPort, ...DEFAULT_PORTS])];
+  const running = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
+  if (running.length === 0) {
+    throw new Error('Metro not found on ports ' + ports.join(', '));
+  }
+  // Prefer a running port that has at least one valid target; else first running.
+  let chosen = running[0];
+  let targets: HermesTarget[] = [];
+  for (const p of running) {
+    try {
+      const valid = filterValidTargets(await fetchTargets(p, DISCOVERY_TIMEOUT_MS * 2));
+      if (valid.length > 0) { chosen = p; targets = valid; break; }
+    } catch { /* try next running port */ }
+  }
+  inferPlatforms(targets);
+  return { port: chosen, targets };
+}
+```
+
+Add a test in `discover-port-selection.test.js` for it:
+
+```js
+test('discoverForList: prefers a running port WITH targets over a detached one', async () => {
+  const { discoverForList } = await import('../../dist/cdp/discovery.js');
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.includes('/status')) return { text: async () => 'packager-status:running' };
+    if (u.includes(':8082/json/list')) return { json: async () => [] };
+    if (u.includes(':8081/json/list')) return {
+      json: async () => [{
+        id: 'page-1', title: 'RN', vm: 'Hermes', description: 'com.app',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:8081/inspector/debug?page=1',
+      }],
+    };
+    return { json: async () => [], text: async () => '' };
+  };
+  try {
+    const res = await discoverForList(8082);
+    assert.equal(res.port, 8081);
+    assert.equal(res.targets.length, 1);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/discover-port-selection.test.js`
+Expected: PASS (9 tests). Then run the discovery's existing tests to confirm no regression:
+Run: `node --test test/unit/*discovery*.test.js 2>/dev/null; node --test test/unit/*discover*.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/cdp-bridge/src/cdp/discovery.ts scripts/cdp-bridge/test/unit/discover-port-selection.test.js
+git commit -S -m "feat(#303): discover() picks the attached port, auto-selects by worktree cwd
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `cdp_status` candidates + cwd-mismatch warning
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/types.ts` (extend `StatusResult.metro`)
+- Modify: `scripts/cdp-bridge/src/cdp/discovery.ts` (add `enumerateMetroCandidates`)
+- Modify: `scripts/cdp-bridge/src/tools/status.ts` (`buildStatusResult` + handler warning)
+- Test: `scripts/cdp-bridge/test/unit/status-metro-mismatch.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+// test/unit/status-metro-mismatch.test.js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeMetroMismatch } from '../../dist/tools/status.js';
+
+test('computeMetroMismatch: warns when servingCwd !== projectRoot', () => {
+  const r = computeMetroMismatch({ servingCwd: '/repo/worktreeB', projectRoot: '/repo/worktreeA', port: 8082 });
+  assert.equal(r.mismatch, true);
+  assert.match(r.warning, /different worktree/i);
+  assert.match(r.warning, /8082/);
+});
+
+test('computeMetroMismatch: silent when equal', () => {
+  const r = computeMetroMismatch({ servingCwd: '/repo/worktreeA', projectRoot: '/repo/worktreeA', port: 8081 });
+  assert.equal(r.mismatch, false);
+  assert.equal(r.warning, undefined);
+});
+
+test('computeMetroMismatch: silent when serving cwd is an app subdir of the project root (monorepo)', () => {
+  const r = computeMetroMismatch({ servingCwd: '/repo/worktreeA/app', projectRoot: '/repo/worktreeA', port: 8081 });
+  assert.equal(r.mismatch, false);
+});
+
+test('computeMetroMismatch: silent when servingCwd unresolved (fail-open)', () => {
+  const r = computeMetroMismatch({ servingCwd: null, projectRoot: '/repo/worktreeA', port: 8081 });
+  assert.equal(r.mismatch, false);
+});
+
+test('computeMetroMismatch: silent when projectRoot unknown', () => {
+  const r = computeMetroMismatch({ servingCwd: '/repo/worktreeA', projectRoot: undefined, port: 8081 });
+  assert.equal(r.mismatch, false);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/status-metro-mismatch.test.js`
+Expected: FAIL — `computeMetroMismatch` not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/types.ts`, add the candidate type and extend `StatusResult.metro` (add fields after `eventsReason`):
+
+```ts
+export interface MetroCandidate {
+  port: number;
+  attached: boolean;
+  cwd: string | null;
+  isConnected: boolean;
+  matchesProjectRoot: boolean;
+}
+```
+
+```ts
+    // GH #303: worktree disambiguation diagnostics.
+    candidates?: MetroCandidate[];
+    projectRoot?: string;
+    servingCwd?: string | null;
+    timings_ms?: { probe: number; cwd: number };
+```
+
+In `src/cdp/discovery.ts`, add an enumeration helper for status (best-effort, reuses the probe + cwd):
+
+```ts
+export async function enumerateMetroCandidates(
+  connectedPort: number,
+  projectRoot: string | undefined,
+): Promise<{ candidates?: MetroCandidate[]; servingCwd: string | null; timings_ms: { probe: number; cwd: number } }> {
+  const t0 = performance.now();
+  const ports = [...new Set([connectedPort, ...DEFAULT_PORTS])];
+  const running = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
+  const tProbe = performance.now();
+
+  // Fast path (honors the spec's "single-Metro = one lsof"): only the connected
+  // Metro is up → skip per-port fetchTargets + extra lsof; resolve just the
+  // connected port's cwd for the mismatch check, and omit the candidates array.
+  if (running.length <= 1) {
+    const servingCwd = cwdForPort(connectedPort);
+    return { servingCwd, timings_ms: { probe: tProbe - t0, cwd: performance.now() - tProbe } };
+  }
+
+  // Ambiguous: >1 Metro running — enumerate attach state + cwd per port.
+  const candidates: MetroCandidate[] = [];
+  let servingCwd: string | null = null;
+  for (const p of running) {
+    let attached = false;
+    try {
+      attached = filterValidTargets(await fetchTargets(p, DISCOVERY_TIMEOUT_MS)).length > 0;
+    } catch { /* treat as detached */ }
+    const cwd = cwdForPort(p);
+    if (p === connectedPort) servingCwd = cwd;
+    candidates.push({
+      port: p,
+      attached,
+      cwd,
+      isConnected: p === connectedPort,
+      matchesProjectRoot: pathMatchesRoot(cwd, projectRoot),
+    });
+  }
+  if (servingCwd === null) servingCwd = cwdForPort(connectedPort);
+  return { candidates, servingCwd, timings_ms: { probe: tProbe - t0, cwd: performance.now() - tProbe } };
+}
+```
+
+Add `import type { MetroCandidate } from '../types.js';` to `discovery.ts`. (`performance` is the Node global — no import needed.)
+
+In `src/tools/status.ts`, add the pure helper and wire it. Add imports:
+
+```ts
+import { enumerateMetroCandidates } from '../cdp/discovery.js';
+import { resolveBridgeProjectRoot, pathMatchesRoot } from '../cdp/metro-cwd.js';
+```
+
+Pure helper (exported for the unit test) — uses `pathMatchesRoot` so a monorepo app subdir / symlinked path is NOT flagged as a mismatch:
+
+```ts
+export function computeMetroMismatch(args: {
+  servingCwd: string | null;
+  projectRoot: string | undefined;
+  port: number | null;
+}): { mismatch: boolean; warning?: string } {
+  const { servingCwd, projectRoot, port } = args;
+  if (!servingCwd || !projectRoot || pathMatchesRoot(servingCwd, projectRoot)) return { mismatch: false };
+  return {
+    mismatch: true,
+    warning:
+      `Connected Metro on :${port} is serving ${servingCwd}, but this session's project root is ${projectRoot} ` +
+      `— you may be verifying against a different worktree's bundle. Restart Metro in this worktree or pass metroPort.`,
+  };
+}
+```
+
+In `buildStatusResult`, after building the `metro` object, enrich it (best-effort) and return. Replace the `metro: { ... }` block's surroundings so that after `deviceSession` is computed you do:
+
+```ts
+  const projectRoot = resolveBridgeProjectRoot() ?? undefined;
+  let candidates: import('../types.js').MetroCandidate[] | undefined;
+  let servingCwd: string | null | undefined;
+  let metroTimings: { probe: number; cwd: number } | undefined;
+  try {
+    const enriched = await enumerateMetroCandidates(client.metroPort, projectRoot);
+    servingCwd = enriched.servingCwd;
+    candidates = enriched.candidates; // already omitted by the fast path when ≤1 Metro
+    metroTimings = enriched.timings_ms;
+  } catch { /* fail-open: omit diagnostics */ }
+```
+
+and add to the returned `metro` object (the `timings_ms` makes the added `cdp_status` discovery cost visible per the repo convention):
+
+```ts
+      candidates,
+      projectRoot,
+      servingCwd,
+      timings_ms: metroTimings,
+```
+
+In `createStatusHandler`, just before the final `return okResult(status, ...)` (after the `helpersInjected` block), insert the mismatch gate:
+
+```ts
+      const mismatch = computeMetroMismatch({
+        servingCwd: status.metro.servingCwd ?? null,
+        projectRoot: status.metro.projectRoot,
+        port: status.metro.port,
+      });
+      if (mismatch.mismatch) {
+        return warnResult(status, mismatch.warning!);
+      }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/status-metro-mismatch.test.js`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/cdp-bridge/src/types.ts scripts/cdp-bridge/src/cdp/discovery.ts scripts/cdp-bridge/src/tools/status.ts scripts/cdp-bridge/test/unit/status-metro-mismatch.test.js
+git commit -S -m "feat(#303): cdp_status surfaces Metro candidates + warns on worktree cwd mismatch
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Changeset, full suite, dist, device-verify
+
+**Files:**
+- Create: `.changeset/metro-port-selection.md`
+
+- [ ] **Step 1: Write the changeset**
+
+```markdown
+---
+"rn-dev-agent": patch
+"cdp-bridge": patch
+---
+
+Fix #303: Metro-port discovery now prefers the port with an attached Hermes target
+over a merely-running one, auto-selects the Metro whose serving directory matches
+this worktree's project root, and cdp_status surfaces all candidate Metros plus a
+warning when the connected bundle comes from a different worktree. Prevents silently
+verifying against the wrong worktree's JS bundle. Fail-open (macOS lsof).
+```
+
+- [ ] **Step 2: Run the full unit suite**
+
+Run: `cd scripts/cdp-bridge && npm test`
+Expected: PASS — all existing tests plus the ~26 new ones green. If a snapshot/count test asserts a fixed tool count, it is unaffected (no tools added).
+
+- [ ] **Step 3: Verify dist is rebuilt and committed**
+
+Run: `cd /Users/anton_personal/GitHub/claude-react-native-dev-plugin && git status --short scripts/cdp-bridge/dist`
+Expected: rebuilt `dist/cdp/metro-cwd.js`, `dist/cdp/discovery.js`, `dist/tools/status.js`, `dist/types.js` present. Stage them.
+
+- [ ] **Step 4: Commit changeset + dist**
+
+```bash
+git add .changeset/metro-port-selection.md scripts/cdp-bridge/dist
+git commit -S -m "chore(#303): changeset + rebuilt dist for Metro-port selection
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 5: Device-verify (manual, dev machine)**
+
+Two-worktree repro: start Metro in two worktrees (`:8081` app attached, `:8082` no app). Confirm:
+1. `cdp_status` (no `metroPort`) connects to `:8081`, not `:8082`.
+2. `metro.candidates` lists both with correct `attached`/`cwd`; the connected one has `isConnected: true`.
+3. With the app on a *different*-worktree Metro than this session's root, `cdp_status` returns the cwd-mismatch warning.
+4. With *all* Metros detached, `cdp_status` still returns `APP_DETACHED` and the iOS auto-relaunch path is unchanged.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Correctness (prefer attached) → Task 2 `selectMetroPort` + Task 3 `discover()`. ✓
+- `AppDetachedError` only when no live Metro attached + lists running ports → Task 2/3. ✓
+- cwd auto-pick by projectRoot → Task 1 (`metro-cwd`) + Task 2 (precedence). ✓
+- preferredBundleId port-level tie-break → Task 2. ✓
+- `cdp_status` candidates/projectRoot/servingCwd + mismatch warning → Task 4. ✓
+- Fail-open everywhere → Task 1 (null returns), Task 4 (`try/catch` enrichment). ✓
+- pid→cwd memoization, port→pid re-resolve → Task 1 test + impl. ✓
+- Testing matrix → Tasks 1–4 tests; device-verify → Task 5. ✓
+- `meta.timings_ms`: now IN SCOPE per plan review — `metro.timings_ms { probe, cwd }` is emitted from `enumerateMetroCandidates` and surfaced in the `cdp_status` result (Task 4). Makes the added discovery cost visible.
+- `discoverForList`/`cdp_targets` consistency → Task 3 (prefer attached port, so it can't disagree with `discover()`). (Added in plan review F2.)
+- projectRoot resolution via canonical `findProjectRoot()` + realpath + containment match → Task 1 (`resolveBridgeProjectRoot`/`pathMatchesRoot`). (Fixes plan review F1 — the headline feature would otherwise be dead/false-positive.)
+
+**2. Placeholder scan:** No TBD/TODO; every code step has full code. ✓
+
+**3. Type consistency:** `selectMetroPort(attached: AttachedPort[], runningPorts, ctx)` — same name/shape in Task 2 def and Task 3 call. `cwdForPort(port, exec?)` / `pathMatchesRoot` / `resolveBridgeProjectRoot` consistent across Tasks 1/2/3/4. `MetroCandidate` defined in types.ts (Task 4), imported in discovery.ts + used in status.ts. `computeMetroMismatch` signature identical in test (Task 4 Step 1) and impl (Step 3). `AppDetachedError(port, runningPorts?)` extended in Task 2, thrown in Task 2/3; `.port` is diagnostic-only (recover-detached relaunches by session, never reads it). ✓
+
+---
+
+## Amendments applied from the multi-LLM plan review (antigravity + codex, 2026-06-16)
+
+Both reviewers ran against the plan + spec + the real source before any code. Findings applied:
+
+- **F1 (BLOCKING — projectRoot was the wrong value).** The cwd auto-pick + mismatch warning compared `lsof`-realpath'd Metro cwd against `resolve(CLAUDE_USER_CWD ?? cwd)`, which (a) is not the bridge's canonical project root (that's `findProjectRoot()` — honors `RN_PROJECT_ROOT`, walks up to the RN `package.json`, sibling-scans) and (b) ignores symlinks (`lsof` returns realpaths like `/private/tmp/...`). The feature would have been dead/false-positive and the unit tests (hand-fed equal strings) wouldn't catch it. **Fix:** `resolveBridgeProjectRoot()` delegates to `findProjectRoot()` + `realpathSync`; new `pathMatchesRoot()` realpath-normalizes both sides and matches on equality OR path-separator-boundary containment (monorepo app subdir); siblings never match. Used in `selectMetroPort` step 1 and `computeMetroMismatch`.
+- **F2 (IMPORTANT — `cdp_targets` left on the buggy path).** `discoverForList()` still used first-match `discoverMetroPort`, so `cdp_targets` could inspect a different Metro than the now-fixed `discover()`/`cdp_status`. **Fix:** Task 3 routes `discoverForList` through `discoverAllMetroPorts` + attached-preference (no cwd auto-pick needed).
+- **F4 (IMPORTANT — hot-path double-probe).** `enumerateMetroCandidates` ran a full multi-port probe + per-port `fetchTargets`/`lsof` on every `cdp_status`, violating the spec's "single-Metro = one lsof." **Fix:** fast path returns just `cwdForPort(connectedPort)` (one lsof, no candidates) when ≤1 Metro is running; full enumeration only when >1.
+- **meta.timings_ms (convention).** Promoted from deferred to in-scope: `metro.timings_ms { probe, cwd }` surfaced on the `cdp_status` result.
+- **Verified clean by both:** lsof flags/parse correct; `cwdForPort` `exec===defaultExec` platform guard + memo test sound; test fetch stubs match `resp.json()`/`resp.text()`; `AppDetachedError`/`recover-detached` contract safe (no `.port` dependency); ports dedup + `RN_METRO_PORT` precedence preserved.

--- a/docs/superpowers/specs/2026-06-16-303-metro-port-selection-design.md
+++ b/docs/superpowers/specs/2026-06-16-303-metro-port-selection-design.md
@@ -1,0 +1,133 @@
+# GH #303 — Correct Metro-port selection + worktree disambiguation
+
+**Status:** Approved (2026-06-16)
+**Issue:** [#303](https://github.com/Lykhoyda/rn-dev-agent/issues/303) — `cdp_status` auto-detects the wrong Metro port with multiple worktree Metros, risking verification against the wrong bundle (`kano:must-be`, `priority:now`, `effort:m`)
+
+## Problem
+
+When two git worktrees each run their own Metro, `cdp_status` (called without `metroPort`) can lock onto the wrong port and return `APP_DETACHED`, masking that the app is attached and healthy on another port. The root cause is in discovery: `discoverMetroPort()` returns the **first** port that responds `packager-status:running` and never checks whether that Metro has an *attached Hermes target*. So with `:8081` (app attached) and `:8082` (no app), discovery can return `:8082`, `fetchTargets()` finds 0 valid targets, and `discover()` throws `AppDetachedError(8082)` — even though a healthy app sits on `:8081`.
+
+Two downstream harms follow:
+
+1. **Silent correctness trap.** An agent that trusts the default can drive/verify a feature against a *different worktree's JS bundle* and report success against code that isn't running. In the reporter's session the running app loaded JS from a sibling worktree (`homeaddress-gate` on `:8082`) while the changes under test lived in another worktree (`ix3030` on `:8081`).
+2. **Misguided auto-relaunch.** `cdp_status` catches `AppDetachedError` and triggers the iOS cold-restart recovery (`recoverDetached`) for the *wrong* port — actively making things worse when the app is healthy elsewhere.
+
+The fix replaces first-match with best-match, and — because the bridge already records its own `projectRoot` — makes "which worktree's bundle is live?" a deterministic equality check rather than a guess.
+
+## Scope (chosen)
+
+**Correctness + cwd auto-pick.** Three layers:
+
+1. **Correctness (must-be):** discovery prefers a port with attached Hermes targets over a merely-running one; `AppDetachedError` fires only when *no* live Metro has an app.
+2. **Worktree auto-pick:** when >1 live Metro has an app, resolve each Metro's serving cwd (PID→`lsof`) and auto-pick the one whose cwd matches this bridge's `projectRoot`.
+3. **Diagnostics:** `cdp_status` surfaces all candidate Metros `{port, attached, cwd}` and **warns** when the connected Metro's cwd differs from `projectRoot` — catching the trap even with a single Metro running.
+
+Every new path is **fail-open**: any `lsof` / non-macOS / permission failure degrades to the existing selection behavior. The fix can never *block* a connection it would have made before — it only makes a *better* choice when it can.
+
+## Architecture
+
+```
+discover(currentPort, filters)                           [cdp/discovery.ts]
+  ├─ discoverAllMetroPorts(ports, timeout): number[]      parallel /status probe (was: first-match)
+  ├─ for each running port: fetchTargets(p) → valid[]     parallel
+  ├─ attachedPorts = running.filter(valid.length > 0)
+  ├─ selectMetroPort(attachedPorts, runningPorts, ctx):   pure selection (new, unit-tested)
+  │     0 attached → AppDetachedError(runningPorts)
+  │     1 attached → that port
+  │     >1 attached → cwd-match(projectRoot) ▸ preferredBundleId ▸ sticky/lowest + warning
+  │     cwd resolved via metroCwd.cwdForPort(p)            [cdp/metro-cwd.ts — new, lsof, cached, fail-open]
+  └─ returns { port, targets, warning, candidates }
+
+cdp_status (status.ts)
+  ├─ metro.candidates / metro.projectRoot from discovery
+  └─ mismatch warning when connected metro.cwd !== projectRoot
+```
+
+### Component: `src/cdp/metro-cwd.ts` (new)
+
+Resolves a Metro listener's serving directory from its TCP port. macOS-first (`lsof`); fail-open everywhere else.
+
+- `metroPidForPort(port, exec?): number | null` — listener PID via `lsof -ti tcp:<port> -sTCP:LISTEN`. First numeric line; `null` on any failure / no listener.
+- `cwdForPid(pid, exec?): string | null` — `lsof -a -p <pid> -d cwd -Fn`, parse the `n`-prefixed field record (the `-F` machine format emits one field per line, `n<path>`). `null` on failure.
+- `cwdForPort(port, exec?): string | null` — compose the two. **Memoize `pid→cwd` only** (a process's cwd is immutable for its lifetime); always re-resolve `port→pid` per call so a port reused by a *new* Metro process (old one died, new one bound the same port) never returns a stale cwd. The repeat-call saving is the second `lsof` (pid→cwd); the first (`port→pid`) is paid each time but is cheap.
+- `exec` is an injectable seam (`(cmd, args) => string`) defaulting to `execFileSync` with a short timeout (`CWD_LSOF_TIMEOUT_MS = 800`) and `stdio: ['ignore','pipe','ignore']`. Unit tests pass fixtures — no subprocess in CI.
+- **Platform guard:** on non-darwin `process.platform`, return `null` immediately (no spawn). The feature degrades to selection-without-cwd off macOS, which is acceptable (the worktree-Metro scenario is a developer-machine case).
+
+### Component: `selectMetroPort()` (new, pure — in `discovery.ts`)
+
+```
+selectMetroPort(attached: number[], running: number[], ctx: {
+  currentPort: number; projectRoot?: string; preferredBundleId?: string;
+  cwdForPort: (port: number) => string | null;
+}): { port: number; warning?: string }
+```
+
+Deterministic precedence when `attached.length > 1`:
+
+1. **projectRoot-cwd match** — resolve cwd for each attached port; if exactly one `cwd === projectRoot` (path-normalized via `resolve()`), pick it. **This beats stickiness and preferredBundleId** — it is the most specific signal for "the worktree I belong to."
+2. **preferredBundleId (port-level)** — if cwd matching is inconclusive (0 matches, >1 match, or no cwd resolved) and a `preferredBundleId` is configured, and **exactly one** attached port has a target whose `description === preferredBundleId`, pick that port. (This is a genuine port-level signal — distinct from `selectTarget()`'s within-port target tie-break, which still runs afterward to choose among that port's targets.) If 0 or >1 ports match, fall through.
+3. **sticky / lowest + warning** — pick `currentPort` if it is in `attached` (avoids flapping), else the lowest attached port; attach a warning enumerating every candidate `{port, cwd}` and advising an explicit `metroPort`.
+
+`attached.length === 0` → throw `AppDetachedError` carrying the running ports. `attached.length === 1` → that port, no warning.
+
+### `AppDetachedError` change
+
+Constructor accepts the resolved port (unchanged primary) and an optional list of all running ports so the message reads `Metro is up on 8082 (also running: 8081, 8082) but no live Metro advertises a Hermes target…`. The single-port message is preserved when only one Metro is running (back-compat with `recover-detached.ts`, which reads `.port`).
+
+### `cdp_status` output + mismatch warning
+
+`StatusResult.metro` gains:
+- `candidates?: Array<{ port: number; attached: boolean; cwd: string | null; isConnected: boolean; matchesProjectRoot: boolean }>` — populated when discovery enumerated >1 running port; omitted for the single-Metro fast path to avoid needless `lsof`.
+- `projectRoot?: string` — the bridge's resolved project root (already known to `DeviceLock`/lockfile).
+- `servingCwd?: string | null` — the connected Metro's cwd.
+
+**Mismatch warning** (the real payoff): after a successful status read, if `servingCwd` resolves and `!== projectRoot` (both normalized), return `warnResult(status, "Connected Metro on :<port> is serving <servingCwd>, but this session's project root is <projectRoot> — you may be verifying against a different worktree's bundle. Restart Metro in this worktree or pass metroPort.")`. Fires even with a single Metro running. **Conservative:** only when both paths are confidently resolved and genuinely differ — never when `servingCwd`/`projectRoot` is null/unknown (no false alarms when started from a parent dir or off-macOS).
+
+## Data flow
+
+1. `cdp_status({ platform: "ios" })` → `autoConnect` → `discover(currentPort, filters)`.
+2. `discoverAllMetroPorts` probes `[currentPort, USER_METRO_PORT?, 8081, 8082, 19000, 19006]` (deduped) in parallel → running ports.
+3. `fetchTargets` (parallel) → attached ports.
+4. `selectMetroPort` picks the port (cwd-match for the worktree case).
+5. `discover` returns `{ port, targets, candidates }`; client connects to the chosen port.
+6. `buildStatusResult` attaches `metro.candidates / projectRoot / servingCwd`; the handler emits the mismatch warning if applicable.
+
+## Error handling — fail-open
+
+- `metro-cwd` never throws; all three functions return `null` on any error / non-macOS / no listener. Selection then skips step 1 and uses preferredBundleId/sticky.
+- `discoverAllMetroPorts` tolerates per-port probe failures (a port that errors is simply "not running"); a global fetch failure for one running port drops it from `attached` (treated as detached) rather than aborting discovery.
+- The mismatch warning is suppressed whenever either path is unresolved — an unknown cwd never produces a scary "wrong worktree" message.
+- `meta.timings_ms` instrumented on `discover` (`probe`, `fetchTargets`, `cwd`) per the repo convention, so the added cost is visible.
+
+## Performance
+
+- **Single Metro (common):** one extra `lsof` for the connected port's cwd (best-effort, memoized, ~10–40ms) to enable the mismatch check. No `candidates` array.
+- **Multiple Metros:** N parallel `/status` probes + N parallel `fetchTargets` + ≤N memoized `lsof` calls. Bounded by `DEFAULT_PORTS` (~5) and short timeouts (`DISCOVERY_TIMEOUT_MS = 1500`, `CWD_LSOF_TIMEOUT_MS = 800`).
+- Parallelizing the port probes (vs today's serial short-circuit) keeps multi-port discovery roughly as fast as the single-port path.
+
+## Testing (TDD)
+
+- **`metro-cwd.test.js`** (pure, injected exec): parse macOS `lsof -Fn` fixture → cwd; `lsof -ti` → PID; memoization (second call doesn't re-exec); fail-open on non-zero exit / empty output / thrown exec; non-darwin returns null without spawning.
+- **`discover-port-selection.test.js`** (mocked fetch + injected cwdForPort):
+  - detached first port (`:8082` 0 targets) is skipped for attached second port (`:8081`) — the core regression.
+  - 0 attached → `AppDetachedError` listing all running ports.
+  - 1 attached → that port, no warning.
+  - >1 attached, exactly one cwd === projectRoot → that port (beats stickiness: currentPort is the *other* attached port).
+  - >1 attached, no cwd match → warning enumerates candidates; sticky currentPort chosen when attached, else lowest.
+  - cwd unresolved (cwdForPort → null) → no crash, falls back to sticky/lowest + warning.
+- **`status-metro-mismatch.test.js`**: mismatch warning fires when servingCwd ≠ projectRoot; silent when equal; silent when servingCwd null; `candidates`/`projectRoot` present in output for multi-Metro, absent for single-Metro fast path.
+- Full existing suite stays green (no behavior change for the single-healthy-Metro path beyond the additive cwd read).
+
+## Device verification
+
+On the dev machine, reproduce the two-worktree setup (two Metros on `:8081`/`:8082`, app attached on one) and confirm: (a) `cdp_status` with no `metroPort` connects to the attached port, (b) `metro.candidates` enumerates both with correct `cwd`/`attached`, (c) the mismatch warning fires when the connected Metro's cwd ≠ this worktree, (d) genuine all-detached still returns `APP_DETACHED` + iOS auto-relaunch unchanged.
+
+## Out of scope
+
+The issue's "secondary friction" is unrelated to port selection and excluded from #303:
+- maestro-runner login failing at "Checking WDA install" — separate WDA-lifecycle concern.
+- `device_screenshot` reporting non-existent paths — already mitigated by the `xcrun simctl io screenshot` fallback (D1249); file separately if it recurs.
+
+## Refs
+
+GH #303. Touches `src/cdp/discovery.ts`, new `src/cdp/metro-cwd.ts`, `src/tools/status.ts`, `src/types.ts` (StatusResult.metro). Related: GH #208 (`AppDetachedError` / `recover-detached.ts`), B111/D643 (`selectTarget`), D1249 (screenshot fallback).

--- a/scripts/cdp-bridge/dist/cdp/discovery.js
+++ b/scripts/cdp-bridge/dist/cdp/discovery.js
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { logger } from '../logger.js';
+import { cwdForPort, pathMatchesRoot, resolveBridgeProjectRoot } from './metro-cwd.js';
 /**
  * GH #208 (RC2): thrown by `discover()` when Metro IS reachable but advertises
  * zero Hermes debug targets — the app has detached (Expo dev launcher,
@@ -10,12 +11,21 @@ import { logger } from '../logger.js';
  */
 export class AppDetachedError extends Error {
     port;
-    constructor(port) {
-        super(`Metro is up on port ${port} but advertises 0 Hermes debug targets — the app isn't attached ` +
+    /**
+     * GH #303: all Metro ports found running at throw time. `.port` is preserved
+     * for back-compat/diagnostics only — recover-detached.ts relaunches by the
+     * active session's deviceId/appId and never reads it.
+     */
+    runningPorts;
+    constructor(port, runningPorts = [port]) {
+        super(`Metro is up on port ${port}` +
+            (runningPorts.length > 1 ? ` (also running: ${runningPorts.join(', ')})` : '') +
+            ` but advertises 0 Hermes debug targets — the app isn't attached ` +
             `(it may be on the Expo dev launcher, backgrounded, or crashed). Relaunch the app, ` +
             `or call cdp_status to auto-relaunch and reconnect.`);
         this.name = 'AppDetachedError';
         this.port = port;
+        this.runningPorts = runningPorts;
     }
 }
 export const DISCOVERY_TIMEOUT_MS = 1500;
@@ -24,25 +34,30 @@ export const DEFAULT_PORTS = [
     ...(USER_METRO_PORT && !isNaN(USER_METRO_PORT) ? [USER_METRO_PORT] : []),
     8081, 8082, 19000, 19006,
 ];
-export async function discoverMetroPort(ports, timeout) {
-    for (const p of ports) {
+/**
+ * GH #303: probe ALL candidate ports in parallel and return every one that is a
+ * running Metro. The caller then prefers a port with an attached Hermes target
+ * so a detached sibling-worktree Metro can't shadow a healthy one. (Replaces the
+ * old first-match `discoverMetroPort`.) Closed localhost ports refuse fast (no
+ * per-port timeout cost); only ports that accept but stall hit the timeout.
+ */
+export async function discoverAllMetroPorts(ports, timeout) {
+    const checks = await Promise.all(ports.map(async (p) => {
         const ctrl = new AbortController();
         const timer = setTimeout(() => ctrl.abort(), timeout);
         try {
             const resp = await fetch(`http://127.0.0.1:${p}/status`, { signal: ctrl.signal });
             const text = await resp.text();
-            if (text.includes('packager-status:running')) {
-                return p;
-            }
+            return text.includes('packager-status:running') ? p : null;
         }
         catch {
-            // Port not available, continue scanning
+            return null;
         }
         finally {
             clearTimeout(timer);
         }
-    }
-    return null;
+    }));
+    return checks.filter((p) => p !== null);
 }
 export async function fetchTargets(port, timeout) {
     const ctrl = new AbortController();
@@ -268,6 +283,51 @@ export function selectTarget(validTargets, filtersOrPlatform) {
     });
     return { targets: sorted, warning: warnings.length > 0 ? warnings.join(' | ') : undefined };
 }
+/**
+ * GH #303: pick the right Metro port among those running. Correctness first
+ * (only `attached` ports — those with a live Hermes target — are candidates),
+ * then worktree disambiguation. Pure + injectable (`cwdForPort`) for testing.
+ *
+ * Precedence when >1 port is attached:
+ *   1. projectRoot cwd-match — the Metro whose serving dir is (or contains / is
+ *      contained by) this bridge's project root. Most specific worktree signal.
+ *   2. preferredBundleId — exactly one attached port serves the preferred bundle.
+ *   3. sticky currentPort if attached, else lowest attached port + a warning.
+ */
+export function selectMetroPort(attached, runningPorts, ctx) {
+    if (attached.length === 0) {
+        throw new AppDetachedError(runningPorts[0] ?? ctx.currentPort, runningPorts);
+    }
+    if (attached.length === 1) {
+        return { port: attached[0].port };
+    }
+    // 1. projectRoot cwd-match (realpath-normalized, containment-aware).
+    if (ctx.projectRoot) {
+        const matches = attached.filter((a) => pathMatchesRoot(ctx.cwdForPort(a.port), ctx.projectRoot));
+        if (matches.length === 1)
+            return { port: matches[0].port };
+    }
+    // 2. preferredBundleId port-level tie-break (exactly one attached port serves it).
+    if (ctx.preferredBundleId) {
+        const pref = ctx.preferredBundleId.toLowerCase();
+        const prefPorts = attached.filter((a) => a.targets.some((t) => (t.description ?? '').toLowerCase() === pref));
+        if (prefPorts.length === 1)
+            return { port: prefPorts[0].port };
+    }
+    // 3. sticky currentPort if attached, else lowest attached port + disambiguation warning.
+    const attachedPortNums = attached.map((a) => a.port).sort((x, y) => x - y);
+    const chosen = attachedPortNums.includes(ctx.currentPort) ? ctx.currentPort : attachedPortNums[0];
+    const list = attached
+        .map((a) => {
+        const cwd = ctx.cwdForPort(a.port);
+        return `:${a.port}${cwd ? ` (${cwd})` : ''}`;
+    })
+        .join(', ');
+    return {
+        port: chosen,
+        warning: `Multiple live Metros with an attached app: ${list}. Picked :${chosen}. Pass metroPort explicitly to choose a different worktree.`,
+    };
+}
 export async function discover(currentPort, platformFilterOrFilters) {
     const filters = typeof platformFilterOrFilters === 'string'
         ? { platform: platformFilterOrFilters }
@@ -283,38 +343,109 @@ export async function discover(currentPort, platformFilterOrFilters) {
     if (filters.preferredBundleId)
         hints.push(`preferredBundleId=${filters.preferredBundleId}`);
     logger.debug('CDP', `Discovering Metro on ports: ${ports.join(', ')}${hints.length ? ` (${hints.join(', ')})` : ''}`);
-    const metroPort = await discoverMetroPort(ports, DISCOVERY_TIMEOUT_MS);
-    if (!metroPort) {
+    // GH #303: probe ALL candidate ports, then prefer one with an attached Hermes
+    // target so a detached sibling-worktree Metro can't shadow a healthy one.
+    const runningPorts = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
+    if (runningPorts.length === 0) {
         throw new Error('Metro not found on ports ' + ports.join(', ') +
             '. Is the dev server running? Try: npx expo start or npx react-native start');
     }
-    logger.info('CDP', `Metro found on port ${metroPort}`);
-    const raw = await fetchTargets(metroPort, DISCOVERY_TIMEOUT_MS * 2);
-    const validTargets = filterValidTargets(raw).filter(t => {
+    const perPort = await Promise.all(runningPorts.map(async (p) => {
         try {
-            const { hostname } = new URL(t.webSocketDebuggerUrl);
-            return hostname === '127.0.0.1' || hostname === 'localhost';
+            const raw = await fetchTargets(p, DISCOVERY_TIMEOUT_MS * 2);
+            const valid = filterValidTargets(raw).filter(t => {
+                try {
+                    const { hostname } = new URL(t.webSocketDebuggerUrl);
+                    return hostname === '127.0.0.1' || hostname === 'localhost';
+                }
+                catch {
+                    return false;
+                }
+            });
+            return { port: p, targets: valid };
         }
         catch {
-            return false;
+            return { port: p, targets: [] };
         }
+    }));
+    const attached = perPort.filter((pp) => pp.targets.length > 0);
+    // selectMetroPort throws AppDetachedError when nothing is attached (preserving
+    // the existing catch in status.ts), carrying the full running-port list.
+    const { port: metroPort, warning: portWarning } = selectMetroPort(attached, runningPorts, {
+        currentPort,
+        projectRoot: resolveBridgeProjectRoot() ?? undefined,
+        preferredBundleId: filters.preferredBundleId,
+        cwdForPort: (p) => cwdForPort(p),
     });
-    if (validTargets.length === 0) {
-        throw new AppDetachedError(metroPort);
-    }
+    logger.info('CDP', `Metro selected on port ${metroPort} (running: ${runningPorts.join(', ')})`);
+    const validTargets = attached.find((pp) => pp.port === metroPort).targets;
     inferPlatforms(validTargets);
-    const { targets: sorted, warning } = selectTarget(validTargets, filters);
+    const { targets: sorted, warning: selectWarning } = selectTarget(validTargets, filters);
+    const warning = [portWarning, selectWarning].filter(Boolean).join(' | ') || undefined;
     logger.debug('CDP', `Found ${sorted.length} valid target(s): ${sorted.map(t => `${t.id} (${t.title}, platform=${t.platform ?? '?'})`).join(', ')}`);
     return { port: metroPort, targets: sorted, warning };
 }
 export async function discoverForList(currentPort, portHint) {
     const ports = [...new Set([portHint ?? currentPort, ...DEFAULT_PORTS])];
-    const metroPort = await discoverMetroPort(ports, DISCOVERY_TIMEOUT_MS);
-    if (!metroPort) {
+    // GH #303: prefer a running port that actually has targets over the first
+    // running one, so cdp_targets can't inspect a different Metro than discover()
+    // selected. No cwd auto-pick needed here — just attached-preference.
+    const running = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
+    if (running.length === 0) {
         throw new Error('Metro not found on ports ' + ports.join(', '));
     }
-    const raw = await fetchTargets(metroPort, DISCOVERY_TIMEOUT_MS * 2);
-    const targets = filterValidTargets(raw);
+    let chosen = running[0];
+    let targets = [];
+    for (const p of running) {
+        try {
+            const valid = filterValidTargets(await fetchTargets(p, DISCOVERY_TIMEOUT_MS * 2));
+            if (valid.length > 0) {
+                chosen = p;
+                targets = valid;
+                break;
+            }
+        }
+        catch { /* try next running port */ }
+    }
     inferPlatforms(targets);
-    return { port: metroPort, targets };
+    return { port: chosen, targets };
+}
+/**
+ * GH #303: best-effort enumeration of live Metros for cdp_status diagnostics —
+ * decoupled from discover() so it works even on the already-connected path. Fast
+ * path (honors the spec's "single-Metro = one lsof"): when only the connected
+ * Metro is up, skip per-port fetchTargets + extra lsof and resolve just the
+ * connected port's cwd for the mismatch check, omitting the candidates array.
+ */
+export async function enumerateMetroCandidates(connectedPort, projectRoot) {
+    const t0 = performance.now();
+    const ports = [...new Set([connectedPort, ...DEFAULT_PORTS])];
+    const running = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
+    const tProbe = performance.now();
+    if (running.length <= 1) {
+        const servingCwd = cwdForPort(connectedPort);
+        return { servingCwd, timings_ms: { probe: tProbe - t0, cwd: performance.now() - tProbe } };
+    }
+    const candidates = [];
+    let servingCwd = null;
+    for (const p of running) {
+        let attached = false;
+        try {
+            attached = filterValidTargets(await fetchTargets(p, DISCOVERY_TIMEOUT_MS)).length > 0;
+        }
+        catch { /* treat as detached */ }
+        const cwd = cwdForPort(p);
+        if (p === connectedPort)
+            servingCwd = cwd;
+        candidates.push({
+            port: p,
+            attached,
+            cwd,
+            isConnected: p === connectedPort,
+            matchesProjectRoot: pathMatchesRoot(cwd, projectRoot),
+        });
+    }
+    if (servingCwd === null)
+        servingCwd = cwdForPort(connectedPort);
+    return { candidates, servingCwd, timings_ms: { probe: tProbe - t0, cwd: performance.now() - tProbe } };
 }

--- a/scripts/cdp-bridge/dist/cdp/metro-cwd.js
+++ b/scripts/cdp-bridge/dist/cdp/metro-cwd.js
@@ -1,0 +1,83 @@
+import { execFileSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import { resolve, sep } from 'node:path';
+import { findProjectRoot } from '../nav-graph/storage.js';
+export const CWD_LSOF_TIMEOUT_MS = 800;
+const defaultExec = (cmd, args) => execFileSync(cmd, args, {
+    timeout: CWD_LSOF_TIMEOUT_MS,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+});
+const pidCwdCache = new Map();
+export function _resetMetroCwdCacheForTest() {
+    pidCwdCache.clear();
+}
+export function parseLsofPid(stdout) {
+    for (const line of stdout.split('\n')) {
+        const n = parseInt(line.trim(), 10);
+        if (!isNaN(n) && n > 0)
+            return n;
+    }
+    return null;
+}
+export function parseLsofCwd(stdout) {
+    for (const line of stdout.split('\n')) {
+        if (line.startsWith('n')) {
+            const path = line.slice(1).trim();
+            if (path)
+                return path;
+        }
+    }
+    return null;
+}
+function pidForPort(port, exec) {
+    try {
+        return parseLsofPid(exec('lsof', ['-ti', `tcp:${port}`, '-sTCP:LISTEN']));
+    }
+    catch {
+        return null;
+    }
+}
+function cwdForPid(pid, exec) {
+    if (pidCwdCache.has(pid))
+        return pidCwdCache.get(pid) ?? null;
+    let cwd = null;
+    try {
+        cwd = parseLsofCwd(exec('lsof', ['-a', '-p', String(pid), '-d', 'cwd', '-Fn']));
+    }
+    catch {
+        cwd = null;
+    }
+    pidCwdCache.set(pid, cwd);
+    return cwd;
+}
+function realpathOrResolve(p) {
+    try {
+        return realpathSync(resolve(p));
+    }
+    catch {
+        return resolve(p);
+    }
+}
+export function cwdForPort(port, exec = defaultExec) {
+    if (exec === defaultExec && process.platform !== 'darwin')
+        return null;
+    const pid = pidForPort(port, exec);
+    if (pid == null)
+        return null;
+    const cwd = cwdForPid(pid, exec);
+    return cwd ? realpathOrResolve(cwd) : null;
+}
+export function pathMatchesRoot(servingCwd, projectRoot) {
+    if (!servingCwd || !projectRoot)
+        return false;
+    const a = realpathOrResolve(servingCwd);
+    const b = realpathOrResolve(projectRoot);
+    if (a === b)
+        return true;
+    return a.startsWith(b + sep) || b.startsWith(a + sep);
+}
+export function resolveBridgeProjectRoot() {
+    const root = findProjectRoot();
+    return root ? realpathOrResolve(root) : null;
+}

--- a/scripts/cdp-bridge/dist/tools/status.js
+++ b/scripts/cdp-bridge/dist/tools/status.js
@@ -8,7 +8,8 @@ import { recoverWedge } from '../cdp/recover-wedge.js';
 import { recoverDetached } from '../cdp/recover-detached.js';
 import { buildNotInstalledAdvice } from '../cdp/app-installed-probe.js';
 import { snapshotHintForBundleId } from './resolve-ios-app-file.js';
-import { AppDetachedError } from '../cdp/discovery.js';
+import { AppDetachedError, enumerateMetroCandidates } from '../cdp/discovery.js';
+import { resolveBridgeProjectRoot, pathMatchesRoot } from '../cdp/metro-cwd.js';
 import { getDeviceSessionHealth } from './device-session-health.js';
 import { detectIosExternalRunner } from '../runners/external-runner-detect.js';
 import { bridgeEnvState } from '../lifecycle/supervisor-core.js';
@@ -17,6 +18,23 @@ import { bridgeEnvState } from '../lifecycle/supervisor-core.js';
 // helper versions that might emit new tokens we don't recognize yet.
 export function narrowArchitecture(raw) {
     return raw === 'new' || raw === 'old' ? raw : 'unknown';
+}
+/**
+ * GH #303: flag when the connected Metro is serving a DIFFERENT worktree than
+ * this session's project root — the silent "verifying the wrong bundle" trap.
+ * Uses pathMatchesRoot so a monorepo app subdir / symlinked path is not flagged.
+ * Fail-open: silent whenever either path is unresolved (never a false alarm).
+ */
+export function computeMetroMismatch(args) {
+    const { servingCwd, projectRoot, port } = args;
+    if (!servingCwd || !projectRoot || pathMatchesRoot(servingCwd, projectRoot)) {
+        return { mismatch: false };
+    }
+    return {
+        mismatch: true,
+        warning: `Connected Metro on :${port} is serving ${servingCwd}, but this session's project root is ${projectRoot} ` +
+            `— you may be verifying against a different worktree's bundle. Restart Metro in this worktree or pass metroPort.`,
+    };
 }
 const STATUS_PROBE_EXPRESSION = `
 (function() {
@@ -55,6 +73,18 @@ async function buildStatusResult(client) {
     const deviceSession = await getDeviceSessionHealth({
         detectForeign: async (udid) => (await detectIosExternalRunner(undefined, udid)) ? { detected: true } : null,
     });
+    // GH #303: worktree-disambiguation diagnostics — best-effort, fail-open.
+    const projectRoot = resolveBridgeProjectRoot() ?? undefined;
+    let candidates;
+    let servingCwd;
+    let metroTimings;
+    try {
+        const enriched = await enumerateMetroCandidates(client.metroPort, projectRoot);
+        servingCwd = enriched.servingCwd;
+        candidates = enriched.candidates; // omitted by the fast path when ≤1 Metro is up
+        metroTimings = enriched.timings_ms;
+    }
+    catch { /* fail-open: omit diagnostics */ }
     return {
         metro: {
             running: true,
@@ -63,6 +93,10 @@ async function buildStatusResult(client) {
             lastBuild: metroEvents?.lastBuild ?? null,
             buildErrors: metroEvents?.buildErrors ?? 0,
             eventsReason: metroEvents?.incompatibleReason ?? null,
+            candidates,
+            projectRoot,
+            servingCwd,
+            timings_ms: metroTimings,
         },
         cdp: { connected: client.isConnected, device: client.connectedTarget?.title ?? null, pageId: client.connectedTarget?.id ?? null, platform: client.connectedTarget?.platform ?? null, bundleId: client.connectedTarget?.description ?? null },
         app: {
@@ -263,6 +297,15 @@ export function createStatusHandler(getClient, setClient, createClient, deps = {
                 && !status.app.hasRedBox
                 && status.app.errorCount === 0) {
                 return warnResult(status, 'CDP connected but app helpers not injected and no JS errors captured. The app may have crashed natively before __RN_AGENT loaded (e.g. missing native module, failed bundle fetch). Call cdp_native_errors to inspect the platform log.');
+            }
+            // GH #303: the connected Metro serves a different worktree than this session.
+            const mismatch = computeMetroMismatch({
+                servingCwd: status.metro.servingCwd ?? null,
+                projectRoot: status.metro.projectRoot,
+                port: status.metro.port,
+            });
+            if (mismatch.mismatch) {
+                return warnResult(status, mismatch.warning);
             }
             return okResult(status, autoRecoveredMessage ? { meta: { autoRecovered: autoRecoveredMessage } } : undefined);
         }

--- a/scripts/cdp-bridge/src/cdp/discovery.ts
+++ b/scripts/cdp-bridge/src/cdp/discovery.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { logger } from '../logger.js';
 import type { HermesTarget } from '../types.js';
+import { pathMatchesRoot } from './metro-cwd.js';
 
 /**
  * GH #208 (RC2): thrown by `discover()` when Metro IS reachable but advertises
@@ -12,14 +13,23 @@ import type { HermesTarget } from '../types.js';
  */
 export class AppDetachedError extends Error {
   readonly port: number;
-  constructor(port: number) {
+  /**
+   * GH #303: all Metro ports found running at throw time. `.port` is preserved
+   * for back-compat/diagnostics only — recover-detached.ts relaunches by the
+   * active session's deviceId/appId and never reads it.
+   */
+  readonly runningPorts: number[];
+  constructor(port: number, runningPorts: number[] = [port]) {
     super(
-      `Metro is up on port ${port} but advertises 0 Hermes debug targets — the app isn't attached ` +
+      `Metro is up on port ${port}` +
+      (runningPorts.length > 1 ? ` (also running: ${runningPorts.join(', ')})` : '') +
+      ` but no live Metro advertises a Hermes debug target — the app isn't attached ` +
       `(it may be on the Expo dev launcher, backgrounded, or crashed). Relaunch the app, ` +
       `or call cdp_status to auto-relaunch and reconnect.`,
     );
     this.name = 'AppDetachedError';
     this.port = port;
+    this.runningPorts = runningPorts;
   }
 }
 
@@ -47,6 +57,33 @@ export async function discoverMetroPort(ports: number[], timeout: number): Promi
     }
   }
   return null;
+}
+
+/**
+ * GH #303: probe ALL candidate ports in parallel and return every one that is a
+ * running Metro (vs `discoverMetroPort` which short-circuits on the first). The
+ * caller then prefers a port with an attached Hermes target so a detached
+ * sibling-worktree Metro can't shadow a healthy one. Closed localhost ports
+ * refuse fast (no per-port timeout cost); only ports that accept but stall hit
+ * the timeout.
+ */
+export async function discoverAllMetroPorts(ports: number[], timeout: number): Promise<number[]> {
+  const checks = await Promise.all(
+    ports.map(async (p) => {
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), timeout);
+      try {
+        const resp = await fetch(`http://127.0.0.1:${p}/status`, { signal: ctrl.signal });
+        const text = await resp.text();
+        return text.includes('packager-status:running') ? p : null;
+      } catch {
+        return null;
+      } finally {
+        clearTimeout(timer);
+      }
+    }),
+  );
+  return checks.filter((p): p is number => p !== null);
 }
 
 export async function fetchTargets(port: number, timeout: number): Promise<HermesTarget[]> {
@@ -310,6 +347,71 @@ export function selectTarget(
   });
 
   return { targets: sorted, warning: warnings.length > 0 ? warnings.join(' | ') : undefined };
+}
+
+export interface AttachedPort {
+  port: number;
+  targets: HermesTarget[];
+}
+
+export interface SelectMetroPortCtx {
+  currentPort: number;
+  projectRoot?: string;
+  preferredBundleId?: string;
+  cwdForPort: (port: number) => string | null;
+}
+
+/**
+ * GH #303: pick the right Metro port among those running. Correctness first
+ * (only `attached` ports — those with a live Hermes target — are candidates),
+ * then worktree disambiguation. Pure + injectable (`cwdForPort`) for testing.
+ *
+ * Precedence when >1 port is attached:
+ *   1. projectRoot cwd-match — the Metro whose serving dir is (or contains / is
+ *      contained by) this bridge's project root. Most specific worktree signal.
+ *   2. preferredBundleId — exactly one attached port serves the preferred bundle.
+ *   3. sticky currentPort if attached, else lowest attached port + a warning.
+ */
+export function selectMetroPort(
+  attached: AttachedPort[],
+  runningPorts: number[],
+  ctx: SelectMetroPortCtx,
+): { port: number; warning?: string } {
+  if (attached.length === 0) {
+    throw new AppDetachedError(runningPorts[0] ?? ctx.currentPort, runningPorts);
+  }
+  if (attached.length === 1) {
+    return { port: attached[0].port };
+  }
+
+  // 1. projectRoot cwd-match (realpath-normalized, containment-aware).
+  if (ctx.projectRoot) {
+    const matches = attached.filter((a) => pathMatchesRoot(ctx.cwdForPort(a.port), ctx.projectRoot));
+    if (matches.length === 1) return { port: matches[0].port };
+  }
+
+  // 2. preferredBundleId port-level tie-break (exactly one attached port serves it).
+  if (ctx.preferredBundleId) {
+    const pref = ctx.preferredBundleId.toLowerCase();
+    const prefPorts = attached.filter((a) =>
+      a.targets.some((t) => (t.description ?? '').toLowerCase() === pref),
+    );
+    if (prefPorts.length === 1) return { port: prefPorts[0].port };
+  }
+
+  // 3. sticky currentPort if attached, else lowest attached port + disambiguation warning.
+  const attachedPortNums = attached.map((a) => a.port).sort((x, y) => x - y);
+  const chosen = attachedPortNums.includes(ctx.currentPort) ? ctx.currentPort : attachedPortNums[0];
+  const list = attached
+    .map((a) => {
+      const cwd = ctx.cwdForPort(a.port);
+      return `:${a.port}${cwd ? ` (${cwd})` : ''}`;
+    })
+    .join(', ');
+  return {
+    port: chosen,
+    warning: `Multiple live Metros with an attached app: ${list}. Picked :${chosen}. Pass metroPort explicitly to choose a different worktree.`,
+  };
 }
 
 export interface DiscoveryResult {

--- a/scripts/cdp-bridge/src/cdp/discovery.ts
+++ b/scripts/cdp-bridge/src/cdp/discovery.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { logger } from '../logger.js';
-import type { HermesTarget } from '../types.js';
+import type { HermesTarget, MetroCandidate } from '../types.js';
 import { cwdForPort, pathMatchesRoot, resolveBridgeProjectRoot } from './metro-cwd.js';
 
 /**
@@ -23,7 +23,7 @@ export class AppDetachedError extends Error {
     super(
       `Metro is up on port ${port}` +
       (runningPorts.length > 1 ? ` (also running: ${runningPorts.join(', ')})` : '') +
-      ` but no live Metro advertises a Hermes debug target — the app isn't attached ` +
+      ` but advertises 0 Hermes debug targets — the app isn't attached ` +
       `(it may be on the Expo dev launcher, backgrounded, or crashed). Relaunch the app, ` +
       `or call cdp_status to auto-relaunch and reconnect.`,
     );
@@ -490,4 +490,46 @@ export async function discoverForList(
   inferPlatforms(targets);
 
   return { port: chosen, targets };
+}
+
+/**
+ * GH #303: best-effort enumeration of live Metros for cdp_status diagnostics —
+ * decoupled from discover() so it works even on the already-connected path. Fast
+ * path (honors the spec's "single-Metro = one lsof"): when only the connected
+ * Metro is up, skip per-port fetchTargets + extra lsof and resolve just the
+ * connected port's cwd for the mismatch check, omitting the candidates array.
+ */
+export async function enumerateMetroCandidates(
+  connectedPort: number,
+  projectRoot: string | undefined,
+): Promise<{ candidates?: MetroCandidate[]; servingCwd: string | null; timings_ms: { probe: number; cwd: number } }> {
+  const t0 = performance.now();
+  const ports = [...new Set([connectedPort, ...DEFAULT_PORTS])];
+  const running = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
+  const tProbe = performance.now();
+
+  if (running.length <= 1) {
+    const servingCwd = cwdForPort(connectedPort);
+    return { servingCwd, timings_ms: { probe: tProbe - t0, cwd: performance.now() - tProbe } };
+  }
+
+  const candidates: MetroCandidate[] = [];
+  let servingCwd: string | null = null;
+  for (const p of running) {
+    let attached = false;
+    try {
+      attached = filterValidTargets(await fetchTargets(p, DISCOVERY_TIMEOUT_MS)).length > 0;
+    } catch { /* treat as detached */ }
+    const cwd = cwdForPort(p);
+    if (p === connectedPort) servingCwd = cwd;
+    candidates.push({
+      port: p,
+      attached,
+      cwd,
+      isConnected: p === connectedPort,
+      matchesProjectRoot: pathMatchesRoot(cwd, projectRoot),
+    });
+  }
+  if (servingCwd === null) servingCwd = cwdForPort(connectedPort);
+  return { candidates, servingCwd, timings_ms: { probe: tProbe - t0, cwd: performance.now() - tProbe } };
 }

--- a/scripts/cdp-bridge/src/cdp/discovery.ts
+++ b/scripts/cdp-bridge/src/cdp/discovery.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { logger } from '../logger.js';
 import type { HermesTarget } from '../types.js';
-import { pathMatchesRoot } from './metro-cwd.js';
+import { cwdForPort, pathMatchesRoot, resolveBridgeProjectRoot } from './metro-cwd.js';
 
 /**
  * GH #208 (RC2): thrown by `discover()` when Metro IS reachable but advertises
@@ -40,32 +40,12 @@ export const DEFAULT_PORTS = [
   8081, 8082, 19000, 19006,
 ];
 
-export async function discoverMetroPort(ports: number[], timeout: number): Promise<number | null> {
-  for (const p of ports) {
-    const ctrl = new AbortController();
-    const timer = setTimeout(() => ctrl.abort(), timeout);
-    try {
-      const resp = await fetch(`http://127.0.0.1:${p}/status`, { signal: ctrl.signal });
-      const text = await resp.text();
-      if (text.includes('packager-status:running')) {
-        return p;
-      }
-    } catch {
-      // Port not available, continue scanning
-    } finally {
-      clearTimeout(timer);
-    }
-  }
-  return null;
-}
-
 /**
  * GH #303: probe ALL candidate ports in parallel and return every one that is a
- * running Metro (vs `discoverMetroPort` which short-circuits on the first). The
- * caller then prefers a port with an attached Hermes target so a detached
- * sibling-worktree Metro can't shadow a healthy one. Closed localhost ports
- * refuse fast (no per-port timeout cost); only ports that accept but stall hit
- * the timeout.
+ * running Metro. The caller then prefers a port with an attached Hermes target
+ * so a detached sibling-worktree Metro can't shadow a healthy one. (Replaces the
+ * old first-match `discoverMetroPort`.) Closed localhost ports refuse fast (no
+ * per-port timeout cost); only ports that accept but stall hit the timeout.
  */
 export async function discoverAllMetroPorts(ports: number[], timeout: number): Promise<number[]> {
   const checks = await Promise.all(
@@ -435,32 +415,52 @@ export async function discover(
   if (filters.preferredBundleId) hints.push(`preferredBundleId=${filters.preferredBundleId}`);
   logger.debug('CDP', `Discovering Metro on ports: ${ports.join(', ')}${hints.length ? ` (${hints.join(', ')})` : ''}`);
 
-  const metroPort = await discoverMetroPort(ports, DISCOVERY_TIMEOUT_MS);
-  if (!metroPort) {
+  // GH #303: probe ALL candidate ports, then prefer one with an attached Hermes
+  // target so a detached sibling-worktree Metro can't shadow a healthy one.
+  const runningPorts = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
+  if (runningPorts.length === 0) {
     throw new Error(
       'Metro not found on ports ' + ports.join(', ') +
       '. Is the dev server running? Try: npx expo start or npx react-native start',
     );
   }
-  logger.info('CDP', `Metro found on port ${metroPort}`);
 
-  const raw = await fetchTargets(metroPort, DISCOVERY_TIMEOUT_MS * 2);
-  const validTargets = filterValidTargets(raw).filter(t => {
-    try {
-      const { hostname } = new URL(t.webSocketDebuggerUrl!);
-      return hostname === '127.0.0.1' || hostname === 'localhost';
-    } catch {
-      return false;
-    }
+  const perPort = await Promise.all(
+    runningPorts.map(async (p) => {
+      try {
+        const raw = await fetchTargets(p, DISCOVERY_TIMEOUT_MS * 2);
+        const valid = filterValidTargets(raw).filter(t => {
+          try {
+            const { hostname } = new URL(t.webSocketDebuggerUrl!);
+            return hostname === '127.0.0.1' || hostname === 'localhost';
+          } catch {
+            return false;
+          }
+        });
+        return { port: p, targets: valid };
+      } catch {
+        return { port: p, targets: [] as HermesTarget[] };
+      }
+    }),
+  );
+
+  const attached = perPort.filter((pp) => pp.targets.length > 0);
+  // selectMetroPort throws AppDetachedError when nothing is attached (preserving
+  // the existing catch in status.ts), carrying the full running-port list.
+  const { port: metroPort, warning: portWarning } = selectMetroPort(attached, runningPorts, {
+    currentPort,
+    projectRoot: resolveBridgeProjectRoot() ?? undefined,
+    preferredBundleId: filters.preferredBundleId,
+    cwdForPort: (p) => cwdForPort(p),
   });
+  logger.info('CDP', `Metro selected on port ${metroPort} (running: ${runningPorts.join(', ')})`);
 
-  if (validTargets.length === 0) {
-    throw new AppDetachedError(metroPort);
-  }
+  const validTargets = attached.find((pp) => pp.port === metroPort)!.targets;
 
   inferPlatforms(validTargets);
 
-  const { targets: sorted, warning } = selectTarget(validTargets, filters);
+  const { targets: sorted, warning: selectWarning } = selectTarget(validTargets, filters);
+  const warning = [portWarning, selectWarning].filter(Boolean).join(' | ') || undefined;
 
   logger.debug('CDP', `Found ${sorted.length} valid target(s): ${sorted.map(t => `${t.id} (${t.title}, platform=${t.platform ?? '?'})`).join(', ')}`);
 
@@ -472,14 +472,22 @@ export async function discoverForList(
   portHint?: number,
 ): Promise<{ port: number; targets: HermesTarget[] }> {
   const ports = [...new Set([portHint ?? currentPort, ...DEFAULT_PORTS])];
-  const metroPort = await discoverMetroPort(ports, DISCOVERY_TIMEOUT_MS);
-  if (!metroPort) {
+  // GH #303: prefer a running port that actually has targets over the first
+  // running one, so cdp_targets can't inspect a different Metro than discover()
+  // selected. No cwd auto-pick needed here — just attached-preference.
+  const running = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
+  if (running.length === 0) {
     throw new Error('Metro not found on ports ' + ports.join(', '));
   }
-
-  const raw = await fetchTargets(metroPort, DISCOVERY_TIMEOUT_MS * 2);
-  const targets = filterValidTargets(raw);
+  let chosen = running[0];
+  let targets: HermesTarget[] = [];
+  for (const p of running) {
+    try {
+      const valid = filterValidTargets(await fetchTargets(p, DISCOVERY_TIMEOUT_MS * 2));
+      if (valid.length > 0) { chosen = p; targets = valid; break; }
+    } catch { /* try next running port */ }
+  }
   inferPlatforms(targets);
 
-  return { port: metroPort, targets };
+  return { port: chosen, targets };
 }

--- a/scripts/cdp-bridge/src/cdp/metro-cwd.ts
+++ b/scripts/cdp-bridge/src/cdp/metro-cwd.ts
@@ -1,0 +1,91 @@
+import { execFileSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import { resolve, sep } from 'node:path';
+import { findProjectRoot } from '../nav-graph/storage.js';
+
+export const CWD_LSOF_TIMEOUT_MS = 800;
+
+export type ExecFn = (cmd: string, args: string[]) => string;
+
+const defaultExec: ExecFn = (cmd, args) =>
+  execFileSync(cmd, args, {
+    timeout: CWD_LSOF_TIMEOUT_MS,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+
+const pidCwdCache = new Map<number, string | null>();
+
+export function _resetMetroCwdCacheForTest(): void {
+  pidCwdCache.clear();
+}
+
+export function parseLsofPid(stdout: string): number | null {
+  for (const line of stdout.split('\n')) {
+    const n = parseInt(line.trim(), 10);
+    if (!isNaN(n) && n > 0) return n;
+  }
+  return null;
+}
+
+export function parseLsofCwd(stdout: string): string | null {
+  for (const line of stdout.split('\n')) {
+    if (line.startsWith('n')) {
+      const path = line.slice(1).trim();
+      if (path) return path;
+    }
+  }
+  return null;
+}
+
+function pidForPort(port: number, exec: ExecFn): number | null {
+  try {
+    return parseLsofPid(exec('lsof', ['-ti', `tcp:${port}`, '-sTCP:LISTEN']));
+  } catch {
+    return null;
+  }
+}
+
+function cwdForPid(pid: number, exec: ExecFn): string | null {
+  if (pidCwdCache.has(pid)) return pidCwdCache.get(pid) ?? null;
+  let cwd: string | null = null;
+  try {
+    cwd = parseLsofCwd(exec('lsof', ['-a', '-p', String(pid), '-d', 'cwd', '-Fn']));
+  } catch {
+    cwd = null;
+  }
+  pidCwdCache.set(pid, cwd);
+  return cwd;
+}
+
+function realpathOrResolve(p: string): string {
+  try {
+    return realpathSync(resolve(p));
+  } catch {
+    return resolve(p);
+  }
+}
+
+export function cwdForPort(port: number, exec: ExecFn = defaultExec): string | null {
+  if (exec === defaultExec && process.platform !== 'darwin') return null;
+  const pid = pidForPort(port, exec);
+  if (pid == null) return null;
+  const cwd = cwdForPid(pid, exec);
+  return cwd ? realpathOrResolve(cwd) : null;
+}
+
+export function pathMatchesRoot(
+  servingCwd: string | null,
+  projectRoot: string | null | undefined,
+): boolean {
+  if (!servingCwd || !projectRoot) return false;
+  const a = realpathOrResolve(servingCwd);
+  const b = realpathOrResolve(projectRoot);
+  if (a === b) return true;
+  return a.startsWith(b + sep) || b.startsWith(a + sep);
+}
+
+export function resolveBridgeProjectRoot(): string | null {
+  const root = findProjectRoot();
+  return root ? realpathOrResolve(root) : null;
+}

--- a/scripts/cdp-bridge/src/tools/status.ts
+++ b/scripts/cdp-bridge/src/tools/status.ts
@@ -1,5 +1,5 @@
 import type { CDPClient } from '../cdp-client.js';
-import type { StatusResult } from '../types.js';
+import type { MetroCandidate, StatusResult } from '../types.js';
 import { okResult, failResult, warnResult } from '../utils.js';
 import { handleDevClientPicker, isDevClientPickerShowing } from './dev-client-picker.js';
 import { PickerBlockingBundleError } from '../cdp/connect.js';
@@ -11,7 +11,8 @@ import { recoverDetached } from '../cdp/recover-detached.js';
 import type { DetachedRecoveryResult, RecoverDetachedDeps } from '../cdp/recover-detached.js';
 import { buildNotInstalledAdvice } from '../cdp/app-installed-probe.js';
 import { snapshotHintForBundleId } from './resolve-ios-app-file.js';
-import { AppDetachedError } from '../cdp/discovery.js';
+import { AppDetachedError, enumerateMetroCandidates } from '../cdp/discovery.js';
+import { resolveBridgeProjectRoot, pathMatchesRoot } from '../cdp/metro-cwd.js';
 import { getDeviceSessionHealth } from './device-session-health.js';
 import { detectIosExternalRunner } from '../runners/external-runner-detect.js';
 import { bridgeEnvState } from '../lifecycle/supervisor-core.js';
@@ -21,6 +22,29 @@ import { bridgeEnvState } from '../lifecycle/supervisor-core.js';
 // helper versions that might emit new tokens we don't recognize yet.
 export function narrowArchitecture(raw: unknown): 'new' | 'old' | 'unknown' {
   return raw === 'new' || raw === 'old' ? raw : 'unknown';
+}
+
+/**
+ * GH #303: flag when the connected Metro is serving a DIFFERENT worktree than
+ * this session's project root — the silent "verifying the wrong bundle" trap.
+ * Uses pathMatchesRoot so a monorepo app subdir / symlinked path is not flagged.
+ * Fail-open: silent whenever either path is unresolved (never a false alarm).
+ */
+export function computeMetroMismatch(args: {
+  servingCwd: string | null;
+  projectRoot: string | undefined;
+  port: number | null;
+}): { mismatch: boolean; warning?: string } {
+  const { servingCwd, projectRoot, port } = args;
+  if (!servingCwd || !projectRoot || pathMatchesRoot(servingCwd, projectRoot)) {
+    return { mismatch: false };
+  }
+  return {
+    mismatch: true,
+    warning:
+      `Connected Metro on :${port} is serving ${servingCwd}, but this session's project root is ${projectRoot} ` +
+      `— you may be verifying against a different worktree's bundle. Restart Metro in this worktree or pass metroPort.`,
+  };
 }
 
 const STATUS_PROBE_EXPRESSION = `
@@ -71,6 +95,18 @@ async function buildStatusResult(client: CDPClient): Promise<StatusResult> {
       (await detectIosExternalRunner(undefined, udid)) ? { detected: true } : null,
   });
 
+  // GH #303: worktree-disambiguation diagnostics — best-effort, fail-open.
+  const projectRoot = resolveBridgeProjectRoot() ?? undefined;
+  let candidates: MetroCandidate[] | undefined;
+  let servingCwd: string | null | undefined;
+  let metroTimings: { probe: number; cwd: number } | undefined;
+  try {
+    const enriched = await enumerateMetroCandidates(client.metroPort, projectRoot);
+    servingCwd = enriched.servingCwd;
+    candidates = enriched.candidates; // omitted by the fast path when ≤1 Metro is up
+    metroTimings = enriched.timings_ms;
+  } catch { /* fail-open: omit diagnostics */ }
+
   return {
     metro: {
       running: true,
@@ -79,6 +115,10 @@ async function buildStatusResult(client: CDPClient): Promise<StatusResult> {
       lastBuild: metroEvents?.lastBuild ?? null,
       buildErrors: metroEvents?.buildErrors ?? 0,
       eventsReason: metroEvents?.incompatibleReason ?? null,
+      candidates,
+      projectRoot,
+      servingCwd,
+      timings_ms: metroTimings,
     },
     cdp: { connected: client.isConnected, device: client.connectedTarget?.title ?? null, pageId: client.connectedTarget?.id ?? null, platform: client.connectedTarget?.platform ?? null, bundleId: client.connectedTarget?.description ?? null },
     app: {
@@ -296,6 +336,16 @@ export function createStatusHandler(
           status,
           'CDP connected but app helpers not injected and no JS errors captured. The app may have crashed natively before __RN_AGENT loaded (e.g. missing native module, failed bundle fetch). Call cdp_native_errors to inspect the platform log.',
         );
+      }
+
+      // GH #303: the connected Metro serves a different worktree than this session.
+      const mismatch = computeMetroMismatch({
+        servingCwd: status.metro.servingCwd ?? null,
+        projectRoot: status.metro.projectRoot,
+        port: status.metro.port,
+      });
+      if (mismatch.mismatch) {
+        return warnResult(status, mismatch.warning!);
       }
 
       return okResult(status, autoRecoveredMessage ? { meta: { autoRecovered: autoRecoveredMessage } } : undefined);

--- a/scripts/cdp-bridge/src/types.ts
+++ b/scripts/cdp-bridge/src/types.ts
@@ -69,6 +69,15 @@ export interface LogEntry {
 
 export type CDPClientState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
 
+/** GH #303: a candidate Metro found while resolving which port to drive. */
+export interface MetroCandidate {
+  port: number;
+  attached: boolean;
+  cwd: string | null;
+  isConnected: boolean;
+  matchesProjectRoot: boolean;
+}
+
 export interface StatusResult {
   metro: {
     running: boolean;
@@ -86,6 +95,11 @@ export interface StatusResult {
      * `eventsConnected` will be false and no events will ever arrive.
      */
     eventsReason?: 'expo-cli-incompatible' | null;
+    // GH #303: worktree disambiguation diagnostics.
+    candidates?: MetroCandidate[];
+    projectRoot?: string;
+    servingCwd?: string | null;
+    timings_ms?: { probe: number; cwd: number };
   };
   cdp: {
     connected: boolean;

--- a/scripts/cdp-bridge/test/unit/discover-port-selection.test.js
+++ b/scripts/cdp-bridge/test/unit/discover-port-selection.test.js
@@ -1,0 +1,64 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { selectMetroPort, AppDetachedError } from '../../dist/cdp/discovery.js';
+
+const T = (description) => ({ id: 'page-1', title: 'RN', vm: 'Hermes', description });
+
+test('selectMetroPort: single attached port wins, no warning', () => {
+  const res = selectMetroPort(
+    [{ port: 8081, targets: [T('com.app')] }],
+    [8081, 8082],
+    { currentPort: 8082, cwdForPort: () => null },
+  );
+  assert.equal(res.port, 8081);
+  assert.equal(res.warning, undefined);
+});
+
+test('selectMetroPort: zero attached → AppDetachedError listing running ports', () => {
+  assert.throws(
+    () => selectMetroPort([], [8081, 8082], { currentPort: 8081, cwdForPort: () => null }),
+    (err) => err instanceof AppDetachedError && err.runningPorts.includes(8082),
+  );
+});
+
+test('selectMetroPort: projectRoot cwd-match beats sticky currentPort', () => {
+  const res = selectMetroPort(
+    [{ port: 8081, targets: [T('com.app')] }, { port: 8082, targets: [T('com.app')] }],
+    [8081, 8082],
+    {
+      currentPort: 8082, // sticky would pick 8082
+      projectRoot: '/repo/worktreeA',
+      cwdForPort: (p) => (p === 8081 ? '/repo/worktreeA' : '/repo/worktreeB'),
+    },
+  );
+  assert.equal(res.port, 8081, 'cwd match wins over stickiness');
+});
+
+test('selectMetroPort: preferredBundleId port-level tie-break when one port matches', () => {
+  const res = selectMetroPort(
+    [{ port: 8081, targets: [T('com.other')] }, { port: 8082, targets: [T('com.app')] }],
+    [8081, 8082],
+    { currentPort: 8081, preferredBundleId: 'com.app', cwdForPort: () => null },
+  );
+  assert.equal(res.port, 8082);
+});
+
+test('selectMetroPort: no cwd match, no pref → sticky currentPort + warning lists candidates', () => {
+  const res = selectMetroPort(
+    [{ port: 8081, targets: [T('com.app')] }, { port: 8082, targets: [T('com.app')] }],
+    [8081, 8082],
+    { currentPort: 8082, projectRoot: '/repo/none', cwdForPort: () => null },
+  );
+  assert.equal(res.port, 8082, 'sticky currentPort chosen');
+  assert.match(res.warning, /8081/);
+  assert.match(res.warning, /metroPort/);
+});
+
+test('selectMetroPort: sticky falls back to lowest attached when currentPort detached', () => {
+  const res = selectMetroPort(
+    [{ port: 8082, targets: [T('com.app')] }, { port: 19000, targets: [T('com.app')] }],
+    [8081, 8082, 19000],
+    { currentPort: 8081, cwdForPort: () => null },
+  );
+  assert.equal(res.port, 8082);
+});

--- a/scripts/cdp-bridge/test/unit/discover-port-selection.test.js
+++ b/scripts/cdp-bridge/test/unit/discover-port-selection.test.js
@@ -62,3 +62,66 @@ test('selectMetroPort: sticky falls back to lowest attached when currentPort det
   );
   assert.equal(res.port, 8082);
 });
+
+test('discover: skips detached first port for attached second port', async () => {
+  const { discover } = await import('../../dist/cdp/discovery.js');
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.includes('/status')) return { text: async () => 'packager-status:running' };
+    if (u.includes(':8082/json/list')) return { json: async () => [] }; // detached
+    if (u.includes(':8081/json/list')) return {
+      json: async () => [{
+        id: 'page-1', title: 'RN', vm: 'Hermes', description: 'com.app',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:8081/inspector/debug?page=1',
+      }],
+    };
+    return { json: async () => [], text: async () => '' };
+  };
+  try {
+    const res = await discover(8082, {}); // currentPort 8082 is the detached one
+    assert.equal(res.port, 8081, 'discovery chose the attached port, not the running-but-detached one');
+    assert.equal(res.targets.length, 1);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test('discover: all-detached still throws AppDetachedError', async () => {
+  const { discover, AppDetachedError } = await import('../../dist/cdp/discovery.js');
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.includes('/status')) return { text: async () => 'packager-status:running' };
+    return { json: async () => [] };
+  };
+  try {
+    await assert.rejects(discover(8081, {}), (e) => e instanceof AppDetachedError);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});
+
+test('discoverForList: prefers a running port WITH targets over a detached one', async () => {
+  const { discoverForList } = await import('../../dist/cdp/discovery.js');
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    const u = String(url);
+    if (u.includes('/status')) return { text: async () => 'packager-status:running' };
+    if (u.includes(':8082/json/list')) return { json: async () => [] };
+    if (u.includes(':8081/json/list')) return {
+      json: async () => [{
+        id: 'page-1', title: 'RN', vm: 'Hermes', description: 'com.app',
+        webSocketDebuggerUrl: 'ws://127.0.0.1:8081/inspector/debug?page=1',
+      }],
+    };
+    return { json: async () => [], text: async () => '' };
+  };
+  try {
+    const res = await discoverForList(8082);
+    assert.equal(res.port, 8081);
+    assert.equal(res.targets.length, 1);
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+});

--- a/scripts/cdp-bridge/test/unit/metro-cwd.test.js
+++ b/scripts/cdp-bridge/test/unit/metro-cwd.test.js
@@ -1,0 +1,84 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseLsofPid,
+  parseLsofCwd,
+  cwdForPort,
+  pathMatchesRoot,
+  _resetMetroCwdCacheForTest,
+} from '../../dist/cdp/metro-cwd.js';
+
+test('parseLsofPid: first numeric line from `lsof -ti` output', () => {
+  assert.equal(parseLsofPid('12345\n'), 12345);
+  assert.equal(parseLsofPid('12345\n12346\n'), 12345);
+});
+
+test('parseLsofPid: null on empty / non-numeric', () => {
+  assert.equal(parseLsofPid(''), null);
+  assert.equal(parseLsofPid('\n  \n'), null);
+});
+
+test('parseLsofCwd: extracts the n-field from `lsof -Fn` machine output', () => {
+  const out = 'p12345\nfcwd\nn/Users/anton/GitHub/ix3030/test-app\n';
+  assert.equal(parseLsofCwd(out), '/Users/anton/GitHub/ix3030/test-app');
+});
+
+test('parseLsofCwd: null when no n-field present', () => {
+  assert.equal(parseLsofCwd('p12345\nfcwd\n'), null);
+});
+
+test('cwdForPort: composes pid→cwd via injected exec', () => {
+  _resetMetroCwdCacheForTest();
+  const calls = [];
+  const exec = (cmd, args) => {
+    calls.push(args.join(' '));
+    if (args.includes('-ti')) return '777\n';
+    return 'p777\nfcwd\nn/repo/worktreeA\n';
+  };
+  assert.equal(cwdForPort(8081, exec), '/repo/worktreeA');
+});
+
+test('cwdForPort: memoizes pid→cwd but re-resolves port→pid each call', () => {
+  _resetMetroCwdCacheForTest();
+  let pidCalls = 0;
+  let cwdCalls = 0;
+  const exec = (cmd, args) => {
+    if (args.includes('-ti')) { pidCalls++; return '777\n'; }
+    cwdCalls++; return 'p777\nfcwd\nn/repo/worktreeA\n';
+  };
+  cwdForPort(8081, exec);
+  cwdForPort(8081, exec);
+  assert.equal(pidCalls, 2, 'port→pid re-resolved each call (guards port reuse)');
+  assert.equal(cwdCalls, 1, 'pid→cwd memoized');
+});
+
+test('cwdForPort: fail-open — null when exec throws or returns junk', () => {
+  _resetMetroCwdCacheForTest();
+  const throwing = () => { throw new Error('lsof not found'); };
+  assert.equal(cwdForPort(8081, throwing), null);
+  _resetMetroCwdCacheForTest();
+  const noPid = (cmd, args) => (args.includes('-ti') ? '' : '');
+  assert.equal(cwdForPort(8081, noPid), null);
+});
+
+test('pathMatchesRoot: equal paths match', () => {
+  assert.equal(pathMatchesRoot('/repo/worktreeA', '/repo/worktreeA'), true);
+});
+
+test('pathMatchesRoot: serving cwd nested under root matches (monorepo app subdir, both directions)', () => {
+  assert.equal(pathMatchesRoot('/repo/worktreeA/app', '/repo/worktreeA'), true);
+  assert.equal(pathMatchesRoot('/repo/worktreeA', '/repo/worktreeA/app'), true);
+});
+
+test('pathMatchesRoot: sibling worktrees do NOT match (the #303 case)', () => {
+  assert.equal(pathMatchesRoot('/repo/worktreeB', '/repo/worktreeA'), false);
+});
+
+test('pathMatchesRoot: shared prefix without a separator boundary does NOT match', () => {
+  assert.equal(pathMatchesRoot('/repo/worktreeA-2', '/repo/worktreeA'), false);
+});
+
+test('pathMatchesRoot: null/undefined operands → false (fail-open)', () => {
+  assert.equal(pathMatchesRoot(null, '/repo/worktreeA'), false);
+  assert.equal(pathMatchesRoot('/repo/worktreeA', undefined), false);
+});

--- a/scripts/cdp-bridge/test/unit/status-metro-mismatch.test.js
+++ b/scripts/cdp-bridge/test/unit/status-metro-mismatch.test.js
@@ -1,0 +1,31 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeMetroMismatch } from '../../dist/tools/status.js';
+
+test('computeMetroMismatch: warns when servingCwd !== projectRoot', () => {
+  const r = computeMetroMismatch({ servingCwd: '/repo/worktreeB', projectRoot: '/repo/worktreeA', port: 8082 });
+  assert.equal(r.mismatch, true);
+  assert.match(r.warning, /different worktree/i);
+  assert.match(r.warning, /8082/);
+});
+
+test('computeMetroMismatch: silent when equal', () => {
+  const r = computeMetroMismatch({ servingCwd: '/repo/worktreeA', projectRoot: '/repo/worktreeA', port: 8081 });
+  assert.equal(r.mismatch, false);
+  assert.equal(r.warning, undefined);
+});
+
+test('computeMetroMismatch: silent when serving cwd is an app subdir of the project root (monorepo)', () => {
+  const r = computeMetroMismatch({ servingCwd: '/repo/worktreeA/app', projectRoot: '/repo/worktreeA', port: 8081 });
+  assert.equal(r.mismatch, false);
+});
+
+test('computeMetroMismatch: silent when servingCwd unresolved (fail-open)', () => {
+  const r = computeMetroMismatch({ servingCwd: null, projectRoot: '/repo/worktreeA', port: 8081 });
+  assert.equal(r.mismatch, false);
+});
+
+test('computeMetroMismatch: silent when projectRoot unknown', () => {
+  const r = computeMetroMismatch({ servingCwd: '/repo/worktreeA', projectRoot: undefined, port: 8081 });
+  assert.equal(r.mismatch, false);
+});


### PR DESCRIPTION
Closes #303.

## Problem
With two git worktrees each running Metro, `cdp_status` (no `metroPort`) locked onto the **first running port** and could return `APP_DETACHED` while the app was healthy on another port. Root cause: `discoverMetroPort()` returned the first port answering `packager-status:running` without ever checking whether it had an *attached Hermes target*. Two harms: (1) an agent silently verifies against a **different worktree's JS bundle** and reports success against code that isn't running; (2) `cdp_status` even fired the iOS auto-relaunch (`recoverDetached`) for the wrong port.

## Fix (3 layers, all fail-open)
1. **Correctness** — `discover()` now probes *all* candidate ports in parallel and prefers one with attached Hermes targets; `AppDetachedError` fires only when **no** live Metro has an app (so the misguided auto-relaunch no longer triggers when the app is healthy elsewhere). `discoverForList`/`cdp_targets` prefers the attached port too.
2. **Worktree auto-pick** — new `cdp/metro-cwd.ts` resolves each Metro's serving cwd (`lsof`, memoized `pid→cwd`, macOS-first). When >1 Metro has an app, the one whose cwd matches this bridge's project root (`findProjectRoot()` + `realpathSync` + separator-boundary containment) wins — beating stickiness and `preferredBundleId`.
3. **Diagnostics** — `cdp_status` gains `metro.candidates` / `projectRoot` / `servingCwd` / `timings_ms`, and **warns** when the connected Metro serves a different worktree — catching the trap even with a single Metro running.

Off macOS, or whenever `lsof`/the project root can't be resolved, every new path degrades to the prior behavior — it can never *block* a connection it would have made before, only make a *better* choice.

## Process
- Spec + TDD plan committed; **multi-LLM plan review** (antigravity + codex) *before* code caught 4 real issues, all applied: wrong project-root resolver (would've made the feature dead code), symlink realpath mismatch, `cdp_targets` left on the buggy path, hot-path double-probe.
- Implemented task-by-task with **codex-pair** per-edit review.
- **Final review**: clean (`tsc` clean, dist synced, invariants proven). _Codex was quota-capped at the end; the final pass was antigravity (manual source verification, as its MCP bridge wasn't registered)._

## Tests
- **+26 unit tests** (`metro-cwd`, `discover-port-selection`, `status-metro-mismatch`) — pure selection + `pathMatchesRoot` + `discover()`/`discoverForList` integration (stubbed fetch) + mismatch gate. Full suite **2198 passing**.
- **Device-verify** (real `lsof` + real `fetch`, two mock-Metro child processes in distinct cwds): `cwdForPort` resolves real worktree cwds; `discover()` picks attached over detached; cwd auto-pick beats stickiness; `enumerateMetroCandidates` emits correct candidates + `servingCwd`.

## Out of scope
The issue's secondary friction (maestro WDA-install failure; `device_screenshot` phantom paths — already mitigated by the simctl fallback, D1249) is unrelated to port selection and excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)