### PR TITLE
fix(core): make selector failure recovery bounded

### DIFF
--- a/.changeset/tidy-waits-resume.md
+++ b/.changeset/tidy-waits-resume.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-plugin": patch
+"rn-dev-agent-core": patch
+---
+
+Classify maestro-runner 1.1.x ID-wait misses as SELECTOR_NOT_FOUND, surface bounded head+tail failure evidence with the exact selector on every terminal path, resume reactive CDP/JS replay at the failed selector instead of redispatching executed mutations, and refuse launchApp keys the CDP transport cannot honor.

--- a/apps/docs-site/src/content/docs/changelog.md
+++ b/apps/docs-site/src/content/docs/changelog.md
@@ -5,6 +5,22 @@ description: "Release history for rn-dev-agent"
 
 ## Claude plugin
 
+### 0.71.3
+
+#### Patch Changes
+
+- 8cd1ea2: Fix inline Maestro cold-start timeouts and authority transitions, bridge-lifetime cleanup refusal, optional learned-action bundle gating, truthful date-picker failures, and sanitized exact-device iOS screenshots with relative-path support.
+- Updated dependencies [8cd1ea2]
+  - rn-dev-agent-core@0.66.3
+
+### 0.71.2
+
+#### Patch Changes
+
+- 802efa2: Allow runner-verified exact iOS keyboard targets to activate once while removing corruption-prone automatic keyboard swipes and rejecting stale runner artifacts.
+- Updated dependencies [802efa2]
+  - rn-dev-agent-core@0.66.2
+
 ### 0.71.1
 
 #### Patch Changes
@@ -1230,6 +1246,18 @@ identifier, hittable? }`, with a `fullNodeCount`. Far fewer tokens; `@ref`s for
   #188 shipped these to `main` with no version bump, leaving them undeliverable to marketplace installs; this patch publishes them.
 
 ## Core MCP server
+
+### 0.66.3
+
+#### Patch Changes
+
+- 8cd1ea2: Fix inline Maestro cold-start timeouts and authority transitions, bridge-lifetime cleanup refusal, optional learned-action bundle gating, truthful date-picker failures, and sanitized exact-device iOS screenshots with relative-path support.
+
+### 0.66.2
+
+#### Patch Changes
+
+- 802efa2: Allow runner-verified exact iOS keyboard targets to activate once while removing corruption-prone automatic keyboard swipes and rejecting stale runner artifacts.
 
 ### 0.66.1
 

--- a/packages/claude-plugin/commands/run-action.md
+++ b/packages/claude-plugin/commands/run-action.md
@@ -126,7 +126,7 @@ Example calls:
        },
        durationMs,
        flowFile,
-       firstAttemptOutput?: string,     // first 500 chars of maestro stdout/stderr
+       firstAttemptOutput?: string,     // bounded maestro stdout/stderr: head + tail, 500 chars
        retryOutput?: string,            // present iff retriedAfterRepair === true
        retriedAfterRepair?: boolean
      }
@@ -139,8 +139,11 @@ Example calls:
 
    On failure (`ok: false`), the envelope's `error` message and
    `meta.underlyingFailure` carry the exact underlying Maestro failure
-   (the runner's headline error, or the failing step name) — read those
-   directly instead of digging through the maestro report output.
+   (the failing step name plus `KIND: selector` when the runner named one),
+   and `meta.failureKind` / `meta.failureSelector` expose the same evidence
+   structurally. Read those directly. The runner's HTML report is a
+   temporary artifact that is deleted after every run — no report path is
+   returned, and none should be looked for.
 
    Branch on `data.autoRepair.outcome`:
    - **`outcome === 'skipped'`** with `attempted: false`: happy path —
@@ -172,7 +175,6 @@ After execution, summarise:
 ```
 ✅ <flow-name> passed (16/16, 18.5s)
 Replayed: <command-line>
-Report: reports/2026-04-29_HH-MM-SS/report.html
 ```
 
 Or:
@@ -180,7 +182,6 @@ Or:
 ```
 ❌ <flow-name> failed at step <N> ("tapOn id: ...")
 Replayed: <command-line>
-Failing screenshot: reports/.../assets/flow-000/cmd-N-after.png
 Likely cause: <one-line diagnosis>
 Next step: <single concrete suggestion>
 ```

--- a/packages/claude-plugin/commands/run-action.md
+++ b/packages/claude-plugin/commands/run-action.md
@@ -155,7 +155,7 @@ Example calls:
      diff .rn-agent/actions/<id>.yaml` to inspect.
    - **`outcome === 'failed'`**: post-repair retry still failed —
      `meta.underlyingFailure` carries the exact failure;
-     `data.retryOutput` has the trailing maestro output for deeper
+     `data.retryOutput` has bounded head-and-tail Maestro output for deeper
      diagnosis.
    - **`outcome === 'refused'`** with `refusedReason`: auto-repair declined
      (user disabled, file edited since load, repair budget exhausted, or

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -27621,9 +27621,21 @@ var init_maestro_dispatch = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/ansi.js
+function stripAnsi(value) {
+  return value.replace(ANSI_RE, "");
+}
+var ANSI_RE;
+var init_ansi = __esm({
+  "packages/rn-dev-agent-core/dist/domain/ansi.js"() {
+    "use strict";
+    ANSI_RE = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g");
+  }
+});
+
 // packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
 function parseTerminalIdWait(output, suppliedFailedStep) {
-  const lines = output.split("\n");
+  const lines = stripAnsi(output).split("\n");
   let terminalStep;
   for (let index = 0; index < lines.length; index++) {
     const match = RUNNER_STEP_RE.exec(lines[index]);
@@ -27714,6 +27726,7 @@ var PATTERNS, RUNNER_STEP_RE, REASON_LINE_RE, ID_WAIT_STEP_RE, ID_WAIT_REASON_RE
 var init_maestro_error_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js"() {
     "use strict";
+    init_ansi();
     PATTERNS = [
       {
         re: /Element with id (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -28046,9 +28059,6 @@ var init_engine_pin = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/maestro-step-parser.js
-function stripAnsi(s) {
-  return s.replace(ANSI_RE, "");
-}
 function cap(s) {
   return s.length > MAX_FIELD ? s.slice(0, MAX_FIELD) + "\u2026" : s;
 }
@@ -28147,12 +28157,13 @@ function formatFailureHeadline(summary, cls, fallbackMsg) {
   }
   return `Maestro flow failed: ${fallbackMsg.slice(0, 500)}`;
 }
-var ANSI_RE, STEP_RE, MAX_FIELD, MAX_STEPS, WDA_TOKEN_RE, WDA_FAILURE_RE;
+var STEP_RE, MAX_FIELD, MAX_STEPS, WDA_TOKEN_RE, WDA_FAILURE_RE;
 var init_maestro_step_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-step-parser.js"() {
     "use strict";
     init_maestro_error_parser();
-    ANSI_RE = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g");
+    init_ansi();
+    init_ansi();
     STEP_RE = /^[ \t]+([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
     MAX_FIELD = 200;
     MAX_STEPS = 1e3;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -27699,6 +27699,16 @@ var init_maestro_error_parser = __esm({
         re: /Element not found:\s*text=(['"])((?:(?!\1).)+)\1/i,
         build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "text", selector: m[2], raw })
       },
+      // maestro-runner 1.1.16/1.1.20 ID-wait shape — issue #580.
+      // "Element '#X' not visible within 1s (cause: context deadline exceeded)".
+      // The `#` immediately after the opening quote is the runner's ID-selector
+      // marker: text and regex waits render without it and keep their current
+      // classification (issue #334 owns those). Process/global timeouts never reach
+      // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
+      {
+        re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
+        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw })
+      },
       {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
         build: (m, raw) => ({
@@ -68597,9 +68607,17 @@ function normalizeSteps(body, params) {
     const key = keys[0];
     const v = raw[key];
     switch (key) {
-      case "launchApp":
+      case "launchApp": {
+        if (isObj(v)) {
+          const unsupported = Object.keys(v).filter((k) => k !== "stopApp");
+          if (unsupported.length > 0)
+            throw new UnsupportedStepError(`launchApp (unsupported keys: ${unsupported.sort().join(", ")})`);
+          if ("stopApp" in v && typeof v.stopApp !== "boolean")
+            throw new UnsupportedStepError("launchApp (stopApp must be a boolean)");
+        }
         out.push({ t: "launch", stopApp: isObj(v) && v.stopApp === true });
         break;
+      }
       case "tapOn": {
         const id = isObj(v) ? asString(v.id) : null;
         if (!id)
@@ -68649,12 +68667,47 @@ function firstTestId(steps) {
   }
   return null;
 }
-async function replayFlow(steps, dispatch) {
+var MAX_ANCHOR_DEPTH = 20;
+function countIdHits(node, params, selector, index, depth, nested, scan) {
+  if (depth > MAX_ANCHOR_DEPTH) {
+    scan.truncated = true;
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const child of node)
+      countIdHits(child, params, selector, index, depth + 1, nested, scan);
+    return;
+  }
+  if (!isObj(node))
+    return;
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "id" && typeof value === "string" && interp(value, params) === selector) {
+      scan.hits.push({ index, nested });
+      continue;
+    }
+    countIdHits(value, params, selector, index, depth + 1, nested || key === "commands", scan);
+  }
+}
+function findResumeAnchor(body, params, selector) {
+  if (!selector)
+    return { found: false, reason: "no-match" };
+  const scan = { hits: [], truncated: false };
+  body.forEach((raw, index) => countIdHits(raw, params, selector, index, 0, false, scan));
+  if (scan.truncated)
+    return { found: false, reason: "too-deep" };
+  if (scan.hits.length === 0)
+    return { found: false, reason: "no-match" };
+  if (scan.hits.length > 1)
+    return { found: false, reason: "ambiguous" };
+  return scan.hits[0].nested ? { found: false, reason: "nested-match" } : { found: true, index: scan.hits[0].index };
+}
+async function replayFlow(steps, dispatch, opts = {}) {
+  const offset = opts.indexOffset ?? 0;
   const trace = [];
   let lastTapped = null;
   const fail3 = (i, reason) => ({
     passed: false,
-    failedStepIndex: i,
+    failedStepIndex: i + offset,
     reason,
     steps: trace
   });
@@ -68696,7 +68749,7 @@ async function replayFlow(steps, dispatch) {
             if (!sub.passed) {
               return {
                 passed: false,
-                failedStepIndex: i,
+                failedStepIndex: i + offset,
                 reason: sub.reason,
                 steps: trace
               };
@@ -68773,10 +68826,19 @@ function isDisabled(props) {
   const a11y = props.accessibilityState;
   return props.disabled === true || a11y?.disabled === true || props.pointerEvents === "none";
 }
-async function runCdpReplay(bodyYaml, params, deps) {
+async function runCdpReplay(bodyYaml, params, deps, opts = {}) {
   const parsed = (0, import_yaml4.parse)(bodyYaml);
-  const steps = normalizeSteps(parsed, params);
-  return replayFlow(steps, buildCdpDispatch(deps));
+  const resume = resolveResume(parsed, params, opts.resumeAtSelector);
+  const startIndex = resume.applied ? resume.startIndex : 0;
+  const steps = normalizeSteps(startIndex === 0 ? parsed : parsed.slice(startIndex), params);
+  const result = await replayFlow(steps, buildCdpDispatch(deps), { indexOffset: startIndex });
+  return { ...result, resume };
+}
+function resolveResume(parsed, params, selector) {
+  if (!selector || !Array.isArray(parsed))
+    return { applied: false, reason: "not-requested" };
+  const anchor = findResumeAnchor(parsed, params, selector);
+  return anchor.found ? { applied: true, selector, startIndex: anchor.index } : { applied: false, reason: anchor.reason };
 }
 function buildCdpDispatch(deps) {
   return {
@@ -68922,13 +68984,34 @@ function readMaestroDeviceAuthority(env) {
     return env.data.deviceAuthority;
   return env.meta?.deviceAuthority;
 }
+function terminalReason(terminal) {
+  if (!terminal?.failureKind)
+    return "";
+  return ` (${terminal.failureKind}${terminal.failureSelector ? `: ${terminal.failureSelector}` : ""})`;
+}
 function readMaestroFailureDetail(env, output) {
   if (typeof env.error === "string" && env.error.trim())
     return env.error.trim();
-  const failedStep = env.meta?.failedStep;
-  if (typeof failedStep?.name === "string")
-    return `Maestro flow failed at step "${failedStep.name}"`;
-  return output.trim().slice(0, 1e3) || "Maestro runner returned no failure detail";
+  const terminal = readMaestroTerminal(env);
+  const reason = terminalReason(terminal);
+  const metaStep = env.meta?.failedStep;
+  const dataStep = env.data?.failedStep;
+  const stepName = typeof metaStep?.name === "string" ? metaStep.name : typeof dataStep?.name === "string" ? dataStep.name : terminal?.failedStep;
+  if (stepName)
+    return `Maestro flow failed at step "${stepName}"${reason}`;
+  if (reason)
+    return `Maestro flow failed${reason.trim()}`;
+  return boundedOutput(output.trim(), 1e3) || "Maestro runner returned no failure detail";
+}
+var OUTPUT_BUDGET = 500;
+var OUTPUT_ELISION = "\n\u2026\n";
+function boundedOutput(output, budget = OUTPUT_BUDGET) {
+  const text = typeof output === "string" ? output : "";
+  if (text.length <= budget)
+    return text;
+  const room = budget - OUTPUT_ELISION.length;
+  const head = Math.ceil(room / 2);
+  return text.slice(0, head) + OUTPUT_ELISION + text.slice(text.length - (room - head));
 }
 function mapRefusedReason(repairCode, repairError) {
   if (repairCode === "SNAPSHOT_FAILED")
@@ -69165,7 +69248,7 @@ function createRunActionHandler(deps = {}) {
           writes: writeDisclosure(promotionDisclosure(persisted2), persisted2),
           durationMs: Date.now() - t0,
           flowFile: action.filePath,
-          firstAttemptOutput: firstOutput.slice(0, 500)
+          firstAttemptOutput: boundedOutput(firstOutput)
         });
       }
       const failure = parseMaestroFailure(firstOutput, readMaestroTerminal(firstEnv));
@@ -69215,8 +69298,17 @@ function createRunActionHandler(deps = {}) {
               reason: probeOutcome.sawTree ? "testid-not-in-tree" : "cdp-unreachable"
             };
           } else {
+            const maestroEvidence = {
+              failureKind: failure.kind,
+              ...failure.kind === "SELECTOR_NOT_FOUND" ? { failureSelector: failure.selector } : {},
+              underlyingFailure: firstFailureDetail,
+              terminal: readMaestroTerminal(firstEnv),
+              firstAttemptOutput: boundedOutput(firstOutput)
+            };
             try {
-              const replay = await runCdpReplay(action.body, args.params ?? {}, replayDeps);
+              const replay = await runCdpReplay(action.body, args.params ?? {}, replayDeps, {
+                resumeAtSelector: failure.kind === "SELECTOR_NOT_FOUND" ? failure.selector : null
+              });
               const status = replay.passed ? "pass" : "fail";
               const autoRepair2 = {
                 attempted: false,
@@ -69245,17 +69337,20 @@ function createRunActionHandler(deps = {}) {
                   autoRepair: autoRepair2,
                   writes: writeDisclosure(promotionDisclosure(persisted2), persisted2),
                   durationMs: Date.now() - t0,
-                  flowFile: action.filePath
+                  flowFile: action.filePath,
+                  resume: replay.resume
                 });
               }
               return failResult(`cdp_run_action: ${args.actionId} replayed via CDP/JS (WDA transport-blind) and failed at step ${replay.failedStepIndex}: ${replay.reason}`, "TRANSPORT_BLIND", {
                 actionId: args.actionId,
                 transport: "cdp-js",
-                failedStepIndex: replay.failedStepIndex
+                failedStepIndex: replay.failedStepIndex,
+                resume: replay.resume,
+                ...maestroEvidence
               });
             } catch (e) {
               if (e instanceof UnsupportedStepError) {
-                return failResult(`cdp_run_action: ${args.actionId} cannot replay via CDP/JS \u2014 ${e.message}. This action uses a step type the iOS 26.x fallback doesn't support; run on iOS 18 (WDA works there).`, "UNSUPPORTED_STEP", { actionId: args.actionId, stepKey: e.stepKey });
+                return failResult(`cdp_run_action: ${args.actionId} cannot replay via CDP/JS \u2014 ${e.message}. This action uses a step type the iOS 26.x fallback doesn't support; run on iOS 18 (WDA works there).`, "UNSUPPORTED_STEP", { actionId: args.actionId, stepKey: e.stepKey, ...maestroEvidence });
               }
               throw e;
             }
@@ -69287,9 +69382,12 @@ function createRunActionHandler(deps = {}) {
         const meta = {
           actionId: args.actionId,
           failureKind: failure.kind,
+          // GH #580: the selector belongs in the envelope structurally, not only
+          // inside the human headline the caller would have to re-parse.
+          ..."selector" in failure && failure.selector ? { failureSelector: failure.selector } : {},
           underlyingFailure: firstFailureDetail,
           autoRepair: autoRepair2,
-          firstAttemptOutput: firstOutput.slice(0, 500),
+          firstAttemptOutput: boundedOutput(firstOutput),
           terminal: readMaestroTerminal(firstEnv),
           runnerResume: firstEnv.meta?.runnerResume,
           ...cdpJsFallback ? { cdpJsFallback } : {}
@@ -69326,15 +69424,21 @@ function createRunActionHandler(deps = {}) {
           durationMs: Date.now() - t0,
           status: "fail",
           failureCode: "SELECTOR_NOT_FOUND",
-          failureDetail: firstOutput.slice(0, 500),
+          // GH #580: the structured detail carries kind + selector; the bounded
+          // stdout slice can lose the failing line to later runner narration.
+          failureDetail: firstFailureDetail.slice(0, 1e3),
           trigger,
           autoRepair: autoRepair2
         });
-        return failResult(`cdp_run_action: ${args.actionId} failed with SELECTOR_NOT_FOUND; auto-repair refused (${refusedReason}): ${repairEnv.error ?? "unknown"}`, refusedReason === "TRANSPORT_BLIND" ? "TRANSPORT_BLIND" : "TESTID_NOT_FOUND", {
+        return failResult(`cdp_run_action: ${args.actionId} failed with SELECTOR_NOT_FOUND (${failure.selector}); auto-repair refused (${refusedReason}): ${repairEnv.error ?? "unknown"}`, refusedReason === "TRANSPORT_BLIND" ? "TRANSPORT_BLIND" : "TESTID_NOT_FOUND", {
           actionId: args.actionId,
+          failureKind: failure.kind,
+          failureSelector: failure.selector,
+          underlyingFailure: firstFailureDetail,
+          terminal: readMaestroTerminal(firstEnv),
           autoRepair: autoRepair2,
           repairError: repairEnv.error,
-          firstAttemptOutput: firstOutput.slice(0, 500)
+          firstAttemptOutput: boundedOutput(firstOutput)
         });
       }
       const repairData = repairEnv.data;
@@ -69440,15 +69544,15 @@ function createRunActionHandler(deps = {}) {
           durationMs: Date.now() - t0,
           flowFile: reloadedAction.filePath,
           retriedAfterRepair: true,
-          retryOutput: retryOutput.slice(0, 500)
+          retryOutput: boundedOutput(retryOutput)
         });
       }
       return failResult(`cdp_run_action: ${args.actionId} still failing after auto-repair (${repairData.oldSelector} \u2192 ${repairData.newSelector}): ${retryFailureDetail}`, "TESTID_NOT_FOUND", {
         actionId: args.actionId,
         autoRepair,
         writes: writeDisclosure("auto-repair", persisted),
-        firstAttemptOutput: firstOutput.slice(0, 500),
-        retryOutput: retryOutput.slice(0, 500),
+        firstAttemptOutput: boundedOutput(firstOutput),
+        retryOutput: boundedOutput(retryOutput),
         underlyingFailure: retryFailureDetail
       });
     } catch (err) {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -27653,7 +27653,14 @@ function parseMaestroFailure(output, terminal) {
   }
   output = raw;
   const lines = output.split("\n");
-  for (const { re, build } of PATTERNS) {
+  const terminalWaitLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line));
+  for (const { re, build, terminalWaitOnly } of PATTERNS) {
+    if (terminalWaitOnly) {
+      const m = terminalWaitLine?.match(re);
+      if (m)
+        return build(m, output);
+      continue;
+    }
     for (let i = lines.length - 1; i >= 0; i--) {
       const line = lines[i];
       if (!line)
@@ -27663,7 +27670,9 @@ function parseMaestroFailure(output, terminal) {
         return build(m, output);
     }
   }
-  for (const { re, build } of PATTERNS) {
+  for (const { re, build, terminalWaitOnly } of PATTERNS) {
+    if (terminalWaitOnly)
+      continue;
     const m = output.match(re);
     if (m)
       return build(m, output);
@@ -27707,7 +27716,8 @@ var init_maestro_error_parser = __esm({
       // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
       {
         re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
-        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw })
+        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw }),
+        terminalWaitOnly: true
       },
       {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -68705,9 +68715,10 @@ async function replayFlow(steps, dispatch, opts = {}) {
   const offset = opts.indexOffset ?? 0;
   const trace = [];
   let lastTapped = null;
+  const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail3 = (i, reason) => ({
     passed: false,
-    failedStepIndex: i + offset,
+    failedStepIndex: sourceIndex(i),
     reason,
     steps: trace
   });
@@ -68717,51 +68728,61 @@ async function replayFlow(steps, dispatch, opts = {}) {
       switch (s.t) {
         case "launch":
           await dispatch.launch(s.stopApp);
-          trace.push({ t: s.t, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, ok: true });
           break;
         case "tap":
           await dispatch.press(s.id);
           lastTapped = s.id;
-          trace.push({ t: s.t, target: s.id, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, target: s.id, ok: true });
           break;
         case "type": {
           if (!lastTapped)
             return fail3(i, "inputText before any tapOn \u2014 no focus target");
           await dispatch.type(lastTapped, s.text);
-          trace.push({ t: s.t, target: lastTapped, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, target: lastTapped, ok: true });
           break;
         }
         case "assert": {
           const ok = await dispatch.isVisible(s.id);
-          trace.push({ t: s.t, target: s.id, ok });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, target: s.id, ok });
           if (!ok)
             return fail3(i, `assertVisible: "${s.id}" not present in CDP tree`);
           break;
         }
         case "wait":
           await dispatch.settle();
-          trace.push({ t: s.t, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, ok: true });
           break;
         case "runFlow": {
           if (await dispatch.isVisible(s.whenVisible)) {
-            const sub = await replayFlow(s.commands, dispatch);
+            const sub = await replayFlow(s.commands, dispatch, { sourceIndex: sourceIndex(i) });
             trace.push(...sub.steps);
             if (!sub.passed) {
               return {
                 passed: false,
-                failedStepIndex: i + offset,
+                failedStepIndex: sourceIndex(i),
                 reason: sub.reason,
                 steps: trace
               };
             }
           } else {
-            trace.push({ t: s.t, target: s.whenVisible, ok: true });
+            trace.push({
+              sourceIndex: sourceIndex(i),
+              t: s.t,
+              target: s.whenVisible,
+              ok: true
+            });
           }
           break;
         }
       }
     } catch (e) {
-      trace.push({ t: s.t, target: "id" in s ? s.id : void 0, ok: false });
+      trace.push({
+        sourceIndex: sourceIndex(i),
+        t: s.t,
+        target: "id" in s ? s.id : void 0,
+        ok: false
+      });
       return fail3(i, e instanceof Error ? e.message : String(e));
     }
   }
@@ -69479,6 +69500,8 @@ function createRunActionHandler(deps = {}) {
       const retryPassed = retryEnv.ok === true && retryEnv.data?.passed === true;
       const retryOutput = readMaestroOutput(retryEnv);
       const retryFailureDetail = readMaestroFailureDetail(retryEnv, retryOutput);
+      const retryTerminal = readMaestroTerminal(retryEnv);
+      const retryFailure = !retryPassed ? parseMaestroFailure(retryOutput, retryTerminal) : void 0;
       const retryDeviceAuthority = readMaestroDeviceAuthority(retryEnv);
       probeDeviceId = retryDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
       if (retryEnv.code === "DEVICE_AUTHORITY_MISMATCH") {
@@ -69501,14 +69524,8 @@ function createRunActionHandler(deps = {}) {
       const repairScore = repairEnv.data?.score;
       const repairTimestamp = reloadedAction.state.repairHistory.length > 0 ? reloadedAction.state.repairHistory[reloadedAction.state.repairHistory.length - 1].timestamp : void 0;
       let nextFailedSelector;
-      if (!retryPassed) {
-        try {
-          const retryFailure = parseMaestroFailure(retryOutput, readMaestroTerminal(retryEnv));
-          if (retryFailure.kind === "SELECTOR_NOT_FOUND" && retryFailure.selector && retryFailure.selector !== repairData.newSelector) {
-            nextFailedSelector = retryFailure.selector;
-          }
-        } catch {
-        }
+      if (retryFailure?.kind === "SELECTOR_NOT_FOUND" && retryFailure.selector && retryFailure.selector !== repairData.newSelector) {
+        nextFailedSelector = retryFailure.selector;
       }
       const autoRepair = {
         attempted: true,
@@ -69553,7 +69570,10 @@ function createRunActionHandler(deps = {}) {
         writes: writeDisclosure("auto-repair", persisted),
         firstAttemptOutput: boundedOutput(firstOutput),
         retryOutput: boundedOutput(retryOutput),
-        underlyingFailure: retryFailureDetail
+        underlyingFailure: retryFailureDetail,
+        ...retryFailure ? { failureKind: retryFailure.kind } : {},
+        ...retryFailure && "selector" in retryFailure && retryFailure.selector ? { failureSelector: retryFailure.selector } : {},
+        terminal: retryTerminal
       });
     } catch (err) {
       if (err instanceof SessionAuthorityError)

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -27680,7 +27680,7 @@ function parseTerminalIdWait(output, suppliedFailedStep) {
   const reasonMatch = ID_WAIT_REASON_RE.exec(reasonLine);
   if (!reasonMatch)
     return null;
-  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep) ?? (terminalStep ? idWaitStepAmongDuplicates(lines, terminalStep.index, reasonLine) : null);
+  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep) ?? (terminalStep && SELECTOR_LESS_ID_WAIT_SUMMARY_RE.test(failedStep) ? idWaitStepAmongDuplicates(lines, terminalStep.index, reasonLine) : null);
   if (!stepMatch || reasonMatch[2] !== stepMatch[2])
     return null;
   return {
@@ -27747,7 +27747,7 @@ function isAutoRepairable(failure) {
 function outputIndicatesFlowFailure(output) {
   return /^\s*(?:\[FAILED\]|(?:Test|Flow) FAILED\b|FAILED\s*$)/m.test(output);
 }
-var PATTERNS, RUNNER_STEP_RE, REASON_LINE_RE, ID_WAIT_STEP_RE, ID_WAIT_REASON_RE;
+var PATTERNS, RUNNER_STEP_RE, REASON_LINE_RE, ID_WAIT_STEP_RE, SELECTOR_LESS_ID_WAIT_SUMMARY_RE, ID_WAIT_REASON_RE;
 var init_maestro_error_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js"() {
     "use strict";
@@ -27800,6 +27800,7 @@ var init_maestro_error_parser = __esm({
     RUNNER_STEP_RE = /^[ \t]+([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
     REASON_LINE_RE = /^[ \t]+╰─\s+/;
     ID_WAIT_STEP_RE = /^extendedWaitUntil:\s+visible\s+id=(['"])((?:(?!\1).)+)\1$/i;
+    SELECTOR_LESS_ID_WAIT_SUMMARY_RE = /^extendedWaitUntil$/;
     ID_WAIT_REASON_RE = /^[ \t]+╰─\s+Element (['"])#((?:(?!\1).)+)\1 not visible within\b/i;
   }
 });
@@ -28090,7 +28091,7 @@ function cap(s) {
 function combineRunnerOutput(stdout, stderr) {
   return (stdout + "\n" + stderr).replace(/^[\r\n]+/, "").trimEnd();
 }
-function parseSteps(output) {
+function parseExactSteps(output) {
   if (!output || typeof output !== "string")
     return [];
   const steps = [];
@@ -28108,13 +28109,19 @@ function parseSteps(output) {
       continue;
     steps.push({
       index: index++,
-      name: cap(name),
+      name,
       verb,
       status: m[1] === "\u2713" ? "pass" : "fail",
       durationMs: Math.round(seconds * 1e3)
     });
   }
   return steps.length > MAX_STEPS ? steps.slice(-MAX_STEPS) : steps;
+}
+function boundStep(step) {
+  return { ...step, name: cap(step.name) };
+}
+function parseSteps(output) {
+  return parseExactSteps(output).map(boundStep);
 }
 function findFailedStep(steps) {
   const last = steps.length ? steps[steps.length - 1] : null;
@@ -28123,20 +28130,25 @@ function findFailedStep(steps) {
 function lastObservedStep(steps) {
   return steps.length ? steps[steps.length - 1] : null;
 }
-function summarizeReason(output, failedStep) {
+function summarizeExactReason(output, failedStep) {
   const f = parseMaestroFailure(output, failedStep ? { failedStep } : void 0);
   if (f.kind === "UNKNOWN" || f.kind === "WDA_BOOTSTRAP_FAILED")
     return null;
   const selector = "selector" in f ? f.selector ?? null : null;
-  return { kind: f.kind, selector: selector === null ? null : cap(selector) };
+  return { kind: f.kind, selector };
 }
 function buildStepSummary(output, opts) {
-  const steps = parseSteps(output);
-  const failedStep = opts.failed ? findFailedStep(steps) : null;
+  const exactSteps = parseExactSteps(output);
+  const exactFailedStep = opts.failed ? findFailedStep(exactSteps) : null;
+  const exactReason = opts.failed ? summarizeExactReason(output, exactFailedStep?.name) : null;
+  const steps = exactSteps.map(boundStep);
   return {
     steps,
-    failedStep,
-    reason: opts.failed ? summarizeReason(output, failedStep?.name) : null,
+    failedStep: exactFailedStep ? boundStep(exactFailedStep) : null,
+    reason: exactReason ? {
+      ...exactReason,
+      selector: exactReason.selector === null ? null : cap(exactReason.selector)
+    } : null,
     lastStep: lastObservedStep(steps)
   };
 }
@@ -28144,17 +28156,19 @@ function isWdaFailureLine(line) {
   return WDA_TOKEN_RE.test(line) && WDA_FAILURE_RE.test(line);
 }
 function buildTerminalEvidence(output, opts = {}) {
-  const summary = buildStepSummary(output, { failed: true });
+  const exactSteps = parseExactSteps(output);
+  const failedStep = findFailedStep(exactSteps);
+  const reason = summarizeExactReason(output, failedStep?.name);
   const bootstrapEvidence = stripAnsi(output).split("\n").filter((line) => isWdaFailureLine(line)).join("\n").slice(0, 500);
-  const exitClass = opts.timedOut ? "timed-out" : opts.spawnError ? "spawn-error" : summary.steps.length === 0 ? "before-first-step" : "step-failure";
+  const exitClass = opts.timedOut ? "timed-out" : opts.spawnError ? "spawn-error" : exactSteps.length === 0 ? "before-first-step" : "step-failure";
   return {
-    completedSteps: summary.steps.filter((step) => step.status === "pass").length,
-    ...summary.failedStep ? { failedStep: summary.failedStep.name } : {},
+    completedSteps: exactSteps.filter((step) => step.status === "pass").length,
+    ...failedStep ? { failedStep: failedStep.name } : {},
     exitClass,
     ...bootstrapEvidence ? { bootstrapEvidence } : {},
-    ...summary.reason ? {
-      failureKind: summary.reason.kind,
-      failureSelector: summary.reason.selector
+    ...reason ? {
+      failureKind: reason.kind,
+      failureSelector: reason.selector
     } : {}
   };
 }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -27653,26 +27653,16 @@ function parseMaestroFailure(output, terminal) {
   }
   output = raw;
   const lines = output.split("\n");
-  const terminalWaitLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line));
-  for (const { re, build, terminalWaitOnly } of PATTERNS) {
-    if (terminalWaitOnly) {
-      const m = terminalWaitLine?.match(re);
-      if (m)
-        return build(m, output);
-      continue;
-    }
-    for (let i = lines.length - 1; i >= 0; i--) {
-      const line = lines[i];
-      if (!line)
-        continue;
-      const m = line.match(re);
+  const terminalFailureLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) || PATTERNS.some(({ re }) => re.test(line)));
+  if (terminalFailureLine) {
+    for (const { re, build } of PATTERNS) {
+      const m = terminalFailureLine.match(re);
       if (m)
         return build(m, output);
     }
+    return { kind: "UNKNOWN", raw: output };
   }
-  for (const { re, build, terminalWaitOnly } of PATTERNS) {
-    if (terminalWaitOnly)
-      continue;
+  for (const { re, build } of PATTERNS) {
     const m = output.match(re);
     if (m)
       return build(m, output);
@@ -27716,8 +27706,7 @@ var init_maestro_error_parser = __esm({
       // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
       {
         re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
-        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw }),
-        terminalWaitOnly: true
+        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw })
       },
       {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -69502,6 +69491,7 @@ function createRunActionHandler(deps = {}) {
       const retryFailureDetail = readMaestroFailureDetail(retryEnv, retryOutput);
       const retryTerminal = readMaestroTerminal(retryEnv);
       const retryFailure = !retryPassed ? parseMaestroFailure(retryOutput, retryTerminal) : void 0;
+      const retryClassification = retryFailure ? classifyFailure(retryFailure) : void 0;
       const retryDeviceAuthority = readMaestroDeviceAuthority(retryEnv);
       probeDeviceId = retryDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
       if (retryEnv.code === "DEVICE_AUTHORITY_MISMATCH") {
@@ -69545,7 +69535,7 @@ function createRunActionHandler(deps = {}) {
         timestamp: (/* @__PURE__ */ new Date()).toISOString(),
         durationMs: Date.now() - t0,
         status: retryPassed ? "pass" : "fail",
-        failureCode: retryPassed ? void 0 : "SELECTOR_NOT_FOUND",
+        failureCode: retryClassification?.actionCode,
         failureDetail: retryPassed ? void 0 : retryFailureDetail.slice(0, 1e3),
         trigger,
         autoRepair
@@ -69564,7 +69554,8 @@ function createRunActionHandler(deps = {}) {
           retryOutput: boundedOutput(retryOutput)
         });
       }
-      return failResult(`cdp_run_action: ${args.actionId} still failing after auto-repair (${repairData.oldSelector} \u2192 ${repairData.newSelector}): ${retryFailureDetail}`, "TESTID_NOT_FOUND", {
+      const retryMessage = `cdp_run_action: ${args.actionId} still failing after auto-repair (${repairData.oldSelector} \u2192 ${repairData.newSelector}): ${retryFailureDetail}`;
+      const retryMeta = {
         actionId: args.actionId,
         autoRepair,
         writes: writeDisclosure("auto-repair", persisted),
@@ -69574,7 +69565,8 @@ function createRunActionHandler(deps = {}) {
         ...retryFailure ? { failureKind: retryFailure.kind } : {},
         ...retryFailure && "selector" in retryFailure && retryFailure.selector ? { failureSelector: retryFailure.selector } : {},
         terminal: retryTerminal
-      });
+      };
+      return retryClassification?.toolCode ? failResult(retryMessage, retryClassification.toolCode, retryMeta) : failResult(retryMessage, retryMeta);
     } catch (err) {
       if (err instanceof SessionAuthorityError)
         throw err;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -27622,6 +27622,37 @@ var init_maestro_dispatch = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
+function parseTerminalIdWait(output, suppliedFailedStep) {
+  const lines = output.split("\n");
+  let terminalStep;
+  for (let index = 0; index < lines.length; index++) {
+    const match = RUNNER_STEP_RE.exec(lines[index]);
+    if (match)
+      terminalStep = { index, status: match[1], name: match[2] };
+  }
+  if (terminalStep?.status === "\u2713")
+    return null;
+  if (suppliedFailedStep && terminalStep && terminalStep.name !== suppliedFailedStep)
+    return null;
+  const failedStep = suppliedFailedStep ?? terminalStep?.name;
+  if (!failedStep || terminalStep && terminalStep.status !== "\u2717")
+    return null;
+  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep);
+  if (!stepMatch)
+    return null;
+  const reasonLine = lines.slice(terminalStep ? terminalStep.index + 1 : 0).filter((line) => REASON_LINE_RE.test(line)).at(-1);
+  if (!reasonLine)
+    return null;
+  const reasonMatch = ID_WAIT_REASON_RE.exec(reasonLine);
+  if (!reasonMatch || reasonMatch[2] !== stepMatch[2])
+    return null;
+  return {
+    kind: "SELECTOR_NOT_FOUND",
+    selectorKind: "id",
+    selector: stepMatch[2],
+    raw: output
+  };
+}
 function parseMaestroFailure(output, terminal) {
   const raw = typeof output === "string" ? output : "";
   if (terminal?.exitClass === "timed-out") {
@@ -27652,15 +27683,19 @@ function parseMaestroFailure(output, terminal) {
     return { kind: "UNKNOWN", raw: "" };
   }
   output = raw;
+  const terminalIdWait = parseTerminalIdWait(output, terminal?.failedStep);
+  if (terminalIdWait)
+    return terminalIdWait;
   const lines = output.split("\n");
-  const terminalFailureLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) || /\bWait timed out\b/i.test(line) || PATTERNS.some(({ re }) => re.test(line)));
-  if (terminalFailureLine) {
-    for (const { re, build } of PATTERNS) {
-      const m = terminalFailureLine.match(re);
+  for (const { re, build } of PATTERNS) {
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i];
+      if (!line)
+        continue;
+      const m = line.match(re);
       if (m)
         return build(m, output);
     }
-    return { kind: "UNKNOWN", raw: output };
   }
   for (const { re, build } of PATTERNS) {
     const m = output.match(re);
@@ -27675,7 +27710,7 @@ function isAutoRepairable(failure) {
 function outputIndicatesFlowFailure(output) {
   return /^\s*(?:\[FAILED\]|(?:Test|Flow) FAILED\b|FAILED\s*$)/m.test(output);
 }
-var PATTERNS;
+var PATTERNS, RUNNER_STEP_RE, REASON_LINE_RE, ID_WAIT_STEP_RE, ID_WAIT_REASON_RE;
 var init_maestro_error_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js"() {
     "use strict";
@@ -27697,16 +27732,6 @@ var init_maestro_error_parser = __esm({
       {
         re: /Element not found:\s*text=(['"])((?:(?!\1).)+)\1/i,
         build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "text", selector: m[2], raw })
-      },
-      // maestro-runner 1.1.16/1.1.20 ID-wait shape — issue #580.
-      // "Element '#X' not visible within 1s (cause: context deadline exceeded)".
-      // The `#` immediately after the opening quote is the runner's ID-selector
-      // marker: text and regex waits render without it and keep their current
-      // classification (issue #334 owns those). Process/global timeouts never reach
-      // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
-      {
-        re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
-        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw })
       },
       {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -27734,6 +27759,10 @@ var init_maestro_error_parser = __esm({
         build: (m, raw) => ({ kind: "ASSERTION_FAILED", selector: m[2], raw })
       }
     ];
+    RUNNER_STEP_RE = /^[ \t]+([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
+    REASON_LINE_RE = /^[ \t]+╰─\s+/;
+    ID_WAIT_STEP_RE = /^extendedWaitUntil:\s+visible\s+id=(['"])((?:(?!\1).)+)\1$/i;
+    ID_WAIT_REASON_RE = /^[ \t]+╰─\s+Element (['"])#((?:(?!\1).)+)\1 not visible within\b/i;
   }
 });
 
@@ -28059,8 +28088,8 @@ function findFailedStep(steps) {
 function lastObservedStep(steps) {
   return steps.length ? steps[steps.length - 1] : null;
 }
-function summarizeReason(output) {
-  const f = parseMaestroFailure(output);
+function summarizeReason(output, failedStep) {
+  const f = parseMaestroFailure(output, failedStep ? { failedStep } : void 0);
   if (f.kind === "UNKNOWN" || f.kind === "WDA_BOOTSTRAP_FAILED")
     return null;
   const selector = "selector" in f ? f.selector ?? null : null;
@@ -28068,10 +28097,11 @@ function summarizeReason(output) {
 }
 function buildStepSummary(output, opts) {
   const steps = parseSteps(output);
+  const failedStep = opts.failed ? findFailedStep(steps) : null;
   return {
     steps,
-    failedStep: opts.failed ? findFailedStep(steps) : null,
-    reason: opts.failed ? summarizeReason(output) : null,
+    failedStep,
+    reason: opts.failed ? summarizeReason(output, failedStep?.name) : null,
     lastStep: lastObservedStep(steps)
   };
 }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -27653,7 +27653,7 @@ function parseMaestroFailure(output, terminal) {
   }
   output = raw;
   const lines = output.split("\n");
-  const terminalFailureLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) || PATTERNS.some(({ re }) => re.test(line)));
+  const terminalFailureLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) || /\bWait timed out\b/i.test(line) || PATTERNS.some(({ re }) => re.test(line)));
   if (terminalFailureLine) {
     for (const { re, build } of PATTERNS) {
       const m = terminalFailureLine.match(re);

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -27634,6 +27634,31 @@ var init_ansi = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
+function blockReasons(lines, stepIndex) {
+  const reasons = [];
+  for (let i = stepIndex + 1; i < lines.length; i++) {
+    if (RUNNER_STEP_RE.test(lines[i]))
+      break;
+    if (REASON_LINE_RE.test(lines[i]))
+      reasons.push(lines[i]);
+  }
+  return reasons;
+}
+function idWaitStepAmongDuplicates(lines, terminalIndex, terminalReason2) {
+  for (let i = terminalIndex - 1; i >= 0; i--) {
+    const step = RUNNER_STEP_RE.exec(lines[i]);
+    if (!step)
+      continue;
+    if (step[1] !== "\u2717")
+      return null;
+    if (!blockReasons(lines, i).includes(terminalReason2))
+      return null;
+    const stepMatch = ID_WAIT_STEP_RE.exec(step[2]);
+    if (stepMatch)
+      return stepMatch;
+  }
+  return null;
+}
 function parseTerminalIdWait(output, suppliedFailedStep) {
   const lines = stripAnsi(output).split("\n");
   let terminalStep;
@@ -27649,14 +27674,14 @@ function parseTerminalIdWait(output, suppliedFailedStep) {
   const failedStep = suppliedFailedStep ?? terminalStep?.name;
   if (!failedStep || terminalStep && terminalStep.status !== "\u2717")
     return null;
-  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep);
-  if (!stepMatch)
-    return null;
   const reasonLine = lines.slice(terminalStep ? terminalStep.index + 1 : 0).filter((line) => REASON_LINE_RE.test(line)).at(-1);
   if (!reasonLine)
     return null;
   const reasonMatch = ID_WAIT_REASON_RE.exec(reasonLine);
-  if (!reasonMatch || reasonMatch[2] !== stepMatch[2])
+  if (!reasonMatch)
+    return null;
+  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep) ?? (terminalStep ? idWaitStepAmongDuplicates(lines, terminalStep.index, reasonLine) : null);
+  if (!stepMatch || reasonMatch[2] !== stepMatch[2])
     return null;
   return {
     kind: "SELECTOR_NOT_FOUND",

--- a/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -10225,10 +10225,20 @@ var init_maestro_dispatch = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/ansi.js
+var ANSI_RE;
+var init_ansi = __esm({
+  "packages/rn-dev-agent-core/dist/domain/ansi.js"() {
+    "use strict";
+    ANSI_RE = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g");
+  }
+});
+
 // packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
 var init_maestro_error_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js"() {
     "use strict";
+    init_ansi();
   }
 });
 
@@ -10252,12 +10262,12 @@ var init_engine_pin = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/maestro-step-parser.js
-var ANSI_RE;
 var init_maestro_step_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-step-parser.js"() {
     "use strict";
     init_maestro_error_parser();
-    ANSI_RE = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g");
+    init_ansi();
+    init_ansi();
   }
 });
 

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -16929,6 +16929,37 @@ var init_maestro_dispatch = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
+function parseTerminalIdWait(output, suppliedFailedStep) {
+  const lines = output.split("\n");
+  let terminalStep;
+  for (let index = 0; index < lines.length; index++) {
+    const match = RUNNER_STEP_RE.exec(lines[index]);
+    if (match)
+      terminalStep = { index, status: match[1], name: match[2] };
+  }
+  if (terminalStep?.status === "\u2713")
+    return null;
+  if (suppliedFailedStep && terminalStep && terminalStep.name !== suppliedFailedStep)
+    return null;
+  const failedStep = suppliedFailedStep ?? terminalStep?.name;
+  if (!failedStep || terminalStep && terminalStep.status !== "\u2717")
+    return null;
+  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep);
+  if (!stepMatch)
+    return null;
+  const reasonLine = lines.slice(terminalStep ? terminalStep.index + 1 : 0).filter((line) => REASON_LINE_RE.test(line)).at(-1);
+  if (!reasonLine)
+    return null;
+  const reasonMatch = ID_WAIT_REASON_RE.exec(reasonLine);
+  if (!reasonMatch || reasonMatch[2] !== stepMatch[2])
+    return null;
+  return {
+    kind: "SELECTOR_NOT_FOUND",
+    selectorKind: "id",
+    selector: stepMatch[2],
+    raw: output
+  };
+}
 function parseMaestroFailure(output, terminal) {
   const raw = typeof output === "string" ? output : "";
   if (terminal?.exitClass === "timed-out") {
@@ -16959,15 +16990,19 @@ function parseMaestroFailure(output, terminal) {
     return { kind: "UNKNOWN", raw: "" };
   }
   output = raw;
+  const terminalIdWait = parseTerminalIdWait(output, terminal?.failedStep);
+  if (terminalIdWait)
+    return terminalIdWait;
   const lines = output.split("\n");
-  const terminalFailureLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) || /\bWait timed out\b/i.test(line) || PATTERNS.some(({ re }) => re.test(line)));
-  if (terminalFailureLine) {
-    for (const { re, build } of PATTERNS) {
-      const m = terminalFailureLine.match(re);
+  for (const { re, build } of PATTERNS) {
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i];
+      if (!line)
+        continue;
+      const m = line.match(re);
       if (m)
         return build(m, output);
     }
-    return { kind: "UNKNOWN", raw: output };
   }
   for (const { re, build } of PATTERNS) {
     const m = output.match(re);
@@ -16982,7 +17017,7 @@ function isAutoRepairable(failure) {
 function outputIndicatesFlowFailure(output) {
   return /^\s*(?:\[FAILED\]|(?:Test|Flow) FAILED\b|FAILED\s*$)/m.test(output);
 }
-var PATTERNS;
+var PATTERNS, RUNNER_STEP_RE, REASON_LINE_RE, ID_WAIT_STEP_RE, ID_WAIT_REASON_RE;
 var init_maestro_error_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js"() {
     "use strict";
@@ -17004,16 +17039,6 @@ var init_maestro_error_parser = __esm({
       {
         re: /Element not found:\s*text=(['"])((?:(?!\1).)+)\1/i,
         build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "text", selector: m[2], raw })
-      },
-      // maestro-runner 1.1.16/1.1.20 ID-wait shape — issue #580.
-      // "Element '#X' not visible within 1s (cause: context deadline exceeded)".
-      // The `#` immediately after the opening quote is the runner's ID-selector
-      // marker: text and regex waits render without it and keep their current
-      // classification (issue #334 owns those). Process/global timeouts never reach
-      // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
-      {
-        re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
-        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw })
       },
       {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -17041,6 +17066,10 @@ var init_maestro_error_parser = __esm({
         build: (m, raw) => ({ kind: "ASSERTION_FAILED", selector: m[2], raw })
       }
     ];
+    RUNNER_STEP_RE = /^[ \t]+([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
+    REASON_LINE_RE = /^[ \t]+╰─\s+/;
+    ID_WAIT_STEP_RE = /^extendedWaitUntil:\s+visible\s+id=(['"])((?:(?!\1).)+)\1$/i;
+    ID_WAIT_REASON_RE = /^[ \t]+╰─\s+Element (['"])#((?:(?!\1).)+)\1 not visible within\b/i;
   }
 });
 
@@ -17366,8 +17395,8 @@ function findFailedStep(steps) {
 function lastObservedStep(steps) {
   return steps.length ? steps[steps.length - 1] : null;
 }
-function summarizeReason(output) {
-  const f = parseMaestroFailure(output);
+function summarizeReason(output, failedStep) {
+  const f = parseMaestroFailure(output, failedStep ? { failedStep } : void 0);
   if (f.kind === "UNKNOWN" || f.kind === "WDA_BOOTSTRAP_FAILED")
     return null;
   const selector = "selector" in f ? f.selector ?? null : null;
@@ -17375,10 +17404,11 @@ function summarizeReason(output) {
 }
 function buildStepSummary(output, opts) {
   const steps = parseSteps(output);
+  const failedStep = opts.failed ? findFailedStep(steps) : null;
   return {
     steps,
-    failedStep: opts.failed ? findFailedStep(steps) : null,
-    reason: opts.failed ? summarizeReason(output) : null,
+    failedStep,
+    reason: opts.failed ? summarizeReason(output, failedStep?.name) : null,
     lastStep: lastObservedStep(steps)
   };
 }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -17006,6 +17006,16 @@ var init_maestro_error_parser = __esm({
         re: /Element not found:\s*text=(['"])((?:(?!\1).)+)\1/i,
         build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "text", selector: m[2], raw })
       },
+      // maestro-runner 1.1.16/1.1.20 ID-wait shape — issue #580.
+      // "Element '#X' not visible within 1s (cause: context deadline exceeded)".
+      // The `#` immediately after the opening quote is the runner's ID-selector
+      // marker: text and regex waits render without it and keep their current
+      // classification (issue #334 owns those). Process/global timeouts never reach
+      // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
+      {
+        re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
+        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw })
+      },
       {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
         build: (m, raw) => ({
@@ -71052,9 +71062,17 @@ function normalizeSteps(body, params) {
     const key = keys[0];
     const v = raw[key];
     switch (key) {
-      case "launchApp":
+      case "launchApp": {
+        if (isObj(v)) {
+          const unsupported = Object.keys(v).filter((k) => k !== "stopApp");
+          if (unsupported.length > 0)
+            throw new UnsupportedStepError(`launchApp (unsupported keys: ${unsupported.sort().join(", ")})`);
+          if ("stopApp" in v && typeof v.stopApp !== "boolean")
+            throw new UnsupportedStepError("launchApp (stopApp must be a boolean)");
+        }
         out.push({ t: "launch", stopApp: isObj(v) && v.stopApp === true });
         break;
+      }
       case "tapOn": {
         const id = isObj(v) ? asString(v.id) : null;
         if (!id)
@@ -71104,12 +71122,46 @@ function firstTestId(steps) {
   }
   return null;
 }
-async function replayFlow(steps, dispatch) {
+function countIdHits(node, params, selector, index, depth, nested, scan) {
+  if (depth > MAX_ANCHOR_DEPTH) {
+    scan.truncated = true;
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const child of node)
+      countIdHits(child, params, selector, index, depth + 1, nested, scan);
+    return;
+  }
+  if (!isObj(node))
+    return;
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "id" && typeof value === "string" && interp(value, params) === selector) {
+      scan.hits.push({ index, nested });
+      continue;
+    }
+    countIdHits(value, params, selector, index, depth + 1, nested || key === "commands", scan);
+  }
+}
+function findResumeAnchor(body, params, selector) {
+  if (!selector)
+    return { found: false, reason: "no-match" };
+  const scan = { hits: [], truncated: false };
+  body.forEach((raw, index) => countIdHits(raw, params, selector, index, 0, false, scan));
+  if (scan.truncated)
+    return { found: false, reason: "too-deep" };
+  if (scan.hits.length === 0)
+    return { found: false, reason: "no-match" };
+  if (scan.hits.length > 1)
+    return { found: false, reason: "ambiguous" };
+  return scan.hits[0].nested ? { found: false, reason: "nested-match" } : { found: true, index: scan.hits[0].index };
+}
+async function replayFlow(steps, dispatch, opts = {}) {
+  const offset = opts.indexOffset ?? 0;
   const trace = [];
   let lastTapped = null;
   const fail3 = (i, reason) => ({
     passed: false,
-    failedStepIndex: i,
+    failedStepIndex: i + offset,
     reason,
     steps: trace
   });
@@ -71151,7 +71203,7 @@ async function replayFlow(steps, dispatch) {
             if (!sub.passed) {
               return {
                 passed: false,
-                failedStepIndex: i,
+                failedStepIndex: i + offset,
                 reason: sub.reason,
                 steps: trace
               };
@@ -71169,7 +71221,7 @@ async function replayFlow(steps, dispatch) {
   }
   return { passed: true, steps: trace };
 }
-var UnsupportedStepError, interp, asString, isObj;
+var UnsupportedStepError, interp, asString, isObj, MAX_ANCHOR_DEPTH;
 var init_cdp_flow_replay = __esm({
   "packages/rn-dev-agent-core/dist/domain/cdp-flow-replay.js"() {
     "use strict";
@@ -71184,6 +71236,7 @@ var init_cdp_flow_replay = __esm({
     interp = (s, p) => s.replace(/\$\{([A-Z_][A-Z0-9_]*)\}/g, (_m, k) => p[k] ?? `\${${k}}`);
     asString = (x) => typeof x === "string" ? x : null;
     isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
+    MAX_ANCHOR_DEPTH = 20;
   }
 });
 
@@ -71245,10 +71298,19 @@ function isDisabled(props) {
   const a11y = props.accessibilityState;
   return props.disabled === true || a11y?.disabled === true || props.pointerEvents === "none";
 }
-async function runCdpReplay(bodyYaml, params, deps) {
+async function runCdpReplay(bodyYaml, params, deps, opts = {}) {
   const parsed = (0, import_yaml4.parse)(bodyYaml);
-  const steps = normalizeSteps(parsed, params);
-  return replayFlow(steps, buildCdpDispatch(deps));
+  const resume = resolveResume(parsed, params, opts.resumeAtSelector);
+  const startIndex = resume.applied ? resume.startIndex : 0;
+  const steps = normalizeSteps(startIndex === 0 ? parsed : parsed.slice(startIndex), params);
+  const result = await replayFlow(steps, buildCdpDispatch(deps), { indexOffset: startIndex });
+  return { ...result, resume };
+}
+function resolveResume(parsed, params, selector) {
+  if (!selector || !Array.isArray(parsed))
+    return { applied: false, reason: "not-requested" };
+  const anchor = findResumeAnchor(parsed, params, selector);
+  return anchor.found ? { applied: true, selector, startIndex: anchor.index } : { applied: false, reason: anchor.reason };
 }
 function buildCdpDispatch(deps) {
   return {
@@ -71407,13 +71469,32 @@ function readMaestroDeviceAuthority(env) {
     return env.data.deviceAuthority;
   return env.meta?.deviceAuthority;
 }
+function terminalReason(terminal) {
+  if (!terminal?.failureKind)
+    return "";
+  return ` (${terminal.failureKind}${terminal.failureSelector ? `: ${terminal.failureSelector}` : ""})`;
+}
 function readMaestroFailureDetail(env, output) {
   if (typeof env.error === "string" && env.error.trim())
     return env.error.trim();
-  const failedStep = env.meta?.failedStep;
-  if (typeof failedStep?.name === "string")
-    return `Maestro flow failed at step "${failedStep.name}"`;
-  return output.trim().slice(0, 1e3) || "Maestro runner returned no failure detail";
+  const terminal = readMaestroTerminal(env);
+  const reason = terminalReason(terminal);
+  const metaStep = env.meta?.failedStep;
+  const dataStep = env.data?.failedStep;
+  const stepName = typeof metaStep?.name === "string" ? metaStep.name : typeof dataStep?.name === "string" ? dataStep.name : terminal?.failedStep;
+  if (stepName)
+    return `Maestro flow failed at step "${stepName}"${reason}`;
+  if (reason)
+    return `Maestro flow failed${reason.trim()}`;
+  return boundedOutput(output.trim(), 1e3) || "Maestro runner returned no failure detail";
+}
+function boundedOutput(output, budget = OUTPUT_BUDGET) {
+  const text = typeof output === "string" ? output : "";
+  if (text.length <= budget)
+    return text;
+  const room = budget - OUTPUT_ELISION.length;
+  const head = Math.ceil(room / 2);
+  return text.slice(0, head) + OUTPUT_ELISION + text.slice(text.length - (room - head));
 }
 function mapRefusedReason(repairCode, repairError) {
   if (repairCode === "SNAPSHOT_FAILED")
@@ -71650,7 +71731,7 @@ function createRunActionHandler(deps = {}) {
           writes: writeDisclosure(promotionDisclosure(persisted2), persisted2),
           durationMs: Date.now() - t0,
           flowFile: action.filePath,
-          firstAttemptOutput: firstOutput.slice(0, 500)
+          firstAttemptOutput: boundedOutput(firstOutput)
         });
       }
       const failure = parseMaestroFailure(firstOutput, readMaestroTerminal(firstEnv));
@@ -71700,8 +71781,17 @@ function createRunActionHandler(deps = {}) {
               reason: probeOutcome.sawTree ? "testid-not-in-tree" : "cdp-unreachable"
             };
           } else {
+            const maestroEvidence = {
+              failureKind: failure.kind,
+              ...failure.kind === "SELECTOR_NOT_FOUND" ? { failureSelector: failure.selector } : {},
+              underlyingFailure: firstFailureDetail,
+              terminal: readMaestroTerminal(firstEnv),
+              firstAttemptOutput: boundedOutput(firstOutput)
+            };
             try {
-              const replay = await runCdpReplay(action.body, args.params ?? {}, replayDeps);
+              const replay = await runCdpReplay(action.body, args.params ?? {}, replayDeps, {
+                resumeAtSelector: failure.kind === "SELECTOR_NOT_FOUND" ? failure.selector : null
+              });
               const status = replay.passed ? "pass" : "fail";
               const autoRepair2 = {
                 attempted: false,
@@ -71730,17 +71820,20 @@ function createRunActionHandler(deps = {}) {
                   autoRepair: autoRepair2,
                   writes: writeDisclosure(promotionDisclosure(persisted2), persisted2),
                   durationMs: Date.now() - t0,
-                  flowFile: action.filePath
+                  flowFile: action.filePath,
+                  resume: replay.resume
                 });
               }
               return failResult(`cdp_run_action: ${args.actionId} replayed via CDP/JS (WDA transport-blind) and failed at step ${replay.failedStepIndex}: ${replay.reason}`, "TRANSPORT_BLIND", {
                 actionId: args.actionId,
                 transport: "cdp-js",
-                failedStepIndex: replay.failedStepIndex
+                failedStepIndex: replay.failedStepIndex,
+                resume: replay.resume,
+                ...maestroEvidence
               });
             } catch (e) {
               if (e instanceof UnsupportedStepError) {
-                return failResult(`cdp_run_action: ${args.actionId} cannot replay via CDP/JS \u2014 ${e.message}. This action uses a step type the iOS 26.x fallback doesn't support; run on iOS 18 (WDA works there).`, "UNSUPPORTED_STEP", { actionId: args.actionId, stepKey: e.stepKey });
+                return failResult(`cdp_run_action: ${args.actionId} cannot replay via CDP/JS \u2014 ${e.message}. This action uses a step type the iOS 26.x fallback doesn't support; run on iOS 18 (WDA works there).`, "UNSUPPORTED_STEP", { actionId: args.actionId, stepKey: e.stepKey, ...maestroEvidence });
               }
               throw e;
             }
@@ -71772,9 +71865,12 @@ function createRunActionHandler(deps = {}) {
         const meta = {
           actionId: args.actionId,
           failureKind: failure.kind,
+          // GH #580: the selector belongs in the envelope structurally, not only
+          // inside the human headline the caller would have to re-parse.
+          ..."selector" in failure && failure.selector ? { failureSelector: failure.selector } : {},
           underlyingFailure: firstFailureDetail,
           autoRepair: autoRepair2,
-          firstAttemptOutput: firstOutput.slice(0, 500),
+          firstAttemptOutput: boundedOutput(firstOutput),
           terminal: readMaestroTerminal(firstEnv),
           runnerResume: firstEnv.meta?.runnerResume,
           ...cdpJsFallback ? { cdpJsFallback } : {}
@@ -71811,15 +71907,21 @@ function createRunActionHandler(deps = {}) {
           durationMs: Date.now() - t0,
           status: "fail",
           failureCode: "SELECTOR_NOT_FOUND",
-          failureDetail: firstOutput.slice(0, 500),
+          // GH #580: the structured detail carries kind + selector; the bounded
+          // stdout slice can lose the failing line to later runner narration.
+          failureDetail: firstFailureDetail.slice(0, 1e3),
           trigger,
           autoRepair: autoRepair2
         });
-        return failResult(`cdp_run_action: ${args.actionId} failed with SELECTOR_NOT_FOUND; auto-repair refused (${refusedReason}): ${repairEnv.error ?? "unknown"}`, refusedReason === "TRANSPORT_BLIND" ? "TRANSPORT_BLIND" : "TESTID_NOT_FOUND", {
+        return failResult(`cdp_run_action: ${args.actionId} failed with SELECTOR_NOT_FOUND (${failure.selector}); auto-repair refused (${refusedReason}): ${repairEnv.error ?? "unknown"}`, refusedReason === "TRANSPORT_BLIND" ? "TRANSPORT_BLIND" : "TESTID_NOT_FOUND", {
           actionId: args.actionId,
+          failureKind: failure.kind,
+          failureSelector: failure.selector,
+          underlyingFailure: firstFailureDetail,
+          terminal: readMaestroTerminal(firstEnv),
           autoRepair: autoRepair2,
           repairError: repairEnv.error,
-          firstAttemptOutput: firstOutput.slice(0, 500)
+          firstAttemptOutput: boundedOutput(firstOutput)
         });
       }
       const repairData = repairEnv.data;
@@ -71925,15 +72027,15 @@ function createRunActionHandler(deps = {}) {
           durationMs: Date.now() - t0,
           flowFile: reloadedAction.filePath,
           retriedAfterRepair: true,
-          retryOutput: retryOutput.slice(0, 500)
+          retryOutput: boundedOutput(retryOutput)
         });
       }
       return failResult(`cdp_run_action: ${args.actionId} still failing after auto-repair (${repairData.oldSelector} \u2192 ${repairData.newSelector}): ${retryFailureDetail}`, "TESTID_NOT_FOUND", {
         actionId: args.actionId,
         autoRepair,
         writes: writeDisclosure("auto-repair", persisted),
-        firstAttemptOutput: firstOutput.slice(0, 500),
-        retryOutput: retryOutput.slice(0, 500),
+        firstAttemptOutput: boundedOutput(firstOutput),
+        retryOutput: boundedOutput(retryOutput),
         underlyingFailure: retryFailureDetail
       });
     } catch (err) {
@@ -72001,6 +72103,7 @@ async function persistRun(actionId, projectRoot, record2) {
   }
   return { promoted: false, promotionRefused: false };
 }
+var OUTPUT_BUDGET, OUTPUT_ELISION;
 var init_run_action = __esm({
   "packages/rn-dev-agent-core/dist/tools/run-action.js"() {
     "use strict";
@@ -72018,6 +72121,8 @@ var init_run_action = __esm({
     init_cdp_flow_replay();
     init_blind_probe_gate();
     init_authority_gate();
+    OUTPUT_BUDGET = 500;
+    OUTPUT_ELISION = "\n\u2026\n";
   }
 });
 

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -16960,7 +16960,14 @@ function parseMaestroFailure(output, terminal) {
   }
   output = raw;
   const lines = output.split("\n");
-  for (const { re, build } of PATTERNS) {
+  const terminalWaitLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line));
+  for (const { re, build, terminalWaitOnly } of PATTERNS) {
+    if (terminalWaitOnly) {
+      const m = terminalWaitLine?.match(re);
+      if (m)
+        return build(m, output);
+      continue;
+    }
     for (let i = lines.length - 1; i >= 0; i--) {
       const line = lines[i];
       if (!line)
@@ -16970,7 +16977,9 @@ function parseMaestroFailure(output, terminal) {
         return build(m, output);
     }
   }
-  for (const { re, build } of PATTERNS) {
+  for (const { re, build, terminalWaitOnly } of PATTERNS) {
+    if (terminalWaitOnly)
+      continue;
     const m = output.match(re);
     if (m)
       return build(m, output);
@@ -17014,7 +17023,8 @@ var init_maestro_error_parser = __esm({
       // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
       {
         re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
-        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw })
+        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw }),
+        terminalWaitOnly: true
       },
       {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -71159,9 +71169,10 @@ async function replayFlow(steps, dispatch, opts = {}) {
   const offset = opts.indexOffset ?? 0;
   const trace = [];
   let lastTapped = null;
+  const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail3 = (i, reason) => ({
     passed: false,
-    failedStepIndex: i + offset,
+    failedStepIndex: sourceIndex(i),
     reason,
     steps: trace
   });
@@ -71171,51 +71182,61 @@ async function replayFlow(steps, dispatch, opts = {}) {
       switch (s.t) {
         case "launch":
           await dispatch.launch(s.stopApp);
-          trace.push({ t: s.t, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, ok: true });
           break;
         case "tap":
           await dispatch.press(s.id);
           lastTapped = s.id;
-          trace.push({ t: s.t, target: s.id, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, target: s.id, ok: true });
           break;
         case "type": {
           if (!lastTapped)
             return fail3(i, "inputText before any tapOn \u2014 no focus target");
           await dispatch.type(lastTapped, s.text);
-          trace.push({ t: s.t, target: lastTapped, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, target: lastTapped, ok: true });
           break;
         }
         case "assert": {
           const ok = await dispatch.isVisible(s.id);
-          trace.push({ t: s.t, target: s.id, ok });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, target: s.id, ok });
           if (!ok)
             return fail3(i, `assertVisible: "${s.id}" not present in CDP tree`);
           break;
         }
         case "wait":
           await dispatch.settle();
-          trace.push({ t: s.t, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, ok: true });
           break;
         case "runFlow": {
           if (await dispatch.isVisible(s.whenVisible)) {
-            const sub = await replayFlow(s.commands, dispatch);
+            const sub = await replayFlow(s.commands, dispatch, { sourceIndex: sourceIndex(i) });
             trace.push(...sub.steps);
             if (!sub.passed) {
               return {
                 passed: false,
-                failedStepIndex: i + offset,
+                failedStepIndex: sourceIndex(i),
                 reason: sub.reason,
                 steps: trace
               };
             }
           } else {
-            trace.push({ t: s.t, target: s.whenVisible, ok: true });
+            trace.push({
+              sourceIndex: sourceIndex(i),
+              t: s.t,
+              target: s.whenVisible,
+              ok: true
+            });
           }
           break;
         }
       }
     } catch (e) {
-      trace.push({ t: s.t, target: "id" in s ? s.id : void 0, ok: false });
+      trace.push({
+        sourceIndex: sourceIndex(i),
+        t: s.t,
+        target: "id" in s ? s.id : void 0,
+        ok: false
+      });
       return fail3(i, e instanceof Error ? e.message : String(e));
     }
   }
@@ -71962,6 +71983,8 @@ function createRunActionHandler(deps = {}) {
       const retryPassed = retryEnv.ok === true && retryEnv.data?.passed === true;
       const retryOutput = readMaestroOutput(retryEnv);
       const retryFailureDetail = readMaestroFailureDetail(retryEnv, retryOutput);
+      const retryTerminal = readMaestroTerminal(retryEnv);
+      const retryFailure = !retryPassed ? parseMaestroFailure(retryOutput, retryTerminal) : void 0;
       const retryDeviceAuthority = readMaestroDeviceAuthority(retryEnv);
       probeDeviceId = retryDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
       if (retryEnv.code === "DEVICE_AUTHORITY_MISMATCH") {
@@ -71984,14 +72007,8 @@ function createRunActionHandler(deps = {}) {
       const repairScore = repairEnv.data?.score;
       const repairTimestamp = reloadedAction.state.repairHistory.length > 0 ? reloadedAction.state.repairHistory[reloadedAction.state.repairHistory.length - 1].timestamp : void 0;
       let nextFailedSelector;
-      if (!retryPassed) {
-        try {
-          const retryFailure = parseMaestroFailure(retryOutput, readMaestroTerminal(retryEnv));
-          if (retryFailure.kind === "SELECTOR_NOT_FOUND" && retryFailure.selector && retryFailure.selector !== repairData.newSelector) {
-            nextFailedSelector = retryFailure.selector;
-          }
-        } catch {
-        }
+      if (retryFailure?.kind === "SELECTOR_NOT_FOUND" && retryFailure.selector && retryFailure.selector !== repairData.newSelector) {
+        nextFailedSelector = retryFailure.selector;
       }
       const autoRepair = {
         attempted: true,
@@ -72036,7 +72053,10 @@ function createRunActionHandler(deps = {}) {
         writes: writeDisclosure("auto-repair", persisted),
         firstAttemptOutput: boundedOutput(firstOutput),
         retryOutput: boundedOutput(retryOutput),
-        underlyingFailure: retryFailureDetail
+        underlyingFailure: retryFailureDetail,
+        ...retryFailure ? { failureKind: retryFailure.kind } : {},
+        ...retryFailure && "selector" in retryFailure && retryFailure.selector ? { failureSelector: retryFailure.selector } : {},
+        terminal: retryTerminal
       });
     } catch (err) {
       if (err instanceof SessionAuthorityError)

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -16960,7 +16960,7 @@ function parseMaestroFailure(output, terminal) {
   }
   output = raw;
   const lines = output.split("\n");
-  const terminalFailureLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) || PATTERNS.some(({ re }) => re.test(line)));
+  const terminalFailureLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) || /\bWait timed out\b/i.test(line) || PATTERNS.some(({ re }) => re.test(line)));
   if (terminalFailureLine) {
     for (const { re, build } of PATTERNS) {
       const m = terminalFailureLine.match(re);

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -16987,7 +16987,7 @@ function parseTerminalIdWait(output, suppliedFailedStep) {
   const reasonMatch = ID_WAIT_REASON_RE.exec(reasonLine);
   if (!reasonMatch)
     return null;
-  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep) ?? (terminalStep ? idWaitStepAmongDuplicates(lines, terminalStep.index, reasonLine) : null);
+  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep) ?? (terminalStep && SELECTOR_LESS_ID_WAIT_SUMMARY_RE.test(failedStep) ? idWaitStepAmongDuplicates(lines, terminalStep.index, reasonLine) : null);
   if (!stepMatch || reasonMatch[2] !== stepMatch[2])
     return null;
   return {
@@ -17054,7 +17054,7 @@ function isAutoRepairable(failure) {
 function outputIndicatesFlowFailure(output) {
   return /^\s*(?:\[FAILED\]|(?:Test|Flow) FAILED\b|FAILED\s*$)/m.test(output);
 }
-var PATTERNS, RUNNER_STEP_RE, REASON_LINE_RE, ID_WAIT_STEP_RE, ID_WAIT_REASON_RE;
+var PATTERNS, RUNNER_STEP_RE, REASON_LINE_RE, ID_WAIT_STEP_RE, SELECTOR_LESS_ID_WAIT_SUMMARY_RE, ID_WAIT_REASON_RE;
 var init_maestro_error_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js"() {
     "use strict";
@@ -17107,6 +17107,7 @@ var init_maestro_error_parser = __esm({
     RUNNER_STEP_RE = /^[ \t]+([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
     REASON_LINE_RE = /^[ \t]+╰─\s+/;
     ID_WAIT_STEP_RE = /^extendedWaitUntil:\s+visible\s+id=(['"])((?:(?!\1).)+)\1$/i;
+    SELECTOR_LESS_ID_WAIT_SUMMARY_RE = /^extendedWaitUntil$/;
     ID_WAIT_REASON_RE = /^[ \t]+╰─\s+Element (['"])#((?:(?!\1).)+)\1 not visible within\b/i;
   }
 });
@@ -17397,7 +17398,7 @@ function cap(s) {
 function combineRunnerOutput(stdout, stderr) {
   return (stdout + "\n" + stderr).replace(/^[\r\n]+/, "").trimEnd();
 }
-function parseSteps(output) {
+function parseExactSteps(output) {
   if (!output || typeof output !== "string")
     return [];
   const steps = [];
@@ -17415,13 +17416,19 @@ function parseSteps(output) {
       continue;
     steps.push({
       index: index++,
-      name: cap(name),
+      name,
       verb,
       status: m[1] === "\u2713" ? "pass" : "fail",
       durationMs: Math.round(seconds * 1e3)
     });
   }
   return steps.length > MAX_STEPS ? steps.slice(-MAX_STEPS) : steps;
+}
+function boundStep(step) {
+  return { ...step, name: cap(step.name) };
+}
+function parseSteps(output) {
+  return parseExactSteps(output).map(boundStep);
 }
 function findFailedStep(steps) {
   const last = steps.length ? steps[steps.length - 1] : null;
@@ -17430,20 +17437,25 @@ function findFailedStep(steps) {
 function lastObservedStep(steps) {
   return steps.length ? steps[steps.length - 1] : null;
 }
-function summarizeReason(output, failedStep) {
+function summarizeExactReason(output, failedStep) {
   const f = parseMaestroFailure(output, failedStep ? { failedStep } : void 0);
   if (f.kind === "UNKNOWN" || f.kind === "WDA_BOOTSTRAP_FAILED")
     return null;
   const selector = "selector" in f ? f.selector ?? null : null;
-  return { kind: f.kind, selector: selector === null ? null : cap(selector) };
+  return { kind: f.kind, selector };
 }
 function buildStepSummary(output, opts) {
-  const steps = parseSteps(output);
-  const failedStep = opts.failed ? findFailedStep(steps) : null;
+  const exactSteps = parseExactSteps(output);
+  const exactFailedStep = opts.failed ? findFailedStep(exactSteps) : null;
+  const exactReason = opts.failed ? summarizeExactReason(output, exactFailedStep?.name) : null;
+  const steps = exactSteps.map(boundStep);
   return {
     steps,
-    failedStep,
-    reason: opts.failed ? summarizeReason(output, failedStep?.name) : null,
+    failedStep: exactFailedStep ? boundStep(exactFailedStep) : null,
+    reason: exactReason ? {
+      ...exactReason,
+      selector: exactReason.selector === null ? null : cap(exactReason.selector)
+    } : null,
     lastStep: lastObservedStep(steps)
   };
 }
@@ -17451,17 +17463,19 @@ function isWdaFailureLine(line) {
   return WDA_TOKEN_RE.test(line) && WDA_FAILURE_RE.test(line);
 }
 function buildTerminalEvidence(output, opts = {}) {
-  const summary = buildStepSummary(output, { failed: true });
+  const exactSteps = parseExactSteps(output);
+  const failedStep = findFailedStep(exactSteps);
+  const reason = summarizeExactReason(output, failedStep?.name);
   const bootstrapEvidence = stripAnsi(output).split("\n").filter((line) => isWdaFailureLine(line)).join("\n").slice(0, 500);
-  const exitClass = opts.timedOut ? "timed-out" : opts.spawnError ? "spawn-error" : summary.steps.length === 0 ? "before-first-step" : "step-failure";
+  const exitClass = opts.timedOut ? "timed-out" : opts.spawnError ? "spawn-error" : exactSteps.length === 0 ? "before-first-step" : "step-failure";
   return {
-    completedSteps: summary.steps.filter((step) => step.status === "pass").length,
-    ...summary.failedStep ? { failedStep: summary.failedStep.name } : {},
+    completedSteps: exactSteps.filter((step) => step.status === "pass").length,
+    ...failedStep ? { failedStep: failedStep.name } : {},
     exitClass,
     ...bootstrapEvidence ? { bootstrapEvidence } : {},
-    ...summary.reason ? {
-      failureKind: summary.reason.kind,
-      failureSelector: summary.reason.selector
+    ...reason ? {
+      failureKind: reason.kind,
+      failureSelector: reason.selector
     } : {}
   };
 }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -16960,26 +16960,16 @@ function parseMaestroFailure(output, terminal) {
   }
   output = raw;
   const lines = output.split("\n");
-  const terminalWaitLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line));
-  for (const { re, build, terminalWaitOnly } of PATTERNS) {
-    if (terminalWaitOnly) {
-      const m = terminalWaitLine?.match(re);
-      if (m)
-        return build(m, output);
-      continue;
-    }
-    for (let i = lines.length - 1; i >= 0; i--) {
-      const line = lines[i];
-      if (!line)
-        continue;
-      const m = line.match(re);
+  const terminalFailureLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) || PATTERNS.some(({ re }) => re.test(line)));
+  if (terminalFailureLine) {
+    for (const { re, build } of PATTERNS) {
+      const m = terminalFailureLine.match(re);
       if (m)
         return build(m, output);
     }
+    return { kind: "UNKNOWN", raw: output };
   }
-  for (const { re, build, terminalWaitOnly } of PATTERNS) {
-    if (terminalWaitOnly)
-      continue;
+  for (const { re, build } of PATTERNS) {
     const m = output.match(re);
     if (m)
       return build(m, output);
@@ -17023,8 +17013,7 @@ var init_maestro_error_parser = __esm({
       // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
       {
         re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
-        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw }),
-        terminalWaitOnly: true
+        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw })
       },
       {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -71985,6 +71974,7 @@ function createRunActionHandler(deps = {}) {
       const retryFailureDetail = readMaestroFailureDetail(retryEnv, retryOutput);
       const retryTerminal = readMaestroTerminal(retryEnv);
       const retryFailure = !retryPassed ? parseMaestroFailure(retryOutput, retryTerminal) : void 0;
+      const retryClassification = retryFailure ? classifyFailure(retryFailure) : void 0;
       const retryDeviceAuthority = readMaestroDeviceAuthority(retryEnv);
       probeDeviceId = retryDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
       if (retryEnv.code === "DEVICE_AUTHORITY_MISMATCH") {
@@ -72028,7 +72018,7 @@ function createRunActionHandler(deps = {}) {
         timestamp: (/* @__PURE__ */ new Date()).toISOString(),
         durationMs: Date.now() - t0,
         status: retryPassed ? "pass" : "fail",
-        failureCode: retryPassed ? void 0 : "SELECTOR_NOT_FOUND",
+        failureCode: retryClassification?.actionCode,
         failureDetail: retryPassed ? void 0 : retryFailureDetail.slice(0, 1e3),
         trigger,
         autoRepair
@@ -72047,7 +72037,8 @@ function createRunActionHandler(deps = {}) {
           retryOutput: boundedOutput(retryOutput)
         });
       }
-      return failResult(`cdp_run_action: ${args.actionId} still failing after auto-repair (${repairData.oldSelector} \u2192 ${repairData.newSelector}): ${retryFailureDetail}`, "TESTID_NOT_FOUND", {
+      const retryMessage = `cdp_run_action: ${args.actionId} still failing after auto-repair (${repairData.oldSelector} \u2192 ${repairData.newSelector}): ${retryFailureDetail}`;
+      const retryMeta = {
         actionId: args.actionId,
         autoRepair,
         writes: writeDisclosure("auto-repair", persisted),
@@ -72057,7 +72048,8 @@ function createRunActionHandler(deps = {}) {
         ...retryFailure ? { failureKind: retryFailure.kind } : {},
         ...retryFailure && "selector" in retryFailure && retryFailure.selector ? { failureSelector: retryFailure.selector } : {},
         terminal: retryTerminal
-      });
+      };
+      return retryClassification?.toolCode ? failResult(retryMessage, retryClassification.toolCode, retryMeta) : failResult(retryMessage, retryMeta);
     } catch (err) {
       if (err instanceof SessionAuthorityError)
         throw err;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -16941,6 +16941,31 @@ var init_ansi = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
+function blockReasons(lines, stepIndex) {
+  const reasons = [];
+  for (let i = stepIndex + 1; i < lines.length; i++) {
+    if (RUNNER_STEP_RE.test(lines[i]))
+      break;
+    if (REASON_LINE_RE.test(lines[i]))
+      reasons.push(lines[i]);
+  }
+  return reasons;
+}
+function idWaitStepAmongDuplicates(lines, terminalIndex, terminalReason2) {
+  for (let i = terminalIndex - 1; i >= 0; i--) {
+    const step = RUNNER_STEP_RE.exec(lines[i]);
+    if (!step)
+      continue;
+    if (step[1] !== "\u2717")
+      return null;
+    if (!blockReasons(lines, i).includes(terminalReason2))
+      return null;
+    const stepMatch = ID_WAIT_STEP_RE.exec(step[2]);
+    if (stepMatch)
+      return stepMatch;
+  }
+  return null;
+}
 function parseTerminalIdWait(output, suppliedFailedStep) {
   const lines = stripAnsi(output).split("\n");
   let terminalStep;
@@ -16956,14 +16981,14 @@ function parseTerminalIdWait(output, suppliedFailedStep) {
   const failedStep = suppliedFailedStep ?? terminalStep?.name;
   if (!failedStep || terminalStep && terminalStep.status !== "\u2717")
     return null;
-  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep);
-  if (!stepMatch)
-    return null;
   const reasonLine = lines.slice(terminalStep ? terminalStep.index + 1 : 0).filter((line) => REASON_LINE_RE.test(line)).at(-1);
   if (!reasonLine)
     return null;
   const reasonMatch = ID_WAIT_REASON_RE.exec(reasonLine);
-  if (!reasonMatch || reasonMatch[2] !== stepMatch[2])
+  if (!reasonMatch)
+    return null;
+  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep) ?? (terminalStep ? idWaitStepAmongDuplicates(lines, terminalStep.index, reasonLine) : null);
+  if (!stepMatch || reasonMatch[2] !== stepMatch[2])
     return null;
   return {
     kind: "SELECTOR_NOT_FOUND",

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -16928,9 +16928,21 @@ var init_maestro_dispatch = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/ansi.js
+function stripAnsi(value) {
+  return value.replace(ANSI_RE, "");
+}
+var ANSI_RE;
+var init_ansi = __esm({
+  "packages/rn-dev-agent-core/dist/domain/ansi.js"() {
+    "use strict";
+    ANSI_RE = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g");
+  }
+});
+
 // packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
 function parseTerminalIdWait(output, suppliedFailedStep) {
-  const lines = output.split("\n");
+  const lines = stripAnsi(output).split("\n");
   let terminalStep;
   for (let index = 0; index < lines.length; index++) {
     const match = RUNNER_STEP_RE.exec(lines[index]);
@@ -17021,6 +17033,7 @@ var PATTERNS, RUNNER_STEP_RE, REASON_LINE_RE, ID_WAIT_STEP_RE, ID_WAIT_REASON_RE
 var init_maestro_error_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js"() {
     "use strict";
+    init_ansi();
     PATTERNS = [
       {
         re: /Element with id (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -17353,9 +17366,6 @@ var init_engine_pin = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/maestro-step-parser.js
-function stripAnsi(s) {
-  return s.replace(ANSI_RE, "");
-}
 function cap(s) {
   return s.length > MAX_FIELD ? s.slice(0, MAX_FIELD) + "\u2026" : s;
 }
@@ -17454,12 +17464,13 @@ function formatFailureHeadline(summary, cls, fallbackMsg) {
   }
   return `Maestro flow failed: ${fallbackMsg.slice(0, 500)}`;
 }
-var ANSI_RE, STEP_RE, MAX_FIELD, MAX_STEPS, WDA_TOKEN_RE, WDA_FAILURE_RE;
+var STEP_RE, MAX_FIELD, MAX_STEPS, WDA_TOKEN_RE, WDA_FAILURE_RE;
 var init_maestro_step_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-step-parser.js"() {
     "use strict";
     init_maestro_error_parser();
-    ANSI_RE = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g");
+    init_ansi();
+    init_ansi();
     STEP_RE = /^[ \t]+([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
     MAX_FIELD = 200;
     MAX_STEPS = 1e3;

--- a/packages/codex-plugin/commands/run-action.md
+++ b/packages/codex-plugin/commands/run-action.md
@@ -157,7 +157,7 @@ $rn-dev-agent:run-action mark-all-done --no-auto-repair    # surface the raw fai
      diff .rn-agent/actions/<id>.yaml` to inspect.
    - **`outcome === 'failed'`**: post-repair retry still failed —
      `meta.underlyingFailure` carries the exact failure;
-     `data.retryOutput` has the trailing maestro output for deeper
+     `data.retryOutput` has bounded head-and-tail Maestro output for deeper
      diagnosis.
    - **`outcome === 'refused'`** with `refusedReason`: auto-repair declined
      (user disabled, file edited since load, repair budget exhausted, or

--- a/packages/codex-plugin/commands/run-action.md
+++ b/packages/codex-plugin/commands/run-action.md
@@ -128,7 +128,7 @@ $rn-dev-agent:run-action mark-all-done --no-auto-repair    # surface the raw fai
        },
        durationMs,
        flowFile,
-       firstAttemptOutput?: string,     // first 500 chars of maestro stdout/stderr
+       firstAttemptOutput?: string,     // bounded maestro stdout/stderr: head + tail, 500 chars
        retryOutput?: string,            // present iff retriedAfterRepair === true
        retriedAfterRepair?: boolean
      }
@@ -141,8 +141,11 @@ $rn-dev-agent:run-action mark-all-done --no-auto-repair    # surface the raw fai
 
    On failure (`ok: false`), the envelope's `error` message and
    `meta.underlyingFailure` carry the exact underlying Maestro failure
-   (the runner's headline error, or the failing step name) — read those
-   directly instead of digging through the maestro report output.
+   (the failing step name plus `KIND: selector` when the runner named one),
+   and `meta.failureKind` / `meta.failureSelector` expose the same evidence
+   structurally. Read those directly. The runner's HTML report is a
+   temporary artifact that is deleted after every run — no report path is
+   returned, and none should be looked for.
 
    Branch on `data.autoRepair.outcome`:
    - **`outcome === 'skipped'`** with `attempted: false`: happy path —
@@ -174,7 +177,6 @@ After execution, summarise:
 ```
 ✅ <flow-name> passed (16/16, 18.5s)
 Replayed: <command-line>
-Report: reports/2026-04-29_HH-MM-SS/report.html
 ```
 
 Or:
@@ -182,7 +184,6 @@ Or:
 ```
 ❌ <flow-name> failed at step <N> ("tapOn id: ...")
 Replayed: <command-line>
-Failing screenshot: reports/.../assets/flow-000/cmd-N-after.png
 Likely cause: <one-line diagnosis>
 Next step: <single concrete suggestion>
 ```

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -27621,9 +27621,21 @@ var init_maestro_dispatch = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/ansi.js
+function stripAnsi(value) {
+  return value.replace(ANSI_RE, "");
+}
+var ANSI_RE;
+var init_ansi = __esm({
+  "packages/rn-dev-agent-core/dist/domain/ansi.js"() {
+    "use strict";
+    ANSI_RE = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g");
+  }
+});
+
 // packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
 function parseTerminalIdWait(output, suppliedFailedStep) {
-  const lines = output.split("\n");
+  const lines = stripAnsi(output).split("\n");
   let terminalStep;
   for (let index = 0; index < lines.length; index++) {
     const match = RUNNER_STEP_RE.exec(lines[index]);
@@ -27714,6 +27726,7 @@ var PATTERNS, RUNNER_STEP_RE, REASON_LINE_RE, ID_WAIT_STEP_RE, ID_WAIT_REASON_RE
 var init_maestro_error_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js"() {
     "use strict";
+    init_ansi();
     PATTERNS = [
       {
         re: /Element with id (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -28046,9 +28059,6 @@ var init_engine_pin = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/maestro-step-parser.js
-function stripAnsi(s) {
-  return s.replace(ANSI_RE, "");
-}
 function cap(s) {
   return s.length > MAX_FIELD ? s.slice(0, MAX_FIELD) + "\u2026" : s;
 }
@@ -28147,12 +28157,13 @@ function formatFailureHeadline(summary, cls, fallbackMsg) {
   }
   return `Maestro flow failed: ${fallbackMsg.slice(0, 500)}`;
 }
-var ANSI_RE, STEP_RE, MAX_FIELD, MAX_STEPS, WDA_TOKEN_RE, WDA_FAILURE_RE;
+var STEP_RE, MAX_FIELD, MAX_STEPS, WDA_TOKEN_RE, WDA_FAILURE_RE;
 var init_maestro_step_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-step-parser.js"() {
     "use strict";
     init_maestro_error_parser();
-    ANSI_RE = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g");
+    init_ansi();
+    init_ansi();
     STEP_RE = /^[ \t]+([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
     MAX_FIELD = 200;
     MAX_STEPS = 1e3;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -27699,6 +27699,16 @@ var init_maestro_error_parser = __esm({
         re: /Element not found:\s*text=(['"])((?:(?!\1).)+)\1/i,
         build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "text", selector: m[2], raw })
       },
+      // maestro-runner 1.1.16/1.1.20 ID-wait shape — issue #580.
+      // "Element '#X' not visible within 1s (cause: context deadline exceeded)".
+      // The `#` immediately after the opening quote is the runner's ID-selector
+      // marker: text and regex waits render without it and keep their current
+      // classification (issue #334 owns those). Process/global timeouts never reach
+      // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
+      {
+        re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
+        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw })
+      },
       {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
         build: (m, raw) => ({
@@ -68597,9 +68607,17 @@ function normalizeSteps(body, params) {
     const key = keys[0];
     const v = raw[key];
     switch (key) {
-      case "launchApp":
+      case "launchApp": {
+        if (isObj(v)) {
+          const unsupported = Object.keys(v).filter((k) => k !== "stopApp");
+          if (unsupported.length > 0)
+            throw new UnsupportedStepError(`launchApp (unsupported keys: ${unsupported.sort().join(", ")})`);
+          if ("stopApp" in v && typeof v.stopApp !== "boolean")
+            throw new UnsupportedStepError("launchApp (stopApp must be a boolean)");
+        }
         out.push({ t: "launch", stopApp: isObj(v) && v.stopApp === true });
         break;
+      }
       case "tapOn": {
         const id = isObj(v) ? asString(v.id) : null;
         if (!id)
@@ -68649,12 +68667,47 @@ function firstTestId(steps) {
   }
   return null;
 }
-async function replayFlow(steps, dispatch) {
+var MAX_ANCHOR_DEPTH = 20;
+function countIdHits(node, params, selector, index, depth, nested, scan) {
+  if (depth > MAX_ANCHOR_DEPTH) {
+    scan.truncated = true;
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const child of node)
+      countIdHits(child, params, selector, index, depth + 1, nested, scan);
+    return;
+  }
+  if (!isObj(node))
+    return;
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "id" && typeof value === "string" && interp(value, params) === selector) {
+      scan.hits.push({ index, nested });
+      continue;
+    }
+    countIdHits(value, params, selector, index, depth + 1, nested || key === "commands", scan);
+  }
+}
+function findResumeAnchor(body, params, selector) {
+  if (!selector)
+    return { found: false, reason: "no-match" };
+  const scan = { hits: [], truncated: false };
+  body.forEach((raw, index) => countIdHits(raw, params, selector, index, 0, false, scan));
+  if (scan.truncated)
+    return { found: false, reason: "too-deep" };
+  if (scan.hits.length === 0)
+    return { found: false, reason: "no-match" };
+  if (scan.hits.length > 1)
+    return { found: false, reason: "ambiguous" };
+  return scan.hits[0].nested ? { found: false, reason: "nested-match" } : { found: true, index: scan.hits[0].index };
+}
+async function replayFlow(steps, dispatch, opts = {}) {
+  const offset = opts.indexOffset ?? 0;
   const trace = [];
   let lastTapped = null;
   const fail3 = (i, reason) => ({
     passed: false,
-    failedStepIndex: i,
+    failedStepIndex: i + offset,
     reason,
     steps: trace
   });
@@ -68696,7 +68749,7 @@ async function replayFlow(steps, dispatch) {
             if (!sub.passed) {
               return {
                 passed: false,
-                failedStepIndex: i,
+                failedStepIndex: i + offset,
                 reason: sub.reason,
                 steps: trace
               };
@@ -68773,10 +68826,19 @@ function isDisabled(props) {
   const a11y = props.accessibilityState;
   return props.disabled === true || a11y?.disabled === true || props.pointerEvents === "none";
 }
-async function runCdpReplay(bodyYaml, params, deps) {
+async function runCdpReplay(bodyYaml, params, deps, opts = {}) {
   const parsed = (0, import_yaml4.parse)(bodyYaml);
-  const steps = normalizeSteps(parsed, params);
-  return replayFlow(steps, buildCdpDispatch(deps));
+  const resume = resolveResume(parsed, params, opts.resumeAtSelector);
+  const startIndex = resume.applied ? resume.startIndex : 0;
+  const steps = normalizeSteps(startIndex === 0 ? parsed : parsed.slice(startIndex), params);
+  const result = await replayFlow(steps, buildCdpDispatch(deps), { indexOffset: startIndex });
+  return { ...result, resume };
+}
+function resolveResume(parsed, params, selector) {
+  if (!selector || !Array.isArray(parsed))
+    return { applied: false, reason: "not-requested" };
+  const anchor = findResumeAnchor(parsed, params, selector);
+  return anchor.found ? { applied: true, selector, startIndex: anchor.index } : { applied: false, reason: anchor.reason };
 }
 function buildCdpDispatch(deps) {
   return {
@@ -68922,13 +68984,34 @@ function readMaestroDeviceAuthority(env) {
     return env.data.deviceAuthority;
   return env.meta?.deviceAuthority;
 }
+function terminalReason(terminal) {
+  if (!terminal?.failureKind)
+    return "";
+  return ` (${terminal.failureKind}${terminal.failureSelector ? `: ${terminal.failureSelector}` : ""})`;
+}
 function readMaestroFailureDetail(env, output) {
   if (typeof env.error === "string" && env.error.trim())
     return env.error.trim();
-  const failedStep = env.meta?.failedStep;
-  if (typeof failedStep?.name === "string")
-    return `Maestro flow failed at step "${failedStep.name}"`;
-  return output.trim().slice(0, 1e3) || "Maestro runner returned no failure detail";
+  const terminal = readMaestroTerminal(env);
+  const reason = terminalReason(terminal);
+  const metaStep = env.meta?.failedStep;
+  const dataStep = env.data?.failedStep;
+  const stepName = typeof metaStep?.name === "string" ? metaStep.name : typeof dataStep?.name === "string" ? dataStep.name : terminal?.failedStep;
+  if (stepName)
+    return `Maestro flow failed at step "${stepName}"${reason}`;
+  if (reason)
+    return `Maestro flow failed${reason.trim()}`;
+  return boundedOutput(output.trim(), 1e3) || "Maestro runner returned no failure detail";
+}
+var OUTPUT_BUDGET = 500;
+var OUTPUT_ELISION = "\n\u2026\n";
+function boundedOutput(output, budget = OUTPUT_BUDGET) {
+  const text = typeof output === "string" ? output : "";
+  if (text.length <= budget)
+    return text;
+  const room = budget - OUTPUT_ELISION.length;
+  const head = Math.ceil(room / 2);
+  return text.slice(0, head) + OUTPUT_ELISION + text.slice(text.length - (room - head));
 }
 function mapRefusedReason(repairCode, repairError) {
   if (repairCode === "SNAPSHOT_FAILED")
@@ -69165,7 +69248,7 @@ function createRunActionHandler(deps = {}) {
           writes: writeDisclosure(promotionDisclosure(persisted2), persisted2),
           durationMs: Date.now() - t0,
           flowFile: action.filePath,
-          firstAttemptOutput: firstOutput.slice(0, 500)
+          firstAttemptOutput: boundedOutput(firstOutput)
         });
       }
       const failure = parseMaestroFailure(firstOutput, readMaestroTerminal(firstEnv));
@@ -69215,8 +69298,17 @@ function createRunActionHandler(deps = {}) {
               reason: probeOutcome.sawTree ? "testid-not-in-tree" : "cdp-unreachable"
             };
           } else {
+            const maestroEvidence = {
+              failureKind: failure.kind,
+              ...failure.kind === "SELECTOR_NOT_FOUND" ? { failureSelector: failure.selector } : {},
+              underlyingFailure: firstFailureDetail,
+              terminal: readMaestroTerminal(firstEnv),
+              firstAttemptOutput: boundedOutput(firstOutput)
+            };
             try {
-              const replay = await runCdpReplay(action.body, args.params ?? {}, replayDeps);
+              const replay = await runCdpReplay(action.body, args.params ?? {}, replayDeps, {
+                resumeAtSelector: failure.kind === "SELECTOR_NOT_FOUND" ? failure.selector : null
+              });
               const status = replay.passed ? "pass" : "fail";
               const autoRepair2 = {
                 attempted: false,
@@ -69245,17 +69337,20 @@ function createRunActionHandler(deps = {}) {
                   autoRepair: autoRepair2,
                   writes: writeDisclosure(promotionDisclosure(persisted2), persisted2),
                   durationMs: Date.now() - t0,
-                  flowFile: action.filePath
+                  flowFile: action.filePath,
+                  resume: replay.resume
                 });
               }
               return failResult(`cdp_run_action: ${args.actionId} replayed via CDP/JS (WDA transport-blind) and failed at step ${replay.failedStepIndex}: ${replay.reason}`, "TRANSPORT_BLIND", {
                 actionId: args.actionId,
                 transport: "cdp-js",
-                failedStepIndex: replay.failedStepIndex
+                failedStepIndex: replay.failedStepIndex,
+                resume: replay.resume,
+                ...maestroEvidence
               });
             } catch (e) {
               if (e instanceof UnsupportedStepError) {
-                return failResult(`cdp_run_action: ${args.actionId} cannot replay via CDP/JS \u2014 ${e.message}. This action uses a step type the iOS 26.x fallback doesn't support; run on iOS 18 (WDA works there).`, "UNSUPPORTED_STEP", { actionId: args.actionId, stepKey: e.stepKey });
+                return failResult(`cdp_run_action: ${args.actionId} cannot replay via CDP/JS \u2014 ${e.message}. This action uses a step type the iOS 26.x fallback doesn't support; run on iOS 18 (WDA works there).`, "UNSUPPORTED_STEP", { actionId: args.actionId, stepKey: e.stepKey, ...maestroEvidence });
               }
               throw e;
             }
@@ -69287,9 +69382,12 @@ function createRunActionHandler(deps = {}) {
         const meta = {
           actionId: args.actionId,
           failureKind: failure.kind,
+          // GH #580: the selector belongs in the envelope structurally, not only
+          // inside the human headline the caller would have to re-parse.
+          ..."selector" in failure && failure.selector ? { failureSelector: failure.selector } : {},
           underlyingFailure: firstFailureDetail,
           autoRepair: autoRepair2,
-          firstAttemptOutput: firstOutput.slice(0, 500),
+          firstAttemptOutput: boundedOutput(firstOutput),
           terminal: readMaestroTerminal(firstEnv),
           runnerResume: firstEnv.meta?.runnerResume,
           ...cdpJsFallback ? { cdpJsFallback } : {}
@@ -69326,15 +69424,21 @@ function createRunActionHandler(deps = {}) {
           durationMs: Date.now() - t0,
           status: "fail",
           failureCode: "SELECTOR_NOT_FOUND",
-          failureDetail: firstOutput.slice(0, 500),
+          // GH #580: the structured detail carries kind + selector; the bounded
+          // stdout slice can lose the failing line to later runner narration.
+          failureDetail: firstFailureDetail.slice(0, 1e3),
           trigger,
           autoRepair: autoRepair2
         });
-        return failResult(`cdp_run_action: ${args.actionId} failed with SELECTOR_NOT_FOUND; auto-repair refused (${refusedReason}): ${repairEnv.error ?? "unknown"}`, refusedReason === "TRANSPORT_BLIND" ? "TRANSPORT_BLIND" : "TESTID_NOT_FOUND", {
+        return failResult(`cdp_run_action: ${args.actionId} failed with SELECTOR_NOT_FOUND (${failure.selector}); auto-repair refused (${refusedReason}): ${repairEnv.error ?? "unknown"}`, refusedReason === "TRANSPORT_BLIND" ? "TRANSPORT_BLIND" : "TESTID_NOT_FOUND", {
           actionId: args.actionId,
+          failureKind: failure.kind,
+          failureSelector: failure.selector,
+          underlyingFailure: firstFailureDetail,
+          terminal: readMaestroTerminal(firstEnv),
           autoRepair: autoRepair2,
           repairError: repairEnv.error,
-          firstAttemptOutput: firstOutput.slice(0, 500)
+          firstAttemptOutput: boundedOutput(firstOutput)
         });
       }
       const repairData = repairEnv.data;
@@ -69440,15 +69544,15 @@ function createRunActionHandler(deps = {}) {
           durationMs: Date.now() - t0,
           flowFile: reloadedAction.filePath,
           retriedAfterRepair: true,
-          retryOutput: retryOutput.slice(0, 500)
+          retryOutput: boundedOutput(retryOutput)
         });
       }
       return failResult(`cdp_run_action: ${args.actionId} still failing after auto-repair (${repairData.oldSelector} \u2192 ${repairData.newSelector}): ${retryFailureDetail}`, "TESTID_NOT_FOUND", {
         actionId: args.actionId,
         autoRepair,
         writes: writeDisclosure("auto-repair", persisted),
-        firstAttemptOutput: firstOutput.slice(0, 500),
-        retryOutput: retryOutput.slice(0, 500),
+        firstAttemptOutput: boundedOutput(firstOutput),
+        retryOutput: boundedOutput(retryOutput),
         underlyingFailure: retryFailureDetail
       });
     } catch (err) {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -27653,7 +27653,14 @@ function parseMaestroFailure(output, terminal) {
   }
   output = raw;
   const lines = output.split("\n");
-  for (const { re, build } of PATTERNS) {
+  const terminalWaitLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line));
+  for (const { re, build, terminalWaitOnly } of PATTERNS) {
+    if (terminalWaitOnly) {
+      const m = terminalWaitLine?.match(re);
+      if (m)
+        return build(m, output);
+      continue;
+    }
     for (let i = lines.length - 1; i >= 0; i--) {
       const line = lines[i];
       if (!line)
@@ -27663,7 +27670,9 @@ function parseMaestroFailure(output, terminal) {
         return build(m, output);
     }
   }
-  for (const { re, build } of PATTERNS) {
+  for (const { re, build, terminalWaitOnly } of PATTERNS) {
+    if (terminalWaitOnly)
+      continue;
     const m = output.match(re);
     if (m)
       return build(m, output);
@@ -27707,7 +27716,8 @@ var init_maestro_error_parser = __esm({
       // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
       {
         re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
-        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw })
+        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw }),
+        terminalWaitOnly: true
       },
       {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -68705,9 +68715,10 @@ async function replayFlow(steps, dispatch, opts = {}) {
   const offset = opts.indexOffset ?? 0;
   const trace = [];
   let lastTapped = null;
+  const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail3 = (i, reason) => ({
     passed: false,
-    failedStepIndex: i + offset,
+    failedStepIndex: sourceIndex(i),
     reason,
     steps: trace
   });
@@ -68717,51 +68728,61 @@ async function replayFlow(steps, dispatch, opts = {}) {
       switch (s.t) {
         case "launch":
           await dispatch.launch(s.stopApp);
-          trace.push({ t: s.t, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, ok: true });
           break;
         case "tap":
           await dispatch.press(s.id);
           lastTapped = s.id;
-          trace.push({ t: s.t, target: s.id, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, target: s.id, ok: true });
           break;
         case "type": {
           if (!lastTapped)
             return fail3(i, "inputText before any tapOn \u2014 no focus target");
           await dispatch.type(lastTapped, s.text);
-          trace.push({ t: s.t, target: lastTapped, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, target: lastTapped, ok: true });
           break;
         }
         case "assert": {
           const ok = await dispatch.isVisible(s.id);
-          trace.push({ t: s.t, target: s.id, ok });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, target: s.id, ok });
           if (!ok)
             return fail3(i, `assertVisible: "${s.id}" not present in CDP tree`);
           break;
         }
         case "wait":
           await dispatch.settle();
-          trace.push({ t: s.t, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, ok: true });
           break;
         case "runFlow": {
           if (await dispatch.isVisible(s.whenVisible)) {
-            const sub = await replayFlow(s.commands, dispatch);
+            const sub = await replayFlow(s.commands, dispatch, { sourceIndex: sourceIndex(i) });
             trace.push(...sub.steps);
             if (!sub.passed) {
               return {
                 passed: false,
-                failedStepIndex: i + offset,
+                failedStepIndex: sourceIndex(i),
                 reason: sub.reason,
                 steps: trace
               };
             }
           } else {
-            trace.push({ t: s.t, target: s.whenVisible, ok: true });
+            trace.push({
+              sourceIndex: sourceIndex(i),
+              t: s.t,
+              target: s.whenVisible,
+              ok: true
+            });
           }
           break;
         }
       }
     } catch (e) {
-      trace.push({ t: s.t, target: "id" in s ? s.id : void 0, ok: false });
+      trace.push({
+        sourceIndex: sourceIndex(i),
+        t: s.t,
+        target: "id" in s ? s.id : void 0,
+        ok: false
+      });
       return fail3(i, e instanceof Error ? e.message : String(e));
     }
   }
@@ -69479,6 +69500,8 @@ function createRunActionHandler(deps = {}) {
       const retryPassed = retryEnv.ok === true && retryEnv.data?.passed === true;
       const retryOutput = readMaestroOutput(retryEnv);
       const retryFailureDetail = readMaestroFailureDetail(retryEnv, retryOutput);
+      const retryTerminal = readMaestroTerminal(retryEnv);
+      const retryFailure = !retryPassed ? parseMaestroFailure(retryOutput, retryTerminal) : void 0;
       const retryDeviceAuthority = readMaestroDeviceAuthority(retryEnv);
       probeDeviceId = retryDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
       if (retryEnv.code === "DEVICE_AUTHORITY_MISMATCH") {
@@ -69501,14 +69524,8 @@ function createRunActionHandler(deps = {}) {
       const repairScore = repairEnv.data?.score;
       const repairTimestamp = reloadedAction.state.repairHistory.length > 0 ? reloadedAction.state.repairHistory[reloadedAction.state.repairHistory.length - 1].timestamp : void 0;
       let nextFailedSelector;
-      if (!retryPassed) {
-        try {
-          const retryFailure = parseMaestroFailure(retryOutput, readMaestroTerminal(retryEnv));
-          if (retryFailure.kind === "SELECTOR_NOT_FOUND" && retryFailure.selector && retryFailure.selector !== repairData.newSelector) {
-            nextFailedSelector = retryFailure.selector;
-          }
-        } catch {
-        }
+      if (retryFailure?.kind === "SELECTOR_NOT_FOUND" && retryFailure.selector && retryFailure.selector !== repairData.newSelector) {
+        nextFailedSelector = retryFailure.selector;
       }
       const autoRepair = {
         attempted: true,
@@ -69553,7 +69570,10 @@ function createRunActionHandler(deps = {}) {
         writes: writeDisclosure("auto-repair", persisted),
         firstAttemptOutput: boundedOutput(firstOutput),
         retryOutput: boundedOutput(retryOutput),
-        underlyingFailure: retryFailureDetail
+        underlyingFailure: retryFailureDetail,
+        ...retryFailure ? { failureKind: retryFailure.kind } : {},
+        ...retryFailure && "selector" in retryFailure && retryFailure.selector ? { failureSelector: retryFailure.selector } : {},
+        terminal: retryTerminal
       });
     } catch (err) {
       if (err instanceof SessionAuthorityError)

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -27680,7 +27680,7 @@ function parseTerminalIdWait(output, suppliedFailedStep) {
   const reasonMatch = ID_WAIT_REASON_RE.exec(reasonLine);
   if (!reasonMatch)
     return null;
-  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep) ?? (terminalStep ? idWaitStepAmongDuplicates(lines, terminalStep.index, reasonLine) : null);
+  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep) ?? (terminalStep && SELECTOR_LESS_ID_WAIT_SUMMARY_RE.test(failedStep) ? idWaitStepAmongDuplicates(lines, terminalStep.index, reasonLine) : null);
   if (!stepMatch || reasonMatch[2] !== stepMatch[2])
     return null;
   return {
@@ -27747,7 +27747,7 @@ function isAutoRepairable(failure) {
 function outputIndicatesFlowFailure(output) {
   return /^\s*(?:\[FAILED\]|(?:Test|Flow) FAILED\b|FAILED\s*$)/m.test(output);
 }
-var PATTERNS, RUNNER_STEP_RE, REASON_LINE_RE, ID_WAIT_STEP_RE, ID_WAIT_REASON_RE;
+var PATTERNS, RUNNER_STEP_RE, REASON_LINE_RE, ID_WAIT_STEP_RE, SELECTOR_LESS_ID_WAIT_SUMMARY_RE, ID_WAIT_REASON_RE;
 var init_maestro_error_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js"() {
     "use strict";
@@ -27800,6 +27800,7 @@ var init_maestro_error_parser = __esm({
     RUNNER_STEP_RE = /^[ \t]+([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
     REASON_LINE_RE = /^[ \t]+╰─\s+/;
     ID_WAIT_STEP_RE = /^extendedWaitUntil:\s+visible\s+id=(['"])((?:(?!\1).)+)\1$/i;
+    SELECTOR_LESS_ID_WAIT_SUMMARY_RE = /^extendedWaitUntil$/;
     ID_WAIT_REASON_RE = /^[ \t]+╰─\s+Element (['"])#((?:(?!\1).)+)\1 not visible within\b/i;
   }
 });
@@ -28090,7 +28091,7 @@ function cap(s) {
 function combineRunnerOutput(stdout, stderr) {
   return (stdout + "\n" + stderr).replace(/^[\r\n]+/, "").trimEnd();
 }
-function parseSteps(output) {
+function parseExactSteps(output) {
   if (!output || typeof output !== "string")
     return [];
   const steps = [];
@@ -28108,13 +28109,19 @@ function parseSteps(output) {
       continue;
     steps.push({
       index: index++,
-      name: cap(name),
+      name,
       verb,
       status: m[1] === "\u2713" ? "pass" : "fail",
       durationMs: Math.round(seconds * 1e3)
     });
   }
   return steps.length > MAX_STEPS ? steps.slice(-MAX_STEPS) : steps;
+}
+function boundStep(step) {
+  return { ...step, name: cap(step.name) };
+}
+function parseSteps(output) {
+  return parseExactSteps(output).map(boundStep);
 }
 function findFailedStep(steps) {
   const last = steps.length ? steps[steps.length - 1] : null;
@@ -28123,20 +28130,25 @@ function findFailedStep(steps) {
 function lastObservedStep(steps) {
   return steps.length ? steps[steps.length - 1] : null;
 }
-function summarizeReason(output, failedStep) {
+function summarizeExactReason(output, failedStep) {
   const f = parseMaestroFailure(output, failedStep ? { failedStep } : void 0);
   if (f.kind === "UNKNOWN" || f.kind === "WDA_BOOTSTRAP_FAILED")
     return null;
   const selector = "selector" in f ? f.selector ?? null : null;
-  return { kind: f.kind, selector: selector === null ? null : cap(selector) };
+  return { kind: f.kind, selector };
 }
 function buildStepSummary(output, opts) {
-  const steps = parseSteps(output);
-  const failedStep = opts.failed ? findFailedStep(steps) : null;
+  const exactSteps = parseExactSteps(output);
+  const exactFailedStep = opts.failed ? findFailedStep(exactSteps) : null;
+  const exactReason = opts.failed ? summarizeExactReason(output, exactFailedStep?.name) : null;
+  const steps = exactSteps.map(boundStep);
   return {
     steps,
-    failedStep,
-    reason: opts.failed ? summarizeReason(output, failedStep?.name) : null,
+    failedStep: exactFailedStep ? boundStep(exactFailedStep) : null,
+    reason: exactReason ? {
+      ...exactReason,
+      selector: exactReason.selector === null ? null : cap(exactReason.selector)
+    } : null,
     lastStep: lastObservedStep(steps)
   };
 }
@@ -28144,17 +28156,19 @@ function isWdaFailureLine(line) {
   return WDA_TOKEN_RE.test(line) && WDA_FAILURE_RE.test(line);
 }
 function buildTerminalEvidence(output, opts = {}) {
-  const summary = buildStepSummary(output, { failed: true });
+  const exactSteps = parseExactSteps(output);
+  const failedStep = findFailedStep(exactSteps);
+  const reason = summarizeExactReason(output, failedStep?.name);
   const bootstrapEvidence = stripAnsi(output).split("\n").filter((line) => isWdaFailureLine(line)).join("\n").slice(0, 500);
-  const exitClass = opts.timedOut ? "timed-out" : opts.spawnError ? "spawn-error" : summary.steps.length === 0 ? "before-first-step" : "step-failure";
+  const exitClass = opts.timedOut ? "timed-out" : opts.spawnError ? "spawn-error" : exactSteps.length === 0 ? "before-first-step" : "step-failure";
   return {
-    completedSteps: summary.steps.filter((step) => step.status === "pass").length,
-    ...summary.failedStep ? { failedStep: summary.failedStep.name } : {},
+    completedSteps: exactSteps.filter((step) => step.status === "pass").length,
+    ...failedStep ? { failedStep: failedStep.name } : {},
     exitClass,
     ...bootstrapEvidence ? { bootstrapEvidence } : {},
-    ...summary.reason ? {
-      failureKind: summary.reason.kind,
-      failureSelector: summary.reason.selector
+    ...reason ? {
+      failureKind: reason.kind,
+      failureSelector: reason.selector
     } : {}
   };
 }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -27653,26 +27653,16 @@ function parseMaestroFailure(output, terminal) {
   }
   output = raw;
   const lines = output.split("\n");
-  const terminalWaitLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line));
-  for (const { re, build, terminalWaitOnly } of PATTERNS) {
-    if (terminalWaitOnly) {
-      const m = terminalWaitLine?.match(re);
-      if (m)
-        return build(m, output);
-      continue;
-    }
-    for (let i = lines.length - 1; i >= 0; i--) {
-      const line = lines[i];
-      if (!line)
-        continue;
-      const m = line.match(re);
+  const terminalFailureLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) || PATTERNS.some(({ re }) => re.test(line)));
+  if (terminalFailureLine) {
+    for (const { re, build } of PATTERNS) {
+      const m = terminalFailureLine.match(re);
       if (m)
         return build(m, output);
     }
+    return { kind: "UNKNOWN", raw: output };
   }
-  for (const { re, build, terminalWaitOnly } of PATTERNS) {
-    if (terminalWaitOnly)
-      continue;
+  for (const { re, build } of PATTERNS) {
     const m = output.match(re);
     if (m)
       return build(m, output);
@@ -27716,8 +27706,7 @@ var init_maestro_error_parser = __esm({
       // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
       {
         re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
-        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw }),
-        terminalWaitOnly: true
+        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw })
       },
       {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -69502,6 +69491,7 @@ function createRunActionHandler(deps = {}) {
       const retryFailureDetail = readMaestroFailureDetail(retryEnv, retryOutput);
       const retryTerminal = readMaestroTerminal(retryEnv);
       const retryFailure = !retryPassed ? parseMaestroFailure(retryOutput, retryTerminal) : void 0;
+      const retryClassification = retryFailure ? classifyFailure(retryFailure) : void 0;
       const retryDeviceAuthority = readMaestroDeviceAuthority(retryEnv);
       probeDeviceId = retryDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
       if (retryEnv.code === "DEVICE_AUTHORITY_MISMATCH") {
@@ -69545,7 +69535,7 @@ function createRunActionHandler(deps = {}) {
         timestamp: (/* @__PURE__ */ new Date()).toISOString(),
         durationMs: Date.now() - t0,
         status: retryPassed ? "pass" : "fail",
-        failureCode: retryPassed ? void 0 : "SELECTOR_NOT_FOUND",
+        failureCode: retryClassification?.actionCode,
         failureDetail: retryPassed ? void 0 : retryFailureDetail.slice(0, 1e3),
         trigger,
         autoRepair
@@ -69564,7 +69554,8 @@ function createRunActionHandler(deps = {}) {
           retryOutput: boundedOutput(retryOutput)
         });
       }
-      return failResult(`cdp_run_action: ${args.actionId} still failing after auto-repair (${repairData.oldSelector} \u2192 ${repairData.newSelector}): ${retryFailureDetail}`, "TESTID_NOT_FOUND", {
+      const retryMessage = `cdp_run_action: ${args.actionId} still failing after auto-repair (${repairData.oldSelector} \u2192 ${repairData.newSelector}): ${retryFailureDetail}`;
+      const retryMeta = {
         actionId: args.actionId,
         autoRepair,
         writes: writeDisclosure("auto-repair", persisted),
@@ -69574,7 +69565,8 @@ function createRunActionHandler(deps = {}) {
         ...retryFailure ? { failureKind: retryFailure.kind } : {},
         ...retryFailure && "selector" in retryFailure && retryFailure.selector ? { failureSelector: retryFailure.selector } : {},
         terminal: retryTerminal
-      });
+      };
+      return retryClassification?.toolCode ? failResult(retryMessage, retryClassification.toolCode, retryMeta) : failResult(retryMessage, retryMeta);
     } catch (err) {
       if (err instanceof SessionAuthorityError)
         throw err;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -27622,6 +27622,37 @@ var init_maestro_dispatch = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
+function parseTerminalIdWait(output, suppliedFailedStep) {
+  const lines = output.split("\n");
+  let terminalStep;
+  for (let index = 0; index < lines.length; index++) {
+    const match = RUNNER_STEP_RE.exec(lines[index]);
+    if (match)
+      terminalStep = { index, status: match[1], name: match[2] };
+  }
+  if (terminalStep?.status === "\u2713")
+    return null;
+  if (suppliedFailedStep && terminalStep && terminalStep.name !== suppliedFailedStep)
+    return null;
+  const failedStep = suppliedFailedStep ?? terminalStep?.name;
+  if (!failedStep || terminalStep && terminalStep.status !== "\u2717")
+    return null;
+  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep);
+  if (!stepMatch)
+    return null;
+  const reasonLine = lines.slice(terminalStep ? terminalStep.index + 1 : 0).filter((line) => REASON_LINE_RE.test(line)).at(-1);
+  if (!reasonLine)
+    return null;
+  const reasonMatch = ID_WAIT_REASON_RE.exec(reasonLine);
+  if (!reasonMatch || reasonMatch[2] !== stepMatch[2])
+    return null;
+  return {
+    kind: "SELECTOR_NOT_FOUND",
+    selectorKind: "id",
+    selector: stepMatch[2],
+    raw: output
+  };
+}
 function parseMaestroFailure(output, terminal) {
   const raw = typeof output === "string" ? output : "";
   if (terminal?.exitClass === "timed-out") {
@@ -27652,15 +27683,19 @@ function parseMaestroFailure(output, terminal) {
     return { kind: "UNKNOWN", raw: "" };
   }
   output = raw;
+  const terminalIdWait = parseTerminalIdWait(output, terminal?.failedStep);
+  if (terminalIdWait)
+    return terminalIdWait;
   const lines = output.split("\n");
-  const terminalFailureLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) || /\bWait timed out\b/i.test(line) || PATTERNS.some(({ re }) => re.test(line)));
-  if (terminalFailureLine) {
-    for (const { re, build } of PATTERNS) {
-      const m = terminalFailureLine.match(re);
+  for (const { re, build } of PATTERNS) {
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i];
+      if (!line)
+        continue;
+      const m = line.match(re);
       if (m)
         return build(m, output);
     }
-    return { kind: "UNKNOWN", raw: output };
   }
   for (const { re, build } of PATTERNS) {
     const m = output.match(re);
@@ -27675,7 +27710,7 @@ function isAutoRepairable(failure) {
 function outputIndicatesFlowFailure(output) {
   return /^\s*(?:\[FAILED\]|(?:Test|Flow) FAILED\b|FAILED\s*$)/m.test(output);
 }
-var PATTERNS;
+var PATTERNS, RUNNER_STEP_RE, REASON_LINE_RE, ID_WAIT_STEP_RE, ID_WAIT_REASON_RE;
 var init_maestro_error_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js"() {
     "use strict";
@@ -27697,16 +27732,6 @@ var init_maestro_error_parser = __esm({
       {
         re: /Element not found:\s*text=(['"])((?:(?!\1).)+)\1/i,
         build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "text", selector: m[2], raw })
-      },
-      // maestro-runner 1.1.16/1.1.20 ID-wait shape — issue #580.
-      // "Element '#X' not visible within 1s (cause: context deadline exceeded)".
-      // The `#` immediately after the opening quote is the runner's ID-selector
-      // marker: text and regex waits render without it and keep their current
-      // classification (issue #334 owns those). Process/global timeouts never reach
-      // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
-      {
-        re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
-        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw })
       },
       {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -27734,6 +27759,10 @@ var init_maestro_error_parser = __esm({
         build: (m, raw) => ({ kind: "ASSERTION_FAILED", selector: m[2], raw })
       }
     ];
+    RUNNER_STEP_RE = /^[ \t]+([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
+    REASON_LINE_RE = /^[ \t]+╰─\s+/;
+    ID_WAIT_STEP_RE = /^extendedWaitUntil:\s+visible\s+id=(['"])((?:(?!\1).)+)\1$/i;
+    ID_WAIT_REASON_RE = /^[ \t]+╰─\s+Element (['"])#((?:(?!\1).)+)\1 not visible within\b/i;
   }
 });
 
@@ -28059,8 +28088,8 @@ function findFailedStep(steps) {
 function lastObservedStep(steps) {
   return steps.length ? steps[steps.length - 1] : null;
 }
-function summarizeReason(output) {
-  const f = parseMaestroFailure(output);
+function summarizeReason(output, failedStep) {
+  const f = parseMaestroFailure(output, failedStep ? { failedStep } : void 0);
   if (f.kind === "UNKNOWN" || f.kind === "WDA_BOOTSTRAP_FAILED")
     return null;
   const selector = "selector" in f ? f.selector ?? null : null;
@@ -28068,10 +28097,11 @@ function summarizeReason(output) {
 }
 function buildStepSummary(output, opts) {
   const steps = parseSteps(output);
+  const failedStep = opts.failed ? findFailedStep(steps) : null;
   return {
     steps,
-    failedStep: opts.failed ? findFailedStep(steps) : null,
-    reason: opts.failed ? summarizeReason(output) : null,
+    failedStep,
+    reason: opts.failed ? summarizeReason(output, failedStep?.name) : null,
     lastStep: lastObservedStep(steps)
   };
 }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -27653,7 +27653,7 @@ function parseMaestroFailure(output, terminal) {
   }
   output = raw;
   const lines = output.split("\n");
-  const terminalFailureLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) || PATTERNS.some(({ re }) => re.test(line)));
+  const terminalFailureLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) || /\bWait timed out\b/i.test(line) || PATTERNS.some(({ re }) => re.test(line)));
   if (terminalFailureLine) {
     for (const { re, build } of PATTERNS) {
       const m = terminalFailureLine.match(re);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -27634,6 +27634,31 @@ var init_ansi = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
+function blockReasons(lines, stepIndex) {
+  const reasons = [];
+  for (let i = stepIndex + 1; i < lines.length; i++) {
+    if (RUNNER_STEP_RE.test(lines[i]))
+      break;
+    if (REASON_LINE_RE.test(lines[i]))
+      reasons.push(lines[i]);
+  }
+  return reasons;
+}
+function idWaitStepAmongDuplicates(lines, terminalIndex, terminalReason2) {
+  for (let i = terminalIndex - 1; i >= 0; i--) {
+    const step = RUNNER_STEP_RE.exec(lines[i]);
+    if (!step)
+      continue;
+    if (step[1] !== "\u2717")
+      return null;
+    if (!blockReasons(lines, i).includes(terminalReason2))
+      return null;
+    const stepMatch = ID_WAIT_STEP_RE.exec(step[2]);
+    if (stepMatch)
+      return stepMatch;
+  }
+  return null;
+}
 function parseTerminalIdWait(output, suppliedFailedStep) {
   const lines = stripAnsi(output).split("\n");
   let terminalStep;
@@ -27649,14 +27674,14 @@ function parseTerminalIdWait(output, suppliedFailedStep) {
   const failedStep = suppliedFailedStep ?? terminalStep?.name;
   if (!failedStep || terminalStep && terminalStep.status !== "\u2717")
     return null;
-  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep);
-  if (!stepMatch)
-    return null;
   const reasonLine = lines.slice(terminalStep ? terminalStep.index + 1 : 0).filter((line) => REASON_LINE_RE.test(line)).at(-1);
   if (!reasonLine)
     return null;
   const reasonMatch = ID_WAIT_REASON_RE.exec(reasonLine);
-  if (!reasonMatch || reasonMatch[2] !== stepMatch[2])
+  if (!reasonMatch)
+    return null;
+  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep) ?? (terminalStep ? idWaitStepAmongDuplicates(lines, terminalStep.index, reasonLine) : null);
+  if (!stepMatch || reasonMatch[2] !== stepMatch[2])
     return null;
   return {
     kind: "SELECTOR_NOT_FOUND",

--- a/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -10225,10 +10225,20 @@ var init_maestro_dispatch = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/ansi.js
+var ANSI_RE;
+var init_ansi = __esm({
+  "packages/rn-dev-agent-core/dist/domain/ansi.js"() {
+    "use strict";
+    ANSI_RE = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g");
+  }
+});
+
 // packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
 var init_maestro_error_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js"() {
     "use strict";
+    init_ansi();
   }
 });
 
@@ -10252,12 +10262,12 @@ var init_engine_pin = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/maestro-step-parser.js
-var ANSI_RE;
 var init_maestro_step_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-step-parser.js"() {
     "use strict";
     init_maestro_error_parser();
-    ANSI_RE = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g");
+    init_ansi();
+    init_ansi();
   }
 });
 

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -16929,6 +16929,37 @@ var init_maestro_dispatch = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
+function parseTerminalIdWait(output, suppliedFailedStep) {
+  const lines = output.split("\n");
+  let terminalStep;
+  for (let index = 0; index < lines.length; index++) {
+    const match = RUNNER_STEP_RE.exec(lines[index]);
+    if (match)
+      terminalStep = { index, status: match[1], name: match[2] };
+  }
+  if (terminalStep?.status === "\u2713")
+    return null;
+  if (suppliedFailedStep && terminalStep && terminalStep.name !== suppliedFailedStep)
+    return null;
+  const failedStep = suppliedFailedStep ?? terminalStep?.name;
+  if (!failedStep || terminalStep && terminalStep.status !== "\u2717")
+    return null;
+  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep);
+  if (!stepMatch)
+    return null;
+  const reasonLine = lines.slice(terminalStep ? terminalStep.index + 1 : 0).filter((line) => REASON_LINE_RE.test(line)).at(-1);
+  if (!reasonLine)
+    return null;
+  const reasonMatch = ID_WAIT_REASON_RE.exec(reasonLine);
+  if (!reasonMatch || reasonMatch[2] !== stepMatch[2])
+    return null;
+  return {
+    kind: "SELECTOR_NOT_FOUND",
+    selectorKind: "id",
+    selector: stepMatch[2],
+    raw: output
+  };
+}
 function parseMaestroFailure(output, terminal) {
   const raw = typeof output === "string" ? output : "";
   if (terminal?.exitClass === "timed-out") {
@@ -16959,15 +16990,19 @@ function parseMaestroFailure(output, terminal) {
     return { kind: "UNKNOWN", raw: "" };
   }
   output = raw;
+  const terminalIdWait = parseTerminalIdWait(output, terminal?.failedStep);
+  if (terminalIdWait)
+    return terminalIdWait;
   const lines = output.split("\n");
-  const terminalFailureLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) || /\bWait timed out\b/i.test(line) || PATTERNS.some(({ re }) => re.test(line)));
-  if (terminalFailureLine) {
-    for (const { re, build } of PATTERNS) {
-      const m = terminalFailureLine.match(re);
+  for (const { re, build } of PATTERNS) {
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i];
+      if (!line)
+        continue;
+      const m = line.match(re);
       if (m)
         return build(m, output);
     }
-    return { kind: "UNKNOWN", raw: output };
   }
   for (const { re, build } of PATTERNS) {
     const m = output.match(re);
@@ -16982,7 +17017,7 @@ function isAutoRepairable(failure) {
 function outputIndicatesFlowFailure(output) {
   return /^\s*(?:\[FAILED\]|(?:Test|Flow) FAILED\b|FAILED\s*$)/m.test(output);
 }
-var PATTERNS;
+var PATTERNS, RUNNER_STEP_RE, REASON_LINE_RE, ID_WAIT_STEP_RE, ID_WAIT_REASON_RE;
 var init_maestro_error_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js"() {
     "use strict";
@@ -17004,16 +17039,6 @@ var init_maestro_error_parser = __esm({
       {
         re: /Element not found:\s*text=(['"])((?:(?!\1).)+)\1/i,
         build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "text", selector: m[2], raw })
-      },
-      // maestro-runner 1.1.16/1.1.20 ID-wait shape — issue #580.
-      // "Element '#X' not visible within 1s (cause: context deadline exceeded)".
-      // The `#` immediately after the opening quote is the runner's ID-selector
-      // marker: text and regex waits render without it and keep their current
-      // classification (issue #334 owns those). Process/global timeouts never reach
-      // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
-      {
-        re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
-        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw })
       },
       {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -17041,6 +17066,10 @@ var init_maestro_error_parser = __esm({
         build: (m, raw) => ({ kind: "ASSERTION_FAILED", selector: m[2], raw })
       }
     ];
+    RUNNER_STEP_RE = /^[ \t]+([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
+    REASON_LINE_RE = /^[ \t]+╰─\s+/;
+    ID_WAIT_STEP_RE = /^extendedWaitUntil:\s+visible\s+id=(['"])((?:(?!\1).)+)\1$/i;
+    ID_WAIT_REASON_RE = /^[ \t]+╰─\s+Element (['"])#((?:(?!\1).)+)\1 not visible within\b/i;
   }
 });
 
@@ -17366,8 +17395,8 @@ function findFailedStep(steps) {
 function lastObservedStep(steps) {
   return steps.length ? steps[steps.length - 1] : null;
 }
-function summarizeReason(output) {
-  const f = parseMaestroFailure(output);
+function summarizeReason(output, failedStep) {
+  const f = parseMaestroFailure(output, failedStep ? { failedStep } : void 0);
   if (f.kind === "UNKNOWN" || f.kind === "WDA_BOOTSTRAP_FAILED")
     return null;
   const selector = "selector" in f ? f.selector ?? null : null;
@@ -17375,10 +17404,11 @@ function summarizeReason(output) {
 }
 function buildStepSummary(output, opts) {
   const steps = parseSteps(output);
+  const failedStep = opts.failed ? findFailedStep(steps) : null;
   return {
     steps,
-    failedStep: opts.failed ? findFailedStep(steps) : null,
-    reason: opts.failed ? summarizeReason(output) : null,
+    failedStep,
+    reason: opts.failed ? summarizeReason(output, failedStep?.name) : null,
     lastStep: lastObservedStep(steps)
   };
 }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -17006,6 +17006,16 @@ var init_maestro_error_parser = __esm({
         re: /Element not found:\s*text=(['"])((?:(?!\1).)+)\1/i,
         build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "text", selector: m[2], raw })
       },
+      // maestro-runner 1.1.16/1.1.20 ID-wait shape — issue #580.
+      // "Element '#X' not visible within 1s (cause: context deadline exceeded)".
+      // The `#` immediately after the opening quote is the runner's ID-selector
+      // marker: text and regex waits render without it and keep their current
+      // classification (issue #334 owns those). Process/global timeouts never reach
+      // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
+      {
+        re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
+        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw })
+      },
       {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
         build: (m, raw) => ({
@@ -71052,9 +71062,17 @@ function normalizeSteps(body, params) {
     const key = keys[0];
     const v = raw[key];
     switch (key) {
-      case "launchApp":
+      case "launchApp": {
+        if (isObj(v)) {
+          const unsupported = Object.keys(v).filter((k) => k !== "stopApp");
+          if (unsupported.length > 0)
+            throw new UnsupportedStepError(`launchApp (unsupported keys: ${unsupported.sort().join(", ")})`);
+          if ("stopApp" in v && typeof v.stopApp !== "boolean")
+            throw new UnsupportedStepError("launchApp (stopApp must be a boolean)");
+        }
         out.push({ t: "launch", stopApp: isObj(v) && v.stopApp === true });
         break;
+      }
       case "tapOn": {
         const id = isObj(v) ? asString(v.id) : null;
         if (!id)
@@ -71104,12 +71122,46 @@ function firstTestId(steps) {
   }
   return null;
 }
-async function replayFlow(steps, dispatch) {
+function countIdHits(node, params, selector, index, depth, nested, scan) {
+  if (depth > MAX_ANCHOR_DEPTH) {
+    scan.truncated = true;
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const child of node)
+      countIdHits(child, params, selector, index, depth + 1, nested, scan);
+    return;
+  }
+  if (!isObj(node))
+    return;
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "id" && typeof value === "string" && interp(value, params) === selector) {
+      scan.hits.push({ index, nested });
+      continue;
+    }
+    countIdHits(value, params, selector, index, depth + 1, nested || key === "commands", scan);
+  }
+}
+function findResumeAnchor(body, params, selector) {
+  if (!selector)
+    return { found: false, reason: "no-match" };
+  const scan = { hits: [], truncated: false };
+  body.forEach((raw, index) => countIdHits(raw, params, selector, index, 0, false, scan));
+  if (scan.truncated)
+    return { found: false, reason: "too-deep" };
+  if (scan.hits.length === 0)
+    return { found: false, reason: "no-match" };
+  if (scan.hits.length > 1)
+    return { found: false, reason: "ambiguous" };
+  return scan.hits[0].nested ? { found: false, reason: "nested-match" } : { found: true, index: scan.hits[0].index };
+}
+async function replayFlow(steps, dispatch, opts = {}) {
+  const offset = opts.indexOffset ?? 0;
   const trace = [];
   let lastTapped = null;
   const fail3 = (i, reason) => ({
     passed: false,
-    failedStepIndex: i,
+    failedStepIndex: i + offset,
     reason,
     steps: trace
   });
@@ -71151,7 +71203,7 @@ async function replayFlow(steps, dispatch) {
             if (!sub.passed) {
               return {
                 passed: false,
-                failedStepIndex: i,
+                failedStepIndex: i + offset,
                 reason: sub.reason,
                 steps: trace
               };
@@ -71169,7 +71221,7 @@ async function replayFlow(steps, dispatch) {
   }
   return { passed: true, steps: trace };
 }
-var UnsupportedStepError, interp, asString, isObj;
+var UnsupportedStepError, interp, asString, isObj, MAX_ANCHOR_DEPTH;
 var init_cdp_flow_replay = __esm({
   "packages/rn-dev-agent-core/dist/domain/cdp-flow-replay.js"() {
     "use strict";
@@ -71184,6 +71236,7 @@ var init_cdp_flow_replay = __esm({
     interp = (s, p) => s.replace(/\$\{([A-Z_][A-Z0-9_]*)\}/g, (_m, k) => p[k] ?? `\${${k}}`);
     asString = (x) => typeof x === "string" ? x : null;
     isObj = (x) => typeof x === "object" && x !== null && !Array.isArray(x);
+    MAX_ANCHOR_DEPTH = 20;
   }
 });
 
@@ -71245,10 +71298,19 @@ function isDisabled(props) {
   const a11y = props.accessibilityState;
   return props.disabled === true || a11y?.disabled === true || props.pointerEvents === "none";
 }
-async function runCdpReplay(bodyYaml, params, deps) {
+async function runCdpReplay(bodyYaml, params, deps, opts = {}) {
   const parsed = (0, import_yaml4.parse)(bodyYaml);
-  const steps = normalizeSteps(parsed, params);
-  return replayFlow(steps, buildCdpDispatch(deps));
+  const resume = resolveResume(parsed, params, opts.resumeAtSelector);
+  const startIndex = resume.applied ? resume.startIndex : 0;
+  const steps = normalizeSteps(startIndex === 0 ? parsed : parsed.slice(startIndex), params);
+  const result = await replayFlow(steps, buildCdpDispatch(deps), { indexOffset: startIndex });
+  return { ...result, resume };
+}
+function resolveResume(parsed, params, selector) {
+  if (!selector || !Array.isArray(parsed))
+    return { applied: false, reason: "not-requested" };
+  const anchor = findResumeAnchor(parsed, params, selector);
+  return anchor.found ? { applied: true, selector, startIndex: anchor.index } : { applied: false, reason: anchor.reason };
 }
 function buildCdpDispatch(deps) {
   return {
@@ -71407,13 +71469,32 @@ function readMaestroDeviceAuthority(env) {
     return env.data.deviceAuthority;
   return env.meta?.deviceAuthority;
 }
+function terminalReason(terminal) {
+  if (!terminal?.failureKind)
+    return "";
+  return ` (${terminal.failureKind}${terminal.failureSelector ? `: ${terminal.failureSelector}` : ""})`;
+}
 function readMaestroFailureDetail(env, output) {
   if (typeof env.error === "string" && env.error.trim())
     return env.error.trim();
-  const failedStep = env.meta?.failedStep;
-  if (typeof failedStep?.name === "string")
-    return `Maestro flow failed at step "${failedStep.name}"`;
-  return output.trim().slice(0, 1e3) || "Maestro runner returned no failure detail";
+  const terminal = readMaestroTerminal(env);
+  const reason = terminalReason(terminal);
+  const metaStep = env.meta?.failedStep;
+  const dataStep = env.data?.failedStep;
+  const stepName = typeof metaStep?.name === "string" ? metaStep.name : typeof dataStep?.name === "string" ? dataStep.name : terminal?.failedStep;
+  if (stepName)
+    return `Maestro flow failed at step "${stepName}"${reason}`;
+  if (reason)
+    return `Maestro flow failed${reason.trim()}`;
+  return boundedOutput(output.trim(), 1e3) || "Maestro runner returned no failure detail";
+}
+function boundedOutput(output, budget = OUTPUT_BUDGET) {
+  const text = typeof output === "string" ? output : "";
+  if (text.length <= budget)
+    return text;
+  const room = budget - OUTPUT_ELISION.length;
+  const head = Math.ceil(room / 2);
+  return text.slice(0, head) + OUTPUT_ELISION + text.slice(text.length - (room - head));
 }
 function mapRefusedReason(repairCode, repairError) {
   if (repairCode === "SNAPSHOT_FAILED")
@@ -71650,7 +71731,7 @@ function createRunActionHandler(deps = {}) {
           writes: writeDisclosure(promotionDisclosure(persisted2), persisted2),
           durationMs: Date.now() - t0,
           flowFile: action.filePath,
-          firstAttemptOutput: firstOutput.slice(0, 500)
+          firstAttemptOutput: boundedOutput(firstOutput)
         });
       }
       const failure = parseMaestroFailure(firstOutput, readMaestroTerminal(firstEnv));
@@ -71700,8 +71781,17 @@ function createRunActionHandler(deps = {}) {
               reason: probeOutcome.sawTree ? "testid-not-in-tree" : "cdp-unreachable"
             };
           } else {
+            const maestroEvidence = {
+              failureKind: failure.kind,
+              ...failure.kind === "SELECTOR_NOT_FOUND" ? { failureSelector: failure.selector } : {},
+              underlyingFailure: firstFailureDetail,
+              terminal: readMaestroTerminal(firstEnv),
+              firstAttemptOutput: boundedOutput(firstOutput)
+            };
             try {
-              const replay = await runCdpReplay(action.body, args.params ?? {}, replayDeps);
+              const replay = await runCdpReplay(action.body, args.params ?? {}, replayDeps, {
+                resumeAtSelector: failure.kind === "SELECTOR_NOT_FOUND" ? failure.selector : null
+              });
               const status = replay.passed ? "pass" : "fail";
               const autoRepair2 = {
                 attempted: false,
@@ -71730,17 +71820,20 @@ function createRunActionHandler(deps = {}) {
                   autoRepair: autoRepair2,
                   writes: writeDisclosure(promotionDisclosure(persisted2), persisted2),
                   durationMs: Date.now() - t0,
-                  flowFile: action.filePath
+                  flowFile: action.filePath,
+                  resume: replay.resume
                 });
               }
               return failResult(`cdp_run_action: ${args.actionId} replayed via CDP/JS (WDA transport-blind) and failed at step ${replay.failedStepIndex}: ${replay.reason}`, "TRANSPORT_BLIND", {
                 actionId: args.actionId,
                 transport: "cdp-js",
-                failedStepIndex: replay.failedStepIndex
+                failedStepIndex: replay.failedStepIndex,
+                resume: replay.resume,
+                ...maestroEvidence
               });
             } catch (e) {
               if (e instanceof UnsupportedStepError) {
-                return failResult(`cdp_run_action: ${args.actionId} cannot replay via CDP/JS \u2014 ${e.message}. This action uses a step type the iOS 26.x fallback doesn't support; run on iOS 18 (WDA works there).`, "UNSUPPORTED_STEP", { actionId: args.actionId, stepKey: e.stepKey });
+                return failResult(`cdp_run_action: ${args.actionId} cannot replay via CDP/JS \u2014 ${e.message}. This action uses a step type the iOS 26.x fallback doesn't support; run on iOS 18 (WDA works there).`, "UNSUPPORTED_STEP", { actionId: args.actionId, stepKey: e.stepKey, ...maestroEvidence });
               }
               throw e;
             }
@@ -71772,9 +71865,12 @@ function createRunActionHandler(deps = {}) {
         const meta = {
           actionId: args.actionId,
           failureKind: failure.kind,
+          // GH #580: the selector belongs in the envelope structurally, not only
+          // inside the human headline the caller would have to re-parse.
+          ..."selector" in failure && failure.selector ? { failureSelector: failure.selector } : {},
           underlyingFailure: firstFailureDetail,
           autoRepair: autoRepair2,
-          firstAttemptOutput: firstOutput.slice(0, 500),
+          firstAttemptOutput: boundedOutput(firstOutput),
           terminal: readMaestroTerminal(firstEnv),
           runnerResume: firstEnv.meta?.runnerResume,
           ...cdpJsFallback ? { cdpJsFallback } : {}
@@ -71811,15 +71907,21 @@ function createRunActionHandler(deps = {}) {
           durationMs: Date.now() - t0,
           status: "fail",
           failureCode: "SELECTOR_NOT_FOUND",
-          failureDetail: firstOutput.slice(0, 500),
+          // GH #580: the structured detail carries kind + selector; the bounded
+          // stdout slice can lose the failing line to later runner narration.
+          failureDetail: firstFailureDetail.slice(0, 1e3),
           trigger,
           autoRepair: autoRepair2
         });
-        return failResult(`cdp_run_action: ${args.actionId} failed with SELECTOR_NOT_FOUND; auto-repair refused (${refusedReason}): ${repairEnv.error ?? "unknown"}`, refusedReason === "TRANSPORT_BLIND" ? "TRANSPORT_BLIND" : "TESTID_NOT_FOUND", {
+        return failResult(`cdp_run_action: ${args.actionId} failed with SELECTOR_NOT_FOUND (${failure.selector}); auto-repair refused (${refusedReason}): ${repairEnv.error ?? "unknown"}`, refusedReason === "TRANSPORT_BLIND" ? "TRANSPORT_BLIND" : "TESTID_NOT_FOUND", {
           actionId: args.actionId,
+          failureKind: failure.kind,
+          failureSelector: failure.selector,
+          underlyingFailure: firstFailureDetail,
+          terminal: readMaestroTerminal(firstEnv),
           autoRepair: autoRepair2,
           repairError: repairEnv.error,
-          firstAttemptOutput: firstOutput.slice(0, 500)
+          firstAttemptOutput: boundedOutput(firstOutput)
         });
       }
       const repairData = repairEnv.data;
@@ -71925,15 +72027,15 @@ function createRunActionHandler(deps = {}) {
           durationMs: Date.now() - t0,
           flowFile: reloadedAction.filePath,
           retriedAfterRepair: true,
-          retryOutput: retryOutput.slice(0, 500)
+          retryOutput: boundedOutput(retryOutput)
         });
       }
       return failResult(`cdp_run_action: ${args.actionId} still failing after auto-repair (${repairData.oldSelector} \u2192 ${repairData.newSelector}): ${retryFailureDetail}`, "TESTID_NOT_FOUND", {
         actionId: args.actionId,
         autoRepair,
         writes: writeDisclosure("auto-repair", persisted),
-        firstAttemptOutput: firstOutput.slice(0, 500),
-        retryOutput: retryOutput.slice(0, 500),
+        firstAttemptOutput: boundedOutput(firstOutput),
+        retryOutput: boundedOutput(retryOutput),
         underlyingFailure: retryFailureDetail
       });
     } catch (err) {
@@ -72001,6 +72103,7 @@ async function persistRun(actionId, projectRoot, record2) {
   }
   return { promoted: false, promotionRefused: false };
 }
+var OUTPUT_BUDGET, OUTPUT_ELISION;
 var init_run_action = __esm({
   "packages/rn-dev-agent-core/dist/tools/run-action.js"() {
     "use strict";
@@ -72018,6 +72121,8 @@ var init_run_action = __esm({
     init_cdp_flow_replay();
     init_blind_probe_gate();
     init_authority_gate();
+    OUTPUT_BUDGET = 500;
+    OUTPUT_ELISION = "\n\u2026\n";
   }
 });
 

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -16960,7 +16960,14 @@ function parseMaestroFailure(output, terminal) {
   }
   output = raw;
   const lines = output.split("\n");
-  for (const { re, build } of PATTERNS) {
+  const terminalWaitLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line));
+  for (const { re, build, terminalWaitOnly } of PATTERNS) {
+    if (terminalWaitOnly) {
+      const m = terminalWaitLine?.match(re);
+      if (m)
+        return build(m, output);
+      continue;
+    }
     for (let i = lines.length - 1; i >= 0; i--) {
       const line = lines[i];
       if (!line)
@@ -16970,7 +16977,9 @@ function parseMaestroFailure(output, terminal) {
         return build(m, output);
     }
   }
-  for (const { re, build } of PATTERNS) {
+  for (const { re, build, terminalWaitOnly } of PATTERNS) {
+    if (terminalWaitOnly)
+      continue;
     const m = output.match(re);
     if (m)
       return build(m, output);
@@ -17014,7 +17023,8 @@ var init_maestro_error_parser = __esm({
       // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
       {
         re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
-        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw })
+        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw }),
+        terminalWaitOnly: true
       },
       {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -71159,9 +71169,10 @@ async function replayFlow(steps, dispatch, opts = {}) {
   const offset = opts.indexOffset ?? 0;
   const trace = [];
   let lastTapped = null;
+  const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
   const fail3 = (i, reason) => ({
     passed: false,
-    failedStepIndex: i + offset,
+    failedStepIndex: sourceIndex(i),
     reason,
     steps: trace
   });
@@ -71171,51 +71182,61 @@ async function replayFlow(steps, dispatch, opts = {}) {
       switch (s.t) {
         case "launch":
           await dispatch.launch(s.stopApp);
-          trace.push({ t: s.t, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, ok: true });
           break;
         case "tap":
           await dispatch.press(s.id);
           lastTapped = s.id;
-          trace.push({ t: s.t, target: s.id, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, target: s.id, ok: true });
           break;
         case "type": {
           if (!lastTapped)
             return fail3(i, "inputText before any tapOn \u2014 no focus target");
           await dispatch.type(lastTapped, s.text);
-          trace.push({ t: s.t, target: lastTapped, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, target: lastTapped, ok: true });
           break;
         }
         case "assert": {
           const ok = await dispatch.isVisible(s.id);
-          trace.push({ t: s.t, target: s.id, ok });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, target: s.id, ok });
           if (!ok)
             return fail3(i, `assertVisible: "${s.id}" not present in CDP tree`);
           break;
         }
         case "wait":
           await dispatch.settle();
-          trace.push({ t: s.t, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, ok: true });
           break;
         case "runFlow": {
           if (await dispatch.isVisible(s.whenVisible)) {
-            const sub = await replayFlow(s.commands, dispatch);
+            const sub = await replayFlow(s.commands, dispatch, { sourceIndex: sourceIndex(i) });
             trace.push(...sub.steps);
             if (!sub.passed) {
               return {
                 passed: false,
-                failedStepIndex: i + offset,
+                failedStepIndex: sourceIndex(i),
                 reason: sub.reason,
                 steps: trace
               };
             }
           } else {
-            trace.push({ t: s.t, target: s.whenVisible, ok: true });
+            trace.push({
+              sourceIndex: sourceIndex(i),
+              t: s.t,
+              target: s.whenVisible,
+              ok: true
+            });
           }
           break;
         }
       }
     } catch (e) {
-      trace.push({ t: s.t, target: "id" in s ? s.id : void 0, ok: false });
+      trace.push({
+        sourceIndex: sourceIndex(i),
+        t: s.t,
+        target: "id" in s ? s.id : void 0,
+        ok: false
+      });
       return fail3(i, e instanceof Error ? e.message : String(e));
     }
   }
@@ -71962,6 +71983,8 @@ function createRunActionHandler(deps = {}) {
       const retryPassed = retryEnv.ok === true && retryEnv.data?.passed === true;
       const retryOutput = readMaestroOutput(retryEnv);
       const retryFailureDetail = readMaestroFailureDetail(retryEnv, retryOutput);
+      const retryTerminal = readMaestroTerminal(retryEnv);
+      const retryFailure = !retryPassed ? parseMaestroFailure(retryOutput, retryTerminal) : void 0;
       const retryDeviceAuthority = readMaestroDeviceAuthority(retryEnv);
       probeDeviceId = retryDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
       if (retryEnv.code === "DEVICE_AUTHORITY_MISMATCH") {
@@ -71984,14 +72007,8 @@ function createRunActionHandler(deps = {}) {
       const repairScore = repairEnv.data?.score;
       const repairTimestamp = reloadedAction.state.repairHistory.length > 0 ? reloadedAction.state.repairHistory[reloadedAction.state.repairHistory.length - 1].timestamp : void 0;
       let nextFailedSelector;
-      if (!retryPassed) {
-        try {
-          const retryFailure = parseMaestroFailure(retryOutput, readMaestroTerminal(retryEnv));
-          if (retryFailure.kind === "SELECTOR_NOT_FOUND" && retryFailure.selector && retryFailure.selector !== repairData.newSelector) {
-            nextFailedSelector = retryFailure.selector;
-          }
-        } catch {
-        }
+      if (retryFailure?.kind === "SELECTOR_NOT_FOUND" && retryFailure.selector && retryFailure.selector !== repairData.newSelector) {
+        nextFailedSelector = retryFailure.selector;
       }
       const autoRepair = {
         attempted: true,
@@ -72036,7 +72053,10 @@ function createRunActionHandler(deps = {}) {
         writes: writeDisclosure("auto-repair", persisted),
         firstAttemptOutput: boundedOutput(firstOutput),
         retryOutput: boundedOutput(retryOutput),
-        underlyingFailure: retryFailureDetail
+        underlyingFailure: retryFailureDetail,
+        ...retryFailure ? { failureKind: retryFailure.kind } : {},
+        ...retryFailure && "selector" in retryFailure && retryFailure.selector ? { failureSelector: retryFailure.selector } : {},
+        terminal: retryTerminal
       });
     } catch (err) {
       if (err instanceof SessionAuthorityError)

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -16960,7 +16960,7 @@ function parseMaestroFailure(output, terminal) {
   }
   output = raw;
   const lines = output.split("\n");
-  const terminalFailureLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) || PATTERNS.some(({ re }) => re.test(line)));
+  const terminalFailureLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) || /\bWait timed out\b/i.test(line) || PATTERNS.some(({ re }) => re.test(line)));
   if (terminalFailureLine) {
     for (const { re, build } of PATTERNS) {
       const m = terminalFailureLine.match(re);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -16987,7 +16987,7 @@ function parseTerminalIdWait(output, suppliedFailedStep) {
   const reasonMatch = ID_WAIT_REASON_RE.exec(reasonLine);
   if (!reasonMatch)
     return null;
-  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep) ?? (terminalStep ? idWaitStepAmongDuplicates(lines, terminalStep.index, reasonLine) : null);
+  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep) ?? (terminalStep && SELECTOR_LESS_ID_WAIT_SUMMARY_RE.test(failedStep) ? idWaitStepAmongDuplicates(lines, terminalStep.index, reasonLine) : null);
   if (!stepMatch || reasonMatch[2] !== stepMatch[2])
     return null;
   return {
@@ -17054,7 +17054,7 @@ function isAutoRepairable(failure) {
 function outputIndicatesFlowFailure(output) {
   return /^\s*(?:\[FAILED\]|(?:Test|Flow) FAILED\b|FAILED\s*$)/m.test(output);
 }
-var PATTERNS, RUNNER_STEP_RE, REASON_LINE_RE, ID_WAIT_STEP_RE, ID_WAIT_REASON_RE;
+var PATTERNS, RUNNER_STEP_RE, REASON_LINE_RE, ID_WAIT_STEP_RE, SELECTOR_LESS_ID_WAIT_SUMMARY_RE, ID_WAIT_REASON_RE;
 var init_maestro_error_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js"() {
     "use strict";
@@ -17107,6 +17107,7 @@ var init_maestro_error_parser = __esm({
     RUNNER_STEP_RE = /^[ \t]+([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
     REASON_LINE_RE = /^[ \t]+╰─\s+/;
     ID_WAIT_STEP_RE = /^extendedWaitUntil:\s+visible\s+id=(['"])((?:(?!\1).)+)\1$/i;
+    SELECTOR_LESS_ID_WAIT_SUMMARY_RE = /^extendedWaitUntil$/;
     ID_WAIT_REASON_RE = /^[ \t]+╰─\s+Element (['"])#((?:(?!\1).)+)\1 not visible within\b/i;
   }
 });
@@ -17397,7 +17398,7 @@ function cap(s) {
 function combineRunnerOutput(stdout, stderr) {
   return (stdout + "\n" + stderr).replace(/^[\r\n]+/, "").trimEnd();
 }
-function parseSteps(output) {
+function parseExactSteps(output) {
   if (!output || typeof output !== "string")
     return [];
   const steps = [];
@@ -17415,13 +17416,19 @@ function parseSteps(output) {
       continue;
     steps.push({
       index: index++,
-      name: cap(name),
+      name,
       verb,
       status: m[1] === "\u2713" ? "pass" : "fail",
       durationMs: Math.round(seconds * 1e3)
     });
   }
   return steps.length > MAX_STEPS ? steps.slice(-MAX_STEPS) : steps;
+}
+function boundStep(step) {
+  return { ...step, name: cap(step.name) };
+}
+function parseSteps(output) {
+  return parseExactSteps(output).map(boundStep);
 }
 function findFailedStep(steps) {
   const last = steps.length ? steps[steps.length - 1] : null;
@@ -17430,20 +17437,25 @@ function findFailedStep(steps) {
 function lastObservedStep(steps) {
   return steps.length ? steps[steps.length - 1] : null;
 }
-function summarizeReason(output, failedStep) {
+function summarizeExactReason(output, failedStep) {
   const f = parseMaestroFailure(output, failedStep ? { failedStep } : void 0);
   if (f.kind === "UNKNOWN" || f.kind === "WDA_BOOTSTRAP_FAILED")
     return null;
   const selector = "selector" in f ? f.selector ?? null : null;
-  return { kind: f.kind, selector: selector === null ? null : cap(selector) };
+  return { kind: f.kind, selector };
 }
 function buildStepSummary(output, opts) {
-  const steps = parseSteps(output);
-  const failedStep = opts.failed ? findFailedStep(steps) : null;
+  const exactSteps = parseExactSteps(output);
+  const exactFailedStep = opts.failed ? findFailedStep(exactSteps) : null;
+  const exactReason = opts.failed ? summarizeExactReason(output, exactFailedStep?.name) : null;
+  const steps = exactSteps.map(boundStep);
   return {
     steps,
-    failedStep,
-    reason: opts.failed ? summarizeReason(output, failedStep?.name) : null,
+    failedStep: exactFailedStep ? boundStep(exactFailedStep) : null,
+    reason: exactReason ? {
+      ...exactReason,
+      selector: exactReason.selector === null ? null : cap(exactReason.selector)
+    } : null,
     lastStep: lastObservedStep(steps)
   };
 }
@@ -17451,17 +17463,19 @@ function isWdaFailureLine(line) {
   return WDA_TOKEN_RE.test(line) && WDA_FAILURE_RE.test(line);
 }
 function buildTerminalEvidence(output, opts = {}) {
-  const summary = buildStepSummary(output, { failed: true });
+  const exactSteps = parseExactSteps(output);
+  const failedStep = findFailedStep(exactSteps);
+  const reason = summarizeExactReason(output, failedStep?.name);
   const bootstrapEvidence = stripAnsi(output).split("\n").filter((line) => isWdaFailureLine(line)).join("\n").slice(0, 500);
-  const exitClass = opts.timedOut ? "timed-out" : opts.spawnError ? "spawn-error" : summary.steps.length === 0 ? "before-first-step" : "step-failure";
+  const exitClass = opts.timedOut ? "timed-out" : opts.spawnError ? "spawn-error" : exactSteps.length === 0 ? "before-first-step" : "step-failure";
   return {
-    completedSteps: summary.steps.filter((step) => step.status === "pass").length,
-    ...summary.failedStep ? { failedStep: summary.failedStep.name } : {},
+    completedSteps: exactSteps.filter((step) => step.status === "pass").length,
+    ...failedStep ? { failedStep: failedStep.name } : {},
     exitClass,
     ...bootstrapEvidence ? { bootstrapEvidence } : {},
-    ...summary.reason ? {
-      failureKind: summary.reason.kind,
-      failureSelector: summary.reason.selector
+    ...reason ? {
+      failureKind: reason.kind,
+      failureSelector: reason.selector
     } : {}
   };
 }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -16960,26 +16960,16 @@ function parseMaestroFailure(output, terminal) {
   }
   output = raw;
   const lines = output.split("\n");
-  const terminalWaitLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line));
-  for (const { re, build, terminalWaitOnly } of PATTERNS) {
-    if (terminalWaitOnly) {
-      const m = terminalWaitLine?.match(re);
-      if (m)
-        return build(m, output);
-      continue;
-    }
-    for (let i = lines.length - 1; i >= 0; i--) {
-      const line = lines[i];
-      if (!line)
-        continue;
-      const m = line.match(re);
+  const terminalFailureLine = [...lines].reverse().find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) || PATTERNS.some(({ re }) => re.test(line)));
+  if (terminalFailureLine) {
+    for (const { re, build } of PATTERNS) {
+      const m = terminalFailureLine.match(re);
       if (m)
         return build(m, output);
     }
+    return { kind: "UNKNOWN", raw: output };
   }
-  for (const { re, build, terminalWaitOnly } of PATTERNS) {
-    if (terminalWaitOnly)
-      continue;
+  for (const { re, build } of PATTERNS) {
     const m = output.match(re);
     if (m)
       return build(m, output);
@@ -17023,8 +17013,7 @@ var init_maestro_error_parser = __esm({
       // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
       {
         re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
-        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw }),
-        terminalWaitOnly: true
+        build: (m, raw) => ({ kind: "SELECTOR_NOT_FOUND", selectorKind: "id", selector: m[2], raw })
       },
       {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -71985,6 +71974,7 @@ function createRunActionHandler(deps = {}) {
       const retryFailureDetail = readMaestroFailureDetail(retryEnv, retryOutput);
       const retryTerminal = readMaestroTerminal(retryEnv);
       const retryFailure = !retryPassed ? parseMaestroFailure(retryOutput, retryTerminal) : void 0;
+      const retryClassification = retryFailure ? classifyFailure(retryFailure) : void 0;
       const retryDeviceAuthority = readMaestroDeviceAuthority(retryEnv);
       probeDeviceId = retryDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
       if (retryEnv.code === "DEVICE_AUTHORITY_MISMATCH") {
@@ -72028,7 +72018,7 @@ function createRunActionHandler(deps = {}) {
         timestamp: (/* @__PURE__ */ new Date()).toISOString(),
         durationMs: Date.now() - t0,
         status: retryPassed ? "pass" : "fail",
-        failureCode: retryPassed ? void 0 : "SELECTOR_NOT_FOUND",
+        failureCode: retryClassification?.actionCode,
         failureDetail: retryPassed ? void 0 : retryFailureDetail.slice(0, 1e3),
         trigger,
         autoRepair
@@ -72047,7 +72037,8 @@ function createRunActionHandler(deps = {}) {
           retryOutput: boundedOutput(retryOutput)
         });
       }
-      return failResult(`cdp_run_action: ${args.actionId} still failing after auto-repair (${repairData.oldSelector} \u2192 ${repairData.newSelector}): ${retryFailureDetail}`, "TESTID_NOT_FOUND", {
+      const retryMessage = `cdp_run_action: ${args.actionId} still failing after auto-repair (${repairData.oldSelector} \u2192 ${repairData.newSelector}): ${retryFailureDetail}`;
+      const retryMeta = {
         actionId: args.actionId,
         autoRepair,
         writes: writeDisclosure("auto-repair", persisted),
@@ -72057,7 +72048,8 @@ function createRunActionHandler(deps = {}) {
         ...retryFailure ? { failureKind: retryFailure.kind } : {},
         ...retryFailure && "selector" in retryFailure && retryFailure.selector ? { failureSelector: retryFailure.selector } : {},
         terminal: retryTerminal
-      });
+      };
+      return retryClassification?.toolCode ? failResult(retryMessage, retryClassification.toolCode, retryMeta) : failResult(retryMessage, retryMeta);
     } catch (err) {
       if (err instanceof SessionAuthorityError)
         throw err;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -16941,6 +16941,31 @@ var init_ansi = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
+function blockReasons(lines, stepIndex) {
+  const reasons = [];
+  for (let i = stepIndex + 1; i < lines.length; i++) {
+    if (RUNNER_STEP_RE.test(lines[i]))
+      break;
+    if (REASON_LINE_RE.test(lines[i]))
+      reasons.push(lines[i]);
+  }
+  return reasons;
+}
+function idWaitStepAmongDuplicates(lines, terminalIndex, terminalReason2) {
+  for (let i = terminalIndex - 1; i >= 0; i--) {
+    const step = RUNNER_STEP_RE.exec(lines[i]);
+    if (!step)
+      continue;
+    if (step[1] !== "\u2717")
+      return null;
+    if (!blockReasons(lines, i).includes(terminalReason2))
+      return null;
+    const stepMatch = ID_WAIT_STEP_RE.exec(step[2]);
+    if (stepMatch)
+      return stepMatch;
+  }
+  return null;
+}
 function parseTerminalIdWait(output, suppliedFailedStep) {
   const lines = stripAnsi(output).split("\n");
   let terminalStep;
@@ -16956,14 +16981,14 @@ function parseTerminalIdWait(output, suppliedFailedStep) {
   const failedStep = suppliedFailedStep ?? terminalStep?.name;
   if (!failedStep || terminalStep && terminalStep.status !== "\u2717")
     return null;
-  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep);
-  if (!stepMatch)
-    return null;
   const reasonLine = lines.slice(terminalStep ? terminalStep.index + 1 : 0).filter((line) => REASON_LINE_RE.test(line)).at(-1);
   if (!reasonLine)
     return null;
   const reasonMatch = ID_WAIT_REASON_RE.exec(reasonLine);
-  if (!reasonMatch || reasonMatch[2] !== stepMatch[2])
+  if (!reasonMatch)
+    return null;
+  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep) ?? (terminalStep ? idWaitStepAmongDuplicates(lines, terminalStep.index, reasonLine) : null);
+  if (!stepMatch || reasonMatch[2] !== stepMatch[2])
     return null;
   return {
     kind: "SELECTOR_NOT_FOUND",

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -16928,9 +16928,21 @@ var init_maestro_dispatch = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/ansi.js
+function stripAnsi(value) {
+  return value.replace(ANSI_RE, "");
+}
+var ANSI_RE;
+var init_ansi = __esm({
+  "packages/rn-dev-agent-core/dist/domain/ansi.js"() {
+    "use strict";
+    ANSI_RE = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g");
+  }
+});
+
 // packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
 function parseTerminalIdWait(output, suppliedFailedStep) {
-  const lines = output.split("\n");
+  const lines = stripAnsi(output).split("\n");
   let terminalStep;
   for (let index = 0; index < lines.length; index++) {
     const match = RUNNER_STEP_RE.exec(lines[index]);
@@ -17021,6 +17033,7 @@ var PATTERNS, RUNNER_STEP_RE, REASON_LINE_RE, ID_WAIT_STEP_RE, ID_WAIT_REASON_RE
 var init_maestro_error_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js"() {
     "use strict";
+    init_ansi();
     PATTERNS = [
       {
         re: /Element with id (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -17353,9 +17366,6 @@ var init_engine_pin = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/maestro-step-parser.js
-function stripAnsi(s) {
-  return s.replace(ANSI_RE, "");
-}
 function cap(s) {
   return s.length > MAX_FIELD ? s.slice(0, MAX_FIELD) + "\u2026" : s;
 }
@@ -17454,12 +17464,13 @@ function formatFailureHeadline(summary, cls, fallbackMsg) {
   }
   return `Maestro flow failed: ${fallbackMsg.slice(0, 500)}`;
 }
-var ANSI_RE, STEP_RE, MAX_FIELD, MAX_STEPS, WDA_TOKEN_RE, WDA_FAILURE_RE;
+var STEP_RE, MAX_FIELD, MAX_STEPS, WDA_TOKEN_RE, WDA_FAILURE_RE;
 var init_maestro_step_parser = __esm({
   "packages/rn-dev-agent-core/dist/domain/maestro-step-parser.js"() {
     "use strict";
     init_maestro_error_parser();
-    ANSI_RE = new RegExp(String.fromCharCode(27) + "\\[[0-9;]*m", "g");
+    init_ansi();
+    init_ansi();
     STEP_RE = /^[ \t]+([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
     MAX_FIELD = 200;
     MAX_STEPS = 1e3;

--- a/packages/rn-dev-agent-core/dist/domain/ansi.js
+++ b/packages/rn-dev-agent-core/dist/domain/ansi.js
@@ -1,0 +1,4 @@
+const ANSI_RE = new RegExp(String.fromCharCode(27) + '\\[[0-9;]*m', 'g');
+export function stripAnsi(value) {
+    return value.replace(ANSI_RE, '');
+}

--- a/packages/rn-dev-agent-core/dist/domain/cdp-flow-replay.js
+++ b/packages/rn-dev-agent-core/dist/domain/cdp-flow-replay.js
@@ -133,10 +133,8 @@ export function findResumeAnchor(body, params, selector) {
         ? { found: false, reason: 'nested-match' }
         : { found: true, index: scan.hits[0].index };
 }
-export async function replayFlow(steps, dispatch, 
-// GH #580: a resumed suffix reports SOURCE step indices, not suffix-relative
-// ones, so TRANSPORT_BLIND messages and failedStepIndex stay honest.
-opts = {}) {
+// GH #580: resumed suffixes report source indices, not suffix-relative indices.
+export async function replayFlow(steps, dispatch, opts = {}) {
     const offset = opts.indexOffset ?? 0;
     const trace = [];
     let lastTapped = null;

--- a/packages/rn-dev-agent-core/dist/domain/cdp-flow-replay.js
+++ b/packages/rn-dev-agent-core/dist/domain/cdp-flow-replay.js
@@ -24,9 +24,21 @@ export function normalizeSteps(body, params) {
         const key = keys[0];
         const v = raw[key];
         switch (key) {
-            case 'launchApp':
+            case 'launchApp': {
+                // GH #580: `simctl launch` cannot clear state (that needs uninstall +
+                // reinstall), so an unhonorable key must refuse, not silently drop.
+                if (isObj(v)) {
+                    const unsupported = Object.keys(v).filter((k) => k !== 'stopApp');
+                    if (unsupported.length > 0)
+                        throw new UnsupportedStepError(`launchApp (unsupported keys: ${unsupported.sort().join(', ')})`);
+                    // A non-boolean stopApp would coerce to false — different launch
+                    // semantics than the author wrote, which is the same silent lie.
+                    if ('stopApp' in v && typeof v.stopApp !== 'boolean')
+                        throw new UnsupportedStepError('launchApp (stopApp must be a boolean)');
+                }
                 out.push({ t: 'launch', stopApp: isObj(v) && v.stopApp === true });
                 break;
+            }
             case 'tapOn': {
                 const id = isObj(v) ? asString(v.id) : null;
                 if (!id)
@@ -76,12 +88,61 @@ export function firstTestId(steps) {
     }
     return null;
 }
-export async function replayFlow(steps, dispatch) {
+// Bound the walk so a pathologically nested action body cannot stall the scan.
+const MAX_ANCHOR_DEPTH = 20;
+// Counted, not OR-ed: two matches inside one step must stay detectably ambiguous.
+function countIdHits(node, params, selector, index, depth, nested, scan) {
+    if (depth > MAX_ANCHOR_DEPTH) {
+        scan.truncated = true;
+        return;
+    }
+    if (Array.isArray(node)) {
+        for (const child of node)
+            countIdHits(child, params, selector, index, depth + 1, nested, scan);
+        return;
+    }
+    if (!isObj(node))
+        return;
+    for (const [key, value] of Object.entries(node)) {
+        if (key === 'id' && typeof value === 'string' && interp(value, params) === selector) {
+            scan.hits.push({ index, nested });
+            continue;
+        }
+        countIdHits(value, params, selector, index, depth + 1, nested || key === 'commands', scan);
+    }
+}
+/**
+ * GH #580: locate the one source step targeting `selector` so a reactive fallback
+ * resumes there instead of replaying already-executed mutations. Anything but a
+ * single top-level occurrence refuses — resuming at an enclosing `runFlow` would
+ * redispatch the siblings preceding a nested match, and a truncated walk cannot
+ * prove a deeper duplicate does not exist.
+ */
+export function findResumeAnchor(body, params, selector) {
+    if (!selector)
+        return { found: false, reason: 'no-match' };
+    const scan = { hits: [], truncated: false };
+    body.forEach((raw, index) => countIdHits(raw, params, selector, index, 0, false, scan));
+    if (scan.truncated)
+        return { found: false, reason: 'too-deep' };
+    if (scan.hits.length === 0)
+        return { found: false, reason: 'no-match' };
+    if (scan.hits.length > 1)
+        return { found: false, reason: 'ambiguous' };
+    return scan.hits[0].nested
+        ? { found: false, reason: 'nested-match' }
+        : { found: true, index: scan.hits[0].index };
+}
+export async function replayFlow(steps, dispatch, 
+// GH #580: a resumed suffix reports SOURCE step indices, not suffix-relative
+// ones, so TRANSPORT_BLIND messages and failedStepIndex stay honest.
+opts = {}) {
+    const offset = opts.indexOffset ?? 0;
     const trace = [];
     let lastTapped = null;
     const fail = (i, reason) => ({
         passed: false,
-        failedStepIndex: i,
+        failedStepIndex: i + offset,
         reason,
         steps: trace,
     });
@@ -123,7 +184,7 @@ export async function replayFlow(steps, dispatch) {
                         if (!sub.passed) {
                             return {
                                 passed: false,
-                                failedStepIndex: i,
+                                failedStepIndex: i + offset,
                                 reason: sub.reason,
                                 steps: trace,
                             };

--- a/packages/rn-dev-agent-core/dist/domain/cdp-flow-replay.js
+++ b/packages/rn-dev-agent-core/dist/domain/cdp-flow-replay.js
@@ -140,9 +140,10 @@ opts = {}) {
     const offset = opts.indexOffset ?? 0;
     const trace = [];
     let lastTapped = null;
+    const sourceIndex = (i) => opts.sourceIndex ?? i + offset;
     const fail = (i, reason) => ({
         passed: false,
-        failedStepIndex: i + offset,
+        failedStepIndex: sourceIndex(i),
         reason,
         steps: trace,
     });
@@ -152,53 +153,63 @@ opts = {}) {
             switch (s.t) {
                 case 'launch':
                     await dispatch.launch(s.stopApp);
-                    trace.push({ t: s.t, ok: true });
+                    trace.push({ sourceIndex: sourceIndex(i), t: s.t, ok: true });
                     break;
                 case 'tap':
                     await dispatch.press(s.id);
                     lastTapped = s.id;
-                    trace.push({ t: s.t, target: s.id, ok: true });
+                    trace.push({ sourceIndex: sourceIndex(i), t: s.t, target: s.id, ok: true });
                     break;
                 case 'type': {
                     if (!lastTapped)
                         return fail(i, 'inputText before any tapOn — no focus target');
                     await dispatch.type(lastTapped, s.text);
-                    trace.push({ t: s.t, target: lastTapped, ok: true });
+                    trace.push({ sourceIndex: sourceIndex(i), t: s.t, target: lastTapped, ok: true });
                     break;
                 }
                 case 'assert': {
                     const ok = await dispatch.isVisible(s.id);
-                    trace.push({ t: s.t, target: s.id, ok });
+                    trace.push({ sourceIndex: sourceIndex(i), t: s.t, target: s.id, ok });
                     if (!ok)
                         return fail(i, `assertVisible: "${s.id}" not present in CDP tree`);
                     break;
                 }
                 case 'wait':
                     await dispatch.settle();
-                    trace.push({ t: s.t, ok: true });
+                    trace.push({ sourceIndex: sourceIndex(i), t: s.t, ok: true });
                     break;
                 case 'runFlow': {
                     if (await dispatch.isVisible(s.whenVisible)) {
-                        const sub = await replayFlow(s.commands, dispatch);
+                        const sub = await replayFlow(s.commands, dispatch, { sourceIndex: sourceIndex(i) });
                         trace.push(...sub.steps);
                         if (!sub.passed) {
                             return {
                                 passed: false,
-                                failedStepIndex: i + offset,
+                                failedStepIndex: sourceIndex(i),
                                 reason: sub.reason,
                                 steps: trace,
                             };
                         }
                     }
                     else {
-                        trace.push({ t: s.t, target: s.whenVisible, ok: true });
+                        trace.push({
+                            sourceIndex: sourceIndex(i),
+                            t: s.t,
+                            target: s.whenVisible,
+                            ok: true,
+                        });
                     }
                     break;
                 }
             }
         }
         catch (e) {
-            trace.push({ t: s.t, target: 'id' in s ? s.id : undefined, ok: false });
+            trace.push({
+                sourceIndex: sourceIndex(i),
+                t: s.t,
+                target: 'id' in s ? s.id : undefined,
+                ok: false,
+            });
             return fail(i, e instanceof Error ? e.message : String(e));
         }
     }

--- a/packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
+++ b/packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
@@ -62,6 +62,37 @@ const RUNNER_STEP_RE = /^[ \t]+([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
 const REASON_LINE_RE = /^[ \t]+╰─\s+/;
 const ID_WAIT_STEP_RE = /^extendedWaitUntil:\s+visible\s+id=(['"])((?:(?!\1).)+)\1$/i;
 const ID_WAIT_REASON_RE = /^[ \t]+╰─\s+Element (['"])#((?:(?!\1).)+)\1 not visible within\b/i;
+// The reason lines belonging to one step block: everything up to the next step line.
+function blockReasons(lines, stepIndex) {
+    const reasons = [];
+    for (let i = stepIndex + 1; i < lines.length; i++) {
+        if (RUNNER_STEP_RE.test(lines[i]))
+            break;
+        if (REASON_LINE_RE.test(lines[i]))
+            reasons.push(lines[i]);
+    }
+    return reasons;
+}
+// GH #580: maestro-runner 1.1.20 can render ONE failure as two blocks — a detailed
+// step naming the id, then a selector-less summary repeating the identical reason.
+// Requiring a byte-identical reason is what makes borrowing that id safe.
+function idWaitStepAmongDuplicates(lines, terminalIndex, terminalReason) {
+    for (let i = terminalIndex - 1; i >= 0; i--) {
+        const step = RUNNER_STEP_RE.exec(lines[i]);
+        if (!step)
+            continue;
+        // A passing step, or a failure whose own reason differs, ends the duplicate
+        // chain: only a block repeating this exact reason is the same failure.
+        if (step[1] !== '✗')
+            return null;
+        if (!blockReasons(lines, i).includes(terminalReason))
+            return null;
+        const stepMatch = ID_WAIT_STEP_RE.exec(step[2]);
+        if (stepMatch)
+            return stepMatch;
+    }
+    return null;
+}
 function parseTerminalIdWait(output, suppliedFailedStep) {
     const lines = stripAnsi(output).split('\n');
     let terminalStep;
@@ -77,9 +108,6 @@ function parseTerminalIdWait(output, suppliedFailedStep) {
     const failedStep = suppliedFailedStep ?? terminalStep?.name;
     if (!failedStep || (terminalStep && terminalStep.status !== '✗'))
         return null;
-    const stepMatch = ID_WAIT_STEP_RE.exec(failedStep);
-    if (!stepMatch)
-        return null;
     const reasonLine = lines
         .slice(terminalStep ? terminalStep.index + 1 : 0)
         .filter((line) => REASON_LINE_RE.test(line))
@@ -87,7 +115,11 @@ function parseTerminalIdWait(output, suppliedFailedStep) {
     if (!reasonLine)
         return null;
     const reasonMatch = ID_WAIT_REASON_RE.exec(reasonLine);
-    if (!reasonMatch || reasonMatch[2] !== stepMatch[2])
+    if (!reasonMatch)
+        return null;
+    const stepMatch = ID_WAIT_STEP_RE.exec(failedStep) ??
+        (terminalStep ? idWaitStepAmongDuplicates(lines, terminalStep.index, reasonLine) : null);
+    if (!stepMatch || reasonMatch[2] !== stepMatch[2])
         return null;
     return {
         kind: 'SELECTOR_NOT_FOUND',

--- a/packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
+++ b/packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
@@ -60,7 +60,6 @@ const PATTERNS = [
     {
         re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
         build: (m, raw) => ({ kind: 'SELECTOR_NOT_FOUND', selectorKind: 'id', selector: m[2], raw }),
-        terminalWaitOnly: true,
     },
     {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -88,30 +87,6 @@ const PATTERNS = [
         build: (m, raw) => ({ kind: 'ASSERTION_FAILED', selector: m[2], raw }),
     },
 ];
-/**
- * Parse the full Maestro stdout+stderr text and classify the failure.
- *
- * Two-axis selection — pattern-specificity dominates, line-position breaks
- * ties within a pattern:
- *
- *   1. Outer loop walks PATTERNS in order (most-specific first). The first
- *      pattern that hits ANY line wins, regardless of where that line sits.
- *      Preserves the existing invariant that the 1.0.9 `id=` shape outranks
- *      the catch-all `Element 'X' not found`.
- *
- *   2. Inner loop scans lines from END to START. Within a single pattern,
- *      the LAST matching line (the terminal failure) wins — earlier matches
- *      are typically transient retries that maestro-runner reports as
- *      `[INFO]` before the auto-retry succeeds. GH #118: PR #115's
- *      first-match-anywhere scan captured a transient retry selector and
- *      sent it to `cdp_repair_action`, wasting a 24h-budget slot.
- *
- * Falls back to a whole-buffer scan when no line matches a known pattern —
- * preserves prior-art behavior for single-line inputs and any pattern that
- * happens to span a line boundary (none today, but defensive).
- *
- * Returns `UNKNOWN` if no pattern matches at all.
- */
 export function parseMaestroFailure(output, terminal) {
     const raw = typeof output === 'string' ? output : '';
     if (terminal?.exitClass === 'timed-out') {
@@ -145,30 +120,21 @@ export function parseMaestroFailure(output, terminal) {
     }
     output = raw;
     const lines = output.split('\n');
-    const terminalWaitLine = [...lines]
+    const terminalFailureLine = [...lines]
         .reverse()
-        .find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line));
-    for (const { re, build, terminalWaitOnly } of PATTERNS) {
-        if (terminalWaitOnly) {
-            const m = terminalWaitLine?.match(re);
-            if (m)
-                return build(m, output);
-            continue;
-        }
-        for (let i = lines.length - 1; i >= 0; i--) {
-            const line = lines[i];
-            if (!line)
-                continue;
-            const m = line.match(re);
+        .find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) ||
+        PATTERNS.some(({ re }) => re.test(line)));
+    if (terminalFailureLine) {
+        for (const { re, build } of PATTERNS) {
+            const m = terminalFailureLine.match(re);
             if (m)
                 return build(m, output);
         }
+        return { kind: 'UNKNOWN', raw: output };
     }
     // Fallback: whole-buffer scan for inputs without line breaks or for
     // any pattern that happens to straddle a `\n`.
-    for (const { re, build, terminalWaitOnly } of PATTERNS) {
-        if (terminalWaitOnly)
-            continue;
+    for (const { re, build } of PATTERNS) {
         const m = output.match(re);
         if (m)
             return build(m, output);

--- a/packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
+++ b/packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
@@ -51,6 +51,16 @@ const PATTERNS = [
         re: /Element not found:\s*text=(['"])((?:(?!\1).)+)\1/i,
         build: (m, raw) => ({ kind: 'SELECTOR_NOT_FOUND', selectorKind: 'text', selector: m[2], raw }),
     },
+    // maestro-runner 1.1.16/1.1.20 ID-wait shape — issue #580.
+    // "Element '#X' not visible within 1s (cause: context deadline exceeded)".
+    // The `#` immediately after the opening quote is the runner's ID-selector
+    // marker: text and regex waits render without it and keep their current
+    // classification (issue #334 owns those). Process/global timeouts never reach
+    // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
+    {
+        re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
+        build: (m, raw) => ({ kind: 'SELECTOR_NOT_FOUND', selectorKind: 'id', selector: m[2], raw }),
+    },
     {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
         build: (m, raw) => ({

--- a/packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
+++ b/packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
@@ -1,23 +1,4 @@
-// Issue #104 — pure parser for Maestro CLI / maestro-runner failure output.
-//
-// `maestro_run` returns the combined stdout+stderr in `data.output`. To
-// auto-repair, we need to classify the failure and extract the failed
-// selector. This module owns that classification — pure regex over the
-// raw output text, no I/O, fully unit-testable.
-//
-// Maestro emits failures in a few canonical shapes (verified against
-// Maestro 1.40+ output, maestro-runner 0.x, and maestro-runner 1.0.9):
-//
-//   - "Element with id 'X' not found"
-//   - "Element with text 'X' not found"
-//   - 'Assertion failed: "X" not visible'
-//   - "Timed out waiting for element 'X'"
-//   - "Element 'X' is not visible"  (assertion variant)
-//   - "Element not found: id='X'"   (maestro-runner 1.0.x shape — issue #105)
-//
-// The parser tries each known shape in order and returns the first
-// match. If none match, returns `{ kind: 'UNKNOWN', raw }` so the caller
-// can decide whether to surface it verbatim or escalate to the user.
+import { stripAnsi } from './ansi.js';
 // Order matters: more-specific patterns first.
 //
 // Matched-quote pattern `(['"])((?:(?!\1).)+)\1` captures a testID
@@ -82,7 +63,7 @@ const REASON_LINE_RE = /^[ \t]+╰─\s+/;
 const ID_WAIT_STEP_RE = /^extendedWaitUntil:\s+visible\s+id=(['"])((?:(?!\1).)+)\1$/i;
 const ID_WAIT_REASON_RE = /^[ \t]+╰─\s+Element (['"])#((?:(?!\1).)+)\1 not visible within\b/i;
 function parseTerminalIdWait(output, suppliedFailedStep) {
-    const lines = output.split('\n');
+    const lines = stripAnsi(output).split('\n');
     let terminalStep;
     for (let index = 0; index < lines.length; index++) {
         const match = RUNNER_STEP_RE.exec(lines[index]);

--- a/packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
+++ b/packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
@@ -60,6 +60,7 @@ const PATTERNS = [
     {
         re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
         build: (m, raw) => ({ kind: 'SELECTOR_NOT_FOUND', selectorKind: 'id', selector: m[2], raw }),
+        terminalWaitOnly: true,
     },
     {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -144,7 +145,16 @@ export function parseMaestroFailure(output, terminal) {
     }
     output = raw;
     const lines = output.split('\n');
-    for (const { re, build } of PATTERNS) {
+    const terminalWaitLine = [...lines]
+        .reverse()
+        .find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line));
+    for (const { re, build, terminalWaitOnly } of PATTERNS) {
+        if (terminalWaitOnly) {
+            const m = terminalWaitLine?.match(re);
+            if (m)
+                return build(m, output);
+            continue;
+        }
         for (let i = lines.length - 1; i >= 0; i--) {
             const line = lines[i];
             if (!line)
@@ -156,7 +166,9 @@ export function parseMaestroFailure(output, terminal) {
     }
     // Fallback: whole-buffer scan for inputs without line breaks or for
     // any pattern that happens to straddle a `\n`.
-    for (const { re, build } of PATTERNS) {
+    for (const { re, build, terminalWaitOnly } of PATTERNS) {
+        if (terminalWaitOnly)
+            continue;
         const m = output.match(re);
         if (m)
             return build(m, output);

--- a/packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
+++ b/packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
@@ -61,6 +61,7 @@ const PATTERNS = [
 const RUNNER_STEP_RE = /^[ \t]+([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
 const REASON_LINE_RE = /^[ \t]+╰─\s+/;
 const ID_WAIT_STEP_RE = /^extendedWaitUntil:\s+visible\s+id=(['"])((?:(?!\1).)+)\1$/i;
+const SELECTOR_LESS_ID_WAIT_SUMMARY_RE = /^extendedWaitUntil$/;
 const ID_WAIT_REASON_RE = /^[ \t]+╰─\s+Element (['"])#((?:(?!\1).)+)\1 not visible within\b/i;
 // The reason lines belonging to one step block: everything up to the next step line.
 function blockReasons(lines, stepIndex) {
@@ -118,7 +119,9 @@ function parseTerminalIdWait(output, suppliedFailedStep) {
     if (!reasonMatch)
         return null;
     const stepMatch = ID_WAIT_STEP_RE.exec(failedStep) ??
-        (terminalStep ? idWaitStepAmongDuplicates(lines, terminalStep.index, reasonLine) : null);
+        (terminalStep && SELECTOR_LESS_ID_WAIT_SUMMARY_RE.test(failedStep)
+            ? idWaitStepAmongDuplicates(lines, terminalStep.index, reasonLine)
+            : null);
     if (!stepMatch || reasonMatch[2] !== stepMatch[2])
         return null;
     return {

--- a/packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
+++ b/packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
@@ -123,6 +123,7 @@ export function parseMaestroFailure(output, terminal) {
     const terminalFailureLine = [...lines]
         .reverse()
         .find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) ||
+        /\bWait timed out\b/i.test(line) ||
         PATTERNS.some(({ re }) => re.test(line)));
     if (terminalFailureLine) {
         for (const { re, build } of PATTERNS) {

--- a/packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
+++ b/packages/rn-dev-agent-core/dist/domain/maestro-error-parser.js
@@ -51,16 +51,6 @@ const PATTERNS = [
         re: /Element not found:\s*text=(['"])((?:(?!\1).)+)\1/i,
         build: (m, raw) => ({ kind: 'SELECTOR_NOT_FOUND', selectorKind: 'text', selector: m[2], raw }),
     },
-    // maestro-runner 1.1.16/1.1.20 ID-wait shape — issue #580.
-    // "Element '#X' not visible within 1s (cause: context deadline exceeded)".
-    // The `#` immediately after the opening quote is the runner's ID-selector
-    // marker: text and regex waits render without it and keep their current
-    // classification (issue #334 owns those). Process/global timeouts never reach
-    // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
-    {
-        re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
-        build: (m, raw) => ({ kind: 'SELECTOR_NOT_FOUND', selectorKind: 'id', selector: m[2], raw }),
-    },
     {
         re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
         build: (m, raw) => ({
@@ -87,6 +77,44 @@ const PATTERNS = [
         build: (m, raw) => ({ kind: 'ASSERTION_FAILED', selector: m[2], raw }),
     },
 ];
+const RUNNER_STEP_RE = /^[ \t]+([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
+const REASON_LINE_RE = /^[ \t]+╰─\s+/;
+const ID_WAIT_STEP_RE = /^extendedWaitUntil:\s+visible\s+id=(['"])((?:(?!\1).)+)\1$/i;
+const ID_WAIT_REASON_RE = /^[ \t]+╰─\s+Element (['"])#((?:(?!\1).)+)\1 not visible within\b/i;
+function parseTerminalIdWait(output, suppliedFailedStep) {
+    const lines = output.split('\n');
+    let terminalStep;
+    for (let index = 0; index < lines.length; index++) {
+        const match = RUNNER_STEP_RE.exec(lines[index]);
+        if (match)
+            terminalStep = { index, status: match[1], name: match[2] };
+    }
+    if (terminalStep?.status === '✓')
+        return null;
+    if (suppliedFailedStep && terminalStep && terminalStep.name !== suppliedFailedStep)
+        return null;
+    const failedStep = suppliedFailedStep ?? terminalStep?.name;
+    if (!failedStep || (terminalStep && terminalStep.status !== '✗'))
+        return null;
+    const stepMatch = ID_WAIT_STEP_RE.exec(failedStep);
+    if (!stepMatch)
+        return null;
+    const reasonLine = lines
+        .slice(terminalStep ? terminalStep.index + 1 : 0)
+        .filter((line) => REASON_LINE_RE.test(line))
+        .at(-1);
+    if (!reasonLine)
+        return null;
+    const reasonMatch = ID_WAIT_REASON_RE.exec(reasonLine);
+    if (!reasonMatch || reasonMatch[2] !== stepMatch[2])
+        return null;
+    return {
+        kind: 'SELECTOR_NOT_FOUND',
+        selectorKind: 'id',
+        selector: stepMatch[2],
+        raw: output,
+    };
+}
 export function parseMaestroFailure(output, terminal) {
     const raw = typeof output === 'string' ? output : '';
     if (terminal?.exitClass === 'timed-out') {
@@ -119,19 +147,19 @@ export function parseMaestroFailure(output, terminal) {
         return { kind: 'UNKNOWN', raw: '' };
     }
     output = raw;
+    const terminalIdWait = parseTerminalIdWait(output, terminal?.failedStep);
+    if (terminalIdWait)
+        return terminalIdWait;
     const lines = output.split('\n');
-    const terminalFailureLine = [...lines]
-        .reverse()
-        .find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) ||
-        /\bWait timed out\b/i.test(line) ||
-        PATTERNS.some(({ re }) => re.test(line)));
-    if (terminalFailureLine) {
-        for (const { re, build } of PATTERNS) {
-            const m = terminalFailureLine.match(re);
+    for (const { re, build } of PATTERNS) {
+        for (let i = lines.length - 1; i >= 0; i--) {
+            const line = lines[i];
+            if (!line)
+                continue;
+            const m = line.match(re);
             if (m)
                 return build(m, output);
         }
-        return { kind: 'UNKNOWN', raw: output };
     }
     // Fallback: whole-buffer scan for inputs without line breaks or for
     // any pattern that happens to straddle a `\n`.

--- a/packages/rn-dev-agent-core/dist/domain/maestro-step-parser.js
+++ b/packages/rn-dev-agent-core/dist/domain/maestro-step-parser.js
@@ -87,8 +87,8 @@ export function lastObservedStep(steps) {
 // Project parseMaestroFailure to {kind, selector}, DROPPING its `raw` field —
 // every MaestroFailure variant carries `raw` = the full unsliced output, which
 // must not be re-embedded into the result (it would defeat the output slice).
-export function summarizeReason(output) {
-    const f = parseMaestroFailure(output);
+export function summarizeReason(output, failedStep) {
+    const f = parseMaestroFailure(output, failedStep ? { failedStep } : undefined);
     if (f.kind === 'UNKNOWN' || f.kind === 'WDA_BOOTSTRAP_FAILED')
         return null;
     const selector = 'selector' in f ? (f.selector ?? null) : null;
@@ -99,10 +99,11 @@ export function summarizeReason(output) {
 // a PASSED run must not report a failedStep (mirrors parseMaestroFailure GH#118).
 export function buildStepSummary(output, opts) {
     const steps = parseSteps(output);
+    const failedStep = opts.failed ? findFailedStep(steps) : null;
     return {
         steps,
-        failedStep: opts.failed ? findFailedStep(steps) : null,
-        reason: opts.failed ? summarizeReason(output) : null,
+        failedStep,
+        reason: opts.failed ? summarizeReason(output, failedStep?.name) : null,
         lastStep: lastObservedStep(steps),
     };
 }

--- a/packages/rn-dev-agent-core/dist/domain/maestro-step-parser.js
+++ b/packages/rn-dev-agent-core/dist/domain/maestro-step-parser.js
@@ -41,7 +41,7 @@ const MAX_STEPS = 1000;
 export function combineRunnerOutput(stdout, stderr) {
     return (stdout + '\n' + stderr).replace(/^[\r\n]+/, '').trimEnd();
 }
-export function parseSteps(output) {
+function parseExactSteps(output) {
     if (!output || typeof output !== 'string')
         return [];
     const steps = [];
@@ -59,13 +59,19 @@ export function parseSteps(output) {
             continue;
         steps.push({
             index: index++,
-            name: cap(name),
+            name,
             verb,
             status: m[1] === '✓' ? 'pass' : 'fail',
             durationMs: Math.round(seconds * 1000),
         });
     }
     return steps.length > MAX_STEPS ? steps.slice(-MAX_STEPS) : steps;
+}
+function boundStep(step) {
+    return { ...step, name: cap(step.name) };
+}
+export function parseSteps(output) {
+    return parseExactSteps(output).map(boundStep);
 }
 // The TERMINAL failed step: the last parsed step iff it failed. maestro-runner
 // stops at the first real failure, so the terminal ✗ is the last parsed step; a
@@ -81,23 +87,36 @@ export function lastObservedStep(steps) {
 // Project parseMaestroFailure to {kind, selector}, DROPPING its `raw` field —
 // every MaestroFailure variant carries `raw` = the full unsliced output, which
 // must not be re-embedded into the result (it would defeat the output slice).
-export function summarizeReason(output, failedStep) {
+function summarizeExactReason(output, failedStep) {
     const f = parseMaestroFailure(output, failedStep ? { failedStep } : undefined);
     if (f.kind === 'UNKNOWN' || f.kind === 'WDA_BOOTSTRAP_FAILED')
         return null;
     const selector = 'selector' in f ? (f.selector ?? null) : null;
-    return { kind: f.kind, selector: selector === null ? null : cap(selector) };
+    return { kind: f.kind, selector };
+}
+export function summarizeReason(output, failedStep) {
+    const reason = summarizeExactReason(output, failedStep);
+    if (!reason)
+        return null;
+    return { ...reason, selector: reason.selector === null ? null : cap(reason.selector) };
 }
 // failedStep/reason are populated ONLY when the run's terminal verdict is fail
 // (opts.failed). maestro-runner logs transient retries; a fail-then-retry-✓ on
 // a PASSED run must not report a failedStep (mirrors parseMaestroFailure GH#118).
 export function buildStepSummary(output, opts) {
-    const steps = parseSteps(output);
-    const failedStep = opts.failed ? findFailedStep(steps) : null;
+    const exactSteps = parseExactSteps(output);
+    const exactFailedStep = opts.failed ? findFailedStep(exactSteps) : null;
+    const exactReason = opts.failed ? summarizeExactReason(output, exactFailedStep?.name) : null;
+    const steps = exactSteps.map(boundStep);
     return {
         steps,
-        failedStep,
-        reason: opts.failed ? summarizeReason(output, failedStep?.name) : null,
+        failedStep: exactFailedStep ? boundStep(exactFailedStep) : null,
+        reason: exactReason
+            ? {
+                ...exactReason,
+                selector: exactReason.selector === null ? null : cap(exactReason.selector),
+            }
+            : null,
         lastStep: lastObservedStep(steps),
     };
 }
@@ -112,7 +131,9 @@ function isWdaFailureLine(line) {
     return WDA_TOKEN_RE.test(line) && WDA_FAILURE_RE.test(line);
 }
 export function buildTerminalEvidence(output, opts = {}) {
-    const summary = buildStepSummary(output, { failed: true });
+    const exactSteps = parseExactSteps(output);
+    const failedStep = findFailedStep(exactSteps);
+    const reason = summarizeExactReason(output, failedStep?.name);
     const bootstrapEvidence = stripAnsi(output)
         .split('\n')
         .filter((line) => isWdaFailureLine(line))
@@ -122,18 +143,18 @@ export function buildTerminalEvidence(output, opts = {}) {
         ? 'timed-out'
         : opts.spawnError
             ? 'spawn-error'
-            : summary.steps.length === 0
+            : exactSteps.length === 0
                 ? 'before-first-step'
                 : 'step-failure';
     return {
-        completedSteps: summary.steps.filter((step) => step.status === 'pass').length,
-        ...(summary.failedStep ? { failedStep: summary.failedStep.name } : {}),
+        completedSteps: exactSteps.filter((step) => step.status === 'pass').length,
+        ...(failedStep ? { failedStep: failedStep.name } : {}),
         exitClass,
         ...(bootstrapEvidence ? { bootstrapEvidence } : {}),
-        ...(summary.reason
+        ...(reason
             ? {
-                failureKind: summary.reason.kind,
-                failureSelector: summary.reason.selector,
+                failureKind: reason.kind,
+                failureSelector: reason.selector,
             }
             : {}),
     };

--- a/packages/rn-dev-agent-core/dist/domain/maestro-step-parser.js
+++ b/packages/rn-dev-agent-core/dist/domain/maestro-step-parser.js
@@ -3,14 +3,8 @@
 // I/O, fail-open: unparseable output yields []. Generalizes the #263 step-line
 // parser (tap-latency.ts derives parseTapLatencies from parseSteps).
 import { parseMaestroFailure } from './maestro-error-parser.js';
-// Strip ANSI SGR/color escape sequences. execFile output is usually un-colored
-// (child stdout is a pipe, not a TTY) but maestro-runner is not guaranteed to
-// honor that, and a glyph-anchored match breaks on a colored `✓`. Built via
-// fromCharCode(27) (ESC) to keep a raw control char out of the source/regex.
-const ANSI_RE = new RegExp(String.fromCharCode(27) + '\\[[0-9;]*m', 'g');
-export function stripAnsi(s) {
-    return s.replace(ANSI_RE, '');
-}
+import { stripAnsi } from './ansi.js';
+export { stripAnsi } from './ansi.js';
 // `<indent>{✓|✗} <name> (N.Ns)` — the leading `[ \t]+` anchors on the runner's
 // line shape: real steps are indented with spaces (live renderer: 4 spaces,
 // nested runFlow sub-steps 6+), so an unindented (column-0) line shaped like a

--- a/packages/rn-dev-agent-core/dist/tools/cdp-replay-dispatch.js
+++ b/packages/rn-dev-agent-core/dist/tools/cdp-replay-dispatch.js
@@ -1,5 +1,5 @@
 import { parse as yamlParse } from 'yaml';
-import { normalizeSteps, replayFlow, firstTestId, } from '../domain/cdp-flow-replay.js';
+import { normalizeSteps, replayFlow, firstTestId, findResumeAnchor, } from '../domain/cdp-flow-replay.js';
 export function firstReplayTestId(bodyYaml, params) {
     try {
         const parsed = yamlParse(bodyYaml);
@@ -69,10 +69,27 @@ function isDisabled(props) {
     const a11y = props.accessibilityState;
     return props.disabled === true || a11y?.disabled === true || props.pointerEvents === 'none';
 }
-export async function runCdpReplay(bodyYaml, params, deps) {
+/**
+ * GH #580: `resumeAtSelector` replays only the suffix from the step targeting that
+ * selector. The anchor is found on the RAW body and normalization applies to the
+ * suffix alone, so unsupported commands in the executed prefix stop disqualifying
+ * the whole action. A refused anchor keeps start-at-zero.
+ */
+export async function runCdpReplay(bodyYaml, params, deps, opts = {}) {
     const parsed = yamlParse(bodyYaml);
-    const steps = normalizeSteps(parsed, params);
-    return replayFlow(steps, buildCdpDispatch(deps));
+    const resume = resolveResume(parsed, params, opts.resumeAtSelector);
+    const startIndex = resume.applied ? resume.startIndex : 0;
+    const steps = normalizeSteps(startIndex === 0 ? parsed : parsed.slice(startIndex), params);
+    const result = await replayFlow(steps, buildCdpDispatch(deps), { indexOffset: startIndex });
+    return { ...result, resume };
+}
+function resolveResume(parsed, params, selector) {
+    if (!selector || !Array.isArray(parsed))
+        return { applied: false, reason: 'not-requested' };
+    const anchor = findResumeAnchor(parsed, params, selector);
+    return anchor.found
+        ? { applied: true, selector, startIndex: anchor.index }
+        : { applied: false, reason: anchor.reason };
 }
 export function buildCdpDispatch(deps) {
     return {

--- a/packages/rn-dev-agent-core/dist/tools/run-action.js
+++ b/packages/rn-dev-agent-core/dist/tools/run-action.js
@@ -775,6 +775,10 @@ export function createRunActionHandler(deps = {}) {
             const retryPassed = retryEnv.ok === true && retryEnv.data?.passed === true;
             const retryOutput = readMaestroOutput(retryEnv);
             const retryFailureDetail = readMaestroFailureDetail(retryEnv, retryOutput);
+            const retryTerminal = readMaestroTerminal(retryEnv);
+            const retryFailure = !retryPassed
+                ? parseMaestroFailure(retryOutput, retryTerminal)
+                : undefined;
             const retryDeviceAuthority = readMaestroDeviceAuthority(retryEnv);
             probeDeviceId = retryDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
             if (retryEnv.code === 'DEVICE_AUTHORITY_MISMATCH') {
@@ -810,18 +814,10 @@ export function createRunActionHandler(deps = {}) {
             // when retry failed; same-selector failures (= patch didn't work)
             // are implicit in the existing diff.
             let nextFailedSelector;
-            if (!retryPassed) {
-                try {
-                    const retryFailure = parseMaestroFailure(retryOutput, readMaestroTerminal(retryEnv));
-                    if (retryFailure.kind === 'SELECTOR_NOT_FOUND' &&
-                        retryFailure.selector &&
-                        retryFailure.selector !== repairData.newSelector) {
-                        nextFailedSelector = retryFailure.selector;
-                    }
-                }
-                catch {
-                    /* best-effort — don't fail the run because the parser hiccuped */
-                }
+            if (retryFailure?.kind === 'SELECTOR_NOT_FOUND' &&
+                retryFailure.selector &&
+                retryFailure.selector !== repairData.newSelector) {
+                nextFailedSelector = retryFailure.selector;
             }
             const autoRepair = {
                 attempted: true,
@@ -867,6 +863,11 @@ export function createRunActionHandler(deps = {}) {
                 firstAttemptOutput: boundedOutput(firstOutput),
                 retryOutput: boundedOutput(retryOutput),
                 underlyingFailure: retryFailureDetail,
+                ...(retryFailure ? { failureKind: retryFailure.kind } : {}),
+                ...(retryFailure && 'selector' in retryFailure && retryFailure.selector
+                    ? { failureSelector: retryFailure.selector }
+                    : {}),
+                terminal: retryTerminal,
             });
         }
         catch (err) {

--- a/packages/rn-dev-agent-core/dist/tools/run-action.js
+++ b/packages/rn-dev-agent-core/dist/tools/run-action.js
@@ -779,6 +779,7 @@ export function createRunActionHandler(deps = {}) {
             const retryFailure = !retryPassed
                 ? parseMaestroFailure(retryOutput, retryTerminal)
                 : undefined;
+            const retryClassification = retryFailure ? classifyFailure(retryFailure) : undefined;
             const retryDeviceAuthority = readMaestroDeviceAuthority(retryEnv);
             probeDeviceId = retryDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
             if (retryEnv.code === 'DEVICE_AUTHORITY_MISMATCH') {
@@ -837,7 +838,7 @@ export function createRunActionHandler(deps = {}) {
                 timestamp: new Date().toISOString(),
                 durationMs: Date.now() - t0,
                 status: retryPassed ? 'pass' : 'fail',
-                failureCode: retryPassed ? undefined : 'SELECTOR_NOT_FOUND',
+                failureCode: retryClassification?.actionCode,
                 failureDetail: retryPassed ? undefined : retryFailureDetail.slice(0, 1000),
                 trigger,
                 autoRepair,
@@ -856,7 +857,8 @@ export function createRunActionHandler(deps = {}) {
                     retryOutput: boundedOutput(retryOutput),
                 });
             }
-            return failResult(`cdp_run_action: ${args.actionId} still failing after auto-repair (${repairData.oldSelector} → ${repairData.newSelector}): ${retryFailureDetail}`, 'TESTID_NOT_FOUND', {
+            const retryMessage = `cdp_run_action: ${args.actionId} still failing after auto-repair (${repairData.oldSelector} → ${repairData.newSelector}): ${retryFailureDetail}`;
+            const retryMeta = {
                 actionId: args.actionId,
                 autoRepair,
                 writes: writeDisclosure('auto-repair', persisted),
@@ -868,7 +870,10 @@ export function createRunActionHandler(deps = {}) {
                     ? { failureSelector: retryFailure.selector }
                     : {}),
                 terminal: retryTerminal,
-            });
+            };
+            return retryClassification?.toolCode
+                ? failResult(retryMessage, retryClassification.toolCode, retryMeta)
+                : failResult(retryMessage, retryMeta);
         }
         catch (err) {
             if (err instanceof SessionAuthorityError)

--- a/packages/rn-dev-agent-core/dist/tools/run-action.js
+++ b/packages/rn-dev-agent-core/dist/tools/run-action.js
@@ -118,19 +118,50 @@ function readMaestroDeviceAuthority(env) {
         return env.data.deviceAuthority;
     return env.meta?.deviceAuthority;
 }
+function terminalReason(terminal) {
+    if (!terminal?.failureKind)
+        return '';
+    return ` (${terminal.failureKind}${terminal.failureSelector ? `: ${terminal.failureSelector}` : ''})`;
+}
 /**
  * maestro_run builds its headline from the full runner stream before slicing
  * data.output/meta.output. Keep that headline as the authoritative failure
  * detail so cdp_run_action never reduces a useful terminal step to UNKNOWN just
  * because the report preamble consumed the bounded output field.
+ *
+ * GH #580: the WARN path (runner exit 0 with failures) carries no `env.error` and
+ * puts its step summary in `data`, not `meta`, so it degraded to a bare slice.
  */
 function readMaestroFailureDetail(env, output) {
     if (typeof env.error === 'string' && env.error.trim())
         return env.error.trim();
-    const failedStep = env.meta?.failedStep;
-    if (typeof failedStep?.name === 'string')
-        return `Maestro flow failed at step "${failedStep.name}"`;
-    return output.trim().slice(0, 1000) || 'Maestro runner returned no failure detail';
+    const terminal = readMaestroTerminal(env);
+    const reason = terminalReason(terminal);
+    const metaStep = env.meta?.failedStep;
+    const dataStep = env.data?.failedStep;
+    const stepName = typeof metaStep?.name === 'string'
+        ? metaStep.name
+        : typeof dataStep?.name === 'string'
+            ? dataStep.name
+            : terminal?.failedStep;
+    if (stepName)
+        return `Maestro flow failed at step "${stepName}"${reason}`;
+    if (reason)
+        return `Maestro flow failed${reason.trim()}`;
+    return boundedOutput(output.trim(), 1000) || 'Maestro runner returned no failure detail';
+}
+// GH #580 defect 3: the terminal failure sits at the TAIL of runner stdout while
+// the head carries the WDA preamble, so a head-only slice showed only the preamble.
+// Over-budget input always returns exactly `budget` characters.
+const OUTPUT_BUDGET = 500;
+const OUTPUT_ELISION = '\n…\n';
+export function boundedOutput(output, budget = OUTPUT_BUDGET) {
+    const text = typeof output === 'string' ? output : '';
+    if (text.length <= budget)
+        return text;
+    const room = budget - OUTPUT_ELISION.length;
+    const head = Math.ceil(room / 2);
+    return text.slice(0, head) + OUTPUT_ELISION + text.slice(text.length - (room - head));
 }
 /**
  * Map repair-action's failResult code → an AutoRepairRefusedReason.
@@ -453,7 +484,7 @@ export function createRunActionHandler(deps = {}) {
                     writes: writeDisclosure(promotionDisclosure(persisted), persisted),
                     durationMs: Date.now() - t0,
                     flowFile: action.filePath,
-                    firstAttemptOutput: firstOutput.slice(0, 500),
+                    firstAttemptOutput: boundedOutput(firstOutput),
                 });
             }
             // ─── First attempt failed — classify ─────────────────────────────
@@ -528,8 +559,23 @@ export function createRunActionHandler(deps = {}) {
                         };
                     }
                     else {
+                        // GH #580: what Maestro actually reported, carried onto every fallback
+                        // failure return so the caller never has to re-derive it from stdout.
+                        const maestroEvidence = {
+                            failureKind: failure.kind,
+                            ...(failure.kind === 'SELECTOR_NOT_FOUND'
+                                ? { failureSelector: failure.selector }
+                                : {}),
+                            underlyingFailure: firstFailureDetail,
+                            terminal: readMaestroTerminal(firstEnv),
+                            firstAttemptOutput: boundedOutput(firstOutput),
+                        };
                         try {
-                            const replay = await runCdpReplay(action.body, args.params ?? {}, replayDeps);
+                            // GH #580: resume at the proven failed selector; UNKNOWN failed before
+                            // any step, so it keeps start-at-zero.
+                            const replay = await runCdpReplay(action.body, args.params ?? {}, replayDeps, {
+                                resumeAtSelector: failure.kind === 'SELECTOR_NOT_FOUND' ? failure.selector : null,
+                            });
                             const status = replay.passed ? 'pass' : 'fail';
                             const autoRepair = {
                                 attempted: false,
@@ -562,17 +608,20 @@ export function createRunActionHandler(deps = {}) {
                                     writes: writeDisclosure(promotionDisclosure(persisted), persisted),
                                     durationMs: Date.now() - t0,
                                     flowFile: action.filePath,
+                                    resume: replay.resume,
                                 });
                             }
                             return failResult(`cdp_run_action: ${args.actionId} replayed via CDP/JS (WDA transport-blind) and failed at step ${replay.failedStepIndex}: ${replay.reason}`, 'TRANSPORT_BLIND', {
                                 actionId: args.actionId,
                                 transport: 'cdp-js',
                                 failedStepIndex: replay.failedStepIndex,
+                                resume: replay.resume,
+                                ...maestroEvidence,
                             });
                         }
                         catch (e) {
                             if (e instanceof UnsupportedStepError) {
-                                return failResult(`cdp_run_action: ${args.actionId} cannot replay via CDP/JS — ${e.message}. This action uses a step type the iOS 26.x fallback doesn't support; run on iOS 18 (WDA works there).`, 'UNSUPPORTED_STEP', { actionId: args.actionId, stepKey: e.stepKey });
+                                return failResult(`cdp_run_action: ${args.actionId} cannot replay via CDP/JS — ${e.message}. This action uses a step type the iOS 26.x fallback doesn't support; run on iOS 18 (WDA works there).`, 'UNSUPPORTED_STEP', { actionId: args.actionId, stepKey: e.stepKey, ...maestroEvidence });
                             }
                             throw e;
                         }
@@ -610,9 +659,14 @@ export function createRunActionHandler(deps = {}) {
                 const meta = {
                     actionId: args.actionId,
                     failureKind: failure.kind,
+                    // GH #580: the selector belongs in the envelope structurally, not only
+                    // inside the human headline the caller would have to re-parse.
+                    ...('selector' in failure && failure.selector
+                        ? { failureSelector: failure.selector }
+                        : {}),
                     underlyingFailure: firstFailureDetail,
                     autoRepair,
-                    firstAttemptOutput: firstOutput.slice(0, 500),
+                    firstAttemptOutput: boundedOutput(firstOutput),
                     terminal: readMaestroTerminal(firstEnv),
                     runnerResume: firstEnv.meta?.runnerResume,
                     ...(cdpJsFallback ? { cdpJsFallback } : {}),
@@ -660,15 +714,21 @@ export function createRunActionHandler(deps = {}) {
                     durationMs: Date.now() - t0,
                     status: 'fail',
                     failureCode: 'SELECTOR_NOT_FOUND',
-                    failureDetail: firstOutput.slice(0, 500),
+                    // GH #580: the structured detail carries kind + selector; the bounded
+                    // stdout slice can lose the failing line to later runner narration.
+                    failureDetail: firstFailureDetail.slice(0, 1000),
                     trigger,
                     autoRepair,
                 });
-                return failResult(`cdp_run_action: ${args.actionId} failed with SELECTOR_NOT_FOUND; auto-repair refused (${refusedReason}): ${repairEnv.error ?? 'unknown'}`, refusedReason === 'TRANSPORT_BLIND' ? 'TRANSPORT_BLIND' : 'TESTID_NOT_FOUND', {
+                return failResult(`cdp_run_action: ${args.actionId} failed with SELECTOR_NOT_FOUND (${failure.selector}); auto-repair refused (${refusedReason}): ${repairEnv.error ?? 'unknown'}`, refusedReason === 'TRANSPORT_BLIND' ? 'TRANSPORT_BLIND' : 'TESTID_NOT_FOUND', {
                     actionId: args.actionId,
+                    failureKind: failure.kind,
+                    failureSelector: failure.selector,
+                    underlyingFailure: firstFailureDetail,
+                    terminal: readMaestroTerminal(firstEnv),
                     autoRepair,
                     repairError: repairEnv.error,
-                    firstAttemptOutput: firstOutput.slice(0, 500),
+                    firstAttemptOutput: boundedOutput(firstOutput),
                 });
             }
             // ─── Repair succeeded — replay once ──────────────────────────────
@@ -797,15 +857,15 @@ export function createRunActionHandler(deps = {}) {
                     durationMs: Date.now() - t0,
                     flowFile: reloadedAction.filePath,
                     retriedAfterRepair: true,
-                    retryOutput: retryOutput.slice(0, 500),
+                    retryOutput: boundedOutput(retryOutput),
                 });
             }
             return failResult(`cdp_run_action: ${args.actionId} still failing after auto-repair (${repairData.oldSelector} → ${repairData.newSelector}): ${retryFailureDetail}`, 'TESTID_NOT_FOUND', {
                 actionId: args.actionId,
                 autoRepair,
                 writes: writeDisclosure('auto-repair', persisted),
-                firstAttemptOutput: firstOutput.slice(0, 500),
-                retryOutput: retryOutput.slice(0, 500),
+                firstAttemptOutput: boundedOutput(firstOutput),
+                retryOutput: boundedOutput(retryOutput),
                 underlyingFailure: retryFailureDetail,
             });
         }

--- a/packages/rn-dev-agent-core/src/domain/ansi.ts
+++ b/packages/rn-dev-agent-core/src/domain/ansi.ts
@@ -1,0 +1,5 @@
+const ANSI_RE = new RegExp(String.fromCharCode(27) + '\\[[0-9;]*m', 'g');
+
+export function stripAnsi(value: string): string {
+  return value.replace(ANSI_RE, '');
+}

--- a/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
+++ b/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
@@ -25,7 +25,7 @@ export interface ReplayResult {
   passed: boolean;
   failedStepIndex?: number;
   reason?: string;
-  steps: { t: string; target?: string; ok: boolean }[];
+  steps: { sourceIndex: number; t: string; target?: string; ok: boolean }[];
 }
 
 const interp = (s: string, p: Record<string, string>): string =>
@@ -184,15 +184,16 @@ export async function replayFlow(
   dispatch: ReplayDispatch,
   // GH #580: a resumed suffix reports SOURCE step indices, not suffix-relative
   // ones, so TRANSPORT_BLIND messages and failedStepIndex stay honest.
-  opts: { indexOffset?: number } = {},
+  opts: { indexOffset?: number; sourceIndex?: number } = {},
 ): Promise<ReplayResult> {
   const offset = opts.indexOffset ?? 0;
   const trace: ReplayResult['steps'] = [];
   let lastTapped: string | null = null;
+  const sourceIndex = (i: number): number => opts.sourceIndex ?? i + offset;
 
   const fail = (i: number, reason: string): ReplayResult => ({
     passed: false,
-    failedStepIndex: i + offset,
+    failedStepIndex: sourceIndex(i),
     reason,
     steps: trace,
   });
@@ -203,49 +204,59 @@ export async function replayFlow(
       switch (s.t) {
         case 'launch':
           await dispatch.launch(s.stopApp);
-          trace.push({ t: s.t, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, ok: true });
           break;
         case 'tap':
           await dispatch.press(s.id);
           lastTapped = s.id;
-          trace.push({ t: s.t, target: s.id, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, target: s.id, ok: true });
           break;
         case 'type': {
           if (!lastTapped) return fail(i, 'inputText before any tapOn — no focus target');
           await dispatch.type(lastTapped, s.text);
-          trace.push({ t: s.t, target: lastTapped, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, target: lastTapped, ok: true });
           break;
         }
         case 'assert': {
           const ok = await dispatch.isVisible(s.id);
-          trace.push({ t: s.t, target: s.id, ok });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, target: s.id, ok });
           if (!ok) return fail(i, `assertVisible: "${s.id}" not present in CDP tree`);
           break;
         }
         case 'wait':
           await dispatch.settle();
-          trace.push({ t: s.t, ok: true });
+          trace.push({ sourceIndex: sourceIndex(i), t: s.t, ok: true });
           break;
         case 'runFlow': {
           if (await dispatch.isVisible(s.whenVisible)) {
-            const sub = await replayFlow(s.commands, dispatch);
+            const sub = await replayFlow(s.commands, dispatch, { sourceIndex: sourceIndex(i) });
             trace.push(...sub.steps);
             if (!sub.passed) {
               return {
                 passed: false,
-                failedStepIndex: i + offset,
+                failedStepIndex: sourceIndex(i),
                 reason: sub.reason,
                 steps: trace,
               };
             }
           } else {
-            trace.push({ t: s.t, target: s.whenVisible, ok: true });
+            trace.push({
+              sourceIndex: sourceIndex(i),
+              t: s.t,
+              target: s.whenVisible,
+              ok: true,
+            });
           }
           break;
         }
       }
     } catch (e) {
-      trace.push({ t: s.t, target: 'id' in s ? s.id : undefined, ok: false });
+      trace.push({
+        sourceIndex: sourceIndex(i),
+        t: s.t,
+        target: 'id' in s ? s.id : undefined,
+        ok: false,
+      });
       return fail(i, e instanceof Error ? e.message : String(e));
     }
   }

--- a/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
+++ b/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
@@ -179,11 +179,10 @@ export function findResumeAnchor(
     : { found: true, index: scan.hits[0].index };
 }
 
+// GH #580: resumed suffixes report source indices, not suffix-relative indices.
 export async function replayFlow(
   steps: ReplayStep[],
   dispatch: ReplayDispatch,
-  // GH #580: a resumed suffix reports SOURCE step indices, not suffix-relative
-  // ones, so TRANSPORT_BLIND messages and failedStepIndex stay honest.
   opts: { indexOffset?: number; sourceIndex?: number } = {},
 ): Promise<ReplayResult> {
   const offset = opts.indexOffset ?? 0;

--- a/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
+++ b/packages/rn-dev-agent-core/src/domain/cdp-flow-replay.ts
@@ -49,9 +49,23 @@ export function normalizeSteps(body: unknown[], params: Record<string, string>):
     const key = keys[0];
     const v = raw[key];
     switch (key) {
-      case 'launchApp':
+      case 'launchApp': {
+        // GH #580: `simctl launch` cannot clear state (that needs uninstall +
+        // reinstall), so an unhonorable key must refuse, not silently drop.
+        if (isObj(v)) {
+          const unsupported = Object.keys(v).filter((k) => k !== 'stopApp');
+          if (unsupported.length > 0)
+            throw new UnsupportedStepError(
+              `launchApp (unsupported keys: ${unsupported.sort().join(', ')})`,
+            );
+          // A non-boolean stopApp would coerce to false — different launch
+          // semantics than the author wrote, which is the same silent lie.
+          if ('stopApp' in v && typeof v.stopApp !== 'boolean')
+            throw new UnsupportedStepError('launchApp (stopApp must be a boolean)');
+        }
         out.push({ t: 'launch', stopApp: isObj(v) && v.stopApp === true });
         break;
+      }
       case 'tapOn': {
         const id = isObj(v) ? asString(v.id) : null;
         if (!id) throw new UnsupportedStepError('tapOn (missing string id)');
@@ -100,16 +114,85 @@ export function firstTestId(steps: ReplayStep[]): string | null {
   return null;
 }
 
+export type ResumeAnchor =
+  | { found: true; index: number }
+  | { found: false; reason: 'no-match' | 'ambiguous' | 'nested-match' | 'too-deep' };
+
+// Bound the walk so a pathologically nested action body cannot stall the scan.
+const MAX_ANCHOR_DEPTH = 20;
+
+interface AnchorScan {
+  /** One entry per `id:` occurrence; true when it sits under a `commands:` list. */
+  hits: { index: number; nested: boolean }[];
+  /** The walk hit MAX_ANCHOR_DEPTH, so a deeper duplicate may be unseen. */
+  truncated: boolean;
+}
+
+// Counted, not OR-ed: two matches inside one step must stay detectably ambiguous.
+function countIdHits(
+  node: unknown,
+  params: Record<string, string>,
+  selector: string,
+  index: number,
+  depth: number,
+  nested: boolean,
+  scan: AnchorScan,
+): void {
+  if (depth > MAX_ANCHOR_DEPTH) {
+    scan.truncated = true;
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) countIdHits(child, params, selector, index, depth + 1, nested, scan);
+    return;
+  }
+  if (!isObj(node)) return;
+  for (const [key, value] of Object.entries(node)) {
+    if (key === 'id' && typeof value === 'string' && interp(value, params) === selector) {
+      scan.hits.push({ index, nested });
+      continue;
+    }
+    countIdHits(value, params, selector, index, depth + 1, nested || key === 'commands', scan);
+  }
+}
+
+/**
+ * GH #580: locate the one source step targeting `selector` so a reactive fallback
+ * resumes there instead of replaying already-executed mutations. Anything but a
+ * single top-level occurrence refuses — resuming at an enclosing `runFlow` would
+ * redispatch the siblings preceding a nested match, and a truncated walk cannot
+ * prove a deeper duplicate does not exist.
+ */
+export function findResumeAnchor(
+  body: unknown[],
+  params: Record<string, string>,
+  selector: string,
+): ResumeAnchor {
+  if (!selector) return { found: false, reason: 'no-match' };
+  const scan: AnchorScan = { hits: [], truncated: false };
+  body.forEach((raw, index) => countIdHits(raw, params, selector, index, 0, false, scan));
+  if (scan.truncated) return { found: false, reason: 'too-deep' };
+  if (scan.hits.length === 0) return { found: false, reason: 'no-match' };
+  if (scan.hits.length > 1) return { found: false, reason: 'ambiguous' };
+  return scan.hits[0].nested
+    ? { found: false, reason: 'nested-match' }
+    : { found: true, index: scan.hits[0].index };
+}
+
 export async function replayFlow(
   steps: ReplayStep[],
   dispatch: ReplayDispatch,
+  // GH #580: a resumed suffix reports SOURCE step indices, not suffix-relative
+  // ones, so TRANSPORT_BLIND messages and failedStepIndex stay honest.
+  opts: { indexOffset?: number } = {},
 ): Promise<ReplayResult> {
+  const offset = opts.indexOffset ?? 0;
   const trace: ReplayResult['steps'] = [];
   let lastTapped: string | null = null;
 
   const fail = (i: number, reason: string): ReplayResult => ({
     passed: false,
-    failedStepIndex: i,
+    failedStepIndex: i + offset,
     reason,
     steps: trace,
   });
@@ -150,7 +233,7 @@ export async function replayFlow(
             if (!sub.passed) {
               return {
                 passed: false,
-                failedStepIndex: i,
+                failedStepIndex: i + offset,
                 reason: sub.reason,
                 steps: trace,
               };

--- a/packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts
+++ b/packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts
@@ -111,6 +111,37 @@ const REASON_LINE_RE = /^[ \t]+╰─\s+/;
 const ID_WAIT_STEP_RE = /^extendedWaitUntil:\s+visible\s+id=(['"])((?:(?!\1).)+)\1$/i;
 const ID_WAIT_REASON_RE = /^[ \t]+╰─\s+Element (['"])#((?:(?!\1).)+)\1 not visible within\b/i;
 
+// The reason lines belonging to one step block: everything up to the next step line.
+function blockReasons(lines: string[], stepIndex: number): string[] {
+  const reasons: string[] = [];
+  for (let i = stepIndex + 1; i < lines.length; i++) {
+    if (RUNNER_STEP_RE.test(lines[i])) break;
+    if (REASON_LINE_RE.test(lines[i])) reasons.push(lines[i]);
+  }
+  return reasons;
+}
+
+// GH #580: maestro-runner 1.1.20 can render ONE failure as two blocks — a detailed
+// step naming the id, then a selector-less summary repeating the identical reason.
+// Requiring a byte-identical reason is what makes borrowing that id safe.
+function idWaitStepAmongDuplicates(
+  lines: string[],
+  terminalIndex: number,
+  terminalReason: string,
+): RegExpExecArray | null {
+  for (let i = terminalIndex - 1; i >= 0; i--) {
+    const step = RUNNER_STEP_RE.exec(lines[i]);
+    if (!step) continue;
+    // A passing step, or a failure whose own reason differs, ends the duplicate
+    // chain: only a block repeating this exact reason is the same failure.
+    if (step[1] !== '✗') return null;
+    if (!blockReasons(lines, i).includes(terminalReason)) return null;
+    const stepMatch = ID_WAIT_STEP_RE.exec(step[2]);
+    if (stepMatch) return stepMatch;
+  }
+  return null;
+}
+
 function parseTerminalIdWait(
   output: string,
   suppliedFailedStep: string | undefined,
@@ -125,15 +156,17 @@ function parseTerminalIdWait(
   if (suppliedFailedStep && terminalStep && terminalStep.name !== suppliedFailedStep) return null;
   const failedStep = suppliedFailedStep ?? terminalStep?.name;
   if (!failedStep || (terminalStep && terminalStep.status !== '✗')) return null;
-  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep);
-  if (!stepMatch) return null;
   const reasonLine = lines
     .slice(terminalStep ? terminalStep.index + 1 : 0)
     .filter((line) => REASON_LINE_RE.test(line))
     .at(-1);
   if (!reasonLine) return null;
   const reasonMatch = ID_WAIT_REASON_RE.exec(reasonLine);
-  if (!reasonMatch || reasonMatch[2] !== stepMatch[2]) return null;
+  if (!reasonMatch) return null;
+  const stepMatch =
+    ID_WAIT_STEP_RE.exec(failedStep) ??
+    (terminalStep ? idWaitStepAmongDuplicates(lines, terminalStep.index, reasonLine) : null);
+  if (!stepMatch || reasonMatch[2] !== stepMatch[2]) return null;
   return {
     kind: 'SELECTOR_NOT_FOUND',
     selectorKind: 'id',

--- a/packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts
+++ b/packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts
@@ -33,6 +33,7 @@ export type MaestroFailure =
 
 export interface MaestroTerminalClassification {
   exitClass?: 'before-first-step' | 'step-failure' | 'timed-out' | 'spawn-error';
+  failedStep?: string;
   bootstrapEvidence?: string;
   failureKind?: 'SELECTOR_NOT_FOUND' | 'TIMEOUT' | 'ASSERTION_FAILED';
   failureSelector?: string | null;
@@ -76,16 +77,6 @@ const PATTERNS: Pattern[] = [
     re: /Element not found:\s*text=(['"])((?:(?!\1).)+)\1/i,
     build: (m, raw) => ({ kind: 'SELECTOR_NOT_FOUND', selectorKind: 'text', selector: m[2], raw }),
   },
-  // maestro-runner 1.1.16/1.1.20 ID-wait shape — issue #580.
-  // "Element '#X' not visible within 1s (cause: context deadline exceeded)".
-  // The `#` immediately after the opening quote is the runner's ID-selector
-  // marker: text and regex waits render without it and keep their current
-  // classification (issue #334 owns those). Process/global timeouts never reach
-  // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
-  {
-    re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
-    build: (m, raw) => ({ kind: 'SELECTOR_NOT_FOUND', selectorKind: 'id', selector: m[2], raw }),
-  },
   {
     re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
     build: (m, raw) => ({
@@ -112,6 +103,43 @@ const PATTERNS: Pattern[] = [
     build: (m, raw) => ({ kind: 'ASSERTION_FAILED', selector: m[2], raw }),
   },
 ];
+
+const RUNNER_STEP_RE = /^[ \t]+([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
+const REASON_LINE_RE = /^[ \t]+╰─\s+/;
+const ID_WAIT_STEP_RE = /^extendedWaitUntil:\s+visible\s+id=(['"])((?:(?!\1).)+)\1$/i;
+const ID_WAIT_REASON_RE =
+  /^[ \t]+╰─\s+Element (['"])#((?:(?!\1).)+)\1 not visible within\b/i;
+
+function parseTerminalIdWait(
+  output: string,
+  suppliedFailedStep: string | undefined,
+): MaestroFailure | null {
+  const lines = output.split('\n');
+  let terminalStep: { index: number; status: string; name: string } | undefined;
+  for (let index = 0; index < lines.length; index++) {
+    const match = RUNNER_STEP_RE.exec(lines[index]);
+    if (match) terminalStep = { index, status: match[1], name: match[2] };
+  }
+  if (terminalStep?.status === '✓') return null;
+  if (suppliedFailedStep && terminalStep && terminalStep.name !== suppliedFailedStep) return null;
+  const failedStep = suppliedFailedStep ?? terminalStep?.name;
+  if (!failedStep || (terminalStep && terminalStep.status !== '✗')) return null;
+  const stepMatch = ID_WAIT_STEP_RE.exec(failedStep);
+  if (!stepMatch) return null;
+  const reasonLine = lines
+    .slice(terminalStep ? terminalStep.index + 1 : 0)
+    .filter((line) => REASON_LINE_RE.test(line))
+    .at(-1);
+  if (!reasonLine) return null;
+  const reasonMatch = ID_WAIT_REASON_RE.exec(reasonLine);
+  if (!reasonMatch || reasonMatch[2] !== stepMatch[2]) return null;
+  return {
+    kind: 'SELECTOR_NOT_FOUND',
+    selectorKind: 'id',
+    selector: stepMatch[2],
+    raw: output,
+  };
+}
 
 export function parseMaestroFailure(
   output: string,
@@ -148,21 +176,16 @@ export function parseMaestroFailure(
     return { kind: 'UNKNOWN', raw: '' };
   }
   output = raw;
+  const terminalIdWait = parseTerminalIdWait(output, terminal?.failedStep);
+  if (terminalIdWait) return terminalIdWait;
   const lines = output.split('\n');
-  const terminalFailureLine = [...lines]
-    .reverse()
-    .find(
-      (line) =>
-        /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) ||
-        /\bWait timed out\b/i.test(line) ||
-        PATTERNS.some(({ re }) => re.test(line)),
-    );
-  if (terminalFailureLine) {
-    for (const { re, build } of PATTERNS) {
-      const m = terminalFailureLine.match(re);
+  for (const { re, build } of PATTERNS) {
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i];
+      if (!line) continue;
+      const m = line.match(re);
       if (m) return build(m as RegExpExecArray, output);
     }
-    return { kind: 'UNKNOWN', raw: output };
   }
   // Fallback: whole-buffer scan for inputs without line breaks or for
   // any pattern that happens to straddle a `\n`.

--- a/packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts
+++ b/packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts
@@ -1,3 +1,5 @@
+import { stripAnsi } from './ansi.js';
+
 // Issue #104 — pure parser for Maestro CLI / maestro-runner failure output.
 //
 // `maestro_run` returns the combined stdout+stderr in `data.output`. To
@@ -114,7 +116,7 @@ function parseTerminalIdWait(
   output: string,
   suppliedFailedStep: string | undefined,
 ): MaestroFailure | null {
-  const lines = output.split('\n');
+  const lines = stripAnsi(output).split('\n');
   let terminalStep: { index: number; status: string; name: string } | undefined;
   for (let index = 0; index < lines.length; index++) {
     const match = RUNNER_STEP_RE.exec(lines[index]);

--- a/packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts
+++ b/packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts
@@ -109,8 +109,7 @@ const PATTERNS: Pattern[] = [
 const RUNNER_STEP_RE = /^[ \t]+([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
 const REASON_LINE_RE = /^[ \t]+╰─\s+/;
 const ID_WAIT_STEP_RE = /^extendedWaitUntil:\s+visible\s+id=(['"])((?:(?!\1).)+)\1$/i;
-const ID_WAIT_REASON_RE =
-  /^[ \t]+╰─\s+Element (['"])#((?:(?!\1).)+)\1 not visible within\b/i;
+const ID_WAIT_REASON_RE = /^[ \t]+╰─\s+Element (['"])#((?:(?!\1).)+)\1 not visible within\b/i;
 
 function parseTerminalIdWait(
   output: string,

--- a/packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts
+++ b/packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts
@@ -154,6 +154,7 @@ export function parseMaestroFailure(
     .find(
       (line) =>
         /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) ||
+        /\bWait timed out\b/i.test(line) ||
         PATTERNS.some(({ re }) => re.test(line)),
     );
   if (terminalFailureLine) {

--- a/packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts
+++ b/packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts
@@ -76,6 +76,16 @@ const PATTERNS: Pattern[] = [
     re: /Element not found:\s*text=(['"])((?:(?!\1).)+)\1/i,
     build: (m, raw) => ({ kind: 'SELECTOR_NOT_FOUND', selectorKind: 'text', selector: m[2], raw }),
   },
+  // maestro-runner 1.1.16/1.1.20 ID-wait shape — issue #580.
+  // "Element '#X' not visible within 1s (cause: context deadline exceeded)".
+  // The `#` immediately after the opening quote is the runner's ID-selector
+  // marker: text and regex waits render without it and keep their current
+  // classification (issue #334 owns those). Process/global timeouts never reach
+  // the pattern list — parseMaestroFailure returns TIMEOUT on `exitClass` first.
+  {
+    re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
+    build: (m, raw) => ({ kind: 'SELECTOR_NOT_FOUND', selectorKind: 'id', selector: m[2], raw }),
+  },
   {
     re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
     build: (m, raw) => ({

--- a/packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts
+++ b/packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts
@@ -109,6 +109,7 @@ const PATTERNS: Pattern[] = [
 const RUNNER_STEP_RE = /^[ \t]+([✓✗])\s+(\S.*\S|\S)\s*\(([\d.]+)s\)\s*$/;
 const REASON_LINE_RE = /^[ \t]+╰─\s+/;
 const ID_WAIT_STEP_RE = /^extendedWaitUntil:\s+visible\s+id=(['"])((?:(?!\1).)+)\1$/i;
+const SELECTOR_LESS_ID_WAIT_SUMMARY_RE = /^extendedWaitUntil$/;
 const ID_WAIT_REASON_RE = /^[ \t]+╰─\s+Element (['"])#((?:(?!\1).)+)\1 not visible within\b/i;
 
 // The reason lines belonging to one step block: everything up to the next step line.
@@ -165,7 +166,9 @@ function parseTerminalIdWait(
   if (!reasonMatch) return null;
   const stepMatch =
     ID_WAIT_STEP_RE.exec(failedStep) ??
-    (terminalStep ? idWaitStepAmongDuplicates(lines, terminalStep.index, reasonLine) : null);
+    (terminalStep && SELECTOR_LESS_ID_WAIT_SUMMARY_RE.test(failedStep)
+      ? idWaitStepAmongDuplicates(lines, terminalStep.index, reasonLine)
+      : null);
   if (!stepMatch || reasonMatch[2] !== stepMatch[2]) return null;
   return {
     kind: 'SELECTOR_NOT_FOUND',

--- a/packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts
+++ b/packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts
@@ -41,6 +41,7 @@ export interface MaestroTerminalClassification {
 interface Pattern {
   re: RegExp;
   build: (m: RegExpExecArray, raw: string) => MaestroFailure;
+  terminalWaitOnly?: boolean;
 }
 
 // Order matters: more-specific patterns first.
@@ -85,6 +86,7 @@ const PATTERNS: Pattern[] = [
   {
     re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
     build: (m, raw) => ({ kind: 'SELECTOR_NOT_FOUND', selectorKind: 'id', selector: m[2], raw }),
+    terminalWaitOnly: true,
   },
   {
     re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -173,7 +175,15 @@ export function parseMaestroFailure(
   }
   output = raw;
   const lines = output.split('\n');
-  for (const { re, build } of PATTERNS) {
+  const terminalWaitLine = [...lines]
+    .reverse()
+    .find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line));
+  for (const { re, build, terminalWaitOnly } of PATTERNS) {
+    if (terminalWaitOnly) {
+      const m = terminalWaitLine?.match(re);
+      if (m) return build(m as RegExpExecArray, output);
+      continue;
+    }
     for (let i = lines.length - 1; i >= 0; i--) {
       const line = lines[i];
       if (!line) continue;
@@ -183,7 +193,8 @@ export function parseMaestroFailure(
   }
   // Fallback: whole-buffer scan for inputs without line breaks or for
   // any pattern that happens to straddle a `\n`.
-  for (const { re, build } of PATTERNS) {
+  for (const { re, build, terminalWaitOnly } of PATTERNS) {
+    if (terminalWaitOnly) continue;
     const m = output.match(re);
     if (m) return build(m as RegExpExecArray, output);
   }

--- a/packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts
+++ b/packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts
@@ -41,7 +41,6 @@ export interface MaestroTerminalClassification {
 interface Pattern {
   re: RegExp;
   build: (m: RegExpExecArray, raw: string) => MaestroFailure;
-  terminalWaitOnly?: boolean;
 }
 
 // Order matters: more-specific patterns first.
@@ -86,7 +85,6 @@ const PATTERNS: Pattern[] = [
   {
     re: /Element (['"])#((?:(?!\1).)+)\1 not visible within/i,
     build: (m, raw) => ({ kind: 'SELECTOR_NOT_FOUND', selectorKind: 'id', selector: m[2], raw }),
-    terminalWaitOnly: true,
   },
   {
     re: /Element (['"])((?:(?!\1).)+)\1 (?:was )?not found/i,
@@ -115,30 +113,6 @@ const PATTERNS: Pattern[] = [
   },
 ];
 
-/**
- * Parse the full Maestro stdout+stderr text and classify the failure.
- *
- * Two-axis selection — pattern-specificity dominates, line-position breaks
- * ties within a pattern:
- *
- *   1. Outer loop walks PATTERNS in order (most-specific first). The first
- *      pattern that hits ANY line wins, regardless of where that line sits.
- *      Preserves the existing invariant that the 1.0.9 `id=` shape outranks
- *      the catch-all `Element 'X' not found`.
- *
- *   2. Inner loop scans lines from END to START. Within a single pattern,
- *      the LAST matching line (the terminal failure) wins — earlier matches
- *      are typically transient retries that maestro-runner reports as
- *      `[INFO]` before the auto-retry succeeds. GH #118: PR #115's
- *      first-match-anywhere scan captured a transient retry selector and
- *      sent it to `cdp_repair_action`, wasting a 24h-budget slot.
- *
- * Falls back to a whole-buffer scan when no line matches a known pattern —
- * preserves prior-art behavior for single-line inputs and any pattern that
- * happens to span a line boundary (none today, but defensive).
- *
- * Returns `UNKNOWN` if no pattern matches at all.
- */
 export function parseMaestroFailure(
   output: string,
   terminal?: MaestroTerminalClassification,
@@ -175,26 +149,23 @@ export function parseMaestroFailure(
   }
   output = raw;
   const lines = output.split('\n');
-  const terminalWaitLine = [...lines]
+  const terminalFailureLine = [...lines]
     .reverse()
-    .find((line) => /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line));
-  for (const { re, build, terminalWaitOnly } of PATTERNS) {
-    if (terminalWaitOnly) {
-      const m = terminalWaitLine?.match(re);
-      if (m) return build(m as RegExpExecArray, output);
-      continue;
-    }
-    for (let i = lines.length - 1; i >= 0; i--) {
-      const line = lines[i];
-      if (!line) continue;
-      const m = line.match(re);
+    .find(
+      (line) =>
+        /Element (['"])(?:(?!\1).)+\1 not visible within/i.test(line) ||
+        PATTERNS.some(({ re }) => re.test(line)),
+    );
+  if (terminalFailureLine) {
+    for (const { re, build } of PATTERNS) {
+      const m = terminalFailureLine.match(re);
       if (m) return build(m as RegExpExecArray, output);
     }
+    return { kind: 'UNKNOWN', raw: output };
   }
   // Fallback: whole-buffer scan for inputs without line breaks or for
   // any pattern that happens to straddle a `\n`.
-  for (const { re, build, terminalWaitOnly } of PATTERNS) {
-    if (terminalWaitOnly) continue;
+  for (const { re, build } of PATTERNS) {
     const m = output.match(re);
     if (m) return build(m as RegExpExecArray, output);
   }

--- a/packages/rn-dev-agent-core/src/domain/maestro-step-parser.ts
+++ b/packages/rn-dev-agent-core/src/domain/maestro-step-parser.ts
@@ -4,6 +4,9 @@
 // parser (tap-latency.ts derives parseTapLatencies from parseSteps).
 
 import { parseMaestroFailure } from './maestro-error-parser.js';
+import { stripAnsi } from './ansi.js';
+
+export { stripAnsi } from './ansi.js';
 
 export interface MaestroStep {
   index: number;
@@ -11,15 +14,6 @@ export interface MaestroStep {
   verb: string;
   status: 'pass' | 'fail';
   durationMs: number;
-}
-
-// Strip ANSI SGR/color escape sequences. execFile output is usually un-colored
-// (child stdout is a pipe, not a TTY) but maestro-runner is not guaranteed to
-// honor that, and a glyph-anchored match breaks on a colored `✓`. Built via
-// fromCharCode(27) (ESC) to keep a raw control char out of the source/regex.
-const ANSI_RE = new RegExp(String.fromCharCode(27) + '\\[[0-9;]*m', 'g');
-export function stripAnsi(s: string): string {
-  return s.replace(ANSI_RE, '');
 }
 
 // `<indent>{✓|✗} <name> (N.Ns)` — the leading `[ \t]+` anchors on the runner's

--- a/packages/rn-dev-agent-core/src/domain/maestro-step-parser.ts
+++ b/packages/rn-dev-agent-core/src/domain/maestro-step-parser.ts
@@ -106,8 +106,8 @@ export interface ReasonSummary {
 // Project parseMaestroFailure to {kind, selector}, DROPPING its `raw` field —
 // every MaestroFailure variant carries `raw` = the full unsliced output, which
 // must not be re-embedded into the result (it would defeat the output slice).
-export function summarizeReason(output: string): ReasonSummary | null {
-  const f = parseMaestroFailure(output);
+export function summarizeReason(output: string, failedStep?: string): ReasonSummary | null {
+  const f = parseMaestroFailure(output, failedStep ? { failedStep } : undefined);
   if (f.kind === 'UNKNOWN' || f.kind === 'WDA_BOOTSTRAP_FAILED') return null;
   const selector = 'selector' in f ? (f.selector ?? null) : null;
   return { kind: f.kind, selector: selector === null ? null : cap(selector) };
@@ -125,10 +125,11 @@ export interface StepSummary {
 // a PASSED run must not report a failedStep (mirrors parseMaestroFailure GH#118).
 export function buildStepSummary(output: string, opts: { failed: boolean }): StepSummary {
   const steps = parseSteps(output);
+  const failedStep = opts.failed ? findFailedStep(steps) : null;
   return {
     steps,
-    failedStep: opts.failed ? findFailedStep(steps) : null,
-    reason: opts.failed ? summarizeReason(output) : null,
+    failedStep,
+    reason: opts.failed ? summarizeReason(output, failedStep?.name) : null,
     lastStep: lastObservedStep(steps),
   };
 }

--- a/packages/rn-dev-agent-core/src/domain/maestro-step-parser.ts
+++ b/packages/rn-dev-agent-core/src/domain/maestro-step-parser.ts
@@ -56,7 +56,7 @@ export function combineRunnerOutput(stdout: string, stderr: string): string {
   return (stdout + '\n' + stderr).replace(/^[\r\n]+/, '').trimEnd();
 }
 
-export function parseSteps(output: string): MaestroStep[] {
+function parseExactSteps(output: string): MaestroStep[] {
   if (!output || typeof output !== 'string') return [];
   const steps: MaestroStep[] = [];
   let index = 0;
@@ -70,13 +70,21 @@ export function parseSteps(output: string): MaestroStep[] {
     if (!Number.isFinite(seconds)) continue;
     steps.push({
       index: index++,
-      name: cap(name),
+      name,
       verb,
       status: m[1] === '✓' ? 'pass' : 'fail',
       durationMs: Math.round(seconds * 1000),
     });
   }
   return steps.length > MAX_STEPS ? steps.slice(-MAX_STEPS) : steps;
+}
+
+function boundStep(step: MaestroStep): MaestroStep {
+  return { ...step, name: cap(step.name) };
+}
+
+export function parseSteps(output: string): MaestroStep[] {
+  return parseExactSteps(output).map(boundStep);
 }
 
 // The TERMINAL failed step: the last parsed step iff it failed. maestro-runner
@@ -100,11 +108,17 @@ export interface ReasonSummary {
 // Project parseMaestroFailure to {kind, selector}, DROPPING its `raw` field —
 // every MaestroFailure variant carries `raw` = the full unsliced output, which
 // must not be re-embedded into the result (it would defeat the output slice).
-export function summarizeReason(output: string, failedStep?: string): ReasonSummary | null {
+function summarizeExactReason(output: string, failedStep?: string): ReasonSummary | null {
   const f = parseMaestroFailure(output, failedStep ? { failedStep } : undefined);
   if (f.kind === 'UNKNOWN' || f.kind === 'WDA_BOOTSTRAP_FAILED') return null;
   const selector = 'selector' in f ? (f.selector ?? null) : null;
-  return { kind: f.kind, selector: selector === null ? null : cap(selector) };
+  return { kind: f.kind, selector };
+}
+
+export function summarizeReason(output: string, failedStep?: string): ReasonSummary | null {
+  const reason = summarizeExactReason(output, failedStep);
+  if (!reason) return null;
+  return { ...reason, selector: reason.selector === null ? null : cap(reason.selector) };
 }
 
 export interface StepSummary {
@@ -118,12 +132,19 @@ export interface StepSummary {
 // (opts.failed). maestro-runner logs transient retries; a fail-then-retry-✓ on
 // a PASSED run must not report a failedStep (mirrors parseMaestroFailure GH#118).
 export function buildStepSummary(output: string, opts: { failed: boolean }): StepSummary {
-  const steps = parseSteps(output);
-  const failedStep = opts.failed ? findFailedStep(steps) : null;
+  const exactSteps = parseExactSteps(output);
+  const exactFailedStep = opts.failed ? findFailedStep(exactSteps) : null;
+  const exactReason = opts.failed ? summarizeExactReason(output, exactFailedStep?.name) : null;
+  const steps = exactSteps.map(boundStep);
   return {
     steps,
-    failedStep,
-    reason: opts.failed ? summarizeReason(output, failedStep?.name) : null,
+    failedStep: exactFailedStep ? boundStep(exactFailedStep) : null,
+    reason: exactReason
+      ? {
+          ...exactReason,
+          selector: exactReason.selector === null ? null : cap(exactReason.selector),
+        }
+      : null,
     lastStep: lastObservedStep(steps),
   };
 }
@@ -161,7 +182,9 @@ export function buildTerminalEvidence(
   output: string,
   opts: { timedOut?: boolean; spawnError?: boolean } = {},
 ): MaestroTerminalEvidence {
-  const summary = buildStepSummary(output, { failed: true });
+  const exactSteps = parseExactSteps(output);
+  const failedStep = findFailedStep(exactSteps);
+  const reason = summarizeExactReason(output, failedStep?.name);
   const bootstrapEvidence = stripAnsi(output)
     .split('\n')
     .filter((line) => isWdaFailureLine(line))
@@ -171,18 +194,18 @@ export function buildTerminalEvidence(
     ? 'timed-out'
     : opts.spawnError
       ? 'spawn-error'
-      : summary.steps.length === 0
+      : exactSteps.length === 0
         ? 'before-first-step'
         : 'step-failure';
   return {
-    completedSteps: summary.steps.filter((step) => step.status === 'pass').length,
-    ...(summary.failedStep ? { failedStep: summary.failedStep.name } : {}),
+    completedSteps: exactSteps.filter((step) => step.status === 'pass').length,
+    ...(failedStep ? { failedStep: failedStep.name } : {}),
     exitClass,
     ...(bootstrapEvidence ? { bootstrapEvidence } : {}),
-    ...(summary.reason
+    ...(reason
       ? {
-          failureKind: summary.reason.kind,
-          failureSelector: summary.reason.selector,
+          failureKind: reason.kind,
+          failureSelector: reason.selector,
         }
       : {}),
   };

--- a/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
+++ b/packages/rn-dev-agent-core/src/tools/cdp-replay-dispatch.ts
@@ -3,6 +3,7 @@ import {
   normalizeSteps,
   replayFlow,
   firstTestId,
+  findResumeAnchor,
   type ReplayResult,
 } from '../domain/cdp-flow-replay.js';
 import type { ReplayDispatch } from '../domain/cdp-flow-replay.js';
@@ -78,14 +79,48 @@ function isDisabled(props: Record<string, unknown> | null): boolean {
   return props.disabled === true || a11y?.disabled === true || props.pointerEvents === 'none';
 }
 
+/** GH #580: why a reactive replay did or did not resume at the failed selector. */
+export type CdpReplayResume =
+  | { applied: true; selector: string; startIndex: number }
+  | {
+      applied: false;
+      reason: 'not-requested' | 'no-match' | 'ambiguous' | 'nested-match' | 'too-deep';
+    };
+
+export interface CdpReplayResult extends ReplayResult {
+  resume: CdpReplayResume;
+}
+
+/**
+ * GH #580: `resumeAtSelector` replays only the suffix from the step targeting that
+ * selector. The anchor is found on the RAW body and normalization applies to the
+ * suffix alone, so unsupported commands in the executed prefix stop disqualifying
+ * the whole action. A refused anchor keeps start-at-zero.
+ */
 export async function runCdpReplay(
   bodyYaml: string,
   params: Record<string, string>,
   deps: CdpReplayDeps,
-): Promise<ReplayResult> {
+  opts: { resumeAtSelector?: string | null } = {},
+): Promise<CdpReplayResult> {
   const parsed = yamlParse(bodyYaml) as unknown[];
-  const steps = normalizeSteps(parsed, params);
-  return replayFlow(steps, buildCdpDispatch(deps));
+  const resume = resolveResume(parsed, params, opts.resumeAtSelector);
+  const startIndex = resume.applied ? resume.startIndex : 0;
+  const steps = normalizeSteps(startIndex === 0 ? parsed : parsed.slice(startIndex), params);
+  const result = await replayFlow(steps, buildCdpDispatch(deps), { indexOffset: startIndex });
+  return { ...result, resume };
+}
+
+function resolveResume(
+  parsed: unknown[],
+  params: Record<string, string>,
+  selector: string | null | undefined,
+): CdpReplayResume {
+  if (!selector || !Array.isArray(parsed)) return { applied: false, reason: 'not-requested' };
+  const anchor = findResumeAnchor(parsed, params, selector);
+  return anchor.found
+    ? { applied: true, selector, startIndex: anchor.index }
+    : { applied: false, reason: anchor.reason };
 }
 
 export function buildCdpDispatch(deps: CdpReplayDeps): ReplayDispatch {

--- a/packages/rn-dev-agent-core/src/tools/run-action.ts
+++ b/packages/rn-dev-agent-core/src/tools/run-action.ts
@@ -1055,6 +1055,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
       const retryFailure = !retryPassed
         ? parseMaestroFailure(retryOutput, retryTerminal)
         : undefined;
+      const retryClassification = retryFailure ? classifyFailure(retryFailure) : undefined;
       const retryDeviceAuthority = readMaestroDeviceAuthority(retryEnv);
       probeDeviceId = retryDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
 
@@ -1125,7 +1126,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
         timestamp: new Date().toISOString(),
         durationMs: Date.now() - t0,
         status: retryPassed ? 'pass' : 'fail',
-        failureCode: retryPassed ? undefined : 'SELECTOR_NOT_FOUND',
+        failureCode: retryClassification?.actionCode,
         failureDetail: retryPassed ? undefined : retryFailureDetail.slice(0, 1000),
         trigger,
         autoRepair,
@@ -1146,23 +1147,23 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
         });
       }
 
-      return failResult(
-        `cdp_run_action: ${args.actionId} still failing after auto-repair (${repairData.oldSelector} → ${repairData.newSelector}): ${retryFailureDetail}`,
-        'TESTID_NOT_FOUND',
-        {
-          actionId: args.actionId,
-          autoRepair,
-          writes: writeDisclosure('auto-repair', persisted),
-          firstAttemptOutput: boundedOutput(firstOutput),
-          retryOutput: boundedOutput(retryOutput),
-          underlyingFailure: retryFailureDetail,
-          ...(retryFailure ? { failureKind: retryFailure.kind } : {}),
-          ...(retryFailure && 'selector' in retryFailure && retryFailure.selector
-            ? { failureSelector: retryFailure.selector }
-            : {}),
-          terminal: retryTerminal,
-        },
-      );
+      const retryMessage = `cdp_run_action: ${args.actionId} still failing after auto-repair (${repairData.oldSelector} → ${repairData.newSelector}): ${retryFailureDetail}`;
+      const retryMeta = {
+        actionId: args.actionId,
+        autoRepair,
+        writes: writeDisclosure('auto-repair', persisted),
+        firstAttemptOutput: boundedOutput(firstOutput),
+        retryOutput: boundedOutput(retryOutput),
+        underlyingFailure: retryFailureDetail,
+        ...(retryFailure ? { failureKind: retryFailure.kind } : {}),
+        ...(retryFailure && 'selector' in retryFailure && retryFailure.selector
+          ? { failureSelector: retryFailure.selector }
+          : {}),
+        terminal: retryTerminal,
+      };
+      return retryClassification?.toolCode
+        ? failResult(retryMessage, retryClassification.toolCode, retryMeta)
+        : failResult(retryMessage, retryMeta);
     } catch (err) {
       if (err instanceof SessionAuthorityError) throw err;
       // Multi-LLM review of PR #115 (Gemini conf 95): top-level catch

--- a/packages/rn-dev-agent-core/src/tools/run-action.ts
+++ b/packages/rn-dev-agent-core/src/tools/run-action.ts
@@ -260,18 +260,49 @@ function readMaestroDeviceAuthority(env: MaestroEnvelope): MaestroDeviceAuthorit
   return (env.meta as { deviceAuthority?: MaestroDeviceAuthority } | undefined)?.deviceAuthority;
 }
 
+function terminalReason(terminal: MaestroTerminal | undefined): string {
+  if (!terminal?.failureKind) return '';
+  return ` (${terminal.failureKind}${terminal.failureSelector ? `: ${terminal.failureSelector}` : ''})`;
+}
+
 /**
  * maestro_run builds its headline from the full runner stream before slicing
  * data.output/meta.output. Keep that headline as the authoritative failure
  * detail so cdp_run_action never reduces a useful terminal step to UNKNOWN just
  * because the report preamble consumed the bounded output field.
+ *
+ * GH #580: the WARN path (runner exit 0 with failures) carries no `env.error` and
+ * puts its step summary in `data`, not `meta`, so it degraded to a bare slice.
  */
 function readMaestroFailureDetail(env: MaestroEnvelope, output: string): string {
   if (typeof env.error === 'string' && env.error.trim()) return env.error.trim();
-  const failedStep = (env.meta as { failedStep?: { name?: unknown } } | undefined)?.failedStep;
-  if (typeof failedStep?.name === 'string')
-    return `Maestro flow failed at step "${failedStep.name}"`;
-  return output.trim().slice(0, 1000) || 'Maestro runner returned no failure detail';
+  const terminal = readMaestroTerminal(env);
+  const reason = terminalReason(terminal);
+  const metaStep = (env.meta as { failedStep?: { name?: unknown } } | undefined)?.failedStep;
+  const dataStep = (env.data as { failedStep?: { name?: unknown } } | undefined)?.failedStep;
+  const stepName =
+    typeof metaStep?.name === 'string'
+      ? metaStep.name
+      : typeof dataStep?.name === 'string'
+        ? dataStep.name
+        : terminal?.failedStep;
+  if (stepName) return `Maestro flow failed at step "${stepName}"${reason}`;
+  if (reason) return `Maestro flow failed${reason.trim()}`;
+  return boundedOutput(output.trim(), 1000) || 'Maestro runner returned no failure detail';
+}
+
+// GH #580 defect 3: the terminal failure sits at the TAIL of runner stdout while
+// the head carries the WDA preamble, so a head-only slice showed only the preamble.
+// Over-budget input always returns exactly `budget` characters.
+const OUTPUT_BUDGET = 500;
+const OUTPUT_ELISION = '\n…\n';
+
+export function boundedOutput(output: string, budget: number = OUTPUT_BUDGET): string {
+  const text = typeof output === 'string' ? output : '';
+  if (text.length <= budget) return text;
+  const room = budget - OUTPUT_ELISION.length;
+  const head = Math.ceil(room / 2);
+  return text.slice(0, head) + OUTPUT_ELISION + text.slice(text.length - (room - head));
 }
 
 /**
@@ -693,7 +724,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
           writes: writeDisclosure(promotionDisclosure(persisted), persisted),
           durationMs: Date.now() - t0,
           flowFile: action.filePath,
-          firstAttemptOutput: firstOutput.slice(0, 500),
+          firstAttemptOutput: boundedOutput(firstOutput),
         });
       }
 
@@ -772,8 +803,23 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
               reason: probeOutcome.sawTree ? 'testid-not-in-tree' : 'cdp-unreachable',
             };
           } else {
+            // GH #580: what Maestro actually reported, carried onto every fallback
+            // failure return so the caller never has to re-derive it from stdout.
+            const maestroEvidence = {
+              failureKind: failure.kind,
+              ...(failure.kind === 'SELECTOR_NOT_FOUND'
+                ? { failureSelector: failure.selector }
+                : {}),
+              underlyingFailure: firstFailureDetail,
+              terminal: readMaestroTerminal(firstEnv),
+              firstAttemptOutput: boundedOutput(firstOutput),
+            };
             try {
-              const replay = await runCdpReplay(action.body, args.params ?? {}, replayDeps);
+              // GH #580: resume at the proven failed selector; UNKNOWN failed before
+              // any step, so it keeps start-at-zero.
+              const replay = await runCdpReplay(action.body, args.params ?? {}, replayDeps, {
+                resumeAtSelector: failure.kind === 'SELECTOR_NOT_FOUND' ? failure.selector : null,
+              });
               const status = replay.passed ? 'pass' : 'fail';
               const autoRepair: AutoRepairOutcome = {
                 attempted: false,
@@ -806,6 +852,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
                   writes: writeDisclosure(promotionDisclosure(persisted), persisted),
                   durationMs: Date.now() - t0,
                   flowFile: action.filePath,
+                  resume: replay.resume,
                 });
               }
               return failResult(
@@ -815,6 +862,8 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
                   actionId: args.actionId,
                   transport: 'cdp-js',
                   failedStepIndex: replay.failedStepIndex,
+                  resume: replay.resume,
+                  ...maestroEvidence,
                 },
               );
             } catch (e) {
@@ -822,7 +871,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
                 return failResult(
                   `cdp_run_action: ${args.actionId} cannot replay via CDP/JS — ${e.message}. This action uses a step type the iOS 26.x fallback doesn't support; run on iOS 18 (WDA works there).`,
                   'UNSUPPORTED_STEP' as ToolErrorCode,
-                  { actionId: args.actionId, stepKey: e.stepKey },
+                  { actionId: args.actionId, stepKey: e.stepKey, ...maestroEvidence },
                 );
               }
               throw e;
@@ -863,9 +912,14 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
         const meta = {
           actionId: args.actionId,
           failureKind: failure.kind,
+          // GH #580: the selector belongs in the envelope structurally, not only
+          // inside the human headline the caller would have to re-parse.
+          ...('selector' in failure && failure.selector
+            ? { failureSelector: failure.selector }
+            : {}),
           underlyingFailure: firstFailureDetail,
           autoRepair,
-          firstAttemptOutput: firstOutput.slice(0, 500),
+          firstAttemptOutput: boundedOutput(firstOutput),
           terminal: readMaestroTerminal(firstEnv),
           runnerResume: (firstEnv.meta as { runnerResume?: unknown } | undefined)?.runnerResume,
           ...(cdpJsFallback ? { cdpJsFallback } : {}),
@@ -923,18 +977,24 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
           durationMs: Date.now() - t0,
           status: 'fail',
           failureCode: 'SELECTOR_NOT_FOUND',
-          failureDetail: firstOutput.slice(0, 500),
+          // GH #580: the structured detail carries kind + selector; the bounded
+          // stdout slice can lose the failing line to later runner narration.
+          failureDetail: firstFailureDetail.slice(0, 1000),
           trigger,
           autoRepair,
         });
         return failResult(
-          `cdp_run_action: ${args.actionId} failed with SELECTOR_NOT_FOUND; auto-repair refused (${refusedReason}): ${repairEnv.error ?? 'unknown'}`,
+          `cdp_run_action: ${args.actionId} failed with SELECTOR_NOT_FOUND (${failure.selector}); auto-repair refused (${refusedReason}): ${repairEnv.error ?? 'unknown'}`,
           refusedReason === 'TRANSPORT_BLIND' ? 'TRANSPORT_BLIND' : 'TESTID_NOT_FOUND',
           {
             actionId: args.actionId,
+            failureKind: failure.kind,
+            failureSelector: failure.selector,
+            underlyingFailure: firstFailureDetail,
+            terminal: readMaestroTerminal(firstEnv),
             autoRepair,
             repairError: repairEnv.error,
-            firstAttemptOutput: firstOutput.slice(0, 500),
+            firstAttemptOutput: boundedOutput(firstOutput),
           },
         );
       }
@@ -1085,7 +1145,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
           durationMs: Date.now() - t0,
           flowFile: reloadedAction.filePath,
           retriedAfterRepair: true,
-          retryOutput: retryOutput.slice(0, 500),
+          retryOutput: boundedOutput(retryOutput),
         });
       }
 
@@ -1096,8 +1156,8 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
           actionId: args.actionId,
           autoRepair,
           writes: writeDisclosure('auto-repair', persisted),
-          firstAttemptOutput: firstOutput.slice(0, 500),
-          retryOutput: retryOutput.slice(0, 500),
+          firstAttemptOutput: boundedOutput(firstOutput),
+          retryOutput: boundedOutput(retryOutput),
           underlyingFailure: retryFailureDetail,
         },
       );

--- a/packages/rn-dev-agent-core/src/tools/run-action.ts
+++ b/packages/rn-dev-agent-core/src/tools/run-action.ts
@@ -1051,6 +1051,10 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
       const retryPassed = retryEnv.ok === true && retryEnv.data?.passed === true;
       const retryOutput = readMaestroOutput(retryEnv);
       const retryFailureDetail = readMaestroFailureDetail(retryEnv, retryOutput);
+      const retryTerminal = readMaestroTerminal(retryEnv);
+      const retryFailure = !retryPassed
+        ? parseMaestroFailure(retryOutput, retryTerminal)
+        : undefined;
       const retryDeviceAuthority = readMaestroDeviceAuthority(retryEnv);
       probeDeviceId = retryDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
 
@@ -1094,19 +1098,12 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
       // when retry failed; same-selector failures (= patch didn't work)
       // are implicit in the existing diff.
       let nextFailedSelector: string | undefined;
-      if (!retryPassed) {
-        try {
-          const retryFailure = parseMaestroFailure(retryOutput, readMaestroTerminal(retryEnv));
-          if (
-            retryFailure.kind === 'SELECTOR_NOT_FOUND' &&
-            retryFailure.selector &&
-            retryFailure.selector !== repairData.newSelector
-          ) {
-            nextFailedSelector = retryFailure.selector;
-          }
-        } catch {
-          /* best-effort — don't fail the run because the parser hiccuped */
-        }
+      if (
+        retryFailure?.kind === 'SELECTOR_NOT_FOUND' &&
+        retryFailure.selector &&
+        retryFailure.selector !== repairData.newSelector
+      ) {
+        nextFailedSelector = retryFailure.selector;
       }
 
       const autoRepair: AutoRepairOutcome = {
@@ -1159,6 +1156,11 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
           firstAttemptOutput: boundedOutput(firstOutput),
           retryOutput: boundedOutput(retryOutput),
           underlyingFailure: retryFailureDetail,
+          ...(retryFailure ? { failureKind: retryFailure.kind } : {}),
+          ...(retryFailure && 'selector' in retryFailure && retryFailure.selector
+            ? { failureSelector: retryFailure.selector }
+            : {}),
+          terminal: retryTerminal,
         },
       );
     } catch (err) {

--- a/packages/rn-dev-agent-core/test/unit/cdp-flow-replay.test.js
+++ b/packages/rn-dev-agent-core/test/unit/cdp-flow-replay.test.js
@@ -130,7 +130,7 @@ test('replayFlow happy path: type routes to last tapped, all pass', async () => 
 });
 
 test('replayFlow runFlow recurses only when whenVisible present', async () => {
-  const d = mockDispatch({ visible: ['tabs'] }); // onboarding NOT visible, tabs IS visible
+  const d = mockDispatch({ visible: ['onboarding', 'tabs'] });
   const r = await replayFlow(
     [
       { t: 'runFlow', whenVisible: 'onboarding', commands: [{ t: 'tap', id: 'done' }] },
@@ -139,6 +139,10 @@ test('replayFlow runFlow recurses only when whenVisible present', async () => {
     d,
   );
   assert.equal(r.passed, true);
+  assert.deepEqual(
+    r.steps.map((step) => step.sourceIndex),
+    [0, 1],
+  );
 });
 
 test('replayFlow fails the step when a target is disabled (no false green)', async () => {

--- a/packages/rn-dev-agent-core/test/unit/gh-580-selector-resume.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-580-selector-resume.test.ts
@@ -214,6 +214,10 @@ test('gh-580: a unique selector resumes at its source step and skips prior mutat
   assert.equal(result.passed, true);
   assert.deepEqual(result.resume, { applied: true, selector: 'otp_sheet', startIndex: 3 });
   assert.deepEqual(
+    result.steps.map((step) => step.sourceIndex),
+    [3, 4],
+  );
+  assert.deepEqual(
     calls,
     ['press:otp_submit'],
     'launch, the login tap and the email inputText were NOT redispatched',
@@ -629,3 +633,41 @@ test('gh-580: the warn path (runner exit 0 with failures) reports kind + selecto
     'the warn path used to degrade to a bare stdout slice',
   );
 });
+
+for (const retryShape of ['warn', 'throw'] as const) {
+  test(`gh-580: a ${retryShape} post-repair failure keeps structural terminal evidence`, async () => {
+    project.seedAction('register', actionYaml(['- tapOn:', '    id: "otp"']));
+    let maestroCalls = 0;
+    const handler = createRunActionHandler({
+      maestroRun: async (...args: unknown[]) => {
+        maestroCalls++;
+        return maestroCalls === 1
+          ? waitFailureEnvelope('otp')(...(args as []))
+          : waitFailureEnvelope('otp_retry', retryShape)(...(args as []));
+      },
+      repairAction: async () => ({
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              data: {
+                patched: true,
+                oldSelector: 'otp',
+                newSelector: 'otp_retry',
+                score: 0.9,
+              },
+            }),
+          },
+        ],
+      }),
+    });
+
+    const env = readEnvelope(await handler({ actionId: 'register', projectRoot: project.root }));
+    assert.equal(env.ok, false);
+    assert.equal(env.meta.failureKind, 'SELECTOR_NOT_FOUND');
+    assert.equal(env.meta.failureSelector, 'otp_retry');
+    assert.equal(env.meta.terminal.failureKind, 'SELECTOR_NOT_FOUND');
+    assert.equal(env.meta.terminal.failureSelector, 'otp_retry');
+  });
+}

--- a/packages/rn-dev-agent-core/test/unit/gh-580-selector-resume.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-580-selector-resume.test.ts
@@ -1,0 +1,631 @@
+// GH #580 — three bounded replay-reliability behaviors:
+//
+//   1. `launchApp` maps carrying keys the CDP/JS transport cannot honor (notably
+//      `clearState: true`, which needs uninstall+reinstall, not `simctl launch`)
+//      are refused instead of silently normalized to a plain launch.
+//   2. A reactive fallback resumes at the single source step that targets the
+//      proven failed selector, so already-executed mutations are not redispatched.
+//      Zero, duplicate, or sub-flow-nested matches refuse and keep start-at-zero.
+//   3. The reclassified 1.1.x wait reaches auto-repair for the first time, so the
+//      #631 completed-flow false negative must still end with no YAML write while
+//      the #317 exact-native TRANSPORT_BLIND refusal keeps firing.
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  normalizeSteps,
+  findResumeAnchor,
+  UnsupportedStepError,
+} from '../../dist/domain/cdp-flow-replay.js';
+import { runCdpReplay, firstReplayTestId } from '../../dist/tools/cdp-replay-dispatch.js';
+import { attemptRepair, detectTransportBlind } from '../../dist/domain/repair-engine.js';
+import { loadAction } from '../../dist/domain/action-store.js';
+import { createRunActionHandler } from '../../dist/tools/run-action.js';
+import { createTmpProject } from '../helpers/tmp-project.js';
+
+let project: ReturnType<typeof createTmpProject>;
+beforeEach(() => {
+  project = createTmpProject();
+});
+afterEach(() => {
+  project.cleanup();
+});
+
+function actionYaml(bodyLines: string[], id = 'demo'): string {
+  return [
+    'appId: com.test.app',
+    '---',
+    `# id: ${id}`,
+    '# intent: test fixture',
+    '# tags: [fixture]',
+    '# mutates: false',
+    '# status: experimental',
+    '',
+    ...bodyLines,
+    '',
+  ].join('\n');
+}
+
+function readEnvelope(result: { content: Array<{ type: string; text: string }> }): any {
+  return JSON.parse(result.content[0].text);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. launchApp keys the transport cannot honor
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('gh-580: launchApp { clearState: true } is refused, not silently dropped', () => {
+  assert.throws(
+    () => normalizeSteps([{ launchApp: { clearState: true } }], {}),
+    (e: unknown) => {
+      assert.ok(e instanceof UnsupportedStepError);
+      assert.equal(e.stepKey, 'launchApp (unsupported keys: clearState)');
+      return true;
+    },
+  );
+  // The standalone `- clearState` form already threw; the two are now consistent.
+  assert.throws(() => normalizeSteps(['clearState'], {}), UnsupportedStepError);
+});
+
+test('gh-580: every unhonorable launchApp key is refused and named; stopApp still works', () => {
+  assert.throws(
+    () => normalizeSteps([{ launchApp: { clearState: false } }], {}),
+    UnsupportedStepError,
+  );
+  assert.throws(
+    () => normalizeSteps([{ launchApp: { permissions: { all: 'allow' } } }], {}),
+    (e: unknown) => {
+      assert.equal(
+        (e as UnsupportedStepError).stepKey,
+        'launchApp (unsupported keys: permissions)',
+      );
+      return true;
+    },
+  );
+  assert.throws(
+    () => normalizeSteps([{ launchApp: { arguments: {}, clearState: true } }], {}),
+    (e: unknown) => {
+      assert.equal(
+        (e as UnsupportedStepError).stepKey,
+        'launchApp (unsupported keys: arguments, clearState)',
+      );
+      return true;
+    },
+  );
+
+  // A non-boolean stopApp would coerce to false — the same silent lie.
+  assert.throws(
+    () => normalizeSteps([{ launchApp: { stopApp: 'true' } }], {}),
+    (e: unknown) => {
+      assert.equal((e as UnsupportedStepError).stepKey, 'launchApp (stopApp must be a boolean)');
+      return true;
+    },
+  );
+  assert.throws(() => normalizeSteps([{ launchApp: { stopApp: null } }], {}), UnsupportedStepError);
+
+  // Supported shapes are untouched.
+  assert.deepEqual(normalizeSteps([{ launchApp: { stopApp: true } }], {}), [
+    { t: 'launch', stopApp: true },
+  ]);
+  assert.deepEqual(normalizeSteps([{ launchApp: { stopApp: false } }], {}), [
+    { t: 'launch', stopApp: false },
+  ]);
+  assert.deepEqual(normalizeSteps([{ launchApp: null }], {}), [{ t: 'launch', stopApp: false }]);
+});
+
+test('gh-580: a clearState action yields no proactive probe anchor', () => {
+  const body = '- launchApp:\n    clearState: true\n- tapOn:\n    id: "direct_login_button"\n';
+  assert.equal(firstReplayTestId(body, {}), null);
+});
+
+test('gh-580: proactive at-risk path does NOT route a clearState action to CDP/JS', async () => {
+  project.seedAction(
+    'demo',
+    actionYaml(['- launchApp:', '    clearState: true', '- tapOn:', '    id: "fab-create-task"']),
+  );
+  const maestro = { calls: 0 };
+  const pressCalls: string[] = [];
+  const handler = createRunActionHandler({
+    maestroRun: async () => {
+      maestro.calls++;
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: true,
+              data: {
+                passed: true,
+                output: 'Flow PASSED',
+                flowFile: 'x',
+                platform: 'ios',
+                transport: 'maestro-runner',
+                fallback: 'none',
+                steps: [],
+              },
+            }),
+          },
+        ],
+      };
+    },
+    replayDeps: () => ({
+      pressByTestId: async (id: string) => {
+        pressCalls.push(id);
+      },
+      typeByTestId: async () => {},
+      treeFor: async (id: string) => ({ testID: id, children: [] }),
+      launchApp: async () => {},
+      settle: async () => {},
+    }),
+    blindProbeContext: async () => ({ deviceId: 'UDID-1', iosRuntimeMajor: 26 }),
+    probeRetry: { attempts: 1, delayMs: 0 },
+  });
+
+  const env = readEnvelope(
+    await handler({ actionId: 'demo', projectRoot: project.root, platform: 'ios' }),
+  );
+  assert.equal(env.data.transport, 'maestro-runner', 'stays maestro-first');
+  assert.equal(maestro.calls, 1, 'maestro must run — CDP/JS cannot honor clearState');
+  assert.deepEqual(pressCalls, [], 'nothing was replayed through the blind transport');
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Selector-anchored resume
+// ─────────────────────────────────────────────────────────────────────────────
+
+const RESUME_BODY = [
+  '- launchApp:',
+  '    stopApp: false',
+  '- tapOn:',
+  '    id: "direct_login_button"',
+  '- inputText: "user@example.com"',
+  '- assertVisible:',
+  '    id: "otp_sheet"',
+  '- tapOn:',
+  '    id: "otp_submit"',
+].join('\n');
+
+function spyDeps(visible: (id: string) => boolean = () => true) {
+  const calls: string[] = [];
+  return {
+    calls,
+    deps: {
+      pressByTestId: async (id: string) => {
+        calls.push(`press:${id}`);
+      },
+      typeByTestId: async (id: string, text: string) => {
+        calls.push(`type:${id}:${text}`);
+      },
+      treeFor: async (id: string) =>
+        visible(id) ? { testID: id, children: [] } : { testID: 'other', children: [] },
+      launchApp: async (stopApp: boolean) => {
+        calls.push(`launch:${stopApp}`);
+      },
+      settle: async () => {
+        calls.push('settle');
+      },
+    },
+  };
+}
+
+test('gh-580: a unique selector resumes at its source step and skips prior mutations', async () => {
+  const { calls, deps } = spyDeps();
+  const result = await runCdpReplay(RESUME_BODY, {}, deps, { resumeAtSelector: 'otp_sheet' });
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.resume, { applied: true, selector: 'otp_sheet', startIndex: 3 });
+  assert.deepEqual(
+    calls,
+    ['press:otp_submit'],
+    'launch, the login tap and the email inputText were NOT redispatched',
+  );
+});
+
+test('gh-580: resume reports SOURCE step indices, not suffix-relative ones', async () => {
+  // otp_submit is absent from the tree, so the resumed suffix fails on it.
+  const { deps } = spyDeps((id) => id !== 'otp_submit');
+  const result = await runCdpReplay(RESUME_BODY, {}, deps, { resumeAtSelector: 'otp_sheet' });
+
+  assert.equal(result.passed, false);
+  assert.equal(result.failedStepIndex, 4, 'source index of the tapOn, not suffix index 1');
+  assert.match(result.reason ?? '', /otp_submit/);
+});
+
+test('gh-580: an unsupported PREFIX no longer blocks a resumed suffix', async () => {
+  // Whole-flow normalization refuses this body (clearState); the suffix does not.
+  const body = [
+    '- launchApp:',
+    '    clearState: true',
+    '- tapOn:',
+    '    id: "direct_login_button"',
+    '- assertVisible:',
+    '    id: "otp_sheet"',
+  ].join('\n');
+  await assert.rejects(() => runCdpReplay(body, {}, spyDeps().deps), UnsupportedStepError);
+
+  const { calls, deps } = spyDeps();
+  const result = await runCdpReplay(body, {}, deps, { resumeAtSelector: 'otp_sheet' });
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.resume, { applied: true, selector: 'otp_sheet', startIndex: 2 });
+  assert.deepEqual(calls, [], 'assertVisible only probes the tree; nothing was mutated');
+});
+
+test('gh-580: a selector absent from the body refuses to resume and replays from zero', async () => {
+  const { calls, deps } = spyDeps();
+  const result = await runCdpReplay(RESUME_BODY, {}, deps, { resumeAtSelector: 'never_here' });
+
+  assert.deepEqual(result.resume, { applied: false, reason: 'no-match' });
+  assert.deepEqual(calls, [
+    'launch:false',
+    'press:direct_login_button',
+    'type:direct_login_button:user@example.com',
+    'press:otp_submit',
+  ]);
+});
+
+test('gh-580: a duplicated selector refuses to resume — never guess which one failed', async () => {
+  const body = [
+    '- tapOn:',
+    '    id: "retry_button"',
+    '- assertVisible:',
+    '    id: "otp_sheet"',
+    '- tapOn:',
+    '    id: "retry_button"',
+  ].join('\n');
+  const { calls, deps } = spyDeps();
+  const result = await runCdpReplay(body, {}, deps, { resumeAtSelector: 'retry_button' });
+
+  assert.deepEqual(result.resume, { applied: false, reason: 'ambiguous' });
+  assert.deepEqual(calls, ['press:retry_button', 'press:retry_button'], 'start-at-zero preserved');
+});
+
+test('gh-580: a match nested inside a sub-flow refuses — the wrapper would replay siblings', () => {
+  const body = [
+    { launchApp: { stopApp: false } },
+    {
+      runFlow: {
+        when: { visible: { id: 'onboarding' } },
+        commands: [{ tapOn: { id: 'accept_terms' } }, { tapOn: { id: 'otp_sheet' } }],
+      },
+    },
+  ];
+  assert.deepEqual(findResumeAnchor(body, {}, 'otp_sheet'), {
+    found: false,
+    reason: 'nested-match',
+  });
+  // Two occurrences inside ONE wrapper stay detectably ambiguous, not "one match".
+  const twice = [
+    {
+      runFlow: {
+        when: { visible: { id: 'g' } },
+        commands: [{ tapOn: { id: 'dup' } }, { assertVisible: { id: 'dup' } }],
+      },
+    },
+  ];
+  assert.deepEqual(findResumeAnchor(twice, {}, 'dup'), { found: false, reason: 'ambiguous' });
+});
+
+test('gh-580: a body too deep to scan completely refuses rather than claim uniqueness', () => {
+  // A shallow hit plus a duplicate buried below the depth bound must never read
+  // as "exactly one match" — the walk cannot prove the deeper one is absent.
+  let deep: Record<string, unknown> = { tapOn: { id: 'buried' } };
+  for (let i = 0; i < 30; i++) deep = { wrapper: deep };
+  assert.deepEqual(findResumeAnchor([{ tapOn: { id: 'buried' } }, deep], {}, 'buried'), {
+    found: false,
+    reason: 'too-deep',
+  });
+});
+
+test('gh-580: the anchor honors ${PARAM} interpolation and an empty selector never matches', () => {
+  const body = [{ tapOn: { id: 'row-${ROW}' } }, { assertVisible: { id: 'done' } }];
+  assert.deepEqual(findResumeAnchor(body, { ROW: '7' }, 'row-7'), { found: true, index: 0 });
+  assert.deepEqual(findResumeAnchor(body, { ROW: '7' }, 'row-9'), {
+    found: false,
+    reason: 'no-match',
+  });
+  assert.deepEqual(findResumeAnchor(body, {}, ''), { found: false, reason: 'no-match' });
+});
+
+test('gh-580: a resumed inputText with no focus target still fails loudly', async () => {
+  const body = [
+    '- tapOn:',
+    '    id: "login"',
+    '- assertVisible:',
+    '    id: "otp_form"',
+    '- inputText: "123456"',
+  ].join('\n');
+  const { calls, deps } = spyDeps();
+  const result = await runCdpReplay(body, {}, deps, { resumeAtSelector: 'otp_form' });
+
+  assert.equal(result.passed, false);
+  assert.equal(result.reason, 'inputText before any tapOn — no focus target');
+  assert.equal(result.failedStepIndex, 2, 'source index of the inputText');
+  assert.deepEqual(calls, [], 'nothing was typed into an unknown field');
+});
+
+test('gh-580: the proactive path never resumes — it replays the whole flow from zero', async () => {
+  const { calls, deps } = spyDeps();
+  const result = await runCdpReplay(RESUME_BODY, {}, deps);
+
+  assert.deepEqual(result.resume, { applied: false, reason: 'not-requested' });
+  assert.equal(calls[0], 'launch:false', 'launch is still executed');
+  assert.equal(calls.length, 4);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Auto-repair safety for the newly reclassified wait
+// ─────────────────────────────────────────────────────────────────────────────
+
+const OTP_SELECTOR = 'EmailOtpFormContent_email-pressable';
+
+// #631 shape: registration actually completed, so the live screen is the push
+// prompt and the OTP selector is absent from the native snapshot entirely.
+const PUSH_PROMPT_CANDIDATES = ['PushPrimer_title', 'PushPrimer_allow-button', 'PushPrimer_skip'];
+
+test('gh-631: the repair engine refuses a reclassified wait whose selector is absent', () => {
+  project.seedAction('register', actionYaml(['- tapOn:', `    id: "${OTP_SELECTOR}"`]));
+  const action = loadAction(project.root, 'register');
+
+  assert.equal(
+    detectTransportBlind(OTP_SELECTOR, PUSH_PROMPT_CANDIDATES),
+    false,
+    'the #317 guard cannot fire — the selector is genuinely absent',
+  );
+  const result = attemptRepair(action, OTP_SELECTOR, PUSH_PROMPT_CANDIDATES);
+  assert.equal(result.kind, 'no-match', 'the fuzzy matcher must refuse, not patch');
+  assert.ok(!('newSelector' in result), 'no replacement selector was produced');
+});
+
+test('gh-317: the exact-native oracle still flags a snapshot-visible selector as blind', () => {
+  assert.equal(detectTransportBlind(OTP_SELECTOR, ['Header_title', OTP_SELECTOR]), true);
+  assert.equal(detectTransportBlind(OTP_SELECTOR, PUSH_PROMPT_CANDIDATES), false);
+});
+
+/** A maestro_run envelope carrying the 1.1.x ID-wait wording for `selector`. */
+function waitFailureEnvelope(selector: string, shape: 'throw' | 'warn' = 'throw') {
+  const step = `extendedWaitUntil: visible id="${selector}"`;
+  const terminal = {
+    completedSteps: 1,
+    failedStep: step,
+    exitClass: 'step-failure',
+    failureKind: 'SELECTOR_NOT_FOUND',
+    failureSelector: selector,
+  };
+  const output = `${'x'.repeat(600)}\n  ╰─ Element '#${selector}' not visible within 15s`;
+  const envelope =
+    shape === 'throw'
+      ? {
+          ok: false,
+          error: `Maestro flow failed at step "${step}" (SELECTOR_NOT_FOUND: ${selector})`,
+          data: { passed: false, output, flowFile: 'x', platform: 'ios', terminal },
+        }
+      : {
+          ok: true,
+          data: {
+            passed: false,
+            output,
+            flowFile: 'x',
+            platform: 'ios',
+            failedStep: { name: step, verb: 'extendedWaitUntil' },
+            terminal,
+          },
+          meta: { warning: 'Flow completed with warnings or failures' },
+        };
+  return async () => ({
+    content: [{ type: 'text' as const, text: JSON.stringify(envelope) }],
+    ...(shape === 'throw' ? { isError: true as const } : {}),
+  });
+}
+
+function fakeRepair(envelope: Record<string, unknown>, seen: { failedSelector?: string }) {
+  return async (args: { failedSelector?: string }) => {
+    seen.failedSelector = args.failedSelector;
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(envelope) }],
+      isError: true as const,
+    };
+  };
+}
+
+test('gh-631: absent selector → repair gets the exact selector, refuses, and writes no YAML', async () => {
+  project.seedAction('register', actionYaml(['- tapOn:', `    id: "${OTP_SELECTOR}"`]));
+  const before = project.readYaml('register');
+  const seen: { failedSelector?: string } = {};
+
+  const handler = createRunActionHandler({
+    maestroRun: waitFailureEnvelope(OTP_SELECTOR),
+    // CDP agrees the selector is gone, so the fallback is skipped and the run
+    // reaches the YAML-writing repair path.
+    replayDeps: () => ({
+      pressByTestId: async () => {},
+      typeByTestId: async () => {},
+      treeFor: async () => ({ testID: 'PushPrimer_title', children: [] }),
+      launchApp: async () => {},
+      settle: async () => {},
+    }),
+    probeRetry: { attempts: 1, delayMs: 0 },
+    repairAction: fakeRepair(
+      {
+        ok: false,
+        error: `cdp_repair_action: no confident replacement for "${OTP_SELECTOR}"`,
+        code: 'TESTID_NOT_FOUND',
+      },
+      seen,
+    ),
+  });
+
+  const env = readEnvelope(await handler({ actionId: 'register', projectRoot: project.root }));
+  assert.equal(seen.failedSelector, OTP_SELECTOR, 'repair received the parsed exact selector');
+  assert.equal(env.ok, false);
+  assert.equal(env.meta.autoRepair.outcome, 'refused');
+  assert.equal(env.meta.autoRepair.refusedReason, 'NO_MATCH');
+  assert.equal(project.readYaml('register'), before, 'the saved action is byte-identical');
+});
+
+test('gh-317: a TRANSPORT_BLIND repair refusal is preserved verbatim and writes no YAML', async () => {
+  project.seedAction('register', actionYaml(['- tapOn:', `    id: "${OTP_SELECTOR}"`]));
+  const before = project.readYaml('register');
+  const seen: { failedSelector?: string } = {};
+  let maestroCalls = 0;
+
+  const handler = createRunActionHandler({
+    maestroRun: async (...a: unknown[]) => {
+      maestroCalls++;
+      return waitFailureEnvelope(OTP_SELECTOR)(...(a as []));
+    },
+    repairAction: fakeRepair(
+      {
+        ok: false,
+        error: 'cdp_repair_action: Maestro/WDA reported it not visible, but rn-fast-runner sees it',
+        code: 'TRANSPORT_BLIND',
+      },
+      seen,
+    ),
+  });
+
+  const env = readEnvelope(await handler({ actionId: 'register', projectRoot: project.root }));
+  assert.equal(env.code, 'TRANSPORT_BLIND', 'the honest transport verdict survives');
+  assert.equal(env.meta.autoRepair.refusedReason, 'TRANSPORT_BLIND');
+  assert.equal(maestroCalls, 1, 'no retry after a refused repair');
+  assert.equal(project.readYaml('register'), before);
+});
+
+test('gh-580: the handler resumes reactive replay at the parsed selector', async () => {
+  project.seedAction(
+    'register',
+    actionYaml([
+      '- launchApp:',
+      '    stopApp: false',
+      '- tapOn:',
+      '    id: "direct_login_button"',
+      '- inputText: "user@example.com"',
+      '- assertVisible:',
+      '    id: "otp_sheet"',
+      '- tapOn:',
+      '    id: "otp_submit"',
+    ]),
+  );
+  const { calls, deps } = spyDeps();
+
+  const handler = createRunActionHandler({
+    maestroRun: waitFailureEnvelope('otp_sheet'),
+    replayDeps: () => deps,
+    probeRetry: { attempts: 1, delayMs: 0 },
+  });
+
+  const env = readEnvelope(await handler({ actionId: 'register', projectRoot: project.root }));
+  assert.equal(env.ok, true);
+  assert.equal(env.data.transport, 'cdp-js');
+  assert.deepEqual(env.data.resume, { applied: true, selector: 'otp_sheet', startIndex: 3 });
+  assert.deepEqual(
+    calls,
+    ['press:otp_submit'],
+    'the login tap and email inputText were NOT redispatched through the fallback',
+  );
+});
+
+test('gh-580: repair refusal surfaces the exact selector instead of a raw stdout dump', async () => {
+  project.seedAction('register', actionYaml(['- tapOn:', `    id: "${OTP_SELECTOR}"`]));
+  const before = project.readYaml('register');
+  const handler = createRunActionHandler({
+    maestroRun: async () => ({
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            ok: false,
+            error: `Maestro flow failed at step "extendedWaitUntil: visible id=\\"${OTP_SELECTOR}\\"" (SELECTOR_NOT_FOUND: ${OTP_SELECTOR})`,
+            data: {
+              passed: false,
+              output: `x`.repeat(600) + `\n  ╰─ Element '#${OTP_SELECTOR}' not visible within 15s`,
+              flowFile: 'x',
+              platform: 'ios',
+              terminal: {
+                completedSteps: 1,
+                failedStep: `extendedWaitUntil: visible id="${OTP_SELECTOR}"`,
+                exitClass: 'step-failure',
+                failureKind: 'SELECTOR_NOT_FOUND',
+                failureSelector: OTP_SELECTOR,
+              },
+            },
+          }),
+        },
+      ],
+      isError: true as const,
+    }),
+    repairAction: async () => ({
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            ok: false,
+            error: `cdp_repair_action: no confident replacement for "${OTP_SELECTOR}"`,
+            code: 'TESTID_NOT_FOUND',
+          }),
+        },
+      ],
+      isError: true as const,
+    }),
+  });
+
+  const env = readEnvelope(await handler({ actionId: 'register', projectRoot: project.root }));
+  assert.equal(env.ok, false);
+  assert.equal(env.meta.failureKind, 'SELECTOR_NOT_FOUND');
+  assert.equal(env.meta.failureSelector, OTP_SELECTOR);
+  assert.equal(env.meta.terminal.failureSelector, OTP_SELECTOR);
+  assert.match(env.error, new RegExp(OTP_SELECTOR));
+  assert.ok(
+    env.meta.firstAttemptOutput.includes("Element '#" + OTP_SELECTOR + "' not visible within 15s"),
+    'the head+tail bound keeps the terminal line that a head-only slice dropped',
+  );
+  assert.equal(project.readYaml('register'), before, 'a refused repair writes nothing');
+});
+
+test('gh-580: the warn path (runner exit 0 with failures) reports kind + selector too', async () => {
+  project.seedAction('register', actionYaml(['- tapOn:', `    id: "${OTP_SELECTOR}"`]));
+  const handler = createRunActionHandler({
+    // maestro_run's warnResult shape: ok:true, no `error`, step summary in DATA.
+    maestroRun: async () => ({
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            ok: true,
+            data: {
+              passed: false,
+              output: "maestro-runner 1.1.20\n  ╰─ Element '#otp' not visible within 15s",
+              flowFile: 'x',
+              platform: 'ios',
+              failedStep: {
+                name: 'extendedWaitUntil: visible id="otp"',
+                verb: 'extendedWaitUntil',
+              },
+              terminal: {
+                completedSteps: 1,
+                failedStep: 'extendedWaitUntil: visible id="otp"',
+                exitClass: 'step-failure',
+                failureKind: 'SELECTOR_NOT_FOUND',
+                failureSelector: 'otp',
+              },
+            },
+            meta: { warning: 'Flow completed with warnings or failures' },
+          }),
+        },
+      ],
+    }),
+  });
+
+  const env = readEnvelope(
+    await handler({ actionId: 'register', projectRoot: project.root, autoRepair: false }),
+  );
+  assert.equal(env.ok, false);
+  // Structurally, exactly what the throw path exposes.
+  assert.equal(env.meta.failureKind, 'SELECTOR_NOT_FOUND');
+  assert.equal(env.meta.failureSelector, 'otp');
+  assert.equal(env.meta.terminal.failureSelector, 'otp');
+  assert.match(env.meta.underlyingFailure, /extendedWaitUntil: visible id="otp"/);
+  assert.match(
+    env.meta.underlyingFailure,
+    /\(SELECTOR_NOT_FOUND: otp\)/,
+    'the warn path used to degrade to a bare stdout slice',
+  );
+});

--- a/packages/rn-dev-agent-core/test/unit/gh-580-selector-resume.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-580-selector-resume.test.ts
@@ -671,3 +671,61 @@ for (const retryShape of ['warn', 'throw'] as const) {
     assert.equal(env.meta.terminal.failureSelector, 'otp_retry');
   });
 }
+
+test('gh-580: a killed post-repair retry persists and returns TIMEOUT', async () => {
+  project.seedAction('register', actionYaml(['- tapOn:', '    id: "otp"']));
+  let maestroCalls = 0;
+  const handler = createRunActionHandler({
+    maestroRun: async (...args: unknown[]) => {
+      maestroCalls++;
+      if (maestroCalls === 1) return waitFailureEnvelope('otp')(...(args as []));
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              ok: false,
+              error: 'Maestro flow timed out after step "extendedWaitUntil"',
+              data: {
+                passed: false,
+                output: "Element '#otp_retry' not visible within 15s",
+                terminal: {
+                  completedSteps: 1,
+                  exitClass: 'timed-out',
+                  failureKind: 'SELECTOR_NOT_FOUND',
+                  failureSelector: 'otp_retry',
+                },
+              },
+            }),
+          },
+        ],
+        isError: true as const,
+      };
+    },
+    repairAction: async () => ({
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            ok: true,
+            data: {
+              patched: true,
+              oldSelector: 'otp',
+              newSelector: 'otp_retry',
+              score: 0.9,
+            },
+          }),
+        },
+      ],
+    }),
+  });
+
+  const env = readEnvelope(await handler({ actionId: 'register', projectRoot: project.root }));
+  assert.equal(env.ok, false);
+  assert.equal(env.code, undefined);
+  assert.equal(env.meta.failureKind, 'TIMEOUT');
+  assert.equal(env.meta.failureSelector, 'otp_retry');
+  assert.equal(env.meta.terminal.exitClass, 'timed-out');
+  const sidecar = project.readSidecar('register');
+  assert.equal(sidecar.runHistory.at(-1)?.failureCode, 'TIMEOUT');
+});

--- a/packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts
@@ -7,7 +7,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { parseMaestroFailure, isAutoRepairable } from '../../dist/domain/maestro-error-parser.js';
-import { buildTerminalEvidence } from '../../dist/domain/maestro-step-parser.js';
+import {
+  buildStepSummary,
+  buildTerminalEvidence,
+} from '../../dist/domain/maestro-step-parser.js';
 import { boundedOutput } from '../../dist/tools/run-action.js';
 
 // The exact live capture from the issue, at the runner's real 4-space indent.
@@ -192,6 +195,37 @@ test('gh-580: a selector-less summary cannot borrow an unrelated earlier ID wait
   ].join('\n');
   assert.equal(parseMaestroFailure(output).kind, 'UNKNOWN');
   assert.equal(buildTerminalEvidence(output).failureKind, undefined);
+});
+
+test('gh-580: a terminal text wait cannot borrow a duplicate ID-shaped reason', () => {
+  const output = [
+    '    ✗ extendedWaitUntil: visible id="otp" (1.2s)',
+    "      ╰─ Element '#otp' not visible within 1.1s",
+    '    ✗ extendedWaitUntil: visible text="#otp" (1.4s)',
+    "      ╰─ Element '#otp' not visible within 1.1s",
+  ].join('\n');
+  assert.equal(parseMaestroFailure(output).kind, 'UNKNOWN');
+  assert.equal(buildTerminalEvidence(output).failureKind, undefined);
+});
+
+test('gh-580: exact long IDs survive bounded display projection', () => {
+  const selector = `terminal_${'x'.repeat(220)}`;
+  const output = [
+    `    ✗ extendedWaitUntil: visible id="${selector}" (1.2s)`,
+    `      ╰─ Element '#${selector}' not visible within 1.1s`,
+  ].join('\n');
+  const summary = buildStepSummary(output, { failed: true });
+  assert.equal(summary.failedStep?.name.length, 201);
+  assert.equal(summary.reason?.selector?.length, 201);
+
+  const terminal = buildTerminalEvidence(output);
+  assert.equal(terminal.failureKind, 'SELECTOR_NOT_FOUND');
+  assert.equal(terminal.failureSelector, selector);
+  assert.equal(terminal.failedStep, `extendedWaitUntil: visible id="${selector}"`);
+
+  const failure = parseMaestroFailure('', terminal);
+  assert.equal(failure.kind, 'SELECTOR_NOT_FOUND');
+  assert.equal(failure.selector, selector);
 });
 
 test('gh-580: an earlier transient wait miss loses to the terminal one (GH #118 ordering)', () => {

--- a/packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts
@@ -108,6 +108,18 @@ test('gh-580: an earlier transient wait miss loses to the terminal one (GH #118 
   assert.equal(parseMaestroFailure(retried).selector, 'real_terminal_target');
 });
 
+test('gh-580: an earlier ID wait cannot outrank a terminal text or regex wait', () => {
+  for (const terminalSelector of ["'Continue'", '".*"']) {
+    const output = [
+      '    ✗ extendedWaitUntil: visible text="Continue" (15.0s)',
+      "      ╰─ Element '#stale_transient' not visible within 1s",
+      `      ╰─ Element ${terminalSelector} not visible within 15s`,
+    ].join('\n');
+    assert.equal(parseMaestroFailure(output).kind, 'UNKNOWN');
+    assert.equal(buildTerminalEvidence(output).failureKind, undefined);
+  }
+});
+
 test('gh-580: boundedOutput keeps head AND tail inside one 500-char budget', () => {
   const short = 'maestro-runner 1.1.20\n    ✓ launchApp (2.7s)';
   assert.equal(boundedOutput(short), short, 'output within budget is returned verbatim');

--- a/packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts
@@ -120,6 +120,32 @@ test('gh-580: an earlier ID wait cannot outrank a terminal text or regex wait', 
   }
 });
 
+test('gh-580: an earlier ID wait cannot outrank a terminal assertion or timeout', () => {
+  const cases = [
+    {
+      terminal: '      ╰─ Assertion failed: "ready" not visible',
+      kind: 'ASSERTION_FAILED',
+      selector: 'ready',
+    },
+    {
+      terminal: '      ╰─ Timed out waiting for element "spinner"',
+      kind: 'TIMEOUT',
+      selector: 'spinner',
+    },
+  ] as const;
+  for (const { terminal, kind, selector } of cases) {
+    const output = ["      ╰─ Element '#stale_transient' not visible within 1s", terminal].join(
+      '\n',
+    );
+    const failure = parseMaestroFailure(output);
+    assert.equal(failure.kind, kind);
+    assert.equal(failure.selector, selector);
+    const evidence = buildTerminalEvidence(output);
+    assert.equal(evidence.failureKind, kind);
+    assert.equal(evidence.failureSelector, selector);
+  }
+});
+
 test('gh-580: boundedOutput keeps head AND tail inside one 500-char budget', () => {
   const short = 'maestro-runner 1.1.20\n    ✓ launchApp (2.7s)';
   assert.equal(boundedOutput(short), short, 'output within budget is returned verbatim');

--- a/packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts
@@ -190,6 +190,21 @@ test('gh-580: an unrelated trailing app timeout log cannot hide terminal ID evid
   assert.equal(failure.selector, 'expected');
 });
 
+test('gh-580: ANSI-colored terminal step and reason preserve raw evidence', () => {
+  const esc = String.fromCharCode(27);
+  const output = [
+    `${esc}[31m    ✗ extendedWaitUntil: visible id="colored" (15.0s)${esc}[0m`,
+    `${esc}[31m      ╰─ Element '#colored' not visible within 15s${esc}[0m`,
+  ].join('\n');
+  const failure = parseMaestroFailure(output);
+  assert.equal(failure.kind, 'SELECTOR_NOT_FOUND');
+  assert.equal(failure.selector, 'colored');
+  assert.equal(failure.raw, output);
+  const terminal = buildTerminalEvidence(output);
+  assert.equal(terminal.failureKind, 'SELECTOR_NOT_FOUND');
+  assert.equal(terminal.failureSelector, 'colored');
+});
+
 test('gh-580: boundedOutput keeps head AND tail inside one 500-char budget', () => {
   const short = 'maestro-runner 1.1.20\n    ✓ launchApp (2.7s)';
   assert.equal(boundedOutput(short), short, 'output within budget is returned verbatim');

--- a/packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts
@@ -120,6 +120,17 @@ test('gh-580: an earlier ID wait cannot outrank a terminal text or regex wait', 
   }
 });
 
+test('gh-580: an earlier ID wait cannot cross a selector-less timeout barrier', () => {
+  const output = [
+    "      ╰─ Element '#stale_transient' not visible within 1s",
+    '      ╰─ Wait timed out (cause: context deadline exceeded)',
+  ].join('\n');
+  const failure = parseMaestroFailure(output);
+  assert.equal(failure.kind, 'UNKNOWN');
+  assert.equal(isAutoRepairable(failure), false);
+  assert.equal(buildTerminalEvidence(output).failureKind, undefined);
+});
+
 test('gh-580: an earlier ID wait cannot outrank a terminal assertion or timeout', () => {
   const cases = [
     {

--- a/packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts
@@ -1,0 +1,129 @@
+// GH #580 — maestro-runner 1.1.16/1.1.20 renders an ID wait miss as
+// `Element '#X' not visible within Ns`, a wording the parser did not know, so an
+// ordinary missing-selector failure was classified UNKNOWN and refused repair
+// with NOT_REPAIRABLE_KIND. These tests pin the new classification, the shapes it
+// must NOT claim, and the head+tail output contract that replaced the head-only
+// slice which only ever showed the WDA preamble.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseMaestroFailure, isAutoRepairable } from '../../dist/domain/maestro-error-parser.js';
+import { buildTerminalEvidence } from '../../dist/domain/maestro-step-parser.js';
+import { boundedOutput } from '../../dist/tools/run-action.js';
+
+// The exact live capture from the issue, at the runner's real 4-space indent.
+const RUNNER_1_1_20_STDOUT = [
+  'maestro-runner 1.1.20',
+  'Starting WDA on device 1234-ABCD',
+  '    ✓ launchApp (2.7s)',
+  '    ✗ extendedWaitUntil: visible id="fixture_never_exists" (1.2s)',
+  "      ╰─ Element '#fixture_never_exists' not visible within 1s (cause: context deadline exceeded)",
+].join('\n');
+
+test('gh-580: raw 1.1.20 ID-wait stdout classifies SELECTOR_NOT_FOUND with the exact id', () => {
+  const failure = parseMaestroFailure(RUNNER_1_1_20_STDOUT);
+  assert.equal(failure.kind, 'SELECTOR_NOT_FOUND');
+  assert.equal(failure.selector, 'fixture_never_exists');
+  assert.equal(failure.selectorKind, 'id');
+  assert.equal(isAutoRepairable(failure), true);
+});
+
+test('gh-580: the same wording survives buildTerminalEvidence as kind + exact selector', () => {
+  const terminal = buildTerminalEvidence(RUNNER_1_1_20_STDOUT);
+  assert.equal(terminal.exitClass, 'step-failure');
+  assert.equal(terminal.failureKind, 'SELECTOR_NOT_FOUND');
+  assert.equal(terminal.failureSelector, 'fixture_never_exists');
+  assert.equal(terminal.failedStep, 'extendedWaitUntil: visible id="fixture_never_exists"');
+
+  // …and the caller-side parse agrees when it reads terminal evidence instead
+  // of the (possibly truncated) stdout.
+  const failure = parseMaestroFailure('', terminal);
+  assert.equal(failure.kind, 'SELECTOR_NOT_FOUND');
+  assert.equal(failure.selector, 'fixture_never_exists');
+});
+
+test('gh-580: double-quoted rendering and ids containing quotes/# still extract exactly', () => {
+  const dq = parseMaestroFailure('  ╰─ Element "#user\'s-tasks" not visible within 15s');
+  assert.equal(dq.kind, 'SELECTOR_NOT_FOUND');
+  assert.equal(dq.selector, "user's-tasks");
+
+  const hashInside = parseMaestroFailure("  ╰─ Element '#tag#42' not visible within 2s");
+  assert.equal(hashInside.kind, 'SELECTOR_NOT_FOUND');
+  assert.equal(hashInside.selector, 'tag#42');
+});
+
+test('gh-580: text and regex waits are NOT reclassified — #334 owns that grammar', () => {
+  // No `#` marker → a text selector. Must stay UNKNOWN, not become a fake id.
+  const text = parseMaestroFailure("  ╰─ Element 'Continue' not visible within 15s");
+  assert.equal(text.kind, 'UNKNOWN');
+
+  const regex = parseMaestroFailure('  ╰─ Element ".*" not visible within 15s');
+  assert.equal(regex.kind, 'UNKNOWN');
+
+  // A selector-less deadline stays UNKNOWN too.
+  assert.equal(
+    parseMaestroFailure('  ╰─ Wait timed out (cause: context deadline exceeded)').kind,
+    'UNKNOWN',
+  );
+
+  // An empty id renders no selector to extract — refuse rather than invent one.
+  assert.equal(parseMaestroFailure("  ╰─ Element '#' not visible within 1s").kind, 'UNKNOWN');
+});
+
+test('gh-580: a killed process outranks a matching wait line — process TIMEOUT precedence', () => {
+  const terminal = buildTerminalEvidence(RUNNER_1_1_20_STDOUT, { timedOut: true });
+  assert.equal(terminal.exitClass, 'timed-out');
+  // The wait wording IS present and classified inside the terminal evidence…
+  assert.equal(terminal.failureKind, 'SELECTOR_NOT_FOUND');
+
+  // …but exitClass wins, so the run stays a non-repairable TIMEOUT and can never
+  // reach the YAML-rewriting repair path.
+  const failure = parseMaestroFailure(RUNNER_1_1_20_STDOUT, terminal);
+  assert.equal(failure.kind, 'TIMEOUT');
+  assert.equal(isAutoRepairable(failure), false);
+});
+
+test('gh-580: duplicated staged runner output does not change the classified selector', () => {
+  // Authority staging re-invokes the runner with the same argv, so a passing
+  // stage's narration is concatenated ahead of the failing stage's.
+  const staged = [
+    'maestro-runner 1.1.20',
+    '    ✓ launchApp (2.7s)',
+    'maestro-runner 1.1.20',
+    '    ✓ launchApp (1.1s)',
+    '    ✗ extendedWaitUntil: visible id="otp_field" (1.2s)',
+    "      ╰─ Element '#otp_field' not visible within 15s (cause: context deadline exceeded)",
+  ].join('\n');
+  const terminal = buildTerminalEvidence(staged);
+  assert.equal(terminal.failureKind, 'SELECTOR_NOT_FOUND');
+  assert.equal(terminal.failureSelector, 'otp_field');
+  assert.equal(parseMaestroFailure(staged).selector, 'otp_field');
+});
+
+test('gh-580: an earlier transient wait miss loses to the terminal one (GH #118 ordering)', () => {
+  const retried = [
+    "    ╰─ Element '#stale_transient' not visible within 1s",
+    '    ✓ tapOn: retry (0.4s)',
+    "    ╰─ Element '#real_terminal_target' not visible within 15s",
+  ].join('\n');
+  assert.equal(parseMaestroFailure(retried).selector, 'real_terminal_target');
+});
+
+test('gh-580: boundedOutput keeps head AND tail inside one 500-char budget', () => {
+  const short = 'maestro-runner 1.1.20\n    ✓ launchApp (2.7s)';
+  assert.equal(boundedOutput(short), short, 'output within budget is returned verbatim');
+  assert.equal(boundedOutput(''), '');
+
+  const head = 'H'.repeat(400);
+  const tail = "  ╰─ Element '#otp_field' not visible within 15s".padStart(400, 'T');
+  const long = head + tail;
+  const bounded = boundedOutput(long);
+
+  assert.equal(bounded.length, 500, 'exactly the budget, never more');
+  assert.equal(bounded.slice(0, 249), long.slice(0, 249), 'first 249 chars are the head');
+  assert.equal(bounded.slice(-248), long.slice(-248), 'last 248 chars are the tail');
+  assert.equal(bounded.slice(249, 252), '\n…\n', 'the elision is explicit');
+  assert.ok(
+    bounded.includes("Element '#otp_field' not visible within 15s"),
+    'the terminal failure at the tail now survives the bound (defect 3)',
+  );
+});

--- a/packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts
@@ -42,11 +42,21 @@ test('gh-580: the same wording survives buildTerminalEvidence as kind + exact se
 });
 
 test('gh-580: double-quoted rendering and ids containing quotes/# still extract exactly', () => {
-  const dq = parseMaestroFailure('  ╰─ Element "#user\'s-tasks" not visible within 15s');
+  const dq = parseMaestroFailure(
+    [
+      '    ✗ extendedWaitUntil: visible id="user\'s-tasks" (15.0s)',
+      '      ╰─ Element "#user\'s-tasks" not visible within 15s',
+    ].join('\n'),
+  );
   assert.equal(dq.kind, 'SELECTOR_NOT_FOUND');
   assert.equal(dq.selector, "user's-tasks");
 
-  const hashInside = parseMaestroFailure("  ╰─ Element '#tag#42' not visible within 2s");
+  const hashInside = parseMaestroFailure(
+    [
+      "    ✗ extendedWaitUntil: visible id='tag#42' (2.0s)",
+      "      ╰─ Element '#tag#42' not visible within 2s",
+    ].join('\n'),
+  );
   assert.equal(hashInside.kind, 'SELECTOR_NOT_FOUND');
   assert.equal(hashInside.selector, 'tag#42');
 });
@@ -102,7 +112,7 @@ test('gh-580: duplicated staged runner output does not change the classified sel
 test('gh-580: an earlier transient wait miss loses to the terminal one (GH #118 ordering)', () => {
   const retried = [
     "    ╰─ Element '#stale_transient' not visible within 1s",
-    '    ✓ tapOn: retry (0.4s)',
+    '    ✗ extendedWaitUntil: visible id="real_terminal_target" (15.0s)',
     "    ╰─ Element '#real_terminal_target' not visible within 15s",
   ].join('\n');
   assert.equal(parseMaestroFailure(retried).selector, 'real_terminal_target');
@@ -111,8 +121,8 @@ test('gh-580: an earlier transient wait miss loses to the terminal one (GH #118 
 test('gh-580: an earlier ID wait cannot outrank a terminal text or regex wait', () => {
   for (const terminalSelector of ["'Continue'", '".*"']) {
     const output = [
-      '    ✗ extendedWaitUntil: visible text="Continue" (15.0s)',
       "      ╰─ Element '#stale_transient' not visible within 1s",
+      '    ✗ extendedWaitUntil: visible text="Continue" (15.0s)',
       `      ╰─ Element ${terminalSelector} not visible within 15s`,
     ].join('\n');
     assert.equal(parseMaestroFailure(output).kind, 'UNKNOWN');
@@ -123,6 +133,7 @@ test('gh-580: an earlier ID wait cannot outrank a terminal text or regex wait', 
 test('gh-580: an earlier ID wait cannot cross a selector-less timeout barrier', () => {
   const output = [
     "      ╰─ Element '#stale_transient' not visible within 1s",
+    '    ✗ extendedWaitUntil: visible text="Continue" (15.0s)',
     '      ╰─ Wait timed out (cause: context deadline exceeded)',
   ].join('\n');
   const failure = parseMaestroFailure(output);
@@ -145,9 +156,11 @@ test('gh-580: an earlier ID wait cannot outrank a terminal assertion or timeout'
     },
   ] as const;
   for (const { terminal, kind, selector } of cases) {
-    const output = ["      ╰─ Element '#stale_transient' not visible within 1s", terminal].join(
-      '\n',
-    );
+    const output = [
+      "      ╰─ Element '#stale_transient' not visible within 1s",
+      '    ✗ assertVisible: id="ready" (15.0s)',
+      terminal,
+    ].join('\n');
     const failure = parseMaestroFailure(output);
     assert.equal(failure.kind, kind);
     assert.equal(failure.selector, selector);
@@ -155,6 +168,26 @@ test('gh-580: an earlier ID wait cannot outrank a terminal assertion or timeout'
     assert.equal(evidence.failureKind, kind);
     assert.equal(evidence.failureSelector, selector);
   }
+});
+
+test('gh-580: mismatched terminal step and reason IDs stay UNKNOWN', () => {
+  const output = [
+    '    ✗ extendedWaitUntil: visible id="expected" (15.0s)',
+    "      ╰─ Element '#other' not visible within 15s",
+  ].join('\n');
+  assert.equal(parseMaestroFailure(output).kind, 'UNKNOWN');
+  assert.equal(buildTerminalEvidence(output).failureKind, undefined);
+});
+
+test('gh-580: an unrelated trailing app timeout log cannot hide terminal ID evidence', () => {
+  const output = [
+    '    ✗ extendedWaitUntil: visible id="expected" (15.0s)',
+    "      ╰─ Element '#expected' not visible within 15s",
+    'console: Wait timed out while refreshing analytics',
+  ].join('\n');
+  const failure = parseMaestroFailure(output);
+  assert.equal(failure.kind, 'SELECTOR_NOT_FOUND');
+  assert.equal(failure.selector, 'expected');
 });
 
 test('gh-580: boundedOutput keeps head AND tail inside one 500-char budget', () => {

--- a/packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts
@@ -109,6 +109,91 @@ test('gh-580: duplicated staged runner output does not change the classified sel
   assert.equal(parseMaestroFailure(staged).selector, 'otp_field');
 });
 
+// Captured verbatim from maestro-runner 1.1.20 driving a dedicated iOS 26.4
+// simulator (PR #665 live validation): the runner renders ONE failure as a
+// detailed ID-bearing block followed by a selector-less summary that repeats the
+// identical reason. `findFailedStep` takes the LAST step, so the terse summary
+// became the failed step and the exact ID was lost to UNKNOWN.
+const RUNNER_1_1_20_DUPLICATE_SUMMARY = [
+  'maestro-runner 1.1.20',
+  '    ✗ extendedWaitUntil: visible id="rn580_terminal_missing" (1.2s)',
+  "      ╰─ Element '#rn580_terminal_missing' not visible within 1.1s (cause: context deadline exceeded)",
+  '',
+  '    ✗ extendedWaitUntil (1.4s)',
+  "      ╰─ Element '#rn580_terminal_missing' not visible within 1.1s (cause: context deadline exceeded)",
+].join('\n');
+
+test('gh-580: a selector-less duplicate summary does not erase the real terminal ID', () => {
+  const terminal = buildTerminalEvidence(RUNNER_1_1_20_DUPLICATE_SUMMARY);
+  assert.equal(terminal.exitClass, 'step-failure');
+  assert.equal(terminal.failureKind, 'SELECTOR_NOT_FOUND');
+  assert.equal(terminal.failureSelector, 'rn580_terminal_missing');
+
+  const failure = parseMaestroFailure(RUNNER_1_1_20_DUPLICATE_SUMMARY, terminal);
+  assert.equal(failure.kind, 'SELECTOR_NOT_FOUND');
+  assert.equal(failure.selector, 'rn580_terminal_missing');
+  assert.equal(isAutoRepairable(failure), true);
+
+  // …and from raw stdout alone, with no terminal evidence supplied.
+  const fromRaw = parseMaestroFailure(RUNNER_1_1_20_DUPLICATE_SUMMARY);
+  assert.equal(fromRaw.kind, 'SELECTOR_NOT_FOUND');
+  assert.equal(fromRaw.selector, 'rn580_terminal_missing');
+  assert.equal(fromRaw.selectorKind, 'id');
+});
+
+test('gh-580: a killed process still outranks the duplicate-summary rendering', () => {
+  const terminal = buildTerminalEvidence(RUNNER_1_1_20_DUPLICATE_SUMMARY, { timedOut: true });
+  assert.equal(terminal.exitClass, 'timed-out');
+  const failure = parseMaestroFailure(RUNNER_1_1_20_DUPLICATE_SUMMARY, terminal);
+  assert.equal(failure.kind, 'TIMEOUT');
+  assert.equal(isAutoRepairable(failure), false);
+});
+
+test('gh-580: only a byte-identical repeated reason counts as a duplicate rendering', () => {
+  // Different ID in the terminal reason → the earlier block is a DIFFERENT
+  // failure, so nothing binds and the stale ID cannot be promoted.
+  const mismatched = [
+    '    ✗ extendedWaitUntil: visible id="stale_id" (1.2s)',
+    "      ╰─ Element '#stale_id' not visible within 1.1s",
+    '    ✗ extendedWaitUntil (1.4s)',
+    "      ╰─ Element '#different_id' not visible within 1.1s",
+  ].join('\n');
+  assert.equal(parseMaestroFailure(mismatched).kind, 'UNKNOWN');
+
+  // Same ID but a different reason line (different timeout) is likewise not a
+  // duplicate rendering — refuse rather than assume.
+  const differentReason = [
+    '    ✗ extendedWaitUntil: visible id="otp" (1.2s)',
+    "      ╰─ Element '#otp' not visible within 1.1s",
+    '    ✗ extendedWaitUntil (9.0s)',
+    "      ╰─ Element '#otp' not visible within 9s",
+  ].join('\n');
+  assert.equal(parseMaestroFailure(differentReason).kind, 'UNKNOWN');
+
+  // A passing step between the blocks ends the duplicate chain.
+  const interrupted = [
+    '    ✗ extendedWaitUntil: visible id="otp" (1.2s)',
+    "      ╰─ Element '#otp' not visible within 1.1s",
+    '    ✓ tapOn: retry (0.4s)',
+    '    ✗ extendedWaitUntil (1.4s)',
+    "      ╰─ Element '#otp' not visible within 1.1s",
+  ].join('\n');
+  assert.equal(parseMaestroFailure(interrupted).kind, 'UNKNOWN');
+});
+
+test('gh-580: a selector-less summary cannot borrow an unrelated earlier ID wait', () => {
+  // The terminal reason is text-shaped, so no ID may bind even though an
+  // ID-bearing block appears earlier in the stream.
+  const output = [
+    '    ✗ extendedWaitUntil: visible id="stale_id" (1.2s)',
+    "      ╰─ Element '#stale_id' not visible within 1.1s",
+    '    ✗ extendedWaitUntil (1.4s)',
+    "      ╰─ Element 'Continue' not visible within 1.1s",
+  ].join('\n');
+  assert.equal(parseMaestroFailure(output).kind, 'UNKNOWN');
+  assert.equal(buildTerminalEvidence(output).failureKind, undefined);
+});
+
 test('gh-580: an earlier transient wait miss loses to the terminal one (GH #118 ordering)', () => {
   const retried = [
     "    ╰─ Element '#stale_transient' not visible within 1s",

--- a/packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts
@@ -7,10 +7,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { parseMaestroFailure, isAutoRepairable } from '../../dist/domain/maestro-error-parser.js';
-import {
-  buildStepSummary,
-  buildTerminalEvidence,
-} from '../../dist/domain/maestro-step-parser.js';
+import { buildStepSummary, buildTerminalEvidence } from '../../dist/domain/maestro-step-parser.js';
 import { boundedOutput } from '../../dist/tools/run-action.js';
 
 // The exact live capture from the issue, at the runner's real 4-space indent.

--- a/packages/rn-dev-agent-core/test/unit/gh-584-managed-automation.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-584-managed-automation.test.ts
@@ -12,9 +12,23 @@ import { spawnManagedProcessGroup } from '../../dist/session/managed-automation.
 function alive(pid: number): boolean {
   try {
     process.kill(pid, 0);
-    return true;
   } catch {
     return false;
+  }
+
+  if (process.platform !== 'linux') return true;
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+    const commandEnd = stat.lastIndexOf(')');
+    return (
+      commandEnd < 0 ||
+      stat
+        .slice(commandEnd + 1)
+        .trim()
+        .split(/\s+/, 1)[0] !== 'Z'
+    );
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ENOENT';
   }
 }
 

--- a/packages/rn-dev-agent-core/test/unit/maestro-error-parser.test.js
+++ b/packages/rn-dev-agent-core/test/unit/maestro-error-parser.test.js
@@ -310,13 +310,18 @@ test('parser: 1.0.9 shape — full realistic maestro-runner 1.0.9 stderr', () =>
   assert.equal(out.selector, 'task-mark-all-done');
 });
 
-test('parser: 1.0.9 id= shape has priority over the generic fallback', () => {
-  // The 1.0.9 id= pattern is more specific than the catch-all "Element 'X' not found".
-  // Pattern order in maestro-error-parser.ts MUST keep id-shape ahead of the fallback.
-  // If a regression reorders patterns, this test catches it.
+test('parser: 1.0.9 id= shape has priority on the same terminal line', () => {
+  const out = parseMaestroFailure(
+    "Element not found: id='specific-id'; also seen: Element 'fallback-id' not found",
+  );
+  assert.equal(out.selectorKind, 'id');
+  assert.equal(out.selector, 'specific-id');
+});
+
+test('parser: the newest failure line outranks an earlier more-specific shape', () => {
   const out = parseMaestroFailure(
     "Element not found: id='specific-id'\nAlso seen: Element 'fallback-id' not found",
   );
-  assert.equal(out.selectorKind, 'id', 'id= shape must win over fallback when both present');
-  assert.equal(out.selector, 'specific-id');
+  assert.equal(out.selectorKind, 'unknown');
+  assert.equal(out.selector, 'fallback-id');
 });

--- a/packages/rn-dev-agent-core/test/unit/maestro-error-parser.test.js
+++ b/packages/rn-dev-agent-core/test/unit/maestro-error-parser.test.js
@@ -310,18 +310,13 @@ test('parser: 1.0.9 shape — full realistic maestro-runner 1.0.9 stderr', () =>
   assert.equal(out.selector, 'task-mark-all-done');
 });
 
-test('parser: 1.0.9 id= shape has priority on the same terminal line', () => {
-  const out = parseMaestroFailure(
-    "Element not found: id='specific-id'; also seen: Element 'fallback-id' not found",
-  );
-  assert.equal(out.selectorKind, 'id');
-  assert.equal(out.selector, 'specific-id');
-});
-
-test('parser: the newest failure line outranks an earlier more-specific shape', () => {
+test('parser: 1.0.9 id= shape has priority over the generic fallback', () => {
+  // The 1.0.9 id= pattern is more specific than the catch-all "Element 'X' not found".
+  // Pattern order in maestro-error-parser.ts MUST keep id-shape ahead of the fallback.
+  // If a regression reorders patterns, this test catches it.
   const out = parseMaestroFailure(
     "Element not found: id='specific-id'\nAlso seen: Element 'fallback-id' not found",
   );
-  assert.equal(out.selectorKind, 'unknown');
-  assert.equal(out.selector, 'fallback-id');
+  assert.equal(out.selectorKind, 'id', 'id= shape must win over fallback when both present');
+  assert.equal(out.selector, 'specific-id');
 });

--- a/packages/shared-agent-knowledge/commands/run-action.md
+++ b/packages/shared-agent-knowledge/commands/run-action.md
@@ -126,7 +126,7 @@ Example calls:
        },
        durationMs,
        flowFile,
-       firstAttemptOutput?: string,     // first 500 chars of maestro stdout/stderr
+       firstAttemptOutput?: string,     // bounded maestro stdout/stderr: head + tail, 500 chars
        retryOutput?: string,            // present iff retriedAfterRepair === true
        retriedAfterRepair?: boolean
      }
@@ -139,8 +139,11 @@ Example calls:
 
    On failure (`ok: false`), the envelope's `error` message and
    `meta.underlyingFailure` carry the exact underlying Maestro failure
-   (the runner's headline error, or the failing step name) — read those
-   directly instead of digging through the maestro report output.
+   (the failing step name plus `KIND: selector` when the runner named one),
+   and `meta.failureKind` / `meta.failureSelector` expose the same evidence
+   structurally. Read those directly. The runner's HTML report is a
+   temporary artifact that is deleted after every run — no report path is
+   returned, and none should be looked for.
 
    Branch on `data.autoRepair.outcome`:
    - **`outcome === 'skipped'`** with `attempted: false`: happy path —
@@ -172,7 +175,6 @@ After execution, summarise:
 ```
 ✅ <flow-name> passed (16/16, 18.5s)
 Replayed: <command-line>
-Report: reports/2026-04-29_HH-MM-SS/report.html
 ```
 
 Or:
@@ -180,7 +182,6 @@ Or:
 ```
 ❌ <flow-name> failed at step <N> ("tapOn id: ...")
 Replayed: <command-line>
-Failing screenshot: reports/.../assets/flow-000/cmd-N-after.png
 Likely cause: <one-line diagnosis>
 Next step: <single concrete suggestion>
 ```

--- a/packages/shared-agent-knowledge/commands/run-action.md
+++ b/packages/shared-agent-knowledge/commands/run-action.md
@@ -155,7 +155,7 @@ Example calls:
      diff .rn-agent/actions/<id>.yaml` to inspect.
    - **`outcome === 'failed'`**: post-repair retry still failed —
      `meta.underlyingFailure` carries the exact failure;
-     `data.retryOutput` has the trailing maestro output for deeper
+     `data.retryOutput` has bounded head-and-tail Maestro output for deeper
      diagnosis.
    - **`outcome === 'refused'`** with `refusedReason`: auto-repair declined
      (user disabled, file edited since load, repair budget exhausted, or


### PR DESCRIPTION
## Intent

Correct PR #665 (github.com/Lykhoyda/rn-dev-agent) after final real-runner validation FAILED at head 7f7b12e2. This is the bounded issue #580 code slice. Do NOT merge, and do NOT treat #580 as closed: issue #334 separately owns fallback-grammar expansion, and the #580 umbrella stays open until #334 lands and the real registration action succeeds.

WHAT WAS ALREADY ACCEPTED AND MERGED INTO THIS BRANCH (do not re-litigate; these are deliberate, captain-approved decisions):
1. Classify the maestro-runner 1.1.16/1.1.20 ID-wait wording ("Element '#X' not visible within ...") as SELECTOR_NOT_FOUND with exact ID X. Text/regex waits must NOT be reclassified — issue #334 owns that grammar. Process/global timeout precedence must stay TIMEOUT even when matching wait text is present.
2. Bounded terminal failure evidence on both the warning path (runner exit 0 with failures) and the throw path, preferring kind + selector, using existing terminal fields. Head-only stdout slicing replaced with a bounded head+tail representation (exactly 500 chars over budget, explicit elision) because the terminal failure lives at the tail while the head is WDA preamble. No report directories exposed or retained.
3. Selector-anchored reactive replay resume: on a parsed exact failed selector, locate exactly one matching source step and normalize/replay only that suffix, preserving source indices. Zero, duplicate, sub-flow-nested, or unscannably-deep matches refuse resume and retain start-at-zero; never guess an index. A resumed inputText without a preceding focus target must keep failing loudly. Proactive and pre-first-step paths stay start-at-zero and whole-flow.
4. Reject clearState and any launchApp map key the CDP transport cannot honor with a named UnsupportedStepError (simctl launch cannot clear state); preserve supported stopApp; a non-boolean stopApp is also rejected rather than silently coerced. Proactive probing must not route such flows to CDP/JS.
5. Stale documentation promise that every run returns reports/<timestamp>/report.html removed; canonical docs plus generated/mirrored host packages updated through repository scripts; changeset added; generated artifacts rebuilt via documented build commands.

THE ONLY NEW CHANGE IN THIS ROUND (the reproduced blocking defect from live validation):
maestro-runner 1.1.20 on a dedicated iOS 26.4 simulator renders ONE failure as two blocks — a detailed step naming the id, then a selector-less summary repeating the identical reason line:
✗ extendedWaitUntil: visible id="rn580_terminal_missing" (1.2s)
╰─ Element '#rn580_terminal_missing' not visible within 1.1s (cause: context deadline exceeded)
✗ extendedWaitUntil (1.4s)
╰─ Element '#rn580_terminal_missing' not visible within 1.1s (cause: context deadline exceeded)
findFailedStep takes the LAST step, so failedStep became the bare 'extendedWaitUntil', ID_WAIT_STEP_RE could not match it, parseTerminalIdWait returned null, and classification fell through to UNKNOWN instead of SELECTOR_NOT_FOUND with the exact id. This defeated the PR's central accepted behavior on the actual supported runner. It was reproduced verbatim against the built runtime at the PR head before any edit.

Fix and its rationale: the terminal reason line already resolved correctly to the ID-bearing line; ONLY the step-name corroboration failed. So when the terminal step carries no selector, borrow the id from an earlier failed block that repeats the BYTE-IDENTICAL reason line. Byte-identical reason lines necessarily name the same id, which is precisely what makes borrowing safe — the id still originates from the terminal reason, and the earlier block only corroborates that the terminal failure is an ID wait. The duplicate chain is deliberately strict: a passing step between blocks, a differing reason line (including merely a different timeout value), or a mismatched id all end the chain and leave classification unchanged.

CONSTRAINTS THAT MUST NOT REGRESS (several were already re-litigated across three prior review rounds; re-raising them is a false positive):
- Legacy PATTERNS precedence is FROZEN: pattern-specificity dominates and line-position breaks ties within a pattern (GH #118). Global line-first selection was proposed and REJECTED twice by the captain; it must not return.
- The legacy guard test 'parser: 1.0.9 id= shape has priority over the generic fallback' in maestro-error-parser.test.js must stay byte-identical including its tripwire comment. Rewriting or weakening it was explicitly forbidden.
- No third parser architecture and no accreting heuristics. Round 3 deliberately REMOVED both earlier mechanisms (global line-first, and terminalWaitOnly/terminal-barrier machinery) in favour of binding the new classification to matching terminal step + terminal reason ids. This round refines inside that same function only; it adds no new selection mechanism, no terminal barrier, and no report ingestion.
- An earlier stale ID must never outrank a genuinely later text, regex, assertion, process-timeout, or selector-less failure.
- Mismatched IDs must not bind.
- ANSI is stripped before glyph-anchored matching while the returned raw stays unstripped.
- Only SELECTOR_NOT_FOUND is auto-repairable and auto-repair rewrites the user's YAML: no action YAML write on #631-style completed-flow false positives or on true selector drift, and the #317 exact-native TRANSPORT_BLIND refusal must keep firing when the selector IS present in the native snapshot.

EXPLICITLY OUT OF SCOPE (do not expand): the validator also observed candidate cdp_connect rolling back from ready to device_bound. That is NOT proven to be a PR #665 regression and must not be expanded into session-authority work; a clean rerun with a persistent MCP transport will reassess it. Also still excluded: fallback-grammar additions (extendedWaitUntil replay, text selectors, hideKeyboard, pressKey, swipe, maestro_run, suites), structured runner-report ingestion, report retention, generalized 'requires:' schema, prerequisite state machine, native-first replay, and any new YAML-writing mechanism.

Validation already run locally and green: the exact real two-block stream now classifies SELECTOR_NOT_FOUND with selector rn580_terminal_missing from both raw stdout and buildTerminalEvidence; 6 new regressions added (real duplicate-summary capture, killed-process precedence over it, mismatched id, differing reason line, interrupting passing step, and a selector-less summary unable to borrow an unrelated earlier ID wait); focused 9-suite run 158 pass (was 152); full suite 4304 pass / 0 fail; format, lint, check-agent-package-sync, check-dist-fresh, check-typescript-only, docs:generate and build:docs all clean.

## What Changed

- Classify maestro-runner 1.1.x ID-wait failures with the exact selector, including duplicated selector-less terminal summaries only when an earlier failed block has the byte-identical reason, while preserving timeout and non-ID-wait precedence.
- Resume reactive CDP/JS replay at the unique matching failed selector without replaying completed mutations, and fail closed for ambiguous or unsupported flow shapes and launch options.
- Surface bounded head-and-tail terminal evidence across failure and retry paths, and update regression coverage, run-action guidance, generated host runtimes, the docs changelog, and the patch changeset.

## Risk Assessment

✅ Low: Both prior defects are corrected at the appropriate parser boundaries, with exact internal selector evidence preserved while public step summaries remain bounded, and no source-verifiable acceptance regression remains.

## Testing

Author-reported baseline validation included the focused nine-suite run, full suite, formatting, lint, package/dist/TypeScript checks, and docs generation/build; this phase independently exercised the committed parser, terminal-evidence, and selector-resume paths against the literal maestro-runner 1.1.20 failure and strict refusal/precedence cases, captured and read back a direct runtime transcript, confirmed the frozen legacy parser guard file is unchanged, and finished green with a clean worktree.

<details>
<summary>Evidence: Committed runtime classification transcript</summary>

```text
{
  "runtime": "packages/rn-dev-agent-core/dist",
  "realRunnerDuplicateSummary": {
    "terminalEvidence": {
      "completedSteps": 0,
      "failedStep": "extendedWaitUntil",
      "exitClass": "step-failure",
      "failureKind": "SELECTOR_NOT_FOUND",
      "failureSelector": "rn580_terminal_missing"
    },
    "classification": {
      "kind": "SELECTOR_NOT_FOUND",
      "selector": "rn580_terminal_missing",
      "autoRepairable": true
    }
  },
  "killedProcessPrecedence": {
    "terminalEvidence": {
      "completedSteps": 0,
      "failedStep": "extendedWaitUntil",
      "exitClass": "timed-out",
      "failureKind": "SELECTOR_NOT_FOUND",
      "failureSelector": "rn580_terminal_missing"
    },
    "classification": {
      "kind": "TIMEOUT",
      "selector": "rn580_terminal_missing",
      "autoRepairable": false
    }
  },
  "differingReasonRefusal": {
    "terminalEvidence": {
      "completedSteps": 0,
      "failedStep": "extendedWaitUntil",
      "exitClass": "step-failure"
    },
    "classification": {
      "kind": "UNKNOWN",
      "selector": null,
      "autoRepairable": false
    }
  },
  "terminalTextWaitRefusal": {
    "terminalEvidence": {
      "completedSteps": 0,
      "failedStep": "extendedWaitUntil: visible text=\"#otp\"",
      "exitClass": "step-failure"
    },
    "classification": {
      "kind": "UNKNOWN",
      "selector": null,
      "autoRepairable": false
    }
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `packages/rn-dev-agent-core/src/domain/maestro-error-parser.ts:166` - Intent permits borrowing only “when the terminal step carries no selector” and forbids reclassifying text/regex waits. This fallback runs for every failed-step name that is not an ID wait, so a terminal `extendedWaitUntil: visible text=&#34;#otp&#34;` with the same `Element &#39;#otp&#39;...` reason as an earlier ID block borrows that stale ID and becomes auto-repairable. Require the terminal step to match the exact selector-less summary shape before scanning duplicate blocks.
- ⚠️ `packages/rn-dev-agent-core/src/domain/maestro-step-parser.ts:126` - Long valid testIDs lose exact classification: `parseSteps` caps `failedStep.name` at 200 characters, then this call passes the capped name to `parseTerminalIdWait`, which rejects it against the uncapped terminal name; `summarizeReason` also caps the selector later used by auto-repair. Preserve uncapped terminal identity and selector for internal classification/repair, and cap only outward display evidence.

🔧 Fix: Guard duplicate waits and preserve exact selectors
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test packages/rn-dev-agent-core/test/unit/maestro-error-parser.test.js packages/rn-dev-agent-core/test/unit/gh-211-maestro-step-parser.test.js packages/rn-dev-agent-core/test/unit/gh-580-wait-classification.test.ts`
- `node --test packages/rn-dev-agent-core/test/unit/gh-580-selector-resume.test.ts`
- <code>Direct committed-runtime exercise of `parseMaestroFailure`, `buildTerminalEvidence`, and `isAutoRepairable` using the literal maestro-runner 1.1.20 two-block stream plus timeout, differing-reason, and text-wait variants</code>
- `Evidence JSON read-back assertions and SHA-256 calculation`
- `git diff --exit-code 7df05188118df2e2996db6c2ccd0ae8e25105f9d b5ab4151a239a046125c7933f9defaca6f7e1e66 -- packages/rn-dev-agent-core/test/unit/maestro-error-parser.test.js`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
