### PR TITLE
fix(story-06): full-amplitude scroll so Android smoke reaches row 80 (#387)

### DIFF
--- a/.changeset/story-06-android-scroll-amount.md
+++ b/.changeset/story-06-android-scroll-amount.md
@@ -1,0 +1,5 @@
+---
+'rn-dev-agent-plugin': patch
+---
+
+Nightly device-smoke Android lane: scroll the golden-set list at full amplitude (amount 1) so row 80 is reached within the 30-scroll budget. The earlier amount-0.5 guard (added for a local emulator's drag latency) fell ~5 rows short on CI, where all 30 drags run with zero RUNNER_TIMEOUT — the shorter drag bought nothing.

--- a/scripts/cdp-bridge/test/smoke/device-smoke.ts
+++ b/scripts/cdp-bridge/test/smoke/device-smoke.ts
@@ -222,13 +222,13 @@ test(`Phase B golden set (${PLATFORM})`, { timeout: 900_000 }, async () => {
 
     // device_scrollintoview does exactly ONE blind swipe when the target is
     // absent from the snapshot (device-interact.ts:1383) — row 80 is several
-    // screens away (~10 rows visible per screen), so scroll until the row is
-    // IN a snapshot, then let the verb finish on its supported path.
-    // Android: a full-amplitude fling (amount 1) on a loaded emulator can make
-    // the UiAutomator drag gesture exceed the runner's 10s budget; a shorter
-    // drag completes fast and still advances several rows. iOS List needs the
-    // fuller gesture to cover ground within the iteration budget.
-    const scrollAmount = PLATFORM === 'android' ? 0.5 : 1;
+    // screens away, so scroll until the row is IN a snapshot, then let the verb
+    // finish on its supported path. Full amplitude (amount 1) on both platforms:
+    // at SWIPE_FRACTION 0.4, amount 1 travels ~0.4*height per scroll (~5+ rows),
+    // reaching row 80 well inside the 30-iteration budget. (A brief amount-0.5
+    // Android trial fell ~5 rows short at 30 scrolls; the CI emulator runs all
+    // 30 drags with zero RUNNER_TIMEOUT, so the shorter drag bought nothing.)
+    const scrollAmount = 1;
     let rowVisible = false;
     for (let i = 0; i < 30 && !rowVisible; i++) {
       const scroll = record(


### PR DESCRIPTION
First green-path acceptance run [28782056292](https://github.com/Lykhoyda/rn-dev-agent/actions/runs/28782056292): **iOS smoke lane fully green** end-to-end (cold DerivedData build → swiftc fixture → simulator → all 10 golden steps incl. the #370 keyboard-guard refusal contract), **artifact-integrity green**. Android failed only on `row 80 never appeared after 30 scrolls` — and ran **all 30 scrolls with zero RUNNER_TIMEOUT**, confirming the local drag-latency that motivated the amount-0.5 Android guard was host degradation, not a CI constraint.

At `SWIPE_FRACTION=0.4`, amount 0.5 travels ~0.2×height/scroll (~3 rows) → 30 scrolls fell ~5 rows short. Fix: full amplitude (amount 1, ~0.4×height/scroll) on both platforms.

Diff is the smoke driver only (no product-runtime surface). Re-dispatch after merge is the Android acceptance run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)