### PR TITLE
test(contract): #437 golden runner payloads + named wire-contract CI gate

### DIFF
--- a/.changeset/golden-contract-437.md
+++ b/.changeset/golden-contract-437.md
@@ -1,0 +1,27 @@
+---
+'rn-dev-agent-core': patch
+'rn-dev-agent-plugin': patch
+---
+
+Golden wire-contract tests from captured runner payloads + named CI gate (#437, audit P0-B).
+
+The biggest escaped-bug cluster (#396, #353, #418) was host↔runner wire-contract
+drift where hand-written fixtures encoded the wrong shape, so green tests
+certified broken behavior. This closes that hole:
+
+- `test/contract/capture-goldens.ts` records REAL `/health`, raw
+  `POST /command snapshot`, error-envelope, and bridge `device_snapshot`
+  payloads from live rn-fast-runner / rn-android-runner sessions into committed
+  fixtures under `test/fixtures/goldens/<platform>/`, each stamped with capture
+  provenance (device, OS, runner version, date). Goldens are captured, never
+  hand-written.
+- `gh-437-golden-contract.test.ts` pins the TS parsing layer
+  (`classifyRunnerCompatibility`, `findRefByTestID`, the ref-map oracle +
+  snapshot verdict) against those captured payloads for both platforms, and
+  pins the captured `v` stamp to `RUNNER_PROTOCOL_VERSION` — a protocol bump
+  fails CI until goldens are re-captured against the new runner (refresh
+  cadence, enforced).
+- New named CI step "Runner wire-contract gate" runs the #418 tri-surface
+  command-enum sync, the #383 protocol-version sync, and the golden contract
+  tests via `yarn workspace rn-dev-agent-core test:contract`, so wire-contract
+  drift fails a visible gate instead of hiding in the unit blob.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,14 @@ jobs:
       # inline CI glob silently skipped 22 nested unit-test files while
       # `yarn test` ran them. The unit run also emits Node's built-in coverage
       # report (report-only, no thresholds) so untested areas stay visible.
+      # GH#437 (audit P0-B): wire-contract drift must fail a NAMED gate, not
+      # hide in the unit blob — tri-file command-enum/protocol sync (#418/#383)
+      # plus golden contract tests over payloads captured from live runners.
+      # Runs BEFORE the broad unit step so a contract regression fails here,
+      # under the gate's name (the unit globs also include these files).
+      - name: Runner wire-contract gate
+        run: corepack yarn workspace rn-dev-agent-core test:contract
+
       - name: Unit tests (with coverage report)
         run: corepack yarn test:coverage
 

--- a/packages/rn-dev-agent-core/package.json
+++ b/packages/rn-dev-agent-core/package.json
@@ -10,6 +10,7 @@
     "dev": "tsc --watch",
     "test": "yarn build && node --test 'test/unit/*.test.js' 'test/unit/**/*.test.js' 'test/unit/*.test.ts' 'test/unit/**/*.test.ts'",
     "test:coverage": "yarn build && node --test --experimental-test-coverage --test-coverage-exclude='test/**' 'test/unit/*.test.js' 'test/unit/**/*.test.js' 'test/unit/*.test.ts' 'test/unit/**/*.test.ts'",
+    "test:contract": "yarn build && node --test test/unit/gh-383-protocol-sync.test.js test/unit/gh-418-command-surface-sync.test.js test/unit/gh-437-golden-contract.test.ts",
     "test:integration": "yarn build && node --test 'test/integration/*.test.js' 'test/integration/**/*.test.js' 'test/integration/*.test.ts' 'test/integration/**/*.test.ts'",
     "test:all": "yarn build && node --test 'test/unit/*.test.js' 'test/unit/**/*.test.js' 'test/unit/*.test.ts' 'test/unit/**/*.test.ts' 'test/integration/*.test.js' 'test/integration/**/*.test.js' 'test/integration/*.test.ts' 'test/integration/**/*.test.ts'"
   },

--- a/packages/rn-dev-agent-core/test/contract/capture-goldens.ts
+++ b/packages/rn-dev-agent-core/test/contract/capture-goldens.ts
@@ -1,0 +1,318 @@
+// GH #437 (test-confidence audit P0-B): capture REAL runner wire payloads
+// into committed golden fixtures under test/fixtures/goldens/<platform>/.
+// Goldens are captured, never hand-written — the escaped-bug cluster this
+// closes (#396, #353, #418) was hand-written fixtures encoding the WRONG
+// shape, so green tests certified broken behavior.
+//
+// Usage (fixture app installed on the booted device, see test-fixtures/):
+//   GOLDEN_PLATFORM=ios     node test/contract/capture-goldens.ts
+//   GOLDEN_PLATFORM=android node test/contract/capture-goldens.ts
+//
+// What it records, per platform, in ONE live session:
+//   health.json            raw GET /health body (runner HTTP, no bridge)
+//   command-snapshot.json  raw POST /command {command:'snapshot'} body —
+//                          the pre-mapping RunnerSnapshotNode wire shape
+//   command-error.json     raw POST /command with an unknown verb — the
+//                          runner's error-envelope shape
+//   tool-envelope-snapshot.json  the bridge's device_snapshot envelope from
+//                          the same session — the post-mapping FlatNode shape
+//                          findRefByTestID and friends consume
+//
+// Re-capture cadence: whenever RUNNER_PROTOCOL_VERSION bumps or the runner
+// wire shape changes. gh-437-golden-contract.test.ts pins the captured `v`
+// stamp to the current RUNNER_PROTOCOL_VERSION, so a protocol bump fails CI
+// until the goldens are re-captured against the new runner.
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+// @ts-expect-error -- untyped JS test helper
+import { startSupervisor } from '../helpers/supervisor-harness.js';
+import { runnerStatePath, readJsonStateFile } from '../../dist/util/secure-state-file.js';
+
+const PLATFORM = process.env.GOLDEN_PLATFORM;
+const APP_ID = process.env.GOLDEN_APP_ID ?? 'dev.lykhoyda.rndevagent.fixture';
+const OUT_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'fixtures',
+  'goldens',
+  PLATFORM ?? 'unknown',
+);
+
+if (PLATFORM !== 'ios' && PLATFORM !== 'android') {
+  console.error('GOLDEN_PLATFORM must be "ios" or "android"');
+  process.exit(1);
+}
+
+function sh(cmd: string, args: string[], timeout = 15_000): string {
+  return execFileSync(cmd, args, { stdio: 'pipe', timeout }).toString();
+}
+
+function assertFixtureInstalled(): void {
+  try {
+    if (PLATFORM === 'ios') {
+      sh('xcrun', ['simctl', 'get_app_container', 'booted', APP_ID]);
+    } else if (!sh('adb', ['shell', 'pm', 'path', APP_ID]).includes('package:')) {
+      throw new Error('not installed');
+    }
+  } catch {
+    console.error(
+      `Fixture app ${APP_ID} is not installed on the booted ${PLATFORM} device.\n` +
+        `Build + install it first — see test-fixtures/${PLATFORM}-fixture/README.md`,
+    );
+    process.exit(1);
+  }
+}
+
+function launchFixture(): void {
+  if (PLATFORM === 'ios') {
+    sh('xcrun', ['simctl', 'launch', 'booted', APP_ID], 30_000);
+  } else {
+    sh(
+      'adb',
+      ['shell', 'monkey', '-p', APP_ID, '-c', 'android.intent.category.LAUNCHER', '1'],
+      30_000,
+    );
+  }
+}
+
+function deviceProvenance(): { device: string; os: string } {
+  if (PLATFORM === 'ios') {
+    const booted = (
+      JSON.parse(sh('xcrun', ['simctl', 'list', 'devices', 'booted', '-j'])) as {
+        devices: Record<string, Array<{ name: string; udid: string }>>;
+      }
+    ).devices;
+    for (const [runtime, devs] of Object.entries(booted)) {
+      if (devs.length > 0) {
+        return {
+          device: `${devs[0].name} (${devs[0].udid})`,
+          os: runtime.replace('com.apple.CoreSimulator.SimRuntime.', ''),
+        };
+      }
+    }
+    return { device: 'unknown-booted-simulator', os: 'unknown' };
+  }
+  return {
+    device: sh('adb', ['shell', 'getprop', 'ro.product.model']).trim(),
+    os: `Android ${sh('adb', ['shell', 'getprop', 'ro.build.version.release']).trim()}`,
+  };
+}
+
+/** UDID of the booted simulator (iOS) or the adb serial (Android). */
+function deviceKey(): string {
+  if (PLATFORM === 'ios') {
+    const booted = (
+      JSON.parse(sh('xcrun', ['simctl', 'list', 'devices', 'booted', '-j'])) as {
+        devices: Record<string, Array<{ udid: string }>>;
+      }
+    ).devices;
+    for (const devs of Object.values(booted)) {
+      if (devs.length > 0) return devs[0].udid;
+    }
+    throw new Error('no booted iOS simulator');
+  }
+  const lines = sh('adb', ['devices'])
+    .split('\n')
+    .filter((l) => l.endsWith('\tdevice'));
+  if (lines.length === 0) throw new Error('no adb device attached');
+  return lines[0].split('\t')[0];
+}
+
+/**
+ * The bridge persists runner state (port for iOS, forwarded hostPort for
+ * Android) under <stateDir>/runner-state/<platform>-<device>.json. Pin the
+ * lookup to the exact device this capture session opened on — a freshest-file
+ * heuristic could silently read a stale or concurrent session's runner.
+ */
+function discoverRunnerPort(): number {
+  const path = runnerStatePath(`${PLATFORM}-${deviceKey()}`);
+  const state = readJsonStateFile<{ port?: number; hostPort?: number }>(path);
+  const port = PLATFORM === 'ios' ? state?.port : (state?.hostPort ?? state?.port);
+  if (typeof port !== 'number') {
+    throw new Error(`no live runner port in ${path} — did the session open on this device?`);
+  }
+  return port;
+}
+
+interface Captured {
+  httpStatus: number;
+  body: unknown;
+}
+
+// Mirrors the production clients' slow-command ceiling (snapshot can run
+// long while the runner serializes a large tree) — a wedged runner must
+// fail the capture, not hang it.
+const RAW_HTTP_TIMEOUT_MS = 35_000;
+
+async function rawGet(port: number, path: string): Promise<Captured> {
+  const resp = await fetch(`http://127.0.0.1:${port}${path}`, {
+    signal: AbortSignal.timeout(RAW_HTTP_TIMEOUT_MS),
+  });
+  return { httpStatus: resp.status, body: await resp.json() };
+}
+
+async function rawCommand(port: number, body: Record<string, unknown>): Promise<Captured> {
+  const resp = await fetch(`http://127.0.0.1:${port}/command`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(RAW_HTTP_TIMEOUT_MS),
+  });
+  const text = await resp.text();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    parsed = { unparseableBody: text.slice(0, 2000) };
+  }
+  return { httpStatus: resp.status, body: parsed };
+}
+
+function writeGolden(name: string, captured: Captured, extra: Record<string, unknown> = {}): void {
+  mkdirSync(OUT_DIR, { recursive: true });
+  const { device, os } = deviceProvenance();
+  const golden = {
+    _provenance: {
+      capturedAt: new Date().toISOString(),
+      capturedBy: 'test/contract/capture-goldens.ts — captured, never hand-edit',
+      recapture:
+        're-run when RUNNER_PROTOCOL_VERSION bumps or the runner wire shape changes ' +
+        `(GOLDEN_PLATFORM=${PLATFORM} node test/contract/capture-goldens.ts)`,
+      platform: PLATFORM,
+      device,
+      os,
+      appId: APP_ID,
+      httpStatus: captured.httpStatus,
+      ...extra,
+    },
+    payload: captured.body,
+  };
+  const outPath = join(OUT_DIR, name);
+  writeFileSync(outPath, JSON.stringify(golden, null, 2) + '\n');
+  console.log(`wrote ${outPath} (HTTP ${captured.httpStatus})`);
+}
+
+async function rpc(s: any, method: string, params?: unknown) {
+  const id = s.send(method, params);
+  for (;;) {
+    const line = JSON.parse(await s.nextLine());
+    if (line.id === id) return line;
+  }
+}
+
+async function callTool(s: any, name: string, args: Record<string, unknown> = {}) {
+  const line = await rpc(s, 'tools/call', { name, arguments: args });
+  const text: string = line.result?.content?.[0]?.text ?? '';
+  let envelope: any = null;
+  try {
+    envelope = JSON.parse(text);
+  } catch {
+    /* non-JSON tool output */
+  }
+  return { isError: Boolean(line.result?.isError), envelope, text };
+}
+
+async function main(): Promise<void> {
+  assertFixtureInstalled();
+  launchFixture();
+
+  const cwd = mkdtempSync(join(tmpdir(), 'rn-agent-goldens-'));
+  const s = startSupervisor({ cwd, lineTimeoutMs: 600_000, env: { RN_RUNNER_BUILD: 'local' } });
+  let opened = false;
+  try {
+    const init = await rpc(s, 'initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'capture-goldens', version: '1.0.0' },
+    });
+    if (!init.result) throw new Error(`initialize failed: ${JSON.stringify(init).slice(0, 300)}`);
+    s.notify('notifications/initialized');
+
+    const open = await callTool(s, 'device_snapshot', {
+      action: 'open',
+      platform: PLATFORM,
+      appId: APP_ID,
+      attachOnly: true,
+    });
+    if (open.envelope?.ok !== true) {
+      console.error('--- supervisor stderr tail ---\n' + s.stderrText().slice(-4000));
+      throw new Error(`session open failed: ${open.text.slice(0, 500)}`);
+    }
+    opened = true;
+
+    // Post-mapping layer first: the bridge's own snapshot envelope, exactly
+    // what findRefByTestID / parseSnapshotEnvelope consume in production.
+    const toolSnap = await callTool(s, 'device_snapshot', { action: 'snapshot' });
+    if (toolSnap.envelope?.ok !== true) {
+      throw new Error(`device_snapshot failed: ${toolSnap.text.slice(0, 500)}`);
+    }
+
+    // Raw wire layer: talk to the runner's HTTP surface directly. A golden
+    // that captured a failure would pin the WRONG contract, so success-path
+    // payloads are asserted healthy before anything is written (the unknown-
+    // verb golden is the one deliberate error capture).
+    const port = discoverRunnerPort();
+    const health = await rawGet(port, '/health');
+    const healthBody = health.body as {
+      ok?: boolean;
+      runnerVersion?: string;
+      protocolVersion?: number;
+    };
+    if (health.httpStatus !== 200 || healthBody?.ok !== true) {
+      throw new Error(
+        `/health not healthy: HTTP ${health.httpStatus} ${JSON.stringify(health.body).slice(0, 300)}`,
+      );
+    }
+    const stamp = {
+      runnerVersion: healthBody.runnerVersion,
+      protocolVersion: healthBody.protocolVersion,
+      runnerPort: port,
+    };
+
+    const rawSnap = await rawCommand(port, { command: 'snapshot', appBundleId: APP_ID });
+    const rawSnapBody = rawSnap.body as { ok?: boolean; data?: { nodes?: unknown[] } };
+    if (
+      rawSnap.httpStatus !== 200 ||
+      rawSnapBody?.ok !== true ||
+      !Array.isArray(rawSnapBody?.data?.nodes) ||
+      rawSnapBody.data.nodes.length === 0
+    ) {
+      throw new Error(
+        `raw snapshot unhealthy: HTTP ${rawSnap.httpStatus} ${JSON.stringify(rawSnap.body).slice(0, 300)}`,
+      );
+    }
+
+    writeGolden('health.json', health, stamp);
+    writeGolden('command-snapshot.json', rawSnap, stamp);
+    writeGolden(
+      'command-error.json',
+      await rawCommand(port, { command: 'gh437-unknown-command-probe' }),
+      { ...stamp, note: 'deliberately unknown verb — pins the error-envelope shape' },
+    );
+    writeGolden(
+      'tool-envelope-snapshot.json',
+      { httpStatus: 200, body: toolSnap.envelope },
+      { ...stamp, note: 'bridge device_snapshot envelope (post-mapping FlatNode layer)' },
+    );
+  } finally {
+    if (opened) {
+      // Close from the failure path too — an open session left behind keeps
+      // device locks / adb forwards / the native runner alive.
+      await callTool(s, 'device_snapshot', { action: 'close' }).catch((err) => {
+        console.error(`session close failed (continuing): ${err}`);
+      });
+    }
+    s.child.kill('SIGTERM');
+  }
+}
+
+main().then(
+  () => process.exit(0),
+  (err) => {
+    console.error(err);
+    process.exit(1);
+  },
+);

