### PR TITLE
feat(story-16): #409 snapshot quality verdicts — degraded captures must say so

### DIFF
--- a/.changeset/story-16-snapshot-quality-verdicts.md
+++ b/.changeset/story-16-snapshot-quality-verdicts.md
@@ -1,0 +1,29 @@
+---
+"rn-dev-agent-core": minor
+"rn-dev-agent-plugin": minor
+---
+
+Story 16 (#409) — snapshot quality verdicts: degraded captures must say so.
+
+Every tree/snapshot capture now carries a structured quality verdict computed
+once at capture time, so a sparse or empty result caused by a degraded walk is
+no longer indistinguishable from a legitimately empty screen:
+
+- `cdp_component_tree` returns `meta.treeVerdict` (`state: ok|degraded|failed`,
+  `path`, `reasons`, `rootsSeeded`, `scannedNodes`, `effectiveDepth`,
+  `droppedSubtrees`, `collapsedChildLists`, `rendererErrors`,
+  `unscannedRendererIds`). Previously-silent drop classes are now counted:
+  per-renderer exception swallows, registered-but-unscanned renderers (the #126
+  early-exit class), depth-cap subtree drops, scan-budget/wall-clock
+  exhaustion, and output truncation. Requires injected helpers v34 — a stale
+  bundle simply omits the verdict.
+- `device_snapshot` (iOS + Android runners) returns `meta.snapshotVerdict`
+  (`state`, `source`, `nodeCount`, `refMapUpdated`, `reasons`).
+- Sparse captures never overwrite the last-known-good @ref map: a zero-node
+  snapshot leaves refs bound to the last verified capture
+  (`meta.snapshotVerdict.refMapUpdated: false`, reason `empty-capture`) instead
+  of wiping the map self-healing taps depend on.
+- Interactive consumers fail closed: `device_find` (exact + fuzzy) and
+  `device_focus_next` refuse a zero-node capture with `SNAPSHOT_DEGRADED`
+  rather than asserting NOT_FOUND / "nothing on screen" on evidence that
+  cannot support it.

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -19255,7 +19255,27 @@ function clearRefMap() {
   lastUpdated = 0;
   lastSnapshotHash = null;
 }
+function buildSnapshotVerdict(source, nodeCount, outcome) {
+  const reasons = [];
+  if (nodeCount === 0)
+    reasons.push("empty-capture");
+  return {
+    state: reasons.length > 0 ? "degraded" : "ok",
+    source,
+    nodeCount,
+    refMapUpdated: outcome.applied,
+    reasons
+  };
+}
 function updateRefMapFromFlat(nodes) {
+  let validCount = 0;
+  for (const node of nodes) {
+    if (node.ref && node.rect)
+      validCount++;
+  }
+  if (validCount === 0 && refMap.size > 0) {
+    return { applied: false, reason: "empty-capture" };
+  }
   refMap.clear();
   screenRect = null;
   const hashed = [];
@@ -19282,6 +19302,7 @@ function updateRefMapFromFlat(nodes) {
     lastSnapshotHash = null;
   }
   lastUpdated = Date.now();
+  return { applied: true };
 }
 function getCachedMetadata(ref) {
   const key = ref.startsWith("@") ? ref.slice(1) : ref;
@@ -20603,8 +20624,9 @@ async function runIOS(args) {
     const data = resp.data;
     if (Array.isArray(data.nodes)) {
       const flat = mapRunnerNodesToFlat(data.nodes);
-      updateRefMapFromFlat(flat);
-      return okResult({ nodes: flat }, announce ? { meta: announce } : void 0);
+      const outcome = updateRefMapFromFlat(flat);
+      const snapshotVerdict = buildSnapshotVerdict("rn-fast-runner", flat.length, outcome);
+      return okResult({ nodes: flat }, { meta: { ...announce, snapshotVerdict } });
     }
     return okResult(resp.data, announce ? { meta: announce } : void 0);
   }
@@ -21706,8 +21728,9 @@ async function runAndroid(args) {
     const data = resp.data;
     if (Array.isArray(data.nodes)) {
       const flat = mapRunnerNodesToFlat2(data.nodes);
-      updateRefMapFromFlat(flat);
-      return okResult({ nodes: flat });
+      const outcome = updateRefMapFromFlat(flat);
+      const snapshotVerdict = buildSnapshotVerdict("rn-android-runner", flat.length, outcome);
+      return okResult({ nodes: flat }, { meta: { snapshotVerdict } });
     }
   }
   if (args.command === "screenshot") {
@@ -25326,6 +25349,8 @@ async function fetchSnapshotNodes(allowCache = false) {
   const initialNodes = parseSnapshotEnvelope(first);
   if (initialNodes === null)
     return { ok: false, reason: "fetch-failed" };
+  if (initialNodes.length === 0)
+    return { ok: false, reason: "empty-capture" };
   if (!isAgentDeviceRunnerSentinel(initialNodes)) {
     const platform2 = getActiveSession()?.platform;
     if (platform2)
@@ -25350,10 +25375,15 @@ async function fetchSnapshotNodes(allowCache = false) {
   const recoveredNodes = parseSnapshotEnvelope(recovery.result);
   if (recoveredNodes === null)
     return { ok: false, reason: "fetch-failed" };
+  if (recoveredNodes.length === 0)
+    return { ok: false, reason: "empty-capture" };
   const platform = getActiveSession()?.platform;
   if (platform)
     cacheSnapshot(platform, recoveredNodes);
   return { ok: true, nodes: recoveredNodes, recoveredTier: recovery.tier };
+}
+function emptyCaptureFailResult(query) {
+  return failResult(`Snapshot returned zero nodes \u2014 cannot distinguish an empty screen from a degraded capture` + (query !== void 0 ? `; not asserting "${query}" is absent` : "") + `. Confirm the screen with device_screenshot or cdp_component_tree, then retry.`, { code: "SNAPSHOT_DEGRADED", ...query !== void 0 ? { query } : {} });
 }
 async function fetchFindCandidates(query, exact = false, allowCache = false) {
   const snap = await fetchSnapshotNodes(allowCache);
@@ -25405,6 +25435,9 @@ function createDeviceFindHandler() {
         if (find.reason === "runner-leak-unrecovered") {
           return runnerLeakFailResult(args.text, find.recoveryReason);
         }
+        if (find.reason === "empty-capture") {
+          return emptyCaptureFailResult(args.text);
+        }
         return failResult(`Snapshot unavailable \u2014 cannot resolve ${args.exact ? "exact" : "index-based"} match for "${args.text}". Retry after device_snapshot action=open/snapshot.`, { code: "SNAPSHOT_UNAVAILABLE", query: args.text });
       }
       const { candidates, recoveredTier } = find;
@@ -25437,6 +25470,9 @@ function createDeviceFindHandler() {
       if (!find.ok) {
         if (find.reason === "runner-leak-unrecovered") {
           return runnerLeakFailResult(args.text, find.recoveryReason);
+        }
+        if (find.reason === "empty-capture") {
+          return emptyCaptureFailResult(args.text);
         }
         return failResult(`Snapshot unavailable \u2014 cannot resolve "${args.text}"`, {
           code: "SNAPSHOT_UNAVAILABLE",
@@ -26099,6 +26135,9 @@ function createDeviceFocusNextHandler() {
     if (!snap.ok) {
       if (snap.reason === "runner-leak-unrecovered") {
         return runnerLeakFailResult(void 0, snap.recoveryReason);
+      }
+      if (snap.reason === "empty-capture") {
+        return emptyCaptureFailResult();
       }
       return failResult("Snapshot unavailable \u2014 cannot look for keyboard key. Retry after device_snapshot action=open/snapshot.", { code: "SNAPSHOT_UNAVAILABLE" });
     }
@@ -42019,7 +42058,7 @@ async function detectBridge(client2) {
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 33;
+var HELPERS_VERSION = 34;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -42035,11 +42074,29 @@ var INJECTED_HELPERS = `
   var MAX_RENDERER_IDS = 20;
   var EARLY_EXIT_EMPTY_STREAK = 3;
 
+  // Reset by every root-iteration pass; only valid when read synchronously
+  // after the pass that produced the tree (many helpers share the iterators).
+  var lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+
+  function computeUnscannedRendererIds() {
+    try {
+      var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+      if (!hook || !hook.renderers || typeof hook.renderers.forEach !== 'function') return [];
+      var out = [];
+      hook.renderers.forEach(function(_v, id) {
+        if (typeof id === 'number' && id > lastRootScan.probedUpTo) out.push(id);
+      });
+      return out;
+    } catch (_) { return []; }
+  }
+
   function findActiveRenderer() {
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
     var emptyStreak = 0;
     for (var i = 1; i <= MAX_RENDERER_IDS; i++) {
+      lastRootScan.probedUpTo = i;
       try {
         var roots = hook.getFiberRoots(i);
         if (roots && roots.size > 0) {
@@ -42049,6 +42106,7 @@ var INJECTED_HELPERS = `
         if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && i >= 5) return null;
       } catch (_) {
         emptyStreak++;
+        lastRootScan.rendererErrors++;
       }
     }
     return null;
@@ -42062,18 +42120,17 @@ var INJECTED_HELPERS = `
   //
   // Per-renderer try/catch protects against one renderer's getFiberRoots
   // throwing during teardown/HMR/worklet init (Gemini A3, 2026-04-23,
-  // conf 80) \u2014 a single bad renderer must not poison the union.
-  //
-  // Task 4 will add an extra-roots step here that consults
-  // globalThis.__RN_AGENT_EXTRA_ROOTS__ AFTER the native renderer loop
-  // so user-registered portals stay lower priority than React's own
-  // registry. Not in this commit \u2014 refactor isolated from new behavior
-  // for cleaner bisects.
+  // conf 80) \u2014 a single bad renderer must not poison the union. The
+  // extra-roots step (globalThis.__RN_AGENT_EXTRA_ROOTS__) runs AFTER the
+  // native renderer loop so user-registered portals stay lower priority
+  // than React's own registry.
   function iterateAllRoots(cb) {
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (hook && typeof hook.getFiberRoots === 'function') {
       var emptyStreak = 0;
       for (var ri = 1; ri <= MAX_RENDERER_IDS; ri++) {
+        lastRootScan.probedUpTo = ri;
         try {
           var roots = hook.getFiberRoots(ri);
           if (roots && roots.size) {
@@ -42092,6 +42149,7 @@ var INJECTED_HELPERS = `
           }
         } catch (_) {
           emptyStreak++;
+          lastRootScan.rendererErrors++;
         }
       }
     }
@@ -42117,7 +42175,10 @@ var INJECTED_HELPERS = `
           }
         }
       }
-    } catch (_) { /* swallow \u2014 resolver bug must not break iteration */ }
+    } catch (_) {
+      // swallow \u2014 resolver bug must not break iteration
+      lastRootScan.rendererErrors++;
+    }
     return null;
   }
 
@@ -42228,9 +42289,39 @@ var INJECTED_HELPERS = `
     var maxDepth = opts.maxDepth || 4;
     var filter = opts.filter || opts.testID || opts.type || null;
 
+    // Story 16 (#409): quality verdict computed once at capture, from the same
+    // pass that produced the tree \u2014 downstream tools render it, never re-derive.
+    var walkQuality = { droppedSubtrees: 0, collapsedChildLists: 0 };
+    function buildVerdict(path, o) {
+      o = o || {};
+      var reasons = [];
+      if (o.noRenderer) reasons.push('no-renderer');
+      if (lastRootScan.rendererErrors > 0) reasons.push('renderer-error');
+      var unscanned = computeUnscannedRendererIds();
+      if (unscanned.length > 0) reasons.push('renderers-unscanned');
+      if (o.scanBudgetExhausted) reasons.push('scan-budget-exhausted');
+      if (o.outputTruncated) reasons.push('output-truncated');
+      var state = (o.noRenderer || o.failed) ? 'failed' : (reasons.length > 0 ? 'degraded' : 'ok');
+      return {
+        state: state,
+        path: path,
+        reasons: reasons,
+        rootsSeeded: o.rootsSeeded || 0,
+        scannedNodes: o.scannedNodes || 0,
+        effectiveDepth: maxDepth,
+        droppedSubtrees: walkQuality.droppedSubtrees,
+        collapsedChildLists: walkQuality.collapsedChildLists,
+        rendererErrors: lastRootScan.rendererErrors,
+        unscannedRendererIds: unscanned
+      };
+    }
+
     var renderer = findActiveRenderer();
     if (!renderer) {
-      return JSON.stringify({ error: 'React DevTools hook not available or no fiber roots \u2014 app may still be loading' });
+      return JSON.stringify({
+        error: 'React DevTools hook not available or no fiber roots \u2014 app may still be loading',
+        verdict: buildVerdict('none', { noRenderer: true })
+      });
     }
 
     var visited = new WeakSet();
@@ -42271,7 +42362,15 @@ var INJECTED_HELPERS = `
     }
 
     function walkSubtree(fiber, depth, limit, vis) {
-      if (!fiber || depth > limit || vis.has(fiber)) return null;
+      if (!fiber) return null;
+      if (depth > limit) {
+        // Depth-cap drop: expected under the requested cap, but must be
+        // counted \u2014 a sparse-because-shallow tree previously looked identical
+        // to a legitimately small one.
+        walkQuality.droppedSubtrees++;
+        return null;
+      }
+      if (vis.has(fiber)) return null;
       vis.add(fiber);
       totalNodes++;
 
@@ -42351,6 +42450,7 @@ var INJECTED_HELPERS = `
       }
 
       if (children.length > 0) {
+        if (children.length > 20) walkQuality.collapsedChildLists++;
         result.children = children.length > 20
           ? children.slice(0, 10).concat([{ _truncated: (children.length - 10) + ' more' }])
           : children;
@@ -42452,6 +42552,11 @@ var INJECTED_HELPERS = `
         iOut.truncated = true;
         iOut.hint = 'More interactive elements exist beyond the cap \u2014 scope with filter or device_scrollintoview.';
       }
+      iOut.verdict = buildVerdict('interactive', {
+        rootsSeeded: iRoots.length,
+        scannedNodes: iScanned,
+        scanBudgetExhausted: iQueue.length > 0
+      });
       return safeStringify(iOut, 999999);
     }
 
@@ -42509,8 +42614,21 @@ var INJECTED_HELPERS = `
       // Codex review (conf 80): field renamed from renderersScanned to
       // rootsSeeded to match actual semantic (roots pushed into the BFS
       // queue, not renderers walked 1..5).
+      // A no-match verdict distinguishes "scanned everything, truly absent"
+      // from "budget ran out mid-scan" \u2014 the sparse-vs-empty ambiguity #409
+      // exists to kill.
+      var filterBudgetHit = queue.length > 0;
       if (matchFibers.length === 0) {
-        return JSON.stringify({ tree: null, totalNodes: scanned, rootsSeeded: allRoots.length });
+        return JSON.stringify({
+          tree: null,
+          totalNodes: scanned,
+          rootsSeeded: allRoots.length,
+          verdict: buildVerdict('filter', {
+            rootsSeeded: allRoots.length,
+            scannedNodes: scanned,
+            scanBudgetExhausted: filterBudgetHit
+          })
+        });
       }
 
       var matches = [];
@@ -42520,10 +42638,16 @@ var INJECTED_HELPERS = `
         if (subtree) matches.push(subtree);
       }
       totalNodes = scanned;
+      var filterVerdictOpts = {
+        rootsSeeded: allRoots.length,
+        scannedNodes: scanned,
+        scanBudgetExhausted: filterBudgetHit
+      };
       var tree = matches.length === 1 ? matches[0] : { matches: matches };
-      var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRoots.length }, 999999);
+      var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRoots.length, verdict: buildVerdict('filter', filterVerdictOpts) }, 999999);
       if (output.length > 50000) {
-        return safeStringify({ tree: matches[0] || null, totalNodes: totalNodes, rootsSeeded: allRoots.length, truncated: true });
+        filterVerdictOpts.outputTruncated = true;
+        return safeStringify({ tree: matches[0] || null, totalNodes: totalNodes, rootsSeeded: allRoots.length, truncated: true, verdict: buildVerdict('filter', filterVerdictOpts) });
       }
       return output;
     }
@@ -42540,10 +42664,13 @@ var INJECTED_HELPERS = `
       var sub = walkSubtree(allRootsU[ri].fiber, 0, maxDepth, visited);
       if (sub) trees.push(sub);
     }
+    var fullVerdictOpts = { rootsSeeded: allRootsU.length, scannedNodes: totalNodes };
     var tree = trees.length === 1 ? trees[0] : (trees.length === 0 ? null : { _wrapper: true, children: trees });
-    var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRootsU.length }, 999999);
+    var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRootsU.length, verdict: buildVerdict('full', fullVerdictOpts) }, 999999);
     if (output.length > 50000) {
-      return safeStringify({ error: 'Tree too large (' + output.length + ' chars). Use a filter parameter to scope the query.' });
+      fullVerdictOpts.failed = true;
+      fullVerdictOpts.outputTruncated = true;
+      return safeStringify({ error: 'Tree too large (' + output.length + ' chars). Use a filter parameter to scope the query.', verdict: buildVerdict('full', fullVerdictOpts) });
     }
     return output;
   }
