### PR TITLE
perf(#321): cached device_find reuse (invalidate-on-mutation) + verify-via-state guidance

### DIFF
--- a/.changeset/321-cached-find-reuse.md
+++ b/.changeset/321-cached-find-reuse.md
@@ -14,9 +14,14 @@ an unchanged screen to ~0.004 ms (in-memory filter), saving ~1.45 s per avoided
 find.
 
 Correctness is gated on a two-condition validity check, not just a TTL: the cache
-is invalidated by any screen-mutating verb (tap/press/fill/type/swipe/scroll/back/
-longpress/pinch/keyboard/drag) at the `runNative` dispatch choke point, AND it must
-be within the freshness budget. A tap that navigates therefore forces a fresh
-snapshot — a cache is never reused against a screen it no longer describes. Only the
-`device_find` handler opts in (`allowCache`); all other snapshot callers are
-unchanged.
+must be clean AND within the freshness budget. Invalidation is **fail-safe and
+centralized at the MCP tool boundary** (`trackedTool`): every tool call that is not
+on an explicit read allowlist marks the cache dirty — so JS-level mutations that
+bypass the native dispatch path (`cdp_interact`, `cdp_navigate`, the `fastSwipe`
+swipe/scroll path, `device_deeplink`, `cdp_dispatch`/`cdp_reload`/`maestro_run`, …)
+all invalidate it, and any future tool defaults to "invalidate" until proven a pure
+read. The native `runNative` choke point also marks dirty as defense-in-depth for
+direct (intra-composite) handler calls. A tap or navigation therefore forces a
+fresh snapshot — the cache is never reused against a screen it no longer describes.
+Only the `device_find` handler opts in (`allowCache`); all other snapshot callers
+are unchanged.

--- a/.changeset/321-cached-find-reuse.md
+++ b/.changeset/321-cached-find-reuse.md
@@ -1,0 +1,22 @@
+---
+"rn-dev-agent-plugin": patch
+---
+
+Live-sim speedup (GH #321): `device_find` now reuses the snapshot it already
+captured instead of issuing a redundant runner round-trip — but only while that
+snapshot is still a faithful picture of the screen.
+
+A snapshot cache already existed (`cacheSnapshot`) but nothing read it for
+targeting, so every `device_find` re-snapshotted. On the live iOS test-app a warm
+`device_find` measured ~1,449 ms — essentially one full XCUITest accessibility
+snapshot (~1,435 ms) plus matching. Reusing a valid cache drops a repeated find on
+an unchanged screen to ~0.004 ms (in-memory filter), saving ~1.45 s per avoided
+find.
+
+Correctness is gated on a two-condition validity check, not just a TTL: the cache
+is invalidated by any screen-mutating verb (tap/press/fill/type/swipe/scroll/back/
+longpress/pinch/keyboard/drag) at the `runNative` dispatch choke point, AND it must
+be within the freshness budget. A tap that navigates therefore forces a fresh
+snapshot — a cache is never reused against a screen it no longer describes. Only the
+`device_find` handler opts in (`allowCache`); all other snapshot callers are
+unchanged.

--- a/agents/rn-debugger.md
+++ b/agents/rn-debugger.md
@@ -213,9 +213,16 @@ After identifying root cause:
 
 ### Step 6: Verify Recovery
 
+Confirm the fix by its EFFECT on internal state first; re-perceive the screen only
+when you need visual proof (GH #321 — a `device_snapshot` is a full XCUITest
+round-trip, ~1,450 ms; a screenshot spends image tokens). Cheap signals first:
+`expect_route`/`expect_redux`/`expect_text`, then scoped `cdp_store_state`/
+`cdp_navigation_state`/`cdp_error_log`, then a screenshot for the visual record.
+
 After the fix:
 1. `cdp_status` -- confirm no errors, RedBox gone
-2. Take a new screenshot and compare to Step 1
+2. Confirm the fixed state cheaply (`expect_*` / `cdp_store_state`); take a
+   screenshot to compare with Step 1 when a visual record is needed
 3. `cdp_error_log` -- confirm the error is cleared
 4. Re-run the failing user action with Maestro to confirm it works.
    Substitute placeholders with actual values from Step 0:

--- a/agents/rn-tester.md
+++ b/agents/rn-tester.md
@@ -313,6 +313,20 @@ Verify: `cdp_navigation_state` confirms you're on the right screen.
 
 ### Step 4: Execute and Verify (The Core Loop)
 
+**Verification cost hierarchy (GH #321 — confirm the EFFECT, don't re-perceive the screen).**
+After an action, prove it worked with the CHEAPEST signal that demonstrates the
+effect — re-perceiving the whole screen after every step is the dominant per-step
+cost (a `device_snapshot` is a full XCUITest accessibility round-trip, measured at
+~1,450 ms on iOS; a screenshot spends image tokens). Prefer, in order:
+
+1. **State assertions** — `expect_route`, `expect_redux`, `expect_visible_by_testid`,
+   `expect_text`. Internal-state truth, ~hundreds of tokens, no snapshot.
+2. **Scoped CDP reads** — `cdp_store_state(path=…)`, `cdp_navigation_state`,
+   `cdp_component_tree(filter=…, depth≤2)`. Source of truth, cheap.
+3. **Full re-perception** — `device_snapshot` / `device_screenshot`. Use ONLY when
+   you genuinely need fresh `@refs` to act next, or a cheap assertion failed and you
+   must diagnose visually. Not the default confirm step.
+
 For EACH step in the flow:
 
 1. **Act**: Use agent-device for native interaction (preferred), or Maestro for

--- a/scripts/cdp-bridge/dist/agent-device-wrapper.js
+++ b/scripts/cdp-bridge/dist/agent-device-wrapper.js
@@ -5,7 +5,7 @@ import { createHash } from 'node:crypto';
 import { failResult } from './utils.js';
 import { startFastRunner, probeFastRunnerLiveness, reapStaleFastRunner, hasBuiltTestProduct, derivedDataPathForRunner, } from './runners/rn-fast-runner-client.js';
 import { resolveBootedIosUdid } from './tools/device-screenshot-raw.js';
-import { refCenter, getScreenRect, clearRefMap, isRefMapFresh } from './fast-runner-ref-map.js';
+import { refCenter, getScreenRect, clearRefMap, isRefMapFresh, MAX_REF_MAP_AGE_MS } from './fast-runner-ref-map.js';
 import { resolveBundleId } from './project-config.js';
 /**
  * CDP-015: derive a per-user, per-project session file path. The previous
@@ -123,15 +123,47 @@ export function getSessionFilePathForTest() { return SESSION_FILE; }
 export function resetActiveSessionInMemoryForTest() {
     activeSession = null;
 }
+// Test-only: set the in-memory session pointer WITHOUT the on-disk write that
+// setActiveSession() performs. Tests that exercise platform-gated paths (e.g.
+// the GH #321 cached-find reuse) must not clobber a developer's live MCP
+// session file, which is a shared, uid-keyed path.
+export function setActiveSessionInMemoryForTest(info) {
+    activeSession = info;
+}
 export function hasActiveSession() {
     return activeSession !== null;
 }
 const snapshotCache = new Map();
+// Live-sim speedup (GH #321): device_find reuses the snapshot it already
+// captured instead of re-snapshotting every call — but only while that snapshot
+// still faithfully describes the screen. A tap/navigation changes the screen, so
+// reuse is gated on TWO conditions: not dirtied by a mutating verb since capture,
+// AND within the TTL (coordinate-drift guard, mirrors MAX_REF_MAP_AGE_MS). The
+// dirty flag is the load-bearing correctness piece: a fresh-by-time but
+// stale-by-content cache would drive a wrong-element tap.
+let snapshotCacheDirty = true;
 export function cacheSnapshot(platform, nodes) {
-    snapshotCache.set(platform, { platform, nodes, capturedAt: new Date().toISOString() });
+    snapshotCache.set(platform, { platform, nodes, capturedAt: new Date().toISOString(), capturedAtMs: Date.now() });
+    // A fresh snapshot is, by definition, a clean picture of the current screen.
+    snapshotCacheDirty = false;
 }
 export function getCachedSnapshot(platform) {
     return snapshotCache.get(platform);
+}
+// Called at the runNative dispatch choke point on any screen-mutating verb
+// (tap/press/fill/type/swipe/scroll/back/longpress/pinch/keyboard/drag).
+export function markSnapshotDirty() {
+    snapshotCacheDirty = true;
+}
+// True only when the cached snapshot is safe to reuse for targeting: present,
+// not invalidated by a mutating verb, and within the freshness budget.
+export function isSnapshotCacheValid(platform, maxAgeMs = MAX_REF_MAP_AGE_MS) {
+    if (snapshotCacheDirty)
+        return false;
+    const entry = snapshotCache.get(platform);
+    if (!entry)
+        return false;
+    return Date.now() - entry.capturedAtMs <= maxAgeMs;
 }
 export function listCachedSnapshots() {
     return [...snapshotCache.keys()];
@@ -181,6 +213,22 @@ const RN_FAST_RUNNER_COMMANDS = new Set([
     'keyboard',
     'swipe',
     'scroll',
+    'longpress',
+    'pinch',
+]);
+// GH #321: verbs that can change what's on screen, so a cached snapshot can no
+// longer be trusted for targeting after one runs. snapshot/screenshot are reads
+// and are deliberately absent.
+const SNAPSHOT_MUTATING_VERBS = new Set([
+    'tap',
+    'press',
+    'fill',
+    'type',
+    'back',
+    'keyboard',
+    'swipe',
+    'scroll',
+    'drag',
     'longpress',
     'pinch',
 ]);
@@ -535,6 +583,14 @@ export async function runNative(cliArgs, opts = {}) {
     if (!_testSeamFused) {
         _testSeamFused = true;
         _testSeamFuseBlownBy = cliArgs[0] ?? '<empty>';
+    }
+    // GH #321 (live-sim speedup): a screen-mutating verb invalidates the snapshot
+    // cache so a subsequent device_find re-snapshots instead of targeting against
+    // a now-stale picture of the screen. Marked here, at the single dispatch choke
+    // point, so it covers iOS and Android uniformly. snapshot/screenshot don't
+    // change the screen and are intentionally excluded.
+    if (SNAPSHOT_MUTATING_VERBS.has(cliArgs[0])) {
+        markSnapshotDirty();
     }
     // GH #105 iOS-MVP §3.1: iOS short-circuit. Every supported command goes
     // through our rn-fast-runner HTTP client (no daemon, no CLI). The runner

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -57,7 +57,7 @@ import { Lockfile, formatLockConflictMessage } from './lifecycle/lockfile.js';
 import { startParentDeathWatch } from './lifecycle/parent-watch.js';
 import { arbiterWrap, arbiter } from './lifecycle/device-arbiter.js';
 import { setForeignGateUdidProvider, foreignFlowGate } from './lifecycle/foreign-flow-gate.js';
-import { getActiveSession } from './agent-device-wrapper.js';
+import { getActiveSession, markSnapshotDirty } from './agent-device-wrapper.js';
 import { createMaestroRunHandler } from './tools/maestro-run.js';
 import { createMaestroGenerateHandler } from './tools/maestro-generate.js';
 import { createMaestroTestAllHandler } from './tools/maestro-test-all.js';
@@ -69,7 +69,7 @@ import { stopFastRunner } from './runners/rn-fast-runner-client.js';
 import { ensureSingleRunner } from './runners/ensure-single-runner.js';
 import { instrumentTool, setToolObserver } from './observability/instrumentation.js';
 import { recorder } from './observability/recorder.js';
-import { maybeCaptureLiveFrame, isStateMutating, mayTriggerLiveCapture, buildLiveDeps } from './observability/live-device.js';
+import { maybeCaptureLiveFrame, isStateMutating, mayTriggerLiveCapture, toolInvalidatesSnapshotCache, buildLiveDeps } from './observability/live-device.js';
 import { tryRawScreenshot } from './tools/device-screenshot-raw.js';
 import { observeHandler, observeSchema } from './tools/observe.js';
 const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
@@ -149,18 +149,23 @@ const liveDeps = buildLiveDeps({
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function trackedTool(name, desc, schema, handler) {
     const base = instrumentTool(name, arbiterWrap(name, handler));
-    // Install the live-capture wrapper for any tool that COULD mutate (some only
-    // do for certain args, e.g. device_find action="click"), then make the actual
-    // decision per-call from the args (PR #296 review P2).
-    const wrapped = (liveEnabled && mayTriggerLiveCapture(name))
-        ? async (...a) => {
-            const result = await base(...a);
-            if (isStateMutating(name, a[0])) {
-                void maybeCaptureLiveFrame(liveDeps);
-            }
-            return result;
+    // GH #321: the device_find snapshot-cache must be invalidated after ANY tool
+    // that could change the screen — including JS-level mutations that bypass the
+    // runNative choke point (cdp_interact, cdp_navigate, device_deeplink, the
+    // fastSwipe path, cdp_dispatch/reload/maestro_*). trackedTool is the one
+    // boundary every external call crosses, so the fail-safe invalidation lives
+    // here and runs regardless of liveEnabled. GH #206 live capture layers on top.
+    const installLiveCapture = liveEnabled && mayTriggerLiveCapture(name);
+    const wrapped = async (...a) => {
+        const result = await base(...a);
+        const args = a[0];
+        if (toolInvalidatesSnapshotCache(name, args))
+            markSnapshotDirty();
+        if (installLiveCapture && isStateMutating(name, args)) {
+            void maybeCaptureLiveFrame(liveDeps);
         }
-        : base;
+        return result;
+    };
     server.tool(name, desc, schema, wrapped);
 }
 trackedTool('cdp_status', 'Get full environment status. Auto-connects if not connected. Returns Metro status, CDP connection, app info, capabilities, active errors, and RedBox/paused state. Call this FIRST before any testing.', {

--- a/scripts/cdp-bridge/dist/observability/live-device.js
+++ b/scripts/cdp-bridge/dist/observability/live-device.js
@@ -21,6 +21,42 @@ export function isStateMutating(tool, args) {
     return false;
 }
 /**
+ * GH #321: tools that NEVER change the on-screen UI, so a valid snapshot cache
+ * (used by device_find to skip a redundant ~1,450 ms snapshot) survives them.
+ * This is the allowlist for a FAIL-SAFE rule: any tool NOT listed here is treated
+ * as a potential mutation and invalidates the cache. A redundant snapshot is
+ * cheap; serving a stale snapshot after an unlisted mutation (cdp_dispatch,
+ * cdp_reload, maestro_run, cdp_evaluate, cdp_mmkv write, …) would be a
+ * wrong-element tap. New tools therefore default to "invalidate" until proven a
+ * pure read.
+ */
+const SNAPSHOT_CACHE_READS = new Set([
+    // CDP / native introspection
+    'cdp_component_tree', 'cdp_component_state', 'cdp_store_state', 'cdp_network_log',
+    'cdp_network_body', 'cdp_console_log', 'cdp_error_log', 'cdp_native_errors',
+    'cdp_diagnostic_renderers', 'cdp_object_inspect', 'cdp_heap_usage', 'collect_logs',
+    'cdp_metro_events', 'cdp_wait_for_network',
+    // perception (the cache's producer + consumer)
+    'device_snapshot', 'device_screenshot',
+    // navigation reads (NOT cdp_navigate, which changes the screen)
+    'cdp_navigation_state', 'cdp_nav_graph',
+    // diagnostics / connection
+    'cdp_status', 'cdp_targets', 'device_list', 'observe',
+    // state assertions (verify-via-state — pure reads)
+    'expect_redux', 'expect_route', 'expect_visible_by_testid', 'expect_text',
+    'cross_platform_verify',
+]);
+/**
+ * GH #321: should this tool call invalidate the device_find snapshot cache?
+ * Fail-safe: invalidate unless the tool is a known read. `device_find` is a read
+ * UNLESS it taps (`action: 'click'`), mirroring isStateMutating's per-call rule.
+ */
+export function toolInvalidatesSnapshotCache(tool, args) {
+    if (tool === 'device_find')
+        return args?.action === 'click';
+    return !SNAPSHOT_CACHE_READS.has(tool);
+}
+/**
  * Registration-time gate: could this tool EVER trigger a live capture (for
  * some args)? Used to decide whether to install the per-call wrapper at all.
  * Tools that can only mutate for certain args (device_find) must still be

--- a/scripts/cdp-bridge/dist/tools/device-interact.js
+++ b/scripts/cdp-bridge/dist/tools/device-interact.js
@@ -1,6 +1,6 @@
 import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
-import { runNative, getActiveSession, clearActiveSession, getCachedScreenRect, getAdbSerial, cacheSnapshot } from '../agent-device-wrapper.js';
+import { runNative, getActiveSession, clearActiveSession, getCachedScreenRect, getAdbSerial, cacheSnapshot, getCachedSnapshot, isSnapshotCacheValid } from '../agent-device-wrapper.js';
 import { isFastRunnerAvailable, fastSwipe, stopFastRunner } from '../runners/rn-fast-runner-client.js';
 import { stopAndroidRunner } from '../runners/rn-android-runner-client.js';
 import { withSession } from '../utils.js';
@@ -98,7 +98,19 @@ function parseSnapshotEnvelope(result) {
         return null;
     }
 }
-async function fetchSnapshotNodes() {
+async function fetchSnapshotNodes(allowCache = false) {
+    // GH #321 (live-sim speedup): serve device_find from the snapshot we already
+    // captured when it's still a faithful picture of the screen (clean + fresh),
+    // skipping a redundant runner round-trip. isSnapshotCacheValid() is false the
+    // moment any mutating verb runs, so we never target against a stale screen.
+    if (allowCache) {
+        const platform = getActiveSession()?.platform;
+        if (platform && isSnapshotCacheValid(platform)) {
+            const cached = getCachedSnapshot(platform);
+            if (cached)
+                return { ok: true, nodes: cached.nodes };
+        }
+    }
     const first = await runNative(['snapshot', '-i']);
     const initialNodes = parseSnapshotEnvelope(first);
     if (initialNodes === null)
@@ -127,8 +139,8 @@ async function fetchSnapshotNodes() {
         cacheSnapshot(platform, recoveredNodes);
     return { ok: true, nodes: recoveredNodes, recoveredTier: recovery.tier };
 }
-export async function fetchFindCandidates(query, exact = false) {
-    const snap = await fetchSnapshotNodes();
+export async function fetchFindCandidates(query, exact = false, allowCache = false) {
+    const snap = await fetchSnapshotNodes(allowCache);
     if (!snap.ok)
         return snap;
     const needle = query.toLowerCase();
@@ -183,7 +195,7 @@ export function createDeviceFindHandler() {
         // go straight to a snapshot-based client-side match so we never roll the dice
         // on agent-device's fuzzy matcher returning AMBIGUOUS_MATCH.
         if (args.exact === true || args.index !== undefined) {
-            const find = await fetchFindCandidates(args.text, args.exact === true);
+            const find = await fetchFindCandidates(args.text, args.exact === true, true);
             if (!find.ok) {
                 if (find.reason === 'runner-leak-unrecovered') {
                     return runnerLeakFailResult(args.text, find.recoveryReason);
@@ -220,7 +232,7 @@ export function createDeviceFindHandler() {
         const usesInTreeRunner = activeSession?.platform === 'ios' ||
             (activeSession?.platform === 'android' && process.env.RN_ANDROID_RUNNER !== '0');
         if (usesInTreeRunner) {
-            const find = await fetchFindCandidates(args.text, false);
+            const find = await fetchFindCandidates(args.text, false, true);
             if (!find.ok) {
                 if (find.reason === 'runner-leak-unrecovered') {
                     return runnerLeakFailResult(args.text, find.recoveryReason);

--- a/scripts/cdp-bridge/src/agent-device-wrapper.ts
+++ b/scripts/cdp-bridge/src/agent-device-wrapper.ts
@@ -15,7 +15,7 @@ import {
 } from './runners/rn-fast-runner-client.js';
 import type { FastRunnerLiveness } from './runners/rn-fast-runner-client.js';
 import { resolveBootedIosUdid } from './tools/device-screenshot-raw.js';
-import { refCenter, getScreenRect, clearRefMap, isRefMapFresh } from './fast-runner-ref-map.js';
+import { refCenter, getScreenRect, clearRefMap, isRefMapFresh, MAX_REF_MAP_AGE_MS } from './fast-runner-ref-map.js';
 import { resolveBundleId } from './project-config.js';
 
 /**
@@ -137,6 +137,14 @@ export function resetActiveSessionInMemoryForTest(): void {
   activeSession = null;
 }
 
+// Test-only: set the in-memory session pointer WITHOUT the on-disk write that
+// setActiveSession() performs. Tests that exercise platform-gated paths (e.g.
+// the GH #321 cached-find reuse) must not clobber a developer's live MCP
+// session file, which is a shared, uid-keyed path.
+export function setActiveSessionInMemoryForTest(info: SessionState): void {
+  activeSession = info;
+}
+
 export function hasActiveSession(): boolean {
   return activeSession !== null;
 }
@@ -145,18 +153,47 @@ export function hasActiveSession(): boolean {
 // Updated by fetchSnapshotNodes() in device-interact.ts whenever a snapshot succeeds.
 interface CachedSnapshot {
   platform: string;
-  nodes: { ref: string; label?: string; identifier?: string; type?: string; hittable?: boolean }[];
+  // Lossless: the full runner nodes are stored (rect/enabled included) so a
+  // cache-served device_find ranks and dedups identically to a fresh snapshot.
+  nodes: { ref: string; label?: string; identifier?: string; type?: string; hittable?: boolean; enabled?: boolean; rect?: { x: number; y: number; width: number; height: number } }[];
   capturedAt: string;
+  capturedAtMs: number;
 }
 
 const snapshotCache = new Map<string, CachedSnapshot>();
 
+// Live-sim speedup (GH #321): device_find reuses the snapshot it already
+// captured instead of re-snapshotting every call — but only while that snapshot
+// still faithfully describes the screen. A tap/navigation changes the screen, so
+// reuse is gated on TWO conditions: not dirtied by a mutating verb since capture,
+// AND within the TTL (coordinate-drift guard, mirrors MAX_REF_MAP_AGE_MS). The
+// dirty flag is the load-bearing correctness piece: a fresh-by-time but
+// stale-by-content cache would drive a wrong-element tap.
+let snapshotCacheDirty = true;
+
 export function cacheSnapshot(platform: string, nodes: CachedSnapshot['nodes']): void {
-  snapshotCache.set(platform, { platform, nodes, capturedAt: new Date().toISOString() });
+  snapshotCache.set(platform, { platform, nodes, capturedAt: new Date().toISOString(), capturedAtMs: Date.now() });
+  // A fresh snapshot is, by definition, a clean picture of the current screen.
+  snapshotCacheDirty = false;
 }
 
 export function getCachedSnapshot(platform: string): CachedSnapshot | undefined {
   return snapshotCache.get(platform);
+}
+
+// Called at the runNative dispatch choke point on any screen-mutating verb
+// (tap/press/fill/type/swipe/scroll/back/longpress/pinch/keyboard/drag).
+export function markSnapshotDirty(): void {
+  snapshotCacheDirty = true;
+}
+
+// True only when the cached snapshot is safe to reuse for targeting: present,
+// not invalidated by a mutating verb, and within the freshness budget.
+export function isSnapshotCacheValid(platform: string, maxAgeMs: number = MAX_REF_MAP_AGE_MS): boolean {
+  if (snapshotCacheDirty) return false;
+  const entry = snapshotCache.get(platform);
+  if (!entry) return false;
+  return Date.now() - entry.capturedAtMs <= maxAgeMs;
 }
 
 export function listCachedSnapshots(): string[] {
@@ -208,6 +245,23 @@ const RN_FAST_RUNNER_COMMANDS = new Set<string>([
   'keyboard',
   'swipe',
   'scroll',
+  'longpress',
+  'pinch',
+]);
+
+// GH #321: verbs that can change what's on screen, so a cached snapshot can no
+// longer be trusted for targeting after one runs. snapshot/screenshot are reads
+// and are deliberately absent.
+const SNAPSHOT_MUTATING_VERBS = new Set<string>([
+  'tap',
+  'press',
+  'fill',
+  'type',
+  'back',
+  'keyboard',
+  'swipe',
+  'scroll',
+  'drag',
   'longpress',
   'pinch',
 ]);
@@ -608,6 +662,15 @@ export async function runNative(
   if (!_testSeamFused) {
     _testSeamFused = true;
     _testSeamFuseBlownBy = cliArgs[0] ?? '<empty>';
+  }
+
+  // GH #321 (live-sim speedup): a screen-mutating verb invalidates the snapshot
+  // cache so a subsequent device_find re-snapshots instead of targeting against
+  // a now-stale picture of the screen. Marked here, at the single dispatch choke
+  // point, so it covers iOS and Android uniformly. snapshot/screenshot don't
+  // change the screen and are intentionally excluded.
+  if (SNAPSHOT_MUTATING_VERBS.has(cliArgs[0])) {
+    markSnapshotDirty();
   }
 
   // GH #105 iOS-MVP §3.1: iOS short-circuit. Every supported command goes

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -79,7 +79,7 @@ import { Lockfile, formatLockConflictMessage } from './lifecycle/lockfile.js';
 import { startParentDeathWatch } from './lifecycle/parent-watch.js';
 import { arbiterWrap, arbiter } from './lifecycle/device-arbiter.js';
 import { setForeignGateUdidProvider, foreignFlowGate } from './lifecycle/foreign-flow-gate.js';
-import { getActiveSession } from './agent-device-wrapper.js';
+import { getActiveSession, markSnapshotDirty } from './agent-device-wrapper.js';
 import { createMaestroRunHandler } from './tools/maestro-run.js';
 import { createMaestroGenerateHandler } from './tools/maestro-generate.js';
 import { createMaestroTestAllHandler } from './tools/maestro-test-all.js';
@@ -99,7 +99,7 @@ import { stopFastRunner } from './runners/rn-fast-runner-client.js';
 import { ensureSingleRunner } from './runners/ensure-single-runner.js';
 import { instrumentTool, setToolObserver } from './observability/instrumentation.js';
 import { recorder } from './observability/recorder.js';
-import { maybeCaptureLiveFrame, isStateMutating, mayTriggerLiveCapture, buildLiveDeps } from './observability/live-device.js';
+import { maybeCaptureLiveFrame, isStateMutating, mayTriggerLiveCapture, toolInvalidatesSnapshotCache, buildLiveDeps } from './observability/live-device.js';
 import { tryRawScreenshot } from './tools/device-screenshot-raw.js';
 import { observeHandler, observeSchema } from './tools/observe.js';
 
@@ -186,18 +186,22 @@ function trackedTool(name: string, desc: string, schema: any, handler: any): voi
     name,
     handler as (...args: unknown[]) => Promise<import('./utils.js').ToolResult>,
   ) as (...args: unknown[]) => Promise<unknown>);
-  // Install the live-capture wrapper for any tool that COULD mutate (some only
-  // do for certain args, e.g. device_find action="click"), then make the actual
-  // decision per-call from the args (PR #296 review P2).
-  const wrapped = (liveEnabled && mayTriggerLiveCapture(name))
-    ? async (...a: unknown[]): Promise<unknown> => {
-        const result = await base(...a);
-        if (isStateMutating(name, a[0] as Record<string, unknown> | undefined)) {
-          void maybeCaptureLiveFrame(liveDeps);
-        }
-        return result;
-      }
-    : base;
+  // GH #321: the device_find snapshot-cache must be invalidated after ANY tool
+  // that could change the screen — including JS-level mutations that bypass the
+  // runNative choke point (cdp_interact, cdp_navigate, device_deeplink, the
+  // fastSwipe path, cdp_dispatch/reload/maestro_*). trackedTool is the one
+  // boundary every external call crosses, so the fail-safe invalidation lives
+  // here and runs regardless of liveEnabled. GH #206 live capture layers on top.
+  const installLiveCapture = liveEnabled && mayTriggerLiveCapture(name);
+  const wrapped = async (...a: unknown[]): Promise<unknown> => {
+    const result = await base(...a);
+    const args = a[0] as Record<string, unknown> | undefined;
+    if (toolInvalidatesSnapshotCache(name, args)) markSnapshotDirty();
+    if (installLiveCapture && isStateMutating(name, args)) {
+      void maybeCaptureLiveFrame(liveDeps);
+    }
+    return result;
+  };
   server.tool(name, desc, schema, wrapped as typeof handler);
 }
 

--- a/scripts/cdp-bridge/src/observability/live-device.ts
+++ b/scripts/cdp-bridge/src/observability/live-device.ts
@@ -21,6 +21,43 @@ export function isStateMutating(tool: string, args?: Record<string, unknown>): b
 }
 
 /**
+ * GH #321: tools that NEVER change the on-screen UI, so a valid snapshot cache
+ * (used by device_find to skip a redundant ~1,450 ms snapshot) survives them.
+ * This is the allowlist for a FAIL-SAFE rule: any tool NOT listed here is treated
+ * as a potential mutation and invalidates the cache. A redundant snapshot is
+ * cheap; serving a stale snapshot after an unlisted mutation (cdp_dispatch,
+ * cdp_reload, maestro_run, cdp_evaluate, cdp_mmkv write, …) would be a
+ * wrong-element tap. New tools therefore default to "invalidate" until proven a
+ * pure read.
+ */
+const SNAPSHOT_CACHE_READS = new Set<string>([
+  // CDP / native introspection
+  'cdp_component_tree', 'cdp_component_state', 'cdp_store_state', 'cdp_network_log',
+  'cdp_network_body', 'cdp_console_log', 'cdp_error_log', 'cdp_native_errors',
+  'cdp_diagnostic_renderers', 'cdp_object_inspect', 'cdp_heap_usage', 'collect_logs',
+  'cdp_metro_events', 'cdp_wait_for_network',
+  // perception (the cache's producer + consumer)
+  'device_snapshot', 'device_screenshot',
+  // navigation reads (NOT cdp_navigate, which changes the screen)
+  'cdp_navigation_state', 'cdp_nav_graph',
+  // diagnostics / connection
+  'cdp_status', 'cdp_targets', 'device_list', 'observe',
+  // state assertions (verify-via-state — pure reads)
+  'expect_redux', 'expect_route', 'expect_visible_by_testid', 'expect_text',
+  'cross_platform_verify',
+]);
+
+/**
+ * GH #321: should this tool call invalidate the device_find snapshot cache?
+ * Fail-safe: invalidate unless the tool is a known read. `device_find` is a read
+ * UNLESS it taps (`action: 'click'`), mirroring isStateMutating's per-call rule.
+ */
+export function toolInvalidatesSnapshotCache(tool: string, args?: Record<string, unknown>): boolean {
+  if (tool === 'device_find') return args?.action === 'click';
+  return !SNAPSHOT_CACHE_READS.has(tool);
+}
+
+/**
  * Registration-time gate: could this tool EVER trigger a live capture (for
  * some args)? Used to decide whether to install the per-call wrapper at all.
  * Tools that can only mutate for certain args (device_find) must still be

--- a/scripts/cdp-bridge/src/tools/device-interact.ts
+++ b/scripts/cdp-bridge/src/tools/device-interact.ts
@@ -1,6 +1,6 @@
 import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
-import { runNative, getActiveSession, clearActiveSession, getCachedScreenRect, getAdbSerial, cacheSnapshot } from '../agent-device-wrapper.js';
+import { runNative, getActiveSession, clearActiveSession, getCachedScreenRect, getAdbSerial, cacheSnapshot, getCachedSnapshot, isSnapshotCacheValid } from '../agent-device-wrapper.js';
 import { isFastRunnerAvailable, fastSwipe, stopFastRunner } from '../runners/rn-fast-runner-client.js';
 import { stopAndroidRunner } from '../runners/rn-android-runner-client.js';
 import { withSession } from '../utils.js';
@@ -132,7 +132,19 @@ export type SnapshotFetchResult =
   | { ok: false; reason: 'fetch-failed' }
   | { ok: false; reason: 'runner-leak-unrecovered'; recoveryReason?: string };
 
-async function fetchSnapshotNodes(): Promise<SnapshotFetchResult> {
+async function fetchSnapshotNodes(allowCache = false): Promise<SnapshotFetchResult> {
+  // GH #321 (live-sim speedup): serve device_find from the snapshot we already
+  // captured when it's still a faithful picture of the screen (clean + fresh),
+  // skipping a redundant runner round-trip. isSnapshotCacheValid() is false the
+  // moment any mutating verb runs, so we never target against a stale screen.
+  if (allowCache) {
+    const platform = getActiveSession()?.platform;
+    if (platform && isSnapshotCacheValid(platform)) {
+      const cached = getCachedSnapshot(platform);
+      if (cached) return { ok: true, nodes: cached.nodes };
+    }
+  }
+
   const first = await runNative(['snapshot', '-i']);
   const initialNodes = parseSnapshotEnvelope(first);
   if (initialNodes === null) return { ok: false, reason: 'fetch-failed' };
@@ -172,8 +184,8 @@ export type FindCandidatesResult =
   | { ok: false; reason: 'fetch-failed' }
   | { ok: false; reason: 'runner-leak-unrecovered'; recoveryReason?: string };
 
-export async function fetchFindCandidates(query: string, exact = false): Promise<FindCandidatesResult> {
-  const snap = await fetchSnapshotNodes();
+export async function fetchFindCandidates(query: string, exact = false, allowCache = false): Promise<FindCandidatesResult> {
+  const snap = await fetchSnapshotNodes(allowCache);
   if (!snap.ok) return snap;
 
   const needle = query.toLowerCase();
@@ -241,7 +253,7 @@ export function createDeviceFindHandler(): (args: FindArgs) => Promise<ToolResul
     // go straight to a snapshot-based client-side match so we never roll the dice
     // on agent-device's fuzzy matcher returning AMBIGUOUS_MATCH.
     if (args.exact === true || args.index !== undefined) {
-      const find = await fetchFindCandidates(args.text, args.exact === true);
+      const find = await fetchFindCandidates(args.text, args.exact === true, true);
       if (!find.ok) {
         if (find.reason === 'runner-leak-unrecovered') {
           return runnerLeakFailResult(args.text, find.recoveryReason);
@@ -292,7 +304,7 @@ export function createDeviceFindHandler(): (args: FindArgs) => Promise<ToolResul
       activeSession?.platform === 'ios' ||
       (activeSession?.platform === 'android' && process.env.RN_ANDROID_RUNNER !== '0');
     if (usesInTreeRunner) {
-      const find = await fetchFindCandidates(args.text, false);
+      const find = await fetchFindCandidates(args.text, false, true);
       if (!find.ok) {
         if (find.reason === 'runner-leak-unrecovered') {
           return runnerLeakFailResult(args.text, find.recoveryReason);

--- a/scripts/cdp-bridge/test/unit/live-sim-cached-find.test.js
+++ b/scripts/cdp-bridge/test/unit/live-sim-cached-find.test.js
@@ -1,0 +1,78 @@
+// Live-sim speedup (GH #321): device_find reuses a valid snapshot cache instead
+// of issuing a redundant runner snapshot — but re-snapshots once the cache is
+// invalidated by a mutating verb. This verifies the BEHAVIOR end-to-end through
+// fetchFindCandidates by counting runner dispatches.
+//
+// Uses the one-shot _setRunAgentDeviceForTest fuse, so it lives in its own file
+// (node --test isolates per file) and installs the override before any dispatch.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  _setRunAgentDeviceForTest,
+  setActiveSessionInMemoryForTest,
+  resetActiveSessionInMemoryForTest,
+  cacheSnapshot,
+  markSnapshotDirty,
+} from '../../dist/agent-device-wrapper.js';
+import { fetchFindCandidates } from '../../dist/tools/device-interact.js';
+
+const NODES = [
+  { ref: '@e0', label: 'Continue', identifier: 'continue-btn', type: 'Button', hittable: true, rect: { x: 10, y: 20, width: 100, height: 40 } },
+];
+
+function envelope(nodes) {
+  return { content: [{ type: 'text', text: JSON.stringify({ ok: true, data: { nodes } }) }] };
+}
+
+test('device_find serves from a valid cache without a runner snapshot; re-snapshots after a mutation', async () => {
+  let snapshotDispatches = 0;
+  _setRunAgentDeviceForTest((cliArgs) => {
+    if (cliArgs[0] === 'snapshot') snapshotDispatches++;
+    return Promise.resolve(envelope(NODES));
+  });
+  setActiveSessionInMemoryForTest({ name: 't', platform: 'ios', appId: 'com.test', openedAt: 'now' });
+
+  try {
+    // Prime a clean cache (as a real snapshot would).
+    cacheSnapshot('ios', NODES);
+
+    // 1st find: cache is valid -> NO runner dispatch.
+    const a = await fetchFindCandidates('Continue', false, true);
+    assert.equal(a.ok, true);
+    assert.equal(a.candidates[0].label, 'Continue');
+    assert.equal(snapshotDispatches, 0, 'a valid cache must not trigger a runner snapshot');
+
+    // 2nd find: still clean -> still NO dispatch.
+    await fetchFindCandidates('Continue', false, true);
+    assert.equal(snapshotDispatches, 0, 'repeated finds on an unchanged screen stay cache-served');
+
+    // A mutating verb happened -> cache is stale-by-content.
+    markSnapshotDirty();
+
+    // 3rd find: cache invalid -> exactly one fresh runner snapshot.
+    const c = await fetchFindCandidates('Continue', false, true);
+    assert.equal(c.ok, true);
+    assert.equal(snapshotDispatches, 1, 'a mutation must force a fresh snapshot');
+  } finally {
+    _setRunAgentDeviceForTest(null);
+    resetActiveSessionInMemoryForTest();
+  }
+});
+
+test('device_find with allowCache=false always re-snapshots (no behavior change for non-find callers)', async () => {
+  let snapshotDispatches = 0;
+  _setRunAgentDeviceForTest((cliArgs) => {
+    if (cliArgs[0] === 'snapshot') snapshotDispatches++;
+    return Promise.resolve(envelope(NODES));
+  });
+  setActiveSessionInMemoryForTest({ name: 't', platform: 'ios', appId: 'com.test', openedAt: 'now' });
+
+  try {
+    cacheSnapshot('ios', NODES); // even with a valid cache present...
+    await fetchFindCandidates('Continue', false, false); // ...allowCache=false ignores it
+    assert.equal(snapshotDispatches, 1, 'allowCache=false must always take a fresh snapshot');
+  } finally {
+    _setRunAgentDeviceForTest(null);
+    resetActiveSessionInMemoryForTest();
+  }
+});

--- a/scripts/cdp-bridge/test/unit/live-sim-snapshot-cache.test.js
+++ b/scripts/cdp-bridge/test/unit/live-sim-snapshot-cache.test.js
@@ -1,0 +1,77 @@
+// Live-sim speedup (quick win #2): device_find should reuse the snapshot it
+// already captured instead of re-snapshotting on every call — but ONLY while
+// that snapshot is still a faithful picture of the screen. A tap/navigation
+// changes the screen, so the cache must be invalidated by mutating verbs, not
+// just by a time-to-live (a fresh-by-time but stale-by-content cache would
+// drive a wrong-element tap — worse than a slow-but-correct snapshot).
+//
+// These tests pin the cache-validity STATE MACHINE:
+//   cacheSnapshot()      -> present + clean
+//   markSnapshotDirty()  -> invalid (a mutating verb happened)
+//   TTL                  -> invalid once too old
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  cacheSnapshot,
+  getCachedSnapshot,
+  markSnapshotDirty,
+  isSnapshotCacheValid,
+} from '../../dist/agent-device-wrapper.js';
+
+const NODES = [{ ref: '@e0', label: 'Continue', type: 'Button', hittable: true }];
+
+test('snapshot cache: a freshly cached snapshot is valid', () => {
+  cacheSnapshot('ios', NODES);
+  assert.equal(isSnapshotCacheValid('ios'), true);
+  assert.deepEqual(getCachedSnapshot('ios')?.nodes, NODES);
+});
+
+test('snapshot cache: a mutating verb invalidates the cache (content staleness)', () => {
+  cacheSnapshot('ios', NODES);
+  assert.equal(isSnapshotCacheValid('ios'), true);
+  markSnapshotDirty();
+  assert.equal(isSnapshotCacheValid('ios'), false, 'a tap/press must invalidate the cache');
+});
+
+test('snapshot cache: re-caching after a mutation makes it valid (clean) again', () => {
+  cacheSnapshot('ios', NODES);
+  markSnapshotDirty();
+  assert.equal(isSnapshotCacheValid('ios'), false);
+  cacheSnapshot('ios', NODES); // a fresh snapshot taken after the screen settled
+  assert.equal(isSnapshotCacheValid('ios'), true);
+});
+
+test('snapshot cache: an unknown platform is never valid', () => {
+  cacheSnapshot('ios', NODES);
+  assert.equal(isSnapshotCacheValid('android'), false);
+});
+
+test('snapshot cache: an over-age cache is invalid even when clean (TTL)', () => {
+  cacheSnapshot('ios', NODES);
+  // Force-expire with a negative age budget: any real age (>= 0) exceeds it,
+  // so this deterministically exercises the TTL branch without sleeping.
+  assert.equal(isSnapshotCacheValid('ios', -1), false);
+});
+
+test('snapshot cache: dirty flag is global but validity is keyed per platform read', () => {
+  // markSnapshotDirty invalidates the active device's cache; a subsequent fresh
+  // cache for that platform clears it. (The bridge drives one device at a time.)
+  cacheSnapshot('android', NODES);
+  assert.equal(isSnapshotCacheValid('android'), true);
+  markSnapshotDirty();
+  assert.equal(isSnapshotCacheValid('android'), false);
+});
+
+// Source guard: the invalidation MUST be wired at the runNative dispatch choke
+// point, otherwise the cache silently goes stale after taps in production.
+test('source guard: markSnapshotDirty is invoked inside runNative for mutating verbs', async () => {
+  const { readFileSync } = await import('node:fs');
+  const { fileURLToPath } = await import('node:url');
+  const { dirname, join } = await import('node:path');
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(join(__dirname, '../../dist/agent-device-wrapper.js'), 'utf-8');
+  // The wiring (not just the definition) must be present: the mutating-verb set
+  // is consulted at the dispatch choke point and triggers the invalidation.
+  assert.match(src, /SNAPSHOT_MUTATING_VERBS\.has\(/, 'runNative must gate invalidation on the mutating-verb set');
+  assert.match(src, /markSnapshotDirty\(\)/, 'runNative must call markSnapshotDirty() on mutating verbs');
+});

--- a/scripts/cdp-bridge/test/unit/live-sim-snapshot-cache.test.js
+++ b/scripts/cdp-bridge/test/unit/live-sim-snapshot-cache.test.js
@@ -17,6 +17,7 @@ import {
   markSnapshotDirty,
   isSnapshotCacheValid,
 } from '../../dist/agent-device-wrapper.js';
+import { toolInvalidatesSnapshotCache } from '../../dist/observability/live-device.js';
 
 const NODES = [{ ref: '@e0', label: 'Continue', type: 'Button', hittable: true }];
 
@@ -62,6 +63,45 @@ test('snapshot cache: dirty flag is global but validity is keyed per platform re
   assert.equal(isSnapshotCacheValid('android'), false);
 });
 
+// toolInvalidatesSnapshotCache: the FAIL-SAFE rule at the MCP tool boundary.
+// This is the load-bearing fix for the review finding that JS-level mutations
+// (cdp_interact, cdp_navigate), the fastSwipe path, deeplinks, dispatch, reloads,
+// and flows all bypass the runNative choke point.
+
+test('cache invalidation: pure reads PRESERVE the cache (return false)', () => {
+  for (const t of [
+    'device_snapshot', 'device_screenshot', 'cdp_store_state', 'cdp_component_tree',
+    'cdp_navigation_state', 'cdp_nav_graph', 'cdp_status', 'cdp_network_log',
+    'expect_route', 'expect_redux', 'expect_visible_by_testid', 'expect_text',
+    'cross_platform_verify', 'collect_logs',
+  ]) {
+    assert.equal(toolInvalidatesSnapshotCache(t), false, `${t} is a read and must preserve the cache`);
+  }
+});
+
+test('cache invalidation: screen-mutating tools INVALIDATE (return true) — incl. runNative-bypassing ones', () => {
+  for (const t of [
+    'cdp_interact', 'cdp_navigate', 'device_deeplink', // bypass runNative (the review finding)
+    'device_press', 'device_fill', 'device_swipe', 'device_scroll', 'device_back',
+    'device_longpress', 'device_pinch', 'device_batch',
+    'maestro_run', 'maestro_test_all', 'cdp_run_action', 'cdp_auto_login', // flows
+    'cdp_reload', 'cdp_restart', // lifecycle screen changes
+    'cdp_dispatch', 'cdp_evaluate', 'cdp_mmkv', 'cdp_set_shared_value', // 'other' mutators
+  ]) {
+    assert.equal(toolInvalidatesSnapshotCache(t), true, `${t} can change the screen and must invalidate`);
+  }
+});
+
+test('cache invalidation: device_find is a read unless it taps (action=click)', () => {
+  assert.equal(toolInvalidatesSnapshotCache('device_find'), false);
+  assert.equal(toolInvalidatesSnapshotCache('device_find', { text: 'x' }), false);
+  assert.equal(toolInvalidatesSnapshotCache('device_find', { action: 'click' }), true);
+});
+
+test('cache invalidation: fail-safe — an unknown/new tool invalidates by default', () => {
+  assert.equal(toolInvalidatesSnapshotCache('some_future_tool_we_have_not_classified'), true);
+});
+
 // Source guard: the invalidation MUST be wired at the runNative dispatch choke
 // point, otherwise the cache silently goes stale after taps in production.
 test('source guard: markSnapshotDirty is invoked inside runNative for mutating verbs', async () => {
@@ -74,4 +114,15 @@ test('source guard: markSnapshotDirty is invoked inside runNative for mutating v
   // is consulted at the dispatch choke point and triggers the invalidation.
   assert.match(src, /SNAPSHOT_MUTATING_VERBS\.has\(/, 'runNative must gate invalidation on the mutating-verb set');
   assert.match(src, /markSnapshotDirty\(\)/, 'runNative must call markSnapshotDirty() on mutating verbs');
+});
+
+test('source guard: the central trackedTool boundary wires fail-safe cache invalidation', async () => {
+  const { readFileSync } = await import('node:fs');
+  const { fileURLToPath } = await import('node:url');
+  const { dirname, join } = await import('node:path');
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(join(__dirname, '../../dist/index.js'), 'utf-8');
+  // Every external tool crosses trackedTool; the fail-safe invalidation must run there.
+  assert.match(src, /toolInvalidatesSnapshotCache\(/, 'trackedTool must consult the fail-safe predicate');
+  assert.match(src, /markSnapshotDirty\(\)/, 'trackedTool must invalidate the cache for mutating tools');
 });


### PR DESCRIPTION
## What

Two live-simulator speedups from the #321 brainstorm:

1. **Cached `device_find` (invalidate-on-mutation).** `device_find` reuses the snapshot it already captured instead of issuing a redundant runner round-trip — but only while that snapshot still faithfully describes the screen.
2. **Verify-via-state guidance** for `rn-tester`/`rn-debugger`: confirm an action's *effect* via `expect_*`/`cdp_store_state` before re-perceiving the whole screen.

## Why (measured, live iOS test-app)

`device_batch` of snapshot/find steps on the dev-menu screen:

| Operation | Duration |
|---|---|
| snapshot (cold, runner warmup) | 13,553 ms |
| find "Continue" (warm) | **1,449 ms** |
| snapshot (warm) | **1,435 ms** |
| find "Continue" (warm) | **1,460 ms** |

A warm `device_find` (~1,449 ms) ≈ one XCUITest accessibility snapshot (~1,435 ms) + matching. The snapshot round-trip dominates. A snapshot cache (`cacheSnapshot`) already existed but **nothing read it for targeting**, so every find re-snapshotted.

**After:** a repeated find on an unchanged screen serves from cache in **~0.004 ms** (in-memory filter, measured) — ~1.45 s saved per avoided find.

## Correctness — invalidate-on-mutation, not just TTL

The brainstorm's first instinct (trust the 60 s ref-map TTL) is unsafe: a tap that navigates leaves a cache that is *fresh by time but stale by content* → a wrong-element tap. Instead validity is two conditions:

- A `snapshotCacheDirty` flag set on **any screen-mutating verb** (tap/press/fill/type/swipe/scroll/back/longpress/pinch/keyboard/drag) at the single `runNative` dispatch choke point (covers iOS + Android), cleared when a fresh snapshot is cached.
- Within the freshness budget (`MAX_REF_MAP_AGE_MS`).

So `snapshot → find → find` = **one** round-trip; `snapshot → find → press → find` correctly re-snapshots after the press. Only the `device_find` handler opts in (`allowCache`); all other snapshot callers are byte-for-byte unchanged. The cache was widened to lossless so cached finds rank/dedup identically to fresh ones.

## Tests

- 7 state-machine unit tests (clean/dirty/TTL/per-platform/source-guard).
- 2 behavioral tests through `fetchFindCandidates`: valid cache → **0** runner snapshots; after a mutation → exactly **1**; `allowCache=false` always re-snapshots.
- Full unit suite **2195/2195** green.

## Verification status

Unit-tested + micro-benchmarked against this branch's `dist`. Live MCP end-to-end runs the *installed* plugin dist, so the cached path goes live on release; the behavior is proven here via the dist-level behavioral test. Logic is platform-agnostic (shared `runNative` choke point; Android `drag` covered) — full iOS+Android device-verify will follow on the released build.

## Changeset

`rn-dev-agent-plugin` patch (cdp-bridge src changed).

Refs #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)