### PR TITLE
feat(core): make Observe a Session-owned read-only child

### DIFF
--- a/.changeset/observe-session-child.md
+++ b/.changeset/observe-session-child.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-core": minor
+"rn-dev-agent-plugin": minor
+---
+
+Make Observe a read-only child of the session: `observe start` and `restart` now require only the live session (matching autostart's degraded mode) instead of the full device/Metro/bundle/runner authority chain, while the observe-port claim, capability and instance request authentication, fenced stop/cleanup chain, and the full authority gates on the E2E run and action panels all stay exactly as before.

--- a/apps/docs-site/src/content/docs/changelog.md
+++ b/apps/docs-site/src/content/docs/changelog.md
@@ -5,6 +5,30 @@ description: "Release history for rn-dev-agent"
 
 ## Claude plugin
 
+### 0.71.8
+
+#### Patch Changes
+
+- 76a6045: Stop a second supervisor for the same app root from misreading the live owner as a reused PID and stealing its single-instance lock, keep blocked contenders from opening operational children, rotate expired adoption handles so `status` never advertises a capability `adopt_stale` refuses, add a bounded capability-authenticated release for a proven-dead device or runner owner discovered after startup that transfers only the exact device cleanup obligations, and report whether recovery needs a transport restart, an attach, or an adoption.
+- Updated dependencies [76a6045]
+  - rn-dev-agent-core@0.66.8
+
+### 0.71.7
+
+#### Patch Changes
+
+- 3ee229d: Keep managed Metro descendants strict by default while allowing only Expo's canonical runtime-version manifest utility without session capability and requiring exact managed launch provenance.
+- Updated dependencies [3ee229d]
+  - rn-dev-agent-core@0.66.7
+
+### 0.71.6
+
+#### Patch Changes
+
+- 5b0a93f: Keep `.rn-agent` real and worktree-local by inheriting only `.rn-agent/actions` through consented setup and repository-local post-checkout integration, keeping SessionStart report-only, and migrating recognized legacy root links without copying mutable integration or session state.
+- Updated dependencies [5b0a93f]
+  - rn-dev-agent-core@0.66.6
+
 ### 0.71.5
 
 #### Patch Changes
@@ -1262,6 +1286,24 @@ identifier, hittable? }`, with a `fullNodeCount`. Far fewer tokens; `@ref`s for
   #188 shipped these to `main` with no version bump, leaving them undeliverable to marketplace installs; this patch publishes them.
 
 ## Core MCP server
+
+### 0.66.8
+
+#### Patch Changes
+
+- 76a6045: Stop a second supervisor for the same app root from misreading the live owner as a reused PID and stealing its single-instance lock, keep blocked contenders from opening operational children, rotate expired adoption handles so `status` never advertises a capability `adopt_stale` refuses, add a bounded capability-authenticated release for a proven-dead device or runner owner discovered after startup that transfers only the exact device cleanup obligations, and report whether recovery needs a transport restart, an attach, or an adoption.
+
+### 0.66.7
+
+#### Patch Changes
+
+- 3ee229d: Keep managed Metro descendants strict by default while allowing only Expo's canonical runtime-version manifest utility without session capability and requiring exact managed launch provenance.
+
+### 0.66.6
+
+#### Patch Changes
+
+- 5b0a93f: Keep `.rn-agent` real and worktree-local by inheriting only `.rn-agent/actions` through consented setup and repository-local post-checkout integration, keeping SessionStart report-only, and migrating recognized legacy root links without copying mutable integration or session state.
 
 ### 0.66.5
 

--- a/apps/docs-site/src/content/docs/session-authority.mdx
+++ b/apps/docs-site/src/content/docs/session-authority.mdx
@@ -86,7 +86,7 @@ Every successful authoritative call receives a preflight/postflight authority re
 
 ## Observe, actions, proof, and feedback
 
-Observe uses its allocated port, random capability, and instance ID on every API, event-stream, state, and action request. A page from a crashed session cannot attach to a later listener.
+Observe is a read-only child of the session: `observe start` and `restart` require only the live session, matching autostart's degraded mode, so a session with no device bound still serves the UI, and Observe always stops with its session. Its E2E run and action panels still pass the full authority gates of `cdp_run_e2e_suite` and `cdp_run_action`. Observe uses its allocated port, random capability, and instance ID on every API, event-stream, state, and action request. A page from a crashed session cannot attach to a later listener.
 
 Mutable action sidecars, E2E runs, bundle state, and proof runtime state live under the session root. Recorder claims live in the session registry, while authenticated recorder sidecars and provisional media use a private user-local runtime directory; finalized media is published only to the requested output path. Canonical action YAML remains worktree knowledge. For a private untracked corpus, consented setup or repository-local post-checkout integration may link only `.rn-agent/actions` inside a real worktree-local `.rn-agent`; mutable integration, session state, recordings, generated launchers, and runtime data remain local, while root and unsafe nested symlinks fail closed.
 

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -29301,9 +29301,9 @@ var init_tool_profiles = __esm({
     });
     add(observe, {
       kind: "authoritative",
-      axes: ["C", "S", "I", "M", "B", "D", "O"],
+      axes: ["C", "S"],
       mutation: false,
-      liveBundleProbe: true
+      liveBundleProbe: false
     });
     add(proof, {
       kind: "authoritative",
@@ -29697,13 +29697,8 @@ function createAuthorityGate(runtime, dependencies) {
       if (runtimeStatus.available && runtimeStatus.state === "blocked") {
         return authorityFailure(new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "blocked contender exposes only accept_handoff and adopt_stale recovery"));
       }
-      if (runtimeStatus.available && tool === "observe" && args.action === "start" && runtimeStatus.bindings.observe) {
-        profile = {
-          kind: "authoritative",
-          axes: ["C", "S", "O"],
-          mutation: false,
-          liveBundleProbe: false
-        };
+      if (runtimeStatus.available && tool === "observe" && (args.action === "start" && runtimeStatus.bindings.observe || args.action === "stop" && !runtimeStatus.bindings.observe)) {
+        profile = baseProfile;
       }
       if (runtimeStatus.available && tool === "cdp_disconnect" && !runtimeStatus.bindings.bundle) {
         profile = {
@@ -29751,12 +29746,6 @@ function createAuthorityGate(runtime, dependencies) {
           } : {
             before: ["C", "S", "D"],
             after: ["C", "S", "D"]
-          } : tool === "observe" ? args.action === "stop" ? {
-            before: ["C", "S", "O"],
-            after: ["C", "S"]
-          } : {
-            before: ["C", "S", "I", "M", "B", "D", "R"],
-            after: ["C", "S", "I", "M", "B", "D", "R", "O"]
           } : tool === "rn_session" && args.action === "prepare_handoff" ? { before: [...profile.axes], after: [] } : tool === "cdp_restart" && args.hardReset === true && args.platform === "ios" ? {
             before: [...profile.axes],
             after: profile.axes.filter((axis) => axis !== "R")
@@ -30359,7 +30348,6 @@ var init_authority_gate = __esm({
       B: "bundle",
       D: "device",
       R: "runner",
-      O: "observe",
       P: "proof"
     };
     axisErrors = {
@@ -30371,7 +30359,6 @@ var init_authority_gate = __esm({
       B: "BUNDLE_HANDSHAKE_UNAVAILABLE",
       D: "DEVICE_AUTHORITY_MISMATCH",
       R: "RUNNER_OWNERSHIP_MISMATCH",
-      O: "OBSERVE_AUTHORITY_MISMATCH",
       P: "PROOF_AUTHORITY_MISMATCH"
     };
   }
@@ -81439,21 +81426,6 @@ function createLocalAuthorityProbe(dependencies) {
           protocolVersion: runner.protocolVersion
         })
       };
-    }
-    if (axis === "O") {
-      const observe2 = objectBinding(status, "observe");
-      const port = Number(observe2.port);
-      const capability = dependencies.getSecret()?.observeCapability ?? "";
-      const observed = await fetchJson(`http://127.0.0.1:${port}/api/authority`, {
-        headers: {
-          authorization: `Bearer ${capability}`,
-          "x-rn-observe-instance": String(observe2.instanceId ?? "")
-        }
-      });
-      if (observed.sessionId !== status.sessionId || observed.instanceId !== observe2.instanceId) {
-        throw new SessionAuthorityError("OBSERVE_AUTHORITY_MISMATCH", "Observe endpoint no longer matches the session binding");
-      }
-      return { axis, identity: identity(observed) };
     }
     const proof2 = objectBinding(status, "proof");
     const runId = String(proof2.runId ?? "");

