### PR TITLE
fix(core): prevent orphaned integrations from hanging builds

### DIFF
--- a/.changeset/orphaned-integration-refuses-build.md
+++ b/.changeset/orphaned-integration-refuses-build.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-core": patch
+"rn-dev-agent-plugin": patch
+---
+
+Refuse a build with exit code 2 and the supported `restore_integration` repair command when package integration is installed but no live session owns the worktree, instead of silently re-running the project's raw build script and leaving an unmanaged bundler holding the foreground forever, and bound every stdio-capturing session-CLI wait in the generated adapter so a wedged CLI fails typed rather than reading as a truncated success. Projects integrated by an earlier version keep their on-disk adapter copy until integration is re-applied.

--- a/.changeset/orphaned-integration-refuses-build.md
+++ b/.changeset/orphaned-integration-refuses-build.md
@@ -3,4 +3,4 @@
 "rn-dev-agent-plugin": patch
 ---
 
-Refuse a build with exit code 2 and the supported `restore_integration` repair command when package integration is installed but no live session owns the worktree, instead of silently re-running the project's raw build script and leaving an unmanaged bundler holding the foreground forever, and bound every stdio-capturing session-CLI wait in the generated adapter so a wedged CLI fails typed rather than reading as a truncated success. Projects integrated by an earlier version keep their on-disk adapter copy until integration is re-applied.
+Refuse orphaned integrated builds with exit code 2 and the supported `restore_integration` repair instead of starting an unmanaged bundler, and bound every stdio-capturing session-CLI wait so wedged CLIs fail typed; projects integrated by an earlier version must re-apply integration to refresh their on-disk adapter.

--- a/apps/docs-site/src/content/docs/session-authority.mdx
+++ b/apps/docs-site/src/content/docs/session-authority.mdx
@@ -52,7 +52,7 @@ Supervisor shutdown follows the same fail-closed resource cleanup. It first rese
 
 Session initialization is transactional: if port allocation, resource claiming, shared-knowledge preparation, or receipt creation fails, partial claims are released before startup reports the failure.
 
-When no matching live session or installed integration is available, the copied package adapter runs the original package script and user arguments unchanged. An explicit session ID is accepted only for the current canonical worktree and app root. When a session exists, unsupported command shapes or conflicting explicit flags fail rather than falling through.
+When the integration manifest has no session CLI, the copied package adapter runs the original package script and user arguments unchanged. When a session-capable integration is installed but no matching live session owns the worktree, the adapter exits with code 2 before starting the original script and names the supported repair: `rn_session(action="restore_integration", confirmed=true)`. An explicit session ID is accepted only for the current canonical worktree and app root. When a session exists, unsupported command shapes or conflicting explicit flags fail rather than falling through.
 
 ## What each source identity proves
 

--- a/apps/docs-site/src/content/docs/troubleshooting.mdx
+++ b/apps/docs-site/src/content/docs/troubleshooting.mdx
@@ -181,6 +181,7 @@ Codes returned by `cdp_*`/`device_*`/flow tools, what they mean, and the fix.
 | Codes | Meaning and repair |
 |---|---|
 | `SESSION_NOT_INITIALIZED`, `SESSION_AUTHORITY_REQUIRED`, `SESSION_OWNER_LOST` | The supervised worker has no current fenced owner. Inspect `rn_session(action="status")`; create or rebind the intended session instead of selecting ambient state. |
+| `SESSION_CLI_TIMEOUT` | The generated build adapter's bounded `prepare-build`, `ensure-metro`, or `complete-build` session-CLI call did not return within 120 seconds. Inspect `rn_session(action="status")`; retry only after the named authority step is healthy. The build fails instead of treating truncated output as success. |
 | `SESSION_INITIALIZATION_ROLLBACK_FAILED` | Session startup failed and could not prove that every partial claim was released. Do not retry against the same resources until `rn_session(action="status")` shows their ownership clearly. |
 | `SESSION_INTEGRATION_PATH_UNSAFE` | `.rn-agent`, its integration directory, or a retained path ancestor was symlinked, replaced, or changed during a fenced operation. Restore the intended real directory tree, inspect any preserved recovery journal, and retry. |
 | `AUTHORITY_STORE_UNAVAILABLE`, `AUTHORITY_STORE_BUSY`, `PROCESS_BIRTH_UNAVAILABLE` | The SQLite registry or conservative process identity is unavailable. Retry after the named substrate is healthy; there is no JSON, PID-only, or warning-only fallback. |

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -63734,8 +63734,9 @@ function failBuild(code, message) {
   reportAbortOutcome(abortFailure);
   process.exit(code);
 }
-function failOnSessionCliError(result, label) {
+async function failOnSessionCliError(result, label) {
   if (!result.error) return;
+  await drainBuildTerminationSignals();
   failBuild(2, result.error.code === 'ETIMEDOUT'
     ? 'SESSION_CLI_TIMEOUT: rn-session ' + label + ' did not return within ' + (SESSION_CLI_TIMEOUT_MS / 1000) + 's'
     : 'SESSION_AUTHORITY_REQUIRED: rn-session ' + label + ' failed: ' + result.error.message);
@@ -63877,7 +63878,7 @@ function managedMetroProxyUrl(binding) {
       timeout: SESSION_CLI_TIMEOUT_MS,
       killSignal: 'SIGKILL',
     });
-    failOnSessionCliError(probe, 'prepare-build');
+    await failOnSessionCliError(probe, 'prepare-build');
     if (probe.status !== 0 && String(probe.stderr).includes('live Metro binding')) {
       const metro = spawnSync(process.execPath, [...sqliteFlag, manifest.sessionCli, 'ensure-metro'], {
         cwd: process.cwd(),
@@ -63886,7 +63887,7 @@ function managedMetroProxyUrl(binding) {
         timeout: SESSION_CLI_TIMEOUT_MS,
         killSignal: 'SIGKILL',
       });
-      failOnSessionCliError(metro, 'ensure-metro');
+      await failOnSessionCliError(metro, 'ensure-metro');
       if (metro.status !== 0) {
         await drainBuildTerminationSignals();
         failBuild(2, String(metro.stderr).trim() || 'METRO_START_UNAVAILABLE: managed Metro failed');
@@ -63898,7 +63899,7 @@ function managedMetroProxyUrl(binding) {
         timeout: SESSION_CLI_TIMEOUT_MS,
         killSignal: 'SIGKILL',
       });
-      failOnSessionCliError(probe, 'prepare-build');
+      await failOnSessionCliError(probe, 'prepare-build');
     }
     if (probe.status === 0) {
       let parsed = null;
@@ -64027,7 +64028,7 @@ function managedMetroProxyUrl(binding) {
       timeout: SESSION_CLI_TIMEOUT_MS,
       killSignal: 'SIGKILL',
     });
-    failOnSessionCliError(complete, 'complete-build');
+    await failOnSessionCliError(complete, 'complete-build');
     if (complete.status !== 0) {
       failBuild(2, String(complete.stderr).trim() || 'APP_INSTALL_IDENTITY_CHANGED: build receipt could not be recorded');
     }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -63691,6 +63691,7 @@ let sessionCli = null;
 let buildCapability = null;
 let buildKind = null;
 const MANAGED_BUILD_SIGNALS = ['SIGINT', 'SIGTERM', 'SIGHUP'];
+const SESSION_CLI_TIMEOUT_MS = 120000;
 const buildRecovery = { abortAttempted: false, abortFailure: null, released: false, completed: false };
 function abortPendingBuild() {
   if (!buildCapability || !sessionCli) return null;
@@ -63701,6 +63702,8 @@ function abortPendingBuild() {
       RN_DEV_AGENT_SESSION_ID: session.sessionId,
     } : process.env,
     encoding: 'utf8',
+    timeout: SESSION_CLI_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
   });
   if (abort.error) return abort.error.message;
   if (abort.status !== 0) return String(abort.stderr).trim() || ('abort-build exited with status ' + abort.status);
@@ -63730,6 +63733,12 @@ function failBuild(code, message) {
   if (message) process.stderr.write(message + '\n');
   reportAbortOutcome(abortFailure);
   process.exit(code);
+}
+function failOnSessionCliError(result, label) {
+  if (!result.error) return;
+  failBuild(2, result.error.code === 'ETIMEDOUT'
+    ? 'SESSION_CLI_TIMEOUT: rn-session ' + label + ' did not return within ' + (SESSION_CLI_TIMEOUT_MS / 1000) + 's'
+    : 'SESSION_AUTHORITY_REQUIRED: rn-session ' + label + ' failed: ' + result.error.message);
 }
 function exitForBuildSignal(signal) {
   for (const name of MANAGED_BUILD_SIGNALS) process.removeAllListeners(name);
@@ -63786,6 +63795,8 @@ function resolveExpoAndroidDevice(deviceId) {
       RN_DEV_AGENT_SESSION_ID: session.sessionId,
     },
     encoding: 'utf8',
+    timeout: SESSION_CLI_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
   });
   if (resolved.error || resolved.status !== 0) {
     failBuild(2, String(resolved.stderr).trim() || 'EXPO_DEVICE_IDENTITY_MISMATCH: exact Android device identity resolution failed');
@@ -63863,13 +63874,19 @@ function managedMetroProxyUrl(binding) {
       cwd: process.cwd(),
       env: process.env,
       encoding: 'utf8',
+      timeout: SESSION_CLI_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
     });
