### PR TITLE
fix(428): harden Android raw screenshot capture

### DIFF
--- a/.changeset/gh-428-android-raw-screenshot-hardening.md
+++ b/.changeset/gh-428-android-raw-screenshot-hardening.md
@@ -1,0 +1,20 @@
+---
+'rn-dev-agent-cdp': patch
+'rn-dev-agent-plugin': patch
+---
+
+Harden the Android **raw** screenshot capture path (`device_screenshot`, GH #428),
+mirroring the iOS hardening from #427:
+
+- **Truncate-before-success**: raw capture now stages `adb exec-out screencap`
+  bytes in a unique sibling temp file and `renameSync`s onto the caller's path
+  only after both the write stream drains and adb exits 0. A failed or timed-out
+  capture can no longer truncate-then-delete an existing file the tool never
+  created.
+- **Multi-emulator first-pick**: with several emulators booted and no session
+  binding, resolution now refuses (exactly-one-or-null via `resolveAndroidEmu`)
+  instead of silently grabbing the first emulator — matching iOS
+  exactly-one-or-refuse. Sessions still bind to their device id.
+- **adb child leak on stream error**: a write-stream error (ENOSPC/EACCES) now
+  unpipes and kills the `adb` child before settling, instead of leaving it
+  running blocked on stdout.

--- a/scripts/cdp-bridge/dist/tools/device-list.js
+++ b/scripts/cdp-bridge/dist/tools/device-list.js
@@ -277,7 +277,7 @@ export async function captureAndResizeScreenshot(args) {
     // capturing the other platform via agent-device's broken `--platform`
     // routing defeats the entire purpose of passing the arg. Re-evidence on
     // the user-reported regression: an OOM-unstable emulator leaves
-    // `adb devices` returning the emulator as `offline`, parseAdbDevicesEmu
+    // `adb devices` returning the emulator as `offline`, parseAdbDevicesEmuAll
     // skips it, the fallback fires, iOS screen is returned.
     const rawResultOk = (path, platform) => ({
         content: [

--- a/scripts/cdp-bridge/dist/tools/device-screenshot-raw.js
+++ b/scripts/cdp-bridge/dist/tools/device-screenshot-raw.js
@@ -19,7 +19,8 @@
  * spawning real `xcrun`/`adb` subprocesses.
  */
 import { execFile, spawn } from 'node:child_process';
-import { createWriteStream, unlinkSync } from 'node:fs';
+import { createWriteStream, renameSync, unlinkSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
 import { promisify } from 'node:util';
 const execFileAsync = promisify(execFile);
 // GH #422: the single-pick parseSimctlBootedUDID was removed — first-booted
@@ -75,19 +76,44 @@ export async function resolveIosUdid(explicit, probe = defaultSimctlBootedJson) 
     }
 }
 const EMU_LINE = /^(emulator-\d+)\s+device\b/;
-export function parseAdbDevicesEmu(stdout) {
-    const lines = stdout.split('\n');
-    for (const line of lines) {
+// GH #428: the single-pick parseAdbDevicesEmu was removed — first-booted
+// selection was a silent wrong-device capture with several emulators booted and
+// no session binding. All resolution goes through parseAdbDevicesEmuAll +
+// exactly-one, mirroring the iOS parseSimctlBootedAll hardening from GH #422/#427.
+export function parseAdbDevicesEmuAll(stdout) {
+    const ids = [];
+    for (const line of stdout.split('\n')) {
         const trimmed = line.trim();
-        if (!trimmed)
-            continue;
-        if (trimmed.startsWith('List of devices'))
+        if (!trimmed || trimmed.startsWith('List of devices'))
             continue;
         const match = trimmed.match(EMU_LINE);
         if (match)
-            return match[1];
+            ids.push(match[1]);
     }
-    return null;
+    return ids;
+}
+async function defaultAdbDevicesStdout() {
+    const { stdout } = await execFileAsync('adb', ['devices'], {
+        timeout: 5000,
+        maxBuffer: 1024 * 1024,
+    });
+    return stdout;
+}
+/**
+ * GH #428: exactly-one-or-refuse Android emulator resolution, mirroring the iOS
+ * resolveIosUdid contract. With several emulators booted and no session UDID,
+ * first-pick could silently capture the wrong device — refuse (return null) so
+ * the caller hard-fails with an actionable message instead. Callers with a
+ * session pass its device id through tryRawScreenshot's preferredDeviceId.
+ */
+export async function resolveAndroidEmu(probe = defaultAdbDevicesStdout) {
+    try {
+        const all = parseAdbDevicesEmuAll(await probe());
+        return all.length === 1 ? all[0] : null;
+    }
+    catch {
+        return null;
+    }
 }
 const defaultIosResolver = async () => {
     try {
@@ -109,18 +135,7 @@ const defaultIosResolver = async () => {
 export async function resolveBootedIosUdid() {
     return defaultIosResolver();
 }
-const defaultAndroidResolver = async () => {
-    try {
-        const { stdout } = await execFileAsync('adb', ['devices'], {
-            timeout: 5000,
-            maxBuffer: 1024 * 1024,
-        });
-        return parseAdbDevicesEmu(stdout);
-    }
-    catch {
-        return null;
-    }
-};
+const defaultAndroidResolver = () => resolveAndroidEmu();
 // Honor the requested format via the path extension, matching how the
 // agent-device path infers format. Writing JPEG bytes into a `.png` file
 // (the prior hardcoded `--type=jpeg`) produced a mislabeled image because
@@ -147,6 +162,28 @@ export function resolveCaptureOutcome(streamFinished, procCode) {
         return 'pending';
     return procCode === 0 ? 'success' : 'failure';
 }
+/**
+ * GH #428 finding 1: the caller's FINAL path must never be opened until capture
+ * succeeds. Staging bytes in a unique sibling temp file (same directory → the
+ * rename is an atomic same-filesystem move, never a cross-device EXDEV copy)
+ * means a failed/timed-out `adb screencap` can't truncate-then-unlink a file
+ * the tool didn't create. The name is dotfile-prefixed and `.rawtmp`-suffixed
+ * so a crash leaves an obviously-transient artifact, not a plausible screenshot.
+ */
+export function rawTempPath(finalPath, uniq) {
+    return join(dirname(finalPath), `.${basename(finalPath)}.${uniq}.rawtmp`);
+}
+// Per-process monotonic suffix — collision-free across rapid successive captures
+// without Date.now()/Math.random(), which keeps temp names deterministic in tests.
+let captureCounter = 0;
+function nextCaptureSuffix() {
+    captureCounter += 1;
+    return `${process.pid}.${captureCounter}`;
+}
+const defaultAndroidSpawn = (emuId) => spawn('adb', ['-s', emuId, 'exec-out', 'screencap', '-p'], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+});
+let androidSpawn = defaultAndroidSpawn;
 // Android needs the binary screen bytes piped to a file. execFile can't redirect
 // stdout, so spawn directly and pipe to a write stream — no shell, so the path
 // is safely passed as a literal filename, not interpolated into a command string.
@@ -156,22 +193,22 @@ export function resolveCaptureOutcome(streamFinished, procCode) {
 // alone is insufficient: 'finish' before non-zero close = truncated/partial
 // file reported as success (deepsec 2026-05-12 finding); 'close' before
 // 'finish' = success reported before bytes hit disk (earlier multi-LLM
-// review finding). On any failure path, the partial file is unlinked so
-// `resizeWithSips` never sees a corrupt artifact.
-const defaultAndroidCapturer = async (emuId, path) => new Promise((resolve) => {
+// review finding). Bytes are staged in a temp file (GH #428 finding 1) and
+// promoted onto `path` via renameSync only once the outcome is success; every
+// failure path unlinks the temp and leaves the caller's path untouched.
+export const defaultAndroidCapturer = async (emuId, path) => new Promise((resolve) => {
     let settled = false;
     let streamFinished = false;
     let procCode = null;
-    const proc = spawn('adb', ['-s', emuId, 'exec-out', 'screencap', '-p'], {
-        stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    const out = createWriteStream(path);
-    const cleanupPartial = () => {
+    const proc = androidSpawn(emuId);
+    const tmp = rawTempPath(path, nextCaptureSuffix());
+    const out = createWriteStream(tmp);
+    const cleanupTemp = () => {
         try {
-            unlinkSync(path);
+            unlinkSync(tmp);
         }
         catch {
-            /* file may not exist yet — ignore */
+            /* temp may not exist yet — ignore */
         }
     };
     const timer = setTimeout(() => {
@@ -179,7 +216,7 @@ const defaultAndroidCapturer = async (emuId, path) => new Promise((resolve) => {
             return;
         proc.kill();
         out.destroy();
-        cleanupPartial();
+        cleanupTemp();
         settle(false);
     }, 15_000);
     const settle = (ok) => {
@@ -195,9 +232,21 @@ const defaultAndroidCapturer = async (emuId, path) => new Promise((resolve) => {
             return;
         if (outcome === 'failure') {
             out.destroy();
-            cleanupPartial();
+            cleanupTemp();
+            settle(false);
+            return;
         }
-        settle(outcome === 'success');
+        // success: promote the staged temp onto the caller's path only now that
+        // both the stream drained AND adb exited 0. A rename failure (e.g. cross
+        // volume, vanished dir) degrades to capture-failed rather than a partial.
+        try {
+            renameSync(tmp, path);
+            settle(true);
+        }
+        catch {
+            cleanupTemp();
+            settle(false);
+        }
     };
     proc.stdout.pipe(out);
     out.on('finish', () => {
@@ -205,12 +254,16 @@ const defaultAndroidCapturer = async (emuId, path) => new Promise((resolve) => {
         maybeSettle();
     });
     out.on('error', () => {
-        cleanupPartial();
+        // GH #428 finding 3: unpipe + kill the adb child before settling — else it
+        // keeps running, blocked writing to a stdout no one is draining.
+        proc.stdout.unpipe(out);
+        proc.kill();
+        cleanupTemp();
         settle(false);
     });
     proc.on('error', () => {
         out.destroy();
-        cleanupPartial();
+        cleanupTemp();
         settle(false);
     });
     proc.on('close', (code) => {
@@ -231,12 +284,15 @@ export function _setForTest(overrides) {
         iosCapturer = overrides.iosCapturer;
     if (overrides.androidCapturer)
         androidCapturer = overrides.androidCapturer;
+    if (overrides.androidSpawn)
+        androidSpawn = overrides.androidSpawn;
 }
 export function _resetForTest() {
     iosResolver = defaultIosResolver;
     androidResolver = defaultAndroidResolver;
     iosCapturer = defaultIosCapturer;
     androidCapturer = defaultAndroidCapturer;
+    androidSpawn = defaultAndroidSpawn;
 }
 export async function tryRawScreenshot(platform, path, preferredDeviceId) {
     const resolver = platform === 'ios' ? iosResolver : androidResolver;

--- a/scripts/cdp-bridge/src/tools/device-list.ts
+++ b/scripts/cdp-bridge/src/tools/device-list.ts
@@ -367,7 +367,7 @@ export async function captureAndResizeScreenshot(args: ScreenshotArgs): Promise<
   // capturing the other platform via agent-device's broken `--platform`
   // routing defeats the entire purpose of passing the arg. Re-evidence on
   // the user-reported regression: an OOM-unstable emulator leaves
-  // `adb devices` returning the emulator as `offline`, parseAdbDevicesEmu
+  // `adb devices` returning the emulator as `offline`, parseAdbDevicesEmuAll
   // skips it, the fallback fires, iOS screen is returned.
   const rawResultOk = (path: string, platform: 'ios' | 'android'): ToolResult => ({
     content: [

--- a/scripts/cdp-bridge/src/tools/device-screenshot-raw.ts
+++ b/scripts/cdp-bridge/src/tools/device-screenshot-raw.ts
@@ -19,7 +19,9 @@
  * spawning real `xcrun`/`adb` subprocesses.
  */
 import { execFile, spawn } from 'node:child_process';
-import { createWriteStream, unlinkSync } from 'node:fs';
+import { createWriteStream, renameSync, unlinkSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import type { Readable } from 'node:stream';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
@@ -91,16 +93,45 @@ export async function resolveIosUdid(
 
 const EMU_LINE = /^(emulator-\d+)\s+device\b/;
 
-export function parseAdbDevicesEmu(stdout: string): string | null {
-  const lines = stdout.split('\n');
-  for (const line of lines) {
+// GH #428: the single-pick parseAdbDevicesEmu was removed — first-booted
+// selection was a silent wrong-device capture with several emulators booted and
+// no session binding. All resolution goes through parseAdbDevicesEmuAll +
+// exactly-one, mirroring the iOS parseSimctlBootedAll hardening from GH #422/#427.
+export function parseAdbDevicesEmuAll(stdout: string): string[] {
+  const ids: string[] = [];
+  for (const line of stdout.split('\n')) {
     const trimmed = line.trim();
-    if (!trimmed) continue;
-    if (trimmed.startsWith('List of devices')) continue;
+    if (!trimmed || trimmed.startsWith('List of devices')) continue;
     const match = trimmed.match(EMU_LINE);
-    if (match) return match[1];
+    if (match) ids.push(match[1]);
   }
-  return null;
+  return ids;
+}
+
+async function defaultAdbDevicesStdout(): Promise<string> {
+  const { stdout } = await execFileAsync('adb', ['devices'], {
+    timeout: 5000,
+    maxBuffer: 1024 * 1024,
+  });
+  return stdout;
+}
+
+/**
+ * GH #428: exactly-one-or-refuse Android emulator resolution, mirroring the iOS
+ * resolveIosUdid contract. With several emulators booted and no session UDID,
+ * first-pick could silently capture the wrong device — refuse (return null) so
+ * the caller hard-fails with an actionable message instead. Callers with a
+ * session pass its device id through tryRawScreenshot's preferredDeviceId.
+ */
+export async function resolveAndroidEmu(
+  probe: () => Promise<string> = defaultAdbDevicesStdout,
+): Promise<string | null> {
+  try {
+    const all = parseAdbDevicesEmuAll(await probe());
+    return all.length === 1 ? all[0] : null;
+  } catch {
+    return null;
+  }
 }
 
 const defaultIosResolver: RawResolver = async () => {
@@ -124,17 +155,7 @@ export async function resolveBootedIosUdid(): Promise<string | null> {
   return defaultIosResolver();
 }
 
-const defaultAndroidResolver: RawResolver = async () => {
-  try {
-    const { stdout } = await execFileAsync('adb', ['devices'], {
-      timeout: 5000,
-      maxBuffer: 1024 * 1024,
-    });
-    return parseAdbDevicesEmu(stdout);
-  } catch {
-    return null;
-  }
-};
+const defaultAndroidResolver: RawResolver = () => resolveAndroidEmu();
 
 // Honor the requested format via the path extension, matching how the
 // agent-device path infers format. Writing JPEG bytes into a `.png` file
@@ -178,6 +199,46 @@ export function resolveCaptureOutcome(
   return procCode === 0 ? 'success' : 'failure';
 }
 
+/**
+ * GH #428 finding 1: the caller's FINAL path must never be opened until capture
+ * succeeds. Staging bytes in a unique sibling temp file (same directory → the
+ * rename is an atomic same-filesystem move, never a cross-device EXDEV copy)
+ * means a failed/timed-out `adb screencap` can't truncate-then-unlink a file
+ * the tool didn't create. The name is dotfile-prefixed and `.rawtmp`-suffixed
+ * so a crash leaves an obviously-transient artifact, not a plausible screenshot.
+ */
+export function rawTempPath(finalPath: string, uniq: string): string {
+  return join(dirname(finalPath), `.${basename(finalPath)}.${uniq}.rawtmp`);
+}
+
+// Per-process monotonic suffix — collision-free across rapid successive captures
+// without Date.now()/Math.random(), which keeps temp names deterministic in tests.
+let captureCounter = 0;
+function nextCaptureSuffix(): string {
+  captureCounter += 1;
+  return `${process.pid}.${captureCounter}`;
+}
+
+/**
+ * The subset of a spawned child process the Android capturer touches. Injecting
+ * a spawner (`androidSpawn`) lets unit tests drive the full capture lifecycle —
+ * stream finish, non-zero exit, write-stream error — without a real `adb`.
+ */
+export interface CaptureProc {
+  stdout: Readable;
+  on(event: 'error', listener: (err: Error) => void): unknown;
+  on(event: 'close', listener: (code: number | null) => void): unknown;
+  kill(signal?: NodeJS.Signals | number): boolean;
+}
+export type AndroidSpawn = (emuId: string) => CaptureProc;
+
+const defaultAndroidSpawn: AndroidSpawn = (emuId) =>
+  spawn('adb', ['-s', emuId, 'exec-out', 'screencap', '-p'], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }) as unknown as CaptureProc;
+
+let androidSpawn: AndroidSpawn = defaultAndroidSpawn;
+
 // Android needs the binary screen bytes piped to a file. execFile can't redirect
 // stdout, so spawn directly and pipe to a write stream — no shell, so the path
 // is safely passed as a literal filename, not interpolated into a command string.
@@ -187,29 +248,29 @@ export function resolveCaptureOutcome(
 // alone is insufficient: 'finish' before non-zero close = truncated/partial
 // file reported as success (deepsec 2026-05-12 finding); 'close' before
 // 'finish' = success reported before bytes hit disk (earlier multi-LLM
-// review finding). On any failure path, the partial file is unlinked so
-// `resizeWithSips` never sees a corrupt artifact.
-const defaultAndroidCapturer: RawCapturer = async (emuId, path) =>
+// review finding). Bytes are staged in a temp file (GH #428 finding 1) and
+// promoted onto `path` via renameSync only once the outcome is success; every
+// failure path unlinks the temp and leaves the caller's path untouched.
+export const defaultAndroidCapturer: RawCapturer = async (emuId, path) =>
   new Promise<boolean>((resolve) => {
     let settled = false;
     let streamFinished = false;
     let procCode: number | null = null;
-    const proc = spawn('adb', ['-s', emuId, 'exec-out', 'screencap', '-p'], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    const out = createWriteStream(path);
-    const cleanupPartial = (): void => {
+    const proc = androidSpawn(emuId);
+    const tmp = rawTempPath(path, nextCaptureSuffix());
+    const out = createWriteStream(tmp);
+    const cleanupTemp = (): void => {
       try {
-        unlinkSync(path);
+        unlinkSync(tmp);
       } catch {
-        /* file may not exist yet — ignore */
+        /* temp may not exist yet — ignore */
       }
     };
     const timer = setTimeout(() => {
       if (settled) return;
       proc.kill();
       out.destroy();
-      cleanupPartial();
+      cleanupTemp();
       settle(false);
     }, 15_000);
     const settle = (ok: boolean): void => {
@@ -223,9 +284,20 @@ const defaultAndroidCapturer: RawCapturer = async (emuId, path) =>
       if (outcome === 'pending') return;
       if (outcome === 'failure') {
         out.destroy();
-        cleanupPartial();
+        cleanupTemp();
+        settle(false);
+        return;
       }
-      settle(outcome === 'success');
+      // success: promote the staged temp onto the caller's path only now that
+      // both the stream drained AND adb exited 0. A rename failure (e.g. cross
+      // volume, vanished dir) degrades to capture-failed rather than a partial.
+      try {
+        renameSync(tmp, path);
+        settle(true);
+      } catch {
+        cleanupTemp();
+        settle(false);
+      }
     };
     proc.stdout.pipe(out);
     out.on('finish', () => {
@@ -233,12 +305,16 @@ const defaultAndroidCapturer: RawCapturer = async (emuId, path) =>
       maybeSettle();
     });
     out.on('error', () => {
-      cleanupPartial();
+      // GH #428 finding 3: unpipe + kill the adb child before settling — else it
+      // keeps running, blocked writing to a stdout no one is draining.
+      proc.stdout.unpipe(out);
+      proc.kill();
+      cleanupTemp();
       settle(false);
     });
     proc.on('error', () => {
       out.destroy();
-      cleanupPartial();
+      cleanupTemp();
       settle(false);
     });
     proc.on('close', (code) => {
@@ -257,6 +333,9 @@ export interface TestOverrides {
   androidResolver?: RawResolver;
   iosCapturer?: RawCapturer;
   androidCapturer?: RawCapturer;
+  // GH #428: fine-grained seam so tests exercise the real defaultAndroidCapturer
+  // (temp-file/rename, two-track settle, stream-error kill) with a fake adb.
+  androidSpawn?: AndroidSpawn;
 }
 
 export function _setForTest(overrides: TestOverrides): void {
@@ -264,6 +343,7 @@ export function _setForTest(overrides: TestOverrides): void {
   if (overrides.androidResolver) androidResolver = overrides.androidResolver;
   if (overrides.iosCapturer) iosCapturer = overrides.iosCapturer;
   if (overrides.androidCapturer) androidCapturer = overrides.androidCapturer;
+  if (overrides.androidSpawn) androidSpawn = overrides.androidSpawn;
 }
 
 export function _resetForTest(): void {
@@ -271,6 +351,7 @@ export function _resetForTest(): void {
   androidResolver = defaultAndroidResolver;
   iosCapturer = defaultIosCapturer;
   androidCapturer = defaultAndroidCapturer;
+  androidSpawn = defaultAndroidSpawn;
 }
 
 export type RawScreenshotFailureReason = 'no-device' | 'capture-failed';

--- a/scripts/cdp-bridge/test/unit/gh-136-screenshot-raw-platform.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-136-screenshot-raw-platform.test.js
@@ -138,25 +138,12 @@ test('parseSimctlBootedAll: returns [] on no Booted device or malformed JSON', a
   assert.deepEqual(parseSimctlBootedAll('{}'), []);
 });
 
-test('parseAdbDevicesEmu: returns first emulator-N device, skips offline/unauthorized', async () => {
-  const { parseAdbDevicesEmu } = await import(RAW_MOD);
-  // adb devices output format. Note: physical device IDs are typically
-  // alphanumeric without the emulator- prefix, so they're skipped.
-  const stdout =
-    'List of devices attached\n' +
-    'emulator-5554\toffline\n' +
-    'physical-abc-123\tdevice\n' +
-    'emulator-5556\tdevice\n' +
-    'emulator-5558\tunauthorized\n';
-  assert.equal(parseAdbDevicesEmu(stdout), 'emulator-5556');
-});
-
-test('parseAdbDevicesEmu: returns null when no online emulator', async () => {
-  const { parseAdbDevicesEmu } = await import(RAW_MOD);
-  assert.equal(parseAdbDevicesEmu(''), null);
-  assert.equal(parseAdbDevicesEmu('List of devices attached\n'), null);
-  assert.equal(parseAdbDevicesEmu('List of devices attached\nemulator-5554\toffline\n'), null);
-});
+// GH #428: the first-pick parseAdbDevicesEmu was removed — with several
+// emulators booted and no session binding it silently captured the wrong
+// device. The Android adb-devices parser + exactly-one-or-refuse resolver
+// (parseAdbDevicesEmuAll / resolveAndroidEmu) are covered in
+// gh-428-android-raw-screenshot.test.ts, mirroring the iOS parseSimctlBootedAll
+// tests above.
 
 // ── tryRawScreenshot orchestrator ───────────────────────────────────
 

--- a/scripts/cdp-bridge/test/unit/gh-173-device-record-multi-device.test.js
+++ b/scripts/cdp-bridge/test/unit/gh-173-device-record-multi-device.test.js
@@ -45,7 +45,7 @@ test('parseAllBootedIosDevices: empty / malformed JSON yields empty list', () =>
 // ─────────────────────────────────────────────────────────────────────────────
 
 test('parseAllAdbDevices: returns emulators AND physical devices (multi-device disambiguation)', () => {
-  // Note: parseAdbDevicesEmu in device-screenshot-raw.ts only matches
+  // Note: parseAdbDevicesEmuAll in device-screenshot-raw.ts only matches
   // emulator-* — for device_record's multi-device check we need physical
   // devices to count too. This test pins that distinction.
   const stdout =

--- a/scripts/cdp-bridge/test/unit/gh-428-android-raw-screenshot.test.ts
+++ b/scripts/cdp-bridge/test/unit/gh-428-android-raw-screenshot.test.ts
@@ -1,0 +1,179 @@
+// GH #428: hardening the Android **raw** screenshot capture path
+// (`device-screenshot-raw.ts`). #427 hardened the iOS raw path; the Android raw
+// path remained fallback-only and unchanged, carrying three pre-existing bugs:
+//
+//   1. Truncate-before-success — `createWriteStream(path)` opened the caller's
+//      FINAL path (truncating it) before capture was known good, and a failed
+//      `adb exec-out screencap` then `unlinkSync(path)`'d a file the tool never
+//      created. Fix: write to a unique sibling temp file, `renameSync` onto the
+//      final path only after BOTH the stream and adb succeed.
+//   2. Multi-emulator first-pick — the resolver returned the FIRST emulator
+//      line, so with several emulators booted and no session binding a raw
+//      screenshot could hit the wrong device. iOS got exactly-one-or-refuse in
+//      #427; Android now mirrors it (`resolveAndroidEmu`).
+//   3. adb child leak on stream error — on `out.on('error')` (ENOSPC/EACCES)
+//      the stream settled false but the `adb` child kept running, blocked on
+//      stdout. Fix: unpipe + kill the child before settling.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { PassThrough } from 'node:stream';
+import { EventEmitter } from 'node:events';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const RAW_MOD = '../../dist/tools/device-screenshot-raw.js';
+
+// A minimal stand-in for the `adb exec-out screencap` child process. It exposes
+// exactly what the capturer touches — `stdout` (a Readable to pipe), `on` for
+// 'error'/'close', and `kill()` — plus test hooks to drive lifecycle events and
+// counters to assert the leak fix (finding 3).
+function makeFakeAdb() {
+  const ee = new EventEmitter();
+  const stdout = new PassThrough();
+  let unpipeCount = 0;
+  const realUnpipe = stdout.unpipe.bind(stdout);
+  stdout.unpipe = (dest?: NodeJS.WritableStream) => {
+    unpipeCount += 1;
+    return realUnpipe(dest);
+  };
+  const proc = {
+    stdout,
+    killed: false,
+    killCount: 0,
+    get unpipeCount() {
+      return unpipeCount;
+    },
+    on(event: string, cb: (...args: unknown[]) => void) {
+      ee.on(event, cb);
+      return proc;
+    },
+    kill() {
+      proc.killed = true;
+      proc.killCount += 1;
+      return true;
+    },
+    emitClose(code: number) {
+      ee.emit('close', code);
+    },
+    emitError(err: Error) {
+      ee.emit('error', err);
+    },
+  };
+  return proc;
+}
+
+// ── Finding 2: exactly-one-or-refuse resolver ───────────────────────────────
+
+test('parseAdbDevicesEmuAll: returns ALL online emulators, skips offline/unauthorized/physical (GH #428)', async () => {
+  const { parseAdbDevicesEmuAll } = await import(RAW_MOD);
+  const stdout =
+    'List of devices attached\n' +
+    'emulator-5554\tdevice\n' +
+    'physical-abc-123\tdevice\n' +
+    'emulator-5556\tdevice\n' +
+    'emulator-5558\tunauthorized\n' +
+    'emulator-5560\toffline\n';
+  assert.deepEqual(parseAdbDevicesEmuAll(stdout), ['emulator-5554', 'emulator-5556']);
+});
+
+test('parseAdbDevicesEmuAll: returns [] when no online emulator', async () => {
+  const { parseAdbDevicesEmuAll } = await import(RAW_MOD);
+  assert.deepEqual(parseAdbDevicesEmuAll(''), []);
+  assert.deepEqual(parseAdbDevicesEmuAll('List of devices attached\n'), []);
+  assert.deepEqual(parseAdbDevicesEmuAll('List of devices attached\nemulator-5554\toffline\n'), []);
+});
+
+test('resolveAndroidEmu: exactly one booted emulator → returns it (GH #428 finding 2)', async () => {
+  const { resolveAndroidEmu } = await import(RAW_MOD);
+  const one = 'List of devices attached\nemulator-5554\tdevice\n';
+  assert.equal(await resolveAndroidEmu(async () => one), 'emulator-5554');
+});
+
+test('resolveAndroidEmu: TWO booted emulators → null (refuse first-pick, mirrors iOS GH #427)', async () => {
+  const { resolveAndroidEmu } = await import(RAW_MOD);
+  const two = 'List of devices attached\nemulator-5554\tdevice\nemulator-5556\tdevice\n';
+  assert.equal(await resolveAndroidEmu(async () => two), null);
+});
+
+test('resolveAndroidEmu: no emulator → null', async () => {
+  const { resolveAndroidEmu } = await import(RAW_MOD);
+  assert.equal(await resolveAndroidEmu(async () => 'List of devices attached\n'), null);
+});
+
+test('resolveAndroidEmu: probe throws → null (never throws)', async () => {
+  const { resolveAndroidEmu } = await import(RAW_MOD);
+  assert.equal(
+    await resolveAndroidEmu(async () => {
+      throw new Error('adb not found');
+    }),
+    null,
+  );
+});
+
+// ── Finding 1: temp-file + rename (never truncate the caller's path early) ───
+
+test('rawTempPath: sits in the same directory as the final path (atomic rename) (GH #428 finding 1)', async () => {
+  const { rawTempPath } = await import(RAW_MOD);
+  assert.equal(rawTempPath('/a/b/shot.png', '999.1'), '/a/b/.shot.png.999.1.rawtmp');
+});
+
+test('defaultAndroidCapturer: success renames temp onto path, leaves no temp behind (GH #428 finding 1)', async () => {
+  const raw = await import(RAW_MOD);
+  const dir = mkdtempSync(join(tmpdir(), 'gh428-ok-'));
+  const path = join(dir, 'shot.png');
+  const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const proc = makeFakeAdb();
+  raw._setForTest({ androidSpawn: () => proc });
+  try {
+    const p = raw.defaultAndroidCapturer('emulator-5554', path);
+    proc.stdout.end(bytes);
+    proc.emitClose(0);
+    assert.equal(await p, true);
+    assert.deepEqual(readFileSync(path), bytes);
+    assert.deepEqual(readdirSync(dir), ['shot.png']);
+  } finally {
+    raw._resetForTest();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('defaultAndroidCapturer: failed adb preserves a pre-existing file at path (GH #428 finding 1)', async () => {
+  const raw = await import(RAW_MOD);
+  const dir = mkdtempSync(join(tmpdir(), 'gh428-fail-'));
+  const path = join(dir, 'existing.png');
+  const sentinel = Buffer.from('DO-NOT-DESTROY-THIS-USER-FILE');
+  writeFileSync(path, sentinel);
+  const proc = makeFakeAdb();
+  raw._setForTest({ androidSpawn: () => proc });
+  try {
+    const p = raw.defaultAndroidCapturer('emulator-5554', path);
+    proc.stdout.end(Buffer.from([0x00]));
+    proc.emitClose(1); // adb exited non-zero
+    assert.equal(await p, false);
+    // The file the tool did NOT create must survive a failed capture.
+    assert.deepEqual(readFileSync(path), sentinel);
+    assert.deepEqual(readdirSync(dir), ['existing.png']); // temp cleaned up
+  } finally {
+    raw._resetForTest();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── Finding 3: kill the adb child when the write stream errors ───────────────
+
+test('defaultAndroidCapturer: write-stream error kills + unpipes the adb child (GH #428 finding 3)', async () => {
+  const raw = await import(RAW_MOD);
+  // Parent directory does not exist → createWriteStream emits ENOENT 'error'.
+  const path = join(tmpdir(), `gh428-nodir-${process.pid}`, 'missing', 'shot.png');
+  const proc = makeFakeAdb();
+  raw._setForTest({ androidSpawn: () => proc });
+  try {
+    const ok = await raw.defaultAndroidCapturer('emulator-5554', path);
+    assert.equal(ok, false);
+    assert.equal(proc.killed, true, 'adb child must be killed on write-stream error (no leak)');
+    assert.ok(proc.unpipeCount >= 1, 'stdout must be unpiped from the errored write stream');
+  } finally {
+    raw._resetForTest();
+  }
+});


### PR DESCRIPTION
Closes #428.

Follow-up to #427 (which hardened the **iOS** raw path). The Android raw screenshot path in `device-screenshot-raw.ts` remained fallback-only and unchanged, carrying three pre-existing bugs. This PR mirrors the iOS hardening to Android.

## Findings fixed

**1. Truncate-before-success** — `createWriteStream(path)` opened the caller's **final** path (truncating it) the instant capture *started*, and `unlinkSync(path)` deleted it on failure — so a failed/timed-out `adb exec-out screencap` could destroy an existing file the tool never created. Now bytes are staged in a unique **sibling temp file** and `renameSync`d onto the final path only after **both** the write stream drained **and** adb exited `0`. Same-directory temp keeps the rename an atomic same-filesystem move (no EXDEV).

**2. Multi-emulator first-pick** — the resolver returned the *first* emulator line, so with several emulators booted and no session binding a raw screenshot could hit the wrong device. Now **exactly-one-or-refuse** via `resolveAndroidEmu` (returns `null` on ambiguity → caller hard-fails with an actionable message), mirroring iOS `resolveIosUdid`. The first-pick `parseAdbDevicesEmu` is removed (replaced by `parseAdbDevicesEmuAll`). Sessions still bind to their device id through `tryRawScreenshot`'s `preferredDeviceId`.

**3. adb child leak on write-stream error** — on `out.on('error')` (ENOSPC/EACCES) the stream settled `false` but the `adb` child kept running, blocked on stdout. Now `unpipe` + `kill` the child before settling.

## Why the state machine stays safe
- **Exactly one settle**: `settled` guard is idempotent.
- **At most one rename**: whichever of `finish`/`close` fires first sees `pending`; only the second reaches success. A killed adb reports `close` with `code === null` → `pending`, never `success`, so a hung-then-killed capture structurally can't rename.
- **No temp/child leak**: every terminal path (`failure`, timeout, write-stream `error`, spawn `error`) calls `cleanupTemp()`; `cleanupTemp` only ever unlinks the temp, never the caller's path.

## Tests (TDD — written first, watched fail, then implemented)
New `test/unit/gh-428-android-raw-screenshot.test.ts` (10 tests) injects a fake-`adb` spawn seam so the **real** `defaultAndroidCapturer` is exercised without spawning a subprocess:
- temp→rename on success (no temp left behind); pre-existing file preserved on adb failure
- write-stream error kills + unpipes the child
- `parseAdbDevicesEmuAll` / `resolveAndroidEmu` exactly-one-or-refuse (0/1/2 emulators, probe-throws)

Full unit suite green (**2924 pass, 0 fail**). oxlint / oxfmt / typescript-only / dist-fresh gates all pass. Independently reviewed by Codex (no findings).

## Follow-up (out of scope)
The child's `proc.stdout` has no `'error'` listener — pre-existing, neither introduced nor worsened here. Candidate for a separate belt-and-suspenders hardening ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)