### PR TITLE
feat(observe): autostart the observe web UI + lifecycle controls (restart, config opt-out, stable port)

### DIFF
--- a/.changeset/observe-autostart-lifecycle.md
+++ b/.changeset/observe-autostart-lifecycle.md
@@ -1,0 +1,11 @@
+---
+"rn-dev-agent-cdp": minor
+"rn-dev-agent-plugin": minor
+---
+
+The observe web UI now autostarts when the MCP worker boots in an RN project, listening on a
+stable default port (7333, `http://127.0.0.1:7333`) with an ephemeral fallback on collision.
+New `.rn-agent/config.json` block `{ "observe": { "autoStart": boolean, "port": number } }`
+plus `RN_AGENT_OBSERVE_AUTOSTART` env override (precedence env > config > default, matching
+`cdp.autoConnect`). The `observe` tool gains a `restart` action; `stop` is session-scoped.
+The live URL is recorded in a per-project state file and announced at SessionStart.

--- a/commands/observe.md
+++ b/commands/observe.md
@@ -1,18 +1,21 @@
 ---
 command: observe
 description: Show the observability web UI URL (it autostarts with the session); stop or restart it.
+argument-hint: [stop|restart]
 ---
 
 The observe web UI autostarts when the session begins in an RN project. Permanent opt-out:
 `.rn-agent/config.json` → `{ "observe": { "autoStart": false } }` (port via `observe.port`,
 default 7333; env `RN_AGENT_OBSERVE_AUTOSTART` / `RN_AGENT_OBSERVE_PORT` override config).
 
-- Default (`/observe` with no argument): call the `observe` MCP tool with `action: "status"`.
-  If running, print the returned `url` prominently and tell the user to open it in a browser
-  to watch the live tool-call timeline, device screenshot, and app state. If NOT running
-  (autostart disabled or previously stopped), call `action: "start"` — an explicit /observe
-  is an explicit request to see the UI — and print the URL.
-- `/observe stop`: call with `action: "stop"`. The UI stays down for the rest of the session;
-  mention the config opt-out if the user wants it permanent.
-- `/observe restart`: call with `action: "restart"` and print the (possibly new) URL. The
-  event timeline is preserved across restarts.
+The user's argument: "$ARGUMENTS"
+
+- If the argument is empty: call the `observe` MCP tool with `action: "status"`. If running,
+  print the returned `url` prominently and tell the user to open it in a browser to watch the
+  live tool-call timeline, device screenshot, and app state. If NOT running (autostart disabled
+  or previously stopped), call `action: "start"` — an explicit /observe is an explicit request
+  to see the UI — and print the URL.
+- If the argument is `stop`: call with `action: "stop"`. The UI stays down for the rest of the
+  session; mention the config opt-out if the user wants it permanent.
+- If the argument is `restart`: call with `action: "restart"` and print the (possibly new) URL.
+  The event timeline is preserved across restarts.

--- a/commands/observe.md
+++ b/commands/observe.md
@@ -1,6 +1,18 @@
 ---
 command: observe
-description: Start the read-only observability web UI and print the URL to watch the agent live.
+description: Show the observability web UI URL (it autostarts with the session); stop or restart it.
 ---
 
-Call the `observe` MCP tool with `action: "start"`. Print the returned `url` prominently and tell the user to open it in a browser to watch the live tool-call timeline, device screenshot, and app state. If it's already running, `observe status` returns the existing URL; to stop, call `observe` with `action: "stop"`.
+The observe web UI autostarts when the session begins in an RN project. Permanent opt-out:
+`.rn-agent/config.json` → `{ "observe": { "autoStart": false } }` (port via `observe.port`,
+default 7333; env `RN_AGENT_OBSERVE_AUTOSTART` / `RN_AGENT_OBSERVE_PORT` override config).
+
+- Default (`/observe` with no argument): call the `observe` MCP tool with `action: "status"`.
+  If running, print the returned `url` prominently and tell the user to open it in a browser
+  to watch the live tool-call timeline, device screenshot, and app state. If NOT running
+  (autostart disabled or previously stopped), call `action: "start"` — an explicit /observe
+  is an explicit request to see the UI — and print the URL.
+- `/observe stop`: call with `action: "stop"`. The UI stays down for the rest of the session;
+  mention the config opt-out if the user wants it permanent.
+- `/observe restart`: call with `action: "restart"` and print the (possibly new) URL. The
+  event timeline is preserved across restarts.