+    failOnSessionCliError(probe, 'prepare-build');
     if (probe.status !== 0 && String(probe.stderr).includes('live Metro binding')) {
       const metro = spawnSync(process.execPath, [...sqliteFlag, manifest.sessionCli, 'ensure-metro'], {
         cwd: process.cwd(),
         env: process.env,
         encoding: 'utf8',
+        timeout: SESSION_CLI_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
       });
+      failOnSessionCliError(metro, 'ensure-metro');
       if (metro.status !== 0) {
         await drainBuildTerminationSignals();
         failBuild(2, String(metro.stderr).trim() || 'METRO_START_UNAVAILABLE: managed Metro failed');
@@ -63878,7 +63895,10 @@ function managedMetroProxyUrl(binding) {
         cwd: process.cwd(),
         env: process.env,
         encoding: 'utf8',
+        timeout: SESSION_CLI_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
       });
+      failOnSessionCliError(probe, 'prepare-build');
     }
     if (probe.status === 0) {
       let parsed = null;
@@ -63890,6 +63910,8 @@ function managedMetroProxyUrl(binding) {
       session = parsed;
     } else if (String(probe.stderr).includes('no live session matches this canonical worktree')) {
       buildCapability = null;
+      await drainBuildTerminationSignals();
+      failBuild(2, 'SESSION_AUTHORITY_REQUIRED: package integration is installed but no live session owns this worktree; start a session before building, or restore the original scripts with rn_session(action="restore_integration", confirmed=true)');
     } else {
       await drainBuildTerminationSignals();
       failBuild(2, String(probe.stderr).trim() || 'SESSION_AUTHORITY_REQUIRED: rn-session lookup failed');
@@ -64002,7 +64024,10 @@ function managedMetroProxyUrl(binding) {
         RN_DEV_AGENT_SESSION_ID: session.sessionId,
       },
       encoding: 'utf8',
+      timeout: SESSION_CLI_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
     });
+    failOnSessionCliError(complete, 'complete-build');
     if (complete.status !== 0) {
       failBuild(2, String(complete.stderr).trim() || 'APP_INSTALL_IDENTITY_CHANGED: build receipt could not be recorded');
     }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -17130,8 +17130,9 @@ function failBuild(code, message) {
   reportAbortOutcome(abortFailure);
   process.exit(code);
 }
-function failOnSessionCliError(result, label) {
+async function failOnSessionCliError(result, label) {
   if (!result.error) return;
+  await drainBuildTerminationSignals();
   failBuild(2, result.error.code === 'ETIMEDOUT'
     ? 'SESSION_CLI_TIMEOUT: rn-session ' + label + ' did not return within ' + (SESSION_CLI_TIMEOUT_MS / 1000) + 's'
     : 'SESSION_AUTHORITY_REQUIRED: rn-session ' + label + ' failed: ' + result.error.message);
@@ -17273,7 +17274,7 @@ function managedMetroProxyUrl(binding) {
       timeout: SESSION_CLI_TIMEOUT_MS,
       killSignal: 'SIGKILL',
     });
-    failOnSessionCliError(probe, 'prepare-build');
+    await failOnSessionCliError(probe, 'prepare-build');
     if (probe.status !== 0 && String(probe.stderr).includes('live Metro binding')) {
       const metro = spawnSync(process.execPath, [...sqliteFlag, manifest.sessionCli, 'ensure-metro'], {
         cwd: process.cwd(),
@@ -17282,7 +17283,7 @@ function managedMetroProxyUrl(binding) {
         timeout: SESSION_CLI_TIMEOUT_MS,
         killSignal: 'SIGKILL',
       });
-      failOnSessionCliError(metro, 'ensure-metro');
+      await failOnSessionCliError(metro, 'ensure-metro');
       if (metro.status !== 0) {
         await drainBuildTerminationSignals();
         failBuild(2, String(metro.stderr).trim() || 'METRO_START_UNAVAILABLE: managed Metro failed');
@@ -17294,7 +17295,7 @@ function managedMetroProxyUrl(binding) {
         timeout: SESSION_CLI_TIMEOUT_MS,
         killSignal: 'SIGKILL',
       });
-      failOnSessionCliError(probe, 'prepare-build');
+      await failOnSessionCliError(probe, 'prepare-build');
     }
     if (probe.status === 0) {
       let parsed = null;
@@ -17423,7 +17424,7 @@ function managedMetroProxyUrl(binding) {
       timeout: SESSION_CLI_TIMEOUT_MS,
       killSignal: 'SIGKILL',
     });
-    failOnSessionCliError(complete, 'complete-build');
+    await failOnSessionCliError(complete, 'complete-build');
     if (complete.status !== 0) {
       failBuild(2, String(complete.stderr).trim() || 'APP_INSTALL_IDENTITY_CHANGED: build receipt could not be recorded');
     }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -17087,6 +17087,7 @@ let sessionCli = null;
 let buildCapability = null;
 let buildKind = null;
 const MANAGED_BUILD_SIGNALS = ['SIGINT', 'SIGTERM', 'SIGHUP'];
+const SESSION_CLI_TIMEOUT_MS = 120000;
 const buildRecovery = { abortAttempted: false, abortFailure: null, released: false, completed: false };
 function abortPendingBuild() {
   if (!buildCapability || !sessionCli) return null;
@@ -17097,6 +17098,8 @@ function abortPendingBuild() {
       RN_DEV_AGENT_SESSION_ID: session.sessionId,
     } : process.env,
     encoding: 'utf8',
+    timeout: SESSION_CLI_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
   });
   if (abort.error) return abort.error.message;
   if (abort.status !== 0) return String(abort.stderr).trim() || ('abort-build exited with status ' + abort.status);
@@ -17126,6 +17129,12 @@ function failBuild(code, message) {
   if (message) process.stderr.write(message + '\n');
   reportAbortOutcome(abortFailure);
   process.exit(code);
+}
+function failOnSessionCliError(result, label) {
+  if (!result.error) return;
+  failBuild(2, result.error.code === 'ETIMEDOUT'
+    ? 'SESSION_CLI_TIMEOUT: rn-session ' + label + ' did not return within ' + (SESSION_CLI_TIMEOUT_MS / 1000) + 's'
+    : 'SESSION_AUTHORITY_REQUIRED: rn-session ' + label + ' failed: ' + result.error.message);
 }
 function exitForBuildSignal(signal) {
   for (const name of MANAGED_BUILD_SIGNALS) process.removeAllListeners(name);
@@ -17182,6 +17191,8 @@ function resolveExpoAndroidDevice(deviceId) {
       RN_DEV_AGENT_SESSION_ID: session.sessionId,
     },
     encoding: 'utf8',
+    timeout: SESSION_CLI_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
   });
   if (resolved.error || resolved.status !== 0) {
     failBuild(2, String(resolved.stderr).trim() || 'EXPO_DEVICE_IDENTITY_MISMATCH: exact Android device identity resolution failed');
@@ -17259,13 +17270,19 @@ function managedMetroProxyUrl(binding) {
       cwd: process.cwd(),
       env: process.env,
       encoding: 'utf8',
+      timeout: SESSION_CLI_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
     });