@@ -44867,8 +44994,10 @@ var REACT_READY_PROBE_JS = `(function() {
   // so the readiness gate can't miss a late-registered renderer (Bridgeless +
   // Reanimated register secondary renderers above id 5).
   for (var i = 1; i <= 20; i++) {
-    var r = h.getFiberRoots(i);
-    if (r && r.size > 0) return true;
+    try {
+      var r = h.getFiberRoots(i);
+      if (r && r.size > 0) return true;
+    } catch (_) { /* one throwing renderer must not abort the readiness scan */ }
   }
   return false;
 })()`;
@@ -47841,15 +47970,19 @@ function createComponentTreeHandler(getClient2) {
     } catch {
       return failResult("Failed to parse component tree response");
     }
+    const verdict = parsed.verdict;
+    const meta = verdict ? { treeVerdict: verdict } : void 0;
     if (parsed.error) {
-      return failResult(`Component tree error: ${parsed.error}`);
+      return failResult(`Component tree error: ${parsed.error}`, meta);
     }
     if (parsed.warning === "APP_HAS_REDBOX") {
       return warnResult({
         message: parsed.message ?? "App is showing an error screen. Use cdp_error_log to read the error, fix the code, then cdp_reload."
-      }, "APP_HAS_REDBOX");
+      }, "APP_HAS_REDBOX", meta);
     }
