### PR TITLE
fix(ci): run nested test dirs in CI (#340)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,11 @@ jobs:
         working-directory: scripts/cdp-bridge
 
       - name: Unit tests
-        run: node --test 'test/unit/*.test.js'
+        run: node --test 'test/unit/*.test.js' 'test/unit/**/*.test.js'
         working-directory: scripts/cdp-bridge
 
       - name: Integration tests
-        run: node --test 'test/integration/*.test.js'
+        run: node --test 'test/integration/*.test.js' 'test/integration/**/*.test.js'
         working-directory: scripts/cdp-bridge
 
       # Runs at repo root (no working-directory) — guards the changeset CI gate.


### PR DESCRIPTION
## Summary

CI's `Build & Test` job ran `node --test 'test/unit/*.test.js'` — a **top-level glob only** — while the canonical `npm test` script runs both `test/unit/*.test.js` **and** `test/unit/**/*.test.js`. As a result, six nested test files were **never executed in CI**, so a regression in any of them could reach `main` undetected (a false-green safety net).

Skipped nested files (all under `scripts/cdp-bridge/test/unit/`):
- `runners/external-runner-detect.test.js`
- `runners/rn-android-runner-client.test.js`
- `runners/rn-fast-runner-build-args.test.js`
- `runners/rn-fast-runner-client.test.js`
- `tools/find-orchestration.test.js`
- `tools/scrollintoview-orchestration.test.js`

These cover critical paths — the iOS/Android runner clients, external-runner detection, and find/scrollintoview orchestration.

## Fix

Align the CI **Unit tests** and **Integration tests** globs in `.github/workflows/ci.yml` with `npm test` (surgical change — keeps the separate CI step names and the dedicated build step). The integration glob gets the same nested coverage preemptively (no nested integration files exist yet).

## Verification

Ran both globs locally after a clean build:

| Glob | Tests run |
|------|-----------|
| Old (CI today): `test/unit/*.test.js` | **2341** |
| New (aligned): `+ test/unit/**/*.test.js` | **2363** |

**+22 tests, all passing** — coverage hardening, not a live failure. The aligned count matches the canonical `npm test` total exactly, confirming `node:test` dedupes the resolved file set (no double execution).

## Notes

- CI-only change — no shippable `scripts/cdp-bridge/src/` change, so no changeset required (per `scripts/require-changeset.sh`).
- Refs: workspace BUGS.md B217, DECISIONS D1281.

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)