+    failOnSessionCliError(probe, 'prepare-build');
     if (probe.status !== 0 && String(probe.stderr).includes('live Metro binding')) {
       const metro = spawnSync(process.execPath, [...sqliteFlag, manifest.sessionCli, 'ensure-metro'], {
         cwd: process.cwd(),
         env: process.env,
         encoding: 'utf8',
+        timeout: SESSION_CLI_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
       });
+      failOnSessionCliError(metro, 'ensure-metro');
       if (metro.status !== 0) {
         await drainBuildTerminationSignals();
         failBuild(2, String(metro.stderr).trim() || 'METRO_START_UNAVAILABLE: managed Metro failed');
@@ -17274,7 +17291,10 @@ function managedMetroProxyUrl(binding) {
         cwd: process.cwd(),
         env: process.env,
         encoding: 'utf8',
+        timeout: SESSION_CLI_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
       });
+      failOnSessionCliError(probe, 'prepare-build');
     }
     if (probe.status === 0) {
       let parsed = null;
@@ -17286,6 +17306,8 @@ function managedMetroProxyUrl(binding) {
       session = parsed;
     } else if (String(probe.stderr).includes('no live session matches this canonical worktree')) {
       buildCapability = null;
+      await drainBuildTerminationSignals();
+      failBuild(2, 'SESSION_AUTHORITY_REQUIRED: package integration is installed but no live session owns this worktree; start a session before building, or restore the original scripts with rn_session(action="restore_integration", confirmed=true)');
     } else {
       await drainBuildTerminationSignals();
       failBuild(2, String(probe.stderr).trim() || 'SESSION_AUTHORITY_REQUIRED: rn-session lookup failed');
@@ -17398,7 +17420,10 @@ function managedMetroProxyUrl(binding) {
         RN_DEV_AGENT_SESSION_ID: session.sessionId,
       },
       encoding: 'utf8',
+      timeout: SESSION_CLI_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
     });
+    failOnSessionCliError(complete, 'complete-build');
     if (complete.status !== 0) {
       failBuild(2, String(complete.stderr).trim() || 'APP_INSTALL_IDENTITY_CHANGED: build receipt could not be recorded');
     }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -63734,8 +63734,9 @@ function failBuild(code, message) {
   reportAbortOutcome(abortFailure);
   process.exit(code);
 }
-function failOnSessionCliError(result, label) {
+async function failOnSessionCliError(result, label) {
   if (!result.error) return;
+  await drainBuildTerminationSignals();
   failBuild(2, result.error.code === 'ETIMEDOUT'
     ? 'SESSION_CLI_TIMEOUT: rn-session ' + label + ' did not return within ' + (SESSION_CLI_TIMEOUT_MS / 1000) + 's'
     : 'SESSION_AUTHORITY_REQUIRED: rn-session ' + label + ' failed: ' + result.error.message);
@@ -63877,7 +63878,7 @@ function managedMetroProxyUrl(binding) {
       timeout: SESSION_CLI_TIMEOUT_MS,
       killSignal: 'SIGKILL',
     });
-    failOnSessionCliError(probe, 'prepare-build');
+    await failOnSessionCliError(probe, 'prepare-build');
     if (probe.status !== 0 && String(probe.stderr).includes('live Metro binding')) {
       const metro = spawnSync(process.execPath, [...sqliteFlag, manifest.sessionCli, 'ensure-metro'], {
         cwd: process.cwd(),
@@ -63886,7 +63887,7 @@ function managedMetroProxyUrl(binding) {
         timeout: SESSION_CLI_TIMEOUT_MS,
         killSignal: 'SIGKILL',
       });
-      failOnSessionCliError(metro, 'ensure-metro');
+      await failOnSessionCliError(metro, 'ensure-metro');
       if (metro.status !== 0) {
         await drainBuildTerminationSignals();
         failBuild(2, String(metro.stderr).trim() || 'METRO_START_UNAVAILABLE: managed Metro failed');
@@ -63898,7 +63899,7 @@ function managedMetroProxyUrl(binding) {
         timeout: SESSION_CLI_TIMEOUT_MS,
         killSignal: 'SIGKILL',
       });
-      failOnSessionCliError(probe, 'prepare-build');
+      await failOnSessionCliError(probe, 'prepare-build');
     }
     if (probe.status === 0) {
       let parsed = null;
@@ -64027,7 +64028,7 @@ function managedMetroProxyUrl(binding) {
       timeout: SESSION_CLI_TIMEOUT_MS,
       killSignal: 'SIGKILL',
     });
-    failOnSessionCliError(complete, 'complete-build');
+    await failOnSessionCliError(complete, 'complete-build');
     if (complete.status !== 0) {
       failBuild(2, String(complete.stderr).trim() || 'APP_INSTALL_IDENTITY_CHANGED: build receipt could not be recorded');
     }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -63691,6 +63691,7 @@ let sessionCli = null;
 let buildCapability = null;
 let buildKind = null;
 const MANAGED_BUILD_SIGNALS = ['SIGINT', 'SIGTERM', 'SIGHUP'];
+const SESSION_CLI_TIMEOUT_MS = 120000;
 const buildRecovery = { abortAttempted: false, abortFailure: null, released: false, completed: false };
 function abortPendingBuild() {
   if (!buildCapability || !sessionCli) return null;
@@ -63701,6 +63702,8 @@ function abortPendingBuild() {
       RN_DEV_AGENT_SESSION_ID: session.sessionId,
     } : process.env,
     encoding: 'utf8',
+    timeout: SESSION_CLI_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
   });
   if (abort.error) return abort.error.message;
   if (abort.status !== 0) return String(abort.stderr).trim() || ('abort-build exited with status ' + abort.status);
@@ -63730,6 +63733,12 @@ function failBuild(code, message) {
   if (message) process.stderr.write(message + '\n');
   reportAbortOutcome(abortFailure);
   process.exit(code);
+}
+function failOnSessionCliError(result, label) {
+  if (!result.error) return;
+  failBuild(2, result.error.code === 'ETIMEDOUT'
+    ? 'SESSION_CLI_TIMEOUT: rn-session ' + label + ' did not return within ' + (SESSION_CLI_TIMEOUT_MS / 1000) + 's'
+    : 'SESSION_AUTHORITY_REQUIRED: rn-session ' + label + ' failed: ' + result.error.message);
 }
 function exitForBuildSignal(signal) {
   for (const name of MANAGED_BUILD_SIGNALS) process.removeAllListeners(name);
@@ -63786,6 +63795,8 @@ function resolveExpoAndroidDevice(deviceId) {
       RN_DEV_AGENT_SESSION_ID: session.sessionId,
     },
     encoding: 'utf8',
+    timeout: SESSION_CLI_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
   });
   if (resolved.error || resolved.status !== 0) {
     failBuild(2, String(resolved.stderr).trim() || 'EXPO_DEVICE_IDENTITY_MISMATCH: exact Android device identity resolution failed');
@@ -63863,13 +63874,19 @@ function managedMetroProxyUrl(binding) {
       cwd: process.cwd(),
       env: process.env,
       encoding: 'utf8',
+      timeout: SESSION_CLI_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
     });
