### PR TITLE
chore: add husky pre-push hook (oxlint + oxfmt --check)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,6 @@
+# Mirror the CI lint-format gate locally: block the push if oxlint or oxfmt fails.
+# Run both so all problems surface in one attempt; fail if either did.
+status=0
+npm run lint || status=1
+npm run format:check || status=1
+exit $status

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       ],
       "devDependencies": {
         "@changesets/cli": "^2.27.10",
+        "husky": "^9.1.7",
         "oxfmt": "0.55.0",
         "oxlint": "^1.70.0"
       }
@@ -1383,6 +1384,22 @@
       "license": "MIT",
       "bin": {
         "human-id": "dist/cli.js"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "format": "oxfmt",
-    "format:check": "oxfmt --check"
+    "format:check": "oxfmt --check",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.10",
+    "husky": "^9.1.7",
     "oxfmt": "0.55.0",
     "oxlint": "^1.70.0"
   },


### PR DESCRIPTION
## Summary

Adds a **Husky v9 `pre-push` hook** that runs the same checks as the CI `lint-format` gate — `npm run lint` (oxlint) + `npm run format:check` (oxfmt) — so lint/format drift is caught **locally before push**, not after a round-trip through CI.

## Behavior

- **Verify, never mutate.** The hook runs `oxlint` + `oxfmt --check`; it does not auto-format (that would dirty the tree after commit). If either fails, the push is blocked — fix with `npm run format` / `npm run lint:fix`, then re-push.
- **Both checks always run** so all problems surface in one attempt; the hook exits non-zero if *either* failed (a naive two-line script would only report the last command's status).
- Whole-repo checks are cheap (~100–200ms on 404 files), so no `lint-staged` indirection is needed.

```sh
# .husky/pre-push
status=0
npm run lint || status=1
npm run format:check || status=1
exit $status
```

## Wiring

- `husky@^9.1.7` devDependency + `"prepare": "husky"` in the **root** `package.json` (self-installs hooks on `npm install`). Root is `private: true`, so `prepare` never runs on a published install; the shippable `rn-dev-agent-cdp` package is a separate manifest and is unaffected.
- `.husky/_` is gitignored by Husky; only `.husky/pre-push` is tracked.

## Verification

- **Clean repo → hook exit 0** (format:check passes, 404 files).
- **Injected violation → hook exit 1** (oxlint flags the unused var AND format:check runs).
- **This PR's own push exercised the hook** — it ran and passed before the branch was created.

No changeset: `require-changeset` only watches `scripts/cdp-bridge/src/`; this is CI/tooling-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
