### PR TITLE
ensure-ffmpeg.sh exits inconsistently when ffmpeg cannot be ensured

### DIFF
--- a/.changeset/consistent-ffmpeg-exit.md
+++ b/.changeset/consistent-ffmpeg-exit.md
@@ -1,0 +1,5 @@
+---
+'rn-dev-agent-plugin': patch
+---
+
+Return a consistent non-zero status when ffmpeg cannot be ensured.

--- a/packages/claude-plugin/scripts/ensure-ffmpeg.sh
+++ b/packages/claude-plugin/scripts/ensure-ffmpeg.sh
@@ -19,4 +19,4 @@ fi
 
 echo "Warning: ffmpeg not found and Homebrew not available. GIF conversion will be skipped." >&2
 echo "Install manually: brew install ffmpeg" >&2
-exit 0
+exit 1

--- a/packages/rn-dev-agent-core/test/integration/ensure-ffmpeg-exit-contract.test.ts
+++ b/packages/rn-dev-agent-core/test/integration/ensure-ffmpeg-exit-contract.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+const contractTest = join(repositoryRoot, 'scripts', 'test', 'ensure-ffmpeg.test.sh');
+
+for (const [label, helper] of [
+  ['source', join(repositoryRoot, 'scripts', 'ensure-ffmpeg.sh')],
+  ['packaged', join(repositoryRoot, 'packages', 'claude-plugin', 'scripts', 'ensure-ffmpeg.sh')],
+] as const) {
+  test(`ensure-ffmpeg has consistent four-branch exits in the ${label} helper`, async () => {
+    const { stdout, stderr } = await execFileAsync('bash', [contractTest, helper, label], {
+      encoding: 'utf8',
+    });
+
+    assert.equal(stderr, '');
+    const receipt = JSON.parse(stdout.trim()) as {
+      status: string;
+      helper: string;
+      cases: Array<{ case: string; expectedExit: number; actualExit: number }>;
+    };
+    assert.equal(receipt.status, 'passed');
+    assert.equal(receipt.helper, label);
+    assert.deepEqual(
+      receipt.cases.map(({ case: caseName, expectedExit, actualExit }) => ({
+        case: caseName,
+        expectedExit,
+        actualExit,
+      })),
+      [
+        { case: 'pre-installed', expectedExit: 0, actualExit: 0 },
+        { case: 'homebrew-install-success', expectedExit: 0, actualExit: 0 },
+        { case: 'homebrew-install-failure', expectedExit: 1, actualExit: 1 },
+        { case: 'homebrew-absent', expectedExit: 1, actualExit: 1 },
+      ],
+    );
+  });
+}

--- a/scripts/ensure-ffmpeg.sh
+++ b/scripts/ensure-ffmpeg.sh
@@ -19,4 +19,4 @@ fi
 
 echo "Warning: ffmpeg not found and Homebrew not available. GIF conversion will be skipped." >&2
 echo "Install manually: brew install ffmpeg" >&2
-exit 0
+exit 1

--- a/scripts/test/ensure-ffmpeg.test.sh
+++ b/scripts/test/ensure-ffmpeg.test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Four-branch exit contract for scripts/ensure-ffmpeg.sh.
+# An optional first argument selects another packaged copy of the helper.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${1:-$SCRIPT_DIR/ensure-ffmpeg.sh}"
+LABEL="${2:-source}"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/ensure-ffmpeg.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+make_stub() {
+  local directory="$1"
+  local name="$2"
+  local body="$3"
+  printf '#!/bin/sh\n%s\n' "$body" > "$directory/$name"
+  chmod +x "$directory/$name"
+}
+
+run_case() {
+  local name="$1"
+  local expected_status="$2"
+  local ffmpeg_body="$3"
+  local brew_body="$4"
+  local expect_skip="$5"
+  local stubs="$TMP/$name/stubs"
+  local stdout="$TMP/$name/stdout"
+  local stderr="$TMP/$name/stderr"
+  local actual_status
+
+  mkdir -p "$stubs"
+  make_stub "$stubs" head 'exec /usr/bin/head "$@"'
+  if [ -n "$ffmpeg_body" ]; then
+    make_stub "$stubs" ffmpeg "$ffmpeg_body"
+  fi
+  if [ -n "$brew_body" ]; then
+    make_stub "$stubs" brew "$brew_body"
+  fi
+
+  env PATH="$stubs" /bin/bash "$SCRIPT" >"$stdout" 2>"$stderr"
+  actual_status=$?
+
+  [ "$actual_status" -eq "$expected_status" ] ||
+    fail "$name: expected exit $expected_status, got $actual_status; stderr: $(cat "$stderr")"
+
+  if [ "$expect_skip" = true ]; then
+    grep -Fq "GIF conversion will be skipped" "$stderr" ||
+      fail "$name: missing skip-GIF guidance on stderr"
+  elif grep -Fq "GIF conversion will be skipped" "$stderr"; then
+    fail "$name: unexpected skip-GIF guidance"
+  fi
+
+  CASE_RECEIPTS="${CASE_RECEIPTS}${CASE_RECEIPTS:+,}{\"case\":\"$name\",\"expectedExit\":$expected_status,\"actualExit\":$actual_status}"
+}
+
+[ -f "$SCRIPT" ] || fail "helper not found: $SCRIPT"
+
+CASE_RECEIPTS=""
+run_case "pre-installed" 0 'echo "ffmpeg version test"; exit 0' '' false
+run_case "homebrew-install-success" 0 '' 'exit 0' false
+run_case "homebrew-install-failure" 1 '' 'exit 42' true
+run_case "homebrew-absent" 1 '' '' true
+
+printf '{"status":"passed","helper":"%s","cases":[%s]}\n' "$LABEL" "$CASE_RECEIPTS"


### PR DESCRIPTION
Closes #598

<!-- story-factory:pr:v1 run=Lykhoyda/rn-dev-agent#598:94baab34-607b-4057-8b00-453cea8b89fa fingerprint=df3e05148cb14cc84c473a65c9b2a9f9a63448caa959d5ee6f7eaf5cd3028416 -->