--- a/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -10951,9 +10951,9 @@ var init_tool_profiles = __esm({
     });
     add(observe, {
       kind: "authoritative",
-      axes: ["C", "S", "I", "M", "B", "D", "O"],
+      axes: ["C", "S"],
       mutation: false,
-      liveBundleProbe: true
+      liveBundleProbe: false
     });
     add(proof, {
       kind: "authoritative",

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -18609,9 +18609,9 @@ var init_tool_profiles = __esm({
     });
     add(observe, {
       kind: "authoritative",
-      axes: ["C", "S", "I", "M", "B", "D", "O"],
+      axes: ["C", "S"],
       mutation: false,
-      liveBundleProbe: true
+      liveBundleProbe: false
     });
     add(proof, {
       kind: "authoritative",
@@ -19005,13 +19005,8 @@ function createAuthorityGate(runtime, dependencies) {
       if (runtimeStatus.available && runtimeStatus.state === "blocked") {
         return authorityFailure(new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "blocked contender exposes only accept_handoff and adopt_stale recovery"));
       }
-      if (runtimeStatus.available && tool === "observe" && args.action === "start" && runtimeStatus.bindings.observe) {
-        profile = {
-          kind: "authoritative",
-          axes: ["C", "S", "O"],
-          mutation: false,
-          liveBundleProbe: false
-        };
+      if (runtimeStatus.available && tool === "observe" && (args.action === "start" && runtimeStatus.bindings.observe || args.action === "stop" && !runtimeStatus.bindings.observe)) {
+        profile = baseProfile;
       }
       if (runtimeStatus.available && tool === "cdp_disconnect" && !runtimeStatus.bindings.bundle) {
         profile = {
@@ -19059,12 +19054,6 @@ function createAuthorityGate(runtime, dependencies) {
           } : {
             before: ["C", "S", "D"],
             after: ["C", "S", "D"]
-          } : tool === "observe" ? args.action === "stop" ? {
-            before: ["C", "S", "O"],
-            after: ["C", "S"]
-          } : {
-            before: ["C", "S", "I", "M", "B", "D", "R"],
-            after: ["C", "S", "I", "M", "B", "D", "R", "O"]
           } : tool === "rn_session" && args.action === "prepare_handoff" ? { before: [...profile.axes], after: [] } : tool === "cdp_restart" && args.hardReset === true && args.platform === "ios" ? {
             before: [...profile.axes],
             after: profile.axes.filter((axis) => axis !== "R")
@@ -19667,7 +19656,6 @@ var init_authority_gate = __esm({
       B: "bundle",
       D: "device",
       R: "runner",
-      O: "observe",
       P: "proof"
     };
     axisErrors = {
@@ -19679,7 +19667,6 @@ var init_authority_gate = __esm({
       B: "BUNDLE_HANDSHAKE_UNAVAILABLE",
       D: "DEVICE_AUTHORITY_MISMATCH",
       R: "RUNNER_OWNERSHIP_MISMATCH",
-      O: "OBSERVE_AUTHORITY_MISMATCH",
       P: "PROOF_AUTHORITY_MISMATCH"
     };
   }
@@ -83217,21 +83204,6 @@ function createLocalAuthorityProbe(dependencies) {
           protocolVersion: runner.protocolVersion
         })
       };
-    }
-    if (axis === "O") {
-      const observe2 = objectBinding(status, "observe");
-      const port = Number(observe2.port);
-      const capability = dependencies.getSecret()?.observeCapability ?? "";
-      const observed = await fetchJson(`http://127.0.0.1:${port}/api/authority`, {
-        headers: {
-          authorization: `Bearer ${capability}`,
-          "x-rn-observe-instance": String(observe2.instanceId ?? "")
-        }
-      });
-      if (observed.sessionId !== status.sessionId || observed.instanceId !== observe2.instanceId) {
-        throw new SessionAuthorityError("OBSERVE_AUTHORITY_MISMATCH", "Observe endpoint no longer matches the session binding");
-      }
-      return { axis, identity: identity(observed) };
     }
     const proof2 = objectBinding(status, "proof");
     const runId = String(proof2.runId ?? "");

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -29301,9 +29301,9 @@ var init_tool_profiles = __esm({
     });
     add(observe, {
       kind: "authoritative",
-      axes: ["C", "S", "I", "M", "B", "D", "O"],
+      axes: ["C", "S"],
       mutation: false,
-      liveBundleProbe: true
+      liveBundleProbe: false
     });
     add(proof, {
       kind: "authoritative",
@@ -29697,13 +29697,8 @@ function createAuthorityGate(runtime, dependencies) {
       if (runtimeStatus.available && runtimeStatus.state === "blocked") {
         return authorityFailure(new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "blocked contender exposes only accept_handoff and adopt_stale recovery"));
       }
-      if (runtimeStatus.available && tool === "observe" && args.action === "start" && runtimeStatus.bindings.observe) {
-        profile = {
-          kind: "authoritative",
-          axes: ["C", "S", "O"],
-          mutation: false,
-          liveBundleProbe: false
-        };
+      if (runtimeStatus.available && tool === "observe" && (args.action === "start" && runtimeStatus.bindings.observe || args.action === "stop" && !runtimeStatus.bindings.observe)) {
+        profile = baseProfile;
       }
       if (runtimeStatus.available && tool === "cdp_disconnect" && !runtimeStatus.bindings.bundle) {
         profile = {
@@ -29751,12 +29746,6 @@ function createAuthorityGate(runtime, dependencies) {
           } : {
             before: ["C", "S", "D"],
             after: ["C", "S", "D"]
-          } : tool === "observe" ? args.action === "stop" ? {
-            before: ["C", "S", "O"],
-            after: ["C", "S"]
-          } : {
-            before: ["C", "S", "I", "M", "B", "D", "R"],
-            after: ["C", "S", "I", "M", "B", "D", "R", "O"]
           } : tool === "rn_session" && args.action === "prepare_handoff" ? { before: [...profile.axes], after: [] } : tool === "cdp_restart" && args.hardReset === true && args.platform === "ios" ? {
             before: [...profile.axes],
             after: profile.axes.filter((axis) => axis !== "R")
@@ -30359,7 +30348,6 @@ var init_authority_gate = __esm({
       B: "bundle",
       D: "device",
       R: "runner",
-      O: "observe",
       P: "proof"
     };
     axisErrors = {
@@ -30371,7 +30359,6 @@ var init_authority_gate = __esm({
       B: "BUNDLE_HANDSHAKE_UNAVAILABLE",
       D: "DEVICE_AUTHORITY_MISMATCH",
       R: "RUNNER_OWNERSHIP_MISMATCH",
-      O: "OBSERVE_AUTHORITY_MISMATCH",
       P: "PROOF_AUTHORITY_MISMATCH"
     };
   }
@@ -81439,21 +81426,6 @@ function createLocalAuthorityProbe(dependencies) {
           protocolVersion: runner.protocolVersion
         })
       };
-    }
-    if (axis === "O") {
-      const observe2 = objectBinding(status, "observe");
-      const port = Number(observe2.port);
-      const capability = dependencies.getSecret()?.observeCapability ?? "";
-      const observed = await fetchJson(`http://127.0.0.1:${port}/api/authority`, {
-        headers: {
-          authorization: `Bearer ${capability}`,
-          "x-rn-observe-instance": String(observe2.instanceId ?? "")
-        }
-      });
-      if (observed.sessionId !== status.sessionId || observed.instanceId !== observe2.instanceId) {
-        throw new SessionAuthorityError("OBSERVE_AUTHORITY_MISMATCH", "Observe endpoint no longer matches the session binding");
-      }
-      return { axis, identity: identity(observed) };
     }
     const proof2 = objectBinding(status, "proof");
     const runId = String(proof2.runId ?? "");

--- a/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -10951,9 +10951,9 @@ var init_tool_profiles = __esm({
     });
     add(observe, {
       kind: "authoritative",
-      axes: ["C", "S", "I", "M", "B", "D", "O"],
+      axes: ["C", "S"],
       mutation: false,
-      liveBundleProbe: true
+      liveBundleProbe: false
     });
     add(proof, {
       kind: "authoritative",

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -18609,9 +18609,9 @@ var init_tool_profiles = __esm({
     });
     add(observe, {
       kind: "authoritative",
-      axes: ["C", "S", "I", "M", "B", "D", "O"],
+      axes: ["C", "S"],
       mutation: false,
-      liveBundleProbe: true
+      liveBundleProbe: false
     });
     add(proof, {
       kind: "authoritative",
@@ -19005,13 +19005,8 @@ function createAuthorityGate(runtime, dependencies) {
       if (runtimeStatus.available && runtimeStatus.state === "blocked") {
         return authorityFailure(new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "blocked contender exposes only accept_handoff and adopt_stale recovery"));
       }
-      if (runtimeStatus.available && tool === "observe" && args.action === "start" && runtimeStatus.bindings.observe) {
-        profile = {
-          kind: "authoritative",
-          axes: ["C", "S", "O"],
-          mutation: false,
-          liveBundleProbe: false
-        };
+      if (runtimeStatus.available && tool === "observe" && (args.action === "start" && runtimeStatus.bindings.observe || args.action === "stop" && !runtimeStatus.bindings.observe)) {
+        profile = baseProfile;
       }
       if (runtimeStatus.available && tool === "cdp_disconnect" && !runtimeStatus.bindings.bundle) {
         profile = {
@@ -19059,12 +19054,6 @@ function createAuthorityGate(runtime, dependencies) {
           } : {
             before: ["C", "S", "D"],
             after: ["C", "S", "D"]
-          } : tool === "observe" ? args.action === "stop" ? {
-            before: ["C", "S", "O"],
-            after: ["C", "S"]
-          } : {
-            before: ["C", "S", "I", "M", "B", "D", "R"],
-            after: ["C", "S", "I", "M", "B", "D", "R", "O"]
           } : tool === "rn_session" && args.action === "prepare_handoff" ? { before: [...profile.axes], after: [] } : tool === "cdp_restart" && args.hardReset === true && args.platform === "ios" ? {
             before: [...profile.axes],
             after: profile.axes.filter((axis) => axis !== "R")
@@ -19667,7 +19656,6 @@ var init_authority_gate = __esm({
       B: "bundle",
       D: "device",
       R: "runner",
-      O: "observe",
       P: "proof"
     };
     axisErrors = {
@@ -19679,7 +19667,6 @@ var init_authority_gate = __esm({
       B: "BUNDLE_HANDSHAKE_UNAVAILABLE",
       D: "DEVICE_AUTHORITY_MISMATCH",
       R: "RUNNER_OWNERSHIP_MISMATCH",
-      O: "OBSERVE_AUTHORITY_MISMATCH",
       P: "PROOF_AUTHORITY_MISMATCH"
     };
   }
@@ -83217,21 +83204,6 @@ function createLocalAuthorityProbe(dependencies) {
           protocolVersion: runner.protocolVersion
         })
       };
-    }
-    if (axis === "O") {
-      const observe2 = objectBinding(status, "observe");
-      const port = Number(observe2.port);
-      const capability = dependencies.getSecret()?.observeCapability ?? "";
-      const observed = await fetchJson(`http://127.0.0.1:${port}/api/authority`, {
-        headers: {
-          authorization: `Bearer ${capability}`,
-          "x-rn-observe-instance": String(observe2.instanceId ?? "")
-        }
-      });
-      if (observed.sessionId !== status.sessionId || observed.instanceId !== observe2.instanceId) {
-        throw new SessionAuthorityError("OBSERVE_AUTHORITY_MISMATCH", "Observe endpoint no longer matches the session binding");
-      }
-      return { axis, identity: identity(observed) };
     }
     const proof2 = objectBinding(status, "proof");
     const runId = String(proof2.runId ?? "");

--- a/packages/rn-dev-agent-core/dist/session/authority-gate.js
+++ b/packages/rn-dev-agent-core/dist/session/authority-gate.js
@@ -47,7 +47,6 @@ const axisBinding = {
     B: 'bundle',
     D: 'device',
     R: 'runner',
-    O: 'observe',
     P: 'proof',
 };
 const axisErrors = {
@@ -59,7 +58,6 @@ const axisErrors = {
     B: 'BUNDLE_HANDSHAKE_UNAVAILABLE',
     D: 'DEVICE_AUTHORITY_MISMATCH',
     R: 'RUNNER_OWNERSHIP_MISMATCH',
-    O: 'OBSERVE_AUTHORITY_MISMATCH',
     P: 'PROOF_AUTHORITY_MISMATCH',
 };
 function requireCompleteAxes(status, profile) {
@@ -495,14 +493,9 @@ export function createAuthorityGate(runtime, dependencies) {
             }
             if (runtimeStatus.available &&
                 tool === 'observe' &&
-                args.action === 'start' &&
-                runtimeStatus.bindings.observe) {
-                profile = {
-                    kind: 'authoritative',
-                    axes: ['C', 'S', 'O'],
-                    mutation: false,
-                    liveBundleProbe: false,
-                };
+                ((args.action === 'start' && runtimeStatus.bindings.observe) ||
+                    (args.action === 'stop' && !runtimeStatus.bindings.observe))) {
+                profile = baseProfile;
             }
             if (runtimeStatus.available &&
                 tool === 'cdp_disconnect' &&
@@ -559,24 +552,14 @@ export function createAuthorityGate(runtime, dependencies) {
                                 before: ['C', 'S', 'D'],
                                 after: ['C', 'S', 'D'],
                             }
-                        : tool === 'observe'
-                            ? args.action === 'stop'
+                        : tool === 'rn_session' && args.action === 'prepare_handoff'
+                            ? { before: [...profile.axes], after: [] }
+                            : tool === 'cdp_restart' && args.hardReset === true && args.platform === 'ios'
                                 ? {
-                                    before: ['C', 'S', 'O'],
-                                    after: ['C', 'S'],
+                                    before: [...profile.axes],
+                                    after: profile.axes.filter((axis) => axis !== 'R'),
                                 }
-                                : {
-                                    before: ['C', 'S', 'I', 'M', 'B', 'D', 'R'],
-                                    after: ['C', 'S', 'I', 'M', 'B', 'D', 'R', 'O'],
-                                }
-                            : tool === 'rn_session' && args.action === 'prepare_handoff'
-                                ? { before: [...profile.axes], after: [] }
-                                : tool === 'cdp_restart' && args.hardReset === true && args.platform === 'ios'
-                                    ? {
-                                        before: [...profile.axes],
-                                        after: profile.axes.filter((axis) => axis !== 'R'),
-                                    }
-                                    : { before: [...profile.axes], after: [...profile.axes] };
+                                : { before: [...profile.axes], after: [...profile.axes] };
                     requireCompleteAxes(status, { ...profile, axes: transitionAxes.before });
                     const operationInput = {
                         operationId: randomUUID(),

--- a/packages/rn-dev-agent-core/dist/session/local-authority-probe.js
+++ b/packages/rn-dev-agent-core/dist/session/local-authority-probe.js
@@ -325,21 +325,6 @@ export function createLocalAuthorityProbe(dependencies) {
                 }),
             };
         }
-        if (axis === 'O') {
-            const observe = objectBinding(status, 'observe');
-            const port = Number(observe.port);
-            const capability = dependencies.getSecret()?.observeCapability ?? '';
-            const observed = await fetchJson(`http://127.0.0.1:${port}/api/authority`, {
-                headers: {
-                    authorization: `Bearer ${capability}`,
-                    'x-rn-observe-instance': String(observe.instanceId ?? ''),
-                },
-            });
-            if (observed.sessionId !== status.sessionId || observed.instanceId !== observe.instanceId) {
-                throw new SessionAuthorityError('OBSERVE_AUTHORITY_MISMATCH', 'Observe endpoint no longer matches the session binding');
-            }
-            return { axis, identity: identity(observed) };
-        }
         const proof = objectBinding(status, 'proof');
         const runId = String(proof.runId ?? '');
         if (!runId || !dependencies.proofActive?.(runId)) {

--- a/packages/rn-dev-agent-core/dist/session/tool-profiles.js
+++ b/packages/rn-dev-agent-core/dist/session/tool-profiles.js
@@ -160,8 +160,7 @@ add(cdpMutation, {
     mutation: true,
     liveBundleProbe: true,
 });
-// Read-only Session child: admits with a live session only (autostart parity);
-// its mutating e2e web routes keep the full gates of the tools they invoke.
+// Observe is a read-only Session child; its mutating web routes keep their own gates.
 add(observe, {
     kind: 'authoritative',
     axes: ['C', 'S'],

--- a/packages/rn-dev-agent-core/dist/session/tool-profiles.js
+++ b/packages/rn-dev-agent-core/dist/session/tool-profiles.js
@@ -160,11 +160,13 @@ add(cdpMutation, {
     mutation: true,
     liveBundleProbe: true,
 });
+// Read-only Session child: admits with a live session only (autostart parity);
+// its mutating e2e web routes keep the full gates of the tools they invoke.
 add(observe, {
     kind: 'authoritative',
-    axes: ['C', 'S', 'I', 'M', 'B', 'D', 'O'],
+    axes: ['C', 'S'],
     mutation: false,
-    liveBundleProbe: true,
+    liveBundleProbe: false,
 });
 add(proof, {
     kind: 'authoritative',

--- a/packages/rn-dev-agent-core/src/session/authority-gate.ts
+++ b/packages/rn-dev-agent-core/src/session/authority-gate.ts
@@ -113,7 +113,6 @@ const axisBinding: Partial<Record<AuthorityAxis, string>> = {
   B: 'bundle',
   D: 'device',
   R: 'runner',
-  O: 'observe',
   P: 'proof',
 };
 
@@ -126,7 +125,6 @@ const axisErrors: Record<AuthorityAxis, ToolErrorCode> = {
   B: 'BUNDLE_HANDSHAKE_UNAVAILABLE',
   D: 'DEVICE_AUTHORITY_MISMATCH',
   R: 'RUNNER_OWNERSHIP_MISMATCH',
-  O: 'OBSERVE_AUTHORITY_MISMATCH',
   P: 'PROOF_AUTHORITY_MISMATCH',
 };
 
@@ -746,15 +744,10 @@ export function createAuthorityGate(
         if (
           runtimeStatus.available &&
           tool === 'observe' &&
-          args.action === 'start' &&
-          runtimeStatus.bindings.observe
+          ((args.action === 'start' && runtimeStatus.bindings.observe) ||
+            (args.action === 'stop' && !runtimeStatus.bindings.observe))
         ) {
-          profile = {
-            kind: 'authoritative',
-            axes: ['C', 'S', 'O'],
-            mutation: false,
-            liveBundleProbe: false,
-          };
+          profile = baseProfile;
         }
         if (
           runtimeStatus.available &&
@@ -816,24 +809,14 @@ export function createAuthorityGate(
                       before: ['C', 'S', 'D'] as AuthorityAxis[],
                       after: ['C', 'S', 'D'] as AuthorityAxis[],
                     }
-                : tool === 'observe'
-                  ? args.action === 'stop'
+                : tool === 'rn_session' && args.action === 'prepare_handoff'
+                  ? { before: [...profile.axes], after: [] as AuthorityAxis[] }
+                  : tool === 'cdp_restart' && args.hardReset === true && args.platform === 'ios'
                     ? {
-                        before: ['C', 'S', 'O'] as AuthorityAxis[],
-                        after: ['C', 'S'] as AuthorityAxis[],
+                        before: [...profile.axes],
+                        after: profile.axes.filter((axis) => axis !== 'R'),
                       }
-                    : {
-                        before: ['C', 'S', 'I', 'M', 'B', 'D', 'R'] as AuthorityAxis[],
-                        after: ['C', 'S', 'I', 'M', 'B', 'D', 'R', 'O'] as AuthorityAxis[],
-                      }
-                  : tool === 'rn_session' && args.action === 'prepare_handoff'
-                    ? { before: [...profile.axes], after: [] as AuthorityAxis[] }
-                    : tool === 'cdp_restart' && args.hardReset === true && args.platform === 'ios'
-                      ? {
-                          before: [...profile.axes],
-                          after: profile.axes.filter((axis) => axis !== 'R'),
-                        }
-                      : { before: [...profile.axes], after: [...profile.axes] };
+                    : { before: [...profile.axes], after: [...profile.axes] };
             requireCompleteAxes(status, { ...profile, axes: transitionAxes.before });
             const operationInput = {
               operationId: randomUUID(),

--- a/packages/rn-dev-agent-core/src/session/local-authority-probe.ts
+++ b/packages/rn-dev-agent-core/src/session/local-authority-probe.ts
@@ -27,7 +27,7 @@ import { deviceExistsOnHost } from './device-existence.js';
 interface LocalAuthorityProbeDependencies {
   runtime: WorkerAuthorityRuntime;
   getClient: () => CDPClient;
-  getSecret: () => { signerCapability?: string; observeCapability?: string } | null;
+  getSecret: () => { signerCapability?: string } | null;
   resolveSource?: (status: SessionStatus) => SourceIdentity;
   fetchText?: (url: string, init?: RequestInit) => Promise<string>;
   fetchJson?: (url: string, init?: RequestInit) => Promise<Record<string, unknown>>;
@@ -466,25 +466,6 @@ export function createLocalAuthorityProbe(
           protocolVersion: runner.protocolVersion,
         }),
       };
-    }
-
-    if (axis === 'O') {
-      const observe = objectBinding(status, 'observe');
-      const port = Number(observe.port);
-      const capability = dependencies.getSecret()?.observeCapability ?? '';
-      const observed = await fetchJson(`http://127.0.0.1:${port}/api/authority`, {
-        headers: {
-          authorization: `Bearer ${capability}`,
-          'x-rn-observe-instance': String(observe.instanceId ?? ''),
-        },
-      });
-      if (observed.sessionId !== status.sessionId || observed.instanceId !== observe.instanceId) {
-        throw new SessionAuthorityError(
-          'OBSERVE_AUTHORITY_MISMATCH',
-          'Observe endpoint no longer matches the session binding',
-        );
-      }
-      return { axis, identity: identity(observed) };
     }
 
     const proof = objectBinding(status, 'proof');

--- a/packages/rn-dev-agent-core/src/session/tool-profiles.ts
+++ b/packages/rn-dev-agent-core/src/session/tool-profiles.ts
@@ -1,4 +1,4 @@
-export type AuthorityAxis = 'C' | 'S' | 'I' | 'M' | 'A' | 'B' | 'D' | 'R' | 'O' | 'P';
+export type AuthorityAxis = 'C' | 'S' | 'I' | 'M' | 'A' | 'B' | 'D' | 'R' | 'P';
 
 export interface AuthorityProfile {
   kind: 'diagnostic' | 'transition' | 'authoritative';
@@ -184,11 +184,13 @@ add(cdpMutation, {
   mutation: true,
   liveBundleProbe: true,
 });
+// Read-only Session child: admits with a live session only (autostart parity);
+// its mutating e2e web routes keep the full gates of the tools they invoke.
 add(observe, {
   kind: 'authoritative',
-  axes: ['C', 'S', 'I', 'M', 'B', 'D', 'O'],
+  axes: ['C', 'S'],
   mutation: false,
-  liveBundleProbe: true,
+  liveBundleProbe: false,
 });
 add(proof, {
   kind: 'authoritative',

--- a/packages/rn-dev-agent-core/src/session/tool-profiles.ts
+++ b/packages/rn-dev-agent-core/src/session/tool-profiles.ts
@@ -184,8 +184,7 @@ add(cdpMutation, {
   mutation: true,
   liveBundleProbe: true,
 });
-// Read-only Session child: admits with a live session only (autostart parity);
-// its mutating e2e web routes keep the full gates of the tools they invoke.
+// Observe is a read-only Session child; its mutating web routes keep their own gates.
 add(observe, {
   kind: 'authoritative',
   axes: ['C', 'S'],

--- a/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
@@ -1427,11 +1427,11 @@ test('repeated Observe start is an authoritative idempotent read of the existing
   assert.equal(envelope.meta.authorityTransition, undefined);
   assert.deepEqual(
     calls.filter((call) => call.startsWith('preflight:')),
-    ['preflight:C', 'preflight:S', 'preflight:O'],
+    ['preflight:C', 'preflight:S'],
   );
 });
 
-test('Observe stop requires only controller, source, and Observe authority', async () => {
+test('Observe stop requires only controller and source authority', async () => {
   const { runtime, status, calls } = fixture();
   status.bindings.bundle = null;
   status.bindings.runner = null;
@@ -1452,8 +1452,105 @@ test('Observe stop requires only controller, source, and Observe authority', asy
   assert.equal(envelope.ok, true);
   assert.deepEqual(
     calls.filter((call) => call.startsWith('preflight:')),
-    ['preflight:C', 'preflight:S', 'preflight:O'],
+    ['preflight:C', 'preflight:S'],
   );
+  assert.deepEqual(
+    calls.filter((call) => call.startsWith('postflight:')),
+    ['postflight:C', 'postflight:S'],
+  );
+});
+
+test('Observe start and restart admit with a live Session only, matching autostart degraded mode', async () => {
+  for (const action of ['start', 'restart']) {
+    const { runtime, status, calls } = fixture();
+    status.state = 'source_bound';
+    status.bindings = {
+      install: null,
+      metro: null,
+      bundle: null,
+      device: null,
+      runner: null,
+      observe: null,
+      proof: null,
+    };
+    const gate = createAuthorityGate(runtime, {
+      probe: async ({ axis, phase }) => {
+        calls.push(`${phase}:${axis}`);
+        return { axis, identity: `${axis}-identity` };
+      },
+    });
+
+    const result = await gate.wrap('observe', async () => {
+      status.bindings.observe = { instanceId: 'observe-new' };
+      status.authorityVersion += 1;
+      return okResult({ running: true });
+    })({ action });
+    const envelope = JSON.parse(result.content[0].text);
+
+    assert.equal(envelope.ok, true, `observe ${action} must admit at source_bound`);
+    assert.equal(envelope.meta.authorityTransition, true);
+    assert.deepEqual(
+      calls.filter((call) => call.startsWith('preflight:')),
+      ['preflight:C', 'preflight:S'],
+    );
+    assert.deepEqual(
+      calls.filter((call) => call.startsWith('postflight:')),
+      ['postflight:C', 'postflight:S'],
+    );
+  }
+});
+
+test('Observe stop with no bound child is an idempotent authoritative no-op', async () => {
+  const { runtime, status, calls } = fixture();
+  status.bindings.observe = null;
+  const gate = createAuthorityGate(runtime, {
+    probe: async ({ axis, phase }) => {
+      calls.push(`${phase}:${axis}`);
+      return { axis, identity: `${axis}-identity` };
+    },
+  });
+
+  const result = await gate.wrap('observe', async () => okResult({ running: false }))({
+    action: 'stop',
+  });
+  const envelope = JSON.parse(result.content[0].text);
+
+  assert.equal(envelope.ok, true);
+  assert.equal(envelope.meta.authorityTransition, undefined);
+  assert.deepEqual(
+    calls.filter((call) => call.startsWith('preflight:')),
+    ['preflight:C', 'preflight:S'],
+  );
+});
+
+test('Observe e2e panel tools still require full authority at a session-bound-only state', async () => {
+  for (const tool of ['cdp_run_e2e_suite', 'cdp_run_action']) {
+    const { runtime, status } = fixture();
+    status.state = 'source_bound';
+    status.bindings = {
+      install: null,
+      metro: null,
+      bundle: null,
+      device: null,
+      runner: null,
+      observe: null,
+      proof: null,
+    };
+    let dispatched = false;
+    const gate = createAuthorityGate(runtime, {
+      probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
+    });
+
+    const result = await gate.wrap(tool, async () => {
+      dispatched = true;
+      return okResult({ started: true });
+    })({});
+    const envelope = JSON.parse(result.content[0].text);
+
+    assert.equal(envelope.ok, false, `${tool} must refuse without full authority`);
+    assert.equal(envelope.code, 'APP_INSTALL_IDENTITY_CHANGED');
+    assert.equal(dispatched, false);
+  }
 });
 
 test('unbound CDP disconnect is an idempotent authoritative operation', async () => {
@@ -1770,9 +1867,12 @@ test('runner transitions and idempotent Observe starts probe their exact axes', 
   })({ action: 'start' });
   assert.deepEqual(
     calls.filter((call) => call.startsWith('preflight:')),
-    ['preflight:C', 'preflight:S', 'preflight:O'],
+    ['preflight:C', 'preflight:S'],
   );
-  assert.ok(calls.includes('postflight:O'));
+  assert.deepEqual(
+    calls.filter((call) => call.startsWith('postflight:')),
+    ['postflight:C', 'postflight:S'],
+  );
 });
 
 test('runner close authenticates dead retained ownership after runtime loss', async () => {

--- a/packages/rn-dev-agent-core/test/unit/session/observe-session-child.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/observe-session-child.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { ObservabilityServer } from '../../../dist/observability/server.js';
+import { Recorder } from '../../../dist/observability/recorder.js';
+
+const authority = {
+  sessionId: 'session-child',
+  claimEpoch: 7,
+  instanceId: 'observe-live',
+  capability: 'capability-live',
+};
+
+function headers(value = authority) {
+  return {
+    authorization: `Bearer ${value.capability}`,
+    'x-rn-observe-instance': value.instanceId,
+  };
+}
+
+test('Observe serves a session-bound view without any device authority', async () => {
+  const server = new ObservabilityServer(
+    new Recorder(),
+    undefined,
+    undefined,
+    undefined,
+    authority,
+  );
+  const { url } = await server.start();
+  try {
+    const origin = new URL(url).origin;
+    assert.equal((await fetch(origin)).status, 200);
+    const identity = await fetch(`${origin}/api/authority`, { headers: headers() });
+    assert.equal(identity.status, 200);
+    assert.deepEqual(await identity.json(), {
+      sessionId: 'session-child',
+      claimEpoch: 7,
+      instanceId: 'observe-live',
+    });
+    const state = await fetch(`${origin}/api/state/route`, { headers: headers() });
+    assert.equal(state.status, 501);
+  } finally {
+    await server.stop();
+  }
+});
+
+test('Observe refuses stale or foreign endpoint identity on every API request', async () => {
+  const server = new ObservabilityServer(
+    new Recorder(),
+    undefined,
+    undefined,
+    undefined,
+    authority,
+  );
+  const { url } = await server.start();
+  try {
+    const origin = new URL(url).origin;
+    const invalid: RequestInit[] = [
+      {},
+      { headers: headers({ ...authority, capability: 'capability-forged' }) },
+      { headers: headers({ ...authority, instanceId: 'observe-from-crashed-session' }) },
+    ];
+    for (const init of invalid) {
+      assert.equal((await fetch(`${origin}/api/authority`, init)).status, 403);
+      assert.equal((await fetch(`${origin}/api/state/route`, init)).status, 403);
+    }
+  } finally {
+    await server.stop();
+  }
+});
+
+test('mutating e2e routes stay behind CSRF and their gated tool handlers', async () => {
+  const invoked: string[] = [];
+  const e2e = {
+    token: 'csrf-token-1',
+    triggerRun: async (pattern?: string) => {
+      invoked.push(`run:${pattern ?? ''}`);
+      return { started: true };
+    },
+    listRuns: async () => [],
+    loadRun: async () => null,
+    listActions: async () => [],
+    runAction: async (actionId: string) => {
+      invoked.push(`action:${actionId}`);
+      return { ok: false as const, error: 'SESSION_AUTHORITY_REQUIRED: refused by the tool gate' };
+    },
+  };
+  const server = new ObservabilityServer(new Recorder(), e2e, undefined, undefined, authority);
+  const { url } = await server.start();
+  try {
+    const origin = new URL(url).origin;
+    const authenticated = { ...headers(), 'content-type': 'application/json' };
+    const noCsrfRun = await fetch(`${origin}/api/e2e/run`, {
+      method: 'POST',
+      headers: authenticated,
+      body: '{}',
+    });
+    assert.equal(noCsrfRun.status, 403);
+    const noCsrfAction = await fetch(`${origin}/api/e2e/actions/run`, {
+      method: 'POST',
+      headers: authenticated,
+      body: JSON.stringify({ actionId: 'login' }),
+    });
+    assert.equal(noCsrfAction.status, 403);
+    assert.deepEqual(invoked, []);
+
+    const csrf = { ...authenticated, 'x-csrf-token': 'csrf-token-1' };
+    const run = await fetch(`${origin}/api/e2e/run`, { method: 'POST', headers: csrf, body: '{}' });
+    assert.equal(run.status, 200);
+    const action = await fetch(`${origin}/api/e2e/actions/run`, {
+      method: 'POST',
+      headers: csrf,
+      body: JSON.stringify({ actionId: 'login' }),
+    });
+    assert.equal(action.status, 500);
+    assert.deepEqual(invoked, ['run:', 'action:login']);
+  } finally {
+    await server.stop();
+  }
+});

--- a/packages/rn-dev-agent-core/test/unit/session/tool-profiles.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/tool-profiles.test.ts
@@ -154,6 +154,24 @@ test('native crash diagnostics do not require Metro or bundle authority', () => 
   assert.equal(profile.mutation, false);
 });
 
+test('Observe is a session-scoped read-only child', () => {
+  const profile = authorityProfileFor('observe');
+
+  assert.equal(profile.kind, 'authoritative');
+  assert.deepEqual(profile.axes, ['C', 'S']);
+  assert.equal(profile.mutation, false);
+  assert.equal(profile.liveBundleProbe, false);
+});
+
+test('the retired O axis appears in no tool profile', () => {
+  for (const tool of registered) {
+    const profile = authorityProfileFor(tool);
+    for (const axes of [profile.axes, profile.postflightAxes ?? [], profile.optionalAxes ?? []]) {
+      assert.equal(axes.includes('O'), false, `${tool} must not carry the retired O axis`);
+    }
+  }
+});
+
 test('iOS hard reset transitions through runner authority', () => {
   const profile = authorityProfileFor('cdp_restart', { hardReset: true, platform: 'ios' });
 


### PR DESCRIPTION
## Intent

Implement only slice L1 from the rn-dev-agent ownership/lifecycle simplification ADR (data/rn-dev-agent-ownership-simplification-fable/report.md, analyzed at main b5a502e2): formalize Observe as a Session-owned read-only child while preserving every independent mutation and endpoint safety boundary. Required scope, in its accepted form: (1) Observe 'start'/'restart' tool-gate admission must require one live Session (controller C + source S) instead of the previous full C,S,I,M,B,D,R chain, matching the shipped autostart degraded-mode semantics where a session with no device authority already serves the UI; (2) retire O only as an independent tool-gate axis/ownership concept - deleted from the AuthorityAxis union, the gate's axisBinding/axisErrors maps, the observe profile row (now C,S with no live-bundle probe), the authority-gate transition special case, and the gate-side O endpoint probe - while preserving unchanged the exact observe-port claim at session creation, the random capability plus instance-ID request authentication on every Observe API request (server guard), session/instance verification, process-birth fencing, the proven stopBoundObserve stop/cleanup chain and registry cleanup branch, and Observe's child lifetime under the Session; (3) preserve full independent authority gating, CSRF, and capability checks for the two mutating web routes /api/e2e/run and /api/e2e/actions/run (they still delegate to gate-wrapped cdp_run_e2e_suite and cdp_run_action with their existing full profiles) - read-only child ownership must not weaken those routes; (4) add focused tests that Observe starts at a source/session-bound state, serves a no-device-bound view, refuses invalid endpoint identity, and keeps both mutating routes behind their existing full authority checks, while keeping existing Observe authority and cleanup regressions green (observe-authority.test.ts intentionally unchanged); (5) update authoritative docs, generated host artifacts, and changeset only as required, keeping Claude and Codex package outputs synchronized. Deliberate decisions made during implementation: unbound 'observe stop' became an idempotent authoritative no-op mirroring the existing unbound cdp_disconnect carve-out, because with the O preflight gone a no-op stop would otherwise surface a misleading AUTHORITY_LOST_DURING_OPERATION from the transition version-advance check; the already-running 'observe start' idempotent carve-out now reuses the base read-only child profile (C,S); the registry errorAxes diagnostic map intentionally keeps the 'O' letter for OBSERVE_AUTHORITY_MISMATCH cleanup-error metadata because the cleanup chain and its error code are preserved verbatim; the OBSERVE_AUTHORITY_MISMATCH error code itself is retained (cleanup chain, session handlers, CLI); docs changes are one truthful sentence in session-authority.mdx plus mechanical docs:generate output that also caught the docs changelog copy up to the already-released v0.71.7/0.71.8 entries; a single-sentence minor changeset bumps rn-dev-agent-core and rn-dev-agent-plugin; host runtimes were regenerated in the same commit so both host packages carry the updated bundled runtime. Explicitly out of scope and deliberately untouched: L0 and L2+ slices, regrouping of other axes/profiles, proof machinery, registry schema, recovery/actions, Android build logic, and open PRs 668/677/680 (never merge or stage them). Ship to a green PR for captain merge; never merge the PR.

## What Changed

- Make Observe a Session-owned read-only child: `start` and `restart` now require only live controller and source authority, while an unbound `stop` is an idempotent no-op.
- Retire Observe’s independent authority axis while preserving endpoint authentication, session-scoped cleanup, and the full authority and CSRF gates for mutating E2E and action routes.
- Add focused authority and server regressions, update the session-authority documentation and changeset, and regenerate synchronized Claude and Codex host runtimes.

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves the required endpoint and mutation safeguards, keeps generated host runtimes synchronized, and adds focused coverage for the revised Observe authority model.

## Testing

Exact target provenance was confirmed; focused automated authority, Observe, route-security, lifecycle-cleanup, and browser tests passed after installing locked dependencies; manual rendered/API evidence demonstrates live no-device degraded mode plus fail-closed identity and CSRF boundaries; generated host bundles match and all worktree transients were removed.

- Evidence: Observe live at source-bound/no-device state (local file: <code>/var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/no-mistakes-evidence/01KZA4JH05QKBMEVMV059GEA2G/observe-source-bound-no-device.png</code>)
<details>
<summary>Evidence: Observe security-boundary transcript</summary>

`Observe rendered live (200); unavailable device route returned 501; forged endpoint identity returned 403; both mutation routes without CSRF returned 403 and invoked no delegated handlers.`

```text
{
  "observePage": {
    "status": 200,
    "renderedConnection": "live"
  },
  "noDeviceRouteRead": {
    "status": 501
  },
  "forgedEndpointIdentity": {
    "status": 403
  },
  "mutationsWithoutCsrf": {
    "suiteStatus": 403,
    "actionStatus": 403,
    "delegatedHandlersInvoked": []
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Verified exact checkout using `git rev-parse HEAD`, base/target resolution, and base-to-target diff inventory.</code>
- <code>Ran `node --test --test-concurrency=2 packages/rn-dev-agent-core/test/unit/session/observe-session-child.test.ts packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts packages/rn-dev-agent-core/test/unit/session/tool-profiles.test.ts packages/rn-dev-agent-core/test/unit/session/observe-authority.test.ts packages/rn-dev-agent-core/test/unit/observability-server.test.js packages/rn-dev-agent-core/test/unit/e2e-csrf.test.js packages/rn-dev-agent-core/test/unit/e2e-server-routes.test.js packages/rn-dev-agent-core/test/unit/observe-autostart.test.js packages/rn-dev-agent-core/test/unit/observe-restart-action.test.js`; the initial setup-only module errors were resolved with `corepack yarn install --immutable`, then the focused set passed.</code>
- <code>Ran `node --test --test-concurrency=2 packages/rn-dev-agent-core/test/unit/session/process-cleanup.test.ts packages/rn-dev-agent-core/test/unit/session/supervisor-authority.test.ts packages/rn-dev-agent-core/test/unit/session/session-handler.test.ts`.</code>
- <code>Ran targeted Chromium tests with `corepack yarn workspace rn-dev-agent-core playwright test --config test/e2e-web/playwright.config.ts --grep &#39;timeline renders seeded events|Run E2E Suite round-trips|actions panel enforces&#39;`.</code>
- <code>Started the real `ObservabilityServer` without device/state authority, rendered it in headless Chromium, captured a screenshot, and directly exercised no-device reads, forged endpoint identity, and CSRF-less mutation requests.</code>
- <code>Compared the three changed Claude and Codex host runtime bundles byte-for-byte with `cmp`, inspected the changeset, removed transient dependency/test output, and confirmed `git status --short` is empty.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