-    return okResult(parsed);
+    if (verdict)
+      delete parsed.verdict;
+    return okResult(parsed, meta ? { meta } : void 0);
   });
 }
 

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -27416,7 +27416,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 33;
+    HELPERS_VERSION = 34;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -27432,11 +27432,29 @@ var init_injected_helpers = __esm({
   var MAX_RENDERER_IDS = 20;
   var EARLY_EXIT_EMPTY_STREAK = 3;
 
+  // Reset by every root-iteration pass; only valid when read synchronously
+  // after the pass that produced the tree (many helpers share the iterators).
+  var lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+
+  function computeUnscannedRendererIds() {
+    try {
+      var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+      if (!hook || !hook.renderers || typeof hook.renderers.forEach !== 'function') return [];
+      var out = [];
+      hook.renderers.forEach(function(_v, id) {
+        if (typeof id === 'number' && id > lastRootScan.probedUpTo) out.push(id);
+      });
+      return out;
+    } catch (_) { return []; }
+  }
+
   function findActiveRenderer() {
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
     var emptyStreak = 0;
     for (var i = 1; i <= MAX_RENDERER_IDS; i++) {
+      lastRootScan.probedUpTo = i;
       try {
         var roots = hook.getFiberRoots(i);
         if (roots && roots.size > 0) {
@@ -27446,6 +27464,7 @@ var init_injected_helpers = __esm({
         if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && i >= 5) return null;
       } catch (_) {
         emptyStreak++;
+        lastRootScan.rendererErrors++;
       }
     }
     return null;
@@ -27459,18 +27478,17 @@ var init_injected_helpers = __esm({
   //
   // Per-renderer try/catch protects against one renderer's getFiberRoots
   // throwing during teardown/HMR/worklet init (Gemini A3, 2026-04-23,
-  // conf 80) \u2014 a single bad renderer must not poison the union.
-  //
-  // Task 4 will add an extra-roots step here that consults
-  // globalThis.__RN_AGENT_EXTRA_ROOTS__ AFTER the native renderer loop
-  // so user-registered portals stay lower priority than React's own
-  // registry. Not in this commit \u2014 refactor isolated from new behavior
-  // for cleaner bisects.
+  // conf 80) \u2014 a single bad renderer must not poison the union. The
+  // extra-roots step (globalThis.__RN_AGENT_EXTRA_ROOTS__) runs AFTER the
+  // native renderer loop so user-registered portals stay lower priority
+  // than React's own registry.
   function iterateAllRoots(cb) {
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (hook && typeof hook.getFiberRoots === 'function') {
       var emptyStreak = 0;
       for (var ri = 1; ri <= MAX_RENDERER_IDS; ri++) {
+        lastRootScan.probedUpTo = ri;
         try {
           var roots = hook.getFiberRoots(ri);
           if (roots && roots.size) {
@@ -27489,6 +27507,7 @@ var init_injected_helpers = __esm({
           }
         } catch (_) {
           emptyStreak++;
+          lastRootScan.rendererErrors++;
         }
       }
     }
@@ -27514,7 +27533,10 @@ var init_injected_helpers = __esm({
           }
         }
       }
-    } catch (_) { /* swallow \u2014 resolver bug must not break iteration */ }
+    } catch (_) {
+      // swallow \u2014 resolver bug must not break iteration
+      lastRootScan.rendererErrors++;
+    }
     return null;
   }
 
@@ -27625,9 +27647,39 @@ var init_injected_helpers = __esm({
     var maxDepth = opts.maxDepth || 4;
     var filter = opts.filter || opts.testID || opts.type || null;
 
+    // Story 16 (#409): quality verdict computed once at capture, from the same
+    // pass that produced the tree \u2014 downstream tools render it, never re-derive.
+    var walkQuality = { droppedSubtrees: 0, collapsedChildLists: 0 };
+    function buildVerdict(path, o) {
+      o = o || {};
+      var reasons = [];
+      if (o.noRenderer) reasons.push('no-renderer');
+      if (lastRootScan.rendererErrors > 0) reasons.push('renderer-error');
+      var unscanned = computeUnscannedRendererIds();
+      if (unscanned.length > 0) reasons.push('renderers-unscanned');
+      if (o.scanBudgetExhausted) reasons.push('scan-budget-exhausted');
+      if (o.outputTruncated) reasons.push('output-truncated');
+      var state = (o.noRenderer || o.failed) ? 'failed' : (reasons.length > 0 ? 'degraded' : 'ok');
+      return {
+        state: state,
+        path: path,
+        reasons: reasons,
+        rootsSeeded: o.rootsSeeded || 0,
+        scannedNodes: o.scannedNodes || 0,
+        effectiveDepth: maxDepth,
+        droppedSubtrees: walkQuality.droppedSubtrees,
+        collapsedChildLists: walkQuality.collapsedChildLists,
+        rendererErrors: lastRootScan.rendererErrors,
+        unscannedRendererIds: unscanned
+      };
+    }
+
     var renderer = findActiveRenderer();
     if (!renderer) {
-      return JSON.stringify({ error: 'React DevTools hook not available or no fiber roots \u2014 app may still be loading' });
+      return JSON.stringify({
+        error: 'React DevTools hook not available or no fiber roots \u2014 app may still be loading',
+        verdict: buildVerdict('none', { noRenderer: true })
+      });
     }
 
     var visited = new WeakSet();
@@ -27668,7 +27720,15 @@ var init_injected_helpers = __esm({
     }
 
     function walkSubtree(fiber, depth, limit, vis) {
-      if (!fiber || depth > limit || vis.has(fiber)) return null;
+      if (!fiber) return null;
+      if (depth > limit) {
+        // Depth-cap drop: expected under the requested cap, but must be
+        // counted \u2014 a sparse-because-shallow tree previously looked identical
+        // to a legitimately small one.
+        walkQuality.droppedSubtrees++;
+        return null;
+      }
+      if (vis.has(fiber)) return null;
       vis.add(fiber);
       totalNodes++;
 
@@ -27748,6 +27808,7 @@ var init_injected_helpers = __esm({
       }
 
       if (children.length > 0) {
+        if (children.length > 20) walkQuality.collapsedChildLists++;
         result.children = children.length > 20
           ? children.slice(0, 10).concat([{ _truncated: (children.length - 10) + ' more' }])
           : children;
@@ -27849,6 +27910,11 @@ var init_injected_helpers = __esm({
         iOut.truncated = true;
         iOut.hint = 'More interactive elements exist beyond the cap \u2014 scope with filter or device_scrollintoview.';
       }
+      iOut.verdict = buildVerdict('interactive', {
+        rootsSeeded: iRoots.length,
+        scannedNodes: iScanned,
+        scanBudgetExhausted: iQueue.length > 0
+      });
       return safeStringify(iOut, 999999);
     }
 
@@ -27906,8 +27972,21 @@ var init_injected_helpers = __esm({
       // Codex review (conf 80): field renamed from renderersScanned to
       // rootsSeeded to match actual semantic (roots pushed into the BFS
       // queue, not renderers walked 1..5).
+      // A no-match verdict distinguishes "scanned everything, truly absent"
+      // from "budget ran out mid-scan" \u2014 the sparse-vs-empty ambiguity #409
+      // exists to kill.
+      var filterBudgetHit = queue.length > 0;
       if (matchFibers.length === 0) {
-        return JSON.stringify({ tree: null, totalNodes: scanned, rootsSeeded: allRoots.length });
+        return JSON.stringify({
+          tree: null,
+          totalNodes: scanned,
+          rootsSeeded: allRoots.length,
+          verdict: buildVerdict('filter', {
+            rootsSeeded: allRoots.length,
+            scannedNodes: scanned,
+            scanBudgetExhausted: filterBudgetHit
+          })
+        });
       }
 
       var matches = [];
@@ -27917,10 +27996,16 @@ var init_injected_helpers = __esm({
         if (subtree) matches.push(subtree);
       }
       totalNodes = scanned;
+      var filterVerdictOpts = {
+        rootsSeeded: allRoots.length,
+        scannedNodes: scanned,
+        scanBudgetExhausted: filterBudgetHit
+      };
       var tree = matches.length === 1 ? matches[0] : { matches: matches };
-      var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRoots.length }, 999999);
+      var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRoots.length, verdict: buildVerdict('filter', filterVerdictOpts) }, 999999);
       if (output.length > 50000) {
-        return safeStringify({ tree: matches[0] || null, totalNodes: totalNodes, rootsSeeded: allRoots.length, truncated: true });
+        filterVerdictOpts.outputTruncated = true;
+        return safeStringify({ tree: matches[0] || null, totalNodes: totalNodes, rootsSeeded: allRoots.length, truncated: true, verdict: buildVerdict('filter', filterVerdictOpts) });
       }
       return output;
     }
@@ -27937,10 +28022,13 @@ var init_injected_helpers = __esm({
       var sub = walkSubtree(allRootsU[ri].fiber, 0, maxDepth, visited);
       if (sub) trees.push(sub);
     }
+    var fullVerdictOpts = { rootsSeeded: allRootsU.length, scannedNodes: totalNodes };
     var tree = trees.length === 1 ? trees[0] : (trees.length === 0 ? null : { _wrapper: true, children: trees });
-    var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRootsU.length }, 999999);
+    var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRootsU.length, verdict: buildVerdict('full', fullVerdictOpts) }, 999999);
     if (output.length > 50000) {
-      return safeStringify({ error: 'Tree too large (' + output.length + ' chars). Use a filter parameter to scope the query.' });
+      fullVerdictOpts.failed = true;
+      fullVerdictOpts.outputTruncated = true;
+      return safeStringify({ error: 'Tree too large (' + output.length + ' chars). Use a filter parameter to scope the query.', verdict: buildVerdict('full', fullVerdictOpts) });
     }
     return output;
   }
@@ -30264,8 +30352,10 @@ var init_injected_helpers = __esm({
   // so the readiness gate can't miss a late-registered renderer (Bridgeless +
   // Reanimated register secondary renderers above id 5).
   for (var i = 1; i <= 20; i++) {
-    var r = h.getFiberRoots(i);
-    if (r && r.size > 0) return true;
+    try {
+      var r = h.getFiberRoots(i);
+      if (r && r.size > 0) return true;
+    } catch (_) { /* one throwing renderer must not abort the readiness scan */ }
   }
   return false;
 })()`;
@@ -40104,7 +40194,27 @@ function clearRefMap() {
   lastUpdated = 0;
   lastSnapshotHash = null;
 }
+function buildSnapshotVerdict(source, nodeCount, outcome) {
+  const reasons = [];
+  if (nodeCount === 0)
+    reasons.push("empty-capture");
+  return {
+    state: reasons.length > 0 ? "degraded" : "ok",
+    source,
+    nodeCount,
+    refMapUpdated: outcome.applied,
+    reasons
+  };
+}
 function updateRefMapFromFlat(nodes) {
+  let validCount = 0;
+  for (const node of nodes) {
+    if (node.ref && node.rect)
+      validCount++;
+  }
+  if (validCount === 0 && refMap.size > 0) {
+    return { applied: false, reason: "empty-capture" };
+  }
   refMap.clear();
   screenRect = null;
   const hashed = [];
@@ -40131,6 +40241,7 @@ function updateRefMapFromFlat(nodes) {
     lastSnapshotHash = null;
   }
   lastUpdated = Date.now();
+  return { applied: true };
 }
 function getCachedMetadata(ref) {
   const key = ref.startsWith("@") ? ref.slice(1) : ref;
@@ -41452,8 +41563,9 @@ async function runIOS(args) {
     const data = resp.data;
     if (Array.isArray(data.nodes)) {
       const flat = mapRunnerNodesToFlat(data.nodes);
-      updateRefMapFromFlat(flat);
-      return okResult({ nodes: flat }, announce ? { meta: announce } : void 0);
+      const outcome = updateRefMapFromFlat(flat);
+      const snapshotVerdict = buildSnapshotVerdict("rn-fast-runner", flat.length, outcome);
+      return okResult({ nodes: flat }, { meta: { ...announce, snapshotVerdict } });
     }
     return okResult(resp.data, announce ? { meta: announce } : void 0);
   }
@@ -42555,8 +42667,9 @@ async function runAndroid(args) {
     const data = resp.data;
     if (Array.isArray(data.nodes)) {
       const flat = mapRunnerNodesToFlat2(data.nodes);
-      updateRefMapFromFlat(flat);
-      return okResult({ nodes: flat });
+      const outcome = updateRefMapFromFlat(flat);
+      const snapshotVerdict = buildSnapshotVerdict("rn-android-runner", flat.length, outcome);
+      return okResult({ nodes: flat }, { meta: { snapshotVerdict } });
     }
   }
   if (args.command === "screenshot") {
@@ -46175,6 +46288,8 @@ async function fetchSnapshotNodes(allowCache = false) {
   const initialNodes = parseSnapshotEnvelope(first);
   if (initialNodes === null)
     return { ok: false, reason: "fetch-failed" };
+  if (initialNodes.length === 0)
+    return { ok: false, reason: "empty-capture" };
   if (!isAgentDeviceRunnerSentinel(initialNodes)) {
     const platform2 = getActiveSession()?.platform;
     if (platform2)
@@ -46199,10 +46314,15 @@ async function fetchSnapshotNodes(allowCache = false) {
   const recoveredNodes = parseSnapshotEnvelope(recovery.result);
   if (recoveredNodes === null)
     return { ok: false, reason: "fetch-failed" };
+  if (recoveredNodes.length === 0)
+    return { ok: false, reason: "empty-capture" };
   const platform = getActiveSession()?.platform;
   if (platform)
     cacheSnapshot(platform, recoveredNodes);
   return { ok: true, nodes: recoveredNodes, recoveredTier: recovery.tier };
+}
+function emptyCaptureFailResult(query) {
+  return failResult(`Snapshot returned zero nodes \u2014 cannot distinguish an empty screen from a degraded capture` + (query !== void 0 ? `; not asserting "${query}" is absent` : "") + `. Confirm the screen with device_screenshot or cdp_component_tree, then retry.`, { code: "SNAPSHOT_DEGRADED", ...query !== void 0 ? { query } : {} });
 }
 async function fetchFindCandidates(query, exact = false, allowCache = false) {
   const snap = await fetchSnapshotNodes(allowCache);
@@ -46254,6 +46374,9 @@ function createDeviceFindHandler() {
         if (find.reason === "runner-leak-unrecovered") {
           return runnerLeakFailResult(args.text, find.recoveryReason);
         }
+        if (find.reason === "empty-capture") {
+          return emptyCaptureFailResult(args.text);
+        }
         return failResult(`Snapshot unavailable \u2014 cannot resolve ${args.exact ? "exact" : "index-based"} match for "${args.text}". Retry after device_snapshot action=open/snapshot.`, { code: "SNAPSHOT_UNAVAILABLE", query: args.text });
       }
       const { candidates, recoveredTier } = find;
@@ -46286,6 +46409,9 @@ function createDeviceFindHandler() {
       if (!find.ok) {
         if (find.reason === "runner-leak-unrecovered") {
           return runnerLeakFailResult(args.text, find.recoveryReason);
+        }
+        if (find.reason === "empty-capture") {
+          return emptyCaptureFailResult(args.text);
         }
         return failResult(`Snapshot unavailable \u2014 cannot resolve "${args.text}"`, {
           code: "SNAPSHOT_UNAVAILABLE",
@@ -46948,6 +47074,9 @@ function createDeviceFocusNextHandler() {
     if (!snap.ok) {
       if (snap.reason === "runner-leak-unrecovered") {
         return runnerLeakFailResult(void 0, snap.recoveryReason);
+      }
+      if (snap.reason === "empty-capture") {
+        return emptyCaptureFailResult();
       }
       return failResult("Snapshot unavailable \u2014 cannot look for keyboard key. Retry after device_snapshot action=open/snapshot.", { code: "SNAPSHOT_UNAVAILABLE" });
     }
@@ -49252,15 +49381,19 @@ function createComponentTreeHandler(getClient2) {
     } catch {
       return failResult("Failed to parse component tree response");
     }
+    const verdict = parsed.verdict;
+    const meta = verdict ? { treeVerdict: verdict } : void 0;
     if (parsed.error) {
-      return failResult(`Component tree error: ${parsed.error}`);
+      return failResult(`Component tree error: ${parsed.error}`, meta);
     }
     if (parsed.warning === "APP_HAS_REDBOX") {
       return warnResult({
         message: parsed.message ?? "App is showing an error screen. Use cdp_error_log to read the error, fix the code, then cdp_reload."
-      }, "APP_HAS_REDBOX");
+      }, "APP_HAS_REDBOX", meta);
     }
-    return okResult(parsed);
+    if (verdict)
+      delete parsed.verdict;
+    return okResult(parsed, meta ? { meta } : void 0);
   });
 }
 var init_component_tree = __esm({

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -19255,7 +19255,27 @@ function clearRefMap() {
   lastUpdated = 0;
   lastSnapshotHash = null;
 }
+function buildSnapshotVerdict(source, nodeCount, outcome) {
+  const reasons = [];
+  if (nodeCount === 0)
+    reasons.push("empty-capture");
+  return {
+    state: reasons.length > 0 ? "degraded" : "ok",
+    source,
+    nodeCount,
+    refMapUpdated: outcome.applied,
+    reasons
+  };
+}
 function updateRefMapFromFlat(nodes) {
+  let validCount = 0;
+  for (const node of nodes) {
+    if (node.ref && node.rect)
+      validCount++;
+  }
+  if (validCount === 0 && refMap.size > 0) {
+    return { applied: false, reason: "empty-capture" };
+  }
   refMap.clear();
   screenRect = null;
   const hashed = [];
@@ -19282,6 +19302,7 @@ function updateRefMapFromFlat(nodes) {
     lastSnapshotHash = null;
   }
   lastUpdated = Date.now();
+  return { applied: true };
 }
 function getCachedMetadata(ref) {
   const key = ref.startsWith("@") ? ref.slice(1) : ref;
@@ -20603,8 +20624,9 @@ async function runIOS(args) {
     const data = resp.data;
     if (Array.isArray(data.nodes)) {
       const flat = mapRunnerNodesToFlat(data.nodes);
-      updateRefMapFromFlat(flat);
-      return okResult({ nodes: flat }, announce ? { meta: announce } : void 0);
+      const outcome = updateRefMapFromFlat(flat);
+      const snapshotVerdict = buildSnapshotVerdict("rn-fast-runner", flat.length, outcome);
+      return okResult({ nodes: flat }, { meta: { ...announce, snapshotVerdict } });
     }
     return okResult(resp.data, announce ? { meta: announce } : void 0);
   }
@@ -21706,8 +21728,9 @@ async function runAndroid(args) {
     const data = resp.data;
     if (Array.isArray(data.nodes)) {
       const flat = mapRunnerNodesToFlat2(data.nodes);
-      updateRefMapFromFlat(flat);
-      return okResult({ nodes: flat });
+      const outcome = updateRefMapFromFlat(flat);
+      const snapshotVerdict = buildSnapshotVerdict("rn-android-runner", flat.length, outcome);
+      return okResult({ nodes: flat }, { meta: { snapshotVerdict } });
     }
   }
   if (args.command === "screenshot") {
@@ -25326,6 +25349,8 @@ async function fetchSnapshotNodes(allowCache = false) {
   const initialNodes = parseSnapshotEnvelope(first);
   if (initialNodes === null)
     return { ok: false, reason: "fetch-failed" };
+  if (initialNodes.length === 0)
+    return { ok: false, reason: "empty-capture" };
   if (!isAgentDeviceRunnerSentinel(initialNodes)) {
     const platform2 = getActiveSession()?.platform;
     if (platform2)
@@ -25350,10 +25375,15 @@ async function fetchSnapshotNodes(allowCache = false) {
   const recoveredNodes = parseSnapshotEnvelope(recovery.result);
   if (recoveredNodes === null)
     return { ok: false, reason: "fetch-failed" };
+  if (recoveredNodes.length === 0)
+    return { ok: false, reason: "empty-capture" };
   const platform = getActiveSession()?.platform;
   if (platform)
     cacheSnapshot(platform, recoveredNodes);
   return { ok: true, nodes: recoveredNodes, recoveredTier: recovery.tier };
+}
+function emptyCaptureFailResult(query) {
+  return failResult(`Snapshot returned zero nodes \u2014 cannot distinguish an empty screen from a degraded capture` + (query !== void 0 ? `; not asserting "${query}" is absent` : "") + `. Confirm the screen with device_screenshot or cdp_component_tree, then retry.`, { code: "SNAPSHOT_DEGRADED", ...query !== void 0 ? { query } : {} });
 }
 async function fetchFindCandidates(query, exact = false, allowCache = false) {
   const snap = await fetchSnapshotNodes(allowCache);
@@ -25405,6 +25435,9 @@ function createDeviceFindHandler() {
         if (find.reason === "runner-leak-unrecovered") {
           return runnerLeakFailResult(args.text, find.recoveryReason);
         }
+        if (find.reason === "empty-capture") {
+          return emptyCaptureFailResult(args.text);
+        }
         return failResult(`Snapshot unavailable \u2014 cannot resolve ${args.exact ? "exact" : "index-based"} match for "${args.text}". Retry after device_snapshot action=open/snapshot.`, { code: "SNAPSHOT_UNAVAILABLE", query: args.text });
       }
       const { candidates, recoveredTier } = find;
@@ -25437,6 +25470,9 @@ function createDeviceFindHandler() {
       if (!find.ok) {
         if (find.reason === "runner-leak-unrecovered") {
           return runnerLeakFailResult(args.text, find.recoveryReason);
+        }
+        if (find.reason === "empty-capture") {
+          return emptyCaptureFailResult(args.text);
         }
         return failResult(`Snapshot unavailable \u2014 cannot resolve "${args.text}"`, {
           code: "SNAPSHOT_UNAVAILABLE",
@@ -26099,6 +26135,9 @@ function createDeviceFocusNextHandler() {
     if (!snap.ok) {
       if (snap.reason === "runner-leak-unrecovered") {
         return runnerLeakFailResult(void 0, snap.recoveryReason);
+      }
+      if (snap.reason === "empty-capture") {
+        return emptyCaptureFailResult();
       }
       return failResult("Snapshot unavailable \u2014 cannot look for keyboard key. Retry after device_snapshot action=open/snapshot.", { code: "SNAPSHOT_UNAVAILABLE" });
     }
@@ -42019,7 +42058,7 @@ async function detectBridge(client2) {
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 33;
+var HELPERS_VERSION = 34;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -42035,11 +42074,29 @@ var INJECTED_HELPERS = `
   var MAX_RENDERER_IDS = 20;
   var EARLY_EXIT_EMPTY_STREAK = 3;
 
+  // Reset by every root-iteration pass; only valid when read synchronously
+  // after the pass that produced the tree (many helpers share the iterators).
+  var lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+
+  function computeUnscannedRendererIds() {
+    try {
+      var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+      if (!hook || !hook.renderers || typeof hook.renderers.forEach !== 'function') return [];
+      var out = [];
+      hook.renderers.forEach(function(_v, id) {
+        if (typeof id === 'number' && id > lastRootScan.probedUpTo) out.push(id);
+      });
+      return out;
+    } catch (_) { return []; }
+  }
+
   function findActiveRenderer() {
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
     var emptyStreak = 0;
     for (var i = 1; i <= MAX_RENDERER_IDS; i++) {
+      lastRootScan.probedUpTo = i;
       try {
         var roots = hook.getFiberRoots(i);
         if (roots && roots.size > 0) {
@@ -42049,6 +42106,7 @@ var INJECTED_HELPERS = `
         if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && i >= 5) return null;
       } catch (_) {
         emptyStreak++;
+        lastRootScan.rendererErrors++;
       }
     }
     return null;
@@ -42062,18 +42120,17 @@ var INJECTED_HELPERS = `
   //
   // Per-renderer try/catch protects against one renderer's getFiberRoots
   // throwing during teardown/HMR/worklet init (Gemini A3, 2026-04-23,
-  // conf 80) \u2014 a single bad renderer must not poison the union.
-  //
-  // Task 4 will add an extra-roots step here that consults
-  // globalThis.__RN_AGENT_EXTRA_ROOTS__ AFTER the native renderer loop
-  // so user-registered portals stay lower priority than React's own
-  // registry. Not in this commit \u2014 refactor isolated from new behavior
-  // for cleaner bisects.
+  // conf 80) \u2014 a single bad renderer must not poison the union. The
+  // extra-roots step (globalThis.__RN_AGENT_EXTRA_ROOTS__) runs AFTER the
+  // native renderer loop so user-registered portals stay lower priority
+  // than React's own registry.
   function iterateAllRoots(cb) {
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (hook && typeof hook.getFiberRoots === 'function') {
       var emptyStreak = 0;
       for (var ri = 1; ri <= MAX_RENDERER_IDS; ri++) {
+        lastRootScan.probedUpTo = ri;
         try {
           var roots = hook.getFiberRoots(ri);
           if (roots && roots.size) {
@@ -42092,6 +42149,7 @@ var INJECTED_HELPERS = `
           }
         } catch (_) {
           emptyStreak++;
+          lastRootScan.rendererErrors++;
         }
       }
     }
@@ -42117,7 +42175,10 @@ var INJECTED_HELPERS = `
           }
         }
       }
-    } catch (_) { /* swallow \u2014 resolver bug must not break iteration */ }
+    } catch (_) {
+      // swallow \u2014 resolver bug must not break iteration
+      lastRootScan.rendererErrors++;
+    }
     return null;
   }
 
@@ -42228,9 +42289,39 @@ var INJECTED_HELPERS = `
     var maxDepth = opts.maxDepth || 4;
     var filter = opts.filter || opts.testID || opts.type || null;
 
+    // Story 16 (#409): quality verdict computed once at capture, from the same
+    // pass that produced the tree \u2014 downstream tools render it, never re-derive.
+    var walkQuality = { droppedSubtrees: 0, collapsedChildLists: 0 };
+    function buildVerdict(path, o) {
+      o = o || {};
+      var reasons = [];
+      if (o.noRenderer) reasons.push('no-renderer');
+      if (lastRootScan.rendererErrors > 0) reasons.push('renderer-error');
+      var unscanned = computeUnscannedRendererIds();
+      if (unscanned.length > 0) reasons.push('renderers-unscanned');
+      if (o.scanBudgetExhausted) reasons.push('scan-budget-exhausted');
+      if (o.outputTruncated) reasons.push('output-truncated');
+      var state = (o.noRenderer || o.failed) ? 'failed' : (reasons.length > 0 ? 'degraded' : 'ok');
+      return {
+        state: state,
+        path: path,
+        reasons: reasons,
+        rootsSeeded: o.rootsSeeded || 0,
+        scannedNodes: o.scannedNodes || 0,
+        effectiveDepth: maxDepth,
+        droppedSubtrees: walkQuality.droppedSubtrees,
+        collapsedChildLists: walkQuality.collapsedChildLists,
+        rendererErrors: lastRootScan.rendererErrors,
+        unscannedRendererIds: unscanned
+      };
+    }
+
     var renderer = findActiveRenderer();
     if (!renderer) {
-      return JSON.stringify({ error: 'React DevTools hook not available or no fiber roots \u2014 app may still be loading' });
+      return JSON.stringify({
+        error: 'React DevTools hook not available or no fiber roots \u2014 app may still be loading',
+        verdict: buildVerdict('none', { noRenderer: true })
+      });
     }
 
     var visited = new WeakSet();
@@ -42271,7 +42362,15 @@ var INJECTED_HELPERS = `
     }
 
     function walkSubtree(fiber, depth, limit, vis) {
-      if (!fiber || depth > limit || vis.has(fiber)) return null;
+      if (!fiber) return null;
+      if (depth > limit) {
+        // Depth-cap drop: expected under the requested cap, but must be
+        // counted \u2014 a sparse-because-shallow tree previously looked identical
+        // to a legitimately small one.
+        walkQuality.droppedSubtrees++;
+        return null;
+      }
+      if (vis.has(fiber)) return null;
       vis.add(fiber);
       totalNodes++;
 
@@ -42351,6 +42450,7 @@ var INJECTED_HELPERS = `
       }
 
       if (children.length > 0) {
+        if (children.length > 20) walkQuality.collapsedChildLists++;
         result.children = children.length > 20
           ? children.slice(0, 10).concat([{ _truncated: (children.length - 10) + ' more' }])
           : children;
@@ -42452,6 +42552,11 @@ var INJECTED_HELPERS = `
         iOut.truncated = true;
         iOut.hint = 'More interactive elements exist beyond the cap \u2014 scope with filter or device_scrollintoview.';
       }
+      iOut.verdict = buildVerdict('interactive', {
+        rootsSeeded: iRoots.length,
+        scannedNodes: iScanned,
+        scanBudgetExhausted: iQueue.length > 0
+      });
       return safeStringify(iOut, 999999);
     }
 
@@ -42509,8 +42614,21 @@ var INJECTED_HELPERS = `
       // Codex review (conf 80): field renamed from renderersScanned to
       // rootsSeeded to match actual semantic (roots pushed into the BFS
       // queue, not renderers walked 1..5).
+      // A no-match verdict distinguishes "scanned everything, truly absent"
+      // from "budget ran out mid-scan" \u2014 the sparse-vs-empty ambiguity #409
+      // exists to kill.
+      var filterBudgetHit = queue.length > 0;
       if (matchFibers.length === 0) {
-        return JSON.stringify({ tree: null, totalNodes: scanned, rootsSeeded: allRoots.length });
+        return JSON.stringify({
+          tree: null,
+          totalNodes: scanned,
+          rootsSeeded: allRoots.length,
+          verdict: buildVerdict('filter', {
+            rootsSeeded: allRoots.length,
+            scannedNodes: scanned,
+            scanBudgetExhausted: filterBudgetHit
+          })
+        });
       }
 
       var matches = [];
@@ -42520,10 +42638,16 @@ var INJECTED_HELPERS = `
         if (subtree) matches.push(subtree);
       }
       totalNodes = scanned;
+      var filterVerdictOpts = {
+        rootsSeeded: allRoots.length,
+        scannedNodes: scanned,
+        scanBudgetExhausted: filterBudgetHit
+      };
       var tree = matches.length === 1 ? matches[0] : { matches: matches };
-      var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRoots.length }, 999999);
+      var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRoots.length, verdict: buildVerdict('filter', filterVerdictOpts) }, 999999);
       if (output.length > 50000) {
-        return safeStringify({ tree: matches[0] || null, totalNodes: totalNodes, rootsSeeded: allRoots.length, truncated: true });
+        filterVerdictOpts.outputTruncated = true;
+        return safeStringify({ tree: matches[0] || null, totalNodes: totalNodes, rootsSeeded: allRoots.length, truncated: true, verdict: buildVerdict('filter', filterVerdictOpts) });
       }
       return output;
     }
@@ -42540,10 +42664,13 @@ var INJECTED_HELPERS = `
       var sub = walkSubtree(allRootsU[ri].fiber, 0, maxDepth, visited);
       if (sub) trees.push(sub);
     }
+    var fullVerdictOpts = { rootsSeeded: allRootsU.length, scannedNodes: totalNodes };
     var tree = trees.length === 1 ? trees[0] : (trees.length === 0 ? null : { _wrapper: true, children: trees });
-    var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRootsU.length }, 999999);
+    var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRootsU.length, verdict: buildVerdict('full', fullVerdictOpts) }, 999999);
     if (output.length > 50000) {
-      return safeStringify({ error: 'Tree too large (' + output.length + ' chars). Use a filter parameter to scope the query.' });
+      fullVerdictOpts.failed = true;
+      fullVerdictOpts.outputTruncated = true;
+      return safeStringify({ error: 'Tree too large (' + output.length + ' chars). Use a filter parameter to scope the query.', verdict: buildVerdict('full', fullVerdictOpts) });
     }
     return output;
   }
@@ -44867,8 +44994,10 @@ var REACT_READY_PROBE_JS = `(function() {
   // so the readiness gate can't miss a late-registered renderer (Bridgeless +
   // Reanimated register secondary renderers above id 5).
   for (var i = 1; i <= 20; i++) {
-    var r = h.getFiberRoots(i);
-    if (r && r.size > 0) return true;
+    try {
+      var r = h.getFiberRoots(i);
+      if (r && r.size > 0) return true;
+    } catch (_) { /* one throwing renderer must not abort the readiness scan */ }
   }
   return false;
 })()`;
@@ -47841,15 +47970,19 @@ function createComponentTreeHandler(getClient2) {
     } catch {
       return failResult("Failed to parse component tree response");
     }
+    const verdict = parsed.verdict;
+    const meta = verdict ? { treeVerdict: verdict } : void 0;
     if (parsed.error) {
-      return failResult(`Component tree error: ${parsed.error}`);
+      return failResult(`Component tree error: ${parsed.error}`, meta);
     }
     if (parsed.warning === "APP_HAS_REDBOX") {
       return warnResult({
         message: parsed.message ?? "App is showing an error screen. Use cdp_error_log to read the error, fix the code, then cdp_reload."
-      }, "APP_HAS_REDBOX");
+      }, "APP_HAS_REDBOX", meta);
     }
-    return okResult(parsed);
+    if (verdict)
+      delete parsed.verdict;
+    return okResult(parsed, meta ? { meta } : void 0);
   });
 }
 

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -27416,7 +27416,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 33;
+    HELPERS_VERSION = 34;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -27432,11 +27432,29 @@ var init_injected_helpers = __esm({
   var MAX_RENDERER_IDS = 20;
   var EARLY_EXIT_EMPTY_STREAK = 3;
 
+  // Reset by every root-iteration pass; only valid when read synchronously
+  // after the pass that produced the tree (many helpers share the iterators).
+  var lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+
+  function computeUnscannedRendererIds() {
+    try {
+      var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+      if (!hook || !hook.renderers || typeof hook.renderers.forEach !== 'function') return [];
+      var out = [];
+      hook.renderers.forEach(function(_v, id) {
+        if (typeof id === 'number' && id > lastRootScan.probedUpTo) out.push(id);
+      });
+      return out;
+    } catch (_) { return []; }
+  }
+
   function findActiveRenderer() {
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
     var emptyStreak = 0;
     for (var i = 1; i <= MAX_RENDERER_IDS; i++) {
+      lastRootScan.probedUpTo = i;
       try {
         var roots = hook.getFiberRoots(i);
         if (roots && roots.size > 0) {
@@ -27446,6 +27464,7 @@ var init_injected_helpers = __esm({
         if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && i >= 5) return null;
       } catch (_) {
         emptyStreak++;
+        lastRootScan.rendererErrors++;
       }
     }
     return null;
@@ -27459,18 +27478,17 @@ var init_injected_helpers = __esm({
   //
   // Per-renderer try/catch protects against one renderer's getFiberRoots
   // throwing during teardown/HMR/worklet init (Gemini A3, 2026-04-23,
-  // conf 80) \u2014 a single bad renderer must not poison the union.
-  //
-  // Task 4 will add an extra-roots step here that consults
-  // globalThis.__RN_AGENT_EXTRA_ROOTS__ AFTER the native renderer loop
-  // so user-registered portals stay lower priority than React's own
-  // registry. Not in this commit \u2014 refactor isolated from new behavior
-  // for cleaner bisects.
+  // conf 80) \u2014 a single bad renderer must not poison the union. The
+  // extra-roots step (globalThis.__RN_AGENT_EXTRA_ROOTS__) runs AFTER the
+  // native renderer loop so user-registered portals stay lower priority
+  // than React's own registry.
   function iterateAllRoots(cb) {
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (hook && typeof hook.getFiberRoots === 'function') {
       var emptyStreak = 0;
       for (var ri = 1; ri <= MAX_RENDERER_IDS; ri++) {
+        lastRootScan.probedUpTo = ri;
         try {
           var roots = hook.getFiberRoots(ri);
           if (roots && roots.size) {
@@ -27489,6 +27507,7 @@ var init_injected_helpers = __esm({
           }
         } catch (_) {
           emptyStreak++;
+          lastRootScan.rendererErrors++;
         }
       }
     }
@@ -27514,7 +27533,10 @@ var init_injected_helpers = __esm({
           }
         }
       }
-    } catch (_) { /* swallow \u2014 resolver bug must not break iteration */ }
+    } catch (_) {
+      // swallow \u2014 resolver bug must not break iteration
+      lastRootScan.rendererErrors++;
+    }
     return null;
   }
 
@@ -27625,9 +27647,39 @@ var init_injected_helpers = __esm({
     var maxDepth = opts.maxDepth || 4;
     var filter = opts.filter || opts.testID || opts.type || null;
 
+    // Story 16 (#409): quality verdict computed once at capture, from the same
+    // pass that produced the tree \u2014 downstream tools render it, never re-derive.
+    var walkQuality = { droppedSubtrees: 0, collapsedChildLists: 0 };
+    function buildVerdict(path, o) {
+      o = o || {};
+      var reasons = [];
+      if (o.noRenderer) reasons.push('no-renderer');
+      if (lastRootScan.rendererErrors > 0) reasons.push('renderer-error');
+      var unscanned = computeUnscannedRendererIds();
+      if (unscanned.length > 0) reasons.push('renderers-unscanned');
+      if (o.scanBudgetExhausted) reasons.push('scan-budget-exhausted');
+      if (o.outputTruncated) reasons.push('output-truncated');
+      var state = (o.noRenderer || o.failed) ? 'failed' : (reasons.length > 0 ? 'degraded' : 'ok');
+      return {
+        state: state,
+        path: path,
+        reasons: reasons,
+        rootsSeeded: o.rootsSeeded || 0,
+        scannedNodes: o.scannedNodes || 0,
+        effectiveDepth: maxDepth,
+        droppedSubtrees: walkQuality.droppedSubtrees,
+        collapsedChildLists: walkQuality.collapsedChildLists,
+        rendererErrors: lastRootScan.rendererErrors,
+        unscannedRendererIds: unscanned
+      };
+    }
+
     var renderer = findActiveRenderer();
     if (!renderer) {
-      return JSON.stringify({ error: 'React DevTools hook not available or no fiber roots \u2014 app may still be loading' });
+      return JSON.stringify({
+        error: 'React DevTools hook not available or no fiber roots \u2014 app may still be loading',
+        verdict: buildVerdict('none', { noRenderer: true })
+      });
     }
 
     var visited = new WeakSet();
@@ -27668,7 +27720,15 @@ var init_injected_helpers = __esm({
     }
 
     function walkSubtree(fiber, depth, limit, vis) {
-      if (!fiber || depth > limit || vis.has(fiber)) return null;
+      if (!fiber) return null;
+      if (depth > limit) {
+        // Depth-cap drop: expected under the requested cap, but must be
+        // counted \u2014 a sparse-because-shallow tree previously looked identical
+        // to a legitimately small one.
+        walkQuality.droppedSubtrees++;
+        return null;
+      }
+      if (vis.has(fiber)) return null;
       vis.add(fiber);
       totalNodes++;
 
@@ -27748,6 +27808,7 @@ var init_injected_helpers = __esm({
       }
 
       if (children.length > 0) {
+        if (children.length > 20) walkQuality.collapsedChildLists++;
         result.children = children.length > 20
           ? children.slice(0, 10).concat([{ _truncated: (children.length - 10) + ' more' }])
           : children;
@@ -27849,6 +27910,11 @@ var init_injected_helpers = __esm({
         iOut.truncated = true;
         iOut.hint = 'More interactive elements exist beyond the cap \u2014 scope with filter or device_scrollintoview.';
       }
+      iOut.verdict = buildVerdict('interactive', {
+        rootsSeeded: iRoots.length,
+        scannedNodes: iScanned,
+        scanBudgetExhausted: iQueue.length > 0
+      });
       return safeStringify(iOut, 999999);
     }
 
@@ -27906,8 +27972,21 @@ var init_injected_helpers = __esm({
       // Codex review (conf 80): field renamed from renderersScanned to
       // rootsSeeded to match actual semantic (roots pushed into the BFS
       // queue, not renderers walked 1..5).
+      // A no-match verdict distinguishes "scanned everything, truly absent"
+      // from "budget ran out mid-scan" \u2014 the sparse-vs-empty ambiguity #409
+      // exists to kill.
+      var filterBudgetHit = queue.length > 0;
       if (matchFibers.length === 0) {
-        return JSON.stringify({ tree: null, totalNodes: scanned, rootsSeeded: allRoots.length });
+        return JSON.stringify({
+          tree: null,
+          totalNodes: scanned,
+          rootsSeeded: allRoots.length,
+          verdict: buildVerdict('filter', {
+            rootsSeeded: allRoots.length,
+            scannedNodes: scanned,
+            scanBudgetExhausted: filterBudgetHit
+          })
+        });
       }
 
       var matches = [];
@@ -27917,10 +27996,16 @@ var init_injected_helpers = __esm({
         if (subtree) matches.push(subtree);
       }
       totalNodes = scanned;
+      var filterVerdictOpts = {
+        rootsSeeded: allRoots.length,
+        scannedNodes: scanned,
+        scanBudgetExhausted: filterBudgetHit
+      };
       var tree = matches.length === 1 ? matches[0] : { matches: matches };
-      var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRoots.length }, 999999);
+      var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRoots.length, verdict: buildVerdict('filter', filterVerdictOpts) }, 999999);
       if (output.length > 50000) {
-        return safeStringify({ tree: matches[0] || null, totalNodes: totalNodes, rootsSeeded: allRoots.length, truncated: true });
+        filterVerdictOpts.outputTruncated = true;
+        return safeStringify({ tree: matches[0] || null, totalNodes: totalNodes, rootsSeeded: allRoots.length, truncated: true, verdict: buildVerdict('filter', filterVerdictOpts) });
       }
       return output;
     }
@@ -27937,10 +28022,13 @@ var init_injected_helpers = __esm({
       var sub = walkSubtree(allRootsU[ri].fiber, 0, maxDepth, visited);
       if (sub) trees.push(sub);
     }
+    var fullVerdictOpts = { rootsSeeded: allRootsU.length, scannedNodes: totalNodes };
     var tree = trees.length === 1 ? trees[0] : (trees.length === 0 ? null : { _wrapper: true, children: trees });
-    var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRootsU.length }, 999999);
+    var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRootsU.length, verdict: buildVerdict('full', fullVerdictOpts) }, 999999);
     if (output.length > 50000) {
-      return safeStringify({ error: 'Tree too large (' + output.length + ' chars). Use a filter parameter to scope the query.' });
+      fullVerdictOpts.failed = true;
+      fullVerdictOpts.outputTruncated = true;
+      return safeStringify({ error: 'Tree too large (' + output.length + ' chars). Use a filter parameter to scope the query.', verdict: buildVerdict('full', fullVerdictOpts) });
     }
     return output;
   }
@@ -30264,8 +30352,10 @@ var init_injected_helpers = __esm({
   // so the readiness gate can't miss a late-registered renderer (Bridgeless +
   // Reanimated register secondary renderers above id 5).
   for (var i = 1; i <= 20; i++) {
-    var r = h.getFiberRoots(i);
-    if (r && r.size > 0) return true;
+    try {
+      var r = h.getFiberRoots(i);
+      if (r && r.size > 0) return true;
+    } catch (_) { /* one throwing renderer must not abort the readiness scan */ }
   }
   return false;
 })()`;
@@ -40104,7 +40194,27 @@ function clearRefMap() {
   lastUpdated = 0;
   lastSnapshotHash = null;
 }
+function buildSnapshotVerdict(source, nodeCount, outcome) {
+  const reasons = [];
+  if (nodeCount === 0)
+    reasons.push("empty-capture");
+  return {
+    state: reasons.length > 0 ? "degraded" : "ok",
+    source,
+    nodeCount,
+    refMapUpdated: outcome.applied,
+    reasons
+  };
+}
 function updateRefMapFromFlat(nodes) {
+  let validCount = 0;
+  for (const node of nodes) {
+    if (node.ref && node.rect)
+      validCount++;
+  }
+  if (validCount === 0 && refMap.size > 0) {
+    return { applied: false, reason: "empty-capture" };
+  }
   refMap.clear();
   screenRect = null;
   const hashed = [];
@@ -40131,6 +40241,7 @@ function updateRefMapFromFlat(nodes) {
     lastSnapshotHash = null;
   }
   lastUpdated = Date.now();
+  return { applied: true };
 }
 function getCachedMetadata(ref) {
   const key = ref.startsWith("@") ? ref.slice(1) : ref;
@@ -41452,8 +41563,9 @@ async function runIOS(args) {
     const data = resp.data;
     if (Array.isArray(data.nodes)) {
       const flat = mapRunnerNodesToFlat(data.nodes);
-      updateRefMapFromFlat(flat);
-      return okResult({ nodes: flat }, announce ? { meta: announce } : void 0);
+      const outcome = updateRefMapFromFlat(flat);
+      const snapshotVerdict = buildSnapshotVerdict("rn-fast-runner", flat.length, outcome);
+      return okResult({ nodes: flat }, { meta: { ...announce, snapshotVerdict } });
     }
     return okResult(resp.data, announce ? { meta: announce } : void 0);
   }
@@ -42555,8 +42667,9 @@ async function runAndroid(args) {
     const data = resp.data;
     if (Array.isArray(data.nodes)) {
       const flat = mapRunnerNodesToFlat2(data.nodes);
-      updateRefMapFromFlat(flat);
-      return okResult({ nodes: flat });
+      const outcome = updateRefMapFromFlat(flat);
+      const snapshotVerdict = buildSnapshotVerdict("rn-android-runner", flat.length, outcome);
+      return okResult({ nodes: flat }, { meta: { snapshotVerdict } });
     }
   }
   if (args.command === "screenshot") {
@@ -46175,6 +46288,8 @@ async function fetchSnapshotNodes(allowCache = false) {
   const initialNodes = parseSnapshotEnvelope(first);
   if (initialNodes === null)
     return { ok: false, reason: "fetch-failed" };
+  if (initialNodes.length === 0)
+    return { ok: false, reason: "empty-capture" };
   if (!isAgentDeviceRunnerSentinel(initialNodes)) {
     const platform2 = getActiveSession()?.platform;
     if (platform2)
@@ -46199,10 +46314,15 @@ async function fetchSnapshotNodes(allowCache = false) {
   const recoveredNodes = parseSnapshotEnvelope(recovery.result);
   if (recoveredNodes === null)
     return { ok: false, reason: "fetch-failed" };
+  if (recoveredNodes.length === 0)
+    return { ok: false, reason: "empty-capture" };
   const platform = getActiveSession()?.platform;
   if (platform)
     cacheSnapshot(platform, recoveredNodes);
   return { ok: true, nodes: recoveredNodes, recoveredTier: recovery.tier };
+}
+function emptyCaptureFailResult(query) {
+  return failResult(`Snapshot returned zero nodes \u2014 cannot distinguish an empty screen from a degraded capture` + (query !== void 0 ? `; not asserting "${query}" is absent` : "") + `. Confirm the screen with device_screenshot or cdp_component_tree, then retry.`, { code: "SNAPSHOT_DEGRADED", ...query !== void 0 ? { query } : {} });
 }
 async function fetchFindCandidates(query, exact = false, allowCache = false) {
   const snap = await fetchSnapshotNodes(allowCache);
@@ -46254,6 +46374,9 @@ function createDeviceFindHandler() {
         if (find.reason === "runner-leak-unrecovered") {
           return runnerLeakFailResult(args.text, find.recoveryReason);
         }
+        if (find.reason === "empty-capture") {
+          return emptyCaptureFailResult(args.text);
+        }
         return failResult(`Snapshot unavailable \u2014 cannot resolve ${args.exact ? "exact" : "index-based"} match for "${args.text}". Retry after device_snapshot action=open/snapshot.`, { code: "SNAPSHOT_UNAVAILABLE", query: args.text });
       }
       const { candidates, recoveredTier } = find;
@@ -46286,6 +46409,9 @@ function createDeviceFindHandler() {
       if (!find.ok) {
         if (find.reason === "runner-leak-unrecovered") {
           return runnerLeakFailResult(args.text, find.recoveryReason);
+        }
+        if (find.reason === "empty-capture") {
+          return emptyCaptureFailResult(args.text);
         }
         return failResult(`Snapshot unavailable \u2014 cannot resolve "${args.text}"`, {
           code: "SNAPSHOT_UNAVAILABLE",
@@ -46948,6 +47074,9 @@ function createDeviceFocusNextHandler() {
     if (!snap.ok) {
       if (snap.reason === "runner-leak-unrecovered") {
         return runnerLeakFailResult(void 0, snap.recoveryReason);
+      }
+      if (snap.reason === "empty-capture") {
+        return emptyCaptureFailResult();
       }
       return failResult("Snapshot unavailable \u2014 cannot look for keyboard key. Retry after device_snapshot action=open/snapshot.", { code: "SNAPSHOT_UNAVAILABLE" });
     }
@@ -49252,15 +49381,19 @@ function createComponentTreeHandler(getClient2) {
     } catch {
       return failResult("Failed to parse component tree response");
     }
+    const verdict = parsed.verdict;
+    const meta = verdict ? { treeVerdict: verdict } : void 0;
     if (parsed.error) {
-      return failResult(`Component tree error: ${parsed.error}`);
+      return failResult(`Component tree error: ${parsed.error}`, meta);
     }
     if (parsed.warning === "APP_HAS_REDBOX") {
       return warnResult({
         message: parsed.message ?? "App is showing an error screen. Use cdp_error_log to read the error, fix the code, then cdp_reload."
-      }, "APP_HAS_REDBOX");
+      }, "APP_HAS_REDBOX", meta);
     }
-    return okResult(parsed);
+    if (verdict)
+      delete parsed.verdict;
+    return okResult(parsed, meta ? { meta } : void 0);
   });
 }
 var init_component_tree = __esm({

--- a/packages/rn-dev-agent-core/dist/fast-runner-ref-map.js
+++ b/packages/rn-dev-agent-core/dist/fast-runner-ref-map.js
@@ -179,7 +179,32 @@ export function flattenXCUITree(tree) {
     walk(tree);
     return { nodes, refMap: localRefMap };
 }
+export function buildSnapshotVerdict(source, nodeCount, outcome) {
+    const reasons = [];
+    if (nodeCount === 0)
+        reasons.push('empty-capture');
+    return {
+        state: reasons.length > 0 ? 'degraded' : 'ok',
+        source,
+        nodeCount,
+        refMapUpdated: outcome.applied,
+        reasons,
+    };
+}
 export function updateRefMapFromFlat(nodes) {
+    // GH #409: a zero-node capture is indistinguishable from a degraded walk
+    // (AX failure, wedged runner, mid-transition screen). It must never wipe the
+    // last-known-good map — refs stay bound to the last verified capture, and a
+    // genuinely emptied screen surfaces as STALE_REF on the next tap instead of
+    // silently serving nothing.
+    let validCount = 0;
+    for (const node of nodes) {
+        if (node.ref && node.rect)
+            validCount++;
+    }
+    if (validCount === 0 && refMap.size > 0) {
+        return { applied: false, reason: 'empty-capture' };
+    }
     // refMap IS cleared (coordinates must never be served across generations —
     // only the CURRENT snapshot is tappable), but metadataMap is NOT: ref ids are
     // positional, so ids absent from this snapshot cannot collide with current
@@ -222,6 +247,7 @@ export function updateRefMapFromFlat(nodes) {
         lastSnapshotHash = null;
     }
     lastUpdated = Date.now();
+    return { applied: true };
 }
 export function getCachedMetadata(ref) {
     const key = ref.startsWith('@') ? ref.slice(1) : ref;

--- a/packages/rn-dev-agent-core/dist/injected-helpers.js
+++ b/packages/rn-dev-agent-core/dist/injected-helpers.js
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 33;
+export const HELPERS_VERSION = 34;
 export const INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -18,11 +18,29 @@ export const INJECTED_HELPERS = `
   var MAX_RENDERER_IDS = 20;
   var EARLY_EXIT_EMPTY_STREAK = 3;
 
+  // Reset by every root-iteration pass; only valid when read synchronously
+  // after the pass that produced the tree (many helpers share the iterators).
+  var lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+
+  function computeUnscannedRendererIds() {
+    try {
+      var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+      if (!hook || !hook.renderers || typeof hook.renderers.forEach !== 'function') return [];
+      var out = [];
+      hook.renderers.forEach(function(_v, id) {
+        if (typeof id === 'number' && id > lastRootScan.probedUpTo) out.push(id);
+      });
+      return out;
+    } catch (_) { return []; }
+  }
+
   function findActiveRenderer() {
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
     var emptyStreak = 0;
     for (var i = 1; i <= MAX_RENDERER_IDS; i++) {
+      lastRootScan.probedUpTo = i;
       try {
         var roots = hook.getFiberRoots(i);
         if (roots && roots.size > 0) {
@@ -32,6 +50,7 @@ export const INJECTED_HELPERS = `
         if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && i >= 5) return null;
       } catch (_) {
         emptyStreak++;
+        lastRootScan.rendererErrors++;
       }
     }
     return null;
@@ -45,18 +64,17 @@ export const INJECTED_HELPERS = `
   //
   // Per-renderer try/catch protects against one renderer's getFiberRoots
   // throwing during teardown/HMR/worklet init (Gemini A3, 2026-04-23,
-  // conf 80) — a single bad renderer must not poison the union.
-  //
-  // Task 4 will add an extra-roots step here that consults
-  // globalThis.__RN_AGENT_EXTRA_ROOTS__ AFTER the native renderer loop
-  // so user-registered portals stay lower priority than React's own
-  // registry. Not in this commit — refactor isolated from new behavior
-  // for cleaner bisects.
+  // conf 80) — a single bad renderer must not poison the union. The
+  // extra-roots step (globalThis.__RN_AGENT_EXTRA_ROOTS__) runs AFTER the
+  // native renderer loop so user-registered portals stay lower priority
+  // than React's own registry.
   function iterateAllRoots(cb) {
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (hook && typeof hook.getFiberRoots === 'function') {
       var emptyStreak = 0;
       for (var ri = 1; ri <= MAX_RENDERER_IDS; ri++) {
+        lastRootScan.probedUpTo = ri;
         try {
           var roots = hook.getFiberRoots(ri);
           if (roots && roots.size) {
@@ -75,6 +93,7 @@ export const INJECTED_HELPERS = `
           }
         } catch (_) {
           emptyStreak++;
+          lastRootScan.rendererErrors++;
         }
       }
     }
@@ -100,7 +119,10 @@ export const INJECTED_HELPERS = `
           }
         }
       }
-    } catch (_) { /* swallow — resolver bug must not break iteration */ }
+    } catch (_) {
+      // swallow — resolver bug must not break iteration
+      lastRootScan.rendererErrors++;
+    }
     return null;
   }
 
@@ -211,9 +233,39 @@ export const INJECTED_HELPERS = `
     var maxDepth = opts.maxDepth || 4;
     var filter = opts.filter || opts.testID || opts.type || null;
 
+    // Story 16 (#409): quality verdict computed once at capture, from the same
+    // pass that produced the tree — downstream tools render it, never re-derive.
+    var walkQuality = { droppedSubtrees: 0, collapsedChildLists: 0 };
+    function buildVerdict(path, o) {
+      o = o || {};
+      var reasons = [];
+      if (o.noRenderer) reasons.push('no-renderer');
+      if (lastRootScan.rendererErrors > 0) reasons.push('renderer-error');
+      var unscanned = computeUnscannedRendererIds();
+      if (unscanned.length > 0) reasons.push('renderers-unscanned');
+      if (o.scanBudgetExhausted) reasons.push('scan-budget-exhausted');
+      if (o.outputTruncated) reasons.push('output-truncated');
+      var state = (o.noRenderer || o.failed) ? 'failed' : (reasons.length > 0 ? 'degraded' : 'ok');
+      return {
+        state: state,
+        path: path,
+        reasons: reasons,
+        rootsSeeded: o.rootsSeeded || 0,
+        scannedNodes: o.scannedNodes || 0,
+        effectiveDepth: maxDepth,
+        droppedSubtrees: walkQuality.droppedSubtrees,
+        collapsedChildLists: walkQuality.collapsedChildLists,
+        rendererErrors: lastRootScan.rendererErrors,
+        unscannedRendererIds: unscanned
+      };
+    }
+
     var renderer = findActiveRenderer();
     if (!renderer) {
-      return JSON.stringify({ error: 'React DevTools hook not available or no fiber roots — app may still be loading' });
+      return JSON.stringify({
+        error: 'React DevTools hook not available or no fiber roots — app may still be loading',
+        verdict: buildVerdict('none', { noRenderer: true })
+      });
     }
 
     var visited = new WeakSet();
@@ -254,7 +306,15 @@ export const INJECTED_HELPERS = `
     }
 
     function walkSubtree(fiber, depth, limit, vis) {
-      if (!fiber || depth > limit || vis.has(fiber)) return null;
+      if (!fiber) return null;
+      if (depth > limit) {
+        // Depth-cap drop: expected under the requested cap, but must be
+        // counted — a sparse-because-shallow tree previously looked identical
+        // to a legitimately small one.
+        walkQuality.droppedSubtrees++;
+        return null;
+      }
+      if (vis.has(fiber)) return null;
       vis.add(fiber);
       totalNodes++;
 
@@ -334,6 +394,7 @@ export const INJECTED_HELPERS = `
       }
 
       if (children.length > 0) {
+        if (children.length > 20) walkQuality.collapsedChildLists++;
         result.children = children.length > 20
           ? children.slice(0, 10).concat([{ _truncated: (children.length - 10) + ' more' }])
           : children;
@@ -435,6 +496,11 @@ export const INJECTED_HELPERS = `
         iOut.truncated = true;
         iOut.hint = 'More interactive elements exist beyond the cap — scope with filter or device_scrollintoview.';
       }
+      iOut.verdict = buildVerdict('interactive', {
+        rootsSeeded: iRoots.length,
+        scannedNodes: iScanned,
+        scanBudgetExhausted: iQueue.length > 0
+      });
       return safeStringify(iOut, 999999);
     }
 
@@ -492,8 +558,21 @@ export const INJECTED_HELPERS = `
       // Codex review (conf 80): field renamed from renderersScanned to
       // rootsSeeded to match actual semantic (roots pushed into the BFS
       // queue, not renderers walked 1..5).
+      // A no-match verdict distinguishes "scanned everything, truly absent"
+      // from "budget ran out mid-scan" — the sparse-vs-empty ambiguity #409
+      // exists to kill.
+      var filterBudgetHit = queue.length > 0;
       if (matchFibers.length === 0) {
-        return JSON.stringify({ tree: null, totalNodes: scanned, rootsSeeded: allRoots.length });
+        return JSON.stringify({
+          tree: null,
+          totalNodes: scanned,
+          rootsSeeded: allRoots.length,
+          verdict: buildVerdict('filter', {
+            rootsSeeded: allRoots.length,
+            scannedNodes: scanned,
+            scanBudgetExhausted: filterBudgetHit
+          })
+        });
       }
 
       var matches = [];
@@ -503,10 +582,16 @@ export const INJECTED_HELPERS = `
         if (subtree) matches.push(subtree);
       }
       totalNodes = scanned;
+      var filterVerdictOpts = {
+        rootsSeeded: allRoots.length,
+        scannedNodes: scanned,
+        scanBudgetExhausted: filterBudgetHit
+      };
       var tree = matches.length === 1 ? matches[0] : { matches: matches };
-      var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRoots.length }, 999999);
+      var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRoots.length, verdict: buildVerdict('filter', filterVerdictOpts) }, 999999);
       if (output.length > 50000) {
-        return safeStringify({ tree: matches[0] || null, totalNodes: totalNodes, rootsSeeded: allRoots.length, truncated: true });
+        filterVerdictOpts.outputTruncated = true;
+        return safeStringify({ tree: matches[0] || null, totalNodes: totalNodes, rootsSeeded: allRoots.length, truncated: true, verdict: buildVerdict('filter', filterVerdictOpts) });
       }
       return output;
     }
@@ -523,10 +608,13 @@ export const INJECTED_HELPERS = `
       var sub = walkSubtree(allRootsU[ri].fiber, 0, maxDepth, visited);
       if (sub) trees.push(sub);
     }
+    var fullVerdictOpts = { rootsSeeded: allRootsU.length, scannedNodes: totalNodes };
     var tree = trees.length === 1 ? trees[0] : (trees.length === 0 ? null : { _wrapper: true, children: trees });
-    var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRootsU.length }, 999999);
+    var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRootsU.length, verdict: buildVerdict('full', fullVerdictOpts) }, 999999);
     if (output.length > 50000) {
-      return safeStringify({ error: 'Tree too large (' + output.length + ' chars). Use a filter parameter to scope the query.' });
+      fullVerdictOpts.failed = true;
+      fullVerdictOpts.outputTruncated = true;
+      return safeStringify({ error: 'Tree too large (' + output.length + ' chars). Use a filter parameter to scope the query.', verdict: buildVerdict('full', fullVerdictOpts) });
     }
     return output;
   }
