### PR TITLE
fix(ci): build iOS runner artifacts on macos-15 — Xcode 16 for project format 77

### DIFF
--- a/.changeset/runner-artifacts-xcode16.md
+++ b/.changeset/runner-artifacts-xcode16.md
@@ -1,0 +1,11 @@
+---
+'rn-dev-agent-plugin': patch
+---
+
+Fix the release-triggered iOS runner-artifact build (Runner artifacts workflow):
+the `build-ios` job ran on `macos-14` (Xcode 15.4), which cannot open
+`RnFastRunner.xcodeproj` in project format 77 — its first real invocation (the
+v0.64.2 release push) failed with "future Xcode project file format (77)" and
+the runner manifest was never generated, so installs kept resolving to local
+builds. The job now runs on `macos-15` (Xcode 16.x), matching `native-tests.yml`
+and `codeql.yml`, which already build this project green.

--- a/.github/workflows/runner-artifacts.yml
+++ b/.github/workflows/runner-artifacts.yml
@@ -81,7 +81,10 @@ jobs:
     name: Build rn-fast-runner (iOS)
     needs: detect
     if: needs.detect.outputs.changed == 'true'
-    runs-on: macos-14
+    # macos-15 ships Xcode 16.x — required since RnFastRunner.xcodeproj moved to
+    # project format 77 (Xcode 15.4 on macos-14 refuses to open it). Same runner
+    # choice as native-tests.yml and codeql.yml, which build this project green.
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2 — SHA pin
       - name: build-for-testing (no code signing, both arches)


### PR DESCRIPTION
## What broke

The first real (release-triggered) invocation of the **Runner artifacts** workflow — the v0.64.2 push, [run 28738892339](https://github.com/Lykhoyda/rn-dev-agent/actions/runs/28738892339) — failed in `Build rn-fast-runner (iOS)`:

```
xcodebuild: error: Unable to read project 'RnFastRunner.xcodeproj' …
Reason: The project 'RnFastRunner' cannot be opened because it is in a
future Xcode project file format (77).
```

`build-ios` ran on `macos-14`, whose Xcode 15.4 can't open project format 77 (Xcode 16+). All prior "successes" of this workflow were 6-7s version-gate skips — the Story 01 (#382) scaffold had never been exercised until a version bump landed, exactly as its header comment warned. Downstream, `Generate + commit runner-manifest.json` was skipped, so **v0.64.2 shipped with no prebuilt artifacts** — installs resolve to `local` builds (fail-open by design, degraded not broken).

## Fix

`runs-on: macos-14` → `macos-15` (preinstalled Xcode 16.x) — the same runner choice `native-tests.yml` (#464) and `codeql.yml` already use to build this exact project green.

## After merge

1. `workflow_dispatch` with `force_version=0.64.2` to backfill artifacts + manifest for the already-released version (release exists; uploads use `--clobber`).
2. The next Version Packages merge (this PR's changeset + #469's) exercises the automatic path end-to-end for 0.64.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)