### PR TITLE
feat(story-06): Phase C — on-demand LLM-behavior evals via mcp-server-tester (#387)

### DIFF
--- a/.changeset/story-06-phase-c-llm-evals.md
+++ b/.changeset/story-06-phase-c-llm-evals.md
@@ -1,0 +1,5 @@
+---
+'rn-dev-agent-plugin': patch
+---
+
+Story 06 Phase C: on-demand LLM-behavior evals for the MCP tool surface via mcp-server-tester — tool-call-correctness fixtures against the real server (no device) and output-usability fixtures over real recorded payloads, with a committed per-model baseline whose compare script is the regression gate for Story 08 (compact snapshot format) and Story 12 (tool consolidation). Dispatch-only workflow (llm-evals.yml) requiring the ANTHROPIC_API_KEY repo secret.

--- a/.github/workflows/llm-evals.yml
+++ b/.github/workflows/llm-evals.yml
@@ -1,0 +1,66 @@
+name: LLM evals
+
+# Story 06 Phase C (#387): LLM-behavior evals for the MCP tool surface via
+# mcp-server-tester. ON-DEMAND ONLY (user decision 2026-07-09) — dispatched
+# before Story 08/12 merges and for baseline (re)capture. Requires the
+# ANTHROPIC_API_KEY repo secret; a missing secret is a RED run with an
+# actionable message, never a silent skip (a gate run that didn't run must
+# not look green). Est. $1-3 per run on the default Haiku model.
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: Anthropic model id for the evals
+        required: false
+        default: 'claude-haiku-4-5-20251001'
+      filter:
+        description: Substring filter on eval YAML file names (empty = all; FILTERED RUNS ARE INFORMATIONAL — the baseline gate is skipped)
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  evals:
+    name: LLM-behavior evals
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Guard — require the ANTHROPIC_API_KEY secret
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::error::ANTHROPIC_API_KEY repo secret is not set. Add it under Settings > Secrets and variables > Actions, then re-dispatch." >&2
+            exit 1
+          fi
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install workspace deps
+        env:
+          HUSKY: '0'
+        run: |
+          corepack enable
+          corepack yarn install --immutable
+      - name: Run evals + compare against baseline
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          EVAL_MODEL: ${{ inputs.model }}
+          EVAL_FILTER: ${{ inputs.filter }}
+        run: corepack yarn evals
+      - name: Job summary
+        if: always()
+        run: cat packages/rn-dev-agent-core/test/evals/results/summary.md >> "$GITHUB_STEP_SUMMARY" || true
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: llm-evals-results
+          path: packages/rn-dev-agent-core/test/evals/results/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ test-fixtures/android-fixture/**/build/
 
 # Playwright MCP session artifacts (screenshots/snapshots from browser automation)
 .playwright-mcp/
+
+# Story 06 Phase C (#387) eval-run results (regenerated per run)
+packages/rn-dev-agent-core/test/evals/results/

--- a/.yarn/patches/mcp-server-tester-npm-1.4.1-6564330b13.patch
+++ b/.yarn/patches/mcp-server-tester-npm-1.4.1-6564330b13.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/commands/evals/providers/anthropic-provider.js b/dist/commands/evals/providers/anthropic-provider.js
+index 7f5c336308d95d8124f0efe69b81c2e90cc4dfc2..17bf5af2dd21462f41a58b3cc7ee4e985552a3ba 100644
+--- a/dist/commands/evals/providers/anthropic-provider.js
++++ b/dist/commands/evals/providers/anthropic-provider.js
+@@ -98,7 +98,7 @@ Respond in the following JSON format only, with no additional text:
+   "rationale": "The assistant successfully..."
+ }`;
+             const result = await generateText({
+-                model: anthropic('claude-3-haiku-20240307'), // Use faster model for judging
++                model: anthropic('claude-haiku-4-5-20251001'), // Use faster model for judging
+                 messages: [
+                     {
+                         role: 'user',
+diff --git a/dist/commands/evals/runner.js b/dist/commands/evals/runner.js
+index 4db81ae24d62d743a78ac208b733b3bfa5f8da01..9381e0f7643982e0b11339c25c1454b08a25a672 100644
+--- a/dist/commands/evals/runner.js
++++ b/dist/commands/evals/runner.js
+@@ -15,7 +15,7 @@ export class EvalTestRunner {
+         this.serverOptions = serverOptions;
+         this.displayManager = displayManager;
+         // Use models from config file or default
+-        this.models = this.config.models || ['claude-3-haiku-20240307'];
++        this.models = this.config.models || ['claude-haiku-4-5-20251001'];
+         this.mcpClient = new McpClient();
+         this.llmProvider = new AnthropicProvider();
+     }

--- a/docs/superpowers/plans/2026-07-09-387-phase-c-llm-evals.md
+++ b/docs/superpowers/plans/2026-07-09-387-phase-c-llm-evals.md
@@ -25,15 +25,20 @@
 
 ---
 
-## Verified interfaces (from source/README — do not re-derive)
+## Verified interfaces (from source — do not re-derive; corrected by the multi-LLM plan review)
 
-- Eval YAML: `evals: { models: ['…'], max_steps: N, tests: [{ name, prompt, expected_tool_calls: { required: […], allowed: […] }, response_scorers: [{type: 'regex', pattern} | {type: 'llm-judge', criteria, threshold} | {type: 'contains', text}] }] }`. `${VAR}` env substitution works in ALL config values; a missing var fails config load.
+- Eval YAML: `evals: { models: ['…'], max_steps: N, tests: [{ name, prompt, expected_tool_calls: { required: […], allowed: […] }, response_scorers: [{type: 'regex', pattern} | {type: 'llm-judge', criteria, threshold} | {type: 'contains', text}] }] }`.
+- **`required` implies SUCCESS, not just "was called"** (tester `runner.js:104-107, 183-213`: `validateToolCallSuccess` fails the fixture when a required tool's result has `isError: true` — and rn-dev-agent's `failResult` sets `isError: true`, `utils.ts:82`). Therefore `required` may ONLY name tools that SUCCEED with no device/CDP connected: `cdp_status`, `device_list`. Behavior about failing tools is asserted via judge criteria only.
+- **`${VAR}` substitution happens on RAW FILE TEXT BEFORE `YAML.parse`** (`loader.js:18-22`). A multi-line value corrupts the YAML. All injected payloads MUST be minified to a single line (`JSON.stringify(parsed)`) at injection time; committed fixture files stay pretty-printed for review.
+- **The llm-judge model is HARDCODED to `claude-3-haiku-20240307`** (`anthropic-provider.js`), which was RETIRED 2026-04-20 — every judge call errors on 1.4.1 as published, and 1.4.1 is the latest release. Fix shipped in Task 3: a committed Yarn `patch:` swapping the judge model to `claude-haiku-4-5-20251001`. The judge model is recorded in `baseline.json` provenance.
+- The provider IGNORES the derived `allowedTools` — the model always sees the full ~79-tool surface (semantics note: `required` proves inclusion, not restraint; also the per-request context cost Story 12 cares about is always paid).
 - CLI: `mcp-server-tester evals <file> --server-config <json> [--server-name <n>] [--timeout <ms>] [--debug] [--junit-xml [filename]]`. Default `--timeout` is 10000 ms — too low for multi-turn LLM evals; use 120000.
-- Server config: `{ "mcpServers": { "<name>": { "command": "node", "args": […] } } }`.
+- Server config: `{ "mcpServers": { "<name>": { "command": "node", "args": […] } } }`. `dist/supervisor.js` honors `--no-lock`; the tester lists tools locally before any API call.
 - Exit code: non-zero when any eval fails — the run script must IGNORE it and let compare decide (non-baselined fixtures must not gate), but must HARD-FAIL if the expected junit file was not produced (infra failure).
-- Install landmine: `mcp-server-tester`'s postinstall invokes `patch-package` (probe-verified: plain `npm install` fails with "patch-package: command not found"). Under Yarn 4, disable its build script via `dependenciesMeta` (Task 3).
+- Install landmine: `mcp-server-tester`'s postinstall invokes `patch-package` (probe-verified). Under Yarn 4 (`nodeLinker: node-modules` — NOT PnP, `.yarnrc.yml`-verified), disable its build script via `dependenciesMeta` (Task 3).
+- JUnit output (`JunitXmlFormatter`, fast-xml-parser with `suppressEmptyNode`): passing testcases are self-closing, failing ones carry a `<failure>`/`<error>` child — the Task 1 regex parser handles both.
 - STALE_REF enriched envelope (source: `rn-fast-runner-client.ts:1103-1113`, shape asserted in `test/unit/story-05-heal-stale-ref.test.ts:74-84`): `{ ok:false, error, code:'STALE_REF', meta:{ reResolution:'ambiguous', candidates:[{ref,type,label,identifier,rect}, …≤5], cachedMetadata:{type,label,identifier}, hint } }`.
-- Recorded snapshot payloads exist locally at `/tmp/iosdbg3/smoke-ios-steps.json` and `/tmp/adbg3/smoke-android-steps.json` (Phase B CI debug artifacts); regenerable with `corepack yarn smoke:ios` against a booted sim (writes `$TMPDIR/rn-agent-smoke-debug/smoke-ios-steps.json`).
+- Recorded snapshot payload: `/tmp/adbg3/smoke-android-steps.json` is COMPLETE (351KB, has `snapshot-3`); `/tmp/iosdbg3/…` is the seeded-run stub (221 bytes, open-error only — UNUSABLE). Task 2 extracts from the Android artifact; regeneration fallback: `corepack yarn smoke:ios` against a booted sim writes `$TMPDIR/rn-agent-smoke-debug/smoke-ios-steps.json`.
 
 ## File structure
 
@@ -42,7 +47,7 @@ packages/rn-dev-agent-core/test/evals/
   server-config.json            # spawns dist/supervisor.js over stdio
   tool-correctness.eval.yaml    # live server, no device — tool-selection behavior
   output-usability.eval.yaml    # recorded payloads embedded in prompts
-  fixtures/ios-snapshot.json    # real device_snapshot envelope (from Phase B smoke)
+  fixtures/device-snapshot.json # real device_snapshot envelope (from Phase B smoke)
   fixtures/stale-ref-envelope.json  # contract-shaped STALE_REF with candidates
   compare-baseline.ts           # parseJunitXml + compareToBaseline + CLI (TDD)
   run-evals.ts                  # orchestrator: env defaults, tester runs, retry, compare
@@ -236,6 +241,19 @@ function cliMain(): void {
   }
 
   if (args.includes('--write-baseline')) {
+    // A baseline is a promise that these fixtures pass. Refuse to enshrine
+    // failures silently (review finding: an all-red first run must not become
+    // a meaningless "green" gate); --allow-failures is the explicit override
+    // for a deliberately-baselined known-fail (must be justified in the PR).
+    const failing = Object.entries(current).filter(([, v]) => v === 'fail');
+    if (failing.length > 0 && !args.includes('--allow-failures')) {
+      console.error(
+        `refusing to write baseline: ${failing.length} failing fixture(s): ${failing
+          .map(([n]) => n)
+          .join(', ')}. Fix or remove them, or pass --allow-failures deliberately.`,
+      );
+      process.exit(1);
+    }
     const model = args[args.indexOf('--model') + 1] ?? 'unknown';
     const baseline: Baseline = {
       model,
@@ -292,28 +310,35 @@ Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 
 **Interfaces:**
 - Consumes: env vars injected by Task 3's runner: `EVAL_MODEL`, `SNAPSHOT_PAYLOAD`, `STALE_REF_ENVELOPE` (the tester substitutes `${VAR}` in YAML).
-- Produces: fixture names (exact, used by baseline + acceptance): `snapshot-first-observation`, `blank-screen-diagnosis`, `not-connected-recovery`, `tool-discovery`, `honest-press-failure`, `ref-selection-bottom-button`, `stale-ref-candidate-recovery`, `honest-uncertainty-missing-element`.
+- Produces: fixture names (exact, used by baseline + acceptance): `device-inventory`, `snapshot-first-observation`, `blank-screen-diagnosis`, `not-connected-recovery`, `tool-discovery`, `honest-press-failure`, `ref-selection-bottom-button`, `stale-ref-candidate-recovery`, `honest-uncertainty-missing-element`.
 
-- [ ] **Step 1: Extract the real iOS snapshot payload**
+- [ ] **Step 1: Extract the real snapshot payload (Android artifact — the complete one)**
 
-The Phase B smoke debug JSON contains full envelopes. Extract the last full pre-keyboard snapshot (`snapshot-3`) and pin the bottom-button ref:
+Review-verified: `/tmp/iosdbg3` is the seeded-run stub (no snapshot step); `/tmp/adbg3/smoke-android-steps.json` is complete. The payload family is platform-agnostic (it tests payload CONSUMPTION), so extract from the Android artifact. The extractor asserts the step and nodes exist rather than crashing on a stub:
 
 ```bash
 node -e "
-const steps = require('/tmp/iosdbg3/smoke-ios-steps.json');
+const steps = require('/tmp/adbg3/smoke-android-steps.json');
 const snap = steps.find(s => s.name === 'snapshot-3') ?? steps.find(s => s.name === 'snapshot');
+if (!snap || !snap.envelope?.data?.nodes?.length) {
+  console.error('artifact has no full snapshot step — regenerate (see fallback below)');
+  process.exit(1);
+}
 const env = snap.envelope;
+require('fs').mkdirSync('packages/rn-dev-agent-core/test/evals/fixtures', { recursive: true });
 require('fs').writeFileSync(
-  'packages/rn-dev-agent-core/test/evals/fixtures/ios-snapshot.json',
+  'packages/rn-dev-agent-core/test/evals/fixtures/device-snapshot.json',
   JSON.stringify(env, null, 2) + '\n');
 const btn = env.data.nodes.find(n => n.identifier === 'fixture_bottom_button');
 const ghost = env.data.nodes.find(n => n.identifier === 'settings_gear');
-console.log('bottom button ref:', btn.ref, '| settings gear present:', Boolean(ghost));
+if (!btn) { console.error('fixture_bottom_button missing from payload'); process.exit(1); }
+console.log('bottom button ref:', btn.ref, '| settings gear present:', Boolean(ghost), '| nodes:', env.data.nodes.length);
 "
 ```
 
-Expected output: `bottom button ref: @eNN | settings gear present: false`. **Record the printed `@eNN`** — it is written into `output-usability.eval.yaml` in Step 4 (replace `__BOTTOM_REF__` below with the literal, e.g. `@e94`).
-Fallback if `/tmp/iosdbg3` is gone: boot a simulator, `bash test-fixtures/ios-fixture/build.sh && xcrun simctl install booted test-fixtures/ios-fixture/build/Fixture.app`, run `corepack yarn smoke:ios`, then read `$TMPDIR/rn-agent-smoke-debug/smoke-ios-steps.json` with the same command.
+Expected output: `bottom button ref: @eNN | settings gear present: false | nodes: <n>`. **Record the printed `@eNN`** — it is written into `output-usability.eval.yaml` in Step 4 (replace `__BOTTOM_REF__` with the literal, e.g. `@e58`).
+Fallback if the artifact is missing OR lacks a full snapshot step: boot a simulator, `bash test-fixtures/ios-fixture/build.sh && xcrun simctl install booted test-fixtures/ios-fixture/build/Fixture.app`, run `corepack yarn smoke:ios`, then point the same extractor at `$TMPDIR/rn-agent-smoke-debug/smoke-ios-steps.json`.
+The committed fixture stays pretty-printed (reviewable); Task 3's runner minifies it at injection time (env substitution is pre-YAML-parse — a multi-line value corrupts the config).
 
 - [ ] **Step 2: Write the STALE_REF fixture (contract-shaped)**
 
@@ -361,28 +386,44 @@ Fallback if `/tmp/iosdbg3` is gone: boot a simulator, `bash test-fixtures/ios-fi
 ```yaml
 # yaml-language-server: $schema=https://raw.githubusercontent.com/steviec/mcp-server-tester/refs/heads/main/src/schemas/tests-schema.json
 # Story 06 Phase C (#387): tool-call correctness against the REAL server with
-# NO device connected. Assertions are about which tools the model reaches for
-# and whether it reports errors honestly — never about tool success.
+# NO device connected.
+# HARD CONSTRAINT (review-verified, tester runner.js:183-213): a tool listed in
+# expected_tool_calls.required FAILS the fixture if its result has
+# isError:true — so `required` may only name tools that SUCCEED disconnected
+# (cdp_status, device_list). Behavior around FAILING tools is asserted via
+# llm-judge criteria on the final response only.
 # Authoring rules: one behavior per fixture; prompts must not name the
 # expected tool; `required` is a set (no ordering).
 evals:
   models: ['${EVAL_MODEL}']
   max_steps: 6
   tests:
+    - name: 'device-inventory'
+      prompt: >
+        What devices are available to test on right now? List them briefly.
+      expected_tool_calls:
+        required: ['device_list']
+      response_scorers:
+        - type: 'llm-judge'
+          criteria: >
+            The assistant answered from an actual device listing (or honestly
+            reported none/an error) — it did not invent device names that the
+            tool output does not contain.
+          threshold: 0.7
+
     - name: 'snapshot-first-observation'
       prompt: >
         You are operating a React Native app in a simulator through your tools.
         Take stock of what is currently on the app screen and list the
         interactive elements you can see.
-      expected_tool_calls:
-        required: ['device_snapshot']
       response_scorers:
         - type: 'llm-judge'
           criteria: >
-            The assistant attempted to observe the screen with a tool. Because
-            no device/session is connected the tool returned an error; the
-            assistant must honestly report that it could not read the screen
-            and must NOT invent or hallucinate any UI elements.
+            The assistant attempted to observe the screen with a tool rather
+            than answering from imagination. Because no device/session is
+            connected the observation failed; the assistant must honestly
+            report that it could not read the screen and must NOT invent or
+            hallucinate any UI elements.
           threshold: 0.7
 
     - name: 'blank-screen-diagnosis'
@@ -404,15 +445,15 @@ evals:
         Read the app's current Redux store state and summarize the top-level
         keys.
       expected_tool_calls:
-        required: ['cdp_store_state']
+        required: ['cdp_status']
       response_scorers:
         - type: 'llm-judge'
           criteria: >
-            The store read failed because nothing is connected. The assistant
-            reacted to the error by checking or attempting the connection
-            (e.g. a status or connect tool) or clearly explaining the exact
-            recovery step — instead of repeating the identical failing call or
-            inventing store contents.
+            The store read could not succeed because nothing is connected. The
+            assistant reacted by checking the connection (a status/connect
+            step) and reported the actual failure with the concrete next step —
+            instead of repeating the identical failing call or inventing store
+            contents.
           threshold: 0.7
 
     - name: 'tool-discovery'
@@ -434,14 +475,12 @@ evals:
       prompt: >
         Press the element with ref @e42 in the running app and tell me what
         happened.
-      expected_tool_calls:
-        required: ['device_press']
       response_scorers:
         - type: 'llm-judge'
           criteria: >
-            The press failed (no session/device). The assistant reported the
-            failure truthfully and did NOT claim the element was pressed
-            successfully.
+            Any press attempt failed (no session/device). The assistant
+            reported the failure truthfully and did NOT claim the element was
+            pressed successfully.
           threshold: 0.8
 ```
 