+    failOnSessionCliError(probe, 'prepare-build');
     if (probe.status !== 0 && String(probe.stderr).includes('live Metro binding')) {
       const metro = spawnSync(process.execPath, [...sqliteFlag, manifest.sessionCli, 'ensure-metro'], {
         cwd: process.cwd(),
         env: process.env,
         encoding: 'utf8',
+        timeout: SESSION_CLI_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
       });
+      failOnSessionCliError(metro, 'ensure-metro');
       if (metro.status !== 0) {
         await drainBuildTerminationSignals();
         failBuild(2, String(metro.stderr).trim() || 'METRO_START_UNAVAILABLE: managed Metro failed');
@@ -63878,7 +63895,10 @@ function managedMetroProxyUrl(binding) {
         cwd: process.cwd(),
         env: process.env,
         encoding: 'utf8',
+        timeout: SESSION_CLI_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
       });
+      failOnSessionCliError(probe, 'prepare-build');
     }
     if (probe.status === 0) {
       let parsed = null;
@@ -63890,6 +63910,8 @@ function managedMetroProxyUrl(binding) {
       session = parsed;
     } else if (String(probe.stderr).includes('no live session matches this canonical worktree')) {
       buildCapability = null;
+      await drainBuildTerminationSignals();
+      failBuild(2, 'SESSION_AUTHORITY_REQUIRED: package integration is installed but no live session owns this worktree; start a session before building, or restore the original scripts with rn_session(action="restore_integration", confirmed=true)');
     } else {
       await drainBuildTerminationSignals();
       failBuild(2, String(probe.stderr).trim() || 'SESSION_AUTHORITY_REQUIRED: rn-session lookup failed');
@@ -64002,7 +64024,10 @@ function managedMetroProxyUrl(binding) {
         RN_DEV_AGENT_SESSION_ID: session.sessionId,
       },
       encoding: 'utf8',
+      timeout: SESSION_CLI_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
     });
+    failOnSessionCliError(complete, 'complete-build');
     if (complete.status !== 0) {
       failBuild(2, String(complete.stderr).trim() || 'APP_INSTALL_IDENTITY_CHANGED: build receipt could not be recorded');
     }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -17130,8 +17130,9 @@ function failBuild(code, message) {
   reportAbortOutcome(abortFailure);
   process.exit(code);
 }
-function failOnSessionCliError(result, label) {
+async function failOnSessionCliError(result, label) {
   if (!result.error) return;
+  await drainBuildTerminationSignals();
   failBuild(2, result.error.code === 'ETIMEDOUT'
     ? 'SESSION_CLI_TIMEOUT: rn-session ' + label + ' did not return within ' + (SESSION_CLI_TIMEOUT_MS / 1000) + 's'
     : 'SESSION_AUTHORITY_REQUIRED: rn-session ' + label + ' failed: ' + result.error.message);
@@ -17273,7 +17274,7 @@ function managedMetroProxyUrl(binding) {
       timeout: SESSION_CLI_TIMEOUT_MS,
       killSignal: 'SIGKILL',
     });
-    failOnSessionCliError(probe, 'prepare-build');
+    await failOnSessionCliError(probe, 'prepare-build');
     if (probe.status !== 0 && String(probe.stderr).includes('live Metro binding')) {
       const metro = spawnSync(process.execPath, [...sqliteFlag, manifest.sessionCli, 'ensure-metro'], {
         cwd: process.cwd(),
@@ -17282,7 +17283,7 @@ function managedMetroProxyUrl(binding) {
         timeout: SESSION_CLI_TIMEOUT_MS,
         killSignal: 'SIGKILL',
       });
-      failOnSessionCliError(metro, 'ensure-metro');
+      await failOnSessionCliError(metro, 'ensure-metro');
       if (metro.status !== 0) {
         await drainBuildTerminationSignals();
         failBuild(2, String(metro.stderr).trim() || 'METRO_START_UNAVAILABLE: managed Metro failed');
@@ -17294,7 +17295,7 @@ function managedMetroProxyUrl(binding) {
         timeout: SESSION_CLI_TIMEOUT_MS,
         killSignal: 'SIGKILL',
       });
-      failOnSessionCliError(probe, 'prepare-build');
+      await failOnSessionCliError(probe, 'prepare-build');
     }
     if (probe.status === 0) {
       let parsed = null;
@@ -17423,7 +17424,7 @@ function managedMetroProxyUrl(binding) {
       timeout: SESSION_CLI_TIMEOUT_MS,
       killSignal: 'SIGKILL',
     });
-    failOnSessionCliError(complete, 'complete-build');
+    await failOnSessionCliError(complete, 'complete-build');
     if (complete.status !== 0) {
       failBuild(2, String(complete.stderr).trim() || 'APP_INSTALL_IDENTITY_CHANGED: build receipt could not be recorded');
     }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -17087,6 +17087,7 @@ let sessionCli = null;
 let buildCapability = null;
 let buildKind = null;
 const MANAGED_BUILD_SIGNALS = ['SIGINT', 'SIGTERM', 'SIGHUP'];
+const SESSION_CLI_TIMEOUT_MS = 120000;
 const buildRecovery = { abortAttempted: false, abortFailure: null, released: false, completed: false };
 function abortPendingBuild() {
   if (!buildCapability || !sessionCli) return null;
@@ -17097,6 +17098,8 @@ function abortPendingBuild() {
       RN_DEV_AGENT_SESSION_ID: session.sessionId,
     } : process.env,
     encoding: 'utf8',
+    timeout: SESSION_CLI_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
   });
   if (abort.error) return abort.error.message;
   if (abort.status !== 0) return String(abort.stderr).trim() || ('abort-build exited with status ' + abort.status);
@@ -17126,6 +17129,12 @@ function failBuild(code, message) {
   if (message) process.stderr.write(message + '\n');
   reportAbortOutcome(abortFailure);
   process.exit(code);
+}
+function failOnSessionCliError(result, label) {
+  if (!result.error) return;
+  failBuild(2, result.error.code === 'ETIMEDOUT'
+    ? 'SESSION_CLI_TIMEOUT: rn-session ' + label + ' did not return within ' + (SESSION_CLI_TIMEOUT_MS / 1000) + 's'
+    : 'SESSION_AUTHORITY_REQUIRED: rn-session ' + label + ' failed: ' + result.error.message);
 }
 function exitForBuildSignal(signal) {
   for (const name of MANAGED_BUILD_SIGNALS) process.removeAllListeners(name);
@@ -17182,6 +17191,8 @@ function resolveExpoAndroidDevice(deviceId) {
       RN_DEV_AGENT_SESSION_ID: session.sessionId,
     },
     encoding: 'utf8',
+    timeout: SESSION_CLI_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
   });
   if (resolved.error || resolved.status !== 0) {
     failBuild(2, String(resolved.stderr).trim() || 'EXPO_DEVICE_IDENTITY_MISMATCH: exact Android device identity resolution failed');
@@ -17259,13 +17270,19 @@ function managedMetroProxyUrl(binding) {
       cwd: process.cwd(),
       env: process.env,
       encoding: 'utf8',
+      timeout: SESSION_CLI_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
     });
