### PR TITLE
fix(core): distinguish a broken idb client from a missing one

### DIFF
--- a/.changeset/idb-broken-client-verdict.md
+++ b/.changeset/idb-broken-client-verdict.md
@@ -1,0 +1,6 @@
+---
+'rn-dev-agent-core': patch
+'rn-dev-agent-plugin': patch
+---
+
+Report an installed-but-crashing fb-idb client as an interpreter incompatibility instead of looping on an "install idb" hint that reinstalls the same broken combination (#578).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,12 @@ jobs:
       - name: MCP upgrade-notice + bridge-probe guard
         run: bash scripts/test/mcp-upgrade-notice.test.sh
 
+      # GH#578: an installed-but-crashing idb client must be reported as an
+      # interpreter incompatibility, never as "idb missing" with an install
+      # hint that reinstalls the same broken combination.
+      - name: ensure-idb client-state guard
+        run: bash scripts/test/ensure-idb.test.sh
+
       # GH#432: the freshness gate is itself tested (house rule for CI guards).
       - name: Dist-freshness guard unit test
         run: bash scripts/test/check-dist-fresh.test.sh

--- a/apps/docs-site/src/content/docs/commands/observe.mdx
+++ b/apps/docs-site/src/content/docs/commands/observe.mdx
@@ -42,7 +42,7 @@ The page is a three-pane layout:
 | Pane | Contents |
 |------|----------|
 | **Timeline** (left) | Every tool call as it happens — colour-coded by family (interaction, introspection, navigation, lifecycle, testing), with duration, success/failure, and self-healing "ghost" markers. Filter by family, free-text search, or errors-only. Click an event to inspect its arguments and (redacted) payload; events that produced a screenshot show it inline. |
-| **Device mirror** (middle) | A live mirror of the simulator/emulator screen. iOS uses `idb video-stream` when `idb` + `idb-companion` are installed, falling back to a `simctl` screenshot loop otherwise; Android streams `adb screenrecord` through `ffmpeg`. The current route is overlaid as it changes. |
+| **Device mirror** (middle) | A live mirror of the simulator/emulator screen. iOS uses `idb video-stream` when `idb` + `idb-companion` are installed and the client actually runs, falling back to a `simctl` screenshot loop otherwise — an installed-but-crashing client is reported as an interpreter incompatibility, not as a missing install; Android streams `adb screenrecord` through `ffmpeg`. The current route is overlaid as it changes. |
 | **State** (right) | Five tabs: **Route** (latest navigation state), **Store** (latest Zustand/Redux snapshot), **Tree** (latest component tree), **Actions**, and **E2E**. The first three update whenever the agent reads that state — you're seeing exactly what the agent saw. |
 
 ## Using observe with actions

--- a/packages/claude-plugin/commands/doctor.md
+++ b/packages/claude-plugin/commands/doctor.md
@@ -18,10 +18,13 @@ For **linked-worktree action inheritance**, resolve the RN app root and run the 
 
 For **idb**, require both a healthy `idb --help` and `idb_companion`; an active
 install PID is INSTALLING. A client on PATH whose `idb --help` fails is BROKEN,
-not MISSING — report the interpreter incompatibility (GH#578) and the pinned
-repair command, never a bare `pipx install fb-idb`. Otherwise report MISSING and
-the documented install command. This row is YELLOW because mirroring has a
-screenshot fallback.
+not MISSING — report it as installed but not responding, naming the Python 3.14
+interpreter incompatibility as the *probable* cause rather than a certainty (the
+probe cannot separate a crash from a timeout or EACCES), and give the pinned
+repair command, never a bare `pipx install fb-idb`. On a machine with no
+supported interpreter, prefix that command with `brew install python@3.13 &&`.
+Otherwise report MISSING and the documented install command. This row is YELLOW
+because mirroring has a screenshot fallback.
 
 For runner provenance, inspect the runner artifact/state metadata documented by
 `rn-setup`. For helpers, use a narrow gated CDP read. For CDP auto-reconnect,

--- a/packages/claude-plugin/commands/doctor.md
+++ b/packages/claude-plugin/commands/doctor.md
@@ -17,8 +17,11 @@ auto-reconnect configuration from passive `cdp_status`.
 For **linked-worktree action inheritance**, resolve the RN app root and run the packaged `worktree-inheritance.js plan --host claude --app-root <app> --json`. Report `.rn-agent/actions` as tracked, inherited, missing, legacy-migration-needed, unsafe, or refused. Also report `hook status`. Never apply, repair, install a hook, print a private source path, or inspect an action body from doctor.
 
 For **idb**, require both a healthy `idb --help` and `idb_companion`; an active
-install PID is INSTALLING, otherwise report MISSING and the documented install
-command. This row is YELLOW because mirroring has a screenshot fallback.
+install PID is INSTALLING. A client on PATH whose `idb --help` fails is BROKEN,
+not MISSING — report the interpreter incompatibility (GH#578) and the pinned
+repair command, never a bare `pipx install fb-idb`. Otherwise report MISSING and
+the documented install command. This row is YELLOW because mirroring has a
+screenshot fallback.
 
 For runner provenance, inspect the runner artifact/state metadata documented by
 `rn-setup`. For helpers, use a narrow gated CDP read. For CDP auto-reconnect,

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -56566,6 +56566,7 @@ function getBoundDirectoryJournalKey(layout = createAuthorityStateLayout()) {
 // packages/rn-dev-agent-core/dist/session/bound-directory.js
 var WAIT_BUFFER = new Int32Array(new SharedArrayBuffer(4));
 var WORKER_READY_TIMEOUT_MS = 3e4;
+var WORKER_OPERATION_TIMEOUT_MS = 3e4;
 var BOUND_DIRECTORY_LIFECYCLE_MONITOR = String.raw`
 const fs = require('node:fs');
 const path = require('node:path');
@@ -57861,7 +57862,7 @@ function runBoundOperation(directory, request2, dependencies = {}) {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: bound directory path changed");
   }
   try {
-    const result = sendOperation(directory, request2, dependencies.timeoutMs ?? 5e3);
+    const result = sendOperation(directory, request2, dependencies.timeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
     if (!result.ok)
       throwOperationFailure(result);
     if (request2.operation === "cas" && result.cleanupPending) {
@@ -57875,7 +57876,7 @@ function runBoundOperation(directory, request2, dependencies = {}) {
           cleanupRecoveryDelayMs: dependencies.cleanupRecoveryDelayMs ?? 0,
           journal: request2.journal,
           writes: request2.writes
-        }, dependencies.recoveryTimeoutMs ?? 5e3);
+        }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
         if (!cleanup.ok)
           throwOperationFailure(cleanup);
         if (!cleanup.committed) {
@@ -57892,7 +57893,7 @@ function runBoundOperation(directory, request2, dependencies = {}) {
               failCleanupRecovery: dependencies.failCleanupRecovery ?? false,
               journal: request2.journal,
               writes: request2.writes
-            }, dependencies.recoveryTimeoutMs ?? 5e3);
+            }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
             if (!cleanup.ok)
               throwOperationFailure(cleanup);
             if (!cleanup.committed) {
@@ -57924,7 +57925,7 @@ function runBoundOperation(directory, request2, dependencies = {}) {
           journal: request2.journal,
           writes: request2.writes,
           recoveryDelayAfterUnlinkMs: dependencies.recoveryDelayAfterUnlinkMs ?? 0
-        }, dependencies.recoveryTimeoutMs ?? 5e3);
+        }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
         if (!recovery.ok)
           throwOperationFailure(recovery);
         break;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -80086,9 +80086,9 @@ var RestartGate = class {
     return this.exits.length < this.limit;
   }
 };
-var IDB_INSTALL_COMMAND = "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 fb-idb";
+var IDB_INSTALL_COMMAND = "brew install python@3.13 && brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb";
 var SIMCTL_HINT = `install idb for smoother mirroring (${IDB_INSTALL_COMMAND})`;
-var SIMCTL_BROKEN_IDB_HINT = "idb is installed but its client crashes on every invocation \u2014 fb-idb 1.1.7 needs asyncio.get_event_loop(), removed in Python 3.14. Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb";
+var SIMCTL_BROKEN_IDB_HINT = "idb is installed but did not respond successfully \u2014 most likely fb-idb 1.1.7 under Python 3.14, which removed the asyncio.get_event_loop() it needs. Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb";
 var IDB_HINT = `idb not found \u2014 ${IDB_INSTALL_COMMAND}`;
 var FFMPEG_HINT = "ffmpeg not found \u2014 run scripts/ensure-ffmpeg.sh or brew install ffmpeg";
 var sleep6 = (ms) => new Promise((resolve11) => setTimeout(resolve11, ms));

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -80086,8 +80086,10 @@ var RestartGate = class {
     return this.exits.length < this.limit;
   }
 };
-var SIMCTL_HINT = "install idb for smoother mirroring (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb)";
-var IDB_HINT = "idb not found \u2014 brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb";
+var IDB_INSTALL_COMMAND = "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 fb-idb";
+var SIMCTL_HINT = `install idb for smoother mirroring (${IDB_INSTALL_COMMAND})`;
+var SIMCTL_BROKEN_IDB_HINT = "idb is installed but its client crashes on every invocation \u2014 fb-idb 1.1.7 needs asyncio.get_event_loop(), removed in Python 3.14. Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb";
+var IDB_HINT = `idb not found \u2014 ${IDB_INSTALL_COMMAND}`;
 var FFMPEG_HINT = "ffmpeg not found \u2014 run scripts/ensure-ffmpeg.sh or brew install ffmpeg";
 var sleep6 = (ms) => new Promise((resolve11) => setTimeout(resolve11, ms));
 var scheduleAfter = (fn, delayMs) => {
@@ -80097,9 +80099,13 @@ var scheduleAfter = (fn, delayMs) => {
     setTimeout(fn, delayMs);
 };
 var defaultSpawn = (cmd, args) => spawn9(cmd, args, { stdio: ["pipe", "pipe", "pipe"] });
-async function detectIdb(execFileFn = execFile25) {
+async function probeIdbClient(execFileFn = execFile25) {
   return new Promise((resolve11) => {
-    execFileFn("idb", ["--help"], { timeout: 3e3 }, (err) => resolve11(!err));
+    execFileFn("idb", ["--help"], { timeout: 3e3 }, (err) => {
+      if (!err)
+        return resolve11("ready");
+      resolve11(isEnoent(err) ? "absent" : "broken");
+    });
   });
 }
 function isEnoent(err) {
@@ -80179,6 +80185,7 @@ var IosSimctlLoopSource = class {
   udid;
   pipeline = "simctl";
   nominalFps = 6;
+  degradedHint;
   active = false;
   inFlight = null;
   execJpeg;
@@ -80193,6 +80200,7 @@ var IosSimctlLoopSource = class {
     this.idleDelayMs = opts.idleDelayMs ?? 25;
     this.failurePauseMs = opts.failurePauseMs ?? 500;
     this.tmpPath = opts.tmpPath ?? (() => join47(tmpdir14(), "rn-mirror-simctl-" + process.pid + ".jpg"));
+    this.degradedHint = opts.degradedHint ?? SIMCTL_HINT;
   }
   start(sink) {
     this.active = true;
@@ -80213,7 +80221,7 @@ var IosSimctlLoopSource = class {
           break;
         if (!this.gate.record()) {
           if (this.active)
-            sink.onExit({ reason: "simctl screenshot failing", hint: SIMCTL_HINT });
+            sink.onExit({ reason: "simctl screenshot failing", hint: this.degradedHint });
           this.active = false;
           break;
         }
@@ -80366,8 +80374,12 @@ async function createMirrorSource(target, fps) {
   if (target.platform === "android") {
     return new AndroidScreenrecordSource(target.deviceId);
   }
-  const hasIdb = await detectIdb();
-  return hasIdb ? new IosIdbSource(target.deviceId, fps) : new IosSimctlLoopSource(target.deviceId);
+  const state = await probeIdbClient();
+  if (state === "ready")
+    return new IosIdbSource(target.deviceId, fps);
+  return new IosSimctlLoopSource(target.deviceId, {
+    degradedHint: state === "broken" ? SIMCTL_BROKEN_IDB_HINT : SIMCTL_HINT
+  });
 }
 
 // packages/rn-dev-agent-core/dist/observability/mirror/manager.js
@@ -80568,7 +80580,7 @@ var MirrorManager = class {
         deviceId: target.deviceId,
         pipeline: source.pipeline,
         fps: source.nominalFps,
-        hint: source.pipeline === "simctl" ? SIMCTL_HINT : void 0
+        hint: source.pipeline === "simctl" ? source.degradedHint ?? SIMCTL_HINT : void 0
       });
     }
     this.broadcast(frame);

--- a/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -15109,6 +15109,7 @@ import { tmpdir } from "node:os";
 import { join as join7 } from "node:path";
 var WAIT_BUFFER = new Int32Array(new SharedArrayBuffer(4));
 var WORKER_READY_TIMEOUT_MS = 3e4;
+var WORKER_OPERATION_TIMEOUT_MS = 3e4;
 var BOUND_DIRECTORY_LIFECYCLE_MONITOR = String.raw`
 const fs = require('node:fs');
 const path = require('node:path');
@@ -16404,7 +16405,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: bound directory path changed");
   }
   try {
-    const result = sendOperation(directory, request, dependencies.timeoutMs ?? 5e3);
+    const result = sendOperation(directory, request, dependencies.timeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
     if (!result.ok)
       throwOperationFailure(result);
     if (request.operation === "cas" && result.cleanupPending) {
@@ -16418,7 +16419,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
           cleanupRecoveryDelayMs: dependencies.cleanupRecoveryDelayMs ?? 0,
           journal: request.journal,
           writes: request.writes
-        }, dependencies.recoveryTimeoutMs ?? 5e3);
+        }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
         if (!cleanup.ok)
           throwOperationFailure(cleanup);
         if (!cleanup.committed) {
@@ -16435,7 +16436,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
               failCleanupRecovery: dependencies.failCleanupRecovery ?? false,
               journal: request.journal,
               writes: request.writes
-            }, dependencies.recoveryTimeoutMs ?? 5e3);
+            }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
             if (!cleanup.ok)
               throwOperationFailure(cleanup);
             if (!cleanup.committed) {
@@ -16467,7 +16468,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
           journal: request.journal,
           writes: request.writes,
           recoveryDelayAfterUnlinkMs: dependencies.recoveryDelayAfterUnlinkMs ?? 0
-        }, dependencies.recoveryTimeoutMs ?? 5e3);
+        }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
         if (!recovery.ok)
           throwOperationFailure(recovery);
         break;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -82584,9 +82584,9 @@ var init_sources = __esm({
         return this.exits.length < this.limit;
       }
     };
-    IDB_INSTALL_COMMAND = "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 fb-idb";
+    IDB_INSTALL_COMMAND = "brew install python@3.13 && brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb";
     SIMCTL_HINT = `install idb for smoother mirroring (${IDB_INSTALL_COMMAND})`;
-    SIMCTL_BROKEN_IDB_HINT = "idb is installed but its client crashes on every invocation \u2014 fb-idb 1.1.7 needs asyncio.get_event_loop(), removed in Python 3.14. Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb";
+    SIMCTL_BROKEN_IDB_HINT = "idb is installed but did not respond successfully \u2014 most likely fb-idb 1.1.7 under Python 3.14, which removed the asyncio.get_event_loop() it needs. Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb";
     IDB_HINT = `idb not found \u2014 ${IDB_INSTALL_COMMAND}`;
     FFMPEG_HINT = "ffmpeg not found \u2014 run scripts/ensure-ffmpeg.sh or brew install ffmpeg";
     sleep6 = (ms) => new Promise((resolve11) => setTimeout(resolve11, ms));

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -12375,7 +12375,7 @@ function runBoundOperation(directory, request2, dependencies = {}) {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: bound directory path changed");
   }
   try {
-    const result = sendOperation(directory, request2, dependencies.timeoutMs ?? 5e3);
+    const result = sendOperation(directory, request2, dependencies.timeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
     if (!result.ok)
       throwOperationFailure(result);
     if (request2.operation === "cas" && result.cleanupPending) {
@@ -12389,7 +12389,7 @@ function runBoundOperation(directory, request2, dependencies = {}) {
           cleanupRecoveryDelayMs: dependencies.cleanupRecoveryDelayMs ?? 0,
           journal: request2.journal,
           writes: request2.writes
-        }, dependencies.recoveryTimeoutMs ?? 5e3);
+        }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
         if (!cleanup.ok)
           throwOperationFailure(cleanup);
         if (!cleanup.committed) {
@@ -12406,7 +12406,7 @@ function runBoundOperation(directory, request2, dependencies = {}) {
               failCleanupRecovery: dependencies.failCleanupRecovery ?? false,
               journal: request2.journal,
               writes: request2.writes
-            }, dependencies.recoveryTimeoutMs ?? 5e3);
+            }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
             if (!cleanup.ok)
               throwOperationFailure(cleanup);
             if (!cleanup.committed) {
@@ -12438,7 +12438,7 @@ function runBoundOperation(directory, request2, dependencies = {}) {
           journal: request2.journal,
           writes: request2.writes,
           recoveryDelayAfterUnlinkMs: dependencies.recoveryDelayAfterUnlinkMs ?? 0
-        }, dependencies.recoveryTimeoutMs ?? 5e3);
+        }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
         if (!recovery.ok)
           throwOperationFailure(recovery);
         break;
@@ -12761,13 +12761,14 @@ function retryBoundDirectoryCleanup(directory, obligation, dependencies = {}) {
   }
   directory.pendingCleanups.delete(obligation.transactionId);
 }
-var WAIT_BUFFER, WORKER_READY_TIMEOUT_MS, BOUND_DIRECTORY_LIFECYCLE_MONITOR, BOUND_DIRECTORY_TERMINATION_WATCHDOG, BOUND_DIRECTORY_ANCESTRY_MONITOR, BOUND_DIRECTORY_WORKER;
+var WAIT_BUFFER, WORKER_READY_TIMEOUT_MS, WORKER_OPERATION_TIMEOUT_MS, BOUND_DIRECTORY_LIFECYCLE_MONITOR, BOUND_DIRECTORY_TERMINATION_WATCHDOG, BOUND_DIRECTORY_ANCESTRY_MONITOR, BOUND_DIRECTORY_WORKER;
 var init_bound_directory = __esm({
   "packages/rn-dev-agent-core/dist/session/bound-directory.js"() {
     "use strict";
     init_state_root();
     WAIT_BUFFER = new Int32Array(new SharedArrayBuffer(4));
     WORKER_READY_TIMEOUT_MS = 3e4;
+    WORKER_OPERATION_TIMEOUT_MS = 3e4;
     BOUND_DIRECTORY_LIFECYCLE_MONITOR = String.raw`
 const fs = require('node:fs');
 const path = require('node:path');

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -82519,9 +82519,13 @@ import { spawn as spawn9, execFile as execFile25 } from "node:child_process";
 import { readFile as readFile2, unlink } from "node:fs/promises";
 import { tmpdir as tmpdir14 } from "node:os";
 import { join as join50 } from "node:path";
-async function detectIdb(execFileFn = execFile25) {
+async function probeIdbClient(execFileFn = execFile25) {
   return new Promise((resolve11) => {
-    execFileFn("idb", ["--help"], { timeout: 3e3 }, (err) => resolve11(!err));
+    execFileFn("idb", ["--help"], { timeout: 3e3 }, (err) => {
+      if (!err)
+        return resolve11("ready");
+      resolve11(isEnoent(err) ? "absent" : "broken");
+    });
   });
 }
 function isEnoent(err) {
@@ -82551,10 +82555,14 @@ async function createMirrorSource(target, fps) {
   if (target.platform === "android") {
     return new AndroidScreenrecordSource(target.deviceId);
   }
-  const hasIdb = await detectIdb();
-  return hasIdb ? new IosIdbSource(target.deviceId, fps) : new IosSimctlLoopSource(target.deviceId);
+  const state = await probeIdbClient();
+  if (state === "ready")
+    return new IosIdbSource(target.deviceId, fps);
+  return new IosSimctlLoopSource(target.deviceId, {
+    degradedHint: state === "broken" ? SIMCTL_BROKEN_IDB_HINT : SIMCTL_HINT
+  });
 }
-var RestartGate, SIMCTL_HINT, IDB_HINT, FFMPEG_HINT, sleep6, scheduleAfter, defaultSpawn, IosIdbSource, IosSimctlLoopSource, AndroidScreenrecordSource;
+var RestartGate, IDB_INSTALL_COMMAND, SIMCTL_HINT, SIMCTL_BROKEN_IDB_HINT, IDB_HINT, FFMPEG_HINT, sleep6, scheduleAfter, defaultSpawn, IosIdbSource, IosSimctlLoopSource, AndroidScreenrecordSource;
 var init_sources = __esm({
   "packages/rn-dev-agent-core/dist/observability/mirror/sources.js"() {
     "use strict";
@@ -82576,8 +82584,10 @@ var init_sources = __esm({
         return this.exits.length < this.limit;
       }
     };
-    SIMCTL_HINT = "install idb for smoother mirroring (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb)";
-    IDB_HINT = "idb not found \u2014 brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb";
+    IDB_INSTALL_COMMAND = "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 fb-idb";
+    SIMCTL_HINT = `install idb for smoother mirroring (${IDB_INSTALL_COMMAND})`;
+    SIMCTL_BROKEN_IDB_HINT = "idb is installed but its client crashes on every invocation \u2014 fb-idb 1.1.7 needs asyncio.get_event_loop(), removed in Python 3.14. Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb";
+    IDB_HINT = `idb not found \u2014 ${IDB_INSTALL_COMMAND}`;
     FFMPEG_HINT = "ffmpeg not found \u2014 run scripts/ensure-ffmpeg.sh or brew install ffmpeg";
     sleep6 = (ms) => new Promise((resolve11) => setTimeout(resolve11, ms));
     scheduleAfter = (fn, delayMs) => {
@@ -82661,6 +82671,7 @@ var init_sources = __esm({
       udid;
       pipeline = "simctl";
       nominalFps = 6;
+      degradedHint;
       active = false;
       inFlight = null;
       execJpeg;
@@ -82675,6 +82686,7 @@ var init_sources = __esm({
         this.idleDelayMs = opts.idleDelayMs ?? 25;
         this.failurePauseMs = opts.failurePauseMs ?? 500;
         this.tmpPath = opts.tmpPath ?? (() => join50(tmpdir14(), "rn-mirror-simctl-" + process.pid + ".jpg"));
+        this.degradedHint = opts.degradedHint ?? SIMCTL_HINT;
       }
       start(sink) {
         this.active = true;
@@ -82695,7 +82707,7 @@ var init_sources = __esm({
               break;
             if (!this.gate.record()) {
               if (this.active)
-                sink.onExit({ reason: "simctl screenshot failing", hint: SIMCTL_HINT });
+                sink.onExit({ reason: "simctl screenshot failing", hint: this.degradedHint });
               this.active = false;
               break;
             }
@@ -83030,7 +83042,7 @@ var init_manager = __esm({
             deviceId: target.deviceId,
             pipeline: source.pipeline,
             fps: source.nominalFps,
-            hint: source.pipeline === "simctl" ? SIMCTL_HINT : void 0
+            hint: source.pipeline === "simctl" ? source.degradedHint ?? SIMCTL_HINT : void 0
           });
         }
         this.broadcast(frame);

--- a/packages/claude-plugin/rn-dev-agent-core/dist/workflow-check.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/workflow-check.js
@@ -8570,6 +8570,7 @@ function getBoundDirectoryJournalKey(layout = createAuthorityStateLayout()) {
 // packages/rn-dev-agent-core/dist/session/bound-directory.js
 var WAIT_BUFFER = new Int32Array(new SharedArrayBuffer(4));
 var WORKER_READY_TIMEOUT_MS = 3e4;
+var WORKER_OPERATION_TIMEOUT_MS = 3e4;
 var BOUND_DIRECTORY_LIFECYCLE_MONITOR = String.raw`
 const fs = require('node:fs');
 const path = require('node:path');
@@ -9865,7 +9866,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: bound directory path changed");
   }
   try {
-    const result = sendOperation(directory, request, dependencies.timeoutMs ?? 5e3);
+    const result = sendOperation(directory, request, dependencies.timeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
     if (!result.ok)
       throwOperationFailure(result);
     if (request.operation === "cas" && result.cleanupPending) {
@@ -9879,7 +9880,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
           cleanupRecoveryDelayMs: dependencies.cleanupRecoveryDelayMs ?? 0,
           journal: request.journal,
           writes: request.writes
-        }, dependencies.recoveryTimeoutMs ?? 5e3);
+        }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
         if (!cleanup.ok)
           throwOperationFailure(cleanup);
         if (!cleanup.committed) {
@@ -9896,7 +9897,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
               failCleanupRecovery: dependencies.failCleanupRecovery ?? false,
               journal: request.journal,
               writes: request.writes
-            }, dependencies.recoveryTimeoutMs ?? 5e3);
+            }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
             if (!cleanup.ok)
               throwOperationFailure(cleanup);
             if (!cleanup.committed) {
@@ -9928,7 +9929,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
           journal: request.journal,
           writes: request.writes,
           recoveryDelayAfterUnlinkMs: dependencies.recoveryDelayAfterUnlinkMs ?? 0
-        }, dependencies.recoveryTimeoutMs ?? 5e3);
+        }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
         if (!recovery.ok)
           throwOperationFailure(recovery);
         break;

--- a/packages/claude-plugin/scripts/ensure-idb.sh
+++ b/packages/claude-plugin/scripts/ensure-idb.sh
@@ -266,11 +266,11 @@ if [ "${LAST_STATUS:-}" = "failed" ] && [ -n "${LAST_TS:-}" ]; then
     # This line is what the developer reads for the next 24h, so it must carry
     # the cause the worker determined rather than defaulting to an install
     # command that, for the shim case, already succeeded.
-    if [ "${LAST_CAUSE:-}" = "path-shim" ]; then
+    if [ "$CLIENT_STATE" = ready ]; then
+      echo "idb-companion install failed recently — retrying after backoff (manual: $(companion_command), log: $LOG)"
+    elif [ "$CLIENT_STATE" = absent ] && [ "${LAST_CAUSE:-}" = "path-shim" ]; then
       path_shim_explanation
       echo "Retrying the install after backoff anyway (log: $LOG)."
-    elif [ "$CLIENT_STATE" = ready ]; then
-      echo "idb-companion install failed recently — retrying after backoff (manual: $(companion_command), log: $LOG)"
     else
       echo "idb install failed recently — retrying after backoff (manual: $(install_command), log: $LOG)"
     fi

--- a/packages/claude-plugin/scripts/ensure-idb.sh
+++ b/packages/claude-plugin/scripts/ensure-idb.sh
@@ -102,6 +102,12 @@ install_command() {
   fi
 }
 
