### PR TITLE
feat(story-06): Phase B — nightly device smoke (#387)

### DIFF
--- a/.changeset/story-06-android-screenrect-visibility.md
+++ b/.changeset/story-06-android-screenrect-visibility.md
@@ -1,0 +1,5 @@
+---
+'rn-dev-agent-plugin': patch
+---
+
+Fix two Android device-control defects surfaced by the Story 06 Phase B smoke: (1) with interactive-windows snapshots (#370), the status bar precedes the app window, and the screen-rect heuristic took the first (0,0)-anchored node — so direction-based device_scroll/device_swipe computed gestures inside the status bar; it now picks the largest full-bleed rect. (2) The in-tree rn-android-runner could not re-foreground an app under test on API 30+ because its manifest lacked a package-visibility <queries> declaration (getLaunchIntentForPackage returned null → "No launch intent for package …"); a MAIN/LAUNCHER queries entry restores visibility.

--- a/.changeset/story-06-fastswipe-bundleid.md
+++ b/.changeset/story-06-fastswipe-bundleid.md
@@ -1,0 +1,5 @@
+---
+'rn-dev-agent-plugin': patch
+---
+
+Fix device_scroll/device_swipe silently no-oping on iOS: the drag /command body omitted the target appBundleId, so the runner cleared its target, activated its own RnFastRunner host app, and dragged on a blank screen — every coordinate scroll/swipe returned ok:true with zero movement while foreground-stealing from the app under test. All fastSwipe dispatch sites now forward the active session's appId. Found by the Story 06 Phase B golden-set smoke before it ever reached CI.

--- a/.changeset/story-06-phase-b-device-smoke.md
+++ b/.changeset/story-06-phase-b-device-smoke.md
@@ -1,0 +1,5 @@
+---
+'rn-dev-agent-plugin': patch
+---
+
+Story 06 Phase B: add a nightly device-smoke workflow that drives the golden device_* command set through the real bridge (MCP over stdio) against tiny native contract fixtures (test-fixtures/{ios,android}-fixture) on a booted simulator/emulator, plus a release-artifact-integrity lane and 2-consecutive-red tracking-issue alerting. Local `npm run smoke:ios` / `smoke:android` run the same golden set against a developer's own device.

--- a/.github/workflows/nightly-device-smoke.yml
+++ b/.github/workflows/nightly-device-smoke.yml
@@ -1,0 +1,211 @@
+name: Nightly device smoke
+
+# Story 06 Phase B (#387): golden device_* set through the real bridge
+# (dist/supervisor.js over MCP stdio) against the contract fixtures, plus an
+# artifact-integrity lane for the Story 01 release artifacts. Nightly and NOT
+# merge-gating by design; alerting fires only on 2 consecutive red scheduled
+# runs (report job). Smoke lanes build main-HEAD runners (cached) —
+# RUNNER_COMMANDS_STALE noise from old release bits is impossible here.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch: {}
+
+concurrency: nightly-device-smoke
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+jobs:
+  ios-smoke:
+    name: iOS device smoke
+    runs-on: macos-15
+    timeout-minutes: 40
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install bridge deps
+        working-directory: scripts/cdp-bridge
+        run: npm ci
+      - name: Xcode version for the cache key
+        run: echo "XCODE_V=$(xcodebuild -version | head -1 | tr ' ' '-')" >> "$GITHUB_ENV"
+      - name: Restore runner DerivedData
+        id: dd-cache
+        uses: actions/cache@v4
+        with:
+          path: scripts/rn-fast-runner/build/DerivedData
+          key: rn-fast-runner-dd-${{ runner.os }}-${{ env.XCODE_V }}-${{ hashFiles('scripts/rn-fast-runner/**') }}
+      - name: Disable simulator hardware keyboard (software keyboard must appear)
+        run: defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false
+      - name: Pre-boot simulator
+        run: |
+          set -euo pipefail
+          UDID="$(xcrun simctl list devices available --json | jq -r '[.devices[] | .[] | select(.name == "iPhone 16")][0].udid // empty')"
+          if [ -z "$UDID" ]; then
+            echo "No 'iPhone 16' on this image — falling back to the first available iPhone" >&2
+            UDID="$(xcrun simctl list devices available --json | jq -r '[.devices[] | .[] | select(.name | startswith("iPhone"))][0].udid // empty')"
+          fi
+          [ -n "$UDID" ]
+          xcrun simctl boot "$UDID" || true
+          xcrun simctl bootstatus "$UDID" -b
+          echo "SMOKE_UDID=$UDID" >> "$GITHUB_ENV"
+      - name: Build runner (cache miss only)
+        if: steps.dd-cache.outputs.cache-hit != 'true'
+        run: |
+          xcodebuild build-for-testing \
+            -project scripts/rn-fast-runner/RnFastRunner/RnFastRunner.xcodeproj \
+            -scheme RnFastRunner \
+            -destination "id=$SMOKE_UDID" \
+            -derivedDataPath scripts/rn-fast-runner/build/DerivedData \
+            CODE_SIGNING_ALLOWED=NO
+      - name: Build + install fixture
+        run: |
+          bash test-fixtures/ios-fixture/build.sh
+          xcrun simctl install "$SMOKE_UDID" test-fixtures/ios-fixture/build/Fixture.app
+      - name: Run golden set
+        env:
+          SMOKE_DEBUG_DIR: ${{ runner.temp }}/smoke-debug
+        run: npm run smoke:ios
+      - name: Collect simulator diagnostics (on failure)
+        if: failure()
+        run: |
+          mkdir -p "$RUNNER_TEMP/smoke-debug"
+          xcrun simctl spawn "$SMOKE_UDID" log collect --output "$RUNNER_TEMP/smoke-debug/sim.logarchive" || true
+      - name: Upload smoke debug (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-smoke-debug
+          path: ${{ runner.temp }}/smoke-debug
+          retention-days: 7
+
+  android-smoke:
+    name: Android device smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install bridge deps
+        working-directory: scripts/cdp-bridge
+        run: npm ci
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Set up Gradle (cache)
+        uses: gradle/actions/setup-gradle@v4
+      - name: Build runner APKs + fixture APK (before the emulator boots)
+        run: |
+          (cd scripts/rn-android-runner && ./gradlew :app:assembleDebug :app:assembleDebugAndroidTest --no-daemon)
+          scripts/rn-android-runner/gradlew -p test-fixtures/android-fixture :app:assembleDebug --no-daemon
+      - name: Run golden set on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          disable-animations: true
+          script: |
+            adb shell settings put secure show_ime_with_hard_keyboard 1
+            adb install -r test-fixtures/android-fixture/app/build/outputs/apk/debug/app-debug.apk
+            SMOKE_DEBUG_DIR="$RUNNER_TEMP/smoke-debug" npm run smoke:android
+      - name: Upload smoke debug (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-smoke-debug
+          path: ${{ runner.temp }}/smoke-debug
+          retention-days: 7
+
+  artifact-integrity:
+    name: Release artifact integrity (Story 01)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Verify released runner artifacts against the committed manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          V=$(jq -r '.version // empty' runner-manifest.json)
+          if [ -z "$V" ] || [ "$V" = "null" ]; then
+            echo "runner-manifest.json is still the empty seed — the artifact pipeline has never published." >&2
+            echo "Fix: dispatch the runner-artifacts workflow once (catch-up mode publishes the current version)." >&2
+            exit 1
+          fi
+          mkdir -p /tmp/assets && cd /tmp/assets
+          gh release download "v$V" --repo "$GITHUB_REPOSITORY" \
+            --pattern "rn-fast-runner-$V-sim.zip" \
+            --pattern "rn-android-runner-$V.zip"
+          for P in ios android; do
+            NAME=$(jq -r ".assets.$P[0].name" "$GITHUB_WORKSPACE/runner-manifest.json")
+            SHA=$(jq -r ".assets.$P[0].sha256" "$GITHUB_WORKSPACE/runner-manifest.json")
+            BYTES=$(jq -r ".assets.$P[0].bytes" "$GITHUB_WORKSPACE/runner-manifest.json")
+            echo "$SHA  $NAME" | sha256sum -c -
+            ACTUAL=$(stat -c%s "$NAME")
+            [ "$ACTUAL" = "$BYTES" ] || { echo "size mismatch for $NAME: manifest=$BYTES actual=$ACTUAL" >&2; exit 1; }
+          done
+          for Z in *.zip; do
+            if unzip -l "$Z" | awk 'NR>3 {print $4}' | grep -E '^/|(^|/)\.\.(/|$)'; then
+              echo "suspicious path in $Z" >&2
+              exit 1
+            fi
+          done
+          unzip -l "rn-fast-runner-$V-sim.zip" | grep -q '\.xctestrun' || { echo "iOS zip missing .xctestrun" >&2; exit 1; }
+          unzip -l "rn-android-runner-$V.zip" | grep -q 'app-debug\.apk' || { echo "android zip missing app-debug.apk" >&2; exit 1; }
+          unzip -l "rn-android-runner-$V.zip" | grep -q 'app-debug-androidTest\.apk' || { echo "android zip missing androidTest apk" >&2; exit 1; }
+          echo "artifact integrity OK for v$V"
+
+  report:
+    name: Consecutive-red alerting
+    needs: [ios-smoke, android-smoke, artifact-integrity]
+    if: always() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Open/refresh or close the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RED: ${{ contains(needs.*.result, 'failure') }}
+        run: |
+          set -euo pipefail
+          PREV=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow nightly-device-smoke.yml \
+            --event schedule --limit 2 --json databaseId,conclusion \
+            --jq "[.[] | select(.databaseId != $GITHUB_RUN_ID)][0].conclusion // \"none\"")
+          echo "this-red=$RED previous=$PREV"
+          OPEN=$(gh issue list --repo "$GITHUB_REPOSITORY" --label nightly-smoke-red --state open --json number --jq '.[0].number // empty')
+          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          if [ "$RED" = "true" ] && [ "$PREV" = "failure" ]; then
+            if [ -n "$OPEN" ]; then
+              gh issue comment "$OPEN" --repo "$GITHUB_REPOSITORY" --body "Still red: $RUN_URL"
+            else
+              gh issue create --repo "$GITHUB_REPOSITORY" \
+                --title "Nightly device smoke: 2 consecutive red nights" \
+                --label nightly-smoke-red \
+                --body "The nightly device smoke has failed on 2+ consecutive scheduled runs. Latest: $RUN_URL"
+            fi
+          elif [ "$RED" = "false" ] && [ -n "$OPEN" ]; then
+            gh issue comment "$OPEN" --repo "$GITHUB_REPOSITORY" --body "Recovered: $RUN_URL"
+            gh issue close "$OPEN" --repo "$GITHUB_REPOSITORY"
+          fi

--- a/.github/workflows/nightly-device-smoke.yml
+++ b/.github/workflows/nightly-device-smoke.yml
@@ -14,10 +14,10 @@ on:
 
 concurrency: nightly-device-smoke
 
+# Least privilege: smoke + integrity jobs only read the repo. The report job
+# escalates to issues:write / actions:read in its own block.
 permissions:
   contents: read
-  issues: write
-  actions: read
 
 jobs:
   ios-smoke:
@@ -167,7 +167,9 @@ jobs:
             [ "$ACTUAL" = "$BYTES" ] || { echo "size mismatch for $NAME: manifest=$BYTES actual=$ACTUAL" >&2; exit 1; }
           done
           for Z in *.zip; do
-            if unzip -l "$Z" | awk 'NR>3 {print $4}' | grep -E '^/|(^|/)\.\.(/|$)'; then
+            # -Z1: one full entry path per line (machine-readable), so an entry
+            # with spaces or an embedded ../ is checked as a whole path.
+            if unzip -Z1 "$Z" | grep -E '^/|(^|/)\.\.(/|$)'; then
               echo "suspicious path in $Z" >&2
               exit 1
             fi
@@ -183,20 +185,33 @@ jobs:
     if: always() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      issues: write
+      actions: read
     steps:
       - name: Open/refresh or close the tracking issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RED: ${{ contains(needs.*.result, 'failure') }}
+          # Red = NOT all-success: cancelled / timed_out / skipped all count as
+          # a failed night, not a pass.
+          RED: ${{ !(needs.ios-smoke.result == 'success' && needs.android-smoke.result == 'success' && needs.artifact-integrity.result == 'success') }}
         run: |
           set -euo pipefail
           PREV=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow nightly-device-smoke.yml \
             --event schedule --limit 2 --json databaseId,conclusion \
             --jq "[.[] | select(.databaseId != $GITHUB_RUN_ID)][0].conclusion // \"none\"")
-          echo "this-red=$RED previous=$PREV"
+          # Previous run is red only if a prior scheduled run EXISTS and did not
+          # succeed (cancelled / timed_out / failure). "none" = no prior run, so
+          # the first-ever red night never pages on its own.
+          PREV_RED=false
+          case "$PREV" in
+            none | success) PREV_RED=false ;;
+            *) PREV_RED=true ;;
+          esac
+          echo "this-red=$RED previous=$PREV (prev-red=$PREV_RED)"
           OPEN=$(gh issue list --repo "$GITHUB_REPOSITORY" --label nightly-smoke-red --state open --json number --jq '.[0].number // empty')
           RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-          if [ "$RED" = "true" ] && [ "$PREV" = "failure" ]; then
+          if [ "$RED" = "true" ] && [ "$PREV_RED" = "true" ]; then
             if [ -n "$OPEN" ]; then
               gh issue comment "$OPEN" --repo "$GITHUB_REPOSITORY" --body "Still red: $RUN_URL"
             else

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ scripts/cdp-bridge/eval/
 .rn-agent/state/e2e-runs/
 # E2E param values (may hold secrets) — local/personal, never committed
 .rn-agent/e2e.config.json
+
+# Story 06 Phase B fixtures (#387)
+test-fixtures/ios-fixture/build/
+test-fixtures/android-fixture/.gradle/
+test-fixtures/android-fixture/**/build/

--- a/docs/stories/06-native-runner-ci-and-evals.md
+++ b/docs/stories/06-native-runner-ci-and-evals.md
@@ -1,12 +1,18 @@
 # Story 06 — Native runner tests in CI + LLM-behavior evals
 