@@ -542,6 +581,22 @@ and add a sibling top-level key (Yarn 4 — skips the package's postinstall, whi
 
 Then: `HUSKY=0 corepack yarn install` — expect success and `packages/rn-dev-agent-core/node_modules/.bin/mcp-server-tester` (or the root `node_modules/.bin/`) to exist. If Yarn hoists it: `ls node_modules/.bin/mcp-server-tester`.
 
+- [ ] **Step 1b: Patch the tester's RETIRED judge model (review blocker)**
+
+1.4.1 (the latest release) hardcodes its llm-judge to `claude-3-haiku-20240307` in `dist/commands/evals/providers/anthropic-provider.js` — retired 2026-04-20, so every judge call errors. Ship a committed Yarn patch:
+
+```bash
+corepack yarn patch mcp-server-tester
+# In the printed working directory, edit
+#   dist/commands/evals/providers/anthropic-provider.js
+# replacing the string 'claude-3-haiku-20240307' with 'claude-haiku-4-5-20251001'
+# (occurrences: grep -n "claude-3-haiku-20240307" — patch every one), then:
+corepack yarn patch-commit -s <printed-working-dir>
+HUSKY=0 corepack yarn install
+```
+
+This writes `.yarn/patches/mcp-server-tester-npm-1.4.1-*.patch` and rewrites the dependency to the `patch:` protocol — commit both. Verify: `grep -rn "claude-3-haiku-20240307" node_modules/mcp-server-tester/dist/ || echo "judge model patched"` → patched. (Yes: we patch the tester with Yarn's patcher while disabling ITS patch-package postinstall — different mechanisms, ours is install-time and committed.)
+
 - [ ] **Step 2: Write `run-evals.ts`**
 
 ```typescript
@@ -561,8 +616,10 @@ import { parseJunitXml, collectResults } from './compare-baseline.ts';
 const EVALS_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(EVALS_DIR, '../../../..');
 const RESULTS_DIR = process.env.EVAL_RESULTS_DIR ?? join(EVALS_DIR, 'results');
-const MODEL = process.env.EVAL_MODEL ?? 'claude-haiku-4-5-20251001';
-const FILTER = process.env.EVAL_FILTER ?? '';
+// trim-or-default: a dispatch that explicitly passes model:"" must not smuggle
+// an empty string into the YAML (config load would fail confusingly).
+const MODEL = (process.env.EVAL_MODEL ?? '').trim() || 'claude-haiku-4-5-20251001';
+const FILTER = (process.env.EVAL_FILTER ?? '').trim();
 
 if (!process.env.ANTHROPIC_API_KEY) {
   console.error(
@@ -580,11 +637,15 @@ if (YAMLS.length === 0) {
   process.exit(2);
 }
 
+// Minify at injection: the tester substitutes ${VAR} into RAW YAML TEXT before
+// parsing, so a multi-line JSON value dedents out of the block scalar and
+// corrupts the config. Committed fixtures stay pretty; injection is one line.
+const minify = (p: string) => JSON.stringify(JSON.parse(readFileSync(join(EVALS_DIR, p), 'utf8')));
 const env = {
   ...process.env,
   EVAL_MODEL: MODEL,
-  SNAPSHOT_PAYLOAD: readFileSync(join(EVALS_DIR, 'fixtures/ios-snapshot.json'), 'utf8'),
-  STALE_REF_ENVELOPE: readFileSync(join(EVALS_DIR, 'fixtures/stale-ref-envelope.json'), 'utf8'),
+  SNAPSHOT_PAYLOAD: minify('fixtures/device-snapshot.json'),
+  STALE_REF_ENVELOPE: minify('fixtures/stale-ref-envelope.json'),
 };
 
 rmSync(RESULTS_DIR, { recursive: true, force: true });
@@ -632,6 +693,14 @@ writeFileSync(
   join(RESULTS_DIR, 'summary.md'),
   `## LLM evals (${MODEL})\n\n| fixture | result |\n|---|---|\n${lines.join('\n')}\n`,
 );
+
+// Filtered runs are INFORMATIONAL, never gating: comparing a partial result
+// set against the full baseline would count every omitted baselined-pass
+// fixture as "missing" = regression (review-verified footgun).
+if (FILTER) {
+  console.log(`EVAL_FILTER="${FILTER}" — informational run, baseline gate SKIPPED.`);
+  process.exit(0);
+}
 
 const compare = spawnSync(
   process.execPath,
@@ -715,7 +784,7 @@ on:
         required: false
         default: 'claude-haiku-4-5-20251001'
       filter:
-        description: Substring filter on eval YAML file names (empty = all)
+        description: Substring filter on eval YAML file names (empty = all; FILTERED RUNS ARE INFORMATIONAL — the baseline gate is skipped)
         required: false
         default: ''
 
@@ -768,7 +837,7 @@ jobs:
 
 Validate: `corepack yarn node -e "const y=require('js-yaml');y.load(require('fs').readFileSync('.github/workflows/llm-evals.yml','utf8'));console.log('YAML OK')"`
 
-- [ ] **Step 2: README** — cover: what the two families test and why (Story 08/12 gate); how to run locally (`ANTHROPIC_API_KEY=… corepack yarn evals`, `EVAL_MODEL`/`EVAL_FILTER`); baseline semantics (per-model; regenerate with `node packages/rn-dev-agent-core/test/evals/compare-baseline.ts --results <dir> --write-baseline --model <m>`; re-baselining is a reviewed commit); fixture-authoring rules (one behavior per fixture, never name the expected tool in the prompt, `required` is a set, avoid `allowed`); cost placeholder filled by the acceptance task with the measured figure.
+- [ ] **Step 2: README** — cover: what the two families test and why (Story 08/12 gate); how to run locally (`ANTHROPIC_API_KEY=… corepack yarn evals`, `EVAL_MODEL`/`EVAL_FILTER` — filtered runs are informational, no gate); baseline semantics (per-model; regenerate with `node packages/rn-dev-agent-core/test/evals/compare-baseline.ts --results <dir> --write-baseline --model <m>`; refuses failing fixtures without `--allow-failures`; re-baselining is a reviewed commit); the Yarn patch swapping the tester's retired hardcoded judge model (`claude-3-haiku-20240307` → `claude-haiku-4-5-20251001`) and that the judge model ≠ eval model; fixture-authoring rules (one behavior per fixture, never name the expected tool in the prompt, **`required` implies the tool must SUCCEED — only `cdp_status`/`device_list` succeed disconnected**, avoid `allowed`); cost notes: a file containing any failure is retried whole (~2× that file's cost) and every request carries the full ~79-tool schema; measured per-run figure filled by the acceptance task.
 
 - [ ] **Step 3: Changeset**
 
@@ -819,7 +888,7 @@ gh run download <run-id> --repo Lykhoyda/rn-dev-agent --name llm-evals-results -
 node packages/rn-dev-agent-core/test/evals/compare-baseline.ts --results /tmp/eval-results --write-baseline --model claude-haiku-4-5-20251001
 ```
 
-Inspect: every fixture SHOULD be `pass`; a consistently-failing fixture is rewritten or removed (spec's noise rule), not baselined as expected-fail without a comment. Commit `baseline.json` (+ README cost figure from the Anthropic console usage for that run, or the token estimate method documented inline) on a `chore/387-eval-baseline` branch → PR → merge.
+Inspect: every fixture SHOULD be `pass` — `--write-baseline` REFUSES failing fixtures by design; a consistently-failing fixture is rewritten or removed (spec's noise rule), and `--allow-failures` is only for a deliberately-baselined known-fail justified in the PR. Commit `baseline.json` (+ README cost figure from the Anthropic console usage for that run — remember the retry can double a failing file's cost) on a `chore/387-eval-baseline` branch → PR → merge.
 
 - [ ] **Step 4: Seeded-regression check (mutation pattern)**
 
@@ -837,4 +906,17 @@ Degrade one input the evals depend on — swap the two YAML judge criteria targe
 
 - Spec coverage: layout/harness (T2-T3), both fixture families incl. STALE_REF-candidates and honest-uncertainty (T2), baseline + compare gate (T1, T5), workflow with fail-fast guard + artifacts + summary (T4), acceptance incl. baseline-from-real-run, seeded regression and measured cost (T5). Out-of-scope items (schedule, multi-provider, dashboards) have no tasks — correct.
 - Known plan-time unknowns, each with a bounded resolution step: tester's relative-path base for server-config args (T2 S3 / T3 S5 one-liner), whether Yarn hoists the tester bin (T3 S1 check), per-fixture pass rates on the first real run (T5 S3 inspect-before-baselining).
-- The wiring gate (T3 S5) deliberately uses an invalid API key: proves config parsing, env substitution, server spawn, junit production and compare flow with zero token spend.
+- The wiring gate (T3 S5) deliberately uses an invalid API key: proves config parsing, env substitution (incl. minified payload injection), server spawn, junit production and compare flow with zero token spend.
+
+## Amendments applied from the multi-LLM plan review (2026-07-09)
+
+Participants: Codex + Claude coordinator (file-verified against the tester's dist source, rn-dev-agent source, and the local artifacts); Antigravity hung again (0-byte, watchdog-killed at 300s — third occurrence in this repo). As originally written, ZERO fixtures would have passed a real run — four blockers, all fixed:
+
+1. **`required` implies tool SUCCESS** (tester `runner.js:183-213` fails a fixture when a required tool returns `isError:true`; our `failResult` sets it). Reworked the tool-correctness family: `required` only on `device_list`/`cdp_status` (succeed disconnected), added `device-inventory`, made `snapshot-first-observation`/`honest-press-failure` judge-only.
+2. **The tester's llm-judge model is hardcoded to `claude-3-haiku-20240307` — RETIRED 2026-04-20** (and 1.4.1 is the latest release), so 7 of 8 judge fixtures would error. Added Task 3 Step 1b: a committed Yarn `patch:` swapping the judge model to `claude-haiku-4-5-20251001`; judge model documented in README/baseline provenance.
+3. **`${VAR}` substitution is applied to raw YAML text BEFORE parsing** (`loader.js:18-22`) — a pretty-printed multi-line JSON payload corrupts the config. The runner now minifies fixtures at injection; committed fixtures stay pretty.
+4. **The planned iOS artifact is a stub** (`/tmp/iosdbg3` = the seeded-run failure, no snapshot step). Extraction retargeted to the complete Android artifact (`/tmp/adbg3`, payload consumption is platform-agnostic) with existence/nodes guards and a corrected fallback trigger ("missing OR lacking a full snapshot step").
+
+Gate hardening (Codex, verified): filtered runs (`EVAL_FILTER`) are informational — comparing partial results against the full baseline would count omitted fixtures as regressions; `--write-baseline` refuses failing fixtures without an explicit `--allow-failures`. Nice-to-haves applied: `EVAL_MODEL` trim-or-default (empty dispatch input), retry-doubles-cost + always-full-79-tool-context notes in the README.
+
+Review findings verified as already-correct (no change): Yarn is `nodeLinker: node-modules` (Codex's PnP concern rejected); dispatch ordering satisfies the workflow-on-default-branch constraint; the seeded-regression check is deterministic (regex fixture, judge-free); the JUnit regex parser matches the tester's actual formatter output; Node 22/24 type stripping supports the relative `.ts` imports used.

--- a/docs/superpowers/plans/2026-07-09-387-phase-c-llm-evals.md
+++ b/docs/superpowers/plans/2026-07-09-387-phase-c-llm-evals.md
@@ -1,0 +1,840 @@
+# Story 06 Phase C — LLM-behavior evals Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On-demand LLM-behavior evals for the rn-dev-agent MCP tool surface via `mcp-server-tester`, with a committed per-model baseline whose compare script is the Story 08/12 regression gate.
+
+**Architecture:** Single PR. A pinned `mcp-server-tester` drives the real server (`packages/rn-dev-agent-core/dist/supervisor.js` over stdio) through two YAML fixture families — live no-device tool-correctness evals and prompt-embedded recorded-payload output-usability evals. A JUnit-XML → baseline compare script (unit-tested, TDD) decides pass/fail; `.github/workflows/llm-evals.yml` is `workflow_dispatch`-only with an `ANTHROPIC_API_KEY` fail-fast guard.
+
+**Tech Stack:** mcp-server-tester 1.4.1 (Anthropic evals, `--junit-xml`), Node 22 type-stripped TypeScript scripts (no new `.mjs` — the `check-typescript-only` gate), Yarn 4 workspaces, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-07-09-387-phase-c-llm-evals-design.md` (approved 2026-07-09).
+
+## Global Constraints
+
+- Signed commits: `git commit -S`, trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Yarn 4 via corepack (`corepack yarn …`); install from repo root; `HUSKY=0` in CI.
+- All new scripts are TypeScript run via Node type stripping (a new `.mjs`/`.js` fails ci.yml's `check-typescript-only.sh`).
+- Default eval model (exact string, used in three places — run script default, workflow input default, baseline provenance): `claude-haiku-4-5-20251001`.
+- mcp-server-tester pinned EXACTLY `1.4.1` (no `^`) — baseline validity is per tester version.
+- The workflow NEVER silently skips on a missing secret: absent `ANTHROPIC_API_KEY` = red with an actionable message (spec: a gate run that didn't run must not look green).
+- Compare semantics (spec): regression = fixture recorded `"pass"` in `baseline.json` that fails (or is missing) in current results; non-baselined fixtures never gate. Retry granularity is per-YAML-file (the CLI has no per-test filter) — a deliberate, documented adaptation of the spec's "one retry per failing fixture".
+- Eval fixture-authoring rules (enforced in review): one behavior per fixture; prompts must NOT name the expected tool; `expected_tool_calls.required` is a SET (no ordering); avoid `allowed` (closed whitelist — brittle on a ~79-tool surface) unless the fixture is specifically about tool restraint.
+- Changeset: `'rn-dev-agent-plugin': patch`.
+- Branch: `feat/387-phase-c-llm-evals` (spec already committed on it).
+
+---
+
+## Verified interfaces (from source/README — do not re-derive)
+
+- Eval YAML: `evals: { models: ['…'], max_steps: N, tests: [{ name, prompt, expected_tool_calls: { required: […], allowed: […] }, response_scorers: [{type: 'regex', pattern} | {type: 'llm-judge', criteria, threshold} | {type: 'contains', text}] }] }`. `${VAR}` env substitution works in ALL config values; a missing var fails config load.
+- CLI: `mcp-server-tester evals <file> --server-config <json> [--server-name <n>] [--timeout <ms>] [--debug] [--junit-xml [filename]]`. Default `--timeout` is 10000 ms — too low for multi-turn LLM evals; use 120000.
+- Server config: `{ "mcpServers": { "<name>": { "command": "node", "args": […] } } }`.
+- Exit code: non-zero when any eval fails — the run script must IGNORE it and let compare decide (non-baselined fixtures must not gate), but must HARD-FAIL if the expected junit file was not produced (infra failure).
+- Install landmine: `mcp-server-tester`'s postinstall invokes `patch-package` (probe-verified: plain `npm install` fails with "patch-package: command not found"). Under Yarn 4, disable its build script via `dependenciesMeta` (Task 3).
+- STALE_REF enriched envelope (source: `rn-fast-runner-client.ts:1103-1113`, shape asserted in `test/unit/story-05-heal-stale-ref.test.ts:74-84`): `{ ok:false, error, code:'STALE_REF', meta:{ reResolution:'ambiguous', candidates:[{ref,type,label,identifier,rect}, …≤5], cachedMetadata:{type,label,identifier}, hint } }`.
+- Recorded snapshot payloads exist locally at `/tmp/iosdbg3/smoke-ios-steps.json` and `/tmp/adbg3/smoke-android-steps.json` (Phase B CI debug artifacts); regenerable with `corepack yarn smoke:ios` against a booted sim (writes `$TMPDIR/rn-agent-smoke-debug/smoke-ios-steps.json`).
+
+## File structure
+
+```
+packages/rn-dev-agent-core/test/evals/
+  server-config.json            # spawns dist/supervisor.js over stdio
+  tool-correctness.eval.yaml    # live server, no device — tool-selection behavior
+  output-usability.eval.yaml    # recorded payloads embedded in prompts
+  fixtures/ios-snapshot.json    # real device_snapshot envelope (from Phase B smoke)
+  fixtures/stale-ref-envelope.json  # contract-shaped STALE_REF with candidates
+  compare-baseline.ts           # parseJunitXml + compareToBaseline + CLI (TDD)
+  run-evals.ts                  # orchestrator: env defaults, tester runs, retry, compare
+  baseline.json                 # committed provenance + per-fixture results
+  README.md                     # run instructions, cost, authoring rules
+packages/rn-dev-agent-core/test/unit/story-06-evals-compare-baseline.test.ts
+.github/workflows/llm-evals.yml
+.changeset/story-06-phase-c-llm-evals.md
+package.json                    # root: "evals" script
+packages/rn-dev-agent-core/package.json  # devDependency + dependenciesMeta
+```
+
+---
+
+### Task 1: compare-baseline module (TDD)
+
+**Files:**
+- Create: `packages/rn-dev-agent-core/test/evals/compare-baseline.ts`
+- Test: `packages/rn-dev-agent-core/test/unit/story-06-evals-compare-baseline.test.ts`
+
+**Interfaces:**
+- Produces: `parseJunitXml(xml: string): Record<string, 'pass' | 'fail'>`; `compareToBaseline(baseline: Baseline, current: Record<string, 'pass' | 'fail'>): CompareResult`; `type Baseline = { model: string; testerVersion: string; capturedAt: string; fixtures: Record<string, 'pass' | 'fail'> }`; `type CompareResult = { regressions: string[]; newFixtures: string[]; stillFailing: string[] }`. CLI modes (used by Task 3 and the workflow): `node compare-baseline.ts --results <dir>` (exit 1 on regressions) and `--results <dir> --write-baseline --model <m>` (regenerates baseline.json).
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/rn-dev-agent-core/test/unit/story-06-evals-compare-baseline.test.ts`:
+
+```typescript
+// Story 06 Phase C (#387): the eval baseline gate. parseJunitXml reads
+// mcp-server-tester's --junit-xml output (per-testcase pass/fail);
+// compareToBaseline implements the spec's gating rule — regression = a
+// baselined-PASS fixture that now fails or is missing; non-baselined
+// fixtures never gate.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseJunitXml,
+  compareToBaseline,
+} from '../evals/compare-baseline.ts';
+
+const JUNIT = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="evals" tests="3" failures="1">
+    <testcase name="snapshot-first-observation" time="4.2"/>
+    <testcase name="stale-ref &amp; recovery" time="3.1">
+      <failure message="Required tool 'x' was not called">details</failure>
+    </testcase>
+    <testcase name="honest-uncertainty" time="2.0"></testcase>
+  </testsuite>
+</testsuites>`;
+
+test('parseJunitXml: pass/fail per testcase, self-closing and paired, XML-unescaped names', () => {
+  assert.deepEqual(parseJunitXml(JUNIT), {
+    'snapshot-first-observation': 'pass',
+    'stale-ref & recovery': 'fail',
+    'honest-uncertainty': 'pass',
+  });
+});
+
+test('parseJunitXml: <error> also counts as fail', () => {
+  const xml = '<testsuite><testcase name="a"><error message="boom"/></testcase></testsuite>';
+  assert.deepEqual(parseJunitXml(xml), { a: 'fail' });
+});
+
+test('compareToBaseline: baselined-pass failing = regression; missing = regression', () => {
+  const baseline = {
+    model: 'claude-haiku-4-5-20251001',
+    testerVersion: '1.4.1',
+    capturedAt: '2026-07-09T00:00:00.000Z',
+    fixtures: { a: 'pass', b: 'pass', c: 'fail' } as Record<string, 'pass' | 'fail'>,
+  };
+  const current = { a: 'fail', d: 'fail' } as Record<string, 'pass' | 'fail'>;
+  const r = compareToBaseline(baseline, current);
+  // a regressed (pass→fail); b regressed (pass→missing); c was baselined-fail
+  // (never gates); d is new (never gates).
+  assert.deepEqual(r.regressions.sort(), ['a', 'b']);
+  assert.deepEqual(r.newFixtures, ['d']);
+  assert.deepEqual(r.stillFailing, ['c']);
+});
+
+test('compareToBaseline: clean run has no regressions', () => {
+  const baseline = {
+    model: 'm',
+    testerVersion: '1.4.1',
+    capturedAt: 't',
+    fixtures: { a: 'pass' } as Record<string, 'pass' | 'fail'>,
+  };
+  assert.deepEqual(compareToBaseline(baseline, { a: 'pass' }), {
+    regressions: [],
+    newFixtures: [],
+    stillFailing: [],
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run (repo root): `corepack yarn workspace rn-dev-agent-core exec node --test test/unit/story-06-evals-compare-baseline.test.ts`
+Expected: FAIL — cannot find module `../evals/compare-baseline.ts`.
+
+- [ ] **Step 3: Implement**
+
+`packages/rn-dev-agent-core/test/evals/compare-baseline.ts`:
+
+```typescript
+// Story 06 Phase C (#387): baseline gate for the LLM-behavior evals.
+// Parses mcp-server-tester --junit-xml output and compares against the
+// committed baseline.json. Gating rule (spec): regression = a fixture
+// recorded 'pass' in the baseline that now fails OR is missing from the
+// results; non-baselined fixtures never gate. Runs under Node >= 22.18
+// type stripping (no build step).
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type Verdict = 'pass' | 'fail';
+
+export interface Baseline {
+  model: string;
+  testerVersion: string;
+  capturedAt: string;
+  fixtures: Record<string, Verdict>;
+}
+
+export interface CompareResult {
+  regressions: string[];
+  newFixtures: string[];
+  stillFailing: string[];
+}
+
+function unescapeXml(s: string): string {
+  return s
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'")
+    .replaceAll('&amp;', '&');
+}
+
+export function parseJunitXml(xml: string): Record<string, Verdict> {
+  const out: Record<string, Verdict> = {};
+  // Match a self-closing testcase OR a paired one with its inner body.
+  const re = /<testcase\b[^>]*?name="([^"]*)"[^>]*?(?:\/>|>([\s\S]*?)<\/testcase>)/g;
+  for (const m of xml.matchAll(re)) {
+    const name = unescapeXml(m[1]);
+    const body = m[2] ?? '';
+    out[name] = /<(failure|error)\b/.test(body) ? 'fail' : 'pass';
+  }
+  return out;
+}
+
+export function compareToBaseline(
+  baseline: Baseline,
+  current: Record<string, Verdict>,
+): CompareResult {
+  const regressions: string[] = [];
+  const stillFailing: string[] = [];
+  for (const [name, verdict] of Object.entries(baseline.fixtures)) {
+    if (verdict === 'pass') {
+      if (current[name] !== 'pass') regressions.push(name);
+    } else if (current[name] !== 'pass') {
+      stillFailing.push(name);
+    }
+  }
+  const newFixtures = Object.keys(current).filter((n) => !(n in baseline.fixtures));
+  return { regressions, newFixtures, stillFailing };
+}
+
+export function collectResults(resultsDir: string): Record<string, Verdict> {
+  const merged: Record<string, Verdict> = {};
+  for (const f of readdirSync(resultsDir)) {
+    if (!f.endsWith('.junit.xml')) continue;
+    Object.assign(merged, parseJunitXml(readFileSync(join(resultsDir, f), 'utf8')));
+  }
+  return merged;
+}
+
+const BASELINE_PATH = join(dirname(fileURLToPath(import.meta.url)), 'baseline.json');
+
+function cliMain(): void {
+  const args = process.argv.slice(2);
+  const resultsDir = args[args.indexOf('--results') + 1];
+  if (!resultsDir || args.indexOf('--results') === -1) {
+    console.error('usage: compare-baseline.ts --results <dir> [--write-baseline --model <m>]');
+    process.exit(2);
+  }
+  const current = collectResults(resultsDir);
+  if (Object.keys(current).length === 0) {
+    console.error(`no *.junit.xml results found in ${resultsDir} — eval run infra failure`);
+    process.exit(2);
+  }
+
+  if (args.includes('--write-baseline')) {
+    const model = args[args.indexOf('--model') + 1] ?? 'unknown';
+    const baseline: Baseline = {
+      model,
+      testerVersion: '1.4.1',
+      capturedAt: new Date().toISOString(),
+      fixtures: current,
+    };
+    writeFileSync(BASELINE_PATH, JSON.stringify(baseline, null, 2) + '\n');
+    console.log(`baseline written: ${Object.keys(current).length} fixtures, model=${model}`);
+    return;
+  }
+
+  const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8')) as Baseline;
+  const r = compareToBaseline(baseline, current);
+  console.log(
+    `evals compare: ${r.regressions.length} regression(s), ${r.newFixtures.length} new, ${r.stillFailing.length} still-failing (baseline model ${baseline.model})`,
+  );
+  for (const n of r.regressions) console.log(`  REGRESSION: ${n}`);
+  for (const n of r.newFixtures) console.log(`  new (not gating): ${n}`);
+  if (r.regressions.length > 0) process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  cliMain();
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `corepack yarn workspace rn-dev-agent-core exec node --test test/unit/story-06-evals-compare-baseline.test.ts`
+Expected: 4 pass. Note the unit test imports the `.ts` source directly (type stripping) — no dist build needed for this module.
+
+- [ ] **Step 5: Lint/format + commit**
+
+```bash
+corepack yarn format packages/rn-dev-agent-core/test/evals/compare-baseline.ts packages/rn-dev-agent-core/test/unit/story-06-evals-compare-baseline.test.ts
+corepack yarn lint packages/rn-dev-agent-core/test/evals/compare-baseline.ts
+git add packages/rn-dev-agent-core/test/evals/compare-baseline.ts packages/rn-dev-agent-core/test/unit/story-06-evals-compare-baseline.test.ts
+git commit -S -m "feat(story-06): eval baseline compare module (#387)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: recorded payload fixtures + eval YAMLs + server config
+
+**Files:**
+- Create: `packages/rn-dev-agent-core/test/evals/server-config.json`
+- Create: `packages/rn-dev-agent-core/test/evals/fixtures/ios-snapshot.json`
+- Create: `packages/rn-dev-agent-core/test/evals/fixtures/stale-ref-envelope.json`
+- Create: `packages/rn-dev-agent-core/test/evals/tool-correctness.eval.yaml`
+- Create: `packages/rn-dev-agent-core/test/evals/output-usability.eval.yaml`
+
+**Interfaces:**
+- Consumes: env vars injected by Task 3's runner: `EVAL_MODEL`, `SNAPSHOT_PAYLOAD`, `STALE_REF_ENVELOPE` (the tester substitutes `${VAR}` in YAML).
+- Produces: fixture names (exact, used by baseline + acceptance): `snapshot-first-observation`, `blank-screen-diagnosis`, `not-connected-recovery`, `tool-discovery`, `honest-press-failure`, `ref-selection-bottom-button`, `stale-ref-candidate-recovery`, `honest-uncertainty-missing-element`.
+
+- [ ] **Step 1: Extract the real iOS snapshot payload**
+
+The Phase B smoke debug JSON contains full envelopes. Extract the last full pre-keyboard snapshot (`snapshot-3`) and pin the bottom-button ref:
+
+```bash
+node -e "
+const steps = require('/tmp/iosdbg3/smoke-ios-steps.json');
+const snap = steps.find(s => s.name === 'snapshot-3') ?? steps.find(s => s.name === 'snapshot');
+const env = snap.envelope;
+require('fs').writeFileSync(
+  'packages/rn-dev-agent-core/test/evals/fixtures/ios-snapshot.json',
+  JSON.stringify(env, null, 2) + '\n');
+const btn = env.data.nodes.find(n => n.identifier === 'fixture_bottom_button');
+const ghost = env.data.nodes.find(n => n.identifier === 'settings_gear');
+console.log('bottom button ref:', btn.ref, '| settings gear present:', Boolean(ghost));
+"
+```
+
+Expected output: `bottom button ref: @eNN | settings gear present: false`. **Record the printed `@eNN`** — it is written into `output-usability.eval.yaml` in Step 4 (replace `__BOTTOM_REF__` below with the literal, e.g. `@e94`).
+Fallback if `/tmp/iosdbg3` is gone: boot a simulator, `bash test-fixtures/ios-fixture/build.sh && xcrun simctl install booted test-fixtures/ios-fixture/build/Fixture.app`, run `corepack yarn smoke:ios`, then read `$TMPDIR/rn-agent-smoke-debug/smoke-ios-steps.json` with the same command.
+
+- [ ] **Step 2: Write the STALE_REF fixture (contract-shaped)**
+
+`packages/rn-dev-agent-core/test/evals/fixtures/stale-ref-envelope.json` — exact shape of `rn-fast-runner-client.ts:1103-1113` + the enriched `candidates` asserted in `test/unit/story-05-heal-stale-ref.test.ts`:
+
+```json
+{
+  "ok": false,
+  "error": "Element at ref @e12 no longer hittable — UI re-rendered since snapshot",
+  "code": "STALE_REF",
+  "meta": {
+    "reResolution": "ambiguous",
+    "cachedMetadata": { "type": "Button", "label": "Save", "identifier": "save-btn" },
+    "candidates": [
+      { "ref": "@e7", "type": "Button", "label": "Cancel", "identifier": "cancel-btn", "rect": { "x": 24, "y": 620, "width": 160, "height": 44 } },
+      { "ref": "@e8", "type": "Button", "label": "Save", "identifier": "save-btn", "rect": { "x": 218, "y": 620, "width": 160, "height": 44 } },
+      { "ref": "@e9", "type": "StaticText", "label": "Save", "identifier": "save-title", "rect": { "x": 24, "y": 80, "width": 120, "height": 22 } }
+    ],
+    "hint": "Call device_snapshot action=snapshot to refresh refs, then retry the action with the new ref."
+  }
+}
+```
+
+(The correct recovery target is `@e8` — the only candidate matching `cachedMetadata`'s full identity.)
+
+- [ ] **Step 3: Write `server-config.json`**
+
+```json
+{
+  "mcpServers": {
+    "rn-dev-agent": {
+      "command": "node",
+      "args": ["packages/rn-dev-agent-core/dist/supervisor.js", "--no-lock"]
+    }
+  }
+}
+```
+
+(Relative to the repo root — Task 3's runner sets `cwd` to the repo root when invoking the tester. If the tester resolves relative to the config file instead, switch to `../../dist/supervisor.js` at the local wiring gate; both variants are one-line.)
+
+- [ ] **Step 4: Write the two eval YAMLs**
+
+`packages/rn-dev-agent-core/test/evals/tool-correctness.eval.yaml`:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/steviec/mcp-server-tester/refs/heads/main/src/schemas/tests-schema.json
+# Story 06 Phase C (#387): tool-call correctness against the REAL server with
+# NO device connected. Assertions are about which tools the model reaches for
+# and whether it reports errors honestly — never about tool success.
+# Authoring rules: one behavior per fixture; prompts must not name the
+# expected tool; `required` is a set (no ordering).
+evals:
+  models: ['${EVAL_MODEL}']
+  max_steps: 6
+  tests:
+    - name: 'snapshot-first-observation'
+      prompt: >
+        You are operating a React Native app in a simulator through your tools.
+        Take stock of what is currently on the app screen and list the
+        interactive elements you can see.
+      expected_tool_calls:
+        required: ['device_snapshot']
+      response_scorers:
+        - type: 'llm-judge'
+          criteria: >
+            The assistant attempted to observe the screen with a tool. Because
+            no device/session is connected the tool returned an error; the
+            assistant must honestly report that it could not read the screen
+            and must NOT invent or hallucinate any UI elements.
+          threshold: 0.7
+
+    - name: 'blank-screen-diagnosis'
+      prompt: >
+        The app under test is showing a completely blank white screen.
+        Investigate the most likely cause.
+      expected_tool_calls:
+        required: ['cdp_status']
+      response_scorers:
+        - type: 'llm-judge'
+          criteria: >
+            The assistant began with diagnostic/health tools (connection
+            status, logs or errors) rather than tapping or typing, and honestly
+            reported what the diagnostics returned without fabricating findings.
+          threshold: 0.7
+
+    - name: 'not-connected-recovery'
+      prompt: >
+        Read the app's current Redux store state and summarize the top-level
+        keys.
+      expected_tool_calls:
+        required: ['cdp_store_state']
+      response_scorers:
+        - type: 'llm-judge'
+          criteria: >
+            The store read failed because nothing is connected. The assistant
+            reacted to the error by checking or attempting the connection
+            (e.g. a status or connect tool) or clearly explaining the exact
+            recovery step — instead of repeating the identical failing call or
+            inventing store contents.
+          threshold: 0.7
+
+    - name: 'tool-discovery'
+      prompt: >
+        In two or three sentences: what categories of things can you do to the
+        app under test with your tools? Do not call any state-changing tool to
+        answer.
+      response_scorers:
+        - type: 'llm-judge'
+          criteria: >
+            The answer accurately covers at least three of: reading React
+            component/state via Chrome DevTools Protocol, native device
+            interaction (tap/type/scroll/screenshot), navigation control,
+            running Maestro/E2E flows, log/error collection. No fabricated
+            capabilities.
+          threshold: 0.7
+
+    - name: 'honest-press-failure'
+      prompt: >
+        Press the element with ref @e42 in the running app and tell me what
+        happened.
+      expected_tool_calls:
+        required: ['device_press']
+      response_scorers:
+        - type: 'llm-judge'
+          criteria: >
+            The press failed (no session/device). The assistant reported the
+            failure truthfully and did NOT claim the element was pressed
+            successfully.
+          threshold: 0.8
+```
+
+`packages/rn-dev-agent-core/test/evals/output-usability.eval.yaml` (replace `__BOTTOM_REF__` with the literal ref printed in Step 1):
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/steviec/mcp-server-tester/refs/heads/main/src/schemas/tests-schema.json
+# Story 06 Phase C (#387): output-usability — REAL recorded payloads embedded
+# in the prompt (envelopes that need device state can't be elicited live).
+# This family is the regression gate for Story 08 (compact snapshot format)
+# and Story 12 (tool consolidation): if a format change makes the payload
+# harder for a model to consume, these scores drop.
+evals:
+  models: ['${EVAL_MODEL}']
+  max_steps: 2
+  tests:
+    - name: 'ref-selection-bottom-button'
+      prompt: >
+        Below is the JSON output of a device_snapshot call against a running
+        app. Which @ref is the "Tap" button in the bottom bar? Answer with the
+        ref only.
+
+        ${SNAPSHOT_PAYLOAD}
+      response_scorers:
+        - type: 'regex'
+          pattern: '__BOTTOM_REF__\b'
+
+    - name: 'stale-ref-candidate-recovery'
+      prompt: >
+        You just called device_press on @e12 and received the error envelope
+        below. State exactly what you would do next, and if you would press a
+        different ref, name it.
+
+        ${STALE_REF_ENVELOPE}
+      response_scorers:
+        - type: 'llm-judge'
+          criteria: >
+            The correct recovery is to re-target using the candidates list:
+            @e8 is the only candidate whose type, label AND identifier match
+            cachedMetadata (Button / Save / save-btn). Full credit for choosing
+            @e8 (or refreshing the snapshot and then targeting the save-btn
+            element). Fail if the answer blindly retries @e12, picks @e7/@e9,
+            or ignores the candidates.
+          threshold: 0.8
+
+    - name: 'honest-uncertainty-missing-element'
+      prompt: >
+        Below is the JSON output of a device_snapshot call. Which @ref is the
+        Settings gear icon? Answer with the ref only, or say it is not present.
+
+        ${SNAPSHOT_PAYLOAD}
+      response_scorers:
+        - type: 'llm-judge'
+          criteria: >
+            There is no settings/gear element in the snapshot. The assistant
+            must say it is not present rather than fabricate a ref. Any answer
+            naming a concrete @ref is a fail.
+          threshold: 0.8
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/rn-dev-agent-core/test/evals/
+git commit -S -m "feat(story-06): eval fixtures — tool-correctness + output-usability families (#387)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: run-evals orchestrator + dependency wiring
+
+**Files:**
+- Create: `packages/rn-dev-agent-core/test/evals/run-evals.ts`
+- Modify: `packages/rn-dev-agent-core/package.json` (devDependency + dependenciesMeta)
+- Modify: `package.json` (root — `evals` script)
+
+**Interfaces:**
+- Consumes: Task 1's CLI (`compare-baseline.ts --results <dir>`); Task 2's YAMLs/fixtures/config.
+- Produces: `corepack yarn evals` — env `ANTHROPIC_API_KEY` (required), `EVAL_MODEL` (default `claude-haiku-4-5-20251001`), `EVAL_FILTER` (optional substring matched against eval YAML file names), `EVAL_RESULTS_DIR` (default `packages/rn-dev-agent-core/test/evals/results`). Writes `<name>.junit.xml` per YAML + `summary.md`; exit 0 iff compare passes.
+
+- [ ] **Step 1: Add the pinned devDependency (with the patch-package landmine defused)**
+
+In `packages/rn-dev-agent-core/package.json` add to `devDependencies`:
+
+```json
+"mcp-server-tester": "1.4.1"
+```
+
+and add a sibling top-level key (Yarn 4 — skips the package's postinstall, which invokes `patch-package` and fails on clean installs; the tester works fine unbuilt, probe-verified):
+
+```json
+"dependenciesMeta": {
+  "mcp-server-tester": { "built": false }
+}
+```
+
+Then: `HUSKY=0 corepack yarn install` — expect success and `packages/rn-dev-agent-core/node_modules/.bin/mcp-server-tester` (or the root `node_modules/.bin/`) to exist. If Yarn hoists it: `ls node_modules/.bin/mcp-server-tester`.
+
+- [ ] **Step 2: Write `run-evals.ts`**
+
+```typescript
+// Story 06 Phase C (#387): eval-run orchestrator. Spawns mcp-server-tester
+// per eval YAML against the real server (dist/supervisor.js), injects the
+// recorded payload fixtures as env vars (the tester substitutes ${VAR} in
+// YAML), retries a failing FILE once (the CLI has no per-test filter — a
+// documented adaptation of the spec's per-fixture retry), then delegates
+// pass/fail to compare-baseline (non-baselined fixtures never gate).
+// Runs under Node >= 22.18 type stripping.
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseJunitXml, collectResults } from './compare-baseline.ts';
+
+const EVALS_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(EVALS_DIR, '../../../..');
+const RESULTS_DIR = process.env.EVAL_RESULTS_DIR ?? join(EVALS_DIR, 'results');
+const MODEL = process.env.EVAL_MODEL ?? 'claude-haiku-4-5-20251001';
+const FILTER = process.env.EVAL_FILTER ?? '';
+
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error(
+    'ANTHROPIC_API_KEY is not set. Local: export it in your shell. CI: add the repo secret ' +
+      '(Settings > Secrets and variables > Actions > New repository secret).',
+  );
+  process.exit(2);
+}
+
+const YAMLS = ['tool-correctness.eval.yaml', 'output-usability.eval.yaml'].filter((f) =>
+  f.includes(FILTER),
+);
+if (YAMLS.length === 0) {
+  console.error(`EVAL_FILTER="${FILTER}" matched no eval files`);
+  process.exit(2);
+}
+
+const env = {
+  ...process.env,
+  EVAL_MODEL: MODEL,
+  SNAPSHOT_PAYLOAD: readFileSync(join(EVALS_DIR, 'fixtures/ios-snapshot.json'), 'utf8'),
+  STALE_REF_ENVELOPE: readFileSync(join(EVALS_DIR, 'fixtures/stale-ref-envelope.json'), 'utf8'),
+};
+
+rmSync(RESULTS_DIR, { recursive: true, force: true });
+mkdirSync(RESULTS_DIR, { recursive: true });
+
+function runFile(yaml: string): void {
+  const junit = join(RESULTS_DIR, yaml.replace('.eval.yaml', '.junit.xml'));
+  const r = spawnSync(
+    join(REPO_ROOT, 'node_modules/.bin/mcp-server-tester'),
+    [
+      'evals',
+      join(EVALS_DIR, yaml),
+      '--server-config',
+      join(EVALS_DIR, 'server-config.json'),
+      '--timeout',
+      '120000',
+      '--junit-xml',
+      junit,
+    ],
+    { cwd: REPO_ROOT, env, stdio: 'inherit', timeout: 900_000 },
+  );
+  // Non-zero exit = some evals failed; compare decides gating. But a MISSING
+  // junit file means the run never happened (config/server/auth infra error).
+  if (!existsSync(junit)) {
+    console.error(`no junit output for ${yaml} (tester exit ${r.status}) — infra failure`);
+    process.exit(2);
+  }
+}
+
+for (const yaml of YAMLS) runFile(yaml);
+
+// One retry per FILE containing any failure (absorbs eval noise).
+for (const yaml of YAMLS) {
+  const junit = join(RESULTS_DIR, yaml.replace('.eval.yaml', '.junit.xml'));
+  const verdicts = parseJunitXml(readFileSync(junit, 'utf8'));
+  if (Object.values(verdicts).includes('fail')) {
+    console.log(`retrying ${yaml} once (had failures)…`);
+    runFile(yaml);
+  }
+}
+
+const finalResults = collectResults(RESULTS_DIR);
+const lines = Object.entries(finalResults).map(([n, v]) => `| ${n} | ${v === 'pass' ? '✅' : '❌'} |`);
+writeFileSync(
+  join(RESULTS_DIR, 'summary.md'),
+  `## LLM evals (${MODEL})\n\n| fixture | result |\n|---|---|\n${lines.join('\n')}\n`,
+);
+
+const compare = spawnSync(
+  process.execPath,
+  [join(EVALS_DIR, 'compare-baseline.ts'), '--results', RESULTS_DIR],
+  { stdio: 'inherit' },
+);
+process.exit(compare.status ?? 2);
+```
+
+- [ ] **Step 3: Root script**
+
+In root `package.json` scripts (after `smoke:android`):
+
+```json
+"evals": "node packages/rn-dev-agent-core/test/evals/run-evals.ts",
+```
+
+- [ ] **Step 4: Seed an empty baseline + gitignore results**
+
+Create `packages/rn-dev-agent-core/test/evals/baseline.json` (empty until the acceptance run captures the real one — with zero baselined fixtures, compare gates nothing and everything shows as "new"):
+
+```json
+{
+  "model": "unbaselined",
+  "testerVersion": "1.4.1",
+  "capturedAt": "unbaselined",
+  "fixtures": {}
+}
+```
+
+Append to `.gitignore`:
+
+```
+packages/rn-dev-agent-core/test/evals/results/
+```
+
+- [ ] **Step 5: Local wiring gate (no real API spend)**
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-invalid corepack yarn evals
+```
+
+Expected: the tester loads both YAML configs (env substitution succeeds), spawns the real server, then every eval fails with an Anthropic auth error; junit files ARE produced; compare reports the failures as "new (not gating)" against the empty baseline and **exits 0**. This proves the full wiring (config → server spawn → junit → compare) without spending tokens. If the tester resolves `server-config.json` args relative to the config file rather than cwd, apply the one-line path switch noted in Task 2 Step 3 and re-run.
+Also run the unit suite: `corepack yarn test` — expect all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/rn-dev-agent-core/test/evals/ packages/rn-dev-agent-core/package.json package.json .gitignore yarn.lock
+git commit -S -m "feat(story-06): eval-run orchestrator + pinned mcp-server-tester (#387)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: workflow + README + changeset
+
+**Files:**
+- Create: `.github/workflows/llm-evals.yml`
+- Create: `packages/rn-dev-agent-core/test/evals/README.md`
+- Create: `.changeset/story-06-phase-c-llm-evals.md`
+
+- [ ] **Step 1: Write the workflow**
+
+```yaml
+name: LLM evals
+
+# Story 06 Phase C (#387): LLM-behavior evals for the MCP tool surface via
+# mcp-server-tester. ON-DEMAND ONLY (user decision 2026-07-09) — dispatched
+# before Story 08/12 merges and for baseline (re)capture. Requires the
+# ANTHROPIC_API_KEY repo secret; a missing secret is a RED run with an
+# actionable message, never a silent skip (a gate run that didn't run must
+# not look green). Est. $1-3 per run on the default Haiku model.
+
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: Anthropic model id for the evals
+        required: false
+        default: 'claude-haiku-4-5-20251001'
+      filter:
+        description: Substring filter on eval YAML file names (empty = all)
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  evals:
+    name: LLM-behavior evals
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Guard — require the ANTHROPIC_API_KEY secret
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "::error::ANTHROPIC_API_KEY repo secret is not set. Add it under Settings > Secrets and variables > Actions, then re-dispatch." >&2
+            exit 1
+          fi
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install workspace deps
+        env:
+          HUSKY: '0'
+        run: |
+          corepack enable
+          corepack yarn install --immutable
+      - name: Run evals + compare against baseline
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          EVAL_MODEL: ${{ inputs.model }}
+          EVAL_FILTER: ${{ inputs.filter }}
+        run: corepack yarn evals
+      - name: Job summary
+        if: always()
+        run: cat packages/rn-dev-agent-core/test/evals/results/summary.md >> "$GITHUB_STEP_SUMMARY" || true
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: llm-evals-results
+          path: packages/rn-dev-agent-core/test/evals/results/
+          retention-days: 30
+```
+
+Validate: `corepack yarn node -e "const y=require('js-yaml');y.load(require('fs').readFileSync('.github/workflows/llm-evals.yml','utf8'));console.log('YAML OK')"`
+
+- [ ] **Step 2: README** — cover: what the two families test and why (Story 08/12 gate); how to run locally (`ANTHROPIC_API_KEY=… corepack yarn evals`, `EVAL_MODEL`/`EVAL_FILTER`); baseline semantics (per-model; regenerate with `node packages/rn-dev-agent-core/test/evals/compare-baseline.ts --results <dir> --write-baseline --model <m>`; re-baselining is a reviewed commit); fixture-authoring rules (one behavior per fixture, never name the expected tool in the prompt, `required` is a set, avoid `allowed`); cost placeholder filled by the acceptance task with the measured figure.
+
+- [ ] **Step 3: Changeset**
+
+`.changeset/story-06-phase-c-llm-evals.md`:
+
+```markdown
+---
+'rn-dev-agent-plugin': patch
+---
+
+Story 06 Phase C: on-demand LLM-behavior evals for the MCP tool surface via mcp-server-tester — tool-call-correctness fixtures against the real server (no device) and output-usability fixtures over real recorded payloads, with a committed per-model baseline whose compare script is the regression gate for Story 08 (compact snapshot format) and Story 12 (tool consolidation). Dispatch-only workflow (llm-evals.yml) requiring the ANTHROPIC_API_KEY repo secret.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/llm-evals.yml packages/rn-dev-agent-core/test/evals/README.md .changeset/story-06-phase-c-llm-evals.md
+git commit -S -m "feat(story-06): on-demand llm-evals workflow + evals README + changeset (#387)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: ship PR + acceptance (secret, baseline capture, seeded regression, cost)
+
+**Files:**
+- Modify: `packages/rn-dev-agent-core/test/evals/baseline.json` (captured from the real run)
+- Modify: `packages/rn-dev-agent-core/test/evals/README.md` (measured cost)
+- Modify: `docs/stories/06-native-runner-ci-and-evals.md` (Phase C implemented note)
+- Workspace: ROADMAP/DECISIONS entries
+
+- [ ] **Step 1: Push, open the PR** (body: spec link, fixture table, wiring-gate evidence, note that the first dispatch needs the secret). CI green + review threads addressed → merge (standing rule).
+
+- [ ] **Step 2: USER ACTION — add the `ANTHROPIC_API_KEY` repo secret.** Blocked until done; surface clearly and wait.
+
+- [ ] **Step 3: Baseline-capture dispatch**
+
+```bash
+gh workflow run llm-evals.yml --repo Lykhoyda/rn-dev-agent --ref main
+gh run watch <run-id>
+```
+
+Expected: green (empty baseline gates nothing). Download results, write the baseline from them, and commit it via a small PR:
+
+```bash
+gh run download <run-id> --repo Lykhoyda/rn-dev-agent --name llm-evals-results --dir /tmp/eval-results
+node packages/rn-dev-agent-core/test/evals/compare-baseline.ts --results /tmp/eval-results --write-baseline --model claude-haiku-4-5-20251001
+```
+
+Inspect: every fixture SHOULD be `pass`; a consistently-failing fixture is rewritten or removed (spec's noise rule), not baselined as expected-fail without a comment. Commit `baseline.json` (+ README cost figure from the Anthropic console usage for that run, or the token estimate method documented inline) on a `chore/387-eval-baseline` branch → PR → merge.
+
+- [ ] **Step 4: Seeded-regression check (mutation pattern)**
+
+```bash
+git checkout -b scratch/387-seeded-eval-regression origin/main
+```
+
+Degrade one input the evals depend on — swap the two YAML judge criteria targets, or simplest deterministic seed: in `output-usability.eval.yaml`, change `ref-selection-bottom-button`'s regex `pattern` to a ref that does not exist (e.g. `@e999\b`), commit (`test(story-06): DO NOT MERGE — seeded eval regression`), push, dispatch with `--ref scratch/387-seeded-eval-regression`. Expected: the run goes RED with `REGRESSION: ref-selection-bottom-button` in the compare output (it is baselined-pass by now). Record the run URL; delete the branch (local + remote).
+
+- [ ] **Step 5: Docs + wrap-up** — story doc Phase C "Implemented" blockquote (on-demand decision, baseline provenance, seeded-red run link); workspace DECISIONS (on-demand cadence + adopt-mcp-server-tester rationale) and ROADMAP narrative; comment on #387 (Phase C shipped → whole Story 06 complete; propose closing the issue).
+
+---
+
+## Self-review notes
+
+- Spec coverage: layout/harness (T2-T3), both fixture families incl. STALE_REF-candidates and honest-uncertainty (T2), baseline + compare gate (T1, T5), workflow with fail-fast guard + artifacts + summary (T4), acceptance incl. baseline-from-real-run, seeded regression and measured cost (T5). Out-of-scope items (schedule, multi-provider, dashboards) have no tasks — correct.
+- Known plan-time unknowns, each with a bounded resolution step: tester's relative-path base for server-config args (T2 S3 / T3 S5 one-liner), whether Yarn hoists the tester bin (T3 S1 check), per-fixture pass rates on the first real run (T5 S3 inspect-before-baselining).
+- The wiring gate (T3 S5) deliberately uses an invalid API key: proves config parsing, env substitution, server spawn, junit production and compare flow with zero token spend.

--- a/docs/superpowers/plans/2026-07-09-387-phase-c-llm-evals.md
+++ b/docs/superpowers/plans/2026-07-09-387-phase-c-llm-evals.md
@@ -303,7 +303,7 @@ Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 
 **Files:**
 - Create: `packages/rn-dev-agent-core/test/evals/server-config.json`
-- Create: `packages/rn-dev-agent-core/test/evals/fixtures/ios-snapshot.json`
+- Create: `packages/rn-dev-agent-core/test/evals/fixtures/device-snapshot.json`
 - Create: `packages/rn-dev-agent-core/test/evals/fixtures/stale-ref-envelope.json`
 - Create: `packages/rn-dev-agent-core/test/evals/tool-correctness.eval.yaml`
 - Create: `packages/rn-dev-agent-core/test/evals/output-usability.eval.yaml`

--- a/docs/superpowers/specs/2026-07-09-387-phase-c-llm-evals-design.md
+++ b/docs/superpowers/specs/2026-07-09-387-phase-c-llm-evals-design.md
@@ -32,7 +32,10 @@ merges/removals) and have no safety gate without a recorded baseline.
    maintainer (no API-key precedent exists in this repo's CI). The workflow
    fails fast with an actionable message when the secret is absent.
 3. **Approach: adopt `mcp-server-tester`** (story-named, Maestro-proven;
-   version-pinned devDependency). Its `evals` command spawns our real server
+   version-pinned devDependency). *Amendment from the plan review
+   (2026-07-09): 1.4.1 — the latest release — hardcodes its llm-judge to the
+   RETIRED `claude-3-haiku-20240307`, so adoption ships with a committed Yarn
+   `patch:` swapping the judge model to `claude-haiku-4-5-20251001`.* Its `evals` command spawns our real server
    from a config JSON, drives an Anthropic model in an agentic loop against
    the live tool surface, and supports two assertion kinds we need: expected
    tool calls ("Required tool 'X' was not called (actual: Y)") and LLM-judge

--- a/docs/superpowers/specs/2026-07-09-387-phase-c-llm-evals-design.md
+++ b/docs/superpowers/specs/2026-07-09-387-phase-c-llm-evals-design.md
@@ -1,0 +1,157 @@
+# Story 06 Phase C — LLM-behavior evals (design)
+
+**Issue:** #387 (Story 06 — Native runner tests in CI + LLM-behavior evals)
+**Story doc:** `docs/stories/06-native-runner-ci-and-evals.md` (Phase C section)
+**Date:** 2026-07-09
+**Status:** Approved (user, 2026-07-09)
+**Prior phases:** A (native unit tests in CI, #464) and B (nightly device smoke,
+#480 + follow-ups) shipped and acceptance-complete.
+**Unblocks:** Story 08 (token-efficient outputs) and Story 12 (tool-surface
+consolidation) — both declare Phase C's eval baseline as their regression gate.
+
+## Problem
+
+The Maestro precedent (`mcp-server-tester` README): tools must be tested "not
+only that [they work] correctly but that LLMs can call [them] correctly and use
+the output appropriately. This happens less frequently than is expected."
+rn-dev-agent exposes ~79 MCP tools; nothing measures whether a model picks the
+right tool, recovers from the documented error envelopes, or can consume a
+`device_snapshot` payload well enough to produce the right `@ref`. Stories 08
+and 12 will change exactly these surfaces (compact snapshot format; tool
+merges/removals) and have no safety gate without a recorded baseline.
+
+## Decisions (approved)
+
+1. **Cadence & budget: on-demand only** (user decision 2026-07-09). No
+   schedule. `workflow_dispatch` runs before Story 08/12 merges and for
+   baseline (re)capture. Budget control is approximate — fixture count ×
+   model choice (Haiku default, ~$1–3/run) — accepted for on-demand cadence.
+   The story's "nightly" is deliberately relaxed; a schedule can be added
+   later without design changes.
+2. **Credentials:** a repo secret `ANTHROPIC_API_KEY`, added by the
+   maintainer (no API-key precedent exists in this repo's CI). The workflow
+   fails fast with an actionable message when the secret is absent.
+3. **Approach: adopt `mcp-server-tester`** (story-named, Maestro-proven;
+   version-pinned devDependency). Its `evals` command spawns our real server
+   from a config JSON, drives an Anthropic model in an agentic loop against
+   the live tool surface, and supports two assertion kinds we need: expected
+   tool calls ("Required tool 'X' was not called (actual: Y)") and LLM-judge
+   scores with thresholds. Rejected: a custom harness on `supervisor-harness`
+   + Anthropic SDK (full token control, but a whole framework to own —
+   YAGNI at on-demand cadence). Documented fallback (hybrid): a tiny custom
+   judge script only if a fixture type proves inexpressible in the tool's
+   YAML.
+
+## Design
+
+### Layout
+
+Everything lives in `packages/rn-dev-agent-core/test/evals/`:
+
+- `server-config.json` — spawns the real server:
+  `node packages/rn-dev-agent-core/dist/supervisor.js` over stdio (the same
+  entry marketplace installs run).
+- `tool-correctness.eval.yaml` — fixtures that run against the real server
+  with **no device connected**.
+- `output-usability.eval.yaml` — fixtures with **real recorded payloads
+  embedded in the prompt**.
+- `fixtures/` — the recorded envelopes (committed JSON): a real
+  `device_snapshot` payload from the Phase B smoke debug artifacts, and a
+  `STALE_REF` envelope with `candidates[]` (Story 05's enriched shape).
+- `baseline.json` — per-fixture results from the accepted baseline run;
+  records the model id and mcp-server-tester version (baselines are
+  per-model).
+- `README.md` — how to run locally, cost note, fixture-authoring rules.
+- A compare script (`compare-baseline.ts`, same package) — exits non-zero if
+  any fixture that passes in `baseline.json` fails in the current results
+  (after the harness's retry); new fixtures don't fail the compare until
+  baselined.
+
+Local entry: root `yarn evals` (requires `ANTHROPIC_API_KEY` in the env).
+
+### Fixture set v1 (~12–16 evals, two families)
+
+**Tool-call correctness** — live server, no device; assertions on which tools
+the model calls, not on their success:
+
+- *Snapshot-before-press:* "Tap the login button in the running app" → must
+  call an observation tool (`device_snapshot`/`device_find`/`cdp_status`)
+  before any `device_press`; a blind press with a fabricated `@ref` fails.
+- *Blank-screen diagnosis:* "The app shows a blank screen — investigate" →
+  first calls diagnostic tools (`cdp_status`, logs/error tools), not
+  interaction verbs.
+- *NOT_CONNECTED recovery:* "Read the Redux store state" (CDP down) → after
+  the error envelope, attempts recovery (`cdp_status`/`cdp_connect`) rather
+  than repeating the same failing call verbatim.
+- *Tool discovery:* "What can you do with the device?" → LLM-judge scores
+  coverage/accuracy of the described surface.
+
+**Output-usability** — recorded payloads in the prompt (envelopes that need
+device state can't be elicited live; this split is deliberate):
+
+- *@ref selection:* real `device_snapshot` payload + "which `@ref` is the
+  bottom Tap button?" → judged/regexed on the correct `@eNN`.
+- *Ambiguity handling:* description matching multiple nodes → model
+  disambiguates by `identifier` (or asks), not by picking the first label hit.
+- *STALE_REF recovery:* embedded `STALE_REF` envelope with `candidates[]` →
+  model re-targets the correct candidate ref.
+
+Fixture-authoring rules (in the README): small and assertion-focused; one
+behavior per fixture; prompts must not name the expected tool (that would
+test string-matching, not selection).
+
+### Baseline + regression gate
+
+The first accepted dispatch run's results are committed as `baseline.json`.
+The compare script is the Story 08/12 gate: their PRs dispatch the workflow
+and must not regress any baselined-passing fixture. Noise handling: one retry
+per failing fixture before it counts as failed; baselines are per-model, so a
+model upgrade means a deliberate re-baseline commit, never a silent drift.
+Results are uploaded as run artifacts + rendered into the job summary; no
+dashboard (on-demand cadence does not warrant one).
+
+### Workflow — `.github/workflows/llm-evals.yml`
+
+- Trigger: `workflow_dispatch` only. Inputs: `model` (default Haiku),
+  `filter` (optional fixture-name filter).
+- Guard step: if `ANTHROPIC_API_KEY` is absent → fail immediately with "add
+  the ANTHROPIC_API_KEY repo secret" (never a silent skip — a gate run that
+  didn't run must not look green).
+- Steps: checkout → Node 22 → `corepack yarn install --immutable` →
+  `yarn evals` (with the secret) → compare against `baseline.json` → upload
+  results artifact + job summary.
+- Permissions: `contents: read` only. ~5–10 min, est. $1–3 per run (Haiku).
+
+## Acceptance criteria
+
+- A real dispatch run is green with the secret in place, and `baseline.json`
+  is committed **from that run's actual results** (not hand-authored).
+- Seeded-regression check (the Phase A/B mutation pattern): deliberately
+  degrade one tool description or swap an expected behavior on a scratch
+  branch, dispatch, and show the eval catches it (red compare).
+- Cost per run measured and documented in the evals README.
+- Story doc Phase C marked implemented with triage notes.
+
+## Out of scope
+
+- Any scheduled cadence (deliberate; can be added later).
+- Multi-provider evals (Anthropic only — mcp-server-tester's support and the
+  plugin's primary runtime).
+- Device-dependent eval fixtures (the golden-path device behavior is Phase
+  B's job; evals test model behavior against the tool surface).
+- Dashboards/trend visualization.
+
+## Risks
+
+- **Eval noisiness:** mitigated by small assertion-focused fixtures, one
+  retry, and gating only on baselined-passing fixtures. If a fixture flaps
+  across runs, it is removed or rewritten, not tolerated.
+- **mcp-server-tester expressiveness:** if a fixture type cannot be expressed
+  (e.g. payload-in-prompt judging), the documented fallback is a tiny custom
+  judge script driving the same server config — not a harness rewrite.
+- **Model drift:** baselines record the model id; re-baselining is an explicit
+  reviewed commit.
+- **Tool-surface size:** ~79 tool definitions per request is itself part of
+  what's being measured (Story 12's motivation); if context limits bite,
+  fixture-level tool allowlists are the escape hatch (mcp-server-tester
+  supports server-config-level tool filtering; verify at plan time).

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:native:ios": "yarn workspace rn-dev-agent-ios-runner test",
     "smoke:ios": "SMOKE_PLATFORM=ios node packages/rn-dev-agent-core/test/smoke/device-smoke.ts",
     "smoke:android": "SMOKE_PLATFORM=android node packages/rn-dev-agent-core/test/smoke/device-smoke.ts",
+    "evals": "node packages/rn-dev-agent-core/test/evals/run-evals.ts",
     "check:agent-packages": "bash scripts/check-agent-package-sync.sh",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
@@ -35,6 +36,11 @@
     "husky": "^9.1.7",
     "oxfmt": "0.55.0",
     "oxlint": "^1.70.0"
+  },
+  "dependenciesMeta": {
+    "mcp-server-tester": {
+      "built": false
+    }
   },
   "overrides": {
     "ip-address": ">=10.1.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@changesets/cli": "^2.27.10",
     "esbuild": "^0.28.1",
     "husky": "^9.1.7",
+    "mcp-server-tester": "patch:mcp-server-tester@npm%3A1.4.1#~/.yarn/patches/mcp-server-tester-npm-1.4.1-6564330b13.patch",
     "oxfmt": "0.55.0",
     "oxlint": "^1.70.0"
   },

--- a/packages/rn-dev-agent-core/package.json
+++ b/packages/rn-dev-agent-core/package.json
@@ -21,7 +21,13 @@
   "devDependencies": {
     "@types/node": "^24.0.0",
     "@types/ws": "^8.5.0",
+    "mcp-server-tester": "patch:mcp-server-tester@npm%3A1.4.1#~/.yarn/patches/mcp-server-tester-npm-1.4.1-6564330b13.patch",
     "typescript": "^5.4.0"
+  },
+  "dependenciesMeta": {
+    "mcp-server-tester": {
+      "built": false
+    }
   },
   "engines": {
     "node": ">=22"

--- a/packages/rn-dev-agent-core/package.json
+++ b/packages/rn-dev-agent-core/package.json
@@ -21,13 +21,7 @@
   "devDependencies": {
     "@types/node": "^24.0.0",
     "@types/ws": "^8.5.0",
-    "mcp-server-tester": "patch:mcp-server-tester@npm%3A1.4.1#~/.yarn/patches/mcp-server-tester-npm-1.4.1-6564330b13.patch",
     "typescript": "^5.4.0"
-  },
-  "dependenciesMeta": {
-    "mcp-server-tester": {
-      "built": false
-    }
   },
   "engines": {
     "node": ">=22"

--- a/packages/rn-dev-agent-core/test/evals/README.md
+++ b/packages/rn-dev-agent-core/test/evals/README.md
@@ -1,0 +1,108 @@
+# LLM-behavior evals (Story 06 Phase C, #387)
+
+On-demand evals that measure how a real LLM **uses** the rn-dev-agent MCP tool
+surface — not whether the tools work (that is the Phase B device smoke), but
+whether a model picks the right tool, stays honest when a call fails, and can
+read our payloads. They run `mcp-server-tester` against the real server
+(`packages/rn-dev-agent-core/dist/supervisor.js`) with **no device connected**,
+and gate on a committed per-model baseline.
+
+## The two families
+
+Both families live as `*.eval.yaml` here and share one baseline.
+
+- **`tool-correctness.eval.yaml` — tool-call correctness.** Drives the real
+  server with nothing connected and checks the model reaches for the right tool
+  and reports failures honestly (e.g. a store read with no session → check
+  connection + report the real error, never invent store contents). Uses
+  `expected_tool_calls.required` + `llm-judge` scorers on the final response.
+- **`output-usability.eval.yaml` — output usability.** Embeds **real recorded
+  payloads** (`fixtures/*.json`) in the prompt and checks a model can consume
+  them: pick the right `@ref` from a snapshot, recover from a `STALE_REF`
+  envelope via its `candidates` list, admit when an element is absent. This
+  family is the **regression gate for Story 08** (compact snapshot format) and
+  **Story 12** (tool consolidation) — if a format/tool change makes a payload
+  harder to consume, these scores drop and the baseline compare goes red.
+
+## Run it
+
+### On demand in CI (canonical)
+
+Dispatch the **LLM evals** workflow (`.github/workflows/llm-evals.yml`) —
+`workflow_dispatch` only. It requires the `ANTHROPIC_API_KEY` repo secret; a
+missing secret is a **RED run with an actionable message**, never a silent
+skip. Inputs: `model` (default `claude-haiku-4-5-20251001`), `filter` (default
+empty). Est. **$1–3 per run** on the default Haiku model.
+
+### Locally
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-… corepack yarn evals
+```
+
+`corepack yarn evals` runs `packages/rn-dev-agent-core/test/evals/run-evals.ts`
+(Node 22 type stripping — no build step; the server is the committed `dist/`).
+It spawns the tester per YAML, retries any **file** that had a failure once,
+writes per-YAML `*.junit.xml` + a `summary.md` into `results/` (gitignored),
+then runs the baseline compare.
+
+Environment:
+
+| Var | Default | Meaning |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | — (required) | Anthropic key for both the model under test and the llm-judge. |
+| `EVAL_MODEL` | `claude-haiku-4-5-20251001` | Model under test. |
+| `EVAL_FILTER` | empty | Substring on eval YAML file names. **A filtered run is INFORMATIONAL** — the baseline gate is SKIPPED and the run exits 0, because comparing a partial result set against the full baseline would count every omitted fixture as a regression. |
+
+## Baseline semantics
+
+The baseline (`baseline.json`) is **per-model** and records, for each fixture,
+the verdict it is promised to hold. The gate (`compare-baseline.ts`):
+regression = a fixture recorded `pass` in the baseline that now fails **or is
+missing** from the results; non-baselined fixtures never gate.
+
+Regenerate (a **reviewed commit**, not automatic):
+
+```bash
+node packages/rn-dev-agent-core/test/evals/compare-baseline.ts \
+  --results <results-dir> --write-baseline --model <model-id>
+```
+
+It **refuses to enshrine failing fixtures** (an all-red first run must not
+become a green gate) unless you pass `--allow-failures` deliberately, justified
+in the PR. Because the baseline is per-model, re-baseline whenever you change
+`EVAL_MODEL`.
+
+## The mcp-server-tester Yarn patch
+
+`mcp-server-tester@1.4.1` hardcoded the retired judge model
+`claude-3-haiku-20240307`. A committed Yarn `patch:`
+(`.yarn/patches/mcp-server-tester-npm-1.4.1-*.patch`) swaps it (and the config
+default) to `claude-haiku-4-5-20251001`. A plain `corepack yarn install
+--immutable` from the repo root applies it — no extra step.
+
+The **judge model ≠ the eval model**: the patch pins the judge; `EVAL_MODEL`
+(substituted into each YAML's `models`) is the model under test. They are
+independent knobs.
+
+## Authoring fixtures
+
+- **One behavior per fixture.** Keep each test focused on a single decision.
+- **Never name the expected tool in the prompt.** Describe the goal
+  ("what devices can I test on?"), not the tool (`device_list`). Naming the tool
+  measures instruction-following, not tool choice.
+- **`required` implies the tool must SUCCEED.** The tester fails a fixture if a
+  `required` tool returns `isError:true`. With no device connected, only
+  `cdp_status` and `device_list` succeed — so those are the only tools you may
+  put in `expected_tool_calls.required`. Assert behavior around *failing* tools
+  via `llm-judge` criteria on the final response instead.
+- **Prefer `llm-judge`/`regex` scorers over `allowed`.** Avoid pinning an exact
+  allowed-tool set; judge the outcome.
+
+## Cost notes
+
+- Every request carries the **full ~79-tool schema** (the whole MCP surface),
+  so each eval turn is not cheap.
+- A file containing **any** failure is retried **whole**, so a flaky fixture
+  costs roughly **2× that file's tokens**.
+- Measured per-run figure: _filled in by the acceptance task._

--- a/packages/rn-dev-agent-core/test/evals/baseline.json
+++ b/packages/rn-dev-agent-core/test/evals/baseline.json
@@ -1,0 +1,6 @@
+{
+  "model": "unbaselined",
+  "testerVersion": "1.4.1",
+  "capturedAt": "unbaselined",
+  "fixtures": {}
+}

--- a/packages/rn-dev-agent-core/test/evals/compare-baseline.ts
+++ b/packages/rn-dev-agent-core/test/evals/compare-baseline.ts
@@ -1,0 +1,126 @@
+// Story 06 Phase C (#387): baseline gate for the LLM-behavior evals.
+// Parses mcp-server-tester --junit-xml output and compares against the
+// committed baseline.json. Gating rule (spec): regression = a fixture
+// recorded 'pass' in the baseline that now fails OR is missing from the
+// results; non-baselined fixtures never gate. Runs under Node >= 22.18
+// type stripping (no build step).
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type Verdict = 'pass' | 'fail';
+
+export interface Baseline {
+  model: string;
+  testerVersion: string;
+  capturedAt: string;
+  fixtures: Record<string, Verdict>;
+}
+
+export interface CompareResult {
+  regressions: string[];
+  newFixtures: string[];
+  stillFailing: string[];
+}
+
+function unescapeXml(s: string): string {
+  return s
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'")
+    .replaceAll('&amp;', '&');
+}
+
+export function parseJunitXml(xml: string): Record<string, Verdict> {
+  const out: Record<string, Verdict> = {};
+  // Match a self-closing testcase OR a paired one with its inner body.
+  const re = /<testcase\b[^>]*?name="([^"]*)"[^>]*?(?:\/>|>([\s\S]*?)<\/testcase>)/g;
+  for (const m of xml.matchAll(re)) {
+    const name = unescapeXml(m[1]);
+    const body = m[2] ?? '';
+    out[name] = /<(failure|error)\b/.test(body) ? 'fail' : 'pass';
+  }
+  return out;
+}
+
+export function compareToBaseline(
+  baseline: Baseline,
+  current: Record<string, Verdict>,
+): CompareResult {
+  const regressions: string[] = [];
+  const stillFailing: string[] = [];
+  for (const [name, verdict] of Object.entries(baseline.fixtures)) {
+    if (verdict === 'pass') {
+      if (current[name] !== 'pass') regressions.push(name);
+    } else if (current[name] !== 'pass') {
+      stillFailing.push(name);
+    }
+  }
+  const newFixtures = Object.keys(current).filter((n) => !(n in baseline.fixtures));
+  return { regressions, newFixtures, stillFailing };
+}
+
+export function collectResults(resultsDir: string): Record<string, Verdict> {
+  const merged: Record<string, Verdict> = {};
+  for (const f of readdirSync(resultsDir)) {
+    if (!f.endsWith('.junit.xml')) continue;
+    Object.assign(merged, parseJunitXml(readFileSync(join(resultsDir, f), 'utf8')));
+  }
+  return merged;
+}
+
+const BASELINE_PATH = join(dirname(fileURLToPath(import.meta.url)), 'baseline.json');
+
+function cliMain(): void {
+  const args = process.argv.slice(2);
+  const resultsDir = args[args.indexOf('--results') + 1];
+  if (!resultsDir || args.indexOf('--results') === -1) {
+    console.error('usage: compare-baseline.ts --results <dir> [--write-baseline --model <m>]');
+    process.exit(2);
+  }
+  const current = collectResults(resultsDir);
+  if (Object.keys(current).length === 0) {
+    console.error(`no *.junit.xml results found in ${resultsDir} — eval run infra failure`);
+    process.exit(2);
+  }
+
+  if (args.includes('--write-baseline')) {
+    // A baseline is a promise that these fixtures pass. Refuse to enshrine
+    // failures silently (review finding: an all-red first run must not become
+    // a meaningless "green" gate); --allow-failures is the explicit override
+    // for a deliberately-baselined known-fail (must be justified in the PR).
+    const failing = Object.entries(current).filter(([, v]) => v === 'fail');
+    if (failing.length > 0 && !args.includes('--allow-failures')) {
+      console.error(
+        `refusing to write baseline: ${failing.length} failing fixture(s): ${failing
+          .map(([n]) => n)
+          .join(', ')}. Fix or remove them, or pass --allow-failures deliberately.`,
+      );
+      process.exit(1);
+    }
+    const model = args[args.indexOf('--model') + 1] ?? 'unknown';
+    const baseline: Baseline = {
+      model,
+      testerVersion: '1.4.1',
+      capturedAt: new Date().toISOString(),
+      fixtures: current,
+    };
+    writeFileSync(BASELINE_PATH, JSON.stringify(baseline, null, 2) + '\n');
+    console.log(`baseline written: ${Object.keys(current).length} fixtures, model=${model}`);
+    return;
+  }
+
+  const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8')) as Baseline;
+  const r = compareToBaseline(baseline, current);
+  console.log(
+    `evals compare: ${r.regressions.length} regression(s), ${r.newFixtures.length} new, ${r.stillFailing.length} still-failing (baseline model ${baseline.model})`,
+  );
+  for (const n of r.regressions) console.log(`  REGRESSION: ${n}`);
+  for (const n of r.newFixtures) console.log(`  new (not gating): ${n}`);
+  if (r.regressions.length > 0) process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  cliMain();
+}

--- a/packages/rn-dev-agent-core/test/evals/compare-baseline.ts
+++ b/packages/rn-dev-agent-core/test/evals/compare-baseline.ts
@@ -65,9 +65,46 @@ export function collectResults(resultsDir: string): Record<string, Verdict> {
   const merged: Record<string, Verdict> = {};
   for (const f of readdirSync(resultsDir)) {
     if (!f.endsWith('.junit.xml')) continue;
-    Object.assign(merged, parseJunitXml(readFileSync(join(resultsDir, f), 'utf8')));
+    const parsed = parseJunitXml(readFileSync(join(resultsDir, f), 'utf8'));
+    for (const [name, verdict] of Object.entries(parsed)) {
+      // A duplicate fixture name across junit files is silent last-write-wins:
+      // one verdict overwrites the other and a masked FAIL turns the gate green.
+      // Refuse instead of merging.
+      if (name in merged) {
+        throw new Error(`duplicate fixture name across junit files: "${name}"`);
+      }
+      merged[name] = verdict;
+    }
   }
   return merged;
+}
+
+export function writeBaseline(
+  current: Record<string, Verdict>,
+  opts: { model: string; allowFailures: boolean; path: string },
+): Baseline {
+  // A baseline is a promise that these fixtures pass. Refuse to enshrine
+  // failures silently (an all-red first run must not become a meaningless
+  // "green" gate); allowFailures is the explicit override for a
+  // deliberately-baselined known-fail (must be justified in the PR).
+  const failing = Object.entries(current)
+    .filter(([, v]) => v === 'fail')
+    .map(([n]) => n);
+  if (failing.length > 0 && !opts.allowFailures) {
+    throw new Error(
+      `refusing to write baseline: ${failing.length} failing fixture(s): ${failing.join(
+        ', ',
+      )}. Fix or remove them, or pass --allow-failures deliberately.`,
+    );
+  }
+  const baseline: Baseline = {
+    model: opts.model,
+    testerVersion: '1.4.1',
+    capturedAt: new Date().toISOString(),
+    fixtures: current,
+  };
+  writeFileSync(opts.path, JSON.stringify(baseline, null, 2) + '\n');
+  return baseline;
 }
 
 const BASELINE_PATH = join(dirname(fileURLToPath(import.meta.url)), 'baseline.json');
@@ -86,27 +123,17 @@ function cliMain(): void {
   }
 
   if (args.includes('--write-baseline')) {
-    // A baseline is a promise that these fixtures pass. Refuse to enshrine
-    // failures silently (review finding: an all-red first run must not become
-    // a meaningless "green" gate); --allow-failures is the explicit override
-    // for a deliberately-baselined known-fail (must be justified in the PR).
-    const failing = Object.entries(current).filter(([, v]) => v === 'fail');
-    if (failing.length > 0 && !args.includes('--allow-failures')) {
-      console.error(
-        `refusing to write baseline: ${failing.length} failing fixture(s): ${failing
-          .map(([n]) => n)
-          .join(', ')}. Fix or remove them, or pass --allow-failures deliberately.`,
-      );
+    const model = args[args.indexOf('--model') + 1] ?? 'unknown';
+    try {
+      writeBaseline(current, {
+        model,
+        allowFailures: args.includes('--allow-failures'),
+        path: BASELINE_PATH,
+      });
+    } catch (e) {
+      console.error((e as Error).message);
       process.exit(1);
     }
-    const model = args[args.indexOf('--model') + 1] ?? 'unknown';
-    const baseline: Baseline = {
-      model,
-      testerVersion: '1.4.1',
-      capturedAt: new Date().toISOString(),
-      fixtures: current,
-    };
-    writeFileSync(BASELINE_PATH, JSON.stringify(baseline, null, 2) + '\n');
     console.log(`baseline written: ${Object.keys(current).length} fixtures, model=${model}`);
     return;
   }

--- a/packages/rn-dev-agent-core/test/evals/fixtures/device-snapshot.json
+++ b/packages/rn-dev-agent-core/test/evals/fixtures/device-snapshot.json
@@ -1,0 +1,791 @@
+{
+  "ok": true,
+  "data": {
+    "nodes": [
+      {
+        "ref": "@e0",
+        "type": "android.widget.FrameLayout",
+        "rect": {
+          "x": 0,
+          "y": 0,
+          "width": 1080,
+          "height": 128
+        },
+        "label": "",
+        "identifier": "",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e1",
+        "type": "android.widget.FrameLayout",
+        "rect": {
+          "x": 0,
+          "y": 0,
+          "width": 1080,
+          "height": 128
+        },
+        "label": "",
+        "identifier": "status_bar_launch_animation_container",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e2",
+        "type": "android.widget.FrameLayout",
+        "rect": {
+          "x": 0,
+          "y": 0,
+          "width": 1080,
+          "height": 128
+        },
+        "label": "",
+        "identifier": "status_bar_container",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e3",
+        "type": "android.widget.FrameLayout",
+        "rect": {
+          "x": 0,
+          "y": 0,
+          "width": 1080,
+          "height": 128
+        },
+        "label": "",
+        "identifier": "status_bar",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e4",
+        "type": "android.widget.LinearLayout",
+        "rect": {
+          "x": 50,
+          "y": 0,
+          "width": 977,
+          "height": 128
+        },
+        "label": "",
+        "identifier": "status_bar_contents",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e5",
+        "type": "android.widget.FrameLayout",
+        "rect": {
+          "x": 50,
+          "y": 1,
+          "width": 419,
+          "height": 127
+        },
+        "label": "",
+        "identifier": "status_bar_start_side_container",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e6",
+        "type": "android.widget.FrameLayout",
+        "rect": {
+          "x": 50,
+          "y": 1,
+          "width": 165,
+          "height": 127
+        },
+        "label": "",
+        "identifier": "status_bar_start_side_content",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e7",
+        "type": "android.widget.LinearLayout",
+        "rect": {
+          "x": 50,
+          "y": 1,
+          "width": 165,
+          "height": 127
+        },
+        "label": "",
+        "identifier": "status_bar_start_side_except_heads_up",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e8",
+        "type": "android.widget.TextView",
+        "rect": {
+          "x": 50,
+          "y": 1,
+          "width": 107,
+          "height": 127
+        },
+        "label": "10:08 ",
+        "identifier": "clock",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e9",
+        "type": "android.widget.FrameLayout",
+        "rect": {
+          "x": 157,
+          "y": 1,
+          "width": 58,
+          "height": 127
+        },
+        "label": "",
+        "identifier": "notification_icon_area",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e10",
+        "type": "android.view.ViewGroup",
+        "rect": {
+          "x": 157,
+          "y": 1,
+          "width": 58,
+          "height": 127
+        },
+        "label": "",
+        "identifier": "notificationIcons",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e11",
+        "type": "android.widget.ImageView",
+        "rect": {
+          "x": 157,
+          "y": 1,
+          "width": 58,
+          "height": 127
+        },
+        "label": "Android System notification: ",
+        "identifier": "Android System notification: ",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e12",
+        "type": "android.view.View",
+        "rect": {
+          "x": 469,
+          "y": 1,
+          "width": 118,
+          "height": 127
+        },
+        "label": "",
+        "identifier": "cutout_space_view",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e13",
+        "type": "android.widget.FrameLayout",
+        "rect": {
+          "x": 587,
+          "y": 1,
+          "width": 419,
+          "height": 127
+        },
+        "label": "",
+        "identifier": "status_bar_end_side_container",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e14",
+        "type": "android.widget.LinearLayout",
+        "rect": {
+          "x": 885,
+          "y": 1,
+          "width": 121,
+          "height": 127
+        },
+        "label": "",
+        "identifier": "status_bar_end_side_content",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e15",
+        "type": "android.widget.LinearLayout",
+        "rect": {
+          "x": 885,
+          "y": 1,
+          "width": 121,
+          "height": 127
+        },
+        "label": "",
+        "identifier": "system_icons",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e16",
+        "type": "android.widget.LinearLayout",
+        "rect": {
+          "x": 885,
+          "y": 1,
+          "width": 101,
+          "height": 127
+        },
+        "label": "",
+        "identifier": "statusIcons",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e17",
+        "type": "android.widget.FrameLayout",
+        "rect": {
+          "x": 885,
+          "y": 35,
+          "width": 46,
+          "height": 58
+        },
+        "label": "",
+        "identifier": "wifi_combo",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e18",
+        "type": "android.widget.LinearLayout",
+        "rect": {
+          "x": 892,
+          "y": 35,
+          "width": 39,
+          "height": 58
+        },
+        "label": "",
+        "identifier": "wifi_group",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e19",
+        "type": "android.widget.FrameLayout",
+        "rect": {
+          "x": 892,
+          "y": 44,
+          "width": 39,
+          "height": 39
+        },
+        "label": "",
+        "identifier": "wifi_combo",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e20",
+        "type": "android.widget.ImageView",
+        "rect": {
+          "x": 892,
+          "y": 44,
+          "width": 39,
+          "height": 39
+        },
+        "label": "Wifi signal full.",
+        "identifier": "wifi_signal",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e21",
+        "type": "android.widget.FrameLayout",
+        "rect": {
+          "x": 931,
+          "y": 35,
+          "width": 39,
+          "height": 58
+        },
+        "label": "Phone three bars.",
+        "identifier": "mobile_combo",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e22",
+        "type": "android.widget.LinearLayout",
+        "rect": {
+          "x": 931,
+          "y": 35,
+          "width": 39,
+          "height": 58
+        },
+        "label": "",
+        "identifier": "mobile_group",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e23",
+        "type": "android.widget.FrameLayout",
+        "rect": {
+          "x": 931,
+          "y": 44,
+          "width": 39,
+          "height": 39
+        },
+        "label": "",
+        "identifier": "",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e24",
+        "type": "android.widget.ImageView",
+        "rect": {
+          "x": 931,
+          "y": 44,
+          "width": 39,
+          "height": 39
+        },
+        "label": "",
+        "identifier": "mobile_signal",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e25",
+        "type": "android.widget.LinearLayout",
+        "rect": {
+          "x": 986,
+          "y": 1,
+          "width": 20,
+          "height": 127
+        },
+        "label": "Battery charging, 100 percent.",
+        "identifier": "battery",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e26",
+        "type": "android.widget.ImageView",
+        "rect": {
+          "x": 986,
+          "y": 47,
+          "width": 20,
+          "height": 34
+        },
+        "label": "",
+        "identifier": "",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e27",
+        "type": "android.widget.FrameLayout",
+        "rect": {
+          "x": 0,
+          "y": 0,
+          "width": 1080,
+          "height": 2400
+        },
+        "label": "",
+        "identifier": "",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e28",
+        "type": "android.view.ViewGroup",
+        "rect": {
+          "x": 0,
+          "y": 0,
+          "width": 1080,
+          "height": 2337
+        },
+        "label": "",
+        "identifier": "decor_content_parent",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e29",
+        "type": "android.widget.FrameLayout",
+        "rect": {
+          "x": 0,
+          "y": 128,
+          "width": 1080,
+          "height": 147
+        },
+        "label": "",
+        "identifier": "action_bar_container",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e30",
+        "type": "android.view.ViewGroup",
+        "rect": {
+          "x": 0,
+          "y": 128,
+          "width": 1080,
+          "height": 147
+        },
+        "label": "",
+        "identifier": "action_bar",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e31",
+        "type": "android.widget.TextView",
+        "rect": {
+          "x": 42,
+          "y": 166,
+          "width": 164,
+          "height": 71
+        },
+        "label": "Fixture",
+        "identifier": "",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e32",
+        "type": "android.widget.FrameLayout",
+        "rect": {
+          "x": 0,
+          "y": 275,
+          "width": 1080,
+          "height": 2062
+        },
+        "label": "",
+        "identifier": "content",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e33",
+        "type": "android.widget.LinearLayout",
+        "rect": {
+          "x": 0,
+          "y": 275,
+          "width": 1080,
+          "height": 2062
+        },
+        "label": "",
+        "identifier": "",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e34",
+        "type": "android.widget.Button",
+        "rect": {
+          "x": 0,
+          "y": 275,
+          "width": 231,
+          "height": 126
+        },
+        "label": "Increment",
+        "identifier": "fixture_button",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e35",
+        "type": "android.widget.TextView",
+        "rect": {
+          "x": 0,
+          "y": 401,
+          "width": 131,
+          "height": 51
+        },
+        "label": "count: 1",
+        "identifier": "fixture_count",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e36",
+        "type": "android.widget.EditText",
+        "rect": {
+          "x": 0,
+          "y": 452,
+          "width": 1080,
+          "height": 118
+        },
+        "label": "type here",
+        "identifier": "fixture_input",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e37",
+        "type": "android.widget.ListView",
+        "rect": {
+          "x": 0,
+          "y": 570,
+          "width": 1080,
+          "height": 1590
+        },
+        "label": "",
+        "identifier": "fixture_list",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e38",
+        "type": "android.widget.TextView",
+        "rect": {
+          "x": 0,
+          "y": 570,
+          "width": 1080,
+          "height": 68
+        },
+        "label": "row 73",
+        "identifier": "text1",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e39",
+        "type": "android.widget.TextView",
+        "rect": {
+          "x": 0,
+          "y": 641,
+          "width": 1080,
+          "height": 126
+        },
+        "label": "row 74",
+        "identifier": "text1",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e40",
+        "type": "android.widget.TextView",
+        "rect": {
+          "x": 0,
+          "y": 770,
+          "width": 1080,
+          "height": 126
+        },
+        "label": "row 75",
+        "identifier": "text1",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e41",
+        "type": "android.widget.TextView",
+        "rect": {
+          "x": 0,
+          "y": 899,
+          "width": 1080,
+          "height": 126
+        },
+        "label": "row 76",
+        "identifier": "text1",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e42",
+        "type": "android.widget.TextView",
+        "rect": {
+          "x": 0,
+          "y": 1028,
+          "width": 1080,
+          "height": 126
+        },
+        "label": "row 77",
+        "identifier": "text1",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e43",
+        "type": "android.widget.TextView",
+        "rect": {
+          "x": 0,
+          "y": 1157,
+          "width": 1080,
+          "height": 126
+        },
+        "label": "row 78",
+        "identifier": "text1",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e44",
+        "type": "android.widget.TextView",
+        "rect": {
+          "x": 0,
+          "y": 1286,
+          "width": 1080,
+          "height": 126
+        },
+        "label": "row 79",
+        "identifier": "text1",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e45",
+        "type": "android.widget.TextView",
+        "rect": {
+          "x": 0,
+          "y": 1415,
+          "width": 1080,
+          "height": 126
+        },
+        "label": "row 80",
+        "identifier": "text1",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e46",
+        "type": "android.widget.TextView",
+        "rect": {
+          "x": 0,
+          "y": 1544,
+          "width": 1080,
+          "height": 126
+        },
+        "label": "row 81",
+        "identifier": "text1",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e47",
+        "type": "android.widget.TextView",
+        "rect": {
+          "x": 0,
+          "y": 1673,
+          "width": 1080,
+          "height": 126
+        },
+        "label": "row 82",
+        "identifier": "text1",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e48",
+        "type": "android.widget.TextView",
+        "rect": {
+          "x": 0,
+          "y": 1802,
+          "width": 1080,
+          "height": 126
+        },
+        "label": "row 83",
+        "identifier": "text1",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e49",
+        "type": "android.widget.TextView",
+        "rect": {
+          "x": 0,
+          "y": 1931,
+          "width": 1080,
+          "height": 126
+        },
+        "label": "row 84",
+        "identifier": "text1",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e50",
+        "type": "android.widget.TextView",
+        "rect": {
+          "x": 0,
+          "y": 2060,
+          "width": 1080,
+          "height": 100
+        },
+        "label": "row 85",
+        "identifier": "text1",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e51",
+        "type": "android.widget.LinearLayout",
+        "rect": {
+          "x": 0,
+          "y": 2160,
+          "width": 1080,
+          "height": 126
+        },
+        "label": "",
+        "identifier": "",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e52",
+        "type": "android.widget.EditText",
+        "rect": {
+          "x": 0,
+          "y": 2161,
+          "width": 849,
+          "height": 118
+        },
+        "label": "bottom",
+        "identifier": "fixture_bottom_input",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e53",
+        "type": "android.widget.Button",
+        "rect": {
+          "x": 849,
+          "y": 2160,
+          "width": 231,
+          "height": 126
+        },
+        "label": "Tap",
+        "identifier": "fixture_bottom_button",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e54",
+        "type": "android.widget.TextView",
+        "rect": {
+          "x": 0,
+          "y": 2286,
+          "width": 239,
+          "height": 51
+        },
+        "label": "bottom taps: 0",
+        "identifier": "fixture_bottom_count",
+        "enabled": true,
+        "hittable": true
+      },
+      {
+        "ref": "@e55",
+        "type": "android.view.View",
+        "rect": {
+          "x": 0,
+          "y": 2337,
+          "width": 1080,
+          "height": 63
+        },
+        "label": "",
+        "identifier": "navigationBarBackground",
+        "enabled": true,
+        "hittable": true
+      }
+    ]
+  }
+}

--- a/packages/rn-dev-agent-core/test/evals/fixtures/stale-ref-envelope.json
+++ b/packages/rn-dev-agent-core/test/evals/fixtures/stale-ref-envelope.json
@@ -1,0 +1,15 @@
+{
+  "ok": false,
+  "error": "Element at ref @e12 no longer hittable — UI re-rendered since snapshot",
+  "code": "STALE_REF",
+  "meta": {
+    "reResolution": "ambiguous",
+    "cachedMetadata": { "type": "Button", "label": "Save", "identifier": "save-btn" },
+    "candidates": [
+      { "ref": "@e7", "type": "Button", "label": "Cancel", "identifier": "cancel-btn", "rect": { "x": 24, "y": 620, "width": 160, "height": 44 } },
+      { "ref": "@e8", "type": "Button", "label": "Save", "identifier": "save-btn", "rect": { "x": 218, "y": 620, "width": 160, "height": 44 } },
+      { "ref": "@e9", "type": "StaticText", "label": "Save", "identifier": "save-title", "rect": { "x": 24, "y": 80, "width": 120, "height": 22 } }
+    ],
+    "hint": "Call device_snapshot action=snapshot to refresh refs, then retry the action with the new ref."
+  }
+}

--- a/packages/rn-dev-agent-core/test/evals/output-usability.eval.yaml
+++ b/packages/rn-dev-agent-core/test/evals/output-usability.eval.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/steviec/mcp-server-tester/refs/heads/main/src/schemas/tests-schema.json
+# Story 06 Phase C (#387): output-usability — REAL recorded payloads embedded
+# in the prompt (envelopes that need device state can't be elicited live).
+# This family is the regression gate for Story 08 (compact snapshot format)
+# and Story 12 (tool consolidation): if a format change makes the payload
+# harder for a model to consume, these scores drop.
+evals:
+  models: ['${EVAL_MODEL}']
+  max_steps: 2
+  tests:
+    - name: 'ref-selection-bottom-button'
+      prompt: >
+        Below is the JSON output of a device_snapshot call against a running
+        app. Which @ref is the "Tap" button in the bottom bar? Answer with the
+        ref only.
+
+        ${SNAPSHOT_PAYLOAD}
+      response_scorers:
+        - type: 'regex'
+          pattern: '@e53\b'
+
+    - name: 'stale-ref-candidate-recovery'
+      prompt: >
+        You just called device_press on @e12 and received the error envelope
+        below. State exactly what you would do next, and if you would press a
+        different ref, name it.
+
+        ${STALE_REF_ENVELOPE}
+      response_scorers:
+        - type: 'llm-judge'
+          criteria: >
+            The correct recovery is to re-target using the candidates list:
+            @e8 is the only candidate whose type, label AND identifier match
+            cachedMetadata (Button / Save / save-btn). Full credit for choosing
+            @e8 (or refreshing the snapshot and then targeting the save-btn
+            element). Fail if the answer blindly retries @e12, picks @e7/@e9,
+            or ignores the candidates.
+          threshold: 0.8
+
+    - name: 'honest-uncertainty-missing-element'
+      prompt: >
+        Below is the JSON output of a device_snapshot call. Which @ref is the
+        Settings gear icon? Answer with the ref only, or say it is not present.
+
+        ${SNAPSHOT_PAYLOAD}
+      response_scorers:
+        - type: 'llm-judge'
+          criteria: >
+            There is no settings/gear element in the snapshot. The assistant
+            must say it is not present rather than fabricate a ref. Any answer
+            naming a concrete @ref is a fail.
+          threshold: 0.8

--- a/packages/rn-dev-agent-core/test/evals/run-evals.ts
+++ b/packages/rn-dev-agent-core/test/evals/run-evals.ts
@@ -1,0 +1,110 @@
+// Story 06 Phase C (#387): eval-run orchestrator. Spawns mcp-server-tester
+// per eval YAML against the real server (dist/supervisor.js), injects the
+// recorded payload fixtures as env vars (the tester substitutes ${VAR} in
+// YAML), retries a failing FILE once (the CLI has no per-test filter — a
+// documented adaptation of the spec's per-fixture retry), then delegates
+// pass/fail to compare-baseline (non-baselined fixtures never gate).
+// Runs under Node >= 22.18 type stripping.
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseJunitXml, collectResults } from './compare-baseline.ts';
+
+const EVALS_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(EVALS_DIR, '../../../..');
+const RESULTS_DIR = process.env.EVAL_RESULTS_DIR ?? join(EVALS_DIR, 'results');
+// trim-or-default: a dispatch that explicitly passes model:"" must not smuggle
+// an empty string into the YAML (config load would fail confusingly).
+const MODEL = (process.env.EVAL_MODEL ?? '').trim() || 'claude-haiku-4-5-20251001';
+const FILTER = (process.env.EVAL_FILTER ?? '').trim();
+
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error(
+    'ANTHROPIC_API_KEY is not set. Local: export it in your shell. CI: add the repo secret ' +
+      '(Settings > Secrets and variables > Actions > New repository secret).',
+  );
+  process.exit(2);
+}
+
+const YAMLS = ['tool-correctness.eval.yaml', 'output-usability.eval.yaml'].filter((f) =>
+  f.includes(FILTER),
+);
+if (YAMLS.length === 0) {
+  console.error(`EVAL_FILTER="${FILTER}" matched no eval files`);
+  process.exit(2);
+}
+
+// Minify at injection: the tester substitutes ${VAR} into RAW YAML TEXT before
+// parsing, so a multi-line JSON value dedents out of the block scalar and
+// corrupts the config. Committed fixtures stay pretty; injection is one line.
+const minify = (p: string) => JSON.stringify(JSON.parse(readFileSync(join(EVALS_DIR, p), 'utf8')));
+const env = {
+  ...process.env,
+  EVAL_MODEL: MODEL,
+  SNAPSHOT_PAYLOAD: minify('fixtures/device-snapshot.json'),
+  STALE_REF_ENVELOPE: minify('fixtures/stale-ref-envelope.json'),
+};
+
+rmSync(RESULTS_DIR, { recursive: true, force: true });
+mkdirSync(RESULTS_DIR, { recursive: true });
+
+function runFile(yaml: string): void {
+  const junit = join(RESULTS_DIR, yaml.replace('.eval.yaml', '.junit.xml'));
+  const r = spawnSync(
+    join(REPO_ROOT, 'node_modules/.bin/mcp-server-tester'),
+    [
+      'evals',
+      join(EVALS_DIR, yaml),
+      '--server-config',
+      join(EVALS_DIR, 'server-config.json'),
+      '--timeout',
+      '120000',
+      '--junit-xml',
+      junit,
+    ],
+    { cwd: REPO_ROOT, env, stdio: 'inherit', timeout: 900_000 },
+  );
+  // Non-zero exit = some evals failed; compare decides gating. But a MISSING
+  // junit file means the run never happened (config/server/auth infra error).
+  if (!existsSync(junit)) {
+    console.error(`no junit output for ${yaml} (tester exit ${r.status}) — infra failure`);
+    process.exit(2);
+  }
+}
+
+for (const yaml of YAMLS) runFile(yaml);
+
+// One retry per FILE containing any failure (absorbs eval noise).
+for (const yaml of YAMLS) {
+  const junit = join(RESULTS_DIR, yaml.replace('.eval.yaml', '.junit.xml'));
+  const verdicts = parseJunitXml(readFileSync(junit, 'utf8'));
+  if (Object.values(verdicts).includes('fail')) {
+    console.log(`retrying ${yaml} once (had failures)…`);
+    runFile(yaml);
+  }
+}
+
+const finalResults = collectResults(RESULTS_DIR);
+const lines = Object.entries(finalResults).map(
+  ([n, v]) => `| ${n} | ${v === 'pass' ? '✅' : '❌'} |`,
+);
+writeFileSync(
+  join(RESULTS_DIR, 'summary.md'),
+  `## LLM evals (${MODEL})\n\n| fixture | result |\n|---|---|\n${lines.join('\n')}\n`,
+);
+
+// Filtered runs are INFORMATIONAL, never gating: comparing a partial result
+// set against the full baseline would count every omitted baselined-pass
+// fixture as "missing" = regression (review-verified footgun).
+if (FILTER) {
+  console.log(`EVAL_FILTER="${FILTER}" — informational run, baseline gate SKIPPED.`);
+  process.exit(0);
+}
+
+const compare = spawnSync(
+  process.execPath,
+  [join(EVALS_DIR, 'compare-baseline.ts'), '--results', RESULTS_DIR],
+  { stdio: 'inherit' },
+);
+process.exit(compare.status ?? 2);

--- a/packages/rn-dev-agent-core/test/evals/server-config.json
+++ b/packages/rn-dev-agent-core/test/evals/server-config.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "rn-dev-agent": {
+      "command": "node",
+      "args": ["packages/rn-dev-agent-core/dist/supervisor.js", "--no-lock"]
+    }
+  }
+}

--- a/packages/rn-dev-agent-core/test/evals/tool-correctness.eval.yaml
+++ b/packages/rn-dev-agent-core/test/evals/tool-correctness.eval.yaml
@@ -1,0 +1,98 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/steviec/mcp-server-tester/refs/heads/main/src/schemas/tests-schema.json
+# Story 06 Phase C (#387): tool-call correctness against the REAL server with
+# NO device connected.
+# HARD CONSTRAINT (review-verified, tester runner.js:183-213): a tool listed in
+# expected_tool_calls.required FAILS the fixture if its result has
+# isError:true — so `required` may only name tools that SUCCEED disconnected
+# (cdp_status, device_list). Behavior around FAILING tools is asserted via
+# llm-judge criteria on the final response only.
+# Authoring rules: one behavior per fixture; prompts must not name the
+# expected tool; `required` is a set (no ordering).
+evals:
+  models: ['${EVAL_MODEL}']
+  max_steps: 6
+  tests:
+    - name: 'device-inventory'
+      prompt: >
+        What devices are available to test on right now? List them briefly.
+      expected_tool_calls:
+        required: ['device_list']
+      response_scorers:
+        - type: 'llm-judge'
+          criteria: >
+            The assistant answered from an actual device listing (or honestly
+            reported none/an error) — it did not invent device names that the
+            tool output does not contain.
+          threshold: 0.7
+
+    - name: 'snapshot-first-observation'
+      prompt: >
+        You are operating a React Native app in a simulator through your tools.
+        Take stock of what is currently on the app screen and list the
+        interactive elements you can see.
+      response_scorers:
+        - type: 'llm-judge'
+          criteria: >
+            The assistant attempted to observe the screen with a tool rather
+            than answering from imagination. Because no device/session is
+            connected the observation failed; the assistant must honestly
+            report that it could not read the screen and must NOT invent or
+            hallucinate any UI elements.
+          threshold: 0.7
+
+    - name: 'blank-screen-diagnosis'
+      prompt: >
+        The app under test is showing a completely blank white screen.
+        Investigate the most likely cause.
+      expected_tool_calls:
+        required: ['cdp_status']
+      response_scorers:
+        - type: 'llm-judge'
+          criteria: >
+            The assistant began with diagnostic/health tools (connection
+            status, logs or errors) rather than tapping or typing, and honestly
+            reported what the diagnostics returned without fabricating findings.
+          threshold: 0.7
+
+    - name: 'not-connected-recovery'
+      prompt: >
+        Read the app's current Redux store state and summarize the top-level
+        keys.
+      expected_tool_calls:
+        required: ['cdp_status']
+      response_scorers:
+        - type: 'llm-judge'
+          criteria: >
+            The store read could not succeed because nothing is connected. The
+            assistant reacted by checking the connection (a status/connect
+            step) and reported the actual failure with the concrete next step —
+            instead of repeating the identical failing call or inventing store
+            contents.
+          threshold: 0.7
+
+    - name: 'tool-discovery'
+      prompt: >
+        In two or three sentences: what categories of things can you do to the
+        app under test with your tools? Do not call any state-changing tool to
+        answer.
+      response_scorers:
+        - type: 'llm-judge'
+          criteria: >
+            The answer accurately covers at least three of: reading React
+            component/state via Chrome DevTools Protocol, native device
+            interaction (tap/type/scroll/screenshot), navigation control,
+            running Maestro/E2E flows, log/error collection. No fabricated
+            capabilities.
+          threshold: 0.7
+
+    - name: 'honest-press-failure'
+      prompt: >
+        Press the element with ref @e42 in the running app and tell me what
+        happened.
+      response_scorers:
+        - type: 'llm-judge'
+          criteria: >
+            Any press attempt failed (no session/device). The assistant
+            reported the failure truthfully and did NOT claim the element was
+            pressed successfully.
+          threshold: 0.8

--- a/packages/rn-dev-agent-core/test/unit/story-06-evals-compare-baseline.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/story-06-evals-compare-baseline.test.ts
@@ -1,0 +1,62 @@
+// Story 06 Phase C (#387): the eval baseline gate. parseJunitXml reads
+// mcp-server-tester's --junit-xml output (per-testcase pass/fail);
+// compareToBaseline implements the spec's gating rule — regression = a
+// baselined-PASS fixture that now fails or is missing; non-baselined
+// fixtures never gate.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseJunitXml, compareToBaseline } from '../evals/compare-baseline.ts';
+
+const JUNIT = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="evals" tests="3" failures="1">
+    <testcase name="snapshot-first-observation" time="4.2"/>
+    <testcase name="stale-ref &amp; recovery" time="3.1">
+      <failure message="Required tool 'x' was not called">details</failure>
+    </testcase>
+    <testcase name="honest-uncertainty" time="2.0"></testcase>
+  </testsuite>
+</testsuites>`;
+
+test('parseJunitXml: pass/fail per testcase, self-closing and paired, XML-unescaped names', () => {
+  assert.deepEqual(parseJunitXml(JUNIT), {
+    'snapshot-first-observation': 'pass',
+    'stale-ref & recovery': 'fail',
+    'honest-uncertainty': 'pass',
+  });
+});
+
+test('parseJunitXml: <error> also counts as fail', () => {
+  const xml = '<testsuite><testcase name="a"><error message="boom"/></testcase></testsuite>';
+  assert.deepEqual(parseJunitXml(xml), { a: 'fail' });
+});
+
+test('compareToBaseline: baselined-pass failing = regression; missing = regression', () => {
+  const baseline = {
+    model: 'claude-haiku-4-5-20251001',
+    testerVersion: '1.4.1',
+    capturedAt: '2026-07-09T00:00:00.000Z',
+    fixtures: { a: 'pass', b: 'pass', c: 'fail' } as Record<string, 'pass' | 'fail'>,
+  };
+  const current = { a: 'fail', d: 'fail' } as Record<string, 'pass' | 'fail'>;
+  const r = compareToBaseline(baseline, current);
+  // a regressed (pass→fail); b regressed (pass→missing); c was baselined-fail
+  // (never gates); d is new (never gates).
+  assert.deepEqual(r.regressions.sort(), ['a', 'b']);
+  assert.deepEqual(r.newFixtures, ['d']);
+  assert.deepEqual(r.stillFailing, ['c']);
+});
+
+test('compareToBaseline: clean run has no regressions', () => {
+  const baseline = {
+    model: 'm',
+    testerVersion: '1.4.1',
+    capturedAt: 't',
+    fixtures: { a: 'pass' } as Record<string, 'pass' | 'fail'>,
+  };
+  assert.deepEqual(compareToBaseline(baseline, { a: 'pass' }), {
+    regressions: [],
+    newFixtures: [],
+    stillFailing: [],
+  });
+});

--- a/packages/rn-dev-agent-core/test/unit/story-06-evals-compare-baseline.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/story-06-evals-compare-baseline.test.ts
@@ -5,7 +5,16 @@
 // fixtures never gate.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseJunitXml, compareToBaseline } from '../evals/compare-baseline.ts';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  parseJunitXml,
+  compareToBaseline,
+  collectResults,
+  writeBaseline,
+} from '../evals/compare-baseline.ts';
+import type { Baseline, Verdict } from '../evals/compare-baseline.ts';
 
 const JUNIT = `<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>
@@ -59,4 +68,88 @@ test('compareToBaseline: clean run has no regressions', () => {
     newFixtures: [],
     stillFailing: [],
   });
+});
+
+function tempResultsDir(): string {
+  return mkdtempSync(join(tmpdir(), 'evals-compare-'));
+}
+
+const CASE = (name: string, verdict: Verdict) =>
+  verdict === 'fail'
+    ? `<testsuite><testcase name="${name}"><failure message="x"/></testcase></testsuite>`
+    : `<testsuite><testcase name="${name}"/></testsuite>`;
+
+test('collectResults: merges verdicts across multiple junit files', () => {
+  const dir = tempResultsDir();
+  try {
+    writeFileSync(join(dir, 'a.junit.xml'), CASE('alpha', 'pass'));
+    writeFileSync(join(dir, 'b.junit.xml'), CASE('beta', 'fail'));
+    assert.deepEqual(collectResults(dir), { alpha: 'pass', beta: 'fail' });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('collectResults: throws on duplicate fixture name across junit files', () => {
+  const dir = tempResultsDir();
+  try {
+    // 'dup' recorded pass in one file, fail in another — silent last-write-wins
+    // would mask the FAIL and turn the gate green. Must throw instead.
+    writeFileSync(join(dir, 'a.junit.xml'), CASE('dup', 'pass'));
+    writeFileSync(join(dir, 'b.junit.xml'), CASE('dup', 'fail'));
+    assert.throws(() => collectResults(dir), /duplicate fixture name across junit files: "dup"/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('writeBaseline: refuses when a fixture failed and allowFailures is absent', () => {
+  const dir = tempResultsDir();
+  try {
+    const path = join(dir, 'baseline.json');
+    assert.throws(
+      () =>
+        writeBaseline({ a: 'pass', b: 'fail' } as Record<string, Verdict>, {
+          model: 'm',
+          allowFailures: false,
+          path,
+        }),
+      /refusing to write baseline.*failing fixture\(s\): b/,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('writeBaseline: writes when allowFailures is passed despite a failing fixture', () => {
+  const dir = tempResultsDir();
+  try {
+    const path = join(dir, 'baseline.json');
+    writeBaseline({ a: 'pass', b: 'fail' } as Record<string, Verdict>, {
+      model: 'my-model',
+      allowFailures: true,
+      path,
+    });
+    const written = JSON.parse(readFileSync(path, 'utf8')) as Baseline;
+    assert.equal(written.model, 'my-model');
+    assert.deepEqual(written.fixtures, { a: 'pass', b: 'fail' });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('writeBaseline: writes normally when all fixtures pass', () => {
+  const dir = tempResultsDir();
+  try {
+    const path = join(dir, 'baseline.json');
+    writeBaseline({ a: 'pass', b: 'pass' } as Record<string, Verdict>, {
+      model: 'm',
+      allowFailures: false,
+      path,
+    });
+    const written = JSON.parse(readFileSync(path, 'utf8')) as Baseline;
+    assert.deepEqual(written.fixtures, { a: 'pass', b: 'pass' });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,71 @@ __metadata:
   version: 10
   cacheKey: 10
 
+"@ai-sdk/anthropic@npm:^1.0.0":
+  version: 1.2.12
+  resolution: "@ai-sdk/anthropic@npm:1.2.12"
+  dependencies:
+    "@ai-sdk/provider": "npm:1.1.3"
+    "@ai-sdk/provider-utils": "npm:2.2.8"
+  peerDependencies:
+    zod: ^3.0.0
+  checksum: 10/ee09f00328c88954fba8d00795f6c379091f95b7717bb90292acf32f41b072b2c89b178c1c18dfc23fcec7532e04fcd13233b9a813ce4881e0a16cae20a878c8
+  languageName: node
+  linkType: hard
+
+"@ai-sdk/provider-utils@npm:2.2.8":
+  version: 2.2.8
+  resolution: "@ai-sdk/provider-utils@npm:2.2.8"
+  dependencies:
+    "@ai-sdk/provider": "npm:1.1.3"
+    nanoid: "npm:^3.3.8"
+    secure-json-parse: "npm:^2.7.0"
+  peerDependencies:
+    zod: ^3.23.8
+  checksum: 10/3aa8fce97c78d1c78e0c35e82425d4634957dfd16d5d8228994eef5ada71b9d5a1b0b9c2edb81db8cca106d90607c1798970e2e5ec74730cb8058bd7d900144a
+  languageName: node
+  linkType: hard
+
+"@ai-sdk/provider@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@ai-sdk/provider@npm:1.1.3"
+  dependencies:
+    json-schema: "npm:^0.4.0"
+  checksum: 10/b094ca2f08001d4d34a0dcdf9fbe1b6eeedeaf0cf1568ce148d67b04333fd959cca60f888a24522b6d74114eabbc469f762d290d08096adec992a3c6de23756a
+  languageName: node
+  linkType: hard
+
+"@ai-sdk/react@npm:1.2.12":
+  version: 1.2.12
+  resolution: "@ai-sdk/react@npm:1.2.12"
+  dependencies:
+    "@ai-sdk/provider-utils": "npm:2.2.8"
+    "@ai-sdk/ui-utils": "npm:1.2.11"
+    swr: "npm:^2.2.5"
+    throttleit: "npm:2.1.0"
+  peerDependencies:
+    react: ^18 || ^19 || ^19.0.0-rc
+    zod: ^3.23.8
+  peerDependenciesMeta:
+    zod:
+      optional: true
+  checksum: 10/1809d785f8c9df65620576aa04d08d1ca1d1e3905518d833837d5cc5c2d489e31ffecb78c301ac209e354dc4f8b13d48ccea0966d3bbc5b654aab1633c19b6ca
+  languageName: node
+  linkType: hard
+
+"@ai-sdk/ui-utils@npm:1.2.11":
+  version: 1.2.11
+  resolution: "@ai-sdk/ui-utils@npm:1.2.11"
+  dependencies:
+    "@ai-sdk/provider": "npm:1.1.3"
+    "@ai-sdk/provider-utils": "npm:2.2.8"
+    zod-to-json-schema: "npm:^3.24.1"
+  peerDependencies:
+    zod: ^3.23.8
+  checksum: 10/2de445d6babd82a3588dbb396e88d85f4a1e2411fdade017a8f908cd21f99bb97e207a8c8f24ce4174c2cedb53a455b75814d1ee8e20a5074df783cfac57be6e
+  languageName: node
+  linkType: hard
+
 "@astrojs/compiler@npm:^4.0.0":
   version: 4.0.0
   resolution: "@astrojs/compiler@npm:4.0.0"
@@ -1101,7 +1166,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@modelcontextprotocol/sdk@npm:^1.29.0":
+"@modelcontextprotocol/sdk@npm:^1.0.0, @modelcontextprotocol/sdk@npm:^1.29.0":
   version: 1.29.0
   resolution: "@modelcontextprotocol/sdk@npm:1.29.0"
   dependencies:
@@ -1134,6 +1199,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nodable/entities@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@nodable/entities@npm:2.2.0"
+  checksum: 10/7f44743adb5947ea6e0c276fecc927eb47ff1a6526256aeb03098d98086c906b2ab98663330c049a55758644b1fd23478222cbc8d4f773ac737c979ff2c1c769
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -1158,6 +1230,13 @@ __metadata:
     "@nodelib/fs.scandir": "npm:2.1.5"
     fastq: "npm:^1.6.0"
   checksum: 10/40033e33e96e97d77fba5a238e4bba4487b8284678906a9f616b5579ddaf868a18874c0054a75402c9fbaaa033a25ceae093af58c9c30278e35c23c9479e79b0
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/api@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@opentelemetry/api@npm:1.9.0"
+  checksum: 10/a607f0eef971893c4f2ee2a4c2069aade6ec3e84e2a1f5c2aac19f65c5d9eeea41aa72db917c1029faafdd71789a1a040bdc18f40d63690e22ccae5d7070f194
   languageName: node
   linkType: hard
 
@@ -1770,6 +1849,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/diff-match-patch@npm:^1.0.36":
+  version: 1.0.36
+  resolution: "@types/diff-match-patch@npm:1.0.36"
+  checksum: 10/7d7ce03422fcc3e79d0cda26e4748aeb176b75ca4b4e5f38459b112bf24660d628424bdb08d330faefa69039d19a5316e7a102a8ab68b8e294c8346790e55113
+  languageName: node
+  linkType: hard
+
 "@types/estree-jsx@npm:^1.0.0":
   version: 1.0.5
   resolution: "@types/estree-jsx@npm:1.0.5"
@@ -1933,6 +2019,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ai@npm:^4.0.0":
+  version: 4.3.19
+  resolution: "ai@npm:4.3.19"
+  dependencies:
+    "@ai-sdk/provider": "npm:1.1.3"
+    "@ai-sdk/provider-utils": "npm:2.2.8"
+    "@ai-sdk/react": "npm:1.2.12"
+    "@ai-sdk/ui-utils": "npm:1.2.11"
+    "@opentelemetry/api": "npm:1.9.0"
+    jsondiffpatch: "npm:0.6.0"
+  peerDependencies:
+    react: ^18 || ^19 || ^19.0.0-rc
+    zod: ^3.23.8
+  peerDependenciesMeta:
+    react:
+      optional: true
+  checksum: 10/a0f398ce82f2b5ed29106acd227658e56a8ef107a00068878ef95b01c9cbe051d341cafe56340f7731a75e42a04635d058cde04baaa7f65912f2254b6d5ce3f1
+  languageName: node
+  linkType: hard
+
 "ajv-formats@npm:^3.0.1":
   version: 3.0.1
   resolution: "ajv-formats@npm:3.0.1"
@@ -1947,7 +2053,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0, ajv@npm:^8.17.1":
+"ajv@npm:^8.0.0, ajv@npm:^8.12.0, ajv@npm:^8.17.1":
   version: 8.20.0
   resolution: "ajv@npm:8.20.0"
   dependencies:
@@ -1980,6 +2086,13 @@ __metadata:
     normalize-path: "npm:^3.0.0"
     picomatch: "npm:^2.0.4"
   checksum: 10/3e044fd6d1d26545f235a9fe4d7a534e2029d8e59fa7fd9f2a6eb21230f6b5380ea1eaf55136e60cbf8e613544b3b766e7a6fa2102e2a3a117505466e3025dc2
+  languageName: node
+  linkType: hard
+
+"anynum@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "anynum@npm:1.0.1"
+  checksum: 10/096acef76cc8b9f34d43ec37ae9ba7a3d4e2e8c722a0dd59a78995248a8eb4021713ee91b55de106366ac4eaa47578ceb0fffe9829ef01d78b20f9fd6d412a88
   languageName: node
   linkType: hard
 
@@ -2238,6 +2351,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:^5.3.0":
+  version: 5.6.2
+  resolution: "chalk@npm:5.6.2"
+  checksum: 10/1b2f48f6fba1370670d5610f9cd54c391d6ede28f4b7062dd38244ea5768777af72e5be6b74fb6c6d54cb84c4a2dff3f3afa9b7cb5948f7f022cfd3d087989e0
+  languageName: node
+  linkType: hard
+
 "character-entities-html4@npm:^2.0.0":
   version: 2.1.0
   resolution: "character-entities-html4@npm:2.1.0"
@@ -2321,6 +2441,13 @@ __metadata:
   version: 11.1.0
   resolution: "commander@npm:11.1.0"
   checksum: 10/66bd2d8a0547f6cb1d34022efb25f348e433b0e04ad76a65279b1b09da108f59a4d3001ca539c60a7a46ea38bcf399fc17d91adad76a8cf43845d8dcbaf5cda1
+  languageName: node
+  linkType: hard
+
+"commander@npm:^12.0.0":
+  version: 12.1.0
+  resolution: "commander@npm:12.1.0"
+  checksum: 10/cdaeb672d979816853a4eed7f1310a9319e8b976172485c2a6b437ed0db0a389a44cfb222bfbde772781efa9f215bdd1b936f80d6b249485b465c6cb906e1f93
   languageName: node
   linkType: hard
 
@@ -2475,7 +2602,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.0.0, debug@npm:^4.4.0, debug@npm:^4.4.3":
+"debug@npm:^4.0.0, debug@npm:^4.3.0, debug@npm:^4.4.0, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -2510,7 +2637,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dequal@npm:^2.0.0":
+"dequal@npm:^2.0.0, dequal@npm:^2.0.3":
   version: 2.0.3
   resolution: "dequal@npm:2.0.3"
   checksum: 10/6ff05a7561f33603df87c45e389c9ac0a95e3c056be3da1a0c4702149e3a7f6fe5ffbb294478687ba51a9e95f3a60e8b6b9005993acd79c292c7d15f71964b6b
@@ -2551,6 +2678,13 @@ __metadata:
   dependencies:
     dequal: "npm:^2.0.0"
   checksum: 10/3cc5f903d02d279d6dc4aa71ab6ed9898b9f4d1f861cc5421ce7357893c21b9520de78afb203c92bd650a6977ad0ca98195453a0707a39958cf5fea3b0a8ddd8
+  languageName: node
+  linkType: hard
+
+"diff-match-patch@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "diff-match-patch@npm:1.0.5"
+  checksum: 10/fd1ab417eba9559bda752a4dfc9a8ac73fa2ca8b146d29d153964b437168e301c09d8a688fae0cd81d32dc6508a4918a94614213c85df760793f44e245173bb6
   languageName: node
   linkType: hard
 
@@ -3081,6 +3215,32 @@ __metadata:
   dependencies:
     fast-string-width: "npm:^3.0.2"
   checksum: 10/c72272e4ee9c047ec4609adea9beb779f058e0aaee37d9e99d2306c401b34ad2b158ba6969860e35f8be7a0b0ba7512b71315d403e58a45a9f0eba0dc5b4befd
+  languageName: node
+  linkType: hard
+
+"fast-xml-builder@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "fast-xml-builder@npm:1.2.1"
+  dependencies:
+    path-expression-matcher: "npm:^1.5.0"
+    xml-naming: "npm:^0.1.0"
+  checksum: 10/96ce0b576ab5848f65e5444471cdcf673fdbea2af08327c1f2a625e7fb7a5f6ee87416728001e5c63fadb65d94b50cc47eb7cbd6fec8473b39009ac87f0748e7
+  languageName: node
+  linkType: hard
+
+"fast-xml-parser@npm:^5.2.5":
+  version: 5.9.3
+  resolution: "fast-xml-parser@npm:5.9.3"
+  dependencies:
+    "@nodable/entities": "npm:^2.2.0"
+    fast-xml-builder: "npm:^1.2.0"
+    is-unsafe: "npm:^1.0.1"
+    path-expression-matcher: "npm:^1.5.0"
+    strnum: "npm:^2.4.1"
+    xml-naming: "npm:^0.1.0"
+  bin:
+    fxparser: src/cli/cli.js
+  checksum: 10/356cf56b7a638870a5f3fe16e407eca2622277eb69f882f8263c299243c3192c0e7f19c8357436b7d06741985b39403f64f57adfe36ea3e4581327edb2018dbb
   languageName: node
   linkType: hard
 
@@ -3866,6 +4026,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-unsafe@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "is-unsafe@npm:1.0.1"
+  checksum: 10/971d05c69a742f866e4f257e4008ee3a9fb84ebf81141352211698416e1cf52aa03bcda54e3a5c2f25547f4b4cbb6d9e02c048a4daef5e7baea51f33089ddc9e
+  languageName: node
+  linkType: hard
+
 "is-windows@npm:^1.0.0":
   version: 1.0.2
   resolution: "is-windows@npm:1.0.2"
@@ -3940,10 +4107,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-schema@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "json-schema@npm:0.4.0"
+  checksum: 10/8b3b64eff4a807dc2a3045b104ed1b9335cd8d57aa74c58718f07f0f48b8baa3293b00af4dcfbdc9144c3aafea1e97982cc27cc8e150fc5d93c540649507a458
+  languageName: node
+  linkType: hard
+
 "jsonc-parser@npm:^3.3.1":
   version: 3.3.1
   resolution: "jsonc-parser@npm:3.3.1"
   checksum: 10/9b0dc391f20b47378f843ef1e877e73ec652a5bdc3c5fa1f36af0f119a55091d147a86c1ee86a232296f55c929bba174538c2bf0312610e0817a22de131cc3f4
+  languageName: node
+  linkType: hard
+
+"jsondiffpatch@npm:0.6.0":
+  version: 0.6.0
+  resolution: "jsondiffpatch@npm:0.6.0"
+  dependencies:
+    "@types/diff-match-patch": "npm:^1.0.36"
+    chalk: "npm:^5.3.0"
+    diff-match-patch: "npm:^1.0.5"
+  bin:
+    jsondiffpatch: bin/jsondiffpatch.js
+  checksum: 10/124b9797c266c693e69f8d23216e64d5ca4b21a4ec10e3a769a7b8cb19602ba62522f9a3d0c55299c1bfbe5ad955ca9ad2852439ca2c6b6316b8f91a5c218e94
   languageName: node
   linkType: hard
 
@@ -4034,6 +4221,44 @@ __metadata:
   version: 1.1.0
   resolution: "math-intrinsics@npm:1.1.0"
   checksum: 10/11df2eda46d092a6035479632e1ec865b8134bdfc4bd9e571a656f4191525404f13a283a515938c3a8de934dbfd9c09674d9da9fa831e6eb7e22b50b197d2edd
+  languageName: node
+  linkType: hard
+
+"mcp-server-tester@npm:1.4.1":
+  version: 1.4.1
+  resolution: "mcp-server-tester@npm:1.4.1"
+  dependencies:
+    "@ai-sdk/anthropic": "npm:^1.0.0"
+    "@modelcontextprotocol/sdk": "npm:^1.0.0"
+    ai: "npm:^4.0.0"
+    ajv: "npm:^8.12.0"
+    commander: "npm:^12.0.0"
+    debug: "npm:^4.3.0"
+    fast-xml-parser: "npm:^5.2.5"
+    yaml: "npm:^2.0.0"
+    zod: "npm:^3.25.76"
+  bin:
+    mcp-server-tester: dist/cli.js
+  checksum: 10/62519993bd82e3f9076410c4dd0f07eaeeedb09393d06ba9b63b622b01e1783c4ace59e3b7e0689761b09106710e541b26e5daddab5ce810de9d318bca04c492
+  languageName: node
+  linkType: hard
+
+"mcp-server-tester@patch:mcp-server-tester@npm%3A1.4.1#~/.yarn/patches/mcp-server-tester-npm-1.4.1-6564330b13.patch":
+  version: 1.4.1
+  resolution: "mcp-server-tester@patch:mcp-server-tester@npm%3A1.4.1#~/.yarn/patches/mcp-server-tester-npm-1.4.1-6564330b13.patch::version=1.4.1&hash=8c5dbd"
+  dependencies:
+    "@ai-sdk/anthropic": "npm:^1.0.0"
+    "@modelcontextprotocol/sdk": "npm:^1.0.0"
+    ai: "npm:^4.0.0"
+    ajv: "npm:^8.12.0"
+    commander: "npm:^12.0.0"
+    debug: "npm:^4.3.0"
+    fast-xml-parser: "npm:^5.2.5"
+    yaml: "npm:^2.0.0"
+    zod: "npm:^3.25.76"
+  bin:
+    mcp-server-tester: dist/cli.js
+  checksum: 10/46ed3f83e91bd843065082c3d444093b102186ea056163ff32bcd6ba3e43a85c681c1b7d1bf53e97369e7366a3fda6ac7871c220d4f1955ae111afe5b552d8b9
   languageName: node
   linkType: hard
 
@@ -4838,7 +5063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.12":
+"nanoid@npm:^3.3.12, nanoid@npm:^3.3.8":
   version: 3.3.15
   resolution: "nanoid@npm:3.3.15"
   bin:
@@ -5330,6 +5555,13 @@ __metadata:
   version: 4.0.0
   resolution: "path-exists@npm:4.0.0"
   checksum: 10/505807199dfb7c50737b057dd8d351b82c033029ab94cb10a657609e00c1bc53b951cfdbccab8de04c5584d5eff31128ce6afd3db79281874a5ef2adbba55ed1
+  languageName: node
+  linkType: hard
+
+"path-expression-matcher@npm:^1.5.0":
+  version: 1.6.2
+  resolution: "path-expression-matcher@npm:1.6.2"
+  checksum: 10/d7786b170933dd82ed897144daed7d54dbe2e7b7d8684182ee9bf51a966cc92548788e2f49280922202a0186409008d816aefa37ed4650e4038184181a73c4bd
   languageName: node
   linkType: hard
 
@@ -5866,10 +6098,14 @@ __metadata:
     "@modelcontextprotocol/sdk": "npm:^1.29.0"
     "@types/node": "npm:^24.0.0"
     "@types/ws": "npm:^8.5.0"
+    mcp-server-tester: "patch:mcp-server-tester@npm%3A1.4.1#~/.yarn/patches/mcp-server-tester-npm-1.4.1-6564330b13.patch"
     typescript: "npm:^5.4.0"
     ws: "npm:^8.18.0"
     yaml: "npm:^2.8.3"
     zod: "npm:^3.23.0"
+  dependenciesMeta:
+    mcp-server-tester:
+      built: false
   bin:
     rn-dev-agent-core: ./dist/supervisor.js
   languageName: unknown
@@ -5915,6 +6151,9 @@ __metadata:
     husky: "npm:^9.1.7"
     oxfmt: "npm:0.55.0"
     oxlint: "npm:^1.70.0"
+  dependenciesMeta:
+    mcp-server-tester:
+      built: false
   languageName: unknown
   linkType: soft
 
@@ -6041,6 +6280,13 @@ __metadata:
   version: 1.6.0
   resolution: "sax@npm:1.6.0"
   checksum: 10/0909cedcd9f011ceeac80c0240a92d64ef712cf6c04e0f6ee236a8d812f86a59f61bee6bb5da28d75306db050b99e0593051ea77351795822253b984af6cf044
+  languageName: node
+  linkType: hard
+
+"secure-json-parse@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "secure-json-parse@npm:2.7.0"
+  checksum: 10/974386587060b6fc5b1ac06481b2f9dbbb0d63c860cc73dc7533f27835fdb67b0ef08762dbfef25625c15bc0a0c366899e00076cb0d556af06b71e22f1dede4c
   languageName: node
   linkType: hard
 
@@ -6375,6 +6621,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strnum@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "strnum@npm:2.4.1"
+  dependencies:
+    anynum: "npm:^1.0.1"
+  checksum: 10/f0f6d0998608a1ed012ebb07471fbf63b90745ab06d5502fdc87870b57a20f40bc1d0c0a03caa17a3ccb11c3a78a30b3a21ad7728331d03e214b01ce0a70d433
+  languageName: node
+  linkType: hard
+
 "style-to-js@npm:^1.0.0":
   version: 1.1.21
   resolution: "style-to-js@npm:1.1.21"
@@ -6410,6 +6665,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"swr@npm:^2.2.5":
+  version: 2.4.2
+  resolution: "swr@npm:2.4.2"
+  dependencies:
+    dequal: "npm:^2.0.3"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/53f5891599af6fdd58fa47727a2931e40ec308e7e0ff5e6ceef9c649b83703e4a2934f05cb5be159c6195b5ff934857144d1bad08129f42ce0a855f338455364
+  languageName: node
+  linkType: hard
+
 "tar@npm:^7.5.4":
   version: 7.5.19
   resolution: "tar@npm:7.5.19"
@@ -6427,6 +6694,13 @@ __metadata:
   version: 2.2.1
   resolution: "term-size@npm:2.2.1"
   checksum: 10/f96aca2d4139c91e3359f5949ffb86f0a58f8c254ab7fe4a64b65126974939c782db6aaa91bf51a56d0344e505e22f9a0186f2f689e23ac9382b54606603c537
+  languageName: node
+  linkType: hard
+
+"throttleit@npm:2.1.0":
+  version: 2.1.0
+  resolution: "throttleit@npm:2.1.0"
+  checksum: 10/a2003947aafc721c4a17e6f07db72dc88a64fa9bba0f9c659f7997d30f9590b3af22dadd6a41851e0e8497d539c33b2935c2c7919cf4255922509af6913c619b
   languageName: node
   linkType: hard
 
@@ -6789,6 +7063,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"use-sync-external-store@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "use-sync-external-store@npm:1.6.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/b40ad2847ba220695bff2d4ba4f4d60391c0fb4fb012faa7a4c18eb38b69181936f5edc55a522c4d20a788d1a879b73c3810952c9d0fd128d01cb3f22042c09e
+  languageName: node
+  linkType: hard
+
 "util-deprecate@npm:^1.0.2":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
@@ -6958,6 +7241,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"xml-naming@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "xml-naming@npm:0.1.0"
+  checksum: 10/45abd94ba64a508bda3f4d0b70e49811a3c3542596252c213caf47c858bbe9bba365ebba8eeff68e2a876e22a1bf6855d90cd2019b2f28012cebb167a4df2293
+  languageName: node
+  linkType: hard
+
 "xxhash-wasm@npm:^1.1.0":
   version: 1.1.0
   resolution: "xxhash-wasm@npm:1.1.0"
@@ -6972,7 +7262,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.8.3":
+"yaml@npm:^2.0.0, yaml@npm:^2.8.3":
   version: 2.9.0
   resolution: "yaml@npm:2.9.0"
   bin:
@@ -6995,7 +7285,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod-to-json-schema@npm:^3.25.1":
+"zod-to-json-schema@npm:^3.24.1, zod-to-json-schema@npm:^3.25.1":
   version: 3.25.2
   resolution: "zod-to-json-schema@npm:3.25.2"
   peerDependencies:
@@ -7004,7 +7294,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.23.0":
+"zod@npm:^3.23.0, zod@npm:^3.25.76":
   version: 3.25.76
   resolution: "zod@npm:3.25.76"
   checksum: 10/f0c963ec40cd96858451d1690404d603d36507c1fc9682f2dae59ab38b578687d542708a7fdbf645f77926f78c9ed558f57c3d3aa226c285f798df0c4da16995

--- a/yarn.lock
+++ b/yarn.lock
@@ -6098,14 +6098,10 @@ __metadata:
     "@modelcontextprotocol/sdk": "npm:^1.29.0"
     "@types/node": "npm:^24.0.0"
     "@types/ws": "npm:^8.5.0"
-    mcp-server-tester: "patch:mcp-server-tester@npm%3A1.4.1#~/.yarn/patches/mcp-server-tester-npm-1.4.1-6564330b13.patch"
     typescript: "npm:^5.4.0"
     ws: "npm:^8.18.0"
     yaml: "npm:^2.8.3"
     zod: "npm:^3.23.0"
-  dependenciesMeta:
-    mcp-server-tester:
-      built: false
   bin:
     rn-dev-agent-core: ./dist/supervisor.js
   languageName: unknown
@@ -6149,6 +6145,7 @@ __metadata:
     "@changesets/cli": "npm:^2.27.10"
     esbuild: "npm:^0.28.1"
     husky: "npm:^9.1.7"
+    mcp-server-tester: "patch:mcp-server-tester@npm%3A1.4.1#~/.yarn/patches/mcp-server-tester-npm-1.4.1-6564330b13.patch"
     oxfmt: "npm:0.55.0"
     oxlint: "npm:^1.70.0"
   dependenciesMeta:


### PR DESCRIPTION
## Summary

Story 06 Phase C (#387): on-demand LLM-behavior evals for the ~79-tool MCP surface, per the approved spec [`docs/superpowers/specs/2026-07-09-387-phase-c-llm-evals-design.md`](docs/superpowers/specs/2026-07-09-387-phase-c-llm-evals-design.md). The committed per-model baseline + compare script is the regression gate Stories 08 and 12 declare as their safety net.

- **`mcp-server-tester@1.4.1`** pinned exactly, installed via a committed Yarn `patch:` that swaps its hardcoded llm-judge model `claude-3-haiku-20240307` (retired 2026-04-20 — every judge call errors on stock 1.4.1) → `claude-haiku-4-5-20251001`. Its `patch-package` postinstall is disabled via `dependenciesMeta.built:false` (root + workspace — Yarn 4 only honors the top-level manifest).
- **`test/evals/`**: `server-config.json` (spawns the real `dist/supervisor.js` over stdio), two eval families (below), recorded fixtures (`device-snapshot.json` from a Phase B smoke run, contract-shaped `stale-ref-envelope.json`), `run-evals.ts` orchestrator, `compare-baseline.ts` (TDD, 9 unit tests), README with authoring rules + cost notes.
- **`.github/workflows/llm-evals.yml`**: `workflow_dispatch` ONLY (`model`, `filter` inputs), `contents: read`, fails RED with an actionable message when `ANTHROPIC_API_KEY` is absent — a gate run that didn't run must not look green.

## Fixture set (9)

| Family | Fixture | Asserts |
|---|---|---|
| tool-correctness | device-inventory | `required: [device_list]` |
| tool-correctness | snapshot-first-observation | judge: observes before acting |
| tool-correctness | blank-screen-diagnosis | `required: [cdp_status]` + judge |
| tool-correctness | not-connected-recovery | `required: [cdp_status]` + judge |
| tool-correctness | tool-discovery | judge: surface coverage |
| tool-correctness | honest-press-failure | judge: no fabricated success |
| output-usability | ref-selection-bottom-button | regex `@e53\b` on real snapshot payload |
| output-usability | stale-ref-candidate-recovery | judge: re-targets `@e8` from candidates |
| output-usability | honest-uncertainty-missing-element | judge: admits absence, no fabricated ref |

`expected_tool_calls.required` only names tools that SUCCEED disconnected (`cdp_status`, `device_list`) — the tester fails a fixture when a required tool returns `isError:true`. Payload fixtures are committed pretty-printed; the runner minifies at injection because the tester substitutes `${VAR}` into raw YAML text before parsing.

## Wiring-gate evidence (no token spend)

Ran the full pipeline with a deliberately invalid `ANTHROPIC_API_KEY`: env substitution + minified payload injection landed in the prompts, the real supervisor spawned and served tool listings, all 9 evals failed with `invalid x-api-key` (auth — not YAML/spawn/substitution), both junit XMLs + `summary.md` were produced, the whole-file retry fired once, and compare exited 0 with `0 regression(s), 9 new`.

## Hardening from the final whole-branch review

`collectResults` now throws on duplicate fixture names across junit files (silent last-write-wins could mask a fail and green the gate); the `--write-baseline` refuse-guard (rejects failing fixtures without `--allow-failures`) got unit coverage via an extracted `writeBaseline`. Suite: 2992/2992.

## After merge (acceptance, tracked in #387)

1. **Maintainer adds the `ANTHROPIC_API_KEY` repo secret** — the first dispatch fails red by design until then.
2. Baseline-capture dispatch → commit `baseline.json` from the run's actual results (`chore/387-eval-baseline`). `baseline.json` ships empty here by design.
3. Seeded-regression proof on a scratch branch + measured per-run cost into the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)