### PR TITLE
test(core): guard package-lock dependency-range drift (#441 follow-up)

### DIFF
--- a/packages/rn-dev-agent-core/test/unit/gh-441-lock-version-sync.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-441-lock-version-sync.test.ts
@@ -17,12 +17,16 @@ const BRIDGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 interface PackageLock {
   name: string;
   version: string;
-  packages: Record<string, { name?: string; version?: string }>;
+  packages: Record<
+    string,
+    { name?: string; version?: string; dependencies?: Record<string, string> }
+  >;
 }
 
 const pkg = JSON.parse(readFileSync(join(BRIDGE_ROOT, 'package.json'), 'utf8')) as {
   name: string;
   version: string;
+  dependencies?: Record<string, string>;
 };
 const lock = JSON.parse(
   readFileSync(join(BRIDGE_ROOT, 'package-lock.json'), 'utf8'),
@@ -43,4 +47,21 @@ test('gh-441: lock root-package entry version matches package.json', () => {
 
 test('gh-441: lock name matches package.json', () => {
   assert.equal(lock.name, pkg.name);
+});
+
+// Version-field equality proves the lock was regenerated since the last
+// version bump, but NOT since the last dependency edit: hand-changing a range
+// in package.json leaves both version fields matching while the resolution
+// graph users install is still the old one. Compare the ranges themselves.
+// (overrides are not recorded in the lock's root entry, so override drift
+// still requires a deliberate regeneration — see sync-versions.sh.)
+test('gh-441: lock root-package dependency ranges match package.json', () => {
+  assert.deepEqual(
+    lock.packages['']?.dependencies,
+    pkg.dependencies,
+    'package-lock.json dependency ranges drifted from package.json — the lock was not ' +
+      'regenerated after a dependency edit. Regenerate in an isolated dir (npm cannot ' +
+      'resolve inside the yarn workspace): copy package.json to an empty dir, run ' +
+      '`npm install --package-lock-only`, copy package-lock.json back.',
+  );
 });


### PR DESCRIPTION
## Summary

Small follow-up to #536 (which superseded #535 for #441). The `gh-441-lock-version-sync` tripwire catches version-field staleness, but version-field equality only proves the lock was regenerated since the last **version bump** — not since the last **dependency edit**. Hand-changing a range in `package.json` without regenerating leaves both version fields matching while users still `npm install --production` against the old resolution graph. That mixed state is exactly how the original 0.38-era lock looked (partially-refreshed resolutions, stale fields).

## Change

One new test in `gh-441-lock-version-sync.test.ts`: `assert.deepEqual` of the lock root entry's `dependencies` against `package.json`'s. Failure message includes the isolated-dir regeneration recipe (npm can't resolve inside the yarn workspace).

Known limitation, documented in the test: npm does not record `overrides` in the lock's root entry, so drift in the new major-cap overrides from #536 is not detectable this way and still relies on deliberate regeneration.

## Validation

- 4/4 tests pass on main's current lock
- Mutation-verified: seeding `ws: "^9.0.0"` into `package.json` fails exactly the new test; restoring passes
- `yarn format:check` clean; test-only change (no changeset required — `require-changeset` watches `src/` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)