### PR TITLE
fix(story-06): nightly device smoke — install deps from repo root (#387)

### DIFF
--- a/.changeset/story-06-nightly-npm-ci-fix.md
+++ b/.changeset/story-06-nightly-npm-ci-fix.md
@@ -1,0 +1,5 @@
+---
+'rn-dev-agent-plugin': patch
+---
+
+Fix the nightly device-smoke workflow failing at setup: it ran `npm ci` inside `scripts/cdp-bridge`, which fights the root lockfile and triggers the root `prepare: husky` without husky installed (exit 127). Both lanes now install from the repo root (npm workspaces resolves the cdp-bridge deps) with `HUSKY=0`.

--- a/.github/workflows/nightly-device-smoke.yml
+++ b/.github/workflows/nightly-device-smoke.yml
@@ -31,8 +31,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: Install bridge deps
-        working-directory: scripts/cdp-bridge
+      - name: Install workspace deps
+        # Install from the repo root so npm workspaces resolves the cdp-bridge
+        # deps against the root lockfile (a `npm ci` inside scripts/cdp-bridge
+        # fights the root lockfile and runs the root `prepare: husky` without
+        # husky installed — ci.yml installs from root for the same reason).
+        # HUSKY=0 skips the git-hook install, which is pointless in CI.
+        env:
+          HUSKY: '0'
         run: npm ci
       - name: Xcode version for the cache key
         run: echo "XCODE_V=$(xcodebuild -version | head -1 | tr ' ' '-')" >> "$GITHUB_ENV"
@@ -102,8 +108,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: Install bridge deps
-        working-directory: scripts/cdp-bridge
+      - name: Install workspace deps
+        # Install from the repo root so npm workspaces resolves the cdp-bridge
+        # deps against the root lockfile (a `npm ci` inside scripts/cdp-bridge
+        # fights the root lockfile and runs the root `prepare: husky` without
+        # husky installed — ci.yml installs from root for the same reason).
+        # HUSKY=0 skips the git-hook install, which is pointless in CI.
+        env:
+          HUSKY: '0'
         run: npm ci
       - name: Set up Java
         uses: actions/setup-java@v4


### PR DESCRIPTION
The first real dispatch of `nightly-device-smoke.yml` (run 28781659187) failed both lanes at the **Install bridge deps** step: `npm ci` inside `scripts/cdp-bridge` fights the root lockfile and runs the root `prepare: husky` with husky absent → `npm error code 127, command sh -c husky`.

Fix: install from the repo root (npm workspaces resolves the cdp-bridge deps) with `HUSKY=0` — exactly what `ci.yml` does and documents ("npm ci inside scripts/cdp-bridge would fight the root lockfile").

The artifact-integrity lane passed on that same run, so this is purely the two smoke lanes' setup step. Re-dispatch after merge is the acceptance run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)