### PR TITLE
fix(proof): tolerate encoded video tail drift

### DIFF
--- a/.changeset/proof-video-tail-tolerance.md
+++ b/.changeset/proof-video-tail-tolerance.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-plugin": patch
+"rn-dev-agent-core": patch
+---
+
+Accept a visually matched final proof screenshot when iOS video metadata ends up to two seconds before the assertion timestamp.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Unit tests (with coverage report)
         run: corepack yarn test:coverage
 
+      - name: Install proof-media integration dependency
+        run: sudo apt-get update && sudo apt-get install --yes ffmpeg
+
       - name: Integration tests
         run: corepack yarn test:integration
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,9 @@ jobs:
       - name: Unit tests
         run: corepack yarn test
 
+      - name: Install proof-media integration dependency
+        run: sudo apt-get update && sudo apt-get install --yes ffmpeg
+
       - name: Integration tests
         run: corepack yarn test:integration
 

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -56185,6 +56185,28 @@ var proofCaptureInputSchema = external_exports.discriminatedUnion("action", [
   sessionActionSchema("discard"),
   sessionActionSchema("contract")
 ]);
+var PROOF_VIDEO_TAIL_TOLERANCE_MS = 2e3;
+function evidenceTimingReasons(timestamps, videoDurationMs, steps) {
+  if (timestamps.length !== steps.length)
+    return ["SCREENSHOT_TIMESTAMPS_INVALID"];
+  const lastIndex = timestamps.length - 1;
+  const increasing = timestamps.every((timestamp, index) => {
+    const withinVideo = timestamp <= videoDurationMs;
+    const withinEncodedTail = index === lastIndex && timestamp <= videoDurationMs + PROOF_VIDEO_TAIL_TOLERANCE_MS;
+    return timestamp >= 0 && (withinVideo || withinEncodedTail) && (index === 0 || timestamp > timestamps[index - 1]);
+  });
+  const reasons = increasing ? [] : ["SCREENSHOT_TIMESTAMPS_INVALID"];
+  for (const [index, step] of steps.entries()) {
+    const timestamp = timestamps[index] ?? 0;
+    const dwellEnd = timestamps[index + 1] ?? Math.max(videoDurationMs, timestamp);
+    const dwell = dwellEnd - timestamp;
+    if (dwell < step.expectedDwellMs || dwell > step.maximumDwellMs) {
+      reasons.push("STEP_DWELL_OUT_OF_BOUNDS");
+      break;
+    }
+  }
+  return reasons;
+}
 var readinessSchema = external_exports.object({
   cdpAttached: external_exports.boolean(),
   helpersAttached: external_exports.boolean(),
@@ -56995,16 +57017,7 @@ function createProofCaptureHandler(deps) {
         evidenceReasons.push(...media.reasons);
       if (media.ok) {
         const timestamps = evidence.map((item) => item.timestampMs);
-        const increasing = timestamps.every((timestamp, index) => timestamp >= 0 && timestamp <= media.video.durationMs && (index === 0 || timestamp > timestamps[index - 1]));
-        if (!increasing)
-          evidenceReasons.push("SCREENSHOT_TIMESTAMPS_INVALID");
-        for (const [index, step] of steps.entries()) {
-          const dwellEnd = timestamps[index + 1] ?? media.video.durationMs;
-          const dwell = dwellEnd - (timestamps[index] ?? 0);
-          if (dwell < step.expectedDwellMs || dwell > step.maximumDwellMs) {
-            evidenceReasons.push("STEP_DWELL_OUT_OF_BOUNDS");
-          }
-        }
+        evidenceReasons.push(...evidenceTimingReasons(timestamps, media.video.durationMs, steps));
         if (media.screenshots.length !== evidence.length || media.screenshots.some((screenshot, index) => screenshot.stepId !== evidence[index]?.stepId || screenshot.path !== evidence[index]?.screenshotPath || screenshot.timestampMs !== evidence[index]?.timestampMs)) {
           evidenceReasons.push("MEDIA_EVIDENCE_MISMATCH");
         }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -57335,7 +57335,7 @@ async function matchScreenshotAt(process3, input) {
       "-i",
       framePath,
       "-lavfi",
-      "[1:v][0:v]scale2ref=w=rw:h=rh:flags=lanczos[frame][reference];[reference][frame]ssim",
+      "[0:v][1:v]ssim",
       "-f",
       "null",
       "-"

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -57891,6 +57891,27 @@ import { execFileSync as execFileSync7 } from "node:child_process";
 import { chmodSync, closeSync as closeSync4, fsyncSync, lstatSync as lstatSync3, mkdirSync as mkdirSync14, openSync as openSync4, readFileSync as readFileSync20, renameSync as renameSync5, unlinkSync as unlinkSync10, writeFileSync as writeFileSync14 } from "node:fs";
 import { basename as basename5, dirname as dirname13, extname, isAbsolute as isAbsolute3, join as join30, relative, resolve as resolve4, sep as sep5 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
+function evidenceTimingReasons(timestamps, videoDurationMs, steps) {
+  if (timestamps.length !== steps.length)
+    return ["SCREENSHOT_TIMESTAMPS_INVALID"];
+  const lastIndex = timestamps.length - 1;
+  const increasing = timestamps.every((timestamp, index) => {
+    const withinVideo = timestamp <= videoDurationMs;
+    const withinEncodedTail = index === lastIndex && timestamp <= videoDurationMs + PROOF_VIDEO_TAIL_TOLERANCE_MS;
+    return timestamp >= 0 && (withinVideo || withinEncodedTail) && (index === 0 || timestamp > timestamps[index - 1]);
+  });
+  const reasons = increasing ? [] : ["SCREENSHOT_TIMESTAMPS_INVALID"];
+  for (const [index, step] of steps.entries()) {
+    const timestamp = timestamps[index] ?? 0;
+    const dwellEnd = timestamps[index + 1] ?? Math.max(videoDurationMs, timestamp);
+    const dwell = dwellEnd - timestamp;
+    if (dwell < step.expectedDwellMs || dwell > step.maximumDwellMs) {
+      reasons.push("STEP_DWELL_OUT_OF_BOUNDS");
+      break;
+    }
+  }
+  return reasons;
+}
 function hashBytes(bytes) {
   return createHash7("sha256").update(bytes).digest("hex");
 }
@@ -58688,16 +58709,7 @@ function createProofCaptureHandler(deps) {
         evidenceReasons.push(...media.reasons);
       if (media.ok) {
         const timestamps = evidence.map((item) => item.timestampMs);
-        const increasing = timestamps.every((timestamp, index) => timestamp >= 0 && timestamp <= media.video.durationMs && (index === 0 || timestamp > timestamps[index - 1]));
-        if (!increasing)
-          evidenceReasons.push("SCREENSHOT_TIMESTAMPS_INVALID");
-        for (const [index, step] of steps.entries()) {
-          const dwellEnd = timestamps[index + 1] ?? media.video.durationMs;
-          const dwell = dwellEnd - (timestamps[index] ?? 0);
-          if (dwell < step.expectedDwellMs || dwell > step.maximumDwellMs) {
-            evidenceReasons.push("STEP_DWELL_OUT_OF_BOUNDS");
-          }
-        }
+        evidenceReasons.push(...evidenceTimingReasons(timestamps, media.video.durationMs, steps));
         if (media.screenshots.length !== evidence.length || media.screenshots.some((screenshot, index) => screenshot.stepId !== evidence[index]?.stepId || screenshot.path !== evidence[index]?.screenshotPath || screenshot.timestampMs !== evidence[index]?.timestampMs)) {
           evidenceReasons.push("MEDIA_EVIDENCE_MISMATCH");
         }
@@ -58817,7 +58829,7 @@ function createProofCaptureHandler(deps) {
     return proofFailure(["INVALID_PROOF_STAGE"], active.stage);
   };
 }
-var absolutePathSchema, beginRehearsalSchema, sessionActionSchema, validateSchema, finalizeSchema, proofCaptureInputSchema, readinessSchema;
+var absolutePathSchema, beginRehearsalSchema, sessionActionSchema, validateSchema, finalizeSchema, proofCaptureInputSchema, PROOF_VIDEO_TAIL_TOLERANCE_MS, readinessSchema;
 var init_proof_capture2 = __esm({
   "packages/rn-dev-agent-core/dist/tools/proof-capture.js"() {
     "use strict";
@@ -58861,6 +58873,7 @@ var init_proof_capture2 = __esm({
       sessionActionSchema("discard"),
       sessionActionSchema("contract")
     ]);
+    PROOF_VIDEO_TAIL_TOLERANCE_MS = 2e3;
     readinessSchema = external_exports.object({
       cdpAttached: external_exports.boolean(),
       helpersAttached: external_exports.boolean(),

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -59079,7 +59079,7 @@ async function matchScreenshotAt(process3, input) {
       "-i",
       framePath,
       "-lavfi",
-      "[1:v][0:v]scale2ref=w=rw:h=rh:flags=lanczos[frame][reference];[reference][frame]ssim",
+      "[0:v][1:v]ssim",
       "-f",
       "null",
       "-"

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -56185,6 +56185,28 @@ var proofCaptureInputSchema = external_exports.discriminatedUnion("action", [
   sessionActionSchema("discard"),
   sessionActionSchema("contract")
 ]);
+var PROOF_VIDEO_TAIL_TOLERANCE_MS = 2e3;
+function evidenceTimingReasons(timestamps, videoDurationMs, steps) {
+  if (timestamps.length !== steps.length)
+    return ["SCREENSHOT_TIMESTAMPS_INVALID"];
+  const lastIndex = timestamps.length - 1;
+  const increasing = timestamps.every((timestamp, index) => {
+    const withinVideo = timestamp <= videoDurationMs;
+    const withinEncodedTail = index === lastIndex && timestamp <= videoDurationMs + PROOF_VIDEO_TAIL_TOLERANCE_MS;
+    return timestamp >= 0 && (withinVideo || withinEncodedTail) && (index === 0 || timestamp > timestamps[index - 1]);
+  });
+  const reasons = increasing ? [] : ["SCREENSHOT_TIMESTAMPS_INVALID"];
+  for (const [index, step] of steps.entries()) {
+    const timestamp = timestamps[index] ?? 0;
+    const dwellEnd = timestamps[index + 1] ?? Math.max(videoDurationMs, timestamp);
+    const dwell = dwellEnd - timestamp;
+    if (dwell < step.expectedDwellMs || dwell > step.maximumDwellMs) {
+      reasons.push("STEP_DWELL_OUT_OF_BOUNDS");
+      break;
+    }
+  }
+  return reasons;
+}
 var readinessSchema = external_exports.object({
   cdpAttached: external_exports.boolean(),
   helpersAttached: external_exports.boolean(),
@@ -56995,16 +57017,7 @@ function createProofCaptureHandler(deps) {
         evidenceReasons.push(...media.reasons);
       if (media.ok) {
         const timestamps = evidence.map((item) => item.timestampMs);
-        const increasing = timestamps.every((timestamp, index) => timestamp >= 0 && timestamp <= media.video.durationMs && (index === 0 || timestamp > timestamps[index - 1]));
-        if (!increasing)
-          evidenceReasons.push("SCREENSHOT_TIMESTAMPS_INVALID");
-        for (const [index, step] of steps.entries()) {
-          const dwellEnd = timestamps[index + 1] ?? media.video.durationMs;
-          const dwell = dwellEnd - (timestamps[index] ?? 0);
-          if (dwell < step.expectedDwellMs || dwell > step.maximumDwellMs) {
-            evidenceReasons.push("STEP_DWELL_OUT_OF_BOUNDS");
-          }
-        }
+        evidenceReasons.push(...evidenceTimingReasons(timestamps, media.video.durationMs, steps));
         if (media.screenshots.length !== evidence.length || media.screenshots.some((screenshot, index) => screenshot.stepId !== evidence[index]?.stepId || screenshot.path !== evidence[index]?.screenshotPath || screenshot.timestampMs !== evidence[index]?.timestampMs)) {
           evidenceReasons.push("MEDIA_EVIDENCE_MISMATCH");
         }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -57335,7 +57335,7 @@ async function matchScreenshotAt(process3, input) {
       "-i",
       framePath,
       "-lavfi",
-      "[1:v][0:v]scale2ref=w=rw:h=rh:flags=lanczos[frame][reference];[reference][frame]ssim",
+      "[0:v][1:v]ssim",
       "-f",
       "null",
       "-"

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -57891,6 +57891,27 @@ import { execFileSync as execFileSync7 } from "node:child_process";
 import { chmodSync, closeSync as closeSync4, fsyncSync, lstatSync as lstatSync3, mkdirSync as mkdirSync14, openSync as openSync4, readFileSync as readFileSync20, renameSync as renameSync5, unlinkSync as unlinkSync10, writeFileSync as writeFileSync14 } from "node:fs";
 import { basename as basename5, dirname as dirname13, extname, isAbsolute as isAbsolute3, join as join30, relative, resolve as resolve4, sep as sep5 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
+function evidenceTimingReasons(timestamps, videoDurationMs, steps) {
+  if (timestamps.length !== steps.length)
+    return ["SCREENSHOT_TIMESTAMPS_INVALID"];
+  const lastIndex = timestamps.length - 1;
+  const increasing = timestamps.every((timestamp, index) => {
+    const withinVideo = timestamp <= videoDurationMs;
+    const withinEncodedTail = index === lastIndex && timestamp <= videoDurationMs + PROOF_VIDEO_TAIL_TOLERANCE_MS;
+    return timestamp >= 0 && (withinVideo || withinEncodedTail) && (index === 0 || timestamp > timestamps[index - 1]);
+  });
+  const reasons = increasing ? [] : ["SCREENSHOT_TIMESTAMPS_INVALID"];
+  for (const [index, step] of steps.entries()) {
+    const timestamp = timestamps[index] ?? 0;
+    const dwellEnd = timestamps[index + 1] ?? Math.max(videoDurationMs, timestamp);
+    const dwell = dwellEnd - timestamp;
+    if (dwell < step.expectedDwellMs || dwell > step.maximumDwellMs) {
+      reasons.push("STEP_DWELL_OUT_OF_BOUNDS");
+      break;
+    }
+  }
+  return reasons;
+}
 function hashBytes(bytes) {
   return createHash7("sha256").update(bytes).digest("hex");
 }
@@ -58688,16 +58709,7 @@ function createProofCaptureHandler(deps) {
         evidenceReasons.push(...media.reasons);
       if (media.ok) {
         const timestamps = evidence.map((item) => item.timestampMs);
-        const increasing = timestamps.every((timestamp, index) => timestamp >= 0 && timestamp <= media.video.durationMs && (index === 0 || timestamp > timestamps[index - 1]));
-        if (!increasing)
-          evidenceReasons.push("SCREENSHOT_TIMESTAMPS_INVALID");
-        for (const [index, step] of steps.entries()) {
-          const dwellEnd = timestamps[index + 1] ?? media.video.durationMs;
-          const dwell = dwellEnd - (timestamps[index] ?? 0);
-          if (dwell < step.expectedDwellMs || dwell > step.maximumDwellMs) {
-            evidenceReasons.push("STEP_DWELL_OUT_OF_BOUNDS");
-          }
-        }
+        evidenceReasons.push(...evidenceTimingReasons(timestamps, media.video.durationMs, steps));
         if (media.screenshots.length !== evidence.length || media.screenshots.some((screenshot, index) => screenshot.stepId !== evidence[index]?.stepId || screenshot.path !== evidence[index]?.screenshotPath || screenshot.timestampMs !== evidence[index]?.timestampMs)) {
           evidenceReasons.push("MEDIA_EVIDENCE_MISMATCH");
         }
@@ -58817,7 +58829,7 @@ function createProofCaptureHandler(deps) {
     return proofFailure(["INVALID_PROOF_STAGE"], active.stage);
   };
 }
-var absolutePathSchema, beginRehearsalSchema, sessionActionSchema, validateSchema, finalizeSchema, proofCaptureInputSchema, readinessSchema;
+var absolutePathSchema, beginRehearsalSchema, sessionActionSchema, validateSchema, finalizeSchema, proofCaptureInputSchema, PROOF_VIDEO_TAIL_TOLERANCE_MS, readinessSchema;
 var init_proof_capture2 = __esm({
   "packages/rn-dev-agent-core/dist/tools/proof-capture.js"() {
     "use strict";
@@ -58861,6 +58873,7 @@ var init_proof_capture2 = __esm({
       sessionActionSchema("discard"),
       sessionActionSchema("contract")
     ]);
+    PROOF_VIDEO_TAIL_TOLERANCE_MS = 2e3;
     readinessSchema = external_exports.object({
       cdpAttached: external_exports.boolean(),
       helpersAttached: external_exports.boolean(),

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -59079,7 +59079,7 @@ async function matchScreenshotAt(process3, input) {
       "-i",
       framePath,
       "-lavfi",
-      "[1:v][0:v]scale2ref=w=rw:h=rh:flags=lanczos[frame][reference];[reference][frame]ssim",
+      "[0:v][1:v]ssim",
       "-f",
       "null",
       "-"

--- a/packages/rn-dev-agent-core/dist/tools/proof-capture.js
+++ b/packages/rn-dev-agent-core/dist/tools/proof-capture.js
@@ -47,6 +47,30 @@ export const proofCaptureInputSchema = z.discriminatedUnion('action', [
     sessionActionSchema('discard'),
     sessionActionSchema('contract'),
 ]);
+const PROOF_VIDEO_TAIL_TOLERANCE_MS = 2_000;
+export function evidenceTimingReasons(timestamps, videoDurationMs, steps) {
+    if (timestamps.length !== steps.length)
+        return ['SCREENSHOT_TIMESTAMPS_INVALID'];
+    const lastIndex = timestamps.length - 1;
+    const increasing = timestamps.every((timestamp, index) => {
+        const withinVideo = timestamp <= videoDurationMs;
+        const withinEncodedTail = index === lastIndex && timestamp <= videoDurationMs + PROOF_VIDEO_TAIL_TOLERANCE_MS;
+        return (timestamp >= 0 &&
+            (withinVideo || withinEncodedTail) &&
+            (index === 0 || timestamp > timestamps[index - 1]));
+    });
+    const reasons = increasing ? [] : ['SCREENSHOT_TIMESTAMPS_INVALID'];
+    for (const [index, step] of steps.entries()) {
+        const timestamp = timestamps[index] ?? 0;
+        const dwellEnd = timestamps[index + 1] ?? Math.max(videoDurationMs, timestamp);
+        const dwell = dwellEnd - timestamp;
+        if (dwell < step.expectedDwellMs || dwell > step.maximumDwellMs) {
+            reasons.push('STEP_DWELL_OUT_OF_BOUNDS');
+            break;
+        }
+    }
+    return reasons;
+}
 const readinessSchema = z
     .object({
     cdpAttached: z.boolean(),
@@ -1003,18 +1027,7 @@ export function createProofCaptureHandler(deps) {
                 evidenceReasons.push(...media.reasons);
             if (media.ok) {
                 const timestamps = evidence.map((item) => item.timestampMs);
-                const increasing = timestamps.every((timestamp, index) => timestamp >= 0 &&
-                    timestamp <= media.video.durationMs &&
-                    (index === 0 || timestamp > timestamps[index - 1]));
-                if (!increasing)
-                    evidenceReasons.push('SCREENSHOT_TIMESTAMPS_INVALID');
-                for (const [index, step] of steps.entries()) {
-                    const dwellEnd = timestamps[index + 1] ?? media.video.durationMs;
-                    const dwell = dwellEnd - (timestamps[index] ?? 0);
-                    if (dwell < step.expectedDwellMs || dwell > step.maximumDwellMs) {
-                        evidenceReasons.push('STEP_DWELL_OUT_OF_BOUNDS');
-                    }
-                }
+                evidenceReasons.push(...evidenceTimingReasons(timestamps, media.video.durationMs, steps));
                 if (media.screenshots.length !== evidence.length ||
                     media.screenshots.some((screenshot, index) => screenshot.stepId !== evidence[index]?.stepId ||
                         screenshot.path !== evidence[index]?.screenshotPath ||

--- a/packages/rn-dev-agent-core/dist/tools/proof-media.js
+++ b/packages/rn-dev-agent-core/dist/tools/proof-media.js
@@ -238,7 +238,7 @@ export async function matchScreenshotAt(process, input) {
             '-i',
             framePath,
             '-lavfi',
-            '[1:v][0:v]scale2ref=w=rw:h=rh:flags=lanczos[frame][reference];[reference][frame]ssim',
+            '[0:v][1:v]ssim',
             '-f',
             'null',
             '-',

--- a/packages/rn-dev-agent-core/src/tools/proof-capture.ts
+++ b/packages/rn-dev-agent-core/src/tools/proof-capture.ts
@@ -174,6 +174,40 @@ interface DerivedEvidence {
   };
 }
 
+const PROOF_VIDEO_TAIL_TOLERANCE_MS = 2_000;
+
+export function evidenceTimingReasons(
+  timestamps: readonly number[],
+  videoDurationMs: number,
+  steps: readonly { expectedDwellMs: number; maximumDwellMs: number }[],
+): string[] {
+  if (timestamps.length !== steps.length) return ['SCREENSHOT_TIMESTAMPS_INVALID'];
+  const lastIndex = timestamps.length - 1;
+  const increasing = timestamps.every((timestamp, index) => {
+    const withinVideo = timestamp <= videoDurationMs;
+    const withinEncodedTail =
+      index === lastIndex && timestamp <= videoDurationMs + PROOF_VIDEO_TAIL_TOLERANCE_MS;
+    return (
+      timestamp >= 0 &&
+      (withinVideo || withinEncodedTail) &&
+      (index === 0 || timestamp > timestamps[index - 1]!)
+    );
+  });
+  const reasons = increasing ? [] : ['SCREENSHOT_TIMESTAMPS_INVALID'];
+
+  for (const [index, step] of steps.entries()) {
+    const timestamp = timestamps[index] ?? 0;
+    const dwellEnd = timestamps[index + 1] ?? Math.max(videoDurationMs, timestamp);
+    const dwell = dwellEnd - timestamp;
+    if (dwell < step.expectedDwellMs || dwell > step.maximumDwellMs) {
+      reasons.push('STEP_DWELL_OUT_OF_BOUNDS');
+      break;
+    }
+  }
+
+  return reasons;
+}
+
 const readinessSchema = z
   .object({
     cdpAttached: z.boolean(),
@@ -1235,20 +1269,7 @@ export function createProofCaptureHandler(
 
       if (media.ok) {
         const timestamps = evidence.map((item) => item.timestampMs);
-        const increasing = timestamps.every(
-          (timestamp, index) =>
-            timestamp >= 0 &&
-            timestamp <= media.video.durationMs &&
-            (index === 0 || timestamp > timestamps[index - 1]!),
-        );
-        if (!increasing) evidenceReasons.push('SCREENSHOT_TIMESTAMPS_INVALID');
-        for (const [index, step] of steps.entries()) {
-          const dwellEnd = timestamps[index + 1] ?? media.video.durationMs;
-          const dwell = dwellEnd - (timestamps[index] ?? 0);
-          if (dwell < step.expectedDwellMs || dwell > step.maximumDwellMs) {
-            evidenceReasons.push('STEP_DWELL_OUT_OF_BOUNDS');
-          }
-        }
+        evidenceReasons.push(...evidenceTimingReasons(timestamps, media.video.durationMs, steps));
         if (
           media.screenshots.length !== evidence.length ||
           media.screenshots.some(

--- a/packages/rn-dev-agent-core/src/tools/proof-media.ts
+++ b/packages/rn-dev-agent-core/src/tools/proof-media.ts
@@ -329,7 +329,7 @@ export async function matchScreenshotAt(
       '-i',
       framePath,
       '-lavfi',
-      '[1:v][0:v]scale2ref=w=rw:h=rh:flags=lanczos[frame][reference];[reference][frame]ssim',
+      '[0:v][1:v]ssim',
       '-f',
       'null',
       '-',

--- a/packages/rn-dev-agent-core/test/integration/proof-video-tail-tolerance.test.ts
+++ b/packages/rn-dev-agent-core/test/integration/proof-video-tail-tolerance.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { promisify } from 'node:util';
+import { evidenceTimingReasons } from '../../dist/tools/proof-capture.js';
+import { validateMedia, type MediaProcess } from '../../dist/tools/proof-media.js';
+
+const execFileAsync = promisify(execFile);
+
+const mediaProcess: MediaProcess = {
+  async run(command, args) {
+    const { stdout, stderr } = await execFileAsync(command, args, {
+      encoding: 'utf8',
+      maxBuffer: 8 * 1024 * 1024,
+    });
+    return { stdout, stderr };
+  },
+};
+
+test('accepts a visually matched final screenshot within the encoded video tail tolerance', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'proof-tail-tolerance-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const videoPath = join(root, 'proof.mp4');
+  const screenshotPath = join(root, 'screen.jpg');
+  const contactSheetPath = join(root, 'contact-sheet.jpg');
+
+  await mediaProcess.run('ffmpeg', [
+    '-y',
+    '-f',
+    'lavfi',
+    '-i',
+    'color=c=white:s=320x640:d=6',
+    '-pix_fmt',
+    'yuv420p',
+    videoPath,
+  ]);
+  await mediaProcess.run('ffmpeg', [
+    '-y',
+    '-f',
+    'lavfi',
+    '-i',
+    'color=c=white:s=320x640',
+    '-frames:v',
+    '1',
+    screenshotPath,
+  ]);
+
+  const timestamps = [1_000, 3_000, 6_325];
+  const media = await validateMedia(mediaProcess, {
+    videoPath,
+    rehearsalDurationMs: 7_000,
+    screenshots: timestamps.map((timestampMs, index) => ({
+      stepId: `step-${index + 1}`,
+      path: screenshotPath,
+      timestampMs,
+    })),
+    contactSheetPath,
+    scratchRoot: root,
+  });
+
+  assert.equal(media.ok, true);
+  if (!media.ok) assert.fail(media.reasons.join(', '));
+  assert.ok(timestamps.at(-1)! > media.video.durationMs);
+  assert.deepEqual(
+    evidenceTimingReasons(
+      timestamps,
+      media.video.durationMs,
+      timestamps.map(() => ({ expectedDwellMs: 0, maximumDwellMs: 30_000 })),
+    ),
+    [],
+  );
+});

--- a/packages/rn-dev-agent-core/test/integration/proof-video-tail-tolerance.test.ts
+++ b/packages/rn-dev-agent-core/test/integration/proof-video-tail-tolerance.test.ts
@@ -9,18 +9,27 @@ import { evidenceTimingReasons } from '../../dist/tools/proof-capture.js';
 import { validateMedia, type MediaProcess } from '../../dist/tools/proof-media.js';
 
 const execFileAsync = promisify(execFile);
+const mediaFailures: string[] = [];
 
 const mediaProcess: MediaProcess = {
   async run(command, args) {
-    const { stdout, stderr } = await execFileAsync(command, args, {
-      encoding: 'utf8',
-      maxBuffer: 8 * 1024 * 1024,
-    });
-    return { stdout, stderr };
+    try {
+      const { stdout, stderr } = await execFileAsync(command, args, {
+        encoding: 'utf8',
+        maxBuffer: 8 * 1024 * 1024,
+      });
+      return { stdout, stderr };
+    } catch (error) {
+      const stderr =
+        error && typeof error === 'object' && 'stderr' in error ? String(error.stderr) : '';
+      mediaFailures.push(`${command} ${args.join(' ')}\n${stderr.slice(-2_000)}`);
+      throw error;
+    }
   },
 };
 
 test('accepts a visually matched final screenshot within the encoded video tail tolerance', async (t) => {
+  mediaFailures.length = 0;
   const root = await mkdtemp(join(tmpdir(), 'proof-tail-tolerance-'));
   t.after(() => rm(root, { recursive: true, force: true }));
   const videoPath = join(root, 'proof.mp4');
@@ -73,7 +82,7 @@ test('accepts a visually matched final screenshot within the encoded video tail 
     scratchRoot: root,
   });
 
-  if (!media.ok) assert.fail(media.reasons.join(', '));
+  if (!media.ok) assert.fail(`${media.reasons.join(', ')}\n${mediaFailures.join('\n---\n')}`);
   assert.equal(media.ok, true);
   assert.ok(timestamps.at(-1)! > media.video.durationMs);
   assert.deepEqual(

--- a/packages/rn-dev-agent-core/test/integration/proof-video-tail-tolerance.test.ts
+++ b/packages/rn-dev-agent-core/test/integration/proof-video-tail-tolerance.test.ts
@@ -48,7 +48,19 @@ test('accepts a visually matched final screenshot within the encoded video tail 
     screenshotPath,
   ]);
 
-  const timestamps = [1_000, 3_000, 6_325];
+  const probe = await mediaProcess.run('ffprobe', [
+    '-v',
+    'error',
+    '-show_entries',
+    'format=duration',
+    '-of',
+    'json',
+    videoPath,
+  ]);
+  const encodedDurationMs = Math.round(
+    Number((JSON.parse(probe.stdout) as { format: { duration: string } }).format.duration) * 1_000,
+  );
+  const timestamps = [1_000, 3_000, encodedDurationMs + 325];
   const media = await validateMedia(mediaProcess, {
     videoPath,
     rehearsalDurationMs: 7_000,
@@ -61,8 +73,8 @@ test('accepts a visually matched final screenshot within the encoded video tail 
     scratchRoot: root,
   });
 
-  assert.equal(media.ok, true);
   if (!media.ok) assert.fail(media.reasons.join(', '));
+  assert.equal(media.ok, true);
   assert.ok(timestamps.at(-1)! > media.video.durationMs);
   assert.deepEqual(
     evidenceTimingReasons(

--- a/packages/rn-dev-agent-core/test/unit/proof-capture-tool.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/proof-capture-tool.test.ts
@@ -1256,7 +1256,7 @@ test('screenshot timestamp and per-state dwell constraints are enforced', async 
     },
     {
       name: 'outside video',
-      timestamps: [1_000, 5_000, 9_000, 16_001],
+      timestamps: [1_000, 5_000, 9_000, 18_001],
       expected: 'SCREENSHOT_TIMESTAMPS_INVALID',
     },
     {
@@ -1285,6 +1285,23 @@ test('screenshot timestamp and per-state dwell constraints are enforced', async 
       assert.equal(harness.written.length, 0);
     });
   }
+});
+
+test('mechanical validation accepts a matched final screenshot inside the encoded tail', async (t) => {
+  const harness = createHarness(t);
+  const args = beginArgs();
+  args.storyboard.steps.at(-1)!.expectedDwellMs = 0;
+  const timestamps = [1_000, 5_000, 9_000, 13_000];
+  await stoppedCapture(harness, { timestampOverrides: timestamps }, args);
+  const media = successfulMedia();
+  media.video.durationMs = 12_675;
+  media.screenshots.forEach((shot, index) => void (shot.timestampMs = timestamps[index]!));
+  harness.setMedia(media);
+
+  const validation = await harness.handler({ action: 'validate' });
+
+  assert.equal(envelope(validation).ok, true, validation.content[0]!.text);
+  assert.equal(harness.written.length, 0);
 });
 
 test('bounded duration tolerance reaches an accepted receipt only with clean timing', async (t) => {

--- a/packages/rn-dev-agent-core/test/unit/proof-media.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/proof-media.test.ts
@@ -249,7 +249,7 @@ test('matchScreenshotAt skips an undecodable VFR tail when an earlier sample mat
   assert.equal(result.frameMatch.score, 0.97);
 });
 
-test('matchScreenshotAt scales video samples to the normalized screenshot dimensions', async (t) => {
+test('matchScreenshotAt compares independently normalized media without version-specific filters', async (t) => {
   const fixture = await createFixture(t);
   const scratchDir = join(fixture.root, 'dimension-match');
   await mkdir(scratchDir);
@@ -266,13 +266,7 @@ test('matchScreenshotAt scales video samples to the normalized screenshot dimens
     (call) => call.command === 'ffmpeg' && call.args.some((arg) => arg.includes('ssim')),
   );
   assert.equal(comparisons.length, 3);
-  assert.ok(
-    comparisons.every((call) =>
-      call.args.includes(
-        '[1:v][0:v]scale2ref=w=rw:h=rh:flags=lanczos[frame][reference];[reference][frame]ssim',
-      ),
-    ),
-  );
+  assert.ok(comparisons.every((call) => call.args.includes('[0:v][1:v]ssim')));
 });
 
 test('buildContactSheet creates and hashes a tiled JPEG', async (t) => {


### PR DESCRIPTION
## Summary

- allow only the final screenshot timestamp to trail encoded video metadata by at most two seconds
- retain strict timing for every earlier milestone and require the existing visual frame match
- exercise the real ffmpeg and ffprobe boundary in integration tests on both PR and release runners

## Behavior

No application UI behavior changes. This is proof-capture infrastructure; the external test app is used only to demonstrate the canonical Tasks to Calendar to Tasks regression flow.

## Validation

- `corepack yarn test`
- `corepack yarn test:integration`
- `bash scripts/check-dist-fresh.sh`
- `bash scripts/check-typescript-only.sh`
- `corepack yarn lint`
- `corepack yarn format:check`

## Proof

- [Feature-only video](https://github.com/Lykhoyda/rn-dev-agent/releases/download/proof-pr-586-d896c3e6/proof.mp4)
- [Contact sheet](https://github.com/Lykhoyda/rn-dev-agent/releases/download/proof-pr-586-d896c3e6/proof-contact-sheet.jpg)
- [Tasks start](https://github.com/Lykhoyda/rn-dev-agent/releases/download/proof-pr-586-d896c3e6/01-tasks.jpg)
- [Calendar open](https://github.com/Lykhoyda/rn-dev-agent/releases/download/proof-pr-586-d896c3e6/02-calendar.jpg)
- [Tasks returned](https://github.com/Lykhoyda/rn-dev-agent/releases/download/proof-pr-586-d896c3e6/03-returned-tasks.jpg)
- [Accepted proof receipt](https://github.com/Lykhoyda/rn-dev-agent/releases/download/proof-pr-586-d896c3e6/proof-receipt.json)

Proof head: `d896c3e60e3562e160333ef19cb19f33aca9c198`

- iPhone 17 Pro, external `rn-dev-agent-workspace/test-app`, Metro 8082
- video 6.362 s; final screenshot 6.525 s; bounded tail drift 163 ms
- frame matches: 0.988519, 0.991693, 0.988375 SSIM
- exact six-event storyboard trace; error baseline remained zero
- independent visual review: exact feature only, no debugging/recovery screens, unrelated UI, or personal data

Follow-up to #573.