+# The companion half alone: a client that already works must never be told to
+# reinstall fb-idb.
+companion_command() {
+  echo "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion"
+}
+
 # The probe only observes a non-zero exit (a timeout or EACCES lands here too),
 # so the cause is stated as probable rather than asserted as fact.
 incompatible_explanation() {
@@ -219,7 +225,7 @@ if [ "$CLIENT_STATE" != ready ] && [ "${LAST_STATUS:-}" = "incompatible" ] && [ 
     echo "idb is not installed, and no supported Python is available to install it (need one of: $SUPPORTED_PYTHONS)."
     echo "Recover with: $(install_command)"
   fi
-  echo "Not retrying until the installed Python interpreters change (log: $LOG). Mirroring stays on the ~6fps simctl tier."
+  echo "Not retrying until the installed Python interpreters change — delete $MARKER to force a retry (e.g. after a newer fb-idb ships). Log: $LOG. Mirroring stays on the ~6fps simctl tier."
   exit 0
 fi
 
@@ -230,8 +236,13 @@ if [ "$CLIENT_STATE" = broken ]; then
     exit 0
   fi
 elif ! command -v brew >/dev/null 2>&1; then
-  echo "idb not installed (optional — enables 20-30fps screen mirroring instead of ~6fps)."
-  echo "Install manually: $(install_command)"
+  if [ "$CLIENT_STATE" = ready ]; then
+    echo "idb-companion not installed (the idb client works; the companion is the missing half)."
+    echo "Install manually: $(companion_command)"
+  else
+    echo "idb not installed (optional — enables 20-30fps screen mirroring instead of ~6fps)."
+    echo "Install manually: $(install_command)"
+  fi
   exit 0
 fi
 
@@ -258,6 +269,8 @@ if [ "${LAST_STATUS:-}" = "failed" ] && [ -n "${LAST_TS:-}" ]; then
     if [ "${LAST_CAUSE:-}" = "path-shim" ]; then
       path_shim_explanation
       echo "Retrying the install after backoff anyway (log: $LOG)."
+    elif [ "$CLIENT_STATE" = ready ]; then
+      echo "idb-companion install failed recently — retrying after backoff (manual: $(companion_command), log: $LOG)"
     else
       echo "idb install failed recently — retrying after backoff (manual: $(install_command), log: $LOG)"
     fi
@@ -270,6 +283,10 @@ fi
 # they then prevent.
 if [ "$CLIENT_STATE" = absent ]; then
   NOTICE="idb missing — installing in background ($(install_command)). Log: $LOG"
+elif [ "$CLIENT_STATE" = ready ]; then
+  # The client already works; the worker's own guard skips pipx entirely here,
+  # so promising an interpreter repair would describe work that never runs.
+  NOTICE="idb-companion missing — installing it in background ($(companion_command)). Log: $LOG"
 else
   NOTICE="Repairing in the background under a supported interpreter ($SUPPORTED_PYTHONS). Manual: $(install_command). Log: $LOG"
 fi

--- a/packages/claude-plugin/scripts/ensure-idb.sh
+++ b/packages/claude-plugin/scripts/ensure-idb.sh
@@ -122,26 +122,37 @@ if [ "${1:-}" = "--install-worker" ]; then
       # newest, which is exactly the one that produces a crashing client.
       # Walk the supported interpreters until one yields a healthy client.
       tried=""
+      installed=""
       for py in $SUPPORTED_PYTHONS; do
         command -v "$py" >/dev/null 2>&1 || continue
         echo "installing fb-idb under $py"
         tried="$tried $py"
         pipx install --python "$py" --force fb-idb || continue
+        installed=yes
         [ "$(idb_client_state)" = ready ] && break
       done
       if [ "$(idb_client_state)" != ready ]; then
-        # No available interpreter produces a working client. Retrying cannot
-        # change that, so record a distinct verdict with the interpreter
-        # fingerprint and stop — the foreground path reports the truth instead
-        # of re-showing an install hint the developer has already followed.
-        # A brew failure earlier in this run stays `failed`: that one IS worth
-        # retrying, and its backoff must not be replaced by a terminal verdict.
-        [ "$status" = failed ] || status=incompatible
-        incompatible_explanation
-        if [ -n "$tried" ]; then
-          echo "tried:$tried — none produced a working client; the mirror stays on the simctl tier"
+        if [ -n "$tried" ] && [ -z "$installed" ]; then
+          # Every pinned install command itself failed (network, PyPI, pipx).
+          # That is transient, so it must stay retryable: the terminal verdict
+          # requires evidence of incompatibility, not merely absence of success.
+          status=failed
+          echo "tried:$tried — every pinned install failed; retrying after backoff"
         else
-          echo "no supported Python found (need one of: $SUPPORTED_PYTHONS). Install one, then re-run: $(install_command)"
+          # Either a pinned install succeeded and the client still crashes, or
+          # no supported interpreter exists at all. Retrying cannot change that,
+          # so record a distinct verdict with the interpreter fingerprint and
+          # stop — the foreground path reports the truth instead of re-showing
+          # an install hint the developer has already followed.
+          # A brew failure earlier in this run stays `failed`: that one IS worth
+          # retrying, and its backoff must not be replaced by a terminal verdict.
+          [ "$status" = failed ] || status=incompatible
+          if [ -n "$tried" ]; then
+            incompatible_explanation
+            echo "tried:$tried — none produced a working client; the mirror stays on the simctl tier"
+          else
+            echo "no supported Python found (need one of: $SUPPORTED_PYTHONS). Install one, then re-run: $(install_command)"
+          fi
         fi
       fi
     else
@@ -169,10 +180,13 @@ if [ -f "$MARKER" ]; then
   read -r LAST_STATUS LAST_TS LAST_FP < "$MARKER" 2>/dev/null || LAST_STATUS=""
 fi
 
-# The incompatible verdict outranks every other branch: it is the one state
-# where an install hint is actively wrong (GH#578). It holds until the set of
-# installed interpreters changes; delete "$MARKER" to force a retry.
-if [ "${LAST_STATUS:-}" = "incompatible" ] && [ "${LAST_FP:-}" = "$(python_fingerprint)" ]; then
+# The incompatible verdict outranks every other branch while the client is
+# actually broken: that is the one state where an install hint is actively
+# wrong (GH#578). It holds until the set of installed interpreters changes;
+# delete "$MARKER" to force a retry. A verdict may never contradict the live
+# probe — a client that now reads ready or absent falls through to the normal
+# path so the missing piece (companion, or the client itself) still gets fixed.
+if [ "$CLIENT_STATE" = broken ] && [ "${LAST_STATUS:-}" = "incompatible" ] && [ "${LAST_FP:-}" = "$(python_fingerprint)" ]; then
   incompatible_explanation
   if first_supported_python >/dev/null; then
     echo "Recover with: $(install_command)"
@@ -189,7 +203,6 @@ if [ "$CLIENT_STATE" = broken ]; then
     echo "Recover with: $(install_command)"
     exit 0
   fi
-  echo "Repairing in the background under a supported interpreter ($SUPPORTED_PYTHONS). Manual: $(install_command)"
 elif ! command -v brew >/dev/null 2>&1; then
   echo "idb not installed (optional — enables 20-30fps screen mirroring instead of ~6fps)."
   echo "Install manually: $(install_command)"
@@ -218,10 +231,13 @@ if [ "${LAST_STATUS:-}" = "failed" ] && [ -n "${LAST_TS:-}" ]; then
   fi
 fi
 
+# Only this path actually spawns, so the "repairing" claim belongs here — the
+# pidfile and backoff guards above must not be preceded by a promise of work
+# they then prevent.
 if [ "$CLIENT_STATE" = absent ]; then
   NOTICE="idb missing — installing in background ($(install_command)). Log: $LOG"
 else
-  NOTICE="idb repair running in background. Log: $LOG"
+  NOTICE="Repairing in the background under a supported interpreter ($SUPPORTED_PYTHONS). Manual: $(install_command). Log: $LOG"
 fi
 
 if [ "${RN_AGENT_IDB_DRY_SPAWN:-}" = "1" ]; then

--- a/packages/claude-plugin/scripts/ensure-idb.sh
+++ b/packages/claude-plugin/scripts/ensure-idb.sh
@@ -4,23 +4,34 @@
 # The mirror's iOS fast path is `idb video-stream` (20-30fps MJPEG); without
 # idb it degrades to a ~6fps `simctl screenshot` loop. idb needs two pieces
 # (idb-companion lives in the facebook/fb tap, not homebrew-core):
-#   brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion   (the macOS daemon)
-#   pipx install fb-idb                                   (the Python CLI client)
+#   brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion
+#   pipx install --python python3.13 fb-idb                (the Python CLI client)
+#
+# GH#578: the interpreter pin is load-bearing. fb-idb 1.1.7 calls
+# asyncio.get_event_loop() at CLI startup, which Python 3.14 removed, so a
+# bare `pipx install fb-idb` on a 3.14-default machine installs a client that
+# crashes on every invocation. This script therefore treats the client as
+# three distinct states — absent, ready, broken — and never prints an install
+# command that would recreate the broken combination.
 #
 # SessionStart contract (GH#252/B196: session start must be BOUNDED): this
-# script's foreground path only does `command -v` checks and (at most) spawns
-# ONE detached worker — it NEVER runs brew/pipx inline. The worker is
-# nohup'd + disown'd with all stdio detached so the SessionStart hook's
-# timeout cannot be held open by inherited FDs.
+# script's foreground path only does `command -v` / `idb --help` checks and
+# (at most) spawns ONE detached worker — it NEVER runs brew/pipx inline. The
+# worker is nohup'd + disown'd with all stdio detached so the SessionStart
+# hook's timeout cannot be held open by inherited FDs.
 #
 # Re-entry guards:
 #   - pidfile:      a live worker is never duplicated across session starts
 #   - last-attempt: a failed install is not retried for 24h (brew failures
 #     are usually environmental; hammering it every session start is noise)
+#   - incompatible verdict: once no available interpreter can produce a
+#     working client, retrying cannot succeed, so it stops until the set of
+#     installed Python interpreters changes (GH#578).
 #
 # Test seams (scripts/test/ensure-idb.test.sh):
 #   RN_AGENT_IDB_STATE_DIR   state dir      (default: ~/.rn-dev-agent/idb)
 #   RN_AGENT_IDB_UNAME       fake `uname -s`
+#   RN_AGENT_IDB_PYTHONS     override the supported-interpreter candidate list
 #   RN_AGENT_IDB_DRY_SPAWN=1 record the spawn to spawn.log instead of running
 #
 # Exit code: always 0 from the foreground path (mirror works without idb —
@@ -34,6 +45,10 @@ MARKER="$STATE_DIR/last-attempt"
 LOG="$STATE_DIR/install.log"
 BACKOFF_SECS=86400
 
+# Newest first. 3.14 is excluded on purpose: it is the interpreter that breaks
+# fb-idb 1.1.7. Add newer versions here once a compatible fb-idb release ships.
+SUPPORTED_PYTHONS="${RN_AGENT_IDB_PYTHONS:-python3.13 python3.12 python3.11}"
+
 OS="${RN_AGENT_IDB_UNAME:-$(uname -s)}"
 [ "$OS" = "Darwin" ] || exit 0
 
@@ -44,14 +59,51 @@ has_companion() {
   command -v idb_companion >/dev/null 2>&1 || command -v idb-companion >/dev/null 2>&1
 }
 
-# B269: PATH presence is not health — fb-idb installed under an incompatible
-# Python (e.g. 3.14) crashes on EVERY invocation (asyncio get_event_loop).
-# Treating such a client as "present" both skips repair AND poisons the
-# mirror's tier selection (B263). `idb --help` initializes the CLI without
-# contacting a companion, so it exits 0 for a healthy client and non-zero
-# for a broken one.
-idb_client_healthy() {
-  command -v idb >/dev/null 2>&1 && idb --help >/dev/null 2>&1
+# B269: PATH presence is not health. `idb --help` initializes the CLI without
+# contacting a companion, so it exits 0 for a healthy client and non-zero for
+# one crashing under an incompatible interpreter.
+idb_client_state() {
+  if ! command -v idb >/dev/null 2>&1; then
+    echo absent
+  elif idb --help >/dev/null 2>&1; then
+    echo ready
+  else
+    echo broken
+  fi
+}
+
+first_supported_python() {
+  for py in $SUPPORTED_PYTHONS; do
+    if command -v "$py" >/dev/null 2>&1; then
+      echo "$py"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# The only thing that can turn an "incompatible" verdict back into a solvable
+# problem is a change to the installed interpreters, so that is the fingerprint.
+python_fingerprint() {
+  local fp=""
+  for py in $SUPPORTED_PYTHONS; do
+    command -v "$py" >/dev/null 2>&1 && fp="$fp$py,"
+  done
+  echo "${fp:-none}"
+}
+
+install_command() {
+  local py
+  py="$(first_supported_python)" || py=""
+  if [ -n "$py" ]; then
+    echo "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python $py --force fb-idb"
+  else
+    echo "brew install python@3.13 && brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb"
+  fi
+}
+
+incompatible_explanation() {
+  echo "idb is installed but unusable: the fb-idb client crashes on every invocation — it calls asyncio.get_event_loop(), which Python 3.14 removed. Installing it again under the same interpreter reproduces this."
 }
 
 # --install-worker: the detached background job (never reached at SessionStart).
@@ -61,49 +113,82 @@ if [ "${1:-}" = "--install-worker" ]; then
   if ! has_companion; then
     brew tap facebook/fb && { brew trust facebook/fb >/dev/null 2>&1 || true; } && brew install idb-companion || status=failed
   fi
-  if ! idb_client_healthy; then
+  if [ "$(idb_client_state)" != ready ]; then
     if ! command -v pipx >/dev/null 2>&1; then
       brew install pipx && pipx ensurepath || status=failed
     fi
     if command -v pipx >/dev/null 2>&1; then
-      # A present-but-broken client must be replaced, not trusted (B269).
-      if command -v idb >/dev/null 2>&1; then
-        pipx uninstall fb-idb >/dev/null 2>&1 || true
-      fi
-      pipx install fb-idb || status=failed
-      if ! idb_client_healthy; then
-        # Never leave a crash-on-invocation client on PATH: it provides
-        # nothing and re-arms the B263 mirror failure. Uninstall and let the
-        # 24h backoff retry (a future fb-idb release may fix compatibility).
-        pipx uninstall fb-idb >/dev/null 2>&1 || true
-        status=failed
-        echo "fb-idb installed but the client crashes on invocation (incompatible Python?) — uninstalled; the mirror stays on the simctl tier"
+      # GH#578: never let pipx resolve the interpreter itself — it picks the
+      # newest, which is exactly the one that produces a crashing client.
+      # Walk the supported interpreters until one yields a healthy client.
+      for py in $SUPPORTED_PYTHONS; do
+        command -v "$py" >/dev/null 2>&1 || continue
+        echo "installing fb-idb under $py"
+        pipx install --python "$py" --force fb-idb || continue
+        [ "$(idb_client_state)" = ready ] && break
+      done
+      if [ "$(idb_client_state)" != ready ]; then
+        # No available interpreter produces a working client. Retrying cannot
+        # change that, so record a distinct verdict with the interpreter
+        # fingerprint and stop — the foreground path reports the truth instead
+        # of re-showing an install hint the developer has already followed.
+        status=incompatible
+        incompatible_explanation
+        if first_supported_python >/dev/null; then
+          echo "tried: $SUPPORTED_PYTHONS — none produced a working client; the mirror stays on the simctl tier"
+        else
+          echo "no supported Python found (need one of: $SUPPORTED_PYTHONS). Install one, then re-run: $(install_command)"
+        fi
       fi
     else
       status=failed
     fi
   fi
-  echo "$status $(date +%s)" > "$MARKER"
+  echo "$status $(date +%s) $(python_fingerprint)" > "$MARKER"
   rm -f "$PIDFILE"
   echo "ensure-idb worker finished: $status"
   exit 0
 fi
 
-# Foreground path — bounded: checks + at most one detached spawn. The client
-# check is a health probe (one `idb --help` invocation, no daemon contact),
-# not a PATH check — see idb_client_healthy (B269).
-if idb_client_healthy && has_companion; then
+# Foreground path — bounded: checks + at most one detached spawn.
+CLIENT_STATE="$(idb_client_state)"
+
+if [ "$CLIENT_STATE" = ready ] && has_companion; then
+  # A previous verdict no longer describes reality — clear it so a future
+  # break re-arms the full repair path.
+  rm -f "$MARKER"
   echo "idb available: screen mirroring uses the fast path (idb video-stream)"
   exit 0
 fi
 
-if command -v idb >/dev/null 2>&1 && ! idb_client_healthy; then
-  echo "idb client on PATH is broken (crashes on invocation) — the background worker will replace or remove it (B269)"
+if [ -f "$MARKER" ]; then
+  read -r LAST_STATUS LAST_TS LAST_FP < "$MARKER" 2>/dev/null || LAST_STATUS=""
 fi
 
-if ! command -v brew >/dev/null 2>&1; then
+# The incompatible verdict outranks every other branch: it is the one state
+# where an install hint is actively wrong (GH#578). It holds until the set of
+# installed interpreters changes; delete "$MARKER" to force a retry.
+if [ "${LAST_STATUS:-}" = "incompatible" ] && [ "${LAST_FP:-}" = "$(python_fingerprint)" ]; then
+  incompatible_explanation
+  if first_supported_python >/dev/null; then
+    echo "Recover with: $(install_command)"
+  else
+    echo "No supported Python is installed (need one of: $SUPPORTED_PYTHONS). Recover with: $(install_command)"
+  fi
+  echo "Not retrying until the installed Python interpreters change (log: $LOG). Mirroring stays on the ~6fps simctl tier."
+  exit 0
+fi
+
+if [ "$CLIENT_STATE" = broken ]; then
+  incompatible_explanation
+  if ! command -v brew >/dev/null 2>&1; then
+    echo "Recover with: $(install_command)"
+    exit 0
+  fi
+  echo "Repairing in the background under a supported interpreter ($SUPPORTED_PYTHONS). Manual: $(install_command)"
+elif ! command -v brew >/dev/null 2>&1; then
   echo "idb not installed (optional — enables 20-30fps screen mirroring instead of ~6fps)."
-  echo "Install manually: brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb"
+  echo "Install manually: $(install_command)"
   exit 0
 fi
 
@@ -120,19 +205,24 @@ if [ -f "$PIDFILE" ]; then
 fi
 
 # A recent failed attempt backs off for 24h; success never re-enters here
-# (the command -v fast path above wins once binaries exist).
-if [ -f "$MARKER" ]; then
-  read -r LAST_STATUS LAST_TS < "$MARKER" 2>/dev/null || LAST_STATUS=""
+# (the ready fast path above wins once a healthy client exists).
+if [ "${LAST_STATUS:-}" = "failed" ] && [ -n "${LAST_TS:-}" ]; then
   NOW="$(date +%s)"
-  if [ "$LAST_STATUS" = "failed" ] && [ -n "${LAST_TS:-}" ] && [ $((NOW - LAST_TS)) -lt "$BACKOFF_SECS" ]; then
-    echo "idb install failed recently — retrying after backoff (manual: brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb, log: $LOG)"
+  if [ $((NOW - LAST_TS)) -lt "$BACKOFF_SECS" ]; then
+    echo "idb install failed recently — retrying after backoff (manual: $(install_command), log: $LOG)"
     exit 0
   fi
 fi
 
+if [ "$CLIENT_STATE" = absent ]; then
+  NOTICE="idb missing — installing in background ($(install_command)). Log: $LOG"
+else
+  NOTICE="idb repair running in background. Log: $LOG"
+fi
+
 if [ "${RN_AGENT_IDB_DRY_SPAWN:-}" = "1" ]; then
   echo "spawn --install-worker" >> "$STATE_DIR/spawn.log"
-  echo "idb missing — installing in background (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb). Log: $LOG"
+  echo "$NOTICE"
   exit 0
 fi
 
@@ -140,5 +230,5 @@ nohup bash "$0" --install-worker >> "$LOG" 2>&1 < /dev/null &
 WORKER_PID=$!
 disown "$WORKER_PID" 2>/dev/null || true
 echo "$WORKER_PID" > "$PIDFILE"
-echo "idb missing — installing in background (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb). Log: $LOG"
+echo "$NOTICE"
 exit 0

--- a/packages/claude-plugin/scripts/ensure-idb.sh
+++ b/packages/claude-plugin/scripts/ensure-idb.sh
@@ -102,14 +102,27 @@ install_command() {
   fi
 }
 
+# The probe only observes a non-zero exit (a timeout or EACCES lands here too),
+# so the cause is stated as probable rather than asserted as fact.
 incompatible_explanation() {
-  echo "idb is installed but unusable: the fb-idb client crashes on every invocation — it calls asyncio.get_event_loop(), which Python 3.14 removed. Installing it again under the same interpreter reproduces this."
+  echo "idb is installed but did not respond successfully: the most likely cause is fb-idb calling asyncio.get_event_loop(), which Python 3.14 removed. Installing it again under the same interpreter would reproduce this."
+}
+
+# GH#578: a pinned install that SUCCEEDS but leaves no client on PATH is a shim
+# visibility problem, not an interpreter incompatibility — retryable, and the
+# remedy is the PATH, never the install command that already succeeded.
+path_shim_explanation() {
+  echo "fb-idb installed successfully, but no idb client is visible on PATH — the pipx shim directory (usually ~/.local/bin) is not exported. Run 'pipx ensurepath' and start a new shell, or add that directory to PATH."
 }
 
 # --install-worker: the detached background job (never reached at SessionStart).
 if [ "${1:-}" = "--install-worker" ]; then
   mkdir -p "$STATE_DIR"
   status=ok
+  # The cause is persisted alongside the status: messages rendered FROM the
+  # marker (notably the 24h backoff line) would otherwise fall back to the
+  # generic install command and lose what the worker actually determined.
+  cause=none
   if ! has_companion; then
     brew tap facebook/fb && { brew trust facebook/fb >/dev/null 2>&1 || true; } && brew install idb-companion || status=failed
   fi
@@ -131,35 +144,45 @@ if [ "${1:-}" = "--install-worker" ]; then
         installed=yes
         [ "$(idb_client_state)" = ready ] && break
       done
-      if [ "$(idb_client_state)" != ready ]; then
+      # Four outcomes, derived from what the worker already knows: whether any
+      # install ran (`installed`) and what the probe now reads. Only a client
+      # that ran an install and still fails is genuinely terminal.
+      final_state="$(idb_client_state)"
+      if [ "$final_state" != ready ]; then
         if [ -n "$tried" ] && [ -z "$installed" ]; then
           # Every pinned install command itself failed (network, PyPI, pipx).
-          # That is transient, so it must stay retryable: the terminal verdict
-          # requires evidence of incompatibility, not merely absence of success.
+          # Transient, so it stays retryable.
           status=failed
+          cause=install-failed
           echo "tried:$tried — every pinned install failed; retrying after backoff"
-        else
-          # Either a pinned install succeeded and the client still crashes, or
-          # no supported interpreter exists at all. Retrying cannot change that,
-          # so record a distinct verdict with the interpreter fingerprint and
-          # stop — the foreground path reports the truth instead of re-showing
-          # an install hint the developer has already followed.
-          # A brew failure earlier in this run stays `failed`: that one IS worth
-          # retrying, and its backoff must not be replaced by a terminal verdict.
+        elif [ -n "$installed" ] && [ "$final_state" = absent ]; then
+          # The install worked; the shim just is not visible. Orthogonal to the
+          # interpreter fingerprint, so it must never be terminal.
+          status=failed
+          cause=path-shim
+          path_shim_explanation
+        elif [ -n "$installed" ]; then
+          # A pinned install succeeded and the client still fails to run.
+          # Retrying cannot change that. A brew failure earlier in this run
+          # stays `failed`: that one IS worth retrying.
           [ "$status" = failed ] || status=incompatible
-          if [ -n "$tried" ]; then
-            incompatible_explanation
-            echo "tried:$tried — none produced a working client; the mirror stays on the simctl tier"
-          else
-            echo "no supported Python found (need one of: $SUPPORTED_PYTHONS). Install one, then re-run: $(install_command)"
-          fi
+          [ "$status" = failed ] || cause=client-unusable
+          incompatible_explanation
+          echo "tried:$tried — none produced a working client; the mirror stays on the simctl tier"
+        else
+          # No supported interpreter exists at all. The fingerprint re-arms this
+          # as soon as one is installed.
+          [ "$status" = failed ] || status=incompatible
+          [ "$status" = failed ] || cause=no-interpreter
+          echo "no supported Python found (need one of: $SUPPORTED_PYTHONS). Install one, then re-run: $(install_command)"
         fi
       fi
     else
       status=failed
     fi
   fi
-  echo "$status $(date +%s) $(python_fingerprint)" > "$MARKER"
+  [ "$status" = failed ] && [ "$cause" = none ] && cause=install-error
+  echo "$status $(date +%s) $(python_fingerprint) $cause" > "$MARKER"
   rm -f "$PIDFILE"
   echo "ensure-idb worker finished: $status"
   exit 0
@@ -177,7 +200,7 @@ if [ "$CLIENT_STATE" = ready ] && has_companion; then
 fi
 
 if [ -f "$MARKER" ]; then
-  read -r LAST_STATUS LAST_TS LAST_FP < "$MARKER" 2>/dev/null || LAST_STATUS=""
+  read -r LAST_STATUS LAST_TS LAST_FP LAST_CAUSE < "$MARKER" 2>/dev/null || LAST_STATUS=""
 fi
 
 # The incompatible verdict outranks every other branch while the client is
@@ -186,12 +209,15 @@ fi
 # delete "$MARKER" to force a retry. A verdict may never contradict the live
 # probe — a client that now reads ready or absent falls through to the normal
 # path so the missing piece (companion, or the client itself) still gets fixed.
-if [ "$CLIENT_STATE" = broken ] && [ "${LAST_STATUS:-}" = "incompatible" ] && [ "${LAST_FP:-}" = "$(python_fingerprint)" ]; then
-  incompatible_explanation
-  if first_supported_python >/dev/null; then
+if [ "$CLIENT_STATE" != ready ] && [ "${LAST_STATUS:-}" = "incompatible" ] && [ "${LAST_FP:-}" = "$(python_fingerprint)" ]; then
+  # Terminal only for the two causes that retrying cannot change. The message
+  # follows the live state, never the other state's story.
+  if [ "$CLIENT_STATE" = broken ]; then
+    incompatible_explanation
     echo "Recover with: $(install_command)"
   else
-    echo "No supported Python is installed (need one of: $SUPPORTED_PYTHONS). Recover with: $(install_command)"
+    echo "idb is not installed, and no supported Python is available to install it (need one of: $SUPPORTED_PYTHONS)."
+    echo "Recover with: $(install_command)"
   fi
   echo "Not retrying until the installed Python interpreters change (log: $LOG). Mirroring stays on the ~6fps simctl tier."
   exit 0
@@ -226,7 +252,15 @@ fi
 if [ "${LAST_STATUS:-}" = "failed" ] && [ -n "${LAST_TS:-}" ]; then
   NOW="$(date +%s)"
   if [ $((NOW - LAST_TS)) -lt "$BACKOFF_SECS" ]; then
-    echo "idb install failed recently — retrying after backoff (manual: $(install_command), log: $LOG)"
+    # This line is what the developer reads for the next 24h, so it must carry
+    # the cause the worker determined rather than defaulting to an install
+    # command that, for the shim case, already succeeded.
+    if [ "${LAST_CAUSE:-}" = "path-shim" ]; then
+      path_shim_explanation
+      echo "Retrying the install after backoff anyway (log: $LOG)."
+    else
+      echo "idb install failed recently — retrying after backoff (manual: $(install_command), log: $LOG)"
+    fi
     exit 0
   fi
 fi

--- a/packages/claude-plugin/scripts/ensure-idb.sh
+++ b/packages/claude-plugin/scripts/ensure-idb.sh
@@ -121,9 +121,11 @@ if [ "${1:-}" = "--install-worker" ]; then
       # GH#578: never let pipx resolve the interpreter itself — it picks the
       # newest, which is exactly the one that produces a crashing client.
       # Walk the supported interpreters until one yields a healthy client.
+      tried=""
       for py in $SUPPORTED_PYTHONS; do
         command -v "$py" >/dev/null 2>&1 || continue
         echo "installing fb-idb under $py"
+        tried="$tried $py"
         pipx install --python "$py" --force fb-idb || continue
         [ "$(idb_client_state)" = ready ] && break
       done
@@ -132,10 +134,12 @@ if [ "${1:-}" = "--install-worker" ]; then
         # change that, so record a distinct verdict with the interpreter
         # fingerprint and stop — the foreground path reports the truth instead
         # of re-showing an install hint the developer has already followed.
-        status=incompatible
+        # A brew failure earlier in this run stays `failed`: that one IS worth
+        # retrying, and its backoff must not be replaced by a terminal verdict.
+        [ "$status" = failed ] || status=incompatible
         incompatible_explanation
-        if first_supported_python >/dev/null; then
-          echo "tried: $SUPPORTED_PYTHONS — none produced a working client; the mirror stays on the simctl tier"
+        if [ -n "$tried" ]; then
+          echo "tried:$tried — none produced a working client; the mirror stays on the simctl tier"
         else
           echo "no supported Python found (need one of: $SUPPORTED_PYTHONS). Install one, then re-run: $(install_command)"
         fi

--- a/packages/claude-plugin/skills/rn-setup/SKILL.md
+++ b/packages/claude-plugin/skills/rn-setup/SKILL.md
@@ -193,6 +193,9 @@ interpreter pin is required; a bare `pipx install fb-idb` resolves the newest Py
 and recreates the break): `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb`.
 On a machine with no supported interpreter, prepend the interpreter install:
 `brew install python@3.13 && ...` (same form `install_command()` produces).
+When the client is OK and only the companion is missing, give the companion half
+alone — `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion`
+(same form `companion_command()` produces) — never the fb-idb reinstall.
 
 ### 11. Physical device prerequisites (optional — M9 / Phase 111)
 
@@ -301,7 +304,7 @@ Present results as a table:
 | CDP connection | CONNECTED | — |
 | Injected helpers | OK / MISSING | If MISSING: fall back to `device_*` tools or call `cdp_reload`. Do not retry `cdp_status` in a loop. |
 | ffmpeg | OK (v7.1) | — |
-| idb (screen mirror fast path) | OK / INSTALLING (background) / BROKEN (installed, did not respond) / MISSING | If MISSING or BROKEN: `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb`, prefixed with `brew install python@3.13 &&` when no supported interpreter is installed. The `--python` pin is required (GH#578). Report the incompatibility as the probable cause, not a certainty. Optional — mirror falls back to ~6fps simctl |
+| idb (screen mirror fast path) | OK / INSTALLING (background) / BROKEN (installed, did not respond) / MISSING | If MISSING or BROKEN: `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb`, prefixed with `brew install python@3.13 &&` when no supported interpreter is installed. If only the companion is missing, drop the `pipx` half. The `--python` pin is required (GH#578). Report the incompatibility as the probable cause, not a certainty. Optional — mirror falls back to ~6fps simctl |
 | Physical devices | N/A (none connected) OR "Android USB reverse: OK" / "iOS: idb-companion missing — install with brew" | Run installed command if iOS-companion missing |
 | Plugin version | OK (latest) / BEHIND (installed X, latest Y) / OFFLINE / AHEAD (dev install) | Run: `/plugin update rn-dev-agent` if BEHIND |
 | Vercel rules sync | OK (N rules, fetched X days ago) / STALE (> 30 days) / MISSING / DRIFT / N/A (installed plugin) | Repo checkout only: node scripts/sync-vercel-skills.mjs --fix --ref \<sha\> |

--- a/packages/claude-plugin/skills/rn-setup/SKILL.md
+++ b/packages/claude-plugin/skills/rn-setup/SKILL.md
@@ -176,7 +176,9 @@ If missing: `brew install ffmpeg` (not critical — videos work without it, GIF 
 
 ### 10. idb (optional — fast screen mirroring)
 ```bash
-idb --help >/dev/null 2>&1 && { command -v idb_companion || command -v idb-companion; }
+command -v idb || echo "idb MISSING"
+idb --help >/dev/null 2>&1 && echo "idb client OK" || echo "idb client BROKEN (only if the line above found it)"
+command -v idb_companion || command -v idb-companion || echo "idb-companion MISSING"
 ```
 Both binaries present → the observe UI's live mirror uses `idb video-stream`
 (20–30fps). Missing → the mirror still works via a ~6fps `simctl screenshot`

--- a/packages/claude-plugin/skills/rn-setup/SKILL.md
+++ b/packages/claude-plugin/skills/rn-setup/SKILL.md
@@ -183,12 +183,15 @@ Both binaries present → the observe UI's live mirror uses `idb video-stream`
 loop. SessionStart auto-installs in the background (`scripts/ensure-idb.sh`);
 if `~/.rn-dev-agent/idb/install.pid` exists and its PID is alive, report
 "installing in background (log: ~/.rn-dev-agent/idb/install.log)" instead of
-MISSING. A client that is on PATH but exits non-zero is BROKEN, not MISSING: fb-idb
-1.1.7 needs `asyncio.get_event_loop()`, removed in Python 3.14, so it crashes on
-every invocation (GH#578). Report the incompatibility — never tell the developer to
-install what they already installed. Manual install/repair (the interpreter pin is
-required; a bare `pipx install fb-idb` resolves the newest Python and recreates the
-break): `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb`.
+MISSING. A client that is on PATH but exits non-zero is BROKEN, not MISSING. State
+the cause as probable, not certain: the probe only sees a non-zero exit, and a
+timeout or EACCES lands there too. The most likely cause is fb-idb needing
+`asyncio.get_event_loop()`, which Python 3.14 removed (GH#578). Never tell the
+developer to install what they already installed. Manual install/repair (the
+interpreter pin is required; a bare `pipx install fb-idb` resolves the newest Python
+and recreates the break): `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb`.
+On a machine with no supported interpreter, prepend the interpreter install:
+`brew install python@3.13 && ...` (same form `install_command()` produces).
 
 ### 11. Physical device prerequisites (optional — M9 / Phase 111)
 
@@ -297,7 +300,7 @@ Present results as a table:
 | CDP connection | CONNECTED | — |
 | Injected helpers | OK / MISSING | If MISSING: fall back to `device_*` tools or call `cdp_reload`. Do not retry `cdp_status` in a loop. |
 | ffmpeg | OK (v7.1) | — |
-| idb (screen mirror fast path) | OK / INSTALLING (background) / BROKEN (installed, crashes) / MISSING | If MISSING or BROKEN: `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb` — the `--python` pin is required (GH#578); optional, mirror falls back to ~6fps simctl |
+| idb (screen mirror fast path) | OK / INSTALLING (background) / BROKEN (installed, did not respond) / MISSING | If MISSING or BROKEN: `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb`, prefixed with `brew install python@3.13 &&` when no supported interpreter is installed. The `--python` pin is required (GH#578). Report the incompatibility as the probable cause, not a certainty. Optional — mirror falls back to ~6fps simctl |
 | Physical devices | N/A (none connected) OR "Android USB reverse: OK" / "iOS: idb-companion missing — install with brew" | Run installed command if iOS-companion missing |
 | Plugin version | OK (latest) / BEHIND (installed X, latest Y) / OFFLINE / AHEAD (dev install) | Run: `/plugin update rn-dev-agent` if BEHIND |
 | Vercel rules sync | OK (N rules, fetched X days ago) / STALE (> 30 days) / MISSING / DRIFT / N/A (installed plugin) | Repo checkout only: node scripts/sync-vercel-skills.mjs --fix --ref \<sha\> |

--- a/packages/claude-plugin/skills/rn-setup/SKILL.md
+++ b/packages/claude-plugin/skills/rn-setup/SKILL.md
@@ -176,9 +176,8 @@ If missing: `brew install ffmpeg` (not critical — videos work without it, GIF 
 
 ### 10. idb (optional — fast screen mirroring)
 ```bash
-command -v idb || echo "idb MISSING"
-idb --help >/dev/null 2>&1 && echo "idb client OK" || echo "idb client BROKEN (only if the line above found it)"
-command -v idb_companion || command -v idb-companion || echo "idb-companion MISSING"
+command -v idb >/dev/null && { idb --help >/dev/null 2>&1 && echo "idb client OK" || echo "idb client BROKEN"; } || echo "idb MISSING"
+command -v idb_companion >/dev/null || command -v idb-companion >/dev/null && echo "idb-companion OK" || echo "idb-companion MISSING"
 ```
 Both binaries present → the observe UI's live mirror uses `idb video-stream`
 (20–30fps). Missing → the mirror still works via a ~6fps `simctl screenshot`

--- a/packages/claude-plugin/skills/rn-setup/SKILL.md
+++ b/packages/claude-plugin/skills/rn-setup/SKILL.md
@@ -176,14 +176,19 @@ If missing: `brew install ffmpeg` (not critical — videos work without it, GIF 
 
 ### 10. idb (optional — fast screen mirroring)
 ```bash
-command -v idb && { command -v idb_companion || command -v idb-companion; }
+idb --help >/dev/null 2>&1 && { command -v idb_companion || command -v idb-companion; }
 ```
 Both binaries present → the observe UI's live mirror uses `idb video-stream`
 (20–30fps). Missing → the mirror still works via a ~6fps `simctl screenshot`
 loop. SessionStart auto-installs in the background (`scripts/ensure-idb.sh`);
 if `~/.rn-dev-agent/idb/install.pid` exists and its PID is alive, report
 "installing in background (log: ~/.rn-dev-agent/idb/install.log)" instead of
-MISSING. Manual install: `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb`.
+MISSING. A client that is on PATH but exits non-zero is BROKEN, not MISSING: fb-idb
+1.1.7 needs `asyncio.get_event_loop()`, removed in Python 3.14, so it crashes on
+every invocation (GH#578). Report the incompatibility — never tell the developer to
+install what they already installed. Manual install/repair (the interpreter pin is
+required; a bare `pipx install fb-idb` resolves the newest Python and recreates the
+break): `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb`.
 
 ### 11. Physical device prerequisites (optional — M9 / Phase 111)
 
@@ -292,7 +297,7 @@ Present results as a table:
 | CDP connection | CONNECTED | — |
 | Injected helpers | OK / MISSING | If MISSING: fall back to `device_*` tools or call `cdp_reload`. Do not retry `cdp_status` in a loop. |
 | ffmpeg | OK (v7.1) | — |
-| idb (screen mirror fast path) | OK / INSTALLING (background) / MISSING | If MISSING: `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb` (optional — mirror falls back to ~6fps simctl) |
+| idb (screen mirror fast path) | OK / INSTALLING (background) / BROKEN (installed, crashes) / MISSING | If MISSING or BROKEN: `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb` — the `--python` pin is required (GH#578); optional, mirror falls back to ~6fps simctl |
 | Physical devices | N/A (none connected) OR "Android USB reverse: OK" / "iOS: idb-companion missing — install with brew" | Run installed command if iOS-companion missing |
 | Plugin version | OK (latest) / BEHIND (installed X, latest Y) / OFFLINE / AHEAD (dev install) | Run: `/plugin update rn-dev-agent` if BEHIND |
 | Vercel rules sync | OK (N rules, fetched X days ago) / STALE (> 30 days) / MISSING / DRIFT / N/A (installed plugin) | Repo checkout only: node scripts/sync-vercel-skills.mjs --fix --ref \<sha\> |

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -56566,6 +56566,7 @@ function getBoundDirectoryJournalKey(layout = createAuthorityStateLayout()) {
 // packages/rn-dev-agent-core/dist/session/bound-directory.js
 var WAIT_BUFFER = new Int32Array(new SharedArrayBuffer(4));
 var WORKER_READY_TIMEOUT_MS = 3e4;
+var WORKER_OPERATION_TIMEOUT_MS = 3e4;
 var BOUND_DIRECTORY_LIFECYCLE_MONITOR = String.raw`
 const fs = require('node:fs');
 const path = require('node:path');
@@ -57861,7 +57862,7 @@ function runBoundOperation(directory, request2, dependencies = {}) {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: bound directory path changed");
   }
   try {
-    const result = sendOperation(directory, request2, dependencies.timeoutMs ?? 5e3);
+    const result = sendOperation(directory, request2, dependencies.timeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
     if (!result.ok)
       throwOperationFailure(result);
     if (request2.operation === "cas" && result.cleanupPending) {
@@ -57875,7 +57876,7 @@ function runBoundOperation(directory, request2, dependencies = {}) {
           cleanupRecoveryDelayMs: dependencies.cleanupRecoveryDelayMs ?? 0,
           journal: request2.journal,
           writes: request2.writes
-        }, dependencies.recoveryTimeoutMs ?? 5e3);
+        }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
         if (!cleanup.ok)
           throwOperationFailure(cleanup);
         if (!cleanup.committed) {
@@ -57892,7 +57893,7 @@ function runBoundOperation(directory, request2, dependencies = {}) {
               failCleanupRecovery: dependencies.failCleanupRecovery ?? false,
               journal: request2.journal,
               writes: request2.writes
-            }, dependencies.recoveryTimeoutMs ?? 5e3);
+            }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
             if (!cleanup.ok)
               throwOperationFailure(cleanup);
             if (!cleanup.committed) {
@@ -57924,7 +57925,7 @@ function runBoundOperation(directory, request2, dependencies = {}) {
           journal: request2.journal,
           writes: request2.writes,
           recoveryDelayAfterUnlinkMs: dependencies.recoveryDelayAfterUnlinkMs ?? 0
-        }, dependencies.recoveryTimeoutMs ?? 5e3);
+        }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
         if (!recovery.ok)
           throwOperationFailure(recovery);
         break;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -80086,9 +80086,9 @@ var RestartGate = class {
     return this.exits.length < this.limit;
   }
 };
-var IDB_INSTALL_COMMAND = "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 fb-idb";
+var IDB_INSTALL_COMMAND = "brew install python@3.13 && brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb";
 var SIMCTL_HINT = `install idb for smoother mirroring (${IDB_INSTALL_COMMAND})`;
-var SIMCTL_BROKEN_IDB_HINT = "idb is installed but its client crashes on every invocation \u2014 fb-idb 1.1.7 needs asyncio.get_event_loop(), removed in Python 3.14. Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb";
+var SIMCTL_BROKEN_IDB_HINT = "idb is installed but did not respond successfully \u2014 most likely fb-idb 1.1.7 under Python 3.14, which removed the asyncio.get_event_loop() it needs. Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb";
 var IDB_HINT = `idb not found \u2014 ${IDB_INSTALL_COMMAND}`;
 var FFMPEG_HINT = "ffmpeg not found \u2014 run scripts/ensure-ffmpeg.sh or brew install ffmpeg";
 var sleep6 = (ms) => new Promise((resolve11) => setTimeout(resolve11, ms));

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -80086,8 +80086,10 @@ var RestartGate = class {
     return this.exits.length < this.limit;
   }
 };
-var SIMCTL_HINT = "install idb for smoother mirroring (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb)";
-var IDB_HINT = "idb not found \u2014 brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb";
+var IDB_INSTALL_COMMAND = "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 fb-idb";
+var SIMCTL_HINT = `install idb for smoother mirroring (${IDB_INSTALL_COMMAND})`;
+var SIMCTL_BROKEN_IDB_HINT = "idb is installed but its client crashes on every invocation \u2014 fb-idb 1.1.7 needs asyncio.get_event_loop(), removed in Python 3.14. Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb";
+var IDB_HINT = `idb not found \u2014 ${IDB_INSTALL_COMMAND}`;
 var FFMPEG_HINT = "ffmpeg not found \u2014 run scripts/ensure-ffmpeg.sh or brew install ffmpeg";
 var sleep6 = (ms) => new Promise((resolve11) => setTimeout(resolve11, ms));
 var scheduleAfter = (fn, delayMs) => {
@@ -80097,9 +80099,13 @@ var scheduleAfter = (fn, delayMs) => {
     setTimeout(fn, delayMs);
 };
 var defaultSpawn = (cmd, args) => spawn9(cmd, args, { stdio: ["pipe", "pipe", "pipe"] });
-async function detectIdb(execFileFn = execFile25) {
+async function probeIdbClient(execFileFn = execFile25) {
   return new Promise((resolve11) => {
-    execFileFn("idb", ["--help"], { timeout: 3e3 }, (err) => resolve11(!err));
+    execFileFn("idb", ["--help"], { timeout: 3e3 }, (err) => {
+      if (!err)
+        return resolve11("ready");
+      resolve11(isEnoent(err) ? "absent" : "broken");
+    });
   });
 }
 function isEnoent(err) {
@@ -80179,6 +80185,7 @@ var IosSimctlLoopSource = class {
   udid;
   pipeline = "simctl";
   nominalFps = 6;
+  degradedHint;
   active = false;
   inFlight = null;
   execJpeg;
@@ -80193,6 +80200,7 @@ var IosSimctlLoopSource = class {
     this.idleDelayMs = opts.idleDelayMs ?? 25;
     this.failurePauseMs = opts.failurePauseMs ?? 500;
     this.tmpPath = opts.tmpPath ?? (() => join47(tmpdir14(), "rn-mirror-simctl-" + process.pid + ".jpg"));
+    this.degradedHint = opts.degradedHint ?? SIMCTL_HINT;
   }
   start(sink) {
     this.active = true;
@@ -80213,7 +80221,7 @@ var IosSimctlLoopSource = class {
           break;
         if (!this.gate.record()) {
           if (this.active)
-            sink.onExit({ reason: "simctl screenshot failing", hint: SIMCTL_HINT });
+            sink.onExit({ reason: "simctl screenshot failing", hint: this.degradedHint });
           this.active = false;
           break;
         }
@@ -80366,8 +80374,12 @@ async function createMirrorSource(target, fps) {
   if (target.platform === "android") {
     return new AndroidScreenrecordSource(target.deviceId);
   }
-  const hasIdb = await detectIdb();
-  return hasIdb ? new IosIdbSource(target.deviceId, fps) : new IosSimctlLoopSource(target.deviceId);
+  const state = await probeIdbClient();
+  if (state === "ready")
+    return new IosIdbSource(target.deviceId, fps);
+  return new IosSimctlLoopSource(target.deviceId, {
+    degradedHint: state === "broken" ? SIMCTL_BROKEN_IDB_HINT : SIMCTL_HINT
+  });
 }
 
 // packages/rn-dev-agent-core/dist/observability/mirror/manager.js
@@ -80568,7 +80580,7 @@ var MirrorManager = class {
         deviceId: target.deviceId,
         pipeline: source.pipeline,
         fps: source.nominalFps,
-        hint: source.pipeline === "simctl" ? SIMCTL_HINT : void 0
+        hint: source.pipeline === "simctl" ? source.degradedHint ?? SIMCTL_HINT : void 0
       });
     }
     this.broadcast(frame);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -15109,6 +15109,7 @@ import { tmpdir } from "node:os";
 import { join as join7 } from "node:path";
 var WAIT_BUFFER = new Int32Array(new SharedArrayBuffer(4));
 var WORKER_READY_TIMEOUT_MS = 3e4;
+var WORKER_OPERATION_TIMEOUT_MS = 3e4;
 var BOUND_DIRECTORY_LIFECYCLE_MONITOR = String.raw`
 const fs = require('node:fs');
 const path = require('node:path');
@@ -16404,7 +16405,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: bound directory path changed");
   }
   try {
-    const result = sendOperation(directory, request, dependencies.timeoutMs ?? 5e3);
+    const result = sendOperation(directory, request, dependencies.timeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
     if (!result.ok)
       throwOperationFailure(result);
     if (request.operation === "cas" && result.cleanupPending) {
@@ -16418,7 +16419,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
           cleanupRecoveryDelayMs: dependencies.cleanupRecoveryDelayMs ?? 0,
           journal: request.journal,
           writes: request.writes
-        }, dependencies.recoveryTimeoutMs ?? 5e3);
+        }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
         if (!cleanup.ok)
           throwOperationFailure(cleanup);
         if (!cleanup.committed) {
@@ -16435,7 +16436,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
               failCleanupRecovery: dependencies.failCleanupRecovery ?? false,
               journal: request.journal,
               writes: request.writes
-            }, dependencies.recoveryTimeoutMs ?? 5e3);
+            }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
             if (!cleanup.ok)
               throwOperationFailure(cleanup);
             if (!cleanup.committed) {
@@ -16467,7 +16468,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
           journal: request.journal,
           writes: request.writes,
           recoveryDelayAfterUnlinkMs: dependencies.recoveryDelayAfterUnlinkMs ?? 0
-        }, dependencies.recoveryTimeoutMs ?? 5e3);
+        }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
         if (!recovery.ok)
           throwOperationFailure(recovery);
         break;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -82584,9 +82584,9 @@ var init_sources = __esm({
         return this.exits.length < this.limit;
       }
     };
-    IDB_INSTALL_COMMAND = "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 fb-idb";
+    IDB_INSTALL_COMMAND = "brew install python@3.13 && brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb";
     SIMCTL_HINT = `install idb for smoother mirroring (${IDB_INSTALL_COMMAND})`;
-    SIMCTL_BROKEN_IDB_HINT = "idb is installed but its client crashes on every invocation \u2014 fb-idb 1.1.7 needs asyncio.get_event_loop(), removed in Python 3.14. Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb";
+    SIMCTL_BROKEN_IDB_HINT = "idb is installed but did not respond successfully \u2014 most likely fb-idb 1.1.7 under Python 3.14, which removed the asyncio.get_event_loop() it needs. Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb";
     IDB_HINT = `idb not found \u2014 ${IDB_INSTALL_COMMAND}`;
     FFMPEG_HINT = "ffmpeg not found \u2014 run scripts/ensure-ffmpeg.sh or brew install ffmpeg";
     sleep6 = (ms) => new Promise((resolve11) => setTimeout(resolve11, ms));

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -12375,7 +12375,7 @@ function runBoundOperation(directory, request2, dependencies = {}) {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: bound directory path changed");
   }
   try {
-    const result = sendOperation(directory, request2, dependencies.timeoutMs ?? 5e3);
+    const result = sendOperation(directory, request2, dependencies.timeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
     if (!result.ok)
       throwOperationFailure(result);
     if (request2.operation === "cas" && result.cleanupPending) {
@@ -12389,7 +12389,7 @@ function runBoundOperation(directory, request2, dependencies = {}) {
           cleanupRecoveryDelayMs: dependencies.cleanupRecoveryDelayMs ?? 0,
           journal: request2.journal,
           writes: request2.writes
-        }, dependencies.recoveryTimeoutMs ?? 5e3);
+        }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
         if (!cleanup.ok)
           throwOperationFailure(cleanup);
         if (!cleanup.committed) {
@@ -12406,7 +12406,7 @@ function runBoundOperation(directory, request2, dependencies = {}) {
               failCleanupRecovery: dependencies.failCleanupRecovery ?? false,
               journal: request2.journal,
               writes: request2.writes
-            }, dependencies.recoveryTimeoutMs ?? 5e3);
+            }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
             if (!cleanup.ok)
               throwOperationFailure(cleanup);
             if (!cleanup.committed) {
@@ -12438,7 +12438,7 @@ function runBoundOperation(directory, request2, dependencies = {}) {
           journal: request2.journal,
           writes: request2.writes,
           recoveryDelayAfterUnlinkMs: dependencies.recoveryDelayAfterUnlinkMs ?? 0
-        }, dependencies.recoveryTimeoutMs ?? 5e3);
+        }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
         if (!recovery.ok)
           throwOperationFailure(recovery);
         break;
@@ -12761,13 +12761,14 @@ function retryBoundDirectoryCleanup(directory, obligation, dependencies = {}) {
   }
   directory.pendingCleanups.delete(obligation.transactionId);
 }
-var WAIT_BUFFER, WORKER_READY_TIMEOUT_MS, BOUND_DIRECTORY_LIFECYCLE_MONITOR, BOUND_DIRECTORY_TERMINATION_WATCHDOG, BOUND_DIRECTORY_ANCESTRY_MONITOR, BOUND_DIRECTORY_WORKER;
+var WAIT_BUFFER, WORKER_READY_TIMEOUT_MS, WORKER_OPERATION_TIMEOUT_MS, BOUND_DIRECTORY_LIFECYCLE_MONITOR, BOUND_DIRECTORY_TERMINATION_WATCHDOG, BOUND_DIRECTORY_ANCESTRY_MONITOR, BOUND_DIRECTORY_WORKER;
 var init_bound_directory = __esm({
   "packages/rn-dev-agent-core/dist/session/bound-directory.js"() {
     "use strict";
     init_state_root();
     WAIT_BUFFER = new Int32Array(new SharedArrayBuffer(4));
     WORKER_READY_TIMEOUT_MS = 3e4;
+    WORKER_OPERATION_TIMEOUT_MS = 3e4;
     BOUND_DIRECTORY_LIFECYCLE_MONITOR = String.raw`
 const fs = require('node:fs');
 const path = require('node:path');

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -82519,9 +82519,13 @@ import { spawn as spawn9, execFile as execFile25 } from "node:child_process";
 import { readFile as readFile2, unlink } from "node:fs/promises";
 import { tmpdir as tmpdir14 } from "node:os";
 import { join as join50 } from "node:path";
-async function detectIdb(execFileFn = execFile25) {
+async function probeIdbClient(execFileFn = execFile25) {
   return new Promise((resolve11) => {
-    execFileFn("idb", ["--help"], { timeout: 3e3 }, (err) => resolve11(!err));
+    execFileFn("idb", ["--help"], { timeout: 3e3 }, (err) => {
+      if (!err)
+        return resolve11("ready");
+      resolve11(isEnoent(err) ? "absent" : "broken");
+    });
   });
 }
 function isEnoent(err) {
@@ -82551,10 +82555,14 @@ async function createMirrorSource(target, fps) {
   if (target.platform === "android") {
     return new AndroidScreenrecordSource(target.deviceId);
   }
-  const hasIdb = await detectIdb();
-  return hasIdb ? new IosIdbSource(target.deviceId, fps) : new IosSimctlLoopSource(target.deviceId);
+  const state = await probeIdbClient();
+  if (state === "ready")
+    return new IosIdbSource(target.deviceId, fps);
+  return new IosSimctlLoopSource(target.deviceId, {
+    degradedHint: state === "broken" ? SIMCTL_BROKEN_IDB_HINT : SIMCTL_HINT
+  });
 }
-var RestartGate, SIMCTL_HINT, IDB_HINT, FFMPEG_HINT, sleep6, scheduleAfter, defaultSpawn, IosIdbSource, IosSimctlLoopSource, AndroidScreenrecordSource;
+var RestartGate, IDB_INSTALL_COMMAND, SIMCTL_HINT, SIMCTL_BROKEN_IDB_HINT, IDB_HINT, FFMPEG_HINT, sleep6, scheduleAfter, defaultSpawn, IosIdbSource, IosSimctlLoopSource, AndroidScreenrecordSource;
 var init_sources = __esm({
   "packages/rn-dev-agent-core/dist/observability/mirror/sources.js"() {
     "use strict";
@@ -82576,8 +82584,10 @@ var init_sources = __esm({
         return this.exits.length < this.limit;
       }
     };
-    SIMCTL_HINT = "install idb for smoother mirroring (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb)";
-    IDB_HINT = "idb not found \u2014 brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb";
+    IDB_INSTALL_COMMAND = "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 fb-idb";
+    SIMCTL_HINT = `install idb for smoother mirroring (${IDB_INSTALL_COMMAND})`;
+    SIMCTL_BROKEN_IDB_HINT = "idb is installed but its client crashes on every invocation \u2014 fb-idb 1.1.7 needs asyncio.get_event_loop(), removed in Python 3.14. Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb";
+    IDB_HINT = `idb not found \u2014 ${IDB_INSTALL_COMMAND}`;
     FFMPEG_HINT = "ffmpeg not found \u2014 run scripts/ensure-ffmpeg.sh or brew install ffmpeg";
     sleep6 = (ms) => new Promise((resolve11) => setTimeout(resolve11, ms));
     scheduleAfter = (fn, delayMs) => {
@@ -82661,6 +82671,7 @@ var init_sources = __esm({
       udid;
       pipeline = "simctl";
       nominalFps = 6;
+      degradedHint;
       active = false;
       inFlight = null;
       execJpeg;
@@ -82675,6 +82686,7 @@ var init_sources = __esm({
         this.idleDelayMs = opts.idleDelayMs ?? 25;
         this.failurePauseMs = opts.failurePauseMs ?? 500;
         this.tmpPath = opts.tmpPath ?? (() => join50(tmpdir14(), "rn-mirror-simctl-" + process.pid + ".jpg"));
+        this.degradedHint = opts.degradedHint ?? SIMCTL_HINT;
       }
       start(sink) {
         this.active = true;
@@ -82695,7 +82707,7 @@ var init_sources = __esm({
               break;
             if (!this.gate.record()) {
               if (this.active)
-                sink.onExit({ reason: "simctl screenshot failing", hint: SIMCTL_HINT });
+                sink.onExit({ reason: "simctl screenshot failing", hint: this.degradedHint });
               this.active = false;
               break;
             }
@@ -83030,7 +83042,7 @@ var init_manager = __esm({
             deviceId: target.deviceId,
             pipeline: source.pipeline,
             fps: source.nominalFps,
-            hint: source.pipeline === "simctl" ? SIMCTL_HINT : void 0
+            hint: source.pipeline === "simctl" ? source.degradedHint ?? SIMCTL_HINT : void 0
           });
         }
         this.broadcast(frame);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/workflow-check.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/workflow-check.js
@@ -8570,6 +8570,7 @@ function getBoundDirectoryJournalKey(layout = createAuthorityStateLayout()) {
 // packages/rn-dev-agent-core/dist/session/bound-directory.js
 var WAIT_BUFFER = new Int32Array(new SharedArrayBuffer(4));
 var WORKER_READY_TIMEOUT_MS = 3e4;
+var WORKER_OPERATION_TIMEOUT_MS = 3e4;
 var BOUND_DIRECTORY_LIFECYCLE_MONITOR = String.raw`
 const fs = require('node:fs');
 const path = require('node:path');
@@ -9865,7 +9866,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: bound directory path changed");
   }
   try {
-    const result = sendOperation(directory, request, dependencies.timeoutMs ?? 5e3);
+    const result = sendOperation(directory, request, dependencies.timeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
     if (!result.ok)
       throwOperationFailure(result);
     if (request.operation === "cas" && result.cleanupPending) {
@@ -9879,7 +9880,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
           cleanupRecoveryDelayMs: dependencies.cleanupRecoveryDelayMs ?? 0,
           journal: request.journal,
           writes: request.writes
-        }, dependencies.recoveryTimeoutMs ?? 5e3);
+        }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
         if (!cleanup.ok)
           throwOperationFailure(cleanup);
         if (!cleanup.committed) {
@@ -9896,7 +9897,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
               failCleanupRecovery: dependencies.failCleanupRecovery ?? false,
               journal: request.journal,
               writes: request.writes
-            }, dependencies.recoveryTimeoutMs ?? 5e3);
+            }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
             if (!cleanup.ok)
               throwOperationFailure(cleanup);
             if (!cleanup.committed) {
@@ -9928,7 +9929,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
           journal: request.journal,
           writes: request.writes,
           recoveryDelayAfterUnlinkMs: dependencies.recoveryDelayAfterUnlinkMs ?? 0
-        }, dependencies.recoveryTimeoutMs ?? 5e3);
+        }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
         if (!recovery.ok)
           throwOperationFailure(recovery);
         break;

--- a/packages/rn-dev-agent-core/dist/observability/mirror/manager.js
+++ b/packages/rn-dev-agent-core/dist/observability/mirror/manager.js
@@ -218,7 +218,7 @@ export class MirrorManager {
                 deviceId: target.deviceId,
                 pipeline: source.pipeline,
                 fps: source.nominalFps,
-                hint: source.pipeline === 'simctl' ? SIMCTL_HINT : undefined,
+                hint: source.pipeline === 'simctl' ? (source.degradedHint ?? SIMCTL_HINT) : undefined,
             });
         }
         this.broadcast(frame);

--- a/packages/rn-dev-agent-core/dist/observability/mirror/sources.js
+++ b/packages/rn-dev-agent-core/dist/observability/mirror/sources.js
@@ -25,9 +25,16 @@ export class RestartGate {
 // Python 3.14 that reinstalls the exact combination that crashes (fb-idb 1.1.7
 // calls asyncio.get_event_loop(), removed in 3.14), so the hint the user
 // follows recreates the break. Every printed command pins the interpreter.
-export const IDB_INSTALL_COMMAND = 'brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 fb-idb';
+// Mirrors the no-interpreter variant of install_command() in
+// scripts/ensure-idb.sh: the interpreter install is prepended because a
+// python3.14-only machine would otherwise get `pipx: No such python` — a hint
+// the developer cannot follow, which is the defect this change removes.
+export const IDB_INSTALL_COMMAND = 'brew install python@3.13 && brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb';
 export const SIMCTL_HINT = `install idb for smoother mirroring (${IDB_INSTALL_COMMAND})`;
-export const SIMCTL_BROKEN_IDB_HINT = 'idb is installed but its client crashes on every invocation — fb-idb 1.1.7 needs asyncio.get_event_loop(), removed in Python 3.14. ' +
+// The probe only sees a non-zero exit, so the cause is stated as probable:
+// a timeout or EACCES lands here too, and a confidently wrong diagnosis is the
+// same defect as a hint that cannot be followed.
+export const SIMCTL_BROKEN_IDB_HINT = 'idb is installed but did not respond successfully — most likely fb-idb 1.1.7 under Python 3.14, which removed the asyncio.get_event_loop() it needs. ' +
     'Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb';
 const IDB_HINT = `idb not found — ${IDB_INSTALL_COMMAND}`;
 const FFMPEG_HINT = 'ffmpeg not found — run scripts/ensure-ffmpeg.sh or brew install ffmpeg';

--- a/packages/rn-dev-agent-core/dist/observability/mirror/sources.js
+++ b/packages/rn-dev-agent-core/dist/observability/mirror/sources.js
@@ -21,8 +21,15 @@ export class RestartGate {
         return this.exits.length < this.limit;
     }
 }
-export const SIMCTL_HINT = 'install idb for smoother mirroring (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb)';
-const IDB_HINT = 'idb not found — brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb';
+// GH#578: a bare `pipx install fb-idb` resolves the newest interpreter. On
+// Python 3.14 that reinstalls the exact combination that crashes (fb-idb 1.1.7
+// calls asyncio.get_event_loop(), removed in 3.14), so the hint the user
+// follows recreates the break. Every printed command pins the interpreter.
+export const IDB_INSTALL_COMMAND = 'brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 fb-idb';
+export const SIMCTL_HINT = `install idb for smoother mirroring (${IDB_INSTALL_COMMAND})`;
+export const SIMCTL_BROKEN_IDB_HINT = 'idb is installed but its client crashes on every invocation — fb-idb 1.1.7 needs asyncio.get_event_loop(), removed in Python 3.14. ' +
+    'Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb';
+const IDB_HINT = `idb not found — ${IDB_INSTALL_COMMAND}`;
 const FFMPEG_HINT = 'ffmpeg not found — run scripts/ensure-ffmpeg.sh or brew install ffmpeg';
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 // setTimeout(fn, 0) is clamped and raced against the timers phase, so a 0ms
@@ -36,15 +43,22 @@ const scheduleAfter = (fn, delayMs) => {
         setTimeout(fn, delayMs);
 };
 const defaultSpawn = (cmd, args) => spawn(cmd, args, { stdio: ['pipe', 'pipe', 'pipe'] });
-export async function detectIdb(execFileFn = execFile) {
+export async function probeIdbClient(execFileFn = execFile) {
     return new Promise((resolve) => {
         // B269/B263: PATH presence is not health. fb-idb on an incompatible
         // Python (e.g. 3.14) crashes on EVERY invocation; selecting the idb tier
         // for such a client kills the mirror ("idb video-stream keeps exiting")
-        // instead of using the working simctl fallback. Probe a real invocation:
-        // ENOENT, a crash, or a hang all resolve false -> simctl tier.
-        execFileFn('idb', ['--help'], { timeout: 3000 }, (err) => resolve(!err));
+        // instead of using the working simctl fallback. `idb --help` initializes
+        // the CLI without contacting a companion, so it separates the states.
+        execFileFn('idb', ['--help'], { timeout: 3000 }, (err) => {
+            if (!err)
+                return resolve('ready');
+            resolve(isEnoent(err) ? 'absent' : 'broken');
+        });
     });
+}
+export async function detectIdb(execFileFn = execFile) {
+    return (await probeIdbClient(execFileFn)) === 'ready';
 }
 function isEnoent(err) {
     return !!err && typeof err === 'object' && err.code === 'ENOENT';
@@ -126,6 +140,7 @@ export class IosSimctlLoopSource {
     udid;
     pipeline = 'simctl';
     nominalFps = 6;
+    degradedHint;
     active = false;
     inFlight = null;
     execJpeg;
@@ -141,6 +156,7 @@ export class IosSimctlLoopSource {
         this.failurePauseMs = opts.failurePauseMs ?? 500;
         this.tmpPath =
             opts.tmpPath ?? (() => join(tmpdir(), 'rn-mirror-simctl-' + process.pid + '.jpg'));
+        this.degradedHint = opts.degradedHint ?? SIMCTL_HINT;
     }
     start(sink) {
         this.active = true;
@@ -165,7 +181,7 @@ export class IosSimctlLoopSource {
                     break;
                 if (!this.gate.record()) {
                     if (this.active)
-                        sink.onExit({ reason: 'simctl screenshot failing', hint: SIMCTL_HINT });
+                        sink.onExit({ reason: 'simctl screenshot failing', hint: this.degradedHint });
                     this.active = false;
                     break;
                 }
@@ -329,6 +345,12 @@ export async function createMirrorSource(target, fps) {
     if (target.platform === 'android') {
         return new AndroidScreenrecordSource(target.deviceId);
     }
-    const hasIdb = await detectIdb();
-    return hasIdb ? new IosIdbSource(target.deviceId, fps) : new IosSimctlLoopSource(target.deviceId);
+    const state = await probeIdbClient();
+    if (state === 'ready')
+        return new IosIdbSource(target.deviceId, fps);
+    // GH#578: a crashing client is NOT "idb missing" — telling the developer to
+    // install what they already installed is the loop this fix removes.
+    return new IosSimctlLoopSource(target.deviceId, {
+        degradedHint: state === 'broken' ? SIMCTL_BROKEN_IDB_HINT : SIMCTL_HINT,
+    });
 }

--- a/packages/rn-dev-agent-core/dist/session/bound-directory.js
+++ b/packages/rn-dev-agent-core/dist/session/bound-directory.js
@@ -6,6 +6,9 @@ import { join } from 'node:path';
 import { getBoundDirectoryJournalKey } from './state-root.js';
 const WAIT_BUFFER = new Int32Array(new SharedArrayBuffer(4));
 const WORKER_READY_TIMEOUT_MS = 30_000;
+// NOTE: bound writes fsync, so a loaded host can stall one round trip for
+// seconds — this budget must only catch a wedged worker, not a slow one.
+const WORKER_OPERATION_TIMEOUT_MS = 30_000;
 const BOUND_DIRECTORY_LIFECYCLE_MONITOR = String.raw `
 const fs = require('node:fs');
 const path = require('node:path');
@@ -1323,7 +1326,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
         throw new Error('SESSION_INTEGRATION_PATH_UNSAFE: bound directory path changed');
     }
     try {
-        const result = sendOperation(directory, request, dependencies.timeoutMs ?? 5_000);
+        const result = sendOperation(directory, request, dependencies.timeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
         if (!result.ok)
             throwOperationFailure(result);
         if (request.operation === 'cas' && result.cleanupPending) {
@@ -1337,7 +1340,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
                     cleanupRecoveryDelayMs: dependencies.cleanupRecoveryDelayMs ?? 0,
                     journal: request.journal,
                     writes: request.writes,
-                }, dependencies.recoveryTimeoutMs ?? 5_000);
+                }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
                 if (!cleanup.ok)
                     throwOperationFailure(cleanup);
                 if (!cleanup.committed) {
@@ -1356,7 +1359,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
                             failCleanupRecovery: dependencies.failCleanupRecovery ?? false,
                             journal: request.journal,
                             writes: request.writes,
-                        }, dependencies.recoveryTimeoutMs ?? 5_000);
+                        }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
                         if (!cleanup.ok)
                             throwOperationFailure(cleanup);
                         if (!cleanup.committed) {
@@ -1394,7 +1397,7 @@ function runBoundOperation(directory, request, dependencies = {}) {
                     journal: request.journal,
                     writes: request.writes,
                     recoveryDelayAfterUnlinkMs: dependencies.recoveryDelayAfterUnlinkMs ?? 0,
-                }, dependencies.recoveryTimeoutMs ?? 5_000);
+                }, dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS);
                 if (!recovery.ok)
                     throwOperationFailure(recovery);
                 break;

--- a/packages/rn-dev-agent-core/src/observability/mirror/manager.ts
+++ b/packages/rn-dev-agent-core/src/observability/mirror/manager.ts
@@ -259,7 +259,7 @@ export class MirrorManager {
         deviceId: target.deviceId,
         pipeline: source.pipeline,
         fps: source.nominalFps,
-        hint: source.pipeline === 'simctl' ? SIMCTL_HINT : undefined,
+        hint: source.pipeline === 'simctl' ? (source.degradedHint ?? SIMCTL_HINT) : undefined,
       });
     }
     this.broadcast(frame);

--- a/packages/rn-dev-agent-core/src/observability/mirror/sources.ts
+++ b/packages/rn-dev-agent-core/src/observability/mirror/sources.ts
@@ -14,6 +14,8 @@ export interface MirrorFrameSink {
 export interface MirrorSource {
   readonly pipeline: 'idb' | 'simctl' | 'screenrecord';
   readonly nominalFps: number;
+  /** Why this source is a degraded fallback, when the reason is not the default one. */
+  readonly degradedHint?: string;
   start(sink: MirrorFrameSink): void;
   /**
    * IosSimctlLoopSource aborts its in-flight capture on stop() via
@@ -51,6 +53,7 @@ export interface LoopOpts {
   idleDelayMs?: number;
   failurePauseMs?: number;
   tmpPath?: () => string;
+  degradedHint?: string;
 }
 
 export type SpawnFn = (cmd: string, args: string[]) => SpawnedLike;
@@ -63,11 +66,20 @@ export interface SpawnedLike {
   kill(): void;
 }
 
-export const SIMCTL_HINT =
-  'install idb for smoother mirroring (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb)';
+// GH#578: a bare `pipx install fb-idb` resolves the newest interpreter. On
+// Python 3.14 that reinstalls the exact combination that crashes (fb-idb 1.1.7
+// calls asyncio.get_event_loop(), removed in 3.14), so the hint the user
+// follows recreates the break. Every printed command pins the interpreter.
+export const IDB_INSTALL_COMMAND =
+  'brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 fb-idb';
 
-const IDB_HINT =
-  'idb not found — brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb';
+export const SIMCTL_HINT = `install idb for smoother mirroring (${IDB_INSTALL_COMMAND})`;
+
+export const SIMCTL_BROKEN_IDB_HINT =
+  'idb is installed but its client crashes on every invocation — fb-idb 1.1.7 needs asyncio.get_event_loop(), removed in Python 3.14. ' +
+  'Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb';
+
+const IDB_HINT = `idb not found — ${IDB_INSTALL_COMMAND}`;
 const FFMPEG_HINT = 'ffmpeg not found — run scripts/ensure-ffmpeg.sh or brew install ffmpeg';
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
@@ -84,15 +96,27 @@ const scheduleAfter = (fn: () => void, delayMs: number): void => {
 const defaultSpawn: SpawnFn = (cmd, args) =>
   spawn(cmd, args, { stdio: ['pipe', 'pipe', 'pipe'] }) as unknown as SpawnedLike;
 
-export async function detectIdb(execFileFn: typeof execFile = execFile): Promise<boolean> {
+/** absent = not on PATH, ready = usable, broken = present but crashes (GH#578). */
+export type IdbClientState = 'absent' | 'ready' | 'broken';
+
+export async function probeIdbClient(
+  execFileFn: typeof execFile = execFile,
+): Promise<IdbClientState> {
   return new Promise((resolve) => {
     // B269/B263: PATH presence is not health. fb-idb on an incompatible
     // Python (e.g. 3.14) crashes on EVERY invocation; selecting the idb tier
     // for such a client kills the mirror ("idb video-stream keeps exiting")
-    // instead of using the working simctl fallback. Probe a real invocation:
-    // ENOENT, a crash, or a hang all resolve false -> simctl tier.
-    execFileFn('idb', ['--help'], { timeout: 3000 }, (err) => resolve(!err));
+    // instead of using the working simctl fallback. `idb --help` initializes
+    // the CLI without contacting a companion, so it separates the states.
+    execFileFn('idb', ['--help'], { timeout: 3000 }, (err) => {
+      if (!err) return resolve('ready');
+      resolve(isEnoent(err) ? 'absent' : 'broken');
+    });
   });
+}
+
+export async function detectIdb(execFileFn: typeof execFile = execFile): Promise<boolean> {
+  return (await probeIdbClient(execFileFn)) === 'ready';
 }
 
 function isEnoent(err: unknown): boolean {
@@ -179,6 +203,7 @@ export class IosIdbSource implements MirrorSource {
 export class IosSimctlLoopSource implements MirrorSource {
   readonly pipeline = 'simctl' as const;
   readonly nominalFps = 6;
+  readonly degradedHint: string;
   private active = false;
   private inFlight: AbortController | null = null;
   private readonly execJpeg: (cmd: string, args: string[], signal?: AbortSignal) => Promise<Buffer>;
@@ -197,6 +222,7 @@ export class IosSimctlLoopSource implements MirrorSource {
     this.failurePauseMs = opts.failurePauseMs ?? 500;
     this.tmpPath =
       opts.tmpPath ?? (() => join(tmpdir(), 'rn-mirror-simctl-' + process.pid + '.jpg'));
+    this.degradedHint = opts.degradedHint ?? SIMCTL_HINT;
   }
 
   start(sink: MirrorFrameSink): void {
@@ -223,7 +249,8 @@ export class IosSimctlLoopSource implements MirrorSource {
         // RestartGate or trigger a failure pause.
         if (!this.active) break;
         if (!this.gate.record()) {
-          if (this.active) sink.onExit({ reason: 'simctl screenshot failing', hint: SIMCTL_HINT });
+          if (this.active)
+            sink.onExit({ reason: 'simctl screenshot failing', hint: this.degradedHint });
           this.active = false;
           break;
         }
@@ -397,6 +424,11 @@ export async function createMirrorSource(
   if (target.platform === 'android') {
     return new AndroidScreenrecordSource(target.deviceId);
   }
-  const hasIdb = await detectIdb();
-  return hasIdb ? new IosIdbSource(target.deviceId, fps) : new IosSimctlLoopSource(target.deviceId);
+  const state = await probeIdbClient();
+  if (state === 'ready') return new IosIdbSource(target.deviceId, fps);
+  // GH#578: a crashing client is NOT "idb missing" — telling the developer to
+  // install what they already installed is the loop this fix removes.
+  return new IosSimctlLoopSource(target.deviceId, {
+    degradedHint: state === 'broken' ? SIMCTL_BROKEN_IDB_HINT : SIMCTL_HINT,
+  });
 }

--- a/packages/rn-dev-agent-core/src/observability/mirror/sources.ts
+++ b/packages/rn-dev-agent-core/src/observability/mirror/sources.ts
@@ -70,13 +70,20 @@ export interface SpawnedLike {
 // Python 3.14 that reinstalls the exact combination that crashes (fb-idb 1.1.7
 // calls asyncio.get_event_loop(), removed in 3.14), so the hint the user
 // follows recreates the break. Every printed command pins the interpreter.
+// Mirrors the no-interpreter variant of install_command() in
+// scripts/ensure-idb.sh: the interpreter install is prepended because a
+// python3.14-only machine would otherwise get `pipx: No such python` — a hint
+// the developer cannot follow, which is the defect this change removes.
 export const IDB_INSTALL_COMMAND =
-  'brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 fb-idb';
+  'brew install python@3.13 && brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb';
 
 export const SIMCTL_HINT = `install idb for smoother mirroring (${IDB_INSTALL_COMMAND})`;
 
+// The probe only sees a non-zero exit, so the cause is stated as probable:
+// a timeout or EACCES lands here too, and a confidently wrong diagnosis is the
+// same defect as a hint that cannot be followed.
 export const SIMCTL_BROKEN_IDB_HINT =
-  'idb is installed but its client crashes on every invocation — fb-idb 1.1.7 needs asyncio.get_event_loop(), removed in Python 3.14. ' +
+  'idb is installed but did not respond successfully — most likely fb-idb 1.1.7 under Python 3.14, which removed the asyncio.get_event_loop() it needs. ' +
   'Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb';
 
 const IDB_HINT = `idb not found — ${IDB_INSTALL_COMMAND}`;

--- a/packages/rn-dev-agent-core/src/session/bound-directory.ts
+++ b/packages/rn-dev-agent-core/src/session/bound-directory.ts
@@ -105,6 +105,9 @@ export interface BoundOperationDependencies {
 
 const WAIT_BUFFER = new Int32Array(new SharedArrayBuffer(4));
 const WORKER_READY_TIMEOUT_MS = 30_000;
+// NOTE: bound writes fsync, so a loaded host can stall one round trip for
+// seconds — this budget must only catch a wedged worker, not a slow one.
+const WORKER_OPERATION_TIMEOUT_MS = 30_000;
 
 const BOUND_DIRECTORY_LIFECYCLE_MONITOR = String.raw`
 const fs = require('node:fs');
@@ -1500,7 +1503,11 @@ function runBoundOperation(
     throw new Error('SESSION_INTEGRATION_PATH_UNSAFE: bound directory path changed');
   }
   try {
-    const result = sendOperation(directory, request, dependencies.timeoutMs ?? 5_000);
+    const result = sendOperation(
+      directory,
+      request,
+      dependencies.timeoutMs ?? WORKER_OPERATION_TIMEOUT_MS,
+    );
     if (!result.ok) throwOperationFailure(result);
     if (request.operation === 'cas' && result.cleanupPending) {
       if (result.cleanupError) return result;
@@ -1515,7 +1522,7 @@ function runBoundOperation(
             journal: request.journal,
             writes: request.writes,
           },
-          dependencies.recoveryTimeoutMs ?? 5_000,
+          dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS,
         );
         if (!cleanup.ok) throwOperationFailure(cleanup);
         if (!cleanup.committed) {
@@ -1540,7 +1547,7 @@ function runBoundOperation(
                 journal: request.journal,
                 writes: request.writes,
               },
-              dependencies.recoveryTimeoutMs ?? 5_000,
+              dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS,
             );
             if (!cleanup.ok) throwOperationFailure(cleanup);
             if (!cleanup.committed) {
@@ -1584,7 +1591,7 @@ function runBoundOperation(
             writes: request.writes,
             recoveryDelayAfterUnlinkMs: dependencies.recoveryDelayAfterUnlinkMs ?? 0,
           },
-          dependencies.recoveryTimeoutMs ?? 5_000,
+          dependencies.recoveryTimeoutMs ?? WORKER_OPERATION_TIMEOUT_MS,
         );
         if (!recovery.ok) throwOperationFailure(recovery);
         break;

--- a/packages/rn-dev-agent-core/test/unit/mirror-sources.test.js
+++ b/packages/rn-dev-agent-core/test/unit/mirror-sources.test.js
@@ -2,6 +2,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
+import { readFileSync } from 'node:fs';
 import { PassThrough } from 'node:stream';
 import {
   RestartGate,
@@ -377,7 +378,9 @@ test('probeIdbClient: crash on invocation -> broken, distinct from absent', asyn
 });
 
 test('idb install command pins the interpreter (never bare `pipx install fb-idb`)', () => {
-  assert.match(IDB_INSTALL_COMMAND, /pipx install --python python3\.13 fb-idb/);
+  assert.match(IDB_INSTALL_COMMAND, /pipx install --python python3\.13 --force fb-idb/);
+  // GH#578: a python3.14-only machine must not be handed `pipx: No such python`.
+  assert.match(IDB_INSTALL_COMMAND, /^brew install python@3\.13 &&/);
   for (const hint of [SIMCTL_HINT, SIMCTL_BROKEN_IDB_HINT, IDB_INSTALL_COMMAND]) {
     assert.doesNotMatch(hint, /pipx install fb-idb/);
   }
@@ -394,4 +397,15 @@ test('simctl fallback carries the broken-client hint when idb crashes', () => {
   const broken = new IosSimctlLoopSource('UDID', { degradedHint: SIMCTL_BROKEN_IDB_HINT });
   assert.equal(broken.degradedHint, SIMCTL_BROKEN_IDB_HINT);
   assert.equal(new IosSimctlLoopSource('UDID').degradedHint, SIMCTL_HINT);
+});
+
+// The TS constant duplicates the shell's no-interpreter install command by
+// design (no runtime probing in the core package), so guard the duplication
+// rather than building machinery to keep the two in sync.
+test('IDB_INSTALL_COMMAND matches the command ensure-idb.sh produces', () => {
+  const shell = readFileSync(new URL('../../../../scripts/ensure-idb.sh', import.meta.url), 'utf8');
+  assert.ok(
+    shell.includes(IDB_INSTALL_COMMAND),
+    'ensure-idb.sh no longer emits the exact IDB_INSTALL_COMMAND string — they have drifted',
+  );
 });

--- a/packages/rn-dev-agent-core/test/unit/mirror-sources.test.js
+++ b/packages/rn-dev-agent-core/test/unit/mirror-sources.test.js
@@ -9,7 +9,10 @@ import {
   IosSimctlLoopSource,
   AndroidScreenrecordSource,
   SIMCTL_HINT,
+  SIMCTL_BROKEN_IDB_HINT,
+  IDB_INSTALL_COMMAND,
   detectIdb,
+  probeIdbClient,
 } from '../../dist/observability/mirror/sources.js';
 
 const SOI = Buffer.from([0xff, 0xd8]);
@@ -348,4 +351,47 @@ test('detectIdb: missing client (ENOENT) resolves false', async () => {
     cb(Object.assign(new Error('spawn idb ENOENT'), { code: 'ENOENT' }));
   });
   assert.equal(ok, false);
+});
+
+// GH#578: the three client states must stay distinct. Collapsing
+// present-but-broken into absent is what produced the non-converging
+// "install idb" loop, and the printed command must never be the unpinned
+// `pipx install fb-idb` that reinstalls the crashing combination.
+test('probeIdbClient: exit 0 -> ready', async () => {
+  const state = await probeIdbClient((_cmd, _args, _opts, cb) => cb(null));
+  assert.equal(state, 'ready');
+});
+
+test('probeIdbClient: ENOENT -> absent', async () => {
+  const state = await probeIdbClient((_cmd, _args, _opts, cb) =>
+    cb(Object.assign(new Error('spawn idb ENOENT'), { code: 'ENOENT' })),
+  );
+  assert.equal(state, 'absent');
+});
+
+test('probeIdbClient: crash on invocation -> broken, distinct from absent', async () => {
+  const state = await probeIdbClient((_cmd, _args, _opts, cb) =>
+    cb(Object.assign(new Error('RuntimeError: There is no current event loop'), { code: 1 })),
+  );
+  assert.equal(state, 'broken');
+});
+
+test('idb install command pins the interpreter (never bare `pipx install fb-idb`)', () => {
+  assert.match(IDB_INSTALL_COMMAND, /pipx install --python python3\.13 fb-idb/);
+  for (const hint of [SIMCTL_HINT, SIMCTL_BROKEN_IDB_HINT, IDB_INSTALL_COMMAND]) {
+    assert.doesNotMatch(hint, /pipx install fb-idb/);
+  }
+});
+
+test('SIMCTL_BROKEN_IDB_HINT names the incompatibility, not a missing install', () => {
+  assert.match(SIMCTL_BROKEN_IDB_HINT, /installed/);
+  assert.match(SIMCTL_BROKEN_IDB_HINT, /Python 3\.14/);
+  assert.match(SIMCTL_BROKEN_IDB_HINT, /asyncio\.get_event_loop/);
+  assert.doesNotMatch(SIMCTL_BROKEN_IDB_HINT, /install idb for smoother mirroring/);
+});
+
+test('simctl fallback carries the broken-client hint when idb crashes', () => {
+  const broken = new IosSimctlLoopSource('UDID', { degradedHint: SIMCTL_BROKEN_IDB_HINT });
+  assert.equal(broken.degradedHint, SIMCTL_BROKEN_IDB_HINT);
+  assert.equal(new IosSimctlLoopSource('UDID').degradedHint, SIMCTL_HINT);
 });

--- a/packages/rn-dev-agent-core/test/unit/session/package-integration.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/package-integration.test.ts
@@ -2890,6 +2890,31 @@ test('bounded CAS recovery restores a file captured during worker timeout', () =
   }
 });
 
+test('a bound operation slower than five seconds commits instead of timing out', () => {
+  const root = mkdtempSync(join(tmpdir(), 'rn-session-bound-slow-'));
+  const markerPath = join(root, 'authority-marker.js');
+  writeFileSync(markerPath, 'before\n');
+  const directory = openBoundDirectory(root);
+  try {
+    casBoundDirectoryFiles(
+      directory,
+      [
+        {
+          expected: Buffer.from('before\n'),
+          mode: 0o600,
+          name: 'authority-marker.js',
+          replacement: Buffer.from('after\n'),
+        },
+      ],
+      { afterCaptureDelayMs: 6_000 },
+    );
+    assert.equal(readFileSync(markerPath, 'utf8'), 'after\n');
+  } finally {
+    closeBoundDirectory(directory);
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
 test('bounded CAS recovery refuses a journal-less timeout outcome', () => {
   const root = mkdtempSync(join(tmpdir(), 'rn-session-bound-unknown-'));
   const markerPath = join(root, 'authority-marker.js');

--- a/packages/shared-agent-knowledge/commands/doctor.md
+++ b/packages/shared-agent-knowledge/commands/doctor.md
@@ -18,10 +18,13 @@ For **linked-worktree action inheritance**, resolve the RN app root and run the 
 
 For **idb**, require both a healthy `idb --help` and `idb_companion`; an active
 install PID is INSTALLING. A client on PATH whose `idb --help` fails is BROKEN,
-not MISSING — report the interpreter incompatibility (GH#578) and the pinned
-repair command, never a bare `pipx install fb-idb`. Otherwise report MISSING and
-the documented install command. This row is YELLOW because mirroring has a
-screenshot fallback.
+not MISSING — report it as installed but not responding, naming the Python 3.14
+interpreter incompatibility as the *probable* cause rather than a certainty (the
+probe cannot separate a crash from a timeout or EACCES), and give the pinned
+repair command, never a bare `pipx install fb-idb`. On a machine with no
+supported interpreter, prefix that command with `brew install python@3.13 &&`.
+Otherwise report MISSING and the documented install command. This row is YELLOW
+because mirroring has a screenshot fallback.
 
 For runner provenance, inspect the runner artifact/state metadata documented by
 `rn-setup`. For helpers, use a narrow gated CDP read. For CDP auto-reconnect,

--- a/packages/shared-agent-knowledge/commands/doctor.md
+++ b/packages/shared-agent-knowledge/commands/doctor.md
@@ -17,8 +17,11 @@ auto-reconnect configuration from passive `cdp_status`.
 For **linked-worktree action inheritance**, resolve the RN app root and run the packaged `worktree-inheritance.js plan --host claude --app-root <app> --json`. Report `.rn-agent/actions` as tracked, inherited, missing, legacy-migration-needed, unsafe, or refused. Also report `hook status`. Never apply, repair, install a hook, print a private source path, or inspect an action body from doctor.
 
 For **idb**, require both a healthy `idb --help` and `idb_companion`; an active
-install PID is INSTALLING, otherwise report MISSING and the documented install
-command. This row is YELLOW because mirroring has a screenshot fallback.
+install PID is INSTALLING. A client on PATH whose `idb --help` fails is BROKEN,
+not MISSING — report the interpreter incompatibility (GH#578) and the pinned
+repair command, never a bare `pipx install fb-idb`. Otherwise report MISSING and
+the documented install command. This row is YELLOW because mirroring has a
+screenshot fallback.
 
 For runner provenance, inspect the runner artifact/state metadata documented by
 `rn-setup`. For helpers, use a narrow gated CDP read. For CDP auto-reconnect,

--- a/packages/shared-agent-knowledge/skills/rn-setup/SKILL.md
+++ b/packages/shared-agent-knowledge/skills/rn-setup/SKILL.md
@@ -193,6 +193,9 @@ interpreter pin is required; a bare `pipx install fb-idb` resolves the newest Py
 and recreates the break): `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb`.
 On a machine with no supported interpreter, prepend the interpreter install:
 `brew install python@3.13 && ...` (same form `install_command()` produces).
+When the client is OK and only the companion is missing, give the companion half
+alone — `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion`
+(same form `companion_command()` produces) — never the fb-idb reinstall.
 
 ### 11. Physical device prerequisites (optional — M9 / Phase 111)
 
@@ -301,7 +304,7 @@ Present results as a table:
 | CDP connection | CONNECTED | — |
 | Injected helpers | OK / MISSING | If MISSING: fall back to `device_*` tools or call `cdp_reload`. Do not retry `cdp_status` in a loop. |
 | ffmpeg | OK (v7.1) | — |
-| idb (screen mirror fast path) | OK / INSTALLING (background) / BROKEN (installed, did not respond) / MISSING | If MISSING or BROKEN: `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb`, prefixed with `brew install python@3.13 &&` when no supported interpreter is installed. The `--python` pin is required (GH#578). Report the incompatibility as the probable cause, not a certainty. Optional — mirror falls back to ~6fps simctl |
+| idb (screen mirror fast path) | OK / INSTALLING (background) / BROKEN (installed, did not respond) / MISSING | If MISSING or BROKEN: `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb`, prefixed with `brew install python@3.13 &&` when no supported interpreter is installed. If only the companion is missing, drop the `pipx` half. The `--python` pin is required (GH#578). Report the incompatibility as the probable cause, not a certainty. Optional — mirror falls back to ~6fps simctl |
 | Physical devices | N/A (none connected) OR "Android USB reverse: OK" / "iOS: idb-companion missing — install with brew" | Run installed command if iOS-companion missing |
 | Plugin version | OK (latest) / BEHIND (installed X, latest Y) / OFFLINE / AHEAD (dev install) | Run: `/plugin update rn-dev-agent` if BEHIND |
 | Vercel rules sync | OK (N rules, fetched X days ago) / STALE (> 30 days) / MISSING / DRIFT / N/A (installed plugin) | Repo checkout only: node scripts/sync-vercel-skills.mjs --fix --ref \<sha\> |

--- a/packages/shared-agent-knowledge/skills/rn-setup/SKILL.md
+++ b/packages/shared-agent-knowledge/skills/rn-setup/SKILL.md
@@ -176,7 +176,9 @@ If missing: `brew install ffmpeg` (not critical — videos work without it, GIF 
 
 ### 10. idb (optional — fast screen mirroring)
 ```bash
-idb --help >/dev/null 2>&1 && { command -v idb_companion || command -v idb-companion; }
+command -v idb || echo "idb MISSING"
+idb --help >/dev/null 2>&1 && echo "idb client OK" || echo "idb client BROKEN (only if the line above found it)"
+command -v idb_companion || command -v idb-companion || echo "idb-companion MISSING"
 ```
 Both binaries present → the observe UI's live mirror uses `idb video-stream`
 (20–30fps). Missing → the mirror still works via a ~6fps `simctl screenshot`

--- a/packages/shared-agent-knowledge/skills/rn-setup/SKILL.md
+++ b/packages/shared-agent-knowledge/skills/rn-setup/SKILL.md
@@ -183,12 +183,15 @@ Both binaries present → the observe UI's live mirror uses `idb video-stream`
 loop. SessionStart auto-installs in the background (`scripts/ensure-idb.sh`);
 if `~/.rn-dev-agent/idb/install.pid` exists and its PID is alive, report
 "installing in background (log: ~/.rn-dev-agent/idb/install.log)" instead of
-MISSING. A client that is on PATH but exits non-zero is BROKEN, not MISSING: fb-idb
-1.1.7 needs `asyncio.get_event_loop()`, removed in Python 3.14, so it crashes on
-every invocation (GH#578). Report the incompatibility — never tell the developer to
-install what they already installed. Manual install/repair (the interpreter pin is
-required; a bare `pipx install fb-idb` resolves the newest Python and recreates the
-break): `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb`.
+MISSING. A client that is on PATH but exits non-zero is BROKEN, not MISSING. State
+the cause as probable, not certain: the probe only sees a non-zero exit, and a
+timeout or EACCES lands there too. The most likely cause is fb-idb needing
+`asyncio.get_event_loop()`, which Python 3.14 removed (GH#578). Never tell the
+developer to install what they already installed. Manual install/repair (the
+interpreter pin is required; a bare `pipx install fb-idb` resolves the newest Python
+and recreates the break): `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb`.
+On a machine with no supported interpreter, prepend the interpreter install:
+`brew install python@3.13 && ...` (same form `install_command()` produces).
 
 ### 11. Physical device prerequisites (optional — M9 / Phase 111)
 
@@ -297,7 +300,7 @@ Present results as a table:
 | CDP connection | CONNECTED | — |
 | Injected helpers | OK / MISSING | If MISSING: fall back to `device_*` tools or call `cdp_reload`. Do not retry `cdp_status` in a loop. |
 | ffmpeg | OK (v7.1) | — |
-| idb (screen mirror fast path) | OK / INSTALLING (background) / BROKEN (installed, crashes) / MISSING | If MISSING or BROKEN: `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb` — the `--python` pin is required (GH#578); optional, mirror falls back to ~6fps simctl |
+| idb (screen mirror fast path) | OK / INSTALLING (background) / BROKEN (installed, did not respond) / MISSING | If MISSING or BROKEN: `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb`, prefixed with `brew install python@3.13 &&` when no supported interpreter is installed. The `--python` pin is required (GH#578). Report the incompatibility as the probable cause, not a certainty. Optional — mirror falls back to ~6fps simctl |
 | Physical devices | N/A (none connected) OR "Android USB reverse: OK" / "iOS: idb-companion missing — install with brew" | Run installed command if iOS-companion missing |
 | Plugin version | OK (latest) / BEHIND (installed X, latest Y) / OFFLINE / AHEAD (dev install) | Run: `/plugin update rn-dev-agent` if BEHIND |
 | Vercel rules sync | OK (N rules, fetched X days ago) / STALE (> 30 days) / MISSING / DRIFT / N/A (installed plugin) | Repo checkout only: node scripts/sync-vercel-skills.mjs --fix --ref \<sha\> |

--- a/packages/shared-agent-knowledge/skills/rn-setup/SKILL.md
+++ b/packages/shared-agent-knowledge/skills/rn-setup/SKILL.md
@@ -176,9 +176,8 @@ If missing: `brew install ffmpeg` (not critical — videos work without it, GIF 
 
 ### 10. idb (optional — fast screen mirroring)
 ```bash
-command -v idb || echo "idb MISSING"
-idb --help >/dev/null 2>&1 && echo "idb client OK" || echo "idb client BROKEN (only if the line above found it)"
-command -v idb_companion || command -v idb-companion || echo "idb-companion MISSING"
+command -v idb >/dev/null && { idb --help >/dev/null 2>&1 && echo "idb client OK" || echo "idb client BROKEN"; } || echo "idb MISSING"
+command -v idb_companion >/dev/null || command -v idb-companion >/dev/null && echo "idb-companion OK" || echo "idb-companion MISSING"
 ```
 Both binaries present → the observe UI's live mirror uses `idb video-stream`
 (20–30fps). Missing → the mirror still works via a ~6fps `simctl screenshot`

--- a/packages/shared-agent-knowledge/skills/rn-setup/SKILL.md
+++ b/packages/shared-agent-knowledge/skills/rn-setup/SKILL.md
@@ -176,14 +176,19 @@ If missing: `brew install ffmpeg` (not critical — videos work without it, GIF 
 
 ### 10. idb (optional — fast screen mirroring)
 ```bash
-command -v idb && { command -v idb_companion || command -v idb-companion; }
+idb --help >/dev/null 2>&1 && { command -v idb_companion || command -v idb-companion; }
 ```
 Both binaries present → the observe UI's live mirror uses `idb video-stream`
 (20–30fps). Missing → the mirror still works via a ~6fps `simctl screenshot`
 loop. SessionStart auto-installs in the background (`scripts/ensure-idb.sh`);
 if `~/.rn-dev-agent/idb/install.pid` exists and its PID is alive, report
 "installing in background (log: ~/.rn-dev-agent/idb/install.log)" instead of
-MISSING. Manual install: `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb`.
+MISSING. A client that is on PATH but exits non-zero is BROKEN, not MISSING: fb-idb
+1.1.7 needs `asyncio.get_event_loop()`, removed in Python 3.14, so it crashes on
+every invocation (GH#578). Report the incompatibility — never tell the developer to
+install what they already installed. Manual install/repair (the interpreter pin is
+required; a bare `pipx install fb-idb` resolves the newest Python and recreates the
+break): `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb`.
 
 ### 11. Physical device prerequisites (optional — M9 / Phase 111)
 
@@ -292,7 +297,7 @@ Present results as a table:
 | CDP connection | CONNECTED | — |
 | Injected helpers | OK / MISSING | If MISSING: fall back to `device_*` tools or call `cdp_reload`. Do not retry `cdp_status` in a loop. |
 | ffmpeg | OK (v7.1) | — |
-| idb (screen mirror fast path) | OK / INSTALLING (background) / MISSING | If MISSING: `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb` (optional — mirror falls back to ~6fps simctl) |
+| idb (screen mirror fast path) | OK / INSTALLING (background) / BROKEN (installed, crashes) / MISSING | If MISSING or BROKEN: `brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb` — the `--python` pin is required (GH#578); optional, mirror falls back to ~6fps simctl |
 | Physical devices | N/A (none connected) OR "Android USB reverse: OK" / "iOS: idb-companion missing — install with brew" | Run installed command if iOS-companion missing |
 | Plugin version | OK (latest) / BEHIND (installed X, latest Y) / OFFLINE / AHEAD (dev install) | Run: `/plugin update rn-dev-agent` if BEHIND |
 | Vercel rules sync | OK (N rules, fetched X days ago) / STALE (> 30 days) / MISSING / DRIFT / N/A (installed plugin) | Repo checkout only: node scripts/sync-vercel-skills.mjs --fix --ref \<sha\> |

--- a/scripts/ensure-idb.sh
+++ b/scripts/ensure-idb.sh
@@ -266,11 +266,11 @@ if [ "${LAST_STATUS:-}" = "failed" ] && [ -n "${LAST_TS:-}" ]; then
     # This line is what the developer reads for the next 24h, so it must carry
     # the cause the worker determined rather than defaulting to an install
     # command that, for the shim case, already succeeded.
-    if [ "${LAST_CAUSE:-}" = "path-shim" ]; then
+    if [ "$CLIENT_STATE" = ready ]; then
+      echo "idb-companion install failed recently — retrying after backoff (manual: $(companion_command), log: $LOG)"
+    elif [ "$CLIENT_STATE" = absent ] && [ "${LAST_CAUSE:-}" = "path-shim" ]; then
       path_shim_explanation
       echo "Retrying the install after backoff anyway (log: $LOG)."
-    elif [ "$CLIENT_STATE" = ready ]; then
-      echo "idb-companion install failed recently — retrying after backoff (manual: $(companion_command), log: $LOG)"
     else
       echo "idb install failed recently — retrying after backoff (manual: $(install_command), log: $LOG)"
     fi

--- a/scripts/ensure-idb.sh
+++ b/scripts/ensure-idb.sh
@@ -102,6 +102,12 @@ install_command() {
   fi
 }
 
+# The companion half alone: a client that already works must never be told to
+# reinstall fb-idb.
+companion_command() {
+  echo "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion"
+}
+
 # The probe only observes a non-zero exit (a timeout or EACCES lands here too),
 # so the cause is stated as probable rather than asserted as fact.
 incompatible_explanation() {
@@ -219,7 +225,7 @@ if [ "$CLIENT_STATE" != ready ] && [ "${LAST_STATUS:-}" = "incompatible" ] && [ 
     echo "idb is not installed, and no supported Python is available to install it (need one of: $SUPPORTED_PYTHONS)."
     echo "Recover with: $(install_command)"
   fi
-  echo "Not retrying until the installed Python interpreters change (log: $LOG). Mirroring stays on the ~6fps simctl tier."
+  echo "Not retrying until the installed Python interpreters change — delete $MARKER to force a retry (e.g. after a newer fb-idb ships). Log: $LOG. Mirroring stays on the ~6fps simctl tier."
   exit 0
 fi
 
@@ -230,8 +236,13 @@ if [ "$CLIENT_STATE" = broken ]; then
     exit 0
   fi
 elif ! command -v brew >/dev/null 2>&1; then
-  echo "idb not installed (optional — enables 20-30fps screen mirroring instead of ~6fps)."
-  echo "Install manually: $(install_command)"
+  if [ "$CLIENT_STATE" = ready ]; then
+    echo "idb-companion not installed (the idb client works; the companion is the missing half)."
+    echo "Install manually: $(companion_command)"
+  else
+    echo "idb not installed (optional — enables 20-30fps screen mirroring instead of ~6fps)."
+    echo "Install manually: $(install_command)"
+  fi
   exit 0
 fi
 
@@ -258,6 +269,8 @@ if [ "${LAST_STATUS:-}" = "failed" ] && [ -n "${LAST_TS:-}" ]; then
     if [ "${LAST_CAUSE:-}" = "path-shim" ]; then
       path_shim_explanation
       echo "Retrying the install after backoff anyway (log: $LOG)."
+    elif [ "$CLIENT_STATE" = ready ]; then
+      echo "idb-companion install failed recently — retrying after backoff (manual: $(companion_command), log: $LOG)"
     else
       echo "idb install failed recently — retrying after backoff (manual: $(install_command), log: $LOG)"
     fi
@@ -270,6 +283,10 @@ fi
 # they then prevent.
 if [ "$CLIENT_STATE" = absent ]; then
   NOTICE="idb missing — installing in background ($(install_command)). Log: $LOG"
+elif [ "$CLIENT_STATE" = ready ]; then
+  # The client already works; the worker's own guard skips pipx entirely here,
+  # so promising an interpreter repair would describe work that never runs.
+  NOTICE="idb-companion missing — installing it in background ($(companion_command)). Log: $LOG"
 else
   NOTICE="Repairing in the background under a supported interpreter ($SUPPORTED_PYTHONS). Manual: $(install_command). Log: $LOG"
 fi

--- a/scripts/ensure-idb.sh
+++ b/scripts/ensure-idb.sh
@@ -122,26 +122,37 @@ if [ "${1:-}" = "--install-worker" ]; then
       # newest, which is exactly the one that produces a crashing client.
       # Walk the supported interpreters until one yields a healthy client.
       tried=""
+      installed=""
       for py in $SUPPORTED_PYTHONS; do
         command -v "$py" >/dev/null 2>&1 || continue
         echo "installing fb-idb under $py"
         tried="$tried $py"
         pipx install --python "$py" --force fb-idb || continue
+        installed=yes
         [ "$(idb_client_state)" = ready ] && break
       done
       if [ "$(idb_client_state)" != ready ]; then
-        # No available interpreter produces a working client. Retrying cannot
-        # change that, so record a distinct verdict with the interpreter
-        # fingerprint and stop — the foreground path reports the truth instead
-        # of re-showing an install hint the developer has already followed.
-        # A brew failure earlier in this run stays `failed`: that one IS worth
-        # retrying, and its backoff must not be replaced by a terminal verdict.
-        [ "$status" = failed ] || status=incompatible
-        incompatible_explanation
-        if [ -n "$tried" ]; then
-          echo "tried:$tried — none produced a working client; the mirror stays on the simctl tier"
+        if [ -n "$tried" ] && [ -z "$installed" ]; then
+          # Every pinned install command itself failed (network, PyPI, pipx).
+          # That is transient, so it must stay retryable: the terminal verdict
+          # requires evidence of incompatibility, not merely absence of success.
+          status=failed
+          echo "tried:$tried — every pinned install failed; retrying after backoff"
         else
-          echo "no supported Python found (need one of: $SUPPORTED_PYTHONS). Install one, then re-run: $(install_command)"
+          # Either a pinned install succeeded and the client still crashes, or
+          # no supported interpreter exists at all. Retrying cannot change that,
+          # so record a distinct verdict with the interpreter fingerprint and
+          # stop — the foreground path reports the truth instead of re-showing
+          # an install hint the developer has already followed.
+          # A brew failure earlier in this run stays `failed`: that one IS worth
+          # retrying, and its backoff must not be replaced by a terminal verdict.
+          [ "$status" = failed ] || status=incompatible
+          if [ -n "$tried" ]; then
+            incompatible_explanation
+            echo "tried:$tried — none produced a working client; the mirror stays on the simctl tier"
+          else
+            echo "no supported Python found (need one of: $SUPPORTED_PYTHONS). Install one, then re-run: $(install_command)"
+          fi
         fi
       fi
     else
@@ -169,10 +180,13 @@ if [ -f "$MARKER" ]; then
   read -r LAST_STATUS LAST_TS LAST_FP < "$MARKER" 2>/dev/null || LAST_STATUS=""
 fi
 
-# The incompatible verdict outranks every other branch: it is the one state
-# where an install hint is actively wrong (GH#578). It holds until the set of
-# installed interpreters changes; delete "$MARKER" to force a retry.
-if [ "${LAST_STATUS:-}" = "incompatible" ] && [ "${LAST_FP:-}" = "$(python_fingerprint)" ]; then
+# The incompatible verdict outranks every other branch while the client is
+# actually broken: that is the one state where an install hint is actively
+# wrong (GH#578). It holds until the set of installed interpreters changes;
+# delete "$MARKER" to force a retry. A verdict may never contradict the live
+# probe — a client that now reads ready or absent falls through to the normal
+# path so the missing piece (companion, or the client itself) still gets fixed.
+if [ "$CLIENT_STATE" = broken ] && [ "${LAST_STATUS:-}" = "incompatible" ] && [ "${LAST_FP:-}" = "$(python_fingerprint)" ]; then
   incompatible_explanation
   if first_supported_python >/dev/null; then
     echo "Recover with: $(install_command)"
@@ -189,7 +203,6 @@ if [ "$CLIENT_STATE" = broken ]; then
     echo "Recover with: $(install_command)"
     exit 0
   fi
-  echo "Repairing in the background under a supported interpreter ($SUPPORTED_PYTHONS). Manual: $(install_command)"
 elif ! command -v brew >/dev/null 2>&1; then
   echo "idb not installed (optional — enables 20-30fps screen mirroring instead of ~6fps)."
   echo "Install manually: $(install_command)"
@@ -218,10 +231,13 @@ if [ "${LAST_STATUS:-}" = "failed" ] && [ -n "${LAST_TS:-}" ]; then
   fi
 fi
 
+# Only this path actually spawns, so the "repairing" claim belongs here — the
+# pidfile and backoff guards above must not be preceded by a promise of work
+# they then prevent.
 if [ "$CLIENT_STATE" = absent ]; then
   NOTICE="idb missing — installing in background ($(install_command)). Log: $LOG"
 else
-  NOTICE="idb repair running in background. Log: $LOG"
+  NOTICE="Repairing in the background under a supported interpreter ($SUPPORTED_PYTHONS). Manual: $(install_command). Log: $LOG"
 fi
 
 if [ "${RN_AGENT_IDB_DRY_SPAWN:-}" = "1" ]; then

--- a/scripts/ensure-idb.sh
+++ b/scripts/ensure-idb.sh
@@ -4,23 +4,34 @@
 # The mirror's iOS fast path is `idb video-stream` (20-30fps MJPEG); without
 # idb it degrades to a ~6fps `simctl screenshot` loop. idb needs two pieces
 # (idb-companion lives in the facebook/fb tap, not homebrew-core):
-#   brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion   (the macOS daemon)
-#   pipx install fb-idb                                   (the Python CLI client)
+#   brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion
+#   pipx install --python python3.13 fb-idb                (the Python CLI client)
+#
+# GH#578: the interpreter pin is load-bearing. fb-idb 1.1.7 calls
+# asyncio.get_event_loop() at CLI startup, which Python 3.14 removed, so a
+# bare `pipx install fb-idb` on a 3.14-default machine installs a client that
+# crashes on every invocation. This script therefore treats the client as
+# three distinct states — absent, ready, broken — and never prints an install
+# command that would recreate the broken combination.
 #
 # SessionStart contract (GH#252/B196: session start must be BOUNDED): this
-# script's foreground path only does `command -v` checks and (at most) spawns
-# ONE detached worker — it NEVER runs brew/pipx inline. The worker is
-# nohup'd + disown'd with all stdio detached so the SessionStart hook's
-# timeout cannot be held open by inherited FDs.
+# script's foreground path only does `command -v` / `idb --help` checks and
+# (at most) spawns ONE detached worker — it NEVER runs brew/pipx inline. The
+# worker is nohup'd + disown'd with all stdio detached so the SessionStart
+# hook's timeout cannot be held open by inherited FDs.
 #
 # Re-entry guards:
 #   - pidfile:      a live worker is never duplicated across session starts
 #   - last-attempt: a failed install is not retried for 24h (brew failures
 #     are usually environmental; hammering it every session start is noise)
+#   - incompatible verdict: once no available interpreter can produce a
+#     working client, retrying cannot succeed, so it stops until the set of
+#     installed Python interpreters changes (GH#578).
 #
 # Test seams (scripts/test/ensure-idb.test.sh):
 #   RN_AGENT_IDB_STATE_DIR   state dir      (default: ~/.rn-dev-agent/idb)
 #   RN_AGENT_IDB_UNAME       fake `uname -s`
+#   RN_AGENT_IDB_PYTHONS     override the supported-interpreter candidate list
 #   RN_AGENT_IDB_DRY_SPAWN=1 record the spawn to spawn.log instead of running
 #
 # Exit code: always 0 from the foreground path (mirror works without idb —
@@ -34,6 +45,10 @@ MARKER="$STATE_DIR/last-attempt"
 LOG="$STATE_DIR/install.log"
 BACKOFF_SECS=86400
 
+# Newest first. 3.14 is excluded on purpose: it is the interpreter that breaks
+# fb-idb 1.1.7. Add newer versions here once a compatible fb-idb release ships.
+SUPPORTED_PYTHONS="${RN_AGENT_IDB_PYTHONS:-python3.13 python3.12 python3.11}"
+
 OS="${RN_AGENT_IDB_UNAME:-$(uname -s)}"
 [ "$OS" = "Darwin" ] || exit 0
 
@@ -44,14 +59,51 @@ has_companion() {
   command -v idb_companion >/dev/null 2>&1 || command -v idb-companion >/dev/null 2>&1
 }
 
-# B269: PATH presence is not health — fb-idb installed under an incompatible
-# Python (e.g. 3.14) crashes on EVERY invocation (asyncio get_event_loop).
-# Treating such a client as "present" both skips repair AND poisons the
-# mirror's tier selection (B263). `idb --help` initializes the CLI without
-# contacting a companion, so it exits 0 for a healthy client and non-zero
-# for a broken one.
-idb_client_healthy() {
-  command -v idb >/dev/null 2>&1 && idb --help >/dev/null 2>&1
+# B269: PATH presence is not health. `idb --help` initializes the CLI without
+# contacting a companion, so it exits 0 for a healthy client and non-zero for
+# one crashing under an incompatible interpreter.
+idb_client_state() {
+  if ! command -v idb >/dev/null 2>&1; then
+    echo absent
+  elif idb --help >/dev/null 2>&1; then
+    echo ready
+  else
+    echo broken
+  fi
+}
+
+first_supported_python() {
+  for py in $SUPPORTED_PYTHONS; do
+    if command -v "$py" >/dev/null 2>&1; then
+      echo "$py"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# The only thing that can turn an "incompatible" verdict back into a solvable
+# problem is a change to the installed interpreters, so that is the fingerprint.
+python_fingerprint() {
+  local fp=""
+  for py in $SUPPORTED_PYTHONS; do
+    command -v "$py" >/dev/null 2>&1 && fp="$fp$py,"
+  done
+  echo "${fp:-none}"
+}
+
+install_command() {
+  local py
+  py="$(first_supported_python)" || py=""
+  if [ -n "$py" ]; then
+    echo "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python $py --force fb-idb"
+  else
+    echo "brew install python@3.13 && brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb"
+  fi
+}
+
+incompatible_explanation() {
+  echo "idb is installed but unusable: the fb-idb client crashes on every invocation — it calls asyncio.get_event_loop(), which Python 3.14 removed. Installing it again under the same interpreter reproduces this."
 }
 
 # --install-worker: the detached background job (never reached at SessionStart).
@@ -61,49 +113,82 @@ if [ "${1:-}" = "--install-worker" ]; then
   if ! has_companion; then
     brew tap facebook/fb && { brew trust facebook/fb >/dev/null 2>&1 || true; } && brew install idb-companion || status=failed
   fi
-  if ! idb_client_healthy; then
+  if [ "$(idb_client_state)" != ready ]; then
     if ! command -v pipx >/dev/null 2>&1; then
       brew install pipx && pipx ensurepath || status=failed
     fi
     if command -v pipx >/dev/null 2>&1; then
-      # A present-but-broken client must be replaced, not trusted (B269).
-      if command -v idb >/dev/null 2>&1; then
-        pipx uninstall fb-idb >/dev/null 2>&1 || true
-      fi
-      pipx install fb-idb || status=failed
-      if ! idb_client_healthy; then
-        # Never leave a crash-on-invocation client on PATH: it provides
-        # nothing and re-arms the B263 mirror failure. Uninstall and let the
-        # 24h backoff retry (a future fb-idb release may fix compatibility).
-        pipx uninstall fb-idb >/dev/null 2>&1 || true
-        status=failed
-        echo "fb-idb installed but the client crashes on invocation (incompatible Python?) — uninstalled; the mirror stays on the simctl tier"
+      # GH#578: never let pipx resolve the interpreter itself — it picks the
+      # newest, which is exactly the one that produces a crashing client.
+      # Walk the supported interpreters until one yields a healthy client.
+      for py in $SUPPORTED_PYTHONS; do
+        command -v "$py" >/dev/null 2>&1 || continue
+        echo "installing fb-idb under $py"
+        pipx install --python "$py" --force fb-idb || continue
+        [ "$(idb_client_state)" = ready ] && break
+      done
+      if [ "$(idb_client_state)" != ready ]; then
+        # No available interpreter produces a working client. Retrying cannot
+        # change that, so record a distinct verdict with the interpreter
+        # fingerprint and stop — the foreground path reports the truth instead
+        # of re-showing an install hint the developer has already followed.
+        status=incompatible
+        incompatible_explanation
+        if first_supported_python >/dev/null; then
+          echo "tried: $SUPPORTED_PYTHONS — none produced a working client; the mirror stays on the simctl tier"
+        else
+          echo "no supported Python found (need one of: $SUPPORTED_PYTHONS). Install one, then re-run: $(install_command)"
+        fi
       fi
     else
       status=failed
     fi
   fi
-  echo "$status $(date +%s)" > "$MARKER"
+  echo "$status $(date +%s) $(python_fingerprint)" > "$MARKER"
   rm -f "$PIDFILE"
   echo "ensure-idb worker finished: $status"
   exit 0
 fi
 
-# Foreground path — bounded: checks + at most one detached spawn. The client
-# check is a health probe (one `idb --help` invocation, no daemon contact),
-# not a PATH check — see idb_client_healthy (B269).
-if idb_client_healthy && has_companion; then
+# Foreground path — bounded: checks + at most one detached spawn.
+CLIENT_STATE="$(idb_client_state)"
+
+if [ "$CLIENT_STATE" = ready ] && has_companion; then
+  # A previous verdict no longer describes reality — clear it so a future
+  # break re-arms the full repair path.
+  rm -f "$MARKER"
   echo "idb available: screen mirroring uses the fast path (idb video-stream)"
   exit 0
 fi
 
-if command -v idb >/dev/null 2>&1 && ! idb_client_healthy; then
-  echo "idb client on PATH is broken (crashes on invocation) — the background worker will replace or remove it (B269)"
+if [ -f "$MARKER" ]; then
+  read -r LAST_STATUS LAST_TS LAST_FP < "$MARKER" 2>/dev/null || LAST_STATUS=""
 fi
 
-if ! command -v brew >/dev/null 2>&1; then
+# The incompatible verdict outranks every other branch: it is the one state
+# where an install hint is actively wrong (GH#578). It holds until the set of
+# installed interpreters changes; delete "$MARKER" to force a retry.
+if [ "${LAST_STATUS:-}" = "incompatible" ] && [ "${LAST_FP:-}" = "$(python_fingerprint)" ]; then
+  incompatible_explanation
+  if first_supported_python >/dev/null; then
+    echo "Recover with: $(install_command)"
+  else
+    echo "No supported Python is installed (need one of: $SUPPORTED_PYTHONS). Recover with: $(install_command)"
+  fi
+  echo "Not retrying until the installed Python interpreters change (log: $LOG). Mirroring stays on the ~6fps simctl tier."
+  exit 0
+fi
+
+if [ "$CLIENT_STATE" = broken ]; then
+  incompatible_explanation
+  if ! command -v brew >/dev/null 2>&1; then
+    echo "Recover with: $(install_command)"
+    exit 0
+  fi
+  echo "Repairing in the background under a supported interpreter ($SUPPORTED_PYTHONS). Manual: $(install_command)"
+elif ! command -v brew >/dev/null 2>&1; then
   echo "idb not installed (optional — enables 20-30fps screen mirroring instead of ~6fps)."
-  echo "Install manually: brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb"
+  echo "Install manually: $(install_command)"
   exit 0
 fi
 
@@ -120,19 +205,24 @@ if [ -f "$PIDFILE" ]; then
 fi
 
 # A recent failed attempt backs off for 24h; success never re-enters here
-# (the command -v fast path above wins once binaries exist).
-if [ -f "$MARKER" ]; then
-  read -r LAST_STATUS LAST_TS < "$MARKER" 2>/dev/null || LAST_STATUS=""
+# (the ready fast path above wins once a healthy client exists).
+if [ "${LAST_STATUS:-}" = "failed" ] && [ -n "${LAST_TS:-}" ]; then
   NOW="$(date +%s)"
-  if [ "$LAST_STATUS" = "failed" ] && [ -n "${LAST_TS:-}" ] && [ $((NOW - LAST_TS)) -lt "$BACKOFF_SECS" ]; then
-    echo "idb install failed recently — retrying after backoff (manual: brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb, log: $LOG)"
+  if [ $((NOW - LAST_TS)) -lt "$BACKOFF_SECS" ]; then
+    echo "idb install failed recently — retrying after backoff (manual: $(install_command), log: $LOG)"
     exit 0
   fi
 fi
 
+if [ "$CLIENT_STATE" = absent ]; then
+  NOTICE="idb missing — installing in background ($(install_command)). Log: $LOG"
+else
+  NOTICE="idb repair running in background. Log: $LOG"
+fi
+
 if [ "${RN_AGENT_IDB_DRY_SPAWN:-}" = "1" ]; then
   echo "spawn --install-worker" >> "$STATE_DIR/spawn.log"
-  echo "idb missing — installing in background (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb). Log: $LOG"
+  echo "$NOTICE"
   exit 0
 fi
 
@@ -140,5 +230,5 @@ nohup bash "$0" --install-worker >> "$LOG" 2>&1 < /dev/null &
 WORKER_PID=$!
 disown "$WORKER_PID" 2>/dev/null || true
 echo "$WORKER_PID" > "$PIDFILE"
-echo "idb missing — installing in background (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb). Log: $LOG"
+echo "$NOTICE"
 exit 0

--- a/scripts/ensure-idb.sh
+++ b/scripts/ensure-idb.sh
@@ -102,14 +102,27 @@ install_command() {
   fi
 }
 
+# The probe only observes a non-zero exit (a timeout or EACCES lands here too),
+# so the cause is stated as probable rather than asserted as fact.
 incompatible_explanation() {
-  echo "idb is installed but unusable: the fb-idb client crashes on every invocation — it calls asyncio.get_event_loop(), which Python 3.14 removed. Installing it again under the same interpreter reproduces this."
+  echo "idb is installed but did not respond successfully: the most likely cause is fb-idb calling asyncio.get_event_loop(), which Python 3.14 removed. Installing it again under the same interpreter would reproduce this."
+}
+
+# GH#578: a pinned install that SUCCEEDS but leaves no client on PATH is a shim
+# visibility problem, not an interpreter incompatibility — retryable, and the
+# remedy is the PATH, never the install command that already succeeded.
+path_shim_explanation() {
+  echo "fb-idb installed successfully, but no idb client is visible on PATH — the pipx shim directory (usually ~/.local/bin) is not exported. Run 'pipx ensurepath' and start a new shell, or add that directory to PATH."
 }
 
 # --install-worker: the detached background job (never reached at SessionStart).
 if [ "${1:-}" = "--install-worker" ]; then
   mkdir -p "$STATE_DIR"
   status=ok
+  # The cause is persisted alongside the status: messages rendered FROM the
+  # marker (notably the 24h backoff line) would otherwise fall back to the
+  # generic install command and lose what the worker actually determined.
+  cause=none
   if ! has_companion; then
     brew tap facebook/fb && { brew trust facebook/fb >/dev/null 2>&1 || true; } && brew install idb-companion || status=failed
   fi
@@ -131,35 +144,45 @@ if [ "${1:-}" = "--install-worker" ]; then
         installed=yes
         [ "$(idb_client_state)" = ready ] && break
       done
-      if [ "$(idb_client_state)" != ready ]; then
+      # Four outcomes, derived from what the worker already knows: whether any
+      # install ran (`installed`) and what the probe now reads. Only a client
+      # that ran an install and still fails is genuinely terminal.
+      final_state="$(idb_client_state)"
+      if [ "$final_state" != ready ]; then
         if [ -n "$tried" ] && [ -z "$installed" ]; then
           # Every pinned install command itself failed (network, PyPI, pipx).
-          # That is transient, so it must stay retryable: the terminal verdict
-          # requires evidence of incompatibility, not merely absence of success.
+          # Transient, so it stays retryable.
           status=failed
+          cause=install-failed
           echo "tried:$tried — every pinned install failed; retrying after backoff"
-        else
-          # Either a pinned install succeeded and the client still crashes, or
-          # no supported interpreter exists at all. Retrying cannot change that,
-          # so record a distinct verdict with the interpreter fingerprint and
-          # stop — the foreground path reports the truth instead of re-showing
-          # an install hint the developer has already followed.
-          # A brew failure earlier in this run stays `failed`: that one IS worth
-          # retrying, and its backoff must not be replaced by a terminal verdict.
+        elif [ -n "$installed" ] && [ "$final_state" = absent ]; then
+          # The install worked; the shim just is not visible. Orthogonal to the
+          # interpreter fingerprint, so it must never be terminal.
+          status=failed
+          cause=path-shim
+          path_shim_explanation
+        elif [ -n "$installed" ]; then
+          # A pinned install succeeded and the client still fails to run.
+          # Retrying cannot change that. A brew failure earlier in this run
+          # stays `failed`: that one IS worth retrying.
           [ "$status" = failed ] || status=incompatible
-          if [ -n "$tried" ]; then
-            incompatible_explanation
-            echo "tried:$tried — none produced a working client; the mirror stays on the simctl tier"
-          else
-            echo "no supported Python found (need one of: $SUPPORTED_PYTHONS). Install one, then re-run: $(install_command)"
-          fi
+          [ "$status" = failed ] || cause=client-unusable
+          incompatible_explanation
+          echo "tried:$tried — none produced a working client; the mirror stays on the simctl tier"
+        else
+          # No supported interpreter exists at all. The fingerprint re-arms this
+          # as soon as one is installed.
+          [ "$status" = failed ] || status=incompatible
+          [ "$status" = failed ] || cause=no-interpreter
+          echo "no supported Python found (need one of: $SUPPORTED_PYTHONS). Install one, then re-run: $(install_command)"
         fi
       fi
     else
       status=failed
     fi
   fi
-  echo "$status $(date +%s) $(python_fingerprint)" > "$MARKER"
+  [ "$status" = failed ] && [ "$cause" = none ] && cause=install-error
+  echo "$status $(date +%s) $(python_fingerprint) $cause" > "$MARKER"
   rm -f "$PIDFILE"
   echo "ensure-idb worker finished: $status"
   exit 0
@@ -177,7 +200,7 @@ if [ "$CLIENT_STATE" = ready ] && has_companion; then
 fi
 
 if [ -f "$MARKER" ]; then
-  read -r LAST_STATUS LAST_TS LAST_FP < "$MARKER" 2>/dev/null || LAST_STATUS=""
+  read -r LAST_STATUS LAST_TS LAST_FP LAST_CAUSE < "$MARKER" 2>/dev/null || LAST_STATUS=""
 fi
 
 # The incompatible verdict outranks every other branch while the client is
@@ -186,12 +209,15 @@ fi
 # delete "$MARKER" to force a retry. A verdict may never contradict the live
 # probe — a client that now reads ready or absent falls through to the normal
 # path so the missing piece (companion, or the client itself) still gets fixed.
-if [ "$CLIENT_STATE" = broken ] && [ "${LAST_STATUS:-}" = "incompatible" ] && [ "${LAST_FP:-}" = "$(python_fingerprint)" ]; then
-  incompatible_explanation
-  if first_supported_python >/dev/null; then
+if [ "$CLIENT_STATE" != ready ] && [ "${LAST_STATUS:-}" = "incompatible" ] && [ "${LAST_FP:-}" = "$(python_fingerprint)" ]; then
+  # Terminal only for the two causes that retrying cannot change. The message
+  # follows the live state, never the other state's story.
+  if [ "$CLIENT_STATE" = broken ]; then
+    incompatible_explanation
     echo "Recover with: $(install_command)"
   else
-    echo "No supported Python is installed (need one of: $SUPPORTED_PYTHONS). Recover with: $(install_command)"
+    echo "idb is not installed, and no supported Python is available to install it (need one of: $SUPPORTED_PYTHONS)."
+    echo "Recover with: $(install_command)"
   fi
   echo "Not retrying until the installed Python interpreters change (log: $LOG). Mirroring stays on the ~6fps simctl tier."
   exit 0
@@ -226,7 +252,15 @@ fi
 if [ "${LAST_STATUS:-}" = "failed" ] && [ -n "${LAST_TS:-}" ]; then
   NOW="$(date +%s)"
   if [ $((NOW - LAST_TS)) -lt "$BACKOFF_SECS" ]; then
-    echo "idb install failed recently — retrying after backoff (manual: $(install_command), log: $LOG)"
+    # This line is what the developer reads for the next 24h, so it must carry
+    # the cause the worker determined rather than defaulting to an install
+    # command that, for the shim case, already succeeded.
+    if [ "${LAST_CAUSE:-}" = "path-shim" ]; then
+      path_shim_explanation
+      echo "Retrying the install after backoff anyway (log: $LOG)."
+    else
+      echo "idb install failed recently — retrying after backoff (manual: $(install_command), log: $LOG)"
+    fi
     exit 0
   fi
 fi

--- a/scripts/ensure-idb.sh
+++ b/scripts/ensure-idb.sh
@@ -121,9 +121,11 @@ if [ "${1:-}" = "--install-worker" ]; then
       # GH#578: never let pipx resolve the interpreter itself — it picks the
       # newest, which is exactly the one that produces a crashing client.
       # Walk the supported interpreters until one yields a healthy client.
+      tried=""
       for py in $SUPPORTED_PYTHONS; do
         command -v "$py" >/dev/null 2>&1 || continue
         echo "installing fb-idb under $py"
+        tried="$tried $py"
         pipx install --python "$py" --force fb-idb || continue
         [ "$(idb_client_state)" = ready ] && break
       done
@@ -132,10 +134,12 @@ if [ "${1:-}" = "--install-worker" ]; then
         # change that, so record a distinct verdict with the interpreter
         # fingerprint and stop — the foreground path reports the truth instead
         # of re-showing an install hint the developer has already followed.
-        status=incompatible
+        # A brew failure earlier in this run stays `failed`: that one IS worth
+        # retrying, and its backoff must not be replaced by a terminal verdict.
+        [ "$status" = failed ] || status=incompatible
         incompatible_explanation
-        if first_supported_python >/dev/null; then
-          echo "tried: $SUPPORTED_PYTHONS — none produced a working client; the mirror stays on the simctl tier"
+        if [ -n "$tried" ]; then
+          echo "tried:$tried — none produced a working client; the mirror stays on the simctl tier"
         else
           echo "no supported Python found (need one of: $SUPPORTED_PYTHONS). Install one, then re-run: $(install_command)"
         fi

--- a/scripts/test/ensure-idb.test.sh
+++ b/scripts/test/ensure-idb.test.sh
@@ -88,7 +88,7 @@ STATE="$TMP/state1c"
 STUBS="$(mkstubs "idb_companion brew")"
 printf '#!/bin/sh\nexit 1\n' > "$STUBS/idb"; chmod +x "$STUBS/idb"
 OUT="$(run_script "$STUBS")"
-if echo "$OUT" | grep -qi "installed but unusable"; then
+if echo "$OUT" | grep -qi "is installed but"; then
   ok "broken-client: reports present-but-unusable"
 else bad "broken-client: expected present-but-unusable notice, got: $OUT"; fi
 if echo "$OUT" | grep -q "asyncio.get_event_loop" && echo "$OUT" | grep -q "Python 3.14"; then
@@ -208,7 +208,7 @@ STUBS="$(mkstubs "idb_companion brew python3.13")"
 printf '#!/bin/sh\nexit 1\n' > "$STUBS/idb"; chmod +x "$STUBS/idb"
 echo "incompatible $(date +%s) python3.13," > "$STATE/last-attempt"
 OUT="$(run_script "$STUBS")"
-if echo "$OUT" | grep -qi "installed but unusable"; then
+if echo "$OUT" | grep -qi "is installed but"; then
   ok "verdict: explains the incompatibility"
 else bad "verdict: expected incompatibility explanation, got: $OUT"; fi
 if echo "$OUT" | grep -qi "Not retrying until the installed Python interpreters change"; then
@@ -238,7 +238,7 @@ OUT="$(run_script "$STUBS")"
 if echo "$OUT" | grep -qi "idb missing"; then
   ok "absent: still reported as missing"
 else bad "absent: expected missing notice, got: $OUT"; fi
-if echo "$OUT" | grep -qi "installed but unusable"; then
+if echo "$OUT" | grep -qi "is installed but"; then
   bad "absent: wrongly reported as installed-but-broken"
 else ok "absent: not confused with the broken state"; fi
 assert_no_unpinned_install "absent" "$OUT"
@@ -267,7 +267,7 @@ run_worker "$STUBS" "$TMP/worker7h.out"
 if grep -q "^failed " "$STATE/last-attempt" 2>/dev/null; then
   ok "worker: failing pipx stays retryable (no terminal verdict)"
 else bad "worker: expected failed marker, got: $(cat "$STATE/last-attempt" 2>/dev/null)"; fi
-if grep -qi "installed but unusable" "$TMP/worker7h.out"; then
+if grep -qi "is installed but" "$TMP/worker7h.out"; then
   bad "worker: absent client described as installed-but-broken"
 else ok "worker: never calls a never-installed client unusable"; fi
 
@@ -279,7 +279,7 @@ mkdir -p "$STATE"
 STUBS="$(mkstubs "idb brew python3.13")"
 echo "incompatible $(date +%s) python3.13," > "$STATE/last-attempt"
 OUT="$(run_script "$STUBS")"
-if echo "$OUT" | grep -qi "installed but unusable"; then
+if echo "$OUT" | grep -qi "is installed but"; then
   bad "stale-verdict: claimed a working client crashes, got: $OUT"
 else ok "stale-verdict: live probe outranks the marker"; fi
 [ -f "$STATE/spawn.log" ] && ok "stale-verdict: still spawns the companion install" || bad "stale-verdict: blocked the companion repair, got: $OUT"
@@ -296,9 +296,63 @@ OUT="$(run_script "$STUBS")"
 if echo "$OUT" | grep -qi "Repairing in the background"; then
   bad "repair-notice: announced a repair that never started, got: $OUT"
 else ok "repair-notice: silent when no worker is spawned"; fi
-if echo "$OUT" | grep -qi "installed but unusable"; then
+if echo "$OUT" | grep -qi "is installed but"; then
   ok "repair-notice: still explains the incompatibility truthfully"
 else bad "repair-notice: dropped the broken-client explanation, got: $OUT"; fi
+
+# 7h. GH#578 round 4: a pinned install that SUCCEEDS but leaves no client on
+#     PATH is a shim-visibility problem, not an incompatibility. It must stay
+#     retryable (`failed`), must record the cause, and must never tell the
+#     developer to re-run the install command that already succeeded.
+STATE="$TMP/state7h"
+mkdir -p "$STATE"
+STUBS="$(mkstubs "idb_companion brew python3.13")"
+printf '#!/bin/sh\nexit 0\n' > "$STUBS/pipx"; chmod +x "$STUBS/pipx"
+run_worker "$STUBS" "$TMP/worker7h.out"
+if grep -q "^failed " "$STATE/last-attempt" 2>/dev/null; then
+  ok "path-shim: retryable failed verdict, not terminal"
+else bad "path-shim: expected failed marker, got: $(cat "$STATE/last-attempt" 2>/dev/null)"; fi
+if grep -q "path-shim" "$STATE/last-attempt" 2>/dev/null; then
+  ok "path-shim: cause persisted to the marker"
+else bad "path-shim: expected cause in marker, got: $(cat "$STATE/last-attempt" 2>/dev/null)"; fi
+if grep -qi "asyncio.get_event_loop" "$TMP/worker7h.out"; then
+  bad "path-shim: falsely blamed the interpreter incompatibility"
+else ok "path-shim: does not blame the interpreter"; fi
+
+# 7i. The foreground line the developer reads for the next 24h must carry that
+#     cause instead of defaulting to the already-successful install command.
+OUT="$(run_script "$STUBS")"
+if echo "$OUT" | grep -qi "not exported\|ensurepath"; then
+  ok "path-shim: backoff line names the PATH cause"
+else bad "path-shim: expected PATH remedy, got: $OUT"; fi
+if echo "$OUT" | grep -q "idb install failed recently"; then
+  bad "path-shim: fell back to the generic install-failed line"
+else ok "path-shim: no generic install-failed fallback"; fi
+assert_no_unpinned_install "path-shim" "$OUT"
+
+# 7j. The no-interpreter terminal verdict must not narrate the crashing-client
+#     story: in that state the client is absent, so that explanation is false.
+STATE="$TMP/state7j"
+mkdir -p "$STATE"
+STUBS="$(mkstubs "idb_companion brew")"
+echo "incompatible $(date +%s) none no-interpreter" > "$STATE/last-attempt"
+OUT="$(FAKE_PYTHONS=python3.13 run_script "$STUBS")"
+if echo "$OUT" | grep -qi "no supported Python"; then
+  ok "no-interpreter: names the missing interpreter"
+else bad "no-interpreter: expected interpreter message, got: $OUT"; fi
+if echo "$OUT" | grep -qi "did not respond successfully"; then
+  bad "no-interpreter: narrated the crashing-client story for an absent client"
+else ok "no-interpreter: does not claim a crashing client"; fi
+
+# 7k. The cause claim is hedged, never asserted as fact — the probe cannot
+#     separate a crash from a timeout or EACCES.
+STATE="$TMP/state7k"
+STUBS="$(mkstubs "idb_companion brew python3.13")"
+printf '#!/bin/sh\nexit 1\n' > "$STUBS/idb"; chmod +x "$STUBS/idb"
+OUT="$(run_script "$STUBS")"
+if echo "$OUT" | grep -qi "most likely"; then
+  ok "hedging: cause stated as probable"
+else bad "hedging: expected hedged cause, got: $OUT"; fi
 
 # 8. SessionStart safety: foreground path must not invoke brew/pipx inline.
 #    The dry-spawn seam proves the install goes through the detached worker;

--- a/scripts/test/ensure-idb.test.sh
+++ b/scripts/test/ensure-idb.test.sh
@@ -14,6 +14,7 @@
 #   - transient install failure    -> retryable `failed`, never the verdict
 #   - stale verdict vs live probe  -> the probe wins, repair still spawns
 #   - "repairing" notice           -> printed only when a worker really spawns
+#   - ready client, no companion   -> companion notice only, never an fb-idb one
 #   - no message ever prints the unpinned `pipx install fb-idb` (GH#578)
 #   - SessionStart safety: the foreground path never runs brew/pipx inline
 #
@@ -300,27 +301,34 @@ if echo "$OUT" | grep -qi "is installed but"; then
   ok "repair-notice: still explains the incompatibility truthfully"
 else bad "repair-notice: dropped the broken-client explanation, got: $OUT"; fi
 
-# 7h. GH#578 round 4: a pinned install that SUCCEEDS but leaves no client on
+# 7l. GH#578 round 4: a pinned install that SUCCEEDS but leaves no client on
 #     PATH is a shim-visibility problem, not an incompatibility. It must stay
 #     retryable (`failed`), must record the cause, and must never tell the
 #     developer to re-run the install command that already succeeded.
-STATE="$TMP/state7h"
+STATE="$TMP/state7l"
 mkdir -p "$STATE"
 STUBS="$(mkstubs "idb_companion brew python3.13")"
 printf '#!/bin/sh\nexit 0\n' > "$STUBS/pipx"; chmod +x "$STUBS/pipx"
-run_worker "$STUBS" "$TMP/worker7h.out"
+run_worker "$STUBS" "$TMP/worker7l.out"
 if grep -q "^failed " "$STATE/last-attempt" 2>/dev/null; then
   ok "path-shim: retryable failed verdict, not terminal"
 else bad "path-shim: expected failed marker, got: $(cat "$STATE/last-attempt" 2>/dev/null)"; fi
 if grep -q "path-shim" "$STATE/last-attempt" 2>/dev/null; then
   ok "path-shim: cause persisted to the marker"
 else bad "path-shim: expected cause in marker, got: $(cat "$STATE/last-attempt" 2>/dev/null)"; fi
-if grep -qi "asyncio.get_event_loop" "$TMP/worker7h.out"; then
+if grep -qi "asyncio.get_event_loop" "$TMP/worker7l.out"; then
   bad "path-shim: falsely blamed the interpreter incompatibility"
 else ok "path-shim: does not blame the interpreter"; fi
 
-# 7i. The foreground line the developer reads for the next 24h must carry that
+# 7m. The foreground line the developer reads for the next 24h must carry that
 #     cause instead of defaulting to the already-successful install command.
+#     Self-contained: its own state dir and stubs, with the path-shim marker
+#     produced by a worker run of its own rather than inherited from 7l.
+STATE="$TMP/state7m"
+mkdir -p "$STATE"
+STUBS="$(mkstubs "idb_companion brew python3.13")"
+printf '#!/bin/sh\nexit 0\n' > "$STUBS/pipx"; chmod +x "$STUBS/pipx"
+run_worker "$STUBS" "$TMP/worker7m.out"
 OUT="$(run_script "$STUBS")"
 if echo "$OUT" | grep -qi "not exported\|ensurepath"; then
   ok "path-shim: backoff line names the PATH cause"
@@ -330,9 +338,9 @@ if echo "$OUT" | grep -q "idb install failed recently"; then
 else ok "path-shim: no generic install-failed fallback"; fi
 assert_no_unpinned_install "path-shim" "$OUT"
 
-# 7j. The no-interpreter terminal verdict must not narrate the crashing-client
+# 7n. The no-interpreter terminal verdict must not narrate the crashing-client
 #     story: in that state the client is absent, so that explanation is false.
-STATE="$TMP/state7j"
+STATE="$TMP/state7n"
 mkdir -p "$STATE"
 STUBS="$(mkstubs "idb_companion brew")"
 echo "incompatible $(date +%s) none no-interpreter" > "$STATE/last-attempt"
@@ -343,6 +351,9 @@ else bad "no-interpreter: expected interpreter message, got: $OUT"; fi
 if echo "$OUT" | grep -qi "did not respond successfully"; then
   bad "no-interpreter: narrated the crashing-client story for an absent client"
 else ok "no-interpreter: does not claim a crashing client"; fi
+if echo "$OUT" | grep -q "$STATE/last-attempt"; then
+  ok "no-interpreter: names the marker path as the escape hatch"
+else bad "no-interpreter: expected the marker path in the terminal line, got: $OUT"; fi
 
 # 7k. The cause claim is hedged, never asserted as fact — the probe cannot
 #     separate a crash from a timeout or EACCES.
@@ -353,6 +364,31 @@ OUT="$(run_script "$STUBS")"
 if echo "$OUT" | grep -qi "most likely"; then
   ok "hedging: cause stated as probable"
 else bad "hedging: expected hedged cause, got: $OUT"; fi
+
+# 7o. A healthy client whose only missing piece is the companion must not be
+#     told an interpreter repair is underway: the worker's own guard skips pipx
+#     entirely in that state, so the fb-idb command describes work never run.
+STATE="$TMP/state7o"
+STUBS="$(mkstubs "idb brew python3.13")"
+OUT="$(run_script "$STUBS")"
+if echo "$OUT" | grep -qi "idb-companion missing"; then
+  ok "ready-no-companion: names the companion as the missing piece"
+else bad "ready-no-companion: expected a companion notice, got: $OUT"; fi
+if echo "$OUT" | grep -qiE "Repairing in the background|pipx|fb-idb"; then
+  bad "ready-no-companion: offered an fb-idb repair for a working client, got: $OUT"
+else ok "ready-no-companion: no fb-idb reinstall suggested"; fi
+[ -f "$STATE/spawn.log" ] && ok "ready-no-companion: still spawns the companion install" || bad "ready-no-companion: no spawn recorded"
+
+# 7p. Same state without brew: the manual hint is the companion half only.
+STATE="$TMP/state7p"
+STUBS="$(mkstubs "idb")"
+OUT="$(run_script "$STUBS")"
+if echo "$OUT" | grep -qiE "pipx|fb-idb"; then
+  bad "ready-no-brew: printed an fb-idb command for a working client, got: $OUT"
+else ok "ready-no-brew: companion-only manual hint"; fi
+if echo "$OUT" | grep -q "brew install idb-companion"; then
+  ok "ready-no-brew: names the companion install"
+else bad "ready-no-brew: expected the companion command, got: $OUT"; fi
 
 # 8. SessionStart safety: foreground path must not invoke brew/pipx inline.
 #    The dry-spawn seam proves the install goes through the detached worker;

--- a/scripts/test/ensure-idb.test.sh
+++ b/scripts/test/ensure-idb.test.sh
@@ -9,11 +9,15 @@
 #   - missing binaries + brew      -> spawns ONE detached worker, prints notice
 #   - worker already running       -> no second spawn (pidfile guard)
 #   - recent failed attempt (<24h) -> no respawn (backoff marker)
+#   - present-but-broken client    -> incompatibility named, never "missing"
+#   - incompatible verdict         -> no respawn until interpreters change
+#   - no message ever prints the unpinned `pipx install fb-idb` (GH#578)
 #   - SessionStart safety: the foreground path never runs brew/pipx inline
 #
 # Test seams (env):
 #   RN_AGENT_IDB_STATE_DIR   state dir (pidfile, marker, log)
 #   RN_AGENT_IDB_UNAME       fake uname -s output
+#   RN_AGENT_IDB_PYTHONS     supported-interpreter candidate list
 #   RN_AGENT_IDB_PATH_STUBS  dir prepended to PATH (fake idb/idb_companion/brew)
 #   RN_AGENT_IDB_DRY_SPAWN=1 record the would-be spawn instead of nohup'ing it
 #
@@ -235,6 +239,19 @@ if echo "$OUT" | grep -qi "installed but unusable"; then
   bad "absent: wrongly reported as installed-but-broken"
 else ok "absent: not confused with the broken state"; fi
 assert_no_unpinned_install "absent" "$OUT"
+
+# 7g. A brew failure must stay `failed` (retryable) rather than being masked by
+#     the terminal incompatible verdict — only the client verdict is terminal.
+STATE="$TMP/state7g"
+mkdir -p "$STATE"
+STUBS="$(mkstubs "python3.13")"
+printf '#!/bin/sh\nexit 1\n' > "$STUBS/idb"; chmod +x "$STUBS/idb"
+printf '#!/bin/sh\nexit 1\n' > "$STUBS/brew"; chmod +x "$STUBS/brew"
+printf '#!/bin/sh\nexit 0\n' > "$STUBS/pipx"; chmod +x "$STUBS/pipx"
+run_worker "$STUBS" "$TMP/worker7g.out"
+if grep -q "^failed " "$STATE/last-attempt" 2>/dev/null; then
+  ok "worker: brew failure keeps the retryable failed verdict"
+else bad "worker: expected failed marker, got: $(cat "$STATE/last-attempt" 2>/dev/null)"; fi
 
 # 8. SessionStart safety: foreground path must not invoke brew/pipx inline.
 #    The dry-spawn seam proves the install goes through the detached worker;

--- a/scripts/test/ensure-idb.test.sh
+++ b/scripts/test/ensure-idb.test.sh
@@ -11,6 +11,9 @@
 #   - recent failed attempt (<24h) -> no respawn (backoff marker)
 #   - present-but-broken client    -> incompatibility named, never "missing"
 #   - incompatible verdict         -> no respawn until interpreters change
+#   - transient install failure    -> retryable `failed`, never the verdict
+#   - stale verdict vs live probe  -> the probe wins, repair still spawns
+#   - "repairing" notice           -> printed only when a worker really spawns
 #   - no message ever prints the unpinned `pipx install fb-idb` (GH#578)
 #   - SessionStart safety: the foreground path never runs brew/pipx inline
 #
@@ -252,6 +255,50 @@ run_worker "$STUBS" "$TMP/worker7g.out"
 if grep -q "^failed " "$STATE/last-attempt" 2>/dev/null; then
   ok "worker: brew failure keeps the retryable failed verdict"
 else bad "worker: expected failed marker, got: $(cat "$STATE/last-attempt" 2>/dev/null)"; fi
+
+# 7h. A transient install failure (network/PyPI/pipx) is NOT evidence of the
+#     interpreter incompatibility: every pinned install failing must keep the
+#     retryable `failed` verdict, or a blip pins a permanent false diagnosis.
+STATE="$TMP/state7h"
+mkdir -p "$STATE"
+STUBS="$(mkstubs "idb_companion brew python3.13")"
+printf '#!/bin/sh\nexit 1\n' > "$STUBS/pipx"; chmod +x "$STUBS/pipx"
+run_worker "$STUBS" "$TMP/worker7h.out"
+if grep -q "^failed " "$STATE/last-attempt" 2>/dev/null; then
+  ok "worker: failing pipx stays retryable (no terminal verdict)"
+else bad "worker: expected failed marker, got: $(cat "$STATE/last-attempt" 2>/dev/null)"; fi
+if grep -qi "installed but unusable" "$TMP/worker7h.out"; then
+  bad "worker: absent client described as installed-but-broken"
+else ok "worker: never calls a never-installed client unusable"; fi
+
+# 7i. A stale verdict must never outrank the live probe: a client that now
+#     works (with the companion still missing) falls through to the repair
+#     spawn instead of being reported as crashing.
+STATE="$TMP/state7i"
+mkdir -p "$STATE"
+STUBS="$(mkstubs "idb brew python3.13")"
+echo "incompatible $(date +%s) python3.13," > "$STATE/last-attempt"
+OUT="$(run_script "$STUBS")"
+if echo "$OUT" | grep -qi "installed but unusable"; then
+  bad "stale-verdict: claimed a working client crashes, got: $OUT"
+else ok "stale-verdict: live probe outranks the marker"; fi
+[ -f "$STATE/spawn.log" ] && ok "stale-verdict: still spawns the companion install" || bad "stale-verdict: blocked the companion repair, got: $OUT"
+
+# 7j. The "repairing in the background" claim may only be printed when a worker
+#     is actually spawned — the backoff guard must not be preceded by a promise.
+STATE="$TMP/state7j"
+mkdir -p "$STATE"
+echo "failed $(date +%s)" > "$STATE/last-attempt"
+STUBS="$(mkstubs "idb_companion brew python3.13")"
+printf '#!/bin/sh\nexit 1\n' > "$STUBS/idb"; chmod +x "$STUBS/idb"
+OUT="$(run_script "$STUBS")"
+[ ! -f "$STATE/spawn.log" ] && ok "repair-notice: backoff still blocks the spawn" || bad "repair-notice: spawned inside backoff window"
+if echo "$OUT" | grep -qi "Repairing in the background"; then
+  bad "repair-notice: announced a repair that never started, got: $OUT"
+else ok "repair-notice: silent when no worker is spawned"; fi
+if echo "$OUT" | grep -qi "installed but unusable"; then
+  ok "repair-notice: still explains the incompatibility truthfully"
+else bad "repair-notice: dropped the broken-client explanation, got: $OUT"; fi
 
 # 8. SessionStart safety: foreground path must not invoke brew/pipx inline.
 #    The dry-spawn seam proves the install goes through the detached worker;

--- a/scripts/test/ensure-idb.test.sh
+++ b/scripts/test/ensure-idb.test.sh
@@ -390,6 +390,21 @@ if echo "$OUT" | grep -q "brew install idb-companion"; then
   ok "ready-no-brew: names the companion install"
 else bad "ready-no-brew: expected the companion command, got: $OUT"; fi
 
+# 7q. A stale path-shim cause must never outrank the live probe: once the shim
+#     is exported the client reads ready, so the "no idb client is visible on
+#     PATH" story is false and the companion is the only missing half.
+STATE="$TMP/state7q"
+mkdir -p "$STATE"
+echo "failed $(date +%s) python3.13, path-shim" > "$STATE/last-attempt"
+STUBS="$(mkstubs "idb brew python3.13")"
+OUT="$(run_script "$STUBS")"
+if echo "$OUT" | grep -qi "not exported\|ensurepath"; then
+  bad "stale-path-shim: claimed an invisible shim for a working client, got: $OUT"
+else ok "stale-path-shim: live probe outranks the persisted cause"; fi
+if echo "$OUT" | grep -qiE "pipx install|fb-idb"; then
+  bad "stale-path-shim: offered an fb-idb command for a working client, got: $OUT"
+else ok "stale-path-shim: companion-only remedy"; fi
+
 # 8. SessionStart safety: foreground path must not invoke brew/pipx inline.
 #    The dry-spawn seam proves the install goes through the detached worker;
 #    additionally the script source must route the real spawn through nohup.

--- a/scripts/test/ensure-idb.test.sh
+++ b/scripts/test/ensure-idb.test.sh
@@ -46,8 +46,18 @@ run_script() { # $1 = stubs dir, rest = extra env
   env PATH="$stubs:/usr/bin:/bin" \
     RN_AGENT_IDB_STATE_DIR="$STATE" \
     RN_AGENT_IDB_UNAME="${FAKE_UNAME:-Darwin}" \
+    RN_AGENT_IDB_PYTHONS="${FAKE_PYTHONS:-python3.13}" \
     RN_AGENT_IDB_DRY_SPAWN=1 \
     "$@" bash "$SCRIPT" 2>&1
+}
+
+# GH#578: `pipx install fb-idb` without a pinned interpreter resolves the
+# newest Python, which is exactly the combination that crashes. No user-facing
+# message may ever print it.
+assert_no_unpinned_install() { # $1 = label, $2 = output
+  if echo "$2" | grep -q "pipx install fb-idb"; then
+    bad "$1: printed the known-broken unpinned install command"
+  else ok "$1: no unpinned install command"; fi
 }
 
 # 1. Both binaries present -> reports available, no spawn.
@@ -64,13 +74,23 @@ OUT="$(run_script "$STUBS")"
 if echo "$OUT" | grep -qi "idb available"; then ok "hyphen: idb-companion accepted"; else bad "hyphen: expected available, got: $OUT"; fi
 [ ! -f "$STATE/spawn.log" ] && ok "hyphen: no spawn" || bad "hyphen: unexpected spawn"
 
-# 1c. B269: client on PATH but BROKEN (crashes on invocation) -> not treated
-#     as present; prints the broken notice and spawns the repair worker.
+# 1c. B269/GH#578: client on PATH but BROKEN (crashes on invocation) -> not
+#     treated as present, and NOT reported as absent either: the message names
+#     the interpreter incompatibility and a repair worker is spawned.
 STATE="$TMP/state1c"
 STUBS="$(mkstubs "idb_companion brew")"
 printf '#!/bin/sh\nexit 1\n' > "$STUBS/idb"; chmod +x "$STUBS/idb"
 OUT="$(run_script "$STUBS")"
-if echo "$OUT" | grep -qi "broken"; then ok "broken-client: prints broken notice"; else bad "broken-client: expected broken notice, got: $OUT"; fi
+if echo "$OUT" | grep -qi "installed but unusable"; then
+  ok "broken-client: reports present-but-unusable"
+else bad "broken-client: expected present-but-unusable notice, got: $OUT"; fi
+if echo "$OUT" | grep -q "asyncio.get_event_loop" && echo "$OUT" | grep -q "Python 3.14"; then
+  ok "broken-client: names the actual incompatibility"
+else bad "broken-client: expected the Python 3.14 explanation, got: $OUT"; fi
+if echo "$OUT" | grep -qiE "idb (not installed|missing)"; then
+  bad "broken-client: still described as missing (states 1 and 3 collapsed)"
+else ok "broken-client: not described as missing"; fi
+assert_no_unpinned_install "broken-client" "$OUT"
 if [ -f "$STATE/spawn.log" ] && [ "$(wc -l < "$STATE/spawn.log")" -eq 1 ]; then
   ok "broken-client: spawns repair worker"
 else bad "broken-client: expected one spawn record"; fi
@@ -86,7 +106,7 @@ OUT="$(FAKE_UNAME=Linux run_script "$STUBS")"
 STATE="$TMP/state3"
 STUBS="$(mkstubs "")"
 OUT="$(run_script "$STUBS")"
-if echo "$OUT" | grep -q "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb"; then
+if echo "$OUT" | grep -q "brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3\.13 --force fb-idb"; then
   ok "no-brew: prints manual command"
 else bad "no-brew: missing manual command, got: $OUT"; fi
 [ ! -f "$STATE/spawn.log" ] && ok "no-brew: no spawn" || bad "no-brew: unexpected spawn"
@@ -128,24 +148,93 @@ STUBS="$(mkstubs "brew")"
 OUT="$(run_script "$STUBS")"
 [ -f "$STATE/spawn.log" ] && ok "backoff: stale marker allows retry" || bad "backoff: stale marker still blocked retry"
 
-# 7b. B269 worker invariant: a client that is still broken after reinstall is
-#     UNINSTALLED (never left on PATH) and the attempt is marked failed.
+run_worker() { # $1 = stubs dir, $2 = output file
+  env PATH="$1:/usr/bin:/bin" RN_AGENT_IDB_STATE_DIR="$STATE" RN_AGENT_IDB_UNAME=Darwin \
+    RN_AGENT_IDB_PYTHONS="${FAKE_PYTHONS:-python3.13}" \
+    bash "$SCRIPT" --install-worker > "$2" 2>&1
+}
+
+# 7b. GH#578 worker: the install is pinned to a supported interpreter, never
+#     resolved by pipx (which would pick the breaking 3.14). A client that is
+#     still broken afterwards yields the terminal `incompatible` verdict.
 STATE="$TMP/state7b"
 mkdir -p "$STATE"
-STUBS="$(mkstubs "idb_companion brew")"
+STUBS="$(mkstubs "idb_companion brew python3.13")"
 printf '#!/bin/sh\nexit 1\n' > "$STUBS/idb"; chmod +x "$STUBS/idb"
 printf '#!/bin/sh\necho "$@" >> "%s/pipx.log"\nexit 0\n' "$STATE" > "$STUBS/pipx"; chmod +x "$STUBS/pipx"
-env PATH="$STUBS:/usr/bin:/bin" RN_AGENT_IDB_STATE_DIR="$STATE" RN_AGENT_IDB_UNAME=Darwin \
-  bash "$SCRIPT" --install-worker > "$TMP/worker7b.out" 2>&1
-if grep -q "uninstall fb-idb" "$STATE/pipx.log" 2>/dev/null; then
-  ok "worker: broken client uninstalled (never left on PATH)"
-else bad "worker: expected pipx uninstall fb-idb, got: $(cat "$STATE/pipx.log" 2>/dev/null)"; fi
-if grep -q "^failed " "$STATE/last-attempt" 2>/dev/null; then
-  ok "worker: broken client marks attempt failed (backoff engages)"
-else bad "worker: expected failed marker, got: $(cat "$STATE/last-attempt" 2>/dev/null)"; fi
-if grep -qi "crashes on invocation" "$TMP/worker7b.out"; then
-  ok "worker: explains the uninstall in the log"
+run_worker "$STUBS" "$TMP/worker7b.out"
+if grep -q -- "--python python3.13 --force fb-idb" "$STATE/pipx.log" 2>/dev/null; then
+  ok "worker: installs fb-idb under a pinned supported interpreter"
+else bad "worker: expected pinned install, got: $(cat "$STATE/pipx.log" 2>/dev/null)"; fi
+if grep -qE "^install fb-idb$" "$STATE/pipx.log" 2>/dev/null; then
+  bad "worker: ran the unpinned install that reproduces the break"
+else ok "worker: never runs the unpinned install"; fi
+if grep -q "^incompatible " "$STATE/last-attempt" 2>/dev/null; then
+  ok "worker: records the terminal incompatible verdict"
+else bad "worker: expected incompatible marker, got: $(cat "$STATE/last-attempt" 2>/dev/null)"; fi
+if grep -q "python3.13," "$STATE/last-attempt" 2>/dev/null; then
+  ok "worker: verdict carries the interpreter fingerprint"
+else bad "worker: expected fingerprint in marker, got: $(cat "$STATE/last-attempt" 2>/dev/null)"; fi
+if grep -qi "asyncio.get_event_loop" "$TMP/worker7b.out"; then
+  ok "worker: explains the incompatibility in the log"
 else bad "worker: expected crash explanation, got: $(cat "$TMP/worker7b.out")"; fi
+
+# 7c. Worker success path: when the pinned interpreter yields a healthy client
+#     the verdict is plain `ok` — the repair path still converges.
+STATE="$TMP/state7c"
+mkdir -p "$STATE"
+STUBS="$(mkstubs "idb_companion brew python3.13")"
+printf '#!/bin/sh\nexit 1\n' > "$STUBS/idb"; chmod +x "$STUBS/idb"
+printf '#!/bin/sh\nprintf "#!/bin/sh\\nexit 0\\n" > "%s/idb"\nchmod +x "%s/idb"\nexit 0\n' "$STUBS" "$STUBS" > "$STUBS/pipx"
+chmod +x "$STUBS/pipx"
+run_worker "$STUBS" "$TMP/worker7c.out"
+if grep -q "^ok " "$STATE/last-attempt" 2>/dev/null; then
+  ok "worker: pinned reinstall that works records ok"
+else bad "worker: expected ok marker, got: $(cat "$STATE/last-attempt" 2>/dev/null)"; fi
+
+# 7d. GH#578 core regression: with the incompatible verdict recorded and the
+#     interpreter set unchanged, session start explains the incompatibility,
+#     does NOT re-show an install hint, and does NOT respawn. This is the loop.
+STATE="$TMP/state7d"
+mkdir -p "$STATE"
+STUBS="$(mkstubs "idb_companion brew python3.13")"
+printf '#!/bin/sh\nexit 1\n' > "$STUBS/idb"; chmod +x "$STUBS/idb"
+echo "incompatible $(date +%s) python3.13," > "$STATE/last-attempt"
+OUT="$(run_script "$STUBS")"
+if echo "$OUT" | grep -qi "installed but unusable"; then
+  ok "verdict: explains the incompatibility"
+else bad "verdict: expected incompatibility explanation, got: $OUT"; fi
+if echo "$OUT" | grep -qi "Not retrying until the installed Python interpreters change"; then
+  ok "verdict: states the loop has stopped and what would restart it"
+else bad "verdict: expected non-retry statement, got: $OUT"; fi
+[ ! -f "$STATE/spawn.log" ] && ok "verdict: no respawn (loop terminated)" || bad "verdict: respawned despite terminal verdict"
+assert_no_unpinned_install "verdict" "$OUT"
+if echo "$OUT" | grep -qiE "idb (not installed|missing)"; then
+  bad "verdict: reported as missing despite being installed"
+else ok "verdict: never claims idb is missing"; fi
+
+# 7e. The verdict is not permanent: installing a supported interpreter changes
+#     the fingerprint, which re-arms the repair worker.
+STATE="$TMP/state7e"
+mkdir -p "$STATE"
+STUBS="$(mkstubs "idb_companion brew python3.13")"
+printf '#!/bin/sh\nexit 1\n' > "$STUBS/idb"; chmod +x "$STUBS/idb"
+echo "incompatible $(date +%s) none" > "$STATE/last-attempt"
+OUT="$(run_script "$STUBS")"
+[ -f "$STATE/spawn.log" ] && ok "verdict: changed interpreter set re-arms repair" || bad "verdict: env change did not re-arm, got: $OUT"
+
+# 7f. A genuinely absent client stays state 1 — it is still reported missing
+#     and still gets an install hint (the fix must not blur the states).
+STATE="$TMP/state7f"
+STUBS="$(mkstubs "idb_companion brew python3.13")"
+OUT="$(run_script "$STUBS")"
+if echo "$OUT" | grep -qi "idb missing"; then
+  ok "absent: still reported as missing"
+else bad "absent: expected missing notice, got: $OUT"; fi
+if echo "$OUT" | grep -qi "installed but unusable"; then
+  bad "absent: wrongly reported as installed-but-broken"
+else ok "absent: not confused with the broken state"; fi
+assert_no_unpinned_install "absent" "$OUT"
 
 # 8. SessionStart safety: foreground path must not invoke brew/pipx inline.
 #    The dry-spawn seam proves the install goes through the detached worker;


### PR DESCRIPTION
## Intent

Fix GitHub issue #578: the session-start warning tells the developer to install idb, and keeps telling them, even when idb_companion 1.1.8 and fb-idb 1.1.7 are both already installed.

Root cause (established in the issue, confirmed not rediscovered): fb-idb 1.1.7 calls asyncio.get_event_loop() at CLI startup; Python 3.14 removed implicit event-loop creation, so every idb invocation crashes. pipx resolves the newest interpreter, so the plugin's own suggested command reinstalls the identical broken combination. The ensure-idb worker saw the crash, uninstalled fb-idb, retried after backoff, and re-showed the hint. The loop never converged. This is a first-run experience defect: a developer following our own printed instructions ends up in a loop our own tooling created.

Accepted contract: (1) stop the non-converging loop - when idb is present but unusable, say so truthfully, naming the incompatibility, rather than repeating an install hint that cannot fix it; (2) never print an install command known to reproduce the broken combination; (3) regression-test the present-but-crashing case distinctly from the genuinely-absent case. Constraints: guide the developer to a working combination where one exists (pin the interpreter) rather than only reporting failure; 80/20 - fix detection and guidance only, explicitly NOT vendoring or forking idb, NOT adding a version-manager abstraction, NOT building a dependency-repair framework; distinguish absent / present-and-working / present-but-broken explicitly, since the bug is the third collapsing into the first; do not silence the warning when idb is broken, because mirroring genuinely degrades and the developer needs to know why.

Base implementation (commits eaba2e34, 351e808c, ac79951e, 2a5f1cf1): probeIdbClient() returns absent|ready|broken from a real invocation (ENOENT vs non-zero exit), with detectIdb() kept as a thin wrapper; the mirror's simctl fallback carries a state-appropriate degradedHint, which matters because the string quoted in the issue title is SIMCTL_HINT, so the mirror surface printed the broken command too; ensure-idb.sh treats the client as three states, installs only under a pinned supported interpreter (python3.13/3.12/3.11, never letting pipx choose), and records a terminal verdict fingerprinted by the installed interpreters so the retry stops until the environment could actually produce a different result; docs and CI wiring updated; changeset bumps rn-dev-agent-core and rn-dev-agent-plugin.

Commit 94deca6b then fixed three findings from earlier review rounds, all the same shape - the tool asserting a cause it had not established, or printing guidance that could not help:
(1) IDB_INSTALL_COMMAND hardcoded --python python3.13 with no fallback, so a python3.14-only machine got , an unfollowable hint - the same defect one layer up. It now matches the no-interpreter command install_command() produces, prepending . Runtime interpreter probing in the core package was explicitly REJECTED as scope growth; the duplication is guarded by a unit test that reads scripts/ensure-idb.sh and asserts the exact string still appears.
(2) The worker collapsed two unrelated failures into one terminal verdict. It now derives four outcomes from information it already had - installed-but-probe-absent is a PATH/shim-visibility problem (retryable , remedy is pipx ensurepath or exporting ~/.local/bin, never the install command that already succeeded); installed-but-probe-broken is genuinely terminal; no-interpreter-available is terminal but re-arms on fingerprint change; every-install-failed stays retryable. No new state machine was added.
(3) The cause was discarded at write time: the marker stored only a status word, so the 24h backoff line - the message a developer actually reads - fell back to the generic install command. The cause now reaches the marker and the message rendered from it.
Because the probe sees only a non-zero exit and a timeout or EACCES lands there too, code and docs now state the Python 3.14 story as the PROBABLE cause rather than as fact: SIMCTL_BROKEN_IDB_HINT, incompatible_explanation, rn-setup SKILL.md prose AND its summary table row, and commands/doctor.md, with the no-supported-interpreter repair variant added to the docs.

Deliberately OUT OF SCOPE, reserved to the project owner and NOT to be fixed in review: making the probe distinguish a crash from a timeout from EACCES (by capturing exit code or stderr), or dropping the cause claim altogether. Four review rounds have circled this same root; the decision to re-architect the probe or stop claiming a cause is a scope decision, not a review round. Please do not open it here.

Six pre-existing test assertions were relaxed from the exact word to the semantic predicate , deliberately: three assert the message MUST make that claim (broken client, terminal verdict, broken-with-spawn-suppressed) and three assert it MUST NOT (genuinely absent, worker that never installed anything, healthy client with a stale verdict), so the predicate cannot be satisfied by dropping the phrase or by printing it everywhere.

Validation already green locally at 94deca6b: 4584 unit tests, 52 ensure-idb shell assertions, lint, format:check, check-dist-fresh, check-agent-package-sync, check-typescript-only. An end-to-end stub run confirms the previously-permanent PATH-shim case now records , prints the PATH remedy instead of an install command, and remains retryable.

## What Changed

- `probeIdbClient()` in `packages/rn-dev-agent-core/src/observability/mirror/sources.ts` now returns `absent | ready | broken` from a real `idb` invocation (ENOENT vs non-zero exit), with `detectIdb()` kept as a thin wrapper; the mirror's simctl fallback carries a state-appropriate `degradedHint`, so a present-but-crashing client is reported as an incompatibility (probable fb-idb / Python 3.14 event-loop breakage) instead of repeating an install hint that cannot fix it.
- `scripts/ensure-idb.sh` (and its synced `packages/claude-plugin` copy) treats the client as three states, installs only under a pinned supported interpreter (python3.13/3.12/3.11, never letting pipx choose), and derives four worker outcomes — retryable PATH/shim visibility, terminal broken client, terminal no-interpreter re-armed on the installed-interpreter fingerprint, and retryable install failure — with the cause persisted in the backoff marker so the 24h message matches reality and is overridden by the live probe. Notices branch on the observed client state, so a healthy client missing only `idb_companion` gets companion-only guidance.
- Added shell regression coverage (60 assertions across broken/absent/terminal/PATH-shim/no-interpreter/ready-no-companion plus a no-unpinned-install rule), unit tests for the three probe states and the shell↔TS install-command sync guard, a CI step running the guard, updated `rn-setup` SKILL.md / `doctor.md` / observe docs for the broken and companion-only states, and a changeset bumping `rn-dev-agent-core` and `rn-dev-agent-plugin`.

## Risk Assessment

✅ Low: Both round-2 findings are fixed with minimal, correctly-scoped changes that complete the live-probe-outranks-persisted-cause invariant across every foreground message branch, the new regression assertion locks the fixed path, and no further issues surfaced in a full re-pass of the branch.

## Testing

Ran the two targeted suites (26 mirror-source unit tests, 60 ensure-idb shell assertions) and then reproduced the actual developer experience: three consecutive session starts against a stubbed machine where idb and idb_companion are installed but idb crashes. The base script repeats the unpinned "idb missing — ... pipx install fb-idb" hint forever; HEAD explains the probable Python 3.14 incompatibility, attempts one repair pinned to python3.13, then converges to a terminal verdict that names the marker file as the escape hatch and states mirroring stays on the simctl tier. Absent and healthy controls still behave correctly and no message prints the unpinned install command. For the UI surface I drove the real MirrorManager/createMirrorSource against a crashing idb on PATH, captured the mirror status payload the observe web UI consumes, and screenshotted the Device pane banner rendered with the app's own CSS and markup — before/after side by side. The documented /doctor probe distinguishes BROKEN, MISSING and OK as claimed. Everything passed; no findings. Note on the visual artifact: the observe UI needs a live simulator and an unbuilt Vite bundle, so the screenshot is a faithful reconstruction of DevicePane's markup with the project's real theme CSS, with the hint text taken verbatim from the live code path rather than hand-written. Transient stubs and temp scripts were removed and the worktree is clean.

<details>
<summary>Evidence: Session-start notice: before/after over 3 consecutive sessions, plus absent/healthy controls</summary>

<code>BEFORE (base 2d4b44f4), sessions 1-3 identical:&#10;idb client on PATH is broken (crashes on invocation) — the background worker will replace or remove it (B269)&#10;idb missing — installing in background (brew tap facebook/fb &amp;&amp; brew trust facebook/fb &amp;&amp; brew install idb-companion &amp;&amp; pipx install fb-idb). Log: ...&#10;&#10;AFTER (HEAD 76b64993), session 1:&#10;idb is installed but did not respond successfully: the most likely cause is fb-idb calling asyncio.get_event_loop(), which Python 3.14 removed. Installing it again under the same interpreter would reproduce this.&#10;Repairing in the background under a supported interpreter (python3.13). Manual: brew tap facebook/fb &amp;&amp; brew trust facebook/fb &amp;&amp; brew install idb-companion &amp;&amp; pipx install --python python3.13 --force fb-idb. Log: ...&#10;&#10;AFTER, sessions 2 and 3 (converged, no respawn):&#10;idb is installed but did not respond successfully: the most likely cause is fb-idb calling asyncio.get_event_loop(), which Python 3.14 removed. ...&#10;Recover with: brew tap facebook/fb &amp;&amp; brew trust facebook/fb &amp;&amp; brew install idb-companion &amp;&amp; pipx install --python python3.13 --force fb-idb&#10;Not retrying until the installed Python interpreters change — delete &lt;state&gt;/last-attempt to force a retry (e.g. after a newer fb-idb ships). Log: ... Mirroring stays on the ~6fps simctl tier.&#10;&#10;CONTROL idb absent:&#10;idb missing — installing in background (brew install python@3.13 &amp;&amp; brew tap facebook/fb &amp;&amp; brew trust facebook/fb &amp;&amp; brew install idb-companion &amp;&amp; pipx install --python python3.13 --force fb-idb). Log: ...&#10;&#10;CONTROL idb healthy:&#10;idb available: screen mirroring uses the fast path (idb video-stream)</code>

```text
SCENARIO  idb_companion 1.1.8 and fb-idb 1.1.7 are BOTH already installed.
          Every `idb` invocation crashes (Python 3.14). GitHub issue #578.

==============================================================
 BEFORE  (base 2d4b44f4)
==============================================================
--- session start #1 ---
idb client on PATH is broken (crashes on invocation) — the background worker will replace or remove it (B269)
idb missing — installing in background (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb). Log: /var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/tmp.mKTZa75r1p/state-BEFORE/install.log

--- session start #2 ---
idb client on PATH is broken (crashes on invocation) — the background worker will replace or remove it (B269)
idb missing — installing in background (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb). Log: /var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/tmp.mKTZa75r1p/state-BEFORE/install.log

--- session start #3 ---
idb client on PATH is broken (crashes on invocation) — the background worker will replace or remove it (B269)
idb missing — installing in background (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb). Log: /var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/tmp.mKTZa75r1p/state-BEFORE/install.log

==============================================================
 AFTER  (HEAD 76b64993)
==============================================================
--- session start #1 ---
idb is installed but did not respond successfully: the most likely cause is fb-idb calling asyncio.get_event_loop(), which Python 3.14 removed. Installing it again under the same interpreter would reproduce this.
Repairing in the background under a supported interpreter (python3.13). Manual: brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb. Log: /var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/tmp.mKTZa75r1p/state-AFTER/install.log

--- session start #2 ---
idb is installed but did not respond successfully: the most likely cause is fb-idb calling asyncio.get_event_loop(), which Python 3.14 removed. Installing it again under the same interpreter would reproduce this.
Recover with: brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb
Not retrying until the installed Python interpreters change — delete /var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/tmp.mKTZa75r1p/state-AFTER/last-attempt to force a retry (e.g. after a newer fb-idb ships). Log: /var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/tmp.mKTZa75r1p/state-AFTER/install.log. Mirroring stays on the ~6fps simctl tier.

--- session start #3 ---
idb is installed but did not respond successfully: the most likely cause is fb-idb calling asyncio.get_event_loop(), which Python 3.14 removed. Installing it again under the same interpreter would reproduce this.
Recover with: brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb
Not retrying until the installed Python interpreters change — delete /var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/tmp.mKTZa75r1p/state-AFTER/last-attempt to force a retry (e.g. after a newer fb-idb ships). Log: /var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/tmp.mKTZa75r1p/state-AFTER/install.log. Mirroring stays on the ~6fps simctl tier.

==============================================================
 CONTROL  idb genuinely absent -> must still ask for an install
==============================================================
idb missing — installing in background (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb). Log: /var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/tmp.mKTZa75r1p/state-absent/install.log

==============================================================
 CONTROL  idb present and working -> no warning at all
==============================================================
idb available: screen mirroring uses the fast path (idb video-stream)
```
</details>
- Evidence: observe UI Device pane — mirror banner before/after (crashing idb) (local file: <code>/var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/no-mistakes-evidence/01KZHJDHRNAP01B57V2ZJDXN11/observe-device-pane-idb-hint.png</code>)
<details>
<summary>Evidence: Rendered HTML source for the Device pane comparison</summary>

```text
<!doctype html><html><head><meta charset="utf-8">
<style>
* { box-sizing: border-box; }
html, body, #root { height: 100%; margin: 0; }
body {
  background: #16161e; color: #c0caf5;
  font: 13px/1.45 -apple-system, system-ui, sans-serif;
}
pre, .mono, .tool, .dur, .summ, .time, .reg-testid { font-family: ui-monospace, "SF Mono", Menlo, monospace; }
button { font: inherit; }
.app { display: flex; flex-direction: column; height: 100%; }

/* ── Header ─────────────────────────────────────────────── */
.header {
  display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
  padding: 8px 16px; background: #1a1b26; border-bottom: 1px solid #2a2b3d;
}
.brand { display: flex; align-items: baseline; gap: 8px; }
.brand strong { font-size: 14px; letter-spacing: 0.3px; }
.brand span { color: #565f89; font-size: 11px; text-transform: uppercase; letter-spacing: 1px; }
.conn-pill {
  display: inline-flex; align-items: center; gap: 6px;
  background: #1f2335; border: 1px solid #2a2b3d; border-radius: 999px;
  padding: 2px 10px; font-size: 11px; color: #a9b1d6;
}
.dot { width: 8px; height: 8px; border-radius: 50%; background: #787c99; flex: none; }
.dot.open { background: #9ece6a; box-shadow: 0 0 6px #9ece6a66; }
.dot.connecting { background: #e0af68; }
.dot.error { background: #f7768e; }
.chip {
  background: #1f2335; border: 1px solid #2a2b3d; border-radius: 6px;
  padding: 2px 8px; font-size: 11px; color: #a9b1d6; max-width: 260px;
  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
}
.chip.route { color: #9ece6a; }
.chip b { color: #565f89; font-weight: 600; margin-right: 5px; text-transform: uppercase; font-size: 10px; }
.hstats { margin-left: auto; display: flex; align-items: center; gap: 14px; }
.stat { display: flex; flex-direction: column; align-items: flex-end; line-height: 1.2; }
.stat .v { font-weight: 700; font-size: 13px; }
.stat .k { color: #565f89; font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; }
.stat .v.bad { color: #f7768e; }

/* ── Panes ──────────────────────────────────────────────── */
.panes { display: flex; flex: 1; min-height: 0; }
.pane { display: flex; flex-direction: column; min-width: 0; border-right: 1px solid #2a2b3d; }
.pane.left { flex: 0 0 33%; min-width: 380px; }
/* The mirror is a portrait phone screen capped at ~100vh height, so width
   beyond ~400px is dead space — the state pane absorbs the surplus instead. */
.pane.center { flex: 0 1 400px; min-width: 280px; }
.pane.right { flex: 1 1 26%; min-width: 340px; border-right: none; }
.pane-head {
  display: flex; align-items: center; gap: 8px;
  padding: 7px 12px; background: #1a1b26; border-bottom: 1px solid #2a2b3d;
  font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.6px; color: #a9b1d6;
}

/* ── Filter bar ─────────────────────────────────────────── */
.filterbar {
  display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
  padding: 8px 10px; background: #1a1b26; border-bottom: 1px solid #2a2b3d;
}
.fchip {
  display: inline-flex; align-items: center; gap: 6px; cursor: pointer;
  background: #1f2335; color: #a9b1d6; border: 1px solid #2a2b3d;
  border-radius: 999px; padding: 2px 10px; font-size: 11px;
}
.fchip .fdot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
.fchip .n { color: #565f89; }
.fchip.off { opacity: 0.35; }
.fchip.errors.on { border-color: #f7768e; color: #f7768e; }
.search {
  flex: 1; min-width: 130px; background: #1f2335; border: 1px solid #2a2b3d;
  border-radius: 6px; color: #c0caf5; padding: 4px 10px; font: inherit; font-size: 12px;
}
.search::placeholder { color: #565f89; }
.search:focus { outline: none; border-color: #7aa2f7; }

/* ── Timeline ───────────────────────────────────────────── */
.timeline-wrap { position: relative; flex: 1; min-height: 0; display: flex; flex-direction: column; }
.timeline { flex: 1; overflow: auto; padding: 4px 0; }
.row {
  display: flex; align-items: center; gap: 8px;
  padding: 4px 12px; cursor: pointer; white-space: nowrap;
}
.row:hover { background: #1f2335; }
.row.sel { background: #283457; }
.row.err { box-shadow: inset 2px 0 0 #f7768e; }
.time { color: #565f89; font-size: 11px; flex: none; }
.fam { color: #16161e; border-radius: 3px; padding: 0 5px; font-size: 10px; font-weight: 700; text-transform: uppercase; flex: none; }
.tool { color: #7dcfff; flex: none; }
.summ { color: #a9b1d6; overflow: hidden; text-overflow: ellipsis; flex: 1; min-width: 0; }
.ghost { color: #16161e; background: #e0af68; border-radius: 3px; padding: 0 4px; font-size: 10px; font-weight: 700; flex: none; }
.ok { flex: none; } .ok.pass { color: #9ece6a; } .ok.fail { color: #f7768e; }
.dur { color: #565f89; font-size: 11px; flex: none; }
.dur.slow { color: #e0af68; font-weight: 700; }
.detail { background: #13141c; border-top: 1px solid #2a2b3d; border-bottom: 1px solid #2a2b3d; padding: 8px 12px; }
.dlabel { color: #787c99; text-transform: uppercase; font-size: 10px; margin: 6px 0 2px; letter-spacing: 0.5px; }
.detail pre, .state pre { margin: 0; white-space: pre-wrap; word-break: break-word; font-size: 12px; }
.detail pre.errtext { color: #f7768e; }
.jump {
  position: absolute; bottom: 14px; left: 50%; transform: translateX(-50%);
  background: #283457; color: #c0caf5; border: 1px solid #7aa2f7; border-radius: 999px;
  padding: 5px 14px; cursor: pointer; font-size: 12px; font-weight: 600;
  box-shadow: 0 4px 14px #00000088;
}
.jump:hover { background: #3b4261; }
.count-note { padding: 4px 12px; color: #565f89; font-size: 11px; border-top: 1px solid #1f2335; }

/* ── Device pane ────────────────────────────────────────── */
.screen { flex: 1; overflow: auto; display: flex; align-items: center; justify-content: center; padding: 16px; }
.device-frame {
  background: #101018; border: 1px solid #2a2b3d; border-radius: 22px;
  padding: 10px; box-shadow: 0 8px 30px #00000066; max-width: 100%; max-height: 100%;
}
.device-frame img { display: block; max-width: 100%; max-height: calc(100vh - 160px); border-radius: 14px; }
.route-chip {
  margin-left: auto; background: #1f2335; color: #9ece6a; border: 1px solid #2a2b3d;
  border-radius: 999px; padding: 1px 10px; font-size: 11px; font-weight: 600; text-transform: none; letter-spacing: 0;
}
.mirror-footer {
  flex: none; padding: 3px 12px; text-align: center; font-size: 11px; color: #565f89;
  background: #1a1b26; border-top: 1px solid #2a2b3d; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
}
.mirror-banner {
  flex: none; padding: 5px 12px; font-size: 11px; line-height: 1.45;
  color: #e0af68; background: #1a1b26; border-bottom: 1px solid #2a2b3d;
}

/* ── Tabs / state pane ──────────────────────────────────── */
.tabs { display: flex; flex-wrap: wrap; gap: 6px; padding: 7px 10px; background: #1a1b26; border-bottom: 1px solid #2a2b3d; }
.tab {
  background: #1f2335; color: #a9b1d6; border: 1px solid #2a2b3d; border-radius: 6px;
  padding: 3px 10px; cursor: pointer;
}
.tab.on { background: #283457; color: #c0caf5; border-color: #7aa2f7; }
.state { flex: 1; overflow: auto; padding: 10px 12px; }
.state-panel { display: flex; flex-direction: column; flex: 1; min-height: 0; }
.trunc { color: #e0af68; font-size: 11px; margin-bottom: 6px; }
.liveroute { color: #9ece6a; font-weight: 600; margin-bottom: 8px; word-break: break-all; }
.state-live-row { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
.state-refresh-btn {
  background: #283457; color: #c0caf5; border: 1px solid #7aa2f7; border-radius: 6px;
  padding: 3px 10px; cursor: pointer; font-size: 12px;
}
.state-refresh-btn:hover:not(:disabled) { background: #3b4261; }
.state-refresh-btn

... [258 bytes truncated] ...

─────────────────────────────── */
.empty { color: #565f89; padding: 14px; }
.empty-guide { margin: auto; max-width: 320px; text-align: center; line-height: 1.6; }
.empty-guide .empty-title { color: #a9b1d6; font-weight: 600; margin-bottom: 6px; font-size: 14px; }

/* ── E2E panel (run history + suite results) ───────────── */
/* The right pane is ~340-450px wide; tables cannot shrink below their
   column content, so results, history, and actions render as stacked
   rows that truncate/wrap instead. */
.reg-container { display: flex; flex-direction: column; flex: 1; min-height: 0; overflow: auto; padding: 10px; gap: 10px; }
.reg-panel, .actions-panel, .reg-history { background: #1a1b26; border: 1px solid #2a2b3d; border-radius: 8px; overflow: hidden; flex: none; }
.reg-header { display: flex; align-items: center; gap: 10px; padding: 12px; flex-wrap: wrap; }
.reg-run-btn {
  background: #283457; color: #c0caf5; border: 1px solid #7aa2f7; border-radius: 6px;
  padding: 6px 18px; cursor: pointer; font-weight: 600;
}
.reg-run-btn:hover:not(:disabled) { background: #3b4261; }
.reg-run-btn:disabled { opacity: 0.5; cursor: not-allowed; }
.reg-progress { color: #e0af68; font-size: 12px; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
.reg-verdict { font-weight: 700; border-radius: 6px; padding: 3px 12px; font-size: 13px; }
.reg-verdict.pass { background: #1a2d1a; color: #9ece6a; border: 1px solid #9ece6a; }
.reg-verdict.fail { background: #2d1a1a; color: #f7768e; border: 1px solid #f7768e; }
.reg-verdict.none { background: #1f2335; color: #787c99; border: 1px solid #565f89; }
.reg-empty-hint { color: #787c99; font-size: 12px; font-style: italic; }
.reg-testid { color: #7dcfff; }
.reg-pass { color: #9ece6a; font-weight: 600; }
.reg-fail { color: #f7768e; font-weight: 600; }
.reg-none { color: #787c99; font-weight: 600; }
.reg-badge { border-radius: 3px; padding: 1px 6px; font-size: 10px; font-weight: 700; text-transform: uppercase; flex: none; }
.reg-badge-pass { background: #1a2d1a; color: #9ece6a; }
.reg-badge-regression { background: #2d1a1a; color: #f7768e; }
.reg-badge-infra { background: #2d2a1a; color: #e0af68; }
.reg-badge-skipped { background: #1f2335; color: #787c99; }
.result-list { border-top: 1px solid #2a2b3d; }
.result-row { display: flex; align-items: center; gap: 7px; padding: 5px 12px; font-size: 12px; }
.result-row + .result-row, .errx + .result-row { border-top: 1px solid #1f2335; }
.result-row.newly-failing { background: #2d1a1a; }
.result-mark { flex: none; }
.result-id { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
.result-ms { color: #565f89; font-size: 11px; flex: none; }
.errx {
  color: #f7768e; font-size: 11px; white-space: pre-wrap; word-break: break-word;
  padding: 0 12px 5px 31px;
}
.hist-item + .hist-item { border-top: 1px solid #1f2335; }
.hist-toggle {
  display: flex; align-items: center; gap: 7px; width: 100%;
  background: none; border: none; color: inherit; text-align: left;
  padding: 7px 12px; cursor: pointer; font-size: 12px;
}
.hist-toggle:hover { background: #1f2335; }
.hist-caret { color: #565f89; font-size: 10px; flex: none; }
.hist-id { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
.hist-time { color: #565f89; font-size: 11px; flex: none; }
.hist-totals { font-size: 11px; flex: none; }
.hist-verdict { font-size: 11px; flex: none; }
.hist-body { background: #13141c; border-top: 1px solid #1f2335; padding-bottom: 5px; }
.hist-body .result-row { padding-left: 12px; }
.hist-meta { color: #787c99; font-size: 11px; padding: 7px 12px 4px; }

/* ── Actions panel ──────────────────────────────────────── */
.action-item { padding: 9px 12px; }
.action-item + .action-item { border-top: 1px solid #1f2335; }
.action-top { display: flex; align-items: center; gap: 7px; }
.action-id { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
.action-intent {
  color: #787c99; font-size: 12px; line-height: 1.4; margin-top: 3px;
  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
}
.actions-params { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 7px; }
.param-input {
  background: #1f2335; border: 1px solid #2a2b3d; border-radius: 4px; color: #c0caf5;
  padding: 3px 8px; font-size: 11px; font-family: ui-monospace, "SF Mono", Menlo, monospace;
  flex: 1 1 90px; min-width: 0;
}
.param-input::placeholder { color: #565f89; }
.param-input:focus { outline: none; border-color: #7aa2f7; }
.param-input.missing { border-color: #f7768e; }
.actions-mutates { background: #2d2a1a; color: #e0af68; border-radius: 3px; padding: 1px 4px; font-size: 10px; font-weight: 700; flex: none; }
.actions-status-active { background: #1a2d1a; color: #9ece6a; }
.actions-status-experimental { background: #2d2a1a; color: #e0af68; }
.actions-status-deprecated { background: #1f2335; color: #787c99; }
.actions-run-btn {
  background: #283457; color: #c0caf5; border: 1px solid #2a2b3d; border-radius: 4px;
  padding: 3px 12px; cursor: pointer; font-size: 11px; flex: none;
}
.actions-run-btn:hover:not(:disabled) { background: #3b4261; border-color: #7aa2f7; }
.actions-run-btn:disabled { opacity: 0.5; cursor: not-allowed; }
.action-result { margin-top: 6px; font-size: 11px; }
.actions-result-ok { color: #9ece6a; font-weight: 600; cursor: pointer; }
.actions-result-fail { color: #f7768e; cursor: pointer; word-break: break-word; }
.action-output {
  margin: 6px 0 0; background: #13141c; border: 1px solid #1f2335; border-radius: 6px;
  padding: 8px 10px; font-size: 11px; white-space: pre-wrap; word-break: break-word;
  max-height: 240px; overflow: auto;
}

body { padding: 20px; }
.cols { display: flex; gap: 24px; align-items: flex-start; }
.col { flex: 0 0 480px; }
.cap { font-size: 12px; font-weight: 700; letter-spacing: .6px; text-transform: uppercase; margin-bottom: 8px; }
.cap.b { color: #f7768e; } .cap.a { color: #9ece6a; }
.pane.center { flex: none; width: 480px; border: 1px solid #2a2b3d; border-radius: 8px; overflow: hidden; }
.fake-screen { width: 200px; height: 380px; display: flex; align-items: center; justify-content: center;
  text-align: center; color: #565f89; background: #101018; border-radius: 14px; font-size: 12px; }
h1 { font-size: 15px; margin: 0 0 4px; } .sub { color: #787c99; font-size: 12px; margin-bottom: 18px; }
</style></head><body>
<h1>observe UI — Device pane, iOS simulator with idb installed but crashing (GH#578)</h1>
<div class="sub">Hint strings produced by the real MirrorManager + createMirrorSource against a crashing <code>idb</code> on PATH.</div>
<div class="cols">
  <div class="col"><div class="cap b">BEFORE — base 2d4b44f4</div>
<div class="pane center" data-testid="device-pane">
  <div class="pane-head">Device<span class="route-chip">/home</span></div>
  <div class="mirror-banner">install idb for smoother mirroring (brew tap facebook/fb &amp;&amp; brew trust facebook/fb &amp;&amp; brew install idb-companion &amp;&amp; pipx install fb-idb)</div>
  <div class="screen">
    <div class="device-frame"><div class="fake-screen">simulator screen<br/>(~6fps simctl fallback)</div></div>
  </div>
  <div class="mirror-footer">mirror: simctl ~6fps</div>
</div></div>
  <div class="col"><div class="cap a">AFTER — HEAD 76b64993</div>
<div class="pane center" data-testid="device-pane">
  <div class="pane-head">Device<span class="route-chip">/home</span></div>
  <div class="mirror-banner">idb is installed but did not respond successfully — most likely fb-idb 1.1.7 under Python 3.14, which removed the asyncio.get_event_loop() it needs. Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb</div>
  <div class="screen">
    <div class="device-frame"><div class="fake-screen">simulator screen<br/>(~6fps simctl fallback)</div></div>
  </div>
  <div class="mirror-footer">mirror: simctl ~6fps</div>
</div></div>
</div></body></html>
```
</details>
<details>
<summary>Evidence: Mirror status payload pushed to the observe UI (real MirrorManager, base vs HEAD, broken vs absent)</summary>

<code>BEFORE (base) hint: &#34;install idb for smoother mirroring (brew tap facebook/fb &amp;&amp; brew trust facebook/fb &amp;&amp; brew install idb-companion &amp;&amp; pipx install fb-idb)&#34;&#10;AFTER (HEAD) hint: &#34;idb is installed but did not respond successfully — most likely fb-idb 1.1.7 under Python 3.14, which removed the asyncio.get_event_loop() it needs. Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb&#34;&#10;AFTER, idb absent hint: &#34;install idb for smoother mirroring (brew install python@3.13 &amp;&amp; brew tap facebook/fb &amp;&amp; brew trust facebook/fb &amp;&amp; brew install idb-companion &amp;&amp; pipx install --python python3.13 --force fb-idb)&#34;</code>

```text
### mirror status pushed to the observe UI — idb installed but crashing (GH#578)

--- BEFORE (base 2d4b44f4) ---
[
  {
    "type": "mirror",
    "status": "starting",
    "platform": "ios",
    "deviceId": "A1B2C3D4-SIM"
  },
  {
    "type": "mirror",
    "status": "streaming",
    "platform": "ios",
    "deviceId": "A1B2C3D4-SIM",
    "pipeline": "simctl",
    "fps": 6,
    "hint": "install idb for smoother mirroring (brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install fb-idb)"
  }
]

--- AFTER (HEAD 76b64993) ---
[
  {
    "type": "mirror",
    "status": "starting",
    "platform": "ios",
    "deviceId": "A1B2C3D4-SIM"
  },
  {
    "type": "mirror",
    "status": "streaming",
    "platform": "ios",
    "deviceId": "A1B2C3D4-SIM",
    "pipeline": "simctl",
    "fps": 6,
    "hint": "idb is installed but did not respond successfully — most likely fb-idb 1.1.7 under Python 3.14, which removed the asyncio.get_event_loop() it needs. Reinstall it under a supported interpreter: pipx install --python python3.13 --force fb-idb"
  }
]

--- AFTER, idb genuinely absent ---
[
  {
    "type": "mirror",
    "status": "starting",
    "platform": "ios",
    "deviceId": "A1B2C3D4-SIM"
  },
  {
    "type": "mirror",
    "status": "streaming",
    "platform": "ios",
    "deviceId": "A1B2C3D4-SIM",
    "pipeline": "simctl",
    "fps": 6,
    "hint": "install idb for smoother mirroring (brew install python@3.13 && brew tap facebook/fb && brew trust facebook/fb && brew install idb-companion && pipx install --python python3.13 --force fb-idb)"
  }
]
```
</details>
<details>
<summary>Evidence: /doctor probe snippet distinguishes all three client states</summary>

<code>$ # idb + companion installed, idb crashes on every call (GH#578)&#10;idb client BROKEN&#10;idb-companion OK&#10;&#10;$ # idb genuinely absent&#10;idb MISSING&#10;idb-companion MISSING&#10;&#10;$ # idb healthy&#10;idb client OK&#10;idb-companion OK</code>

```text
### /doctor probe snippet from rn-setup SKILL.md (lines 179-180), run against each client state

$ # idb + companion installed, idb crashes on every call (GH#578)
idb client BROKEN
idb-companion OK

$ # idb genuinely absent
idb MISSING
idb-companion MISSING

$ # idb healthy
idb client OK
idb-companion OK
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `packages/shared-agent-knowledge/skills/rn-setup/SKILL.md:179` - The doctor verification snippet was changed from `command -v idb &amp;&amp; { … }` to `idb --help &gt;/dev/null 2&gt;&amp;1 &amp;&amp; { … }`, dropping the PATH check. The prose immediately below (and the summary table row) requires the agent to report BROKEN (&#34;on PATH but exits non-zero&#34;) distinctly from MISSING, but the single command it is told to run returns one undifferentiated non-zero exit for both an absent binary and a crashing one — the exact absent/broken collapse this change exists to remove, reproduced at the /doctor surface. The identical line exists at packages/claude-plugin/skills/rn-setup/SKILL.md:179. Fix mechanically: `command -v idb &amp;&amp; idb --help &gt;/dev/null 2&gt;&amp;1 &amp;&amp; { command -v idb_companion || command -v idb-companion; }`, or a two-step snippet mirroring idb_client_state().
- ⚠️ `scripts/ensure-idb.sh:274` - The NOTICE else-branch is entered for CLIENT_STATE=broken AND CLIENT_STATE=ready. A developer with a healthy fb-idb client but no idb_companion (reachable: passes line 194 only because has_companion is false, and line 212 is skipped because the state is ready) is told &#34;Repairing in the background under a supported interpreter (python3.13 python3.12 python3.11). Manual: … pipx install --python python3.13 --force fb-idb&#34;. Both halves are wrong for that state: the worker&#39;s line 129 guard (`[ &#34;$(idb_client_state)&#34; != ready ]`) skips pipx entirely and only installs the companion, and following the printed manual command would force-reinstall a client that already works, possibly onto a different interpreter. The notice should branch on the missing piece (companion vs client), not lump ready in with broken. Same wording is reused for the identical branch in packages/claude-plugin/scripts/ensure-idb.sh.
- ℹ️ `scripts/test/ensure-idb.test.sh:249` - Section identifiers 7h, 7i and 7j are each used twice, and the duplicated blocks reuse the same STATE directories ($TMP/state7h, $TMP/state7j) and output files ($TMP/worker7h.out). The second 7i block sets no STATE or STUBS of its own and silently depends on the state and stubs left behind by the second 7h, so reordering or editing 7h changes what 7i asserts, and a failure message naming &#34;7h&#34; is ambiguous. Renumber the round-4 blocks (7l–7n) and give each its own state dir.
- ℹ️ `scripts/ensure-idb.sh:222` - The terminal `incompatible` verdict is fingerprinted only by the installed interpreter set, so a future fb-idb release that fixes Python 3.14 compatibility will never re-arm the repair path. The escape hatch (delete $MARKER) exists only in the code comment at line 209; the message the developer actually reads says just &#34;Not retrying until the installed Python interpreters change (log: $LOG)&#34;. Naming the marker path in that line would let a developer force a retry after upgrading fb-idb without reading the script.

🔧 Fix: branch idb notices by observed client state
2 issues (1 warning, 1 info) still open:
- ⚠️ `scripts/ensure-idb.sh:269` - The 24h backoff block selects its message from the persisted LAST_CAUSE before consulting the live probe, so a stale `path-shim` marker can contradict reality. Reachable path: a worker run in which the companion `brew install` fails AND the pinned pipx install succeeds without a visible shim records `failed &lt;ts&gt; &lt;fp&gt; path-shim` (the path-shim branch at line ~161 sets status/cause unconditionally, overriding the earlier brew failure). The developer then runs `pipx ensurepath` and opens a new shell. Next session start reads CLIENT_STATE=ready, skips the fast path because the companion is still missing, skips the terminal-verdict branch (correctly guarded by `CLIENT_STATE != ready` at line 212), and lands here — printing &#34;fb-idb installed successfully, but no idb client is visible on PATH — the pipx shim directory (usually ~/.local/bin) is not exported. Run &#39;pipx ensurepath&#39;&#34; to a developer whose client is now visible and working. This violates the invariant the script states in its own comment at line 212 (&#34;A verdict may never contradict the live probe&#34;), which the terminal branch enforces and this branch does not. Fix by testing `[ &#34;$CLIENT_STATE&#34; = ready ]` before `[ &#34;${LAST_CAUSE:-}&#34; = &#34;path-shim&#34; ]` — a reorder of the existing conditions, adding no state and no re-arm logic. Same lines in the generated packages/claude-plugin/scripts/ensure-idb.sh.
- ℹ️ `packages/shared-agent-knowledge/skills/rn-setup/SKILL.md:180` - The restored probe does separate presence from health, but its second line runs unconditionally, so a machine with no idb at all emits `idb MISSING` immediately followed by `idb client BROKEN (only if the line above found it)`. The correct state is derivable from the parenthetical, but the literal word BROKEN printed for an absent binary is the wrong-word-for-the-state pattern this change exists to remove, and it relies on the reading agent correlating two lines. Nesting the health check inside the presence check removes the ambiguity entirely, e.g. `command -v idb &gt;/dev/null &amp;&amp; { idb --help &gt;/dev/null 2&gt;&amp;1 &amp;&amp; echo &#34;idb client OK&#34; || echo &#34;idb client BROKEN&#34;; } || echo &#34;idb MISSING&#34;`. The identical line is at packages/claude-plugin/skills/rn-setup/SKILL.md:180; both copies must stay byte-identical for check-agent-package-sync.sh.

🔧 Fix: let live idb probe outrank persisted cause
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --test test/unit/mirror-sources.test.js` in packages/rn-dev-agent-core (26 tests, includes the probeIdbClient absent/ready/broken cases and the shell↔TS install-command sync guard)</code>
- <code>`bash scripts/test/ensure-idb.test.sh` (60 assertions covering broken vs absent client, terminal verdict, PATH-shim, no-interpreter, ready-no-companion, and the no-unpinned-install rule)</code>
- <code>Manual end-to-end replay of the issue scenario: ran base `scripts/ensure-idb.sh` (2d4b44f4) and HEAD `scripts/ensure-idb.sh` for 3 consecutive simulated session starts each, with a stub `idb` that exits non-zero, plus stub idb_companion/brew/pipx/python3.13, running the real `--install-worker` between sessions and aging the backoff marker</code>
- <code>Manual control runs of HEAD `scripts/ensure-idb.sh` with idb genuinely absent and with a healthy idb</code>
- <code>Drove the real `MirrorManager` + `createMirrorSource` from `packages/rn-dev-agent-core/dist` against a crashing `idb` on PATH (and against an absent idb) and captured the `status: streaming` payload the observe UI consumes, for both base and HEAD dist</code>
- `Rendered the observe UI Device pane (real theme.ts CSS + DevicePane.tsx markup, hint strings injected from the live MirrorManager payloads) and screenshotted the before/after mirror banner via chrome-devtools-axi`
- <code>Ran the `/doctor` probe snippet documented in `packages/shared-agent-knowledge/skills/rn-setup/SKILL.md` (lines 179-180) against all three client states</code>
- <code>`grep -rn &#39;pipx install fb-idb&#39;` across packages/scripts/docs to confirm the unpinned command survives only in prohibitive prose, comments, and historical CHANGELOG entries</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/superpowers/specs/2026-07-06-observe-idb-hint-header-design.md:10` - The archived design docs docs/superpowers/specs/2026-07-06-observe-idb-hint-header-design.md (line 10) and docs/superpowers/plans/2026-07-04-observe-live-mirror.md (lines 358, 614, 641) quote the old SIMCTL_HINT / IDB_HINT strings with a bare `pipx install fb-idb`, which this change replaced with the interpreter-pinned IDB_INSTALL_COMMAND. I left them unedited: they are dated, unreferenced historical plan/spec records of a completed change, and rewriting an archive to match today&#39;s code destroys its record value while adding a fourth prose copy of a fact now owned by sources.ts. If these are treated as living reference docs rather than archives, they should instead be reduced to a pointer at IDB_INSTALL_COMMAND — a judgment call for the owner, not a fix to make here.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
