### PR TITLE
test(core): stabilize the nightly device smoke driver

### DIFF
--- a/docs/stories/06-native-runner-ci-and-evals.md
+++ b/docs/stories/06-native-runner-ci-and-evals.md
@@ -35,7 +35,8 @@ CI (` .github/workflows/ci.yml`) runs 2,522 TS unit cases, 3 integration tests, 
 ### Phase B — nightly device smoke (golden command set)
 
 > **Implemented 2026-07-06** (#387): `.github/workflows/nightly-device-smoke.yml` +
-> `test-fixtures/{ios,android}-fixture/` + `scripts/cdp-bridge/test/smoke/device-smoke.ts`
+> `test-fixtures/{ios,android}-fixture/` +
+> `packages/rn-dev-agent-core/test/smoke/device-smoke.ts`
 > + root `smoke:{ios,android}` scripts.
 >
 > Triage notes:

--- a/docs/superpowers/specs/2026-07-05-387-phase-b-device-smoke-design.md
+++ b/docs/superpowers/specs/2026-07-05-387-phase-b-device-smoke-design.md
@@ -116,11 +116,13 @@ seeded-bug acceptance check). Permissions: `contents: read`, `issues: write`
   fixture APK → inside the emulator step: `adb install` fixture → run driver.
 - Simulator/emulator logs + screenshots uploaded as artifacts on failure.
 
-### Golden-set driver — `scripts/cdp-bridge/test/smoke/device-smoke.ts`
+### Golden-set driver — `packages/rn-dev-agent-core/test/smoke/device-smoke.ts`
 
 `node:test`, reusing `test/helpers/supervisor-harness.js`: spawn
