### PR TITLE
fix(record): guard empty ${adb_args[@]} so device_record stop survives macOS bash 3.2 (#374)

### DIFF
--- a/.changeset/374-record-proof-adb-args-unbound.md
+++ b/.changeset/374-record-proof-adb-args-unbound.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-cdp": patch
+"rn-dev-agent-plugin": patch
+---
+
+fix(record): `device_record stop` no longer crashes on macOS with `adb_args[@]: unbound variable` (#374). In `record_proof.sh` the Android stop branch expanded an empty `adb_args` array unguarded (`"${adb_args[@]}"`); under `set -euo pipefail` on bash 3.2 (the macOS default `/bin/bash`) that is an unbound-variable error, aborting the stop before the pull/convert — so recording finalize (and, via a leftover Android `.pid`, even iOS stops) failed. All three expansions now use the `+`-default guard already present elsewhere in the file. Regression-guarded by a static invariant test (effective on bash 5.x CI) plus a behavioral reproduction gated to bash < 4.4.

--- a/scripts/cdp-bridge/test/unit/gh-374-record-proof-adb-args-unbound.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-374-record-proof-adb-args-unbound.test.js
@@ -1,0 +1,101 @@
+// GH #374: `device_record action=stop` aborted on macOS with
+//   record_proof.sh: line 180: adb_args[@]: unbound variable
+// Root cause: cmd_stop's Android branch declares `local -a adb_args=()` and
+// only fills it when a `.serial` sidecar exists. In the single-device case
+// cmd_start rm's that sidecar, so adb_args stays empty — and under
+// `set -euo pipefail` on bash 3.2 (the macOS default /bin/bash) expanding an
+// empty array as "${adb_args[@]}" is an UNBOUND-VARIABLE error, aborting the
+// stop before the pull/convert. Bash >= 4.4 removed that behavior, which is
+// why ubuntu-latest CI (bash 5.x) never caught it. The same file already used
+// the correct guard `"${saved_paths[@]+"${saved_paths[@]}"}"` at another site.
+//
+// Two-layer regression guard:
+//  1. STATIC invariant (runs everywhere, incl. CI): no unguarded
+//     `adb "${adb_args[@]}"` remains — every expansion uses the `+`-default
+//     guard. This is the CI-effective guard because the runtime crash does not
+//     reproduce on bash >= 4.4.
+//  2. BEHAVIORAL reproduction (only meaningful where empty-array expansion is
+//     an error, i.e. bash < 4.4 / macOS): runs `stop` against an intentionally
+//     UNPATCHED copy (asserts it DOES crash — proving the test detects the bug)
+//     and against the real PATCHED script (asserts it does NOT). Skipped on
+//     bash >= 4.4, where layer 1 carries the guarantee.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'record_proof.sh');
+const GUARDED = '${adb_args[@]+"${adb_args[@]}"}';
+
+// Does THIS bash treat an empty-array expansion under `set -u` as unbound?
+function bashErrorsOnEmptyArray() {
+  const r = spawnSync('bash', ['-uc', 'a=(); printf "%s" "${a[@]}"'], { encoding: 'utf8' });
+  return r.status !== 0 && /unbound variable/i.test(r.stderr || '');
+}
+
+test('static: no unguarded ${adb_args[@]} expansion survives (the #374 invariant)', () => {
+  const src = readFileSync(SCRIPT, 'utf8');
+  assert.doesNotMatch(
+    src,
+    /adb "\$\{adb_args\[@\]\}"/,
+    'record_proof.sh must not expand adb_args unguarded — empty-array + set -u aborts on bash 3.2',
+  );
+  const guardedCount = src.split(GUARDED).length - 1;
+  assert.ok(
+    guardedCount >= 3,
+    `expected the 3 known adb_args expansions to use the +-default guard, found ${guardedCount}`,
+  );
+});
+
+test('behavioral: stop survives a serial-less single-device Android state (repros on bash < 4.4)', (t) => {
+  if (!bashErrorsOnEmptyArray()) {
+    t.skip(
+      'bash >= 4.4: empty-array expansion is not an error here; the static test covers the invariant',
+    );
+    return;
+  }
+
+  const base = mkdtempSync(join(tmpdir(), 'gh374-'));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  // Hermetic copy: rewrite the hardcoded /tmp prefixes so we never touch real
+  // recorder state, and seed a single-device Android stop state with NO .serial
+  // sidecar (the exact shape that leaves adb_args empty).
+  const realSrc = readFileSync(SCRIPT, 'utf8');
+  const pidPrefix = join(base, 'rec');
+  const hermetic = realSrc
+    .replace('PID_PREFIX="/tmp/rn-dev-agent-record"', `PID_PREFIX="${pidPrefix}"`)
+    .replace('RAW_PREFIX="/tmp/rn-dev-agent-raw"', `RAW_PREFIX="${join(base, 'raw')}"`);
+
+  const seedState = () => {
+    writeFileSync(`${pidPrefix}-android.pid`, '999999'); // dead pid → no wait loop
+    writeFileSync(`${pidPrefix}-android.path`, join(base, 'out.mp4'));
+    writeFileSync(`${pidPrefix}-android.device-path`, '/sdcard/gh374-nonexistent.mp4');
+    // deliberately NO `${pidPrefix}-android.serial`
+  };
+  const runStop = (scriptText) => {
+    const p = join(base, 'record_proof.sh');
+    writeFileSync(p, scriptText);
+    seedState();
+    const r = spawnSync('bash', [p, 'stop'], { encoding: 'utf8' });
+    return `${r.stdout || ''}\n${r.stderr || ''}`;
+  };
+
+  // RED: reverting the guard reintroduces the crash — proves the test detects it.
+  const unpatched = hermetic.replaceAll(GUARDED, '${adb_args[@]}');
+  assert.match(
+    runStop(unpatched),
+    /adb_args\[@\]: unbound variable/,
+    'sanity: the unguarded form must still crash, or this test proves nothing',
+  );
+
+  // GREEN: the real (patched) script must not crash on the same state.
+  assert.doesNotMatch(
+    runStop(hermetic),
+    /unbound variable/,
+    'patched record_proof.sh must survive a serial-less single-device Android stop',
+  );
+});

--- a/scripts/record_proof.sh
+++ b/scripts/record_proof.sh
@@ -177,14 +177,14 @@ cmd_stop() {
         adb_args+=(-s "$(cat "$serialf")")
       fi
       # Ensure remote screenrecord is stopped (local SIGINT may not propagate)
-      adb "${adb_args[@]}" shell pkill -2 screenrecord 2>/dev/null || true
+      adb "${adb_args[@]+"${adb_args[@]}"}" shell pkill -2 screenrecord 2>/dev/null || true
       local device_pathf="${PID_PREFIX}-${platform}.device-path"
       if [[ -f "$device_pathf" ]]; then
         local device_path
         device_path="$(cat "$device_pathf")"
         sleep 2
-        adb "${adb_args[@]}" pull "$device_path" "$raw_file" >/dev/null 2>&1 || echo "Warning: Failed to pull recording from device" >&2
-        adb "${adb_args[@]}" shell rm -f "$device_path" 2>/dev/null || true
+        adb "${adb_args[@]+"${adb_args[@]}"}" pull "$device_path" "$raw_file" >/dev/null 2>&1 || echo "Warning: Failed to pull recording from device" >&2
+        adb "${adb_args[@]+"${adb_args[@]}"}" shell rm -f "$device_path" 2>/dev/null || true
         rm -f "$device_pathf"
       fi
       rm -f "$serialf"


### PR DESCRIPTION
Fixes #374.

## What
`device_record action=stop` aborted on macOS with:
```
record_proof.sh: line 180: adb_args[@]: unbound variable
```
`cmd_stop`'s Android branch declares `local -a adb_args=()` and only fills it when a `.serial` sidecar exists. In the **single-device** case `cmd_start` `rm`'s that sidecar, so `adb_args` stays empty — and under `set -euo pipefail` on **bash 3.2 (the macOS default `/bin/bash`)** expanding an empty array as `"${adb_args[@]}"` is an unbound-variable error, aborting the stop before the pull/convert. Because `cmd_stop` loops over **all** `${PID_PREFIX}-*.pid` sidecars, a leftover Android `.pid` made even **iOS** stops crash.

Bash ≥ 4.4 removed that behavior, so it never reproduced on `ubuntu-latest` CI — which is why the full unit suite never caught it.

## Fix
Apply the `+`-default guard **already used in the same file** (`saved_paths` at what was line 249) to the three `adb_args` expansions:
```bash
adb "${adb_args[@]+"${adb_args[@]}"}" …
```
`+3 −3` in `scripts/record_proof.sh`.

## Tests (`gh-374-record-proof-adb-args-unbound.test.js`)
Two layers, because the runtime crash is bash-version-specific:
1. **Static invariant** (CI-effective on bash 5.x): asserts no unguarded `adb "${adb_args[@]}"` remains and the 3 guarded forms are present. Verified it flips to **fail** when the guard is reverted.
2. **Behavioral reproduction** (gated to bash < 4.4 / macOS): seeds a serial-less single-device Android stop state in a hermetic temp prefix, asserts an intentionally-unpatched copy **does** crash (proving the test detects the bug) and the real patched script **does not**.

- Full suite: **2539 passing** (added 2).
- `oxlint` + `oxfmt --check`: clean.

## Device-verified
Found while device-verifying #282 on a live Android emulator + iOS sim. After the fix, Android `stop` finalized a 38 s MP4 where it crashed twice before; iOS unaffected. (The #282 investigation separately confirmed #282 was already mitigated — closed as such.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)