### PR TITLE
fix(release): correct changeset package name → rn-dev-agent-plugin

### DIFF
--- a/.changeset/android-device-lock-port-hardening.md
+++ b/.changeset/android-device-lock-port-hardening.md
@@ -1,5 +1,5 @@
 ---
-"rn-dev-agent": minor
+"rn-dev-agent-plugin": minor
 ---
 
 Harden device-control conflicts: add an Android serial-scoped device lock (parity with iOS) that engages on a normal emulator, separate the Android runner's probed host port from its fixed device-listener port (`adb forward`), and let the iOS runner self-assign a free port when 22088 is taken.

--- a/.changeset/android-runner-self-install.md
+++ b/.changeset/android-runner-self-install.md
@@ -1,5 +1,5 @@
 ---
-"rn-dev-agent": minor
+"rn-dev-agent-plugin": minor
 ---
 
 Android `rn-android-runner` now self-installs on first use (parity with the iOS `rn-fast-runner` cold build): `startAndroidRunner` installs the prebuilt APKs — and cold-builds them via Gradle if absent — when the instrumentation isn't on the device yet. No external CLI or manual `gradlew + adb install` step is required; this makes the `/setup` and `/doctor` "builds/installs on first use" promise true on Android.

--- a/.changeset/eradicate-agent-device-cutover.md
+++ b/.changeset/eradicate-agent-device-cutover.md
@@ -1,5 +1,5 @@
 ---
-"rn-dev-agent": minor
+"rn-dev-agent-plugin": minor
 ---
 
 Remove the agent-device dependency entirely. The Android daemon-socket + CLI fallback tiers are deleted; session open/close/list and find now route natively (simctl/adb + the in-tree rn-fast-runner / rn-android-runner), the Android dispatch gained an ensure-on-dispatch choke point (parity with iOS), session open validates the appId and acquires the device lock before any side-effect, RN_ANDROID_RUNNER=0 now errors (RUNNER_DISABLED) instead of silently falling back, and the agent-device install script + its SessionStart hook are gone. The in-tree runners are the sole device backend; the foreign-AgentDeviceRunner cleanup (self-heal for old installs) is retained.

--- a/.changeset/metro-port-selection.md
+++ b/.changeset/metro-port-selection.md
@@ -1,5 +1,5 @@
 ---
-"rn-dev-agent": patch
+"rn-dev-agent-plugin": patch
 ---
 
 Fix #303: Metro-port discovery now prefers the port with an attached Hermes target over a merely-running one, and when several Metros have an app it auto-selects the one whose serving directory matches this worktree's project root (resolved via `findProjectRoot` + realpath, containment-aware). `cdp_status` surfaces all candidate Metros (`metro.candidates`) plus `projectRoot`/`servingCwd`, and warns when the connected Metro serves a different worktree — catching the silent trap where an agent verifies against the wrong worktree's JS bundle even with a single Metro running. `cdp_targets` (`discoverForList`) prefers the attached port too. Fail-open throughout (macOS `lsof`; degrades to prior behavior off-darwin or when paths can't be resolved).


### PR DESCRIPTION
## Problem
The **release workflow has been failing on `main` since #304** — every merge (#305/#307/#308/#309/#310/#313) left the changeset Version PR uncreated. `changeset version` aborts:

```
🦋 error: Found changeset android-device-lock-port-hardening for package rn-dev-agent which is not in the workspace
```

## Root cause
Changesets versions a **synthetic package named `rn-dev-agent-plugin`** (`.claude-plugin/package.json` — the version source of truth that `scripts/sync-plugin-manifest.mjs` mirrors into `plugin.json`/`marketplace.json`). But four pending changesets referenced `rn-dev-agent` (the *marketplace* name, not the npm package name). The typo entered in #308 and was copied by #305/#309/#313. `require-changeset` CI only checks a changeset *exists*, not that its package name is valid — so it sailed through PR CI and only broke `release.yml` on main.

## Fix
Rename the package key `"rn-dev-agent"` → `"rn-dev-agent-plugin"` in all four pending changesets. No code change.

Validated locally:
```
$ npx changeset status
🦋 info Packages to be bumped at minor:
🦋 - rn-dev-agent-plugin
```
(aggregate of 3 minors + 1 patch → `0.54.7` → `0.55.0`)

Once merged, `release.yml` re-runs and produces the Version PR.

## Follow-up (not in this PR)
Harden the `require-changeset` CI job to also validate changeset package names against the workspace, so a typo'd name fails the PR instead of silently blocking releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)