### PR TITLE
fix(record): convert-gif mkdirs its explicit gifPath parent before the ffmpeg write (#377)

### DIFF
--- a/.changeset/377-convert-gif-mkdir-gifpath.md
+++ b/.changeset/377-convert-gif-mkdir-gifpath.md
@@ -1,0 +1,5 @@
+---
+'rn-dev-agent-plugin': patch
+---
+
+Fix #377: `record_proof.sh convert-gif` now creates the output's parent directory before invoking ffmpeg, so `device_record action=stop gif=true gifPath=<fresh-dir>/clip.gif` with an explicit path into a not-yet-existing directory succeeds instead of failing the ffmpeg write with ENOENT. If the parent cannot be created (e.g. a path component is a regular file), the command fails with an honest error naming the directory instead of a silent ffmpeg exit. Mirrors the `mkdir -p` already done by `cmd_start`/`cmd_stop`; regression-guarded by a PATH-stubbed ffmpeg test in CI.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,10 @@ jobs:
       - name: Dist-freshness guard unit test
         run: bash scripts/test/check-dist-fresh.test.sh
 
+      # GH#377: convert-gif must mkdir an explicit gifPath's parent before ffmpeg.
+      - name: record_proof convert-gif output-dir guard
+        run: bash scripts/test/record-proof-convert-gif.test.sh
+
       # GH#498: workspace package split contract for core/shared/host adapters.
       - name: Agent package split guard
         run: bash scripts/check-agent-package-sync.sh

--- a/packages/claude-plugin/scripts/record_proof.sh
+++ b/packages/claude-plugin/scripts/record_proof.sh
@@ -284,6 +284,11 @@ cmd_convert_gif() {
     exit 0
   fi
 
+  if ! mkdir -p "$(dirname "$output")" 2>/dev/null; then
+    echo "Error: Could not create output directory: $(dirname "$output")" >&2
+    exit 1
+  fi
+
   ffmpeg -i "$input" -vf "fps=10,scale=360:-1:flags=lanczos" -y "$output" 2>/dev/null
 
   local size

--- a/packages/codex-plugin/scripts/record_proof.sh
+++ b/packages/codex-plugin/scripts/record_proof.sh
@@ -284,6 +284,11 @@ cmd_convert_gif() {
     exit 0
   fi
 
+  if ! mkdir -p "$(dirname "$output")" 2>/dev/null; then
+    echo "Error: Could not create output directory: $(dirname "$output")" >&2
+    exit 1
+  fi
+
   ffmpeg -i "$input" -vf "fps=10,scale=360:-1:flags=lanczos" -y "$output" 2>/dev/null
 
   local size

--- a/scripts/record_proof.sh
+++ b/scripts/record_proof.sh
@@ -284,6 +284,11 @@ cmd_convert_gif() {
     exit 0
   fi
 
+  if ! mkdir -p "$(dirname "$output")" 2>/dev/null; then
+    echo "Error: Could not create output directory: $(dirname "$output")" >&2
+    exit 1
+  fi
+
   ffmpeg -i "$input" -vf "fps=10,scale=360:-1:flags=lanczos" -y "$output" 2>/dev/null
 
   local size

--- a/scripts/test/record-proof-convert-gif.test.sh
+++ b/scripts/test/record-proof-convert-gif.test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Regression test for record_proof.sh cmd_convert_gif (GH#377) — an explicit
+# gifPath pointing into a not-yet-existing directory must succeed: the command
+# must mkdir -p the output's parent before invoking ffmpeg, mirroring
+# cmd_start/cmd_stop. When the parent cannot be created (path component is a
+# file), it must fail with an honest error naming the directory.
+#
+# Uses a PATH-stubbed ffmpeg that mimics the real binary: it can only write
+# the output file if the parent directory already exists.
+#
+# Run: bash scripts/test/record-proof-convert-gif.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+RECORD="$SCRIPT_DIR/record_proof.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$tmp/bin"
+cat > "$tmp/bin/ffmpeg" <<'EOF'
+#!/usr/bin/env bash
+# Fake ffmpeg: last argument is the output path (record_proof.sh always
+# passes it last). Like the real binary, fail if the parent dir is missing.
+out=""
+for a in "$@"; do out="$a"; done
+if [ ! -d "$(dirname "$out")" ]; then
+  echo "$out: No such file or directory" >&2
+  exit 1
+fi
+printf 'GIF89a-fake' > "$out"
+EOF
+chmod +x "$tmp/bin/ffmpeg"
+export PATH="$tmp/bin:$PATH"
+
+printf 'fake-video' > "$tmp/input.mov"
+
+fail=0
+
+# Case 1 (GH#377): explicit output path in a fresh, nonexistent directory.
+out_gif="$tmp/fresh/nested/clip.gif"
+if bash "$RECORD" convert-gif "$tmp/input.mov" "$out_gif" >/dev/null 2>&1 \
+  && [ -s "$out_gif" ]; then
+  echo "ok: convert-gif creates missing parent dirs for explicit gifPath"
+else
+  echo "FAIL: convert-gif did not create output in a fresh directory"
+  fail=1
+fi
+
+# Case 2: existing directory keeps working (the default-gifPath path).
+out_gif2="$tmp/clip2.gif"
+if bash "$RECORD" convert-gif "$tmp/input.mov" "$out_gif2" >/dev/null 2>&1 \
+  && [ -s "$out_gif2" ]; then
+  echo "ok: convert-gif still works when the parent dir exists"
+else
+  echo "FAIL: convert-gif broke for an existing parent dir"
+  fail=1
+fi
+
+# Case 3: uncreatable parent (a path component is a regular file) must fail
+# loudly, naming the directory it could not create.
+printf 'blocker' > "$tmp/blocker"
+err="$(bash "$RECORD" convert-gif "$tmp/input.mov" "$tmp/blocker/clip.gif" 2>&1 >/dev/null)"
+rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$err" | grep -qF "$tmp/blocker"; then
+  echo "ok: uncreatable parent fails with an error naming the directory"
+else
+  echo "FAIL: uncreatable parent did not produce an honest error (rc=$rc, err=$err)"
+  fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "PASS: record-proof-convert-gif.test.sh"
+else
+  echo "FAILED: record-proof-convert-gif.test.sh"
+fi
+exit "$fail"


### PR DESCRIPTION
## Summary
Fixes #377.

`record_proof.sh cmd_convert_gif` ran ffmpeg without creating the output's parent directory, so `device_record action=stop gif=true gifPath=<fresh dir>/clip.gif` with an explicit path into a not-yet-existing directory failed the write (ENOENT). Under `set -euo pipefail` the subcommand then aborted at the `wc -c` size probe with no honest diagnostic.

## Changes
- `cmd_convert_gif` now runs `mkdir -p "$(dirname "$output")"` before the ffmpeg call, mirroring the pattern `cmd_start`/`cmd_stop` already use, and exits with an error naming the directory when the parent cannot be created (e.g. a path component is a regular file).
- All three script copies updated in sync (canonical `scripts/`, `packages/claude-plugin`, `packages/codex-plugin`); the agent-package split guard passes.
- New CI-wired regression test `scripts/test/record-proof-convert-gif.test.sh` with a PATH-stubbed ffmpeg that mimics the real binary's ENOENT behavior. Covers: fresh nested dir (the bug), existing dir (default gifPath path), and uncreatable parent (honest error).
- Changeset: `rn-dev-agent-plugin` patch.

## Verification
- Test fails on the unfixed script (red), passes after the fix (green).
- `bash scripts/check-agent-package-sync.sh` → in sync.
- `bash scripts/validate-changeset-names.sh` → valid.
- `npm run format:check` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)