### PR TITLE
bug: install idb hint shows despite idb installed - fb-idb 1.1.7 incompatible with Python 3.14, ensure-idb loops

### DIFF
--- a/.changeset/fix-idb-python-314.md
+++ b/.changeset/fix-idb-python-314.md
@@ -1,0 +1,5 @@
+---
+'rn-dev-agent-plugin': patch
+---
+
+Report installed fb-idb clients that crash under Python 3.14 as interpreter-incompatible, recommend a forced reinstall with Homebrew Python 3.13, and suppress automatic retries until the client environment changes.

--- a/packages/claude-plugin/scripts/ensure-idb.sh
+++ b/packages/claude-plugin/scripts/ensure-idb.sh
@@ -5,7 +5,9 @@
 # idb it degrades to a ~6fps `simctl screenshot` loop. idb needs two pieces
 # (idb-companion lives in the facebook/fb tap, not homebrew-core):
 #   brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion   (the macOS daemon)
-#   pipx install fb-idb                                   (the Python CLI client)
+#   brew install python@3.13 && pipx install --python
+#     "$(brew --prefix python@3.13)/bin/python3.13" --force fb-idb
+#                                                        (the Python CLI client)
 #
 # SessionStart contract (GH#252/B196: session start must be BOUNDED): this
 # script's foreground path only does `command -v` checks and (at most) spawns
@@ -17,6 +19,8 @@
 #   - pidfile:      a live worker is never duplicated across session starts
 #   - last-attempt: a failed install is not retried for 24h (brew failures
 #     are usually environmental; hammering it every session start is noise)
+#   - incompatible-environment: Python 3.14 client crashes never start the
+#     worker; the fingerprint is refreshed only when that environment changes
 #
 # Test seams (scripts/test/ensure-idb.test.sh):
 #   RN_AGENT_IDB_STATE_DIR   state dir      (default: ~/.rn-dev-agent/idb)
@@ -31,8 +35,10 @@ set -uo pipefail
 STATE_DIR="${RN_AGENT_IDB_STATE_DIR:-$HOME/.rn-dev-agent/idb}"
 PIDFILE="$STATE_DIR/install.pid"
 MARKER="$STATE_DIR/last-attempt"
+INCOMPATIBLE_MARKER="$STATE_DIR/incompatible-environment"
 LOG="$STATE_DIR/install.log"
 BACKOFF_SECS=86400
+RECOVERY_COMMAND='brew install python@3.13 && pipx install --python "$(brew --prefix python@3.13)/bin/python3.13" --force fb-idb'
 
 OS="${RN_AGENT_IDB_UNAME:-$(uname -s)}"
 [ "$OS" = "Darwin" ] || exit 0
