### PR TITLE
fix(story-06): reuse warm sim + env-configurable runner ready timeout (#387)

### DIFF
--- a/.changeset/story-06-ios-runner-warm-sim-timeout.md
+++ b/.changeset/story-06-ios-runner-warm-sim-timeout.md
@@ -1,0 +1,5 @@
+---
+'rn-dev-agent-plugin': patch
+---
+
+Make the rn-fast-runner warm-launch ready gate overridable via `RN_FAST_RUNNER_READY_TIMEOUT_MS` (default 30s) so a slow CI simulator that needs longer to install+launch+attach the XCUITest runner is not a false `RN_FAST_RUNNER_DOWN`. The nightly iOS device-smoke lane also now reuses the image's already-booted (warm) simulator and shuts down only extras, instead of a blanket `shutdown all` that cold-boots the target and makes the runner launch time out.

--- a/.github/workflows/nightly-device-smoke.yml
+++ b/.github/workflows/nightly-device-smoke.yml
@@ -46,17 +46,26 @@ jobs:
       - name: Pre-boot simulator
         run: |
           set -euo pipefail
-          UDID="$(xcrun simctl list devices available --json | jq -r '[.devices[] | .[] | select(.name == "iPhone 16")][0].udid // empty')"
+          # Prefer an ALREADY-BOOTED iPhone as the target. device_snapshot open
+          # refuses on >1 booted, but a blanket `shutdown all` + fresh boot
+          # cold-boots the target and the XCUITest runner launch then times out
+          # (device-proven RN_FAST_RUNNER_DOWN). Reusing the image's warm sim and
+          # only shutting down EXTRAS keeps the runner launch fast AND leaves
+          # exactly one booted.
+          UDID="$(xcrun simctl list devices booted --json | jq -r '[.devices[] | .[] | select(.name | startswith("iPhone"))][0].udid // empty')"
           if [ -z "$UDID" ]; then
-            echo "No 'iPhone 16' on this image — falling back to the first available iPhone" >&2
-            UDID="$(xcrun simctl list devices available --json | jq -r '[.devices[] | .[] | select(.name | startswith("iPhone"))][0].udid // empty')"
+            UDID="$(xcrun simctl list devices available --json | jq -r '[.devices[] | .[] | select(.name == "iPhone 16")][0].udid // empty')"
+            if [ -z "$UDID" ]; then
+              echo "No 'iPhone 16' on this image — falling back to the first available iPhone" >&2
+              UDID="$(xcrun simctl list devices available --json | jq -r '[.devices[] | .[] | select(.name | startswith("iPhone"))][0].udid // empty')"
+            fi
+            [ -n "$UDID" ]
+            xcrun simctl boot "$UDID"
           fi
-          [ -n "$UDID" ]
-          # Shut down any pre-booted simulators first: device_snapshot open
-          # resolves "the booted iOS device" and refuses on >1 booted. The
-          # macos image can auto-boot a default sim, so boot EXACTLY one.
-          xcrun simctl shutdown all || true
-          xcrun simctl boot "$UDID"
+          # Shut down every OTHER booted sim so open sees exactly one.
+          for d in $(xcrun simctl list devices booted --json | jq -r '[.devices[] | .[] | .udid] | .[]'); do
+            [ "$d" = "$UDID" ] || xcrun simctl shutdown "$d" || true
+          done
           xcrun simctl bootstatus "$UDID" -b
           echo "SMOKE_UDID=$UDID" >> "$GITHUB_ENV"
       - name: Build runner (fresh — no DerivedData cache)
@@ -79,6 +88,10 @@ jobs:
       - name: Run golden set
         env:
           SMOKE_DEBUG_DIR: ${{ runner.temp }}/smoke-debug
+          # CI simulators install+launch+attach the XCUITest runner slower than
+          # a dev machine — widen the 30s ready gate so a slow warm launch is
+          # not a false RN_FAST_RUNNER_DOWN.
+          RN_FAST_RUNNER_READY_TIMEOUT_MS: '120000'
         run: npm run smoke:ios
       - name: Collect simulator diagnostics (on failure)
         if: failure()

--- a/scripts/cdp-bridge/dist/runners/rn-fast-runner-client.js
+++ b/scripts/cdp-bridge/dist/runners/rn-fast-runner-client.js
@@ -10,7 +10,14 @@ import { RUNNER_PROTOCOL_VERSION, REQUIRED_IOS_COMMANDS, getPluginVersion, class
 import { buildRunnerQuiescenceEnv } from './quiescence.js';
 import { artifactProvenanceToState, resolveIosRunnerArtifacts } from './runner-artifacts.js';
 const DEFAULT_PORT = 22088;
-const READY_TIMEOUT_MS = 30_000;
+// Warm-launch ready gate. Overridable via RN_FAST_RUNNER_READY_TIMEOUT_MS
+// because a cold/slow CI simulator can need well over 30s to install + launch
+// + attach the XCUITest runner (device-proven on GitHub macos runners).
+export function resolveReadyTimeoutMs() {
+    const raw = Number(process.env.RN_FAST_RUNNER_READY_TIMEOUT_MS);
+    return Number.isFinite(raw) && raw > 0 ? raw : 30_000;
+}
+const READY_TIMEOUT_MS = resolveReadyTimeoutMs();
 // A cold `xcodebuild test` compiles the runner project before launching it; on a
 // fresh machine (no prebuilt .xctestrun) that can take several minutes, so the
 // ready-signal timeout is widened for the build path.

--- a/scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts
+++ b/scripts/cdp-bridge/src/runners/rn-fast-runner-client.ts
@@ -36,7 +36,14 @@ import { buildRunnerQuiescenceEnv } from './quiescence.js';
 import { artifactProvenanceToState, resolveIosRunnerArtifacts } from './runner-artifacts.js';
 
 const DEFAULT_PORT = 22088;
-const READY_TIMEOUT_MS = 30_000;
+// Warm-launch ready gate. Overridable via RN_FAST_RUNNER_READY_TIMEOUT_MS
+// because a cold/slow CI simulator can need well over 30s to install + launch
+// + attach the XCUITest runner (device-proven on GitHub macos runners).
+export function resolveReadyTimeoutMs(): number {
+  const raw = Number(process.env.RN_FAST_RUNNER_READY_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 30_000;
+}
+const READY_TIMEOUT_MS = resolveReadyTimeoutMs();
 // A cold `xcodebuild test` compiles the runner project before launching it; on a
 // fresh machine (no prebuilt .xctestrun) that can take several minutes, so the
 // ready-signal timeout is widened for the build path.

--- a/scripts/cdp-bridge/test/smoke/device-smoke.ts
+++ b/scripts/cdp-bridge/test/smoke/device-smoke.ts
@@ -175,6 +175,11 @@ test(`Phase B golden set (${PLATFORM})`, { timeout: 900_000 }, async () => {
         attachOnly: true,
       }),
     );
+    if (open.envelope?.ok !== true) {
+      // Surface the worker's stderr: the open envelope swallows the underlying
+      // runner spawn / xcodebuild error (RN_FAST_RUNNER_DOWN just says "retry").
+      console.error('--- supervisor stderr (open failure) ---\n' + s.stderrText().slice(-4000));
+    }
     assert.equal(open.envelope?.ok, true, `open failed: ${open.text.slice(0, 500)}`);
 
     let snap = record('snapshot', await callTool(s, 'device_snapshot', { action: 'snapshot' }));

--- a/scripts/cdp-bridge/test/unit/story-06-runner-ready-timeout.test.ts
+++ b/scripts/cdp-bridge/test/unit/story-06-runner-ready-timeout.test.ts
@@ -1,0 +1,32 @@
+// Story 06 Phase B (#387): the rn-fast-runner warm-launch ready gate is
+// overridable via RN_FAST_RUNNER_READY_TIMEOUT_MS so a slow CI simulator (where
+// install+launch+attach of the XCUITest runner can exceed 30s) can widen it.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveReadyTimeoutMs } from '../../dist/runners/rn-fast-runner-client.js';
+
+function withEnv(value: string | undefined, fn: () => void) {
+  const prev = process.env.RN_FAST_RUNNER_READY_TIMEOUT_MS;
+  if (value === undefined) delete process.env.RN_FAST_RUNNER_READY_TIMEOUT_MS;
+  else process.env.RN_FAST_RUNNER_READY_TIMEOUT_MS = value;
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) delete process.env.RN_FAST_RUNNER_READY_TIMEOUT_MS;
+    else process.env.RN_FAST_RUNNER_READY_TIMEOUT_MS = prev;
+  }
+}
+
+test('ready timeout defaults to 30s when the env var is unset', () => {
+  withEnv(undefined, () => assert.equal(resolveReadyTimeoutMs(), 30_000));
+});
+
+test('ready timeout honors a positive override', () => {
+  withEnv('120000', () => assert.equal(resolveReadyTimeoutMs(), 120_000));
+});
+
+test('ready timeout ignores non-numeric / non-positive values (falls back to 30s)', () => {
+  withEnv('nonsense', () => assert.equal(resolveReadyTimeoutMs(), 30_000));
+  withEnv('0', () => assert.equal(resolveReadyTimeoutMs(), 30_000));
+  withEnv('-5', () => assert.equal(resolveReadyTimeoutMs(), 30_000));
+});


### PR DESCRIPTION
iOS acceptance data across runs: **WITHOUT** `shutdown all`, iOS was green 2/3 (one flaky 'multiple booted'); **WITH** the #490 `shutdown all` it went `RN_FAST_RUNNER_DOWN` 2/2 (runs 28784562282, 28785320802). The blanket shutdown cold-boots the *target* sim, and the XCUITest runner's warm launch then exceeds the 30s ready gate (the build step succeeds; the golden set's `open` times out at ~30s).

Three fixes:
- **Pre-boot reuses the image's already-booted (warm) iPhone** and shuts down only *extras* — keeps the runner launch fast AND leaves exactly one booted (the reason `shutdown all` existed).
- **`READY_TIMEOUT_MS` is overridable** via `RN_FAST_RUNNER_READY_TIMEOUT_MS`; the iOS lane sets 120s so a slow CI warm launch isn't a false DOWN. Unit-tested.
- The smoke driver **dumps the worker stderr on open failure** (the open envelope swallows the real runner/xcodebuild error), so any future spawn failure is diagnosable from the log.

Android is green and unaffected. Re-dispatch after merge is the both-lanes-green acceptance run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)