### PR TITLE
fix(observe): recorder reads only capture-granted screenshot paths, fd-bound (#429)

### DIFF
--- a/.changeset/recorder-shot-hardening.md
+++ b/.changeset/recorder-shot-hardening.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-core": patch
+"rn-dev-agent-plugin": patch
+---
+
+Harden observe-recorder screenshot ingestion (GH #429): the recorder now only reads screenshot files the capture pipeline itself just wrote (single-use trust grants registered by `device_screenshot`), instead of any absolute image path named in a tool observation — closing an arbitrary local-file read surface on the observe server. The read itself is now TOCTOU-safe: one descriptor for the size check and the read, `O_NOFOLLOW` (no symlink following), and a hard byte cap enforced on the bytes actually read.

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -424,11 +424,11 @@ var require_codegen = __commonJS({
         const rhs = this.rhs === void 0 ? "" : ` = ${this.rhs}`;
         return `${varKind} ${this.name}${rhs};` + _n;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         if (!names[this.name.str])
           return;
         if (this.rhs)
-          this.rhs = optimizeExpr(this.rhs, names, constants);
+          this.rhs = optimizeExpr(this.rhs, names, constants2);
         return this;
       }
       get names() {
@@ -445,10 +445,10 @@ var require_codegen = __commonJS({
       render({ _n }) {
         return `${this.lhs} = ${this.rhs};` + _n;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         if (this.lhs instanceof code_1.Name && !names[this.lhs.str] && !this.sideEffects)
           return;
-        this.rhs = optimizeExpr(this.rhs, names, constants);
+        this.rhs = optimizeExpr(this.rhs, names, constants2);
         return this;
       }
       get names() {
@@ -509,8 +509,8 @@ var require_codegen = __commonJS({
       optimizeNodes() {
         return `${this.code}` ? this : void 0;
       }
-      optimizeNames(names, constants) {
-        this.code = optimizeExpr(this.code, names, constants);
+      optimizeNames(names, constants2) {
+        this.code = optimizeExpr(this.code, names, constants2);
         return this;
       }
       get names() {
@@ -539,12 +539,12 @@ var require_codegen = __commonJS({
         }
         return nodes.length > 0 ? this : void 0;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         const { nodes } = this;
         let i = nodes.length;
         while (i--) {
           const n = nodes[i];
-          if (n.optimizeNames(names, constants))
+          if (n.optimizeNames(names, constants2))
             continue;
           subtractNames(names, n.names);
           nodes.splice(i, 1);
@@ -597,12 +597,12 @@ var require_codegen = __commonJS({
           return void 0;
         return this;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         var _a;
-        this.else = (_a = this.else) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants);
-        if (!(super.optimizeNames(names, constants) || this.else))
+        this.else = (_a = this.else) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants2);
+        if (!(super.optimizeNames(names, constants2) || this.else))
           return;
-        this.condition = optimizeExpr(this.condition, names, constants);
+        this.condition = optimizeExpr(this.condition, names, constants2);
         return this;
       }
       get names() {
@@ -625,10 +625,10 @@ var require_codegen = __commonJS({
       render(opts) {
         return `for(${this.iteration})` + super.render(opts);
       }
-      optimizeNames(names, constants) {
-        if (!super.optimizeNames(names, constants))
+      optimizeNames(names, constants2) {
+        if (!super.optimizeNames(names, constants2))
           return;
-        this.iteration = optimizeExpr(this.iteration, names, constants);
+        this.iteration = optimizeExpr(this.iteration, names, constants2);
         return this;
       }
       get names() {
@@ -664,10 +664,10 @@ var require_codegen = __commonJS({
       render(opts) {
         return `for(${this.varKind} ${this.name} ${this.loop} ${this.iterable})` + super.render(opts);
       }
-      optimizeNames(names, constants) {
-        if (!super.optimizeNames(names, constants))
+      optimizeNames(names, constants2) {
+        if (!super.optimizeNames(names, constants2))
           return;
-        this.iterable = optimizeExpr(this.iterable, names, constants);
+        this.iterable = optimizeExpr(this.iterable, names, constants2);
         return this;
       }
       get names() {
@@ -709,11 +709,11 @@ var require_codegen = __commonJS({
         (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNodes();
         return this;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         var _a, _b;
-        super.optimizeNames(names, constants);
-        (_a = this.catch) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants);
-        (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNames(names, constants);
+        super.optimizeNames(names, constants2);
+        (_a = this.catch) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants2);
+        (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNames(names, constants2);
         return this;
       }
       get names() {
@@ -1014,7 +1014,7 @@ var require_codegen = __commonJS({
     function addExprNames(names, from) {
       return from instanceof code_1._CodeOrName ? addNames(names, from.names) : names;
     }
-    function optimizeExpr(expr, names, constants) {
+    function optimizeExpr(expr, names, constants2) {
       if (expr instanceof code_1.Name)
         return replaceName(expr);
       if (!canOptimize(expr))
@@ -1029,14 +1029,14 @@ var require_codegen = __commonJS({
         return items;
       }, []));
       function replaceName(n) {
-        const c = constants[n.str];
+        const c = constants2[n.str];
         if (c === void 0 || names[n.str] !== 1)
           return n;
         delete names[n.str];
         return c;
       }
       function canOptimize(e) {
-        return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants[c.str] !== void 0);
+        return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants2[c.str] !== void 0);
       }
     }
     function subtractNames(names, from) {
@@ -26750,7 +26750,7 @@ ensureJavaEnv();
 ensureCwd();
 
 // packages/rn-dev-agent-core/dist/index.js
-import { readFileSync as readFileSync30 } from "node:fs";
+import { readFileSync as readFileSync29 } from "node:fs";
 import { execFile as execFile27 } from "node:child_process";
 import { promisify as promisify28 } from "node:util";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
@@ -49029,7 +49029,7 @@ import { mkdirSync as mkdirSync11 } from "node:fs";
 import { execFile as execFile16 } from "node:child_process";
 import { promisify as promisify17 } from "node:util";
 import { dirname as dirname9, join as join24 } from "node:path";
-import { homedir as homedir8 } from "node:os";
+import { homedir as homedir9 } from "node:os";
 
 // packages/rn-dev-agent-core/dist/tools/device-screenshot-resize.js
 import { execFile as execFileCb13 } from "node:child_process";
@@ -49172,6 +49172,415 @@ function pathHasTraversal(p) {
 
 // packages/rn-dev-agent-core/dist/tools/device-list.js
 init_rn_android_runner_client();
+
+// packages/rn-dev-agent-core/dist/observability/recorder.js
+import { closeSync as closeSync2, constants, fstatSync, openSync as openSync2, readSync } from "node:fs";
+import { isAbsolute as isAbsolute2 } from "node:path";
+
+// packages/rn-dev-agent-core/dist/util/redact.js
+import { homedir as homedir8 } from "node:os";
+var HOME = homedir8();
+var HOME_RE = new RegExp(HOME.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g");
+var SECRET_PATTERNS = [
+  /(?:sk|pk|api|key|token|secret|password|auth)[-_]?[A-Za-z0-9_-]{20,}/gi,
+  /Bearer\s+[A-Za-z0-9_\-./+=]{20,}/g,
+  /ghp_[A-Za-z0-9_]{36}/g,
+  /eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\bxox[baprs]-[A-Za-z0-9-]+\b/g,
+  /\bAIza[0-9A-Za-z\-_]{35}\b/g,
+  // Any private-key label variant: PRIVATE KEY, RSA PRIVATE KEY,
+  // OPENSSH PRIVATE KEY, EC/DSA/ENCRYPTED PRIVATE KEY, ... The old single-word
+  // `(?:RSA |OPENSSH |PRIVATE )?KEY` form never matched multi-word labels like
+  // "RSA PRIVATE KEY" — the most common ssh-keygen header — so keys leaked.
+  /-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----/g
+];
+var KEYED_SECRET_RE = /((?:token|secret|password|passwd|pwd|api[_-]?key|apikey|authorization|auth|access[_-]?token|refresh[_-]?token|client[_-]?secret)["']?\s*[:=]\s*["']?)([^"'\s,;}]{6,})/gi;
+var PII_PATTERNS = [
+  /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
+  // Require separators so bare digit runs (timestamps, latencies, ids) are not
+  // mistaken for phone/SSN numbers (previously `[-.]?`/`[-]?` made them
+  // optional, redacting any 9-10 digit number).
+  /\b\d{3}[-.]\d{3}[-.]\d{4}\b/g,
+  /\b\d{3}-\d{2}-\d{4}\b/g
+];
+var AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
+var MAX_STRING_LENGTH = 2e3;
+function redactString(value) {
+  let result = value.replace(HOME_RE, "~");
+  KEYED_SECRET_RE.lastIndex = 0;
+  result = result.replace(KEYED_SECRET_RE, "$1[REDACTED_SECRET]");
+  for (const pattern of SECRET_PATTERNS) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, "[REDACTED_SECRET]");
+  }
+  for (const pattern of PII_PATTERNS) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, "[PII_REDACTED]");
+  }
+  if (result.length > MAX_STRING_LENGTH) {
+    result = result.slice(0, MAX_STRING_LENGTH) + `[TRUNCATED:${result.length}]`;
+  }
+  return result;
+}
+function redactValue(value, path) {
+  if (value === null || value === void 0)
+    return value;
+  if (typeof value === "string")
+    return redactString(value);
+  if (Array.isArray(value)) {
+    return value.map((item, i) => redactValue(item, `${path}[${i}]`));
+  }
+  if (typeof value === "object") {
+    const obj = value;
+    const result = {};
+    for (const [key, val] of Object.entries(obj)) {
+      const fullPath = path ? `${path}.${key}` : key;
+      if (AUTH_PATHS.test(key)) {
+        result[key] = Array.isArray(val) ? "[REDACTED:array]" : `[REDACTED:${typeof val}]`;
+      } else {
+        result[key] = redactValue(val, fullPath);
+      }
+    }
+    return result;
+  }
+  return value;
+}
+function redact(data) {
+  return redactValue(data, "");
+}
+
+// packages/rn-dev-agent-core/dist/observability/events.js
+var CLIP_LIMIT = 16e3;
+var INTERACTION = /* @__PURE__ */ new Set([
+  "device_press",
+  "device_fill",
+  "device_swipe",
+  "device_scroll",
+  "device_longpress",
+  "device_pinch",
+  "device_back",
+  "device_batch",
+  "device_scrollintoview",
+  "cdp_interact",
+  "device_focus_next",
+  "device_pick_date",
+  "device_pick_value",
+  "device_deeplink"
+]);
+var NAVIGATION = /* @__PURE__ */ new Set(["cdp_navigation_state", "cdp_nav_graph", "cdp_navigate"]);
+var INTROSPECTION = /* @__PURE__ */ new Set([
+  "cdp_component_tree",
+  "cdp_component_state",
+  "cdp_store_state",
+  "device_snapshot",
+  "device_screenshot",
+  "cdp_network_log",
+  "cdp_network_body",
+  "cdp_console_log",
+  "cdp_error_log",
+  "cdp_native_errors",
+  "cdp_diagnostic_renderers",
+  "cdp_object_inspect",
+  "cdp_heap_usage",
+  "collect_logs"
+]);
+var LIFECYCLE = /* @__PURE__ */ new Set([
+  "cdp_status",
+  "cdp_connect",
+  "cdp_disconnect",
+  "cdp_targets",
+  "cdp_reload",
+  "cdp_restart",
+  "cdp_dev_settings",
+  "cdp_open_devtools",
+  "device_list",
+  "observe"
+]);
+var TESTING = /* @__PURE__ */ new Set([
+  "maestro_run",
+  "maestro_generate",
+  "maestro_test_all",
+  "cdp_run_action",
+  "cdp_repair_action",
+  "proof_step",
+  "cross_platform_verify",
+  "cdp_auto_login",
+  "expect_redux",
+  "expect_route",
+  "expect_visible_by_testid",
+  "expect_text"
+]);
+function classifyFamily(tool) {
+  if (INTERACTION.has(tool))
+    return "interaction";
+  if (NAVIGATION.has(tool))
+    return "navigation";
+  if (INTROSPECTION.has(tool))
+    return "introspection";
+  if (LIFECYCLE.has(tool))
+    return "lifecycle";
+  if (TESTING.has(tool))
+    return "testing";
+  return "other";
+}
+function clipThenRedact(args, payload) {
+  let redactedArgs;
+  try {
+    redactedArgs = redact(args ?? {});
+  } catch {
+    redactedArgs = { redacted: true };
+  }
+  if (payload === null || payload === void 0) {
+    return { args: redactedArgs };
+  }
+  try {
+    let json;
+    try {
+      json = JSON.stringify(payload);
+    } catch {
+      return { args: redactedArgs, payload: { redacted: true } };
+    }
+    let clipped = payload;
+    let truncated = false;
+    if (typeof json === "string" && json.length > CLIP_LIMIT) {
+      clipped = { _clipped: json.slice(0, CLIP_LIMIT) };
+      truncated = true;
+    }
+    const redactedPayload = redact({ v: clipped }).v;
+    return truncated ? { args: redactedArgs, payload: redactedPayload, truncated: true } : { args: redactedArgs, payload: redactedPayload };
+  } catch {
+    return { args: redactedArgs, payload: { redacted: true } };
+  }
+}
+function unwrapResult(result) {
+  if (!result || typeof result !== "object")
+    return void 0;
+  const env = result;
+  const text = env.content?.[0]?.text;
+  if (typeof text !== "string")
+    return void 0;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return void 0;
+  }
+}
+function summarize(tool, _family, args, ok) {
+  const target = args.testID ?? args.ref ?? args.text ?? args.screen ?? args.path ?? "";
+  const head = target ? `${tool} ${String(target).slice(0, 60)}` : tool;
+  return ok ? head : `${head} \u2717`;
+}
+function mapObservation(seq, o) {
+  const family = classifyFamily(o.tool);
+  const ok = o.status === "PASS";
+  const unwrapped = unwrapResult(o.result);
+  const payloadSource = ok ? unwrapped ? unwrapped.data : o.result : void 0;
+  const { args, payload, truncated } = clipThenRedact(o.params ?? {}, payloadSource);
+  const summary = summarize(o.tool, family, args, ok);
+  const event = {
+    seq,
+    ts: Date.now(),
+    tool: o.tool,
+    family,
+    args,
+    ok,
+    durationMs: o.latencyMs,
+    summary
+  };
+  if (payload !== void 0)
+    event.payload = payload;
+  if (truncated)
+    event.truncated = true;
+  if (!ok && o.error) {
+    const raw = String(o.error).slice(0, 500);
+    let message;
+    try {
+      message = String(redact({ m: raw }).m);
+    } catch {
+      message = "[REDACTED:error]";
+    }
+    event.error = { message };
+  }
+  if (o.ghost?.attempted)
+    event.ghost = o.ghost;
+  return event;
+}
+
+// packages/rn-dev-agent-core/dist/observability/recorder.js
+var DEFAULT_CAP = 500;
+var MAX_SHOT_BYTES = 4e6;
+var SHOT_REGISTRY_CAP = 64;
+function screenshotPath(result) {
+  const data = unwrapResult(result)?.data ?? result?.data;
+  const p = data?.path ?? data?.message;
+  return typeof p === "string" && isAbsolute2(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
+}
+function readShotBounded(p) {
+  let fd;
+  try {
+    fd = openSync2(p, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+    const st = fstatSync(fd);
+    if (!st.isFile() || st.size > MAX_SHOT_BYTES)
+      return null;
+    const size = Number(st.size);
+    const buf = Buffer.alloc(size + 1);
+    const n = readSync(fd, buf, 0, size + 1, 0);
+    if (n > size)
+      return null;
+    return buf.subarray(0, n);
+  } catch {
+    return null;
+  } finally {
+    if (fd !== void 0) {
+      try {
+        closeSync2(fd);
+      } catch {
+      }
+    }
+  }
+}
+var Recorder = class {
+  buf;
+  seq = 0;
+  subs = /* @__PURE__ */ new Set();
+  shots = /* @__PURE__ */ new Map();
+  // GH #429: single-use trust grants from the capture pipeline (insertion-
+  // ordered, FIFO-evicted). Observations name paths, but only paths this
+  // process just captured may be read back — otherwise any tool result that
+  // mentions "/…/x.png" becomes an arbitrary local file read served over the
+  // observe server.
+  trustedShotPaths = /* @__PURE__ */ new Set();
+  shotCap;
+  liveShotData;
+  liveSeqVal = 0;
+  constructor(capacity = DEFAULT_CAP) {
+    this.buf = new RingBuffer(capacity);
+    this.shotCap = Math.max(8, Math.floor(capacity / 10));
+  }
+  record(o) {
+    try {
+      if (!o || typeof o !== "object" || typeof o.tool !== "string")
+        return;
+      const ev = mapObservation(++this.seq, o);
+      this.buf.push(ev);
+      this.captureScreenshot(ev, o);
+      for (const fn of this.subs) {
+        try {
+          fn(ev);
+        } catch {
+        }
+      }
+    } catch {
+    }
+  }
+  snapshot() {
+    return this.buf.getLast(this.buf.size);
+  }
+  attach(fn) {
+    const snapshot = this.buf.getLast(this.buf.size);
+    this.subs.add(fn);
+    return {
+      snapshot,
+      detach: () => {
+        this.subs.delete(fn);
+      }
+    };
+  }
+  getScreenshot(seq) {
+    return this.shots.get(seq);
+  }
+  /**
+   * GH #429: grant a one-shot read for a file the capture pipeline just
+   * wrote. `captureScreenshot` consumes the grant on first use, so a later
+   * observation replaying the same path is refused. User-chosen destinations
+   * (docs/proof/…, ~/Desktop/…) keep working because the grant is issued for
+   * whatever path the pipeline actually captured to.
+   */
+  registerCapturedScreenshot(p) {
+    if (typeof p !== "string" || !isAbsolute2(p))
+      return;
+    this.trustedShotPaths.delete(p);
+    this.trustedShotPaths.add(p);
+    while (this.trustedShotPaths.size > SHOT_REGISTRY_CAP) {
+      const oldest = this.trustedShotPaths.values().next().value;
+      if (oldest === void 0)
+        break;
+      this.trustedShotPaths.delete(oldest);
+    }
+  }
+  hasSubscribers() {
+    return this.subs.size > 0;
+  }
+  getLiveScreenshot() {
+    return this.liveShotData;
+  }
+  pushLive(frame) {
+    const ev = { type: "live" };
+    let changed = false;
+    if (frame.shot && frame.shot.buf.length <= MAX_SHOT_BYTES) {
+      this.liveShotData = frame.shot;
+      ev.shotSeq = ++this.liveSeqVal;
+      changed = true;
+    }
+    if (typeof frame.route === "string" && frame.route.length > 0) {
+      ev.route = frame.route;
+      changed = true;
+    }
+    if (!changed)
+      return;
+    for (const fn of this.subs) {
+      try {
+        fn(ev);
+      } catch {
+      }
+    }
+  }
+  push(ev) {
+    for (const fn of this.subs) {
+      try {
+        fn(ev);
+      } catch {
+      }
+    }
+  }
+  clear() {
+    this.buf.clear();
+    for (const fn of this.subs) {
+      try {
+        fn({ type: "cleared" });
+      } catch {
+      }
+    }
+    this.subs.clear();
+    this.shots.clear();
+    this.trustedShotPaths.clear();
+    this.seq = 0;
+    this.liveShotData = void 0;
+    this.liveSeqVal = 0;
+  }
+  captureScreenshot(ev, o) {
+    if (ev.tool !== "device_screenshot" || !ev.ok)
+      return;
+    const p = screenshotPath(o.result);
+    if (!p || !this.trustedShotPaths.delete(p))
+      return;
+    const buf = readShotBounded(p);
+    if (!buf)
+      return;
+    const contentType = p.endsWith(".png") ? "image/png" : "image/jpeg";
+    this.shots.set(ev.seq, { buf, contentType });
+    while (this.shots.size > this.shotCap) {
+      const oldest = this.shots.keys().next().value;
+      if (oldest === void 0)
+        break;
+      this.shots.delete(oldest);
+    }
+  }
+};
+var recorder = new Recorder();
+
+// packages/rn-dev-agent-core/dist/tools/device-list.js
 var runAgentDeviceFn2 = runNative;
 var execFileAsync3 = promisify17(execFile16);
 var defaultExec2 = (cmd, args) => execFileAsync3(cmd, args);
@@ -49218,7 +49627,7 @@ function deriveScreenshotPath(args, now = Date.now, rand = Math.random) {
   }
   if (args.path?.startsWith("~")) {
     if (args.path.startsWith("~/"))
-      return join24(homedir8(), args.path.slice(2));
+      return join24(homedir9(), args.path.slice(2));
     throw new TildeScreenshotPathError(`Screenshot path "${args.path}" starts with '~' which the bridge cannot expand (only a leading '~/' is expanded to the home directory). Pass an absolute path instead.`);
   }
   if (args.path)
@@ -49383,6 +49792,8 @@ async function captureAndResizeScreenshot(args) {
   if (result.isError)
     return result;
   const actualPath = resolveScreenshotPath(result, requestedPath);
+  recorder.registerCapturedScreenshot(requestedPath);
+  recorder.registerCapturedScreenshot(actualPath);
   const resizeOpts = {};
   if (args.maxWidth !== void 0)
     resizeOpts.maxWidth = args.maxWidth;
@@ -56094,7 +56505,7 @@ import { execFile as execFileCb19 } from "node:child_process";
 import { promisify as promisify25 } from "node:util";
 import { existsSync as existsSync23, readFileSync as readFileSync19, writeFileSync as writeFileSync13, readdirSync as readdirSync7 } from "node:fs";
 import { join as join29 } from "node:path";
-import { homedir as homedir9 } from "node:os";
+import { homedir as homedir10 } from "node:os";
 var execFile24 = promisify25(execFileCb19);
 var AUTH_ROUTE_PATTERNS = [
   "login",
@@ -56245,7 +56656,7 @@ async function handleAutoLogin(client2, opts = {}) {
   }
   const wrapperPath = "/tmp/rn-auto-login-wrapper.yaml";
   writeFileSync13(wrapperPath, wrapperContent, "utf-8");
-  const runnerPath = join29(homedir9(), ".maestro-runner", "bin", "maestro-runner");
+  const runnerPath = join29(homedir10(), ".maestro-runner", "bin", "maestro-runner");
   if (!existsSync23(runnerPath)) {
     return {
       loggedIn: false,
@@ -56711,7 +57122,7 @@ function buildGracefulShutdown(deps) {
 // packages/rn-dev-agent-core/dist/lifecycle/lockfile.js
 import { createHash as createHash5 } from "node:crypto";
 import { execFileSync as execFileSync7 } from "node:child_process";
-import { closeSync as closeSync2, existsSync as existsSync24, mkdirSync as mkdirSync13, openSync as openSync2, readFileSync as readFileSync20, statSync as statSync8, unlinkSync as unlinkSync9, writeFileSync as writeFileSync14, writeSync as writeSync2 } from "node:fs";
+import { closeSync as closeSync3, existsSync as existsSync24, mkdirSync as mkdirSync13, openSync as openSync3, readFileSync as readFileSync20, statSync as statSync8, unlinkSync as unlinkSync9, writeFileSync as writeFileSync14, writeSync as writeSync2 } from "node:fs";
 import { tmpdir as tmpdir8, userInfo as userInfo2 } from "node:os";
 import { join as join30, resolve as resolve3 } from "node:path";
 var DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
@@ -56931,11 +57342,11 @@ var Lockfile = class {
     if (!existsSync24(dir)) {
       mkdirSync13(dir, { recursive: true });
     }
-    const fd = openSync2(this.lockPath, "wx");
+    const fd = openSync3(this.lockPath, "wx");
     try {
       writeSync2(fd, JSON.stringify(body, null, 2));
     } finally {
-      closeSync2(fd);
+      closeSync3(fd);
     }
   }
 };
@@ -57620,365 +58031,6 @@ function instrumentTool(toolName, handler) {
   };
 }
 
-// packages/rn-dev-agent-core/dist/observability/recorder.js
-import { readFileSync as readFileSync23, statSync as statSync9 } from "node:fs";
-import { isAbsolute as isAbsolute2 } from "node:path";
-
-// packages/rn-dev-agent-core/dist/util/redact.js
-import { homedir as homedir10 } from "node:os";
-var HOME = homedir10();
-var HOME_RE = new RegExp(HOME.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g");
-var SECRET_PATTERNS = [
-  /(?:sk|pk|api|key|token|secret|password|auth)[-_]?[A-Za-z0-9_-]{20,}/gi,
-  /Bearer\s+[A-Za-z0-9_\-./+=]{20,}/g,
-  /ghp_[A-Za-z0-9_]{36}/g,
-  /eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g,
-  /\bAKIA[0-9A-Z]{16}\b/g,
-  /\bxox[baprs]-[A-Za-z0-9-]+\b/g,
-  /\bAIza[0-9A-Za-z\-_]{35}\b/g,
-  // Any private-key label variant: PRIVATE KEY, RSA PRIVATE KEY,
-  // OPENSSH PRIVATE KEY, EC/DSA/ENCRYPTED PRIVATE KEY, ... The old single-word
-  // `(?:RSA |OPENSSH |PRIVATE )?KEY` form never matched multi-word labels like
-  // "RSA PRIVATE KEY" — the most common ssh-keygen header — so keys leaked.
-  /-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----/g
-];
-var KEYED_SECRET_RE = /((?:token|secret|password|passwd|pwd|api[_-]?key|apikey|authorization|auth|access[_-]?token|refresh[_-]?token|client[_-]?secret)["']?\s*[:=]\s*["']?)([^"'\s,;}]{6,})/gi;
-var PII_PATTERNS = [
-  /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
-  // Require separators so bare digit runs (timestamps, latencies, ids) are not
-  // mistaken for phone/SSN numbers (previously `[-.]?`/`[-]?` made them
-  // optional, redacting any 9-10 digit number).
-  /\b\d{3}[-.]\d{3}[-.]\d{4}\b/g,
-  /\b\d{3}-\d{2}-\d{4}\b/g
-];
-var AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
-var MAX_STRING_LENGTH = 2e3;
-function redactString(value) {
-  let result = value.replace(HOME_RE, "~");
-  KEYED_SECRET_RE.lastIndex = 0;
-  result = result.replace(KEYED_SECRET_RE, "$1[REDACTED_SECRET]");
-  for (const pattern of SECRET_PATTERNS) {
-    pattern.lastIndex = 0;
-    result = result.replace(pattern, "[REDACTED_SECRET]");
-  }
-  for (const pattern of PII_PATTERNS) {
-    pattern.lastIndex = 0;
-    result = result.replace(pattern, "[PII_REDACTED]");
-  }
-  if (result.length > MAX_STRING_LENGTH) {
-    result = result.slice(0, MAX_STRING_LENGTH) + `[TRUNCATED:${result.length}]`;
-  }
-  return result;
-}
-function redactValue(value, path) {
-  if (value === null || value === void 0)
-    return value;
-  if (typeof value === "string")
-    return redactString(value);
-  if (Array.isArray(value)) {
-    return value.map((item, i) => redactValue(item, `${path}[${i}]`));
-  }
-  if (typeof value === "object") {
-    const obj = value;
-    const result = {};
-    for (const [key, val] of Object.entries(obj)) {
-      const fullPath = path ? `${path}.${key}` : key;
-      if (AUTH_PATHS.test(key)) {
-        result[key] = Array.isArray(val) ? "[REDACTED:array]" : `[REDACTED:${typeof val}]`;
-      } else {
-        result[key] = redactValue(val, fullPath);
-      }
-    }
-    return result;
-  }
-  return value;
-}
-function redact(data) {
-  return redactValue(data, "");
-}
-
-// packages/rn-dev-agent-core/dist/observability/events.js
-var CLIP_LIMIT = 16e3;
-var INTERACTION = /* @__PURE__ */ new Set([
-  "device_press",
-  "device_fill",
-  "device_swipe",
-  "device_scroll",
-  "device_longpress",
-  "device_pinch",
-  "device_back",
-  "device_batch",
-  "device_scrollintoview",
-  "cdp_interact",
-  "device_focus_next",
-  "device_pick_date",
-  "device_pick_value",
-  "device_deeplink"
-]);
-var NAVIGATION = /* @__PURE__ */ new Set(["cdp_navigation_state", "cdp_nav_graph", "cdp_navigate"]);
-var INTROSPECTION = /* @__PURE__ */ new Set([
-  "cdp_component_tree",
-  "cdp_component_state",
-  "cdp_store_state",
-  "device_snapshot",
-  "device_screenshot",
-  "cdp_network_log",
-  "cdp_network_body",
-  "cdp_console_log",
-  "cdp_error_log",
-  "cdp_native_errors",
-  "cdp_diagnostic_renderers",
-  "cdp_object_inspect",
-  "cdp_heap_usage",
-  "collect_logs"
-]);
-var LIFECYCLE = /* @__PURE__ */ new Set([
-  "cdp_status",
-  "cdp_connect",
-  "cdp_disconnect",
-  "cdp_targets",
-  "cdp_reload",
-  "cdp_restart",
-  "cdp_dev_settings",
-  "cdp_open_devtools",
-  "device_list",
-  "observe"
-]);
-var TESTING = /* @__PURE__ */ new Set([
-  "maestro_run",
-  "maestro_generate",
-  "maestro_test_all",
-  "cdp_run_action",
-  "cdp_repair_action",
-  "proof_step",
-  "cross_platform_verify",
-  "cdp_auto_login",
-  "expect_redux",
-  "expect_route",
-  "expect_visible_by_testid",
-  "expect_text"
-]);
-function classifyFamily(tool) {
-  if (INTERACTION.has(tool))
-    return "interaction";
-  if (NAVIGATION.has(tool))
-    return "navigation";
-  if (INTROSPECTION.has(tool))
-    return "introspection";
-  if (LIFECYCLE.has(tool))
-    return "lifecycle";
-  if (TESTING.has(tool))
-    return "testing";
-  return "other";
-}
-function clipThenRedact(args, payload) {
-  let redactedArgs;
-  try {
-    redactedArgs = redact(args ?? {});
-  } catch {
-    redactedArgs = { redacted: true };
-  }
-  if (payload === null || payload === void 0) {
-    return { args: redactedArgs };
-  }
-  try {
-    let json;
-    try {
-      json = JSON.stringify(payload);
-    } catch {
-      return { args: redactedArgs, payload: { redacted: true } };
-    }
-    let clipped = payload;
-    let truncated = false;
-    if (typeof json === "string" && json.length > CLIP_LIMIT) {
-      clipped = { _clipped: json.slice(0, CLIP_LIMIT) };
-      truncated = true;
-    }
-    const redactedPayload = redact({ v: clipped }).v;
-    return truncated ? { args: redactedArgs, payload: redactedPayload, truncated: true } : { args: redactedArgs, payload: redactedPayload };
-  } catch {
-    return { args: redactedArgs, payload: { redacted: true } };
-  }
-}
-function unwrapResult(result) {
-  if (!result || typeof result !== "object")
-    return void 0;
-  const env = result;
-  const text = env.content?.[0]?.text;
-  if (typeof text !== "string")
-    return void 0;
-  try {
-    return JSON.parse(text);
-  } catch {
-    return void 0;
-  }
-}
-function summarize(tool, _family, args, ok) {
-  const target = args.testID ?? args.ref ?? args.text ?? args.screen ?? args.path ?? "";
-  const head = target ? `${tool} ${String(target).slice(0, 60)}` : tool;
-  return ok ? head : `${head} \u2717`;
-}
-function mapObservation(seq, o) {
-  const family = classifyFamily(o.tool);
-  const ok = o.status === "PASS";
-  const unwrapped = unwrapResult(o.result);
-  const payloadSource = ok ? unwrapped ? unwrapped.data : o.result : void 0;
-  const { args, payload, truncated } = clipThenRedact(o.params ?? {}, payloadSource);
-  const summary = summarize(o.tool, family, args, ok);
-  const event = {
-    seq,
-    ts: Date.now(),
-    tool: o.tool,
-    family,
-    args,
-    ok,
-    durationMs: o.latencyMs,
-    summary
-  };
-  if (payload !== void 0)
-    event.payload = payload;
-  if (truncated)
-    event.truncated = true;
-  if (!ok && o.error) {
-    const raw = String(o.error).slice(0, 500);
-    let message;
-    try {
-      message = String(redact({ m: raw }).m);
-    } catch {
-      message = "[REDACTED:error]";
-    }
-    event.error = { message };
-  }
-  if (o.ghost?.attempted)
-    event.ghost = o.ghost;
-  return event;
-}
-
-// packages/rn-dev-agent-core/dist/observability/recorder.js
-var DEFAULT_CAP = 500;
-var MAX_SHOT_BYTES = 4e6;
-function screenshotPath(result) {
-  const data = unwrapResult(result)?.data ?? result?.data;
-  const p = data?.path ?? data?.message;
-  return typeof p === "string" && isAbsolute2(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
-}
-var Recorder = class {
-  buf;
-  seq = 0;
-  subs = /* @__PURE__ */ new Set();
-  shots = /* @__PURE__ */ new Map();
-  shotCap;
-  liveShotData;
-  liveSeqVal = 0;
-  constructor(capacity = DEFAULT_CAP) {
-    this.buf = new RingBuffer(capacity);
-    this.shotCap = Math.max(8, Math.floor(capacity / 10));
-  }
-  record(o) {
-    try {
-      if (!o || typeof o !== "object" || typeof o.tool !== "string")
-        return;
-      const ev = mapObservation(++this.seq, o);
-      this.buf.push(ev);
-      this.captureScreenshot(ev, o);
-      for (const fn of this.subs) {
-        try {
-          fn(ev);
-        } catch {
-        }
-      }
-    } catch {
-    }
-  }
-  snapshot() {
-    return this.buf.getLast(this.buf.size);
-  }
-  attach(fn) {
-    const snapshot = this.buf.getLast(this.buf.size);
-    this.subs.add(fn);
-    return {
-      snapshot,
-      detach: () => {
-        this.subs.delete(fn);
-      }
-    };
-  }
-  getScreenshot(seq) {
-    return this.shots.get(seq);
-  }
-  hasSubscribers() {
-    return this.subs.size > 0;
-  }
-  getLiveScreenshot() {
-    return this.liveShotData;
-  }
-  pushLive(frame) {
-    const ev = { type: "live" };
-    let changed = false;
-    if (frame.shot && frame.shot.buf.length <= MAX_SHOT_BYTES) {
-      this.liveShotData = frame.shot;
-      ev.shotSeq = ++this.liveSeqVal;
-      changed = true;
-    }
-    if (typeof frame.route === "string" && frame.route.length > 0) {
-      ev.route = frame.route;
-      changed = true;
-    }
-    if (!changed)
-      return;
-    for (const fn of this.subs) {
-      try {
-        fn(ev);
-      } catch {
-      }
-    }
-  }
-  push(ev) {
-    for (const fn of this.subs) {
-      try {
-        fn(ev);
-      } catch {
-      }
-    }
-  }
-  clear() {
-    this.buf.clear();
-    for (const fn of this.subs) {
-      try {
-        fn({ type: "cleared" });
-      } catch {
-      }
-    }
-    this.subs.clear();
-    this.shots.clear();
-    this.seq = 0;
-    this.liveShotData = void 0;
-    this.liveSeqVal = 0;
-  }
-  captureScreenshot(ev, o) {
-    if (ev.tool !== "device_screenshot" || !ev.ok)
-      return;
-    const p = screenshotPath(o.result);
-    if (!p)
-      return;
-    try {
-      if (statSync9(p).size > MAX_SHOT_BYTES)
-        return;
-      const buf = readFileSync23(p);
-      const contentType = p.endsWith(".png") ? "image/png" : "image/jpeg";
-      this.shots.set(ev.seq, { buf, contentType });
-      while (this.shots.size > this.shotCap) {
-        const oldest = this.shots.keys().next().value;
-        if (oldest === void 0)
-          break;
-        this.shots.delete(oldest);
-      }
-    } catch {
-    }
-  }
-};
-var recorder = new Recorder();
-
 // packages/rn-dev-agent-core/dist/observability/live-device.js
 import { join as join34 } from "node:path";
 import { tmpdir as tmpdir10 } from "node:os";
@@ -58137,7 +58189,7 @@ init_utils();
 
 // packages/rn-dev-agent-core/dist/observability/server.js
 import { createServer as createServer3 } from "node:http";
-import { readFileSync as readFileSync24 } from "node:fs";
+import { readFileSync as readFileSync23 } from "node:fs";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 import { dirname as dirname13, join as join35 } from "node:path";
 
@@ -58344,7 +58396,7 @@ var ObservabilityServer = class {
   }
   index(res) {
     try {
-      let html = readFileSync24(join35(__dir, "web-dist", "index.html"), "utf8");
+      let html = readFileSync23(join35(__dir, "web-dist", "index.html"), "utf8");
       if (this.e2e) {
         const tokenJs = JSON.stringify(this.e2e.token).replace(/</g, "\\u003c");
         html = html.replace("</head>", `<script>window.__E2E_CSRF__=${tokenJs}</script></head>`);
@@ -59239,11 +59291,11 @@ function buildMirrorTargetResolver(deps) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/lock-e2e-test.js
-import { readFileSync as readFileSync27 } from "node:fs";
+import { readFileSync as readFileSync26 } from "node:fs";
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
 import { dirname as dirname14, join as join38 } from "node:path";
-import { mkdirSync as mkdirSync15, writeFileSync as writeFileSync17, renameSync as renameSync5, readFileSync as readFileSync25, readdirSync as readdirSync10, existsSync as existsSync27 } from "node:fs";
+import { mkdirSync as mkdirSync15, writeFileSync as writeFileSync17, renameSync as renameSync5, readFileSync as readFileSync24, readdirSync as readdirSync10, existsSync as existsSync27 } from "node:fs";
 import { createHash as createHash6 } from "node:crypto";
 var FLOW_SENTINEL = "# e2e-locked-flow-below";
 function e2eDirFor(projectRoot) {
@@ -59302,7 +59354,7 @@ function loadLockedTest(projectRoot, id) {
   const filePath = e2ePathFor(projectRoot, id);
   if (!existsSync27(filePath))
     return null;
-  return parseLockedTest(readFileSync25(filePath, "utf8"), filePath);
+  return parseLockedTest(readFileSync24(filePath, "utf8"), filePath);
 }
 function discoverLockedTests(projectRoot) {
   const dir = e2eDirFor(projectRoot);
@@ -59345,12 +59397,12 @@ function parseLockedTest(text, filePath) {
 }
 
 // packages/rn-dev-agent-core/dist/domain/e2e-config.js
-import { readFileSync as readFileSync26 } from "node:fs";
+import { readFileSync as readFileSync25 } from "node:fs";
 import { join as join39 } from "node:path";
 function loadE2eConfig(projectRoot) {
   const filePath = join39(projectRoot, ".rn-agent", "e2e.config.json");
   try {
-    const raw = readFileSync26(filePath, "utf8");
+    const raw = readFileSync25(filePath, "utf8");
     return JSON.parse(raw);
   } catch {
     return {};
@@ -59417,7 +59469,7 @@ function readPassed(result) {
 async function lockE2eTestCore(args, deps = {}) {
   const projectRoot = args.projectRoot ?? findProjectRoot() ?? process.cwd();
   const load = deps.loadAction ?? loadAction;
-  const readFile3 = deps.readActionFile ?? ((p) => readFileSync27(p, "utf8"));
+  const readFile3 = deps.readActionFile ?? ((p) => readFileSync26(p, "utf8"));
   const getGit = deps.getGitInfo ?? getGitInfo;
   const getSession = deps.getSession ?? getActiveSession;
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
@@ -59476,7 +59528,7 @@ function createLockE2eTestHandler(deps = {}) {
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
 init_maestro_error_parser();
 import { join as join40 } from "node:path";
-import { mkdirSync as mkdirSync16, writeFileSync as writeFileSync18, renameSync as renameSync6, readFileSync as readFileSync28, existsSync as existsSync28 } from "node:fs";
+import { mkdirSync as mkdirSync16, writeFileSync as writeFileSync18, renameSync as renameSync6, readFileSync as readFileSync27, existsSync as existsSync28 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
     return {
@@ -59544,7 +59596,7 @@ function loadIndex(projectRoot) {
   if (!existsSync28(file))
     return [];
   try {
-    const parsed = JSON.parse(readFileSync28(file, "utf8"));
+    const parsed = JSON.parse(readFileSync27(file, "utf8"));
     return Array.isArray(parsed) ? parsed : [];
   } catch {
     return [];
@@ -59569,7 +59621,7 @@ function loadRunRecord(projectRoot, runId) {
   if (!existsSync28(file))
     return null;
   try {
-    return JSON.parse(readFileSync28(file, "utf8"));
+    return JSON.parse(readFileSync27(file, "utf8"));
   } catch {
     return null;
   }
@@ -59585,7 +59637,7 @@ init_utils();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
 import { join as join41 } from "node:path";
-import { mkdirSync as mkdirSync17, writeFileSync as writeFileSync19, renameSync as renameSync7, readFileSync as readFileSync29, readdirSync as readdirSync11, existsSync as existsSync29 } from "node:fs";
+import { mkdirSync as mkdirSync17, writeFileSync as writeFileSync19, renameSync as renameSync7, readFileSync as readFileSync28, readdirSync as readdirSync11, existsSync as existsSync29 } from "node:fs";
 var TERMINAL_STATUSES = /* @__PURE__ */ new Set([
   "done",
   "failed",
@@ -59611,7 +59663,7 @@ function loadRequest(projectRoot, runId) {
   if (!existsSync29(file))
     return null;
   try {
-    return JSON.parse(readFileSync29(file, "utf8"));
+    return JSON.parse(readFileSync28(file, "utf8"));
   } catch {
     return null;
   }
@@ -59952,7 +60004,7 @@ async function listActions(projectRoot) {
 
 // packages/rn-dev-agent-core/dist/index.js
 var pkgPath = join43(dirname15(fileURLToPath3(import.meta.url)), "..", "package.json");
-var pkgVersion = JSON.parse(readFileSync30(pkgPath, "utf8")).version;
+var pkgVersion = JSON.parse(readFileSync29(pkgPath, "utf8")).version;
 var lockfile = null;
 var noLock = process.argv.includes("--no-lock");
 if (!noLock) {
@@ -60090,7 +60142,7 @@ var liveDeps = buildLiveDeps({
   readRoute: (c) => readLiveRoute(c),
   readShotFile: (path) => {
     try {
-      const buf = readFileSync30(path);
+      const buf = readFileSync29(path);
       const isPng = buf.length >= 4 && buf[0] === 137 && buf[1] === 80 && buf[2] === 78 && buf[3] === 71;
       return { buf, contentType: isPng ? "image/png" : "image/jpeg" };
     } catch {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -49411,7 +49411,7 @@ function mapObservation(seq, o) {
 var DEFAULT_CAP = 500;
 var MAX_SHOT_BYTES = 4e6;
 var SHOT_REGISTRY_CAP = 64;
-function screenshotPath(result) {
+function extractScreenshotPath(result) {
   const data = unwrapResult(result)?.data ?? result?.data;
   const p = data?.path ?? data?.message;
   return typeof p === "string" && isAbsolute2(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
@@ -49562,7 +49562,7 @@ var Recorder = class {
   captureScreenshot(ev, o) {
     if (ev.tool !== "device_screenshot" || !ev.ok)
       return;
-    const p = screenshotPath(o.result);
+    const p = extractScreenshotPath(o.result);
     if (!p || !this.trustedShotPaths.delete(p))
       return;
     const buf = readShotBounded(p);
@@ -49792,8 +49792,6 @@ async function captureAndResizeScreenshot(args) {
   if (result.isError)
     return result;
   const actualPath = resolveScreenshotPath(result, requestedPath);
-  recorder.registerCapturedScreenshot(requestedPath);
-  recorder.registerCapturedScreenshot(actualPath);
   const resizeOpts = {};
   if (args.maxWidth !== void 0)
     resizeOpts.maxWidth = args.maxWidth;
@@ -49801,7 +49799,13 @@ async function captureAndResizeScreenshot(args) {
     resizeOpts.quality = args.quality;
   const resize = await resizeWithSips(actualPath, resizeOpts);
   const resized = wrapResultWithResize(result, resize);
-  return wrapResultWithAdvisories(resized, advisories);
+  const finalResult = wrapResultWithAdvisories(resized, advisories);
+  recorder.registerCapturedScreenshot(requestedPath);
+  recorder.registerCapturedScreenshot(actualPath);
+  const observedPath = extractScreenshotPath(finalResult);
+  if (observedPath)
+    recorder.registerCapturedScreenshot(observedPath);
+  return finalResult;
 }
 function createDeviceScreenshotHandler(getClient2) {
   return async (args) => {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -50908,7 +50908,7 @@ var init_events = __esm({
 // packages/rn-dev-agent-core/dist/observability/recorder.js
 import { closeSync as closeSync3, constants, fstatSync, openSync as openSync3, readSync } from "node:fs";
 import { isAbsolute as isAbsolute2 } from "node:path";
-function screenshotPath(result) {
+function extractScreenshotPath(result) {
   const data = unwrapResult(result)?.data ?? result?.data;
   const p = data?.path ?? data?.message;
   return typeof p === "string" && isAbsolute2(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
@@ -51068,7 +51068,7 @@ var init_recorder = __esm({
       captureScreenshot(ev, o) {
         if (ev.tool !== "device_screenshot" || !ev.ok)
           return;
-        const p = screenshotPath(o.result);
+        const p = extractScreenshotPath(o.result);
         if (!p || !this.trustedShotPaths.delete(p))
           return;
         const buf = readShotBounded(p);
@@ -51289,8 +51289,6 @@ async function captureAndResizeScreenshot(args) {
   if (result.isError)
     return result;
   const actualPath = resolveScreenshotPath(result, requestedPath);
-  recorder.registerCapturedScreenshot(requestedPath);
-  recorder.registerCapturedScreenshot(actualPath);
   const resizeOpts = {};
   if (args.maxWidth !== void 0)
     resizeOpts.maxWidth = args.maxWidth;
@@ -51298,7 +51296,13 @@ async function captureAndResizeScreenshot(args) {
     resizeOpts.quality = args.quality;
   const resize = await resizeWithSips(actualPath, resizeOpts);
   const resized = wrapResultWithResize(result, resize);
-  return wrapResultWithAdvisories(resized, advisories);
+  const finalResult = wrapResultWithAdvisories(resized, advisories);
+  recorder.registerCapturedScreenshot(requestedPath);
+  recorder.registerCapturedScreenshot(actualPath);
+  const observedPath = extractScreenshotPath(finalResult);
+  if (observedPath)
+    recorder.registerCapturedScreenshot(observedPath);
+  return finalResult;
 }
 function createDeviceScreenshotHandler(getClient2) {
   return async (args) => {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -14273,11 +14273,11 @@ var require_codegen = __commonJS({
         const rhs = this.rhs === void 0 ? "" : ` = ${this.rhs}`;
         return `${varKind} ${this.name}${rhs};` + _n;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         if (!names[this.name.str])
           return;
         if (this.rhs)
-          this.rhs = optimizeExpr(this.rhs, names, constants);
+          this.rhs = optimizeExpr(this.rhs, names, constants2);
         return this;
       }
       get names() {
@@ -14294,10 +14294,10 @@ var require_codegen = __commonJS({
       render({ _n }) {
         return `${this.lhs} = ${this.rhs};` + _n;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         if (this.lhs instanceof code_1.Name && !names[this.lhs.str] && !this.sideEffects)
           return;
-        this.rhs = optimizeExpr(this.rhs, names, constants);
+        this.rhs = optimizeExpr(this.rhs, names, constants2);
         return this;
       }
       get names() {
@@ -14358,8 +14358,8 @@ var require_codegen = __commonJS({
       optimizeNodes() {
         return `${this.code}` ? this : void 0;
       }
-      optimizeNames(names, constants) {
-        this.code = optimizeExpr(this.code, names, constants);
+      optimizeNames(names, constants2) {
+        this.code = optimizeExpr(this.code, names, constants2);
         return this;
       }
       get names() {
@@ -14388,12 +14388,12 @@ var require_codegen = __commonJS({
         }
         return nodes.length > 0 ? this : void 0;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         const { nodes } = this;
         let i = nodes.length;
         while (i--) {
           const n = nodes[i];
-          if (n.optimizeNames(names, constants))
+          if (n.optimizeNames(names, constants2))
             continue;
           subtractNames(names, n.names);
           nodes.splice(i, 1);
@@ -14446,12 +14446,12 @@ var require_codegen = __commonJS({
           return void 0;
         return this;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         var _a;
-        this.else = (_a = this.else) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants);
-        if (!(super.optimizeNames(names, constants) || this.else))
+        this.else = (_a = this.else) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants2);
+        if (!(super.optimizeNames(names, constants2) || this.else))
           return;
-        this.condition = optimizeExpr(this.condition, names, constants);
+        this.condition = optimizeExpr(this.condition, names, constants2);
         return this;
       }
       get names() {
@@ -14474,10 +14474,10 @@ var require_codegen = __commonJS({
       render(opts) {
         return `for(${this.iteration})` + super.render(opts);
       }
-      optimizeNames(names, constants) {
-        if (!super.optimizeNames(names, constants))
+      optimizeNames(names, constants2) {
+        if (!super.optimizeNames(names, constants2))
           return;
-        this.iteration = optimizeExpr(this.iteration, names, constants);
+        this.iteration = optimizeExpr(this.iteration, names, constants2);
         return this;
       }
       get names() {
@@ -14513,10 +14513,10 @@ var require_codegen = __commonJS({
       render(opts) {
         return `for(${this.varKind} ${this.name} ${this.loop} ${this.iterable})` + super.render(opts);
       }
-      optimizeNames(names, constants) {
-        if (!super.optimizeNames(names, constants))
+      optimizeNames(names, constants2) {
+        if (!super.optimizeNames(names, constants2))
           return;
-        this.iterable = optimizeExpr(this.iterable, names, constants);
+        this.iterable = optimizeExpr(this.iterable, names, constants2);
         return this;
       }
       get names() {
@@ -14558,11 +14558,11 @@ var require_codegen = __commonJS({
         (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNodes();
         return this;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         var _a, _b;
-        super.optimizeNames(names, constants);
-        (_a = this.catch) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants);
-        (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNames(names, constants);
+        super.optimizeNames(names, constants2);
+        (_a = this.catch) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants2);
+        (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNames(names, constants2);
         return this;
       }
       get names() {
@@ -14863,7 +14863,7 @@ var require_codegen = __commonJS({
     function addExprNames(names, from) {
       return from instanceof code_1._CodeOrName ? addNames(names, from.names) : names;
     }
-    function optimizeExpr(expr, names, constants) {
+    function optimizeExpr(expr, names, constants2) {
       if (expr instanceof code_1.Name)
         return replaceName(expr);
       if (!canOptimize(expr))
@@ -14878,14 +14878,14 @@ var require_codegen = __commonJS({
         return items;
       }, []));
       function replaceName(n) {
-        const c = constants[n.str];
+        const c = constants2[n.str];
         if (c === void 0 || names[n.str] !== 1)
           return n;
         delete names[n.str];
         return c;
       }
       function canOptimize(e) {
-        return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants[c.str] !== void 0);
+        return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants2[c.str] !== void 0);
       }
     }
     function subtractNames(names, from) {
@@ -50662,12 +50662,438 @@ var init_path_safety = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/util/redact.js
+import { homedir as homedir8 } from "node:os";
+function redactString(value) {
+  let result = value.replace(HOME_RE, "~");
+  KEYED_SECRET_RE.lastIndex = 0;
+  result = result.replace(KEYED_SECRET_RE, "$1[REDACTED_SECRET]");
+  for (const pattern of SECRET_PATTERNS) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, "[REDACTED_SECRET]");
+  }
+  for (const pattern of PII_PATTERNS) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, "[PII_REDACTED]");
+  }
+  if (result.length > MAX_STRING_LENGTH) {
+    result = result.slice(0, MAX_STRING_LENGTH) + `[TRUNCATED:${result.length}]`;
+  }
+  return result;
+}
+function redactValue(value, path) {
+  if (value === null || value === void 0)
+    return value;
+  if (typeof value === "string")
+    return redactString(value);
+  if (Array.isArray(value)) {
+    return value.map((item, i) => redactValue(item, `${path}[${i}]`));
+  }
+  if (typeof value === "object") {
+    const obj = value;
+    const result = {};
+    for (const [key, val] of Object.entries(obj)) {
+      const fullPath = path ? `${path}.${key}` : key;
+      if (AUTH_PATHS.test(key)) {
+        result[key] = Array.isArray(val) ? "[REDACTED:array]" : `[REDACTED:${typeof val}]`;
+      } else {
+        result[key] = redactValue(val, fullPath);
+      }
+    }
+    return result;
+  }
+  return value;
+}
+function redact(data) {
+  return redactValue(data, "");
+}
+var HOME, HOME_RE, SECRET_PATTERNS, KEYED_SECRET_RE, PII_PATTERNS, AUTH_PATHS, MAX_STRING_LENGTH;
+var init_redact = __esm({
+  "packages/rn-dev-agent-core/dist/util/redact.js"() {
+    "use strict";
+    HOME = homedir8();
+    HOME_RE = new RegExp(HOME.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g");
+    SECRET_PATTERNS = [
+      /(?:sk|pk|api|key|token|secret|password|auth)[-_]?[A-Za-z0-9_-]{20,}/gi,
+      /Bearer\s+[A-Za-z0-9_\-./+=]{20,}/g,
+      /ghp_[A-Za-z0-9_]{36}/g,
+      /eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g,
+      /\bAKIA[0-9A-Z]{16}\b/g,
+      /\bxox[baprs]-[A-Za-z0-9-]+\b/g,
+      /\bAIza[0-9A-Za-z\-_]{35}\b/g,
+      // Any private-key label variant: PRIVATE KEY, RSA PRIVATE KEY,
+      // OPENSSH PRIVATE KEY, EC/DSA/ENCRYPTED PRIVATE KEY, ... The old single-word
+      // `(?:RSA |OPENSSH |PRIVATE )?KEY` form never matched multi-word labels like
+      // "RSA PRIVATE KEY" — the most common ssh-keygen header — so keys leaked.
+      /-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----/g
+    ];
+    KEYED_SECRET_RE = /((?:token|secret|password|passwd|pwd|api[_-]?key|apikey|authorization|auth|access[_-]?token|refresh[_-]?token|client[_-]?secret)["']?\s*[:=]\s*["']?)([^"'\s,;}]{6,})/gi;
+    PII_PATTERNS = [
+      /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
+      // Require separators so bare digit runs (timestamps, latencies, ids) are not
+      // mistaken for phone/SSN numbers (previously `[-.]?`/`[-]?` made them
+      // optional, redacting any 9-10 digit number).
+      /\b\d{3}[-.]\d{3}[-.]\d{4}\b/g,
+      /\b\d{3}-\d{2}-\d{4}\b/g
+    ];
+    AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
+    MAX_STRING_LENGTH = 2e3;
+  }
+});
+
+// packages/rn-dev-agent-core/dist/observability/events.js
+function classifyFamily(tool) {
+  if (INTERACTION.has(tool))
+    return "interaction";
+  if (NAVIGATION.has(tool))
+    return "navigation";
+  if (INTROSPECTION.has(tool))
+    return "introspection";
+  if (LIFECYCLE.has(tool))
+    return "lifecycle";
+  if (TESTING.has(tool))
+    return "testing";
+  return "other";
+}
+function clipThenRedact(args, payload) {
+  let redactedArgs;
+  try {
+    redactedArgs = redact(args ?? {});
+  } catch {
+    redactedArgs = { redacted: true };
+  }
+  if (payload === null || payload === void 0) {
+    return { args: redactedArgs };
+  }
+  try {
+    let json;
+    try {
+      json = JSON.stringify(payload);
+    } catch {
+      return { args: redactedArgs, payload: { redacted: true } };
+    }
+    let clipped = payload;
+    let truncated = false;
+    if (typeof json === "string" && json.length > CLIP_LIMIT) {
+      clipped = { _clipped: json.slice(0, CLIP_LIMIT) };
+      truncated = true;
+    }
+    const redactedPayload = redact({ v: clipped }).v;
+    return truncated ? { args: redactedArgs, payload: redactedPayload, truncated: true } : { args: redactedArgs, payload: redactedPayload };
+  } catch {
+    return { args: redactedArgs, payload: { redacted: true } };
+  }
+}
+function unwrapResult(result) {
+  if (!result || typeof result !== "object")
+    return void 0;
+  const env = result;
+  const text = env.content?.[0]?.text;
+  if (typeof text !== "string")
+    return void 0;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return void 0;
+  }
+}
+function summarize(tool, _family, args, ok) {
+  const target = args.testID ?? args.ref ?? args.text ?? args.screen ?? args.path ?? "";
+  const head = target ? `${tool} ${String(target).slice(0, 60)}` : tool;
+  return ok ? head : `${head} \u2717`;
+}
+function mapObservation(seq, o) {
+  const family = classifyFamily(o.tool);
+  const ok = o.status === "PASS";
+  const unwrapped = unwrapResult(o.result);
+  const payloadSource = ok ? unwrapped ? unwrapped.data : o.result : void 0;
+  const { args, payload, truncated } = clipThenRedact(o.params ?? {}, payloadSource);
+  const summary = summarize(o.tool, family, args, ok);
+  const event = {
+    seq,
+    ts: Date.now(),
+    tool: o.tool,
+    family,
+    args,
+    ok,
+    durationMs: o.latencyMs,
+    summary
+  };
+  if (payload !== void 0)
+    event.payload = payload;
+  if (truncated)
+    event.truncated = true;
+  if (!ok && o.error) {
+    const raw = String(o.error).slice(0, 500);
+    let message;
+    try {
+      message = String(redact({ m: raw }).m);
+    } catch {
+      message = "[REDACTED:error]";
+    }
+    event.error = { message };
+  }
+  if (o.ghost?.attempted)
+    event.ghost = o.ghost;
+  return event;
+}
+var CLIP_LIMIT, INTERACTION, NAVIGATION, INTROSPECTION, LIFECYCLE, TESTING;
+var init_events = __esm({
+  "packages/rn-dev-agent-core/dist/observability/events.js"() {
+    "use strict";
+    init_redact();
+    CLIP_LIMIT = 16e3;
+    INTERACTION = /* @__PURE__ */ new Set([
+      "device_press",
+      "device_fill",
+      "device_swipe",
+      "device_scroll",
+      "device_longpress",
+      "device_pinch",
+      "device_back",
+      "device_batch",
+      "device_scrollintoview",
+      "cdp_interact",
+      "device_focus_next",
+      "device_pick_date",
+      "device_pick_value",
+      "device_deeplink"
+    ]);
+    NAVIGATION = /* @__PURE__ */ new Set(["cdp_navigation_state", "cdp_nav_graph", "cdp_navigate"]);
+    INTROSPECTION = /* @__PURE__ */ new Set([
+      "cdp_component_tree",
+      "cdp_component_state",
+      "cdp_store_state",
+      "device_snapshot",
+      "device_screenshot",
+      "cdp_network_log",
+      "cdp_network_body",
+      "cdp_console_log",
+      "cdp_error_log",
+      "cdp_native_errors",
+      "cdp_diagnostic_renderers",
+      "cdp_object_inspect",
+      "cdp_heap_usage",
+      "collect_logs"
+    ]);
+    LIFECYCLE = /* @__PURE__ */ new Set([
+      "cdp_status",
+      "cdp_connect",
+      "cdp_disconnect",
+      "cdp_targets",
+      "cdp_reload",
+      "cdp_restart",
+      "cdp_dev_settings",
+      "cdp_open_devtools",
+      "device_list",
+      "observe"
+    ]);
+    TESTING = /* @__PURE__ */ new Set([
+      "maestro_run",
+      "maestro_generate",
+      "maestro_test_all",
+      "cdp_run_action",
+      "cdp_repair_action",
+      "proof_step",
+      "cross_platform_verify",
+      "cdp_auto_login",
+      "expect_redux",
+      "expect_route",
+      "expect_visible_by_testid",
+      "expect_text"
+    ]);
+  }
+});
+
+// packages/rn-dev-agent-core/dist/observability/recorder.js
+import { closeSync as closeSync3, constants, fstatSync, openSync as openSync3, readSync } from "node:fs";
+import { isAbsolute as isAbsolute2 } from "node:path";
+function screenshotPath(result) {
+  const data = unwrapResult(result)?.data ?? result?.data;
+  const p = data?.path ?? data?.message;
+  return typeof p === "string" && isAbsolute2(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
+}
+function readShotBounded(p) {
+  let fd;
+  try {
+    fd = openSync3(p, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+    const st = fstatSync(fd);
+    if (!st.isFile() || st.size > MAX_SHOT_BYTES)
+      return null;
+    const size = Number(st.size);
+    const buf = Buffer.alloc(size + 1);
+    const n = readSync(fd, buf, 0, size + 1, 0);
+    if (n > size)
+      return null;
+    return buf.subarray(0, n);
+  } catch {
+    return null;
+  } finally {
+    if (fd !== void 0) {
+      try {
+        closeSync3(fd);
+      } catch {
+      }
+    }
+  }
+}
+var DEFAULT_CAP, MAX_SHOT_BYTES, SHOT_REGISTRY_CAP, Recorder, recorder;
+var init_recorder = __esm({
+  "packages/rn-dev-agent-core/dist/observability/recorder.js"() {
+    "use strict";
+    init_ring_buffer();
+    init_events();
+    DEFAULT_CAP = 500;
+    MAX_SHOT_BYTES = 4e6;
+    SHOT_REGISTRY_CAP = 64;
+    Recorder = class {
+      buf;
+      seq = 0;
+      subs = /* @__PURE__ */ new Set();
+      shots = /* @__PURE__ */ new Map();
+      // GH #429: single-use trust grants from the capture pipeline (insertion-
+      // ordered, FIFO-evicted). Observations name paths, but only paths this
+      // process just captured may be read back — otherwise any tool result that
+      // mentions "/…/x.png" becomes an arbitrary local file read served over the
+      // observe server.
+      trustedShotPaths = /* @__PURE__ */ new Set();
+      shotCap;
+      liveShotData;
+      liveSeqVal = 0;
+      constructor(capacity = DEFAULT_CAP) {
+        this.buf = new RingBuffer(capacity);
+        this.shotCap = Math.max(8, Math.floor(capacity / 10));
+      }
+      record(o) {
+        try {
+          if (!o || typeof o !== "object" || typeof o.tool !== "string")
+            return;
+          const ev = mapObservation(++this.seq, o);
+          this.buf.push(ev);
+          this.captureScreenshot(ev, o);
+          for (const fn of this.subs) {
+            try {
+              fn(ev);
+            } catch {
+            }
+          }
+        } catch {
+        }
+      }
+      snapshot() {
+        return this.buf.getLast(this.buf.size);
+      }
+      attach(fn) {
+        const snapshot = this.buf.getLast(this.buf.size);
+        this.subs.add(fn);
+        return {
+          snapshot,
+          detach: () => {
+            this.subs.delete(fn);
+          }
+        };
+      }
+      getScreenshot(seq) {
+        return this.shots.get(seq);
+      }
+      /**
+       * GH #429: grant a one-shot read for a file the capture pipeline just
+       * wrote. `captureScreenshot` consumes the grant on first use, so a later
+       * observation replaying the same path is refused. User-chosen destinations
+       * (docs/proof/…, ~/Desktop/…) keep working because the grant is issued for
+       * whatever path the pipeline actually captured to.
+       */
+      registerCapturedScreenshot(p) {
+        if (typeof p !== "string" || !isAbsolute2(p))
+          return;
+        this.trustedShotPaths.delete(p);
+        this.trustedShotPaths.add(p);
+        while (this.trustedShotPaths.size > SHOT_REGISTRY_CAP) {
+          const oldest = this.trustedShotPaths.values().next().value;
+          if (oldest === void 0)
+            break;
+          this.trustedShotPaths.delete(oldest);
+        }
+      }
+      hasSubscribers() {
+        return this.subs.size > 0;
+      }
+      getLiveScreenshot() {
+        return this.liveShotData;
+      }
+      pushLive(frame) {
+        const ev = { type: "live" };
+        let changed = false;
+        if (frame.shot && frame.shot.buf.length <= MAX_SHOT_BYTES) {
+          this.liveShotData = frame.shot;
+          ev.shotSeq = ++this.liveSeqVal;
+          changed = true;
+        }
+        if (typeof frame.route === "string" && frame.route.length > 0) {
+          ev.route = frame.route;
+          changed = true;
+        }
+        if (!changed)
+          return;
+        for (const fn of this.subs) {
+          try {
+            fn(ev);
+          } catch {
+          }
+        }
+      }
+      push(ev) {
+        for (const fn of this.subs) {
+          try {
+            fn(ev);
+          } catch {
+          }
+        }
+      }
+      clear() {
+        this.buf.clear();
+        for (const fn of this.subs) {
+          try {
+            fn({ type: "cleared" });
+          } catch {
+          }
+        }
+        this.subs.clear();
+        this.shots.clear();
+        this.trustedShotPaths.clear();
+        this.seq = 0;
+        this.liveShotData = void 0;
+        this.liveSeqVal = 0;
+      }
+      captureScreenshot(ev, o) {
+        if (ev.tool !== "device_screenshot" || !ev.ok)
+          return;
+        const p = screenshotPath(o.result);
+        if (!p || !this.trustedShotPaths.delete(p))
+          return;
+        const buf = readShotBounded(p);
+        if (!buf)
+          return;
+        const contentType = p.endsWith(".png") ? "image/png" : "image/jpeg";
+        this.shots.set(ev.seq, { buf, contentType });
+        while (this.shots.size > this.shotCap) {
+          const oldest = this.shots.keys().next().value;
+          if (oldest === void 0)
+            break;
+          this.shots.delete(oldest);
+        }
+      }
+    };
+    recorder = new Recorder();
+  }
+});
+
 // packages/rn-dev-agent-core/dist/tools/device-list.js
 import { mkdirSync as mkdirSync12 } from "node:fs";
 import { execFile as execFile16 } from "node:child_process";
 import { promisify as promisify17 } from "node:util";
 import { dirname as dirname9, join as join25 } from "node:path";
-import { homedir as homedir8 } from "node:os";
+import { homedir as homedir9 } from "node:os";
 function parseSimctlDevicesAll(jsonText) {
   try {
     const parsed = JSON.parse(jsonText);
@@ -50710,7 +51136,7 @@ function deriveScreenshotPath(args, now = Date.now, rand = Math.random) {
   }
   if (args.path?.startsWith("~")) {
     if (args.path.startsWith("~/"))
-      return join25(homedir8(), args.path.slice(2));
+      return join25(homedir9(), args.path.slice(2));
     throw new TildeScreenshotPathError(`Screenshot path "${args.path}" starts with '~' which the bridge cannot expand (only a leading '~/' is expanded to the home directory). Pass an absolute path instead.`);
   }
   if (args.path)
@@ -50863,6 +51289,8 @@ async function captureAndResizeScreenshot(args) {
   if (result.isError)
     return result;
   const actualPath = resolveScreenshotPath(result, requestedPath);
+  recorder.registerCapturedScreenshot(requestedPath);
+  recorder.registerCapturedScreenshot(actualPath);
   const resizeOpts = {};
   if (args.maxWidth !== void 0)
     resizeOpts.maxWidth = args.maxWidth;
@@ -50892,6 +51320,7 @@ var init_device_list = __esm({
     init_foreign_flow_gate();
     init_path_safety();
     init_rn_android_runner_client();
+    init_recorder();
     runAgentDeviceFn2 = runNative;
     execFileAsync3 = promisify17(execFile16);
     defaultExec2 = (cmd, args) => execFileAsync3(cmd, args);
@@ -57827,7 +58256,7 @@ import { execFile as execFileCb19 } from "node:child_process";
 import { promisify as promisify25 } from "node:util";
 import { existsSync as existsSync24, readFileSync as readFileSync20, writeFileSync as writeFileSync14, readdirSync as readdirSync7 } from "node:fs";
 import { join as join30 } from "node:path";
-import { homedir as homedir9 } from "node:os";
+import { homedir as homedir10 } from "node:os";
 function matchesAuthPattern(routeName) {
   const lower = routeName.toLowerCase();
   return AUTH_ROUTE_PATTERNS.some((p) => lower.includes(p));
@@ -57947,7 +58376,7 @@ async function handleAutoLogin(client2, opts = {}) {
   }
   const wrapperPath = "/tmp/rn-auto-login-wrapper.yaml";
   writeFileSync14(wrapperPath, wrapperContent, "utf-8");
-  const runnerPath = join30(homedir9(), ".maestro-runner", "bin", "maestro-runner");
+  const runnerPath = join30(homedir10(), ".maestro-runner", "bin", "maestro-runner");
   if (!existsSync24(runnerPath)) {
     return {
       loggedIn: false,
@@ -59132,384 +59561,6 @@ var init_instrumentation = __esm({
   }
 });
 
-// packages/rn-dev-agent-core/dist/util/redact.js
-import { homedir as homedir10 } from "node:os";
-function redactString(value) {
-  let result = value.replace(HOME_RE, "~");
-  KEYED_SECRET_RE.lastIndex = 0;
-  result = result.replace(KEYED_SECRET_RE, "$1[REDACTED_SECRET]");
-  for (const pattern of SECRET_PATTERNS) {
-    pattern.lastIndex = 0;
-    result = result.replace(pattern, "[REDACTED_SECRET]");
-  }
-  for (const pattern of PII_PATTERNS) {
-    pattern.lastIndex = 0;
-    result = result.replace(pattern, "[PII_REDACTED]");
-  }
-  if (result.length > MAX_STRING_LENGTH) {
-    result = result.slice(0, MAX_STRING_LENGTH) + `[TRUNCATED:${result.length}]`;
-  }
-  return result;
-}
-function redactValue(value, path) {
-  if (value === null || value === void 0)
-    return value;
-  if (typeof value === "string")
-    return redactString(value);
-  if (Array.isArray(value)) {
-    return value.map((item, i) => redactValue(item, `${path}[${i}]`));
-  }
-  if (typeof value === "object") {
-    const obj = value;
-    const result = {};
-    for (const [key, val] of Object.entries(obj)) {
-      const fullPath = path ? `${path}.${key}` : key;
-      if (AUTH_PATHS.test(key)) {
-        result[key] = Array.isArray(val) ? "[REDACTED:array]" : `[REDACTED:${typeof val}]`;
-      } else {
-        result[key] = redactValue(val, fullPath);
-      }
-    }
-    return result;
-  }
-  return value;
-}
-function redact(data) {
-  return redactValue(data, "");
-}
-var HOME, HOME_RE, SECRET_PATTERNS, KEYED_SECRET_RE, PII_PATTERNS, AUTH_PATHS, MAX_STRING_LENGTH;
-var init_redact = __esm({
-  "packages/rn-dev-agent-core/dist/util/redact.js"() {
-    "use strict";
-    HOME = homedir10();
-    HOME_RE = new RegExp(HOME.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g");
-    SECRET_PATTERNS = [
-      /(?:sk|pk|api|key|token|secret|password|auth)[-_]?[A-Za-z0-9_-]{20,}/gi,
-      /Bearer\s+[A-Za-z0-9_\-./+=]{20,}/g,
-      /ghp_[A-Za-z0-9_]{36}/g,
-      /eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g,
-      /\bAKIA[0-9A-Z]{16}\b/g,
-      /\bxox[baprs]-[A-Za-z0-9-]+\b/g,
-      /\bAIza[0-9A-Za-z\-_]{35}\b/g,
-      // Any private-key label variant: PRIVATE KEY, RSA PRIVATE KEY,
-      // OPENSSH PRIVATE KEY, EC/DSA/ENCRYPTED PRIVATE KEY, ... The old single-word
-      // `(?:RSA |OPENSSH |PRIVATE )?KEY` form never matched multi-word labels like
-      // "RSA PRIVATE KEY" — the most common ssh-keygen header — so keys leaked.
-      /-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----/g
-    ];
-    KEYED_SECRET_RE = /((?:token|secret|password|passwd|pwd|api[_-]?key|apikey|authorization|auth|access[_-]?token|refresh[_-]?token|client[_-]?secret)["']?\s*[:=]\s*["']?)([^"'\s,;}]{6,})/gi;
-    PII_PATTERNS = [
-      /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
-      // Require separators so bare digit runs (timestamps, latencies, ids) are not
-      // mistaken for phone/SSN numbers (previously `[-.]?`/`[-]?` made them
-      // optional, redacting any 9-10 digit number).
-      /\b\d{3}[-.]\d{3}[-.]\d{4}\b/g,
-      /\b\d{3}-\d{2}-\d{4}\b/g
-    ];
-    AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
-    MAX_STRING_LENGTH = 2e3;
-  }
-});
-
-// packages/rn-dev-agent-core/dist/observability/events.js
-function classifyFamily(tool) {
-  if (INTERACTION.has(tool))
-    return "interaction";
-  if (NAVIGATION.has(tool))
-    return "navigation";
-  if (INTROSPECTION.has(tool))
-    return "introspection";
-  if (LIFECYCLE.has(tool))
-    return "lifecycle";
-  if (TESTING.has(tool))
-    return "testing";
-  return "other";
-}
-function clipThenRedact(args, payload) {
-  let redactedArgs;
-  try {
-    redactedArgs = redact(args ?? {});
-  } catch {
-    redactedArgs = { redacted: true };
-  }
-  if (payload === null || payload === void 0) {
-    return { args: redactedArgs };
-  }
-  try {
-    let json;
-    try {
-      json = JSON.stringify(payload);
-    } catch {
-      return { args: redactedArgs, payload: { redacted: true } };
-    }
-    let clipped = payload;
-    let truncated = false;
-    if (typeof json === "string" && json.length > CLIP_LIMIT) {
-      clipped = { _clipped: json.slice(0, CLIP_LIMIT) };
-      truncated = true;
-    }
-    const redactedPayload = redact({ v: clipped }).v;
-    return truncated ? { args: redactedArgs, payload: redactedPayload, truncated: true } : { args: redactedArgs, payload: redactedPayload };
-  } catch {
-    return { args: redactedArgs, payload: { redacted: true } };
-  }
-}
-function unwrapResult(result) {
-  if (!result || typeof result !== "object")
-    return void 0;
-  const env = result;
-  const text = env.content?.[0]?.text;
-  if (typeof text !== "string")
-    return void 0;
-  try {
-    return JSON.parse(text);
-  } catch {
-    return void 0;
-  }
-}
-function summarize(tool, _family, args, ok) {
-  const target = args.testID ?? args.ref ?? args.text ?? args.screen ?? args.path ?? "";
-  const head = target ? `${tool} ${String(target).slice(0, 60)}` : tool;
-  return ok ? head : `${head} \u2717`;
-}
-function mapObservation(seq, o) {
-  const family = classifyFamily(o.tool);
-  const ok = o.status === "PASS";
-  const unwrapped = unwrapResult(o.result);
-  const payloadSource = ok ? unwrapped ? unwrapped.data : o.result : void 0;
-  const { args, payload, truncated } = clipThenRedact(o.params ?? {}, payloadSource);
-  const summary = summarize(o.tool, family, args, ok);
-  const event = {
-    seq,
-    ts: Date.now(),
-    tool: o.tool,
-    family,
-    args,
-    ok,
-    durationMs: o.latencyMs,
-    summary
-  };
-  if (payload !== void 0)
-    event.payload = payload;
-  if (truncated)
-    event.truncated = true;
-  if (!ok && o.error) {
-    const raw = String(o.error).slice(0, 500);
-    let message;
-    try {
-      message = String(redact({ m: raw }).m);
-    } catch {
-      message = "[REDACTED:error]";
-    }
-    event.error = { message };
-  }
-  if (o.ghost?.attempted)
-    event.ghost = o.ghost;
-  return event;
-}
-var CLIP_LIMIT, INTERACTION, NAVIGATION, INTROSPECTION, LIFECYCLE, TESTING;
-var init_events = __esm({
-  "packages/rn-dev-agent-core/dist/observability/events.js"() {
-    "use strict";
-    init_redact();
-    CLIP_LIMIT = 16e3;
-    INTERACTION = /* @__PURE__ */ new Set([
-      "device_press",
-      "device_fill",
-      "device_swipe",
-      "device_scroll",
-      "device_longpress",
-      "device_pinch",
-      "device_back",
-      "device_batch",
-      "device_scrollintoview",
-      "cdp_interact",
-      "device_focus_next",
-      "device_pick_date",
-      "device_pick_value",
-      "device_deeplink"
-    ]);
-    NAVIGATION = /* @__PURE__ */ new Set(["cdp_navigation_state", "cdp_nav_graph", "cdp_navigate"]);
-    INTROSPECTION = /* @__PURE__ */ new Set([
-      "cdp_component_tree",
-      "cdp_component_state",
-      "cdp_store_state",
-      "device_snapshot",
-      "device_screenshot",
-      "cdp_network_log",
-      "cdp_network_body",
-      "cdp_console_log",
-      "cdp_error_log",
-      "cdp_native_errors",
-      "cdp_diagnostic_renderers",
-      "cdp_object_inspect",
-      "cdp_heap_usage",
-      "collect_logs"
-    ]);
-    LIFECYCLE = /* @__PURE__ */ new Set([
-      "cdp_status",
-      "cdp_connect",
-      "cdp_disconnect",
-      "cdp_targets",
-      "cdp_reload",
-      "cdp_restart",
-      "cdp_dev_settings",
-      "cdp_open_devtools",
-      "device_list",
-      "observe"
-    ]);
-    TESTING = /* @__PURE__ */ new Set([
-      "maestro_run",
-      "maestro_generate",
-      "maestro_test_all",
-      "cdp_run_action",
-      "cdp_repair_action",
-      "proof_step",
-      "cross_platform_verify",
-      "cdp_auto_login",
-      "expect_redux",
-      "expect_route",
-      "expect_visible_by_testid",
-      "expect_text"
-    ]);
-  }
-});
-
-// packages/rn-dev-agent-core/dist/observability/recorder.js
-import { readFileSync as readFileSync23, statSync as statSync9 } from "node:fs";
-import { isAbsolute as isAbsolute2 } from "node:path";
-function screenshotPath(result) {
-  const data = unwrapResult(result)?.data ?? result?.data;
-  const p = data?.path ?? data?.message;
-  return typeof p === "string" && isAbsolute2(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
-}
-var DEFAULT_CAP, MAX_SHOT_BYTES, Recorder, recorder;
-var init_recorder = __esm({
-  "packages/rn-dev-agent-core/dist/observability/recorder.js"() {
-    "use strict";
-    init_ring_buffer();
-    init_events();
-    DEFAULT_CAP = 500;
-    MAX_SHOT_BYTES = 4e6;
-    Recorder = class {
-      buf;
-      seq = 0;
-      subs = /* @__PURE__ */ new Set();
-      shots = /* @__PURE__ */ new Map();
-      shotCap;
-      liveShotData;
-      liveSeqVal = 0;
-      constructor(capacity = DEFAULT_CAP) {
-        this.buf = new RingBuffer(capacity);
-        this.shotCap = Math.max(8, Math.floor(capacity / 10));
-      }
-      record(o) {
-        try {
-          if (!o || typeof o !== "object" || typeof o.tool !== "string")
-            return;
-          const ev = mapObservation(++this.seq, o);
-          this.buf.push(ev);
-          this.captureScreenshot(ev, o);
-          for (const fn of this.subs) {
-            try {
-              fn(ev);
-            } catch {
-            }
-          }
-        } catch {
-        }
-      }
-      snapshot() {
-        return this.buf.getLast(this.buf.size);
-      }
-      attach(fn) {
-        const snapshot = this.buf.getLast(this.buf.size);
-        this.subs.add(fn);
-        return {
-          snapshot,
-          detach: () => {
-            this.subs.delete(fn);
-          }
-        };
-      }
-      getScreenshot(seq) {
-        return this.shots.get(seq);
-      }
-      hasSubscribers() {
-        return this.subs.size > 0;
-      }
-      getLiveScreenshot() {
-        return this.liveShotData;
-      }
-      pushLive(frame) {
-        const ev = { type: "live" };
-        let changed = false;
-        if (frame.shot && frame.shot.buf.length <= MAX_SHOT_BYTES) {
-          this.liveShotData = frame.shot;
-          ev.shotSeq = ++this.liveSeqVal;
-          changed = true;
-        }
-        if (typeof frame.route === "string" && frame.route.length > 0) {
-          ev.route = frame.route;
-          changed = true;
-        }
-        if (!changed)
-          return;
-        for (const fn of this.subs) {
-          try {
-            fn(ev);
-          } catch {
-          }
-        }
-      }
-      push(ev) {
-        for (const fn of this.subs) {
-          try {
-            fn(ev);
-          } catch {
-          }
-        }
-      }
-      clear() {
-        this.buf.clear();
-        for (const fn of this.subs) {
-          try {
-            fn({ type: "cleared" });
-          } catch {
-          }
-        }
-        this.subs.clear();
-        this.shots.clear();
-        this.seq = 0;
-        this.liveShotData = void 0;
-        this.liveSeqVal = 0;
-      }
-      captureScreenshot(ev, o) {
-        if (ev.tool !== "device_screenshot" || !ev.ok)
-          return;
-        const p = screenshotPath(o.result);
-        if (!p)
-          return;
-        try {
-          if (statSync9(p).size > MAX_SHOT_BYTES)
-            return;
-          const buf = readFileSync23(p);
-          const contentType = p.endsWith(".png") ? "image/png" : "image/jpeg";
-          this.shots.set(ev.seq, { buf, contentType });
-          while (this.shots.size > this.shotCap) {
-            const oldest = this.shots.keys().next().value;
-            if (oldest === void 0)
-              break;
-            this.shots.delete(oldest);
-          }
-        } catch {
-        }
-      }
-    };
-    recorder = new Recorder();
-  }
-});
-
 // packages/rn-dev-agent-core/dist/observability/live-device.js
 import { join as join34 } from "node:path";
 import { tmpdir as tmpdir10 } from "node:os";
@@ -59701,7 +59752,7 @@ var init_e2e_csrf = __esm({
 
 // packages/rn-dev-agent-core/dist/observability/server.js
 import { createServer as createServer3 } from "node:http";
-import { readFileSync as readFileSync24 } from "node:fs";
+import { readFileSync as readFileSync23 } from "node:fs";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 import { dirname as dirname13, join as join35 } from "node:path";
 function listen(server3, port) {
@@ -59897,7 +59948,7 @@ var init_server3 = __esm({
       }
       index(res) {
         try {
-          let html = readFileSync24(join35(__dir, "web-dist", "index.html"), "utf8");
+          let html = readFileSync23(join35(__dir, "web-dist", "index.html"), "utf8");
           if (this.e2e) {
             const tokenJs = JSON.stringify(this.e2e.token).replace(/</g, "\\u003c");
             html = html.replace("</head>", `<script>window.__E2E_CSRF__=${tokenJs}</script></head>`);
@@ -60818,7 +60869,7 @@ var init_target = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
 import { dirname as dirname14, join as join38 } from "node:path";
-import { mkdirSync as mkdirSync15, writeFileSync as writeFileSync17, renameSync as renameSync5, readFileSync as readFileSync25, readdirSync as readdirSync10, existsSync as existsSync27 } from "node:fs";
+import { mkdirSync as mkdirSync15, writeFileSync as writeFileSync17, renameSync as renameSync5, readFileSync as readFileSync24, readdirSync as readdirSync10, existsSync as existsSync27 } from "node:fs";
 import { createHash as createHash6 } from "node:crypto";
 function e2eDirFor(projectRoot) {
   return join38(projectRoot, ".rn-agent", "e2e");
@@ -60876,7 +60927,7 @@ function loadLockedTest(projectRoot, id) {
   const filePath = e2ePathFor(projectRoot, id);
   if (!existsSync27(filePath))
     return null;
-  return parseLockedTest(readFileSync25(filePath, "utf8"), filePath);
+  return parseLockedTest(readFileSync24(filePath, "utf8"), filePath);
 }
 function discoverLockedTests(projectRoot) {
   const dir = e2eDirFor(projectRoot);
@@ -60927,12 +60978,12 @@ var init_e2e_test = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/e2e-config.js
-import { readFileSync as readFileSync26 } from "node:fs";
+import { readFileSync as readFileSync25 } from "node:fs";
 import { join as join39 } from "node:path";
 function loadE2eConfig(projectRoot) {
   const filePath = join39(projectRoot, ".rn-agent", "e2e.config.json");
   try {
-    const raw = readFileSync26(filePath, "utf8");
+    const raw = readFileSync25(filePath, "utf8");
     return JSON.parse(raw);
   } catch {
     return {};
@@ -60993,7 +61044,7 @@ var init_git_info = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/lock-e2e-test.js
-import { readFileSync as readFileSync27 } from "node:fs";
+import { readFileSync as readFileSync26 } from "node:fs";
 function readPassed(result) {
   try {
     const env = JSON.parse(result.content[0].text);
@@ -61008,7 +61059,7 @@ function readPassed(result) {
 async function lockE2eTestCore(args, deps = {}) {
   const projectRoot = args.projectRoot ?? findProjectRoot() ?? process.cwd();
   const load = deps.loadAction ?? loadAction;
-  const readFile3 = deps.readActionFile ?? ((p) => readFileSync27(p, "utf8"));
+  const readFile3 = deps.readActionFile ?? ((p) => readFileSync26(p, "utf8"));
   const getGit = deps.getGitInfo ?? getGitInfo;
   const getSession = deps.getSession ?? getActiveSession;
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
@@ -61079,7 +61130,7 @@ var init_lock_e2e_test = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
 import { join as join40 } from "node:path";
-import { mkdirSync as mkdirSync16, writeFileSync as writeFileSync18, renameSync as renameSync6, readFileSync as readFileSync28, existsSync as existsSync28 } from "node:fs";
+import { mkdirSync as mkdirSync16, writeFileSync as writeFileSync18, renameSync as renameSync6, readFileSync as readFileSync27, existsSync as existsSync28 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
     return {
@@ -61146,7 +61197,7 @@ function loadIndex(projectRoot) {
   if (!existsSync28(file))
     return [];
   try {
-    const parsed = JSON.parse(readFileSync28(file, "utf8"));
+    const parsed = JSON.parse(readFileSync27(file, "utf8"));
     return Array.isArray(parsed) ? parsed : [];
   } catch {
     return [];
@@ -61171,7 +61222,7 @@ function loadRunRecord(projectRoot, runId) {
   if (!existsSync28(file))
     return null;
   try {
-    return JSON.parse(readFileSync28(file, "utf8"));
+    return JSON.parse(readFileSync27(file, "utf8"));
   } catch {
     return null;
   }
@@ -61191,7 +61242,7 @@ var init_e2e_run = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
 import { join as join41 } from "node:path";
-import { mkdirSync as mkdirSync17, writeFileSync as writeFileSync19, renameSync as renameSync7, readFileSync as readFileSync29, readdirSync as readdirSync11, existsSync as existsSync29 } from "node:fs";
+import { mkdirSync as mkdirSync17, writeFileSync as writeFileSync19, renameSync as renameSync7, readFileSync as readFileSync28, readdirSync as readdirSync11, existsSync as existsSync29 } from "node:fs";
 function requestsDir(projectRoot) {
   return join41(e2eRunsDirFor(projectRoot), "requests");
 }
@@ -61211,7 +61262,7 @@ function loadRequest(projectRoot, runId) {
   if (!existsSync29(file))
     return null;
   try {
-    return JSON.parse(readFileSync29(file, "utf8"));
+    return JSON.parse(readFileSync28(file, "utf8"));
   } catch {
     return null;
   }
@@ -61587,7 +61638,7 @@ var init_action_inventory = __esm({
 
 // packages/rn-dev-agent-core/dist/index.js
 var index_exports = {};
-import { readFileSync as readFileSync30 } from "node:fs";
+import { readFileSync as readFileSync29 } from "node:fs";
 import { execFile as execFile27 } from "node:child_process";
 import { promisify as promisify28 } from "node:util";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
@@ -61746,7 +61797,7 @@ var init_index = __esm({
     init_action_store();
     init_e2e_config();
     pkgPath = join43(dirname15(fileURLToPath3(import.meta.url)), "..", "package.json");
-    pkgVersion = JSON.parse(readFileSync30(pkgPath, "utf8")).version;
+    pkgVersion = JSON.parse(readFileSync29(pkgPath, "utf8")).version;
     lockfile = null;
     noLock = process.argv.includes("--no-lock");
     if (!noLock) {
@@ -61884,7 +61935,7 @@ var init_index = __esm({
       readRoute: (c) => readLiveRoute(c),
       readShotFile: (path) => {
         try {
-          const buf = readFileSync30(path);
+          const buf = readFileSync29(path);
           const isPng = buf.length >= 4 && buf[0] === 137 && buf[1] === 80 && buf[2] === 78 && buf[3] === 71;
           return { buf, contentType: isPng ? "image/png" : "image/jpeg" };
         } catch {
@@ -62654,7 +62705,7 @@ var init_index = __esm({
 init_lockfile();
 init_parent_watch();
 import { spawn as spawn6 } from "node:child_process";
-import { readFileSync as readFileSync31 } from "node:fs";
+import { readFileSync as readFileSync30 } from "node:fs";
 import { dirname as dirname16, join as join44 } from "node:path";
 import { fileURLToPath as fileURLToPath4 } from "node:url";
 
@@ -62771,7 +62822,7 @@ if (process.env.RN_BRIDGE_SUPERVISOR === "0") {
   const noLock2 = process.argv.includes("--no-lock");
   let lockfile2 = null;
   if (!noLock2) {
-    const pkg = JSON.parse(readFileSync31(join44(here, "..", "package.json"), "utf8"));
+    const pkg = JSON.parse(readFileSync30(join44(here, "..", "package.json"), "utf8"));
     lockfile2 = new Lockfile({ version: pkg.version });
     const lockResult = lockfile2.acquire();
     if (lockResult.status === "conflict") {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -424,11 +424,11 @@ var require_codegen = __commonJS({
         const rhs = this.rhs === void 0 ? "" : ` = ${this.rhs}`;
         return `${varKind} ${this.name}${rhs};` + _n;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         if (!names[this.name.str])
           return;
         if (this.rhs)
-          this.rhs = optimizeExpr(this.rhs, names, constants);
+          this.rhs = optimizeExpr(this.rhs, names, constants2);
         return this;
       }
       get names() {
@@ -445,10 +445,10 @@ var require_codegen = __commonJS({
       render({ _n }) {
         return `${this.lhs} = ${this.rhs};` + _n;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         if (this.lhs instanceof code_1.Name && !names[this.lhs.str] && !this.sideEffects)
           return;
-        this.rhs = optimizeExpr(this.rhs, names, constants);
+        this.rhs = optimizeExpr(this.rhs, names, constants2);
         return this;
       }
       get names() {
@@ -509,8 +509,8 @@ var require_codegen = __commonJS({
       optimizeNodes() {
         return `${this.code}` ? this : void 0;
       }
-      optimizeNames(names, constants) {
-        this.code = optimizeExpr(this.code, names, constants);
+      optimizeNames(names, constants2) {
+        this.code = optimizeExpr(this.code, names, constants2);
         return this;
       }
       get names() {
@@ -539,12 +539,12 @@ var require_codegen = __commonJS({
         }
         return nodes.length > 0 ? this : void 0;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         const { nodes } = this;
         let i = nodes.length;
         while (i--) {
           const n = nodes[i];
-          if (n.optimizeNames(names, constants))
+          if (n.optimizeNames(names, constants2))
             continue;
           subtractNames(names, n.names);
           nodes.splice(i, 1);
@@ -597,12 +597,12 @@ var require_codegen = __commonJS({
           return void 0;
         return this;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         var _a;
-        this.else = (_a = this.else) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants);
-        if (!(super.optimizeNames(names, constants) || this.else))
+        this.else = (_a = this.else) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants2);
+        if (!(super.optimizeNames(names, constants2) || this.else))
           return;
-        this.condition = optimizeExpr(this.condition, names, constants);
+        this.condition = optimizeExpr(this.condition, names, constants2);
         return this;
       }
       get names() {
@@ -625,10 +625,10 @@ var require_codegen = __commonJS({
       render(opts) {
         return `for(${this.iteration})` + super.render(opts);
       }
-      optimizeNames(names, constants) {
-        if (!super.optimizeNames(names, constants))
+      optimizeNames(names, constants2) {
+        if (!super.optimizeNames(names, constants2))
           return;
-        this.iteration = optimizeExpr(this.iteration, names, constants);
+        this.iteration = optimizeExpr(this.iteration, names, constants2);
         return this;
       }
       get names() {
@@ -664,10 +664,10 @@ var require_codegen = __commonJS({
       render(opts) {
         return `for(${this.varKind} ${this.name} ${this.loop} ${this.iterable})` + super.render(opts);
       }
-      optimizeNames(names, constants) {
-        if (!super.optimizeNames(names, constants))
+      optimizeNames(names, constants2) {
+        if (!super.optimizeNames(names, constants2))
           return;
-        this.iterable = optimizeExpr(this.iterable, names, constants);
+        this.iterable = optimizeExpr(this.iterable, names, constants2);
         return this;
       }
       get names() {
@@ -709,11 +709,11 @@ var require_codegen = __commonJS({
         (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNodes();
         return this;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         var _a, _b;
-        super.optimizeNames(names, constants);
-        (_a = this.catch) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants);
-        (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNames(names, constants);
+        super.optimizeNames(names, constants2);
+        (_a = this.catch) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants2);
+        (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNames(names, constants2);
         return this;
       }
       get names() {
@@ -1014,7 +1014,7 @@ var require_codegen = __commonJS({
     function addExprNames(names, from) {
       return from instanceof code_1._CodeOrName ? addNames(names, from.names) : names;
     }
-    function optimizeExpr(expr, names, constants) {
+    function optimizeExpr(expr, names, constants2) {
       if (expr instanceof code_1.Name)
         return replaceName(expr);
       if (!canOptimize(expr))
@@ -1029,14 +1029,14 @@ var require_codegen = __commonJS({
         return items;
       }, []));
       function replaceName(n) {
-        const c = constants[n.str];
+        const c = constants2[n.str];
         if (c === void 0 || names[n.str] !== 1)
           return n;
         delete names[n.str];
         return c;
       }
       function canOptimize(e) {
-        return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants[c.str] !== void 0);
+        return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants2[c.str] !== void 0);
       }
     }
     function subtractNames(names, from) {
@@ -26750,7 +26750,7 @@ ensureJavaEnv();
 ensureCwd();
 
 // packages/rn-dev-agent-core/dist/index.js
-import { readFileSync as readFileSync30 } from "node:fs";
+import { readFileSync as readFileSync29 } from "node:fs";
 import { execFile as execFile27 } from "node:child_process";
 import { promisify as promisify28 } from "node:util";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
@@ -49029,7 +49029,7 @@ import { mkdirSync as mkdirSync11 } from "node:fs";
 import { execFile as execFile16 } from "node:child_process";
 import { promisify as promisify17 } from "node:util";
 import { dirname as dirname9, join as join24 } from "node:path";
-import { homedir as homedir8 } from "node:os";
+import { homedir as homedir9 } from "node:os";
 
 // packages/rn-dev-agent-core/dist/tools/device-screenshot-resize.js
 import { execFile as execFileCb13 } from "node:child_process";
@@ -49172,6 +49172,415 @@ function pathHasTraversal(p) {
 
 // packages/rn-dev-agent-core/dist/tools/device-list.js
 init_rn_android_runner_client();
+
+// packages/rn-dev-agent-core/dist/observability/recorder.js
+import { closeSync as closeSync2, constants, fstatSync, openSync as openSync2, readSync } from "node:fs";
+import { isAbsolute as isAbsolute2 } from "node:path";
+
+// packages/rn-dev-agent-core/dist/util/redact.js
+import { homedir as homedir8 } from "node:os";
+var HOME = homedir8();
+var HOME_RE = new RegExp(HOME.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g");
+var SECRET_PATTERNS = [
+  /(?:sk|pk|api|key|token|secret|password|auth)[-_]?[A-Za-z0-9_-]{20,}/gi,
+  /Bearer\s+[A-Za-z0-9_\-./+=]{20,}/g,
+  /ghp_[A-Za-z0-9_]{36}/g,
+  /eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\bxox[baprs]-[A-Za-z0-9-]+\b/g,
+  /\bAIza[0-9A-Za-z\-_]{35}\b/g,
+  // Any private-key label variant: PRIVATE KEY, RSA PRIVATE KEY,
+  // OPENSSH PRIVATE KEY, EC/DSA/ENCRYPTED PRIVATE KEY, ... The old single-word
+  // `(?:RSA |OPENSSH |PRIVATE )?KEY` form never matched multi-word labels like
+  // "RSA PRIVATE KEY" — the most common ssh-keygen header — so keys leaked.
+  /-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----/g
+];
+var KEYED_SECRET_RE = /((?:token|secret|password|passwd|pwd|api[_-]?key|apikey|authorization|auth|access[_-]?token|refresh[_-]?token|client[_-]?secret)["']?\s*[:=]\s*["']?)([^"'\s,;}]{6,})/gi;
+var PII_PATTERNS = [
+  /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
+  // Require separators so bare digit runs (timestamps, latencies, ids) are not
+  // mistaken for phone/SSN numbers (previously `[-.]?`/`[-]?` made them
+  // optional, redacting any 9-10 digit number).
+  /\b\d{3}[-.]\d{3}[-.]\d{4}\b/g,
+  /\b\d{3}-\d{2}-\d{4}\b/g
+];
+var AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
+var MAX_STRING_LENGTH = 2e3;
+function redactString(value) {
+  let result = value.replace(HOME_RE, "~");
+  KEYED_SECRET_RE.lastIndex = 0;
+  result = result.replace(KEYED_SECRET_RE, "$1[REDACTED_SECRET]");
+  for (const pattern of SECRET_PATTERNS) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, "[REDACTED_SECRET]");
+  }
+  for (const pattern of PII_PATTERNS) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, "[PII_REDACTED]");
+  }
+  if (result.length > MAX_STRING_LENGTH) {
+    result = result.slice(0, MAX_STRING_LENGTH) + `[TRUNCATED:${result.length}]`;
+  }
+  return result;
+}
+function redactValue(value, path) {
+  if (value === null || value === void 0)
+    return value;
+  if (typeof value === "string")
+    return redactString(value);
+  if (Array.isArray(value)) {
+    return value.map((item, i) => redactValue(item, `${path}[${i}]`));
+  }
+  if (typeof value === "object") {
+    const obj = value;
+    const result = {};
+    for (const [key, val] of Object.entries(obj)) {
+      const fullPath = path ? `${path}.${key}` : key;
+      if (AUTH_PATHS.test(key)) {
+        result[key] = Array.isArray(val) ? "[REDACTED:array]" : `[REDACTED:${typeof val}]`;
+      } else {
+        result[key] = redactValue(val, fullPath);
+      }
+    }
+    return result;
+  }
+  return value;
+}
+function redact(data) {
+  return redactValue(data, "");
+}
+
+// packages/rn-dev-agent-core/dist/observability/events.js
+var CLIP_LIMIT = 16e3;
+var INTERACTION = /* @__PURE__ */ new Set([
+  "device_press",
+  "device_fill",
+  "device_swipe",
+  "device_scroll",
+  "device_longpress",
+  "device_pinch",
+  "device_back",
+  "device_batch",
+  "device_scrollintoview",
+  "cdp_interact",
+  "device_focus_next",
+  "device_pick_date",
+  "device_pick_value",
+  "device_deeplink"
+]);
+var NAVIGATION = /* @__PURE__ */ new Set(["cdp_navigation_state", "cdp_nav_graph", "cdp_navigate"]);
+var INTROSPECTION = /* @__PURE__ */ new Set([
+  "cdp_component_tree",
+  "cdp_component_state",
+  "cdp_store_state",
+  "device_snapshot",
+  "device_screenshot",
+  "cdp_network_log",
+  "cdp_network_body",
+  "cdp_console_log",
+  "cdp_error_log",
+  "cdp_native_errors",
+  "cdp_diagnostic_renderers",
+  "cdp_object_inspect",
+  "cdp_heap_usage",
+  "collect_logs"
+]);
+var LIFECYCLE = /* @__PURE__ */ new Set([
+  "cdp_status",
+  "cdp_connect",
+  "cdp_disconnect",
+  "cdp_targets",
+  "cdp_reload",
+  "cdp_restart",
+  "cdp_dev_settings",
+  "cdp_open_devtools",
+  "device_list",
+  "observe"
+]);
+var TESTING = /* @__PURE__ */ new Set([
+  "maestro_run",
+  "maestro_generate",
+  "maestro_test_all",
+  "cdp_run_action",
+  "cdp_repair_action",
+  "proof_step",
+  "cross_platform_verify",
+  "cdp_auto_login",
+  "expect_redux",
+  "expect_route",
+  "expect_visible_by_testid",
+  "expect_text"
+]);
+function classifyFamily(tool) {
+  if (INTERACTION.has(tool))
+    return "interaction";
+  if (NAVIGATION.has(tool))
+    return "navigation";
+  if (INTROSPECTION.has(tool))
+    return "introspection";
+  if (LIFECYCLE.has(tool))
+    return "lifecycle";
+  if (TESTING.has(tool))
+    return "testing";
+  return "other";
+}
+function clipThenRedact(args, payload) {
+  let redactedArgs;
+  try {
+    redactedArgs = redact(args ?? {});
+  } catch {
+    redactedArgs = { redacted: true };
+  }
+  if (payload === null || payload === void 0) {
+    return { args: redactedArgs };
+  }
+  try {
+    let json;
+    try {
+      json = JSON.stringify(payload);
+    } catch {
+      return { args: redactedArgs, payload: { redacted: true } };
+    }
+    let clipped = payload;
+    let truncated = false;
+    if (typeof json === "string" && json.length > CLIP_LIMIT) {
+      clipped = { _clipped: json.slice(0, CLIP_LIMIT) };
+      truncated = true;
+    }
+    const redactedPayload = redact({ v: clipped }).v;
+    return truncated ? { args: redactedArgs, payload: redactedPayload, truncated: true } : { args: redactedArgs, payload: redactedPayload };
+  } catch {
+    return { args: redactedArgs, payload: { redacted: true } };
+  }
+}
+function unwrapResult(result) {
+  if (!result || typeof result !== "object")
+    return void 0;
+  const env = result;
+  const text = env.content?.[0]?.text;
+  if (typeof text !== "string")
+    return void 0;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return void 0;
+  }
+}
+function summarize(tool, _family, args, ok) {
+  const target = args.testID ?? args.ref ?? args.text ?? args.screen ?? args.path ?? "";
+  const head = target ? `${tool} ${String(target).slice(0, 60)}` : tool;
+  return ok ? head : `${head} \u2717`;
+}
+function mapObservation(seq, o) {
+  const family = classifyFamily(o.tool);
+  const ok = o.status === "PASS";
+  const unwrapped = unwrapResult(o.result);
+  const payloadSource = ok ? unwrapped ? unwrapped.data : o.result : void 0;
+  const { args, payload, truncated } = clipThenRedact(o.params ?? {}, payloadSource);
+  const summary = summarize(o.tool, family, args, ok);
+  const event = {
+    seq,
+    ts: Date.now(),
+    tool: o.tool,
+    family,
+    args,
+    ok,
+    durationMs: o.latencyMs,
+    summary
+  };
+  if (payload !== void 0)
+    event.payload = payload;
+  if (truncated)
+    event.truncated = true;
+  if (!ok && o.error) {
+    const raw = String(o.error).slice(0, 500);
+    let message;
+    try {
+      message = String(redact({ m: raw }).m);
+    } catch {
+      message = "[REDACTED:error]";
+    }
+    event.error = { message };
+  }
+  if (o.ghost?.attempted)
+    event.ghost = o.ghost;
+  return event;
+}
+
+// packages/rn-dev-agent-core/dist/observability/recorder.js
+var DEFAULT_CAP = 500;
+var MAX_SHOT_BYTES = 4e6;
+var SHOT_REGISTRY_CAP = 64;
+function screenshotPath(result) {
+  const data = unwrapResult(result)?.data ?? result?.data;
+  const p = data?.path ?? data?.message;
+  return typeof p === "string" && isAbsolute2(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
+}
+function readShotBounded(p) {
+  let fd;
+  try {
+    fd = openSync2(p, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+    const st = fstatSync(fd);
+    if (!st.isFile() || st.size > MAX_SHOT_BYTES)
+      return null;
+    const size = Number(st.size);
+    const buf = Buffer.alloc(size + 1);
+    const n = readSync(fd, buf, 0, size + 1, 0);
+    if (n > size)
+      return null;
+    return buf.subarray(0, n);
+  } catch {
+    return null;
+  } finally {
+    if (fd !== void 0) {
+      try {
+        closeSync2(fd);
+      } catch {
+      }
+    }
+  }
+}
+var Recorder = class {
+  buf;
+  seq = 0;
+  subs = /* @__PURE__ */ new Set();
+  shots = /* @__PURE__ */ new Map();
+  // GH #429: single-use trust grants from the capture pipeline (insertion-
+  // ordered, FIFO-evicted). Observations name paths, but only paths this
+  // process just captured may be read back — otherwise any tool result that
+  // mentions "/…/x.png" becomes an arbitrary local file read served over the
+  // observe server.
+  trustedShotPaths = /* @__PURE__ */ new Set();
+  shotCap;
+  liveShotData;
+  liveSeqVal = 0;
+  constructor(capacity = DEFAULT_CAP) {
+    this.buf = new RingBuffer(capacity);
+    this.shotCap = Math.max(8, Math.floor(capacity / 10));
+  }
+  record(o) {
+    try {
+      if (!o || typeof o !== "object" || typeof o.tool !== "string")
+        return;
+      const ev = mapObservation(++this.seq, o);
+      this.buf.push(ev);
+      this.captureScreenshot(ev, o);
+      for (const fn of this.subs) {
+        try {
+          fn(ev);
+        } catch {
+        }
+      }
+    } catch {
+    }
+  }
+  snapshot() {
+    return this.buf.getLast(this.buf.size);
+  }
+  attach(fn) {
+    const snapshot = this.buf.getLast(this.buf.size);
+    this.subs.add(fn);
+    return {
+      snapshot,
+      detach: () => {
+        this.subs.delete(fn);
+      }
+    };
+  }
+  getScreenshot(seq) {
+    return this.shots.get(seq);
+  }
+  /**
+   * GH #429: grant a one-shot read for a file the capture pipeline just
+   * wrote. `captureScreenshot` consumes the grant on first use, so a later
+   * observation replaying the same path is refused. User-chosen destinations
+   * (docs/proof/…, ~/Desktop/…) keep working because the grant is issued for
+   * whatever path the pipeline actually captured to.
+   */
+  registerCapturedScreenshot(p) {
+    if (typeof p !== "string" || !isAbsolute2(p))
+      return;
+    this.trustedShotPaths.delete(p);
+    this.trustedShotPaths.add(p);
+    while (this.trustedShotPaths.size > SHOT_REGISTRY_CAP) {
+      const oldest = this.trustedShotPaths.values().next().value;
+      if (oldest === void 0)
+        break;
+      this.trustedShotPaths.delete(oldest);
+    }
+  }
+  hasSubscribers() {
+    return this.subs.size > 0;
+  }
+  getLiveScreenshot() {
+    return this.liveShotData;
+  }
+  pushLive(frame) {
+    const ev = { type: "live" };
+    let changed = false;
+    if (frame.shot && frame.shot.buf.length <= MAX_SHOT_BYTES) {
+      this.liveShotData = frame.shot;
+      ev.shotSeq = ++this.liveSeqVal;
+      changed = true;
+    }
+    if (typeof frame.route === "string" && frame.route.length > 0) {
+      ev.route = frame.route;
+      changed = true;
+    }
+    if (!changed)
+      return;
+    for (const fn of this.subs) {
+      try {
+        fn(ev);
+      } catch {
+      }
+    }
+  }
+  push(ev) {
+    for (const fn of this.subs) {
+      try {
+        fn(ev);
+      } catch {
+      }
+    }
+  }
+  clear() {
+    this.buf.clear();
+    for (const fn of this.subs) {
+      try {
+        fn({ type: "cleared" });
+      } catch {
+      }
+    }
+    this.subs.clear();
+    this.shots.clear();
+    this.trustedShotPaths.clear();
+    this.seq = 0;
+    this.liveShotData = void 0;
+    this.liveSeqVal = 0;
+  }
+  captureScreenshot(ev, o) {
+    if (ev.tool !== "device_screenshot" || !ev.ok)
+      return;
+    const p = screenshotPath(o.result);
+    if (!p || !this.trustedShotPaths.delete(p))
+      return;
+    const buf = readShotBounded(p);
+    if (!buf)
+      return;
+    const contentType = p.endsWith(".png") ? "image/png" : "image/jpeg";
+    this.shots.set(ev.seq, { buf, contentType });
+    while (this.shots.size > this.shotCap) {
+      const oldest = this.shots.keys().next().value;
+      if (oldest === void 0)
+        break;
+      this.shots.delete(oldest);
+    }
+  }
+};
+var recorder = new Recorder();
+
+// packages/rn-dev-agent-core/dist/tools/device-list.js
 var runAgentDeviceFn2 = runNative;
 var execFileAsync3 = promisify17(execFile16);
 var defaultExec2 = (cmd, args) => execFileAsync3(cmd, args);
@@ -49218,7 +49627,7 @@ function deriveScreenshotPath(args, now = Date.now, rand = Math.random) {
   }
   if (args.path?.startsWith("~")) {
     if (args.path.startsWith("~/"))
-      return join24(homedir8(), args.path.slice(2));
+      return join24(homedir9(), args.path.slice(2));
     throw new TildeScreenshotPathError(`Screenshot path "${args.path}" starts with '~' which the bridge cannot expand (only a leading '~/' is expanded to the home directory). Pass an absolute path instead.`);
   }
   if (args.path)
@@ -49383,6 +49792,8 @@ async function captureAndResizeScreenshot(args) {
   if (result.isError)
     return result;
   const actualPath = resolveScreenshotPath(result, requestedPath);
+  recorder.registerCapturedScreenshot(requestedPath);
+  recorder.registerCapturedScreenshot(actualPath);
   const resizeOpts = {};
   if (args.maxWidth !== void 0)
     resizeOpts.maxWidth = args.maxWidth;
@@ -56094,7 +56505,7 @@ import { execFile as execFileCb19 } from "node:child_process";
 import { promisify as promisify25 } from "node:util";
 import { existsSync as existsSync23, readFileSync as readFileSync19, writeFileSync as writeFileSync13, readdirSync as readdirSync7 } from "node:fs";
 import { join as join29 } from "node:path";
-import { homedir as homedir9 } from "node:os";
+import { homedir as homedir10 } from "node:os";
 var execFile24 = promisify25(execFileCb19);
 var AUTH_ROUTE_PATTERNS = [
   "login",
@@ -56245,7 +56656,7 @@ async function handleAutoLogin(client2, opts = {}) {
   }
   const wrapperPath = "/tmp/rn-auto-login-wrapper.yaml";
   writeFileSync13(wrapperPath, wrapperContent, "utf-8");
-  const runnerPath = join29(homedir9(), ".maestro-runner", "bin", "maestro-runner");
+  const runnerPath = join29(homedir10(), ".maestro-runner", "bin", "maestro-runner");
   if (!existsSync23(runnerPath)) {
     return {
       loggedIn: false,
@@ -56711,7 +57122,7 @@ function buildGracefulShutdown(deps) {
 // packages/rn-dev-agent-core/dist/lifecycle/lockfile.js
 import { createHash as createHash5 } from "node:crypto";
 import { execFileSync as execFileSync7 } from "node:child_process";
-import { closeSync as closeSync2, existsSync as existsSync24, mkdirSync as mkdirSync13, openSync as openSync2, readFileSync as readFileSync20, statSync as statSync8, unlinkSync as unlinkSync9, writeFileSync as writeFileSync14, writeSync as writeSync2 } from "node:fs";
+import { closeSync as closeSync3, existsSync as existsSync24, mkdirSync as mkdirSync13, openSync as openSync3, readFileSync as readFileSync20, statSync as statSync8, unlinkSync as unlinkSync9, writeFileSync as writeFileSync14, writeSync as writeSync2 } from "node:fs";
 import { tmpdir as tmpdir8, userInfo as userInfo2 } from "node:os";
 import { join as join30, resolve as resolve3 } from "node:path";
 var DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
@@ -56931,11 +57342,11 @@ var Lockfile = class {
     if (!existsSync24(dir)) {
       mkdirSync13(dir, { recursive: true });
     }
-    const fd = openSync2(this.lockPath, "wx");
+    const fd = openSync3(this.lockPath, "wx");
     try {
       writeSync2(fd, JSON.stringify(body, null, 2));
     } finally {
-      closeSync2(fd);
+      closeSync3(fd);
     }
   }
 };
@@ -57620,365 +58031,6 @@ function instrumentTool(toolName, handler) {
   };
 }
 
-// packages/rn-dev-agent-core/dist/observability/recorder.js
-import { readFileSync as readFileSync23, statSync as statSync9 } from "node:fs";
-import { isAbsolute as isAbsolute2 } from "node:path";
-
-// packages/rn-dev-agent-core/dist/util/redact.js
-import { homedir as homedir10 } from "node:os";
-var HOME = homedir10();
-var HOME_RE = new RegExp(HOME.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g");
-var SECRET_PATTERNS = [
-  /(?:sk|pk|api|key|token|secret|password|auth)[-_]?[A-Za-z0-9_-]{20,}/gi,
-  /Bearer\s+[A-Za-z0-9_\-./+=]{20,}/g,
-  /ghp_[A-Za-z0-9_]{36}/g,
-  /eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g,
-  /\bAKIA[0-9A-Z]{16}\b/g,
-  /\bxox[baprs]-[A-Za-z0-9-]+\b/g,
-  /\bAIza[0-9A-Za-z\-_]{35}\b/g,
-  // Any private-key label variant: PRIVATE KEY, RSA PRIVATE KEY,
-  // OPENSSH PRIVATE KEY, EC/DSA/ENCRYPTED PRIVATE KEY, ... The old single-word
-  // `(?:RSA |OPENSSH |PRIVATE )?KEY` form never matched multi-word labels like
-  // "RSA PRIVATE KEY" — the most common ssh-keygen header — so keys leaked.
-  /-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----/g
-];
-var KEYED_SECRET_RE = /((?:token|secret|password|passwd|pwd|api[_-]?key|apikey|authorization|auth|access[_-]?token|refresh[_-]?token|client[_-]?secret)["']?\s*[:=]\s*["']?)([^"'\s,;}]{6,})/gi;
-var PII_PATTERNS = [
-  /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
-  // Require separators so bare digit runs (timestamps, latencies, ids) are not
-  // mistaken for phone/SSN numbers (previously `[-.]?`/`[-]?` made them
-  // optional, redacting any 9-10 digit number).
-  /\b\d{3}[-.]\d{3}[-.]\d{4}\b/g,
-  /\b\d{3}-\d{2}-\d{4}\b/g
-];
-var AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
-var MAX_STRING_LENGTH = 2e3;
-function redactString(value) {
-  let result = value.replace(HOME_RE, "~");
-  KEYED_SECRET_RE.lastIndex = 0;
-  result = result.replace(KEYED_SECRET_RE, "$1[REDACTED_SECRET]");
-  for (const pattern of SECRET_PATTERNS) {
-    pattern.lastIndex = 0;
-    result = result.replace(pattern, "[REDACTED_SECRET]");
-  }
-  for (const pattern of PII_PATTERNS) {
-    pattern.lastIndex = 0;
-    result = result.replace(pattern, "[PII_REDACTED]");
-  }
-  if (result.length > MAX_STRING_LENGTH) {
-    result = result.slice(0, MAX_STRING_LENGTH) + `[TRUNCATED:${result.length}]`;
-  }
-  return result;
-}
-function redactValue(value, path) {
-  if (value === null || value === void 0)
-    return value;
-  if (typeof value === "string")
-    return redactString(value);
-  if (Array.isArray(value)) {
-    return value.map((item, i) => redactValue(item, `${path}[${i}]`));
-  }
-  if (typeof value === "object") {
-    const obj = value;
-    const result = {};
-    for (const [key, val] of Object.entries(obj)) {
-      const fullPath = path ? `${path}.${key}` : key;
-      if (AUTH_PATHS.test(key)) {
-        result[key] = Array.isArray(val) ? "[REDACTED:array]" : `[REDACTED:${typeof val}]`;
-      } else {
-        result[key] = redactValue(val, fullPath);
-      }
-    }
-    return result;
-  }
-  return value;
-}
-function redact(data) {
-  return redactValue(data, "");
-}
-
-// packages/rn-dev-agent-core/dist/observability/events.js
-var CLIP_LIMIT = 16e3;
-var INTERACTION = /* @__PURE__ */ new Set([
-  "device_press",
-  "device_fill",
-  "device_swipe",
-  "device_scroll",
-  "device_longpress",
-  "device_pinch",
-  "device_back",
-  "device_batch",
-  "device_scrollintoview",
-  "cdp_interact",
-  "device_focus_next",
-  "device_pick_date",
-  "device_pick_value",
-  "device_deeplink"
-]);
-var NAVIGATION = /* @__PURE__ */ new Set(["cdp_navigation_state", "cdp_nav_graph", "cdp_navigate"]);
-var INTROSPECTION = /* @__PURE__ */ new Set([
-  "cdp_component_tree",
-  "cdp_component_state",
-  "cdp_store_state",
-  "device_snapshot",
-  "device_screenshot",
-  "cdp_network_log",
-  "cdp_network_body",
-  "cdp_console_log",
-  "cdp_error_log",
-  "cdp_native_errors",
-  "cdp_diagnostic_renderers",
-  "cdp_object_inspect",
-  "cdp_heap_usage",
-  "collect_logs"
-]);
-var LIFECYCLE = /* @__PURE__ */ new Set([
-  "cdp_status",
-  "cdp_connect",
-  "cdp_disconnect",
-  "cdp_targets",
-  "cdp_reload",
-  "cdp_restart",
-  "cdp_dev_settings",
-  "cdp_open_devtools",
-  "device_list",
-  "observe"
-]);
-var TESTING = /* @__PURE__ */ new Set([
-  "maestro_run",
-  "maestro_generate",
-  "maestro_test_all",
-  "cdp_run_action",
-  "cdp_repair_action",
-  "proof_step",
-  "cross_platform_verify",
-  "cdp_auto_login",
-  "expect_redux",
-  "expect_route",
-  "expect_visible_by_testid",
-  "expect_text"
-]);
-function classifyFamily(tool) {
-  if (INTERACTION.has(tool))
-    return "interaction";
-  if (NAVIGATION.has(tool))
-    return "navigation";
-  if (INTROSPECTION.has(tool))
-    return "introspection";
-  if (LIFECYCLE.has(tool))
-    return "lifecycle";
-  if (TESTING.has(tool))
-    return "testing";
-  return "other";
-}
-function clipThenRedact(args, payload) {
-  let redactedArgs;
-  try {
-    redactedArgs = redact(args ?? {});
-  } catch {
-    redactedArgs = { redacted: true };
-  }
-  if (payload === null || payload === void 0) {
-    return { args: redactedArgs };
-  }
-  try {
-    let json;
-    try {
-      json = JSON.stringify(payload);
-    } catch {
-      return { args: redactedArgs, payload: { redacted: true } };
-    }
-    let clipped = payload;
-    let truncated = false;
-    if (typeof json === "string" && json.length > CLIP_LIMIT) {
-      clipped = { _clipped: json.slice(0, CLIP_LIMIT) };
-      truncated = true;
-    }
-    const redactedPayload = redact({ v: clipped }).v;
-    return truncated ? { args: redactedArgs, payload: redactedPayload, truncated: true } : { args: redactedArgs, payload: redactedPayload };
-  } catch {
-    return { args: redactedArgs, payload: { redacted: true } };
-  }
-}
-function unwrapResult(result) {
-  if (!result || typeof result !== "object")
-    return void 0;
-  const env = result;
-  const text = env.content?.[0]?.text;
-  if (typeof text !== "string")
-    return void 0;
-  try {
-    return JSON.parse(text);
-  } catch {
-    return void 0;
-  }
-}
-function summarize(tool, _family, args, ok) {
-  const target = args.testID ?? args.ref ?? args.text ?? args.screen ?? args.path ?? "";
-  const head = target ? `${tool} ${String(target).slice(0, 60)}` : tool;
-  return ok ? head : `${head} \u2717`;
-}
-function mapObservation(seq, o) {
-  const family = classifyFamily(o.tool);
-  const ok = o.status === "PASS";
-  const unwrapped = unwrapResult(o.result);
-  const payloadSource = ok ? unwrapped ? unwrapped.data : o.result : void 0;
-  const { args, payload, truncated } = clipThenRedact(o.params ?? {}, payloadSource);
-  const summary = summarize(o.tool, family, args, ok);
-  const event = {
-    seq,
-    ts: Date.now(),
-    tool: o.tool,
-    family,
-    args,
-    ok,
-    durationMs: o.latencyMs,
-    summary
-  };
-  if (payload !== void 0)
-    event.payload = payload;
-  if (truncated)
-    event.truncated = true;
-  if (!ok && o.error) {
-    const raw = String(o.error).slice(0, 500);
-    let message;
-    try {
-      message = String(redact({ m: raw }).m);
-    } catch {
-      message = "[REDACTED:error]";
-    }
-    event.error = { message };
-  }
-  if (o.ghost?.attempted)
-    event.ghost = o.ghost;
-  return event;
-}
-
-// packages/rn-dev-agent-core/dist/observability/recorder.js
-var DEFAULT_CAP = 500;
-var MAX_SHOT_BYTES = 4e6;
-function screenshotPath(result) {
-  const data = unwrapResult(result)?.data ?? result?.data;
-  const p = data?.path ?? data?.message;
-  return typeof p === "string" && isAbsolute2(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
-}
-var Recorder = class {
-  buf;
-  seq = 0;
-  subs = /* @__PURE__ */ new Set();
-  shots = /* @__PURE__ */ new Map();
-  shotCap;
-  liveShotData;
-  liveSeqVal = 0;
-  constructor(capacity = DEFAULT_CAP) {
-    this.buf = new RingBuffer(capacity);
-    this.shotCap = Math.max(8, Math.floor(capacity / 10));
-  }
-  record(o) {
-    try {
-      if (!o || typeof o !== "object" || typeof o.tool !== "string")
-        return;
-      const ev = mapObservation(++this.seq, o);
-      this.buf.push(ev);
-      this.captureScreenshot(ev, o);
-      for (const fn of this.subs) {
-        try {
-          fn(ev);
-        } catch {
-        }
-      }
-    } catch {
-    }
-  }
-  snapshot() {
-    return this.buf.getLast(this.buf.size);
-  }
-  attach(fn) {
-    const snapshot = this.buf.getLast(this.buf.size);
-    this.subs.add(fn);
-    return {
-      snapshot,
-      detach: () => {
-        this.subs.delete(fn);
-      }
-    };
-  }
-  getScreenshot(seq) {
-    return this.shots.get(seq);
-  }
-  hasSubscribers() {
-    return this.subs.size > 0;
-  }
-  getLiveScreenshot() {
-    return this.liveShotData;
-  }
-  pushLive(frame) {
-    const ev = { type: "live" };
-    let changed = false;
-    if (frame.shot && frame.shot.buf.length <= MAX_SHOT_BYTES) {
-      this.liveShotData = frame.shot;
-      ev.shotSeq = ++this.liveSeqVal;
-      changed = true;
-    }
-    if (typeof frame.route === "string" && frame.route.length > 0) {
-      ev.route = frame.route;
-      changed = true;
-    }
-    if (!changed)
-      return;
-    for (const fn of this.subs) {
-      try {
-        fn(ev);
-      } catch {
-      }
-    }
-  }
-  push(ev) {
-    for (const fn of this.subs) {
-      try {
-        fn(ev);
-      } catch {
-      }
-    }
-  }
-  clear() {
-    this.buf.clear();
-    for (const fn of this.subs) {
-      try {
-        fn({ type: "cleared" });
-      } catch {
-      }
-    }
-    this.subs.clear();
-    this.shots.clear();
-    this.seq = 0;
-    this.liveShotData = void 0;
-    this.liveSeqVal = 0;
-  }
-  captureScreenshot(ev, o) {
-    if (ev.tool !== "device_screenshot" || !ev.ok)
-      return;
-    const p = screenshotPath(o.result);
-    if (!p)
-      return;
-    try {
-      if (statSync9(p).size > MAX_SHOT_BYTES)
-        return;
-      const buf = readFileSync23(p);
-      const contentType = p.endsWith(".png") ? "image/png" : "image/jpeg";
-      this.shots.set(ev.seq, { buf, contentType });
-      while (this.shots.size > this.shotCap) {
-        const oldest = this.shots.keys().next().value;
-        if (oldest === void 0)
-          break;
-        this.shots.delete(oldest);
-      }
-    } catch {
-    }
-  }
-};
-var recorder = new Recorder();
-
 // packages/rn-dev-agent-core/dist/observability/live-device.js
 import { join as join34 } from "node:path";
 import { tmpdir as tmpdir10 } from "node:os";
@@ -58137,7 +58189,7 @@ init_utils();
 
 // packages/rn-dev-agent-core/dist/observability/server.js
 import { createServer as createServer3 } from "node:http";
-import { readFileSync as readFileSync24 } from "node:fs";
+import { readFileSync as readFileSync23 } from "node:fs";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 import { dirname as dirname13, join as join35 } from "node:path";
 
@@ -58344,7 +58396,7 @@ var ObservabilityServer = class {
   }
   index(res) {
     try {
-      let html = readFileSync24(join35(__dir, "web-dist", "index.html"), "utf8");
+      let html = readFileSync23(join35(__dir, "web-dist", "index.html"), "utf8");
       if (this.e2e) {
         const tokenJs = JSON.stringify(this.e2e.token).replace(/</g, "\\u003c");
         html = html.replace("</head>", `<script>window.__E2E_CSRF__=${tokenJs}</script></head>`);
@@ -59239,11 +59291,11 @@ function buildMirrorTargetResolver(deps) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/lock-e2e-test.js
-import { readFileSync as readFileSync27 } from "node:fs";
+import { readFileSync as readFileSync26 } from "node:fs";
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
 import { dirname as dirname14, join as join38 } from "node:path";
-import { mkdirSync as mkdirSync15, writeFileSync as writeFileSync17, renameSync as renameSync5, readFileSync as readFileSync25, readdirSync as readdirSync10, existsSync as existsSync27 } from "node:fs";
+import { mkdirSync as mkdirSync15, writeFileSync as writeFileSync17, renameSync as renameSync5, readFileSync as readFileSync24, readdirSync as readdirSync10, existsSync as existsSync27 } from "node:fs";
 import { createHash as createHash6 } from "node:crypto";
 var FLOW_SENTINEL = "# e2e-locked-flow-below";
 function e2eDirFor(projectRoot) {
@@ -59302,7 +59354,7 @@ function loadLockedTest(projectRoot, id) {
   const filePath = e2ePathFor(projectRoot, id);
   if (!existsSync27(filePath))
     return null;
-  return parseLockedTest(readFileSync25(filePath, "utf8"), filePath);
+  return parseLockedTest(readFileSync24(filePath, "utf8"), filePath);
 }
 function discoverLockedTests(projectRoot) {
   const dir = e2eDirFor(projectRoot);
@@ -59345,12 +59397,12 @@ function parseLockedTest(text, filePath) {
 }
 
 // packages/rn-dev-agent-core/dist/domain/e2e-config.js
-import { readFileSync as readFileSync26 } from "node:fs";
+import { readFileSync as readFileSync25 } from "node:fs";
 import { join as join39 } from "node:path";
 function loadE2eConfig(projectRoot) {
   const filePath = join39(projectRoot, ".rn-agent", "e2e.config.json");
   try {
-    const raw = readFileSync26(filePath, "utf8");
+    const raw = readFileSync25(filePath, "utf8");
     return JSON.parse(raw);
   } catch {
     return {};
@@ -59417,7 +59469,7 @@ function readPassed(result) {
 async function lockE2eTestCore(args, deps = {}) {
   const projectRoot = args.projectRoot ?? findProjectRoot() ?? process.cwd();
   const load = deps.loadAction ?? loadAction;
-  const readFile3 = deps.readActionFile ?? ((p) => readFileSync27(p, "utf8"));
+  const readFile3 = deps.readActionFile ?? ((p) => readFileSync26(p, "utf8"));
   const getGit = deps.getGitInfo ?? getGitInfo;
   const getSession = deps.getSession ?? getActiveSession;
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
@@ -59476,7 +59528,7 @@ function createLockE2eTestHandler(deps = {}) {
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
 init_maestro_error_parser();
 import { join as join40 } from "node:path";
-import { mkdirSync as mkdirSync16, writeFileSync as writeFileSync18, renameSync as renameSync6, readFileSync as readFileSync28, existsSync as existsSync28 } from "node:fs";
+import { mkdirSync as mkdirSync16, writeFileSync as writeFileSync18, renameSync as renameSync6, readFileSync as readFileSync27, existsSync as existsSync28 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
     return {
@@ -59544,7 +59596,7 @@ function loadIndex(projectRoot) {
   if (!existsSync28(file))
     return [];
   try {
-    const parsed = JSON.parse(readFileSync28(file, "utf8"));
+    const parsed = JSON.parse(readFileSync27(file, "utf8"));
     return Array.isArray(parsed) ? parsed : [];
   } catch {
     return [];
@@ -59569,7 +59621,7 @@ function loadRunRecord(projectRoot, runId) {
   if (!existsSync28(file))
     return null;
   try {
-    return JSON.parse(readFileSync28(file, "utf8"));
+    return JSON.parse(readFileSync27(file, "utf8"));
   } catch {
     return null;
   }
@@ -59585,7 +59637,7 @@ init_utils();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
 import { join as join41 } from "node:path";
-import { mkdirSync as mkdirSync17, writeFileSync as writeFileSync19, renameSync as renameSync7, readFileSync as readFileSync29, readdirSync as readdirSync11, existsSync as existsSync29 } from "node:fs";
+import { mkdirSync as mkdirSync17, writeFileSync as writeFileSync19, renameSync as renameSync7, readFileSync as readFileSync28, readdirSync as readdirSync11, existsSync as existsSync29 } from "node:fs";
 var TERMINAL_STATUSES = /* @__PURE__ */ new Set([
   "done",
   "failed",
@@ -59611,7 +59663,7 @@ function loadRequest(projectRoot, runId) {
   if (!existsSync29(file))
     return null;
   try {
-    return JSON.parse(readFileSync29(file, "utf8"));
+    return JSON.parse(readFileSync28(file, "utf8"));
   } catch {
     return null;
   }
@@ -59952,7 +60004,7 @@ async function listActions(projectRoot) {
 
 // packages/rn-dev-agent-core/dist/index.js
 var pkgPath = join43(dirname15(fileURLToPath3(import.meta.url)), "..", "package.json");
-var pkgVersion = JSON.parse(readFileSync30(pkgPath, "utf8")).version;
+var pkgVersion = JSON.parse(readFileSync29(pkgPath, "utf8")).version;
 var lockfile = null;
 var noLock = process.argv.includes("--no-lock");
 if (!noLock) {
@@ -60090,7 +60142,7 @@ var liveDeps = buildLiveDeps({
   readRoute: (c) => readLiveRoute(c),
   readShotFile: (path) => {
     try {
-      const buf = readFileSync30(path);
+      const buf = readFileSync29(path);
       const isPng = buf.length >= 4 && buf[0] === 137 && buf[1] === 80 && buf[2] === 78 && buf[3] === 71;
       return { buf, contentType: isPng ? "image/png" : "image/jpeg" };
     } catch {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -49411,7 +49411,7 @@ function mapObservation(seq, o) {
 var DEFAULT_CAP = 500;
 var MAX_SHOT_BYTES = 4e6;
 var SHOT_REGISTRY_CAP = 64;
-function screenshotPath(result) {
+function extractScreenshotPath(result) {
   const data = unwrapResult(result)?.data ?? result?.data;
   const p = data?.path ?? data?.message;
   return typeof p === "string" && isAbsolute2(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
@@ -49562,7 +49562,7 @@ var Recorder = class {
   captureScreenshot(ev, o) {
     if (ev.tool !== "device_screenshot" || !ev.ok)
       return;
-    const p = screenshotPath(o.result);
+    const p = extractScreenshotPath(o.result);
     if (!p || !this.trustedShotPaths.delete(p))
       return;
     const buf = readShotBounded(p);
@@ -49792,8 +49792,6 @@ async function captureAndResizeScreenshot(args) {
   if (result.isError)
     return result;
   const actualPath = resolveScreenshotPath(result, requestedPath);
-  recorder.registerCapturedScreenshot(requestedPath);
-  recorder.registerCapturedScreenshot(actualPath);
   const resizeOpts = {};
   if (args.maxWidth !== void 0)
     resizeOpts.maxWidth = args.maxWidth;
@@ -49801,7 +49799,13 @@ async function captureAndResizeScreenshot(args) {
     resizeOpts.quality = args.quality;
   const resize = await resizeWithSips(actualPath, resizeOpts);
   const resized = wrapResultWithResize(result, resize);
-  return wrapResultWithAdvisories(resized, advisories);
+  const finalResult = wrapResultWithAdvisories(resized, advisories);
+  recorder.registerCapturedScreenshot(requestedPath);
+  recorder.registerCapturedScreenshot(actualPath);
+  const observedPath = extractScreenshotPath(finalResult);
+  if (observedPath)
+    recorder.registerCapturedScreenshot(observedPath);
+  return finalResult;
 }
 function createDeviceScreenshotHandler(getClient2) {
   return async (args) => {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -50908,7 +50908,7 @@ var init_events = __esm({
 // packages/rn-dev-agent-core/dist/observability/recorder.js
 import { closeSync as closeSync3, constants, fstatSync, openSync as openSync3, readSync } from "node:fs";
 import { isAbsolute as isAbsolute2 } from "node:path";
-function screenshotPath(result) {
+function extractScreenshotPath(result) {
   const data = unwrapResult(result)?.data ?? result?.data;
   const p = data?.path ?? data?.message;
   return typeof p === "string" && isAbsolute2(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
@@ -51068,7 +51068,7 @@ var init_recorder = __esm({
       captureScreenshot(ev, o) {
         if (ev.tool !== "device_screenshot" || !ev.ok)
           return;
-        const p = screenshotPath(o.result);
+        const p = extractScreenshotPath(o.result);
         if (!p || !this.trustedShotPaths.delete(p))
           return;
         const buf = readShotBounded(p);
@@ -51289,8 +51289,6 @@ async function captureAndResizeScreenshot(args) {
   if (result.isError)
     return result;
   const actualPath = resolveScreenshotPath(result, requestedPath);
-  recorder.registerCapturedScreenshot(requestedPath);
-  recorder.registerCapturedScreenshot(actualPath);
   const resizeOpts = {};
   if (args.maxWidth !== void 0)
     resizeOpts.maxWidth = args.maxWidth;
@@ -51298,7 +51296,13 @@ async function captureAndResizeScreenshot(args) {
     resizeOpts.quality = args.quality;
   const resize = await resizeWithSips(actualPath, resizeOpts);
   const resized = wrapResultWithResize(result, resize);
-  return wrapResultWithAdvisories(resized, advisories);
+  const finalResult = wrapResultWithAdvisories(resized, advisories);
+  recorder.registerCapturedScreenshot(requestedPath);
+  recorder.registerCapturedScreenshot(actualPath);
+  const observedPath = extractScreenshotPath(finalResult);
+  if (observedPath)
+    recorder.registerCapturedScreenshot(observedPath);
+  return finalResult;
 }
 function createDeviceScreenshotHandler(getClient2) {
   return async (args) => {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -14273,11 +14273,11 @@ var require_codegen = __commonJS({
         const rhs = this.rhs === void 0 ? "" : ` = ${this.rhs}`;
         return `${varKind} ${this.name}${rhs};` + _n;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         if (!names[this.name.str])
           return;
         if (this.rhs)
-          this.rhs = optimizeExpr(this.rhs, names, constants);
+          this.rhs = optimizeExpr(this.rhs, names, constants2);
         return this;
       }
       get names() {
@@ -14294,10 +14294,10 @@ var require_codegen = __commonJS({
       render({ _n }) {
         return `${this.lhs} = ${this.rhs};` + _n;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         if (this.lhs instanceof code_1.Name && !names[this.lhs.str] && !this.sideEffects)
           return;
-        this.rhs = optimizeExpr(this.rhs, names, constants);
+        this.rhs = optimizeExpr(this.rhs, names, constants2);
         return this;
       }
       get names() {
@@ -14358,8 +14358,8 @@ var require_codegen = __commonJS({
       optimizeNodes() {
         return `${this.code}` ? this : void 0;
       }
-      optimizeNames(names, constants) {
-        this.code = optimizeExpr(this.code, names, constants);
+      optimizeNames(names, constants2) {
+        this.code = optimizeExpr(this.code, names, constants2);
         return this;
       }
       get names() {
@@ -14388,12 +14388,12 @@ var require_codegen = __commonJS({
         }
         return nodes.length > 0 ? this : void 0;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         const { nodes } = this;
         let i = nodes.length;
         while (i--) {
           const n = nodes[i];
-          if (n.optimizeNames(names, constants))
+          if (n.optimizeNames(names, constants2))
             continue;
           subtractNames(names, n.names);
           nodes.splice(i, 1);
@@ -14446,12 +14446,12 @@ var require_codegen = __commonJS({
           return void 0;
         return this;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         var _a;
-        this.else = (_a = this.else) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants);
-        if (!(super.optimizeNames(names, constants) || this.else))
+        this.else = (_a = this.else) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants2);
+        if (!(super.optimizeNames(names, constants2) || this.else))
           return;
-        this.condition = optimizeExpr(this.condition, names, constants);
+        this.condition = optimizeExpr(this.condition, names, constants2);
         return this;
       }
       get names() {
@@ -14474,10 +14474,10 @@ var require_codegen = __commonJS({
       render(opts) {
         return `for(${this.iteration})` + super.render(opts);
       }
-      optimizeNames(names, constants) {
-        if (!super.optimizeNames(names, constants))
+      optimizeNames(names, constants2) {
+        if (!super.optimizeNames(names, constants2))
           return;
-        this.iteration = optimizeExpr(this.iteration, names, constants);
+        this.iteration = optimizeExpr(this.iteration, names, constants2);
         return this;
       }
       get names() {
@@ -14513,10 +14513,10 @@ var require_codegen = __commonJS({
       render(opts) {
         return `for(${this.varKind} ${this.name} ${this.loop} ${this.iterable})` + super.render(opts);
       }
-      optimizeNames(names, constants) {
-        if (!super.optimizeNames(names, constants))
+      optimizeNames(names, constants2) {
+        if (!super.optimizeNames(names, constants2))
           return;
-        this.iterable = optimizeExpr(this.iterable, names, constants);
+        this.iterable = optimizeExpr(this.iterable, names, constants2);
         return this;
       }
       get names() {
@@ -14558,11 +14558,11 @@ var require_codegen = __commonJS({
         (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNodes();
         return this;
       }
-      optimizeNames(names, constants) {
+      optimizeNames(names, constants2) {
         var _a, _b;
-        super.optimizeNames(names, constants);
-        (_a = this.catch) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants);
-        (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNames(names, constants);
+        super.optimizeNames(names, constants2);
+        (_a = this.catch) === null || _a === void 0 ? void 0 : _a.optimizeNames(names, constants2);
+        (_b = this.finally) === null || _b === void 0 ? void 0 : _b.optimizeNames(names, constants2);
         return this;
       }
       get names() {
@@ -14863,7 +14863,7 @@ var require_codegen = __commonJS({
     function addExprNames(names, from) {
       return from instanceof code_1._CodeOrName ? addNames(names, from.names) : names;
     }
-    function optimizeExpr(expr, names, constants) {
+    function optimizeExpr(expr, names, constants2) {
       if (expr instanceof code_1.Name)
         return replaceName(expr);
       if (!canOptimize(expr))
@@ -14878,14 +14878,14 @@ var require_codegen = __commonJS({
         return items;
       }, []));
       function replaceName(n) {
-        const c = constants[n.str];
+        const c = constants2[n.str];
         if (c === void 0 || names[n.str] !== 1)
           return n;
         delete names[n.str];
         return c;
       }
       function canOptimize(e) {
-        return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants[c.str] !== void 0);
+        return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants2[c.str] !== void 0);
       }
     }
     function subtractNames(names, from) {
@@ -50662,12 +50662,438 @@ var init_path_safety = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/util/redact.js
+import { homedir as homedir8 } from "node:os";
+function redactString(value) {
+  let result = value.replace(HOME_RE, "~");
+  KEYED_SECRET_RE.lastIndex = 0;
+  result = result.replace(KEYED_SECRET_RE, "$1[REDACTED_SECRET]");
+  for (const pattern of SECRET_PATTERNS) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, "[REDACTED_SECRET]");
+  }
+  for (const pattern of PII_PATTERNS) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, "[PII_REDACTED]");
+  }
+  if (result.length > MAX_STRING_LENGTH) {
+    result = result.slice(0, MAX_STRING_LENGTH) + `[TRUNCATED:${result.length}]`;
+  }
+  return result;
+}
+function redactValue(value, path) {
+  if (value === null || value === void 0)
+    return value;
+  if (typeof value === "string")
+    return redactString(value);
+  if (Array.isArray(value)) {
+    return value.map((item, i) => redactValue(item, `${path}[${i}]`));
+  }
+  if (typeof value === "object") {
+    const obj = value;
+    const result = {};
+    for (const [key, val] of Object.entries(obj)) {
+      const fullPath = path ? `${path}.${key}` : key;
+      if (AUTH_PATHS.test(key)) {
+        result[key] = Array.isArray(val) ? "[REDACTED:array]" : `[REDACTED:${typeof val}]`;
+      } else {
+        result[key] = redactValue(val, fullPath);
+      }
+    }
+    return result;
+  }
+  return value;
+}
+function redact(data) {
+  return redactValue(data, "");
+}
+var HOME, HOME_RE, SECRET_PATTERNS, KEYED_SECRET_RE, PII_PATTERNS, AUTH_PATHS, MAX_STRING_LENGTH;
+var init_redact = __esm({
+  "packages/rn-dev-agent-core/dist/util/redact.js"() {
+    "use strict";
+    HOME = homedir8();
+    HOME_RE = new RegExp(HOME.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g");
+    SECRET_PATTERNS = [
+      /(?:sk|pk|api|key|token|secret|password|auth)[-_]?[A-Za-z0-9_-]{20,}/gi,
+      /Bearer\s+[A-Za-z0-9_\-./+=]{20,}/g,
+      /ghp_[A-Za-z0-9_]{36}/g,
+      /eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g,
+      /\bAKIA[0-9A-Z]{16}\b/g,
+      /\bxox[baprs]-[A-Za-z0-9-]+\b/g,
+      /\bAIza[0-9A-Za-z\-_]{35}\b/g,
+      // Any private-key label variant: PRIVATE KEY, RSA PRIVATE KEY,
+      // OPENSSH PRIVATE KEY, EC/DSA/ENCRYPTED PRIVATE KEY, ... The old single-word
+      // `(?:RSA |OPENSSH |PRIVATE )?KEY` form never matched multi-word labels like
+      // "RSA PRIVATE KEY" — the most common ssh-keygen header — so keys leaked.
+      /-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----/g
+    ];
+    KEYED_SECRET_RE = /((?:token|secret|password|passwd|pwd|api[_-]?key|apikey|authorization|auth|access[_-]?token|refresh[_-]?token|client[_-]?secret)["']?\s*[:=]\s*["']?)([^"'\s,;}]{6,})/gi;
+    PII_PATTERNS = [
+      /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
+      // Require separators so bare digit runs (timestamps, latencies, ids) are not
+      // mistaken for phone/SSN numbers (previously `[-.]?`/`[-]?` made them
+      // optional, redacting any 9-10 digit number).
+      /\b\d{3}[-.]\d{3}[-.]\d{4}\b/g,
+      /\b\d{3}-\d{2}-\d{4}\b/g
+    ];
+    AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
+    MAX_STRING_LENGTH = 2e3;
+  }
+});
+
+// packages/rn-dev-agent-core/dist/observability/events.js
+function classifyFamily(tool) {
+  if (INTERACTION.has(tool))
+    return "interaction";
+  if (NAVIGATION.has(tool))
+    return "navigation";
+  if (INTROSPECTION.has(tool))
+    return "introspection";
+  if (LIFECYCLE.has(tool))
+    return "lifecycle";
+  if (TESTING.has(tool))
+    return "testing";
+  return "other";
+}
+function clipThenRedact(args, payload) {
+  let redactedArgs;
+  try {
+    redactedArgs = redact(args ?? {});
+  } catch {
+    redactedArgs = { redacted: true };
+  }
+  if (payload === null || payload === void 0) {
+    return { args: redactedArgs };
+  }
+  try {
+    let json;
+    try {
+      json = JSON.stringify(payload);
+    } catch {
+      return { args: redactedArgs, payload: { redacted: true } };
+    }
+    let clipped = payload;
+    let truncated = false;
+    if (typeof json === "string" && json.length > CLIP_LIMIT) {
+      clipped = { _clipped: json.slice(0, CLIP_LIMIT) };
+      truncated = true;
+    }
+    const redactedPayload = redact({ v: clipped }).v;
+    return truncated ? { args: redactedArgs, payload: redactedPayload, truncated: true } : { args: redactedArgs, payload: redactedPayload };
+  } catch {
+    return { args: redactedArgs, payload: { redacted: true } };
+  }
+}
+function unwrapResult(result) {
+  if (!result || typeof result !== "object")
+    return void 0;
+  const env = result;
+  const text = env.content?.[0]?.text;
+  if (typeof text !== "string")
+    return void 0;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return void 0;
+  }
+}
+function summarize(tool, _family, args, ok) {
+  const target = args.testID ?? args.ref ?? args.text ?? args.screen ?? args.path ?? "";
+  const head = target ? `${tool} ${String(target).slice(0, 60)}` : tool;
+  return ok ? head : `${head} \u2717`;
+}
+function mapObservation(seq, o) {
+  const family = classifyFamily(o.tool);
+  const ok = o.status === "PASS";
+  const unwrapped = unwrapResult(o.result);
+  const payloadSource = ok ? unwrapped ? unwrapped.data : o.result : void 0;
+  const { args, payload, truncated } = clipThenRedact(o.params ?? {}, payloadSource);
+  const summary = summarize(o.tool, family, args, ok);
+  const event = {
+    seq,
+    ts: Date.now(),
+    tool: o.tool,
+    family,
+    args,
+    ok,
+    durationMs: o.latencyMs,
+    summary
+  };
+  if (payload !== void 0)
+    event.payload = payload;
+  if (truncated)
+    event.truncated = true;
+  if (!ok && o.error) {
+    const raw = String(o.error).slice(0, 500);
+    let message;
+    try {
+      message = String(redact({ m: raw }).m);
+    } catch {
+      message = "[REDACTED:error]";
+    }
+    event.error = { message };
+  }
+  if (o.ghost?.attempted)
+    event.ghost = o.ghost;
+  return event;
+}
+var CLIP_LIMIT, INTERACTION, NAVIGATION, INTROSPECTION, LIFECYCLE, TESTING;
+var init_events = __esm({
+  "packages/rn-dev-agent-core/dist/observability/events.js"() {
+    "use strict";
+    init_redact();
+    CLIP_LIMIT = 16e3;
+    INTERACTION = /* @__PURE__ */ new Set([
+      "device_press",
+      "device_fill",
+      "device_swipe",
+      "device_scroll",
+      "device_longpress",
+      "device_pinch",
+      "device_back",
+      "device_batch",
+      "device_scrollintoview",
+      "cdp_interact",
+      "device_focus_next",
+      "device_pick_date",
+      "device_pick_value",
+      "device_deeplink"
+    ]);
+    NAVIGATION = /* @__PURE__ */ new Set(["cdp_navigation_state", "cdp_nav_graph", "cdp_navigate"]);
+    INTROSPECTION = /* @__PURE__ */ new Set([
+      "cdp_component_tree",
+      "cdp_component_state",
+      "cdp_store_state",
+      "device_snapshot",
+      "device_screenshot",
+      "cdp_network_log",
+      "cdp_network_body",
+      "cdp_console_log",
+      "cdp_error_log",
+      "cdp_native_errors",
+      "cdp_diagnostic_renderers",
+      "cdp_object_inspect",
+      "cdp_heap_usage",
+      "collect_logs"
+    ]);
+    LIFECYCLE = /* @__PURE__ */ new Set([
+      "cdp_status",
+      "cdp_connect",
+      "cdp_disconnect",
+      "cdp_targets",
+      "cdp_reload",
+      "cdp_restart",
+      "cdp_dev_settings",
+      "cdp_open_devtools",
+      "device_list",
+      "observe"
+    ]);
+    TESTING = /* @__PURE__ */ new Set([
+      "maestro_run",
+      "maestro_generate",
+      "maestro_test_all",
+      "cdp_run_action",
+      "cdp_repair_action",
+      "proof_step",
+      "cross_platform_verify",
+      "cdp_auto_login",
+      "expect_redux",
+      "expect_route",
+      "expect_visible_by_testid",
+      "expect_text"
+    ]);
+  }
+});
+
+// packages/rn-dev-agent-core/dist/observability/recorder.js
+import { closeSync as closeSync3, constants, fstatSync, openSync as openSync3, readSync } from "node:fs";
+import { isAbsolute as isAbsolute2 } from "node:path";
+function screenshotPath(result) {
+  const data = unwrapResult(result)?.data ?? result?.data;
+  const p = data?.path ?? data?.message;
+  return typeof p === "string" && isAbsolute2(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
+}
+function readShotBounded(p) {
+  let fd;
+  try {
+    fd = openSync3(p, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+    const st = fstatSync(fd);
+    if (!st.isFile() || st.size > MAX_SHOT_BYTES)
+      return null;
+    const size = Number(st.size);
+    const buf = Buffer.alloc(size + 1);
+    const n = readSync(fd, buf, 0, size + 1, 0);
+    if (n > size)
+      return null;
+    return buf.subarray(0, n);
+  } catch {
+    return null;
+  } finally {
+    if (fd !== void 0) {
+      try {
+        closeSync3(fd);
+      } catch {
+      }
+    }
+  }
+}
+var DEFAULT_CAP, MAX_SHOT_BYTES, SHOT_REGISTRY_CAP, Recorder, recorder;
+var init_recorder = __esm({
+  "packages/rn-dev-agent-core/dist/observability/recorder.js"() {
+    "use strict";
+    init_ring_buffer();
+    init_events();
+    DEFAULT_CAP = 500;
+    MAX_SHOT_BYTES = 4e6;
+    SHOT_REGISTRY_CAP = 64;
+    Recorder = class {
+      buf;
+      seq = 0;
+      subs = /* @__PURE__ */ new Set();
+      shots = /* @__PURE__ */ new Map();
+      // GH #429: single-use trust grants from the capture pipeline (insertion-
+      // ordered, FIFO-evicted). Observations name paths, but only paths this
+      // process just captured may be read back — otherwise any tool result that
+      // mentions "/…/x.png" becomes an arbitrary local file read served over the
+      // observe server.
+      trustedShotPaths = /* @__PURE__ */ new Set();
+      shotCap;
+      liveShotData;
+      liveSeqVal = 0;
+      constructor(capacity = DEFAULT_CAP) {
+        this.buf = new RingBuffer(capacity);
+        this.shotCap = Math.max(8, Math.floor(capacity / 10));
+      }
+      record(o) {
+        try {
+          if (!o || typeof o !== "object" || typeof o.tool !== "string")
+            return;
+          const ev = mapObservation(++this.seq, o);
+          this.buf.push(ev);
+          this.captureScreenshot(ev, o);
+          for (const fn of this.subs) {
+            try {
+              fn(ev);
+            } catch {
+            }
+          }
+        } catch {
+        }
+      }
+      snapshot() {
+        return this.buf.getLast(this.buf.size);
+      }
+      attach(fn) {
+        const snapshot = this.buf.getLast(this.buf.size);
+        this.subs.add(fn);
+        return {
+          snapshot,
+          detach: () => {
+            this.subs.delete(fn);
+          }
+        };
+      }
+      getScreenshot(seq) {
+        return this.shots.get(seq);
+      }
+      /**
+       * GH #429: grant a one-shot read for a file the capture pipeline just
+       * wrote. `captureScreenshot` consumes the grant on first use, so a later
+       * observation replaying the same path is refused. User-chosen destinations
+       * (docs/proof/…, ~/Desktop/…) keep working because the grant is issued for
+       * whatever path the pipeline actually captured to.
+       */
+      registerCapturedScreenshot(p) {
+        if (typeof p !== "string" || !isAbsolute2(p))
+          return;
+        this.trustedShotPaths.delete(p);
+        this.trustedShotPaths.add(p);
+        while (this.trustedShotPaths.size > SHOT_REGISTRY_CAP) {
+          const oldest = this.trustedShotPaths.values().next().value;
+          if (oldest === void 0)
+            break;
+          this.trustedShotPaths.delete(oldest);
+        }
+      }
+      hasSubscribers() {
+        return this.subs.size > 0;
+      }
+      getLiveScreenshot() {
+        return this.liveShotData;
+      }
+      pushLive(frame) {
+        const ev = { type: "live" };
+        let changed = false;
+        if (frame.shot && frame.shot.buf.length <= MAX_SHOT_BYTES) {
+          this.liveShotData = frame.shot;
+          ev.shotSeq = ++this.liveSeqVal;
+          changed = true;
+        }
+        if (typeof frame.route === "string" && frame.route.length > 0) {
+          ev.route = frame.route;
+          changed = true;
+        }
+        if (!changed)
+          return;
+        for (const fn of this.subs) {
+          try {
+            fn(ev);
+          } catch {
+          }
+        }
+      }
+      push(ev) {
+        for (const fn of this.subs) {
+          try {
+            fn(ev);
+          } catch {
+          }
+        }
+      }
+      clear() {
+        this.buf.clear();
+        for (const fn of this.subs) {
+          try {
+            fn({ type: "cleared" });
+          } catch {
+          }
+        }
+        this.subs.clear();
+        this.shots.clear();
+        this.trustedShotPaths.clear();
+        this.seq = 0;
+        this.liveShotData = void 0;
+        this.liveSeqVal = 0;
+      }
+      captureScreenshot(ev, o) {
+        if (ev.tool !== "device_screenshot" || !ev.ok)
+          return;
+        const p = screenshotPath(o.result);
+        if (!p || !this.trustedShotPaths.delete(p))
+          return;
+        const buf = readShotBounded(p);
+        if (!buf)
+          return;
+        const contentType = p.endsWith(".png") ? "image/png" : "image/jpeg";
+        this.shots.set(ev.seq, { buf, contentType });
+        while (this.shots.size > this.shotCap) {
+          const oldest = this.shots.keys().next().value;
+          if (oldest === void 0)
+            break;
+          this.shots.delete(oldest);
+        }
+      }
+    };
+    recorder = new Recorder();
+  }
+});
+
 // packages/rn-dev-agent-core/dist/tools/device-list.js
 import { mkdirSync as mkdirSync12 } from "node:fs";
 import { execFile as execFile16 } from "node:child_process";
 import { promisify as promisify17 } from "node:util";
 import { dirname as dirname9, join as join25 } from "node:path";
-import { homedir as homedir8 } from "node:os";
+import { homedir as homedir9 } from "node:os";
 function parseSimctlDevicesAll(jsonText) {
   try {
     const parsed = JSON.parse(jsonText);
@@ -50710,7 +51136,7 @@ function deriveScreenshotPath(args, now = Date.now, rand = Math.random) {
   }
   if (args.path?.startsWith("~")) {
     if (args.path.startsWith("~/"))
-      return join25(homedir8(), args.path.slice(2));
+      return join25(homedir9(), args.path.slice(2));
     throw new TildeScreenshotPathError(`Screenshot path "${args.path}" starts with '~' which the bridge cannot expand (only a leading '~/' is expanded to the home directory). Pass an absolute path instead.`);
   }
   if (args.path)
@@ -50863,6 +51289,8 @@ async function captureAndResizeScreenshot(args) {
   if (result.isError)
     return result;
   const actualPath = resolveScreenshotPath(result, requestedPath);
+  recorder.registerCapturedScreenshot(requestedPath);
+  recorder.registerCapturedScreenshot(actualPath);
   const resizeOpts = {};
   if (args.maxWidth !== void 0)
     resizeOpts.maxWidth = args.maxWidth;
@@ -50892,6 +51320,7 @@ var init_device_list = __esm({
     init_foreign_flow_gate();
     init_path_safety();
     init_rn_android_runner_client();
+    init_recorder();
     runAgentDeviceFn2 = runNative;
     execFileAsync3 = promisify17(execFile16);
     defaultExec2 = (cmd, args) => execFileAsync3(cmd, args);
@@ -57827,7 +58256,7 @@ import { execFile as execFileCb19 } from "node:child_process";
 import { promisify as promisify25 } from "node:util";
 import { existsSync as existsSync24, readFileSync as readFileSync20, writeFileSync as writeFileSync14, readdirSync as readdirSync7 } from "node:fs";
 import { join as join30 } from "node:path";
-import { homedir as homedir9 } from "node:os";
+import { homedir as homedir10 } from "node:os";
 function matchesAuthPattern(routeName) {
   const lower = routeName.toLowerCase();
   return AUTH_ROUTE_PATTERNS.some((p) => lower.includes(p));
@@ -57947,7 +58376,7 @@ async function handleAutoLogin(client2, opts = {}) {
   }
   const wrapperPath = "/tmp/rn-auto-login-wrapper.yaml";
   writeFileSync14(wrapperPath, wrapperContent, "utf-8");
-  const runnerPath = join30(homedir9(), ".maestro-runner", "bin", "maestro-runner");
+  const runnerPath = join30(homedir10(), ".maestro-runner", "bin", "maestro-runner");
   if (!existsSync24(runnerPath)) {
     return {
       loggedIn: false,
@@ -59132,384 +59561,6 @@ var init_instrumentation = __esm({
   }
 });
 
-// packages/rn-dev-agent-core/dist/util/redact.js
-import { homedir as homedir10 } from "node:os";
-function redactString(value) {
-  let result = value.replace(HOME_RE, "~");
-  KEYED_SECRET_RE.lastIndex = 0;
-  result = result.replace(KEYED_SECRET_RE, "$1[REDACTED_SECRET]");
-  for (const pattern of SECRET_PATTERNS) {
-    pattern.lastIndex = 0;
-    result = result.replace(pattern, "[REDACTED_SECRET]");
-  }
-  for (const pattern of PII_PATTERNS) {
-    pattern.lastIndex = 0;
-    result = result.replace(pattern, "[PII_REDACTED]");
-  }
-  if (result.length > MAX_STRING_LENGTH) {
-    result = result.slice(0, MAX_STRING_LENGTH) + `[TRUNCATED:${result.length}]`;
-  }
-  return result;
-}
-function redactValue(value, path) {
-  if (value === null || value === void 0)
-    return value;
-  if (typeof value === "string")
-    return redactString(value);
-  if (Array.isArray(value)) {
-    return value.map((item, i) => redactValue(item, `${path}[${i}]`));
-  }
-  if (typeof value === "object") {
-    const obj = value;
-    const result = {};
-    for (const [key, val] of Object.entries(obj)) {
-      const fullPath = path ? `${path}.${key}` : key;
-      if (AUTH_PATHS.test(key)) {
-        result[key] = Array.isArray(val) ? "[REDACTED:array]" : `[REDACTED:${typeof val}]`;
-      } else {
-        result[key] = redactValue(val, fullPath);
-      }
-    }
-    return result;
-  }
-  return value;
-}
-function redact(data) {
-  return redactValue(data, "");
-}
-var HOME, HOME_RE, SECRET_PATTERNS, KEYED_SECRET_RE, PII_PATTERNS, AUTH_PATHS, MAX_STRING_LENGTH;
-var init_redact = __esm({
-  "packages/rn-dev-agent-core/dist/util/redact.js"() {
-    "use strict";
-    HOME = homedir10();
-    HOME_RE = new RegExp(HOME.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g");
-    SECRET_PATTERNS = [
-      /(?:sk|pk|api|key|token|secret|password|auth)[-_]?[A-Za-z0-9_-]{20,}/gi,
-      /Bearer\s+[A-Za-z0-9_\-./+=]{20,}/g,
-      /ghp_[A-Za-z0-9_]{36}/g,
-      /eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g,
-      /\bAKIA[0-9A-Z]{16}\b/g,
-      /\bxox[baprs]-[A-Za-z0-9-]+\b/g,
-      /\bAIza[0-9A-Za-z\-_]{35}\b/g,
-      // Any private-key label variant: PRIVATE KEY, RSA PRIVATE KEY,
-      // OPENSSH PRIVATE KEY, EC/DSA/ENCRYPTED PRIVATE KEY, ... The old single-word
-      // `(?:RSA |OPENSSH |PRIVATE )?KEY` form never matched multi-word labels like
-      // "RSA PRIVATE KEY" — the most common ssh-keygen header — so keys leaked.
-      /-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----/g
-    ];
-    KEYED_SECRET_RE = /((?:token|secret|password|passwd|pwd|api[_-]?key|apikey|authorization|auth|access[_-]?token|refresh[_-]?token|client[_-]?secret)["']?\s*[:=]\s*["']?)([^"'\s,;}]{6,})/gi;
-    PII_PATTERNS = [
-      /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
-      // Require separators so bare digit runs (timestamps, latencies, ids) are not
-      // mistaken for phone/SSN numbers (previously `[-.]?`/`[-]?` made them
-      // optional, redacting any 9-10 digit number).
-      /\b\d{3}[-.]\d{3}[-.]\d{4}\b/g,
-      /\b\d{3}-\d{2}-\d{4}\b/g
-    ];
-    AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
-    MAX_STRING_LENGTH = 2e3;
-  }
-});
-
-// packages/rn-dev-agent-core/dist/observability/events.js
-function classifyFamily(tool) {
-  if (INTERACTION.has(tool))
-    return "interaction";
-  if (NAVIGATION.has(tool))
-    return "navigation";
-  if (INTROSPECTION.has(tool))
-    return "introspection";
-  if (LIFECYCLE.has(tool))
-    return "lifecycle";
-  if (TESTING.has(tool))
-    return "testing";
-  return "other";
-}
-function clipThenRedact(args, payload) {
-  let redactedArgs;
-  try {
-    redactedArgs = redact(args ?? {});
-  } catch {
-    redactedArgs = { redacted: true };
-  }
-  if (payload === null || payload === void 0) {
-    return { args: redactedArgs };
-  }
-  try {
-    let json;
-    try {
-      json = JSON.stringify(payload);
-    } catch {
-      return { args: redactedArgs, payload: { redacted: true } };
-    }
-    let clipped = payload;
-    let truncated = false;
-    if (typeof json === "string" && json.length > CLIP_LIMIT) {
-      clipped = { _clipped: json.slice(0, CLIP_LIMIT) };
-      truncated = true;
-    }
-    const redactedPayload = redact({ v: clipped }).v;
-    return truncated ? { args: redactedArgs, payload: redactedPayload, truncated: true } : { args: redactedArgs, payload: redactedPayload };
-  } catch {
-    return { args: redactedArgs, payload: { redacted: true } };
-  }
-}
-function unwrapResult(result) {
-  if (!result || typeof result !== "object")
-    return void 0;
-  const env = result;
-  const text = env.content?.[0]?.text;
-  if (typeof text !== "string")
-    return void 0;
-  try {
-    return JSON.parse(text);
-  } catch {
-    return void 0;
-  }
-}
-function summarize(tool, _family, args, ok) {
-  const target = args.testID ?? args.ref ?? args.text ?? args.screen ?? args.path ?? "";
-  const head = target ? `${tool} ${String(target).slice(0, 60)}` : tool;
-  return ok ? head : `${head} \u2717`;
-}
-function mapObservation(seq, o) {
-  const family = classifyFamily(o.tool);
-  const ok = o.status === "PASS";
-  const unwrapped = unwrapResult(o.result);
-  const payloadSource = ok ? unwrapped ? unwrapped.data : o.result : void 0;
-  const { args, payload, truncated } = clipThenRedact(o.params ?? {}, payloadSource);
-  const summary = summarize(o.tool, family, args, ok);
-  const event = {
-    seq,
-    ts: Date.now(),
-    tool: o.tool,
-    family,
-    args,
-    ok,
-    durationMs: o.latencyMs,
-    summary
-  };
-  if (payload !== void 0)
-    event.payload = payload;
-  if (truncated)
-    event.truncated = true;
-  if (!ok && o.error) {
-    const raw = String(o.error).slice(0, 500);
-    let message;
-    try {
-      message = String(redact({ m: raw }).m);
-    } catch {
-      message = "[REDACTED:error]";
-    }
-    event.error = { message };
-  }
-  if (o.ghost?.attempted)
-    event.ghost = o.ghost;
-  return event;
-}
-var CLIP_LIMIT, INTERACTION, NAVIGATION, INTROSPECTION, LIFECYCLE, TESTING;
-var init_events = __esm({
-  "packages/rn-dev-agent-core/dist/observability/events.js"() {
-    "use strict";
-    init_redact();
-    CLIP_LIMIT = 16e3;
-    INTERACTION = /* @__PURE__ */ new Set([
-      "device_press",
-      "device_fill",
-      "device_swipe",
-      "device_scroll",
-      "device_longpress",
-      "device_pinch",
-      "device_back",
-      "device_batch",
-      "device_scrollintoview",
-      "cdp_interact",
-      "device_focus_next",
-      "device_pick_date",
-      "device_pick_value",
-      "device_deeplink"
-    ]);
-    NAVIGATION = /* @__PURE__ */ new Set(["cdp_navigation_state", "cdp_nav_graph", "cdp_navigate"]);
-    INTROSPECTION = /* @__PURE__ */ new Set([
-      "cdp_component_tree",
-      "cdp_component_state",
-      "cdp_store_state",
-      "device_snapshot",
-      "device_screenshot",
-      "cdp_network_log",
-      "cdp_network_body",
-      "cdp_console_log",
-      "cdp_error_log",
-      "cdp_native_errors",
-      "cdp_diagnostic_renderers",
-      "cdp_object_inspect",
-      "cdp_heap_usage",
-      "collect_logs"
-    ]);
-    LIFECYCLE = /* @__PURE__ */ new Set([
-      "cdp_status",
-      "cdp_connect",
-      "cdp_disconnect",
-      "cdp_targets",
-      "cdp_reload",
-      "cdp_restart",
-      "cdp_dev_settings",
-      "cdp_open_devtools",
-      "device_list",
-      "observe"
-    ]);
-    TESTING = /* @__PURE__ */ new Set([
-      "maestro_run",
-      "maestro_generate",
-      "maestro_test_all",
-      "cdp_run_action",
-      "cdp_repair_action",
-      "proof_step",
-      "cross_platform_verify",
-      "cdp_auto_login",
-      "expect_redux",
-      "expect_route",
-      "expect_visible_by_testid",
-      "expect_text"
-    ]);
-  }
-});
-
-// packages/rn-dev-agent-core/dist/observability/recorder.js
-import { readFileSync as readFileSync23, statSync as statSync9 } from "node:fs";
-import { isAbsolute as isAbsolute2 } from "node:path";
-function screenshotPath(result) {
-  const data = unwrapResult(result)?.data ?? result?.data;
-  const p = data?.path ?? data?.message;
-  return typeof p === "string" && isAbsolute2(p) && (p.endsWith(".jpg") || p.endsWith(".jpeg") || p.endsWith(".png")) ? p : null;
-}
-var DEFAULT_CAP, MAX_SHOT_BYTES, Recorder, recorder;
-var init_recorder = __esm({
-  "packages/rn-dev-agent-core/dist/observability/recorder.js"() {
-    "use strict";
-    init_ring_buffer();
-    init_events();
-    DEFAULT_CAP = 500;
-    MAX_SHOT_BYTES = 4e6;
-    Recorder = class {
-      buf;
-      seq = 0;
-      subs = /* @__PURE__ */ new Set();
-      shots = /* @__PURE__ */ new Map();
-      shotCap;
-      liveShotData;
-      liveSeqVal = 0;
-      constructor(capacity = DEFAULT_CAP) {
-        this.buf = new RingBuffer(capacity);
-        this.shotCap = Math.max(8, Math.floor(capacity / 10));
-      }
-      record(o) {
-        try {
-          if (!o || typeof o !== "object" || typeof o.tool !== "string")
-            return;
-          const ev = mapObservation(++this.seq, o);
-          this.buf.push(ev);
-          this.captureScreenshot(ev, o);
-          for (const fn of this.subs) {
-            try {
-              fn(ev);
-            } catch {
-            }
-          }
-        } catch {
-        }
-      }
-      snapshot() {
-        return this.buf.getLast(this.buf.size);
-      }
-      attach(fn) {
-        const snapshot = this.buf.getLast(this.buf.size);
-        this.subs.add(fn);
-        return {
-          snapshot,
-          detach: () => {
-            this.subs.delete(fn);
-          }
-        };
-      }
-      getScreenshot(seq) {
-        return this.shots.get(seq);
-      }
-      hasSubscribers() {
-        return this.subs.size > 0;
-      }
-      getLiveScreenshot() {
-        return this.liveShotData;
-      }
-      pushLive(frame) {
-        const ev = { type: "live" };
-        let changed = false;
-        if (frame.shot && frame.shot.buf.length <= MAX_SHOT_BYTES) {
-          this.liveShotData = frame.shot;
-          ev.shotSeq = ++this.liveSeqVal;
-          changed = true;
-        }
-        if (typeof frame.route === "string" && frame.route.length > 0) {
-          ev.route = frame.route;
-          changed = true;
-        }
-        if (!changed)
-          return;
-        for (const fn of this.subs) {
-          try {
-            fn(ev);
-          } catch {
-          }
-        }
-      }
-      push(ev) {
-        for (const fn of this.subs) {
-          try {
-            fn(ev);
-          } catch {
-          }
-        }
-      }
-      clear() {
-        this.buf.clear();
-        for (const fn of this.subs) {
-          try {
-            fn({ type: "cleared" });
-          } catch {
-          }
-        }
-        this.subs.clear();
-        this.shots.clear();
-        this.seq = 0;
-        this.liveShotData = void 0;
-        this.liveSeqVal = 0;
-      }
-      captureScreenshot(ev, o) {
-        if (ev.tool !== "device_screenshot" || !ev.ok)
-          return;
-        const p = screenshotPath(o.result);
-        if (!p)
-          return;
-        try {
-          if (statSync9(p).size > MAX_SHOT_BYTES)
-            return;
-          const buf = readFileSync23(p);
-          const contentType = p.endsWith(".png") ? "image/png" : "image/jpeg";
-          this.shots.set(ev.seq, { buf, contentType });
-          while (this.shots.size > this.shotCap) {
-            const oldest = this.shots.keys().next().value;
-            if (oldest === void 0)
-              break;
-            this.shots.delete(oldest);
-          }
-        } catch {
-        }
-      }
-    };
-    recorder = new Recorder();
-  }
-});
-
 // packages/rn-dev-agent-core/dist/observability/live-device.js
 import { join as join34 } from "node:path";
 import { tmpdir as tmpdir10 } from "node:os";
@@ -59701,7 +59752,7 @@ var init_e2e_csrf = __esm({
 
 // packages/rn-dev-agent-core/dist/observability/server.js
 import { createServer as createServer3 } from "node:http";
-import { readFileSync as readFileSync24 } from "node:fs";
+import { readFileSync as readFileSync23 } from "node:fs";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
 import { dirname as dirname13, join as join35 } from "node:path";
 function listen(server3, port) {
@@ -59897,7 +59948,7 @@ var init_server3 = __esm({
       }
       index(res) {
         try {
-          let html = readFileSync24(join35(__dir, "web-dist", "index.html"), "utf8");
+          let html = readFileSync23(join35(__dir, "web-dist", "index.html"), "utf8");
           if (this.e2e) {
             const tokenJs = JSON.stringify(this.e2e.token).replace(/</g, "\\u003c");
             html = html.replace("</head>", `<script>window.__E2E_CSRF__=${tokenJs}</script></head>`);
@@ -60818,7 +60869,7 @@ var init_target = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
 import { dirname as dirname14, join as join38 } from "node:path";
-import { mkdirSync as mkdirSync15, writeFileSync as writeFileSync17, renameSync as renameSync5, readFileSync as readFileSync25, readdirSync as readdirSync10, existsSync as existsSync27 } from "node:fs";
+import { mkdirSync as mkdirSync15, writeFileSync as writeFileSync17, renameSync as renameSync5, readFileSync as readFileSync24, readdirSync as readdirSync10, existsSync as existsSync27 } from "node:fs";
 import { createHash as createHash6 } from "node:crypto";
 function e2eDirFor(projectRoot) {
   return join38(projectRoot, ".rn-agent", "e2e");
@@ -60876,7 +60927,7 @@ function loadLockedTest(projectRoot, id) {
   const filePath = e2ePathFor(projectRoot, id);
   if (!existsSync27(filePath))
     return null;
-  return parseLockedTest(readFileSync25(filePath, "utf8"), filePath);
+  return parseLockedTest(readFileSync24(filePath, "utf8"), filePath);
 }
 function discoverLockedTests(projectRoot) {
   const dir = e2eDirFor(projectRoot);
@@ -60927,12 +60978,12 @@ var init_e2e_test = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/e2e-config.js
-import { readFileSync as readFileSync26 } from "node:fs";
+import { readFileSync as readFileSync25 } from "node:fs";
 import { join as join39 } from "node:path";
 function loadE2eConfig(projectRoot) {
   const filePath = join39(projectRoot, ".rn-agent", "e2e.config.json");
   try {
-    const raw = readFileSync26(filePath, "utf8");
+    const raw = readFileSync25(filePath, "utf8");
     return JSON.parse(raw);
   } catch {
     return {};
@@ -60993,7 +61044,7 @@ var init_git_info = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/lock-e2e-test.js
-import { readFileSync as readFileSync27 } from "node:fs";
+import { readFileSync as readFileSync26 } from "node:fs";
 function readPassed(result) {
   try {
     const env = JSON.parse(result.content[0].text);
@@ -61008,7 +61059,7 @@ function readPassed(result) {
 async function lockE2eTestCore(args, deps = {}) {
   const projectRoot = args.projectRoot ?? findProjectRoot() ?? process.cwd();
   const load = deps.loadAction ?? loadAction;
-  const readFile3 = deps.readActionFile ?? ((p) => readFileSync27(p, "utf8"));
+  const readFile3 = deps.readActionFile ?? ((p) => readFileSync26(p, "utf8"));
   const getGit = deps.getGitInfo ?? getGitInfo;
   const getSession = deps.getSession ?? getActiveSession;
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
@@ -61079,7 +61130,7 @@ var init_lock_e2e_test = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
 import { join as join40 } from "node:path";
-import { mkdirSync as mkdirSync16, writeFileSync as writeFileSync18, renameSync as renameSync6, readFileSync as readFileSync28, existsSync as existsSync28 } from "node:fs";
+import { mkdirSync as mkdirSync16, writeFileSync as writeFileSync18, renameSync as renameSync6, readFileSync as readFileSync27, existsSync as existsSync28 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
     return {
@@ -61146,7 +61197,7 @@ function loadIndex(projectRoot) {
   if (!existsSync28(file))
     return [];
   try {
-    const parsed = JSON.parse(readFileSync28(file, "utf8"));
+    const parsed = JSON.parse(readFileSync27(file, "utf8"));
     return Array.isArray(parsed) ? parsed : [];
   } catch {
     return [];
@@ -61171,7 +61222,7 @@ function loadRunRecord(projectRoot, runId) {
   if (!existsSync28(file))
     return null;
   try {
-    return JSON.parse(readFileSync28(file, "utf8"));
+    return JSON.parse(readFileSync27(file, "utf8"));
   } catch {
     return null;
   }
@@ -61191,7 +61242,7 @@ var init_e2e_run = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
 import { join as join41 } from "node:path";
-import { mkdirSync as mkdirSync17, writeFileSync as writeFileSync19, renameSync as renameSync7, readFileSync as readFileSync29, readdirSync as readdirSync11, existsSync as existsSync29 } from "node:fs";
+import { mkdirSync as mkdirSync17, writeFileSync as writeFileSync19, renameSync as renameSync7, readFileSync as readFileSync28, readdirSync as readdirSync11, existsSync as existsSync29 } from "node:fs";
 function requestsDir(projectRoot) {
   return join41(e2eRunsDirFor(projectRoot), "requests");
 }
@@ -61211,7 +61262,7 @@ function loadRequest(projectRoot, runId) {
   if (!existsSync29(file))
     return null;
   try {
-    return JSON.parse(readFileSync29(file, "utf8"));
+    return JSON.parse(readFileSync28(file, "utf8"));
   } catch {
     return null;
   }
@@ -61587,7 +61638,7 @@ var init_action_inventory = __esm({
 
 // packages/rn-dev-agent-core/dist/index.js
 var index_exports = {};
-import { readFileSync as readFileSync30 } from "node:fs";
+import { readFileSync as readFileSync29 } from "node:fs";
 import { execFile as execFile27 } from "node:child_process";
 import { promisify as promisify28 } from "node:util";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
@@ -61746,7 +61797,7 @@ var init_index = __esm({
     init_action_store();
     init_e2e_config();
     pkgPath = join43(dirname15(fileURLToPath3(import.meta.url)), "..", "package.json");
-    pkgVersion = JSON.parse(readFileSync30(pkgPath, "utf8")).version;
+    pkgVersion = JSON.parse(readFileSync29(pkgPath, "utf8")).version;
     lockfile = null;
     noLock = process.argv.includes("--no-lock");
     if (!noLock) {
@@ -61884,7 +61935,7 @@ var init_index = __esm({
       readRoute: (c) => readLiveRoute(c),
       readShotFile: (path) => {
         try {
-          const buf = readFileSync30(path);
+          const buf = readFileSync29(path);
           const isPng = buf.length >= 4 && buf[0] === 137 && buf[1] === 80 && buf[2] === 78 && buf[3] === 71;
           return { buf, contentType: isPng ? "image/png" : "image/jpeg" };
         } catch {
@@ -62654,7 +62705,7 @@ var init_index = __esm({
 init_lockfile();
 init_parent_watch();
 import { spawn as spawn6 } from "node:child_process";
-import { readFileSync as readFileSync31 } from "node:fs";
+import { readFileSync as readFileSync30 } from "node:fs";
 import { dirname as dirname16, join as join44 } from "node:path";
 import { fileURLToPath as fileURLToPath4 } from "node:url";
 
@@ -62771,7 +62822,7 @@ if (process.env.RN_BRIDGE_SUPERVISOR === "0") {
   const noLock2 = process.argv.includes("--no-lock");
   let lockfile2 = null;
   if (!noLock2) {
-    const pkg = JSON.parse(readFileSync31(join44(here, "..", "package.json"), "utf8"));
+    const pkg = JSON.parse(readFileSync30(join44(here, "..", "package.json"), "utf8"));
     lockfile2 = new Lockfile({ version: pkg.version });
     const lockResult = lockfile2.acquire();
     if (lockResult.status === "conflict") {

--- a/packages/rn-dev-agent-core/dist/observability/recorder.js
+++ b/packages/rn-dev-agent-core/dist/observability/recorder.js
@@ -1,9 +1,14 @@
-import { readFileSync, statSync } from 'node:fs';
+import { closeSync, constants, fstatSync, openSync, readSync } from 'node:fs';
 import { isAbsolute } from 'node:path';
 import { RingBuffer } from '../ring-buffer.js';
 import { mapObservation, unwrapResult } from './events.js';
 const DEFAULT_CAP = 500;
 const MAX_SHOT_BYTES = 4_000_000;
+// GH #429: how many capture-registered paths to remember. Each successful
+// device_screenshot registers 1-2 paths and the very next observation
+// consumes one, so the bound only matters for pipelines (proof_step,
+// device_batch) whose registrations are never consumed.
+const SHOT_REGISTRY_CAP = 64;
 // GH #422: absolute paths only — a runner-internal relative path (e.g. iOS
 // "tmp/…") would resolve against the bridge cwd, silently blanking the panel
 // or reading an unrelated file that shares the name.
@@ -16,11 +21,50 @@ function screenshotPath(result) {
         ? p
         : null;
 }
+// GH #429: TOCTOU-safe bounded read. One descriptor for the whole
+// check-then-read (a stat-then-readFileSync pair can be raced by swapping the
+// file between the two calls); O_NOFOLLOW refuses symlinks outright and
+// O_NONBLOCK keeps a FIFO planted at the path from hanging the open. Reading
+// size+1 bytes detects a file that grew past the fstat between the two calls.
+function readShotBounded(p) {
+    let fd;
+    try {
+        fd = openSync(p, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+        const st = fstatSync(fd);
+        if (!st.isFile() || st.size > MAX_SHOT_BYTES)
+            return null;
+        const size = Number(st.size);
+        const buf = Buffer.alloc(size + 1);
+        const n = readSync(fd, buf, 0, size + 1, 0);
+        if (n > size)
+            return null;
+        return buf.subarray(0, n);
+    }
+    catch {
+        return null;
+    }
+    finally {
+        if (fd !== undefined) {
+            try {
+                closeSync(fd);
+            }
+            catch {
+                /* already closed */
+            }
+        }
+    }
+}
 export class Recorder {
     buf;
     seq = 0;
     subs = new Set();
     shots = new Map();
+    // GH #429: single-use trust grants from the capture pipeline (insertion-
+    // ordered, FIFO-evicted). Observations name paths, but only paths this
+    // process just captured may be read back — otherwise any tool result that
+    // mentions "/…/x.png" becomes an arbitrary local file read served over the
+    // observe server.
+    trustedShotPaths = new Set();
     shotCap;
     liveShotData;
     liveSeqVal = 0;
@@ -63,6 +107,25 @@ export class Recorder {
     }
     getScreenshot(seq) {
         return this.shots.get(seq);
+    }
+    /**
+     * GH #429: grant a one-shot read for a file the capture pipeline just
+     * wrote. `captureScreenshot` consumes the grant on first use, so a later
+     * observation replaying the same path is refused. User-chosen destinations
+     * (docs/proof/…, ~/Desktop/…) keep working because the grant is issued for
+     * whatever path the pipeline actually captured to.
+     */
+    registerCapturedScreenshot(p) {
+        if (typeof p !== 'string' || !isAbsolute(p))
+            return;
+        this.trustedShotPaths.delete(p);
+        this.trustedShotPaths.add(p);
+        while (this.trustedShotPaths.size > SHOT_REGISTRY_CAP) {
+            const oldest = this.trustedShotPaths.values().next().value;
+            if (oldest === undefined)
+                break;
+            this.trustedShotPaths.delete(oldest);
+        }
     }
     hasSubscribers() {
         return this.subs.size > 0;
@@ -119,6 +182,7 @@ export class Recorder {
         }
         this.subs.clear();
         this.shots.clear();
+        this.trustedShotPaths.clear();
         this.seq = 0;
         this.liveShotData = undefined;
         this.liveSeqVal = 0;
@@ -127,23 +191,21 @@ export class Recorder {
         if (ev.tool !== 'device_screenshot' || !ev.ok)
             return;
         const p = screenshotPath(o.result);
-        if (!p)
+        // GH #429: consume-on-attempt — a grant is spent even when the read
+        // fails, so a vanished file can't leave a live grant behind for a
+        // later forged observation naming the same path.
+        if (!p || !this.trustedShotPaths.delete(p))
             return;
-        try {
-            if (statSync(p).size > MAX_SHOT_BYTES)
-                return;
-            const buf = readFileSync(p);
-            const contentType = p.endsWith('.png') ? 'image/png' : 'image/jpeg';
-            this.shots.set(ev.seq, { buf, contentType });
-            while (this.shots.size > this.shotCap) {
-                const oldest = this.shots.keys().next().value;
-                if (oldest === undefined)
-                    break;
-                this.shots.delete(oldest);
-            }
-        }
-        catch {
-            /* file vanished/unreadable — fail-safe */
+        const buf = readShotBounded(p);
+        if (!buf)
+            return;
+        const contentType = p.endsWith('.png') ? 'image/png' : 'image/jpeg';
+        this.shots.set(ev.seq, { buf, contentType });
+        while (this.shots.size > this.shotCap) {
+            const oldest = this.shots.keys().next().value;
+            if (oldest === undefined)
+                break;
+            this.shots.delete(oldest);
         }
     }
 }

--- a/packages/rn-dev-agent-core/dist/observability/recorder.js
+++ b/packages/rn-dev-agent-core/dist/observability/recorder.js
@@ -12,7 +12,11 @@ const SHOT_REGISTRY_CAP = 64;
 // GH #422: absolute paths only — a runner-internal relative path (e.g. iOS
 // "tmp/…") would resolve against the bridge cwd, silently blanking the panel
 // or reading an unrelated file that shares the name.
-function screenshotPath(result) {
+// GH #429: exported so the capture pipeline can grant exactly the path this
+// extractor will later pull out of the observation — envelope wrapping can
+// rewrite data.path, and legacy envelopes carry the file in data.message,
+// so grants derived any other way can miss the consumed path.
+export function extractScreenshotPath(result) {
     const data = (unwrapResult(result)?.data ?? result?.data);
     const p = data?.path ?? data?.message;
     return typeof p === 'string' &&
@@ -190,7 +194,7 @@ export class Recorder {
     captureScreenshot(ev, o) {
         if (ev.tool !== 'device_screenshot' || !ev.ok)
             return;
-        const p = screenshotPath(o.result);
+        const p = extractScreenshotPath(o.result);
         // GH #429: consume-on-attempt — a grant is spent even when the read
         // fails, so a vanished file can't leave a live grant behind for a
         // later forged observation naming the same path.

--- a/packages/rn-dev-agent-core/dist/tools/device-list.js
+++ b/packages/rn-dev-agent-core/dist/tools/device-list.js
@@ -11,6 +11,7 @@ import { arbiter } from '../lifecycle/device-arbiter.js';
 import { foreignFlowGate } from '../lifecycle/foreign-flow-gate.js';
 import { pathHasTraversal } from '../domain/path-safety.js';
 import { parseAdbDevicesSerials } from '../runners/rn-android-runner-client.js';
+import { recorder } from '../observability/recorder.js';
 let runAgentDeviceFn = runNative;
 export function _setRunAgentDeviceForTest(fn) {
     runAgentDeviceFn = fn;
@@ -347,6 +348,12 @@ export async function captureAndResizeScreenshot(args) {
     if (result.isError)
         return result;
     const actualPath = resolveScreenshotPath(result, requestedPath);
+    // GH #429: grant the observe recorder a one-shot read of what THIS capture
+    // wrote. Both paths are granted because legacy runner envelopes surface the
+    // file via data.message, which resolveScreenshotPath can't see (it falls
+    // back to requestedPath) while the recorder-side extractor still reads it.
+    recorder.registerCapturedScreenshot(requestedPath);
+    recorder.registerCapturedScreenshot(actualPath);
     const resizeOpts = {};
     if (args.maxWidth !== undefined)
         resizeOpts.maxWidth = args.maxWidth;

--- a/packages/rn-dev-agent-core/dist/tools/device-list.js
+++ b/packages/rn-dev-agent-core/dist/tools/device-list.js
@@ -11,7 +11,7 @@ import { arbiter } from '../lifecycle/device-arbiter.js';
 import { foreignFlowGate } from '../lifecycle/foreign-flow-gate.js';
 import { pathHasTraversal } from '../domain/path-safety.js';
 import { parseAdbDevicesSerials } from '../runners/rn-android-runner-client.js';
-import { recorder } from '../observability/recorder.js';
+import { extractScreenshotPath, recorder } from '../observability/recorder.js';
 let runAgentDeviceFn = runNative;
 export function _setRunAgentDeviceForTest(fn) {
     runAgentDeviceFn = fn;
@@ -348,12 +348,6 @@ export async function captureAndResizeScreenshot(args) {
     if (result.isError)
         return result;
     const actualPath = resolveScreenshotPath(result, requestedPath);
-    // GH #429: grant the observe recorder a one-shot read of what THIS capture
-    // wrote. Both paths are granted because legacy runner envelopes surface the
-    // file via data.message, which resolveScreenshotPath can't see (it falls
-    // back to requestedPath) while the recorder-side extractor still reads it.
-    recorder.registerCapturedScreenshot(requestedPath);
-    recorder.registerCapturedScreenshot(actualPath);
     const resizeOpts = {};
     if (args.maxWidth !== undefined)
         resizeOpts.maxWidth = args.maxWidth;
@@ -361,7 +355,19 @@ export async function captureAndResizeScreenshot(args) {
         resizeOpts.quality = args.quality;
     const resize = await resizeWithSips(actualPath, resizeOpts);
     const resized = wrapResultWithResize(result, resize);
-    return wrapResultWithAdvisories(resized, advisories);
+    const finalResult = wrapResultWithAdvisories(resized, advisories);
+    // GH #429: grant the observe recorder a one-shot read of what THIS capture
+    // wrote. The recorder's own extractor is run on the FINAL envelope so the
+    // grant set structurally covers whatever path the observation will name
+    // (resize can rewrite data.path; legacy runner envelopes carry the file in
+    // data.message only). requested/actual are granted too — they are the files
+    // actually written when the envelope omits or post-dates them.
+    recorder.registerCapturedScreenshot(requestedPath);
+    recorder.registerCapturedScreenshot(actualPath);
+    const observedPath = extractScreenshotPath(finalResult);
+    if (observedPath)
+        recorder.registerCapturedScreenshot(observedPath);
+    return finalResult;
 }
 /**
  * B117/D638: device_screenshot accepts an optional `platform` and, when not

--- a/packages/rn-dev-agent-core/src/observability/recorder.ts
+++ b/packages/rn-dev-agent-core/src/observability/recorder.ts
@@ -19,7 +19,11 @@ export interface ScreenshotBytes {
 // GH #422: absolute paths only — a runner-internal relative path (e.g. iOS
 // "tmp/…") would resolve against the bridge cwd, silently blanking the panel
 // or reading an unrelated file that shares the name.
-function screenshotPath(result: unknown): string | null {
+// GH #429: exported so the capture pipeline can grant exactly the path this
+// extractor will later pull out of the observation — envelope wrapping can
+// rewrite data.path, and legacy envelopes carry the file in data.message,
+// so grants derived any other way can miss the consumed path.
+export function extractScreenshotPath(result: unknown): string | null {
   const data = (unwrapResult(result)?.data ?? (result as { data?: unknown })?.data) as
     | { message?: string; path?: string }
     | undefined;
@@ -187,7 +191,7 @@ export class Recorder {
   }
   protected captureScreenshot(ev: AgentEvent, o: ToolObservation): void {
     if (ev.tool !== 'device_screenshot' || !ev.ok) return;
-    const p = screenshotPath(o.result);
+    const p = extractScreenshotPath(o.result);
     // GH #429: consume-on-attempt — a grant is spent even when the read
     // fails, so a vanished file can't leave a live grant behind for a
     // later forged observation naming the same path.

--- a/packages/rn-dev-agent-core/src/observability/recorder.ts
+++ b/packages/rn-dev-agent-core/src/observability/recorder.ts
@@ -1,4 +1,4 @@
-import { readFileSync, statSync } from 'node:fs';
+import { closeSync, constants, fstatSync, openSync, readSync } from 'node:fs';
 import { isAbsolute } from 'node:path';
 import { RingBuffer } from '../ring-buffer.js';
 import { mapObservation, unwrapResult } from './events.js';
@@ -6,6 +6,11 @@ import type { AgentEvent, ToolObservation } from './events.js';
 
 const DEFAULT_CAP = 500;
 const MAX_SHOT_BYTES = 4_000_000;
+// GH #429: how many capture-registered paths to remember. Each successful
+// device_screenshot registers 1-2 paths and the very next observation
+// consumes one, so the bound only matters for pipelines (proof_step,
+// device_batch) whose registrations are never consumed.
+const SHOT_REGISTRY_CAP = 64;
 export interface ScreenshotBytes {
   buf: Buffer;
   contentType: string;
@@ -26,11 +31,46 @@ function screenshotPath(result: unknown): string | null {
     : null;
 }
 
+// GH #429: TOCTOU-safe bounded read. One descriptor for the whole
+// check-then-read (a stat-then-readFileSync pair can be raced by swapping the
+// file between the two calls); O_NOFOLLOW refuses symlinks outright and
+// O_NONBLOCK keeps a FIFO planted at the path from hanging the open. Reading
+// size+1 bytes detects a file that grew past the fstat between the two calls.
+function readShotBounded(p: string): Buffer | null {
+  let fd: number | undefined;
+  try {
+    fd = openSync(p, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+    const st = fstatSync(fd);
+    if (!st.isFile() || st.size > MAX_SHOT_BYTES) return null;
+    const size = Number(st.size);
+    const buf = Buffer.alloc(size + 1);
+    const n = readSync(fd, buf, 0, size + 1, 0);
+    if (n > size) return null;
+    return buf.subarray(0, n);
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}
+
 export class Recorder {
   private buf: RingBuffer<AgentEvent>;
   private seq = 0;
   private subs = new Set<(e: AgentEvent) => void>();
   private shots = new Map<number, ScreenshotBytes>();
+  // GH #429: single-use trust grants from the capture pipeline (insertion-
+  // ordered, FIFO-evicted). Observations name paths, but only paths this
+  // process just captured may be read back — otherwise any tool result that
+  // mentions "/…/x.png" becomes an arbitrary local file read served over the
+  // observe server.
+  private trustedShotPaths = new Set<string>();
   private readonly shotCap: number;
   private liveShotData: ScreenshotBytes | undefined;
   private liveSeqVal = 0;
@@ -71,6 +111,23 @@ export class Recorder {
   }
   getScreenshot(seq: number): ScreenshotBytes | undefined {
     return this.shots.get(seq);
+  }
+  /**
+   * GH #429: grant a one-shot read for a file the capture pipeline just
+   * wrote. `captureScreenshot` consumes the grant on first use, so a later
+   * observation replaying the same path is refused. User-chosen destinations
+   * (docs/proof/…, ~/Desktop/…) keep working because the grant is issued for
+   * whatever path the pipeline actually captured to.
+   */
+  registerCapturedScreenshot(p: string): void {
+    if (typeof p !== 'string' || !isAbsolute(p)) return;
+    this.trustedShotPaths.delete(p);
+    this.trustedShotPaths.add(p);
+    while (this.trustedShotPaths.size > SHOT_REGISTRY_CAP) {
+      const oldest = this.trustedShotPaths.values().next().value;
+      if (oldest === undefined) break;
+      this.trustedShotPaths.delete(oldest);
+    }
   }
   hasSubscribers(): boolean {
     return this.subs.size > 0;
@@ -123,6 +180,7 @@ export class Recorder {
     }
     this.subs.clear();
     this.shots.clear();
+    this.trustedShotPaths.clear();
     this.seq = 0;
     this.liveShotData = undefined;
     this.liveSeqVal = 0;
@@ -130,19 +188,18 @@ export class Recorder {
   protected captureScreenshot(ev: AgentEvent, o: ToolObservation): void {
     if (ev.tool !== 'device_screenshot' || !ev.ok) return;
     const p = screenshotPath(o.result);
-    if (!p) return;
-    try {
-      if (statSync(p).size > MAX_SHOT_BYTES) return;
-      const buf = readFileSync(p);
-      const contentType = p.endsWith('.png') ? 'image/png' : 'image/jpeg';
-      this.shots.set(ev.seq, { buf, contentType });
-      while (this.shots.size > this.shotCap) {
-        const oldest = this.shots.keys().next().value;
-        if (oldest === undefined) break;
-        this.shots.delete(oldest);
-      }
-    } catch {
-      /* file vanished/unreadable — fail-safe */
+    // GH #429: consume-on-attempt — a grant is spent even when the read
+    // fails, so a vanished file can't leave a live grant behind for a
+    // later forged observation naming the same path.
+    if (!p || !this.trustedShotPaths.delete(p)) return;
+    const buf = readShotBounded(p);
+    if (!buf) return;
+    const contentType = p.endsWith('.png') ? 'image/png' : 'image/jpeg';
+    this.shots.set(ev.seq, { buf, contentType });
+    while (this.shots.size > this.shotCap) {
+      const oldest = this.shots.keys().next().value;
+      if (oldest === undefined) break;
+      this.shots.delete(oldest);
     }
   }
 }

--- a/packages/rn-dev-agent-core/src/tools/device-list.ts
+++ b/packages/rn-dev-agent-core/src/tools/device-list.ts
@@ -13,6 +13,7 @@ import { arbiter } from '../lifecycle/device-arbiter.js';
 import { foreignFlowGate } from '../lifecycle/foreign-flow-gate.js';
 import { pathHasTraversal } from '../domain/path-safety.js';
 import { parseAdbDevicesSerials } from '../runners/rn-android-runner-client.js';
+import { recorder } from '../observability/recorder.js';
 
 // ── screenshot test seam (used by captureAndResizeScreenshot tests) ────────────
 type RunAgentDeviceFn = typeof runNative;
@@ -449,6 +450,12 @@ export async function captureAndResizeScreenshot(args: ScreenshotArgs): Promise<
   if (result.isError) return result;
 
   const actualPath = resolveScreenshotPath(result, requestedPath);
+  // GH #429: grant the observe recorder a one-shot read of what THIS capture
+  // wrote. Both paths are granted because legacy runner envelopes surface the
+  // file via data.message, which resolveScreenshotPath can't see (it falls
+  // back to requestedPath) while the recorder-side extractor still reads it.
+  recorder.registerCapturedScreenshot(requestedPath);
+  recorder.registerCapturedScreenshot(actualPath);
   const resizeOpts: ResizeOpts = {};
   if (args.maxWidth !== undefined) resizeOpts.maxWidth = args.maxWidth;
   if (args.quality !== undefined) resizeOpts.quality = args.quality;

--- a/packages/rn-dev-agent-core/src/tools/device-list.ts
+++ b/packages/rn-dev-agent-core/src/tools/device-list.ts
@@ -13,7 +13,7 @@ import { arbiter } from '../lifecycle/device-arbiter.js';
 import { foreignFlowGate } from '../lifecycle/foreign-flow-gate.js';
 import { pathHasTraversal } from '../domain/path-safety.js';
 import { parseAdbDevicesSerials } from '../runners/rn-android-runner-client.js';
-import { recorder } from '../observability/recorder.js';
+import { extractScreenshotPath, recorder } from '../observability/recorder.js';
 
 // ── screenshot test seam (used by captureAndResizeScreenshot tests) ────────────
 type RunAgentDeviceFn = typeof runNative;
@@ -450,18 +450,23 @@ export async function captureAndResizeScreenshot(args: ScreenshotArgs): Promise<
   if (result.isError) return result;
 
   const actualPath = resolveScreenshotPath(result, requestedPath);
-  // GH #429: grant the observe recorder a one-shot read of what THIS capture
-  // wrote. Both paths are granted because legacy runner envelopes surface the
-  // file via data.message, which resolveScreenshotPath can't see (it falls
-  // back to requestedPath) while the recorder-side extractor still reads it.
-  recorder.registerCapturedScreenshot(requestedPath);
-  recorder.registerCapturedScreenshot(actualPath);
   const resizeOpts: ResizeOpts = {};
   if (args.maxWidth !== undefined) resizeOpts.maxWidth = args.maxWidth;
   if (args.quality !== undefined) resizeOpts.quality = args.quality;
   const resize = await resizeWithSips(actualPath, resizeOpts);
   const resized = wrapResultWithResize(result, resize);
-  return wrapResultWithAdvisories(resized, advisories);
+  const finalResult = wrapResultWithAdvisories(resized, advisories);
+  // GH #429: grant the observe recorder a one-shot read of what THIS capture
+  // wrote. The recorder's own extractor is run on the FINAL envelope so the
+  // grant set structurally covers whatever path the observation will name
+  // (resize can rewrite data.path; legacy runner envelopes carry the file in
+  // data.message only). requested/actual are granted too — they are the files
+  // actually written when the envelope omits or post-dates them.
+  recorder.registerCapturedScreenshot(requestedPath);
+  recorder.registerCapturedScreenshot(actualPath);
+  const observedPath = extractScreenshotPath(finalResult);
+  if (observedPath) recorder.registerCapturedScreenshot(observedPath);
+  return finalResult;
 }
 
 /**

--- a/packages/rn-dev-agent-core/test/e2e-web/fixture-server.ts
+++ b/packages/rn-dev-agent-core/test/e2e-web/fixture-server.ts
@@ -50,6 +50,7 @@ export async function startFixture(): Promise<Fixture> {
     latencyMs: 4100,
     error: { message: 'flow failed at step 3' },
   });
+  recorder.registerCapturedScreenshot(shotPath); // GH #429: reads require a capture grant
   recorder.record({
     tool: 'device_screenshot',
     params: {},

--- a/packages/rn-dev-agent-core/test/unit/gh-429-recorder-shot-hardening.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-429-recorder-shot-hardening.test.ts
@@ -95,6 +95,32 @@ test('#429 registry is bounded — oldest registration is evicted', () => {
   assert.equal(r.getScreenshot(1), undefined, 'evicted registration must not be readable');
 });
 
+test('#429 wiring: message-only envelope whose path differs from the requested path is granted', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'gh429-'));
+  const runnerChose = join(dir, 'runner-chose.png');
+  writeFileSync(runnerChose, PNG);
+  const requested = join(dir, 'requested.png'); // never written by the stub
+  _setRunAgentDeviceForTest(async () => ({
+    content: [{ type: 'text', text: JSON.stringify({ ok: true, data: { message: runnerChose } }) }],
+  }));
+  try {
+    const res = await captureAndResizeScreenshot({ path: requested, maxWidth: 0 });
+    assert.ok(!res.isError, 'stubbed capture must succeed');
+    recorder.record({
+      tool: 'device_screenshot',
+      params: {},
+      status: 'PASS',
+      latencyMs: 1,
+      result: JSON.parse(res.content[0].text),
+    });
+    const events = recorder.snapshot();
+    const seq = events[events.length - 1].seq;
+    assert.ok(recorder.getScreenshot(seq), 'message-only runner path must be served');
+  } finally {
+    _resetRunAgentDeviceForTest();
+  }
+});
+
 test('#429 wiring: captureAndResizeScreenshot registers its output with the singleton recorder', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'gh429-'));
   const p = join(dir, 'wired.png');

--- a/packages/rn-dev-agent-core/test/unit/gh-429-recorder-shot-hardening.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-429-recorder-shot-hardening.test.ts
@@ -1,0 +1,115 @@
+// GH #429: Recorder screenshot-ingestion hardening. The recorder must only
+// read files the capture pipeline itself just wrote (trusted registration,
+// single-use), never an arbitrary absolute path that appears in an
+// observation — and the read itself must be fd-bound (no stat→read TOCTOU,
+// no symlink follow, hard byte cap).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, symlinkSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { Recorder, recorder } from '../../dist/observability/recorder.js';
+import {
+  captureAndResizeScreenshot,
+  _setRunAgentDeviceForTest,
+  _resetRunAgentDeviceForTest,
+} from '../../dist/tools/device-list.js';
+
+const JPEG = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+
+function shotObs(p) {
+  return {
+    tool: 'device_screenshot',
+    params: {},
+    status: 'PASS',
+    latencyMs: 1,
+    result: { ok: true, data: { path: p } },
+  };
+}
+
+test('#429 unregistered absolute image path is refused (no arbitrary local file read)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'gh429-'));
+  const p = join(dir, 'not-ours.png');
+  writeFileSync(p, PNG);
+  const r = new Recorder(5);
+  r.record(shotObs(p));
+  assert.equal(r.getScreenshot(1), undefined);
+});
+
+test('#429 capture-registered path is served', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'gh429-'));
+  const p = join(dir, 'shot.jpg');
+  writeFileSync(p, JPEG);
+  const r = new Recorder(5);
+  r.registerCapturedScreenshot(p);
+  r.record(shotObs(p));
+  const shot = r.getScreenshot(1);
+  assert.ok(shot, 'registered capture must be served');
+  assert.equal(shot.contentType, 'image/jpeg');
+  assert.equal(shot.buf.length, JPEG.length);
+});
+
+test('#429 registration is single-use (stale-path replay is refused)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'gh429-'));
+  const p = join(dir, 'shot.png');
+  writeFileSync(p, PNG);
+  const r = new Recorder(5);
+  r.registerCapturedScreenshot(p);
+  r.record(shotObs(p));
+  r.record(shotObs(p));
+  assert.ok(r.getScreenshot(1), 'first observation consumes the registration');
+  assert.equal(r.getScreenshot(2), undefined, 'replayed path must not be re-read');
+});
+
+test('#429 symlink at a registered path is refused (no symlink follow)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'gh429-'));
+  const target = join(dir, 'target.png');
+  const link = join(dir, 'link.png');
+  writeFileSync(target, PNG);
+  symlinkSync(target, link);
+  const r = new Recorder(5);
+  r.registerCapturedScreenshot(link);
+  r.record(shotObs(link));
+  assert.equal(r.getScreenshot(1), undefined);
+});
+
+test('#429 oversized file is refused even when registered', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'gh429-'));
+  const p = join(dir, 'huge.png');
+  writeFileSync(p, Buffer.alloc(4_000_001));
+  const r = new Recorder(5);
+  r.registerCapturedScreenshot(p);
+  r.record(shotObs(p));
+  assert.equal(r.getScreenshot(1), undefined);
+});
+
+test('#429 registry is bounded — oldest registration is evicted', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'gh429-'));
+  const first = join(dir, 'first.png');
+  writeFileSync(first, PNG);
+  const r = new Recorder(5);
+  r.registerCapturedScreenshot(first);
+  for (let i = 0; i < 64; i++) r.registerCapturedScreenshot(join(dir, `filler-${i}.png`));
+  r.record(shotObs(first));
+  assert.equal(r.getScreenshot(1), undefined, 'evicted registration must not be readable');
+});
+
+test('#429 wiring: captureAndResizeScreenshot registers its output with the singleton recorder', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'gh429-'));
+  const p = join(dir, 'wired.png');
+  writeFileSync(p, PNG);
+  _setRunAgentDeviceForTest(async () => ({
+    content: [{ type: 'text', text: JSON.stringify({ ok: true, data: { path: p } }) }],
+  }));
+  try {
+    const res = await captureAndResizeScreenshot({ path: p, maxWidth: 0 });
+    assert.ok(!res.isError, 'stubbed capture must succeed');
+    recorder.record(shotObs(p));
+    const events = recorder.snapshot();
+    const seq = events[events.length - 1].seq;
+    assert.ok(recorder.getScreenshot(seq), 'pipeline-captured path must be served');
+  } finally {
+    _resetRunAgentDeviceForTest();
+  }
+});

--- a/packages/rn-dev-agent-core/test/unit/observability-recorder.test.js
+++ b/packages/rn-dev-agent-core/test/unit/observability-recorder.test.js
@@ -43,6 +43,7 @@ test('captureScreenshot reads bytes at record time and serves by seq', () => {
   const png = join(dir, 'shot.jpg');
   writeFileSync(png, Buffer.from([0xff, 0xd8, 0xff, 0xe0]));
   const r = new Recorder(5);
+  r.registerCapturedScreenshot(png); // GH #429: reads require a capture grant
   r.record({
     tool: 'device_screenshot',
     params: {},
@@ -71,6 +72,7 @@ test('captureScreenshot bytes survive deletion of the source file (captured at r
   const png = join(dir, 'shot.png');
   writeFileSync(png, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
   const r = new Recorder(5);
+  r.registerCapturedScreenshot(png); // GH #429
   r.record({
     tool: 'device_screenshot',
     params: {},
@@ -88,6 +90,7 @@ test('captureScreenshot skips an oversized file (>4MB)', () => {
   const big = join(dir, 'big.jpg');
   writeFileSync(big, Buffer.alloc(4_000_001, 0xff));
   const r = new Recorder(5);
+  r.registerCapturedScreenshot(big); // GH #429
   r.record({
     tool: 'device_screenshot',
     params: {},
@@ -103,6 +106,7 @@ test('captureScreenshot FIFO-evicts beyond shotCap', () => {
   const png = join(dir, 's.jpg');
   writeFileSync(png, Buffer.from([0xff, 0xd8, 0xff, 0xe0]));
   for (let i = 0; i < 10; i++) {
+    r.registerCapturedScreenshot(png); // GH #429: grants are single-use
     r.record({
       tool: 'device_screenshot',
       params: {},
@@ -132,6 +136,7 @@ test('captureScreenshot reads bytes from the REAL MCP envelope (content[0].text)
   const jpg = join(dir, 'real-envelope.jpg');
   writeFileSync(jpg, Buffer.from([0xff, 0xd8, 0xff, 0xe0]));
   const r = new Recorder(5);
+  r.registerCapturedScreenshot(jpg); // GH #429
   r.record({
     tool: 'device_screenshot',
     params: {},

--- a/packages/rn-dev-agent-core/test/unit/observability-server.test.js
+++ b/packages/rn-dev-agent-core/test/unit/observability-server.test.js
@@ -69,6 +69,7 @@ test('GET /api/screenshot/:seq serves bytes from the recorder buffer only', asyn
   const rec = new Recorder(10);
   const p = join(mkdtempSync(join(tmpdir(), 'obs-')), 's.jpg');
   writeFileSync(p, Buffer.from([0xff, 0xd8, 0xff, 0xe0]));
+  rec.registerCapturedScreenshot(p); // GH #429: reads require a capture grant
   rec.record({
     tool: 'device_screenshot',
     params: {},


### PR DESCRIPTION
## Summary

Hardens observe-recorder screenshot ingestion (GH #429, flagged during #427 review):

**Read surface.** `Recorder.captureScreenshot` previously `readFileSync`'d **any** absolute `.png/.jpg/.jpeg` path found in a `device_screenshot` observation and served the bytes on the localhost observe server — an arbitrary local file read for image-extension files if tool results ever become externally influenceable. Now the capture pipeline (`captureAndResizeScreenshot`) registers the exact path(s) it just wrote as **single-use trust grants** on the recorder, and observations naming any other path are refused. This is the issue's "trusted channel" option: user-chosen destinations (`docs/proof/…`, `~/Desktop/…`) keep working because the grant follows whatever path the pipeline actually captured — no allowlist to break them.

- Grants are consume-on-attempt (a vanished file can't leave a live grant behind for a later forged observation), FIFO-bounded (64), and cleared on `recorder.clear()`.
- Both `requestedPath` and `resolveScreenshotPath(...)` are granted, because legacy runner envelopes surface the file via `data.message`, which the resolver can't see while the recorder-side extractor still reads it.

**TOCTOU.** The `statSync(p).size` → `readFileSync(p)` pair could be raced by swapping the file between the two calls. The read now uses one descriptor for the whole check-then-read: `O_NOFOLLOW` (symlinks refused outright), `O_NONBLOCK` (a FIFO planted at the path can't hang the open), `fstat` on the same fd, and the 4MB cap enforced on the bytes actually read (`size+1` probe detects mid-read growth).

## Tests

- New `gh-429-recorder-shot-hardening.test.ts` (7 tests, written first / watched fail): unregistered-path refusal, grant round-trip, single-use consumption, symlink refusal, oversize refusal, registry FIFO bound, and pipeline→recorder wiring (discriminating: it can only pass if `captureAndResizeScreenshot` actually registers, since unregistered paths are refused).
- Legacy recorder/server tests updated to issue grants (5 call sites) — they keep testing what they meant to (byte capture, envelope unwrap, size cap, FIFO eviction, HTTP serving) rather than the new refusal path.
- Full `rn-dev-agent-core` suite: **3,121 tests, 0 failures** on this base; oxlint + oxfmt clean.

Closes #429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RKLei35BHPzghheSA4eoa