@@ -50,8 +56,28 @@ has_companion() {
 # mirror's tier selection (B263). `idb --help` initializes the CLI without
 # contacting a companion, so it exits 0 for a healthy client and non-zero
 # for a broken one.
+probe_idb_client() {
+  IDB_PATH="$(command -v idb 2>/dev/null || true)"
+  IDB_PROBE_OUTPUT=""
+  IDB_PROBE_STATUS=127
+  [ -n "$IDB_PATH" ] || return 1
+  IDB_PROBE_OUTPUT="$(idb --help 2>&1)"
+  IDB_PROBE_STATUS=$?
+  [ "$IDB_PROBE_STATUS" -eq 0 ]
+}
+
 idb_client_healthy() {
-  command -v idb >/dev/null 2>&1 && idb --help >/dev/null 2>&1
+  probe_idb_client
+}
+
+idb_python_314_incompatible() {
+  [ "${IDB_PROBE_STATUS:-0}" -ne 0 ] &&
+    printf '%s\n' "${IDB_PROBE_OUTPUT:-}" | grep -Eqi 'python([ /]|/)?3\.14|python3\.14' &&
+    printf '%s\n' "${IDB_PROBE_OUTPUT:-}" | grep -Eqi 'There is no current event loop|asyncio\.get_event_loop'
+}
+
+incompatible_fingerprint() {
+  printf '%s\n%s\n' "${IDB_PATH:-}" "${IDB_PROBE_OUTPUT:-}" | cksum | awk '{print $1 ":" $2}'
 }
 
 # --install-worker: the detached background job (never reached at SessionStart).
@@ -70,7 +96,18 @@ if [ "${1:-}" = "--install-worker" ]; then
       if command -v idb >/dev/null 2>&1; then
         pipx uninstall fb-idb >/dev/null 2>&1 || true
       fi
-      pipx install fb-idb || status=failed
+      python_313_prefix="$(brew --prefix python@3.13 2>/dev/null || true)"
+      python_313="$python_313_prefix/bin/python3.13"
+      if [ ! -x "$python_313" ]; then
+        brew install python@3.13 || status=failed
+        python_313_prefix="$(brew --prefix python@3.13 2>/dev/null || true)"
+        python_313="$python_313_prefix/bin/python3.13"
+      fi
+      if [ -x "$python_313" ]; then
+        pipx install --python "$python_313" --force fb-idb || status=failed
+      else
+        status=failed
+      fi
       if ! idb_client_healthy; then
         # Never leave a crash-on-invocation client on PATH: it provides
         # nothing and re-arms the B263 mirror failure. Uninstall and let the
@@ -92,18 +129,43 @@ fi
 # Foreground path — bounded: checks + at most one detached spawn. The client
 # check is a health probe (one `idb --help` invocation, no daemon contact),
 # not a PATH check — see idb_client_healthy (B269).
-if idb_client_healthy && has_companion; then
-  echo "idb available: screen mirroring uses the fast path (idb video-stream)"
+IDB_CLIENT_HEALTHY=0
+if probe_idb_client; then
+  IDB_CLIENT_HEALTHY=1
+  if has_companion; then
+    rm -f "$INCOMPATIBLE_MARKER" "$MARKER"
+    echo "idb available: screen mirroring uses the fast path (idb video-stream)"
+    exit 0
+  fi
+fi
+
+if [ "$IDB_CLIENT_HEALTHY" -eq 0 ] && [ -n "${IDB_PATH:-}" ] && idb_python_314_incompatible; then
+  mkdir -p "$STATE_DIR"
+  FINGERPRINT="$(incompatible_fingerprint)"
+  PREVIOUS_FINGERPRINT="$(cat "$INCOMPATIBLE_MARKER" 2>/dev/null || true)"
+  if [ "$FINGERPRINT" != "$PREVIOUS_FINGERPRINT" ]; then
+    printf '%s\n' "$FINGERPRINT" > "$INCOMPATIBLE_MARKER"
+  fi
+  echo "fb-idb is installed but incompatible with Python 3.14; screen mirroring stays on the simctl fallback."
+  echo "Reinstall with a compatible interpreter: $RECOVERY_COMMAND"
   exit 0
 fi
 
-if command -v idb >/dev/null 2>&1 && ! idb_client_healthy; then
+if [ -f "$INCOMPATIBLE_MARKER" ]; then
+  # The persisted incompatibility verdict is valid only for the fingerprint
+  # that produced it. Once the probe changes to a repairable verdict, an old
+  # worker backoff must not prevent the newly changed environment from being
+  # evaluated immediately.
+  rm -f "$INCOMPATIBLE_MARKER" "$MARKER"
+fi
+
+if [ "$IDB_CLIENT_HEALTHY" -eq 0 ] && [ -n "${IDB_PATH:-}" ]; then
   echo "idb client on PATH is broken (crashes on invocation) — the background worker will replace or remove it (B269)"
 fi
 
 if ! command -v brew >/dev/null 2>&1; then
   echo "idb not installed (optional — enables 20-30fps screen mirroring instead of ~6fps)."
-  echo "Install manually: brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb"
+  echo "Install manually: brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && $RECOVERY_COMMAND"
   exit 0
 fi
 
@@ -125,14 +187,14 @@ if [ -f "$MARKER" ]; then
   read -r LAST_STATUS LAST_TS < "$MARKER" 2>/dev/null || LAST_STATUS=""
   NOW="$(date +%s)"
   if [ "$LAST_STATUS" = "failed" ] && [ -n "${LAST_TS:-}" ] && [ $((NOW - LAST_TS)) -lt "$BACKOFF_SECS" ]; then
-    echo "idb install failed recently — retrying after backoff (manual: brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb, log: $LOG)"
+    echo "idb install failed recently — retrying after backoff (manual: brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && $RECOVERY_COMMAND, log: $LOG)"
     exit 0
   fi
 fi
 
 if [ "${RN_AGENT_IDB_DRY_SPAWN:-}" = "1" ]; then
   echo "spawn --install-worker" >> "$STATE_DIR/spawn.log"
-  echo "idb missing — installing in background (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb). Log: $LOG"
+  echo "idb missing — installing in background (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && $RECOVERY_COMMAND). Log: $LOG"
   exit 0
 fi
 
@@ -140,5 +202,5 @@ nohup bash "$0" --install-worker >> "$LOG" 2>&1 < /dev/null &
 WORKER_PID=$!
 disown "$WORKER_PID" 2>/dev/null || true
 echo "$WORKER_PID" > "$PIDFILE"
-echo "idb missing — installing in background (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb). Log: $LOG"
+echo "idb missing — installing in background (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && $RECOVERY_COMMAND). Log: $LOG"
 exit 0

--- a/packages/rn-dev-agent-core/test/integration/ensure-idb-session-start.test.ts
+++ b/packages/rn-dev-agent-core/test/integration/ensure-idb-session-start.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+const contractScript = resolve(repositoryRoot, 'scripts/test/ensure-idb.test.sh');
+
+for (const [name, helperPath] of [
+  ['source', resolve(repositoryRoot, 'scripts/ensure-idb.sh')],
+  ['packaged', resolve(repositoryRoot, 'packages/claude-plugin/scripts/ensure-idb.sh')],
+] as const) {
+  test(`ensure-idb SessionStart contract (${name} helper)`, async () => {
+    const { stdout, stderr } = await execFileAsync('bash', [contractScript], {
+      cwd: repositoryRoot,
+      env: { ...process.env, SCRIPT_UNDER_TEST: helperPath },
+      encoding: 'utf8',
+      maxBuffer: 1024 * 1024,
+    });
+
+    assert.equal(stderr, '');
+    assert.match(stdout, /incompatible-client: reports interpreter incompatibility/);
+    assert.match(stdout, /incompatible-client: unchanged environment remains suppressed/);
+    assert.match(stdout, /incompatible-client: environment change is re-evaluated/);
+    assert.match(stdout, /present: reports available/);
+    assert.match(stdout, /install: exactly one spawn recorded/);
+    assert.doesNotMatch(stdout, /^FAIL:/m);
+  });
+}

--- a/scripts/ensure-idb.sh
+++ b/scripts/ensure-idb.sh
@@ -5,7 +5,9 @@
 # idb it degrades to a ~6fps `simctl screenshot` loop. idb needs two pieces
 # (idb-companion lives in the facebook/fb tap, not homebrew-core):
 #   brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion   (the macOS daemon)
-#   pipx install fb-idb                                   (the Python CLI client)
+#   brew install python@3.13 && pipx install --python
+#     "$(brew --prefix python@3.13)/bin/python3.13" --force fb-idb
+#                                                        (the Python CLI client)
 #
 # SessionStart contract (GH#252/B196: session start must be BOUNDED): this
 # script's foreground path only does `command -v` checks and (at most) spawns
@@ -17,6 +19,8 @@
 #   - pidfile:      a live worker is never duplicated across session starts
 #   - last-attempt: a failed install is not retried for 24h (brew failures
 #     are usually environmental; hammering it every session start is noise)
+#   - incompatible-environment: Python 3.14 client crashes never start the
+#     worker; the fingerprint is refreshed only when that environment changes
 #
 # Test seams (scripts/test/ensure-idb.test.sh):
 #   RN_AGENT_IDB_STATE_DIR   state dir      (default: ~/.rn-dev-agent/idb)
@@ -31,8 +35,10 @@ set -uo pipefail
 STATE_DIR="${RN_AGENT_IDB_STATE_DIR:-$HOME/.rn-dev-agent/idb}"
 PIDFILE="$STATE_DIR/install.pid"
 MARKER="$STATE_DIR/last-attempt"
+INCOMPATIBLE_MARKER="$STATE_DIR/incompatible-environment"
 LOG="$STATE_DIR/install.log"
 BACKOFF_SECS=86400
+RECOVERY_COMMAND='brew install python@3.13 && pipx install --python "$(brew --prefix python@3.13)/bin/python3.13" --force fb-idb'
 
 OS="${RN_AGENT_IDB_UNAME:-$(uname -s)}"
 [ "$OS" = "Darwin" ] || exit 0
@@ -50,8 +56,28 @@ has_companion() {
 # mirror's tier selection (B263). `idb --help` initializes the CLI without
 # contacting a companion, so it exits 0 for a healthy client and non-zero
 # for a broken one.
+probe_idb_client() {
+  IDB_PATH="$(command -v idb 2>/dev/null || true)"
+  IDB_PROBE_OUTPUT=""
+  IDB_PROBE_STATUS=127
+  [ -n "$IDB_PATH" ] || return 1
+  IDB_PROBE_OUTPUT="$(idb --help 2>&1)"
+  IDB_PROBE_STATUS=$?
+  [ "$IDB_PROBE_STATUS" -eq 0 ]
+}
+
 idb_client_healthy() {
-  command -v idb >/dev/null 2>&1 && idb --help >/dev/null 2>&1
+  probe_idb_client
+}
+
+idb_python_314_incompatible() {
+  [ "${IDB_PROBE_STATUS:-0}" -ne 0 ] &&
+    printf '%s\n' "${IDB_PROBE_OUTPUT:-}" | grep -Eqi 'python([ /]|/)?3\.14|python3\.14' &&
+    printf '%s\n' "${IDB_PROBE_OUTPUT:-}" | grep -Eqi 'There is no current event loop|asyncio\.get_event_loop'
+}
+
+incompatible_fingerprint() {
+  printf '%s\n%s\n' "${IDB_PATH:-}" "${IDB_PROBE_OUTPUT:-}" | cksum | awk '{print $1 ":" $2}'
 }
 
 # --install-worker: the detached background job (never reached at SessionStart).
@@ -70,7 +96,18 @@ if [ "${1:-}" = "--install-worker" ]; then
       if command -v idb >/dev/null 2>&1; then
         pipx uninstall fb-idb >/dev/null 2>&1 || true
       fi
-      pipx install fb-idb || status=failed
+      python_313_prefix="$(brew --prefix python@3.13 2>/dev/null || true)"
+      python_313="$python_313_prefix/bin/python3.13"
+      if [ ! -x "$python_313" ]; then
+        brew install python@3.13 || status=failed
+        python_313_prefix="$(brew --prefix python@3.13 2>/dev/null || true)"
+        python_313="$python_313_prefix/bin/python3.13"
+      fi
+      if [ -x "$python_313" ]; then
+        pipx install --python "$python_313" --force fb-idb || status=failed
+      else
+        status=failed
+      fi
       if ! idb_client_healthy; then
         # Never leave a crash-on-invocation client on PATH: it provides
         # nothing and re-arms the B263 mirror failure. Uninstall and let the
@@ -92,18 +129,43 @@ fi
 # Foreground path — bounded: checks + at most one detached spawn. The client
 # check is a health probe (one `idb --help` invocation, no daemon contact),
 # not a PATH check — see idb_client_healthy (B269).
-if idb_client_healthy && has_companion; then
-  echo "idb available: screen mirroring uses the fast path (idb video-stream)"
+IDB_CLIENT_HEALTHY=0
+if probe_idb_client; then
+  IDB_CLIENT_HEALTHY=1
+  if has_companion; then
+    rm -f "$INCOMPATIBLE_MARKER" "$MARKER"
+    echo "idb available: screen mirroring uses the fast path (idb video-stream)"
+    exit 0
+  fi
+fi
+
+if [ "$IDB_CLIENT_HEALTHY" -eq 0 ] && [ -n "${IDB_PATH:-}" ] && idb_python_314_incompatible; then
+  mkdir -p "$STATE_DIR"
+  FINGERPRINT="$(incompatible_fingerprint)"
+  PREVIOUS_FINGERPRINT="$(cat "$INCOMPATIBLE_MARKER" 2>/dev/null || true)"
+  if [ "$FINGERPRINT" != "$PREVIOUS_FINGERPRINT" ]; then
+    printf '%s\n' "$FINGERPRINT" > "$INCOMPATIBLE_MARKER"
+  fi
+  echo "fb-idb is installed but incompatible with Python 3.14; screen mirroring stays on the simctl fallback."
+  echo "Reinstall with a compatible interpreter: $RECOVERY_COMMAND"
   exit 0
 fi
 
-if command -v idb >/dev/null 2>&1 && ! idb_client_healthy; then
+if [ -f "$INCOMPATIBLE_MARKER" ]; then
+  # The persisted incompatibility verdict is valid only for the fingerprint
+  # that produced it. Once the probe changes to a repairable verdict, an old
+  # worker backoff must not prevent the newly changed environment from being
+  # evaluated immediately.
+  rm -f "$INCOMPATIBLE_MARKER" "$MARKER"
+fi
+
+if [ "$IDB_CLIENT_HEALTHY" -eq 0 ] && [ -n "${IDB_PATH:-}" ]; then
   echo "idb client on PATH is broken (crashes on invocation) — the background worker will replace or remove it (B269)"
 fi
 
 if ! command -v brew >/dev/null 2>&1; then
   echo "idb not installed (optional — enables 20-30fps screen mirroring instead of ~6fps)."
-  echo "Install manually: brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb"
+  echo "Install manually: brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && $RECOVERY_COMMAND"
   exit 0
 fi
 
@@ -125,14 +187,14 @@ if [ -f "$MARKER" ]; then
   read -r LAST_STATUS LAST_TS < "$MARKER" 2>/dev/null || LAST_STATUS=""
   NOW="$(date +%s)"
   if [ "$LAST_STATUS" = "failed" ] && [ -n "${LAST_TS:-}" ] && [ $((NOW - LAST_TS)) -lt "$BACKOFF_SECS" ]; then
-    echo "idb install failed recently — retrying after backoff (manual: brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb, log: $LOG)"
+    echo "idb install failed recently — retrying after backoff (manual: brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && $RECOVERY_COMMAND, log: $LOG)"
     exit 0
   fi
 fi
 
 if [ "${RN_AGENT_IDB_DRY_SPAWN:-}" = "1" ]; then
   echo "spawn --install-worker" >> "$STATE_DIR/spawn.log"
-  echo "idb missing — installing in background (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb). Log: $LOG"
+  echo "idb missing — installing in background (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && $RECOVERY_COMMAND). Log: $LOG"
   exit 0
 fi
 
@@ -140,5 +202,5 @@ nohup bash "$0" --install-worker >> "$LOG" 2>&1 < /dev/null &
 WORKER_PID=$!
 disown "$WORKER_PID" 2>/dev/null || true
 echo "$WORKER_PID" > "$PIDFILE"
-echo "idb missing — installing in background (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb). Log: $LOG"
+echo "idb missing — installing in background (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && $RECOVERY_COMMAND). Log: $LOG"
 exit 0

--- a/scripts/test/ensure-idb.test.sh
+++ b/scripts/test/ensure-idb.test.sh
@@ -22,13 +22,22 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-SCRIPT="$SCRIPT_DIR/ensure-idb.sh"
+SCRIPT="${SCRIPT_UNDER_TEST:-$SCRIPT_DIR/ensure-idb.sh}"
+RECOVERY_COMMAND='brew install python@3.13 && pipx install --python "$(brew --prefix python@3.13)/bin/python3.13" --force fb-idb'
 
 fail=0
 ok() { echo "ok: $1"; }
 bad() { echo "FAIL: $1"; fail=1; }
 
-TMP="$(mktemp -d)"
+if [ -n "${RN_AGENT_TEST_TMP_ROOT:-}" ]; then
+  mkdir -p "$RN_AGENT_TEST_TMP_ROOT"
+  TMP="$(mktemp -d "$RN_AGENT_TEST_TMP_ROOT/ensure-idb.XXXXXX")"
+elif [ -n "${TMPDIR:-}" ]; then
+  mkdir -p "$TMPDIR"
+  TMP="$(mktemp -d "${TMPDIR%/}/ensure-idb.XXXXXX")"
+else
+  TMP="$(mktemp -d)"
+fi
 trap 'rm -rf "$TMP"' EXIT
 
 mkstubs() { # $1 = space-separated binary names to stub as present
@@ -64,16 +73,46 @@ OUT="$(run_script "$STUBS")"
 if echo "$OUT" | grep -qi "idb available"; then ok "hyphen: idb-companion accepted"; else bad "hyphen: expected available, got: $OUT"; fi
 [ ! -f "$STATE/spawn.log" ] && ok "hyphen: no spawn" || bad "hyphen: unexpected spawn"
 
-# 1c. B269: client on PATH but BROKEN (crashes on invocation) -> not treated
-#     as present; prints the broken notice and spawns the repair worker.
+# 1bb. A healthy client with a missing companion needs companion installation,
+#      but must not be misreported as a broken client.
+STATE="$TMP/state1bb"
+STUBS="$(mkstubs "idb brew")"
+OUT="$(run_script "$STUBS")"
+if ! echo "$OUT" | grep -qi "broken"; then ok "healthy-client: missing companion is not a client failure"; else bad "healthy-client: incorrectly reported broken, got: $OUT"; fi
+[ -f "$STATE/spawn.log" ] && ok "healthy-client: missing companion starts repair" || bad "healthy-client: missing companion did not start repair"
+
+# 1c. A Python 3.14 client on PATH that crashes is classified as incompatible,
+#     receives an actionable recovery command, and never spawns a worker.
 STATE="$TMP/state1c"
 STUBS="$(mkstubs "idb_companion brew")"
-printf '#!/bin/sh\nexit 1\n' > "$STUBS/idb"; chmod +x "$STUBS/idb"
+printf '#!/bin/sh\necho "  File /pipx/venvs/fb-idb/lib/python3.14/site-packages/idb/cli/main.py" >&2\necho "RuntimeError: There is no current event loop" >&2\nexit 1\n' > "$STUBS/idb"; chmod +x "$STUBS/idb"
 OUT="$(run_script "$STUBS")"
-if echo "$OUT" | grep -qi "broken"; then ok "broken-client: prints broken notice"; else bad "broken-client: expected broken notice, got: $OUT"; fi
-if [ -f "$STATE/spawn.log" ] && [ "$(wc -l < "$STATE/spawn.log")" -eq 1 ]; then
-  ok "broken-client: spawns repair worker"
-else bad "broken-client: expected one spawn record"; fi
+if echo "$OUT" | grep -q "installed but incompatible with Python 3.14"; then ok "incompatible-client: reports interpreter incompatibility"; else bad "incompatible-client: expected incompatibility notice, got: $OUT"; fi
+if ! echo "$OUT" | grep -qi "idb not installed"; then ok "incompatible-client: does not report idb as missing"; else bad "incompatible-client: incorrectly reported idb as missing, got: $OUT"; fi
+if echo "$OUT" | grep -Fq "$RECOVERY_COMMAND"; then ok "incompatible-client: prints pinned Python 3.13 recovery"; else bad "incompatible-client: missing recovery command, got: $OUT"; fi
+[ ! -f "$STATE/spawn.log" ] && ok "incompatible-client: no repair spawn" || bad "incompatible-client: unexpectedly spawned repair"
+FINGERPRINT_BEFORE="$(cat "$STATE/incompatible-environment" 2>/dev/null)"
+OUT_REPEAT="$(run_script "$STUBS")"
+[ ! -f "$STATE/spawn.log" ] && ok "incompatible-client: unchanged environment remains suppressed" || bad "incompatible-client: unchanged environment spawned repair"
+[ "$(cat "$STATE/incompatible-environment" 2>/dev/null)" = "$FINGERPRINT_BEFORE" ] && ok "incompatible-client: stable environment fingerprint" || bad "incompatible-client: fingerprint changed unexpectedly"
+printf '#!/bin/sh\necho "  File /changed/fb-idb/lib/python3.14/site-packages/idb/cli/main.py" >&2\necho "RuntimeError: There is no current event loop" >&2\nexit 1\n' > "$STUBS/idb"; chmod +x "$STUBS/idb"
+OUT_CHANGED="$(run_script "$STUBS")"
+[ "$(cat "$STATE/incompatible-environment" 2>/dev/null)" != "$FINGERPRINT_BEFORE" ] && ok "incompatible-client: environment change is re-evaluated" || bad "incompatible-client: environment change was not recorded"
+[ ! -f "$STATE/spawn.log" ] && ok "incompatible-client: changed but still-incompatible environment stays suppressed" || bad "incompatible-client: still-incompatible environment spawned repair"
+printf '#!/bin/sh\necho "new non-interpreter client failure" >&2\nexit 1\n' > "$STUBS/idb"; chmod +x "$STUBS/idb"
+echo "failed $(date +%s)" > "$STATE/last-attempt"
+OUT_RECOVERABLE="$(run_script "$STUBS")"
+[ -f "$STATE/spawn.log" ] && ok "incompatible-client: changed verdict re-enables repair" || bad "incompatible-client: environment change did not re-enable repair"
+[ ! -f "$STATE/incompatible-environment" ] && ok "incompatible-client: changed verdict clears fingerprint" || bad "incompatible-client: stale fingerprint survived environment change"
+[ ! -f "$STATE/last-attempt" ] && ok "incompatible-client: changed verdict clears stale backoff" || bad "incompatible-client: stale backoff survived environment change"
+
+# 1d. A non-Python-3.14 crash retains the generic background repair path.
+STATE="$TMP/state1d"
+STUBS="$(mkstubs "idb_companion brew")"
+printf '#!/bin/sh\necho "  File /pipx/venvs/fb-idb/lib/python3.14/site-packages/idb/cli/main.py" >&2\necho "unexpected client failure" >&2\nexit 1\n' > "$STUBS/idb"; chmod +x "$STUBS/idb"
+OUT="$(run_script "$STUBS")"
+if echo "$OUT" | grep -qi "broken"; then ok "broken-client: prints generic broken notice"; else bad "broken-client: expected broken notice, got: $OUT"; fi
+[ -f "$STATE/spawn.log" ] && ok "broken-client: spawns generic repair worker" || bad "broken-client: expected repair spawn"
 
 # 2. Non-macOS -> silent success, no spawn.
 STATE="$TMP/state2"
@@ -86,7 +125,7 @@ OUT="$(FAKE_UNAME=Linux run_script "$STUBS")"
 STATE="$TMP/state3"
 STUBS="$(mkstubs "")"
 OUT="$(run_script "$STUBS")"
-if echo "$OUT" | grep -q "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb"; then
+if echo "$OUT" | grep -Fq "$RECOVERY_COMMAND"; then
   ok "no-brew: prints manual command"
 else bad "no-brew: missing manual command, got: $OUT"; fi
 [ ! -f "$STATE/spawn.log" ] && ok "no-brew: no spawn" || bad "no-brew: unexpected spawn"
@@ -135,11 +174,18 @@ mkdir -p "$STATE"
 STUBS="$(mkstubs "idb_companion brew")"
 printf '#!/bin/sh\nexit 1\n' > "$STUBS/idb"; chmod +x "$STUBS/idb"
 printf '#!/bin/sh\necho "$@" >> "%s/pipx.log"\nexit 0\n' "$STATE" > "$STUBS/pipx"; chmod +x "$STUBS/pipx"
+PYTHON_PREFIX="$TMP/python-3.13"
+mkdir -p "$PYTHON_PREFIX/bin"
+printf '#!/bin/sh\nexit 0\n' > "$PYTHON_PREFIX/bin/python3.13"; chmod +x "$PYTHON_PREFIX/bin/python3.13"
+printf '#!/bin/sh\nif [ "$1" = "--prefix" ]; then echo "%s"; fi\nexit 0\n' "$PYTHON_PREFIX" > "$STUBS/brew"; chmod +x "$STUBS/brew"
 env PATH="$STUBS:/usr/bin:/bin" RN_AGENT_IDB_STATE_DIR="$STATE" RN_AGENT_IDB_UNAME=Darwin \
   bash "$SCRIPT" --install-worker > "$TMP/worker7b.out" 2>&1
 if grep -q "uninstall fb-idb" "$STATE/pipx.log" 2>/dev/null; then
   ok "worker: broken client uninstalled (never left on PATH)"
 else bad "worker: expected pipx uninstall fb-idb, got: $(cat "$STATE/pipx.log" 2>/dev/null)"; fi
+if grep -Fq "install --python $PYTHON_PREFIX/bin/python3.13 --force fb-idb" "$STATE/pipx.log" 2>/dev/null; then
+  ok "worker: install is pinned to Python 3.13"
+else bad "worker: expected pinned pipx install, got: $(cat "$STATE/pipx.log" 2>/dev/null)"; fi
 if grep -q "^failed " "$STATE/last-attempt" 2>/dev/null; then
   ok "worker: broken client marks attempt failed (backoff engages)"
 else bad "worker: expected failed marker, got: $(cat "$STATE/last-attempt" 2>/dev/null)"; fi


### PR DESCRIPTION
Closes #578

<!-- story-factory:pr:v1 run=Lykhoyda/rn-dev-agent#578:16107a8b-238f-4f31-b360-6084878482a1 fingerprint=1a8b622778315203a4e9e3f02369324da595eecedde1e47470c58369b9fa7798 -->