--- a/docs/superpowers/plans/2026-07-02-observe-autostart-lifecycle.md
+++ b/docs/superpowers/plans/2026-07-02-observe-autostart-lifecycle.md
@@ -1,0 +1,929 @@
+# Observe Autostart + Lifecycle Implementation Plan (PR 1 of 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The observability web UI autostarts when the MCP worker boots in an RN project, on a stable default port (7333), with `.rn-agent/config.json` opt-out, env overrides, a new `restart` action, and a per-project state file recording the live URL.
+
+**Architecture:** All logic lives in `scripts/cdp-bridge`. New config resolvers in `project-config.ts` follow the existing `resolveAutoConnect` precedence pattern (env > config > default). The observe tool keeps its module-global server; a small DI-testable `autostartObserve()` is called from `index.ts` `main()`. The supervisor process stays socket-free (documented invariant) — only the worker listens.
+
+**Tech Stack:** TypeScript (ESM, `tsc` build), `node:test` + `node:assert/strict` tests running against compiled `dist/` output, changesets for versioning.
+
+**Source spec:** `docs/superpowers/specs/2026-07-02-observe-ui-autostart-design.md`
+
+## Global Constraints
+
+- Node >= 22; no new runtime dependencies.
+- Tests are `node:test` files in `scripts/cdp-bridge/test/unit/*.test.js`, importing from `../../dist/...` (compiled output). `npm test` runs `tsc` first.
+- All commands below run from `scripts/cdp-bridge/` unless stated otherwise.
+- Default observe port: **7333**. Env vars: `RN_AGENT_OBSERVE_AUTOSTART` (autostart on/off), `RN_AGENT_OBSERVE_PORT` (port pin, already exists).
+- Config file: `.rn-agent/config.json` → `{ "observe": { "autoStart": boolean, "port": number } }`.
+- Autostart failure must NEVER break MCP boot (warn once, continue).
+- Do not touch `src/supervisor.ts` — it must keep zero network sockets.
+- In tool-level tests, always pin a unique `RN_AGENT_OBSERVE_PORT` per test file (or unset it and accept any port) — never assert on the literal default 7333 in a test that binds a socket, because parallel test files could collide and trigger the ephemeral fallback.
+- Repo-root gates before finishing: `npx oxlint` and `npx oxfmt --check` (root `package.json` has `lint`/`format:check` scripts).
+
+---
+
+### Task 1: Config resolvers in `project-config.ts`
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/project-config.ts` (append after `resolveAutoConnect`, line 140)
+- Test: `scripts/cdp-bridge/test/unit/observe-config.test.js` (create)
+
+**Interfaces:**
+- Consumes: existing `readRnAgentConfig`, `RnAgentConfig` from `project-config.ts`.
+- Produces (used by Tasks 2 and 4):
+  - `parsePort(raw: string | undefined): number | undefined`
+  - `DEFAULT_OBSERVE_PORT = 7333`
+  - `resolveObserveAutostart(deps?: { env?: string; readConfig?: () => RnAgentConfig | null }): { enabled: boolean; source: 'env' | 'config' | 'default' }`
+  - `resolveObservePort(deps?: { env?: string; readConfig?: () => RnAgentConfig | null }): { port: number; source: 'env' | 'config' | 'default' }`
+  - `RnAgentConfig` gains `observe?: { autoStart?: boolean; port?: number }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/cdp-bridge/test/unit/observe-config.test.js`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parsePort,
+  DEFAULT_OBSERVE_PORT,
+  resolveObserveAutostart,
+  resolveObservePort,
+} from '../../dist/project-config.js';
+
+// Spec 2026-07-02-observe-ui-autostart-design: precedence is
+// env > .rn-agent/config.json observe block > default. Config errors fail open.
+
+test('parsePort accepts a valid port and rejects junk / NaN / out-of-range', () => {
+  assert.equal(parsePort('51234'), 51234);
+  assert.equal(parsePort(undefined), undefined);
+  assert.equal(parsePort(''), undefined);
+  assert.equal(parsePort('abc'), undefined);
+  assert.equal(parsePort('0'), undefined);
+  assert.equal(parsePort('70000'), undefined, 'out of range');
+});
+
+test('resolveObserveAutostart: env "0"/"false" wins over config true', () => {
+  const readConfig = () => ({ observe: { autoStart: true } });
+  assert.deepEqual(resolveObserveAutostart({ env: '0', readConfig }), {
+    enabled: false,
+    source: 'env',
+  });
+  assert.deepEqual(resolveObserveAutostart({ env: 'false', readConfig }), {
+    enabled: false,
+    source: 'env',
+  });
+});
+
+test('resolveObserveAutostart: env "1"/"true" forces on over config false', () => {
+  const readConfig = () => ({ observe: { autoStart: false } });
+  assert.deepEqual(resolveObserveAutostart({ env: '1', readConfig }), {
+    enabled: true,
+    source: 'env',
+  });
+  assert.deepEqual(resolveObserveAutostart({ env: 'true', readConfig }), {
+    enabled: true,
+    source: 'env',
+  });
+});
+
+test('resolveObserveAutostart: unset env falls through to config', () => {
+  const r = resolveObserveAutostart({
+    env: undefined,
+    readConfig: () => ({ observe: { autoStart: false } }),
+  });
+  assert.deepEqual(r, { enabled: false, source: 'config' });
+});
+
+test('resolveObserveAutostart: no config / non-boolean value → default true', () => {
+  assert.deepEqual(resolveObserveAutostart({ env: undefined, readConfig: () => null }), {
+    enabled: true,
+    source: 'default',
+  });
+  assert.deepEqual(
+    resolveObserveAutostart({
+      env: undefined,
+      readConfig: () => ({ observe: { autoStart: 'nope' } }),
+    }),
+    { enabled: true, source: 'default' },
+  );
+});
+
+test('resolveObservePort: valid env wins over config', () => {
+  const r = resolveObservePort({
+    env: '51888',
+    readConfig: () => ({ observe: { port: 51999 } }),
+  });
+  assert.deepEqual(r, { port: 51888, source: 'env' });
+});
+
+test('resolveObservePort: invalid env falls through to config', () => {
+  const r = resolveObservePort({
+    env: 'abc',
+    readConfig: () => ({ observe: { port: 51999 } }),
+  });
+  assert.deepEqual(r, { port: 51999, source: 'config' });
+});
+
+test('resolveObservePort: invalid config port falls through to default', () => {
+  assert.deepEqual(
+    resolveObservePort({ env: undefined, readConfig: () => ({ observe: { port: 0 } }) }),
+    { port: DEFAULT_OBSERVE_PORT, source: 'default' },
+  );
+  assert.deepEqual(
+    resolveObservePort({ env: undefined, readConfig: () => ({ observe: { port: 99999 } }) }),
+    { port: DEFAULT_OBSERVE_PORT, source: 'default' },
+  );
+  assert.deepEqual(
+    resolveObservePort({ env: undefined, readConfig: () => ({ observe: { port: 7.5 } }) }),
+    { port: DEFAULT_OBSERVE_PORT, source: 'default' },
+  );
+});
+
+test('resolveObservePort: no env, no config → default 7333', () => {
+  assert.deepEqual(resolveObservePort({ env: undefined, readConfig: () => null }), {
+    port: 7333,
+    source: 'default',
+  });
+  assert.equal(DEFAULT_OBSERVE_PORT, 7333);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run build && node --test test/unit/observe-config.test.js`
+Expected: FAIL — `parsePort`, `DEFAULT_OBSERVE_PORT`, `resolveObserveAutostart`, `resolveObservePort` are not exported from `dist/project-config.js` (SyntaxError on the named import).
+
+- [ ] **Step 3: Write the implementation**
+
+In `scripts/cdp-bridge/src/project-config.ts`:
+
+(a) Extend the existing `RnAgentConfig` interface (currently `{ cdp?: { autoConnect?: boolean } }`):
+
+```ts
+export interface RnAgentConfig {
+  cdp?: { autoConnect?: boolean };
+  observe?: { autoStart?: boolean; port?: number };
+}
+```
+
+(b) Append at the end of the file:
+
+```ts
+/**
+ * Spec 2026-07-02 (observe autostart): shared port validation. Also re-exported
+ * from tools/observe.ts as `parsePinnedPort` for backward compatibility.
+ */
+export function parsePort(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const n = Number.parseInt(raw, 10);
+  return Number.isInteger(n) && n > 0 && n <= 65535 ? n : undefined;
+}
+
+export const DEFAULT_OBSERVE_PORT = 7333;
+
+export interface ObserveAutostartResolution {
+  enabled: boolean;
+  source: 'env' | 'config' | 'default';
+}
+
+export function resolveObserveAutostart(
+  deps: {
+    env?: string;
+    readConfig?: () => RnAgentConfig | null;
+  } = {},
+): ObserveAutostartResolution {
+  // Present-but-undefined `env` means "treat as unset, do NOT fall back to
+  // process.env" (test seam) — same contract as resolveAutoConnect.
+  const envRaw = 'env' in deps ? deps.env : process.env.RN_AGENT_OBSERVE_AUTOSTART;
+  if (envRaw === '0' || envRaw === 'false') return { enabled: false, source: 'env' };
+  if (envRaw === '1' || envRaw === 'true') return { enabled: true, source: 'env' };
+  const cfg = (deps.readConfig ?? readRnAgentConfig)();
+  if (typeof cfg?.observe?.autoStart === 'boolean') {
+    return { enabled: cfg.observe.autoStart, source: 'config' };
+  }
+  return { enabled: true, source: 'default' };
+}
+
+export interface ObservePortResolution {
+  port: number;
+  source: 'env' | 'config' | 'default';
+}
+
+export function resolveObservePort(
+  deps: {
+    env?: string;
+    readConfig?: () => RnAgentConfig | null;
+  } = {},
+): ObservePortResolution {
+  const envRaw = 'env' in deps ? deps.env : process.env.RN_AGENT_OBSERVE_PORT;
+  const envPort = parsePort(envRaw);
+  if (envPort !== undefined) return { port: envPort, source: 'env' };
+  const cfg = (deps.readConfig ?? readRnAgentConfig)();
+  const cfgPort = cfg?.observe?.port;
+  if (typeof cfgPort === 'number' && Number.isInteger(cfgPort) && cfgPort > 0 && cfgPort <= 65535) {
+    return { port: cfgPort, source: 'config' };
+  }
+  return { port: DEFAULT_OBSERVE_PORT, source: 'default' };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run build && node --test test/unit/observe-config.test.js`
+Expected: PASS (all 8 tests).
+
+- [ ] **Step 5: Run the full unit suite to check for regressions**
+
+Run: `npm test`
+Expected: PASS — in particular `auto-connect-config.test.js` and `project-config.test.js` still green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/project-config.ts test/unit/observe-config.test.js
+git commit -m "feat(observe): config resolvers for autostart + port (env > .rn-agent/config.json > default 7333)"
+```
+
+---
+
+### Task 2: `restart` action + resolved port in the observe tool
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/tools/observe.ts` (full file replacement below)
+- Test: `scripts/cdp-bridge/test/unit/observe-restart-action.test.js` (create)
+
+**Interfaces:**
+- Consumes: `resolveObservePort`, `parsePort` from Task 1; existing `ObservabilityServer`, `recorder`.
+- Produces (used by Tasks 3 and 4):
+  - `observeSchema.action` now `enum(['start', 'stop', 'restart', 'status'])`
+  - `startObserveServer(): Promise<{ url: string; port: number }>` (exported — autostart entry point)
+  - `parsePinnedPort` re-exported (existing test `observability-observe-tool.test.js` imports it)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/cdp-bridge/test/unit/observe-restart-action.test.js`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { observeHandler, startObserveServer } from '../../dist/tools/observe.js';
+import { recorder } from '../../dist/observability/recorder.js';
+
+// Pin a unique port for this file so parallel test files can't collide on the
+// default 7333 (which would flake via the EADDRINUSE ephemeral fallback).
+process.env.RN_AGENT_OBSERVE_PORT = '51733';
+
+function parse(res) {
+  return JSON.parse(res.content[0].text);
+}
+
+test('restart on a running server keeps the recorder timeline and serves again', async () => {
+  recorder.record({ tool: 'device_press', params: { testID: 'x' }, status: 'PASS', latencyMs: 5 });
+  const before = recorder.snapshot().length;
+  assert.ok(before >= 1, 'recorder has at least the seeded event');
+
+  const start = parse(await observeHandler({ action: 'start' }));
+  assert.equal(start.ok, true);
+  assert.equal(start.data.port, 51733);
+
+  const restart = parse(await observeHandler({ action: 'restart' }));
+  assert.equal(restart.ok, true);
+  assert.equal(restart.data.running, true);
+  assert.match(restart.data.url, /^http:\/\/127\.0\.0\.1:\d+$/);
+
+  // The module-global recorder survives the HTTP server restart.
+  assert.equal(recorder.snapshot().length, before);
+
+  // The restarted server actually serves.
+  const status = parse(await observeHandler({ action: 'status' }));
+  assert.equal(status.data.running, true);
+
+  await observeHandler({ action: 'stop' });
+});
+
+test('restart when nothing is running starts fresh', async () => {
+  const restart = parse(await observeHandler({ action: 'restart' }));
+  assert.equal(restart.ok, true);
+  assert.equal(restart.data.running, true);
+  await observeHandler({ action: 'stop' });
+});
+
+test('startObserveServer is idempotent and returns the same port', async () => {
+  const a = await startObserveServer();
+  const b = await startObserveServer();
+  assert.equal(a.port, b.port);
+  await observeHandler({ action: 'stop' });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run build && node --test test/unit/observe-restart-action.test.js`
+Expected: FAIL — `startObserveServer` is not exported / `restart` is rejected by the zod enum.
+
+- [ ] **Step 3: Replace `src/tools/observe.ts` with**
+
+```ts
+import { z } from 'zod';
+import { okResult, failResult } from '../utils.js';
+import type { ToolResult } from '../utils.js';
+import { ObservabilityServer } from '../observability/server.js';
+import type { E2eServerDeps } from '../observability/server.js';
+import { recorder } from '../observability/recorder.js';
+import { resolveObservePort } from '../project-config.js';
+
+// Back-compat alias: parsePinnedPort predates the shared resolver (spec
+// 2026-07-02); the validation now lives in project-config.parsePort.
+export { parsePort as parsePinnedPort } from '../project-config.js';
+
+export const observeSchema = {
+  action: z
+    .enum(['start', 'stop', 'restart', 'status'])
+    .default('status')
+    .describe(
+      'start = launch the web UI and return its URL; stop = tear it down for the rest of the session; restart = stop then start fresh (keeps the event timeline); status = report whether it is running',
+    ),
+};
+
+export interface ObserveArgs {
+  action?: 'start' | 'stop' | 'restart' | 'status';
+}
+
+let server: ObservabilityServer | null = null;
+let e2eDeps: E2eServerDeps | undefined;
+
+export function setObserveE2eDeps(d: E2eServerDeps): void {
+  e2eDeps = d;
+}
+
+/**
+ * Start (or return) the module-global observability server on the resolved
+ * port (env RN_AGENT_OBSERVE_PORT > .rn-agent/config.json observe.port > 7333).
+ * Exported as the autostart entry point so `observe status/stop` sees the
+ * autostarted instance.
+ */
+export async function startObserveServer(): Promise<{ url: string; port: number }> {
+  if (!server) server = new ObservabilityServer(recorder, e2eDeps);
+  const { port } = resolveObservePort();
+  return server.start(port);
+}
+
+async function stopObserveServer(): Promise<void> {
+  await server?.stop();
+  server = null;
+}
+
+export async function observeHandler(args: ObserveArgs): Promise<ToolResult> {
+  const action = args.action ?? 'status';
+  try {
+    if (action === 'start' || action === 'restart') {
+      if (action === 'restart') await stopObserveServer();
+      const { url, port } = await startObserveServer();
+      return okResult({ url, port, running: true, hint: `Open ${url} to watch the agent live.` });
+    }
+    if (action === 'stop') {
+      await stopObserveServer();
+      return okResult({ running: false });
+    }
+    if (server) {
+      const { url, port } = await server.start();
+      return okResult({ running: true, url, port });
+    }
+    return okResult({ running: false });
+  } catch (e) {
+    return failResult(e instanceof Error ? e.message : String(e));
+  }
+}
+```
+
+Note what changed vs. the old file: `parsePinnedPort` became a re-export; the schema gained `restart`; `start` logic moved into exported `startObserveServer()` and now resolves the port from config (not just env); `restart` = stop + start.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run build && node --test test/unit/observe-restart-action.test.js`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run the existing observe-tool test for regressions**
+
+Run: `node --test test/unit/observability-observe-tool.test.js`
+Expected: PASS — `parsePinnedPort` re-export keeps its contract; start/status/stop behavior unchanged. (No rebuild needed — Step 4 built.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tools/observe.ts test/unit/observe-restart-action.test.js
+git commit -m "feat(observe): restart action + config-resolved port in observe tool"
+```
+
+---
+
+### Task 3: Per-project state file (`observe-state.ts`)
+
+**Files:**
+- Create: `scripts/cdp-bridge/src/observability/observe-state.ts`
+- Modify: `scripts/cdp-bridge/src/tools/observe.ts` (wire write/remove into start/stop)
+- Test: `scripts/cdp-bridge/test/unit/observe-state-file.test.js` (create)
+
+**Interfaces:**
+- Consumes: `getStateDir`, `writeJsonStateFileAtomic`, `readJsonStateFile`, `deleteStateFile` from `src/util/secure-state-file.ts`; `findProjectRoot` from `src/nav-graph/storage.ts`.
+- Produces (used by Task 4's exit hook):
+  - `observeStatePath(projectRoot: string): string`
+  - `writeObserveState(url: string, port: number, projectRoot?: string | null, now?: () => Date): void`
+  - `removeObserveState(projectRoot?: string | null): void`
+  - `interface ObserveState { url: string; port: number; pid: number; projectRoot: string; startedAt: string }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/cdp-bridge/test/unit/observe-state-file.test.js`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Redirect the state dir BEFORE importing the module under test —
+// getStateDir() reads XDG_STATE_HOME at call time, but keeping the env set
+// for the whole file is the simplest correct setup.
+const stateHome = mkdtempSync(join(tmpdir(), 'rn-observe-state-'));
+process.env.XDG_STATE_HOME = stateHome;
+
+const { observeStatePath, writeObserveState, removeObserveState } = await import(
+  '../../dist/observability/observe-state.js'
+);
+
+const fakeRoot = '/Users/someone/projects/my app';
+
+test('writeObserveState writes an atomic per-project state file', () => {
+  writeObserveState('http://127.0.0.1:7333', 7333, fakeRoot, () => new Date('2026-07-02T10:00:00Z'));
+  const p = observeStatePath(fakeRoot);
+  assert.ok(p.startsWith(join(stateHome, 'rn-dev-agent', 'observe')), p);
+  assert.ok(existsSync(p));
+  const state = JSON.parse(readFileSync(p, 'utf8'));
+  assert.deepEqual(state, {
+    url: 'http://127.0.0.1:7333',
+    port: 7333,
+    pid: process.pid,
+    projectRoot: fakeRoot,
+    startedAt: '2026-07-02T10:00:00.000Z',
+  });
+});
+
+test('project roots with unsafe characters are sanitized in the filename', () => {
+  const p = observeStatePath('/a/b?c:d e');
+  const base = p.split('/').pop();
+  assert.match(base, /^[A-Za-z0-9._-]+\.json$/);
+});
+
+test('removeObserveState deletes only a file owned by this pid', () => {
+  const p = observeStatePath(fakeRoot);
+  // Owned by us (written in the first test) → deleted.
+  removeObserveState(fakeRoot);
+  assert.ok(!existsSync(p));
+
+  // Owned by another live session → left alone.
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(
+    p,
+    JSON.stringify({ url: 'x', port: 1, pid: process.pid + 1, projectRoot: fakeRoot, startedAt: 'x' }),
+  );
+  removeObserveState(fakeRoot);
+  assert.ok(existsSync(p), 'foreign-pid state file must not be deleted');
+});
+
+test('null project root is a silent no-op', () => {
+  writeObserveState('http://127.0.0.1:7333', 7333, null);
+  removeObserveState(null);
+});
+
+test('cleanup', () => {
+  rmSync(stateHome, { recursive: true, force: true });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run build && node --test test/unit/observe-state-file.test.js`
+Expected: FAIL — `dist/observability/observe-state.js` does not exist (ERR_MODULE_NOT_FOUND).
+
+- [ ] **Step 3: Create `src/observability/observe-state.ts`**
+
+```ts
+import { join } from 'node:path';
+import {
+  getStateDir,
+  writeJsonStateFileAtomic,
+  readJsonStateFile,
+  deleteStateFile,
+} from '../util/secure-state-file.js';
+import { findProjectRoot } from '../nav-graph/storage.js';
+
+/**
+ * Spec 2026-07-02 (observe autostart): best-effort discovery aid. The MCP
+ * worker records where the observe UI is listening so out-of-band consumers
+ * (SessionStart hook, doctor, humans) can find the live URL without calling
+ * the tool. Uses the GH #383 hardened state-file helpers (atomic writes,
+ * symlink-refusing reads, per-user app-support dir). Every function here is
+ * fail-safe: state-file problems must never affect the observe server itself.
+ */
+export interface ObserveState {
+  url: string;
+  port: number;
+  pid: number;
+  projectRoot: string;
+  startedAt: string;
+}
+
+export function observeStatePath(projectRoot: string): string {
+  const safe = projectRoot.replace(/[^A-Za-z0-9._-]/g, '_');
+  return join(getStateDir(), 'observe', `${safe}.json`);
+}
+
+export function writeObserveState(
+  url: string,
+  port: number,
+  projectRoot: string | null = findProjectRoot(),
+  now: () => Date = () => new Date(),
+): void {
+  try {
+    if (!projectRoot) return;
+    const state: ObserveState = {
+      url,
+      port,
+      pid: process.pid,
+      projectRoot,
+      startedAt: now().toISOString(),
+    };
+    writeJsonStateFileAtomic(observeStatePath(projectRoot), state);
+  } catch {
+    /* best-effort — never fail the caller */
+  }
+}
+
+export function removeObserveState(projectRoot: string | null = findProjectRoot()): void {
+  try {
+    if (!projectRoot) return;
+    const p = observeStatePath(projectRoot);
+    const existing = readJsonStateFile<ObserveState>(p);
+    // A different pid means another live session overwrote the file after we
+    // started (port-collision fallback scenario) — their record, not ours.
+    if (existing && existing.pid !== process.pid) return;
+    deleteStateFile(p);
+  } catch {
+    /* best-effort */
+  }
+}
+```
+
+- [ ] **Step 4: Wire into the observe tool**
+
+In `src/tools/observe.ts`, add the import:
+
+```ts
+import { writeObserveState, removeObserveState } from '../observability/observe-state.js';
+```
+
+Change `startObserveServer` to record the state after a successful listen:
+
+```ts
+export async function startObserveServer(): Promise<{ url: string; port: number }> {
+  if (!server) server = new ObservabilityServer(recorder, e2eDeps);
+  const { port } = resolveObservePort();
+  const res = await server.start(port);
+  writeObserveState(res.url, res.port);
+  return res;
+}
+```
+
+Change `stopObserveServer` to clean up:
+
+```ts
+async function stopObserveServer(): Promise<void> {
+  await server?.stop();
+  server = null;
+  removeObserveState();
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm run build && node --test test/unit/observe-state-file.test.js test/unit/observe-restart-action.test.js test/unit/observability-observe-tool.test.js`
+Expected: PASS. (The tool tests run outside a project root, so `findProjectRoot()` returns null and state writes are silent no-ops — exactly the fail-safe contract.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/observability/observe-state.ts src/tools/observe.ts test/unit/observe-state-file.test.js
+git commit -m "feat(observe): per-project state file records the live UI url (GH #383 state-file pattern)"
+```
+
+---
+
+### Task 4: Autostart module + `index.ts` wiring
+
+**Files:**
+- Create: `scripts/cdp-bridge/src/observability/autostart.ts`
+- Modify: `scripts/cdp-bridge/src/index.ts` (two small additions, exact locations below)
+- Test: `scripts/cdp-bridge/test/unit/observe-autostart.test.js` (create)
+
+**Interfaces:**
+- Consumes: `resolveObserveAutostart` (Task 1), `startObserveServer` (Task 2), `removeObserveState` (Task 3), existing `findProjectRoot`, `logger`.
+- Produces: `autostartObserve(deps: AutostartDeps): Promise<{ url: string } | null>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/cdp-bridge/test/unit/observe-autostart.test.js`:
+
+```js
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { autostartObserve } from '../../dist/observability/autostart.js';
+
+function deps(overrides = {}) {
+  const calls = { start: 0, warn: [], info: [] };
+  const d = {
+    findRoot: () => '/some/project',
+    resolveEnabled: () => ({ enabled: true, source: 'default' }),
+    start: async () => {
+      calls.start++;
+      return { url: 'http://127.0.0.1:7333', port: 7333 };
+    },
+    warn: (m) => calls.warn.push(m),
+    info: (m) => calls.info.push(m),
+    ...overrides,
+  };
+  return { d, calls };
+}
+
+test('starts and reports the url when a project root exists and autostart is enabled', async () => {
+  const { d, calls } = deps();
+  const res = await autostartObserve(d);
+  assert.deepEqual(res, { url: 'http://127.0.0.1:7333' });
+  assert.equal(calls.start, 1);
+  assert.equal(calls.warn.length, 0);
+  assert.match(calls.info.join('\n'), /http:\/\/127\.0\.0\.1:7333/);
+});
+
+test('no project root → never starts', async () => {
+  const { d, calls } = deps({ findRoot: () => null });
+  assert.equal(await autostartObserve(d), null);
+  assert.equal(calls.start, 0);
+});
+
+test('disabled via env/config → never starts, logs the source', async () => {
+  const { d, calls } = deps({ resolveEnabled: () => ({ enabled: false, source: 'config' }) });
+  assert.equal(await autostartObserve(d), null);
+  assert.equal(calls.start, 0);
+  assert.match(calls.info.join('\n'), /disabled \(config\)/);
+});
+
+test('start failure warns and returns null — never throws', async () => {
+  const { d, calls } = deps({
+    start: async () => {
+      throw new Error('EACCES: boom');
+    },
+  });
+  assert.equal(await autostartObserve(d), null);
+  assert.equal(calls.warn.length, 1);
+  assert.match(calls.warn[0], /EACCES: boom/);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run build && node --test test/unit/observe-autostart.test.js`
+Expected: FAIL — `dist/observability/autostart.js` does not exist.
+
+- [ ] **Step 3: Create `src/observability/autostart.ts`**
+
+```ts
+/**
+ * Spec 2026-07-02: autostart the observe web UI at MCP worker boot — but only
+ * inside a detected RN project, only when enabled (env > config > default on),
+ * and NEVER fatally: an autostart failure is a warning, not a boot error.
+ * Dependency-injected so the gating logic is unit-testable without sockets.
+ */
+export interface AutostartDeps {
+  findRoot: () => string | null;
+  resolveEnabled: () => { enabled: boolean; source: 'env' | 'config' | 'default' };
+  start: () => Promise<{ url: string; port: number }>;
+  warn: (msg: string) => void;
+  info: (msg: string) => void;
+}
+
+export async function autostartObserve(deps: AutostartDeps): Promise<{ url: string } | null> {
+  try {
+    if (!deps.findRoot()) return null;
+    const res = deps.resolveEnabled();
+    if (!res.enabled) {
+      deps.info(`observe UI autostart disabled (${res.source})`);
+      return null;
+    }
+    const { url } = await deps.start();
+    deps.info(`observe UI autostarted: ${url}`);
+    return { url };
+  } catch (e) {
+    deps.warn(`observe UI autostart failed: ${e instanceof Error ? e.message : String(e)}`);
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run build && node --test test/unit/observe-autostart.test.js`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Wire into `src/index.ts`**
+
+(a) Add imports next to the existing observe import (`import { observeHandler, observeSchema, setObserveE2eDeps } from './tools/observe.js';`, around line 118):
+
+```ts
+import { observeHandler, observeSchema, setObserveE2eDeps, startObserveServer } from './tools/observe.js';
+import { autostartObserve } from './observability/autostart.js';
+import { removeObserveState } from './observability/observe-state.js';
+```
+
+and add `resolveObserveAutostart` to the existing `./project-config.js` import in the same file.
+
+(b) In `main()`, after the `recoverInterruptedRequests` block (the `{ const root = findProjectRoot(); ... }` block at the end of `main()`), append:
+
+```ts
+  await autostartObserve({
+    findRoot: findProjectRoot,
+    resolveEnabled: resolveObserveAutostart,
+    start: startObserveServer,
+    warn: (m) => logger.warn('OBSERVE', m),
+    info: (m) => logger.info('OBSERVE', m),
+  });
+```
+
+(c) Next to the existing `process.on('exit', () => stopParentWatch());` (around line 2410), add:
+
+```ts
+process.on('exit', () => removeObserveState());
+```
+
+(All exit paths — graceful shutdown, uncaught exception, parent death — funnel through `process.exit`, so this reliably clears our own state file; the pid guard in `removeObserveState` protects a newer session's file.)
+
+- [ ] **Step 6: Build + full unit suite**
+
+Run: `npm test`
+Expected: PASS. `tsc` catching a typo in the `index.ts` wiring counts as this step's real gate — there is no unit test for `main()` itself (it owns a stdio transport); live verification happens in Task 6.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/observability/autostart.ts src/index.ts test/unit/observe-autostart.test.js
+git commit -m "feat(observe): autostart web UI at MCP boot in RN projects (non-fatal, env/config gated)"
+```
+
+---
+
+### Task 5: SessionStart hook notice + `/observe` command rewrite
+
+**Files:**
+- Modify: `hooks/detect-rn-project.sh` (append inside the `has_rn_config` block, after the final `EOF` heredoc at line ~142)
+- Modify: `commands/observe.md` (full replacement)
+
+**Interfaces:**
+- Consumes: the same env/config precedence as Task 1 — the shell snippet mirrors `resolveObserveAutostart` + `resolveObservePort` semantics (it cannot import them; keep the constants in sync: default on, default port 7333).
+- Produces: one line of SessionStart context, e.g. `Observe UI: http://127.0.0.1:7333 — /rn-dev-agent:observe to stop/restart`.
+
+- [ ] **Step 1: Append the notice to `hooks/detect-rn-project.sh`**
+
+Insert after the closing `EOF` of the banner heredoc (still inside `if [ "$has_rn_config" = true ]; then ... fi`):
+
+```bash
+  # Observe UI autostart notice (spec 2026-07-02). The MCP worker autostarts
+  # the observability web UI unless disabled via env/config; print the expected
+  # URL so the user can open it without running /observe. Mirrors the
+  # resolveObserveAutostart/resolveObservePort precedence (env > config >
+  # default on, port 7333). Best-effort: any failure prints nothing.
+  OBSERVE_LINE=$(node -e '
+    let cfg = {};
+    try { cfg = JSON.parse(require("fs").readFileSync(".rn-agent/config.json", "utf8")); } catch {}
+    const o = cfg.observe || {};
+    const autoEnv = process.env.RN_AGENT_OBSERVE_AUTOSTART;
+    const auto = autoEnv === "0" || autoEnv === "false" ? false
+      : autoEnv === "1" || autoEnv === "true" ? true
+      : typeof o.autoStart === "boolean" ? o.autoStart : true;
+    if (!auto) process.exit(0);
+    const pe = Number.parseInt(process.env.RN_AGENT_OBSERVE_PORT ?? "", 10);
+    const port = Number.isInteger(pe) && pe > 0 && pe <= 65535 ? pe
+      : Number.isInteger(o.port) && o.port > 0 && o.port <= 65535 ? o.port : 7333;
+    console.log("Observe UI: http://127.0.0.1:" + port + " — /rn-dev-agent:observe to stop/restart (disable autostart via .rn-agent/config.json observe.autoStart=false)");
+  ' 2>/dev/null || true)
+  if [ -n "$OBSERVE_LINE" ]; then
+    echo ""
+    echo "$OBSERVE_LINE"
+  fi
+```
+
+- [ ] **Step 2: Verify the hook**
+
+Syntax check: `bash -n hooks/detect-rn-project.sh` → no output.
+
+Behavior check of the snippet in isolation (run from repo root):
+
+```bash
+cd "$(mktemp -d)"
+# default: prints the 7333 URL
+node -e '<paste the node -e body from Step 1>'
+# config disable: prints nothing
+mkdir -p .rn-agent && echo '{"observe":{"autoStart":false}}' > .rn-agent/config.json
+node -e '<same body>'
+# config port override
+echo '{"observe":{"port":7440}}' > .rn-agent/config.json
+node -e '<same body>'
+# env beats config
+RN_AGENT_OBSERVE_AUTOSTART=0 node -e '<same body>'
+```
+
+Expected: URL with 7333 / empty / URL with 7440 / empty.
+
+- [ ] **Step 3: Replace `commands/observe.md` with**
+
+```markdown
+---
+command: observe
+description: Show the observability web UI URL (it autostarts with the session); stop or restart it.
+---
+
+The observe web UI autostarts when the session begins in an RN project. Permanent opt-out:
+`.rn-agent/config.json` → `{ "observe": { "autoStart": false } }` (port via `observe.port`,
+default 7333; env `RN_AGENT_OBSERVE_AUTOSTART` / `RN_AGENT_OBSERVE_PORT` override config).
+
+- Default (`/observe` with no argument): call the `observe` MCP tool with `action: "status"`.
+  If running, print the returned `url` prominently and tell the user to open it in a browser
+  to watch the live tool-call timeline, device screenshot, and app state. If NOT running
+  (autostart disabled or previously stopped), call `action: "start"` — an explicit /observe
+  is an explicit request to see the UI — and print the URL.
+- `/observe stop`: call with `action: "stop"`. The UI stays down for the rest of the session;
+  mention the config opt-out if the user wants it permanent.
+- `/observe restart`: call with `action: "restart"` and print the (possibly new) URL. The
+  event timeline is preserved across restarts.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add hooks/detect-rn-project.sh commands/observe.md
+git commit -m "feat(observe): SessionStart URL notice + /observe command covers stop/restart and autostart opt-out"
+```
+
+---
+
+### Task 6: Gates, changeset, live verification
+
+**Files:**
+- Create: `.changeset/observe-autostart-lifecycle.md`
+
+- [ ] **Step 1: Full test suite + repo gates**
+
+```bash
+cd scripts/cdp-bridge && npm test
+cd ../.. && npx oxlint && npx oxfmt --check
+```
+
+Expected: all pass. Fix any lint/format findings in the new files (run `npx oxfmt` to autoformat).
+
+- [ ] **Step 2: Create the changeset**
+
+Create `.changeset/observe-autostart-lifecycle.md`:
+
+```markdown
+---
+"rn-dev-agent-cdp": minor
+"rn-dev-agent-plugin": minor
+---
+
+The observe web UI now autostarts when the MCP worker boots in an RN project, listening on a
+stable default port (7333, `http://127.0.0.1:7333`) with an ephemeral fallback on collision.
+New `.rn-agent/config.json` block `{ "observe": { "autoStart": boolean, "port": number } }`
+plus `RN_AGENT_OBSERVE_AUTOSTART` env override (precedence env > config > default, matching
+`cdp.autoConnect`). The `observe` tool gains a `restart` action; `stop` is session-scoped.
+The live URL is recorded in a per-project state file and announced at SessionStart.
+```
+
+- [ ] **Step 3: Live verification (verify skill applies — drive the real flow)**
+
+In a real RN project with the locally-built plugin active:
+
+1. Start a fresh Claude Code session → SessionStart context shows `Observe UI: http://127.0.0.1:7333 …`.
+2. Open the URL → UI loads, events stream.
+3. `observe` tool `action: "restart"` → URL still works, previous timeline events still visible.
+4. `action: "stop"` → port closed (`curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:7333` fails to connect).
+5. `.rn-agent/config.json` with `{"observe":{"autoStart":false}}` → new session does NOT listen on 7333 and the SessionStart notice is absent.
+6. Check the state file: `cat "$HOME/Library/Application Support/rn-dev-agent/observe/"*.json` shows url/port/pid while running (macOS path; XDG path on Linux).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .changeset/observe-autostart-lifecycle.md
+git commit -m "chore: changeset for observe autostart + lifecycle"
+```

--- a/docs/superpowers/plans/2026-07-02-observe-ui-overhaul.md
+++ b/docs/superpowers/plans/2026-07-02-observe-ui-overhaul.md
@@ -1,0 +1,1662 @@
+# Observe Web UI Overhaul Implementation Plan (PR 2 of 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the observe SPA — header with session stats, filterable/searchable timeline with follow/pause autoscroll, device-screenshot hero pane, guided empty states, inline action param inputs, and E2E run-history drill-down — by splitting the 670-line `main.tsx` into focused modules.
+
+**Architecture:** Pure client-side restructure of `scripts/cdp-bridge/src/observability/web/src/` (React 19 + Vite single-file bundle) plus ONE tiny server-side change: `resolveParams` accepts caller-provided param overrides so the UI's inline inputs actually work. Each new module is written once in its final form; the old `main.tsx` keeps working until the final task flips the app shell over.
+
+**Tech Stack:** React 19, TypeScript, Vite (`vite-plugin-singlefile`, output to `dist/observability/web-dist/`), CSS-in-a-string injected at mount (existing pattern). Server-side: `node:test` against `dist/`.
+
+**Source spec:** `docs/superpowers/specs/2026-07-02-observe-ui-autostart-design.md`
+
+## Global Constraints
+
+- No new runtime dependencies — `web/package.json` keeps exactly `react` + `react-dom`.
+- No new server endpoints; the only bridge change is the `resolveParams` extension (Task 1).
+- Keep the Tokyo Night palette; dark theme only.
+- SPA type gate: `npx tsc --noEmit` inside `src/observability/web/` (vite build does NOT typecheck). Build gate: `npm run build:web` from `scripts/cdp-bridge/`.
+- Component annotations use `JSX.Element` (existing codebase style).
+- The web app talks to: `GET /api/stream` (SSE), `GET /api/screenshot/:seq`, `GET /api/live-screenshot/:seq`, `POST /api/e2e/run`, `GET /api/e2e/runs`, `GET /api/e2e/runs/:id`, `GET /api/e2e/actions`, `POST /api/e2e/actions/run` — all existing. CSRF token comes from `window.__E2E_CSRF__`.
+- All `scripts/cdp-bridge` commands run from that directory; web commands from `scripts/cdp-bridge/src/observability/web/`.
+
+---
+
+### Task 1: Server-side — `resolveParams` accepts UI-provided overrides
+
+Today `POST /api/e2e/actions/run` discards the request's `params` whenever the action declares required params: the `runAction` closure in `index.ts` overwrites them with config-resolved values or fails with `missingParams`. The UI's inline inputs (Task 6) need provided params to win.
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/domain/e2e-config.ts:20-36`
+- Modify: `scripts/cdp-bridge/src/index.ts` (the `setObserveE2eDeps.runAction` closure, ~line 2336: `const resolved = resolveParams(config, actionId, required);`)
+- Test: `scripts/cdp-bridge/test/unit/e2e-config.test.js` (extend)
+
+**Interfaces:**
+- Produces: `resolveParams(config, testId, required, provided?)` — 4th optional arg `provided?: Record<string, string>`; non-empty provided values take precedence over config; return shape unchanged (`{ ok: true, params } | { ok: false, missing }`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `scripts/cdp-bridge/test/unit/e2e-config.test.js`:
+
+```js
+test('resolveParams: caller-provided params win over config and fill gaps', () => {
+  const config = { defaults: { params: { user: 'from-config', pass: 'cfg-pw' } } };
+  const r = resolveParams(config, 'login', ['user', 'pass'], { user: 'from-ui' });
+  assert.deepEqual(r, { ok: true, params: { user: 'from-ui', pass: 'cfg-pw' } });
+});
+
+test('resolveParams: empty-string provided values do not mask config values', () => {
+  const config = { defaults: { params: { user: 'from-config' } } };
+  const r = resolveParams(config, 'login', ['user'], { user: '' });
+  assert.deepEqual(r, { ok: true, params: { user: 'from-config' } });
+});
+
+test('resolveParams: provided params satisfy otherwise-missing requirements', () => {
+  const r = resolveParams({}, 'login', ['user'], { user: 'typed' });
+  assert.deepEqual(r, { ok: true, params: { user: 'typed' } });
+});
+```
+
+(The file already imports `resolveParams` and `assert` — check its header; if `resolveParams` is not yet imported there, add it to the existing import from `../../dist/domain/e2e-config.js`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run build && node --test test/unit/e2e-config.test.js`
+Expected: FAIL — the 4th argument is ignored, so `user` resolves to `'from-config'` instead of `'from-ui'`, and the gap-fill case returns `{ ok: false, missing: ['user'] }`.
+
+- [ ] **Step 3: Extend `resolveParams` in `src/domain/e2e-config.ts`**
+
+```ts
+export function resolveParams(
+  config: E2eConfig,
+  testId: string,
+  required: string[],
+  provided?: Record<string, string>,
+): { ok: true; params: Record<string, string> } | { ok: false; missing: string[] } {
+  // Caller-provided values (e.g. typed into the observe UI) take precedence
+  // over config; empty strings are treated as "not provided" so a blank input
+  // never masks a configured value.
+  const overrides = Object.fromEntries(
+    Object.entries(provided ?? {}).filter(([, v]) => typeof v === 'string' && v !== ''),
+  );
+  const merged: Record<string, string> = {
+    ...config.defaults?.params,
+    ...config.tests?.[testId]?.params,
+    ...overrides,
+  };
+  const missing = required.filter((k) => !merged[k]);
+  if (missing.length > 0) return { ok: false, missing };
+  // Return ONLY the params the action declares — never leak unrelated
+  // defaults (which may include secrets) into a test that doesn't use them.
+  const params: Record<string, string> = {};
+  for (const k of required) params[k] = merged[k] as string;
+  return { ok: true, params };
+}
+```
+
+- [ ] **Step 4: Pass the HTTP params through in `src/index.ts`**
+
+In the `setObserveE2eDeps({ ... runAction ... })` closure, change:
+
+```ts
+      const resolved = resolveParams(config, actionId, required);
+```
+
+to:
+
+```ts
+      const resolved = resolveParams(config, actionId, required, params);
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm test`
+Expected: PASS — the three new tests plus all existing `e2e-config` and run-action tests (the new argument is optional, so `cdp_run_e2e_suite`'s call sites are unaffected).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/domain/e2e-config.ts src/index.ts test/unit/e2e-config.test.js
+git commit -m "feat(e2e): resolveParams accepts caller-provided overrides so the observe UI can supply action params"
+```
+
+---
+
+### Task 2: Web scaffolding — `types.ts`, `derive.ts`, `theme.ts`
+
+New modules only; `main.tsx` untouched (still builds and behaves as before).
+
+**Files:**
+- Create: `scripts/cdp-bridge/src/observability/web/src/types.ts`
+- Create: `scripts/cdp-bridge/src/observability/web/src/derive.ts`
+- Create: `scripts/cdp-bridge/src/observability/web/src/theme.ts`
+
+**Interfaces:**
+- Produces (consumed by every later task): all shared types; pure helpers `latestByTool`, `latestByFamily`, `pretty`, `routeOf`, `appOf`, `fmtClock`, `fmtElapsed`, `csrfToken`; theme exports `FAMILY_COLOR`, `FAMILIES`, `CSS`.
+
+- [ ] **Step 1: Create `src/types.ts`**
+
+```ts
+export type Family =
+  | 'interaction'
+  | 'introspection'
+  | 'navigation'
+  | 'lifecycle'
+  | 'testing'
+  | 'other';
+
+export interface AgentEvent {
+  seq: number;
+  ts: number;
+  tool: string;
+  family: Family;
+  args: Record<string, unknown>;
+  ok: boolean;
+  durationMs?: number;
+  error?: { message: string; code?: string };
+  ghost?: { attempted: boolean; outcome: string };
+  summary: string;
+  payload?: unknown;
+  truncated?: boolean;
+}
+
+export type Conn = 'connecting' | 'open' | 'error';
+
+export interface ActionSummary {
+  id: string;
+  intent: string;
+  status: string;
+  params?: string[];
+  mutates?: boolean;
+  appId?: string;
+}
+
+export interface ActionRunResult {
+  ok: boolean;
+  output?: string;
+  error?: string;
+  missingParams?: string[];
+}
+
+export interface ActionRunState {
+  running: boolean;
+  result?: ActionRunResult;
+}
+
+export interface E2eProgress {
+  completed: number;
+  total: number;
+  lastTestId: string;
+}
+
+export interface E2eFlowResult {
+  testId: string;
+  intent?: string;
+  passed: boolean;
+  durationMs?: number;
+  classification: string;
+  errorExcerpt?: string | null;
+}
+
+export interface E2eRunResult {
+  ok?: boolean;
+  data?: {
+    runId?: string | null;
+    verdict?: string | null;
+    totals?: { total: number; passed: number; failed: number; skipped: number };
+    results?: E2eFlowResult[];
+    newlyFailing?: string[];
+  };
+}
+
+export interface E2eRunIndexEntry {
+  runId: string;
+  finishedAt: string;
+  verdict: string;
+  totals: { total: number; passed: number; failed: number; skipped: number };
+}
+
+/** Shape of GET /api/e2e/runs/:id — the bridge's E2eRunRecord. */
+export interface E2eRunDetail {
+  runId: string;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  platform: string;
+  verdict: string;
+  totals: { total: number; passed: number; failed: number; skipped: number };
+  results: E2eFlowResult[];
+}
+```
+
+- [ ] **Step 2: Create `src/derive.ts`** (pure helpers moved out of the old `main.tsx`, plus formatters)
+
+```ts
+import type { AgentEvent, Family } from './types';
+
+export function latestByTool(events: AgentEvent[], tools: string[]): AgentEvent | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (tools.includes(events[i].tool)) return events[i];
+  }
+  return undefined;
+}
+
+export function latestByFamily(events: AgentEvent[], family: Family): AgentEvent | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i].family === family) return events[i];
+  }
+  return undefined;
+}
+
+export function pretty(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export function routeOf(ev: AgentEvent | undefined): string | undefined {
+  if (!ev) return undefined;
+  const p = ev.payload as
+    | { routeName?: string; nested?: { routeName?: string; nested?: { routeName?: string } } }
+    | undefined;
+  const cand = p?.nested?.nested?.routeName ?? p?.nested?.routeName ?? p?.routeName;
+  return typeof cand === 'string' ? cand : undefined;
+}
+
+export function appOf(events: AgentEvent[]): string | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const a = events[i].args as { appId?: unknown; bundleId?: unknown; bundle?: unknown };
+    const id = a.appId ?? a.bundleId ?? a.bundle;
+    if (typeof id === 'string' && id) return id;
+  }
+  return undefined;
+}
+
+export function fmtClock(ts: number): string {
+  return new Date(ts).toLocaleTimeString(undefined, { hour12: false });
+}
+
+export function fmtElapsed(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  const mm = String(m).padStart(2, '0');
+  const ss = String(sec).padStart(2, '0');
+  return h > 0 ? `${h}:${mm}:${ss}` : `${m}:${ss.padStart(2, '0')}`;
+}
+
+export function csrfToken(): string {
+  return (window as unknown as { __E2E_CSRF__?: string }).__E2E_CSRF__ ?? '';
+}
+```
+
+- [ ] **Step 3: Create `src/theme.ts`** (tokens + the full stylesheet; injected by `main.tsx` in Task 6)
+
+```ts
+import type { Family } from './types';
+
+export const FAMILIES: Family[] = [
+  'interaction',
+  'introspection',
+  'navigation',
+  'lifecycle',
+  'testing',
+  'other',
+];
+
+export const FAMILY_COLOR: Record<Family, string> = {
+  interaction: '#7aa2f7',
+  introspection: '#9ece6a',
+  navigation: '#e0af68',
+  lifecycle: '#bb9af7',
+  testing: '#f7768e',
+  other: '#787c99',
+};
+
+// Tokyo Night tokens
+// bg #16161e | surface #1a1b26 | raised #1f2335 | selected #283457 | border #2a2b3d
+// text #c0caf5 | soft #a9b1d6 | muted #787c99 | dim #565f89
+// blue #7aa2f7 | cyan #7dcfff | green #9ece6a | yellow #e0af68 | purple #bb9af7 | red #f7768e
+
+export const CSS = `
+* { box-sizing: border-box; }
+html, body, #root { height: 100%; margin: 0; }
+body {
+  background: #16161e; color: #c0caf5;
+  font: 13px/1.45 -apple-system, system-ui, sans-serif;
+}
+pre, .mono, .tool, .dur, .summ, .time, .reg-testid { font-family: ui-monospace, "SF Mono", Menlo, monospace; }
+button { font: inherit; }
+.app { display: flex; flex-direction: column; height: 100%; }
+
+/* ── Header ─────────────────────────────────────────────── */
+.header {
+  display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+  padding: 8px 16px; background: #1a1b26; border-bottom: 1px solid #2a2b3d;
+}
+.brand { display: flex; align-items: baseline; gap: 8px; }
+.brand strong { font-size: 14px; letter-spacing: 0.3px; }
+.brand span { color: #565f89; font-size: 11px; text-transform: uppercase; letter-spacing: 1px; }
+.conn-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: #1f2335; border: 1px solid #2a2b3d; border-radius: 999px;
+  padding: 2px 10px; font-size: 11px; color: #a9b1d6;
+}
+.dot { width: 8px; height: 8px; border-radius: 50%; background: #787c99; flex: none; }
+.dot.open { background: #9ece6a; box-shadow: 0 0 6px #9ece6a66; }
+.dot.connecting { background: #e0af68; }
+.dot.error { background: #f7768e; }
+.chip {
+  background: #1f2335; border: 1px solid #2a2b3d; border-radius: 6px;
+  padding: 2px 8px; font-size: 11px; color: #a9b1d6; max-width: 260px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.chip.route { color: #9ece6a; }
+.chip b { color: #565f89; font-weight: 600; margin-right: 5px; text-transform: uppercase; font-size: 10px; }
+.hstats { margin-left: auto; display: flex; align-items: center; gap: 14px; }
+.stat { display: flex; flex-direction: column; align-items: flex-end; line-height: 1.2; }
+.stat .v { font-weight: 700; font-size: 13px; }
+.stat .k { color: #565f89; font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; }
+.stat .v.bad { color: #f7768e; }
+.view-toggle { display: flex; gap: 4px; }
+
+/* ── Panes ──────────────────────────────────────────────── */
+.panes { display: flex; flex: 1; min-height: 0; }
+.pane { display: flex; flex-direction: column; min-width: 0; border-right: 1px solid #2a2b3d; }
+.pane.left { flex: 0 0 40%; }
+.pane.center { flex: 1; }
+.pane.right { flex: 0 0 26%; border-right: none; }
+.pane-head {
+  display: flex; align-items: center; gap: 8px;
+  padding: 7px 12px; background: #1a1b26; border-bottom: 1px solid #2a2b3d;
+  font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.6px; color: #a9b1d6;
+}
+
+/* ── Filter bar ─────────────────────────────────────────── */
+.filterbar {
+  display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
+  padding: 8px 10px; background: #1a1b26; border-bottom: 1px solid #2a2b3d;
+}
+.fchip {
+  display: inline-flex; align-items: center; gap: 6px; cursor: pointer;
+  background: #1f2335; color: #a9b1d6; border: 1px solid #2a2b3d;
+  border-radius: 999px; padding: 2px 10px; font-size: 11px;
+}
+.fchip .fdot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
+.fchip .n { color: #565f89; }
+.fchip.off { opacity: 0.35; }
+.fchip.errors.on { border-color: #f7768e; color: #f7768e; }
+.search {
+  flex: 1; min-width: 130px; background: #1f2335; border: 1px solid #2a2b3d;
+  border-radius: 6px; color: #c0caf5; padding: 4px 10px; font: inherit; font-size: 12px;
+}
+.search::placeholder { color: #565f89; }
+.search:focus { outline: none; border-color: #7aa2f7; }
+
+/* ── Timeline ───────────────────────────────────────────── */
+.timeline-wrap { position: relative; flex: 1; min-height: 0; display: flex; flex-direction: column; }
+.timeline { flex: 1; overflow: auto; padding: 4px 0; }
+.row {
+  display: flex; align-items: center; gap: 8px;
+  padding: 4px 12px; cursor: pointer; white-space: nowrap;
+}
+.row:hover { background: #1f2335; }
+.row.sel { background: #283457; }
+.row.err { box-shadow: inset 2px 0 0 #f7768e; }
+.time { color: #565f89; font-size: 11px; flex: none; }
+.fam { color: #16161e; border-radius: 3px; padding: 0 5px; font-size: 10px; font-weight: 700; text-transform: uppercase; flex: none; }
+.tool { color: #7dcfff; flex: none; }
+.summ { color: #a9b1d6; overflow: hidden; text-overflow: ellipsis; flex: 1; min-width: 0; }
+.ghost { color: #16161e; background: #e0af68; border-radius: 3px; padding: 0 4px; font-size: 10px; font-weight: 700; flex: none; }
+.ok { flex: none; } .ok.pass { color: #9ece6a; } .ok.fail { color: #f7768e; }
+.dur { color: #565f89; font-size: 11px; flex: none; }
+.dur.slow { color: #e0af68; font-weight: 700; }
+.detail { background: #13141c; border-top: 1px solid #2a2b3d; border-bottom: 1px solid #2a2b3d; padding: 8px 12px; }
+.dlabel { color: #787c99; text-transform: uppercase; font-size: 10px; margin: 6px 0 2px; letter-spacing: 0.5px; }
+.detail pre, .state pre { margin: 0; white-space: pre-wrap; word-break: break-word; font-size: 12px; }
+.detail pre.errtext { color: #f7768e; }
+.jump {
+  position: absolute; bottom: 14px; left: 50%; transform: translateX(-50%);
+  background: #283457; color: #c0caf5; border: 1px solid #7aa2f7; border-radius: 999px;
+  padding: 5px 14px; cursor: pointer; font-size: 12px; font-weight: 600;
+  box-shadow: 0 4px 14px #00000088;
+}
+.jump:hover { background: #3b4261; }
+.count-note { padding: 4px 12px; color: #565f89; font-size: 11px; border-top: 1px solid #1f2335; }
+
+/* ── Device pane ────────────────────────────────────────── */
+.screen { flex: 1; overflow: auto; display: flex; align-items: center; justify-content: center; padding: 16px; }
+.device-frame {
+  background: #101018; border: 1px solid #2a2b3d; border-radius: 22px;
+  padding: 10px; box-shadow: 0 8px 30px #00000066; max-width: 100%; max-height: 100%;
+}
+.device-frame img { display: block; max-width: 100%; max-height: calc(100vh - 180px); border-radius: 14px; }
+.route-chip {
+  margin-left: auto; background: #1f2335; color: #9ece6a; border: 1px solid #2a2b3d;
+  border-radius: 999px; padding: 1px 10px; font-size: 11px; font-weight: 600; text-transform: none; letter-spacing: 0;
+}
+
+/* ── Tabs / state pane ──────────────────────────────────── */
+.tabs { display: flex; gap: 6px; padding: 7px 10px; background: #1a1b26; border-bottom: 1px solid #2a2b3d; }
+.tab {
+  background: #1f2335; color: #a9b1d6; border: 1px solid #2a2b3d; border-radius: 6px;
+  padding: 3px 12px; cursor: pointer;
+}
+.tab.on { background: #283457; color: #c0caf5; border-color: #7aa2f7; }
+.state { flex: 1; overflow: auto; padding: 10px 12px; }
+.trunc { color: #e0af68; font-size: 11px; margin-bottom: 6px; }
+.liveroute { color: #9ece6a; font-weight: 600; margin-bottom: 8px; }
+
+/* ── Empty states ───────────────────────────────────────── */
+.empty { color: #565f89; padding: 14px; }
+.empty-guide { margin: auto; max-width: 320px; text-align: center; line-height: 1.6; }
+.empty-guide .empty-title { color: #a9b1d6; font-weight: 600; margin-bottom: 6px; font-size: 14px; }
+
+/* ── Regression view ────────────────────────────────────── */
+.reg-container { display: flex; flex-direction: column; flex: 1; min-height: 0; overflow: auto; padding: 16px; gap: 16px; }
+.reg-panel, .actions-panel, .reg-history { background: #1a1b26; border: 1px solid #2a2b3d; border-radius: 8px; }
+.reg-panel { padding: 14px; }
+.reg-header { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; flex-wrap: wrap; }
+.reg-run-btn {
+  background: #283457; color: #c0caf5; border: 1px solid #7aa2f7; border-radius: 6px;
+  padding: 6px 18px; cursor: pointer; font-weight: 600;
+}
+.reg-run-btn:hover:not(:disabled) { background: #3b4261; }
+.reg-run-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.reg-progress { color: #e0af68; font-size: 12px; }
+.reg-verdict { font-weight: 700; border-radius: 6px; padding: 3px 12px; font-size: 13px; }
+.reg-verdict.pass { background: #1a2d1a; color: #9ece6a; border: 1px solid #9ece6a; }
+.reg-verdict.fail { background: #2d1a1a; color: #f7768e; border: 1px solid #f7768e; }
+.reg-verdict.none { background: #1f2335; color: #787c99; border: 1px solid #565f89; }
+.reg-empty-hint { color: #787c99; font-size: 12px; font-style: italic; }
+.reg-none { color: #787c99; font-weight: 600; }
+.reg-results { overflow: auto; }
+.reg-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+.reg-table th { padding: 7px 12px; text-align: left; background: #13141c; color: #787c99; font-weight: 600; border-bottom: 1px solid #2a2b3d; }
+.reg-table td { padding: 6px 12px; border-bottom: 1px solid #1f2335; }
+.reg-table tr:last-child td { border-bottom: none; }
+.reg-table tbody tr:hover td { background: #1f2335; }
+.reg-testid { color: #7dcfff; }
+.reg-pass { color: #9ece6a; font-weight: 600; }
+.reg-fail { color: #f7768e; font-weight: 600; }
+.reg-newly-failing td { background: #2d1a1a !important; }
+.reg-badge { border-radius: 3px; padding: 1px 6px; font-size: 10px; font-weight: 700; text-transform: uppercase; }
+.reg-badge-pass { background: #1a2d1a; color: #9ece6a; }
+.reg-badge-regression { background: #2d1a1a; color: #f7768e; }
+.reg-badge-infra { background: #2d2a1a; color: #e0af68; }
+.reg-badge-skipped { background: #1f2335; color: #787c99; }
+.hist-row { cursor: pointer; }
+.hist-detail td { background: #13141c !important; padding: 10px 12px; }
+.hist-detail .errx { color: #f7768e; font-size: 11px; white-space: pre-wrap; word-break: break-word; margin: 2px 0 8px; }
+.hist-meta { color: #787c99; font-size: 11px; margin-bottom: 8px; }
+
+/* ── Actions panel ──────────────────────────────────────── */
+.actions-table { width: 100%; }
+.actions-intent { color: #a9b1d6; max-width: 260px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.actions-params { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
+.param-input {
+  background: #1f2335; border: 1px solid #2a2b3d; border-radius: 4px; color: #c0caf5;
+  padding: 2px 7px; font-size: 11px; font-family: ui-monospace, "SF Mono", Menlo, monospace; width: 110px;
+}
+.param-input::placeholder { color: #565f89; }
+.param-input:focus { outline: none; border-color: #7aa2f7; }
+.param-input.missing { border-color: #f7768e; }
+.actions-mutates { background: #2d2a1a; color: #e0af68; border-radius: 3px; padding: 1px 4px; font-size: 10px; font-weight: 700; margin-left: 4px; }
+.actions-status-active { background: #1a2d1a; color: #9ece6a; }
+.actions-status-experimental { background: #2d2a1a; color: #e0af68; }
+.actions-status-deprecated { background: #1f2335; color: #787c99; }
+.actions-run-cell { display: flex; align-items: center; gap: 8px; white-space: nowrap; }
+.actions-run-btn {
+  background: #283457; color: #c0caf5; border: 1px solid #2a2b3d; border-radius: 4px;
+  padding: 3px 12px; cursor: pointer; font-size: 11px;
+}
+.actions-run-btn:hover:not(:disabled) { background: #3b4261; border-color: #7aa2f7; }
+.actions-run-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.actions-result-ok { color: #9ece6a; font-size: 11px; font-weight: 600; cursor: pointer; }
+.actions-result-fail { color: #f7768e; font-size: 11px; cursor: pointer; }
+.action-output td { background: #13141c !important; }
+.action-output pre { margin: 0; font-size: 11px; white-space: pre-wrap; word-break: break-word; max-height: 240px; overflow: auto; }
+`;
+```
+
+- [ ] **Step 4: Type + build gate**
+
+```bash
+cd src/observability/web
+npx tsc --noEmit
+npm run build
+```
+
+Expected: both succeed (new modules are not imported yet — that's fine; `tsc --noEmit` checks them, vite ignores them).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/observability/web/src/types.ts src/observability/web/src/derive.ts src/observability/web/src/theme.ts
+git commit -m "refactor(observe-ui): extract types, derive helpers, and theme tokens/stylesheet"
+```
+
+---
+
+### Task 3: `hooks/useEventStream.ts`
+
+**Files:**
+- Create: `scripts/cdp-bridge/src/observability/web/src/hooks/useEventStream.ts`
+
+**Interfaces:**
+- Consumes: `AgentEvent`, `Conn`, `E2eProgress` from `../types`.
+- Produces: `useEventStream(): EventStream` where `EventStream = { events, conn, liveShotSeq, liveRoute, e2eProgress, e2eDoneCount }`. `e2eDoneCount` increments on every `e2e-done` SSE message — consumers refetch history when it changes.
+
+- [ ] **Step 1: Create the hook**
+
+```ts
+import { useEffect, useRef, useState } from 'react';
+import type { AgentEvent, Conn, E2eProgress } from '../types';
+
+const MAX_EVENTS = 500;
+
+export interface EventStream {
+  events: AgentEvent[];
+  conn: Conn;
+  liveShotSeq: number | null;
+  liveRoute: string | null;
+  e2eProgress: E2eProgress | null;
+  /** Increments on every e2e-done SSE message — watch it to refetch run history. */
+  e2eDoneCount: number;
+}
+
+export function useEventStream(): EventStream {
+  const [events, setEvents] = useState<AgentEvent[]>([]);
+  const [conn, setConn] = useState<Conn>('connecting');
+  const [liveShotSeq, setLiveShotSeq] = useState<number | null>(null);
+  const [liveRoute, setLiveRoute] = useState<string | null>(null);
+  const [e2eProgress, setE2eProgress] = useState<E2eProgress | null>(null);
+  const [e2eDoneCount, setE2eDoneCount] = useState(0);
+  const maxSeqRef = useRef(0);
+
+  useEffect(() => {
+    const merge = (incoming: AgentEvent[]): void => {
+      const fresh = incoming.filter(
+        (e) => e && typeof e.seq === 'number' && e.seq > maxSeqRef.current,
+      );
+      if (fresh.length === 0) return;
+      for (const e of fresh) if (e.seq > maxSeqRef.current) maxSeqRef.current = e.seq;
+      setEvents((prev) => {
+        const next = prev.concat(fresh);
+        return next.length > MAX_EVENTS ? next.slice(next.length - MAX_EVENTS) : next;
+      });
+    };
+
+    const es = new EventSource('/api/stream');
+    es.onopen = () => setConn('open');
+    es.onerror = () => setConn('error');
+    es.onmessage = (msg) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(msg.data);
+      } catch {
+        return;
+      }
+      const type =
+        parsed && typeof parsed === 'object' ? (parsed as { type?: string }).type : undefined;
+      if (type === 'shutdown') {
+        es.close();
+        setConn('error');
+        setLiveShotSeq(null);
+        setLiveRoute(null);
+        return;
+      }
+      if (type === 'live') {
+        const p = parsed as { shotSeq?: number; route?: string };
+        if (typeof p.shotSeq === 'number') setLiveShotSeq(p.shotSeq);
+        if (typeof p.route === 'string') setLiveRoute(p.route);
+        return;
+      }
+      if (type === 'e2e-progress') {
+        const p = parsed as { completed?: number; total?: number; lastTestId?: string };
+        setE2eProgress({
+          completed: p.completed ?? 0,
+          total: p.total ?? 0,
+          lastTestId: p.lastTestId ?? '',
+        });
+        return;
+      }
+      if (type === 'e2e-done') {
+        setE2eProgress(null);
+        setE2eDoneCount((n) => n + 1);
+        return;
+      }
+      if (type === 'snapshot') {
+        merge((parsed as { events?: AgentEvent[] }).events ?? []);
+      } else {
+        merge([parsed as AgentEvent]);
+      }
+    };
+    return () => es.close();
+  }, []);
+
+  return { events, conn, liveShotSeq, liveRoute, e2eProgress, e2eDoneCount };
+}
+```
+
+- [ ] **Step 2: Type gate + commit**
+
+```bash
+cd src/observability/web && npx tsc --noEmit
+git add src/hooks/useEventStream.ts
+git commit -m "refactor(observe-ui): extract SSE wiring into useEventStream hook"
+```
+
+(Run `git add` from the repo with the full path `scripts/cdp-bridge/src/observability/web/src/hooks/useEventStream.ts` if the cwd differs.)
+
+---
+
+### Task 4: `Header`, `FilterBar`, `Timeline` components
+
+**Files:**
+- Create: `scripts/cdp-bridge/src/observability/web/src/components/Header.tsx`
+- Create: `scripts/cdp-bridge/src/observability/web/src/components/FilterBar.tsx`
+- Create: `scripts/cdp-bridge/src/observability/web/src/components/Timeline.tsx`
+
+**Interfaces:**
+- Consumes: types from `../types`, `FAMILY_COLOR`/`FAMILIES` from `../theme`, `pretty`/`fmtClock`/`fmtElapsed` from `../derive`.
+- Produces (consumed by `main.tsx` in Task 7):
+  - `Header({ conn, app, route, events, view, onViewChange })`
+  - `FilterBar({ counts, active, onToggleFamily, search, onSearch, errorsOnly, onErrorsOnly })`
+  - `Timeline({ events, totalCount, selected, onSelect })`
+
+- [ ] **Step 1: Create `src/components/Header.tsx`**
+
+```tsx
+import { useEffect, useState } from 'react';
+import type { AgentEvent, Conn } from '../types';
+import { fmtElapsed } from '../derive';
+
+export type View = 'live' | 'regression';
+
+interface HeaderProps {
+  conn: Conn;
+  app?: string;
+  route?: string;
+  events: AgentEvent[];
+  view: View;
+  onViewChange: (v: View) => void;
+}
+
+export function Header({ conn, app, route, events, view, onViewChange }: HeaderProps): JSX.Element {
+  const startTs = events.length > 0 ? events[0].ts : null;
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (startTs == null) return;
+    const t = setInterval(() => setTick((n) => n + 1), 1000);
+    return () => clearInterval(t);
+  }, [startTs]);
+
+  const errors = events.reduce((n, e) => (e.ok ? n : n + 1), 0);
+
+  return (
+    <div className="header">
+      <div className="brand">
+        <strong>Observe</strong>
+        <span>rn-dev-agent</span>
+      </div>
+      <span className="conn-pill">
+        <span className={`dot ${conn}`} />
+        {conn === 'open' ? 'live' : conn}
+      </span>
+      {app && (
+        <span className="chip" title={app}>
+          <b>app</b>
+          {app}
+        </span>
+      )}
+      {route && (
+        <span className="chip route" title={route}>
+          <b>route</b>
+          {route}
+        </span>
+      )}
+      <div className="hstats">
+        {startTs != null && (
+          <span className="stat">
+            <span className="v">{fmtElapsed(Date.now() - startTs)}</span>
+            <span className="k">session</span>
+          </span>
+        )}
+        <span className="stat">
+          <span className="v">{events.length}</span>
+          <span className="k">calls</span>
+        </span>
+        <span className="stat">
+          <span className={errors > 0 ? 'v bad' : 'v'}>{errors}</span>
+          <span className="k">errors</span>
+        </span>
+        <span className="view-toggle">
+          <button className={view === 'live' ? 'tab on' : 'tab'} onClick={() => onViewChange('live')}>
+            Live
+          </button>
+          <button
+            className={view === 'regression' ? 'tab on' : 'tab'}
+            onClick={() => onViewChange('regression')}
+          >
+            Regression
+          </button>
+        </span>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create `src/components/FilterBar.tsx`**
+
+```tsx
+import type { Family } from '../types';
+import { FAMILIES, FAMILY_COLOR } from '../theme';
+
+interface FilterBarProps {
+  counts: Record<Family, number>;
+  active: ReadonlySet<Family>;
+  onToggleFamily: (f: Family) => void;
+  search: string;
+  onSearch: (q: string) => void;
+  errorsOnly: boolean;
+  onErrorsOnly: (on: boolean) => void;
+}
+
+export function FilterBar({
+  counts,
+  active,
+  onToggleFamily,
+  search,
+  onSearch,
+  errorsOnly,
+  onErrorsOnly,
+}: FilterBarProps): JSX.Element {
+  return (
+    <div className="filterbar">
+      {FAMILIES.map((f) => (
+        <button
+          key={f}
+          className={active.has(f) ? 'fchip' : 'fchip off'}
+          onClick={() => onToggleFamily(f)}
+          title={`toggle ${f} events`}
+        >
+          <span className="fdot" style={{ background: FAMILY_COLOR[f] }} />
+          {f}
+          <span className="n">{counts[f] ?? 0}</span>
+        </button>
+      ))}
+      <button
+        className={errorsOnly ? 'fchip errors on' : 'fchip errors'}
+        onClick={() => onErrorsOnly(!errorsOnly)}
+        title="only failed calls"
+      >
+        ✗ errors
+      </button>
+      <input
+        className="search"
+        placeholder="search tool or summary…"
+        value={search}
+        onChange={(e) => onSearch(e.target.value)}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Create `src/components/Timeline.tsx`**
+
+```tsx
+import { useEffect, useRef, useState } from 'react';
+import type { AgentEvent } from '../types';
+import { FAMILY_COLOR } from '../theme';
+import { fmtClock, pretty } from '../derive';
+
+const SLOW_MS = 2000;
+const BOTTOM_SLACK_PX = 48;
+
+interface TimelineProps {
+  /** Filtered events to render (already capped upstream). */
+  events: AgentEvent[];
+  /** Unfiltered buffer size, for the "showing X of Y" note. */
+  totalCount: number;
+  selected: number | null;
+  onSelect: (seq: number | null) => void;
+}
+
+export function Timeline({ events, totalCount, selected, onSelect }: TimelineProps): JSX.Element {
+  const ref = useRef<HTMLDivElement>(null);
+  const [following, setFollowing] = useState(true);
+  const countAtPauseRef = useRef(0);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (el && following) el.scrollTop = el.scrollHeight;
+  }, [events, following]);
+
+  const onScroll = (): void => {
+    const el = ref.current;
+    if (!el) return;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < BOTTOM_SLACK_PX;
+    if (atBottom && !following) setFollowing(true);
+    if (!atBottom && following) {
+      countAtPauseRef.current = events.length;
+      setFollowing(false);
+    }
+  };
+
+  const newCount = following ? 0 : Math.max(0, events.length - countAtPauseRef.current);
+
+  return (
+    <div className="timeline-wrap">
+      <div className="timeline" ref={ref} onScroll={onScroll}>
+        {events.map((e) => (
+          <div key={e.seq}>
+            <div
+              className={`row ${selected === e.seq ? 'sel' : ''} ${e.ok ? '' : 'err'}`}
+              onClick={() => onSelect(selected === e.seq ? null : e.seq)}
+            >
+              <span className="time">{fmtClock(e.ts)}</span>
+              <span className="fam" style={{ background: FAMILY_COLOR[e.family] }}>
+                {e.family.slice(0, 4)}
+              </span>
+              <span className="tool">{e.tool}</span>
+              <span className="summ">{e.summary}</span>
+              {e.ghost && <span className="ghost">ghost</span>}
+              <span className={`ok ${e.ok ? 'pass' : 'fail'}`}>{e.ok ? '✓' : '✗'}</span>
+              {e.durationMs != null && (
+                <span className={e.durationMs > SLOW_MS ? 'dur slow' : 'dur'}>{e.durationMs}ms</span>
+              )}
+            </div>
+            {selected === e.seq && (
+              <div className="detail">
+                <div className="dlabel">args</div>
+                <pre>{pretty(e.args)}</pre>
+                {e.error && (
+                  <>
+                    <div className="dlabel">error</div>
+                    <pre className="errtext">{pretty(e.error)}</pre>
+                  </>
+                )}
+                {e.payload !== undefined && (
+                  <>
+                    <div className="dlabel">payload{e.truncated ? ' (truncated)' : ''}</div>
+                    <pre>{pretty(e.payload)}</pre>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+        {events.length === 0 && totalCount === 0 && (
+          <div className="empty empty-guide">
+            <div className="empty-title">Waiting for agent activity</div>
+            <div>Tool calls appear here as the agent works. Ask it to interact with the app.</div>
+          </div>
+        )}
+        {events.length === 0 && totalCount > 0 && (
+          <div className="empty">no events match the current filters</div>
+        )}
+      </div>
+      {events.length < totalCount && (
+        <div className="count-note">
+          showing {events.length} of {totalCount} events
+        </div>
+      )}
+      {!following && (
+        <button className="jump" onClick={() => setFollowing(true)}>
+          ↓ latest{newCount > 0 ? ` (${newCount} new)` : ''}
+        </button>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Type gate + commit**
+
+```bash
+cd src/observability/web && npx tsc --noEmit
+git add src/components/Header.tsx src/components/FilterBar.tsx src/components/Timeline.tsx
+git commit -m "feat(observe-ui): header with session stats, filter bar, timeline with follow/pause autoscroll"
+```
+
+---
+
+### Task 5: `DevicePane` + `StatePane` components
+
+**Files:**
+- Create: `scripts/cdp-bridge/src/observability/web/src/components/DevicePane.tsx`
+- Create: `scripts/cdp-bridge/src/observability/web/src/components/StatePane.tsx`
+
+**Interfaces:**
+- Produces (consumed by `main.tsx`):
+  - `DevicePane({ liveShotSeq, fallbackSeq, route })`
+  - `StatePane({ navEv, storeEv, treeEv, liveRoute })` (owns its own tab state)
+
+- [ ] **Step 1: Create `src/components/DevicePane.tsx`**
+
+```tsx
+interface DevicePaneProps {
+  liveShotSeq: number | null;
+  /** seq of the latest device_screenshot event, used before any live frame exists. */
+  fallbackSeq: number | null;
+  route: string | null;
+}
+
+export function DevicePane({ liveShotSeq, fallbackSeq, route }: DevicePaneProps): JSX.Element {
+  const src =
+    liveShotSeq != null
+      ? `/api/live-screenshot/${liveShotSeq}`
+      : fallbackSeq != null
+        ? `/api/screenshot/${fallbackSeq}`
+        : null;
+  return (
+    <div className="pane center">
+      <div className="pane-head">
+        Device
+        {route && <span className="route-chip">{route}</span>}
+      </div>
+      <div className="screen">
+        {src ? (
+          <div className="device-frame">
+            <img src={src} alt="device screenshot" />
+          </div>
+        ) : (
+          <div className="empty empty-guide">
+            <div className="empty-title">No screenshot yet</div>
+            <div>
+              The screen appears here automatically after the agent interacts with the app.
+            </div>
+            <div>Nothing showing? Check the connection with cdp_status.</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create `src/components/StatePane.tsx`**
+
+```tsx
+import { useState } from 'react';
+import type { AgentEvent } from '../types';
+import { pretty } from '../derive';
+
+type Tab = 'route' | 'store' | 'tree';
+
+const EMPTY_HINT: Record<Tab, string> = {
+  route: 'no navigation state yet — run cdp_navigation_state',
+  store: 'no store snapshot yet — run cdp_store_state',
+  tree: 'no component tree yet — run cdp_component_tree',
+};
+
+interface StatePaneProps {
+  navEv?: AgentEvent;
+  storeEv?: AgentEvent;
+  treeEv?: AgentEvent;
+  liveRoute: string | null;
+}
+
+export function StatePane({ navEv, storeEv, treeEv, liveRoute }: StatePaneProps): JSX.Element {
+  const [tab, setTab] = useState<Tab>('route');
+  const tabEv = tab === 'route' ? navEv : tab === 'store' ? storeEv : treeEv;
+
+  return (
+    <div className="pane right">
+      <div className="tabs">
+        {(['route', 'store', 'tree'] as const).map((t) => (
+          <button key={t} className={tab === t ? 'tab on' : 'tab'} onClick={() => setTab(t)}>
+            {t}
+          </button>
+        ))}
+      </div>
+      <div className="state">
+        {tab === 'route' && liveRoute && <div className="liveroute">live route: {liveRoute}</div>}
+        {tabEv ? (
+          <>
+            {tabEv.truncated && <div className="trunc">payload truncated</div>}
+            <pre>{pretty(tabEv.payload)}</pre>
+          </>
+        ) : tab === 'route' && liveRoute ? null : (
+          <div className="empty">{EMPTY_HINT[tab]}</div>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Type gate + commit**
+
+```bash
+cd src/observability/web && npx tsc --noEmit
+git add src/components/DevicePane.tsx src/components/StatePane.tsx
+git commit -m "feat(observe-ui): device hero pane with route chip + state pane with guided empty states"
+```
+
+---
+
+### Task 6: `ActionsPanel` + `RegressionView` components
+
+**Files:**
+- Create: `scripts/cdp-bridge/src/observability/web/src/components/ActionsPanel.tsx`
+- Create: `scripts/cdp-bridge/src/observability/web/src/components/RegressionView.tsx`
+
+**Interfaces:**
+- Consumes: Task 1's server behavior (provided params win); `csrfToken` from `../derive`.
+- Produces (consumed by `main.tsx`): `RegressionView({ e2eProgress, e2eDoneCount })` — self-contained (fetches actions + history itself); it renders `ActionsPanel` internally.
+
+- [ ] **Step 1: Create `src/components/ActionsPanel.tsx`**
+
+```tsx
+import { useState } from 'react';
+import type { ActionRunState, ActionSummary } from '../types';
+import { csrfToken } from '../derive';
+
+interface ActionsPanelProps {
+  actions: ActionSummary[];
+}
+
+export function ActionsPanel({ actions }: ActionsPanelProps): JSX.Element {
+  const [states, setStates] = useState<Record<string, ActionRunState>>({});
+  const [paramValues, setParamValues] = useState<Record<string, Record<string, string>>>({});
+  const [openOutput, setOpenOutput] = useState<string | null>(null);
+
+  const setParam = (actionId: string, key: string, value: string): void => {
+    setParamValues((prev) => ({ ...prev, [actionId]: { ...prev[actionId], [key]: value } }));
+  };
+
+  const run = async (a: ActionSummary): Promise<void> => {
+    setStates((prev) => ({ ...prev, [a.id]: { running: true } }));
+    try {
+      const r = await fetch('/api/e2e/actions/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken() },
+        body: JSON.stringify({ actionId: a.id, params: paramValues[a.id] ?? {} }),
+      });
+      const result = (await r.json()) as ActionRunState['result'];
+      setStates((prev) => ({ ...prev, [a.id]: { running: false, result } }));
+      if (result && (!result.ok || result.output)) setOpenOutput(a.id);
+    } catch {
+      setStates((prev) => ({
+        ...prev,
+        [a.id]: { running: false, result: { ok: false, error: 'network error' } },
+      }));
+    }
+  };
+
+  return (
+    <div className="actions-panel">
+      <div className="pane-head">Actions</div>
+      {actions.length === 0 ? (
+        <div className="empty empty-guide">
+          <div className="empty-title">No learned actions</div>
+          <div>Save a verified flow with cdp_record_test_save_as_action and it appears here.</div>
+        </div>
+      ) : (
+        <table className="reg-table actions-table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Intent</th>
+              <th>Status</th>
+              <th>Params</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {actions.map((a) => {
+              const st = states[a.id];
+              const missing = st?.result?.missingParams ?? [];
+              return (
+                <ActionRow
+                  key={a.id}
+                  action={a}
+                  state={st}
+                  missing={missing}
+                  values={paramValues[a.id] ?? {}}
+                  onParam={(k, v) => setParam(a.id, k, v)}
+                  onRun={() => void run(a)}
+                  outputOpen={openOutput === a.id}
+                  onToggleOutput={() => setOpenOutput(openOutput === a.id ? null : a.id)}
+                />
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+interface ActionRowProps {
+  action: ActionSummary;
+  state?: ActionRunState;
+  missing: string[];
+  values: Record<string, string>;
+  onParam: (key: string, value: string) => void;
+  onRun: () => void;
+  outputOpen: boolean;
+  onToggleOutput: () => void;
+}
+
+function ActionRow({
+  action: a,
+  state: st,
+  missing,
+  values,
+  onParam,
+  onRun,
+  outputOpen,
+  onToggleOutput,
+}: ActionRowProps): JSX.Element {
+  const res = st?.result;
+  return (
+    <>
+      <tr>
+        <td className="reg-testid">{a.id}</td>
+        <td className="actions-intent" title={a.intent}>
+          {a.intent}
+        </td>
+        <td>
+          <span className={`reg-badge actions-status-${a.status}`}>{a.status}</span>
+          {a.mutates && (
+            <span className="actions-mutates" title="mutates state">
+              M
+            </span>
+          )}
+        </td>
+        <td>
+          <span className="actions-params">
+            {(a.params ?? []).map((p) => (
+              <input
+                key={p}
+                className={missing.includes(p) ? 'param-input missing' : 'param-input'}
+                placeholder={p}
+                value={values[p] ?? ''}
+                onChange={(e) => onParam(p, e.target.value)}
+              />
+            ))}
+          </span>
+        </td>
+        <td className="actions-run-cell">
+          <button className="actions-run-btn" disabled={st?.running} onClick={onRun}>
+            {st?.running ? '…' : 'Run'}
+          </button>
+          {res && (
+            <span
+              className={res.ok ? 'actions-result-ok' : 'actions-result-fail'}
+              onClick={onToggleOutput}
+              title="show output"
+            >
+              {res.ok
+                ? '✓ output'
+                : res.missingParams
+                  ? `missing: ${res.missingParams.join(', ')}`
+                  : (res.error ?? 'failed')}
+            </span>
+          )}
+        </td>
+      </tr>
+      {outputOpen && res && (res.output || res.error) && (
+        <tr className="action-output">
+          <td colSpan={5}>
+            <pre>{res.output ?? res.error}</pre>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Create `src/components/RegressionView.tsx`**
+
+```tsx
+import { useEffect, useState } from 'react';
+import type {
+  ActionSummary,
+  E2eProgress,
+  E2eRunDetail,
+  E2eRunIndexEntry,
+  E2eRunResult,
+} from '../types';
+import { csrfToken } from '../derive';
+import { ActionsPanel } from './ActionsPanel';
+
+interface RegressionViewProps {
+  e2eProgress: E2eProgress | null;
+  /** From useEventStream — bumps when a suite finishes anywhere (tool or UI). */
+  e2eDoneCount: number;
+}
+
+export function RegressionView({ e2eProgress, e2eDoneCount }: RegressionViewProps): JSX.Element {
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<E2eRunResult | null>(null);
+  const [history, setHistory] = useState<E2eRunIndexEntry[]>([]);
+  const [actions, setActions] = useState<ActionSummary[]>([]);
+  const [openRun, setOpenRun] = useState<string | null>(null);
+  const [runDetails, setRunDetails] = useState<Record<string, E2eRunDetail | 'loading' | 'error'>>(
+    {},
+  );
+
+  const fetchHistory = async (): Promise<void> => {
+    try {
+      const r = await fetch('/api/e2e/runs');
+      if (r.ok) setHistory((await r.json()) as E2eRunIndexEntry[]);
+    } catch {
+      /* non-fatal */
+    }
+  };
+
+  const fetchActions = async (): Promise<void> => {
+    try {
+      const r = await fetch('/api/e2e/actions');
+      if (r.ok) setActions((await r.json()) as ActionSummary[]);
+    } catch {
+      /* non-fatal */
+    }
+  };
+
+  useEffect(() => {
+    void fetchHistory();
+    void fetchActions();
+  }, [e2eDoneCount]);
+
+  const toggleRun = (runId: string): void => {
+    const next = openRun === runId ? null : runId;
+    setOpenRun(next);
+    if (next && runDetails[next] === undefined) {
+      setRunDetails((prev) => ({ ...prev, [next]: 'loading' }));
+      fetch(`/api/e2e/runs/${encodeURIComponent(next)}`)
+        .then(async (r) => {
+          if (!r.ok) throw new Error(String(r.status));
+          const detail = (await r.json()) as E2eRunDetail;
+          setRunDetails((prev) => ({ ...prev, [next]: detail }));
+        })
+        .catch(() => {
+          setRunDetails((prev) => ({ ...prev, [next]: 'error' }));
+        });
+    }
+  };
+
+  const runSuite = async (): Promise<void> => {
+    setRunning(true);
+    setResult(null);
+    try {
+      const r = await fetch('/api/e2e/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken() },
+        body: '{}',
+      });
+      setResult((await r.json()) as E2eRunResult);
+      await fetchHistory();
+    } catch {
+      /* non-fatal */
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const verdict = result?.data?.verdict;
+  const newlyFailing = result?.data?.newlyFailing ?? [];
+
+  return (
+    <div className="reg-container">
+      <ActionsPanel actions={actions} />
+      <div className="reg-panel">
+        <div className="reg-header">
+          <button className="reg-run-btn" disabled={running} onClick={() => void runSuite()}>
+            {running ? 'Running…' : 'Run E2E Suite'}
+          </button>
+          {e2eProgress && (
+            <span className="reg-progress mono">
+              test {e2eProgress.completed}/{e2eProgress.total} — {e2eProgress.lastTestId}
+            </span>
+          )}
+          {verdict && (
+            <span
+              className={`reg-verdict ${verdict === 'green' ? 'pass' : verdict === 'empty' ? 'none' : 'fail'}`}
+            >
+              {verdict === 'green' ? 'PASS' : verdict === 'empty' ? 'NO TESTS' : 'FAIL'}
+            </span>
+          )}
+          {verdict === 'empty' && (
+            <span className="reg-empty-hint">No locked tests — lock one with cdp_lock_e2e_test</span>
+          )}
+        </div>
+        {result?.data?.results && result.data.results.length > 0 && (
+          <div className="reg-results">
+            <table className="reg-table">
+              <thead>
+                <tr>
+                  <th>Test ID</th>
+                  <th>Result</th>
+                  <th>Classification</th>
+                </tr>
+              </thead>
+              <tbody>
+                {result.data.results.map((r) => (
+                  <tr
+                    key={r.testId}
+                    className={newlyFailing.includes(r.testId) ? 'reg-newly-failing' : ''}
+                  >
+                    <td className="reg-testid">{r.testId}</td>
+                    <td className={r.passed ? 'reg-pass' : 'reg-fail'}>
+                      {r.passed ? 'pass' : 'fail'}
+                    </td>
+                    <td>
+                      <span className={`reg-badge reg-badge-${r.classification}`}>
+                        {r.classification}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+      <div className="reg-history">
+        <div className="pane-head">Run History</div>
+        {history.length === 0 ? (
+          <div className="empty">no runs yet</div>
+        ) : (
+          <table className="reg-table">
+            <thead>
+              <tr>
+                <th>Run ID</th>
+                <th>Finished</th>
+                <th>Verdict</th>
+                <th>Pass/Fail/Skip</th>
+              </tr>
+            </thead>
+            <tbody>
+              {history.map((h) => (
+                <HistoryRow
+                  key={h.runId}
+                  entry={h}
+                  open={openRun === h.runId}
+                  detail={runDetails[h.runId]}
+                  onToggle={() => toggleRun(h.runId)}
+                />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface HistoryRowProps {
+  entry: E2eRunIndexEntry;
+  open: boolean;
+  detail?: E2eRunDetail | 'loading' | 'error';
+  onToggle: () => void;
+}
+
+function HistoryRow({ entry: h, open, detail, onToggle }: HistoryRowProps): JSX.Element {
+  return (
+    <>
+      <tr className="hist-row" onClick={onToggle}>
+        <td className="reg-testid">
+          {open ? '▾ ' : '▸ '}
+          {h.runId}
+        </td>
+        <td>{new Date(h.finishedAt).toLocaleTimeString()}</td>
+        <td
+          className={
+            h.verdict === 'green' ? 'reg-pass' : h.verdict === 'empty' ? 'reg-none' : 'reg-fail'
+          }
+        >
+          {h.verdict === 'green' ? 'PASS' : h.verdict === 'empty' ? 'NO TESTS' : 'FAIL'}
+        </td>
+        <td>
+          {h.totals.passed}/{h.totals.failed}/{h.totals.skipped}
+        </td>
+      </tr>
+      {open && (
+        <tr className="hist-detail">
+          <td colSpan={4}>
+            {detail === 'loading' || detail === undefined ? (
+              <div className="empty">loading run…</div>
+            ) : detail === 'error' ? (
+              <div className="empty">failed to load run detail</div>
+            ) : (
+              <>
+                <div className="hist-meta mono">
+                  {detail.platform} · {Math.round(detail.durationMs / 1000)}s ·{' '}
+                  {new Date(detail.startedAt).toLocaleTimeString()} →{' '}
+                  {new Date(detail.finishedAt).toLocaleTimeString()}
+                </div>
+                {detail.results.map((r) => (
+                  <div key={r.testId}>
+                    <span className={r.passed ? 'reg-pass' : 'reg-fail'}>
+                      {r.passed ? '✓' : '✗'}
+                    </span>{' '}
+                    <span className="reg-testid">{r.testId}</span>{' '}
+                    <span className={`reg-badge reg-badge-${r.classification}`}>
+                      {r.classification}
+                    </span>
+                    {r.durationMs != null && <span className="mono"> {r.durationMs}ms</span>}
+                    {r.errorExcerpt && <div className="errx">{r.errorExcerpt}</div>}
+                  </div>
+                ))}
+              </>
+            )}
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+```
+
+- [ ] **Step 3: Type gate + commit**
+
+```bash
+cd src/observability/web && npx tsc --noEmit
+git add src/components/ActionsPanel.tsx src/components/RegressionView.tsx
+git commit -m "feat(observe-ui): action param inputs + run output, e2e history drill-down"
+```
+
+---
+
+### Task 7: New `main.tsx` shell — flip the app over
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/observability/web/src/main.tsx` (full replacement — the old inline components, helpers, and CSS string are deleted; everything now comes from the Task 2–6 modules)
+
+**Interfaces:**
+- Consumes: everything produced by Tasks 2–6.
+
+- [ ] **Step 1: Replace `src/main.tsx` with**
+
+```tsx
+import { useMemo, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { AgentEvent, Family } from './types';
+import { CSS, FAMILIES } from './theme';
+import { appOf, latestByFamily, latestByTool, routeOf } from './derive';
+import { useEventStream } from './hooks/useEventStream';
+import { Header, type View } from './components/Header';
+import { FilterBar } from './components/FilterBar';
+import { Timeline } from './components/Timeline';
+import { DevicePane } from './components/DevicePane';
+import { StatePane } from './components/StatePane';
+import { RegressionView } from './components/RegressionView';
+
+const RENDER_ROWS = 250;
+
+function App(): JSX.Element {
+  const { events, conn, liveShotSeq, liveRoute, e2eProgress, e2eDoneCount } = useEventStream();
+  const [view, setView] = useState<View>('live');
+  const [selected, setSelected] = useState<number | null>(null);
+  const [activeFamilies, setActiveFamilies] = useState<ReadonlySet<Family>>(new Set(FAMILIES));
+  const [search, setSearch] = useState('');
+  const [errorsOnly, setErrorsOnly] = useState(false);
+
+  const toggleFamily = (f: Family): void => {
+    setActiveFamilies((prev) => {
+      const next = new Set(prev);
+      if (next.has(f)) next.delete(f);
+      else next.add(f);
+      return next;
+    });
+  };
+
+  const counts = useMemo(() => {
+    const c = Object.fromEntries(FAMILIES.map((f) => [f, 0])) as Record<Family, number>;
+    for (const e of events) c[e.family] = (c[e.family] ?? 0) + 1;
+    return c;
+  }, [events]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const match = (e: AgentEvent): boolean => {
+      if (!activeFamilies.has(e.family)) return false;
+      if (errorsOnly && e.ok) return false;
+      if (q && !e.tool.toLowerCase().includes(q) && !e.summary.toLowerCase().includes(q))
+        return false;
+      return true;
+    };
+    const out = events.filter(match);
+    return out.length > RENDER_ROWS ? out.slice(out.length - RENDER_ROWS) : out;
+  }, [events, activeFamilies, search, errorsOnly]);
+
+  const navEv =
+    latestByTool(events, ['cdp_navigation_state']) ?? latestByFamily(events, 'navigation');
+  const storeEv = latestByTool(events, ['cdp_store_state']);
+  const treeEv = latestByTool(events, ['cdp_component_tree']);
+  const shotEv = latestByTool(events, ['device_screenshot']);
+  const route = liveRoute ?? routeOf(navEv) ?? null;
+  const app = appOf(events);
+
+  return (
+    <div className="app">
+      <Header
+        conn={conn}
+        app={app}
+        route={route ?? undefined}
+        events={events}
+        view={view}
+        onViewChange={setView}
+      />
+      {view === 'live' ? (
+        <div className="panes">
+          <div className="pane left">
+            <FilterBar
+              counts={counts}
+              active={activeFamilies}
+              onToggleFamily={toggleFamily}
+              search={search}
+              onSearch={setSearch}
+              errorsOnly={errorsOnly}
+              onErrorsOnly={setErrorsOnly}
+            />
+            <Timeline
+              events={filtered}
+              totalCount={events.length}
+              selected={selected}
+              onSelect={setSelected}
+            />
+          </div>
+          <DevicePane
+            liveShotSeq={liveShotSeq}
+            fallbackSeq={shotEv && shotEv.ok ? shotEv.seq : null}
+            route={route}
+          />
+          <StatePane navEv={navEv} storeEv={storeEv} treeEv={treeEv} liveRoute={liveRoute} />
+        </div>
+      ) : (
+        <RegressionView e2eProgress={e2eProgress} e2eDoneCount={e2eDoneCount} />
+      )}
+    </div>
+  );
+}
+
+const style = document.createElement('style');
+style.textContent = CSS;
+document.head.appendChild(style);
+
+createRoot(document.getElementById('root')!).render(<App />);
+```
+
+Behavior notes vs. the old shell (for the reviewer):
+- `shotEv` now uses `latestByTool` + `ok` guard instead of the old `[...events].reverse().find(...)` — same result, no copy.
+- The old `device_screenshot` fallback filtered on `family === 'introspection'` AND tool — tool name alone is sufficient (family is derived from the tool).
+- `RENDER_ROWS` capping moved after filtering so a filter can surface older rows that the cap would have hidden.
+- Filter/search/errors state lives here (not in FilterBar) so `filtered` feeds both Timeline and the "showing X of Y" note.
+
+- [ ] **Step 2: Type + build + bundle into dist**
+
+```bash
+cd src/observability/web && npx tsc --noEmit && cd ../../..
+npm run build:web
+ls dist/observability/web-dist/index.html
+```
+
+Expected: type check clean, vite build succeeds, single-file bundle exists.
+
+- [ ] **Step 3: Smoke the built UI against a real server**
+
+Run the unit suite first (`npm test` — server + tool tests must stay green), then live-drive it:
+
+1. In an RN project session with the locally-built plugin: `observe` tool `action: "start"` → open the URL.
+2. Live view: events stream in; family chips filter; search narrows; errors-only isolates failures; scrolling up pauses autoscroll and shows "↓ latest (N new)"; clicking it resumes; screenshot renders in the device frame with the route chip; state tabs show route/store/tree with the new empty hints.
+3. Regression view: actions table renders; an action with params shows inline inputs; running with a typed param succeeds (Task 1 server change); the ✓/✗ toggles the output row; Run History rows expand and load per-flow detail with error excerpts.
+4. `observe` tool `action: "restart"` → reload the tab → timeline still shows pre-restart events.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/observability/web/src/main.tsx
+git commit -m "feat(observe-ui): new app shell — filterable timeline, session header, device hero, regression drill-down"
+```
+
+---
+
+### Task 8: Gates + changeset
+
+**Files:**
+- Create: `.changeset/observe-ui-overhaul.md`
+
+- [ ] **Step 1: Full gates**
+
+```bash
+cd scripts/cdp-bridge && npm test && npm run build:web
+cd ../.. && npx oxlint && npx oxfmt --check
+```
+
+Expected: all pass (run `npx oxfmt` to fix formatting if needed).
+
+- [ ] **Step 2: Create the changeset**
+
+Create `.changeset/observe-ui-overhaul.md`:
+
+```markdown
+---
+"rn-dev-agent-cdp": minor
+"rn-dev-agent-plugin": minor
+---
+
+Observe web UI overhaul: session header (connection, app, route, duration, call/error stats),
+filterable + searchable timeline with follow/pause autoscroll, device-screenshot hero pane with
+route chip, guided empty states, inline param inputs for learned actions (server now honors
+UI-provided params), expandable action output, and E2E run-history drill-down with per-flow
+error excerpts. The SPA is split from one 670-line file into focused modules.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .changeset/observe-ui-overhaul.md
+git commit -m "chore: changeset for observe UI overhaul"
+```

--- a/docs/superpowers/specs/2026-07-02-observe-ui-autostart-design.md
+++ b/docs/superpowers/specs/2026-07-02-observe-ui-autostart-design.md
@@ -1,0 +1,175 @@
+# Observe UI overhaul + autostart — design spec
+
+**Date:** 2026-07-02
+**Status:** awaiting user review
+**Scope:** `scripts/cdp-bridge` (observe tool, observability server/web UI, project config), `hooks/detect-rn-project.sh`, `commands/observe.md`
+
+## Problem
+
+1. The observability web UI must be started manually (`/observe`), its port is random each
+   session, and most users never discover it.
+2. The UI itself is a raw dev tool: weak visual hierarchy, an unfilterable event stream, no
+   session overview, and a Regression view that cannot run parameterized actions.
+3. There is no way to opt out of (or into) observe behavior persistently — the only knobs are
+   per-call tool actions and one env var (`RN_AGENT_OBSERVE_PORT`).
+
+## Decisions
+
+Decisions marked ⚑ were made autonomously (user AFK during clarification) and need explicit
+confirmation at review.
+
+| # | Decision | Choice |
+|---|----------|--------|
+| D1 | Autostart trigger | Worker MCP boot (`index.ts`), gated on RN project detection via `findProjectRoot()` |
+| D2 | Autostart default | **On** (`observe.autoStart` default `true`) |
+| D3 ⚑ | Default port | Fixed **7333**; `EADDRINUSE` → ephemeral fallback (existing behavior) |
+| D4 ⚑ | Browser auto-open | **No** — URL is printed, never auto-opened |
+| D5 | Config surface | Extend existing `.rn-agent/config.json` with an `observe` block (same file/pattern as `cdp.autoConnect`) |
+| D6 | Precedence | env > config > default, mirroring `resolveAutoConnect` |
+| D7 | Command fate | Keep a single `/observe` command as the control surface (status/stop/restart); no separate start command needed since autostart covers the common path |
+| D8 | Stop semantics | `stop` is session-scoped; persistent opt-out is `observe.autoStart: false` |
+| D9 | UI approach | Overhaul within existing architecture (React + Vite, no new runtime deps, no new server APIs); split `main.tsx` into modules |
+| D10 | URL discovery | Actual URL written to a hardened per-project state file (`secure-state-file.ts`, GH #383 pattern); SessionStart hook prints the expected URL optimistically |
+
+## Design
+
+### 1. Autostart
+
+In `index.ts`, after tool registration:
+
+```
+if (findProjectRoot() && resolveObserveAutostart().enabled) {
+  try { await startObserveServer(); writeObserveStateFile(url); }
+  catch (e) { logger.warn('OBSERVE', `autostart failed: ${e}`); }
+}
+```
+
+- `startObserveServer()` reuses the module-global server instance in `tools/observe.ts` so a
+  later `observe status/stop` sees the autostarted server (extract the shared start logic from
+  `observeHandler` rather than duplicating it).
+- Autostart failure is non-fatal and logged once.
+- The supervisor process stays socket-free (its documented invariant); only the worker listens.
+
+### 2. Port & URL resolution
+
+- `resolveObservePort()`: `RN_AGENT_OBSERVE_PORT` env > `observe.port` config > `7333`.
+  Invalid values fall through to the next source (reuse `parsePinnedPort` semantics).
+- `ObservabilityServer.start(pinned)` already falls back to an ephemeral port on
+  `EADDRINUSE` — unchanged. Second concurrent session therefore still works; its true URL
+  comes from `observe status` / the state file.
+- On successful start, write `{ url, port, pid, projectRoot, startedAt }` to
+  `getStateDir()/observe/<sanitized-project-key>.json` via `writeJsonStateFileAtomic`.
+  Delete it on `stop` and via the existing graceful-shutdown path.
+
+### 3. Config (`.rn-agent/config.json`)
+
+```json
+{
+  "cdp":     { "autoConnect": true },
+  "observe": { "autoStart": true, "port": 7333 }
+}
+```
+
+- Extend `RnAgentConfig` in `project-config.ts`:
+  `observe?: { autoStart?: boolean; port?: number }`.
+- Add `resolveObserveAutostart(deps?)` and `resolveObservePort(deps?)` with the same
+  `{ env, readConfig }` test seams and `source: 'env' | 'config' | 'default'` result shape as
+  `resolveAutoConnect`.
+- Unreadable config keeps the existing warn-once-and-ignore behavior.
+
+### 4. Observe tool: `restart` action
+
+- Schema becomes `enum(['start', 'stop', 'restart', 'status'])`.
+- `restart` = `stop()` then `start(resolvedPort)` on a fresh `ObservabilityServer`. The
+  recorder is module-global, so the event timeline survives; SSE clients receive the existing
+  `shutdown` sentinel and the browser tab shows the reconnect state.
+- `start`/`restart` use `resolveObservePort()` (today `start` only reads the env var).
+
+### 5. `/observe` command + SessionStart hook
+
+- `commands/observe.md` rewritten: the default action reports status + URL; if the server is
+  down (autostart disabled or previously stopped), an explicit `/observe` starts it — invoking
+  the command is an explicit request to see the UI. `stop` and `restart` map to the tool
+  actions; the doc mentions `observe.autoStart: false` in `.rn-agent/config.json` for
+  permanent opt-out.
+- `hooks/detect-rn-project.sh`: when an RN project is detected and autostart resolves
+  enabled (cheap check: env var, else `node -e` one-liner reading `.rn-agent/config.json`),
+  append one line of additional context:
+  `Observe UI: http://127.0.0.1:<port> — /observe to stop/restart`.
+  If config parsing fails, stay silent (never block session start).
+
+### 6. Web UI overhaul
+
+File split under `src/observability/web/src/`:
+
+```
+main.tsx            — mount + top-level App state only
+theme.ts            — design tokens (colors, spacing, type scale) + global CSS string
+types.ts            — AgentEvent, ActionSummary, E2e* interfaces
+hooks/useEventStream.ts — SSE wiring, event merge, live frame + e2e progress state
+components/Header.tsx        — title, connection dot, app id, route chip, session clock, call/error counters
+components/FilterBar.tsx     — family chips (color + count), search input, errors-only toggle
+components/Timeline.tsx      — rows, expand-on-click detail, follow/pause autoscroll + "↓ latest"
+components/DevicePane.tsx    — framed screenshot hero, route overlay, guided empty state
+components/StatePane.tsx     — route/store/tree tabs
+components/RegressionView.tsx — e2e runner, results, expandable history (loads /api/e2e/runs/:id)
+components/ActionsPanel.tsx  — actions table, inline param inputs, expandable run output
+```
+
+Behavioral changes:
+
+- **Filtering** is client-side over the in-memory buffer: family toggles, substring search on
+  `tool` + `summary`, errors-only. Filters compose (AND).
+- **Autoscroll** follows the tail only while the user is at (or near) the bottom; scrolling up
+  pauses following and shows a "↓ latest (N new)" affordance.
+- **Timestamps** render as `HH:MM:SS` with slow-call emphasis (duration > 2s highlighted).
+- **Session stats** derive from the event buffer (first event ts → clock; counts per family;
+  error count). No new endpoints.
+- **Actions with params** get inline text inputs (from `ActionSummary.params`) posted as
+  `params` to `/api/e2e/actions/run` — fixing the current dead-end `missingParams` failure.
+- **Run history drill-down** fetches `/api/e2e/runs/:id` on row expand and renders per-flow
+  results (endpoint already exists, currently unused by the UI).
+- Same dark palette (Tokyo Night), no light theme (localhost dev dashboard; YAGNI).
+- No new runtime dependencies; bundle stays React + inlined CSS.
+
+### 7. Out of scope
+
+- Auto-opening the browser.
+- New server/API endpoints; auth changes (localhost + host/sec-fetch-site guard + CSRF token
+  stay as-is).
+- Light theme, mobile layout.
+- A user-visible daemon beyond the MCP worker lifetime (UI dies with the session, as today).
+
+## Error handling
+
+- Autostart: try/catch → single `logger.warn`; MCP boot unaffected.
+- Config: existing warn-once for unparseable JSON; invalid `observe.port` values ignored
+  (fall through to default).
+- State file: write failures swallowed (best-effort discovery aid); stale files are
+  overwritten on next start and removed on graceful shutdown.
+- UI: SSE `shutdown`/`error` states already handled; new fetches (`runs/:id`) render inline
+  error text, never crash the app shell.
+
+## Testing
+
+Unit (vitest, existing patterns in `test/unit/`):
+
+- `resolveObserveAutostart` / `resolveObservePort` precedence: env beats config beats default;
+  malformed values skip to next source.
+- Autostart gating: no project root → no listen; `autoStart: false` → no listen; failure →
+  warn, boot continues.
+- `restart`: recorder buffer preserved; old SSE clients get `shutdown`; new server listens.
+- State file: written atomically on start, removed on stop.
+
+Build/manual:
+
+- `npm run build:web` gates the SPA changes; live verification of both views (Live +
+  Regression) against a running simulator before ship.
+
+## Delivery
+
+Two sequential PRs off this spec:
+
+1. **Lifecycle**: config resolvers, autostart, `restart` action, state file, hook + command
+   docs. (Pure TS, fully unit-testable.)
+2. **UI overhaul**: web/src split + redesign. (Isolated to the SPA; no bridge changes.)

--- a/hooks/detect-rn-project.sh
+++ b/hooks/detect-rn-project.sh
@@ -148,7 +148,7 @@ EOF
   # default on, port 7333). Best-effort: any failure prints nothing.
   OBSERVE_LINE=$(node -e '
     let cfg = {};
-    try { cfg = JSON.parse(require("fs").readFileSync(".rn-agent/config.json", "utf8")); } catch {}
+    try { cfg = JSON.parse(require("fs").readFileSync(".rn-agent/config.json", "utf8")) || {}; } catch {}
     const o = cfg.observe || {};
     const autoEnv = process.env.RN_AGENT_OBSERVE_AUTOSTART;
     const auto = autoEnv === "0" || autoEnv === "false" ? false

--- a/hooks/detect-rn-project.sh
+++ b/hooks/detect-rn-project.sh
@@ -140,4 +140,28 @@ Always run `cdp_status` first. If it fails to connect, run `/rn-dev-agent:check-
 to diagnose missing dependencies (Metro, simulator, agent-device, etc.).
 Do NOT proceed to Phase 5.5 verification without a successful `cdp_status`.
 EOF
+
+  # Observe UI autostart notice (spec 2026-07-02). The MCP worker autostarts
+  # the observability web UI unless disabled via env/config; print the expected
+  # URL so the user can open it without running /observe. Mirrors the
+  # resolveObserveAutostart/resolveObservePort precedence (env > config >
+  # default on, port 7333). Best-effort: any failure prints nothing.
+  OBSERVE_LINE=$(node -e '
+    let cfg = {};
+    try { cfg = JSON.parse(require("fs").readFileSync(".rn-agent/config.json", "utf8")); } catch {}
+    const o = cfg.observe || {};
+    const autoEnv = process.env.RN_AGENT_OBSERVE_AUTOSTART;
+    const auto = autoEnv === "0" || autoEnv === "false" ? false
+      : autoEnv === "1" || autoEnv === "true" ? true
+      : typeof o.autoStart === "boolean" ? o.autoStart : true;
+    if (!auto) process.exit(0);
+    const pe = Number.parseInt(process.env.RN_AGENT_OBSERVE_PORT ?? "", 10);
+    const port = Number.isInteger(pe) && pe > 0 && pe <= 65535 ? pe
+      : Number.isInteger(o.port) && o.port > 0 && o.port <= 65535 ? o.port : 7333;
+    console.log("Observe UI: http://127.0.0.1:" + port + " — /rn-dev-agent:observe to stop/restart (disable autostart via .rn-agent/config.json observe.autoStart=false)");
+  ' 2>/dev/null || true)
+  if [ -n "$OBSERVE_LINE" ]; then
+    echo ""
+    echo "$OBSERVE_LINE"
+  fi
 fi

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -74,7 +74,10 @@ import { instrumentTool, setToolObserver } from './observability/instrumentation
 import { recorder } from './observability/recorder.js';
 import { maybeCaptureLiveFrame, isStateMutating, mayTriggerLiveCapture, toolInvalidatesSnapshotCache, buildLiveDeps, } from './observability/live-device.js';
 import { tryRawScreenshot } from './tools/device-screenshot-raw.js';
-import { observeHandler, observeSchema, setObserveE2eDeps } from './tools/observe.js';
+import { observeHandler, observeSchema, setObserveE2eDeps, startObserveServer, } from './tools/observe.js';
+import { autostartObserve } from './observability/autostart.js';
+import { removeObserveState } from './observability/observe-state.js';
+import { resolveObserveAutostart } from './project-config.js';
 import { createLockE2eTestHandler } from './tools/lock-e2e-test.js';
 import { createRunE2eSuiteHandler } from './tools/run-e2e-suite.js';
 import { recoverInterruptedRequests } from './domain/e2e-run-request.js';
@@ -1711,6 +1714,7 @@ const stopParentWatch = startParentDeathWatch({
     },
 });
 process.on('exit', () => stopParentWatch());
+process.on('exit', () => removeObserveState());
 async function main() {
     logger.info('MCP', `Starting rn-dev-agent-cdp v0.9.1 (log level: ${logger.level})`);
     if (logger.logFilePath) {
@@ -1738,6 +1742,13 @@ async function main() {
                 console.error(`[e2e] marked interrupted runs: ${recovered.join(', ')}`);
         }
     }
+    await autostartObserve({
+        findRoot: findProjectRoot,
+        resolveEnabled: resolveObserveAutostart,
+        start: startObserveServer,
+        warn: (m) => logger.warn('OBSERVE', m),
+        info: (m) => logger.info('OBSERVE', m),
+    });
 }
 main().catch((err) => {
     logger.error('MCP', `Fatal error: ${err instanceof Error ? err.message : err}`);

--- a/scripts/cdp-bridge/dist/index.js
+++ b/scripts/cdp-bridge/dist/index.js
@@ -1742,13 +1742,16 @@ async function main() {
                 console.error(`[e2e] marked interrupted runs: ${recovered.join(', ')}`);
         }
     }
-    await autostartObserve({
+    // Autostart is fire-and-forget: nothing downstream depends on its result,
+    // and even a throwing logger in its catch must not reject main() after MCP
+    // is already connected.
+    void autostartObserve({
         findRoot: findProjectRoot,
         resolveEnabled: resolveObserveAutostart,
         start: startObserveServer,
         warn: (m) => logger.warn('OBSERVE', m),
         info: (m) => logger.info('OBSERVE', m),
-    });
+    }).catch(() => { });
 }
 main().catch((err) => {
     logger.error('MCP', `Fatal error: ${err instanceof Error ? err.message : err}`);

--- a/scripts/cdp-bridge/dist/observability/autostart.js
+++ b/scripts/cdp-bridge/dist/observability/autostart.js
@@ -1,0 +1,18 @@
+export async function autostartObserve(deps) {
+    try {
+        if (!deps.findRoot())
+            return null;
+        const res = deps.resolveEnabled();
+        if (!res.enabled) {
+            deps.info(`observe UI autostart disabled (${res.source})`);
+            return null;
+        }
+        const { url } = await deps.start();
+        deps.info(`observe UI autostarted: ${url}`);
+        return { url };
+    }
+    catch (e) {
+        deps.warn(`observe UI autostart failed: ${e instanceof Error ? e.message : String(e)}`);
+        return null;
+    }
+}

--- a/scripts/cdp-bridge/dist/observability/observe-state.js
+++ b/scripts/cdp-bridge/dist/observability/observe-state.js
@@ -1,0 +1,40 @@
+import { join } from 'node:path';
+import { getStateDir, writeJsonStateFileAtomic, readJsonStateFile, deleteStateFile, } from '../util/secure-state-file.js';
+import { findProjectRoot } from '../nav-graph/storage.js';
+export function observeStatePath(projectRoot) {
+    const safe = projectRoot.replace(/[^A-Za-z0-9._-]/g, '_');
+    return join(getStateDir(), 'observe', `${safe}.json`);
+}
+export function writeObserveState(url, port, projectRoot = findProjectRoot(), now = () => new Date()) {
+    try {
+        if (!projectRoot)
+            return;
+        const state = {
+            url,
+            port,
+            pid: process.pid,
+            projectRoot,
+            startedAt: now().toISOString(),
+        };
+        writeJsonStateFileAtomic(observeStatePath(projectRoot), state);
+    }
+    catch {
+        /* best-effort — never fail the caller */
+    }
+}
+export function removeObserveState(projectRoot = findProjectRoot()) {
+    try {
+        if (!projectRoot)
+            return;
+        const p = observeStatePath(projectRoot);
+        const existing = readJsonStateFile(p);
+        // A different pid means another live session overwrote the file after we
+        // started (port-collision fallback scenario) — their record, not ours.
+        if (existing && existing.pid !== process.pid)
+            return;
+        deleteStateFile(p);
+    }
+    catch {
+        /* best-effort */
+    }
+}

--- a/scripts/cdp-bridge/dist/project-config.js
+++ b/scripts/cdp-bridge/dist/project-config.js
@@ -119,3 +119,40 @@ export function resolveAutoConnect(deps = {}) {
     }
     return { enabled: true, source: 'default' };
 }
+/**
+ * Spec 2026-07-02 (observe autostart): shared port validation. Also re-exported
+ * from tools/observe.ts as `parsePinnedPort` for backward compatibility.
+ */
+export function parsePort(raw) {
+    if (!raw)
+        return undefined;
+    const n = Number.parseInt(raw, 10);
+    return Number.isInteger(n) && n > 0 && n <= 65535 ? n : undefined;
+}
+export const DEFAULT_OBSERVE_PORT = 7333;
+export function resolveObserveAutostart(deps = {}) {
+    // Present-but-undefined `env` means "treat as unset, do NOT fall back to
+    // process.env" (test seam) — same contract as resolveAutoConnect.
+    const envRaw = 'env' in deps ? deps.env : process.env.RN_AGENT_OBSERVE_AUTOSTART;
+    if (envRaw === '0' || envRaw === 'false')
+        return { enabled: false, source: 'env' };
+    if (envRaw === '1' || envRaw === 'true')
+        return { enabled: true, source: 'env' };
+    const cfg = (deps.readConfig ?? readRnAgentConfig)();
+    if (typeof cfg?.observe?.autoStart === 'boolean') {
+        return { enabled: cfg.observe.autoStart, source: 'config' };
+    }
+    return { enabled: true, source: 'default' };
+}
+export function resolveObservePort(deps = {}) {
+    const envRaw = 'env' in deps ? deps.env : process.env.RN_AGENT_OBSERVE_PORT;
+    const envPort = parsePort(envRaw);
+    if (envPort !== undefined)
+        return { port: envPort, source: 'env' };
+    const cfg = (deps.readConfig ?? readRnAgentConfig)();
+    const cfgPort = cfg?.observe?.port;
+    if (typeof cfgPort === 'number' && Number.isInteger(cfgPort) && cfgPort > 0 && cfgPort <= 65535) {
+        return { port: cfgPort, source: 'config' };
+    }
+    return { port: DEFAULT_OBSERVE_PORT, source: 'default' };
+}

--- a/scripts/cdp-bridge/dist/tools/observe.js
+++ b/scripts/cdp-bridge/dist/tools/observe.js
@@ -2,36 +2,52 @@ import { z } from 'zod';
 import { okResult, failResult } from '../utils.js';
 import { ObservabilityServer } from '../observability/server.js';
 import { recorder } from '../observability/recorder.js';
+import { resolveObservePort } from '../project-config.js';
+import { writeObserveState, removeObserveState } from '../observability/observe-state.js';
+// Back-compat alias: parsePinnedPort predates the shared resolver (spec
+// 2026-07-02); the validation now lives in project-config.parsePort.
+export { parsePort as parsePinnedPort } from '../project-config.js';
 export const observeSchema = {
     action: z
-        .enum(['start', 'stop', 'status'])
+        .enum(['start', 'stop', 'restart', 'status'])
         .default('status')
-        .describe('start = launch the web UI and return its URL; stop = tear it down; status = report whether it is running'),
+        .describe('start = launch the web UI and return its URL; stop = tear it down for the rest of the session; restart = stop then start fresh (keeps the event timeline); status = report whether it is running'),
 };
-export function parsePinnedPort(raw) {
-    if (!raw)
-        return undefined;
-    const n = Number.parseInt(raw, 10);
-    return Number.isInteger(n) && n > 0 && n <= 65535 ? n : undefined;
-}
 let server = null;
 let e2eDeps;
 export function setObserveE2eDeps(d) {
     e2eDeps = d;
 }
+/**
+ * Start (or return) the module-global observability server on the resolved
+ * port (env RN_AGENT_OBSERVE_PORT > .rn-agent/config.json observe.port > 7333).
+ * Exported as the autostart entry point so `observe status/stop` sees the
+ * autostarted instance.
+ */
+export async function startObserveServer() {
+    if (!server)
+        server = new ObservabilityServer(recorder, e2eDeps);
+    const { port } = resolveObservePort();
+    const res = await server.start(port);
+    writeObserveState(res.url, res.port);
+    return res;
+}
+async function stopObserveServer() {
+    await server?.stop();
+    server = null;
+    removeObserveState();
+}
 export async function observeHandler(args) {
     const action = args.action ?? 'status';
     try {
-        if (action === 'start') {
-            if (!server)
-                server = new ObservabilityServer(recorder, e2eDeps);
-            const pinned = parsePinnedPort(process.env.RN_AGENT_OBSERVE_PORT);
-            const { url, port } = await server.start(pinned);
+        if (action === 'start' || action === 'restart') {
+            if (action === 'restart')
+                await stopObserveServer();
+            const { url, port } = await startObserveServer();
             return okResult({ url, port, running: true, hint: `Open ${url} to watch the agent live.` });
         }
         if (action === 'stop') {
-            await server?.stop();
-            server = null;
+            await stopObserveServer();
             return okResult({ running: false });
         }
         if (server) {

--- a/scripts/cdp-bridge/dist/tools/observe.js
+++ b/scripts/cdp-bridge/dist/tools/observe.js
@@ -18,21 +18,44 @@ let e2eDeps;
 export function setObserveE2eDeps(d) {
     e2eDeps = d;
 }
+let starting = null;
 /**
  * Start (or return) the module-global observability server on the resolved
  * port (env RN_AGENT_OBSERVE_PORT > .rn-agent/config.json observe.port > 7333).
  * Exported as the autostart entry point so `observe status/stop` sees the
- * autostarted instance.
+ * autostarted instance. Concurrent callers share one in-flight start, and
+ * stopObserveServer awaits it, so a stop racing a pending start can never
+ * orphan a listening server (PR #403 review).
  */
 export async function startObserveServer() {
-    if (!server)
-        server = new ObservabilityServer(recorder, e2eDeps);
-    const { port } = resolveObservePort();
-    const res = await server.start(port);
-    writeObserveState(res.url, res.port);
-    return res;
+    if (starting)
+        return starting;
+    starting = (async () => {
+        if (!server)
+            server = new ObservabilityServer(recorder, e2eDeps);
+        const { port } = resolveObservePort();
+        const res = await server.start(port);
+        writeObserveState(res.url, res.port);
+        return res;
+    })();
+    try {
+        return await starting;
+    }
+    catch (e) {
+        starting = null;
+        throw e;
+    }
 }
 async function stopObserveServer() {
+    if (starting) {
+        try {
+            await starting;
+        }
+        catch {
+            /* start failed — nothing bound */
+        }
+    }
+    starting = null;
     await server?.stop();
     server = null;
     removeObserveState();

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -2486,13 +2486,16 @@ async function main() {
     }
   }
 
-  await autostartObserve({
+  // Autostart is fire-and-forget: nothing downstream depends on its result,
+  // and even a throwing logger in its catch must not reject main() after MCP
+  // is already connected.
+  void autostartObserve({
     findRoot: findProjectRoot,
     resolveEnabled: resolveObserveAutostart,
     start: startObserveServer,
     warn: (m) => logger.warn('OBSERVE', m),
     info: (m) => logger.info('OBSERVE', m),
-  });
+  }).catch(() => {});
 }
 
 main().catch((err) => {

--- a/scripts/cdp-bridge/src/index.ts
+++ b/scripts/cdp-bridge/src/index.ts
@@ -115,7 +115,15 @@ import {
   buildLiveDeps,
 } from './observability/live-device.js';
 import { tryRawScreenshot } from './tools/device-screenshot-raw.js';
-import { observeHandler, observeSchema, setObserveE2eDeps } from './tools/observe.js';
+import {
+  observeHandler,
+  observeSchema,
+  setObserveE2eDeps,
+  startObserveServer,
+} from './tools/observe.js';
+import { autostartObserve } from './observability/autostart.js';
+import { removeObserveState } from './observability/observe-state.js';
+import { resolveObserveAutostart } from './project-config.js';
 import { createLockE2eTestHandler } from './tools/lock-e2e-test.js';
 import { createRunE2eSuiteHandler } from './tools/run-e2e-suite.js';
 import { recoverInterruptedRequests } from './domain/e2e-run-request.js';
@@ -2438,6 +2446,7 @@ const stopParentWatch = startParentDeathWatch({
   },
 });
 process.on('exit', () => stopParentWatch());
+process.on('exit', () => removeObserveState());
 
 async function main() {
   logger.info('MCP', `Starting rn-dev-agent-cdp v0.9.1 (log level: ${logger.level})`);
@@ -2476,6 +2485,14 @@ async function main() {
       if (recovered.length) console.error(`[e2e] marked interrupted runs: ${recovered.join(', ')}`);
     }
   }
+
+  await autostartObserve({
+    findRoot: findProjectRoot,
+    resolveEnabled: resolveObserveAutostart,
+    start: startObserveServer,
+    warn: (m) => logger.warn('OBSERVE', m),
+    info: (m) => logger.info('OBSERVE', m),
+  });
 }
 
 main().catch((err) => {

--- a/scripts/cdp-bridge/src/observability/autostart.ts
+++ b/scripts/cdp-bridge/src/observability/autostart.ts
@@ -1,0 +1,30 @@
+/**
+ * Spec 2026-07-02: autostart the observe web UI at MCP worker boot — but only
+ * inside a detected RN project, only when enabled (env > config > default on),
+ * and NEVER fatally: an autostart failure is a warning, not a boot error.
+ * Dependency-injected so the gating logic is unit-testable without sockets.
+ */
+export interface AutostartDeps {
+  findRoot: () => string | null;
+  resolveEnabled: () => { enabled: boolean; source: 'env' | 'config' | 'default' };
+  start: () => Promise<{ url: string; port: number }>;
+  warn: (msg: string) => void;
+  info: (msg: string) => void;
+}
+
+export async function autostartObserve(deps: AutostartDeps): Promise<{ url: string } | null> {
+  try {
+    if (!deps.findRoot()) return null;
+    const res = deps.resolveEnabled();
+    if (!res.enabled) {
+      deps.info(`observe UI autostart disabled (${res.source})`);
+      return null;
+    }
+    const { url } = await deps.start();
+    deps.info(`observe UI autostarted: ${url}`);
+    return { url };
+  } catch (e) {
+    deps.warn(`observe UI autostart failed: ${e instanceof Error ? e.message : String(e)}`);
+    return null;
+  }
+}

--- a/scripts/cdp-bridge/src/observability/observe-state.ts
+++ b/scripts/cdp-bridge/src/observability/observe-state.ts
@@ -1,0 +1,64 @@
+import { join } from 'node:path';
+import {
+  getStateDir,
+  writeJsonStateFileAtomic,
+  readJsonStateFile,
+  deleteStateFile,
+} from '../util/secure-state-file.js';
+import { findProjectRoot } from '../nav-graph/storage.js';
+
+/**
+ * Spec 2026-07-02 (observe autostart): best-effort discovery aid. The MCP
+ * worker records where the observe UI is listening so out-of-band consumers
+ * (SessionStart hook, doctor, humans) can find the live URL without calling
+ * the tool. Uses the GH #383 hardened state-file helpers (atomic writes,
+ * symlink-refusing reads, per-user app-support dir). Every function here is
+ * fail-safe: state-file problems must never affect the observe server itself.
+ */
+export interface ObserveState {
+  url: string;
+  port: number;
+  pid: number;
+  projectRoot: string;
+  startedAt: string;
+}
+
+export function observeStatePath(projectRoot: string): string {
+  const safe = projectRoot.replace(/[^A-Za-z0-9._-]/g, '_');
+  return join(getStateDir(), 'observe', `${safe}.json`);
+}
+
+export function writeObserveState(
+  url: string,
+  port: number,
+  projectRoot: string | null = findProjectRoot(),
+  now: () => Date = () => new Date(),
+): void {
+  try {
+    if (!projectRoot) return;
+    const state: ObserveState = {
+      url,
+      port,
+      pid: process.pid,
+      projectRoot,
+      startedAt: now().toISOString(),
+    };
+    writeJsonStateFileAtomic(observeStatePath(projectRoot), state);
+  } catch {
+    /* best-effort — never fail the caller */
+  }
+}
+
+export function removeObserveState(projectRoot: string | null = findProjectRoot()): void {
+  try {
+    if (!projectRoot) return;
+    const p = observeStatePath(projectRoot);
+    const existing = readJsonStateFile<ObserveState>(p);
+    // A different pid means another live session overwrote the file after we
+    // started (port-collision fallback scenario) — their record, not ours.
+    if (existing && existing.pid !== process.pid) return;
+    deleteStateFile(p);
+  } catch {
+    /* best-effort */
+  }
+}

--- a/scripts/cdp-bridge/src/project-config.ts
+++ b/scripts/cdp-bridge/src/project-config.ts
@@ -93,6 +93,7 @@ export function readExpoSlug(): string | null {
 
 export interface RnAgentConfig {
   cdp?: { autoConnect?: boolean };
+  observe?: { autoStart?: boolean; port?: number };
 }
 
 let warnedBadConfig = false;
@@ -137,4 +138,61 @@ export function resolveAutoConnect(
     return { enabled: cfg.cdp.autoConnect, source: 'config' };
   }
   return { enabled: true, source: 'default' };
+}
+
+/**
+ * Spec 2026-07-02 (observe autostart): shared port validation. Also re-exported
+ * from tools/observe.ts as `parsePinnedPort` for backward compatibility.
+ */
+export function parsePort(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const n = Number.parseInt(raw, 10);
+  return Number.isInteger(n) && n > 0 && n <= 65535 ? n : undefined;
+}
+
+export const DEFAULT_OBSERVE_PORT = 7333;
+
+export interface ObserveAutostartResolution {
+  enabled: boolean;
+  source: 'env' | 'config' | 'default';
+}
+
+export function resolveObserveAutostart(
+  deps: {
+    env?: string;
+    readConfig?: () => RnAgentConfig | null;
+  } = {},
+): ObserveAutostartResolution {
+  // Present-but-undefined `env` means "treat as unset, do NOT fall back to
+  // process.env" (test seam) — same contract as resolveAutoConnect.
+  const envRaw = 'env' in deps ? deps.env : process.env.RN_AGENT_OBSERVE_AUTOSTART;
+  if (envRaw === '0' || envRaw === 'false') return { enabled: false, source: 'env' };
+  if (envRaw === '1' || envRaw === 'true') return { enabled: true, source: 'env' };
+  const cfg = (deps.readConfig ?? readRnAgentConfig)();
+  if (typeof cfg?.observe?.autoStart === 'boolean') {
+    return { enabled: cfg.observe.autoStart, source: 'config' };
+  }
+  return { enabled: true, source: 'default' };
+}
+
+export interface ObservePortResolution {
+  port: number;
+  source: 'env' | 'config' | 'default';
+}
+
+export function resolveObservePort(
+  deps: {
+    env?: string;
+    readConfig?: () => RnAgentConfig | null;
+  } = {},
+): ObservePortResolution {
+  const envRaw = 'env' in deps ? deps.env : process.env.RN_AGENT_OBSERVE_PORT;
+  const envPort = parsePort(envRaw);
+  if (envPort !== undefined) return { port: envPort, source: 'env' };
+  const cfg = (deps.readConfig ?? readRnAgentConfig)();
+  const cfgPort = cfg?.observe?.port;
+  if (typeof cfgPort === 'number' && Number.isInteger(cfgPort) && cfgPort > 0 && cfgPort <= 65535) {
+    return { port: cfgPort, source: 'config' };
+  }
+  return { port: DEFAULT_OBSERVE_PORT, source: 'default' };
 }

--- a/scripts/cdp-bridge/src/tools/observe.ts
+++ b/scripts/cdp-bridge/src/tools/observe.ts
@@ -31,21 +31,42 @@ export function setObserveE2eDeps(d: E2eServerDeps): void {
   e2eDeps = d;
 }
 
+let starting: Promise<{ url: string; port: number }> | null = null;
+
 /**
  * Start (or return) the module-global observability server on the resolved
  * port (env RN_AGENT_OBSERVE_PORT > .rn-agent/config.json observe.port > 7333).
  * Exported as the autostart entry point so `observe status/stop` sees the
- * autostarted instance.
+ * autostarted instance. Concurrent callers share one in-flight start, and
+ * stopObserveServer awaits it, so a stop racing a pending start can never
+ * orphan a listening server (PR #403 review).
  */
 export async function startObserveServer(): Promise<{ url: string; port: number }> {
-  if (!server) server = new ObservabilityServer(recorder, e2eDeps);
-  const { port } = resolveObservePort();
-  const res = await server.start(port);
-  writeObserveState(res.url, res.port);
-  return res;
+  if (starting) return starting;
+  starting = (async () => {
+    if (!server) server = new ObservabilityServer(recorder, e2eDeps);
+    const { port } = resolveObservePort();
+    const res = await server.start(port);
+    writeObserveState(res.url, res.port);
+    return res;
+  })();
+  try {
+    return await starting;
+  } catch (e) {
+    starting = null;
+    throw e;
+  }
 }
 
 async function stopObserveServer(): Promise<void> {
+  if (starting) {
+    try {
+      await starting;
+    } catch {
+      /* start failed — nothing bound */
+    }
+  }
+  starting = null;
   await server?.stop();
   server = null;
   removeObserveState();

--- a/scripts/cdp-bridge/src/tools/observe.ts
+++ b/scripts/cdp-bridge/src/tools/observe.ts
@@ -4,24 +4,23 @@ import type { ToolResult } from '../utils.js';
 import { ObservabilityServer } from '../observability/server.js';
 import type { E2eServerDeps } from '../observability/server.js';
 import { recorder } from '../observability/recorder.js';
+import { resolveObservePort } from '../project-config.js';
+
+// Back-compat alias: parsePinnedPort predates the shared resolver (spec
+// 2026-07-02); the validation now lives in project-config.parsePort.
+export { parsePort as parsePinnedPort } from '../project-config.js';
 
 export const observeSchema = {
   action: z
-    .enum(['start', 'stop', 'status'])
+    .enum(['start', 'stop', 'restart', 'status'])
     .default('status')
     .describe(
-      'start = launch the web UI and return its URL; stop = tear it down; status = report whether it is running',
+      'start = launch the web UI and return its URL; stop = tear it down for the rest of the session; restart = stop then start fresh (keeps the event timeline); status = report whether it is running',
     ),
 };
 
 export interface ObserveArgs {
-  action?: 'start' | 'stop' | 'status';
-}
-
-export function parsePinnedPort(raw: string | undefined): number | undefined {
-  if (!raw) return undefined;
-  const n = Number.parseInt(raw, 10);
-  return Number.isInteger(n) && n > 0 && n <= 65535 ? n : undefined;
+  action?: 'start' | 'stop' | 'restart' | 'status';
 }
 
 let server: ObservabilityServer | null = null;
@@ -31,18 +30,33 @@ export function setObserveE2eDeps(d: E2eServerDeps): void {
   e2eDeps = d;
 }
 
+/**
+ * Start (or return) the module-global observability server on the resolved
+ * port (env RN_AGENT_OBSERVE_PORT > .rn-agent/config.json observe.port > 7333).
+ * Exported as the autostart entry point so `observe status/stop` sees the
+ * autostarted instance.
+ */
+export async function startObserveServer(): Promise<{ url: string; port: number }> {
+  if (!server) server = new ObservabilityServer(recorder, e2eDeps);
+  const { port } = resolveObservePort();
+  return server.start(port);
+}
+
+async function stopObserveServer(): Promise<void> {
+  await server?.stop();
+  server = null;
+}
+
 export async function observeHandler(args: ObserveArgs): Promise<ToolResult> {
   const action = args.action ?? 'status';
   try {
-    if (action === 'start') {
-      if (!server) server = new ObservabilityServer(recorder, e2eDeps);
-      const pinned = parsePinnedPort(process.env.RN_AGENT_OBSERVE_PORT);
-      const { url, port } = await server.start(pinned);
+    if (action === 'start' || action === 'restart') {
+      if (action === 'restart') await stopObserveServer();
+      const { url, port } = await startObserveServer();
       return okResult({ url, port, running: true, hint: `Open ${url} to watch the agent live.` });
     }
     if (action === 'stop') {
-      await server?.stop();
-      server = null;
+      await stopObserveServer();
       return okResult({ running: false });
     }
     if (server) {

--- a/scripts/cdp-bridge/src/tools/observe.ts
+++ b/scripts/cdp-bridge/src/tools/observe.ts
@@ -5,6 +5,7 @@ import { ObservabilityServer } from '../observability/server.js';
 import type { E2eServerDeps } from '../observability/server.js';
 import { recorder } from '../observability/recorder.js';
 import { resolveObservePort } from '../project-config.js';
+import { writeObserveState, removeObserveState } from '../observability/observe-state.js';
 
 // Back-compat alias: parsePinnedPort predates the shared resolver (spec
 // 2026-07-02); the validation now lives in project-config.parsePort.
@@ -39,12 +40,15 @@ export function setObserveE2eDeps(d: E2eServerDeps): void {
 export async function startObserveServer(): Promise<{ url: string; port: number }> {
   if (!server) server = new ObservabilityServer(recorder, e2eDeps);
   const { port } = resolveObservePort();
-  return server.start(port);
+  const res = await server.start(port);
+  writeObserveState(res.url, res.port);
+  return res;
 }
 
 async function stopObserveServer(): Promise<void> {
   await server?.stop();
   server = null;
+  removeObserveState();
 }
 
 export async function observeHandler(args: ObserveArgs): Promise<ToolResult> {

--- a/scripts/cdp-bridge/test/unit/observability-observe-tool.test.js
+++ b/scripts/cdp-bridge/test/unit/observability-observe-tool.test.js
@@ -2,6 +2,10 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { observeHandler, parsePinnedPort } from '../../dist/tools/observe.js';
 
+// Pin a unique port for this file so the suite never seizes the real default
+// observe port (7333) and parallel test files can't collide.
+process.env.RN_AGENT_OBSERVE_PORT = '51734';
+
 test('parsePinnedPort accepts a valid port and rejects junk / NaN / out-of-range', () => {
   assert.equal(parsePinnedPort('51234'), 51234);
   assert.equal(parsePinnedPort(undefined), undefined);

--- a/scripts/cdp-bridge/test/unit/observe-autostart.test.js
+++ b/scripts/cdp-bridge/test/unit/observe-autostart.test.js
@@ -1,0 +1,52 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { autostartObserve } from '../../dist/observability/autostart.js';
+
+function deps(overrides = {}) {
+  const calls = { start: 0, warn: [], info: [] };
+  const d = {
+    findRoot: () => '/some/project',
+    resolveEnabled: () => ({ enabled: true, source: 'default' }),
+    start: async () => {
+      calls.start++;
+      return { url: 'http://127.0.0.1:7333', port: 7333 };
+    },
+    warn: (m) => calls.warn.push(m),
+    info: (m) => calls.info.push(m),
+    ...overrides,
+  };
+  return { d, calls };
+}
+
+test('starts and reports the url when a project root exists and autostart is enabled', async () => {
+  const { d, calls } = deps();
+  const res = await autostartObserve(d);
+  assert.deepEqual(res, { url: 'http://127.0.0.1:7333' });
+  assert.equal(calls.start, 1);
+  assert.equal(calls.warn.length, 0);
+  assert.match(calls.info.join('\n'), /http:\/\/127\.0\.0\.1:7333/);
+});
+
+test('no project root → never starts', async () => {
+  const { d, calls } = deps({ findRoot: () => null });
+  assert.equal(await autostartObserve(d), null);
+  assert.equal(calls.start, 0);
+});
+
+test('disabled via env/config → never starts, logs the source', async () => {
+  const { d, calls } = deps({ resolveEnabled: () => ({ enabled: false, source: 'config' }) });
+  assert.equal(await autostartObserve(d), null);
+  assert.equal(calls.start, 0);
+  assert.match(calls.info.join('\n'), /disabled \(config\)/);
+});
+
+test('start failure warns and returns null — never throws', async () => {
+  const { d, calls } = deps({
+    start: async () => {
+      throw new Error('EACCES: boom');
+    },
+  });
+  assert.equal(await autostartObserve(d), null);
+  assert.equal(calls.warn.length, 1);
+  assert.match(calls.warn[0], /EACCES: boom/);
+});

--- a/scripts/cdp-bridge/test/unit/observe-config.test.js
+++ b/scripts/cdp-bridge/test/unit/observe-config.test.js
@@ -1,0 +1,105 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parsePort,
+  DEFAULT_OBSERVE_PORT,
+  resolveObserveAutostart,
+  resolveObservePort,
+} from '../../dist/project-config.js';
+
+// Spec 2026-07-02-observe-ui-autostart-design: precedence is
+// env > .rn-agent/config.json observe block > default. Config errors fail open.
+
+test('parsePort accepts a valid port and rejects junk / NaN / out-of-range', () => {
+  assert.equal(parsePort('51234'), 51234);
+  assert.equal(parsePort(undefined), undefined);
+  assert.equal(parsePort(''), undefined);
+  assert.equal(parsePort('abc'), undefined);
+  assert.equal(parsePort('0'), undefined);
+  assert.equal(parsePort('70000'), undefined, 'out of range');
+});
+
+test('resolveObserveAutostart: env "0"/"false" wins over config true', () => {
+  const readConfig = () => ({ observe: { autoStart: true } });
+  assert.deepEqual(resolveObserveAutostart({ env: '0', readConfig }), {
+    enabled: false,
+    source: 'env',
+  });
+  assert.deepEqual(resolveObserveAutostart({ env: 'false', readConfig }), {
+    enabled: false,
+    source: 'env',
+  });
+});
+
+test('resolveObserveAutostart: env "1"/"true" forces on over config false', () => {
+  const readConfig = () => ({ observe: { autoStart: false } });
+  assert.deepEqual(resolveObserveAutostart({ env: '1', readConfig }), {
+    enabled: true,
+    source: 'env',
+  });
+  assert.deepEqual(resolveObserveAutostart({ env: 'true', readConfig }), {
+    enabled: true,
+    source: 'env',
+  });
+});
+
+test('resolveObserveAutostart: unset env falls through to config', () => {
+  const r = resolveObserveAutostart({
+    env: undefined,
+    readConfig: () => ({ observe: { autoStart: false } }),
+  });
+  assert.deepEqual(r, { enabled: false, source: 'config' });
+});
+
+test('resolveObserveAutostart: no config / non-boolean value → default true', () => {
+  assert.deepEqual(resolveObserveAutostart({ env: undefined, readConfig: () => null }), {
+    enabled: true,
+    source: 'default',
+  });
+  assert.deepEqual(
+    resolveObserveAutostart({
+      env: undefined,
+      readConfig: () => ({ observe: { autoStart: 'nope' } }),
+    }),
+    { enabled: true, source: 'default' },
+  );
+});
+
+test('resolveObservePort: valid env wins over config', () => {
+  const r = resolveObservePort({
+    env: '51888',
+    readConfig: () => ({ observe: { port: 51999 } }),
+  });
+  assert.deepEqual(r, { port: 51888, source: 'env' });
+});
+
+test('resolveObservePort: invalid env falls through to config', () => {
+  const r = resolveObservePort({
+    env: 'abc',
+    readConfig: () => ({ observe: { port: 51999 } }),
+  });
+  assert.deepEqual(r, { port: 51999, source: 'config' });
+});
+
+test('resolveObservePort: invalid config port falls through to default', () => {
+  assert.deepEqual(
+    resolveObservePort({ env: undefined, readConfig: () => ({ observe: { port: 0 } }) }),
+    { port: DEFAULT_OBSERVE_PORT, source: 'default' },
+  );
+  assert.deepEqual(
+    resolveObservePort({ env: undefined, readConfig: () => ({ observe: { port: 99999 } }) }),
+    { port: DEFAULT_OBSERVE_PORT, source: 'default' },
+  );
+  assert.deepEqual(
+    resolveObservePort({ env: undefined, readConfig: () => ({ observe: { port: 7.5 } }) }),
+    { port: DEFAULT_OBSERVE_PORT, source: 'default' },
+  );
+});
+
+test('resolveObservePort: no env, no config → default 7333', () => {
+  assert.deepEqual(resolveObservePort({ env: undefined, readConfig: () => null }), {
+    port: 7333,
+    source: 'default',
+  });
+  assert.equal(DEFAULT_OBSERVE_PORT, 7333);
+});

--- a/scripts/cdp-bridge/test/unit/observe-restart-action.test.js
+++ b/scripts/cdp-bridge/test/unit/observe-restart-action.test.js
@@ -63,3 +63,16 @@ test('stop closes the listening port while the process stays alive', async () =>
   // refuse connections (fetch rejects with ECONNREFUSED under the hood).
   await assert.rejects(fetch(`${url}/`, { signal: AbortSignal.timeout(2000) }));
 });
+
+test('stop racing a pending start closes the server instead of orphaning it', async () => {
+  // Deliberately NOT awaited: stop is issued while start's listen() is pending.
+  const startP = startObserveServer();
+  const stopP = observeHandler({ action: 'stop' });
+  const [startRes] = await Promise.all([startP, stopP]);
+  // After both settle nothing may be listening on the port start resolved to.
+  await assert.rejects(
+    fetch(`http://127.0.0.1:${startRes.port}/`, { signal: AbortSignal.timeout(2000) }),
+  );
+  const status = parse(await observeHandler({ action: 'status' }));
+  assert.equal(status.data.running, false);
+});

--- a/scripts/cdp-bridge/test/unit/observe-restart-action.test.js
+++ b/scripts/cdp-bridge/test/unit/observe-restart-action.test.js
@@ -48,3 +48,18 @@ test('startObserveServer is idempotent and returns the same port', async () => {
   assert.equal(a.port, b.port);
   await observeHandler({ action: 'stop' });
 });
+
+test('stop closes the listening port while the process stays alive', async () => {
+  const start = parse(await observeHandler({ action: 'start' }));
+  assert.equal(start.data.running, true);
+  const url = start.data.url;
+  // Listening while running: any HTTP status proves the socket is open
+  // (200 = SPA served, 503 = SPA bundle not built in this checkout).
+  const before = await fetch(`${url}/`, { signal: AbortSignal.timeout(2000) });
+  assert.ok([200, 503].includes(before.status), `unexpected status ${before.status}`);
+  const stop = parse(await observeHandler({ action: 'stop' }));
+  assert.equal(stop.data.running, false);
+  // After a tool-level stop — with this process still alive — the port must
+  // refuse connections (fetch rejects with ECONNREFUSED under the hood).
+  await assert.rejects(fetch(`${url}/`, { signal: AbortSignal.timeout(2000) }));
+});

--- a/scripts/cdp-bridge/test/unit/observe-restart-action.test.js
+++ b/scripts/cdp-bridge/test/unit/observe-restart-action.test.js
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { observeHandler, startObserveServer } from '../../dist/tools/observe.js';
+import { recorder } from '../../dist/observability/recorder.js';
+
+// Pin a unique port for this file so parallel test files can't collide on the
+// default 7333 (which would flake via the EADDRINUSE ephemeral fallback).
+process.env.RN_AGENT_OBSERVE_PORT = '51733';
+
+function parse(res) {
+  return JSON.parse(res.content[0].text);
+}
+
+test('restart on a running server keeps the recorder timeline and serves again', async () => {
+  recorder.record({ tool: 'device_press', params: { testID: 'x' }, status: 'PASS', latencyMs: 5 });
+  const before = recorder.snapshot().length;
+  assert.ok(before >= 1, 'recorder has at least the seeded event');
+
+  const start = parse(await observeHandler({ action: 'start' }));
+  assert.equal(start.ok, true);
+  assert.equal(start.data.port, 51733);
+
+  const restart = parse(await observeHandler({ action: 'restart' }));
+  assert.equal(restart.ok, true);
+  assert.equal(restart.data.running, true);
+  assert.match(restart.data.url, /^http:\/\/127\.0\.0\.1:\d+$/);
+
+  // The module-global recorder survives the HTTP server restart.
+  assert.equal(recorder.snapshot().length, before);
+
+  // The restarted server actually serves.
+  const status = parse(await observeHandler({ action: 'status' }));
+  assert.equal(status.data.running, true);
+
+  await observeHandler({ action: 'stop' });
+});
+
+test('restart when nothing is running starts fresh', async () => {
+  const restart = parse(await observeHandler({ action: 'restart' }));
+  assert.equal(restart.ok, true);
+  assert.equal(restart.data.running, true);
+  await observeHandler({ action: 'stop' });
+});
+
+test('startObserveServer is idempotent and returns the same port', async () => {
+  const a = await startObserveServer();
+  const b = await startObserveServer();
+  assert.equal(a.port, b.port);
+  await observeHandler({ action: 'stop' });
+});

--- a/scripts/cdp-bridge/test/unit/observe-state-file.test.js
+++ b/scripts/cdp-bridge/test/unit/observe-state-file.test.js
@@ -1,0 +1,63 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Redirect the state dir BEFORE importing the module under test —
+// getStateDir() reads XDG_STATE_HOME at call time, but keeping the env set
+// for the whole file is the simplest correct setup.
+const stateHome = mkdtempSync(join(tmpdir(), 'rn-observe-state-'));
+process.env.XDG_STATE_HOME = stateHome;
+
+const { observeStatePath, writeObserveState, removeObserveState } = await import(
+  '../../dist/observability/observe-state.js'
+);
+
+const fakeRoot = '/Users/someone/projects/my app';
+
+test('writeObserveState writes an atomic per-project state file', () => {
+  writeObserveState('http://127.0.0.1:7333', 7333, fakeRoot, () => new Date('2026-07-02T10:00:00Z'));
+  const p = observeStatePath(fakeRoot);
+  assert.ok(p.startsWith(join(stateHome, 'rn-dev-agent', 'observe')), p);
+  assert.ok(existsSync(p));
+  const state = JSON.parse(readFileSync(p, 'utf8'));
+  assert.deepEqual(state, {
+    url: 'http://127.0.0.1:7333',
+    port: 7333,
+    pid: process.pid,
+    projectRoot: fakeRoot,
+    startedAt: '2026-07-02T10:00:00.000Z',
+  });
+});
+
+test('project roots with unsafe characters are sanitized in the filename', () => {
+  const p = observeStatePath('/a/b?c:d e');
+  const base = p.split('/').pop();
+  assert.match(base, /^[A-Za-z0-9._-]+\.json$/);
+});
+
+test('removeObserveState deletes only a file owned by this pid', () => {
+  const p = observeStatePath(fakeRoot);
+  // Owned by us (written in the first test) → deleted.
+  removeObserveState(fakeRoot);
+  assert.ok(!existsSync(p));
+
+  // Owned by another live session → left alone.
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(
+    p,
+    JSON.stringify({ url: 'x', port: 1, pid: process.pid + 1, projectRoot: fakeRoot, startedAt: 'x' }),
+  );
+  removeObserveState(fakeRoot);
+  assert.ok(existsSync(p), 'foreign-pid state file must not be deleted');
+});
+
+test('null project root is a silent no-op', () => {
+  writeObserveState('http://127.0.0.1:7333', 7333, null);
+  removeObserveState(null);
+});
+
+test('cleanup', () => {
+  rmSync(stateHome, { recursive: true, force: true });
+});

--- a/scripts/cdp-bridge/test/unit/observe-state-file.test.js
+++ b/scripts/cdp-bridge/test/unit/observe-state-file.test.js
@@ -10,14 +10,18 @@ import { tmpdir } from 'node:os';
 const stateHome = mkdtempSync(join(tmpdir(), 'rn-observe-state-'));
 process.env.XDG_STATE_HOME = stateHome;
 
-const { observeStatePath, writeObserveState, removeObserveState } = await import(
-  '../../dist/observability/observe-state.js'
-);
+const { observeStatePath, writeObserveState, removeObserveState } =
+  await import('../../dist/observability/observe-state.js');
 
 const fakeRoot = '/Users/someone/projects/my app';
 
 test('writeObserveState writes an atomic per-project state file', () => {
-  writeObserveState('http://127.0.0.1:7333', 7333, fakeRoot, () => new Date('2026-07-02T10:00:00Z'));
+  writeObserveState(
+    'http://127.0.0.1:7333',
+    7333,
+    fakeRoot,
+    () => new Date('2026-07-02T10:00:00Z'),
+  );
   const p = observeStatePath(fakeRoot);
   assert.ok(p.startsWith(join(stateHome, 'rn-dev-agent', 'observe')), p);
   assert.ok(existsSync(p));
@@ -47,7 +51,13 @@ test('removeObserveState deletes only a file owned by this pid', () => {
   mkdirSync(dirname(p), { recursive: true });
   writeFileSync(
     p,
-    JSON.stringify({ url: 'x', port: 1, pid: process.pid + 1, projectRoot: fakeRoot, startedAt: 'x' }),
+    JSON.stringify({
+      url: 'x',
+      port: 1,
+      pid: process.pid + 1,
+      projectRoot: fakeRoot,
+      startedAt: 'x',
+    }),
   );
   removeObserveState(fakeRoot);
   assert.ok(existsSync(p), 'foreign-pid state file must not be deleted');


### PR DESCRIPTION
## Summary

PR 1 of 2 from the approved spec [`docs/superpowers/specs/2026-07-02-observe-ui-autostart-design.md`](docs/superpowers/specs/2026-07-02-observe-ui-autostart-design.md) (PR 2 will be the web-UI overhaul).

- **Autostart:** the observe web UI now starts automatically when the MCP worker boots in an RN project — non-fatal (a failure logs a warning, never breaks MCP boot), fire-and-forget, and only when a project root is detected. The supervisor stays socket-free.
- **Stable URL:** default port is now **7333** (`http://127.0.0.1:7333`, bookmarkable), with ephemeral fallback on `EADDRINUSE`. Precedence: `RN_AGENT_OBSERVE_PORT` env > `.rn-agent/config.json` `observe.port` > 7333.
- **Opt-out config:** new `.rn-agent/config.json` block `{ "observe": { "autoStart": false, "port": N } }` + `RN_AGENT_OBSERVE_AUTOSTART` env override — same env > config > default pattern (and test seams) as `cdp.autoConnect`.
- **`restart` action:** the `observe` tool grew `restart` (stop + fresh server; the event timeline survives because the recorder is module-global). `stop` is session-scoped.
- **State file:** the live URL/port/pid is recorded per-project via the hardened GH #383 state-file helpers, removed on stop/exit with a pid guard.
- **SessionStart notice:** `detect-rn-project.sh` prints the expected observe URL (optimistic per spec D10); `commands/observe.md` rewritten with `$ARGUMENTS` routing for `stop`/`restart`.

## Test plan

- 20 new unit tests (node:test against dist): resolver precedence, restart semantics, stop-closes-port-while-alive, state-file write/pid-guard/cleanup, autostart gating (no root / disabled / start-throws).
- Full suite green: 2622 pass / 0 fail; oxlint + oxfmt clean; dist rebuilt and committed.
- Live-verified by driving the built worker from a temp RN project: autostart on 7333 + SSE snapshot, state file content, exit cleanup, config opt-out, env-beats-config on port 51740 — 6/6 scenarios pass.

Executed via subagent-driven development with per-task spec+quality reviews and a final whole-branch review (verdict: ready to merge, no Critical/Important findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)