### PR TITLE
fix(core): keep the session alive across a clearState reinstall

### DIFF
--- a/.changeset/clearstate-reinstall-install-receipt.md
+++ b/.changeset/clearstate-reinstall-install-receipt.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-core": patch
+"rn-dev-agent-plugin": patch
+---
+
+Re-issue the install receipt after a Maestro `clearState` reinstall of the session's own artifact — proven by re-hashing the installed bytes against the bound artifact digest, with any other or unattestable artifact still refused as `APP_INSTALL_IDENTITY_CHANGED` — and accept an `appFile` on `cdp_run_action` that otherwise resolves from that same receipt.

--- a/apps/docs-site/src/content/docs/session-authority.mdx
+++ b/apps/docs-site/src/content/docs/session-authority.mdx
@@ -81,6 +81,8 @@ The HMAC-signed runtime marker proves that the **initial bundle** came from the 
 
 If marker signing is unavailable, Metro may emit an unsigned `unavailable` marker so development builds continue, but authoritative tools return `BUNDLE_HANDSHAKE_UNAVAILABLE`. The installed-app digest is captured once for each build generation and reused as that generation's install identity.
 
+A Maestro flow that opens with `launchApp: clearState: true` uninstalls and reinstalls the app, which rotates that install identity. `maestro_run` (including through `cdp_run_action`) re-issues the install receipt after such a reinstall, but only after re-hashing the freshly installed bytes and proving they still match the bound receipt's artifact digest. Any other artifact, or an install that cannot be attested at all, still fails as `APP_INSTALL_IDENTITY_CHANGED`. `cdp_run_action` accepts an `appFile` for the reinstall source and otherwise resolves it from the attested receipt's exact device and app.
+
 ## Tool authority
 
 All published tools have an exhaustive authority profile, and worker startup validates the complete registered tool surface before accepting requests. Profile bookkeeping follows the same four ownership groups exposed by session status: Session resolves controller and source authority, Target adds device and install authority, Runtime adds Metro and bundle authority plus the independently verified app-to-device association, and Automation adds runner authority. Individual tools retain narrower resolved profiles where their operation does not need every facet. Session-bound arguments omitted by legacy callers are filled only from the current session; a conflicting platform, device, app, port, or target returns a named authority error.

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_run_action.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_run_action.mdx
@@ -12,6 +12,7 @@ Replay a learned action by id with end-to-end auto-repair. Loads the action from
 | `actionId` | `unknown` | Yes |  |  | Action id matching &lt;projectRoot&gt;/.rn-agent/actions/&lt;actionId&gt;.yaml. |
 | `projectRoot` | `string` | No |  |  | Override project root (default: process.cwd()). |
 | `platform` | `unknown` | No |  |  |  |
+| `appFile` | `unknown` | No |  |  |  |
 | `autoRepair` | `unknown` | No |  |  |  |
 | `timeoutMs` | `unknown` | No |  |  | Maestro execution timeout per attempt (ms). Default 120_000. |
 | `trigger` | `unknown` | No |  |  | RunRecord trigger annotation. Default "agent". CI calls should pass "ci". |

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -29652,7 +29652,7 @@ function authorityProfileFor(tool, args = {}) {
       postflightAxes: facetsOf(throughRuntime, { without: ["A", "B"] }),
       managedOrigin: true,
       managedRunnerPark: true,
-      managedInstallReissue: true,
+      managedInstallReissue: tool === "maestro_run",
       mutation: true,
       liveBundleProbe: false
     };

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -28643,7 +28643,7 @@ function resolveIosAppFile(bundleId, deps = {}) {
   const exists = deps.exists ?? existsSync13;
   const getAppContainer = deps.getAppContainer ?? defaultGetAppContainer;
   const snapshotApp = deps.snapshotApp ?? defaultSnapshotApp;
-  const fromContainer = getAppContainer(bundleId);
+  const fromContainer = getAppContainer(bundleId, deps.deviceId);
   if (fromContainer && exists(fromContainer)) {
     const snapshot = snapshotApp(fromContainer);
     if (snapshot)
@@ -28674,9 +28674,10 @@ function resolveAppFileForClearState(platform, flowText, headerAppId, explicitAp
   }
   return { ok: true, appFile };
 }
-function defaultGetAppContainer(bundleId) {
+function defaultGetAppContainer(bundleId, deviceId) {
   try {
-    const out = execFileSync6("xcrun", ["simctl", "get_app_container", "booted", bundleId, "app"], {
+    const target = deviceId && !/\s/.test(deviceId) ? deviceId : "booted";
+    const out = execFileSync6("xcrun", ["simctl", "get_app_container", target, bundleId, "app"], {
       encoding: "utf8",
       timeout: 5e3
     }).trim();
@@ -29342,6 +29343,226 @@ var init_maestro_runner_report = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/session/install-authority.js
+import { execFileSync as execFileSync7 } from "node:child_process";
+import { createHash as createHash7 } from "node:crypto";
+import { lstatSync as lstatSync5, readFileSync as readFileSync13, readdirSync as readdirSync5, readlinkSync as readlinkSync2, realpathSync as realpathSync4, statSync as statSync6 } from "node:fs";
+import { isAbsolute as isAbsolute3, join as join19, relative } from "node:path";
+function runText(command, args) {
+  return execFileSync7(command, [...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 1e4,
+    maxBuffer: 8 * 1024 * 1024
+  });
+}
+function runBuffer(command, args) {
+  return execFileSync7(command, [...args], {
+    encoding: "buffer",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 3e4,
+    maxBuffer: 512 * 1024 * 1024
+  });
+}
+function digest(parts) {
+  const hash = createHash7("sha256");
+  for (const part of parts) {
+    hash.update(`${part.byteLength}:`);
+    hash.update(part);
+  }
+  return hash.digest("hex");
+}
+function generation(parts) {
+  return digest(parts.map((part) => Buffer.from(part)));
+}
+function listAppFiles(appPath) {
+  const files = [];
+  const visit = (directory) => {
+    for (const entry of readdirSync5(directory, { withFileTypes: true })) {
+      const path = join19(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(path);
+      } else if (entry.isFile() || entry.isSymbolicLink()) {
+        files.push(relative(appPath, path));
+      } else {
+        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
+      }
+    }
+  };
+  visit(appPath);
+  return files.sort();
+}
+function iosAppFiles(appPath, dependencies) {
+  return [...(dependencies.listAppFiles ?? listAppFiles)(appPath)].sort();
+}
+function assertIosSymlinkContained(appPath, path, realpath) {
+  const target = realpath(path);
+  const child = relative(realpath(appPath), target);
+  if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute3(child)) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app symlink escapes the installed bundle");
+  }
+}
+function androidApkPaths(target, text) {
+  return text("adb", ["-s", target.deviceId, "shell", "pm", "path", target.appId]).split("\n").map((line) => line.trim()).filter((line) => line.startsWith("package:")).map((line) => line.slice("package:".length)).sort();
+}
+function captureInstallGeneration(target, dependencies = {}) {
+  const text = dependencies.runText ?? runText;
+  if (target.platform === "ios") {
+    const appPath = text("xcrun", [
+      "simctl",
+      "get_app_container",
+      target.deviceId,
+      target.appId,
+      "app"
+    ]).trim();
+    if (!appPath) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
+    }
+    const infoPath = join19(appPath, "Info.plist");
+    const executable = text("plutil", [
+      "-extract",
+      "CFBundleExecutable",
+      "raw",
+      "-o",
+      "-",
+      infoPath
+    ]).trim();
+    if (!executable) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
+    }
+    const stat2 = dependencies.stat ?? statSync6;
+    const metadata2 = iosAppFiles(appPath, dependencies).map((entry) => {
+      const path = join19(appPath, entry);
+      const value = stat2(path);
+      return `${entry}:${String(value.ino)}:${value.size}:${value.mtimeMs}`;
+    });
+    return generation(metadata2);
+  }
+  const apkPaths = androidApkPaths(target, text);
+  if (!apkPaths.length) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
+  }
+  const metadata = text("adb", [
+    "-s",
+    target.deviceId,
+    "shell",
+    "stat",
+    "-c",
+    "%n:%i:%s:%Y",
+    ...apkPaths
+  ]).split("\n").map((line) => line.trim()).filter(Boolean).sort();
+  if (metadata.length !== apkPaths.length) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: Android install generation is unavailable");
+  }
+  return generation(metadata);
+}
+function captureInstalledArtifact(target, dependencies = {}) {
+  const text = dependencies.runText ?? runText;
+  const buffer = dependencies.runBuffer ?? runBuffer;
+  const read = dependencies.read ?? readFileSync13;
+  if (target.platform === "ios") {
+    const appPath = text("xcrun", [
+      "simctl",
+      "get_app_container",
+      target.deviceId,
+      target.appId,
+      "app"
+    ]).trim();
+    if (!appPath) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
+    }
+    const infoPath = join19(appPath, "Info.plist");
+    const executable = text("plutil", [
+      "-extract",
+      "CFBundleExecutable",
+      "raw",
+      "-o",
+      "-",
+      infoPath
+    ]).trim();
+    if (!executable) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
+    }
+    const files = iosAppFiles(appPath, dependencies);
+    const lstat = dependencies.lstat ?? lstatSync5;
+    const readLink = dependencies.readLink ?? readlinkSync2;
+    const realpath = dependencies.realpath ?? realpathSync4;
+    const artifactParts = [];
+    for (const entry of files) {
+      const path = join19(appPath, entry);
+      const stat2 = lstat(path);
+      artifactParts.push(Buffer.from(entry));
+      if (stat2.isFile()) {
+        artifactParts.push(Buffer.from("file"), read(path));
+      } else if (stat2.isSymbolicLink()) {
+        assertIosSymlinkContained(appPath, path, realpath);
+        artifactParts.push(Buffer.from("symlink"), Buffer.from(readLink(path)));
+      } else {
+        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
+      }
+    }
+    return {
+      ...target,
+      artifactDigest: digest(artifactParts),
+      installGeneration: captureInstallGeneration(target, dependencies)
+    };
+  }
+  const apkPaths = androidApkPaths(target, text);
+  if (!apkPaths.length) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
+  }
+  return {
+    ...target,
+    artifactDigest: digest(apkPaths.map((path) => buffer("adb", ["-s", target.deviceId, "exec-out", "cat", path]))),
+    installGeneration: captureInstallGeneration(target, dependencies)
+  };
+}
+function verifyInstalledArtifact(expected, observed) {
+  if (expected.platform !== observed.platform || expected.deviceId !== observed.deviceId || expected.appId !== observed.appId || expected.artifactDigest !== observed.artifactDigest || expected.installGeneration !== observed.installGeneration) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: installed artifact no longer matches the session build");
+  }
+}
+var init_install_authority = __esm({
+  "packages/rn-dev-agent-core/dist/session/install-authority.js"() {
+    "use strict";
+  }
+});
+
+// packages/rn-dev-agent-core/dist/session/install-reissue.js
+function reissueInstallBinding(install, dependencies = {}) {
+  const platform = install?.platform;
+  const deviceId = install?.deviceId;
+  const appId = install?.appId;
+  const artifactDigest = install?.artifactDigest;
+  const installGeneration = install?.installGeneration;
+  if (platform !== "ios" && platform !== "android" || typeof deviceId !== "string" || typeof appId !== "string" || typeof artifactDigest !== "string" || typeof installGeneration !== "string") {
+    throw new SessionAuthorityError("APP_INSTALL_IDENTITY_CHANGED", "no attested install receipt is bound to re-issue after the reinstall");
+  }
+  let observed;
+  try {
+    observed = (dependencies.captureInstalled ?? captureInstalledArtifact)({
+      platform,
+      deviceId,
+      appId
+    });
+  } catch {
+    throw new SessionAuthorityError("APP_INSTALL_IDENTITY_CHANGED", "the reinstalled artifact could not be attested");
+  }
+  if (observed.artifactDigest !== artifactDigest) {
+    throw new SessionAuthorityError("APP_INSTALL_IDENTITY_CHANGED", "the reinstalled artifact is not the attested session build");
+  }
+  if (observed.installGeneration === installGeneration)
+    return null;
+  return { ...install, installGeneration: observed.installGeneration };
+}
+var init_install_reissue = __esm({
+  "packages/rn-dev-agent-core/dist/session/install-reissue.js"() {
+    "use strict";
+    init_install_authority();
+    init_registry();
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -29431,6 +29652,7 @@ function authorityProfileFor(tool, args = {}) {
       postflightAxes: facetsOf(throughRuntime, { without: ["A", "B"] }),
       managedOrigin: true,
       managedRunnerPark: true,
+      managedInstallReissue: true,
       mutation: true,
       liveBundleProbe: false
     };
@@ -29616,6 +29838,7 @@ var init_tool_profiles = __esm({
       optionalAxes: ["B"],
       managedOrigin: true,
       managedRunnerPark: true,
+      managedInstallReissue: true,
       mutation: true,
       liveBundleProbe: true
     });
@@ -29659,8 +29882,8 @@ var init_tool_profiles = __esm({
 
 // packages/rn-dev-agent-core/dist/session/authority-gate.js
 import { randomUUID as randomUUID4 } from "node:crypto";
-import { realpathSync as realpathSync4 } from "node:fs";
-import { isAbsolute as isAbsolute3, relative, resolve as resolve2 } from "node:path";
+import { realpathSync as realpathSync5 } from "node:fs";
+import { isAbsolute as isAbsolute4, relative as relative2, resolve as resolve2 } from "node:path";
 async function claimOptionalBundleAuthority(args) {
   return await args[optionalBundleAdmission]?.() ?? false;
 }
@@ -29684,6 +29907,16 @@ async function relaunchManagedNativeOriginApp(args) {
     throw new SessionAuthorityError("METRO_ORIGIN_MISMATCH", "managed native origin relaunch authority is unavailable");
   }
   await authority.relaunch();
+}
+async function reissueManagedInstallAuthority(args) {
+  const reissue = args[managedInstallReissue];
+  if (!reissue) {
+    throw new SessionAuthorityError("APP_INSTALL_IDENTITY_CHANGED", "managed install re-issue authority is unavailable");
+  }
+  await reissue();
+}
+function hasManagedInstallReissueAuthority(args) {
+  return typeof args[managedInstallReissue] === "function";
 }
 function hasManagedRunnerParkAuthority(args) {
   return typeof args[managedRunnerPark] === "function";
@@ -29814,7 +30047,7 @@ function bindSourcePaths(status, args) {
   try {
     if (typeof status.source.appRoot !== "string")
       throw new Error("missing app root");
-    appRoot = realpathSync4(status.source.appRoot);
+    appRoot = realpathSync5(status.source.appRoot);
   } catch {
     throw new SessionAuthorityError("SOURCE_WORKTREE_MISMATCH", "active session app root is unavailable");
   }
@@ -29827,12 +30060,12 @@ function bindSourcePaths(status, args) {
     }
     let candidate;
     try {
-      candidate = realpathSync4(isAbsolute3(supplied) ? supplied : resolve2(appRoot, supplied));
+      candidate = realpathSync5(isAbsolute4(supplied) ? supplied : resolve2(appRoot, supplied));
     } catch {
       throw new SessionAuthorityError("SOURCE_WORKTREE_MISMATCH", `${field2} cannot be resolved within the active app root`);
     }
-    const child = relative(appRoot, candidate);
-    if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute3(child)) {
+    const child = relative2(appRoot, candidate);
+    if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute4(child)) {
       throw new SessionAuthorityError("SOURCE_WORKTREE_MISMATCH", `${field2} is outside the active session app root`);
     }
     args[field2] = candidate;
@@ -30255,6 +30488,7 @@ function createAuthorityGate(runtime, dependencies) {
         let optionalBundleClaimed = false;
         let optionalBundleRecoveryFailed = false;
         let managedRunnerParked = false;
+        let installReceiptReissued = false;
         if (profile.optionalAxes?.includes("B")) {
           Object.defineProperty(args, optionalBundleAdmission, {
             configurable: true,
@@ -30458,6 +30692,30 @@ function createAuthorityGate(runtime, dependencies) {
             }
           });
         }
+        if (profile.managedInstallReissue) {
+          Object.defineProperty(args, managedInstallReissue, {
+            configurable: true,
+            value: async () => {
+              const currentStatus = runtime.status();
+              if (!currentStatus.available) {
+                throw new SessionAuthorityError(currentStatus.code, currentStatus.reason);
+              }
+              registry2.verifyOperation(operation);
+              const install = (dependencies.reissueInstallBinding ?? reissueInstallBinding)(currentStatus.bindings.install);
+              if (!install)
+                return;
+              operation = registry2.replaceBindingsDuringOperation(operation, {
+                bindings: { install }
+              });
+              const reissuedStatus = runtime.status();
+              if (!reissuedStatus.available) {
+                throw new SessionAuthorityError(reissuedStatus.code, reissuedStatus.reason);
+              }
+              status = reissuedStatus;
+              installReceiptReissued = true;
+            }
+          });
+        }
         if (profile.managedRunnerPark) {
           Object.defineProperty(args, managedRunnerPark, {
             configurable: true,
@@ -30609,6 +30867,8 @@ function createAuthorityGate(runtime, dependencies) {
           if ((runtimeTargetChanged || managedRuntimeTargetChanged) && observation.axis === "B") {
             continue;
           }
+          if (installReceiptReissued && observation.axis === "I")
+            continue;
           if (!postflightAxes.includes(observation.axis))
             continue;
           const postflight = after.find((candidate) => candidate.axis === observation.axis);
@@ -30675,16 +30935,18 @@ function createAuthorityGate(runtime, dependencies) {
     }
   };
 }
-var optionalBundleAdmission, managedNativeOrigin, managedRunnerPark, axisBinding, axisErrors;
+var optionalBundleAdmission, managedNativeOrigin, managedRunnerPark, managedInstallReissue, axisBinding, axisErrors;
 var init_authority_gate = __esm({
   "packages/rn-dev-agent-core/dist/session/authority-gate.js"() {
     "use strict";
     init_utils();
     init_registry();
+    init_install_reissue();
     init_tool_profiles();
     optionalBundleAdmission = /* @__PURE__ */ Symbol("optionalBundleAdmission");
     managedNativeOrigin = /* @__PURE__ */ Symbol("managedNativeOrigin");
     managedRunnerPark = /* @__PURE__ */ Symbol("managedRunnerPark");
+    managedInstallReissue = /* @__PURE__ */ Symbol("managedInstallReissue");
     axisBinding = {
       I: "install",
       M: "metro",
@@ -30710,9 +30972,9 @@ var init_authority_gate = __esm({
 // packages/rn-dev-agent-core/dist/tools/maestro-run.js
 import { execFile as execFileCb4 } from "node:child_process";
 import { promisify as promisify6 } from "node:util";
-import { existsSync as existsSync15, readFileSync as readFileSync13, writeFileSync as writeFileSync7 } from "node:fs";
+import { existsSync as existsSync15, readFileSync as readFileSync14, writeFileSync as writeFileSync7 } from "node:fs";
 import { tmpdir as tmpdir6 } from "node:os";
-import { join as join19, dirname as dirname8 } from "node:path";
+import { join as join20, dirname as dirname8 } from "node:path";
 async function runFlowParked(run, opts = {}) {
   const stale = opts.markCdpStale ?? markCdpStale;
   try {
@@ -30738,7 +31000,8 @@ function nestedMaestroAuthorityCallbacks(args) {
     claimNativeOrigin: () => claimManagedNativeOriginAuthority(args),
     completeNativeOrigin: (targetExpected) => completeManagedNativeOriginAuthority(args, targetExpected),
     relaunchManagedApp: () => relaunchManagedNativeOriginApp(args),
-    completeRunnerPark: () => completeManagedRunnerParkAuthority(args)
+    completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+    reissueInstallReceipt: hasManagedInstallReissueAuthority(args) ? () => reissueManagedInstallAuthority(args) : null
   };
 }
 function commandName(command) {
@@ -30878,7 +31141,7 @@ function createMaestroRunHandler(deps = {}) {
         return failResult(`Flow file not found: ${args.flowPath}`);
       }
       try {
-        rawYaml = readFileSync13(args.flowPath, "utf-8");
+        rawYaml = readFileSync14(args.flowPath, "utf-8");
       } catch (err) {
         return failResult(`Failed to read flow file: ${err.message}`);
       }
@@ -30894,7 +31157,7 @@ function createMaestroRunHandler(deps = {}) {
       const rawAppId = resolveAppId(args.appId, platform);
       headerAppId = resolveMaestroFlowAppId(rawAppId || void 0, parsed.appId);
       validatedContent = buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, parsed.commands);
-      flowFile = join19(tmpdir6(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      flowFile = join20(tmpdir6(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
       writeFileSync7(flowFile, validatedContent, "utf-8");
     } catch (err) {
       if (err instanceof MaestroValidationError) {
@@ -30908,10 +31171,19 @@ function createMaestroRunHandler(deps = {}) {
     }
     const timeout = args.timeoutMs ?? 12e4;
     const flowDeadline = now() + timeout;
-    const appFileResolution = resolveAppFileForClearState(platform, validatedContent, headerAppId, args.appFile);
+    const appFileResolution = resolveAppFileForClearState(platform, validatedContent, headerAppId, args.appFile, { deviceId: requestedDeviceId });
     if (!appFileResolution.ok) {
       return failResult(appFileResolution.error);
     }
+    const reinstallsApp = Boolean(appFileResolution.appFile) && flowUsesClearState(validatedContent);
+    const reissueInstallReceipt = args.reissueInstallReceipt ?? deps.reissueInstallReceipt ?? nestedMaestroAuthorityCallbacks(args).reissueInstallReceipt;
+    let installReceiptCommitted = false;
+    const commitReinstalledInstall = async () => {
+      if (!reinstallsApp || installReceiptCommitted || !reissueInstallReceipt)
+        return;
+      installReceiptCommitted = true;
+      await reissueInstallReceipt();
+    };
     const baseArgs = dispatch.buildArgs(platform, flowFile, appFileResolution.appFile, requestedDeviceId);
     const paramArgs = [];
     if (args.params) {
@@ -30954,6 +31226,7 @@ function createMaestroRunHandler(deps = {}) {
         deviceId: requestedDeviceId,
         completeRunnerPark: args.completeRunnerPark ?? managedAuthority.completeRunnerPark
       });
+      await commitReinstalledInstall();
       const stdout = stageResults.map((result) => result.stdout).join("\n");
       const stderr = stageResults.map((result) => result.stderr).join("\n");
       const output = combineRunnerOutput(stdout, stderr);
@@ -31011,6 +31284,7 @@ function createMaestroRunHandler(deps = {}) {
       const warnAug = augmentFailureWithDegradation(output, resolveFloorMs(process.env.RN_RUNTIME_DEGRADED_FLOOR_MS), baseWarnMsg, meta);
       return warnResult(warnAug.meta, warnAug.message);
     } catch (err) {
+      await commitReinstalledInstall();
       if (err instanceof SessionAuthorityError)
         throw err;
       const stageError = err instanceof MaestroStageExecutionError ? err.stageError : err;
@@ -31130,7 +31404,7 @@ var init_maestro_run = __esm({
 
 // packages/rn-dev-agent-core/dist/session/managed-automation.js
 import { spawn as spawn4 } from "node:child_process";
-import { readdirSync as readdirSync5, readFileSync as readFileSync14, unlinkSync as unlinkSync6 } from "node:fs";
+import { readdirSync as readdirSync6, readFileSync as readFileSync15, unlinkSync as unlinkSync6 } from "node:fs";
 function sleep3(ms) {
   return new Promise((resolve11) => setTimeout(resolve11, ms));
 }
@@ -31147,12 +31421,12 @@ function processGroupLiveness(pgid) {
   if (process.platform !== "linux")
     return "unknown";
   try {
-    for (const entry of readdirSync5("/proc", { withFileTypes: true })) {
+    for (const entry of readdirSync6("/proc", { withFileTypes: true })) {
       if (!entry.isDirectory() || !/^\d+$/.test(entry.name))
         continue;
       let stat2;
       try {
-        stat2 = readFileSync14(`/proc/${entry.name}/stat`, "utf8");
+        stat2 = readFileSync15(`/proc/${entry.name}/stat`, "utf8");
       } catch (error2) {
         if (error2.code === "ENOENT")
           continue;
@@ -31763,7 +32037,7 @@ var init_device_arbiter = __esm({
 
 // packages/rn-dev-agent-core/dist/maestro-invoke.js
 import { existsSync as existsSync16, writeFileSync as writeFileSync8 } from "node:fs";
-import { join as join20 } from "node:path";
+import { join as join21 } from "node:path";
 import { homedir as homedir6, tmpdir as tmpdir7 } from "node:os";
 function yamlEscape(s) {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t");
@@ -31781,7 +32055,7 @@ function maestroRefusalResult(result, fallbackMessage, meta) {
   });
 }
 function getMaestroRunnerPath() {
-  const path = join20(homedir6(), ".maestro-runner", "bin", "maestro-runner");
+  const path = join21(homedir6(), ".maestro-runner", "bin", "maestro-runner");
   return existsSync16(path) ? path : null;
 }
 async function runMaestroInline(yaml2, opts, dependencies = {}) {
@@ -31792,7 +32066,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     return { passed: false, output: "", flowFile: "", error: dispatch.error };
   }
   const rawAppId = opts.appId ?? resolveBundleId(opts.platform) ?? readExpoSlug() ?? "";
-  const flowFile = join20(tmpdir7(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+  const flowFile = join21(tmpdir7(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
   let content;
   let headerAppId;
   try {
@@ -32154,10 +32428,10 @@ var init_app_lifecycle = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js
-import { execFileSync as execFileSync7 } from "node:child_process";
-import { existsSync as existsSync17, readFileSync as readFileSync15, unlinkSync as unlinkSync7 } from "node:fs";
+import { execFileSync as execFileSync8 } from "node:child_process";
+import { existsSync as existsSync17, readFileSync as readFileSync16, unlinkSync as unlinkSync7 } from "node:fs";
 import { homedir as homedir7 } from "node:os";
-import { join as join21 } from "node:path";
+import { join as join22 } from "node:path";
 function selectInstalledLegacyApps(installed) {
   return LEGACY_BUNDLE_IDS.filter((id) => installed.has(id));
 }
@@ -32212,7 +32486,7 @@ function defaultDeps2() {
     // caller's try/catch, which records a warning. Swallowing it here and
     // returning '' made single-runner enforcement degrade to a silent no-op
     // with no operator signal — exactly when the machine is busy.
-    listProcesses: () => execFileSync7("ps", ["-A", "-o", "pid=,args="], { encoding: "utf8", timeout: 3e3 }),
+    listProcesses: () => execFileSync8("ps", ["-A", "-o", "pid=,args="], { encoding: "utf8", timeout: 3e3 }),
     kill: (pid, signal) => process.kill(pid, signal),
     isAlive: (pid) => {
       try {
@@ -32224,7 +32498,7 @@ function defaultDeps2() {
     },
     readDaemonPid: () => {
       try {
-        const parsed = JSON.parse(readFileSync15(DAEMON_JSON2, "utf8"));
+        const parsed = JSON.parse(readFileSync16(DAEMON_JSON2, "utf8"));
         return typeof parsed.pid === "number" ? parsed.pid : null;
       } catch {
         return null;
@@ -32233,13 +32507,13 @@ function defaultDeps2() {
     fileExists: (path) => existsSync17(path),
     removeFile: (path) => unlinkSync7(path),
     delay: (ms) => new Promise((resolve11) => setTimeout(resolve11, ms)),
-    listApps: (udid) => execFileSync7("xcrun", ["simctl", "listapps", udid], {
+    listApps: (udid) => execFileSync8("xcrun", ["simctl", "listapps", udid], {
       encoding: "utf8",
       timeout: 5e3,
       stdio: ["ignore", "pipe", "ignore"]
     }),
     uninstallApp: (udid, bundleId) => {
-      execFileSync7("xcrun", ["simctl", "uninstall", udid, bundleId], {
+      execFileSync8("xcrun", ["simctl", "uninstall", udid, bundleId], {
         encoding: "utf8",
         timeout: 1e4,
         stdio: ["ignore", "pipe", "ignore"]
@@ -32313,8 +32587,8 @@ var init_ensure_single_runner = __esm({
   "packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js"() {
     "use strict";
     init_discovery();
-    DAEMON_JSON2 = join21(homedir7(), ".agent-device", "daemon.json");
-    DAEMON_LOCK2 = join21(homedir7(), ".agent-device", "daemon.lock");
+    DAEMON_JSON2 = join22(homedir7(), ".agent-device", "daemon.json");
+    DAEMON_LOCK2 = join22(homedir7(), ".agent-device", "daemon.lock");
     DAEMON_FILES2 = [DAEMON_JSON2, DAEMON_LOCK2];
     SIGKILL_GRACE_MS2 = 500;
     LEGACY_BUNDLE_IDS = [
@@ -32441,9 +32715,9 @@ var init_recover_detached = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/lifecycle/device-lock.js
-import { existsSync as existsSync18, mkdirSync as mkdirSync8, openSync as openSync2, writeSync, closeSync as closeSync2, readFileSync as readFileSync16, unlinkSync as unlinkSync8, writeFileSync as writeFileSync9 } from "node:fs";
+import { existsSync as existsSync18, mkdirSync as mkdirSync8, openSync as openSync2, writeSync, closeSync as closeSync2, readFileSync as readFileSync17, unlinkSync as unlinkSync8, writeFileSync as writeFileSync9 } from "node:fs";
 import { tmpdir as tmpdir8, userInfo } from "node:os";
-import { join as join22 } from "node:path";
+import { join as join23 } from "node:path";
 function defaultProcessAlive3(pid) {
   try {
     process.kill(pid, 0);
@@ -32496,7 +32770,7 @@ var init_device_lock = __esm({
         this.clock = opts.clock ?? Date.now;
         this.processAlive = opts.processAlive ?? defaultProcessAlive3;
         this.staleMs = opts.staleMs ?? DEFAULT_STALE_MS;
-        this.lockPath = join22(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
+        this.lockPath = join23(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
       }
       acquire() {
         try {
@@ -32577,7 +32851,7 @@ var init_device_lock = __esm({
       }
       readExisting() {
         try {
-          const parsed = JSON.parse(readFileSync16(this.lockPath, "utf8"));
+          const parsed = JSON.parse(readFileSync17(this.lockPath, "utf8"));
           if (!isValidBody(parsed))
             return null;
           if (parsed.deviceId !== this.deviceId || parsed.platform !== this.platform)
@@ -54937,8 +55211,8 @@ function annotateMutationAbsence(result, ctx) {
 
 // packages/rn-dev-agent-core/dist/verification/config.js
 init_storage();
-import { existsSync as existsSync19, readFileSync as readFileSync17 } from "node:fs";
-import { join as join23 } from "node:path";
+import { existsSync as existsSync19, readFileSync as readFileSync18 } from "node:fs";
+import { join as join24 } from "node:path";
 var MAX_PATTERN_LENGTH = 200;
 var _cachedProjectRoot;
 function getCachedProjectRoot() {
@@ -54994,14 +55268,14 @@ function loadVerificationConfig(projectRoot) {
   const cached2 = cache2.get(projectRoot);
   if (cached2)
     return cached2;
-  const path = join23(projectRoot, ".rn-agent", "config.json");
+  const path = join24(projectRoot, ".rn-agent", "config.json");
   if (!existsSync19(path)) {
     cache2.set(projectRoot, DEFAULTS);
     return DEFAULTS;
   }
   let raw;
   try {
-    raw = JSON.parse(readFileSync17(path, "utf-8"));
+    raw = JSON.parse(readFileSync18(path, "utf-8"));
   } catch {
     cache2.set(projectRoot, DEFAULTS);
     return DEFAULTS;
@@ -55475,15 +55749,15 @@ import { basename as basename4, dirname as dirname11, sep as sep3 } from "node:p
 
 // packages/rn-dev-agent-core/dist/domain/action-db.js
 import { createRequire as createRequire2 } from "node:module";
-import { existsSync as existsSync20, mkdirSync as mkdirSync10, readdirSync as readdirSync6, readFileSync as readFileSync18 } from "node:fs";
-import { dirname as dirname9, join as join25 } from "node:path";
+import { existsSync as existsSync20, mkdirSync as mkdirSync10, readdirSync as readdirSync7, readFileSync as readFileSync19 } from "node:fs";
+import { dirname as dirname9, join as join26 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/runtime-paths.js
-import { chmodSync as chmodSync2, lstatSync as lstatSync5, mkdirSync as mkdirSync9 } from "node:fs";
-import { join as join24, resolve as resolve3 } from "node:path";
+import { chmodSync as chmodSync2, lstatSync as lstatSync6, mkdirSync as mkdirSync9 } from "node:fs";
+import { join as join25, resolve as resolve3 } from "node:path";
 function privateDirectory(path) {
   mkdirSync9(path, { recursive: true, mode: 448 });
-  const stat2 = lstatSync5(path);
+  const stat2 = lstatSync6(path);
   if (stat2.isSymbolicLink() || !stat2.isDirectory()) {
     throw new Error("SESSION_RUNTIME_ROOT_UNSAFE: runtime root must be a real directory");
   }
@@ -55492,14 +55766,14 @@ function privateDirectory(path) {
 }
 function sessionRuntimeRoot(projectRoot) {
   const configured = process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT;
-  return configured ? privateDirectory(resolve3(configured)) : join24(resolve3(projectRoot), ".rn-agent");
+  return configured ? privateDirectory(resolve3(configured)) : join25(resolve3(projectRoot), ".rn-agent");
 }
 function sessionStateDirectory(projectRoot) {
-  const path = join24(sessionRuntimeRoot(projectRoot), "state");
+  const path = join25(sessionRuntimeRoot(projectRoot), "state");
   return process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT ? privateDirectory(path) : path;
 }
 function sessionRecordingsDirectory(projectRoot) {
-  const path = join24(sessionRuntimeRoot(projectRoot), "recordings");
+  const path = join25(sessionRuntimeRoot(projectRoot), "recordings");
   return process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT ? privateDirectory(path) : path;
 }
 
@@ -55564,7 +55838,7 @@ function openActionDb(projectRoot, opts = {}) {
   if (!Ctor)
     return null;
   try {
-    const dbPath = join25(sessionStateDirectory(projectRoot), "actions.db");
+    const dbPath = join26(sessionStateDirectory(projectRoot), "actions.db");
     mkdirSync10(dirname9(dbPath), { recursive: true });
     const db = new Ctor(dbPath);
     db.exec(SCHEMA);
@@ -55707,11 +55981,11 @@ function openActionDb(projectRoot, opts = {}) {
         return row.cnt;
       },
       migrateSidecars() {
-        const stateDir = join25(projectRoot, ".rn-agent", "state");
+        const stateDir = join26(projectRoot, ".rn-agent", "state");
         if (!existsSync20(stateDir))
           return { migrated: 0 };
         let migrated = 0;
-        for (const f of readdirSync6(stateDir)) {
+        for (const f of readdirSync7(stateDir)) {
           if (!f.endsWith(".state.json"))
             continue;
           const id = f.replace(/\.state\.json$/, "");
@@ -55719,7 +55993,7 @@ function openActionDb(projectRoot, opts = {}) {
           if (exists)
             continue;
           try {
-            const parsed = JSON.parse(readFileSync18(join25(stateDir, f), "utf8"));
+            const parsed = JSON.parse(readFileSync19(join26(stateDir, f), "utf8"));
             if (parsed?.schemaVersion !== 1)
               continue;
             if (!Array.isArray(parsed.runHistory) || !Array.isArray(parsed.repairHistory)) {
@@ -55753,8 +56027,8 @@ var RUN_HISTORY_MAX = 50;
 var REPAIR_HISTORY_MAX = 25;
 
 // packages/rn-dev-agent-core/dist/domain/sidecar-io.js
-import { existsSync as existsSync21, readFileSync as readFileSync19, writeFileSync as writeFileSync10, mkdirSync as mkdirSync11, statSync as statSync6 } from "node:fs";
-import { join as join26, dirname as dirname10 } from "node:path";
+import { existsSync as existsSync21, readFileSync as readFileSync20, writeFileSync as writeFileSync10, mkdirSync as mkdirSync11, statSync as statSync7 } from "node:fs";
+import { join as join27, dirname as dirname10 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/domain/reusable-action.js
 var REPAIR_BUDGET = {
@@ -55951,19 +56225,19 @@ function sidecarPathFor(yamlFilePath) {
   const parent = dirname10(dir);
   const filename = yamlFilePath.replace(/\.ya?ml$/i, ".state.json");
   const base = filename.split(/[\\/]/).pop();
-  const stateDirectory = process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT ? sessionStateDirectory(dirname10(parent)) : join26(parent, "state");
-  return join26(stateDirectory, base);
+  const stateDirectory = process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT ? sessionStateDirectory(dirname10(parent)) : join27(parent, "state");
+  return join27(stateDirectory, base);
 }
 function loadOrInitSidecar(yamlFilePath, now = () => /* @__PURE__ */ new Date()) {
   const path = sidecarPathFor(yamlFilePath);
   if (existsSync21(path)) {
     try {
-      const text = readFileSync19(path, "utf8");
+      const text = readFileSync20(path, "utf8");
       const parsed = JSON.parse(text);
       if (parsed && parsed.schemaVersion === 1 && typeof parsed.revision === "number" && typeof parsed.updatedAt === "string" && Array.isArray(parsed.runHistory) && Array.isArray(parsed.repairHistory) && typeof parsed.stats === "object") {
         if (typeof parsed.lastSeenMtimeMs !== "number") {
           try {
-            parsed.lastSeenMtimeMs = statSync6(yamlFilePath).mtimeMs;
+            parsed.lastSeenMtimeMs = statSync7(yamlFilePath).mtimeMs;
           } catch {
             parsed.lastSeenMtimeMs = 0;
           }
@@ -55975,7 +56249,7 @@ function loadOrInitSidecar(yamlFilePath, now = () => /* @__PURE__ */ new Date())
   }
   let mtimeMs = 0;
   try {
-    mtimeMs = statSync6(yamlFilePath).mtimeMs;
+    mtimeMs = statSync7(yamlFilePath).mtimeMs;
   } catch {
   }
   return freshRuntimeState(now, mtimeMs);
@@ -55990,7 +56264,7 @@ function saveSidecar(yamlFilePath, state) {
 }
 function yamlEditedSinceLastSeen(yamlFilePath, state) {
   try {
-    const current = statSync6(yamlFilePath).mtimeMs;
+    const current = statSync7(yamlFilePath).mtimeMs;
     return current > state.lastSeenMtimeMs;
   } catch {
     return false;
@@ -56064,30 +56338,30 @@ init_engine_pin();
 init_agent_device_wrapper();
 
 // packages/rn-dev-agent-core/dist/session/migration-diagnostic.js
-import { createHash as createHash7 } from "node:crypto";
-import { existsSync as existsSync23, readFileSync as readFileSync22 } from "node:fs";
-import { join as join29 } from "node:path";
+import { createHash as createHash8 } from "node:crypto";
+import { existsSync as existsSync23, readFileSync as readFileSync23 } from "node:fs";
+import { join as join30 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/bound-directory.js
 import { spawn as spawn5 } from "node:child_process";
 import { randomUUID as randomUUID6 } from "node:crypto";
-import { closeSync as closeSync3, constants as constants2, existsSync as existsSync22, fstatSync as fstatSync2, lstatSync as lstatSync7, mkdtempSync, openSync as openSync3, readFileSync as readFileSync21, realpathSync as realpathSync5, renameSync as renameSync5, rmSync as rmSync8, writeFileSync as writeFileSync12 } from "node:fs";
+import { closeSync as closeSync3, constants as constants2, existsSync as existsSync22, fstatSync as fstatSync2, lstatSync as lstatSync8, mkdtempSync, openSync as openSync3, readFileSync as readFileSync22, realpathSync as realpathSync6, renameSync as renameSync5, rmSync as rmSync8, writeFileSync as writeFileSync12 } from "node:fs";
 import { tmpdir as tmpdir9 } from "node:os";
-import { join as join28 } from "node:path";
+import { join as join29 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/state-root.js
 init_secure_state_file();
 import { randomBytes as randomBytes5, randomUUID as randomUUID5 } from "node:crypto";
-import { chmodSync as chmodSync3, linkSync, lstatSync as lstatSync6, mkdirSync as mkdirSync12, readFileSync as readFileSync20, renameSync as renameSync4, rmSync as rmSync7, statSync as statSync7, writeFileSync as writeFileSync11 } from "node:fs";
-import { join as join27 } from "node:path";
+import { chmodSync as chmodSync3, linkSync, lstatSync as lstatSync7, mkdirSync as mkdirSync12, readFileSync as readFileSync21, renameSync as renameSync4, rmSync as rmSync7, statSync as statSync8, writeFileSync as writeFileSync11 } from "node:fs";
+import { join as join28 } from "node:path";
 function fail(code, detail) {
   throw new Error(`${code}: ${detail}`);
 }
 function ensurePrivateDirectory(path) {
   try {
     mkdirSync12(path, { recursive: true, mode: 448 });
-    const link = lstatSync6(path);
-    const stat2 = statSync7(path);
+    const link = lstatSync7(path);
+    const stat2 = statSync8(path);
     if (link.isSymbolicLink() || !link.isDirectory() || typeof process.getuid === "function" && stat2.uid !== process.getuid()) {
       fail("AUTHORITY_STATE_ROOT_UNSAFE", "state directory is not private and user-owned");
     }
@@ -56101,15 +56375,15 @@ function ensurePrivateDirectory(path) {
 }
 function createAuthorityStateLayout(stateDir = getStateDir()) {
   ensurePrivateDirectory(stateDir);
-  const root = join27(stateDir, "v2");
+  const root = join28(stateDir, "v2");
   ensurePrivateDirectory(root);
   const layout = {
     root,
-    registry: join27(root, "registry.sqlite3"),
-    sessions: join27(root, "sessions"),
-    runners: join27(root, "runner"),
-    observe: join27(root, "observe"),
-    migrations: join27(root, "migrations")
+    registry: join28(root, "registry.sqlite3"),
+    sessions: join28(root, "sessions"),
+    runners: join28(root, "runner"),
+    observe: join28(root, "observe"),
+    migrations: join28(root, "migrations")
   };
   for (const path of [layout.sessions, layout.runners, layout.observe, layout.migrations]) {
     ensurePrivateDirectory(path);
@@ -56117,8 +56391,8 @@ function createAuthorityStateLayout(stateDir = getStateDir()) {
   return layout;
 }
 function getBoundDirectoryJournalKey(layout = createAuthorityStateLayout()) {
-  const path = join27(layout.root, "bound-directory.key");
-  const temporary = join27(layout.root, `.bound-directory.${randomUUID5()}.key`);
+  const path = join28(layout.root, "bound-directory.key");
+  const temporary = join28(layout.root, `.bound-directory.${randomUUID5()}.key`);
   try {
     try {
       writeFileSync11(temporary, randomBytes5(32), { flag: "wx", mode: 384, flush: true });
@@ -56131,9 +56405,9 @@ function getBoundDirectoryJournalKey(layout = createAuthorityStateLayout()) {
     } finally {
       rmSync7(temporary, { force: true });
     }
-    const link = lstatSync6(path);
-    const stat2 = statSync7(path);
-    const key = readFileSync20(path);
+    const link = lstatSync7(path);
+    const stat2 = statSync8(path);
+    const key = readFileSync21(path);
     if (link.isSymbolicLink() || !link.isFile() || key.length !== 32 || typeof process.getuid === "function" && stat2.uid !== process.getuid()) {
       fail("AUTHORITY_STATE_ROOT_UNSAFE", "bound-directory journal key is invalid");
     }
@@ -57225,21 +57499,21 @@ function waitForFile(path, timeoutMs) {
   return existsSync22(path);
 }
 function stopWorker(worker, signal = "SIGTERM") {
-  const stoppedPath = join28(worker.controlPath, "stopped");
+  const stoppedPath = join29(worker.controlPath, "stopped");
   if (signal === "SIGTERM") {
     try {
-      writeFileSync12(join28(worker.controlPath, "stop"), "", { flag: "wx", mode: 384 });
+      writeFileSync12(join29(worker.controlPath, "stop"), "", { flag: "wx", mode: 384 });
     } catch {
     }
     if (waitForFile(stoppedPath, 1e3)) {
-      if (!existsSync22(join28(worker.controlPath, "lock-retained"))) {
+      if (!existsSync22(join29(worker.controlPath, "lock-retained"))) {
         rmSync8(worker.controlPath, { force: true, recursive: true });
       }
       return;
     }
   }
   try {
-    writeFileSync12(join28(worker.controlPath, "terminate"), JSON.stringify({
+    writeFileSync12(join29(worker.controlPath, "terminate"), JSON.stringify({
       lifecycleCapability: worker.lifecycleCapability,
       signal: "SIGKILL"
     }), { flag: "wx", mode: 384 });
@@ -57248,7 +57522,7 @@ function stopWorker(worker, signal = "SIGTERM") {
   if (!waitForFile(stoppedPath, 1e4)) {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: bound-directory worker exit was not confirmed");
   }
-  if (!existsSync22(join28(worker.controlPath, "lock-retained"))) {
+  if (!existsSync22(join29(worker.controlPath, "lock-retained"))) {
     rmSync8(worker.controlPath, { force: true, recursive: true });
   }
 }
@@ -57270,13 +57544,13 @@ function bindWorker(controlPath, child, owner, childId, lifecycleCapability = ""
     }
     throw new Error(message);
   };
-  const readyPath = join28(controlPath, "ready");
+  const readyPath = join29(controlPath, "ready");
   if (!waitForFile(readyPath, WORKER_READY_TIMEOUT_MS)) {
     rejectWorker("SESSION_INTEGRATION_PATH_UNSAFE: bound-directory worker unavailable");
   }
   let ready = {};
   try {
-    ready = JSON.parse(readFileSync21(readyPath, "utf8"));
+    ready = JSON.parse(readFileSync22(readyPath, "utf8"));
   } catch {
     rejectWorker("SESSION_INTEGRATION_PATH_UNSAFE: bound-directory worker unavailable");
   }
@@ -57295,7 +57569,7 @@ function bindWorker(controlPath, child, owner, childId, lifecycleCapability = ""
   };
 }
 function startWorker(path, identity2, realPath) {
-  const controlPath = mkdtempSync(join28(tmpdir9(), "rn-bound-directory-"));
+  const controlPath = mkdtempSync(join29(tmpdir9(), "rn-bound-directory-"));
   const lifecycleCapability = randomUUID6();
   const binding = Buffer.from(JSON.stringify({
     dev: identity2.dev.toString(),
@@ -57325,7 +57599,7 @@ function startWorker(path, identity2, realPath) {
   return bindWorker(controlPath, child, void 0, void 0, lifecycleCapability);
 }
 function startSubdirectoryWorker(parent, name, expectedIdentity, expectedRealPath) {
-  const controlPath = mkdtempSync(join28(tmpdir9(), "rn-bound-directory-"));
+  const controlPath = mkdtempSync(join29(tmpdir9(), "rn-bound-directory-"));
   const childId = randomUUID6();
   const lifecycleCapability = randomUUID6();
   let worker;
@@ -57337,7 +57611,7 @@ function startSubdirectoryWorker(parent, name, expectedIdentity, expectedRealPat
       controlPath,
       lifecycleCapability,
       name,
-      publicPath: join28(parent.path, name),
+      publicPath: join29(parent.path, name),
       create: false,
       mode: 448
     });
@@ -57401,9 +57675,9 @@ function rebindDescendants(directory) {
 function sendOperation(directory, request2, timeoutMs) {
   const sequence = ++directory.worker.sequence;
   const prefix = String(sequence).padStart(8, "0");
-  const pendingPath = join28(directory.worker.controlPath, `${prefix}.pending`);
-  const requestPath2 = join28(directory.worker.controlPath, `${prefix}.request`);
-  const responsePath = join28(directory.worker.controlPath, `${prefix}.response`);
+  const pendingPath = join29(directory.worker.controlPath, `${prefix}.pending`);
+  const requestPath2 = join29(directory.worker.controlPath, `${prefix}.request`);
+  const responsePath = join29(directory.worker.controlPath, `${prefix}.response`);
   writeFileSync12(pendingPath, JSON.stringify(request2), { flag: "wx", mode: 384 });
   renameSync5(pendingPath, requestPath2);
   if (!waitForFile(responsePath, timeoutMs)) {
@@ -57411,7 +57685,7 @@ function sendOperation(directory, request2, timeoutMs) {
   }
   let result;
   try {
-    result = JSON.parse(readFileSync21(responsePath, "utf8"));
+    result = JSON.parse(readFileSync22(responsePath, "utf8"));
   } catch {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: bound-directory operation returned invalid output");
   } finally {
@@ -57436,8 +57710,8 @@ function runBoundOperation(directory, request2, dependencies = {}) {
   let current;
   let currentRealPath;
   try {
-    current = lstatSync7(directory.path, { bigint: true });
-    currentRealPath = realpathSync5(directory.path);
+    current = lstatSync8(directory.path, { bigint: true });
+    currentRealPath = realpathSync6(directory.path);
   } catch {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: bound directory path is unavailable");
   }
@@ -57553,14 +57827,14 @@ function openValidatedDirectory(path, expected) {
   let descriptor;
   let worker;
   try {
-    const before = lstatSync7(path, { bigint: true });
+    const before = lstatSync8(path, { bigint: true });
     if (!before.isDirectory() || before.isSymbolicLink()) {
       throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: integration ancestor is not a directory");
     }
     descriptor = openSync3(path, constants2.O_RDONLY | (constants2.O_DIRECTORY ?? 0) | (constants2.O_NOFOLLOW ?? 0));
     const opened = fstatSync2(descriptor, { bigint: true });
-    const after = lstatSync7(path, { bigint: true });
-    const realPath = realpathSync5(path);
+    const after = lstatSync8(path, { bigint: true });
+    const realPath = realpathSync6(path);
     if (!opened.isDirectory() || !sameIdentity(before, opened) || !sameIdentity(after, opened) || expected !== void 0 && (!sameIdentity(expected.identity, opened) || expected.realPath !== realPath)) {
       throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: integration ancestor changed while opening");
     }
@@ -57665,7 +57939,7 @@ function assertBoundDirectoryCurrent(directory) {
   runBoundOperation(directory, { operation: "identity" });
 }
 function openBoundSubdirectoryInternal(parent, name, options = {}) {
-  const controlPath = mkdtempSync(join28(tmpdir9(), "rn-bound-directory-"));
+  const controlPath = mkdtempSync(join29(tmpdir9(), "rn-bound-directory-"));
   const childId = randomUUID6();
   const lifecycleCapability = randomUUID6();
   let worker;
@@ -57677,7 +57951,7 @@ function openBoundSubdirectoryInternal(parent, name, options = {}) {
       controlPath,
       lifecycleCapability,
       name,
-      publicPath: join28(parent.path, name),
+      publicPath: join29(parent.path, name),
       create: options.create ?? false,
       mode: options.mode ?? 448,
       optional: options.optional ?? false,
@@ -57701,7 +57975,7 @@ function openBoundSubdirectoryInternal(parent, name, options = {}) {
       },
       name,
       parent,
-      path: join28(parent.path, name),
+      path: join29(parent.path, name),
       pendingCleanups: /* @__PURE__ */ new Map(),
       realPath: result.directoryIdentity.realPath,
       worker,
@@ -57835,15 +58109,15 @@ function retryBoundDirectoryCleanup(directory, obligation, dependencies = {}) {
 // packages/rn-dev-agent-core/dist/session/migration-diagnostic.js
 init_registry();
 function readPackageIntegrationManifest(appRoot, dependencies) {
-  const manifestPath = join29(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
+  const manifestPath = join30(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
   if (dependencies.exists || dependencies.readText) {
     const exists = dependencies.exists ?? existsSync23;
     if (!exists(manifestPath))
       return void 0;
-    const readText = dependencies.readText ?? ((path) => readFileSync22(path, "utf8"));
+    const readText = dependencies.readText ?? ((path) => readFileSync23(path, "utf8"));
     return readText(manifestPath);
   }
-  const agent = openBoundDirectory(join29(appRoot, ".rn-agent"));
+  const agent = openBoundDirectory(join30(appRoot, ".rn-agent"));
   let integration;
   let primaryError;
   try {
@@ -57880,7 +58154,7 @@ function inspectAuthorityMigration(status, dependencies = {}) {
   const integrationBinding = status.bindings.packageIntegration;
   let bindingDiagnostic = null;
   if (integrationBinding) {
-    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash7("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
+    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash8("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
     const manifestAvailable = manifestVerified(onDiskManifestText) || manifestVerified(integrationBinding.restoration?.phase === "started" ? integrationBinding.restoration.manifestSource : void 0) || manifestVerified(integrationBinding.installation?.phase === "started" ? integrationBinding.installation.manifestSource : void 0) || manifestVerified(integrationBinding.manifestSource);
     const effectiveOwnerSessionId = status.sessionId;
     const trustedDigestRecorded = typeof integrationBinding.manifestSha256 === "string" && /^[0-9a-f]{64}$/.test(integrationBinding.manifestSha256);
@@ -58085,187 +58359,8 @@ function verifyBuildReceipt(receipt2, capability, expected) {
   return receipt2.payload;
 }
 
-// packages/rn-dev-agent-core/dist/session/install-authority.js
-import { execFileSync as execFileSync8 } from "node:child_process";
-import { createHash as createHash8 } from "node:crypto";
-import { lstatSync as lstatSync8, readFileSync as readFileSync23, readdirSync as readdirSync7, readlinkSync as readlinkSync2, realpathSync as realpathSync6, statSync as statSync8 } from "node:fs";
-import { isAbsolute as isAbsolute4, join as join30, relative as relative2 } from "node:path";
-function runText(command, args) {
-  return execFileSync8(command, [...args], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-    timeout: 1e4,
-    maxBuffer: 8 * 1024 * 1024
-  });
-}
-function runBuffer(command, args) {
-  return execFileSync8(command, [...args], {
-    encoding: "buffer",
-    stdio: ["ignore", "pipe", "ignore"],
-    timeout: 3e4,
-    maxBuffer: 512 * 1024 * 1024
-  });
-}
-function digest(parts) {
-  const hash = createHash8("sha256");
-  for (const part of parts) {
-    hash.update(`${part.byteLength}:`);
-    hash.update(part);
-  }
-  return hash.digest("hex");
-}
-function generation(parts) {
-  return digest(parts.map((part) => Buffer.from(part)));
-}
-function listAppFiles(appPath) {
-  const files = [];
-  const visit = (directory) => {
-    for (const entry of readdirSync7(directory, { withFileTypes: true })) {
-      const path = join30(directory, entry.name);
-      if (entry.isDirectory()) {
-        visit(path);
-      } else if (entry.isFile() || entry.isSymbolicLink()) {
-        files.push(relative2(appPath, path));
-      } else {
-        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
-      }
-    }
-  };
-  visit(appPath);
-  return files.sort();
-}
-function iosAppFiles(appPath, dependencies) {
-  return [...(dependencies.listAppFiles ?? listAppFiles)(appPath)].sort();
-}
-function assertIosSymlinkContained(appPath, path, realpath) {
-  const target = realpath(path);
-  const child = relative2(realpath(appPath), target);
-  if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute4(child)) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app symlink escapes the installed bundle");
-  }
-}
-function androidApkPaths(target, text) {
-  return text("adb", ["-s", target.deviceId, "shell", "pm", "path", target.appId]).split("\n").map((line) => line.trim()).filter((line) => line.startsWith("package:")).map((line) => line.slice("package:".length)).sort();
-}
-function captureInstallGeneration(target, dependencies = {}) {
-  const text = dependencies.runText ?? runText;
-  if (target.platform === "ios") {
-    const appPath = text("xcrun", [
-      "simctl",
-      "get_app_container",
-      target.deviceId,
-      target.appId,
-      "app"
-    ]).trim();
-    if (!appPath) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
-    }
-    const infoPath = join30(appPath, "Info.plist");
-    const executable = text("plutil", [
-      "-extract",
-      "CFBundleExecutable",
-      "raw",
-      "-o",
-      "-",
-      infoPath
-    ]).trim();
-    if (!executable) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
-    }
-    const stat2 = dependencies.stat ?? statSync8;
-    const metadata2 = iosAppFiles(appPath, dependencies).map((entry) => {
-      const path = join30(appPath, entry);
-      const value = stat2(path);
-      return `${entry}:${String(value.ino)}:${value.size}:${value.mtimeMs}`;
-    });
-    return generation(metadata2);
-  }
-  const apkPaths = androidApkPaths(target, text);
-  if (!apkPaths.length) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
-  }
-  const metadata = text("adb", [
-    "-s",
-    target.deviceId,
-    "shell",
-    "stat",
-    "-c",
-    "%n:%i:%s:%Y",
-    ...apkPaths
-  ]).split("\n").map((line) => line.trim()).filter(Boolean).sort();
-  if (metadata.length !== apkPaths.length) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: Android install generation is unavailable");
-  }
-  return generation(metadata);
-}
-function captureInstalledArtifact(target, dependencies = {}) {
-  const text = dependencies.runText ?? runText;
-  const buffer = dependencies.runBuffer ?? runBuffer;
-  const read = dependencies.read ?? readFileSync23;
-  if (target.platform === "ios") {
-    const appPath = text("xcrun", [
-      "simctl",
-      "get_app_container",
-      target.deviceId,
-      target.appId,
-      "app"
-    ]).trim();
-    if (!appPath) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
-    }
-    const infoPath = join30(appPath, "Info.plist");
-    const executable = text("plutil", [
-      "-extract",
-      "CFBundleExecutable",
-      "raw",
-      "-o",
-      "-",
-      infoPath
-    ]).trim();
-    if (!executable) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
-    }
-    const files = iosAppFiles(appPath, dependencies);
-    const lstat = dependencies.lstat ?? lstatSync8;
-    const readLink = dependencies.readLink ?? readlinkSync2;
-    const realpath = dependencies.realpath ?? realpathSync6;
-    const artifactParts = [];
-    for (const entry of files) {
-      const path = join30(appPath, entry);
-      const stat2 = lstat(path);
-      artifactParts.push(Buffer.from(entry));
-      if (stat2.isFile()) {
-        artifactParts.push(Buffer.from("file"), read(path));
-      } else if (stat2.isSymbolicLink()) {
-        assertIosSymlinkContained(appPath, path, realpath);
-        artifactParts.push(Buffer.from("symlink"), Buffer.from(readLink(path)));
-      } else {
-        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
-      }
-    }
-    return {
-      ...target,
-      artifactDigest: digest(artifactParts),
-      installGeneration: captureInstallGeneration(target, dependencies)
-    };
-  }
-  const apkPaths = androidApkPaths(target, text);
-  if (!apkPaths.length) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
-  }
-  return {
-    ...target,
-    artifactDigest: digest(apkPaths.map((path) => buffer("adb", ["-s", target.deviceId, "exec-out", "cat", path]))),
-    installGeneration: captureInstallGeneration(target, dependencies)
-  };
-}
-function verifyInstalledArtifact(expected, observed) {
-  if (expected.platform !== observed.platform || expected.deviceId !== observed.deviceId || expected.appId !== observed.appId || expected.artifactDigest !== observed.artifactDigest || expected.installGeneration !== observed.installGeneration) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: installed artifact no longer matches the session build");
-  }
-}
-
 // packages/rn-dev-agent-core/dist/tools/session.js
+init_install_authority();
 init_metro_binding();
 
 // packages/rn-dev-agent-core/dist/session/expo-android-device.js
@@ -70686,6 +70781,167 @@ async function getIosRuntimeMajorForUdid(udid, execFn2 = (cmd, args) => execFile
 
 // packages/rn-dev-agent-core/dist/tools/run-action.js
 init_authority_gate();
+
+// packages/rn-dev-agent-core/dist/session/runtime.js
+init_process_birth();
+init_registry();
+init_secure_state_file();
+var WorkerAuthorityRuntime = class {
+  available;
+  #registry;
+  #session;
+  #unavailable;
+  #recoveryOnly;
+  #recoveryCapability;
+  constructor(registry2, session2, unavailable2, recoveryOnly = false, recoveryCapability = null) {
+    this.#registry = registry2;
+    this.#session = session2;
+    this.#unavailable = unavailable2;
+    this.available = registry2 !== null && session2 !== null;
+    this.#recoveryOnly = recoveryOnly;
+    this.#recoveryCapability = recoveryCapability;
+  }
+  requireAvailable() {
+    if (!this.#registry || !this.#session) {
+      throw new SessionAuthorityError(this.#unavailable?.code ?? "SESSION_NOT_INITIALIZED", this.#unavailable?.reason ?? "authority session is unavailable");
+    }
+    return { registry: this.#registry, session: this.#session };
+  }
+  requireOperational() {
+    const available = this.requireAvailable();
+    const status = this.status();
+    if (status.available && (status.state === "blocked" || status.state === "handoff_cleanup")) {
+      throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "blocked contender exposes only accept_handoff and adopt_stale recovery");
+    }
+    return available;
+  }
+  requireRecovery() {
+    const available = this.requireAvailable();
+    const status = this.status();
+    if (!this.#recoveryOnly || !status.available || status.state !== "blocked" && status.state !== "handoff_cleanup") {
+      throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "session is not a capability-bound recovery contender");
+    }
+    return available;
+  }
+  /**
+   * GH #672: rotate an expired recovery handle before it is advertised. Best-effort by
+   * design — a refresh failure must degrade `status` to an honest expired handle, never
+   * turn a diagnostic call into an authority error.
+   */
+  refreshRecoveryHandles() {
+    if (!this.#registry || !this.#session || !this.#recoveryOnly || !this.#recoveryCapability) {
+      return false;
+    }
+    try {
+      const status = this.#registry.getSessionStatus(this.#session.sessionId);
+      const instanceId = status?.worker.instanceId;
+      if (!status || !instanceId || status.state !== "blocked" && status.state !== "handoff_cleanup") {
+        return false;
+      }
+      return this.#registry.refreshRecoveryHandles(this.#session, { instanceId }, this.#recoveryCapability);
+    } catch {
+      return false;
+    }
+  }
+  inspectRecoveryRequirement() {
+    if (!this.#registry || !this.#session)
+      return void 0;
+    try {
+      return this.#registry.inspectRecoveryRequirement(this.#session.sessionId);
+    } catch {
+      return void 0;
+    }
+  }
+  status() {
+    if (!this.#registry || !this.#session) {
+      return {
+        available: false,
+        code: this.#unavailable?.code ?? "SESSION_NOT_INITIALIZED",
+        reason: this.#unavailable?.reason ?? "authority session is unavailable"
+      };
+    }
+    const status = this.#registry.getSessionStatus(this.#session.sessionId);
+    if (!status) {
+      return {
+        available: false,
+        code: "SESSION_OWNER_LOST",
+        reason: "session is no longer present in the authority registry"
+      };
+    }
+    return { available: true, ...status };
+  }
+  close() {
+    this.#registry?.close();
+  }
+};
+function unavailable(reason, fallbackCode) {
+  const matched = /^([A-Z][A-Z0-9_]+):/.exec(reason);
+  return new WorkerAuthorityRuntime(null, null, {
+    code: matched?.[1] ?? fallbackCode,
+    reason
+  });
+}
+function createWorkerAuthorityRuntime(environment = process.env, dependencies = {}) {
+  if (environment.RN_DEV_AGENT_AUTHORITY_ERROR) {
+    return unavailable(environment.RN_DEV_AGENT_AUTHORITY_ERROR, "AUTHORITY_STORE_UNAVAILABLE");
+  }
+  const sessionId = environment.RN_DEV_AGENT_SESSION_ID;
+  const claimEpoch = Number(environment.RN_DEV_AGENT_CLAIM_EPOCH);
+  const registryPath = environment.RN_DEV_AGENT_REGISTRY_PATH;
+  const workerInstance = environment.RN_DEV_AGENT_WORKER_INSTANCE;
+  if (!sessionId || !Number.isSafeInteger(claimEpoch) || claimEpoch < 1 || !registryPath || !workerInstance) {
+    return unavailable("SESSION_NOT_INITIALIZED: supervisor did not provide a complete authority context", "SESSION_NOT_INITIALIZED");
+  }
+  const birth = (dependencies.readBirth ?? readProcessBirth)(process.pid);
+  if (!birth) {
+    return unavailable("PROCESS_BIRTH_UNAVAILABLE: worker process birth could not be proven conservatively", "PROCESS_BIRTH_UNAVAILABLE");
+  }
+  try {
+    const registry2 = openSessionRegistry(registryPath, {
+      ownerStatus: dependencies.ownerStatus ?? inspectSessionOwner
+    });
+    const session2 = { sessionId, claimEpoch };
+    const status = registry2.getSessionStatus(sessionId);
+    const recoveryOnly = status?.state === "blocked" || status?.state === "handoff_cleanup";
+    let recoveryCapability = null;
+    if (recoveryOnly) {
+      const secretPath = environment.RN_DEV_AGENT_SESSION_SECRET_PATH;
+      recoveryCapability = secretPath ? readJsonStateFile(secretPath)?.recoveryCapability ?? null : null;
+      if (!recoveryCapability) {
+        throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "blocked recovery capability is unavailable");
+      }
+      registry2.bindRecoveryWorker(session2, { instanceId: workerInstance, pid: birth.pid, token: birth.token }, recoveryCapability);
+    } else {
+      registry2.bindWorker(session2, {
+        instanceId: workerInstance,
+        pid: birth.pid,
+        token: birth.token
+      });
+    }
+    return new WorkerAuthorityRuntime(registry2, session2, null, recoveryOnly, recoveryCapability);
+  } catch (error2) {
+    return unavailable(error2 instanceof Error ? error2.message : "AUTHORITY_STORE_UNAVAILABLE: worker authority could not be opened", "AUTHORITY_STORE_UNAVAILABLE");
+  }
+}
+var sharedRuntime = null;
+function getWorkerAuthorityRuntime() {
+  sharedRuntime ??= createWorkerAuthorityRuntime();
+  return sharedRuntime;
+}
+
+// packages/rn-dev-agent-core/dist/tools/run-action.js
+init_resolve_ios_app_file();
+function boundInstallReceipt() {
+  try {
+    const status = getWorkerAuthorityRuntime().status();
+    if (!status.available)
+      return null;
+    const install = status.bindings.install;
+    return install ?? null;
+  } catch {
+    return null;
+  }
+}
 function classifyFailure(failure) {
   switch (failure.kind) {
     case "SELECTOR_NOT_FOUND":
@@ -70824,6 +71080,9 @@ function createRunActionHandler(deps = {}) {
   const claimNativeOrigin = deps.claimNativeOrigin ?? claimManagedNativeOriginAuthority;
   const completeNativeOrigin = deps.completeNativeOrigin ?? completeManagedNativeOriginAuthority;
   const relaunchManagedApp = deps.relaunchManagedApp ?? relaunchManagedNativeOriginApp;
+  const reissueInstallReceipt = deps.reissueInstallReceipt ?? reissueManagedInstallAuthority;
+  const installReceipt = deps.installReceipt ?? boundInstallReceipt;
+  const resolveAppFile = deps.resolveAppFile ?? ((appId, deviceId) => resolveIosAppFile(appId, { deviceId }));
   return async (args) => {
     if (!args.actionId || typeof args.actionId !== "string") {
       return failResult("cdp_run_action requires actionId", "BAD_FILENAME");
@@ -70854,6 +71113,8 @@ function createRunActionHandler(deps = {}) {
       return failResult(`cdp_run_action: requested ${args.platform}, but the active session is ${activeTarget.platform}; refusing cross-platform replay.`, "TARGET_SESSION_MISMATCH", { requestedPlatform: args.platform, activeSession: activeTarget });
     }
     const maestroDeviceId = (!args.platform || activeTarget?.platform === args.platform) && activeTarget?.deviceId ? activeTarget.deviceId : void 0;
+    const receipt2 = args.appFile ? null : installReceipt();
+    const appFile = args.appFile ?? (flowUsesClearState(action.body) && receipt2?.platform === "ios" && typeof receipt2.appId === "string" && typeof receipt2.deviceId === "string" ? resolveAppFile(receipt2.appId, receipt2.deviceId) ?? void 0 : void 0);
     let probeDeviceId = null;
     let observedDeviceId = maestroDeviceId ?? null;
     const persistRunWithDevice = (record2) => proofReplay ? Promise.resolve({ promoted: false, promotionRefused: false }) : persistRun(args.actionId, projectRoot, probeDeviceId ? { ...record2, deviceId: probeDeviceId } : record2);
@@ -70950,13 +71211,15 @@ function createRunActionHandler(deps = {}) {
         flowPath: action.filePath,
         platform: args.platform,
         appId: args.appId,
+        ...appFile ? { appFile } : {},
         deviceId: maestroDeviceId,
         timeoutMs,
         params: args.params,
         claimNativeOrigin: () => claimNativeOrigin(args),
         completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
         relaunchManagedApp: () => relaunchManagedApp(args),
-        completeRunnerPark: () => completeManagedRunnerParkAuthority(args)
+        completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+        reissueInstallReceipt: () => reissueInstallReceipt(args)
       });
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, "maestro_run");
@@ -71230,13 +71493,15 @@ function createRunActionHandler(deps = {}) {
         flowPath: reloadedAction.filePath,
         platform: args.platform,
         appId: args.appId,
+        ...appFile ? { appFile } : {},
         deviceId: maestroDeviceId,
         timeoutMs,
         params: args.params,
         claimNativeOrigin: () => claimNativeOrigin(args),
         completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
         relaunchManagedApp: () => relaunchManagedApp(args),
-        completeRunnerPark: () => completeManagedRunnerParkAuthority(args)
+        completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+        reissueInstallReceipt: () => reissueInstallReceipt(args)
       });
       const retryMs = Date.now() - tBeforeRetry;
       const retryEnv = parseEnvelope(retryResult, "maestro_run");
@@ -73279,155 +73544,6 @@ import { promisify as promisify24 } from "node:util";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 import { dirname as dirname16, join as join36 } from "node:path";
 init_process_birth();
-
-// packages/rn-dev-agent-core/dist/session/runtime.js
-init_process_birth();
-init_registry();
-init_secure_state_file();
-var WorkerAuthorityRuntime = class {
-  available;
-  #registry;
-  #session;
-  #unavailable;
-  #recoveryOnly;
-  #recoveryCapability;
-  constructor(registry2, session2, unavailable2, recoveryOnly = false, recoveryCapability = null) {
-    this.#registry = registry2;
-    this.#session = session2;
-    this.#unavailable = unavailable2;
-    this.available = registry2 !== null && session2 !== null;
-    this.#recoveryOnly = recoveryOnly;
-    this.#recoveryCapability = recoveryCapability;
-  }
-  requireAvailable() {
-    if (!this.#registry || !this.#session) {
-      throw new SessionAuthorityError(this.#unavailable?.code ?? "SESSION_NOT_INITIALIZED", this.#unavailable?.reason ?? "authority session is unavailable");
-    }
-    return { registry: this.#registry, session: this.#session };
-  }
-  requireOperational() {
-    const available = this.requireAvailable();
-    const status = this.status();
-    if (status.available && (status.state === "blocked" || status.state === "handoff_cleanup")) {
-      throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "blocked contender exposes only accept_handoff and adopt_stale recovery");
-    }
-    return available;
-  }
-  requireRecovery() {
-    const available = this.requireAvailable();
-    const status = this.status();
-    if (!this.#recoveryOnly || !status.available || status.state !== "blocked" && status.state !== "handoff_cleanup") {
-      throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "session is not a capability-bound recovery contender");
-    }
-    return available;
-  }
-  /**
-   * GH #672: rotate an expired recovery handle before it is advertised. Best-effort by
-   * design — a refresh failure must degrade `status` to an honest expired handle, never
-   * turn a diagnostic call into an authority error.
-   */
-  refreshRecoveryHandles() {
-    if (!this.#registry || !this.#session || !this.#recoveryOnly || !this.#recoveryCapability) {
-      return false;
-    }
-    try {
-      const status = this.#registry.getSessionStatus(this.#session.sessionId);
-      const instanceId = status?.worker.instanceId;
-      if (!status || !instanceId || status.state !== "blocked" && status.state !== "handoff_cleanup") {
-        return false;
-      }
-      return this.#registry.refreshRecoveryHandles(this.#session, { instanceId }, this.#recoveryCapability);
-    } catch {
-      return false;
-    }
-  }
-  inspectRecoveryRequirement() {
-    if (!this.#registry || !this.#session)
-      return void 0;
-    try {
-      return this.#registry.inspectRecoveryRequirement(this.#session.sessionId);
-    } catch {
-      return void 0;
-    }
-  }
-  status() {
-    if (!this.#registry || !this.#session) {
-      return {
-        available: false,
-        code: this.#unavailable?.code ?? "SESSION_NOT_INITIALIZED",
-        reason: this.#unavailable?.reason ?? "authority session is unavailable"
-      };
-    }
-    const status = this.#registry.getSessionStatus(this.#session.sessionId);
-    if (!status) {
-      return {
-        available: false,
-        code: "SESSION_OWNER_LOST",
-        reason: "session is no longer present in the authority registry"
-      };
-    }
-    return { available: true, ...status };
-  }
-  close() {
-    this.#registry?.close();
-  }
-};
-function unavailable(reason, fallbackCode) {
-  const matched = /^([A-Z][A-Z0-9_]+):/.exec(reason);
-  return new WorkerAuthorityRuntime(null, null, {
-    code: matched?.[1] ?? fallbackCode,
-    reason
-  });
-}
-function createWorkerAuthorityRuntime(environment = process.env, dependencies = {}) {
-  if (environment.RN_DEV_AGENT_AUTHORITY_ERROR) {
-    return unavailable(environment.RN_DEV_AGENT_AUTHORITY_ERROR, "AUTHORITY_STORE_UNAVAILABLE");
-  }
-  const sessionId = environment.RN_DEV_AGENT_SESSION_ID;
-  const claimEpoch = Number(environment.RN_DEV_AGENT_CLAIM_EPOCH);
-  const registryPath = environment.RN_DEV_AGENT_REGISTRY_PATH;
-  const workerInstance = environment.RN_DEV_AGENT_WORKER_INSTANCE;
-  if (!sessionId || !Number.isSafeInteger(claimEpoch) || claimEpoch < 1 || !registryPath || !workerInstance) {
-    return unavailable("SESSION_NOT_INITIALIZED: supervisor did not provide a complete authority context", "SESSION_NOT_INITIALIZED");
-  }
-  const birth = (dependencies.readBirth ?? readProcessBirth)(process.pid);
-  if (!birth) {
-    return unavailable("PROCESS_BIRTH_UNAVAILABLE: worker process birth could not be proven conservatively", "PROCESS_BIRTH_UNAVAILABLE");
-  }
-  try {
-    const registry2 = openSessionRegistry(registryPath, {
-      ownerStatus: dependencies.ownerStatus ?? inspectSessionOwner
-    });
-    const session2 = { sessionId, claimEpoch };
-    const status = registry2.getSessionStatus(sessionId);
-    const recoveryOnly = status?.state === "blocked" || status?.state === "handoff_cleanup";
-    let recoveryCapability = null;
-    if (recoveryOnly) {
-      const secretPath = environment.RN_DEV_AGENT_SESSION_SECRET_PATH;
-      recoveryCapability = secretPath ? readJsonStateFile(secretPath)?.recoveryCapability ?? null : null;
-      if (!recoveryCapability) {
-        throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "blocked recovery capability is unavailable");
-      }
-      registry2.bindRecoveryWorker(session2, { instanceId: workerInstance, pid: birth.pid, token: birth.token }, recoveryCapability);
-    } else {
-      registry2.bindWorker(session2, {
-        instanceId: workerInstance,
-        pid: birth.pid,
-        token: birth.token
-      });
-    }
-    return new WorkerAuthorityRuntime(registry2, session2, null, recoveryOnly, recoveryCapability);
-  } catch (error2) {
-    return unavailable(error2 instanceof Error ? error2.message : "AUTHORITY_STORE_UNAVAILABLE: worker authority could not be opened", "AUTHORITY_STORE_UNAVAILABLE");
-  }
-}
-var sharedRuntime = null;
-function getWorkerAuthorityRuntime() {
-  sharedRuntime ??= createWorkerAuthorityRuntime();
-  return sharedRuntime;
-}
-
-// packages/rn-dev-agent-core/dist/tools/device-record.js
 var execFileAsync5 = promisify24(execFile22);
 var START_TIMEOUT_MS = 1e4;
 var STATUS_TIMEOUT_MS = 5e3;
@@ -78719,6 +78835,7 @@ function createMetroEventsHandler(getClient2) {
 // packages/rn-dev-agent-core/dist/index.js
 init_rn_fast_runner_client();
 init_rn_android_runner_client();
+init_install_authority();
 init_process_birth();
 init_ensure_single_runner();
 
@@ -81050,6 +81167,7 @@ init_authority_gate();
 // packages/rn-dev-agent-core/dist/session/local-authority-probe.js
 init_discovery();
 init_metro_cwd();
+init_install_authority();
 import { execFileSync as execFileSync17 } from "node:child_process";
 import { createHash as createHash19 } from "node:crypto";
 init_metro_binding();
@@ -83960,6 +84078,7 @@ trackedTool(
     actionId: external_exports.string().describe("Action id matching <projectRoot>/.rn-agent/actions/<actionId>.yaml."),
     projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
     platform: external_exports.enum(["ios", "android"]).optional().describe("Force a specific platform; otherwise auto-detected from the active device session."),
+    appFile: external_exports.string().optional().describe("GH #705: path to the .app Maestro reinstalls from after a clearState uninstall. Normally omit it \u2014 an iOS clearState flow resolves the bundle from the session's attested install receipt, and the receipt is re-issued after the reinstall so later device_*/maestro_run calls keep working."),
     autoRepair: external_exports.boolean().optional().describe("Auto-repair on SELECTOR_NOT_FOUND failures. Default true. Pass false to disable (e.g. when investigating a failure manually)."),
     timeoutMs: external_exports.number().optional().describe("Maestro execution timeout per attempt (ms). Default 120_000."),
     trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe('RunRecord trigger annotation. Default "agent". CI calls should pass "ci".'),

--- a/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -44,6 +44,186 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
+// packages/rn-dev-agent-core/dist/session/install-authority.js
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { lstatSync, readFileSync, readdirSync, readlinkSync, realpathSync, statSync } from "node:fs";
+import { isAbsolute, join, relative } from "node:path";
+function runText(command, args) {
+  return execFileSync(command, [...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 1e4,
+    maxBuffer: 8 * 1024 * 1024
+  });
+}
+function runBuffer(command, args) {
+  return execFileSync(command, [...args], {
+    encoding: "buffer",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 3e4,
+    maxBuffer: 512 * 1024 * 1024
+  });
+}
+function digest(parts) {
+  const hash = createHash("sha256");
+  for (const part of parts) {
+    hash.update(`${part.byteLength}:`);
+    hash.update(part);
+  }
+  return hash.digest("hex");
+}
+function generation(parts) {
+  return digest(parts.map((part) => Buffer.from(part)));
+}
+function listAppFiles(appPath) {
+  const files = [];
+  const visit = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(path);
+      } else if (entry.isFile() || entry.isSymbolicLink()) {
+        files.push(relative(appPath, path));
+      } else {
+        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
+      }
+    }
+  };
+  visit(appPath);
+  return files.sort();
+}
+function iosAppFiles(appPath, dependencies) {
+  return [...(dependencies.listAppFiles ?? listAppFiles)(appPath)].sort();
+}
+function assertIosSymlinkContained(appPath, path, realpath) {
+  const target = realpath(path);
+  const child = relative(realpath(appPath), target);
+  if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute(child)) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app symlink escapes the installed bundle");
+  }
+}
+function androidApkPaths(target, text) {
+  return text("adb", ["-s", target.deviceId, "shell", "pm", "path", target.appId]).split("\n").map((line) => line.trim()).filter((line) => line.startsWith("package:")).map((line) => line.slice("package:".length)).sort();
+}
+function captureInstallGeneration(target, dependencies = {}) {
+  const text = dependencies.runText ?? runText;
+  if (target.platform === "ios") {
+    const appPath = text("xcrun", [
+      "simctl",
+      "get_app_container",
+      target.deviceId,
+      target.appId,
+      "app"
+    ]).trim();
+    if (!appPath) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
+    }
+    const infoPath = join(appPath, "Info.plist");
+    const executable = text("plutil", [
+      "-extract",
+      "CFBundleExecutable",
+      "raw",
+      "-o",
+      "-",
+      infoPath
+    ]).trim();
+    if (!executable) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
+    }
+    const stat = dependencies.stat ?? statSync;
+    const metadata2 = iosAppFiles(appPath, dependencies).map((entry) => {
+      const path = join(appPath, entry);
+      const value = stat(path);
+      return `${entry}:${String(value.ino)}:${value.size}:${value.mtimeMs}`;
+    });
+    return generation(metadata2);
+  }
+  const apkPaths = androidApkPaths(target, text);
+  if (!apkPaths.length) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
+  }
+  const metadata = text("adb", [
+    "-s",
+    target.deviceId,
+    "shell",
+    "stat",
+    "-c",
+    "%n:%i:%s:%Y",
+    ...apkPaths
+  ]).split("\n").map((line) => line.trim()).filter(Boolean).sort();
+  if (metadata.length !== apkPaths.length) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: Android install generation is unavailable");
+  }
+  return generation(metadata);
+}
+function captureInstalledArtifact(target, dependencies = {}) {
+  const text = dependencies.runText ?? runText;
+  const buffer = dependencies.runBuffer ?? runBuffer;
+  const read = dependencies.read ?? readFileSync;
+  if (target.platform === "ios") {
+    const appPath = text("xcrun", [
+      "simctl",
+      "get_app_container",
+      target.deviceId,
+      target.appId,
+      "app"
+    ]).trim();
+    if (!appPath) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
+    }
+    const infoPath = join(appPath, "Info.plist");
+    const executable = text("plutil", [
+      "-extract",
+      "CFBundleExecutable",
+      "raw",
+      "-o",
+      "-",
+      infoPath
+    ]).trim();
+    if (!executable) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
+    }
+    const files = iosAppFiles(appPath, dependencies);
+    const lstat = dependencies.lstat ?? lstatSync;
+    const readLink = dependencies.readLink ?? readlinkSync;
+    const realpath = dependencies.realpath ?? realpathSync;
+    const artifactParts = [];
+    for (const entry of files) {
+      const path = join(appPath, entry);
+      const stat = lstat(path);
+      artifactParts.push(Buffer.from(entry));
+      if (stat.isFile()) {
+        artifactParts.push(Buffer.from("file"), read(path));
+      } else if (stat.isSymbolicLink()) {
+        assertIosSymlinkContained(appPath, path, realpath);
+        artifactParts.push(Buffer.from("symlink"), Buffer.from(readLink(path)));
+      } else {
+        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
+      }
+    }
+    return {
+      ...target,
+      artifactDigest: digest(artifactParts),
+      installGeneration: captureInstallGeneration(target, dependencies)
+    };
+  }
+  const apkPaths = androidApkPaths(target, text);
+  if (!apkPaths.length) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
+  }
+  return {
+    ...target,
+    artifactDigest: digest(apkPaths.map((path) => buffer("adb", ["-s", target.deviceId, "exec-out", "cat", path]))),
+    installGeneration: captureInstallGeneration(target, dependencies)
+  };
+}
+var init_install_authority = __esm({
+  "packages/rn-dev-agent-core/dist/session/install-authority.js"() {
+    "use strict";
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/declared-source-contract.js
 function parseDeclaredManifests(value) {
   if (value === void 0)
@@ -11090,6 +11270,15 @@ var init_maestro_runner_report = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/session/install-reissue.js
+var init_install_reissue = __esm({
+  "packages/rn-dev-agent-core/dist/session/install-reissue.js"() {
+    "use strict";
+    init_install_authority();
+    init_registry();
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -11255,6 +11444,7 @@ var init_tool_profiles = __esm({
       optionalAxes: ["B"],
       managedOrigin: true,
       managedRunnerPark: true,
+      managedInstallReissue: true,
       mutation: true,
       liveBundleProbe: true
     });
@@ -11302,6 +11492,7 @@ var init_authority_gate = __esm({
     "use strict";
     init_utils();
     init_registry();
+    init_install_reissue();
     init_tool_profiles();
   }
 });
@@ -11860,180 +12051,8 @@ function createBuildReceipt(payload, capability) {
   return { version: 1, payload, signature: sign(payload, capability) };
 }
 
-// packages/rn-dev-agent-core/dist/session/install-authority.js
-import { execFileSync } from "node:child_process";
-import { createHash } from "node:crypto";
-import { lstatSync, readFileSync, readdirSync, readlinkSync, realpathSync, statSync } from "node:fs";
-import { isAbsolute, join, relative } from "node:path";
-function runText(command, args) {
-  return execFileSync(command, [...args], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-    timeout: 1e4,
-    maxBuffer: 8 * 1024 * 1024
-  });
-}
-function runBuffer(command, args) {
-  return execFileSync(command, [...args], {
-    encoding: "buffer",
-    stdio: ["ignore", "pipe", "ignore"],
-    timeout: 3e4,
-    maxBuffer: 512 * 1024 * 1024
-  });
-}
-function digest(parts) {
-  const hash = createHash("sha256");
-  for (const part of parts) {
-    hash.update(`${part.byteLength}:`);
-    hash.update(part);
-  }
-  return hash.digest("hex");
-}
-function generation(parts) {
-  return digest(parts.map((part) => Buffer.from(part)));
-}
-function listAppFiles(appPath) {
-  const files = [];
-  const visit = (directory) => {
-    for (const entry of readdirSync(directory, { withFileTypes: true })) {
-      const path = join(directory, entry.name);
-      if (entry.isDirectory()) {
-        visit(path);
-      } else if (entry.isFile() || entry.isSymbolicLink()) {
-        files.push(relative(appPath, path));
-      } else {
-        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
-      }
-    }
-  };
-  visit(appPath);
-  return files.sort();
-}
-function iosAppFiles(appPath, dependencies) {
-  return [...(dependencies.listAppFiles ?? listAppFiles)(appPath)].sort();
-}
-function assertIosSymlinkContained(appPath, path, realpath) {
-  const target = realpath(path);
-  const child = relative(realpath(appPath), target);
-  if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute(child)) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app symlink escapes the installed bundle");
-  }
-}
-function androidApkPaths(target, text) {
-  return text("adb", ["-s", target.deviceId, "shell", "pm", "path", target.appId]).split("\n").map((line) => line.trim()).filter((line) => line.startsWith("package:")).map((line) => line.slice("package:".length)).sort();
-}
-function captureInstallGeneration(target, dependencies = {}) {
-  const text = dependencies.runText ?? runText;
-  if (target.platform === "ios") {
-    const appPath = text("xcrun", [
-      "simctl",
-      "get_app_container",
-      target.deviceId,
-      target.appId,
-      "app"
-    ]).trim();
-    if (!appPath) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
-    }
-    const infoPath = join(appPath, "Info.plist");
-    const executable = text("plutil", [
-      "-extract",
-      "CFBundleExecutable",
-      "raw",
-      "-o",
-      "-",
-      infoPath
-    ]).trim();
-    if (!executable) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
-    }
-    const stat = dependencies.stat ?? statSync;
-    const metadata2 = iosAppFiles(appPath, dependencies).map((entry) => {
-      const path = join(appPath, entry);
-      const value = stat(path);
-      return `${entry}:${String(value.ino)}:${value.size}:${value.mtimeMs}`;
-    });
-    return generation(metadata2);
-  }
-  const apkPaths = androidApkPaths(target, text);
-  if (!apkPaths.length) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
-  }
-  const metadata = text("adb", [
-    "-s",
-    target.deviceId,
-    "shell",
-    "stat",
-    "-c",
-    "%n:%i:%s:%Y",
-    ...apkPaths
-  ]).split("\n").map((line) => line.trim()).filter(Boolean).sort();
-  if (metadata.length !== apkPaths.length) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: Android install generation is unavailable");
-  }
-  return generation(metadata);
-}
-function captureInstalledArtifact(target, dependencies = {}) {
-  const text = dependencies.runText ?? runText;
-  const buffer = dependencies.runBuffer ?? runBuffer;
-  const read = dependencies.read ?? readFileSync;
-  if (target.platform === "ios") {
-    const appPath = text("xcrun", [
-      "simctl",
-      "get_app_container",
-      target.deviceId,
-      target.appId,
-      "app"
-    ]).trim();
-    if (!appPath) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
-    }
-    const infoPath = join(appPath, "Info.plist");
-    const executable = text("plutil", [
-      "-extract",
-      "CFBundleExecutable",
-      "raw",
-      "-o",
-      "-",
-      infoPath
-    ]).trim();
-    if (!executable) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
-    }
-    const files = iosAppFiles(appPath, dependencies);
-    const lstat = dependencies.lstat ?? lstatSync;
-    const readLink = dependencies.readLink ?? readlinkSync;
-    const realpath = dependencies.realpath ?? realpathSync;
-    const artifactParts = [];
-    for (const entry of files) {
-      const path = join(appPath, entry);
-      const stat = lstat(path);
-      artifactParts.push(Buffer.from(entry));
-      if (stat.isFile()) {
-        artifactParts.push(Buffer.from("file"), read(path));
-      } else if (stat.isSymbolicLink()) {
-        assertIosSymlinkContained(appPath, path, realpath);
-        artifactParts.push(Buffer.from("symlink"), Buffer.from(readLink(path)));
-      } else {
-        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
-      }
-    }
-    return {
-      ...target,
-      artifactDigest: digest(artifactParts),
-      installGeneration: captureInstallGeneration(target, dependencies)
-    };
-  }
-  const apkPaths = androidApkPaths(target, text);
-  if (!apkPaths.length) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
-  }
-  return {
-    ...target,
-    artifactDigest: digest(apkPaths.map((path) => buffer("adb", ["-s", target.deviceId, "exec-out", "cat", path]))),
-    installGeneration: captureInstallGeneration(target, dependencies)
-  };
-}
+// packages/rn-dev-agent-core/dist/rn-session.js
+init_install_authority();
 
 // packages/rn-dev-agent-core/dist/session/expo-android-device.js
 import { execFileSync as execFileSync2 } from "node:child_process";

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -26549,7 +26549,7 @@ function authorityProfileFor(tool, args = {}) {
       postflightAxes: facetsOf(throughRuntime, { without: ["A", "B"] }),
       managedOrigin: true,
       managedRunnerPark: true,
-      managedInstallReissue: true,
+      managedInstallReissue: tool === "maestro_run",
       mutation: true,
       liveBundleProbe: false
     };

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -25540,7 +25540,7 @@ function resolveIosAppFile(bundleId, deps = {}) {
   const exists = deps.exists ?? existsSync15;
   const getAppContainer = deps.getAppContainer ?? defaultGetAppContainer;
   const snapshotApp = deps.snapshotApp ?? defaultSnapshotApp;
-  const fromContainer = getAppContainer(bundleId);
+  const fromContainer = getAppContainer(bundleId, deps.deviceId);
   if (fromContainer && exists(fromContainer)) {
     const snapshot = snapshotApp(fromContainer);
     if (snapshot)
@@ -25571,9 +25571,10 @@ function resolveAppFileForClearState(platform, flowText, headerAppId, explicitAp
   }
   return { ok: true, appFile };
 }
-function defaultGetAppContainer(bundleId) {
+function defaultGetAppContainer(bundleId, deviceId) {
   try {
-    const out = execFileSync9("xcrun", ["simctl", "get_app_container", "booted", bundleId, "app"], {
+    const target = deviceId && !/\s/.test(deviceId) ? deviceId : "booted";
+    const out = execFileSync9("xcrun", ["simctl", "get_app_container", target, bundleId, "app"], {
       encoding: "utf8",
       timeout: 5e3
     }).trim();
@@ -26239,6 +26240,226 @@ var init_maestro_runner_report = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/session/install-authority.js
+import { execFileSync as execFileSync10 } from "node:child_process";
+import { createHash as createHash11 } from "node:crypto";
+import { lstatSync as lstatSync9, readFileSync as readFileSync18, readdirSync as readdirSync6, readlinkSync as readlinkSync3, realpathSync as realpathSync8, statSync as statSync9 } from "node:fs";
+import { isAbsolute as isAbsolute5, join as join20, relative as relative3 } from "node:path";
+function runText(command, args) {
+  return execFileSync10(command, [...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 1e4,
+    maxBuffer: 8 * 1024 * 1024
+  });
+}
+function runBuffer(command, args) {
+  return execFileSync10(command, [...args], {
+    encoding: "buffer",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 3e4,
+    maxBuffer: 512 * 1024 * 1024
+  });
+}
+function digest2(parts) {
+  const hash = createHash11("sha256");
+  for (const part of parts) {
+    hash.update(`${part.byteLength}:`);
+    hash.update(part);
+  }
+  return hash.digest("hex");
+}
+function generation(parts) {
+  return digest2(parts.map((part) => Buffer.from(part)));
+}
+function listAppFiles(appPath) {
+  const files = [];
+  const visit = (directory) => {
+    for (const entry of readdirSync6(directory, { withFileTypes: true })) {
+      const path = join20(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(path);
+      } else if (entry.isFile() || entry.isSymbolicLink()) {
+        files.push(relative3(appPath, path));
+      } else {
+        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
+      }
+    }
+  };
+  visit(appPath);
+  return files.sort();
+}
+function iosAppFiles(appPath, dependencies) {
+  return [...(dependencies.listAppFiles ?? listAppFiles)(appPath)].sort();
+}
+function assertIosSymlinkContained(appPath, path, realpath) {
+  const target = realpath(path);
+  const child = relative3(realpath(appPath), target);
+  if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute5(child)) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app symlink escapes the installed bundle");
+  }
+}
+function androidApkPaths(target, text) {
+  return text("adb", ["-s", target.deviceId, "shell", "pm", "path", target.appId]).split("\n").map((line) => line.trim()).filter((line) => line.startsWith("package:")).map((line) => line.slice("package:".length)).sort();
+}
+function captureInstallGeneration(target, dependencies = {}) {
+  const text = dependencies.runText ?? runText;
+  if (target.platform === "ios") {
+    const appPath = text("xcrun", [
+      "simctl",
+      "get_app_container",
+      target.deviceId,
+      target.appId,
+      "app"
+    ]).trim();
+    if (!appPath) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
+    }
+    const infoPath = join20(appPath, "Info.plist");
+    const executable = text("plutil", [
+      "-extract",
+      "CFBundleExecutable",
+      "raw",
+      "-o",
+      "-",
+      infoPath
+    ]).trim();
+    if (!executable) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
+    }
+    const stat2 = dependencies.stat ?? statSync9;
+    const metadata2 = iosAppFiles(appPath, dependencies).map((entry) => {
+      const path = join20(appPath, entry);
+      const value = stat2(path);
+      return `${entry}:${String(value.ino)}:${value.size}:${value.mtimeMs}`;
+    });
+    return generation(metadata2);
+  }
+  const apkPaths = androidApkPaths(target, text);
+  if (!apkPaths.length) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
+  }
+  const metadata = text("adb", [
+    "-s",
+    target.deviceId,
+    "shell",
+    "stat",
+    "-c",
+    "%n:%i:%s:%Y",
+    ...apkPaths
+  ]).split("\n").map((line) => line.trim()).filter(Boolean).sort();
+  if (metadata.length !== apkPaths.length) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: Android install generation is unavailable");
+  }
+  return generation(metadata);
+}
+function captureInstalledArtifact(target, dependencies = {}) {
+  const text = dependencies.runText ?? runText;
+  const buffer = dependencies.runBuffer ?? runBuffer;
+  const read = dependencies.read ?? readFileSync18;
+  if (target.platform === "ios") {
+    const appPath = text("xcrun", [
+      "simctl",
+      "get_app_container",
+      target.deviceId,
+      target.appId,
+      "app"
+    ]).trim();
+    if (!appPath) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
+    }
+    const infoPath = join20(appPath, "Info.plist");
+    const executable = text("plutil", [
+      "-extract",
+      "CFBundleExecutable",
+      "raw",
+      "-o",
+      "-",
+      infoPath
+    ]).trim();
+    if (!executable) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
+    }
+    const files = iosAppFiles(appPath, dependencies);
+    const lstat = dependencies.lstat ?? lstatSync9;
+    const readLink = dependencies.readLink ?? readlinkSync3;
+    const realpath = dependencies.realpath ?? realpathSync8;
+    const artifactParts = [];
+    for (const entry of files) {
+      const path = join20(appPath, entry);
+      const stat2 = lstat(path);
+      artifactParts.push(Buffer.from(entry));
+      if (stat2.isFile()) {
+        artifactParts.push(Buffer.from("file"), read(path));
+      } else if (stat2.isSymbolicLink()) {
+        assertIosSymlinkContained(appPath, path, realpath);
+        artifactParts.push(Buffer.from("symlink"), Buffer.from(readLink(path)));
+      } else {
+        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
+      }
+    }
+    return {
+      ...target,
+      artifactDigest: digest2(artifactParts),
+      installGeneration: captureInstallGeneration(target, dependencies)
+    };
+  }
+  const apkPaths = androidApkPaths(target, text);
+  if (!apkPaths.length) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
+  }
+  return {
+    ...target,
+    artifactDigest: digest2(apkPaths.map((path) => buffer("adb", ["-s", target.deviceId, "exec-out", "cat", path]))),
+    installGeneration: captureInstallGeneration(target, dependencies)
+  };
+}
+function verifyInstalledArtifact(expected, observed) {
+  if (expected.platform !== observed.platform || expected.deviceId !== observed.deviceId || expected.appId !== observed.appId || expected.artifactDigest !== observed.artifactDigest || expected.installGeneration !== observed.installGeneration) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: installed artifact no longer matches the session build");
+  }
+}
+var init_install_authority = __esm({
+  "packages/rn-dev-agent-core/dist/session/install-authority.js"() {
+    "use strict";
+  }
+});
+
+// packages/rn-dev-agent-core/dist/session/install-reissue.js
+function reissueInstallBinding(install, dependencies = {}) {
+  const platform = install?.platform;
+  const deviceId = install?.deviceId;
+  const appId = install?.appId;
+  const artifactDigest = install?.artifactDigest;
+  const installGeneration = install?.installGeneration;
+  if (platform !== "ios" && platform !== "android" || typeof deviceId !== "string" || typeof appId !== "string" || typeof artifactDigest !== "string" || typeof installGeneration !== "string") {
+    throw new SessionAuthorityError("APP_INSTALL_IDENTITY_CHANGED", "no attested install receipt is bound to re-issue after the reinstall");
+  }
+  let observed;
+  try {
+    observed = (dependencies.captureInstalled ?? captureInstalledArtifact)({
+      platform,
+      deviceId,
+      appId
+    });
+  } catch {
+    throw new SessionAuthorityError("APP_INSTALL_IDENTITY_CHANGED", "the reinstalled artifact could not be attested");
+  }
+  if (observed.artifactDigest !== artifactDigest) {
+    throw new SessionAuthorityError("APP_INSTALL_IDENTITY_CHANGED", "the reinstalled artifact is not the attested session build");
+  }
+  if (observed.installGeneration === installGeneration)
+    return null;
+  return { ...install, installGeneration: observed.installGeneration };
+}
+var init_install_reissue = __esm({
+  "packages/rn-dev-agent-core/dist/session/install-reissue.js"() {
+    "use strict";
+    init_install_authority();
+    init_registry();
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -26328,6 +26549,7 @@ function authorityProfileFor(tool, args = {}) {
       postflightAxes: facetsOf(throughRuntime, { without: ["A", "B"] }),
       managedOrigin: true,
       managedRunnerPark: true,
+      managedInstallReissue: true,
       mutation: true,
       liveBundleProbe: false
     };
@@ -26513,6 +26735,7 @@ var init_tool_profiles = __esm({
       optionalAxes: ["B"],
       managedOrigin: true,
       managedRunnerPark: true,
+      managedInstallReissue: true,
       mutation: true,
       liveBundleProbe: true
     });
@@ -26556,8 +26779,8 @@ var init_tool_profiles = __esm({
 
 // packages/rn-dev-agent-core/dist/session/authority-gate.js
 import { randomUUID as randomUUID5 } from "node:crypto";
-import { realpathSync as realpathSync8 } from "node:fs";
-import { isAbsolute as isAbsolute5, relative as relative3, resolve as resolve6 } from "node:path";
+import { realpathSync as realpathSync9 } from "node:fs";
+import { isAbsolute as isAbsolute6, relative as relative4, resolve as resolve6 } from "node:path";
 async function claimOptionalBundleAuthority(args) {
   return await args[optionalBundleAdmission]?.() ?? false;
 }
@@ -26581,6 +26804,16 @@ async function relaunchManagedNativeOriginApp(args) {
     throw new SessionAuthorityError("METRO_ORIGIN_MISMATCH", "managed native origin relaunch authority is unavailable");
   }
   await authority.relaunch();
+}
+async function reissueManagedInstallAuthority(args) {
+  const reissue = args[managedInstallReissue];
+  if (!reissue) {
+    throw new SessionAuthorityError("APP_INSTALL_IDENTITY_CHANGED", "managed install re-issue authority is unavailable");
+  }
+  await reissue();
+}
+function hasManagedInstallReissueAuthority(args) {
+  return typeof args[managedInstallReissue] === "function";
 }
 function hasManagedRunnerParkAuthority(args) {
   return typeof args[managedRunnerPark] === "function";
@@ -26711,7 +26944,7 @@ function bindSourcePaths(status, args) {
   try {
     if (typeof status.source.appRoot !== "string")
       throw new Error("missing app root");
-    appRoot = realpathSync8(status.source.appRoot);
+    appRoot = realpathSync9(status.source.appRoot);
   } catch {
     throw new SessionAuthorityError("SOURCE_WORKTREE_MISMATCH", "active session app root is unavailable");
   }
@@ -26724,12 +26957,12 @@ function bindSourcePaths(status, args) {
     }
     let candidate;
     try {
-      candidate = realpathSync8(isAbsolute5(supplied) ? supplied : resolve6(appRoot, supplied));
+      candidate = realpathSync9(isAbsolute6(supplied) ? supplied : resolve6(appRoot, supplied));
     } catch {
       throw new SessionAuthorityError("SOURCE_WORKTREE_MISMATCH", `${field2} cannot be resolved within the active app root`);
     }
-    const child = relative3(appRoot, candidate);
-    if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute5(child)) {
+    const child = relative4(appRoot, candidate);
+    if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute6(child)) {
       throw new SessionAuthorityError("SOURCE_WORKTREE_MISMATCH", `${field2} is outside the active session app root`);
     }
     args[field2] = candidate;
@@ -27152,6 +27385,7 @@ function createAuthorityGate(runtime, dependencies) {
         let optionalBundleClaimed = false;
         let optionalBundleRecoveryFailed = false;
         let managedRunnerParked = false;
+        let installReceiptReissued = false;
         if (profile.optionalAxes?.includes("B")) {
           Object.defineProperty(args, optionalBundleAdmission, {
             configurable: true,
@@ -27355,6 +27589,30 @@ function createAuthorityGate(runtime, dependencies) {
             }
           });
         }
+        if (profile.managedInstallReissue) {
+          Object.defineProperty(args, managedInstallReissue, {
+            configurable: true,
+            value: async () => {
+              const currentStatus = runtime.status();
+              if (!currentStatus.available) {
+                throw new SessionAuthorityError(currentStatus.code, currentStatus.reason);
+              }
+              registry2.verifyOperation(operation);
+              const install = (dependencies.reissueInstallBinding ?? reissueInstallBinding)(currentStatus.bindings.install);
+              if (!install)
+                return;
+              operation = registry2.replaceBindingsDuringOperation(operation, {
+                bindings: { install }
+              });
+              const reissuedStatus = runtime.status();
+              if (!reissuedStatus.available) {
+                throw new SessionAuthorityError(reissuedStatus.code, reissuedStatus.reason);
+              }
+              status = reissuedStatus;
+              installReceiptReissued = true;
+            }
+          });
+        }
         if (profile.managedRunnerPark) {
           Object.defineProperty(args, managedRunnerPark, {
             configurable: true,
@@ -27506,6 +27764,8 @@ function createAuthorityGate(runtime, dependencies) {
           if ((runtimeTargetChanged || managedRuntimeTargetChanged) && observation.axis === "B") {
             continue;
           }
+          if (installReceiptReissued && observation.axis === "I")
+            continue;
           if (!postflightAxes.includes(observation.axis))
             continue;
           const postflight = after.find((candidate) => candidate.axis === observation.axis);
@@ -27572,16 +27832,18 @@ function createAuthorityGate(runtime, dependencies) {
     }
   };
 }
-var optionalBundleAdmission, managedNativeOrigin, managedRunnerPark, axisBinding, axisErrors;
+var optionalBundleAdmission, managedNativeOrigin, managedRunnerPark, managedInstallReissue, axisBinding, axisErrors;
 var init_authority_gate = __esm({
   "packages/rn-dev-agent-core/dist/session/authority-gate.js"() {
     "use strict";
     init_utils();
     init_registry();
+    init_install_reissue();
     init_tool_profiles();
     optionalBundleAdmission = /* @__PURE__ */ Symbol("optionalBundleAdmission");
     managedNativeOrigin = /* @__PURE__ */ Symbol("managedNativeOrigin");
     managedRunnerPark = /* @__PURE__ */ Symbol("managedRunnerPark");
+    managedInstallReissue = /* @__PURE__ */ Symbol("managedInstallReissue");
     axisBinding = {
       I: "install",
       M: "metro",
@@ -27607,9 +27869,9 @@ var init_authority_gate = __esm({
 // packages/rn-dev-agent-core/dist/tools/maestro-run.js
 import { execFile as execFileCb3 } from "node:child_process";
 import { promisify as promisify4 } from "node:util";
-import { existsSync as existsSync17, readFileSync as readFileSync18, writeFileSync as writeFileSync8 } from "node:fs";
+import { existsSync as existsSync17, readFileSync as readFileSync19, writeFileSync as writeFileSync8 } from "node:fs";
 import { tmpdir as tmpdir6 } from "node:os";
-import { join as join20, dirname as dirname10 } from "node:path";
+import { join as join21, dirname as dirname10 } from "node:path";
 async function runFlowParked(run, opts = {}) {
   const stale = opts.markCdpStale ?? markCdpStale;
   try {
@@ -27635,7 +27897,8 @@ function nestedMaestroAuthorityCallbacks(args) {
     claimNativeOrigin: () => claimManagedNativeOriginAuthority(args),
     completeNativeOrigin: (targetExpected) => completeManagedNativeOriginAuthority(args, targetExpected),
     relaunchManagedApp: () => relaunchManagedNativeOriginApp(args),
-    completeRunnerPark: () => completeManagedRunnerParkAuthority(args)
+    completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+    reissueInstallReceipt: hasManagedInstallReissueAuthority(args) ? () => reissueManagedInstallAuthority(args) : null
   };
 }
 function commandName(command) {
@@ -27775,7 +28038,7 @@ function createMaestroRunHandler(deps = {}) {
         return failResult(`Flow file not found: ${args.flowPath}`);
       }
       try {
-        rawYaml = readFileSync18(args.flowPath, "utf-8");
+        rawYaml = readFileSync19(args.flowPath, "utf-8");
       } catch (err) {
         return failResult(`Failed to read flow file: ${err.message}`);
       }
@@ -27791,7 +28054,7 @@ function createMaestroRunHandler(deps = {}) {
       const rawAppId = resolveAppId(args.appId, platform);
       headerAppId = resolveMaestroFlowAppId(rawAppId || void 0, parsed.appId);
       validatedContent = buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, parsed.commands);
-      flowFile = join20(tmpdir6(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      flowFile = join21(tmpdir6(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
       writeFileSync8(flowFile, validatedContent, "utf-8");
     } catch (err) {
       if (err instanceof MaestroValidationError) {
@@ -27805,10 +28068,19 @@ function createMaestroRunHandler(deps = {}) {
     }
     const timeout = args.timeoutMs ?? 12e4;
     const flowDeadline = now() + timeout;
-    const appFileResolution = resolveAppFileForClearState(platform, validatedContent, headerAppId, args.appFile);
+    const appFileResolution = resolveAppFileForClearState(platform, validatedContent, headerAppId, args.appFile, { deviceId: requestedDeviceId });
     if (!appFileResolution.ok) {
       return failResult(appFileResolution.error);
     }
+    const reinstallsApp = Boolean(appFileResolution.appFile) && flowUsesClearState(validatedContent);
+    const reissueInstallReceipt = args.reissueInstallReceipt ?? deps.reissueInstallReceipt ?? nestedMaestroAuthorityCallbacks(args).reissueInstallReceipt;
+    let installReceiptCommitted = false;
+    const commitReinstalledInstall = async () => {
+      if (!reinstallsApp || installReceiptCommitted || !reissueInstallReceipt)
+        return;
+      installReceiptCommitted = true;
+      await reissueInstallReceipt();
+    };
     const baseArgs = dispatch.buildArgs(platform, flowFile, appFileResolution.appFile, requestedDeviceId);
     const paramArgs = [];
     if (args.params) {
@@ -27851,6 +28123,7 @@ function createMaestroRunHandler(deps = {}) {
         deviceId: requestedDeviceId,
         completeRunnerPark: args.completeRunnerPark ?? managedAuthority.completeRunnerPark
       });
+      await commitReinstalledInstall();
       const stdout = stageResults.map((result) => result.stdout).join("\n");
       const stderr = stageResults.map((result) => result.stderr).join("\n");
       const output = combineRunnerOutput(stdout, stderr);
@@ -27908,6 +28181,7 @@ function createMaestroRunHandler(deps = {}) {
       const warnAug = augmentFailureWithDegradation(output, resolveFloorMs(process.env.RN_RUNTIME_DEGRADED_FLOOR_MS), baseWarnMsg, meta);
       return warnResult(warnAug.meta, warnAug.message);
     } catch (err) {
+      await commitReinstalledInstall();
       if (err instanceof SessionAuthorityError)
         throw err;
       const stageError = err instanceof MaestroStageExecutionError ? err.stageError : err;
@@ -28027,7 +28301,7 @@ var init_maestro_run = __esm({
 
 // packages/rn-dev-agent-core/dist/session/managed-automation.js
 import { spawn as spawn5 } from "node:child_process";
-import { readdirSync as readdirSync6, readFileSync as readFileSync19, unlinkSync as unlinkSync5 } from "node:fs";
+import { readdirSync as readdirSync7, readFileSync as readFileSync20, unlinkSync as unlinkSync5 } from "node:fs";
 function sleep2(ms) {
   return new Promise((resolve11) => setTimeout(resolve11, ms));
 }
@@ -28044,12 +28318,12 @@ function processGroupLiveness(pgid) {
   if (process.platform !== "linux")
     return "unknown";
   try {
-    for (const entry of readdirSync6("/proc", { withFileTypes: true })) {
+    for (const entry of readdirSync7("/proc", { withFileTypes: true })) {
       if (!entry.isDirectory() || !/^\d+$/.test(entry.name))
         continue;
       let stat2;
       try {
-        stat2 = readFileSync19(`/proc/${entry.name}/stat`, "utf8");
+        stat2 = readFileSync20(`/proc/${entry.name}/stat`, "utf8");
       } catch (error2) {
         if (error2.code === "ENOENT")
           continue;
@@ -28660,7 +28934,7 @@ var init_device_arbiter = __esm({
 
 // packages/rn-dev-agent-core/dist/maestro-invoke.js
 import { existsSync as existsSync18, writeFileSync as writeFileSync9 } from "node:fs";
-import { join as join21 } from "node:path";
+import { join as join22 } from "node:path";
 import { homedir as homedir5, tmpdir as tmpdir7 } from "node:os";
 function yamlEscape(s) {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t");
@@ -28678,7 +28952,7 @@ function maestroRefusalResult(result, fallbackMessage, meta) {
   });
 }
 function getMaestroRunnerPath() {
-  const path = join21(homedir5(), ".maestro-runner", "bin", "maestro-runner");
+  const path = join22(homedir5(), ".maestro-runner", "bin", "maestro-runner");
   return existsSync18(path) ? path : null;
 }
 async function runMaestroInline(yaml2, opts, dependencies = {}) {
@@ -28689,7 +28963,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     return { passed: false, output: "", flowFile: "", error: dispatch.error };
   }
   const rawAppId = opts.appId ?? resolveBundleId(opts.platform) ?? readExpoSlug() ?? "";
-  const flowFile = join21(tmpdir7(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+  const flowFile = join22(tmpdir7(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
   let content;
   let headerAppId;
   try {
@@ -29051,7 +29325,7 @@ var init_app_lifecycle = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/cdp/discovery.js
-import { execFileSync as execFileSync10 } from "node:child_process";
+import { execFileSync as execFileSync11 } from "node:child_process";
 function resolveDefaultPorts() {
   const override = process.env.RN_CDP_DISCOVERY_PORTS;
   if (override !== void 0) {
@@ -29151,7 +29425,7 @@ function cachedPackageProbe(key, probe, clock = Date.now) {
 }
 function probeAndroidPackages() {
   try {
-    const out = execFileSync10("adb", ["shell", "pm", "list", "packages"], {
+    const out = execFileSync11("adb", ["shell", "pm", "list", "packages"], {
       timeout: 3e3,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"]
@@ -29163,7 +29437,7 @@ function probeAndroidPackages() {
 }
 function bootedSimulatorUdids() {
   try {
-    const out = execFileSync10("xcrun", ["simctl", "list", "devices", "booted", "-j"], {
+    const out = execFileSync11("xcrun", ["simctl", "list", "devices", "booted", "-j"], {
       timeout: 5e3,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"]
@@ -29182,7 +29456,7 @@ function probeIOSPackages() {
   let probed = false;
   for (const udid of udids) {
     try {
-      const out = execFileSync10("xcrun", ["simctl", "listapps", udid], {
+      const out = execFileSync11("xcrun", ["simctl", "listapps", udid], {
         timeout: 5e3,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"]
@@ -29507,10 +29781,10 @@ var init_discovery = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js
-import { execFileSync as execFileSync11 } from "node:child_process";
-import { existsSync as existsSync19, readFileSync as readFileSync20, unlinkSync as unlinkSync6 } from "node:fs";
+import { execFileSync as execFileSync12 } from "node:child_process";
+import { existsSync as existsSync19, readFileSync as readFileSync21, unlinkSync as unlinkSync6 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
-import { join as join22 } from "node:path";
+import { join as join23 } from "node:path";
 function selectInstalledLegacyApps(installed) {
   return LEGACY_BUNDLE_IDS.filter((id) => installed.has(id));
 }
@@ -29565,7 +29839,7 @@ function defaultDeps() {
     // caller's try/catch, which records a warning. Swallowing it here and
     // returning '' made single-runner enforcement degrade to a silent no-op
     // with no operator signal — exactly when the machine is busy.
-    listProcesses: () => execFileSync11("ps", ["-A", "-o", "pid=,args="], { encoding: "utf8", timeout: 3e3 }),
+    listProcesses: () => execFileSync12("ps", ["-A", "-o", "pid=,args="], { encoding: "utf8", timeout: 3e3 }),
     kill: (pid, signal) => process.kill(pid, signal),
     isAlive: (pid) => {
       try {
@@ -29577,7 +29851,7 @@ function defaultDeps() {
     },
     readDaemonPid: () => {
       try {
-        const parsed = JSON.parse(readFileSync20(DAEMON_JSON, "utf8"));
+        const parsed = JSON.parse(readFileSync21(DAEMON_JSON, "utf8"));
         return typeof parsed.pid === "number" ? parsed.pid : null;
       } catch {
         return null;
@@ -29586,13 +29860,13 @@ function defaultDeps() {
     fileExists: (path) => existsSync19(path),
     removeFile: (path) => unlinkSync6(path),
     delay: (ms) => new Promise((resolve11) => setTimeout(resolve11, ms)),
-    listApps: (udid) => execFileSync11("xcrun", ["simctl", "listapps", udid], {
+    listApps: (udid) => execFileSync12("xcrun", ["simctl", "listapps", udid], {
       encoding: "utf8",
       timeout: 5e3,
       stdio: ["ignore", "pipe", "ignore"]
     }),
     uninstallApp: (udid, bundleId) => {
-      execFileSync11("xcrun", ["simctl", "uninstall", udid, bundleId], {
+      execFileSync12("xcrun", ["simctl", "uninstall", udid, bundleId], {
         encoding: "utf8",
         timeout: 1e4,
         stdio: ["ignore", "pipe", "ignore"]
@@ -29666,8 +29940,8 @@ var init_ensure_single_runner = __esm({
   "packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js"() {
     "use strict";
     init_discovery();
-    DAEMON_JSON = join22(homedir6(), ".agent-device", "daemon.json");
-    DAEMON_LOCK = join22(homedir6(), ".agent-device", "daemon.lock");
+    DAEMON_JSON = join23(homedir6(), ".agent-device", "daemon.json");
+    DAEMON_LOCK = join23(homedir6(), ".agent-device", "daemon.lock");
     DAEMON_FILES = [DAEMON_JSON, DAEMON_LOCK];
     SIGKILL_GRACE_MS = 500;
     LEGACY_BUNDLE_IDS = [
@@ -29794,9 +30068,9 @@ var init_recover_detached = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/lifecycle/device-lock.js
-import { existsSync as existsSync20, mkdirSync as mkdirSync12, openSync as openSync8, writeSync as writeSync3, closeSync as closeSync8, readFileSync as readFileSync21, unlinkSync as unlinkSync7, writeFileSync as writeFileSync10 } from "node:fs";
+import { existsSync as existsSync20, mkdirSync as mkdirSync12, openSync as openSync8, writeSync as writeSync3, closeSync as closeSync8, readFileSync as readFileSync22, unlinkSync as unlinkSync7, writeFileSync as writeFileSync10 } from "node:fs";
 import { tmpdir as tmpdir8, userInfo as userInfo2 } from "node:os";
-import { join as join23 } from "node:path";
+import { join as join24 } from "node:path";
 function defaultProcessAlive3(pid) {
   try {
     process.kill(pid, 0);
@@ -29849,7 +30123,7 @@ var init_device_lock = __esm({
         this.clock = opts.clock ?? Date.now;
         this.processAlive = opts.processAlive ?? defaultProcessAlive3;
         this.staleMs = opts.staleMs ?? DEFAULT_STALE_MS2;
-        this.lockPath = join23(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
+        this.lockPath = join24(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
       }
       acquire() {
         try {
@@ -29930,7 +30204,7 @@ var init_device_lock = __esm({
       }
       readExisting() {
         try {
-          const parsed = JSON.parse(readFileSync21(this.lockPath, "utf8"));
+          const parsed = JSON.parse(readFileSync22(this.lockPath, "utf8"));
           if (!isValidBody(parsed))
             return null;
           if (parsed.deviceId !== this.deviceId || parsed.platform !== this.platform)
@@ -32273,7 +32547,7 @@ import { promisify as promisify13 } from "node:util";
 import { existsSync as existsSync21, rmSync as rmSync10, writeFileSync as writeFileSync11 } from "node:fs";
 import { tmpdir as tmpdir9 } from "node:os";
 import { randomBytes as randomBytes5, randomUUID as randomUUID6 } from "node:crypto";
-import { join as join24 } from "node:path";
+import { join as join25 } from "node:path";
 function getAndroidRunnerState() {
   return runnerState2;
 }
@@ -33419,7 +33693,7 @@ async function runAndroid(args) {
     const data = resp.data;
     if (!data?.pngBase64)
       return failResult("Android runner screenshot response did not include pngBase64", "SCREENSHOT_FAILED", recovery ? { transportRecovery: recovery } : void 0);
-    const outPath = args.outPath ?? join24(tmpdir9(), `rn-android-screenshot-${Date.now()}.png`);
+    const outPath = args.outPath ?? join25(tmpdir9(), `rn-android-screenshot-${Date.now()}.png`);
     writeFileSync11(outPath, Buffer.from(data.pngBase64, "base64"));
     return okResult({ path: outPath }, Object.keys(recoveryMeta).length ? { meta: recoveryMeta } : void 0);
   }
@@ -33454,11 +33728,11 @@ var init_rn_android_runner_client = __esm({
     HEALTH_POLL_INTERVAL_MS = 150;
     HEALTH_PROBE_TIMEOUT_MS = 1e3;
     RN_ANDROID_RUNNER_DIR = resolveNativeRunnerDir("rn-android-runner");
-    GRADLEW = join24(RN_ANDROID_RUNNER_DIR, "gradlew");
-    APK_APP = join24(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "debug", "app-debug.apk");
-    APK_TEST = join24(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "androidTest", "debug", "app-debug-androidTest.apk");
-    ANDROID_REBUILD_ROOT = join24(RN_ANDROID_RUNNER_DIR, "app", "build");
-    ANDROID_REBUILD_LOCK_DATABASE = join24(ANDROID_REBUILD_ROOT, ".authority-rebuild", "lock.sqlite");
+    GRADLEW = join25(RN_ANDROID_RUNNER_DIR, "gradlew");
+    APK_APP = join25(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "debug", "app-debug.apk");
+    APK_TEST = join25(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "androidTest", "debug", "app-debug-androidTest.apk");
+    ANDROID_REBUILD_ROOT = join25(RN_ANDROID_RUNNER_DIR, "app", "build");
+    ANDROID_REBUILD_LOCK_DATABASE = join25(ANDROID_REBUILD_ROOT, ".authority-rebuild", "lock.sqlite");
     ANDROID_REBUILD_LOCK_STALE_MS = 15 * 6e4;
     ANDROID_REBUILD_HEARTBEAT_MS = 6e4;
     ANDROID_REBUILD_COMPLETION_RETRY_MS = 1e3;
@@ -33504,9 +33778,9 @@ __export(release_android_slot_exports, {
 });
 import { execFile as execFileCb11 } from "node:child_process";
 import { promisify as promisify14 } from "node:util";
-import { existsSync as existsSync22, readFileSync as readFileSync22, unlinkSync as unlinkSync8 } from "node:fs";
+import { existsSync as existsSync22, readFileSync as readFileSync23, unlinkSync as unlinkSync8 } from "node:fs";
 import { homedir as homedir7 } from "node:os";
-import { join as join25 } from "node:path";
+import { join as join26 } from "node:path";
 function isProtectedPid(pid, selfPid, parentPid) {
   return pid === selfPid || pid === parentPid;
 }
@@ -33523,7 +33797,7 @@ function defaultDeps3() {
     resolveSerial: (deviceId) => deviceId ? ["-s", deviceId] : getAdbSerial(),
     readDaemonPid: () => {
       try {
-        const parsed = JSON.parse(readFileSync22(DAEMON_JSON2, "utf8"));
+        const parsed = JSON.parse(readFileSync23(DAEMON_JSON2, "utf8"));
         return typeof parsed.pid === "number" ? parsed.pid : null;
       } catch {
         return null;
@@ -33642,8 +33916,8 @@ var init_release_android_slot = __esm({
     init_rn_android_runner_client();
     init_agent_device_wrapper();
     execFile13 = promisify14(execFileCb11);
-    DAEMON_JSON2 = join25(homedir7(), ".agent-device", "daemon.json");
-    DAEMON_LOCK2 = join25(homedir7(), ".agent-device", "daemon.lock");
+    DAEMON_JSON2 = join26(homedir7(), ".agent-device", "daemon.json");
+    DAEMON_LOCK2 = join26(homedir7(), ".agent-device", "daemon.lock");
     DAEMON_FILES2 = [DAEMON_JSON2, DAEMON_LOCK2];
     SIGKILL_GRACE_MS2 = 500;
     ADB_TIMEOUT_MS = 5e3;
@@ -33975,8 +34249,8 @@ var init_process_cleanup = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/env-setup.js
-import { existsSync as existsSync23, readFileSync as readFileSync23 } from "node:fs";
-import { join as join28 } from "node:path";
+import { existsSync as existsSync23, readFileSync as readFileSync24 } from "node:fs";
+import { join as join29 } from "node:path";
 function ensureAndroidEnv() {
   if (!process.env.ANDROID_HOME) {
     if (process.env.ANDROID_SDK_ROOT) {
@@ -33984,8 +34258,8 @@ function ensureAndroidEnv() {
     } else {
       const home = process.env.HOME ?? "";
       const candidates = [
-        join28(home, "Library/Android/sdk"),
-        join28(home, "Android/Sdk"),
+        join29(home, "Library/Android/sdk"),
+        join29(home, "Android/Sdk"),
         "/opt/android-sdk"
       ];
       for (const c of candidates) {
@@ -33997,8 +34271,8 @@ function ensureAndroidEnv() {
     }
   }
   if (process.env.ANDROID_HOME) {
-    const pt = join28(process.env.ANDROID_HOME, "platform-tools");
-    const emu = join28(process.env.ANDROID_HOME, "emulator");
+    const pt = join29(process.env.ANDROID_HOME, "platform-tools");
+    const emu = join29(process.env.ANDROID_HOME, "emulator");
     const path = process.env.PATH ?? "";
     if (!path.includes(pt))
       process.env.PATH = `${pt}:${path}`;
@@ -34006,19 +34280,19 @@ function ensureAndroidEnv() {
       process.env.PATH = `${emu}:${process.env.PATH}`;
   }
   if (!process.env.ANDROID_SERIAL) {
-    const serialFile = join28(process.env.TMPDIR ?? "/tmp", "rn-dev-agent-android-serial");
+    const serialFile = join29(process.env.TMPDIR ?? "/tmp", "rn-dev-agent-android-serial");
     if (existsSync23(serialFile)) {
-      process.env.ANDROID_SERIAL = readFileSync23(serialFile, "utf8").trim();
+      process.env.ANDROID_SERIAL = readFileSync24(serialFile, "utf8").trim();
     }
   }
 }
 function ensureJavaEnv() {
   const path = process.env.PATH ?? "";
-  if (path.split(":").some((p) => existsSync23(join28(p, "java"))))
+  if (path.split(":").some((p) => existsSync23(join29(p, "java"))))
     return;
   const candidates = ["/opt/homebrew/opt/openjdk@17", "/opt/homebrew/opt/openjdk"];
   for (const jdk of candidates) {
-    if (existsSync23(join28(jdk, "bin/java"))) {
+    if (existsSync23(join29(jdk, "bin/java"))) {
       process.env.JAVA_HOME = jdk;
       process.env.PATH = `${jdk}/bin:${process.env.PATH}`;
       break;
@@ -59868,7 +60142,7 @@ var init_ws_origin = __esm({
 // packages/rn-dev-agent-core/dist/cdp/state.js
 import { writeFileSync as writeFileSync12, unlinkSync as unlinkSync9 } from "node:fs";
 import { tmpdir as tmpdir10 } from "node:os";
-import { join as join29 } from "node:path";
+import { join as join30 } from "node:path";
 function resetState(s) {
   s.setState("disconnected");
   s.setHelpersInjected(false);
@@ -59914,8 +60188,8 @@ var CDP_ACTIVE_FLAG, CDP_SESSION_FILE;
 var init_state = __esm({
   "packages/rn-dev-agent-core/dist/cdp/state.js"() {
     "use strict";
-    CDP_ACTIVE_FLAG = join29(tmpdir10(), "rn-dev-agent-cdp-active");
-    CDP_SESSION_FILE = join29(tmpdir10(), "rn-dev-agent-cdp-session.json");
+    CDP_ACTIVE_FLAG = join30(tmpdir10(), "rn-dev-agent-cdp-active");
+    CDP_SESSION_FILE = join30(tmpdir10(), "rn-dev-agent-cdp-session.json");
   }
 });
 
@@ -65560,8 +65834,8 @@ var init_mutation_absence = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/verification/config.js
-import { existsSync as existsSync24, readFileSync as readFileSync24 } from "node:fs";
-import { join as join30 } from "node:path";
+import { existsSync as existsSync24, readFileSync as readFileSync25 } from "node:fs";
+import { join as join31 } from "node:path";
 function getCachedProjectRoot() {
   if (_cachedProjectRoot === void 0) {
     _cachedProjectRoot = findProjectRoot();
@@ -65613,14 +65887,14 @@ function loadVerificationConfig(projectRoot) {
   const cached2 = cache2.get(projectRoot);
   if (cached2)
     return cached2;
-  const path = join30(projectRoot, ".rn-agent", "config.json");
+  const path = join31(projectRoot, ".rn-agent", "config.json");
   if (!existsSync24(path)) {
     cache2.set(projectRoot, DEFAULTS);
     return DEFAULTS;
   }
   let raw;
   try {
-    raw = JSON.parse(readFileSync24(path, "utf-8"));
+    raw = JSON.parse(readFileSync25(path, "utf-8"));
   } catch {
     cache2.set(projectRoot, DEFAULTS);
     return DEFAULTS;
@@ -66102,11 +66376,11 @@ var init_device_session_health = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/session/runtime-paths.js
-import { chmodSync as chmodSync3, lstatSync as lstatSync9, mkdirSync as mkdirSync13 } from "node:fs";
-import { join as join31, resolve as resolve7 } from "node:path";
+import { chmodSync as chmodSync3, lstatSync as lstatSync10, mkdirSync as mkdirSync13 } from "node:fs";
+import { join as join32, resolve as resolve7 } from "node:path";
 function privateDirectory(path) {
   mkdirSync13(path, { recursive: true, mode: 448 });
-  const stat2 = lstatSync9(path);
+  const stat2 = lstatSync10(path);
   if (stat2.isSymbolicLink() || !stat2.isDirectory()) {
     throw new Error("SESSION_RUNTIME_ROOT_UNSAFE: runtime root must be a real directory");
   }
@@ -66115,14 +66389,14 @@ function privateDirectory(path) {
 }
 function sessionRuntimeRoot(projectRoot) {
   const configured = process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT;
-  return configured ? privateDirectory(resolve7(configured)) : join31(resolve7(projectRoot), ".rn-agent");
+  return configured ? privateDirectory(resolve7(configured)) : join32(resolve7(projectRoot), ".rn-agent");
 }
 function sessionStateDirectory(projectRoot) {
-  const path = join31(sessionRuntimeRoot(projectRoot), "state");
+  const path = join32(sessionRuntimeRoot(projectRoot), "state");
   return process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT ? privateDirectory(path) : path;
 }
 function sessionRecordingsDirectory(projectRoot) {
-  const path = join31(sessionRuntimeRoot(projectRoot), "recordings");
+  const path = join32(sessionRuntimeRoot(projectRoot), "recordings");
   return process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT ? privateDirectory(path) : path;
 }
 var init_runtime_paths2 = __esm({
@@ -66133,8 +66407,8 @@ var init_runtime_paths2 = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/action-db.js
 import { createRequire as createRequire2 } from "node:module";
-import { existsSync as existsSync25, mkdirSync as mkdirSync14, readdirSync as readdirSync7, readFileSync as readFileSync25 } from "node:fs";
-import { dirname as dirname12, join as join32 } from "node:path";
+import { existsSync as existsSync25, mkdirSync as mkdirSync14, readdirSync as readdirSync8, readFileSync as readFileSync26 } from "node:fs";
+import { dirname as dirname12, join as join33 } from "node:path";
 function loadSqlite() {
   try {
     const mod = _require("node:sqlite");
@@ -66148,7 +66422,7 @@ function openActionDb(projectRoot, opts = {}) {
   if (!Ctor)
     return null;
   try {
-    const dbPath = join32(sessionStateDirectory(projectRoot), "actions.db");
+    const dbPath = join33(sessionStateDirectory(projectRoot), "actions.db");
     mkdirSync14(dirname12(dbPath), { recursive: true });
     const db = new Ctor(dbPath);
     db.exec(SCHEMA);
@@ -66291,11 +66565,11 @@ function openActionDb(projectRoot, opts = {}) {
         return row.cnt;
       },
       migrateSidecars() {
-        const stateDir = join32(projectRoot, ".rn-agent", "state");
+        const stateDir = join33(projectRoot, ".rn-agent", "state");
         if (!existsSync25(stateDir))
           return { migrated: 0 };
         let migrated = 0;
-        for (const f of readdirSync7(stateDir)) {
+        for (const f of readdirSync8(stateDir)) {
           if (!f.endsWith(".state.json"))
             continue;
           const id = f.replace(/\.state\.json$/, "");
@@ -66303,7 +66577,7 @@ function openActionDb(projectRoot, opts = {}) {
           if (exists)
             continue;
           try {
-            const parsed = JSON.parse(readFileSync25(join32(stateDir, f), "utf8"));
+            const parsed = JSON.parse(readFileSync26(join33(stateDir, f), "utf8"));
             if (parsed?.schemaVersion !== 1)
               continue;
             if (!Array.isArray(parsed.runHistory) || !Array.isArray(parsed.repairHistory)) {
@@ -66586,26 +66860,26 @@ var init_reusable_action = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/sidecar-io.js
-import { existsSync as existsSync26, readFileSync as readFileSync26, writeFileSync as writeFileSync13, mkdirSync as mkdirSync15, statSync as statSync9 } from "node:fs";
-import { join as join33, dirname as dirname13 } from "node:path";
+import { existsSync as existsSync26, readFileSync as readFileSync27, writeFileSync as writeFileSync13, mkdirSync as mkdirSync15, statSync as statSync10 } from "node:fs";
+import { join as join34, dirname as dirname13 } from "node:path";
 function sidecarPathFor(yamlFilePath) {
   const dir = dirname13(yamlFilePath);
   const parent = dirname13(dir);
   const filename = yamlFilePath.replace(/\.ya?ml$/i, ".state.json");
   const base = filename.split(/[\\/]/).pop();
-  const stateDirectory = process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT ? sessionStateDirectory(dirname13(parent)) : join33(parent, "state");
-  return join33(stateDirectory, base);
+  const stateDirectory = process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT ? sessionStateDirectory(dirname13(parent)) : join34(parent, "state");
+  return join34(stateDirectory, base);
 }
 function loadOrInitSidecar(yamlFilePath, now = () => /* @__PURE__ */ new Date()) {
   const path = sidecarPathFor(yamlFilePath);
   if (existsSync26(path)) {
     try {
-      const text = readFileSync26(path, "utf8");
+      const text = readFileSync27(path, "utf8");
       const parsed = JSON.parse(text);
       if (parsed && parsed.schemaVersion === 1 && typeof parsed.revision === "number" && typeof parsed.updatedAt === "string" && Array.isArray(parsed.runHistory) && Array.isArray(parsed.repairHistory) && typeof parsed.stats === "object") {
         if (typeof parsed.lastSeenMtimeMs !== "number") {
           try {
-            parsed.lastSeenMtimeMs = statSync9(yamlFilePath).mtimeMs;
+            parsed.lastSeenMtimeMs = statSync10(yamlFilePath).mtimeMs;
           } catch {
             parsed.lastSeenMtimeMs = 0;
           }
@@ -66617,7 +66891,7 @@ function loadOrInitSidecar(yamlFilePath, now = () => /* @__PURE__ */ new Date())
   }
   let mtimeMs = 0;
   try {
-    mtimeMs = statSync9(yamlFilePath).mtimeMs;
+    mtimeMs = statSync10(yamlFilePath).mtimeMs;
   } catch {
   }
   return freshRuntimeState(now, mtimeMs);
@@ -66632,7 +66906,7 @@ function saveSidecar(yamlFilePath, state) {
 }
 function yamlEditedSinceLastSeen(yamlFilePath, state) {
   try {
-    const current = statSync9(yamlFilePath).mtimeMs;
+    const current = statSync10(yamlFilePath).mtimeMs;
     return current > state.lastSeenMtimeMs;
   } catch {
     return false;
@@ -66718,19 +66992,19 @@ var init_action_state_store = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/session/migration-diagnostic.js
-import { createHash as createHash13 } from "node:crypto";
-import { existsSync as existsSync27, readFileSync as readFileSync27 } from "node:fs";
-import { join as join34 } from "node:path";
+import { createHash as createHash14 } from "node:crypto";
+import { existsSync as existsSync27, readFileSync as readFileSync28 } from "node:fs";
+import { join as join35 } from "node:path";
 function readPackageIntegrationManifest(appRoot, dependencies) {
-  const manifestPath = join34(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
+  const manifestPath = join35(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
   if (dependencies.exists || dependencies.readText) {
     const exists = dependencies.exists ?? existsSync27;
     if (!exists(manifestPath))
       return void 0;
-    const readText = dependencies.readText ?? ((path) => readFileSync27(path, "utf8"));
+    const readText = dependencies.readText ?? ((path) => readFileSync28(path, "utf8"));
     return readText(manifestPath);
   }
-  const agent = openBoundDirectory(join34(appRoot, ".rn-agent"));
+  const agent = openBoundDirectory(join35(appRoot, ".rn-agent"));
   let integration;
   let primaryError;
   try {
@@ -66767,7 +67041,7 @@ function inspectAuthorityMigration(status, dependencies = {}) {
   const integrationBinding = status.bindings.packageIntegration;
   let bindingDiagnostic = null;
   if (integrationBinding) {
-    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash13("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
+    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash14("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
     const manifestAvailable = manifestVerified(onDiskManifestText) || manifestVerified(integrationBinding.restoration?.phase === "started" ? integrationBinding.restoration.manifestSource : void 0) || manifestVerified(integrationBinding.installation?.phase === "started" ? integrationBinding.installation.manifestSource : void 0) || manifestVerified(integrationBinding.manifestSource);
     const effectiveOwnerSessionId = status.sessionId;
     const trustedDigestRecorded = typeof integrationBinding.manifestSha256 === "string" && /^[0-9a-f]{64}$/.test(integrationBinding.manifestSha256);
@@ -66983,191 +67257,6 @@ function verifyBuildReceipt(receipt2, capability, expected) {
 }
 var init_build_receipt = __esm({
   "packages/rn-dev-agent-core/dist/session/build-receipt.js"() {
-    "use strict";
-  }
-});
-
-// packages/rn-dev-agent-core/dist/session/install-authority.js
-import { execFileSync as execFileSync12 } from "node:child_process";
-import { createHash as createHash14 } from "node:crypto";
-import { lstatSync as lstatSync10, readFileSync as readFileSync28, readdirSync as readdirSync8, readlinkSync as readlinkSync3, realpathSync as realpathSync9, statSync as statSync10 } from "node:fs";
-import { isAbsolute as isAbsolute6, join as join35, relative as relative4 } from "node:path";
-function runText(command, args) {
-  return execFileSync12(command, [...args], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-    timeout: 1e4,
-    maxBuffer: 8 * 1024 * 1024
-  });
-}
-function runBuffer(command, args) {
-  return execFileSync12(command, [...args], {
-    encoding: "buffer",
-    stdio: ["ignore", "pipe", "ignore"],
-    timeout: 3e4,
-    maxBuffer: 512 * 1024 * 1024
-  });
-}
-function digest2(parts) {
-  const hash = createHash14("sha256");
-  for (const part of parts) {
-    hash.update(`${part.byteLength}:`);
-    hash.update(part);
-  }
-  return hash.digest("hex");
-}
-function generation(parts) {
-  return digest2(parts.map((part) => Buffer.from(part)));
-}
-function listAppFiles(appPath) {
-  const files = [];
-  const visit = (directory) => {
-    for (const entry of readdirSync8(directory, { withFileTypes: true })) {
-      const path = join35(directory, entry.name);
-      if (entry.isDirectory()) {
-        visit(path);
-      } else if (entry.isFile() || entry.isSymbolicLink()) {
-        files.push(relative4(appPath, path));
-      } else {
-        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
-      }
-    }
-  };
-  visit(appPath);
-  return files.sort();
-}
-function iosAppFiles(appPath, dependencies) {
-  return [...(dependencies.listAppFiles ?? listAppFiles)(appPath)].sort();
-}
-function assertIosSymlinkContained(appPath, path, realpath) {
-  const target = realpath(path);
-  const child = relative4(realpath(appPath), target);
-  if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute6(child)) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app symlink escapes the installed bundle");
-  }
-}
-function androidApkPaths(target, text) {
-  return text("adb", ["-s", target.deviceId, "shell", "pm", "path", target.appId]).split("\n").map((line) => line.trim()).filter((line) => line.startsWith("package:")).map((line) => line.slice("package:".length)).sort();
-}
-function captureInstallGeneration(target, dependencies = {}) {
-  const text = dependencies.runText ?? runText;
-  if (target.platform === "ios") {
-    const appPath = text("xcrun", [
-      "simctl",
-      "get_app_container",
-      target.deviceId,
-      target.appId,
-      "app"
-    ]).trim();
-    if (!appPath) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
-    }
-    const infoPath = join35(appPath, "Info.plist");
-    const executable = text("plutil", [
-      "-extract",
-      "CFBundleExecutable",
-      "raw",
-      "-o",
-      "-",
-      infoPath
-    ]).trim();
-    if (!executable) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
-    }
-    const stat2 = dependencies.stat ?? statSync10;
-    const metadata2 = iosAppFiles(appPath, dependencies).map((entry) => {
-      const path = join35(appPath, entry);
-      const value = stat2(path);
-      return `${entry}:${String(value.ino)}:${value.size}:${value.mtimeMs}`;
-    });
-    return generation(metadata2);
-  }
-  const apkPaths = androidApkPaths(target, text);
-  if (!apkPaths.length) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
-  }
-  const metadata = text("adb", [
-    "-s",
-    target.deviceId,
-    "shell",
-    "stat",
-    "-c",
-    "%n:%i:%s:%Y",
-    ...apkPaths
-  ]).split("\n").map((line) => line.trim()).filter(Boolean).sort();
-  if (metadata.length !== apkPaths.length) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: Android install generation is unavailable");
-  }
-  return generation(metadata);
-}
-function captureInstalledArtifact(target, dependencies = {}) {
-  const text = dependencies.runText ?? runText;
-  const buffer = dependencies.runBuffer ?? runBuffer;
-  const read = dependencies.read ?? readFileSync28;
-  if (target.platform === "ios") {
-    const appPath = text("xcrun", [
-      "simctl",
-      "get_app_container",
-      target.deviceId,
-      target.appId,
-      "app"
-    ]).trim();
-    if (!appPath) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
-    }
-    const infoPath = join35(appPath, "Info.plist");
-    const executable = text("plutil", [
-      "-extract",
-      "CFBundleExecutable",
-      "raw",
-      "-o",
-      "-",
-      infoPath
-    ]).trim();
-    if (!executable) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
-    }
-    const files = iosAppFiles(appPath, dependencies);
-    const lstat = dependencies.lstat ?? lstatSync10;
-    const readLink = dependencies.readLink ?? readlinkSync3;
-    const realpath = dependencies.realpath ?? realpathSync9;
-    const artifactParts = [];
-    for (const entry of files) {
-      const path = join35(appPath, entry);
-      const stat2 = lstat(path);
-      artifactParts.push(Buffer.from(entry));
-      if (stat2.isFile()) {
-        artifactParts.push(Buffer.from("file"), read(path));
-      } else if (stat2.isSymbolicLink()) {
-        assertIosSymlinkContained(appPath, path, realpath);
-        artifactParts.push(Buffer.from("symlink"), Buffer.from(readLink(path)));
-      } else {
-        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
-      }
-    }
-    return {
-      ...target,
-      artifactDigest: digest2(artifactParts),
-      installGeneration: captureInstallGeneration(target, dependencies)
-    };
-  }
-  const apkPaths = androidApkPaths(target, text);
-  if (!apkPaths.length) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
-  }
-  return {
-    ...target,
-    artifactDigest: digest2(apkPaths.map((path) => buffer("adb", ["-s", target.deviceId, "exec-out", "cat", path]))),
-    installGeneration: captureInstallGeneration(target, dependencies)
-  };
-}
-function verifyInstalledArtifact(expected, observed) {
-  if (expected.platform !== observed.platform || expected.deviceId !== observed.deviceId || expected.appId !== observed.appId || expected.artifactDigest !== observed.artifactDigest || expected.installGeneration !== observed.installGeneration) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: installed artifact no longer matches the session build");
-  }
-}
-var init_install_authority = __esm({
-  "packages/rn-dev-agent-core/dist/session/install-authority.js"() {
     "use strict";
   }
 });
@@ -73215,7 +73304,172 @@ var init_blind_probe_gate = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/session/runtime.js
+function unavailable(reason, fallbackCode) {
+  const matched = /^([A-Z][A-Z0-9_]+):/.exec(reason);
+  return new WorkerAuthorityRuntime(null, null, {
+    code: matched?.[1] ?? fallbackCode,
+    reason
+  });
+}
+function createWorkerAuthorityRuntime(environment = process.env, dependencies = {}) {
+  if (environment.RN_DEV_AGENT_AUTHORITY_ERROR) {
+    return unavailable(environment.RN_DEV_AGENT_AUTHORITY_ERROR, "AUTHORITY_STORE_UNAVAILABLE");
+  }
+  const sessionId = environment.RN_DEV_AGENT_SESSION_ID;
+  const claimEpoch = Number(environment.RN_DEV_AGENT_CLAIM_EPOCH);
+  const registryPath = environment.RN_DEV_AGENT_REGISTRY_PATH;
+  const workerInstance = environment.RN_DEV_AGENT_WORKER_INSTANCE;
+  if (!sessionId || !Number.isSafeInteger(claimEpoch) || claimEpoch < 1 || !registryPath || !workerInstance) {
+    return unavailable("SESSION_NOT_INITIALIZED: supervisor did not provide a complete authority context", "SESSION_NOT_INITIALIZED");
+  }
+  const birth = (dependencies.readBirth ?? readProcessBirth)(process.pid);
+  if (!birth) {
+    return unavailable("PROCESS_BIRTH_UNAVAILABLE: worker process birth could not be proven conservatively", "PROCESS_BIRTH_UNAVAILABLE");
+  }
+  try {
+    const registry2 = openSessionRegistry(registryPath, {
+      ownerStatus: dependencies.ownerStatus ?? inspectSessionOwner
+    });
+    const session2 = { sessionId, claimEpoch };
+    const status = registry2.getSessionStatus(sessionId);
+    const recoveryOnly = status?.state === "blocked" || status?.state === "handoff_cleanup";
+    let recoveryCapability = null;
+    if (recoveryOnly) {
+      const secretPath = environment.RN_DEV_AGENT_SESSION_SECRET_PATH;
+      recoveryCapability = secretPath ? readJsonStateFile(secretPath)?.recoveryCapability ?? null : null;
+      if (!recoveryCapability) {
+        throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "blocked recovery capability is unavailable");
+      }
+      registry2.bindRecoveryWorker(session2, { instanceId: workerInstance, pid: birth.pid, token: birth.token }, recoveryCapability);
+    } else {
+      registry2.bindWorker(session2, {
+        instanceId: workerInstance,
+        pid: birth.pid,
+        token: birth.token
+      });
+    }
+    return new WorkerAuthorityRuntime(registry2, session2, null, recoveryOnly, recoveryCapability);
+  } catch (error2) {
+    return unavailable(error2 instanceof Error ? error2.message : "AUTHORITY_STORE_UNAVAILABLE: worker authority could not be opened", "AUTHORITY_STORE_UNAVAILABLE");
+  }
+}
+function getWorkerAuthorityRuntime() {
+  sharedRuntime ??= createWorkerAuthorityRuntime();
+  return sharedRuntime;
+}
+var WorkerAuthorityRuntime, sharedRuntime;
+var init_runtime = __esm({
+  "packages/rn-dev-agent-core/dist/session/runtime.js"() {
+    "use strict";
+    init_process_birth();
+    init_process_owner();
+    init_registry();
+    init_secure_state_file();
+    WorkerAuthorityRuntime = class {
+      available;
+      #registry;
+      #session;
+      #unavailable;
+      #recoveryOnly;
+      #recoveryCapability;
+      constructor(registry2, session2, unavailable2, recoveryOnly = false, recoveryCapability = null) {
+        this.#registry = registry2;
+        this.#session = session2;
+        this.#unavailable = unavailable2;
+        this.available = registry2 !== null && session2 !== null;
+        this.#recoveryOnly = recoveryOnly;
+        this.#recoveryCapability = recoveryCapability;
+      }
+      requireAvailable() {
+        if (!this.#registry || !this.#session) {
+          throw new SessionAuthorityError(this.#unavailable?.code ?? "SESSION_NOT_INITIALIZED", this.#unavailable?.reason ?? "authority session is unavailable");
+        }
+        return { registry: this.#registry, session: this.#session };
+      }
+      requireOperational() {
+        const available = this.requireAvailable();
+        const status = this.status();
+        if (status.available && (status.state === "blocked" || status.state === "handoff_cleanup")) {
+          throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "blocked contender exposes only accept_handoff and adopt_stale recovery");
+        }
+        return available;
+      }
+      requireRecovery() {
+        const available = this.requireAvailable();
+        const status = this.status();
+        if (!this.#recoveryOnly || !status.available || status.state !== "blocked" && status.state !== "handoff_cleanup") {
+          throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "session is not a capability-bound recovery contender");
+        }
+        return available;
+      }
+      /**
+       * GH #672: rotate an expired recovery handle before it is advertised. Best-effort by
+       * design — a refresh failure must degrade `status` to an honest expired handle, never
+       * turn a diagnostic call into an authority error.
+       */
+      refreshRecoveryHandles() {
+        if (!this.#registry || !this.#session || !this.#recoveryOnly || !this.#recoveryCapability) {
+          return false;
+        }
+        try {
+          const status = this.#registry.getSessionStatus(this.#session.sessionId);
+          const instanceId = status?.worker.instanceId;
+          if (!status || !instanceId || status.state !== "blocked" && status.state !== "handoff_cleanup") {
+            return false;
+          }
+          return this.#registry.refreshRecoveryHandles(this.#session, { instanceId }, this.#recoveryCapability);
+        } catch {
+          return false;
+        }
+      }
+      inspectRecoveryRequirement() {
+        if (!this.#registry || !this.#session)
+          return void 0;
+        try {
+          return this.#registry.inspectRecoveryRequirement(this.#session.sessionId);
+        } catch {
+          return void 0;
+        }
+      }
+      status() {
+        if (!this.#registry || !this.#session) {
+          return {
+            available: false,
+            code: this.#unavailable?.code ?? "SESSION_NOT_INITIALIZED",
+            reason: this.#unavailable?.reason ?? "authority session is unavailable"
+          };
+        }
+        const status = this.#registry.getSessionStatus(this.#session.sessionId);
+        if (!status) {
+          return {
+            available: false,
+            code: "SESSION_OWNER_LOST",
+            reason: "session is no longer present in the authority registry"
+          };
+        }
+        return { available: true, ...status };
+      }
+      close() {
+        this.#registry?.close();
+      }
+    };
+    sharedRuntime = null;
+  }
+});
+
 // packages/rn-dev-agent-core/dist/tools/run-action.js
+function boundInstallReceipt() {
+  try {
+    const status = getWorkerAuthorityRuntime().status();
+    if (!status.available)
+      return null;
+    const install = status.bindings.install;
+    return install ?? null;
+  } catch {
+    return null;
+  }
+}
 function classifyFailure(failure) {
   switch (failure.kind) {
     case "SELECTOR_NOT_FOUND":
@@ -73352,6 +73606,9 @@ function createRunActionHandler(deps = {}) {
   const claimNativeOrigin = deps.claimNativeOrigin ?? claimManagedNativeOriginAuthority;
   const completeNativeOrigin = deps.completeNativeOrigin ?? completeManagedNativeOriginAuthority;
   const relaunchManagedApp = deps.relaunchManagedApp ?? relaunchManagedNativeOriginApp;
+  const reissueInstallReceipt = deps.reissueInstallReceipt ?? reissueManagedInstallAuthority;
+  const installReceipt = deps.installReceipt ?? boundInstallReceipt;
+  const resolveAppFile = deps.resolveAppFile ?? ((appId, deviceId) => resolveIosAppFile(appId, { deviceId }));
   return async (args) => {
     if (!args.actionId || typeof args.actionId !== "string") {
       return failResult("cdp_run_action requires actionId", "BAD_FILENAME");
@@ -73382,6 +73639,8 @@ function createRunActionHandler(deps = {}) {
       return failResult(`cdp_run_action: requested ${args.platform}, but the active session is ${activeTarget.platform}; refusing cross-platform replay.`, "TARGET_SESSION_MISMATCH", { requestedPlatform: args.platform, activeSession: activeTarget });
     }
     const maestroDeviceId = (!args.platform || activeTarget?.platform === args.platform) && activeTarget?.deviceId ? activeTarget.deviceId : void 0;
+    const receipt2 = args.appFile ? null : installReceipt();
+    const appFile = args.appFile ?? (flowUsesClearState(action.body) && receipt2?.platform === "ios" && typeof receipt2.appId === "string" && typeof receipt2.deviceId === "string" ? resolveAppFile(receipt2.appId, receipt2.deviceId) ?? void 0 : void 0);
     let probeDeviceId = null;
     let observedDeviceId = maestroDeviceId ?? null;
     const persistRunWithDevice = (record2) => proofReplay ? Promise.resolve({ promoted: false, promotionRefused: false }) : persistRun(args.actionId, projectRoot, probeDeviceId ? { ...record2, deviceId: probeDeviceId } : record2);
@@ -73478,13 +73737,15 @@ function createRunActionHandler(deps = {}) {
         flowPath: action.filePath,
         platform: args.platform,
         appId: args.appId,
+        ...appFile ? { appFile } : {},
         deviceId: maestroDeviceId,
         timeoutMs,
         params: args.params,
         claimNativeOrigin: () => claimNativeOrigin(args),
         completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
         relaunchManagedApp: () => relaunchManagedApp(args),
-        completeRunnerPark: () => completeManagedRunnerParkAuthority(args)
+        completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+        reissueInstallReceipt: () => reissueInstallReceipt(args)
       });
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, "maestro_run");
@@ -73758,13 +74019,15 @@ function createRunActionHandler(deps = {}) {
         flowPath: reloadedAction.filePath,
         platform: args.platform,
         appId: args.appId,
+        ...appFile ? { appFile } : {},
         deviceId: maestroDeviceId,
         timeoutMs,
         params: args.params,
         claimNativeOrigin: () => claimNativeOrigin(args),
         completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
         relaunchManagedApp: () => relaunchManagedApp(args),
-        completeRunnerPark: () => completeManagedRunnerParkAuthority(args)
+        completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+        reissueInstallReceipt: () => reissueInstallReceipt(args)
       });
       const retryMs = Date.now() - tBeforeRetry;
       const retryEnv = parseEnvelope(retryResult, "maestro_run");
@@ -73932,6 +74195,8 @@ var init_run_action = __esm({
     init_cdp_flow_replay();
     init_blind_probe_gate();
     init_authority_gate();
+    init_runtime();
+    init_resolve_ios_app_file();
     OUTPUT_BUDGET = 500;
     OUTPUT_ELISION = "\n\u2026\n";
   }
@@ -75872,160 +76137,6 @@ var init_device_deeplink = __esm({
     init_authority_gate();
     execFile21 = promisify23(execFileCb18);
     EXEC_TIMEOUT_MS = 1e4;
-  }
-});
-
-// packages/rn-dev-agent-core/dist/session/runtime.js
-function unavailable(reason, fallbackCode) {
-  const matched = /^([A-Z][A-Z0-9_]+):/.exec(reason);
-  return new WorkerAuthorityRuntime(null, null, {
-    code: matched?.[1] ?? fallbackCode,
-    reason
-  });
-}
-function createWorkerAuthorityRuntime(environment = process.env, dependencies = {}) {
-  if (environment.RN_DEV_AGENT_AUTHORITY_ERROR) {
-    return unavailable(environment.RN_DEV_AGENT_AUTHORITY_ERROR, "AUTHORITY_STORE_UNAVAILABLE");
-  }
-  const sessionId = environment.RN_DEV_AGENT_SESSION_ID;
-  const claimEpoch = Number(environment.RN_DEV_AGENT_CLAIM_EPOCH);
-  const registryPath = environment.RN_DEV_AGENT_REGISTRY_PATH;
-  const workerInstance = environment.RN_DEV_AGENT_WORKER_INSTANCE;
-  if (!sessionId || !Number.isSafeInteger(claimEpoch) || claimEpoch < 1 || !registryPath || !workerInstance) {
-    return unavailable("SESSION_NOT_INITIALIZED: supervisor did not provide a complete authority context", "SESSION_NOT_INITIALIZED");
-  }
-  const birth = (dependencies.readBirth ?? readProcessBirth)(process.pid);
-  if (!birth) {
-    return unavailable("PROCESS_BIRTH_UNAVAILABLE: worker process birth could not be proven conservatively", "PROCESS_BIRTH_UNAVAILABLE");
-  }
-  try {
-    const registry2 = openSessionRegistry(registryPath, {
-      ownerStatus: dependencies.ownerStatus ?? inspectSessionOwner
-    });
-    const session2 = { sessionId, claimEpoch };
-    const status = registry2.getSessionStatus(sessionId);
-    const recoveryOnly = status?.state === "blocked" || status?.state === "handoff_cleanup";
-    let recoveryCapability = null;
-    if (recoveryOnly) {
-      const secretPath = environment.RN_DEV_AGENT_SESSION_SECRET_PATH;
-      recoveryCapability = secretPath ? readJsonStateFile(secretPath)?.recoveryCapability ?? null : null;
-      if (!recoveryCapability) {
-        throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "blocked recovery capability is unavailable");
-      }
-      registry2.bindRecoveryWorker(session2, { instanceId: workerInstance, pid: birth.pid, token: birth.token }, recoveryCapability);
-    } else {
-      registry2.bindWorker(session2, {
-        instanceId: workerInstance,
-        pid: birth.pid,
-        token: birth.token
-      });
-    }
-    return new WorkerAuthorityRuntime(registry2, session2, null, recoveryOnly, recoveryCapability);
-  } catch (error2) {
-    return unavailable(error2 instanceof Error ? error2.message : "AUTHORITY_STORE_UNAVAILABLE: worker authority could not be opened", "AUTHORITY_STORE_UNAVAILABLE");
-  }
-}
-function getWorkerAuthorityRuntime() {
-  sharedRuntime ??= createWorkerAuthorityRuntime();
-  return sharedRuntime;
-}
-var WorkerAuthorityRuntime, sharedRuntime;
-var init_runtime = __esm({
-  "packages/rn-dev-agent-core/dist/session/runtime.js"() {
-    "use strict";
-    init_process_birth();
-    init_process_owner();
-    init_registry();
-    init_secure_state_file();
-    WorkerAuthorityRuntime = class {
-      available;
-      #registry;
-      #session;
-      #unavailable;
-      #recoveryOnly;
-      #recoveryCapability;
-      constructor(registry2, session2, unavailable2, recoveryOnly = false, recoveryCapability = null) {
-        this.#registry = registry2;
-        this.#session = session2;
-        this.#unavailable = unavailable2;
-        this.available = registry2 !== null && session2 !== null;
-        this.#recoveryOnly = recoveryOnly;
-        this.#recoveryCapability = recoveryCapability;
-      }
-      requireAvailable() {
-        if (!this.#registry || !this.#session) {
-          throw new SessionAuthorityError(this.#unavailable?.code ?? "SESSION_NOT_INITIALIZED", this.#unavailable?.reason ?? "authority session is unavailable");
-        }
-        return { registry: this.#registry, session: this.#session };
-      }
-      requireOperational() {
-        const available = this.requireAvailable();
-        const status = this.status();
-        if (status.available && (status.state === "blocked" || status.state === "handoff_cleanup")) {
-          throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "blocked contender exposes only accept_handoff and adopt_stale recovery");
-        }
-        return available;
-      }
-      requireRecovery() {
-        const available = this.requireAvailable();
-        const status = this.status();
-        if (!this.#recoveryOnly || !status.available || status.state !== "blocked" && status.state !== "handoff_cleanup") {
-          throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "session is not a capability-bound recovery contender");
-        }
-        return available;
-      }
-      /**
-       * GH #672: rotate an expired recovery handle before it is advertised. Best-effort by
-       * design — a refresh failure must degrade `status` to an honest expired handle, never
-       * turn a diagnostic call into an authority error.
-       */
-      refreshRecoveryHandles() {
-        if (!this.#registry || !this.#session || !this.#recoveryOnly || !this.#recoveryCapability) {
-          return false;
-        }
-        try {
-          const status = this.#registry.getSessionStatus(this.#session.sessionId);
-          const instanceId = status?.worker.instanceId;
-          if (!status || !instanceId || status.state !== "blocked" && status.state !== "handoff_cleanup") {
-            return false;
-          }
-          return this.#registry.refreshRecoveryHandles(this.#session, { instanceId }, this.#recoveryCapability);
-        } catch {
-          return false;
-        }
-      }
-      inspectRecoveryRequirement() {
-        if (!this.#registry || !this.#session)
-          return void 0;
-        try {
-          return this.#registry.inspectRecoveryRequirement(this.#session.sessionId);
-        } catch {
-          return void 0;
-        }
-      }
-      status() {
-        if (!this.#registry || !this.#session) {
-          return {
-            available: false,
-            code: this.#unavailable?.code ?? "SESSION_NOT_INITIALIZED",
-            reason: this.#unavailable?.reason ?? "authority session is unavailable"
-          };
-        }
-        const status = this.#registry.getSessionStatus(this.#session.sessionId);
-        if (!status) {
-          return {
-            available: false,
-            code: "SESSION_OWNER_LOST",
-            reason: "session is no longer present in the authority registry"
-          };
-        }
-        return { available: true, ...status };
-      }
-      close() {
-        this.#registry?.close();
-      }
-    };
-    sharedRuntime = null;
   }
 });
 
@@ -85965,6 +86076,7 @@ var init_index = __esm({
         actionId: external_exports.string().describe("Action id matching <projectRoot>/.rn-agent/actions/<actionId>.yaml."),
         projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
         platform: external_exports.enum(["ios", "android"]).optional().describe("Force a specific platform; otherwise auto-detected from the active device session."),
+        appFile: external_exports.string().optional().describe("GH #705: path to the .app Maestro reinstalls from after a clearState uninstall. Normally omit it \u2014 an iOS clearState flow resolves the bundle from the session's attested install receipt, and the receipt is re-issued after the reinstall so later device_*/maestro_run calls keep working."),
         autoRepair: external_exports.boolean().optional().describe("Auto-repair on SELECTOR_NOT_FOUND failures. Default true. Pass false to disable (e.g. when investigating a failure manually)."),
         timeoutMs: external_exports.number().optional().describe("Maestro execution timeout per attempt (ms). Default 120_000."),
         trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe('RunRecord trigger annotation. Default "agent". CI calls should pass "ci".'),
@@ -86230,8 +86342,8 @@ init_package_integration();
 init_process_cleanup();
 init_registry();
 init_state_root();
-import { createHash as createHash11 } from "node:crypto";
-import { join as join26 } from "node:path";
+import { createHash as createHash12 } from "node:crypto";
+import { join as join27 } from "node:path";
 function startupCleanupFailureMessage() {
   return "rn-dev-agent startup cleanup failed: STARTUP_CLEANUP_FAILED\n";
 }
@@ -86280,7 +86392,7 @@ async function runStartupCleanupForSource(input) {
       appRootKey: input.source.appRootKey,
       appRoot: input.source.appRoot
     }, {
-      readSessionSecret: (sessionId) => readJsonStateFile(join26(layout.sessions, sessionId, "secret.json"))
+      readSessionSecret: (sessionId) => readJsonStateFile(join27(layout.sessions, sessionId, "secret.json"))
     });
   } finally {
     registry2.close();
@@ -86337,7 +86449,7 @@ function restoreDeadOwnerIntegration(input, prior, plan, dependencies) {
 function verifiedDeadOwnerManifestSource(appRoot, binding, manifestSha256) {
   if (!/^[0-9a-f]{64}$/.test(manifestSha256))
     return void 0;
-  const verified = (candidate) => typeof candidate === "string" && createHash11("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
+  const verified = (candidate) => typeof candidate === "string" && createHash12("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
   let liveManifest;
   try {
     liveManifest = readPackageIntegrationInputs(appRoot).manifest ?? void 0;
@@ -86366,7 +86478,7 @@ init_process_cleanup();
 init_registry();
 init_managed_metro();
 init_state_root();
-import { createHash as createHash12, randomBytes as randomBytes6, randomUUID as randomUUID7 } from "node:crypto";
+import { createHash as createHash13, randomBytes as randomBytes6, randomUUID as randomUUID7 } from "node:crypto";
 var RELEASABLE_SESSION_STATES = /* @__PURE__ */ new Set([
   "active",
   "source_bound",
@@ -86486,7 +86598,7 @@ function createSupervisorAuthority(input, dependencies = {}) {
       metroPort,
       observePort,
       ...adoptionRequired ? {
-        recoveryCapabilityHash: createHash12("sha256").update(recoveryCapability).digest("hex"),
+        recoveryCapabilityHash: createHash13("sha256").update(recoveryCapability).digest("hex"),
         adoptionRequired: {
           sessionId: adoptionRequired.sessionId,
           claimEpoch: adoptionRequired.claimEpoch
@@ -86596,7 +86708,7 @@ function createSupervisorAuthority(input, dependencies = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/supervisor-args.js
-import { dirname as dirname11, join as join27 } from "node:path";
+import { dirname as dirname11, join as join28 } from "node:path";
 function sqliteFlagForNode(version2) {
   const v = version2 ?? process.versions.node;
   const [majorStr, minorStr] = v.split(".");
@@ -86622,7 +86734,7 @@ function workerSpawnArgs(workerPath, sqliteWarningFilterPath2, version2, forward
     "--import",
     sqliteWarningFilterPath2,
     "--import",
-    join27(dirname11(sqliteWarningFilterPath2), "startup-integrity-register.js"),
+    join28(dirname11(sqliteWarningFilterPath2), "startup-integrity-register.js"),
     workerPath,
     "--no-lock",
     ...diagnosticArgs

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -29652,7 +29652,7 @@ function authorityProfileFor(tool, args = {}) {
       postflightAxes: facetsOf(throughRuntime, { without: ["A", "B"] }),
       managedOrigin: true,
       managedRunnerPark: true,
-      managedInstallReissue: true,
+      managedInstallReissue: tool === "maestro_run",
       mutation: true,
       liveBundleProbe: false
     };

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -28643,7 +28643,7 @@ function resolveIosAppFile(bundleId, deps = {}) {
   const exists = deps.exists ?? existsSync13;
   const getAppContainer = deps.getAppContainer ?? defaultGetAppContainer;
   const snapshotApp = deps.snapshotApp ?? defaultSnapshotApp;
-  const fromContainer = getAppContainer(bundleId);
+  const fromContainer = getAppContainer(bundleId, deps.deviceId);
   if (fromContainer && exists(fromContainer)) {
     const snapshot = snapshotApp(fromContainer);
     if (snapshot)
@@ -28674,9 +28674,10 @@ function resolveAppFileForClearState(platform, flowText, headerAppId, explicitAp
   }
   return { ok: true, appFile };
 }
-function defaultGetAppContainer(bundleId) {
+function defaultGetAppContainer(bundleId, deviceId) {
   try {
-    const out = execFileSync6("xcrun", ["simctl", "get_app_container", "booted", bundleId, "app"], {
+    const target = deviceId && !/\s/.test(deviceId) ? deviceId : "booted";
+    const out = execFileSync6("xcrun", ["simctl", "get_app_container", target, bundleId, "app"], {
       encoding: "utf8",
       timeout: 5e3
     }).trim();
@@ -29342,6 +29343,226 @@ var init_maestro_runner_report = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/session/install-authority.js
+import { execFileSync as execFileSync7 } from "node:child_process";
+import { createHash as createHash7 } from "node:crypto";
+import { lstatSync as lstatSync5, readFileSync as readFileSync13, readdirSync as readdirSync5, readlinkSync as readlinkSync2, realpathSync as realpathSync4, statSync as statSync6 } from "node:fs";
+import { isAbsolute as isAbsolute3, join as join19, relative } from "node:path";
+function runText(command, args) {
+  return execFileSync7(command, [...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 1e4,
+    maxBuffer: 8 * 1024 * 1024
+  });
+}
+function runBuffer(command, args) {
+  return execFileSync7(command, [...args], {
+    encoding: "buffer",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 3e4,
+    maxBuffer: 512 * 1024 * 1024
+  });
+}
+function digest(parts) {
+  const hash = createHash7("sha256");
+  for (const part of parts) {
+    hash.update(`${part.byteLength}:`);
+    hash.update(part);
+  }
+  return hash.digest("hex");
+}
+function generation(parts) {
+  return digest(parts.map((part) => Buffer.from(part)));
+}
+function listAppFiles(appPath) {
+  const files = [];
+  const visit = (directory) => {
+    for (const entry of readdirSync5(directory, { withFileTypes: true })) {
+      const path = join19(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(path);
+      } else if (entry.isFile() || entry.isSymbolicLink()) {
+        files.push(relative(appPath, path));
+      } else {
+        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
+      }
+    }
+  };
+  visit(appPath);
+  return files.sort();
+}
+function iosAppFiles(appPath, dependencies) {
+  return [...(dependencies.listAppFiles ?? listAppFiles)(appPath)].sort();
+}
+function assertIosSymlinkContained(appPath, path, realpath) {
+  const target = realpath(path);
+  const child = relative(realpath(appPath), target);
+  if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute3(child)) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app symlink escapes the installed bundle");
+  }
+}
+function androidApkPaths(target, text) {
+  return text("adb", ["-s", target.deviceId, "shell", "pm", "path", target.appId]).split("\n").map((line) => line.trim()).filter((line) => line.startsWith("package:")).map((line) => line.slice("package:".length)).sort();
+}
+function captureInstallGeneration(target, dependencies = {}) {
+  const text = dependencies.runText ?? runText;
+  if (target.platform === "ios") {
+    const appPath = text("xcrun", [
+      "simctl",
+      "get_app_container",
+      target.deviceId,
+      target.appId,
+      "app"
+    ]).trim();
+    if (!appPath) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
+    }
+    const infoPath = join19(appPath, "Info.plist");
+    const executable = text("plutil", [
+      "-extract",
+      "CFBundleExecutable",
+      "raw",
+      "-o",
+      "-",
+      infoPath
+    ]).trim();
+    if (!executable) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
+    }
+    const stat2 = dependencies.stat ?? statSync6;
+    const metadata2 = iosAppFiles(appPath, dependencies).map((entry) => {
+      const path = join19(appPath, entry);
+      const value = stat2(path);
+      return `${entry}:${String(value.ino)}:${value.size}:${value.mtimeMs}`;
+    });
+    return generation(metadata2);
+  }
+  const apkPaths = androidApkPaths(target, text);
+  if (!apkPaths.length) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
+  }
+  const metadata = text("adb", [
+    "-s",
+    target.deviceId,
+    "shell",
+    "stat",
+    "-c",
+    "%n:%i:%s:%Y",
+    ...apkPaths
+  ]).split("\n").map((line) => line.trim()).filter(Boolean).sort();
+  if (metadata.length !== apkPaths.length) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: Android install generation is unavailable");
+  }
+  return generation(metadata);
+}
+function captureInstalledArtifact(target, dependencies = {}) {
+  const text = dependencies.runText ?? runText;
+  const buffer = dependencies.runBuffer ?? runBuffer;
+  const read = dependencies.read ?? readFileSync13;
+  if (target.platform === "ios") {
+    const appPath = text("xcrun", [
+      "simctl",
+      "get_app_container",
+      target.deviceId,
+      target.appId,
+      "app"
+    ]).trim();
+    if (!appPath) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
+    }
+    const infoPath = join19(appPath, "Info.plist");
+    const executable = text("plutil", [
+      "-extract",
+      "CFBundleExecutable",
+      "raw",
+      "-o",
+      "-",
+      infoPath
+    ]).trim();
+    if (!executable) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
+    }
+    const files = iosAppFiles(appPath, dependencies);
+    const lstat = dependencies.lstat ?? lstatSync5;
+    const readLink = dependencies.readLink ?? readlinkSync2;
+    const realpath = dependencies.realpath ?? realpathSync4;
+    const artifactParts = [];
+    for (const entry of files) {
+      const path = join19(appPath, entry);
+      const stat2 = lstat(path);
+      artifactParts.push(Buffer.from(entry));
+      if (stat2.isFile()) {
+        artifactParts.push(Buffer.from("file"), read(path));
+      } else if (stat2.isSymbolicLink()) {
+        assertIosSymlinkContained(appPath, path, realpath);
+        artifactParts.push(Buffer.from("symlink"), Buffer.from(readLink(path)));
+      } else {
+        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
+      }
+    }
+    return {
+      ...target,
+      artifactDigest: digest(artifactParts),
+      installGeneration: captureInstallGeneration(target, dependencies)
+    };
+  }
+  const apkPaths = androidApkPaths(target, text);
+  if (!apkPaths.length) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
+  }
+  return {
+    ...target,
+    artifactDigest: digest(apkPaths.map((path) => buffer("adb", ["-s", target.deviceId, "exec-out", "cat", path]))),
+    installGeneration: captureInstallGeneration(target, dependencies)
+  };
+}
+function verifyInstalledArtifact(expected, observed) {
+  if (expected.platform !== observed.platform || expected.deviceId !== observed.deviceId || expected.appId !== observed.appId || expected.artifactDigest !== observed.artifactDigest || expected.installGeneration !== observed.installGeneration) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: installed artifact no longer matches the session build");
+  }
+}
+var init_install_authority = __esm({
+  "packages/rn-dev-agent-core/dist/session/install-authority.js"() {
+    "use strict";
+  }
+});
+
+// packages/rn-dev-agent-core/dist/session/install-reissue.js
+function reissueInstallBinding(install, dependencies = {}) {
+  const platform = install?.platform;
+  const deviceId = install?.deviceId;
+  const appId = install?.appId;
+  const artifactDigest = install?.artifactDigest;
+  const installGeneration = install?.installGeneration;
+  if (platform !== "ios" && platform !== "android" || typeof deviceId !== "string" || typeof appId !== "string" || typeof artifactDigest !== "string" || typeof installGeneration !== "string") {
+    throw new SessionAuthorityError("APP_INSTALL_IDENTITY_CHANGED", "no attested install receipt is bound to re-issue after the reinstall");
+  }
+  let observed;
+  try {
+    observed = (dependencies.captureInstalled ?? captureInstalledArtifact)({
+      platform,
+      deviceId,
+      appId
+    });
+  } catch {
+    throw new SessionAuthorityError("APP_INSTALL_IDENTITY_CHANGED", "the reinstalled artifact could not be attested");
+  }
+  if (observed.artifactDigest !== artifactDigest) {
+    throw new SessionAuthorityError("APP_INSTALL_IDENTITY_CHANGED", "the reinstalled artifact is not the attested session build");
+  }
+  if (observed.installGeneration === installGeneration)
+    return null;
+  return { ...install, installGeneration: observed.installGeneration };
+}
+var init_install_reissue = __esm({
+  "packages/rn-dev-agent-core/dist/session/install-reissue.js"() {
+    "use strict";
+    init_install_authority();
+    init_registry();
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -29431,6 +29652,7 @@ function authorityProfileFor(tool, args = {}) {
       postflightAxes: facetsOf(throughRuntime, { without: ["A", "B"] }),
       managedOrigin: true,
       managedRunnerPark: true,
+      managedInstallReissue: true,
       mutation: true,
       liveBundleProbe: false
     };
@@ -29616,6 +29838,7 @@ var init_tool_profiles = __esm({
       optionalAxes: ["B"],
       managedOrigin: true,
       managedRunnerPark: true,
+      managedInstallReissue: true,
       mutation: true,
       liveBundleProbe: true
     });
@@ -29659,8 +29882,8 @@ var init_tool_profiles = __esm({
 
 // packages/rn-dev-agent-core/dist/session/authority-gate.js
 import { randomUUID as randomUUID4 } from "node:crypto";
-import { realpathSync as realpathSync4 } from "node:fs";
-import { isAbsolute as isAbsolute3, relative, resolve as resolve2 } from "node:path";
+import { realpathSync as realpathSync5 } from "node:fs";
+import { isAbsolute as isAbsolute4, relative as relative2, resolve as resolve2 } from "node:path";
 async function claimOptionalBundleAuthority(args) {
   return await args[optionalBundleAdmission]?.() ?? false;
 }
@@ -29684,6 +29907,16 @@ async function relaunchManagedNativeOriginApp(args) {
     throw new SessionAuthorityError("METRO_ORIGIN_MISMATCH", "managed native origin relaunch authority is unavailable");
   }
   await authority.relaunch();
+}
+async function reissueManagedInstallAuthority(args) {
+  const reissue = args[managedInstallReissue];
+  if (!reissue) {
+    throw new SessionAuthorityError("APP_INSTALL_IDENTITY_CHANGED", "managed install re-issue authority is unavailable");
+  }
+  await reissue();
+}
+function hasManagedInstallReissueAuthority(args) {
+  return typeof args[managedInstallReissue] === "function";
 }
 function hasManagedRunnerParkAuthority(args) {
   return typeof args[managedRunnerPark] === "function";
@@ -29814,7 +30047,7 @@ function bindSourcePaths(status, args) {
   try {
     if (typeof status.source.appRoot !== "string")
       throw new Error("missing app root");
-    appRoot = realpathSync4(status.source.appRoot);
+    appRoot = realpathSync5(status.source.appRoot);
   } catch {
     throw new SessionAuthorityError("SOURCE_WORKTREE_MISMATCH", "active session app root is unavailable");
   }
@@ -29827,12 +30060,12 @@ function bindSourcePaths(status, args) {
     }
     let candidate;
     try {
-      candidate = realpathSync4(isAbsolute3(supplied) ? supplied : resolve2(appRoot, supplied));
+      candidate = realpathSync5(isAbsolute4(supplied) ? supplied : resolve2(appRoot, supplied));
     } catch {
       throw new SessionAuthorityError("SOURCE_WORKTREE_MISMATCH", `${field2} cannot be resolved within the active app root`);
     }
-    const child = relative(appRoot, candidate);
-    if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute3(child)) {
+    const child = relative2(appRoot, candidate);
+    if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute4(child)) {
       throw new SessionAuthorityError("SOURCE_WORKTREE_MISMATCH", `${field2} is outside the active session app root`);
     }
     args[field2] = candidate;
@@ -30255,6 +30488,7 @@ function createAuthorityGate(runtime, dependencies) {
         let optionalBundleClaimed = false;
         let optionalBundleRecoveryFailed = false;
         let managedRunnerParked = false;
+        let installReceiptReissued = false;
         if (profile.optionalAxes?.includes("B")) {
           Object.defineProperty(args, optionalBundleAdmission, {
             configurable: true,
@@ -30458,6 +30692,30 @@ function createAuthorityGate(runtime, dependencies) {
             }
           });
         }
+        if (profile.managedInstallReissue) {
+          Object.defineProperty(args, managedInstallReissue, {
+            configurable: true,
+            value: async () => {
+              const currentStatus = runtime.status();
+              if (!currentStatus.available) {
+                throw new SessionAuthorityError(currentStatus.code, currentStatus.reason);
+              }
+              registry2.verifyOperation(operation);
+              const install = (dependencies.reissueInstallBinding ?? reissueInstallBinding)(currentStatus.bindings.install);
+              if (!install)
+                return;
+              operation = registry2.replaceBindingsDuringOperation(operation, {
+                bindings: { install }
+              });
+              const reissuedStatus = runtime.status();
+              if (!reissuedStatus.available) {
+                throw new SessionAuthorityError(reissuedStatus.code, reissuedStatus.reason);
+              }
+              status = reissuedStatus;
+              installReceiptReissued = true;
+            }
+          });
+        }
         if (profile.managedRunnerPark) {
           Object.defineProperty(args, managedRunnerPark, {
             configurable: true,
@@ -30609,6 +30867,8 @@ function createAuthorityGate(runtime, dependencies) {
           if ((runtimeTargetChanged || managedRuntimeTargetChanged) && observation.axis === "B") {
             continue;
           }
+          if (installReceiptReissued && observation.axis === "I")
+            continue;
           if (!postflightAxes.includes(observation.axis))
             continue;
           const postflight = after.find((candidate) => candidate.axis === observation.axis);
@@ -30675,16 +30935,18 @@ function createAuthorityGate(runtime, dependencies) {
     }
   };
 }
-var optionalBundleAdmission, managedNativeOrigin, managedRunnerPark, axisBinding, axisErrors;
+var optionalBundleAdmission, managedNativeOrigin, managedRunnerPark, managedInstallReissue, axisBinding, axisErrors;
 var init_authority_gate = __esm({
   "packages/rn-dev-agent-core/dist/session/authority-gate.js"() {
     "use strict";
     init_utils();
     init_registry();
+    init_install_reissue();
     init_tool_profiles();
     optionalBundleAdmission = /* @__PURE__ */ Symbol("optionalBundleAdmission");
     managedNativeOrigin = /* @__PURE__ */ Symbol("managedNativeOrigin");
     managedRunnerPark = /* @__PURE__ */ Symbol("managedRunnerPark");
+    managedInstallReissue = /* @__PURE__ */ Symbol("managedInstallReissue");
     axisBinding = {
       I: "install",
       M: "metro",
@@ -30710,9 +30972,9 @@ var init_authority_gate = __esm({
 // packages/rn-dev-agent-core/dist/tools/maestro-run.js
 import { execFile as execFileCb4 } from "node:child_process";
 import { promisify as promisify6 } from "node:util";
-import { existsSync as existsSync15, readFileSync as readFileSync13, writeFileSync as writeFileSync7 } from "node:fs";
+import { existsSync as existsSync15, readFileSync as readFileSync14, writeFileSync as writeFileSync7 } from "node:fs";
 import { tmpdir as tmpdir6 } from "node:os";
-import { join as join19, dirname as dirname8 } from "node:path";
+import { join as join20, dirname as dirname8 } from "node:path";
 async function runFlowParked(run, opts = {}) {
   const stale = opts.markCdpStale ?? markCdpStale;
   try {
@@ -30738,7 +31000,8 @@ function nestedMaestroAuthorityCallbacks(args) {
     claimNativeOrigin: () => claimManagedNativeOriginAuthority(args),
     completeNativeOrigin: (targetExpected) => completeManagedNativeOriginAuthority(args, targetExpected),
     relaunchManagedApp: () => relaunchManagedNativeOriginApp(args),
-    completeRunnerPark: () => completeManagedRunnerParkAuthority(args)
+    completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+    reissueInstallReceipt: hasManagedInstallReissueAuthority(args) ? () => reissueManagedInstallAuthority(args) : null
   };
 }
 function commandName(command) {
@@ -30878,7 +31141,7 @@ function createMaestroRunHandler(deps = {}) {
         return failResult(`Flow file not found: ${args.flowPath}`);
       }
       try {
-        rawYaml = readFileSync13(args.flowPath, "utf-8");
+        rawYaml = readFileSync14(args.flowPath, "utf-8");
       } catch (err) {
         return failResult(`Failed to read flow file: ${err.message}`);
       }
@@ -30894,7 +31157,7 @@ function createMaestroRunHandler(deps = {}) {
       const rawAppId = resolveAppId(args.appId, platform);
       headerAppId = resolveMaestroFlowAppId(rawAppId || void 0, parsed.appId);
       validatedContent = buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, parsed.commands);
-      flowFile = join19(tmpdir6(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      flowFile = join20(tmpdir6(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
       writeFileSync7(flowFile, validatedContent, "utf-8");
     } catch (err) {
       if (err instanceof MaestroValidationError) {
@@ -30908,10 +31171,19 @@ function createMaestroRunHandler(deps = {}) {
     }
     const timeout = args.timeoutMs ?? 12e4;
     const flowDeadline = now() + timeout;
-    const appFileResolution = resolveAppFileForClearState(platform, validatedContent, headerAppId, args.appFile);
+    const appFileResolution = resolveAppFileForClearState(platform, validatedContent, headerAppId, args.appFile, { deviceId: requestedDeviceId });
     if (!appFileResolution.ok) {
       return failResult(appFileResolution.error);
     }
+    const reinstallsApp = Boolean(appFileResolution.appFile) && flowUsesClearState(validatedContent);
+    const reissueInstallReceipt = args.reissueInstallReceipt ?? deps.reissueInstallReceipt ?? nestedMaestroAuthorityCallbacks(args).reissueInstallReceipt;
+    let installReceiptCommitted = false;
+    const commitReinstalledInstall = async () => {
+      if (!reinstallsApp || installReceiptCommitted || !reissueInstallReceipt)
+        return;
+      installReceiptCommitted = true;
+      await reissueInstallReceipt();
+    };
     const baseArgs = dispatch.buildArgs(platform, flowFile, appFileResolution.appFile, requestedDeviceId);
     const paramArgs = [];
     if (args.params) {
@@ -30954,6 +31226,7 @@ function createMaestroRunHandler(deps = {}) {
         deviceId: requestedDeviceId,
         completeRunnerPark: args.completeRunnerPark ?? managedAuthority.completeRunnerPark
       });
+      await commitReinstalledInstall();
       const stdout = stageResults.map((result) => result.stdout).join("\n");
       const stderr = stageResults.map((result) => result.stderr).join("\n");
       const output = combineRunnerOutput(stdout, stderr);
@@ -31011,6 +31284,7 @@ function createMaestroRunHandler(deps = {}) {
       const warnAug = augmentFailureWithDegradation(output, resolveFloorMs(process.env.RN_RUNTIME_DEGRADED_FLOOR_MS), baseWarnMsg, meta);
       return warnResult(warnAug.meta, warnAug.message);
     } catch (err) {
+      await commitReinstalledInstall();
       if (err instanceof SessionAuthorityError)
         throw err;
       const stageError = err instanceof MaestroStageExecutionError ? err.stageError : err;
@@ -31130,7 +31404,7 @@ var init_maestro_run = __esm({
 
 // packages/rn-dev-agent-core/dist/session/managed-automation.js
 import { spawn as spawn4 } from "node:child_process";
-import { readdirSync as readdirSync5, readFileSync as readFileSync14, unlinkSync as unlinkSync6 } from "node:fs";
+import { readdirSync as readdirSync6, readFileSync as readFileSync15, unlinkSync as unlinkSync6 } from "node:fs";
 function sleep3(ms) {
   return new Promise((resolve11) => setTimeout(resolve11, ms));
 }
@@ -31147,12 +31421,12 @@ function processGroupLiveness(pgid) {
   if (process.platform !== "linux")
     return "unknown";
   try {
-    for (const entry of readdirSync5("/proc", { withFileTypes: true })) {
+    for (const entry of readdirSync6("/proc", { withFileTypes: true })) {
       if (!entry.isDirectory() || !/^\d+$/.test(entry.name))
         continue;
       let stat2;
       try {
-        stat2 = readFileSync14(`/proc/${entry.name}/stat`, "utf8");
+        stat2 = readFileSync15(`/proc/${entry.name}/stat`, "utf8");
       } catch (error2) {
         if (error2.code === "ENOENT")
           continue;
@@ -31763,7 +32037,7 @@ var init_device_arbiter = __esm({
 
 // packages/rn-dev-agent-core/dist/maestro-invoke.js
 import { existsSync as existsSync16, writeFileSync as writeFileSync8 } from "node:fs";
-import { join as join20 } from "node:path";
+import { join as join21 } from "node:path";
 import { homedir as homedir6, tmpdir as tmpdir7 } from "node:os";
 function yamlEscape(s) {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t");
@@ -31781,7 +32055,7 @@ function maestroRefusalResult(result, fallbackMessage, meta) {
   });
 }
 function getMaestroRunnerPath() {
-  const path = join20(homedir6(), ".maestro-runner", "bin", "maestro-runner");
+  const path = join21(homedir6(), ".maestro-runner", "bin", "maestro-runner");
   return existsSync16(path) ? path : null;
 }
 async function runMaestroInline(yaml2, opts, dependencies = {}) {
@@ -31792,7 +32066,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     return { passed: false, output: "", flowFile: "", error: dispatch.error };
   }
   const rawAppId = opts.appId ?? resolveBundleId(opts.platform) ?? readExpoSlug() ?? "";
-  const flowFile = join20(tmpdir7(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+  const flowFile = join21(tmpdir7(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
   let content;
   let headerAppId;
   try {
@@ -32154,10 +32428,10 @@ var init_app_lifecycle = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js
-import { execFileSync as execFileSync7 } from "node:child_process";
-import { existsSync as existsSync17, readFileSync as readFileSync15, unlinkSync as unlinkSync7 } from "node:fs";
+import { execFileSync as execFileSync8 } from "node:child_process";
+import { existsSync as existsSync17, readFileSync as readFileSync16, unlinkSync as unlinkSync7 } from "node:fs";
 import { homedir as homedir7 } from "node:os";
-import { join as join21 } from "node:path";
+import { join as join22 } from "node:path";
 function selectInstalledLegacyApps(installed) {
   return LEGACY_BUNDLE_IDS.filter((id) => installed.has(id));
 }
@@ -32212,7 +32486,7 @@ function defaultDeps2() {
     // caller's try/catch, which records a warning. Swallowing it here and
     // returning '' made single-runner enforcement degrade to a silent no-op
     // with no operator signal — exactly when the machine is busy.
-    listProcesses: () => execFileSync7("ps", ["-A", "-o", "pid=,args="], { encoding: "utf8", timeout: 3e3 }),
+    listProcesses: () => execFileSync8("ps", ["-A", "-o", "pid=,args="], { encoding: "utf8", timeout: 3e3 }),
     kill: (pid, signal) => process.kill(pid, signal),
     isAlive: (pid) => {
       try {
@@ -32224,7 +32498,7 @@ function defaultDeps2() {
     },
     readDaemonPid: () => {
       try {
-        const parsed = JSON.parse(readFileSync15(DAEMON_JSON2, "utf8"));
+        const parsed = JSON.parse(readFileSync16(DAEMON_JSON2, "utf8"));
         return typeof parsed.pid === "number" ? parsed.pid : null;
       } catch {
         return null;
@@ -32233,13 +32507,13 @@ function defaultDeps2() {
     fileExists: (path) => existsSync17(path),
     removeFile: (path) => unlinkSync7(path),
     delay: (ms) => new Promise((resolve11) => setTimeout(resolve11, ms)),
-    listApps: (udid) => execFileSync7("xcrun", ["simctl", "listapps", udid], {
+    listApps: (udid) => execFileSync8("xcrun", ["simctl", "listapps", udid], {
       encoding: "utf8",
       timeout: 5e3,
       stdio: ["ignore", "pipe", "ignore"]
     }),
     uninstallApp: (udid, bundleId) => {
-      execFileSync7("xcrun", ["simctl", "uninstall", udid, bundleId], {
+      execFileSync8("xcrun", ["simctl", "uninstall", udid, bundleId], {
         encoding: "utf8",
         timeout: 1e4,
         stdio: ["ignore", "pipe", "ignore"]
@@ -32313,8 +32587,8 @@ var init_ensure_single_runner = __esm({
   "packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js"() {
     "use strict";
     init_discovery();
-    DAEMON_JSON2 = join21(homedir7(), ".agent-device", "daemon.json");
-    DAEMON_LOCK2 = join21(homedir7(), ".agent-device", "daemon.lock");
+    DAEMON_JSON2 = join22(homedir7(), ".agent-device", "daemon.json");
+    DAEMON_LOCK2 = join22(homedir7(), ".agent-device", "daemon.lock");
     DAEMON_FILES2 = [DAEMON_JSON2, DAEMON_LOCK2];
     SIGKILL_GRACE_MS2 = 500;
     LEGACY_BUNDLE_IDS = [
@@ -32441,9 +32715,9 @@ var init_recover_detached = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/lifecycle/device-lock.js
-import { existsSync as existsSync18, mkdirSync as mkdirSync8, openSync as openSync2, writeSync, closeSync as closeSync2, readFileSync as readFileSync16, unlinkSync as unlinkSync8, writeFileSync as writeFileSync9 } from "node:fs";
+import { existsSync as existsSync18, mkdirSync as mkdirSync8, openSync as openSync2, writeSync, closeSync as closeSync2, readFileSync as readFileSync17, unlinkSync as unlinkSync8, writeFileSync as writeFileSync9 } from "node:fs";
 import { tmpdir as tmpdir8, userInfo } from "node:os";
-import { join as join22 } from "node:path";
+import { join as join23 } from "node:path";
 function defaultProcessAlive3(pid) {
   try {
     process.kill(pid, 0);
@@ -32496,7 +32770,7 @@ var init_device_lock = __esm({
         this.clock = opts.clock ?? Date.now;
         this.processAlive = opts.processAlive ?? defaultProcessAlive3;
         this.staleMs = opts.staleMs ?? DEFAULT_STALE_MS;
-        this.lockPath = join22(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
+        this.lockPath = join23(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
       }
       acquire() {
         try {
@@ -32577,7 +32851,7 @@ var init_device_lock = __esm({
       }
       readExisting() {
         try {
-          const parsed = JSON.parse(readFileSync16(this.lockPath, "utf8"));
+          const parsed = JSON.parse(readFileSync17(this.lockPath, "utf8"));
           if (!isValidBody(parsed))
             return null;
           if (parsed.deviceId !== this.deviceId || parsed.platform !== this.platform)
@@ -54937,8 +55211,8 @@ function annotateMutationAbsence(result, ctx) {
 
 // packages/rn-dev-agent-core/dist/verification/config.js
 init_storage();
-import { existsSync as existsSync19, readFileSync as readFileSync17 } from "node:fs";
-import { join as join23 } from "node:path";
+import { existsSync as existsSync19, readFileSync as readFileSync18 } from "node:fs";
+import { join as join24 } from "node:path";
 var MAX_PATTERN_LENGTH = 200;
 var _cachedProjectRoot;
 function getCachedProjectRoot() {
@@ -54994,14 +55268,14 @@ function loadVerificationConfig(projectRoot) {
   const cached2 = cache2.get(projectRoot);
   if (cached2)
     return cached2;
-  const path = join23(projectRoot, ".rn-agent", "config.json");
+  const path = join24(projectRoot, ".rn-agent", "config.json");
   if (!existsSync19(path)) {
     cache2.set(projectRoot, DEFAULTS);
     return DEFAULTS;
   }
   let raw;
   try {
-    raw = JSON.parse(readFileSync17(path, "utf-8"));
+    raw = JSON.parse(readFileSync18(path, "utf-8"));
   } catch {
     cache2.set(projectRoot, DEFAULTS);
     return DEFAULTS;
@@ -55475,15 +55749,15 @@ import { basename as basename4, dirname as dirname11, sep as sep3 } from "node:p
 
 // packages/rn-dev-agent-core/dist/domain/action-db.js
 import { createRequire as createRequire2 } from "node:module";
-import { existsSync as existsSync20, mkdirSync as mkdirSync10, readdirSync as readdirSync6, readFileSync as readFileSync18 } from "node:fs";
-import { dirname as dirname9, join as join25 } from "node:path";
+import { existsSync as existsSync20, mkdirSync as mkdirSync10, readdirSync as readdirSync7, readFileSync as readFileSync19 } from "node:fs";
+import { dirname as dirname9, join as join26 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/runtime-paths.js
-import { chmodSync as chmodSync2, lstatSync as lstatSync5, mkdirSync as mkdirSync9 } from "node:fs";
-import { join as join24, resolve as resolve3 } from "node:path";
+import { chmodSync as chmodSync2, lstatSync as lstatSync6, mkdirSync as mkdirSync9 } from "node:fs";
+import { join as join25, resolve as resolve3 } from "node:path";
 function privateDirectory(path) {
   mkdirSync9(path, { recursive: true, mode: 448 });
-  const stat2 = lstatSync5(path);
+  const stat2 = lstatSync6(path);
   if (stat2.isSymbolicLink() || !stat2.isDirectory()) {
     throw new Error("SESSION_RUNTIME_ROOT_UNSAFE: runtime root must be a real directory");
   }
@@ -55492,14 +55766,14 @@ function privateDirectory(path) {
 }
 function sessionRuntimeRoot(projectRoot) {
   const configured = process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT;
-  return configured ? privateDirectory(resolve3(configured)) : join24(resolve3(projectRoot), ".rn-agent");
+  return configured ? privateDirectory(resolve3(configured)) : join25(resolve3(projectRoot), ".rn-agent");
 }
 function sessionStateDirectory(projectRoot) {
-  const path = join24(sessionRuntimeRoot(projectRoot), "state");
+  const path = join25(sessionRuntimeRoot(projectRoot), "state");
   return process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT ? privateDirectory(path) : path;
 }
 function sessionRecordingsDirectory(projectRoot) {
-  const path = join24(sessionRuntimeRoot(projectRoot), "recordings");
+  const path = join25(sessionRuntimeRoot(projectRoot), "recordings");
   return process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT ? privateDirectory(path) : path;
 }
 
@@ -55564,7 +55838,7 @@ function openActionDb(projectRoot, opts = {}) {
   if (!Ctor)
     return null;
   try {
-    const dbPath = join25(sessionStateDirectory(projectRoot), "actions.db");
+    const dbPath = join26(sessionStateDirectory(projectRoot), "actions.db");
     mkdirSync10(dirname9(dbPath), { recursive: true });
     const db = new Ctor(dbPath);
     db.exec(SCHEMA);
@@ -55707,11 +55981,11 @@ function openActionDb(projectRoot, opts = {}) {
         return row.cnt;
       },
       migrateSidecars() {
-        const stateDir = join25(projectRoot, ".rn-agent", "state");
+        const stateDir = join26(projectRoot, ".rn-agent", "state");
         if (!existsSync20(stateDir))
           return { migrated: 0 };
         let migrated = 0;
-        for (const f of readdirSync6(stateDir)) {
+        for (const f of readdirSync7(stateDir)) {
           if (!f.endsWith(".state.json"))
             continue;
           const id = f.replace(/\.state\.json$/, "");
@@ -55719,7 +55993,7 @@ function openActionDb(projectRoot, opts = {}) {
           if (exists)
             continue;
           try {
-            const parsed = JSON.parse(readFileSync18(join25(stateDir, f), "utf8"));
+            const parsed = JSON.parse(readFileSync19(join26(stateDir, f), "utf8"));
             if (parsed?.schemaVersion !== 1)
               continue;
             if (!Array.isArray(parsed.runHistory) || !Array.isArray(parsed.repairHistory)) {
@@ -55753,8 +56027,8 @@ var RUN_HISTORY_MAX = 50;
 var REPAIR_HISTORY_MAX = 25;
 
 // packages/rn-dev-agent-core/dist/domain/sidecar-io.js
-import { existsSync as existsSync21, readFileSync as readFileSync19, writeFileSync as writeFileSync10, mkdirSync as mkdirSync11, statSync as statSync6 } from "node:fs";
-import { join as join26, dirname as dirname10 } from "node:path";
+import { existsSync as existsSync21, readFileSync as readFileSync20, writeFileSync as writeFileSync10, mkdirSync as mkdirSync11, statSync as statSync7 } from "node:fs";
+import { join as join27, dirname as dirname10 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/domain/reusable-action.js
 var REPAIR_BUDGET = {
@@ -55951,19 +56225,19 @@ function sidecarPathFor(yamlFilePath) {
   const parent = dirname10(dir);
   const filename = yamlFilePath.replace(/\.ya?ml$/i, ".state.json");
   const base = filename.split(/[\\/]/).pop();
-  const stateDirectory = process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT ? sessionStateDirectory(dirname10(parent)) : join26(parent, "state");
-  return join26(stateDirectory, base);
+  const stateDirectory = process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT ? sessionStateDirectory(dirname10(parent)) : join27(parent, "state");
+  return join27(stateDirectory, base);
 }
 function loadOrInitSidecar(yamlFilePath, now = () => /* @__PURE__ */ new Date()) {
   const path = sidecarPathFor(yamlFilePath);
   if (existsSync21(path)) {
     try {
-      const text = readFileSync19(path, "utf8");
+      const text = readFileSync20(path, "utf8");
       const parsed = JSON.parse(text);
       if (parsed && parsed.schemaVersion === 1 && typeof parsed.revision === "number" && typeof parsed.updatedAt === "string" && Array.isArray(parsed.runHistory) && Array.isArray(parsed.repairHistory) && typeof parsed.stats === "object") {
         if (typeof parsed.lastSeenMtimeMs !== "number") {
           try {
-            parsed.lastSeenMtimeMs = statSync6(yamlFilePath).mtimeMs;
+            parsed.lastSeenMtimeMs = statSync7(yamlFilePath).mtimeMs;
           } catch {
             parsed.lastSeenMtimeMs = 0;
           }
@@ -55975,7 +56249,7 @@ function loadOrInitSidecar(yamlFilePath, now = () => /* @__PURE__ */ new Date())
   }
   let mtimeMs = 0;
   try {
-    mtimeMs = statSync6(yamlFilePath).mtimeMs;
+    mtimeMs = statSync7(yamlFilePath).mtimeMs;
   } catch {
   }
   return freshRuntimeState(now, mtimeMs);
@@ -55990,7 +56264,7 @@ function saveSidecar(yamlFilePath, state) {
 }
 function yamlEditedSinceLastSeen(yamlFilePath, state) {
   try {
-    const current = statSync6(yamlFilePath).mtimeMs;
+    const current = statSync7(yamlFilePath).mtimeMs;
     return current > state.lastSeenMtimeMs;
   } catch {
     return false;
@@ -56064,30 +56338,30 @@ init_engine_pin();
 init_agent_device_wrapper();
 
 // packages/rn-dev-agent-core/dist/session/migration-diagnostic.js
-import { createHash as createHash7 } from "node:crypto";
-import { existsSync as existsSync23, readFileSync as readFileSync22 } from "node:fs";
-import { join as join29 } from "node:path";
+import { createHash as createHash8 } from "node:crypto";
+import { existsSync as existsSync23, readFileSync as readFileSync23 } from "node:fs";
+import { join as join30 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/bound-directory.js
 import { spawn as spawn5 } from "node:child_process";
 import { randomUUID as randomUUID6 } from "node:crypto";
-import { closeSync as closeSync3, constants as constants2, existsSync as existsSync22, fstatSync as fstatSync2, lstatSync as lstatSync7, mkdtempSync, openSync as openSync3, readFileSync as readFileSync21, realpathSync as realpathSync5, renameSync as renameSync5, rmSync as rmSync8, writeFileSync as writeFileSync12 } from "node:fs";
+import { closeSync as closeSync3, constants as constants2, existsSync as existsSync22, fstatSync as fstatSync2, lstatSync as lstatSync8, mkdtempSync, openSync as openSync3, readFileSync as readFileSync22, realpathSync as realpathSync6, renameSync as renameSync5, rmSync as rmSync8, writeFileSync as writeFileSync12 } from "node:fs";
 import { tmpdir as tmpdir9 } from "node:os";
-import { join as join28 } from "node:path";
+import { join as join29 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/state-root.js
 init_secure_state_file();
 import { randomBytes as randomBytes5, randomUUID as randomUUID5 } from "node:crypto";
-import { chmodSync as chmodSync3, linkSync, lstatSync as lstatSync6, mkdirSync as mkdirSync12, readFileSync as readFileSync20, renameSync as renameSync4, rmSync as rmSync7, statSync as statSync7, writeFileSync as writeFileSync11 } from "node:fs";
-import { join as join27 } from "node:path";
+import { chmodSync as chmodSync3, linkSync, lstatSync as lstatSync7, mkdirSync as mkdirSync12, readFileSync as readFileSync21, renameSync as renameSync4, rmSync as rmSync7, statSync as statSync8, writeFileSync as writeFileSync11 } from "node:fs";
+import { join as join28 } from "node:path";
 function fail(code, detail) {
   throw new Error(`${code}: ${detail}`);
 }
 function ensurePrivateDirectory(path) {
   try {
     mkdirSync12(path, { recursive: true, mode: 448 });
-    const link = lstatSync6(path);
-    const stat2 = statSync7(path);
+    const link = lstatSync7(path);
+    const stat2 = statSync8(path);
     if (link.isSymbolicLink() || !link.isDirectory() || typeof process.getuid === "function" && stat2.uid !== process.getuid()) {
       fail("AUTHORITY_STATE_ROOT_UNSAFE", "state directory is not private and user-owned");
     }
@@ -56101,15 +56375,15 @@ function ensurePrivateDirectory(path) {
 }
 function createAuthorityStateLayout(stateDir = getStateDir()) {
   ensurePrivateDirectory(stateDir);
-  const root = join27(stateDir, "v2");
+  const root = join28(stateDir, "v2");
   ensurePrivateDirectory(root);
   const layout = {
     root,
-    registry: join27(root, "registry.sqlite3"),
-    sessions: join27(root, "sessions"),
-    runners: join27(root, "runner"),
-    observe: join27(root, "observe"),
-    migrations: join27(root, "migrations")
+    registry: join28(root, "registry.sqlite3"),
+    sessions: join28(root, "sessions"),
+    runners: join28(root, "runner"),
+    observe: join28(root, "observe"),
+    migrations: join28(root, "migrations")
   };
   for (const path of [layout.sessions, layout.runners, layout.observe, layout.migrations]) {
     ensurePrivateDirectory(path);
@@ -56117,8 +56391,8 @@ function createAuthorityStateLayout(stateDir = getStateDir()) {
   return layout;
 }
 function getBoundDirectoryJournalKey(layout = createAuthorityStateLayout()) {
-  const path = join27(layout.root, "bound-directory.key");
-  const temporary = join27(layout.root, `.bound-directory.${randomUUID5()}.key`);
+  const path = join28(layout.root, "bound-directory.key");
+  const temporary = join28(layout.root, `.bound-directory.${randomUUID5()}.key`);
   try {
     try {
       writeFileSync11(temporary, randomBytes5(32), { flag: "wx", mode: 384, flush: true });
@@ -56131,9 +56405,9 @@ function getBoundDirectoryJournalKey(layout = createAuthorityStateLayout()) {
     } finally {
       rmSync7(temporary, { force: true });
     }
-    const link = lstatSync6(path);
-    const stat2 = statSync7(path);
-    const key = readFileSync20(path);
+    const link = lstatSync7(path);
+    const stat2 = statSync8(path);
+    const key = readFileSync21(path);
     if (link.isSymbolicLink() || !link.isFile() || key.length !== 32 || typeof process.getuid === "function" && stat2.uid !== process.getuid()) {
       fail("AUTHORITY_STATE_ROOT_UNSAFE", "bound-directory journal key is invalid");
     }
@@ -57225,21 +57499,21 @@ function waitForFile(path, timeoutMs) {
   return existsSync22(path);
 }
 function stopWorker(worker, signal = "SIGTERM") {
-  const stoppedPath = join28(worker.controlPath, "stopped");
+  const stoppedPath = join29(worker.controlPath, "stopped");
   if (signal === "SIGTERM") {
     try {
-      writeFileSync12(join28(worker.controlPath, "stop"), "", { flag: "wx", mode: 384 });
+      writeFileSync12(join29(worker.controlPath, "stop"), "", { flag: "wx", mode: 384 });
     } catch {
     }
     if (waitForFile(stoppedPath, 1e3)) {
-      if (!existsSync22(join28(worker.controlPath, "lock-retained"))) {
+      if (!existsSync22(join29(worker.controlPath, "lock-retained"))) {
         rmSync8(worker.controlPath, { force: true, recursive: true });
       }
       return;
     }
   }
   try {
-    writeFileSync12(join28(worker.controlPath, "terminate"), JSON.stringify({
+    writeFileSync12(join29(worker.controlPath, "terminate"), JSON.stringify({
       lifecycleCapability: worker.lifecycleCapability,
       signal: "SIGKILL"
     }), { flag: "wx", mode: 384 });
@@ -57248,7 +57522,7 @@ function stopWorker(worker, signal = "SIGTERM") {
   if (!waitForFile(stoppedPath, 1e4)) {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: bound-directory worker exit was not confirmed");
   }
-  if (!existsSync22(join28(worker.controlPath, "lock-retained"))) {
+  if (!existsSync22(join29(worker.controlPath, "lock-retained"))) {
     rmSync8(worker.controlPath, { force: true, recursive: true });
   }
 }
@@ -57270,13 +57544,13 @@ function bindWorker(controlPath, child, owner, childId, lifecycleCapability = ""
     }
     throw new Error(message);
   };
-  const readyPath = join28(controlPath, "ready");
+  const readyPath = join29(controlPath, "ready");
   if (!waitForFile(readyPath, WORKER_READY_TIMEOUT_MS)) {
     rejectWorker("SESSION_INTEGRATION_PATH_UNSAFE: bound-directory worker unavailable");
   }
   let ready = {};
   try {
-    ready = JSON.parse(readFileSync21(readyPath, "utf8"));
+    ready = JSON.parse(readFileSync22(readyPath, "utf8"));
   } catch {
     rejectWorker("SESSION_INTEGRATION_PATH_UNSAFE: bound-directory worker unavailable");
   }
@@ -57295,7 +57569,7 @@ function bindWorker(controlPath, child, owner, childId, lifecycleCapability = ""
   };
 }
 function startWorker(path, identity2, realPath) {
-  const controlPath = mkdtempSync(join28(tmpdir9(), "rn-bound-directory-"));
+  const controlPath = mkdtempSync(join29(tmpdir9(), "rn-bound-directory-"));
   const lifecycleCapability = randomUUID6();
   const binding = Buffer.from(JSON.stringify({
     dev: identity2.dev.toString(),
@@ -57325,7 +57599,7 @@ function startWorker(path, identity2, realPath) {
   return bindWorker(controlPath, child, void 0, void 0, lifecycleCapability);
 }
 function startSubdirectoryWorker(parent, name, expectedIdentity, expectedRealPath) {
-  const controlPath = mkdtempSync(join28(tmpdir9(), "rn-bound-directory-"));
+  const controlPath = mkdtempSync(join29(tmpdir9(), "rn-bound-directory-"));
   const childId = randomUUID6();
   const lifecycleCapability = randomUUID6();
   let worker;
@@ -57337,7 +57611,7 @@ function startSubdirectoryWorker(parent, name, expectedIdentity, expectedRealPat
       controlPath,
       lifecycleCapability,
       name,
-      publicPath: join28(parent.path, name),
+      publicPath: join29(parent.path, name),
       create: false,
       mode: 448
     });
@@ -57401,9 +57675,9 @@ function rebindDescendants(directory) {
 function sendOperation(directory, request2, timeoutMs) {
   const sequence = ++directory.worker.sequence;
   const prefix = String(sequence).padStart(8, "0");
-  const pendingPath = join28(directory.worker.controlPath, `${prefix}.pending`);
-  const requestPath2 = join28(directory.worker.controlPath, `${prefix}.request`);
-  const responsePath = join28(directory.worker.controlPath, `${prefix}.response`);
+  const pendingPath = join29(directory.worker.controlPath, `${prefix}.pending`);
+  const requestPath2 = join29(directory.worker.controlPath, `${prefix}.request`);
+  const responsePath = join29(directory.worker.controlPath, `${prefix}.response`);
   writeFileSync12(pendingPath, JSON.stringify(request2), { flag: "wx", mode: 384 });
   renameSync5(pendingPath, requestPath2);
   if (!waitForFile(responsePath, timeoutMs)) {
@@ -57411,7 +57685,7 @@ function sendOperation(directory, request2, timeoutMs) {
   }
   let result;
   try {
-    result = JSON.parse(readFileSync21(responsePath, "utf8"));
+    result = JSON.parse(readFileSync22(responsePath, "utf8"));
   } catch {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: bound-directory operation returned invalid output");
   } finally {
@@ -57436,8 +57710,8 @@ function runBoundOperation(directory, request2, dependencies = {}) {
   let current;
   let currentRealPath;
   try {
-    current = lstatSync7(directory.path, { bigint: true });
-    currentRealPath = realpathSync5(directory.path);
+    current = lstatSync8(directory.path, { bigint: true });
+    currentRealPath = realpathSync6(directory.path);
   } catch {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: bound directory path is unavailable");
   }
@@ -57553,14 +57827,14 @@ function openValidatedDirectory(path, expected) {
   let descriptor;
   let worker;
   try {
-    const before = lstatSync7(path, { bigint: true });
+    const before = lstatSync8(path, { bigint: true });
     if (!before.isDirectory() || before.isSymbolicLink()) {
       throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: integration ancestor is not a directory");
     }
     descriptor = openSync3(path, constants2.O_RDONLY | (constants2.O_DIRECTORY ?? 0) | (constants2.O_NOFOLLOW ?? 0));
     const opened = fstatSync2(descriptor, { bigint: true });
-    const after = lstatSync7(path, { bigint: true });
-    const realPath = realpathSync5(path);
+    const after = lstatSync8(path, { bigint: true });
+    const realPath = realpathSync6(path);
     if (!opened.isDirectory() || !sameIdentity(before, opened) || !sameIdentity(after, opened) || expected !== void 0 && (!sameIdentity(expected.identity, opened) || expected.realPath !== realPath)) {
       throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: integration ancestor changed while opening");
     }
@@ -57665,7 +57939,7 @@ function assertBoundDirectoryCurrent(directory) {
   runBoundOperation(directory, { operation: "identity" });
 }
 function openBoundSubdirectoryInternal(parent, name, options = {}) {
-  const controlPath = mkdtempSync(join28(tmpdir9(), "rn-bound-directory-"));
+  const controlPath = mkdtempSync(join29(tmpdir9(), "rn-bound-directory-"));
   const childId = randomUUID6();
   const lifecycleCapability = randomUUID6();
   let worker;
@@ -57677,7 +57951,7 @@ function openBoundSubdirectoryInternal(parent, name, options = {}) {
       controlPath,
       lifecycleCapability,
       name,
-      publicPath: join28(parent.path, name),
+      publicPath: join29(parent.path, name),
       create: options.create ?? false,
       mode: options.mode ?? 448,
       optional: options.optional ?? false,
@@ -57701,7 +57975,7 @@ function openBoundSubdirectoryInternal(parent, name, options = {}) {
       },
       name,
       parent,
-      path: join28(parent.path, name),
+      path: join29(parent.path, name),
       pendingCleanups: /* @__PURE__ */ new Map(),
       realPath: result.directoryIdentity.realPath,
       worker,
@@ -57835,15 +58109,15 @@ function retryBoundDirectoryCleanup(directory, obligation, dependencies = {}) {
 // packages/rn-dev-agent-core/dist/session/migration-diagnostic.js
 init_registry();
 function readPackageIntegrationManifest(appRoot, dependencies) {
-  const manifestPath = join29(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
+  const manifestPath = join30(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
   if (dependencies.exists || dependencies.readText) {
     const exists = dependencies.exists ?? existsSync23;
     if (!exists(manifestPath))
       return void 0;
-    const readText = dependencies.readText ?? ((path) => readFileSync22(path, "utf8"));
+    const readText = dependencies.readText ?? ((path) => readFileSync23(path, "utf8"));
     return readText(manifestPath);
   }
-  const agent = openBoundDirectory(join29(appRoot, ".rn-agent"));
+  const agent = openBoundDirectory(join30(appRoot, ".rn-agent"));
   let integration;
   let primaryError;
   try {
@@ -57880,7 +58154,7 @@ function inspectAuthorityMigration(status, dependencies = {}) {
   const integrationBinding = status.bindings.packageIntegration;
   let bindingDiagnostic = null;
   if (integrationBinding) {
-    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash7("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
+    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash8("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
     const manifestAvailable = manifestVerified(onDiskManifestText) || manifestVerified(integrationBinding.restoration?.phase === "started" ? integrationBinding.restoration.manifestSource : void 0) || manifestVerified(integrationBinding.installation?.phase === "started" ? integrationBinding.installation.manifestSource : void 0) || manifestVerified(integrationBinding.manifestSource);
     const effectiveOwnerSessionId = status.sessionId;
     const trustedDigestRecorded = typeof integrationBinding.manifestSha256 === "string" && /^[0-9a-f]{64}$/.test(integrationBinding.manifestSha256);
@@ -58085,187 +58359,8 @@ function verifyBuildReceipt(receipt2, capability, expected) {
   return receipt2.payload;
 }
 
-// packages/rn-dev-agent-core/dist/session/install-authority.js
-import { execFileSync as execFileSync8 } from "node:child_process";
-import { createHash as createHash8 } from "node:crypto";
-import { lstatSync as lstatSync8, readFileSync as readFileSync23, readdirSync as readdirSync7, readlinkSync as readlinkSync2, realpathSync as realpathSync6, statSync as statSync8 } from "node:fs";
-import { isAbsolute as isAbsolute4, join as join30, relative as relative2 } from "node:path";
-function runText(command, args) {
-  return execFileSync8(command, [...args], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-    timeout: 1e4,
-    maxBuffer: 8 * 1024 * 1024
-  });
-}
-function runBuffer(command, args) {
-  return execFileSync8(command, [...args], {
-    encoding: "buffer",
-    stdio: ["ignore", "pipe", "ignore"],
-    timeout: 3e4,
-    maxBuffer: 512 * 1024 * 1024
-  });
-}
-function digest(parts) {
-  const hash = createHash8("sha256");
-  for (const part of parts) {
-    hash.update(`${part.byteLength}:`);
-    hash.update(part);
-  }
-  return hash.digest("hex");
-}
-function generation(parts) {
-  return digest(parts.map((part) => Buffer.from(part)));
-}
-function listAppFiles(appPath) {
-  const files = [];
-  const visit = (directory) => {
-    for (const entry of readdirSync7(directory, { withFileTypes: true })) {
-      const path = join30(directory, entry.name);
-      if (entry.isDirectory()) {
-        visit(path);
-      } else if (entry.isFile() || entry.isSymbolicLink()) {
-        files.push(relative2(appPath, path));
-      } else {
-        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
-      }
-    }
-  };
-  visit(appPath);
-  return files.sort();
-}
-function iosAppFiles(appPath, dependencies) {
-  return [...(dependencies.listAppFiles ?? listAppFiles)(appPath)].sort();
-}
-function assertIosSymlinkContained(appPath, path, realpath) {
-  const target = realpath(path);
-  const child = relative2(realpath(appPath), target);
-  if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute4(child)) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app symlink escapes the installed bundle");
-  }
-}
-function androidApkPaths(target, text) {
-  return text("adb", ["-s", target.deviceId, "shell", "pm", "path", target.appId]).split("\n").map((line) => line.trim()).filter((line) => line.startsWith("package:")).map((line) => line.slice("package:".length)).sort();
-}
-function captureInstallGeneration(target, dependencies = {}) {
-  const text = dependencies.runText ?? runText;
-  if (target.platform === "ios") {
-    const appPath = text("xcrun", [
-      "simctl",
-      "get_app_container",
-      target.deviceId,
-      target.appId,
-      "app"
-    ]).trim();
-    if (!appPath) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
-    }
-    const infoPath = join30(appPath, "Info.plist");
-    const executable = text("plutil", [
-      "-extract",
-      "CFBundleExecutable",
-      "raw",
-      "-o",
-      "-",
-      infoPath
-    ]).trim();
-    if (!executable) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
-    }
-    const stat2 = dependencies.stat ?? statSync8;
-    const metadata2 = iosAppFiles(appPath, dependencies).map((entry) => {
-      const path = join30(appPath, entry);
-      const value = stat2(path);
-      return `${entry}:${String(value.ino)}:${value.size}:${value.mtimeMs}`;
-    });
-    return generation(metadata2);
-  }
-  const apkPaths = androidApkPaths(target, text);
-  if (!apkPaths.length) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
-  }
-  const metadata = text("adb", [
-    "-s",
-    target.deviceId,
-    "shell",
-    "stat",
-    "-c",
-    "%n:%i:%s:%Y",
-    ...apkPaths
-  ]).split("\n").map((line) => line.trim()).filter(Boolean).sort();
-  if (metadata.length !== apkPaths.length) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: Android install generation is unavailable");
-  }
-  return generation(metadata);
-}
-function captureInstalledArtifact(target, dependencies = {}) {
-  const text = dependencies.runText ?? runText;
-  const buffer = dependencies.runBuffer ?? runBuffer;
-  const read = dependencies.read ?? readFileSync23;
-  if (target.platform === "ios") {
-    const appPath = text("xcrun", [
-      "simctl",
-      "get_app_container",
-      target.deviceId,
-      target.appId,
-      "app"
-    ]).trim();
-    if (!appPath) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
-    }
-    const infoPath = join30(appPath, "Info.plist");
-    const executable = text("plutil", [
-      "-extract",
-      "CFBundleExecutable",
-      "raw",
-      "-o",
-      "-",
-      infoPath
-    ]).trim();
-    if (!executable) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
-    }
-    const files = iosAppFiles(appPath, dependencies);
-    const lstat = dependencies.lstat ?? lstatSync8;
-    const readLink = dependencies.readLink ?? readlinkSync2;
-    const realpath = dependencies.realpath ?? realpathSync6;
-    const artifactParts = [];
-    for (const entry of files) {
-      const path = join30(appPath, entry);
-      const stat2 = lstat(path);
-      artifactParts.push(Buffer.from(entry));
-      if (stat2.isFile()) {
-        artifactParts.push(Buffer.from("file"), read(path));
-      } else if (stat2.isSymbolicLink()) {
-        assertIosSymlinkContained(appPath, path, realpath);
-        artifactParts.push(Buffer.from("symlink"), Buffer.from(readLink(path)));
-      } else {
-        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
-      }
-    }
-    return {
-      ...target,
-      artifactDigest: digest(artifactParts),
-      installGeneration: captureInstallGeneration(target, dependencies)
-    };
-  }
-  const apkPaths = androidApkPaths(target, text);
-  if (!apkPaths.length) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
-  }
-  return {
-    ...target,
-    artifactDigest: digest(apkPaths.map((path) => buffer("adb", ["-s", target.deviceId, "exec-out", "cat", path]))),
-    installGeneration: captureInstallGeneration(target, dependencies)
-  };
-}
-function verifyInstalledArtifact(expected, observed) {
-  if (expected.platform !== observed.platform || expected.deviceId !== observed.deviceId || expected.appId !== observed.appId || expected.artifactDigest !== observed.artifactDigest || expected.installGeneration !== observed.installGeneration) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: installed artifact no longer matches the session build");
-  }
-}
-
 // packages/rn-dev-agent-core/dist/tools/session.js
+init_install_authority();
 init_metro_binding();
 
 // packages/rn-dev-agent-core/dist/session/expo-android-device.js
@@ -70686,6 +70781,167 @@ async function getIosRuntimeMajorForUdid(udid, execFn2 = (cmd, args) => execFile
 
 // packages/rn-dev-agent-core/dist/tools/run-action.js
 init_authority_gate();
+
+// packages/rn-dev-agent-core/dist/session/runtime.js
+init_process_birth();
+init_registry();
+init_secure_state_file();
+var WorkerAuthorityRuntime = class {
+  available;
+  #registry;
+  #session;
+  #unavailable;
+  #recoveryOnly;
+  #recoveryCapability;
+  constructor(registry2, session2, unavailable2, recoveryOnly = false, recoveryCapability = null) {
+    this.#registry = registry2;
+    this.#session = session2;
+    this.#unavailable = unavailable2;
+    this.available = registry2 !== null && session2 !== null;
+    this.#recoveryOnly = recoveryOnly;
+    this.#recoveryCapability = recoveryCapability;
+  }
+  requireAvailable() {
+    if (!this.#registry || !this.#session) {
+      throw new SessionAuthorityError(this.#unavailable?.code ?? "SESSION_NOT_INITIALIZED", this.#unavailable?.reason ?? "authority session is unavailable");
+    }
+    return { registry: this.#registry, session: this.#session };
+  }
+  requireOperational() {
+    const available = this.requireAvailable();
+    const status = this.status();
+    if (status.available && (status.state === "blocked" || status.state === "handoff_cleanup")) {
+      throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "blocked contender exposes only accept_handoff and adopt_stale recovery");
+    }
+    return available;
+  }
+  requireRecovery() {
+    const available = this.requireAvailable();
+    const status = this.status();
+    if (!this.#recoveryOnly || !status.available || status.state !== "blocked" && status.state !== "handoff_cleanup") {
+      throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "session is not a capability-bound recovery contender");
+    }
+    return available;
+  }
+  /**
+   * GH #672: rotate an expired recovery handle before it is advertised. Best-effort by
+   * design — a refresh failure must degrade `status` to an honest expired handle, never
+   * turn a diagnostic call into an authority error.
+   */
+  refreshRecoveryHandles() {
+    if (!this.#registry || !this.#session || !this.#recoveryOnly || !this.#recoveryCapability) {
+      return false;
+    }
+    try {
+      const status = this.#registry.getSessionStatus(this.#session.sessionId);
+      const instanceId = status?.worker.instanceId;
+      if (!status || !instanceId || status.state !== "blocked" && status.state !== "handoff_cleanup") {
+        return false;
+      }
+      return this.#registry.refreshRecoveryHandles(this.#session, { instanceId }, this.#recoveryCapability);
+    } catch {
+      return false;
+    }
+  }
+  inspectRecoveryRequirement() {
+    if (!this.#registry || !this.#session)
+      return void 0;
+    try {
+      return this.#registry.inspectRecoveryRequirement(this.#session.sessionId);
+    } catch {
+      return void 0;
+    }
+  }
+  status() {
+    if (!this.#registry || !this.#session) {
+      return {
+        available: false,
+        code: this.#unavailable?.code ?? "SESSION_NOT_INITIALIZED",
+        reason: this.#unavailable?.reason ?? "authority session is unavailable"
+      };
+    }
+    const status = this.#registry.getSessionStatus(this.#session.sessionId);
+    if (!status) {
+      return {
+        available: false,
+        code: "SESSION_OWNER_LOST",
+        reason: "session is no longer present in the authority registry"
+      };
+    }
+    return { available: true, ...status };
+  }
+  close() {
+    this.#registry?.close();
+  }
+};
+function unavailable(reason, fallbackCode) {
+  const matched = /^([A-Z][A-Z0-9_]+):/.exec(reason);
+  return new WorkerAuthorityRuntime(null, null, {
+    code: matched?.[1] ?? fallbackCode,
+    reason
+  });
+}
+function createWorkerAuthorityRuntime(environment = process.env, dependencies = {}) {
+  if (environment.RN_DEV_AGENT_AUTHORITY_ERROR) {
+    return unavailable(environment.RN_DEV_AGENT_AUTHORITY_ERROR, "AUTHORITY_STORE_UNAVAILABLE");
+  }
+  const sessionId = environment.RN_DEV_AGENT_SESSION_ID;
+  const claimEpoch = Number(environment.RN_DEV_AGENT_CLAIM_EPOCH);
+  const registryPath = environment.RN_DEV_AGENT_REGISTRY_PATH;
+  const workerInstance = environment.RN_DEV_AGENT_WORKER_INSTANCE;
+  if (!sessionId || !Number.isSafeInteger(claimEpoch) || claimEpoch < 1 || !registryPath || !workerInstance) {
+    return unavailable("SESSION_NOT_INITIALIZED: supervisor did not provide a complete authority context", "SESSION_NOT_INITIALIZED");
+  }
+  const birth = (dependencies.readBirth ?? readProcessBirth)(process.pid);
+  if (!birth) {
+    return unavailable("PROCESS_BIRTH_UNAVAILABLE: worker process birth could not be proven conservatively", "PROCESS_BIRTH_UNAVAILABLE");
+  }
+  try {
+    const registry2 = openSessionRegistry(registryPath, {
+      ownerStatus: dependencies.ownerStatus ?? inspectSessionOwner
+    });
+    const session2 = { sessionId, claimEpoch };
+    const status = registry2.getSessionStatus(sessionId);
+    const recoveryOnly = status?.state === "blocked" || status?.state === "handoff_cleanup";
+    let recoveryCapability = null;
+    if (recoveryOnly) {
+      const secretPath = environment.RN_DEV_AGENT_SESSION_SECRET_PATH;
+      recoveryCapability = secretPath ? readJsonStateFile(secretPath)?.recoveryCapability ?? null : null;
+      if (!recoveryCapability) {
+        throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "blocked recovery capability is unavailable");
+      }
+      registry2.bindRecoveryWorker(session2, { instanceId: workerInstance, pid: birth.pid, token: birth.token }, recoveryCapability);
+    } else {
+      registry2.bindWorker(session2, {
+        instanceId: workerInstance,
+        pid: birth.pid,
+        token: birth.token
+      });
+    }
+    return new WorkerAuthorityRuntime(registry2, session2, null, recoveryOnly, recoveryCapability);
+  } catch (error2) {
+    return unavailable(error2 instanceof Error ? error2.message : "AUTHORITY_STORE_UNAVAILABLE: worker authority could not be opened", "AUTHORITY_STORE_UNAVAILABLE");
+  }
+}
+var sharedRuntime = null;
+function getWorkerAuthorityRuntime() {
+  sharedRuntime ??= createWorkerAuthorityRuntime();
+  return sharedRuntime;
+}
+
+// packages/rn-dev-agent-core/dist/tools/run-action.js
+init_resolve_ios_app_file();
+function boundInstallReceipt() {
+  try {
+    const status = getWorkerAuthorityRuntime().status();
+    if (!status.available)
+      return null;
+    const install = status.bindings.install;
+    return install ?? null;
+  } catch {
+    return null;
+  }
+}
 function classifyFailure(failure) {
   switch (failure.kind) {
     case "SELECTOR_NOT_FOUND":
@@ -70824,6 +71080,9 @@ function createRunActionHandler(deps = {}) {
   const claimNativeOrigin = deps.claimNativeOrigin ?? claimManagedNativeOriginAuthority;
   const completeNativeOrigin = deps.completeNativeOrigin ?? completeManagedNativeOriginAuthority;
   const relaunchManagedApp = deps.relaunchManagedApp ?? relaunchManagedNativeOriginApp;
+  const reissueInstallReceipt = deps.reissueInstallReceipt ?? reissueManagedInstallAuthority;
+  const installReceipt = deps.installReceipt ?? boundInstallReceipt;
+  const resolveAppFile = deps.resolveAppFile ?? ((appId, deviceId) => resolveIosAppFile(appId, { deviceId }));
   return async (args) => {
     if (!args.actionId || typeof args.actionId !== "string") {
       return failResult("cdp_run_action requires actionId", "BAD_FILENAME");
@@ -70854,6 +71113,8 @@ function createRunActionHandler(deps = {}) {
       return failResult(`cdp_run_action: requested ${args.platform}, but the active session is ${activeTarget.platform}; refusing cross-platform replay.`, "TARGET_SESSION_MISMATCH", { requestedPlatform: args.platform, activeSession: activeTarget });
     }
     const maestroDeviceId = (!args.platform || activeTarget?.platform === args.platform) && activeTarget?.deviceId ? activeTarget.deviceId : void 0;
+    const receipt2 = args.appFile ? null : installReceipt();
+    const appFile = args.appFile ?? (flowUsesClearState(action.body) && receipt2?.platform === "ios" && typeof receipt2.appId === "string" && typeof receipt2.deviceId === "string" ? resolveAppFile(receipt2.appId, receipt2.deviceId) ?? void 0 : void 0);
     let probeDeviceId = null;
     let observedDeviceId = maestroDeviceId ?? null;
     const persistRunWithDevice = (record2) => proofReplay ? Promise.resolve({ promoted: false, promotionRefused: false }) : persistRun(args.actionId, projectRoot, probeDeviceId ? { ...record2, deviceId: probeDeviceId } : record2);
@@ -70950,13 +71211,15 @@ function createRunActionHandler(deps = {}) {
         flowPath: action.filePath,
         platform: args.platform,
         appId: args.appId,
+        ...appFile ? { appFile } : {},
         deviceId: maestroDeviceId,
         timeoutMs,
         params: args.params,
         claimNativeOrigin: () => claimNativeOrigin(args),
         completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
         relaunchManagedApp: () => relaunchManagedApp(args),
-        completeRunnerPark: () => completeManagedRunnerParkAuthority(args)
+        completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+        reissueInstallReceipt: () => reissueInstallReceipt(args)
       });
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, "maestro_run");
@@ -71230,13 +71493,15 @@ function createRunActionHandler(deps = {}) {
         flowPath: reloadedAction.filePath,
         platform: args.platform,
         appId: args.appId,
+        ...appFile ? { appFile } : {},
         deviceId: maestroDeviceId,
         timeoutMs,
         params: args.params,
         claimNativeOrigin: () => claimNativeOrigin(args),
         completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
         relaunchManagedApp: () => relaunchManagedApp(args),
-        completeRunnerPark: () => completeManagedRunnerParkAuthority(args)
+        completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+        reissueInstallReceipt: () => reissueInstallReceipt(args)
       });
       const retryMs = Date.now() - tBeforeRetry;
       const retryEnv = parseEnvelope(retryResult, "maestro_run");
@@ -73279,155 +73544,6 @@ import { promisify as promisify24 } from "node:util";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
 import { dirname as dirname16, join as join36 } from "node:path";
 init_process_birth();
-
-// packages/rn-dev-agent-core/dist/session/runtime.js
-init_process_birth();
-init_registry();
-init_secure_state_file();
-var WorkerAuthorityRuntime = class {
-  available;
-  #registry;
-  #session;
-  #unavailable;
-  #recoveryOnly;
-  #recoveryCapability;
-  constructor(registry2, session2, unavailable2, recoveryOnly = false, recoveryCapability = null) {
-    this.#registry = registry2;
-    this.#session = session2;
-    this.#unavailable = unavailable2;
-    this.available = registry2 !== null && session2 !== null;
-    this.#recoveryOnly = recoveryOnly;
-    this.#recoveryCapability = recoveryCapability;
-  }
-  requireAvailable() {
-    if (!this.#registry || !this.#session) {
-      throw new SessionAuthorityError(this.#unavailable?.code ?? "SESSION_NOT_INITIALIZED", this.#unavailable?.reason ?? "authority session is unavailable");
-    }
-    return { registry: this.#registry, session: this.#session };
-  }
-  requireOperational() {
-    const available = this.requireAvailable();
-    const status = this.status();
-    if (status.available && (status.state === "blocked" || status.state === "handoff_cleanup")) {
-      throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "blocked contender exposes only accept_handoff and adopt_stale recovery");
-    }
-    return available;
-  }
-  requireRecovery() {
-    const available = this.requireAvailable();
-    const status = this.status();
-    if (!this.#recoveryOnly || !status.available || status.state !== "blocked" && status.state !== "handoff_cleanup") {
-      throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "session is not a capability-bound recovery contender");
-    }
-    return available;
-  }
-  /**
-   * GH #672: rotate an expired recovery handle before it is advertised. Best-effort by
-   * design — a refresh failure must degrade `status` to an honest expired handle, never
-   * turn a diagnostic call into an authority error.
-   */
-  refreshRecoveryHandles() {
-    if (!this.#registry || !this.#session || !this.#recoveryOnly || !this.#recoveryCapability) {
-      return false;
-    }
-    try {
-      const status = this.#registry.getSessionStatus(this.#session.sessionId);
-      const instanceId = status?.worker.instanceId;
-      if (!status || !instanceId || status.state !== "blocked" && status.state !== "handoff_cleanup") {
-        return false;
-      }
-      return this.#registry.refreshRecoveryHandles(this.#session, { instanceId }, this.#recoveryCapability);
-    } catch {
-      return false;
-    }
-  }
-  inspectRecoveryRequirement() {
-    if (!this.#registry || !this.#session)
-      return void 0;
-    try {
-      return this.#registry.inspectRecoveryRequirement(this.#session.sessionId);
-    } catch {
-      return void 0;
-    }
-  }
-  status() {
-    if (!this.#registry || !this.#session) {
-      return {
-        available: false,
-        code: this.#unavailable?.code ?? "SESSION_NOT_INITIALIZED",
-        reason: this.#unavailable?.reason ?? "authority session is unavailable"
-      };
-    }
-    const status = this.#registry.getSessionStatus(this.#session.sessionId);
-    if (!status) {
-      return {
-        available: false,
-        code: "SESSION_OWNER_LOST",
-        reason: "session is no longer present in the authority registry"
-      };
-    }
-    return { available: true, ...status };
-  }
-  close() {
-    this.#registry?.close();
-  }
-};
-function unavailable(reason, fallbackCode) {
-  const matched = /^([A-Z][A-Z0-9_]+):/.exec(reason);
-  return new WorkerAuthorityRuntime(null, null, {
-    code: matched?.[1] ?? fallbackCode,
-    reason
-  });
-}
-function createWorkerAuthorityRuntime(environment = process.env, dependencies = {}) {
-  if (environment.RN_DEV_AGENT_AUTHORITY_ERROR) {
-    return unavailable(environment.RN_DEV_AGENT_AUTHORITY_ERROR, "AUTHORITY_STORE_UNAVAILABLE");
-  }
-  const sessionId = environment.RN_DEV_AGENT_SESSION_ID;
-  const claimEpoch = Number(environment.RN_DEV_AGENT_CLAIM_EPOCH);
-  const registryPath = environment.RN_DEV_AGENT_REGISTRY_PATH;
-  const workerInstance = environment.RN_DEV_AGENT_WORKER_INSTANCE;
-  if (!sessionId || !Number.isSafeInteger(claimEpoch) || claimEpoch < 1 || !registryPath || !workerInstance) {
-    return unavailable("SESSION_NOT_INITIALIZED: supervisor did not provide a complete authority context", "SESSION_NOT_INITIALIZED");
-  }
-  const birth = (dependencies.readBirth ?? readProcessBirth)(process.pid);
-  if (!birth) {
-    return unavailable("PROCESS_BIRTH_UNAVAILABLE: worker process birth could not be proven conservatively", "PROCESS_BIRTH_UNAVAILABLE");
-  }
-  try {
-    const registry2 = openSessionRegistry(registryPath, {
-      ownerStatus: dependencies.ownerStatus ?? inspectSessionOwner
-    });
-    const session2 = { sessionId, claimEpoch };
-    const status = registry2.getSessionStatus(sessionId);
-    const recoveryOnly = status?.state === "blocked" || status?.state === "handoff_cleanup";
-    let recoveryCapability = null;
-    if (recoveryOnly) {
-      const secretPath = environment.RN_DEV_AGENT_SESSION_SECRET_PATH;
-      recoveryCapability = secretPath ? readJsonStateFile(secretPath)?.recoveryCapability ?? null : null;
-      if (!recoveryCapability) {
-        throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "blocked recovery capability is unavailable");
-      }
-      registry2.bindRecoveryWorker(session2, { instanceId: workerInstance, pid: birth.pid, token: birth.token }, recoveryCapability);
-    } else {
-      registry2.bindWorker(session2, {
-        instanceId: workerInstance,
-        pid: birth.pid,
-        token: birth.token
-      });
-    }
-    return new WorkerAuthorityRuntime(registry2, session2, null, recoveryOnly, recoveryCapability);
-  } catch (error2) {
-    return unavailable(error2 instanceof Error ? error2.message : "AUTHORITY_STORE_UNAVAILABLE: worker authority could not be opened", "AUTHORITY_STORE_UNAVAILABLE");
-  }
-}
-var sharedRuntime = null;
-function getWorkerAuthorityRuntime() {
-  sharedRuntime ??= createWorkerAuthorityRuntime();
-  return sharedRuntime;
-}
-
-// packages/rn-dev-agent-core/dist/tools/device-record.js
 var execFileAsync5 = promisify24(execFile22);
 var START_TIMEOUT_MS = 1e4;
 var STATUS_TIMEOUT_MS = 5e3;
@@ -78719,6 +78835,7 @@ function createMetroEventsHandler(getClient2) {
 // packages/rn-dev-agent-core/dist/index.js
 init_rn_fast_runner_client();
 init_rn_android_runner_client();
+init_install_authority();
 init_process_birth();
 init_ensure_single_runner();
 
@@ -81050,6 +81167,7 @@ init_authority_gate();
 // packages/rn-dev-agent-core/dist/session/local-authority-probe.js
 init_discovery();
 init_metro_cwd();
+init_install_authority();
 import { execFileSync as execFileSync17 } from "node:child_process";
 import { createHash as createHash19 } from "node:crypto";
 init_metro_binding();
@@ -83960,6 +84078,7 @@ trackedTool(
     actionId: external_exports.string().describe("Action id matching <projectRoot>/.rn-agent/actions/<actionId>.yaml."),
     projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
     platform: external_exports.enum(["ios", "android"]).optional().describe("Force a specific platform; otherwise auto-detected from the active device session."),
+    appFile: external_exports.string().optional().describe("GH #705: path to the .app Maestro reinstalls from after a clearState uninstall. Normally omit it \u2014 an iOS clearState flow resolves the bundle from the session's attested install receipt, and the receipt is re-issued after the reinstall so later device_*/maestro_run calls keep working."),
     autoRepair: external_exports.boolean().optional().describe("Auto-repair on SELECTOR_NOT_FOUND failures. Default true. Pass false to disable (e.g. when investigating a failure manually)."),
     timeoutMs: external_exports.number().optional().describe("Maestro execution timeout per attempt (ms). Default 120_000."),
     trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe('RunRecord trigger annotation. Default "agent". CI calls should pass "ci".'),

--- a/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -44,6 +44,186 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
+// packages/rn-dev-agent-core/dist/session/install-authority.js
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { lstatSync, readFileSync, readdirSync, readlinkSync, realpathSync, statSync } from "node:fs";
+import { isAbsolute, join, relative } from "node:path";
+function runText(command, args) {
+  return execFileSync(command, [...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 1e4,
+    maxBuffer: 8 * 1024 * 1024
+  });
+}
+function runBuffer(command, args) {
+  return execFileSync(command, [...args], {
+    encoding: "buffer",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 3e4,
+    maxBuffer: 512 * 1024 * 1024
+  });
+}
+function digest(parts) {
+  const hash = createHash("sha256");
+  for (const part of parts) {
+    hash.update(`${part.byteLength}:`);
+    hash.update(part);
+  }
+  return hash.digest("hex");
+}
+function generation(parts) {
+  return digest(parts.map((part) => Buffer.from(part)));
+}
+function listAppFiles(appPath) {
+  const files = [];
+  const visit = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(path);
+      } else if (entry.isFile() || entry.isSymbolicLink()) {
+        files.push(relative(appPath, path));
+      } else {
+        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
+      }
+    }
+  };
+  visit(appPath);
+  return files.sort();
+}
+function iosAppFiles(appPath, dependencies) {
+  return [...(dependencies.listAppFiles ?? listAppFiles)(appPath)].sort();
+}
+function assertIosSymlinkContained(appPath, path, realpath) {
+  const target = realpath(path);
+  const child = relative(realpath(appPath), target);
+  if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute(child)) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app symlink escapes the installed bundle");
+  }
+}
+function androidApkPaths(target, text) {
+  return text("adb", ["-s", target.deviceId, "shell", "pm", "path", target.appId]).split("\n").map((line) => line.trim()).filter((line) => line.startsWith("package:")).map((line) => line.slice("package:".length)).sort();
+}
+function captureInstallGeneration(target, dependencies = {}) {
+  const text = dependencies.runText ?? runText;
+  if (target.platform === "ios") {
+    const appPath = text("xcrun", [
+      "simctl",
+      "get_app_container",
+      target.deviceId,
+      target.appId,
+      "app"
+    ]).trim();
+    if (!appPath) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
+    }
+    const infoPath = join(appPath, "Info.plist");
+    const executable = text("plutil", [
+      "-extract",
+      "CFBundleExecutable",
+      "raw",
+      "-o",
+      "-",
+      infoPath
+    ]).trim();
+    if (!executable) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
+    }
+    const stat = dependencies.stat ?? statSync;
+    const metadata2 = iosAppFiles(appPath, dependencies).map((entry) => {
+      const path = join(appPath, entry);
+      const value = stat(path);
+      return `${entry}:${String(value.ino)}:${value.size}:${value.mtimeMs}`;
+    });
+    return generation(metadata2);
+  }
+  const apkPaths = androidApkPaths(target, text);
+  if (!apkPaths.length) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
+  }
+  const metadata = text("adb", [
+    "-s",
+    target.deviceId,
+    "shell",
+    "stat",
+    "-c",
+    "%n:%i:%s:%Y",
+    ...apkPaths
+  ]).split("\n").map((line) => line.trim()).filter(Boolean).sort();
+  if (metadata.length !== apkPaths.length) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: Android install generation is unavailable");
+  }
+  return generation(metadata);
+}
+function captureInstalledArtifact(target, dependencies = {}) {
+  const text = dependencies.runText ?? runText;
+  const buffer = dependencies.runBuffer ?? runBuffer;
+  const read = dependencies.read ?? readFileSync;
+  if (target.platform === "ios") {
+    const appPath = text("xcrun", [
+      "simctl",
+      "get_app_container",
+      target.deviceId,
+      target.appId,
+      "app"
+    ]).trim();
+    if (!appPath) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
+    }
+    const infoPath = join(appPath, "Info.plist");
+    const executable = text("plutil", [
+      "-extract",
+      "CFBundleExecutable",
+      "raw",
+      "-o",
+      "-",
+      infoPath
+    ]).trim();
+    if (!executable) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
+    }
+    const files = iosAppFiles(appPath, dependencies);
+    const lstat = dependencies.lstat ?? lstatSync;
+    const readLink = dependencies.readLink ?? readlinkSync;
+    const realpath = dependencies.realpath ?? realpathSync;
+    const artifactParts = [];
+    for (const entry of files) {
+      const path = join(appPath, entry);
+      const stat = lstat(path);
+      artifactParts.push(Buffer.from(entry));
+      if (stat.isFile()) {
+        artifactParts.push(Buffer.from("file"), read(path));
+      } else if (stat.isSymbolicLink()) {
+        assertIosSymlinkContained(appPath, path, realpath);
+        artifactParts.push(Buffer.from("symlink"), Buffer.from(readLink(path)));
+      } else {
+        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
+      }
+    }
+    return {
+      ...target,
+      artifactDigest: digest(artifactParts),
+      installGeneration: captureInstallGeneration(target, dependencies)
+    };
+  }
+  const apkPaths = androidApkPaths(target, text);
+  if (!apkPaths.length) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
+  }
+  return {
+    ...target,
+    artifactDigest: digest(apkPaths.map((path) => buffer("adb", ["-s", target.deviceId, "exec-out", "cat", path]))),
+    installGeneration: captureInstallGeneration(target, dependencies)
+  };
+}
+var init_install_authority = __esm({
+  "packages/rn-dev-agent-core/dist/session/install-authority.js"() {
+    "use strict";
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/declared-source-contract.js
 function parseDeclaredManifests(value) {
   if (value === void 0)
@@ -11090,6 +11270,15 @@ var init_maestro_runner_report = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/session/install-reissue.js
+var init_install_reissue = __esm({
+  "packages/rn-dev-agent-core/dist/session/install-reissue.js"() {
+    "use strict";
+    init_install_authority();
+    init_registry();
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -11255,6 +11444,7 @@ var init_tool_profiles = __esm({
       optionalAxes: ["B"],
       managedOrigin: true,
       managedRunnerPark: true,
+      managedInstallReissue: true,
       mutation: true,
       liveBundleProbe: true
     });
@@ -11302,6 +11492,7 @@ var init_authority_gate = __esm({
     "use strict";
     init_utils();
     init_registry();
+    init_install_reissue();
     init_tool_profiles();
   }
 });
@@ -11860,180 +12051,8 @@ function createBuildReceipt(payload, capability) {
   return { version: 1, payload, signature: sign(payload, capability) };
 }
 
-// packages/rn-dev-agent-core/dist/session/install-authority.js
-import { execFileSync } from "node:child_process";
-import { createHash } from "node:crypto";
-import { lstatSync, readFileSync, readdirSync, readlinkSync, realpathSync, statSync } from "node:fs";
-import { isAbsolute, join, relative } from "node:path";
-function runText(command, args) {
-  return execFileSync(command, [...args], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-    timeout: 1e4,
-    maxBuffer: 8 * 1024 * 1024
-  });
-}
-function runBuffer(command, args) {
-  return execFileSync(command, [...args], {
-    encoding: "buffer",
-    stdio: ["ignore", "pipe", "ignore"],
-    timeout: 3e4,
-    maxBuffer: 512 * 1024 * 1024
-  });
-}
-function digest(parts) {
-  const hash = createHash("sha256");
-  for (const part of parts) {
-    hash.update(`${part.byteLength}:`);
-    hash.update(part);
-  }
-  return hash.digest("hex");
-}
-function generation(parts) {
-  return digest(parts.map((part) => Buffer.from(part)));
-}
-function listAppFiles(appPath) {
-  const files = [];
-  const visit = (directory) => {
-    for (const entry of readdirSync(directory, { withFileTypes: true })) {
-      const path = join(directory, entry.name);
-      if (entry.isDirectory()) {
-        visit(path);
-      } else if (entry.isFile() || entry.isSymbolicLink()) {
-        files.push(relative(appPath, path));
-      } else {
-        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
-      }
-    }
-  };
-  visit(appPath);
-  return files.sort();
-}
-function iosAppFiles(appPath, dependencies) {
-  return [...(dependencies.listAppFiles ?? listAppFiles)(appPath)].sort();
-}
-function assertIosSymlinkContained(appPath, path, realpath) {
-  const target = realpath(path);
-  const child = relative(realpath(appPath), target);
-  if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute(child)) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app symlink escapes the installed bundle");
-  }
-}
-function androidApkPaths(target, text) {
-  return text("adb", ["-s", target.deviceId, "shell", "pm", "path", target.appId]).split("\n").map((line) => line.trim()).filter((line) => line.startsWith("package:")).map((line) => line.slice("package:".length)).sort();
-}
-function captureInstallGeneration(target, dependencies = {}) {
-  const text = dependencies.runText ?? runText;
-  if (target.platform === "ios") {
-    const appPath = text("xcrun", [
-      "simctl",
-      "get_app_container",
-      target.deviceId,
-      target.appId,
-      "app"
-    ]).trim();
-    if (!appPath) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
-    }
-    const infoPath = join(appPath, "Info.plist");
-    const executable = text("plutil", [
-      "-extract",
-      "CFBundleExecutable",
-      "raw",
-      "-o",
-      "-",
-      infoPath
-    ]).trim();
-    if (!executable) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
-    }
-    const stat = dependencies.stat ?? statSync;
-    const metadata2 = iosAppFiles(appPath, dependencies).map((entry) => {
-      const path = join(appPath, entry);
-      const value = stat(path);
-      return `${entry}:${String(value.ino)}:${value.size}:${value.mtimeMs}`;
-    });
-    return generation(metadata2);
-  }
-  const apkPaths = androidApkPaths(target, text);
-  if (!apkPaths.length) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
-  }
-  const metadata = text("adb", [
-    "-s",
-    target.deviceId,
-    "shell",
-    "stat",
-    "-c",
-    "%n:%i:%s:%Y",
-    ...apkPaths
-  ]).split("\n").map((line) => line.trim()).filter(Boolean).sort();
-  if (metadata.length !== apkPaths.length) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: Android install generation is unavailable");
-  }
-  return generation(metadata);
-}
-function captureInstalledArtifact(target, dependencies = {}) {
-  const text = dependencies.runText ?? runText;
-  const buffer = dependencies.runBuffer ?? runBuffer;
-  const read = dependencies.read ?? readFileSync;
-  if (target.platform === "ios") {
-    const appPath = text("xcrun", [
-      "simctl",
-      "get_app_container",
-      target.deviceId,
-      target.appId,
-      "app"
-    ]).trim();
-    if (!appPath) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
-    }
-    const infoPath = join(appPath, "Info.plist");
-    const executable = text("plutil", [
-      "-extract",
-      "CFBundleExecutable",
-      "raw",
-      "-o",
-      "-",
-      infoPath
-    ]).trim();
-    if (!executable) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
-    }
-    const files = iosAppFiles(appPath, dependencies);
-    const lstat = dependencies.lstat ?? lstatSync;
-    const readLink = dependencies.readLink ?? readlinkSync;
-    const realpath = dependencies.realpath ?? realpathSync;
-    const artifactParts = [];
-    for (const entry of files) {
-      const path = join(appPath, entry);
-      const stat = lstat(path);
-      artifactParts.push(Buffer.from(entry));
-      if (stat.isFile()) {
-        artifactParts.push(Buffer.from("file"), read(path));
-      } else if (stat.isSymbolicLink()) {
-        assertIosSymlinkContained(appPath, path, realpath);
-        artifactParts.push(Buffer.from("symlink"), Buffer.from(readLink(path)));
-      } else {
-        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
-      }
-    }
-    return {
-      ...target,
-      artifactDigest: digest(artifactParts),
-      installGeneration: captureInstallGeneration(target, dependencies)
-    };
-  }
-  const apkPaths = androidApkPaths(target, text);
-  if (!apkPaths.length) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
-  }
-  return {
-    ...target,
-    artifactDigest: digest(apkPaths.map((path) => buffer("adb", ["-s", target.deviceId, "exec-out", "cat", path]))),
-    installGeneration: captureInstallGeneration(target, dependencies)
-  };
-}
+// packages/rn-dev-agent-core/dist/rn-session.js
+init_install_authority();
 
 // packages/rn-dev-agent-core/dist/session/expo-android-device.js
 import { execFileSync as execFileSync2 } from "node:child_process";

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -26549,7 +26549,7 @@ function authorityProfileFor(tool, args = {}) {
       postflightAxes: facetsOf(throughRuntime, { without: ["A", "B"] }),
       managedOrigin: true,
       managedRunnerPark: true,
-      managedInstallReissue: true,
+      managedInstallReissue: tool === "maestro_run",
       mutation: true,
       liveBundleProbe: false
     };

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -25540,7 +25540,7 @@ function resolveIosAppFile(bundleId, deps = {}) {
   const exists = deps.exists ?? existsSync15;
   const getAppContainer = deps.getAppContainer ?? defaultGetAppContainer;
   const snapshotApp = deps.snapshotApp ?? defaultSnapshotApp;
-  const fromContainer = getAppContainer(bundleId);
+  const fromContainer = getAppContainer(bundleId, deps.deviceId);
   if (fromContainer && exists(fromContainer)) {
     const snapshot = snapshotApp(fromContainer);
     if (snapshot)
@@ -25571,9 +25571,10 @@ function resolveAppFileForClearState(platform, flowText, headerAppId, explicitAp
   }
   return { ok: true, appFile };
 }
-function defaultGetAppContainer(bundleId) {
+function defaultGetAppContainer(bundleId, deviceId) {
   try {
-    const out = execFileSync9("xcrun", ["simctl", "get_app_container", "booted", bundleId, "app"], {
+    const target = deviceId && !/\s/.test(deviceId) ? deviceId : "booted";
+    const out = execFileSync9("xcrun", ["simctl", "get_app_container", target, bundleId, "app"], {
       encoding: "utf8",
       timeout: 5e3
     }).trim();
@@ -26239,6 +26240,226 @@ var init_maestro_runner_report = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/session/install-authority.js
+import { execFileSync as execFileSync10 } from "node:child_process";
+import { createHash as createHash11 } from "node:crypto";
+import { lstatSync as lstatSync9, readFileSync as readFileSync18, readdirSync as readdirSync6, readlinkSync as readlinkSync3, realpathSync as realpathSync8, statSync as statSync9 } from "node:fs";
+import { isAbsolute as isAbsolute5, join as join20, relative as relative3 } from "node:path";
+function runText(command, args) {
+  return execFileSync10(command, [...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 1e4,
+    maxBuffer: 8 * 1024 * 1024
+  });
+}
+function runBuffer(command, args) {
+  return execFileSync10(command, [...args], {
+    encoding: "buffer",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 3e4,
+    maxBuffer: 512 * 1024 * 1024
+  });
+}
+function digest2(parts) {
+  const hash = createHash11("sha256");
+  for (const part of parts) {
+    hash.update(`${part.byteLength}:`);
+    hash.update(part);
+  }
+  return hash.digest("hex");
+}
+function generation(parts) {
+  return digest2(parts.map((part) => Buffer.from(part)));
+}
+function listAppFiles(appPath) {
+  const files = [];
+  const visit = (directory) => {
+    for (const entry of readdirSync6(directory, { withFileTypes: true })) {
+      const path = join20(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(path);
+      } else if (entry.isFile() || entry.isSymbolicLink()) {
+        files.push(relative3(appPath, path));
+      } else {
+        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
+      }
+    }
+  };
+  visit(appPath);
+  return files.sort();
+}
+function iosAppFiles(appPath, dependencies) {
+  return [...(dependencies.listAppFiles ?? listAppFiles)(appPath)].sort();
+}
+function assertIosSymlinkContained(appPath, path, realpath) {
+  const target = realpath(path);
+  const child = relative3(realpath(appPath), target);
+  if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute5(child)) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app symlink escapes the installed bundle");
+  }
+}
+function androidApkPaths(target, text) {
+  return text("adb", ["-s", target.deviceId, "shell", "pm", "path", target.appId]).split("\n").map((line) => line.trim()).filter((line) => line.startsWith("package:")).map((line) => line.slice("package:".length)).sort();
+}
+function captureInstallGeneration(target, dependencies = {}) {
+  const text = dependencies.runText ?? runText;
+  if (target.platform === "ios") {
+    const appPath = text("xcrun", [
+      "simctl",
+      "get_app_container",
+      target.deviceId,
+      target.appId,
+      "app"
+    ]).trim();
+    if (!appPath) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
+    }
+    const infoPath = join20(appPath, "Info.plist");
+    const executable = text("plutil", [
+      "-extract",
+      "CFBundleExecutable",
+      "raw",
+      "-o",
+      "-",
+      infoPath
+    ]).trim();
+    if (!executable) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
+    }
+    const stat2 = dependencies.stat ?? statSync9;
+    const metadata2 = iosAppFiles(appPath, dependencies).map((entry) => {
+      const path = join20(appPath, entry);
+      const value = stat2(path);
+      return `${entry}:${String(value.ino)}:${value.size}:${value.mtimeMs}`;
+    });
+    return generation(metadata2);
+  }
+  const apkPaths = androidApkPaths(target, text);
+  if (!apkPaths.length) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
+  }
+  const metadata = text("adb", [
+    "-s",
+    target.deviceId,
+    "shell",
+    "stat",
+    "-c",
+    "%n:%i:%s:%Y",
+    ...apkPaths
+  ]).split("\n").map((line) => line.trim()).filter(Boolean).sort();
+  if (metadata.length !== apkPaths.length) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: Android install generation is unavailable");
+  }
+  return generation(metadata);
+}
+function captureInstalledArtifact(target, dependencies = {}) {
+  const text = dependencies.runText ?? runText;
+  const buffer = dependencies.runBuffer ?? runBuffer;
+  const read = dependencies.read ?? readFileSync18;
+  if (target.platform === "ios") {
+    const appPath = text("xcrun", [
+      "simctl",
+      "get_app_container",
+      target.deviceId,
+      target.appId,
+      "app"
+    ]).trim();
+    if (!appPath) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
+    }
+    const infoPath = join20(appPath, "Info.plist");
+    const executable = text("plutil", [
+      "-extract",
+      "CFBundleExecutable",
+      "raw",
+      "-o",
+      "-",
+      infoPath
+    ]).trim();
+    if (!executable) {
+      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
+    }
+    const files = iosAppFiles(appPath, dependencies);
+    const lstat = dependencies.lstat ?? lstatSync9;
+    const readLink = dependencies.readLink ?? readlinkSync3;
+    const realpath = dependencies.realpath ?? realpathSync8;
+    const artifactParts = [];
+    for (const entry of files) {
+      const path = join20(appPath, entry);
+      const stat2 = lstat(path);
+      artifactParts.push(Buffer.from(entry));
+      if (stat2.isFile()) {
+        artifactParts.push(Buffer.from("file"), read(path));
+      } else if (stat2.isSymbolicLink()) {
+        assertIosSymlinkContained(appPath, path, realpath);
+        artifactParts.push(Buffer.from("symlink"), Buffer.from(readLink(path)));
+      } else {
+        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
+      }
+    }
+    return {
+      ...target,
+      artifactDigest: digest2(artifactParts),
+      installGeneration: captureInstallGeneration(target, dependencies)
+    };
+  }
+  const apkPaths = androidApkPaths(target, text);
+  if (!apkPaths.length) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
+  }
+  return {
+    ...target,
+    artifactDigest: digest2(apkPaths.map((path) => buffer("adb", ["-s", target.deviceId, "exec-out", "cat", path]))),
+    installGeneration: captureInstallGeneration(target, dependencies)
+  };
+}
+function verifyInstalledArtifact(expected, observed) {
+  if (expected.platform !== observed.platform || expected.deviceId !== observed.deviceId || expected.appId !== observed.appId || expected.artifactDigest !== observed.artifactDigest || expected.installGeneration !== observed.installGeneration) {
+    throw new Error("APP_INSTALL_IDENTITY_CHANGED: installed artifact no longer matches the session build");
+  }
+}
+var init_install_authority = __esm({
+  "packages/rn-dev-agent-core/dist/session/install-authority.js"() {
+    "use strict";
+  }
+});
+
+// packages/rn-dev-agent-core/dist/session/install-reissue.js
+function reissueInstallBinding(install, dependencies = {}) {
+  const platform = install?.platform;
+  const deviceId = install?.deviceId;
+  const appId = install?.appId;
+  const artifactDigest = install?.artifactDigest;
+  const installGeneration = install?.installGeneration;
+  if (platform !== "ios" && platform !== "android" || typeof deviceId !== "string" || typeof appId !== "string" || typeof artifactDigest !== "string" || typeof installGeneration !== "string") {
+    throw new SessionAuthorityError("APP_INSTALL_IDENTITY_CHANGED", "no attested install receipt is bound to re-issue after the reinstall");
+  }
+  let observed;
+  try {
+    observed = (dependencies.captureInstalled ?? captureInstalledArtifact)({
+      platform,
+      deviceId,
+      appId
+    });
+  } catch {
+    throw new SessionAuthorityError("APP_INSTALL_IDENTITY_CHANGED", "the reinstalled artifact could not be attested");
+  }
+  if (observed.artifactDigest !== artifactDigest) {
+    throw new SessionAuthorityError("APP_INSTALL_IDENTITY_CHANGED", "the reinstalled artifact is not the attested session build");
+  }
+  if (observed.installGeneration === installGeneration)
+    return null;
+  return { ...install, installGeneration: observed.installGeneration };
+}
+var init_install_reissue = __esm({
+  "packages/rn-dev-agent-core/dist/session/install-reissue.js"() {
+    "use strict";
+    init_install_authority();
+    init_registry();
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -26328,6 +26549,7 @@ function authorityProfileFor(tool, args = {}) {
       postflightAxes: facetsOf(throughRuntime, { without: ["A", "B"] }),
       managedOrigin: true,
       managedRunnerPark: true,
+      managedInstallReissue: true,
       mutation: true,
       liveBundleProbe: false
     };
@@ -26513,6 +26735,7 @@ var init_tool_profiles = __esm({
       optionalAxes: ["B"],
       managedOrigin: true,
       managedRunnerPark: true,
+      managedInstallReissue: true,
       mutation: true,
       liveBundleProbe: true
     });
@@ -26556,8 +26779,8 @@ var init_tool_profiles = __esm({
 
 // packages/rn-dev-agent-core/dist/session/authority-gate.js
 import { randomUUID as randomUUID5 } from "node:crypto";
-import { realpathSync as realpathSync8 } from "node:fs";
-import { isAbsolute as isAbsolute5, relative as relative3, resolve as resolve6 } from "node:path";
+import { realpathSync as realpathSync9 } from "node:fs";
+import { isAbsolute as isAbsolute6, relative as relative4, resolve as resolve6 } from "node:path";
 async function claimOptionalBundleAuthority(args) {
   return await args[optionalBundleAdmission]?.() ?? false;
 }
@@ -26581,6 +26804,16 @@ async function relaunchManagedNativeOriginApp(args) {
     throw new SessionAuthorityError("METRO_ORIGIN_MISMATCH", "managed native origin relaunch authority is unavailable");
   }
   await authority.relaunch();
+}
+async function reissueManagedInstallAuthority(args) {
+  const reissue = args[managedInstallReissue];
+  if (!reissue) {
+    throw new SessionAuthorityError("APP_INSTALL_IDENTITY_CHANGED", "managed install re-issue authority is unavailable");
+  }
+  await reissue();
+}
+function hasManagedInstallReissueAuthority(args) {
+  return typeof args[managedInstallReissue] === "function";
 }
 function hasManagedRunnerParkAuthority(args) {
   return typeof args[managedRunnerPark] === "function";
@@ -26711,7 +26944,7 @@ function bindSourcePaths(status, args) {
   try {
     if (typeof status.source.appRoot !== "string")
       throw new Error("missing app root");
-    appRoot = realpathSync8(status.source.appRoot);
+    appRoot = realpathSync9(status.source.appRoot);
   } catch {
     throw new SessionAuthorityError("SOURCE_WORKTREE_MISMATCH", "active session app root is unavailable");
   }
@@ -26724,12 +26957,12 @@ function bindSourcePaths(status, args) {
     }
     let candidate;
     try {
-      candidate = realpathSync8(isAbsolute5(supplied) ? supplied : resolve6(appRoot, supplied));
+      candidate = realpathSync9(isAbsolute6(supplied) ? supplied : resolve6(appRoot, supplied));
     } catch {
       throw new SessionAuthorityError("SOURCE_WORKTREE_MISMATCH", `${field2} cannot be resolved within the active app root`);
     }
-    const child = relative3(appRoot, candidate);
-    if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute5(child)) {
+    const child = relative4(appRoot, candidate);
+    if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute6(child)) {
       throw new SessionAuthorityError("SOURCE_WORKTREE_MISMATCH", `${field2} is outside the active session app root`);
     }
     args[field2] = candidate;
@@ -27152,6 +27385,7 @@ function createAuthorityGate(runtime, dependencies) {
         let optionalBundleClaimed = false;
         let optionalBundleRecoveryFailed = false;
         let managedRunnerParked = false;
+        let installReceiptReissued = false;
         if (profile.optionalAxes?.includes("B")) {
           Object.defineProperty(args, optionalBundleAdmission, {
             configurable: true,
@@ -27355,6 +27589,30 @@ function createAuthorityGate(runtime, dependencies) {
             }
           });
         }
+        if (profile.managedInstallReissue) {
+          Object.defineProperty(args, managedInstallReissue, {
+            configurable: true,
+            value: async () => {
+              const currentStatus = runtime.status();
+              if (!currentStatus.available) {
+                throw new SessionAuthorityError(currentStatus.code, currentStatus.reason);
+              }
+              registry2.verifyOperation(operation);
+              const install = (dependencies.reissueInstallBinding ?? reissueInstallBinding)(currentStatus.bindings.install);
+              if (!install)
+                return;
+              operation = registry2.replaceBindingsDuringOperation(operation, {
+                bindings: { install }
+              });
+              const reissuedStatus = runtime.status();
+              if (!reissuedStatus.available) {
+                throw new SessionAuthorityError(reissuedStatus.code, reissuedStatus.reason);
+              }
+              status = reissuedStatus;
+              installReceiptReissued = true;
+            }
+          });
+        }
         if (profile.managedRunnerPark) {
           Object.defineProperty(args, managedRunnerPark, {
             configurable: true,
@@ -27506,6 +27764,8 @@ function createAuthorityGate(runtime, dependencies) {
           if ((runtimeTargetChanged || managedRuntimeTargetChanged) && observation.axis === "B") {
             continue;
           }
+          if (installReceiptReissued && observation.axis === "I")
+            continue;
           if (!postflightAxes.includes(observation.axis))
             continue;
           const postflight = after.find((candidate) => candidate.axis === observation.axis);
@@ -27572,16 +27832,18 @@ function createAuthorityGate(runtime, dependencies) {
     }
   };
 }
-var optionalBundleAdmission, managedNativeOrigin, managedRunnerPark, axisBinding, axisErrors;
+var optionalBundleAdmission, managedNativeOrigin, managedRunnerPark, managedInstallReissue, axisBinding, axisErrors;
 var init_authority_gate = __esm({
   "packages/rn-dev-agent-core/dist/session/authority-gate.js"() {
     "use strict";
     init_utils();
     init_registry();
+    init_install_reissue();
     init_tool_profiles();
     optionalBundleAdmission = /* @__PURE__ */ Symbol("optionalBundleAdmission");
     managedNativeOrigin = /* @__PURE__ */ Symbol("managedNativeOrigin");
     managedRunnerPark = /* @__PURE__ */ Symbol("managedRunnerPark");
+    managedInstallReissue = /* @__PURE__ */ Symbol("managedInstallReissue");
     axisBinding = {
       I: "install",
       M: "metro",
@@ -27607,9 +27869,9 @@ var init_authority_gate = __esm({
 // packages/rn-dev-agent-core/dist/tools/maestro-run.js
 import { execFile as execFileCb3 } from "node:child_process";
 import { promisify as promisify4 } from "node:util";
-import { existsSync as existsSync17, readFileSync as readFileSync18, writeFileSync as writeFileSync8 } from "node:fs";
+import { existsSync as existsSync17, readFileSync as readFileSync19, writeFileSync as writeFileSync8 } from "node:fs";
 import { tmpdir as tmpdir6 } from "node:os";
-import { join as join20, dirname as dirname10 } from "node:path";
+import { join as join21, dirname as dirname10 } from "node:path";
 async function runFlowParked(run, opts = {}) {
   const stale = opts.markCdpStale ?? markCdpStale;
   try {
@@ -27635,7 +27897,8 @@ function nestedMaestroAuthorityCallbacks(args) {
     claimNativeOrigin: () => claimManagedNativeOriginAuthority(args),
     completeNativeOrigin: (targetExpected) => completeManagedNativeOriginAuthority(args, targetExpected),
     relaunchManagedApp: () => relaunchManagedNativeOriginApp(args),
-    completeRunnerPark: () => completeManagedRunnerParkAuthority(args)
+    completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+    reissueInstallReceipt: hasManagedInstallReissueAuthority(args) ? () => reissueManagedInstallAuthority(args) : null
   };
 }
 function commandName(command) {
@@ -27775,7 +28038,7 @@ function createMaestroRunHandler(deps = {}) {
         return failResult(`Flow file not found: ${args.flowPath}`);
       }
       try {
-        rawYaml = readFileSync18(args.flowPath, "utf-8");
+        rawYaml = readFileSync19(args.flowPath, "utf-8");
       } catch (err) {
         return failResult(`Failed to read flow file: ${err.message}`);
       }
@@ -27791,7 +28054,7 @@ function createMaestroRunHandler(deps = {}) {
       const rawAppId = resolveAppId(args.appId, platform);
       headerAppId = resolveMaestroFlowAppId(rawAppId || void 0, parsed.appId);
       validatedContent = buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, parsed.commands);
-      flowFile = join20(tmpdir6(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      flowFile = join21(tmpdir6(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
       writeFileSync8(flowFile, validatedContent, "utf-8");
     } catch (err) {
       if (err instanceof MaestroValidationError) {
@@ -27805,10 +28068,19 @@ function createMaestroRunHandler(deps = {}) {
     }
     const timeout = args.timeoutMs ?? 12e4;
     const flowDeadline = now() + timeout;
-    const appFileResolution = resolveAppFileForClearState(platform, validatedContent, headerAppId, args.appFile);
+    const appFileResolution = resolveAppFileForClearState(platform, validatedContent, headerAppId, args.appFile, { deviceId: requestedDeviceId });
     if (!appFileResolution.ok) {
       return failResult(appFileResolution.error);
     }
+    const reinstallsApp = Boolean(appFileResolution.appFile) && flowUsesClearState(validatedContent);
+    const reissueInstallReceipt = args.reissueInstallReceipt ?? deps.reissueInstallReceipt ?? nestedMaestroAuthorityCallbacks(args).reissueInstallReceipt;
+    let installReceiptCommitted = false;
+    const commitReinstalledInstall = async () => {
+      if (!reinstallsApp || installReceiptCommitted || !reissueInstallReceipt)
+        return;
+      installReceiptCommitted = true;
+      await reissueInstallReceipt();
+    };
     const baseArgs = dispatch.buildArgs(platform, flowFile, appFileResolution.appFile, requestedDeviceId);
     const paramArgs = [];
     if (args.params) {
@@ -27851,6 +28123,7 @@ function createMaestroRunHandler(deps = {}) {
         deviceId: requestedDeviceId,
         completeRunnerPark: args.completeRunnerPark ?? managedAuthority.completeRunnerPark
       });
+      await commitReinstalledInstall();
       const stdout = stageResults.map((result) => result.stdout).join("\n");
       const stderr = stageResults.map((result) => result.stderr).join("\n");
       const output = combineRunnerOutput(stdout, stderr);
@@ -27908,6 +28181,7 @@ function createMaestroRunHandler(deps = {}) {
       const warnAug = augmentFailureWithDegradation(output, resolveFloorMs(process.env.RN_RUNTIME_DEGRADED_FLOOR_MS), baseWarnMsg, meta);
       return warnResult(warnAug.meta, warnAug.message);
     } catch (err) {
+      await commitReinstalledInstall();
       if (err instanceof SessionAuthorityError)
         throw err;
       const stageError = err instanceof MaestroStageExecutionError ? err.stageError : err;
@@ -28027,7 +28301,7 @@ var init_maestro_run = __esm({
 
 // packages/rn-dev-agent-core/dist/session/managed-automation.js
 import { spawn as spawn5 } from "node:child_process";
-import { readdirSync as readdirSync6, readFileSync as readFileSync19, unlinkSync as unlinkSync5 } from "node:fs";
+import { readdirSync as readdirSync7, readFileSync as readFileSync20, unlinkSync as unlinkSync5 } from "node:fs";
 function sleep2(ms) {
   return new Promise((resolve11) => setTimeout(resolve11, ms));
 }
@@ -28044,12 +28318,12 @@ function processGroupLiveness(pgid) {
   if (process.platform !== "linux")
     return "unknown";
   try {
-    for (const entry of readdirSync6("/proc", { withFileTypes: true })) {
+    for (const entry of readdirSync7("/proc", { withFileTypes: true })) {
       if (!entry.isDirectory() || !/^\d+$/.test(entry.name))
         continue;
       let stat2;
       try {
-        stat2 = readFileSync19(`/proc/${entry.name}/stat`, "utf8");
+        stat2 = readFileSync20(`/proc/${entry.name}/stat`, "utf8");
       } catch (error2) {
         if (error2.code === "ENOENT")
           continue;
@@ -28660,7 +28934,7 @@ var init_device_arbiter = __esm({
 
 // packages/rn-dev-agent-core/dist/maestro-invoke.js
 import { existsSync as existsSync18, writeFileSync as writeFileSync9 } from "node:fs";
-import { join as join21 } from "node:path";
+import { join as join22 } from "node:path";
 import { homedir as homedir5, tmpdir as tmpdir7 } from "node:os";
 function yamlEscape(s) {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t");
@@ -28678,7 +28952,7 @@ function maestroRefusalResult(result, fallbackMessage, meta) {
   });
 }
 function getMaestroRunnerPath() {
-  const path = join21(homedir5(), ".maestro-runner", "bin", "maestro-runner");
+  const path = join22(homedir5(), ".maestro-runner", "bin", "maestro-runner");
   return existsSync18(path) ? path : null;
 }
 async function runMaestroInline(yaml2, opts, dependencies = {}) {
@@ -28689,7 +28963,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     return { passed: false, output: "", flowFile: "", error: dispatch.error };
   }
   const rawAppId = opts.appId ?? resolveBundleId(opts.platform) ?? readExpoSlug() ?? "";
-  const flowFile = join21(tmpdir7(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+  const flowFile = join22(tmpdir7(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
   let content;
   let headerAppId;
   try {
@@ -29051,7 +29325,7 @@ var init_app_lifecycle = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/cdp/discovery.js
-import { execFileSync as execFileSync10 } from "node:child_process";
+import { execFileSync as execFileSync11 } from "node:child_process";
 function resolveDefaultPorts() {
   const override = process.env.RN_CDP_DISCOVERY_PORTS;
   if (override !== void 0) {
@@ -29151,7 +29425,7 @@ function cachedPackageProbe(key, probe, clock = Date.now) {
 }
 function probeAndroidPackages() {
   try {
-    const out = execFileSync10("adb", ["shell", "pm", "list", "packages"], {
+    const out = execFileSync11("adb", ["shell", "pm", "list", "packages"], {
       timeout: 3e3,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"]
@@ -29163,7 +29437,7 @@ function probeAndroidPackages() {
 }
 function bootedSimulatorUdids() {
   try {
-    const out = execFileSync10("xcrun", ["simctl", "list", "devices", "booted", "-j"], {
+    const out = execFileSync11("xcrun", ["simctl", "list", "devices", "booted", "-j"], {
       timeout: 5e3,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"]
@@ -29182,7 +29456,7 @@ function probeIOSPackages() {
   let probed = false;
   for (const udid of udids) {
     try {
-      const out = execFileSync10("xcrun", ["simctl", "listapps", udid], {
+      const out = execFileSync11("xcrun", ["simctl", "listapps", udid], {
         timeout: 5e3,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"]
@@ -29507,10 +29781,10 @@ var init_discovery = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js
-import { execFileSync as execFileSync11 } from "node:child_process";
-import { existsSync as existsSync19, readFileSync as readFileSync20, unlinkSync as unlinkSync6 } from "node:fs";
+import { execFileSync as execFileSync12 } from "node:child_process";
+import { existsSync as existsSync19, readFileSync as readFileSync21, unlinkSync as unlinkSync6 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
-import { join as join22 } from "node:path";
+import { join as join23 } from "node:path";
 function selectInstalledLegacyApps(installed) {
   return LEGACY_BUNDLE_IDS.filter((id) => installed.has(id));
 }
@@ -29565,7 +29839,7 @@ function defaultDeps() {
     // caller's try/catch, which records a warning. Swallowing it here and
     // returning '' made single-runner enforcement degrade to a silent no-op
     // with no operator signal — exactly when the machine is busy.
-    listProcesses: () => execFileSync11("ps", ["-A", "-o", "pid=,args="], { encoding: "utf8", timeout: 3e3 }),
+    listProcesses: () => execFileSync12("ps", ["-A", "-o", "pid=,args="], { encoding: "utf8", timeout: 3e3 }),
     kill: (pid, signal) => process.kill(pid, signal),
     isAlive: (pid) => {
       try {
@@ -29577,7 +29851,7 @@ function defaultDeps() {
     },
     readDaemonPid: () => {
       try {
-        const parsed = JSON.parse(readFileSync20(DAEMON_JSON, "utf8"));
+        const parsed = JSON.parse(readFileSync21(DAEMON_JSON, "utf8"));
         return typeof parsed.pid === "number" ? parsed.pid : null;
       } catch {
         return null;
@@ -29586,13 +29860,13 @@ function defaultDeps() {
     fileExists: (path) => existsSync19(path),
     removeFile: (path) => unlinkSync6(path),
     delay: (ms) => new Promise((resolve11) => setTimeout(resolve11, ms)),
-    listApps: (udid) => execFileSync11("xcrun", ["simctl", "listapps", udid], {
+    listApps: (udid) => execFileSync12("xcrun", ["simctl", "listapps", udid], {
       encoding: "utf8",
       timeout: 5e3,
       stdio: ["ignore", "pipe", "ignore"]
     }),
     uninstallApp: (udid, bundleId) => {
-      execFileSync11("xcrun", ["simctl", "uninstall", udid, bundleId], {
+      execFileSync12("xcrun", ["simctl", "uninstall", udid, bundleId], {
         encoding: "utf8",
         timeout: 1e4,
         stdio: ["ignore", "pipe", "ignore"]
@@ -29666,8 +29940,8 @@ var init_ensure_single_runner = __esm({
   "packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js"() {
     "use strict";
     init_discovery();
-    DAEMON_JSON = join22(homedir6(), ".agent-device", "daemon.json");
-    DAEMON_LOCK = join22(homedir6(), ".agent-device", "daemon.lock");
+    DAEMON_JSON = join23(homedir6(), ".agent-device", "daemon.json");
+    DAEMON_LOCK = join23(homedir6(), ".agent-device", "daemon.lock");
     DAEMON_FILES = [DAEMON_JSON, DAEMON_LOCK];
     SIGKILL_GRACE_MS = 500;
     LEGACY_BUNDLE_IDS = [
@@ -29794,9 +30068,9 @@ var init_recover_detached = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/lifecycle/device-lock.js
-import { existsSync as existsSync20, mkdirSync as mkdirSync12, openSync as openSync8, writeSync as writeSync3, closeSync as closeSync8, readFileSync as readFileSync21, unlinkSync as unlinkSync7, writeFileSync as writeFileSync10 } from "node:fs";
+import { existsSync as existsSync20, mkdirSync as mkdirSync12, openSync as openSync8, writeSync as writeSync3, closeSync as closeSync8, readFileSync as readFileSync22, unlinkSync as unlinkSync7, writeFileSync as writeFileSync10 } from "node:fs";
 import { tmpdir as tmpdir8, userInfo as userInfo2 } from "node:os";
-import { join as join23 } from "node:path";
+import { join as join24 } from "node:path";
 function defaultProcessAlive3(pid) {
   try {
     process.kill(pid, 0);
@@ -29849,7 +30123,7 @@ var init_device_lock = __esm({
         this.clock = opts.clock ?? Date.now;
         this.processAlive = opts.processAlive ?? defaultProcessAlive3;
         this.staleMs = opts.staleMs ?? DEFAULT_STALE_MS2;
-        this.lockPath = join23(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
+        this.lockPath = join24(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
       }
       acquire() {
         try {
@@ -29930,7 +30204,7 @@ var init_device_lock = __esm({
       }
       readExisting() {
         try {
-          const parsed = JSON.parse(readFileSync21(this.lockPath, "utf8"));
+          const parsed = JSON.parse(readFileSync22(this.lockPath, "utf8"));
           if (!isValidBody(parsed))
             return null;
           if (parsed.deviceId !== this.deviceId || parsed.platform !== this.platform)
@@ -32273,7 +32547,7 @@ import { promisify as promisify13 } from "node:util";
 import { existsSync as existsSync21, rmSync as rmSync10, writeFileSync as writeFileSync11 } from "node:fs";
 import { tmpdir as tmpdir9 } from "node:os";
 import { randomBytes as randomBytes5, randomUUID as randomUUID6 } from "node:crypto";
-import { join as join24 } from "node:path";
+import { join as join25 } from "node:path";
 function getAndroidRunnerState() {
   return runnerState2;
 }
@@ -33419,7 +33693,7 @@ async function runAndroid(args) {
     const data = resp.data;
     if (!data?.pngBase64)
       return failResult("Android runner screenshot response did not include pngBase64", "SCREENSHOT_FAILED", recovery ? { transportRecovery: recovery } : void 0);
-    const outPath = args.outPath ?? join24(tmpdir9(), `rn-android-screenshot-${Date.now()}.png`);
+    const outPath = args.outPath ?? join25(tmpdir9(), `rn-android-screenshot-${Date.now()}.png`);
     writeFileSync11(outPath, Buffer.from(data.pngBase64, "base64"));
     return okResult({ path: outPath }, Object.keys(recoveryMeta).length ? { meta: recoveryMeta } : void 0);
   }
@@ -33454,11 +33728,11 @@ var init_rn_android_runner_client = __esm({
     HEALTH_POLL_INTERVAL_MS = 150;
     HEALTH_PROBE_TIMEOUT_MS = 1e3;
     RN_ANDROID_RUNNER_DIR = resolveNativeRunnerDir("rn-android-runner");
-    GRADLEW = join24(RN_ANDROID_RUNNER_DIR, "gradlew");
-    APK_APP = join24(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "debug", "app-debug.apk");
-    APK_TEST = join24(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "androidTest", "debug", "app-debug-androidTest.apk");
-    ANDROID_REBUILD_ROOT = join24(RN_ANDROID_RUNNER_DIR, "app", "build");
-    ANDROID_REBUILD_LOCK_DATABASE = join24(ANDROID_REBUILD_ROOT, ".authority-rebuild", "lock.sqlite");
+    GRADLEW = join25(RN_ANDROID_RUNNER_DIR, "gradlew");
+    APK_APP = join25(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "debug", "app-debug.apk");
+    APK_TEST = join25(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "androidTest", "debug", "app-debug-androidTest.apk");
+    ANDROID_REBUILD_ROOT = join25(RN_ANDROID_RUNNER_DIR, "app", "build");
+    ANDROID_REBUILD_LOCK_DATABASE = join25(ANDROID_REBUILD_ROOT, ".authority-rebuild", "lock.sqlite");
     ANDROID_REBUILD_LOCK_STALE_MS = 15 * 6e4;
     ANDROID_REBUILD_HEARTBEAT_MS = 6e4;
     ANDROID_REBUILD_COMPLETION_RETRY_MS = 1e3;
@@ -33504,9 +33778,9 @@ __export(release_android_slot_exports, {
 });
 import { execFile as execFileCb11 } from "node:child_process";
 import { promisify as promisify14 } from "node:util";
-import { existsSync as existsSync22, readFileSync as readFileSync22, unlinkSync as unlinkSync8 } from "node:fs";
+import { existsSync as existsSync22, readFileSync as readFileSync23, unlinkSync as unlinkSync8 } from "node:fs";
 import { homedir as homedir7 } from "node:os";
-import { join as join25 } from "node:path";
+import { join as join26 } from "node:path";
 function isProtectedPid(pid, selfPid, parentPid) {
   return pid === selfPid || pid === parentPid;
 }
@@ -33523,7 +33797,7 @@ function defaultDeps3() {
     resolveSerial: (deviceId) => deviceId ? ["-s", deviceId] : getAdbSerial(),
     readDaemonPid: () => {
       try {
-        const parsed = JSON.parse(readFileSync22(DAEMON_JSON2, "utf8"));
+        const parsed = JSON.parse(readFileSync23(DAEMON_JSON2, "utf8"));
         return typeof parsed.pid === "number" ? parsed.pid : null;
       } catch {
         return null;
@@ -33642,8 +33916,8 @@ var init_release_android_slot = __esm({
     init_rn_android_runner_client();
     init_agent_device_wrapper();
     execFile13 = promisify14(execFileCb11);
-    DAEMON_JSON2 = join25(homedir7(), ".agent-device", "daemon.json");
-    DAEMON_LOCK2 = join25(homedir7(), ".agent-device", "daemon.lock");
+    DAEMON_JSON2 = join26(homedir7(), ".agent-device", "daemon.json");
+    DAEMON_LOCK2 = join26(homedir7(), ".agent-device", "daemon.lock");
     DAEMON_FILES2 = [DAEMON_JSON2, DAEMON_LOCK2];
     SIGKILL_GRACE_MS2 = 500;
     ADB_TIMEOUT_MS = 5e3;
@@ -33975,8 +34249,8 @@ var init_process_cleanup = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/env-setup.js
-import { existsSync as existsSync23, readFileSync as readFileSync23 } from "node:fs";
-import { join as join28 } from "node:path";
+import { existsSync as existsSync23, readFileSync as readFileSync24 } from "node:fs";
+import { join as join29 } from "node:path";
 function ensureAndroidEnv() {
   if (!process.env.ANDROID_HOME) {
     if (process.env.ANDROID_SDK_ROOT) {
@@ -33984,8 +34258,8 @@ function ensureAndroidEnv() {
     } else {
       const home = process.env.HOME ?? "";
       const candidates = [
-        join28(home, "Library/Android/sdk"),
-        join28(home, "Android/Sdk"),
+        join29(home, "Library/Android/sdk"),
+        join29(home, "Android/Sdk"),
         "/opt/android-sdk"
       ];
       for (const c of candidates) {
@@ -33997,8 +34271,8 @@ function ensureAndroidEnv() {
     }
   }
   if (process.env.ANDROID_HOME) {
-    const pt = join28(process.env.ANDROID_HOME, "platform-tools");
-    const emu = join28(process.env.ANDROID_HOME, "emulator");
+    const pt = join29(process.env.ANDROID_HOME, "platform-tools");
+    const emu = join29(process.env.ANDROID_HOME, "emulator");
     const path = process.env.PATH ?? "";
     if (!path.includes(pt))
       process.env.PATH = `${pt}:${path}`;
@@ -34006,19 +34280,19 @@ function ensureAndroidEnv() {
       process.env.PATH = `${emu}:${process.env.PATH}`;
   }
   if (!process.env.ANDROID_SERIAL) {
-    const serialFile = join28(process.env.TMPDIR ?? "/tmp", "rn-dev-agent-android-serial");
+    const serialFile = join29(process.env.TMPDIR ?? "/tmp", "rn-dev-agent-android-serial");
     if (existsSync23(serialFile)) {
-      process.env.ANDROID_SERIAL = readFileSync23(serialFile, "utf8").trim();
+      process.env.ANDROID_SERIAL = readFileSync24(serialFile, "utf8").trim();
     }
   }
 }
 function ensureJavaEnv() {
   const path = process.env.PATH ?? "";
-  if (path.split(":").some((p) => existsSync23(join28(p, "java"))))
+  if (path.split(":").some((p) => existsSync23(join29(p, "java"))))
     return;
   const candidates = ["/opt/homebrew/opt/openjdk@17", "/opt/homebrew/opt/openjdk"];
   for (const jdk of candidates) {
-    if (existsSync23(join28(jdk, "bin/java"))) {
+    if (existsSync23(join29(jdk, "bin/java"))) {
       process.env.JAVA_HOME = jdk;
       process.env.PATH = `${jdk}/bin:${process.env.PATH}`;
       break;
@@ -59868,7 +60142,7 @@ var init_ws_origin = __esm({
 // packages/rn-dev-agent-core/dist/cdp/state.js
 import { writeFileSync as writeFileSync12, unlinkSync as unlinkSync9 } from "node:fs";
 import { tmpdir as tmpdir10 } from "node:os";
-import { join as join29 } from "node:path";
+import { join as join30 } from "node:path";
 function resetState(s) {
   s.setState("disconnected");
   s.setHelpersInjected(false);
@@ -59914,8 +60188,8 @@ var CDP_ACTIVE_FLAG, CDP_SESSION_FILE;
 var init_state = __esm({
   "packages/rn-dev-agent-core/dist/cdp/state.js"() {
     "use strict";
-    CDP_ACTIVE_FLAG = join29(tmpdir10(), "rn-dev-agent-cdp-active");
-    CDP_SESSION_FILE = join29(tmpdir10(), "rn-dev-agent-cdp-session.json");
+    CDP_ACTIVE_FLAG = join30(tmpdir10(), "rn-dev-agent-cdp-active");
+    CDP_SESSION_FILE = join30(tmpdir10(), "rn-dev-agent-cdp-session.json");
   }
 });
 
@@ -65560,8 +65834,8 @@ var init_mutation_absence = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/verification/config.js
-import { existsSync as existsSync24, readFileSync as readFileSync24 } from "node:fs";
-import { join as join30 } from "node:path";
+import { existsSync as existsSync24, readFileSync as readFileSync25 } from "node:fs";
+import { join as join31 } from "node:path";
 function getCachedProjectRoot() {
   if (_cachedProjectRoot === void 0) {
     _cachedProjectRoot = findProjectRoot();
@@ -65613,14 +65887,14 @@ function loadVerificationConfig(projectRoot) {
   const cached2 = cache2.get(projectRoot);
   if (cached2)
     return cached2;
-  const path = join30(projectRoot, ".rn-agent", "config.json");
+  const path = join31(projectRoot, ".rn-agent", "config.json");
   if (!existsSync24(path)) {
     cache2.set(projectRoot, DEFAULTS);
     return DEFAULTS;
   }
   let raw;
   try {
-    raw = JSON.parse(readFileSync24(path, "utf-8"));
+    raw = JSON.parse(readFileSync25(path, "utf-8"));
   } catch {
     cache2.set(projectRoot, DEFAULTS);
     return DEFAULTS;
@@ -66102,11 +66376,11 @@ var init_device_session_health = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/session/runtime-paths.js
-import { chmodSync as chmodSync3, lstatSync as lstatSync9, mkdirSync as mkdirSync13 } from "node:fs";
-import { join as join31, resolve as resolve7 } from "node:path";
+import { chmodSync as chmodSync3, lstatSync as lstatSync10, mkdirSync as mkdirSync13 } from "node:fs";
+import { join as join32, resolve as resolve7 } from "node:path";
 function privateDirectory(path) {
   mkdirSync13(path, { recursive: true, mode: 448 });
-  const stat2 = lstatSync9(path);
+  const stat2 = lstatSync10(path);
   if (stat2.isSymbolicLink() || !stat2.isDirectory()) {
     throw new Error("SESSION_RUNTIME_ROOT_UNSAFE: runtime root must be a real directory");
   }
@@ -66115,14 +66389,14 @@ function privateDirectory(path) {
 }
 function sessionRuntimeRoot(projectRoot) {
   const configured = process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT;
-  return configured ? privateDirectory(resolve7(configured)) : join31(resolve7(projectRoot), ".rn-agent");
+  return configured ? privateDirectory(resolve7(configured)) : join32(resolve7(projectRoot), ".rn-agent");
 }
 function sessionStateDirectory(projectRoot) {
-  const path = join31(sessionRuntimeRoot(projectRoot), "state");
+  const path = join32(sessionRuntimeRoot(projectRoot), "state");
   return process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT ? privateDirectory(path) : path;
 }
 function sessionRecordingsDirectory(projectRoot) {
-  const path = join31(sessionRuntimeRoot(projectRoot), "recordings");
+  const path = join32(sessionRuntimeRoot(projectRoot), "recordings");
   return process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT ? privateDirectory(path) : path;
 }
 var init_runtime_paths2 = __esm({
@@ -66133,8 +66407,8 @@ var init_runtime_paths2 = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/action-db.js
 import { createRequire as createRequire2 } from "node:module";
-import { existsSync as existsSync25, mkdirSync as mkdirSync14, readdirSync as readdirSync7, readFileSync as readFileSync25 } from "node:fs";
-import { dirname as dirname12, join as join32 } from "node:path";
+import { existsSync as existsSync25, mkdirSync as mkdirSync14, readdirSync as readdirSync8, readFileSync as readFileSync26 } from "node:fs";
+import { dirname as dirname12, join as join33 } from "node:path";
 function loadSqlite() {
   try {
     const mod = _require("node:sqlite");
@@ -66148,7 +66422,7 @@ function openActionDb(projectRoot, opts = {}) {
   if (!Ctor)
     return null;
   try {
-    const dbPath = join32(sessionStateDirectory(projectRoot), "actions.db");
+    const dbPath = join33(sessionStateDirectory(projectRoot), "actions.db");
     mkdirSync14(dirname12(dbPath), { recursive: true });
     const db = new Ctor(dbPath);
     db.exec(SCHEMA);
@@ -66291,11 +66565,11 @@ function openActionDb(projectRoot, opts = {}) {
         return row.cnt;
       },
       migrateSidecars() {
-        const stateDir = join32(projectRoot, ".rn-agent", "state");
+        const stateDir = join33(projectRoot, ".rn-agent", "state");
         if (!existsSync25(stateDir))
           return { migrated: 0 };
         let migrated = 0;
-        for (const f of readdirSync7(stateDir)) {
+        for (const f of readdirSync8(stateDir)) {
           if (!f.endsWith(".state.json"))
             continue;
           const id = f.replace(/\.state\.json$/, "");
@@ -66303,7 +66577,7 @@ function openActionDb(projectRoot, opts = {}) {
           if (exists)
             continue;
           try {
-            const parsed = JSON.parse(readFileSync25(join32(stateDir, f), "utf8"));
+            const parsed = JSON.parse(readFileSync26(join33(stateDir, f), "utf8"));
             if (parsed?.schemaVersion !== 1)
               continue;
             if (!Array.isArray(parsed.runHistory) || !Array.isArray(parsed.repairHistory)) {
@@ -66586,26 +66860,26 @@ var init_reusable_action = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/sidecar-io.js
-import { existsSync as existsSync26, readFileSync as readFileSync26, writeFileSync as writeFileSync13, mkdirSync as mkdirSync15, statSync as statSync9 } from "node:fs";
-import { join as join33, dirname as dirname13 } from "node:path";
+import { existsSync as existsSync26, readFileSync as readFileSync27, writeFileSync as writeFileSync13, mkdirSync as mkdirSync15, statSync as statSync10 } from "node:fs";
+import { join as join34, dirname as dirname13 } from "node:path";
 function sidecarPathFor(yamlFilePath) {
   const dir = dirname13(yamlFilePath);
   const parent = dirname13(dir);
   const filename = yamlFilePath.replace(/\.ya?ml$/i, ".state.json");
   const base = filename.split(/[\\/]/).pop();
-  const stateDirectory = process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT ? sessionStateDirectory(dirname13(parent)) : join33(parent, "state");
-  return join33(stateDirectory, base);
+  const stateDirectory = process.env.RN_DEV_AGENT_SESSION_RUNTIME_ROOT ? sessionStateDirectory(dirname13(parent)) : join34(parent, "state");
+  return join34(stateDirectory, base);
 }
 function loadOrInitSidecar(yamlFilePath, now = () => /* @__PURE__ */ new Date()) {
   const path = sidecarPathFor(yamlFilePath);
   if (existsSync26(path)) {
     try {
-      const text = readFileSync26(path, "utf8");
+      const text = readFileSync27(path, "utf8");
       const parsed = JSON.parse(text);
       if (parsed && parsed.schemaVersion === 1 && typeof parsed.revision === "number" && typeof parsed.updatedAt === "string" && Array.isArray(parsed.runHistory) && Array.isArray(parsed.repairHistory) && typeof parsed.stats === "object") {
         if (typeof parsed.lastSeenMtimeMs !== "number") {
           try {
-            parsed.lastSeenMtimeMs = statSync9(yamlFilePath).mtimeMs;
+            parsed.lastSeenMtimeMs = statSync10(yamlFilePath).mtimeMs;
           } catch {
             parsed.lastSeenMtimeMs = 0;
           }
@@ -66617,7 +66891,7 @@ function loadOrInitSidecar(yamlFilePath, now = () => /* @__PURE__ */ new Date())
   }
   let mtimeMs = 0;
   try {
-    mtimeMs = statSync9(yamlFilePath).mtimeMs;
+    mtimeMs = statSync10(yamlFilePath).mtimeMs;
   } catch {
   }
   return freshRuntimeState(now, mtimeMs);
@@ -66632,7 +66906,7 @@ function saveSidecar(yamlFilePath, state) {
 }
 function yamlEditedSinceLastSeen(yamlFilePath, state) {
   try {
-    const current = statSync9(yamlFilePath).mtimeMs;
+    const current = statSync10(yamlFilePath).mtimeMs;
     return current > state.lastSeenMtimeMs;
   } catch {
     return false;
@@ -66718,19 +66992,19 @@ var init_action_state_store = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/session/migration-diagnostic.js
-import { createHash as createHash13 } from "node:crypto";
-import { existsSync as existsSync27, readFileSync as readFileSync27 } from "node:fs";
-import { join as join34 } from "node:path";
+import { createHash as createHash14 } from "node:crypto";
+import { existsSync as existsSync27, readFileSync as readFileSync28 } from "node:fs";
+import { join as join35 } from "node:path";
 function readPackageIntegrationManifest(appRoot, dependencies) {
-  const manifestPath = join34(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
+  const manifestPath = join35(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
   if (dependencies.exists || dependencies.readText) {
     const exists = dependencies.exists ?? existsSync27;
     if (!exists(manifestPath))
       return void 0;
-    const readText = dependencies.readText ?? ((path) => readFileSync27(path, "utf8"));
+    const readText = dependencies.readText ?? ((path) => readFileSync28(path, "utf8"));
     return readText(manifestPath);
   }
-  const agent = openBoundDirectory(join34(appRoot, ".rn-agent"));
+  const agent = openBoundDirectory(join35(appRoot, ".rn-agent"));
   let integration;
   let primaryError;
   try {
@@ -66767,7 +67041,7 @@ function inspectAuthorityMigration(status, dependencies = {}) {
   const integrationBinding = status.bindings.packageIntegration;
   let bindingDiagnostic = null;
   if (integrationBinding) {
-    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash13("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
+    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash14("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
     const manifestAvailable = manifestVerified(onDiskManifestText) || manifestVerified(integrationBinding.restoration?.phase === "started" ? integrationBinding.restoration.manifestSource : void 0) || manifestVerified(integrationBinding.installation?.phase === "started" ? integrationBinding.installation.manifestSource : void 0) || manifestVerified(integrationBinding.manifestSource);
     const effectiveOwnerSessionId = status.sessionId;
     const trustedDigestRecorded = typeof integrationBinding.manifestSha256 === "string" && /^[0-9a-f]{64}$/.test(integrationBinding.manifestSha256);
@@ -66983,191 +67257,6 @@ function verifyBuildReceipt(receipt2, capability, expected) {
 }
 var init_build_receipt = __esm({
   "packages/rn-dev-agent-core/dist/session/build-receipt.js"() {
-    "use strict";
-  }
-});
-
-// packages/rn-dev-agent-core/dist/session/install-authority.js
-import { execFileSync as execFileSync12 } from "node:child_process";
-import { createHash as createHash14 } from "node:crypto";
-import { lstatSync as lstatSync10, readFileSync as readFileSync28, readdirSync as readdirSync8, readlinkSync as readlinkSync3, realpathSync as realpathSync9, statSync as statSync10 } from "node:fs";
-import { isAbsolute as isAbsolute6, join as join35, relative as relative4 } from "node:path";
-function runText(command, args) {
-  return execFileSync12(command, [...args], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
-    timeout: 1e4,
-    maxBuffer: 8 * 1024 * 1024
-  });
-}
-function runBuffer(command, args) {
-  return execFileSync12(command, [...args], {
-    encoding: "buffer",
-    stdio: ["ignore", "pipe", "ignore"],
-    timeout: 3e4,
-    maxBuffer: 512 * 1024 * 1024
-  });
-}
-function digest2(parts) {
-  const hash = createHash14("sha256");
-  for (const part of parts) {
-    hash.update(`${part.byteLength}:`);
-    hash.update(part);
-  }
-  return hash.digest("hex");
-}
-function generation(parts) {
-  return digest2(parts.map((part) => Buffer.from(part)));
-}
-function listAppFiles(appPath) {
-  const files = [];
-  const visit = (directory) => {
-    for (const entry of readdirSync8(directory, { withFileTypes: true })) {
-      const path = join35(directory, entry.name);
-      if (entry.isDirectory()) {
-        visit(path);
-      } else if (entry.isFile() || entry.isSymbolicLink()) {
-        files.push(relative4(appPath, path));
-      } else {
-        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
-      }
-    }
-  };
-  visit(appPath);
-  return files.sort();
-}
-function iosAppFiles(appPath, dependencies) {
-  return [...(dependencies.listAppFiles ?? listAppFiles)(appPath)].sort();
-}
-function assertIosSymlinkContained(appPath, path, realpath) {
-  const target = realpath(path);
-  const child = relative4(realpath(appPath), target);
-  if (child === ".." || child.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute6(child)) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app symlink escapes the installed bundle");
-  }
-}
-function androidApkPaths(target, text) {
-  return text("adb", ["-s", target.deviceId, "shell", "pm", "path", target.appId]).split("\n").map((line) => line.trim()).filter((line) => line.startsWith("package:")).map((line) => line.slice("package:".length)).sort();
-}
-function captureInstallGeneration(target, dependencies = {}) {
-  const text = dependencies.runText ?? runText;
-  if (target.platform === "ios") {
-    const appPath = text("xcrun", [
-      "simctl",
-      "get_app_container",
-      target.deviceId,
-      target.appId,
-      "app"
-    ]).trim();
-    if (!appPath) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
-    }
-    const infoPath = join35(appPath, "Info.plist");
-    const executable = text("plutil", [
-      "-extract",
-      "CFBundleExecutable",
-      "raw",
-      "-o",
-      "-",
-      infoPath
-    ]).trim();
-    if (!executable) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
-    }
-    const stat2 = dependencies.stat ?? statSync10;
-    const metadata2 = iosAppFiles(appPath, dependencies).map((entry) => {
-      const path = join35(appPath, entry);
-      const value = stat2(path);
-      return `${entry}:${String(value.ino)}:${value.size}:${value.mtimeMs}`;
-    });
-    return generation(metadata2);
-  }
-  const apkPaths = androidApkPaths(target, text);
-  if (!apkPaths.length) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
-  }
-  const metadata = text("adb", [
-    "-s",
-    target.deviceId,
-    "shell",
-    "stat",
-    "-c",
-    "%n:%i:%s:%Y",
-    ...apkPaths
-  ]).split("\n").map((line) => line.trim()).filter(Boolean).sort();
-  if (metadata.length !== apkPaths.length) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: Android install generation is unavailable");
-  }
-  return generation(metadata);
-}
-function captureInstalledArtifact(target, dependencies = {}) {
-  const text = dependencies.runText ?? runText;
-  const buffer = dependencies.runBuffer ?? runBuffer;
-  const read = dependencies.read ?? readFileSync28;
-  if (target.platform === "ios") {
-    const appPath = text("xcrun", [
-      "simctl",
-      "get_app_container",
-      target.deviceId,
-      target.appId,
-      "app"
-    ]).trim();
-    if (!appPath) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact iOS app container was not found");
-    }
-    const infoPath = join35(appPath, "Info.plist");
-    const executable = text("plutil", [
-      "-extract",
-      "CFBundleExecutable",
-      "raw",
-      "-o",
-      "-",
-      infoPath
-    ]).trim();
-    if (!executable) {
-      throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS executable identity is unavailable");
-    }
-    const files = iosAppFiles(appPath, dependencies);
-    const lstat = dependencies.lstat ?? lstatSync10;
-    const readLink = dependencies.readLink ?? readlinkSync3;
-    const realpath = dependencies.realpath ?? realpathSync9;
-    const artifactParts = [];
-    for (const entry of files) {
-      const path = join35(appPath, entry);
-      const stat2 = lstat(path);
-      artifactParts.push(Buffer.from(entry));
-      if (stat2.isFile()) {
-        artifactParts.push(Buffer.from("file"), read(path));
-      } else if (stat2.isSymbolicLink()) {
-        assertIosSymlinkContained(appPath, path, realpath);
-        artifactParts.push(Buffer.from("symlink"), Buffer.from(readLink(path)));
-      } else {
-        throw new Error("APP_INSTALL_IDENTITY_CHANGED: iOS app contains an unsupported filesystem entry");
-      }
-    }
-    return {
-      ...target,
-      artifactDigest: digest2(artifactParts),
-      installGeneration: captureInstallGeneration(target, dependencies)
-    };
-  }
-  const apkPaths = androidApkPaths(target, text);
-  if (!apkPaths.length) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: exact Android package was not found");
-  }
-  return {
-    ...target,
-    artifactDigest: digest2(apkPaths.map((path) => buffer("adb", ["-s", target.deviceId, "exec-out", "cat", path]))),
-    installGeneration: captureInstallGeneration(target, dependencies)
-  };
-}
-function verifyInstalledArtifact(expected, observed) {
-  if (expected.platform !== observed.platform || expected.deviceId !== observed.deviceId || expected.appId !== observed.appId || expected.artifactDigest !== observed.artifactDigest || expected.installGeneration !== observed.installGeneration) {
-    throw new Error("APP_INSTALL_IDENTITY_CHANGED: installed artifact no longer matches the session build");
-  }
-}
-var init_install_authority = __esm({
-  "packages/rn-dev-agent-core/dist/session/install-authority.js"() {
     "use strict";
   }
 });
@@ -73215,7 +73304,172 @@ var init_blind_probe_gate = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/session/runtime.js
+function unavailable(reason, fallbackCode) {
+  const matched = /^([A-Z][A-Z0-9_]+):/.exec(reason);
+  return new WorkerAuthorityRuntime(null, null, {
+    code: matched?.[1] ?? fallbackCode,
+    reason
+  });
+}
+function createWorkerAuthorityRuntime(environment = process.env, dependencies = {}) {
+  if (environment.RN_DEV_AGENT_AUTHORITY_ERROR) {
+    return unavailable(environment.RN_DEV_AGENT_AUTHORITY_ERROR, "AUTHORITY_STORE_UNAVAILABLE");
+  }
+  const sessionId = environment.RN_DEV_AGENT_SESSION_ID;
+  const claimEpoch = Number(environment.RN_DEV_AGENT_CLAIM_EPOCH);
+  const registryPath = environment.RN_DEV_AGENT_REGISTRY_PATH;
+  const workerInstance = environment.RN_DEV_AGENT_WORKER_INSTANCE;
+  if (!sessionId || !Number.isSafeInteger(claimEpoch) || claimEpoch < 1 || !registryPath || !workerInstance) {
+    return unavailable("SESSION_NOT_INITIALIZED: supervisor did not provide a complete authority context", "SESSION_NOT_INITIALIZED");
+  }
+  const birth = (dependencies.readBirth ?? readProcessBirth)(process.pid);
+  if (!birth) {
+    return unavailable("PROCESS_BIRTH_UNAVAILABLE: worker process birth could not be proven conservatively", "PROCESS_BIRTH_UNAVAILABLE");
+  }
+  try {
+    const registry2 = openSessionRegistry(registryPath, {
+      ownerStatus: dependencies.ownerStatus ?? inspectSessionOwner
+    });
+    const session2 = { sessionId, claimEpoch };
+    const status = registry2.getSessionStatus(sessionId);
+    const recoveryOnly = status?.state === "blocked" || status?.state === "handoff_cleanup";
+    let recoveryCapability = null;
+    if (recoveryOnly) {
+      const secretPath = environment.RN_DEV_AGENT_SESSION_SECRET_PATH;
+      recoveryCapability = secretPath ? readJsonStateFile(secretPath)?.recoveryCapability ?? null : null;
+      if (!recoveryCapability) {
+        throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "blocked recovery capability is unavailable");
+      }
+      registry2.bindRecoveryWorker(session2, { instanceId: workerInstance, pid: birth.pid, token: birth.token }, recoveryCapability);
+    } else {
+      registry2.bindWorker(session2, {
+        instanceId: workerInstance,
+        pid: birth.pid,
+        token: birth.token
+      });
+    }
+    return new WorkerAuthorityRuntime(registry2, session2, null, recoveryOnly, recoveryCapability);
+  } catch (error2) {
+    return unavailable(error2 instanceof Error ? error2.message : "AUTHORITY_STORE_UNAVAILABLE: worker authority could not be opened", "AUTHORITY_STORE_UNAVAILABLE");
+  }
+}
+function getWorkerAuthorityRuntime() {
+  sharedRuntime ??= createWorkerAuthorityRuntime();
+  return sharedRuntime;
+}
+var WorkerAuthorityRuntime, sharedRuntime;
+var init_runtime = __esm({
+  "packages/rn-dev-agent-core/dist/session/runtime.js"() {
+    "use strict";
+    init_process_birth();
+    init_process_owner();
+    init_registry();
+    init_secure_state_file();
+    WorkerAuthorityRuntime = class {
+      available;
+      #registry;
+      #session;
+      #unavailable;
+      #recoveryOnly;
+      #recoveryCapability;
+      constructor(registry2, session2, unavailable2, recoveryOnly = false, recoveryCapability = null) {
+        this.#registry = registry2;
+        this.#session = session2;
+        this.#unavailable = unavailable2;
+        this.available = registry2 !== null && session2 !== null;
+        this.#recoveryOnly = recoveryOnly;
+        this.#recoveryCapability = recoveryCapability;
+      }
+      requireAvailable() {
+        if (!this.#registry || !this.#session) {
+          throw new SessionAuthorityError(this.#unavailable?.code ?? "SESSION_NOT_INITIALIZED", this.#unavailable?.reason ?? "authority session is unavailable");
+        }
+        return { registry: this.#registry, session: this.#session };
+      }
+      requireOperational() {
+        const available = this.requireAvailable();
+        const status = this.status();
+        if (status.available && (status.state === "blocked" || status.state === "handoff_cleanup")) {
+          throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "blocked contender exposes only accept_handoff and adopt_stale recovery");
+        }
+        return available;
+      }
+      requireRecovery() {
+        const available = this.requireAvailable();
+        const status = this.status();
+        if (!this.#recoveryOnly || !status.available || status.state !== "blocked" && status.state !== "handoff_cleanup") {
+          throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "session is not a capability-bound recovery contender");
+        }
+        return available;
+      }
+      /**
+       * GH #672: rotate an expired recovery handle before it is advertised. Best-effort by
+       * design — a refresh failure must degrade `status` to an honest expired handle, never
+       * turn a diagnostic call into an authority error.
+       */
+      refreshRecoveryHandles() {
+        if (!this.#registry || !this.#session || !this.#recoveryOnly || !this.#recoveryCapability) {
+          return false;
+        }
+        try {
+          const status = this.#registry.getSessionStatus(this.#session.sessionId);
+          const instanceId = status?.worker.instanceId;
+          if (!status || !instanceId || status.state !== "blocked" && status.state !== "handoff_cleanup") {
+            return false;
+          }
+          return this.#registry.refreshRecoveryHandles(this.#session, { instanceId }, this.#recoveryCapability);
+        } catch {
+          return false;
+        }
+      }
+      inspectRecoveryRequirement() {
+        if (!this.#registry || !this.#session)
+          return void 0;
+        try {
+          return this.#registry.inspectRecoveryRequirement(this.#session.sessionId);
+        } catch {
+          return void 0;
+        }
+      }
+      status() {
+        if (!this.#registry || !this.#session) {
+          return {
+            available: false,
+            code: this.#unavailable?.code ?? "SESSION_NOT_INITIALIZED",
+            reason: this.#unavailable?.reason ?? "authority session is unavailable"
+          };
+        }
+        const status = this.#registry.getSessionStatus(this.#session.sessionId);
+        if (!status) {
+          return {
+            available: false,
+            code: "SESSION_OWNER_LOST",
+            reason: "session is no longer present in the authority registry"
+          };
+        }
+        return { available: true, ...status };
+      }
+      close() {
+        this.#registry?.close();
+      }
+    };
+    sharedRuntime = null;
+  }
+});
+
 // packages/rn-dev-agent-core/dist/tools/run-action.js
+function boundInstallReceipt() {
+  try {
+    const status = getWorkerAuthorityRuntime().status();
+    if (!status.available)
+      return null;
+    const install = status.bindings.install;
+    return install ?? null;
+  } catch {
+    return null;
+  }
+}
 function classifyFailure(failure) {
   switch (failure.kind) {
     case "SELECTOR_NOT_FOUND":
@@ -73352,6 +73606,9 @@ function createRunActionHandler(deps = {}) {
   const claimNativeOrigin = deps.claimNativeOrigin ?? claimManagedNativeOriginAuthority;
   const completeNativeOrigin = deps.completeNativeOrigin ?? completeManagedNativeOriginAuthority;
   const relaunchManagedApp = deps.relaunchManagedApp ?? relaunchManagedNativeOriginApp;
+  const reissueInstallReceipt = deps.reissueInstallReceipt ?? reissueManagedInstallAuthority;
+  const installReceipt = deps.installReceipt ?? boundInstallReceipt;
+  const resolveAppFile = deps.resolveAppFile ?? ((appId, deviceId) => resolveIosAppFile(appId, { deviceId }));
   return async (args) => {
     if (!args.actionId || typeof args.actionId !== "string") {
       return failResult("cdp_run_action requires actionId", "BAD_FILENAME");
@@ -73382,6 +73639,8 @@ function createRunActionHandler(deps = {}) {
       return failResult(`cdp_run_action: requested ${args.platform}, but the active session is ${activeTarget.platform}; refusing cross-platform replay.`, "TARGET_SESSION_MISMATCH", { requestedPlatform: args.platform, activeSession: activeTarget });
     }
     const maestroDeviceId = (!args.platform || activeTarget?.platform === args.platform) && activeTarget?.deviceId ? activeTarget.deviceId : void 0;
+    const receipt2 = args.appFile ? null : installReceipt();
+    const appFile = args.appFile ?? (flowUsesClearState(action.body) && receipt2?.platform === "ios" && typeof receipt2.appId === "string" && typeof receipt2.deviceId === "string" ? resolveAppFile(receipt2.appId, receipt2.deviceId) ?? void 0 : void 0);
     let probeDeviceId = null;
     let observedDeviceId = maestroDeviceId ?? null;
     const persistRunWithDevice = (record2) => proofReplay ? Promise.resolve({ promoted: false, promotionRefused: false }) : persistRun(args.actionId, projectRoot, probeDeviceId ? { ...record2, deviceId: probeDeviceId } : record2);
@@ -73478,13 +73737,15 @@ function createRunActionHandler(deps = {}) {
         flowPath: action.filePath,
         platform: args.platform,
         appId: args.appId,
+        ...appFile ? { appFile } : {},
         deviceId: maestroDeviceId,
         timeoutMs,
         params: args.params,
         claimNativeOrigin: () => claimNativeOrigin(args),
         completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
         relaunchManagedApp: () => relaunchManagedApp(args),
-        completeRunnerPark: () => completeManagedRunnerParkAuthority(args)
+        completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+        reissueInstallReceipt: () => reissueInstallReceipt(args)
       });
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, "maestro_run");
@@ -73758,13 +74019,15 @@ function createRunActionHandler(deps = {}) {
         flowPath: reloadedAction.filePath,
         platform: args.platform,
         appId: args.appId,
+        ...appFile ? { appFile } : {},
         deviceId: maestroDeviceId,
         timeoutMs,
         params: args.params,
         claimNativeOrigin: () => claimNativeOrigin(args),
         completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
         relaunchManagedApp: () => relaunchManagedApp(args),
-        completeRunnerPark: () => completeManagedRunnerParkAuthority(args)
+        completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+        reissueInstallReceipt: () => reissueInstallReceipt(args)
       });
       const retryMs = Date.now() - tBeforeRetry;
       const retryEnv = parseEnvelope(retryResult, "maestro_run");
@@ -73932,6 +74195,8 @@ var init_run_action = __esm({
     init_cdp_flow_replay();
     init_blind_probe_gate();
     init_authority_gate();
+    init_runtime();
+    init_resolve_ios_app_file();
     OUTPUT_BUDGET = 500;
     OUTPUT_ELISION = "\n\u2026\n";
   }
@@ -75872,160 +76137,6 @@ var init_device_deeplink = __esm({
     init_authority_gate();
     execFile21 = promisify23(execFileCb18);
     EXEC_TIMEOUT_MS = 1e4;
-  }
-});
-
-// packages/rn-dev-agent-core/dist/session/runtime.js
-function unavailable(reason, fallbackCode) {
-  const matched = /^([A-Z][A-Z0-9_]+):/.exec(reason);
-  return new WorkerAuthorityRuntime(null, null, {
-    code: matched?.[1] ?? fallbackCode,
-    reason
-  });
-}
-function createWorkerAuthorityRuntime(environment = process.env, dependencies = {}) {
-  if (environment.RN_DEV_AGENT_AUTHORITY_ERROR) {
-    return unavailable(environment.RN_DEV_AGENT_AUTHORITY_ERROR, "AUTHORITY_STORE_UNAVAILABLE");
-  }
-  const sessionId = environment.RN_DEV_AGENT_SESSION_ID;
-  const claimEpoch = Number(environment.RN_DEV_AGENT_CLAIM_EPOCH);
-  const registryPath = environment.RN_DEV_AGENT_REGISTRY_PATH;
-  const workerInstance = environment.RN_DEV_AGENT_WORKER_INSTANCE;
-  if (!sessionId || !Number.isSafeInteger(claimEpoch) || claimEpoch < 1 || !registryPath || !workerInstance) {
-    return unavailable("SESSION_NOT_INITIALIZED: supervisor did not provide a complete authority context", "SESSION_NOT_INITIALIZED");
-  }
-  const birth = (dependencies.readBirth ?? readProcessBirth)(process.pid);
-  if (!birth) {
-    return unavailable("PROCESS_BIRTH_UNAVAILABLE: worker process birth could not be proven conservatively", "PROCESS_BIRTH_UNAVAILABLE");
-  }
-  try {
-    const registry2 = openSessionRegistry(registryPath, {
-      ownerStatus: dependencies.ownerStatus ?? inspectSessionOwner
-    });
-    const session2 = { sessionId, claimEpoch };
-    const status = registry2.getSessionStatus(sessionId);
-    const recoveryOnly = status?.state === "blocked" || status?.state === "handoff_cleanup";
-    let recoveryCapability = null;
-    if (recoveryOnly) {
-      const secretPath = environment.RN_DEV_AGENT_SESSION_SECRET_PATH;
-      recoveryCapability = secretPath ? readJsonStateFile(secretPath)?.recoveryCapability ?? null : null;
-      if (!recoveryCapability) {
-        throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "blocked recovery capability is unavailable");
-      }
-      registry2.bindRecoveryWorker(session2, { instanceId: workerInstance, pid: birth.pid, token: birth.token }, recoveryCapability);
-    } else {
-      registry2.bindWorker(session2, {
-        instanceId: workerInstance,
-        pid: birth.pid,
-        token: birth.token
-      });
-    }
-    return new WorkerAuthorityRuntime(registry2, session2, null, recoveryOnly, recoveryCapability);
-  } catch (error2) {
-    return unavailable(error2 instanceof Error ? error2.message : "AUTHORITY_STORE_UNAVAILABLE: worker authority could not be opened", "AUTHORITY_STORE_UNAVAILABLE");
-  }
-}
-function getWorkerAuthorityRuntime() {
-  sharedRuntime ??= createWorkerAuthorityRuntime();
-  return sharedRuntime;
-}
-var WorkerAuthorityRuntime, sharedRuntime;
-var init_runtime = __esm({
-  "packages/rn-dev-agent-core/dist/session/runtime.js"() {
-    "use strict";
-    init_process_birth();
-    init_process_owner();
-    init_registry();
-    init_secure_state_file();
-    WorkerAuthorityRuntime = class {
-      available;
-      #registry;
-      #session;
-      #unavailable;
-      #recoveryOnly;
-      #recoveryCapability;
-      constructor(registry2, session2, unavailable2, recoveryOnly = false, recoveryCapability = null) {
-        this.#registry = registry2;
-        this.#session = session2;
-        this.#unavailable = unavailable2;
-        this.available = registry2 !== null && session2 !== null;
-        this.#recoveryOnly = recoveryOnly;
-        this.#recoveryCapability = recoveryCapability;
-      }
-      requireAvailable() {
-        if (!this.#registry || !this.#session) {
-          throw new SessionAuthorityError(this.#unavailable?.code ?? "SESSION_NOT_INITIALIZED", this.#unavailable?.reason ?? "authority session is unavailable");
-        }
-        return { registry: this.#registry, session: this.#session };
-      }
-      requireOperational() {
-        const available = this.requireAvailable();
-        const status = this.status();
-        if (status.available && (status.state === "blocked" || status.state === "handoff_cleanup")) {
-          throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "blocked contender exposes only accept_handoff and adopt_stale recovery");
-        }
-        return available;
-      }
-      requireRecovery() {
-        const available = this.requireAvailable();
-        const status = this.status();
-        if (!this.#recoveryOnly || !status.available || status.state !== "blocked" && status.state !== "handoff_cleanup") {
-          throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "session is not a capability-bound recovery contender");
-        }
-        return available;
-      }
-      /**
-       * GH #672: rotate an expired recovery handle before it is advertised. Best-effort by
-       * design — a refresh failure must degrade `status` to an honest expired handle, never
-       * turn a diagnostic call into an authority error.
-       */
-      refreshRecoveryHandles() {
-        if (!this.#registry || !this.#session || !this.#recoveryOnly || !this.#recoveryCapability) {
-          return false;
-        }
-        try {
-          const status = this.#registry.getSessionStatus(this.#session.sessionId);
-          const instanceId = status?.worker.instanceId;
-          if (!status || !instanceId || status.state !== "blocked" && status.state !== "handoff_cleanup") {
-            return false;
-          }
-          return this.#registry.refreshRecoveryHandles(this.#session, { instanceId }, this.#recoveryCapability);
-        } catch {
-          return false;
-        }
-      }
-      inspectRecoveryRequirement() {
-        if (!this.#registry || !this.#session)
-          return void 0;
-        try {
-          return this.#registry.inspectRecoveryRequirement(this.#session.sessionId);
-        } catch {
-          return void 0;
-        }
-      }
-      status() {
-        if (!this.#registry || !this.#session) {
-          return {
-            available: false,
-            code: this.#unavailable?.code ?? "SESSION_NOT_INITIALIZED",
-            reason: this.#unavailable?.reason ?? "authority session is unavailable"
-          };
-        }
-        const status = this.#registry.getSessionStatus(this.#session.sessionId);
-        if (!status) {
-          return {
-            available: false,
-            code: "SESSION_OWNER_LOST",
-            reason: "session is no longer present in the authority registry"
-          };
-        }
-        return { available: true, ...status };
-      }
-      close() {
-        this.#registry?.close();
-      }
-    };
-    sharedRuntime = null;
   }
 });
 
@@ -85965,6 +86076,7 @@ var init_index = __esm({
         actionId: external_exports.string().describe("Action id matching <projectRoot>/.rn-agent/actions/<actionId>.yaml."),
         projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
         platform: external_exports.enum(["ios", "android"]).optional().describe("Force a specific platform; otherwise auto-detected from the active device session."),
+        appFile: external_exports.string().optional().describe("GH #705: path to the .app Maestro reinstalls from after a clearState uninstall. Normally omit it \u2014 an iOS clearState flow resolves the bundle from the session's attested install receipt, and the receipt is re-issued after the reinstall so later device_*/maestro_run calls keep working."),
         autoRepair: external_exports.boolean().optional().describe("Auto-repair on SELECTOR_NOT_FOUND failures. Default true. Pass false to disable (e.g. when investigating a failure manually)."),
         timeoutMs: external_exports.number().optional().describe("Maestro execution timeout per attempt (ms). Default 120_000."),
         trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe('RunRecord trigger annotation. Default "agent". CI calls should pass "ci".'),
@@ -86230,8 +86342,8 @@ init_package_integration();
 init_process_cleanup();
 init_registry();
 init_state_root();
-import { createHash as createHash11 } from "node:crypto";
-import { join as join26 } from "node:path";
+import { createHash as createHash12 } from "node:crypto";
+import { join as join27 } from "node:path";
 function startupCleanupFailureMessage() {
   return "rn-dev-agent startup cleanup failed: STARTUP_CLEANUP_FAILED\n";
 }
@@ -86280,7 +86392,7 @@ async function runStartupCleanupForSource(input) {
       appRootKey: input.source.appRootKey,
       appRoot: input.source.appRoot
     }, {
-      readSessionSecret: (sessionId) => readJsonStateFile(join26(layout.sessions, sessionId, "secret.json"))
+      readSessionSecret: (sessionId) => readJsonStateFile(join27(layout.sessions, sessionId, "secret.json"))
     });
   } finally {
     registry2.close();
@@ -86337,7 +86449,7 @@ function restoreDeadOwnerIntegration(input, prior, plan, dependencies) {
 function verifiedDeadOwnerManifestSource(appRoot, binding, manifestSha256) {
   if (!/^[0-9a-f]{64}$/.test(manifestSha256))
     return void 0;
-  const verified = (candidate) => typeof candidate === "string" && createHash11("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
+  const verified = (candidate) => typeof candidate === "string" && createHash12("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
   let liveManifest;
   try {
     liveManifest = readPackageIntegrationInputs(appRoot).manifest ?? void 0;
@@ -86366,7 +86478,7 @@ init_process_cleanup();
 init_registry();
 init_managed_metro();
 init_state_root();
-import { createHash as createHash12, randomBytes as randomBytes6, randomUUID as randomUUID7 } from "node:crypto";
+import { createHash as createHash13, randomBytes as randomBytes6, randomUUID as randomUUID7 } from "node:crypto";
 var RELEASABLE_SESSION_STATES = /* @__PURE__ */ new Set([
   "active",
   "source_bound",
@@ -86486,7 +86598,7 @@ function createSupervisorAuthority(input, dependencies = {}) {
       metroPort,
       observePort,
       ...adoptionRequired ? {
-        recoveryCapabilityHash: createHash12("sha256").update(recoveryCapability).digest("hex"),
+        recoveryCapabilityHash: createHash13("sha256").update(recoveryCapability).digest("hex"),
         adoptionRequired: {
           sessionId: adoptionRequired.sessionId,
           claimEpoch: adoptionRequired.claimEpoch
@@ -86596,7 +86708,7 @@ function createSupervisorAuthority(input, dependencies = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/supervisor-args.js
-import { dirname as dirname11, join as join27 } from "node:path";
+import { dirname as dirname11, join as join28 } from "node:path";
 function sqliteFlagForNode(version2) {
   const v = version2 ?? process.versions.node;
   const [majorStr, minorStr] = v.split(".");
@@ -86622,7 +86734,7 @@ function workerSpawnArgs(workerPath, sqliteWarningFilterPath2, version2, forward
     "--import",
     sqliteWarningFilterPath2,
     "--import",
-    join27(dirname11(sqliteWarningFilterPath2), "startup-integrity-register.js"),
+    join28(dirname11(sqliteWarningFilterPath2), "startup-integrity-register.js"),
     workerPath,
     "--no-lock",
     ...diagnosticArgs

--- a/packages/rn-dev-agent-core/dist/index.js
+++ b/packages/rn-dev-agent-core/dist/index.js
@@ -2668,6 +2668,10 @@ trackedTool('cdp_run_action', "Replay a learned action by id with end-to-end aut
         .enum(['ios', 'android'])
         .optional()
         .describe('Force a specific platform; otherwise auto-detected from the active device session.'),
+    appFile: z
+        .string()
+        .optional()
+        .describe("GH #705: path to the .app Maestro reinstalls from after a clearState uninstall. Normally omit it — an iOS clearState flow resolves the bundle from the session's attested install receipt, and the receipt is re-issued after the reinstall so later device_*/maestro_run calls keep working."),
     autoRepair: z
         .boolean()
         .optional()

--- a/packages/rn-dev-agent-core/dist/session/authority-gate.js
+++ b/packages/rn-dev-agent-core/dist/session/authority-gate.js
@@ -3,10 +3,12 @@ import { realpathSync } from 'node:fs';
 import { isAbsolute, relative, resolve } from 'node:path';
 import { failResult } from '../utils.js';
 import { authorityErrorMeta, SessionAuthorityError, shortAuthorityIdentity } from './registry.js';
+import { reissueInstallBinding } from './install-reissue.js';
 import { authorityProfileFor } from './tool-profiles.js';
 const optionalBundleAdmission = Symbol('optionalBundleAdmission');
 const managedNativeOrigin = Symbol('managedNativeOrigin');
 const managedRunnerPark = Symbol('managedRunnerPark');
+const managedInstallReissue = Symbol('managedInstallReissue');
 export async function claimOptionalBundleAuthority(args) {
     return (await args[optionalBundleAdmission]?.()) ?? false;
 }
@@ -30,6 +32,21 @@ export async function relaunchManagedNativeOriginApp(args) {
         throw new SessionAuthorityError('METRO_ORIGIN_MISMATCH', 'managed native origin relaunch authority is unavailable');
     }
     await authority.relaunch();
+}
+/**
+ * GH #705: commit a new install receipt after Maestro reinstalled the session's
+ * own attested `.app` for a `clearState` flow. Refuses unless the freshly
+ * installed bytes still hash to the bound receipt's artifactDigest.
+ */
+export async function reissueManagedInstallAuthority(args) {
+    const reissue = args[managedInstallReissue];
+    if (!reissue) {
+        throw new SessionAuthorityError('APP_INSTALL_IDENTITY_CHANGED', 'managed install re-issue authority is unavailable');
+    }
+    await reissue();
+}
+export function hasManagedInstallReissueAuthority(args) {
+    return typeof args[managedInstallReissue] === 'function';
 }
 export function hasManagedRunnerParkAuthority(args) {
     return typeof args[managedRunnerPark] === 'function';
@@ -730,6 +747,7 @@ export function createAuthorityGate(runtime, dependencies) {
                 let optionalBundleClaimed = false;
                 let optionalBundleRecoveryFailed = false;
                 let managedRunnerParked = false;
+                let installReceiptReissued = false;
                 if (profile.optionalAxes?.includes('B')) {
                     Object.defineProperty(args, optionalBundleAdmission, {
                         configurable: true,
@@ -946,6 +964,30 @@ export function createAuthorityGate(runtime, dependencies) {
                         },
                     });
                 }
+                if (profile.managedInstallReissue) {
+                    Object.defineProperty(args, managedInstallReissue, {
+                        configurable: true,
+                        value: async () => {
+                            const currentStatus = runtime.status();
+                            if (!currentStatus.available) {
+                                throw new SessionAuthorityError(currentStatus.code, currentStatus.reason);
+                            }
+                            registry.verifyOperation(operation);
+                            const install = (dependencies.reissueInstallBinding ?? reissueInstallBinding)(currentStatus.bindings.install);
+                            if (!install)
+                                return;
+                            operation = registry.replaceBindingsDuringOperation(operation, {
+                                bindings: { install },
+                            });
+                            const reissuedStatus = runtime.status();
+                            if (!reissuedStatus.available) {
+                                throw new SessionAuthorityError(reissuedStatus.code, reissuedStatus.reason);
+                            }
+                            status = reissuedStatus;
+                            installReceiptReissued = true;
+                        },
+                    });
+                }
                 if (profile.managedRunnerPark) {
                     Object.defineProperty(args, managedRunnerPark, {
                         configurable: true,
@@ -1125,6 +1167,11 @@ export function createAuthorityGate(runtime, dependencies) {
                     if ((runtimeTargetChanged || managedRuntimeTargetChanged) && observation.axis === 'B') {
                         continue;
                     }
+                    // GH #705: a digest-proven reinstall of the session's own artifact
+                    // re-issues the install receipt mid-operation; only that exact
+                    // gate-owned transition may move I.
+                    if (installReceiptReissued && observation.axis === 'I')
+                        continue;
                     if (!postflightAxes.includes(observation.axis))
                         continue;
                     const postflight = after.find((candidate) => candidate.axis === observation.axis);

--- a/packages/rn-dev-agent-core/dist/session/install-reissue.js
+++ b/packages/rn-dev-agent-core/dist/session/install-reissue.js
@@ -1,0 +1,37 @@
+import { captureInstalledArtifact } from './install-authority.js';
+import { SessionAuthorityError } from './registry.js';
+// GH #705: axis I pins the cheap installGeneration (inode/size/mtime), so a
+// Maestro `clearState` reinstall of the SAME bytes still reads as a foreign
+// install. Re-stamping the generation is only safe behind the expensive
+// artifactDigest proof — a digest mismatch must stay a refusal.
+export function reissueInstallBinding(install, dependencies = {}) {
+    const platform = install?.platform;
+    const deviceId = install?.deviceId;
+    const appId = install?.appId;
+    const artifactDigest = install?.artifactDigest;
+    const installGeneration = install?.installGeneration;
+    if ((platform !== 'ios' && platform !== 'android') ||
+        typeof deviceId !== 'string' ||
+        typeof appId !== 'string' ||
+        typeof artifactDigest !== 'string' ||
+        typeof installGeneration !== 'string') {
+        throw new SessionAuthorityError('APP_INSTALL_IDENTITY_CHANGED', 'no attested install receipt is bound to re-issue after the reinstall');
+    }
+    let observed;
+    try {
+        observed = (dependencies.captureInstalled ?? captureInstalledArtifact)({
+            platform,
+            deviceId,
+            appId,
+        });
+    }
+    catch {
+        throw new SessionAuthorityError('APP_INSTALL_IDENTITY_CHANGED', 'the reinstalled artifact could not be attested');
+    }
+    if (observed.artifactDigest !== artifactDigest) {
+        throw new SessionAuthorityError('APP_INSTALL_IDENTITY_CHANGED', 'the reinstalled artifact is not the attested session build');
+    }
+    if (observed.installGeneration === installGeneration)
+        return null;
+    return { ...install, installGeneration: observed.installGeneration };
+}

--- a/packages/rn-dev-agent-core/dist/session/tool-profiles.js
+++ b/packages/rn-dev-agent-core/dist/session/tool-profiles.js
@@ -287,7 +287,7 @@ export function authorityProfileFor(tool, args = {}) {
             postflightAxes: facetsOf(throughRuntime, { without: ['A', 'B'] }),
             managedOrigin: true,
             managedRunnerPark: true,
-            managedInstallReissue: true,
+            managedInstallReissue: tool === 'maestro_run',
             mutation: true,
             liveBundleProbe: false,
         };

--- a/packages/rn-dev-agent-core/dist/session/tool-profiles.js
+++ b/packages/rn-dev-agent-core/dist/session/tool-profiles.js
@@ -168,6 +168,7 @@ add(optionalHybridMutation, {
     optionalAxes: ['B'],
     managedOrigin: true,
     managedRunnerPark: true,
+    managedInstallReissue: true,
     mutation: true,
     liveBundleProbe: true,
 });
@@ -286,6 +287,7 @@ export function authorityProfileFor(tool, args = {}) {
             postflightAxes: facetsOf(throughRuntime, { without: ['A', 'B'] }),
             managedOrigin: true,
             managedRunnerPark: true,
+            managedInstallReissue: true,
             mutation: true,
             liveBundleProbe: false,
         };

--- a/packages/rn-dev-agent-core/dist/tools/maestro-run.js
+++ b/packages/rn-dev-agent-core/dist/tools/maestro-run.js
@@ -8,7 +8,7 @@ import { getEngineStatus, enginePinCaveat, strictPinRefusal } from '../domain/en
 import { getActiveSession } from '../agent-device-wrapper.js';
 import { resolveBundleId, readExpoSlug } from '../project-config.js';
 import { chooseMaestroDispatch, shouldWarnFallback, flowContainsHideKeyboard, } from './maestro-dispatch.js';
-import { resolveAppFileForClearState } from './resolve-ios-app-file.js';
+import { flowUsesClearState, resolveAppFileForClearState } from './resolve-ios-app-file.js';
 import { buildMaestroFlow, parseAndValidateFlow, isValidBundleId, MaestroValidationError, } from '../domain/maestro-validator.js';
 import { outputIndicatesFlowFailure } from '../domain/maestro-error-parser.js';
 import { augmentFailureWithDegradation, resolveFloorMs } from '../domain/tap-latency.js';
@@ -18,7 +18,7 @@ import { releaseAndroidInteractionSlot as defaultReleaseAndroidSlot } from '../r
 import { markCdpStale as defaultMarkCdpStale } from '../cdp/recovery.js';
 import { maestroAuthorityRefusal, sameDevice, verifyMaestroDeviceAuthority, } from '../domain/maestro-device-authority.js';
 import { collectDirectRunnerEvidence, createRunnerReportDir, disposeRunnerReportDir, runnerReportArgs, } from '../domain/maestro-runner-report.js';
-import { completeManagedRunnerParkAuthority, claimManagedNativeOriginAuthority, completeManagedNativeOriginAuthority, relaunchManagedNativeOriginApp, } from '../session/authority-gate.js';
+import { completeManagedRunnerParkAuthority, claimManagedNativeOriginAuthority, completeManagedNativeOriginAuthority, hasManagedInstallReissueAuthority, reissueManagedInstallAuthority, relaunchManagedNativeOriginApp, } from '../session/authority-gate.js';
 import { SessionAuthorityError } from '../session/registry.js';
 const defaultExecFile = promisify(execFileCb);
 /**
@@ -63,6 +63,9 @@ export function nestedMaestroAuthorityCallbacks(args) {
         completeNativeOrigin: (targetExpected) => completeManagedNativeOriginAuthority(args, targetExpected),
         relaunchManagedApp: () => relaunchManagedNativeOriginApp(args),
         completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+        reissueInstallReceipt: hasManagedInstallReissueAuthority(args)
+            ? () => reissueManagedInstallAuthority(args)
+            : null,
     };
 }
 export class MaestroStageExecutionError extends Error {
@@ -296,10 +299,23 @@ export function createMaestroRunHandler(deps = {}) {
         // params. Validation already ran at the top of the handler so by
         // this point every key matches PARAM_KEY_RE and every value is a
         // string — no need to re-check.
-        const appFileResolution = resolveAppFileForClearState(platform, validatedContent, headerAppId, args.appFile);
+        const appFileResolution = resolveAppFileForClearState(platform, validatedContent, headerAppId, args.appFile, { deviceId: requestedDeviceId });
         if (!appFileResolution.ok) {
             return failResult(appFileResolution.error);
         }
+        // GH #705: only a clearState flow uninstalls and reinstalls; an --app-file
+        // carried by any other flow is inert and must not re-issue the receipt.
+        const reinstallsApp = Boolean(appFileResolution.appFile) && flowUsesClearState(validatedContent);
+        const reissueInstallReceipt = args.reissueInstallReceipt ??
+            deps.reissueInstallReceipt ??
+            nestedMaestroAuthorityCallbacks(args).reissueInstallReceipt;
+        let installReceiptCommitted = false;
+        const commitReinstalledInstall = async () => {
+            if (!reinstallsApp || installReceiptCommitted || !reissueInstallReceipt)
+                return;
+            installReceiptCommitted = true;
+            await reissueInstallReceipt();
+        };
         const baseArgs = dispatch.buildArgs(platform, flowFile, appFileResolution.appFile, requestedDeviceId);
         const paramArgs = [];
         if (args.params) {
@@ -353,6 +369,7 @@ export function createMaestroRunHandler(deps = {}) {
                 deviceId: requestedDeviceId,
                 completeRunnerPark: args.completeRunnerPark ?? managedAuthority.completeRunnerPark,
             });
+            await commitReinstalledInstall();
             const stdout = stageResults.map((result) => result.stdout).join('\n');
             const stderr = stageResults.map((result) => result.stderr).join('\n');
             // combineRunnerOutput (not .trim()) so the step parser's leading-indent
@@ -432,6 +449,9 @@ export function createMaestroRunHandler(deps = {}) {
             return warnResult(warnAug.meta, warnAug.message);
         }
         catch (err) {
+            // A flow that died mid-way may still have reinstalled: re-issue before
+            // reporting, so the failure is the flow's and not a broken axis I.
+            await commitReinstalledInstall();
             if (err instanceof SessionAuthorityError)
                 throw err;
             const stageError = err instanceof MaestroStageExecutionError ? err.stageError : err;

--- a/packages/rn-dev-agent-core/dist/tools/resolve-ios-app-file.js
+++ b/packages/rn-dev-agent-core/dist/tools/resolve-ios-app-file.js
@@ -47,7 +47,7 @@ export function resolveIosAppFile(bundleId, deps = {}) {
     const exists = deps.exists ?? existsSync;
     const getAppContainer = deps.getAppContainer ?? defaultGetAppContainer;
     const snapshotApp = deps.snapshotApp ?? defaultSnapshotApp;
-    const fromContainer = getAppContainer(bundleId);
+    const fromContainer = getAppContainer(bundleId, deps.deviceId);
     if (fromContainer && exists(fromContainer)) {
         const snapshot = snapshotApp(fromContainer);
         if (snapshot)
@@ -88,9 +88,10 @@ export function resolveAppFileForClearState(platform, flowText, headerAppId, exp
     }
     return { ok: true, appFile };
 }
-function defaultGetAppContainer(bundleId) {
+function defaultGetAppContainer(bundleId, deviceId) {
     try {
-        const out = execFileSync('xcrun', ['simctl', 'get_app_container', 'booted', bundleId, 'app'], {
+        const target = deviceId && !/\s/.test(deviceId) ? deviceId : 'booted';
+        const out = execFileSync('xcrun', ['simctl', 'get_app_container', target, bundleId, 'app'], {
             encoding: 'utf8',
             timeout: 5_000,
         }).trim();

--- a/packages/rn-dev-agent-core/dist/tools/run-action.js
+++ b/packages/rn-dev-agent-core/dist/tools/run-action.js
@@ -40,7 +40,22 @@ import { SessionAuthorityError } from '../session/registry.js';
 import { isExactPresent, runCdpReplay, firstReplayTestId, } from './cdp-replay-dispatch.js';
 import { UnsupportedStepError } from '../domain/cdp-flow-replay.js';
 import { evaluateBlindProbeGate } from '../domain/blind-probe-gate.js';
-import { claimManagedNativeOriginAuthority, completeManagedRunnerParkAuthority, completeManagedNativeOriginAuthority, relaunchManagedNativeOriginApp, } from '../session/authority-gate.js';
+import { claimManagedNativeOriginAuthority, completeManagedRunnerParkAuthority, completeManagedNativeOriginAuthority, reissueManagedInstallAuthority, relaunchManagedNativeOriginApp, } from '../session/authority-gate.js';
+import { getWorkerAuthorityRuntime } from '../session/runtime.js';
+import { flowUsesClearState, resolveIosAppFile } from './resolve-ios-app-file.js';
+/** GH #705: the session's attested install receipt, or null outside a session. */
+function boundInstallReceipt() {
+    try {
+        const status = getWorkerAuthorityRuntime().status();
+        if (!status.available)
+            return null;
+        const install = status.bindings.install;
+        return install ?? null;
+    }
+    catch {
+        return null;
+    }
+}
 /**
  * Map a parsed Maestro failure kind to an `ActionFailureCode` (for
  * RunRecord telemetry) and a `ToolErrorCode` (for the failResult
@@ -240,6 +255,10 @@ export function createRunActionHandler(deps = {}) {
     const claimNativeOrigin = deps.claimNativeOrigin ?? claimManagedNativeOriginAuthority;
     const completeNativeOrigin = deps.completeNativeOrigin ?? completeManagedNativeOriginAuthority;
     const relaunchManagedApp = deps.relaunchManagedApp ?? relaunchManagedNativeOriginApp;
+    const reissueInstallReceipt = deps.reissueInstallReceipt ?? reissueManagedInstallAuthority;
+    const installReceipt = deps.installReceipt ?? boundInstallReceipt;
+    const resolveAppFile = deps.resolveAppFile ??
+        ((appId, deviceId) => resolveIosAppFile(appId, { deviceId }));
     return async (args) => {
         if (!args.actionId || typeof args.actionId !== 'string') {
             return failResult('cdp_run_action requires actionId', 'BAD_FILENAME');
@@ -279,6 +298,18 @@ export function createRunActionHandler(deps = {}) {
         const maestroDeviceId = (!args.platform || activeTarget?.platform === args.platform) && activeTarget?.deviceId
             ? activeTarget.deviceId
             : undefined;
+        // GH #705: a clearState flow uninstalls the app, so Maestro needs the
+        // bundle to reinstall from. Resolve it off the session's attested install
+        // receipt — the exact device and appId it was signed for — so the
+        // "Pass appFile=<path>" advice is followable through this tool.
+        const receipt = args.appFile ? null : installReceipt();
+        const appFile = args.appFile ??
+            (flowUsesClearState(action.body) &&
+                receipt?.platform === 'ios' &&
+                typeof receipt.appId === 'string' &&
+                typeof receipt.deviceId === 'string'
+                ? (resolveAppFile(receipt.appId, receipt.deviceId) ?? undefined)
+                : undefined);
         // GH #397: deviceId threading. Handler-scoped (not inside the try) because
         // the outer catch also persists a RunRecord and must carry the device too.
         let probeDeviceId = null;
@@ -421,6 +452,7 @@ export function createRunActionHandler(deps = {}) {
                 flowPath: action.filePath,
                 platform: args.platform,
                 appId: args.appId,
+                ...(appFile ? { appFile } : {}),
                 deviceId: maestroDeviceId,
                 timeoutMs,
                 params: args.params,
@@ -428,6 +460,7 @@ export function createRunActionHandler(deps = {}) {
                 completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
                 relaunchManagedApp: () => relaunchManagedApp(args),
                 completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+                reissueInstallReceipt: () => reissueInstallReceipt(args),
             });
             const firstAttemptMs = Date.now() - tBeforeFirst;
             const firstEnv = parseEnvelope(firstResult, 'maestro_run');
@@ -762,6 +795,7 @@ export function createRunActionHandler(deps = {}) {
                 flowPath: reloadedAction.filePath,
                 platform: args.platform,
                 appId: args.appId,
+                ...(appFile ? { appFile } : {}),
                 deviceId: maestroDeviceId,
                 timeoutMs,
                 params: args.params,
@@ -769,6 +803,7 @@ export function createRunActionHandler(deps = {}) {
                 completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
                 relaunchManagedApp: () => relaunchManagedApp(args),
                 completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+                reissueInstallReceipt: () => reissueInstallReceipt(args),
             });
             const retryMs = Date.now() - tBeforeRetry;
             const retryEnv = parseEnvelope(retryResult, 'maestro_run');

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -3605,6 +3605,12 @@ trackedTool(
       .describe(
         'Force a specific platform; otherwise auto-detected from the active device session.',
       ),
+    appFile: z
+      .string()
+      .optional()
+      .describe(
+        "GH #705: path to the .app Maestro reinstalls from after a clearState uninstall. Normally omit it — an iOS clearState flow resolves the bundle from the session's attested install receipt, and the receipt is re-issued after the reinstall so later device_*/maestro_run calls keep working.",
+      ),
     autoRepair: z
       .boolean()
       .optional()

--- a/packages/rn-dev-agent-core/src/session/authority-gate.ts
+++ b/packages/rn-dev-agent-core/src/session/authority-gate.ts
@@ -5,6 +5,7 @@ import type { ToolErrorCode } from '../types.js';
 import { failResult, type ToolResult } from '../utils.js';
 import type { OperationRef, SessionRef, SessionRegistry, SessionStatus } from './registry.js';
 import { authorityErrorMeta, SessionAuthorityError, shortAuthorityIdentity } from './registry.js';
+import { reissueInstallBinding } from './install-reissue.js';
 import type { WorkerAuthorityStatus } from './runtime.js';
 import { authorityProfileFor, type AuthorityAxis, type AuthorityProfile } from './tool-profiles.js';
 
@@ -36,11 +37,15 @@ interface AuthorityGateDependencies {
   relaunchBoundRuntime?(status: SessionStatus): Promise<void>;
   onRunnerReleased?(runner: Record<string, unknown>): Promise<void> | void;
   onRuntimeBundleInvalidated?(): void;
+  reissueInstallBinding?(
+    install: Record<string, unknown> | undefined,
+  ): Record<string, unknown> | null;
 }
 
 const optionalBundleAdmission = Symbol('optionalBundleAdmission');
 const managedNativeOrigin = Symbol('managedNativeOrigin');
 const managedRunnerPark = Symbol('managedRunnerPark');
+const managedInstallReissue = Symbol('managedInstallReissue');
 
 type AuthorityAwareArgs = Record<string, unknown> & {
   [optionalBundleAdmission]?: () => Promise<boolean>;
@@ -50,6 +55,7 @@ type AuthorityAwareArgs = Record<string, unknown> & {
     relaunch(): Promise<void>;
   };
   [managedRunnerPark]?: () => Promise<void>;
+  [managedInstallReissue]?: () => Promise<void>;
 };
 
 export async function claimOptionalBundleAuthority(args: object): Promise<boolean> {
@@ -90,6 +96,26 @@ export async function relaunchManagedNativeOriginApp(args: object): Promise<void
     );
   }
   await authority.relaunch();
+}
+
+/**
+ * GH #705: commit a new install receipt after Maestro reinstalled the session's
+ * own attested `.app` for a `clearState` flow. Refuses unless the freshly
+ * installed bytes still hash to the bound receipt's artifactDigest.
+ */
+export async function reissueManagedInstallAuthority(args: object): Promise<void> {
+  const reissue = (args as AuthorityAwareArgs)[managedInstallReissue];
+  if (!reissue) {
+    throw new SessionAuthorityError(
+      'APP_INSTALL_IDENTITY_CHANGED',
+      'managed install re-issue authority is unavailable',
+    );
+  }
+  await reissue();
+}
+
+export function hasManagedInstallReissueAuthority(args: object): boolean {
+  return typeof (args as AuthorityAwareArgs)[managedInstallReissue] === 'function';
 }
 
 export function hasManagedRunnerParkAuthority(args: object): boolean {
@@ -1045,6 +1071,7 @@ export function createAuthorityGate(
           let optionalBundleClaimed = false;
           let optionalBundleRecoveryFailed = false;
           let managedRunnerParked = false;
+          let installReceiptReissued = false;
           if (profile.optionalAxes?.includes('B')) {
             Object.defineProperty(args, optionalBundleAdmission, {
               configurable: true,
@@ -1285,6 +1312,31 @@ export function createAuthorityGate(
               },
             });
           }
+          if (profile.managedInstallReissue) {
+            Object.defineProperty(args, managedInstallReissue, {
+              configurable: true,
+              value: async () => {
+                const currentStatus = runtime.status();
+                if (!currentStatus.available) {
+                  throw new SessionAuthorityError(currentStatus.code, currentStatus.reason);
+                }
+                registry!.verifyOperation(operation!);
+                const install = (dependencies.reissueInstallBinding ?? reissueInstallBinding)(
+                  currentStatus.bindings.install as Record<string, unknown> | undefined,
+                );
+                if (!install) return;
+                operation = registry!.replaceBindingsDuringOperation(operation!, {
+                  bindings: { install },
+                });
+                const reissuedStatus = runtime.status();
+                if (!reissuedStatus.available) {
+                  throw new SessionAuthorityError(reissuedStatus.code, reissuedStatus.reason);
+                }
+                status = reissuedStatus;
+                installReceiptReissued = true;
+              },
+            });
+          }
           if (profile.managedRunnerPark) {
             Object.defineProperty(args, managedRunnerPark, {
               configurable: true,
@@ -1510,6 +1562,10 @@ export function createAuthorityGate(
             if ((runtimeTargetChanged || managedRuntimeTargetChanged) && observation.axis === 'B') {
               continue;
             }
+            // GH #705: a digest-proven reinstall of the session's own artifact
+            // re-issues the install receipt mid-operation; only that exact
+            // gate-owned transition may move I.
+            if (installReceiptReissued && observation.axis === 'I') continue;
             if (!postflightAxes.includes(observation.axis)) continue;
             const postflight = after.find((candidate) => candidate.axis === observation.axis);
             if (observation.identity !== postflight?.identity) {

--- a/packages/rn-dev-agent-core/src/session/install-reissue.ts
+++ b/packages/rn-dev-agent-core/src/session/install-reissue.ts
@@ -1,0 +1,54 @@
+import { captureInstalledArtifact } from './install-authority.js';
+import { SessionAuthorityError } from './registry.js';
+
+export interface InstallReissueDependencies {
+  captureInstalled?: typeof captureInstalledArtifact;
+}
+
+// GH #705: axis I pins the cheap installGeneration (inode/size/mtime), so a
+// Maestro `clearState` reinstall of the SAME bytes still reads as a foreign
+// install. Re-stamping the generation is only safe behind the expensive
+// artifactDigest proof — a digest mismatch must stay a refusal.
+export function reissueInstallBinding(
+  install: Record<string, unknown> | null | undefined,
+  dependencies: InstallReissueDependencies = {},
+): Record<string, unknown> | null {
+  const platform = install?.platform;
+  const deviceId = install?.deviceId;
+  const appId = install?.appId;
+  const artifactDigest = install?.artifactDigest;
+  const installGeneration = install?.installGeneration;
+  if (
+    (platform !== 'ios' && platform !== 'android') ||
+    typeof deviceId !== 'string' ||
+    typeof appId !== 'string' ||
+    typeof artifactDigest !== 'string' ||
+    typeof installGeneration !== 'string'
+  ) {
+    throw new SessionAuthorityError(
+      'APP_INSTALL_IDENTITY_CHANGED',
+      'no attested install receipt is bound to re-issue after the reinstall',
+    );
+  }
+  let observed;
+  try {
+    observed = (dependencies.captureInstalled ?? captureInstalledArtifact)({
+      platform,
+      deviceId,
+      appId,
+    });
+  } catch {
+    throw new SessionAuthorityError(
+      'APP_INSTALL_IDENTITY_CHANGED',
+      'the reinstalled artifact could not be attested',
+    );
+  }
+  if (observed.artifactDigest !== artifactDigest) {
+    throw new SessionAuthorityError(
+      'APP_INSTALL_IDENTITY_CHANGED',
+      'the reinstalled artifact is not the attested session build',
+    );
+  }
+  if (observed.installGeneration === installGeneration) return null;
+  return { ...install, installGeneration: observed.installGeneration };
+}

--- a/packages/rn-dev-agent-core/src/session/tool-profiles.ts
+++ b/packages/rn-dev-agent-core/src/session/tool-profiles.ts
@@ -35,6 +35,7 @@ export interface AuthorityProfile {
   optionalAxes?: readonly AuthorityAxis[];
   managedOrigin?: boolean;
   managedRunnerPark?: boolean;
+  managedInstallReissue?: boolean;
   sessionIdentity?: boolean;
   mutation: boolean;
   liveBundleProbe: boolean;
@@ -200,6 +201,7 @@ add(optionalHybridMutation, {
   optionalAxes: ['B'],
   managedOrigin: true,
   managedRunnerPark: true,
+  managedInstallReissue: true,
   mutation: true,
   liveBundleProbe: true,
 });
@@ -322,6 +324,7 @@ export function authorityProfileFor(
       postflightAxes: facetsOf(throughRuntime, { without: ['A', 'B'] }),
       managedOrigin: true,
       managedRunnerPark: true,
+      managedInstallReissue: true,
       mutation: true,
       liveBundleProbe: false,
     };

--- a/packages/rn-dev-agent-core/src/session/tool-profiles.ts
+++ b/packages/rn-dev-agent-core/src/session/tool-profiles.ts
@@ -324,7 +324,7 @@ export function authorityProfileFor(
       postflightAxes: facetsOf(throughRuntime, { without: ['A', 'B'] }),
       managedOrigin: true,
       managedRunnerPark: true,
-      managedInstallReissue: true,
+      managedInstallReissue: tool === 'maestro_run',
       mutation: true,
       liveBundleProbe: false,
     };

--- a/packages/rn-dev-agent-core/src/tools/maestro-run.ts
+++ b/packages/rn-dev-agent-core/src/tools/maestro-run.ts
@@ -14,7 +14,7 @@ import {
   flowContainsHideKeyboard,
   type MaestroDispatchInputs,
 } from './maestro-dispatch.js';
-import { resolveAppFileForClearState } from './resolve-ios-app-file.js';
+import { flowUsesClearState, resolveAppFileForClearState } from './resolve-ios-app-file.js';
 import {
   buildMaestroFlow,
   parseAndValidateFlow,
@@ -52,6 +52,8 @@ import {
   completeManagedRunnerParkAuthority,
   claimManagedNativeOriginAuthority,
   completeManagedNativeOriginAuthority,
+  hasManagedInstallReissueAuthority,
+  reissueManagedInstallAuthority,
   relaunchManagedNativeOriginApp,
 } from '../session/authority-gate.js';
 import { SessionAuthorityError } from '../session/registry.js';
@@ -125,6 +127,8 @@ export interface MaestroRunArgs {
   completeNativeOrigin?: (targetExpected: boolean) => Promise<void>;
   relaunchManagedApp?: () => Promise<void>;
   completeRunnerPark?: () => Promise<void>;
+  /** GH #705: commit a new install receipt after a clearState reinstall. */
+  reissueInstallReceipt?: (() => Promise<void>) | null;
 }
 
 export interface MaestroAuthorityCallbacks {
@@ -132,6 +136,7 @@ export interface MaestroAuthorityCallbacks {
   completeNativeOrigin: (targetExpected: boolean) => Promise<void>;
   relaunchManagedApp: () => Promise<void>;
   completeRunnerPark: () => Promise<void>;
+  reissueInstallReceipt: (() => Promise<void>) | null;
 }
 
 export function nestedMaestroAuthorityCallbacks(args: object): MaestroAuthorityCallbacks {
@@ -141,6 +146,9 @@ export function nestedMaestroAuthorityCallbacks(args: object): MaestroAuthorityC
       completeManagedNativeOriginAuthority(args, targetExpected),
     relaunchManagedApp: () => relaunchManagedNativeOriginApp(args),
     completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+    reissueInstallReceipt: hasManagedInstallReissueAuthority(args)
+      ? () => reissueManagedInstallAuthority(args)
+      : null,
   };
 }
 
@@ -284,6 +292,7 @@ export interface MaestroRunDeps {
   claimNativeOrigin?: () => Promise<void>;
   completeNativeOrigin?: (targetExpected: boolean) => Promise<void>;
   relaunchManagedApp?: () => Promise<void>;
+  reissueInstallReceipt?: () => Promise<void>;
   now?: () => number;
   execFile?: (
     file: string,
@@ -459,10 +468,25 @@ export function createMaestroRunHandler(
       validatedContent,
       headerAppId,
       args.appFile,
+      { deviceId: requestedDeviceId },
     );
     if (!appFileResolution.ok) {
       return failResult(appFileResolution.error);
     }
+    // GH #705: only a clearState flow uninstalls and reinstalls; an --app-file
+    // carried by any other flow is inert and must not re-issue the receipt.
+    const reinstallsApp =
+      Boolean(appFileResolution.appFile) && flowUsesClearState(validatedContent);
+    const reissueInstallReceipt =
+      args.reissueInstallReceipt ??
+      deps.reissueInstallReceipt ??
+      nestedMaestroAuthorityCallbacks(args).reissueInstallReceipt;
+    let installReceiptCommitted = false;
+    const commitReinstalledInstall = async (): Promise<void> => {
+      if (!reinstallsApp || installReceiptCommitted || !reissueInstallReceipt) return;
+      installReceiptCommitted = true;
+      await reissueInstallReceipt();
+    };
     const baseArgs = dispatch.buildArgs(
       platform,
       flowFile,
@@ -542,6 +566,7 @@ export function createMaestroRunHandler(
           completeRunnerPark: args.completeRunnerPark ?? managedAuthority.completeRunnerPark,
         },
       );
+      await commitReinstalledInstall();
       const stdout = stageResults.map((result) => result.stdout).join('\n');
       const stderr = stageResults.map((result) => result.stderr).join('\n');
 
@@ -628,6 +653,9 @@ export function createMaestroRunHandler(
       );
       return warnResult(warnAug.meta, warnAug.message);
     } catch (err) {
+      // A flow that died mid-way may still have reinstalled: re-issue before
+      // reporting, so the failure is the flow's and not a broken axis I.
+      await commitReinstalledInstall();
       if (err instanceof SessionAuthorityError) throw err;
       const stageError = err instanceof MaestroStageExecutionError ? err.stageError : err;
       const msg = stageError instanceof Error ? stageError.message : String(stageError);

--- a/packages/rn-dev-agent-core/src/tools/resolve-ios-app-file.ts
+++ b/packages/rn-dev-agent-core/src/tools/resolve-ios-app-file.ts
@@ -15,8 +15,10 @@ export function flowUsesClearState(flowText: string): boolean {
 }
 
 export interface ResolveAppFileDeps {
+  /** GH #705: exact simulator UDID to read the container from; `booted` otherwise. */
+  deviceId?: string;
   /** Returns the installed `.app` container path for a bundle id, or null. */
-  getAppContainer?: (bundleId: string) => string | null;
+  getAppContainer?: (bundleId: string, deviceId?: string) => string | null;
   /** Returns the newest built `.app` under DerivedData, or null. */
   newestDerivedDataApp?: () => string | null;
   /** Existence check (injectable for tests). */
@@ -60,7 +62,7 @@ export function resolveIosAppFile(bundleId: string, deps: ResolveAppFileDeps = {
   const exists = deps.exists ?? existsSync;
   const getAppContainer = deps.getAppContainer ?? defaultGetAppContainer;
   const snapshotApp = deps.snapshotApp ?? defaultSnapshotApp;
-  const fromContainer = getAppContainer(bundleId);
+  const fromContainer = getAppContainer(bundleId, deps.deviceId);
   if (fromContainer && exists(fromContainer)) {
     const snapshot = snapshotApp(fromContainer);
     if (snapshot) return snapshot;
@@ -109,9 +111,10 @@ export function resolveAppFileForClearState(
   return { ok: true, appFile };
 }
 
-function defaultGetAppContainer(bundleId: string): string | null {
+function defaultGetAppContainer(bundleId: string, deviceId?: string): string | null {
   try {
-    const out = execFileSync('xcrun', ['simctl', 'get_app_container', 'booted', bundleId, 'app'], {
+    const target = deviceId && !/\s/.test(deviceId) ? deviceId : 'booted';
+    const out = execFileSync('xcrun', ['simctl', 'get_app_container', target, bundleId, 'app'], {
       encoding: 'utf8',
       timeout: 5_000,
     }).trim();

--- a/packages/rn-dev-agent-core/src/tools/run-action.ts
+++ b/packages/rn-dev-agent-core/src/tools/run-action.ts
@@ -70,8 +70,23 @@ import {
   claimManagedNativeOriginAuthority,
   completeManagedRunnerParkAuthority,
   completeManagedNativeOriginAuthority,
+  reissueManagedInstallAuthority,
   relaunchManagedNativeOriginApp,
 } from '../session/authority-gate.js';
+import { getWorkerAuthorityRuntime } from '../session/runtime.js';
+import { flowUsesClearState, resolveIosAppFile } from './resolve-ios-app-file.js';
+
+/** GH #705: the session's attested install receipt, or null outside a session. */
+function boundInstallReceipt(): { platform?: unknown; deviceId?: unknown; appId?: unknown } | null {
+  try {
+    const status = getWorkerAuthorityRuntime().status();
+    if (!status.available) return null;
+    const install = status.bindings.install as Record<string, unknown> | undefined;
+    return install ?? null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Map a parsed Maestro failure kind to an `ActionFailureCode` (for
@@ -103,6 +118,12 @@ export interface RunActionArgs {
   /** Action id matching `<projectRoot>/.rn-agent/actions/<actionId>.yaml`. */
   actionId: string;
   appId?: string;
+  /**
+   * GH #705: path to the `.app` Maestro reinstalls from after a `clearState`
+   * uninstall. Omit it — the session's attested install receipt resolves the
+   * bundle automatically for iOS clearState flows.
+   */
+  appFile?: string;
   /**
    * Override the project root. Default: process.cwd(). Useful for tests
    * and for projects where cdp-bridge isn't invoked from the project dir.
@@ -392,6 +413,10 @@ export interface RunActionDeps {
   claimNativeOrigin?: (args: RunActionArgs) => Promise<void>;
   completeNativeOrigin?: (args: RunActionArgs, targetExpected: boolean) => Promise<void>;
   relaunchManagedApp?: (args: RunActionArgs) => Promise<void>;
+  reissueInstallReceipt?: (args: RunActionArgs) => Promise<void>;
+  /** GH #705: the session's attested install receipt, for appFile auto-resolution. */
+  installReceipt?: () => { platform?: unknown; deviceId?: unknown; appId?: unknown } | null;
+  resolveAppFile?: (appId: string, deviceId: string) => string | null;
 }
 
 /** GH #423: why the CDP/JS fallback did not replay — surfaced in failure meta. */
@@ -440,6 +465,11 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
   const claimNativeOrigin = deps.claimNativeOrigin ?? claimManagedNativeOriginAuthority;
   const completeNativeOrigin = deps.completeNativeOrigin ?? completeManagedNativeOriginAuthority;
   const relaunchManagedApp = deps.relaunchManagedApp ?? relaunchManagedNativeOriginApp;
+  const reissueInstallReceipt = deps.reissueInstallReceipt ?? reissueManagedInstallAuthority;
+  const installReceipt = deps.installReceipt ?? boundInstallReceipt;
+  const resolveAppFile =
+    deps.resolveAppFile ??
+    ((appId: string, deviceId: string) => resolveIosAppFile(appId, { deviceId }));
   return async (args: RunActionArgs): Promise<ToolResult> => {
     if (!args.actionId || typeof args.actionId !== 'string') {
       return failResult('cdp_run_action requires actionId', 'BAD_FILENAME');
@@ -496,6 +526,20 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
       (!args.platform || activeTarget?.platform === args.platform) && activeTarget?.deviceId
         ? activeTarget.deviceId
         : undefined;
+
+    // GH #705: a clearState flow uninstalls the app, so Maestro needs the
+    // bundle to reinstall from. Resolve it off the session's attested install
+    // receipt — the exact device and appId it was signed for — so the
+    // "Pass appFile=<path>" advice is followable through this tool.
+    const receipt = args.appFile ? null : installReceipt();
+    const appFile =
+      args.appFile ??
+      (flowUsesClearState(action.body) &&
+      receipt?.platform === 'ios' &&
+      typeof receipt.appId === 'string' &&
+      typeof receipt.deviceId === 'string'
+        ? (resolveAppFile(receipt.appId, receipt.deviceId) ?? undefined)
+        : undefined);
 
     // GH #397: deviceId threading. Handler-scoped (not inside the try) because
     // the outer catch also persists a RunRecord and must carry the device too.
@@ -655,6 +699,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
         flowPath: action.filePath,
         platform: args.platform,
         appId: args.appId,
+        ...(appFile ? { appFile } : {}),
         deviceId: maestroDeviceId,
         timeoutMs,
         params: args.params,
@@ -662,6 +707,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
         completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
         relaunchManagedApp: () => relaunchManagedApp(args),
         completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+        reissueInstallReceipt: () => reissueInstallReceipt(args),
       });
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, 'maestro_run');
@@ -1038,6 +1084,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
         flowPath: reloadedAction.filePath,
         platform: args.platform,
         appId: args.appId,
+        ...(appFile ? { appFile } : {}),
         deviceId: maestroDeviceId,
         timeoutMs,
         params: args.params,
@@ -1045,6 +1092,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
         completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
         relaunchManagedApp: () => relaunchManagedApp(args),
         completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+        reissueInstallReceipt: () => reissueInstallReceipt(args),
       });
       const retryMs = Date.now() - tBeforeRetry;
       const retryEnv = parseEnvelope(retryResult, 'maestro_run');

--- a/packages/rn-dev-agent-core/test/unit/gh-705-clearstate-appfile-forwarding.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-705-clearstate-appfile-forwarding.test.ts
@@ -1,0 +1,252 @@
+// GH #705: maestro_run must commit a fresh install receipt after a clearState
+// reinstall, and cdp_run_action must be able to supply the `.app` at all —
+// its missing `appFile` parameter made the documented advice unfollowable.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createMaestroRunHandler } from '../../dist/tools/maestro-run.js';
+import { chooseMaestroDispatch } from '../../dist/tools/maestro-dispatch.js';
+import { createRunActionHandler } from '../../dist/tools/run-action.js';
+import { createTmpProject } from '../helpers/tmp-project.js';
+
+const EXACT = '5C10B45B-2065-458B-B885-0F83F49747C8';
+const APP_ID = 'com.rndevagent.testapp';
+const APP_FILE = '/tmp/rn-appfile-snapshots/TestApp.app';
+
+const CLEAR_STATE_FLOW = ['- launchApp:', '    clearState: true', '- tapOn:', '    id: "go"'].join(
+  '\n',
+);
+const PLAIN_FLOW = ['- launchApp', '- tapOn:', '    id: "go"'].join('\n');
+
+function runnerLog(): string {
+  return [
+    'Single device execution mode',
+    `Building WDA for device ${EXACT} (team ID: )`,
+    `Starting WDA on device ${EXACT} (port: 8447)`,
+    'Flow execution completed: 1 passed, 0 failed, 0 skipped',
+  ].join('\n');
+}
+
+function fakeRunnerDispatch() {
+  const dispatch = chooseMaestroDispatch({
+    platform: 'ios',
+    whichAdb: () => '/usr/bin/adb',
+    whichMaestro: () => '/usr/bin/maestro',
+    maestroRunnerPath: () => '/fake/maestro-runner',
+  });
+  if ('error' in dispatch) throw new Error(dispatch.error);
+  return dispatch;
+}
+
+function maestroHandler(
+  reissues: string[],
+  outcome: 'pass' | 'fail' = 'pass',
+  seenArgs: string[][] = [],
+) {
+  return createMaestroRunHandler({
+    getActiveSession: () => ({
+      name: 'exact',
+      platform: 'ios',
+      deviceId: EXACT,
+      appId: APP_ID,
+      openedAt: new Date(0).toISOString(),
+    }),
+    chooseDispatch: () => fakeRunnerDispatch(),
+    parkFlow: async (run: () => Promise<unknown>) => run(),
+    claimNativeOrigin: async () => {},
+    completeNativeOrigin: async () => {},
+    relaunchManagedApp: async () => {},
+    reissueInstallReceipt: async () => {
+      reissues.push('reissued');
+    },
+    execFile: async (_file: string, args: string[]) => {
+      seenArgs.push(args);
+      const index = args.indexOf('--output');
+      const dir = args[index + 1];
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'maestro-runner.log'), runnerLog(), 'utf8');
+      writeFileSync(
+        join(dir, 'report.json'),
+        JSON.stringify({
+          device: { id: EXACT, platform: 'ios' },
+          flows: [{ device: { id: EXACT, platform: 'ios' } }],
+        }),
+        'utf8',
+      );
+      if (outcome === 'fail') {
+        throw Object.assign(new Error('runner exited 1'), {
+          stdout: '',
+          stderr: 'Element not found',
+          code: 1,
+        });
+      }
+      return { stdout: runnerLog(), stderr: '' };
+    },
+  });
+}
+
+test('GH#705 a clearState reinstall re-issues the install receipt', async () => {
+  const reissues: string[] = [];
+  const seenArgs: string[][] = [];
+  await maestroHandler(
+    reissues,
+    'pass',
+    seenArgs,
+  )({
+    inlineYaml: CLEAR_STATE_FLOW,
+    platform: 'ios',
+    appId: APP_ID,
+    appFile: APP_FILE,
+    deviceId: EXACT,
+  });
+  assert.deepEqual(reissues, ['reissued']);
+  assert.ok(
+    seenArgs.some((args) => args.includes(APP_FILE)),
+    'maestro-runner must receive the --app-file the receipt was re-issued for',
+  );
+});
+
+test('GH#705 a failed clearState flow still re-issues the receipt', async () => {
+  const reissues: string[] = [];
+  await maestroHandler(
+    reissues,
+    'fail',
+  )({
+    inlineYaml: CLEAR_STATE_FLOW,
+    platform: 'ios',
+    appId: APP_ID,
+    appFile: APP_FILE,
+    deviceId: EXACT,
+  });
+  assert.deepEqual(reissues, ['reissued']);
+});
+
+test('GH#705 a flow that never reinstalls does not re-issue the receipt', async () => {
+  const reissues: string[] = [];
+  await maestroHandler(reissues)({
+    inlineYaml: PLAIN_FLOW,
+    platform: 'ios',
+    appId: APP_ID,
+    appFile: APP_FILE,
+    deviceId: EXACT,
+  });
+  assert.deepEqual(reissues, []);
+});
+
+function clearStateAction(id: string): string {
+  return [
+    `appId: ${APP_ID}`,
+    '---',
+    `# id: ${id}`,
+    '# intent: log in',
+    '# tags: [auth]',
+    '# mutates: false',
+    '# status: active',
+    '',
+    '- launchApp:',
+    '    clearState: true',
+    '- tapOn:',
+    '    id: "sign-in"',
+    '',
+  ].join('\n');
+}
+
+function passEnvelope() {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({
+          ok: true,
+          data: { passed: true, output: 'Flow passed', flowFile: 'x', platform: 'ios' },
+        }),
+      },
+    ],
+  };
+}
+
+test('GH#705 cdp_run_action resolves appFile from the session install receipt', async () => {
+  const project = createTmpProject();
+  try {
+    project.seedAction('login-de', clearStateAction('login-de'), null);
+    const forwarded: Record<string, unknown>[] = [];
+    const handler = createRunActionHandler({
+      maestroRun: async (args: Record<string, unknown>) => {
+        forwarded.push(args);
+        return passEnvelope();
+      },
+      installReceipt: () => ({ platform: 'ios', deviceId: EXACT, appId: APP_ID }),
+      resolveAppFile: () => APP_FILE,
+      reissueInstallReceipt: async () => {},
+      claimNativeOrigin: async () => {},
+      completeNativeOrigin: async () => {},
+      relaunchManagedApp: async () => {},
+    });
+    const result = await handler({ actionId: 'login-de', projectRoot: project.root });
+    assert.equal(JSON.parse(result.content[0].text).ok, true);
+    assert.equal(forwarded[0].appFile, APP_FILE);
+    assert.equal(typeof forwarded[0].reissueInstallReceipt, 'function');
+  } finally {
+    project.cleanup();
+  }
+});
+
+test('GH#705 an explicit cdp_run_action appFile wins over auto-resolution', async () => {
+  const project = createTmpProject();
+  try {
+    project.seedAction('login-en', clearStateAction('login-en'), null);
+    const forwarded: Record<string, unknown>[] = [];
+    const handler = createRunActionHandler({
+      maestroRun: async (args: Record<string, unknown>) => {
+        forwarded.push(args);
+        return passEnvelope();
+      },
+      installReceipt: () => {
+        throw new Error('the receipt must not be read when appFile is explicit');
+      },
+      resolveAppFile: () => APP_FILE,
+      reissueInstallReceipt: async () => {},
+      claimNativeOrigin: async () => {},
+      completeNativeOrigin: async () => {},
+      relaunchManagedApp: async () => {},
+    });
+    await handler({
+      actionId: 'login-en',
+      projectRoot: project.root,
+      appFile: '/explicit/Other.app',
+    });
+    assert.equal(forwarded[0].appFile, '/explicit/Other.app');
+  } finally {
+    project.cleanup();
+  }
+});
+
+test('GH#705 a non-clearState action forwards no appFile', async () => {
+  const project = createTmpProject();
+  try {
+    project.seedAction(
+      'plain',
+      clearStateAction('plain').replace('- launchApp:\n    clearState: true', '- launchApp'),
+      null,
+    );
+    const forwarded: Record<string, unknown>[] = [];
+    const handler = createRunActionHandler({
+      maestroRun: async (args: Record<string, unknown>) => {
+        forwarded.push(args);
+        return passEnvelope();
+      },
+      installReceipt: () => ({ platform: 'ios', deviceId: EXACT, appId: APP_ID }),
+      resolveAppFile: () => APP_FILE,
+      reissueInstallReceipt: async () => {},
+      claimNativeOrigin: async () => {},
+      completeNativeOrigin: async () => {},
+      relaunchManagedApp: async () => {},
+    });
+    await handler({ actionId: 'plain', projectRoot: project.root });
+    assert.equal(forwarded[0].appFile, undefined);
+  } finally {
+    project.cleanup();
+  }
+});

--- a/packages/rn-dev-agent-core/test/unit/session/gh-705-clearstate-reinstall.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/gh-705-clearstate-reinstall.test.ts
@@ -1,0 +1,229 @@
+// GH #705: a `launchApp: clearState: true` flow makes Maestro reinstall the
+// app, which rotates every inode/mtime and so rotates the installGeneration
+// axis I pins. Re-issuing the receipt is allowed ONLY for the session's own
+// attested artifact — proven by the artifactDigest, which hashes file bytes.
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createAuthorityGate } from '../../../dist/session/authority-gate.js';
+import { reissueInstallBinding } from '../../../dist/session/install-reissue.js';
+import { okResult } from '../../../dist/utils.js';
+
+const BOUND_INSTALL = {
+  platform: 'ios',
+  deviceId: 'device',
+  appId: 'dev.example',
+  artifactDigest: 'attested-digest',
+  installGeneration: 'generation-1',
+  buildGeneration: 3,
+};
+
+function captureReturning(artifactDigest: string, installGeneration: string) {
+  return () => ({
+    platform: 'ios' as const,
+    deviceId: 'device',
+    appId: 'dev.example',
+    artifactDigest,
+    installGeneration,
+  });
+}
+
+test('GH#705 the session artifact re-issues the receipt with the new generation', () => {
+  const reissued = reissueInstallBinding(BOUND_INSTALL, {
+    captureInstalled: captureReturning('attested-digest', 'generation-2'),
+  });
+  assert.deepEqual(reissued, { ...BOUND_INSTALL, installGeneration: 'generation-2' });
+});
+
+test('GH#705 a foreign artifact is refused, never re-issued', () => {
+  assert.throws(
+    () =>
+      reissueInstallBinding(BOUND_INSTALL, {
+        captureInstalled: captureReturning('foreign-digest', 'generation-2'),
+      }),
+    /APP_INSTALL_IDENTITY_CHANGED/,
+  );
+});
+
+test('GH#705 an unchanged install re-issues nothing', () => {
+  assert.equal(
+    reissueInstallBinding(BOUND_INSTALL, {
+      captureInstalled: captureReturning('attested-digest', 'generation-1'),
+    }),
+    null,
+  );
+});
+
+test('GH#705 an unattestable install is refused', () => {
+  assert.throws(
+    () =>
+      reissueInstallBinding(BOUND_INSTALL, {
+        captureInstalled: () => {
+          throw new Error('exact iOS app container was not found');
+        },
+      }),
+    /APP_INSTALL_IDENTITY_CHANGED/,
+  );
+  assert.throws(
+    () => reissueInstallBinding({ platform: 'ios', deviceId: 'device' }, {}),
+    /APP_INSTALL_IDENTITY_CHANGED/,
+  );
+});
+
+function gateFixture() {
+  const status = {
+    available: true,
+    sessionId: 'session-a',
+    sourceKey: 'source',
+    worktreeKey: 'worktree',
+    appRootKey: 'app',
+    state: 'ready',
+    claimEpoch: 4,
+    authorityVersion: 9,
+    leaseUntilMs: 1000,
+    source: { kind: 'git', appRoot: process.cwd() },
+    bindings: {
+      install: { ...BOUND_INSTALL },
+      metro: { instanceId: 'metro', port: 8193 },
+      bundle: null,
+      device: { platform: 'ios', deviceId: 'device', appId: 'dev.example' },
+      runner: { instanceId: 'runner' },
+      observe: null,
+      proof: null,
+    } as Record<string, unknown>,
+    claims: [],
+    worker: { instanceId: 'worker', pid: 1, birthAvailable: true },
+  };
+  const registry = {
+    beginOperation: (_session: unknown, input: { operationId: string }) => ({
+      operationId: input.operationId,
+      sessionId: 'session-a',
+      claimEpoch: 4,
+      authorityVersion: 9,
+    }),
+    getClaim: () => null,
+    verifyOperation: () => {},
+    operationHasAxis: () => true,
+    runWithOperation: async (_operation: unknown, callback: () => unknown) => callback(),
+    commitPlatformAuthorityReceipts: () => {},
+    endOperation: () => {},
+    cancelOperation: () => {},
+    refreshOperation: (operation: { authorityVersion: number }) => ({
+      ...operation,
+      authorityVersion: status.authorityVersion,
+    }),
+    replaceBindingsDuringOperation: (
+      operation: { authorityVersion: number },
+      input: { bindings: Record<string, unknown> },
+    ) => {
+      status.bindings = { ...status.bindings, ...input.bindings };
+      status.authorityVersion += 1;
+      return { ...operation, authorityVersion: operation.authorityVersion + 1 };
+    },
+  };
+  const runtime = {
+    requireAvailable: () => ({ registry, session: { sessionId: 'session-a', claimEpoch: 4 } }),
+    status: () => status,
+  };
+  // Axis I's identity is derived from the bound receipt, exactly as the real
+  // probe does — so a re-issued binding MUST move the postflight identity.
+  const probe = async ({ axis, status: probed }: { axis: string; status: typeof status }) => ({
+    axis,
+    identity:
+      axis === 'I'
+        ? `I:${(probed.bindings.install as { installGeneration: string }).installGeneration}`
+        : `${axis}-identity`,
+  });
+  return { registry, runtime, status, probe };
+}
+
+test('GH#705 maestro_run keeps axis I after re-issuing its own reinstall', async () => {
+  const { runtime, status, probe } = gateFixture();
+  const gate = createAuthorityGate(runtime, {
+    probe,
+    reissueInstallBinding: (install: Record<string, unknown> | undefined) =>
+      reissueInstallBinding(install, {
+        captureInstalled: captureReturning('attested-digest', 'generation-2'),
+      }),
+  });
+
+  const wrapped = gate.wrap('maestro_run', async (args: Record<string, unknown>) => {
+    const { reissueManagedInstallAuthority } =
+      await import('../../../dist/session/authority-gate.js');
+    await reissueManagedInstallAuthority(args);
+    return okResult({ passed: true });
+  });
+
+  const envelope = JSON.parse((await wrapped({})).content[0].text);
+  assert.equal(envelope.ok, true, envelope.error);
+  assert.equal(
+    (status.bindings.install as { installGeneration: string }).installGeneration,
+    'generation-2',
+  );
+});
+
+test('GH#705 a foreign reinstall still refuses maestro_run with axis I', async () => {
+  const { runtime, status, probe } = gateFixture();
+  const gate = createAuthorityGate(runtime, {
+    probe,
+    reissueInstallBinding: (install: Record<string, unknown> | undefined) =>
+      reissueInstallBinding(install, {
+        captureInstalled: captureReturning('foreign-digest', 'generation-2'),
+      }),
+  });
+
+  const wrapped = gate.wrap('maestro_run', async (args: Record<string, unknown>) => {
+    const { reissueManagedInstallAuthority } =
+      await import('../../../dist/session/authority-gate.js');
+    await reissueManagedInstallAuthority(args);
+    return okResult({ passed: true });
+  });
+
+  const envelope = JSON.parse((await wrapped({})).content[0].text);
+  assert.equal(envelope.ok, false);
+  assert.equal(envelope.code, 'APP_INSTALL_IDENTITY_CHANGED');
+  assert.equal(
+    (status.bindings.install as { installGeneration: string }).installGeneration,
+    'generation-1',
+  );
+});
+
+test('GH#705 axis I moving without a re-issue is still lost authority', async () => {
+  const { runtime, status, probe } = gateFixture();
+  const gate = createAuthorityGate(runtime, { probe });
+
+  const wrapped = gate.wrap('maestro_run', async () => {
+    // An out-of-band reinstall: nothing proved the artifact, nothing re-issued.
+    (status.bindings.install as { installGeneration: string }).installGeneration = 'generation-9';
+    return okResult({ passed: true });
+  });
+
+  const envelope = JSON.parse((await wrapped({})).content[0].text);
+  assert.equal(envelope.ok, false);
+  assert.equal(envelope.code, 'AUTHORITY_LOST_DURING_OPERATION');
+});
+
+test('GH#705 tools without the re-issue profile cannot reach the capability', async () => {
+  const { runtime, probe } = gateFixture();
+  let reissued = false;
+  const gate = createAuthorityGate(runtime, {
+    probe,
+    reissueInstallBinding: () => {
+      reissued = true;
+      return { ...BOUND_INSTALL, installGeneration: 'generation-2' };
+    },
+  });
+
+  const wrapped = gate.wrap('device_press', async (args: Record<string, unknown>) => {
+    const { hasManagedInstallReissueAuthority, reissueManagedInstallAuthority } =
+      await import('../../../dist/session/authority-gate.js');
+    assert.equal(hasManagedInstallReissueAuthority(args), false);
+    await reissueManagedInstallAuthority(args);
+    return okResult({ pressed: true });
+  });
+
+  const envelope = JSON.parse((await wrapped({})).content[0].text);
+  assert.equal(envelope.ok, false);
+  assert.equal(envelope.code, 'APP_INSTALL_IDENTITY_CHANGED');
+  assert.equal(reissued, false);
+});

--- a/packages/rn-dev-agent-core/test/unit/session/tool-profiles.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/tool-profiles.test.ts
@@ -567,6 +567,8 @@ test('device_find click and lifecycle tools use mutation-aware origin authority'
   for (const tool of ['maestro_run', 'maestro_test_all']) {
     assert.equal(authorityProfileFor(tool).managedRunnerPark, true);
   }
+  assert.equal(authorityProfileFor('maestro_run').managedInstallReissue, true);
+  assert.equal(authorityProfileFor('maestro_test_all').managedInstallReissue, false);
   const storageReset = authorityProfileFor('device_reset_state', { storageKeys: ['token'] });
   assert.equal(storageReset.axes.includes('B'), true);
   assert.equal(storageReset.postflightAxes?.includes('B'), false);


### PR DESCRIPTION
## Intent

Fix GitHub issue #705 in Lykhoyda/rn-dev-agent: under strict session enforcement, any Maestro flow opening with `launchApp: clearState: true` destroys its own session. Maestro reinstalls the app from the .app outside the adapter's attested build path, so the installed artifact stops matching the signed install receipt, and every later device_* / maestro_run call refuses with APP_INSTALL_IDENTITY_CHANGED (authority axis I) until a full new adapter build reissues the receipt. Every auth action in the workspace corpus (login-de, login-en, login-new-user, register-new-user) opens with clearState, so the whole auth corpus is unrunnable. A second gap compounds it: cdp_run_action had no appFile parameter, so a clearState flow failed even earlier with advice ('Pass appFile=<path>') that could not be followed through that tool.

ACCEPTED MINIMAL CONTRACT - exactly these two behaviors and nothing wider:
1. When maestro_run reinstalls the session's OWN attested .app - the artifact digest matches the session's build receipt - record a new install receipt after Maestro's reinstall instead of breaking axis I. A reinstall of any artifact that does NOT match the attested digest must keep failing exactly as it does today.
2. Forward appFile through cdp_run_action, auto-resolving it from the session's build receipt so the documented advice becomes followable.

CONSTRAINTS THE USER SET:
- 80/20: make the real auth-corpus path work. Do NOT build a general reinstall broker, a new attestation scheme, extra ownership state, or a recovery framework. Deliberate narrowness is the accepted design, not an oversight.
- The identity guarantee is a safety boundary: only a digest-matched, session-owned artifact may re-issue a receipt. Never weaken axis I into a blanket bypass, and never let a foreign or unverified artifact pass.
- Do NOT 'fix' this by removing or relaxing strict enforcement.
- Add regression tests encoding both the accepted reinstall (receipt re-issued) and the rejected one (foreign artifact still refused).
- Findings that would broaden this contract belong in a follow-up issue, not in this PR.

DEFINITION OF SUCCESS: a flow whose first step is `launchApp: clearState: true` runs through cdp_run_action without a manual appFile, and subsequent device_* / maestro_run calls in the same session keep working rather than refusing with APP_INSTALL_IDENTITY_CHANGED.

IMPLEMENTATION DECISIONS AND TRADEOFFS MADE WHILE DOING THE WORK (context a reviewer reading only the diff would not have):
- Root cause: install-authority.ts computes two values - artifactDigest (hash of every file's BYTES) and installGeneration (hash of every file's inode/size/mtime). Axis I's hot path checks only the cheap installGeneration, so a reinstall of a byte-identical .app still trips it. The fix exploits exactly that asymmetry: prove the expensive content digest, then re-stamp the cheap generation.
- The stored bindings.install payload is the UNSIGNED BuildReceiptPayload (rn-session.ts stores receipt.payload; tools/session.ts stores verifyBuildReceipt()'s return, also the payload). So 're-issue the receipt' is deliberately a binding replacement under the operation fence - no signer plumbing was added, and the registry CAS in replaceBindingsDuringOperation is what keeps it honest. This was a considered choice, not a missed signature step.
- New module src/session/install-reissue.ts holds the whole proof: it re-hashes the installed bundle via captureInstalledArtifact and returns a re-stamped binding ONLY when artifactDigest still matches; a mismatched digest, an unattestable install, and a malformed/absent binding each throw SessionAuthorityError('APP_INSTALL_IDENTITY_CHANGED'). An unchanged generation returns null (no-op).
- The capability is gate-owned: a new managedInstallReissue symbol on authority-gate.ts, installed on args only when the tool profile carries managedInstallReissue (maestro_run / maestro_test_all / cdp_run_action). Handlers reach it through reissueManagedInstallAuthority(args); a tool without the profile flag gets APP_INSTALL_IDENTITY_CHANGED instead. Only that gate-owned closure sets installReceiptReissued, which is what lets axis I move in the gate's before/after identity fence - deliberately the same shape as the existing runtimeTargetChanged (axis B) and controllerGenerationAdvanced (axis C) exemptions. A handler cannot forge it. Axis I moving WITHOUT that proof is still AUTHORITY_LOST_DURING_OPERATION.
- maestro_run invokes the re-issue only when an --app-file was resolved AND the flow actually uses clearState (an inert --app-file on a non-clearState flow must not re-issue). It is invoked on BOTH the pass path and the catch path, because a flow can die after the reinstall; on the failure path a refusal deliberately propagates and masks the flow error, which is the intended fail-closed behavior when a foreign artifact is on the device.
- cdp_run_action gained an appFile arg forwarded verbatim to both the first attempt and the post-repair retry; when absent it auto-resolves ONLY for iOS clearState actions, from the install receipt's exact deviceId and appId. Gating auto-resolution on clearState is deliberate: passing an explicit appFile to maestro_run short-circuits its own clearState check, so an ungated auto-resolve would attach --app-file to every flow.
- resolveIosAppFile now takes an optional deviceId (new field on ResolveAppFileDeps) and asks simctl get_app_container for that exact UDID instead of always 'booted'. This is likely the original cause of the reporter's 'no built .app could be located' with two devices attached.
- MaestroRunArgs.reissueInstallReceipt is typed (() => Promise<void>) | null because sibling tools (cdp_run_e2e_suite, cdp_lock_e2e_test) spread nestedMaestroAuthorityCallbacks into MaestroRunArgs and correctly receive null there - their profiles intentionally do NOT carry the new capability, per the narrow contract.
- Tests: packages/rn-dev-agent-core/test/unit/session/gh-705-clearstate-reinstall.test.ts (accepted re-issue; foreign artifact refused with the binding left untouched; unattestable install refused; unchanged generation is a no-op; axis I moving without a re-issue still AUTHORITY_LOST_DURING_OPERATION; unprofiled tools cannot reach the capability) and packages/rn-dev-agent-core/test/unit/gh-705-clearstate-appfile-forwarding.test.ts (clearState reinstall re-issues; failed clearState flow still re-issues; non-clearState flow does not; cdp_run_action auto-resolves appFile from the receipt; explicit appFile wins; non-clearState action forwards none).
- Also updated: docs-site session-authority.mdx prose, regenerated cdp_run_action.mdx, a changeset patch-bumping rn-dev-agent-core and rn-dev-agent-plugin, and rebuilt host runtimes via scripts/build-host-runtimes.ts. The regenerated docs changelog.md sync was reverted as unrelated release noise.
- KNOWN AND DELIBERATELY OUT OF SCOPE (follow-up issue material, not this PR): cdp_run_e2e_suite and cdp_lock_e2e_test still break axis I on a clearState flow because their profiles do not carry the capability; and the docs generator renders multi-line .describe() blocks as an empty description, a pre-existing limitation the new appFile param inherits.

Full unit suite (4477 tests) green, oxlint and oxfmt clean.

## What Changed

- Added `src/session/install-reissue.ts` plus a gate-owned `managedInstallReissue` capability on the authority gate: after Maestro reinstalls the app, the installed bundle is re-hashed and the session's install binding is re-stamped **only** when the artifact digest still matches the attested build receipt. A mismatched, unattestable, or missing binding still throws `APP_INSTALL_IDENTITY_CHANGED`, and axis I moving without that gate-issued proof remains `AUTHORITY_LOST_DURING_OPERATION`.
- Wired the capability into `maestro_run`, which invokes it on both the pass and failure paths but only when an `--app-file` was resolved and the flow actually uses `clearState`; the tool profile grants the flag to `maestro_run` alone, so unprofiled tools cannot reach it.
- Added an `appFile` parameter to `cdp_run_action`, forwarded verbatim to the first attempt and the post-repair retry and auto-resolved from the install receipt for iOS `clearState` actions; `resolveIosAppFile` now queries `simctl get_app_container` for the session's exact UDID instead of `booted`. Covered by new regression tests for the accepted re-issue and the refused foreign artifact, with docs and a changeset updated alongside.

## Risk Assessment

✅ Low: The follow-up commit is a one-line profile narrowing plus a two-line locking test that resolves the only substantive round-1 finding without touching the re-issue mechanism, leaving a well-bounded change whose safety boundary (digest-proven, gate-owned axis-I exemption) and regression coverage were already verified.

## Testing

After installing the missing workspace dependencies and rebuilding dist from source (zero drift, so the committed build matches src), I ran the two new GH #705 regression files and every existing test file covering the touched modules — maestro-run, run-action, resolve-ios-app-file, authority-gate and tool-profiles — 320 tests, all green. Since the unit tests stub the digest proof, I additionally built an end-to-end harness that drives the real cdp_run_action handler through the real maestro_run handler, the real authority gate and a real SQLite session registry, with the production install attestation hashing a real .app directory on disk that is genuinely uninstalled and reinstalled the way clearState does; only simctl, plutil and the maestro-runner binary are shimmed. Its transcript reproduces the reported bug, then shows the fix: a clearState action runs through cdp_run_action with no manual appFile (resolved from the receipt's exact simulator UDID), the receipt is re-issued with the artifact digest unchanged, and device_press, device_snapshot, maestro_run and a second cdp_run_action all keep succeeding in the same session — while a foreign artifact is refused with the binding untouched and the same reinstall inside an unprofiled tool still fails closed. For the two docs pages in the diff I captured rendered screenshots from a local docs server; the session-authority prose renders correctly, and the cdp_run_action parameter table shows appFile with an empty description cell, which is the pre-existing docs-generator limitation the author already flagged (platform, autoRepair and forceReload render identically), not a regression. Everything passed and the worktree is clean.

<details>
<summary>Evidence: End-to-end transcript: clearState auth flow survives the reinstall, foreign artifact still refused</summary>

<code>GH #705 — clearState auth flows under strict session enforcement&#10;====&#10;&#10;SCENARIO A — the reported bug: a clearState reinstall nobody attested&#10;&#10;── step 1: session is fenced to its attested build ───────────────────&#10;artifactDigest 880307606a9c… (hash of every file&#39;s BYTES)&#10;installGeneration 4dd2e0408d6c… (hash of inode/size/mtime)&#10;&#10;── step 2: a clearState reinstall happens with nothing proving the artifact&#10;same bytes? true&#10;same generation? false&#10;&#10;── step 3: the next device_* call in the same session ────────────────&#10;device_press: ok=false code=APP_INSTALL_IDENTITY_CHANGED — installed artifact identity no longer matches the session build&#10;&#10;====&#10;SCENARIO B — the fix: cdp_run_action runs the auth flow, session survives&#10;&#10;── step 4: the auth corpus action opens with clearState ──────────────&#10;.rn-agent/actions/login-de.yaml:&#10;- launchApp:&#10;clearState: true&#10;- tapOn:&#10;id: &#34;sign-in&#34;&#10;bound installGeneration d2bd1a9cc9ab…&#10;&#10;── step 5: the .app is resolved from the receipt, for that EXACT simulator&#10;receipt deviceId 5C10B45B-2065-458B-B885-0F83F49747C8 -&gt; /tmp/rn-appfile-snapshots/TestApp.app&#10;a different UDID A1111111-2222-3333-4444-555555555555 -&gt; null&#10;&#10;── step 6: cdp_run_action login-de — no appFile passed by the caller ─&#10;maestro-runner: uninstalled com.rndevagent.testapp, reinstalled from /tmp/rn-appfile-snapshots/TestApp.app&#10;cdp_run_action: ok=true&#10;reinstalls performed by maestro-runner: 1&#10;&#10;── step 7: the install receipt after the reinstall ───────────────────&#10;artifactDigest 880307606a9c… (unchanged — same attested bytes)&#10;installGeneration bc55d8ed0c63… (re-stamped for the new inodes)&#10;receipt re-issued: true&#10;&#10;── step 8: subsequent calls in the SAME session ──────────────────────&#10;device_press: ok=true&#10;device_snapshot: ok=true&#10;maestro_run (plain flow): ok=true&#10;cdp_run_action (2nd run): ok=true&#10;&#10;====&#10;SCENARIO C — safety boundary: a FOREIGN artifact is still refused&#10;&#10;── step 9: a different .app is on the device after the reinstall ─────&#10;bound artifactDigest 880307606a9c…&#10;&#10;── step 10: cdp_run_action login-de reinstalls that foreign artifact ──&#10;cdp_run_action: ok=false code=APP_INSTALL_IDENTITY_CHANGED — the reinstalled artifact is not the attested session build&#10;installed artifactDigest bfc734aed4e1… (≠ attested)&#10;&#10;── step 11: the bound receipt was left untouched, and the session stays refused&#10;receipt unchanged: true&#10;device_press: ok=false code=APP_INSTALL_IDENTITY_CHANGED&#10;&#10;====&#10;SCENARIO D — narrowness: the same reinstall through an unprofiled tool&#10;&#10;── step 12: device_press does the exact same byte-identical reinstall mid-call&#10;device_press: ok=false code=APP_INSTALL_IDENTITY_CHANGED&#10;→ only maestro_run / cdp_run_action carry the re-issue capability.</code>

```text
GH #705 — clearState auth flows under strict session enforcement
==========================================================================

SCENARIO A — the reported bug: a clearState reinstall nobody attested

── step 1: session is fenced to its attested build ───────────────────
   artifactDigest    880307606a9c… (hash of every file's BYTES)
   installGeneration 4dd2e0408d6c… (hash of inode/size/mtime)

── step 2: a clearState reinstall happens with nothing proving the artifact 
   same bytes?          true
   same generation?     false

── step 3: the next device_* call in the same session ────────────────
   device_press: ok=false code=APP_INSTALL_IDENTITY_CHANGED — APP_INSTALL_IDENTITY_CHANGED: installed artifact identity no longer matches the session build

==========================================================================
SCENARIO B — the fix: cdp_run_action runs the auth flow, session survives

── step 4: the auth corpus action opens with clearState ──────────────
   .rn-agent/actions/login-de.yaml:
     - launchApp:
         clearState: true
     - tapOn:
         id: "sign-in"
   bound installGeneration d2bd1a9cc9ab…

── step 5: the .app is resolved from the receipt, for that EXACT simulator 
   receipt deviceId 5C10B45B-2065-458B-B885-0F83F49747C8 -> /var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/rn-appfile-snapshots/TestApp.app
   a different UDID  A1111111-2222-3333-4444-555555555555 -> null

── step 6: cdp_run_action login-de — no appFile passed by the caller ─
   maestro-runner: uninstalled com.rndevagent.testapp, reinstalled from /var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/rn-appfile-snapshots/TestApp.app
   cdp_run_action: ok=true
   reinstalls performed by maestro-runner: 1

── step 7: the install receipt after the reinstall ───────────────────
   artifactDigest    880307606a9c… (unchanged — same attested bytes)
   installGeneration bc55d8ed0c63… (re-stamped for the new inodes)
   receipt re-issued: true

── step 8: subsequent calls in the SAME session ──────────────────────
   device_press: ok=true
   device_snapshot: ok=true
   maestro_run (plain flow): ok=true
   maestro-runner: uninstalled com.rndevagent.testapp, reinstalled from /var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/rn-appfile-snapshots/TestApp.app
   cdp_run_action (2nd run): ok=true

==========================================================================
SCENARIO C — safety boundary: a FOREIGN artifact is still refused

── step 9: a different .app is on the device after the reinstall ─────
   bound artifactDigest    880307606a9c…

── step 10: cdp_run_action login-de reinstalls that foreign artifact ──
   maestro-runner: uninstalled com.rndevagent.testapp, reinstalled from /var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/rn-appfile-snapshots/TestApp.app
   cdp_run_action: ok=false code=APP_INSTALL_IDENTITY_CHANGED — APP_INSTALL_IDENTITY_CHANGED: the reinstalled artifact is not the attested session build
   installed artifactDigest bfc734aed4e1… (≠ attested)

── step 11: the bound receipt was left untouched, and the session stays refused 
   receipt unchanged: true
   device_press: ok=false code=APP_INSTALL_IDENTITY_CHANGED — APP_INSTALL_IDENTITY_CHANGED: installed artifact identity no longer matches the session build

==========================================================================
SCENARIO D — narrowness: the same reinstall through an unprofiled tool

── step 12: device_press does the exact same byte-identical reinstall mid-call 
   device_press: ok=false code=APP_INSTALL_IDENTITY_CHANGED — APP_INSTALL_IDENTITY_CHANGED: installed artifact identity no longer matches the session build
   → only maestro_run / cdp_run_action carry the re-issue capability.

==========================================================================
done.
```
</details>
<details>
<summary>Evidence: Harness source (real gate + registry + install attestation over a real .app)</summary>

```text
// GH #705 end-to-end evidence harness.
//
// Drives the REAL cdp_run_action handler -> REAL maestro_run handler -> REAL
// authority gate -> REAL SQLite session registry, with the REAL install
// attestation (byte-level artifactDigest + inode/size/mtime installGeneration)
// computed over a REAL .app directory on disk that is genuinely uninstalled and
// reinstalled the way Maestro's `launchApp: clearState: true` does.
//
// Only the host OS edges are shimmed: `xcrun simctl get_app_container`,
// `plutil`, and the maestro-runner binary (whose stand-in performs the actual
// reinstall on disk).

import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, statSync } from 'node:fs';
import { join } from 'node:path';

const CORE = process.env.CORE_DIST!;
const { openSessionRegistry } = await import(`${CORE}/session/registry.js`);
const { createWorkerAuthorityRuntime } = await import(
  `${CORE}/session/runtime.js`
);
const { createAuthorityGate } = await import(`${CORE}/session/authority-gate.js`);
const { createLocalAuthorityProbe } = await import(`${CORE}/session/local-authority-probe.js`);
const { captureInstalledArtifact, captureInstallGeneration } = await import(
  `${CORE}/session/install-authority.js`
);
const { reissueInstallBinding } = await import(`${CORE}/session/install-reissue.js`);
const { createRunActionHandler } = await import(`${CORE}/tools/run-action.js`);
const { createMaestroRunHandler } = await import(`${CORE}/tools/maestro-run.js`);
const { chooseMaestroDispatch } = await import(`${CORE}/tools/maestro-dispatch.js`);
const { resolveIosAppFile } = await import(`${CORE}/tools/resolve-ios-app-file.js`);
const { okResult } = await import(`${CORE}/utils.js`);

const UDID = '5C10B45B-2065-458B-B885-0F83F49747C8';
const OTHER_UDID = 'A1111111-2222-3333-4444-555555555555';
const APP_ID = 'com.rndevagent.testapp';

const roots: string[] = [];
function tmpRoot(prefix: string): string {
  const root = mkdtempSync(join(process.env.EVIDENCE_DIR!, prefix));
  roots.push(root);
  return root;
}

let step = 0;
function say(line = ''): void {
  process.stdout.write(`${line}\n`);
}
function head(title: string): void {
  step += 1;
  say();
  say(`── step ${step}: ${title} ${'─'.repeat(Math.max(0, 58 - title.length))}`);
}
function short(value: string): string {
  return `${value.slice(0, 12)}…`;
}

// ── the "adapter build output" and the "simulator container" ────────────────
function writeApp(dir: string, marker: string): void {
  mkdirSync(join(dir, 'Frameworks'), { recursive: true });
  writeFileSync(join(dir, 'Info.plist'), `<plist>CFBundleExecutable=TestApp ${marker}</plist>`);
  writeFileSync(join(dir, 'TestApp'), `MACH-O-BINARY-${marker}\n`.repeat(64));
  writeFileSync(join(dir, 'Frameworks', 'Hermes.framework'), `HERMES-${marker}\n`.repeat(16));
}

interface World {
  root: string;
  buildApp: string;
  containerApp: string;
  reinstalls: number;
}

function makeWorld(prefix: string): World {
  const root = tmpRoot(prefix);
  const buildApp = join(root, 'DerivedData', 'Build', 'Products', 'Debug-iphonesimulator', 'TestApp.app');
  const containerApp = join(root, 'CoreSimulator', UDID, 'Bundle', 'Application', 'TestApp.app');
  writeApp(buildApp, 'attested-session-build');
  mkdirSync(join(root, 'CoreSimulator', UDID, 'Bundle', 'Application'), { recursive: true });
  cpSync(buildApp, containerApp, { recursive: true });
  return { root, buildApp, containerApp, reinstalls: 0 };
}

/** Stand-in for `xcrun simctl get_app_container <udid> <appId> app`. */
function containerFor(world: World, deviceId: string | undefined, appId: string): string {
  if (deviceId !== UDID || appId !== APP_ID) {
    throw new Error(`No such device or app: device=${deviceId} app=${appId}`);
  }
  return world.containerApp;
}

function probeShims(world: World) {
  return {
    runText: (command: string, args: readonly string[]): string => {
      if (command === 'xcrun' && args[1] === 'get_app_container') {
        return `${containerFor(world, args[2], args[3])}\n`;
      }
      if (command === 'plutil') return 'TestApp\n';
      throw new Error(`unexpected host command: ${command} ${args.join(' ')}`);
    },
  };
}

const capture = (world: World, target: Record<string, unknown>) =>
  captureInstalledArtifact(target, probeShims(world));

// ── a fenced session with a real attested install receipt ───────────────────
function openSession(world: World) {
  const registryPath = join(world.root, 'registry.sqlite3');
  const registry = openSessionRegistry(registryPath, { ownerStatus: () => 'match' });
  const session = registry.createSession({
    sessionId: 'session-gh705',
    sourceKey: 'source',
    worktreeKey: 'worktree',
    appRootKey: 'app',
    supervisor: { pid: process.pid, token: 'supervisor-birth' },
    source: { kind: 'git', appRoot: world.root, sourceKey: 'source', worktreeKey: 'worktree', appRootKey: 'app' },
  });
  const receipt = capture(world, { platform: 'ios', deviceId: UDID, appId: APP_ID });
  registry.updateBindings(session, {
    bindings: {
      install: { ...receipt, buildGeneration: 1 },
      device: { platform: 'ios', deviceId: UDID, appId: APP_ID },
      metro: { instanceId: 'metro', port: 8081 },
      runner: { instanceId: 'runner' },
    },
  });
  registry.close();

  process.env.RN_DEV_AGENT_SESSION_ID = session.sessionId;
  process.env.RN_DEV_AGENT_CLAIM_EPOCH = String(session.claimEpoch);
  process.env.RN_DEV_AGENT_REGISTRY_PATH = registryPath;
  process.env.RN_DEV_AGENT_WORKER_INSTANCE = 'worker-gh705';
  const runtime = createWorkerAuthorityRuntime(process.env, {
    readBirth: () => ({ pid: process.pid, source: 'darwin-ps', token: 'worker-birth' }),
    ownerStatus: () => 'match',
  });
  return { runtime, receipt };
}

function installBinding(runtime: { status(): Record<string, any> }): Record<string, string> {
  return runtime.status().bindings.install as Record<string, string>;
}

// ── the authority gate, wired as index.ts wires it ─────────────────────────
function makeGate(world: World, runtime: any) {
  const localProbe = createLocalAuthorityProbe({
    runtime,
    getClient: () => ({}),
    getSecret: () => null,
    proofActive: () => false,
    captureInstalled: (target: Record<string, unknown>) => capture(world, target),
    captureInstallGeneration: (target: Record<string, unknown>) =>
      captureInstallGeneration(target, probeShims(world)),
  });
  return createAuthorityGate(runtime, {
    // Managed-lifecycle edges maestro_run drives around the flow; unrelated to
    // axis I, so they are satisfied without a real Metro/CDP seat.
    relaunchBoundRuntime: async () => {},
    refreshRuntimeBinding: async () => ({ targetId: 'target-1', port: 8081 }),
    // Axis I — the axis this change moves — runs the production probe against
    // the real bundle on disk. The unrelated axes are held steady.
    probe: async (input: { axis: string }) =>
      input.axis === 'I' ? localProbe(input) : { axis: input.axis, identity: `${input.axis}-steady` },
    reissueInstallBinding: (install: Record<string, unknown> | undefined) =>
      reissueInstallBinding(install, {
        captureInstalled: (target: Record<string, unknown>) => capture(world, target),
      }),
  });
}

// ── maestro-runner stand-in: performs the real clearState reinstall ────────
function maestroHandler(world: World, source: () => string) {
  const dispatch = chooseMaestroDispatch({
    platform: 'ios',
    whichAdb: () => '/usr/bin/adb',
    whichMaestro: () => '/usr/bin/maestro',
    maestroRunnerPath: () => '/fake/maestro-runner',
  });
  if ('error' in dispatch) throw new Error(dispatch.error);
  return createMaestroRunHandler({
    getActiveSession: () => ({
      name: 'exact',
      platform: 'ios',
      deviceId: UDID,
      appId: APP_ID,
      openedAt: new Date(0).toISOString(),
    }),
    chooseDispatch: () => dispatch,
    parkFlow: async (run: () => Promise<unknown>) => run(),
    execFile: async (_file: string, args: string[]) => {
      const appFi

... [2904 bytes truncated] ...

     maestroRun: maestroHandler(world, source),
      // Exactly what the shipped default computes, read from this scenario's
      // session instead of the process-wide singleton.
      installReceipt: () => runtime.status().bindings.install,
      // The real receipt-driven resolution: exact UDID from the receipt, real
      // resolver, real snapshot-out-of-container copy.
      resolveAppFile: (appId: string, deviceId: string) =>
        resolveIosAppFile(appId, {
          deviceId,
          getAppContainer: (bundleId: string, udid?: string) => {
            try {
              return containerFor(world, udid, bundleId);
            } catch {
              return null;
            }
          },
        }),
    }),
  );
}

function envelopeOf(result: { content: { text: string }[] }): Record<string, any> {
  return JSON.parse(result.content[0].text);
}

function report(label: string, envelope: Record<string, any>): void {
  say(
    `   ${label}: ok=${envelope.ok}${envelope.code ? ` code=${envelope.code}` : ''}${
      envelope.error ? ` — ${String(envelope.error).slice(0, 200)}` : ''
    }`,
  );
}

// ═══════════════════════════════════════════════════════════════════════════
say('GH #705 — clearState auth flows under strict session enforcement');
say('='.repeat(74));

// ── Scenario A: today's bug, reproduced ───────────────────────────────────
say();
say('SCENARIO A — the reported bug: a clearState reinstall nobody attested');
{
  const world = makeWorld('gh705-a-');
  const { runtime, receipt } = openSession(world);
  const gate = makeGate(world, runtime);

  head('session is fenced to its attested build');
  say(`   artifactDigest    ${short(receipt.artifactDigest)} (hash of every file's BYTES)`);
  say(`   installGeneration ${short(receipt.installGeneration)} (hash of inode/size/mtime)`);

  head('a clearState reinstall happens with nothing proving the artifact');
  rmSync(world.containerApp, { recursive: true, force: true });
  cpSync(world.buildApp, world.containerApp, { recursive: true });
  const after = capture(world, { platform: 'ios', deviceId: UDID, appId: APP_ID });
  say(`   same bytes?          ${after.artifactDigest === receipt.artifactDigest}`);
  say(`   same generation?     ${after.installGeneration === receipt.installGeneration}`);

  head('the next device_* call in the same session');
  const press = gate.wrap('device_press', async () => okResult({ pressed: true }));
  report('device_press', envelopeOf(await press({ testId: 'sign-in' })));
  runtime.close();
}

// ── Scenario B: the fix, end to end ───────────────────────────────────────
say();
say('='.repeat(74));
say('SCENARIO B — the fix: cdp_run_action runs the auth flow, session survives');
{
  const world = makeWorld('gh705-b-');
  const { runtime, receipt } = openSession(world);
  const gate = makeGate(world, runtime);
  const projectRoot = seedProject(world);
  const runAction = runActionHandler(world, gate, runtime, () => world.buildApp);

  head('the auth corpus action opens with clearState');
  say('   .rn-agent/actions/login-de.yaml:');
  for (const line of ['- launchApp:', '    clearState: true', '- tapOn:', '    id: "sign-in"']) {
    say(`     ${line}`);
  }
  say(`   bound installGeneration ${short(receipt.installGeneration)}`);

  head('the .app is resolved from the receipt, for that EXACT simulator');
  const resolver = (deviceId: string) =>
    resolveIosAppFile(APP_ID, {
      deviceId,
      getAppContainer: (bundleId: string, udid?: string) => {
        try {
          return containerFor(world, udid, bundleId);
        } catch {
          return null;
        }
      },
    });
  say(`   receipt deviceId ${UDID} -> ${resolver(UDID)}`);
  say(`   a different UDID  ${OTHER_UDID} -> ${resolver(OTHER_UDID)}`);

  head('cdp_run_action login-de — no appFile passed by the caller');
  const envelope = envelopeOf(await runAction({ actionId: 'login-de', projectRoot }));
  report('cdp_run_action', envelope);
  say(`   reinstalls performed by maestro-runner: ${world.reinstalls}`);

  head('the install receipt after the reinstall');
  const rebound = installBinding(runtime);
  say(`   artifactDigest    ${short(rebound.artifactDigest)} (unchanged — same attested bytes)`);
  say(`   installGeneration ${short(rebound.installGeneration)} (re-stamped for the new inodes)`);
  say(`   receipt re-issued: ${rebound.installGeneration !== receipt.installGeneration}`);

  head('subsequent calls in the SAME session');
  const press = gate.wrap('device_press', async () => okResult({ pressed: true }));
  report('device_press', envelopeOf(await press({ testId: 'continue' })));
  const snapshot = gate.wrap('device_snapshot', async () => okResult({ nodes: 42 }));
  report('device_snapshot', envelopeOf(await snapshot({})));
  const plainRun = gate.wrap('maestro_run', maestroHandler(world, () => world.buildApp));
  report(
    'maestro_run (plain flow)',
    envelopeOf(
      await plainRun({
        inlineYaml: '- launchApp\n- tapOn:\n    id: "go"',
        platform: 'ios',
        appId: APP_ID,
        deviceId: UDID,
      }),
    ),
  );
  const second = envelopeOf(await runAction({ actionId: 'login-de', projectRoot }));
  report('cdp_run_action (2nd run)', second);
  runtime.close();
}

// ── Scenario C: the safety boundary holds ─────────────────────────────────
say();
say('='.repeat(74));
say('SCENARIO C — safety boundary: a FOREIGN artifact is still refused');
{
  const world = makeWorld('gh705-c-');
  const { runtime, receipt } = openSession(world);
  const gate = makeGate(world, runtime);
  const projectRoot = seedProject(world);

  const foreignApp = join(world.root, 'Foreign', 'TestApp.app');
  writeApp(foreignApp, 'someone-elses-build');
  const runAction = runActionHandler(world, gate, runtime, () => foreignApp);

  head('a different .app is on the device after the reinstall');
  say(`   bound artifactDigest    ${short(receipt.artifactDigest)}`);

  head('cdp_run_action login-de reinstalls that foreign artifact');
  report('cdp_run_action', envelopeOf(await runAction({ actionId: 'login-de', projectRoot })));
  const foreignDigest = capture(world, { platform: 'ios', deviceId: UDID, appId: APP_ID });
  say(`   installed artifactDigest ${short(foreignDigest.artifactDigest)} (≠ attested)`);

  head('the bound receipt was left untouched, and the session stays refused');
  const stillBound = installBinding(runtime);
  say(`   receipt unchanged: ${stillBound.installGeneration === receipt.installGeneration}`);
  const press = gate.wrap('device_press', async () => okResult({ pressed: true }));
  report('device_press', envelopeOf(await press({ testId: 'sign-in' })));
  runtime.close();
}

// ── Scenario D: the grant is narrow ───────────────────────────────────────
say();
say('='.repeat(74));
say('SCENARIO D — narrowness: the same reinstall through an unprofiled tool');
{
  const world = makeWorld('gh705-d-');
  const { runtime } = openSession(world);
  const gate = makeGate(world, runtime);

  head('device_press does the exact same byte-identical reinstall mid-call');
  const press = gate.wrap('device_press', async () => {
    rmSync(world.containerApp, { recursive: true, force: true });
    cpSync(world.buildApp, world.containerApp, { recursive: true });
    return okResult({ pressed: true });
  });
  report('device_press', envelopeOf(await press({ testId: 'sign-in' })));
  say('   → only maestro_run / cdp_run_action carry the re-issue capability.');
  runtime.close();
}

say();
say('='.repeat(74));
for (const root of roots) rmSync(root, { force: true, recursive: true });
rmSync(join(process.env.TMPDIR ?? '/tmp', 'rn-appfile-snapshots'), {
  force: true,
  recursive: true,
});
say('done.');
```
</details>
<details>
<summary>Evidence: Live MCP tools/list: cdp_run_action&#39;s new appFile parameter as an agent sees it</summary>

<code>{&#10;&#34;tool&#34;: &#34;cdp_run_action&#34;,&#10;&#34;appFile&#34;: {&#10;&#34;type&#34;: &#34;string&#34;,&#10;&#34;description&#34;: &#34;GH #705: path to the .app Maestro reinstalls from after a clearState uninstall. Normally omit it — an iOS clearState flow resolves the bundle from the session&#39;s attested install receipt, and the receipt is re-issued after the reinstall so later device_*/maestro_run calls keep working.&#34;&#10;}&#10;}</code>

```text
{
  "tool": "cdp_run_action",
  "appFile": {
    "type": "string",
    "description": "GH #705: path to the .app Maestro reinstalls from after a clearState uninstall. Normally omit it \u2014 an iOS clearState flow resolves the bundle from the session's attested install receipt, and the receipt is re-issued after the reinstall so later device_*/maestro_run calls keep working."
  }
}
```
</details>
- Evidence: Rendered docs: session-authority page with the new clearState re-issue paragraph (local file: <code>/var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/no-mistakes-evidence/01KZC9TF68WHQSDTZGJQYHQ33A/gh705-docs-session-authority.png</code>)
- Evidence: Rendered docs: cdp_run_action parameter table with the new appFile row (description cell empty — pre-existing generator limitation, same as platform/autoRepair) (local file: <code>/var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/no-mistakes-evidence/01KZC9TF68WHQSDTZGJQYHQ33A/gh705-docs-cdp_run_action-params.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `packages/rn-dev-agent-core/src/session/tool-profiles.ts:327` - `maestro_test_all` is granted `managedInstallReissue: true` in the same profile branch as `maestro_run`, but its handler never reaches the capability: `maestro-test-all.ts` builds and executes flows itself (resolveAppFileForClearState at maestro-test-all.ts:186, then executeMaestroAuthorityStages directly) and never calls `reissueManagedInstallAuthority` / `nestedMaestroAuthorityCallbacks`. The gate closure is therefore installed on args and never invoked. Concrete reachable path: `maestro_test_all` over a `.maestro/` dir containing the auth corpus (login-de.yaml etc., which open with `launchApp: clearState: true`) -&gt; Maestro uninstalls+reinstalls the .app -&gt; installGeneration rotates -&gt; the profile&#39;s postflightAxes include `I`, so the postflight probe in local-authority-probe.ts:195 throws APP_INSTALL_IDENTITY_CHANGED, the suite fails, and the session&#39;s install receipt stays broken for every subsequent device_*/maestro_run call. That is the exact authorized failure the intent says is fixed, still reachable through a tool the intent lists as carrying the capability. Either wire `reissueInstallReceipt` into the per-flow loop in maestro-test-all.ts (the earliest shared boundary is the same commit-after-run point maestro-run.ts:485 uses), or drop the flag from this profile branch and record maestro_test_all alongside cdp_run_e2e_suite/cdp_lock_e2e_test in the follow-up issue so no inert authority grant ships.
- ℹ️ `packages/rn-dev-agent-core/src/tools/maestro-test-all.ts:186` - `resolveAppFileForClearState` is called here with no `deps`, so `defaultGetAppContainer` still targets `booted` instead of the session&#39;s exact UDID. The intent identifies that as the likely cause of the reporter&#39;s &#34;no built .app could be located&#34; with two devices attached; `requestedDeviceId` is already in scope in this handler, so passing `{ deviceId: requestedDeviceId }` would close it the same way maestro-run.ts:471 does. Same applies to maestro-invoke.ts:189 (inline device_* flows, where clearState is not currently used). Noting only — deliberately narrow scope is the accepted design.
- ℹ️ `apps/docs-site/src/content/docs/tools/cdp/cdp_run_action.mdx:15` - The regenerated docs row for the new `appFile` param has an empty description because the generator only picks up single-line `.describe(&#39;...&#39;)` calls (same as the pre-existing `platform`/`autoRepair` rows). Since the whole point of the change is making the documented &#34;Pass appFile=&lt;path&gt;&#34; advice followable, the published docs currently say nothing about it. The author flagged this as a known pre-existing generator limitation, so recording it rather than asking for a change.

🔧 Fix: narrow managedInstallReissue grant to maestro_run only
1 info still open:
- ℹ️ `packages/rn-dev-agent-core/src/session/tool-profiles.ts:327` - With `managedInstallReissue: tool === &#39;maestro_run&#39;`, `maestro_test_all` no longer receives the inert grant — correct per the round-1 instruction, and its runtime behavior is unchanged since its handler never invoked the capability. Consequence to record: `maestro_test_all` now belongs alongside `cdp_run_e2e_suite` and `cdp_lock_e2e_test` in the intent&#39;s &#34;KNOWN AND DELIBERATELY OUT OF SCOPE&#34; list — a clearState flow in a suite still trips axis I at the postflight `I` probe. Worth naming in the follow-up issue so all three unprofiled paths are tracked together. No code change requested.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`yarn install --immutable` + `yarn build:core` — dependencies were absent in the worktree; rebuilding dist produced zero drift, confirming the committed build matches src</code>
- <code>`node --test test/unit/session/gh-705-clearstate-reinstall.test.ts test/unit/gh-705-clearstate-appfile-forwarding.test.ts test/unit/session/tool-profiles.test.ts` — 31 tests, all pass</code>
- <code>`node --test test/unit/*maestro*.test.* test/unit/*run-action*.test.* test/unit/*app-file*.test.* test/unit/*resolver*.test.* test/unit/session/authority-gate.test.ts test/unit/session/tool-profiles.test.ts test/unit/session/gh-705-*.test.ts test/unit/gh-705-*.test.ts` — targeted regression over every touched module: 320 tests, all pass</code>
- <code>End-to-end harness `gh705-e2e-harness.ts`: real cdp_run_action -&gt; real maestro_run -&gt; real authority gate -&gt; real SQLite session registry -&gt; real install attestation (byte-level artifactDigest + inode/size/mtime installGeneration) over a real .app directory genuinely uninstalled and reinstalled; only simctl get_app_container, plutil, and the maestro-runner binary are shimmed</code>
- `Scenario A (bug reproduction): an unattested byte-identical clearState reinstall -> next device_press refuses APP_INSTALL_IDENTITY_CHANGED`
- <code>Scenario B (definition of success): `cdp_run_action { actionId: &#39;login-de&#39; }` with no appFile auto-resolves the .app from the receipt&#39;s exact UDID (a different UDID resolves null), passes, re-issues the receipt (artifactDigest unchanged, installGeneration re-stamped), and device_press / device_snapshot / maestro_run / a second cdp_run_action all succeed in the same session</code>
- `Scenario C (safety boundary): the same flow reinstalling a foreign .app is refused with APP_INSTALL_IDENTITY_CHANGED, the bound receipt is left untouched, and the session stays fail-closed`
- `Scenario D (narrowness): the identical byte-identical reinstall performed inside device_press still fails APP_INSTALL_IDENTITY_CHANGED — only maestro_run / cdp_run_action carry the capability`
- <code>Live MCP surface: piped `initialize` + `tools/list` over stdio into `node dist/index.js` and extracted cdp_run_action&#39;s appFile parameter schema</code>
- `Rendered docs pages screenshotted from a local astro dev server: /session-authority (new clearState/re-issue paragraph) and /tools/cdp/cdp_run_action (new appFile parameter row)`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `apps/docs-site/src/content/docs/tools/cdp/cdp_run_action.mdx:15` - The new user-facing `appFile` parameter renders with an empty description in the generated tool docs (both cdp_run_action.mdx and maestro_run.mdx), so its guidance — omit it and the session&#39;s attested install receipt resolves the bundle — is not visible to readers. Root cause is in apps/docs-site/scripts/generate-tool-docs.mjs: the description regex `/\.describe\(([&#39;&#34;`])([\s\S]*?)\1\s*\)/` requires the closing quote to be followed only by whitespace and `)`, but oxfmt formats wrapped calls as `.describe(\n  &#34;...&#34;,\n)` with a trailing comma, so every multi-line `.describe()` in index.ts silently yields no description (the same reason `type` shows `unknown` instead of `string` for chained multi-line zod defs). Left unfixed deliberately: relaxing the regex would re-render descriptions across many unrelated tool pages, which exceeds this change&#39;s scope. Suggested follow-up issue: allow an optional trailing comma in the describe/type extraction and regenerate the tool docs in one dedicated commit.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
