### PR TITLE
fix(core): isolate empty-Metro lifecycle tests from live default-port Hermes targets

### DIFF
--- a/.changeset/isolate-empty-metro-discovery.md
+++ b/.changeset/isolate-empty-metro-discovery.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-plugin": patch
+"rn-dev-agent-core": patch
+---
+
+Isolate the empty-Metro lifecycle integration tests from live default-port Hermes targets (#577): CDP discovery's default port list (8081/8082/19000/19006 + `RN_METRO_PORT`) is now resolved lazily per call, and a new `RN_CDP_DISCOVERY_PORTS` override replaces it entirely — so the integration suite owns its whole discovery surface and stays deterministic while a real React Native app is running on the host. Production discovery is unchanged when the variable is unset.

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -18628,6 +18628,20 @@ var init_metro_cwd = __esm({
 
 // packages/rn-dev-agent-core/dist/cdp/discovery.js
 import { execFileSync as execFileSync2 } from "node:child_process";
+function resolveDefaultPorts() {
+  const override = process.env.RN_CDP_DISCOVERY_PORTS;
+  if (override !== void 0) {
+    return override.split(",").map((entry) => entry.trim() === "" ? NaN : Number(entry.trim())).filter((port) => Number.isInteger(port) && port > 0);
+  }
+  const userPort = process.env.RN_METRO_PORT ? parseInt(process.env.RN_METRO_PORT, 10) : NaN;
+  return [
+    ...Number.isInteger(userPort) && userPort > 0 ? [userPort] : [],
+    8081,
+    8082,
+    19e3,
+    19006
+  ];
+}
 async function discoverAllMetroPorts(ports, timeout) {
   const checks = await Promise.all(ports.map(async (p) => {
     const ctrl = new AbortController();
@@ -18826,7 +18840,7 @@ function selectMetroPort(attached, runningPorts, ctx) {
 }
 async function discover(currentPort, platformFilterOrFilters) {
   const filters = typeof platformFilterOrFilters === "string" ? { platform: platformFilterOrFilters } : platformFilterOrFilters ?? {};
-  const ports = [.../* @__PURE__ */ new Set([currentPort, ...DEFAULT_PORTS])];
+  const ports = [.../* @__PURE__ */ new Set([currentPort, ...resolveDefaultPorts()])];
   const hints = [];
   if (filters.platform)
     hints.push(`platform=${filters.platform}`);
@@ -18873,7 +18887,7 @@ async function discover(currentPort, platformFilterOrFilters) {
   return { port: metroPort, targets: sorted, warning };
 }
 async function discoverForList(currentPort, portHint) {
-  const ports = [.../* @__PURE__ */ new Set([portHint ?? currentPort, ...DEFAULT_PORTS])];
+  const ports = [.../* @__PURE__ */ new Set([portHint ?? currentPort, ...resolveDefaultPorts()])];
   const running = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
   if (running.length === 0) {
     throw new Error("Metro not found on ports " + ports.join(", "));
@@ -18896,7 +18910,7 @@ async function discoverForList(currentPort, portHint) {
 }
 async function enumerateMetroCandidates(connectedPort, projectRoot) {
   const t0 = performance.now();
-  const ports = [.../* @__PURE__ */ new Set([connectedPort, ...DEFAULT_PORTS])];
+  const ports = [.../* @__PURE__ */ new Set([connectedPort, ...resolveDefaultPorts()])];
   const running = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
   const tProbe = performance.now();
   if (running.length <= 1) {
@@ -18930,7 +18944,7 @@ async function enumerateMetroCandidates(connectedPort, projectRoot) {
     timings_ms: { probe: tProbe - t0, cwd: performance.now() - tProbe }
   };
 }
-var AppDetachedError, DISCOVERY_TIMEOUT_MS, USER_METRO_PORT, DEFAULT_PORTS;
+var AppDetachedError, DISCOVERY_TIMEOUT_MS;
 var init_discovery = __esm({
   "packages/rn-dev-agent-core/dist/cdp/discovery.js"() {
     "use strict";
@@ -18952,14 +18966,6 @@ var init_discovery = __esm({
       }
     };
     DISCOVERY_TIMEOUT_MS = 1500;
-    USER_METRO_PORT = process.env.RN_METRO_PORT ? parseInt(process.env.RN_METRO_PORT, 10) : null;
-    DEFAULT_PORTS = [
-      ...USER_METRO_PORT && !isNaN(USER_METRO_PORT) ? [USER_METRO_PORT] : [],
-      8081,
-      8082,
-      19e3,
-      19006
-    ];
   }
 });
 

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -38609,6 +38609,20 @@ var init_metro_cwd = __esm({
 
 // packages/rn-dev-agent-core/dist/cdp/discovery.js
 import { execFileSync as execFileSync3 } from "node:child_process";
+function resolveDefaultPorts() {
+  const override = process.env.RN_CDP_DISCOVERY_PORTS;
+  if (override !== void 0) {
+    return override.split(",").map((entry) => entry.trim() === "" ? NaN : Number(entry.trim())).filter((port) => Number.isInteger(port) && port > 0);
+  }
+  const userPort = process.env.RN_METRO_PORT ? parseInt(process.env.RN_METRO_PORT, 10) : NaN;
+  return [
+    ...Number.isInteger(userPort) && userPort > 0 ? [userPort] : [],
+    8081,
+    8082,
+    19e3,
+    19006
+  ];
+}
 async function discoverAllMetroPorts(ports, timeout) {
   const checks = await Promise.all(ports.map(async (p) => {
     const ctrl = new AbortController();
@@ -38807,7 +38821,7 @@ function selectMetroPort(attached, runningPorts, ctx) {
 }
 async function discover(currentPort, platformFilterOrFilters) {
   const filters = typeof platformFilterOrFilters === "string" ? { platform: platformFilterOrFilters } : platformFilterOrFilters ?? {};
-  const ports = [.../* @__PURE__ */ new Set([currentPort, ...DEFAULT_PORTS])];
+  const ports = [.../* @__PURE__ */ new Set([currentPort, ...resolveDefaultPorts()])];
   const hints = [];
   if (filters.platform)
     hints.push(`platform=${filters.platform}`);
@@ -38854,7 +38868,7 @@ async function discover(currentPort, platformFilterOrFilters) {
   return { port: metroPort, targets: sorted, warning };
 }
 async function discoverForList(currentPort, portHint) {
-  const ports = [.../* @__PURE__ */ new Set([portHint ?? currentPort, ...DEFAULT_PORTS])];
+  const ports = [.../* @__PURE__ */ new Set([portHint ?? currentPort, ...resolveDefaultPorts()])];
   const running = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
   if (running.length === 0) {
     throw new Error("Metro not found on ports " + ports.join(", "));
@@ -38877,7 +38891,7 @@ async function discoverForList(currentPort, portHint) {
 }
 async function enumerateMetroCandidates(connectedPort, projectRoot) {
   const t0 = performance.now();
-  const ports = [.../* @__PURE__ */ new Set([connectedPort, ...DEFAULT_PORTS])];
+  const ports = [.../* @__PURE__ */ new Set([connectedPort, ...resolveDefaultPorts()])];
   const running = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
   const tProbe = performance.now();
   if (running.length <= 1) {
@@ -38911,7 +38925,7 @@ async function enumerateMetroCandidates(connectedPort, projectRoot) {
     timings_ms: { probe: tProbe - t0, cwd: performance.now() - tProbe }
   };
 }
-var AppDetachedError, DISCOVERY_TIMEOUT_MS, USER_METRO_PORT, DEFAULT_PORTS;
+var AppDetachedError, DISCOVERY_TIMEOUT_MS;
 var init_discovery = __esm({
   "packages/rn-dev-agent-core/dist/cdp/discovery.js"() {
     "use strict";
@@ -38933,14 +38947,6 @@ var init_discovery = __esm({
       }
     };
     DISCOVERY_TIMEOUT_MS = 1500;
-    USER_METRO_PORT = process.env.RN_METRO_PORT ? parseInt(process.env.RN_METRO_PORT, 10) : null;
-    DEFAULT_PORTS = [
-      ...USER_METRO_PORT && !isNaN(USER_METRO_PORT) ? [USER_METRO_PORT] : [],
-      8081,
-      8082,
-      19e3,
-      19006
-    ];
   }
 });
 

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -18628,6 +18628,20 @@ var init_metro_cwd = __esm({
 
 // packages/rn-dev-agent-core/dist/cdp/discovery.js
 import { execFileSync as execFileSync2 } from "node:child_process";
+function resolveDefaultPorts() {
+  const override = process.env.RN_CDP_DISCOVERY_PORTS;
+  if (override !== void 0) {
+    return override.split(",").map((entry) => entry.trim() === "" ? NaN : Number(entry.trim())).filter((port) => Number.isInteger(port) && port > 0);
+  }
+  const userPort = process.env.RN_METRO_PORT ? parseInt(process.env.RN_METRO_PORT, 10) : NaN;
+  return [
+    ...Number.isInteger(userPort) && userPort > 0 ? [userPort] : [],
+    8081,
+    8082,
+    19e3,
+    19006
+  ];
+}
 async function discoverAllMetroPorts(ports, timeout) {
   const checks = await Promise.all(ports.map(async (p) => {
     const ctrl = new AbortController();
@@ -18826,7 +18840,7 @@ function selectMetroPort(attached, runningPorts, ctx) {
 }
 async function discover(currentPort, platformFilterOrFilters) {
   const filters = typeof platformFilterOrFilters === "string" ? { platform: platformFilterOrFilters } : platformFilterOrFilters ?? {};
-  const ports = [.../* @__PURE__ */ new Set([currentPort, ...DEFAULT_PORTS])];
+  const ports = [.../* @__PURE__ */ new Set([currentPort, ...resolveDefaultPorts()])];
   const hints = [];
   if (filters.platform)
     hints.push(`platform=${filters.platform}`);
@@ -18873,7 +18887,7 @@ async function discover(currentPort, platformFilterOrFilters) {
   return { port: metroPort, targets: sorted, warning };
 }
 async function discoverForList(currentPort, portHint) {
-  const ports = [.../* @__PURE__ */ new Set([portHint ?? currentPort, ...DEFAULT_PORTS])];
+  const ports = [.../* @__PURE__ */ new Set([portHint ?? currentPort, ...resolveDefaultPorts()])];
   const running = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
   if (running.length === 0) {
     throw new Error("Metro not found on ports " + ports.join(", "));
@@ -18896,7 +18910,7 @@ async function discoverForList(currentPort, portHint) {
 }
 async function enumerateMetroCandidates(connectedPort, projectRoot) {
   const t0 = performance.now();
-  const ports = [.../* @__PURE__ */ new Set([connectedPort, ...DEFAULT_PORTS])];
+  const ports = [.../* @__PURE__ */ new Set([connectedPort, ...resolveDefaultPorts()])];
   const running = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
   const tProbe = performance.now();
   if (running.length <= 1) {
@@ -18930,7 +18944,7 @@ async function enumerateMetroCandidates(connectedPort, projectRoot) {
     timings_ms: { probe: tProbe - t0, cwd: performance.now() - tProbe }
   };
 }
-var AppDetachedError, DISCOVERY_TIMEOUT_MS, USER_METRO_PORT, DEFAULT_PORTS;
+var AppDetachedError, DISCOVERY_TIMEOUT_MS;
 var init_discovery = __esm({
   "packages/rn-dev-agent-core/dist/cdp/discovery.js"() {
     "use strict";
@@ -18952,14 +18966,6 @@ var init_discovery = __esm({
       }
     };
     DISCOVERY_TIMEOUT_MS = 1500;
-    USER_METRO_PORT = process.env.RN_METRO_PORT ? parseInt(process.env.RN_METRO_PORT, 10) : null;
-    DEFAULT_PORTS = [
-      ...USER_METRO_PORT && !isNaN(USER_METRO_PORT) ? [USER_METRO_PORT] : [],
-      8081,
-      8082,
-      19e3,
-      19006
-    ];
   }
 });
 

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -38609,6 +38609,20 @@ var init_metro_cwd = __esm({
 
 // packages/rn-dev-agent-core/dist/cdp/discovery.js
 import { execFileSync as execFileSync3 } from "node:child_process";
+function resolveDefaultPorts() {
+  const override = process.env.RN_CDP_DISCOVERY_PORTS;
+  if (override !== void 0) {
+    return override.split(",").map((entry) => entry.trim() === "" ? NaN : Number(entry.trim())).filter((port) => Number.isInteger(port) && port > 0);
+  }
+  const userPort = process.env.RN_METRO_PORT ? parseInt(process.env.RN_METRO_PORT, 10) : NaN;
+  return [
+    ...Number.isInteger(userPort) && userPort > 0 ? [userPort] : [],
+    8081,
+    8082,
+    19e3,
+    19006
+  ];
+}
 async function discoverAllMetroPorts(ports, timeout) {
   const checks = await Promise.all(ports.map(async (p) => {
     const ctrl = new AbortController();
@@ -38807,7 +38821,7 @@ function selectMetroPort(attached, runningPorts, ctx) {
 }
 async function discover(currentPort, platformFilterOrFilters) {
   const filters = typeof platformFilterOrFilters === "string" ? { platform: platformFilterOrFilters } : platformFilterOrFilters ?? {};
-  const ports = [.../* @__PURE__ */ new Set([currentPort, ...DEFAULT_PORTS])];
+  const ports = [.../* @__PURE__ */ new Set([currentPort, ...resolveDefaultPorts()])];
   const hints = [];
   if (filters.platform)
     hints.push(`platform=${filters.platform}`);
@@ -38854,7 +38868,7 @@ async function discover(currentPort, platformFilterOrFilters) {
   return { port: metroPort, targets: sorted, warning };
 }
 async function discoverForList(currentPort, portHint) {
-  const ports = [.../* @__PURE__ */ new Set([portHint ?? currentPort, ...DEFAULT_PORTS])];
+  const ports = [.../* @__PURE__ */ new Set([portHint ?? currentPort, ...resolveDefaultPorts()])];
   const running = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
   if (running.length === 0) {
     throw new Error("Metro not found on ports " + ports.join(", "));
@@ -38877,7 +38891,7 @@ async function discoverForList(currentPort, portHint) {
 }
 async function enumerateMetroCandidates(connectedPort, projectRoot) {
   const t0 = performance.now();
-  const ports = [.../* @__PURE__ */ new Set([connectedPort, ...DEFAULT_PORTS])];
+  const ports = [.../* @__PURE__ */ new Set([connectedPort, ...resolveDefaultPorts()])];
   const running = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
   const tProbe = performance.now();
   if (running.length <= 1) {
@@ -38911,7 +38925,7 @@ async function enumerateMetroCandidates(connectedPort, projectRoot) {
     timings_ms: { probe: tProbe - t0, cwd: performance.now() - tProbe }
   };
 }
-var AppDetachedError, DISCOVERY_TIMEOUT_MS, USER_METRO_PORT, DEFAULT_PORTS;
+var AppDetachedError, DISCOVERY_TIMEOUT_MS;
 var init_discovery = __esm({
   "packages/rn-dev-agent-core/dist/cdp/discovery.js"() {
     "use strict";
@@ -38933,14 +38947,6 @@ var init_discovery = __esm({
       }
     };
     DISCOVERY_TIMEOUT_MS = 1500;
-    USER_METRO_PORT = process.env.RN_METRO_PORT ? parseInt(process.env.RN_METRO_PORT, 10) : null;
-    DEFAULT_PORTS = [
-      ...USER_METRO_PORT && !isNaN(USER_METRO_PORT) ? [USER_METRO_PORT] : [],
-      8081,
-      8082,
-      19e3,
-      19006
-    ];
   }
 });
 

--- a/packages/rn-dev-agent-core/dist/cdp/discovery.js
+++ b/packages/rn-dev-agent-core/dist/cdp/discovery.js
@@ -29,16 +29,33 @@ export class AppDetachedError extends Error {
     }
 }
 export const DISCOVERY_TIMEOUT_MS = 1500;
-export const USER_METRO_PORT = process.env.RN_METRO_PORT
-    ? parseInt(process.env.RN_METRO_PORT, 10)
-    : null;
-export const DEFAULT_PORTS = [
-    ...(USER_METRO_PORT && !isNaN(USER_METRO_PORT) ? [USER_METRO_PORT] : []),
-    8081,
-    8082,
-    19000,
-    19006,
-];
+/**
+ * GH #577: default discovery ports, resolved lazily at call time. When
+ * RN_CDP_DISCOVERY_PORTS is set it REPLACES the built-in defaults (including
+ * the RN_METRO_PORT entry) — an empty value yields no defaults, so discovery
+ * probes only the caller-supplied current/hint port. This lets integration
+ * tests own their entire discovery surface; production behavior is unchanged
+ * when the variable is unset.
+ */
+export function resolveDefaultPorts() {
+    const override = process.env.RN_CDP_DISCOVERY_PORTS;
+    if (override !== undefined) {
+        return (override
+            .split(',')
+            // Whole-value parse — parseInt would accept "9123abc"/"8081.5" as
+            // 9123/8081 and silently probe an unintended Metro after a typo.
+            .map((entry) => (entry.trim() === '' ? NaN : Number(entry.trim())))
+            .filter((port) => Number.isInteger(port) && port > 0));
+    }
+    const userPort = process.env.RN_METRO_PORT ? parseInt(process.env.RN_METRO_PORT, 10) : NaN;
+    return [
+        ...(Number.isInteger(userPort) && userPort > 0 ? [userPort] : []),
+        8081,
+        8082,
+        19000,
+        19006,
+    ];
+}
 /**
  * GH #303: probe ALL candidate ports in parallel and return every one that is a
  * running Metro. The caller then prefers a port with an attached Hermes target
@@ -341,7 +358,7 @@ export async function discover(currentPort, platformFilterOrFilters) {
     const filters = typeof platformFilterOrFilters === 'string'
         ? { platform: platformFilterOrFilters }
         : (platformFilterOrFilters ?? {});
-    const ports = [...new Set([currentPort, ...DEFAULT_PORTS])];
+    const ports = [...new Set([currentPort, ...resolveDefaultPorts()])];
     const hints = [];
     if (filters.platform)
         hints.push(`platform=${filters.platform}`);
@@ -396,7 +413,7 @@ export async function discover(currentPort, platformFilterOrFilters) {
     return { port: metroPort, targets: sorted, warning };
 }
 export async function discoverForList(currentPort, portHint) {
-    const ports = [...new Set([portHint ?? currentPort, ...DEFAULT_PORTS])];
+    const ports = [...new Set([portHint ?? currentPort, ...resolveDefaultPorts()])];
     // GH #303: prefer a running port that actually has targets over the first
     // running one, so cdp_targets can't inspect a different Metro than discover()
     // selected. No cwd auto-pick needed here — just attached-preference.
@@ -431,7 +448,7 @@ export async function discoverForList(currentPort, portHint) {
  */
 export async function enumerateMetroCandidates(connectedPort, projectRoot) {
     const t0 = performance.now();
-    const ports = [...new Set([connectedPort, ...DEFAULT_PORTS])];
+    const ports = [...new Set([connectedPort, ...resolveDefaultPorts()])];
     const running = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
     const tProbe = performance.now();
     if (running.length <= 1) {

--- a/packages/rn-dev-agent-core/src/cdp/discovery.ts
+++ b/packages/rn-dev-agent-core/src/cdp/discovery.ts
@@ -34,16 +34,36 @@ export class AppDetachedError extends Error {
 }
 
 export const DISCOVERY_TIMEOUT_MS = 1500;
-export const USER_METRO_PORT = process.env.RN_METRO_PORT
-  ? parseInt(process.env.RN_METRO_PORT, 10)
-  : null;
-export const DEFAULT_PORTS = [
-  ...(USER_METRO_PORT && !isNaN(USER_METRO_PORT) ? [USER_METRO_PORT] : []),
-  8081,
-  8082,
-  19000,
-  19006,
-];
+
+/**
+ * GH #577: default discovery ports, resolved lazily at call time. When
+ * RN_CDP_DISCOVERY_PORTS is set it REPLACES the built-in defaults (including
+ * the RN_METRO_PORT entry) — an empty value yields no defaults, so discovery
+ * probes only the caller-supplied current/hint port. This lets integration
+ * tests own their entire discovery surface; production behavior is unchanged
+ * when the variable is unset.
+ */
+export function resolveDefaultPorts(): number[] {
+  const override = process.env.RN_CDP_DISCOVERY_PORTS;
+  if (override !== undefined) {
+    return (
+      override
+        .split(',')
+        // Whole-value parse — parseInt would accept "9123abc"/"8081.5" as
+        // 9123/8081 and silently probe an unintended Metro after a typo.
+        .map((entry) => (entry.trim() === '' ? NaN : Number(entry.trim())))
+        .filter((port) => Number.isInteger(port) && port > 0)
+    );
+  }
+  const userPort = process.env.RN_METRO_PORT ? parseInt(process.env.RN_METRO_PORT, 10) : NaN;
+  return [
+    ...(Number.isInteger(userPort) && userPort > 0 ? [userPort] : []),
+    8081,
+    8082,
+    19000,
+    19006,
+  ];
+}
 
 /**
  * GH #303: probe ALL candidate ports in parallel and return every one that is a
@@ -433,7 +453,7 @@ export async function discover(
     typeof platformFilterOrFilters === 'string'
       ? { platform: platformFilterOrFilters }
       : (platformFilterOrFilters ?? {});
-  const ports = [...new Set([currentPort, ...DEFAULT_PORTS])];
+  const ports = [...new Set([currentPort, ...resolveDefaultPorts()])];
   const hints: string[] = [];
   if (filters.platform) hints.push(`platform=${filters.platform}`);
   if (filters.targetId) hints.push(`targetId=${filters.targetId}`);
@@ -504,7 +524,7 @@ export async function discoverForList(
   currentPort: number,
   portHint?: number,
 ): Promise<{ port: number; targets: HermesTarget[] }> {
-  const ports = [...new Set([portHint ?? currentPort, ...DEFAULT_PORTS])];
+  const ports = [...new Set([portHint ?? currentPort, ...resolveDefaultPorts()])];
   // GH #303: prefer a running port that actually has targets over the first
   // running one, so cdp_targets can't inspect a different Metro than discover()
   // selected. No cwd auto-pick needed here — just attached-preference.
@@ -547,7 +567,7 @@ export async function enumerateMetroCandidates(
   timings_ms: { probe: number; cwd: number };
 }> {
   const t0 = performance.now();
-  const ports = [...new Set([connectedPort, ...DEFAULT_PORTS])];
+  const ports = [...new Set([connectedPort, ...resolveDefaultPorts()])];
   const running = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
   const tProbe = performance.now();
 

--- a/packages/rn-dev-agent-core/test/integration/cdp-client-lifecycle.test.js
+++ b/packages/rn-dev-agent-core/test/integration/cdp-client-lifecycle.test.js
@@ -97,7 +97,11 @@ describe('CDPClient lifecycle', () => {
     }
   });
 
-  test('autoConnect reports empty Metro unless another default Metro has an attached target', async () => {
+  // GH #577: the empty-Metro cases must own their entire discovery surface.
+  // RN_CDP_DISCOVERY_PORTS replaces the built-in default ports (8081/8082/…),
+  // so a developer's live Metro on a default port can never leak into these
+  // tests — neither as a false connect nor as pending reconnect work.
+  async function startEmptyMetro() {
     const { createServer } = await import('node:http');
     const srv = createServer((req, res) => {
       if (req.url === '/status') {
@@ -119,33 +123,70 @@ describe('CDPClient lifecycle', () => {
       srv.once('error', reject);
     });
 
-    const { port: emptyPort } = srv.address();
-    const client = new CDPClient(emptyPort);
+    return srv;
+  }
+
+  async function withEnv(overrides, fn) {
+    const saved = {};
+    for (const [key, value] of Object.entries(overrides)) {
+      saved[key] = process.env[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
     try {
+      return await fn();
+    } finally {
+      for (const [key, value] of Object.entries(saved)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  }
+
+  test('empty Metro rejects deterministically when discovery is isolated (GH #577)', async () => {
+    const srv = await startEmptyMetro();
+    const { port: emptyPort } = srv.address();
+    // Hostile condition: simulate a developer's live Metro with an attached
+    // target on a "default" port (the shared fake CDP server). The isolation
+    // override must make it invisible to discovery.
+    await withEnv({ RN_CDP_DISCOVERY_PORTS: '', RN_METRO_PORT: String(server.port) }, async () => {
+      const client = new CDPClient(emptyPort);
+      try {
+        await assert.rejects(
+          client.autoConnect(emptyPort),
+          // GH #208 (RC2): the hinted Metro is up with 0 targets, so the only
+          // correct outcome is the typed AppDetachedError. "Metro not found"
+          // would mean discovery failed to probe the hinted server at all —
+          // exactly the regression class this test exists to catch.
+          (err) => err instanceof Error && err.name === 'AppDetachedError',
+          'isolated discovery must reject with AppDetachedError — it may never select a host-environment Metro',
+        );
+        assert.equal(client.isConnected, false, 'failed connect must leave the client down');
+      } finally {
+        await client.disconnect();
+      }
+    }).finally(() => new Promise((resolve) => srv.close(resolve)));
+  });
+
+  test('attached Metro on a default port is preferred over an empty hinted Metro (GH #303 via #577 seam)', async () => {
+    const srv = await startEmptyMetro();
+    const { port: emptyPort } = srv.address();
+    // Deterministic re-creation of the GH #303 scenario the old tolerant test
+    // could only observe by accident: the "default" list contains a live,
+    // attached Metro (the fake CDP server), which must win over the empty hint.
+    await withEnv({ RN_CDP_DISCOVERY_PORTS: String(server.port) }, async () => {
+      const client = new CDPClient(emptyPort);
       try {
         const message = await client.autoConnect(emptyPort);
-        // GH #303: discovery intentionally scans default Metro ports too. A
-        // developer running a real app on :8081 should not make this integration
-        // test fail just because the empty test Metro was not selected.
-        assert.notEqual(
+        assert.equal(
           client.metroPort,
-          emptyPort,
-          'success is only valid when discovery selected a different attached Metro',
+          server.port,
+          'discovery must select the attached default-port Metro',
         );
         assert.match(message, /Connected to/);
-      } catch (err) {
-        assert.ok(err instanceof Error);
-        // GH #208 (RC2): a Metro-up-but-0-targets autoConnect now rejects with the
-        // typed AppDetachedError ("…advertises 0 Hermes debug targets…"); the
-        // genuine no-Metro case still surfaces "Metro not found".
-        assert.ok(
-          err.name === 'AppDetachedError' || err.message.includes('Metro not found'),
-          `Unexpected error: ${err.message}`,
-        );
+      } finally {
+        await client.disconnect();
       }
-    } finally {
-      await client.disconnect();
-      await new Promise((resolve) => srv.close(resolve));
-    }
+    }).finally(() => new Promise((resolve) => srv.close(resolve)));
   });
 });

--- a/packages/rn-dev-agent-core/test/unit/discovery-ports.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/discovery-ports.test.ts
@@ -1,0 +1,61 @@
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveDefaultPorts } from '../../dist/cdp/discovery.js';
+
+const savedDiscoveryPorts = process.env.RN_CDP_DISCOVERY_PORTS;
+const savedMetroPort = process.env.RN_METRO_PORT;
+
+beforeEach(() => {
+  delete process.env.RN_CDP_DISCOVERY_PORTS;
+  delete process.env.RN_METRO_PORT;
+});
+
+afterEach(() => {
+  if (savedDiscoveryPorts === undefined) delete process.env.RN_CDP_DISCOVERY_PORTS;
+  else process.env.RN_CDP_DISCOVERY_PORTS = savedDiscoveryPorts;
+  if (savedMetroPort === undefined) delete process.env.RN_METRO_PORT;
+  else process.env.RN_METRO_PORT = savedMetroPort;
+});
+
+// ── GH #577: lazily-resolved discovery port defaults ───────────────────
+
+test('resolveDefaultPorts returns built-in defaults when no env is set', () => {
+  assert.deepEqual(resolveDefaultPorts(), [8081, 8082, 19000, 19006]);
+});
+
+test('resolveDefaultPorts prepends RN_METRO_PORT, read lazily at call time', () => {
+  process.env.RN_METRO_PORT = '9765';
+  assert.deepEqual(resolveDefaultPorts(), [9765, 8081, 8082, 19000, 19006]);
+});
+
+test('resolveDefaultPorts ignores a non-numeric RN_METRO_PORT', () => {
+  process.env.RN_METRO_PORT = 'not-a-port';
+  assert.deepEqual(resolveDefaultPorts(), [8081, 8082, 19000, 19006]);
+});
+
+test('RN_CDP_DISCOVERY_PORTS replaces the built-in default list entirely', () => {
+  process.env.RN_CDP_DISCOVERY_PORTS = '9123, 9124';
+  assert.deepEqual(resolveDefaultPorts(), [9123, 9124]);
+});
+
+test('empty RN_CDP_DISCOVERY_PORTS yields no defaults (test isolation mode)', () => {
+  process.env.RN_CDP_DISCOVERY_PORTS = '';
+  assert.deepEqual(resolveDefaultPorts(), []);
+});
+
+test('RN_CDP_DISCOVERY_PORTS override beats RN_METRO_PORT', () => {
+  process.env.RN_METRO_PORT = '9765';
+  process.env.RN_CDP_DISCOVERY_PORTS = '9123';
+  assert.deepEqual(resolveDefaultPorts(), [9123]);
+});
+
+test('RN_CDP_DISCOVERY_PORTS drops invalid entries', () => {
+  process.env.RN_CDP_DISCOVERY_PORTS = '9123,abc,-1,0';
+  assert.deepEqual(resolveDefaultPorts(), [9123]);
+});
+
+test('RN_CDP_DISCOVERY_PORTS rejects malformed entries with numeric prefixes (whole-value parse)', () => {
+  // parseInt would accept these as 9123/8081 and probe an unintended Metro.
+  process.env.RN_CDP_DISCOVERY_PORTS = '9123abc,8081.5, 9124 ';
+  assert.deepEqual(resolveDefaultPorts(), [9124]);
+});


### PR DESCRIPTION
Closes #577

## Problem

The cdp-client lifecycle integration test for an empty Metro scanned the built-in default ports (8081/8082/19000/19006 + `RN_METRO_PORT`), which are unioned into every discovery call as a module-load constant. When a real Metro on a default port advertised a live or transient Hermes target, the test connected to that unrelated developer app instead of exercising the empty-Metro path — the old test even had a tolerance branch accepting that outcome, and the transient connection could leave reconnect work pending across the suite.

## Fix

- **`resolveDefaultPorts()`** (`src/cdp/discovery.ts`): the default discovery port list is now resolved lazily at call time. A new **`RN_CDP_DISCOVERY_PORTS`** env override *replaces* the built-in defaults entirely — an empty value yields no defaults, so discovery probes only the caller-supplied port. Production behavior is unchanged when the variable is unset (verified: identical list, `RN_METRO_PORT` still honored, now read lazily).
- **Strict empty-Metro test**: runs with `RN_CDP_DISCOVERY_PORTS=''` plus a *hostile injected* default-port Metro (`RN_METRO_PORT` pointed at the fake attached CDP server) and requires the typed `AppDetachedError` — "Metro not found" is no longer accepted, so a failure to probe the hinted server can't pass silently.
- **GH #303 preference test**: the attached-default-Metro-wins behavior the old tolerance branch could only observe by accident is now covered deterministically by placing the fake attached server in the override list.
- Unit tests for the resolver's env semantics (override replaces list, empty = isolation mode, invalid entries dropped, lazy `RN_METRO_PORT`).

## Acceptance criteria (from #577)

- ✅ the test binds only test-owned ports or stubs default-port discovery
- ✅ a live Metro/Hermes target on 8081 or 8082 cannot affect the result
- ✅ failed connections leave no reconnect work pending (failed `autoConnect` never schedules reconnect work; the reconnect loop is disposal-checked at ≤500ms slices)
- ✅ the lifecycle integration suite is repeatable while another React Native app is running

## Verification

- 3426/3426 unit tests, 23/23 integration tests, lint + format clean, agent-package sync gate green
- Lifecycle integration suite run 3× consecutively **with a real Metro live on 127.0.0.1:8081** on the host — 7/7 each run
- TDD: both new tests watched failing against the pre-fix build (the preference test fails deterministically without the seam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)