+    failOnSessionCliError(probe, 'prepare-build');
     if (probe.status !== 0 && String(probe.stderr).includes('live Metro binding')) {
       const metro = spawnSync(process.execPath, [...sqliteFlag, manifest.sessionCli, 'ensure-metro'], {
         cwd: process.cwd(),
         env: process.env,
         encoding: 'utf8',
+        timeout: SESSION_CLI_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
       });
+      failOnSessionCliError(metro, 'ensure-metro');
       if (metro.status !== 0) {
         await drainBuildTerminationSignals();
         failBuild(2, String(metro.stderr).trim() || 'METRO_START_UNAVAILABLE: managed Metro failed');
@@ -17274,7 +17291,10 @@ function managedMetroProxyUrl(binding) {
         cwd: process.cwd(),
         env: process.env,
         encoding: 'utf8',
+        timeout: SESSION_CLI_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
       });
+      failOnSessionCliError(probe, 'prepare-build');
     }
     if (probe.status === 0) {
       let parsed = null;
@@ -17286,6 +17306,8 @@ function managedMetroProxyUrl(binding) {
       session = parsed;
     } else if (String(probe.stderr).includes('no live session matches this canonical worktree')) {
       buildCapability = null;
+      await drainBuildTerminationSignals();
+      failBuild(2, 'SESSION_AUTHORITY_REQUIRED: package integration is installed but no live session owns this worktree; start a session before building, or restore the original scripts with rn_session(action="restore_integration", confirmed=true)');
     } else {
       await drainBuildTerminationSignals();
       failBuild(2, String(probe.stderr).trim() || 'SESSION_AUTHORITY_REQUIRED: rn-session lookup failed');
@@ -17398,7 +17420,10 @@ function managedMetroProxyUrl(binding) {
         RN_DEV_AGENT_SESSION_ID: session.sessionId,
       },
       encoding: 'utf8',
+      timeout: SESSION_CLI_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
     });
+    failOnSessionCliError(complete, 'complete-build');
     if (complete.status !== 0) {
       failBuild(2, String(complete.stderr).trim() || 'APP_INSTALL_IDENTITY_CHANGED: build receipt could not be recorded');
     }

--- a/packages/rn-dev-agent-core/dist/session/package-integration.js
+++ b/packages/rn-dev-agent-core/dist/session/package-integration.js
@@ -3289,8 +3289,9 @@ function failBuild(code, message) {
   reportAbortOutcome(abortFailure);
   process.exit(code);
 }
-function failOnSessionCliError(result, label) {
+async function failOnSessionCliError(result, label) {
   if (!result.error) return;
+  await drainBuildTerminationSignals();
   failBuild(2, result.error.code === 'ETIMEDOUT'
     ? 'SESSION_CLI_TIMEOUT: rn-session ' + label + ' did not return within ' + (SESSION_CLI_TIMEOUT_MS / 1000) + 's'
     : 'SESSION_AUTHORITY_REQUIRED: rn-session ' + label + ' failed: ' + result.error.message);
@@ -3432,7 +3433,7 @@ function managedMetroProxyUrl(binding) {
       timeout: SESSION_CLI_TIMEOUT_MS,
       killSignal: 'SIGKILL',
     });
-    failOnSessionCliError(probe, 'prepare-build');
+    await failOnSessionCliError(probe, 'prepare-build');
     if (probe.status !== 0 && String(probe.stderr).includes('live Metro binding')) {
       const metro = spawnSync(process.execPath, [...sqliteFlag, manifest.sessionCli, 'ensure-metro'], {
         cwd: process.cwd(),
@@ -3441,7 +3442,7 @@ function managedMetroProxyUrl(binding) {
         timeout: SESSION_CLI_TIMEOUT_MS,
         killSignal: 'SIGKILL',
       });
-      failOnSessionCliError(metro, 'ensure-metro');
+      await failOnSessionCliError(metro, 'ensure-metro');
       if (metro.status !== 0) {
         await drainBuildTerminationSignals();
         failBuild(2, String(metro.stderr).trim() || 'METRO_START_UNAVAILABLE: managed Metro failed');
@@ -3453,7 +3454,7 @@ function managedMetroProxyUrl(binding) {
         timeout: SESSION_CLI_TIMEOUT_MS,
         killSignal: 'SIGKILL',
       });
-      failOnSessionCliError(probe, 'prepare-build');
+      await failOnSessionCliError(probe, 'prepare-build');
     }
     if (probe.status === 0) {
       let parsed = null;
@@ -3582,7 +3583,7 @@ function managedMetroProxyUrl(binding) {
       timeout: SESSION_CLI_TIMEOUT_MS,
       killSignal: 'SIGKILL',
     });
-    failOnSessionCliError(complete, 'complete-build');
+    await failOnSessionCliError(complete, 'complete-build');
     if (complete.status !== 0) {
       failBuild(2, String(complete.stderr).trim() || 'APP_INSTALL_IDENTITY_CHANGED: build receipt could not be recorded');
     }

--- a/packages/rn-dev-agent-core/dist/session/package-integration.js
+++ b/packages/rn-dev-agent-core/dist/session/package-integration.js
@@ -3246,6 +3246,7 @@ let sessionCli = null;
 let buildCapability = null;
 let buildKind = null;
 const MANAGED_BUILD_SIGNALS = ['SIGINT', 'SIGTERM', 'SIGHUP'];
+const SESSION_CLI_TIMEOUT_MS = 120000;
 const buildRecovery = { abortAttempted: false, abortFailure: null, released: false, completed: false };
 function abortPendingBuild() {
   if (!buildCapability || !sessionCli) return null;
@@ -3256,6 +3257,8 @@ function abortPendingBuild() {
       RN_DEV_AGENT_SESSION_ID: session.sessionId,
     } : process.env,
     encoding: 'utf8',
+    timeout: SESSION_CLI_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
   });
   if (abort.error) return abort.error.message;
   if (abort.status !== 0) return String(abort.stderr).trim() || ('abort-build exited with status ' + abort.status);
@@ -3285,6 +3288,12 @@ function failBuild(code, message) {
   if (message) process.stderr.write(message + '\n');
   reportAbortOutcome(abortFailure);
   process.exit(code);
+}
+function failOnSessionCliError(result, label) {
+  if (!result.error) return;
+  failBuild(2, result.error.code === 'ETIMEDOUT'
+    ? 'SESSION_CLI_TIMEOUT: rn-session ' + label + ' did not return within ' + (SESSION_CLI_TIMEOUT_MS / 1000) + 's'
+    : 'SESSION_AUTHORITY_REQUIRED: rn-session ' + label + ' failed: ' + result.error.message);
 }
 function exitForBuildSignal(signal) {
   for (const name of MANAGED_BUILD_SIGNALS) process.removeAllListeners(name);
@@ -3341,6 +3350,8 @@ function resolveExpoAndroidDevice(deviceId) {
       RN_DEV_AGENT_SESSION_ID: session.sessionId,
     },
     encoding: 'utf8',
+    timeout: SESSION_CLI_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
   });
   if (resolved.error || resolved.status !== 0) {
     failBuild(2, String(resolved.stderr).trim() || 'EXPO_DEVICE_IDENTITY_MISMATCH: exact Android device identity resolution failed');
@@ -3418,13 +3429,19 @@ function managedMetroProxyUrl(binding) {
       cwd: process.cwd(),
       env: process.env,
       encoding: 'utf8',
+      timeout: SESSION_CLI_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
     });
+    failOnSessionCliError(probe, 'prepare-build');
     if (probe.status !== 0 && String(probe.stderr).includes('live Metro binding')) {
       const metro = spawnSync(process.execPath, [...sqliteFlag, manifest.sessionCli, 'ensure-metro'], {
         cwd: process.cwd(),
         env: process.env,
         encoding: 'utf8',
+        timeout: SESSION_CLI_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
       });
+      failOnSessionCliError(metro, 'ensure-metro');
       if (metro.status !== 0) {
         await drainBuildTerminationSignals();
         failBuild(2, String(metro.stderr).trim() || 'METRO_START_UNAVAILABLE: managed Metro failed');
@@ -3433,7 +3450,10 @@ function managedMetroProxyUrl(binding) {
         cwd: process.cwd(),
         env: process.env,
         encoding: 'utf8',
+        timeout: SESSION_CLI_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
       });
+      failOnSessionCliError(probe, 'prepare-build');
     }
     if (probe.status === 0) {
       let parsed = null;
@@ -3445,6 +3465,8 @@ function managedMetroProxyUrl(binding) {
       session = parsed;
     } else if (String(probe.stderr).includes('no live session matches this canonical worktree')) {
       buildCapability = null;
+      await drainBuildTerminationSignals();
+      failBuild(2, 'SESSION_AUTHORITY_REQUIRED: package integration is installed but no live session owns this worktree; start a session before building, or restore the original scripts with rn_session(action="restore_integration", confirmed=true)');
     } else {
       await drainBuildTerminationSignals();
       failBuild(2, String(probe.stderr).trim() || 'SESSION_AUTHORITY_REQUIRED: rn-session lookup failed');
@@ -3557,7 +3579,10 @@ function managedMetroProxyUrl(binding) {
         RN_DEV_AGENT_SESSION_ID: session.sessionId,
       },
       encoding: 'utf8',
+      timeout: SESSION_CLI_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
     });
