### PR TITLE
test(core): follow active plugin version in GH-588 runner timeout fixture

### DIFF
--- a/packages/rn-dev-agent-core/test/unit/gh-588-runner-timeout-truth.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-588-runner-timeout-truth.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { _setActiveSessionForTest, runNative } from '../../dist/agent-device-wrapper.js';
-import { REQUIRED_IOS_COMMANDS } from '../../dist/runners/protocol.js';
+import { getPluginVersion, REQUIRED_IOS_COMMANDS } from '../../dist/runners/protocol.js';
 import {
   _setFastRunnerStateForTest,
   _setFetchForTest,
@@ -217,6 +217,8 @@ test('GH-588 V6: a replacement runner is preserved when prior type authority is 
 });
 
 test('GH-588 V6: success-shaped fill fails closed when settle observes runner authority loss', async (t) => {
+  const pluginVersion = getPluginVersion();
+  assert.ok(pluginVersion, 'source-checkout tests resolve the current plugin version');
   const dummy = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
     stdio: 'ignore',
   });
@@ -249,7 +251,7 @@ test('GH-588 V6: success-shaped fill fails closed when settle observes runner au
         JSON.stringify({
           ok: true,
           protocolVersion: 2,
-          runnerVersion: '0.70.8',
+          runnerVersion: pluginVersion,
           capabilities: ['SCREEN_STATIC', 'HONEST_HITTABLE'],
           commands: REQUIRED_IOS_COMMANDS,
         }),


### PR DESCRIPTION
## Intent

Correct the post-merge Release CI failure after PR #609 with a bounded test-only fix. The GH-588 runner-timeout test must advertise the active production plugin version rather than a release-specific 0.70.8 literal, while preserving exactly one type dispatch, fail-closed RUNNER_TIMEOUT, post-settle authority-loss, unverified readback, and already-absent/no-reap assertions. Keep production version-skew protection and all product code unchanged, add no changeset, and do not launch rn-dev-agent device validation or MCP for this test-only correction.

## What Changed

- `gh-588-runner-timeout-truth.test.ts` now imports `getPluginVersion()` from `dist/runners/protocol.js` and uses it for the stubbed handshake's `runnerVersion`, replacing the hardcoded `0.70.8` literal that went stale once the release bumped the plugin to 0.70.9 and started failing post-merge Release CI on version skew.
- The fixture asserts the plugin version resolves before use, so an unresolvable manifest fails fast instead of silently disabling the version-skew branch it is exercising.
- Test-only change: no product code, no changeset, and the existing GH-588 V6 assertions (single type dispatch, fail-closed `RUNNER_TIMEOUT`, post-settle authority loss, unverified readback, already-absent/no-reap) are unchanged. The full `rn-dev-agent-core` unit suite passes (3558 tests), and the same test reproducibly fails at the base commit.

## Risk Assessment

✅ Low: A 4-line test-only change that replaces a release-specific version literal with the same `getPluginVersion()` source production uses, leaving all product code and every required assertion in the GH-588 fixture unchanged.

## Testing

Reproduced the post-merge Release CI failure at the base commit (the hardcoded 0.70.8 runnerVersion trips production's version-skew guard against the now-active 0.70.9 manifest, so the mutating type command never dispatches and `typeReplies` is 0 instead of 1), then confirmed the fixture change makes it pass by resolving the same version production reads; the GH-588 file is 9/9, the whole 3558-test unit suite is green, the diff stays test-only with no changeset and all five required assertions intact, and no rn-dev-agent/MCP device validation was used. No screenshot or rendered artifact applies here — this is a headless Node test-fixture correction with no end-user UI surface, so the reviewer-visible evidence is the before/after CLI transcript.

<details>
<summary>Evidence: GH-588 runner-timeout fixture: before/after CLI transcript + resolved plugin version</summary>

<code>### Active plugin version resolved by production code&#10;getPluginVersion() =&gt; 0.70.9&#10;runner-manifest.json version =&gt; 0.70.9&#10;&#10;### BEFORE (base c6d4d41f, hardcoded runnerVersion &#39;0.70.8&#39;) — reproduces post-merge Release CI failure&#10;✖ GH-588 V6: success-shaped fill fails closed when settle observes runner authority loss&#10;AssertionError [ERR_ASSERTION]: the mutating type command is never resent&#10;0 !== 1&#10;ℹ pass 0 / fail 1&#10;&#10;### AFTER (HEAD 833c3168, runnerVersion = getPluginVersion())&#10;✔ GH-588 Slice C: timeout succeeds only as exact-readback recovery&#10;✔ GH-588 Slice C: mismatch and unavailable CDP fail closed as RUNNER_TIMEOUT&#10;✔ GH-588 V6: a replacement runner is preserved when prior type authority is lost&#10;✔ GH-588 V6: success-shaped fill fails closed when settle observes runner authority loss&#10;ℹ tests 9 / pass 9 / fail 0</code>

```text
### Active plugin version resolved by production code
getPluginVersion() => 0.70.9
runner-manifest.json version => 0.70.9

### BEFORE (base c6d4d41f, hardcoded runnerVersion '0.70.8') — reproduces post-merge Release CI failure
✖ GH-588 V6: success-shaped fill fails closed when settle observes runner authority loss (45.5845ms)
ℹ tests 1
ℹ suites 0
ℹ pass 0
ℹ fail 1
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 219.906125

✖ failing tests:

test at test/unit/zz-baseline-tmp.test.ts:219:1
✖ GH-588 V6: success-shaped fill fails closed when settle observes runner authority loss (45.5845ms)
  AssertionError [ERR_ASSERTION]: the mutating type command is never resent
  
  0 !== 1
  
      at TestContext.<anonymous> (file://<repo>/packages/rn-dev-agent-core/test/unit/zz-baseline-tmp.test.ts:287:10)
      at async Test.run (node:internal/test_runner/test:1125:7)
      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:358:3) {
    generatedMessage: false,
    code: 'ERR_ASSERTION',
    actual: 0,
    expected: 1,
    operator: 'strictEqual',
    diff: 'simple'
  }

### AFTER (HEAD 833c3168, runnerVersion = getPluginVersion())
✔ GH-588 runner lifecycle: default launch requests an isolated OS-assigned listener port (0.767166ms)
✔ GH-588 Slice C: deterministic wedge hook is compile-gated out of release artifacts (3.622333ms)
✔ GH-588 Slice C: deterministic fault uses the TEST_RUNNER_ XCUITest launch contract (0.111875ms)
✔ GH-588 Slice C: timeout succeeds only as exact-readback recovery (517.376917ms)
✔ GH-588 Slice C: mismatch and unavailable CDP fail closed as RUNNER_TIMEOUT (1053.976ms)
✔ GH-588 Slice C: adopted runner postmortem is honestly unavailable (0.717125ms)
✔ GH-588 Slice C: a second mutator is refused while the triggering runner is poisoned (503.936625ms)
✔ GH-588 V6: a replacement runner is preserved when prior type authority is lost (1.950291ms)
✔ GH-588 V6: success-shaped fill fails closed when settle observes runner authority loss (7.225334ms)
ℹ tests 9
ℹ suites 0
ℹ pass 9
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 2220.265291
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `packages/rn-dev-agent-core/test/unit/gh-588-runner-timeout-truth.test.ts:221` - `assert.ok(pluginVersion)` turns an unresolvable plugin manifest into a test failure, even though `getPluginVersion()` is deliberately fail-open (returns null, disabling the version-skew check in classifyRunnerCompatibility) and the fixture would still exercise the intended post-settle authority-loss path with a null plugin version. In a source checkout the `packages/rn-dev-agent-core/package.json` fallback always resolves, so this is a deliberate fail-fast guard rather than a real breakage — noting it only as a tradeoff.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`yarn install --immutable` + `yarn workspace rn-dev-agent-core build` (tests import from dist/)</code>
- <code>Baseline repro: `git show c6d4d41f:...gh-588-runner-timeout-truth.test.ts` copied into test/unit and run with `node --test --test-name-pattern &#34;settle observes runner authority loss&#34;` — fails with `0 !== 1` (temp copy deleted afterwards)</code>
- <code>`node --test test/unit/gh-588-runner-timeout-truth.test.ts` at HEAD — 9/9 pass</code>
- <code>`node -e &#34;import(&#39;./dist/runners/protocol.js&#39;).then(m=&gt;console.log(m.getPluginVersion()))&#34;` vs `runner-manifest.json` version — both 0.70.9</code>
- <code>Full unit suite: `node --test &#39;test/unit/*.test.js&#39; &#39;test/unit/**/*.test.js&#39; &#39;test/unit/*.test.ts&#39; &#39;test/unit/**/*.test.ts&#39;` — 3558 pass, 0 fail</code>
- <code>Scope audit: `git diff --name-only c6d4d41f..HEAD` (one test file, no product code, no `.changeset/*` entry) and manual read of the preserved assertions at gh-588-runner-timeout-truth.test.ts:289-301</code>
- <code>`git status --short` clean after reverting a build-induced file-mode change on packages/rn-dev-agent-core/dist/supervisor.js</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
