### PR TITLE
fix(core): give hardReset a reachable cold start

### DIFF
--- a/.changeset/reachable-hard-reset-cold-start.md
+++ b/.changeset/reachable-hard-reset-cold-start.md
@@ -1,0 +1,6 @@
+---
+'rn-dev-agent-core': patch
+'rn-dev-agent-plugin': patch
+---
+
+Let `cdp_restart hardReset=true` complete the cold start it promises from a runner-bound session by classifying a terminated-but-unreaped process as absent rather than as an unreadable identity, and by escalating the bound runner's stop to SIGKILL after its SIGTERM grace once the pid is re-proven to carry that binding's exact birth token.

--- a/apps/docs-site/src/content/docs/session-authority.mdx
+++ b/apps/docs-site/src/content/docs/session-authority.mdx
@@ -48,6 +48,8 @@ Recovery from a dead owner is bounded and explicit, never lease garbage collecti
 
 Closing a bound runner releases its exclusive claim and clears the runner binding in one atomic registry transaction, so an interrupted close or reacquire cannot leave a store whose runner binding survives without its claim row. A store already carrying that divergence — written by an interrupted unbind under an older plugin — is unsupported legacy state: `adopt_stale` refuses it with `RUNNER_OWNERSHIP_MISMATCH`, ownership is never relaxed to accommodate it, and no migration exists. The supported recovery is the latest plugin plus fresh authority state: with no supervisor running for any session in the store, remove the user-local `v2` state root and let the next start recreate it.
 
+Proving a bound runner stopped sends SIGTERM, then escalates to SIGKILL after its grace period only once the pid is re-proven to carry that binding's exact process-birth token, so a reused pid or another session's runner is never signaled. A process that has terminated but whose parent has not yet reaped it counts as stopped, not as an unreadable identity — that is what lets `cdp_restart hardReset=true` and the `device_snapshot action=close` → `release` sequence complete instead of refusing with `RUNNER_ADOPTION_REQUIRED`.
+
 Supervisor shutdown follows the same fail-closed resource cleanup. It first reserves the session for closing and cancels active operations, then releases claims only after runner, Observe, and managed Metro teardown succeeds.
 
 Session initialization is transactional: if port allocation, resource claiming, shared-knowledge preparation, or receipt creation fails, partial claims are released before startup reports the failure.

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -20803,11 +20803,14 @@ function probeProcessBirth(pid, dependencies = {}) {
   const runVerifiedHelper = dependencies.runVerifiedHelper ?? defaultRunVerifiedHelper;
   try {
     if (platform === "darwin") {
-      const observedPid = run("/bin/ps", ["-p", String(pid), "-o", "pid="]).trim();
-      if (observedPid.length === 0)
+      const observed = run("/bin/ps", ["-p", String(pid), "-o", "pid=,state="]).trim();
+      if (observed.length === 0)
         return { status: "absent" };
-      if (Number(observedPid) !== pid)
+      const observedFields = /^(\d+)(?:\s+(\S+))?$/.exec(observed);
+      if (!observedFields || Number(observedFields[1]) !== pid)
         return { status: "unknown" };
+      if (observedFields[2]?.startsWith("Z"))
+        return { status: "absent" };
       const helper = verifyDarwinProcessBirthHelper(dependencies);
       const processInfo = runVerifiedHelper(helper.path, pid, helper.requirement).trim();
       const processMatch = /^(\d+):(\d+):(\d+)$/.exec(processInfo);
@@ -20836,6 +20839,8 @@ function probeProcessBirth(pid, dependencies = {}) {
       }
       const commandEnd = stat2.lastIndexOf(")");
       const fields = commandEnd >= 0 ? stat2.slice(commandEnd + 1).trim().split(/\s+/) : [];
+      if (fields[0] === "Z")
+        return { status: "absent" };
       const started = fields[19];
       if (!boot || !started || !/^\d+$/.test(started))
         return { status: "unknown" };
@@ -64942,18 +64947,22 @@ async function runRecordProofScript(script, args, timeout = 6e4, dependencies = 
     }
   }));
 }
-async function waitForExactStopped(probe, deadlineMs, code, message) {
+async function awaitExactStopped(probe, deadlineMs, code, message) {
   while (true) {
     const status = probe();
     if (status === "stopped")
-      return;
+      return true;
     if (status === "unknown") {
       throw new SessionAuthorityError(code, `${message}; shutdown identity is unknown`);
     }
-    if (Date.now() >= deadlineMs) {
-      throw new SessionAuthorityError(code, message);
-    }
+    if (Date.now() >= deadlineMs)
+      return false;
     await new Promise((resolve11) => setTimeout(resolve11, 25));
+  }
+}
+async function waitForExactStopped(probe, deadlineMs, code, message) {
+  if (!await awaitExactStopped(probe, deadlineMs, code, message)) {
+    throw new SessionAuthorityError(code, message);
   }
 }
 async function stopBoundObserve(binding, listenerProbe = probeManagedMetroListener, processProbe = probeProcessBirth, timeoutMs = 2e3, request2 = fetch) {
@@ -65013,7 +65022,7 @@ async function stopBoundObserve(binding, listenerProbe = probeManagedMetroListen
     return observed.status === "listening" && observed.pid === pid ? "running" : "stopped";
   }, deadlineMs, "OBSERVE_AUTHORITY_MISMATCH", "Observe listener did not stop before the cleanup deadline");
 }
