### PR TITLE
fix: /mcp-reconnect-first upgrade notice + cross-install bridge probe (#419)

### DIFF
--- a/.changeset/fix-419-mcp-upgrade-notice.md
+++ b/.changeset/fix-419-mcp-upgrade-notice.md
@@ -1,0 +1,5 @@
+---
+'rn-dev-agent-plugin': patch
+---
+
+SessionStart hook no longer misleads after a plugin upgrade (GH #419): the upgrade notice now recommends the field-proven cheap recovery — `/mcp` → reconnect the rn-dev-agent server — before a full Claude Code restart; a new read-only lockfile probe (`scripts/mcp-bridge-probe.mjs`) explicitly flags a live bridge still running from a PREVIOUS plugin install (the cause of zero-tool sessions after marketplace upgrades) naming its PID and path; and the banner no longer asserts a static "76 MCP tools" count that can't reflect actual registration — it states the installed plugin version and tells the agent the reconnect recovery path when ToolSearch finds no cdp_*/device_* tools.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,12 @@ jobs:
       - name: Feedback telemetry staleness guard
         run: bash scripts/test/telemetry-staleness.test.sh
 
+      # GH#419: upgrade notice must recommend /mcp reconnect before restart; the
+      # SessionStart banner must not assert a static tool count; the lockfile
+      # probe must flag a live bridge from a previous plugin install.
+      - name: MCP upgrade-notice + bridge-probe guard
+        run: bash scripts/test/mcp-upgrade-notice.test.sh
+
   lint-format:
     name: Lint & format
     runs-on: ubuntu-latest

--- a/hooks/detect-rn-project.sh
+++ b/hooks/detect-rn-project.sh
@@ -24,17 +24,32 @@ if [ "$has_rn_config" = true ]; then
   # Resolve plugin root (hooks/ is one level down from plugin root)
   PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-  # Detect plugin upgrade — warn user to restart Claude Code if MCP server keys may have changed (GH #30, D605)
+  # Detect plugin upgrade (GH #30, D605). Advice order per GH #419: a manual
+  # /mcp reconnect is field-proven to restore a dead MCP server without a full
+  # Claude Code restart — recommend the cheap step first.
   PLUGIN_VERSION=$(jq -r '.version // "unknown"' "$PLUGIN_ROOT/.claude-plugin/plugin.json" 2>/dev/null || echo "unknown")
   LAST_VERSION_FILE="${TMPDIR:-/tmp}/rn-dev-agent-last-version"
+  UPGRADE_DETECTED=0
   if [ -f "$LAST_VERSION_FILE" ]; then
     LAST_VERSION=$(cat "$LAST_VERSION_FILE" 2>/dev/null || echo "")
     if [ -n "$LAST_VERSION" ] && [ "$LAST_VERSION" != "$PLUGIN_VERSION" ]; then
-      echo "NOTICE: rn-dev-agent upgraded from v${LAST_VERSION} to v${PLUGIN_VERSION}. If MCP tools fail, restart Claude Code to reinitialize MCP servers."
+      UPGRADE_DETECTED=1
+      echo "NOTICE: rn-dev-agent upgraded from v${LAST_VERSION} to v${PLUGIN_VERSION}. If MCP tools (cdp_*/device_*) are missing, run /mcp and reconnect the rn-dev-agent server — restart Claude Code only if reconnect doesn't fix it."
       echo ""
     fi
   fi
   echo "$PLUGIN_VERSION" > "$LAST_VERSION_FILE" 2>/dev/null || true
+
+  # GH #419: read-only probe of the supervisor lockfile. The plugin cache is
+  # versioned per install, so a bridge surviving an upgrade runs from the OLD
+  # version dir while holding this project's lock — the new session's MCP
+  # server then exits on the conflict and registers zero tools. Fail-silent,
+  # no polling (SessionStart stays bounded, GH #252).
+  PROBE_OUT=$(node "$PLUGIN_ROOT/scripts/mcp-bridge-probe.mjs" --plugin-root "$PLUGIN_ROOT" --upgraded "$UPGRADE_DETECTED" 2>/dev/null || true)
+  if [ -n "$PROBE_OUT" ]; then
+    echo "$PROBE_OUT"
+    echo ""
+  fi
 
   # Warn if Node.js is not an LTS version (even numbers: 22, 24, ...)
   NODE_MAJOR=$(node -e 'console.log(process.versions.node.split(".")[0])' 2>/dev/null)
@@ -121,8 +136,11 @@ if [ "$has_rn_config" = true ]; then
     fi
   fi
 
+  # GH #419: no static tool count here — the hook cannot see Claude Code's
+  # actual MCP registration, and a hardcoded count misleads when the server
+  # registered zero tools (or when the shipped count drifts).
+  echo "React Native project detected. The rn-dev-agent plugin v${PLUGIN_VERSION} is active."
   cat <<'EOF'
-React Native project detected. The rn-dev-agent plugin is active with 76 MCP tools.
 
 ## How to interact with the running app
 
@@ -158,6 +176,10 @@ The CDP tools handle connection, reconnection, and error recovery automatically.
 Always run `cdp_status` first. If it fails to connect, run `/rn-dev-agent:check-env`
 to diagnose missing dependencies (Metro, simulator, agent-device, etc.).
 Do NOT proceed to Phase 5.5 verification without a successful `cdp_status`.
+
+If ToolSearch finds no cdp_* / device_* tools at all, the MCP server did not
+register with this session — ask the user to run /mcp and reconnect the
+rn-dev-agent server (a full Claude Code restart is rarely needed).
 EOF
 
   # Observe UI autostart notice (spec 2026-07-02). The MCP worker autostarts

--- a/scripts/mcp-bridge-probe.mjs
+++ b/scripts/mcp-bridge-probe.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// mcp-bridge-probe.mjs — SessionStart helper (GH #419).
+//
+// Read-only probe of the cdp-bridge supervisor lockfile. The plugin cache is
+// versioned per install, so a bridge that outlives an upgrade keeps running
+// from the OLD version directory while holding this project's lock — the new
+// session's supervisor then exits on the lock conflict and the MCP server
+// contributes zero tools. The hook can't see Claude Code's tool registry, but
+// it CAN see the lock holder: this script names a stale holder explicitly and
+// gives the cheap recovery path (/mcp reconnect) instead of a full restart.
+//
+// Contract: stdout is zero or more advisory lines; always exits 0; never
+// waits or polls (SessionStart must stay bounded, GH #252).
+
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, realpathSync } from 'node:fs';
+import { tmpdir, userInfo } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+
+const RECONNECT_ADVICE =
+  'run /mcp and reconnect the rn-dev-agent server (no full Claude Code restart needed)';
+
+function arg(name) {
+  const i = process.argv.indexOf(name);
+  return i !== -1 ? process.argv[i + 1] : undefined;
+}
+
+function realpathOr(p) {
+  try {
+    return realpathSync(p);
+  } catch {
+    return resolve(p);
+  }
+}
+
+try {
+  const pluginRoot = arg('--plugin-root');
+  const upgraded = arg('--upgraded') === '1';
+  if (!pluginRoot) process.exit(0);
+
+  // Mirrors lifecycle/lockfile.ts exactly: tmpdir + uid + md5(projectRoot):8.
+  const projectRoot = resolve(process.env.CLAUDE_USER_CWD ?? process.cwd());
+  const hash = createHash('md5').update(projectRoot).digest('hex').slice(0, 8);
+  const lockPath = join(tmpdir(), `rn-dev-agent-cdp-${userInfo().uid}-${hash}.lock`);
+
+  let lock = null;
+  try {
+    lock = JSON.parse(readFileSync(lockPath, 'utf8'));
+  } catch {
+    lock = null;
+  }
+
+  const pid = lock && typeof lock.pid === 'number' ? lock.pid : null;
+  let alive = false;
+  if (pid !== null) {
+    try {
+      process.kill(pid, 0);
+      alive = true;
+    } catch {
+      alive = false;
+    }
+  }
+
+  if (!alive) {
+    // Absent/dead lock is inconclusive at SessionStart: the hook may simply
+    // have run before Claude Code spawned the MCP server. Only worth a
+    // conditional note in the risky window right after an upgrade.
+    if (upgraded) {
+      console.log(
+        `MCP bridge check: no bridge is running for this project yet. If cdp_*/device_* tools are missing once the session is up, ${RECONNECT_ADVICE}.`,
+      );
+    }
+    process.exit(0);
+  }
+
+  let psArgs = '';
+  try {
+    psArgs = execFileSync('ps', ['-p', String(pid), '-o', 'args='], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 1000,
+    }).trim();
+  } catch {
+    process.exit(0);
+  }
+
+  // Identify the running bridge's install dir from its argv. No match → not
+  // provably a bridge (PID reuse, redacted ps) → stay silent (fail open).
+  const m = psArgs.match(/\/\S*\/scripts\/cdp-bridge\/dist\/(?:supervisor|index)\.js/);
+  if (!m) process.exit(0);
+
+  const runningDist = realpathOr(dirname(m[0]));
+  const currentDist = realpathOr(join(resolve(pluginRoot), 'scripts', 'cdp-bridge', 'dist'));
+
+  if (runningDist === currentDist) {
+    if (upgraded) {
+      console.log(`MCP bridge check: a bridge from the current install is running (PID ${pid}).`);
+    }
+    process.exit(0);
+  }
+
+  const bridgeVersion =
+    lock && typeof lock.version === 'string' && lock.version ? ` bridge v${lock.version},` : '';
+  console.log(
+    `WARNING: an MCP bridge from a different plugin install (usually a previous version) is still running (PID ${pid},${bridgeVersion} ${dirname(m[0])}) and holds this project's bridge lock. This session's MCP server may have failed to register (zero cdp_*/device_* tools). Run /mcp and reconnect the rn-dev-agent server; if reconnect still fails, close the other Claude Code window using this project or run \`kill ${pid}\`, then reconnect.`,
+  );
+} catch {
+  // Never block or fail SessionStart.
+}

