### PR TITLE
fix(observe): thread projectRoot into per-action Run (flow now reaches the device)

### DIFF
--- a/.changeset/fix-observe-runaction-projectroot.md
+++ b/.changeset/fix-observe-runaction-projectroot.md
@@ -1,0 +1,5 @@
+---
+"rn-dev-agent-cdp": patch
+---
+
+Fix the observe Regression tab's per-action **Run** button doing nothing. The observe `runAction` wiring resolved the correct project root for `loadAction` but then called the inner `runActionHandler` (`cdp_run_action`) without passing `projectRoot`, so the runner re-derived it from `process.cwd()` (the plugin repo) and failed instantly with `NO_PROJECT_ROOT` before ever reaching the device. The resolved root is now threaded into `runActionHandler`, so a clicked action runs its Maestro flow on the connected app's project. (Follow-up to #348, which fixed the same root-resolution family for the actions list and suite.)

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -1551,6 +1551,7 @@ setObserveE2eDeps({
             const result = await runActionHandler({
                 actionId,
                 params,
+                projectRoot: root,
                 platform: (getActiveSession()?.platform ?? 'ios'),
                 trigger: 'human',
             });

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -2263,6 +2263,7 @@ setObserveE2eDeps({
       const result = await runActionHandler({
         actionId,
         params,
+        projectRoot: root,
         platform: (getActiveSession()?.platform ?? 'ios') as 'ios' | 'android',
         trigger: 'human',
       });


### PR DESCRIPTION
## Summary
Follow-up to #348. The observe Regression tab's per-action **Run** button did nothing — it failed *instantly* with `NO_PROJECT_ROOT` and never drove the simulator.

## Root cause
The observe `runAction` closure (`index.ts`) resolves the correct project root for `loadAction()`, but then called the inner `runActionHandler` (`cdp_run_action`) **without `projectRoot`**. `RunActionArgs.projectRoot` defaults to `process.cwd()` (run-action.ts:227) — the plugin repo — so the runner looked for `…/claude-react-native-dev-plugin/.rn-agent/actions/<id>.yaml`, didn't find it, and bailed before dispatch. #348 fixed this root-resolution family for the **list** and the **suite**, but the per-action Run path re-derived its own root.

## Fix
Thread the already-resolved `root` into the `runActionHandler` call (one line).

## Verification (e2e, on device)
Re-ran `cycle-task-priority` via `POST /api/e2e/actions/run` against the booted iPhone 17:
- **Before:** `NO_PROJECT_ROOT`, <1s, never reached the device.
- **After:** finds the YAML and runs `maestro-runner 1.0.9` on `3C6085C0-…`, reaching WDA/execution (40s).

> Note: on this iOS **26.5** simulator the flow then hits `SELECTOR_NOT_FOUND` — that's the separate, pre-existing **#317** (bridgeless WDA empty accessibility tree), not this change. This PR is verified by the run reaching the device and executing maestro, which it could not do before.

2337/2337 unit tests pass; oxlint + oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)