### PR TITLE
fix(core): coordinate helper injection per execution world

### DIFF
--- a/.changeset/calm-helpers-coordinate.md
+++ b/.changeset/calm-helpers-coordinate.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-plugin": patch
+"rn-dev-agent-core": patch
+---
+
+Coalesce helper setup and reinjection per execution world, require the exact helper version, and report bounded truthful helper-health evidence.

--- a/apps/docs-site/src/content/docs/architecture.mdx
+++ b/apps/docs-site/src/content/docs/architecture.mdx
@@ -138,7 +138,7 @@ Since MCP is pull-based (tools are called on demand), events that fire between c
 
 | Decision | Rationale |
 |----------|-----------|
-| Inject helpers ONCE on connect | ~2KB JS, then call `__RN_AGENT.*` — small payloads per call |
+| Coalesce helper setup and reinjection per execution world | Inject once for the current helper world, then call `__RN_AGENT.*` with small payloads |
 | 5-second timeout on ALL CDP calls | Prevents hanging promises |
 | RedBox detection before tree return | Check fiber root for LogBox/ErrorWindow, warn instead of returning error overlay |
 | `Debugger.paused` auto-resume | Prevents silent JS thread freeze from `debugger;` statements |

--- a/apps/docs-site/src/content/docs/changelog.md
+++ b/apps/docs-site/src/content/docs/changelog.md
@@ -5,6 +5,24 @@ description: "Release history for rn-dev-agent"
 
 ## Claude plugin
 
+### 0.71.0
+
+#### Minor Changes
+
+- 784c880: Add fail-closed fenced worktree sessions with exact build, Metro, device, runner, Observe, and strict-proof authority.
+
+#### Patch Changes
+
+- 784c880: Store the package-integration restoration manifest durably inside the session binding, let on-disk manifest bytes authorize only the current owner's restore_integration, and make stale adoption, handoff acceptance, and resumed cleanup validate their capability non-mutatingly — resumed handoff cleanup now re-proves the exact consumed handoff and its original token against a durable cleanup binding pinned to the accepting target session and claim epoch, so a stale-adoption transfer revokes the old handoff capability in favor of the adoption handle — and refuse before any transfer or mutation unless the binding itself carries a SHA-256-verified restoration manifest, reporting file-state diagnostics and the supported recovery step instead of auto-reconciling.
+- 784c880: Launch Expo session builds with a command shape the installed Expo CLI accepts and release pending build authority through an authenticated abort when the native command fails before completion.
+- 784c880: Guarantee single-emission signed Metro startup with gate-composed strict-proof input handling, pre-helper error evidence, allocated-port exact-device reconnects, and authoritative migration, runner, and stale-Metro recovery.
+- Updated dependencies [784c880]
+- Updated dependencies [784c880]
+- Updated dependencies [784c880]
+- Updated dependencies [784c880]
+- Updated dependencies [784c880]
+  - rn-dev-agent-core@0.66.0
+
 ### 0.70.10
 
 #### Patch Changes
