### PR TITLE
feat(#317): TRANSPORT_BLIND diagnostic (Phase 1)

### DIFF
--- a/.changeset/transport-blind-317.md
+++ b/.changeset/transport-blind-317.md
@@ -1,0 +1,5 @@
+---
+"rn-dev-agent-plugin": patch
+---
+
+cdp_repair_action now reports TRANSPORT_BLIND when the failed Maestro selector is present in the live rn-fast-runner snapshot — the iOS 26.2 + bridgeless empty-a11y-tree case (GH #317) — instead of the misleading "no confident replacement". cdp_run_action surfaces it as a terminal refusal with refusedReason TRANSPORT_BLIND. Diagnostic-only; restoring replay on that runtime is Phase 2.

--- a/docs/superpowers/plans/2026-06-17-317-transport-blind-diagnostic.md
+++ b/docs/superpowers/plans/2026-06-17-317-transport-blind-diagnostic.md
@@ -209,6 +209,30 @@ test('GH #317: empty snapshot (0 testIDs) stays TESTID_NOT_FOUND, not TRANSPORT_
   assert.equal(env.code, 'TESTID_NOT_FOUND');
   assert.match(env.error, /0 testIDs/);
 });
+
+test('GH #317: bad hint not in body but coincidentally in snapshot → BAD_FILENAME, not TRANSPORT_BLIND', async () => {
+  // The action body uses "submit_email_form"; the caller passes a WRONG hint
+  // that happens to be on the live screen. Body-membership precondition must
+  // keep the deliberate "your hint is wrong" diagnostic (Issue #102 A3).
+  project.seedAction(
+    'register-new-user-4',
+    fixtureYaml({ id: 'register-new-user-4', selectors: ['submit_email_form'] }),
+  );
+  _setRunAgentDeviceForTest(async () => ({
+    content: [{ type: 'text', text: fakeSnapshot(['header-home', 'btn-cancel']) }],
+  }));
+
+  const handler = createRepairActionHandler();
+  const result = await handler({
+    actionId: 'register-new-user-4',
+    failedSelector: 'header-home', // present in snapshot, NOT in the action body
+    projectRoot: project.root,
+  });
+
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'BAD_FILENAME');
+});
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -224,22 +248,29 @@ In `src/types.ts`, in the `ToolErrorCode` union, add after the `| 'RUNNER_LEAK'`
   | 'TRANSPORT_BLIND'          // GH #317: rn-fast-runner sees the selector but Maestro/WDA reported it not visible (empty a11y tree)
 ```
 
-- [ ] **Step 3b: Add the import in repair-action.ts**
+- [ ] **Step 3b: Add the imports in repair-action.ts**
 
-In `src/tools/repair-action.ts`, find the import from `'../domain/repair-engine.js'` (it already imports `extractAllTestIDs`, `attemptRepair`, `applyRepair`, `DEFAULT_REPAIR_THRESHOLD`) and add `detectTransportBlind` to that named-import list.
+In `src/tools/repair-action.ts`, find the import from `'../domain/repair-engine.js'` (it already imports `extractAllTestIDs`, `attemptRepair`, `applyRepair`, `DEFAULT_REPAIR_THRESHOLD`) and add `detectTransportBlind` **and** `extractIdSelectors` to that named-import list (the guard needs `extractIdSelectors` for the body-membership precondition — see Step 3c).
 
 - [ ] **Step 3c: Insert the guard before `attemptRepair`**
 
 In `src/tools/repair-action.ts`, between the end of the `if (candidates.length === 0) { ... }` block (~line 294) and `const result = attemptRepair(...)` (~line 296), insert:
 
 ```typescript
