### PR TITLE
fix(story-06): build iOS smoke runner fresh, drop flaky DerivedData cache (#387)

### DIFF
--- a/.changeset/story-06-ios-runner-fresh-build.md
+++ b/.changeset/story-06-ios-runner-fresh-build.md
@@ -1,0 +1,5 @@
+---
+'rn-dev-agent-plugin': patch
+---
+
+Nightly iOS device-smoke lane: build the rn-fast-runner fresh each run instead of restoring DerivedData from cache. A restored DerivedData drove an unreliable `test-without-building` warm launch (`RN_FAST_RUNNER_DOWN`), whereas a fresh `build-for-testing` then warm launch is the known-good path. The ~5 min build is well within the 40 min lane timeout and the nightly budget.

--- a/.github/workflows/nightly-device-smoke.yml
+++ b/.github/workflows/nightly-device-smoke.yml
@@ -4,8 +4,9 @@ name: Nightly device smoke
 # (dist/supervisor.js over MCP stdio) against the contract fixtures, plus an
 # artifact-integrity lane for the Story 01 release artifacts. Nightly and NOT
 # merge-gating by design; alerting fires only on 2 consecutive red scheduled
-# runs (report job). Smoke lanes build main-HEAD runners (cached) —
-# RUNNER_COMMANDS_STALE noise from old release bits is impossible here.
+# runs (report job). Smoke lanes build main-HEAD runners fresh (the iOS
+# DerivedData is NOT cached — a restored one drives an unreliable warm
+# launch) — RUNNER_COMMANDS_STALE noise from old release bits is impossible.
 
 on:
   schedule:
@@ -40,14 +41,6 @@ jobs:
         env:
           HUSKY: '0'
         run: npm ci
-      - name: Xcode version for the cache key
-        run: echo "XCODE_V=$(xcodebuild -version | head -1 | tr ' ' '-')" >> "$GITHUB_ENV"
-      - name: Restore runner DerivedData
-        id: dd-cache
-        uses: actions/cache@v4
-        with:
-          path: scripts/rn-fast-runner/build/DerivedData
-          key: rn-fast-runner-dd-${{ runner.os }}-${{ env.XCODE_V }}-${{ hashFiles('scripts/rn-fast-runner/**') }}
       - name: Disable simulator hardware keyboard (software keyboard must appear)
         run: defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false
       - name: Pre-boot simulator
@@ -66,8 +59,12 @@ jobs:
           xcrun simctl boot "$UDID"
           xcrun simctl bootstatus "$UDID" -b
           echo "SMOKE_UDID=$UDID" >> "$GITHUB_ENV"
-      - name: Build runner (cache miss only)
-        if: steps.dd-cache.outputs.cache-hit != 'true'
+      - name: Build runner (fresh — no DerivedData cache)
+        # No actions/cache: a RESTORED DerivedData drives an unreliable
+        # test-without-building warm launch (RN_FAST_RUNNER_DOWN,
+        # device-proven), while a fresh build-for-testing then warm launch is
+        # the known-good path. A ~5 min build per nightly is well within the
+        # 40 min lane timeout and the ≤45 min nightly budget.
         run: |
           xcodebuild build-for-testing \
             -project scripts/rn-fast-runner/RnFastRunner/RnFastRunner.xcodeproj \


### PR DESCRIPTION
Run [28784562282](https://github.com/Lykhoyda/rn-dev-agent/actions/runs/28784562282): **Android smoke lane fully green** (union-bbox scroll + platform-split keyboard-guard both work end-to-end), integrity green, and the iOS device-resolution fix landed (SMOKE_UDID resolved, no 'multiple booted'). But the iOS lane then failed `RN_FAST_RUNNER_DOWN` — a **restored DerivedData** drives an unreliable `test-without-building` warm launch. The green iOS runs were all cache-**misses** (fresh `build-for-testing` then warm launch).

Fix: drop the `actions/cache` + its Xcode-version key step; always build the runner fresh (~5 min, well within the 40 min lane timeout and ≤45 min budget). Android's Gradle cache is unaffected (that lane is green).

Diff is the iOS lane's build steps. Re-dispatch after merge is the both-lanes-green acceptance run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)