-async function stopBoundRunner(binding, processProbe = probeProcessBirth, signalProcess = process.kill, timeoutMs = 2e3, runAdb = async (args) => execFile14("adb", args, { timeout: 5e3, encoding: "utf8" })) {
+async function stopBoundRunner(binding, processProbe = probeProcessBirth, signalProcess = process.kill, timeoutMs = 2e3, runAdb = async (args) => execFile14("adb", args, { timeout: 5e3, encoding: "utf8" }), termGraceMs = 500) {
   const deadlineMs = Date.now() + timeoutMs;
   const pid = Number(binding.pid);
   const expectedBirth = String(binding.processBirth ?? "");
@@ -65030,13 +65039,25 @@ async function stopBoundRunner(binding, processProbe = probeProcessBirth, signal
     throw new SessionAuthorityError("RUNNER_ADOPTION_REQUIRED", "runner process identity is unavailable");
   }
   if (current.status === "present" && current.birth.token === expectedBirth) {
-    signalProcess(pid, "SIGTERM");
-    await waitForExactStopped(() => {
+    const observeStop = () => {
       const observed = processProbe(pid);
       if (observed.status === "unknown")
         return "unknown";
       return observed.status === "present" && observed.birth.token === expectedBirth ? "running" : "stopped";
-    }, deadlineMs, "RUNNER_ADOPTION_REQUIRED", "runner process did not stop before the cleanup deadline");
+    };
+    const message = "runner process did not stop before the cleanup deadline";
+    signalProcess(pid, "SIGTERM");
+    const graceDeadlineMs = Math.min(deadlineMs, Date.now() + termGraceMs);
+    if (!await awaitExactStopped(observeStop, graceDeadlineMs, "RUNNER_ADOPTION_REQUIRED", message)) {
+      const escalation = processProbe(pid);
+      if (escalation.status === "unknown") {
+        throw new SessionAuthorityError("RUNNER_ADOPTION_REQUIRED", `${message}; shutdown identity is unknown`);
+      }
+      if (escalation.status === "present" && escalation.birth.token === expectedBirth) {
+        signalProcess(pid, "SIGKILL");
+      }
+      await waitForExactStopped(observeStop, deadlineMs, "RUNNER_ADOPTION_REQUIRED", message);
+    }
   }
   if (platform !== "android")
     return;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -65046,7 +65046,13 @@ async function stopBoundRunner(binding, processProbe = probeProcessBirth, signal
       return observed.status === "present" && observed.birth.token === expectedBirth ? "running" : "stopped";
     };
     const message = "runner process did not stop before the cleanup deadline";
-    signalProcess(pid, "SIGTERM");
+    const signalTolerated = (value) => {
+      try {
+        signalProcess(pid, value);
+      } catch {
+      }
+    };
+    signalTolerated("SIGTERM");
     const graceDeadlineMs = Math.min(deadlineMs, Date.now() + termGraceMs);
     if (!await awaitExactStopped(observeStop, graceDeadlineMs, "RUNNER_ADOPTION_REQUIRED", message)) {
       const escalation = processProbe(pid);
@@ -65054,7 +65060,7 @@ async function stopBoundRunner(binding, processProbe = probeProcessBirth, signal
         throw new SessionAuthorityError("RUNNER_ADOPTION_REQUIRED", `${message}; shutdown identity is unknown`);
       }
       if (escalation.status === "present" && escalation.birth.token === expectedBirth) {
-        signalProcess(pid, "SIGKILL");
+        signalTolerated("SIGKILL");
       }
       await waitForExactStopped(observeStop, deadlineMs, "RUNNER_ADOPTION_REQUIRED", message);
     }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -17267,7 +17267,13 @@ async function stopBoundRunner(binding, processProbe = probeProcessBirth, signal
       return observed.status === "present" && observed.birth.token === expectedBirth ? "running" : "stopped";
     };
     const message = "runner process did not stop before the cleanup deadline";
-    signalProcess(pid, "SIGTERM");
+    const signalTolerated = (value) => {
+      try {
+        signalProcess(pid, value);
+      } catch {
+      }
+    };
+    signalTolerated("SIGTERM");
     const graceDeadlineMs = Math.min(deadlineMs, Date.now() + termGraceMs);
     if (!await awaitExactStopped(observeStop, graceDeadlineMs, "RUNNER_ADOPTION_REQUIRED", message)) {
       const escalation = processProbe(pid);
@@ -17275,7 +17281,7 @@ async function stopBoundRunner(binding, processProbe = probeProcessBirth, signal
         throw new SessionAuthorityError("RUNNER_ADOPTION_REQUIRED", `${message}; shutdown identity is unknown`);
       }
       if (escalation.status === "present" && escalation.birth.token === expectedBirth) {
-        signalProcess(pid, "SIGKILL");
+        signalTolerated("SIGKILL");
       }
       await waitForExactStopped(observeStop, deadlineMs, "RUNNER_ADOPTION_REQUIRED", message);
     }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -7817,11 +7817,14 @@ function probeProcessBirth(pid, dependencies = {}) {
   const runVerifiedHelper = dependencies.runVerifiedHelper ?? defaultRunVerifiedHelper;
   try {
     if (platform === "darwin") {
-      const observedPid = run("/bin/ps", ["-p", String(pid), "-o", "pid="]).trim();
-      if (observedPid.length === 0)
+      const observed = run("/bin/ps", ["-p", String(pid), "-o", "pid=,state="]).trim();
+      if (observed.length === 0)
         return { status: "absent" };
-      if (Number(observedPid) !== pid)
+      const observedFields = /^(\d+)(?:\s+(\S+))?$/.exec(observed);
+      if (!observedFields || Number(observedFields[1]) !== pid)
         return { status: "unknown" };
+      if (observedFields[2]?.startsWith("Z"))
+        return { status: "absent" };
       const helper = verifyDarwinProcessBirthHelper(dependencies);
       const processInfo = runVerifiedHelper(helper.path, pid, helper.requirement).trim();
       const processMatch = /^(\d+):(\d+):(\d+)$/.exec(processInfo);
@@ -7850,6 +7853,8 @@ function probeProcessBirth(pid, dependencies = {}) {
       }
       const commandEnd = stat.lastIndexOf(")");
       const fields = commandEnd >= 0 ? stat.slice(commandEnd + 1).trim().split(/\s+/) : [];
+      if (fields[0] === "Z")
+        return { status: "absent" };
       const started = fields[19];
       if (!boot || !started || !/^\d+$/.test(started))
         return { status: "unknown" };
@@ -17163,18 +17168,22 @@ async function runRecordProofScript(script, args, timeout = 6e4, dependencies = 
     }
   }));
 }
-async function waitForExactStopped(probe, deadlineMs, code, message) {
+async function awaitExactStopped(probe, deadlineMs, code, message) {
   while (true) {
     const status = probe();
     if (status === "stopped")
-      return;
+      return true;
     if (status === "unknown") {
       throw new SessionAuthorityError(code, `${message}; shutdown identity is unknown`);
     }
-    if (Date.now() >= deadlineMs) {
-      throw new SessionAuthorityError(code, message);
-    }
+    if (Date.now() >= deadlineMs)
+      return false;
     await new Promise((resolve5) => setTimeout(resolve5, 25));
+  }
+}
+async function waitForExactStopped(probe, deadlineMs, code, message) {
+  if (!await awaitExactStopped(probe, deadlineMs, code, message)) {
+    throw new SessionAuthorityError(code, message);
   }
 }
 async function stopBoundObserve(binding, listenerProbe = probeManagedMetroListener, processProbe = probeProcessBirth, timeoutMs = 2e3, request = fetch) {
@@ -17234,7 +17243,7 @@ async function stopBoundObserve(binding, listenerProbe = probeManagedMetroListen
     return observed.status === "listening" && observed.pid === pid ? "running" : "stopped";
   }, deadlineMs, "OBSERVE_AUTHORITY_MISMATCH", "Observe listener did not stop before the cleanup deadline");
 }
-async function stopBoundRunner(binding, processProbe = probeProcessBirth, signalProcess = process.kill, timeoutMs = 2e3, runAdb = async (args) => execFile14("adb", args, { timeout: 5e3, encoding: "utf8" })) {
+async function stopBoundRunner(binding, processProbe = probeProcessBirth, signalProcess = process.kill, timeoutMs = 2e3, runAdb = async (args) => execFile14("adb", args, { timeout: 5e3, encoding: "utf8" }), termGraceMs = 500) {
   const deadlineMs = Date.now() + timeoutMs;
   const pid = Number(binding.pid);
   const expectedBirth = String(binding.processBirth ?? "");
@@ -17251,13 +17260,25 @@ async function stopBoundRunner(binding, processProbe = probeProcessBirth, signal
     throw new SessionAuthorityError("RUNNER_ADOPTION_REQUIRED", "runner process identity is unavailable");
   }
   if (current.status === "present" && current.birth.token === expectedBirth) {
-    signalProcess(pid, "SIGTERM");
-    await waitForExactStopped(() => {
+    const observeStop = () => {
       const observed = processProbe(pid);
       if (observed.status === "unknown")
         return "unknown";
       return observed.status === "present" && observed.birth.token === expectedBirth ? "running" : "stopped";
-    }, deadlineMs, "RUNNER_ADOPTION_REQUIRED", "runner process did not stop before the cleanup deadline");
+    };
+    const message = "runner process did not stop before the cleanup deadline";
+    signalProcess(pid, "SIGTERM");
+    const graceDeadlineMs = Math.min(deadlineMs, Date.now() + termGraceMs);
+    if (!await awaitExactStopped(observeStop, graceDeadlineMs, "RUNNER_ADOPTION_REQUIRED", message)) {
+      const escalation = processProbe(pid);
+      if (escalation.status === "unknown") {
+        throw new SessionAuthorityError("RUNNER_ADOPTION_REQUIRED", `${message}; shutdown identity is unknown`);
+      }
+      if (escalation.status === "present" && escalation.birth.token === expectedBirth) {
+        signalProcess(pid, "SIGKILL");
+      }
+      await waitForExactStopped(observeStop, deadlineMs, "RUNNER_ADOPTION_REQUIRED", message);
+    }
   }
   if (platform !== "android")
     return;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -836,11 +836,14 @@ function probeProcessBirth(pid, dependencies = {}) {
   const runVerifiedHelper = dependencies.runVerifiedHelper ?? defaultRunVerifiedHelper;
   try {
     if (platform === "darwin") {
-      const observedPid = run("/bin/ps", ["-p", String(pid), "-o", "pid="]).trim();
-      if (observedPid.length === 0)
+      const observed = run("/bin/ps", ["-p", String(pid), "-o", "pid=,state="]).trim();
+      if (observed.length === 0)
         return { status: "absent" };
-      if (Number(observedPid) !== pid)
+      const observedFields = /^(\d+)(?:\s+(\S+))?$/.exec(observed);
+      if (!observedFields || Number(observedFields[1]) !== pid)
         return { status: "unknown" };
+      if (observedFields[2]?.startsWith("Z"))
+        return { status: "absent" };
       const helper = verifyDarwinProcessBirthHelper(dependencies);
       const processInfo = runVerifiedHelper(helper.path, pid, helper.requirement).trim();
       const processMatch = /^(\d+):(\d+):(\d+)$/.exec(processInfo);
@@ -869,6 +872,8 @@ function probeProcessBirth(pid, dependencies = {}) {
       }
       const commandEnd = stat2.lastIndexOf(")");
       const fields = commandEnd >= 0 ? stat2.slice(commandEnd + 1).trim().split(/\s+/) : [];
+      if (fields[0] === "Z")
+        return { status: "absent" };
       const started = fields[19];
       if (!boot || !started || !/^\d+$/.test(started))
         return { status: "unknown" };
@@ -34166,18 +34171,22 @@ async function runRecordProofScript(script, args, timeout = 6e4, dependencies = 
     }
   }));
 }
-async function waitForExactStopped(probe, deadlineMs, code, message) {
+async function awaitExactStopped(probe, deadlineMs, code, message) {
   while (true) {
     const status = probe();
     if (status === "stopped")
-      return;
+      return true;
     if (status === "unknown") {
       throw new SessionAuthorityError(code, `${message}; shutdown identity is unknown`);
     }
-    if (Date.now() >= deadlineMs) {
-      throw new SessionAuthorityError(code, message);
-    }
+    if (Date.now() >= deadlineMs)
+      return false;
     await new Promise((resolve11) => setTimeout(resolve11, 25));
+  }
+}
+async function waitForExactStopped(probe, deadlineMs, code, message) {
+  if (!await awaitExactStopped(probe, deadlineMs, code, message)) {
+    throw new SessionAuthorityError(code, message);
   }
 }
 async function stopBoundObserve(binding, listenerProbe = probeManagedMetroListener, processProbe = probeProcessBirth, timeoutMs = 2e3, request2 = fetch) {
@@ -34237,7 +34246,7 @@ async function stopBoundObserve(binding, listenerProbe = probeManagedMetroListen
     return observed.status === "listening" && observed.pid === pid ? "running" : "stopped";
   }, deadlineMs, "OBSERVE_AUTHORITY_MISMATCH", "Observe listener did not stop before the cleanup deadline");
 }
-async function stopBoundRunner(binding, processProbe = probeProcessBirth, signalProcess = process.kill, timeoutMs = 2e3, runAdb = async (args) => execFile14("adb", args, { timeout: 5e3, encoding: "utf8" })) {
+async function stopBoundRunner(binding, processProbe = probeProcessBirth, signalProcess = process.kill, timeoutMs = 2e3, runAdb = async (args) => execFile14("adb", args, { timeout: 5e3, encoding: "utf8" }), termGraceMs = 500) {
   const deadlineMs = Date.now() + timeoutMs;
   const pid = Number(binding.pid);
   const expectedBirth = String(binding.processBirth ?? "");
@@ -34254,13 +34263,25 @@ async function stopBoundRunner(binding, processProbe = probeProcessBirth, signal
     throw new SessionAuthorityError("RUNNER_ADOPTION_REQUIRED", "runner process identity is unavailable");
   }
   if (current.status === "present" && current.birth.token === expectedBirth) {
-    signalProcess(pid, "SIGTERM");
-    await waitForExactStopped(() => {
+    const observeStop = () => {
       const observed = processProbe(pid);
       if (observed.status === "unknown")
         return "unknown";
       return observed.status === "present" && observed.birth.token === expectedBirth ? "running" : "stopped";
-    }, deadlineMs, "RUNNER_ADOPTION_REQUIRED", "runner process did not stop before the cleanup deadline");
+    };
+    const message = "runner process did not stop before the cleanup deadline";
+    signalProcess(pid, "SIGTERM");
+    const graceDeadlineMs = Math.min(deadlineMs, Date.now() + termGraceMs);
+    if (!await awaitExactStopped(observeStop, graceDeadlineMs, "RUNNER_ADOPTION_REQUIRED", message)) {
+      const escalation = processProbe(pid);
+      if (escalation.status === "unknown") {
+        throw new SessionAuthorityError("RUNNER_ADOPTION_REQUIRED", `${message}; shutdown identity is unknown`);
+      }
+      if (escalation.status === "present" && escalation.birth.token === expectedBirth) {
+        signalProcess(pid, "SIGKILL");
+      }
+      await waitForExactStopped(observeStop, deadlineMs, "RUNNER_ADOPTION_REQUIRED", message);
+    }
   }
   if (platform !== "android")
     return;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -34270,7 +34270,13 @@ async function stopBoundRunner(binding, processProbe = probeProcessBirth, signal
       return observed.status === "present" && observed.birth.token === expectedBirth ? "running" : "stopped";
     };
     const message = "runner process did not stop before the cleanup deadline";
-    signalProcess(pid, "SIGTERM");
+    const signalTolerated = (value) => {
+      try {
+        signalProcess(pid, value);
+      } catch {
+      }
+    };
+    signalTolerated("SIGTERM");
     const graceDeadlineMs = Math.min(deadlineMs, Date.now() + termGraceMs);
     if (!await awaitExactStopped(observeStop, graceDeadlineMs, "RUNNER_ADOPTION_REQUIRED", message)) {
       const escalation = processProbe(pid);
@@ -34278,7 +34284,7 @@ async function stopBoundRunner(binding, processProbe = probeProcessBirth, signal
         throw new SessionAuthorityError("RUNNER_ADOPTION_REQUIRED", `${message}; shutdown identity is unknown`);
       }
       if (escalation.status === "present" && escalation.birth.token === expectedBirth) {
-        signalProcess(pid, "SIGKILL");
+        signalTolerated("SIGKILL");
       }
       await waitForExactStopped(observeStop, deadlineMs, "RUNNER_ADOPTION_REQUIRED", message);
     }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -20803,11 +20803,14 @@ function probeProcessBirth(pid, dependencies = {}) {
   const runVerifiedHelper = dependencies.runVerifiedHelper ?? defaultRunVerifiedHelper;
   try {
     if (platform === "darwin") {
-      const observedPid = run("/bin/ps", ["-p", String(pid), "-o", "pid="]).trim();
-      if (observedPid.length === 0)
+      const observed = run("/bin/ps", ["-p", String(pid), "-o", "pid=,state="]).trim();
+      if (observed.length === 0)
         return { status: "absent" };
-      if (Number(observedPid) !== pid)
+      const observedFields = /^(\d+)(?:\s+(\S+))?$/.exec(observed);
+      if (!observedFields || Number(observedFields[1]) !== pid)
         return { status: "unknown" };
+      if (observedFields[2]?.startsWith("Z"))
+        return { status: "absent" };
       const helper = verifyDarwinProcessBirthHelper(dependencies);
       const processInfo = runVerifiedHelper(helper.path, pid, helper.requirement).trim();
       const processMatch = /^(\d+):(\d+):(\d+)$/.exec(processInfo);
@@ -20836,6 +20839,8 @@ function probeProcessBirth(pid, dependencies = {}) {
       }
       const commandEnd = stat2.lastIndexOf(")");
       const fields = commandEnd >= 0 ? stat2.slice(commandEnd + 1).trim().split(/\s+/) : [];
+      if (fields[0] === "Z")
+        return { status: "absent" };
       const started = fields[19];
       if (!boot || !started || !/^\d+$/.test(started))
         return { status: "unknown" };
@@ -64942,18 +64947,22 @@ async function runRecordProofScript(script, args, timeout = 6e4, dependencies = 
     }
   }));
 }
-async function waitForExactStopped(probe, deadlineMs, code, message) {
+async function awaitExactStopped(probe, deadlineMs, code, message) {
   while (true) {
     const status = probe();
     if (status === "stopped")
-      return;
+      return true;
     if (status === "unknown") {
       throw new SessionAuthorityError(code, `${message}; shutdown identity is unknown`);
     }
-    if (Date.now() >= deadlineMs) {
-      throw new SessionAuthorityError(code, message);
-    }
+    if (Date.now() >= deadlineMs)
+      return false;
     await new Promise((resolve11) => setTimeout(resolve11, 25));
+  }
+}
+async function waitForExactStopped(probe, deadlineMs, code, message) {
+  if (!await awaitExactStopped(probe, deadlineMs, code, message)) {
+    throw new SessionAuthorityError(code, message);
   }
 }
 async function stopBoundObserve(binding, listenerProbe = probeManagedMetroListener, processProbe = probeProcessBirth, timeoutMs = 2e3, request2 = fetch) {
@@ -65013,7 +65022,7 @@ async function stopBoundObserve(binding, listenerProbe = probeManagedMetroListen
     return observed.status === "listening" && observed.pid === pid ? "running" : "stopped";
   }, deadlineMs, "OBSERVE_AUTHORITY_MISMATCH", "Observe listener did not stop before the cleanup deadline");
 }
-async function stopBoundRunner(binding, processProbe = probeProcessBirth, signalProcess = process.kill, timeoutMs = 2e3, runAdb = async (args) => execFile14("adb", args, { timeout: 5e3, encoding: "utf8" })) {
+async function stopBoundRunner(binding, processProbe = probeProcessBirth, signalProcess = process.kill, timeoutMs = 2e3, runAdb = async (args) => execFile14("adb", args, { timeout: 5e3, encoding: "utf8" }), termGraceMs = 500) {
   const deadlineMs = Date.now() + timeoutMs;
   const pid = Number(binding.pid);
   const expectedBirth = String(binding.processBirth ?? "");
@@ -65030,13 +65039,25 @@ async function stopBoundRunner(binding, processProbe = probeProcessBirth, signal
     throw new SessionAuthorityError("RUNNER_ADOPTION_REQUIRED", "runner process identity is unavailable");
   }
   if (current.status === "present" && current.birth.token === expectedBirth) {
-    signalProcess(pid, "SIGTERM");
-    await waitForExactStopped(() => {
+    const observeStop = () => {
       const observed = processProbe(pid);
       if (observed.status === "unknown")
         return "unknown";
       return observed.status === "present" && observed.birth.token === expectedBirth ? "running" : "stopped";
-    }, deadlineMs, "RUNNER_ADOPTION_REQUIRED", "runner process did not stop before the cleanup deadline");
+    };
+    const message = "runner process did not stop before the cleanup deadline";
+    signalProcess(pid, "SIGTERM");
+    const graceDeadlineMs = Math.min(deadlineMs, Date.now() + termGraceMs);
+    if (!await awaitExactStopped(observeStop, graceDeadlineMs, "RUNNER_ADOPTION_REQUIRED", message)) {
+      const escalation = processProbe(pid);
+      if (escalation.status === "unknown") {
+        throw new SessionAuthorityError("RUNNER_ADOPTION_REQUIRED", `${message}; shutdown identity is unknown`);
+      }
+      if (escalation.status === "present" && escalation.birth.token === expectedBirth) {
+        signalProcess(pid, "SIGKILL");
+      }
+      await waitForExactStopped(observeStop, deadlineMs, "RUNNER_ADOPTION_REQUIRED", message);
+    }
   }
   if (platform !== "android")
     return;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -65046,7 +65046,13 @@ async function stopBoundRunner(binding, processProbe = probeProcessBirth, signal
       return observed.status === "present" && observed.birth.token === expectedBirth ? "running" : "stopped";
     };
     const message = "runner process did not stop before the cleanup deadline";
-    signalProcess(pid, "SIGTERM");
+    const signalTolerated = (value) => {
+      try {
+        signalProcess(pid, value);
+      } catch {
+      }
+    };
+    signalTolerated("SIGTERM");
     const graceDeadlineMs = Math.min(deadlineMs, Date.now() + termGraceMs);
     if (!await awaitExactStopped(observeStop, graceDeadlineMs, "RUNNER_ADOPTION_REQUIRED", message)) {
       const escalation = processProbe(pid);
@@ -65054,7 +65060,7 @@ async function stopBoundRunner(binding, processProbe = probeProcessBirth, signal
         throw new SessionAuthorityError("RUNNER_ADOPTION_REQUIRED", `${message}; shutdown identity is unknown`);
       }
       if (escalation.status === "present" && escalation.birth.token === expectedBirth) {
-        signalProcess(pid, "SIGKILL");
+        signalTolerated("SIGKILL");
       }
       await waitForExactStopped(observeStop, deadlineMs, "RUNNER_ADOPTION_REQUIRED", message);
     }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -17267,7 +17267,13 @@ async function stopBoundRunner(binding, processProbe = probeProcessBirth, signal
       return observed.status === "present" && observed.birth.token === expectedBirth ? "running" : "stopped";
     };
     const message = "runner process did not stop before the cleanup deadline";
-    signalProcess(pid, "SIGTERM");
+    const signalTolerated = (value) => {
+      try {
+        signalProcess(pid, value);
+      } catch {
+      }
+    };
+    signalTolerated("SIGTERM");
     const graceDeadlineMs = Math.min(deadlineMs, Date.now() + termGraceMs);
     if (!await awaitExactStopped(observeStop, graceDeadlineMs, "RUNNER_ADOPTION_REQUIRED", message)) {
       const escalation = processProbe(pid);
@@ -17275,7 +17281,7 @@ async function stopBoundRunner(binding, processProbe = probeProcessBirth, signal
         throw new SessionAuthorityError("RUNNER_ADOPTION_REQUIRED", `${message}; shutdown identity is unknown`);
       }
       if (escalation.status === "present" && escalation.birth.token === expectedBirth) {
-        signalProcess(pid, "SIGKILL");
+        signalTolerated("SIGKILL");
       }
       await waitForExactStopped(observeStop, deadlineMs, "RUNNER_ADOPTION_REQUIRED", message);
     }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -7817,11 +7817,14 @@ function probeProcessBirth(pid, dependencies = {}) {
   const runVerifiedHelper = dependencies.runVerifiedHelper ?? defaultRunVerifiedHelper;
   try {
     if (platform === "darwin") {
-      const observedPid = run("/bin/ps", ["-p", String(pid), "-o", "pid="]).trim();
-      if (observedPid.length === 0)
+      const observed = run("/bin/ps", ["-p", String(pid), "-o", "pid=,state="]).trim();
+      if (observed.length === 0)
         return { status: "absent" };
-      if (Number(observedPid) !== pid)
+      const observedFields = /^(\d+)(?:\s+(\S+))?$/.exec(observed);
+      if (!observedFields || Number(observedFields[1]) !== pid)
         return { status: "unknown" };
+      if (observedFields[2]?.startsWith("Z"))
+        return { status: "absent" };
       const helper = verifyDarwinProcessBirthHelper(dependencies);
       const processInfo = runVerifiedHelper(helper.path, pid, helper.requirement).trim();
       const processMatch = /^(\d+):(\d+):(\d+)$/.exec(processInfo);
@@ -7850,6 +7853,8 @@ function probeProcessBirth(pid, dependencies = {}) {
       }
       const commandEnd = stat.lastIndexOf(")");
       const fields = commandEnd >= 0 ? stat.slice(commandEnd + 1).trim().split(/\s+/) : [];
+      if (fields[0] === "Z")
+        return { status: "absent" };
       const started = fields[19];
       if (!boot || !started || !/^\d+$/.test(started))
         return { status: "unknown" };
@@ -17163,18 +17168,22 @@ async function runRecordProofScript(script, args, timeout = 6e4, dependencies = 
     }
   }));
 }
-async function waitForExactStopped(probe, deadlineMs, code, message) {
+async function awaitExactStopped(probe, deadlineMs, code, message) {
   while (true) {
     const status = probe();
     if (status === "stopped")
-      return;
+      return true;
     if (status === "unknown") {
       throw new SessionAuthorityError(code, `${message}; shutdown identity is unknown`);
     }
-    if (Date.now() >= deadlineMs) {
-      throw new SessionAuthorityError(code, message);
-    }
+    if (Date.now() >= deadlineMs)
+      return false;
     await new Promise((resolve5) => setTimeout(resolve5, 25));
+  }
+}
+async function waitForExactStopped(probe, deadlineMs, code, message) {
+  if (!await awaitExactStopped(probe, deadlineMs, code, message)) {
+    throw new SessionAuthorityError(code, message);
   }
 }
 async function stopBoundObserve(binding, listenerProbe = probeManagedMetroListener, processProbe = probeProcessBirth, timeoutMs = 2e3, request = fetch) {
@@ -17234,7 +17243,7 @@ async function stopBoundObserve(binding, listenerProbe = probeManagedMetroListen
     return observed.status === "listening" && observed.pid === pid ? "running" : "stopped";
   }, deadlineMs, "OBSERVE_AUTHORITY_MISMATCH", "Observe listener did not stop before the cleanup deadline");
 }
-async function stopBoundRunner(binding, processProbe = probeProcessBirth, signalProcess = process.kill, timeoutMs = 2e3, runAdb = async (args) => execFile14("adb", args, { timeout: 5e3, encoding: "utf8" })) {
+async function stopBoundRunner(binding, processProbe = probeProcessBirth, signalProcess = process.kill, timeoutMs = 2e3, runAdb = async (args) => execFile14("adb", args, { timeout: 5e3, encoding: "utf8" }), termGraceMs = 500) {
   const deadlineMs = Date.now() + timeoutMs;
   const pid = Number(binding.pid);
   const expectedBirth = String(binding.processBirth ?? "");
@@ -17251,13 +17260,25 @@ async function stopBoundRunner(binding, processProbe = probeProcessBirth, signal
     throw new SessionAuthorityError("RUNNER_ADOPTION_REQUIRED", "runner process identity is unavailable");
   }
   if (current.status === "present" && current.birth.token === expectedBirth) {
-    signalProcess(pid, "SIGTERM");
-    await waitForExactStopped(() => {
+    const observeStop = () => {
       const observed = processProbe(pid);
       if (observed.status === "unknown")
         return "unknown";
       return observed.status === "present" && observed.birth.token === expectedBirth ? "running" : "stopped";
-    }, deadlineMs, "RUNNER_ADOPTION_REQUIRED", "runner process did not stop before the cleanup deadline");
+    };
+    const message = "runner process did not stop before the cleanup deadline";
+    signalProcess(pid, "SIGTERM");
+    const graceDeadlineMs = Math.min(deadlineMs, Date.now() + termGraceMs);
+    if (!await awaitExactStopped(observeStop, graceDeadlineMs, "RUNNER_ADOPTION_REQUIRED", message)) {
+      const escalation = processProbe(pid);
+      if (escalation.status === "unknown") {
+        throw new SessionAuthorityError("RUNNER_ADOPTION_REQUIRED", `${message}; shutdown identity is unknown`);
+      }
+      if (escalation.status === "present" && escalation.birth.token === expectedBirth) {
+        signalProcess(pid, "SIGKILL");
+      }
+      await waitForExactStopped(observeStop, deadlineMs, "RUNNER_ADOPTION_REQUIRED", message);
+    }
   }
   if (platform !== "android")
     return;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -836,11 +836,14 @@ function probeProcessBirth(pid, dependencies = {}) {
   const runVerifiedHelper = dependencies.runVerifiedHelper ?? defaultRunVerifiedHelper;
   try {
     if (platform === "darwin") {
-      const observedPid = run("/bin/ps", ["-p", String(pid), "-o", "pid="]).trim();
-      if (observedPid.length === 0)
+      const observed = run("/bin/ps", ["-p", String(pid), "-o", "pid=,state="]).trim();
+      if (observed.length === 0)
         return { status: "absent" };
-      if (Number(observedPid) !== pid)
+      const observedFields = /^(\d+)(?:\s+(\S+))?$/.exec(observed);
+      if (!observedFields || Number(observedFields[1]) !== pid)
         return { status: "unknown" };
+      if (observedFields[2]?.startsWith("Z"))
+        return { status: "absent" };
       const helper = verifyDarwinProcessBirthHelper(dependencies);
       const processInfo = runVerifiedHelper(helper.path, pid, helper.requirement).trim();
       const processMatch = /^(\d+):(\d+):(\d+)$/.exec(processInfo);
@@ -869,6 +872,8 @@ function probeProcessBirth(pid, dependencies = {}) {
       }
       const commandEnd = stat2.lastIndexOf(")");
       const fields = commandEnd >= 0 ? stat2.slice(commandEnd + 1).trim().split(/\s+/) : [];
+      if (fields[0] === "Z")
+        return { status: "absent" };
       const started = fields[19];
       if (!boot || !started || !/^\d+$/.test(started))
         return { status: "unknown" };
@@ -34166,18 +34171,22 @@ async function runRecordProofScript(script, args, timeout = 6e4, dependencies = 
     }
   }));
 }
-async function waitForExactStopped(probe, deadlineMs, code, message) {
+async function awaitExactStopped(probe, deadlineMs, code, message) {
   while (true) {
     const status = probe();
     if (status === "stopped")
-      return;
+      return true;
     if (status === "unknown") {
       throw new SessionAuthorityError(code, `${message}; shutdown identity is unknown`);
     }
-    if (Date.now() >= deadlineMs) {
-      throw new SessionAuthorityError(code, message);
-    }
+    if (Date.now() >= deadlineMs)
+      return false;
     await new Promise((resolve11) => setTimeout(resolve11, 25));
+  }
+}
+async function waitForExactStopped(probe, deadlineMs, code, message) {
+  if (!await awaitExactStopped(probe, deadlineMs, code, message)) {
+    throw new SessionAuthorityError(code, message);
   }
 }
 async function stopBoundObserve(binding, listenerProbe = probeManagedMetroListener, processProbe = probeProcessBirth, timeoutMs = 2e3, request2 = fetch) {
@@ -34237,7 +34246,7 @@ async function stopBoundObserve(binding, listenerProbe = probeManagedMetroListen
     return observed.status === "listening" && observed.pid === pid ? "running" : "stopped";
   }, deadlineMs, "OBSERVE_AUTHORITY_MISMATCH", "Observe listener did not stop before the cleanup deadline");
 }
-async function stopBoundRunner(binding, processProbe = probeProcessBirth, signalProcess = process.kill, timeoutMs = 2e3, runAdb = async (args) => execFile14("adb", args, { timeout: 5e3, encoding: "utf8" })) {
+async function stopBoundRunner(binding, processProbe = probeProcessBirth, signalProcess = process.kill, timeoutMs = 2e3, runAdb = async (args) => execFile14("adb", args, { timeout: 5e3, encoding: "utf8" }), termGraceMs = 500) {
   const deadlineMs = Date.now() + timeoutMs;
   const pid = Number(binding.pid);
   const expectedBirth = String(binding.processBirth ?? "");
@@ -34254,13 +34263,25 @@ async function stopBoundRunner(binding, processProbe = probeProcessBirth, signal
     throw new SessionAuthorityError("RUNNER_ADOPTION_REQUIRED", "runner process identity is unavailable");
   }
   if (current.status === "present" && current.birth.token === expectedBirth) {
-    signalProcess(pid, "SIGTERM");
-    await waitForExactStopped(() => {
+    const observeStop = () => {
       const observed = processProbe(pid);
       if (observed.status === "unknown")
         return "unknown";
       return observed.status === "present" && observed.birth.token === expectedBirth ? "running" : "stopped";
-    }, deadlineMs, "RUNNER_ADOPTION_REQUIRED", "runner process did not stop before the cleanup deadline");
+    };
+    const message = "runner process did not stop before the cleanup deadline";
+    signalProcess(pid, "SIGTERM");
+    const graceDeadlineMs = Math.min(deadlineMs, Date.now() + termGraceMs);
+    if (!await awaitExactStopped(observeStop, graceDeadlineMs, "RUNNER_ADOPTION_REQUIRED", message)) {
+      const escalation = processProbe(pid);
+      if (escalation.status === "unknown") {
+        throw new SessionAuthorityError("RUNNER_ADOPTION_REQUIRED", `${message}; shutdown identity is unknown`);
+      }
+      if (escalation.status === "present" && escalation.birth.token === expectedBirth) {
+        signalProcess(pid, "SIGKILL");
+      }
+      await waitForExactStopped(observeStop, deadlineMs, "RUNNER_ADOPTION_REQUIRED", message);
+    }
   }
   if (platform !== "android")
     return;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -34270,7 +34270,13 @@ async function stopBoundRunner(binding, processProbe = probeProcessBirth, signal
       return observed.status === "present" && observed.birth.token === expectedBirth ? "running" : "stopped";
     };
     const message = "runner process did not stop before the cleanup deadline";
-    signalProcess(pid, "SIGTERM");
+    const signalTolerated = (value) => {
+      try {
+        signalProcess(pid, value);
+      } catch {
+      }
+    };
+    signalTolerated("SIGTERM");
     const graceDeadlineMs = Math.min(deadlineMs, Date.now() + termGraceMs);
     if (!await awaitExactStopped(observeStop, graceDeadlineMs, "RUNNER_ADOPTION_REQUIRED", message)) {
       const escalation = processProbe(pid);
@@ -34278,7 +34284,7 @@ async function stopBoundRunner(binding, processProbe = probeProcessBirth, signal
         throw new SessionAuthorityError("RUNNER_ADOPTION_REQUIRED", `${message}; shutdown identity is unknown`);
       }
       if (escalation.status === "present" && escalation.birth.token === expectedBirth) {
-        signalProcess(pid, "SIGKILL");
+        signalTolerated("SIGKILL");
       }
       await waitForExactStopped(observeStop, deadlineMs, "RUNNER_ADOPTION_REQUIRED", message);
     }

--- a/packages/rn-dev-agent-core/dist/session/process-birth.js
+++ b/packages/rn-dev-agent-core/dist/session/process-birth.js
@@ -193,11 +193,18 @@ export function probeProcessBirth(pid, dependencies = {}) {
     const runVerifiedHelper = dependencies.runVerifiedHelper ?? defaultRunVerifiedHelper;
     try {
         if (platform === 'darwin') {
-            const observedPid = run('/bin/ps', ['-p', String(pid), '-o', 'pid=']).trim();
-            if (observedPid.length === 0)
+            const observed = run('/bin/ps', ['-p', String(pid), '-o', 'pid=,state=']).trim();
+            if (observed.length === 0)
                 return { status: 'absent' };
-            if (Number(observedPid) !== pid)
+            const observedFields = /^(\d+)(?:\s+(\S+))?$/.exec(observed);
+            if (!observedFields || Number(observedFields[1]) !== pid)
                 return { status: 'unknown' };
+            // A zombie has already terminated; it runs no code and its pid cannot be
+            // reused until the parent reaps it. Reporting it as absent — rather than
+            // as an unreadable identity — is what lets a caller prove a stop it just
+            // performed (GH #707).
+            if (observedFields[2]?.startsWith('Z'))
+                return { status: 'absent' };
             const helper = verifyDarwinProcessBirthHelper(dependencies);
             const processInfo = runVerifiedHelper(helper.path, pid, helper.requirement).trim();
             const processMatch = /^(\d+):(\d+):(\d+)$/.exec(processInfo);
@@ -234,6 +241,8 @@ export function probeProcessBirth(pid, dependencies = {}) {
                     .trim()
                     .split(/\s+/)
                 : [];
+            if (fields[0] === 'Z')
+                return { status: 'absent' };
             const started = fields[19];
             if (!boot || !started || !/^\d+$/.test(started))
                 return { status: 'unknown' };

--- a/packages/rn-dev-agent-core/dist/session/process-cleanup.js
+++ b/packages/rn-dev-agent-core/dist/session/process-cleanup.js
@@ -249,19 +249,23 @@ export async function stopBoundRunner(binding, processProbe = probeProcessBirth,
                 : 'stopped';
         };
         const message = 'runner process did not stop before the cleanup deadline';
-        signalProcess(pid, 'SIGTERM');
+        const signalTolerated = (value) => {
+            try {
+                signalProcess(pid, value);
+            }
+            catch { }
+        };
+        signalTolerated('SIGTERM');
         const graceDeadlineMs = Math.min(deadlineMs, Date.now() + termGraceMs);
         if (!(await awaitExactStopped(observeStop, graceDeadlineMs, 'RUNNER_ADOPTION_REQUIRED', message))) {
-            // The iOS runner is an xcodebuild test host that does not unwind on a
-            // single SIGTERM. Escalate — but only after re-proving the pid still
-            // carries this binding's exact birth token, so a reused pid or another
-            // session's runner is never killed (GH #707).
+            // Escalate only while the pid still carries this binding's exact birth
+            // token, so a reused pid or another session's runner is never killed.
             const escalation = processProbe(pid);
             if (escalation.status === 'unknown') {
                 throw new SessionAuthorityError('RUNNER_ADOPTION_REQUIRED', `${message}; shutdown identity is unknown`);
             }
             if (escalation.status === 'present' && escalation.birth.token === expectedBirth) {
-                signalProcess(pid, 'SIGKILL');
+                signalTolerated('SIGKILL');
             }
             await waitForExactStopped(observeStop, deadlineMs, 'RUNNER_ADOPTION_REQUIRED', message);
         }

--- a/packages/rn-dev-agent-core/dist/session/process-cleanup.js
+++ b/packages/rn-dev-agent-core/dist/session/process-cleanup.js
@@ -142,18 +142,22 @@ export async function runRecordProofScript(script, args, timeout = 60_000, depen
         },
     }));
 }
-async function waitForExactStopped(probe, deadlineMs, code, message) {
+async function awaitExactStopped(probe, deadlineMs, code, message) {
     while (true) {
         const status = probe();
         if (status === 'stopped')
-            return;
+            return true;
         if (status === 'unknown') {
             throw new SessionAuthorityError(code, `${message}; shutdown identity is unknown`);
         }
-        if (Date.now() >= deadlineMs) {
-            throw new SessionAuthorityError(code, message);
-        }
+        if (Date.now() >= deadlineMs)
+            return false;
         await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+}
+async function waitForExactStopped(probe, deadlineMs, code, message) {
+    if (!(await awaitExactStopped(probe, deadlineMs, code, message))) {
+        throw new SessionAuthorityError(code, message);
     }
 }
 export async function stopBoundObserve(binding, listenerProbe = probeManagedMetroListener, processProbe = probeProcessBirth, timeoutMs = 2_000, request = fetch) {
@@ -219,7 +223,7 @@ export async function stopBoundObserve(binding, listenerProbe = probeManagedMetr
         return observed.status === 'listening' && observed.pid === pid ? 'running' : 'stopped';
     }, deadlineMs, 'OBSERVE_AUTHORITY_MISMATCH', 'Observe listener did not stop before the cleanup deadline');
 }
-export async function stopBoundRunner(binding, processProbe = probeProcessBirth, signalProcess = process.kill, timeoutMs = 2_000, runAdb = async (args) => execFile('adb', args, { timeout: 5_000, encoding: 'utf8' })) {
+export async function stopBoundRunner(binding, processProbe = probeProcessBirth, signalProcess = process.kill, timeoutMs = 2_000, runAdb = async (args) => execFile('adb', args, { timeout: 5_000, encoding: 'utf8' }), termGraceMs = 500) {
     const deadlineMs = Date.now() + timeoutMs;
     const pid = Number(binding.pid);
     const expectedBirth = String(binding.processBirth ?? '');
@@ -236,15 +240,31 @@ export async function stopBoundRunner(binding, processProbe = probeProcessBirth,
         throw new SessionAuthorityError('RUNNER_ADOPTION_REQUIRED', 'runner process identity is unavailable');
     }
     if (current.status === 'present' && current.birth.token === expectedBirth) {
-        signalProcess(pid, 'SIGTERM');
-        await waitForExactStopped(() => {
+        const observeStop = () => {
             const observed = processProbe(pid);
             if (observed.status === 'unknown')
                 return 'unknown';
             return observed.status === 'present' && observed.birth.token === expectedBirth
                 ? 'running'
                 : 'stopped';
-        }, deadlineMs, 'RUNNER_ADOPTION_REQUIRED', 'runner process did not stop before the cleanup deadline');
+        };
+        const message = 'runner process did not stop before the cleanup deadline';
+        signalProcess(pid, 'SIGTERM');
+        const graceDeadlineMs = Math.min(deadlineMs, Date.now() + termGraceMs);
+        if (!(await awaitExactStopped(observeStop, graceDeadlineMs, 'RUNNER_ADOPTION_REQUIRED', message))) {
+            // The iOS runner is an xcodebuild test host that does not unwind on a
+            // single SIGTERM. Escalate — but only after re-proving the pid still
+            // carries this binding's exact birth token, so a reused pid or another
+            // session's runner is never killed (GH #707).
+            const escalation = processProbe(pid);
+            if (escalation.status === 'unknown') {
+                throw new SessionAuthorityError('RUNNER_ADOPTION_REQUIRED', `${message}; shutdown identity is unknown`);
+            }
+            if (escalation.status === 'present' && escalation.birth.token === expectedBirth) {
+                signalProcess(pid, 'SIGKILL');
+            }
+            await waitForExactStopped(observeStop, deadlineMs, 'RUNNER_ADOPTION_REQUIRED', message);
+        }
     }
     if (platform !== 'android')
         return;

--- a/packages/rn-dev-agent-core/src/session/process-birth.ts
+++ b/packages/rn-dev-agent-core/src/session/process-birth.ts
@@ -285,9 +285,15 @@ export function probeProcessBirth(
 
   try {
     if (platform === 'darwin') {
-      const observedPid = run('/bin/ps', ['-p', String(pid), '-o', 'pid=']).trim();
-      if (observedPid.length === 0) return { status: 'absent' };
-      if (Number(observedPid) !== pid) return { status: 'unknown' };
+      const observed = run('/bin/ps', ['-p', String(pid), '-o', 'pid=,state=']).trim();
+      if (observed.length === 0) return { status: 'absent' };
+      const observedFields = /^(\d+)(?:\s+(\S+))?$/.exec(observed);
+      if (!observedFields || Number(observedFields[1]) !== pid) return { status: 'unknown' };
+      // A zombie has already terminated; it runs no code and its pid cannot be
+      // reused until the parent reaps it. Reporting it as absent — rather than
+      // as an unreadable identity — is what lets a caller prove a stop it just
+      // performed (GH #707).
+      if (observedFields[2]?.startsWith('Z')) return { status: 'absent' };
       const helper = verifyDarwinProcessBirthHelper(dependencies);
       const processInfo = runVerifiedHelper(helper.path, pid, helper.requirement).trim();
       const processMatch = /^(\d+):(\d+):(\d+)$/.exec(processInfo);
@@ -324,6 +330,7 @@ export function probeProcessBirth(
               .trim()
               .split(/\s+/)
           : [];
+      if (fields[0] === 'Z') return { status: 'absent' };
       const started = fields[19];
       if (!boot || !started || !/^\d+$/.test(started)) return { status: 'unknown' };
       return {

--- a/packages/rn-dev-agent-core/src/session/process-cleanup.ts
+++ b/packages/rn-dev-agent-core/src/session/process-cleanup.ts
@@ -336,15 +336,18 @@ export async function stopBoundRunner(
         : 'stopped';
     };
     const message = 'runner process did not stop before the cleanup deadline';
-    signalProcess(pid, 'SIGTERM');
+    const signalTolerated = (value: NodeJS.Signals): void => {
+      try {
+        signalProcess(pid, value);
+      } catch {}
+    };
+    signalTolerated('SIGTERM');
     const graceDeadlineMs = Math.min(deadlineMs, Date.now() + termGraceMs);
     if (
       !(await awaitExactStopped(observeStop, graceDeadlineMs, 'RUNNER_ADOPTION_REQUIRED', message))
     ) {
-      // The iOS runner is an xcodebuild test host that does not unwind on a
-      // single SIGTERM. Escalate — but only after re-proving the pid still
-      // carries this binding's exact birth token, so a reused pid or another
-      // session's runner is never killed (GH #707).
+      // Escalate only while the pid still carries this binding's exact birth
+      // token, so a reused pid or another session's runner is never killed.
       const escalation = processProbe(pid);
       if (escalation.status === 'unknown') {
         throw new SessionAuthorityError(
@@ -353,7 +356,7 @@ export async function stopBoundRunner(
         );
       }
       if (escalation.status === 'present' && escalation.birth.token === expectedBirth) {
-        signalProcess(pid, 'SIGKILL');
+        signalTolerated('SIGKILL');
       }
       await waitForExactStopped(observeStop, deadlineMs, 'RUNNER_ADOPTION_REQUIRED', message);
     }

--- a/packages/rn-dev-agent-core/src/session/process-cleanup.ts
+++ b/packages/rn-dev-agent-core/src/session/process-cleanup.ts
@@ -172,22 +172,31 @@ export async function runRecordProofScript(
   );
 }
 
+async function awaitExactStopped(
+  probe: () => 'running' | 'stopped' | 'unknown',
+  deadlineMs: number,
+  code: string,
+  message: string,
+): Promise<boolean> {
+  while (true) {
+    const status = probe();
+    if (status === 'stopped') return true;
+    if (status === 'unknown') {
+      throw new SessionAuthorityError(code, `${message}; shutdown identity is unknown`);
+    }
+    if (Date.now() >= deadlineMs) return false;
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+  }
+}
+
 async function waitForExactStopped(
   probe: () => 'running' | 'stopped' | 'unknown',
   deadlineMs: number,
   code: string,
   message: string,
 ): Promise<void> {
-  while (true) {
-    const status = probe();
-    if (status === 'stopped') return;
-    if (status === 'unknown') {
-      throw new SessionAuthorityError(code, `${message}; shutdown identity is unknown`);
-    }
-    if (Date.now() >= deadlineMs) {
-      throw new SessionAuthorityError(code, message);
-    }
-    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+  if (!(await awaitExactStopped(probe, deadlineMs, code, message))) {
+    throw new SessionAuthorityError(code, message);
   }
 }
 
@@ -295,6 +304,7 @@ export async function stopBoundRunner(
   timeoutMs = 2_000,
   runAdb: (args: string[]) => Promise<{ stdout: string; stderr: string }> = async (args) =>
     execFile('adb', args, { timeout: 5_000, encoding: 'utf8' }),
+  termGraceMs = 500,
 ): Promise<void> {
   const deadlineMs = Date.now() + timeoutMs;
   const pid = Number(binding.pid);
@@ -318,19 +328,35 @@ export async function stopBoundRunner(
     );
   }
   if (current.status === 'present' && current.birth.token === expectedBirth) {
+    const observeStop = (): 'running' | 'stopped' | 'unknown' => {
+      const observed = processProbe(pid);
+      if (observed.status === 'unknown') return 'unknown';
+      return observed.status === 'present' && observed.birth.token === expectedBirth
+        ? 'running'
+        : 'stopped';
+    };
+    const message = 'runner process did not stop before the cleanup deadline';
     signalProcess(pid, 'SIGTERM');
-    await waitForExactStopped(
-      () => {
-        const observed = processProbe(pid);
-        if (observed.status === 'unknown') return 'unknown';
-        return observed.status === 'present' && observed.birth.token === expectedBirth
-          ? 'running'
-          : 'stopped';
-      },
-      deadlineMs,
-      'RUNNER_ADOPTION_REQUIRED',
-      'runner process did not stop before the cleanup deadline',
-    );
+    const graceDeadlineMs = Math.min(deadlineMs, Date.now() + termGraceMs);
+    if (
+      !(await awaitExactStopped(observeStop, graceDeadlineMs, 'RUNNER_ADOPTION_REQUIRED', message))
+    ) {
+      // The iOS runner is an xcodebuild test host that does not unwind on a
+      // single SIGTERM. Escalate — but only after re-proving the pid still
+      // carries this binding's exact birth token, so a reused pid or another
+      // session's runner is never killed (GH #707).
+      const escalation = processProbe(pid);
+      if (escalation.status === 'unknown') {
+        throw new SessionAuthorityError(
+          'RUNNER_ADOPTION_REQUIRED',
+          `${message}; shutdown identity is unknown`,
+        );
+      }
+      if (escalation.status === 'present' && escalation.birth.token === expectedBirth) {
+        signalProcess(pid, 'SIGKILL');
+      }
+      await waitForExactStopped(observeStop, deadlineMs, 'RUNNER_ADOPTION_REQUIRED', message);
+    }
   }
   if (platform !== 'android') return;
   if (!deviceId || !Number.isSafeInteger(port)) {

--- a/packages/rn-dev-agent-core/test/unit/session/gh-707-hard-reset-cold-start.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/gh-707-hard-reset-cold-start.test.ts
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { test } from 'node:test';
+import { probeProcessBirth } from '../../../dist/session/process-birth.js';
+import { stopBoundRunner } from '../../../dist/session/process-cleanup.js';
+import { authorityProfileFor } from '../../../dist/session/tool-profiles.js';
+import { createRestartHandler } from '../../../dist/tools/restart.js';
+
+const supported = process.platform === 'darwin' || process.platform === 'linux';
+
+// A stand-in for the bound iOS runner: `xcodebuild test-without-building` does
+// not exit on a single polite SIGTERM, and once it does die its parent has not
+// reaped it yet, so the pid lingers as a zombie. Both states must still let the
+// owning session prove the stop.
+interface StubbornRunner {
+  pid: number;
+  processBirth: string;
+  dispose: () => void;
+}
+
+async function spawnStubbornRunner(): Promise<StubbornRunner> {
+  // The outer shell never wait()s, so the runner stays a zombie after it dies —
+  // exactly the window stopBoundRunner polls into.
+  // zsh does not reap a background job while it sleeps, so where it exists the
+  // runner also stays a zombie — the unreaped window stopBoundRunner polls into.
+  // Elsewhere /bin/sh still covers the SIGTERM-resistant half; the zombie
+  // classification itself is pinned by process-birth.test.ts on every host.
+  const shell = existsSync('/bin/zsh') ? '/bin/zsh' : '/bin/sh';
+  const holder = spawn(shell, ['-c', '{ trap "" TERM; exec sleep 300; } & echo $!; sleep 60'], {
+    stdio: ['ignore', 'pipe', 'ignore'],
+    detached: true,
+  });
+  let out = '';
+  holder.stdout.setEncoding('utf8');
+  const pid = await new Promise<number>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('runner stub did not report its pid')), 5_000);
+    holder.stdout.on('data', (chunk: string) => {
+      out += chunk;
+      const parsed = Number(out.trim());
+      if (Number.isSafeInteger(parsed) && parsed > 0) {
+        clearTimeout(timer);
+        resolve(parsed);
+      }
+    });
+  });
+  const birth = probeProcessBirth(pid);
+  assert.equal(birth.status, 'present', 'runner stub identity must be provable before the stop');
+  return {
+    pid,
+    processBirth: birth.status === 'present' ? birth.birth.token : '',
+    dispose: () => {
+      try {
+        process.kill(-holder.pid!, 'SIGKILL');
+      } catch {
+        /* already gone */
+      }
+      holder.stdout.destroy();
+    },
+  };
+}
+
+function runnerBinding(runner: StubbornRunner): Record<string, unknown> {
+  return {
+    platform: 'ios',
+    deviceId: 'A1B2C3D4-1111-2222-3333-444455556666',
+    pid: runner.pid,
+    processBirth: runner.processBirth,
+    instanceId: 'runner-707',
+    capability: 'runner-capability-707',
+  };
+}
+
+test(
+  'GH #707: the owning session can stop a runner that ignores SIGTERM and then lingers unreaped',
+  { skip: supported ? false : 'process-birth probes are POSIX-only here' },
+  async () => {
+    const runner = await spawnStubbornRunner();
+    try {
+      await stopBoundRunner(runnerBinding(runner));
+    } finally {
+      runner.dispose();
+    }
+  },
+);
+
+test(
+  'GH #707: hardReset has a reachable cold start — the runner-bound state must not refuse it',
+  { skip: supported ? false : 'process-birth probes are POSIX-only here' },
+  async () => {
+    // The authority gate refuses hardReset outright when R is unbound, so the
+    // runner-bound state is the only candidate. If it refuses too, the
+    // operation has no reachable state at all — the #707 deadlock.
+    const profile = authorityProfileFor('cdp_restart', { hardReset: true, platform: 'ios' });
+    assert.ok(
+      profile.axes.includes('R'),
+      'hardReset still requires R; the runner-unbound state cannot be the reachable one',
+    );
+
+    const runner = await spawnStubbornRunner();
+    const binding = runnerBinding(runner);
+    const client = {
+      metroPort: 8081,
+      isConnected: false,
+      connectedTarget: { platform: 'ios' },
+      disconnect: async () => {},
+      connectExact: async function (this: { isConnected: boolean }) {
+        this.isConnected = true;
+      },
+    };
+    let unbound = false;
+    const restart = createRestartHandler(
+      () => client as never,
+      () => {},
+      () => client as never,
+      {
+        // Mirrors how index.ts wires cdp_restart to the session-bound runner.
+        stopFastRunner: async () => {
+          await stopBoundRunner(binding);
+        },
+        unbindRunner: () => {
+          unbound = true;
+        },
+        execFile: async () => ({ stdout: '', stderr: '' }),
+        sleep: async () => {},
+        probeAppInstalled: async () => true,
+        resetDetachedBudget: () => {},
+        resolveExactTargetId: async () => 'target-707',
+      },
+    );
+
+    let envelope: { content: Array<{ text: string }> };
+    try {
+      envelope = (await restart({
+        hardReset: true,
+        platform: 'ios',
+        deviceId: binding.deviceId as string,
+        appId: 'com.example.app',
+        metroPort: 8081,
+      })) as { content: Array<{ text: string }> };
+    } finally {
+      runner.dispose();
+    }
+    const result = JSON.parse(envelope.content[0]!.text) as { ok?: boolean; error?: string };
+
+    assert.equal(
+      result.ok,
+      true,
+      `hardReset refused the only reachable runner state: ${result.error ?? 'unknown'}`,
+    );
+    assert.equal(unbound, true, 'a completed hardReset must release the runner it stopped');
+  },
+);

--- a/packages/rn-dev-agent-core/test/unit/session/gh-707-hard-reset-cold-start.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/gh-707-hard-reset-cold-start.test.ts
@@ -114,7 +114,9 @@ test(
       () => {},
       () => client as never,
       {
-        // Mirrors how index.ts wires cdp_restart to the session-bound runner.
+        // Covers the stopBoundRunner half of index.ts's stopFastRunner wiring;
+        // clearFastRunnerAfterVerifiedStop is omitted to keep this test off
+        // persisted runner state.
         stopFastRunner: async () => {
           await stopBoundRunner(binding);
         },

--- a/packages/rn-dev-agent-core/test/unit/session/gh-707-hard-reset-cold-start.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/gh-707-hard-reset-cold-start.test.ts
@@ -84,6 +84,50 @@ test(
   },
 );
 
+test('GH #707: escalation never SIGKILLs a pid that no longer carries this binding’s birth', async () => {
+  const binding = {
+    platform: 'ios',
+    deviceId: 'A1B2C3D4-1111-2222-3333-444455556666',
+    pid: 4242,
+    processBirth: 'birth-mine',
+    instanceId: 'runner-707',
+    capability: 'runner-capability-707',
+  };
+  const escalate = async (birthAfterGrace: string): Promise<string[]> => {
+    const signals: string[] = [];
+    let probes = 0;
+    // A zero grace makes the poll schedule exact: probe 1 admits the binding,
+    // probe 2 closes the grace window, probe 3 IS the escalation re-probe.
+    const probe = (): { status: 'present'; birth: { token: string } } => {
+      probes += 1;
+      return {
+        status: 'present',
+        birth: { token: probes <= 2 ? 'birth-mine' : birthAfterGrace },
+      };
+    };
+    await stopBoundRunner(
+      binding,
+      probe as never,
+      (_pid: number, signal: NodeJS.Signals) => signals.push(signal),
+      300,
+      async () => ({ stdout: '', stderr: '' }),
+      0,
+    ).catch(() => {});
+    return signals;
+  };
+
+  assert.deepEqual(
+    await escalate('birth-mine'),
+    ['SIGTERM', 'SIGKILL'],
+    'a runner still proven to be mine may be escalated',
+  );
+  assert.deepEqual(
+    await escalate('birth-someone-else'),
+    ['SIGTERM'],
+    'a pid recycled inside the grace window must never be killed',
+  );
+});
+
 test(
   'GH #707: hardReset has a reachable cold start — the runner-bound state must not refuse it',
   { skip: supported ? false : 'process-birth probes are POSIX-only here' },

--- a/packages/rn-dev-agent-core/test/unit/session/process-birth.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/process-birth.test.ts
@@ -13,7 +13,7 @@ test('macOS process identity uses full kernel start time and boot session', () =
   const runForBoot = (bootSession, startMicroseconds = '345678') => ({
     run: (command, args) => {
       if (command === '/bin/ps') {
-        assert.deepEqual(args, ['-p', '123', '-o', 'pid=']);
+        assert.deepEqual(args, ['-p', '123', '-o', 'pid=,state=']);
         return '123\n';
       }
       if (command === '/usr/sbin/sysctl') {
@@ -62,6 +62,25 @@ test('macOS process probes distinguish confirmed absence from unreadable identit
       run: (command) => (command === '/bin/ps' ? '123\n' : 'unparseable\n'),
     }),
     { status: 'unknown' },
+  );
+});
+
+test('a terminated but unreaped process reads as absent, not as an unknown identity', () => {
+  assert.deepEqual(
+    probeProcessBirth(123, {
+      platform: 'darwin',
+      run: (command) => (command === '/bin/ps' ? '  123 Z+\n' : assert.fail()),
+      runVerifiedHelper: () => assert.fail('a zombie must not reach the identity helper'),
+    }),
+    { status: 'absent' },
+  );
+  assert.deepEqual(
+    probeProcessBirth(123, {
+      platform: 'linux',
+      read: (path) =>
+        path.includes('boot_id') ? 'boot-1\n' : '123 (runner) Z 1 1 0 0 -1 0 0 0 0 0 0 0\n',
+    }),
+    { status: 'absent' },
   );
 });
 


### PR DESCRIPTION
## Intent

Fix GitHub issue #707 in Lykhoyda/rn-dev-agent: 'cdp_restart hardReset=true' is unusable because it fails in BOTH runner states, which is a genuine deadlock rather than an ordinary bug. With runner authority bound: RUNNER_ADOPTION_REQUIRED — the runner process did not stop before the cleanup deadline, shutdown identity unknown, plus authorityInvalidated demanding pin_dev_client. Without runner authority bound: RUNNER_OWNERSHIP_MISMATCH: R authority is not bound. So the operation requires the runner authority to be bound, and yet with it bound it cannot stop the very runner it requires. There is no state a user can reach where the sanctioned cold start works.

ACCEPTED MINIMAL CONTRACT: cdp_restart hardReset=true completes successfully from a healthy bound session, performing the cold start it promises. Add a regression test that fails if both branches refuse — one that would have caught this deadlock.

CONSTRAINTS ACCEPTED FOR THIS WORK:
- Diagnose before fixing. Establish WHY the runner does not stop before the deadline with authority bound; do not assume it is merely a short timeout. A deadline extension that hides a shutdown that never completes is NOT an acceptable fix.
- 80/20 scope: restore the sanctioned cold-start path only. Do NOT redesign runner ownership, add a new authority state, introduce a broker, or build a general recovery framework.
- Same causal family as issues #692 and #706 (recovery paths with no way out). #706 is already fixed on main; read how it was resolved before designing this one. If one corrected rule would cover both this and #692, say so in the status rather than quietly building a second special case. Do NOT expand scope to fix #692 here; just report the finding.
- Ownership safety is a HARD boundary: never force-stop or steal a runner that is genuinely held by another live session. The fix must distinguish 'my own runner that I am entitled to stop' from 'someone else's'.
- Findings that would broaden this contract belong in a follow-up issue, not this PR.

WHAT I DIAGNOSED AND WHY THE DIFF LOOKS THE WAY IT DOES (a reviewer reading only the diff would not know this):
The reported error message is misleading and that mattered. 'runner process did not stop before the cleanup deadline; shutdown identity is unknown' — waitForExactStopped in src/session/process-cleanup.ts appends the '; shutdown identity is unknown' suffix ONLY on the 'unknown' probe branch, which throws IMMEDIATELY without consulting any deadline. So the deadline was never the cause. I then proved empirically on darwin that a zombie process (terminated but not yet reaped by its parent) probes as status 'unknown', not 'absent' (ran a real experiment: ps showed state Z, probeProcessBirth returned {status:'unknown'}). Conclusion: the runner HAD stopped, and the proof machinery reported its successful death as unknowable. Extending the deadline would have changed nothing — which is exactly the non-fix the constraints forbid.

A second independent defect sat behind it: stopBoundRunner sent a single SIGTERM and gave up with no escalation, while the bound iOS runner is an 'xcodebuild test-without-building' test host that does not unwind on one polite signal. Its sibling reapStaleFastRunner in src/runners/rn-fast-runner-client.ts already escalates SIGTERM -> 500ms -> SIGKILL for this exact process; the registry-bound cleanup path had simply lost that escalation. index.ts wires cdp_restart's stopFastRunner dependency to stopBoundRunner + clearFastRunnerAfterVerifiedStop, bypassing the escalating path entirely.

DELIBERATE DECISIONS IN THIS DIFF:
1. I corrected two rules rather than widening any timeout. Rule one: a zombie counts as 'absent', not 'unknown' — it runs no code and its pid cannot be reused until reaped, so it is genuinely stopped rather than unreadable. Applied in probeProcessBirth for BOTH darwin (via 'ps -o pid=,state=', state prefix Z) and linux (/proc stat state field Z), deliberately at the probe layer so every caller benefits rather than special-casing the restart path. This required changing the ps argument list, so the existing assertion in process-birth.test.ts was updated in the same pass.
2. Rule two: stopBoundRunner escalates SIGTERM -> grace (new termGraceMs param, default 500ms, appended last so existing positional callers are unaffected) -> SIGKILL. Ownership safety is preserved deliberately and explicitly: the escalation re-probes and only signals when the pid still carries THAT binding's exact process-birth token, so a reused pid or another session's runner is never killed. I intentionally kept the 'unknown' branch fail-closed (still throws) rather than making it retry — that would have been scope expansion beyond the proven cause.
3. I refactored waitForExactStopped into awaitExactStopped (returns boolean at deadline, still throws on 'unknown') plus a thin throwing wrapper, so the grace phase can fall through to escalation instead of throwing. stopBoundObserve's behavior is unchanged.
4. I did NOT make the runner-unbound state work. The authority gate requires R bound before the hardReset transition by construction; with the bound state fixed there IS a reachable state, which satisfies the accepted contract without touching ownership design.
5. I deliberately dropped an unrelated pre-existing regeneration diff in apps/docs-site/src/content/docs/changelog.md (0.75.3 release entries drifted on main) to keep this diff focused on #707.

REGRESSION TEST: packages/rn-dev-agent-core/test/unit/session/gh-707-hard-reset-cold-start.test.ts drives the real seam — a genuinely SIGTERM-resistant process that then lingers unreaped as a zombie, stopped through the same composition index.ts wires cdp_restart to, plus the full createRestartHandler path. It also asserts authorityProfileFor still includes the R axis, which is what makes 'the bound state must succeed' a proof that SOME state is reachable — the test therefore fails if both runner states refuse again. I verified by ablation that reverting EITHER fix makes it reproduce the issue's error string verbatim. The zombie holder uses /bin/zsh where present (zsh does not reap a background job while sleeping, so the zombie persists) and falls back to /bin/sh elsewhere; the zombie classification itself is pinned deterministically on every host by injected-dependency cases in process-birth.test.ts.

REPORTED FINDING ON #692 (deliberately NOT acted on, per constraints): same causal family as #706/#707 — fail-closed proof with no exit — but NOT one corrected rule. #692 fails in a claim-SCHEMA validation check against a proven-dead owner, not in process-liveness classification, so this fix does not touch it; it needs its own rule about what a dead owner's unverifiable claim may veto.

VALIDATION ALREADY RUN LOCALLY: 4570/4570 tests pass, lint clean, format clean, check-agent-package-sync clean, check-dist-fresh clean, check-typescript-only clean, build:docs clean. dist and both host-package runtimes were regenerated via build:core + build:host-runtimes and committed, and a changeset bumping rn-dev-agent-core and rn-dev-agent-plugin (patch) is included as required for src changes. session-authority.mdx documents the two corrected rules.

## What Changed

- `probeProcessBirth` now classifies a terminated-but-unreaped process as `absent` instead of `unknown` on both darwin (`ps -o pid=,state=`, state prefix `Z`) and linux (`/proc` stat state field `Z`), so a caller can prove a stop it just performed; the darwin `ps` argument change is reflected in the existing `process-birth.test.ts` assertion.
- `stopBoundRunner` escalates SIGTERM → grace (new trailing `termGraceMs` param, default 500ms) → SIGKILL, re-probing first and signalling only while the pid still carries that binding's exact process-birth token, so a recycled pid or another session's runner is never killed; both signals tolerate an already-dead target and `waitForExactStopped` remains the sole arbiter of a proven stop. `waitForExactStopped` was split into `awaitExactStopped` (returns a boolean at the deadline, still throws on `unknown`) plus a thin throwing wrapper so the grace phase can fall through to escalation; `stopBoundObserve` behavior is unchanged.
- Added `test/unit/session/gh-707-hard-reset-cold-start.test.ts`, which drives a genuinely SIGTERM-resistant process that lingers as an unreaped zombie through the same composition `index.ts` wires `cdp_restart` to, plus the full `createRestartHandler` path and an ownership-safety case; committed `dist`/host-runtime bundles, a patch changeset, and the two corrected rules in `session-authority.mdx` are included.

## Risk Assessment

✅ Low: The branch is a tightly-scoped, correctly-diagnosed fix to two liveness-classification and escalation rules that preserves the hard ownership boundary and the fail-closed 'unknown' branches, ships with probe-layer unit tests plus a real-process regression test and regenerated dist, and the one substantiated defect from the prior round (an unguarded SIGKILL that could surface a raw ESRCH as RUNNER_ADOPTION_REQUIRED) is now fixed using this file's existing already-dead-target convention with proof still delegated to waitForExactStopped.

## Testing

Built the core package and ran the targeted session/restart tests (72 pass), then went beyond pass/fail to product-level evidence: a harness that spawns a genuinely SIGTERM-resistant runner which lingers as an unreaped zombie — the exact process shape of the bound iOS `xcodebuild test-without-building` host — and drives it through the same `stopBoundRunner` composition `index.ts` wires `cdp_restart` to, plus the full restart handler. The captured tool envelope is `ok: true` with all four `hardResetSteps` succeeding in 609ms, the runner released and the pid actually stopped, which is what an end user experiences as the cold start working. To prove the deadlock is genuinely gone rather than merely masked, I ablated each corrected rule separately in the built output; each one independently brings back the issue's error string verbatim and fails the regression test, confirming both rules are load-bearing and that a deadline extension alone would not have helped. I also found that the intent's hard ownership-safety boundary was unasserted — removing the birth-token guard before SIGKILL left every committed test green — so I added a focused case that deterministically exercises the escalation re-probe and now fails when that guard is removed. There is no UI, HTML, or rendered surface in this change; `cdp_restart` is an MCP tool whose end-user surface is the JSON response envelope, so the captured CLI transcript of that envelope is the reviewer-visible artifact rather than a screenshot. Worktree left clean apart from the intentional test addition, with all ablations reverted.

<details>
<summary>Evidence: cdp_restart hardReset=true succeeds end-to-end (actual tool envelope)</summary>

<code>cdp_restart hardReset=true required authority axes: [&#34;C&#34;,&#34;S&#34;,&#34;I&#34;,&#34;M&#34;,&#34;B&#34;,&#34;D&#34;,&#34;R&#34;]&#10;-&gt; R (runner) is required, so the runner-UNBOUND state is refused by the gate by construction.&#10;-&gt; therefore the runner-BOUND state is the only candidate for a reachable cold start.&#10;&#10;bound iOS runner stub: pid=58666 (SIGTERM-resistant, lingers unreaped as a zombie after death)&#10;&#10;$ cdp_restart { hardReset: true, platform: &#34;ios&#34;, deviceId: &#34;A1B2C3D4-...&#34;, appId: &#34;com.example.app&#34;, metroPort: 8081 }&#10;{&#10;&#34;ok&#34;: true,&#10;&#34;data&#34;: {&#10;&#34;restarted&#34;: true,&#10;&#34;connected&#34;: true,&#10;&#34;port&#34;: 8081,&#10;&#34;hardReset&#34;: true,&#10;&#34;hardResetSteps&#34;: [&#10;&#34;stopFastRunner:ok&#34;,&#10;&#34;unbindRunner:ok&#34;,&#10;&#34;simctl terminate com.example.app:ok&#34;,&#10;&#34;simctl launch com.example.app:ok&#34;&#10;],&#10;&#34;bundleId&#34;: &#34;com.example.app&#34;&#10;}&#10;}&#10;&#10;elapsed: 609ms&#10;runner released (unbindRunner called): true&#10;runner pid 58666 still runnable afterwards: no (actually stopped)</code>

```text
cdp_restart hardReset=true required authority axes: ["C","S","I","M","B","D","R"]
  -> R (runner) is required, so the runner-UNBOUND state is refused by the gate by construction.
  -> therefore the runner-BOUND state is the only candidate for a reachable cold start.

bound iOS runner stub: pid=58666 (SIGTERM-resistant, lingers unreaped as a zombie after death)

$ cdp_restart { hardReset: true, platform: "ios", deviceId: "A1B2C3D4-...", appId: "com.example.app", metroPort: 8081 }
{
  "ok": true,
  "data": {
    "restarted": true,
    "connected": true,
    "port": 8081,
    "hardReset": true,
    "hardResetSteps": [
      "stopFastRunner:ok",
      "unbindRunner:ok",
      "simctl terminate com.example.app:ok",
      "simctl launch com.example.app:ok"
    ],
    "bundleId": "com.example.app"
  }
}

elapsed: 609ms
runner released (unbindRunner called): true
runner pid 58666 still runnable afterwards: no (actually stopped)
```
</details>
<details>
<summary>Evidence: Ablation: each corrected rule independently reproduces the #707 error verbatim</summary>

<code>ABLATION: rule 1 reverted (zombie no longer classified as absent; SIGKILL escalation kept)&#10;&#34;ok&#34;: false,&#10;&#34;error&#34;: &#34;cdp_restart retained runner authority because exact shutdown was not proven: RUNNER_ADOPTION_REQUIRED: runner process did not stop before the cleanup deadline; shutdown identity is unknown&#34;&#10;regression test: 2 failed&#10;&#10;ABLATION: rule 2 reverted (single SIGTERM, no escalation; zombie rule kept)&#10;&#34;ok&#34;: false,&#10;&#34;error&#34;: &#34;cdp_restart retained runner authority because exact shutdown was not proven: RUNNER_ADOPTION_REQUIRED: runner process did not stop before the cleanup deadline&#34;&#10;regression test: 2 failed</code>

```text
==============================================================
ABLATION: rule 1 reverted (zombie no longer classified as absent; SIGKILL escalation kept)
==============================================================
  -> R (runner) is required, so the runner-UNBOUND state is refused by the gate by construction.
  -> therefore the runner-BOUND state is the only candidate for a reachable cold start.

bound iOS runner stub: pid=62746 (SIGTERM-resistant, lingers unreaped as a zombie after death)

$ cdp_restart { hardReset: true, platform: "ios", deviceId: "A1B2C3D4-...", appId: "com.example.app", metroPort: 8081 }
{
  "ok": false,
  "error": "cdp_restart retained runner authority because exact shutdown was not proven: RUNNER_ADOPTION_REQUIRED: runner process did not stop before the cleanup deadline; shutdown identity is unknown",
  "code": "RUNNER_ADOPTION_REQUIRED",
  "meta": {
    "hardResetSteps": [
      "stopFastRunner:err(RUNNER_ADOPTION_REQUIRED: runner process did not stop before the cleanup deadline; shutdown identity is unknown)"
    ]
  }
}

elapsed: 628ms
runner released (unbindRunner called): false
runner pid 62746 still runnable afterwards: no (actually stopped)

--- regression test under the same ablation ---
✖ GH #707: the owning session can stop a runner that ignores SIGTERM and then lingers unreaped (703.088042ms)
✖ GH #707: hardReset has a reachable cold start — the runner-bound state must not refuse it (738.525167ms)
ℹ tests 2
ℹ pass 0
ℹ fail 2
✖ failing tests:
✖ GH #707: the owning session can stop a runner that ignores SIGTERM and then lingers unreaped (703.088042ms)
✖ GH #707: hardReset has a reachable cold start — the runner-bound state must not refuse it (738.525167ms)

==============================================================
ABLATION: rule 2 reverted (single SIGTERM, no escalation; zombie rule kept)
==============================================================
  -> R (runner) is required, so the runner-UNBOUND state is refused by the gate by construction.
  -> therefore the runner-BOUND state is the only candidate for a reachable cold start.

bound iOS runner stub: pid=64031 (SIGTERM-resistant, lingers unreaped as a zombie after death)

$ cdp_restart { hardReset: true, platform: "ios", deviceId: "A1B2C3D4-...", appId: "com.example.app", metroPort: 8081 }
{
  "ok": false,
  "error": "cdp_restart retained runner authority because exact shutdown was not proven: RUNNER_ADOPTION_REQUIRED: runner process did not stop before the cleanup deadline",
  "code": "RUNNER_ADOPTION_REQUIRED",
  "meta": {
    "hardResetSteps": [
      "stopFastRunner:err(RUNNER_ADOPTION_REQUIRED: runner process did not stop before the cleanup deadline)"
    ]
  }
}

elapsed: 2033ms
runner released (unbindRunner called): false
runner pid 64031 still runnable afterwards: no (actually stopped)

--- regression test under the same ablation ---
✖ GH #707: the owning session can stop a runner that ignores SIGTERM and then lingers unreaped (2062.853791ms)
✖ GH #707: hardReset has a reachable cold start — the runner-bound state must not refuse it (2069.174042ms)
ℹ tests 2
ℹ pass 0
ℹ fail 2
✖ failing tests:
✖ GH #707: the owning session can stop a runner that ignores SIGTERM and then lingers unreaped (2062.853791ms)
✖ GH #707: hardReset has a reachable cold start — the runner-bound state must not refuse it (2069.174042ms)
```
</details>
<details>
<summary>Evidence: Ownership safety: SIGKILL only while the pid still carries this binding&#39;s birth token</summary>

<code>[A] pid still carries my runner&#39;s birth token after the grace window&#10;signals sent: [&#34;SIGTERM-&gt;pid 4242&#34;,&#34;SIGKILL-&gt;pid 4242&#34;]&#10;&#10;[B] pid was recycled to someone else between polls (different birth token)&#10;signals sent: [&#34;SIGTERM-&gt;pid 4242&#34;]&#10;result: stop accepted</code>

```text
Ownership safety: escalation re-probes and only SIGKILLs while the pid still carries THIS binding's birth token.

[A] pid still carries my runner's birth token after the grace window
  signals sent: ["SIGTERM->pid 4242","SIGKILL->pid 4242"]
  result: refused -> RUNNER_ADOPTION_REQUIRED: runner process did not stop before the cleanup deadline

[B] pid was recycled to someone else between polls (different birth token)
  signals sent: ["SIGTERM->pid 4242"]
  result: stop accepted
```
</details>
<details>
<summary>Evidence: Newly added ownership-guard test fails when the guard is removed</summary>

<code>### fixed code (guard present) ###&#10;✔ GH #707: escalation never SIGKILLs a pid that no longer carries this binding&#39;s birth&#10;&#10;### ABLATION: ownership guard removed (kill any live pid, not only my binding&#39;s birth) ###&#10;✖ GH #707: escalation never SIGKILLs a pid that no longer carries this binding&#39;s birth&#10;AssertionError: a pid recycled inside the grace window must never be killed&#10;actual: [ &#39;SIGTERM&#39;, &#39;SIGKILL&#39; ]&#10;expected: [ &#39;SIGTERM&#39; ]</code>

```text
### ABLATION: ownership guard removed (kill any live pid, not only my binding's birth) ###
✖ GH #707: escalation never SIGKILLs a pid that no longer carries this binding’s birth (313.720583ms)
ℹ pass 0
ℹ fail 1
✖ GH #707: escalation never SIGKILLs a pid that no longer carries this binding’s birth (313.720583ms)
  AssertionError [ERR_ASSERTION]: a pid recycled inside the grace window must never be killed
  + actual - expected
  +   'SIGKILL'
    actual: [ 'SIGTERM', 'SIGKILL' ],
    expected: [ 'SIGTERM' ],
```
</details>
<details>
<summary>Evidence: Targeted test run across #707 regression, process-birth, cleanup and restart callers</summary>

<code>ℹ tests 72&#10;ℹ pass 72&#10;ℹ fail 0&#10;ℹ duration_ms 1992.730542</code>

```text
✔ supervisor close retains claims when runner or Observe cleanup is unproven (288.889583ms)
✔ supervisor close retains an unpublished managed Metro transition (139.816834ms)
✔ supervisor close retains authority when durable Metro cleanup is unproven (134.606458ms)
✔ a blocked supervisor never touches a foreign .rn-agent root (140.264917ms)
ℹ tests 72
ℹ suites 0
ℹ pass 72
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1992.730542
```
</details>
<details>
<summary>Evidence: Evidence harness driving the real cdp_restart hardReset path</summary>

```text
import { spawn } from 'node:child_process';
import { existsSync } from 'node:fs';
import { probeProcessBirth } from '/Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZDWXDBH6X2YFDCBY9PPQ4GS/packages/rn-dev-agent-core/dist/session/process-birth.js';
import { stopBoundRunner } from '/Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZDWXDBH6X2YFDCBY9PPQ4GS/packages/rn-dev-agent-core/dist/session/process-cleanup.js';
import { authorityProfileFor } from '/Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZDWXDBH6X2YFDCBY9PPQ4GS/packages/rn-dev-agent-core/dist/session/tool-profiles.js';
import { createRestartHandler } from '/Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZDWXDBH6X2YFDCBY9PPQ4GS/packages/rn-dev-agent-core/dist/tools/restart.js';

async function spawnStubbornRunner() {
  const shell = existsSync('/bin/zsh') ? '/bin/zsh' : '/bin/sh';
  const holder = spawn(shell, ['-c', '{ trap "" TERM; exec sleep 300; } & echo $!; sleep 60'], {
    stdio: ['ignore', 'pipe', 'ignore'], detached: true,
  });
  holder.stdout.setEncoding('utf8');
  let out = '';
  const pid = await new Promise((res, rej) => {
    const t = setTimeout(() => rej(new Error('no pid')), 5000);
    holder.stdout.on('data', (c) => { out += c; const n = Number(out.trim());
      if (Number.isSafeInteger(n) && n > 0) { clearTimeout(t); res(n); } });
  });
  const birth = probeProcessBirth(pid);
  return { pid, processBirth: birth.status === 'present' ? birth.birth.token : '',
    dispose: () => { try { process.kill(-holder.pid, 'SIGKILL'); } catch {} holder.stdout.destroy(); } };
}

const profile = authorityProfileFor('cdp_restart', { hardReset: true, platform: 'ios' });
console.log('cdp_restart hardReset=true required authority axes:', JSON.stringify(profile.axes));
console.log('  -> R (runner) is required, so the runner-UNBOUND state is refused by the gate by construction.');
console.log('  -> therefore the runner-BOUND state is the only candidate for a reachable cold start.\n');

const runner = await spawnStubbornRunner();
const binding = { platform: 'ios', deviceId: 'A1B2C3D4-1111-2222-3333-444455556666',
  pid: runner.pid, processBirth: runner.processBirth, instanceId: 'runner-707',
  capability: 'runner-capability-707' };
console.log(`bound iOS runner stub: pid=${runner.pid} (SIGTERM-resistant, lingers unreaped as a zombie after death)`);

const client = { metroPort: 8081, isConnected: false, connectedTarget: { platform: 'ios' },
  disconnect: async () => {}, connectExact: async function () { this.isConnected = true; } };
let unbound = false;
const restart = createRestartHandler(() => client, () => {}, () => client, {
  stopFastRunner: async () => { await stopBoundRunner(binding); },
  unbindRunner: () => { unbound = true; },
  execFile: async () => ({ stdout: '', stderr: '' }),
  sleep: async () => {}, probeAppInstalled: async () => true,
  resetDetachedBudget: () => {}, resolveExactTargetId: async () => 'target-707',
});

console.log('\n$ cdp_restart { hardReset: true, platform: "ios", deviceId: "A1B2C3D4-...", appId: "com.example.app", metroPort: 8081 }');
const started = Date.now();
let envelope;
try {
  envelope = await restart({ hardReset: true, platform: 'ios', deviceId: binding.deviceId,
    appId: 'com.example.app', metroPort: 8081 });
} finally { runner.dispose(); }
console.log(JSON.stringify(JSON.parse(envelope.content[0].text), null, 2));
console.log(`\nelapsed: ${Date.now() - started}ms`);
console.log('runner released (unbindRunner called):', unbound);
let alive = true;
try { process.kill(runner.pid, 0); } catch { alive = false; }
console.log(`runner pid ${runner.pid} still runnable afterwards:`, alive === false ? 'no (actually stopped)' : 'YES');
```
</details>
<details>
<summary>Evidence: Ownership-safety probe harness (injected dependencies)</summary>

```text
import { stopBoundRunner } from '/Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZDWXDBH6X2YFDCBY9PPQ4GS/packages/rn-dev-agent-core/dist/session/process-cleanup.js';
const mine = { pid: 4242, processBirth: 'birth-mine', platform: 'ios', deviceId: 'D', instanceId: 'i', capability: 'c' };
async function scenario(name, tokenAfterGrace) {
  const signals = [];
  let calls = 0;
  const probe = () => {
    calls += 1;
    const token = calls <= 2 ? 'birth-mine' : tokenAfterGrace;
    return { status: 'present', birth: { token } };
  };
  try {
    await stopBoundRunner(mine, probe, (pid, sig) => signals.push(`${sig}->pid ${pid}`), 2000, async () => ({ stdout: '', stderr: '' }), 5);
    console.log(`${name}\n  signals sent: ${JSON.stringify(signals)}\n  result: stop accepted\n`);
  } catch (e) {
    console.log(`${name}\n  signals sent: ${JSON.stringify(signals)}\n  result: refused -> ${e.message}\n`);
  }
}
console.log('Ownership safety: escalation re-probes and only SIGKILLs while the pid still carries THIS binding\'s birth token.\n');
await scenario('[A] pid still carries my runner\'s birth token after the grace window', 'birth-mine');
await scenario('[B] pid was recycled to someone else between polls (different birth token)', 'birth-someone-else');
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `packages/rn-dev-agent-core/src/session/process-cleanup.ts:356` - The new escalation calls `signalProcess(pid, &#39;SIGKILL&#39;)` unguarded (process-cleanup.ts:356). If the runner exits and is reaped by its parent in the window between the escalation re-probe at line 351 and this call, `process.kill` throws `ESRCH` (or `EPERM`), which propagates out of `stopBoundRunner` as a plain Error rather than a SessionAuthorityError. `createRestartHandler` catches it and returns `RUNNER_ADOPTION_REQUIRED: cdp_restart retained runner authority because exact shutdown was not proven: kill ESRCH` — reintroducing the #707 symptom for a stop that actually succeeded. This file&#39;s own signal helper (process-cleanup.ts:66-72) and the sibling `reapStaleFastRunner` (rn-fast-runner-client.ts:1352-1368) both wrap SIGTERM and SIGKILL in try/catch for exactly this race. Wrap the SIGKILL (and, while there, the SIGTERM at line 339) and let the subsequent `waitForExactStopped` be the sole arbiter of whether the stop was proven.
- ℹ️ `packages/rn-dev-agent-core/test/unit/session/gh-707-hard-reset-cold-start.test.ts:117` - The regression test&#39;s `stopFastRunner` stub comments that it &#34;Mirrors how index.ts wires cdp_restart to the session-bound runner&#34; but only calls `stopBoundRunner(binding)`; index.ts:3296-3297 calls `stopBoundRunner(runner)` followed by `clearFastRunnerAfterVerifiedStop(runner)`, which can itself throw `RUNNER_ADOPTION_REQUIRED` (rn-fast-runner-client.ts:893, 906, 909). A future regression originating in that second half would not be caught by this test despite its stated claim. Not a defect in the fix — `clearFastRunnerAfterVerifiedStop` does no process probing, so it is not part of the #707 cause — and stubbing it out avoids touching module-global runner state and the user-local state file, so this is a fidelity note rather than a required change.

🔧 Fix: tolerate already-dead target when signalling bound runner
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`yarn build` in packages/rn-dev-agent-core (committed dist rebuilt byte-identical from src — `git status` clean for dist)</code>
- <code>`node --test test/unit/session/gh-707-hard-reset-cold-start.test.ts` — the new #707 regression file, including the ownership-safety case I added</code>
- <code>`node --test test/unit/session/process-birth.test.ts` — injected-dependency cases pinning zombie→absent on darwin and linux</code>
- <code>`node --test test/unit/session/process-cleanup.test.ts test/unit/session/startup-dead-owner-cleanup.test.ts test/unit/session/new-session-authority-recovery.test.ts test/unit/session/supervisor-authority.test.ts test/unit/tools/restart.test.ts` — the other stopBoundRunner/restart callers (72 tests, all pass)</code>
- <code>Manual end-to-end harness: spawned a real SIGTERM-resistant, unreaped-zombie runner stub and drove `createRestartHandler({hardReset: true, platform: &#39;ios&#39;, ...})` through `stopBoundRunner`, capturing the raw tool envelope</code>
- <code>Ablation A: reverted the zombie→absent probe rule in dist (`&#39;-o&#39;,&#39;pid=,state=&#39;` → `&#39;-o&#39;,&#39;pid=&#39;`) — reproduced `RUNNER_ADOPTION_REQUIRED: runner process did not stop before the cleanup deadline; shutdown identity is unknown` verbatim; regression test failed</code>
- <code>Ablation B: removed the `signalTolerated(&#39;SIGKILL&#39;)` escalation in dist — reproduced `RUNNER_ADOPTION_REQUIRED: runner process did not stop before the cleanup deadline` verbatim; regression test failed</code>
- <code>Ablation C: removed the `escalation.birth.token === expectedBirth` ownership guard in dist — confirmed no committed test caught it, then confirmed the newly added case does</code>
- `Ownership-safety probe with injected dependencies: SIGKILL is sent only while the pid still carries the binding's birth token; a pid recycled inside the grace window receives SIGTERM only`
- <code>`git status --porcelain` — worktree clean apart from the intentional test addition; all dist ablations restored</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