-    // GH #317: transport-blindness guard. If the failed selector is present
-    // verbatim in OUR snapshot, the element is rendered and rn-fast-runner can
-    // see it — Maestro/WDA reported "not visible" because it read an empty a11y
-    // tree (e.g. iOS 26.2 + bridgeless), NOT because the testID drifted. Fire
-    // BEFORE attemptRepair, which filters the selector out of candidates and
-    // would otherwise mislead ("no confident replacement") or mis-patch it.
-    if (detectTransportBlind(args.failedSelector, candidates)) {
+    // GH #317: transport-blindness guard. If the failed selector is BOTH used by
+    // the action AND present verbatim in OUR live snapshot, the element is
+    // rendered and rn-fast-runner can see it — Maestro/WDA reported "not visible"
+    // because it read an empty a11y tree (e.g. iOS 26.2 + bridgeless), NOT because
+    // the testID drifted. The body-membership check preserves the deliberate
+    // BAD_FILENAME "your hint is wrong" diagnostic (Issue #102 A3): a hint that
+    // is NOT in the action body but coincidentally on-screen must NOT be reported
+    // as transport-blind. Fire BEFORE attemptRepair, which filters the selector
+    // out of candidates and would otherwise mislead ("no confident replacement")
+    // or mis-patch it.
+    if (
+      extractIdSelectors(action.body).includes(args.failedSelector) &&
+      detectTransportBlind(args.failedSelector, candidates)
+    ) {
       return failResult(
         `cdp_repair_action: Maestro/WDA reported "${args.failedSelector}" not visible, but rn-fast-runner sees it (${candidates.length} testIDs in the live snapshot). This is transport-blindness, not testID drift — WDA reads an empty/partial accessibility tree on this runtime (e.g. iOS 26.2 + bridgeless, GH #317). Maestro-based replay is blocked here; drive the screen with device_* primitives (device_find/press/fill), which go through rn-fast-runner and work. rn-fast-runner-native action replay is tracked in #317 Phase 2.`,
         'TRANSPORT_BLIND',
@@ -368,6 +399,8 @@ In `src/tools/run-action.ts`, in the `if (!repairPatched) { ... }` block, the `r
 
 (`refusedReason` is already in scope from line 378. The message and `meta` stay as-is — the detailed transport-blind text flows through `repairEnv.error`.)
 
+**Meta contract (intentional):** the structured `meta` fields repair-action attaches (`snapshotTestIdCount`, `candidatesSample`, `hint`) are **repair-action-only** — `cdp_run_action` builds its own refusal `meta` (`{ actionId, autoRepair, repairError, firstAttemptOutput }`) and surfaces transport-blindness via the prose `repairEnv.error` + `code: 'TRANSPORT_BLIND'` + `refusedReason: 'TRANSPORT_BLIND'`. This matches how `RUNNER_LEAK`/`SNAPSHOT_FAILED` already behave; do not widen run-action's meta in this slice.
+
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/run-action-handler.test.js`
@@ -401,21 +434,22 @@ Expected: PASS — the entire `test/unit/**` suite green (prior baseline 2216 + 
 
 - [ ] **Step 2: Create the changeset**
 
-Inspect an existing changeset for the package name and bump convention:
+The changeset key MUST be `"rn-dev-agent-plugin"` — that is what every existing changeset uses (e.g. `.changeset/321-batch-salient-payload.md`). Do **not** use the cdp-bridge package name (`rn-dev-agent-cdp`) or the workspace name; the #316/B215 CI validator rejects keys that don't match a real published package, and `rn-dev-agent-plugin` is the one the release pipeline consumes.
 
-Run: `cat /Users/anton_personal/GitHub/claude-react-native-dev-plugin/.changeset/*.md | head -20`
+First confirm the convention:
 
-Create `.changeset/transport-blind-317.md` with the package-name key from that example (the cdp-bridge package), e.g.:
+Run: `head -5 /Users/anton_personal/GitHub/claude-react-native-dev-plugin/.changeset/321-batch-salient-payload.md`
+Expected: a frontmatter block keyed `"rn-dev-agent-plugin": patch`.
+
+Create `.changeset/transport-blind-317.md`:
 
 ```markdown
 ---
-"<cdp-bridge-package-name>": patch
+"rn-dev-agent-plugin": patch
 ---
 
 cdp_repair_action now reports TRANSPORT_BLIND when the failed Maestro selector is present in the live rn-fast-runner snapshot — the iOS 26.2 + bridgeless empty-a11y-tree case (GH #317) — instead of the misleading "no confident replacement". cdp_run_action surfaces it as a terminal refusal with refusedReason TRANSPORT_BLIND. Diagnostic-only; restoring replay on that runtime is Phase 2.
 ```
-
-(Use the exact package name(s) the repo's existing changesets reference. If the CI changeset-name validator from #316/B215 is present, double-check the key matches a real workspace package.)
 
 - [ ] **Step 3: Verify nothing else references the old behavior**
 
@@ -433,6 +467,15 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 ```
 
 ---
+
+## Coverage & known limitation (from plan review)
+
+The hard verdict depends on the failed selector being present in the rn-fast-runner snapshot **at repair time**. Two cases:
+
+- **Normal route (primary #317 case):** the element persists, so the repair-time snapshot contains the selector → the guard fires. This is consistent with the reported symptom: the repro's *"no candidate scored at or above 0.6"* is exactly what `attemptRepair` produces when the selector **is** present — `repair-engine.ts:274` filters the selector out of `candidates` before scoring, so the real match is removed and nothing else clears 0.6. The message therefore implies presence, not absence. The hard verdict is **not** dead code for this case.
+- **Sheet-dismissed case (#317 secondary issue):** starting a Maestro/WDA session dismisses an open `react-native-actions-sheet`, so by repair time the element may be gone and the snapshot sparse → the guard stays silent and the **soft hint** (Task 2 Step 3d) is the fallback. Full coverage of this case requires rn-fast-runner-native replay (**Phase 2**), out of scope here.
+
+This is an accepted, documented limitation — the slice strictly improves the diagnostic (hard verdict where provable, soft hint otherwise) and never regresses behavior.
 
 ## Self-Review
 

--- a/docs/superpowers/plans/2026-06-17-317-transport-blind-diagnostic.md
+++ b/docs/superpowers/plans/2026-06-17-317-transport-blind-diagnostic.md
@@ -1,0 +1,453 @@
+# #317 Phase 1 — TRANSPORT_BLIND diagnostic Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `cdp_repair_action` emit a truthful `TRANSPORT_BLIND` diagnostic — instead of the misleading "no confident replacement" — when Maestro/WDA reports a selector "not visible" but rn-fast-runner's own snapshot still contains it (the iOS 26.2 + bridgeless empty-a11y-tree failure in GH #317).
+
+**Architecture:** A pure detector (`detectTransportBlind`) in `repair-engine.ts` checks whether the failed selector is present verbatim in the live rn-fast-runner snapshot. `cdp_repair_action` calls it **before** `attemptRepair` (which would otherwise filter the selector out and mislead/mis-patch) and short-circuits to a `TRANSPORT_BLIND` failResult; the no-confident-match path gains a soft transport-blind hint. `cdp_run_action` maps the new code to a `TRANSPORT_BLIND` refusal reason so telemetry and its own envelope are honest. No new device round-trips — the snapshot repair already takes is reused.
+
+**Tech Stack:** TypeScript (Node ≥ 22), MCP bridge under `scripts/cdp-bridge/`. Tests: `node:test` + `node:assert/strict`, importing from compiled `dist/`.
+
+## Global Constraints
+
+- **Node.js ≥ 22 LTS.**
+- **Tests build first:** the `test` npm script is `npm run build && node --test '...'`. Tests import from `dist/`, so always `npm run build` before running tests. Working dir for all commands: `scripts/cdp-bridge`.
+- **`dist/` is tracked** — rebuild (`npm run build`) and stage the compiled output in every commit alongside `src`/`test`.
+- **Commits:** signed (`git commit -S`), small, one per task. End every commit message with: `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- **One changeset** for the whole change (Task 4).
+- **Explicit type imports** (`import type { ... }`). **No unnecessary comments** beyond the rationale comments shown.
+- **Detection is verbatim + case-sensitive** (`candidates.includes(failedSelector)`); `failedSelector` is a bare testID by contract (`maestro-error-parser` captures `m[2]`).
+- **The guard fires BEFORE `attemptRepair`** in `repair-action.ts`.
+- **Error/message wording is the verbatim spec text** (Task 2 / Task 3 steps).
+
+Spec: `docs/superpowers/specs/2026-06-17-317-transport-blind-diagnostic-design.md`.
+
+## File Structure
+
+- `src/domain/repair-engine.ts` — **modify**: add pure `detectTransportBlind(failedSelector, candidates)`. (Pure helpers home; no I/O.)
+- `src/types.ts` — **modify**: add `'TRANSPORT_BLIND'` to `ToolErrorCode`.
+- `src/tools/repair-action.ts` — **modify**: call the guard before `attemptRepair`; append soft hint to the no-match message.
+- `src/domain/reusable-action.ts` — **modify**: add `'TRANSPORT_BLIND'` to `AutoRepairRefusedReason`.
+- `src/tools/run-action.ts` — **modify**: map the code in `mapRefusedReason`; return code `TRANSPORT_BLIND` on that refusal.
+- `test/unit/repair-engine.test.js` — **modify**: pure-helper tests.
+- `test/unit/repair-action-handler.test.js` — **modify**: handler tests (verdict + soft hint + unchanged empty-snapshot).
+- `test/unit/run-action-handler.test.js` — **modify**: refusal-mapping test.
+- `.changeset/*.md` — **create**: changeset.
+
+---
+
+### Task 1: Pure detector `detectTransportBlind`
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/domain/repair-engine.ts` (add after `walkTree`, ~line 133)
+- Test: `scripts/cdp-bridge/test/unit/repair-engine.test.js`
+
+**Interfaces:**
+- Produces: `detectTransportBlind(failedSelector: string, candidates: string[]): boolean` — `true` iff `failedSelector` appears verbatim in `candidates`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add `detectTransportBlind` to the existing import block in `test/unit/repair-engine.test.js` (the `import { ... } from '../../dist/domain/repair-engine.js';` at lines 6–16), then append these tests:
+
+```javascript
+test('detectTransportBlind: failed selector present in snapshot → true (transport-blind)', () => {
+  assert.equal(detectTransportBlind('submit_email_form', ['submit_email_form', 'other-1']), true);
+});
+
+test('detectTransportBlind: failed selector absent, other candidates present → false (possible drift)', () => {
+  assert.equal(detectTransportBlind('submit_email_form', ['other-1', 'other-2']), false);
+});
+
+test('detectTransportBlind: empty candidate list → false', () => {
+  assert.equal(detectTransportBlind('submit_email_form', []), false);
+});
+
+test('detectTransportBlind: verbatim match is case-sensitive', () => {
+  assert.equal(detectTransportBlind('Submit', ['submit']), false);
+});
+
+test('detectTransportBlind: empty selector → false', () => {
+  assert.equal(detectTransportBlind('', ['submit_email_form']), false);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/repair-engine.test.js`
+Expected: build fails (`detectTransportBlind` not exported) or tests fail with "detectTransportBlind is not a function".
+
+- [ ] **Step 3: Implement the detector**
+
+In `src/domain/repair-engine.ts`, after `walkTree` (the `}` at ~line 133), add:
+
+```typescript
+/**
+ * GH #317 — transport-blindness detector. Returns true when the
+ * Maestro-reported failed selector is present VERBATIM in the live
+ * rn-fast-runner snapshot's testID list: the element IS rendered and our
+ * transport sees it, yet Maestro/WDA reported it "not visible" — i.e. WDA
+ * read an empty/partial a11y tree (e.g. iOS 26.2 + bridgeless), not a
+ * testID drift. A genuinely-renamed selector is absent from the snapshot,
+ * so this stays false and real drift still flows to attemptRepair.
+ *
+ * Pure function — exported for unit tests.
+ */
+export function detectTransportBlind(failedSelector: string, candidates: string[]): boolean {
+  if (!failedSelector) return false;
+  return candidates.includes(failedSelector);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/repair-engine.test.js`
+Expected: PASS (all `detectTransportBlind:` tests green; existing tests unaffected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/anton_personal/GitHub/claude-react-native-dev-plugin
+git add scripts/cdp-bridge/src/domain/repair-engine.ts \
+        scripts/cdp-bridge/dist/domain/repair-engine.js \
+        scripts/cdp-bridge/test/unit/repair-engine.test.js
+git commit -S -m "feat(#317): detectTransportBlind pure helper
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `TRANSPORT_BLIND` guard + soft hint in `cdp_repair_action`
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/types.ts` (add code to `ToolErrorCode`, ~line 245 after `RUNNER_LEAK`)
+- Modify: `scripts/cdp-bridge/src/tools/repair-action.ts` (guard before `attemptRepair` ~line 296; soft hint on no-match ~line 319)
+- Test: `scripts/cdp-bridge/test/unit/repair-action-handler.test.js`
+
+**Interfaces:**
+- Consumes: `detectTransportBlind` (Task 1).
+- Produces: `cdp_repair_action` failResult with code `'TRANSPORT_BLIND'` and `meta = { actionId, failedSelector, snapshotTestIdCount, candidatesSample, hint }`.
+
+- [ ] **Step 1: Write the failing handler tests**
+
+Append to `test/unit/repair-action-handler.test.js` (helpers `fakeSnapshot`, `_setRunAgentDeviceForTest`, `project.seedAction`, `fixtureYaml`, `FAKE_SESSION` already exist in this file):
+
+```javascript
+// ─────────────────────────────────────────────────────────────────────────────
+// GH #317 — transport-blindness: rn-fast-runner sees the selector Maestro/WDA missed
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('GH #317: failed selector present in snapshot → TRANSPORT_BLIND, not no-match', async () => {
+  project.seedAction(
+    'register-new-user',
+    fixtureYaml({ id: 'register-new-user', selectors: ['submit_email_form'] }),
+  );
+  // The snapshot DOES contain the failed selector — rn-fast-runner sees it.
+  _setRunAgentDeviceForTest(async () => ({
+    content: [{ type: 'text', text: fakeSnapshot(['submit_email_form', 'header-home', 'btn-cancel']) }],
+  }));
+
+  const handler = createRepairActionHandler();
+  const result = await handler({
+    actionId: 'register-new-user',
+    failedSelector: 'submit_email_form',
+    projectRoot: project.root,
+  });
+
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'TRANSPORT_BLIND');
+  assert.equal(env.meta.snapshotTestIdCount, 3);
+  assert.equal(env.meta.failedSelector, 'submit_email_form');
+  assert.match(env.error, /transport-blindness/i);
+  assert.match(env.error, /rn-fast-runner sees it/i);
+});
+
+test('GH #317: selector absent + no confident match → TESTID_NOT_FOUND with transport-blind soft hint', async () => {
+  project.seedAction(
+    'register-new-user-2',
+    fixtureYaml({ id: 'register-new-user-2', selectors: ['submit_email_form'] }),
+  );
+  // Snapshot has unrelated testIDs, none similar enough to clear 0.6.
+  _setRunAgentDeviceForTest(async () => ({
+    content: [{ type: 'text', text: fakeSnapshot(['totally-unrelated-aaa', 'zzz-different-bbb']) }],
+  }));
+
+  const handler = createRepairActionHandler();
+  const result = await handler({
+    actionId: 'register-new-user-2',
+    failedSelector: 'submit_email_form',
+    projectRoot: project.root,
+  });
+
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'TESTID_NOT_FOUND');
+  assert.match(env.error, /no confident replacement/i);
+  assert.match(env.error, /transport-blind/i);
+  assert.match(env.error, /GH #317/);
+});
+
+test('GH #317: empty snapshot (0 testIDs) stays TESTID_NOT_FOUND, not TRANSPORT_BLIND', async () => {
+  project.seedAction(
+    'register-new-user-3',
+    fixtureYaml({ id: 'register-new-user-3', selectors: ['submit_email_form'] }),
+  );
+  _setRunAgentDeviceForTest(async () => ({
+    content: [{ type: 'text', text: fakeSnapshot([]) }],
+  }));
+
+  const handler = createRepairActionHandler();
+  const result = await handler({
+    actionId: 'register-new-user-3',
+    failedSelector: 'submit_email_form',
+    projectRoot: project.root,
+  });
+
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'TESTID_NOT_FOUND');
+  assert.match(env.error, /0 testIDs/);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/repair-action-handler.test.js`
+Expected: the two new `TRANSPORT_BLIND`/soft-hint tests FAIL (first returns `TESTID_NOT_FOUND` not `TRANSPORT_BLIND`; second lacks the hint). The empty-snapshot test passes already.
+
+- [ ] **Step 3a: Add the ToolErrorCode**
+
+In `src/types.ts`, in the `ToolErrorCode` union, add after the `| 'RUNNER_LEAK'` line (~245):
+
+```typescript
+  | 'TRANSPORT_BLIND'          // GH #317: rn-fast-runner sees the selector but Maestro/WDA reported it not visible (empty a11y tree)
+```
+
+- [ ] **Step 3b: Add the import in repair-action.ts**
+
+In `src/tools/repair-action.ts`, find the import from `'../domain/repair-engine.js'` (it already imports `extractAllTestIDs`, `attemptRepair`, `applyRepair`, `DEFAULT_REPAIR_THRESHOLD`) and add `detectTransportBlind` to that named-import list.
+
+- [ ] **Step 3c: Insert the guard before `attemptRepair`**
+
+In `src/tools/repair-action.ts`, between the end of the `if (candidates.length === 0) { ... }` block (~line 294) and `const result = attemptRepair(...)` (~line 296), insert:
+
+```typescript
+    // GH #317: transport-blindness guard. If the failed selector is present
+    // verbatim in OUR snapshot, the element is rendered and rn-fast-runner can
+    // see it — Maestro/WDA reported "not visible" because it read an empty a11y
+    // tree (e.g. iOS 26.2 + bridgeless), NOT because the testID drifted. Fire
+    // BEFORE attemptRepair, which filters the selector out of candidates and
+    // would otherwise mislead ("no confident replacement") or mis-patch it.
+    if (detectTransportBlind(args.failedSelector, candidates)) {
+      return failResult(
+        `cdp_repair_action: Maestro/WDA reported "${args.failedSelector}" not visible, but rn-fast-runner sees it (${candidates.length} testIDs in the live snapshot). This is transport-blindness, not testID drift — WDA reads an empty/partial accessibility tree on this runtime (e.g. iOS 26.2 + bridgeless, GH #317). Maestro-based replay is blocked here; drive the screen with device_* primitives (device_find/press/fill), which go through rn-fast-runner and work. rn-fast-runner-native action replay is tracked in #317 Phase 2.`,
+        'TRANSPORT_BLIND',
+        {
+          actionId: args.actionId,
+          failedSelector: args.failedSelector,
+          snapshotTestIdCount: candidates.length,
+          candidatesSample: candidates.slice(0, 50),
+          hint: 'Verify with device_snapshot — it uses rn-fast-runner. If the element is present there, this is a WDA transport limitation, not your testID.',
+        },
+      );
+    }
+```
+
+- [ ] **Step 3d: Append the soft hint to the no-match message**
+
+In `src/tools/repair-action.ts`, in the `if (result.kind === 'no-match')` block (~line 318), replace the first `failResult` argument string:
+
+```typescript
+        `cdp_repair_action: no confident replacement for "${args.failedSelector}". ${result.reason}`,
+```
+
+with:
+
+```typescript
+        `cdp_repair_action: no confident replacement for "${args.failedSelector}". ${result.reason} If "${args.failedSelector}" is in fact correct and the screen renders, WDA may be transport-blind on this runtime (empty a11y tree; see GH #317) — confirm with device_snapshot, which uses rn-fast-runner.`,
+```
+
+(Leave the `'TESTID_NOT_FOUND'` code and `meta` unchanged.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/repair-action-handler.test.js`
+Expected: PASS (all three GH #317 tests green; existing repair-action tests unaffected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/anton_personal/GitHub/claude-react-native-dev-plugin
+git add scripts/cdp-bridge/src/types.ts \
+        scripts/cdp-bridge/src/tools/repair-action.ts \
+        scripts/cdp-bridge/dist/types.js \
+        scripts/cdp-bridge/dist/tools/repair-action.js \
+        scripts/cdp-bridge/test/unit/repair-action-handler.test.js
+git commit -S -m "feat(#317): TRANSPORT_BLIND guard + soft hint in cdp_repair_action
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Map `TRANSPORT_BLIND` refusal in `cdp_run_action`
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/domain/reusable-action.ts` (add to `AutoRepairRefusedReason`, ~line 155)
+- Modify: `scripts/cdp-bridge/src/tools/run-action.ts` (`mapRefusedReason` ~line 166; refusal-return code ~line 397)
+- Test: `scripts/cdp-bridge/test/unit/run-action-handler.test.js`
+
+**Interfaces:**
+- Consumes: `cdp_repair_action` returning code `'TRANSPORT_BLIND'` (Task 2).
+- Produces: `cdp_run_action` returns code `'TRANSPORT_BLIND'` with `meta.autoRepair.refusedReason === 'TRANSPORT_BLIND'`, no retry.
+
+- [ ] **Step 1: Write the failing test**
+
+In `test/unit/run-action-handler.test.js`, add a transport-blind repair envelope near the other `REPAIR_*_ENV` consts (~line 79):
+
+```javascript
+const REPAIR_TRANSPORT_BLIND_ENV = {
+  ok: false,
+  error: 'cdp_repair_action: Maestro/WDA reported "fab-create-task" not visible, but rn-fast-runner sees it (3 testIDs in the live snapshot). This is transport-blindness, not testID drift (GH #317).',
+  code: 'TRANSPORT_BLIND',
+};
+```
+
+Then append this test (mirror the existing refusal tests; seed an action whose body has the selector the `FAIL_SELECTOR_ENV` references — `fab-create-task`):
+
+```javascript
+test('run-action: repair returns TRANSPORT_BLIND → refused, no retry, honest code', async () => {
+  project.seedAction(
+    'demo',
+    fixtureYaml({ id: 'demo', selectors: ['fab-create-task'] }),
+  );
+  const handler = createRunActionHandler({
+    maestroRun: fakeMaestroRun([FAIL_SELECTOR_ENV]),
+    repairAction: fakeRepairAction(REPAIR_TRANSPORT_BLIND_ENV),
+  });
+
+  const result = await handler({ actionId: 'demo', projectRoot: project.root });
+
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'TRANSPORT_BLIND');
+  assert.equal(env.meta.autoRepair.outcome, 'refused');
+  assert.equal(env.meta.autoRepair.refusedReason, 'TRANSPORT_BLIND');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/run-action-handler.test.js`
+Expected: FAIL — `env.code` is `TESTID_NOT_FOUND` (hardcoded) and `refusedReason` is `INTERNAL_ERROR` (unmapped `TRANSPORT_BLIND` falls through).
+
+- [ ] **Step 3a: Add the refusal reason to the union**
+
+In `src/domain/reusable-action.ts`, in the `AutoRepairRefusedReason` union (~line 155), add a member:
+
+```typescript
+  | 'TRANSPORT_BLIND'
+```
+
+- [ ] **Step 3b: Map the code in `mapRefusedReason`**
+
+In `src/tools/run-action.ts`, in `mapRefusedReason` (~line 166), add immediately after the `RUNNER_LEAK` mapping (line 173):
+
+```typescript
+  if (repairCode === 'TRANSPORT_BLIND') return 'TRANSPORT_BLIND';
+```
+
+- [ ] **Step 3c: Return the honest code on the refusal**
+
+In `src/tools/run-action.ts`, in the `if (!repairPatched) { ... }` block, the `return failResult(...)` (~line 397) currently passes the literal `'TESTID_NOT_FOUND'`. Change that code argument to:
+
+```typescript
+        refusedReason === 'TRANSPORT_BLIND' ? 'TRANSPORT_BLIND' : 'TESTID_NOT_FOUND',
+```
+
+(`refusedReason` is already in scope from line 378. The message and `meta` stay as-is — the detailed transport-blind text flows through `repairEnv.error`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/run-action-handler.test.js`
+Expected: PASS (the new test green; existing run-action tests, including the `REPAIR_NO_MATCH_ENV → NO_MATCH` refusal, unaffected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/anton_personal/GitHub/claude-react-native-dev-plugin
+git add scripts/cdp-bridge/src/domain/reusable-action.ts \
+        scripts/cdp-bridge/src/tools/run-action.ts \
+        scripts/cdp-bridge/dist/domain/reusable-action.js \
+        scripts/cdp-bridge/dist/tools/run-action.js \
+        scripts/cdp-bridge/test/unit/run-action-handler.test.js
+git commit -S -m "feat(#317): map TRANSPORT_BLIND refusal in cdp_run_action
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Changeset + full-suite verification
+
+**Files:**
+- Create: `.changeset/<descriptive-slug>.md`
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `cd scripts/cdp-bridge && npm test`
+Expected: PASS — the entire `test/unit/**` suite green (prior baseline 2216 + the new tests).
+
+- [ ] **Step 2: Create the changeset**
+
+Inspect an existing changeset for the package name and bump convention:
+
+Run: `cat /Users/anton_personal/GitHub/claude-react-native-dev-plugin/.changeset/*.md | head -20`
+
+Create `.changeset/transport-blind-317.md` with the package-name key from that example (the cdp-bridge package), e.g.:
+
+```markdown
+---
+"<cdp-bridge-package-name>": patch
+---
+
+cdp_repair_action now reports TRANSPORT_BLIND when the failed Maestro selector is present in the live rn-fast-runner snapshot — the iOS 26.2 + bridgeless empty-a11y-tree case (GH #317) — instead of the misleading "no confident replacement". cdp_run_action surfaces it as a terminal refusal with refusedReason TRANSPORT_BLIND. Diagnostic-only; restoring replay on that runtime is Phase 2.
+```
+
+(Use the exact package name(s) the repo's existing changesets reference. If the CI changeset-name validator from #316/B215 is present, double-check the key matches a real workspace package.)
+
+- [ ] **Step 3: Verify nothing else references the old behavior**
+
+Run: `cd scripts/cdp-bridge && grep -rn "TRANSPORT_BLIND" src/ test/`
+Expected: references only in `repair-engine.ts`, `types.ts`, `repair-action.ts`, `reusable-action.ts`, `run-action.ts`, and the three test files — no stragglers, no typos.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/anton_personal/GitHub/claude-react-native-dev-plugin
+git add .changeset/transport-blind-317.md
+git commit -S -m "chore(#317): changeset for TRANSPORT_BLIND diagnostic
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Detection rule (verbatim exact-present) → Task 1 (`detectTransportBlind`).
+- Guard placed before `attemptRepair` → Task 2 Step 3c.
+- Hard verdict `TRANSPORT_BLIND` with `snapshotTestIdCount` + message → Task 2 Step 3a/3c + tests.
+- Soft hint on no-match → Task 2 Step 3d + test.
+- Empty snapshot stays `TESTID_NOT_FOUND` → Task 2 test 3.
+- `AutoRepairRefusedReason` gains `TRANSPORT_BLIND` → Task 3 Step 3a.
+- `mapRefusedReason` mapping (avoid `INTERNAL_ERROR`) → Task 3 Step 3b.
+- `cdp_run_action` honest code + no retry → Task 3 Step 3c + test.
+- Changeset + full suite green + no new device round-trips → Task 4 (round-trips: the guard reuses the existing snapshot; no new device calls added — verified by reading repair-action.ts, no new `runNative`).
+- "Tests build first / dist tracked / signed commits / one changeset" → Global Constraints + every Step 5 / Task 4.
+
+**2. Placeholder scan:** The only `<...>` is the changeset package-name key, which Task 4 Step 2 resolves by reading an existing changeset — deliberate, not a TODO. All code steps show full code.
+
+**3. Type consistency:** `detectTransportBlind(failedSelector: string, candidates: string[]): boolean` is defined in Task 1 and consumed verbatim in Task 2. `'TRANSPORT_BLIND'` is added to `ToolErrorCode` (Task 2) before being passed to `failResult`, and to `AutoRepairRefusedReason` (Task 3) before `mapRefusedReason` returns it — no use-before-definition. `env.meta.*` (not `env.data.*`) matches `failResult(error, code, meta)`'s envelope shape.

--- a/docs/superpowers/specs/2026-06-17-317-transport-blind-diagnostic-design.md
+++ b/docs/superpowers/specs/2026-06-17-317-transport-blind-diagnostic-design.md
@@ -23,7 +23,7 @@ A second, latent harm hides in the same case. `attemptRepair` first **removes th
 
 **repair-action guard only**, exact-present hard verdict + soft hint. One detection point, zero new device round-trips (reuses the snapshot repair already takes), fully unit-testable without iOS 26.2 hardware.
 
-1. **Hard verdict `TRANSPORT_BLIND`:** when the (normalized) failed selector is present **verbatim** in the rn-fast-runner snapshot's testID set — we see it, Maestro didn't — emit `TRANSPORT_BLIND` instead of attempting a no-op self-repair or reporting `TESTID_NOT_FOUND`. Unambiguous; near-zero false positives.
+1. **Hard verdict `TRANSPORT_BLIND`:** when the failed selector is *used by the action body* **and** present **verbatim** in the rn-fast-runner snapshot's testID set — we see it, Maestro didn't — emit `TRANSPORT_BLIND` instead of reporting `TESTID_NOT_FOUND`. Unambiguous; near-zero false positives. (The body-membership condition preserves the existing `BAD_FILENAME` "your hint is wrong" diagnostic: a hint not in the body but coincidentally on-screen must not be mislabeled transport-blind — plan-review finding #1.)
 2. **Soft hint:** on the existing no-confident-match path (selector absent, other candidates present), keep the `TESTID_NOT_FOUND` verdict but **append** a line naming transport-blindness as a possibility to verify with `device_snapshot`. Message-only; no verdict change.
 3. **`cdp_run_action` integration:** treat `TRANSPORT_BLIND` as a **terminal refusal** (no retry), record it in `autoRepair` telemetry as `refused / transport_blind`, and surface the diagnostic.
 

--- a/docs/superpowers/specs/2026-06-17-317-transport-blind-diagnostic-design.md
+++ b/docs/superpowers/specs/2026-06-17-317-transport-blind-diagnostic-design.md
@@ -13,7 +13,7 @@ When a flow fails this way, `cdp_run_action` calls `cdp_repair_action`. Repair t
 
 This message is **actively misleading**: it tells the user the testID drifted, sending them toward testID-drift debugging, when the real cause is a blind transport (WDA sees 0 nodes). #317 calls this out directly: *"auto-repair is misleading here: the real cause is 'WDA sees 0 nodes' but it reports 'no confident replacement'."*
 
-A second, latent harm hides in the clean case: when the failed selector **is** present verbatim in the rn-fast-runner snapshot, `findBestMatch` scores it `1.0`, "repairs" `X → X` (a no-op patch), retries Maestro, and fails identically because WDA is still blind — a silent, futile repair+retry cycle.
+A second, latent harm hides in the same case. `attemptRepair` first **removes the failed selector from the candidate pool** (`repair-engine.ts:274` — `candidates.filter(c => c !== failedSelector)`), then fuzzy-matches the failed selector against *the remaining* testIDs. So when the screen genuinely renders the element (transport-blind), repair never even considers it. Two outcomes follow: **(a)** nothing else clears the 0.6 threshold → the misleading "no confident replacement" above (the actual #317 symptom); or worse, **(b)** some *unrelated* testID happens to score ≥ 0.6 → repair silently patches `X → Y`, **corrupting the action with the wrong selector** and demoting it, while the real cause is the blind transport. A guard placed *before* `attemptRepair` prevents both.
 
 ## Why the bridge cannot see WDA directly
 
@@ -60,7 +60,9 @@ types.ts
   └─ ⟢ NEW: ToolErrorCode |= 'TRANSPORT_BLIND'   // GH #317
 ```
 
-The new check is placed **after** `extractAllTestIDs` (so `candidates` exists) and the empty-snapshot guard, but **before** `attemptRepair` — so the exact-present case short-circuits to the truth instead of the futile `X → X` no-op repair + retry.
+The new check is placed **after** `extractAllTestIDs` (so `candidates` exists) and the empty-snapshot guard, but **before** `attemptRepair` — so the exact-present case short-circuits to the truth instead of letting `attemptRepair` filter the selector out and then either mislead (no-match) or mis-patch (`X → Y`).
+
+A drifted selector (genuinely renamed) is **absent** from the new snapshot, so `candidates` never contains it → the guard stays silent and real drift still flows to `attemptRepair`. This makes exact-present a clean discriminator between transport-blindness and drift.
 
 ## Components
 
@@ -72,8 +74,8 @@ Add `'TRANSPORT_BLIND'` to the `ToolErrorCode` union (near `TESTID_NOT_FOUND` / 
 detectTransportBlind(failedSelector: string, candidates: string[]): boolean
 ```
 - Takes the same `candidates` array `cdp_repair_action` already builds from `extractAllTestIDs` (used today as `candidates.length` / `candidates.slice(0,50)`).
-- Normalizes `failedSelector` to a bare testID — strips Maestro selector decoration (`id:X`, `#X`) to `X`. Reuse / mirror the existing selector parsing (`extractIdSelectors`) so normalization matches how candidates were extracted.
-- Returns whether the normalized testID appears **verbatim** in `candidates` (case-sensitive — testIDs are case-sensitive). Build a `Set` internally for O(1) membership if preferred.
+- Returns whether `failedSelector` appears **verbatim** in `candidates` (case-sensitive — testIDs are case-sensitive). Build a `Set` internally for O(1) membership if preferred.
+- **No normalization needed:** `failedSelector` is already a bare testID by contract. `maestro-error-parser` captures the inner value (`selector: m[2]`, no `#`/`id:` decoration), and `attemptRepair` already compares it verbatim against bare testIDs (`candidates.filter(c => c !== failedSelector)`, `extractIdSelectors(body).includes(failedSelector)`). Verbatim membership keeps this helper consistent with that existing contract.
 - Pure, no I/O → trivially unit-testable.
 
 ### `src/tools/repair-action.ts`
@@ -85,10 +87,13 @@ detectTransportBlind(failedSelector: string, candidates: string[]): boolean
   - the message below.
 - On the existing `no-match` branch, append the soft hint to the message (verdict stays `TESTID_NOT_FOUND`).
 
+### `src/domain/reusable-action.ts`
+Add `'TRANSPORT_BLIND'` to the `AutoRepairRefusedReason` union (`reusable-action.ts:155`) so the refusal reason can be recorded honestly in `RunRecord.autoRepair`.
+
 ### `src/tools/run-action.ts` (`cdp_run_action`)
-- When `cdp_repair_action` returns `TRANSPORT_BLIND`, do **not** retry the flow (terminal refusal).
-- Record in the `RunRecord` `autoRepair` telemetry as `refused` with reason `transport_blind`.
-- Surface the diagnostic message to the caller.
+A non-patched repair is **already terminal** here — `run-action.ts:377–407` maps the reason, persists a `RunRecord`, and returns; there is no retry loop. So "no retry on `TRANSPORT_BLIND`" is the *existing* behavior. Two wiring changes:
+- **`mapRefusedReason`** (`run-action.ts:166`): add `if (repairCode === 'TRANSPORT_BLIND') return 'TRANSPORT_BLIND';` — otherwise it falls through to `INTERNAL_ERROR` (the same gap that affected `RUNNER_LEAK`).
+- **The refusal return** (`run-action.ts:397–406`): when `refusedReason === 'TRANSPORT_BLIND'`, return the result with code `'TRANSPORT_BLIND'` (not the hardcoded `'TESTID_NOT_FOUND'`) so `cdp_run_action`'s own envelope is honest; the detailed message flows through `repairEnv.error`.
 
 ## The diagnostic message (the actual UX)
 
@@ -108,7 +113,7 @@ All tests are pure-helper or handler-level with synthetic snapshot envelopes —
 1. exact-present (`X` in candidates) → `true`.
 2. selector absent, other candidates present → `false`.
 3. empty candidate set → `false`.
-4. normalization variants — `id:X`, `#X`, bare `X` all resolve to `X` and match a candidate `X`.
+4. case-sensitivity — `Submit` against candidate `submit` → `false` (testIDs are case-sensitive; verbatim match).
 
 `cdp_repair_action` handler:
 5. exact-present → returns code `TRANSPORT_BLIND` (not `TESTID_NOT_FOUND`), `meta.snapshotTestIdCount` correct, message names the selector + `N`.
@@ -131,5 +136,5 @@ All tests are pure-helper or handler-level with synthetic snapshot envelopes —
 ## Notes / risks
 
 - **False-positive containment:** the hard verdict fires only on a verbatim selector match in our own snapshot, so it cannot relabel a genuine drift (where the old selector is gone) as transport-blind. The ambiguous "no confident match" case keeps its drift-oriented verdict and only *gains* a hint.
-- **Selector normalization is the one fragile seam:** if `failedSelector` arrives in a form `extractIdSelectors`/`extractAllTestIDs` normalize differently, exact-match could miss. The normalization-variant tests (case 4) pin this; verify the actual `args.failedSelector` shape during implementation.
+- **Verbatim match is contract-consistent, not fragile:** `failedSelector` is already a bare testID (`maestro-error-parser` captures `m[2]`; `attemptRepair` compares it verbatim today), so a verbatim `includes` cannot drift out of step with the existing comparison. If that contract ever changed, drift repair would already be broken — this guard rides the same invariant.
 - This slice does not *unblock* replay on iOS 26.2 — it stops the tooling from lying about *why* it's blocked and points at the working path. Restoring replay is Phase 2 (rn-fast-runner-native replay).

--- a/docs/superpowers/specs/2026-06-17-317-transport-blind-diagnostic-design.md
+++ b/docs/superpowers/specs/2026-06-17-317-transport-blind-diagnostic-design.md
@@ -1,0 +1,135 @@
+# GH #317 — Phase 1: `TRANSPORT_BLIND` diagnostic (cdp_repair_action guard)
+
+**Status:** Approved (2026-06-17)
+**Issue:** [#317](https://github.com/Lykhoyda/rn-dev-agent/issues/317) — iOS 26.2 + bridgeless + react-native-actions-sheet: Maestro/WDA reads an empty a11y tree → all `maestro_run`/`cdp_run_action` fail at the first selector, while rn-fast-runner sees everything (`kano:must-be`, `priority:now`, `effort:l` overall — this spec is the small, unblocked first slice).
+
+## Problem
+
+On iOS 26.2 + bridgeless (new architecture) running an Expo Dev Client, WebDriverAgent/XCTest reads an **empty or partial accessibility tree** for the app. Every Maestro-driven call (`maestro_run`, `cdp_run_action`) therefore fails at the first `extendedWaitUntil`/`tapOn` with `Element '#<testID>' not visible`, even though the in-tree **rn-fast-runner** (`device_snapshot`) sees and interacts with the exact same element by the exact same testID milliseconds earlier.
+
+When a flow fails this way, `cdp_run_action` calls `cdp_repair_action`. Repair takes its **own** rn-fast-runner snapshot (`runNative(['snapshot','-i'])` — `repair-action.ts:251`), fails to confidently match the failed selector, and returns:
+
+> `no confident replacement for "<X>". No candidate scored at or above 0.6` (code `TESTID_NOT_FOUND`, `repair-action.ts:317–329`)
+
+This message is **actively misleading**: it tells the user the testID drifted, sending them toward testID-drift debugging, when the real cause is a blind transport (WDA sees 0 nodes). #317 calls this out directly: *"auto-repair is misleading here: the real cause is 'WDA sees 0 nodes' but it reports 'no confident replacement'."*
+
+A second, latent harm hides in the clean case: when the failed selector **is** present verbatim in the rn-fast-runner snapshot, `findBestMatch` scores it `1.0`, "repairs" `X → X` (a no-op patch), retries Maestro, and fails identically because WDA is still blind — a silent, futile repair+retry cycle.
+
+## Why the bridge cannot see WDA directly
+
+`maestro-runner` is invoked via `execFile` (`maestro-run.ts:206–218`) and returns **only stdout/stderr text** — no node counts, no view hierarchy. There is no WDA/XCUIElement tree exposed anywhere inside the bridge. So "WDA is blind" can never be **observed** directly; it can only be **inferred** by comparing what Maestro reported against a transport we *can* read: the rn-fast-runner snapshot that `cdp_repair_action` already takes. The transport disagreement is the signal.
+
+## Scope (chosen)
+
+**repair-action guard only**, exact-present hard verdict + soft hint. One detection point, zero new device round-trips (reuses the snapshot repair already takes), fully unit-testable without iOS 26.2 hardware.
+
+1. **Hard verdict `TRANSPORT_BLIND`:** when the (normalized) failed selector is present **verbatim** in the rn-fast-runner snapshot's testID set — we see it, Maestro didn't — emit `TRANSPORT_BLIND` instead of attempting a no-op self-repair or reporting `TESTID_NOT_FOUND`. Unambiguous; near-zero false positives.
+2. **Soft hint:** on the existing no-confident-match path (selector absent, other candidates present), keep the `TESTID_NOT_FOUND` verdict but **append** a line naming transport-blindness as a possibility to verify with `device_snapshot`. Message-only; no verdict change.
+3. **`cdp_run_action` integration:** treat `TRANSPORT_BLIND` as a **terminal refusal** (no retry), record it in `autoRepair` telemetry as `refused / transport_blind`, and surface the diagnostic.
+
+### Explicitly out of scope (Phase 2+)
+
+- Routing action replay through rn-fast-runner when WDA is blind (the larger effort:L piece; needs the real repro stack to device-verify).
+- Any `maestro_run` hot-path probe / failure-path snapshot.
+- Fuzzy or heuristic transport-blind verdicts (e.g. "populated tree + ≥0.95 near-match"). Exact-present only, to avoid relabeling genuine testID drift.
+- The unrelated secondary items in #317 (WDA boot dismissing an open actions-sheet; `device_screenshot` simctl-transition flakiness; `clearState` Dev Client relaunch). Tracked separately.
+
+## Architecture
+
+```
+cdp_run_action (run-action.ts)
+  └─ on flow failure → cdp_repair_action
+        │
+cdp_repair_action  (tools/repair-action.ts)
+  ├─ snapEnvelope = runNative(['snapshot','-i'])           rn-fast-runner snapshot (existing)
+  ├─ RUNNER_LEAK sentinel check                            (existing)
+  ├─ candidates = extractAllTestIDs(snapEnvelope)          (existing, repair-engine.ts:103)
+  ├─ if candidates.length === 0 → TESTID_NOT_FOUND         (existing — we see nothing either)
+  ├─ ⟢ NEW: if detectTransportBlind(failedSelector, candidates)
+  │        → failResult(msg, 'TRANSPORT_BLIND', meta)      hard verdict, before attemptRepair
+  ├─ result = attemptRepair(action, failedSelector, candidates, threshold)   (existing)
+  └─ if result.kind === 'no-match'
+         → failResult(msg + ⟢ NEW soft transport-blind hint, 'TESTID_NOT_FOUND', meta)
+
+repair-engine.ts
+  └─ ⟢ NEW: detectTransportBlind(failedSelector, candidates: string[]): boolean
+            normalize selector (id:/# decoration → bare testID, case-sensitive)
+            return candidates includes the normalized testID (verbatim)
+
+types.ts
+  └─ ⟢ NEW: ToolErrorCode |= 'TRANSPORT_BLIND'   // GH #317
+```
+
+The new check is placed **after** `extractAllTestIDs` (so `candidates` exists) and the empty-snapshot guard, but **before** `attemptRepair` — so the exact-present case short-circuits to the truth instead of the futile `X → X` no-op repair + retry.
+
+## Components
+
+### `src/types.ts`
+Add `'TRANSPORT_BLIND'` to the `ToolErrorCode` union (near `TESTID_NOT_FOUND` / `SNAPSHOT_FAILED` / `RN_FAST_RUNNER_DOWN`, `types.ts:200–273`), with a `// GH #317` comment.
+
+### `src/domain/repair-engine.ts` (new pure helper)
+```
+detectTransportBlind(failedSelector: string, candidates: string[]): boolean
+```
+- Takes the same `candidates` array `cdp_repair_action` already builds from `extractAllTestIDs` (used today as `candidates.length` / `candidates.slice(0,50)`).
+- Normalizes `failedSelector` to a bare testID — strips Maestro selector decoration (`id:X`, `#X`) to `X`. Reuse / mirror the existing selector parsing (`extractIdSelectors`) so normalization matches how candidates were extracted.
+- Returns whether the normalized testID appears **verbatim** in `candidates` (case-sensitive — testIDs are case-sensitive). Build a `Set` internally for O(1) membership if preferred.
+- Pure, no I/O → trivially unit-testable.
+
+### `src/tools/repair-action.ts`
+- Call `detectTransportBlind(args.failedSelector, candidatesSet)` after the empty-snapshot guard, before `attemptRepair`.
+- On `true`, return `failResult(message, 'TRANSPORT_BLIND', meta)` where `meta` carries:
+  - `failedSelector`
+  - `snapshotTestIdCount` (the `N` rn-fast-runner saw)
+  - `actionId`
+  - the message below.
+- On the existing `no-match` branch, append the soft hint to the message (verdict stays `TESTID_NOT_FOUND`).
+
+### `src/tools/run-action.ts` (`cdp_run_action`)
+- When `cdp_repair_action` returns `TRANSPORT_BLIND`, do **not** retry the flow (terminal refusal).
+- Record in the `RunRecord` `autoRepair` telemetry as `refused` with reason `transport_blind`.
+- Surface the diagnostic message to the caller.
+
+## The diagnostic message (the actual UX)
+
+Hard verdict (`TRANSPORT_BLIND`):
+
+> `TRANSPORT_BLIND: Maestro/WDA reported "<X>" not visible, but rn-fast-runner sees it (N testIDs in the live snapshot). This is transport-blindness, not testID drift — WDA reads an empty/partial accessibility tree on this runtime (e.g. iOS 26.2 + bridgeless, GH #317). Maestro-based replay (maestro_run/cdp_run_action) is blocked here; drive the screen with device_* primitives (device_find/press/fill), which go through rn-fast-runner and work. rn-fast-runner-native action replay is tracked in #317 Phase 2.`
+
+Soft hint (appended to the existing `no confident replacement` message):
+
+> `If "<X>" is in fact correct and the screen renders, WDA may be transport-blind on this runtime (empty a11y tree; see GH #317) — confirm with device_snapshot, which uses rn-fast-runner.`
+
+## Testing (TDD, `node:test` + `node:assert/strict`)
+
+All tests are pure-helper or handler-level with synthetic snapshot envelopes — **no device required**. Test files alongside existing repair tests in `scripts/cdp-bridge/test/unit/` (e.g. `audit-b3-repair-grammar.test.js` style; imports from compiled `../../dist/...`).
+
+`detectTransportBlind` (pure):
+1. exact-present (`X` in candidates) → `true`.
+2. selector absent, other candidates present → `false`.
+3. empty candidate set → `false`.
+4. normalization variants — `id:X`, `#X`, bare `X` all resolve to `X` and match a candidate `X`.
+
+`cdp_repair_action` handler:
+5. exact-present → returns code `TRANSPORT_BLIND` (not `TESTID_NOT_FOUND`), `meta.snapshotTestIdCount` correct, message names the selector + `N`.
+6. selector absent, candidates present, best score < 0.6 → still `TESTID_NOT_FOUND`, message **includes the soft hint**.
+7. empty snapshot (0 testIDs) → stays `TESTID_NOT_FOUND` (genuinely not transport-blind — we see nothing either).
+8. exact-present case does **not** invoke a no-op `X → X` repair/retry (guard short-circuits before `attemptRepair`).
+
+`cdp_run_action`:
+9. `TRANSPORT_BLIND` from repair ⇒ no flow retry; `autoRepair` telemetry records `refused / transport_blind`; diagnostic surfaced.
+
+## Acceptance criteria
+
+- `cdp_repair_action` returns `TRANSPORT_BLIND` (with actionable message + `snapshotTestIdCount`) whenever the failed selector is present verbatim in the rn-fast-runner snapshot.
+- The no-confident-match path is unchanged except for the appended soft hint.
+- `cdp_run_action` does not retry on `TRANSPORT_BLIND` and logs `refused/transport_blind`.
+- No new device round-trips added; the existing snapshot is reused.
+- All new unit tests pass; the full cdp-bridge suite stays green.
+- A changeset is added; `dist/` is rebuilt and staged (tracked outputs).
+
+## Notes / risks
+
+- **False-positive containment:** the hard verdict fires only on a verbatim selector match in our own snapshot, so it cannot relabel a genuine drift (where the old selector is gone) as transport-blind. The ambiguous "no confident match" case keeps its drift-oriented verdict and only *gains* a hint.
+- **Selector normalization is the one fragile seam:** if `failedSelector` arrives in a form `extractIdSelectors`/`extractAllTestIDs` normalize differently, exact-match could miss. The normalization-variant tests (case 4) pin this; verify the actual `args.failedSelector` shape during implementation.
+- This slice does not *unblock* replay on iOS 26.2 — it stops the tooling from lying about *why* it's blocked and points at the working path. Restoring replay is Phase 2 (rn-fast-runner-native replay).

--- a/scripts/cdp-bridge/dist/domain/repair-engine.js
+++ b/scripts/cdp-bridge/dist/domain/repair-engine.js
@@ -108,6 +108,22 @@ function walkTree(node, acc) {
             walkTree(child, acc);
     }
 }
+/**
+ * GH #317 — transport-blindness detector. Returns true when the
+ * Maestro-reported failed selector is present VERBATIM in the live
+ * rn-fast-runner snapshot's testID list: the element IS rendered and our
+ * transport sees it, yet Maestro/WDA reported it "not visible" — i.e. WDA
+ * read an empty/partial a11y tree (e.g. iOS 26.2 + bridgeless), not a
+ * testID drift. A genuinely-renamed selector is absent from the snapshot,
+ * so this stays false and real drift still flows to attemptRepair.
+ *
+ * Pure function — exported for unit tests.
+ */
+export function detectTransportBlind(failedSelector, candidates) {
+    if (!failedSelector)
+        return false;
+    return candidates.includes(failedSelector);
+}
 // ─────────────────────────────────────────────────────────────────────────────
 // Maestro YAML body — find + replace selectors
 // ─────────────────────────────────────────────────────────────────────────────

--- a/scripts/cdp-bridge/dist/tools/repair-action.js
+++ b/scripts/cdp-bridge/dist/tools/repair-action.js
@@ -11,7 +11,7 @@ import { ensureFastRunner, getActiveSession, runNative } from '../agent-device-w
 import { okResult, failResult, withSession } from '../utils.js';
 import { isValidActionId } from '../domain/path-safety.js';
 import { loadAction, saveAction, actionWasEditedExternally, } from '../domain/action-store.js';
-import { extractAllTestIDs, attemptRepair, applyRepair, DEFAULT_REPAIR_THRESHOLD, } from '../domain/repair-engine.js';
+import { extractAllTestIDs, extractIdSelectors, detectTransportBlind, attemptRepair, applyRepair, DEFAULT_REPAIR_THRESHOLD, } from '../domain/repair-engine.js';
 import { repairBudgetAvailable, recentRepairCount } from '../domain/reusable-action.js';
 import { snapshotEnvelopeFailed } from './device-batch.js';
 import { resolveBundleId } from '../project-config.js';
@@ -202,6 +202,24 @@ export function createRepairActionHandler() {
                 hint: 'The screen may not have any rendered elements with testIDs (e.g. you are on a loading screen, splash, or dev-client picker). Navigate to the target screen first.',
             });
         }
+        // GH #317: transport-blindness guard. If the failed selector is BOTH used by
+        // the action AND present verbatim in OUR live snapshot, the element is
+        // rendered and rn-fast-runner can see it — Maestro/WDA reported "not visible"
+        // because it read an empty a11y tree (e.g. iOS 26.2 + bridgeless), NOT because
+        // the testID drifted. The body-membership check preserves the deliberate
+        // BAD_FILENAME "your hint is wrong" diagnostic (Issue #102 A3). Fire BEFORE
+        // attemptRepair, which filters the selector out of candidates and would
+        // otherwise mislead ("no confident replacement") or mis-patch it.
+        if (extractIdSelectors(action.body).includes(args.failedSelector) &&
+            detectTransportBlind(args.failedSelector, candidates)) {
+            return failResult(`cdp_repair_action: Maestro/WDA reported "${args.failedSelector}" not visible, but rn-fast-runner sees it (${candidates.length} testIDs in the live snapshot). This is transport-blindness, not testID drift — WDA reads an empty/partial accessibility tree on this runtime (e.g. iOS 26.2 + bridgeless, GH #317). Maestro-based replay is blocked here; drive the screen with device_* primitives (device_find/press/fill), which go through rn-fast-runner and work. rn-fast-runner-native action replay is tracked in #317 Phase 2.`, 'TRANSPORT_BLIND', {
+                actionId: args.actionId,
+                failedSelector: args.failedSelector,
+                snapshotTestIdCount: candidates.length,
+                candidatesSample: candidates.slice(0, 50),
+                hint: 'Verify with device_snapshot — it uses rn-fast-runner. If the element is present there, this is a WDA transport limitation, not your testID.',
+            });
+        }
         const result = attemptRepair(action, args.failedSelector, candidates, args.threshold ?? DEFAULT_REPAIR_THRESHOLD);
         if (result.kind === 'no-stale-selector') {
             // Issue #102 A3: this surfaces "the caller passed a failedSelector
@@ -219,7 +237,7 @@ export function createRepairActionHandler() {
             });
         }
         if (result.kind === 'no-match') {
-            return failResult(`cdp_repair_action: no confident replacement for "${args.failedSelector}". ${result.reason}`, 'TESTID_NOT_FOUND', {
+            return failResult(`cdp_repair_action: no confident replacement for "${args.failedSelector}". ${result.reason} If "${args.failedSelector}" is in fact correct and the screen renders, WDA may be transport-blind on this runtime (empty a11y tree; see GH #317) — confirm with device_snapshot, which uses rn-fast-runner.`, 'TESTID_NOT_FOUND', {
                 actionId: args.actionId,
                 failedSelector: args.failedSelector,
                 bestScore: result.bestScore,

--- a/scripts/cdp-bridge/dist/tools/run-action.js
+++ b/scripts/cdp-bridge/dist/tools/run-action.js
@@ -103,6 +103,10 @@ function mapRefusedReason(repairCode, repairError) {
     // under INTERNAL_ERROR.
     if (repairCode === 'RUNNER_LEAK')
         return 'SNAPSHOT_FAILED';
+    // GH #317: rn-fast-runner saw the selector but Maestro/WDA could not. Surface
+    // it as its own reason (NOT INTERNAL_ERROR) so MTTR sees transport-blindness.
+    if (repairCode === 'TRANSPORT_BLIND')
+        return 'TRANSPORT_BLIND';
     if (repairCode === 'TESTID_NOT_FOUND')
         return 'NO_MATCH';
     if (repairCode === 'STALE_TARGET') {
@@ -285,7 +289,7 @@ export function createRunActionHandler(deps = {}) {
                     trigger,
                     autoRepair,
                 });
-                return failResult(`cdp_run_action: ${args.actionId} failed with SELECTOR_NOT_FOUND; auto-repair refused (${refusedReason}): ${repairEnv.error ?? 'unknown'}`, 'TESTID_NOT_FOUND', {
+                return failResult(`cdp_run_action: ${args.actionId} failed with SELECTOR_NOT_FOUND; auto-repair refused (${refusedReason}): ${repairEnv.error ?? 'unknown'}`, refusedReason === 'TRANSPORT_BLIND' ? 'TRANSPORT_BLIND' : 'TESTID_NOT_FOUND', {
                     actionId: args.actionId,
                     autoRepair,
                     repairError: repairEnv.error,

--- a/scripts/cdp-bridge/src/domain/repair-engine.ts
+++ b/scripts/cdp-bridge/src/domain/repair-engine.ts
@@ -132,6 +132,22 @@ function walkTree(node: SnapshotNodeTree, acc: Set<string>): void {
   }
 }
 
+/**
+ * GH #317 — transport-blindness detector. Returns true when the
+ * Maestro-reported failed selector is present VERBATIM in the live
+ * rn-fast-runner snapshot's testID list: the element IS rendered and our
+ * transport sees it, yet Maestro/WDA reported it "not visible" — i.e. WDA
+ * read an empty/partial a11y tree (e.g. iOS 26.2 + bridgeless), not a
+ * testID drift. A genuinely-renamed selector is absent from the snapshot,
+ * so this stays false and real drift still flows to attemptRepair.
+ *
+ * Pure function — exported for unit tests.
+ */
+export function detectTransportBlind(failedSelector: string, candidates: string[]): boolean {
+  if (!failedSelector) return false;
+  return candidates.includes(failedSelector);
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Maestro YAML body — find + replace selectors
 // ─────────────────────────────────────────────────────────────────────────────

--- a/scripts/cdp-bridge/src/domain/reusable-action.ts
+++ b/scripts/cdp-bridge/src/domain/reusable-action.ts
@@ -165,6 +165,10 @@ export type AutoRepairRefusedReason =
   // genuine refusals so MTTR analysis (#105) can see "user disabled
   // repair" as operationally healthy vs. budget/edit/match refusals.
   | 'USER_DISABLED'
+  // GH #317: rn-fast-runner saw the selector but Maestro/WDA reported it not
+  // visible (empty a11y tree). A transport limitation, not testID drift —
+  // repair is correctly refused and replay is blocked on this runtime.
+  | 'TRANSPORT_BLIND'
   // Internal/unexpected: parseEnvelope failed, repair-action returned
   // an unmapped error code, or the orchestrator hit a defensive path.
   // Keep separate from NO_MATCH so MTTR doesn't conflate transport

--- a/scripts/cdp-bridge/src/tools/repair-action.ts
+++ b/scripts/cdp-bridge/src/tools/repair-action.ts
@@ -19,6 +19,8 @@ import {
 } from '../domain/action-store.js';
 import {
   extractAllTestIDs,
+  extractIdSelectors,
+  detectTransportBlind,
   attemptRepair,
   applyRepair,
   DEFAULT_REPAIR_THRESHOLD,
@@ -293,6 +295,31 @@ export function createRepairActionHandler() {
       );
     }
 
+    // GH #317: transport-blindness guard. If the failed selector is BOTH used by
+    // the action AND present verbatim in OUR live snapshot, the element is
+    // rendered and rn-fast-runner can see it — Maestro/WDA reported "not visible"
+    // because it read an empty a11y tree (e.g. iOS 26.2 + bridgeless), NOT because
+    // the testID drifted. The body-membership check preserves the deliberate
+    // BAD_FILENAME "your hint is wrong" diagnostic (Issue #102 A3). Fire BEFORE
+    // attemptRepair, which filters the selector out of candidates and would
+    // otherwise mislead ("no confident replacement") or mis-patch it.
+    if (
+      extractIdSelectors(action.body).includes(args.failedSelector) &&
+      detectTransportBlind(args.failedSelector, candidates)
+    ) {
+      return failResult(
+        `cdp_repair_action: Maestro/WDA reported "${args.failedSelector}" not visible, but rn-fast-runner sees it (${candidates.length} testIDs in the live snapshot). This is transport-blindness, not testID drift — WDA reads an empty/partial accessibility tree on this runtime (e.g. iOS 26.2 + bridgeless, GH #317). Maestro-based replay is blocked here; drive the screen with device_* primitives (device_find/press/fill), which go through rn-fast-runner and work. rn-fast-runner-native action replay is tracked in #317 Phase 2.`,
+        'TRANSPORT_BLIND',
+        {
+          actionId: args.actionId,
+          failedSelector: args.failedSelector,
+          snapshotTestIdCount: candidates.length,
+          candidatesSample: candidates.slice(0, 50),
+          hint: 'Verify with device_snapshot — it uses rn-fast-runner. If the element is present there, this is a WDA transport limitation, not your testID.',
+        },
+      );
+    }
+
     const result = attemptRepair(action, args.failedSelector, candidates, args.threshold ?? DEFAULT_REPAIR_THRESHOLD);
 
     if (result.kind === 'no-stale-selector') {
@@ -316,7 +343,7 @@ export function createRepairActionHandler() {
     }
     if (result.kind === 'no-match') {
       return failResult(
-        `cdp_repair_action: no confident replacement for "${args.failedSelector}". ${result.reason}`,
+        `cdp_repair_action: no confident replacement for "${args.failedSelector}". ${result.reason} If "${args.failedSelector}" is in fact correct and the screen renders, WDA may be transport-blind on this runtime (empty a11y tree; see GH #317) — confirm with device_snapshot, which uses rn-fast-runner.`,
         'TESTID_NOT_FOUND',
         {
           actionId: args.actionId,

--- a/scripts/cdp-bridge/src/tools/run-action.ts
+++ b/scripts/cdp-bridge/src/tools/run-action.ts
@@ -171,6 +171,9 @@ function mapRefusedReason(repairCode: string | undefined, repairError: string): 
   // it with SNAPSHOT_FAILED so MTTR analytics surface it instead of hiding it
   // under INTERNAL_ERROR.
   if (repairCode === 'RUNNER_LEAK') return 'SNAPSHOT_FAILED';
+  // GH #317: rn-fast-runner saw the selector but Maestro/WDA could not. Surface
+  // it as its own reason (NOT INTERNAL_ERROR) so MTTR sees transport-blindness.
+  if (repairCode === 'TRANSPORT_BLIND') return 'TRANSPORT_BLIND';
   if (repairCode === 'TESTID_NOT_FOUND') return 'NO_MATCH';
   if (repairCode === 'STALE_TARGET') {
     if (/repair budget/i.test(repairError)) return 'BUDGET_EXHAUSTED';
@@ -396,7 +399,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
         });
         return failResult(
           `cdp_run_action: ${args.actionId} failed with SELECTOR_NOT_FOUND; auto-repair refused (${refusedReason}): ${repairEnv.error ?? 'unknown'}`,
-          'TESTID_NOT_FOUND',
+          refusedReason === 'TRANSPORT_BLIND' ? 'TRANSPORT_BLIND' : 'TESTID_NOT_FOUND',
           {
             actionId: args.actionId,
             autoRepair,

--- a/scripts/cdp-bridge/src/types.ts
+++ b/scripts/cdp-bridge/src/types.ts
@@ -243,6 +243,8 @@ export type ToolErrorCode =
   | 'INVALID_BUNDLE_ID'         // GH #262 codex-pair: cdp_restart explicit bundleId arg failed strict validation
   // GH #105 / B153: cdp_repair_action's snapshot landed on Agent Device Runner.
   | 'RUNNER_LEAK'
+  // GH #317: rn-fast-runner sees the selector but Maestro/WDA reported it not visible (empty a11y tree).
+  | 'TRANSPORT_BLIND'
   // GH #105 / iOS-MVP §3.1: runIOS press/fill with a @ref no longer in the
   // ref-map (snapshot is stale / UI re-rendered). Caller must device_snapshot
   // to refresh refs, then retry.

--- a/scripts/cdp-bridge/test/unit/repair-action-handler.test.js
+++ b/scripts/cdp-bridge/test/unit/repair-action-handler.test.js
@@ -568,6 +568,7 @@ test('GH #317: failed selector present in snapshot → TRANSPORT_BLIND, not no-m
   assert.equal(result.isError, true);
   const env = JSON.parse(result.content[0].text);
   assert.equal(env.code, 'TRANSPORT_BLIND');
+  assert.equal(env.meta.actionId, 'register-new-user');
   assert.equal(env.meta.snapshotTestIdCount, 3);
   assert.equal(env.meta.failedSelector, 'submit_email_form');
   assert.match(env.error, /transport-blindness/i);

--- a/scripts/cdp-bridge/test/unit/repair-action-handler.test.js
+++ b/scripts/cdp-bridge/test/unit/repair-action-handler.test.js
@@ -544,3 +544,99 @@ test('repair-action: when YAML write fails after sidecar succeeds, no false-posi
   // not advertise a successful patch.
   assert.match(action.body, /id:\s+"fab-create-task"/);
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GH #317 — transport-blindness: rn-fast-runner sees the selector Maestro/WDA missed
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('GH #317: failed selector present in snapshot → TRANSPORT_BLIND, not no-match', async () => {
+  project.seedAction(
+    'register-new-user',
+    fixtureYaml({ id: 'register-new-user', selectors: ['submit_email_form'] }),
+  );
+  _setRunAgentDeviceForTest(async () => ({
+    content: [{ type: 'text', text: fakeSnapshot(['submit_email_form', 'header-home', 'btn-cancel']) }],
+  }));
+
+  const handler = createRepairActionHandler();
+  const result = await handler({
+    actionId: 'register-new-user',
+    failedSelector: 'submit_email_form',
+    projectRoot: project.root,
+  });
+
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'TRANSPORT_BLIND');
+  assert.equal(env.meta.snapshotTestIdCount, 3);
+  assert.equal(env.meta.failedSelector, 'submit_email_form');
+  assert.match(env.error, /transport-blindness/i);
+  assert.match(env.error, /rn-fast-runner sees it/i);
+});
+
+test('GH #317: selector absent + no confident match → TESTID_NOT_FOUND with transport-blind soft hint', async () => {
+  project.seedAction(
+    'register-new-user-2',
+    fixtureYaml({ id: 'register-new-user-2', selectors: ['submit_email_form'] }),
+  );
+  _setRunAgentDeviceForTest(async () => ({
+    content: [{ type: 'text', text: fakeSnapshot(['totally-unrelated-aaa', 'zzz-different-bbb']) }],
+  }));
+
+  const handler = createRepairActionHandler();
+  const result = await handler({
+    actionId: 'register-new-user-2',
+    failedSelector: 'submit_email_form',
+    projectRoot: project.root,
+  });
+
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'TESTID_NOT_FOUND');
+  assert.match(env.error, /no confident replacement/i);
+  assert.match(env.error, /transport-blind/i);
+  assert.match(env.error, /GH #317/);
+});
+
+test('GH #317: empty snapshot (0 testIDs) stays TESTID_NOT_FOUND, not TRANSPORT_BLIND', async () => {
+  project.seedAction(
+    'register-new-user-3',
+    fixtureYaml({ id: 'register-new-user-3', selectors: ['submit_email_form'] }),
+  );
+  _setRunAgentDeviceForTest(async () => ({
+    content: [{ type: 'text', text: fakeSnapshot([]) }],
+  }));
+
+  const handler = createRepairActionHandler();
+  const result = await handler({
+    actionId: 'register-new-user-3',
+    failedSelector: 'submit_email_form',
+    projectRoot: project.root,
+  });
+
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'TESTID_NOT_FOUND');
+  assert.match(env.error, /0 testIDs/);
+});
+
+test('GH #317: bad hint not in body but coincidentally in snapshot → BAD_FILENAME, not TRANSPORT_BLIND', async () => {
+  project.seedAction(
+    'register-new-user-4',
+    fixtureYaml({ id: 'register-new-user-4', selectors: ['submit_email_form'] }),
+  );
+  _setRunAgentDeviceForTest(async () => ({
+    content: [{ type: 'text', text: fakeSnapshot(['header-home', 'btn-cancel']) }],
+  }));
+
+  const handler = createRepairActionHandler();
+  const result = await handler({
+    actionId: 'register-new-user-4',
+    failedSelector: 'header-home', // present in snapshot, NOT in the action body
+    projectRoot: project.root,
+  });
+
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'BAD_FILENAME');
+});

--- a/scripts/cdp-bridge/test/unit/repair-engine.test.js
+++ b/scripts/cdp-bridge/test/unit/repair-engine.test.js
@@ -13,6 +13,7 @@ import {
   replaceIdSelector,
   attemptRepair,
   applyRepair,
+  detectTransportBlind,
 } from '../../dist/domain/repair-engine.js';
 import { freshRuntimeState } from '../../dist/domain/reusable-action.js';
 
@@ -394,4 +395,25 @@ test('Phase129 applyRepair: writes the patched body, not the original', () => {
   const repaired = applyRepair(action, result, fixedNow);
   assert.match(repaired.body, /id: "fab-create-task-btn"/);
   assert.doesNotMatch(repaired.body, /id: "fab-create-task"$/m);
+});
+
+// GH #317 — transport-blindness detector
+test('detectTransportBlind: failed selector present in snapshot → true (transport-blind)', () => {
+  assert.equal(detectTransportBlind('submit_email_form', ['submit_email_form', 'other-1']), true);
+});
+
+test('detectTransportBlind: failed selector absent, other candidates present → false (possible drift)', () => {
+  assert.equal(detectTransportBlind('submit_email_form', ['other-1', 'other-2']), false);
+});
+
+test('detectTransportBlind: empty candidate list → false', () => {
+  assert.equal(detectTransportBlind('submit_email_form', []), false);
+});
+
+test('detectTransportBlind: verbatim match is case-sensitive', () => {
+  assert.equal(detectTransportBlind('Submit', ['submit']), false);
+});
+
+test('detectTransportBlind: empty selector → false', () => {
+  assert.equal(detectTransportBlind('', ['submit_email_form']), false);
 });

--- a/scripts/cdp-bridge/test/unit/run-action-handler.test.js
+++ b/scripts/cdp-bridge/test/unit/run-action-handler.test.js
@@ -77,6 +77,11 @@ const REPAIR_NO_MATCH_ENV = {
   error: 'cdp_repair_action: no confident replacement for "fab-create-task"',
   code: 'TESTID_NOT_FOUND',
 };
+const REPAIR_TRANSPORT_BLIND_ENV = {
+  ok: false,
+  error: 'cdp_repair_action: Maestro/WDA reported "fab-create-task" not visible, but rn-fast-runner sees it (3 testIDs in the live snapshot). This is transport-blindness, not testID drift (GH #317).',
+  code: 'TRANSPORT_BLIND',
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Validation paths
@@ -266,6 +271,22 @@ test('run-action: repair refused (no fuzzy match) → autoRepair.refusedReason =
   assert.equal(result.isError, true);
   const env = JSON.parse(result.content[0].text);
   assert.equal(env.meta.autoRepair.refusedReason, 'NO_MATCH');
+});
+
+test('GH #317: repair returns TRANSPORT_BLIND → refused, no retry, honest code', async () => {
+  project.seedAction('demo', fixtureYaml({ id: 'demo', selectors: ['fab-create-task'] }));
+
+  const handler = createRunActionHandler({
+    maestroRun: fakeMaestroRun([FAIL_SELECTOR_ENV]),
+    repairAction: fakeRepairAction(REPAIR_TRANSPORT_BLIND_ENV),
+  });
+  const result = await handler({ actionId: 'demo', projectRoot: project.root });
+
+  assert.equal(result.isError, true);
+  const env = JSON.parse(result.content[0].text);
+  assert.equal(env.code, 'TRANSPORT_BLIND');
+  assert.equal(env.meta.autoRepair.outcome, 'refused');
+  assert.equal(env.meta.autoRepair.refusedReason, 'TRANSPORT_BLIND');
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What & why

Closes part of #317 (Phase 1). On **iOS 26.2 + bridgeless**, WebDriverAgent reads an empty/partial accessibility tree, so every `maestro_run` / `cdp_run_action` fails at the first selector "not visible" — even though the in-tree **rn-fast-runner** sees the element fine. `cdp_repair_action` then reported the misleading **"no confident replacement"** (i.e. testID drift), sending users down a wrong debugging path.

This slice makes the tooling **tell the truth**: when the failed selector is present in repair-action's own rn-fast-runner snapshot, it emits a `TRANSPORT_BLIND` diagnostic instead.

## How it works

`cdp_repair_action` already takes an rn-fast-runner snapshot to find replacement testIDs. The transport disagreement is the signal:

- **Hard verdict `TRANSPORT_BLIND`** — fired *before* `attemptRepair` when the failed selector is **(a)** used by the action body **and (b)** present verbatim in the live snapshot. We see it, Maestro didn't → WDA is blind, not drift. (`attemptRepair` filters the selector out of candidates, so without this guard the case degrades to "no confident replacement" or — worse — a wrong `X → Y` patch.)
- **Soft hint** — on the ambiguous no-confident-match path, the existing `TESTID_NOT_FOUND` message gains a line pointing at transport-blindness to verify with `device_snapshot`.
- **`cdp_run_action`** maps the new code to `refusedReason: TRANSPORT_BLIND` (terminal, no retry) and returns code `TRANSPORT_BLIND` so its own envelope is honest — closing the same `INTERNAL_ERROR` fall-through gap that affected `RUNNER_LEAK`.

No new device round-trips — the existing snapshot is reused.

## Scope

- **In:** the diagnostic + guard (this PR). Diagnostic-only.
- **Out (Phase 2):** routing action replay through rn-fast-runner when WDA is blind (the actual fix that restores replay on that runtime); needs the iOS 26.2 repro to device-verify.

## Coverage / known limitation

The hard verdict fires on the **normal-route** case (element persists in the snapshot). For the **sheet-dismissed** case (#317 secondary: WDA boot dismisses an open `react-native-actions-sheet`, leaving the snapshot sparse), the **soft hint** is the fallback. Full coverage is Phase 2.

## Testing

- TDD throughout; cdp-bridge unit suite green (**2249/2249** on clean runs).
- New tests: `detectTransportBlind` pure helper (5 cases); repair-action handler (verdict, soft hint, empty-snapshot unchanged, bad-hint→`BAD_FILENAME` regression); run-action refusal mapping.
- Plan was multi-LLM reviewed pre-code (body-membership precondition, changeset key, and coverage limitation applied from findings); finished diff reviewed (2 reviewers, `tsc --noEmit` clean, no actionable findings).
- **Device verification:** the `TRANSPORT_BLIND` path can only be triggered on the iOS 26.2 + bridgeless empty-a11y-tree runtime, which isn't available here — hence the comprehensive unit coverage. The change is a bridge-internal diagnostic and cannot regress normal repair/replay.

> Note: a pre-existing flaky test (`cdp_restart hardReset: bundleId is cached across calls`) intermittently fails in the full-suite run (passes in isolation; unrelated to this diff — `cdp_restart` is untouched). Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)