### PR TITLE
perf(#321): device_batch salient final payload + finalSnapshot option

### DIFF
--- a/.changeset/321-batch-salient-payload.md
+++ b/.changeset/321-batch-salient-payload.md
@@ -1,0 +1,23 @@
+---
+"rn-dev-agent-plugin": patch
+---
+
+Live-sim speedup (GH #321, quick win #4): `device_batch` returns a **salient final
+payload** by default and gains a `finalSnapshot` option (`salient` | `full` |
+`none`).
+
+`device_batch` already collapses N interactions into one MCP round-trip, but its
+`final_snapshot` was always the full a11y node list (large) and it always took an
+implicit trailing snapshot. Now:
+
+- `salient` (default) — `final_snapshot` is compacted to only actionable nodes
+  (Button/TextField/Switch/Slider/Cell/Link/…), each `{ ref, type, label,
+  identifier, hittable? }`, with a `fullNodeCount`. Far fewer tokens; `@ref`s for
+  actionable elements are preserved so follow-up `device_press(ref)` still works.
+- `none` — skips the implicit trailing snapshot entirely (~1,450 ms saved) for
+  action-only batches verified via `expect_*`/`cdp_store_state`.
+- `full` — the legacy complete node list.
+
+An explicit `snapshot` step or `screenshotOn:'end'` still populates the payload;
+the option only governs the implicit trailing snapshot and its shape. `rn-tester`
+now recommends a single `device_batch` for known multi-step sequences.

--- a/agents/rn-tester.md
+++ b/agents/rn-tester.md
@@ -333,7 +333,12 @@ cost (a `device_snapshot` is a full XCUITest accessibility round-trip, measured 
 For EACH step in the flow:
 
 1. **Act**: Use agent-device for native interaction (preferred), or Maestro for
-   complex multi-step flows:
+   complex multi-step flows.
+
+   For a KNOWN multi-step sequence, prefer a single `device_batch` over N separate
+   tool calls — it executes all steps in ONE round-trip. Use `finalSnapshot:'none'`
+   when you'll verify via `expect_*`/`cdp_store_state` (skips a ~1,450 ms trailing
+   snapshot), or the default `'salient'` for a compact actionable-elements payload.
 
    **agent-device (preferred — no YAML, native touch):**
    ```

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -569,6 +569,7 @@ trackedTool('device_batch', 'Execute a sequence of UI interactions in ONE tool c
     delayMs: z.number().default(300).describe('Delay between steps in ms (default 300)'),
     screenshotOn: z.enum(['none', 'failure', 'end', 'each']).default('failure').describe('When to capture screenshots'),
     continueOnError: z.boolean().default(false).describe('When true, a failed non-optional step is recorded but the batch continues. Result includes failure_count + failures array. Default false (fail-fast). Use for diagnostic batches where partial results > first-failure abort.'),
+    finalSnapshot: z.enum(['salient', 'full', 'none']).default('salient').describe('Shape of the batch final_snapshot. salient (default): compact list of only actionable nodes (Button/TextField/Switch/etc) — far fewer tokens. full: complete node list (legacy). none: skip the implicit trailing snapshot entirely (~1,450 ms saved) for action-only batches you verify via expect_*/cdp_store_state.'),
 }, createDeviceBatchHandler());
 trackedTool('cdp_auto_login', 'Pre-flight check: detect if the app is on a login/auth screen and auto-login via Maestro subflows from the project. Scans .maestro/subflows/ for login.yaml, sign_in.yaml, auth.yaml, flow_start.yaml, register_user.yaml. Returns { loggedIn: true/false, reason, flow }. Call before proof capture or feature testing when app may be logged out.', {
     appId: z.string().optional().describe('App bundle ID override (auto-detected from app.json if omitted)'),

--- a/scripts/cdp-bridge/dist/tools/device-batch.js
+++ b/scripts/cdp-bridge/dist/tools/device-batch.js
@@ -2,6 +2,45 @@ import { runNative } from '../agent-device-wrapper.js';
 import { buildDirectionalScrollCliArgs, buildDirectionalSwipeCliArgs, fetchFindCandidates, pressCandidate } from './device-interact.js';
 import { withSession, okResult, failResult } from '../utils.js';
 import { captureAndResizeScreenshot } from './device-list.js';
+// GH #321: a11y node types that represent something the agent can act on. Used
+// to compact the batch's final payload to just the actionable surface.
+const INTERACTIVE_A11Y_TYPES = new Set([
+    'Button', 'TextField', 'SecureTextField', 'TextView', 'Switch', 'Slider',
+    'Link', 'Cell', 'MenuItem', 'Tab', 'Stepper', 'SegmentedControl',
+    'SearchField', 'Toggle', 'CheckBox', 'RadioButton',
+]);
+/**
+ * GH #321: reduce a device_snapshot payload to only its actionable nodes, each
+ * compacted to { ref, type, label, identifier, hittable? }. Non-node payloads
+ * (e.g. a screenshot result) and falsy input pass through unchanged. Exported
+ * for unit tests; pure.
+ */
+export function salientizeSnapshotData(data) {
+    if (!data || typeof data !== 'object')
+        return data;
+    const d = data;
+    if (!Array.isArray(d.nodes))
+        return data; // not a node snapshot — leave as-is
+    const nodes = [];
+    for (const n of d.nodes) {
+        const type = typeof n.type === 'string' ? n.type : '';
+        if (!INTERACTIVE_A11Y_TYPES.has(type))
+            continue;
+        const entry = {};
+        if (n.ref)
+            entry.ref = n.ref;
+        if (type)
+            entry.type = type;
+        if (typeof n.label === 'string' && n.label)
+            entry.label = n.label;
+        if (typeof n.identifier === 'string' && n.identifier)
+            entry.identifier = n.identifier;
+        if (n.hittable === false)
+            entry.hittable = false; // surface dead controls
+        nodes.push(entry);
+    }
+    return { nodes, salient: true, fullNodeCount: d.nodes.length };
+}
 /**
  * Phase 125: snapshot-based testID resolution — single source of truth for
  * testID-keyed batch steps. Each call snapshots, returning the fresh ref so
@@ -208,7 +247,7 @@ function extractData(result) {
 }
 export function createDeviceBatchHandler() {
     return withSession(async (args) => {
-        const { steps, delayMs = 300, screenshotOn = 'failure', continueOnError = false } = args;
+        const { steps, delayMs = 300, screenshotOn = 'failure', continueOnError = false, finalSnapshot: finalSnapshotMode = 'salient' } = args;
         if (!steps || steps.length === 0) {
             return failResult('steps array is required and must not be empty');
         }
@@ -297,7 +336,10 @@ export function createDeviceBatchHandler() {
             }
             catch { /* best effort */ }
         }
-        if (!finalSnapshot && !failedStep) {
+        // GH #321: skip the implicit trailing snapshot when the caller doesn't want
+        // it (action-only batches that verify via expect_*/cdp_store_state) — saves a
+        // full ~1,450 ms snapshot round-trip.
+        if (!finalSnapshot && !failedStep && finalSnapshotMode !== 'none') {
             try {
                 const snapResult = await runNative(['snapshot', '-i']);
                 if (isOk(snapResult)) {
@@ -305,6 +347,12 @@ export function createDeviceBatchHandler() {
                 }
             }
             catch { /* best effort */ }
+        }
+        // GH #321: by default return only the actionable surface (compact salient
+        // digest). 'full' keeps the legacy complete node list. A node-shaped payload
+        // is required; a screenshot 'end' payload passes through untouched.
+        if (finalSnapshot && finalSnapshotMode === 'salient') {
+            finalSnapshot = salientizeSnapshotData(finalSnapshot);
         }
         const totalDuration = Date.now() - batchStart;
         if (failedStep) {

--- a/scripts/cdp-bridge/dist/tools/device-batch.js
+++ b/scripts/cdp-bridge/dist/tools/device-batch.js
@@ -24,7 +24,11 @@ export function salientizeSnapshotData(data) {
     const nodes = [];
     for (const n of d.nodes) {
         const type = typeof n.type === 'string' ? n.type : '';
-        if (!INTERACTIVE_A11Y_TYPES.has(type))
+        const identifier = typeof n.identifier === 'string' && n.identifier ? n.identifier : '';
+        // Fail-safe: keep a node if it's an interactive type OR carries a testID.
+        // A custom Pressable can surface as a11y type "Other" — dropping it on type
+        // alone would strand the agent ("nothing to tap here") on a real control.
+        if (!INTERACTIVE_A11Y_TYPES.has(type) && !identifier)
             continue;
         const entry = {};
         if (n.ref)
@@ -33,8 +37,8 @@ export function salientizeSnapshotData(data) {
             entry.type = type;
         if (typeof n.label === 'string' && n.label)
             entry.label = n.label;
-        if (typeof n.identifier === 'string' && n.identifier)
-            entry.identifier = n.identifier;
+        if (identifier)
+            entry.identifier = identifier;
         if (n.hittable === false)
             entry.hittable = false; // surface dead controls
         nodes.push(entry);

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -901,6 +901,7 @@ trackedTool(
     delayMs: z.number().default(300).describe('Delay between steps in ms (default 300)'),
     screenshotOn: z.enum(['none', 'failure', 'end', 'each']).default('failure').describe('When to capture screenshots'),
     continueOnError: z.boolean().default(false).describe('When true, a failed non-optional step is recorded but the batch continues. Result includes failure_count + failures array. Default false (fail-fast). Use for diagnostic batches where partial results > first-failure abort.'),
+    finalSnapshot: z.enum(['salient', 'full', 'none']).default('salient').describe('Shape of the batch final_snapshot. salient (default): compact list of only actionable nodes (Button/TextField/Switch/etc) — far fewer tokens. full: complete node list (legacy). none: skip the implicit trailing snapshot entirely (~1,450 ms saved) for action-only batches you verify via expect_*/cdp_store_state.'),
   },
   createDeviceBatchHandler(),
 );

--- a/scripts/cdp-bridge/src/tools/device-batch.ts
+++ b/scripts/cdp-bridge/src/tools/device-batch.ts
@@ -74,12 +74,16 @@ export function salientizeSnapshotData(data: unknown): unknown {
   const nodes: Array<Record<string, unknown>> = [];
   for (const n of d.nodes) {
     const type = typeof n.type === 'string' ? n.type : '';
-    if (!INTERACTIVE_A11Y_TYPES.has(type)) continue;
+    const identifier = typeof n.identifier === 'string' && n.identifier ? n.identifier : '';
+    // Fail-safe: keep a node if it's an interactive type OR carries a testID.
+    // A custom Pressable can surface as a11y type "Other" — dropping it on type
+    // alone would strand the agent ("nothing to tap here") on a real control.
+    if (!INTERACTIVE_A11Y_TYPES.has(type) && !identifier) continue;
     const entry: Record<string, unknown> = {};
     if (n.ref) entry.ref = n.ref;
     if (type) entry.type = type;
     if (typeof n.label === 'string' && n.label) entry.label = n.label;
-    if (typeof n.identifier === 'string' && n.identifier) entry.identifier = n.identifier;
+    if (identifier) entry.identifier = identifier;
     if (n.hittable === false) entry.hittable = false; // surface dead controls
     nodes.push(entry);
   }

--- a/scripts/cdp-bridge/src/tools/device-batch.ts
+++ b/scripts/cdp-bridge/src/tools/device-batch.ts
@@ -42,6 +42,48 @@ export interface BatchArgs {
    * are more valuable than the first-failure abort.
    */
   continueOnError?: boolean;
+  // GH #321 (quick win #4): shape of the batch's final UI payload.
+  //   salient (default): compact list of only actionable a11y nodes
+  //     (Button/TextField/Switch/etc) -- live-loop default, far fewer tokens.
+  //   full: the complete node list (legacy shape) -- when every node is needed.
+  //   none: skip the implicit trailing snapshot (~1,450 ms saved) for
+  //     action-only batches that verify via expect_*/cdp_store_state.
+  // An explicit snapshot step or screenshotOn=end still populates the payload;
+  // this only governs the IMPLICIT trailing snapshot and its shape.
+  finalSnapshot?: 'salient' | 'full' | 'none';
+}
+
+// GH #321: a11y node types that represent something the agent can act on. Used
+// to compact the batch's final payload to just the actionable surface.
+const INTERACTIVE_A11Y_TYPES = new Set<string>([
+  'Button', 'TextField', 'SecureTextField', 'TextView', 'Switch', 'Slider',
+  'Link', 'Cell', 'MenuItem', 'Tab', 'Stepper', 'SegmentedControl',
+  'SearchField', 'Toggle', 'CheckBox', 'RadioButton',
+]);
+
+/**
+ * GH #321: reduce a device_snapshot payload to only its actionable nodes, each
+ * compacted to { ref, type, label, identifier, hittable? }. Non-node payloads
+ * (e.g. a screenshot result) and falsy input pass through unchanged. Exported
+ * for unit tests; pure.
+ */
+export function salientizeSnapshotData(data: unknown): unknown {
+  if (!data || typeof data !== 'object') return data;
+  const d = data as { nodes?: Array<Record<string, unknown>> };
+  if (!Array.isArray(d.nodes)) return data; // not a node snapshot — leave as-is
+  const nodes: Array<Record<string, unknown>> = [];
+  for (const n of d.nodes) {
+    const type = typeof n.type === 'string' ? n.type : '';
+    if (!INTERACTIVE_A11Y_TYPES.has(type)) continue;
+    const entry: Record<string, unknown> = {};
+    if (n.ref) entry.ref = n.ref;
+    if (type) entry.type = type;
+    if (typeof n.label === 'string' && n.label) entry.label = n.label;
+    if (typeof n.identifier === 'string' && n.identifier) entry.identifier = n.identifier;
+    if (n.hittable === false) entry.hittable = false; // surface dead controls
+    nodes.push(entry);
+  }
+  return { nodes, salient: true, fullNodeCount: d.nodes.length };
 }
 
 /**
@@ -279,7 +321,7 @@ function extractData(result: ToolResult): unknown {
 
 export function createDeviceBatchHandler(): (args: BatchArgs) => Promise<ToolResult> {
   return withSession(async (args) => {
-    const { steps, delayMs = 300, screenshotOn = 'failure', continueOnError = false } = args;
+    const { steps, delayMs = 300, screenshotOn = 'failure', continueOnError = false, finalSnapshot: finalSnapshotMode = 'salient' } = args;
 
     if (!steps || steps.length === 0) {
       return failResult('steps array is required and must not be empty');
@@ -374,13 +416,23 @@ export function createDeviceBatchHandler(): (args: BatchArgs) => Promise<ToolRes
       } catch { /* best effort */ }
     }
 
-    if (!finalSnapshot && !failedStep) {
+    // GH #321: skip the implicit trailing snapshot when the caller doesn't want
+    // it (action-only batches that verify via expect_*/cdp_store_state) — saves a
+    // full ~1,450 ms snapshot round-trip.
+    if (!finalSnapshot && !failedStep && finalSnapshotMode !== 'none') {
       try {
         const snapResult = await runNative(['snapshot', '-i']);
         if (isOk(snapResult)) {
           finalSnapshot = extractData(snapResult);
         }
       } catch { /* best effort */ }
+    }
+
+    // GH #321: by default return only the actionable surface (compact salient
+    // digest). 'full' keeps the legacy complete node list. A node-shaped payload
+    // is required; a screenshot 'end' payload passes through untouched.
+    if (finalSnapshot && finalSnapshotMode === 'salient') {
+      finalSnapshot = salientizeSnapshotData(finalSnapshot);
     }
 
     const totalDuration = Date.now() - batchStart;

--- a/scripts/cdp-bridge/test/unit/device-batch-salient.test.js
+++ b/scripts/cdp-bridge/test/unit/device-batch-salient.test.js
@@ -1,0 +1,116 @@
+// Live-sim speedup (GH #321, quick win #4): device_batch returns a compact
+// SALIENT final payload (only actionable a11y nodes) by default instead of the
+// full snapshot, and a `finalSnapshot: 'none'` option skips the implicit
+// trailing snapshot entirely (~1,450 ms saved for action-only batches).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  salientizeSnapshotData,
+  createDeviceBatchHandler,
+} from '../../dist/tools/device-batch.js';
+import {
+  _setRunAgentDeviceForTest,
+  setActiveSessionInMemoryForTest,
+  resetActiveSessionInMemoryForTest,
+} from '../../dist/agent-device-wrapper.js';
+
+const FULL = {
+  nodes: [
+    { ref: '@e0', type: 'Application', label: 'app', rect: { x: 0, y: 0, width: 1, height: 1 }, enabled: true, hittable: true },
+    { ref: '@e1', type: 'StaticText', label: 'Welcome', rect: { x: 0, y: 0, width: 1, height: 1 }, enabled: true },
+    { ref: '@e2', type: 'Button', label: 'Submit', identifier: 'submit-btn', rect: { x: 0, y: 0, width: 1, height: 1 }, enabled: true, hittable: true },
+    { ref: '@e3', type: 'TextField', label: '', identifier: 'email', rect: { x: 0, y: 0, width: 1, height: 1 }, enabled: true, hittable: true },
+    { ref: '@e4', type: 'Switch', label: 'Notifications', rect: { x: 0, y: 0, width: 1, height: 1 }, enabled: true, hittable: true },
+    { ref: '@e5', type: 'Image', identifier: 'house.fill', rect: { x: 0, y: 0, width: 1, height: 1 } },
+  ],
+};
+
+// ── pure salientizer ────────────────────────────────────────────────────
+
+test('salientizeSnapshotData keeps only actionable a11y types', () => {
+  const out = salientizeSnapshotData(FULL);
+  const types = out.nodes.map((n) => n.type).sort();
+  assert.deepEqual(types, ['Button', 'Switch', 'TextField']);
+  assert.equal(out.salient, true);
+  assert.equal(out.fullNodeCount, 6);
+});
+
+test('salientizeSnapshotData compacts entries (drops rect/enabled) but keeps ref/identifier', () => {
+  const out = salientizeSnapshotData(FULL);
+  const btn = out.nodes.find((n) => n.identifier === 'submit-btn');
+  assert.equal(btn.ref, '@e2');
+  assert.equal(btn.label, 'Submit');
+  assert.equal(btn.rect, undefined);
+  assert.equal(btn.enabled, undefined);
+});
+
+test('salientizeSnapshotData passes through non-node data (e.g. a screenshot result)', () => {
+  const shot = { path: '/tmp/x.jpg', resize: { width: 800 } };
+  assert.deepEqual(salientizeSnapshotData(shot), shot);
+});
+
+test('salientizeSnapshotData tolerates missing/empty nodes', () => {
+  assert.deepEqual(salientizeSnapshotData({ nodes: [] }), { nodes: [], salient: true, fullNodeCount: 0 });
+  assert.deepEqual(salientizeSnapshotData(null), null);
+});
+
+// ── handler wiring ──────────────────────────────────────────────────────
+
+function envelope(data) {
+  return { content: [{ type: 'text', text: JSON.stringify({ ok: true, data }) }] };
+}
+
+test('device_batch default returns a SALIENT final snapshot', async () => {
+  let snapshots = 0;
+  _setRunAgentDeviceForTest((cliArgs) => {
+    if (cliArgs[0] === 'snapshot') snapshots++;
+    return Promise.resolve(envelope(FULL));
+  });
+  setActiveSessionInMemoryForTest({ name: 't', platform: 'ios', appId: 'com.test', openedAt: 'now' });
+  try {
+    const handler = createDeviceBatchHandler();
+    const res = await handler({ steps: [{ action: 'wait', ms: 0 }], delayMs: 0 });
+    const body = JSON.parse(res.content[0].text);
+    assert.equal(body.ok, true);
+    assert.equal(body.data.final_snapshot.salient, true, 'default final payload is salient');
+    assert.equal(snapshots, 1, 'one trailing snapshot taken');
+  } finally {
+    _setRunAgentDeviceForTest(null);
+    resetActiveSessionInMemoryForTest();
+  }
+});
+
+test("device_batch finalSnapshot:'none' skips the implicit trailing snapshot", async () => {
+  let snapshots = 0;
+  _setRunAgentDeviceForTest((cliArgs) => {
+    if (cliArgs[0] === 'snapshot') snapshots++;
+    return Promise.resolve(envelope(FULL));
+  });
+  setActiveSessionInMemoryForTest({ name: 't', platform: 'ios', appId: 'com.test', openedAt: 'now' });
+  try {
+    const handler = createDeviceBatchHandler();
+    const res = await handler({ steps: [{ action: 'wait', ms: 0 }], delayMs: 0, finalSnapshot: 'none' });
+    const body = JSON.parse(res.content[0].text);
+    assert.equal(body.ok, true);
+    assert.equal(snapshots, 0, 'no trailing snapshot round-trip when finalSnapshot=none');
+    assert.equal(body.data.final_snapshot ?? null, null);
+  } finally {
+    _setRunAgentDeviceForTest(null);
+    resetActiveSessionInMemoryForTest();
+  }
+});
+
+test("device_batch finalSnapshot:'full' preserves the full node list", async () => {
+  _setRunAgentDeviceForTest(() => Promise.resolve(envelope(FULL)));
+  setActiveSessionInMemoryForTest({ name: 't', platform: 'ios', appId: 'com.test', openedAt: 'now' });
+  try {
+    const handler = createDeviceBatchHandler();
+    const res = await handler({ steps: [{ action: 'wait', ms: 0 }], delayMs: 0, finalSnapshot: 'full' });
+    const body = JSON.parse(res.content[0].text);
+    assert.equal(body.data.final_snapshot.nodes.length, 6, 'full node list preserved');
+    assert.equal(body.data.final_snapshot.salient, undefined);
+  } finally {
+    _setRunAgentDeviceForTest(null);
+    resetActiveSessionInMemoryForTest();
+  }
+});

--- a/scripts/cdp-bridge/test/unit/device-batch-salient.test.js
+++ b/scripts/cdp-bridge/test/unit/device-batch-salient.test.js
@@ -27,12 +27,23 @@ const FULL = {
 
 // ── pure salientizer ────────────────────────────────────────────────────
 
-test('salientizeSnapshotData keeps only actionable a11y types', () => {
+test('salientizeSnapshotData keeps actionable types AND any identified (testID) node', () => {
   const out = salientizeSnapshotData(FULL);
   const types = out.nodes.map((n) => n.type).sort();
-  assert.deepEqual(types, ['Button', 'Switch', 'TextField']);
+  // Button/TextField/Switch by type; the Image is kept because it has an identifier.
+  assert.deepEqual(types, ['Button', 'Image', 'Switch', 'TextField']);
   assert.equal(out.salient, true);
   assert.equal(out.fullNodeCount, 6);
+});
+
+test('salientizeSnapshotData keeps a testID-bearing node even when its type is not interactive (fail-safe)', () => {
+  const data = { nodes: [
+    { ref: '@e0', type: 'Other', identifier: 'custom-pressable', label: 'Tap me', hittable: true },
+    { ref: '@e1', type: 'Other', label: 'decorative wrapper' }, // no testID, non-interactive -> dropped
+  ] };
+  const out = salientizeSnapshotData(data);
+  assert.deepEqual(out.nodes.map((n) => n.identifier), ['custom-pressable']);
+  assert.equal(out.nodes.length, 1, 'a custom Pressable surfacing as type Other is NOT dropped');
 });
 
 test('salientizeSnapshotData compacts entries (drops rect/enabled) but keeps ref/identifier', () => {


### PR DESCRIPTION
## What

Makes `device_batch` a leaner live primitive (#321 quick win #4). It already collapses N interactions into one round-trip; this trims its output and lets callers skip the implicit trailing snapshot.

New `finalSnapshot` option (`salient` | `full` | `none`, default **salient**):
- **salient** — `final_snapshot` is compacted to only actionable a11y nodes (Button/TextField/Switch/Slider/Cell/Link/…), each `{ ref, type, label, identifier, hittable? }`, plus `fullNodeCount`. Actionable `@ref`s are preserved, so a follow-up `device_press(ref)` still works.
- **none** — skips the implicit trailing snapshot entirely (**~1,450 ms saved**) for action-only batches verified via `expect_*`/`cdp_store_state`.
- **full** — the legacy complete node list.

## Why

The batch's `final_snapshot` was always the full a11y node list (thousands of tokens for a real screen — in live testing a 58-node dev-menu was ~6 KB), and the batch always paid an implicit trailing ~1,450 ms snapshot even when the agent was going to verify by state. This is the payload + latency lever from the brainstorm, building on the cached-find (#322) and salient-digest (#324) work already merged.

## How

- `salientizeSnapshotData()` — pure, exported, unit-tested. Filters to interactive a11y types and compacts each entry; non-node payloads (e.g. a screenshot `end` result) pass through untouched.
- Handler: `finalSnapshot:'none'` skips the implicit trailing snapshot; `'salient'` (default) compacts a node-shaped payload.
- `index.ts`: `device_batch` schema gains `finalSnapshot`.
- `rn-tester.md`: recommends a single `device_batch` for known multi-step sequences.

## Tests

7 new (4 pure salientizer: filter/compact/passthrough/empty; 3 handler wiring: salient default, none-skips-trailing-snapshot, full-preserves). 50 existing batch tests still green. **Full unit suite 2216/2216.**

## Changeset

`rn-dev-agent-plugin` patch (cdp-bridge src changed).

Refs #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)