### PR TITLE
ci(#316): validate changeset package names against the workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
       - name: Changeset-guard unit test
         run: bash scripts/test/require-changeset.test.sh
 
+      # GH#316/B215: changeset package names must resolve to real workspace packages.
+      - name: Changeset-name validator unit test
+        run: bash scripts/test/validate-changeset-names.test.sh
+
       # GH#252/B196: SessionStart must stay bounded (hook timeout + curl time limits).
       - name: SessionStart bounded-startup guard
         run: bash scripts/test/session-start-bounded.test.sh
@@ -80,6 +84,11 @@ jobs:
         run: |
           git fetch origin "$BASE_REF_NAME"
           BASE_REF="origin/$BASE_REF_NAME" bash scripts/require-changeset.sh
+
+      # GH#316/B215: validate that every present changeset names a real workspace
+      # package, so a typo fails the PR instead of release.yml's `changeset version`.
+      - name: Validate changeset package names
+        run: bash scripts/validate-changeset-names.sh
 
   web-bundle:
     name: Web bundle freshness

--- a/scripts/test/validate-changeset-names.test.sh
+++ b/scripts/test/validate-changeset-names.test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Regression test for validate-changeset-names.sh — the CI guard that fails a PR
+# whose changeset frontmatter references a package name that is not a real
+# workspace package. Without it a typo'd name (B215 / PR #314: "rn-dev-agent"
+# instead of "rn-dev-agent-plugin") passes PR CI and only explodes later in
+# release.yml's `changeset version` on main, blocking every subsequent release.
+#
+# Run: bash scripts/test/validate-changeset-names.test.sh
+#
+# Test seams (see validate-changeset-names.sh):
+#   REPO_ROOT           where to look for .changeset/ (default: repo root)
+#   WORKSPACE_PACKAGES  newline/space-separated valid names (overrides workspace scan)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+GUARD="$SCRIPT_DIR/validate-changeset-names.sh"
+
+fail=0
+check() { # description expected_exit actual_exit
+  if [ "$2" = "$3" ]; then
+    echo "ok: $1"
+  else
+    echo "FAIL: $1 — expected exit $2, got $3"
+    fail=1
+  fi
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/.changeset"
+echo "# changesets readme" > "$tmp/.changeset/README.md"
+
+VALID='rn-dev-agent-plugin
+rn-dev-agent-cdp'
+
+reset_changesets() { find "$tmp/.changeset" -maxdepth 1 -type f -name '*.md' ! -name 'README.md' -delete; }
+
+# 1. valid package name -> passes
+printf -- '---\n"rn-dev-agent-plugin": patch\n---\nfix\n' > "$tmp/.changeset/a.md"
+WORKSPACE_PACKAGES="$VALID" REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "valid name passes" 0 $?
+reset_changesets
+
+# 2. invalid package name (the B215 case) -> fails
+printf -- '---\n"rn-dev-agent": patch\n---\nfix\n' > "$tmp/.changeset/a.md"
+WORKSPACE_PACKAGES="$VALID" REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "invalid name (B215 rn-dev-agent) fails" 1 $?
+reset_changesets
+
+# 3. the other valid workspace package name -> passes
+printf -- '---\n"rn-dev-agent-cdp": minor\n---\nfix\n' > "$tmp/.changeset/a.md"
+WORKSPACE_PACKAGES="$VALID" REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "second valid name passes" 0 $?
+reset_changesets
+
+# 4. multiple valid names in one changeset -> passes
+printf -- '---\n"rn-dev-agent-plugin": patch\n"rn-dev-agent-cdp": minor\n---\nfix\n' > "$tmp/.changeset/a.md"
+WORKSPACE_PACKAGES="$VALID" REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "multiple valid names pass" 0 $?
+reset_changesets
+
+# 5. mix of valid + invalid in one changeset -> fails
+printf -- '---\n"rn-dev-agent-plugin": patch\n"rn-dev-agent": minor\n---\nfix\n' > "$tmp/.changeset/a.md"
+WORKSPACE_PACKAGES="$VALID" REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "mixed valid+invalid fails" 1 $?
+reset_changesets
+
+# 6. only README present (no changesets) -> passes (nothing to validate)
+WORKSPACE_PACKAGES="$VALID" REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "no changesets passes" 0 $?
+
+# 7. empty changeset (frontmatter, no package bump lines) -> passes
+printf -- '---\n---\nrelease note only\n' > "$tmp/.changeset/a.md"
+WORKSPACE_PACKAGES="$VALID" REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "empty changeset passes" 0 $?
+reset_changesets
+
+# 8. two changeset files, one valid + one invalid -> fails
+printf -- '---\n"rn-dev-agent-plugin": patch\n---\nok\n' > "$tmp/.changeset/good.md"
+printf -- '---\n"rn-dev-agent": patch\n---\nbad\n' > "$tmp/.changeset/bad.md"
+WORKSPACE_PACKAGES="$VALID" REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "one bad changeset among many fails" 1 $?
+reset_changesets
+
+# 9. valid names derived from a real workspace (no WORKSPACE_PACKAGES override)
+mkdir -p "$tmp/pkg-a" "$tmp/pkg-b"
+printf -- '{"name":"rn-dev-agent-plugin"}\n' > "$tmp/pkg-a/package.json"
+printf -- '{"name":"rn-dev-agent-cdp"}\n' > "$tmp/pkg-b/package.json"
+printf -- '{"private":true,"workspaces":["pkg-a","pkg-b"]}\n' > "$tmp/package.json"
+printf -- '---\n"rn-dev-agent-cdp": patch\n---\nok\n' > "$tmp/.changeset/a.md"
+REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "name validated against scanned workspace passes" 0 $?
+printf -- '---\n"rn-dev-agent": patch\n---\nbad\n' > "$tmp/.changeset/a.md"
+REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "bad name validated against scanned workspace fails" 1 $?
+rm -f "$tmp/package.json"; rm -rf "$tmp/pkg-a" "$tmp/pkg-b"; reset_changesets
+
+# 10. CRLF line endings (a Windows-authored changeset): the trailing \r must not
+# hide a bad name. Relies on [[:space:]] matching \r in both BSD + GNU awk/sed.
+printf -- '---\r\n"rn-dev-agent": patch\r\n---\r\nbad\r\n' > "$tmp/.changeset/a.md"
+WORKSPACE_PACKAGES="$VALID" REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "CRLF bad name fails" 1 $?
+printf -- '---\r\n"rn-dev-agent-plugin": patch\r\n---\r\nok\r\n' > "$tmp/.changeset/a.md"
+WORKSPACE_PACKAGES="$VALID" REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "CRLF valid name passes" 0 $?
+reset_changesets
+
+# 11. unquoted key (valid) -> passes
+printf -- '---\nrn-dev-agent-plugin: patch\n---\nok\n' > "$tmp/.changeset/a.md"
+WORKSPACE_PACKAGES="$VALID" REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "unquoted valid key passes" 0 $?
+reset_changesets
+
+# 12. unquoted key (invalid) -> fails
+printf -- '---\nrn-dev-agent: patch\n---\nbad\n' > "$tmp/.changeset/a.md"
+WORKSPACE_PACKAGES="$VALID" REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "unquoted invalid key fails" 1 $?
+reset_changesets
+
+# 13. single-quoted key (valid YAML) -> passes (no false positive)
+printf -- "---\n'rn-dev-agent-plugin': patch\n---\nok\n" > "$tmp/.changeset/a.md"
+WORKSPACE_PACKAGES="$VALID" REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "single-quoted valid key passes" 0 $?
+reset_changesets
+
+# 14. quoted BUMP VALUE with a bad name -> must still fail (no false negative)
+printf -- '---\n"rn-dev-agent": "patch"\n---\nbad\n' > "$tmp/.changeset/a.md"
+WORKSPACE_PACKAGES="$VALID" REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "quoted bump value with bad name fails" 1 $?
+reset_changesets
+
+# 15. fail-open: workspace set underivable (no package.json, no override) -> exit 0
+printf -- '---\n"rn-dev-agent": patch\n---\nbad\n' > "$tmp/.changeset/a.md"
+REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "fail-open when workspace undeterminable" 0 $?
+reset_changesets
+
+if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; exit 1; fi

--- a/scripts/validate-changeset-names.sh
+++ b/scripts/validate-changeset-names.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# CI guard (GH #316 / B215 / PR #314 post-mortem): every package name in a
+# pending .changeset/*.md frontmatter MUST be a real workspace package. A typo
+# (e.g. "rn-dev-agent" instead of the version-source package "rn-dev-agent-plugin")
+# passes the existence-only require-changeset gate, then aborts release.yml's
+# `changeset version` on main with "Found changeset … for package X which is not
+# in the workspace" — silently blocking every subsequent release until fixed.
+# Catch it on the PR, not on main.
+#
+# Validates ALL present changesets (additive to require-changeset.sh, which only
+# asks whether a changeset EXISTS — this asks whether the ones present are valid).
+#
+# Test seams (scripts/test/validate-changeset-names.test.sh):
+#   REPO_ROOT           where to look for .changeset/ + package.json (default: repo root)
+#   WORKSPACE_PACKAGES  newline/space-separated valid names (overrides workspace scan)
+set -uo pipefail
+
+ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+# Build the set of valid package names, newline-separated.
+if [ -n "${WORKSPACE_PACKAGES+x}" ]; then
+  # Intentional word-split: normalize space/newline-separated input to newlines.
+  # shellcheck disable=SC2086
+  valid="$(printf '%s\n' $WORKSPACE_PACKAGES)"
+else
+  valid=""
+  while IFS= read -r pattern; do
+    [ -n "$pattern" ] || continue
+    # $pattern is left unquoted so workspace globs (e.g. packages/*) expand;
+    # a literal path yields itself.
+    for pj in "$ROOT"/$pattern/package.json; do
+      [ -f "$pj" ] || continue
+      name="$(jq -r '.name // empty' "$pj" 2>/dev/null || true)"
+      [ -n "$name" ] && valid="${valid}${name}"$'\n'
+    done
+  done < <(jq -r '.workspaces[]?' "$ROOT/package.json" 2>/dev/null || true)
+fi
+
+# Fail open: a name validator that cannot enumerate the workspace must not block
+# every PR. The authoritative check still runs at release time.
+if [ -z "${valid//[[:space:]]/}" ]; then
+  echo "validate-changeset-names: WARNING — could not determine workspace package names; skipping validation." >&2
+  exit 0
+fi
+
+is_valid() { printf '%s\n' "$valid" | grep -Fxq -- "$1"; }
+
+changesets="$(find "$ROOT/.changeset" -maxdepth 1 -type f -name '*.md' ! -name 'README.md' 2>/dev/null || true)"
+
+if [ -z "$changesets" ]; then
+  echo "validate-changeset-names: no changesets present — nothing to validate."
+  exit 0
+fi
+
+errors=""
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  # Frontmatter = lines strictly between the first and second '---' delimiters.
+  frontmatter="$(awk '$0 ~ /^---[[:space:]]*$/ { d++; next } d==1 { print }' "$file")"
+  while IFS= read -r line; do
+    case "$line" in *:*) ;; *) continue ;; esac
+    val="${line#*:}"
+    val="$(printf '%s' "$val" | sed -E 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    val="${val#\"}"; val="${val%\"}"; val="${val#\'}"; val="${val%\'}"
+    case "$val" in
+      patch|minor|major) ;;
+      *) continue ;;
+    esac
+    key="${line%%:*}"
+    key="$(printf '%s' "$key" | sed -E 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    key="${key#\"}"; key="${key%\"}"; key="${key#\'}"; key="${key%\'}"
+    [ -n "$key" ] || continue
+    if ! is_valid "$key"; then
+      errors="${errors}  ${file##*/}: \"${key}\""$'\n'
+    fi
+  done <<EOF
+$frontmatter
+EOF
+done <<EOF
+$changesets
+EOF
+
+if [ -n "$errors" ]; then
+  echo "ERROR: changeset references package name(s) not in the workspace:" >&2
+  printf '%s' "$errors" >&2
+  echo >&2
+  echo "Valid workspace packages:" >&2
+  printf '%s\n' "$valid" | grep -v '^$' | sed 's/^/  /' >&2
+  cat >&2 <<'MSG'
+
+A changeset with an unknown package name passes PR CI but aborts
+`changeset version` in release.yml on main, blocking every subsequent
+release (GH #316 / B215 / PR #314).
+
+Fix: edit the changeset frontmatter to use a real workspace package name
+(see the list above). The version-source package is "rn-dev-agent-plugin".
+MSG
+  exit 1
+fi
+
+echo "validate-changeset-names: all changeset package names are valid workspace packages."
+printf '%s\n' "$changesets" | sed 's/^/  /'
+exit 0


### PR DESCRIPTION
## What

Adds a CI guard that fails a PR whose `.changeset/*.md` frontmatter references a package name that is not a real workspace package — so a typo is caught on the **PR**, not on **main**.

## Why (#316 / B215)

`require-changeset` only asserted a changeset *exists*. A typo'd package name (`"rn-dev-agent"` instead of the version-source package `"rn-dev-agent-plugin"`, B215 / PR #314) passed PR CI and then aborted `changeset version` in `release.yml` on `main` with *"Found changeset … for package rn-dev-agent which is not in the workspace"*, **blocking six merges (#304→#313)** until #314 fixed the names.

## How

- **`scripts/validate-changeset-names.sh`** — pure-bash guard. Derives valid names from root `package.json` `workspaces` via `jq` (no hardcoded list, no drift), validates **all** present changesets, and **fails open** with a warning if the workspace set can't be determined (a name validator must not become a new way to block every PR; `release.yml` stays the authoritative check). Handles quoted/unquoted/single-quoted keys, quoted bump values, scoped `@scope/name`, and CRLF.
- **`scripts/test/validate-changeset-names.test.sh`** — 17 assertions (valid/invalid, multi-package, multi-file, CRLF, quote variants, quoted bump value, fail-open, workspace-scan). bash 3.2 + 5 compatible.
- **`.github/workflows/ci.yml`** — unit test in the `test` job + a `Validate changeset package names` step in the PR-only `require-changeset` job.

## Verification

- 17/17 new tests pass; existing `require-changeset.test.sh` still green.
- Run against the real repo: derives `rn-dev-agent-cdp` + `rn-dev-agent-plugin`, passes the pending changeset, and — fed the exact B215 typo — fails with an actionable message naming the bad package + valid set.
- Reviewed by Codex + Gemini (no blocking/important issues; both advisories — single-quote false-positive, quoted-value false-negative — folded in and pinned by tests).

## Changeset

None — CI-only change (outside the guard's own `^scripts/cdp-bridge/src/` shippable-source path), so no version bump.

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)