### PR TITLE
fix(story-06): retry the fixture launch in the device smoke (#387)

### DIFF
--- a/.changeset/story-06-fixture-launch-retry.md
+++ b/.changeset/story-06-fixture-launch-retry.md
@@ -1,0 +1,5 @@
+---
+'rn-dev-agent-plugin': patch
+---
+
+Nightly device-smoke: retry the fixture launch (two ~30s attempts) instead of a single 20s deadline. A reused-but-cold CI simulator/emulator can take longer than one short window to foreground the fixture app; the old single 20s deadline occasionally tripped ("fixture did not start within 20s"). The re-launch is idempotent.

--- a/packages/rn-dev-agent-core/test/smoke/device-smoke.ts
+++ b/packages/rn-dev-agent-core/test/smoke/device-smoke.ts
@@ -89,11 +89,7 @@ function fixtureRunning(): boolean {
   }
 }
 
-async function launchFixture() {
-  // The driver owns the fixture lifecycle: launch it OURSELVES and open the
-  // session with attachOnly (the documented race-free path). Launch-at-open
-  // proved flaky on a loaded emulator — the bridge's `adb shell monkey` has a
-  // 10s timeout that a cold app on a busy host can exceed.
+function launchFixtureOnce() {
   if (PLATFORM === 'ios') {
     execFileSync('xcrun', ['simctl', 'launch', 'booted', APP_ID], {
       stdio: 'pipe',
@@ -106,12 +102,27 @@ async function launchFixture() {
       { stdio: 'pipe', timeout: 20_000 },
     );
   }
-  const deadline = Date.now() + 20_000;
-  while (Date.now() < deadline) {
-    if (fixtureRunning()) return;
-    await new Promise((r) => setTimeout(r, 500));
+}
+
+async function launchFixture() {
+  // The driver owns the fixture lifecycle: launch it OURSELVES and open the
+  // session with attachOnly (the documented race-free path). Launch-at-open
+  // proved flaky on a loaded emulator — the bridge's `adb shell monkey` has a
+  // 10s timeout that a cold app on a busy host can exceed.
+  //
+  // Two launch attempts, ~30s each: a reused-but-cold CI simulator/emulator can
+  // take longer than a single short window to bring the app to foreground
+  // (device-proven: a lone slow launch tripped the old 20s deadline). The
+  // re-launch is idempotent (foregrounds an already-running app).
+  for (let attempt = 0; attempt < 2; attempt++) {
+    launchFixtureOnce();
+    const deadline = Date.now() + 30_000;
+    while (Date.now() < deadline) {
+      if (fixtureRunning()) return;
+      await new Promise((r) => setTimeout(r, 500));
+    }
   }
-  throw new Error(`fixture ${APP_ID} did not start within 20s of launch`);
+  throw new Error(`fixture ${APP_ID} did not start within 2x30s of launch`);
 }
 
 async function rpc(s: any, method: string, params?: unknown) {


### PR DESCRIPTION
Run [29027707045](https://github.com/Lykhoyda/rn-dev-agent/actions/runs/29027707045): **Android green** (the iOS-only keyboard-guard change made it reliable) and integrity green — iOS hit a *different* transient this time: `fixture did not start within 20s of launch`. A reused-but-cold CI simulator can take longer than one 20s window to foreground the app.

Fix: two ~30s launch attempts (the re-launch idempotently foregrounds an already-running app) instead of a single 20s deadline. iOS has proven fully green on several prior runs (28792678817, 28793808085); this closes the last transient device-CI flake so the lanes reach reliable both-green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)