### PR TITLE
fix: rn-android-runner findText refuses blank text with INVALID_ARGUMENT (#444)

### DIFF
--- a/.changeset/gh-444-findtext-blank-guard.md
+++ b/.changeset/gh-444-findtext-blank-guard.md
@@ -1,0 +1,12 @@
+---
+"rn-dev-agent-cdp": patch
+"rn-dev-agent-plugin": patch
+---
+
+rn-android-runner `findText` refuses missing/blank `text` with a typed
+`INVALID_ARGUMENT` error (#444). Previously `optString("text")` silently
+defaulted to `""`, falling through to `By.textContains("")` — which matches an
+arbitrary node — so a malformed request reported `found: true` for whatever
+element UIAutomator visited first instead of surfacing an argument error. The
+guard runs in the dispatch when-branch before any selector is constructed;
+a source-sync test (gh-418 style) enforces it in CI without an emulator.

--- a/scripts/cdp-bridge/test/unit/gh-444-findtext-blank-guard.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-444-findtext-blank-guard.test.js
@@ -31,7 +31,9 @@ function findTextWhenBranch() {
   const src = readFileSync(KOTLIN_DISPATCHER, 'utf8');
   // The dispatch when-branch: from `"findText" ->` up to the next when-label
   // or the else-branch. Tolerates both expression and block bodies.
-  const m = src.match(/"findText"\s*->\s*([\s\S]*?)(?=\n\s*(?:\/\/[^\n]*\n\s*)*(?:"\w+(?:",\s*"\w+)*"\s*->|else\s*->))/);
+  const m = src.match(
+    /"findText"\s*->\s*([\s\S]*?)(?=\n\s*(?:\/\/[^\n]*\n\s*)*(?:"\w+(?:",\s*"\w+)*"\s*->|else\s*->))/,
+  );
   assert.ok(m, 'findText when-branch not found in CommandDispatcher.kt');
   return m[1];
 }

--- a/scripts/cdp-bridge/test/unit/gh-444-findtext-blank-guard.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-444-findtext-blank-guard.test.js
@@ -1,0 +1,62 @@
+// GH #444: CommandDispatcher.kt findText used cmd.optString("text"), which
+// silently defaults a missing/blank argument to "" — falling through to
+// By.textContains("") and reporting an arbitrary match instead of an error.
+// The dispatcher must refuse blank text with a typed INVALID_ARGUMENT before
+// any selector is constructed. Instrumented tests need an emulator, so this
+// is a source-parsing guard (gh-418-command-surface-sync style).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const KOTLIN_DISPATCHER = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+  'rn-android-runner',
+  'app',
+  'src',
+  'androidTest',
+  'java',
+  'dev',
+  'lykhoyda',
+  'rndevagent',
+  'androidrunner',
+  'CommandDispatcher.kt',
+);
+
+function findTextWhenBranch() {
+  const src = readFileSync(KOTLIN_DISPATCHER, 'utf8');
+  // The dispatch when-branch: from `"findText" ->` up to the next when-label
+  // or the else-branch. Tolerates both expression and block bodies.
+  const m = src.match(/"findText"\s*->\s*([\s\S]*?)(?=\n\s*(?:\/\/[^\n]*\n\s*)*(?:"\w+(?:",\s*"\w+)*"\s*->|else\s*->))/);
+  assert.ok(m, 'findText when-branch not found in CommandDispatcher.kt');
+  return m[1];
+}
+
+test('gh-444: findText when-branch refuses blank text with INVALID_ARGUMENT', () => {
+  const branch = findTextWhenBranch();
+  assert.match(
+    branch,
+    /isBlank\(\)/,
+    'findText branch must check the text argument for blank before dispatching',
+  );
+  assert.match(
+    branch,
+    /return\s+error\(\s*"INVALID_ARGUMENT"/,
+    'findText branch must return a typed INVALID_ARGUMENT error envelope',
+  );
+});
+
+test('gh-444: blank guard runs before the findText handler builds selectors', () => {
+  const branch = findTextWhenBranch();
+  const guardAt = branch.indexOf('INVALID_ARGUMENT');
+  const dispatchAt = branch.indexOf('findText(cmd)');
+  assert.ok(dispatchAt !== -1, 'findText branch must still dispatch to findText(cmd)');
+  assert.ok(
+    guardAt !== -1 && guardAt < dispatchAt,
+    'INVALID_ARGUMENT guard must precede the findText(cmd) call',
+  );
+});

--- a/scripts/rn-android-runner/app/src/androidTest/java/dev/lykhoyda/rndevagent/androidrunner/CommandDispatcher.kt
+++ b/scripts/rn-android-runner/app/src/androidTest/java/dev/lykhoyda/rndevagent/androidrunner/CommandDispatcher.kt
@@ -84,7 +84,14 @@ class CommandDispatcher(private val instrumentation: Instrumentation) {
             }
             "longPress" -> longPress(cmd)
             "pinch" -> pinch(cmd)
-            "findText" -> findText(cmd)
+            // GH #444: optString defaults missing text to "" and By.textContains("")
+            // matches an arbitrary node — refuse malformed requests instead.
+            "findText" -> {
+                if (cmd.optString("text").isBlank()) {
+                    return error("INVALID_ARGUMENT", "findText requires a non-blank 'text' argument")
+                }
+                findText(cmd)
+            }
             // Note: TS-side `device_find` is a snapshot-based orchestrator (mirrors iOS).
             // The runner exposes `findText` only as an opt-in fast-path for existence checks.
             else -> return error("UNSUPPORTED_COMMAND", "Unsupported Android runner command: $command")


### PR DESCRIPTION
## Summary

Fixes #444 — `CommandDispatcher.kt`'s `findText` used `cmd.optString("text")`, which silently defaults a missing/blank argument to `""`. That falls through to `By.textContains("")`, which matches **any** node with a text attribute, so a malformed request reported `found: true` for an arbitrary element instead of a structured argument error.

## Fix

One when-branch guard in `dispatch()`, exactly as the issue prescribes: refuse blank `text` with a typed `INVALID_ARGUMENT` envelope **before any selector is constructed**, mirroring the existing `UNSUPPORTED_COMMAND` pattern.

No TS changes needed: `CommandServer.kt` returns the dispatch envelope verbatim, and `rn-android-runner-client.ts` already forwards `error.code` into a typed `failResult` — `INVALID_ARGUMENT` propagates end-to-end for free.

## Test

`gh-444-findtext-blank-guard.test.js` — a gh-418-style source-sync test (instrumented tests need an emulator, so this runs in plain Node CI):
1. The `findText` when-branch checks `isBlank()` and returns `error("INVALID_ARGUMENT", …)`.
2. The guard precedes the `findText(cmd)` dispatch call.

TDD: both tests watched failing against the pre-fix source (extractor confirmed grabbing the bare `findText(cmd)` branch), then green after the guard.

## Verification

- `node --test` full suite: **2735/2735 pass** (2733 prior + 2 new)
- gh-418 command-surface sync tests still green (block-body `"findText" -> {` label still parses)
- `./gradlew :app:compileDebugAndroidTestKotlin` — compiles clean
- Changeset added (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)