### PR TITLE
docs: complete README overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,30 @@
 # rn-dev-agent
 
-A coding-agent plugin for Claude Code and Codex that turns an AI agent into a React Native development partner. It explores your codebase, designs architecture, implements features, then **verifies everything live on the simulator** — reading the component tree, store state, and navigation stack through Chrome DevTools Protocol.
+[![CI](https://github.com/Lykhoyda/rn-dev-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/Lykhoyda/rn-dev-agent/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-lykhoyda.github.io%2Frn--dev--agent-blue)](https://lykhoyda.github.io/rn-dev-agent/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-**74 MCP tools** · **5 agents** · **17 commands** · **1180+ tests** · **46 best-practice rules** · [Full documentation](https://lykhoyda.github.io/rn-dev-agent/)
+A coding-agent plugin for **Claude Code** and **Codex** that turns an AI agent into a React Native development partner. It explores your codebase, designs architecture, implements features — then **proves everything works live on the simulator** by reading the component tree, store state, and navigation stack through the Chrome DevTools Protocol, driving the app like a user, and recording the evidence.
+
+**78 MCP tools** · **5 agents** · **15 commands** · **8 skills** · **118 best-practice rules** · **2,976 unit tests** · [Full documentation](https://lykhoyda.github.io/rn-dev-agent/)
 
 ---
 
-## Install
+## Why this exists
 
-### Claude Code
+Coding agents are good at writing React Native code and bad at knowing whether it actually works. This plugin closes that loop:
 
-Published install:
+- **Live verification, not "trust me it works."** After implementing a feature, the agent connects to your running app via CDP, navigates to the screen, checks the component tree, exercises interactions, and confirms store state — before declaring victory.
+- **Replayable actions.** Every verified flow is saved as a parameterised Maestro action in `.rn-agent/actions/`. A 3-step wizard that took ~14 minutes as an interactive walk replays in **~4 seconds** (~210× faster). Actions self-repair when `testID`s drift.
+- **Native device control on both platforms.** In-tree XCTest (iOS) and UiAutomator (Android) runners give the agent real taps, typing, scrolling, and screenshots — with prebuilt artifacts so first use skips the multi-minute cold build.
+- **Curated best practices.** 118 indexed rules (48 React Native + 70 React/web, integrated from [Vercel's agent skills](https://github.com/vercel-labs/agent-skills)) applied during architecture and review — crash prevention, list performance, animations, state management.
+- **Watch it work.** `/rn-dev-agent:observe` serves a read-only local web UI with a live tool-call timeline, device mirror, and route/store/component-tree panels.
+
+## Quick start
+
+### 1. Install
+
+**Claude Code** (published marketplace):
 
 ```bash
 /plugin marketplace add Lykhoyda/rn-dev-agent
@@ -18,50 +32,18 @@ Published install:
 /reload-plugins
 ```
 
-Local source path:
+Local checkout: `claude --plugin-dir /path/to/rn-dev-agent` (the root `.claude-plugin/marketplace.json` resolves the plugin package from `packages/claude-plugin/`).
 
-```bash
-claude --plugin-dir /path/to/rn-dev-agent
-```
-
-Point Claude Code at the repository root. The root
-`.claude-plugin/marketplace.json` resolves the actual plugin package from
-`packages/claude-plugin/`, which owns the Claude manifest, slash commands,
-agents, skills, hooks, and MCP registration. If a tool asks for the package
-root directly, use `/path/to/rn-dev-agent/packages/claude-plugin`.
-
-### Codex
-
-Install from the marketplace (recommended):
+**Codex** (published marketplace):
 
 ```bash
 codex plugin marketplace add Lykhoyda/rn-dev-agent
 codex plugin add rn-dev-agent@rn-dev-agent
 ```
 
-The repo's `.agents/plugins/marketplace.json` resolves the Codex payload from
-`packages/codex-plugin/`, and the installed plugin is fully self-contained
-(bundled MCP runtime, native runner sources, runner manifest).
+Local checkout: register the package directory `/path/to/rn-dev-agent/packages/codex-plugin` — not the repository root. The Codex package is self-contained (bundled MCP runtime, native runner sources, runner manifest) and loads the same `cdp` MCP server from its `.mcp.json`. Codex does not load Claude Code hooks — `No plugin hooks` in the Codex plugin detail screen is expected.
 
-For a local checkout instead, register the package directory
-`/path/to/rn-dev-agent/packages/codex-plugin`.
-
-This checkout ships a Codex package in `packages/codex-plugin/` with
-`.codex-plugin/plugin.json`, `.mcp.json`, package-local shared skill adapters,
-and a bundled MCP runtime at `packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js`.
-When installing locally through Codex, select or register that package
-directory, not the repository root and not `packages/claude-plugin/`.
-
-Codex does not load Claude Code hooks. Seeing `No plugin hooks` in the Codex
-plugin detail screen is expected; Codex loads the package-local skills and the
-same `cdp` MCP server from `.mcp.json`.
-
-The core source lives in `packages/rn-dev-agent-core/`; both host packages are
-generated from `packages/shared-agent-knowledge/`.
-
-## Setup
-
-Navigate to your React Native project and run the setup check:
+### 2. Set up your project
 
 ```bash
 cd /path/to/your-rn-app
@@ -71,97 +53,129 @@ cd /path/to/your-rn-app
 /rn-dev-agent:setup
 ```
 
-This checks **10 prerequisites** and fixes what it can automatically:
+Setup checks the full toolchain and fixes what it can automatically:
 
 | Check | Required | Auto-install |
-|-------|----------|-------------|
-| Node.js >= 22.18 LTS | Yes | No |
+|-------|----------|--------------|
+| Node.js ≥ 22.18 LTS | Yes | No |
 | CDP bridge deps | Yes | Yes |
-| rn-fast-runner (iOS) | iOS targets only — ships in-tree; prebuilt artifact on releases, one-time `xcodebuild build-for-testing` fallback | No |
-| rn-android-runner (Android) | Android targets only — ships in-tree; prebuilt artifact on releases, Gradle build fallback on first use | No |
-| [maestro-runner](https://github.com/devicelab-dev/maestro-runner) | Yes | Yes |
+| rn-fast-runner (iOS) | iOS targets only | Prebuilt artifact on releases; one-time `xcodebuild build-for-testing` fallback |
+| rn-android-runner (Android) | Android targets only | Prebuilt artifact on releases; Gradle build fallback on first use |
+| [maestro-runner](https://github.com/devicelab-dev/maestro-runner) | Yes | Yes (pinned engine, checksum-verified) |
 | iOS Simulator / Android Emulator | One platform | No |
 | Metro dev server | Yes | No |
 | CDP connection | Yes | Auto via `cdp_status` |
-| ffmpeg | Optional | No |
+| ffmpeg | Optional (proof videos) | Yes |
+| idb + idb-companion | Optional (smooth observe-UI mirroring) | Yes |
 
-If auto-install fails for any dependency, the setup command gives step-by-step manual instructions. [Full setup guide](https://lykhoyda.github.io/rn-dev-agent/getting-started/)
+If auto-install fails, setup gives step-by-step manual instructions. [Full setup guide](https://lykhoyda.github.io/rn-dev-agent/getting-started/)
 
-**Prebuilt runners:** on a released version the device runners install from a verified prebuilt artifact (a SHA-256-checked local cache, then the GitHub Release asset for your exact plugin version), so the first `device_snapshot action=open` skips the multi-minute cold `xcodebuild` / Gradle build. Resolution is fail-open — offline, a checksum mismatch, or a dev/unreleased checkout transparently falls back to the on-machine build (`/rn-dev-agent:doctor` shows `prebuilt v<X> (cache/download)` vs `local-built`). Force the local build with `RN_RUNNER_BUILD=local`.
+**Prebuilt runners:** on a released version, the device runners install from a verified prebuilt artifact (SHA-256-checked local cache, then the GitHub Release asset for your exact plugin version), so the first `device_snapshot action=open` skips the cold build. Resolution is fail-open — offline, a checksum mismatch, or a dev checkout falls back transparently to the on-machine build (`/rn-dev-agent:doctor` shows which one you got). Force local builds with `RN_RUNNER_BUILD=local`.
 
-## Usage
-
-Tell your agent what to build:
+### 3. Build something
 
 ```
 /rn-dev-agent:rn-feature-dev add a shopping cart with badge, item list, and checkout flow
 ```
 
-The plugin runs an [8-phase pipeline](https://lykhoyda.github.io/rn-dev-agent/commands/rn-feature-dev/) — from understanding your codebase to verified code with proof screenshots:
+## The pipeline
+
+`/rn-feature-dev` runs an [8-phase pipeline](https://lykhoyda.github.io/rn-dev-agent/commands/rn-feature-dev/) — from understanding your codebase to verified code with proof recordings:
 
 | Phase | What happens |
-|-------|-------------|
+|-------|--------------|
 | 1. Discovery | Understand the feature, create a task plan |
 | 2. Exploration | Parallel agents map screens, store, navigation, conventions |
 | 3. Questions | Clarify edge cases, error states, data flow |
-| 4. Architecture | Design implementation with Opus-powered architect |
+| 4. Architecture | Design the implementation with the architect agent |
 | 5. Implementation | Build the feature — store, components, navigation, testIDs |
 | 5.5. Verification | **Prove it works live** — CDP health, component tree, store state, interaction, screenshot |
 | 6. Review | Parallel review agents check correctness and RN conventions |
-| 7. Proof | **Rehearse off camera**, persist a Maestro action with metadata, then record a deterministic replay — discovery never appears in the video |
+| 7. Proof | **Rehearse off camera**, persist a Maestro action, then record a deterministic replay — discovery never appears in the video |
 
-### Other commands
+## Commands
 
 **Develop & test:**
 
 | Command | Purpose |
 |---------|---------|
-| `/rn-dev-agent:test-feature <desc>` | Test an already-implemented feature; auto-replays an existing Maestro action if one matches |
-| `/rn-dev-agent:debug-screen` | Diagnose and fix a broken screen — gathers parallel evidence from CDP + native logs + component tree |
-| `/rn-dev-agent:build-and-test <desc>` | Build app (local or EAS), install on device, then test |
-| `/rn-dev-agent:proof-capture <desc>` | Rehearsal-gated video + screenshots + PR body |
-| `/rn-dev-agent:observe` | Start a read-only local web UI to **watch the agent live** — tool-call timeline, latest device screenshot, and route/store/component-tree panels. Prints a `127.0.0.1` URL to open in a browser. |
+| `/rn-dev-agent:rn-feature-dev <desc>` | Full 8-phase feature pipeline (above) |
+| `/rn-dev-agent:test-feature <desc>` | Test an already-implemented feature; auto-replays a matching saved action |
+| `/rn-dev-agent:debug-screen` | Diagnose and fix a broken screen — parallel evidence from CDP + native logs + component tree |
+| `/rn-dev-agent:build-and-test <desc>` | Build the app (local or EAS), install on device, then test |
+| `/rn-dev-agent:proof-capture <desc>` | Rehearsal-gated video + screenshots + generated PR body |
+| `/rn-dev-agent:observe` | Read-only local web UI to **watch the agent live** — tool-call timeline, device mirror, route/store/component-tree panels |
 
-**Actions: replayable app flows + the LLM/pragmatic hybrid**
+**Actions & regression:**
 
-An **action** is a saved Maestro flow the agent **emits** when `/test-feature` verification passes — not something you author. Each task is then composed of two regimes: **pragmatic reusable actions** for predictable parts (login, navigation, multi-step setup) and **LLM-driven discovery** for the part that's actually new. The agent uses actions as prologues to reach a known state before doing fresh interactive work. Measured: a 3-step wizard that took **13 min 55 s** as an interactive walk runs in **~4 s** when replayed — ~210× faster.
-
-| | |
-|---|---|
-| **What** | A saved, parameterised flow with a metadata header and `${KEY}` placeholders. |
-| **Where** | `.rn-agent/actions/<name>.yaml`. The plugin's home in your project is `.rn-agent/`. |
-| **Create one** | Run `/rn-dev-agent:test-feature <description>`. The verified walk is saved as an action. |
-| **Run one** | List with `/rn-dev-agent:list-learned-actions`; replay with `/rn-dev-agent:run-action <name>`. The agent also picks an action automatically when it needs to reach a known state. |
-| **Self-repair** | If a `testID` changes, `cdp_repair_action` fuzzy-matches against the live snapshot, patches the YAML, and retries. Small UI drift absorbed; broken product logic surfaced, not auto-fixed. |
-| **Why hybrid** | Pure scripts don't adapt; pure LLM re-derives everything every session. Actions are the memory of the LLM loop — every successful verification adds one, every drift gets quietly absorbed, every truly broken flow escalates. |
-
-[Full actions guide — why the hybrid matters, tool surface, comparison vs Detox/Maestro/pure-LLM](https://lykhoyda.github.io/rn-dev-agent/actions/)
+| Command | Purpose |
+|---------|---------|
+| `/rn-dev-agent:list-learned-actions` | List persisted actions, flows, and feedback memories |
+| `/rn-dev-agent:run-action <name>` | Replay a saved action with auto-repair and structured run records |
+| `/rn-dev-agent:lock-e2e <name>` | Promote a verified action into a **frozen, locked e2e regression test** (strict no-repair run required) |
 
 **Setup & diagnostics:**
 
 | Command | Purpose |
 |---------|---------|
-| `/rn-dev-agent:setup` | Inject CLAUDE.md tool-routing rules + nav-ref + Zustand exposure |
-| `/rn-dev-agent:doctor` | 15-row diagnostic table — Node, CDP, rn-fast-runner (iOS), rn-android-runner (Android), maestro-runner, simulators, Metro, helpers freshness, plugin version, CDP auto-reconnect mode |
+| `/rn-dev-agent:setup` | Onboard a project — prerequisites + CLAUDE.md tool-routing rules + nav-ref + Zustand exposure (refreshes stale template blocks in place) |
+| `/rn-dev-agent:doctor` | Full diagnostic table — Node, CDP, device runners, maestro-runner engine pin, simulators, Metro, helpers freshness, plugin version |
 | `/rn-dev-agent:check-env` | Quick environment-readiness check |
 | `/rn-dev-agent:nav-graph` | Extract and inspect the app navigation graph |
+| `/rn-dev-agent:check-vercel-rules` | Report drift between bundled best-practice rules and upstream |
 | `/rn-dev-agent:send-feedback` | Open a GitHub issue with sanitized environment context |
 
-Repo-local troubleshooting memory: the agent maintains a gitignored `.rn-agent/local/troubleshooting.md` per project (auto-captured failures + config notes), read at session start and updated at session end.
+The plugin also keeps a gitignored per-project troubleshooting memory (`.rn-agent/local/troubleshooting.md`) — auto-captured failures and config notes, read at session start.
 
-## What makes this different
+## Actions: replayable flows + the LLM/pragmatic hybrid
 
-**Live verification** — After implementing a feature, Claude connects to your running app via CDP, navigates to the screen, checks the component tree, exercises interactions, and confirms store state. No "trust me it works."
+An **action** is a saved Maestro flow the agent **emits** when verification passes — not something you author. Each task then splits into two regimes: **pragmatic reusable actions** for the predictable parts (login, navigation, multi-step setup) and **LLM-driven discovery** for the part that's actually new. Actions serve as prologues to reach a known state before fresh interactive work.
 
-**46 best-practice rules** — Integrated from [Vercel's React Native skills](https://github.com/vercel-labs/agent-skills), covering crash prevention, list performance, animations, and state management. Applied during architecture and review. [Browse rules](https://lykhoyda.github.io/rn-dev-agent/best-practices/)
+| | |
+|---|---|
+| **What** | A saved, parameterised flow with a metadata header and `${KEY}` placeholders |
+| **Where** | `.rn-agent/actions/<name>.yaml` — the plugin's home in your project is `.rn-agent/` |
+| **Create one** | Run `/rn-dev-agent:test-feature <description>`; the verified walk is saved automatically |
+| **Run one** | `/rn-dev-agent:run-action <name>` — the agent also picks actions automatically when it needs a known state |
+| **Self-repair** | If a `testID` changes, `cdp_repair_action` fuzzy-matches against the live snapshot, patches the YAML, and retries. Small UI drift is absorbed; broken product logic is surfaced, never auto-fixed |
+| **Lock it in** | `/rn-dev-agent:lock-e2e` freezes a passing action into `.rn-agent/e2e/` — locked tests run strict (no repair) via `cdp_run_e2e_suite` |
+| **Why hybrid** | Pure scripts don't adapt; pure LLM re-derives everything every session. Actions are the memory of the LLM loop — every successful verification adds one, every drift gets quietly absorbed, every truly broken flow escalates |
 
-**5 specialized agents** — [tester](https://lykhoyda.github.io/rn-dev-agent/agents/rn-tester/), [debugger](https://lykhoyda.github.io/rn-dev-agent/agents/rn-debugger/), [code explorer](https://lykhoyda.github.io/rn-dev-agent/agents/rn-code-explorer/), [architect](https://lykhoyda.github.io/rn-dev-agent/agents/rn-code-architect/), [reviewer](https://lykhoyda.github.io/rn-dev-agent/agents/rn-code-reviewer/). Each runs a focused protocol for its domain.
+[Full actions guide — why the hybrid matters, tool surface, comparison vs Detox/Maestro/pure-LLM](https://lykhoyda.github.io/rn-dev-agent/actions/)
+
+## MCP tools
+
+The plugin exposes **78 MCP tools** across five families ([full reference](https://lykhoyda.github.io/rn-dev-agent/tools/)):
+
+| Family | What it's for | Examples |
+|---|---|---|
+| **CDP** | React internals via Chrome DevTools Protocol | `cdp_status`, `cdp_component_tree`, `cdp_store_state`, `cdp_evaluate`, `cdp_native_errors`, `cdp_navigate`, `collect_logs` |
+| **Device** | Native interaction with the simulator/emulator | `device_find`, `device_press`, `device_fill`, `device_screenshot`, `device_pick_date`, `device_batch` |
+| **Actions** | Record / replay / self-repair persistent flows | `cdp_run_action`, `cdp_repair_action`, `cdp_record_test_save_as_action`, `cdp_lock_e2e_test`, `cdp_run_e2e_suite` |
+| **Testing** | E2E replay and PR-ready proof | `proof_step`, `cross_platform_verify`, `maestro_run`, `maestro_test_all`, `cdp_auto_login` |
+| **Macro-Asserts** | State-assertive replays — internal state, not pixels | `expect_redux`, `expect_route`, `expect_visible_by_testid`, `expect_text` |
+
+The committed tool surface is asserted in CI against a golden registry (`packages/rn-dev-agent-core/test/fixtures/tool-registry.json`), so this count can't silently drift.
+
+**Reliability features baked into the tool layer:**
+
+- **Self-healing taps** — a stale `@ref` is re-bound by identity (testID/label/role, unique match only), and a tap whose settle hash shows no UI change is re-tapped exactly once. Opt out with `RN_SELF_HEAL=0`.
+- **Quiescence bypass (iOS)** — XCTest's private idle-wait is disabled by default so apps with Reanimated/looping animations can't hang queries (the same WebDriverAgent-lineage technique Maestro uses). Opt out with `RN_QUIESCENCE_BYPASS=0`.
+- **Engine pinning** — maestro-runner installs a tested pin, checksum-verified fail-closed; `/doctor` and `cdp_status` report drift.
+- **Degraded-runtime detection** — when taps succeed but the app doesn't respond, results carry a "simulator likely wedged, reboot it" hint instead of a misleading "element not found."
+
+## Specialized agents
+
+Five agents, each running a focused protocol: [tester](https://lykhoyda.github.io/rn-dev-agent/agents/rn-tester/), [debugger](https://lykhoyda.github.io/rn-dev-agent/agents/rn-debugger/), [code explorer](https://lykhoyda.github.io/rn-dev-agent/agents/rn-code-explorer/), [architect](https://lykhoyda.github.io/rn-dev-agent/agents/rn-code-architect/), [reviewer](https://lykhoyda.github.io/rn-dev-agent/agents/rn-code-reviewer/).
+
+> **Note:** `rn-tester` and `rn-debugger` need MCP tools, which don't propagate to spawned subagents — use `/rn-dev-agent:test-feature` and `/rn-dev-agent:debug-screen`, which run the protocols inline (GH #31).
 
 ## App setup
 
 **Most apps need zero setup** — the plugin reads the React fiber tree directly via Metro's CDP endpoint.
 
 **Zustand stores** — one line in your app entry ([details](https://lykhoyda.github.io/rn-dev-agent/getting-started/#zustand-stores-one-line)):
+
 ```typescript
 if (__DEV__) {
   global.__ZUSTAND_STORES__ = { auth: useAuthStore, cart: useCartStore };
@@ -171,53 +185,31 @@ if (__DEV__) {
 **Redux** — auto-detected, no setup needed.
 
 **testIDs** — add to interactive elements for reliable queries:
+
 ```tsx
 <Pressable testID="checkout-button" onPress={handleCheckout}>
   <Text testID="cart-badge">{itemCount}</Text>
 </Pressable>
 ```
 
-## MCP Tools
-
-The plugin exposes **74 MCP tools** across five families. See the [tools reference](https://lykhoyda.github.io/rn-dev-agent/tools/) for the full list.
-
-| Family | What it's for | Examples |
-|---|---|---|
-| **CDP** | React internals via Chrome DevTools Protocol | `cdp_status`, `cdp_component_tree`, `cdp_store_state`, `cdp_evaluate`, `cdp_native_errors`, `cdp_navigate`, `collect_logs` |
-| **Device** | Native interaction with the simulator/emulator | `device_find`, `device_press`, `device_fill`, `device_screenshot`, `device_pick_date`, `device_batch` |
-| **Actions** | Record / replay / self-repair persistent flows ([guide](https://lykhoyda.github.io/rn-dev-agent/actions/)) | `cdp_run_action`, `cdp_repair_action`, `cdp_record_test_save_as_action`, `cdp_record_test_*` |
-| **Testing** | E2E replay and PR-ready proof | `proof_step`, `cross_platform_verify`, `maestro_run`, `maestro_test_all`, `cdp_auto_login` |
-| **Macro-Asserts** | State-assertive replays — internal state, not pixels | `expect_redux`, `expect_route`, `expect_visible_by_testid`, `expect_text` |
-
-### What's new in v0.44.18 (2026-05-05)
-
-- **Self-healing actions** — new `cdp_repair_action` patches a stale `testID` via fuzzy match against the live snapshot when `/run-action` fails with `SELECTOR_NOT_FOUND`. Guardrails: refuses on human edits (mtime check), refuses past 3 repairs in 24h, refuses on snapshot infrastructure failure.
-- **Auto-repair-aware action replay** — new `cdp_run_action` orchestrates `maestro_run` + parser + `cdp_repair_action` + retry, then persists a `RunRecord` with structured `autoRepair` telemetry (passed / failed / refused / skipped, plus phase-level timing for MTTR analysis).
-- **Auto-emission of recorded walks** — new `cdp_record_test_save_as_action` turns a recorded walk into a first-class `.rn-agent/actions/<id>.yaml` with a full metadata header and initialised sidecar. Auto-promotes to `status: active` on first clean replay.
-- **Macro-Asserts** — `expect_redux`, `expect_route`, `expect_visible_by_testid`, `expect_text` for state-assertive replays. Maestro asserts pixels; these assert internal state. Differentiated capability over Maestro Cloud / KaneAI / BrowserStack.
-- **testID-keyed `device_batch`** — re-resolves via fresh fiber-tree snapshot per call, immune to stale-ref-across-step-transitions failures.
-- **Three-layer architecture** — Workflow (rn-feature-dev) / Discovery (CDP + device tools) / Reproducible Actions is the canonical mental model. See [architecture](https://lykhoyda.github.io/rn-dev-agent/architecture/).
-- **Atomic YAML+sidecar pair-write** — sidecar-first ordering with future-mtime buffer guarantees no false-positive "external edit" alarms even on partial-write failures (D1101 / issue #101).
-- **CAS read-modify-write protection** — `saveActionWithCAS` detects concurrent writer races on the same actionId and retries, so RunRecord history doesn't lose entries under heavy parallel runs (issue #117).
-- **1180+ unit tests** in cdp-bridge (was 994 in v0.44.5, 249 in v0.23.0).
-
 ## Architecture
 
 ```
-Claude Code
+Claude Code / Codex
   ├── Skills (knowledge) + Agents (protocols) + Commands (entry points)
   │
   ├── MCP Server (CDP Bridge) ─── WebSocket → Metro → Hermes CDP
-  │   74 tools: component tree, store state, profiling, network, interaction, recording, self-healing
+  │   78 tools: component tree, store state, profiling, network,
+  │   interaction, recording, self-healing replay
   │
   └── Device interaction
-      ├── iOS    → in-tree rn-fast-runner (XCTest /command HTTP)  ← D1219, PR #164
+      ├── iOS    → in-tree rn-fast-runner (XCTest /command HTTP)
       └── Android → in-tree rn-android-runner (UiAutomator instrumentation)
           │                         │
      iOS Simulator           Android Emulator
 
       Device lifecycle (boot / install / launch): xcrun simctl + adb
-      E2E test execution: maestro-runner (preferred) / Maestro (fallback)
+      E2E test execution: maestro-runner (pinned) / Maestro (fallback)
 ```
 
 [Architecture details](https://lykhoyda.github.io/rn-dev-agent/architecture/)
@@ -228,10 +220,10 @@ Claude Code
 
 | Complexity | Time | Crashes | Manual interventions |
 |-----------|------|---------|---------------------|
-| Simple (search, toggle, store) | 3-5 min | 0 | 0 |
-| Medium (forms, charts, lists) | 5-10 min | 0 | 0 |
-| Complex (3-step wizard, onboarding) | 11-25 min | 0 | 0 |
-| Glass UI (BlurView, Reanimated, haptics) | 27-90 min | 0 | 1 (Metro restart) |
+| Simple (search, toggle, store) | 3–5 min | 0 | 0 |
+| Medium (forms, charts, lists) | 5–10 min | 0 | 0 |
+| Complex (3-step wizard, onboarding) | 11–25 min | 0 | 0 |
+| Glass UI (BlurView, Reanimated, haptics) | 27–90 min | 0 | 1 (Metro restart) |
 
 **Libraries tested:** react-hook-form, zod, @tanstack/react-query, @gorhom/bottom-sheet, @shopify/flash-list, zustand, react-native-svg, expo-notifications, react-native-reanimated, react-native-gesture-handler, expo-haptics, expo-blur
 
@@ -240,34 +232,41 @@ Claude Code
 | Problem | Solution |
 |---------|----------|
 | "Metro not found" | Start Metro: `npx expo start` or `npx react-native start` |
-| "No Hermes target" | Open the app on simulator, ensure Hermes is enabled |
+| "No Hermes target" | Open the app on the simulator, ensure Hermes is enabled |
 | CDP rejected (1006) | Close React Native DevTools, Flipper, or Chrome DevTools |
 | Zustand store error | Add `global.__ZUSTAND_STORES__` ([setup](https://lykhoyda.github.io/rn-dev-agent/getting-started/#zustand-stores-one-line)) |
 | Plugin not detected | `/plugin install rn-dev-agent@rn-dev-agent` then `/reload-plugins` |
 | Tools fail after upgrade | Restart Claude Code ([why](https://lykhoyda.github.io/rn-dev-agent/troubleshooting/)) |
-| Spawned subagent says "MCP tools unavailable" | Never spawn `rn-tester` / `rn-debugger` via Task tool — MCP stdio doesn't propagate to subprocesses (GH #31). Use `/rn-dev-agent:test-feature` or `/rn-dev-agent:debug-screen` instead; protocols run inline in the parent session. |
-| Blank white screen after many reloads | NativeWind stylesheet corruption after 5+ `cdp_reload` cycles. Kill Metro, restart it, relaunch the app. `cdp_status` warns when reload count is high. |
-| `device_scroll` times out on Reanimated screens | A `waitForIdle` round-trip can deadlock against Reanimated worklets. Scroll routes through the in-tree runner's HID synthesis instead. Ensure the runner is healthy via the device session (iOS: `rn-fast-runner`, Android: `rn-android-runner`). |
-| Legacy `AgentDeviceRunner` re-appears on iOS sim | Stale `~/.agent-device/daemon.json` respawns the upstream runner alongside our in-tree `rn-fast-runner`. Since #202 the plugin terminates stale `AgentDeviceRunner` processes at session-open by default (scoped to the target simulator UDID) and clears orphaned `~/.agent-device/daemon.{json,lock}`, so this self-heals. Opt out with `RN_DEVICE_KILL_LEGACY=0`; to clean up manually: `pkill -f AgentDeviceRunner && rm -f ~/.agent-device/daemon.{json,lock}`. |
-| iOS `device_*` calls fail with "rn-fast-runner did not become ready" | The runner self-build may have timed out or failed. In a source checkout, pre-build once: `cd packages/rn-fast-runner/RnFastRunner && xcodebuild build-for-testing -project RnFastRunner.xcodeproj -scheme RnFastRunner -destination "platform=iOS Simulator,id=<UDID>" -derivedDataPath ../build/DerivedData`. After that, the runner spawns lazily on `device_snapshot action=open`. |
-| iOS `device_fill` returns "main thread execution timed out" but text appears in the field | Known XCTest-internal quiescence behavior; the TS client treats this specific error as success on `.type` (`meta.runnerTimeoutShim: true`). The side-effect succeeded — proceed. |
-| Want XCTest's stock idle-waits back / suspect mid-animation snapshots | Since #384 the iOS runner makes XCTest's private quiescence wait a no-op (default ON) so React Native apps with Reanimated/looping animations can't hang queries — the same WebDriverAgent-lineage bypass Maestro uses. Opt out with `RN_QUIESCENCE_BYPASS=0` (read when the runner spawns — an already-running runner keeps its old state and survives session reopen by design, so kill it first: `pkill -f RnFastRunnerUITests`, then reopen the device session and confirm via `cdp_status` → `deviceSession.runnerCapabilities`). Audit: first `device_*` result after boot carries `meta.quiescenceBypass`, and `cdp_status` → `deviceSession.runnerCapabilities` lists `QUIESCENCE_BYPASS` while active. If the runner logs `RN_FAST_RUNNER_QUIESCENCE_UNAVAILABLE`, Apple renamed the private selector on your Xcode — everything still works, just without the bypass; please file an issue. |
-| Taps on stale @refs succeed now instead of STALE_REF / seeing `meta.reResolved` or `meta.tapRetried` | Story 05 (#386) self-healing taps: a stale `@ref` is re-bound by identity (testID/label/role, unique match only — ambiguity still returns `STALE_REF`, now with a `candidates` list) and a tap whose settle hash shows no UI change is re-tapped exactly once (`meta.tapRetried`), then reported as `meta.noUiChange: true`. 3 consecutive no-change taps on distinct targets add a wedged-runtime `meta.hint` (see spec 2026-06-14-263). Opt out per call with `retryIfNoChange: false` (device_press/device_longpress) or globally with `RN_SELF_HEAL=0` (disables both re-resolution and re-tap). Change detection costs one extra snapshot probe per tap on the fast settle tiers; non-tap verbs are unaffected. |
+| Subagent says "MCP tools unavailable" | Never spawn `rn-tester`/`rn-debugger` via the Task tool — use `/rn-dev-agent:test-feature` or `/rn-dev-agent:debug-screen` instead (GH #31) |
+| Blank white screen after many reloads | NativeWind stylesheet corruption after 5+ `cdp_reload` cycles — kill and restart Metro, relaunch the app |
+
+<details>
+<summary><strong>Advanced: device-runner issues</strong></summary>
+
+| Problem | Solution |
+|---------|----------|
+| `device_scroll` times out on Reanimated screens | A `waitForIdle` round-trip can deadlock against Reanimated worklets; scroll routes through the in-tree runner's HID synthesis instead. Ensure the runner is healthy via the device session |
+| Legacy `AgentDeviceRunner` re-appears on iOS | Stale `~/.agent-device/daemon.json` respawns the upstream runner. The plugin terminates stale processes at session-open (opt out: `RN_DEVICE_KILL_LEGACY=0`); manual cleanup: `pkill -f AgentDeviceRunner && rm -f ~/.agent-device/daemon.{json,lock}` |
+| iOS "rn-fast-runner did not become ready" | The runner self-build timed out or failed. In a source checkout, pre-build once: `cd packages/rn-fast-runner/RnFastRunner && xcodebuild build-for-testing -project RnFastRunner.xcodeproj -scheme RnFastRunner -destination "platform=iOS Simulator,id=<UDID>" -derivedDataPath ../build/DerivedData` |
+| `device_fill` reports "main thread execution timed out" but the text appeared | Known XCTest-internal quiescence behavior; the client treats this specific error as success on `.type` (`meta.runnerTimeoutShim: true`). Proceed |
+| Want XCTest's stock idle-waits back | Kill the running runner (`pkill -f RnFastRunnerUITests`), set `RN_QUIESCENCE_BYPASS=0`, reopen the device session. Audit via `cdp_status` → `deviceSession.runnerCapabilities` |
+| Seeing `meta.reResolved` / `meta.tapRetried` | Self-healing taps at work (Story 05, #386). Disable per call with `retryIfNoChange: false` or globally with `RN_SELF_HEAL=0` |
+
+</details>
 
 [Full troubleshooting guide](https://lykhoyda.github.io/rn-dev-agent/troubleshooting/)
 
 ## Security
 
-The `cdp_evaluate` tool runs arbitrary JavaScript in your app's Hermes runtime with full access to component tree, store state, AsyncStorage, and any in-memory secrets. This is **intentional** — runtime introspection is what makes the plugin useful for debugging — but it means **only run this plugin against apps where you trust the agent's prompts**.
+The `cdp_evaluate` tool runs arbitrary JavaScript in your app's Hermes runtime with full access to the component tree, store state, AsyncStorage, and any in-memory secrets. This is **intentional** — runtime introspection is what makes the plugin useful — but it means **only run this plugin against apps where you trust the agent's prompts**.
 
-Recommended usage:
 - **Local dev environments only.** Do not point the plugin at production builds, store-signed apps, or any app holding real user data.
-- **Treat the agent like a developer with shell access to your laptop.** Any prompt that reaches `cdp_evaluate` (directly or through another tool that calls it) can read or mutate your app's runtime state.
-- **Don't connect to CDP targets you didn't intentionally launch.** The plugin filters Metro endpoints to `127.0.0.1` / `localhost`, but if you're running multiple Hermes targets on your machine, double-check `cdp_targets` before relying on tool output.
+- **Treat the agent like a developer with shell access to your laptop.** Any prompt that reaches `cdp_evaluate` (directly or through another tool) can read or mutate your app's runtime state.
+- **Don't connect to CDP targets you didn't intentionally launch.** The plugin filters Metro endpoints to `127.0.0.1`/`localhost`, but if multiple Hermes targets are running, double-check `cdp_targets`.
 
-The plugin makes no attempt to sandbox `cdp_evaluate` calls. If you need that, gate the agent's tool access through Claude Code's permission prompts rather than trusting the tool layer to enforce safety.
+The plugin makes no attempt to sandbox `cdp_evaluate`. If you need that, gate tool access through your agent's permission prompts rather than trusting the tool layer.
 
-The **observability UI** (`/rn-dev-agent:observe`) is opt-in and read-only: it binds to `127.0.0.1` on a random port, rejects cross-origin requests via Host-header + `Sec-Fetch-Site` checks, and serves no mutation endpoints. Tool arguments and payloads are deep-redacted (fail-closed — an unredactable value is dropped, not leaked) before they ever reach the stream, so tokens, passwords, and PII render as `[REDACTED_*]`. The recorder keeps only a small bounded in-memory ring buffer (recent events, never written to disk); nothing is exposed until you explicitly start the server.
+The **observability UI** (`/rn-dev-agent:observe`) is opt-in and read-only: it binds to `127.0.0.1` on a random port, rejects cross-origin requests via Host-header + `Sec-Fetch-Site` checks, and serves no mutation endpoints. Tool arguments are deep-redacted fail-closed before reaching the stream (tokens, passwords, and PII render as `[REDACTED_*]`), and the recorder keeps only a small bounded in-memory ring buffer — nothing touches disk, and nothing is exposed until you start the server.
 
 ## Keeping up to date
 
@@ -278,21 +277,39 @@ Enable auto-update in the plugin manager (Marketplaces tab), or update manually:
 /reload-plugins
 ```
 
+Release notes: [GitHub Releases](https://github.com/Lykhoyda/rn-dev-agent/releases) · [core changelog](packages/rn-dev-agent-core/CHANGELOG.md)
+
 ## Development
+
+This is a Yarn workspace monorepo:
+
+| Package | What it is |
+|---------|------------|
+| `packages/rn-dev-agent-core` | The MCP server (CDP bridge, device control, actions, testing) — all TypeScript source and tests |
+| `packages/claude-plugin` | Claude Code plugin package — manifest, commands, agents, skills, hooks, MCP registration |
+| `packages/codex-plugin` | Codex plugin package — self-contained with bundled runtime |
+| `packages/shared-agent-knowledge` | Source of truth both host packages are generated from |
+| `packages/rn-fast-runner` | In-tree iOS XCTest device runner |
+| `packages/rn-android-runner` | In-tree Android UiAutomator device runner |
+| `apps/docs-site` | Astro Starlight docs → [lykhoyda.github.io/rn-dev-agent](https://lykhoyda.github.io/rn-dev-agent/) |
 
 ```bash
 git clone https://github.com/Lykhoyda/rn-dev-agent.git
 cd rn-dev-agent
 corepack enable
 corepack yarn install --immutable
-corepack yarn workspace rn-dev-agent-core build
-corepack yarn build:host-runtimes
+corepack yarn build:host-runtimes   # builds core + generates both host packages
 ```
 
-Claude Code local path: `claude --plugin-dir /path/to/rn-dev-agent`.
-Codex local path: `/path/to/rn-dev-agent/packages/codex-plugin`.
+Run locally: `claude --plugin-dir /path/to/rn-dev-agent` (Claude Code) or register `packages/codex-plugin` (Codex).
 
-Tests: `corepack yarn test` (1180+ tests, [CI](../../actions))
+```bash
+corepack yarn test          # 2,976 unit tests
+corepack yarn lint          # oxlint
+corepack yarn format:check  # oxfmt
+```
+
+Versioning uses [changesets](https://github.com/changesets/changesets); every tool-surface change must update the golden registry (`node scripts/update-tool-registry.mjs`).
 
 ## License
 


### PR DESCRIPTION
## Summary

Complete restructure of the README, with every release-coupled fact re-verified against the current repo state (v0.66.2).

### Fact corrections (all verified from committed artifacts)
| Claim | Old | New | Source |
|---|---|---|---|
| MCP tools | 74 | **78** | `test/fixtures/tool-registry.json` (CI-asserted golden) |
| Unit tests | 1180+ | **2,976** | full `yarn test` run, 0 failures |
| Commands | 17 | **15** | `packages/claude-plugin/commands/` |
| Best-practice rules | 46 | **118** (48 RN + 70 React/web) | `rules.index.json` |

### Structural changes
- **Removed** the "What's new in v0.44.18" section (22 minor versions stale) → replaced with GitHub Releases + core changelog links, which can't rot
- **Added** previously undocumented commands: `/lock-e2e`, `/check-vercel-rules`
- **Added** "Why this exists" overview and a tool-layer reliability subsection (self-healing taps, quiescence bypass, engine pinning, degraded-runtime detection)
- **Added** monorepo package layout table to Development (reflecting the #500 workspace split)
- **Added** idb + ffmpeg auto-install rows to the setup table (post-#485/B269)
- **Folded** the six deep device-runner troubleshooting entries into a collapsible `<details>` block — common issues stay scannable, nothing was deleted
- **Added** CI / docs / license badges

No source, behavior, or docs-site changes — README only, so no changeset needed per `require-changeset.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)