--- a/packages/rn-dev-agent-core/test/fixtures/goldens/android/command-error.json
+++ b/packages/rn-dev-agent-core/test/fixtures/goldens/android/command-error.json
@@ -1,0 +1,24 @@
+{
+  "_provenance": {
+    "capturedAt": "2026-07-11T15:57:13.756Z",
+    "capturedBy": "test/contract/capture-goldens.ts — captured, never hand-edit",
+    "recapture": "re-run when RUNNER_PROTOCOL_VERSION bumps or the runner wire shape changes (GOLDEN_PLATFORM=android node test/contract/capture-goldens.ts)",
+    "platform": "android",
+    "device": "sdk_gphone16k_arm64",
+    "os": "Android 17",
+    "appId": "dev.lykhoyda.rndevagent.fixture",
+    "httpStatus": 200,
+    "runnerVersion": "0.67.0",
+    "protocolVersion": 1,
+    "runnerPort": 22089,
+    "note": "deliberately unknown verb — pins the error-envelope shape"
+  },
+  "payload": {
+    "ok": false,
+    "error": {
+      "code": "UNSUPPORTED_COMMAND",
+      "message": "Unsupported Android runner command: gh437-unknown-command-probe"
+    },
+    "v": 1
+  }
+}

--- a/packages/rn-dev-agent-core/test/fixtures/goldens/android/command-snapshot.json
+++ b/packages/rn-dev-agent-core/test/fixtures/goldens/android/command-snapshot.json
@@ -1,0 +1,891 @@
+{
+  "_provenance": {
+    "capturedAt": "2026-07-11T15:57:13.704Z",
+    "capturedBy": "test/contract/capture-goldens.ts — captured, never hand-edit",
+    "recapture": "re-run when RUNNER_PROTOCOL_VERSION bumps or the runner wire shape changes (GOLDEN_PLATFORM=android node test/contract/capture-goldens.ts)",
+    "platform": "android",
+    "device": "sdk_gphone16k_arm64",
+    "os": "Android 17",
+    "appId": "dev.lykhoyda.rndevagent.fixture",
+    "httpStatus": 200,
+    "runnerVersion": "0.67.0",
+    "protocolVersion": 1,
+    "runnerPort": 22089
+  },
+  "payload": {
+    "ok": true,
+    "data": {
+      "nodes": [
+        {
+          "index": 0,
+          "type": "android.widget.FrameLayout",
+          "label": "",
+          "identifier": "",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 156
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 1,
+          "type": "android.widget.FrameLayout",
+          "label": "",
+          "identifier": "status_bar_launch_animation_container",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 156
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 2,
+          "type": "android.widget.FrameLayout",
+          "label": "",
+          "identifier": "status_bar_container",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 156
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 3,
+          "type": "androidx.compose.ui.platform.ComposeView",
+          "label": "",
+          "identifier": "",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 156
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 4,
+          "type": "android.view.View",
+          "label": "",
+          "identifier": "",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 156
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 5,
+          "type": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+          "label": "",
+          "identifier": "",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 156
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 6,
+          "type": "android.widget.FrameLayout",
+          "label": "",
+          "identifier": "status_bar",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 156
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 7,
+          "type": "android.widget.LinearLayout",
+          "label": "",
+          "identifier": "status_bar_contents",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1220,
+            "height": 156
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 8,
+          "type": "android.widget.FrameLayout",
+          "label": "",
+          "identifier": "status_bar_start_side_container",
+          "rect": {
+            "x": 48,
+            "y": 0,
+            "width": 525,
+            "height": 156
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 9,
+          "type": "android.widget.FrameLayout",
+          "label": "",
+          "identifier": "status_bar_start_side_content",
+          "rect": {
+            "x": 48,
+            "y": 0,
+            "width": 196,
+            "height": 156
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 10,
+          "type": "android.widget.LinearLayout",
+          "label": "",
+          "identifier": "status_bar_start_side_except_heads_up",
+          "rect": {
+            "x": 48,
+            "y": 0,
+            "width": 196,
+            "height": 156
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 11,
+          "type": "android.widget.TextView",
+          "label": "5:57",
+          "identifier": "clock",
+          "rect": {
+            "x": 48,
+            "y": 45,
+            "width": 130,
+            "height": 66
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 12,
+          "type": "android.widget.FrameLayout",
+          "label": "",
+          "identifier": "start_side_notif_and_chip_container",
+          "rect": {
+            "x": 178,
+            "y": 0,
+            "width": 66,
+            "height": 156
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 13,
+          "type": "android.widget.FrameLayout",
+          "label": "",
+          "identifier": "notification_icon_area",
+          "rect": {
+            "x": 178,
+            "y": 0,
+            "width": 66,
+            "height": 156
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 14,
+          "type": "android.view.ViewGroup",
+          "label": "",
+          "identifier": "notificationIcons",
+          "rect": {
+            "x": 178,
+            "y": 0,
+            "width": 66,
+            "height": 156
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 15,
+          "type": "android.widget.ImageView",
+          "label": "Security & privacy notification: ",
+          "identifier": "Security & privacy notification: ",
+          "rect": {
+            "x": 178,
+            "y": 0,
+            "width": 66,
+            "height": 156
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 16,
+          "type": "android.view.View",
+          "label": "",
+          "identifier": "cutout_space_view",
+          "rect": {
+            "x": 573,
+            "y": 0,
+            "width": 109,
+            "height": 156
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 17,
+          "type": "android.widget.FrameLayout",
+          "label": "",
+          "identifier": "status_bar_end_side_container",
+          "rect": {
+            "x": 682,
+            "y": 0,
+            "width": 526,
+            "height": 156
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 18,
+          "type": "android.widget.LinearLayout",
+          "label": "",
+          "identifier": "status_bar_end_side_content",
+          "rect": {
+            "x": 963,
+            "y": 0,
+            "width": 245,
+            "height": 156
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 19,
+          "type": "android.widget.LinearLayout",
+          "label": "",
+          "identifier": "system_icons",
+          "rect": {
+            "x": 963,
+            "y": 45,
+            "width": 245,
+            "height": 66
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 20,
+          "type": "android.widget.LinearLayout",
+          "label": "",
+          "identifier": "statusIcons",
+          "rect": {
+            "x": 972,
+            "y": 45,
+            "width": 144,
+            "height": 66
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 21,
+          "type": "android.widget.FrameLayout",
+          "label": "T-Mobile, three bars.",
+          "identifier": "mobile_combo",
+          "rect": {
+            "x": 972,
+            "y": 45,
+            "width": 69,
+            "height": 66
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 22,
+          "type": "android.widget.LinearLayout",
+          "label": "",
+          "identifier": "mobile_group",
+          "rect": {
+            "x": 981,
+            "y": 45,
+            "width": 51,
+            "height": 66
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 23,
+          "type": "android.widget.FrameLayout",
+          "label": "",
+          "identifier": "",
+          "rect": {
+            "x": 981,
+            "y": 60,
+            "width": 51,
+            "height": 36
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 24,
+          "type": "android.widget.ImageView",
+          "label": "",
+          "identifier": "mobile_signal",
+          "rect": {
+            "x": 981,
+            "y": 60,
+            "width": 51,
+            "height": 36
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 25,
+          "type": "android.widget.FrameLayout",
+          "label": "",
+          "identifier": "wifi_combo",
+          "rect": {
+            "x": 1041,
+            "y": 45,
+            "width": 66,
+            "height": 66
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 26,
+          "type": "android.widget.LinearLayout",
+          "label": "",
+          "identifier": "wifi_group",
+          "rect": {
+            "x": 1050,
+            "y": 45,
+            "width": 48,
+            "height": 66
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 27,
+          "type": "android.widget.FrameLayout",
+          "label": "",
+          "identifier": "wifi_combo",
+          "rect": {
+            "x": 1050,
+            "y": 60,
+            "width": 48,
+            "height": 36
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 28,
+          "type": "android.widget.ImageView",
+          "label": "Wifi signal full.",
+          "identifier": "wifi_signal",
+          "rect": {
+            "x": 1050,
+            "y": 60,
+            "width": 48,
+            "height": 36
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 29,
+          "type": "androidx.compose.ui.platform.ComposeView",
+          "label": "",
+          "identifier": "",
+          "rect": {
+            "x": 1116,
+            "y": 58,
+            "width": 80,
+            "height": 39
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 30,
+          "type": "android.view.View",
+          "label": "",
+          "identifier": "",
+          "rect": {
+            "x": 1116,
+            "y": 58,
+            "width": 80,
+            "height": 39
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 31,
+          "type": "android.view.View",
+          "label": "",
+          "identifier": "battery",
+          "rect": {
+            "x": 1116,
+            "y": 58,
+            "width": 80,
+            "height": 39
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 32,
+          "type": "android.view.View",
+          "label": "Battery 100 percent.",
+          "identifier": "Battery 100 percent.",
+          "rect": {
+            "x": 1116,
+            "y": 58,
+            "width": 72,
+            "height": 39
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 33,
+          "type": "android.widget.FrameLayout",
+          "label": "",
+          "identifier": "",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 2856
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 34,
+          "type": "android.view.ViewGroup",
+          "label": "",
+          "identifier": "decor_content_parent",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 2856
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 35,
+          "type": "android.widget.FrameLayout",
+          "label": "",
+          "identifier": "content",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 2856
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 36,
+          "type": "android.widget.LinearLayout",
+          "label": "",
+          "identifier": "",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 2856
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 37,
+          "type": "android.widget.Button",
+          "label": "Increment",
+          "identifier": "fixture_button",
+          "rect": {
+            "x": 0,
+            "y": 324,
+            "width": 264,
+            "height": 144
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 38,
+          "type": "android.widget.TextView",
+          "label": "count: 0",
+          "identifier": "fixture_count",
+          "rect": {
+            "x": 0,
+            "y": 468,
+            "width": 150,
+            "height": 57
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 39,
+          "type": "android.widget.Button",
+          "label": "Disabled",
+          "identifier": "fixture_disabled_button",
+          "rect": {
+            "x": 0,
+            "y": 525,
+            "width": 264,
+            "height": 144
+          },
+          "hittable": false,
+          "enabled": false
+        },
+        {
+          "index": 40,
+          "type": "android.widget.EditText",
+          "label": "type here",
+          "identifier": "fixture_input",
+          "rect": {
+            "x": 0,
+            "y": 669,
+            "width": 1280,
+            "height": 136
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 41,
+          "type": "android.widget.ListView",
+          "label": "",
+          "identifier": "fixture_list",
+          "rect": {
+            "x": 0,
+            "y": 805,
+            "width": 1280,
+            "height": 1778
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 42,
+          "type": "android.widget.TextView",
+          "label": "row 1",
+          "identifier": "text1",
+          "rect": {
+            "x": 0,
+            "y": 805,
+            "width": 1280,
+            "height": 144
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 43,
+          "type": "android.widget.TextView",
+          "label": "row 2",
+          "identifier": "text1",
+          "rect": {
+            "x": 0,
+            "y": 952,
+            "width": 1280,
+            "height": 144
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 44,
+          "type": "android.widget.TextView",
+          "label": "row 3",
+          "identifier": "text1",
+          "rect": {
+            "x": 0,
+            "y": 1099,
+            "width": 1280,
+            "height": 144
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 45,
+          "type": "android.widget.TextView",
+          "label": "row 4",
+          "identifier": "text1",
+          "rect": {
+            "x": 0,
+            "y": 1246,
+            "width": 1280,
+            "height": 144
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 46,
+          "type": "android.widget.TextView",
+          "label": "row 5",
+          "identifier": "text1",
+          "rect": {
+            "x": 0,
+            "y": 1393,
+            "width": 1280,
+            "height": 144
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 47,
+          "type": "android.widget.TextView",
+          "label": "row 6",
+          "identifier": "text1",
+          "rect": {
+            "x": 0,
+            "y": 1540,
+            "width": 1280,
+            "height": 144
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 48,
+          "type": "android.widget.TextView",
+          "label": "row 7",
+          "identifier": "text1",
+          "rect": {
+            "x": 0,
+            "y": 1687,
+            "width": 1280,
+            "height": 144
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 49,
+          "type": "android.widget.TextView",
+          "label": "row 8",
+          "identifier": "text1",
+          "rect": {
+            "x": 0,
+            "y": 1834,
+            "width": 1280,
+            "height": 144
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 50,
+          "type": "android.widget.TextView",
+          "label": "row 9",
+          "identifier": "text1",
+          "rect": {
+            "x": 0,
+            "y": 1981,
+            "width": 1280,
+            "height": 144
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 51,
+          "type": "android.widget.TextView",
+          "label": "row 10",
+          "identifier": "text1",
+          "rect": {
+            "x": 0,
+            "y": 2128,
+            "width": 1280,
+            "height": 144
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 52,
+          "type": "android.widget.TextView",
+          "label": "row 11",
+          "identifier": "text1",
+          "rect": {
+            "x": 0,
+            "y": 2275,
+            "width": 1280,
+            "height": 144
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 53,
+          "type": "android.widget.TextView",
+          "label": "row 12",
+          "identifier": "text1",
+          "rect": {
+            "x": 0,
+            "y": 2422,
+            "width": 1280,
+            "height": 144
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 54,
+          "type": "android.widget.TextView",
+          "label": "row 13",
+          "identifier": "text1",
+          "rect": {
+            "x": 0,
+            "y": 2569,
+            "width": 1280,
+            "height": 14
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 55,
+          "type": "android.widget.LinearLayout",
+          "label": "",
+          "identifier": "",
+          "rect": {
+            "x": 0,
+            "y": 2583,
+            "width": 1280,
+            "height": 144
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 56,
+          "type": "android.widget.EditText",
+          "label": "bottom",
+          "identifier": "fixture_bottom_input",
+          "rect": {
+            "x": 0,
+            "y": 2583,
+            "width": 1016,
+            "height": 136
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 57,
+          "type": "android.widget.Button",
+          "label": "Tap",
+          "identifier": "fixture_bottom_button",
+          "rect": {
+            "x": 1016,
+            "y": 2583,
+            "width": 264,
+            "height": 144
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 58,
+          "type": "android.widget.TextView",
+          "label": "bottom taps: 0",
+          "identifier": "fixture_bottom_count",
+          "rect": {
+            "x": 0,
+            "y": 2727,
+            "width": 274,
+            "height": 57
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 59,
+          "type": "android.widget.FrameLayout",
+          "label": "",
+          "identifier": "action_bar_container",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 324
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 60,
+          "type": "android.view.ViewGroup",
+          "label": "",
+          "identifier": "action_bar",
+          "rect": {
+            "x": 0,
+            "y": 156,
+            "width": 1280,
+            "height": 168
+          },
+          "hittable": true,
+          "enabled": true
+        },
+        {
+          "index": 61,
+          "type": "android.widget.TextView",
+          "label": "Fixture",
+          "identifier": "",
+          "rect": {
+            "x": 48,
+            "y": 199,
+            "width": 184,
+            "height": 81
+          },
+          "hittable": true,
+          "enabled": true
+        }
+      ]
+    },
+    "v": 1
+  }
+}

--- a/packages/rn-dev-agent-core/test/fixtures/goldens/android/health.json
+++ b/packages/rn-dev-agent-core/test/fixtures/goldens/android/health.json
@@ -1,0 +1,43 @@
+{
+  "_provenance": {
+    "capturedAt": "2026-07-11T15:57:13.659Z",
+    "capturedBy": "test/contract/capture-goldens.ts — captured, never hand-edit",
+    "recapture": "re-run when RUNNER_PROTOCOL_VERSION bumps or the runner wire shape changes (GOLDEN_PLATFORM=android node test/contract/capture-goldens.ts)",
+    "platform": "android",
+    "device": "sdk_gphone16k_arm64",
+    "os": "Android 17",
+    "appId": "dev.lykhoyda.rndevagent.fixture",
+    "httpStatus": 200,
+    "runnerVersion": "0.67.0",
+    "protocolVersion": 1,
+    "runnerPort": 22089
+  },
+  "payload": {
+    "ok": true,
+    "protocolVersion": 1,
+    "capabilities": [
+      "WINDOW_UPDATE",
+      "HONEST_HITTABLE"
+    ],
+    "commands": [
+      "snapshot",
+      "tap",
+      "press",
+      "type",
+      "fill",
+      "drag",
+      "swipe",
+      "scroll",
+      "screenshot",
+      "back",
+      "dismissKeyboard",
+      "keyboard",
+      "longPress",
+      "pinch",
+      "findText",
+      "isWindowUpdating"
+    ],
+    "runnerVersion": "0.67.0",
+    "v": 1
+  }
+}

--- a/packages/rn-dev-agent-core/test/fixtures/goldens/android/tool-envelope-snapshot.json
+++ b/packages/rn-dev-agent-core/test/fixtures/goldens/android/tool-envelope-snapshot.json
@@ -1,0 +1,900 @@
+{
+  "_provenance": {
+    "capturedAt": "2026-07-11T15:57:13.806Z",
+    "capturedBy": "test/contract/capture-goldens.ts — captured, never hand-edit",
+    "recapture": "re-run when RUNNER_PROTOCOL_VERSION bumps or the runner wire shape changes (GOLDEN_PLATFORM=android node test/contract/capture-goldens.ts)",
+    "platform": "android",
+    "device": "sdk_gphone16k_arm64",
+    "os": "Android 17",
+    "appId": "dev.lykhoyda.rndevagent.fixture",
+    "httpStatus": 200,
+    "runnerVersion": "0.67.0",
+    "protocolVersion": 1,
+    "runnerPort": 22089,
+    "note": "bridge device_snapshot envelope (post-mapping FlatNode layer)"
+  },
+  "payload": {
+    "ok": true,
+    "data": {
+      "nodes": [
+        {
+          "ref": "@e0",
+          "type": "android.widget.FrameLayout",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 156
+          },
+          "label": "",
+          "identifier": "",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e1",
+          "type": "android.widget.FrameLayout",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 156
+          },
+          "label": "",
+          "identifier": "status_bar_launch_animation_container",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e2",
+          "type": "android.widget.FrameLayout",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 156
+          },
+          "label": "",
+          "identifier": "status_bar_container",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e3",
+          "type": "androidx.compose.ui.platform.ComposeView",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 156
+          },
+          "label": "",
+          "identifier": "",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e4",
+          "type": "android.view.View",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 156
+          },
+          "label": "",
+          "identifier": "",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e5",
+          "type": "androidx.compose.ui.viewinterop.ViewFactoryHolder",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 156
+          },
+          "label": "",
+          "identifier": "",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e6",
+          "type": "android.widget.FrameLayout",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 156
+          },
+          "label": "",
+          "identifier": "status_bar",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e7",
+          "type": "android.widget.LinearLayout",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1220,
+            "height": 156
+          },
+          "label": "",
+          "identifier": "status_bar_contents",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e8",
+          "type": "android.widget.FrameLayout",
+          "rect": {
+            "x": 48,
+            "y": 0,
+            "width": 525,
+            "height": 156
+          },
+          "label": "",
+          "identifier": "status_bar_start_side_container",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e9",
+          "type": "android.widget.FrameLayout",
+          "rect": {
+            "x": 48,
+            "y": 0,
+            "width": 196,
+            "height": 156
+          },
+          "label": "",
+          "identifier": "status_bar_start_side_content",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e10",
+          "type": "android.widget.LinearLayout",
+          "rect": {
+            "x": 48,
+            "y": 0,
+            "width": 196,
+            "height": 156
+          },
+          "label": "",
+          "identifier": "status_bar_start_side_except_heads_up",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e11",
+          "type": "android.widget.TextView",
+          "rect": {
+            "x": 48,
+            "y": 45,
+            "width": 130,
+            "height": 66
+          },
+          "label": "5:57",
+          "identifier": "clock",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e12",
+          "type": "android.widget.FrameLayout",
+          "rect": {
+            "x": 178,
+            "y": 0,
+            "width": 66,
+            "height": 156
+          },
+          "label": "",
+          "identifier": "start_side_notif_and_chip_container",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e13",
+          "type": "android.widget.FrameLayout",
+          "rect": {
+            "x": 178,
+            "y": 0,
+            "width": 66,
+            "height": 156
+          },
+          "label": "",
+          "identifier": "notification_icon_area",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e14",
+          "type": "android.view.ViewGroup",
+          "rect": {
+            "x": 178,
+            "y": 0,
+            "width": 66,
+            "height": 156
+          },
+          "label": "",
+          "identifier": "notificationIcons",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e15",
+          "type": "android.widget.ImageView",
+          "rect": {
+            "x": 178,
+            "y": 0,
+            "width": 66,
+            "height": 156
+          },
+          "label": "Security & privacy notification: ",
+          "identifier": "Security & privacy notification: ",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e16",
+          "type": "android.view.View",
+          "rect": {
+            "x": 573,
+            "y": 0,
+            "width": 109,
+            "height": 156
+          },
+          "label": "",
+          "identifier": "cutout_space_view",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e17",
+          "type": "android.widget.FrameLayout",
+          "rect": {
+            "x": 682,
+            "y": 0,
+            "width": 526,
+            "height": 156
+          },
+          "label": "",
+          "identifier": "status_bar_end_side_container",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e18",
+          "type": "android.widget.LinearLayout",
+          "rect": {
+            "x": 963,
+            "y": 0,
+            "width": 245,
+            "height": 156
+          },
+          "label": "",
+          "identifier": "status_bar_end_side_content",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e19",
+          "type": "android.widget.LinearLayout",
+          "rect": {
+            "x": 963,
+            "y": 45,
+            "width": 245,
+            "height": 66
+          },
+          "label": "",
+          "identifier": "system_icons",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e20",
+          "type": "android.widget.LinearLayout",
+          "rect": {
+            "x": 972,
+            "y": 45,
+            "width": 144,
+            "height": 66
+          },
+          "label": "",
+          "identifier": "statusIcons",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e21",
+          "type": "android.widget.FrameLayout",
+          "rect": {
+            "x": 972,
+            "y": 45,
+            "width": 69,
+            "height": 66
+          },
+          "label": "T-Mobile, three bars.",
+          "identifier": "mobile_combo",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e22",
+          "type": "android.widget.LinearLayout",
+          "rect": {
+            "x": 981,
+            "y": 45,
+            "width": 51,
+            "height": 66
+          },
+          "label": "",
+          "identifier": "mobile_group",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e23",
+          "type": "android.widget.FrameLayout",
+          "rect": {
+            "x": 981,
+            "y": 60,
+            "width": 51,
+            "height": 36
+          },
+          "label": "",
+          "identifier": "",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e24",
+          "type": "android.widget.ImageView",
+          "rect": {
+            "x": 981,
+            "y": 60,
+            "width": 51,
+            "height": 36
+          },
+          "label": "",
+          "identifier": "mobile_signal",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e25",
+          "type": "android.widget.FrameLayout",
+          "rect": {
+            "x": 1041,
+            "y": 45,
+            "width": 66,
+            "height": 66
+          },
+          "label": "",
+          "identifier": "wifi_combo",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e26",
+          "type": "android.widget.LinearLayout",
+          "rect": {
+            "x": 1050,
+            "y": 45,
+            "width": 48,
+            "height": 66
+          },
+          "label": "",
+          "identifier": "wifi_group",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e27",
+          "type": "android.widget.FrameLayout",
+          "rect": {
+            "x": 1050,
+            "y": 60,
+            "width": 48,
+            "height": 36
+          },
+          "label": "",
+          "identifier": "wifi_combo",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e28",
+          "type": "android.widget.ImageView",
+          "rect": {
+            "x": 1050,
+            "y": 60,
+            "width": 48,
+            "height": 36
+          },
+          "label": "Wifi signal full.",
+          "identifier": "wifi_signal",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e29",
+          "type": "androidx.compose.ui.platform.ComposeView",
+          "rect": {
+            "x": 1116,
+            "y": 58,
+            "width": 80,
+            "height": 39
+          },
+          "label": "",
+          "identifier": "",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e30",
+          "type": "android.view.View",
+          "rect": {
+            "x": 1116,
+            "y": 58,
+            "width": 80,
+            "height": 39
+          },
+          "label": "",
+          "identifier": "",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e31",
+          "type": "android.view.View",
+          "rect": {
+            "x": 1116,
+            "y": 58,
+            "width": 80,
+            "height": 39
+          },
+          "label": "",
+          "identifier": "battery",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e32",
+          "type": "android.view.View",
+          "rect": {
+            "x": 1116,
+            "y": 58,
+            "width": 72,
+            "height": 39
+          },
+          "label": "Battery 100 percent.",
+          "identifier": "Battery 100 percent.",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e33",
+          "type": "android.widget.FrameLayout",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 2856
+          },
+          "label": "",
+          "identifier": "",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e34",
+          "type": "android.view.ViewGroup",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 2856
+          },
+          "label": "",
+          "identifier": "decor_content_parent",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e35",
+          "type": "android.widget.FrameLayout",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 2856
+          },
+          "label": "",
+          "identifier": "content",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e36",
+          "type": "android.widget.LinearLayout",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 2856
+          },
+          "label": "",
+          "identifier": "",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e37",
+          "type": "android.widget.Button",
+          "rect": {
+            "x": 0,
+            "y": 324,
+            "width": 264,
+            "height": 144
+          },
+          "label": "Increment",
+          "identifier": "fixture_button",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e38",
+          "type": "android.widget.TextView",
+          "rect": {
+            "x": 0,
+            "y": 468,
+            "width": 150,
+            "height": 57
+          },
+          "label": "count: 0",
+          "identifier": "fixture_count",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e39",
+          "type": "android.widget.Button",
+          "rect": {
+            "x": 0,
+            "y": 525,
+            "width": 264,
+            "height": 144
+          },
+          "label": "Disabled",
+          "identifier": "fixture_disabled_button",
+          "enabled": false,
+          "hittable": false
+        },
+        {
+          "ref": "@e40",
+          "type": "android.widget.EditText",
+          "rect": {
+            "x": 0,
+            "y": 669,
+            "width": 1280,
+            "height": 136
+          },
+          "label": "type here",
+          "identifier": "fixture_input",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e41",
+          "type": "android.widget.ListView",
+          "rect": {
+            "x": 0,
+            "y": 805,
+            "width": 1280,
+            "height": 1778
+          },
+          "label": "",
+          "identifier": "fixture_list",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e42",
+          "type": "android.widget.TextView",
+          "rect": {
+            "x": 0,
+            "y": 805,
+            "width": 1280,
+            "height": 144
+          },
+          "label": "row 1",
+          "identifier": "text1",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e43",
+          "type": "android.widget.TextView",
+          "rect": {
+            "x": 0,
+            "y": 952,
+            "width": 1280,
+            "height": 144
+          },
+          "label": "row 2",
+          "identifier": "text1",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e44",
+          "type": "android.widget.TextView",
+          "rect": {
+            "x": 0,
+            "y": 1099,
+            "width": 1280,
+            "height": 144
+          },
+          "label": "row 3",
+          "identifier": "text1",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e45",
+          "type": "android.widget.TextView",
+          "rect": {
+            "x": 0,
+            "y": 1246,
+            "width": 1280,
+            "height": 144
+          },
+          "label": "row 4",
+          "identifier": "text1",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e46",
+          "type": "android.widget.TextView",
+          "rect": {
+            "x": 0,
+            "y": 1393,
+            "width": 1280,
+            "height": 144
+          },
+          "label": "row 5",
+          "identifier": "text1",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e47",
+          "type": "android.widget.TextView",
+          "rect": {
+            "x": 0,
+            "y": 1540,
+            "width": 1280,
+            "height": 144
+          },
+          "label": "row 6",
+          "identifier": "text1",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e48",
+          "type": "android.widget.TextView",
+          "rect": {
+            "x": 0,
+            "y": 1687,
+            "width": 1280,
+            "height": 144
+          },
+          "label": "row 7",
+          "identifier": "text1",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e49",
+          "type": "android.widget.TextView",
+          "rect": {
+            "x": 0,
+            "y": 1834,
+            "width": 1280,
+            "height": 144
+          },
+          "label": "row 8",
+          "identifier": "text1",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e50",
+          "type": "android.widget.TextView",
+          "rect": {
+            "x": 0,
+            "y": 1981,
+            "width": 1280,
+            "height": 144
+          },
+          "label": "row 9",
+          "identifier": "text1",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e51",
+          "type": "android.widget.TextView",
+          "rect": {
+            "x": 0,
+            "y": 2128,
+            "width": 1280,
+            "height": 144
+          },
+          "label": "row 10",
+          "identifier": "text1",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e52",
+          "type": "android.widget.TextView",
+          "rect": {
+            "x": 0,
+            "y": 2275,
+            "width": 1280,
+            "height": 144
+          },
+          "label": "row 11",
+          "identifier": "text1",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e53",
+          "type": "android.widget.TextView",
+          "rect": {
+            "x": 0,
+            "y": 2422,
+            "width": 1280,
+            "height": 144
+          },
+          "label": "row 12",
+          "identifier": "text1",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e54",
+          "type": "android.widget.TextView",
+          "rect": {
+            "x": 0,
+            "y": 2569,
+            "width": 1280,
+            "height": 14
+          },
+          "label": "row 13",
+          "identifier": "text1",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e55",
+          "type": "android.widget.LinearLayout",
+          "rect": {
+            "x": 0,
+            "y": 2583,
+            "width": 1280,
+            "height": 144
+          },
+          "label": "",
+          "identifier": "",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e56",
+          "type": "android.widget.EditText",
+          "rect": {
+            "x": 0,
+            "y": 2583,
+            "width": 1016,
+            "height": 136
+          },
+          "label": "bottom",
+          "identifier": "fixture_bottom_input",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e57",
+          "type": "android.widget.Button",
+          "rect": {
+            "x": 1016,
+            "y": 2583,
+            "width": 264,
+            "height": 144
+          },
+          "label": "Tap",
+          "identifier": "fixture_bottom_button",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e58",
+          "type": "android.widget.TextView",
+          "rect": {
+            "x": 0,
+            "y": 2727,
+            "width": 274,
+            "height": 57
+          },
+          "label": "bottom taps: 0",
+          "identifier": "fixture_bottom_count",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e59",
+          "type": "android.widget.FrameLayout",
+          "rect": {
+            "x": 0,
+            "y": 0,
+            "width": 1280,
+            "height": 324
+          },
+          "label": "",
+          "identifier": "action_bar_container",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e60",
+          "type": "android.view.ViewGroup",
+          "rect": {
+            "x": 0,
+            "y": 156,
+            "width": 1280,
+            "height": 168
+          },
+          "label": "",
+          "identifier": "action_bar",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e61",
+          "type": "android.widget.TextView",
+          "rect": {
+            "x": 48,
+            "y": 199,
+            "width": 184,
+            "height": 81
+          },
+          "label": "Fixture",
+          "identifier": "",
+          "enabled": true,
+          "hittable": true
+        }
+      ]
+    },
+    "meta": {
+      "snapshotVerdict": {
+        "state": "ok",
+        "source": "rn-android-runner",
+        "nodeCount": 62,
+        "refMapUpdated": true,
+        "reasons": []
+      }
+    }
+  }
+}

--- a/packages/rn-dev-agent-core/test/fixtures/goldens/ios/command-error.json
+++ b/packages/rn-dev-agent-core/test/fixtures/goldens/ios/command-error.json
@@ -1,0 +1,24 @@
+{
+  "_provenance": {
+    "capturedAt": "2026-07-11T15:56:58.793Z",
+    "capturedBy": "test/contract/capture-goldens.ts — captured, never hand-edit",
+    "recapture": "re-run when RUNNER_PROTOCOL_VERSION bumps or the runner wire shape changes (GOLDEN_PLATFORM=ios node test/contract/capture-goldens.ts)",
+    "platform": "ios",
+    "device": "iPhone 17 (3C6085C0-2F72-4C82-87AF-5F2807AC55F1)",
+    "os": "iOS-26-5",
+    "appId": "dev.lykhoyda.rndevagent.fixture",
+    "httpStatus": 200,
+    "runnerVersion": "0.67.0",
+    "protocolVersion": 1,
+    "runnerPort": 22088,
+    "note": "deliberately unknown verb — pins the error-envelope shape"
+  },
+  "payload": {
+    "v": 1,
+    "error": {
+      "code": "UNSUPPORTED_COMMAND",
+      "message": "Unsupported iOS runner command: gh437-unknown-command-probe — the runner artifact predates it; re-open the device session (device_snapshot action=open) to rebuild."
+    },
+    "ok": false
+  }
+}

--- a/packages/rn-dev-agent-core/test/fixtures/goldens/ios/command-snapshot.json
+++ b/packages/rn-dev-agent-core/test/fixtures/goldens/ios/command-snapshot.json
@@ -1,0 +1,1021 @@
+{
+  "_provenance": {
+    "capturedAt": "2026-07-11T15:56:58.667Z",
+    "capturedBy": "test/contract/capture-goldens.ts — captured, never hand-edit",
+    "recapture": "re-run when RUNNER_PROTOCOL_VERSION bumps or the runner wire shape changes (GOLDEN_PLATFORM=ios node test/contract/capture-goldens.ts)",
+    "platform": "ios",
+    "device": "iPhone 17 (3C6085C0-2F72-4C82-87AF-5F2807AC55F1)",
+    "os": "iOS-26-5",
+    "appId": "dev.lykhoyda.rndevagent.fixture",
+    "httpStatus": 200,
+    "runnerVersion": "0.67.0",
+    "protocolVersion": 1,
+    "runnerPort": 22088
+  },
+  "payload": {
+    "ok": true,
+    "v": 1,
+    "data": {
+      "nodes": [
+        {
+          "rect": {
+            "height": 874,
+            "x": 0,
+            "y": 0,
+            "width": 402
+          },
+          "index": 0,
+          "type": "Application",
+          "hittable": true,
+          "enabled": true,
+          "label": "Fixture",
+          "depth": 0
+        },
+        {
+          "rect": {
+            "height": 874,
+            "x": 0,
+            "y": 0,
+            "width": 402
+          },
+          "index": 1,
+          "type": "Window",
+          "hittable": true,
+          "enabled": true,
+          "depth": 1,
+          "parentIndex": 0
+        },
+        {
+          "rect": {
+            "height": 874,
+            "x": 0,
+            "y": 0,
+            "width": 402
+          },
+          "parentIndex": 1,
+          "hittable": true,
+          "enabled": true,
+          "label": "Increment",
+          "depth": 2,
+          "type": "Other",
+          "index": 2
+        },
+        {
+          "rect": {
+            "height": 20.33333333333333,
+            "x": 162.66666666666666,
+            "y": 78,
+            "width": 76.66666666666666
+          },
+          "parentIndex": 2,
+          "hittable": true,
+          "enabled": true,
+          "label": "Increment",
+          "depth": 3,
+          "type": "Button",
+          "index": 3,
+          "identifier": "fixture_button"
+        },
+        {
+          "rect": {
+            "height": 20.33333333333333,
+            "x": 169.66666666666666,
+            "y": 106.33333333333339,
+            "width": 62.66666666666666
+          },
+          "parentIndex": 2,
+          "hittable": true,
+          "enabled": true,
+          "label": "count: 0",
+          "depth": 3,
+          "type": "StaticText",
+          "index": 4,
+          "identifier": "fixture_count"
+        },
+        {
+          "rect": {
+            "height": 34,
+            "x": 16,
+            "y": 134.66666666666666,
+            "width": 370
+          },
+          "parentIndex": 2,
+          "hittable": true,
+          "enabled": true,
+          "depth": 3,
+          "type": "TextField",
+          "index": 5,
+          "identifier": "fixture_input"
+        },
+        {
+          "rect": {
+            "height": 577,
+            "x": 0,
+            "y": 176.66666666666666,
+            "width": 402
+          },
+          "parentIndex": 2,
+          "hittable": true,
+          "enabled": true,
+          "label": "Vertical scroll bar, 10 pages",
+          "depth": 3,
+          "type": "CollectionView",
+          "index": 6,
+          "identifier": "fixture_list"
+        },
+        {
+          "hittable": false,
+          "parentIndex": 6,
+          "rect": {
+            "height": 7563,
+            "x": -16,
+            "y": -977.3333333333334,
+            "width": 434
+          },
+          "type": "Other",
+          "enabled": true,
+          "index": 7,
+          "depth": 4
+        },
+        {
+          "depth": 4,
+          "hittable": true,
+          "parentIndex": 6,
+          "rect": {
+            "height": 51.99999999999997,
+            "x": 16,
+            "y": 211.66666666666666,
+            "width": 370
+          },
+          "type": "Cell",
+          "enabled": true,
+          "index": 8,
+          "label": "row 1"
+        },
+        {
+          "hittable": true,
+          "parentIndex": 8,
+          "rect": {
+            "height": 51.99999999999997,
+            "y": 211.66666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "type": "Other",
+          "enabled": true,
+          "index": 9,
+          "depth": 5
+        },
+        {
+          "depth": 5,
+          "hittable": true,
+          "parentIndex": 8,
+          "rect": {
+            "height": 51.99999999999997,
+            "y": 211.66666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "type": "Other",
+          "enabled": true,
+          "index": 10,
+          "label": "row 1"
+        },
+        {
+          "depth": 6,
+          "hittable": true,
+          "parentIndex": 10,
+          "rect": {
+            "height": 51.99999999999997,
+            "y": 211.66666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "identifier": "fixture_row_1",
+          "type": "StaticText",
+          "enabled": true,
+          "index": 11,
+          "label": "row 1"
+        },
+        {
+          "depth": 4,
+          "hittable": true,
+          "parentIndex": 6,
+          "rect": {
+            "height": 52,
+            "y": 263.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "type": "Cell",
+          "enabled": true,
+          "index": 12,
+          "label": "row 2"
+        },
+        {
+          "hittable": true,
+          "parentIndex": 12,
+          "rect": {
+            "height": 52,
+            "y": 263.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "type": "Other",
+          "enabled": true,
+          "index": 13,
+          "depth": 5
+        },
+        {
+          "depth": 5,
+          "hittable": true,
+          "parentIndex": 12,
+          "rect": {
+            "height": 52,
+            "y": 263.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "type": "Other",
+          "enabled": true,
+          "index": 14,
+          "label": "row 2"
+        },
+        {
+          "depth": 6,
+          "hittable": true,
+          "parentIndex": 14,
+          "rect": {
+            "height": 52,
+            "y": 263.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "identifier": "fixture_row_2",
+          "type": "StaticText",
+          "enabled": true,
+          "index": 15,
+          "label": "row 2"
+        },
+        {
+          "hittable": true,
+          "parentIndex": 6,
+          "rect": {
+            "height": 1,
+            "y": 262.66666666666663,
+            "x": 32,
+            "width": 338
+          },
+          "type": "Other",
+          "enabled": true,
+          "index": 16,
+          "depth": 4
+        },
+        {
+          "depth": 4,
+          "hittable": true,
+          "parentIndex": 6,
+          "rect": {
+            "height": 52,
+            "y": 315.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "type": "Cell",
+          "enabled": true,
+          "index": 17,
+          "label": "row 3"
+        },
+        {
+          "hittable": true,
+          "parentIndex": 17,
+          "rect": {
+            "height": 52,
+            "y": 315.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "type": "Other",
+          "enabled": true,
+          "index": 18,
+          "depth": 5
+        },
+        {
+          "depth": 5,
+          "hittable": true,
+          "parentIndex": 17,
+          "rect": {
+            "height": 52,
+            "y": 315.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "type": "Other",
+          "enabled": true,
+          "index": 19,
+          "label": "row 3"
+        },
+        {
+          "depth": 6,
+          "hittable": true,
+          "parentIndex": 19,
+          "rect": {
+            "height": 52,
+            "y": 315.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "identifier": "fixture_row_3",
+          "type": "StaticText",
+          "enabled": true,
+          "index": 20,
+          "label": "row 3"
+        },
+        {
+          "hittable": true,
+          "parentIndex": 6,
+          "rect": {
+            "height": 1,
+            "y": 314.66666666666663,
+            "x": 32,
+            "width": 338
+          },
+          "type": "Other",
+          "enabled": true,
+          "index": 21,
+          "depth": 4
+        },
+        {
+          "depth": 4,
+          "hittable": true,
+          "parentIndex": 6,
+          "rect": {
+            "height": 52,
+            "y": 367.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "type": "Cell",
+          "enabled": true,
+          "index": 22,
+          "label": "row 4"
+        },
+        {
+          "hittable": true,
+          "parentIndex": 22,
+          "rect": {
+            "height": 52,
+            "y": 367.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "type": "Other",
+          "enabled": true,
+          "index": 23,
+          "depth": 5
+        },
+        {
+          "depth": 5,
+          "hittable": true,
+          "parentIndex": 22,
+          "rect": {
+            "height": 52,
+            "y": 367.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "type": "Other",
+          "enabled": true,
+          "index": 24,
+          "label": "row 4"
+        },
+        {
+          "depth": 6,
+          "hittable": true,
+          "parentIndex": 24,
+          "rect": {
+            "height": 52,
+            "y": 367.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "identifier": "fixture_row_4",
+          "type": "StaticText",
+          "enabled": true,
+          "index": 25,
+          "label": "row 4"
+        },
+        {
+          "hittable": true,
+          "parentIndex": 6,
+          "rect": {
+            "height": 1,
+            "y": 366.66666666666663,
+            "x": 32,
+            "width": 338
+          },
+          "type": "Other",
+          "enabled": true,
+          "index": 26,
+          "depth": 4
+        },
+        {
+          "depth": 4,
+          "hittable": true,
+          "parentIndex": 6,
+          "rect": {
+            "height": 52,
+            "y": 419.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "type": "Cell",
+          "enabled": true,
+          "index": 27,
+          "label": "row 5"
+        },
+        {
+          "rect": {
+            "height": 52,
+            "y": 419.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "parentIndex": 27,
+          "hittable": true,
+          "enabled": true,
+          "depth": 5,
+          "type": "Other",
+          "index": 28
+        },
+        {
+          "index": 29,
+          "rect": {
+            "height": 52,
+            "y": 419.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "parentIndex": 27,
+          "hittable": true,
+          "enabled": true,
+          "depth": 5,
+          "label": "row 5",
+          "type": "Other"
+        },
+        {
+          "index": 30,
+          "rect": {
+            "height": 52,
+            "y": 419.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "parentIndex": 29,
+          "identifier": "fixture_row_5",
+          "hittable": true,
+          "enabled": true,
+          "depth": 6,
+          "label": "row 5",
+          "type": "StaticText"
+        },
+        {
+          "rect": {
+            "height": 1,
+            "y": 418.66666666666663,
+            "x": 32,
+            "width": 338
+          },
+          "parentIndex": 6,
+          "hittable": true,
+          "enabled": true,
+          "depth": 4,
+          "type": "Other",
+          "index": 31
+        },
+        {
+          "index": 32,
+          "rect": {
+            "height": 52,
+            "y": 471.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "parentIndex": 6,
+          "hittable": true,
+          "enabled": true,
+          "depth": 4,
+          "label": "row 6",
+          "type": "Cell"
+        },
+        {
+          "rect": {
+            "height": 52,
+            "y": 471.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "parentIndex": 32,
+          "hittable": true,
+          "enabled": true,
+          "depth": 5,
+          "type": "Other",
+          "index": 33
+        },
+        {
+          "index": 34,
+          "rect": {
+            "height": 52,
+            "y": 471.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "parentIndex": 32,
+          "hittable": true,
+          "enabled": true,
+          "depth": 5,
+          "label": "row 6",
+          "type": "Other"
+        },
+        {
+          "index": 35,
+          "rect": {
+            "height": 52,
+            "y": 471.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "parentIndex": 34,
+          "identifier": "fixture_row_6",
+          "hittable": true,
+          "enabled": true,
+          "depth": 6,
+          "label": "row 6",
+          "type": "StaticText"
+        },
+        {
+          "rect": {
+            "height": 1,
+            "y": 470.66666666666663,
+            "x": 32,
+            "width": 338
+          },
+          "parentIndex": 6,
+          "hittable": true,
+          "enabled": true,
+          "depth": 4,
+          "type": "Other",
+          "index": 36
+        },
+        {
+          "index": 37,
+          "rect": {
+            "height": 52,
+            "y": 523.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "parentIndex": 6,
+          "hittable": true,
+          "enabled": true,
+          "depth": 4,
+          "label": "row 7",
+          "type": "Cell"
+        },
+        {
+          "rect": {
+            "height": 52,
+            "y": 523.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "parentIndex": 37,
+          "hittable": true,
+          "enabled": true,
+          "depth": 5,
+          "type": "Other",
+          "index": 38
+        },
+        {
+          "index": 39,
+          "rect": {
+            "height": 52,
+            "y": 523.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "parentIndex": 37,
+          "hittable": true,
+          "enabled": true,
+          "depth": 5,
+          "label": "row 7",
+          "type": "Other"
+        },
+        {
+          "index": 40,
+          "rect": {
+            "height": 52,
+            "y": 523.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "parentIndex": 39,
+          "identifier": "fixture_row_7",
+          "hittable": true,
+          "enabled": true,
+          "depth": 6,
+          "label": "row 7",
+          "type": "StaticText"
+        },
+        {
+          "rect": {
+            "height": 1,
+            "y": 522.6666666666666,
+            "x": 32,
+            "width": 338
+          },
+          "parentIndex": 6,
+          "hittable": true,
+          "enabled": true,
+          "depth": 4,
+          "type": "Other",
+          "index": 41
+        },
+        {
+          "index": 42,
+          "rect": {
+            "height": 52,
+            "y": 575.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "parentIndex": 6,
+          "hittable": true,
+          "enabled": true,
+          "depth": 4,
+          "label": "row 8",
+          "type": "Cell"
+        },
+        {
+          "rect": {
+            "x": 16,
+            "width": 370,
+            "y": 575.6666666666666,
+            "height": 52
+          },
+          "parentIndex": 42,
+          "hittable": true,
+          "enabled": true,
+          "depth": 5,
+          "type": "Other",
+          "index": 43
+        },
+        {
+          "index": 44,
+          "rect": {
+            "height": 52,
+            "x": 16,
+            "y": 575.6666666666666,
+            "width": 370
+          },
+          "parentIndex": 42,
+          "hittable": true,
+          "enabled": true,
+          "depth": 5,
+          "label": "row 8",
+          "type": "Other"
+        },
+        {
+          "label": "row 8",
+          "rect": {
+            "width": 370,
+            "y": 575.6666666666666,
+            "height": 52,
+            "x": 16
+          },
+          "parentIndex": 44,
+          "identifier": "fixture_row_8",
+          "hittable": true,
+          "enabled": true,
+          "depth": 6,
+          "type": "StaticText",
+          "index": 45
+        },
+        {
+          "rect": {
+            "width": 338,
+            "y": 574.6666666666666,
+            "height": 1,
+            "x": 32
+          },
+          "parentIndex": 6,
+          "hittable": true,
+          "enabled": true,
+          "depth": 4,
+          "type": "Other",
+          "index": 46
+        },
+        {
+          "label": "row 9",
+          "rect": {
+            "width": 370,
+            "y": 627.6666666666666,
+            "height": 52,
+            "x": 16
+          },
+          "parentIndex": 6,
+          "hittable": true,
+          "enabled": true,
+          "depth": 4,
+          "type": "Cell",
+          "index": 47
+        },
+        {
+          "rect": {
+            "width": 370,
+            "y": 627.6666666666666,
+            "height": 52,
+            "x": 16
+          },
+          "parentIndex": 47,
+          "hittable": true,
+          "enabled": true,
+          "depth": 5,
+          "type": "Other",
+          "index": 48
+        },
+        {
+          "index": 49,
+          "rect": {
+            "width": 370,
+            "y": 627.6666666666666,
+            "height": 52,
+            "x": 16
+          },
+          "label": "row 9",
+          "type": "Other",
+          "enabled": true,
+          "depth": 5,
+          "hittable": true,
+          "parentIndex": 47
+        },
+        {
+          "index": 50,
+          "rect": {
+            "width": 370,
+            "y": 627.6666666666666,
+            "height": 52,
+            "x": 16
+          },
+          "label": "row 9",
+          "parentIndex": 49,
+          "type": "StaticText",
+          "enabled": true,
+          "identifier": "fixture_row_9",
+          "hittable": true,
+          "depth": 6
+        },
+        {
+          "index": 51,
+          "rect": {
+            "width": 338,
+            "y": 626.6666666666666,
+            "height": 1,
+            "x": 32
+          },
+          "type": "Other",
+          "enabled": true,
+          "depth": 4,
+          "hittable": true,
+          "parentIndex": 6
+        },
+        {
+          "index": 52,
+          "rect": {
+            "width": 370,
+            "y": 679.6666666666666,
+            "height": 52,
+            "x": 16
+          },
+          "label": "row 10",
+          "type": "Cell",
+          "enabled": true,
+          "depth": 4,
+          "hittable": true,
+          "parentIndex": 6
+        },
+        {
+          "index": 53,
+          "rect": {
+            "width": 370,
+            "y": 679.6666666666666,
+            "height": 52,
+            "x": 16
+          },
+          "type": "Other",
+          "enabled": true,
+          "depth": 5,
+          "hittable": true,
+          "parentIndex": 52
+        },
+        {
+          "index": 54,
+          "rect": {
+            "width": 370,
+            "y": 679.6666666666666,
+            "height": 52,
+            "x": 16
+          },
+          "label": "row 10",
+          "type": "Other",
+          "enabled": true,
+          "depth": 5,
+          "hittable": true,
+          "parentIndex": 52
+        },
+        {
+          "index": 55,
+          "rect": {
+            "width": 370,
+            "y": 679.6666666666666,
+            "height": 52,
+            "x": 16
+          },
+          "label": "row 10",
+          "parentIndex": 54,
+          "type": "StaticText",
+          "enabled": true,
+          "identifier": "fixture_row_10",
+          "hittable": true,
+          "depth": 6
+        },
+        {
+          "index": 56,
+          "rect": {
+            "width": 338,
+            "y": 678.6666666666666,
+            "height": 1,
+            "x": 32
+          },
+          "type": "Other",
+          "enabled": true,
+          "depth": 4,
+          "hittable": true,
+          "parentIndex": 6
+        },
+        {
+          "index": 57,
+          "rect": {
+            "width": 370,
+            "y": 731.6666666666666,
+            "height": 52,
+            "x": 16
+          },
+          "label": "row 11",
+          "type": "Cell",
+          "enabled": true,
+          "depth": 4,
+          "hittable": true,
+          "parentIndex": 6
+        },
+        {
+          "index": 58,
+          "rect": {
+            "width": 370,
+            "y": 731.6666666666666,
+            "height": 52,
+            "x": 16
+          },
+          "type": "Other",
+          "enabled": true,
+          "depth": 5,
+          "hittable": true,
+          "parentIndex": 57
+        },
+        {
+          "index": 59,
+          "rect": {
+            "width": 370,
+            "y": 731.6666666666666,
+            "height": 52,
+            "x": 16
+          },
+          "label": "row 11",
+          "type": "Other",
+          "enabled": true,
+          "depth": 5,
+          "hittable": true,
+          "parentIndex": 57
+        },
+        {
+          "index": 60,
+          "rect": {
+            "width": 370,
+            "y": 731.6666666666666,
+            "height": 52,
+            "x": 16
+          },
+          "label": "row 11",
+          "parentIndex": 59,
+          "type": "StaticText",
+          "enabled": true,
+          "identifier": "fixture_row_11",
+          "hittable": true,
+          "depth": 6
+        },
+        {
+          "index": 61,
+          "rect": {
+            "width": 338,
+            "y": 730.6666666666666,
+            "height": 1,
+            "x": 32
+          },
+          "type": "Other",
+          "enabled": true,
+          "depth": 4,
+          "hittable": true,
+          "parentIndex": 6
+        },
+        {
+          "index": 62,
+          "rect": {
+            "width": 30,
+            "y": 176.66666666666666,
+            "height": 577,
+            "x": 369
+          },
+          "label": "Vertical scroll bar, 10 pages",
+          "parentIndex": 6,
+          "type": "Other",
+          "enabled": true,
+          "depth": 4,
+          "hittable": true,
+          "value": "0 %"
+        },
+        {
+          "index": 63,
+          "rect": {
+            "width": 3,
+            "y": 179.66666666666666,
+            "height": 62.66666666666666,
+            "x": 396
+          },
+          "type": "Other",
+          "enabled": true,
+          "depth": 5,
+          "hittable": true,
+          "parentIndex": 62
+        },
+        {
+          "index": 64,
+          "rect": {
+            "width": 334.3333333333333,
+            "y": 761.6666666666666,
+            "height": 34,
+            "x": 16
+          },
+          "parentIndex": 2,
+          "type": "TextField",
+          "enabled": true,
+          "identifier": "fixture_bottom_input",
+          "hittable": true,
+          "depth": 3
+        },
+        {
+          "index": 65,
+          "rect": {
+            "width": 27.666666666666686,
+            "y": 768.6666666666666,
+            "height": 20.33333333333337,
+            "x": 358.3333333333333
+          },
+          "label": "Tap",
+          "parentIndex": 2,
+          "type": "Button",
+          "enabled": true,
+          "identifier": "fixture_bottom_button",
+          "hittable": true,
+          "depth": 3
+        },
+        {
+          "index": 66,
+          "rect": {
+            "width": 111.66666666666669,
+            "y": 803.6666666666666,
+            "height": 20.33333333333337,
+            "x": 145.16666666666669
+          },
+          "label": "bottom taps: 0",
+          "parentIndex": 2,
+          "type": "StaticText",
+          "enabled": true,
+          "identifier": "fixture_bottom_count",
+          "hittable": true,
+          "depth": 3
+        }
+      ],
+      "truncated": false
+    }
+  }
+}

--- a/packages/rn-dev-agent-core/test/fixtures/goldens/ios/health.json
+++ b/packages/rn-dev-agent-core/test/fixtures/goldens/ios/health.json
@@ -1,0 +1,54 @@
+{
+  "_provenance": {
+    "capturedAt": "2026-07-11T15:56:58.558Z",
+    "capturedBy": "test/contract/capture-goldens.ts — captured, never hand-edit",
+    "recapture": "re-run when RUNNER_PROTOCOL_VERSION bumps or the runner wire shape changes (GOLDEN_PLATFORM=ios node test/contract/capture-goldens.ts)",
+    "platform": "ios",
+    "device": "iPhone 17 (3C6085C0-2F72-4C82-87AF-5F2807AC55F1)",
+    "os": "iOS-26-5",
+    "appId": "dev.lykhoyda.rndevagent.fixture",
+    "httpStatus": 200,
+    "runnerVersion": "0.67.0",
+    "protocolVersion": 1,
+    "runnerPort": 22088
+  },
+  "payload": {
+    "v": 1,
+    "protocolVersion": 1,
+    "capabilities": [
+      "QUIESCENCE_BYPASS",
+      "SCREEN_STATIC",
+      "HONEST_HITTABLE"
+    ],
+    "ok": true,
+    "commands": [
+      "tap",
+      "mouseClick",
+      "tapSeries",
+      "longPress",
+      "interactionFrame",
+      "drag",
+      "dragSeries",
+      "remotePress",
+      "type",
+      "swipe",
+      "findText",
+      "readText",
+      "snapshot",
+      "screenshot",
+      "back",
+      "backInApp",
+      "backSystem",
+      "home",
+      "rotate",
+      "appSwitcher",
+      "keyboardDismiss",
+      "alert",
+      "pinch",
+      "isScreenStatic",
+      "uptime",
+      "shutdown"
+    ],
+    "runnerVersion": "0.67.0"
+  }
+}

--- a/packages/rn-dev-agent-core/test/fixtures/goldens/ios/tool-envelope-snapshot.json
+++ b/packages/rn-dev-agent-core/test/fixtures/goldens/ios/tool-envelope-snapshot.json
@@ -1,0 +1,608 @@
+{
+  "_provenance": {
+    "capturedAt": "2026-07-11T15:56:58.903Z",
+    "capturedBy": "test/contract/capture-goldens.ts — captured, never hand-edit",
+    "recapture": "re-run when RUNNER_PROTOCOL_VERSION bumps or the runner wire shape changes (GOLDEN_PLATFORM=ios node test/contract/capture-goldens.ts)",
+    "platform": "ios",
+    "device": "iPhone 17 (3C6085C0-2F72-4C82-87AF-5F2807AC55F1)",
+    "os": "iOS-26-5",
+    "appId": "dev.lykhoyda.rndevagent.fixture",
+    "httpStatus": 200,
+    "runnerVersion": "0.67.0",
+    "protocolVersion": 1,
+    "runnerPort": 22088,
+    "note": "bridge device_snapshot envelope (post-mapping FlatNode layer)"
+  },
+  "payload": {
+    "ok": true,
+    "data": {
+      "nodes": [
+        {
+          "ref": "@e0",
+          "type": "Application",
+          "rect": {
+            "width": 402,
+            "height": 874,
+            "x": 0,
+            "y": 0
+          },
+          "label": "Fixture",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e1",
+          "type": "Other",
+          "rect": {
+            "width": 402,
+            "height": 874,
+            "x": 0,
+            "y": 0
+          },
+          "label": "Increment",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e2",
+          "type": "Button",
+          "rect": {
+            "width": 76.66666666666666,
+            "height": 20.33333333333333,
+            "x": 162.66666666666666,
+            "y": 78
+          },
+          "label": "Increment",
+          "identifier": "fixture_button",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e3",
+          "type": "StaticText",
+          "rect": {
+            "width": 62.66666666666666,
+            "height": 20.33333333333333,
+            "x": 169.66666666666666,
+            "y": 106.33333333333339
+          },
+          "label": "count: 0",
+          "identifier": "fixture_count",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e4",
+          "type": "TextField",
+          "rect": {
+            "width": 370,
+            "height": 34,
+            "x": 16,
+            "y": 134.66666666666666
+          },
+          "identifier": "fixture_input",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e5",
+          "type": "CollectionView",
+          "rect": {
+            "width": 402,
+            "height": 577,
+            "x": 0,
+            "y": 176.66666666666666
+          },
+          "label": "Vertical scroll bar, 10 pages",
+          "identifier": "fixture_list",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e6",
+          "type": "Cell",
+          "rect": {
+            "width": 370,
+            "height": 51.99999999999997,
+            "x": 16,
+            "y": 211.66666666666666
+          },
+          "label": "row 1",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e7",
+          "type": "Other",
+          "rect": {
+            "width": 370,
+            "height": 51.99999999999997,
+            "x": 16,
+            "y": 211.66666666666666
+          },
+          "label": "row 1",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e8",
+          "type": "StaticText",
+          "rect": {
+            "width": 370,
+            "height": 51.99999999999997,
+            "x": 16,
+            "y": 211.66666666666666
+          },
+          "label": "row 1",
+          "identifier": "fixture_row_1",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e9",
+          "type": "Cell",
+          "rect": {
+            "width": 370,
+            "height": 52,
+            "x": 16,
+            "y": 263.66666666666663
+          },
+          "label": "row 2",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e10",
+          "type": "Other",
+          "rect": {
+            "width": 370,
+            "height": 52,
+            "x": 16,
+            "y": 263.66666666666663
+          },
+          "label": "row 2",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e11",
+          "type": "StaticText",
+          "rect": {
+            "width": 370,
+            "height": 52,
+            "x": 16,
+            "y": 263.66666666666663
+          },
+          "label": "row 2",
+          "identifier": "fixture_row_2",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e12",
+          "type": "Cell",
+          "rect": {
+            "width": 370,
+            "height": 52,
+            "x": 16,
+            "y": 315.66666666666663
+          },
+          "label": "row 3",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e13",
+          "type": "Other",
+          "rect": {
+            "width": 370,
+            "height": 52,
+            "x": 16,
+            "y": 315.66666666666663
+          },
+          "label": "row 3",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e14",
+          "type": "StaticText",
+          "rect": {
+            "width": 370,
+            "height": 52,
+            "x": 16,
+            "y": 315.66666666666663
+          },
+          "label": "row 3",
+          "identifier": "fixture_row_3",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e15",
+          "type": "Cell",
+          "rect": {
+            "height": 52,
+            "y": 367.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 4",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e16",
+          "type": "Other",
+          "rect": {
+            "height": 52,
+            "y": 367.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 4",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e17",
+          "type": "StaticText",
+          "rect": {
+            "height": 52,
+            "y": 367.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 4",
+          "identifier": "fixture_row_4",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e18",
+          "type": "Cell",
+          "rect": {
+            "height": 52,
+            "y": 419.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 5",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e19",
+          "type": "Other",
+          "rect": {
+            "height": 52,
+            "y": 419.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 5",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e20",
+          "type": "StaticText",
+          "rect": {
+            "height": 52,
+            "y": 419.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 5",
+          "identifier": "fixture_row_5",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e21",
+          "type": "Cell",
+          "rect": {
+            "height": 52,
+            "y": 471.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 6",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e22",
+          "type": "Other",
+          "rect": {
+            "height": 52,
+            "y": 471.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 6",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e23",
+          "type": "StaticText",
+          "rect": {
+            "height": 52,
+            "y": 471.66666666666663,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 6",
+          "identifier": "fixture_row_6",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e24",
+          "type": "Cell",
+          "rect": {
+            "height": 52,
+            "y": 523.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 7",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e25",
+          "type": "Other",
+          "rect": {
+            "height": 52,
+            "y": 523.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 7",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e26",
+          "type": "StaticText",
+          "rect": {
+            "height": 52,
+            "y": 523.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 7",
+          "identifier": "fixture_row_7",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e27",
+          "type": "Cell",
+          "rect": {
+            "height": 52,
+            "y": 575.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 8",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e28",
+          "type": "Other",
+          "rect": {
+            "height": 52,
+            "y": 575.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 8",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e29",
+          "type": "StaticText",
+          "rect": {
+            "height": 52,
+            "y": 575.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 8",
+          "identifier": "fixture_row_8",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e30",
+          "type": "Cell",
+          "rect": {
+            "height": 52,
+            "y": 627.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 9",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e31",
+          "type": "Other",
+          "rect": {
+            "height": 52,
+            "y": 627.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 9",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e32",
+          "type": "StaticText",
+          "rect": {
+            "height": 52,
+            "y": 627.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 9",
+          "identifier": "fixture_row_9",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e33",
+          "type": "Cell",
+          "rect": {
+            "height": 52,
+            "y": 679.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 10",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e34",
+          "type": "Other",
+          "rect": {
+            "height": 52,
+            "y": 679.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 10",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e35",
+          "type": "StaticText",
+          "rect": {
+            "height": 52,
+            "y": 679.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 10",
+          "identifier": "fixture_row_10",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e36",
+          "type": "Cell",
+          "rect": {
+            "height": 52,
+            "y": 731.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 11",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e37",
+          "type": "Other",
+          "rect": {
+            "height": 52,
+            "y": 731.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 11",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e38",
+          "type": "StaticText",
+          "rect": {
+            "height": 52,
+            "y": 731.6666666666666,
+            "x": 16,
+            "width": 370
+          },
+          "label": "row 11",
+          "identifier": "fixture_row_11",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e39",
+          "type": "Other",
+          "rect": {
+            "height": 577,
+            "y": 176.66666666666666,
+            "x": 369,
+            "width": 30
+          },
+          "label": "Vertical scroll bar, 10 pages",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e40",
+          "type": "TextField",
+          "rect": {
+            "height": 34,
+            "y": 761.6666666666666,
+            "x": 16,
+            "width": 334.3333333333333
+          },
+          "identifier": "fixture_bottom_input",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e41",
+          "type": "Button",
+          "rect": {
+            "height": 20.33333333333337,
+            "y": 768.6666666666666,
+            "x": 358.3333333333333,
+            "width": 27.666666666666686
+          },
+          "label": "Tap",
+          "identifier": "fixture_bottom_button",
+          "enabled": true,
+          "hittable": true
+        },
+        {
+          "ref": "@e42",
+          "type": "StaticText",
+          "rect": {
+            "height": 20.33333333333337,
+            "y": 803.6666666666666,
+            "x": 145.16666666666669,
+            "width": 111.66666666666669
+          },
+          "label": "bottom taps: 0",
+          "identifier": "fixture_bottom_count",
+          "enabled": true,
+          "hittable": true
+        }
+      ]
+    },
+    "meta": {
+      "quiescenceBypass": "active",
+      "snapshotVerdict": {
+        "state": "ok",
+        "source": "rn-fast-runner",
+        "nodeCount": 43,
+        "refMapUpdated": true,
+        "reasons": []
+      }
+    }
+  }
+}

--- a/packages/rn-dev-agent-core/test/unit/gh-437-golden-contract.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-437-golden-contract.test.ts
@@ -1,0 +1,196 @@
+// GH #437 (test-confidence audit P0-B): contract tests over CAPTURED golden
+// runner payloads. The escaped-bug cluster this closes — #396 (envelope test
+// pinned the buggy `@@` passthrough), #353 (oracle tests fed bare nodes
+// instead of the real `.tree`-wrapped payload), #418 (command-enum additions
+// invisible to the protocol gate) — was hand-written fixtures encoding the
+// WRONG wire shape. These fixtures are captured from live runners by
+// test/contract/capture-goldens.ts; the `v`-stamp test below forces a
+// re-capture whenever RUNNER_PROTOCOL_VERSION bumps.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  REQUIRED_IOS_COMMANDS,
+  REQUIRED_ANDROID_COMMANDS,
+  RUNNER_PROTOCOL_VERSION,
+  classifyRunnerCompatibility,
+} from '../../dist/runners/protocol.js';
+import { findRefByTestID, snapshotEnvelopeFailed } from '../../dist/tools/device-batch.js';
+import { updateRefMapFromFlat, buildSnapshotVerdict } from '../../dist/fast-runner-ref-map.js';
+
+const GOLDENS_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures', 'goldens');
+
+interface Golden {
+  _provenance: {
+    capturedAt?: string;
+    capturedBy?: string;
+    platform?: string;
+    runnerVersion?: string;
+    protocolVersion?: number;
+  };
+  payload: any;
+}
+
+interface HealthPayload {
+  ok?: boolean;
+  protocolVersion?: number;
+  runnerVersion?: string;
+  commands?: string[];
+}
+
+function loadGolden(platform: string, name: string): Golden {
+  const path = join(GOLDENS_DIR, platform, name);
+  return JSON.parse(readFileSync(path, 'utf8')) as Golden;
+}
+
+const PLATFORMS = [
+  { platform: 'ios', required: REQUIRED_IOS_COMMANDS, source: 'rn-fast-runner' },
+  { platform: 'android', required: REQUIRED_ANDROID_COMMANDS, source: 'rn-android-runner' },
+] as const;
+
+const GOLDEN_NAMES = [
+  'health.json',
+  'command-snapshot.json',
+  'command-error.json',
+  'tool-envelope-snapshot.json',
+];
+
+// Anchors the whole suite: identifiers the contract fixture app is REQUIRED
+// to expose (test-fixtures/*/README.md golden-set roles).
+const FIXTURE_TESTIDS = ['fixture_button', 'fixture_count', 'fixture_input'];
+
+for (const { platform, required, source } of PLATFORMS) {
+  test(`gh-437 ${platform}: goldens carry capture provenance, never hand-written`, () => {
+    for (const name of GOLDEN_NAMES) {
+      const g = loadGolden(platform, name);
+      assert.ok(g._provenance, `${name} missing _provenance — goldens must be captured`);
+      assert.ok(g._provenance.capturedAt, `${name} missing _provenance.capturedAt`);
+      assert.match(
+        g._provenance.capturedBy ?? '',
+        /capture-goldens/,
+        `${name} not stamped by the capture script`,
+      );
+      assert.equal(g._provenance.platform, platform);
+      assert.ok(g.payload !== undefined, `${name} missing payload`);
+    }
+  });
+
+  test(`gh-437 ${platform}: captured /health classifies as compatible`, () => {
+    const health = loadGolden(platform, 'health.json').payload as HealthPayload;
+    const verdict = classifyRunnerCompatibility(health, null, required);
+    assert.deepEqual(
+      verdict,
+      { compatible: true },
+      `captured ${platform} health must satisfy the liveness gate: ${JSON.stringify(verdict)}`,
+    );
+  });
+
+  test(`gh-437 ${platform}: captured /health advertises every REQUIRED command`, () => {
+    const health = loadGolden(platform, 'health.json').payload as HealthPayload;
+    const advertised = new Set(health.commands ?? []);
+    const missing = required.filter((c) => !advertised.has(c));
+    assert.deepEqual(
+      missing,
+      [],
+      `${platform} runner artifact does not advertise: ${missing.join(', ')}`,
+    );
+  });
+
+  test(`gh-437 ${platform}: classifier rejections derive correctly from the real payload`, () => {
+    const health = loadGolden(platform, 'health.json').payload as HealthPayload;
+
+    const legacy = classifyRunnerCompatibility({ ...health, protocolVersion: undefined }, null);
+    assert.deepEqual(legacy, { compatible: false, reason: 'legacy' });
+
+    const newer = classifyRunnerCompatibility(
+      { ...health, protocolVersion: RUNNER_PROTOCOL_VERSION + 1 },
+      null,
+    );
+    assert.deepEqual(newer, { compatible: false, reason: 'protocol-newer' });
+
+    const [firstRequired] = required;
+    const gutted = classifyRunnerCompatibility(
+      { ...health, commands: (health.commands ?? []).filter((c) => c !== firstRequired) },
+      null,
+      required,
+    );
+    assert.deepEqual(gutted, {
+      compatible: false,
+      reason: 'missing-commands',
+      missing: [firstRequired],
+    });
+
+    assert.ok(health.runnerVersion, `${platform} health golden must carry runnerVersion`);
+    const skew = classifyRunnerCompatibility(health, `${health.runnerVersion}-not`);
+    assert.deepEqual(skew, { compatible: false, reason: 'version-skew' });
+  });
+
+  test(`gh-437 ${platform}: raw snapshot wire stamp matches RUNNER_PROTOCOL_VERSION`, () => {
+    const snap = loadGolden(platform, 'command-snapshot.json').payload;
+    assert.equal(
+      snap.v,
+      RUNNER_PROTOCOL_VERSION,
+      `golden captured at wire v${snap.v}, bridge now speaks v${RUNNER_PROTOCOL_VERSION} — ` +
+        're-capture the goldens against the current runner (see capture-goldens.ts header)',
+    );
+  });
+
+  test(`gh-437 ${platform}: raw snapshot carries a well-formed node array`, () => {
+    const snap = loadGolden(platform, 'command-snapshot.json').payload;
+    assert.equal(snap.ok, true);
+    assert.ok(Array.isArray(snap.data?.nodes), 'raw snapshot data.nodes must be an array');
+    assert.ok(snap.data.nodes.length > 0, 'raw snapshot must not be empty');
+    for (const node of snap.data.nodes) {
+      if (node.rect === undefined) continue;
+      for (const k of ['x', 'y', 'width', 'height']) {
+        assert.equal(
+          typeof node.rect[k],
+          'number',
+          `node rect.${k} must be numeric: ${JSON.stringify(node).slice(0, 200)}`,
+        );
+      }
+    }
+    const identifiers = new Set(
+      snap.data.nodes.map((n: { identifier?: string }) => n.identifier).filter(Boolean),
+    );
+    for (const id of FIXTURE_TESTIDS) {
+      assert.ok(identifiers.has(id), `raw ${platform} snapshot missing fixture testID ${id}`);
+    }
+  });
+
+  test(`gh-437 ${platform}: captured error envelope keeps the error contract`, () => {
+    const err = loadGolden(platform, 'command-error.json').payload;
+    assert.equal(err.ok, false, 'unknown verb must produce ok:false');
+    assert.equal(typeof err.error?.message, 'string');
+    assert.ok(err.error.message.length > 0, 'error.message must be non-empty');
+    if (err.v !== undefined) assert.equal(err.v, RUNNER_PROTOCOL_VERSION);
+  });
+
+  test(`gh-437 ${platform}: findRefByTestID resolves fixture testIDs from the tool envelope`, () => {
+    const envelope = loadGolden(platform, 'tool-envelope-snapshot.json').payload;
+    const text = JSON.stringify(envelope);
+    assert.equal(snapshotEnvelopeFailed(text), false);
+    for (const id of FIXTURE_TESTIDS) {
+      const ref = findRefByTestID(text, id);
+      assert.ok(ref, `findRefByTestID(${id}) resolved nothing on ${platform}`);
+      // GH #396 regression contract: bare id, never a passed-through '@'.
+      assert.match(ref, /^e\d+$/, `ref must be bare (no @): got "${ref}"`);
+    }
+  });
+
+  test(`gh-437 ${platform}: tool-envelope nodes drive the ref-map oracle to an ok verdict`, () => {
+    const envelope = loadGolden(platform, 'tool-envelope-snapshot.json').payload;
+    const nodes = envelope.data?.nodes;
+    assert.ok(Array.isArray(nodes) && nodes.length > 0, 'tool envelope must carry nodes');
+    for (const node of nodes) {
+      assert.match(node.ref ?? '', /^@e\d+$/, `envelope ref malformed: ${JSON.stringify(node)}`);
+    }
+    const outcome = updateRefMapFromFlat(nodes);
+    assert.equal(outcome.applied, true, `real capture must update the ref map: ${outcome.reason}`);
+    const verdict = buildSnapshotVerdict(source, nodes.length, outcome);
+    assert.equal(verdict.state, 'ok');
+    assert.equal(verdict.refMapUpdated, true);
+  });
+}


### PR DESCRIPTION
Closes #437 (test-confidence audit P0-B).

## Problem

The biggest escaped-bug cluster is host↔runner wire-contract drift where hand-written fixtures encoded the WRONG shape, so green tests certified broken behavior: #396 (envelope test pinned the buggy `@@` passthrough), #353 (oracle tests fed bare nodes instead of the real `.tree`-wrapped payload), #418 (command-enum additions invisible to the protocol gate).

## What this ships

1. **`test/contract/capture-goldens.ts`** — with a live device session, records real `/health`, raw `POST /command snapshot` (pre-mapping `RunnerSnapshotNode` wire shape), a deliberate unknown-verb error envelope, and the bridge's own `device_snapshot` envelope (post-mapping `FlatNode` layer) into committed fixtures under `test/fixtures/goldens/<platform>/`. Every fixture carries a provenance header (device, OS, runner version, capture date, re-capture instructions). **Captured, never hand-written.** The runner port is pinned to the exact device the session opened on (state-file key `<platform>-<udid|serial>`), raw HTTP calls carry abort timeouts, success payloads are asserted healthy before overwriting a golden, and the session closes from the failure path too.
2. **`test/unit/gh-437-golden-contract.test.ts`** — 18 contract tests validating the TS parsing layer against the captured payloads for BOTH platforms: `classifyRunnerCompatibility` (compatible on real health + derived legacy / protocol-newer / missing-commands / version-skew rejections), `findRefByTestID` (resolves the fixture app's testIDs, bare-ref #396 regression contract), `snapshotEnvelopeFailed`, and the ref-map oracle (`updateRefMapFromFlat` → `buildSnapshotVerdict` ok).
3. **Refresh cadence, enforced** — the raw snapshot golden's `v` stamp is pinned to `RUNNER_PROTOCOL_VERSION`: a protocol bump fails CI until goldens are re-captured against the new runner.
4. **Named CI gate** — new `Runner wire-contract gate` step runs the #418 tri-surface command-enum sync, the #383 protocol sync, and the golden contracts via `yarn workspace rn-dev-agent-core test:contract`, placed BEFORE the unit blob so contract drift fails under the gate's name.

## Capture provenance

Goldens captured live in one session per platform: iPhone 17 / iOS 26.5 simulator and Pixel 9 Pro emulator (Android 16), fixture app `dev.lykhoyda.rndevagent.fixture` (the Story 06 contract fixture), runner 0.67.0, protocol v1.

## Verification

- `test:contract` gate: 27/27 (gh-383 sync + gh-418 sync + 18 golden contracts)
- Full unit suite: 3112/3112
- Capture script re-run end-to-end on both platforms after review hardening (device-pinned port discovery, HTTP timeouts, healthy-payload assertions, close-in-finally)
- Local gates: oxlint, oxfmt, typescript-only, dist-fresh, agent-package-sync all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RKLei35BHPzghheSA4eoa