### PR TITLE
fix(ci): require a rn-dev-agent-plugin changeset for cdp-bridge/src changes

### DIFF
--- a/scripts/require-changeset.sh
+++ b/scripts/require-changeset.sh
@@ -53,7 +53,20 @@ fi
 # (the internal package) advances the bundled dist but leaves the manifest pinned,
 # so `/plugin update` never delivers the change to installs (#361/#363 delivery
 # gap). Require a `rn-dev-agent-plugin` entry so the manifest bumps and ships.
-plugin_changeset="$(grep -lE '"rn-dev-agent-plugin"' $changesets 2>/dev/null || true)"
+#
+# Parse ONLY the frontmatter package keys (the lines strictly between the first
+# and second `---`), not the whole file — otherwise a cdp-only changeset whose
+# release-note body merely mentions `"rn-dev-agent-plugin"` would falsely pass
+# (Codex PR #364 P1). Same frontmatter extraction as validate-changeset-names.sh.
+plugin_changeset=""
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  frontmatter="$(awk '$0 ~ /^---[[:space:]]*$/ { d++; next } d==1 { print }' "$file")"
+  if printf '%s\n' "$frontmatter" | grep -Eq '^[[:space:]]*"?rn-dev-agent-plugin"?[[:space:]]*:'; then
+    plugin_changeset="$file"
+    break
+  fi
+done < <(printf '%s\n' "$changesets")
 
 if [ -z "$plugin_changeset" ]; then
   echo "ERROR: this PR changes shippable source but no changeset bumps rn-dev-agent-plugin:" >&2

--- a/scripts/require-changeset.sh
+++ b/scripts/require-changeset.sh
@@ -62,7 +62,7 @@ plugin_changeset=""
 while IFS= read -r file; do
   [ -n "$file" ] || continue
   frontmatter="$(awk '$0 ~ /^---[[:space:]]*$/ { d++; next } d==1 { print }' "$file")"
-  if printf '%s\n' "$frontmatter" | grep -Eq '^[[:space:]]*"?rn-dev-agent-plugin"?[[:space:]]*:'; then
+  if printf '%s\n' "$frontmatter" | grep -Eq "^[[:space:]]*[\"']?rn-dev-agent-plugin[\"']?[[:space:]]*:"; then
     plugin_changeset="$file"
     break
   fi

--- a/scripts/require-changeset.sh
+++ b/scripts/require-changeset.sh
@@ -47,6 +47,35 @@ MSG
   exit 1
 fi
 
-echo "require-changeset: shippable src changed AND a changeset is present — OK."
+# A changeset exists — but cdp-bridge ships to users ONLY via the plugin manifest
+# (plugin.json / marketplace.json), which is versioned by the synthetic
+# `rn-dev-agent-plugin` package. A changeset that bumps only `rn-dev-agent-cdp`
+# (the internal package) advances the bundled dist but leaves the manifest pinned,
+# so `/plugin update` never delivers the change to installs (#361/#363 delivery
+# gap). Require a `rn-dev-agent-plugin` entry so the manifest bumps and ships.
+plugin_changeset="$(grep -lE '"rn-dev-agent-plugin"' $changesets 2>/dev/null || true)"
+
+if [ -z "$plugin_changeset" ]; then
+  echo "ERROR: this PR changes shippable source but no changeset bumps rn-dev-agent-plugin:" >&2
+  printf '%s\n' "$src_changed" | sed 's/^/  /' >&2
+  cat >&2 <<'MSG'
+
+A `rn-dev-agent-cdp`-only changeset bumps the internal package but NOT the plugin
+manifest (plugin.json / marketplace.json) — so the change ships to main but never
+reaches marketplace installs via `/plugin update` (#361/#363 post-mortem: the
+cdp-bridge advanced through 0.48→0.49 while the plugin stayed pinned at 0.55.5).
+
+Fix: add a `rn-dev-agent-plugin` entry to a changeset (typically alongside the
+`rn-dev-agent-cdp` bump), e.g.:
+
+  ---
+  "rn-dev-agent-cdp": patch
+  "rn-dev-agent-plugin": patch
+  ---
+MSG
+  exit 1
+fi
+
+echo "require-changeset: shippable src changed AND a rn-dev-agent-plugin changeset is present — OK."
 printf '%s\n' "$changesets" | sed 's/^/  /'
 exit 0

--- a/scripts/test/require-changeset.test.sh
+++ b/scripts/test/require-changeset.test.sh
@@ -33,12 +33,30 @@ CHANGED_FILES=$'scripts/cdp-bridge/src/domain/maestro-validator.ts' \
   REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
 check "src change without changeset fails" 1 $?
 
-# 2. shippable src changed, changeset present -> passes
+# 2. shippable src changed, but changeset bumps ONLY rn-dev-agent-cdp -> MUST fail.
+# rn-dev-agent-cdp is the internal package; it ships to users only via the plugin
+# manifest, which is bumped by a rn-dev-agent-plugin changeset. A cdp-only bump
+# leaves plugin.json/marketplace.json pinned, so the change never reaches installs
+# (the #361/#363 delivery-gap that this guard now closes).
 printf -- '---\n"rn-dev-agent-cdp": patch\n---\nfix\n' > "$tmp/.changeset/brave-lions.md"
 CHANGED_FILES=$'scripts/cdp-bridge/src/domain/maestro-validator.ts' \
   REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
-check "src change with changeset passes" 0 $?
+check "src change with cdp-only changeset fails (no plugin bump)" 1 $?
 rm -f "$tmp/.changeset/brave-lions.md"
