### PR TITLE
feat(e2e): params source — lockable/runnable parameterized e2e tests (Plan 3)

### DIFF
--- a/.changeset/e2e-params-source.md
+++ b/.changeset/e2e-params-source.md
@@ -1,0 +1,5 @@
+---
+"rn-dev-agent-cdp": minor
+---
+
+feat(e2e): params source — `.rn-agent/e2e.config.json` supplies per-test param values (with shared `defaults` + secret redaction) so parameterized actions can be locked and run as e2e tests. `cdp_lock_e2e_test` now accepts a param-needing action when the config covers all its params (else `MISSING_PARAMS` listing the gaps); `cdp_run_e2e_suite` runs param tests with their resolved values (else skips with a clear reason). Secret param values (names in `secretParams`) are redacted to `***` in failure output and run records, and only an action's declared params are passed to Maestro (unrelated defaults never leak).

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ scripts/cdp-bridge/eval/
 
 # E2E regression run records (machine state); locked tests under .rn-agent/e2e/ stay tracked
 .rn-agent/state/e2e-runs/
+# E2E param values (may hold secrets) — local/personal, never committed
+.rn-agent/e2e.config.json

--- a/docs/superpowers/plans/2026-06-18-e2e-params-source.md
+++ b/docs/superpowers/plans/2026-06-18-e2e-params-source.md
@@ -1,0 +1,71 @@
+# E2E Params Source — lockable/runnable parameterized e2e tests (Plan 3)
+
+**Goal:** Let parameterized actions become locked e2e tests by supplying values from a local, gitignored `.rn-agent/e2e.config.json`, with secret-value redaction. Removes v1's blanket `PARAMS_UNSUPPORTED` refusal.
+
+**Built on:** the Plan-1 engine (`lock-e2e-test.ts`, `run-e2e-suite.ts`).
+
+## Config shape (`.rn-agent/e2e.config.json`, gitignored)
+
+```json
+{
+  "defaults": { "params": { "EMAIL": "test@example.com" } },
+  "tests": { "login-create-task": { "params": { "TITLE": "Ship demo", "DESC": "e2e", "PRIORITY": "high", "TAG": "feature" } } },
+  "secretParams": ["PASSWORD", "TOKEN", "PIN", "OTP"]
+}
+```
+Resolution for a test = `defaults.params` merged with `tests[id].params` (test wins). A required param (from the action's `# params`) is satisfied only if it resolves to a non-empty string.
+
+## Global constraints
+- Node>=22, TS strict, ESM `.js` imports, `import type`, single-quote, no unnecessary comments.
+- Tests at `test/unit/*.test.js` (top-level), `node:test`, import from `../../dist/*.js`. Build via `npm run build`; `dist/` tracked.
+- Secret param VALUES must never appear in: lock `failureDetail`, suite `errorExcerpt`/output, run records, or SSE — redact to `***`.
+
+## Task 1 — `domain/e2e-config.ts` (pure, TDD)
+
+**Produces:**
+```
+interface E2eConfig { defaults?: { params?: Record<string,string> }; tests?: Record<string,{ params?: Record<string,string> }>; secretParams?: string[] }
+loadE2eConfig(projectRoot): E2eConfig            // .rn-agent/e2e.config.json; {} on missing/corrupt
+resolveParams(config, testId, required: string[]): { ok:true; params:Record<string,string> } | { ok:false; missing:string[] }
+secretValuesFor(config, params: Record<string,string>): string[]   // values of params whose NAME is in secretParams (non-empty)
+redactSecrets(text: string, secretValues: string[]): string        // replace each secret value occurrence with '***'
+```
+Tests: missing/corrupt→`{}`; defaults+test merge with test-override; missing detection (absent + empty-string both → missing); `secretValuesFor` picks only secret-named non-empty values; `redactSecrets` replaces all occurrences, leaves non-secrets, no-op on empty list.
+
+- [ ] failing test `test/unit/e2e-config.test.js` → build+run fail → implement → pass → commit.
+
+## Task 2 — lock accepts param tests when config covers them
+
+`tools/lock-e2e-test.ts`: add `deps.loadConfig?` (default `loadE2eConfig`). Replace the blanket `PARAMS_UNSUPPORTED` branch:
+- param-free → unchanged.
+- param-needing → `resolveParams(config, actionId, metadata.params)`:
+  - `!ok` → `failResult('missing param values for '+missing.join(', ')+' — add them to .rn-agent/e2e.config.json (tests.'+actionId+'.params or defaults.params)', 'MISSING_PARAMS')`.
+  - `ok` → strict `maestroRun({ flowPath, platform, params })`; on fail → `STRICT_RUN_FAILED` with `redactSecrets(output, secretValuesFor(config, params))`; on pass → freeze (unchanged).
+- Add `MISSING_PARAMS` to `ToolErrorCode` (types.ts).
+
+Tests (extend `lock-e2e-test.test.js`): param test + config-with-values → frozen (inject `loadConfig`); param test + missing value → `MISSING_PARAMS` listing the missing name, no maestro call; a secret value present in maestro fail output → redacted (`***`) in the returned meta.
+
+- [ ] failing test → fail → implement → pass → commit.
+
+## Task 3 — suite runs param tests from config (else skip)
+
+`tools/run-e2e-suite.ts`: add `deps.loadConfig?` (default `loadE2eConfig`). Replace the `locked.params?.length → skippedResult` branch:
+- `resolveParams(config, id, locked.params)`: `!ok` → `skippedResult(id, intent, 'missing param values: '+missing.join(', '))`; `ok` → `maestroRun({ flowPath, platform, params })`, then `classifyFlowResult` on `redactSecrets(output, secretValuesFor(config, params))`.
+
+Tests (extend `run-e2e-suite-core.test.js`): param locked test + config values → runs (assert maestroRun received the params) + classified normally; + missing value → skipped with the reason; secret value redacted in a failing param test's `errorExcerpt`.
+
+- [ ] failing test → fail → implement → pass → commit.
+
+## Task 4 — wiring: gitignore + test-app config + changeset
+
+- `.gitignore`: add `.rn-agent/e2e.config.json` (may hold secrets). Optionally a committed `.rn-agent/e2e.config.example.json`.
+- Create `rn-dev-agent-workspace/test-app/.rn-agent/e2e.config.json` with `login-create-task` params (TITLE/DESC/PRIORITY/TAG; no secrets here).
+- Changeset (`rn-dev-agent-cdp`, minor).
+- Full `npm test` + lint + format:check green; commit.
+
+## Verification
+- Unit tests cover config resolution, redaction, lock-with-config, suite-with-config (the real logic).
+- Live: blocked on this iOS 26.5 sim (#317 WDA a11y) — proven on iOS 18 in the follow-up step (`/lock-e2e login-create-task` then the Regression Run button).
+
+## Known limits
+- Config is local/gitignored (personal e2e values). Secret redaction is value-substring based; param names in `secretParams` are global.

--- a/scripts/cdp-bridge/dist/domain/e2e-config.js
+++ b/scripts/cdp-bridge/dist/domain/e2e-config.js
@@ -18,14 +18,12 @@ export function resolveParams(config, testId, required) {
     const missing = required.filter((k) => !merged[k]);
     if (missing.length > 0)
         return { ok: false, missing };
+    // Return ONLY the params the action declares — never leak unrelated
+    // defaults (which may include secrets) into a test that doesn't use them.
     const params = {};
     for (const k of required)
         params[k] = merged[k];
-    for (const k of Object.keys(merged)) {
-        if (!(k in params))
-            params[k] = merged[k];
-    }
-    return { ok: true, params: merged };
+    return { ok: true, params };
 }
 export function secretValuesFor(config, params) {
     const names = new Set(config.secretParams ?? []);

--- a/scripts/cdp-bridge/dist/domain/e2e-config.js
+++ b/scripts/cdp-bridge/dist/domain/e2e-config.js
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+export function loadE2eConfig(projectRoot) {
+    const filePath = join(projectRoot, '.rn-agent', 'e2e.config.json');
+    try {
+        const raw = readFileSync(filePath, 'utf8');
+        return JSON.parse(raw);
+    }
+    catch {
+        return {};
+    }
+}
+export function resolveParams(config, testId, required) {
+    const merged = {
+        ...config.defaults?.params,
+        ...config.tests?.[testId]?.params,
+    };
+    const missing = required.filter((k) => !merged[k]);
+    if (missing.length > 0)
+        return { ok: false, missing };
+    const params = {};
+    for (const k of required)
+        params[k] = merged[k];
+    for (const k of Object.keys(merged)) {
+        if (!(k in params))
+            params[k] = merged[k];
+    }
+    return { ok: true, params: merged };
+}
+export function secretValuesFor(config, params) {
+    const names = new Set(config.secretParams ?? []);
+    return Object.entries(params)
+        .filter(([k, v]) => names.has(k) && v !== '')
+        .map(([, v]) => v);
+}
+export function redactSecrets(text, secretValues) {
+    const active = secretValues.filter((s) => s !== '');
+    if (active.length === 0)
+        return text;
+    let result = text;
+    for (const secret of active) {
+        result = result.split(secret).join('***');
+    }
+    return result;
+}

--- a/scripts/cdp-bridge/dist/tools/lock-e2e-test.js
+++ b/scripts/cdp-bridge/dist/tools/lock-e2e-test.js
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { loadAction } from '../domain/action-store.js';
 import { freezeLockedTest, loadLockedTest } from '../domain/e2e-test.js';
+import { loadE2eConfig, resolveParams, secretValuesFor, redactSecrets, } from '../domain/e2e-config.js';
 import { getGitInfo as realGetGitInfo } from '../e2e/git-info.js';
 import { getActiveSession } from '../agent-device-wrapper.js';
 import { createMaestroRunHandler } from './maestro-run.js';
@@ -29,18 +30,33 @@ export async function lockE2eTestCore(args, deps = {}) {
     const action = load(projectRoot, args.actionId);
     if (!action)
         return failResult(`Action '${args.actionId}' not found`, 'NOT_FOUND');
+    const loadCfg = deps.loadConfig ?? loadE2eConfig;
+    let resolvedParams;
     if (action.metadata.params?.length) {
-        return failResult(`'${args.actionId}' needs params (${action.metadata.params.join(', ')}). Param-needing tests are not supported in v1 — a params source (.rn-agent/e2e.config.json) lands in a later phase.`, 'PARAMS_UNSUPPORTED');
+        const config = loadCfg(projectRoot);
+        const resolved = resolveParams(config, args.actionId, action.metadata.params);
+        if (!resolved.ok) {
+            return failResult(`missing param values for ${resolved.missing.join(', ')} — add them to .rn-agent/e2e.config.json (tests.${args.actionId}.params or defaults.params)`, 'MISSING_PARAMS');
+        }
+        resolvedParams = resolved.params;
     }
     if (!args.relock && loadLockedTest(projectRoot, args.actionId)) {
         return failResult(`'${args.actionId}' is already locked — pass relock:true to re-lock`, 'ALREADY_LOCKED');
     }
     const session = getSession();
     const platform = session?.platform ?? undefined;
-    const result = await maestroRun({ flowPath: action.filePath, platform });
+    const runArgs = { flowPath: action.filePath, platform };
+    if (resolvedParams)
+        runArgs['params'] = resolvedParams;
+    const result = await maestroRun(runArgs);
     const { passed, output } = readPassed(result);
     if (!passed) {
-        return failResult(`'${args.actionId}' did not pass a strict run — repair it until it passes, then lock`, 'STRICT_RUN_FAILED', { output: output.slice(0, 500) });
+        let failOutput = output.slice(0, 500);
+        if (resolvedParams) {
+            const config = loadCfg(projectRoot);
+            failOutput = redactSecrets(failOutput, secretValuesFor(config, resolvedParams));
+        }
+        return failResult(`'${args.actionId}' did not pass a strict run — repair it until it passes, then lock`, 'STRICT_RUN_FAILED', { output: failOutput });
     }
     const git = getGit(projectRoot);
     const locked = freezeLockedTest(projectRoot, {

--- a/scripts/cdp-bridge/dist/tools/run-e2e-suite.js
+++ b/scripts/cdp-bridge/dist/tools/run-e2e-suite.js
@@ -1,5 +1,6 @@
 import { discoverLockedTests, loadLockedTest } from '../domain/e2e-test.js';
 import { classifyFlowResult, skippedResult, unloadableResult, computeVerdict, diffNewlyFailing, writeRunRecord, loadRunRecord, lastGreenRunId, } from '../domain/e2e-run.js';
+import { loadE2eConfig, resolveParams, secretValuesFor, redactSecrets, } from '../domain/e2e-config.js';
 import { getGitInfo as realGetGitInfo } from '../e2e/git-info.js';
 import { getActiveSession } from '../agent-device-wrapper.js';
 import { createMaestroRunHandler } from './maestro-run.js';
@@ -68,6 +69,8 @@ export async function runE2eSuiteCore(args, deps = {}) {
             metroReloaded = false;
         }
     }
+    const loadCfg = deps.loadConfig ?? loadE2eConfig;
+    const config = loadCfg(projectRoot);
     const results = [];
     for (const id of ids) {
         const locked = load(projectRoot, id);
@@ -77,7 +80,27 @@ export async function runE2eSuiteCore(args, deps = {}) {
             continue;
         }
         if (locked.params?.length) {
-            results.push(skippedResult(id, locked.intent, 'needs params (unsupported in v1)'));
+            const resolved = resolveParams(config, id, locked.params);
+            if (!resolved.ok) {
+                results.push(skippedResult(id, locked.intent, 'missing param values: ' + resolved.missing.join(', ')));
+                deps.onProgress?.(results.length, ids.length, id);
+                continue;
+            }
+            const t0 = now().getTime();
+            const result = await maestroRun({
+                flowPath: locked.filePath,
+                platform: platform,
+                params: resolved.params,
+            });
+            const { passed, output } = readMaestro(result);
+            const safeOutput = redactSecrets(output, secretValuesFor(config, resolved.params));
+            results.push(classifyFlowResult({
+                testId: id,
+                intent: locked.intent,
+                passed,
+                durationMs: now().getTime() - t0,
+                output: safeOutput,
+            }));
             deps.onProgress?.(results.length, ids.length, id);
             continue;
         }

--- a/scripts/cdp-bridge/src/domain/e2e-config.ts
+++ b/scripts/cdp-bridge/src/domain/e2e-config.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface E2eConfig {
+  defaults?: { params?: Record<string, string> };
+  tests?: Record<string, { params?: Record<string, string> }>;
+  secretParams?: string[];
+}
+
+export function loadE2eConfig(projectRoot: string): E2eConfig {
+  const filePath = join(projectRoot, '.rn-agent', 'e2e.config.json');
+  try {
+    const raw = readFileSync(filePath, 'utf8');
+    return JSON.parse(raw) as E2eConfig;
+  } catch {
+    return {};
+  }
+}
+
+export function resolveParams(
+  config: E2eConfig,
+  testId: string,
+  required: string[],
+): { ok: true; params: Record<string, string> } | { ok: false; missing: string[] } {
+  const merged: Record<string, string> = {
+    ...config.defaults?.params,
+    ...config.tests?.[testId]?.params,
+  };
+  const missing = required.filter((k) => !merged[k]);
+  if (missing.length > 0) return { ok: false, missing };
+  const params: Record<string, string> = {};
+  for (const k of required) params[k] = merged[k] as string;
+  for (const k of Object.keys(merged)) {
+    if (!(k in params)) params[k] = merged[k] as string;
+  }
+  return { ok: true, params: merged };
+}
+
+export function secretValuesFor(
+  config: E2eConfig,
+  params: Record<string, string>,
+): string[] {
+  const names = new Set(config.secretParams ?? []);
+  return Object.entries(params)
+    .filter(([k, v]) => names.has(k) && v !== '')
+    .map(([, v]) => v);
+}
+
+export function redactSecrets(text: string, secretValues: string[]): string {
+  const active = secretValues.filter((s) => s !== '');
+  if (active.length === 0) return text;
+  let result = text;
+  for (const secret of active) {
+    result = result.split(secret).join('***');
+  }
+  return result;
+}

--- a/scripts/cdp-bridge/src/domain/e2e-config.ts
+++ b/scripts/cdp-bridge/src/domain/e2e-config.ts
@@ -36,10 +36,7 @@ export function resolveParams(
   return { ok: true, params: merged };
 }
 
-export function secretValuesFor(
-  config: E2eConfig,
-  params: Record<string, string>,
-): string[] {
+export function secretValuesFor(config: E2eConfig, params: Record<string, string>): string[] {
   const names = new Set(config.secretParams ?? []);
   return Object.entries(params)
     .filter(([k, v]) => names.has(k) && v !== '')

--- a/scripts/cdp-bridge/src/domain/e2e-config.ts
+++ b/scripts/cdp-bridge/src/domain/e2e-config.ts
@@ -28,12 +28,11 @@ export function resolveParams(
   };
   const missing = required.filter((k) => !merged[k]);
   if (missing.length > 0) return { ok: false, missing };
+  // Return ONLY the params the action declares — never leak unrelated
+  // defaults (which may include secrets) into a test that doesn't use them.
   const params: Record<string, string> = {};
   for (const k of required) params[k] = merged[k] as string;
-  for (const k of Object.keys(merged)) {
-    if (!(k in params)) params[k] = merged[k] as string;
-  }
-  return { ok: true, params: merged };
+  return { ok: true, params };
 }
 
 export function secretValuesFor(config: E2eConfig, params: Record<string, string>): string[] {

--- a/scripts/cdp-bridge/src/tools/lock-e2e-test.ts
+++ b/scripts/cdp-bridge/src/tools/lock-e2e-test.ts
@@ -1,6 +1,12 @@
 import { readFileSync } from 'node:fs';
 import { loadAction } from '../domain/action-store.js';
 import { freezeLockedTest, loadLockedTest } from '../domain/e2e-test.js';
+import {
+  loadE2eConfig,
+  resolveParams,
+  secretValuesFor,
+  redactSecrets,
+} from '../domain/e2e-config.js';
 import { getGitInfo as realGetGitInfo } from '../e2e/git-info.js';
 import { getActiveSession } from '../agent-device-wrapper.js';
 import { createMaestroRunHandler } from './maestro-run.js';
@@ -8,6 +14,7 @@ import { findProjectRoot } from '../nav-graph/storage.js';
 import { okResult, failResult } from '../utils.js';
 import type { ToolResult } from '../utils.js';
 import type { SessionState } from '../types.js';
+import type { E2eConfig } from '../domain/e2e-config.js';
 
 export interface LockE2eTestArgs {
   actionId: string;
@@ -22,6 +29,7 @@ export interface LockE2eTestDeps {
   getGitInfo?: (projectRoot: string) => { sha: string | null; dirty: boolean };
   getSession?: () => SessionState | null;
   now?: () => Date;
+  loadConfig?: (projectRoot: string) => E2eConfig;
 }
 
 function readPassed(result: ToolResult): { passed: boolean; output: string } {
@@ -56,11 +64,19 @@ export async function lockE2eTestCore(
   const action = load(projectRoot, args.actionId);
   if (!action) return failResult(`Action '${args.actionId}' not found`, 'NOT_FOUND');
 
+  const loadCfg = deps.loadConfig ?? loadE2eConfig;
+
+  let resolvedParams: Record<string, string> | undefined;
   if (action.metadata.params?.length) {
-    return failResult(
-      `'${args.actionId}' needs params (${action.metadata.params.join(', ')}). Param-needing tests are not supported in v1 — a params source (.rn-agent/e2e.config.json) lands in a later phase.`,
-      'PARAMS_UNSUPPORTED',
-    );
+    const config = loadCfg(projectRoot);
+    const resolved = resolveParams(config, args.actionId, action.metadata.params);
+    if (!resolved.ok) {
+      return failResult(
+        `missing param values for ${resolved.missing.join(', ')} — add them to .rn-agent/e2e.config.json (tests.${args.actionId}.params or defaults.params)`,
+        'MISSING_PARAMS',
+      );
+    }
+    resolvedParams = resolved.params;
   }
 
   if (!args.relock && loadLockedTest(projectRoot, args.actionId)) {
@@ -73,13 +89,21 @@ export async function lockE2eTestCore(
   const session = getSession();
   const platform = (session?.platform as 'ios' | 'android' | undefined) ?? undefined;
 
-  const result = await maestroRun({ flowPath: action.filePath, platform });
+  const runArgs: Record<string, unknown> = { flowPath: action.filePath, platform };
+  if (resolvedParams) runArgs['params'] = resolvedParams;
+
+  const result = await maestroRun(runArgs);
   const { passed, output } = readPassed(result);
   if (!passed) {
+    let failOutput = output.slice(0, 500);
+    if (resolvedParams) {
+      const config = loadCfg(projectRoot);
+      failOutput = redactSecrets(failOutput, secretValuesFor(config, resolvedParams));
+    }
     return failResult(
       `'${args.actionId}' did not pass a strict run — repair it until it passes, then lock`,
       'STRICT_RUN_FAILED',
-      { output: output.slice(0, 500) },
+      { output: failOutput },
     );
   }
 

--- a/scripts/cdp-bridge/src/tools/run-e2e-suite.ts
+++ b/scripts/cdp-bridge/src/tools/run-e2e-suite.ts
@@ -11,6 +11,13 @@ import {
 } from '../domain/e2e-run.js';
 import type { E2eFlowResult, E2eRunRecord } from '../domain/e2e-run.js';
 import type { LockedE2eTest } from '../domain/e2e-test.js';
+import {
+  loadE2eConfig,
+  resolveParams,
+  secretValuesFor,
+  redactSecrets,
+} from '../domain/e2e-config.js';
+import type { E2eConfig } from '../domain/e2e-config.js';
 import { getGitInfo as realGetGitInfo } from '../e2e/git-info.js';
 import { getActiveSession } from '../agent-device-wrapper.js';
 import { createMaestroRunHandler } from './maestro-run.js';
@@ -41,6 +48,7 @@ export interface RunE2eSuiteDeps {
   makeRunId?: (now: () => Date, rand: () => string) => string;
   runReload?: () => Promise<boolean>;
   onProgress?: (completed: number, total: number, lastTestId: string) => void;
+  loadConfig?: (projectRoot: string) => E2eConfig;
 }
 
 export function makeRunId(now: () => Date, rand: () => string): string {
@@ -120,6 +128,9 @@ export async function runE2eSuiteCore(
     }
   }
 
+  const loadCfg = deps.loadConfig ?? loadE2eConfig;
+  const config = loadCfg(projectRoot);
+
   const results: E2eFlowResult[] = [];
   for (const id of ids) {
     const locked = load(projectRoot, id);
@@ -134,7 +145,31 @@ export async function runE2eSuiteCore(
       continue;
     }
     if (locked.params?.length) {
-      results.push(skippedResult(id, locked.intent, 'needs params (unsupported in v1)'));
+      const resolved = resolveParams(config, id, locked.params);
+      if (!resolved.ok) {
+        results.push(
+          skippedResult(id, locked.intent, 'missing param values: ' + resolved.missing.join(', ')),
+        );
+        deps.onProgress?.(results.length, ids.length, id);
+        continue;
+      }
+      const t0 = now().getTime();
+      const result = await maestroRun({
+        flowPath: locked.filePath,
+        platform: platform as 'ios' | 'android',
+        params: resolved.params,
+      });
+      const { passed, output } = readMaestro(result);
+      const safeOutput = redactSecrets(output, secretValuesFor(config, resolved.params));
+      results.push(
+        classifyFlowResult({
+          testId: id,
+          intent: locked.intent,
+          passed,
+          durationMs: now().getTime() - t0,
+          output: safeOutput,
+        }),
+      );
       deps.onProgress?.(results.length, ids.length, id);
       continue;
     }

--- a/scripts/cdp-bridge/src/types.ts
+++ b/scripts/cdp-bridge/src/types.ts
@@ -278,6 +278,7 @@ export type ToolErrorCode =
   | 'ALREADY_LOCKED'
   | 'STRICT_RUN_FAILED'
   | 'PARAMS_UNSUPPORTED'
+  | 'MISSING_PARAMS'
   | 'SETUP_ERROR'
   | 'NO_E2E_TESTS'
   | 'E2E_RUN_ACTIVE'

--- a/scripts/cdp-bridge/test/unit/e2e-config.test.js
+++ b/scripts/cdp-bridge/test/unit/e2e-config.test.js
@@ -1,0 +1,151 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  loadE2eConfig,
+  resolveParams,
+  secretValuesFor,
+  redactSecrets,
+} from '../../dist/domain/e2e-config.js';
+
+// ── loadE2eConfig ──────────────────────────────────────────────────────────
+
+test('loadE2eConfig: missing file → {}', () => {
+  const root = mkdtempSync(join(tmpdir(), 'e2ecfg-'));
+  try {
+    assert.deepEqual(loadE2eConfig(root), {});
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('loadE2eConfig: corrupt JSON → {}', () => {
+  const root = mkdtempSync(join(tmpdir(), 'e2ecfg-'));
+  try {
+    const dir = join(root, '.rn-agent');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'e2e.config.json'), '{not valid json', 'utf8');
+    assert.deepEqual(loadE2eConfig(root), {});
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('loadE2eConfig: valid file → parsed config', () => {
+  const root = mkdtempSync(join(tmpdir(), 'e2ecfg-'));
+  try {
+    const dir = join(root, '.rn-agent');
+    mkdirSync(dir, { recursive: true });
+    const cfg = {
+      defaults: { params: { EMAIL: 'test@example.com' } },
+      tests: { login: { params: { TITLE: 'Ship demo' } } },
+      secretParams: ['PASSWORD'],
+    };
+    writeFileSync(join(dir, 'e2e.config.json'), JSON.stringify(cfg), 'utf8');
+    assert.deepEqual(loadE2eConfig(root), cfg);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── resolveParams ──────────────────────────────────────────────────────────
+
+test('resolveParams: no required params → ok with empty', () => {
+  const result = resolveParams({}, 'login', []);
+  assert.equal(result.ok, true);
+  if (result.ok) assert.deepEqual(result.params, {});
+});
+
+test('resolveParams: defaults only cover required → ok', () => {
+  const config = { defaults: { params: { EMAIL: 'a@b.com' } } };
+  const result = resolveParams(config, 'login', ['EMAIL']);
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.params['EMAIL'], 'a@b.com');
+});
+
+test('resolveParams: test-level params override defaults', () => {
+  const config = {
+    defaults: { params: { EMAIL: 'default@b.com', TITLE: 'Default' } },
+    tests: { login: { params: { EMAIL: 'override@b.com' } } },
+  };
+  const result = resolveParams(config, 'login', ['EMAIL', 'TITLE']);
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.params['EMAIL'], 'override@b.com');
+    assert.equal(result.params['TITLE'], 'Default');
+  }
+});
+
+test('resolveParams: absent param → missing', () => {
+  const result = resolveParams({}, 'login', ['EMAIL']);
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.deepEqual(result.missing, ['EMAIL']);
+});
+
+test('resolveParams: empty-string param → missing', () => {
+  const config = { defaults: { params: { EMAIL: '' } } };
+  const result = resolveParams(config, 'login', ['EMAIL']);
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.deepEqual(result.missing, ['EMAIL']);
+});
+
+test('resolveParams: partial coverage → lists all missing', () => {
+  const config = { defaults: { params: { EMAIL: 'a@b.com' } } };
+  const result = resolveParams(config, 'login', ['EMAIL', 'PASSWORD', 'TOKEN']);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.ok(result.missing.includes('PASSWORD'));
+    assert.ok(result.missing.includes('TOKEN'));
+    assert.ok(!result.missing.includes('EMAIL'));
+  }
+});
+
+// ── secretValuesFor ────────────────────────────────────────────────────────
+
+test('secretValuesFor: no secretParams → empty list', () => {
+  const config = {};
+  const params = { EMAIL: 'a@b.com', PASSWORD: 'secret' };
+  assert.deepEqual(secretValuesFor(config, params), []);
+});
+
+test('secretValuesFor: picks only values of secret-named non-empty params', () => {
+  const config = { secretParams: ['PASSWORD', 'TOKEN'] };
+  const params = { EMAIL: 'a@b.com', PASSWORD: 'my-secret', TOKEN: '' };
+  const vals = secretValuesFor(config, params);
+  assert.ok(vals.includes('my-secret'), 'should include PASSWORD value');
+  assert.ok(!vals.includes('a@b.com'), 'should not include EMAIL value');
+  assert.ok(!vals.includes(''), 'should not include empty TOKEN value');
+});
+
+test('secretValuesFor: empty params → empty list', () => {
+  const config = { secretParams: ['PASSWORD'] };
+  assert.deepEqual(secretValuesFor(config, {}), []);
+});
+
+// ── redactSecrets ──────────────────────────────────────────────────────────
+
+test('redactSecrets: no-op on empty secret list', () => {
+  assert.equal(redactSecrets('some output with stuff', []), 'some output with stuff');
+});
+
+test('redactSecrets: replaces all occurrences of each secret', () => {
+  const text = 'password=abc123 and again abc123 end';
+  assert.equal(redactSecrets(text, ['abc123']), 'password=*** and again *** end');
+});
+
+test('redactSecrets: multiple secrets all redacted', () => {
+  const text = 'tok=T1 pass=P2';
+  assert.equal(redactSecrets(text, ['T1', 'P2']), 'tok=*** pass=***');
+});
+
+test('redactSecrets: non-secret text unchanged', () => {
+  const text = 'no secrets here';
+  assert.equal(redactSecrets(text, ['abc123']), 'no secrets here');
+});
+
+test('redactSecrets: guards against empty-string secret value (no infinite loop)', () => {
+  const text = 'hello world';
+  assert.equal(redactSecrets(text, ['', 'world']), 'hello ***');
+});

--- a/scripts/cdp-bridge/test/unit/e2e-config.test.js
+++ b/scripts/cdp-bridge/test/unit/e2e-config.test.js
@@ -78,6 +78,13 @@ test('resolveParams: test-level params override defaults', () => {
   }
 });
 
+test('resolveParams: excludes defaults not in required (no leak of unrelated params)', () => {
+  const config = { defaults: { params: { EMAIL: 'a@b.com', PASSWORD: 'secret' } } };
+  const result = resolveParams(config, 'login', ['EMAIL']);
+  assert.equal(result.ok, true);
+  if (result.ok) assert.deepEqual(result.params, { EMAIL: 'a@b.com' });
+});
+
 test('resolveParams: absent param → missing', () => {
   const result = resolveParams({}, 'login', ['EMAIL']);
   assert.equal(result.ok, false);

--- a/scripts/cdp-bridge/test/unit/lock-e2e-test.test.js
+++ b/scripts/cdp-bridge/test/unit/lock-e2e-test.test.js
@@ -5,6 +5,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { lockE2eTestCore } from '../../dist/tools/lock-e2e-test.js';
 
+function writeConfig(root, cfg) {
+  const dir = join(root, '.rn-agent');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'e2e.config.json'), JSON.stringify(cfg), 'utf8');
+}
+
 function parse(r) {
   return JSON.parse(r.content[0].text);
 }
@@ -88,7 +94,7 @@ test('strict fail → refuses, no file written', async () => {
   }
 });
 
-test('param-needing action → refused PARAMS_UNSUPPORTED (no maestro run)', async () => {
+test('param-needing action + no config → MISSING_PARAMS (no maestro run)', async () => {
   const root = mkdtempSync(join(tmpdir(), 'lock-'));
   try {
     seedAction(root, 'login', 'EMAIL');
@@ -102,8 +108,99 @@ test('param-needing action → refused PARAMS_UNSUPPORTED (no maestro run)', asy
         }),
       ),
     );
-    assert.equal(res.code, 'PARAMS_UNSUPPORTED');
+    assert.equal(res.code, 'MISSING_PARAMS');
+    assert.ok(res.error.includes('EMAIL'), 'error should mention missing param name');
     assert.equal(called, false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('param-needing action + config with values → frozen (maestroRun receives params)', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'lock-'));
+  try {
+    seedAction(root, 'login', 'EMAIL');
+    writeConfig(root, { defaults: { params: { EMAIL: 'test@example.com' } } });
+    let capturedArgs = null;
+    const res = parse(
+      await lockE2eTestCore(
+        { actionId: 'login', projectRoot: root },
+        {
+          ...deps(async (args) => {
+            capturedArgs = args;
+            return okMaestro();
+          }),
+          loadConfig: () => ({ defaults: { params: { EMAIL: 'test@example.com' } } }),
+        },
+      ),
+    );
+    assert.equal(res.ok, true);
+    assert.equal(res.data.locked, true);
+    assert.ok(capturedArgs !== null, 'maestroRun should have been called');
+    assert.deepEqual(capturedArgs.params, { EMAIL: 'test@example.com' });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('param-needing action + config missing value → MISSING_PARAMS listing the name', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'lock-'));
+  try {
+    seedAction(root, 'login', 'EMAIL PASSWORD');
+    let called = false;
+    const res = parse(
+      await lockE2eTestCore(
+        { actionId: 'login', projectRoot: root },
+        {
+          ...deps(async () => {
+            called = true;
+            return okMaestro();
+          }),
+          loadConfig: () => ({ defaults: { params: { EMAIL: 'a@b.com' } } }),
+        },
+      ),
+    );
+    assert.equal(res.code, 'MISSING_PARAMS');
+    assert.ok(res.error.includes('PASSWORD'), 'error should list the missing param');
+    assert.equal(called, false, 'maestroRun must not be called');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('param action + maestro fail with secret value → secret redacted in meta', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'lock-'));
+  try {
+    seedAction(root, 'login', 'PASSWORD');
+    const secretValue = 'hunter2';
+    const res = parse(
+      await lockE2eTestCore(
+        { actionId: 'login', projectRoot: root },
+        {
+          ...deps(async () => ({
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  ok: false,
+                  error: `auth failed: password=${secretValue}`,
+                  meta: { output: `auth failed: password=${secretValue}` },
+                }),
+              },
+            ],
+            isError: true,
+          })),
+          loadConfig: () => ({
+            defaults: { params: { PASSWORD: secretValue } },
+            secretParams: ['PASSWORD'],
+          }),
+        },
+      ),
+    );
+    assert.equal(res.code, 'STRICT_RUN_FAILED');
+    const output = res.meta?.output ?? '';
+    assert.ok(!output.includes(secretValue), 'secret value must not appear in meta.output');
+    assert.ok(output.includes('***'), 'redacted placeholder must appear');
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/cdp-bridge/test/unit/run-e2e-suite-core.test.js
+++ b/scripts/cdp-bridge/test/unit/run-e2e-suite-core.test.js
@@ -6,6 +6,15 @@ import { join } from 'node:path';
 import { runE2eSuiteCore, makeRunId } from '../../dist/tools/run-e2e-suite.js';
 import { loadIndex } from '../../dist/domain/e2e-run.js';
 
+function failEnvWithOutput(out) {
+  return {
+    content: [
+      { type: 'text', text: JSON.stringify({ ok: false, error: out, meta: { output: out } }) },
+    ],
+    isError: true,
+  };
+}
+
 function parse(r) {
   return JSON.parse(r.content[0].text);
 }
@@ -94,24 +103,80 @@ test('selector failure (real maestro string) → red + regression', async () => 
   }
 });
 
-test('param-needing locked test → skipped, not counted as failed', async () => {
+test('param-needing locked test + no config → skipped with missing-param reason', async () => {
   const root = mkdtempSync(join(tmpdir(), 'suite-'));
   try {
     let maestroCalls = 0;
     const load = (_root, id) => lockedFixture(id, id === 'paid' ? ['EMAIL'] : undefined);
-    const deps = baseDeps(
-      ['free', 'paid'],
-      () => {
-        maestroCalls++;
-        return passEnv();
-      },
-      load,
-    );
+    const deps = {
+      ...baseDeps(
+        ['free', 'paid'],
+        () => {
+          maestroCalls++;
+          return passEnv();
+        },
+        load,
+      ),
+      loadConfig: () => ({}),
+    };
     const res = parse(await runE2eSuiteCore({ projectRoot: root }, deps));
     assert.equal(res.data.verdict, 'green');
     assert.equal(res.data.totals.skipped, 1);
-    assert.equal(res.data.results.find((r) => r.testId === 'paid').classification, 'skipped');
+    const paidResult = res.data.results.find((r) => r.testId === 'paid');
+    assert.equal(paidResult.classification, 'skipped');
+    assert.ok(
+      paidResult.infraAnnotation?.includes('EMAIL'),
+      'infraAnnotation should mention missing param',
+    );
     assert.equal(maestroCalls, 1, 'maestroRun called only for free, not for paid');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('param-needing locked test + config values → runs, maestroRun receives params', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'suite-'));
+  try {
+    let capturedArgs = null;
+    const load = (_root, id) => lockedFixture(id, id === 'paid' ? ['EMAIL'] : undefined);
+    const deps = {
+      ...baseDeps(['free', 'paid'], () => passEnv(), load),
+      maestroRun: async (args) => {
+        capturedArgs = args;
+        return passEnv();
+      },
+      loadConfig: () => ({ defaults: { params: { EMAIL: 'test@example.com' } } }),
+    };
+    const res = parse(await runE2eSuiteCore({ projectRoot: root }, deps));
+    assert.equal(res.data.verdict, 'green');
+    assert.equal(res.data.totals.passed, 2);
+    assert.equal(res.data.totals.skipped, 0);
+    assert.ok(capturedArgs !== null, 'maestroRun must have been called for paid');
+    assert.deepEqual(capturedArgs.params, { EMAIL: 'test@example.com' });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('param-needing test + config + maestro fail → secret value redacted in errorExcerpt', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'suite-'));
+  try {
+    const secretValue = 'hunter2';
+    const load = (_root, id) => lockedFixture(id, id === 'secure' ? ['PASSWORD'] : undefined);
+    const deps = {
+      ...baseDeps(['secure'], () => failEnvWithOutput(`auth failed: pass=${secretValue}`), load),
+      loadConfig: () => ({
+        defaults: { params: { PASSWORD: secretValue } },
+        secretParams: ['PASSWORD'],
+      }),
+    };
+    const res = parse(await runE2eSuiteCore({ projectRoot: root }, deps));
+    const secureResult = res.data.results.find((r) => r.testId === 'secure');
+    assert.ok(secureResult, 'secure result should exist');
+    assert.notEqual(secureResult.classification, 'skipped', 'should have run, not skipped');
+    const excerpt = secureResult.errorExcerpt ?? '';
+    assert.ok(!excerpt.includes(secretValue), 'secret must not appear in errorExcerpt');
+    if (excerpt.length > 0) assert.ok(excerpt.includes('***'), 'redacted placeholder must appear');
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Stacked on #343

> Base is `feat/e2e-regression-page` (#343). Stack: engine #342 → page #343 → **this**. Review/merge after the bases.

## What

Removes v1's blanket `PARAMS_UNSUPPORTED` refusal: a local **`.rn-agent/e2e.config.json`** supplies per-test param values, so **parameterized actions can be locked and run as e2e tests**.

- **`domain/e2e-config.ts`** (pure): `loadE2eConfig` (tolerant), `resolveParams` (merge `defaults.params` + `tests[id].params`, test wins; required satisfied only if non-empty; returns **only the declared params** — unrelated defaults/secrets never leak), `secretValuesFor`, `redactSecrets`.
- **`cdp_lock_e2e_test`**: a param-needing action is accepted when the config covers all its params (runs strict with them, freezes), else `MISSING_PARAMS` listing the gaps.
- **`cdp_run_e2e_suite`**: param tests run with resolved values, else skip with a clear reason.
- **Secret redaction**: values of params named in `secretParams` are scrubbed to `***` in failure output and run records.
- Config is **gitignored** (may hold secrets); `.rn-agent/e2e/` locked tests stay tracked.

## Verification

- **2324/2324 unit tests** (config resolution incl. the no-leak case, redaction in both lock + suite, lock-accepts-with-config / `MISSING_PARAMS`, suite-runs-with-config / skip). Lint + format clean.
- A security review of the redaction caught + fixed a latent leak (`resolveParams` returned all merged params incl. unrelated `defaults`); now returns required-only, with a regression test.
- Live tap-based replay remains blocked on iOS 26.5 (#317 WDA a11y) — to be proven on iOS 18.

Plan: `docs/superpowers/plans/2026-06-18-e2e-params-source.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)