+    failOnSessionCliError(complete, 'complete-build');
     if (complete.status !== 0) {
       failBuild(2, String(complete.stderr).trim() || 'APP_INSTALL_IDENTITY_CHANGED: build receipt could not be recorded');
     }

--- a/packages/rn-dev-agent-core/src/session/package-integration.ts
+++ b/packages/rn-dev-agent-core/src/session/package-integration.ts
@@ -3309,6 +3309,7 @@ let sessionCli = null;
 let buildCapability = null;
 let buildKind = null;
 const MANAGED_BUILD_SIGNALS = ['SIGINT', 'SIGTERM', 'SIGHUP'];
+const SESSION_CLI_TIMEOUT_MS = 120000;
 const buildRecovery = { abortAttempted: false, abortFailure: null, released: false, completed: false };
 function abortPendingBuild() {
   if (!buildCapability || !sessionCli) return null;
@@ -3319,6 +3320,8 @@ function abortPendingBuild() {
       RN_DEV_AGENT_SESSION_ID: session.sessionId,
     } : process.env,
     encoding: 'utf8',
+    timeout: SESSION_CLI_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
   });
   if (abort.error) return abort.error.message;
   if (abort.status !== 0) return String(abort.stderr).trim() || ('abort-build exited with status ' + abort.status);
@@ -3348,6 +3351,12 @@ function failBuild(code, message) {
   if (message) process.stderr.write(message + '\n');
   reportAbortOutcome(abortFailure);
   process.exit(code);
+}
+function failOnSessionCliError(result, label) {
+  if (!result.error) return;
+  failBuild(2, result.error.code === 'ETIMEDOUT'
+    ? 'SESSION_CLI_TIMEOUT: rn-session ' + label + ' did not return within ' + (SESSION_CLI_TIMEOUT_MS / 1000) + 's'
+    : 'SESSION_AUTHORITY_REQUIRED: rn-session ' + label + ' failed: ' + result.error.message);
 }
 function exitForBuildSignal(signal) {
   for (const name of MANAGED_BUILD_SIGNALS) process.removeAllListeners(name);
@@ -3404,6 +3413,8 @@ function resolveExpoAndroidDevice(deviceId) {
       RN_DEV_AGENT_SESSION_ID: session.sessionId,
     },
     encoding: 'utf8',
+    timeout: SESSION_CLI_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
   });
   if (resolved.error || resolved.status !== 0) {
     failBuild(2, String(resolved.stderr).trim() || 'EXPO_DEVICE_IDENTITY_MISMATCH: exact Android device identity resolution failed');
@@ -3481,13 +3492,19 @@ function managedMetroProxyUrl(binding) {
       cwd: process.cwd(),
       env: process.env,
       encoding: 'utf8',
+      timeout: SESSION_CLI_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
     });
+    failOnSessionCliError(probe, 'prepare-build');
     if (probe.status !== 0 && String(probe.stderr).includes('live Metro binding')) {
       const metro = spawnSync(process.execPath, [...sqliteFlag, manifest.sessionCli, 'ensure-metro'], {
         cwd: process.cwd(),
         env: process.env,
         encoding: 'utf8',
+        timeout: SESSION_CLI_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
       });
+      failOnSessionCliError(metro, 'ensure-metro');
       if (metro.status !== 0) {
         await drainBuildTerminationSignals();
         failBuild(2, String(metro.stderr).trim() || 'METRO_START_UNAVAILABLE: managed Metro failed');
@@ -3496,7 +3513,10 @@ function managedMetroProxyUrl(binding) {
         cwd: process.cwd(),
         env: process.env,
         encoding: 'utf8',
+        timeout: SESSION_CLI_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
       });
+      failOnSessionCliError(probe, 'prepare-build');
     }
     if (probe.status === 0) {
       let parsed = null;
@@ -3508,6 +3528,8 @@ function managedMetroProxyUrl(binding) {
       session = parsed;
     } else if (String(probe.stderr).includes('no live session matches this canonical worktree')) {
       buildCapability = null;
+      await drainBuildTerminationSignals();
+      failBuild(2, 'SESSION_AUTHORITY_REQUIRED: package integration is installed but no live session owns this worktree; start a session before building, or restore the original scripts with rn_session(action="restore_integration", confirmed=true)');
     } else {
       await drainBuildTerminationSignals();
       failBuild(2, String(probe.stderr).trim() || 'SESSION_AUTHORITY_REQUIRED: rn-session lookup failed');
@@ -3620,7 +3642,10 @@ function managedMetroProxyUrl(binding) {
         RN_DEV_AGENT_SESSION_ID: session.sessionId,
       },
       encoding: 'utf8',
+      timeout: SESSION_CLI_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
     });
+    failOnSessionCliError(complete, 'complete-build');
     if (complete.status !== 0) {
       failBuild(2, String(complete.stderr).trim() || 'APP_INSTALL_IDENTITY_CHANGED: build receipt could not be recorded');
     }

--- a/packages/rn-dev-agent-core/src/session/package-integration.ts
+++ b/packages/rn-dev-agent-core/src/session/package-integration.ts
@@ -3352,8 +3352,9 @@ function failBuild(code, message) {
   reportAbortOutcome(abortFailure);
   process.exit(code);
 }
-function failOnSessionCliError(result, label) {
+async function failOnSessionCliError(result, label) {
   if (!result.error) return;
+  await drainBuildTerminationSignals();
   failBuild(2, result.error.code === 'ETIMEDOUT'
     ? 'SESSION_CLI_TIMEOUT: rn-session ' + label + ' did not return within ' + (SESSION_CLI_TIMEOUT_MS / 1000) + 's'
     : 'SESSION_AUTHORITY_REQUIRED: rn-session ' + label + ' failed: ' + result.error.message);
@@ -3495,7 +3496,7 @@ function managedMetroProxyUrl(binding) {
       timeout: SESSION_CLI_TIMEOUT_MS,
       killSignal: 'SIGKILL',
     });
-    failOnSessionCliError(probe, 'prepare-build');
+    await failOnSessionCliError(probe, 'prepare-build');
     if (probe.status !== 0 && String(probe.stderr).includes('live Metro binding')) {
       const metro = spawnSync(process.execPath, [...sqliteFlag, manifest.sessionCli, 'ensure-metro'], {
         cwd: process.cwd(),
@@ -3504,7 +3505,7 @@ function managedMetroProxyUrl(binding) {
         timeout: SESSION_CLI_TIMEOUT_MS,
         killSignal: 'SIGKILL',
       });
-      failOnSessionCliError(metro, 'ensure-metro');
+      await failOnSessionCliError(metro, 'ensure-metro');
       if (metro.status !== 0) {
         await drainBuildTerminationSignals();
         failBuild(2, String(metro.stderr).trim() || 'METRO_START_UNAVAILABLE: managed Metro failed');
@@ -3516,7 +3517,7 @@ function managedMetroProxyUrl(binding) {
         timeout: SESSION_CLI_TIMEOUT_MS,
         killSignal: 'SIGKILL',
       });
-      failOnSessionCliError(probe, 'prepare-build');
+      await failOnSessionCliError(probe, 'prepare-build');
     }
     if (probe.status === 0) {
       let parsed = null;
@@ -3645,7 +3646,7 @@ function managedMetroProxyUrl(binding) {
       timeout: SESSION_CLI_TIMEOUT_MS,
       killSignal: 'SIGKILL',
     });
-    failOnSessionCliError(complete, 'complete-build');
+    await failOnSessionCliError(complete, 'complete-build');
     if (complete.status !== 0) {
       failBuild(2, String(complete.stderr).trim() || 'APP_INSTALL_IDENTITY_CHANGED: build receipt could not be recorded');
     }

--- a/packages/rn-dev-agent-core/test/unit/session/package-integration.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/package-integration.test.ts
@@ -4579,3 +4579,118 @@ test('a first authenticated child exchange that never completes fails typed inst
     rmSync(root, { force: true, recursive: true });
   }
 });