+
+# 2b. shippable src changed, changeset bumps rn-dev-agent-plugin -> passes
+printf -- '---\n"rn-dev-agent-plugin": minor\n---\nship it\n' > "$tmp/.changeset/keen-otters.md"
+CHANGED_FILES=$'scripts/cdp-bridge/src/domain/maestro-validator.ts' \
+  REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "src change with rn-dev-agent-plugin changeset passes" 0 $?
+rm -f "$tmp/.changeset/keen-otters.md"
+
+# 2c. shippable src changed, changeset bumps BOTH cdp + plugin (the ideal) -> passes
+printf -- '---\n"rn-dev-agent-cdp": patch\n"rn-dev-agent-plugin": patch\n---\nfix + ship\n' > "$tmp/.changeset/wise-pandas.md"
+CHANGED_FILES=$'scripts/cdp-bridge/src/domain/maestro-validator.ts' \
+  REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "src change with cdp+plugin changeset passes" 0 $?
+rm -f "$tmp/.changeset/wise-pandas.md"
 
 # 3. only non-shippable changes (tests / docs / CI) -> passes without a changeset
 CHANGED_FILES=$'scripts/cdp-bridge/test/unit/x.test.js\ndocs-site/foo.mdx\n.github/workflows/ci.yml' \

--- a/scripts/test/require-changeset.test.sh
+++ b/scripts/test/require-changeset.test.sh
@@ -58,6 +58,16 @@ CHANGED_FILES=$'scripts/cdp-bridge/src/domain/maestro-validator.ts' \
 check "src change with cdp+plugin changeset passes" 0 $?
 rm -f "$tmp/.changeset/wise-pandas.md"
 
+# 2d. cdp-only FRONTMATTER, but the BODY merely mentions rn-dev-agent-plugin -> MUST fail.
+# The guard must parse frontmatter package keys, not scan the whole file — else a
+# release note that name-drops the plugin would falsely satisfy the manifest-bump
+# requirement (Codex PR #364 P1).
+printf -- '---\n"rn-dev-agent-cdp": patch\n---\nNote: a future change should also add "rn-dev-agent-plugin": patch to ship it.\n' > "$tmp/.changeset/sly-foxes.md"
+CHANGED_FILES=$'scripts/cdp-bridge/src/domain/maestro-validator.ts' \
+  REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "src change with cdp-only changeset mentioning plugin in BODY fails" 1 $?
+rm -f "$tmp/.changeset/sly-foxes.md"
+
 # 3. only non-shippable changes (tests / docs / CI) -> passes without a changeset
 CHANGED_FILES=$'scripts/cdp-bridge/test/unit/x.test.js\ndocs-site/foo.mdx\n.github/workflows/ci.yml' \
   REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1

--- a/scripts/test/require-changeset.test.sh
+++ b/scripts/test/require-changeset.test.sh
@@ -68,6 +68,14 @@ CHANGED_FILES=$'scripts/cdp-bridge/src/domain/maestro-validator.ts' \
 check "src change with cdp-only changeset mentioning plugin in BODY fails" 1 $?
 rm -f "$tmp/.changeset/sly-foxes.md"
 
+# 2e. shippable src changed, plugin key uses valid YAML SINGLE quotes -> passes
+# (Codex PR #364 P2: must accept 'rn-dev-agent-plugin' as well as "rn-dev-agent-plugin").
+printf -- "---\n'rn-dev-agent-plugin': patch\n---\nship\n" > "$tmp/.changeset/glad-bats.md"
+CHANGED_FILES=$'scripts/cdp-bridge/src/domain/maestro-validator.ts' \
+  REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "src change with single-quoted plugin changeset passes" 0 $?
+rm -f "$tmp/.changeset/glad-bats.md"
+
 # 3. only non-shippable changes (tests / docs / CI) -> passes without a changeset
 CHANGED_FILES=$'scripts/cdp-bridge/test/unit/x.test.js\ndocs-site/foo.mdx\n.github/workflows/ci.yml' \
   REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1


### PR DESCRIPTION
## Why

Closes the delivery gap behind #361/#363 **at the source**. cdp-bridge code ships to users only via the **plugin manifest** (`plugin.json`/`marketplace.json`), which is versioned by the synthetic **`rn-dev-agent-plugin`** package. A changeset that bumps only **`rn-dev-agent-cdp`** (the internal package) advances the bundled `dist/` but leaves the manifest pinned — so the change lands on `main` but **never reaches marketplace installs** via `/plugin update`.

That's exactly what happened: cdp-bridge advanced `0.48 → 0.49` (carrying #351/#353/#359) while the plugin sat at `0.55.5`, so installed users ran pre-#351 code until #361/#363 manually bumped the manifest to 0.56.0. Without a guard, the next cdp-bridge-only changeset repeats it.

## What

`scripts/require-changeset.sh`: when `scripts/cdp-bridge/src/` changes, now also require a changeset that bumps **`rn-dev-agent-plugin`** (not just any changeset), with an actionable error showing the `cdp + plugin` changeset shape to add.

Regression test (`scripts/test/require-changeset.test.sh`) updated:
- `src change with cdp-only changeset` → now **fails** (was the gap)
- `src change with rn-dev-agent-plugin changeset` → passes
- `src change with cdp+plugin changeset` → passes
- no-changeset / non-src / empty-diff → unchanged

`ALL PASS` locally (RED→GREEN verified).

## Notes

- Keeps `rn-dev-agent-cdp` and `rn-dev-agent-plugin` on **independent version lines** (no changesets `linked`/`fixed`) — `sync-versions.sh` documents that the two versions legitimately differ; this enforces the *delivery* invariant without fusing the version numbers.
- This PR touches only the guard script + its test (not `cdp-bridge/src`), so it needs no changeset itself (the guard agrees: "changeset not required").

🤖 Generated with [Claude Code](https://claude.com/claude-code)