@@ -2860,8 +2948,10 @@ export const REACT_READY_PROBE_JS = `(function() {
   // so the readiness gate can't miss a late-registered renderer (Bridgeless +
   // Reanimated register secondary renderers above id 5).
   for (var i = 1; i <= 20; i++) {
-    var r = h.getFiberRoots(i);
-    if (r && r.size > 0) return true;
+    try {
+      var r = h.getFiberRoots(i);
+      if (r && r.size > 0) return true;
+    } catch (_) { /* one throwing renderer must not abort the readiness scan */ }
   }
   return false;
 })()`;

--- a/packages/rn-dev-agent-core/dist/runners/rn-android-runner-client.js
+++ b/packages/rn-dev-agent-core/dist/runners/rn-android-runner-client.js
@@ -7,7 +7,7 @@ import { promisify } from 'node:util';
 import { writeFileSync, existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { okResult, failResult } from '../utils.js';
-import { updateRefMapFromFlat, getCachedMetadata } from '../fast-runner-ref-map.js';
+import { updateRefMapFromFlat, buildSnapshotVerdict, getCachedMetadata, } from '../fast-runner-ref-map.js';
 import { findFreePort } from './free-port.js';
 import { join } from 'node:path';
 import { withKeyboardGuard } from './keyboard-guard.js';
@@ -833,8 +833,11 @@ export async function runAndroid(args) {
         const data = resp.data;
         if (Array.isArray(data.nodes)) {
             const flat = mapRunnerNodesToFlat(data.nodes);
-            updateRefMapFromFlat(flat);
-            return okResult({ nodes: flat });
+            const outcome = updateRefMapFromFlat(flat);
+            // GH #409: same capture-quality contract as the iOS client — empty
+            // captures report degraded and never clobber last-known-good refs.
+            const snapshotVerdict = buildSnapshotVerdict('rn-android-runner', flat.length, outcome);
+            return okResult({ nodes: flat }, { meta: { snapshotVerdict } });
         }
     }
     if (args.command === 'screenshot') {

--- a/packages/rn-dev-agent-core/dist/runners/rn-fast-runner-client.js
+++ b/packages/rn-dev-agent-core/dist/runners/rn-fast-runner-client.js
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process';
 import { join } from 'node:path';
 import { existsSync, readdirSync, mkdirSync, rmSync, statSync, readFileSync, writeFileSync, } from 'node:fs';
 import { okResult, failResult } from '../utils.js';
-import { updateRefMapFromFlat, getCachedMetadata } from '../fast-runner-ref-map.js';
+import { updateRefMapFromFlat, buildSnapshotVerdict, getCachedMetadata, } from '../fast-runner-ref-map.js';
 import { isPortFree } from './free-port.js';
 import { withKeyboardGuard } from './keyboard-guard.js';
 import { runnerStatePath, readJsonStateFile, writeJsonStateFileAtomic, deleteStateFile, readLegacyTmpState, cleanupLegacyTmpState, } from '../util/secure-state-file.js';
@@ -902,8 +902,12 @@ export async function runIOS(args) {
         const data = resp.data;
         if (Array.isArray(data.nodes)) {
             const flat = mapRunnerNodesToFlat(data.nodes);
-            updateRefMapFromFlat(flat);
-            return okResult({ nodes: flat }, announce ? { meta: announce } : undefined);
+            const outcome = updateRefMapFromFlat(flat);
+            // GH #409: verdict rendered from the same call that decided whether the
+            // ref map was overwritten — an empty capture is reported as degraded and
+            // leaves the last-known-good refs bound.
+            const snapshotVerdict = buildSnapshotVerdict('rn-fast-runner', flat.length, outcome);
+            return okResult({ nodes: flat }, { meta: { ...announce, snapshotVerdict } });
         }
         // Defensive fallback: the test seam mocks `{ tree: ... }`. Don't crash.
         return okResult(resp.data, announce ? { meta: announce } : undefined);

--- a/packages/rn-dev-agent-core/dist/tools/component-tree.js
+++ b/packages/rn-dev-agent-core/dist/tools/component-tree.js
@@ -22,15 +22,21 @@ export function createComponentTreeHandler(getClient) {
         catch {
             return failResult('Failed to parse component tree response');
         }
+        // GH #409: the capture-time quality verdict renders once, as
+        // meta.treeVerdict — absent for stale injected helpers (< v34).
+        const verdict = parsed.verdict;
+        const meta = verdict ? { treeVerdict: verdict } : undefined;
         if (parsed.error) {
-            return failResult(`Component tree error: ${parsed.error}`);
+            return failResult(`Component tree error: ${parsed.error}`, meta);
         }
         if (parsed.warning === 'APP_HAS_REDBOX') {
             return warnResult({
                 message: parsed.message ??
                     'App is showing an error screen. Use cdp_error_log to read the error, fix the code, then cdp_reload.',
-            }, 'APP_HAS_REDBOX');
+            }, 'APP_HAS_REDBOX', meta);
         }
-        return okResult(parsed);
+        if (verdict)
+            delete parsed.verdict;
+        return okResult(parsed, meta ? { meta } : undefined);
     });
 }