+
+test('orphaned package integration refuses instead of starting an unmanaged bundler', () => {
+  const root = mkdtempSync(join(tmpdir(), 'rn-session-adapter-orphaned-'));
+  try {
+    const integrationRoot = join(root, '.rn-agent', 'integration');
+    const binRoot = join(root, 'bin');
+    const adapterPath = join(integrationRoot, 'rn-session-adapter.cjs');
+    const sessionCliPath = join(root, 'rn-session.cjs');
+    const bundlerStartedPath = join(root, 'bundler-started.json');
+    const abortPath = join(root, 'abort.jsonl');
+    mkdirSync(integrationRoot, { recursive: true });
+    mkdirSync(binRoot, { recursive: true });
+    writeFileSync(adapterPath, renderProjectAdapter(), { mode: 0o755 });
+    writeFileSync(
+      join(integrationRoot, 'rn-session-integration.json'),
+      JSON.stringify({
+        version: 1,
+        adapter: '.rn-agent/integration/rn-session-adapter.cjs',
+        sessionCli: sessionCliPath,
+        originalScripts: {
+          ios: ['npx', 'expo', 'run:ios'],
+          android: ['npx', 'expo', 'run:android'],
+        },
+      }),
+    );
+    writeFileSync(
+      sessionCliPath,
+      "const fs=require('node:fs');const args=process.argv.slice(2);if(args[0]==='prepare-build'){process.stderr.write('SESSION_AUTHORITY_REQUIRED: no live session matches this canonical worktree and app root\\n');process.exit(2);}fs.appendFileSync(process.env.ADAPTER_ABORT,JSON.stringify({args})+'\\n');process.stdout.write('{}\\n');",
+    );
+    writeFileSync(
+      join(binRoot, 'npx'),
+      "#!/usr/bin/env node\nconst fs=require('node:fs');const net=require('node:net');const server=net.createServer();server.listen(0,'127.0.0.1',()=>{fs.writeFileSync(process.env.BUNDLER_STARTED,JSON.stringify({pid:process.pid,port:server.address().port,args:process.argv.slice(2)}));});setInterval(()=>{},1000);\n",
+    );
+    chmodSync(join(binRoot, 'npx'), 0o755);
+
+    // A regression re-spawns the original script and blocks the adapter in spawnSync, where
+    // its own SIGTERM handler can never run. File-backed stdio plus SIGKILL keep that a
+    // failed assertion rather than a hung test run.
+    const logPath = join(root, 'adapter.log');
+    const logFd = openSync(logPath, 'a');
+    let result;
+    try {
+      result = spawnSync(process.execPath, [adapterPath, 'ios'], {
+        cwd: root,
+        encoding: 'utf8',
+        timeout: 30_000,
+        killSignal: 'SIGKILL',
+        stdio: ['ignore', logFd, logFd],
+        env: {
+          ...process.env,
+          PATH: `${binRoot}:${process.env.PATH}`,
+          ADAPTER_ABORT: abortPath,
+          BUNDLER_STARTED: bundlerStartedPath,
+        },
+      });
+    } finally {
+      closeSync(logFd);
+    }
+    const output = readFileSync(logPath, 'utf8');
+
+    assert.equal(
+      result.error,
+      undefined,
+      `the adapter must return without hitting the deadline: ${output}`,
+    );
+    assert.equal(result.status, 2, output);
+    assert.match(output, /SESSION_AUTHORITY_REQUIRED/);
+    assert.match(output, /no live session owns this worktree/);
+    assert.match(output, /rn_session\(action="restore_integration", confirmed=true\)/);
+    assert.equal(
+      existsSync(bundlerStartedPath),
+      false,
+      'a refused build must never start an unmanaged bundler',
+    );
+    assert.equal(
+      existsSync(abortPath),
+      false,
+      'no build capability was ever published, so nothing may be aborted',
+    );
+  } finally {
+    if (existsSync(join(root, 'bundler-started.json'))) {
+      const leaked = JSON.parse(readFileSync(join(root, 'bundler-started.json'), 'utf8')) as {
+        pid: number;
+      };
+      try {
+        process.kill(leaked.pid, 'SIGKILL');
+      } catch {}
+    }
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test('every stdio-capturing session-CLI wait in the adapter is bounded', () => {
+  const adapter = renderProjectAdapter();
+  const spawnBlocks = adapter
+    .split('spawnSync(')
+    .slice(1)
+    .map((block) => block.slice(0, block.indexOf('});')));
+
+  for (const block of spawnBlocks) {
+    if (block.includes("stdio: 'inherit'")) continue;
+    assert.match(
+      block,
+      /timeout:/,
+      `a stdio-capturing spawnSync must declare a timeout: ${block.slice(0, 120)}`,
+    );
+  }
+
+  assert.match(
+    adapter,
+    /failOnSessionCliError\(complete, 'complete-build'\)/,
+    'a timed-out complete-build must fail instead of reading as a truncated success',
+  );
+  assert.match(adapter, /SESSION_CLI_TIMEOUT/);
+});

--- a/packages/rn-dev-agent-core/test/unit/session/package-integration.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/package-integration.test.ts
@@ -4614,9 +4614,7 @@ test('orphaned package integration refuses instead of starting an unmanaged bund
     );
     chmodSync(join(binRoot, 'npx'), 0o755);
 
-    // A regression re-spawns the original script and blocks the adapter in spawnSync, where
-    // its own SIGTERM handler can never run. File-backed stdio plus SIGKILL keep that a
-    // failed assertion rather than a hung test run.
+    // File-backed stdio plus SIGKILL turns a leaked spawnSync child into a failed assertion.
     const logPath = join(root, 'adapter.log');
     const logFd = openSync(logPath, 'a');
     let result;


### PR DESCRIPTION
## Intent

Fix a turn-ending defect in the managed React Native build path, shipping a diagnosis that was already accepted plus captain decision A.

The defect: when package integration is installed but no live rn-dev-agent session owns the worktree (a stale/orphaned integration), the generated build adapter in renderProjectAdapter silently set buildCapability = null and fell through to re-execute the project raw build script. For every supported script shape that raw script is a long-running dev server, so the adapter completion contract silently changed from "build, install, receipt, exit 0" to "never return". A literal pnpm run ios stayed foreground for over eight minutes after BUILD SUCCEEDED with an unmanaged bundler holding the terminal and no managed Metro listener, exhausting the authority-owning turn. The adapter was also unkillable politely: it installs SIGINT/SIGTERM/SIGHUP handlers, which removes the default disposition, and the handler can never run while the JS thread is blocked in spawnSync.

Captain decision A (already made, not open): fail immediately with exit code 2 and the exact supported repair command. Explicitly rejected alternatives: option B warn loudly and continue (does not fix the wedge), and option C refuse only under a session-capable context. The accepted trade-off is deliberate and known: a human running plain pnpm ios in an orphaned worktree now gets a refusal instead of a build. That is intended, because a refusal is recoverable in-turn and a hang is not.

Deliberate implementation decisions a reviewer reading only the diff would not know:
- buildCapability = null is intentionally KEPT and ordered FIRST before failBuild. The adapter had already minted a randomUUID build token that no session ever published, so clearing it first makes abortPendingBuildOnce short-circuit and prevents spawning a bogus abort-build against a capability nothing accepted.
- await drainBuildTerminationSignals() before failBuild is intentional and preserves signal precedence. It is a setImmediate that yields the loop so a signal queued while spawnSync blocked the JS thread runs its handler first. This is what keeps the pre-existing signal test at package-integration.test.ts:4239 green, which asserts the adapter dies BY SIGNAL, not by exit 2.
- The branch deliberately stays inside if (typeof manifest.sessionCli === "string"), so manifests without a session CLI keep transparent passthrough unchanged. Explicitly unintegrated and plugin-absent flows must not change; two pre-existing passthrough tests cover this and pass unmodified.
- The repair command named in the message is the documented one, rn_session(action="restore_integration", confirmed=true), per docs session-authority.mdx which states restore_integration with confirmed true restores the package scripts only after runtime authority is absent, which is exactly the orphaned state.
- Secondary hardening is scoped to directly evidenced bounded piped session-CLI waits only: SESSION_CLI_TIMEOUT_MS 120000 plus killSignal SIGKILL on the stdio-capturing session-CLI spawnSync calls, and a failOnSessionCliError helper so a timeout fails typed. This closes a proven trap: a pipe-held timeout returns status 0, so bounding alone would have converted the hang into a SILENT FALSE SUCCESS with a truncated receipt. The helper is applied only at the four guards that were status-only (prepare-build twice, ensure-metro, complete-build).
- abort-build and resolve-expo-android-device intentionally received the timeout bound but NOT the helper, because both already test .error and adding the helper would make their existing .error branch dead code.
- The native build spawnSync is intentionally left UNBOUNDED because it uses stdio inherit and builds are legitimately long; a hermetic counterfactual proved inherited stdio cannot wedge the caller. 9 spawnSync sites, 8 bounds, by design.
- killSignal SIGKILL is required rather than a plain timeout precisely because the adapter handles SIGTERM and cannot run its handler while blocked.

Regression contract: an end-to-end test proving no unmanaged bundler starts. The fixture uses the real rendered adapter, a manifest WITH sessionCli, a fake CLI whose prepare-build emits the orphaned-worktree stderr and exits 2, and a fake npx on PATH that binds a TCP socket and serves forever. It asserts exit 2, the exact repair command in stderr, no bundler marker, and no abort recorded. The test deliberately uses file-backed stdio and killSignal SIGKILL so that a regression fails as a timeout-with-verdict rather than hanging CI; with pipes the leaked bundler grandchild holds the captured pipes and the harness itself blocks forever. This was verified: against an adapter patched to re-introduce only the deleted edge, the run takes 8004ms and ends ETIMEDOUT with a bundler listening, versus 78ms and exit 2 after the fix. A second static invariant test asserts every stdio-capturing spawnSync in the rendered adapter declares a timeout, chosen specifically to avoid adding a test-only env seam to production code.

Explicitly out of scope and deliberately NOT built: no broker, daemon, watcher, recovery mode, background or detached build mode, async spawn rewrite, generalized process-lifecycle framework, longer authority lifetime, or adapter-side auto-restoration of package integration. No doc-only substitute. No changes to session/build-adapter.ts, CLAUDE-MD-TEMPLATE.md, rn-session.ts missing forced exit, or eager stale-integration restoration; those remain separate smaller follow-ups. No issue-357 branch changes and no PR 668/677/680 work.

Rebuild obligation discharged per repo CLAUDE.md: renderProjectAdapter is embedded verbatim in the shipped host runtimes, so build:core and build:host-runtimes were run and the regenerated dist for rn-dev-agent-core, claude-plugin, and codex-plugin is committed. A changeset patch-bumps rn-dev-agent-core and rn-dev-agent-plugin and notes that already-integrated projects keep their stale on-disk adapter until integration is re-applied. Full suite is 4465/4465 green; format, lint, agent-package-sync, typescript-only, and dist-fresh all pass.

## What Changed

- Refuse session-capable package integrations with no live worktree owner, exiting with code 2 before launching the original script and pointing users to `rn_session(action="restore_integration", confirmed=true)`.
- Bound stdio-capturing session CLI calls to 120 seconds with `SIGKILL` and typed failures while preserving queued termination-signal precedence.
- Add regression coverage and documentation for orphaned builds and CLI timeouts, regenerate the Claude and Codex host runtimes, and declare patch releases for the core and plugin packages.

## Risk Assessment

✅ Low: The prior signal-precedence finding is correctly resolved at the shared timeout-error boundary, and the complete change remains narrowly aligned with the durable fail-fast intent.

## Testing

The author-reported baseline already covered core/host rebuilds, the full suite, formatting, lint, package sync, TypeScript-only, and dist-fresh checks; within this targeted test phase I re-ran the relevant adapter contracts, verified all shipped host bundles, and exercised the end-user `pnpm run ios` path, which refused in 1603 ms with the exact repair command and without starting a bundler or recording an abort.

<details>
<summary>Evidence: End-user pnpm orphan-refusal transcript</summary>

<code>SESSION_AUTHORITY_REQUIRED: package integration is installed but no live session owns this worktree; start a session before building, or restore the original scripts with rn_session(action=&#34;restore_integration&#34;, confirmed=true)&#10;exit_code=2&#10;signal=none&#10;timed_out=false&#10;elapsed_ms=1603&#10;bundler_started=false&#10;abort_recorded=false</code>

```text
$ COREPACK_ENABLE_PROJECT_SPEC=0 pnpm run ios

> managed-build-orphan-evidence@ ios /private/var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/no-mistakes-evidence/01KZBYPMPWRRQWTP5NYAHREHTE/managed-build-cli-fixture
> node .rn-agent/integration/rn-session-adapter.cjs ios

SESSION_AUTHORITY_REQUIRED: package integration is installed but no live session owns this worktree; start a session before building, or restore the original scripts with rn_session(action="restore_integration", confirmed=true)
 ELIFECYCLE  Command failed with exit code 2.
 WARN   Local package.json exists, but node_modules missing, did you mean to install?

exit_code=2
signal=none
timed_out=false
elapsed_ms=1603
bundler_started=false
abort_recorded=false
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `packages/rn-dev-agent-core/src/session/package-integration.ts:3357` - Preserve queued termination signals in the new timeout helper. If SIGINT/SIGTERM/SIGHUP arrives while `prepare-build` or `ensure-metro` is blocked, `spawnSync` queues the handler; when the timeout returns, this helper immediately runs synchronous abort cleanup and `process.exit(2)`, so the signal never executes. These paths previously yielded through `drainBuildTerminationSignals()` before failing. Make this shared helper async, drain signals before `failBuild`, and await all four calls.

🔧 Fix: Preserve session CLI timeout signal precedence
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test --test-concurrency=1 --test-name-pattern='orphaned package integration refuses|every stdio-capturing session-CLI wait|copied adapter remains a transparent passthrough|plugin-absent passthrough|copied adapter arms interruption recovery' packages/rn-dev-agent-core/test/unit/session/package-integration.test.ts`
- <code>Rendered the committed adapter into a disposable orphaned-integration fixture and executed `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm run ios`.</code>
- <code>Asserted the exact refusal, 120-second session-CLI timeout, and SIGKILL policy are embedded in both Claude and Codex `index.js` and `supervisor.js` host runtimes.</code>
- `Read back and asserted the evidence contract: exit 2, no signal or timeout, elapsed time below the 8-second verdict deadline, exact repair command, no bundler marker, and no abort record.`
- <code>`git status --short --branch` after removing the temporary harness.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
