### PR TITLE
fix(story-06): union-bbox screen rect so Android direction scroll moves the list (#387)

### DIFF
--- a/.changeset/story-06-screenrect-union-bbox.md
+++ b/.changeset/story-06-screenrect-union-bbox.md
@@ -1,0 +1,5 @@
+---
+'rn-dev-agent-plugin': patch
+---
+
+Fix direction `device_scroll`/`device_swipe` computing a no-op gesture on Android when no snapshot node spans the full window. The screen rect (used to size direction gestures) was picked as the largest `(0,0)`-anchored node; on some Android snapshots that is a ~128px top-chrome strip while the scrollable content sits below it, so scrolls dragged ~50px in the status bar and never moved the list. The screen rect is now the union bounding box of all node rects (max extent), recovering the true viewport on both platforms.

--- a/scripts/cdp-bridge/dist/fast-runner-ref-map.js
+++ b/scripts/cdp-bridge/dist/fast-runner-ref-map.js
@@ -7,21 +7,28 @@ let lastSnapshotHash = null;
 export function updateRefMap(nodes) {
     refMap.clear();
     screenRect = null;
+    // Screen rect = the union bounding box of all node rects. A (0,0)-anchored
+    // heuristic is fragile: on some Android snapshots (#387 Phase B device-proven)
+    // NO node spans the full window — the tallest (0,0) node is a ~128px top-chrome
+    // strip, so a "largest (0,0) rect" pick yields a tiny viewport and direction
+    // scrolls compute a ~50px drag in the status bar that never moves the list.
+    // The max extent across all nodes recovers the true viewport on both platforms.
+    let maxRight = 0;
+    let maxBottom = 0;
     for (const node of nodes) {
         if (!node.ref || !node.rect)
             continue;
         refMap.set(node.ref, node.rect);
-        // Largest (0,0)-anchored rect wins: with interactive windows in the
-        // Android snapshot (#370), the status bar (0,0,w,~156) precedes the app
-        // window, and first-match sent direction gestures into the status bar
-        // (#387 Phase B device-proven).
-        if (node.rect.x === 0 && node.rect.y === 0 && node.rect.width > 300) {
-            if (!screenRect ||
-                node.rect.width * node.rect.height > screenRect.width * screenRect.height) {
-                screenRect = node.rect;
-            }
+        const { x, y, width, height } = node.rect;
+        if (width > 0 && height > 0) {
+            maxRight = Math.max(maxRight, x + width);
+            maxBottom = Math.max(maxBottom, y + height);
         }
     }
+    // width > 300 keeps the same sanity floor the old heuristic used (ignore
+    // degenerate all-tiny-node snapshots rather than emit a bogus rect).
+    screenRect =
+        maxRight > 300 && maxBottom > 0 ? { x: 0, y: 0, width: maxRight, height: maxBottom } : null;
     lastUpdated = Date.now();
 }
 export function lookupRef(ref) {
@@ -113,6 +120,11 @@ export function updateRefMapFromFlat(nodes) {
     refMap.clear();
     screenRect = null;
     const hashed = [];
+    // Screen rect = union bounding box of all node rects (same rationale as
+    // updateRefMap — a (0,0)-anchored pick is fragile when no node spans the
+    // full window).
+    let maxRight = 0;
+    let maxBottom = 0;
     for (let i = 0; i < nodes.length; i++) {
         const node = nodes[i];
         if (!node.ref || !node.rect)
@@ -126,10 +138,14 @@ export function updateRefMapFromFlat(nodes) {
             meta.identifier = node.identifier;
         metadataMap.set(key, meta);
         hashed.push(node);
-        if (!screenRect && node.rect.x === 0 && node.rect.y === 0 && node.rect.width > 300) {
-            screenRect = node.rect;
+        const { x, y, width, height } = node.rect;
+        if (width > 0 && height > 0) {
+            maxRight = Math.max(maxRight, x + width);
+            maxBottom = Math.max(maxBottom, y + height);
         }
     }
+    screenRect =
+        maxRight > 300 && maxBottom > 0 ? { x: 0, y: 0, width: maxRight, height: maxBottom } : null;
     // Hash only the nodes that passed the ref/rect filter: hashSnapshotNodes
     // dereferences node.rect.* unconditionally, and a malformed entry must not
     // throw mid-update. For real runner data the filtered subset equals the full

--- a/scripts/cdp-bridge/src/fast-runner-ref-map.ts
+++ b/scripts/cdp-bridge/src/fast-runner-ref-map.ts
@@ -66,23 +66,28 @@ export function updateRefMap(nodes: SnapshotNode[]): void {
   refMap.clear();
   screenRect = null;
 
+  // Screen rect = the union bounding box of all node rects. A (0,0)-anchored
+  // heuristic is fragile: on some Android snapshots (#387 Phase B device-proven)
+  // NO node spans the full window — the tallest (0,0) node is a ~128px top-chrome
+  // strip, so a "largest (0,0) rect" pick yields a tiny viewport and direction
+  // scrolls compute a ~50px drag in the status bar that never moves the list.
+  // The max extent across all nodes recovers the true viewport on both platforms.
+  let maxRight = 0;
+  let maxBottom = 0;
   for (const node of nodes) {
     if (!node.ref || !node.rect) continue;
     refMap.set(node.ref, node.rect);
 
-    // Largest (0,0)-anchored rect wins: with interactive windows in the
-    // Android snapshot (#370), the status bar (0,0,w,~156) precedes the app
-    // window, and first-match sent direction gestures into the status bar
-    // (#387 Phase B device-proven).
-    if (node.rect.x === 0 && node.rect.y === 0 && node.rect.width > 300) {
-      if (
-        !screenRect ||
-        node.rect.width * node.rect.height > screenRect.width * screenRect.height
-      ) {
-        screenRect = node.rect;
-      }
+    const { x, y, width, height } = node.rect;
+    if (width > 0 && height > 0) {
+      maxRight = Math.max(maxRight, x + width);
+      maxBottom = Math.max(maxBottom, y + height);
     }
   }
+  // width > 300 keeps the same sanity floor the old heuristic used (ignore
+  // degenerate all-tiny-node snapshots rather than emit a bogus rect).
+  screenRect =
+    maxRight > 300 && maxBottom > 0 ? { x: 0, y: 0, width: maxRight, height: maxBottom } : null;
 
   lastUpdated = Date.now();
 }
@@ -184,6 +189,11 @@ export function updateRefMapFromFlat(nodes: FlatNode[]): void {
   screenRect = null;
 
   const hashed: FlatNode[] = [];
+  // Screen rect = union bounding box of all node rects (same rationale as
+  // updateRefMap — a (0,0)-anchored pick is fragile when no node spans the
+  // full window).
+  let maxRight = 0;
+  let maxBottom = 0;
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
     if (!node.ref || !node.rect) continue;
@@ -196,10 +206,14 @@ export function updateRefMapFromFlat(nodes: FlatNode[]): void {
     metadataMap.set(key, meta);
     hashed.push(node);
 
-    if (!screenRect && node.rect.x === 0 && node.rect.y === 0 && node.rect.width > 300) {
-      screenRect = node.rect;
+    const { x, y, width, height } = node.rect;
+    if (width > 0 && height > 0) {
+      maxRight = Math.max(maxRight, x + width);
+      maxBottom = Math.max(maxBottom, y + height);
     }
   }
+  screenRect =
+    maxRight > 300 && maxBottom > 0 ? { x: 0, y: 0, width: maxRight, height: maxBottom } : null;
 
   // Hash only the nodes that passed the ref/rect filter: hashSnapshotNodes
   // dereferences node.rect.* unconditionally, and a malformed entry must not

--- a/scripts/cdp-bridge/test/unit/story-06-screenrect-system-windows.test.ts
+++ b/scripts/cdp-bridge/test/unit/story-06-screenrect-system-windows.test.ts
@@ -1,16 +1,35 @@
-// Story 06 Phase B (#387): with FLAG_RETRIEVE_INTERACTIVE_WINDOWS (#370),
-// Android snapshots include SYSTEM windows, and the status bar
-// (0,0,1280,156) precedes the app window in node order. updateRefMap's
-// screen-rect heuristic took the FIRST (0,0)-anchored wide node, so
-// direction-based device_scroll/device_swipe computed gestures inside the
-// status bar (device-proven: a 62px drag at y 47-109 opened the shade and
-// knocked the fixture out of the foreground). The heuristic must pick the
-// LARGEST full-bleed rect.
+// Story 06 Phase B (#387): the screen rect that direction scroll/swipe compute
+// their gesture from is the UNION BOUNDING BOX of all snapshot node rects. A
+// (0,0)-anchored heuristic was fragile — device-proven on CI Android, where NO
+// node spans the full window (the tallest (0,0) node is a ~128px top-chrome
+// strip while the scrollable list sits at y=570,h=1590), so a "largest (0,0)
+// rect" pick produced a 128px-tall viewport and every direction scroll dragged
+// ~50px in the status bar, never moving the list.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { updateRefMap, getScreenRect } from '../../dist/fast-runner-ref-map.js';
 
-test('screen rect: largest (0,0)-anchored rect wins over a leading status-bar window', () => {
+test('screen rect: CI-Android shape — no full-window (0,0) node, list below the chrome', () => {
+  // Exactly the failing snapshot shape (app=0,0,1080,128; list at y=570,h=1590).
+  updateRefMap([
+    { ref: 'e0', rect: { x: 0, y: 0, width: 1080, height: 128 } },
+    { ref: 'e1', rect: { x: 0, y: 570, width: 1080, height: 1590 } },
+    { ref: 'e2', rect: { x: 16, y: 2170, width: 300, height: 60 } },
+  ] as never);
+  // Union bbox height reaches the bottom-most node (2170+60), NOT the 128 chrome.
+  assert.deepEqual(getScreenRect(), { x: 0, y: 0, width: 1080, height: 2230 });
+});
+
+test('screen rect: iOS shape — full-window Application node sets the extent', () => {
+  updateRefMap([
+    { ref: 'e0', rect: { x: 0, y: 0, width: 402, height: 874 } },
+    { ref: 'e1', rect: { x: 0, y: 0, width: 402, height: 874 } },
+    { ref: 'e2', rect: { x: 16, y: 134, width: 370, height: 34 } },
+  ] as never);
+  assert.deepEqual(getScreenRect(), { x: 0, y: 0, width: 402, height: 874 });
+});
+
+test('screen rect: a leading status-bar node does not cap the extent', () => {
   updateRefMap([
     { ref: 'e0', rect: { x: 0, y: 0, width: 1280, height: 156 } },
     { ref: 'e1', rect: { x: 0, y: 0, width: 1280, height: 156 } },
@@ -20,11 +39,7 @@ test('screen rect: largest (0,0)-anchored rect wins over a leading status-bar wi
   assert.deepEqual(getScreenRect(), { x: 0, y: 0, width: 1280, height: 2856 });
 });
 
-test('screen rect: unchanged behavior when the app window comes first (iOS shape)', () => {
-  updateRefMap([
-    { ref: 'e0', rect: { x: 0, y: 0, width: 402, height: 874 } },
-    { ref: 'e1', rect: { x: 0, y: 0, width: 402, height: 874 } },
-    { ref: 'e2', rect: { x: 16, y: 134, width: 370, height: 34 } },
-  ] as never);
-  assert.deepEqual(getScreenRect(), { x: 0, y: 0, width: 402, height: 874 });
+test('screen rect: degenerate all-tiny-node snapshot yields null (sanity floor)', () => {
+  updateRefMap([{ ref: 'e0', rect: { x: 0, y: 0, width: 40, height: 40 } }] as never);
+  assert.equal(getScreenRect(), null);
 });


### PR DESCRIPTION
Acceptance run [28782750670](https://github.com/Lykhoyda/rn-dev-agent/actions/runs/28782750670): **iOS + artifact-integrity green**, Android failed with the list stuck on rows 1-13 after 30 `amount:1` scrolls. Root cause (from the uploaded debug artifact): the scroll gesture was a **52px drag at y=38-90** because the screen rect resolved to a `1080x128` top-chrome node — on that snapshot **no node spans the full window**, so the "largest (0,0)-anchored rect" heuristic picked the chrome strip and the drag landed in the status bar.

Fix: compute the screen rect as the **union bounding box of all node rects** (`max(x+width)`, `max(y+height)`), recovering the true viewport. iOS is unchanged (its Application node already spans full-screen). Applied to both `updateRefMap` (Android flat) and `updateRefMapFromFlat` (iOS XCUITree); unit-tested against the exact CI-failing snapshot shape.

**Seeded-bug acceptance already proven** in run [28782781889](https://github.com/Lykhoyda/rn-dev-agent/actions/runs/28782781889): a deliberate +120pt tap offset rebuilt the runner (cache-miss) and turned the iOS smoke red at the counter assertion (`fixture_count` stayed `count: 0`).

Diff is the screen-rect derivation + its unit test. Re-dispatch after merge is the both-lanes-green acceptance run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)