@@ -1204,6 +1222,19 @@ identifier, hittable? }`, with a `fullNodeCount`. Far fewer tokens; `@ref`s for
   #188 shipped these to `main` with no version bump, leaving them undeliverable to marketplace installs; this patch publishes them.
 
 ## Core MCP server
+
+### 0.66.0
+
+#### Minor Changes
+
+- 784c880: Add fail-closed fenced worktree sessions with exact build, Metro, device, runner, Observe, and strict-proof authority.
+
+#### Patch Changes
+
+- 784c880: Store the package-integration restoration manifest durably inside the session binding, let on-disk manifest bytes authorize only the current owner's restore_integration, and make stale adoption, handoff acceptance, and resumed cleanup validate their capability non-mutatingly — resumed handoff cleanup now re-proves the exact consumed handoff and its original token against a durable cleanup binding pinned to the accepting target session and claim epoch, so a stale-adoption transfer revokes the old handoff capability in favor of the adoption handle — and refuse before any transfer or mutation unless the binding itself carries a SHA-256-verified restoration manifest, reporting file-state diagnostics and the supported recovery step instead of auto-reconciling.
+- 784c880: Launch Expo session builds with a command shape the installed Expo CLI accepts and release pending build authority through an authenticated abort when the native command fails before completion.
+- 784c880: Give authenticated managed-Metro descendants an open stdin so Tailwind-backed transforms cannot stall, and fail typed instead of hanging when a child's first authenticated exchange never completes.
+- 784c880: Guarantee single-emission signed Metro startup with gate-composed strict-proof input handling, pre-helper error evidence, allocated-port exact-device reconnects, and authoritative migration, runner, and stale-Metro recovery.
 
 ### 0.65.8
 

--- a/apps/docs-site/src/content/docs/commands/check-env.mdx
+++ b/apps/docs-site/src/content/docs/commands/check-env.mdx
@@ -35,7 +35,7 @@ from an ambient port or the first available device.
 | CDP code 1006 | Close React Native DevTools, Flipper, or Chrome DevTools |
 | `cdp_component_tree` reports RedBox | Run `/rn-dev-agent:debug-screen` |
 | Narrow gated CDP read times out | Check for a blocked JS thread, then use `cdp_reload` |
-| `HELPERS_NOT_INJECTED` | Use a `__DEV__` Hermes build; retry through the gated tool after reload |
+| `HELPERS_NOT_INJECTED` | Read bounded `meta.helperHealth`; use a `__DEV__` Hermes build and retry through the gated tool after reload |
 | No devices | Boot a simulator: `xcrun simctl boot "iPhone 16"` |
 
 ## When to Use

--- a/apps/docs-site/src/content/docs/skills/rn-debugging.mdx
+++ b/apps/docs-site/src/content/docs/skills/rn-debugging.mdx
@@ -52,6 +52,9 @@ Call `rn_session(action="status")` first, then passive `cdp_status`.
 - A disconnected exact target means open the bound app and call `cdp_connect`.
 - Use `cdp_component_tree` for helper and RedBox health.
 - Use `cdp_error_log` for active JavaScript errors.
+- For `HELPERS_NOT_INJECTED`, read bounded `meta.helperHealth` and follow the
+  packaged debugging skill's recovery order; a probe timeout does not prove a
+  JavaScript hang.
 
 ### Connection Troubleshooting
 

--- a/packages/claude-plugin/commands/check-env.md
+++ b/packages/claude-plugin/commands/check-env.md
@@ -27,7 +27,7 @@ If issues are found, suggest the appropriate fix:
 | CDP code 1006 | Close React Native DevTools, Flipper, Chrome DevTools |
 | `cdp_component_tree` reports RedBox | Run `/rn-dev-agent:debug-screen` |
 | Narrow gated CDP read times out | Check for a blocked JS thread, then use `cdp_reload` |
-| `HELPERS_NOT_INJECTED` | Use a `__DEV__` Hermes build; retry through the gated tool after reload |
+| `HELPERS_NOT_INJECTED` | Read bounded `meta.helperHealth`; use a `__DEV__` Hermes build and retry through the gated tool after reload |
 | No devices in device_list | Boot a simulator: `xcrun simctl boot "iPhone 16"` or start an emulator |
 
 Present results clearly with a pass/fail indicator for each subsystem.

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -25946,31 +25946,7 @@ function consumeCdpStale() {
   return was;
 }
 async function probeFreshness(client2, timeoutMs = FRESHNESS_PROBE_MS) {
-  if (!client2.isConnected) {
-    return { fresh: false, version: null, probed: false };
-  }
-  let probeTimer;
-  try {
-    const evalPromise = client2.evaluate('typeof globalThis.__RN_AGENT === "object" && globalThis.__RN_AGENT.__v');
-    evalPromise.catch(() => {
-    });
-    const result = await Promise.race([
-      evalPromise,
-      new Promise((resolve10) => {
-        probeTimer = setTimeout(() => resolve10({ error: "timeout" }), timeoutMs);
-      })
-    ]);
-    if (probeTimer)
-      clearTimeout(probeTimer);
-    if (result.error || typeof result.value !== "number") {
-      return { fresh: false, version: null, probed: true };
-    }
-    return { fresh: true, version: result.value, probed: true };
-  } catch {
-    if (probeTimer)
-      clearTimeout(probeTimer);
-    return { fresh: false, version: null, probed: true };
-  }
+  return client2.probeHelperFreshness(timeoutMs);
 }
 async function recoverFromStaleTarget(client2) {
   if (!client2.isConnected) {
@@ -33135,18 +33111,28 @@ function isFreshnessCached(client2) {
   const entry = freshnessCache.get(client2);
   if (!entry)
     return false;
-  if (entry.generation !== client2.connectionGeneration)
+  if (entry.generation !== client2.helperWorldGeneration)
     return false;
   return Date.now() < entry.expiresAt;
 }
 function rememberFreshness(client2) {
   freshnessCache.set(client2, {
-    generation: client2.connectionGeneration,
+    generation: client2.helperWorldGeneration,
     expiresAt: Date.now() + FRESHNESS_CACHE_MS
   });
 }
 function forgetFreshness(client2) {
   freshnessCache.delete(client2);
+}
+async function helpersNotInjectedResult(client2, boundary) {
+  const helperHealth = await client2.probeHelperHealth(2e3);
+  if (helperHealth.jsWorld === "responsive" && helperHealth.helper === "current") {
+    rememberFreshness(client2);
+    return null;
+  }
+  forgetFreshness(client2);
+  const message = helperHealth.jsWorld === "timeout" ? `Helpers are not ready and the bounded ${helperHealth.probeBudgetMs}ms health probe received no response; JavaScript may be busy, paused, or blocked.` : helperHealth.jsWorld === "transport-error" ? "Helpers are not ready and their health could not be measured because the CDP transport failed." : helperHealth.jsWorld === "superseded" ? "Helpers are not ready because the JavaScript execution world changed during the bounded health probe." : helperHealth.helper === "version-mismatch" ? "Helpers are not ready because the responsive JavaScript world contains a different helper version." : helperHealth.helper === "missing" ? "Helpers are not ready because they are missing from the responsive JavaScript world." : "Helpers are not ready because the responsive JavaScript world contains an invalid helper value.";
+  return failResult(`${boundary === "stale-recovery" ? "Stale target recovery completed, but " : ""}${message} Fall back to device_* tools or call cdp_reload once.`, "HELPERS_NOT_INJECTED", { helperHealth });
 }
 function createStepTimer() {
   let last = Date.now();
@@ -33235,7 +33221,9 @@ function withConnection(getClient2, handler, options = {}) {
             }
           }
           if (!client2.helpersInjected) {
-            return failResult("Connected but helpers still not injected after passive wait, active re-inject, and Dev Client picker dismissal. The JS world may be hung. Fall back to device_* tools (XCTest path \u2014 no helpers required) or call cdp_reload to restart the bundle.", "HELPERS_NOT_INJECTED");
+            const helperError = await helpersNotInjectedResult(client2, "initial");
+            if (helperError)
+              return helperError;
           }
         }
       }
@@ -33323,7 +33311,14 @@ function withConnection(getClient2, handler, options = {}) {
               return failResult(`Retry after stale-target recovery failed: ${retryMsg}`, "STALE_TARGET", { originalError: message });
             }
           }
-          return failResult("Stale target recovery: reconnected but helpers not injected.", "HELPERS_NOT_INJECTED", { originalError: message });
+          const helperError = await helpersNotInjectedResult(client2, "stale-recovery");
+          if (helperError)
+            return helperError;
+          try {
+            return await handler(args, client2);
+          } catch {
+            return failResult("Retry after stale-target helper reconciliation failed.", "STALE_TARGET");
+          }
         }
         if (recovery.reason === "reconnect-failed") {
           return failResult(`Stale target recovery failed: ${recovery.error}`, "STALE_TARGET", {
@@ -48655,9 +48650,9 @@ var DETECT_EXPRESSION = `
   return JSON.stringify({ present: true, version: b.__v || null });
 })()
 `;
-async function detectBridge(client2) {
+async function detectBridge(client2, evaluate = (expression) => client2.evaluate(expression)) {
   try {
-    const result = await client2.evaluate(DETECT_EXPRESSION);
+    const result = await evaluate(DETECT_EXPRESSION);
     if (result.value && typeof result.value === "string") {
       return JSON.parse(result.value);
     }
@@ -51783,7 +51778,10 @@ function defaultTimeout(platform) {
 var REACT_READY_TIMEOUT_MS = 3e4;
 var REACT_READY_POLL_MS = 500;
 async function performSetup(opts) {
-  const { send, evaluate, port, connectedTarget, networkManager, getDeviceKey, setupEventHandlers, clearScripts, clearEventHandlers, probeWaits } = opts;
+  const { send, evaluate, setupHelpers, port, networkManager, getDeviceKey, setupEventHandlers, clearScripts, clearEventHandlers, probeWaits } = opts;
+  clearEventHandlers();
+  clearScripts();
+  setupEventHandlers();
   logger.debug("CDP", "Running setup: Runtime.enable, Debugger.enable...");
   await send("Runtime.enable", void 0, timeoutForMethod("Runtime.enable"));
   await send("Debugger.enable", void 0, timeoutForMethod("Debugger.enable"));
@@ -51809,24 +51807,8 @@ async function performSetup(opts) {
   ]);
   const profilerAvailable = profilerProbe.status === "fulfilled" && profilerProbe.value === true;
   const heapProfilerAvailable = heapProbe.status === "fulfilled" && heapProbe.value === true;
-  clearEventHandlers();
-  clearScripts();
-  setupEventHandlers();
-  await waitForReact(evaluate, REACT_READY_TIMEOUT_MS);
-  const helperResult = await evaluate(INJECTED_HELPERS);
-  if (helperResult.error) {
-    console.error("CDP: failed to inject helpers:", helperResult.error);
-    return {
-      networkMode,
-      helpersInjected: false,
-      logDomainEnabled,
-      profilerAvailable,
-      heapProfilerAvailable
-    };
-  }
-  const verify = await evaluate('typeof globalThis.__RN_AGENT === "object"');
-  if (verify.value !== true) {
-    console.error("CDP: helper injection succeeded but __RN_AGENT not found");
+  const helpersInjected = await setupHelpers(REACT_READY_TIMEOUT_MS);
+  if (!helpersInjected) {
     return {
       networkMode,
       helpersInjected: false,
@@ -51843,8 +51825,7 @@ async function performSetup(opts) {
     }
     networkDomainEnabled = false;
   }
-  logger.info("CDP", `Helpers injected (v${HELPERS_VERSION}), network mode: ${networkMode}`);
-  setActiveFlag(port, connectedTarget);
+  logger.info("CDP", `Helpers current (v${HELPERS_VERSION}), network mode: ${networkMode}`);
   if (networkMode === "cdp") {
     networkMode = await probeNetworkDomain({
       evaluate,
@@ -51892,19 +51873,6 @@ async function probeNetworkDomain(opts) {
   }
   logger.info("CDP", `Network.enable accepted but no events fired after ${waits.length} attempt(s) \u2014 falling back to hooks`);
   return "none";
-}
-async function reinjectHelpers(evaluate, waitTimeout) {
-  await waitForReact(evaluate, waitTimeout ?? REACT_READY_TIMEOUT_MS);
-  const helperResult = await evaluate(INJECTED_HELPERS);
-  if (helperResult.error) {
-    console.error("CDP: failed to re-inject helpers:", helperResult.error);
-    return false;
-  }
-  const verify = await evaluate('typeof globalThis.__RN_AGENT === "object"');
-  if (verify.value !== true) {
-    return false;
-  }
-  return true;
 }
 async function probeReactReachable(evaluate, budgetMs, pollMs = REACT_READY_POLL_MS) {
   const start = Date.now();
@@ -51996,7 +51964,16 @@ function handleMessage(data, pending2, eventHandlers, onConsoleHook) {
 }
 
 // packages/rn-dev-agent-core/dist/cdp/event-handlers.js
-function wireEventHandlers(eventHandlers, buffers, sendFn, getIsPaused, setIsPaused, getDeviceKey) {
+function wireEventHandlers(eventHandlers, buffers, sendFn, getIsPaused, setIsPaused, getDeviceKey, executionContexts) {
+  if (executionContexts) {
+    eventHandlers.set("Runtime.executionContextCreated", (params) => {
+      executionContexts.created(params);
+    });
+    eventHandlers.set("Runtime.executionContextDestroyed", (params) => {
+      executionContexts.destroyed(params);
+    });
+    eventHandlers.set("Runtime.executionContextsCleared", () => executionContexts.cleared());
+  }
   eventHandlers.set("Runtime.consoleAPICalled", (params) => {
     const p = params;
     const text = p.args?.map((a) => a.value !== void 0 ? String(a.value) : a.description ?? "").join(" ") ?? "";
@@ -52408,6 +52385,16 @@ var CDPClient = class {
   reconnecting = false;
   disposed = false;
   _helpersInjected = false;
+  _helperWorldGeneration = 0;
+  _helperContext = null;
+  _helperToken = {
+    generation: 0,
+    ws: null,
+    targetId: null,
+    contextId: null,
+    contextUniqueId: null
+  };
+  _helperInjectionInFlight = null;
   _networkMode = "none";
   _isPaused = false;
   _connectedTarget = null;
@@ -52467,6 +52454,10 @@ var CDPClient = class {
   }
   get helpersInjected() {
     return this._helpersInjected;
+  }
+  /** Private helper-world epoch exposed only for process-local cache identity. */
+  get helperWorldGeneration() {
+    return this._helperWorldGeneration;
   }
   get metroPort() {
     return this._port;
@@ -52566,17 +52557,182 @@ var CDPClient = class {
   async reinjectHelpers(waitTimeout) {
     if (!this.isConnected)
       return false;
-    const ok = await reinjectHelpers((expr) => this.evaluate(expr), waitTimeout);
-    this._helpersInjected = ok;
-    if (ok) {
-      setActiveFlag(this._port, this._connectedTarget);
-      detectBridge(this).then((r) => {
-        this._bridgeDetected = r.present;
-        this._bridgeVersion = r.version;
-      }).catch(() => {
-      });
+    await waitForReact((expr) => this.evaluateCurrentHelperWorld(expr), waitTimeout);
+    return this.ensureCurrentHelpers("reinject_started");
+  }
+  /**
+   * One bounded, context-pinned health read used only at final
+   * HELPERS_NOT_INJECTED boundaries. It never returns app values or errors.
+   */
+  async probeHelperHealth(probeBudgetMs = 2e3) {
+    const token2 = this._helperToken;
+    if (!this.isHelperTokenCurrent(token2)) {
+      return { jsWorld: "superseded", helper: "unknown", probeBudgetMs };
     }
-    return ok;
+    const expression = `(function(){try{var d=Object.getOwnPropertyDescriptor(globalThis,'__RN_AGENT');if(!d)return 'missing';if(!('value' in d)||typeof d.value!=='object'||d.value===null)return 'invalid';var v=Object.getOwnPropertyDescriptor(d.value,'__v');if(!v||!('value' in v)||typeof v.value!=='number')return 'invalid';return v.value===${HELPERS_VERSION}?'current':'version-mismatch';}catch(_){return 'invalid';}})()`;
+    try {
+      const result = await this.evaluateForHelperToken(token2, expression, probeBudgetMs);
+      if (!this.isHelperTokenCurrent(token2)) {
+        return { jsWorld: "superseded", helper: "unknown", probeBudgetMs };
+      }
+      const helper = result.value === "current" || result.value === "missing" || result.value === "version-mismatch" || result.value === "invalid" ? result.value : "invalid";
+      if (helper === "current")
+        this.markHelpersReady(token2, "health_reconciled_current");
+      return { jsWorld: "responsive", helper, probeBudgetMs };
+    } catch (err) {
+      if (!this.isHelperTokenCurrent(token2)) {
+        return { jsWorld: "superseded", helper: "unknown", probeBudgetMs };
+      }
+      const timedOut = err instanceof Error && err.message.startsWith("CDP timeout (");
+      return {
+        jsWorld: timedOut ? "timeout" : "transport-error",
+        helper: "unknown",
+        probeBudgetMs
+      };
+    }
+  }
+  async probeHelperFreshness(timeoutMs = 2e3) {
+    if (!this.isConnected)
+      return { fresh: false, version: null, probed: false };
+    const token2 = this._helperToken;
+    try {
+      const result = await this.evaluateForHelperToken(token2, `typeof globalThis.__RN_AGENT === 'object' && globalThis.__RN_AGENT !== null ? globalThis.__RN_AGENT.__v : null`, timeoutMs);
+      if (!this.isHelperTokenCurrent(token2))
+        return { fresh: false, version: null, probed: true };
+      const version2 = typeof result.value === "number" ? result.value : null;
+      const fresh = version2 === HELPERS_VERSION;
+      if (!fresh) {
+        this.markHelpersUnready(token2, version2 === null ? "freshness_missing" : "freshness_version_mismatch");
+      }
+      return { fresh, version: version2, probed: true };
+    } catch {
+      return { fresh: false, version: null, probed: true };
+    }
+  }
+  invalidateHelperWorld(cause) {
+    this._helperWorldGeneration++;
+    this._helpersInjected = false;
+    this._bridgeDetected = false;
+    this._bridgeVersion = null;
+    this._helperToken = {
+      generation: this._helperWorldGeneration,
+      ws: this.ws,
+      targetId: this._connectedTarget?.id ?? null,
+      contextId: this._helperContext?.id ?? null,
+      contextUniqueId: this._helperContext?.uniqueId ?? null
+    };
+    logger.info("CDP", `Helper state invalidated cause=${cause} helperEpoch=${this._helperWorldGeneration} connectionGeneration=${this._connectionGeneration}`);
+  }
+  isHelperTokenCurrent(token2) {
+    return token2 === this._helperToken && token2.ws === this.ws && token2.targetId === (this._connectedTarget?.id ?? null);
+  }
+  async evaluateCurrentHelperWorld(expression) {
+    const token2 = this._helperToken;
+    try {
+      return await this.evaluateForHelperToken(token2, expression, defaultTimeout(this.effectivePlatform));
+    } catch {
+      return { error: "helper-world evaluation unavailable" };
+    }
+  }
+  async evaluateForHelperToken(token2, expression, timeoutMs) {
+    if (!this.isHelperTokenCurrent(token2))
+      throw new Error("helper world superseded");
+    const params = {
+      expression,
+      returnByValue: true
+    };
+    if (token2.contextId !== null)
+      params.contextId = token2.contextId;
+    const result = await this.sendWithTimeout("Runtime.evaluate", params, timeoutMs);
+    if (!this.isHelperTokenCurrent(token2))
+      throw new Error("helper world superseded");
+    if (result?.exceptionDetails)
+      return { error: "helper-world expression failed" };
+    return { value: result?.result?.value };
+  }
+  async ensureCurrentHelpers(cause) {
+    const token2 = this._helperToken;
+    if (!this.isHelperTokenCurrent(token2) || !this.isConnected)
+      return false;
+    if (this._helpersInjected)
+      return true;
+    if (this._helperInjectionInFlight?.token === token2) {
+      return this._helperInjectionInFlight.promise;
+    }
+    const slot = {
+      token: token2,
+      promise: Promise.resolve(false)
+    };
+    slot.promise = this.injectAndVerifyHelpers(token2, cause).finally(() => {
+      if (this._helperInjectionInFlight === slot)
+        this._helperInjectionInFlight = null;
+    });
+    this._helperInjectionInFlight = slot;
+    return slot.promise;
+  }
+  markHelpersUnready(token2, cause) {
+    if (!this.isHelperTokenCurrent(token2))
+      return false;
+    this._helpersInjected = false;
+    this._bridgeDetected = false;
+    this._bridgeVersion = null;
+    logger.warn("CDP", `Helper state unavailable cause=${cause} helperEpoch=${token2.generation} connectionGeneration=${this._connectionGeneration}`);
+    return false;
+  }
+  async injectAndVerifyHelpers(token2, cause) {
+    logger.info("CDP", `Helper injection ${cause} helperEpoch=${token2.generation} connectionGeneration=${this._connectionGeneration}`);
+    try {
+      const injected = await this.evaluateForHelperToken(token2, INJECTED_HELPERS, defaultTimeout(this.effectivePlatform));
+      if (injected.error) {
+        return this.markHelpersUnready(token2, cause === "setup_started" ? "setup_failed" : "reinject_failed");
+      }
+      const verified = await this.evaluateForHelperToken(token2, `typeof globalThis.__RN_AGENT === 'object' && globalThis.__RN_AGENT !== null && globalThis.__RN_AGENT.__v === ${HELPERS_VERSION}`, defaultTimeout(this.effectivePlatform));
+      if (verified.value !== true || !this.isHelperTokenCurrent(token2)) {
+        return this.markHelpersUnready(token2, cause === "setup_started" ? "setup_failed" : "reinject_failed");
+      }
+      this.markHelpersReady(token2, cause === "setup_started" ? "setup_current" : "reinject_current");
+      return true;
+    } catch {
+      return this.markHelpersUnready(token2, cause === "setup_started" ? "setup_failed" : "reinject_failed");
+    }
+  }
+  markHelpersReady(token2, cause) {
+    if (!this.isHelperTokenCurrent(token2))
+      return;
+    this._helpersInjected = true;
+    setActiveFlag(this._port, this._connectedTarget);
+    logger.info("CDP", `Helper state ready cause=${cause} helperEpoch=${token2.generation} connectionGeneration=${this._connectionGeneration}`);
+    detectBridge(this, (expression) => this.evaluateForHelperToken(token2, expression, defaultTimeout(this.effectivePlatform))).then((r) => {
+      if (!this.isHelperTokenCurrent(token2))
+        return;
+      this._bridgeDetected = r.present;
+      this._bridgeVersion = r.version;
+    }).catch(() => {
+    });
+  }
+  handleExecutionContextCreated(params) {
+    const id = params.context?.id;
+    if (typeof id !== "number" || params.context?.auxData?.isDefault === false)
+      return;
+    const next = { id, uniqueId: params.context?.uniqueId };
+    if (this._helperContext?.id === next.id && this._helperContext.uniqueId === next.uniqueId)
+      return;
+    this._helperContext = next;
+    this.invalidateHelperWorld("context_created");
+  }
+  handleExecutionContextDestroyed(params) {
+    if (!this._helperContext)
+      return;
+    const matchesId = params.executionContextId === this._helperContext.id;
+    const matchesUnique = params.executionContextUniqueId !== void 0 && params.executionContextUniqueId === this._helperContext.uniqueId;
+    if (!matchesId && !matchesUnique)
+      return;
+    this._helperContext = null;
+    this.invalidateHelperWorld("context_destroyed");
+  }
+  handleExecutionContextsCleared() {
+    this._helperContext = null;
+    this.invalidateHelperWorld("contexts_cleared");
   }
   async autoConnect(portHint, filtersOrPlatform, intent = "default") {
     const filters = typeof filtersOrPlatform === "string" ? { platform: filtersOrPlatform } : filtersOrPlatform ?? {};
@@ -52727,6 +52883,7 @@ var CDPClient = class {
     if (this.disposed)
       return;
     this.disposed = true;
+    this.invalidateHelperWorld("explicit_disconnect");
     resetState(this.buildResettableState());
     clearActiveFlag();
     this.stopBackgroundPoll();
@@ -52849,8 +53006,11 @@ var CDPClient = class {
     const result = await performSetup({
       send: (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)),
       evaluate: (expr) => this.evaluate(expr),
+      setupHelpers: async (waitTimeout) => {
+        await waitForReact((expr) => this.evaluateCurrentHelperWorld(expr), waitTimeout);
+        return this.ensureCurrentHelpers("setup_started");
+      },
       port: this._port,
-      connectedTarget: this._connectedTarget,
       networkManager: this._networkBufferManager,
       getDeviceKey: () => this.activeDeviceKey,
       setupEventHandlers: () => this.setupEventHandlers(),
@@ -52858,18 +53018,9 @@ var CDPClient = class {
       clearEventHandlers: () => this.eventHandlers.clear()
     });
     this._networkMode = result.networkMode;
-    this._helpersInjected = result.helpersInjected;
     this._logDomainEnabled = result.logDomainEnabled;
     this._profilerAvailable = result.profilerAvailable;
     this._heapProfilerAvailable = result.heapProfilerAvailable;
-    if (result.helpersInjected) {
-      detectBridge(this).then((r) => {
-        this._bridgeDetected = r.present;
-        this._bridgeVersion = r.version;
-        logger.debug("CDP", `Bridge detection: present=${r.present}, version=${r.version}`);
-      }).catch(() => {
-      });
-    }
   }
   async ensureMetroEventsClient() {
     if (this._metroEventsClient && this._metroEventsClient.port !== this._port) {
@@ -52889,9 +53040,15 @@ var CDPClient = class {
       scripts: this._scripts
     }, (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)), () => this._isPaused, (v) => {
       this._isPaused = v;
-    }, () => this.activeDeviceKey);
+    }, () => this.activeDeviceKey, {
+      created: (params) => this.handleExecutionContextCreated(params),
+      destroyed: (params) => this.handleExecutionContextDestroyed(params),
+      cleared: () => this.handleExecutionContextsCleared()
+    });
   }
   handleClose(code) {
+    this.ws = null;
+    this.invalidateHelperWorld("socket_closed");
     if (this._proxyUrl) {
       void this._suspendProxy();
     }
@@ -52932,6 +53089,8 @@ var CDPClient = class {
             this.ws.close();
           }
           this.ws = null;
+          this._helperContext = null;
+          this.invalidateHelperWorld("soft_reconnect");
         }
       },
       rejectAllPending: (reason) => this.rejectAllPending(reason),
@@ -52969,13 +53128,21 @@ var CDPClient = class {
       },
       getWs: () => this.ws,
       setWs: (ws) => {
+        if (this.ws === ws)
+          return;
         this.ws = ws;
+        this._helperContext = null;
+        this.invalidateHelperWorld(ws ? "socket_opened" : "socket_closed");
       },
       setHelpersInjected: (v) => {
-        this._helpersInjected = v;
+        if (!v)
+          this.invalidateHelperWorld("candidate_rejected");
       },
       setConnectedTarget: (t) => {
+        if (this._connectedTarget === t)
+          return;
         this._connectedTarget = t;
+        this.invalidateHelperWorld(t ? "candidate_selected" : "candidate_rejected");
       },
       setConnectedAt: (ms) => {
         this._connectedAt = ms;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -52290,8 +52290,6 @@ async function connectToTarget(ctx, target, retries = 5, intent = "default") {
       await ctx.setup();
       return;
     } catch (err) {
-      if (err instanceof ConnectionSetupSupersededError)
-        throw err;
       if (err instanceof PickerBlockingBundleError) {
         if (!closeConnectionAttempt(ctx, attemptWs)) {
           throw new ConnectionSetupSupersededError();
@@ -52303,6 +52301,8 @@ async function connectToTarget(ctx, target, retries = 5, intent = "default") {
       lastError = err instanceof Error ? err : new Error(String(err));
       attempts3.push({ handshakeOk, probeTimedOut });
       if (!closeConnectionAttempt(ctx, attemptWs)) {
+        if (err instanceof ConnectionSetupSupersededError)
+          throw err;
         throw new ConnectionSetupSupersededError();
       }
       if (lastError.message.includes("refused")) {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -52606,6 +52606,7 @@ var CDPClient = class {
       }
       return { fresh, version: version2, probed: true };
     } catch {
+      this.markHelpersUnready(token2, "freshness_probe_failed");
       return { fresh: false, version: null, probed: true };
     }
   }
@@ -52614,6 +52615,7 @@ var CDPClient = class {
     this._helpersInjected = false;
     this._bridgeDetected = false;
     this._bridgeVersion = null;
+    clearActiveFlag();
     this._helperToken = {
       generation: this._helperWorldGeneration,
       ws: this.ws,
@@ -52676,6 +52678,7 @@ var CDPClient = class {
     this._helpersInjected = false;
     this._bridgeDetected = false;
     this._bridgeVersion = null;
+    clearActiveFlag();
     logger.warn("CDP", `Helper state unavailable cause=${cause} helperEpoch=${token2.generation} connectionGeneration=${this._connectionGeneration}`);
     return false;
   }
@@ -53003,12 +53006,38 @@ var CDPClient = class {
   async setup() {
     this.ensureMetroEventsClient().catch(() => {
     });
+    const setupWs = this.ws;
+    const setupTargetId = this._connectedTarget?.id ?? null;
+    let setupHelperToken = null;
+    const assertSetupCurrent = () => {
+      const connectionIsCurrent = this.ws === setupWs && (this._connectedTarget?.id ?? null) === setupTargetId;
+      const helpersAreCurrent = setupHelperToken === null || this.isHelperTokenCurrent(setupHelperToken);
+      if (!connectionIsCurrent || !helpersAreCurrent)
+        throw new Error("setup superseded");
+    };
+    const sendForSetup = async (method, params, ms) => {
+      assertSetupCurrent();
+      const response = await this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform));
+      assertSetupCurrent();
+      return response;
+    };
+    const evaluateForSetup = async (expression) => {
+      assertSetupCurrent();
+      const response = await this.evaluate(expression);
+      assertSetupCurrent();
+      return response;
+    };
     const result = await performSetup({
-      send: (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)),
-      evaluate: (expr) => this.evaluate(expr),
+      send: sendForSetup,
+      evaluate: evaluateForSetup,
       setupHelpers: async (waitTimeout) => {
+        assertSetupCurrent();
         await waitForReact((expr) => this.evaluateCurrentHelperWorld(expr), waitTimeout);
-        return this.ensureCurrentHelpers("setup_started");
+        assertSetupCurrent();
+        setupHelperToken = this._helperToken;
+        const helpersInjected = await this.ensureCurrentHelpers("setup_started");
+        assertSetupCurrent();
+        return helpersInjected;
       },
       port: this._port,
       networkManager: this._networkBufferManager,
@@ -53017,6 +53046,7 @@ var CDPClient = class {
       clearScripts: () => this._scripts.clear(),
       clearEventHandlers: () => this.eventHandlers.clear()
     });
+    assertSetupCurrent();
     this._networkMode = result.networkMode;
     this._logDomainEnabled = result.logDomainEnabled;
     this._profilerAvailable = result.profilerAvailable;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -52132,6 +52132,12 @@ var PickerBlockingBundleError = class extends Error {
     this.target = target;
   }
 };
+var ConnectionSetupSupersededError = class extends Error {
+  constructor() {
+    super("Connection setup superseded");
+    this.name = "ConnectionSetupSupersededError";
+  }
+};
 function shouldRunPickerProbe(intent, target) {
   return intent === "status" && target.vm !== "Hermes";
 }
@@ -52211,6 +52217,8 @@ async function discoverAndConnect(ctx, portHint, filters, discoverFn = discover,
       console.error("CDP: no target with __DEV__=true found, using last available target");
       connectedTarget = candidate;
     } catch (err) {
+      if (err instanceof ConnectionSetupSupersededError)
+        throw err;
       if (err instanceof PickerBlockingBundleError) {
         ctx.setState("disconnected");
         throw err;
@@ -52254,13 +52262,14 @@ async function connectToTarget(ctx, target, retries = 5, intent = "default") {
     }
     let handshakeOk = false;
     let probeTimedOut = false;
+    let attemptWs = null;
     try {
       const proxyUrl = ctx.getProxyUrl();
       const url = proxyUrl ?? target.webSocketDebuggerUrl;
       if (proxyUrl) {
         logger.info("CDP", `Routing via multiplexer proxy: ${proxyUrl}`);
       }
-      await connectWs(ctx, url);
+      attemptWs = await connectWs(ctx, url);
       handshakeOk = true;
       try {
         await ctx.sendWithTimeout("Runtime.evaluate", {
@@ -52281,15 +52290,21 @@ async function connectToTarget(ctx, target, retries = 5, intent = "default") {
       await ctx.setup();
       return;
     } catch (err) {
+      if (err instanceof ConnectionSetupSupersededError)
+        throw err;
       if (err instanceof PickerBlockingBundleError) {
-        closeAndResetWs(ctx);
+        if (!closeConnectionAttempt(ctx, attemptWs)) {
+          throw new ConnectionSetupSupersededError();
+        }
         ctx.setConnectedTarget(null);
         ctx.setState("disconnected");
         throw err;
       }
       lastError = err instanceof Error ? err : new Error(String(err));
       attempts3.push({ handshakeOk, probeTimedOut });
-      closeAndResetWs(ctx);
+      if (!closeConnectionAttempt(ctx, attemptWs)) {
+        throw new ConnectionSetupSupersededError();
+      }
       if (lastError.message.includes("refused")) {
         ctx.setState("disconnected");
         throw new Error("CDP connection refused. Is Metro running and the app loaded?");
@@ -52324,7 +52339,7 @@ function connectWs(ctx, url) {
       clearTimeout(guard);
       ctx.setWs(ws);
       ctx.setState("connected");
-      resolve10();
+      resolve10(ws);
     });
     ws.on("error", (err) => {
       if (!settled) {
@@ -52365,6 +52380,18 @@ function closeAndResetWs(ctx) {
     }
     ctx.setWs(null);
   }
+}
+function closeConnectionAttempt(ctx, attemptWs) {
+  if (ctx.getWs() !== attemptWs)
+    return false;
+  if (!attemptWs)
+    return true;
+  attemptWs.removeAllListeners();
+  if (attemptWs.readyState === wrapper_default.OPEN || attemptWs.readyState === wrapper_default.CONNECTING) {
+    attemptWs.close();
+  }
+  ctx.setWs(null);
+  return true;
 }
 
 // packages/rn-dev-agent-core/dist/cdp-client.js
@@ -53012,8 +53039,9 @@ var CDPClient = class {
     const assertSetupCurrent = () => {
       const connectionIsCurrent = this.ws === setupWs && (this._connectedTarget?.id ?? null) === setupTargetId;
       const helpersAreCurrent = setupHelperToken === null || this.isHelperTokenCurrent(setupHelperToken);
-      if (!connectionIsCurrent || !helpersAreCurrent)
-        throw new Error("setup superseded");
+      if (!connectionIsCurrent || !helpersAreCurrent) {
+        throw new ConnectionSetupSupersededError();
+      }
     };
     const sendForSetup = async (method, params, ms) => {
       assertSetupCurrent();

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -56634,6 +56634,8 @@ async function discoverAndConnect(ctx, portHint, filters, discoverFn = discover,
       console.error("CDP: no target with __DEV__=true found, using last available target");
       connectedTarget = candidate;
     } catch (err) {
+      if (err instanceof ConnectionSetupSupersededError)
+        throw err;
       if (err instanceof PickerBlockingBundleError) {
         ctx.setState("disconnected");
         throw err;
@@ -56677,13 +56679,14 @@ async function connectToTarget(ctx, target, retries = 5, intent = "default") {
     }
     let handshakeOk = false;
     let probeTimedOut = false;
+    let attemptWs = null;
     try {
       const proxyUrl = ctx.getProxyUrl();
       const url = proxyUrl ?? target.webSocketDebuggerUrl;
       if (proxyUrl) {
         logger.info("CDP", `Routing via multiplexer proxy: ${proxyUrl}`);
       }
-      await connectWs(ctx, url);
+      attemptWs = await connectWs(ctx, url);
       handshakeOk = true;
       try {
         await ctx.sendWithTimeout("Runtime.evaluate", {
@@ -56704,15 +56707,21 @@ async function connectToTarget(ctx, target, retries = 5, intent = "default") {
       await ctx.setup();
       return;
     } catch (err) {
+      if (err instanceof ConnectionSetupSupersededError)
+        throw err;
       if (err instanceof PickerBlockingBundleError) {
-        closeAndResetWs(ctx);
+        if (!closeConnectionAttempt(ctx, attemptWs)) {
+          throw new ConnectionSetupSupersededError();
+        }
         ctx.setConnectedTarget(null);
         ctx.setState("disconnected");
         throw err;
       }
       lastError = err instanceof Error ? err : new Error(String(err));
       attempts3.push({ handshakeOk, probeTimedOut });
-      closeAndResetWs(ctx);
+      if (!closeConnectionAttempt(ctx, attemptWs)) {
+        throw new ConnectionSetupSupersededError();
+      }
       if (lastError.message.includes("refused")) {
         ctx.setState("disconnected");
         throw new Error("CDP connection refused. Is Metro running and the app loaded?");
@@ -56747,7 +56756,7 @@ function connectWs(ctx, url) {
       clearTimeout(guard);
       ctx.setWs(ws);
       ctx.setState("connected");
-      resolve11();
+      resolve11(ws);
     });
     ws.on("error", (err) => {
       if (!settled) {
@@ -56789,7 +56798,19 @@ function closeAndResetWs(ctx) {
     ctx.setWs(null);
   }
 }
-var PICKER_PROBE_BUDGET_MS, PickerBlockingBundleError;
+function closeConnectionAttempt(ctx, attemptWs) {
+  if (ctx.getWs() !== attemptWs)
+    return false;
+  if (!attemptWs)
+    return true;
+  attemptWs.removeAllListeners();
+  if (attemptWs.readyState === wrapper_default.OPEN || attemptWs.readyState === wrapper_default.CONNECTING) {
+    attemptWs.close();
+  }
+  ctx.setWs(null);
+  return true;
+}
+var PICKER_PROBE_BUDGET_MS, PickerBlockingBundleError, ConnectionSetupSupersededError;
 var init_connect = __esm({
   "packages/rn-dev-agent-core/dist/cdp/connect.js"() {
     "use strict";
@@ -56811,6 +56832,12 @@ var init_connect = __esm({
         super(`Dev Client picker appears to be blocking the bundle: React was not reachable on target "${target.title}" (vm=${target.vm}). If the Expo "Development servers" picker is showing on the simulator, select your Metro server, then retry cdp_status. (If the bundle is still building, just retry.)`);
         this.name = "PickerBlockingBundleError";
         this.target = target;
+      }
+    };
+    ConnectionSetupSupersededError = class extends Error {
+      constructor() {
+        super("Connection setup superseded");
+        this.name = "ConnectionSetupSupersededError";
       }
     };
   }
@@ -57482,8 +57509,9 @@ var init_cdp_client = __esm({
         const assertSetupCurrent = () => {
           const connectionIsCurrent = this.ws === setupWs && (this._connectedTarget?.id ?? null) === setupTargetId;
           const helpersAreCurrent = setupHelperToken === null || this.isHelperTokenCurrent(setupHelperToken);
-          if (!connectionIsCurrent || !helpersAreCurrent)
-            throw new Error("setup superseded");
+          if (!connectionIsCurrent || !helpersAreCurrent) {
+            throw new ConnectionSetupSupersededError();
+          }
         };
         const sendForSetup = async (method, params, ms) => {
           assertSetupCurrent();

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -57076,6 +57076,7 @@ var init_cdp_client = __esm({
           }
           return { fresh, version: version2, probed: true };
         } catch {
+          this.markHelpersUnready(token2, "freshness_probe_failed");
           return { fresh: false, version: null, probed: true };
         }
       }
@@ -57084,6 +57085,7 @@ var init_cdp_client = __esm({
         this._helpersInjected = false;
         this._bridgeDetected = false;
         this._bridgeVersion = null;
+        clearActiveFlag();
         this._helperToken = {
           generation: this._helperWorldGeneration,
           ws: this.ws,
@@ -57146,6 +57148,7 @@ var init_cdp_client = __esm({
         this._helpersInjected = false;
         this._bridgeDetected = false;
         this._bridgeVersion = null;
+        clearActiveFlag();
         logger.warn("CDP", `Helper state unavailable cause=${cause} helperEpoch=${token2.generation} connectionGeneration=${this._connectionGeneration}`);
         return false;
       }
@@ -57473,12 +57476,38 @@ var init_cdp_client = __esm({
       async setup() {
         this.ensureMetroEventsClient().catch(() => {
         });
+        const setupWs = this.ws;
+        const setupTargetId = this._connectedTarget?.id ?? null;
+        let setupHelperToken = null;
+        const assertSetupCurrent = () => {
+          const connectionIsCurrent = this.ws === setupWs && (this._connectedTarget?.id ?? null) === setupTargetId;
+          const helpersAreCurrent = setupHelperToken === null || this.isHelperTokenCurrent(setupHelperToken);
+          if (!connectionIsCurrent || !helpersAreCurrent)
+            throw new Error("setup superseded");
+        };
+        const sendForSetup = async (method, params, ms) => {
+          assertSetupCurrent();
+          const response = await this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform));
+          assertSetupCurrent();
+          return response;
+        };
+        const evaluateForSetup = async (expression) => {
+          assertSetupCurrent();
+          const response = await this.evaluate(expression);
+          assertSetupCurrent();
+          return response;
+        };
         const result = await performSetup({
-          send: (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)),
-          evaluate: (expr) => this.evaluate(expr),
+          send: sendForSetup,
+          evaluate: evaluateForSetup,
           setupHelpers: async (waitTimeout) => {
+            assertSetupCurrent();
             await waitForReact((expr) => this.evaluateCurrentHelperWorld(expr), waitTimeout);
-            return this.ensureCurrentHelpers("setup_started");
+            assertSetupCurrent();
+            setupHelperToken = this._helperToken;
+            const helpersInjected = await this.ensureCurrentHelpers("setup_started");
+            assertSetupCurrent();
+            return helpersInjected;
           },
           port: this._port,
           networkManager: this._networkBufferManager,
@@ -57487,6 +57516,7 @@ var init_cdp_client = __esm({
           clearScripts: () => this._scripts.clear(),
           clearEventHandlers: () => this.eventHandlers.clear()
         });
+        assertSetupCurrent();
         this._networkMode = result.networkMode;
         this._logDomainEnabled = result.logDomainEnabled;
         this._profilerAvailable = result.profilerAvailable;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -56707,8 +56707,6 @@ async function connectToTarget(ctx, target, retries = 5, intent = "default") {
       await ctx.setup();
       return;
     } catch (err) {
-      if (err instanceof ConnectionSetupSupersededError)
-        throw err;
       if (err instanceof PickerBlockingBundleError) {
         if (!closeConnectionAttempt(ctx, attemptWs)) {
           throw new ConnectionSetupSupersededError();
@@ -56720,6 +56718,8 @@ async function connectToTarget(ctx, target, retries = 5, intent = "default") {
       lastError = err instanceof Error ? err : new Error(String(err));
       attempts3.push({ handshakeOk, probeTimedOut });
       if (!closeConnectionAttempt(ctx, attemptWs)) {
+        if (err instanceof ConnectionSetupSupersededError)
+          throw err;
         throw new ConnectionSetupSupersededError();
       }
       if (lastError.message.includes("refused")) {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -15093,31 +15093,7 @@ function consumeCdpStale() {
   return was;
 }
 async function probeFreshness(client2, timeoutMs = FRESHNESS_PROBE_MS) {
-  if (!client2.isConnected) {
-    return { fresh: false, version: null, probed: false };
-  }
-  let probeTimer;
-  try {
-    const evalPromise = client2.evaluate('typeof globalThis.__RN_AGENT === "object" && globalThis.__RN_AGENT.__v');
-    evalPromise.catch(() => {
-    });
-    const result = await Promise.race([
-      evalPromise,
-      new Promise((resolve11) => {
-        probeTimer = setTimeout(() => resolve11({ error: "timeout" }), timeoutMs);
-      })
-    ]);
-    if (probeTimer)
-      clearTimeout(probeTimer);
-    if (result.error || typeof result.value !== "number") {
-      return { fresh: false, version: null, probed: true };
-    }
-    return { fresh: true, version: result.value, probed: true };
-  } catch {
-    if (probeTimer)
-      clearTimeout(probeTimer);
-    return { fresh: false, version: null, probed: true };
-  }
+  return client2.probeHelperFreshness(timeoutMs);
 }
 async function recoverFromStaleTarget(client2) {
   if (!client2.isConnected) {
@@ -22874,18 +22850,28 @@ function isFreshnessCached(client2) {
   const entry = freshnessCache.get(client2);
   if (!entry)
     return false;
-  if (entry.generation !== client2.connectionGeneration)
+  if (entry.generation !== client2.helperWorldGeneration)
     return false;
   return Date.now() < entry.expiresAt;
 }
 function rememberFreshness(client2) {
   freshnessCache.set(client2, {
-    generation: client2.connectionGeneration,
+    generation: client2.helperWorldGeneration,
     expiresAt: Date.now() + FRESHNESS_CACHE_MS
   });
 }
 function forgetFreshness(client2) {
   freshnessCache.delete(client2);
+}
+async function helpersNotInjectedResult(client2, boundary) {
+  const helperHealth = await client2.probeHelperHealth(2e3);
+  if (helperHealth.jsWorld === "responsive" && helperHealth.helper === "current") {
+    rememberFreshness(client2);
+    return null;
+  }
+  forgetFreshness(client2);
+  const message = helperHealth.jsWorld === "timeout" ? `Helpers are not ready and the bounded ${helperHealth.probeBudgetMs}ms health probe received no response; JavaScript may be busy, paused, or blocked.` : helperHealth.jsWorld === "transport-error" ? "Helpers are not ready and their health could not be measured because the CDP transport failed." : helperHealth.jsWorld === "superseded" ? "Helpers are not ready because the JavaScript execution world changed during the bounded health probe." : helperHealth.helper === "version-mismatch" ? "Helpers are not ready because the responsive JavaScript world contains a different helper version." : helperHealth.helper === "missing" ? "Helpers are not ready because they are missing from the responsive JavaScript world." : "Helpers are not ready because the responsive JavaScript world contains an invalid helper value.";
+  return failResult(`${boundary === "stale-recovery" ? "Stale target recovery completed, but " : ""}${message} Fall back to device_* tools or call cdp_reload once.`, "HELPERS_NOT_INJECTED", { helperHealth });
 }
 function createStepTimer() {
   let last = Date.now();
@@ -22974,7 +22960,9 @@ function withConnection(getClient2, handler, options = {}) {
             }
           }
           if (!client2.helpersInjected) {
-            return failResult("Connected but helpers still not injected after passive wait, active re-inject, and Dev Client picker dismissal. The JS world may be hung. Fall back to device_* tools (XCTest path \u2014 no helpers required) or call cdp_reload to restart the bundle.", "HELPERS_NOT_INJECTED");
+            const helperError = await helpersNotInjectedResult(client2, "initial");
+            if (helperError)
+              return helperError;
           }
         }
       }
@@ -23062,7 +23050,14 @@ function withConnection(getClient2, handler, options = {}) {
               return failResult(`Retry after stale-target recovery failed: ${retryMsg}`, "STALE_TARGET", { originalError: message });
             }
           }
-          return failResult("Stale target recovery: reconnected but helpers not injected.", "HELPERS_NOT_INJECTED", { originalError: message });
+          const helperError = await helpersNotInjectedResult(client2, "stale-recovery");
+          if (helperError)
+            return helperError;
+          try {
+            return await handler(args, client2);
+          } catch {
+            return failResult("Retry after stale-target helper reconciliation failed.", "STALE_TARGET");
+          }
         }
         if (recovery.reason === "reconnect-failed") {
           return failResult(`Stale target recovery failed: ${recovery.error}`, "STALE_TARGET", {
@@ -53046,9 +53041,9 @@ var init_multiplexer = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/bridge-detector.js
-async function detectBridge(client2) {
+async function detectBridge(client2, evaluate = (expression) => client2.evaluate(expression)) {
   try {
-    const result = await client2.evaluate(DETECT_EXPRESSION);
+    const result = await evaluate(DETECT_EXPRESSION);
     if (result.value && typeof result.value === "string") {
       return JSON.parse(result.value);
     }
@@ -56195,7 +56190,10 @@ var init_timeout_config = __esm({
 
 // packages/rn-dev-agent-core/dist/cdp/setup.js
 async function performSetup(opts) {
-  const { send, evaluate, port, connectedTarget, networkManager, getDeviceKey, setupEventHandlers, clearScripts, clearEventHandlers, probeWaits } = opts;
+  const { send, evaluate, setupHelpers, port, networkManager, getDeviceKey, setupEventHandlers, clearScripts, clearEventHandlers, probeWaits } = opts;
+  clearEventHandlers();
+  clearScripts();
+  setupEventHandlers();
   logger.debug("CDP", "Running setup: Runtime.enable, Debugger.enable...");
   await send("Runtime.enable", void 0, timeoutForMethod("Runtime.enable"));
   await send("Debugger.enable", void 0, timeoutForMethod("Debugger.enable"));
@@ -56221,24 +56219,8 @@ async function performSetup(opts) {
   ]);
   const profilerAvailable = profilerProbe.status === "fulfilled" && profilerProbe.value === true;
   const heapProfilerAvailable = heapProbe.status === "fulfilled" && heapProbe.value === true;
-  clearEventHandlers();
-  clearScripts();
-  setupEventHandlers();
-  await waitForReact(evaluate, REACT_READY_TIMEOUT_MS);
-  const helperResult = await evaluate(INJECTED_HELPERS);
-  if (helperResult.error) {
-    console.error("CDP: failed to inject helpers:", helperResult.error);
-    return {
-      networkMode,
-      helpersInjected: false,
-      logDomainEnabled,
-      profilerAvailable,
-      heapProfilerAvailable
-    };
-  }
-  const verify = await evaluate('typeof globalThis.__RN_AGENT === "object"');
-  if (verify.value !== true) {
-    console.error("CDP: helper injection succeeded but __RN_AGENT not found");
+  const helpersInjected = await setupHelpers(REACT_READY_TIMEOUT_MS);
+  if (!helpersInjected) {
     return {
       networkMode,
       helpersInjected: false,
@@ -56255,8 +56237,7 @@ async function performSetup(opts) {
     }
     networkDomainEnabled = false;
   }
-  logger.info("CDP", `Helpers injected (v${HELPERS_VERSION}), network mode: ${networkMode}`);
-  setActiveFlag(port, connectedTarget);
+  logger.info("CDP", `Helpers current (v${HELPERS_VERSION}), network mode: ${networkMode}`);
   if (networkMode === "cdp") {
     networkMode = await probeNetworkDomain({
       evaluate,
@@ -56304,19 +56285,6 @@ async function probeNetworkDomain(opts) {
   }
   logger.info("CDP", `Network.enable accepted but no events fired after ${waits.length} attempt(s) \u2014 falling back to hooks`);
   return "none";
-}
-async function reinjectHelpers(evaluate, waitTimeout) {
-  await waitForReact(evaluate, waitTimeout ?? REACT_READY_TIMEOUT_MS);
-  const helperResult = await evaluate(INJECTED_HELPERS);
-  if (helperResult.error) {
-    console.error("CDP: failed to re-inject helpers:", helperResult.error);
-    return false;
-  }
-  const verify = await evaluate('typeof globalThis.__RN_AGENT === "object"');
-  if (verify.value !== true) {
-    return false;
-  }
-  return true;
 }
 async function probeReactReachable(evaluate, budgetMs, pollMs = REACT_READY_POLL_MS) {
   const start = Date.now();
@@ -56426,7 +56394,16 @@ var init_transport = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/cdp/event-handlers.js
-function wireEventHandlers(eventHandlers, buffers, sendFn, getIsPaused, setIsPaused, getDeviceKey) {
+function wireEventHandlers(eventHandlers, buffers, sendFn, getIsPaused, setIsPaused, getDeviceKey, executionContexts) {
+  if (executionContexts) {
+    eventHandlers.set("Runtime.executionContextCreated", (params) => {
+      executionContexts.created(params);
+    });
+    eventHandlers.set("Runtime.executionContextDestroyed", (params) => {
+      executionContexts.destroyed(params);
+    });
+    eventHandlers.set("Runtime.executionContextsCleared", () => executionContexts.cleared());
+  }
   eventHandlers.set("Runtime.consoleAPICalled", (params) => {
     const p = params;
     const text = p.args?.map((a) => a.value !== void 0 ? String(a.value) : a.description ?? "").join(" ") ?? "";
@@ -56852,6 +56829,7 @@ var init_cdp_client = __esm({
     init_bridge_detector();
     init_logger();
     init_setup();
+    init_injected_helpers();
     init_state();
     init_timeout_config();
     init_transport();
@@ -56877,6 +56855,16 @@ var init_cdp_client = __esm({
       reconnecting = false;
       disposed = false;
       _helpersInjected = false;
+      _helperWorldGeneration = 0;
+      _helperContext = null;
+      _helperToken = {
+        generation: 0,
+        ws: null,
+        targetId: null,
+        contextId: null,
+        contextUniqueId: null
+      };
+      _helperInjectionInFlight = null;
       _networkMode = "none";
       _isPaused = false;
       _connectedTarget = null;
@@ -56936,6 +56924,10 @@ var init_cdp_client = __esm({
       }
       get helpersInjected() {
         return this._helpersInjected;
+      }
+      /** Private helper-world epoch exposed only for process-local cache identity. */
+      get helperWorldGeneration() {
+        return this._helperWorldGeneration;
       }
       get metroPort() {
         return this._port;
@@ -57035,17 +57027,182 @@ var init_cdp_client = __esm({
       async reinjectHelpers(waitTimeout) {
         if (!this.isConnected)
           return false;
-        const ok = await reinjectHelpers((expr) => this.evaluate(expr), waitTimeout);
-        this._helpersInjected = ok;
-        if (ok) {
-          setActiveFlag(this._port, this._connectedTarget);
-          detectBridge(this).then((r) => {
-            this._bridgeDetected = r.present;
-            this._bridgeVersion = r.version;
-          }).catch(() => {
-          });
+        await waitForReact((expr) => this.evaluateCurrentHelperWorld(expr), waitTimeout);
+        return this.ensureCurrentHelpers("reinject_started");
+      }
+      /**
+       * One bounded, context-pinned health read used only at final
+       * HELPERS_NOT_INJECTED boundaries. It never returns app values or errors.
+       */
+      async probeHelperHealth(probeBudgetMs = 2e3) {
+        const token2 = this._helperToken;
+        if (!this.isHelperTokenCurrent(token2)) {
+          return { jsWorld: "superseded", helper: "unknown", probeBudgetMs };
         }
-        return ok;
+        const expression = `(function(){try{var d=Object.getOwnPropertyDescriptor(globalThis,'__RN_AGENT');if(!d)return 'missing';if(!('value' in d)||typeof d.value!=='object'||d.value===null)return 'invalid';var v=Object.getOwnPropertyDescriptor(d.value,'__v');if(!v||!('value' in v)||typeof v.value!=='number')return 'invalid';return v.value===${HELPERS_VERSION}?'current':'version-mismatch';}catch(_){return 'invalid';}})()`;
+        try {
+          const result = await this.evaluateForHelperToken(token2, expression, probeBudgetMs);
+          if (!this.isHelperTokenCurrent(token2)) {
+            return { jsWorld: "superseded", helper: "unknown", probeBudgetMs };
+          }
+          const helper = result.value === "current" || result.value === "missing" || result.value === "version-mismatch" || result.value === "invalid" ? result.value : "invalid";
+          if (helper === "current")
+            this.markHelpersReady(token2, "health_reconciled_current");
+          return { jsWorld: "responsive", helper, probeBudgetMs };
+        } catch (err) {
+          if (!this.isHelperTokenCurrent(token2)) {
+            return { jsWorld: "superseded", helper: "unknown", probeBudgetMs };
+          }
+          const timedOut = err instanceof Error && err.message.startsWith("CDP timeout (");
+          return {
+            jsWorld: timedOut ? "timeout" : "transport-error",
+            helper: "unknown",
+            probeBudgetMs
+          };
+        }
+      }
+      async probeHelperFreshness(timeoutMs = 2e3) {
+        if (!this.isConnected)
+          return { fresh: false, version: null, probed: false };
+        const token2 = this._helperToken;
+        try {
+          const result = await this.evaluateForHelperToken(token2, `typeof globalThis.__RN_AGENT === 'object' && globalThis.__RN_AGENT !== null ? globalThis.__RN_AGENT.__v : null`, timeoutMs);
+          if (!this.isHelperTokenCurrent(token2))
+            return { fresh: false, version: null, probed: true };
+          const version2 = typeof result.value === "number" ? result.value : null;
+          const fresh = version2 === HELPERS_VERSION;
+          if (!fresh) {
+            this.markHelpersUnready(token2, version2 === null ? "freshness_missing" : "freshness_version_mismatch");
+          }
+          return { fresh, version: version2, probed: true };
+        } catch {
+          return { fresh: false, version: null, probed: true };
+        }
+      }
+      invalidateHelperWorld(cause) {
+        this._helperWorldGeneration++;
+        this._helpersInjected = false;
+        this._bridgeDetected = false;
+        this._bridgeVersion = null;
+        this._helperToken = {
+          generation: this._helperWorldGeneration,
+          ws: this.ws,
+          targetId: this._connectedTarget?.id ?? null,
+          contextId: this._helperContext?.id ?? null,
+          contextUniqueId: this._helperContext?.uniqueId ?? null
+        };
+        logger.info("CDP", `Helper state invalidated cause=${cause} helperEpoch=${this._helperWorldGeneration} connectionGeneration=${this._connectionGeneration}`);
+      }
+      isHelperTokenCurrent(token2) {
+        return token2 === this._helperToken && token2.ws === this.ws && token2.targetId === (this._connectedTarget?.id ?? null);
+      }
+      async evaluateCurrentHelperWorld(expression) {
+        const token2 = this._helperToken;
+        try {
+          return await this.evaluateForHelperToken(token2, expression, defaultTimeout(this.effectivePlatform));
+        } catch {
+          return { error: "helper-world evaluation unavailable" };
+        }
+      }
+      async evaluateForHelperToken(token2, expression, timeoutMs) {
+        if (!this.isHelperTokenCurrent(token2))
+          throw new Error("helper world superseded");
+        const params = {
+          expression,
+          returnByValue: true
+        };
+        if (token2.contextId !== null)
+          params.contextId = token2.contextId;
+        const result = await this.sendWithTimeout("Runtime.evaluate", params, timeoutMs);
+        if (!this.isHelperTokenCurrent(token2))
+          throw new Error("helper world superseded");
+        if (result?.exceptionDetails)
+          return { error: "helper-world expression failed" };
+        return { value: result?.result?.value };
+      }
+      async ensureCurrentHelpers(cause) {
+        const token2 = this._helperToken;
+        if (!this.isHelperTokenCurrent(token2) || !this.isConnected)
+          return false;
+        if (this._helpersInjected)
+          return true;
+        if (this._helperInjectionInFlight?.token === token2) {
+          return this._helperInjectionInFlight.promise;
+        }
+        const slot = {
+          token: token2,
+          promise: Promise.resolve(false)
+        };
+        slot.promise = this.injectAndVerifyHelpers(token2, cause).finally(() => {
+          if (this._helperInjectionInFlight === slot)
+            this._helperInjectionInFlight = null;
+        });
+        this._helperInjectionInFlight = slot;
+        return slot.promise;
+      }
+      markHelpersUnready(token2, cause) {
+        if (!this.isHelperTokenCurrent(token2))
+          return false;
+        this._helpersInjected = false;
+        this._bridgeDetected = false;
+        this._bridgeVersion = null;
+        logger.warn("CDP", `Helper state unavailable cause=${cause} helperEpoch=${token2.generation} connectionGeneration=${this._connectionGeneration}`);
+        return false;
+      }
+      async injectAndVerifyHelpers(token2, cause) {
+        logger.info("CDP", `Helper injection ${cause} helperEpoch=${token2.generation} connectionGeneration=${this._connectionGeneration}`);
+        try {
+          const injected = await this.evaluateForHelperToken(token2, INJECTED_HELPERS, defaultTimeout(this.effectivePlatform));
+          if (injected.error) {
+            return this.markHelpersUnready(token2, cause === "setup_started" ? "setup_failed" : "reinject_failed");
+          }
+          const verified = await this.evaluateForHelperToken(token2, `typeof globalThis.__RN_AGENT === 'object' && globalThis.__RN_AGENT !== null && globalThis.__RN_AGENT.__v === ${HELPERS_VERSION}`, defaultTimeout(this.effectivePlatform));
+          if (verified.value !== true || !this.isHelperTokenCurrent(token2)) {
+            return this.markHelpersUnready(token2, cause === "setup_started" ? "setup_failed" : "reinject_failed");
+          }
+          this.markHelpersReady(token2, cause === "setup_started" ? "setup_current" : "reinject_current");
+          return true;
+        } catch {
+          return this.markHelpersUnready(token2, cause === "setup_started" ? "setup_failed" : "reinject_failed");
+        }
+      }
+      markHelpersReady(token2, cause) {
+        if (!this.isHelperTokenCurrent(token2))
+          return;
+        this._helpersInjected = true;
+        setActiveFlag(this._port, this._connectedTarget);
+        logger.info("CDP", `Helper state ready cause=${cause} helperEpoch=${token2.generation} connectionGeneration=${this._connectionGeneration}`);
+        detectBridge(this, (expression) => this.evaluateForHelperToken(token2, expression, defaultTimeout(this.effectivePlatform))).then((r) => {
+          if (!this.isHelperTokenCurrent(token2))
+            return;
+          this._bridgeDetected = r.present;
+          this._bridgeVersion = r.version;
+        }).catch(() => {
+        });
+      }
+      handleExecutionContextCreated(params) {
+        const id = params.context?.id;
+        if (typeof id !== "number" || params.context?.auxData?.isDefault === false)
+          return;
+        const next = { id, uniqueId: params.context?.uniqueId };
+        if (this._helperContext?.id === next.id && this._helperContext.uniqueId === next.uniqueId)
+          return;
+        this._helperContext = next;
+        this.invalidateHelperWorld("context_created");
+      }
+      handleExecutionContextDestroyed(params) {
+        if (!this._helperContext)
+          return;
+        const matchesId = params.executionContextId === this._helperContext.id;
+        const matchesUnique = params.executionContextUniqueId !== void 0 && params.executionContextUniqueId === this._helperContext.uniqueId;
+        if (!matchesId && !matchesUnique)
+          return;
+        this._helperContext = null;
+        this.invalidateHelperWorld("context_destroyed");
+      }
+      handleExecutionContextsCleared() {
+        this._helperContext = null;
+        this.invalidateHelperWorld("contexts_cleared");
       }
       async autoConnect(portHint, filtersOrPlatform, intent = "default") {
         const filters = typeof filtersOrPlatform === "string" ? { platform: filtersOrPlatform } : filtersOrPlatform ?? {};
@@ -57196,6 +57353,7 @@ var init_cdp_client = __esm({
         if (this.disposed)
           return;
         this.disposed = true;
+        this.invalidateHelperWorld("explicit_disconnect");
         resetState(this.buildResettableState());
         clearActiveFlag();
         this.stopBackgroundPoll();
@@ -57318,8 +57476,11 @@ var init_cdp_client = __esm({
         const result = await performSetup({
           send: (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)),
           evaluate: (expr) => this.evaluate(expr),
+          setupHelpers: async (waitTimeout) => {
+            await waitForReact((expr) => this.evaluateCurrentHelperWorld(expr), waitTimeout);
+            return this.ensureCurrentHelpers("setup_started");
+          },
           port: this._port,
-          connectedTarget: this._connectedTarget,
           networkManager: this._networkBufferManager,
           getDeviceKey: () => this.activeDeviceKey,
           setupEventHandlers: () => this.setupEventHandlers(),
@@ -57327,18 +57488,9 @@ var init_cdp_client = __esm({
           clearEventHandlers: () => this.eventHandlers.clear()
         });
         this._networkMode = result.networkMode;
-        this._helpersInjected = result.helpersInjected;
         this._logDomainEnabled = result.logDomainEnabled;
         this._profilerAvailable = result.profilerAvailable;
         this._heapProfilerAvailable = result.heapProfilerAvailable;
-        if (result.helpersInjected) {
-          detectBridge(this).then((r) => {
-            this._bridgeDetected = r.present;
-            this._bridgeVersion = r.version;
-            logger.debug("CDP", `Bridge detection: present=${r.present}, version=${r.version}`);
-          }).catch(() => {
-          });
-        }
       }
       async ensureMetroEventsClient() {
         if (this._metroEventsClient && this._metroEventsClient.port !== this._port) {
@@ -57358,9 +57510,15 @@ var init_cdp_client = __esm({
           scripts: this._scripts
         }, (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)), () => this._isPaused, (v) => {
           this._isPaused = v;
-        }, () => this.activeDeviceKey);
+        }, () => this.activeDeviceKey, {
+          created: (params) => this.handleExecutionContextCreated(params),
+          destroyed: (params) => this.handleExecutionContextDestroyed(params),
+          cleared: () => this.handleExecutionContextsCleared()
+        });
       }
       handleClose(code) {
+        this.ws = null;
+        this.invalidateHelperWorld("socket_closed");
         if (this._proxyUrl) {
           void this._suspendProxy();
         }
@@ -57401,6 +57559,8 @@ var init_cdp_client = __esm({
                 this.ws.close();
               }
               this.ws = null;
+              this._helperContext = null;
+              this.invalidateHelperWorld("soft_reconnect");
             }
           },
           rejectAllPending: (reason) => this.rejectAllPending(reason),
@@ -57438,13 +57598,21 @@ var init_cdp_client = __esm({
           },
           getWs: () => this.ws,
           setWs: (ws) => {
+            if (this.ws === ws)
+              return;
             this.ws = ws;
+            this._helperContext = null;
+            this.invalidateHelperWorld(ws ? "socket_opened" : "socket_closed");
           },
           setHelpersInjected: (v) => {
-            this._helpersInjected = v;
+            if (!v)
+              this.invalidateHelperWorld("candidate_rejected");
           },
           setConnectedTarget: (t) => {
+            if (this._connectedTarget === t)
+              return;
             this._connectedTarget = t;
+            this.invalidateHelperWorld(t ? "candidate_selected" : "candidate_rejected");
           },
           setConnectedAt: (ms) => {
             this._connectedAt = ms;

--- a/packages/claude-plugin/skills/rn-debugging/SKILL.md
+++ b/packages/claude-plugin/skills/rn-debugging/SKILL.md
@@ -110,7 +110,7 @@ When a `cdp_*` tool returns `code: HELPERS_NOT_INJECTED`, the bridge has already
 3. Attempted a Dev Client picker dismissal (in case a native overlay was blocking React)
 4. Waited up to another 30s if the picker was dismissed
 
-So when this error appears, **the JS world is genuinely hung** — Hermes is up but `__RN_AGENT` won't land. Two recovery paths, in order:
+The final error includes `meta.helperHealth`: `jsWorld` is one of `responsive`, `timeout`, `transport-error`, or `superseded`; `helper` is one of `current`, `missing`, `version-mismatch`, `invalid`, or `unknown`; and `probeBudgetMs` reports the bounded probe budget. A timeout proves only that the probe received no response within that budget — JavaScript may be busy, paused, or blocked. A responsive/current result is reconciled automatically and the gated call continues, so an emitted error describes missing, mismatched, invalid, unmeasurable, or superseded helper evidence rather than claiming a genuine hang. Use these two recovery paths, in order:
 
 | Step | Action | Why |
 |------|--------|-----|

--- a/packages/claude-plugin/skills/rn-setup/SKILL.md
+++ b/packages/claude-plugin/skills/rn-setup/SKILL.md
@@ -140,8 +140,8 @@ injection; passive status deliberately does not duplicate helper capability
 state.
 
 If it returns `HELPERS_NOT_INJECTED`:
-- The gated call already attempted reinjection. If it still fails, the JS world is hung — Hermes is up but `__RN_AGENT` won't land.
-- Surface this in the table as MISSING with action: "JS-tier tools (`cdp_interact`, `cdp_component_tree`, `cdp_store_state`, `cdp_navigation_state`) will fail with HELPERS_NOT_INJECTED. Fall back to `device_*` tools (XCTest path — no helpers required) for UI work, or call `cdp_reload` once to rebuild the JS context. If you also see `app.hasRedBox: true` or `app.errorCount > 0`, fix those first — `cdp_reload` won't help if the bundle itself errors out."
+- The gated call already attempted reinjection and then ran one bounded health probe. Read `meta.helperHealth`: bounded timeout means only "no response within the reported budget," not proof of a hung world; responsive results distinguish missing, version-mismatched, and invalid helpers. Responsive/current evidence is reconciled automatically and does not emit this error.
+- Surface this in the table as MISSING with action: "JS-tier tools (`cdp_interact`, `cdp_component_tree`, `cdp_store_state`, `cdp_navigation_state`) will fail with HELPERS_NOT_INJECTED. Report the fixed `meta.helperHealth` categories, fall back to `device_*` tools (XCTest path — no helpers required) for UI work, or call `cdp_reload` once to rebuild the JS context. If you also see `app.hasRedBox: true` or `app.errorCount > 0`, fix those first — `cdp_reload` won't help if the bundle itself errors out."
 - Also mention: don't sit in a status retry loop; use the gated helper result.
 
 ### 9. ffmpeg (optional — for video recording)

--- a/packages/codex-plugin/commands/check-env.md
+++ b/packages/codex-plugin/commands/check-env.md
@@ -29,7 +29,7 @@ If issues are found, suggest the appropriate fix:
 | CDP code 1006 | Close React Native DevTools, Flipper, Chrome DevTools |
 | `cdp_component_tree` reports RedBox | Run `$rn-dev-agent:debug-screen` |
 | Narrow gated CDP read times out | Check for a blocked JS thread, then use `cdp_reload` |
-| `HELPERS_NOT_INJECTED` | Use a `__DEV__` Hermes build; retry through the gated tool after reload |
+| `HELPERS_NOT_INJECTED` | Read bounded `meta.helperHealth`; use a `__DEV__` Hermes build and retry through the gated tool after reload |
 | No devices in device_list | Boot a simulator: `xcrun simctl boot "iPhone 16"` or start an emulator |
 
 Present results clearly with a pass/fail indicator for each subsystem.

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -25946,31 +25946,7 @@ function consumeCdpStale() {
   return was;
 }
 async function probeFreshness(client2, timeoutMs = FRESHNESS_PROBE_MS) {
-  if (!client2.isConnected) {
-    return { fresh: false, version: null, probed: false };
-  }
-  let probeTimer;
-  try {
-    const evalPromise = client2.evaluate('typeof globalThis.__RN_AGENT === "object" && globalThis.__RN_AGENT.__v');
-    evalPromise.catch(() => {
-    });
-    const result = await Promise.race([
-      evalPromise,
-      new Promise((resolve10) => {
-        probeTimer = setTimeout(() => resolve10({ error: "timeout" }), timeoutMs);
-      })
-    ]);
-    if (probeTimer)
-      clearTimeout(probeTimer);
-    if (result.error || typeof result.value !== "number") {
-      return { fresh: false, version: null, probed: true };
-    }
-    return { fresh: true, version: result.value, probed: true };
-  } catch {
-    if (probeTimer)
-      clearTimeout(probeTimer);
-    return { fresh: false, version: null, probed: true };
-  }
+  return client2.probeHelperFreshness(timeoutMs);
 }
 async function recoverFromStaleTarget(client2) {
   if (!client2.isConnected) {
@@ -33135,18 +33111,28 @@ function isFreshnessCached(client2) {
   const entry = freshnessCache.get(client2);
   if (!entry)
     return false;
-  if (entry.generation !== client2.connectionGeneration)
+  if (entry.generation !== client2.helperWorldGeneration)
     return false;
   return Date.now() < entry.expiresAt;
 }
 function rememberFreshness(client2) {
   freshnessCache.set(client2, {
-    generation: client2.connectionGeneration,
+    generation: client2.helperWorldGeneration,
     expiresAt: Date.now() + FRESHNESS_CACHE_MS
   });
 }
 function forgetFreshness(client2) {
   freshnessCache.delete(client2);
+}
+async function helpersNotInjectedResult(client2, boundary) {
+  const helperHealth = await client2.probeHelperHealth(2e3);
+  if (helperHealth.jsWorld === "responsive" && helperHealth.helper === "current") {
+    rememberFreshness(client2);
+    return null;
+  }
+  forgetFreshness(client2);
+  const message = helperHealth.jsWorld === "timeout" ? `Helpers are not ready and the bounded ${helperHealth.probeBudgetMs}ms health probe received no response; JavaScript may be busy, paused, or blocked.` : helperHealth.jsWorld === "transport-error" ? "Helpers are not ready and their health could not be measured because the CDP transport failed." : helperHealth.jsWorld === "superseded" ? "Helpers are not ready because the JavaScript execution world changed during the bounded health probe." : helperHealth.helper === "version-mismatch" ? "Helpers are not ready because the responsive JavaScript world contains a different helper version." : helperHealth.helper === "missing" ? "Helpers are not ready because they are missing from the responsive JavaScript world." : "Helpers are not ready because the responsive JavaScript world contains an invalid helper value.";
+  return failResult(`${boundary === "stale-recovery" ? "Stale target recovery completed, but " : ""}${message} Fall back to device_* tools or call cdp_reload once.`, "HELPERS_NOT_INJECTED", { helperHealth });
 }
 function createStepTimer() {
   let last = Date.now();
@@ -33235,7 +33221,9 @@ function withConnection(getClient2, handler, options = {}) {
             }
           }
           if (!client2.helpersInjected) {
-            return failResult("Connected but helpers still not injected after passive wait, active re-inject, and Dev Client picker dismissal. The JS world may be hung. Fall back to device_* tools (XCTest path \u2014 no helpers required) or call cdp_reload to restart the bundle.", "HELPERS_NOT_INJECTED");
+            const helperError = await helpersNotInjectedResult(client2, "initial");
+            if (helperError)
+              return helperError;
           }
         }
       }
@@ -33323,7 +33311,14 @@ function withConnection(getClient2, handler, options = {}) {
               return failResult(`Retry after stale-target recovery failed: ${retryMsg}`, "STALE_TARGET", { originalError: message });
             }
           }
-          return failResult("Stale target recovery: reconnected but helpers not injected.", "HELPERS_NOT_INJECTED", { originalError: message });
+          const helperError = await helpersNotInjectedResult(client2, "stale-recovery");
+          if (helperError)
+            return helperError;
+          try {
+            return await handler(args, client2);
+          } catch {
+            return failResult("Retry after stale-target helper reconciliation failed.", "STALE_TARGET");
+          }
         }
         if (recovery.reason === "reconnect-failed") {
           return failResult(`Stale target recovery failed: ${recovery.error}`, "STALE_TARGET", {
@@ -48655,9 +48650,9 @@ var DETECT_EXPRESSION = `
   return JSON.stringify({ present: true, version: b.__v || null });
 })()
 `;
-async function detectBridge(client2) {
+async function detectBridge(client2, evaluate = (expression) => client2.evaluate(expression)) {
   try {
-    const result = await client2.evaluate(DETECT_EXPRESSION);
+    const result = await evaluate(DETECT_EXPRESSION);
     if (result.value && typeof result.value === "string") {
       return JSON.parse(result.value);
     }
@@ -51783,7 +51778,10 @@ function defaultTimeout(platform) {
 var REACT_READY_TIMEOUT_MS = 3e4;
 var REACT_READY_POLL_MS = 500;
 async function performSetup(opts) {
-  const { send, evaluate, port, connectedTarget, networkManager, getDeviceKey, setupEventHandlers, clearScripts, clearEventHandlers, probeWaits } = opts;
+  const { send, evaluate, setupHelpers, port, networkManager, getDeviceKey, setupEventHandlers, clearScripts, clearEventHandlers, probeWaits } = opts;
+  clearEventHandlers();
+  clearScripts();
+  setupEventHandlers();
   logger.debug("CDP", "Running setup: Runtime.enable, Debugger.enable...");
   await send("Runtime.enable", void 0, timeoutForMethod("Runtime.enable"));
   await send("Debugger.enable", void 0, timeoutForMethod("Debugger.enable"));
@@ -51809,24 +51807,8 @@ async function performSetup(opts) {
   ]);
   const profilerAvailable = profilerProbe.status === "fulfilled" && profilerProbe.value === true;
   const heapProfilerAvailable = heapProbe.status === "fulfilled" && heapProbe.value === true;
-  clearEventHandlers();
-  clearScripts();
-  setupEventHandlers();
-  await waitForReact(evaluate, REACT_READY_TIMEOUT_MS);
-  const helperResult = await evaluate(INJECTED_HELPERS);
-  if (helperResult.error) {
-    console.error("CDP: failed to inject helpers:", helperResult.error);
-    return {
-      networkMode,
-      helpersInjected: false,
-      logDomainEnabled,
-      profilerAvailable,
-      heapProfilerAvailable
-    };
-  }
-  const verify = await evaluate('typeof globalThis.__RN_AGENT === "object"');
-  if (verify.value !== true) {
-    console.error("CDP: helper injection succeeded but __RN_AGENT not found");
+  const helpersInjected = await setupHelpers(REACT_READY_TIMEOUT_MS);
+  if (!helpersInjected) {
     return {
       networkMode,
       helpersInjected: false,
@@ -51843,8 +51825,7 @@ async function performSetup(opts) {
     }
     networkDomainEnabled = false;
   }
-  logger.info("CDP", `Helpers injected (v${HELPERS_VERSION}), network mode: ${networkMode}`);
-  setActiveFlag(port, connectedTarget);
+  logger.info("CDP", `Helpers current (v${HELPERS_VERSION}), network mode: ${networkMode}`);
   if (networkMode === "cdp") {
     networkMode = await probeNetworkDomain({
       evaluate,
@@ -51892,19 +51873,6 @@ async function probeNetworkDomain(opts) {
   }
   logger.info("CDP", `Network.enable accepted but no events fired after ${waits.length} attempt(s) \u2014 falling back to hooks`);
   return "none";
-}
-async function reinjectHelpers(evaluate, waitTimeout) {
-  await waitForReact(evaluate, waitTimeout ?? REACT_READY_TIMEOUT_MS);
-  const helperResult = await evaluate(INJECTED_HELPERS);
-  if (helperResult.error) {
-    console.error("CDP: failed to re-inject helpers:", helperResult.error);
-    return false;
-  }
-  const verify = await evaluate('typeof globalThis.__RN_AGENT === "object"');
-  if (verify.value !== true) {
-    return false;
-  }
-  return true;
 }
 async function probeReactReachable(evaluate, budgetMs, pollMs = REACT_READY_POLL_MS) {
   const start = Date.now();
@@ -51996,7 +51964,16 @@ function handleMessage(data, pending2, eventHandlers, onConsoleHook) {
 }
 
 // packages/rn-dev-agent-core/dist/cdp/event-handlers.js
-function wireEventHandlers(eventHandlers, buffers, sendFn, getIsPaused, setIsPaused, getDeviceKey) {
+function wireEventHandlers(eventHandlers, buffers, sendFn, getIsPaused, setIsPaused, getDeviceKey, executionContexts) {
+  if (executionContexts) {
+    eventHandlers.set("Runtime.executionContextCreated", (params) => {
+      executionContexts.created(params);
+    });
+    eventHandlers.set("Runtime.executionContextDestroyed", (params) => {
+      executionContexts.destroyed(params);
+    });
+    eventHandlers.set("Runtime.executionContextsCleared", () => executionContexts.cleared());
+  }
   eventHandlers.set("Runtime.consoleAPICalled", (params) => {
     const p = params;
     const text = p.args?.map((a) => a.value !== void 0 ? String(a.value) : a.description ?? "").join(" ") ?? "";
@@ -52408,6 +52385,16 @@ var CDPClient = class {
   reconnecting = false;
   disposed = false;
   _helpersInjected = false;
+  _helperWorldGeneration = 0;
+  _helperContext = null;
+  _helperToken = {
+    generation: 0,
+    ws: null,
+    targetId: null,
+    contextId: null,
+    contextUniqueId: null
+  };
+  _helperInjectionInFlight = null;
   _networkMode = "none";
   _isPaused = false;
   _connectedTarget = null;
@@ -52467,6 +52454,10 @@ var CDPClient = class {
   }
   get helpersInjected() {
     return this._helpersInjected;
+  }
+  /** Private helper-world epoch exposed only for process-local cache identity. */
+  get helperWorldGeneration() {
+    return this._helperWorldGeneration;
   }
   get metroPort() {
     return this._port;
@@ -52566,17 +52557,182 @@ var CDPClient = class {
   async reinjectHelpers(waitTimeout) {
     if (!this.isConnected)
       return false;
-    const ok = await reinjectHelpers((expr) => this.evaluate(expr), waitTimeout);
-    this._helpersInjected = ok;
-    if (ok) {
-      setActiveFlag(this._port, this._connectedTarget);
-      detectBridge(this).then((r) => {
-        this._bridgeDetected = r.present;
-        this._bridgeVersion = r.version;
-      }).catch(() => {
-      });
+    await waitForReact((expr) => this.evaluateCurrentHelperWorld(expr), waitTimeout);
+    return this.ensureCurrentHelpers("reinject_started");
+  }
+  /**
+   * One bounded, context-pinned health read used only at final
+   * HELPERS_NOT_INJECTED boundaries. It never returns app values or errors.
+   */
+  async probeHelperHealth(probeBudgetMs = 2e3) {
+    const token2 = this._helperToken;
+    if (!this.isHelperTokenCurrent(token2)) {
+      return { jsWorld: "superseded", helper: "unknown", probeBudgetMs };
     }
-    return ok;
+    const expression = `(function(){try{var d=Object.getOwnPropertyDescriptor(globalThis,'__RN_AGENT');if(!d)return 'missing';if(!('value' in d)||typeof d.value!=='object'||d.value===null)return 'invalid';var v=Object.getOwnPropertyDescriptor(d.value,'__v');if(!v||!('value' in v)||typeof v.value!=='number')return 'invalid';return v.value===${HELPERS_VERSION}?'current':'version-mismatch';}catch(_){return 'invalid';}})()`;
+    try {
+      const result = await this.evaluateForHelperToken(token2, expression, probeBudgetMs);
+      if (!this.isHelperTokenCurrent(token2)) {
+        return { jsWorld: "superseded", helper: "unknown", probeBudgetMs };
+      }
+      const helper = result.value === "current" || result.value === "missing" || result.value === "version-mismatch" || result.value === "invalid" ? result.value : "invalid";
+      if (helper === "current")
+        this.markHelpersReady(token2, "health_reconciled_current");
+      return { jsWorld: "responsive", helper, probeBudgetMs };
+    } catch (err) {
+      if (!this.isHelperTokenCurrent(token2)) {
+        return { jsWorld: "superseded", helper: "unknown", probeBudgetMs };
+      }
+      const timedOut = err instanceof Error && err.message.startsWith("CDP timeout (");
+      return {
+        jsWorld: timedOut ? "timeout" : "transport-error",
+        helper: "unknown",
+        probeBudgetMs
+      };
+    }
+  }
+  async probeHelperFreshness(timeoutMs = 2e3) {
+    if (!this.isConnected)
+      return { fresh: false, version: null, probed: false };
+    const token2 = this._helperToken;
+    try {
+      const result = await this.evaluateForHelperToken(token2, `typeof globalThis.__RN_AGENT === 'object' && globalThis.__RN_AGENT !== null ? globalThis.__RN_AGENT.__v : null`, timeoutMs);
+      if (!this.isHelperTokenCurrent(token2))
+        return { fresh: false, version: null, probed: true };
+      const version2 = typeof result.value === "number" ? result.value : null;
+      const fresh = version2 === HELPERS_VERSION;
+      if (!fresh) {
+        this.markHelpersUnready(token2, version2 === null ? "freshness_missing" : "freshness_version_mismatch");
+      }
+      return { fresh, version: version2, probed: true };
+    } catch {
+      return { fresh: false, version: null, probed: true };
+    }
+  }
+  invalidateHelperWorld(cause) {
+    this._helperWorldGeneration++;
+    this._helpersInjected = false;
+    this._bridgeDetected = false;
+    this._bridgeVersion = null;
+    this._helperToken = {
+      generation: this._helperWorldGeneration,
+      ws: this.ws,
+      targetId: this._connectedTarget?.id ?? null,
+      contextId: this._helperContext?.id ?? null,
+      contextUniqueId: this._helperContext?.uniqueId ?? null
+    };
+    logger.info("CDP", `Helper state invalidated cause=${cause} helperEpoch=${this._helperWorldGeneration} connectionGeneration=${this._connectionGeneration}`);
+  }
+  isHelperTokenCurrent(token2) {
+    return token2 === this._helperToken && token2.ws === this.ws && token2.targetId === (this._connectedTarget?.id ?? null);
+  }
+  async evaluateCurrentHelperWorld(expression) {
+    const token2 = this._helperToken;
+    try {
+      return await this.evaluateForHelperToken(token2, expression, defaultTimeout(this.effectivePlatform));
+    } catch {
+      return { error: "helper-world evaluation unavailable" };
+    }
+  }
+  async evaluateForHelperToken(token2, expression, timeoutMs) {
+    if (!this.isHelperTokenCurrent(token2))
+      throw new Error("helper world superseded");
+    const params = {
+      expression,
+      returnByValue: true
+    };
+    if (token2.contextId !== null)
+      params.contextId = token2.contextId;
+    const result = await this.sendWithTimeout("Runtime.evaluate", params, timeoutMs);
+    if (!this.isHelperTokenCurrent(token2))
+      throw new Error("helper world superseded");
+    if (result?.exceptionDetails)
+      return { error: "helper-world expression failed" };
+    return { value: result?.result?.value };
+  }
+  async ensureCurrentHelpers(cause) {
+    const token2 = this._helperToken;
+    if (!this.isHelperTokenCurrent(token2) || !this.isConnected)
+      return false;
+    if (this._helpersInjected)
+      return true;
+    if (this._helperInjectionInFlight?.token === token2) {
+      return this._helperInjectionInFlight.promise;
+    }
+    const slot = {
+      token: token2,
+      promise: Promise.resolve(false)
+    };
+    slot.promise = this.injectAndVerifyHelpers(token2, cause).finally(() => {
+      if (this._helperInjectionInFlight === slot)
+        this._helperInjectionInFlight = null;
+    });
+    this._helperInjectionInFlight = slot;
+    return slot.promise;
+  }
+  markHelpersUnready(token2, cause) {
+    if (!this.isHelperTokenCurrent(token2))
+      return false;
+    this._helpersInjected = false;
+    this._bridgeDetected = false;
+    this._bridgeVersion = null;
+    logger.warn("CDP", `Helper state unavailable cause=${cause} helperEpoch=${token2.generation} connectionGeneration=${this._connectionGeneration}`);
+    return false;
+  }
+  async injectAndVerifyHelpers(token2, cause) {
+    logger.info("CDP", `Helper injection ${cause} helperEpoch=${token2.generation} connectionGeneration=${this._connectionGeneration}`);
+    try {
+      const injected = await this.evaluateForHelperToken(token2, INJECTED_HELPERS, defaultTimeout(this.effectivePlatform));
+      if (injected.error) {
+        return this.markHelpersUnready(token2, cause === "setup_started" ? "setup_failed" : "reinject_failed");
+      }
+      const verified = await this.evaluateForHelperToken(token2, `typeof globalThis.__RN_AGENT === 'object' && globalThis.__RN_AGENT !== null && globalThis.__RN_AGENT.__v === ${HELPERS_VERSION}`, defaultTimeout(this.effectivePlatform));
+      if (verified.value !== true || !this.isHelperTokenCurrent(token2)) {
+        return this.markHelpersUnready(token2, cause === "setup_started" ? "setup_failed" : "reinject_failed");
+      }
+      this.markHelpersReady(token2, cause === "setup_started" ? "setup_current" : "reinject_current");
+      return true;
+    } catch {
+      return this.markHelpersUnready(token2, cause === "setup_started" ? "setup_failed" : "reinject_failed");
+    }
+  }
+  markHelpersReady(token2, cause) {
+    if (!this.isHelperTokenCurrent(token2))
+      return;
+    this._helpersInjected = true;
+    setActiveFlag(this._port, this._connectedTarget);
+    logger.info("CDP", `Helper state ready cause=${cause} helperEpoch=${token2.generation} connectionGeneration=${this._connectionGeneration}`);
+    detectBridge(this, (expression) => this.evaluateForHelperToken(token2, expression, defaultTimeout(this.effectivePlatform))).then((r) => {
+      if (!this.isHelperTokenCurrent(token2))
+        return;
+      this._bridgeDetected = r.present;
+      this._bridgeVersion = r.version;
+    }).catch(() => {
+    });
+  }
+  handleExecutionContextCreated(params) {
+    const id = params.context?.id;
+    if (typeof id !== "number" || params.context?.auxData?.isDefault === false)
+      return;
+    const next = { id, uniqueId: params.context?.uniqueId };
+    if (this._helperContext?.id === next.id && this._helperContext.uniqueId === next.uniqueId)
+      return;
+    this._helperContext = next;
+    this.invalidateHelperWorld("context_created");
+  }
+  handleExecutionContextDestroyed(params) {
+    if (!this._helperContext)
+      return;
+    const matchesId = params.executionContextId === this._helperContext.id;
+    const matchesUnique = params.executionContextUniqueId !== void 0 && params.executionContextUniqueId === this._helperContext.uniqueId;
+    if (!matchesId && !matchesUnique)
+      return;
+    this._helperContext = null;
+    this.invalidateHelperWorld("context_destroyed");
+  }
+  handleExecutionContextsCleared() {
+    this._helperContext = null;
+    this.invalidateHelperWorld("contexts_cleared");
   }
   async autoConnect(portHint, filtersOrPlatform, intent = "default") {
     const filters = typeof filtersOrPlatform === "string" ? { platform: filtersOrPlatform } : filtersOrPlatform ?? {};
@@ -52727,6 +52883,7 @@ var CDPClient = class {
     if (this.disposed)
       return;
     this.disposed = true;
+    this.invalidateHelperWorld("explicit_disconnect");
     resetState(this.buildResettableState());
     clearActiveFlag();
     this.stopBackgroundPoll();
@@ -52849,8 +53006,11 @@ var CDPClient = class {
     const result = await performSetup({
       send: (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)),
       evaluate: (expr) => this.evaluate(expr),
+      setupHelpers: async (waitTimeout) => {
+        await waitForReact((expr) => this.evaluateCurrentHelperWorld(expr), waitTimeout);
+        return this.ensureCurrentHelpers("setup_started");
+      },
       port: this._port,
-      connectedTarget: this._connectedTarget,
       networkManager: this._networkBufferManager,
       getDeviceKey: () => this.activeDeviceKey,
       setupEventHandlers: () => this.setupEventHandlers(),
@@ -52858,18 +53018,9 @@ var CDPClient = class {
       clearEventHandlers: () => this.eventHandlers.clear()
     });
     this._networkMode = result.networkMode;
-    this._helpersInjected = result.helpersInjected;
     this._logDomainEnabled = result.logDomainEnabled;
     this._profilerAvailable = result.profilerAvailable;
     this._heapProfilerAvailable = result.heapProfilerAvailable;
-    if (result.helpersInjected) {
-      detectBridge(this).then((r) => {
-        this._bridgeDetected = r.present;
-        this._bridgeVersion = r.version;
-        logger.debug("CDP", `Bridge detection: present=${r.present}, version=${r.version}`);
-      }).catch(() => {
-      });
-    }
   }
   async ensureMetroEventsClient() {
     if (this._metroEventsClient && this._metroEventsClient.port !== this._port) {
@@ -52889,9 +53040,15 @@ var CDPClient = class {
       scripts: this._scripts
     }, (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)), () => this._isPaused, (v) => {
       this._isPaused = v;
-    }, () => this.activeDeviceKey);
+    }, () => this.activeDeviceKey, {
+      created: (params) => this.handleExecutionContextCreated(params),
+      destroyed: (params) => this.handleExecutionContextDestroyed(params),
+      cleared: () => this.handleExecutionContextsCleared()
+    });
   }
   handleClose(code) {
+    this.ws = null;
+    this.invalidateHelperWorld("socket_closed");
     if (this._proxyUrl) {
       void this._suspendProxy();
     }
@@ -52932,6 +53089,8 @@ var CDPClient = class {
             this.ws.close();
           }
           this.ws = null;
+          this._helperContext = null;
+          this.invalidateHelperWorld("soft_reconnect");
         }
       },
       rejectAllPending: (reason) => this.rejectAllPending(reason),
@@ -52969,13 +53128,21 @@ var CDPClient = class {
       },
       getWs: () => this.ws,
       setWs: (ws) => {
+        if (this.ws === ws)
+          return;
         this.ws = ws;
+        this._helperContext = null;
+        this.invalidateHelperWorld(ws ? "socket_opened" : "socket_closed");
       },
       setHelpersInjected: (v) => {
-        this._helpersInjected = v;
+        if (!v)
+          this.invalidateHelperWorld("candidate_rejected");
       },
       setConnectedTarget: (t) => {
+        if (this._connectedTarget === t)
+          return;
         this._connectedTarget = t;
+        this.invalidateHelperWorld(t ? "candidate_selected" : "candidate_rejected");
       },
       setConnectedAt: (ms) => {
         this._connectedAt = ms;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -52290,8 +52290,6 @@ async function connectToTarget(ctx, target, retries = 5, intent = "default") {
       await ctx.setup();
       return;
     } catch (err) {
-      if (err instanceof ConnectionSetupSupersededError)
-        throw err;
       if (err instanceof PickerBlockingBundleError) {
         if (!closeConnectionAttempt(ctx, attemptWs)) {
           throw new ConnectionSetupSupersededError();
@@ -52303,6 +52301,8 @@ async function connectToTarget(ctx, target, retries = 5, intent = "default") {
       lastError = err instanceof Error ? err : new Error(String(err));
       attempts3.push({ handshakeOk, probeTimedOut });
       if (!closeConnectionAttempt(ctx, attemptWs)) {
+        if (err instanceof ConnectionSetupSupersededError)
+          throw err;
         throw new ConnectionSetupSupersededError();
       }
       if (lastError.message.includes("refused")) {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -52606,6 +52606,7 @@ var CDPClient = class {
       }
       return { fresh, version: version2, probed: true };
     } catch {
+      this.markHelpersUnready(token2, "freshness_probe_failed");
       return { fresh: false, version: null, probed: true };
     }
   }
@@ -52614,6 +52615,7 @@ var CDPClient = class {
     this._helpersInjected = false;
     this._bridgeDetected = false;
     this._bridgeVersion = null;
+    clearActiveFlag();
     this._helperToken = {
       generation: this._helperWorldGeneration,
       ws: this.ws,
@@ -52676,6 +52678,7 @@ var CDPClient = class {
     this._helpersInjected = false;
     this._bridgeDetected = false;
     this._bridgeVersion = null;
+    clearActiveFlag();
     logger.warn("CDP", `Helper state unavailable cause=${cause} helperEpoch=${token2.generation} connectionGeneration=${this._connectionGeneration}`);
     return false;
   }
@@ -53003,12 +53006,38 @@ var CDPClient = class {
   async setup() {
     this.ensureMetroEventsClient().catch(() => {
     });
+    const setupWs = this.ws;
+    const setupTargetId = this._connectedTarget?.id ?? null;
+    let setupHelperToken = null;
+    const assertSetupCurrent = () => {
+      const connectionIsCurrent = this.ws === setupWs && (this._connectedTarget?.id ?? null) === setupTargetId;
+      const helpersAreCurrent = setupHelperToken === null || this.isHelperTokenCurrent(setupHelperToken);
+      if (!connectionIsCurrent || !helpersAreCurrent)
+        throw new Error("setup superseded");
+    };
+    const sendForSetup = async (method, params, ms) => {
+      assertSetupCurrent();
+      const response = await this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform));
+      assertSetupCurrent();
+      return response;
+    };
+    const evaluateForSetup = async (expression) => {
+      assertSetupCurrent();
+      const response = await this.evaluate(expression);
+      assertSetupCurrent();
+      return response;
+    };
     const result = await performSetup({
-      send: (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)),
-      evaluate: (expr) => this.evaluate(expr),
+      send: sendForSetup,
+      evaluate: evaluateForSetup,
       setupHelpers: async (waitTimeout) => {
+        assertSetupCurrent();
         await waitForReact((expr) => this.evaluateCurrentHelperWorld(expr), waitTimeout);
-        return this.ensureCurrentHelpers("setup_started");
+        assertSetupCurrent();
+        setupHelperToken = this._helperToken;
+        const helpersInjected = await this.ensureCurrentHelpers("setup_started");
+        assertSetupCurrent();
+        return helpersInjected;
       },
       port: this._port,
       networkManager: this._networkBufferManager,
@@ -53017,6 +53046,7 @@ var CDPClient = class {
       clearScripts: () => this._scripts.clear(),
       clearEventHandlers: () => this.eventHandlers.clear()
     });
+    assertSetupCurrent();
     this._networkMode = result.networkMode;
     this._logDomainEnabled = result.logDomainEnabled;
     this._profilerAvailable = result.profilerAvailable;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -52132,6 +52132,12 @@ var PickerBlockingBundleError = class extends Error {
     this.target = target;
   }
 };
+var ConnectionSetupSupersededError = class extends Error {
+  constructor() {
+    super("Connection setup superseded");
+    this.name = "ConnectionSetupSupersededError";
+  }
+};
 function shouldRunPickerProbe(intent, target) {
   return intent === "status" && target.vm !== "Hermes";
 }
@@ -52211,6 +52217,8 @@ async function discoverAndConnect(ctx, portHint, filters, discoverFn = discover,
       console.error("CDP: no target with __DEV__=true found, using last available target");
       connectedTarget = candidate;
     } catch (err) {
+      if (err instanceof ConnectionSetupSupersededError)
+        throw err;
       if (err instanceof PickerBlockingBundleError) {
         ctx.setState("disconnected");
         throw err;
@@ -52254,13 +52262,14 @@ async function connectToTarget(ctx, target, retries = 5, intent = "default") {
     }
     let handshakeOk = false;
     let probeTimedOut = false;
+    let attemptWs = null;
     try {
       const proxyUrl = ctx.getProxyUrl();
       const url = proxyUrl ?? target.webSocketDebuggerUrl;
       if (proxyUrl) {
         logger.info("CDP", `Routing via multiplexer proxy: ${proxyUrl}`);
       }
-      await connectWs(ctx, url);
+      attemptWs = await connectWs(ctx, url);
       handshakeOk = true;
       try {
         await ctx.sendWithTimeout("Runtime.evaluate", {
@@ -52281,15 +52290,21 @@ async function connectToTarget(ctx, target, retries = 5, intent = "default") {
       await ctx.setup();
       return;
     } catch (err) {
+      if (err instanceof ConnectionSetupSupersededError)
+        throw err;
       if (err instanceof PickerBlockingBundleError) {
-        closeAndResetWs(ctx);
+        if (!closeConnectionAttempt(ctx, attemptWs)) {
+          throw new ConnectionSetupSupersededError();
+        }
         ctx.setConnectedTarget(null);
         ctx.setState("disconnected");
         throw err;
       }
       lastError = err instanceof Error ? err : new Error(String(err));
       attempts3.push({ handshakeOk, probeTimedOut });
-      closeAndResetWs(ctx);
+      if (!closeConnectionAttempt(ctx, attemptWs)) {
+        throw new ConnectionSetupSupersededError();
+      }
       if (lastError.message.includes("refused")) {
         ctx.setState("disconnected");
         throw new Error("CDP connection refused. Is Metro running and the app loaded?");
@@ -52324,7 +52339,7 @@ function connectWs(ctx, url) {
       clearTimeout(guard);
       ctx.setWs(ws);
       ctx.setState("connected");
-      resolve10();
+      resolve10(ws);
     });
     ws.on("error", (err) => {
       if (!settled) {
@@ -52365,6 +52380,18 @@ function closeAndResetWs(ctx) {
     }
     ctx.setWs(null);
   }
+}
+function closeConnectionAttempt(ctx, attemptWs) {
+  if (ctx.getWs() !== attemptWs)
+    return false;
+  if (!attemptWs)
+    return true;
+  attemptWs.removeAllListeners();
+  if (attemptWs.readyState === wrapper_default.OPEN || attemptWs.readyState === wrapper_default.CONNECTING) {
+    attemptWs.close();
+  }
+  ctx.setWs(null);
+  return true;
 }
 
 // packages/rn-dev-agent-core/dist/cdp-client.js
@@ -53012,8 +53039,9 @@ var CDPClient = class {
     const assertSetupCurrent = () => {
       const connectionIsCurrent = this.ws === setupWs && (this._connectedTarget?.id ?? null) === setupTargetId;
       const helpersAreCurrent = setupHelperToken === null || this.isHelperTokenCurrent(setupHelperToken);
-      if (!connectionIsCurrent || !helpersAreCurrent)
-        throw new Error("setup superseded");
+      if (!connectionIsCurrent || !helpersAreCurrent) {
+        throw new ConnectionSetupSupersededError();
+      }
     };
     const sendForSetup = async (method, params, ms) => {
       assertSetupCurrent();

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -56634,6 +56634,8 @@ async function discoverAndConnect(ctx, portHint, filters, discoverFn = discover,
       console.error("CDP: no target with __DEV__=true found, using last available target");
       connectedTarget = candidate;
     } catch (err) {
+      if (err instanceof ConnectionSetupSupersededError)
+        throw err;
       if (err instanceof PickerBlockingBundleError) {
         ctx.setState("disconnected");
         throw err;
@@ -56677,13 +56679,14 @@ async function connectToTarget(ctx, target, retries = 5, intent = "default") {
     }
     let handshakeOk = false;
     let probeTimedOut = false;
+    let attemptWs = null;
     try {
       const proxyUrl = ctx.getProxyUrl();
       const url = proxyUrl ?? target.webSocketDebuggerUrl;
       if (proxyUrl) {
         logger.info("CDP", `Routing via multiplexer proxy: ${proxyUrl}`);
       }
-      await connectWs(ctx, url);
+      attemptWs = await connectWs(ctx, url);
       handshakeOk = true;
       try {
         await ctx.sendWithTimeout("Runtime.evaluate", {
@@ -56704,15 +56707,21 @@ async function connectToTarget(ctx, target, retries = 5, intent = "default") {
       await ctx.setup();
       return;
     } catch (err) {
+      if (err instanceof ConnectionSetupSupersededError)
+        throw err;
       if (err instanceof PickerBlockingBundleError) {
-        closeAndResetWs(ctx);
+        if (!closeConnectionAttempt(ctx, attemptWs)) {
+          throw new ConnectionSetupSupersededError();
+        }
         ctx.setConnectedTarget(null);
         ctx.setState("disconnected");
         throw err;
       }
       lastError = err instanceof Error ? err : new Error(String(err));
       attempts3.push({ handshakeOk, probeTimedOut });
-      closeAndResetWs(ctx);
+      if (!closeConnectionAttempt(ctx, attemptWs)) {
+        throw new ConnectionSetupSupersededError();
+      }
       if (lastError.message.includes("refused")) {
         ctx.setState("disconnected");
         throw new Error("CDP connection refused. Is Metro running and the app loaded?");
@@ -56747,7 +56756,7 @@ function connectWs(ctx, url) {
       clearTimeout(guard);
       ctx.setWs(ws);
       ctx.setState("connected");
-      resolve11();
+      resolve11(ws);
     });
     ws.on("error", (err) => {
       if (!settled) {
@@ -56789,7 +56798,19 @@ function closeAndResetWs(ctx) {
     ctx.setWs(null);
   }
 }
-var PICKER_PROBE_BUDGET_MS, PickerBlockingBundleError;
+function closeConnectionAttempt(ctx, attemptWs) {
+  if (ctx.getWs() !== attemptWs)
+    return false;
+  if (!attemptWs)
+    return true;
+  attemptWs.removeAllListeners();
+  if (attemptWs.readyState === wrapper_default.OPEN || attemptWs.readyState === wrapper_default.CONNECTING) {
+    attemptWs.close();
+  }
+  ctx.setWs(null);
+  return true;
+}
+var PICKER_PROBE_BUDGET_MS, PickerBlockingBundleError, ConnectionSetupSupersededError;
 var init_connect = __esm({
   "packages/rn-dev-agent-core/dist/cdp/connect.js"() {
     "use strict";
@@ -56811,6 +56832,12 @@ var init_connect = __esm({
         super(`Dev Client picker appears to be blocking the bundle: React was not reachable on target "${target.title}" (vm=${target.vm}). If the Expo "Development servers" picker is showing on the simulator, select your Metro server, then retry cdp_status. (If the bundle is still building, just retry.)`);
         this.name = "PickerBlockingBundleError";
         this.target = target;
+      }
+    };
+    ConnectionSetupSupersededError = class extends Error {
+      constructor() {
+        super("Connection setup superseded");
+        this.name = "ConnectionSetupSupersededError";
       }
     };
   }
@@ -57482,8 +57509,9 @@ var init_cdp_client = __esm({
         const assertSetupCurrent = () => {
           const connectionIsCurrent = this.ws === setupWs && (this._connectedTarget?.id ?? null) === setupTargetId;
           const helpersAreCurrent = setupHelperToken === null || this.isHelperTokenCurrent(setupHelperToken);
-          if (!connectionIsCurrent || !helpersAreCurrent)
-            throw new Error("setup superseded");
+          if (!connectionIsCurrent || !helpersAreCurrent) {
+            throw new ConnectionSetupSupersededError();
+          }
         };
         const sendForSetup = async (method, params, ms) => {
           assertSetupCurrent();

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -57076,6 +57076,7 @@ var init_cdp_client = __esm({
           }
           return { fresh, version: version2, probed: true };
         } catch {
+          this.markHelpersUnready(token2, "freshness_probe_failed");
           return { fresh: false, version: null, probed: true };
         }
       }
@@ -57084,6 +57085,7 @@ var init_cdp_client = __esm({
         this._helpersInjected = false;
         this._bridgeDetected = false;
         this._bridgeVersion = null;
+        clearActiveFlag();
         this._helperToken = {
           generation: this._helperWorldGeneration,
           ws: this.ws,
@@ -57146,6 +57148,7 @@ var init_cdp_client = __esm({
         this._helpersInjected = false;
         this._bridgeDetected = false;
         this._bridgeVersion = null;
+        clearActiveFlag();
         logger.warn("CDP", `Helper state unavailable cause=${cause} helperEpoch=${token2.generation} connectionGeneration=${this._connectionGeneration}`);
         return false;
       }
@@ -57473,12 +57476,38 @@ var init_cdp_client = __esm({
       async setup() {
         this.ensureMetroEventsClient().catch(() => {
         });
+        const setupWs = this.ws;
+        const setupTargetId = this._connectedTarget?.id ?? null;
+        let setupHelperToken = null;
+        const assertSetupCurrent = () => {
+          const connectionIsCurrent = this.ws === setupWs && (this._connectedTarget?.id ?? null) === setupTargetId;
+          const helpersAreCurrent = setupHelperToken === null || this.isHelperTokenCurrent(setupHelperToken);
+          if (!connectionIsCurrent || !helpersAreCurrent)
+            throw new Error("setup superseded");
+        };
+        const sendForSetup = async (method, params, ms) => {
+          assertSetupCurrent();
+          const response = await this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform));
+          assertSetupCurrent();
+          return response;
+        };
+        const evaluateForSetup = async (expression) => {
+          assertSetupCurrent();
+          const response = await this.evaluate(expression);
+          assertSetupCurrent();
+          return response;
+        };
         const result = await performSetup({
-          send: (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)),
-          evaluate: (expr) => this.evaluate(expr),
+          send: sendForSetup,
+          evaluate: evaluateForSetup,
           setupHelpers: async (waitTimeout) => {
+            assertSetupCurrent();
             await waitForReact((expr) => this.evaluateCurrentHelperWorld(expr), waitTimeout);
-            return this.ensureCurrentHelpers("setup_started");
+            assertSetupCurrent();
+            setupHelperToken = this._helperToken;
+            const helpersInjected = await this.ensureCurrentHelpers("setup_started");
+            assertSetupCurrent();
+            return helpersInjected;
           },
           port: this._port,
           networkManager: this._networkBufferManager,
@@ -57487,6 +57516,7 @@ var init_cdp_client = __esm({
           clearScripts: () => this._scripts.clear(),
           clearEventHandlers: () => this.eventHandlers.clear()
         });
+        assertSetupCurrent();
         this._networkMode = result.networkMode;
         this._logDomainEnabled = result.logDomainEnabled;
         this._profilerAvailable = result.profilerAvailable;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -56707,8 +56707,6 @@ async function connectToTarget(ctx, target, retries = 5, intent = "default") {
       await ctx.setup();
       return;
     } catch (err) {
-      if (err instanceof ConnectionSetupSupersededError)
-        throw err;
       if (err instanceof PickerBlockingBundleError) {
         if (!closeConnectionAttempt(ctx, attemptWs)) {
           throw new ConnectionSetupSupersededError();
@@ -56720,6 +56718,8 @@ async function connectToTarget(ctx, target, retries = 5, intent = "default") {
       lastError = err instanceof Error ? err : new Error(String(err));
       attempts3.push({ handshakeOk, probeTimedOut });
       if (!closeConnectionAttempt(ctx, attemptWs)) {
+        if (err instanceof ConnectionSetupSupersededError)
+          throw err;
         throw new ConnectionSetupSupersededError();
       }
       if (lastError.message.includes("refused")) {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -15093,31 +15093,7 @@ function consumeCdpStale() {
   return was;
 }
 async function probeFreshness(client2, timeoutMs = FRESHNESS_PROBE_MS) {
-  if (!client2.isConnected) {
-    return { fresh: false, version: null, probed: false };
-  }
-  let probeTimer;
-  try {
-    const evalPromise = client2.evaluate('typeof globalThis.__RN_AGENT === "object" && globalThis.__RN_AGENT.__v');
-    evalPromise.catch(() => {
-    });
-    const result = await Promise.race([
-      evalPromise,
-      new Promise((resolve11) => {
-        probeTimer = setTimeout(() => resolve11({ error: "timeout" }), timeoutMs);
-      })
-    ]);
-    if (probeTimer)
-      clearTimeout(probeTimer);
-    if (result.error || typeof result.value !== "number") {
-      return { fresh: false, version: null, probed: true };
-    }
-    return { fresh: true, version: result.value, probed: true };
-  } catch {
-    if (probeTimer)
-      clearTimeout(probeTimer);
-    return { fresh: false, version: null, probed: true };
-  }
+  return client2.probeHelperFreshness(timeoutMs);
 }
 async function recoverFromStaleTarget(client2) {
   if (!client2.isConnected) {
@@ -22874,18 +22850,28 @@ function isFreshnessCached(client2) {
   const entry = freshnessCache.get(client2);
   if (!entry)
     return false;
-  if (entry.generation !== client2.connectionGeneration)
+  if (entry.generation !== client2.helperWorldGeneration)
     return false;
   return Date.now() < entry.expiresAt;
 }
 function rememberFreshness(client2) {
   freshnessCache.set(client2, {
-    generation: client2.connectionGeneration,
+    generation: client2.helperWorldGeneration,
     expiresAt: Date.now() + FRESHNESS_CACHE_MS
   });
 }
 function forgetFreshness(client2) {
   freshnessCache.delete(client2);
+}
+async function helpersNotInjectedResult(client2, boundary) {
+  const helperHealth = await client2.probeHelperHealth(2e3);
+  if (helperHealth.jsWorld === "responsive" && helperHealth.helper === "current") {
+    rememberFreshness(client2);
+    return null;
+  }
+  forgetFreshness(client2);
+  const message = helperHealth.jsWorld === "timeout" ? `Helpers are not ready and the bounded ${helperHealth.probeBudgetMs}ms health probe received no response; JavaScript may be busy, paused, or blocked.` : helperHealth.jsWorld === "transport-error" ? "Helpers are not ready and their health could not be measured because the CDP transport failed." : helperHealth.jsWorld === "superseded" ? "Helpers are not ready because the JavaScript execution world changed during the bounded health probe." : helperHealth.helper === "version-mismatch" ? "Helpers are not ready because the responsive JavaScript world contains a different helper version." : helperHealth.helper === "missing" ? "Helpers are not ready because they are missing from the responsive JavaScript world." : "Helpers are not ready because the responsive JavaScript world contains an invalid helper value.";
+  return failResult(`${boundary === "stale-recovery" ? "Stale target recovery completed, but " : ""}${message} Fall back to device_* tools or call cdp_reload once.`, "HELPERS_NOT_INJECTED", { helperHealth });
 }
 function createStepTimer() {
   let last = Date.now();
@@ -22974,7 +22960,9 @@ function withConnection(getClient2, handler, options = {}) {
             }
           }
           if (!client2.helpersInjected) {
-            return failResult("Connected but helpers still not injected after passive wait, active re-inject, and Dev Client picker dismissal. The JS world may be hung. Fall back to device_* tools (XCTest path \u2014 no helpers required) or call cdp_reload to restart the bundle.", "HELPERS_NOT_INJECTED");
+            const helperError = await helpersNotInjectedResult(client2, "initial");
+            if (helperError)
+              return helperError;
           }
         }
       }
@@ -23062,7 +23050,14 @@ function withConnection(getClient2, handler, options = {}) {
               return failResult(`Retry after stale-target recovery failed: ${retryMsg}`, "STALE_TARGET", { originalError: message });
             }
           }
-          return failResult("Stale target recovery: reconnected but helpers not injected.", "HELPERS_NOT_INJECTED", { originalError: message });
+          const helperError = await helpersNotInjectedResult(client2, "stale-recovery");
+          if (helperError)
+            return helperError;
+          try {
+            return await handler(args, client2);
+          } catch {
+            return failResult("Retry after stale-target helper reconciliation failed.", "STALE_TARGET");
+          }
         }
         if (recovery.reason === "reconnect-failed") {
           return failResult(`Stale target recovery failed: ${recovery.error}`, "STALE_TARGET", {
@@ -53046,9 +53041,9 @@ var init_multiplexer = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/bridge-detector.js
-async function detectBridge(client2) {
+async function detectBridge(client2, evaluate = (expression) => client2.evaluate(expression)) {
   try {
-    const result = await client2.evaluate(DETECT_EXPRESSION);
+    const result = await evaluate(DETECT_EXPRESSION);
     if (result.value && typeof result.value === "string") {
       return JSON.parse(result.value);
     }
@@ -56195,7 +56190,10 @@ var init_timeout_config = __esm({
 
 // packages/rn-dev-agent-core/dist/cdp/setup.js
 async function performSetup(opts) {
-  const { send, evaluate, port, connectedTarget, networkManager, getDeviceKey, setupEventHandlers, clearScripts, clearEventHandlers, probeWaits } = opts;
+  const { send, evaluate, setupHelpers, port, networkManager, getDeviceKey, setupEventHandlers, clearScripts, clearEventHandlers, probeWaits } = opts;
+  clearEventHandlers();
+  clearScripts();
+  setupEventHandlers();
   logger.debug("CDP", "Running setup: Runtime.enable, Debugger.enable...");
   await send("Runtime.enable", void 0, timeoutForMethod("Runtime.enable"));
   await send("Debugger.enable", void 0, timeoutForMethod("Debugger.enable"));
@@ -56221,24 +56219,8 @@ async function performSetup(opts) {
   ]);
   const profilerAvailable = profilerProbe.status === "fulfilled" && profilerProbe.value === true;
   const heapProfilerAvailable = heapProbe.status === "fulfilled" && heapProbe.value === true;
-  clearEventHandlers();
-  clearScripts();
-  setupEventHandlers();
-  await waitForReact(evaluate, REACT_READY_TIMEOUT_MS);
-  const helperResult = await evaluate(INJECTED_HELPERS);
-  if (helperResult.error) {
-    console.error("CDP: failed to inject helpers:", helperResult.error);
-    return {
-      networkMode,
-      helpersInjected: false,
-      logDomainEnabled,
-      profilerAvailable,
-      heapProfilerAvailable
-    };
-  }
-  const verify = await evaluate('typeof globalThis.__RN_AGENT === "object"');
-  if (verify.value !== true) {
-    console.error("CDP: helper injection succeeded but __RN_AGENT not found");
+  const helpersInjected = await setupHelpers(REACT_READY_TIMEOUT_MS);
+  if (!helpersInjected) {
     return {
       networkMode,
       helpersInjected: false,
@@ -56255,8 +56237,7 @@ async function performSetup(opts) {
     }
     networkDomainEnabled = false;
   }
-  logger.info("CDP", `Helpers injected (v${HELPERS_VERSION}), network mode: ${networkMode}`);
-  setActiveFlag(port, connectedTarget);
+  logger.info("CDP", `Helpers current (v${HELPERS_VERSION}), network mode: ${networkMode}`);
   if (networkMode === "cdp") {
     networkMode = await probeNetworkDomain({
       evaluate,
@@ -56304,19 +56285,6 @@ async function probeNetworkDomain(opts) {
   }
   logger.info("CDP", `Network.enable accepted but no events fired after ${waits.length} attempt(s) \u2014 falling back to hooks`);
   return "none";
-}
-async function reinjectHelpers(evaluate, waitTimeout) {
-  await waitForReact(evaluate, waitTimeout ?? REACT_READY_TIMEOUT_MS);
-  const helperResult = await evaluate(INJECTED_HELPERS);
-  if (helperResult.error) {
-    console.error("CDP: failed to re-inject helpers:", helperResult.error);
-    return false;
-  }
-  const verify = await evaluate('typeof globalThis.__RN_AGENT === "object"');
-  if (verify.value !== true) {
-    return false;
-  }
-  return true;
 }
 async function probeReactReachable(evaluate, budgetMs, pollMs = REACT_READY_POLL_MS) {
   const start = Date.now();
@@ -56426,7 +56394,16 @@ var init_transport = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/cdp/event-handlers.js
-function wireEventHandlers(eventHandlers, buffers, sendFn, getIsPaused, setIsPaused, getDeviceKey) {
+function wireEventHandlers(eventHandlers, buffers, sendFn, getIsPaused, setIsPaused, getDeviceKey, executionContexts) {
+  if (executionContexts) {
+    eventHandlers.set("Runtime.executionContextCreated", (params) => {
+      executionContexts.created(params);
+    });
+    eventHandlers.set("Runtime.executionContextDestroyed", (params) => {
+      executionContexts.destroyed(params);
+    });
+    eventHandlers.set("Runtime.executionContextsCleared", () => executionContexts.cleared());
+  }
   eventHandlers.set("Runtime.consoleAPICalled", (params) => {
     const p = params;
     const text = p.args?.map((a) => a.value !== void 0 ? String(a.value) : a.description ?? "").join(" ") ?? "";
@@ -56852,6 +56829,7 @@ var init_cdp_client = __esm({
     init_bridge_detector();
     init_logger();
     init_setup();
+    init_injected_helpers();
     init_state();
     init_timeout_config();
     init_transport();
@@ -56877,6 +56855,16 @@ var init_cdp_client = __esm({
       reconnecting = false;
       disposed = false;
       _helpersInjected = false;
+      _helperWorldGeneration = 0;
+      _helperContext = null;
+      _helperToken = {
+        generation: 0,
+        ws: null,
+        targetId: null,
+        contextId: null,
+        contextUniqueId: null
+      };
+      _helperInjectionInFlight = null;
       _networkMode = "none";
       _isPaused = false;
       _connectedTarget = null;
@@ -56936,6 +56924,10 @@ var init_cdp_client = __esm({
       }
       get helpersInjected() {
         return this._helpersInjected;
+      }
+      /** Private helper-world epoch exposed only for process-local cache identity. */
+      get helperWorldGeneration() {
+        return this._helperWorldGeneration;
       }
       get metroPort() {
         return this._port;
@@ -57035,17 +57027,182 @@ var init_cdp_client = __esm({
       async reinjectHelpers(waitTimeout) {
         if (!this.isConnected)
           return false;
-        const ok = await reinjectHelpers((expr) => this.evaluate(expr), waitTimeout);
-        this._helpersInjected = ok;
-        if (ok) {
-          setActiveFlag(this._port, this._connectedTarget);
-          detectBridge(this).then((r) => {
-            this._bridgeDetected = r.present;
-            this._bridgeVersion = r.version;
-          }).catch(() => {
-          });
+        await waitForReact((expr) => this.evaluateCurrentHelperWorld(expr), waitTimeout);
+        return this.ensureCurrentHelpers("reinject_started");
+      }
+      /**
+       * One bounded, context-pinned health read used only at final
+       * HELPERS_NOT_INJECTED boundaries. It never returns app values or errors.
+       */
+      async probeHelperHealth(probeBudgetMs = 2e3) {
+        const token2 = this._helperToken;
+        if (!this.isHelperTokenCurrent(token2)) {
+          return { jsWorld: "superseded", helper: "unknown", probeBudgetMs };
         }
-        return ok;
+        const expression = `(function(){try{var d=Object.getOwnPropertyDescriptor(globalThis,'__RN_AGENT');if(!d)return 'missing';if(!('value' in d)||typeof d.value!=='object'||d.value===null)return 'invalid';var v=Object.getOwnPropertyDescriptor(d.value,'__v');if(!v||!('value' in v)||typeof v.value!=='number')return 'invalid';return v.value===${HELPERS_VERSION}?'current':'version-mismatch';}catch(_){return 'invalid';}})()`;
+        try {
+          const result = await this.evaluateForHelperToken(token2, expression, probeBudgetMs);
+          if (!this.isHelperTokenCurrent(token2)) {
+            return { jsWorld: "superseded", helper: "unknown", probeBudgetMs };
+          }
+          const helper = result.value === "current" || result.value === "missing" || result.value === "version-mismatch" || result.value === "invalid" ? result.value : "invalid";
+          if (helper === "current")
+            this.markHelpersReady(token2, "health_reconciled_current");
+          return { jsWorld: "responsive", helper, probeBudgetMs };
+        } catch (err) {
+          if (!this.isHelperTokenCurrent(token2)) {
+            return { jsWorld: "superseded", helper: "unknown", probeBudgetMs };
+          }
+          const timedOut = err instanceof Error && err.message.startsWith("CDP timeout (");
+          return {
+            jsWorld: timedOut ? "timeout" : "transport-error",
+            helper: "unknown",
+            probeBudgetMs
+          };
+        }
+      }
+      async probeHelperFreshness(timeoutMs = 2e3) {
+        if (!this.isConnected)
+          return { fresh: false, version: null, probed: false };
+        const token2 = this._helperToken;
+        try {
+          const result = await this.evaluateForHelperToken(token2, `typeof globalThis.__RN_AGENT === 'object' && globalThis.__RN_AGENT !== null ? globalThis.__RN_AGENT.__v : null`, timeoutMs);
+          if (!this.isHelperTokenCurrent(token2))
+            return { fresh: false, version: null, probed: true };
+          const version2 = typeof result.value === "number" ? result.value : null;
+          const fresh = version2 === HELPERS_VERSION;
+          if (!fresh) {
+            this.markHelpersUnready(token2, version2 === null ? "freshness_missing" : "freshness_version_mismatch");
+          }
+          return { fresh, version: version2, probed: true };
+        } catch {
+          return { fresh: false, version: null, probed: true };
+        }
+      }
+      invalidateHelperWorld(cause) {
+        this._helperWorldGeneration++;
+        this._helpersInjected = false;
+        this._bridgeDetected = false;
+        this._bridgeVersion = null;
+        this._helperToken = {
+          generation: this._helperWorldGeneration,
+          ws: this.ws,
+          targetId: this._connectedTarget?.id ?? null,
+          contextId: this._helperContext?.id ?? null,
+          contextUniqueId: this._helperContext?.uniqueId ?? null
+        };
+        logger.info("CDP", `Helper state invalidated cause=${cause} helperEpoch=${this._helperWorldGeneration} connectionGeneration=${this._connectionGeneration}`);
+      }
+      isHelperTokenCurrent(token2) {
+        return token2 === this._helperToken && token2.ws === this.ws && token2.targetId === (this._connectedTarget?.id ?? null);
+      }
+      async evaluateCurrentHelperWorld(expression) {
+        const token2 = this._helperToken;
+        try {
+          return await this.evaluateForHelperToken(token2, expression, defaultTimeout(this.effectivePlatform));
+        } catch {
+          return { error: "helper-world evaluation unavailable" };
+        }
+      }
+      async evaluateForHelperToken(token2, expression, timeoutMs) {
+        if (!this.isHelperTokenCurrent(token2))
+          throw new Error("helper world superseded");
+        const params = {
+          expression,
+          returnByValue: true
+        };
+        if (token2.contextId !== null)
+          params.contextId = token2.contextId;
+        const result = await this.sendWithTimeout("Runtime.evaluate", params, timeoutMs);
+        if (!this.isHelperTokenCurrent(token2))
+          throw new Error("helper world superseded");
+        if (result?.exceptionDetails)
+          return { error: "helper-world expression failed" };
+        return { value: result?.result?.value };
+      }
+      async ensureCurrentHelpers(cause) {
+        const token2 = this._helperToken;
+        if (!this.isHelperTokenCurrent(token2) || !this.isConnected)
+          return false;
+        if (this._helpersInjected)
+          return true;
+        if (this._helperInjectionInFlight?.token === token2) {
+          return this._helperInjectionInFlight.promise;
+        }
+        const slot = {
+          token: token2,
+          promise: Promise.resolve(false)
+        };
+        slot.promise = this.injectAndVerifyHelpers(token2, cause).finally(() => {
+          if (this._helperInjectionInFlight === slot)
+            this._helperInjectionInFlight = null;
+        });
+        this._helperInjectionInFlight = slot;
+        return slot.promise;
+      }
+      markHelpersUnready(token2, cause) {
+        if (!this.isHelperTokenCurrent(token2))
+          return false;
+        this._helpersInjected = false;
+        this._bridgeDetected = false;
+        this._bridgeVersion = null;
+        logger.warn("CDP", `Helper state unavailable cause=${cause} helperEpoch=${token2.generation} connectionGeneration=${this._connectionGeneration}`);
+        return false;
+      }
+      async injectAndVerifyHelpers(token2, cause) {
+        logger.info("CDP", `Helper injection ${cause} helperEpoch=${token2.generation} connectionGeneration=${this._connectionGeneration}`);
+        try {
+          const injected = await this.evaluateForHelperToken(token2, INJECTED_HELPERS, defaultTimeout(this.effectivePlatform));
+          if (injected.error) {
+            return this.markHelpersUnready(token2, cause === "setup_started" ? "setup_failed" : "reinject_failed");
+          }
+          const verified = await this.evaluateForHelperToken(token2, `typeof globalThis.__RN_AGENT === 'object' && globalThis.__RN_AGENT !== null && globalThis.__RN_AGENT.__v === ${HELPERS_VERSION}`, defaultTimeout(this.effectivePlatform));
+          if (verified.value !== true || !this.isHelperTokenCurrent(token2)) {
+            return this.markHelpersUnready(token2, cause === "setup_started" ? "setup_failed" : "reinject_failed");
+          }
+          this.markHelpersReady(token2, cause === "setup_started" ? "setup_current" : "reinject_current");
+          return true;
+        } catch {
+          return this.markHelpersUnready(token2, cause === "setup_started" ? "setup_failed" : "reinject_failed");
+        }
+      }
+      markHelpersReady(token2, cause) {
+        if (!this.isHelperTokenCurrent(token2))
+          return;
+        this._helpersInjected = true;
+        setActiveFlag(this._port, this._connectedTarget);
+        logger.info("CDP", `Helper state ready cause=${cause} helperEpoch=${token2.generation} connectionGeneration=${this._connectionGeneration}`);
+        detectBridge(this, (expression) => this.evaluateForHelperToken(token2, expression, defaultTimeout(this.effectivePlatform))).then((r) => {
+          if (!this.isHelperTokenCurrent(token2))
+            return;
+          this._bridgeDetected = r.present;
+          this._bridgeVersion = r.version;
+        }).catch(() => {
+        });
+      }
+      handleExecutionContextCreated(params) {
+        const id = params.context?.id;
+        if (typeof id !== "number" || params.context?.auxData?.isDefault === false)
+          return;
+        const next = { id, uniqueId: params.context?.uniqueId };
+        if (this._helperContext?.id === next.id && this._helperContext.uniqueId === next.uniqueId)
+          return;
+        this._helperContext = next;
+        this.invalidateHelperWorld("context_created");
+      }
+      handleExecutionContextDestroyed(params) {
+        if (!this._helperContext)
+          return;
+        const matchesId = params.executionContextId === this._helperContext.id;
+        const matchesUnique = params.executionContextUniqueId !== void 0 && params.executionContextUniqueId === this._helperContext.uniqueId;
+        if (!matchesId && !matchesUnique)
+          return;
+        this._helperContext = null;
+        this.invalidateHelperWorld("context_destroyed");
+      }
+      handleExecutionContextsCleared() {
+        this._helperContext = null;
+        this.invalidateHelperWorld("contexts_cleared");
       }
       async autoConnect(portHint, filtersOrPlatform, intent = "default") {
         const filters = typeof filtersOrPlatform === "string" ? { platform: filtersOrPlatform } : filtersOrPlatform ?? {};
@@ -57196,6 +57353,7 @@ var init_cdp_client = __esm({
         if (this.disposed)
           return;
         this.disposed = true;
+        this.invalidateHelperWorld("explicit_disconnect");
         resetState(this.buildResettableState());
         clearActiveFlag();
         this.stopBackgroundPoll();
@@ -57318,8 +57476,11 @@ var init_cdp_client = __esm({
         const result = await performSetup({
           send: (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)),
           evaluate: (expr) => this.evaluate(expr),
+          setupHelpers: async (waitTimeout) => {
+            await waitForReact((expr) => this.evaluateCurrentHelperWorld(expr), waitTimeout);
+            return this.ensureCurrentHelpers("setup_started");
+          },
           port: this._port,
-          connectedTarget: this._connectedTarget,
           networkManager: this._networkBufferManager,
           getDeviceKey: () => this.activeDeviceKey,
           setupEventHandlers: () => this.setupEventHandlers(),
@@ -57327,18 +57488,9 @@ var init_cdp_client = __esm({
           clearEventHandlers: () => this.eventHandlers.clear()
         });
         this._networkMode = result.networkMode;
-        this._helpersInjected = result.helpersInjected;
         this._logDomainEnabled = result.logDomainEnabled;
         this._profilerAvailable = result.profilerAvailable;
         this._heapProfilerAvailable = result.heapProfilerAvailable;
-        if (result.helpersInjected) {
-          detectBridge(this).then((r) => {
-            this._bridgeDetected = r.present;
-            this._bridgeVersion = r.version;
-            logger.debug("CDP", `Bridge detection: present=${r.present}, version=${r.version}`);
-          }).catch(() => {
-          });
-        }
       }
       async ensureMetroEventsClient() {
         if (this._metroEventsClient && this._metroEventsClient.port !== this._port) {
@@ -57358,9 +57510,15 @@ var init_cdp_client = __esm({
           scripts: this._scripts
         }, (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)), () => this._isPaused, (v) => {
           this._isPaused = v;
-        }, () => this.activeDeviceKey);
+        }, () => this.activeDeviceKey, {
+          created: (params) => this.handleExecutionContextCreated(params),
+          destroyed: (params) => this.handleExecutionContextDestroyed(params),
+          cleared: () => this.handleExecutionContextsCleared()
+        });
       }
       handleClose(code) {
+        this.ws = null;
+        this.invalidateHelperWorld("socket_closed");
         if (this._proxyUrl) {
           void this._suspendProxy();
         }
@@ -57401,6 +57559,8 @@ var init_cdp_client = __esm({
                 this.ws.close();
               }
               this.ws = null;
+              this._helperContext = null;
+              this.invalidateHelperWorld("soft_reconnect");
             }
           },
           rejectAllPending: (reason) => this.rejectAllPending(reason),
@@ -57438,13 +57598,21 @@ var init_cdp_client = __esm({
           },
           getWs: () => this.ws,
           setWs: (ws) => {
+            if (this.ws === ws)
+              return;
             this.ws = ws;
+            this._helperContext = null;
+            this.invalidateHelperWorld(ws ? "socket_opened" : "socket_closed");
           },
           setHelpersInjected: (v) => {
-            this._helpersInjected = v;
+            if (!v)
+              this.invalidateHelperWorld("candidate_rejected");
           },
           setConnectedTarget: (t) => {
+            if (this._connectedTarget === t)
+              return;
             this._connectedTarget = t;
+            this.invalidateHelperWorld(t ? "candidate_selected" : "candidate_rejected");
           },
           setConnectedAt: (ms) => {
             this._connectedAt = ms;

--- a/packages/codex-plugin/skills/rn-debugging/SKILL.md
+++ b/packages/codex-plugin/skills/rn-debugging/SKILL.md
@@ -110,7 +110,7 @@ When a `cdp_*` tool returns `code: HELPERS_NOT_INJECTED`, the bridge has already
 3. Attempted a Dev Client picker dismissal (in case a native overlay was blocking React)
 4. Waited up to another 30s if the picker was dismissed
 
-So when this error appears, **the JS world is genuinely hung** — Hermes is up but `__RN_AGENT` won't land. Two recovery paths, in order:
+The final error includes `meta.helperHealth`: `jsWorld` is one of `responsive`, `timeout`, `transport-error`, or `superseded`; `helper` is one of `current`, `missing`, `version-mismatch`, `invalid`, or `unknown`; and `probeBudgetMs` reports the bounded probe budget. A timeout proves only that the probe received no response within that budget — JavaScript may be busy, paused, or blocked. A responsive/current result is reconciled automatically and the gated call continues, so an emitted error describes missing, mismatched, invalid, unmeasurable, or superseded helper evidence rather than claiming a genuine hang. Use these two recovery paths, in order:
 
 | Step | Action | Why |
 |------|--------|-----|

--- a/packages/rn-dev-agent-core/dist/bridge-detector.js
+++ b/packages/rn-dev-agent-core/dist/bridge-detector.js
@@ -9,9 +9,9 @@ const DETECT_EXPRESSION = `
   return JSON.stringify({ present: true, version: b.__v || null });
 })()
 `;
-export async function detectBridge(client) {
+export async function detectBridge(client, evaluate = (expression) => client.evaluate(expression)) {
     try {
-        const result = await client.evaluate(DETECT_EXPRESSION);
+        const result = await evaluate(DETECT_EXPRESSION);
         if (result.value && typeof result.value === 'string') {
             return JSON.parse(result.value);
         }

--- a/packages/rn-dev-agent-core/dist/cdp-client.js
+++ b/packages/rn-dev-agent-core/dist/cdp-client.js
@@ -5,7 +5,8 @@ import { MetroEventsClient } from './metro/events-client.js';
 import { CDPMultiplexer } from './cdp/multiplexer.js';
 import { detectBridge } from './bridge-detector.js';
 import { logger } from './logger.js';
-import { performSetup, reinjectHelpers as reinjectHelpersFn } from './cdp/setup.js';
+import { performSetup, waitForReact } from './cdp/setup.js';
+import { HELPERS_VERSION, INJECTED_HELPERS } from './injected-helpers.js';
 import { resetState, setActiveFlag, clearActiveFlag, sleep } from './cdp/state.js';
 import { defaultTimeout, timeoutForMethod } from './cdp/timeout-config.js';
 import { sendWithTimeout as sendMsg, rejectAllPending as rejectPending, handleMessage as handleMsg, } from './cdp/transport.js';
@@ -31,6 +32,16 @@ export class CDPClient {
     reconnecting = false;
     disposed = false;
     _helpersInjected = false;
+    _helperWorldGeneration = 0;
+    _helperContext = null;
+    _helperToken = {
+        generation: 0,
+        ws: null,
+        targetId: null,
+        contextId: null,
+        contextUniqueId: null,
+    };
+    _helperInjectionInFlight = null;
     _networkMode = 'none';
     _isPaused = false;
     _connectedTarget = null;
@@ -92,6 +103,10 @@ export class CDPClient {
     }
     get helpersInjected() {
         return this._helpersInjected;
+    }
+    /** Private helper-world epoch exposed only for process-local cache identity. */
+    get helperWorldGeneration() {
+        return this._helperWorldGeneration;
     }
     get metroPort() {
         return this._port;
@@ -191,18 +206,201 @@ export class CDPClient {
     async reinjectHelpers(waitTimeout) {
         if (!this.isConnected)
             return false;
-        const ok = await reinjectHelpersFn((expr) => this.evaluate(expr), waitTimeout);
-        this._helpersInjected = ok;
-        if (ok) {
-            setActiveFlag(this._port, this._connectedTarget);
-            detectBridge(this)
-                .then((r) => {
-                this._bridgeDetected = r.present;
-                this._bridgeVersion = r.version;
-            })
-                .catch(() => { });
+        // Caller-specific React readiness stays outside the shared injection core.
+        await waitForReact((expr) => this.evaluateCurrentHelperWorld(expr), waitTimeout);
+        return this.ensureCurrentHelpers('reinject_started');
+    }
+    /**
+     * One bounded, context-pinned health read used only at final
+     * HELPERS_NOT_INJECTED boundaries. It never returns app values or errors.
+     */
+    async probeHelperHealth(probeBudgetMs = 2000) {
+        const token = this._helperToken;
+        if (!this.isHelperTokenCurrent(token)) {
+            return { jsWorld: 'superseded', helper: 'unknown', probeBudgetMs };
         }
-        return ok;
+        const expression = `(function(){try{var d=Object.getOwnPropertyDescriptor(globalThis,'__RN_AGENT');if(!d)return 'missing';if(!('value' in d)||typeof d.value!=='object'||d.value===null)return 'invalid';var v=Object.getOwnPropertyDescriptor(d.value,'__v');if(!v||!('value' in v)||typeof v.value!=='number')return 'invalid';return v.value===${HELPERS_VERSION}?'current':'version-mismatch';}catch(_){return 'invalid';}})()`;
+        try {
+            const result = await this.evaluateForHelperToken(token, expression, probeBudgetMs);
+            if (!this.isHelperTokenCurrent(token)) {
+                return { jsWorld: 'superseded', helper: 'unknown', probeBudgetMs };
+            }
+            const helper = result.value === 'current' ||
+                result.value === 'missing' ||
+                result.value === 'version-mismatch' ||
+                result.value === 'invalid'
+                ? result.value
+                : 'invalid';
+            if (helper === 'current')
+                this.markHelpersReady(token, 'health_reconciled_current');
+            return { jsWorld: 'responsive', helper, probeBudgetMs };
+        }
+        catch (err) {
+            if (!this.isHelperTokenCurrent(token)) {
+                return { jsWorld: 'superseded', helper: 'unknown', probeBudgetMs };
+            }
+            const timedOut = err instanceof Error && err.message.startsWith('CDP timeout (');
+            return {
+                jsWorld: timedOut ? 'timeout' : 'transport-error',
+                helper: 'unknown',
+                probeBudgetMs,
+            };
+        }
+    }
+    async probeHelperFreshness(timeoutMs = 2000) {
+        if (!this.isConnected)
+            return { fresh: false, version: null, probed: false };
+        const token = this._helperToken;
+        try {
+            const result = await this.evaluateForHelperToken(token, `typeof globalThis.__RN_AGENT === 'object' && globalThis.__RN_AGENT !== null ? globalThis.__RN_AGENT.__v : null`, timeoutMs);
+            if (!this.isHelperTokenCurrent(token))
+                return { fresh: false, version: null, probed: true };
+            const version = typeof result.value === 'number' ? result.value : null;
+            const fresh = version === HELPERS_VERSION;
+            if (!fresh) {
+                this.markHelpersUnready(token, version === null ? 'freshness_missing' : 'freshness_version_mismatch');
+            }
+            return { fresh, version, probed: true };
+        }
+        catch {
+            return { fresh: false, version: null, probed: true };
+        }
+    }
+    invalidateHelperWorld(cause) {
+        this._helperWorldGeneration++;
+        this._helpersInjected = false;
+        this._bridgeDetected = false;
+        this._bridgeVersion = null;
+        this._helperToken = {
+            generation: this._helperWorldGeneration,
+            ws: this.ws,
+            targetId: this._connectedTarget?.id ?? null,
+            contextId: this._helperContext?.id ?? null,
+            contextUniqueId: this._helperContext?.uniqueId ?? null,
+        };
+        logger.info('CDP', `Helper state invalidated cause=${cause} helperEpoch=${this._helperWorldGeneration} connectionGeneration=${this._connectionGeneration}`);
+    }
+    isHelperTokenCurrent(token) {
+        return (token === this._helperToken &&
+            token.ws === this.ws &&
+            token.targetId === (this._connectedTarget?.id ?? null));
+    }
+    async evaluateCurrentHelperWorld(expression) {
+        const token = this._helperToken;
+        try {
+            return await this.evaluateForHelperToken(token, expression, defaultTimeout(this.effectivePlatform));
+        }
+        catch {
+            return { error: 'helper-world evaluation unavailable' };
+        }
+    }
+    async evaluateForHelperToken(token, expression, timeoutMs) {
+        if (!this.isHelperTokenCurrent(token))
+            throw new Error('helper world superseded');
+        const params = {
+            expression,
+            returnByValue: true,
+        };
+        if (token.contextId !== null)
+            params.contextId = token.contextId;
+        const result = (await this.sendWithTimeout('Runtime.evaluate', params, timeoutMs));
+        if (!this.isHelperTokenCurrent(token))
+            throw new Error('helper world superseded');
+        if (result?.exceptionDetails)
+            return { error: 'helper-world expression failed' };
+        return { value: result?.result?.value };
+    }
+    async ensureCurrentHelpers(cause) {
+        const token = this._helperToken;
+        if (!this.isHelperTokenCurrent(token) || !this.isConnected)
+            return false;
+        if (this._helpersInjected)
+            return true;
+        if (this._helperInjectionInFlight?.token === token) {
+            return this._helperInjectionInFlight.promise;
+        }
+        const slot = {
+            token,
+            promise: Promise.resolve(false),
+        };
+        slot.promise = this.injectAndVerifyHelpers(token, cause).finally(() => {
+            // Identity cleanup: an old world's late finally cannot clear a newer slot.
+            if (this._helperInjectionInFlight === slot)
+                this._helperInjectionInFlight = null;
+        });
+        this._helperInjectionInFlight = slot;
+        return slot.promise;
+    }
+    markHelpersUnready(token, cause) {
+        if (!this.isHelperTokenCurrent(token))
+            return false;
+        this._helpersInjected = false;
+        this._bridgeDetected = false;
+        this._bridgeVersion = null;
+        logger.warn('CDP', `Helper state unavailable cause=${cause} helperEpoch=${token.generation} connectionGeneration=${this._connectionGeneration}`);
+        return false;
+    }
+    async injectAndVerifyHelpers(token, cause) {
+        logger.info('CDP', `Helper injection ${cause} helperEpoch=${token.generation} connectionGeneration=${this._connectionGeneration}`);
+        try {
+            const injected = await this.evaluateForHelperToken(token, INJECTED_HELPERS, defaultTimeout(this.effectivePlatform));
+            if (injected.error) {
+                return this.markHelpersUnready(token, cause === 'setup_started' ? 'setup_failed' : 'reinject_failed');
+            }
+            const verified = await this.evaluateForHelperToken(token, `typeof globalThis.__RN_AGENT === 'object' && globalThis.__RN_AGENT !== null && globalThis.__RN_AGENT.__v === ${HELPERS_VERSION}`, defaultTimeout(this.effectivePlatform));
+            if (verified.value !== true || !this.isHelperTokenCurrent(token)) {
+                return this.markHelpersUnready(token, cause === 'setup_started' ? 'setup_failed' : 'reinject_failed');
+            }
+            this.markHelpersReady(token, cause === 'setup_started' ? 'setup_current' : 'reinject_current');
+            return true;
+        }
+        catch {
+            // Expected transport/context replacement failures are a bounded false;
+            // stale worlds are intentionally not allowed to log a current transition.
+            return this.markHelpersUnready(token, cause === 'setup_started' ? 'setup_failed' : 'reinject_failed');
+        }
+    }
+    markHelpersReady(token, cause) {
+        if (!this.isHelperTokenCurrent(token))
+            return;
+        this._helpersInjected = true;
+        setActiveFlag(this._port, this._connectedTarget);
+        logger.info('CDP', `Helper state ready cause=${cause} helperEpoch=${token.generation} connectionGeneration=${this._connectionGeneration}`);
+        detectBridge(this, (expression) => this.evaluateForHelperToken(token, expression, defaultTimeout(this.effectivePlatform)))
+            .then((r) => {
+            if (!this.isHelperTokenCurrent(token))
+                return;
+            this._bridgeDetected = r.present;
+            this._bridgeVersion = r.version;
+        })
+            .catch(() => { });
+    }
+    handleExecutionContextCreated(params) {
+        const id = params.context?.id;
+        // Modern RN marks its announced runtime as the default context. Ignore
+        // explicitly auxiliary contexts; legacy one-context backends omit auxData.
+        if (typeof id !== 'number' || params.context?.auxData?.isDefault === false)
+            return;
+        const next = { id, uniqueId: params.context?.uniqueId };
+        if (this._helperContext?.id === next.id && this._helperContext.uniqueId === next.uniqueId)
+            return;
+        this._helperContext = next;
+        this.invalidateHelperWorld('context_created');
+    }
+    handleExecutionContextDestroyed(params) {
+        if (!this._helperContext)
+            return;
+        const matchesId = params.executionContextId === this._helperContext.id;
+        const matchesUnique = params.executionContextUniqueId !== undefined &&
+            params.executionContextUniqueId === this._helperContext.uniqueId;
+        if (!matchesId && !matchesUnique)
+            return;
+        this._helperContext = null;
+        this.invalidateHelperWorld('context_destroyed');
+    }
+    handleExecutionContextsCleared() {
+        this._helperContext = null;
+        this.invalidateHelperWorld('contexts_cleared');
     }
     async autoConnect(portHint, filtersOrPlatform, intent = 'default') {
         const filters = typeof filtersOrPlatform === 'string'
@@ -394,6 +592,7 @@ export class CDPClient {
         if (this.disposed)
             return;
         this.disposed = true;
+        this.invalidateHelperWorld('explicit_disconnect');
         resetState(this.buildResettableState());
         clearActiveFlag();
         this.stopBackgroundPoll();
@@ -537,8 +736,11 @@ export class CDPClient {
         const result = await performSetup({
             send: (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)),
             evaluate: (expr) => this.evaluate(expr),
+            setupHelpers: async (waitTimeout) => {
+                await waitForReact((expr) => this.evaluateCurrentHelperWorld(expr), waitTimeout);
+                return this.ensureCurrentHelpers('setup_started');
+            },
             port: this._port,
-            connectedTarget: this._connectedTarget,
             networkManager: this._networkBufferManager,
             getDeviceKey: () => this.activeDeviceKey,
             setupEventHandlers: () => this.setupEventHandlers(),
@@ -546,19 +748,10 @@ export class CDPClient {
             clearEventHandlers: () => this.eventHandlers.clear(),
         });
         this._networkMode = result.networkMode;
-        this._helpersInjected = result.helpersInjected;
+        // Helper state is owned exclusively by the token-scoped coordinator.
         this._logDomainEnabled = result.logDomainEnabled;
         this._profilerAvailable = result.profilerAvailable;
         this._heapProfilerAvailable = result.heapProfilerAvailable;
-        if (result.helpersInjected) {
-            detectBridge(this)
-                .then((r) => {
-                this._bridgeDetected = r.present;
-                this._bridgeVersion = r.version;
-                logger.debug('CDP', `Bridge detection: present=${r.present}, version=${r.version}`);
-            })
-                .catch(() => { });
-        }
     }
     async ensureMetroEventsClient() {
         // Multi-review catch: if Metro hopped ports (CDPClient's `_port` was updated
@@ -583,9 +776,16 @@ export class CDPClient {
             scripts: this._scripts,
         }, (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)), () => this._isPaused, (v) => {
             this._isPaused = v;
-        }, () => this.activeDeviceKey);
+        }, () => this.activeDeviceKey, {
+            created: (params) => this.handleExecutionContextCreated(params),
+            destroyed: (params) => this.handleExecutionContextDestroyed(params),
+            cleared: () => this.handleExecutionContextsCleared(),
+        });
     }
     handleClose(code) {
+        // Invalidate synchronously before reconnect/reset can await or select a new world.
+        this.ws = null;
+        this.invalidateHelperWorld('socket_closed');
         // B132: if the proxy is active when the upstream closes, suspend it BEFORE
         // the reconnect loop fires. `_suspendProxy` clears `_proxyUrl` synchronously
         // at its start (before the first await), so by the time `reconnect()` calls
@@ -633,6 +833,8 @@ export class CDPClient {
                         this.ws.close();
                     }
                     this.ws = null;
+                    this._helperContext = null;
+                    this.invalidateHelperWorld('soft_reconnect');
                 }
             },
             rejectAllPending: (reason) => this.rejectAllPending(reason),
@@ -670,13 +872,21 @@ export class CDPClient {
             },
             getWs: () => this.ws,
             setWs: (ws) => {
+                if (this.ws === ws)
+                    return;
                 this.ws = ws;
+                this._helperContext = null;
+                this.invalidateHelperWorld(ws ? 'socket_opened' : 'socket_closed');
             },
             setHelpersInjected: (v) => {
-                this._helpersInjected = v;
+                if (!v)
+                    this.invalidateHelperWorld('candidate_rejected');
             },
             setConnectedTarget: (t) => {
+                if (this._connectedTarget === t)
+                    return;
                 this._connectedTarget = t;
+                this.invalidateHelperWorld(t ? 'candidate_selected' : 'candidate_rejected');
             },
             setConnectedAt: (ms) => {
                 this._connectedAt = ms;

--- a/packages/rn-dev-agent-core/dist/cdp-client.js
+++ b/packages/rn-dev-agent-core/dist/cdp-client.js
@@ -13,7 +13,7 @@ import { sendWithTimeout as sendMsg, rejectAllPending as rejectPending, handleMe
 import { wireEventHandlers, parseNetworkHookMessage as parseNetHook, } from './cdp/event-handlers.js';
 import { discoverForList } from './cdp/discovery.js';
 import { helperExpr as helperExprFn, bridgeWithFallback as bridgeWithFallbackFn, } from './cdp/helper-expr.js';
-import { autoConnect as autoConnectFn, discoverAndConnect as discoverAndConnectFn, } from './cdp/connect.js';
+import { autoConnect as autoConnectFn, ConnectionSetupSupersededError, discoverAndConnect as discoverAndConnectFn, } from './cdp/connect.js';
 import { resolveAutoConnect } from './project-config.js';
 import { handleClose as handleCloseFn, reconnect as reconnectFn, softReconnect as softReconnectFn, startBackgroundPoll as startBgPoll, stopBackgroundPoll as stopBgPoll, } from './cdp/reconnection.js';
 export class CDPClient {
@@ -742,8 +742,9 @@ export class CDPClient {
         const assertSetupCurrent = () => {
             const connectionIsCurrent = this.ws === setupWs && (this._connectedTarget?.id ?? null) === setupTargetId;
             const helpersAreCurrent = setupHelperToken === null || this.isHelperTokenCurrent(setupHelperToken);
-            if (!connectionIsCurrent || !helpersAreCurrent)
-                throw new Error('setup superseded');
+            if (!connectionIsCurrent || !helpersAreCurrent) {
+                throw new ConnectionSetupSupersededError();
+            }
         };
         const sendForSetup = async (method, params, ms) => {
             assertSetupCurrent();

--- a/packages/rn-dev-agent-core/dist/cdp-client.js
+++ b/packages/rn-dev-agent-core/dist/cdp-client.js
@@ -263,6 +263,7 @@ export class CDPClient {
             return { fresh, version, probed: true };
         }
         catch {
+            this.markHelpersUnready(token, 'freshness_probe_failed');
             return { fresh: false, version: null, probed: true };
         }
     }
@@ -271,6 +272,7 @@ export class CDPClient {
         this._helpersInjected = false;
         this._bridgeDetected = false;
         this._bridgeVersion = null;
+        clearActiveFlag();
         this._helperToken = {
             generation: this._helperWorldGeneration,
             ws: this.ws,
@@ -337,6 +339,7 @@ export class CDPClient {
         this._helpersInjected = false;
         this._bridgeDetected = false;
         this._bridgeVersion = null;
+        clearActiveFlag();
         logger.warn('CDP', `Helper state unavailable cause=${cause} helperEpoch=${token.generation} connectionGeneration=${this._connectionGeneration}`);
         return false;
     }
@@ -733,12 +736,38 @@ export class CDPClient {
         this.ensureMetroEventsClient().catch(() => {
             /* MetroEventsClient handles its own reconnects */
         });
+        const setupWs = this.ws;
+        const setupTargetId = this._connectedTarget?.id ?? null;
+        let setupHelperToken = null;
+        const assertSetupCurrent = () => {
+            const connectionIsCurrent = this.ws === setupWs && (this._connectedTarget?.id ?? null) === setupTargetId;
+            const helpersAreCurrent = setupHelperToken === null || this.isHelperTokenCurrent(setupHelperToken);
+            if (!connectionIsCurrent || !helpersAreCurrent)
+                throw new Error('setup superseded');
+        };
+        const sendForSetup = async (method, params, ms) => {
+            assertSetupCurrent();
+            const response = await this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform));
+            assertSetupCurrent();
+            return response;
+        };
+        const evaluateForSetup = async (expression) => {
+            assertSetupCurrent();
+            const response = await this.evaluate(expression);
+            assertSetupCurrent();
+            return response;
+        };
         const result = await performSetup({
-            send: (method, params, ms) => this.sendWithTimeout(method, params, ms ?? timeoutForMethod(method, this.effectivePlatform)),
-            evaluate: (expr) => this.evaluate(expr),
+            send: sendForSetup,
+            evaluate: evaluateForSetup,
             setupHelpers: async (waitTimeout) => {
+                assertSetupCurrent();
                 await waitForReact((expr) => this.evaluateCurrentHelperWorld(expr), waitTimeout);
-                return this.ensureCurrentHelpers('setup_started');
+                assertSetupCurrent();
+                setupHelperToken = this._helperToken;
+                const helpersInjected = await this.ensureCurrentHelpers('setup_started');
+                assertSetupCurrent();
+                return helpersInjected;
             },
             port: this._port,
             networkManager: this._networkBufferManager,
@@ -747,6 +776,7 @@ export class CDPClient {
             clearScripts: () => this._scripts.clear(),
             clearEventHandlers: () => this.eventHandlers.clear(),
         });
+        assertSetupCurrent();
         this._networkMode = result.networkMode;
         // Helper state is owned exclusively by the token-scoped coordinator.
         this._logDomainEnabled = result.logDomainEnabled;

--- a/packages/rn-dev-agent-core/dist/cdp/connect.js
+++ b/packages/rn-dev-agent-core/dist/cdp/connect.js
@@ -31,6 +31,12 @@ export class PickerBlockingBundleError extends Error {
         this.target = target;
     }
 }
+export class ConnectionSetupSupersededError extends Error {
+    constructor() {
+        super('Connection setup superseded');
+        this.name = 'ConnectionSetupSupersededError';
+    }
+}
 /**
  * GH #184: run the bounded picker probe only for a status-intent connect against
  * a non-Hermes target. Hermes targets are skipped so a genuinely slow Hermes
@@ -134,6 +140,8 @@ intent = 'default') {
         catch (err) {
             // GH #184: picker-blocking affects the whole bundle — every other
             // candidate is the same stale C++ target, so don't waste a probe on each.
+            if (err instanceof ConnectionSetupSupersededError)
+                throw err;
             if (err instanceof PickerBlockingBundleError) {
                 ctx.setState('disconnected');
                 throw err;
@@ -211,6 +219,7 @@ async function connectToTarget(ctx, target, retries = 5, intent = 'default') {
         }
         let handshakeOk = false;
         let probeTimedOut = false;
+        let attemptWs = null;
         try {
             // M1b: ride the multiplexer when _proxyUrl is set (from CDPClient.startProxy).
             // Falls back to the target's direct webSocketDebuggerUrl when no proxy is active.
@@ -219,7 +228,7 @@ async function connectToTarget(ctx, target, retries = 5, intent = 'default') {
             if (proxyUrl) {
                 logger.info('CDP', `Routing via multiplexer proxy: ${proxyUrl}`);
             }
-            await connectWs(ctx, url);
+            attemptWs = await connectWs(ctx, url);
             handshakeOk = true;
             // D594: Early stale-target detection — quick probe before full setup
             try {
@@ -250,17 +259,23 @@ async function connectToTarget(ctx, target, retries = 5, intent = 'default') {
             return;
         }
         catch (err) {
+            if (err instanceof ConnectionSetupSupersededError)
+                throw err;
             // GH #184: the picker-blocking abort is deterministic, not transient —
             // don't burn the retry budget on it; clean up and surface it immediately.
             if (err instanceof PickerBlockingBundleError) {
-                closeAndResetWs(ctx);
+                if (!closeConnectionAttempt(ctx, attemptWs)) {
+                    throw new ConnectionSetupSupersededError();
+                }
                 ctx.setConnectedTarget(null);
                 ctx.setState('disconnected');
                 throw err;
             }
             lastError = err instanceof Error ? err : new Error(String(err));
             attempts.push({ handshakeOk, probeTimedOut });
-            closeAndResetWs(ctx);
+            if (!closeConnectionAttempt(ctx, attemptWs)) {
+                throw new ConnectionSetupSupersededError();
+            }
             if (lastError.message.includes('refused')) {
                 ctx.setState('disconnected');
                 throw new Error('CDP connection refused. Is Metro running and the app loaded?');
@@ -300,7 +315,7 @@ function connectWs(ctx, url) {
             clearTimeout(guard);
             ctx.setWs(ws);
             ctx.setState('connected');
-            resolve();
+            resolve(ws);
         });
         ws.on('error', (err) => {
             if (!settled) {
@@ -344,4 +359,16 @@ function closeAndResetWs(ctx) {
         }
         ctx.setWs(null);
     }
+}
+export function closeConnectionAttempt(ctx, attemptWs) {
+    if (ctx.getWs() !== attemptWs)
+        return false;
+    if (!attemptWs)
+        return true;
+    attemptWs.removeAllListeners();
+    if (attemptWs.readyState === WebSocket.OPEN || attemptWs.readyState === WebSocket.CONNECTING) {
+        attemptWs.close();
+    }
+    ctx.setWs(null);
+    return true;
 }

--- a/packages/rn-dev-agent-core/dist/cdp/connect.js
+++ b/packages/rn-dev-agent-core/dist/cdp/connect.js
@@ -259,8 +259,6 @@ async function connectToTarget(ctx, target, retries = 5, intent = 'default') {
             return;
         }
         catch (err) {
-            if (err instanceof ConnectionSetupSupersededError)
-                throw err;
             // GH #184: the picker-blocking abort is deterministic, not transient —
             // don't burn the retry budget on it; clean up and surface it immediately.
             if (err instanceof PickerBlockingBundleError) {
@@ -274,6 +272,8 @@ async function connectToTarget(ctx, target, retries = 5, intent = 'default') {
             lastError = err instanceof Error ? err : new Error(String(err));
             attempts.push({ handshakeOk, probeTimedOut });
             if (!closeConnectionAttempt(ctx, attemptWs)) {
+                if (err instanceof ConnectionSetupSupersededError)
+                    throw err;
                 throw new ConnectionSetupSupersededError();
             }
             if (lastError.message.includes('refused')) {

--- a/packages/rn-dev-agent-core/dist/cdp/event-handlers.js
+++ b/packages/rn-dev-agent-core/dist/cdp/event-handlers.js
@@ -1,4 +1,13 @@
-export function wireEventHandlers(eventHandlers, buffers, sendFn, getIsPaused, setIsPaused, getDeviceKey) {
+export function wireEventHandlers(eventHandlers, buffers, sendFn, getIsPaused, setIsPaused, getDeviceKey, executionContexts) {
+    if (executionContexts) {
+        eventHandlers.set('Runtime.executionContextCreated', (params) => {
+            executionContexts.created(params);
+        });
+        eventHandlers.set('Runtime.executionContextDestroyed', (params) => {
+            executionContexts.destroyed(params);
+        });
+        eventHandlers.set('Runtime.executionContextsCleared', () => executionContexts.cleared());
+    }
     eventHandlers.set('Runtime.consoleAPICalled', (params) => {
         const p = params;
         const text = p.args

--- a/packages/rn-dev-agent-core/dist/cdp/recovery.js
+++ b/packages/rn-dev-agent-core/dist/cdp/recovery.js
@@ -19,36 +19,9 @@ export function consumeCdpStale() {
     return was;
 }
 export async function probeFreshness(client, timeoutMs = FRESHNESS_PROBE_MS) {
-    if (!client.isConnected) {
-        return { fresh: false, version: null, probed: false };
-    }
-    let probeTimer;
-    try {
-        // If the timeout wins the race, this evaluate() promise is orphaned; attach
-        // a no-op catch so a later rejection (e.g. a mid-probe WebSocket close)
-        // can't surface as an unhandledRejection and crash the MCP process.
-        const evalPromise = client.evaluate('typeof globalThis.__RN_AGENT === "object" && globalThis.__RN_AGENT.__v');
-        evalPromise.catch(() => {
-            /* swallowed if the timeout already settled the race */
-        });
-        const result = await Promise.race([
-            evalPromise,
-            new Promise((resolve) => {
-                probeTimer = setTimeout(() => resolve({ error: 'timeout' }), timeoutMs);
-            }),
-        ]);
-        if (probeTimer)
-            clearTimeout(probeTimer);
-        if (result.error || typeof result.value !== 'number') {
-            return { fresh: false, version: null, probed: true };
-        }
-        return { fresh: true, version: result.value, probed: true };
-    }
-    catch {
-        if (probeTimer)
-            clearTimeout(probeTimer);
-        return { fresh: false, version: null, probed: true };
-    }
+    // The client owns the token/context fence and the actual CDP timeout. Only
+    // the exact shipped helper version is fresh; no orphaned outer race remains.
+    return client.probeHelperFreshness(timeoutMs);
 }
 export async function recoverFromStaleTarget(client) {
     if (!client.isConnected) {

--- a/packages/rn-dev-agent-core/dist/cdp/setup.js
+++ b/packages/rn-dev-agent-core/dist/cdp/setup.js
@@ -1,11 +1,16 @@
-import { HELPERS_VERSION, INJECTED_HELPERS, NETWORK_CB_BUFFERED_SCRIPT, NETWORK_HOOK_SCRIPT, REACT_READY_PROBE_JS, } from '../injected-helpers.js';
+import { HELPERS_VERSION, NETWORK_CB_BUFFERED_SCRIPT, NETWORK_HOOK_SCRIPT, REACT_READY_PROBE_JS, } from '../injected-helpers.js';
 import { logger } from '../logger.js';
-import { setActiveFlag, sleep } from './state.js';
+import { sleep } from './state.js';
 import { CDP_TIMEOUT_FAST, timeoutForMethod } from './timeout-config.js';
 export const REACT_READY_TIMEOUT_MS = 30_000;
 export const REACT_READY_POLL_MS = 500;
 export async function performSetup(opts) {
-    const { send, evaluate, port, connectedTarget, networkManager, getDeviceKey, setupEventHandlers, clearScripts, clearEventHandlers, probeWaits, } = opts;
+    const { send, evaluate, setupHelpers, port, networkManager, getDeviceKey, setupEventHandlers, clearScripts, clearEventHandlers, probeWaits, } = opts;
+    // Runtime.enable may synchronously announce the current execution context.
+    // Install lifecycle observation first so helper-world identity cannot miss it.
+    clearEventHandlers();
+    clearScripts();
+    setupEventHandlers();
     logger.debug('CDP', 'Running setup: Runtime.enable, Debugger.enable...');
     await send('Runtime.enable', undefined, timeoutForMethod('Runtime.enable'));
     await send('Debugger.enable', undefined, timeoutForMethod('Debugger.enable'));
@@ -39,24 +44,10 @@ export async function performSetup(opts) {
     ]);
     const profilerAvailable = profilerProbe.status === 'fulfilled' && profilerProbe.value === true;
     const heapProfilerAvailable = heapProbe.status === 'fulfilled' && heapProbe.value === true;
-    clearEventHandlers();
-    clearScripts();
-    setupEventHandlers();
-    await waitForReact(evaluate, REACT_READY_TIMEOUT_MS);
-    const helperResult = await evaluate(INJECTED_HELPERS);
-    if (helperResult.error) {
-        console.error('CDP: failed to inject helpers:', helperResult.error);
-        return {
-            networkMode,
-            helpersInjected: false,
-            logDomainEnabled,
-            profilerAvailable,
-            heapProfilerAvailable,
-        };
-    }
-    const verify = await evaluate('typeof globalThis.__RN_AGENT === "object"');
-    if (verify.value !== true) {
-        console.error('CDP: helper injection succeeded but __RN_AGENT not found');
+    // Connect setup and reinjection share one token-keyed payload + exact-version
+    // verification operation. The React-ready budget remains caller-specific.
+    const helpersInjected = await setupHelpers(REACT_READY_TIMEOUT_MS);
+    if (!helpersInjected) {
         return {
             networkMode,
             helpersInjected: false,
@@ -79,8 +70,7 @@ export async function performSetup(opts) {
         }
         networkDomainEnabled = false;
     }
-    logger.info('CDP', `Helpers injected (v${HELPERS_VERSION}), network mode: ${networkMode}`);
-    setActiveFlag(port, connectedTarget);
+    logger.info('CDP', `Helpers current (v${HELPERS_VERSION}), network mode: ${networkMode}`);
     // D626 (B1 fix): Probe whether Network.enable actually delivers events.
     // GH #59 #9: a single 500ms probe is too tight after platform switches /
     // reload — the fresh JS context needs time to flush the probe fetch through
@@ -160,19 +150,6 @@ export async function probeNetworkDomain(opts) {
     }
     logger.info('CDP', `Network.enable accepted but no events fired after ${waits.length} attempt(s) — falling back to hooks`);
     return 'none';
-}
-export async function reinjectHelpers(evaluate, waitTimeout) {
-    await waitForReact(evaluate, waitTimeout ?? REACT_READY_TIMEOUT_MS);
-    const helperResult = await evaluate(INJECTED_HELPERS);
-    if (helperResult.error) {
-        console.error('CDP: failed to re-inject helpers:', helperResult.error);
-        return false;
-    }
-    const verify = await evaluate('typeof globalThis.__RN_AGENT === "object"');
-    if (verify.value !== true) {
-        return false;
-    }
-    return true;
 }
 /**
  * GH #184: bounded variant of waitForReact that RETURNS whether React became

--- a/packages/rn-dev-agent-core/dist/utils.js
+++ b/packages/rn-dev-agent-core/dist/utils.js
@@ -1,27 +1,47 @@
 import { hasActiveSession } from './agent-device-wrapper.js';
 import { handleDevClientPicker } from './tools/dev-client-picker.js';
 import { probeFreshness, recoverFromStaleTarget, consumeCdpStale } from './cdp/recovery.js';
-// S1 (D631): cache the freshness probe for up to 2s per (client, generation).
-// Eliminates a CDP round-trip on back-to-back tool calls while still invalidating
-// on reconnect (connectionGeneration bumps) and on any failure (cache is never set).
+// Cache exact-version freshness for up to 2s per private helper world. Public
+// connectionGeneration intentionally advances only after successful setup and
+// therefore cannot fence reset/context churn.
 const FRESHNESS_CACHE_MS = 2000;
 const freshnessCache = new WeakMap();
 function isFreshnessCached(client) {
     const entry = freshnessCache.get(client);
     if (!entry)
         return false;
-    if (entry.generation !== client.connectionGeneration)
+    if (entry.generation !== client.helperWorldGeneration)
         return false;
     return Date.now() < entry.expiresAt;
 }
 function rememberFreshness(client) {
     freshnessCache.set(client, {
-        generation: client.connectionGeneration,
+        generation: client.helperWorldGeneration,
         expiresAt: Date.now() + FRESHNESS_CACHE_MS,
     });
 }
 function forgetFreshness(client) {
     freshnessCache.delete(client);
+}
+export async function helpersNotInjectedResult(client, boundary) {
+    const helperHealth = await client.probeHelperHealth(2000);
+    if (helperHealth.jsWorld === 'responsive' && helperHealth.helper === 'current') {
+        rememberFreshness(client);
+        return null;
+    }
+    forgetFreshness(client);
+    const message = helperHealth.jsWorld === 'timeout'
+        ? `Helpers are not ready and the bounded ${helperHealth.probeBudgetMs}ms health probe received no response; JavaScript may be busy, paused, or blocked.`
+        : helperHealth.jsWorld === 'transport-error'
+            ? 'Helpers are not ready and their health could not be measured because the CDP transport failed.'
+            : helperHealth.jsWorld === 'superseded'
+                ? 'Helpers are not ready because the JavaScript execution world changed during the bounded health probe.'
+                : helperHealth.helper === 'version-mismatch'
+                    ? 'Helpers are not ready because the responsive JavaScript world contains a different helper version.'
+                    : helperHealth.helper === 'missing'
+                        ? 'Helpers are not ready because they are missing from the responsive JavaScript world.'
+                        : 'Helpers are not ready because the responsive JavaScript world contains an invalid helper value.';
+    return failResult(`${boundary === 'stale-recovery' ? 'Stale target recovery completed, but ' : ''}${message} Fall back to device_* tools or call cdp_reload once.`, 'HELPERS_NOT_INJECTED', { helperHealth });
 }
 // Per-step timing collector for the `meta.timings_ms` convention (CLAUDE.md):
 // instrument variable-cost paths (dispatch, snapshot, repair, reconnect) so the
@@ -113,11 +133,8 @@ export function withConnection(getClient, handler, options = {}) {
                 // world is ~6-7s, not 3s. That's still well under the user-visible
                 // 30s picker fallback.
                 //
-                // Concurrency: two simultaneous withConnection callers can both reach
-                // this branch and both fire reinjectHelpers. The injected bundle is
-                // idempotent (reassigns globalThis.__RN_AGENT), so this is wasted
-                // work but not a correctness bug. Coalescing is tracked as a future
-                // optimization in GitHub Issues.
+                // Concurrent callers and connect-time setup share one helper-world
+                // payload+exact-version operation inside CDPClient.
                 if (!client.helpersInjected && client.isConnected) {
                     try {
                         const reinjected = await client.reinjectHelpers(3_000);
@@ -142,7 +159,9 @@ export function withConnection(getClient, handler, options = {}) {
                         }
                     }
                     if (!client.helpersInjected) {
-                        return failResult('Connected but helpers still not injected after passive wait, active re-inject, and Dev Client picker dismissal. The JS world may be hung. Fall back to device_* tools (XCTest path — no helpers required) or call cdp_reload to restart the bundle.', 'HELPERS_NOT_INJECTED');
+                        const helperError = await helpersNotInjectedResult(client, 'initial');
+                        if (helperError)
+                            return helperError;
                     }
                 }
             }
@@ -252,7 +271,15 @@ export function withConnection(getClient, handler, options = {}) {
                             return failResult(`Retry after stale-target recovery failed: ${retryMsg}`, 'STALE_TARGET', { originalError: message });
                         }
                     }
-                    return failResult('Stale target recovery: reconnected but helpers not injected.', 'HELPERS_NOT_INJECTED', { originalError: message });
+                    const helperError = await helpersNotInjectedResult(client, 'stale-recovery');
+                    if (helperError)
+                        return helperError;
+                    try {
+                        return await handler(args, client);
+                    }
+                    catch {
+                        return failResult('Retry after stale-target helper reconciliation failed.', 'STALE_TARGET');
+                    }
                 }
                 if (recovery.reason === 'reconnect-failed') {
                     return failResult(`Stale target recovery failed: ${recovery.error}`, 'STALE_TARGET', {

--- a/packages/rn-dev-agent-core/src/bridge-detector.ts
+++ b/packages/rn-dev-agent-core/src/bridge-detector.ts
@@ -1,4 +1,5 @@
 import type { CDPClient } from './cdp-client.js';
+import type { EvaluateResult } from './types.js';
 
 export interface BridgePresence {
   present: boolean;
@@ -17,9 +18,13 @@ const DETECT_EXPRESSION = `
 })()
 `;
 
-export async function detectBridge(client: CDPClient): Promise<BridgePresence> {
+export async function detectBridge(
+  client: CDPClient,
+  evaluate: (expression: string) => Promise<EvaluateResult> = (expression) =>
+    client.evaluate(expression),
+): Promise<BridgePresence> {
   try {
-    const result = await client.evaluate(DETECT_EXPRESSION);
+    const result = await evaluate(DETECT_EXPRESSION);
     if (result.value && typeof result.value === 'string') {
       return JSON.parse(result.value) as BridgePresence;
     }

--- a/packages/rn-dev-agent-core/src/cdp-client.ts
+++ b/packages/rn-dev-agent-core/src/cdp-client.ts
@@ -6,7 +6,8 @@ import { CDPMultiplexer } from './cdp/multiplexer.js';
 import type { MultiplexerOptions } from './cdp/multiplexer.js';
 import { detectBridge } from './bridge-detector.js';
 import { logger } from './logger.js';
-import { performSetup, reinjectHelpers as reinjectHelpersFn } from './cdp/setup.js';
+import { performSetup, waitForReact } from './cdp/setup.js';
+import { HELPERS_VERSION, INJECTED_HELPERS } from './injected-helpers.js';
 import { resetState, setActiveFlag, clearActiveFlag, sleep } from './cdp/state.js';
 import type { ResettableState } from './cdp/state.js';
 import { defaultTimeout, timeoutForMethod } from './cdp/timeout-config.js';
@@ -66,6 +67,25 @@ export class CDPClient {
   private reconnecting = false;
   private disposed = false;
   private _helpersInjected = false;
+  private _helperWorldGeneration = 0;
+  private _helperContext: { id: number; uniqueId?: string } | null = null;
+  private _helperToken: {
+    generation: number;
+    ws: WebSocket | null;
+    targetId: string | null;
+    contextId: number | null;
+    contextUniqueId: string | null;
+  } = {
+    generation: 0,
+    ws: null,
+    targetId: null,
+    contextId: null,
+    contextUniqueId: null,
+  };
+  private _helperInjectionInFlight: {
+    token: CDPClient['_helperToken'];
+    promise: Promise<boolean>;
+  } | null = null;
   private _networkMode: 'cdp' | 'hook' | 'none' = 'none';
   private _isPaused = false;
   private _connectedTarget: HermesTarget | null = null;
@@ -136,6 +156,10 @@ export class CDPClient {
   }
   get helpersInjected(): boolean {
     return this._helpersInjected;
+  }
+  /** Private helper-world epoch exposed only for process-local cache identity. */
+  get helperWorldGeneration(): number {
+    return this._helperWorldGeneration;
   }
   get metroPort(): number {
     return this._port;
@@ -239,18 +263,286 @@ export class CDPClient {
 
   async reinjectHelpers(waitTimeout?: number): Promise<boolean> {
     if (!this.isConnected) return false;
-    const ok = await reinjectHelpersFn((expr) => this.evaluate(expr), waitTimeout);
-    this._helpersInjected = ok;
-    if (ok) {
-      setActiveFlag(this._port, this._connectedTarget);
-      detectBridge(this)
-        .then((r) => {
-          this._bridgeDetected = r.present;
-          this._bridgeVersion = r.version;
-        })
-        .catch(() => {});
+    // Caller-specific React readiness stays outside the shared injection core.
+    await waitForReact((expr) => this.evaluateCurrentHelperWorld(expr), waitTimeout);
+    return this.ensureCurrentHelpers('reinject_started');
+  }
+
+  /**
+   * One bounded, context-pinned health read used only at final
+   * HELPERS_NOT_INJECTED boundaries. It never returns app values or errors.
+   */
+  async probeHelperHealth(probeBudgetMs = 2000): Promise<{
+    jsWorld: 'responsive' | 'timeout' | 'transport-error' | 'superseded';
+    helper: 'current' | 'missing' | 'version-mismatch' | 'invalid' | 'unknown';
+    probeBudgetMs: number;
+  }> {
+    const token = this._helperToken;
+    if (!this.isHelperTokenCurrent(token)) {
+      return { jsWorld: 'superseded', helper: 'unknown', probeBudgetMs };
     }
-    return ok;
+    const expression = `(function(){try{var d=Object.getOwnPropertyDescriptor(globalThis,'__RN_AGENT');if(!d)return 'missing';if(!('value' in d)||typeof d.value!=='object'||d.value===null)return 'invalid';var v=Object.getOwnPropertyDescriptor(d.value,'__v');if(!v||!('value' in v)||typeof v.value!=='number')return 'invalid';return v.value===${HELPERS_VERSION}?'current':'version-mismatch';}catch(_){return 'invalid';}})()`;
+    try {
+      const result = await this.evaluateForHelperToken(token, expression, probeBudgetMs);
+      if (!this.isHelperTokenCurrent(token)) {
+        return { jsWorld: 'superseded', helper: 'unknown', probeBudgetMs };
+      }
+      const helper =
+        result.value === 'current' ||
+        result.value === 'missing' ||
+        result.value === 'version-mismatch' ||
+        result.value === 'invalid'
+          ? result.value
+          : 'invalid';
+      if (helper === 'current') this.markHelpersReady(token, 'health_reconciled_current');
+      return { jsWorld: 'responsive', helper, probeBudgetMs };
+    } catch (err) {
+      if (!this.isHelperTokenCurrent(token)) {
+        return { jsWorld: 'superseded', helper: 'unknown', probeBudgetMs };
+      }
+      const timedOut = err instanceof Error && err.message.startsWith('CDP timeout (');
+      return {
+        jsWorld: timedOut ? 'timeout' : 'transport-error',
+        helper: 'unknown',
+        probeBudgetMs,
+      };
+    }
+  }
+
+  async probeHelperFreshness(timeoutMs = 2000): Promise<{
+    fresh: boolean;
+    version: number | null;
+    probed: boolean;
+  }> {
+    if (!this.isConnected) return { fresh: false, version: null, probed: false };
+    const token = this._helperToken;
+    try {
+      const result = await this.evaluateForHelperToken(
+        token,
+        `typeof globalThis.__RN_AGENT === 'object' && globalThis.__RN_AGENT !== null ? globalThis.__RN_AGENT.__v : null`,
+        timeoutMs,
+      );
+      if (!this.isHelperTokenCurrent(token)) return { fresh: false, version: null, probed: true };
+      const version = typeof result.value === 'number' ? result.value : null;
+      const fresh = version === HELPERS_VERSION;
+      if (!fresh) {
+        this.markHelpersUnready(
+          token,
+          version === null ? 'freshness_missing' : 'freshness_version_mismatch',
+        );
+      }
+      return { fresh, version, probed: true };
+    } catch {
+      return { fresh: false, version: null, probed: true };
+    }
+  }
+
+  private invalidateHelperWorld(
+    cause:
+      | 'socket_opened'
+      | 'socket_closed'
+      | 'explicit_disconnect'
+      | 'soft_reconnect'
+      | 'candidate_selected'
+      | 'candidate_rejected'
+      | 'context_created'
+      | 'context_destroyed'
+      | 'contexts_cleared',
+  ): void {
+    this._helperWorldGeneration++;
+    this._helpersInjected = false;
+    this._bridgeDetected = false;
+    this._bridgeVersion = null;
+    this._helperToken = {
+      generation: this._helperWorldGeneration,
+      ws: this.ws,
+      targetId: this._connectedTarget?.id ?? null,
+      contextId: this._helperContext?.id ?? null,
+      contextUniqueId: this._helperContext?.uniqueId ?? null,
+    };
+    logger.info(
+      'CDP',
+      `Helper state invalidated cause=${cause} helperEpoch=${this._helperWorldGeneration} connectionGeneration=${this._connectionGeneration}`,
+    );
+  }
+
+  private isHelperTokenCurrent(token: CDPClient['_helperToken']): boolean {
+    return (
+      token === this._helperToken &&
+      token.ws === this.ws &&
+      token.targetId === (this._connectedTarget?.id ?? null)
+    );
+  }
+
+  private async evaluateCurrentHelperWorld(expression: string): Promise<EvaluateResult> {
+    const token = this._helperToken;
+    try {
+      return await this.evaluateForHelperToken(
+        token,
+        expression,
+        defaultTimeout(this.effectivePlatform),
+      );
+    } catch {
+      return { error: 'helper-world evaluation unavailable' };
+    }
+  }
+
+  private async evaluateForHelperToken(
+    token: CDPClient['_helperToken'],
+    expression: string,
+    timeoutMs: number,
+  ): Promise<EvaluateResult> {
+    if (!this.isHelperTokenCurrent(token)) throw new Error('helper world superseded');
+    const params: { expression: string; returnByValue: true; contextId?: number } = {
+      expression,
+      returnByValue: true,
+    };
+    if (token.contextId !== null) params.contextId = token.contextId;
+    const result = (await this.sendWithTimeout('Runtime.evaluate', params, timeoutMs)) as {
+      result?: { value?: unknown };
+      exceptionDetails?: unknown;
+    };
+    if (!this.isHelperTokenCurrent(token)) throw new Error('helper world superseded');
+    if (result?.exceptionDetails) return { error: 'helper-world expression failed' };
+    return { value: result?.result?.value };
+  }
+
+  private async ensureCurrentHelpers(
+    cause: 'setup_started' | 'reinject_started',
+  ): Promise<boolean> {
+    const token = this._helperToken;
+    if (!this.isHelperTokenCurrent(token) || !this.isConnected) return false;
+    if (this._helpersInjected) return true;
+    if (this._helperInjectionInFlight?.token === token) {
+      return this._helperInjectionInFlight.promise;
+    }
+
+    const slot = {
+      token,
+      promise: Promise.resolve(false) as Promise<boolean>,
+    };
+    slot.promise = this.injectAndVerifyHelpers(token, cause).finally(() => {
+      // Identity cleanup: an old world's late finally cannot clear a newer slot.
+      if (this._helperInjectionInFlight === slot) this._helperInjectionInFlight = null;
+    });
+    this._helperInjectionInFlight = slot;
+    return slot.promise;
+  }
+
+  private markHelpersUnready(
+    token: CDPClient['_helperToken'],
+    cause: 'setup_failed' | 'reinject_failed' | 'freshness_missing' | 'freshness_version_mismatch',
+  ): false {
+    if (!this.isHelperTokenCurrent(token)) return false;
+    this._helpersInjected = false;
+    this._bridgeDetected = false;
+    this._bridgeVersion = null;
+    logger.warn(
+      'CDP',
+      `Helper state unavailable cause=${cause} helperEpoch=${token.generation} connectionGeneration=${this._connectionGeneration}`,
+    );
+    return false;
+  }
+
+  private async injectAndVerifyHelpers(
+    token: CDPClient['_helperToken'],
+    cause: 'setup_started' | 'reinject_started',
+  ): Promise<boolean> {
+    logger.info(
+      'CDP',
+      `Helper injection ${cause} helperEpoch=${token.generation} connectionGeneration=${this._connectionGeneration}`,
+    );
+    try {
+      const injected = await this.evaluateForHelperToken(
+        token,
+        INJECTED_HELPERS,
+        defaultTimeout(this.effectivePlatform),
+      );
+      if (injected.error) {
+        return this.markHelpersUnready(
+          token,
+          cause === 'setup_started' ? 'setup_failed' : 'reinject_failed',
+        );
+      }
+      const verified = await this.evaluateForHelperToken(
+        token,
+        `typeof globalThis.__RN_AGENT === 'object' && globalThis.__RN_AGENT !== null && globalThis.__RN_AGENT.__v === ${HELPERS_VERSION}`,
+        defaultTimeout(this.effectivePlatform),
+      );
+      if (verified.value !== true || !this.isHelperTokenCurrent(token)) {
+        return this.markHelpersUnready(
+          token,
+          cause === 'setup_started' ? 'setup_failed' : 'reinject_failed',
+        );
+      }
+      this.markHelpersReady(
+        token,
+        cause === 'setup_started' ? 'setup_current' : 'reinject_current',
+      );
+      return true;
+    } catch {
+      // Expected transport/context replacement failures are a bounded false;
+      // stale worlds are intentionally not allowed to log a current transition.
+      return this.markHelpersUnready(
+        token,
+        cause === 'setup_started' ? 'setup_failed' : 'reinject_failed',
+      );
+    }
+  }
+
+  private markHelpersReady(
+    token: CDPClient['_helperToken'],
+    cause: 'setup_current' | 'reinject_current' | 'health_reconciled_current',
+  ): void {
+    if (!this.isHelperTokenCurrent(token)) return;
+    this._helpersInjected = true;
+    setActiveFlag(this._port, this._connectedTarget);
+    logger.info(
+      'CDP',
+      `Helper state ready cause=${cause} helperEpoch=${token.generation} connectionGeneration=${this._connectionGeneration}`,
+    );
+    detectBridge(this, (expression) =>
+      this.evaluateForHelperToken(token, expression, defaultTimeout(this.effectivePlatform)),
+    )
+      .then((r) => {
+        if (!this.isHelperTokenCurrent(token)) return;
+        this._bridgeDetected = r.present;
+        this._bridgeVersion = r.version;
+      })
+      .catch(() => {});
+  }
+
+  private handleExecutionContextCreated(params: {
+    context?: { id?: number; uniqueId?: string; auxData?: { isDefault?: boolean } };
+  }): void {
+    const id = params.context?.id;
+    // Modern RN marks its announced runtime as the default context. Ignore
+    // explicitly auxiliary contexts; legacy one-context backends omit auxData.
+    if (typeof id !== 'number' || params.context?.auxData?.isDefault === false) return;
+    const next = { id, uniqueId: params.context?.uniqueId };
+    if (this._helperContext?.id === next.id && this._helperContext.uniqueId === next.uniqueId)
+      return;
+    this._helperContext = next;
+    this.invalidateHelperWorld('context_created');
+  }
+
+  private handleExecutionContextDestroyed(params: {
+    executionContextId?: number;
+    executionContextUniqueId?: string;
+  }): void {
+    if (!this._helperContext) return;
+    const matchesId = params.executionContextId === this._helperContext.id;
+    const matchesUnique =
+      params.executionContextUniqueId !== undefined &&
+      params.executionContextUniqueId === this._helperContext.uniqueId;
+    if (!matchesId && !matchesUnique) return;
+    this._helperContext = null;
+    this.invalidateHelperWorld('context_destroyed');
+  }
+
+  private handleExecutionContextsCleared(): void {
+    this._helperContext = null;
+    this.invalidateHelperWorld('contexts_cleared');
   }
 
   async autoConnect(
@@ -452,6 +744,7 @@ export class CDPClient {
     // caller sees already-disposed and returns cleanly.
     if (this.disposed) return;
     this.disposed = true;
+    this.invalidateHelperWorld('explicit_disconnect');
     resetState(this.buildResettableState());
     clearActiveFlag();
     this.stopBackgroundPoll();
@@ -643,8 +936,11 @@ export class CDPClient {
           ms ?? timeoutForMethod(method, this.effectivePlatform),
         ),
       evaluate: (expr) => this.evaluate(expr),
+      setupHelpers: async (waitTimeout) => {
+        await waitForReact((expr) => this.evaluateCurrentHelperWorld(expr), waitTimeout);
+        return this.ensureCurrentHelpers('setup_started');
+      },
       port: this._port,
-      connectedTarget: this._connectedTarget,
       networkManager: this._networkBufferManager,
       getDeviceKey: () => this.activeDeviceKey,
       setupEventHandlers: () => this.setupEventHandlers(),
@@ -652,19 +948,10 @@ export class CDPClient {
       clearEventHandlers: () => this.eventHandlers.clear(),
     });
     this._networkMode = result.networkMode;
-    this._helpersInjected = result.helpersInjected;
+    // Helper state is owned exclusively by the token-scoped coordinator.
     this._logDomainEnabled = result.logDomainEnabled;
     this._profilerAvailable = result.profilerAvailable;
     this._heapProfilerAvailable = result.heapProfilerAvailable;
-    if (result.helpersInjected) {
-      detectBridge(this)
-        .then((r) => {
-          this._bridgeDetected = r.present;
-          this._bridgeVersion = r.version;
-          logger.debug('CDP', `Bridge detection: present=${r.present}, version=${r.version}`);
-        })
-        .catch(() => {});
-    }
   }
 
   private async ensureMetroEventsClient(): Promise<void> {
@@ -703,10 +990,18 @@ export class CDPClient {
         this._isPaused = v;
       },
       () => this.activeDeviceKey,
+      {
+        created: (params) => this.handleExecutionContextCreated(params),
+        destroyed: (params) => this.handleExecutionContextDestroyed(params),
+        cleared: () => this.handleExecutionContextsCleared(),
+      },
     );
   }
 
   private handleClose(code: number): void {
+    // Invalidate synchronously before reconnect/reset can await or select a new world.
+    this.ws = null;
+    this.invalidateHelperWorld('socket_closed');
     // B132: if the proxy is active when the upstream closes, suspend it BEFORE
     // the reconnect loop fires. `_suspendProxy` clears `_proxyUrl` synchronously
     // at its start (before the first await), so by the time `reconnect()` calls
@@ -760,6 +1055,8 @@ export class CDPClient {
             this.ws.close();
           }
           this.ws = null;
+          this._helperContext = null;
+          this.invalidateHelperWorld('soft_reconnect');
         }
       },
       rejectAllPending: (reason) => this.rejectAllPending(reason),
@@ -798,13 +1095,18 @@ export class CDPClient {
       },
       getWs: () => this.ws,
       setWs: (ws) => {
+        if (this.ws === ws) return;
         this.ws = ws;
+        this._helperContext = null;
+        this.invalidateHelperWorld(ws ? 'socket_opened' : 'socket_closed');
       },
       setHelpersInjected: (v) => {
-        this._helpersInjected = v;
+        if (!v) this.invalidateHelperWorld('candidate_rejected');
       },
       setConnectedTarget: (t) => {
+        if (this._connectedTarget === t) return;
         this._connectedTarget = t;
+        this.invalidateHelperWorld(t ? 'candidate_selected' : 'candidate_rejected');
       },
       setConnectedAt: (ms) => {
         this._connectedAt = ms;

--- a/packages/rn-dev-agent-core/src/cdp-client.ts
+++ b/packages/rn-dev-agent-core/src/cdp-client.ts
@@ -949,7 +949,11 @@ export class CDPClient {
         throw new ConnectionSetupSupersededError();
       }
     };
-    const sendForSetup = async (method: string, params?: unknown, ms?: number): Promise<unknown> => {
+    const sendForSetup = async (
+      method: string,
+      params?: unknown,
+      ms?: number,
+    ): Promise<unknown> => {
       assertSetupCurrent();
       const response = await this.sendWithTimeout(
         method,

--- a/packages/rn-dev-agent-core/src/cdp-client.ts
+++ b/packages/rn-dev-agent-core/src/cdp-client.ts
@@ -28,6 +28,7 @@ import {
 } from './cdp/helper-expr.js';
 import {
   autoConnect as autoConnectFn,
+  ConnectionSetupSupersededError,
   discoverAndConnect as discoverAndConnectFn,
 } from './cdp/connect.js';
 import type { ConnectContext, ConnectFilters, ConnectIntent } from './cdp/connect.js';
@@ -944,7 +945,9 @@ export class CDPClient {
         this.ws === setupWs && (this._connectedTarget?.id ?? null) === setupTargetId;
       const helpersAreCurrent =
         setupHelperToken === null || this.isHelperTokenCurrent(setupHelperToken);
-      if (!connectionIsCurrent || !helpersAreCurrent) throw new Error('setup superseded');
+      if (!connectionIsCurrent || !helpersAreCurrent) {
+        throw new ConnectionSetupSupersededError();
+      }
     };
     const sendForSetup = async (method: string, params?: unknown, ms?: number): Promise<unknown> => {
       assertSetupCurrent();

--- a/packages/rn-dev-agent-core/src/cdp-client.ts
+++ b/packages/rn-dev-agent-core/src/cdp-client.ts
@@ -333,6 +333,7 @@ export class CDPClient {
       }
       return { fresh, version, probed: true };
     } catch {
+      this.markHelpersUnready(token, 'freshness_probe_failed');
       return { fresh: false, version: null, probed: true };
     }
   }
@@ -353,6 +354,7 @@ export class CDPClient {
     this._helpersInjected = false;
     this._bridgeDetected = false;
     this._bridgeVersion = null;
+    clearActiveFlag();
     this._helperToken = {
       generation: this._helperWorldGeneration,
       ws: this.ws,
@@ -431,12 +433,18 @@ export class CDPClient {
 
   private markHelpersUnready(
     token: CDPClient['_helperToken'],
-    cause: 'setup_failed' | 'reinject_failed' | 'freshness_missing' | 'freshness_version_mismatch',
+    cause:
+      | 'setup_failed'
+      | 'reinject_failed'
+      | 'freshness_missing'
+      | 'freshness_version_mismatch'
+      | 'freshness_probe_failed',
   ): false {
     if (!this.isHelperTokenCurrent(token)) return false;
     this._helpersInjected = false;
     this._bridgeDetected = false;
     this._bridgeVersion = null;
+    clearActiveFlag();
     logger.warn(
       'CDP',
       `Helper state unavailable cause=${cause} helperEpoch=${token.generation} connectionGeneration=${this._connectionGeneration}`,
@@ -928,17 +936,44 @@ export class CDPClient {
       /* MetroEventsClient handles its own reconnects */
     });
 
+    const setupWs = this.ws;
+    const setupTargetId = this._connectedTarget?.id ?? null;
+    let setupHelperToken: CDPClient['_helperToken'] | null = null;
+    const assertSetupCurrent = (): void => {
+      const connectionIsCurrent =
+        this.ws === setupWs && (this._connectedTarget?.id ?? null) === setupTargetId;
+      const helpersAreCurrent =
+        setupHelperToken === null || this.isHelperTokenCurrent(setupHelperToken);
+      if (!connectionIsCurrent || !helpersAreCurrent) throw new Error('setup superseded');
+    };
+    const sendForSetup = async (method: string, params?: unknown, ms?: number): Promise<unknown> => {
+      assertSetupCurrent();
+      const response = await this.sendWithTimeout(
+        method,
+        params,
+        ms ?? timeoutForMethod(method, this.effectivePlatform),
+      );
+      assertSetupCurrent();
+      return response;
+    };
+    const evaluateForSetup = async (expression: string): Promise<EvaluateResult> => {
+      assertSetupCurrent();
+      const response = await this.evaluate(expression);
+      assertSetupCurrent();
+      return response;
+    };
+
     const result = await performSetup({
-      send: (method, params, ms) =>
-        this.sendWithTimeout(
-          method,
-          params,
-          ms ?? timeoutForMethod(method, this.effectivePlatform),
-        ),
-      evaluate: (expr) => this.evaluate(expr),
+      send: sendForSetup,
+      evaluate: evaluateForSetup,
       setupHelpers: async (waitTimeout) => {
+        assertSetupCurrent();
         await waitForReact((expr) => this.evaluateCurrentHelperWorld(expr), waitTimeout);
-        return this.ensureCurrentHelpers('setup_started');
+        assertSetupCurrent();
+        setupHelperToken = this._helperToken;
+        const helpersInjected = await this.ensureCurrentHelpers('setup_started');
+        assertSetupCurrent();
+        return helpersInjected;
       },
       port: this._port,
       networkManager: this._networkBufferManager,
@@ -947,6 +982,7 @@ export class CDPClient {
       clearScripts: () => this._scripts.clear(),
       clearEventHandlers: () => this.eventHandlers.clear(),
     });
+    assertSetupCurrent();
     this._networkMode = result.networkMode;
     // Helper state is owned exclusively by the token-scoped coordinator.
     this._logDomainEnabled = result.logDomainEnabled;

--- a/packages/rn-dev-agent-core/src/cdp/connect.ts
+++ b/packages/rn-dev-agent-core/src/cdp/connect.ts
@@ -354,7 +354,6 @@ async function connectToTarget(
       await ctx.setup();
       return;
     } catch (err) {
-      if (err instanceof ConnectionSetupSupersededError) throw err;
       // GH #184: the picker-blocking abort is deterministic, not transient —
       // don't burn the retry budget on it; clean up and surface it immediately.
       if (err instanceof PickerBlockingBundleError) {
@@ -368,6 +367,7 @@ async function connectToTarget(
       lastError = err instanceof Error ? err : new Error(String(err));
       attempts.push({ handshakeOk, probeTimedOut });
       if (!closeConnectionAttempt(ctx, attemptWs)) {
+        if (err instanceof ConnectionSetupSupersededError) throw err;
         throw new ConnectionSetupSupersededError();
       }
       if (lastError.message.includes('refused')) {

--- a/packages/rn-dev-agent-core/src/cdp/connect.ts
+++ b/packages/rn-dev-agent-core/src/cdp/connect.ts
@@ -43,6 +43,13 @@ export class PickerBlockingBundleError extends Error {
   }
 }
 
+export class ConnectionSetupSupersededError extends Error {
+  constructor() {
+    super('Connection setup superseded');
+    this.name = 'ConnectionSetupSupersededError';
+  }
+}
+
 /**
  * GH #184: run the bounded picker probe only for a status-intent connect against
  * a non-Hermes target. Hermes targets are skipped so a genuinely slow Hermes
@@ -205,6 +212,7 @@ export async function discoverAndConnect(
     } catch (err) {
       // GH #184: picker-blocking affects the whole bundle — every other
       // candidate is the same stale C++ target, so don't waste a probe on each.
+      if (err instanceof ConnectionSetupSupersededError) throw err;
       if (err instanceof PickerBlockingBundleError) {
         ctx.setState('disconnected');
         throw err;
@@ -302,6 +310,7 @@ async function connectToTarget(
     }
     let handshakeOk = false;
     let probeTimedOut = false;
+    let attemptWs: WebSocket | null = null;
     try {
       // M1b: ride the multiplexer when _proxyUrl is set (from CDPClient.startProxy).
       // Falls back to the target's direct webSocketDebuggerUrl when no proxy is active.
@@ -310,7 +319,7 @@ async function connectToTarget(
       if (proxyUrl) {
         logger.info('CDP', `Routing via multiplexer proxy: ${proxyUrl}`);
       }
-      await connectWs(ctx, url);
+      attemptWs = await connectWs(ctx, url);
       handshakeOk = true;
       // D594: Early stale-target detection — quick probe before full setup
       try {
@@ -345,17 +354,22 @@ async function connectToTarget(
       await ctx.setup();
       return;
     } catch (err) {
+      if (err instanceof ConnectionSetupSupersededError) throw err;
       // GH #184: the picker-blocking abort is deterministic, not transient —
       // don't burn the retry budget on it; clean up and surface it immediately.
       if (err instanceof PickerBlockingBundleError) {
-        closeAndResetWs(ctx);
+        if (!closeConnectionAttempt(ctx, attemptWs)) {
+          throw new ConnectionSetupSupersededError();
+        }
         ctx.setConnectedTarget(null);
         ctx.setState('disconnected');
         throw err;
       }
       lastError = err instanceof Error ? err : new Error(String(err));
       attempts.push({ handshakeOk, probeTimedOut });
-      closeAndResetWs(ctx);
+      if (!closeConnectionAttempt(ctx, attemptWs)) {
+        throw new ConnectionSetupSupersededError();
+      }
       if (lastError.message.includes('refused')) {
         ctx.setState('disconnected');
         throw new Error('CDP connection refused. Is Metro running and the app loaded?');
@@ -374,7 +388,7 @@ async function connectToTarget(
   );
 }
 
-function connectWs(ctx: ConnectContext, url: string): Promise<void> {
+function connectWs(ctx: ConnectContext, url: string): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(url, {
       handshakeTimeout: 5000,
@@ -401,7 +415,7 @@ function connectWs(ctx: ConnectContext, url: string): Promise<void> {
       clearTimeout(guard);
       ctx.setWs(ws);
       ctx.setState('connected');
-      resolve();
+      resolve(ws);
     });
 
     ws.on('error', (err) => {
@@ -447,4 +461,18 @@ function closeAndResetWs(ctx: ConnectContext): void {
     }
     ctx.setWs(null);
   }
+}
+
+export function closeConnectionAttempt(
+  ctx: Pick<ConnectContext, 'getWs' | 'setWs'>,
+  attemptWs: WebSocket | null,
+): boolean {
+  if (ctx.getWs() !== attemptWs) return false;
+  if (!attemptWs) return true;
+  attemptWs.removeAllListeners();
+  if (attemptWs.readyState === WebSocket.OPEN || attemptWs.readyState === WebSocket.CONNECTING) {
+    attemptWs.close();
+  }
+  ctx.setWs(null);
+  return true;
 }

--- a/packages/rn-dev-agent-core/src/cdp/event-handlers.ts
+++ b/packages/rn-dev-agent-core/src/cdp/event-handlers.ts
@@ -15,7 +15,30 @@ export function wireEventHandlers(
   getIsPaused: () => boolean,
   setIsPaused: (v: boolean) => void,
   getDeviceKey: () => string,
+  executionContexts?: {
+    created(params: {
+      context?: { id?: number; uniqueId?: string; auxData?: { isDefault?: boolean } };
+    }): void;
+    destroyed(params: { executionContextId?: number; executionContextUniqueId?: string }): void;
+    cleared(): void;
+  },
 ): void {
+  if (executionContexts) {
+    eventHandlers.set('Runtime.executionContextCreated', (params) => {
+      executionContexts.created(
+        params as {
+          context?: { id?: number; uniqueId?: string; auxData?: { isDefault?: boolean } };
+        },
+      );
+    });
+    eventHandlers.set('Runtime.executionContextDestroyed', (params) => {
+      executionContexts.destroyed(
+        params as { executionContextId?: number; executionContextUniqueId?: string },
+      );
+    });
+    eventHandlers.set('Runtime.executionContextsCleared', () => executionContexts.cleared());
+  }
+
   eventHandlers.set('Runtime.consoleAPICalled', (params: unknown) => {
     const p = params as { type: string; args?: Array<{ value?: unknown; description?: string }> };
     const text =

--- a/packages/rn-dev-agent-core/src/cdp/recovery.ts
+++ b/packages/rn-dev-agent-core/src/cdp/recovery.ts
@@ -33,35 +33,9 @@ export async function probeFreshness(
   client: CDPClient,
   timeoutMs: number = FRESHNESS_PROBE_MS,
 ): Promise<FreshnessResult> {
-  if (!client.isConnected) {
-    return { fresh: false, version: null, probed: false };
-  }
-  let probeTimer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    // If the timeout wins the race, this evaluate() promise is orphaned; attach
-    // a no-op catch so a later rejection (e.g. a mid-probe WebSocket close)
-    // can't surface as an unhandledRejection and crash the MCP process.
-    const evalPromise = client.evaluate(
-      'typeof globalThis.__RN_AGENT === "object" && globalThis.__RN_AGENT.__v',
-    );
-    evalPromise.catch(() => {
-      /* swallowed if the timeout already settled the race */
-    });
-    const result = await Promise.race([
-      evalPromise,
-      new Promise<EvaluateResult>((resolve) => {
-        probeTimer = setTimeout(() => resolve({ error: 'timeout' }), timeoutMs);
-      }),
-    ]);
-    if (probeTimer) clearTimeout(probeTimer);
-    if (result.error || typeof result.value !== 'number') {
-      return { fresh: false, version: null, probed: true };
-    }
-    return { fresh: true, version: result.value, probed: true };
-  } catch {
-    if (probeTimer) clearTimeout(probeTimer);
-    return { fresh: false, version: null, probed: true };
-  }
+  // The client owns the token/context fence and the actual CDP timeout. Only
+  // the exact shipped helper version is fresh; no orphaned outer race remains.
+  return client.probeHelperFreshness(timeoutMs);
 }
 
 export interface StaleRecoveryResult {

--- a/packages/rn-dev-agent-core/src/cdp/setup.ts
+++ b/packages/rn-dev-agent-core/src/cdp/setup.ts
@@ -1,15 +1,14 @@
 import {
   HELPERS_VERSION,
-  INJECTED_HELPERS,
   NETWORK_CB_BUFFERED_SCRIPT,
   NETWORK_HOOK_SCRIPT,
   REACT_READY_PROBE_JS,
 } from '../injected-helpers.js';
 import { logger } from '../logger.js';
-import { setActiveFlag, sleep } from './state.js';
+import { sleep } from './state.js';
 import { CDP_TIMEOUT_FAST, timeoutForMethod } from './timeout-config.js';
 import type { DeviceBufferManager } from '../ring-buffer.js';
-import type { NetworkEntry, EvaluateResult, HermesTarget } from '../types.js';
+import type { NetworkEntry, EvaluateResult } from '../types.js';
 
 export const REACT_READY_TIMEOUT_MS = 30_000;
 export const REACT_READY_POLL_MS = 500;
@@ -25,8 +24,8 @@ export interface SetupResult {
 export async function performSetup(opts: {
   send: (method: string, params?: unknown, ms?: number) => Promise<unknown>;
   evaluate: (expr: string) => Promise<EvaluateResult>;
+  setupHelpers: (waitTimeout: number) => Promise<boolean>;
   port: number;
-  connectedTarget: HermesTarget | null;
   networkManager: DeviceBufferManager<NetworkEntry, string>;
   getDeviceKey: () => string;
   setupEventHandlers: () => void;
@@ -42,8 +41,8 @@ export async function performSetup(opts: {
   const {
     send,
     evaluate,
+    setupHelpers,
     port,
-    connectedTarget,
     networkManager,
     getDeviceKey,
     setupEventHandlers,
@@ -51,6 +50,12 @@ export async function performSetup(opts: {
     clearEventHandlers,
     probeWaits,
   } = opts;
+
+  // Runtime.enable may synchronously announce the current execution context.
+  // Install lifecycle observation first so helper-world identity cannot miss it.
+  clearEventHandlers();
+  clearScripts();
+  setupEventHandlers();
 
   logger.debug('CDP', 'Running setup: Runtime.enable, Debugger.enable...');
   await send('Runtime.enable', undefined, timeoutForMethod('Runtime.enable'));
@@ -87,27 +92,10 @@ export async function performSetup(opts: {
   const profilerAvailable = profilerProbe.status === 'fulfilled' && profilerProbe.value === true;
   const heapProfilerAvailable = heapProbe.status === 'fulfilled' && heapProbe.value === true;
 
-  clearEventHandlers();
-  clearScripts();
-  setupEventHandlers();
-
-  await waitForReact(evaluate, REACT_READY_TIMEOUT_MS);
-
-  const helperResult = await evaluate(INJECTED_HELPERS);
-  if (helperResult.error) {
-    console.error('CDP: failed to inject helpers:', helperResult.error);
-    return {
-      networkMode,
-      helpersInjected: false,
-      logDomainEnabled,
-      profilerAvailable,
-      heapProfilerAvailable,
-    };
-  }
-
-  const verify = await evaluate('typeof globalThis.__RN_AGENT === "object"');
-  if (verify.value !== true) {
-    console.error('CDP: helper injection succeeded but __RN_AGENT not found');
+  // Connect setup and reinjection share one token-keyed payload + exact-version
+  // verification operation. The React-ready budget remains caller-specific.
+  const helpersInjected = await setupHelpers(REACT_READY_TIMEOUT_MS);
+  if (!helpersInjected) {
     return {
       networkMode,
       helpersInjected: false,
@@ -131,8 +119,7 @@ export async function performSetup(opts: {
     networkDomainEnabled = false;
   }
 
-  logger.info('CDP', `Helpers injected (v${HELPERS_VERSION}), network mode: ${networkMode}`);
-  setActiveFlag(port, connectedTarget);
+  logger.info('CDP', `Helpers current (v${HELPERS_VERSION}), network mode: ${networkMode}`);
 
   // D626 (B1 fix): Probe whether Network.enable actually delivers events.
   // GH #59 #9: a single 500ms probe is too tight after platform switches /
@@ -230,23 +217,6 @@ export async function probeNetworkDomain(opts: {
     `Network.enable accepted but no events fired after ${waits.length} attempt(s) — falling back to hooks`,
   );
   return 'none';
-}
-
-export async function reinjectHelpers(
-  evaluate: (expr: string) => Promise<EvaluateResult>,
-  waitTimeout?: number,
-): Promise<boolean> {
-  await waitForReact(evaluate, waitTimeout ?? REACT_READY_TIMEOUT_MS);
-  const helperResult = await evaluate(INJECTED_HELPERS);
-  if (helperResult.error) {
-    console.error('CDP: failed to re-inject helpers:', helperResult.error);
-    return false;
-  }
-  const verify = await evaluate('typeof globalThis.__RN_AGENT === "object"');
-  if (verify.value !== true) {
-    return false;
-  }
-  return true;
 }
 
 /**

--- a/packages/rn-dev-agent-core/src/types.ts
+++ b/packages/rn-dev-agent-core/src/types.ts
@@ -133,10 +133,9 @@ export interface StatusResult {
     supportsMultipleDebuggers: boolean;
     /**
      * D1202: explicit __RN_AGENT helpers status. true when the helper bundle
-     * is loaded into Hermes; false during the post-launch race window or when
-     * the JS world is hung. /doctor and `cdp_status` callers should treat
-     * false as "JS-tier tools (cdp_*) won't work — fall back to device_* or
-     * cdp_reload."
+     * is exactly current in the captured Hermes execution context; false
+     * during setup, context churn, or after missing/version-mismatched evidence.
+     * A false value alone does not prove that JavaScript is hung.
      */
     helpersInjected: boolean;
   };

--- a/packages/rn-dev-agent-core/src/utils.ts
+++ b/packages/rn-dev-agent-core/src/utils.ts
@@ -4,28 +4,57 @@ import { hasActiveSession } from './agent-device-wrapper.js';
 import { handleDevClientPicker } from './tools/dev-client-picker.js';
 import { probeFreshness, recoverFromStaleTarget, consumeCdpStale } from './cdp/recovery.js';
 
-// S1 (D631): cache the freshness probe for up to 2s per (client, generation).
-// Eliminates a CDP round-trip on back-to-back tool calls while still invalidating
-// on reconnect (connectionGeneration bumps) and on any failure (cache is never set).
+// Cache exact-version freshness for up to 2s per private helper world. Public
+// connectionGeneration intentionally advances only after successful setup and
+// therefore cannot fence reset/context churn.
 const FRESHNESS_CACHE_MS = 2000;
 const freshnessCache = new WeakMap<CDPClient, { generation: number; expiresAt: number }>();
 
 function isFreshnessCached(client: CDPClient): boolean {
   const entry = freshnessCache.get(client);
   if (!entry) return false;
-  if (entry.generation !== client.connectionGeneration) return false;
+  if (entry.generation !== client.helperWorldGeneration) return false;
   return Date.now() < entry.expiresAt;
 }
 
 function rememberFreshness(client: CDPClient): void {
   freshnessCache.set(client, {
-    generation: client.connectionGeneration,
+    generation: client.helperWorldGeneration,
     expiresAt: Date.now() + FRESHNESS_CACHE_MS,
   });
 }
 
 function forgetFreshness(client: CDPClient): void {
   freshnessCache.delete(client);
+}
+
+export async function helpersNotInjectedResult(
+  client: CDPClient,
+  boundary: 'initial' | 'stale-recovery',
+): Promise<ToolResult | null> {
+  const helperHealth = await client.probeHelperHealth(2000);
+  if (helperHealth.jsWorld === 'responsive' && helperHealth.helper === 'current') {
+    rememberFreshness(client);
+    return null;
+  }
+  forgetFreshness(client);
+  const message =
+    helperHealth.jsWorld === 'timeout'
+      ? `Helpers are not ready and the bounded ${helperHealth.probeBudgetMs}ms health probe received no response; JavaScript may be busy, paused, or blocked.`
+      : helperHealth.jsWorld === 'transport-error'
+        ? 'Helpers are not ready and their health could not be measured because the CDP transport failed.'
+        : helperHealth.jsWorld === 'superseded'
+          ? 'Helpers are not ready because the JavaScript execution world changed during the bounded health probe.'
+          : helperHealth.helper === 'version-mismatch'
+            ? 'Helpers are not ready because the responsive JavaScript world contains a different helper version.'
+            : helperHealth.helper === 'missing'
+              ? 'Helpers are not ready because they are missing from the responsive JavaScript world.'
+              : 'Helpers are not ready because the responsive JavaScript world contains an invalid helper value.';
+  return failResult(
+    `${boundary === 'stale-recovery' ? 'Stale target recovery completed, but ' : ''}${message} Fall back to device_* tools or call cdp_reload once.`,
+    'HELPERS_NOT_INJECTED',
+    { helperHealth },
+  );
 }
 
 export type ToolResult = {
@@ -148,11 +177,8 @@ export function withConnection<T>(
         // world is ~6-7s, not 3s. That's still well under the user-visible
         // 30s picker fallback.
         //
-        // Concurrency: two simultaneous withConnection callers can both reach
-        // this branch and both fire reinjectHelpers. The injected bundle is
-        // idempotent (reassigns globalThis.__RN_AGENT), so this is wasted
-        // work but not a correctness bug. Coalescing is tracked as a future
-        // optimization in GitHub Issues.
+        // Concurrent callers and connect-time setup share one helper-world
+        // payload+exact-version operation inside CDPClient.
         if (!client.helpersInjected && client.isConnected) {
           try {
             const reinjected = await client.reinjectHelpers(3_000);
@@ -177,10 +203,8 @@ export function withConnection<T>(
             }
           }
           if (!client.helpersInjected) {
-            return failResult(
-              'Connected but helpers still not injected after passive wait, active re-inject, and Dev Client picker dismissal. The JS world may be hung. Fall back to device_* tools (XCTest path — no helpers required) or call cdp_reload to restart the bundle.',
-              'HELPERS_NOT_INJECTED',
-            );
+            const helperError = await helpersNotInjectedResult(client, 'initial');
+            if (helperError) return helperError;
           }
         }
       }
@@ -299,11 +323,16 @@ export function withConnection<T>(
               );
             }
           }
-          return failResult(
-            'Stale target recovery: reconnected but helpers not injected.',
-            'HELPERS_NOT_INJECTED',
-            { originalError: message },
-          );
+          const helperError = await helpersNotInjectedResult(client, 'stale-recovery');
+          if (helperError) return helperError;
+          try {
+            return await handler(args, client);
+          } catch {
+            return failResult(
+              'Retry after stale-target helper reconciliation failed.',
+              'STALE_TARGET',
+            );
+          }
         }
         if (recovery.reason === 'reconnect-failed') {
           return failResult(`Stale target recovery failed: ${recovery.error}`, 'STALE_TARGET', {

--- a/packages/rn-dev-agent-core/test/helpers/mock-cdp-client.js
+++ b/packages/rn-dev-agent-core/test/helpers/mock-cdp-client.js
@@ -61,6 +61,9 @@ export function createMockClient(overrides = {}) {
     get connectionGeneration() {
       return client._connectionGeneration;
     },
+    get helperWorldGeneration() {
+      return client._helperWorldGeneration;
+    },
     get consoleBuffer() {
       return consoleBuffer;
     },
@@ -124,6 +127,7 @@ export function createMockClient(overrides = {}) {
     _heapProfilerAvailable: true,
     _scripts: new Map(),
     _connectionGeneration: 1,
+    _helperWorldGeneration: 1,
     _autoConnectState: { enabled: true, source: 'default' },
     // M11 defaults: connectedAt=1_000_000 and timeNowFn returning 1_000_000
     // means "just connected, 0ms elapsed" — hint should NOT fire by default.
@@ -132,13 +136,13 @@ export function createMockClient(overrides = {}) {
     _timeNowFn: () => 1_000_000,
 
     // D502 freshness probe needs this — withConnection checks `typeof globalThis.__RN_AGENT`
-    // and expects a number. Returning 13 (helpers version) satisfies the probe so tests
-    // exercise the normal happy path, not the stale-helper re-injection recovery path.
+    // and expects the exact helper version. Returning 40 satisfies the probe so tests
+    // exercise the normal happy path, not stale-helper reinjection recovery.
     eventHandlers: new Map(),
 
     // --- Methods ---
     async evaluate(_expr, _awaitPromise) {
-      return { value: 13 };
+      return { value: 40 };
     },
 
     async autoConnect(_port, _platform) {
@@ -182,6 +186,21 @@ export function createMockClient(overrides = {}) {
     async reinjectHelpers() {
       client._helpersInjected = true;
       return true;
+    },
+
+    async probeHelperFreshness() {
+      const result = await client.evaluate(
+        "typeof globalThis.__RN_AGENT === 'object' && globalThis.__RN_AGENT !== null ? globalThis.__RN_AGENT.__v : null",
+      );
+      const version = typeof result.value === 'number' ? result.value : null;
+      return { fresh: version === 40, version, probed: true };
+    },
+
+    async probeHelperHealth(probeBudgetMs = 2000) {
+      if (client._helpersInjected) {
+        return { jsWorld: 'responsive', helper: 'current', probeBudgetMs };
+      }
+      return { jsWorld: 'responsive', helper: 'missing', probeBudgetMs };
     },
 
     async send(_method, _params) {

--- a/packages/rn-dev-agent-core/test/unit/gh-214-network-double-capture.test.js
+++ b/packages/rn-dev-agent-core/test/unit/gh-214-network-double-capture.test.js
@@ -53,6 +53,7 @@ function makeHarness({ enableThrows = false, bufferGrowsOnProbe = false } = {}) 
     opts: {
       send,
       evaluate,
+      setupHelpers: async () => true,
       port: 8081,
       connectedTarget: null,
       networkManager,

--- a/packages/rn-dev-agent-core/test/unit/gh-523-reload-relaunch-chain.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-523-reload-relaunch-chain.test.ts
@@ -15,6 +15,7 @@ function mockClient({
     connectedTarget: { id: 'target', platform, description: appId },
     proxyDesired: false,
     helpersInjected: true,
+    helperWorldGeneration: 1,
     async disconnect() {
       this.isConnected = false;
     },
@@ -31,6 +32,12 @@ function mockClient({
     },
     async reinjectHelpers() {
       return true;
+    },
+    async probeHelperFreshness() {
+      return { fresh: true, version: 40, probed: true };
+    },
+    async probeHelperHealth(probeBudgetMs = 2000) {
+      return { jsWorld: 'responsive', helper: 'current', probeBudgetMs };
     },
   };
 }

--- a/packages/rn-dev-agent-core/test/unit/helper-world-coordinator.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/helper-world-coordinator.test.ts
@@ -3,6 +3,10 @@ import test from 'node:test';
 import WebSocket from 'ws';
 import { CDPClient } from '../../dist/cdp-client.js';
 import {
+  closeConnectionAttempt,
+  ConnectionSetupSupersededError,
+} from '../../dist/cdp/connect.js';
+import {
   HELPERS_VERSION,
   INJECTED_HELPERS,
   NETWORK_HOOK_SCRIPT,
@@ -306,12 +310,39 @@ test('superseded setup cannot commit connection capability state', async () => {
   created.call(client, { context: { id: 9, uniqueId: 'replacement' } });
   hook.resolve({ value: undefined });
 
-  await assert.rejects(setup, /setup superseded/);
+  await assert.rejects(setup, ConnectionSetupSupersededError);
   assert.equal(client.networkMode, 'hook');
   assert.equal(client.logDomainEnabled, false);
   assert.equal(client.profilerAvailable, false);
   assert.equal(client.heapProfilerAvailable, false);
   assert.equal(client.helpersInjected, false);
+});
+
+test('stale connection-attempt cleanup cannot close the replacement socket', () => {
+  const replacementWs = {
+    readyState: WebSocket.OPEN,
+    removeAllListeners: () => {},
+    close: () => {},
+  } as unknown as WebSocket;
+  let currentWs: WebSocket | null = replacementWs;
+  let staleClosed = false;
+  const staleWs = {
+    readyState: WebSocket.OPEN,
+    removeAllListeners: () => {},
+    close: () => {
+      staleClosed = true;
+    },
+  } as unknown as WebSocket;
+  const ctx = {
+    getWs: () => currentWs,
+    setWs: (ws: WebSocket | null) => {
+      currentWs = ws;
+    },
+  };
+
+  assert.equal(closeConnectionAttempt(ctx, staleWs), false);
+  assert.equal(staleClosed, false);
+  assert.equal(currentWs, replacementWs);
 });
 
 test('legacy one-context fallback omits contextId and freshness requires exact version', async () => {

--- a/packages/rn-dev-agent-core/test/unit/helper-world-coordinator.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/helper-world-coordinator.test.ts
@@ -1,0 +1,355 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import WebSocket from 'ws';
+import { CDPClient } from '../../dist/cdp-client.js';
+import {
+  HELPERS_VERSION,
+  INJECTED_HELPERS,
+  REACT_READY_PROBE_JS,
+} from '../../dist/injected-helpers.js';
+import { helpersNotInjectedResult } from '../../dist/utils.js';
+import { performSetup } from '../../dist/cdp/setup.js';
+import { DeviceBufferManager } from '../../dist/ring-buffer.js';
+import type { NetworkEntry } from '../../dist/types.js';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(reason: Error): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+type Send = (
+  method: string,
+  params: { expression?: string; contextId?: number },
+  timeoutMs: number,
+) => Promise<unknown>;
+
+function makeConnectedClient(send: Send): CDPClient {
+  const client = new CDPClient(8081);
+  Reflect.set(client, '_state', 'connected');
+  Reflect.set(client, 'ws', { readyState: WebSocket.OPEN });
+  Reflect.set(client, '_connectedTarget', { id: 'target-a', title: 'A' });
+  Reflect.set(client, 'sendWithTimeout', send);
+  const invalidate = Reflect.get(client, 'invalidateHelperWorld') as (cause: string) => void;
+  invalidate.call(client, 'candidate_selected');
+  return client;
+}
+
+function ensure(client: CDPClient, cause: 'setup_started' | 'reinject_started') {
+  const fn = Reflect.get(client, 'ensureCurrentHelpers') as (cause: string) => Promise<boolean>;
+  return fn.call(client, cause);
+}
+
+function invalidate(client: CDPClient, cause = 'socket_closed') {
+  const fn = Reflect.get(client, 'invalidateHelperWorld') as (cause: string) => void;
+  fn.call(client, cause);
+}
+
+function valueResponse(value: unknown): unknown {
+  return { result: { value } };
+}
+
+function helperAwareSend(onPayload: () => Promise<unknown>): Send {
+  return async (_method, params) => {
+    if (params.expression === INJECTED_HELPERS) return onPayload();
+    if (params.expression?.includes(`__v === ${HELPERS_VERSION}`)) return valueResponse(true);
+    if (params.expression?.includes('__RN_DEV_BRIDGE__')) {
+      return valueResponse(JSON.stringify({ present: false, version: null }));
+    }
+    return valueResponse(true);
+  };
+}
+
+test('execution-context observation is installed before Runtime.enable', async () => {
+  let handlersInstalled = false;
+  const order: string[] = [];
+  const networkManager = new DeviceBufferManager<NetworkEntry, string>({
+    capacityPerDevice: 2,
+    maxDevices: 1,
+    indexKey: (entry) => entry.id,
+    timestampOf: () => 0,
+  });
+  const result = await performSetup({
+    send: async (method) => {
+      if (method === 'Runtime.enable') assert.equal(handlersInstalled, true);
+      order.push(method);
+      if (method === 'Network.enable') throw new Error('unsupported');
+      return {};
+    },
+    evaluate: async () => ({ value: undefined }),
+    setupHelpers: async () => {
+      order.push('helpers');
+      return true;
+    },
+    port: 8081,
+    networkManager,
+    getDeviceKey: () => 'device',
+    setupEventHandlers: () => {
+      handlersInstalled = true;
+      order.push('handlers');
+    },
+    clearScripts: () => {},
+    clearEventHandlers: () => {},
+  });
+  assert.equal(result.helpersInjected, true);
+  assert.ok(order.indexOf('handlers') < order.indexOf('Runtime.enable'));
+  assert.ok(order.indexOf('Runtime.enable') < order.indexOf('helpers'));
+});
+
+test('setup and reinjection callers share one exact-version injection operation', async () => {
+  const payload = deferred<unknown>();
+  let payloads = 0;
+  const client = makeConnectedClient(
+    helperAwareSend(() => {
+      payloads++;
+      return payload.promise;
+    }),
+  );
+
+  const setup = ensure(client, 'setup_started');
+  const reinject = ensure(client, 'reinject_started');
+  assert.equal(payloads, 1);
+  payload.resolve(valueResponse(undefined));
+  assert.deepEqual(await Promise.all([setup, reinject]), [true, true]);
+  assert.equal(payloads, 1);
+  assert.equal(client.helpersInjected, true);
+});
+
+test('mixed caller readiness deadlines stay outside the shared core', async () => {
+  const payload = deferred<unknown>();
+  let payloads = 0;
+  const client = makeConnectedClient(async (_method, params) => {
+    if (params.expression === REACT_READY_PROBE_JS) return valueResponse(true);
+    if (params.expression === INJECTED_HELPERS) {
+      payloads++;
+      return payload.promise;
+    }
+    if (params.expression?.includes(`__v === ${HELPERS_VERSION}`)) return valueResponse(true);
+    if (params.expression?.includes('__RN_DEV_BRIDGE__')) {
+      return valueResponse(JSON.stringify({ present: false, version: null }));
+    }
+    return valueResponse(true);
+  });
+
+  const zeroBudget = client.reinjectHelpers(0);
+  const longBudget = client.reinjectHelpers(30_000);
+  await Promise.resolve();
+  assert.equal(payloads, 1);
+  payload.resolve(valueResponse(undefined));
+  assert.deepEqual(await Promise.all([zeroBudget, longBudget]), [true, true]);
+});
+
+test('failed exact-version verification clears state and permits a later attempt', async () => {
+  let exact = false;
+  let payloads = 0;
+  const client = makeConnectedClient(async (_method, params) => {
+    if (params.expression === INJECTED_HELPERS) {
+      payloads++;
+      return valueResponse(undefined);
+    }
+    if (params.expression?.includes(`__v === ${HELPERS_VERSION}`)) {
+      return valueResponse(exact);
+    }
+    if (params.expression?.includes('__RN_DEV_BRIDGE__')) {
+      return valueResponse(JSON.stringify({ present: false, version: null }));
+    }
+    return valueResponse(undefined);
+  });
+
+  assert.equal(await ensure(client, 'reinject_started'), false);
+  assert.equal(client.helpersInjected, false);
+  exact = true;
+  assert.equal(await ensure(client, 'reinject_started'), true);
+  assert.equal(payloads, 2);
+});
+
+test('old success and late finally are inert after helper-world replacement', async () => {
+  const payloadA = deferred<unknown>();
+  const payloadB = deferred<unknown>();
+  let world = 'A';
+  const client = makeConnectedClient(
+    helperAwareSend(() => (world === 'A' ? payloadA.promise : payloadB.promise)),
+  );
+
+  const oldAttempt = ensure(client, 'reinject_started');
+  world = 'B';
+  Reflect.set(client, 'ws', { readyState: WebSocket.OPEN });
+  Reflect.set(client, '_connectedTarget', { id: 'target-b', title: 'B' });
+  invalidate(client, 'socket_opened');
+  const newAttempt = ensure(client, 'setup_started');
+  const newSlot = Reflect.get(client, '_helperInjectionInFlight');
+
+  payloadA.resolve(valueResponse(undefined));
+  assert.equal(await oldAttempt, false);
+  assert.equal(Reflect.get(client, '_helperInjectionInFlight'), newSlot);
+  assert.equal(client.helpersInjected, false);
+
+  payloadB.resolve(valueResponse(undefined));
+  assert.equal(await newAttempt, true);
+  assert.equal(client.helpersInjected, true);
+});
+
+test('old failure is inert and a rejected operation does not poison recovery', async () => {
+  let attempts = 0;
+  const client = makeConnectedClient(
+    helperAwareSend(async () => {
+      attempts++;
+      if (attempts === 1) throw new Error('sentinel secret transport failure');
+      return valueResponse(undefined);
+    }),
+  );
+
+  assert.equal(await ensure(client, 'reinject_started'), false);
+  assert.equal(Reflect.get(client, '_helperInjectionInFlight'), null);
+  assert.equal(await ensure(client, 'reinject_started'), true);
+  assert.equal(attempts, 2);
+});
+
+test('context lifecycle invalidates synchronously and pins helper evaluations', async () => {
+  const contexts: Array<number | undefined> = [];
+  const client = makeConnectedClient(async (_method, params) => {
+    contexts.push(params.contextId);
+    if (params.expression?.includes(`__v === ${HELPERS_VERSION}`)) return valueResponse(true);
+    if (params.expression?.includes('__RN_DEV_BRIDGE__')) {
+      return valueResponse(JSON.stringify({ present: false, version: null }));
+    }
+    return valueResponse(undefined);
+  });
+  const created = Reflect.get(client, 'handleExecutionContextCreated') as (params: unknown) => void;
+  const destroyed = Reflect.get(client, 'handleExecutionContextDestroyed') as (
+    params: unknown,
+  ) => void;
+
+  const publicGeneration = client.connectionGeneration;
+  const before = client.helperWorldGeneration;
+  created.call(client, { context: { id: 7, uniqueId: 'private-context-id' } });
+  assert.equal(client.helperWorldGeneration, before + 1);
+  assert.equal(client.connectionGeneration, publicGeneration);
+  assert.equal(await ensure(client, 'setup_started'), true);
+  assert.ok(contexts.length >= 2);
+  assert.ok(contexts.every((id) => id === 7));
+
+  destroyed.call(client, { executionContextId: 7 });
+  assert.equal(client.helpersInjected, false);
+  assert.equal(client.connectionGeneration, publicGeneration);
+});
+
+test('freshness mismatch invalidates ready evidence before reinjection', async () => {
+  let response: unknown = 'current';
+  const client = makeConnectedClient(async (_method, params) => {
+    if (params.expression?.includes("Object.getOwnPropertyDescriptor(globalThis,'__RN_AGENT')")) {
+      return valueResponse(response);
+    }
+    return valueResponse(response);
+  });
+  assert.equal((await client.probeHelperHealth(20)).helper, 'current');
+  assert.equal(client.helpersInjected, true);
+  response = HELPERS_VERSION + 1;
+  assert.equal((await client.probeHelperFreshness(20)).fresh, false);
+  assert.equal(client.helpersInjected, false);
+});
+
+test('legacy one-context fallback omits contextId and freshness requires exact version', async () => {
+  let version: number = HELPERS_VERSION - 1;
+  const contexts: Array<number | undefined> = [];
+  const client = makeConnectedClient(async (_method, params) => {
+    contexts.push(params.contextId);
+    return valueResponse(version);
+  });
+
+  assert.deepEqual(await client.probeHelperFreshness(17), {
+    fresh: false,
+    version: HELPERS_VERSION - 1,
+    probed: true,
+  });
+  version = HELPERS_VERSION;
+  assert.equal((await client.probeHelperFreshness(17)).fresh, true);
+  assert.ok(contexts.every((id) => id === undefined));
+});
+
+test('health probe reconciles exact current helper and exposes only safe bounded enums', async () => {
+  const sentinel = 'APP_VALUE_THAT_MUST_NOT_ESCAPE';
+  let outcome: 'current' | 'version-mismatch' | 'invalid' = 'current';
+  const client = makeConnectedClient(async () => valueResponse(outcome));
+
+  const current = await client.probeHelperHealth(23);
+  assert.deepEqual(current, { jsWorld: 'responsive', helper: 'current', probeBudgetMs: 23 });
+  assert.equal(client.helpersInjected, true);
+
+  invalidate(client, 'contexts_cleared');
+  outcome = 'version-mismatch';
+  const mismatch = await client.probeHelperHealth(23);
+  assert.deepEqual(mismatch, {
+    jsWorld: 'responsive',
+    helper: 'version-mismatch',
+    probeBudgetMs: 23,
+  });
+  assert.equal(JSON.stringify(mismatch).includes(sentinel), false);
+});
+
+test('both HELPERS_NOT_INJECTED boundaries use identical safe health metadata', async () => {
+  const health = {
+    jsWorld: 'responsive' as const,
+    helper: 'missing' as const,
+    probeBudgetMs: 2000,
+  };
+  const client = {
+    helperWorldGeneration: 9,
+    probeHelperHealth: async () => health,
+  } as unknown as CDPClient;
+
+  for (const boundary of ['initial', 'stale-recovery'] as const) {
+    const result = await helpersNotInjectedResult(client, boundary);
+    assert.ok(result);
+    const envelope = JSON.parse(result.content[0].text) as {
+      code: string;
+      error: string;
+      meta: { helperHealth: typeof health };
+    };
+    assert.equal(envelope.code, 'HELPERS_NOT_INJECTED');
+    assert.deepEqual(envelope.meta.helperHealth, health);
+    assert.equal(envelope.error.includes('genuinely hung'), false);
+    assert.equal(envelope.error.includes('target metadata'), false);
+  }
+});
+
+test('health probe distinguishes bounded timeout, transport failure, and supersession', async () => {
+  const timeoutClient = makeConnectedClient(async () => {
+    throw new Error('CDP timeout (19ms): Runtime.evaluate. sentinel app value');
+  });
+  assert.deepEqual(await timeoutClient.probeHelperHealth(19), {
+    jsWorld: 'timeout',
+    helper: 'unknown',
+    probeBudgetMs: 19,
+  });
+
+  const transportClient = makeConnectedClient(async () => {
+    throw new Error('raw socket failure with private target metadata');
+  });
+  assert.deepEqual(await transportClient.probeHelperHealth(19), {
+    jsWorld: 'transport-error',
+    helper: 'unknown',
+    probeBudgetMs: 19,
+  });
+
+  const pending = deferred<unknown>();
+  const supersededClient = makeConnectedClient(async () => pending.promise);
+  const probe = supersededClient.probeHelperHealth(19);
+  invalidate(supersededClient, 'context_created');
+  pending.resolve(valueResponse('current'));
+  assert.deepEqual(await probe, {
+    jsWorld: 'superseded',
+    helper: 'unknown',
+    probeBudgetMs: 19,
+  });
+});

--- a/packages/rn-dev-agent-core/test/unit/helper-world-coordinator.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/helper-world-coordinator.test.ts
@@ -5,12 +5,13 @@ import { CDPClient } from '../../dist/cdp-client.js';
 import {
   HELPERS_VERSION,
   INJECTED_HELPERS,
+  NETWORK_HOOK_SCRIPT,
   REACT_READY_PROBE_JS,
 } from '../../dist/injected-helpers.js';
 import { helpersNotInjectedResult } from '../../dist/utils.js';
 import { performSetup } from '../../dist/cdp/setup.js';
 import { DeviceBufferManager } from '../../dist/ring-buffer.js';
-import type { NetworkEntry } from '../../dist/types.js';
+import type { EvaluateResult, NetworkEntry } from '../../dist/types.js';
 
 interface Deferred<T> {
   promise: Promise<T>;
@@ -256,6 +257,60 @@ test('freshness mismatch invalidates ready evidence before reinjection', async (
   assert.equal(client.helpersInjected, true);
   response = HELPERS_VERSION + 1;
   assert.equal((await client.probeHelperFreshness(20)).fresh, false);
+  assert.equal(client.helpersInjected, false);
+});
+
+test('freshness probe failure invalidates ready evidence before reinjection', async () => {
+  let shouldFail = false;
+  const client = makeConnectedClient(async (_method, params) => {
+    if (shouldFail) throw new Error('transport unavailable');
+    if (params.expression?.includes("Object.getOwnPropertyDescriptor(globalThis,'__RN_AGENT')")) {
+      return valueResponse('current');
+    }
+    return valueResponse(HELPERS_VERSION);
+  });
+  assert.equal((await client.probeHelperHealth(20)).helper, 'current');
+  assert.equal(client.helpersInjected, true);
+  shouldFail = true;
+  assert.equal((await client.probeHelperFreshness(20)).fresh, false);
+  assert.equal(client.helpersInjected, false);
+});
+
+test('superseded setup cannot commit connection capability state', async () => {
+  const hook = deferred<EvaluateResult>();
+  const hookStarted = deferred<void>();
+  const client = makeConnectedClient(async (method, params) => {
+    if (method === 'Network.enable') throw new Error('unsupported');
+    if (params?.expression === REACT_READY_PROBE_JS) return valueResponse(true);
+    if (params?.expression === INJECTED_HELPERS) return valueResponse(undefined);
+    if (params?.expression?.includes(`__v === ${HELPERS_VERSION}`)) return valueResponse(true);
+    if (params?.expression?.includes('__RN_DEV_BRIDGE__')) {
+      return valueResponse(JSON.stringify({ present: false, version: null }));
+    }
+    return valueResponse(undefined);
+  });
+  Reflect.set(client, 'ensureMetroEventsClient', async () => {});
+  Reflect.set(client, 'evaluate', async (expression: string) => {
+    assert.equal(expression, NETWORK_HOOK_SCRIPT);
+    hookStarted.resolve();
+    return hook.promise;
+  });
+  Reflect.set(client, '_networkMode', 'hook');
+  Reflect.set(client, '_logDomainEnabled', false);
+  Reflect.set(client, '_profilerAvailable', false);
+  Reflect.set(client, '_heapProfilerAvailable', false);
+
+  const setup = (Reflect.get(client, 'setup') as () => Promise<void>).call(client);
+  await hookStarted.promise;
+  const created = Reflect.get(client, 'handleExecutionContextCreated') as (params: unknown) => void;
+  created.call(client, { context: { id: 9, uniqueId: 'replacement' } });
+  hook.resolve({ value: undefined });
+
+  await assert.rejects(setup, /setup superseded/);
+  assert.equal(client.networkMode, 'hook');
+  assert.equal(client.logDomainEnabled, false);
+  assert.equal(client.profilerAvailable, false);
+  assert.equal(client.heapProfilerAvailable, false);
   assert.equal(client.helpersInjected, false);
 });
 

--- a/packages/rn-dev-agent-core/test/unit/helper-world-coordinator.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/helper-world-coordinator.test.ts
@@ -318,7 +318,7 @@ test('superseded setup cannot commit connection capability state', async () => {
   assert.equal(client.helpersInjected, false);
 });
 
-test('stale connection-attempt cleanup cannot close the replacement socket', () => {
+test('connection-attempt cleanup preserves replacements and closes owned sockets', () => {
   const replacementWs = {
     readyState: WebSocket.OPEN,
     removeAllListeners: () => {},
@@ -343,6 +343,11 @@ test('stale connection-attempt cleanup cannot close the replacement socket', () 
   assert.equal(closeConnectionAttempt(ctx, staleWs), false);
   assert.equal(staleClosed, false);
   assert.equal(currentWs, replacementWs);
+
+  currentWs = staleWs;
+  assert.equal(closeConnectionAttempt(ctx, staleWs), true);
+  assert.equal(staleClosed, true);
+  assert.equal(currentWs, null);
 });
 
 test('legacy one-context fallback omits contextId and freshness requires exact version', async () => {

--- a/packages/rn-dev-agent-core/test/unit/helper-world-coordinator.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/helper-world-coordinator.test.ts
@@ -2,10 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import WebSocket from 'ws';
 import { CDPClient } from '../../dist/cdp-client.js';
-import {
-  closeConnectionAttempt,
-  ConnectionSetupSupersededError,
-} from '../../dist/cdp/connect.js';
+import { closeConnectionAttempt, ConnectionSetupSupersededError } from '../../dist/cdp/connect.js';
 import {
   HELPERS_VERSION,
   INJECTED_HELPERS,

--- a/packages/shared-agent-knowledge/commands/check-env.md
+++ b/packages/shared-agent-knowledge/commands/check-env.md
@@ -27,7 +27,7 @@ If issues are found, suggest the appropriate fix:
 | CDP code 1006 | Close React Native DevTools, Flipper, Chrome DevTools |
 | `cdp_component_tree` reports RedBox | Run `/rn-dev-agent:debug-screen` |
 | Narrow gated CDP read times out | Check for a blocked JS thread, then use `cdp_reload` |
-| `HELPERS_NOT_INJECTED` | Use a `__DEV__` Hermes build; retry through the gated tool after reload |
+| `HELPERS_NOT_INJECTED` | Read bounded `meta.helperHealth`; use a `__DEV__` Hermes build and retry through the gated tool after reload |
 | No devices in device_list | Boot a simulator: `xcrun simctl boot "iPhone 16"` or start an emulator |
 
 Present results clearly with a pass/fail indicator for each subsystem.

--- a/packages/shared-agent-knowledge/skills/rn-debugging/SKILL.md
+++ b/packages/shared-agent-knowledge/skills/rn-debugging/SKILL.md
@@ -110,7 +110,7 @@ When a `cdp_*` tool returns `code: HELPERS_NOT_INJECTED`, the bridge has already
 3. Attempted a Dev Client picker dismissal (in case a native overlay was blocking React)
 4. Waited up to another 30s if the picker was dismissed
 
-So when this error appears, **the JS world is genuinely hung** — Hermes is up but `__RN_AGENT` won't land. Two recovery paths, in order:
+The final error includes `meta.helperHealth`: `jsWorld` is one of `responsive`, `timeout`, `transport-error`, or `superseded`; `helper` is one of `current`, `missing`, `version-mismatch`, `invalid`, or `unknown`; and `probeBudgetMs` reports the bounded probe budget. A timeout proves only that the probe received no response within that budget — JavaScript may be busy, paused, or blocked. A responsive/current result is reconciled automatically and the gated call continues, so an emitted error describes missing, mismatched, invalid, unmeasurable, or superseded helper evidence rather than claiming a genuine hang. Use these two recovery paths, in order:
 
 | Step | Action | Why |
 |------|--------|-----|

--- a/packages/shared-agent-knowledge/skills/rn-setup/SKILL.md
+++ b/packages/shared-agent-knowledge/skills/rn-setup/SKILL.md
@@ -140,8 +140,8 @@ injection; passive status deliberately does not duplicate helper capability
 state.
 
 If it returns `HELPERS_NOT_INJECTED`:
-- The gated call already attempted reinjection. If it still fails, the JS world is hung — Hermes is up but `__RN_AGENT` won't land.
-- Surface this in the table as MISSING with action: "JS-tier tools (`cdp_interact`, `cdp_component_tree`, `cdp_store_state`, `cdp_navigation_state`) will fail with HELPERS_NOT_INJECTED. Fall back to `device_*` tools (XCTest path — no helpers required) for UI work, or call `cdp_reload` once to rebuild the JS context. If you also see `app.hasRedBox: true` or `app.errorCount > 0`, fix those first — `cdp_reload` won't help if the bundle itself errors out."
+- The gated call already attempted reinjection and then ran one bounded health probe. Read `meta.helperHealth`: bounded timeout means only "no response within the reported budget," not proof of a hung world; responsive results distinguish missing, version-mismatched, and invalid helpers. Responsive/current evidence is reconciled automatically and does not emit this error.
+- Surface this in the table as MISSING with action: "JS-tier tools (`cdp_interact`, `cdp_component_tree`, `cdp_store_state`, `cdp_navigation_state`) will fail with HELPERS_NOT_INJECTED. Report the fixed `meta.helperHealth` categories, fall back to `device_*` tools (XCTest path — no helpers required) for UI work, or call `cdp_reload` once to rebuild the JS context. If you also see `app.hasRedBox: true` or `app.errorCount > 0`, fix those first — `cdp_reload` won't help if the bundle itself errors out."
 - Also mention: don't sit in a status retry loop; use the gated helper result.
 
 ### 9. ffmpeg (optional — for video recording)


### PR DESCRIPTION
## Intent

Implement and ship GitHub issue #657 on exact current main: replace the simplistic helper reinjection promise cache with a private per-client/per-socket/per-target/per-connection-epoch/per-execution-context-epoch helper-world coordinator while preserving public connectionGeneration semantics. Connect-time helper setup and all reinjection callers must share one token-keyed payload plus exact HELPERS_VERSION verification operation, with caller-specific React-ready budgets outside it, stale completion/finally/rejection fencing, context lifecycle observation installed before Runtime.enable, context pinning limited to helper lifecycle evaluations, exact-version freshness, and token-fenced helper/cache/active-flag/bridge/log state. Centralize both HELPERS_NOT_INJECTED exits through one approximately 2-second current-context health probe that reconciles responsive/current evidence and otherwise exposes only fixed safe enums and budget without raw app/target/context/error data or claiming timeout proves a hang. Preserve the existing retry/reconnect/picker ladder and do not add unconditional recovery, global reset, broad CDP pinning, cross-process locking, or renderer-generation reinjection. Include deterministic TypeScript concurrency/context/version/health regressions, retain reconnect/authority/proxy compatibility, correct canonical and mirrored host knowledge plus generated docs/help, regenerate core/host runtimes only with authoritative commands, and include the required core/plugin patch changeset. No live-device or visual work is needed and behavior for #581, #584, #655, and #656 must remain unchanged.

## What Changed

- Coordinate setup and reinjection per helper execution world, require the exact helper version, and fence stale context, socket, and setup completions without disrupting reconnect retries.
- Centralize `HELPERS_NOT_INJECTED` handling around a bounded health probe with safe diagnostics and automatic reconciliation of current helpers.
- Add concurrency, lifecycle, version, health, and supersession regressions; update shared and host documentation, regenerate shipped runtimes, and add core/plugin patch changesets.

## Risk Assessment

✅ Low: The latest fix safely retries same-socket setup supersession while preserving replacement sockets, and the full review found no remaining material source-verifiable risks or intent contradictions.

## Testing

No prior baseline command was supplied; targeted coordinator, error-boundary, picker, reconnect, exact-authority reload, proxy, status-recovery, and network-capture tests passed. The shipped-runtime transcript demonstrated one shared payload and exact-version check plus sanitized bounded health output. Visual/live-device evidence was unnecessary because the authoritative intent explicitly excludes it.

<details>
<summary>Evidence: Issue #657 shipped-runtime evidence</summary>

```text
{
  "sharedCoordinator": {
    "payloadEvaluations": 1,
    "exactVersionChecks": 1,
    "results": [
      true,
      true
    ],
    "publicConnectionGeneration": 0,
    "helperWorldGeneration": 1
  },
  "endUserErrorEnvelope": {
    "ok": false,
    "error": "Helpers are not ready because the responsive JavaScript world contains a different helper version. Fall back to device_* tools or call cdp_reload once.",
    "code": "HELPERS_NOT_INJECTED",
    "meta": {
      "helperHealth": {
        "jsWorld": "responsive",
        "helper": "version-mismatch",
        "probeBudgetMs": 2000
      }
    }
  },
  "safetyChecks": {
    "rawTargetDataLeaked": false,
    "timeoutClaimedHang": false
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (3) ✅</summary>

- 🚨 `packages/rn-dev-agent-core/src/cdp-client.ts:336` - A failed exact-version probe returns `fresh:false` without clearing `_helpersInjected`. `withConnection` then calls `reinjectHelpers()`, whose coordinator immediately returns true because the stale flag remains set, so no payload or verification runs and the stale world is cached as fresh. Mark the current token unready on probe failure before returning.
- 🚨 `packages/rn-dev-agent-core/src/cdp-client.ts:951` - The required “stale completion/finally/rejection fencing” and “token-fenced ... log state” are absent around the new setup flow. `setup()` does not capture a token before `performSetup`; an older setup waiting through socket/context replacement can resume against the newer helper world and then unconditionally overwrite `_networkMode`, `_logDomainEnabled`, and profiler state. Fence the complete setup result at the setup/connection boundary so superseded setup work cannot mutate current state or complete the old connection attempt.

🔧 Fix: Fence stale setup and failed freshness state
1 error still open:
- 🚨 `packages/rn-dev-agent-core/src/cdp-client.ts:947` - The required “stale completion/finally/rejection fencing” remains incomplete: this new generic `setup superseded` rejection is handled by the older `connectToTarget` catch, which unconditionally calls `closeAndResetWs(ctx)`. If initial setup A is sleeping in `waitForReact`, its socket can close and reconnect setup B can install a new socket; when A wakes, this assertion rejects and A then closes B’s current socket, potentially causing extra connection-generation advances and reconnect churn. Fence cleanup by the connection attempt/socket identity and propagate supersession without retrying or resetting the newer attempt.

🔧 Fix: Fence stale connection cleanup by socket identity
1 error still open:
- 🚨 `packages/rn-dev-agent-core/src/cdp/connect.ts:357` - The required “preserve the existing retry/reconnect/picker ladder” is contradicted by unconditionally rethrowing this supersession error. Execution-context churn on the same still-current socket can invalidate `setupHelperToken`; `setup()` throws, but this branch bypasses attempt cleanup/retry even though `attemptWs === ctx.getWs()`, leaving an open half-configured connection with no generation advance. Distinguish replacement-socket supersession from same-attempt context churn: preserve a newer socket, but close and retry the still-owned attempt.

🔧 Fix: Retry same-socket setup supersession safely
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test packages/rn-dev-agent-core/test/unit/helper-world-coordinator.test.ts packages/rn-dev-agent-core/test/unit/with-connection.test.js`
- `node --test packages/rn-dev-agent-core/test/unit/cdp-connect.test.js packages/rn-dev-agent-core/test/unit/cdp-client-proxy.test.js packages/rn-dev-agent-core/test/unit/reconnect-delay.test.js packages/rn-dev-agent-core/test/unit/reconnection-passive-mode.test.js packages/rn-dev-agent-core/test/unit/gh-214-network-double-capture.test.js packages/rn-dev-agent-core/test/unit/gh-523-reload-relaunch-chain.test.ts`
- `node --test packages/rn-dev-agent-core/test/unit/gh-184-picker-blocking-probe.test.js packages/rn-dev-agent-core/test/unit/gh-208-status-detached-recovery.test.js packages/rn-dev-agent-core/test/unit/b130-recovery-refmap-clear.test.js`
- <code>Manual shipped-runtime coordinator and `HELPERS_NOT_INJECTED` envelope probe captured in the evidence artifact</code>
- `Manual canonical/Claude/Codex knowledge comparison, host-runtime byte comparison, changeset inspection, and generated changelog inspection`
- `git diff --check 21b19c1adaad3086e7f04b2d108efd8b920a2257 896974d2f577d50b175a6d584d80a48ae9ac606c -- .changeset/calm-helpers-coordinate.md apps/docs-site/src/content/docs/changelog.md packages/shared-agent-knowledge packages/claude-plugin/commands packages/claude-plugin/skills packages/codex-plugin/commands packages/codex-plugin/skills`
- <code>Final `git status --short` and evidence-file read-back</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