-`dist/supervisor.js` over MCP stdio, cwd = tmp project dir, env
-`RN_RUNNER_BUILD=local` (forces `build-local` provenance in
+`dist/supervisor.js` over MCP stdio from a temporary non-Git project containing
+a minimal `package.json`. The driver passes `RN_DEV_AGENT_DECLARED_ROOT=<cwd>`,
+`RN_DEV_AGENT_DECLARED_MANIFESTS=package.json`, and `RN_RUNNER_BUILD=local`
+(which forces `build-local` provenance in
 `runner-artifacts.ts:156` so a version-matching release can never shadow the
 fresh main-HEAD build). CDP is intentionally absent; `device_fill` exercises its
 native read-back path by design.

--- a/packages/rn-dev-agent-core/test/smoke/device-smoke-driver.ts
+++ b/packages/rn-dev-agent-core/test/smoke/device-smoke-driver.ts
@@ -1,0 +1,99 @@
+// Seams of device-smoke.ts that can be proven without a device: the fixture
+// cwd's declared (non-Git) source identity and the fixture-launch retry policy.
+// Covered by test/unit/smoke/device-smoke-driver.test.ts.
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export const FIXTURE_MANIFEST = 'package.json';
+export const LAUNCH_ATTEMPTS = 2;
+export const FOREGROUND_TIMEOUT_MS = 30_000;
+
+export interface DeclaredIdentityEnv {
+  RN_DEV_AGENT_DECLARED_ROOT: string;
+  RN_DEV_AGENT_DECLARED_MANIFESTS: string;
+}
+
+export interface DeclaredFixtureRoot {
+  cwd: string;
+  env: DeclaredIdentityEnv;
+}
+
+// The supervisor resolves source identity from its cwd; a bare temp dir is
+// neither a Git worktree nor a declared root, so it must declare both axes
+// (NON_GIT_MANIFEST_REQUIRED otherwise — GH #666).
+export function createDeclaredFixtureRoot(): DeclaredFixtureRoot {
+  const cwd = mkdtempSync(join(tmpdir(), 'rn-agent-smoke-'));
+  writeFileSync(join(cwd, FIXTURE_MANIFEST), '{"name":"rn-agent-smoke-fixture","private":true}\n');
+  return {
+    cwd,
+    env: {
+      RN_DEV_AGENT_DECLARED_ROOT: cwd,
+      RN_DEV_AGENT_DECLARED_MANIFESTS: FIXTURE_MANIFEST,
+    },
+  };
+}
+
+// Exactly `xcrun simctl launch` hitting its own timeout — the only launch
+// failure the nightly proved to be runner-side CoreSimulator wedging rather
+// than a real fault. A missing binary, a non-zero simctl status, or any other
+// spawn is a truthful failure and must not be retried.
+export function isSimctlLaunchTimeout(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const spawned = error as { code?: unknown; path?: unknown; spawnargs?: unknown };
+  if (spawned.code !== 'ETIMEDOUT' || spawned.path !== 'xcrun') return false;
+  const args: unknown[] = Array.isArray(spawned.spawnargs) ? spawned.spawnargs : [];
+  return args[0] === 'simctl' && args[1] === 'launch';
+}
+
+export interface LaunchFixtureDeps {
+  appId: string;
+  launchOnce: () => void;
+  isRunning: () => boolean;
+  isRetryableLaunchTimeout: (error: unknown) => boolean;
+  foregroundTimeoutMs?: number;
+  pollIntervalMs?: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const describeFailure = (error: unknown) =>
+  error instanceof Error ? error.message : String(error);
+
+export async function launchFixtureWithRetry({
+  appId,
+  launchOnce,
+  isRunning,
+  isRetryableLaunchTimeout,
+  foregroundTimeoutMs = FOREGROUND_TIMEOUT_MS,
+  pollIntervalMs = 500,
+  now = Date.now,
+  sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+}: LaunchFixtureDeps): Promise<void> {
+  const failures: string[] = [];
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= LAUNCH_ATTEMPTS; attempt++) {
+    try {
+      launchOnce();
+    } catch (error) {
+      if (!isRetryableLaunchTimeout(error)) throw error;
+      lastError = error;
+      failures.push(`attempt ${attempt} launch timed out (${describeFailure(error)})`);
+      continue;
+    }
+    const deadline = now() + foregroundTimeoutMs;
+    while (now() < deadline) {
+      if (isRunning()) return;
+      await sleep(pollIntervalMs);
+    }
+    failures.push(
+      `attempt ${attempt} launched but ${appId} was not running within ${foregroundTimeoutMs}ms`,
+    );
+  }
+
+  throw new Error(
+    `fixture ${appId} did not start after ${LAUNCH_ATTEMPTS} launch attempts: ${failures.join('; ')}`,
+    lastError === undefined ? undefined : { cause: lastError },
+  );
+}

--- a/packages/rn-dev-agent-core/test/smoke/device-smoke-driver.ts
+++ b/packages/rn-dev-agent-core/test/smoke/device-smoke-driver.ts
@@ -1,6 +1,4 @@
-// Seams of device-smoke.ts that can be proven without a device: the fixture
-// cwd's declared (non-Git) source identity and the fixture-launch retry policy.
-// Covered by test/unit/smoke/device-smoke-driver.test.ts.
+// Hermetic seams for the smoke fixture's source identity and launch retry policy.
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -19,9 +17,7 @@ export interface DeclaredFixtureRoot {
   env: DeclaredIdentityEnv;
 }
 
-// The supervisor resolves source identity from its cwd; a bare temp dir is
-// neither a Git worktree nor a declared root, so it must declare both axes
-// (NON_GIT_MANIFEST_REQUIRED otherwise — GH #666).
+// A bare temp cwd must declare both source-identity axes (NON_GIT_MANIFEST_REQUIRED otherwise).
 export function createDeclaredFixtureRoot(): DeclaredFixtureRoot {
   const cwd = mkdtempSync(join(tmpdir(), 'rn-agent-smoke-'));
   writeFileSync(join(cwd, FIXTURE_MANIFEST), '{"name":"rn-agent-smoke-fixture","private":true}\n');
@@ -34,10 +30,7 @@ export function createDeclaredFixtureRoot(): DeclaredFixtureRoot {
   };
 }
 
-// Exactly `xcrun simctl launch` hitting its own timeout — the only launch
-// failure the nightly proved to be runner-side CoreSimulator wedging rather
-// than a real fault. A missing binary, a non-zero simctl status, or any other
-// spawn is a truthful failure and must not be retried.
+// Only xcrun simctl launch ETIMEDOUT is proven runner-side; other failures are authoritative.
 export function isSimctlLaunchTimeout(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) return false;
   const spawned = error as { code?: unknown; path?: unknown; spawnargs?: unknown };

--- a/packages/rn-dev-agent-core/test/smoke/device-smoke.ts
+++ b/packages/rn-dev-agent-core/test/smoke/device-smoke.ts
@@ -8,11 +8,16 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 // @ts-expect-error -- untyped JS test helper
 import { startSupervisor } from '../helpers/supervisor-harness.js';
+import {
+  createDeclaredFixtureRoot,
+  isSimctlLaunchTimeout,
+  launchFixtureWithRetry,
+} from './device-smoke-driver.ts';
 
 const PLATFORM = process.env.SMOKE_PLATFORM;
 const APP_ID = process.env.SMOKE_APP_ID ?? 'dev.lykhoyda.rndevagent.fixture';
@@ -126,16 +131,15 @@ async function launchFixture() {
   // Two launch attempts, ~30s each: a reused-but-cold CI simulator/emulator can
   // take longer than a single short window to bring the app to foreground
   // (device-proven: a lone slow launch tripped the old 20s deadline). The
-  // re-launch is idempotent (foregrounds an already-running app).
-  for (let attempt = 0; attempt < 2; attempt++) {
-    launchFixtureOnce();
-    const deadline = Date.now() + 30_000;
-    while (Date.now() < deadline) {
-      if (fixtureRunning()) return;
-      await new Promise((r) => setTimeout(r, 500));
-    }
-  }
-  throw new Error(`fixture ${APP_ID} did not start within 2x30s of launch`);
+  // re-launch is idempotent (foregrounds an already-running app). A wedged
+  // CoreSimulator that times out `simctl launch` consumes an attempt instead of
+  // aborting the run (GH #666); every other launch error still fails at once.
+  await launchFixtureWithRetry({
+    appId: APP_ID,
+    launchOnce: launchFixtureOnce,
+    isRunning: fixtureRunning,
+    isRetryableLaunchTimeout: isSimctlLaunchTimeout,
+  });
 }
 
 async function rpc(s: any, method: string, params?: unknown) {
@@ -169,8 +173,12 @@ test(`Phase B golden set (${PLATFORM})`, { timeout: 900_000 }, async () => {
   stopFixture();
   await launchFixture();
   mkdirSync(DEBUG_DIR, { recursive: true });
-  const cwd = mkdtempSync(join(tmpdir(), 'rn-agent-smoke-'));
-  const s = startSupervisor({ cwd, lineTimeoutMs: 600_000, env: { RN_RUNNER_BUILD: 'local' } });
+  const fixtureRoot = createDeclaredFixtureRoot();
+  const s = startSupervisor({
+    cwd: fixtureRoot.cwd,
+    lineTimeoutMs: 600_000,
+    env: { RN_RUNNER_BUILD: 'local', ...fixtureRoot.env },
+  });
   const steps: Array<{ name: string; isError: boolean; envelope: unknown }> = [];
   const record = (name: string, r: ToolReply) => {
     steps.push({ name, isError: r.isError, envelope: r.envelope });

--- a/packages/rn-dev-agent-core/test/smoke/device-smoke.ts
+++ b/packages/rn-dev-agent-core/test/smoke/device-smoke.ts
@@ -123,17 +123,7 @@ function launchFixtureOnce() {
 }
 
 async function launchFixture() {
-  // The driver owns the fixture lifecycle: launch it OURSELVES and open the
-  // session with attachOnly (the documented race-free path). Launch-at-open
-  // proved flaky on a loaded emulator — the bridge's `adb shell monkey` has a
-  // 10s timeout that a cold app on a busy host can exceed.
-  //
-  // Two launch attempts, ~30s each: a reused-but-cold CI simulator/emulator can
-  // take longer than a single short window to bring the app to foreground
-  // (device-proven: a lone slow launch tripped the old 20s deadline). The
-  // re-launch is idempotent (foregrounds an already-running app). A wedged
-  // CoreSimulator that times out `simctl launch` consumes an attempt instead of
-  // aborting the run (GH #666); every other launch error still fails at once.
+  // Launch before attachOnly; retry only xcrun simctl launch ETIMEDOUT or a 30s foreground miss.
   await launchFixtureWithRetry({
     appId: APP_ID,
     launchOnce: launchFixtureOnce,

--- a/packages/rn-dev-agent-core/test/unit/smoke/device-smoke-driver.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/smoke/device-smoke-driver.test.ts
@@ -1,0 +1,243 @@
+// GH #666: the nightly device smoke went red on two independent harness
+// defects — the fixture cwd never declared a non-Git source identity, and the
+// documented two-attempt launch never retried a wedged `simctl launch`. Both
+// seams live in test/smoke/device-smoke-driver.ts and are proven here without
+// a simulator, an emulator, or a device.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, test } from 'node:test';
+import {
+  createDeclaredFixtureRoot,
+  isSimctlLaunchTimeout,
+  launchFixtureWithRetry,
+  FIXTURE_MANIFEST,
+  LAUNCH_ATTEMPTS,
+} from '../../smoke/device-smoke-driver.ts';
+import { resolveSourceIdentity } from '../../../dist/session/source-identity.js';
+
+const APP_ID = 'dev.lykhoyda.rndevagent.fixture';
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { force: true, recursive: true });
+});
+
+const notAGitRepo = () => {
+  throw new Error('fatal: not a git repository (or any of the parent directories): .git');
+};
+
+// A genuine spawnSync timeout error, so the retry predicate is pinned to the
+// shape Node actually throws rather than to a hand-written stand-in.
+let realTimeoutError: Record<string, unknown> | null = null;
+function spawnTimeoutError(): Record<string, unknown> {
+  if (!realTimeoutError) {
+    try {
+      execFileSync(process.execPath, ['-e', 'setTimeout(() => {}, 5000)'], {
+        stdio: 'pipe',
+        timeout: 200,
+      });
+      assert.fail('the probe command must time out');
+    } catch (error) {
+      realTimeoutError = error as Record<string, unknown>;
+    }
+  }
+  return Object.assign(Object.create(Object.getPrototypeOf(realTimeoutError)), realTimeoutError);
+}
+
+function simctlLaunchTimeout(): Error {
+  const error = spawnTimeoutError();
+  error.path = 'xcrun';
+  error.spawnargs = ['simctl', 'launch', 'booted', APP_ID];
+  error.syscall = 'spawnSync xcrun';
+  (error as { message: string }).message = 'spawnSync xcrun ETIMEDOUT';
+  return error as unknown as Error;
+}
+
+function fakeClock() {
+  let elapsed = 0;
+  return {
+    now: () => elapsed,
+    sleep: async (ms: number) => {
+      elapsed += ms;
+    },
+  };
+}
+
+test('spawnSync timeouts really carry code/path/spawnargs', () => {
+  const error = spawnTimeoutError();
+  assert.equal(error.code, 'ETIMEDOUT');
+  assert.equal(typeof error.path, 'string');
+  assert.ok(Array.isArray(error.spawnargs));
+});
+
+test('the fixture cwd declares a non-Git source identity the shipped resolver accepts', () => {
+  const { cwd, env } = createDeclaredFixtureRoot();
+  roots.push(cwd);
+
+  assert.equal(env.RN_DEV_AGENT_DECLARED_ROOT, cwd);
+  assert.equal(env.RN_DEV_AGENT_DECLARED_MANIFESTS, FIXTURE_MANIFEST);
+  assert.ok(JSON.parse(readFileSync(join(cwd, FIXTURE_MANIFEST), 'utf8')).name);
+
+  // Exactly how supervisor.ts reads the two variables it was handed.
+  const declaredManifests = env.RN_DEV_AGENT_DECLARED_MANIFESTS.split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  const identity = resolveSourceIdentity(cwd, {
+    git: notAGitRepo,
+    declaredRoot: env.RN_DEV_AGENT_DECLARED_ROOT,
+    declaredManifests,
+  });
+
+  assert.equal(identity.kind, 'declared-root');
+  assert.deepEqual(identity.declaredManifests, [FIXTURE_MANIFEST]);
+  assert.match(identity.manifestDigest, /^[a-f0-9]{64}$/);
+});
+
+test('the declaration is what makes it resolve — strict non-Git authority is untouched', () => {
+  const { cwd } = createDeclaredFixtureRoot();
+  roots.push(cwd);
+
+  assert.throws(
+    () => resolveSourceIdentity(cwd, { git: notAGitRepo }),
+    /NON_GIT_MANIFEST_REQUIRED/,
+  );
+});
+
+test('one simctl launch timeout consumes an attempt and the relaunch starts the fixture', async () => {
+  const clock = fakeClock();
+  let launches = 0;
+  let probes = 0;
+
+  await launchFixtureWithRetry({
+    appId: APP_ID,
+    launchOnce: () => {
+      launches += 1;
+      if (launches === 1) throw simctlLaunchTimeout();
+    },
+    isRunning: () => (probes += 1) > 2,
+    isRetryableLaunchTimeout: isSimctlLaunchTimeout,
+    ...clock,
+  });
+
+  assert.equal(launches, 2);
+  assert.equal(probes, 3);
+});
+
+test('a second launch timeout fails truthfully with both attempts and the underlying error', async () => {
+  const clock = fakeClock();
+  let launches = 0;
+  let probes = 0;
+  const second = simctlLaunchTimeout();
+
+  await assert.rejects(
+    launchFixtureWithRetry({
+      appId: APP_ID,
+      launchOnce: () => {
+        launches += 1;
+        if (launches === 2) throw second;
+        throw simctlLaunchTimeout();
+      },
+      isRunning: () => {
+        probes += 1;
+        return true;
+      },
+      isRetryableLaunchTimeout: isSimctlLaunchTimeout,
+      ...clock,
+    }),
+    (error: Error) => {
+      assert.match(error.message, /attempt 1 launch timed out \(spawnSync xcrun ETIMEDOUT\)/);
+      assert.match(error.message, /attempt 2 launch timed out \(spawnSync xcrun ETIMEDOUT\)/);
+      // It must not claim the fixture launched and failed to come up.
+      assert.doesNotMatch(error.message, /was not running within/);
+      assert.equal(error.cause, second);
+      return true;
+    },
+  );
+
+  assert.equal(launches, LAUNCH_ATTEMPTS);
+  assert.equal(probes, 0);
+});
+
+test('a timeout followed by a fixture that never foregrounds reports both attempts', async () => {
+  const clock = fakeClock();
+  let launches = 0;
+
+  await assert.rejects(
+    launchFixtureWithRetry({
+      appId: APP_ID,
+      launchOnce: () => {
+        launches += 1;
+        if (launches === 1) throw simctlLaunchTimeout();
+      },
+      isRunning: () => false,
+      isRetryableLaunchTimeout: isSimctlLaunchTimeout,
+      foregroundTimeoutMs: 1_000,
+      ...clock,
+    }),
+    (error: Error) => {
+      assert.match(error.message, /attempt 1 launch timed out/);
+      assert.match(error.message, /attempt 2 launched but .* was not running within 1000ms/);
+      return true;
+    },
+  );
+
+  assert.equal(launches, 2);
+});
+
+test('a non-timeout launch failure aborts immediately with the original error', async () => {
+  const clock = fakeClock();
+  let launches = 0;
+  let probes = 0;
+  const refusal = Object.assign(new Error('Command failed: xcrun simctl launch booted'), {
+    status: 3,
+  });
+
+  await assert.rejects(
+    launchFixtureWithRetry({
+      appId: APP_ID,
+      launchOnce: () => {
+        launches += 1;
+        throw refusal;
+      },
+      isRunning: () => {
+        probes += 1;
+        return true;
+      },
+      isRetryableLaunchTimeout: isSimctlLaunchTimeout,
+      ...clock,
+    }),
+    (error: unknown) => error === refusal,
+  );
+
+  assert.equal(launches, 1);
+  assert.equal(probes, 0);
+});
+
+test('only an xcrun simctl launch timeout is retryable', () => {
+  assert.equal(isSimctlLaunchTimeout(simctlLaunchTimeout()), true);
+
+  const terminate = simctlLaunchTimeout();
+  (terminate as unknown as { spawnargs: string[] }).spawnargs = [
+    'simctl',
+    'terminate',
+    'booted',
+    APP_ID,
+  ];
+  assert.equal(isSimctlLaunchTimeout(terminate), false);
+
+  const adb = simctlLaunchTimeout();
+  Object.assign(adb, { path: 'adb', spawnargs: ['shell', 'monkey', '-p', APP_ID] });
+  assert.equal(isSimctlLaunchTimeout(adb), false);
+
+  const missingBinary = Object.assign(new Error('spawnSync xcrun ENOENT'), {
+    code: 'ENOENT',
+    path: 'xcrun',
+    spawnargs: ['simctl', 'launch', 'booted', APP_ID],
+  });
+  assert.equal(isSimctlLaunchTimeout(missingBinary), false);
+
+  assert.equal(isSimctlLaunchTimeout(new Error('boom')), false);
+  assert.equal(isSimctlLaunchTimeout(null), false);
+});

--- a/packages/rn-dev-agent-core/test/unit/smoke/device-smoke-driver.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/smoke/device-smoke-driver.test.ts
@@ -1,8 +1,4 @@
-// GH #666: the nightly device smoke went red on two independent harness
-// defects — the fixture cwd never declared a non-Git source identity, and the
-// documented two-attempt launch never retried a wedged `simctl launch`. Both
-// seams live in test/smoke/device-smoke-driver.ts and are proven here without
-// a simulator, an emulator, or a device.
+// Hermetic regression coverage for the GH #666 smoke-driver seams.
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { readFileSync, rmSync } from 'node:fs';
@@ -28,8 +24,7 @@ const notAGitRepo = () => {
   throw new Error('fatal: not a git repository (or any of the parent directories): .git');
 };
 
-// A genuine spawnSync timeout error, so the retry predicate is pinned to the
-// shape Node actually throws rather than to a hand-written stand-in.
+// Use Node's real timeout shape to pin the retry predicate to runtime behavior.
 let realTimeoutError: Record<string, unknown> | null = null;
 function spawnTimeoutError(): Record<string, unknown> {
   if (!realTimeoutError) {


### PR DESCRIPTION
## Intent

Implement the two narrowly proven nightly device-smoke driver corrections diagnosed for issue #666, against current main. Test-harness only; no product behavior change.

(1) In packages/rn-dev-agent-core/test/smoke/device-smoke.ts, make the bare temporary fixture use the supported non-Git identity contract: write the minimal manifest and pass exact RN_DEV_AGENT_DECLARED_ROOT and RN_DEV_AGENT_DECLARED_MANIFESTS values through the existing startSupervisor env option, preserving strict shipped source-identity behavior. Deliberately do NOT initialize a fake Git repository — that is a proven trap: 'git init' without a commit makes 'rev-parse HEAD' fail with an error that is not a definitive non-Git error, so it is rethrown instead of falling through to the declared path. Do not weaken product authority in src/.

(2) Make the documented two-attempt fixture launch actually retry, but only the exact retryable simctl/xcrun launch ETIMEDOUT path, once, while preserving accumulated diagnostic context. A non-timeout configuration or product error (missing binary, non-zero simctl status, adb timeout) must fail immediately with the original error object unchanged; a second timeout must fail truthfully, naming both attempts and carrying the underlying error as cause.

(3) Add hermetic focused tests proving: declared fixture identity; one exact launch timeout then success; second timeout failure with truthful context; and non-retryable immediate failure. No paid, nightly, native-build, simulator, emulator, or physical-device runs may be triggered by the tests or by validation.

Deliberate decisions a reviewer reading only the diff would not know:
- The two seams were extracted into a new test/smoke/device-smoke-driver.ts because device-smoke.ts calls process.exit(1) at import time when SMOKE_PLATFORM is unset and registers a device-touching test(), so it can never be imported by a unit test.
- The retry predicate is intentionally NARROWER than the diagnosis report's sketch (which retried any error on attempt 1): retry requires code==='ETIMEDOUT' AND path==='xcrun' AND spawnargs starting ['simctl','launch']. Android adb/monkey timeouts are intentionally NOT retried, because only the iOS simctl path was proven infrastructure-caused. Mutation-testing the report's broader sketch fails two of the new tests, so the narrowing is load-bearing.
- The identity test asserts against the committed dist/ resolver rather than a re-implementation, because the nightly never builds and dist/ is what executes in CI. It also keeps NON_GIT_MANIFEST_REQUIRED pinned, proving the fix is declaration by the harness, not relaxation of product authority.
- No release changeset was added: repo policy in AGENTS.md ('Changesets And Versions') exempts tests/CI-only changes, and nothing under packages/rn-dev-agent-core/src/ changed. Add one only if repository policy mechanically requires it.
- Do not merge the PR.

## What Changed

- Declare the temporary non-Git smoke fixture through a minimal package manifest and pass its supported source-identity environment to the supervisor.
- Retry launch failures once only for `xcrun simctl launch` timeouts, preserving attempt diagnostics and returning non-retryable errors unchanged.
- Add hermetic coverage for fixture identity and launch retry behavior, and align the nightly smoke documentation with the implemented paths and contract.

## Risk Assessment

✅ Low: The test-only change durably closes both concrete failure paths with a narrowly scoped retry predicate, preserved error identity and diagnostics, declared non-Git authority, and no product-source changes.

## Testing

Checkout and diff baselines confirmed exact target `7b746084…` and test-only scope. The initial raw-Node attempt exposed a missing workspace dependency setup; an immutable build-skipping install resolved it, after which the focused hermetic tests and direct CLI transcript proved declared non-Git identity, unchanged strict authority, one exact iOS launch-timeout retry, truthful second-timeout context/cause, and immediate original-error failures for missing xcrun, non-zero simctl, and adb timeout. Dependency residue was removed and the worktree was clean afterward. No UI artifact applies to this test-harness-only change, and no device, native build, nightly, paid, lint, format, static-analysis, or broad-suite run occurred.

<details>
<summary>Evidence: Hermetic device-smoke driver acceptance transcript</summary>

`resolverKind=declared-root; undeclared fixture=NON_GIT_MANIFEST_REQUIRED; timeout then success=2 launches; second timeout names both attempts and retains cause; ENOENT/non-zero simctl/adb timeout each fail after 1 launch with original error preserved.`

```text
DEVICE-SMOKE DRIVER HERMETIC ACCEPTANCE TRANSCRIPT
{
  "fixtureIdentity": {
    "declaredRootMatchesCwd": true,
    "declaredManifests": [
      "package.json"
    ],
    "manifestConstant": "package.json",
    "resolverKind": "declared-root",
    "manifestDigest": "87f0d607cacd202e2bd8912a79bbc85b8a3cdc69a2b2b83cdd2d9e93f161ddcd",
    "strictWithoutDeclaration": "NON_GIT_MANIFEST_REQUIRED: non-Git authority needs an explicit root and manifest list"
  },
  "timeoutThenSuccess": {
    "launches": 2,
    "events": [
      "launch-1",
      "launch-2",
      "probe-running"
    ]
  },
  "secondTimeout": {
    "launches": 2,
    "message": "fixture dev.lykhoyda.rndevagent.fixture did not start after 2 launch attempts: attempt 1 launch timed out (first xcrun timeout); attempt 2 launch timed out (second xcrun timeout)",
    "causeIsSecondTimeout": true
  },
  "nonRetryableImmediateFailures": [
    {
      "case": "missing-xcrun",
      "retryable": false,
      "launches": 1,
      "originalErrorPreserved": true
    },
    {
      "case": "nonzero-simctl",
      "retryable": false,
      "launches": 1,
      "originalErrorPreserved": true
    },
    {
      "case": "adb-timeout",
      "retryable": false,
      "launches": 1,
      "originalErrorPreserved": true
    }
  ]
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git rev-parse HEAD`; `git cat-file -t e394d3ef62f7f806c909cf5429c88f6a89e81a92`; `git status --short`; inspected the complete base-to-target diff</code>
- <code>`env -u SMOKE_PLATFORM -u RN_RUNNER_BUILD -u RN_DEV_AGENT_DECLARED_ROOT -u RN_DEV_AGENT_DECLARED_MANIFESTS node --test --test-concurrency=1 test/unit/smoke/device-smoke-driver.test.ts` (initial setup attempt failed before collection because dependencies were absent)</code>
- `/Users/antonlykhoyda/.nvm/versions/node/v24.14.0/bin/corepack yarn install --immutable --mode=skip-build`
- `env -u SMOKE_PLATFORM -u RN_RUNNER_BUILD -u RN_DEV_AGENT_DECLARED_ROOT -u RN_DEV_AGENT_DECLARED_MANIFESTS /Users/antonlykhoyda/.nvm/versions/node/v24.14.0/bin/node --test --test-concurrency=1 test/unit/smoke/device-smoke-driver.test.ts`
- <code>Hermetic inline Node acceptance runner exercising `device-smoke-driver.ts` against committed `dist/session/source-identity.js` and writing the acceptance transcript</code>
- <code>Removed workspace-local dependency artifacts, then rechecked target commit, clean worktree, absence of `src/` changes, and evidence-file readability</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