--- a/scripts/mcp-bridge-probe.mjs
+++ b/scripts/mcp-bridge-probe.mjs
@@ -99,17 +99,21 @@ try {
     process.exit(0);
   }
 
-  // Identify the running bridge's install dir from its argv. No match → not
+  // Verdict must not depend on parsing an absolute path out of ps args —
+  // argv separators and in-path spaces are indistinguishable there. Holder is
+  // provably a bridge if the fixed dist suffix appears at a token end; not
   // provably a bridge (PID reuse, redacted ps) → stay silent (fail open).
-  // A space-containing FOREIGN path parses truncated here — the stale verdict
-  // still holds (the current-install case already returned above); only the
-  // displayed path is shortened.
+  if (!/\/scripts\/cdp-bridge\/dist\/(?:supervisor|index)\.js(?:\s|$)/.test(psArgs)) {
+    process.exit(0);
+  }
+
+  // Best-effort path extraction, for display and the symlinked-spawn case
+  // only. A space-containing path parses truncated or not at all — the stale
+  // verdict above is unaffected.
   const m = psArgs.match(/\/\S*\/scripts\/cdp-bridge\/dist\/(?:supervisor|index)\.js/);
-  if (!m) process.exit(0);
+  const holderDist = m ? dirname(m[0]) : null;
 
