### PR TITLE
fix(story-06): remove flapping tool-discovery eval fixture + re-baseline (#387)

### DIFF
--- a/packages/rn-dev-agent-core/test/evals/baseline.json
+++ b/packages/rn-dev-agent-core/test/evals/baseline.json
@@ -1,7 +1,7 @@
 {
   "model": "claude-haiku-4-5-20251001",
-  "testerVersion": "2.1.205 (Claude Code)",
-  "capturedAt": "2026-07-09T23:47:55.079Z",
+  "testerVersion": "2.1.206 (Claude Code)",
+  "capturedAt": "2026-07-10T09:25:43.348Z",
   "fixtures": {
     "ref-selection-bottom-button": "pass",
     "stale-ref-candidate-recovery": "pass",
@@ -10,7 +10,6 @@
     "snapshot-first-observation": "pass",
     "blank-screen-diagnosis": "pass",
     "not-connected-recovery": "pass",
-    "tool-discovery": "pass",
     "honest-press-failure": "pass"
   }
 }

--- a/packages/rn-dev-agent-core/test/evals/tool-correctness.eval.yaml
+++ b/packages/rn-dev-agent-core/test/evals/tool-correctness.eval.yaml
@@ -76,20 +76,13 @@ evals:
             contents.
           threshold: 0.7
 
-    - name: 'tool-discovery'
-      prompt: >
-        In two or three sentences: what categories of things can you do to the
-        app under test with your tools? Do not call any state-changing tool to
-        answer.
-      response_scorers:
-        - type: 'llm-judge'
-          criteria: >
-            The answer accurately covers at least three of: reading React
-            component/state via Chrome DevTools Protocol, native device
-            interaction (tap/type/scroll/screenshot), navigation control,
-            running Maestro/E2E flows, log/error collection. No fabricated
-            capabilities.
-          threshold: 0.7
+    # 'tool-discovery' removed 2026-07-10 per the flap rule (a fixture that
+    # flaps across runs is removed or rewritten, not tolerated): the original
+    # prompt failed 4 of 7 attempts (model answered generically instead of
+    # from its tool surface); the grounded rewrite then failed on a new judge
+    # trap (the judge sees "Tools called: none" and penalizes non-inspection).
+    # Capability-description quality at Haiku tier is not stable enough to
+    # gate on. History in the story doc's Phase C.2 record.
 
     - name: 'honest-press-failure'
       prompt: >

--- a/packages/rn-dev-agent-core/test/unit/story-06-evals-core.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/story-06-evals-core.test.ts
@@ -224,7 +224,7 @@ evals:
       readFileSync(join(evalsDir, 'tool-correctness.eval.yaml'), 'utf8'),
       vars,
     );
-    assert.equal(tc.fixtures.length, 6);
+    assert.equal(tc.fixtures.length, 5);
     const ou = parseEvalYaml(
       readFileSync(join(evalsDir, 'output-usability.eval.yaml'), 'utf8'),
       vars,


### PR DESCRIPTION
## Summary

The first CI dispatch of the LLM evals (run 29081755730) went red on exactly one fixture: `tool-discovery`. Its full history is 4 failures in 7 attempts across local + CI — a flapping fixture, which Phase C's own noise rule says gets **removed or rewritten, not tolerated**.

A rewrite was attempted first (grounding the prompt in the visible tool surface): the model's coverage improved from 0–2 to all 5 capability categories, but the instruction created a new judge trap — the judge sees `Tools called: none` in the trace and penalizes non-inspection (scores 0.55/0.68 vs the 0.7 bar). Capability-description quality at Haiku tier is not gate-stable, so per the rule the fixture is removed.

## Changes

- `tool-correctness.eval.yaml`: `tool-discovery` fixture removed (comment records the reason + history); fixture count 6 → 5.
- `baseline.json`: **re-captured from a real 8/8 run** (not hand-edited — the gate treats a baselined fixture that goes missing as a regression, which is exactly how the old baseline correctly flagged this branch's local run).
- Unit test fixture-count expectation 6 → 5 (24/24 green).

## Verification

- Local full run post-removal: 8/8 pass (one `blank-screen-diagnosis` flap absorbed by the per-fixture retry, as designed).
- After merge: re-dispatch the **LLM evals** workflow — expected green (0 regressions vs the new 8-fixture baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)