--- a/packages/rn-dev-agent-core/dist/tools/device-interact.js
+++ b/packages/rn-dev-agent-core/dist/tools/device-interact.js
@@ -120,6 +120,11 @@ export async function fetchSnapshotNodes(allowCache = false) {
     const initialNodes = parseSnapshotEnvelope(first);
     if (initialNodes === null)
         return { ok: false, reason: 'fetch-failed' };
+    // GH #409: a zero-node capture cannot support any "element absent" verdict —
+    // it is indistinguishable from a degraded walk. Interactive consumers fail
+    // closed instead of concluding "nothing on screen".
+    if (initialNodes.length === 0)
+        return { ok: false, reason: 'empty-capture' };
     if (!isAgentDeviceRunnerSentinel(initialNodes)) {
         const platform = getActiveSession()?.platform;
         if (platform)
@@ -144,10 +149,19 @@ export async function fetchSnapshotNodes(allowCache = false) {
     const recoveredNodes = parseSnapshotEnvelope(recovery.result);
     if (recoveredNodes === null)
         return { ok: false, reason: 'fetch-failed' };
+    if (recoveredNodes.length === 0)
+        return { ok: false, reason: 'empty-capture' };
     const platform = getActiveSession()?.platform;
     if (platform)
         cacheSnapshot(platform, recoveredNodes);
     return { ok: true, nodes: recoveredNodes, recoveredTier: recovery.tier };
+}
+// GH #409: refusal for a zero-node capture — asserting NOT_FOUND on it would
+// present a degraded capture as a legitimately empty screen.
+function emptyCaptureFailResult(query) {
+    return failResult(`Snapshot returned zero nodes — cannot distinguish an empty screen from a degraded capture` +
+        (query !== undefined ? `; not asserting "${query}" is absent` : '') +
+        `. Confirm the screen with device_screenshot or cdp_component_tree, then retry.`, { code: 'SNAPSHOT_DEGRADED', ...(query !== undefined ? { query } : {}) });
 }
 export async function fetchFindCandidates(query, exact = false, allowCache = false) {
     const snap = await fetchSnapshotNodes(allowCache);
@@ -210,6 +224,9 @@ export function createDeviceFindHandler() {
                 if (find.reason === 'runner-leak-unrecovered') {
                     return runnerLeakFailResult(args.text, find.recoveryReason);
                 }
+                if (find.reason === 'empty-capture') {
+                    return emptyCaptureFailResult(args.text);
+                }
                 // Snapshot failed and caller has strict requirements — do NOT fall through
                 // to the fuzzy agent-device path because it cannot honor exact/index. Fail
                 // cleanly so the caller knows exact/index semantics aren't reachable.
@@ -254,6 +271,9 @@ export function createDeviceFindHandler() {
             if (!find.ok) {
                 if (find.reason === 'runner-leak-unrecovered') {
                     return runnerLeakFailResult(args.text, find.recoveryReason);
+                }
+                if (find.reason === 'empty-capture') {
+                    return emptyCaptureFailResult(args.text);
                 }
                 return failResult(`Snapshot unavailable — cannot resolve "${args.text}"`, {
                     code: 'SNAPSHOT_UNAVAILABLE',
@@ -1144,6 +1164,9 @@ export function createDeviceFocusNextHandler() {
         if (!snap.ok) {
             if (snap.reason === 'runner-leak-unrecovered') {
                 return runnerLeakFailResult(undefined, snap.recoveryReason);
+            }
+            if (snap.reason === 'empty-capture') {
+                return emptyCaptureFailResult();
             }
             return failResult('Snapshot unavailable — cannot look for keyboard key. Retry after device_snapshot action=open/snapshot.', { code: 'SNAPSHOT_UNAVAILABLE' });
         }

--- a/packages/rn-dev-agent-core/src/fast-runner-ref-map.ts
+++ b/packages/rn-dev-agent-core/src/fast-runner-ref-map.ts
@@ -274,7 +274,52 @@ export function flattenXCUITree(tree: XCUITreeNode): {
   return { nodes, refMap: localRefMap };
 }
 
-export function updateRefMapFromFlat(nodes: FlatNode[]): void {
+export interface RefMapUpdateOutcome {
+  applied: boolean;
+  reason?: 'empty-capture';
+}
+
+// GH #409 (Story 16): a snapshot quality verdict for the runner capture path,
+// computed once where the ref-map decision is made so meta.snapshotVerdict and
+// the actual overwrite behavior can never disagree.
+export interface SnapshotQualityVerdict {
+  state: 'ok' | 'degraded';
+  source: string;
+  nodeCount: number;
+  refMapUpdated: boolean;
+  reasons: string[];
+}
+
+export function buildSnapshotVerdict(
+  source: string,
+  nodeCount: number,
+  outcome: RefMapUpdateOutcome,
+): SnapshotQualityVerdict {
+  const reasons: string[] = [];
+  if (nodeCount === 0) reasons.push('empty-capture');
+  return {
+    state: reasons.length > 0 ? 'degraded' : 'ok',
+    source,
+    nodeCount,
+    refMapUpdated: outcome.applied,
+    reasons,
+  };
+}
+
+export function updateRefMapFromFlat(nodes: FlatNode[]): RefMapUpdateOutcome {
+  // GH #409: a zero-node capture is indistinguishable from a degraded walk
+  // (AX failure, wedged runner, mid-transition screen). It must never wipe the
+  // last-known-good map — refs stay bound to the last verified capture, and a
+  // genuinely emptied screen surfaces as STALE_REF on the next tap instead of
+  // silently serving nothing.
+  let validCount = 0;
+  for (const node of nodes) {
+    if (node.ref && node.rect) validCount++;
+  }
+  if (validCount === 0 && refMap.size > 0) {
+    return { applied: false, reason: 'empty-capture' };
+  }
+
   // refMap IS cleared (coordinates must never be served across generations —
   // only the CURRENT snapshot is tappable), but metadataMap is NOT: ref ids are
   // positional, so ids absent from this snapshot cannot collide with current
@@ -317,6 +362,7 @@ export function updateRefMapFromFlat(nodes: FlatNode[]): void {
     lastSnapshotHash = null;
   }
   lastUpdated = Date.now();
+  return { applied: true };
 }
 
 export function getCachedMetadata(ref: string): RefMetadata | null {

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 33;
+export const HELPERS_VERSION = 34;
 
 export const INJECTED_HELPERS = `
 (function() {
@@ -19,11 +19,29 @@ export const INJECTED_HELPERS = `
   var MAX_RENDERER_IDS = 20;
   var EARLY_EXIT_EMPTY_STREAK = 3;
 
+  // Reset by every root-iteration pass; only valid when read synchronously
+  // after the pass that produced the tree (many helpers share the iterators).
+  var lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+
+  function computeUnscannedRendererIds() {
+    try {
+      var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+      if (!hook || !hook.renderers || typeof hook.renderers.forEach !== 'function') return [];
+      var out = [];
+      hook.renderers.forEach(function(_v, id) {
+        if (typeof id === 'number' && id > lastRootScan.probedUpTo) out.push(id);
+      });
+      return out;
+    } catch (_) { return []; }
+  }
+
   function findActiveRenderer() {
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
     var emptyStreak = 0;
     for (var i = 1; i <= MAX_RENDERER_IDS; i++) {
+      lastRootScan.probedUpTo = i;
       try {
         var roots = hook.getFiberRoots(i);
         if (roots && roots.size > 0) {
@@ -33,6 +51,7 @@ export const INJECTED_HELPERS = `
         if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && i >= 5) return null;
       } catch (_) {
         emptyStreak++;
+        lastRootScan.rendererErrors++;
       }
     }
     return null;
@@ -46,18 +65,17 @@ export const INJECTED_HELPERS = `
   //
   // Per-renderer try/catch protects against one renderer's getFiberRoots
   // throwing during teardown/HMR/worklet init (Gemini A3, 2026-04-23,
-  // conf 80) — a single bad renderer must not poison the union.
-  //
-  // Task 4 will add an extra-roots step here that consults
-  // globalThis.__RN_AGENT_EXTRA_ROOTS__ AFTER the native renderer loop
-  // so user-registered portals stay lower priority than React's own
-  // registry. Not in this commit — refactor isolated from new behavior
-  // for cleaner bisects.
+  // conf 80) — a single bad renderer must not poison the union. The
+  // extra-roots step (globalThis.__RN_AGENT_EXTRA_ROOTS__) runs AFTER the
+  // native renderer loop so user-registered portals stay lower priority
+  // than React's own registry.
   function iterateAllRoots(cb) {
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (hook && typeof hook.getFiberRoots === 'function') {
       var emptyStreak = 0;
       for (var ri = 1; ri <= MAX_RENDERER_IDS; ri++) {
+        lastRootScan.probedUpTo = ri;
         try {
           var roots = hook.getFiberRoots(ri);
           if (roots && roots.size) {
@@ -76,6 +94,7 @@ export const INJECTED_HELPERS = `
           }
         } catch (_) {
           emptyStreak++;
+          lastRootScan.rendererErrors++;
         }
       }
     }
@@ -101,7 +120,10 @@ export const INJECTED_HELPERS = `
           }
         }
       }
-    } catch (_) { /* swallow — resolver bug must not break iteration */ }
+    } catch (_) {
+      // swallow — resolver bug must not break iteration
+      lastRootScan.rendererErrors++;
+    }
     return null;
   }
 
@@ -212,9 +234,39 @@ export const INJECTED_HELPERS = `
     var maxDepth = opts.maxDepth || 4;
     var filter = opts.filter || opts.testID || opts.type || null;
 
+    // Story 16 (#409): quality verdict computed once at capture, from the same
+    // pass that produced the tree — downstream tools render it, never re-derive.
+    var walkQuality = { droppedSubtrees: 0, collapsedChildLists: 0 };
+    function buildVerdict(path, o) {
+      o = o || {};
+      var reasons = [];
+      if (o.noRenderer) reasons.push('no-renderer');
+      if (lastRootScan.rendererErrors > 0) reasons.push('renderer-error');
+      var unscanned = computeUnscannedRendererIds();
+      if (unscanned.length > 0) reasons.push('renderers-unscanned');
+      if (o.scanBudgetExhausted) reasons.push('scan-budget-exhausted');
+      if (o.outputTruncated) reasons.push('output-truncated');
+      var state = (o.noRenderer || o.failed) ? 'failed' : (reasons.length > 0 ? 'degraded' : 'ok');
+      return {
+        state: state,
+        path: path,
+        reasons: reasons,
+        rootsSeeded: o.rootsSeeded || 0,
+        scannedNodes: o.scannedNodes || 0,
+        effectiveDepth: maxDepth,
+        droppedSubtrees: walkQuality.droppedSubtrees,
+        collapsedChildLists: walkQuality.collapsedChildLists,
+        rendererErrors: lastRootScan.rendererErrors,
+        unscannedRendererIds: unscanned
+      };
+    }
+
     var renderer = findActiveRenderer();
     if (!renderer) {
-      return JSON.stringify({ error: 'React DevTools hook not available or no fiber roots — app may still be loading' });
+      return JSON.stringify({
+        error: 'React DevTools hook not available or no fiber roots — app may still be loading',
+        verdict: buildVerdict('none', { noRenderer: true })
+      });
     }
 
     var visited = new WeakSet();
@@ -255,7 +307,15 @@ export const INJECTED_HELPERS = `
     }
 
     function walkSubtree(fiber, depth, limit, vis) {
-      if (!fiber || depth > limit || vis.has(fiber)) return null;
+      if (!fiber) return null;
+      if (depth > limit) {
+        // Depth-cap drop: expected under the requested cap, but must be
+        // counted — a sparse-because-shallow tree previously looked identical
+        // to a legitimately small one.
+        walkQuality.droppedSubtrees++;
+        return null;
+      }
+      if (vis.has(fiber)) return null;
       vis.add(fiber);
       totalNodes++;
 
@@ -335,6 +395,7 @@ export const INJECTED_HELPERS = `
       }
 
       if (children.length > 0) {
+        if (children.length > 20) walkQuality.collapsedChildLists++;
         result.children = children.length > 20
           ? children.slice(0, 10).concat([{ _truncated: (children.length - 10) + ' more' }])
           : children;
@@ -436,6 +497,11 @@ export const INJECTED_HELPERS = `
         iOut.truncated = true;
         iOut.hint = 'More interactive elements exist beyond the cap — scope with filter or device_scrollintoview.';
       }
+      iOut.verdict = buildVerdict('interactive', {
+        rootsSeeded: iRoots.length,
+        scannedNodes: iScanned,
+        scanBudgetExhausted: iQueue.length > 0
+      });
       return safeStringify(iOut, 999999);
     }
 
@@ -493,8 +559,21 @@ export const INJECTED_HELPERS = `
       // Codex review (conf 80): field renamed from renderersScanned to
       // rootsSeeded to match actual semantic (roots pushed into the BFS
       // queue, not renderers walked 1..5).
+      // A no-match verdict distinguishes "scanned everything, truly absent"
+      // from "budget ran out mid-scan" — the sparse-vs-empty ambiguity #409
+      // exists to kill.
+      var filterBudgetHit = queue.length > 0;
       if (matchFibers.length === 0) {
-        return JSON.stringify({ tree: null, totalNodes: scanned, rootsSeeded: allRoots.length });
+        return JSON.stringify({
+          tree: null,
+          totalNodes: scanned,
+          rootsSeeded: allRoots.length,
+          verdict: buildVerdict('filter', {
+            rootsSeeded: allRoots.length,
+            scannedNodes: scanned,
+            scanBudgetExhausted: filterBudgetHit
+          })
+        });
       }
 
       var matches = [];
@@ -504,10 +583,16 @@ export const INJECTED_HELPERS = `
         if (subtree) matches.push(subtree);
       }
       totalNodes = scanned;
+      var filterVerdictOpts = {
+        rootsSeeded: allRoots.length,
+        scannedNodes: scanned,
+        scanBudgetExhausted: filterBudgetHit
+      };
       var tree = matches.length === 1 ? matches[0] : { matches: matches };
-      var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRoots.length }, 999999);
+      var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRoots.length, verdict: buildVerdict('filter', filterVerdictOpts) }, 999999);
       if (output.length > 50000) {
-        return safeStringify({ tree: matches[0] || null, totalNodes: totalNodes, rootsSeeded: allRoots.length, truncated: true });
+        filterVerdictOpts.outputTruncated = true;
+        return safeStringify({ tree: matches[0] || null, totalNodes: totalNodes, rootsSeeded: allRoots.length, truncated: true, verdict: buildVerdict('filter', filterVerdictOpts) });
       }
       return output;
     }
@@ -524,10 +609,13 @@ export const INJECTED_HELPERS = `
       var sub = walkSubtree(allRootsU[ri].fiber, 0, maxDepth, visited);
       if (sub) trees.push(sub);
     }
+    var fullVerdictOpts = { rootsSeeded: allRootsU.length, scannedNodes: totalNodes };
     var tree = trees.length === 1 ? trees[0] : (trees.length === 0 ? null : { _wrapper: true, children: trees });
-    var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRootsU.length }, 999999);
+    var output = safeStringify({ tree: tree, totalNodes: totalNodes, rootsSeeded: allRootsU.length, verdict: buildVerdict('full', fullVerdictOpts) }, 999999);
     if (output.length > 50000) {
-      return safeStringify({ error: 'Tree too large (' + output.length + ' chars). Use a filter parameter to scope the query.' });
+      fullVerdictOpts.failed = true;
+      fullVerdictOpts.outputTruncated = true;
+      return safeStringify({ error: 'Tree too large (' + output.length + ' chars). Use a filter parameter to scope the query.', verdict: buildVerdict('full', fullVerdictOpts) });
     }
     return output;
   }
@@ -2864,8 +2952,10 @@ export const REACT_READY_PROBE_JS = `(function() {
   // so the readiness gate can't miss a late-registered renderer (Bridgeless +
   // Reanimated register secondary renderers above id 5).
   for (var i = 1; i <= 20; i++) {
-    var r = h.getFiberRoots(i);
-    if (r && r.size > 0) return true;
+    try {
+      var r = h.getFiberRoots(i);
+      if (r && r.size > 0) return true;
+    } catch (_) { /* one throwing renderer must not abort the readiness scan */ }
   }
   return false;
 })()`;

--- a/packages/rn-dev-agent-core/src/runners/rn-android-runner-client.ts
+++ b/packages/rn-dev-agent-core/src/runners/rn-android-runner-client.ts
@@ -9,7 +9,12 @@ import { writeFileSync, existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import type { ToolResult } from '../utils.js';
 import { okResult, failResult } from '../utils.js';
-import { updateRefMapFromFlat, getCachedMetadata, type FlatNode } from '../fast-runner-ref-map.js';
+import {
+  updateRefMapFromFlat,
+  buildSnapshotVerdict,
+  getCachedMetadata,
+  type FlatNode,
+} from '../fast-runner-ref-map.js';
 import { findFreePort } from './free-port.js';
 import { join } from 'node:path';
 import { withKeyboardGuard } from './keyboard-guard.js';
@@ -1061,8 +1066,11 @@ export async function runAndroid(args: RunAndroidArgs): Promise<ToolResult> {
     const data = resp.data as { nodes?: RunnerSnapshotNode[] };
     if (Array.isArray(data.nodes)) {
       const flat = mapRunnerNodesToFlat(data.nodes);
-      updateRefMapFromFlat(flat);
-      return okResult({ nodes: flat });
+      const outcome = updateRefMapFromFlat(flat);
+      // GH #409: same capture-quality contract as the iOS client — empty
+      // captures report degraded and never clobber last-known-good refs.
+      const snapshotVerdict = buildSnapshotVerdict('rn-android-runner', flat.length, outcome);
+      return okResult({ nodes: flat }, { meta: { snapshotVerdict } });
     }
   }
 

--- a/packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts
+++ b/packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts
@@ -13,7 +13,12 @@ import {
 import type { ToolResult } from '../utils.js';
 import { okResult, failResult } from '../utils.js';
 import type { FastRunnerState } from '../types.js';
-import { updateRefMapFromFlat, getCachedMetadata, type FlatNode } from '../fast-runner-ref-map.js';
+import {
+  updateRefMapFromFlat,
+  buildSnapshotVerdict,
+  getCachedMetadata,
+  type FlatNode,
+} from '../fast-runner-ref-map.js';
 import { isPortFree } from './free-port.js';
 import { withKeyboardGuard } from './keyboard-guard.js';
 import {
@@ -1201,8 +1206,12 @@ export async function runIOS(args: RunIOSArgs): Promise<ToolResult> {
     const data = resp.data as { nodes?: RunnerSnapshotNode[]; tree?: unknown };
     if (Array.isArray(data.nodes)) {
       const flat = mapRunnerNodesToFlat(data.nodes);
-      updateRefMapFromFlat(flat);
-      return okResult({ nodes: flat }, announce ? { meta: announce } : undefined);
+      const outcome = updateRefMapFromFlat(flat);
+      // GH #409: verdict rendered from the same call that decided whether the
+      // ref map was overwritten — an empty capture is reported as degraded and
+      // leaves the last-known-good refs bound.
+      const snapshotVerdict = buildSnapshotVerdict('rn-fast-runner', flat.length, outcome);
+      return okResult({ nodes: flat }, { meta: { ...announce, snapshotVerdict } });
     }
     // Defensive fallback: the test seam mocks `{ tree: ... }`. Don't crash.
     return okResult(resp.data, announce ? { meta: announce } : undefined);

--- a/packages/rn-dev-agent-core/src/tools/component-tree.ts
+++ b/packages/rn-dev-agent-core/src/tools/component-tree.ts
@@ -28,8 +28,13 @@ export function createComponentTreeHandler(getClient: () => CDPClient) {
         return failResult('Failed to parse component tree response');
       }
 
+      // GH #409: the capture-time quality verdict renders once, as
+      // meta.treeVerdict — absent for stale injected helpers (< v34).
+      const verdict = parsed.verdict as Record<string, unknown> | undefined;
+      const meta = verdict ? { treeVerdict: verdict } : undefined;
+
       if (parsed.error) {
-        return failResult(`Component tree error: ${parsed.error}`);
+        return failResult(`Component tree error: ${parsed.error}`, meta);
       }
 
       if (parsed.warning === 'APP_HAS_REDBOX') {
@@ -40,10 +45,12 @@ export function createComponentTreeHandler(getClient: () => CDPClient) {
               'App is showing an error screen. Use cdp_error_log to read the error, fix the code, then cdp_reload.',
           },
           'APP_HAS_REDBOX',
+          meta,
         );
       }
 
-      return okResult(parsed);
+      if (verdict) delete parsed.verdict;
+      return okResult(parsed, meta ? { meta } : undefined);
     },
   );
 }

--- a/packages/rn-dev-agent-core/src/tools/device-interact.ts
+++ b/packages/rn-dev-agent-core/src/tools/device-interact.ts
@@ -156,6 +156,7 @@ function parseSnapshotEnvelope(result: ToolResult): SnapshotNode[] | null {
 export type SnapshotFetchResult =
   | { ok: true; nodes: SnapshotNode[]; recoveredTier?: RecoveryTier }
   | { ok: false; reason: 'fetch-failed' }
+  | { ok: false; reason: 'empty-capture' }
   | { ok: false; reason: 'runner-leak-unrecovered'; recoveryReason?: string };
 
 export async function fetchSnapshotNodes(allowCache = false): Promise<SnapshotFetchResult> {
@@ -174,6 +175,10 @@ export async function fetchSnapshotNodes(allowCache = false): Promise<SnapshotFe
   const first = await runNative(['snapshot', '-i']);
   const initialNodes = parseSnapshotEnvelope(first);
   if (initialNodes === null) return { ok: false, reason: 'fetch-failed' };
+  // GH #409: a zero-node capture cannot support any "element absent" verdict —
+  // it is indistinguishable from a degraded walk. Interactive consumers fail
+  // closed instead of concluding "nothing on screen".
+  if (initialNodes.length === 0) return { ok: false, reason: 'empty-capture' };
 
   if (!isAgentDeviceRunnerSentinel(initialNodes)) {
     const platform = getActiveSession()?.platform;
@@ -204,15 +209,28 @@ export async function fetchSnapshotNodes(allowCache = false): Promise<SnapshotFe
 
   const recoveredNodes = parseSnapshotEnvelope(recovery.result);
   if (recoveredNodes === null) return { ok: false, reason: 'fetch-failed' };
+  if (recoveredNodes.length === 0) return { ok: false, reason: 'empty-capture' };
 
   const platform = getActiveSession()?.platform;
   if (platform) cacheSnapshot(platform, recoveredNodes);
   return { ok: true, nodes: recoveredNodes, recoveredTier: recovery.tier };
 }
 
+// GH #409: refusal for a zero-node capture — asserting NOT_FOUND on it would
+// present a degraded capture as a legitimately empty screen.
+function emptyCaptureFailResult(query?: string): ToolResult {
+  return failResult(
+    `Snapshot returned zero nodes — cannot distinguish an empty screen from a degraded capture` +
+      (query !== undefined ? `; not asserting "${query}" is absent` : '') +
+      `. Confirm the screen with device_screenshot or cdp_component_tree, then retry.`,
+    { code: 'SNAPSHOT_DEGRADED', ...(query !== undefined ? { query } : {}) },
+  );
+}
+
 export type FindCandidatesResult =
   | { ok: true; candidates: FindCandidate[]; recoveredTier?: RecoveryTier }
   | { ok: false; reason: 'fetch-failed' }
+  | { ok: false; reason: 'empty-capture' }
   | { ok: false; reason: 'runner-leak-unrecovered'; recoveryReason?: string };
 
 export async function fetchFindCandidates(
@@ -300,6 +318,9 @@ export function createDeviceFindHandler(): (args: FindArgs) => Promise<ToolResul
         if (find.reason === 'runner-leak-unrecovered') {
           return runnerLeakFailResult(args.text, find.recoveryReason);
         }
+        if (find.reason === 'empty-capture') {
+          return emptyCaptureFailResult(args.text);
+        }
         // Snapshot failed and caller has strict requirements — do NOT fall through
         // to the fuzzy agent-device path because it cannot honor exact/index. Fail
         // cleanly so the caller knows exact/index semantics aren't reachable.
@@ -358,6 +379,9 @@ export function createDeviceFindHandler(): (args: FindArgs) => Promise<ToolResul
       if (!find.ok) {
         if (find.reason === 'runner-leak-unrecovered') {
           return runnerLeakFailResult(args.text, find.recoveryReason);
+        }
+        if (find.reason === 'empty-capture') {
+          return emptyCaptureFailResult(args.text);
         }
         return failResult(`Snapshot unavailable — cannot resolve "${args.text}"`, {
           code: 'SNAPSHOT_UNAVAILABLE',
@@ -1507,6 +1531,9 @@ export function createDeviceFocusNextHandler(): (
     if (!snap.ok) {
       if (snap.reason === 'runner-leak-unrecovered') {
         return runnerLeakFailResult(undefined, snap.recoveryReason);
+      }
+      if (snap.reason === 'empty-capture') {
+        return emptyCaptureFailResult();
       }
       return failResult(
         'Snapshot unavailable — cannot look for keyboard key. Retry after device_snapshot action=open/snapshot.',

--- a/packages/rn-dev-agent-core/test/unit/story-16-snapshot-quality-verdicts.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/story-16-snapshot-quality-verdicts.test.ts
@@ -1,0 +1,334 @@
+// Story 16 (GH #409) — snapshot quality verdicts: degraded captures must say
+// so. A sparse/empty tree caused by a degraded walk (renderer errors, unscanned
+// renderers, scan-budget exhaustion, depth caps) was previously
+// indistinguishable from a legitimately empty screen, so agents confidently
+// acted on a lie. Every capture now carries a structured verdict computed at
+// capture time, degraded interactive captures fail closed, and sparse results
+// never overwrite the last-known-good ref map.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import vm from 'node:vm';
+
+import { INJECTED_HELPERS } from '../../dist/injected-helpers.js';
+import { createMockClient } from '../helpers/mock-cdp-client.js';
+import { parseEnvelope } from '../helpers/result-helpers.js';
+import { createComponentTreeHandler } from '../../dist/tools/component-tree.js';
+import { updateRefMapFromFlat, clearRefMap } from '../../dist/fast-runner-ref-map.js';
+import { buildRunIOSArgs, _setRunAgentDeviceForTest } from '../../dist/agent-device-wrapper.js';
+import { fetchSnapshotNodes } from '../../dist/tools/device-interact.js';
+import { okResult } from '../../dist/utils.js';
+import {
+  runIOS,
+  _setRunnerStateForTest,
+  _setFetchForTest,
+} from '../../dist/runners/rn-fast-runner-client.js';
+
+// ── VM sandbox for the injected helpers ─────────────────────────────
+
+function createSandbox(opts = {}) {
+  const sandbox = {
+    globalThis: {},
+    Array,
+    Object,
+    JSON,
+    Map,
+    WeakSet,
+    Error,
+    Date,
+    parseInt,
+    parseFloat,
+    console: { log() {}, error() {}, warn() {}, info() {}, debug() {} },
+    String,
+    Number,
+    Boolean,
+    RegExp,
+    Symbol,
+    Set,
+    Promise,
+    setTimeout,
+    clearTimeout,
+  };
+  sandbox.globalThis = sandbox;
+  if (opts.hook) {
+    sandbox.__REACT_DEVTOOLS_GLOBAL_HOOK__ = opts.hook;
+  } else if (opts.fiberRoot) {
+    sandbox.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+      renderers: new Map([[1, {}]]),
+      // Real hooks only return roots for registered renderer ids — an
+      // id-blind mock would seed the same root once per probed id.
+      getFiberRoots: (id) => (id === 1 ? new Set([{ current: opts.fiberRoot }]) : new Set()),
+    };
+  }
+  vm.createContext(sandbox);
+  vm.runInContext(INJECTED_HELPERS, sandbox);
+  return sandbox;
+}
+
+function userComp(name, child) {
+  return { tag: 1, type: { displayName: name }, memoizedProps: {}, child, sibling: null };
+}
+
+// ── getTree verdicts (computed at capture, inside the helper) ────────
+
+test('getTree: healthy full walk carries verdict.state ok', () => {
+  const fiber = userComp('App', userComp('Home', null));
+  const sandbox = createSandbox({ fiberRoot: fiber });
+  const result = JSON.parse(sandbox.__RN_AGENT.getTree({ maxDepth: 4 }));
+  assert.ok(result.verdict, 'every capture must carry a verdict');
+  assert.equal(result.verdict.state, 'ok');
+  assert.equal(result.verdict.path, 'full');
+  assert.deepEqual(result.verdict.reasons, []);
+  assert.equal(result.verdict.rootsSeeded, 1);
+});
+
+test('getTree: a throwing renderer degrades the verdict (renderer-error)', () => {
+  const fiber = userComp('App', null);
+  const hook = {
+    renderers: new Map([
+      [1, {}],
+      [2, {}],
+    ]),
+    getFiberRoots: (id) => {
+      if (id === 1) return new Set([{ current: fiber }]);
+      if (id === 2) throw new Error('renderer teardown mid-walk');
+      return new Set();
+    },
+  };
+  const sandbox = createSandbox({ hook });
+  const result = JSON.parse(sandbox.__RN_AGENT.getTree({ maxDepth: 4 }));
+  assert.equal(result.verdict.state, 'degraded');
+  assert.ok(result.verdict.reasons.includes('renderer-error'));
+  assert.ok(result.verdict.rendererErrors >= 1);
+  assert.ok(result.tree, 'partial tree is still returned, just marked degraded');
+});
+
+test('getTree: renderer registered beyond the early-exit window fails with renderers-unscanned (#126 class)', () => {
+  const fiber = userComp('App', null);
+  const hook = {
+    renderers: new Map([[9, {}]]),
+    getFiberRoots: (id) => (id === 9 ? new Set([{ current: fiber }]) : new Set()),
+  };
+  const sandbox = createSandbox({ hook });
+  const result = JSON.parse(sandbox.__RN_AGENT.getTree({ maxDepth: 4 }));
+  assert.ok(result.error, 'walk still bails (behavior unchanged)');
+  assert.equal(result.verdict.state, 'failed');
+  assert.ok(result.verdict.reasons.includes('no-renderer'));
+  assert.ok(result.verdict.reasons.includes('renderers-unscanned'));
+  assert.ok(result.verdict.unscannedRendererIds.includes(9));
+});
+
+test('getTree: filter no-match after budget exhaustion is degraded, not a clean empty', () => {
+  let node = null;
+  for (let i = 0; i < 2500; i++) {
+    node = { tag: 5, type: null, memoizedProps: {}, child: node, sibling: null, return: null };
+  }
+  const sandbox = createSandbox({ fiberRoot: node });
+  const result = JSON.parse(sandbox.__RN_AGENT.getTree({ filter: 'zzz-no-match' }));
+  assert.equal(result.tree, null);
+  assert.equal(result.verdict.state, 'degraded');
+  assert.ok(result.verdict.reasons.includes('scan-budget-exhausted'));
+  assert.equal(result.verdict.path, 'filter');
+});
+
+test('getTree: depth-cap drops are counted in the verdict without flipping state', () => {
+  const fiber = userComp(
+    'L1',
+    userComp('L2', userComp('L3', userComp('L4', userComp('L5', userComp('L6', null))))),
+  );
+  const sandbox = createSandbox({ fiberRoot: fiber });
+  const result = JSON.parse(sandbox.__RN_AGENT.getTree({ maxDepth: 2 }));
+  assert.equal(result.verdict.state, 'ok', 'a requested depth cap is not degradation');
+  assert.ok(result.verdict.droppedSubtrees >= 1, 'but the drop must be visible');
+  assert.equal(result.verdict.effectiveDepth, 2);
+});
+
+test('getTree: interactiveOnly cap marks the verdict degraded (scan-budget-exhausted)', () => {
+  let first = null;
+  let prev = null;
+  for (let i = 0; i < 250; i++) {
+    const btn = {
+      tag: 1,
+      type: { displayName: 'Btn' + i },
+      memoizedProps: { onPress: () => {} },
+      child: null,
+      sibling: null,
+    };
+    if (prev) prev.sibling = btn;
+    else first = btn;
+    prev = btn;
+  }
+  const root = {
+    tag: 1,
+    type: { displayName: 'App' },
+    memoizedProps: {},
+    child: first,
+    sibling: null,
+  };
+  const sandbox = createSandbox({ fiberRoot: root });
+  const result = JSON.parse(sandbox.__RN_AGENT.getTree({ interactiveOnly: true }));
+  assert.equal(result.truncated, true, 'existing truncation flag stays');
+  assert.equal(result.verdict.state, 'degraded');
+  assert.ok(result.verdict.reasons.includes('scan-budget-exhausted'));
+  assert.equal(result.verdict.path, 'interactive');
+});
+
+test('getTree: missing hook fails with a no-renderer verdict', () => {
+  const sandbox = createSandbox({});
+  const result = JSON.parse(sandbox.__RN_AGENT.getTree({}));
+  assert.ok(result.error);
+  assert.equal(result.verdict.state, 'failed');
+  assert.ok(result.verdict.reasons.includes('no-renderer'));
+});
+
+// ── cdp_component_tree renders the verdict as meta.treeVerdict ───────
+
+test('component_tree: lifts the capture verdict into meta.treeVerdict', async () => {
+  const payload = {
+    tree: { component: 'App' },
+    totalNodes: 12,
+    rootsSeeded: 1,
+    verdict: { state: 'degraded', path: 'full', reasons: ['renderer-error'], rendererErrors: 1 },
+  };
+  const client = createMockClient({
+    evaluate: async () => ({ value: JSON.stringify(payload) }),
+  });
+  const handler = createComponentTreeHandler(() => client);
+  const result = await handler({ depth: 3 });
+  const env = parseEnvelope(result);
+  assert.equal(env.ok, true);
+  assert.equal(env.meta?.treeVerdict?.state, 'degraded');
+  assert.deepEqual(env.meta?.treeVerdict?.reasons, ['renderer-error']);
+  assert.equal(env.data.verdict, undefined, 'verdict renders once, in meta');
+});
+
+test('component_tree: failed capture returns failResult carrying the verdict', async () => {
+  const payload = {
+    error: 'React DevTools hook not available or no fiber roots — app may still be loading',
+    verdict: { state: 'failed', path: 'none', reasons: ['no-renderer'] },
+  };
+  const client = createMockClient({
+    evaluate: async () => ({ value: JSON.stringify(payload) }),
+  });
+  const handler = createComponentTreeHandler(() => client);
+  const result = await handler({ depth: 3 });
+  const env = parseEnvelope(result);
+  assert.equal(env.ok, false);
+  assert.equal(result.isError, true);
+  assert.equal(env.meta?.treeVerdict?.state, 'failed');
+});
+
+// ── ref map: sparse captures never overwrite last-known-good ─────────
+
+test('updateRefMapFromFlat: empty capture preserves the last-known-good map', () => {
+  clearRefMap();
+  updateRefMapFromFlat([
+    { ref: '@e0', type: 'Button', rect: { x: 10, y: 20, width: 100, height: 40 } },
+    { ref: '@e1', type: 'TextInput', rect: { x: 10, y: 80, width: 100, height: 40 } },
+  ]);
+  const outcome = updateRefMapFromFlat([]);
+  assert.deepEqual(outcome, { applied: false, reason: 'empty-capture' });
+  assert.deepEqual(
+    buildRunIOSArgs(['tap', '@e0']),
+    { command: 'tap', x: 60, y: 40 },
+    'refs stay bound to the last verified capture',
+  );
+  clearRefMap();
+});
+
+test('updateRefMapFromFlat: a non-empty capture still replaces the map', () => {
+  clearRefMap();
+  updateRefMapFromFlat([
+    { ref: '@e0', type: 'Button', rect: { x: 10, y: 20, width: 100, height: 40 } },
+  ]);
+  const outcome = updateRefMapFromFlat([
+    { ref: '@e5', type: 'Button', rect: { x: 0, y: 0, width: 50, height: 50 } },
+  ]);
+  assert.equal(outcome.applied, true);
+  assert.deepEqual(buildRunIOSArgs(['tap', '@e5']), { command: 'tap', x: 25, y: 25 });
+  assert.deepEqual(
+    buildRunIOSArgs(['tap', '@e0']),
+    { command: 'tap', _staleRef: '@e0' },
+    'old generation coordinates are not served',
+  );
+  clearRefMap();
+});
+
+// ── runner snapshot path: meta.snapshotVerdict ───────────────────────
+
+test('runIOS snapshot: empty capture is a degraded verdict and does not clobber the ref map', async () => {
+  clearRefMap();
+  updateRefMapFromFlat([
+    { ref: '@e0', type: 'Button', rect: { x: 10, y: 20, width: 100, height: 40 } },
+  ]);
+  _setRunnerStateForTest({
+    port: 22088,
+    pid: 999999,
+    deviceId: 'sim',
+    bundleId: 'com.test',
+    startedAt: 'now',
+  });
+  _setFetchForTest(async () => ({ json: async () => ({ ok: true, data: { nodes: [] } }) }));
+  try {
+    const result = await runIOS({ command: 'snapshot' });
+    const env = parseEnvelope(result);
+    assert.equal(env.ok, true);
+    assert.equal(env.meta?.snapshotVerdict?.state, 'degraded');
+    assert.ok(env.meta?.snapshotVerdict?.reasons?.includes('empty-capture'));
+    assert.equal(env.meta?.snapshotVerdict?.refMapUpdated, false);
+    assert.deepEqual(
+      buildRunIOSArgs(['tap', '@e0']),
+      { command: 'tap', x: 60, y: 40 },
+      'last-known-good refs survive the sparse capture',
+    );
+  } finally {
+    _setFetchForTest(globalThis.fetch);
+    _setRunnerStateForTest(null);
+    clearRefMap();
+  }
+});
+
+test('runIOS snapshot: healthy capture carries an ok verdict and updates the ref map', async () => {
+  clearRefMap();
+  _setRunnerStateForTest({
+    port: 22088,
+    pid: 999999,
+    deviceId: 'sim',
+    bundleId: 'com.test',
+    startedAt: 'now',
+  });
+  _setFetchForTest(async () => ({
+    json: async () => ({
+      ok: true,
+      data: {
+        nodes: [
+          { index: 0, type: 'Button', rect: { x: 10, y: 20, width: 100, height: 40 }, label: 'Go' },
+        ],
+      },
+    }),
+  }));
+  try {
+    const result = await runIOS({ command: 'snapshot' });
+    const env = parseEnvelope(result);
+    assert.equal(env.ok, true);
+    assert.equal(env.meta?.snapshotVerdict?.state, 'ok');
+    assert.equal(env.meta?.snapshotVerdict?.nodeCount, 1);
+    assert.equal(env.meta?.snapshotVerdict?.refMapUpdated, true);
+    assert.deepEqual(buildRunIOSArgs(['tap', '@e0']), { command: 'tap', x: 60, y: 40 });
+  } finally {
+    _setFetchForTest(globalThis.fetch);
+    _setRunnerStateForTest(null);
+    clearRefMap();
+  }
+});
+
+// ── interactive consumers fail closed on a zero-node capture ─────────
+
+test('fetchSnapshotNodes: zero-node capture refuses with empty-capture instead of "nothing on screen"', async () => {
+  _setRunAgentDeviceForTest(async () => okResult({ nodes: [] }));
+  try {
+    const snap = await fetchSnapshotNodes(false);
+    assert.deepEqual(snap, { ok: false, reason: 'empty-capture' });
+  } finally {
+    _setRunAgentDeviceForTest(null);
+  }
+});


### PR DESCRIPTION
Closes #409 (Story 16, from the 2026-07-03 audit).

## Problem

When a tree walk degrades — fiber roots invisible (the #126 modal/portal class), renderers registered but unscanned, a renderer throwing mid-walk, depth caps, scan-budget exhaustion, or a wedged/empty runner capture — tools returned a sparse or empty tree **indistinguishable from a legitimately empty screen**. The agent then confidently acted on a lie ("no elements found" → wrong recovery, wasted loops), and a single sparse runner capture silently wiped the @ref map that Story 05 self-healing depends on.

## What changed

**1. Quality verdict computed once at capture (CDP path).** `getTree()` (injected helpers v33 → v34) emits `verdict: {state: ok|degraded|failed, path: full|filter|interactive|none, reasons, rootsSeeded, scannedNodes, effectiveDepth, droppedSubtrees, collapsedChildLists, rendererErrors, unscannedRendererIds}` on every return path. Previously-silent drop classes are now visible:
- per-renderer exception swallows and extra-roots resolver throws → `renderer-error` (degraded)
- renderers registered beyond the early-exit window (#126 class) → `renderers-unscanned`; on the no-renderer bail this rides the `failed` verdict with the exact unscanned ids
- BFS budget / wall-clock / salient-cap exhaustion → `scan-budget-exhausted` (degraded) — a filter **no-match after an incomplete scan is no longer a clean-looking empty**
- depth-cap subtree drops and >20-child collapses → counted (`droppedSubtrees`/`collapsedChildLists`) without flipping state, since the caller asked for the cap
- oversized-output truncation → `output-truncated`

`cdp_component_tree` renders it once as `meta.treeVerdict` (kept on `failResult` for failed captures; stripped from `data`). Stale injected bundles (< v34) simply omit the verdict — no compat break.

**2. Runner snapshot verdict (iOS + Android).** The snapshot post-processing in both runner clients emits `meta.snapshotVerdict: {state, source, nodeCount, refMapUpdated, reasons}` — built from the same call that decides the ref-map write, so the verdict and the actual overwrite behavior can never disagree.

**3. Sparse captures never overwrite last-known-good.** `updateRefMapFromFlat()` now refuses a zero-valid-node capture when a map exists (`{applied: false, reason: 'empty-capture'}`): refs stay bound to the last verified capture, and a genuinely emptied screen surfaces as `STALE_REF` on the next tap instead of silently serving nothing. This also guards the settle-probe paths that refresh the ref map as a side effect.

**4. Interactive consumers fail closed.** `device_find` (exact + fuzzy) and `device_focus_next` refuse a zero-node capture with `SNAPSHOT_DEGRADED` + a confirm-with-screenshot hint, rather than asserting `NOT_FOUND` / "nothing on screen" on evidence that cannot support it. `device_scrollintoview` intentionally keeps scrolling on an empty capture (scrolling may legitimately reveal content).

**Drive-by (same failure class, codex-pair finding):** `REACT_READY_PROBE_JS` wraps each `getFiberRoots(i)` in try/catch so one throwing renderer can't abort the readiness scan.

## Measurement gate (issue's acceptance)

TDD — 14 new unit tests in `test/unit/story-16-snapshot-quality-verdicts.test.ts`, all verified failing before implementation, covering every named failure class: renderer-error, renderers-unscanned (#126), scan-budget exhaustion (filter + interactive), depth-cap counting, no-renderer, verdict lift/fail-closed in the handler, ref-map preservation, runner snapshot verdicts, and the zero-node refusal.

## Verification

- 3094/3094 unit, 21/21 integration (Node 22)
- dist-freshness gate, oxlint, oxfmt clean
- changeset bumps `rn-dev-agent-core` + `rn-dev-agent-plugin` (minor)
- codex-pair per-edit review: all findings addressed or triaged (the `findAllRootFibersForTest` mirror and `windowCap` notes are pre-existing #126/#519 scope, untouched by this diff)

Proof-video note: this change is bridge/injected-JS logic with a unit-fixture measurement gate per the issue; no saved-action replay surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KpM53gXa3a3usxdLHBgjJ