### PR TITLE
fix(story-06): post-merge review fixes — hittable-first screen rect + 4 more (#387)

### DIFF
--- a/.changeset/story-06-review-fixes.md
+++ b/.changeset/story-06-review-fixes.md
@@ -1,0 +1,6 @@
+---
+'rn-dev-agent-core': patch
+'rn-dev-agent-plugin': patch
+---
+
+Post-merge review fixes for the Phase B device-smoke surface (two independent reviewers, findings cross-validated): (1) the screen rect used by direction device_scroll/device_swipe and scrollintoview's viewport check is now a hittable-first union — off-screen mounted content (RN FlatList windowing keeps rows past the fold in the tree with real coords, marked hittable:false) can no longer inflate the viewport and push gestures off the physical screen; all-nodes union remains as fallback for snapshots without hittable data. (2) The three direct fastSwipe call sites fall back to resolveBundleId('ios') when a legacy session lacks appId, closing the reopened host-app-drag gap. (3) The nightly integrity lane captures zip listings before grepping (grep -q + pipefail could SIGPIPE-false-fail a successful match). (4) The smoke's counter assertion is anchored (/^count: 1$/) and the screenshot check documents its encoding-only scope.

--- a/.github/workflows/nightly-device-smoke.yml
+++ b/.github/workflows/nightly-device-smoke.yml
@@ -200,9 +200,15 @@ jobs:
               exit 1
             fi
           done
-          unzip -l "rn-fast-runner-$V-sim.zip" | grep -q '\.xctestrun' || { echo "iOS zip missing .xctestrun" >&2; exit 1; }
-          unzip -l "rn-android-runner-$V.zip" | grep -q 'app-debug\.apk' || { echo "android zip missing app-debug.apk" >&2; exit 1; }
-          unzip -l "rn-android-runner-$V.zip" | grep -q 'app-debug-androidTest\.apk' || { echo "android zip missing androidTest apk" >&2; exit 1; }
+          # Capture listings once, then match: `unzip -l | grep -q` under
+          # pipefail can false-fail — grep -q exits on first match, unzip takes
+          # SIGPIPE (exit 141) on a long listing, and pipefail turns a
+          # successful match into a red night.
+          IOS_LIST=$(unzip -Z1 "rn-fast-runner-$V-sim.zip")
+          ANDROID_LIST=$(unzip -Z1 "rn-android-runner-$V.zip")
+          grep -q '\.xctestrun' <<<"$IOS_LIST" || { echo "iOS zip missing .xctestrun" >&2; exit 1; }
+          grep -q 'app-debug\.apk' <<<"$ANDROID_LIST" || { echo "android zip missing app-debug.apk" >&2; exit 1; }
+          grep -q 'app-debug-androidTest\.apk' <<<"$ANDROID_LIST" || { echo "android zip missing androidTest apk" >&2; exit 1; }
           echo "artifact integrity OK for v$V"
 
   report:

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -19156,6 +19156,52 @@ var init_settle_hash = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/fast-runner-ref-map.js
+function extentToRect(right, bottom) {
+  return right > 300 && bottom > 0 ? { x: 0, y: 0, width: right, height: bottom } : null;
+}
+function resolveScreenRect(entries) {
+  let allRight = 0;
+  let allBottom = 0;
+  let hitRight = 0;
+  let hitBottom = 0;
+  const usable = [];
+  for (const e of entries) {
+    const { x, y, width, height } = e.rect;
+    if (width <= 0 || height <= 0)
+      continue;
+    usable.push(e);
+    allRight = Math.max(allRight, x + width);
+    allBottom = Math.max(allBottom, y + height);
+    if (e.hittable === true) {
+      hitRight = Math.max(hitRight, x + width);
+      hitBottom = Math.max(hitBottom, y + height);
+    }
+  }
+  if (hitRight <= 0 || hitBottom <= 0)
+    return extentToRect(allRight, allBottom);
+  let right = hitRight;
+  let bottom = hitBottom;
+  for (let pass = 0; pass < 10; pass++) {
+    let grew = false;
+    for (const e of usable) {
+      const { x, y, width, height } = e.rect;
+      const intersects = x < right && y < bottom && x + width > 0 && y + height > 0;
+      if (!intersects)
+        continue;
+      if (x + width > right) {
+        right = x + width;
+        grew = true;
+      }
+      if (y + height > bottom) {
+        bottom = y + height;
+        grew = true;
+      }
+    }
+    if (!grew)
+      break;
+  }
+  return extentToRect(right, bottom) ?? extentToRect(allRight, allBottom);
+}
 function lookupRef(ref) {
   const clean = ref.startsWith("@") ? ref.slice(1) : ref;
   return refMap.get(clean) ?? null;
@@ -19189,8 +19235,7 @@ function updateRefMapFromFlat(nodes) {
   refMap.clear();
   screenRect = null;
   const hashed = [];
-  let maxRight = 0;
-  let maxBottom = 0;
+  const entries = [];
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
     if (!node.ref || !node.rect)
@@ -19204,13 +19249,9 @@ function updateRefMapFromFlat(nodes) {
       meta.identifier = node.identifier;
     metadataMap.set(key, meta);
     hashed.push(node);
-    const { x, y, width, height } = node.rect;
-    if (width > 0 && height > 0) {
-      maxRight = Math.max(maxRight, x + width);
-      maxBottom = Math.max(maxBottom, y + height);
-    }
+    entries.push({ rect: node.rect, hittable: node.hittable });
   }
-  screenRect = maxRight > 300 && maxBottom > 0 ? { x: 0, y: 0, width: maxRight, height: maxBottom } : null;
+  screenRect = resolveScreenRect(entries);
   try {
     lastSnapshotHash = hashSnapshotNodes(hashed);
   } catch {
@@ -25829,7 +25870,7 @@ function createDeviceSwipeHandler() {
     if (args.x1 != null && args.y1 != null && args.x2 != null && args.y2 != null) {
       if (canUseFastRunner) {
         try {
-          const resp = await fastSwipe(args.x1, args.y1, args.x2, args.y2, args.durationMs, getActiveSession()?.appId);
+          const resp = await fastSwipe(args.x1, args.y1, args.x2, args.y2, args.durationMs, getActiveSession()?.appId ?? resolveBundleId("ios") ?? void 0);
           if (resp.ok) {
             return okResult({
               x1: args.x1,
@@ -25864,7 +25905,7 @@ function createDeviceSwipeHandler() {
       const duration3 = args.durationMs ?? DEFAULT_SWIPE_DURATION_MS;
       if (canUseFastRunner) {
         try {
-          const resp = await fastSwipe(coords.x1, coords.y1, coords.x2, coords.y2, duration3, getActiveSession()?.appId);
+          const resp = await fastSwipe(coords.x1, coords.y1, coords.x2, coords.y2, duration3, getActiveSession()?.appId ?? resolveBundleId("ios") ?? void 0);
           if (resp.ok) {
             return okResult({
               direction: args.direction,
@@ -25907,7 +25948,7 @@ function createDeviceScrollHandler() {
     adoptPersistedFastRunnerState(getActiveSession()?.deviceId);
     if (isFastRunnerAvailable()) {
       try {
-        const resp = await fastSwipe(x1, y1, x2, y2, DEFAULT_SWIPE_DURATION_MS, getActiveSession()?.appId);
+        const resp = await fastSwipe(x1, y1, x2, y2, DEFAULT_SWIPE_DURATION_MS, getActiveSession()?.appId ?? resolveBundleId("ios") ?? void 0);
         if (resp.ok) {
           return okResult({
             direction: args.direction,
@@ -26090,6 +26131,7 @@ var init_device_interact = __esm({
     init_rn_fast_runner_client();
     init_rn_android_runner_client();
     init_keyboard_guard();
+    init_project_config();
     init_utils();
     init_utils();
     init_maestro_invoke();

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -40005,6 +40005,52 @@ var init_settle_hash = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/fast-runner-ref-map.js
+function extentToRect(right, bottom) {
+  return right > 300 && bottom > 0 ? { x: 0, y: 0, width: right, height: bottom } : null;
+}
+function resolveScreenRect(entries) {
+  let allRight = 0;
+  let allBottom = 0;
+  let hitRight = 0;
+  let hitBottom = 0;
+  const usable = [];
+  for (const e of entries) {
+    const { x, y, width, height } = e.rect;
+    if (width <= 0 || height <= 0)
+      continue;
+    usable.push(e);
+    allRight = Math.max(allRight, x + width);
+    allBottom = Math.max(allBottom, y + height);
+    if (e.hittable === true) {
+      hitRight = Math.max(hitRight, x + width);
+      hitBottom = Math.max(hitBottom, y + height);
+    }
+  }
+  if (hitRight <= 0 || hitBottom <= 0)
+    return extentToRect(allRight, allBottom);
+  let right = hitRight;
+  let bottom = hitBottom;
+  for (let pass = 0; pass < 10; pass++) {
+    let grew = false;
+    for (const e of usable) {
+      const { x, y, width, height } = e.rect;
+      const intersects = x < right && y < bottom && x + width > 0 && y + height > 0;
+      if (!intersects)
+        continue;
+      if (x + width > right) {
+        right = x + width;
+        grew = true;
+      }
+      if (y + height > bottom) {
+        bottom = y + height;
+        grew = true;
+      }
+    }
+    if (!grew)
+      break;
+  }
+  return extentToRect(right, bottom) ?? extentToRect(allRight, allBottom);
+}
 function lookupRef(ref) {
   const clean = ref.startsWith("@") ? ref.slice(1) : ref;
   return refMap.get(clean) ?? null;
@@ -40038,8 +40084,7 @@ function updateRefMapFromFlat(nodes) {
   refMap.clear();
   screenRect = null;
   const hashed = [];
-  let maxRight = 0;
-  let maxBottom = 0;
+  const entries = [];
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
     if (!node.ref || !node.rect)
@@ -40053,13 +40098,9 @@ function updateRefMapFromFlat(nodes) {
       meta.identifier = node.identifier;
     metadataMap.set(key, meta);
     hashed.push(node);
-    const { x, y, width, height } = node.rect;
-    if (width > 0 && height > 0) {
-      maxRight = Math.max(maxRight, x + width);
-      maxBottom = Math.max(maxBottom, y + height);
-    }
+    entries.push({ rect: node.rect, hittable: node.hittable });
   }
-  screenRect = maxRight > 300 && maxBottom > 0 ? { x: 0, y: 0, width: maxRight, height: maxBottom } : null;
+  screenRect = resolveScreenRect(entries);
   try {
     lastSnapshotHash = hashSnapshotNodes(hashed);
   } catch {
@@ -46678,7 +46719,7 @@ function createDeviceSwipeHandler() {
     if (args.x1 != null && args.y1 != null && args.x2 != null && args.y2 != null) {
       if (canUseFastRunner) {
         try {
-          const resp = await fastSwipe(args.x1, args.y1, args.x2, args.y2, args.durationMs, getActiveSession()?.appId);
+          const resp = await fastSwipe(args.x1, args.y1, args.x2, args.y2, args.durationMs, getActiveSession()?.appId ?? resolveBundleId("ios") ?? void 0);
           if (resp.ok) {
             return okResult({
               x1: args.x1,
@@ -46713,7 +46754,7 @@ function createDeviceSwipeHandler() {
       const duration3 = args.durationMs ?? DEFAULT_SWIPE_DURATION_MS;
       if (canUseFastRunner) {
         try {
-          const resp = await fastSwipe(coords.x1, coords.y1, coords.x2, coords.y2, duration3, getActiveSession()?.appId);
+          const resp = await fastSwipe(coords.x1, coords.y1, coords.x2, coords.y2, duration3, getActiveSession()?.appId ?? resolveBundleId("ios") ?? void 0);
           if (resp.ok) {
             return okResult({
               direction: args.direction,
@@ -46756,7 +46797,7 @@ function createDeviceScrollHandler() {
     adoptPersistedFastRunnerState(getActiveSession()?.deviceId);
     if (isFastRunnerAvailable()) {
       try {
-        const resp = await fastSwipe(x1, y1, x2, y2, DEFAULT_SWIPE_DURATION_MS, getActiveSession()?.appId);
+        const resp = await fastSwipe(x1, y1, x2, y2, DEFAULT_SWIPE_DURATION_MS, getActiveSession()?.appId ?? resolveBundleId("ios") ?? void 0);
         if (resp.ok) {
           return okResult({
             direction: args.direction,
@@ -46939,6 +46980,7 @@ var init_device_interact = __esm({
     init_rn_fast_runner_client();
     init_rn_android_runner_client();
     init_keyboard_guard();
+    init_project_config();
     init_utils();
     init_utils();
     init_maestro_invoke();

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -19156,6 +19156,52 @@ var init_settle_hash = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/fast-runner-ref-map.js
+function extentToRect(right, bottom) {
+  return right > 300 && bottom > 0 ? { x: 0, y: 0, width: right, height: bottom } : null;
+}
+function resolveScreenRect(entries) {
+  let allRight = 0;
+  let allBottom = 0;
+  let hitRight = 0;
+  let hitBottom = 0;
+  const usable = [];
+  for (const e of entries) {
+    const { x, y, width, height } = e.rect;
+    if (width <= 0 || height <= 0)
+      continue;
+    usable.push(e);
+    allRight = Math.max(allRight, x + width);
+    allBottom = Math.max(allBottom, y + height);
+    if (e.hittable === true) {
+      hitRight = Math.max(hitRight, x + width);
+      hitBottom = Math.max(hitBottom, y + height);
+    }
+  }
+  if (hitRight <= 0 || hitBottom <= 0)
+    return extentToRect(allRight, allBottom);
+  let right = hitRight;
+  let bottom = hitBottom;
+  for (let pass = 0; pass < 10; pass++) {
+    let grew = false;
+    for (const e of usable) {
+      const { x, y, width, height } = e.rect;
+      const intersects = x < right && y < bottom && x + width > 0 && y + height > 0;
+      if (!intersects)
+        continue;
+      if (x + width > right) {
+        right = x + width;
+        grew = true;
+      }
+      if (y + height > bottom) {
+        bottom = y + height;
+        grew = true;
+      }
+    }
+    if (!grew)
+      break;
+  }
+  return extentToRect(right, bottom) ?? extentToRect(allRight, allBottom);
+}
 function lookupRef(ref) {
   const clean = ref.startsWith("@") ? ref.slice(1) : ref;
   return refMap.get(clean) ?? null;
@@ -19189,8 +19235,7 @@ function updateRefMapFromFlat(nodes) {
   refMap.clear();
   screenRect = null;
   const hashed = [];
-  let maxRight = 0;
-  let maxBottom = 0;
+  const entries = [];
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
     if (!node.ref || !node.rect)
@@ -19204,13 +19249,9 @@ function updateRefMapFromFlat(nodes) {
       meta.identifier = node.identifier;
     metadataMap.set(key, meta);
     hashed.push(node);
-    const { x, y, width, height } = node.rect;
-    if (width > 0 && height > 0) {
-      maxRight = Math.max(maxRight, x + width);
-      maxBottom = Math.max(maxBottom, y + height);
-    }
+    entries.push({ rect: node.rect, hittable: node.hittable });
   }
-  screenRect = maxRight > 300 && maxBottom > 0 ? { x: 0, y: 0, width: maxRight, height: maxBottom } : null;
+  screenRect = resolveScreenRect(entries);
   try {
     lastSnapshotHash = hashSnapshotNodes(hashed);
   } catch {
@@ -25829,7 +25870,7 @@ function createDeviceSwipeHandler() {
     if (args.x1 != null && args.y1 != null && args.x2 != null && args.y2 != null) {
       if (canUseFastRunner) {
         try {
-          const resp = await fastSwipe(args.x1, args.y1, args.x2, args.y2, args.durationMs, getActiveSession()?.appId);
+          const resp = await fastSwipe(args.x1, args.y1, args.x2, args.y2, args.durationMs, getActiveSession()?.appId ?? resolveBundleId("ios") ?? void 0);
           if (resp.ok) {
             return okResult({
               x1: args.x1,
@@ -25864,7 +25905,7 @@ function createDeviceSwipeHandler() {
       const duration3 = args.durationMs ?? DEFAULT_SWIPE_DURATION_MS;
       if (canUseFastRunner) {
         try {
-          const resp = await fastSwipe(coords.x1, coords.y1, coords.x2, coords.y2, duration3, getActiveSession()?.appId);
+          const resp = await fastSwipe(coords.x1, coords.y1, coords.x2, coords.y2, duration3, getActiveSession()?.appId ?? resolveBundleId("ios") ?? void 0);
           if (resp.ok) {
             return okResult({
               direction: args.direction,
@@ -25907,7 +25948,7 @@ function createDeviceScrollHandler() {
     adoptPersistedFastRunnerState(getActiveSession()?.deviceId);
     if (isFastRunnerAvailable()) {
       try {
-        const resp = await fastSwipe(x1, y1, x2, y2, DEFAULT_SWIPE_DURATION_MS, getActiveSession()?.appId);
+        const resp = await fastSwipe(x1, y1, x2, y2, DEFAULT_SWIPE_DURATION_MS, getActiveSession()?.appId ?? resolveBundleId("ios") ?? void 0);
         if (resp.ok) {
           return okResult({
             direction: args.direction,
@@ -26090,6 +26131,7 @@ var init_device_interact = __esm({
     init_rn_fast_runner_client();
     init_rn_android_runner_client();
     init_keyboard_guard();
+    init_project_config();
     init_utils();
     init_utils();
     init_maestro_invoke();

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -40005,6 +40005,52 @@ var init_settle_hash = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/fast-runner-ref-map.js
+function extentToRect(right, bottom) {
+  return right > 300 && bottom > 0 ? { x: 0, y: 0, width: right, height: bottom } : null;
+}
+function resolveScreenRect(entries) {
+  let allRight = 0;
+  let allBottom = 0;
+  let hitRight = 0;
+  let hitBottom = 0;
+  const usable = [];
+  for (const e of entries) {
+    const { x, y, width, height } = e.rect;
+    if (width <= 0 || height <= 0)
+      continue;
+    usable.push(e);
+    allRight = Math.max(allRight, x + width);
+    allBottom = Math.max(allBottom, y + height);
+    if (e.hittable === true) {
+      hitRight = Math.max(hitRight, x + width);
+      hitBottom = Math.max(hitBottom, y + height);
+    }
+  }
+  if (hitRight <= 0 || hitBottom <= 0)
+    return extentToRect(allRight, allBottom);
+  let right = hitRight;
+  let bottom = hitBottom;
+  for (let pass = 0; pass < 10; pass++) {
+    let grew = false;
+    for (const e of usable) {
+      const { x, y, width, height } = e.rect;
+      const intersects = x < right && y < bottom && x + width > 0 && y + height > 0;
+      if (!intersects)
+        continue;
+      if (x + width > right) {
+        right = x + width;
+        grew = true;
+      }
+      if (y + height > bottom) {
+        bottom = y + height;
+        grew = true;
+      }
+    }
+    if (!grew)
+      break;
+  }
+  return extentToRect(right, bottom) ?? extentToRect(allRight, allBottom);
+}
 function lookupRef(ref) {
   const clean = ref.startsWith("@") ? ref.slice(1) : ref;
   return refMap.get(clean) ?? null;
@@ -40038,8 +40084,7 @@ function updateRefMapFromFlat(nodes) {
   refMap.clear();
   screenRect = null;
   const hashed = [];
-  let maxRight = 0;
-  let maxBottom = 0;
+  const entries = [];
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
     if (!node.ref || !node.rect)
@@ -40053,13 +40098,9 @@ function updateRefMapFromFlat(nodes) {
       meta.identifier = node.identifier;
     metadataMap.set(key, meta);
     hashed.push(node);
-    const { x, y, width, height } = node.rect;
-    if (width > 0 && height > 0) {
-      maxRight = Math.max(maxRight, x + width);
-      maxBottom = Math.max(maxBottom, y + height);
-    }
+    entries.push({ rect: node.rect, hittable: node.hittable });
   }
-  screenRect = maxRight > 300 && maxBottom > 0 ? { x: 0, y: 0, width: maxRight, height: maxBottom } : null;
+  screenRect = resolveScreenRect(entries);
   try {
     lastSnapshotHash = hashSnapshotNodes(hashed);
   } catch {
@@ -46678,7 +46719,7 @@ function createDeviceSwipeHandler() {
     if (args.x1 != null && args.y1 != null && args.x2 != null && args.y2 != null) {
       if (canUseFastRunner) {
         try {
-          const resp = await fastSwipe(args.x1, args.y1, args.x2, args.y2, args.durationMs, getActiveSession()?.appId);
+          const resp = await fastSwipe(args.x1, args.y1, args.x2, args.y2, args.durationMs, getActiveSession()?.appId ?? resolveBundleId("ios") ?? void 0);
           if (resp.ok) {
             return okResult({
               x1: args.x1,
@@ -46713,7 +46754,7 @@ function createDeviceSwipeHandler() {
       const duration3 = args.durationMs ?? DEFAULT_SWIPE_DURATION_MS;
       if (canUseFastRunner) {
         try {
-          const resp = await fastSwipe(coords.x1, coords.y1, coords.x2, coords.y2, duration3, getActiveSession()?.appId);
+          const resp = await fastSwipe(coords.x1, coords.y1, coords.x2, coords.y2, duration3, getActiveSession()?.appId ?? resolveBundleId("ios") ?? void 0);
           if (resp.ok) {
             return okResult({
               direction: args.direction,
@@ -46756,7 +46797,7 @@ function createDeviceScrollHandler() {
     adoptPersistedFastRunnerState(getActiveSession()?.deviceId);
     if (isFastRunnerAvailable()) {
       try {
-        const resp = await fastSwipe(x1, y1, x2, y2, DEFAULT_SWIPE_DURATION_MS, getActiveSession()?.appId);
+        const resp = await fastSwipe(x1, y1, x2, y2, DEFAULT_SWIPE_DURATION_MS, getActiveSession()?.appId ?? resolveBundleId("ios") ?? void 0);
         if (resp.ok) {
           return okResult({
             direction: args.direction,
@@ -46939,6 +46980,7 @@ var init_device_interact = __esm({
     init_rn_fast_runner_client();
     init_rn_android_runner_client();
     init_keyboard_guard();
+    init_project_config();
     init_utils();
     init_utils();
     init_maestro_invoke();

--- a/packages/rn-dev-agent-core/dist/fast-runner-ref-map.js
+++ b/packages/rn-dev-agent-core/dist/fast-runner-ref-map.js
@@ -4,31 +4,42 @@ let metadataMap = new Map();
 let screenRect = null;
 let lastUpdated = 0;
 let lastSnapshotHash = null;
+function newExtentUnion() {
+    return { hitRight: 0, hitBottom: 0, allRight: 0, allBottom: 0 };
+}
+function accumulateExtent(u, rect, hittable) {
+    const { x, y, width, height } = rect;
+    if (width <= 0 || height <= 0)
+        return;
+    u.allRight = Math.max(u.allRight, x + width);
+    u.allBottom = Math.max(u.allBottom, y + height);
+    if (hittable === true) {
+        u.hitRight = Math.max(u.hitRight, x + width);
+        u.hitBottom = Math.max(u.hitBottom, y + height);
+    }
+}
+// width > 300 keeps the same sanity floor the old heuristic used (ignore
+// degenerate all-tiny snapshots rather than emit a bogus rect).
+function resolveScreenRect(u) {
+    if (u.hitRight > 300 && u.hitBottom > 0) {
+        return { x: 0, y: 0, width: u.hitRight, height: u.hitBottom };
+    }
+    if (u.allRight > 300 && u.allBottom > 0) {
+        return { x: 0, y: 0, width: u.allRight, height: u.allBottom };
+    }
+    return null;
+}
 export function updateRefMap(nodes) {
     refMap.clear();
     screenRect = null;
-    // Screen rect = the union bounding box of all node rects. A (0,0)-anchored
-    // heuristic is fragile: on some Android snapshots (#387 Phase B device-proven)
-    // NO node spans the full window — the tallest (0,0) node is a ~128px top-chrome
-    // strip, so a "largest (0,0) rect" pick yields a tiny viewport and direction
-    // scrolls compute a ~50px drag in the status bar that never moves the list.
-    // The max extent across all nodes recovers the true viewport on both platforms.
-    let maxRight = 0;
-    let maxBottom = 0;
+    const extent = newExtentUnion();
     for (const node of nodes) {
         if (!node.ref || !node.rect)
             continue;
         refMap.set(node.ref, node.rect);
-        const { x, y, width, height } = node.rect;
-        if (width > 0 && height > 0) {
-            maxRight = Math.max(maxRight, x + width);
-            maxBottom = Math.max(maxBottom, y + height);
-        }
+        accumulateExtent(extent, node.rect, node.hittable);
     }
-    // width > 300 keeps the same sanity floor the old heuristic used (ignore
-    // degenerate all-tiny-node snapshots rather than emit a bogus rect).
-    screenRect =
-        maxRight > 300 && maxBottom > 0 ? { x: 0, y: 0, width: maxRight, height: maxBottom } : null;
+    screenRect = resolveScreenRect(extent);
     lastUpdated = Date.now();
 }
 export function lookupRef(ref) {
@@ -120,11 +131,10 @@ export function updateRefMapFromFlat(nodes) {
     refMap.clear();
     screenRect = null;
     const hashed = [];
-    // Screen rect = union bounding box of all node rects (same rationale as
-    // updateRefMap — a (0,0)-anchored pick is fragile when no node spans the
-    // full window).
-    let maxRight = 0;
-    let maxBottom = 0;
+    // Screen rect: hittable-first union with an all-nodes fallback — same
+    // rationale as updateRefMap (off-screen mounted rows must not inflate the
+    // viewport; a (0,0)-anchored pick is fragile when no node spans the window).
+    const extent = newExtentUnion();
     for (let i = 0; i < nodes.length; i++) {
         const node = nodes[i];
         if (!node.ref || !node.rect)
@@ -138,14 +148,9 @@ export function updateRefMapFromFlat(nodes) {
             meta.identifier = node.identifier;
         metadataMap.set(key, meta);
         hashed.push(node);
-        const { x, y, width, height } = node.rect;
-        if (width > 0 && height > 0) {
-            maxRight = Math.max(maxRight, x + width);
-            maxBottom = Math.max(maxBottom, y + height);
-        }
+        accumulateExtent(extent, node.rect, node.hittable);
     }
-    screenRect =
-        maxRight > 300 && maxBottom > 0 ? { x: 0, y: 0, width: maxRight, height: maxBottom } : null;
+    screenRect = resolveScreenRect(extent);
     // Hash only the nodes that passed the ref/rect filter: hashSnapshotNodes
     // dereferences node.rect.* unconditionally, and a malformed entry must not
     // throw mid-update. For real runner data the filtered subset equals the full

--- a/packages/rn-dev-agent-core/dist/fast-runner-ref-map.js
+++ b/packages/rn-dev-agent-core/dist/fast-runner-ref-map.js
@@ -4,42 +4,67 @@ let metadataMap = new Map();
 let screenRect = null;
 let lastUpdated = 0;
 let lastSnapshotHash = null;
-function newExtentUnion() {
-    return { hitRight: 0, hitBottom: 0, allRight: 0, allBottom: 0 };
-}
-function accumulateExtent(u, rect, hittable) {
-    const { x, y, width, height } = rect;
-    if (width <= 0 || height <= 0)
-        return;
-    u.allRight = Math.max(u.allRight, x + width);
-    u.allBottom = Math.max(u.allBottom, y + height);
-    if (hittable === true) {
-        u.hitRight = Math.max(u.hitRight, x + width);
-        u.hitBottom = Math.max(u.hitBottom, y + height);
-    }
-}
 // width > 300 keeps the same sanity floor the old heuristic used (ignore
 // degenerate all-tiny snapshots rather than emit a bogus rect).
-function resolveScreenRect(u) {
-    if (u.hitRight > 300 && u.hitBottom > 0) {
-        return { x: 0, y: 0, width: u.hitRight, height: u.hitBottom };
+function extentToRect(right, bottom) {
+    return right > 300 && bottom > 0 ? { x: 0, y: 0, width: right, height: bottom } : null;
+}
+function resolveScreenRect(entries) {
+    let allRight = 0;
+    let allBottom = 0;
+    let hitRight = 0;
+    let hitBottom = 0;
+    const usable = [];
+    for (const e of entries) {
+        const { x, y, width, height } = e.rect;
+        if (width <= 0 || height <= 0)
+            continue;
+        usable.push(e);
+        allRight = Math.max(allRight, x + width);
+        allBottom = Math.max(allBottom, y + height);
+        if (e.hittable === true) {
+            hitRight = Math.max(hitRight, x + width);
+            hitBottom = Math.max(hitBottom, y + height);
+        }
     }
-    if (u.allRight > 300 && u.allBottom > 0) {
-        return { x: 0, y: 0, width: u.allRight, height: u.allBottom };
+    if (hitRight <= 0 || hitBottom <= 0)
+        return extentToRect(allRight, allBottom);
+    // Grow the hittable seed by overlap until stable (bounded — each pass only
+    // ever extends, and stops as soon as nothing new intersects).
+    let right = hitRight;
+    let bottom = hitBottom;
+    for (let pass = 0; pass < 10; pass++) {
+        let grew = false;
+        for (const e of usable) {
+            const { x, y, width, height } = e.rect;
+            const intersects = x < right && y < bottom && x + width > 0 && y + height > 0;
+            if (!intersects)
+                continue;
+            if (x + width > right) {
+                right = x + width;
+                grew = true;
+            }
+            if (y + height > bottom) {
+                bottom = y + height;
+                grew = true;
+            }
+        }
+        if (!grew)
+            break;
     }
-    return null;
+    return extentToRect(right, bottom) ?? extentToRect(allRight, allBottom);
 }
 export function updateRefMap(nodes) {
     refMap.clear();
     screenRect = null;
-    const extent = newExtentUnion();
+    const entries = [];
     for (const node of nodes) {
         if (!node.ref || !node.rect)
             continue;
         refMap.set(node.ref, node.rect);
-        accumulateExtent(extent, node.rect, node.hittable);
+        entries.push({ rect: node.rect, hittable: node.hittable });
     }
-    screenRect = resolveScreenRect(extent);
+    screenRect = resolveScreenRect(entries);
     lastUpdated = Date.now();
 }
 export function lookupRef(ref) {
@@ -134,7 +159,7 @@ export function updateRefMapFromFlat(nodes) {
     // Screen rect: hittable-first union with an all-nodes fallback — same
     // rationale as updateRefMap (off-screen mounted rows must not inflate the
     // viewport; a (0,0)-anchored pick is fragile when no node spans the window).
-    const extent = newExtentUnion();
+    const entries = [];
     for (let i = 0; i < nodes.length; i++) {
         const node = nodes[i];
         if (!node.ref || !node.rect)
@@ -148,9 +173,9 @@ export function updateRefMapFromFlat(nodes) {
             meta.identifier = node.identifier;
         metadataMap.set(key, meta);
         hashed.push(node);
-        accumulateExtent(extent, node.rect, node.hittable);
+        entries.push({ rect: node.rect, hittable: node.hittable });
     }
-    screenRect = resolveScreenRect(extent);
+    screenRect = resolveScreenRect(entries);
     // Hash only the nodes that passed the ref/rect filter: hashSnapshotNodes
     // dereferences node.rect.* unconditionally, and a malformed entry must not
     // throw mid-update. For real runner data the filtered subset equals the full

--- a/packages/rn-dev-agent-core/dist/tools/device-interact.js
+++ b/packages/rn-dev-agent-core/dist/tools/device-interact.js
@@ -4,6 +4,7 @@ import { runNative, getActiveSession, clearActiveSession, getCachedScreenRect, g
 import { isFastRunnerAvailable, fastSwipe, stopFastRunner, adoptPersistedFastRunnerState, } from '../runners/rn-fast-runner-client.js';
 import { stopAndroidRunner } from '../runners/rn-android-runner-client.js';
 import { surfaceKeyboardGuard } from '../runners/keyboard-guard.js';
+import { resolveBundleId } from '../project-config.js';
 import { withSession } from '../utils.js';
 import { okResult, failResult, createStepTimer } from '../utils.js';
 import { runMaestroInline, yamlEscape } from '../maestro-invoke.js';
@@ -893,7 +894,7 @@ export function createDeviceSwipeHandler() {
         if (args.x1 != null && args.y1 != null && args.x2 != null && args.y2 != null) {
             if (canUseFastRunner) {
                 try {
-                    const resp = await fastSwipe(args.x1, args.y1, args.x2, args.y2, args.durationMs, getActiveSession()?.appId);
+                    const resp = await fastSwipe(args.x1, args.y1, args.x2, args.y2, args.durationMs, getActiveSession()?.appId ?? resolveBundleId('ios') ?? undefined);
                     if (resp.ok) {
                         return okResult({
                             x1: args.x1,
@@ -931,7 +932,7 @@ export function createDeviceSwipeHandler() {
             const duration = args.durationMs ?? DEFAULT_SWIPE_DURATION_MS;
             if (canUseFastRunner) {
                 try {
-                    const resp = await fastSwipe(coords.x1, coords.y1, coords.x2, coords.y2, duration, getActiveSession()?.appId);
+                    const resp = await fastSwipe(coords.x1, coords.y1, coords.x2, coords.y2, duration, getActiveSession()?.appId ?? resolveBundleId('ios') ?? undefined);
                     if (resp.ok) {
                         return okResult({
                             direction: args.direction,
@@ -985,7 +986,7 @@ export function createDeviceScrollHandler() {
         adoptPersistedFastRunnerState(getActiveSession()?.deviceId);
         if (isFastRunnerAvailable()) {
             try {
-                const resp = await fastSwipe(x1, y1, x2, y2, DEFAULT_SWIPE_DURATION_MS, getActiveSession()?.appId);
+                const resp = await fastSwipe(x1, y1, x2, y2, DEFAULT_SWIPE_DURATION_MS, getActiveSession()?.appId ?? resolveBundleId('ios') ?? undefined);
                 if (resp.ok) {
                     return okResult({
                         direction: args.direction,

--- a/packages/rn-dev-agent-core/src/fast-runner-ref-map.ts
+++ b/packages/rn-dev-agent-core/src/fast-runner-ref-map.ts
@@ -62,32 +62,65 @@ let screenRect: ElementRect | null = null;
 let lastUpdated = 0;
 let lastSnapshotHash: string | null = null;
 
+// Screen-rect extents, tracked as two unions:
+//  - hittable-only: the viewport. Both runners keep OFF-SCREEN content-bearing
+//    nodes in the snapshot with their real out-of-viewport coordinates (RN
+//    FlatList windowing mounts rows screens past the fold) but mark them
+//    hittable:false — including them would inflate the rect, push direction
+//    gestures off the physical screen, and false-pass scrollintoview's
+//    isInViewport. A visible element is hittable, so it contributes its own
+//    rect to this union — a truly on-screen target is always inside it.
+//  - all-nodes: fallback for snapshots without usable hittable data (older
+//    runner artifacts, synthetic fixtures) — the pre-hittable behavior.
+// A (0,0)-anchored heuristic is NOT usable at all: on some Android snapshots
+// (#387 Phase B device-proven) no node spans the full window — the tallest
+// (0,0) node is a ~128px top-chrome strip, so direction scrolls computed a
+// ~50px drag in the status bar that never moved the list.
+interface ExtentUnion {
+  hitRight: number;
+  hitBottom: number;
+  allRight: number;
+  allBottom: number;
+}
+
+function newExtentUnion(): ExtentUnion {
+  return { hitRight: 0, hitBottom: 0, allRight: 0, allBottom: 0 };
+}
+
+function accumulateExtent(u: ExtentUnion, rect: ElementRect, hittable: boolean | undefined): void {
+  const { x, y, width, height } = rect;
+  if (width <= 0 || height <= 0) return;
+  u.allRight = Math.max(u.allRight, x + width);
+  u.allBottom = Math.max(u.allBottom, y + height);
+  if (hittable === true) {
+    u.hitRight = Math.max(u.hitRight, x + width);
+    u.hitBottom = Math.max(u.hitBottom, y + height);
+  }
+}
+
+// width > 300 keeps the same sanity floor the old heuristic used (ignore
+// degenerate all-tiny snapshots rather than emit a bogus rect).
+function resolveScreenRect(u: ExtentUnion): ElementRect | null {
+  if (u.hitRight > 300 && u.hitBottom > 0) {
+    return { x: 0, y: 0, width: u.hitRight, height: u.hitBottom };
+  }
+  if (u.allRight > 300 && u.allBottom > 0) {
+    return { x: 0, y: 0, width: u.allRight, height: u.allBottom };
+  }
+  return null;
+}
+
 export function updateRefMap(nodes: SnapshotNode[]): void {
   refMap.clear();
   screenRect = null;
 
-  // Screen rect = the union bounding box of all node rects. A (0,0)-anchored
-  // heuristic is fragile: on some Android snapshots (#387 Phase B device-proven)
-  // NO node spans the full window — the tallest (0,0) node is a ~128px top-chrome
-  // strip, so a "largest (0,0) rect" pick yields a tiny viewport and direction
-  // scrolls compute a ~50px drag in the status bar that never moves the list.
-  // The max extent across all nodes recovers the true viewport on both platforms.
-  let maxRight = 0;
-  let maxBottom = 0;
+  const extent = newExtentUnion();
   for (const node of nodes) {
     if (!node.ref || !node.rect) continue;
     refMap.set(node.ref, node.rect);
-
-    const { x, y, width, height } = node.rect;
-    if (width > 0 && height > 0) {
-      maxRight = Math.max(maxRight, x + width);
-      maxBottom = Math.max(maxBottom, y + height);
-    }
+    accumulateExtent(extent, node.rect, node.hittable);
   }
-  // width > 300 keeps the same sanity floor the old heuristic used (ignore
-  // degenerate all-tiny-node snapshots rather than emit a bogus rect).
-  screenRect =
-    maxRight > 300 && maxBottom > 0 ? { x: 0, y: 0, width: maxRight, height: maxBottom } : null;
+  screenRect = resolveScreenRect(extent);
 
   lastUpdated = Date.now();
 }
@@ -189,11 +222,10 @@ export function updateRefMapFromFlat(nodes: FlatNode[]): void {
   screenRect = null;
 
   const hashed: FlatNode[] = [];
-  // Screen rect = union bounding box of all node rects (same rationale as
-  // updateRefMap — a (0,0)-anchored pick is fragile when no node spans the
-  // full window).
-  let maxRight = 0;
-  let maxBottom = 0;
+  // Screen rect: hittable-first union with an all-nodes fallback — same
+  // rationale as updateRefMap (off-screen mounted rows must not inflate the
+  // viewport; a (0,0)-anchored pick is fragile when no node spans the window).
+  const extent = newExtentUnion();
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
     if (!node.ref || !node.rect) continue;
@@ -206,14 +238,9 @@ export function updateRefMapFromFlat(nodes: FlatNode[]): void {
     metadataMap.set(key, meta);
     hashed.push(node);
 
-    const { x, y, width, height } = node.rect;
-    if (width > 0 && height > 0) {
-      maxRight = Math.max(maxRight, x + width);
-      maxBottom = Math.max(maxBottom, y + height);
-    }
+    accumulateExtent(extent, node.rect, node.hittable);
   }
-  screenRect =
-    maxRight > 300 && maxBottom > 0 ? { x: 0, y: 0, width: maxRight, height: maxBottom } : null;
+  screenRect = resolveScreenRect(extent);
 
   // Hash only the nodes that passed the ref/rect filter: hashSnapshotNodes
   // dereferences node.rect.* unconditionally, and a malformed entry must not

--- a/packages/rn-dev-agent-core/src/fast-runner-ref-map.ts
+++ b/packages/rn-dev-agent-core/src/fast-runner-ref-map.ts
@@ -62,65 +62,94 @@ let screenRect: ElementRect | null = null;
 let lastUpdated = 0;
 let lastSnapshotHash: string | null = null;
 
-// Screen-rect extents, tracked as two unions:
-//  - hittable-only: the viewport. Both runners keep OFF-SCREEN content-bearing
-//    nodes in the snapshot with their real out-of-viewport coordinates (RN
-//    FlatList windowing mounts rows screens past the fold) but mark them
-//    hittable:false — including them would inflate the rect, push direction
-//    gestures off the physical screen, and false-pass scrollintoview's
-//    isInViewport. A visible element is hittable, so it contributes its own
-//    rect to this union — a truly on-screen target is always inside it.
-//  - all-nodes: fallback for snapshots without usable hittable data (older
-//    runner artifacts, synthetic fixtures) — the pre-hittable behavior.
-// A (0,0)-anchored heuristic is NOT usable at all: on some Android snapshots
-// (#387 Phase B device-proven) no node spans the full window — the tallest
-// (0,0) node is a ~128px top-chrome strip, so direction scrolls computed a
-// ~50px drag in the status bar that never moved the list.
-interface ExtentUnion {
-  hitRight: number;
-  hitBottom: number;
-  allRight: number;
-  allBottom: number;
-}
-
-function newExtentUnion(): ExtentUnion {
-  return { hitRight: 0, hitBottom: 0, allRight: 0, allBottom: 0 };
-}
-
-function accumulateExtent(u: ExtentUnion, rect: ElementRect, hittable: boolean | undefined): void {
-  const { x, y, width, height } = rect;
-  if (width <= 0 || height <= 0) return;
-  u.allRight = Math.max(u.allRight, x + width);
-  u.allBottom = Math.max(u.allBottom, y + height);
-  if (hittable === true) {
-    u.hitRight = Math.max(u.hitRight, x + width);
-    u.hitBottom = Math.max(u.hitBottom, y + height);
-  }
+// Screen-rect derivation: hittable-seeded union GROWN BY OVERLAP.
+//
+// Two device/review-proven failure modes bound the problem from both sides:
+//  - An ALL-nodes union over-covers: both runners keep OFF-SCREEN content in
+//    the snapshot with real out-of-viewport coords (RN FlatList windowing
+//    mounts rows screens past the fold; non-virtualized ScrollView children)
+//    marked hittable:false — including them inflates the rect, pushes
+//    direction gestures off the physical screen, and false-passes
+//    scrollintoview's isInViewport.
+//  - A hittable-ONLY union under-covers: container/window nodes can be
+//    hittable:false while only a small control is hittable, collapsing the
+//    "viewport" to that control's extent (short top-of-screen drags).
+// The rule: seed with the union of hittable nodes (a visible element is
+// hittable, so it contributes its own rect), then repeatedly extend by any
+// node whose rect INTERSECTS the current estimate. On-screen containers
+// overlap the seed and pull the extent to the true window; off-screen rows
+// past the fold are disjoint and stay excluded. (Residual accepted risk: a
+// content-sized container rect overlapping the viewport would re-inflate —
+// both runners report frame-bounded container rects, so this is theoretical.)
+// Snapshots with no usable hittable data fall back to the all-nodes union
+// (pre-hittable behavior). A (0,0)-anchored heuristic is NOT usable at all:
+// on some Android snapshots (#387 Phase B device-proven) no node spans the
+// full window and the tallest (0,0) node is a ~128px top-chrome strip.
+interface ExtentEntry {
+  rect: ElementRect;
+  hittable: boolean | undefined;
 }
 
 // width > 300 keeps the same sanity floor the old heuristic used (ignore
 // degenerate all-tiny snapshots rather than emit a bogus rect).
-function resolveScreenRect(u: ExtentUnion): ElementRect | null {
-  if (u.hitRight > 300 && u.hitBottom > 0) {
-    return { x: 0, y: 0, width: u.hitRight, height: u.hitBottom };
+function extentToRect(right: number, bottom: number): ElementRect | null {
+  return right > 300 && bottom > 0 ? { x: 0, y: 0, width: right, height: bottom } : null;
+}
+
+function resolveScreenRect(entries: ExtentEntry[]): ElementRect | null {
+  let allRight = 0;
+  let allBottom = 0;
+  let hitRight = 0;
+  let hitBottom = 0;
+  const usable: ExtentEntry[] = [];
+  for (const e of entries) {
+    const { x, y, width, height } = e.rect;
+    if (width <= 0 || height <= 0) continue;
+    usable.push(e);
+    allRight = Math.max(allRight, x + width);
+    allBottom = Math.max(allBottom, y + height);
+    if (e.hittable === true) {
+      hitRight = Math.max(hitRight, x + width);
+      hitBottom = Math.max(hitBottom, y + height);
+    }
   }
-  if (u.allRight > 300 && u.allBottom > 0) {
-    return { x: 0, y: 0, width: u.allRight, height: u.allBottom };
+  if (hitRight <= 0 || hitBottom <= 0) return extentToRect(allRight, allBottom);
+
+  // Grow the hittable seed by overlap until stable (bounded — each pass only
+  // ever extends, and stops as soon as nothing new intersects).
+  let right = hitRight;
+  let bottom = hitBottom;
+  for (let pass = 0; pass < 10; pass++) {
+    let grew = false;
+    for (const e of usable) {
+      const { x, y, width, height } = e.rect;
+      const intersects = x < right && y < bottom && x + width > 0 && y + height > 0;
+      if (!intersects) continue;
+      if (x + width > right) {
+        right = x + width;
+        grew = true;
+      }
+      if (y + height > bottom) {
+        bottom = y + height;
+        grew = true;
+      }
+    }
+    if (!grew) break;
   }
-  return null;
+  return extentToRect(right, bottom) ?? extentToRect(allRight, allBottom);
 }
 
 export function updateRefMap(nodes: SnapshotNode[]): void {
   refMap.clear();
   screenRect = null;
 
-  const extent = newExtentUnion();
+  const entries: ExtentEntry[] = [];
   for (const node of nodes) {
     if (!node.ref || !node.rect) continue;
     refMap.set(node.ref, node.rect);
-    accumulateExtent(extent, node.rect, node.hittable);
+    entries.push({ rect: node.rect, hittable: node.hittable });
   }
-  screenRect = resolveScreenRect(extent);
+  screenRect = resolveScreenRect(entries);
 
   lastUpdated = Date.now();
 }
@@ -225,7 +254,7 @@ export function updateRefMapFromFlat(nodes: FlatNode[]): void {
   // Screen rect: hittable-first union with an all-nodes fallback — same
   // rationale as updateRefMap (off-screen mounted rows must not inflate the
   // viewport; a (0,0)-anchored pick is fragile when no node spans the window).
-  const extent = newExtentUnion();
+  const entries: ExtentEntry[] = [];
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
     if (!node.ref || !node.rect) continue;
@@ -238,9 +267,9 @@ export function updateRefMapFromFlat(nodes: FlatNode[]): void {
     metadataMap.set(key, meta);
     hashed.push(node);
 
-    accumulateExtent(extent, node.rect, node.hittable);
+    entries.push({ rect: node.rect, hittable: node.hittable });
   }
-  screenRect = resolveScreenRect(extent);
+  screenRect = resolveScreenRect(entries);
 
   // Hash only the nodes that passed the ref/rect filter: hashSnapshotNodes
   // dereferences node.rect.* unconditionally, and a malformed entry must not

--- a/packages/rn-dev-agent-core/src/tools/device-interact.ts
+++ b/packages/rn-dev-agent-core/src/tools/device-interact.ts
@@ -18,6 +18,7 @@ import {
 } from '../runners/rn-fast-runner-client.js';
 import { stopAndroidRunner } from '../runners/rn-android-runner-client.js';
 import { surfaceKeyboardGuard } from '../runners/keyboard-guard.js';
+import { resolveBundleId } from '../project-config.js';
 import { withSession } from '../utils.js';
 import type { ToolResult } from '../utils.js';
 import { okResult, failResult, createStepTimer } from '../utils.js';
@@ -1179,7 +1180,7 @@ export function createDeviceSwipeHandler(): (args: SwipeArgs) => Promise<ToolRes
             args.x2,
             args.y2,
             args.durationMs,
-            getActiveSession()?.appId,
+            getActiveSession()?.appId ?? resolveBundleId('ios') ?? undefined,
           );
           if (resp.ok) {
             return okResult({
@@ -1226,7 +1227,7 @@ export function createDeviceSwipeHandler(): (args: SwipeArgs) => Promise<ToolRes
             coords.x2,
             coords.y2,
             duration,
-            getActiveSession()?.appId,
+            getActiveSession()?.appId ?? resolveBundleId('ios') ?? undefined,
           );
           if (resp.ok) {
             return okResult({
@@ -1298,7 +1299,7 @@ export function createDeviceScrollHandler(): (args: ScrollArgs) => Promise<ToolR
           x2,
           y2,
           DEFAULT_SWIPE_DURATION_MS,
-          getActiveSession()?.appId,
+          getActiveSession()?.appId ?? resolveBundleId('ios') ?? undefined,
         );
         if (resp.ok) {
           return okResult({

--- a/packages/rn-dev-agent-core/test/smoke/device-smoke.ts
+++ b/packages/rn-dev-agent-core/test/smoke/device-smoke.ts
@@ -234,7 +234,8 @@ test(`Phase B golden set (${PLATFORM})`, { timeout: 900_000 }, async () => {
       (n: any) => n.identifier === 'fixture_count',
     );
     assert.ok(countNode, 'fixture_count missing from the post-press snapshot');
-    assert.match(countNode.label ?? '', /count: 1/, 'counter must increment after press');
+    // Anchored: /count: 1/ unanchored would also match 'count: 10'..'count: 19'.
+    assert.match(countNode.label ?? '', /^count: 1$/, 'counter must increment after press');
 
     // device_scrollintoview does exactly ONE blind swipe when the target is
     // absent from the snapshot (device-interact.ts:1383) — row 80 is several
@@ -280,6 +281,9 @@ test(`Phase B golden set (${PLATFORM})`, { timeout: 900_000 }, async () => {
     );
     assert.equal(into.envelope?.ok, true, `scrollintoview failed: ${into.text.slice(0, 500)}`);
 
+    // Known limitation (accepted): this validates ENCODING only, not content —
+    // a capture of the wrong foreground app would still be a valid image. The
+    // surrounding steps pin what is actually on screen (counter label, rows).
     const shot = record('screenshot', await callTool(s, 'device_screenshot', {}));
     const shotPath = shot.envelope?.data?.path;
     if (shotPath) {

--- a/packages/rn-dev-agent-core/test/unit/story-06-screenrect-system-windows.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/story-06-screenrect-system-windows.test.ts
@@ -1,10 +1,16 @@
 // Story 06 Phase B (#387): the screen rect that direction scroll/swipe compute
-// their gesture from is the UNION BOUNDING BOX of all snapshot node rects. A
-// (0,0)-anchored heuristic was fragile — device-proven on CI Android, where NO
-// node spans the full window (the tallest (0,0) node is a ~128px top-chrome
-// strip while the scrollable list sits at y=570,h=1590), so a "largest (0,0)
-// rect" pick produced a 128px-tall viewport and every direction scroll dragged
-// ~50px in the status bar, never moving the list.
+// their gesture from is a HITTABLE-FIRST union bounding box of snapshot node
+// rects, with an all-nodes fallback. Two device-proven failure modes shaped it:
+//  - A (0,0)-anchored heuristic broke on CI Android, where NO node spans the
+//    full window (the tallest (0,0) node is a ~128px top-chrome strip while the
+//    scrollable list sits at y=570,h=1590) — direction scrolls dragged ~50px in
+//    the status bar and never moved the list.
+//  - An ALL-nodes union is inflatable by off-screen mounted content (post-merge
+//    review finding): both runners keep content-bearing nodes in the snapshot
+//    with real out-of-viewport coords (RN FlatList windowing) marked
+//    hittable:false — including them pushes gestures off the physical screen
+//    and false-passes scrollintoview's isInViewport. Hittable-only excludes
+//    them; the all-nodes fallback covers snapshots without hittable data.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { updateRefMap, getScreenRect } from '../../dist/fast-runner-ref-map.js';
@@ -42,4 +48,37 @@ test('screen rect: a leading status-bar node does not cap the extent', () => {
 test('screen rect: degenerate all-tiny-node snapshot yields null (sanity floor)', () => {
   updateRefMap([{ ref: 'e0', rect: { x: 0, y: 0, width: 40, height: 40 } }] as never);
   assert.equal(getScreenRect(), null);
+});
+
+test('screen rect: off-screen non-hittable nodes do not inflate the viewport', () => {
+  // RN FlatList windowing shape: rows mounted screens past the fold stay in the
+  // tree with real coords but hittable:false. The viewport must come from the
+  // hittable union (874), not the mounted-content extent (4060).
+  updateRefMap([
+    { ref: 'e0', rect: { x: 0, y: 0, width: 402, height: 874 }, hittable: true },
+    { ref: 'e1', rect: { x: 16, y: 800, width: 370, height: 60 }, hittable: true },
+    { ref: 'e2', rect: { x: 16, y: 1200, width: 370, height: 60 }, hittable: false },
+    { ref: 'e3', rect: { x: 16, y: 4000, width: 370, height: 60 }, hittable: false },
+  ] as never);
+  assert.deepEqual(getScreenRect(), { x: 0, y: 0, width: 402, height: 874 });
+});
+
+test('screen rect: falls back to the all-nodes union when no node is hittable', () => {
+  // Older runner artifacts / synthetic snapshots without usable hittable data
+  // keep the pre-hittable behavior instead of yielding null.
+  updateRefMap([
+    { ref: 'e0', rect: { x: 0, y: 0, width: 1080, height: 128 }, hittable: false },
+    { ref: 'e1', rect: { x: 0, y: 570, width: 1080, height: 1590 } },
+  ] as never);
+  assert.deepEqual(getScreenRect(), { x: 0, y: 0, width: 1080, height: 2160 });
+});
+
+test('screen rect: tiny hittable set falls back to the all-nodes union (sanity floor)', () => {
+  // If the only hittable node is a small control, the hittable union fails the
+  // width>300 floor — the all-nodes union is a safer estimate than a 40px rect.
+  updateRefMap([
+    { ref: 'e0', rect: { x: 10, y: 10, width: 40, height: 40 }, hittable: true },
+    { ref: 'e1', rect: { x: 0, y: 0, width: 402, height: 874 }, hittable: false },
+  ] as never);
+  assert.deepEqual(getScreenRect(), { x: 0, y: 0, width: 402, height: 874 });
 });

--- a/packages/rn-dev-agent-core/test/unit/story-06-screenrect-system-windows.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/story-06-screenrect-system-windows.test.ts
@@ -73,12 +73,27 @@ test('screen rect: falls back to the all-nodes union when no node is hittable', 
   assert.deepEqual(getScreenRect(), { x: 0, y: 0, width: 1080, height: 2160 });
 });
 
-test('screen rect: tiny hittable set falls back to the all-nodes union (sanity floor)', () => {
-  // If the only hittable node is a small control, the hittable union fails the
-  // width>300 floor — the all-nodes union is a safer estimate than a 40px rect.
+test('screen rect: tiny hittable seed grows to the overlapping full-window container', () => {
+  // If the only hittable node is a small control, the overlap-growth pulls in
+  // the non-hittable window node that intersects it — the viewport is the
+  // window, not a 40px rect.
   updateRefMap([
     { ref: 'e0', rect: { x: 10, y: 10, width: 40, height: 40 }, hittable: true },
     { ref: 'e1', rect: { x: 0, y: 0, width: 402, height: 874 }, hittable: false },
   ] as never);
   assert.deepEqual(getScreenRect(), { x: 0, y: 0, width: 402, height: 874 });
+});
+
+test('screen rect: partial hittable coverage grows to the window, not the widest control (Codex P2)', () => {
+  // Application/Window hittable:false with only a wide button hittable at the
+  // top: a hittable-only union would collapse the viewport to y=244 and
+  // direction gestures would compute short top-of-screen drags. The window
+  // overlaps the button, so growth recovers the full 852 — while a disjoint
+  // off-screen row (y=2000) stays excluded.
+  updateRefMap([
+    { ref: 'e0', rect: { x: 0, y: 0, width: 390, height: 852 }, hittable: false },
+    { ref: 'e1', rect: { x: 14, y: 200, width: 361, height: 44 }, hittable: true },
+    { ref: 'e2', rect: { x: 0, y: 2000, width: 390, height: 60 }, hittable: false },
+  ] as never);
+  assert.deepEqual(getScreenRect(), { x: 0, y: 0, width: 390, height: 852 });
 });


### PR DESCRIPTION
Post-merge re-review of the Phase B surface by **two independent reviewers** (Claude review agent + Codex via ask-llm, findings cross-validated against source). Six findings total; the top one was **independently found by both**:

**1. (High, both reviewers) Screen rect inflatable by off-screen mounted content.** Both runners keep content-bearing nodes in snapshots with real out-of-viewport coords (RN `FlatList` windowing; non-virtualized `ScrollView` children on iOS, whose `shouldInclude` keeps `hasContent` nodes regardless of visibility) — marked `hittable:false` but included in the all-nodes union, inflating `maxBottom` past the physical screen. Consequences: direction `device_scroll`/`device_swipe` endpoints computed off-screen (silent no-op with `ok:true`), and `scrollintoview`'s `isInViewport` false-passing. Phase B's fixtures (virtualized List/ListView) can't catch it — it's a latent real-RN-app regression. **Fix: hittable-first union** (a visible element is hittable and contributes its own rect, so on-screen targets are always inside) with the all-nodes union as fallback for snapshots without hittable data. Unit-tested: off-screen `y=4000` node excluded; no-hittable + tiny-hittable fallbacks.

**2. (Codex) fastSwipe legacy-session gap** — a persisted pre-#35 session without `appId` made `getActiveSession()?.appId` undefined, reopening the exact host-app-drag bug the param fixed. The three call sites now fall back to `resolveBundleId('ios')` (same backstop `runNative` already had).

**3. (Codex) Integrity-lane SIGPIPE false-fail** — `unzip -l | grep -q` under `pipefail`: grep exits at first match, unzip takes exit 141 on long listings, a successful match reads as red. Listings are now captured once and grepped from a variable.

**4-5. (Codex) Smoke assertions** — counter regex anchored (`/^count: 1$/`; unanchored also matched `count: 10..19`), and the screenshot check's encoding-only scope documented.

**Verified sound by both reviewers** (explicitly checked, no issues): all fastSwipe/drag dispatch paths carry bundleId, workflow injection surface + permission scoping, report-job 2-red logic, artifact sha256/traversal checks, iOS keyboard-guard assertion specificity, launch/probe boundedness.

Full unit suite green (2982).

🤖 Generated with [Claude Code](https://claude.com/claude-code)