### PR TITLE
chore(release): bump plugin manifest to ship cdp-bridge work to installs

### DIFF
--- a/.changeset/ship-plugin-manifest-0-56.md
+++ b/.changeset/ship-plugin-manifest-0-56.md
@@ -1,0 +1,11 @@
+---
+"rn-dev-agent-plugin": minor
+---
+
+Bump the plugin manifest so installed users receive the recently-merged cdp-bridge work via `/plugin update`. Until now the changesets flow only versioned the internal `rn-dev-agent-cdp` package, leaving `plugin.json` / `marketplace.json` pinned at 0.55.5 — so the plugin's cache key never moved and updates never reached installs even though the bundled `dist/` had advanced.
+
+This release ships, to installed users:
+- **observe Regression "Run" reaches the device (#351):** the per-action Run resolves the connected app's project root via bundleId instead of falling back to `process.cwd()`, so clicking Run no longer fails with `NO_PROJECT_ROOT`.
+- **iOS 26.x action replay (#353, Phase 2):** when WebDriverAgent reads an empty accessibility tree, `cdp_run_action` falls back to a CDP/JS transport so replays still drive the app.
+- **Durable action store (#359, Phase 1):** run/repair history persists in a derived, gitignored node:sqlite store (dual-write mirror of the JSON sidecars; graceful degradation when node:sqlite is unavailable); `cdp_status` reports the active `actionStore` backend.
+- **CI now runs nested unit test dirs (#340).**


### PR DESCRIPTION
## Why

`/plugin update` keys on the **plugin manifest version** (`.claude-plugin/plugin.json` + `marketplace.json`), but the changesets flow has only ever versioned the internal **`rn-dev-agent-cdp`** package (`scripts/cdp-bridge/package.json`, now 0.49.0). The plugin manifest has stayed pinned at **0.55.5** since before #351 — so the cache key never moved and installed users never refetched, even though the bundled `dist/` advanced. (This is exactly why a live debug session found the installed 0.55.5 plugin running pre-#351 cdp-bridge code.)

## What

Adds a **`rn-dev-agent-plugin` (minor)** changeset so the next Version Packages PR bumps the plugin manifest **0.55.5 → 0.56.0**, making the current `dist/` installable. Delivers to installed users:

- **#351** — observe Regression "Run" resolves the connected app's project root (no more `NO_PROJECT_ROOT`; the run reaches the device).
- **#353** — iOS 26.x CDP/JS action-replay fallback when WebDriverAgent is blind.
- **#359** — durable node:sqlite action store (Phase 1 dual-write mirror, graceful degradation, `cdp_status.actionStore`).
- **#340** — CI runs nested unit test dirs.

`changeset status` confirms: `rn-dev-agent-plugin` → minor (0.56.0); `rn-dev-agent-cdp` unchanged (already at 0.49.0).

## Follow-up (process gap — not in this PR)

cdp-bridge changes ship to users **only** via the plugin manifest, so a `rn-dev-agent-cdp` changeset should be paired with a `rn-dev-agent-plugin` changeset. Recommend hardening `scripts/require-changeset.sh` to require a `rn-dev-agent-plugin` entry whenever `scripts/cdp-bridge/src/` changes — otherwise this recurs.

After merge: the changesets bot opens the canonical `chore(release): version packages` PR bumping the manifest; merging that publishes 0.56.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)