### PR TITLE
feat: command-surface gate — /health.commands enumeration, tiered artifact rebuild, typed UNSUPPORTED_COMMAND (#418)

### DIFF
--- a/.changeset/gh-418-command-surface-gate.md
+++ b/.changeset/gh-418-command-surface-gate.md
@@ -1,0 +1,21 @@
+---
+"rn-dev-agent-cdp": minor
+"rn-dev-agent-plugin": minor
+---
+
+Command-surface gate (#418, B235): both native runners enumerate their supported
+commands in `/health.commands` (iOS derives it from `CommandType.allCases`, Android
+from a sync-tested `SUPPORTED_COMMANDS` list) and the liveness gate classifies a
+runner missing any bridge-required verb as stale (`missing-commands`). Remediation
+is tiered: `device_snapshot action=open` auto-invalidates the stale artifact and
+rebuilds — iOS deletes DerivedData and cold-builds (once per plugin version, behind a
+checkout-scoped build lock), Android deletes the runner APKs so self-install
+Gradle-rebuilds; mid-flow device tools refuse fast with `RUNNER_COMMANDS_STALE`
+instead of silently building. An unknown verb reaching the iOS runner now returns a
+typed `UNSUPPORTED_COMMAND` error instead of a raw Swift decode failure. Root cause
+of B235 fixed: the explicit iOS keyboard-dismiss path posted `dismissKeyboard`,
+which no Swift artifact ever accepted — the wire verb is now `keyboardDismiss`.
+`cdp_status` surfaces `deviceSession.runnerProtocol.missingCommands`. Hardening
+from per-edit review: the iOS runner validates client-supplied Content-Length
+(400 on invalid instead of crash/hang) and Android foregrounds alias verbs
+(press/fill/scroll) before dispatch.

--- a/docs/superpowers/plans/2026-07-03-418-command-surface-gate.md
+++ b/docs/superpowers/plans/2026-07-03-418-command-surface-gate.md
@@ -1,0 +1,1655 @@
+# #418 Command-Surface Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A stale runner build artifact that lacks newer commands is caught by the liveness gate (`missing-commands`), auto-rebuilt at session open, refused fast mid-flow (`RUNNER_COMMANDS_STALE`), and — if a verb ever reaches a runner that doesn't know it — rejected with a typed `UNSUPPORTED_COMMAND` instead of a raw Swift decode error. Includes the root-cause fix for B235: the iOS keyboard-dismiss wire verb never matched the Swift enum.
+
+**Architecture:** Both native runners enumerate their supported commands in `/health.commands` (iOS derives it from `CommandType.allCases`; Android from a `SUPPORTED_COMMANDS` list sync-tested against the dispatcher's `when`). The TS bridge keeps per-platform `REQUIRED_*_COMMANDS` lists in `protocol.ts`; `classifyRunnerCompatibility` gains a `missing-commands` incompatibility reason (strict when the field is absent — every pre-#418 artifact). Remediation is tiered: respawn (cheap, fixes a stale *process*), then artifact invalidation + cold rebuild at `device_snapshot action=open` only (fixes a stale *artifact*), never a silent multi-minute build mid-flow.
+
+**Tech Stack:** TypeScript (Node 22, `node:test`), Swift (XCTest runner), Kotlin (UIAutomator2 runner), changesets.
+
+**Spec:** `docs/superpowers/specs/2026-07-03-418-command-surface-gate-design.md` (committed on this branch).
+
+> **Amendments applied from the multi-LLM plan review (2026-07-03, Codex + Claude Opus coordinator; Gemini CLI unavailable).** BLOCKER 1: Android remediation was non-functional as planned — `resolveAndroidInstallAction` only Gradle-builds when the APKs are ABSENT, so Task 8 now has a real APK-invalidation tier gated behind an open-only flag, and Android `missing-commands` failures surface `RUNNER_COMMANDS_STALE` (not `RUNNER_PROTOCOL_MISMATCH`). BLOCKER 2: `rmSync(DerivedData)` is plugin-checkout-scoped while the device lock is UDID-scoped — Task 7 now reaps before deleting and serializes invalidate+rebuild behind a checkout-scoped mkdir lock, plus a per-plugin-version rebuild budget so a broken checkout can't loop cold builds. SHOULD-FIXes folded in: invalidate-before-first-spawn at open (no wasted stale respawn), raw-value-aware Swift sync regex (Task 5), two additional Android fixture migrations (`runners/rn-android-runner-client.test.js`, `gh-243-android-runner-health.test.js`), stale `dismissKeyboard` reference scrub (Task 1). Rejected on cross-check: exhaustive `satisfies` completeness assertion (REQUIRED is a curated subset by design).
+
+## Global Constraints
+
+- Branch: `feat/418-command-surface-gate` (already checked out; spec committed).
+- All TS work under `scripts/cdp-bridge/`. Tests import from `dist/`, so run `npm test` (which runs `tsc` first) — from `scripts/cdp-bridge/`.
+- Full suite green after every task: `cd scripts/cdp-bridge && npm test` → ~2612+ pass, 0 fail.
+- Use explicit type imports (`import type { ... }`). No unnecessary comments.
+- Commits are signed (`git commit -S`), small, one per task, message ends with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- NO protocol version bump — the `/health.commands` field is additive.
+- The `capabilities` field keeps feature-flag semantics (`QUIESCENCE_BYPASS`); commands do NOT go there.
+- iOS wire verbs after this plan: `tap, type, drag, longPress, pinch, snapshot, screenshot, back, keyboardDismiss`. Android: same but `dismissKeyboard` instead of `keyboardDismiss`.
+- `dist/` is tracked — rebuild and stage it in the final task (Task 10), not per-task.
+
+---
+
+### Task 1: Fix the iOS keyboard-dismiss wire verb (B235 root cause)
+
+The TS bridge posts `{command: "dismissKeyboard"}` to the iOS runner, but the Swift enum case has been `keyboardDismiss` since the original import — the explicit iOS keyboard-dismiss path has never decoded on ANY artifact. Fix the verb TS-side so old and new artifacts both accept it.
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/agent-device-wrapper.ts:331-332` (buildRunIOSArgs `case 'keyboard'`)
+- Modify: `scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts:743` (RunIOSArgs command union)
+- Test: `scripts/cdp-bridge/test/unit/gh-418-ios-keyboard-verb.test.js`
+
+**Interfaces:**
+- Produces: `RunIOSArgs['command']` union member `'keyboardDismiss'` (replaces `'dismissKeyboard'`). Task 2's `REQUIRED_IOS_COMMANDS` includes `'keyboardDismiss'` and is `satisfies`-tied to this union.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/cdp-bridge/test/unit/gh-418-ios-keyboard-verb.test.js`:
+
+```js
+// GH #418 (B235 root cause): the iOS keyboard-dismiss wire verb must be the
+// Swift enum's `keyboardDismiss` — 'dismissKeyboard' has never decoded on any
+// iOS artifact. Android's wire verb stays 'dismissKeyboard' (Kotlin when-label).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildRunIOSArgs, buildRunAndroidArgs } from '../../dist/agent-device-wrapper.js';
+
+test('gh-418: iOS keyboard CLI verb maps to keyboardDismiss on the wire', () => {
+  assert.equal(buildRunIOSArgs(['keyboard']).command, 'keyboardDismiss');
+});
+
+test('gh-418: Android keyboard CLI verbs keep dismissKeyboard on the wire', () => {
+  assert.equal(buildRunAndroidArgs(['keyboard']).command, 'dismissKeyboard');
+  assert.equal(buildRunAndroidArgs(['dismissKeyboard']).command, 'dismissKeyboard');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/gh-418-ios-keyboard-verb.test.js`
+Expected: FAIL — `'dismissKeyboard' !== 'keyboardDismiss'` on the first test.
+
+- [ ] **Step 3: Fix the verb in both files**
+
+In `scripts/cdp-bridge/src/agent-device-wrapper.ts` (the `case 'keyboard':` inside `buildRunIOSArgs`), change:
+
+```ts
+    case 'keyboard':
+      return { command: 'dismissKeyboard', ...(bundleId ? { bundleId } : {}) };
+```
+
+to:
+
+```ts
+    case 'keyboard':
+      // B235/#418: the Swift enum case is keyboardDismiss; 'dismissKeyboard'
+      // (the Android wire verb) never decoded on iOS.
+      return { command: 'keyboardDismiss', ...(bundleId ? { bundleId } : {}) };
+```
+
+In `scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts` (RunIOSArgs union), change the member `| 'dismissKeyboard'` to `| 'keyboardDismiss'`.
+
+Leave `buildRunAndroidArgs` (`case 'keyboard': case 'dismissKeyboard':` → `'dismissKeyboard'`) untouched.
+
+Also scrub the two stale references that would invite the bad verb back (review NICE-TO-HAVE): the historical-endpoints comment near `scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts:461` (change `/dismissKeyboard` to `/keyboardDismiss` in the comment) and `scripts/rn-fast-runner/IMPORT_NOTES.md:13` (annotate that the iOS wire verb is `keyboardDismiss`).
+
+- [ ] **Step 4: Run tests to verify they pass (and nothing else broke)**
+
+Run: `cd scripts/cdp-bridge && npm test`
+Expected: all pass (the pre-existing suite has no assertion on the old iOS verb — verified via `grep -rln dismissKeyboard test/` → no matches; if `tsc` flags any other `'dismissKeyboard'` usage typed against RunIOSArgs, update it to `'keyboardDismiss'`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/cdp-bridge/src/agent-device-wrapper.ts scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts scripts/cdp-bridge/test/unit/gh-418-ios-keyboard-verb.test.js
+git commit -S -m "fix(device): iOS keyboard-dismiss wire verb is keyboardDismiss, not dismissKeyboard (B235 root cause, #418)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: protocol.ts — REQUIRED command lists + `missing-commands` classification + error codes
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/runners/protocol.ts`
+- Modify: `scripts/cdp-bridge/src/types.ts:214` (ToolErrorCode union)
+- Test: `scripts/cdp-bridge/test/unit/gh-418-command-surface-classify.test.js`
+
+**Interfaces:**
+- Consumes: `RunIOSArgs['command']` from Task 1; `RunAndroidArgs['command']` (existing).
+- Produces:
+  - `export const REQUIRED_IOS_COMMANDS: readonly string[]` / `REQUIRED_ANDROID_COMMANDS` (protocol.ts)
+  - `classifyRunnerCompatibility(health: { protocolVersion?: number; runnerVersion?: string; commands?: string[] }, pluginVersion: string | null, requiredCommands?: readonly string[]): RunnerCompatibility` — third param optional, so all existing call sites keep compiling.
+  - `RunnerIncompatibilityReason` gains `'missing-commands'`; the `compatible: false` branch gains `missing?: string[]`.
+  - `ToolErrorCode` gains `'UNSUPPORTED_COMMAND'` and `'RUNNER_COMMANDS_STALE'`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/cdp-bridge/test/unit/gh-418-command-surface-classify.test.js`:
+
+```js
+// GH #418: classifier matrix for the command-surface check. Strict on absence:
+// a runner not advertising `commands` (every pre-#418 artifact) is
+// 'missing-commands' with the full required list as `missing`.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classifyRunnerCompatibility,
+  REQUIRED_IOS_COMMANDS,
+  REQUIRED_ANDROID_COMMANDS,
+} from '../../dist/runners/protocol.js';
+
+const FULL = [...REQUIRED_IOS_COMMANDS];
+
+test('gh-418 classify: commands ⊇ required → compatible', () => {
+  assert.deepEqual(
+    classifyRunnerCompatibility({ protocolVersion: 1, commands: FULL }, null, REQUIRED_IOS_COMMANDS),
+    { compatible: true },
+  );
+});
+
+test('gh-418 classify: extra advertised commands are fine', () => {
+  assert.deepEqual(
+    classifyRunnerCompatibility(
+      { protocolVersion: 1, commands: [...FULL, 'rotate', 'alert'] },
+      null,
+      REQUIRED_IOS_COMMANDS,
+    ),
+    { compatible: true },
+  );
+});
+
+test('gh-418 classify: one missing verb → missing-commands naming it', () => {
+  const withoutKeyboard = FULL.filter((c) => c !== 'keyboardDismiss');
+  assert.deepEqual(
+    classifyRunnerCompatibility(
+      { protocolVersion: 1, commands: withoutKeyboard },
+      null,
+      REQUIRED_IOS_COMMANDS,
+    ),
+    { compatible: false, reason: 'missing-commands', missing: ['keyboardDismiss'] },
+  );
+});
+
+test('gh-418 classify: absent commands field → missing-commands with full list (strict)', () => {
+  assert.deepEqual(
+    classifyRunnerCompatibility({ protocolVersion: 1 }, null, REQUIRED_IOS_COMMANDS),
+    { compatible: false, reason: 'missing-commands', missing: FULL },
+  );
+});
+
+test('gh-418 classify: no requiredCommands param → commands not enforced (back-compat)', () => {
+  assert.deepEqual(classifyRunnerCompatibility({ protocolVersion: 1 }, null), {
+    compatible: true,
+  });
+});
+
+test('gh-418 classify: protocol/skew reasons win over missing-commands', () => {
+  assert.deepEqual(classifyRunnerCompatibility({}, null, REQUIRED_IOS_COMMANDS), {
+    compatible: false,
+    reason: 'legacy',
+  });
+  assert.deepEqual(
+    classifyRunnerCompatibility(
+      { protocolVersion: 1, runnerVersion: '0.0.1' },
+      '0.99.0',
+      REQUIRED_IOS_COMMANDS,
+    ),
+    { compatible: false, reason: 'version-skew' },
+  );
+});
+
+test('gh-418: REQUIRED lists cover both platforms, non-empty, keyboard verbs differ', () => {
+  assert.ok(REQUIRED_IOS_COMMANDS.includes('keyboardDismiss'));
+  assert.ok(!REQUIRED_IOS_COMMANDS.includes('dismissKeyboard'));
+  assert.ok(REQUIRED_ANDROID_COMMANDS.includes('dismissKeyboard'));
+  assert.ok(REQUIRED_IOS_COMMANDS.length >= 9 && REQUIRED_ANDROID_COMMANDS.length >= 9);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/gh-418-command-surface-classify.test.js`
+Expected: FAIL — build error (`REQUIRED_IOS_COMMANDS` not exported) or missing-commands cases failing.
+
+- [ ] **Step 3: Implement in protocol.ts and types.ts**
+
+In `scripts/cdp-bridge/src/runners/protocol.ts`, extend the reason/compat types and classifier, and add the lists (type-only imports of the client unions — safe despite the runtime import cycle direction, since `import type` is erased):
+
+```ts
+import type { RunIOSArgs } from './rn-fast-runner-client.js';
+import type { RunAndroidArgs } from './rn-android-runner-client.js';
+
+export type RunnerIncompatibilityReason =
+  | 'legacy'
+  | 'protocol-older'
+  | 'protocol-newer'
+  | 'version-skew'
+  | 'missing-commands';
+
+export type RunnerCompatibility =
+  | { compatible: true }
+  | { compatible: false; reason: RunnerIncompatibilityReason; missing?: string[] };
+
+// GH #418: every wire verb the bridge can POST to each runner's /command.
+// The satisfies tie makes "verb added to the client union but not here" a
+// compile error; gh-418-command-surface-sync.test.js enforces the native side.
+export const REQUIRED_IOS_COMMANDS = [
+  'tap',
+  'type',
+  'drag',
+  'longPress',
+  'pinch',
+  'snapshot',
+  'screenshot',
+  'back',
+  'keyboardDismiss',
+] as const satisfies readonly RunIOSArgs['command'][];
+
+export const REQUIRED_ANDROID_COMMANDS = [
+  'tap',
+  'type',
+  'drag',
+  'longPress',
+  'pinch',
+  'snapshot',
+  'screenshot',
+  'back',
+  'dismissKeyboard',
+] as const satisfies readonly RunAndroidArgs['command'][];
+
+export function classifyRunnerCompatibility(
+  health: { protocolVersion?: number; runnerVersion?: string; commands?: string[] },
+  pluginVersion: string | null,
+  requiredCommands?: readonly string[],
+): RunnerCompatibility {
+  if (health.protocolVersion === undefined) return { compatible: false, reason: 'legacy' };
+  if (health.protocolVersion < MIN_SUPPORTED_RUNNER_PROTOCOL) {
+    return { compatible: false, reason: 'protocol-older' };
+  }
+  if (health.protocolVersion > RUNNER_PROTOCOL_VERSION) {
+    return { compatible: false, reason: 'protocol-newer' };
+  }
+  if (
+    pluginVersion !== null &&
+    health.runnerVersion !== undefined &&
+    health.runnerVersion !== pluginVersion
+  ) {
+    return { compatible: false, reason: 'version-skew' };
+  }
+  // GH #418: strict on absence — an artifact that doesn't enumerate commands
+  // predates enumeration and by definition predates any newer verb.
+  if (requiredCommands !== undefined) {
+    const advertised = new Set(health.commands ?? []);
+    const missing = requiredCommands.filter((c) => !advertised.has(c));
+    if (missing.length > 0) {
+      return { compatible: false, reason: 'missing-commands', missing };
+    }
+  }
+  return { compatible: true };
+}
+```
+
+(Keep `RUNNER_PROTOCOL_VERSION`, `MIN_SUPPORTED_RUNNER_PROTOCOL`, `getPluginVersion`, `_setPluginVersionForTest` unchanged.)
+
+In `scripts/cdp-bridge/src/types.ts`, extend the ToolErrorCode union (append after the `'INVALID_APPID'` block, matching the file's comment style):
+
+```ts
+  // GH #418: command-surface gate.
+  | 'UNSUPPORTED_COMMAND' // runner rejected a verb its artifact predates (typed by the runner)
+  | 'RUNNER_COMMANDS_STALE' // liveness gate: artifact lacks required commands; re-open to rebuild
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/gh-418-command-surface-classify.test.js && node --test test/unit/gh-383-protocol-sync.test.js`
+Expected: both PASS (gh-383 classify tests keep passing — the third param is optional).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/cdp-bridge/src/runners/protocol.ts scripts/cdp-bridge/src/types.ts scripts/cdp-bridge/test/unit/gh-418-command-surface-classify.test.js
+git commit -S -m "feat(protocol): REQUIRED command lists + missing-commands classification + typed codes (#418)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Swift runner — CaseIterable, /health.commands, typed UNSUPPORTED_COMMAND
+
+**Files:**
+- Modify: `scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RnFastRunnerTests+Models.swift` (enum + Response)
+- Modify: `scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RnFastRunnerTests+Transport.swift` (health emission + pre-decode)
+- Create: `scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/CommandSurfaceTests.swift` (the UITests target uses `PBXFileSystemSynchronizedRootGroup` — new files are picked up without a pbxproj edit)
+
+**Interfaces:**
+- Produces (wire): `/health` gains `commands: [String]` (= `CommandType.allCases.map(\.rawValue)`); unknown `/command` verb returns `{ok:false, error:{code:"UNSUPPORTED_COMMAND", message:"Unsupported iOS runner command: <verb> — …"}}` with HTTP 200. Tasks 5/6 consume both.
+
+- [ ] **Step 1: Write the failing Swift test**
+
+Create `scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/CommandSurfaceTests.swift`:
+
+```swift
+import XCTest
+
+// GH #418: the compiled CommandType enum IS the iOS command surface. These
+// pure-logic tests pin the bridge-required verbs and the alias trap (B235).
+final class CommandSurfaceTests: XCTestCase {
+  func testAllCasesCoverBridgeRequiredVerbs() {
+    let advertised = Set(CommandType.allCases.map(\.rawValue))
+    let required: Set<String> = [
+      "tap", "type", "drag", "longPress", "pinch",
+      "snapshot", "screenshot", "back", "keyboardDismiss",
+    ]
+    XCTAssertTrue(
+      required.isSubset(of: advertised),
+      "CommandType missing: \(required.subtracting(advertised))"
+    )
+  }
+
+  func testAndroidKeyboardVerbIsNotAnIOSCase() {
+    XCTAssertNil(CommandType(rawValue: "dismissKeyboard"))
+    XCTAssertNil(CommandType(rawValue: "definitelyBogusVerb"))
+  }
+}
+```
+
+(This fails to COMPILE until `CommandType` adopts `CaseIterable` — that is the failing state.)
+
+- [ ] **Step 2: Verify it fails to build**
+
+Run (works without a booted simulator):
+```bash
+cd scripts/rn-fast-runner/RnFastRunner && xcodebuild build-for-testing \
+  -project RnFastRunner.xcodeproj -scheme RnFastRunner \
+  -destination "generic/platform=iOS Simulator" \
+  -derivedDataPath ../build/DerivedData-taskcheck 2>&1 | tail -5
+```
+Expected: BUILD FAILED — `type 'CommandType' has no member 'allCases'`.
+
+- [ ] **Step 3: Implement the Swift changes**
+
+In `RnFastRunnerTests+Models.swift`:
+
+1. Enum declaration: `enum CommandType: String, Codable {` → `enum CommandType: String, Codable, CaseIterable {`
+2. `Response` gains a `commands` field. Full updated struct (only `commands` lines are new):
+
+```swift
+struct Response: Codable {
+  let ok: Bool
+  let v: Int
+  let protocolVersion: Int?
+  let runnerVersion: String?
+  let capabilities: [String]?
+  let commands: [String]?
+  let data: DataPayload?
+  let error: ErrorPayload?
+
+  init(
+    ok: Bool,
+    data: DataPayload? = nil,
+    error: ErrorPayload? = nil,
+    protocolVersion: Int? = nil,
+    runnerVersion: String? = nil,
+    capabilities: [String]? = nil,
+    commands: [String]? = nil
+  ) {
+    self.ok = ok
+    self.v = RunnerProtocol.version
+    self.data = data
+    self.error = error
+    self.protocolVersion = protocolVersion
+    self.runnerVersion = runnerVersion
+    self.capabilities = capabilities
+    self.commands = commands
+  }
+}
+```
+
+In `RnFastRunnerTests+Transport.swift`:
+
+1. Health response (inside `if self.isHealthRequest(combined)`), add the `commands` argument:
+
+```swift
+        let response = self.jsonResponse(
+          status: 200,
+          response: Response(
+            ok: true,
+            protocolVersion: RunnerProtocol.version,
+            runnerVersion: RunnerEnv.pluginVersion(),
+            capabilities: QuiescenceStatus.current().capabilities,
+            commands: CommandType.allCases.map(\.rawValue)
+          )
+        )
+```
+
+2. In `handleRequestBody`, pre-decode the verb before the full `Command` decode. Insert immediately before the existing `do { let command = try JSONDecoder().decode(Command.self, from: data)` block:
+
+```swift
+    struct CommandTypeProbe: Decodable { let command: String }
+    if let probe = try? JSONDecoder().decode(CommandTypeProbe.self, from: data),
+       CommandType(rawValue: probe.command) == nil {
+      // GH #418: a verb this artifact doesn't know is a typed refusal, not a
+      // dataCorrupted decode error (B235). Mirrors the Android runner's shape.
+      return (
+        jsonResponse(status: 200, response: Response(
+          ok: false,
+          error: ErrorPayload(
+            code: "UNSUPPORTED_COMMAND",
+            message: "Unsupported iOS runner command: \(probe.command) — the runner artifact predates it; re-open the device session (device_snapshot action=open) to rebuild."
+          )
+        )),
+        false
+      )
+    }
+```
+
+(Any OTHER decode failure — malformed JSON, wrong field types — keeps today's 500 + raw error behavior.)
+
+- [ ] **Step 4: Verify it builds**
+
+Run the same `xcodebuild build-for-testing` command as Step 2.
+Expected: `** TEST BUILD SUCCEEDED **`. Then remove the throwaway DerivedData: `rm -rf scripts/rn-fast-runner/build/DerivedData-taskcheck`. (Running `CommandSurfaceTests` live happens in Task 11 alongside device verification; the compile gate is the fast check here.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RnFastRunnerTests+Models.swift scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RnFastRunnerTests+Transport.swift scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/CommandSurfaceTests.swift
+git commit -S -m "feat(rn-fast-runner): enumerate commands in /health + typed UNSUPPORTED_COMMAND (#418)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Kotlin runner — SUPPORTED_COMMANDS + /health.commands
+
+**Files:**
+- Modify: `scripts/rn-android-runner/app/src/androidTest/java/dev/lykhoyda/rndevagent/androidrunner/CommandDispatcher.kt`
+- Modify: `scripts/rn-android-runner/app/src/androidTest/java/dev/lykhoyda/rndevagent/androidrunner/CommandServer.kt`
+
+**Interfaces:**
+- Produces (wire): Android `/health` gains `commands: [...]` from `CommandDispatcher.SUPPORTED_COMMANDS`. Task 5's sync test asserts the list equals the dispatch `when`-labels; Task 8 consumes the field TS-side.
+
+- [ ] **Step 1: Add the list to CommandDispatcher**
+
+The Android runner has no JVM unit-test source set, so the failing check for this task is the Task 5 sync test; here the compile gate is the verification. Add a companion object to `CommandDispatcher` (immediately after the class's `init` block):
+
+```kotlin
+    companion object {
+        // GH #418: advertised in /health.commands. The Node sync test
+        // (cdp-bridge test/unit/gh-418-command-surface-sync.test.js) enforces
+        // that this list exactly matches the dispatch when-branches below.
+        val SUPPORTED_COMMANDS = listOf(
+            "snapshot", "tap", "press", "type", "fill", "drag", "swipe", "scroll",
+            "screenshot", "back", "dismissKeyboard", "keyboard", "longPress",
+            "pinch", "findText",
+        )
+    }
+```
+
+- [ ] **Step 2: Emit it from /health in CommandServer**
+
+In `CommandServer.kt`, the `/health` body currently reads:
+
+```kotlin
+            val body = JSONObject()
+                .put("ok", true)
+                .put("protocolVersion", RunnerProtocol.VERSION)
+                .put("capabilities", JSONArray())
+```
+
+Change to:
+
+```kotlin
+            val body = JSONObject()
+                .put("ok", true)
+                .put("protocolVersion", RunnerProtocol.VERSION)
+                .put("capabilities", JSONArray())
+                .put("commands", JSONArray(CommandDispatcher.SUPPORTED_COMMANDS))
+```
+
+- [ ] **Step 3: Compile check**
+
+Run: `cd scripts/rn-android-runner && ./gradlew :app:assembleDebugAndroidTest -q`
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/rn-android-runner/app/src/androidTest/java/dev/lykhoyda/rndevagent/androidrunner/CommandDispatcher.kt scripts/rn-android-runner/app/src/androidTest/java/dev/lykhoyda/rndevagent/androidrunner/CommandServer.kt
+git commit -S -m "feat(rn-android-runner): enumerate supported commands in /health (#418)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Tri-file command-surface sync test
+
+**Files:**
+- Test (create): `scripts/cdp-bridge/test/unit/gh-418-command-surface-sync.test.js`
+
+**Interfaces:**
+- Consumes: `REQUIRED_IOS_COMMANDS` / `REQUIRED_ANDROID_COMMANDS` (Task 2), Swift enum (Task 3), Kotlin list + when-labels (Task 4).
+
+- [ ] **Step 1: Write the test (passing if Tasks 1–4 are correct — it's the drift guard)**
+
+```js
+// GH #418: the runner command surface exists in THREE places — the Swift
+// CommandType enum (iOS), the Kotlin SUPPORTED_COMMANDS list (Android, which
+// must itself match the dispatcher when-branches), and the TS REQUIRED_*
+// lists the liveness gate enforces. Source-parsing guard, gh-383-sync style.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  REQUIRED_IOS_COMMANDS,
+  REQUIRED_ANDROID_COMMANDS,
+} from '../../dist/runners/protocol.js';
+
+const BRIDGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SWIFT_MODELS = join(
+  BRIDGE_ROOT, '..', 'rn-fast-runner', 'RnFastRunner', 'RnFastRunnerUITests',
+  'RnFastRunnerTests+Models.swift',
+);
+const KOTLIN_DISPATCHER = join(
+  BRIDGE_ROOT, '..', 'rn-android-runner', 'app', 'src', 'androidTest', 'java',
+  'dev', 'lykhoyda', 'rndevagent', 'androidrunner', 'CommandDispatcher.kt',
+);
+
+function swiftEnumRawValues() {
+  const src = readFileSync(SWIFT_MODELS, 'utf8');
+  const block = src.match(/enum CommandType[^{]*\{([\s\S]*?)\n\}/);
+  assert.ok(block, 'CommandType enum block not found in Models.swift');
+  // Review amendment: /health advertises .rawValue, so parse explicit raw
+  // values (`case foo = "bar"` → "bar"), falling back to the case name.
+  return [...block[1].matchAll(/case (\w+)(?:\s*=\s*"([^"]+)")?/g)].map((m) => m[2] ?? m[1]);
+}
+
+function kotlinSupportedList() {
+  const src = readFileSync(KOTLIN_DISPATCHER, 'utf8');
+  const m = src.match(/val SUPPORTED_COMMANDS = listOf\(([\s\S]*?)\)/);
+  assert.ok(m, 'SUPPORTED_COMMANDS not found in CommandDispatcher.kt');
+  return [...m[1].matchAll(/"(\w+)"/g)].map((x) => x[1]);
+}
+
+function kotlinWhenLabels() {
+  const src = readFileSync(KOTLIN_DISPATCHER, 'utf8');
+  const labels = [];
+  for (const line of src.split('\n')) {
+    const m = line.match(/^\s*((?:"\w+",\s*)*"\w+")\s*->/);
+    if (m) labels.push(...[...m[1].matchAll(/"(\w+)"/g)].map((x) => x[1]));
+  }
+  assert.ok(labels.length > 0, 'no dispatch when-labels found in CommandDispatcher.kt');
+  return labels;
+}
+
+test('gh-418 sync: Swift CommandType raw values cover REQUIRED_IOS_COMMANDS', () => {
+  const rawValues = new Set(swiftEnumRawValues());
+  const missing = REQUIRED_IOS_COMMANDS.filter((c) => !rawValues.has(c));
+  assert.deepEqual(missing, [], `Swift enum missing: ${missing.join(', ')}`);
+});
+
+test('gh-418 sync: Kotlin SUPPORTED_COMMANDS == dispatch when-labels', () => {
+  assert.deepEqual(
+    [...new Set(kotlinSupportedList())].sort(),
+    [...new Set(kotlinWhenLabels())].sort(),
+  );
+});
+
+test('gh-418 sync: Kotlin SUPPORTED_COMMANDS covers REQUIRED_ANDROID_COMMANDS', () => {
+  const supported = new Set(kotlinSupportedList());
+  const missing = REQUIRED_ANDROID_COMMANDS.filter((c) => !supported.has(c));
+  assert.deepEqual(missing, [], `Kotlin list missing: ${missing.join(', ')}`);
+});
+
+test('gh-418 sync: REQUIRED lists have no duplicates', () => {
+  for (const list of [REQUIRED_IOS_COMMANDS, REQUIRED_ANDROID_COMMANDS]) {
+    assert.equal(new Set(list).size, list.length);
+  }
+});
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/gh-418-command-surface-sync.test.js`
+Expected: PASS (4 tests). Sanity-check the guard bites: temporarily remove `"pinch"` from the Kotlin `SUPPORTED_COMMANDS`, re-run, expect the `==` test to FAIL, then restore it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/cdp-bridge/test/unit/gh-418-command-surface-sync.test.js
+git commit -S -m "test(sync): tri-file command-surface drift guard (#418)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: iOS probe parses commands; liveness gate classifies missing-commands
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts` (HttpProbeResult, defaultHttpProbe, FastRunnerLivenessDetail, probeFastRunnerLivenessDetailed)
+- Modify (test migration): `scripts/cdp-bridge/test/unit/fast-runner-liveness.test.js`, `scripts/cdp-bridge/test/unit/gh-383-ios-protocol-gate.test.js`, `scripts/cdp-bridge/test/unit/runners/gh-384-quiescence.test.js` — every injected `httpProbe` body that expects `'alive'` must now advertise the required commands.
+- Test (create): `scripts/cdp-bridge/test/unit/gh-418-ios-command-gate.test.js`
+
+**Interfaces:**
+- Consumes: `classifyRunnerCompatibility(health, plugin, REQUIRED_IOS_COMMANDS)` and `REQUIRED_IOS_COMMANDS` (Task 2).
+- Produces: `HttpProbeResult.commands?: string[]`; `FastRunnerLivenessDetail.missingCommands?: string[]` (set only when `staleReason === 'missing-commands'`). Task 7 and Task 9 consume `missingCommands`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/cdp-bridge/test/unit/gh-418-ios-command-gate.test.js`:
+
+```js
+// GH #418: the iOS liveness gate is strict about the command surface — a
+// healthy, protocol-current runner that does not advertise every
+// REQUIRED_IOS_COMMANDS verb is 'stale'/'missing-commands'.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  probeFastRunnerLivenessDetailed,
+  runIOS,
+  _setRunnerStateForTest,
+  _setFetchForTest,
+} from '../../dist/runners/rn-fast-runner-client.js';
+import { REQUIRED_IOS_COMMANDS } from '../../dist/runners/protocol.js';
+
+const STATE = { pid: 1, port: 22088, deviceId: 'U1', bundleId: 'com.example' };
+const deps = (probeBody, plugin = '0.99.0') => ({
+  getState: () => STATE,
+  processAlive: () => true,
+  httpProbe: async () => probeBody,
+  clearState: () => {},
+  pluginVersion: plugin,
+});
+const HEALTHY = { ok: true, status: 200, bodyOk: true, protocolVersion: 1 };
+
+test('gh-418 gate: full command surface → alive', async () => {
+  const d = await probeFastRunnerLivenessDetailed(
+    deps({ ...HEALTHY, commands: [...REQUIRED_IOS_COMMANDS] }),
+  );
+  assert.equal(d.liveness, 'alive');
+});
+
+test('gh-418 gate: absent commands field (pre-#418 artifact) → stale/missing-commands, full list', async () => {
+  const d = await probeFastRunnerLivenessDetailed(deps({ ...HEALTHY }));
+  assert.equal(d.liveness, 'stale');
+  assert.equal(d.staleReason, 'missing-commands');
+  assert.deepEqual(d.missingCommands, [...REQUIRED_IOS_COMMANDS]);
+});
+
+test('gh-418 gate: one verb missing → stale naming exactly it', async () => {
+  const d = await probeFastRunnerLivenessDetailed(
+    deps({ ...HEALTHY, commands: REQUIRED_IOS_COMMANDS.filter((c) => c !== 'keyboardDismiss') }),
+  );
+  assert.equal(d.staleReason, 'missing-commands');
+  assert.deepEqual(d.missingCommands, ['keyboardDismiss']);
+});
+
+test('gh-418: runIOS surfaces the runner-typed UNSUPPORTED_COMMAND (spec §4 passthrough)', async () => {
+  _setRunnerStateForTest({
+    port: 22088,
+    pid: 999999,
+    deviceId: 'sim',
+    bundleId: 'com.test',
+    startedAt: 'now',
+  });
+  _setFetchForTest(async () => ({
+    json: async () => ({
+      ok: false,
+      v: 1,
+      error: {
+        code: 'UNSUPPORTED_COMMAND',
+        message: 'Unsupported iOS runner command: bogus — the runner artifact predates it.',
+      },
+    }),
+  }));
+  try {
+    const res = await runIOS({ command: 'back' });
+    assert.equal(res.isError, true);
+    assert.match(res.content[0].text, /UNSUPPORTED_COMMAND/);
+    assert.match(res.content[0].text, /artifact predates/);
+  } finally {
+    _setFetchForTest(globalThis.fetch);
+    _setRunnerStateForTest(null);
+  }
+});
+```
+
+(No production change is needed for this passthrough — `runIOS` already forwards `resp.error.code` into `failResult(message, code)`; adding `'UNSUPPORTED_COMMAND'` to ToolErrorCode in Task 2 makes it type-honest, and this test pins the behavior.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/gh-418-ios-command-gate.test.js`
+Expected: FAIL — absent-commands probe currently returns `'alive'`.
+
+- [ ] **Step 3: Implement in rn-fast-runner-client.ts**
+
+1. `HttpProbeResult` gains `commands?: string[]`.
+2. `defaultHttpProbe`: mirror the existing `capabilities` parsing for `commands` — add `commands?: unknown;` to the parsed body type, then:
+
+```ts
+      let commands: string[] | undefined;
+      // …inside the try after capabilities parsing:
+      if (Array.isArray(body.commands)) {
+        commands = body.commands.filter((c): c is string => typeof c === 'string');
+      }
+```
+and spread `...(commands !== undefined ? { commands } : {})` into the returned object.
+3. `FastRunnerLivenessDetail` gains `missingCommands?: string[]`.
+4. `probeFastRunnerLivenessDetailed`: import `REQUIRED_IOS_COMMANDS` from `./protocol.js` (extend the existing import) and change the classify call + stale return:
+
+```ts
+    const compat = classifyRunnerCompatibility(
+      {
+        ...(res.protocolVersion !== undefined ? { protocolVersion: res.protocolVersion } : {}),
+        ...(res.runnerVersion !== undefined ? { runnerVersion: res.runnerVersion } : {}),
+        ...(res.commands !== undefined ? { commands: res.commands } : {}),
+      },
+      plugin,
+      REQUIRED_IOS_COMMANDS,
+    );
+    if (!compat.compatible) {
+      return {
+        liveness: 'stale',
+        staleReason: compat.reason,
+        ...(compat.missing !== undefined ? { missingCommands: compat.missing } : {}),
+        ...(res.protocolVersion !== undefined
+          ? { runnerProtocolVersion: res.protocolVersion }
+          : {}),
+        ...(res.runnerVersion !== undefined ? { runnerVersion: res.runnerVersion } : {}),
+      };
+    }
+```
+
+- [ ] **Step 4: Migrate the three probe-body test files**
+
+Every injected probe body that the test expects to classify `'alive'` must now include the commands. In each of `fast-runner-liveness.test.js`, `gh-383-ios-protocol-gate.test.js`, `runners/gh-384-quiescence.test.js`: import `REQUIRED_IOS_COMMANDS` from `'../../dist/runners/protocol.js'` (adjust relative depth for `runners/`), and add `commands: [...REQUIRED_IOS_COMMANDS]` to those bodies (e.g. gh-383's "healthy + matching protocol + version → alive" test). Bodies that expect stale/legacy/skew outcomes stay untouched — their earlier-reason classification already wins. Where a test asserts the full detail object with `deepEqual`, extend the expectation rather than loosening the assertion.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `cd scripts/cdp-bridge && npm test`
+Expected: all pass — any remaining failure is an unmigrated probe body; fix it the same way.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts scripts/cdp-bridge/test/unit/gh-418-ios-command-gate.test.js scripts/cdp-bridge/test/unit/fast-runner-liveness.test.js scripts/cdp-bridge/test/unit/gh-383-ios-protocol-gate.test.js scripts/cdp-bridge/test/unit/runners/gh-384-quiescence.test.js
+git commit -S -m "feat(ios-gate): classify runners missing required commands as stale (#418)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Tiered remediation — artifact invalidation at open, RUNNER_COMMANDS_STALE mid-flow
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/agent-device-wrapper.ts` (PROTOCOL_STALE_REASONS, EnsureRunnerDeps, ensureRunnerForCommand)
+- Modify: `scripts/cdp-bridge/src/tools/device-session.ts:267` (pass `allowArtifactRebuild: true`)
+- Test (create): `scripts/cdp-bridge/test/unit/gh-418-remediation.test.js`
+
+**Interfaces:**
+- Consumes: `FastRunnerLivenessDetail.missingCommands` (Task 6); `derivedDataPathForRunner()` (already imported in the wrapper); `'RUNNER_COMMANDS_STALE'` ToolErrorCode (Task 2).
+- Produces:
+  - In `rn-fast-runner-client.ts`: `acquireRunnerRebuildLock(): boolean` / `releaseRunnerRebuildLock(): void` (checkout-scoped mkdir mutex at `<FAST_RUNNER_PROJECT>/build/.rebuild-lock`, stale takeover after 15 min, fail-open on fs errors) and `runnerRebuildBudget: { alreadyRebuiltFor(v: string): boolean; recordRebuild(v: string): void }` (JSON at `<FAST_RUNNER_PROJECT>/build/commands-rebuild.json` — sibling of DerivedData, so it survives the invalidation).
+  - `EnsureRunnerDeps` gains `allowArtifactRebuild?: boolean`, `invalidateArtifact?: () => void`, `reap?: () => Promise<void>`, `acquireBuildLock?: () => boolean`, `releaseBuildLock?: () => void`, `rebuildBudget?: { alreadyRebuiltFor(v: string): boolean; recordRebuild(v: string): void }`, `pluginVersion?: string | null` (test seams; production defaults are the client helpers / `getPluginVersion()`).
+  - `ensureRunnerForCommand` returns `{ok:true, note:'runner artifact rebuilt (missing commands: …)'}` on the rebuild path and `{ok:false, code:'RUNNER_COMMANDS_STALE', …}` on every refusal (mid-flow, budget-spent, lock-busy, still-stale-after-rebuild). `device-session.ts` already surfaces `ready.note` as `upgradeNote` — no extra plumbing there beyond the flag.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/cdp-bridge/test/unit/gh-418-remediation.test.js`:
+
+```js
+// GH #418: 'missing-commands' remediation is tiered. Mid-flow callers refuse
+// fast with RUNNER_COMMANDS_STALE (a respawn can't fix a stale ARTIFACT); only
+// device_snapshot action=open (allowArtifactRebuild) invalidates DerivedData
+// and pays the cold rebuild — reap-first, behind a checkout-scoped build lock,
+// at most once per plugin version (multi-LLM review amendments).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ensureRunnerForCommand } from '../../dist/agent-device-wrapper.js';
+
+const MISSING = {
+  liveness: 'stale',
+  staleReason: 'missing-commands',
+  missingCommands: ['keyboardDismiss'],
+};
+const freshBudget = () => {
+  const rebuilt = new Set();
+  return {
+    alreadyRebuiltFor: (v) => rebuilt.has(v),
+    recordRebuild: (v) => rebuilt.add(v),
+  };
+};
+const base = () => ({
+  prebuilt: () => true,
+  adopt: () => {},
+  reap: async () => {},
+  acquireBuildLock: () => true,
+  releaseBuildLock: () => {},
+  rebuildBudget: freshBudget(),
+  pluginVersion: '0.99.0',
+});
+
+test('gh-418: mid-flow, missing-commands survives respawn → RUNNER_COMMANDS_STALE, no invalidation', async () => {
+  let invalidated = 0;
+  const res = await ensureRunnerForCommand('U1', 'com.example', {
+    ...base(),
+    probe: async () => MISSING,
+    ensure: async () => {},
+    invalidateArtifact: () => invalidated++,
+  });
+  assert.equal(invalidated, 0);
+  assert.equal(res.ok, false);
+  assert.equal(res.code, 'RUNNER_COMMANDS_STALE');
+  assert.match(res.message, /keyboardDismiss/);
+  assert.match(res.message, /device_snapshot action=open/);
+});
+
+test('gh-418: mid-flow, respawn fixes a stale process → ok + upgrade note, no invalidation', async () => {
+  const probes = [MISSING, { liveness: 'alive' }];
+  let invalidated = 0;
+  const res = await ensureRunnerForCommand('U1', 'com.example', {
+    ...base(),
+    probe: async () => probes.shift(),
+    ensure: async () => {},
+    invalidateArtifact: () => invalidated++,
+  });
+  assert.equal(invalidated, 0);
+  assert.deepEqual(res, { ok: true, note: 'runner upgraded (stale command surface)' });
+});
+
+test('gh-418: at open, invalidate FIRST (no wasted stale respawn) → single ensure + rebuilt note', async () => {
+  const probes = [MISSING, { liveness: 'alive' }];
+  let invalidated = 0;
+  let ensured = 0;
+  let reaped = 0;
+  const res = await ensureRunnerForCommand('U1', 'com.example', {
+    ...base(),
+    allowArtifactRebuild: true,
+    probe: async () => probes.shift(),
+    ensure: async () => {
+      ensured++;
+    },
+    reap: async () => {
+      reaped++;
+    },
+    invalidateArtifact: () => invalidated++,
+  });
+  assert.equal(reaped, 1);
+  assert.equal(invalidated, 1);
+  assert.equal(ensured, 1);
+  assert.deepEqual(res, {
+    ok: true,
+    note: 'runner artifact rebuilt (missing commands: keyboardDismiss)',
+  });
+});
+
+test('gh-418: at open, rebuild budget already spent for this plugin version → refuse, no invalidation', async () => {
+  const budget = freshBudget();
+  budget.recordRebuild('0.99.0');
+  let invalidated = 0;
+  const res = await ensureRunnerForCommand('U1', 'com.example', {
+    ...base(),
+    allowArtifactRebuild: true,
+    rebuildBudget: budget,
+    probe: async () => MISSING,
+    ensure: async () => {},
+    invalidateArtifact: () => invalidated++,
+  });
+  assert.equal(invalidated, 0);
+  assert.equal(res.ok, false);
+  assert.equal(res.code, 'RUNNER_COMMANDS_STALE');
+  assert.match(res.message, /already cold-rebuilt/i);
+});
+
+test('gh-418: at open, build lock held by another session → refuse, no invalidation', async () => {
+  let invalidated = 0;
+  const res = await ensureRunnerForCommand('U1', 'com.example', {
+    ...base(),
+    allowArtifactRebuild: true,
+    acquireBuildLock: () => false,
+    probe: async () => MISSING,
+    ensure: async () => {},
+    invalidateArtifact: () => invalidated++,
+  });
+  assert.equal(invalidated, 0);
+  assert.equal(res.ok, false);
+  assert.equal(res.code, 'RUNNER_COMMANDS_STALE');
+  assert.match(res.message, /another session/i);
+});
+
+test('gh-418: at open, even a cold rebuild misses commands → RUNNER_COMMANDS_STALE naming plugin update', async () => {
+  let released = 0;
+  const res = await ensureRunnerForCommand('U1', 'com.example', {
+    ...base(),
+    allowArtifactRebuild: true,
+    releaseBuildLock: () => released++,
+    probe: async () => MISSING,
+    ensure: async () => {},
+    invalidateArtifact: () => {},
+  });
+  assert.equal(released, 1, 'lock must be released even on failure');
+  assert.equal(res.ok, false);
+  assert.equal(res.code, 'RUNNER_COMMANDS_STALE');
+  assert.match(res.message, /update the plugin/i);
+});
+
+test('gh-418: protocol reasons keep the existing note and error path', async () => {
+  const probes = [{ liveness: 'stale', staleReason: 'legacy' }, { liveness: 'alive' }];
+  const res = await ensureRunnerForCommand('U1', 'com.example', {
+    ...base(),
+    probe: async () => probes.shift(),
+    ensure: async () => {},
+  });
+  assert.deepEqual(res, { ok: true, note: 'runner upgraded (protocol/version mismatch)' });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/gh-418-remediation.test.js`
+Expected: FAIL — no `invalidateArtifact` support, missing-commands falls into the RUNNER_PROTOCOL_MISMATCH branch or the generic not-ready error.
+
+- [ ] **Step 3: Implement — lock + budget helpers in the client, tiered logic in the wrapper**
+
+1. In `scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts`, add the checkout-scoped rebuild lock and budget (near `derivedDataPathForRunner`; `mkdirSync`/`rmSync`/`statSync`/`readFileSync`/`writeFileSync` from the existing `node:fs` imports):
+
+```ts
+// GH #418 (review amendment): DerivedData is plugin-checkout-scoped while the
+// device lock is UDID-scoped, so two projects sharing this checkout could race
+// invalidate-vs-build. mkdir is atomic — it is the mutex. Fail-open on fs
+// errors (never block a legit session); stale takeover after 15 min.
+const REBUILD_LOCK_DIR = join(FAST_RUNNER_PROJECT, 'build', '.rebuild-lock');
+const REBUILD_LOCK_STALE_MS = 15 * 60_000;
+
+export function acquireRunnerRebuildLock(): boolean {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      mkdirSync(REBUILD_LOCK_DIR, { recursive: false });
+      return true;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') return true; // fail-open
+      try {
+        const age = Date.now() - statSync(REBUILD_LOCK_DIR).mtimeMs;
+        if (age < REBUILD_LOCK_STALE_MS) return false;
+        rmSync(REBUILD_LOCK_DIR, { recursive: true, force: true });
+      } catch {
+        return true; // fail-open
+      }
+    }
+  }
+  return false;
+}
+
+export function releaseRunnerRebuildLock(): void {
+  try {
+    rmSync(REBUILD_LOCK_DIR, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+// GH #418 (review amendment): at most ONE commands-triggered cold rebuild per
+// plugin version — a genuinely-broken checkout must not loop multi-minute
+// builds on every open. Lives in build/ (sibling of DerivedData) so the
+// invalidation itself can't erase it.
+const REBUILD_BUDGET_FILE = join(FAST_RUNNER_PROJECT, 'build', 'commands-rebuild.json');
+
+export const runnerRebuildBudget = {
+  alreadyRebuiltFor(pluginVersion: string): boolean {
+    try {
+      const parsed = JSON.parse(readFileSync(REBUILD_BUDGET_FILE, 'utf8')) as {
+        pluginVersion?: string;
+      };
+      return parsed.pluginVersion === pluginVersion;
+    } catch {
+      return false;
+    }
+  },
+  recordRebuild(pluginVersion: string): void {
+    try {
+      mkdirSync(join(FAST_RUNNER_PROJECT, 'build'), { recursive: true });
+      writeFileSync(
+        REBUILD_BUDGET_FILE,
+        JSON.stringify({ pluginVersion, at: new Date().toISOString() }),
+      );
+    } catch {
+      /* fail-open */
+    }
+  },
+};
+```
+
+2. In `agent-device-wrapper.ts`: add `'missing-commands'` to `PROTOCOL_STALE_REASONS`; import `rmSync` from `node:fs` and `acquireRunnerRebuildLock`, `releaseRunnerRebuildLock`, `runnerRebuildBudget` from the client. Extend `EnsureRunnerDeps`:
+
+```ts
+export interface EnsureRunnerDeps {
+  probe?: () => Promise<FastRunnerLivenessDetail>;
+  ensure?: (deviceId: string, bundleId: string) => Promise<void>;
+  prebuilt?: () => boolean;
+  adopt?: (deviceId: string | undefined) => void;
+  /** GH #418: open-path only — permits DerivedData invalidation + cold rebuild. */
+  allowArtifactRebuild?: boolean;
+  /** GH #418: test seams for the rebuild tier. */
+  invalidateArtifact?: () => void;
+  reap?: () => Promise<void>;
+  acquireBuildLock?: () => boolean;
+  releaseBuildLock?: () => void;
+  rebuildBudget?: { alreadyRebuiltFor(v: string): boolean; recordRebuild(v: string): void };
+  pluginVersion?: string | null;
+}
+```
+
+3. New module-private helper in `agent-device-wrapper.ts` — the open-path rebuild tier (invalidate FIRST; a respawn launches the same stale `.xctestrun`, so it would be a wasted multi-second launch — review amendment):
+
+```ts
+async function rebuildStaleRunnerArtifact(
+  first: FastRunnerLivenessDetail,
+  deviceId: string,
+  bundleId: string,
+  deps: EnsureRunnerDeps,
+): Promise<EnsureRunnerResult> {
+  const missing = (first.missingCommands ?? []).join(', ') || 'unknown';
+  const plugin = deps.pluginVersion !== undefined ? deps.pluginVersion : getPluginVersion();
+  const budget = deps.rebuildBudget ?? runnerRebuildBudget;
+  if (plugin !== null && budget.alreadyRebuiltFor(plugin)) {
+    return {
+      ok: false,
+      code: 'RUNNER_COMMANDS_STALE',
+      message:
+        `rn-fast-runner was already cold-rebuilt once for plugin v${plugin} and still lacks ` +
+        `required commands (missing: ${missing}) — the checkout may be broken; update or ` +
+        `reinstall the plugin, then re-open the device session.`,
+    };
+  }
+  const acquire = deps.acquireBuildLock ?? acquireRunnerRebuildLock;
+  if (!acquire()) {
+    return {
+      ok: false,
+      code: 'RUNNER_COMMANDS_STALE',
+      message:
+        'another session is rebuilding the shared runner artifact — retry this open in a few minutes.',
+    };
+  }
+  const release = deps.releaseBuildLock ?? releaseRunnerRebuildLock;
+  try {
+    const reap = deps.reap ?? reapStaleFastRunner;
+    await reap();
+    const invalidate =
+      deps.invalidateArtifact ??
+      (() => rmSync(derivedDataPathForRunner(), { recursive: true, force: true }));
+    invalidate();
+    if (plugin !== null) budget.recordRebuild(plugin);
+    const ensure = deps.ensure ?? ensureFastRunner;
+    await ensure(deviceId, bundleId);
+  } finally {
+    release();
+  }
+  const probe = deps.probe ?? probeFastRunnerLivenessDetailed;
+  const rebuilt = await probe();
+  if (rebuilt.liveness === 'alive') {
+    return { ok: true, note: `runner artifact rebuilt (missing commands: ${missing})` };
+  }
+  return {
+    ok: false,
+    code: 'RUNNER_COMMANDS_STALE',
+    message:
+      `rn-fast-runner still lacks required commands after a cold rebuild ` +
+      `(missing: ${(rebuilt.missingCommands ?? first.missingCommands ?? []).join(', ') || 'unknown'}). ` +
+      `The plugin checkout itself may be outdated — update the plugin, then re-open the device session.`,
+  };
+}
+```
+
+4. In `ensureRunnerForCommand`: short-circuit into the rebuild tier right after the first probe, and add the mid-flow refusal after the re-probe. Full amended flow (everything not shown stays as-is):
+
+```ts
+  adopt(deviceId ?? undefined);
+  const first = await probe();
+  // GH #418: artifact staleness at open — skip the wasted stale respawn and
+  // invalidate up front. Requires a concrete deviceId to spawn against.
+  if (first.staleReason === 'missing-commands' && deps.allowArtifactRebuild && deviceId) {
+    return rebuildStaleRunnerArtifact(first, deviceId, bundleId, deps);
+  }
+  const decision = decideRunnerSpawn({ liveness: first.liveness, prebuilt: prebuilt(), deviceId });
+  if (decision.action === 'proceed') return { ok: true };
+  if (decision.action === 'error') return { ok: false, message: decision.message };
+
+  await ensure(decision.deviceId, bundleId);
+  const after = await probe();
+  if (after.liveness === 'alive') {
+    if (first.staleReason && PROTOCOL_STALE_REASONS.has(first.staleReason)) {
+      return {
+        ok: true,
+        note:
+          first.staleReason === 'missing-commands'
+            ? 'runner upgraded (stale command surface)'
+            : 'runner upgraded (protocol/version mismatch)',
+      };
+    }
+    return { ok: true };
+  }
+  // GH #418: 'missing-commands' surviving a respawn means the ARTIFACT is
+  // stale — mid-flow callers refuse fast (never a silent multi-minute build).
+  if (after.staleReason === 'missing-commands') {
+    const missing = (after.missingCommands ?? []).join(', ') || 'unknown';
+    return {
+      ok: false,
+      code: 'RUNNER_COMMANDS_STALE',
+      message:
+        `rn-fast-runner artifact lacks required commands (missing: ${missing}). ` +
+        `Re-open the device session (device_snapshot action=open appId=${bundleId} platform=ios) ` +
+        `to rebuild it (cold build, several minutes).`,
+    };
+  }
+  if (after.staleReason && PROTOCOL_STALE_REASONS.has(after.staleReason)) {
+    // …existing RUNNER_PROTOCOL_MISMATCH error block, unchanged…
+  }
+  // …existing did-not-become-ready error, unchanged…
+```
+
+(Order matters twice: the open-path short-circuit precedes `decideRunnerSpawn`, and the mid-flow `missing-commands` branch MUST precede the generic `PROTOCOL_STALE_REASONS` error branch, since the set now contains it.)
+
+5. In `scripts/cdp-bridge/src/tools/device-session.ts`, change line 267:
+
+```ts
+          const ready = await ensureRunnerForCommand(deviceId, appId, {
+            allowArtifactRebuild: true,
+          });
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `cd scripts/cdp-bridge && npm test`
+Expected: all pass, including the untouched gh-383 ensure tests (their reasons still map to the protocol note).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/cdp-bridge/src/agent-device-wrapper.ts scripts/cdp-bridge/src/tools/device-session.ts scripts/cdp-bridge/test/unit/gh-418-remediation.test.js
+git commit -S -m "feat(ios-gate): tiered missing-commands remediation — rebuild at open, refuse mid-flow (#418)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Android — probe parses commands, gate enforces, REAL artifact-invalidation tier
+
+> **Review amendment (BLOCKER):** the original "remediation rides the existing forceReinstall" premise was FALSE. `resolveAndroidInstallAction` (`rn-android-runner-client.ts:310-316`) returns `'reuse'` when the instrumentation is registered and `'install'` (re-install the SAME stale APK, no Gradle) when the APKs exist on disk — it only returns `'build-then-install'` when the APKs are ABSENT. So a stale-but-present APK was never rebuilt, and the fresh-open path (no live runner) never even set `forceReinstall` — post-spawn classify would reject with zero remediation. Android now mirrors iOS: delete the APKs (→ `apksExist` false → `'build-then-install'`), gated behind an open-only `allowArtifactRebuild` flag; mid-flow refuses fast with `RUNNER_COMMANDS_STALE` (never a silent Gradle build — same #210 rule).
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/runners/rn-android-runner-client.ts` (AndroidHealthInfo, probeAndroidRunnerHealthInfo, classifyAndroidHealth, `AndroidCommandsStaleError`, `invalidateAndroidRunnerApks`, `StartAndroidRunnerOpts`, startAndroidRunner retry-once wrapper, ensureAndroidRunnerInstalled forceReinstall threading)
+- Modify: `scripts/cdp-bridge/src/tools/device-session.ts` (`startAndroidRunner(deviceId, appId, undefined, { allowArtifactRebuild: true })` at the open call ~line 282, plus a `RUNNER_COMMANDS_STALE` prefix branch in the catch ~line 312)
+- Modify: `scripts/cdp-bridge/src/agent-device-wrapper.ts` (~line 842: `RUNNER_COMMANDS_STALE` prefix branch in the mid-flow Android start catch, before the `RUNNER_PROTOCOL_MISMATCH` branch)
+- Modify (test migration): `scripts/cdp-bridge/test/unit/runners/rn-android-runner-client.test.js` (~line 28) and `scripts/cdp-bridge/test/unit/gh-243-android-runner-health.test.js` (~line 99) — their reuse-gate `/health` fixtures `{ok:true, protocolVersion:1}` have no `runnerVersion` (skew skipped) and no `commands`, so the strict gate flips them to `missing-commands` and the tests would attempt real adb/Gradle. Add `commands: [...REQUIRED_ANDROID_COMMANDS]` to every fixture the test expects to classify compatible.
+- Test (create): `scripts/cdp-bridge/test/unit/gh-418-android-command-gate.test.js`
+
+**Interfaces:**
+- Consumes: `REQUIRED_ANDROID_COMMANDS` (Task 2); Android `/health.commands` (Task 4); `'RUNNER_COMMANDS_STALE'` ToolErrorCode (Task 2).
+- Produces: `AndroidHealthInfo.commands?: string[]`; `export class AndroidCommandsStaleError extends Error { readonly missing: string[] }` whose message starts with `RUNNER_COMMANDS_STALE:`; `export function invalidateAndroidRunnerApks(): void`; `startAndroidRunner(deviceId?, bundleId?, devicePort?, opts?: { allowArtifactRebuild?: boolean })` — same export name, retry-once wrapper semantics at open.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/cdp-bridge/test/unit/gh-418-android-command-gate.test.js`:
+
+```js
+// GH #418: the Android health probe parses /health.commands, the classify
+// helper enforces REQUIRED_ANDROID_COMMANDS, and remediation is a REAL
+// invalidation tier — deleting the APKs forces resolveAndroidInstallAction
+// into 'build-then-install' (review amendment: 'install' alone re-installs
+// the same stale APK and never runs Gradle).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  probeAndroidRunnerHealthInfo,
+  resolveAndroidInstallAction,
+  AndroidCommandsStaleError,
+  _setFetchForTest,
+} from '../../dist/runners/rn-android-runner-client.js';
+import {
+  classifyRunnerCompatibility,
+  REQUIRED_ANDROID_COMMANDS,
+} from '../../dist/runners/protocol.js';
+
+test('gh-418 android: probe parses commands array (non-strings filtered)', async () => {
+  _setFetchForTest(async () => ({
+    ok: true,
+    json: async () => ({
+      ok: true,
+      protocolVersion: 1,
+      commands: ['tap', 'type', 7, 'snapshot'],
+    }),
+  }));
+  try {
+    const info = await probeAndroidRunnerHealthInfo(4723);
+    assert.deepEqual(info.commands, ['tap', 'type', 'snapshot']);
+  } finally {
+    _setFetchForTest(globalThis.fetch);
+  }
+});
+
+test('gh-418 android: absent commands + required list → missing-commands', () => {
+  assert.deepEqual(
+    classifyRunnerCompatibility({ protocolVersion: 1 }, null, REQUIRED_ANDROID_COMMANDS),
+    {
+      compatible: false,
+      reason: 'missing-commands',
+      missing: [...REQUIRED_ANDROID_COMMANDS],
+    },
+  );
+});
+
+test('gh-418 android: AndroidCommandsStaleError message carries the typed prefix + hint', () => {
+  const err = new AndroidCommandsStaleError(['dismissKeyboard'], 'com.example');
+  assert.ok(err.message.startsWith('RUNNER_COMMANDS_STALE'));
+  assert.match(err.message, /dismissKeyboard/);
+  assert.match(err.message, /device_snapshot action=open/);
+  assert.deepEqual(err.missing, ['dismissKeyboard']);
+});
+
+test('gh-418 android: deleting the APKs flips the install action to build-then-install', () => {
+  // The invalidation tier works BECAUSE of this existing pure decision:
+  assert.equal(
+    resolveAndroidInstallAction({ instrumentationRegistered: false, apksExist: true }),
+    'install',
+  );
+  assert.equal(
+    resolveAndroidInstallAction({ instrumentationRegistered: false, apksExist: false }),
+    'build-then-install',
+  );
+});
+```
+
+(The full open-path loop — stale APK → invalidate → Gradle rebuild → healthy runner — is exercised live in Task 11 Step 5; `startAndroidRunner` spawns real adb, so its retry wrapper is deliberately not unit-mocked here.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/gh-418-android-command-gate.test.js`
+Expected: FAIL — `info.commands` is `undefined`.
+
+- [ ] **Step 3: Implement in rn-android-runner-client.ts**
+
+1. `AndroidHealthInfo` gains `commands?: string[]`.
+2. `probeAndroidRunnerHealthInfo`: add `commands?: unknown;` to the parsed body type and:
+
+```ts
+      ...(Array.isArray(body.commands)
+        ? { commands: body.commands.filter((c): c is string => typeof c === 'string') }
+        : {}),
+```
+
+3. `classifyAndroidHealth` passes the commands + required list:
+
+```ts
+function classifyAndroidHealth(info: AndroidHealthInfo) {
+  return classifyRunnerCompatibility(
+    {
+      ...(info.protocolVersion !== undefined ? { protocolVersion: info.protocolVersion } : {}),
+      ...(info.runnerVersion !== undefined ? { runnerVersion: info.runnerVersion } : {}),
+      ...(info.commands !== undefined ? { commands: info.commands } : {}),
+    },
+    getPluginVersion(),
+    REQUIRED_ANDROID_COMMANDS,
+  );
+}
+```
+
+(import `REQUIRED_ANDROID_COMMANDS` alongside the existing protocol imports.)
+
+4. Add the typed error and the invalidation helper (near `reapMismatchedAndroidRunner`):
+
+```ts
+// GH #418: mid-flow refusal + retry-once signal. The message prefix is the
+// wire contract — device-session.ts and agent-device-wrapper.ts map it to the
+// RUNNER_COMMANDS_STALE ToolErrorCode by startsWith, mirroring
+// RUNNER_PROTOCOL_MISMATCH.
+export class AndroidCommandsStaleError extends Error {
+  constructor(
+    readonly missing: string[],
+    bundleId?: string,
+  ) {
+    super(
+      `RUNNER_COMMANDS_STALE: installed rn-android-runner lacks required commands ` +
+        `(missing: ${missing.join(', ') || 'unknown'}). Re-open the device session ` +
+        `(device_snapshot action=open appId=${bundleId ?? '<your.app.id>'} platform=android) to rebuild it.`,
+    );
+  }
+}
+
+// GH #418: deleting the APKs is the artifact invalidation — apksExist flips
+// false, so resolveAndroidInstallAction returns 'build-then-install' (Gradle).
+export function invalidateAndroidRunnerApks(): void {
+  for (const apk of [APK_APP, APK_TEST]) {
+    try {
+      rmSync(apk, { force: true });
+    } catch {
+      /* best-effort; the install action check re-reads existsSync */
+    }
+  }
+}
+```
+
+5. Thread a force flag through `ensureAndroidRunnerInstalled` (the retry after invalidation must not short-circuit on `instrumentationRegistered` → `'reuse'`): the call at ~line 550 becomes `await ensureAndroidRunnerInstalled(deviceId, { forceReinstall: forceReinstall || opts._forceReinstall === true });`.
+
+6. Rename the current exported `startAndroidRunner` body to module-private `startAndroidRunnerAttempt(deviceId?, bundleId?, devicePort, opts)` and amend two spots inside it:
+
+   a. Reuse path (reachable-but-incompatible, ~lines 537-544):
+
+```ts
+      const compat = classifyAndroidHealth(info);
+      if (compat.compatible) return runnerState!;
+      if (compat.reason === 'missing-commands') {
+        // GH #418: reinstalling the SAME APK can't add commands — this is
+        // artifact staleness. Open invalidates + rebuilds; mid-flow refuses.
+        if (!opts.allowArtifactRebuild) {
+          throw new AndroidCommandsStaleError(compat.missing ?? [], bundleId);
+        }
+        invalidateAndroidRunnerApks();
+        pendingUpgradeNote = `runner artifact rebuilt (missing commands: ${(compat.missing ?? []).join(', ') || 'unknown'})`;
+      } else {
+        pendingUpgradeNote = 'runner upgraded (protocol/version mismatch)';
+      }
+      forceReinstall = true;
+      await reapMismatchedAndroidRunner(deviceId);
+```
+
+   b. Post-install verify (the `waitForAndroidRunnerHealth` callback): reject with the typed error for `missing-commands`, keep `RUNNER_PROTOCOL_MISMATCH` for protocol reasons:
+
+```ts
+        const compat = classifyAndroidHealth(info);
+        if (!compat.compatible) {
+          resolved = true;
+          pendingUpgradeNote = undefined; // never report an upgrade that failed
+          child.kill('SIGTERM');
+          if (compat.reason === 'missing-commands') {
+            reject(new AndroidCommandsStaleError(compat.missing ?? [], bundleId));
+            return;
+          }
+          reject(
+            new Error(
+              `RUNNER_PROTOCOL_MISMATCH: installed rn-android-runner speaks protocol ` +
+                `${info.protocolVersion ?? 'none'} (bridge expects ${RUNNER_PROTOCOL_VERSION}). ` +
+                `Rebuild + reinstall the runner APKs: cd ${RN_ANDROID_RUNNER_DIR} && ` +
+                `./gradlew :app:assembleDebug :app:assembleDebugAndroidTest, then adb install -r both APKs.`,
+            ),
+          );
+          return;
+        }
+```
+
+7. New exported `startAndroidRunner` — retry-once wrapper covering the fresh-open case (stale APK already installed, no live runner: the attempt spawns it, post-install verify throws the typed error, the wrapper invalidates and retries with a forced build):
+
+```ts
+export interface StartAndroidRunnerOpts {
+  /** GH #418: open-path only — permits APK invalidation + Gradle rebuild. */
+  allowArtifactRebuild?: boolean;
+  /** Internal: set by the rebuild retry so the install action can't 'reuse'. */
+  _forceReinstall?: boolean;
+}
+
+export async function startAndroidRunner(
+  deviceId?: string,
+  bundleId?: string,
+  devicePort = DEFAULT_PORT,
+  opts: StartAndroidRunnerOpts = {},
+): Promise<AndroidRunnerState> {
+  try {
+    return await startAndroidRunnerAttempt(deviceId, bundleId, devicePort, opts);
+  } catch (err) {
+    if (opts.allowArtifactRebuild && err instanceof AndroidCommandsStaleError) {
+      invalidateAndroidRunnerApks();
+      const state = await startAndroidRunnerAttempt(deviceId, bundleId, devicePort, {
+        _forceReinstall: true,
+      });
+      pendingUpgradeNote = `runner artifact rebuilt (missing commands: ${err.missing.join(', ') || 'unknown'})`;
+      return state;
+    }
+    throw err;
+  }
+}
+```
+
+8. Map the new prefix at both consumers (BEFORE their `RUNNER_PROTOCOL_MISMATCH` branches):
+   - `scripts/cdp-bridge/src/agent-device-wrapper.ts` ~line 842 (mid-flow Android start catch):
+
+```ts
+        if (msg.startsWith('RUNNER_COMMANDS_STALE')) {
+          return failResult(msg, 'RUNNER_COMMANDS_STALE');
+        }
+```
+
+   - `scripts/cdp-bridge/src/tools/device-session.ts` catch (~line 312): same two-line branch.
+
+9. `scripts/cdp-bridge/src/tools/device-session.ts` ~line 282 (the open path is the ONLY caller that opts in):
+
+```ts
+          await startAndroidRunner(deviceId, appId, undefined, { allowArtifactRebuild: true });
+```
+
+- [ ] **Step 4: Migrate the Android fixture tests, then run the full suite**
+
+Add `commands: [...REQUIRED_ANDROID_COMMANDS]` (importing from `'../../dist/runners/protocol.js'`, depth-adjusted) to every `/health` fixture expected to classify compatible in:
+- `test/unit/runners/rn-android-runner-client.test.js` (~line 28 reuse-gate body `{ok:true, protocolVersion:1}`)
+- `test/unit/gh-243-android-runner-health.test.js` (~line 99 same shape)
+- `gh-383-android-protocol-gate.test.js` / android state-relocation tests IF any of their compatible-path bodies lack `commands` (check by running the suite).
+
+Run: `cd scripts/cdp-bridge && npm test`
+Expected: all pass — any remaining failure is an unmigrated Android fixture; fix it the same way.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/cdp-bridge/src/runners/rn-android-runner-client.ts scripts/cdp-bridge/src/tools/device-session.ts scripts/cdp-bridge/src/agent-device-wrapper.ts scripts/cdp-bridge/test/unit/gh-418-android-command-gate.test.js scripts/cdp-bridge/test/unit/runners/rn-android-runner-client.test.js scripts/cdp-bridge/test/unit/gh-243-android-runner-health.test.js
+git commit -S -m "feat(android-gate): command-surface gate + real APK-invalidation rebuild tier (#418)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+(Include any additionally migrated gh-383 android test files in the `git add`.)
+
+---
+
+### Task 9: cdp_status surfaces missingCommands
+
+**Files:**
+- Modify: `scripts/cdp-bridge/src/tools/device-session-health.ts`
+- Test (create): `scripts/cdp-bridge/test/unit/gh-418-status-missing-commands.test.js`
+
+**Interfaces:**
+- Consumes: `FastRunnerLivenessDetail.missingCommands` (Task 6).
+- Produces: `DeviceSessionHealth.runnerProtocol.missingCommands?: string[]` — present only when the runner is stale for that reason.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/cdp-bridge/test/unit/gh-418-status-missing-commands.test.js`:
+
+```js
+// GH #418: cdp_status.deviceSession.runnerProtocol names the missing verbs so
+// a stale artifact is diagnosable before any device_* call fails.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getDeviceSessionHealth } from '../../dist/tools/device-session-health.js';
+
+const SESSION = { platform: 'ios', appId: 'com.example', deviceId: 'U1' };
+
+test('gh-418 status: stale/missing-commands surfaces missingCommands', async () => {
+  const h = await getDeviceSessionHealth({
+    getActiveSession: () => SESSION,
+    adopt: () => {},
+    probeLiveness: async () => ({
+      liveness: 'stale',
+      staleReason: 'missing-commands',
+      missingCommands: ['keyboardDismiss'],
+      runnerProtocolVersion: 1,
+    }),
+  });
+  assert.equal(h.rnFastRunner, 'stale');
+  assert.deepEqual(h.runnerProtocol?.missingCommands, ['keyboardDismiss']);
+  assert.equal(h.runnerProtocol?.compatible, false);
+});
+
+test('gh-418 status: alive runner has no missingCommands key', async () => {
+  const h = await getDeviceSessionHealth({
+    getActiveSession: () => SESSION,
+    adopt: () => {},
+    probeLiveness: async () => ({ liveness: 'alive', runnerProtocolVersion: 1 }),
+  });
+  assert.equal('missingCommands' in (h.runnerProtocol ?? {}), false);
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd scripts/cdp-bridge && npm run build && node --test test/unit/gh-418-status-missing-commands.test.js`
+Expected: FAIL — `missingCommands` undefined on the stale case.
+
+- [ ] **Step 3: Implement**
+
+In `device-session-health.ts`: the `runnerProtocol` interface member gains `missingCommands?: string[]`, and the population block gains one spread:
+
+```ts
+        health.runnerProtocol = {
+          expected: RUNNER_PROTOCOL_VERSION,
+          ...(detail.runnerProtocolVersion !== undefined
+            ? { runner: detail.runnerProtocolVersion }
+            : {}),
+          ...(detail.runnerVersion !== undefined ? { runnerVersion: detail.runnerVersion } : {}),
+          ...(plugin !== null ? { pluginVersion: plugin } : {}),
+          ...(detail.missingCommands !== undefined
+            ? { missingCommands: detail.missingCommands }
+            : {}),
+          compatible: detail.liveness === 'alive',
+        };
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd scripts/cdp-bridge && npm test`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/cdp-bridge/src/tools/device-session-health.ts scripts/cdp-bridge/test/unit/gh-418-status-missing-commands.test.js
+git commit -S -m "feat(status): surface missing runner commands in deviceSession.runnerProtocol (#418)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Docs, changeset, dist rebuild, full gates
+
+**Files:**
+- Modify: `CLAUDE.md` (Troubleshooting section)
+- Create: `.changeset/gh-418-command-surface-gate.md`
+- Modify: `scripts/cdp-bridge/dist/**` (rebuilt, staged — dist is tracked)
+
+- [ ] **Step 1: CLAUDE.md troubleshooting entry**
+
+In the Troubleshooting list, immediately after the existing `RUNNER_PROTOCOL_MISMATCH` bullet, add:
+
+```markdown
+- **`RUNNER_COMMANDS_STALE` / `UNSUPPORTED_COMMAND` on device_* tools** → The runner build artifact predates a newer command verb (#418). Protocol versions only bump on wire-shape changes, so an old artifact can pass the protocol gate while lacking verbs — both runners now enumerate their commands in `/health.commands` and the liveness gate classifies a missing verb as stale. Self-heals: re-open the device session (`device_snapshot action=open`) — iOS deletes the stale DerivedData and cold-rebuilds (one multi-minute build, `meta.note: "runner artifact rebuilt (missing commands: …)"`, at most once per plugin version and serialized across sessions sharing the checkout), Android deletes the runner APKs and Gradle-rebuilds via self-install. Mid-flow tools refuse fast instead of silently building. `cdp_status` → `deviceSession.runnerProtocol.missingCommands` names the gap. If a COLD build still reports missing commands, the plugin checkout itself is outdated.
+```
+
+- [ ] **Step 2: Changeset**
+
+Create `.changeset/gh-418-command-surface-gate.md`:
+
+```markdown
+---
+"rn-dev-agent-cdp": minor
+"rn-dev-agent-plugin": minor
+---
+
+Command-surface gate (#418, B235): both native runners enumerate their supported
+commands in `/health.commands` (iOS derives it from `CommandType.allCases`, Android
+from a sync-tested `SUPPORTED_COMMANDS` list) and the liveness gate classifies a
+runner missing any bridge-required verb as stale (`missing-commands`). Remediation
+is tiered: `device_snapshot action=open` auto-invalidates the stale artifact and
+rebuilds — iOS deletes DerivedData and cold-builds (once per plugin version, behind a
+checkout-scoped build lock), Android deletes the runner APKs so self-install
+Gradle-rebuilds; mid-flow device tools refuse fast with `RUNNER_COMMANDS_STALE`
+instead of silently building.
+An unknown verb reaching the iOS runner now returns a typed `UNSUPPORTED_COMMAND`
+error instead of a raw Swift decode failure. Root cause of B235 fixed: the explicit
+iOS keyboard-dismiss path posted `dismissKeyboard`, which no Swift artifact ever
+accepted — the wire verb is now `keyboardDismiss`. `cdp_status` surfaces
+`deviceSession.runnerProtocol.missingCommands`.
+```
+
+- [ ] **Step 3: Rebuild dist + full gates**
+
+```bash
+cd scripts/cdp-bridge && npm test        # tsc build + full unit suite
+cd ../.. && git add scripts/cdp-bridge/dist
+```
+Expected: suite fully green. Also run the repo's lint/format if configured (`npx oxlint` per the OXC setup) and fix anything it flags in touched files.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md .changeset/gh-418-command-surface-gate.md scripts/cdp-bridge/dist
+git commit -S -m "docs+chore: #418 troubleshooting entry, changeset, rebuilt dist
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: Device verification (live — iOS simulator AND Android emulator)
+
+No code — this is the workflow's step-5 live pass. Prereqs: Metro running from the workspace (`cd ../rn-dev-agent-workspace/test-app && npx expo start`), booted iOS simulator + Android emulator with the test app.
+
+- [ ] **Step 1: iOS upgrade-migration path (the real pre-#418 artifact!)**
+
+The existing DerivedData prebuild on this machine predates #418 → it advertises no `commands`. Open a session: `device_snapshot action=open appId=com.rndevagent.testapp platform=ios`.
+Expected: the open succeeds after a cold rebuild with `meta.note: "runner artifact rebuilt (missing commands: tap, type, …)"` (full list — the field was absent). This validates the strict-absence policy end-to-end on the genuine migration artifact. Budget several minutes for the cold build.
+
+- [ ] **Step 2: Steady state**
+
+`cdp_status` → expect `deviceSession.rnFastRunner: 'alive'`, `runnerProtocol.compatible: true`, NO `missingCommands`. Run `device_find` + `device_press` on a visible element — normal behavior, no new notes.
+
+- [ ] **Step 3: B235 regression — the keyboard verb**
+
+Focus a text field (`device_press` on an input), then drive the explicit dismissal path (`device_batch` with a hideKeyboard/keyboard step — the exact B235 shape).
+Expected: succeeds (wire verb `keyboardDismiss` decodes); NO `dataCorrupted` error. Also run the Swift unit tests live while the sim is booted:
+```bash
+cd scripts/rn-fast-runner/RnFastRunner && xcodebuild test \
+  -project RnFastRunner.xcodeproj -scheme RnFastRunner \
+  -destination "platform=iOS Simulator,id=$(xcrun simctl list devices booted -j | python3 -c 'import json,sys; print(list(json.load(sys.stdin)["devices"].values())[0][0]["udid"])' 2>/dev/null || echo BOOTED_UDID)" \
+  -derivedDataPath ../build/DerivedData \
+  -only-testing:RnFastRunnerUITests/CommandSurfaceTests
+```
+Expected: both CommandSurfaceTests pass.
+
+- [ ] **Step 4: Typed-error path (defense-in-depth)**
+
+With the session open, POST a bogus verb straight at the runner:
+```bash
+curl -s -X POST http://127.0.0.1:22088/command -H 'content-type: application/json' -d '{"command":"definitelyBogusVerb"}'
+```
+Expected: `{"ok":false,…"error":{"code":"UNSUPPORTED_COMMAND","message":"Unsupported iOS runner command: definitelyBogusVerb — …"}}` — not a `dataCorrupted` string. Also confirm `/health` now includes the full `commands` array: `curl -s http://127.0.0.1:22088/health`.
+
+- [ ] **Step 5: Android pass**
+
+`device_snapshot action=open appId=com.rndevagent.testapp platform=android` against the emulator with the previously-installed (pre-#418) runner APK.
+Expected: open succeeds with `meta.note: "runner artifact rebuilt (missing commands: …)"` — the attempt spawns the stale APK, the post-install verify throws the typed error, and the retry wrapper deletes the APKs and Gradle-rebuilds (budget a few minutes). Then `curl -s http://127.0.0.1:<hostPort>/health` shows `commands`, a `device_press`/`device_fill` round-trip works, and a mid-flow simulation (call a `device_*` tool after manually re-installing a stale APK, if time permits) returns `RUNNER_COMMANDS_STALE` rather than triggering a silent Gradle build.
+
+- [ ] **Step 6: Record evidence**
+
+Capture the open-result notes, cdp_status output, and the curl outputs into `../rn-dev-agent-workspace/docs/proof/2026-07-XX-418-command-surface-gate/` (dated folder) for the PR body.
+
+---
+
+## Execution notes
+
+- Tasks 1→2 are TS-ordered (the union rename feeds the `satisfies` tie). Tasks 3 and 4 are independent of each other. Task 5 needs 2+3+4. Tasks 6→7 are sequential; 8 and 9 only need 2/6 respectively.
+- After the plan lands, run the multi-LLM plan review (`/brainstorm gemini,codex`) BEFORE starting Task 1, per the repo workflow, and apply amendments to this plan.
+- Cold-build warning: Task 11 Step 1 intentionally destroys the local prebuilt DerivedData — that's the migration test. Don't pre-build it away.

--- a/docs/superpowers/specs/2026-07-03-418-command-surface-gate-design.md
+++ b/docs/superpowers/specs/2026-07-03-418-command-surface-gate-design.md
@@ -1,0 +1,178 @@
+# #418 — Typed UNSUPPORTED_COMMAND + command-surface gate (B235)
+
+**Date:** 2026-07-03
+**Issue:** [#418](https://github.com/Lykhoyda/rn-dev-agent/issues/418) · Bug: workspace B235
+**Depends on:** #383 (protocol gate, shipped), #384/PR #406 (dynamic /health capabilities, shipped)
+
+## Problem
+
+A prebuilt runner artifact that predates a command-enum addition passes the #383
+health gate — protocol versions bump on wire-shape changes, not enum additions —
+and then rejects the newer verb at dispatch time. On iOS the failure is a raw
+Swift decode error deep inside a batch:
+
+```
+dataCorrupted … Cannot initialize CommandType from invalid String value dismissKeyboard
+```
+
+Root cause of the gate blind spot: **neither existing health signal fingerprints
+the build artifact's command surface.**
+
+- `protocolVersion` tracks the wire shape (asserted by humans, bumped rarely).
+- `runnerVersion` is injected at **spawn time** (`TEST_RUNNER_RN_PLUGIN_VERSION`
+  env from the spawning bridge), so version-skew catches a runner spawned by an
+  old bridge — but a reap+respawn "fixes" the skew while the same stale binary
+  keeps running. It never sees the artifact.
+
+Three concrete ways a stale artifact is admitted today:
+
+1. Artifact built earlier in the **same release cycle**, before a new verb landed
+   — same version string, missing command (the B235 scenario).
+2. The documented manual pre-build (`xcodebuild build-for-testing`) doesn't
+   inject `RN_PLUGIN_VERSION` → `runnerVersion` absent → skew check skipped
+   (fail-open by design).
+3. Unreadable plugin manifest → `pluginVersion` null → skew check disabled.
+
+Android already returns a typed `UNSUPPORTED_COMMAND` error
+(`CommandDispatcher.kt` `else` branch); its gate has the same blind spot
+(`/health.capabilities` is always `[]`). iOS has neither the typed error nor the
+enumeration.
+
+## Design principle
+
+Derive state from the artifact, don't assert it. `CommandType.allCases` is a
+fact extracted from the compiled binary; enumerating it in `/health` gives the
+gate a signal that cannot drift from the truth. (Same principle as #384's
+dynamic capabilities.)
+
+## Decisions (brainstorm 2026-07-03)
+
+- **Scope: both platforms** in one increment (iOS typed error + enumeration;
+  Android enumeration; shared gate).
+- **Strict on absence + auto-invalidate at open**: a runner not advertising
+  `commands` (every pre-fix artifact) is classified stale; remediation happens
+  at `device_snapshot action=open` where cold builds are already accepted.
+  Mid-flow tools never trigger a silent multi-minute build (#210 rule).
+- **Approach: `/health.commands` enumeration** over `cmd:*` capability entries
+  (display pollution, semantic collision with feature flags) and over a
+  human-bumped `commandSetVersion` int (reintroduces the #383 drift failure
+  mode; no missing-verb diagnostics).
+
+## Design
+
+### 1. Wire change (additive — no protocol bump)
+
+`/health` on both runners gains a `commands: string[]` field alongside
+`ok/protocolVersion/runnerVersion/capabilities`.
+
+- **iOS** (`RnFastRunnerTests+Models.swift`, `+Transport.swift`):
+  `CommandType` adopts `CaseIterable`; the health response includes
+  `CommandType.allCases.map(\.rawValue)`. `Response` gains an optional
+  `commands: [String]?` (nil-omitted, backwards-compatible).
+- **Android** (`CommandServer.kt`, `CommandDispatcher.kt`): a
+  `SUPPORTED_COMMANDS` list declared adjacent to the dispatcher's `when`,
+  emitted from `/health`.
+- **Sync test**: extend the `gh-383-protocol-sync.test.js` source-parsing
+  pattern — one Node test asserts (a) Kotlin `SUPPORTED_COMMANDS` ==
+  the dispatcher's `when` labels, (b) Swift `CommandType` cases ⊇
+  `REQUIRED_IOS_COMMANDS`, (c) Kotlin list ⊇ `REQUIRED_ANDROID_COMMANDS`.
+
+`capabilities` keeps its current meaning (feature flags like
+`QUIESCENCE_BYPASS`); commands do NOT go there.
+
+### 2. Gate (TS — `scripts/cdp-bridge/src/runners/protocol.ts`)
+
+- New per-platform constants: `REQUIRED_IOS_COMMANDS` /
+  `REQUIRED_ANDROID_COMMANDS` — exactly the verbs each client dispatches.
+  Tied to the existing client command union types via `satisfies` so adding a
+  verb to the union without updating the list is a compile error.
+- `classifyRunnerCompatibility` gains an optional commands input and a new
+  `RunnerIncompatibilityReason: 'missing-commands'`; the result carries
+  `missing: string[]` (for absence, `missing` = the full required list).
+- **Strict on absence**: `commands === undefined` → `missing-commands`.
+- Check order: legacy → protocol-older/newer → version-skew →
+  missing-commands (most fundamental mismatch wins).
+- Both platform probes (`defaultHttpProbe` in `rn-fast-runner-client.ts`,
+  the Android info fetch in `rn-android-runner-client.ts`) parse `commands`;
+  liveness detail gains `commands?: string[]` and the new stale reason flows
+  through existing plumbing.
+
+### 3. Remediation — two tiers
+
+`missing-commands` joins `PROTOCOL_STALE_REASONS` (reap + respawn + re-verify),
+but because respawn reuses the same binary, artifact staleness needs its own
+tier:
+
+- **At `device_snapshot action=open`**: when the probe (before or after
+  respawn) classifies `missing-commands`, invalidate the artifact —
+  iOS: stop the runner and delete the **plugin-owned** DerivedData
+  (`derivedDataPathForRunner()` only; never a user path), then let the
+  existing self-build-on-first-use path cold-build; Android: force the #309
+  self-install rebuild/reinstall. Result carries
+  `meta.note: "runner artifact stale (missing commands: <list>) — rebuilt"`.
+- **Mid-flow tools** (`device_find`/`press`/`fill` auto-spawn via
+  `ensureRunnerForCommand`): if still `missing-commands` after the standard
+  reap+respawn, return a structured error with new
+  `ToolErrorCode: 'RUNNER_COMMANDS_STALE'` naming the missing verbs and
+  pointing at `device_snapshot action=open` (which now self-heals). No silent
+  cold build mid-flow, ever.
+
+### 4. Typed error on iOS `/command` (defense-in-depth)
+
+`handleRequestBody` pre-decodes `{command: String}`; if
+`CommandType(rawValue:)` is nil it returns
+`ok:false, error:{code:"UNSUPPORTED_COMMAND", message:"Unsupported iOS runner
+command: <verb> — runner artifact predates it; re-open the device session
+(device_snapshot action=open) to rebuild"}` — mirroring Android's existing
+shape. `ErrorPayload` gains an optional `code` field if absent. Any other
+decode failure keeps today's behavior.
+
+TS `runIOS` maps `code === 'UNSUPPORTED_COMMAND'` to a clean `failResult`
+with the same hint. **No auto-retry** — the gate owns the proactive path;
+this branch only catches mid-session hot-swaps.
+
+### 5. Observability
+
+- `cdp_status.deviceSession.runnerProtocol` gains `missingCommands: string[]`
+  when the runner is stale for this reason.
+- `runnerCapabilities` display rule from #384 (omit empty; feature flags only)
+  is unchanged.
+
+## Testing
+
+- **TS unit (hermetic, deps-injected)**: classify matrix (present / absent /
+  subset-missing / ordering vs protocol+skew reasons); probe parsing of
+  `commands` on both clients; `ensureRunnerForCommand` respawn note + terminal
+  `RUNNER_COMMANDS_STALE`; open-path artifact invalidation (fake fs/build
+  deps); `runIOS` mapping of `UNSUPPORTED_COMMAND`.
+- **Tri-file sync test** extension (section 1).
+- **Swift unit**: `CommandType.allCases` contains every dispatched verb
+  (e.g. `keyboardDismiss`); unknown-verb request → typed
+  `UNSUPPORTED_COMMAND` response.
+- **Device verification**: temporarily add a fake verb to
+  `REQUIRED_IOS_COMMANDS` in a local build → gate classifies live runner
+  stale → open-path rebuild loop proven end-to-end on the simulator; Android
+  equivalent with the emulator. Normal pass afterwards (no fake verb) proves
+  zero-regression happy path.
+
+## Non-goals
+
+- No protocol version bump (the change is additive).
+- No auto-retry after an `UNSUPPORTED_COMMAND` reply.
+- No enumeration of `device_batch`-internal sub-verbs beyond what the clients
+  already dispatch as `/command` verbs.
+- No change to `capabilities` semantics.
+
+## Risks / mitigations
+
+- **Upgrade friction**: every existing DerivedData prebuild is classified
+  stale once → one announced cold rebuild at next session open. Accepted in
+  brainstorm (matches the #383 'legacy' precedent; the alternative leaves
+  B235 unfixed for exactly those artifacts).
+- **REQUIRED list under-maintenance**: a future verb added to the enum but not
+  the REQUIRED list is fail-soft — the gate won't protect it, but the typed
+  `UNSUPPORTED_COMMAND` error still names it. The `satisfies` tie to the
+  client command unions plus the sync test make the miss unlikely.
+- **DerivedData deletion safety**: deletion is scoped to
+  `derivedDataPathForRunner()` (in-tree `scripts/rn-fast-runner/build/`),
+  never a user-configurable path.

--- a/docs/superpowers/specs/2026-07-03-418-command-surface-gate-design.md
+++ b/docs/superpowers/specs/2026-07-03-418-command-surface-gate-design.md
@@ -163,6 +163,29 @@ this branch only catches mid-session hot-swaps.
   already dispatch as `/command` verbs.
 - No change to `capabilities` semantics.
 
+## Addendum (planning discovery, 2026-07-03): B235's true root cause
+
+Plan-time code archaeology (`git log -S`) showed the Swift `CommandType` enum
+**never** had a `dismissKeyboard` case — it has been `keyboardDismiss` since
+the original import — while the TS bridge posts `dismissKeyboard`
+(`buildRunIOSArgs` `case 'keyboard'`). The B235 incident was therefore not a
+stale artifact at all: the explicit iOS keyboard-dismiss wire verb has NEVER
+decoded on any artifact. (The #356/#370 keyboard-guard dismissal is
+Swift-internal via the `guardKeyboard` flag on taps, which is why
+device-verified keyboard work still passed.)
+
+Consequences:
+- The plan adds **Task 1: fix the wire verb TS-side** (`dismissKeyboard` →
+  `keyboardDismiss` in `buildRunIOSArgs` + the `RunIOSArgs` union) so old AND
+  new artifacts accept it. Android keeps `dismissKeyboard` (its Kotlin
+  when-label) — the platforms legitimately differ, which is itself an argument
+  for per-platform REQUIRED lists.
+- The gate blind spot this spec addresses remains real and worth fixing —
+  nothing fingerprints the artifact's command surface — but the device
+  verification uses the genuine pre-#418 artifact (absent `commands` field)
+  as the migration test instead of the fake-verb protocol from the Testing
+  section, which is now optional.
+
 ## Risks / mitigations
 
 - **Upgrade friction**: every existing DerivedData prebuild is classified

--- a/scripts/cdp-bridge/dist/agent-device-wrapper.js
+++ b/scripts/cdp-bridge/dist/agent-device-wrapper.js
@@ -1,8 +1,9 @@
-import { unlinkSync } from 'node:fs';
+import { unlinkSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import { failResult } from './utils.js';
-import { startFastRunner, probeFastRunnerLiveness, probeFastRunnerLivenessDetailed, adoptPersistedFastRunnerState, reapStaleFastRunner, hasBuiltTestProduct, derivedDataPathForRunner, } from './runners/rn-fast-runner-client.js';
+import { startFastRunner, probeFastRunnerLiveness, probeFastRunnerLivenessDetailed, adoptPersistedFastRunnerState, reapStaleFastRunner, hasBuiltTestProduct, derivedDataPathForRunner, acquireRunnerRebuildLock, releaseRunnerRebuildLock, runnerRebuildBudget, } from './runners/rn-fast-runner-client.js';
+import { getPluginVersion } from './runners/protocol.js';
 import { resolveBootedIosUdid } from './tools/device-screenshot-raw.js';
 import { refCenter, getScreenRect, clearRefMap, isRefMapFresh, MAX_REF_MAP_AGE_MS, } from './fast-runner-ref-map.js';
 import { resolveBundleId } from './project-config.js';
@@ -262,7 +263,9 @@ export function buildRunIOSArgs(cliArgs, bundleId) {
         case 'screenshot':
             return { command: 'screenshot', ...(bundleId ? { bundleId } : {}) };
         case 'keyboard':
-            return { command: 'dismissKeyboard', ...(bundleId ? { bundleId } : {}) };
+            // B235/#418: the Swift enum case is keyboardDismiss; 'dismissKeyboard'
+            // (the Android wire verb) never decoded on iOS.
+            return { command: 'keyboardDismiss', ...(bundleId ? { bundleId } : {}) };
         case 'swipe':
         case 'scroll': {
             // Coordinate-based gesture. The Swift `.swipe` is tvOS-only; iOS
@@ -494,7 +497,65 @@ const PROTOCOL_STALE_REASONS = new Set([
     'protocol-older',
     'protocol-newer',
     'version-skew',
+    // GH #418: a respawn can fix a runner PROCESS older than the on-disk
+    // artifact; artifact staleness surviving the respawn is handled separately.
+    'missing-commands',
 ]);
+// GH #418: the open-path rebuild tier. A respawn reuses the same build
+// artifact, so 'missing-commands' can only be fixed by invalidating
+// DerivedData and paying the cold rebuild — allowed at device_snapshot
+// action=open only, reap-first, serialized behind the checkout-scoped build
+// lock, at most once per plugin version (a broken checkout must not loop
+// multi-minute builds).
+async function rebuildStaleRunnerArtifact(first, deviceId, bundleId, deps) {
+    const missing = (first.missingCommands ?? []).join(', ') || 'unknown';
+    const plugin = deps.pluginVersion !== undefined ? deps.pluginVersion : getPluginVersion();
+    const budget = deps.rebuildBudget ?? runnerRebuildBudget;
+    if (plugin !== null && budget.alreadyRebuiltFor(plugin)) {
+        return {
+            ok: false,
+            code: 'RUNNER_COMMANDS_STALE',
+            message: `rn-fast-runner was already cold-rebuilt once for plugin v${plugin} and still lacks ` +
+                `required commands (missing: ${missing}) — the checkout may be broken; update or ` +
+                `reinstall the plugin, then re-open the device session.`,
+        };
+    }
+    const acquire = deps.acquireBuildLock ?? acquireRunnerRebuildLock;
+    if (!acquire()) {
+        return {
+            ok: false,
+            code: 'RUNNER_COMMANDS_STALE',
+            message: 'another session is rebuilding the shared runner artifact — retry this open in a few minutes.',
+        };
+    }
+    const release = deps.releaseBuildLock ?? releaseRunnerRebuildLock;
+    try {
+        const reap = deps.reap ?? reapStaleFastRunner;
+        await reap();
+        const invalidate = deps.invalidateArtifact ??
+            (() => rmSync(derivedDataPathForRunner(), { recursive: true, force: true }));
+        invalidate();
+        if (plugin !== null)
+            budget.recordRebuild(plugin);
+        const ensure = deps.ensure ?? ensureFastRunner;
+        await ensure(deviceId, bundleId);
+    }
+    finally {
+        release();
+    }
+    const probe = deps.probe ?? probeFastRunnerLivenessDetailed;
+    const rebuilt = await probe();
+    if (rebuilt.liveness === 'alive') {
+        return { ok: true, note: `runner artifact rebuilt (missing commands: ${missing})` };
+    }
+    return {
+        ok: false,
+        code: 'RUNNER_COMMANDS_STALE',
+        message: `rn-fast-runner still lacks required commands after a cold rebuild ` +
+            `(missing: ${(rebuilt.missingCommands ?? first.missingCommands ?? []).join(', ') || 'unknown'}). ` +
+            `The plugin checkout itself may be outdated — update the plugin, then re-open the device session.`,
+    };
+}
 // #210: orchestrate probe → gate → spawn → RE-VERIFY → structured result. ensureFastRunner
 // swallows start errors, so the re-probe is what turns a failed spawn into a clean message
 // rather than the unstructured postCommand throw downstream (A6, multi-review).
@@ -508,6 +569,11 @@ export async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
     const adopt = deps.adopt ?? adoptPersistedFastRunnerState;
     adopt(deviceId ?? undefined);
     const first = await probe();
+    // GH #418: artifact staleness at open — a respawn launches the same stale
+    // .xctestrun, so skip it and invalidate up front (multi-LLM review amendment).
+    if (first.staleReason === 'missing-commands' && deps.allowArtifactRebuild && deviceId) {
+        return rebuildStaleRunnerArtifact(first, deviceId, bundleId, deps);
+    }
     const decision = decideRunnerSpawn({ liveness: first.liveness, prebuilt: prebuilt(), deviceId });
     if (decision.action === 'proceed')
         return { ok: true };
@@ -517,9 +583,26 @@ export async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
     const after = await probe();
     if (after.liveness === 'alive') {
         if (first.staleReason && PROTOCOL_STALE_REASONS.has(first.staleReason)) {
-            return { ok: true, note: 'runner upgraded (protocol/version mismatch)' };
+            return {
+                ok: true,
+                note: first.staleReason === 'missing-commands'
+                    ? 'runner upgraded (stale command surface)'
+                    : 'runner upgraded (protocol/version mismatch)',
+            };
         }
         return { ok: true };
+    }
+    // GH #418: 'missing-commands' surviving a respawn means the ARTIFACT is
+    // stale — mid-flow callers refuse fast (never a silent multi-minute build).
+    if (after.staleReason === 'missing-commands') {
+        const missing = (after.missingCommands ?? []).join(', ') || 'unknown';
+        return {
+            ok: false,
+            code: 'RUNNER_COMMANDS_STALE',
+            message: `rn-fast-runner artifact lacks required commands (missing: ${missing}). ` +
+                `Re-open the device session (device_snapshot action=open appId=${bundleId} platform=ios) ` +
+                `to rebuild it (cold build, several minutes).`,
+        };
     }
     if (after.staleReason && PROTOCOL_STALE_REASONS.has(after.staleReason)) {
         return {
@@ -693,6 +776,11 @@ export async function runNative(cliArgs, opts = {}) {
                 // note must never attach to a LATER unrelated result.
                 consumePendingAndroidUpgradeNote();
                 const msg = err instanceof Error ? err.message : String(err);
+                // GH #418: a stale command surface mid-flow is a fast refusal — the
+                // open path (device_snapshot action=open) is the rebuild entry.
+                if (msg.startsWith('RUNNER_COMMANDS_STALE')) {
+                    return failResult(msg, 'RUNNER_COMMANDS_STALE');
+                }
                 // GH #383: a protocol mismatch surviving the reap+reinstall is a distinct,
                 // actionable failure — surface it rather than the generic runner-down.
                 if (msg.startsWith('RUNNER_PROTOCOL_MISMATCH')) {

--- a/scripts/cdp-bridge/dist/agent-device-wrapper.js
+++ b/scripts/cdp-bridge/dist/agent-device-wrapper.js
@@ -595,6 +595,13 @@ export async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
     // GH #418: 'missing-commands' surviving a respawn means the ARTIFACT is
     // stale — mid-flow callers refuse fast (never a silent multi-minute build).
     if (after.staleReason === 'missing-commands') {
+        // Open path, dead-runner-spawned-from-stale-prebuilt case: the first
+        // probe said 'dead', so the up-front short-circuit couldn't fire — the
+        // rebuild tier must still run here or the first open after an upgrade
+        // errors and only the SECOND open heals (device-verify finding).
+        if (deps.allowArtifactRebuild && deviceId) {
+            return rebuildStaleRunnerArtifact(after, deviceId, bundleId, deps);
+        }
         const missing = (after.missingCommands ?? []).join(', ') || 'unknown';
         return {
             ok: false,

--- a/scripts/cdp-bridge/dist/agent-device-wrapper.js
+++ b/scripts/cdp-bridge/dist/agent-device-wrapper.js
@@ -516,8 +516,9 @@ async function rebuildStaleRunnerArtifact(first, deviceId, bundleId, deps) {
             ok: false,
             code: 'RUNNER_COMMANDS_STALE',
             message: `rn-fast-runner was already cold-rebuilt once for plugin v${plugin} and still lacks ` +
-                `required commands (missing: ${missing}) — the checkout may be broken; update or ` +
-                `reinstall the plugin, then re-open the device session.`,
+                `required commands (missing: ${missing}). If that rebuild failed transiently (sim ` +
+                `not booted, xcodebuild flake), delete scripts/rn-fast-runner/build/commands-rebuild.json ` +
+                `and re-open to retry; otherwise update or reinstall the plugin.`,
         };
     }
     const acquire = deps.acquireBuildLock ?? acquireRunnerRebuildLock;
@@ -583,6 +584,19 @@ export async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
     // through to ensure(), which cold-builds. Without this, any runner death
     // after a cold `xcodebuild test` (which leaves no .xctestrun) bricks opens.
     if (decision.action === 'error' && !(deps.allowArtifactRebuild && deviceId)) {
+        // GH #418 (multi-review): a stale runner missing commands surfaces the
+        // typed refusal even when nothing is prebuilt — not the generic
+        // not-prebuilt message, whose code would be RN_FAST_RUNNER_DOWN.
+        if (first.staleReason === 'missing-commands') {
+            const missing = (first.missingCommands ?? []).join(', ') || 'unknown';
+            return {
+                ok: false,
+                code: 'RUNNER_COMMANDS_STALE',
+                message: `rn-fast-runner artifact lacks required commands (missing: ${missing}). ` +
+                    `Re-open the device session (device_snapshot action=open appId=${bundleId} platform=ios) ` +
+                    `to rebuild it (cold build, several minutes).`,
+            };
+        }
         return { ok: false, message: decision.message };
     }
     await ensure(decision.action === 'spawn' ? decision.deviceId : deviceId, bundleId);

--- a/scripts/cdp-bridge/dist/agent-device-wrapper.js
+++ b/scripts/cdp-bridge/dist/agent-device-wrapper.js
@@ -577,9 +577,15 @@ export async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
     const decision = decideRunnerSpawn({ liveness: first.liveness, prebuilt: prebuilt(), deviceId });
     if (decision.action === 'proceed')
         return { ok: true };
-    if (decision.action === 'error')
+    // GH #418 (device-verify finding): open IS the sanctioned cold-build entry —
+    // the not-prebuilt refusal exists for mid-flow auto-spawn (#210), and its
+    // message directs users to open. With a device present, open must fall
+    // through to ensure(), which cold-builds. Without this, any runner death
+    // after a cold `xcodebuild test` (which leaves no .xctestrun) bricks opens.
+    if (decision.action === 'error' && !(deps.allowArtifactRebuild && deviceId)) {
         return { ok: false, message: decision.message };
-    await ensure(decision.deviceId, bundleId);
+    }
+    await ensure(decision.action === 'spawn' ? decision.deviceId : deviceId, bundleId);
     const after = await probe();
     if (after.liveness === 'alive') {
         if (first.staleReason && PROTOCOL_STALE_REASONS.has(first.staleReason)) {

--- a/scripts/cdp-bridge/dist/runners/protocol.js
+++ b/scripts/cdp-bridge/dist/runners/protocol.js
@@ -7,7 +7,33 @@ import { join } from 'node:path';
 // no longer be driven.
 export const RUNNER_PROTOCOL_VERSION = 1;
 export const MIN_SUPPORTED_RUNNER_PROTOCOL = 1;
-export function classifyRunnerCompatibility(health, pluginVersion) {
+// GH #418: every wire verb the bridge can POST to each runner's /command —
+// a curated subset of the client command unions (lifecycle/tvOS verbs are
+// deliberately not gated). The satisfies tie makes a typo'd verb a compile
+// error; gh-418-command-surface-sync.test.js enforces the native side.
+export const REQUIRED_IOS_COMMANDS = [
+    'tap',
+    'type',
+    'drag',
+    'longPress',
+    'pinch',
+    'snapshot',
+    'screenshot',
+    'back',
+    'keyboardDismiss',
+];
+export const REQUIRED_ANDROID_COMMANDS = [
+    'tap',
+    'type',
+    'drag',
+    'longPress',
+    'pinch',
+    'snapshot',
+    'screenshot',
+    'back',
+    'dismissKeyboard',
+];
+export function classifyRunnerCompatibility(health, pluginVersion, requiredCommands) {
     if (health.protocolVersion === undefined)
         return { compatible: false, reason: 'legacy' };
     if (health.protocolVersion < MIN_SUPPORTED_RUNNER_PROTOCOL) {
@@ -20,6 +46,15 @@ export function classifyRunnerCompatibility(health, pluginVersion) {
         health.runnerVersion !== undefined &&
         health.runnerVersion !== pluginVersion) {
         return { compatible: false, reason: 'version-skew' };
+    }
+    // GH #418: strict on absence — an artifact that doesn't enumerate commands
+    // predates enumeration and by definition predates any newer verb.
+    if (requiredCommands !== undefined) {
+        const advertised = new Set(health.commands ?? []);
+        const missing = requiredCommands.filter((c) => !advertised.has(c));
+        if (missing.length > 0) {
+            return { compatible: false, reason: 'missing-commands', missing };
+        }
     }
     return { compatible: true };
 }

--- a/scripts/cdp-bridge/dist/runners/rn-android-runner-client.js
+++ b/scripts/cdp-bridge/dist/runners/rn-android-runner-client.js
@@ -4,7 +4,7 @@
  */
 import { spawn, execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { writeFileSync, existsSync } from 'node:fs';
+import { writeFileSync, existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { okResult, failResult } from '../utils.js';
 import { updateRefMapFromFlat, getCachedMetadata } from '../fast-runner-ref-map.js';
@@ -12,7 +12,7 @@ import { findFreePort } from './free-port.js';
 import { join } from 'node:path';
 import { withKeyboardGuard } from './keyboard-guard.js';
 import { runnerStatePath, readJsonStateFile, writeJsonStateFileAtomic, deleteStateFile, readLegacyTmpState, cleanupLegacyTmpState, } from '../util/secure-state-file.js';
-import { RUNNER_PROTOCOL_VERSION, getPluginVersion, classifyRunnerCompatibility, } from './protocol.js';
+import { RUNNER_PROTOCOL_VERSION, REQUIRED_ANDROID_COMMANDS, getPluginVersion, classifyRunnerCompatibility, } from './protocol.js';
 const execFileAsync = promisify(execFile);
 const DEFAULT_PORT = 22089;
 const READY_TIMEOUT_MS = 30_000;
@@ -227,7 +227,7 @@ async function ensureAndroidRunnerInstalled(deviceId, opts = {}) {
     }
     const action = resolveAndroidInstallAction({
         instrumentationRegistered: !opts.forceReinstall && isInstrumentationRegistered(pmOut, INSTRUMENTATION),
-        apksExist: existsSync(APK_APP) && existsSync(APK_TEST),
+        apksExist: androidRunnerApksExist(),
     });
     if (action === 'reuse')
         return;
@@ -336,6 +336,9 @@ export async function probeAndroidRunnerHealthInfo(port) {
                 ? { protocolVersion: body.protocolVersion }
                 : {}),
             ...(typeof body.runnerVersion === 'string' ? { runnerVersion: body.runnerVersion } : {}),
+            ...(Array.isArray(body.commands)
+                ? { commands: body.commands.filter((c) => typeof c === 'string') }
+                : {}),
         };
     }
     catch {
@@ -369,21 +372,90 @@ function classifyAndroidHealth(info) {
     return classifyRunnerCompatibility({
         ...(info.protocolVersion !== undefined ? { protocolVersion: info.protocolVersion } : {}),
         ...(info.runnerVersion !== undefined ? { runnerVersion: info.runnerVersion } : {}),
-    }, getPluginVersion());
+        ...(info.commands !== undefined ? { commands: info.commands } : {}),
+    }, getPluginVersion(), REQUIRED_ANDROID_COMMANDS);
 }
-export async function startAndroidRunner(deviceId, bundleId, devicePort = DEFAULT_PORT) {
+// GH #418: mid-flow refusal + retry-once signal. The message prefix is the
+// wire contract — device-session.ts and agent-device-wrapper.ts map it to the
+// RUNNER_COMMANDS_STALE ToolErrorCode by startsWith, mirroring
+// RUNNER_PROTOCOL_MISMATCH.
+export class AndroidCommandsStaleError extends Error {
+    missing;
+    constructor(missing, bundleId) {
+        super(`RUNNER_COMMANDS_STALE: installed rn-android-runner lacks required commands ` +
+            `(missing: ${missing.join(', ') || 'unknown'}). Re-open the device session ` +
+            `(device_snapshot action=open appId=${bundleId ?? '<your.app.id>'} platform=android) to rebuild it.`);
+        this.missing = missing;
+    }
+}
+// GH #418: deleting the APKs is the artifact invalidation — apksExist flips
+// false, so resolveAndroidInstallAction returns 'build-then-install' (Gradle).
+// The invalidation and the install-action check share RUNNER_APK_PATHS so
+// they cannot drift apart.
+const RUNNER_APK_PATHS = [APK_APP, APK_TEST];
+export function androidRunnerApksExist() {
+    return RUNNER_APK_PATHS.every((p) => existsSync(p));
+}
+export function _androidRunnerApkPathsForTest() {
+    return RUNNER_APK_PATHS;
+}
+export function invalidateAndroidRunnerApks(rm = (p) => rmSync(p, { force: true })) {
+    for (const apk of RUNNER_APK_PATHS) {
+        try {
+            rm(apk);
+        }
+        catch {
+            /* best-effort; the install action check re-reads existsSync */
+        }
+    }
+}
+// GH #418: retry-once wrapper for the fresh-open case — the attempt spawns the
+// stale installed APK, the post-install verify throws the typed error, and (at
+// open only) we invalidate the APKs so the retry Gradle-rebuilds from source.
+export async function startAndroidRunner(deviceId, bundleId, devicePort = DEFAULT_PORT, opts = {}) {
+    try {
+        return await startAndroidRunnerAttempt(deviceId, bundleId, devicePort, opts);
+    }
+    catch (err) {
+        if (opts.allowArtifactRebuild && err instanceof AndroidCommandsStaleError) {
+            // Killing the local adb child does NOT free the device-side
+            // UiAutomation slot (#237) — reap through the slot-release path so the
+            // rebuilt instrumentation can bind.
+            await reapMismatchedAndroidRunner(deviceId);
+            invalidateAndroidRunnerApks();
+            const state = await startAndroidRunnerAttempt(deviceId, bundleId, devicePort, {
+                _forceReinstall: true,
+            });
+            pendingUpgradeNote = `runner artifact rebuilt (missing commands: ${err.missing.join(', ') || 'unknown'})`;
+            return state;
+        }
+        throw err;
+    }
+}
+async function startAndroidRunnerAttempt(deviceId, bundleId, devicePort = DEFAULT_PORT, opts = {}) {
     const serial = deviceId ?? (await resolveAndroidSerial());
     adoptPersistedAndroidState(serial);
-    let forceReinstall = false;
+    let forceReinstall = opts._forceReinstall === true;
     if (isAndroidRunnerAvailable() && shouldReuseAndroidRunner(runnerState, deviceId)) {
         const info = await probeAndroidRunnerHealthInfo(runnerState.hostPort);
         if (info.reachable && info.ok) {
             const compat = classifyAndroidHealth(info);
             if (compat.compatible)
                 return runnerState;
-            // GH #383: a reachable-but-incompatible runner is reaped (force-stop +
-            // state clear) and force-reinstalled so the fresh APK supersedes it.
-            pendingUpgradeNote = 'runner upgraded (protocol/version mismatch)';
+            if (compat.reason === 'missing-commands') {
+                // GH #418: reinstalling the SAME APK can't add commands — this is
+                // artifact staleness. Open invalidates + rebuilds; mid-flow refuses.
+                if (!opts.allowArtifactRebuild) {
+                    throw new AndroidCommandsStaleError(compat.missing ?? [], bundleId);
+                }
+                invalidateAndroidRunnerApks();
+                pendingUpgradeNote = `runner artifact rebuilt (missing commands: ${(compat.missing ?? []).join(', ') || 'unknown'})`;
+            }
+            else {
+                // GH #383: a reachable-but-incompatible runner is reaped (force-stop +
+                // state clear) and force-reinstalled so the fresh APK supersedes it.
+                pendingUpgradeNote = 'runner upgraded (protocol/version mismatch)';
+            }
             forceReinstall = true;
             await reapMismatchedAndroidRunner(deviceId);
         }
@@ -489,6 +561,12 @@ export async function startAndroidRunner(deviceId, bundleId, devicePort = DEFAUL
                     resolved = true;
                     pendingUpgradeNote = undefined; // review amendment: never report an upgrade that failed
                     child.kill('SIGTERM');
+                    if (compat.reason === 'missing-commands') {
+                        // GH #418: typed — the wrapper's retry-once invalidates the APKs
+                        // at open; mid-flow callers surface RUNNER_COMMANDS_STALE.
+                        reject(new AndroidCommandsStaleError(compat.missing ?? [], bundleId));
+                        return;
+                    }
                     reject(new Error(`RUNNER_PROTOCOL_MISMATCH: installed rn-android-runner speaks protocol ` +
                         `${info.protocolVersion ?? 'none'} (bridge expects ${RUNNER_PROTOCOL_VERSION}). ` +
                         `Rebuild + reinstall the runner APKs: cd ${RN_ANDROID_RUNNER_DIR} && ` +

--- a/scripts/cdp-bridge/dist/runners/rn-android-runner-client.js
+++ b/scripts/cdp-bridge/dist/runners/rn-android-runner-client.js
@@ -443,19 +443,16 @@ async function startAndroidRunnerAttempt(deviceId, bundleId, devicePort = DEFAUL
             if (compat.compatible)
                 return runnerState;
             if (compat.reason === 'missing-commands') {
-                // GH #418: reinstalling the SAME APK can't add commands — this is
-                // artifact staleness. Open invalidates + rebuilds; mid-flow refuses.
-                if (!opts.allowArtifactRebuild) {
-                    throw new AndroidCommandsStaleError(compat.missing ?? [], bundleId);
-                }
-                invalidateAndroidRunnerApks();
-                pendingUpgradeNote = `runner artifact rebuilt (missing commands: ${(compat.missing ?? []).join(', ') || 'unknown'})`;
+                // GH #418: reinstalling the SAME APK can't add commands — artifact
+                // staleness. Always throw the typed error: the retry-once wrapper is
+                // the SINGLE rebuild owner (one Gradle build even on a checkout whose
+                // fresh build still misses commands — multi-review advisory); mid-flow
+                // callers surface the typed refusal.
+                throw new AndroidCommandsStaleError(compat.missing ?? [], bundleId);
             }
-            else {
-                // GH #383: a reachable-but-incompatible runner is reaped (force-stop +
-                // state clear) and force-reinstalled so the fresh APK supersedes it.
-                pendingUpgradeNote = 'runner upgraded (protocol/version mismatch)';
-            }
+            // GH #383: a reachable-but-incompatible runner is reaped (force-stop +
+            // state clear) and force-reinstalled so the fresh APK supersedes it.
+            pendingUpgradeNote = 'runner upgraded (protocol/version mismatch)';
             forceReinstall = true;
             await reapMismatchedAndroidRunner(deviceId);
         }

--- a/scripts/cdp-bridge/dist/runners/rn-fast-runner-client.js
+++ b/scripts/cdp-bridge/dist/runners/rn-fast-runner-client.js
@@ -1,12 +1,12 @@
 import { spawn } from 'node:child_process';
 import { join } from 'node:path';
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, mkdirSync, rmSync, statSync, readFileSync, writeFileSync, } from 'node:fs';
 import { okResult, failResult } from '../utils.js';
 import { updateRefMapFromFlat, getCachedMetadata } from '../fast-runner-ref-map.js';
 import { isPortFree } from './free-port.js';
 import { withKeyboardGuard } from './keyboard-guard.js';
 import { runnerStatePath, readJsonStateFile, writeJsonStateFileAtomic, deleteStateFile, readLegacyTmpState, cleanupLegacyTmpState, } from '../util/secure-state-file.js';
-import { RUNNER_PROTOCOL_VERSION, getPluginVersion, classifyRunnerCompatibility, } from './protocol.js';
+import { RUNNER_PROTOCOL_VERSION, REQUIRED_IOS_COMMANDS, getPluginVersion, classifyRunnerCompatibility, } from './protocol.js';
 import { buildRunnerQuiescenceEnv } from './quiescence.js';
 const DEFAULT_PORT = 22088;
 const READY_TIMEOUT_MS = 30_000;
@@ -242,6 +242,67 @@ export function hasBuiltTestProduct(derivedDataPath) {
 export function derivedDataPathForRunner() {
     return join(FAST_RUNNER_PROJECT, 'build', 'DerivedData');
 }
+// GH #418 (review amendment): DerivedData is plugin-checkout-scoped while the
+// device lock is UDID-scoped, so two projects sharing this checkout could race
+// invalidate-vs-build. mkdir is atomic — it is the mutex. Fail-open on fs
+// errors (never block a legit session); stale takeover after 15 min.
+const REBUILD_LOCK_DIR = join(FAST_RUNNER_PROJECT, 'build', '.rebuild-lock');
+const REBUILD_LOCK_STALE_MS = 15 * 60_000;
+export function acquireRunnerRebuildLock() {
+    for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+            mkdirSync(REBUILD_LOCK_DIR, { recursive: false });
+            return true;
+        }
+        catch (err) {
+            if (err.code !== 'EEXIST')
+                return true; // fail-open
+            try {
+                const age = Date.now() - statSync(REBUILD_LOCK_DIR).mtimeMs;
+                if (age < REBUILD_LOCK_STALE_MS)
+                    return false;
+                rmSync(REBUILD_LOCK_DIR, { recursive: true, force: true });
+            }
+            catch {
+                return true; // fail-open
+            }
+        }
+    }
+    return false;
+}
+export function releaseRunnerRebuildLock() {
+    try {
+        rmSync(REBUILD_LOCK_DIR, { recursive: true, force: true });
+    }
+    catch {
+        /* best-effort */
+    }
+}
+// GH #418 (review amendment): at most ONE commands-triggered cold rebuild per
+// plugin version — a genuinely-broken checkout must not loop multi-minute
+// builds on every open. Lives in build/ (sibling of DerivedData) so the
+// invalidation itself can't erase it.
+const REBUILD_BUDGET_FILE = join(FAST_RUNNER_PROJECT, 'build', 'commands-rebuild.json');
+export const runnerRebuildBudget = {
+    alreadyRebuiltFor(pluginVersion) {
+        try {
+            const parsed = JSON.parse(readFileSync(REBUILD_BUDGET_FILE, 'utf8'));
+            return parsed.pluginVersion === pluginVersion;
+        }
+        catch {
+            return false;
+        }
+    },
+    recordRebuild(pluginVersion) {
+        try {
+            mkdirSync(join(FAST_RUNNER_PROJECT, 'build'), { recursive: true });
+            writeFileSync(REBUILD_BUDGET_FILE, JSON.stringify({ pluginVersion, at: new Date().toISOString() }));
+        }
+        catch {
+            /* fail-open */
+        }
+    },
+};
 // --- Lifecycle ---
 /**
  * GH#202: only adopt an existing runner when it is bound to the SAME
@@ -423,6 +484,7 @@ async function defaultHttpProbe(port, timeoutMs) {
         let protocolVersion;
         let runnerVersion;
         let capabilities;
+        let commands;
         try {
             const body = (await res.json());
             bodyOk = body.ok === true;
@@ -432,6 +494,9 @@ async function defaultHttpProbe(port, timeoutMs) {
                 runnerVersion = body.runnerVersion;
             if (Array.isArray(body.capabilities)) {
                 capabilities = body.capabilities.filter((c) => typeof c === 'string');
+            }
+            if (Array.isArray(body.commands)) {
+                commands = body.commands.filter((c) => typeof c === 'string');
             }
         }
         catch {
@@ -444,6 +509,7 @@ async function defaultHttpProbe(port, timeoutMs) {
             ...(protocolVersion !== undefined ? { protocolVersion } : {}),
             ...(runnerVersion !== undefined ? { runnerVersion } : {}),
             ...(capabilities !== undefined ? { capabilities } : {}),
+            ...(commands !== undefined ? { commands } : {}),
         };
     }
     finally {
@@ -485,11 +551,13 @@ export async function probeFastRunnerLivenessDetailed(deps = {}) {
         const compat = classifyRunnerCompatibility({
             ...(res.protocolVersion !== undefined ? { protocolVersion: res.protocolVersion } : {}),
             ...(res.runnerVersion !== undefined ? { runnerVersion: res.runnerVersion } : {}),
-        }, plugin);
+            ...(res.commands !== undefined ? { commands: res.commands } : {}),
+        }, plugin, REQUIRED_IOS_COMMANDS);
         if (!compat.compatible) {
             return {
                 liveness: 'stale',
                 staleReason: compat.reason,
+                ...(compat.missing !== undefined ? { missingCommands: compat.missing } : {}),
                 ...(res.protocolVersion !== undefined
                     ? { runnerProtocolVersion: res.protocolVersion }
                     : {}),

--- a/scripts/cdp-bridge/dist/tools/device-session-health.js
+++ b/scripts/cdp-bridge/dist/tools/device-session-health.js
@@ -29,6 +29,9 @@ export async function getDeviceSessionHealth(deps = {}) {
                         : {}),
                     ...(detail.runnerVersion !== undefined ? { runnerVersion: detail.runnerVersion } : {}),
                     ...(plugin !== null ? { pluginVersion: plugin } : {}),
+                    ...(detail.missingCommands !== undefined
+                        ? { missingCommands: detail.missingCommands }
+                        : {}),
                     compatible: detail.liveness === 'alive',
                 };
                 // GH #384: omit empty lists — every pre-#384 runner reports

--- a/scripts/cdp-bridge/dist/tools/device-session.js
+++ b/scripts/cdp-bridge/dist/tools/device-session.js
@@ -173,7 +173,11 @@ export function createDeviceSnapshotHandler() {
                     // swallows its own start error), so `open` surfaces RN_FAST_RUNNER_DOWN
                     // here instead of falsely reporting success against an un-prebuilt rig.
                     // GH #383: propagate its typed code (RUNNER_PROTOCOL_MISMATCH) when set.
-                    const ready = await ensureRunnerForCommand(deviceId, appId);
+                    // GH #418: open is the only entry allowed to invalidate a stale
+                    // runner artifact and pay the cold rebuild (mid-flow refuses fast).
+                    const ready = await ensureRunnerForCommand(deviceId, appId, {
+                        allowArtifactRebuild: true,
+                    });
                     if (!ready.ok) {
                         releaseDeviceLockForSession();
                         return failResult(ready.message, ready.code ?? 'RN_FAST_RUNNER_DOWN');
@@ -189,7 +193,8 @@ export function createDeviceSnapshotHandler() {
                     });
                 }
                 else {
-                    await startAndroidRunner(deviceId, appId);
+                    // GH #418: open may invalidate stale runner APKs + Gradle-rebuild.
+                    await startAndroidRunner(deviceId, appId, undefined, { allowArtifactRebuild: true });
                     upgradeNote = consumePendingAndroidUpgradeNote();
                     if (!args.attachOnly) {
                         await execFile('adb', [
@@ -214,6 +219,11 @@ export function createDeviceSnapshotHandler() {
                 // doesn't leak onto the next successful Android result.
                 consumePendingAndroidUpgradeNote();
                 const msg = err instanceof Error ? err.message : String(err);
+                // GH #418: even the open-path rebuild couldn't produce a runner with
+                // the required commands — the checkout itself is suspect.
+                if (msg.startsWith('RUNNER_COMMANDS_STALE')) {
+                    return failResult(msg, 'RUNNER_COMMANDS_STALE');
+                }
                 // GH #383: a protocol mismatch that survived the reap+reinstall is a
                 // distinct, actionable failure — surface it, not the generic runner-down.
                 if (msg.startsWith('RUNNER_PROTOCOL_MISMATCH')) {

--- a/scripts/cdp-bridge/src/agent-device-wrapper.ts
+++ b/scripts/cdp-bridge/src/agent-device-wrapper.ts
@@ -641,8 +641,9 @@ async function rebuildStaleRunnerArtifact(
       code: 'RUNNER_COMMANDS_STALE',
       message:
         `rn-fast-runner was already cold-rebuilt once for plugin v${plugin} and still lacks ` +
-        `required commands (missing: ${missing}) — the checkout may be broken; update or ` +
-        `reinstall the plugin, then re-open the device session.`,
+        `required commands (missing: ${missing}). If that rebuild failed transiently (sim ` +
+        `not booted, xcodebuild flake), delete scripts/rn-fast-runner/build/commands-rebuild.json ` +
+        `and re-open to retry; otherwise update or reinstall the plugin.`,
     };
   }
   const acquire = deps.acquireBuildLock ?? acquireRunnerRebuildLock;
@@ -714,6 +715,20 @@ export async function ensureRunnerForCommand(
   // through to ensure(), which cold-builds. Without this, any runner death
   // after a cold `xcodebuild test` (which leaves no .xctestrun) bricks opens.
   if (decision.action === 'error' && !(deps.allowArtifactRebuild && deviceId)) {
+    // GH #418 (multi-review): a stale runner missing commands surfaces the
+    // typed refusal even when nothing is prebuilt — not the generic
+    // not-prebuilt message, whose code would be RN_FAST_RUNNER_DOWN.
+    if (first.staleReason === 'missing-commands') {
+      const missing = (first.missingCommands ?? []).join(', ') || 'unknown';
+      return {
+        ok: false,
+        code: 'RUNNER_COMMANDS_STALE',
+        message:
+          `rn-fast-runner artifact lacks required commands (missing: ${missing}). ` +
+          `Re-open the device session (device_snapshot action=open appId=${bundleId} platform=ios) ` +
+          `to rebuild it (cold build, several minutes).`,
+      };
+    }
     return { ok: false, message: decision.message };
   }
 

--- a/scripts/cdp-bridge/src/agent-device-wrapper.ts
+++ b/scripts/cdp-bridge/src/agent-device-wrapper.ts
@@ -708,9 +708,16 @@ export async function ensureRunnerForCommand(
   }
   const decision = decideRunnerSpawn({ liveness: first.liveness, prebuilt: prebuilt(), deviceId });
   if (decision.action === 'proceed') return { ok: true };
-  if (decision.action === 'error') return { ok: false, message: decision.message };
+  // GH #418 (device-verify finding): open IS the sanctioned cold-build entry —
+  // the not-prebuilt refusal exists for mid-flow auto-spawn (#210), and its
+  // message directs users to open. With a device present, open must fall
+  // through to ensure(), which cold-builds. Without this, any runner death
+  // after a cold `xcodebuild test` (which leaves no .xctestrun) bricks opens.
+  if (decision.action === 'error' && !(deps.allowArtifactRebuild && deviceId)) {
+    return { ok: false, message: decision.message };
+  }
 
-  await ensure(decision.deviceId, bundleId);
+  await ensure(decision.action === 'spawn' ? decision.deviceId : deviceId!, bundleId);
   const after = await probe();
   if (after.liveness === 'alive') {
     if (first.staleReason && PROTOCOL_STALE_REASONS.has(first.staleReason)) {

--- a/scripts/cdp-bridge/src/agent-device-wrapper.ts
+++ b/scripts/cdp-bridge/src/agent-device-wrapper.ts
@@ -727,6 +727,13 @@ export async function ensureRunnerForCommand(
   // GH #418: 'missing-commands' surviving a respawn means the ARTIFACT is
   // stale — mid-flow callers refuse fast (never a silent multi-minute build).
   if (after.staleReason === 'missing-commands') {
+    // Open path, dead-runner-spawned-from-stale-prebuilt case: the first
+    // probe said 'dead', so the up-front short-circuit couldn't fire — the
+    // rebuild tier must still run here or the first open after an upgrade
+    // errors and only the SECOND open heals (device-verify finding).
+    if (deps.allowArtifactRebuild && deviceId) {
+      return rebuildStaleRunnerArtifact(after, deviceId, bundleId, deps);
+    }
     const missing = (after.missingCommands ?? []).join(', ') || 'unknown';
     return {
       ok: false,

--- a/scripts/cdp-bridge/src/agent-device-wrapper.ts
+++ b/scripts/cdp-bridge/src/agent-device-wrapper.ts
@@ -942,6 +942,11 @@ export async function runNative(
         // note must never attach to a LATER unrelated result.
         consumePendingAndroidUpgradeNote();
         const msg = err instanceof Error ? err.message : String(err);
+        // GH #418: a stale command surface mid-flow is a fast refusal — the
+        // open path (device_snapshot action=open) is the rebuild entry.
+        if (msg.startsWith('RUNNER_COMMANDS_STALE')) {
+          return failResult(msg, 'RUNNER_COMMANDS_STALE');
+        }
         // GH #383: a protocol mismatch surviving the reap+reinstall is a distinct,
         // actionable failure — surface it rather than the generic runner-down.
         if (msg.startsWith('RUNNER_PROTOCOL_MISMATCH')) {

--- a/scripts/cdp-bridge/src/agent-device-wrapper.ts
+++ b/scripts/cdp-bridge/src/agent-device-wrapper.ts
@@ -329,7 +329,9 @@ export function buildRunIOSArgs(
     case 'screenshot':
       return { command: 'screenshot', ...(bundleId ? { bundleId } : {}) };
     case 'keyboard':
-      return { command: 'dismissKeyboard', ...(bundleId ? { bundleId } : {}) };
+      // B235/#418: the Swift enum case is keyboardDismiss; 'dismissKeyboard'
+      // (the Android wire verb) never decoded on iOS.
+      return { command: 'keyboardDismiss', ...(bundleId ? { bundleId } : {}) };
     case 'swipe':
     case 'scroll': {
       // Coordinate-based gesture. The Swift `.swipe` is tvOS-only; iOS

--- a/scripts/cdp-bridge/src/agent-device-wrapper.ts
+++ b/scripts/cdp-bridge/src/agent-device-wrapper.ts
@@ -1,4 +1,4 @@
-import { unlinkSync } from 'node:fs';
+import { unlinkSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import type { ToolResult } from './utils.js';
@@ -12,7 +12,11 @@ import {
   reapStaleFastRunner,
   hasBuiltTestProduct,
   derivedDataPathForRunner,
+  acquireRunnerRebuildLock,
+  releaseRunnerRebuildLock,
+  runnerRebuildBudget,
 } from './runners/rn-fast-runner-client.js';
+import { getPluginVersion } from './runners/protocol.js';
 import type {
   FastRunnerLiveness,
   FastRunnerLivenessDetail,
@@ -591,6 +595,15 @@ export interface EnsureRunnerDeps {
   ensure?: (deviceId: string, bundleId: string) => Promise<void>;
   prebuilt?: () => boolean;
   adopt?: (deviceId: string | undefined) => void;
+  /** GH #418: open-path only — permits DerivedData invalidation + cold rebuild. */
+  allowArtifactRebuild?: boolean;
+  /** GH #418: test seams for the rebuild tier. */
+  invalidateArtifact?: () => void;
+  reap?: () => Promise<void>;
+  acquireBuildLock?: () => boolean;
+  releaseBuildLock?: () => void;
+  rebuildBudget?: { alreadyRebuiltFor(v: string): boolean; recordRebuild(v: string): void };
+  pluginVersion?: string | null;
 }
 
 export type EnsureRunnerResult =
@@ -602,7 +615,73 @@ const PROTOCOL_STALE_REASONS = new Set([
   'protocol-older',
   'protocol-newer',
   'version-skew',
+  // GH #418: a respawn can fix a runner PROCESS older than the on-disk
+  // artifact; artifact staleness surviving the respawn is handled separately.
+  'missing-commands',
 ]);
+
+// GH #418: the open-path rebuild tier. A respawn reuses the same build
+// artifact, so 'missing-commands' can only be fixed by invalidating
+// DerivedData and paying the cold rebuild — allowed at device_snapshot
+// action=open only, reap-first, serialized behind the checkout-scoped build
+// lock, at most once per plugin version (a broken checkout must not loop
+// multi-minute builds).
+async function rebuildStaleRunnerArtifact(
+  first: FastRunnerLivenessDetail,
+  deviceId: string,
+  bundleId: string,
+  deps: EnsureRunnerDeps,
+): Promise<EnsureRunnerResult> {
+  const missing = (first.missingCommands ?? []).join(', ') || 'unknown';
+  const plugin = deps.pluginVersion !== undefined ? deps.pluginVersion : getPluginVersion();
+  const budget = deps.rebuildBudget ?? runnerRebuildBudget;
+  if (plugin !== null && budget.alreadyRebuiltFor(plugin)) {
+    return {
+      ok: false,
+      code: 'RUNNER_COMMANDS_STALE',
+      message:
+        `rn-fast-runner was already cold-rebuilt once for plugin v${plugin} and still lacks ` +
+        `required commands (missing: ${missing}) — the checkout may be broken; update or ` +
+        `reinstall the plugin, then re-open the device session.`,
+    };
+  }
+  const acquire = deps.acquireBuildLock ?? acquireRunnerRebuildLock;
+  if (!acquire()) {
+    return {
+      ok: false,
+      code: 'RUNNER_COMMANDS_STALE',
+      message:
+        'another session is rebuilding the shared runner artifact — retry this open in a few minutes.',
+    };
+  }
+  const release = deps.releaseBuildLock ?? releaseRunnerRebuildLock;
+  try {
+    const reap = deps.reap ?? reapStaleFastRunner;
+    await reap();
+    const invalidate =
+      deps.invalidateArtifact ??
+      (() => rmSync(derivedDataPathForRunner(), { recursive: true, force: true }));
+    invalidate();
+    if (plugin !== null) budget.recordRebuild(plugin);
+    const ensure = deps.ensure ?? ensureFastRunner;
+    await ensure(deviceId, bundleId);
+  } finally {
+    release();
+  }
+  const probe = deps.probe ?? probeFastRunnerLivenessDetailed;
+  const rebuilt = await probe();
+  if (rebuilt.liveness === 'alive') {
+    return { ok: true, note: `runner artifact rebuilt (missing commands: ${missing})` };
+  }
+  return {
+    ok: false,
+    code: 'RUNNER_COMMANDS_STALE',
+    message:
+      `rn-fast-runner still lacks required commands after a cold rebuild ` +
+      `(missing: ${(rebuilt.missingCommands ?? first.missingCommands ?? []).join(', ') || 'unknown'}). ` +
+      `The plugin checkout itself may be outdated — update the plugin, then re-open the device session.`,
+  };
+}
 
 // #210: orchestrate probe → gate → spawn → RE-VERIFY → structured result. ensureFastRunner
 // swallows start errors, so the re-probe is what turns a failed spawn into a clean message
@@ -622,6 +701,11 @@ export async function ensureRunnerForCommand(
 
   adopt(deviceId ?? undefined);
   const first = await probe();
+  // GH #418: artifact staleness at open — a respawn launches the same stale
+  // .xctestrun, so skip it and invalidate up front (multi-LLM review amendment).
+  if (first.staleReason === 'missing-commands' && deps.allowArtifactRebuild && deviceId) {
+    return rebuildStaleRunnerArtifact(first, deviceId, bundleId, deps);
+  }
   const decision = decideRunnerSpawn({ liveness: first.liveness, prebuilt: prebuilt(), deviceId });
   if (decision.action === 'proceed') return { ok: true };
   if (decision.action === 'error') return { ok: false, message: decision.message };
@@ -630,9 +714,28 @@ export async function ensureRunnerForCommand(
   const after = await probe();
   if (after.liveness === 'alive') {
     if (first.staleReason && PROTOCOL_STALE_REASONS.has(first.staleReason)) {
-      return { ok: true, note: 'runner upgraded (protocol/version mismatch)' };
+      return {
+        ok: true,
+        note:
+          first.staleReason === 'missing-commands'
+            ? 'runner upgraded (stale command surface)'
+            : 'runner upgraded (protocol/version mismatch)',
+      };
     }
     return { ok: true };
+  }
+  // GH #418: 'missing-commands' surviving a respawn means the ARTIFACT is
+  // stale — mid-flow callers refuse fast (never a silent multi-minute build).
+  if (after.staleReason === 'missing-commands') {
+    const missing = (after.missingCommands ?? []).join(', ') || 'unknown';
+    return {
+      ok: false,
+      code: 'RUNNER_COMMANDS_STALE',
+      message:
+        `rn-fast-runner artifact lacks required commands (missing: ${missing}). ` +
+        `Re-open the device session (device_snapshot action=open appId=${bundleId} platform=ios) ` +
+        `to rebuild it (cold build, several minutes).`,
+    };
   }
   if (after.staleReason && PROTOCOL_STALE_REASONS.has(after.staleReason)) {
     return {

--- a/scripts/cdp-bridge/src/runners/protocol.ts
+++ b/scripts/cdp-bridge/src/runners/protocol.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import type { RunIOSArgs } from './rn-fast-runner-client.js';
+import type { RunAndroidArgs } from './rn-android-runner-client.js';
 
 // GH #383: the native runner /command wire protocol version. Mirrored by
 // RunnerProtocol.swift (iOS) and RunnerProtocol.kt (Android); the tri-file
@@ -13,15 +15,45 @@ export type RunnerIncompatibilityReason =
   | 'legacy'
   | 'protocol-older'
   | 'protocol-newer'
-  | 'version-skew';
+  | 'version-skew'
+  | 'missing-commands';
 
 export type RunnerCompatibility =
   | { compatible: true }
-  | { compatible: false; reason: RunnerIncompatibilityReason };
+  | { compatible: false; reason: RunnerIncompatibilityReason; missing?: string[] };
+
+// GH #418: every wire verb the bridge can POST to each runner's /command —
+// a curated subset of the client command unions (lifecycle/tvOS verbs are
+// deliberately not gated). The satisfies tie makes a typo'd verb a compile
+// error; gh-418-command-surface-sync.test.js enforces the native side.
+export const REQUIRED_IOS_COMMANDS = [
+  'tap',
+  'type',
+  'drag',
+  'longPress',
+  'pinch',
+  'snapshot',
+  'screenshot',
+  'back',
+  'keyboardDismiss',
+] as const satisfies readonly RunIOSArgs['command'][];
+
+export const REQUIRED_ANDROID_COMMANDS = [
+  'tap',
+  'type',
+  'drag',
+  'longPress',
+  'pinch',
+  'snapshot',
+  'screenshot',
+  'back',
+  'dismissKeyboard',
+] as const satisfies readonly RunAndroidArgs['command'][];
 
 export function classifyRunnerCompatibility(
-  health: { protocolVersion?: number; runnerVersion?: string },
+  health: { protocolVersion?: number; runnerVersion?: string; commands?: string[] },
   pluginVersion: string | null,
+  requiredCommands?: readonly string[],
 ): RunnerCompatibility {
   if (health.protocolVersion === undefined) return { compatible: false, reason: 'legacy' };
   if (health.protocolVersion < MIN_SUPPORTED_RUNNER_PROTOCOL) {
@@ -36,6 +68,15 @@ export function classifyRunnerCompatibility(
     health.runnerVersion !== pluginVersion
   ) {
     return { compatible: false, reason: 'version-skew' };
+  }
+  // GH #418: strict on absence — an artifact that doesn't enumerate commands
+  // predates enumeration and by definition predates any newer verb.
+  if (requiredCommands !== undefined) {
+    const advertised = new Set(health.commands ?? []);
+    const missing = requiredCommands.filter((c) => !advertised.has(c));
+    if (missing.length > 0) {
+      return { compatible: false, reason: 'missing-commands', missing };
+    }
   }
   return { compatible: true };
 }

--- a/scripts/cdp-bridge/src/runners/rn-android-runner-client.ts
+++ b/scripts/cdp-bridge/src/runners/rn-android-runner-client.ts
@@ -5,7 +5,7 @@
 import { spawn, execFile } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
 import { promisify } from 'node:util';
-import { writeFileSync, existsSync } from 'node:fs';
+import { writeFileSync, existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import type { ToolResult } from '../utils.js';
 import { okResult, failResult } from '../utils.js';
@@ -23,6 +23,7 @@ import {
 } from '../util/secure-state-file.js';
 import {
   RUNNER_PROTOCOL_VERSION,
+  REQUIRED_ANDROID_COMMANDS,
   getPluginVersion,
   classifyRunnerCompatibility,
 } from './protocol.js';
@@ -357,7 +358,7 @@ async function ensureAndroidRunnerInstalled(
   const action = resolveAndroidInstallAction({
     instrumentationRegistered:
       !opts.forceReinstall && isInstrumentationRegistered(pmOut, INSTRUMENTATION),
-    apksExist: existsSync(APK_APP) && existsSync(APK_TEST),
+    apksExist: androidRunnerApksExist(),
   });
   if (action === 'reuse') return;
 
@@ -460,6 +461,7 @@ export interface AndroidHealthInfo {
   ok?: boolean;
   protocolVersion?: number;
   runnerVersion?: string;
+  commands?: string[];
 }
 
 export async function probeAndroidRunnerHealthInfo(port: number): Promise<AndroidHealthInfo> {
@@ -474,6 +476,7 @@ export async function probeAndroidRunnerHealthInfo(port: number): Promise<Androi
       ok?: boolean;
       protocolVersion?: number;
       runnerVersion?: string;
+      commands?: unknown;
     };
     return {
       reachable: true,
@@ -482,6 +485,9 @@ export async function probeAndroidRunnerHealthInfo(port: number): Promise<Androi
         ? { protocolVersion: body.protocolVersion }
         : {}),
       ...(typeof body.runnerVersion === 'string' ? { runnerVersion: body.runnerVersion } : {}),
+      ...(Array.isArray(body.commands)
+        ? { commands: body.commands.filter((c): c is string => typeof c === 'string') }
+        : {}),
     };
   } catch {
     return { reachable: false };
@@ -518,27 +524,118 @@ function classifyAndroidHealth(info: AndroidHealthInfo) {
     {
       ...(info.protocolVersion !== undefined ? { protocolVersion: info.protocolVersion } : {}),
       ...(info.runnerVersion !== undefined ? { runnerVersion: info.runnerVersion } : {}),
+      ...(info.commands !== undefined ? { commands: info.commands } : {}),
     },
     getPluginVersion(),
+    REQUIRED_ANDROID_COMMANDS,
   );
 }
 
+// GH #418: mid-flow refusal + retry-once signal. The message prefix is the
+// wire contract — device-session.ts and agent-device-wrapper.ts map it to the
+// RUNNER_COMMANDS_STALE ToolErrorCode by startsWith, mirroring
+// RUNNER_PROTOCOL_MISMATCH.
+export class AndroidCommandsStaleError extends Error {
+  constructor(
+    readonly missing: string[],
+    bundleId?: string,
+  ) {
+    super(
+      `RUNNER_COMMANDS_STALE: installed rn-android-runner lacks required commands ` +
+        `(missing: ${missing.join(', ') || 'unknown'}). Re-open the device session ` +
+        `(device_snapshot action=open appId=${bundleId ?? '<your.app.id>'} platform=android) to rebuild it.`,
+    );
+  }
+}
+
+// GH #418: deleting the APKs is the artifact invalidation — apksExist flips
+// false, so resolveAndroidInstallAction returns 'build-then-install' (Gradle).
+// The invalidation and the install-action check share RUNNER_APK_PATHS so
+// they cannot drift apart.
+const RUNNER_APK_PATHS = [APK_APP, APK_TEST] as const;
+
+export function androidRunnerApksExist(): boolean {
+  return RUNNER_APK_PATHS.every((p) => existsSync(p));
+}
+
+export function _androidRunnerApkPathsForTest(): readonly string[] {
+  return RUNNER_APK_PATHS;
+}
+
+export function invalidateAndroidRunnerApks(
+  rm: (path: string) => void = (p) => rmSync(p, { force: true }),
+): void {
+  for (const apk of RUNNER_APK_PATHS) {
+    try {
+      rm(apk);
+    } catch {
+      /* best-effort; the install action check re-reads existsSync */
+    }
+  }
+}
+
+export interface StartAndroidRunnerOpts {
+  /** GH #418: open-path only — permits APK invalidation + Gradle rebuild. */
+  allowArtifactRebuild?: boolean;
+  /** Internal: set by the rebuild retry so the install action can't 'reuse'. */
+  _forceReinstall?: boolean;
+}
+
+// GH #418: retry-once wrapper for the fresh-open case — the attempt spawns the
+// stale installed APK, the post-install verify throws the typed error, and (at
+// open only) we invalidate the APKs so the retry Gradle-rebuilds from source.
 export async function startAndroidRunner(
   deviceId?: string,
   bundleId?: string,
   devicePort = DEFAULT_PORT,
+  opts: StartAndroidRunnerOpts = {},
+): Promise<AndroidRunnerState> {
+  try {
+    return await startAndroidRunnerAttempt(deviceId, bundleId, devicePort, opts);
+  } catch (err) {
+    if (opts.allowArtifactRebuild && err instanceof AndroidCommandsStaleError) {
+      // Killing the local adb child does NOT free the device-side
+      // UiAutomation slot (#237) — reap through the slot-release path so the
+      // rebuilt instrumentation can bind.
+      await reapMismatchedAndroidRunner(deviceId);
+      invalidateAndroidRunnerApks();
+      const state = await startAndroidRunnerAttempt(deviceId, bundleId, devicePort, {
+        _forceReinstall: true,
+      });
+      pendingUpgradeNote = `runner artifact rebuilt (missing commands: ${err.missing.join(', ') || 'unknown'})`;
+      return state;
+    }
+    throw err;
+  }
+}
+
+async function startAndroidRunnerAttempt(
+  deviceId?: string,
+  bundleId?: string,
+  devicePort = DEFAULT_PORT,
+  opts: StartAndroidRunnerOpts = {},
 ): Promise<AndroidRunnerState> {
   const serial = deviceId ?? (await resolveAndroidSerial());
   adoptPersistedAndroidState(serial);
-  let forceReinstall = false;
+  let forceReinstall = opts._forceReinstall === true;
   if (isAndroidRunnerAvailable() && shouldReuseAndroidRunner(runnerState, deviceId)) {
     const info = await probeAndroidRunnerHealthInfo(runnerState!.hostPort);
     if (info.reachable && info.ok) {
       const compat = classifyAndroidHealth(info);
       if (compat.compatible) return runnerState!;
-      // GH #383: a reachable-but-incompatible runner is reaped (force-stop +
-      // state clear) and force-reinstalled so the fresh APK supersedes it.
-      pendingUpgradeNote = 'runner upgraded (protocol/version mismatch)';
+      if (compat.reason === 'missing-commands') {
+        // GH #418: reinstalling the SAME APK can't add commands — this is
+        // artifact staleness. Open invalidates + rebuilds; mid-flow refuses.
+        if (!opts.allowArtifactRebuild) {
+          throw new AndroidCommandsStaleError(compat.missing ?? [], bundleId);
+        }
+        invalidateAndroidRunnerApks();
+        pendingUpgradeNote = `runner artifact rebuilt (missing commands: ${(compat.missing ?? []).join(', ') || 'unknown'})`;
+      } else {
+        // GH #383: a reachable-but-incompatible runner is reaped (force-stop +
+        // state clear) and force-reinstalled so the fresh APK supersedes it.
+        pendingUpgradeNote = 'runner upgraded (protocol/version mismatch)';
+      }
       forceReinstall = true;
       await reapMismatchedAndroidRunner(deviceId);
     }
@@ -660,6 +757,12 @@ export async function startAndroidRunner(
           resolved = true;
           pendingUpgradeNote = undefined; // review amendment: never report an upgrade that failed
           child.kill('SIGTERM');
+          if (compat.reason === 'missing-commands') {
+            // GH #418: typed — the wrapper's retry-once invalidates the APKs
+            // at open; mid-flow callers surface RUNNER_COMMANDS_STALE.
+            reject(new AndroidCommandsStaleError(compat.missing ?? [], bundleId));
+            return;
+          }
           reject(
             new Error(
               `RUNNER_PROTOCOL_MISMATCH: installed rn-android-runner speaks protocol ` +

--- a/scripts/cdp-bridge/src/runners/rn-android-runner-client.ts
+++ b/scripts/cdp-bridge/src/runners/rn-android-runner-client.ts
@@ -624,18 +624,16 @@ async function startAndroidRunnerAttempt(
       const compat = classifyAndroidHealth(info);
       if (compat.compatible) return runnerState!;
       if (compat.reason === 'missing-commands') {
-        // GH #418: reinstalling the SAME APK can't add commands — this is
-        // artifact staleness. Open invalidates + rebuilds; mid-flow refuses.
-        if (!opts.allowArtifactRebuild) {
-          throw new AndroidCommandsStaleError(compat.missing ?? [], bundleId);
-        }
-        invalidateAndroidRunnerApks();
-        pendingUpgradeNote = `runner artifact rebuilt (missing commands: ${(compat.missing ?? []).join(', ') || 'unknown'})`;
-      } else {
-        // GH #383: a reachable-but-incompatible runner is reaped (force-stop +
-        // state clear) and force-reinstalled so the fresh APK supersedes it.
-        pendingUpgradeNote = 'runner upgraded (protocol/version mismatch)';
+        // GH #418: reinstalling the SAME APK can't add commands — artifact
+        // staleness. Always throw the typed error: the retry-once wrapper is
+        // the SINGLE rebuild owner (one Gradle build even on a checkout whose
+        // fresh build still misses commands — multi-review advisory); mid-flow
+        // callers surface the typed refusal.
+        throw new AndroidCommandsStaleError(compat.missing ?? [], bundleId);
       }
+      // GH #383: a reachable-but-incompatible runner is reaped (force-stop +
+      // state clear) and force-reinstalled so the fresh APK supersedes it.
+      pendingUpgradeNote = 'runner upgraded (protocol/version mismatch)';
       forceReinstall = true;
       await reapMismatchedAndroidRunner(deviceId);
     }

--- a/scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts
+++ b/scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts
@@ -18,6 +18,7 @@ import {
 } from '../util/secure-state-file.js';
 import {
   RUNNER_PROTOCOL_VERSION,
+  REQUIRED_IOS_COMMANDS,
   getPluginVersion,
   classifyRunnerCompatibility,
 } from './protocol.js';
@@ -535,6 +536,7 @@ export interface HttpProbeResult {
   protocolVersion?: number;
   runnerVersion?: string;
   capabilities?: string[];
+  commands?: string[];
 }
 
 export interface LivenessProbeDeps {
@@ -585,18 +587,23 @@ async function defaultHttpProbe(port: number, timeoutMs: number): Promise<HttpPr
     let protocolVersion: number | undefined;
     let runnerVersion: string | undefined;
     let capabilities: string[] | undefined;
+    let commands: string[] | undefined;
     try {
       const body = (await res.json()) as {
         ok?: boolean;
         protocolVersion?: number;
         runnerVersion?: string;
         capabilities?: unknown;
+        commands?: unknown;
       };
       bodyOk = body.ok === true;
       if (typeof body.protocolVersion === 'number') protocolVersion = body.protocolVersion;
       if (typeof body.runnerVersion === 'string') runnerVersion = body.runnerVersion;
       if (Array.isArray(body.capabilities)) {
         capabilities = body.capabilities.filter((c): c is string => typeof c === 'string');
+      }
+      if (Array.isArray(body.commands)) {
+        commands = body.commands.filter((c): c is string => typeof c === 'string');
       }
     } catch {
       bodyOk = false;
@@ -608,6 +615,7 @@ async function defaultHttpProbe(port: number, timeoutMs: number): Promise<HttpPr
       ...(protocolVersion !== undefined ? { protocolVersion } : {}),
       ...(runnerVersion !== undefined ? { runnerVersion } : {}),
       ...(capabilities !== undefined ? { capabilities } : {}),
+      ...(commands !== undefined ? { commands } : {}),
     };
   } finally {
     clearTimeout(timer);
@@ -635,6 +643,8 @@ export interface FastRunnerLivenessDetail {
   runnerProtocolVersion?: number;
   runnerVersion?: string;
   capabilities?: string[];
+  /** GH #418: set only when staleReason === 'missing-commands'. */
+  missingCommands?: string[];
 }
 
 export async function probeFastRunnerLivenessDetailed(
@@ -664,13 +674,16 @@ export async function probeFastRunnerLivenessDetailed(
       {
         ...(res.protocolVersion !== undefined ? { protocolVersion: res.protocolVersion } : {}),
         ...(res.runnerVersion !== undefined ? { runnerVersion: res.runnerVersion } : {}),
+        ...(res.commands !== undefined ? { commands: res.commands } : {}),
       },
       plugin,
+      REQUIRED_IOS_COMMANDS,
     );
     if (!compat.compatible) {
       return {
         liveness: 'stale',
         staleReason: compat.reason,
+        ...(compat.missing !== undefined ? { missingCommands: compat.missing } : {}),
         ...(res.protocolVersion !== undefined
           ? { runnerProtocolVersion: res.protocolVersion }
           : {}),

--- a/scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts
+++ b/scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts
@@ -458,7 +458,7 @@ export function stopFastRunner(deviceId?: string): void {
 // --- Legacy helper kept for device-interact.ts swipe path ---
 //
 // GH #105 iOS-MVP follow-up: the upstream agent-device runner exposed
-// per-verb HTTP endpoints (/tap, /swipe, /snapshot, /screenshot, /dismissKeyboard).
+// per-verb HTTP endpoints (/tap, /swipe, /snapshot, /screenshot, …).
 // Our in-tree RnFastRunner only exposes a single POST /command with
 // {command: '...', ...payload}. The unused fastTap/fastType/fastSnapshot/
 // fastScreenshot/fastDismissKeyboard helpers were dead code post-Task 8 —
@@ -740,7 +740,7 @@ export interface RunIOSArgs {
     | 'pinch'
     | 'findText'
     | 'type'
-    | 'dismissKeyboard'
+    | 'keyboardDismiss'
     | 'screenshot'
     | 'back'
     | 'scroll'

--- a/scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts
+++ b/scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts
@@ -1,7 +1,15 @@
 import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
 import { join } from 'node:path';
-import { existsSync, readdirSync } from 'node:fs';
+import {
+  existsSync,
+  readdirSync,
+  mkdirSync,
+  rmSync,
+  statSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
 import type { ToolResult } from '../utils.js';
 import { okResult, failResult } from '../utils.js';
 import type { FastRunnerState } from '../types.js';
@@ -304,6 +312,70 @@ export function hasBuiltTestProduct(derivedDataPath: string): boolean {
 export function derivedDataPathForRunner(): string {
   return join(FAST_RUNNER_PROJECT, 'build', 'DerivedData');
 }
+
+// GH #418 (review amendment): DerivedData is plugin-checkout-scoped while the
+// device lock is UDID-scoped, so two projects sharing this checkout could race
+// invalidate-vs-build. mkdir is atomic — it is the mutex. Fail-open on fs
+// errors (never block a legit session); stale takeover after 15 min.
+const REBUILD_LOCK_DIR = join(FAST_RUNNER_PROJECT, 'build', '.rebuild-lock');
+const REBUILD_LOCK_STALE_MS = 15 * 60_000;
+
+export function acquireRunnerRebuildLock(): boolean {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      mkdirSync(REBUILD_LOCK_DIR, { recursive: false });
+      return true;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') return true; // fail-open
+      try {
+        const age = Date.now() - statSync(REBUILD_LOCK_DIR).mtimeMs;
+        if (age < REBUILD_LOCK_STALE_MS) return false;
+        rmSync(REBUILD_LOCK_DIR, { recursive: true, force: true });
+      } catch {
+        return true; // fail-open
+      }
+    }
+  }
+  return false;
+}
+
+export function releaseRunnerRebuildLock(): void {
+  try {
+    rmSync(REBUILD_LOCK_DIR, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+// GH #418 (review amendment): at most ONE commands-triggered cold rebuild per
+// plugin version — a genuinely-broken checkout must not loop multi-minute
+// builds on every open. Lives in build/ (sibling of DerivedData) so the
+// invalidation itself can't erase it.
+const REBUILD_BUDGET_FILE = join(FAST_RUNNER_PROJECT, 'build', 'commands-rebuild.json');
+
+export const runnerRebuildBudget = {
+  alreadyRebuiltFor(pluginVersion: string): boolean {
+    try {
+      const parsed = JSON.parse(readFileSync(REBUILD_BUDGET_FILE, 'utf8')) as {
+        pluginVersion?: string;
+      };
+      return parsed.pluginVersion === pluginVersion;
+    } catch {
+      return false;
+    }
+  },
+  recordRebuild(pluginVersion: string): void {
+    try {
+      mkdirSync(join(FAST_RUNNER_PROJECT, 'build'), { recursive: true });
+      writeFileSync(
+        REBUILD_BUDGET_FILE,
+        JSON.stringify({ pluginVersion, at: new Date().toISOString() }),
+      );
+    } catch {
+      /* fail-open */
+    }
+  },
+};
 
 // --- Lifecycle ---
 

--- a/scripts/cdp-bridge/src/tools/device-session-health.ts
+++ b/scripts/cdp-bridge/src/tools/device-session-health.ts
@@ -21,6 +21,8 @@ export interface DeviceSessionHealth {
     runner?: number;
     runnerVersion?: string;
     pluginVersion?: string;
+    /** GH #418: verbs the runner artifact lacks (staleReason 'missing-commands'). */
+    missingCommands?: string[];
     compatible: boolean;
   };
   runnerCapabilities?: string[];
@@ -63,6 +65,9 @@ export async function getDeviceSessionHealth(
             : {}),
           ...(detail.runnerVersion !== undefined ? { runnerVersion: detail.runnerVersion } : {}),
           ...(plugin !== null ? { pluginVersion: plugin } : {}),
+          ...(detail.missingCommands !== undefined
+            ? { missingCommands: detail.missingCommands }
+            : {}),
           compatible: detail.liveness === 'alive',
         };
         // GH #384: omit empty lists — every pre-#384 runner reports

--- a/scripts/cdp-bridge/src/tools/device-session.ts
+++ b/scripts/cdp-bridge/src/tools/device-session.ts
@@ -264,7 +264,11 @@ export function createDeviceSnapshotHandler(): (args: SnapshotArgs) => Promise<T
           // swallows its own start error), so `open` surfaces RN_FAST_RUNNER_DOWN
           // here instead of falsely reporting success against an un-prebuilt rig.
           // GH #383: propagate its typed code (RUNNER_PROTOCOL_MISMATCH) when set.
-          const ready = await ensureRunnerForCommand(deviceId, appId);
+          // GH #418: open is the only entry allowed to invalidate a stale
+          // runner artifact and pay the cold rebuild (mid-flow refuses fast).
+          const ready = await ensureRunnerForCommand(deviceId, appId, {
+            allowArtifactRebuild: true,
+          });
           if (!ready.ok) {
             releaseDeviceLockForSession();
             return failResult(ready.message, ready.code ?? 'RN_FAST_RUNNER_DOWN');

--- a/scripts/cdp-bridge/src/tools/device-session.ts
+++ b/scripts/cdp-bridge/src/tools/device-session.ts
@@ -283,7 +283,8 @@ export function createDeviceSnapshotHandler(): (args: SnapshotArgs) => Promise<T
             /* already frontmost is OK */
           });
         } else {
-          await startAndroidRunner(deviceId, appId);
+          // GH #418: open may invalidate stale runner APKs + Gradle-rebuild.
+          await startAndroidRunner(deviceId, appId, undefined, { allowArtifactRebuild: true });
           upgradeNote = consumePendingAndroidUpgradeNote();
           if (!args.attachOnly) {
             await execFile(
@@ -311,6 +312,11 @@ export function createDeviceSnapshotHandler(): (args: SnapshotArgs) => Promise<T
         // doesn't leak onto the next successful Android result.
         consumePendingAndroidUpgradeNote();
         const msg = err instanceof Error ? err.message : String(err);
+        // GH #418: even the open-path rebuild couldn't produce a runner with
+        // the required commands — the checkout itself is suspect.
+        if (msg.startsWith('RUNNER_COMMANDS_STALE')) {
+          return failResult(msg, 'RUNNER_COMMANDS_STALE');
+        }
         // GH #383: a protocol mismatch that survived the reap+reinstall is a
         // distinct, actionable failure — surface it, not the generic runner-down.
         if (msg.startsWith('RUNNER_PROTOCOL_MISMATCH')) {

--- a/scripts/cdp-bridge/src/types.ts
+++ b/scripts/cdp-bridge/src/types.ts
@@ -252,6 +252,9 @@ export type ToolErrorCode =
   | 'STORE_TRUNCATED' // expect_redux when store payload exceeded safeStringify cap
   // Phase 134.2: appId / packageName validation at adb shell boundary.
   | 'INVALID_APPID' // device_permission
+  // GH #418: command-surface gate.
+  | 'UNSUPPORTED_COMMAND' // runner rejected a verb its artifact predates (typed by the runner)
+  | 'RUNNER_COMMANDS_STALE' // liveness gate: artifact lacks required commands; re-open to rebuild
   | 'DEVICE_RESET_INVALID_APPID' // device_reset_state
   | 'INVALID_PACKAGE_NAME' // device_deeplink
   | 'INVALID_BUNDLE_ID' // GH #262 codex-pair: cdp_restart explicit bundleId arg failed strict validation

--- a/scripts/cdp-bridge/test/unit/fast-runner-liveness.test.js
+++ b/scripts/cdp-bridge/test/unit/fast-runner-liveness.test.js
@@ -117,7 +117,13 @@ test('M7 probe: timeoutMs override forwards to httpProbe', async () => {
     processAlive: () => true,
     httpProbe: async (_port, timeoutMs) => {
       observedTimeout = timeoutMs;
-      return { ok: true, status: 200, bodyOk: true, protocolVersion: 1 };
+      return {
+        ok: true,
+        status: 200,
+        bodyOk: true,
+        protocolVersion: 1,
+        commands: [...REQUIRED_IOS_COMMANDS],
+      };
     },
     pluginVersion: null,
     timeoutMs: 750,
@@ -132,7 +138,13 @@ test('M7 probe: default timeout is 2000ms (matches existing fastHealthCheck)', a
     processAlive: () => true,
     httpProbe: async (_port, timeoutMs) => {
       observedTimeout = timeoutMs;
-      return { ok: true, status: 200, bodyOk: true, protocolVersion: 1 };
+      return {
+        ok: true,
+        status: 200,
+        bodyOk: true,
+        protocolVersion: 1,
+        commands: [...REQUIRED_IOS_COMMANDS],
+      };
     },
     pluginVersion: null,
   });
@@ -159,7 +171,13 @@ test('M7 probe: alive path does NOT clear state', async () => {
   await probeFastRunnerLiveness({
     getState: () => STATE,
     processAlive: () => true,
-    httpProbe: async () => ({ ok: true, status: 200, bodyOk: true, protocolVersion: 1 }),
+    httpProbe: async () => ({
+      ok: true,
+      status: 200,
+      bodyOk: true,
+      protocolVersion: 1,
+      commands: [...REQUIRED_IOS_COMMANDS],
+    }),
     pluginVersion: null,
     clearState: () => {
       clearCalls++;

--- a/scripts/cdp-bridge/test/unit/fast-runner-liveness.test.js
+++ b/scripts/cdp-bridge/test/unit/fast-runner-liveness.test.js
@@ -4,6 +4,7 @@ import {
   probeFastRunnerLiveness,
   reapStaleFastRunner,
 } from '../../dist/runners/rn-fast-runner-client.js';
+import { REQUIRED_IOS_COMMANDS } from '../../dist/runners/protocol.js';
 
 // M7 / D666 — hermetic tests for the tri-state fast-runner liveness probe.
 // Mirrors the injectable-deps pattern from test/unit/lockfile.test.js so we
@@ -46,11 +47,18 @@ test('M7 probe: returns dead and clears state when PID has exited', async () => 
 test('M7 probe: returns alive when PID lives and /health returns {ok:true}', async () => {
   // GH #383: alive now also requires a compatible protocol; `1` matches
   // RUNNER_PROTOCOL_VERSION (tri-file sync test guards drift). pluginVersion:null
-  // keeps this hermetic — no version-skew intent here.
+  // keeps this hermetic — no version-skew intent here. GH #418: alive also
+  // requires the full advertised command surface.
   const liveness = await probeFastRunnerLiveness({
     getState: () => STATE,
     processAlive: () => true,
-    httpProbe: async () => ({ ok: true, status: 200, bodyOk: true, protocolVersion: 1 }),
+    httpProbe: async () => ({
+      ok: true,
+      status: 200,
+      bodyOk: true,
+      protocolVersion: 1,
+      commands: [...REQUIRED_IOS_COMMANDS],
+    }),
     pluginVersion: null,
   });
   assert.equal(liveness, 'alive');

--- a/scripts/cdp-bridge/test/unit/gh-243-android-runner-health.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-243-android-runner-health.test.js
@@ -7,8 +7,10 @@ import {
   _setFetchForTest,
   _setAndroidRunnerStateForTest,
 } from '../../dist/runners/rn-android-runner-client.js';
+import { REQUIRED_ANDROID_COMMANDS } from '../../dist/runners/protocol.js';
 
 afterEach(() => {
+  _setAndroidRunnerStateForTest(null);
   _setFetchForTest(globalThis.fetch);
 });
 
@@ -94,9 +96,18 @@ test('#243 runAndroid returns RN_ANDROID_RUNNER_DOWN (not bare "fetch failed") o
   // GH #383: the reuse gate probes GET /health first — answer it healthy +
   // compatible so the live injected runner is reused (no reap/real adb), then
   // fail the /command POST to exercise the connection-failure → RN_ANDROID_RUNNER_DOWN map.
+  // GH #418: compatible now also requires the full advertised command surface.
   _setFetchForTest(async (url) => {
     if (String(url).endsWith('/health')) {
-      return { ok: true, status: 200, json: async () => ({ ok: true, protocolVersion: 1 }) };
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          protocolVersion: 1,
+          commands: [...REQUIRED_ANDROID_COMMANDS],
+        }),
+      };
     }
     throw new Error('fetch failed');
   });

--- a/scripts/cdp-bridge/test/unit/gh-383-ios-protocol-gate.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-383-ios-protocol-gate.test.js
@@ -5,6 +5,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { probeFastRunnerLivenessDetailed } from '../../dist/runners/rn-fast-runner-client.js';
 import { ensureRunnerForCommand } from '../../dist/agent-device-wrapper.js';
+import { REQUIRED_IOS_COMMANDS } from '../../dist/runners/protocol.js';
 
 const STATE = { pid: 1, port: 22088, deviceId: 'U1', bundleId: 'com.example' };
 const deps = (probeBody, plugin = '0.58.0') => ({
@@ -16,8 +17,16 @@ const deps = (probeBody, plugin = '0.58.0') => ({
 });
 
 test('gh-383 gate: healthy + matching protocol + version → alive', async () => {
+  // GH #418: alive now also requires the full advertised command surface.
   const d = await probeFastRunnerLivenessDetailed(
-    deps({ ok: true, status: 200, bodyOk: true, protocolVersion: 1, runnerVersion: '0.58.0' }),
+    deps({
+      ok: true,
+      status: 200,
+      bodyOk: true,
+      protocolVersion: 1,
+      runnerVersion: '0.58.0',
+      commands: [...REQUIRED_IOS_COMMANDS],
+    }),
   );
   assert.deepEqual(d, {
     liveness: 'alive',
@@ -45,7 +54,17 @@ test('gh-383 gate: newer protocol → stale/protocol-newer; version skew → sta
 
 test('gh-383 gate: version check is fail-open when plugin version unknown', async () => {
   const d = await probeFastRunnerLivenessDetailed(
-    deps({ ok: true, status: 200, bodyOk: true, protocolVersion: 1, runnerVersion: '0.0.1' }, null),
+    deps(
+      {
+        ok: true,
+        status: 200,
+        bodyOk: true,
+        protocolVersion: 1,
+        runnerVersion: '0.0.1',
+        commands: [...REQUIRED_IOS_COMMANDS],
+      },
+      null,
+    ),
   );
   assert.equal(d.liveness, 'alive');
 });

--- a/scripts/cdp-bridge/test/unit/gh-383-open-path-surfacing.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-383-open-path-surfacing.test.js
@@ -29,9 +29,11 @@ test('gh-383: open success carries the upgrade note (iOS ready.note, Android pen
 });
 
 test('gh-383: Android note is consumed immediately after startAndroidRunner succeeds (never left pending)', () => {
+  // GH #418: the open call gained { allowArtifactRebuild: true } — the
+  // invariant is unchanged: the note is consumed on the very next line.
   assert.match(
     sessionSrc,
-    /await startAndroidRunner\(deviceId, appId\);\s*\n\s*upgradeNote = consumePendingAndroidUpgradeNote\(\);/,
+    /await startAndroidRunner\(deviceId, appId, undefined, \{ allowArtifactRebuild: true \}\);\s*\n\s*upgradeNote = consumePendingAndroidUpgradeNote\(\);/,
   );
 });
 

--- a/scripts/cdp-bridge/test/unit/gh-418-android-command-gate.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-418-android-command-gate.test.js
@@ -1,0 +1,76 @@
+// GH #418: the Android health probe parses /health.commands, the classify
+// helper enforces REQUIRED_ANDROID_COMMANDS, and remediation is a REAL
+// invalidation tier — deleting the APKs forces resolveAndroidInstallAction
+// into 'build-then-install' (review amendment: 'install' alone re-installs
+// the same stale APK and never runs Gradle).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  probeAndroidRunnerHealthInfo,
+  resolveAndroidInstallAction,
+  invalidateAndroidRunnerApks,
+  _androidRunnerApkPathsForTest,
+  AndroidCommandsStaleError,
+  _setFetchForTest,
+} from '../../dist/runners/rn-android-runner-client.js';
+import {
+  classifyRunnerCompatibility,
+  REQUIRED_ANDROID_COMMANDS,
+} from '../../dist/runners/protocol.js';
+
+test('gh-418 android: probe parses commands array (non-strings filtered)', async () => {
+  _setFetchForTest(async () => ({
+    ok: true,
+    json: async () => ({
+      ok: true,
+      protocolVersion: 1,
+      commands: ['tap', 'type', 7, 'snapshot'],
+    }),
+  }));
+  try {
+    const info = await probeAndroidRunnerHealthInfo(4723);
+    assert.deepEqual(info.commands, ['tap', 'type', 'snapshot']);
+  } finally {
+    _setFetchForTest(globalThis.fetch);
+  }
+});
+
+test('gh-418 android: absent commands + required list → missing-commands', () => {
+  assert.deepEqual(
+    classifyRunnerCompatibility({ protocolVersion: 1 }, null, REQUIRED_ANDROID_COMMANDS),
+    {
+      compatible: false,
+      reason: 'missing-commands',
+      missing: [...REQUIRED_ANDROID_COMMANDS],
+    },
+  );
+});
+
+test('gh-418 android: AndroidCommandsStaleError message carries the typed prefix + hint', () => {
+  const err = new AndroidCommandsStaleError(['dismissKeyboard'], 'com.example');
+  assert.ok(err.message.startsWith('RUNNER_COMMANDS_STALE'));
+  assert.match(err.message, /dismissKeyboard/);
+  assert.match(err.message, /device_snapshot action=open/);
+  assert.deepEqual(err.missing, ['dismissKeyboard']);
+});
+
+test('gh-418 android: invalidation deletes exactly the paths the apksExist check reads', () => {
+  const removed = [];
+  invalidateAndroidRunnerApks((p) => removed.push(p));
+  // Same source of truth (RUNNER_APK_PATHS) as androidRunnerApksExist — a
+  // drift between what is deleted and what is existence-checked fails here.
+  assert.deepEqual(removed, [..._androidRunnerApkPathsForTest()]);
+  assert.ok(removed.some((p) => p.endsWith('app-debug.apk')));
+  assert.ok(removed.some((p) => p.endsWith('app-debug-androidTest.apk')));
+  // With the APKs gone the pure decision is Gradle:
+  assert.equal(
+    resolveAndroidInstallAction({ instrumentationRegistered: false, apksExist: false }),
+    'build-then-install',
+  );
+  // …whereas a stale-but-present APK alone would only be re-installed, never
+  // rebuilt — the blind spot this tier closes:
+  assert.equal(
+    resolveAndroidInstallAction({ instrumentationRegistered: false, apksExist: true }),
+    'install',
+  );
+});

--- a/scripts/cdp-bridge/test/unit/gh-418-command-surface-classify.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-418-command-surface-classify.test.js
@@ -13,7 +13,11 @@ const FULL = [...REQUIRED_IOS_COMMANDS];
 
 test('gh-418 classify: commands ⊇ required → compatible', () => {
   assert.deepEqual(
-    classifyRunnerCompatibility({ protocolVersion: 1, commands: FULL }, null, REQUIRED_IOS_COMMANDS),
+    classifyRunnerCompatibility(
+      { protocolVersion: 1, commands: FULL },
+      null,
+      REQUIRED_IOS_COMMANDS,
+    ),
     { compatible: true },
   );
 });

--- a/scripts/cdp-bridge/test/unit/gh-418-command-surface-classify.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-418-command-surface-classify.test.js
@@ -1,0 +1,77 @@
+// GH #418: classifier matrix for the command-surface check. Strict on absence:
+// a runner not advertising `commands` (every pre-#418 artifact) is
+// 'missing-commands' with the full required list as `missing`.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classifyRunnerCompatibility,
+  REQUIRED_IOS_COMMANDS,
+  REQUIRED_ANDROID_COMMANDS,
+} from '../../dist/runners/protocol.js';
+
+const FULL = [...REQUIRED_IOS_COMMANDS];
+
+test('gh-418 classify: commands ⊇ required → compatible', () => {
+  assert.deepEqual(
+    classifyRunnerCompatibility({ protocolVersion: 1, commands: FULL }, null, REQUIRED_IOS_COMMANDS),
+    { compatible: true },
+  );
+});
+
+test('gh-418 classify: extra advertised commands are fine', () => {
+  assert.deepEqual(
+    classifyRunnerCompatibility(
+      { protocolVersion: 1, commands: [...FULL, 'rotate', 'alert'] },
+      null,
+      REQUIRED_IOS_COMMANDS,
+    ),
+    { compatible: true },
+  );
+});
+
+test('gh-418 classify: one missing verb → missing-commands naming it', () => {
+  const withoutKeyboard = FULL.filter((c) => c !== 'keyboardDismiss');
+  assert.deepEqual(
+    classifyRunnerCompatibility(
+      { protocolVersion: 1, commands: withoutKeyboard },
+      null,
+      REQUIRED_IOS_COMMANDS,
+    ),
+    { compatible: false, reason: 'missing-commands', missing: ['keyboardDismiss'] },
+  );
+});
+
+test('gh-418 classify: absent commands field → missing-commands with full list (strict)', () => {
+  assert.deepEqual(
+    classifyRunnerCompatibility({ protocolVersion: 1 }, null, REQUIRED_IOS_COMMANDS),
+    { compatible: false, reason: 'missing-commands', missing: FULL },
+  );
+});
+
+test('gh-418 classify: no requiredCommands param → commands not enforced (back-compat)', () => {
+  assert.deepEqual(classifyRunnerCompatibility({ protocolVersion: 1 }, null), {
+    compatible: true,
+  });
+});
+
+test('gh-418 classify: protocol/skew reasons win over missing-commands', () => {
+  assert.deepEqual(classifyRunnerCompatibility({}, null, REQUIRED_IOS_COMMANDS), {
+    compatible: false,
+    reason: 'legacy',
+  });
+  assert.deepEqual(
+    classifyRunnerCompatibility(
+      { protocolVersion: 1, runnerVersion: '0.0.1' },
+      '0.99.0',
+      REQUIRED_IOS_COMMANDS,
+    ),
+    { compatible: false, reason: 'version-skew' },
+  );
+});
+
+test('gh-418: REQUIRED lists cover both platforms, non-empty, keyboard verbs differ', () => {
+  assert.ok(REQUIRED_IOS_COMMANDS.includes('keyboardDismiss'));
+  assert.ok(!REQUIRED_IOS_COMMANDS.includes('dismissKeyboard'));
+  assert.ok(REQUIRED_ANDROID_COMMANDS.includes('dismissKeyboard'));
+  assert.ok(REQUIRED_IOS_COMMANDS.length >= 9 && REQUIRED_ANDROID_COMMANDS.length >= 9);
+});

--- a/scripts/cdp-bridge/test/unit/gh-418-command-surface-sync.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-418-command-surface-sync.test.js
@@ -1,0 +1,99 @@
+// GH #418: the runner command surface exists in THREE places — the Swift
+// CommandType enum (iOS), the Kotlin SUPPORTED_COMMANDS list (Android, which
+// must itself match the dispatcher when-branches), and the TS REQUIRED_*
+// lists the liveness gate enforces. Source-parsing guard, gh-383-sync style.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const BRIDGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+// Parse the REQUIRED lists from protocol.ts SOURCE (not dist) — same rationale
+// as gh-383-protocol-sync: a stale dist must not mask source drift.
+function requiredCommandsFromSource(name) {
+  const src = readFileSync(join(BRIDGE_ROOT, 'src', 'runners', 'protocol.ts'), 'utf8');
+  const m = src.match(new RegExp(`export const ${name} = \\[([\\s\\S]*?)\\]`));
+  assert.ok(m, `${name} not found in protocol.ts`);
+  const list = [...m[1].matchAll(/'(\w+)'/g)].map((x) => x[1]);
+  assert.ok(list.length > 0, `${name} parsed empty`);
+  return list;
+}
+
+const REQUIRED_IOS_COMMANDS = requiredCommandsFromSource('REQUIRED_IOS_COMMANDS');
+const REQUIRED_ANDROID_COMMANDS = requiredCommandsFromSource('REQUIRED_ANDROID_COMMANDS');
+const SWIFT_MODELS = join(
+  BRIDGE_ROOT,
+  '..',
+  'rn-fast-runner',
+  'RnFastRunner',
+  'RnFastRunnerUITests',
+  'RnFastRunnerTests+Models.swift',
+);
+const KOTLIN_DISPATCHER = join(
+  BRIDGE_ROOT,
+  '..',
+  'rn-android-runner',
+  'app',
+  'src',
+  'androidTest',
+  'java',
+  'dev',
+  'lykhoyda',
+  'rndevagent',
+  'androidrunner',
+  'CommandDispatcher.kt',
+);
+
+function swiftEnumRawValues() {
+  const src = readFileSync(SWIFT_MODELS, 'utf8');
+  const block = src.match(/enum CommandType[^{]*\{([\s\S]*?)\n\}/);
+  assert.ok(block, 'CommandType enum block not found in Models.swift');
+  // /health advertises .rawValue, so parse explicit raw values
+  // (`case foo = "bar"` → "bar"), falling back to the case name.
+  return [...block[1].matchAll(/case (\w+)(?:\s*=\s*"([^"]+)")?/g)].map((m) => m[2] ?? m[1]);
+}
+
+function kotlinSupportedList() {
+  const src = readFileSync(KOTLIN_DISPATCHER, 'utf8');
+  const m = src.match(/val SUPPORTED_COMMANDS = listOf\(([\s\S]*?)\)/);
+  assert.ok(m, 'SUPPORTED_COMMANDS not found in CommandDispatcher.kt');
+  return [...m[1].matchAll(/"(\w+)"/g)].map((x) => x[1]);
+}
+
+function kotlinWhenLabels() {
+  const src = readFileSync(KOTLIN_DISPATCHER, 'utf8');
+  const labels = [];
+  for (const line of src.split('\n')) {
+    const m = line.match(/^\s*((?:"\w+",\s*)*"\w+")\s*->/);
+    if (m) labels.push(...[...m[1].matchAll(/"(\w+)"/g)].map((x) => x[1]));
+  }
+  assert.ok(labels.length > 0, 'no dispatch when-labels found in CommandDispatcher.kt');
+  return labels;
+}
+
+test('gh-418 sync: Swift CommandType raw values cover REQUIRED_IOS_COMMANDS', () => {
+  const rawValues = new Set(swiftEnumRawValues());
+  const missing = REQUIRED_IOS_COMMANDS.filter((c) => !rawValues.has(c));
+  assert.deepEqual(missing, [], `Swift enum missing: ${missing.join(', ')}`);
+});
+
+test('gh-418 sync: Kotlin SUPPORTED_COMMANDS == dispatch when-labels', () => {
+  assert.deepEqual(
+    [...new Set(kotlinSupportedList())].sort(),
+    [...new Set(kotlinWhenLabels())].sort(),
+  );
+});
+
+test('gh-418 sync: Kotlin SUPPORTED_COMMANDS covers REQUIRED_ANDROID_COMMANDS', () => {
+  const supported = new Set(kotlinSupportedList());
+  const missing = REQUIRED_ANDROID_COMMANDS.filter((c) => !supported.has(c));
+  assert.deepEqual(missing, [], `Kotlin list missing: ${missing.join(', ')}`);
+});
+
+test('gh-418 sync: REQUIRED lists have no duplicates', () => {
+  for (const list of [REQUIRED_IOS_COMMANDS, REQUIRED_ANDROID_COMMANDS]) {
+    assert.equal(new Set(list).size, list.length);
+  }
+});

--- a/scripts/cdp-bridge/test/unit/gh-418-ios-command-gate.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-418-ios-command-gate.test.js
@@ -1,0 +1,73 @@
+// GH #418: the iOS liveness gate is strict about the command surface — a
+// healthy, protocol-current runner that does not advertise every
+// REQUIRED_IOS_COMMANDS verb is 'stale'/'missing-commands'.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  probeFastRunnerLivenessDetailed,
+  runIOS,
+  _setRunnerStateForTest,
+  _setFetchForTest,
+} from '../../dist/runners/rn-fast-runner-client.js';
+import { REQUIRED_IOS_COMMANDS } from '../../dist/runners/protocol.js';
+
+const STATE = { pid: 1, port: 22088, deviceId: 'U1', bundleId: 'com.example' };
+const deps = (probeBody, plugin = '0.99.0') => ({
+  getState: () => STATE,
+  processAlive: () => true,
+  httpProbe: async () => probeBody,
+  clearState: () => {},
+  pluginVersion: plugin,
+});
+const HEALTHY = { ok: true, status: 200, bodyOk: true, protocolVersion: 1 };
+
+test('gh-418 gate: full command surface → alive', async () => {
+  const d = await probeFastRunnerLivenessDetailed(
+    deps({ ...HEALTHY, commands: [...REQUIRED_IOS_COMMANDS] }),
+  );
+  assert.equal(d.liveness, 'alive');
+});
+
+test('gh-418 gate: absent commands field (pre-#418 artifact) → stale/missing-commands, full list', async () => {
+  const d = await probeFastRunnerLivenessDetailed(deps({ ...HEALTHY }));
+  assert.equal(d.liveness, 'stale');
+  assert.equal(d.staleReason, 'missing-commands');
+  assert.deepEqual(d.missingCommands, [...REQUIRED_IOS_COMMANDS]);
+});
+
+test('gh-418 gate: one verb missing → stale naming exactly it', async () => {
+  const d = await probeFastRunnerLivenessDetailed(
+    deps({ ...HEALTHY, commands: REQUIRED_IOS_COMMANDS.filter((c) => c !== 'keyboardDismiss') }),
+  );
+  assert.equal(d.staleReason, 'missing-commands');
+  assert.deepEqual(d.missingCommands, ['keyboardDismiss']);
+});
+
+test('gh-418: runIOS surfaces the runner-typed UNSUPPORTED_COMMAND (spec §4 passthrough)', async () => {
+  _setRunnerStateForTest({
+    port: 22088,
+    pid: 999999,
+    deviceId: 'sim',
+    bundleId: 'com.test',
+    startedAt: 'now',
+  });
+  _setFetchForTest(async () => ({
+    json: async () => ({
+      ok: false,
+      v: 1,
+      error: {
+        code: 'UNSUPPORTED_COMMAND',
+        message: 'Unsupported iOS runner command: bogus — the runner artifact predates it.',
+      },
+    }),
+  }));
+  try {
+    const res = await runIOS({ command: 'back' });
+    assert.equal(res.isError, true);
+    assert.match(res.content[0].text, /UNSUPPORTED_COMMAND/);
+    assert.match(res.content[0].text, /artifact predates/);
+  } finally {
+    _setFetchForTest(globalThis.fetch);
+    _setRunnerStateForTest(null);
+  }
+});

--- a/scripts/cdp-bridge/test/unit/gh-418-ios-keyboard-verb.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-418-ios-keyboard-verb.test.js
@@ -1,0 +1,15 @@
+// GH #418 (B235 root cause): the iOS keyboard-dismiss wire verb must be the
+// Swift enum's `keyboardDismiss` — 'dismissKeyboard' has never decoded on any
+// iOS artifact. Android's wire verb stays 'dismissKeyboard' (Kotlin when-label).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildRunIOSArgs, buildRunAndroidArgs } from '../../dist/agent-device-wrapper.js';
+
+test('gh-418: iOS keyboard CLI verb maps to keyboardDismiss on the wire', () => {
+  assert.equal(buildRunIOSArgs(['keyboard']).command, 'keyboardDismiss');
+});
+
+test('gh-418: Android keyboard CLI verbs keep dismissKeyboard on the wire', () => {
+  assert.equal(buildRunAndroidArgs(['keyboard']).command, 'dismissKeyboard');
+  assert.equal(buildRunAndroidArgs(['dismissKeyboard']).command, 'dismissKeyboard');
+});

--- a/scripts/cdp-bridge/test/unit/gh-418-remediation.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-418-remediation.test.js
@@ -1,0 +1,144 @@
+// GH #418: 'missing-commands' remediation is tiered. Mid-flow callers refuse
+// fast with RUNNER_COMMANDS_STALE (a respawn can't fix a stale ARTIFACT); only
+// device_snapshot action=open (allowArtifactRebuild) invalidates DerivedData
+// and pays the cold rebuild — reap-first, behind a checkout-scoped build lock,
+// at most once per plugin version (multi-LLM review amendments).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ensureRunnerForCommand } from '../../dist/agent-device-wrapper.js';
+
+const MISSING = {
+  liveness: 'stale',
+  staleReason: 'missing-commands',
+  missingCommands: ['keyboardDismiss'],
+};
+const freshBudget = () => {
+  const rebuilt = new Set();
+  return {
+    alreadyRebuiltFor: (v) => rebuilt.has(v),
+    recordRebuild: (v) => rebuilt.add(v),
+  };
+};
+const base = () => ({
+  prebuilt: () => true,
+  adopt: () => {},
+  reap: async () => {},
+  acquireBuildLock: () => true,
+  releaseBuildLock: () => {},
+  rebuildBudget: freshBudget(),
+  pluginVersion: '0.99.0',
+});
+
+test('gh-418: mid-flow, missing-commands survives respawn → RUNNER_COMMANDS_STALE, no invalidation', async () => {
+  let invalidated = 0;
+  const res = await ensureRunnerForCommand('U1', 'com.example', {
+    ...base(),
+    probe: async () => MISSING,
+    ensure: async () => {},
+    invalidateArtifact: () => invalidated++,
+  });
+  assert.equal(invalidated, 0);
+  assert.equal(res.ok, false);
+  assert.equal(res.code, 'RUNNER_COMMANDS_STALE');
+  assert.match(res.message, /keyboardDismiss/);
+  assert.match(res.message, /device_snapshot action=open/);
+});
+
+test('gh-418: mid-flow, respawn fixes a stale process → ok + upgrade note, no invalidation', async () => {
+  const probes = [MISSING, { liveness: 'alive' }];
+  let invalidated = 0;
+  const res = await ensureRunnerForCommand('U1', 'com.example', {
+    ...base(),
+    probe: async () => probes.shift(),
+    ensure: async () => {},
+    invalidateArtifact: () => invalidated++,
+  });
+  assert.equal(invalidated, 0);
+  assert.deepEqual(res, { ok: true, note: 'runner upgraded (stale command surface)' });
+});
+
+test('gh-418: at open, invalidate FIRST (no wasted stale respawn) → single ensure + rebuilt note', async () => {
+  const probes = [MISSING, { liveness: 'alive' }];
+  let invalidated = 0;
+  let ensured = 0;
+  let reaped = 0;
+  const res = await ensureRunnerForCommand('U1', 'com.example', {
+    ...base(),
+    allowArtifactRebuild: true,
+    probe: async () => probes.shift(),
+    ensure: async () => {
+      ensured++;
+    },
+    reap: async () => {
+      reaped++;
+    },
+    invalidateArtifact: () => invalidated++,
+  });
+  assert.equal(reaped, 1);
+  assert.equal(invalidated, 1);
+  assert.equal(ensured, 1);
+  assert.deepEqual(res, {
+    ok: true,
+    note: 'runner artifact rebuilt (missing commands: keyboardDismiss)',
+  });
+});
+
+test('gh-418: at open, rebuild budget already spent for this plugin version → refuse, no invalidation', async () => {
+  const budget = freshBudget();
+  budget.recordRebuild('0.99.0');
+  let invalidated = 0;
+  const res = await ensureRunnerForCommand('U1', 'com.example', {
+    ...base(),
+    allowArtifactRebuild: true,
+    rebuildBudget: budget,
+    probe: async () => MISSING,
+    ensure: async () => {},
+    invalidateArtifact: () => invalidated++,
+  });
+  assert.equal(invalidated, 0);
+  assert.equal(res.ok, false);
+  assert.equal(res.code, 'RUNNER_COMMANDS_STALE');
+  assert.match(res.message, /already cold-rebuilt/i);
+});
+
+test('gh-418: at open, build lock held by another session → refuse, no invalidation', async () => {
+  let invalidated = 0;
+  const res = await ensureRunnerForCommand('U1', 'com.example', {
+    ...base(),
+    allowArtifactRebuild: true,
+    acquireBuildLock: () => false,
+    probe: async () => MISSING,
+    ensure: async () => {},
+    invalidateArtifact: () => invalidated++,
+  });
+  assert.equal(invalidated, 0);
+  assert.equal(res.ok, false);
+  assert.equal(res.code, 'RUNNER_COMMANDS_STALE');
+  assert.match(res.message, /another session/i);
+});
+
+test('gh-418: at open, even a cold rebuild misses commands → RUNNER_COMMANDS_STALE naming plugin update', async () => {
+  let released = 0;
+  const res = await ensureRunnerForCommand('U1', 'com.example', {
+    ...base(),
+    allowArtifactRebuild: true,
+    releaseBuildLock: () => released++,
+    probe: async () => MISSING,
+    ensure: async () => {},
+    invalidateArtifact: () => {},
+  });
+  assert.equal(released, 1, 'lock must be released even on failure');
+  assert.equal(res.ok, false);
+  assert.equal(res.code, 'RUNNER_COMMANDS_STALE');
+  assert.match(res.message, /update the plugin/i);
+});
+
+test('gh-418: protocol reasons keep the existing note and error path', async () => {
+  const probes = [{ liveness: 'stale', staleReason: 'legacy' }, { liveness: 'alive' }];
+  const res = await ensureRunnerForCommand('U1', 'com.example', {
+    ...base(),
+    probe: async () => probes.shift(),
+    ensure: async () => {},
+  });
+  assert.deepEqual(res, { ok: true, note: 'runner upgraded (protocol/version mismatch)' });
+});

--- a/scripts/cdp-bridge/test/unit/gh-418-remediation.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-418-remediation.test.js
@@ -133,6 +133,30 @@ test('gh-418: at open, even a cold rebuild misses commands → RUNNER_COMMANDS_S
   assert.match(res.message, /update the plugin/i);
 });
 
+test('gh-418: at open, DEAD runner spawned from a stale prebuilt → rebuild tier still fires', async () => {
+  // First probe 'dead' (no runner yet — the common first-open-after-upgrade
+  // case), spawn launches the stale prebuilt, after-probe says
+  // missing-commands: the FIRST open must heal, not error until a second one.
+  const probes = [{ liveness: 'dead' }, MISSING, { liveness: 'alive' }];
+  let invalidated = 0;
+  let ensured = 0;
+  const res = await ensureRunnerForCommand('U1', 'com.example', {
+    ...base(),
+    allowArtifactRebuild: true,
+    probe: async () => probes.shift(),
+    ensure: async () => {
+      ensured++;
+    },
+    invalidateArtifact: () => invalidated++,
+  });
+  assert.equal(invalidated, 1);
+  assert.equal(ensured, 2, 'initial spawn + post-invalidation cold rebuild');
+  assert.deepEqual(res, {
+    ok: true,
+    note: 'runner artifact rebuilt (missing commands: keyboardDismiss)',
+  });
+});
+
 test('gh-418: protocol reasons keep the existing note and error path', async () => {
   const probes = [{ liveness: 'stale', staleReason: 'legacy' }, { liveness: 'alive' }];
   const res = await ensureRunnerForCommand('U1', 'com.example', {

--- a/scripts/cdp-bridge/test/unit/gh-418-remediation.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-418-remediation.test.js
@@ -177,6 +177,20 @@ test('gh-418: at open, dead runner + NOT prebuilt → cold-build via ensure, not
   assert.deepEqual(res, { ok: true });
 });
 
+test('gh-418: mid-flow, STALE missing-commands runner + NOT prebuilt → typed RUNNER_COMMANDS_STALE', async () => {
+  // Multi-review finding: without this, the not-prebuilt decision shadowed the
+  // typed refusal and callers surfaced RN_FAST_RUNNER_DOWN instead.
+  const res = await ensureRunnerForCommand('U1', 'com.example', {
+    ...base(),
+    prebuilt: () => false,
+    probe: async () => MISSING,
+    ensure: async () => {},
+  });
+  assert.equal(res.ok, false);
+  assert.equal(res.code, 'RUNNER_COMMANDS_STALE');
+  assert.match(res.message, /keyboardDismiss/);
+});
+
 test('gh-418: mid-flow, dead runner + NOT prebuilt keeps the #210 refusal', async () => {
   let ensured = 0;
   const res = await ensureRunnerForCommand('U1', 'com.example', {

--- a/scripts/cdp-bridge/test/unit/gh-418-remediation.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-418-remediation.test.js
@@ -157,6 +157,41 @@ test('gh-418: at open, DEAD runner spawned from a stale prebuilt → rebuild tie
   });
 });
 
+test('gh-418: at open, dead runner + NOT prebuilt → cold-build via ensure, not a refusal', async () => {
+  // Open is the sanctioned cold-build entry (its own not-prebuilt error text
+  // directs users here). After #418's invalidation deletes DerivedData — and
+  // because a cold `xcodebuild test` leaves no .xctestrun — a later runner
+  // death must not brick opens (device-verify finding).
+  const probes = [{ liveness: 'dead' }, { liveness: 'alive' }];
+  let ensured = 0;
+  const res = await ensureRunnerForCommand('U1', 'com.example', {
+    ...base(),
+    prebuilt: () => false,
+    allowArtifactRebuild: true,
+    probe: async () => probes.shift(),
+    ensure: async () => {
+      ensured++;
+    },
+  });
+  assert.equal(ensured, 1);
+  assert.deepEqual(res, { ok: true });
+});
+
+test('gh-418: mid-flow, dead runner + NOT prebuilt keeps the #210 refusal', async () => {
+  let ensured = 0;
+  const res = await ensureRunnerForCommand('U1', 'com.example', {
+    ...base(),
+    prebuilt: () => false,
+    probe: async () => ({ liveness: 'dead' }),
+    ensure: async () => {
+      ensured++;
+    },
+  });
+  assert.equal(ensured, 0);
+  assert.equal(res.ok, false);
+  assert.match(res.message, /not prebuilt/);
+});
+
 test('gh-418: protocol reasons keep the existing note and error path', async () => {
   const probes = [{ liveness: 'stale', staleReason: 'legacy' }, { liveness: 'alive' }];
   const res = await ensureRunnerForCommand('U1', 'com.example', {

--- a/scripts/cdp-bridge/test/unit/gh-418-status-missing-commands.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-418-status-missing-commands.test.js
@@ -1,0 +1,32 @@
+// GH #418: cdp_status.deviceSession.runnerProtocol names the missing verbs so
+// a stale artifact is diagnosable before any device_* call fails.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getDeviceSessionHealth } from '../../dist/tools/device-session-health.js';
+
+const SESSION = { platform: 'ios', appId: 'com.example', deviceId: 'U1' };
+
+test('gh-418 status: stale/missing-commands surfaces missingCommands', async () => {
+  const h = await getDeviceSessionHealth({
+    getActiveSession: () => SESSION,
+    adopt: () => {},
+    probeLiveness: async () => ({
+      liveness: 'stale',
+      staleReason: 'missing-commands',
+      missingCommands: ['keyboardDismiss'],
+      runnerProtocolVersion: 1,
+    }),
+  });
+  assert.equal(h.rnFastRunner, 'stale');
+  assert.deepEqual(h.runnerProtocol?.missingCommands, ['keyboardDismiss']);
+  assert.equal(h.runnerProtocol?.compatible, false);
+});
+
+test('gh-418 status: alive runner has no missingCommands key', async () => {
+  const h = await getDeviceSessionHealth({
+    getActiveSession: () => SESSION,
+    adopt: () => {},
+    probeLiveness: async () => ({ liveness: 'alive', runnerProtocolVersion: 1 }),
+  });
+  assert.equal('missingCommands' in (h.runnerProtocol ?? {}), false);
+});

--- a/scripts/cdp-bridge/test/unit/runners/gh-384-quiescence.test.js
+++ b/scripts/cdp-bridge/test/unit/runners/gh-384-quiescence.test.js
@@ -16,6 +16,7 @@ import {
   probeFastRunnerLivenessDetailed,
 } from '../../../dist/runners/rn-fast-runner-client.js';
 import { getDeviceSessionHealth } from '../../../dist/tools/device-session-health.js';
+import { REQUIRED_IOS_COMMANDS } from '../../../dist/runners/protocol.js';
 
 const READY = 'RN_FAST_RUNNER_LISTENER_READY\nRN_FAST_RUNNER_PORT=22088\n';
 
@@ -153,6 +154,7 @@ test('liveness detail carries capabilities from /health', async () => {
       bodyOk: true,
       protocolVersion: 1,
       capabilities: ['QUIESCENCE_BYPASS'],
+      commands: [...REQUIRED_IOS_COMMANDS],
     }),
     pluginVersion: null,
   });

--- a/scripts/cdp-bridge/test/unit/runners/rn-android-runner-client.test.js
+++ b/scripts/cdp-bridge/test/unit/runners/rn-android-runner-client.test.js
@@ -6,6 +6,7 @@ import {
   _setAndroidRunnerStateForTest,
 } from '../../../dist/runners/rn-android-runner-client.js';
 import { refCenter, clearRefMap } from '../../../dist/fast-runner-ref-map.js';
+import { REQUIRED_ANDROID_COMMANDS } from '../../../dist/runners/protocol.js';
 
 _setAndroidRunnerStateForTest({
   hostPort: 22089,
@@ -24,8 +25,17 @@ _setFetchForTest(async (url, init) => {
   // startAndroidRunner (runAndroid calls it per dispatch). Answer /health with a
   // compatible body so the live injected state is reused (not reaped); only
   // /command POSTs are recorded for the command-dispatch assertions.
+  // GH #418: compatible now also requires the full advertised command surface.
   if (String(url).endsWith('/health')) {
-    return { ok: true, status: 200, json: async () => ({ ok: true, protocolVersion: 1 }) };
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        protocolVersion: 1,
+        commands: [...REQUIRED_ANDROID_COMMANDS],
+      }),
+    };
   }
   calls.push({ url, body: JSON.parse(init.body) });
   return { ok: true, status: 200, json: async () => response };

--- a/scripts/rn-android-runner/app/src/androidTest/java/dev/lykhoyda/rndevagent/androidrunner/CommandDispatcher.kt
+++ b/scripts/rn-android-runner/app/src/androidTest/java/dev/lykhoyda/rndevagent/androidrunner/CommandDispatcher.kt
@@ -35,6 +35,17 @@ class SnapshotParseException(message: String) : IllegalStateException(message)
 class CommandDispatcher(private val instrumentation: Instrumentation) {
     private val device: UiDevice = UiDevice.getInstance(instrumentation)
 
+    companion object {
+        // GH #418: advertised in /health.commands. The Node sync test
+        // (cdp-bridge test/unit/gh-418-command-surface-sync.test.js) enforces
+        // that this list exactly matches the dispatch when-branches below.
+        val SUPPORTED_COMMANDS = listOf(
+            "snapshot", "tap", "press", "type", "fill", "drag", "swipe", "scroll",
+            "screenshot", "back", "dismissKeyboard", "keyboard", "longPress",
+            "pinch", "findText",
+        )
+    }
+
     init {
         val ua = instrumentation.uiAutomation
         val info = ua.serviceInfo
@@ -48,7 +59,11 @@ class CommandDispatcher(private val instrumentation: Instrumentation) {
         val command = cmd.getString("command")
         val appPackage = cmd.optString("appBundleId").ifBlank { null }
 
-        if (appPackage != null && command in setOf("snapshot", "findText", "tap", "type", "longPress", "drag", "swipe", "pinch")) {
+        if (appPackage != null && command in setOf(
+                "snapshot", "findText", "tap", "press", "type", "fill",
+                "longPress", "drag", "swipe", "scroll", "pinch",
+            )
+        ) {
             foreground(appPackage)
         }
 

--- a/scripts/rn-android-runner/app/src/androidTest/java/dev/lykhoyda/rndevagent/androidrunner/CommandServer.kt
+++ b/scripts/rn-android-runner/app/src/androidTest/java/dev/lykhoyda/rndevagent/androidrunner/CommandServer.kt
@@ -19,6 +19,7 @@ class CommandServer(port: Int, private val pluginVersion: String? = null) : Nano
                 .put("ok", true)
                 .put("protocolVersion", RunnerProtocol.VERSION)
                 .put("capabilities", JSONArray())
+                .put("commands", JSONArray(CommandDispatcher.SUPPORTED_COMMANDS))
             if (pluginVersion != null) body.put("runnerVersion", pluginVersion)
             return json(Response.Status.OK, body)
         }

--- a/scripts/rn-fast-runner/IMPORT_NOTES.md
+++ b/scripts/rn-fast-runner/IMPORT_NOTES.md
@@ -10,7 +10,7 @@ going forward — no upstream-sync relationship is maintained.
 9 Swift source files providing:
 - HTTP `POST /command` dispatcher
 - Snapshot (XCUI accessibility tree → JSON)
-- Interaction (tap, swipe, type, dismissKeyboard, back, scroll)
+- Interaction (tap, swipe, type, keyboardDismiss — the iOS wire verb (#418), back, scroll)
 - Lifecycle (activate, terminate, state queries)
 - System modal handling (alerts/permission dialogs)
 - Transport (embedded FlyingFox HTTP server)

--- a/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/CommandSurfaceTests.swift
+++ b/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/CommandSurfaceTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+
+// GH #418: the compiled CommandType enum IS the iOS command surface. These
+// pure-logic tests pin the bridge-required verbs and the alias trap (B235).
+final class CommandSurfaceTests: XCTestCase {
+  func testAllCasesCoverBridgeRequiredVerbs() {
+    let advertised = Set(CommandType.allCases.map(\.rawValue))
+    let required: Set<String> = [
+      "tap", "type", "drag", "longPress", "pinch",
+      "snapshot", "screenshot", "back", "keyboardDismiss",
+    ]
+    XCTAssertTrue(
+      required.isSubset(of: advertised),
+      "CommandType missing: \(required.subtracting(advertised))"
+    )
+  }
+
+  func testAndroidKeyboardVerbIsNotAnIOSCase() {
+    XCTAssertNil(CommandType(rawValue: "dismissKeyboard"))
+    XCTAssertNil(CommandType(rawValue: "definitelyBogusVerb"))
+  }
+}

--- a/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RnFastRunnerTests+Models.swift
+++ b/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RnFastRunnerTests+Models.swift
@@ -1,6 +1,6 @@
 // MARK: - Wire Models
 
-enum CommandType: String, Codable {
+enum CommandType: String, Codable, CaseIterable {
   case tap
   case mouseClick
   case tapSeries
@@ -65,6 +65,7 @@ struct Response: Codable {
   let protocolVersion: Int?
   let runnerVersion: String?
   let capabilities: [String]?
+  let commands: [String]?
   let data: DataPayload?
   let error: ErrorPayload?
 
@@ -74,7 +75,8 @@ struct Response: Codable {
     error: ErrorPayload? = nil,
     protocolVersion: Int? = nil,
     runnerVersion: String? = nil,
-    capabilities: [String]? = nil
+    capabilities: [String]? = nil,
+    commands: [String]? = nil
   ) {
     self.ok = ok
     self.v = RunnerProtocol.version
@@ -83,6 +85,7 @@ struct Response: Codable {
     self.protocolVersion = protocolVersion
     self.runnerVersion = runnerVersion
     self.capabilities = capabilities
+    self.commands = commands
   }
 }
 

--- a/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RnFastRunnerTests+Transport.swift
+++ b/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RnFastRunnerTests+Transport.swift
@@ -44,14 +44,21 @@ extension RnFastRunnerTests {
         self.sendResponse(response, over: connection)
         return
       }
-      if let body = self.parseRequest(data: combined) {
+      switch self.parseRequest(data: combined) {
+      case .body(let body):
         let result = self.handleRequestBody(body)
         self.sendResponse(result.data, over: connection) { [weak self] in
           if result.shouldFinish {
             self?.finish()
           }
         }
-      } else {
+      case .invalid:
+        let response = self.jsonResponse(
+          status: 400,
+          response: Response(ok: false, error: ErrorPayload(message: "invalid Content-Length"))
+        )
+        self.sendResponse(response, over: connection)
+      case .incomplete:
         self.receiveRequest(connection: connection, buffer: combined)
       }
     }
@@ -78,22 +85,32 @@ extension RnFastRunnerTests {
     return firstLine.hasPrefix("GET /health")
   }
 
-  private func parseRequest(data: Data) -> Data? {
+  enum ParseOutcome {
+    case incomplete
+    case invalid
+    case body(Data)
+  }
+
+  private func parseRequest(data: Data) -> ParseOutcome {
     guard let headerEnd = data.range(of: Data("\r\n\r\n".utf8)) else {
-      return nil
+      return .incomplete
     }
     let headerData = data.subdata(in: 0..<headerEnd.lowerBound)
     let bodyStart = headerEnd.upperBound
     let headers = String(decoding: headerData, as: UTF8.self)
-    let contentLength = extractContentLength(headers: headers)
-    guard let contentLength = contentLength else {
-      return nil
+    // The header section is complete here, so a missing/negative/oversized
+    // Content-Length can never become valid — answer 400 instead of buffering
+    // forever (and never do range arithmetic on an unchecked length: negative
+    // made an invalid subdata range, huge trapped on integer overflow).
+    guard let contentLength = extractContentLength(headers: headers),
+          contentLength >= 0, contentLength <= maxRequestBytes
+    else {
+      return .invalid
     }
     if data.count < bodyStart + contentLength {
-      return nil
+      return .incomplete
     }
-    let body = data.subdata(in: bodyStart..<(bodyStart + contentLength))
-    return body
+    return .body(data.subdata(in: bodyStart..<(bodyStart + contentLength)))
   }
 
   private func extractContentLength(headers: String) -> Int? {

--- a/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RnFastRunnerTests+Transport.swift
+++ b/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RnFastRunnerTests+Transport.swift
@@ -37,7 +37,8 @@ extension RnFastRunnerTests {
             ok: true,
             protocolVersion: RunnerProtocol.version,
             runnerVersion: RunnerEnv.pluginVersion(),
-            capabilities: QuiescenceStatus.current().capabilities
+            capabilities: QuiescenceStatus.current().capabilities,
+            commands: CommandType.allCases.map(\.rawValue)
           )
         )
         self.sendResponse(response, over: connection)
@@ -115,6 +116,23 @@ extension RnFastRunnerTests {
     guard let data = json.data(using: .utf8) else {
       return (
         jsonResponse(status: 400, response: Response(ok: false, error: ErrorPayload(message: "invalid json"))),
+        false
+      )
+    }
+
+    struct CommandTypeProbe: Decodable { let command: String }
+    if let probe = try? JSONDecoder().decode(CommandTypeProbe.self, from: data),
+       CommandType(rawValue: probe.command) == nil {
+      // GH #418: a verb this artifact doesn't know is a typed refusal, not a
+      // dataCorrupted decode error (B235). Mirrors the Android runner's shape.
+      return (
+        jsonResponse(status: 200, response: Response(
+          ok: false,
+          error: ErrorPayload(
+            code: "UNSUPPORTED_COMMAND",
+            message: "Unsupported iOS runner command: \(probe.command) — the runner artifact predates it; re-open the device session (device_snapshot action=open) to rebuild."
+          )
+        )),
         false
       )
     }


### PR DESCRIPTION
Closes #418 (B235).

## Problem

A runner build artifact that predates a command-enum addition passes the #383 protocol gate (protocol versions bump on wire-shape changes, not enum additions) and then rejects newer verbs — on iOS with a raw Swift decode error deep inside a batch. Nothing fingerprints the artifact's command surface: `protocolVersion` is a human-maintained assertion and `runnerVersion` is injected at spawn time, so a respawn "fixes" the skew while the same stale binary keeps running.

**Discovered root cause of B235 itself:** the incident wasn't a stale artifact at all. The TS bridge posted `dismissKeyboard`, but the Swift enum case has been `keyboardDismiss` since the original import — the explicit iOS keyboard-dismiss path had **never** decoded on any artifact (masked because the #356/#370 keyboard guard dismisses in-Swift via a flag). Fixed here, regression-tested at unit, wire, and full-stack levels.

## Design (spec + plan committed under docs/superpowers/)

- **`/health.commands` enumeration** on both runners: iOS derives it from `CommandType.allCases` (cannot drift from the compiled artifact — the same derive-don't-assert principle as #384's capabilities); Android from a `SUPPORTED_COMMANDS` list sync-tested against the dispatcher's `when` labels. Additive wire change, no protocol bump.
- **Gate:** `classifyRunnerCompatibility` gains per-platform `REQUIRED_*_COMMANDS` (compile-tied to the client command unions via `satisfies`) and a `missing-commands` incompatibility reason carrying the missing verbs. **Strict on absence** — every pre-#418 artifact classifies stale once, by design.
- **Tiered remediation:**
  - `device_snapshot action=open` invalidates the stale artifact and rebuilds: iOS deletes the plugin-owned DerivedData behind a **checkout-scoped mkdir lock** with a **once-per-plugin-version budget** (a broken checkout can't loop multi-minute builds; the refusal message names the `commands-rebuild.json` reset for transient failures); Android deletes the runner APKs so `resolveAndroidInstallAction` flips to `build-then-install` — a **retry-once wrapper** owns all rebuilds (reaps the device-side UiAutomation slot first, #237).
  - Mid-flow `device_*` tools refuse fast with typed **`RUNNER_COMMANDS_STALE`** — never a silent multi-minute build (#210 rule preserved).
- **Typed error:** an unknown verb reaching the iOS runner returns `UNSUPPORTED_COMMAND` with a rebuild hint instead of `dataCorrupted…`. `cdp_status` surfaces `deviceSession.runnerProtocol.missingCommands`.
- **Fixed along the way:** open cold-builds when nothing is prebuilt (the #210 not-prebuilt refusal is mid-flow-only — pre-existing since #383, its own error text directs users to open); dead-runner-spawned-from-stale-prebuilt heals on the FIRST open; Swift transport validates client-supplied Content-Length (400 on invalid instead of crash/hang); Android foregrounds alias verbs (`press`/`fill`/`scroll`).

## Verification

- **2672/2672 unit tests** (35 new across 6 gh-418 files incl. the tri-file source-parsing sync guard), oxlint/oxfmt clean, dist rebuilt + staged.
- **Device-verified on both platforms** against genuine pre-#418 artifacts ([evidence](https://github.com/Lykhoyda/rn-dev-agent-workspace/blob/main/docs/proof/2026-07-03-418-command-surface-gate/device-verification.md)):
  - iOS (iPhone 16 Pro sim): migration open returned `meta.note: "runner artifact rebuilt (missing commands: …all 9…)"`; `/health` shows 25 enum-derived commands; bogus verb → typed `UNSUPPORTED_COMMAND`; the exact B235 `device_batch` fill+hideKeyboard shape passes; `CommandSurfaceTests` 2/2 on-device.
  - Android (Pixel 9 Pro emulator): stale installed instrumentation → typed error → retry wrapper reap + APK invalidation + Gradle rebuild → `meta.note: "runner artifact rebuilt (missing commands: …)"`; `/health.commands` 15 verbs; snapshot + press round-trips.
- **Review trail:** multi-LLM adversarial plan review pre-code (caught 2 blockers in the planned design — non-functional Android remediation, unsynchronized DerivedData deletion — both designed out before implementation); per-edit codex-pair on every edit; final two-provider holistic review (no blockers; 3 advisories all fixed on-branch; 2 false-positive "blockers" rejected with source evidence).

## Follow-up candidates (will file)

- Cold `xcodebuild test` leaves no `.xctestrun`, so "prebuilt" never becomes true after a self-build (runner death → another cold build).
- Android rebuild tier has no budget/lock symmetry with iOS.
- Pre-existing: Android `findText` empty-text match-anything, `pinch` scale validation, gh-243 startup-failure coverage via `runAndroid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)