-  const runningDist = realpathOr(dirname(m[0]));
-
-  if (runningDist === currentDist) {
+  if (holderDist !== null && realpathOr(holderDist) === currentDist) {
     if (upgraded) {
       console.log(`MCP bridge check: a bridge from the current install is running (PID ${pid}).`);
     }
@@ -118,8 +122,9 @@ try {
 
   const bridgeVersion =
     lock && typeof lock.version === 'string' && lock.version ? ` bridge v${lock.version},` : '';
+  const holderDesc = holderDist ?? 'install path unparsable from ps args';
   console.log(
-    `WARNING: an MCP bridge from a different plugin install (usually a previous version) is still running (PID ${pid},${bridgeVersion} ${dirname(m[0])}) and holds this project's bridge lock. This session's MCP server may have failed to register (zero cdp_*/device_* tools). Run /mcp and reconnect the rn-dev-agent server; if reconnect still fails, close the other Claude Code window using this project or run \`kill ${pid}\`, then reconnect.`,
+    `WARNING: an MCP bridge from a different plugin install (usually a previous version) is still running (PID ${pid},${bridgeVersion} ${holderDesc}) and holds this project's bridge lock. This session's MCP server may have failed to register (zero cdp_*/device_* tools). Run /mcp and reconnect the rn-dev-agent server; if reconnect still fails, close the other Claude Code window using this project or run \`kill ${pid}\`, then reconnect.`,
   );
 } catch {
   // Never block or fail SessionStart.

--- a/scripts/mcp-bridge-probe.mjs
+++ b/scripts/mcp-bridge-probe.mjs
@@ -14,7 +14,7 @@
 
 import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
-import { readFileSync, realpathSync } from 'node:fs';
+import { readFileSync, realpathSync, statSync } from 'node:fs';
 import { tmpdir, userInfo } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 
@@ -77,15 +77,23 @@ try {
   }
 
   // A live holder only BLOCKS the new supervisor if lockfile.ts's isLockLive
-  // would refuse to reclaim it. Mirror its cheap checks: argv must prove a
-  // bridge (else it's PID reuse — suffix containment, since argv separators
-  // and in-path spaces are indistinguishable in ps output); a heartbeat >90s
-  // stale is a wedged owner → reclaimed; a live PPID differing from the
-  // recorded one is an orphan → reclaimed. Absent fields skip their check
-  // (pre-0.39 locks), and an unreadable live PPID never downgrades a holder —
-  // both matching lockfile.ts.
+  // would refuse to reclaim it. Mirror its checks: argv must prove a bridge
+  // (else it's PID reuse — suffix containment, since argv separators and
+  // in-path spaces are indistinguishable in ps output); lock mtime >24h is an
+  // abandoned lock → reclaimed; a heartbeat >90s stale is a wedged owner →
+  // reclaimed; a live PPID differing from the recorded one is an orphan →
+  // reclaimed (for pre-0.39 locks with no recorded PPID, reparented-to-init
+  // is the orphan signal). Unreadable mtime/PPID never downgrades a holder —
+  // matching lockfile.ts fail-safe semantics.
   let liveBlocker =
     alive && /\/scripts\/cdp-bridge\/dist\/(?:supervisor|index)\.js(?:\s|$)/.test(psArgs);
+  if (liveBlocker) {
+    try {
+      if (Date.now() - statSync(lockPath).mtimeMs > 24 * 60 * 60 * 1000) liveBlocker = false;
+    } catch {
+      /* fail safe: unreadable mtime keeps the holder a blocker */
+    }
+  }
   if (
     liveBlocker &&
     typeof lock.lastHeartbeat === 'number' &&
@@ -93,7 +101,7 @@ try {
   ) {
     liveBlocker = false;
   }
-  if (liveBlocker && typeof lock.ppid === 'number') {
+  if (liveBlocker) {
     try {
       const out = execFileSync('ps', ['-p', String(pid), '-o', 'ppid='], {
         encoding: 'utf8',
@@ -101,7 +109,14 @@ try {
         timeout: 1000,
       }).trim();
       const livePpid = parseInt(out, 10);
-      if (Number.isFinite(livePpid) && livePpid !== lock.ppid) liveBlocker = false;
+      if (Number.isFinite(livePpid)) {
+        if (typeof lock.ppid === 'number') {
+          if (livePpid !== lock.ppid) liveBlocker = false;
+        } else if (livePpid === 1) {
+          // Pre-0.39 lock with no recorded PPID: reparented to init = orphan.
+          liveBlocker = false;
+        }
+      }
     } catch {
       /* fail safe: unknown PPID keeps the holder a blocker */
     }

--- a/scripts/mcp-bridge-probe.mjs
+++ b/scripts/mcp-bridge-probe.mjs
@@ -85,13 +85,29 @@ try {
     process.exit(0);
   }
 
+  const currentDistRaw = join(resolve(pluginRoot), 'scripts', 'cdp-bridge', 'dist');
+  const currentDist = realpathOr(currentDistRaw);
+
+  // Current-install check FIRST via exact containment — \S-based parsing
+  // cannot span spaces (e.g. an install under "Application Support"), and a
+  // parse-truncated path must never make us call the user's own live bridge
+  // stale. Both raw and realpath'd forms are tried (symlinked spawns).
+  if (psArgs.includes(currentDistRaw) || psArgs.includes(currentDist)) {
+    if (upgraded) {
+      console.log(`MCP bridge check: a bridge from the current install is running (PID ${pid}).`);
+    }
+    process.exit(0);
+  }
+
   // Identify the running bridge's install dir from its argv. No match → not
   // provably a bridge (PID reuse, redacted ps) → stay silent (fail open).
+  // A space-containing FOREIGN path parses truncated here — the stale verdict
+  // still holds (the current-install case already returned above); only the
+  // displayed path is shortened.
   const m = psArgs.match(/\/\S*\/scripts\/cdp-bridge\/dist\/(?:supervisor|index)\.js/);
   if (!m) process.exit(0);
 
   const runningDist = realpathOr(dirname(m[0]));
-  const currentDist = realpathOr(join(resolve(pluginRoot), 'scripts', 'cdp-bridge', 'dist'));
 
   if (runningDist === currentDist) {
     if (upgraded) {

--- a/scripts/mcp-bridge-probe.mjs
+++ b/scripts/mcp-bridge-probe.mjs
@@ -62,26 +62,61 @@ try {
     }
   }
 
-  if (!alive) {
-    // Absent/dead lock is inconclusive at SessionStart: the hook may simply
-    // have run before Claude Code spawned the MCP server. Only worth a
-    // conditional note in the risky window right after an upgrade.
+  let psArgs = '';
+  if (alive) {
+    try {
+      psArgs = execFileSync('ps', ['-p', String(pid), '-o', 'args='], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 1000,
+      }).trim();
+    } catch {
+      // Holder identity unknowable (ps unavailable/redacted) — claim nothing.
+      process.exit(0);
+    }
+  }
+
+  // A live holder only BLOCKS the new supervisor if lockfile.ts's isLockLive
+  // would refuse to reclaim it. Mirror its cheap checks: argv must prove a
+  // bridge (else it's PID reuse — suffix containment, since argv separators
+  // and in-path spaces are indistinguishable in ps output); a heartbeat >90s
+  // stale is a wedged owner → reclaimed; a live PPID differing from the
+  // recorded one is an orphan → reclaimed. Absent fields skip their check
+  // (pre-0.39 locks), and an unreadable live PPID never downgrades a holder —
+  // both matching lockfile.ts.
+  let liveBlocker =
+    alive && /\/scripts\/cdp-bridge\/dist\/(?:supervisor|index)\.js(?:\s|$)/.test(psArgs);
+  if (
+    liveBlocker &&
+    typeof lock.lastHeartbeat === 'number' &&
+    Date.now() - lock.lastHeartbeat > 90_000
+  ) {
+    liveBlocker = false;
+  }
+  if (liveBlocker && typeof lock.ppid === 'number') {
+    try {
+      const out = execFileSync('ps', ['-p', String(pid), '-o', 'ppid='], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 1000,
+      }).trim();
+      const livePpid = parseInt(out, 10);
+      if (Number.isFinite(livePpid) && livePpid !== lock.ppid) liveBlocker = false;
+    } catch {
+      /* fail safe: unknown PPID keeps the holder a blocker */
+    }
+  }
+
+  if (!liveBlocker) {
+    // No blocking holder (lock absent, dead, or one the supervisor would
+    // reclaim) is inconclusive at SessionStart: the hook may simply have run
+    // before Claude Code spawned the MCP server. Only worth a conditional
+    // note in the risky window right after an upgrade.
     if (upgraded) {
       console.log(
         `MCP bridge check: no bridge is running for this project yet. If cdp_*/device_* tools are missing once the session is up, ${RECONNECT_ADVICE}.`,
       );
     }
-    process.exit(0);
-  }
-
-  let psArgs = '';
-  try {
-    psArgs = execFileSync('ps', ['-p', String(pid), '-o', 'args='], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      timeout: 1000,
-    }).trim();
-  } catch {
     process.exit(0);
   }
 
@@ -96,14 +131,6 @@ try {
     if (upgraded) {
       console.log(`MCP bridge check: a bridge from the current install is running (PID ${pid}).`);
     }
-    process.exit(0);
-  }
-
-  // Verdict must not depend on parsing an absolute path out of ps args —
-  // argv separators and in-path spaces are indistinguishable there. Holder is
-  // provably a bridge if the fixed dist suffix appears at a token end; not
-  // provably a bridge (PID reuse, redacted ps) → stay silent (fail open).
-  if (!/\/scripts\/cdp-bridge\/dist\/(?:supervisor|index)\.js(?:\s|$)/.test(psArgs)) {
     process.exit(0);
   }
 

--- a/scripts/test/mcp-upgrade-notice.test.sh
+++ b/scripts/test/mcp-upgrade-notice.test.sh
@@ -261,7 +261,31 @@ echo "$pout" | grep -q "different plugin install" \
   && bad "orphaned (ppid-changed) holder wrongly reported stale" \
   || ok "orphaned holder treated as reclaimable, no warning"
 
-# (d) Fresh-heartbeat, same-ppid holder still warns (true positive intact).
+# (d) Lock file older than 24h (abandoned) — lockfile.ts max-age reclaim.
+spawn_decoy "/fake-old-root/scripts/cdp-bridge/dist/supervisor.js"
+write_lock "$DECOY_PID"
+touch -t 202001010000 "$LOCK_PATH"
+pout="$(run_probe "$SANDBOX" 0)"
+echo "$pout" | grep -q "different plugin install" \
+  && bad ">24h-old lock (reclaimable) wrongly reported stale" \
+  || ok ">24h-old lock treated as reclaimable, no warning"
+
+# (e) Legacy lock (no ppid) held by an init-orphaned process → reclaimable.
+# Only asserted when the orphan actually reparented to PID 1 (platform-dependent).
+orphan_pid=$( (node -e 'setInterval(() => {}, 1000)' "/fake-old-root/scripts/cdp-bridge/dist/supervisor.js" >/dev/null 2>&1 & echo $!) )
+DECOY_PIDS+=("$orphan_pid")
+live_ppid="$(ps -p "$orphan_pid" -o ppid= 2>/dev/null | tr -d ' ')"
+if [ "$live_ppid" = "1" ]; then
+  write_lock "$orphan_pid"
+  pout="$(run_probe "$SANDBOX" 0)"
+  echo "$pout" | grep -q "different plugin install" \
+    && bad "init-orphaned legacy-lock holder wrongly reported stale" \
+    || ok "init-orphaned legacy-lock holder treated as reclaimable"
+else
+  echo "skip: orphan reparented to $live_ppid (not 1) — legacy-orphan case not asserted"
+fi
+
+# (f) Fresh-heartbeat, same-ppid holder still warns (true positive intact).
 spawn_decoy "/fake-old-root/scripts/cdp-bridge/dist/supervisor.js"
 write_lock "$DECOY_PID" ",\"lastHeartbeat\":$(date +%s)000,\"ppid\":$$"
 pout="$(run_probe "$SANDBOX" 0)"

--- a/scripts/test/mcp-upgrade-notice.test.sh
+++ b/scripts/test/mcp-upgrade-notice.test.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Regression test for GH#419 — MCP server registers zero tools after a
+# mid-session plugin upgrade. The SessionStart hook must (1) recommend the
+# cheap /mcp reconnect before a full Claude Code restart, (2) stop asserting
+# a static "N MCP tools" count that can't reflect actual registration, and
+# (3) probe the supervisor lockfile so a live bridge from a PREVIOUS plugin
+# install is called out explicitly.
+#
+# Run: bash scripts/test/mcp-upgrade-notice.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+fail=0
+ok() { echo "ok: $1"; }
+bad() { echo "FAIL: $1"; fail=1; }
+
+tmp="$(mktemp -d)"
+DECOY_PIDS=()
+cleanup() {
+  for p in "${DECOY_PIDS[@]:-}"; do kill "$p" 2>/dev/null; done
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Sandbox: copy the hook + probe into an isolated plugin root with stubbed
+# ensure-* scripts so the test never runs installers or touches the network.
+# ---------------------------------------------------------------------------
+SANDBOX="$tmp/plugin"
+mkdir -p "$SANDBOX/hooks" "$SANDBOX/scripts" "$SANDBOX/.claude-plugin"
+cp "$REPO_ROOT/hooks/detect-rn-project.sh" "$SANDBOX/hooks/"
+cp "$REPO_ROOT/scripts/mcp-bridge-probe.mjs" "$SANDBOX/scripts/" 2>/dev/null \
+  || { echo "FAIL: scripts/mcp-bridge-probe.mjs missing"; exit 1; }
+echo '{"version":"9.9.9"}' > "$SANDBOX/.claude-plugin/plugin.json"
+for s in ensure-cdp-deps ensure-maestro-runner ensure-idb-companion \
+         ensure-ffmpeg ensure-troubleshooting-doc ensure-android-ready; do
+  printf '#!/bin/bash\nexit 0\n' > "$SANDBOX/scripts/$s.sh"
+done
+
+# Fake RN project so the hook's main branch runs.
+PROJ="$tmp/proj"
+mkdir -p "$PROJ"
+echo '{"dependencies":{"react-native":"0.81.0"}}' > "$PROJ/package.json"
+echo '' > "$PROJ/metro.config.js"
+
+# Isolated TMPDIR: both the hook's last-version file and the probe's
+# os.tmpdir()-based lock path resolve here.
+FAKE_TMP="$tmp/tmpdir"
+mkdir -p "$FAKE_TMP"
+
+run_hook() {
+  (cd "$PROJ" && TMPDIR="$FAKE_TMP" CLAUDE_USER_CWD="$PROJ" \
+    bash "$SANDBOX/hooks/detect-rn-project.sh" 2>/dev/null)
+}
+
+# Uses the SANDBOX copy — the same file the sandboxed hook executes.
+run_probe() { # $1=plugin-root $2=upgraded
+  (cd "$PROJ" && TMPDIR="$FAKE_TMP" CLAUDE_USER_CWD="$PROJ" \
+    node "$SANDBOX/scripts/mcp-bridge-probe.mjs" --plugin-root "$1" --upgraded "$2" 2>/dev/null)
+}
+
+# Lock path computed exactly as the bridge's lockfile.ts computes it.
+LOCK_PATH="$(TMPDIR="$FAKE_TMP" node -e '
+  const { createHash } = require("node:crypto");
+  const os = require("node:os"); const path = require("node:path");
+  const root = path.resolve(process.argv[1]);
+  const hash = createHash("md5").update(root).digest("hex").slice(0, 8);
+  console.log(path.join(os.tmpdir(), `rn-dev-agent-cdp-${os.userInfo().uid}-${hash}.lock`));
+' "$PROJ")"
+
+write_lock() { # $1=pid
+  printf '{"pid":%s,"projectRoot":"%s","startedAt":%s,"version":"0.53.0"}\n' \
+    "$1" "$PROJ" "$(date +%s)000" > "$LOCK_PATH"
+}
+
+# Runs in the parent shell (no command substitution) so DECOY_PIDS survives
+# for cleanup and the spawned node stays a waitable child. Sets $DECOY_PID.
+spawn_decoy() { # $1=fake supervisor path
+  node -e 'setInterval(() => {}, 1000)' "$1" >/dev/null 2>&1 &
+  DECOY_PID=$!
+  DECOY_PIDS+=("$DECOY_PID")
+}
+
+# ---------------------------------------------------------------------------
+# 1. Upgrade notice recommends /mcp reconnect first, restart second.
+# ---------------------------------------------------------------------------
+echo "0.0.1" > "$FAKE_TMP/rn-dev-agent-last-version"
+out="$(run_hook)"
+
+notice_line="$(echo "$out" | grep "NOTICE: rn-dev-agent upgraded" || true)"
+echo "$notice_line" | grep -q "from v0.0.1 to v9.9.9" \
+  && ok "upgrade notice fires with both versions" \
+  || bad "upgrade notice missing or malformed"
+echo "$notice_line" | grep -q "/mcp" \
+  && ok "upgrade notice recommends /mcp reconnect" \
+  || bad "upgrade notice does not mention /mcp reconnect"
+echo "$out" | grep -q "If MCP tools fail, restart Claude Code to reinitialize MCP servers." \
+  && bad "old restart-first advice still present" \
+  || ok "restart is no longer the primary advice"
+
+# ---------------------------------------------------------------------------
+# 2. Banner: no static tool count; states the plugin version; self-check line.
+# Asserted on a NON-upgrade run so the NOTICE text can't satisfy the greps.
+# ---------------------------------------------------------------------------
+out="$(run_hook)"
+echo "$out" | grep -qE "[0-9]+ MCP tools" \
+  && bad "banner still asserts a static MCP tool count" \
+  || ok "banner no longer asserts a static tool count"
+echo "$out" | grep -q "plugin v9.9.9 is active" \
+  && ok "banner states the installed plugin version" \
+  || bad "banner missing the plugin version"
+echo "$out" | grep -A2 "ToolSearch finds no cdp_" | grep -q "reconnect the" \
+  && ok "banner tells the agent the /mcp reconnect recovery path" \
+  || bad "banner missing the missing-tools self-check advice"
+
+# ---------------------------------------------------------------------------
+# 3. Probe: live bridge from a PREVIOUS install → explicit stale warning.
+# ---------------------------------------------------------------------------
+spawn_decoy "/fake-old-root/scripts/cdp-bridge/dist/supervisor.js"
+stale_pid="$DECOY_PID"
+write_lock "$stale_pid"
+pout="$(run_probe "$SANDBOX" 0)"
+echo "$pout" | grep -q "different plugin install" \
+  && ok "probe flags a stale bridge (even without an upgrade this session)" \
+  || bad "probe did not flag the stale bridge"
+echo "$pout" | grep -q "$stale_pid" \
+  && ok "stale warning names the holder PID" \
+  || bad "stale warning missing the holder PID"
+echo "$pout" | grep -q "/mcp" \
+  && ok "stale warning advises /mcp reconnect" \
+  || bad "stale warning missing /mcp advice"
+
+# Integration: the hook itself surfaces the probe's stale warning.
+hout="$(run_hook)"
+echo "$hout" | grep -q "different plugin install" \
+  && ok "hook surfaces the probe stale warning" \
+  || bad "hook did not surface the probe stale warning"
+
+# ---------------------------------------------------------------------------
+# 4. Probe: live bridge from the CURRENT install → healthy.
+# ---------------------------------------------------------------------------
+mkdir -p "$SANDBOX/scripts/cdp-bridge/dist"
+spawn_decoy "$SANDBOX/scripts/cdp-bridge/dist/supervisor.js"
+current_pid="$DECOY_PID"
+write_lock "$current_pid"
+pout="$(run_probe "$SANDBOX" 1)"
+echo "$pout" | grep -q "current install" \
+  && ok "probe confirms a current-install bridge after an upgrade" \
+  || bad "probe missing the current-install confirmation"
+echo "$pout" | grep -q "different plugin install" \
+  && bad "probe false-positives a current-install bridge as stale" \
+  || ok "no stale false positive for a current-install bridge"
+pout="$(run_probe "$SANDBOX" 0)"
+[ -z "$pout" ] \
+  && ok "healthy bridge with no upgrade → probe stays silent" \
+  || bad "probe is noisy on a healthy no-upgrade session: $pout"
+
+# Hook-level: an upgrade run must pass --upgraded=1 through to the probe,
+# surfacing the current-install confirmation in the hook output.
+echo "0.0.2" > "$FAKE_TMP/rn-dev-agent-last-version"
+hout="$(run_hook)"
+echo "$hout" | grep -q "current install" \
+  && ok "hook passes the upgrade flag to the probe (confirmation surfaces)" \
+  || bad "hook did not propagate --upgraded to the probe"
+
+# ---------------------------------------------------------------------------
+# 5. Probe: lock absent or holder dead → conditional advice only on upgrade.
+# ---------------------------------------------------------------------------
+rm -f "$LOCK_PATH"
+pout="$(run_probe "$SANDBOX" 1)"
+echo "$pout" | grep -q "reconnect" \
+  && ok "absent lock + upgrade → conditional /mcp advice" \
+  || bad "absent lock + upgrade printed no advice"
+pout="$(run_probe "$SANDBOX" 0)"
+[ -z "$pout" ] \
+  && ok "absent lock + no upgrade → probe stays silent (startup race)" \
+  || bad "probe is noisy on a normal session start: $pout"
+
+# Dead-holder PID from a self-exiting child (never kill a just-forked child:
+# on macOS bash 3.2 the signal can fire the parent's EXIT trap in a subshell,
+# wiping $tmp mid-test).
+node -e '' >/dev/null 2>&1 &
+dead_decoy=$!
+wait "$dead_decoy" 2>/dev/null
+write_lock "$dead_decoy"
+pout="$(run_probe "$SANDBOX" 1)"
+echo "$pout" | grep -q "reconnect" \
+  && ok "dead holder + upgrade → conditional /mcp advice" \
+  || bad "dead holder + upgrade printed no advice"
+echo "$pout" | grep -q "different plugin install" \
+  && bad "dead holder wrongly reported as live stale bridge" \
+  || ok "dead holder not reported as a live stale bridge"
+
+exit $fail

--- a/scripts/test/mcp-upgrade-notice.test.sh
+++ b/scripts/test/mcp-upgrade-notice.test.sh
@@ -116,6 +116,13 @@ echo "$out" | grep -A2 "ToolSearch finds no cdp_" | grep -q "reconnect the" \
   && ok "banner tells the agent the /mcp reconnect recovery path" \
   || bad "banner missing the missing-tools self-check advice"
 
+# Live-holder cases identify the bridge via `ps -o args=`; skip them where ps
+# is unavailable/redacted (restricted sandboxes) rather than fail spuriously.
+if ! ps -p $$ -o args= >/dev/null 2>&1; then
+  echo "skip: ps unusable in this environment — live-holder probe cases not run"
+  exit $fail
+fi
+
 # ---------------------------------------------------------------------------
 # 3. Probe: live bridge from a PREVIOUS install → explicit stale warning.
 # ---------------------------------------------------------------------------
@@ -157,6 +164,21 @@ pout="$(run_probe "$SANDBOX" 0)"
 [ -z "$pout" ] \
   && ok "healthy bridge with no upgrade → probe stays silent" \
   || bad "probe is noisy on a healthy no-upgrade session: $pout"
+
+# Space-containing install path must NOT be reported stale (\S-regex can't
+# span spaces; the exact-containment current-install check must catch it).
+SPACE_ROOT="$tmp/plug in root"
+mkdir -p "$SPACE_ROOT/scripts/cdp-bridge/dist"
+spawn_decoy "$SPACE_ROOT/scripts/cdp-bridge/dist/supervisor.js"
+write_lock "$DECOY_PID"
+pout="$(run_probe "$SPACE_ROOT" 1)"
+echo "$pout" | grep -q "different plugin install" \
+  && bad "current-install bridge under a space-containing path reported stale" \
+  || ok "no stale false positive for a space-containing install path"
+echo "$pout" | grep -q "current install" \
+  && ok "space-containing current install still confirmed after upgrade" \
+  || bad "space-containing current install not recognized"
+write_lock "$current_pid"
 
 # Hook-level: an upgrade run must pass --upgraded=1 through to the probe,
 # surfacing the current-install confirmation in the hook output.

--- a/scripts/test/mcp-upgrade-notice.test.sh
+++ b/scripts/test/mcp-upgrade-notice.test.sh
@@ -178,6 +178,15 @@ echo "$pout" | grep -q "different plugin install" \
 echo "$pout" | grep -q "current install" \
   && ok "space-containing current install still confirmed after upgrade" \
   || bad "space-containing current install not recognized"
+# Foreign holder with a space directly before /scripts (regex-unparsable path)
+# must still be flagged stale — the verdict uses suffix containment, not the
+# path parse.
+spawn_decoy "$tmp/old ver/scripts/cdp-bridge/dist/supervisor.js"
+write_lock "$DECOY_PID"
+pout="$(run_probe "$SANDBOX" 0)"
+echo "$pout" | grep -q "different plugin install" \
+  && ok "space-containing FOREIGN install still flagged stale" \
+  || bad "space-containing foreign install evaded the stale warning"
 write_lock "$current_pid"
 
 # Hook-level: an upgrade run must pass --upgraded=1 through to the probe,

--- a/scripts/test/mcp-upgrade-notice.test.sh
+++ b/scripts/test/mcp-upgrade-notice.test.sh
@@ -71,9 +71,9 @@ LOCK_PATH="$(TMPDIR="$FAKE_TMP" node -e '
   console.log(path.join(os.tmpdir(), `rn-dev-agent-cdp-${os.userInfo().uid}-${hash}.lock`));
 ' "$PROJ")"
 
-write_lock() { # $1=pid
-  printf '{"pid":%s,"projectRoot":"%s","startedAt":%s,"version":"0.53.0"}\n' \
-    "$1" "$PROJ" "$(date +%s)000" > "$LOCK_PATH"
+write_lock() { # $1=pid [$2=extra JSON fields, e.g. ',"ppid":1']
+  printf '{"pid":%s,"projectRoot":"%s","startedAt":%s,"version":"0.53.0"%s}\n' \
+    "$1" "$PROJ" "$(date +%s)000" "${2:-}" > "$LOCK_PATH"
 }
 
 # Runs in the parent shell (no command substitution) so DECOY_PIDS survives
@@ -224,5 +224,49 @@ echo "$pout" | grep -q "reconnect" \
 echo "$pout" | grep -q "different plugin install" \
   && bad "dead holder wrongly reported as live stale bridge" \
   || ok "dead holder not reported as a live stale bridge"
+
+# ---------------------------------------------------------------------------
+# 6. Fail-open branches: holders lockfile.ts would reclaim must never warn.
+# ---------------------------------------------------------------------------
+# (a) Live PID whose argv is NOT a bridge (PID reuse) → treated as no blocker.
+node -e 'setInterval(() => {}, 1000)' >/dev/null 2>&1 &
+DECOY_PID=$!
+DECOY_PIDS+=("$DECOY_PID")
+write_lock "$DECOY_PID"
+pout="$(run_probe "$SANDBOX" 0)"
+[ -z "$pout" ] \
+  && ok "live non-bridge holder (PID reuse) → silent without upgrade" \
+  || bad "live non-bridge holder produced output: $pout"
+pout="$(run_probe "$SANDBOX" 1)"
+echo "$pout" | grep -q "different plugin install" \
+  && bad "live non-bridge holder wrongly reported stale" \
+  || ok "live non-bridge holder not reported stale"
+echo "$pout" | grep -q "reconnect" \
+  && ok "live non-bridge holder + upgrade → conditional /mcp advice" \
+  || bad "live non-bridge holder + upgrade printed no advice"
+
+# (b) Heartbeat-stale bridge holder (wedged — lockfile.ts would reclaim).
+spawn_decoy "/fake-old-root/scripts/cdp-bridge/dist/supervisor.js"
+write_lock "$DECOY_PID" ",\"lastHeartbeat\":$(( ($(date +%s) - 300) * 1000 ))"
+pout="$(run_probe "$SANDBOX" 0)"
+echo "$pout" | grep -q "different plugin install" \
+  && bad "heartbeat-stale (reclaimable) holder wrongly reported stale" \
+  || ok "heartbeat-stale holder treated as reclaimable, no warning"
+
+# (c) Orphaned bridge holder (recorded ppid != live ppid — reclaimable).
+spawn_decoy "/fake-old-root/scripts/cdp-bridge/dist/supervisor.js"
+write_lock "$DECOY_PID" ",\"lastHeartbeat\":$(date +%s)000,\"ppid\":1"
+pout="$(run_probe "$SANDBOX" 0)"
+echo "$pout" | grep -q "different plugin install" \
+  && bad "orphaned (ppid-changed) holder wrongly reported stale" \
+  || ok "orphaned holder treated as reclaimable, no warning"
+
+# (d) Fresh-heartbeat, same-ppid holder still warns (true positive intact).
+spawn_decoy "/fake-old-root/scripts/cdp-bridge/dist/supervisor.js"
+write_lock "$DECOY_PID" ",\"lastHeartbeat\":$(date +%s)000,\"ppid\":$$"
+pout="$(run_probe "$SANDBOX" 0)"
+echo "$pout" | grep -q "different plugin install" \
+  && ok "healthy surviving old-install holder still warns (true positive)" \
+  || bad "true-positive stale warning lost after reclaimability checks: $pout"
 
 exit $fail


### PR DESCRIPTION
Closes #419.

## Problem (field report)
A session starting right after a marketplace auto-upgrade got **zero MCP tools** from rn-dev-agent for ~1 hour, while the SessionStart banner statically claimed "76 MCP tools" and the upgrade notice recommended a full Claude Code restart. A manual `/mcp` reconnect fully restored the registry — no restart needed.

## Root cause (plugin-side)
The plugin cache is versioned per install, so `CLAUDE_PLUGIN_ROOT` swaps on upgrade. A bridge surviving from the old install keeps running from the old version dir **while holding the project's supervisor lock** (`rn-dev-agent-cdp-<uid>-<hash>.lock`); the new session's supervisor exits on the conflict → zero tools. Corroborated live on the dev machine: a v0.57.4 supervisor was still running with v0.61.1 installed. The hook gave stale advice, asserted a tool count it cannot know (shipped count is now 79, actual registration can be 0), and never checked the one signal it *can* check.

## Fix
1. **Upgrade notice** now recommends `/mcp` → reconnect rn-dev-agent first; restart is the explicit fallback.
2. **New `scripts/mcp-bridge-probe.mjs`** (read-only, fail-silent, no polling, ~45 ms): computes the lock path exactly as `lifecycle/lockfile.ts` writes it, checks holder liveness, and identifies the holder's install dir from `ps -o args=`:
   - live holder from a **different install** → explicit WARNING (always) naming PID, bridge version, path + recovery steps (`/mcp` reconnect; close other window / `kill <pid>` if reconnect keeps failing);
   - live holder from the current install → one-line confirmation only on the upgrade path;
   - absent/dead lock → conditional advice only on the upgrade path (SessionStart races MCP spawn, so absence is never asserted as failure).
3. **Banner** no longer asserts a static tool count; it states the installed plugin version and teaches the agent the reconnect recovery path when ToolSearch finds no `cdp_*`/`device_*` tools.

## Verification
- New regression test `scripts/test/mcp-upgrade-notice.test.sh` (18 assertions; sandboxed plugin root with stubbed installers — CI-safe, no network), wired into ci.yml. 3× stable locally.
- **Live-verified on real machine state**: probe flagged the genuine stale v0.57.4 supervisor (PID 54233) against the 0.61.1 install, and confirmed the healthy case with matching roots.
- Existing hook tests (`troubleshooting-inject`, `session-start-bounded`) still pass; oxlint + oxfmt clean.

## Known limitations (documented, accepted)
- A live bridge from the *current* install owned by another Claude Code window (legit two-window conflict) is reported as healthy — ppid-ancestry matching from a hook is too fragile; the supervisor's own conflict message covers that path.
- The hook cannot observe Claude Code's actual tool registry; zero-tools is inferred from the lock holder, never measured — hence the banner's conditional self-check phrasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)