-**Status:** Phase A implemented (2026-07-05, #387); Phases B/C proposed
+**Status:** Phase A shipped (2026-07-05, #387); Phase B workflow shipped (2026-07-06, #387) — one-week-green + seeded-bug acceptance pending its first scheduled runs (post-merge, not a merge gate); Phase C proposed
 **Epic:** [Maestro adoption](README.md)
 **Impact:** The highest-risk layer (native gesture/snapshot/keyboard-guard behavior) currently has zero automated execution; this adds three graduated coverage tiers
 **Effort:** M (Phase A is S; Phases B/C are M)
 **Depends on:** Story 01 for Phase B (prebuilt artifacts make device smoke affordable)
 
 ## Problem
+
+> **Historical (pre-Phase-A) framing.** Phase A now executes the native unit suites
+> (`native-tests.yml`) and Phase B drives them on-device nightly
+> (`nightly-device-smoke.yml`); the "only compiled, never executed" gap below is what
+> those phases closed. What remains is Phase C (LLM-behavior evals) and Phase B's
+> post-merge week-of-green acceptance.
 
 CI (` .github/workflows/ci.yml`) runs 2,522 TS unit cases, 3 integration tests, lint/format, and changeset guards — but the native runners are only **compiled** (CodeQL, ~17 min macOS job), never **executed**. The Swift suites (`RnFastRunnerTests+*.swift`, `KeyboardGuardTests.swift`, `SnapshotForegroundRegressionTest.swift`) and the Kotlin JVM test (`KeyboardGuardTest.kt`) exist in-tree and run only when a developer remembers to. Device behavior is validated by manual smoke sessions recorded in docs (e.g. the Pixel_9_Pro Task-10 run in `BUGS.md`). D1288's lesson applies at layer scale: green TS suites say nothing about the layer where the hardest bugs live.
 
@@ -28,9 +34,43 @@ CI (` .github/workflows/ci.yml`) runs 2,522 TS unit cases, 3 integration tests, 
 
 ### Phase B — nightly device smoke (golden command set)
 
-Nightly macOS job (not per-PR — simulators are too slow/flaky for the merge gate):
+> **Implemented 2026-07-06** (#387): `.github/workflows/nightly-device-smoke.yml` +
+> `test-fixtures/{ios,android}-fixture/` + `scripts/cdp-bridge/test/smoke/device-smoke.ts`
+> + root `smoke:{ios,android}` scripts.
+>
+> Triage notes:
+> - **Runner provenance is main-HEAD, not the release artifact** (deviation from the
+>   original plan, deliberate): the smoke lanes cache-build the runner from the tested
+>   commit (`RN_RUNNER_BUILD=local`) so a red night is a real regression, never
+>   release lag. The released artifacts (Story 01) get their own nightly
+>   **artifact-integrity lane** (download → sha256/bytes/traversal/contents vs
+>   `runner-manifest.json`) — the two signals are kept separate on purpose.
+> - **Native contract fixtures, not Expo/RN** (deliberate): the golden set is `device_*`
+>   (L2), which drives any app via XCUITest/UIAutomator2; CDP (L1) is already covered by
+>   2900+ TS unit cases against mock Hermes. A CDP-driving RN fixture lane is a named
+>   deferral (Phase B2).
+> - **The keyboard-guard assertion is platform-divergent by #370 contract**: Android
+>   dismisses (`meta.keyboardGuard: "dismissed"`); iPhone standard QWERTY refuses
+>   (`KEYBOARD_OCCLUDED`, `dismiss_failed`) because XCTest `swipeDown` on the keyboard
+>   corrupts the focused field. The driver fails loudly (not silently passes) if the
+>   software keyboard never appears — set `show_ime_with_hard_keyboard 1` (Android) and
+>   `ConnectHardwareKeyboard=false` (iOS).
+> - Two runner bugs were found by the smoke before CI: `fastSwipe` omitted the target
+>   `appBundleId` (drags no-op'd on the runner's own host app), and the Android
+>   screen-rect heuristic + missing package-visibility `<queries>` broke scroll and
+>   re-foreground. Both fixed with unit coverage.
 
-1. Download the prebuilt runner artifact for the current main build (Story 01) — no xcodebuild in the smoke job itself.
+The numbered steps below are the ORIGINAL design; the "Implemented" blockquote above
+records where the shipped workflow deliberately deviated (main-HEAD runner provenance
+instead of downloading the release artifact; native fixtures instead of Expo). Read the
+blockquote as authoritative for the current contract.
+
+Nightly job (not per-PR — simulators/emulators are too slow/flaky for the merge gate):
+
+1. ~~Download the prebuilt runner artifact for the current main build (Story 01)~~ →
+   **as-built:** cache-build the runner from the tested commit (`RN_RUNNER_BUILD=local`)
+   so a red night is a real regression, not release lag; the released artifacts get a
+   separate integrity lane.
 2. Boot a pinned simulator (e.g. iPhone 16 / iOS 18 runtime; add an iOS 26 lane when the runner image supports it) and, in a parallel lane, a pinned AVD via `reactivecircus/android-emulator-runner`.
 3. Install a **minimal fixture app** (a tiny native/Expo prebuild app committed under `test-fixtures/`, or the seed-experience app if install-ready) exposing: a button with testID, a text field, a scrollable list, a keyboard-occlusion layout, a Reanimated loop screen (Story 03's fixture).
 4. Drive the golden set through the *real bridge* (spawn `dist/supervisor.js`, speak MCP over stdio — reuse the integration-test harness): `device_snapshot open` → `snapshot` → `device_press @ref` → `device_fill` (verify read-back) → `device_scroll` → `device_screenshot` → keyboard-guard scenario → `device_snapshot close`.

--- a/docs/superpowers/plans/2026-07-05-387-phase-b-device-smoke.md
+++ b/docs/superpowers/plans/2026-07-05-387-phase-b-device-smoke.md
@@ -32,6 +32,17 @@
 
 ## PR 1 — make the artifact pipeline fire
 
+> **SUPERSEDED at execution start (2026-07-06).** Tasks 1–3 shipped independently on
+> main while this session was suspended: PR #473 ("self-healing runner-artifacts
+> gate — state-based check + scheduled sweep", B258) implements a superset of
+> Task 1 (the state check runs on EVERY trigger, 6-hourly sweep at `23 */6 * * *`),
+> and PR #470 fixed the iOS artifact build (macos-15/Xcode 16). No release.yml
+> dispatch step exists — the sweep's ≤6 h lag was accepted instead (their call,
+> equivalent outcome). Proven end-to-end: `runner-manifest.json` on main is
+> populated for v0.64.6 with real sha256/bytes for both platforms. Only PR 2
+> (Tasks 4–9) remains to execute; the integrity lane verifies the already-published
+> release. Tasks 1–3 below are retained for the record, NOT for execution.
+
 ### Task 1: Catch-up sweep in `runner-artifacts.yml`
 
 The pipeline's `detect` job only reacts to a version-bump push — an event that can never fire because `release.yml` merges Version PRs with `GITHUB_TOKEN` (GitHub suppresses workflow triggers for pushes made with that token; bump commits `c4b7afe8`/`462ac66f`/`8e9b844c`/`3fe5e328` have zero runner-artifacts runs). This task makes the workflow level-triggered: on a nightly schedule (and on plain `workflow_dispatch`), it publishes whenever the current version's release is missing any runner asset or the committed manifest lags.

--- a/docs/superpowers/plans/2026-07-05-387-phase-b-device-smoke.md
+++ b/docs/superpowers/plans/2026-07-05-387-phase-b-device-smoke.md
@@ -1220,14 +1220,19 @@ Expected: iOS + Android smoke lanes and integrity lane green (integrity requires
 ```bash
 git checkout -b scratch/387-seeded-tap-offset origin/main
 ```
-In `scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RnFastRunnerTests+Interaction.swift`, find the tap command's coordinate computation and add a deliberate `+ 120` to the y coordinate (marker comment `// DO NOT MERGE — seeded bug for #387 Phase B acceptance`). Push the branch, then:
+In `scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RnFastRunnerTests+Interaction.swift`, find the tap command's coordinate computation and add a deliberate `+ 120` to the y coordinate (marker comment `// DO NOT MERGE — seeded bug for #387 Phase B acceptance`). Commit and push the mutation — `gh workflow run --ref` uses the REMOTE branch, so an uncommitted edit would dispatch an unmutated tree and the red run would prove nothing:
 
 ```bash
+git add scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RnFastRunnerTests+Interaction.swift
+git commit -S -m "test(story-06): DO NOT MERGE — seeded tap offset for #387 Phase B acceptance"
+git push -u origin scratch/387-seeded-tap-offset
 gh workflow run nightly-device-smoke.yml --ref scratch/387-seeded-tap-offset
 ```
-Expected: iOS smoke lane RED (counter never increments → the `count: 1` assertion fails). Record the run URL, then delete the branch:
+Expected: iOS smoke lane RED (counter never increments → the `count: 1` assertion fails). Record the run URL, then delete both branches:
 
 ```bash
+git checkout feat/387-phase-b-device-smoke
+git branch -D scratch/387-seeded-tap-offset
 git push origin --delete scratch/387-seeded-tap-offset
 ```
 

--- a/docs/superpowers/plans/2026-07-05-387-phase-b-device-smoke.md
+++ b/docs/superpowers/plans/2026-07-05-387-phase-b-device-smoke.md
@@ -1,0 +1,1249 @@
+# Story 06 Phase B — Nightly Device Smoke Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A nightly CI job drives the golden `device_*` command set through the real bridge (MCP over stdio) against tiny native fixture apps on a booted simulator/emulator, plus an artifact-integrity lane — and the Story 01 artifact pipeline actually fires (its `GITHUB_TOKEN` trigger bug is fixed first).
+
+**Architecture:** Two PRs. PR 1 fixes the artifact-pipeline trigger (dispatch-after-merge in `release.yml` + a level-triggered nightly catch-up sweep in `runner-artifacts.yml`). PR 2 adds contract fixture apps (`test-fixtures/`), a golden-set driver reusing `supervisor-harness.js`, and `.github/workflows/nightly-device-smoke.yml` with iOS/Android smoke lanes (main-HEAD runners, cached builds), an artifact-integrity lane (released bits), and 2-consecutive-red alerting.
+
+**Tech Stack:** GitHub Actions, bash+jq, SwiftUI (swiftc-built fixture, no Xcode project), Kotlin + android.widget (Gradle fixture reusing rn-android-runner's wrapper), Node 22 `node:test` + the existing MCP stdio harness.
+
+**Spec:** `docs/superpowers/specs/2026-07-05-387-phase-b-device-smoke-design.md` (approved 2026-07-05).
+
+## Global Constraints
+
+- Signed commits: `git commit -S`, message trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- NEVER add `skippedTests` to `RnFastRunnerUITests.xctestplan` (D1312) — not touched by this plan; stated so nobody "helpfully" adds it.
+- Fixture app id (both platforms, exact): `dev.lykhoyda.rndevagent.fixture`.
+- Element identifiers (exact): `fixture_button`, `fixture_count`, `fixture_input`, `fixture_list`, `fixture_row_<n>` (1–100), `fixture_bottom_input`, `fixture_bottom_button`, `fixture_bottom_count`.
+- Keyboard-guard contract (#370), asserted platform-conditionally: Android → `ok:true`, `meta.keyboardGuard: "dismissed"`; iOS → refusal with `KEYBOARD_OCCLUDED` and `keyboardGuard=dismiss_failed`.
+- Smoke lanes must run the bridge with `RN_RUNNER_BUILD=local` (forces `build-local` provenance — `runner-artifacts.ts:156` — so a version-matching release can never shadow the fresh main-HEAD build).
+- Branches: PR 1 = `fix/382-runner-artifacts-trigger`, PR 2 = `feat/387-phase-b-device-smoke` (both off `origin/main`).
+- One changeset per PR: `'rn-dev-agent-plugin': patch`.
+- Workflow YAML validation command (run from repo root; js-yaml is a root dep):
+  `node -e "require('js-yaml').load(require('fs').readFileSync(process.argv[1],'utf8')); console.log('YAML OK')" <file>`
+- The driver is **TypeScript** (`device-smoke.ts`), executed directly via Node's type stripping (Node >= 22.18): any new `.mjs`/`.js` file fails ci.yml's `scripts/check-typescript-only.sh` gate on every PR (files not in `scripts/js-migration-baseline.txt` are rejected), so a `.mjs` driver could never merge.
+- `oxlint` + `oxfmt --check` must stay green (they cover the new `.ts` driver).
+- No `dist/` rebuild needed — this plan changes no bridge TypeScript.
+- Workspace docs (`../rn-dev-agent-workspace` = `/Users/anton_personal/GitHub/rn-dev-agent-workspace`): BUGS/DECISIONS/ROADMAP entries are committed in the workspace repo directly (auto-commit is pre-authorized there).
+- Android fixture reuses the runner's Gradle wrapper: `scripts/rn-android-runner/gradlew -p test-fixtures/android-fixture …` (no second wrapper jar in the repo). Pin the same toolchain: AGP 8.7.3, Kotlin 2.0.21, compileSdk 35, Java 17.
+
+---
+
+## PR 1 — make the artifact pipeline fire
+
+### Task 1: Catch-up sweep in `runner-artifacts.yml`
+
+The pipeline's `detect` job only reacts to a version-bump push — an event that can never fire because `release.yml` merges Version PRs with `GITHUB_TOKEN` (GitHub suppresses workflow triggers for pushes made with that token; bump commits `c4b7afe8`/`462ac66f`/`8e9b844c`/`3fe5e328` have zero runner-artifacts runs). This task makes the workflow level-triggered: on a nightly schedule (and on plain `workflow_dispatch`), it publishes whenever the current version's release is missing any runner asset or the committed manifest lags.
+
+**Files:**
+- Modify: `.github/workflows/runner-artifacts.yml` (triggers + the `id: v` detect step)
+
+**Interfaces:**
+- Consumes: `.claude-plugin/plugin.json` `.version`; `runner-manifest.json` `.version`; `gh release view v<V> --json assets`.
+- Produces: unchanged step outputs `version` / `changed` — the downstream build jobs need no edits.
+
+- [ ] **Step 1: Cut the PR 1 branch**
+
+```bash
+git fetch origin main
+git checkout -b fix/382-runner-artifacts-trigger origin/main
+```
+
+- [ ] **Step 2: Add the schedule trigger**
+
+In `.github/workflows/runner-artifacts.yml`, replace the `on:` block (lines 21–29) with:
+
+```yaml
+on:
+  push:
+    branches: [main]
+  # Catch-up sweep (#387 Phase B / GH #382 bug): the Version-PR merge is pushed
+  # with GITHUB_TOKEN, so the bump push can never trigger this workflow
+  # (recursion guard). Nightly, converge on "current version has all artifacts".
+  # Runs before the 03:00 nightly device smoke so its integrity lane sees them.
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+    inputs:
+      force_version:
+        description: Build+publish artifacts for this exact version (skips bump detection)
+        required: false
+        default: ''
+```
+
+- [ ] **Step 3: Rework the detect step**
+
+Replace the `id: v` step's `run:` block (the whole bash script, lines 52–67) with:
+
+```yaml
+        run: |
+          if [ -n "$FORCE_VERSION" ]; then
+            echo "version=$FORCE_VERSION" >> "$GITHUB_OUTPUT"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          CUR=$(jq -r '.version' .claude-plugin/plugin.json)
+          echo "version=$CUR" >> "$GITHUB_OUTPUT"
+          if [ "$GITHUB_EVENT_NAME" = "schedule" ] || [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            # Level-triggered catch-up: rebuild when the current version's release
+            # is missing any runner asset, or the committed manifest lags it.
+            NEED=false
+            if gh release view "v$CUR" --json assets --jq '[.assets[].name]' > /tmp/assets.json 2>/dev/null; then
+              for A in "rn-fast-runner-$CUR-sim.zip" "rn-android-runner-$CUR.zip" "runner-manifest.json"; do
+                grep -qF "\"$A\"" /tmp/assets.json || { echo "missing asset: $A"; NEED=true; }
+              done
+            else
+              echo "release v$CUR does not exist yet"
+              NEED=true
+            fi
+            MANIFEST_V=$(jq -r '.version // "none"' runner-manifest.json 2>/dev/null || echo none)
+            [ "$MANIFEST_V" = "$CUR" ] || NEED=true
+            echo "catch-up: version=$CUR need=$NEED (manifest=$MANIFEST_V)"
+            echo "changed=$NEED" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git show HEAD~1:.claude-plugin/plugin.json > /tmp/prev.json 2>/dev/null || echo '{}' > /tmp/prev.json
+          PREV=$(jq -r '.version // "none"' /tmp/prev.json)
+          echo "current=$CUR previous=$PREV"
+          if [ "$CUR" != "$PREV" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+```
+
+And add `GH_TOKEN` to that step's `env:` (the catch-up branch calls `gh release view`):
+
+```yaml
+        env:
+          FORCE_VERSION: ${{ github.event.inputs.force_version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Also update the workflow's header comment (lines 3–19): replace the sentence
+"It is wired to fire once per release: on push to main it detects a plugin.json
+version bump" with a note that the push trigger cannot fire for bot-merged
+Version PRs (GITHUB_TOKEN recursion guard) and that the release-time
+`workflow_dispatch` from release.yml plus the nightly catch-up sweep are the
+real publish paths.
+
+- [ ] **Step 4: Validate the YAML**
+
+```bash
+node -e "require('js-yaml').load(require('fs').readFileSync(process.argv[1],'utf8')); console.log('YAML OK')" .github/workflows/runner-artifacts.yml
+```
+Expected: `YAML OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/runner-artifacts.yml
+git commit -S -m "fix(story-01): level-triggered catch-up sweep for runner artifacts (#382, #387)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 2: Dispatch-after-merge in `release.yml`
+
+**Files:**
+- Modify: `.github/workflows/release.yml` (permissions + one new step after the merge step)
+
+**Interfaces:**
+- Consumes: `steps.changesets.outputs.pullRequestNumber` (existing); `origin/main:.claude-plugin/plugin.json` after the merge.
+- Produces: a `workflow_dispatch` of `runner-artifacts.yml` with `force_version=<bumped version>`.
+
+- [ ] **Step 1: Add `actions: write` permission**
+
+Replace the `permissions:` block (lines 26–28) with:
+
+```yaml
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+```
+
+(`gh workflow run` needs `actions: write`; with an explicit permissions block, anything unlisted is denied.)
+
+- [ ] **Step 2: Append the dispatch step**
+
+Add after the "Merge the Version Packages PR" step (after line 81):
+
+```yaml
+      # #382 trigger bug: the merge above used GITHUB_TOKEN, so the bump push
+      # fires no workflows (recursion guard). workflow_dispatch is the
+      # documented exception — dispatch the artifact build explicitly. In the
+      # --auto path the merge may not have landed yet; skip, and the nightly
+      # catch-up sweep in runner-artifacts.yml converges within 24 h.
+      - name: Dispatch runner-artifacts for the released version
+        if: steps.changesets.outputs.pullRequestNumber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
+        run: |
+          STATE=$(gh pr view "$PR_NUMBER" --json state --jq .state)
+          if [ "$STATE" != "MERGED" ]; then
+            echo "Version PR #$PR_NUMBER not merged yet (state=$STATE) — leaving artifact publish to the nightly catch-up sweep"
+            exit 0
+          fi
+          git fetch origin main
+          V=$(git show origin/main:.claude-plugin/plugin.json | jq -r .version)
+          echo "dispatching runner-artifacts for v$V"
+          gh workflow run runner-artifacts.yml -f force_version="$V"
+```
+
+- [ ] **Step 3: Validate the YAML**
+
+```bash
+node -e "require('js-yaml').load(require('fs').readFileSync(process.argv[1],'utf8')); console.log('YAML OK')" .github/workflows/release.yml
+```
+Expected: `YAML OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -S -m "fix(story-01): dispatch runner-artifacts after Version PR merge (#382, #387)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 3: Ship PR 1 and prove the pipeline publishes
+
+**Files:**
+- Create: `.changeset/story-01-runner-artifacts-trigger-fix.md`
+- Workspace: append to `/Users/anton_personal/GitHub/rn-dev-agent-workspace/docs/BUGS.md` and `DECISIONS.md`
+
+- [ ] **Step 1: Changeset**
+
+```markdown
+---
+'rn-dev-agent-plugin': patch
+---
+
+Fix the Story 01 runner-artifact pipeline never firing: Version-PR merges use GITHUB_TOKEN, whose pushes trigger no workflows. release.yml now dispatches runner-artifacts.yml (workflow_dispatch is exempt from the recursion guard) after the merge, and a nightly catch-up sweep publishes whenever the current version's release lacks any runner asset.
+```
+
+```bash
+git add .changeset/story-01-runner-artifacts-trigger-fix.md
+git commit -S -m "chore(story-01): changeset for the artifact-pipeline trigger fix (#382)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 2: Workspace bug + decision entries** (next B/D numbers from the files' tails)
+
+BUGS.md entry (adjust the B-number): the trigger bug, root cause (GITHUB_TOKEN recursion guard vs push-triggered detect), evidence (bump commits with no runs), fix (dispatch + sweep).
+DECISIONS.md entry (adjust the D-number): "Artifact publishing is level-triggered (dispatch-after-merge + nightly catch-up sweep) rather than PAT-based — no new credentials; workflow_dispatch is exempt from the recursion guard."
+Commit both in the workspace repo (pre-authorized).
+
+- [ ] **Step 3: Push, open PR 1**
+
+```bash
+git push -u origin fix/382-runner-artifacts-trigger
+gh pr create --title "fix(story-01): make the runner-artifact pipeline actually fire (#382)" --body "<summary of bug + two mechanisms + evidence links>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 4: CI green + review threads addressed → merge** (standing merge rule; squash)
+
+- [ ] **Step 5: Prove publishing end-to-end (acceptance)**
+
+After merge, dispatch the sweep once instead of waiting for the cron:
+
+```bash
+gh workflow run runner-artifacts.yml
+gh run watch $(gh run list --workflow=runner-artifacts.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+
+Expected: detect → `changed=true` (catch-up), all three build jobs run, and:
+
+```bash
+V=$(jq -r .version .claude-plugin/plugin.json)   # after git pull
+gh release view "v$V" --json assets --jq '[.assets[].name]'
+```
+returns all three assets; `origin/main` gains the `chore(release): runner-manifest for v$V [skip ci]` commit with a populated `runner-manifest.json`.
+
+---
+
+## PR 2 — fixtures, driver, nightly workflow
+
+### Task 4: iOS contract fixture
+
+A single-file SwiftUI app compiled with `swiftc` — no Xcode project. `.ignoresSafeArea(.keyboard)` disables SwiftUI's automatic keyboard avoidance so the bottom bar is genuinely occluded by the keyboard (the keyboard-guard scenario depends on this).
+
+**Files:**
+- Create: `test-fixtures/ios-fixture/Sources/FixtureApp.swift`
+- Create: `test-fixtures/ios-fixture/Info.plist`
+- Create: `test-fixtures/ios-fixture/build.sh` (mode 755)
+- Create: `test-fixtures/ios-fixture/README.md`
+- Modify: `.gitignore` (add `test-fixtures/ios-fixture/build/`)
+
+**Interfaces:**
+- Produces: `test-fixtures/ios-fixture/build/Fixture.app` with bundle id `dev.lykhoyda.rndevagent.fixture`; the element identifiers from Global Constraints (iOS matcher is `identifier == %@ OR label == %@`, so `.accessibilityIdentifier(...)` is the contract).
+
+- [ ] **Step 1: Write `Sources/FixtureApp.swift`**
+
+```swift
+import SwiftUI
+
+@main
+struct FixtureApp: App {
+  var body: some Scene {
+    WindowGroup { ContentView() }
+  }
+}
+
+struct ContentView: View {
+  @State private var count = 0
+  @State private var text = ""
+  @State private var bottomText = ""
+  @State private var bottomTaps = 0
+
+  var body: some View {
+    VStack(spacing: 8) {
+      Button("Increment") { count += 1 }
+        .accessibilityIdentifier("fixture_button")
+      Text("count: \(count)")
+        .accessibilityIdentifier("fixture_count")
+      TextField("type here", text: $text)
+        .textFieldStyle(.roundedBorder)
+        .accessibilityIdentifier("fixture_input")
+        .padding(.horizontal)
+      List(1...100, id: \.self) { n in
+        Text("row \(n)")
+          .accessibilityIdentifier("fixture_row_\(n)")
+      }
+      .accessibilityIdentifier("fixture_list")
+      HStack {
+        TextField("bottom", text: $bottomText)
+          .textFieldStyle(.roundedBorder)
+          .accessibilityIdentifier("fixture_bottom_input")
+        Button("Tap") { bottomTaps += 1 }
+          .accessibilityIdentifier("fixture_bottom_button")
+      }
+      .padding(.horizontal)
+      Text("bottom taps: \(bottomTaps)")
+        .accessibilityIdentifier("fixture_bottom_count")
+    }
+    .padding(.vertical)
+    // Keyboard-guard contract fixture: keep the bottom bar UNDER the keyboard.
+    .ignoresSafeArea(.keyboard)
+  }
+}
+```
+
+- [ ] **Step 2: Write `Info.plist`**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key><string>en</string>
+  <key>CFBundleExecutable</key><string>Fixture</string>
+  <key>CFBundleIdentifier</key><string>dev.lykhoyda.rndevagent.fixture</string>
+  <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+  <key>CFBundleName</key><string>Fixture</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleShortVersionString</key><string>1.0</string>
+  <key>CFBundleVersion</key><string>1</string>
+  <key>CFBundleSupportedPlatforms</key><array><string>iPhoneSimulator</string></array>
+  <key>DTPlatformName</key><string>iphonesimulator</string>
+  <key>DTSDKName</key><string>iphonesimulator</string>
+  <key>LSRequiresIPhoneOS</key><true/>
+  <key>MinimumOSVersion</key><string>16.0</string>
+  <key>UILaunchScreen</key><dict/>
+  <key>UISupportedInterfaceOrientations</key><array><string>UIInterfaceOrientationPortrait</string></array>
+</dict>
+</plist>
+```
+
+- [ ] **Step 3: Write `build.sh`**
+
+```bash
+#!/usr/bin/env bash
+# Builds the iOS contract fixture as an unsigned simulator .app — no Xcode
+# project needed (single-file SwiftUI app compiled with swiftc).
+set -euo pipefail
+cd "$(dirname "$0")"
+ARCH="${FIXTURE_ARCH:-$(uname -m)}"
+OUT=build/Fixture.app
+rm -rf build
+mkdir -p "$OUT"
+xcrun -sdk iphonesimulator swiftc \
+  -parse-as-library -O \
+  -target "$ARCH-apple-ios16.0-simulator" \
+  Sources/FixtureApp.swift \
+  -o "$OUT/Fixture"
+cp Info.plist "$OUT/Info.plist"
+codesign --force --sign - "$OUT"
+echo "built $OUT"
+```
+
+```bash
+chmod +x test-fixtures/ios-fixture/build.sh
+```
+
+- [ ] **Step 4: README.md** — one paragraph: what the fixture is (contract fixture for the nightly golden set, element table from the spec), how to build (`bash build.sh`), install (`xcrun simctl install booted build/Fixture.app`), launch (`xcrun simctl launch booted dev.lykhoyda.rndevagent.fixture`).
+
+- [ ] **Step 5: `.gitignore`** — append:
+
+```
+test-fixtures/ios-fixture/build/
+```
+
+- [ ] **Step 6: Build + install on the booted local simulator (test)**
+
+```bash
+bash test-fixtures/ios-fixture/build.sh
+xcrun simctl list devices booted    # boot one via Simulator.app if empty
+xcrun simctl install booted test-fixtures/ios-fixture/build/Fixture.app
+xcrun simctl launch booted dev.lykhoyda.rndevagent.fixture
+```
+Expected: launch prints a PID; the app shows the Increment button, count label, field, list, bottom bar.
+
+This step is a HARD GATE: the handcrafted-bundle risk (swiftc-built .app, no Xcode project) lives entirely here — do not start Tasks 6 or 8 until install + launch is verified on a real simulator.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add test-fixtures/ios-fixture .gitignore
+git commit -S -m "feat(story-06): iOS contract fixture app for the device smoke (#387)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 5: Android contract fixture
+
+Pure `android.widget` (no androidx dependency), reusing rn-android-runner's Gradle wrapper via `-p`. `android:windowSoftInputMode="adjustNothing"` keeps the bottom bar under the keyboard (occlusion contract). List rows are matched by their visible text (`row <n>`) — note `simple_list_item_1` rows already carry `android:id/text1`, so the snapshot identifier is `text1`; the additional `contentDescription = "fixture_row_<n>"` is informational (the desc fallback only applies to views whose resource-id is blank).
+
+**Files:**
+- Create: `test-fixtures/android-fixture/settings.gradle.kts`
+- Create: `test-fixtures/android-fixture/build.gradle.kts`
+- Create: `test-fixtures/android-fixture/app/build.gradle.kts`
+- Create: `test-fixtures/android-fixture/app/src/main/AndroidManifest.xml`
+- Create: `test-fixtures/android-fixture/app/src/main/java/dev/lykhoyda/rndevagent/fixture/MainActivity.kt`
+- Create: `test-fixtures/android-fixture/app/src/main/res/layout/activity_main.xml`
+- Create: `test-fixtures/android-fixture/README.md`
+- Modify: `.gitignore` (fixture build dirs)
+
+**Interfaces:**
+- Produces: `test-fixtures/android-fixture/app/build/outputs/apk/debug/app-debug.apk`, applicationId `dev.lykhoyda.rndevagent.fixture`; identifiers via `android:id` (top-level elements) and `contentDescription` (list rows).
+
+- [ ] **Step 1: `settings.gradle.kts`**
+
+```kotlin
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "RnDevAgentFixture"
+include(":app")
+```
+
+- [ ] **Step 2: root `build.gradle.kts`**
+
+```kotlin
+plugins {
+    id("com.android.application") version "8.7.3" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+}
+```
+
+- [ ] **Step 3: `app/build.gradle.kts`**
+
+```kotlin
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "dev.lykhoyda.rndevagent.fixture"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "dev.lykhoyda.rndevagent.fixture"
+        minSdk = 23
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+```
+
+- [ ] **Step 4: `AndroidManifest.xml`**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:label="Fixture">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:windowSoftInputMode="adjustNothing">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>
+```
+
+- [ ] **Step 5: `MainActivity.kt`**
+
+```kotlin
+package dev.lykhoyda.rndevagent.fixture
+
+import android.app.Activity
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.ListView
+import android.widget.TextView
+
+class MainActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        val count = findViewById<TextView>(R.id.fixture_count)
+        var taps = 0
+        findViewById<View>(R.id.fixture_button).setOnClickListener {
+            taps += 1
+            count.text = "count: $taps"
+        }
+
+        val bottomCount = findViewById<TextView>(R.id.fixture_bottom_count)
+        var bottomTaps = 0
+        findViewById<View>(R.id.fixture_bottom_button).setOnClickListener {
+            bottomTaps += 1
+            bottomCount.text = "bottom taps: $bottomTaps"
+        }
+
+        val rows = (1..100).map { "row $it" }
+        val list = findViewById<ListView>(R.id.fixture_list)
+        list.adapter = object : ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, rows) {
+            override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+                val v = super.getView(position, convertView, parent)
+                v.contentDescription = "fixture_row_${position + 1}"
+                return v
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 6: `res/layout/activity_main.xml`**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="8dp">
+
+    <!-- textAllCaps=false: device_find exact-matches "Increment" case-sensitively;
+         the platform default would render/announce "INCREMENT". -->
+    <Button
+        android:id="@+id/fixture_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAllCaps="false"
+        android:text="Increment" />
+
+    <TextView
+        android:id="@+id/fixture_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="count: 0" />
+
+    <EditText
+        android:id="@+id/fixture_input"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="type here"
+        android:inputType="text" />
+
+    <ListView
+        android:id="@+id/fixture_list"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <EditText
+            android:id="@+id/fixture_bottom_input"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:hint="bottom"
+            android:inputType="text" />
+
+        <Button
+            android:id="@+id/fixture_bottom_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAllCaps="false"
+            android:text="Tap" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/fixture_bottom_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="bottom taps: 0" />
+</LinearLayout>
+```
+
+- [ ] **Step 7: README.md** — build (`scripts/rn-android-runner/gradlew -p test-fixtures/android-fixture :app:assembleDebug`), install (`adb install -r app/build/outputs/apk/debug/app-debug.apk`), why `adjustNothing` (occlusion contract) and why rows use `contentDescription`.
+
+- [ ] **Step 8: `.gitignore`** — append:
+
+```
+test-fixtures/android-fixture/.gradle/
+test-fixtures/android-fixture/**/build/
+```
+
+- [ ] **Step 9: Build (test)**
+
+```bash
+scripts/rn-android-runner/gradlew -p test-fixtures/android-fixture :app:assembleDebug --no-daemon
+ls test-fixtures/android-fixture/app/build/outputs/apk/debug/app-debug.apk
+```
+Expected: `BUILD SUCCESSFUL`; the APK exists. If an emulator is running, also `adb install -r …` + launch and eyeball the layout.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add test-fixtures/android-fixture .gitignore
+git commit -S -m "feat(story-06): Android contract fixture app for the device smoke (#387)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 6: Golden-set driver + npm entries (iOS local green)
+
+**Files:**
+- Create: `scripts/cdp-bridge/test/smoke/device-smoke.ts`
+- Modify: `package.json` (root — two scripts)
+
+**Interfaces:**
+- Consumes: `startSupervisor({cwd, env, lineTimeoutMs})` → `{child, nextLine, send, notify, stderrText}` from `../helpers/supervisor-harness.js`; tool envelopes `JSON.parse(result.content[0].text)` = `{ok, data, meta}`; snapshot nodes `{ref, identifier?, label?}`.
+- Produces: `npm run smoke:ios` / `smoke:android` (env `SMOKE_PLATFORM` baked in; `SMOKE_APP_ID`, `SMOKE_DEBUG_DIR` optional overrides), exit 0 on green.
+
+- [ ] **Step 1: Root `package.json` scripts** (after `test:native:ios`):
+
+```json
+    "smoke:ios": "SMOKE_PLATFORM=ios node scripts/cdp-bridge/test/smoke/device-smoke.ts",
+    "smoke:android": "SMOKE_PLATFORM=android node scripts/cdp-bridge/test/smoke/device-smoke.ts",
+```
+
+- [ ] **Step 2: Write the driver**
+
+```javascript
+// Story 06 Phase B (#387): golden device_* command set through the real
+// bridge (dist/supervisor.js over MCP stdio) against the contract fixture
+// app (test-fixtures/). SMOKE_PLATFORM=ios|android selects the lane. CDP is
+// intentionally absent — device_fill exercises its native read-back path.
+// RN_RUNNER_BUILD=local pins runner provenance to the checkout's own build.
+// Executed directly as TypeScript via Node >= 22.18 type stripping (a .mjs
+// file would fail ci.yml's check-typescript-only gate).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { startSupervisor } from '../helpers/supervisor-harness.js';
+
+const PLATFORM = process.env.SMOKE_PLATFORM;
+const APP_ID = process.env.SMOKE_APP_ID ?? 'dev.lykhoyda.rndevagent.fixture';
+const DEBUG_DIR = process.env.SMOKE_DEBUG_DIR ?? join(tmpdir(), 'rn-agent-smoke-debug');
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+if (PLATFORM !== 'ios' && PLATFORM !== 'android') {
+  console.error('SMOKE_PLATFORM must be "ios" or "android"');
+  process.exit(1);
+}
+
+function assertFixtureInstalled() {
+  try {
+    if (PLATFORM === 'ios') {
+      execFileSync('xcrun', ['simctl', 'get_app_container', 'booted', APP_ID], { stdio: 'pipe' });
+    } else {
+      const out = execFileSync('adb', ['shell', 'pm', 'path', APP_ID], { stdio: 'pipe' }).toString();
+      if (!out.includes('package:')) throw new Error('not installed');
+    }
+  } catch {
+    console.error(
+      `Fixture app ${APP_ID} is not installed on the booted ${PLATFORM} device.\n` +
+        `Build + install it first — see test-fixtures/${PLATFORM}-fixture/README.md`,
+    );
+    process.exit(1);
+  }
+}
+
+async function rpc(s, method, params) {
+  const id = s.send(method, params);
+  for (;;) {
+    const line = JSON.parse(await s.nextLine());
+    if (line.id === id) return line;
+    // Anything else (notifications, requests from the server) is skipped.
+  }
+}
+
+async function callTool(s, name, args = {}) {
+  const line = await rpc(s, 'tools/call', { name, arguments: args });
+  const text = line.result?.content?.[0]?.text ?? '';
+  let envelope = null;
+  try {
+    envelope = JSON.parse(text);
+  } catch {
+    // Non-JSON tool output (e.g. image content) — callers use `raw`.
+  }
+  return { raw: line, isError: Boolean(line.result?.isError), envelope, text };
+}
+
+const refFor = (snapEnvelope, identifier) =>
+  snapEnvelope?.data?.nodes?.find((n) => n.identifier === identifier)?.ref;
+
+test(`Phase B golden set (${PLATFORM})`, { timeout: 900_000 }, async () => {
+  assertFixtureInstalled();
+  mkdirSync(DEBUG_DIR, { recursive: true });
+  const cwd = mkdtempSync(join(tmpdir(), 'rn-agent-smoke-'));
+  const s = startSupervisor({ cwd, lineTimeoutMs: 600_000, env: { RN_RUNNER_BUILD: 'local' } });
+  const steps = [];
+  const record = (name, r) => {
+    steps.push({ name, isError: r.isError, envelope: r.envelope });
+    console.log(`step ${name}: ${r.isError ? 'ERROR' : (r.envelope?.ok ?? 'n/a')}`);
+    return r;
+  };
+
+  try {
+    const init = await rpc(s, 'initialize');
+    assert.ok(init.result, 'initialize must return a result');
+    s.notify('notifications/initialized');
+
+    const open = record(
+      'open',
+      await callTool(s, 'device_snapshot', { action: 'open', platform: PLATFORM, appId: APP_ID }),
+    );
+    assert.equal(open.envelope?.ok, true, `open failed: ${open.text.slice(0, 500)}`);
+
+    let snap = record('snapshot', await callTool(s, 'device_snapshot', { action: 'snapshot' }));
+    assert.equal(snap.envelope?.ok, true, `snapshot failed: ${snap.text.slice(0, 500)}`);
+    for (const id of ['fixture_button', 'fixture_count', 'fixture_input', 'fixture_bottom_button']) {
+      assert.ok(refFor(snap.envelope, id), `snapshot missing @ref for ${id}`);
+    }
+
+    const find = record('find', await callTool(s, 'device_find', { text: 'Increment', exact: true }));
+    assert.equal(find.envelope?.ok, true, `find failed: ${find.text.slice(0, 500)}`);
+
+    const press = record(
+      'press',
+      await callTool(s, 'device_press', { ref: refFor(snap.envelope, 'fixture_button') }),
+    );
+    assert.equal(press.envelope?.ok, true, `press failed: ${press.text.slice(0, 500)}`);
+    assert.ok(press.envelope?.meta?.settle, 'press must report meta.settle');
+
+    snap = record('snapshot-2', await callTool(s, 'device_snapshot', { action: 'snapshot' }));
+    const countNode = snap.envelope?.data?.nodes?.find((n) => n.identifier === 'fixture_count');
+    assert.ok(countNode, 'fixture_count missing from the post-press snapshot');
+    assert.match(countNode.label ?? '', /count: 1/, 'counter must increment after press');
+
+    // device_scrollintoview does exactly ONE blind swipe when the target is
+    // absent from the snapshot (device-interact.ts:1383) — row 80 is ~3 screens
+    // away, so scroll until the row is IN a snapshot, then let the verb finish
+    // on its supported (target-visible) path.
+    let rowVisible = false;
+    for (let i = 0; i < 10 && !rowVisible; i++) {
+      const scroll = record(`scroll-${i}`, await callTool(s, 'device_scroll', { direction: 'down' }));
+      assert.equal(scroll.envelope?.ok, true, `scroll failed: ${scroll.text.slice(0, 500)}`);
+      const look = record(`snapshot-scroll-${i}`, await callTool(s, 'device_snapshot', { action: 'snapshot' }));
+      rowVisible = Boolean(
+        look.envelope?.data?.nodes?.some((n) => n.label === 'row 80' || n.identifier === 'fixture_row_80'),
+      );
+    }
+    assert.ok(rowVisible, 'row 80 never appeared in a snapshot after 10 scrolls');
+
+    const into = record(
+      'scrollintoview',
+      await callTool(s, 'device_scrollintoview', { text: 'row 80' }),
+    );
+    assert.equal(into.envelope?.ok, true, `scrollintoview failed: ${into.text.slice(0, 500)}`);
+
+    const shot = record('screenshot', await callTool(s, 'device_screenshot', {}));
+    const shotPath = shot.envelope?.data?.path;
+    if (shotPath) {
+      const head = [...readFileSync(shotPath).subarray(0, 8)];
+      assert.deepEqual(head, PNG_MAGIC, 'screenshot file must be a PNG');
+    } else {
+      const img = shot.raw.result?.content?.find((c) => c.type === 'image');
+      assert.ok(img?.data, `screenshot returned neither a path nor image content: ${shot.text.slice(0, 300)}`);
+    }
+
+    snap = record('snapshot-3', await callTool(s, 'device_snapshot', { action: 'snapshot' }));
+    const fill = record(
+      'fill',
+      await callTool(s, 'device_fill', { ref: refFor(snap.envelope, 'fixture_input'), text: 'hello smoke' }),
+    );
+    assert.equal(fill.envelope?.ok, true, `fill failed: ${fill.text.slice(0, 500)}`);
+
+    // Keyboard-guard scenario (#370 contract): the fill above left the
+    // keyboard up; the bottom bar sits under it by fixture design.
+    const kb = record(
+      'keyboard-guard',
+      await callTool(s, 'device_press', { ref: refFor(snap.envelope, 'fixture_bottom_button') }),
+    );
+    const guard = kb.envelope?.meta?.keyboardGuard;
+    if (PLATFORM === 'android') {
+      // no_keyboard = environment problem (soft IME never appeared), not a
+      // contract result — fail with the fix, don't let it masquerade.
+      assert.notEqual(
+        guard,
+        'no_keyboard',
+        'Soft keyboard never appeared — the emulator needs `adb shell settings put secure show_ime_with_hard_keyboard 1` (the nightly workflow sets it)',
+      );
+      assert.equal(kb.envelope?.ok, true, `keyboard-guard press failed: ${kb.text.slice(0, 500)}`);
+      assert.equal(guard, 'dismissed', 'Android must dismiss the keyboard first');
+    } else {
+      assert.notEqual(
+        kb.envelope?.ok,
+        true,
+        `iOS keyboard-guard scenario invalid: the tap went through (keyboardGuard=${guard}). ` +
+          'The software keyboard likely never appeared on this headless simulator — environment problem, not a contract pass.',
+      );
+      const body = kb.text;
+      assert.match(body, /KEYBOARD_OCCLUDED/, `expected KEYBOARD_OCCLUDED: ${body.slice(0, 500)}`);
+      assert.match(body, /dismiss_failed/, `expected keyboardGuard=dismiss_failed: ${body.slice(0, 500)}`);
+    }
+
+    const neg = record(
+      'negative-find',
+      await callTool(s, 'device_find', { text: 'fixture_does_not_exist_zz', exact: true }),
+    );
+    assert.ok(neg.isError || neg.envelope?.ok === false, 'nonexistent element must yield an error envelope');
+
+    const alive = record('snapshot-4', await callTool(s, 'device_snapshot', { action: 'snapshot' }));
+    assert.equal(alive.envelope?.ok, true, 'bridge must stay healthy after the negative case');
+    const total = Object.values(alive.envelope?.meta?.timings_ms ?? {}).reduce(
+      (a, b) => (typeof b === 'number' ? a + b : a),
+      0,
+    );
+    assert.ok(total < 20_000, `snapshot too slow: ${total}ms (ceiling 20000)`);
+
+    const close = record('close', await callTool(s, 'device_snapshot', { action: 'close' }));
+    assert.equal(close.envelope?.ok, true, `close failed: ${close.text.slice(0, 500)}`);
+  } finally {
+    writeFileSync(join(DEBUG_DIR, `smoke-${PLATFORM}-steps.json`), JSON.stringify(steps, null, 2));
+    s.child.kill('SIGTERM');
+  }
+});
+```
+
+- [ ] **Step 3: Run against the local booted iOS simulator (test)**
+
+Prerequisites: simulator booted, fixture installed (Task 4 Step 6), `scripts/cdp-bridge` deps installed (`cd scripts/cdp-bridge && npm ci`).
+
+```bash
+npm run smoke:ios
+```
+Expected: all steps log `ok`, `pass 1`. First run may pay a runner build (RN_RUNNER_BUILD=local with no DerivedData). If an envelope-shape assertion fails (e.g. screenshot path field), fix the DRIVER to the real envelope — the tools are the contract, the driver adapts.
+
+- [ ] **Step 4: Lint + format**
+
+```bash
+npx oxlint scripts/cdp-bridge/test/smoke/device-smoke.ts && npx oxfmt --check scripts/cdp-bridge/test/smoke/device-smoke.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/cdp-bridge/test/smoke/device-smoke.ts package.json
+git commit -S -m "feat(story-06): golden-set device smoke driver over MCP stdio (#387)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 7: Android local green
+
+**Files:**
+- Modify (only if the Android run surfaces driver/fixture issues): `scripts/cdp-bridge/test/smoke/device-smoke.ts`, `test-fixtures/android-fixture/**`
+
+- [ ] **Step 1: Boot an emulator, install the fixture**
+
+```bash
+adb devices    # ensure one emulator
+adb shell settings put secure show_ime_with_hard_keyboard 1
+scripts/rn-android-runner/gradlew -p test-fixtures/android-fixture :app:assembleDebug --no-daemon
+adb install -r test-fixtures/android-fixture/app/build/outputs/apk/debug/app-debug.apk
+```
+(The `show_ime_with_hard_keyboard` setting forces the soft IME even though emulators expose a hardware keyboard — without it the keyboard-guard step reports `no_keyboard`.)
+
+- [ ] **Step 2: Run the driver**
+
+```bash
+npm run smoke:android
+```
+Expected: `pass 1`, including `keyboardGuard: "dismissed"` on the keyboard step. Likely first-run findings: identifier mismatches (resource-id normalization) or `adjustNothing` behavior — fix in the fixture/driver, re-run to green.
+
+- [ ] **Step 3: Commit any fixes**
+
+```bash
+git add -A scripts/cdp-bridge/test/smoke test-fixtures/android-fixture
+git commit -S -m "fix(story-06): Android lane fixes for the golden-set driver (#387)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+(Skip the commit if no changes were needed — note that in the report.)
+
+### Task 8: Nightly workflow
+
+**Files:**
+- Create: `.github/workflows/nightly-device-smoke.yml`
+
+**Interfaces:**
+- Consumes: `npm run smoke:ios|android`; fixture build commands from Tasks 4–5; `runner-manifest.json` (`{version, assets: {ios: [{name, sha256, bytes}], android: [...]}}`).
+- Produces: nightly schedule + dispatch; tracking-issue alerting on the `nightly-smoke-red` label.
+
+- [ ] **Step 1: Write the workflow**
+
+```yaml
+name: Nightly device smoke
+
+# Story 06 Phase B (#387): golden device_* set through the real bridge
+# (dist/supervisor.js over MCP stdio) against the contract fixtures, plus an
+# artifact-integrity lane for the Story 01 release artifacts. Nightly and NOT
+# merge-gating by design; alerting fires only on 2 consecutive red scheduled
+# runs (report job). Smoke lanes build main-HEAD runners (cached) —
+# RUNNER_COMMANDS_STALE noise from old release bits is impossible here.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch: {}
+
+concurrency: nightly-device-smoke
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+jobs:
+  ios-smoke:
+    name: iOS device smoke
+    runs-on: macos-15
+    timeout-minutes: 40
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install bridge deps
+        working-directory: scripts/cdp-bridge
+        run: npm ci
+      - name: Xcode version for the cache key
+        run: echo "XCODE_V=$(xcodebuild -version | head -1 | tr ' ' '-')" >> "$GITHUB_ENV"
+      - name: Restore runner DerivedData
+        id: dd-cache
+        uses: actions/cache@v4
+        with:
+          path: scripts/rn-fast-runner/build/DerivedData
+          key: rn-fast-runner-dd-${{ runner.os }}-${{ env.XCODE_V }}-${{ hashFiles('scripts/rn-fast-runner/**') }}
+      - name: Disable simulator hardware keyboard (software keyboard must appear)
+        run: defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false
+      - name: Pre-boot simulator
+        run: |
+          set -euo pipefail
+          UDID="$(xcrun simctl list devices available --json | jq -r '[.devices[] | .[] | select(.name == "iPhone 16")][0].udid // empty')"
+          if [ -z "$UDID" ]; then
+            echo "No 'iPhone 16' on this image — falling back to the first available iPhone" >&2
+            UDID="$(xcrun simctl list devices available --json | jq -r '[.devices[] | .[] | select(.name | startswith("iPhone"))][0].udid // empty')"
+          fi
+          [ -n "$UDID" ]
+          xcrun simctl boot "$UDID" || true
+          xcrun simctl bootstatus "$UDID" -b
+          echo "SMOKE_UDID=$UDID" >> "$GITHUB_ENV"
+      - name: Build runner (cache miss only)
+        if: steps.dd-cache.outputs.cache-hit != 'true'
+        run: |
+          xcodebuild build-for-testing \
+            -project scripts/rn-fast-runner/RnFastRunner/RnFastRunner.xcodeproj \
+            -scheme RnFastRunner \
+            -destination "id=$SMOKE_UDID" \
+            -derivedDataPath scripts/rn-fast-runner/build/DerivedData \
+            CODE_SIGNING_ALLOWED=NO
+      - name: Build + install fixture
+        run: |
+          bash test-fixtures/ios-fixture/build.sh
+          xcrun simctl install "$SMOKE_UDID" test-fixtures/ios-fixture/build/Fixture.app
+      - name: Run golden set
+        env:
+          SMOKE_DEBUG_DIR: ${{ runner.temp }}/smoke-debug
+        run: npm run smoke:ios
+      - name: Collect simulator diagnostics (on failure)
+        if: failure()
+        run: |
+          mkdir -p "$RUNNER_TEMP/smoke-debug"
+          xcrun simctl spawn "$SMOKE_UDID" log collect --output "$RUNNER_TEMP/smoke-debug/sim.logarchive" || true
+      - name: Upload smoke debug (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-smoke-debug
+          path: ${{ runner.temp }}/smoke-debug
+          retention-days: 7
+
+  android-smoke:
+    name: Android device smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install bridge deps
+        working-directory: scripts/cdp-bridge
+        run: npm ci
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Set up Gradle (cache)
+        uses: gradle/actions/setup-gradle@v4
+      - name: Build runner APKs + fixture APK (before the emulator boots)
+        run: |
+          (cd scripts/rn-android-runner && ./gradlew :app:assembleDebug :app:assembleDebugAndroidTest --no-daemon)
+          scripts/rn-android-runner/gradlew -p test-fixtures/android-fixture :app:assembleDebug --no-daemon
+      - name: Run golden set on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          disable-animations: true
+          script: |
+            adb shell settings put secure show_ime_with_hard_keyboard 1
+            adb install -r test-fixtures/android-fixture/app/build/outputs/apk/debug/app-debug.apk
+            SMOKE_DEBUG_DIR="$RUNNER_TEMP/smoke-debug" npm run smoke:android
+      - name: Upload smoke debug (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-smoke-debug
+          path: ${{ runner.temp }}/smoke-debug
+          retention-days: 7
+
+  artifact-integrity:
+    name: Release artifact integrity (Story 01)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Verify released runner artifacts against the committed manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          V=$(jq -r '.version // empty' runner-manifest.json)
+          if [ -z "$V" ] || [ "$V" = "null" ]; then
+            echo "runner-manifest.json is still the empty seed — the artifact pipeline has never published." >&2
+            echo "Fix: dispatch the runner-artifacts workflow once (catch-up mode publishes the current version)." >&2
+            exit 1
+          fi
+          mkdir -p /tmp/assets && cd /tmp/assets
+          gh release download "v$V" --repo "$GITHUB_REPOSITORY" \
+            --pattern "rn-fast-runner-$V-sim.zip" \
+            --pattern "rn-android-runner-$V.zip"
+          for P in ios android; do
+            NAME=$(jq -r ".assets.$P[0].name" "$GITHUB_WORKSPACE/runner-manifest.json")
+            SHA=$(jq -r ".assets.$P[0].sha256" "$GITHUB_WORKSPACE/runner-manifest.json")
+            BYTES=$(jq -r ".assets.$P[0].bytes" "$GITHUB_WORKSPACE/runner-manifest.json")
+            echo "$SHA  $NAME" | sha256sum -c -
+            ACTUAL=$(stat -c%s "$NAME")
+            [ "$ACTUAL" = "$BYTES" ] || { echo "size mismatch for $NAME: manifest=$BYTES actual=$ACTUAL" >&2; exit 1; }
+          done
+          for Z in *.zip; do
+            if unzip -l "$Z" | awk 'NR>3 {print $4}' | grep -E '^/|(^|/)\.\.(/|$)'; then
+              echo "suspicious path in $Z" >&2
+              exit 1
+            fi
+          done
+          unzip -l "rn-fast-runner-$V-sim.zip" | grep -q '\.xctestrun' || { echo "iOS zip missing .xctestrun" >&2; exit 1; }
+          unzip -l "rn-android-runner-$V.zip" | grep -q 'app-debug\.apk' || { echo "android zip missing app-debug.apk" >&2; exit 1; }
+          unzip -l "rn-android-runner-$V.zip" | grep -q 'app-debug-androidTest\.apk' || { echo "android zip missing androidTest apk" >&2; exit 1; }
+          echo "artifact integrity OK for v$V"
+
+  report:
+    name: Consecutive-red alerting
+    needs: [ios-smoke, android-smoke, artifact-integrity]
+    if: always() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Open/refresh or close the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RED: ${{ contains(needs.*.result, 'failure') }}
+        run: |
+          set -euo pipefail
+          PREV=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow nightly-device-smoke.yml \
+            --event schedule --limit 2 --json databaseId,conclusion \
+            --jq "[.[] | select(.databaseId != $GITHUB_RUN_ID)][0].conclusion // \"none\"")
+          echo "this-red=$RED previous=$PREV"
+          OPEN=$(gh issue list --repo "$GITHUB_REPOSITORY" --label nightly-smoke-red --state open --json number --jq '.[0].number // empty')
+          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          if [ "$RED" = "true" ] && [ "$PREV" = "failure" ]; then
+            if [ -n "$OPEN" ]; then
+              gh issue comment "$OPEN" --repo "$GITHUB_REPOSITORY" --body "Still red: $RUN_URL"
+            else
+              gh issue create --repo "$GITHUB_REPOSITORY" \
+                --title "Nightly device smoke: 2 consecutive red nights" \
+                --label nightly-smoke-red \
+                --body "The nightly device smoke has failed on 2+ consecutive scheduled runs. Latest: $RUN_URL"
+            fi
+          elif [ "$RED" = "false" ] && [ -n "$OPEN" ]; then
+            gh issue comment "$OPEN" --repo "$GITHUB_REPOSITORY" --body "Recovered: $RUN_URL"
+            gh issue close "$OPEN" --repo "$GITHUB_REPOSITORY"
+          fi
+```
+
+- [ ] **Step 2: Validate the YAML**
+
+```bash
+node -e "require('js-yaml').load(require('fs').readFileSync(process.argv[1],'utf8')); console.log('YAML OK')" .github/workflows/nightly-device-smoke.yml
+```
+Expected: `YAML OK`
+
+- [ ] **Step 3: Create the alert label (one-time; `gh issue create --label` fails on a missing label)**
+
+```bash
+gh label create nightly-smoke-red --description "Nightly device smoke red 2+ consecutive scheduled runs" --color B60205 || true
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/nightly-device-smoke.yml
+git commit -S -m "feat(story-06): nightly device smoke workflow — iOS/Android lanes + artifact integrity + 2-red alerting (#387)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 9: Docs, PR 2, acceptance runs
+
+**Files:**
+- Modify: `docs/stories/06-native-runner-ci-and-evals.md` (Status line + a Phase B "Implemented" blockquote mirroring the Phase A one: main-HEAD provenance rationale, keyboard contract assertion, integrity lane, alerting rule, `smoke:*` local entries)
+- Create: `.changeset/story-06-phase-b-device-smoke.md` (`'rn-dev-agent-plugin': patch` — nightly device smoke + fixtures + smoke scripts)
+- Workspace: ROADMAP.md narrative entry; DECISIONS.md entries for (a) hybrid provenance, (b) native contract fixtures over RN fixture
+
+- [ ] **Step 1: Story doc + changeset, commit**
+
+```bash
+git add docs/stories/06-native-runner-ci-and-evals.md .changeset/story-06-phase-b-device-smoke.md
+git commit -S -m "docs(story-06): Phase B status + changeset (#387)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 2: Push, open PR 2** (body: spec link, lane description, local-green evidence from Tasks 6–7, note that scheduled runs start after merge)
+
+- [ ] **Step 3: CI green + threads addressed → merge**
+
+- [ ] **Step 4: Acceptance — real dispatch run green**
+
+```bash
+gh workflow run nightly-device-smoke.yml
+gh run watch $(gh run list --workflow=nightly-device-smoke.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+Expected: iOS + Android smoke lanes and integrity lane green (integrity requires Task 3's published artifacts); report job skipped (`workflow_dispatch`). Wall-clock ≤ 45 min.
+
+- [ ] **Step 5: Acceptance — seeded-bug check (story criterion)**
+
+```bash
+git checkout -b scratch/387-seeded-tap-offset origin/main
+```
+In `scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RnFastRunnerTests+Interaction.swift`, find the tap command's coordinate computation and add a deliberate `+ 120` to the y coordinate (marker comment `// DO NOT MERGE — seeded bug for #387 Phase B acceptance`). Push the branch, then:
+
+```bash
+gh workflow run nightly-device-smoke.yml --ref scratch/387-seeded-tap-offset
+```
+Expected: iOS smoke lane RED (counter never increments → the `count: 1` assertion fails). Record the run URL, then delete the branch:
+
+```bash
+git push origin --delete scratch/387-seeded-tap-offset
+```
+
+- [ ] **Step 6: Workspace docs + issue comment**
+
+ROADMAP.md entry (Phase B shipped: PRs, acceptance run links, seeded-bug run link); DECISIONS entries; comment on #387 mirroring the Phase A comment (Phase B shipped, Phase C remaining). Commit workspace repo.
+
+---
+
+## Self-review notes
+
+- Spec coverage: Task 0 fix (Tasks 1–3), fixtures (4–5), golden set incl. keyboard contract + negative case + timings (6–7), workflow with lanes/integrity/alerting + local `smoke:*` entries (6, 8), acceptance incl. seeded bug (9). Deferred items (RN fixture lane, iOS 26, Phase C) are spec-explicit non-goals.
+- The driver adapts to envelope reality on first local run by design (Task 6 Step 3 note) — the tools are the contract.
+- Known risk consciously accepted: `device_screenshot` payload shape is asserted dual-branch (file path OR MCP image content).
+
+## Amendments applied from the multi-LLM plan review (2026-07-05)
+
+Participants: Codex (gpt-5.5) + Claude coordinator with file-verified research; Antigravity failed (agy hung with 0-byte output on all three dispatches — tool-side stall, not quota).
+
+Blockers fixed (all file-verified):
+1. **`.mjs` driver → `.ts`** (Codex — the review's biggest catch): ci.yml's `check-typescript-only.sh` rejects any new `.js`/`.mjs` not in `scripts/js-migration-baseline.txt` on every PR, so PR 2 could never merge. Driver renamed to `device-smoke.ts`, run via Node >= 22.18 type stripping.
+2. **`device_scrollintoview` one-blind-swipe cap** (`device-interact.ts:1383`): row 80 was unreachable — replaced with a bounded scroll loop that gets the row into a snapshot first, then exercises the verb on its supported path.
+3. **Android `textAllCaps`**: exact-find on "Increment" is case-sensitive against the node text; platform default renders "INCREMENT". Both fixture buttons now set `android:textAllCaps="false"`.
+4. **Android soft keyboard never forced**: emulators expose a hardware keyboard, so the guard would report `no_keyboard`. Workflow + local instructions set `adb shell settings put secure show_ime_with_hard_keyboard 1`; the driver fails actionably on `no_keyboard`.
+5. **iOS keyboard hardening**: `defaults write … ConnectHardwareKeyboard` may be a no-op for headless simctl; the driver's iOS branch now names the likely environment cause when the tap unexpectedly succeeds instead of refusing.
+6. **swiftc fixture proof made a hard gate** (Task 4 Step 6) + simulator `log collect` diagnostics on CI failure.
+
+Nice-to-haves applied: `target: google_apis` on the emulator step; `fixture_count` existence asserted before the increment match; catch-up detect logs the missing asset names; single `version=` write in the force branch; Task 5 rows rationale corrected (`simple_list_item_1` rows carry `android:id/text1`, so contentDescription is informational); spec DerivedData path typo fixed.
+
+Review findings verified as already-correct (no change): `device_find` without `action` is locate-only (cannot corrupt the counter); the DerivedData cache key busts on the Task 9 seeded mutation (the acceptance check is sound); the fixture Gradle pins match the runner wrapper exactly; PR 1's detect bash is `set -e`-safe and the report job's previous-run logic yields no false page on the first scheduled run.

--- a/docs/superpowers/specs/2026-07-05-387-phase-b-device-smoke-design.md
+++ b/docs/superpowers/specs/2026-07-05-387-phase-b-device-smoke-design.md
@@ -106,7 +106,7 @@ seeded-bug acceptance check). Permissions: `contents: read`, `issues: write`
 - **iOS smoke** (`macos-15`, timeout ~35 min): checkout → Node 22 → `npm ci` →
   restore runner DerivedData cache (key: hash of `scripts/rn-fast-runner/**` +
   Xcode version); on miss `xcodebuild build-for-testing` into the client's
-  expected path (`scripts/rn-fast-runner/RnFastRunner/build/DerivedData`, the
+  expected path (`scripts/rn-fast-runner/build/DerivedData`, the
   warm-path location `hasBuiltTestProduct` checks) → build/restore fixture →
   boot pinned simulator (Phase A's UDID-resolution pattern, iPhone 16 preferred)
   → `simctl install` fixture → run golden-set driver.
@@ -116,7 +116,7 @@ seeded-bug acceptance check). Permissions: `contents: read`, `issues: write`
   fixture APK → inside the emulator step: `adb install` fixture → run driver.
 - Simulator/emulator logs + screenshots uploaded as artifacts on failure.
 
-### Golden-set driver — `scripts/cdp-bridge/test/smoke/device-smoke.mjs`
+### Golden-set driver — `scripts/cdp-bridge/test/smoke/device-smoke.ts`
 
 `node:test`, reusing `test/helpers/supervisor-harness.js`: spawn
 `dist/supervisor.js` over MCP stdio, cwd = tmp project dir, env

--- a/docs/superpowers/specs/2026-07-05-387-phase-b-device-smoke-design.md
+++ b/docs/superpowers/specs/2026-07-05-387-phase-b-device-smoke-design.md
@@ -1,0 +1,212 @@
+# Story 06 Phase B — Nightly Device Smoke (design)
+
+**Issue:** #387 (Story 06 — Native runner tests in CI + LLM-behavior evals)
+**Story doc:** `docs/stories/06-native-runner-ci-and-evals.md` (Phase B section)
+**Date:** 2026-07-05
+**Status:** Approved (user, 2026-07-05)
+**Depends on:** Story 01 (#382) artifact pipeline — shipped in #456 but **never fired** (bug, fixed as Task 0 here)
+**Prior phase:** Phase A (native unit tests in CI) shipped in #464, merge `277bc811`
+
+## Problem
+
+Phase A executes the native runners' *unit* tests in CI, but no automated job drives
+the runners on a real device. Gesture dispatch, snapshot capture, keyboard-guard
+behavior, settle timing — the layer where the hardest bugs live (B153/B154, the
+QuickPath corruption find) — is still validated only by manual smoke sessions.
+
+Additionally, during design exploration we found that **Story 01's prebuilt-artifact
+pipeline is dead on arrival**: `release.yml` merges the Version Packages PR with
+`GITHUB_TOKEN`, and GitHub's workflow-recursion guard suppresses all workflow
+triggers for pushes made with that token. The version-bump merge commit — the only
+event `runner-artifacts.yml`'s `detect` job was designed to react to — can never
+trigger it. Four releases (0.60.x → 0.63.0) silently skipped artifact publishing;
+the committed `runner-manifest.json` is still the empty seed (`version: null`).
+Evidence: runs 28720929431…28736816834 all completed in 6–9 s (detect-only no-ops),
+and bump commits `c4b7afe8`/`462ac66f`/`8e9b844c`/`3fe5e328` have **no**
+runner-artifacts runs at all.
+
+## Decisions (approved)
+
+1. **Scope:** Phase B only. Phase C (LLM-behavior evals) stays open in #387.
+2. **Trigger bug fixed in scope** as Task 0 (not a separate session).
+3. **Fixture:** tiny **native** apps (SwiftUI + Kotlin/Views), no RN/Expo/Metro in
+   the nightly. The golden set is `device_*` (L2) verbs, which drive any app via
+   XCUITest/UIAutomator2; CDP (L1) is already covered by the TS unit suites against
+   mock Hermes. An RN-fixture CDP lane is a *named deferral* (possible Phase B2).
+4. **Runner provenance — hybrid (Approach 3):**
+   - Smoke lanes drive **main-HEAD-built runners** (cached) so bridge and runner
+     come from the same commit → a red night means a real regression, never
+     release lag. `RUNNER_COMMANDS_STALE` noise from old release bits is designed
+     behavior, not a smoke signal.
+   - A separate **artifact-integrity lane** validates the *released* bits +
+     manifest, so Story 01's product is exercised nightly without coupling the
+     smoke signal to it.
+
+## Design
+
+### Task 0 — make the artifact pipeline fire (Story 01 bug fix)
+
+Two complementary mechanisms, no new secrets (a PAT would be a new credential to
+rotate; `workflow_dispatch` is the documented exception to the `GITHUB_TOKEN`
+recursion guard):
+
+- **Dispatch-after-merge:** in `release.yml`, after the Version PR merge step
+  succeeds, fetch `origin/main`, read the bumped version from
+  `.claude-plugin/plugin.json` at `origin/main` (NOT the pre-bump checkout), and
+  `gh workflow run runner-artifacts.yml -f force_version=$V`. Building from the
+  dispatch-time main HEAD is safe: Version PRs touch only versions/changelogs,
+  never runner sources.
+- **Nightly catch-up sweep:** add a `schedule` trigger to `runner-artifacts.yml`.
+  In catch-up mode, `detect` reads main's current `plugin.json` version and treats
+  it as `changed=true` when the `v<version>` release is missing OR lacks any of
+  its three assets (`rn-fast-runner-<v>-sim.zip`, `rn-android-runner-<v>.zip`,
+  `runner-manifest.json`). This is level-triggered self-healing: it covers the
+  auto-merge race (`gh pr merge --auto` returns before the merge lands, so the
+  in-run dispatch could fire pre-merge), any future missed event, and — on its
+  **first run** — publishes artifacts for the current already-missed version with
+  no manual seed step.
+- The idempotence guard already exists (`gh release create` only if absent;
+  uploads use `--clobber`).
+- Bug logged to workspace `BUGS.md`; decision (dispatch + sweep over PAT) to
+  `DECISIONS.md`.
+
+### Fixture apps — `test-fixtures/`
+
+Contract fixtures, intentionally tiny, no backend, no JS toolchain:
+
+- `test-fixtures/ios-fixture/` — SwiftUI app, bundle id
+  `dev.lykhoyda.rndevagent.fixture`, built with `xcodebuild build` (no signing,
+  simulator SDK).
+- `test-fixtures/android-fixture/` — Kotlin, minimal Views/XML (lightest build),
+  applicationId `dev.lykhoyda.rndevagent.fixture`, built with
+  `gradle assembleDebug`.
+
+One screen each, identical element contract (identifiers are the runners'
+testID-resolution keys — `accessibilityIdentifier` on iOS, `resource-id` on
+Android; the exact Android attribute is confirmed against the runner's matcher
+during planning):
+
+| Element | Identifier | Purpose in golden set |
+|---|---|---|
+| Counter button | `fixture_button` | tap → visible label increments (observable state change for settle/no-change detection) |
+| Counter label | `fixture_count` | assert increment after `device_press` |
+| Text field | `fixture_input` | `device_fill` + native read-back verify |
+| 100-row list | `fixture_list`, rows `fixture_row_<n>` | `device_scroll`, `device_scrollintoview` |
+| Bottom-anchored field + button | `fixture_bottom_input`, `fixture_bottom_button` | keyboard genuinely occludes the button → keyboard-guard scenario |
+
+Fixture builds are cached (`actions/cache`, key = fixture-source hash + toolchain
+version).
+
+### Nightly smoke workflow — `.github/workflows/nightly-device-smoke.yml`
+
+Triggers: `schedule` (03:00 UTC) + `workflow_dispatch` (on-demand runs and the
+seeded-bug acceptance check). Permissions: `contents: read`, `issues: write`
+(alerting). Lanes run in parallel as independent jobs.
+
+- **iOS smoke** (`macos-15`, timeout ~35 min): checkout → Node 22 → `npm ci` →
+  restore runner DerivedData cache (key: hash of `scripts/rn-fast-runner/**` +
+  Xcode version); on miss `xcodebuild build-for-testing` into the client's
+  expected path (`scripts/rn-fast-runner/RnFastRunner/build/DerivedData`, the
+  warm-path location `hasBuiltTestProduct` checks) → build/restore fixture →
+  boot pinned simulator (Phase A's UDID-resolution pattern, iPhone 16 preferred)
+  → `simctl install` fixture → run golden-set driver.
+- **Android smoke** (`ubuntu-latest` + KVM, `reactivecircus/android-emulator-runner`,
+  pinned API-34 AVD, timeout ~35 min): Gradle-build runner APKs
+  (`assembleDebug` + `assembleDebugAndroidTest`, setup-gradle cache) → build
+  fixture APK → inside the emulator step: `adb install` fixture → run driver.
+- Simulator/emulator logs + screenshots uploaded as artifacts on failure.
+
+### Golden-set driver — `scripts/cdp-bridge/test/smoke/device-smoke.mjs`
+
+`node:test`, reusing `test/helpers/supervisor-harness.js`: spawn
+`dist/supervisor.js` over MCP stdio, cwd = tmp project dir, env
+`RN_RUNNER_BUILD=local` (forces `build-local` provenance in
+`runner-artifacts.ts:156` so a version-matching release can never shadow the
+fresh main-HEAD build). CDP is intentionally absent; `device_fill` exercises its
+native read-back path by design.
+
+Sequence (all assertions on the JSON envelopes; generous `meta.timings_ms`
+ceilings, e.g. snapshot < 10 s):
+
+1. `device_snapshot action=open` with explicit `appId` (the open handler requires
+   it without an `app.json`) → `ok`, runner alive.
+2. `device_snapshot` → `@ref`s present for the contract elements.
+3. `device_find` (exact testID) → found.
+4. `device_press @fixture_button` → next snapshot shows `fixture_count`
+   incremented; `meta.settle` present.
+5. `device_fill @fixture_input` → `meta.verify` read-back passes (native path).
+6. `device_scroll` + `device_scrollintoview fixture_row_80` → row present in
+   snapshot.
+7. `device_screenshot` → PNG magic bytes, non-trivial size.
+8. **Keyboard-guard scenario (platform-conditional by documented #370 contract):**
+   focus `fixture_bottom_input` (keyboard up) → `device_press
+   @fixture_bottom_button`:
+   - Android: `meta.keyboardGuard: "dismissed"`, tap lands.
+   - iOS (iPhone standard QWERTY, no dismiss control): the **designed refusal** —
+     error `KEYBOARD_OCCLUDED`, `keyboardGuard: "dismiss_failed"`.
+9. Negative case: `device_press` on a nonexistent testID → error envelope with
+   the documented code (no crash, no hang).
+10. `device_snapshot action=close` → clean.
+
+### Artifact-integrity lane (Story 01 product validation)
+
+Cheap `ubuntu-latest` job in the same nightly (~1–2 min, no simulator): read the
+committed `runner-manifest.json` → fail actionably if still the empty seed
+(post-Task-0 catch-up it must be populated) → download the named release assets →
+verify sha256 + byte counts against the manifest → traversal-safe extract →
+assert the `.xctestrun` exists in the iOS zip and both APKs in the Android zip.
+Red here means "pipeline/release broke," never "runner regressed."
+
+### Alerting + local entries
+
+- **`report` job** (`needs:` all lanes, `if: always()`): if any lane failed AND
+  the previous *scheduled* run also failed → create-or-refresh a tracking issue
+  (label `nightly-smoke-red`); on a green run, comment-and-close any open one.
+  One-off simulator flake never pages (story's 2-consecutive-red rule).
+- **Local entries** (story test plan): root `package.json` `smoke:ios` /
+  `smoke:android` run the same driver against the developer's own booted
+  simulator/emulator; the driver prints actionable instructions when the fixture
+  app is not installed.
+
+## Deliverable decomposition
+
+- **PR 1 (Task 0):** release.yml dispatch-after-merge + runner-artifacts.yml
+  catch-up sweep + workspace BUGS/DECISIONS entries. Small, independently
+  verifiable (first scheduled sweep publishes 0.63.x artifacts).
+- **PR 2:** fixtures + golden-set driver + `smoke:*` scripts +
+  `nightly-device-smoke.yml` (both lanes + integrity + alerting). Stacked on PR 1
+  only if release timing requires; otherwise independent.
+
+## Acceptance criteria
+
+- Task 0: a real release (or the catch-up sweep) publishes both runner zips +
+  manifest for the current version; `runner-manifest.json` on main is populated.
+- Smoke: both device lanes green on a real scheduled (or dispatch) run.
+- Seeded-bug check (story criterion): a `workflow_dispatch` run against a branch
+  with a deliberate tap-coordinate offset in the runner goes red in the smoke
+  lane (Phase A's mutation-check pattern).
+- Integrity lane green against the seeded current-version artifacts.
+- Nightly wall-clock ≤ 45 min (lanes parallel; worst lane ~25 min cold-cache).
+- Week-of-green: post-merge observation, explicitly NOT a merge gate for these PRs.
+
+## Out of scope
+
+- Reanimated loop screen (Story 03's fixture) and any RN/Expo fixture — deferred,
+  named slot "Phase B2 (CDP lane)".
+- Phase C (LLM-behavior evals) — remains open in #387, needs a budget decision.
+- iOS 26 lane — add when the macos runner images make it pinnable (story note).
+
+## Risks
+
+- **Simulator flake:** mitigated by nightly-not-gating, 2-consecutive-red
+  alerting, pinned runtimes, and parallel independent lanes.
+- **XCUITest keyboard variance on CI images** (hardware-keyboard settings could
+  keep the software keyboard hidden → keyboard-guard scenario degrades to
+  `no_keyboard`): the driver asserts the *envelope contract* and fails loudly if
+  the keyboard never appeared, so the scenario cannot silently pass; the plan
+  includes the known simulator setting (`simctl` connect-hardware-keyboard off)
+  to force the software keyboard.
+- **Cache-miss nights** pay one runner build (~4–6 min iOS, ~2–3 min Android) —
+  exactly the nights fresh bits are wanted anyway.
+- **Auto-merge race in Task 0:** dispatch-after-merge may fire pre-merge in the
+  `--auto` path; the catch-up sweep converges within 24 h by design.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "test": "cd scripts/cdp-bridge && npm test",
     "test:native:android": "cd scripts/rn-android-runner && ./gradlew testDebugUnitTest --no-daemon",
     "test:native:ios": "bash scripts/test-native-ios.sh",
+    "smoke:ios": "SMOKE_PLATFORM=ios node scripts/cdp-bridge/test/smoke/device-smoke.ts",
+    "smoke:android": "SMOKE_PLATFORM=android node scripts/cdp-bridge/test/smoke/device-smoke.ts",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "format": "oxfmt",

--- a/scripts/cdp-bridge/dist/fast-runner-ref-map.js
+++ b/scripts/cdp-bridge/dist/fast-runner-ref-map.js
@@ -11,8 +11,15 @@ export function updateRefMap(nodes) {
         if (!node.ref || !node.rect)
             continue;
         refMap.set(node.ref, node.rect);
-        if (!screenRect && node.rect.x === 0 && node.rect.y === 0 && node.rect.width > 300) {
-            screenRect = node.rect;
+        // Largest (0,0)-anchored rect wins: with interactive windows in the
+        // Android snapshot (#370), the status bar (0,0,w,~156) precedes the app
+        // window, and first-match sent direction gestures into the status bar
+        // (#387 Phase B device-proven).
+        if (node.rect.x === 0 && node.rect.y === 0 && node.rect.width > 300) {
+            if (!screenRect ||
+                node.rect.width * node.rect.height > screenRect.width * screenRect.height) {
+                screenRect = node.rect;
+            }
         }
     }
     lastUpdated = Date.now();

--- a/scripts/cdp-bridge/dist/runners/rn-fast-runner-client.js
+++ b/scripts/cdp-bridge/dist/runners/rn-fast-runner-client.js
@@ -518,10 +518,16 @@ export function stopFastRunner(deviceId) {
     }
     clearStateFile();
 }
-export async function fastSwipe(x1, y1, x2, y2, durationMs) {
+export async function fastSwipe(x1, y1, x2, y2, durationMs, bundleId) {
     const body = { command: 'drag', x: x1, y: y1, x2, y2 };
     if (durationMs != null)
         body.durationMs = durationMs;
+    // Without appBundleId the runner's executeOnMain clears its target and
+    // activates the RnFastRunner HOST app — the drag then lands on the host's
+    // blank screen (ok:true, zero movement) and steals foreground from the
+    // target (#387 Phase B device-proven).
+    if (bundleId)
+        body.appBundleId = bundleId;
     const resp = await postCommand(body);
     return resp;
 }

--- a/scripts/cdp-bridge/dist/tools/device-interact.js
+++ b/scripts/cdp-bridge/dist/tools/device-interact.js
@@ -893,7 +893,7 @@ export function createDeviceSwipeHandler() {
         if (args.x1 != null && args.y1 != null && args.x2 != null && args.y2 != null) {
             if (canUseFastRunner) {
                 try {
-                    const resp = await fastSwipe(args.x1, args.y1, args.x2, args.y2, args.durationMs);
+                    const resp = await fastSwipe(args.x1, args.y1, args.x2, args.y2, args.durationMs, getActiveSession()?.appId);
                     if (resp.ok) {
                         return okResult({
                             x1: args.x1,
@@ -931,7 +931,7 @@ export function createDeviceSwipeHandler() {
             const duration = args.durationMs ?? DEFAULT_SWIPE_DURATION_MS;
             if (canUseFastRunner) {
                 try {
-                    const resp = await fastSwipe(coords.x1, coords.y1, coords.x2, coords.y2, duration);
+                    const resp = await fastSwipe(coords.x1, coords.y1, coords.x2, coords.y2, duration, getActiveSession()?.appId);
                     if (resp.ok) {
                         return okResult({
                             direction: args.direction,
@@ -985,7 +985,7 @@ export function createDeviceScrollHandler() {
         adoptPersistedFastRunnerState(getActiveSession()?.deviceId);
         if (isFastRunnerAvailable()) {
             try {
-                const resp = await fastSwipe(x1, y1, x2, y2, DEFAULT_SWIPE_DURATION_MS);
+                const resp = await fastSwipe(x1, y1, x2, y2, DEFAULT_SWIPE_DURATION_MS, getActiveSession()?.appId);
                 if (resp.ok) {
                     return okResult({
                         direction: args.direction,

--- a/scripts/cdp-bridge/src/fast-runner-ref-map.ts
+++ b/scripts/cdp-bridge/src/fast-runner-ref-map.ts
@@ -70,8 +70,17 @@ export function updateRefMap(nodes: SnapshotNode[]): void {
     if (!node.ref || !node.rect) continue;
     refMap.set(node.ref, node.rect);
 
-    if (!screenRect && node.rect.x === 0 && node.rect.y === 0 && node.rect.width > 300) {
-      screenRect = node.rect;
+    // Largest (0,0)-anchored rect wins: with interactive windows in the
+    // Android snapshot (#370), the status bar (0,0,w,~156) precedes the app
+    // window, and first-match sent direction gestures into the status bar
+    // (#387 Phase B device-proven).
+    if (node.rect.x === 0 && node.rect.y === 0 && node.rect.width > 300) {
+      if (
+        !screenRect ||
+        node.rect.width * node.rect.height > screenRect.width * screenRect.height
+      ) {
+        screenRect = node.rect;
+      }
     }
   }
 

--- a/scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts
+++ b/scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts
@@ -653,9 +653,15 @@ export async function fastSwipe(
   x2: number,
   y2: number,
   durationMs?: number,
+  bundleId?: string,
 ): Promise<FastRunnerResponse> {
   const body: Record<string, unknown> = { command: 'drag', x: x1, y: y1, x2, y2 };
   if (durationMs != null) body.durationMs = durationMs;
+  // Without appBundleId the runner's executeOnMain clears its target and
+  // activates the RnFastRunner HOST app — the drag then lands on the host's
+  // blank screen (ok:true, zero movement) and steals foreground from the
+  // target (#387 Phase B device-proven).
+  if (bundleId) body.appBundleId = bundleId;
   const resp = await postCommand(body);
   return resp as unknown as FastRunnerResponse;
 }

--- a/scripts/cdp-bridge/src/tools/device-interact.ts
+++ b/scripts/cdp-bridge/src/tools/device-interact.ts
@@ -1173,7 +1173,14 @@ export function createDeviceSwipeHandler(): (args: SwipeArgs) => Promise<ToolRes
     if (args.x1 != null && args.y1 != null && args.x2 != null && args.y2 != null) {
       if (canUseFastRunner) {
         try {
-          const resp = await fastSwipe(args.x1, args.y1, args.x2, args.y2, args.durationMs);
+          const resp = await fastSwipe(
+            args.x1,
+            args.y1,
+            args.x2,
+            args.y2,
+            args.durationMs,
+            getActiveSession()?.appId,
+          );
           if (resp.ok) {
             return okResult({
               x1: args.x1,
@@ -1213,7 +1220,14 @@ export function createDeviceSwipeHandler(): (args: SwipeArgs) => Promise<ToolRes
       const duration = args.durationMs ?? DEFAULT_SWIPE_DURATION_MS;
       if (canUseFastRunner) {
         try {
-          const resp = await fastSwipe(coords.x1, coords.y1, coords.x2, coords.y2, duration);
+          const resp = await fastSwipe(
+            coords.x1,
+            coords.y1,
+            coords.x2,
+            coords.y2,
+            duration,
+            getActiveSession()?.appId,
+          );
           if (resp.ok) {
             return okResult({
               direction: args.direction,
@@ -1278,7 +1292,14 @@ export function createDeviceScrollHandler(): (args: ScrollArgs) => Promise<ToolR
     adoptPersistedFastRunnerState(getActiveSession()?.deviceId);
     if (isFastRunnerAvailable()) {
       try {
-        const resp = await fastSwipe(x1, y1, x2, y2, DEFAULT_SWIPE_DURATION_MS);
+        const resp = await fastSwipe(
+          x1,
+          y1,
+          x2,
+          y2,
+          DEFAULT_SWIPE_DURATION_MS,
+          getActiveSession()?.appId,
+        );
         if (resp.ok) {
           return okResult({
             direction: args.direction,

--- a/scripts/cdp-bridge/test/smoke/device-smoke.ts
+++ b/scripts/cdp-bridge/test/smoke/device-smoke.ts
@@ -49,13 +49,65 @@ function stopFixture() {
   // counter, so `open` would attach mid-state and the count assertions drift.
   try {
     if (PLATFORM === 'ios') {
-      execFileSync('xcrun', ['simctl', 'terminate', 'booted', APP_ID], { stdio: 'pipe' });
+      execFileSync('xcrun', ['simctl', 'terminate', 'booted', APP_ID], {
+        stdio: 'pipe',
+        timeout: 10_000,
+      });
     } else {
-      execFileSync('adb', ['shell', 'am', 'force-stop', APP_ID], { stdio: 'pipe' });
+      execFileSync('adb', ['shell', 'am', 'force-stop', APP_ID], {
+        stdio: 'pipe',
+        timeout: 10_000,
+      });
     }
   } catch {
-    // Not running — fine.
+    // Not running (or a wedged probe) — fine.
   }
+}
+
+function fixtureRunning(): boolean {
+  try {
+    if (PLATFORM === 'ios') {
+      const out = execFileSync('xcrun', ['simctl', 'spawn', 'booted', 'launchctl', 'list'], {
+        stdio: 'pipe',
+        timeout: 3_000,
+      }).toString();
+      return out.includes(`UIKitApplication:${APP_ID}`);
+    }
+    const out = execFileSync('adb', ['shell', 'pidof', APP_ID], {
+      stdio: 'pipe',
+      timeout: 3_000,
+    }).toString();
+    return out.trim().length > 0;
+  } catch {
+    // A wedged/timed-out probe reads as "not running" — the outer poll retries,
+    // then fails cleanly at its own wall-clock deadline rather than blocking.
+    return false;
+  }
+}
+
+async function launchFixture() {
+  // The driver owns the fixture lifecycle: launch it OURSELVES and open the
+  // session with attachOnly (the documented race-free path). Launch-at-open
+  // proved flaky on a loaded emulator — the bridge's `adb shell monkey` has a
+  // 10s timeout that a cold app on a busy host can exceed.
+  if (PLATFORM === 'ios') {
+    execFileSync('xcrun', ['simctl', 'launch', 'booted', APP_ID], {
+      stdio: 'pipe',
+      timeout: 20_000,
+    });
+  } else {
+    execFileSync(
+      'adb',
+      ['shell', 'monkey', '-p', APP_ID, '-c', 'android.intent.category.LAUNCHER', '1'],
+      { stdio: 'pipe', timeout: 20_000 },
+    );
+  }
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    if (fixtureRunning()) return;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`fixture ${APP_ID} did not start within 20s of launch`);
 }
 
 async function rpc(s: any, method: string, params?: unknown) {
@@ -87,6 +139,7 @@ const refFor = (snapEnvelope: any, identifier: string) =>
 test(`Phase B golden set (${PLATFORM})`, { timeout: 900_000 }, async () => {
   assertFixtureInstalled();
   stopFixture();
+  await launchFixture();
   mkdirSync(DEBUG_DIR, { recursive: true });
   const cwd = mkdtempSync(join(tmpdir(), 'rn-agent-smoke-'));
   const s = startSupervisor({ cwd, lineTimeoutMs: 600_000, env: { RN_RUNNER_BUILD: 'local' } });
@@ -111,7 +164,12 @@ test(`Phase B golden set (${PLATFORM})`, { timeout: 900_000 }, async () => {
 
     const open = record(
       'open',
-      await callTool(s, 'device_snapshot', { action: 'open', platform: PLATFORM, appId: APP_ID }),
+      await callTool(s, 'device_snapshot', {
+        action: 'open',
+        platform: PLATFORM,
+        appId: APP_ID,
+        attachOnly: true,
+      }),
     );
     assert.equal(open.envelope?.ok, true, `open failed: ${open.text.slice(0, 500)}`);
 
@@ -162,12 +220,19 @@ test(`Phase B golden set (${PLATFORM})`, { timeout: 900_000 }, async () => {
     // absent from the snapshot (device-interact.ts:1383) — row 80 is several
     // screens away (~10 rows visible per screen), so scroll until the row is
     // IN a snapshot, then let the verb finish on its supported path.
+    // Android: a full-amplitude fling (amount 1) on a loaded emulator can make
+    // the UiAutomator drag gesture exceed the runner's 10s budget; a shorter
+    // drag completes fast and still advances several rows. iOS List needs the
+    // fuller gesture to cover ground within the iteration budget.
+    const scrollAmount = PLATFORM === 'android' ? 0.5 : 1;
     let rowVisible = false;
-    for (let i = 0; i < 20 && !rowVisible; i++) {
+    for (let i = 0; i < 30 && !rowVisible; i++) {
       const scroll = record(
         `scroll-${i}`,
-        await callTool(s, 'device_scroll', { direction: 'down', amount: 1 }),
+        await callTool(s, 'device_scroll', { direction: 'down', amount: scrollAmount }),
       );
+      // Fail honestly on any scroll error, including RUNNER_TIMEOUT — a golden
+      // smoke must not mask a runner-command timeout behind a retry.
       assert.equal(scroll.envelope?.ok, true, `scroll failed: ${scroll.text.slice(0, 500)}`);
       const look = record(
         `snapshot-scroll-${i}`,
@@ -179,7 +244,7 @@ test(`Phase B golden set (${PLATFORM})`, { timeout: 900_000 }, async () => {
         ),
       );
     }
-    assert.ok(rowVisible, 'row 80 never appeared in a snapshot after 20 scrolls');
+    assert.ok(rowVisible, 'row 80 never appeared in a snapshot after 30 scrolls');
 
     const into = record(
       'scrollintoview',

--- a/scripts/cdp-bridge/test/smoke/device-smoke.ts
+++ b/scripts/cdp-bridge/test/smoke/device-smoke.ts
@@ -28,10 +28,14 @@ if (PLATFORM !== 'ios' && PLATFORM !== 'android') {
 function assertFixtureInstalled() {
   try {
     if (PLATFORM === 'ios') {
-      execFileSync('xcrun', ['simctl', 'get_app_container', 'booted', APP_ID], { stdio: 'pipe' });
+      execFileSync('xcrun', ['simctl', 'get_app_container', 'booted', APP_ID], {
+        stdio: 'pipe',
+        timeout: 10_000,
+      });
     } else {
       const out = execFileSync('adb', ['shell', 'pm', 'path', APP_ID], {
         stdio: 'pipe',
+        timeout: 10_000,
       }).toString();
       if (!out.includes('package:')) throw new Error('not installed');
     }
@@ -237,6 +241,14 @@ test(`Phase B golden set (${PLATFORM})`, { timeout: 900_000 }, async () => {
       const look = record(
         `snapshot-scroll-${i}`,
         await callTool(s, 'device_snapshot', { action: 'snapshot' }),
+      );
+      // Assert the snapshot itself succeeded — otherwise a failing snapshot
+      // would silently loop 30× and report "row 80 never appeared", hiding the
+      // real bridge/runner error.
+      assert.equal(
+        look.envelope?.ok,
+        true,
+        `snapshot during scroll failed: ${look.text.slice(0, 500)}`,
       );
       rowVisible = Boolean(
         look.envelope?.data?.nodes?.some(

--- a/scripts/cdp-bridge/test/smoke/device-smoke.ts
+++ b/scripts/cdp-bridge/test/smoke/device-smoke.ts
@@ -1,0 +1,277 @@
+// Story 06 Phase B (#387): golden device_* command set through the real
+// bridge (dist/supervisor.js over MCP stdio) against the contract fixture
+// app (test-fixtures/). SMOKE_PLATFORM=ios|android selects the lane. CDP is
+// intentionally absent — device_fill exercises its native read-back path.
+// RN_RUNNER_BUILD=local pins runner provenance to the checkout's own build.
+// Executed directly as TypeScript via Node >= 22.18 type stripping (a .mjs
+// file would fail ci.yml's check-typescript-only gate).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+// @ts-expect-error -- untyped JS test helper
+import { startSupervisor } from '../helpers/supervisor-harness.js';
+
+const PLATFORM = process.env.SMOKE_PLATFORM;
+const APP_ID = process.env.SMOKE_APP_ID ?? 'dev.lykhoyda.rndevagent.fixture';
+const DEBUG_DIR = process.env.SMOKE_DEBUG_DIR ?? join(tmpdir(), 'rn-agent-smoke-debug');
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47];
+const JPEG_MAGIC = [0xff, 0xd8, 0xff];
+
+if (PLATFORM !== 'ios' && PLATFORM !== 'android') {
+  console.error('SMOKE_PLATFORM must be "ios" or "android"');
+  process.exit(1);
+}
+
+function assertFixtureInstalled() {
+  try {
+    if (PLATFORM === 'ios') {
+      execFileSync('xcrun', ['simctl', 'get_app_container', 'booted', APP_ID], { stdio: 'pipe' });
+    } else {
+      const out = execFileSync('adb', ['shell', 'pm', 'path', APP_ID], {
+        stdio: 'pipe',
+      }).toString();
+      if (!out.includes('package:')) throw new Error('not installed');
+    }
+  } catch {
+    console.error(
+      `Fixture app ${APP_ID} is not installed on the booted ${PLATFORM} device.\n` +
+        `Build + install it first — see test-fixtures/${PLATFORM}-fixture/README.md`,
+    );
+    process.exit(1);
+  }
+}
+
+function stopFixture() {
+  // Deterministic fresh state per run: an already-running fixture keeps its
+  // counter, so `open` would attach mid-state and the count assertions drift.
+  try {
+    if (PLATFORM === 'ios') {
+      execFileSync('xcrun', ['simctl', 'terminate', 'booted', APP_ID], { stdio: 'pipe' });
+    } else {
+      execFileSync('adb', ['shell', 'am', 'force-stop', APP_ID], { stdio: 'pipe' });
+    }
+  } catch {
+    // Not running — fine.
+  }
+}
+
+async function rpc(s: any, method: string, params?: unknown) {
+  const id = s.send(method, params);
+  for (;;) {
+    const line = JSON.parse(await s.nextLine());
+    if (line.id === id) return line;
+    // Anything else (notifications, requests from the server) is skipped.
+  }
+}
+
+async function callTool(s: any, name: string, args: Record<string, unknown> = {}) {
+  const line = await rpc(s, 'tools/call', { name, arguments: args });
+  const text = line.result?.content?.[0]?.text ?? '';
+  let envelope = null;
+  try {
+    envelope = JSON.parse(text);
+  } catch {
+    // Non-JSON tool output (e.g. image content) — callers use `raw`.
+  }
+  return { raw: line, isError: Boolean(line.result?.isError), envelope, text };
+}
+
+type ToolReply = Awaited<ReturnType<typeof callTool>>;
+
+const refFor = (snapEnvelope: any, identifier: string) =>
+  snapEnvelope?.data?.nodes?.find((n: any) => n.identifier === identifier)?.ref;
+
+test(`Phase B golden set (${PLATFORM})`, { timeout: 900_000 }, async () => {
+  assertFixtureInstalled();
+  stopFixture();
+  mkdirSync(DEBUG_DIR, { recursive: true });
+  const cwd = mkdtempSync(join(tmpdir(), 'rn-agent-smoke-'));
+  const s = startSupervisor({ cwd, lineTimeoutMs: 600_000, env: { RN_RUNNER_BUILD: 'local' } });
+  const steps: Array<{ name: string; isError: boolean; envelope: unknown }> = [];
+  const record = (name: string, r: ToolReply) => {
+    steps.push({ name, isError: r.isError, envelope: r.envelope });
+    console.log(`step ${name}: ${r.isError ? 'ERROR' : ((r.envelope as any)?.ok ?? 'n/a')}`);
+    return r;
+  };
+
+  try {
+    const init = await rpc(s, 'initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'device-smoke', version: '1.0.0' },
+    });
+    assert.ok(
+      init.result,
+      `initialize must return a result: ${JSON.stringify(init).slice(0, 300)}`,
+    );
+    s.notify('notifications/initialized');
+
+    const open = record(
+      'open',
+      await callTool(s, 'device_snapshot', { action: 'open', platform: PLATFORM, appId: APP_ID }),
+    );
+    assert.equal(open.envelope?.ok, true, `open failed: ${open.text.slice(0, 500)}`);
+
+    let snap = record('snapshot', await callTool(s, 'device_snapshot', { action: 'snapshot' }));
+    assert.equal(snap.envelope?.ok, true, `snapshot failed: ${snap.text.slice(0, 500)}`);
+    for (const id of [
+      'fixture_button',
+      'fixture_count',
+      'fixture_input',
+      'fixture_bottom_button',
+    ]) {
+      assert.ok(refFor(snap.envelope, id), `snapshot missing @ref for ${id}`);
+    }
+
+    // index: 0 — SwiftUI double-exposes a Button's label (inner text element +
+    // the button itself), so exact "Increment" is a designed AMBIGUOUS_MATCH;
+    // the index short-circuit is the documented remedy and worth exercising.
+    const find = record(
+      'find',
+      await callTool(s, 'device_find', { text: 'Increment', exact: true, index: 0 }),
+    );
+    assert.equal(find.envelope?.ok, true, `find failed: ${find.text.slice(0, 500)}`);
+
+    const press = record(
+      'press',
+      await callTool(s, 'device_press', { ref: refFor(snap.envelope, 'fixture_button') }),
+    );
+    assert.equal(press.envelope?.ok, true, `press failed: ${press.text.slice(0, 500)}`);
+    assert.ok(press.envelope?.meta?.settle, 'press must report meta.settle');
+    const pressTimings = Object.values(press.envelope?.meta?.timings_ms ?? {}).filter(
+      (v) => typeof v === 'number',
+    );
+    assert.ok(
+      pressTimings.length > 0,
+      `press must report numeric meta.timings_ms (project convention): ${press.text.slice(0, 300)}`,
+    );
+    const pressTotal = pressTimings.reduce((a: number, b) => a + (b as number), 0);
+    assert.ok(pressTotal < 30_000, `press too slow: ${pressTotal}ms (ceiling 30000)`);
+
+    snap = record('snapshot-2', await callTool(s, 'device_snapshot', { action: 'snapshot' }));
+    const countNode = snap.envelope?.data?.nodes?.find(
+      (n: any) => n.identifier === 'fixture_count',
+    );
+    assert.ok(countNode, 'fixture_count missing from the post-press snapshot');
+    assert.match(countNode.label ?? '', /count: 1/, 'counter must increment after press');
+
+    // device_scrollintoview does exactly ONE blind swipe when the target is
+    // absent from the snapshot (device-interact.ts:1383) — row 80 is several
+    // screens away (~10 rows visible per screen), so scroll until the row is
+    // IN a snapshot, then let the verb finish on its supported path.
+    let rowVisible = false;
+    for (let i = 0; i < 20 && !rowVisible; i++) {
+      const scroll = record(
+        `scroll-${i}`,
+        await callTool(s, 'device_scroll', { direction: 'down', amount: 1 }),
+      );
+      assert.equal(scroll.envelope?.ok, true, `scroll failed: ${scroll.text.slice(0, 500)}`);
+      const look = record(
+        `snapshot-scroll-${i}`,
+        await callTool(s, 'device_snapshot', { action: 'snapshot' }),
+      );
+      rowVisible = Boolean(
+        look.envelope?.data?.nodes?.some(
+          (n: any) => n.label === 'row 80' || n.identifier === 'fixture_row_80',
+        ),
+      );
+    }
+    assert.ok(rowVisible, 'row 80 never appeared in a snapshot after 20 scrolls');
+
+    const into = record(
+      'scrollintoview',
+      await callTool(s, 'device_scrollintoview', { text: 'row 80' }),
+    );
+    assert.equal(into.envelope?.ok, true, `scrollintoview failed: ${into.text.slice(0, 500)}`);
+
+    const shot = record('screenshot', await callTool(s, 'device_screenshot', {}));
+    const shotPath = shot.envelope?.data?.path;
+    if (shotPath) {
+      // Default capture is JPEG (faster); PNG when a .png path is passed.
+      const head = [...readFileSync(shotPath).subarray(0, 4)];
+      const isPng = PNG_MAGIC.every((b, i) => head[i] === b);
+      const isJpeg = JPEG_MAGIC.every((b, i) => head[i] === b);
+      assert.ok(isPng || isJpeg, `screenshot file is neither PNG nor JPEG: [${head.join(',')}]`);
+    } else {
+      const img = shot.raw.result?.content?.find((c: any) => c.type === 'image');
+      assert.ok(
+        img?.data,
+        `screenshot returned neither a path nor image content: ${shot.text.slice(0, 300)}`,
+      );
+    }
+
+    snap = record('snapshot-3', await callTool(s, 'device_snapshot', { action: 'snapshot' }));
+    const fill = record(
+      'fill',
+      await callTool(s, 'device_fill', {
+        ref: refFor(snap.envelope, 'fixture_input'),
+        text: 'hello smoke',
+      }),
+    );
+    assert.equal(fill.envelope?.ok, true, `fill failed: ${fill.text.slice(0, 500)}`);
+
+    // Keyboard-guard scenario (#370 contract): the fill above left the
+    // keyboard up; the bottom bar sits under it by fixture design.
+    // FRESH snapshot first — @eN refs are positional snapshot tokens, and the
+    // keyboard's arrival rewrote the tree, so a pre-fill ref would silently
+    // bind to a different element at the same index (device-proven: it tapped
+    // a list row dead-center instead of the bottom button).
+    snap = record(
+      'snapshot-post-fill',
+      await callTool(s, 'device_snapshot', { action: 'snapshot' }),
+    );
+    const bottomRef = refFor(snap.envelope, 'fixture_bottom_button');
+    assert.ok(bottomRef, 'fixture_bottom_button missing from the post-fill snapshot');
+    const kb = record('keyboard-guard', await callTool(s, 'device_press', { ref: bottomRef }));
+    const guard = kb.envelope?.meta?.keyboardGuard;
+    if (PLATFORM === 'android') {
+      // no_keyboard = environment problem (soft IME never appeared), not a
+      // contract result — fail with the fix, don't let it masquerade.
+      assert.notEqual(
+        guard,
+        'no_keyboard',
+        'Soft keyboard never appeared — the emulator needs `adb shell settings put secure show_ime_with_hard_keyboard 1` (the nightly workflow sets it)',
+      );
+      assert.equal(kb.envelope?.ok, true, `keyboard-guard press failed: ${kb.text.slice(0, 500)}`);
+      assert.equal(guard, 'dismissed', 'Android must dismiss the keyboard first');
+    } else {
+      assert.notEqual(
+        kb.envelope?.ok,
+        true,
+        `iOS keyboard-guard scenario invalid: the tap went through (keyboardGuard=${guard}). ` +
+          'The software keyboard likely never appeared on this headless simulator — environment problem, not a contract pass.',
+      );
+      const body = kb.text;
+      assert.match(body, /KEYBOARD_OCCLUDED/, `expected KEYBOARD_OCCLUDED: ${body.slice(0, 500)}`);
+      assert.match(
+        body,
+        /dismiss_failed/,
+        `expected keyboardGuard=dismiss_failed: ${body.slice(0, 500)}`,
+      );
+    }
+
+    const neg = record(
+      'negative-find',
+      await callTool(s, 'device_find', { text: 'fixture_does_not_exist_zz', exact: true }),
+    );
+    assert.ok(
+      neg.isError || neg.envelope?.ok === false,
+      'nonexistent element must yield an error envelope',
+    );
+
+    const alive = record(
+      'snapshot-4',
+      await callTool(s, 'device_snapshot', { action: 'snapshot' }),
+    );
+    assert.equal(alive.envelope?.ok, true, 'bridge must stay healthy after the negative case');
+
+    const close = record('close', await callTool(s, 'device_snapshot', { action: 'close' }));
+    assert.equal(close.envelope?.ok, true, `close failed: ${close.text.slice(0, 500)}`);
+  } finally {
+    writeFileSync(join(DEBUG_DIR, `smoke-${PLATFORM}-steps.json`), JSON.stringify(steps, null, 2));
+    s.child.kill('SIGTERM');
+  }
+});

--- a/scripts/cdp-bridge/test/unit/story-06-fastswipe-bundleid.test.ts
+++ b/scripts/cdp-bridge/test/unit/story-06-fastswipe-bundleid.test.ts
@@ -1,0 +1,138 @@
+// Story 06 Phase B (#387): device_scroll/device_swipe dispatch through
+// fastSwipe(), whose /command body omitted appBundleId. The runner treats a
+// missing appBundleId as "no target" (executeOnMain clears currentApp), so it
+// activated its OWN host app and dragged on a blank screen — every coordinate
+// drag foreground-stole RnFastRunner and no-op'd with ok:true. Device-proven
+// on the Phase B contract fixture (rows 1-11 static across 14 "ok" scrolls).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  fastSwipe,
+  _setFastRunnerStateForTest,
+  _setFetchForTest,
+} from '../../dist/runners/rn-fast-runner-client.js';
+import {
+  createDeviceScrollHandler,
+  createDeviceSwipeHandler,
+} from '../../dist/tools/device-interact.js';
+import {
+  setActiveSessionInMemoryForTest,
+  resetActiveSessionInMemoryForTest,
+} from '../../dist/agent-device-wrapper.js';
+
+function armFakeRunner(bodies: Array<Record<string, unknown>>) {
+  _setFastRunnerStateForTest({
+    schemaVersion: 1,
+    // process.pid: isFastRunnerAvailable() liveness-probes the pid, so it must
+    // be a live process for the dispatch path to choose the fast-runner branch.
+    pid: process.pid,
+    port: 4242,
+    deviceId: 'TEST-UDID',
+    bundleId: 'dev.lykhoyda.rndevagent.fastrunner',
+    startedAt: '2026-07-06T00:00:00.000Z',
+    protocolVersion: 1,
+  } as never);
+  _setFetchForTest((async (_url: unknown, init: { body: string }) => {
+    bodies.push(JSON.parse(init.body));
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  }) as never);
+}
+
+function disarmFakeRunner() {
+  _setFetchForTest(globalThis.fetch);
+  _setFastRunnerStateForTest(null);
+}
+
+test('device_scroll dispatch carries the active session appId into the drag body', async () => {
+  const bodies: Array<Record<string, unknown>> = [];
+  armFakeRunner(bodies);
+  setActiveSessionInMemoryForTest({
+    name: 'test-session',
+    platform: 'ios',
+    deviceId: 'TEST-UDID',
+    openedAt: '2026-07-06T00:00:00.000Z',
+    appId: 'dev.lykhoyda.rndevagent.fixture',
+  });
+  try {
+    const result = await createDeviceScrollHandler()({ direction: 'down', amount: 1 });
+    const payload = JSON.parse(result.content[0].text);
+    assert.equal(
+      payload.ok,
+      true,
+      `scroll dispatch failed: ${result.content[0].text.slice(0, 300)}`,
+    );
+    const drag = bodies.find((b) => b.command === 'drag');
+    assert.ok(drag, `no drag reached the runner; bodies: ${JSON.stringify(bodies).slice(0, 300)}`);
+    assert.equal(
+      drag.appBundleId,
+      'dev.lykhoyda.rndevagent.fixture',
+      'device_scroll must forward the session appId — omitting it makes the runner activate its own host app',
+    );
+  } finally {
+    // In-memory reset only — clearActiveSession() would unlink the SHARED
+    // session file and clobber a developer's live MCP session.
+    resetActiveSessionInMemoryForTest();
+    disarmFakeRunner();
+  }
+});
+
+test('device_swipe dispatch carries the active session appId into the drag body', async () => {
+  const bodies: Array<Record<string, unknown>> = [];
+  armFakeRunner(bodies);
+  setActiveSessionInMemoryForTest({
+    name: 'test-session',
+    platform: 'ios',
+    deviceId: 'TEST-UDID',
+    openedAt: '2026-07-06T00:00:00.000Z',
+    appId: 'dev.lykhoyda.rndevagent.fixture',
+  });
+  try {
+    const result = await createDeviceSwipeHandler()({ x1: 10, y1: 400, x2: 10, y2: 100 });
+    const payload = JSON.parse(result.content[0].text);
+    assert.equal(
+      payload.ok,
+      true,
+      `swipe dispatch failed: ${result.content[0].text.slice(0, 300)}`,
+    );
+    const drag = bodies.find((b) => b.command === 'drag');
+    assert.ok(drag, `no drag reached the runner; bodies: ${JSON.stringify(bodies).slice(0, 300)}`);
+    assert.equal(
+      drag.appBundleId,
+      'dev.lykhoyda.rndevagent.fixture',
+      'device_swipe must forward the session appId — omitting it makes the runner activate its own host app',
+    );
+  } finally {
+    resetActiveSessionInMemoryForTest();
+    disarmFakeRunner();
+  }
+});
+
+test('fastSwipe sends appBundleId so the runner drags the TARGET app, not its own host', async () => {
+  const bodies: Array<Record<string, unknown>> = [];
+  armFakeRunner(bodies);
+  try {
+    await fastSwipe(10, 20, 30, 40, 250, 'dev.lykhoyda.rndevagent.fixture');
+    assert.equal(bodies.length, 1);
+    assert.equal(bodies[0].command, 'drag');
+    assert.equal(
+      bodies[0].appBundleId,
+      'dev.lykhoyda.rndevagent.fixture',
+      'drag body must carry the target appBundleId — without it the runner activates its own host app',
+    );
+  } finally {
+    disarmFakeRunner();
+  }
+});
+
+test('fastSwipe omits appBundleId when no target is provided (legacy shape preserved)', async () => {
+  const bodies: Array<Record<string, unknown>> = [];
+  armFakeRunner(bodies);
+  try {
+    await fastSwipe(10, 20, 30, 40);
+    assert.equal(bodies.length, 1);
+    assert.ok(!('appBundleId' in bodies[0]), 'no target → no appBundleId key');
+    assert.ok(!('durationMs' in bodies[0]), 'no duration → no durationMs key');
+  } finally {
+    disarmFakeRunner();
+  }
+});

--- a/scripts/cdp-bridge/test/unit/story-06-screenrect-system-windows.test.ts
+++ b/scripts/cdp-bridge/test/unit/story-06-screenrect-system-windows.test.ts
@@ -1,0 +1,30 @@
+// Story 06 Phase B (#387): with FLAG_RETRIEVE_INTERACTIVE_WINDOWS (#370),
+// Android snapshots include SYSTEM windows, and the status bar
+// (0,0,1280,156) precedes the app window in node order. updateRefMap's
+// screen-rect heuristic took the FIRST (0,0)-anchored wide node, so
+// direction-based device_scroll/device_swipe computed gestures inside the
+// status bar (device-proven: a 62px drag at y 47-109 opened the shade and
+// knocked the fixture out of the foreground). The heuristic must pick the
+// LARGEST full-bleed rect.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { updateRefMap, getScreenRect } from '../../dist/fast-runner-ref-map.js';
+
+test('screen rect: largest (0,0)-anchored rect wins over a leading status-bar window', () => {
+  updateRefMap([
+    { ref: 'e0', rect: { x: 0, y: 0, width: 1280, height: 156 } },
+    { ref: 'e1', rect: { x: 0, y: 0, width: 1280, height: 156 } },
+    { ref: 'e2', rect: { x: 0, y: 0, width: 1280, height: 2856 } },
+    { ref: 'e3', rect: { x: 24, y: 24, width: 264, height: 144 } },
+  ] as never);
+  assert.deepEqual(getScreenRect(), { x: 0, y: 0, width: 1280, height: 2856 });
+});
+
+test('screen rect: unchanged behavior when the app window comes first (iOS shape)', () => {
+  updateRefMap([
+    { ref: 'e0', rect: { x: 0, y: 0, width: 402, height: 874 } },
+    { ref: 'e1', rect: { x: 0, y: 0, width: 402, height: 874 } },
+    { ref: 'e2', rect: { x: 16, y: 134, width: 370, height: 34 } },
+  ] as never);
+  assert.deepEqual(getScreenRect(), { x: 0, y: 0, width: 402, height: 874 });
+});

--- a/scripts/rn-android-runner/app/src/main/AndroidManifest.xml
+++ b/scripts/rn-android-runner/app/src/main/AndroidManifest.xml
@@ -6,6 +6,20 @@
         Discovered live during Task 10 smoke-test (EPERM on socket bind).
     -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <!--
+        Package visibility (API 30+): foreground() resolves the app under test
+        via getLaunchIntentForPackage from THIS app's context. Without a
+        <queries> declaration the resolver returns null for any launchable app
+        ("No launch intent for package ..."), so the runner cannot re-foreground
+        a target it lost. Scoped to MAIN/LAUNCHER apps — exactly the set the
+        runner may drive (#387 Phase B device-proven).
+    -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent>
+    </queries>
     <application
         android:label="rn-dev-agent Android runner"
         android:theme="@android:style/Theme.Material.Light.NoActionBar" />

--- a/test-fixtures/android-fixture/README.md
+++ b/test-fixtures/android-fixture/README.md
@@ -1,0 +1,30 @@
+# Android contract fixture
+
+Tiny `android.widget` app (no androidx) the nightly device smoke
+(`npm run smoke:android`) drives through the real bridge — a *contract*
+fixture, not a demo app (Story 06 Phase B, #387).
+
+| Element | android:id | Golden-set role |
+|---|---|---|
+| Increment button | `fixture_button` | tap → observable state change (`textAllCaps=false` keeps the visible text "Increment" for exact `device_find`) |
+| Count label | `fixture_count` | assert increment after `device_press` |
+| Text field | `fixture_input` | `device_fill` + read-back verify |
+| 100-row list | `fixture_list` | `device_scroll` / `device_scrollintoview` — rows are matched by visible text `row <n>`; the `contentDescription = "fixture_row_<n>"` is informational (rows already carry `android:id/text1` from `simple_list_item_1`) |
+| Bottom bar field + button | `fixture_bottom_input`, `fixture_bottom_button` | keyboard-occlusion scenario (#370) |
+
+`android:windowSoftInputMode="adjustNothing"` is load-bearing: the layout does
+NOT resize when the keyboard opens, so the bottom bar stays genuinely occluded.
+
+## Build / install
+
+Reuses rn-android-runner's Gradle wrapper (no second wrapper jar in the repo):
+
+```bash
+scripts/rn-android-runner/gradlew -p test-fixtures/android-fixture :app:assembleDebug
+adb shell settings put secure show_ime_with_hard_keyboard 1
+adb install -r test-fixtures/android-fixture/app/build/outputs/apk/debug/app-debug.apk
+```
+
+The `show_ime_with_hard_keyboard` setting forces the soft IME even though
+emulators expose a hardware keyboard — without it the keyboard-guard step
+reports `no_keyboard`.

--- a/test-fixtures/android-fixture/app/build.gradle.kts
+++ b/test-fixtures/android-fixture/app/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "dev.lykhoyda.rndevagent.fixture"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "dev.lykhoyda.rndevagent.fixture"
+        minSdk = 23
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}

--- a/test-fixtures/android-fixture/app/src/main/AndroidManifest.xml
+++ b/test-fixtures/android-fixture/app/src/main/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:label="Fixture">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:windowSoftInputMode="adjustNothing">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/test-fixtures/android-fixture/app/src/main/java/dev/lykhoyda/rndevagent/fixture/MainActivity.kt
+++ b/test-fixtures/android-fixture/app/src/main/java/dev/lykhoyda/rndevagent/fixture/MainActivity.kt
@@ -1,0 +1,40 @@
+package dev.lykhoyda.rndevagent.fixture
+
+import android.app.Activity
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.ListView
+import android.widget.TextView
+
+class MainActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        val count = findViewById<TextView>(R.id.fixture_count)
+        var taps = 0
+        findViewById<View>(R.id.fixture_button).setOnClickListener {
+            taps += 1
+            count.text = "count: $taps"
+        }
+
+        val bottomCount = findViewById<TextView>(R.id.fixture_bottom_count)
+        var bottomTaps = 0
+        findViewById<View>(R.id.fixture_bottom_button).setOnClickListener {
+            bottomTaps += 1
+            bottomCount.text = "bottom taps: $bottomTaps"
+        }
+
+        val rows = (1..100).map { "row $it" }
+        val list = findViewById<ListView>(R.id.fixture_list)
+        list.adapter = object : ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, rows) {
+            override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+                val v = super.getView(position, convertView, parent)
+                v.contentDescription = "fixture_row_${position + 1}"
+                return v
+            }
+        }
+    }
+}

--- a/test-fixtures/android-fixture/app/src/main/res/layout/activity_main.xml
+++ b/test-fixtures/android-fixture/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="8dp">
+
+    <!-- textAllCaps=false: device_find exact-matches "Increment" case-sensitively;
+         the platform default would render/announce "INCREMENT". -->
+    <Button
+        android:id="@+id/fixture_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAllCaps="false"
+        android:text="Increment" />
+
+    <TextView
+        android:id="@+id/fixture_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="count: 0" />
+
+    <EditText
+        android:id="@+id/fixture_input"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="type here"
+        android:inputType="text" />
+
+    <ListView
+        android:id="@+id/fixture_list"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <EditText
+            android:id="@+id/fixture_bottom_input"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:hint="bottom"
+            android:inputType="text" />
+
+        <Button
+            android:id="@+id/fixture_bottom_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAllCaps="false"
+            android:text="Tap" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/fixture_bottom_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="bottom taps: 0" />
+</LinearLayout>

--- a/test-fixtures/android-fixture/app/src/main/res/layout/activity_main.xml
+++ b/test-fixtures/android-fixture/app/src/main/res/layout/activity_main.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- fitsSystemWindows: targetSdk 35 enforces edge-to-edge, which would put the
+     top controls UNDER the status bar (taps land on system UI, not the button).
+     IME occlusion is unaffected — windowSoftInputMode=adjustNothing governs it. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:padding="8dp">
 
     <!-- textAllCaps=false: device_find exact-matches "Increment" case-sensitively;

--- a/test-fixtures/android-fixture/build.gradle.kts
+++ b/test-fixtures/android-fixture/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.7.3" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+}

--- a/test-fixtures/android-fixture/settings.gradle.kts
+++ b/test-fixtures/android-fixture/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "RnDevAgentFixture"
+include(":app")

--- a/test-fixtures/ios-fixture/Info.plist
+++ b/test-fixtures/ios-fixture/Info.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key><string>en</string>
+  <key>CFBundleExecutable</key><string>Fixture</string>
+  <key>CFBundleIdentifier</key><string>dev.lykhoyda.rndevagent.fixture</string>
+  <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+  <key>CFBundleName</key><string>Fixture</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleShortVersionString</key><string>1.0</string>
+  <key>CFBundleVersion</key><string>1</string>
+  <key>CFBundleSupportedPlatforms</key><array><string>iPhoneSimulator</string></array>
+  <key>DTPlatformName</key><string>iphonesimulator</string>
+  <key>DTSDKName</key><string>iphonesimulator</string>
+  <key>LSRequiresIPhoneOS</key><true/>
+  <key>MinimumOSVersion</key><string>16.0</string>
+  <key>UILaunchScreen</key><dict/>
+  <key>UISupportedInterfaceOrientations</key><array><string>UIInterfaceOrientationPortrait</string></array>
+</dict>
+</plist>

--- a/test-fixtures/ios-fixture/README.md
+++ b/test-fixtures/ios-fixture/README.md
@@ -1,0 +1,24 @@
+# iOS contract fixture
+
+Tiny SwiftUI app the nightly device smoke (`npm run smoke:ios`) drives through
+the real bridge — a *contract* fixture, not a demo app (Story 06 Phase B, #387).
+Single Swift file compiled with `swiftc`; no Xcode project, no JS toolchain.
+
+| Element | accessibilityIdentifier | Golden-set role |
+|---|---|---|
+| Increment button | `fixture_button` | tap → observable state change |
+| Count label | `fixture_count` | assert increment after `device_press` |
+| Text field | `fixture_input` | `device_fill` + read-back verify |
+| 100-row list | `fixture_list`, rows `fixture_row_<n>` | `device_scroll` / `device_scrollintoview` |
+| Bottom bar field + button | `fixture_bottom_input`, `fixture_bottom_button` | keyboard-occlusion scenario (#370) |
+
+`.ignoresSafeArea(.keyboard)` is load-bearing: it disables SwiftUI's keyboard
+avoidance so the bottom bar stays genuinely occluded by the software keyboard.
+
+## Build / install / launch
+
+```bash
+bash build.sh
+xcrun simctl install booted build/Fixture.app
+xcrun simctl launch booted dev.lykhoyda.rndevagent.fixture
+```

--- a/test-fixtures/ios-fixture/Sources/FixtureApp.swift
+++ b/test-fixtures/ios-fixture/Sources/FixtureApp.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+@main
+struct FixtureApp: App {
+  var body: some Scene {
+    WindowGroup { ContentView() }
+  }
+}
+
+struct ContentView: View {
+  @State private var count = 0
+  @State private var text = ""
+  @State private var bottomText = ""
+  @State private var bottomTaps = 0
+
+  var body: some View {
+    VStack(spacing: 8) {
+      Button("Increment") { count += 1 }
+        .accessibilityIdentifier("fixture_button")
+      Text("count: \(count)")
+        .accessibilityIdentifier("fixture_count")
+      TextField("type here", text: $text)
+        .textFieldStyle(.roundedBorder)
+        .accessibilityIdentifier("fixture_input")
+        .padding(.horizontal)
+      List(1...100, id: \.self) { n in
+        Text("row \(n)")
+          .accessibilityIdentifier("fixture_row_\(n)")
+      }
+      .accessibilityIdentifier("fixture_list")
+      HStack {
+        TextField("bottom", text: $bottomText)
+          .textFieldStyle(.roundedBorder)
+          .accessibilityIdentifier("fixture_bottom_input")
+        Button("Tap") { bottomTaps += 1 }
+          .accessibilityIdentifier("fixture_bottom_button")
+      }
+      .padding(.horizontal)
+      Text("bottom taps: \(bottomTaps)")
+        .accessibilityIdentifier("fixture_bottom_count")
+    }
+    .padding(.vertical)
+    // Keyboard-guard contract fixture: keep the bottom bar UNDER the keyboard.
+    .ignoresSafeArea(.keyboard)
+  }
+}

--- a/test-fixtures/ios-fixture/build.sh
+++ b/test-fixtures/ios-fixture/build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Builds the iOS contract fixture as an unsigned simulator .app — no Xcode
+# project needed (single-file SwiftUI app compiled with swiftc).
+set -euo pipefail
+cd "$(dirname "$0")"
+ARCH="${FIXTURE_ARCH:-$(uname -m)}"
+OUT=build/Fixture.app
+rm -rf build
+mkdir -p "$OUT"
+xcrun -sdk iphonesimulator swiftc \
+  -parse-as-library -O \
+  -target "$ARCH-apple-ios16.0-simulator" \
+  Sources/FixtureApp.swift \
+  -o "$OUT/Fixture"
+cp Info.plist "$OUT/Info.plist"
+codesign --force --sign - "$OUT"
+echo "built $OUT"


### PR DESCRIPTION
## Story 06 Phase B — nightly device smoke

Drives the golden `device_*` command set through the **real bridge** (`dist/supervisor.js` over MCP stdio) against tiny **native contract fixtures** on a booted simulator/emulator, nightly and non-gating. Closes the last gap in the three-layer coverage contract: TS logic (`ci.yml`) + packaged artifact (`#432`) + **executed native device behavior** (this).

Spec: `docs/superpowers/specs/2026-07-05-387-phase-b-device-smoke-design.md` · Plan: `docs/superpowers/plans/2026-07-05-387-phase-b-device-smoke.md` (multi-LLM reviewed).

### What's here
- **`.github/workflows/nightly-device-smoke.yml`** — parallel iOS (macos-15, DerivedData cache) + Android (ubuntu KVM, `android-emulator-runner` api-34 `google_apis`) smoke lanes; a **release-artifact-integrity lane** (sha256 + bytes + traversal-safe listing + contents vs `runner-manifest.json`); a **report job** opening/closing a `nightly-smoke-red` tracking issue only on 2 consecutive red scheduled runs.
- **`test-fixtures/{ios,android}-fixture/`** — SwiftUI (`swiftc`, no Xcode project) + Kotlin `android.widget` contract apps: counter button, text field, 100-row list, keyboard-occlusion bottom bar.
- **`scripts/cdp-bridge/test/smoke/device-smoke.ts`** + root `smoke:{ios,android}` — the golden-set driver (TypeScript, run via Node type-stripping so it clears the `check-typescript-only` gate).

### Runner provenance (deliberate deviation from the plan)
Smoke lanes cache-**build the runner from the tested commit** (`RN_RUNNER_BUILD=local`) so a red night is a real regression, never release lag. The released artifacts get their **own** integrity lane — the two signals stay separate.

### Two runner bugs the smoke caught before CI
- **`fastSwipe` omitted the target `appBundleId`** → the runner activated its own `RnFastRunner` host and dragged on a blank screen (every `device_scroll`/`device_swipe` returned `ok:true` with zero movement, foreground-stealing the app under test). Fixed at all three dispatch sites, unit-tested.
- **Android screen-rect heuristic + missing package-visibility `<queries>`** → with interactive-windows snapshots (#370) the status bar preceded the app window (direction gestures computed inside the status bar), and `getLaunchIntentForPackage` returned null on API 30+ (couldn't re-foreground). Both fixed, unit-tested.

### Verification
- **iOS golden set fully green locally** (iPhone 17 / iOS 26.5, ~87s): open → snapshot refs → indexed exact find → press + counter + settle/timings → bounded scroll to row 80 → scrollintoview → screenshot magic-bytes → native-path fill → keyboard-guard **refusal** contract (#370) → negative find → close.
- **Android** verified on-device through open → snapshot → find "Increment" → press + counter increment → scroll-advances-rows (the screen-rect + queries + textAllCaps fixes all confirmed). The scroll-to-row-80 loop is gated **locally only** by a degraded nested-ARM emulator's >10s drag latency (the runner's drag is ~4s direct via curl) — CI's dedicated Android lane is the authoritative gate.
- Full bridge unit suite green (2930 cases, +3 new).

Scheduled runs begin after merge; the one-week-green + seeded-bug acceptance is post-merge observation (not a merge gate, per the spec). Phase C (LLM-behavior evals) remains open in #387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
