### PR TITLE
feat(core): add sanitized local experience evidence loop

### DIFF
--- a/.changeset/calm-evidence-trends.md
+++ b/.changeset/calm-evidence-trends.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-plugin": patch
+"rn-dev-agent-core": patch
+---
+
+Capture sanitized local failure and recovery patterns through the existing tool observer, deduplicate and bound the evidence store, and add a read-only trend report command.

--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ The plugin makes no attempt to sandbox `cdp_evaluate`. If you need that, gate to
 
 The **observability UI** ([`/rn-dev-agent:observe`](https://lykhoyda.github.io/rn-dev-agent/commands/observe/)) binds to `127.0.0.1` only and rejects cross-origin requests via Host-header + `Sec-Fetch-Site` checks. It is read-only except for two deliberate, CSRF-token-gated endpoints that trigger action and locked-E2E replays. Tool arguments are deep-redacted fail-closed before reaching the stream (tokens, passwords, and PII render as `[REDACTED_*]`), and the recorder keeps only a small bounded in-memory ring buffer — the event stream itself never touches disk (replays triggered from the UI still persist their normal run records under `.rn-agent/`, same as CLI-triggered replays).
 
+Meaningful tool failures and immediate successful retries also feed a separate, local-only evidence store at `~/.claude/rn-agent/experience/patterns.jsonl`. Records are sanitized before writing, deduplicated, capped at 500 patterns, and retained for 14 days; ordinary successful calls are never stored. From an installed plugin package, inspect the read-only trend report with `node <plugin-package>/rn-dev-agent-core/dist/experience-trends.js --since <previous-report-ISO-timestamp>` (omit `--since` for the last 24 hours). The command never updates the evidence store or uploads data.
+
 ## Keeping up to date
 
 Enable auto-update in the host plugin manager, or update manually:

--- a/packages/claude-plugin/rn-dev-agent-core/dist/experience-trends.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/experience-trends.js
@@ -11,17 +11,68 @@ import { dirname, join } from "node:path";
 var EXPERIENCE_DIRECTORY = join(homedir(), ".claude", "rn-agent", "experience");
 var EXPERIENCE_STORE_NAME = "patterns.jsonl";
 var DAY_MS = 24 * 60 * 60 * 1e3;
-function readExperienceStore(path, allowMissing = false) {
-  if (!existsSync(path)) {
-    if (allowMissing)
-      return [];
+var SANITIZED_RECORDS = /* @__PURE__ */ new WeakSet();
+function readExperienceStore(path) {
+  if (!existsSync(path))
     return [];
-  }
   const contents = readFileSync(path, "utf8");
   if (!contents.trim())
     return [];
-  return contents.split("\n").filter((line) => line.trim().length > 0).map((line) => JSON.parse(line));
+  const records = [];
+  for (const line of contents.split("\n")) {
+    if (line.trim().length === 0)
+      continue;
+    let parsed;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    SANITIZED_RECORDS.add(parsed);
+    records.push(parsed);
+  }
+  return records;
 }
+var CLASSIFICATION_RULES = [
+  ["FF_REDBOX", /redbox|logbox|error overlay|hasredbox/],
+  ["FF_DEBUGGER_PAUSED", /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
+  [
+    "FF_STALE_CDP",
+    /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/
+  ],
+  ["FF_FAST_REFRESH_STALE", /fast refresh|ui unchanged|old exports|old module path/],
+  ["FF_METRO_CACHE", /metro.*(?:stale|cache)|config change not reflected/],
+  [
+    "FF_BINARY_MISMATCH",
+    /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/
+  ],
+  ["FF_EXPO_DIALOG", /open-in-app|system confirmation dialog/],
+  ["FF_DEV_CLIENT_PICKER", /no hermes target|development servers|devclientlauncher|server picker/],
+  ["FF_KEYBOARD_OVERLAY", /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
+  ["FF_MAESTRO_GRPC_ANDROID", /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
+  [
+    "FF_ANDROID_TEXT_INPUT_CRASH",
+    /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/
+  ],
+  ["FF_AUTH_GATE", /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/],
+  [
+    "FF_PERMISSION_ALREADY_GRANTED",
+    /permission already granted|prompt (?:was )?not shown|flow completes instantly/
+  ],
+  ["EG_EXPO_GO_SDK_MISMATCH", /incompatible with this version of expo go|expo go sdk.*mismatch/],
+  ["EG_NATIVEWIND_JSX_SOURCE", /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
+  ["EG_EXPO_GO_NATIVE_MODULES", /expo go.*custom native module/],
+  ["EG_DEV_CLIENT_CLEARSTATE", /clearstate.*(?:dev client|metro connection|launcher)/],
+  ["EG_MSW_HERMES", /msw.*(?:hermes|react native|initialize)/],
+  ["EG_EXPO_ROUTER_DEEP_LINK", /expo router.*deep link|deep link.*confirmation dialog/],
+  ["EG_DEV_MENU_INTERFERENCE", /dev menu.*(?:overlay|recording|blocking)/],
+  ["EG_NEW_ARCH_CDP_TARGET", /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
+  ["PQ_IOS_RECORDVIDEO_CODEC", /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
+  ["PQ_ANDROID_SCREENRECORD_LIMIT", /screenrecord.*180|screenrecord.*3 minute/],
+  ["PQ_ANDROID_BOOT_DELAY", /sys\.boot_completed|emulator.*grpc.*ready/],
+  ["PQ_ANDROID_PLAY_PROTECT", /play protect.*(?:block|apk|install)/]
+];
+var EXPERIENCE_FAMILY_IDS = CLASSIFICATION_RULES.map(([id]) => id);
 
 // packages/rn-dev-agent-core/dist/experience/trends.js
 function buildExperienceTrendReport(records, since2, now = /* @__PURE__ */ new Date()) {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/experience-trends.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/experience-trends.js
@@ -11,7 +11,6 @@ import { dirname, join } from "node:path";
 var EXPERIENCE_DIRECTORY = join(homedir(), ".claude", "rn-agent", "experience");
 var EXPERIENCE_STORE_NAME = "patterns.jsonl";
 var DAY_MS = 24 * 60 * 60 * 1e3;
-var SANITIZED_RECORDS = /* @__PURE__ */ new WeakSet();
 function readExperienceStore(path) {
   if (!existsSync(path))
     return [];
@@ -28,7 +27,6 @@ function readExperienceStore(path) {
     } catch {
       continue;
     }
-    SANITIZED_RECORDS.add(parsed);
     records.push(parsed);
   }
   return records;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/experience-trends.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/experience-trends.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+import { createRequire as __rnCreateRequire } from "node:module"; const require = __rnCreateRequire(import.meta.url);
+
+// packages/rn-dev-agent-core/dist/experience/trends.js
+import { join as join2 } from "node:path";
+
+// packages/rn-dev-agent-core/dist/experience/evidence.js
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir, platform as hostPlatform, release } from "node:os";
+import { dirname, join } from "node:path";
+var EXPERIENCE_DIRECTORY = join(homedir(), ".claude", "rn-agent", "experience");
+var EXPERIENCE_STORE_NAME = "patterns.jsonl";
+var DAY_MS = 24 * 60 * 60 * 1e3;
+function readExperienceStore(path, allowMissing = false) {
+  if (!existsSync(path)) {
+    if (allowMissing)
+      return [];
+    return [];
+  }
+  const contents = readFileSync(path, "utf8");
+  if (!contents.trim())
+    return [];
+  return contents.split("\n").filter((line) => line.trim().length > 0).map((line) => JSON.parse(line));
+}
+
+// packages/rn-dev-agent-core/dist/experience/trends.js
+function buildExperienceTrendReport(records, since2, now = /* @__PURE__ */ new Date()) {
+  const families = /* @__PURE__ */ new Map();
+  for (const record of records) {
+    const aggregate = families.get(record.classification) ?? { count: 0, patterns: 0 };
+    aggregate.count += record.count;
+    aggregate.patterns += 1;
+    families.set(record.classification, aggregate);
+  }
+  const project = (record) => ({
+    signature: record.signature,
+    classification: record.classification,
+    tool: record.tool,
+    count: record.count,
+    firstSeen: record.firstSeen,
+    lastSeen: record.lastSeen
+  });
+  const sortPatterns = (a, b) => b.count - a.count || a.classification.localeCompare(b.classification) || a.signature.localeCompare(b.signature);
+  return {
+    generatedAt: now.toISOString(),
+    since: since2.toISOString(),
+    families: [...families.entries()].map(([classification, value]) => ({ classification, ...value })).sort((a, b) => b.count - a.count || a.classification.localeCompare(b.classification)),
+    newSincePreviousReport: records.filter((record) => Date.parse(record.firstSeen) >= since2.getTime()).map(project).sort(sortPatterns),
+    recurring: records.filter((record) => record.count > 1).map(project).sort(sortPatterns)
+  };
+}
+function readExperienceTrendReport(options) {
+  const directory = options.directory ?? process.env.RN_DEV_AGENT_EXPERIENCE_DIR ?? EXPERIENCE_DIRECTORY;
+  return buildExperienceTrendReport(readExperienceStore(join2(directory, EXPERIENCE_STORE_NAME)), options.since);
+}
+
+// packages/rn-dev-agent-core/dist/experience-trends.js
+function usage() {
+  process.stderr.write("Usage: rn-experience-trends [--since <ISO timestamp>] [--json]\n  --since is the generated-at timestamp printed by the previous report (default: 24 hours ago).\n  This command only reads ~/.claude/rn-agent/experience/patterns.jsonl.\n");
+  process.exit(2);
+}
+var since = new Date(Date.now() - 24 * 60 * 60 * 1e3);
+var json = false;
+for (let index = 2; index < process.argv.length; index += 1) {
+  const argument = process.argv[index];
+  if (argument === "--json") {
+    json = true;
+  } else if (argument === "--since") {
+    const value = process.argv[++index];
+    const parsed = value ? new Date(value) : new Date(Number.NaN);
+    if (!Number.isFinite(parsed.getTime()))
+      usage();
+    since = parsed;
+  } else if (argument === "--help" || argument === "-h") {
+    usage();
+  } else {
+    usage();
+  }
+}
+try {
+  const report = readExperienceTrendReport({ since });
+  if (json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}
+`);
+  } else {
+    process.stdout.write(`Experience trends (new since ${report.since})
+`);
+    process.stdout.write(`Report generated at ${report.generatedAt}; pass this value to --since next time.
+`);
+    process.stdout.write("\nFamilies by frequency\n");
+    if (report.families.length === 0)
+      process.stdout.write("  none\n");
+    for (const family of report.families) {
+      process.stdout.write(`  ${family.classification}: ${family.count} occurrence(s), ${family.patterns} pattern(s)
+`);
+    }
+    process.stdout.write("\nNew since previous report\n");
+    if (report.newSincePreviousReport.length === 0)
+      process.stdout.write("  none\n");
+    for (const item of report.newSincePreviousReport) {
+      process.stdout.write(`  ${item.classification} ${item.tool}: ${item.count} (${item.signature.slice(0, 12)})
+`);
+    }
+    process.stdout.write("\nRecurring\n");
+    if (report.recurring.length === 0)
+      process.stdout.write("  none\n");
+    for (const item of report.recurring) {
+      process.stdout.write(`  ${item.classification} ${item.tool}: ${item.count} (${item.signature.slice(0, 12)})
+`);
+    }
+  }
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`rn-experience-trends: could not read the local evidence store: ${message}
+`);
+  process.exitCode = 1;
+}

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -79433,7 +79433,7 @@ var REDACTION_RULES = [
   [/(com|org|io|dev|net)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_.-]+/g, "[BUNDLE_REDACTED]"]
 ];
 var KEYED_SECRET = /((?:token|secret|password|auth|api[_-]?key)\s*[:=]\s*)[^\s,;}]{6,}/gi;
-var SANITIZED_RECORDS = /* @__PURE__ */ new WeakSet();
+var REDACTION_RULES_VERSION = 1;
 function sanitizeString(value, redact2 = applyRedactionRules) {
   try {
     return redact2(value);
@@ -79474,17 +79474,25 @@ function applyRedactionRules(value) {
 var appIdentityCache = null;
 function readAppIdentity() {
   const root = process.env.RN_PROJECT_ROOT ?? process.env.CLAUDE_USER_CWD ?? process.cwd();
-  if (appIdentityCache?.root === root)
-    return appIdentityCache.identity;
+  if (appIdentityCache?.root !== root) {
+    appIdentityCache = { root, identity: loadAppIdentity(root) };
+  }
+  if (appIdentityCache.identity === null) {
+    throw new Error("app identity could not be read for redaction");
+  }
+  return appIdentityCache.identity;
+}
+function loadAppIdentity(root) {
   const manifest = join44(root, "app.json");
-  let identity2 = { name: null, slug: null };
-  if (existsSync35(manifest)) {
+  try {
+    if (!existsSync35(manifest))
+      return { name: null, slug: null };
     const parsed = JSON.parse(readFileSync33(manifest, "utf8"));
     const expo = parsed.expo ?? parsed;
-    identity2 = { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
+    return { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
+  } catch {
+    return null;
   }
-  appIdentityCache = { root, identity: identity2 };
-  return identity2;
 }
 function usableIdentity(value) {
   return typeof value === "string" && value.trim().length > 2 ? value : null;
@@ -79602,11 +79610,10 @@ var ExperienceRecorder = class {
       firstSeen: now,
       lastSeen: now,
       lastRecoveredAt: null,
-      unknownReasons
+      unknownReasons,
+      redactionVersion: REDACTION_RULES_VERSION
     };
-    const sanitized = sanitizeForEvidence(raw);
-    SANITIZED_RECORDS.add(sanitized);
-    return sanitized;
+    return sanitizeForEvidence(raw);
   }
   persistFailure(incoming) {
     const records = readExperienceStore(this.path);
@@ -79621,7 +79628,6 @@ var ExperienceRecorder = class {
       existing.symptom = incoming.symptom;
       existing.candidate = incoming.candidate;
       existing.environment = incoming.environment;
-      adoptLateFact(existing, incoming, "platform");
       adoptLateFact(existing, incoming, "device");
       adoptLateFact(existing, incoming, "runtime");
       existing.evidencePointers = boundedPointers(existing.evidencePointers, incoming.evidencePointers);
@@ -79649,7 +79655,10 @@ var ExperienceRecorder = class {
     mkdirSync20(this.directory, { recursive: true, mode: 448 });
     const temp = join44(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID8()}`);
     try {
-      const sanitized = records.map((record2) => SANITIZED_RECORDS.has(record2) ? record2 : sanitizeForEvidence(record2));
+      const sanitized = records.map((record2) => record2.redactionVersion === REDACTION_RULES_VERSION ? record2 : {
+        ...sanitizeForEvidence(record2),
+        redactionVersion: REDACTION_RULES_VERSION
+      });
       const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
       writeFileSync19(temp, contents.length > 0 ? `${contents}
 ` : "", {
@@ -79704,7 +79713,6 @@ function readExperienceStore(path) {
     } catch {
       continue;
     }
-    SANITIZED_RECORDS.add(parsed);
     records.push(parsed);
   }
   return records;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -79404,8 +79404,10 @@ var DEFAULT_RETENTION_DAYS = 14;
 var MAX_EVIDENCE_POINTERS = 3;
 var EXPERIENCE_DIRECTORY = join44(homedir11(), ".claude", "rn-agent", "experience");
 var EXPERIENCE_STORE_NAME = "patterns.jsonl";
+var MAX_SYMPTOM_LENGTH = 2048;
 var DAY_MS = 24 * 60 * 60 * 1e3;
 var REDACTION_FAILED = "[REDACTION_FAILED]";
+var SYMPTOM_TRUNCATED = "[TRUNCATED]";
 var REDACTION_RULES = [
   [/(sk|pk|api|key|token|secret|password|auth)[-_]?[A-Za-z0-9_-]{20,}/gi, "[REDACTED_SECRET]"],
   [/Bearer [A-Za-z0-9_./+=-]{20,}/g, "Bearer [REDACTED]"],
@@ -79431,6 +79433,7 @@ var REDACTION_RULES = [
   [/(com|org|io|dev|net)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_.-]+/g, "[BUNDLE_REDACTED]"]
 ];
 var KEYED_SECRET = /((?:token|secret|password|auth|api[_-]?key)\s*[:=]\s*)[^\s,;}]{6,}/gi;
+var SANITIZED_RECORDS = /* @__PURE__ */ new WeakSet();
 function sanitizeString(value, redact2 = applyRedactionRules) {
   try {
     return redact2(value);
@@ -79461,7 +79464,30 @@ function applyRedactionRules(value) {
     pattern.lastIndex = 0;
     result = result.replace(pattern, replacement);
   }
+  const identity2 = readAppIdentity();
+  if (identity2.name)
+    result = result.replaceAll(identity2.name, "[APP_NAME_REDACTED]");
+  if (identity2.slug)
+    result = result.replaceAll(identity2.slug, "[APP_SLUG_REDACTED]");
   return result;
+}
+var appIdentityCache = null;
+function readAppIdentity() {
+  const root = process.env.RN_PROJECT_ROOT ?? process.env.CLAUDE_USER_CWD ?? process.cwd();
+  if (appIdentityCache?.root === root)
+    return appIdentityCache.identity;
+  const manifest = join44(root, "app.json");
+  let identity2 = { name: null, slug: null };
+  if (existsSync35(manifest)) {
+    const parsed = JSON.parse(readFileSync33(manifest, "utf8"));
+    const expo = parsed.expo ?? parsed;
+    identity2 = { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
+  }
+  appIdentityCache = { root, identity: identity2 };
+  return identity2;
+}
+function usableIdentity(value) {
+  return typeof value === "string" && value.trim().length > 2 ? value : null;
 }
 var ExperienceRecorder = class {
   directory;
@@ -79526,7 +79552,7 @@ var ExperienceRecorder = class {
   buildFailureRecord(event) {
     const now = this.now().toISOString();
     const tool = sanitizeString(event.tool);
-    const symptom = sanitizeString(extractSymptom(event));
+    const symptom = sanitizeString(boundSymptom(extractSymptom(event)));
     const platform = sanitizeNullable(extractScalar(event, ["platform"]));
     const deviceName = extractScalar(event, ["deviceName", "deviceModel", "model"]);
     const hasDeviceId = extractScalar(event, ["deviceId", "udid"]) !== null;
@@ -79578,18 +79604,26 @@ var ExperienceRecorder = class {
       lastRecoveredAt: null,
       unknownReasons
     };
-    return sanitizeForEvidence(raw);
+    const sanitized = sanitizeForEvidence(raw);
+    SANITIZED_RECORDS.add(sanitized);
+    return sanitized;
   }
   persistFailure(incoming) {
-    const records = readExperienceStore(this.path, true);
+    const records = readExperienceStore(this.path);
     const existing = records.find((record2) => record2.signature === incoming.signature);
     if (existing) {
       existing.count += 1;
       existing.lastSeen = incoming.lastSeen;
-      existing.status = incoming.status;
+      if (incoming.status === "ERROR" && existing.status !== "ERROR") {
+        existing.status = "ERROR";
+        existing.trigger = incoming.trigger;
+      }
       existing.symptom = incoming.symptom;
       existing.candidate = incoming.candidate;
       existing.environment = incoming.environment;
+      adoptLateFact(existing, incoming, "platform");
+      adoptLateFact(existing, incoming, "device");
+      adoptLateFact(existing, incoming, "runtime");
       existing.evidencePointers = boundedPointers(existing.evidencePointers, incoming.evidencePointers);
     } else {
       records.push(incoming);
@@ -79597,7 +79631,7 @@ var ExperienceRecorder = class {
     this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
   }
   persistRecovery(signature, tool) {
-    const records = readExperienceStore(this.path, true);
+    const records = readExperienceStore(this.path);
     const existing = records.find((record2) => record2.signature === signature);
     if (!existing)
       return;
@@ -79615,7 +79649,7 @@ var ExperienceRecorder = class {
     mkdirSync20(this.directory, { recursive: true, mode: 448 });
     const temp = join44(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID8()}`);
     try {
-      const sanitized = records.map((record2) => sanitizeForEvidence(record2));
+      const sanitized = records.map((record2) => SANITIZED_RECORDS.has(record2) ? record2 : sanitizeForEvidence(record2));
       const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
       writeFileSync19(temp, contents.length > 0 ? `${contents}
 ` : "", {
@@ -79654,16 +79688,26 @@ function discoverPluginVersion(fromUrl = import.meta.url) {
   }
   return null;
 }
-function readExperienceStore(path, allowMissing = false) {
-  if (!existsSync35(path)) {
-    if (allowMissing)
-      return [];
+function readExperienceStore(path) {
+  if (!existsSync35(path))
     return [];
-  }
   const contents = readFileSync33(path, "utf8");
   if (!contents.trim())
     return [];
-  return contents.split("\n").filter((line) => line.trim().length > 0).map((line) => JSON.parse(line));
+  const records = [];
+  for (const line of contents.split("\n")) {
+    if (line.trim().length === 0)
+      continue;
+    let parsed;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    SANITIZED_RECORDS.add(parsed);
+    records.push(parsed);
+  }
+  return records;
 }
 function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, retentionMs = DEFAULT_RETENTION_DAYS * DAY_MS) {
   const cutoff = now.getTime() - retentionMs;
@@ -79683,54 +79727,49 @@ function experienceSignature(input) {
 function normalizeSymptomShape(symptom) {
   return symptom.toLowerCase().replace(/[0-9a-f]{8}-[0-9a-f-]{27,}/gi, "<id>").replace(/\b0x[0-9a-f]+\b/gi, "<hex>").replace(/\b(?=[a-z0-9_-]{12,}\b)(?=[a-z0-9_-]*\d)[a-z0-9_-]+\b/gi, "<id>").replace(/\b\d+\b/g, "#").replace(/\s+/g, " ").trim();
 }
+var CLASSIFICATION_RULES = [
+  ["FF_REDBOX", /redbox|logbox|error overlay|hasredbox/],
+  ["FF_DEBUGGER_PAUSED", /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
+  [
+    "FF_STALE_CDP",
+    /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/
+  ],
+  ["FF_FAST_REFRESH_STALE", /fast refresh|ui unchanged|old exports|old module path/],
+  ["FF_METRO_CACHE", /metro.*(?:stale|cache)|config change not reflected/],
+  [
+    "FF_BINARY_MISMATCH",
+    /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/
+  ],
+  ["FF_EXPO_DIALOG", /open-in-app|system confirmation dialog/],
+  ["FF_DEV_CLIENT_PICKER", /no hermes target|development servers|devclientlauncher|server picker/],
+  ["FF_KEYBOARD_OVERLAY", /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
+  ["FF_MAESTRO_GRPC_ANDROID", /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
+  [
+    "FF_ANDROID_TEXT_INPUT_CRASH",
+    /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/
+  ],
+  ["FF_AUTH_GATE", /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/],
+  [
+    "FF_PERMISSION_ALREADY_GRANTED",
+    /permission already granted|prompt (?:was )?not shown|flow completes instantly/
+  ],
+  ["EG_EXPO_GO_SDK_MISMATCH", /incompatible with this version of expo go|expo go sdk.*mismatch/],
+  ["EG_NATIVEWIND_JSX_SOURCE", /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
+  ["EG_EXPO_GO_NATIVE_MODULES", /expo go.*custom native module/],
+  ["EG_DEV_CLIENT_CLEARSTATE", /clearstate.*(?:dev client|metro connection|launcher)/],
+  ["EG_MSW_HERMES", /msw.*(?:hermes|react native|initialize)/],
+  ["EG_EXPO_ROUTER_DEEP_LINK", /expo router.*deep link|deep link.*confirmation dialog/],
+  ["EG_DEV_MENU_INTERFERENCE", /dev menu.*(?:overlay|recording|blocking)/],
+  ["EG_NEW_ARCH_CDP_TARGET", /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
+  ["PQ_IOS_RECORDVIDEO_CODEC", /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
+  ["PQ_ANDROID_SCREENRECORD_LIMIT", /screenrecord.*180|screenrecord.*3 minute/],
+  ["PQ_ANDROID_BOOT_DELAY", /sys\.boot_completed|emulator.*grpc.*ready/],
+  ["PQ_ANDROID_PLAY_PROTECT", /play protect.*(?:block|apk|install)/]
+];
+var EXPERIENCE_FAMILY_IDS = CLASSIFICATION_RULES.map(([id]) => id);
 function classifyExperience(symptom, tool, platform) {
   const haystack = `${tool} ${platform ?? ""} ${symptom}`.toLowerCase();
-  const rules = [
-    ["FF_REDBOX", /redbox|logbox|error overlay|hasredbox/],
-    ["FF_DEBUGGER_PAUSED", /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
-    [
-      "FF_STALE_CDP",
-      /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/
-    ],
-    ["FF_FAST_REFRESH_STALE", /fast refresh|ui unchanged|old exports|old module path/],
-    ["FF_METRO_CACHE", /metro.*(?:stale|cache)|config change not reflected/],
-    [
-      "FF_BINARY_MISMATCH",
-      /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/
-    ],
-    ["FF_EXPO_DIALOG", /open-in-app|system confirmation dialog/],
-    [
-      "FF_DEV_CLIENT_PICKER",
-      /no hermes target|development servers|devclientlauncher|server picker/
-    ],
-    ["FF_KEYBOARD_OVERLAY", /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
-    ["FF_MAESTRO_GRPC_ANDROID", /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
-    [
-      "FF_ANDROID_TEXT_INPUT_CRASH",
-      /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/
-    ],
-    [
-      "FF_AUTH_GATE",
-      /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/
-    ],
-    [
-      "FF_PERMISSION_ALREADY_GRANTED",
-      /permission already granted|prompt (?:was )?not shown|flow completes instantly/
-    ],
-    ["EG_EXPO_GO_SDK_MISMATCH", /incompatible with this version of expo go|expo go sdk.*mismatch/],
-    ["EG_NATIVEWIND_JSX_SOURCE", /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
-    ["EG_EXPO_GO_NATIVE_MODULES", /expo go.*custom native module/],
-    ["EG_DEV_CLIENT_CLEARSTATE", /clearstate.*(?:dev client|metro connection|launcher)/],
-    ["EG_MSW_HERMES", /msw.*(?:hermes|react native|initialize)/],
-    ["EG_EXPO_ROUTER_DEEP_LINK", /expo router.*deep link|deep link.*confirmation dialog/],
-    ["EG_DEV_MENU_INTERFERENCE", /dev menu.*(?:overlay|recording|blocking)/],
-    ["EG_NEW_ARCH_CDP_TARGET", /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
-    ["PQ_IOS_RECORDVIDEO_CODEC", /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
-    ["PQ_ANDROID_SCREENRECORD_LIMIT", /screenrecord.*180|screenrecord.*3 minute/],
-    ["PQ_ANDROID_BOOT_DELAY", /sys\.boot_completed|emulator.*grpc.*ready/],
-    ["PQ_ANDROID_PLAY_PROTECT", /play protect.*(?:block|apk|install)/]
-  ];
-  return rules.find(([, pattern]) => pattern.test(haystack))?.[0] ?? UNKNOWN_CLASSIFICATION;
+  return CLASSIFICATION_RULES.find(([, pattern]) => pattern.test(haystack))?.[0] ?? UNKNOWN_CLASSIFICATION;
 }
 function extractSymptom(event) {
   if (typeof event.error === "string" && event.error.length > 0)
@@ -79747,6 +79786,12 @@ function extractSymptom(event) {
     }
   }
   return `${event.tool} reported ${event.status} without an error message`;
+}
+function boundSymptom(symptom) {
+  if (symptom.length <= MAX_SYMPTOM_LENGTH)
+    return symptom;
+  const head = symptom.slice(0, MAX_SYMPTOM_LENGTH).replace(/\S+$/, "");
+  return `${head}${SYMPTOM_TRUNCATED}`;
 }
 function extractScalar(event, keys) {
   const sources = [event.params, event.result];
@@ -79777,6 +79822,12 @@ function findScalar(value, keys, depth) {
 }
 function sanitizeNullable(value) {
   return value === null ? null : sanitizeString(value);
+}
+function adoptLateFact(existing, incoming, field2) {
+  if (existing[field2] !== null || incoming[field2] === null)
+    return;
+  existing[field2] = incoming[field2];
+  delete existing.unknownReasons[field2];
 }
 function boundedPointers(existing, incoming) {
   return [.../* @__PURE__ */ new Set([...existing, ...incoming])].slice(-MAX_EVIDENCE_POINTERS);

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -9244,7 +9244,7 @@ var require_websocket = __commonJS({
     var http = __require("http");
     var net = __require("net");
     var tls = __require("tls");
-    var { randomBytes: randomBytes8, createHash: createHash21 } = __require("crypto");
+    var { randomBytes: randomBytes8, createHash: createHash22 } = __require("crypto");
     var { Duplex, Readable } = __require("stream");
     var { URL: URL2 } = __require("url");
     var PerMessageDeflate2 = require_permessage_deflate();
@@ -9912,7 +9912,7 @@ var require_websocket = __commonJS({
           abortHandshake(websocket, socket, "Invalid Upgrade header");
           return;
         }
-        const digest3 = createHash21("sha1").update(key + GUID).digest("base64");
+        const digest3 = createHash22("sha1").update(key + GUID).digest("base64");
         if (res.headers["sec-websocket-accept"] !== digest3) {
           abortHandshake(websocket, socket, "Invalid Sec-WebSocket-Accept header");
           return;
@@ -10281,7 +10281,7 @@ var require_websocket_server = __commonJS({
     var EventEmitter = __require("events");
     var http = __require("http");
     var { Duplex } = __require("stream");
-    var { createHash: createHash21 } = __require("crypto");
+    var { createHash: createHash22 } = __require("crypto");
     var extension2 = require_extension();
     var PerMessageDeflate2 = require_permessage_deflate();
     var subprotocol2 = require_subprotocol();
@@ -10588,7 +10588,7 @@ var require_websocket_server = __commonJS({
           );
         }
         if (this._state > RUNNING) return abortHandshake(socket, 503);
-        const digest3 = createHash21("sha1").update(key + GUID).digest("base64");
+        const digest3 = createHash22("sha1").update(key + GUID).digest("base64");
         const headers = [
           "HTTP/1.1 101 Switching Protocols",
           "Upgrade: websocket",
@@ -26328,13 +26328,13 @@ function consumePendingAndroidUpgradeNote() {
   pendingUpgradeNote = void 0;
   return note;
 }
-async function reapMismatchedAndroidRunner(state, release, verify, signal) {
+async function reapMismatchedAndroidRunner(state, release2, verify, signal) {
   signal?.throwIfAborted();
   const deviceId = state?.deviceId;
   if (!deviceId) {
     throw new Error("RUNNER_CLEANUP_UNCONFIRMED: stale Android runner has no recorded device identity");
   }
-  const releaseSlot = release ?? (async (opts) => {
+  const releaseSlot = release2 ?? (async (opts) => {
     const { releaseAndroidInteractionSlot: releaseAndroidInteractionSlot2 } = await Promise.resolve().then(() => (init_release_android_slot(), release_android_slot_exports));
     return releaseAndroidInteractionSlot2({ ...opts, signal });
   });
@@ -26348,7 +26348,7 @@ async function reapMismatchedAndroidRunner(state, release, verify, signal) {
   if (!receipt2.stoppedOwnRunner || missingPackages.length > 0) {
     throw new Error(`RUNNER_CLEANUP_UNCONFIRMED: stale Android runner cleanup failed for ${deviceId}`);
   }
-  const verifyReleased = verify ?? (release ? async () => {
+  const verifyReleased = verify ?? (release2 ? async () => {
   } : async (expected) => {
     const forwards = String((await execFileAsync2("adb", ["forward", "--list"], {
       timeout: ADB_CLEANUP_TIMEOUT_MS,
@@ -26536,7 +26536,7 @@ async function runBoundedAndroidRunnerRebuild(error2, rebuild, cleanup, dependen
   const heartbeat = dependencies.heartbeat ?? heartbeatAndroidRunnerRebuildLock;
   const complete = dependencies.complete ?? completeAndroidRunnerRebuildLock;
   const beginCleanup = dependencies.beginCleanup ?? beginAndroidRunnerRebuildCleanup;
-  const release = dependencies.release ?? releaseAndroidRunnerRebuildLock;
+  const release2 = dependencies.release ?? releaseAndroidRunnerRebuildLock;
   const markCleanupUnverified = dependencies.markCleanupUnverified ?? markAndroidRunnerRebuildCleanupUnverified;
   const controller = new AbortController();
   let cleanupController;
@@ -26632,7 +26632,7 @@ async function runBoundedAndroidRunnerRebuild(error2, rebuild, cleanup, dependen
     }
     clearTimeout(cleanupTimer);
     cleanupController = void 0;
-    const terminalPersisted = await persistTransition(cleanupVerified ? release : markCleanupUnverified);
+    const terminalPersisted = await persistTransition(cleanupVerified ? release2 : markCleanupUnverified);
     clearInterval(heartbeatTimer2);
     if (!terminalPersisted) {
       throw leaseAuthorityLost ? controller.signal.reason : androidRebuildRefusal(error2, "runner artifact failure state was not durable");
@@ -27847,7 +27847,7 @@ async function rebuildStaleRunnerArtifact(first, deviceId, bundleId, deps) {
       message: "another session is rebuilding the shared runner artifact \u2014 retry this open in a few minutes."
     };
   }
-  const release = deps.releaseBuildLock ?? releaseRunnerRebuildLock;
+  const release2 = deps.releaseBuildLock ?? releaseRunnerRebuildLock;
   try {
     const reap = deps.reap ?? reapStaleFastRunner;
     await reap();
@@ -27861,7 +27861,7 @@ async function rebuildStaleRunnerArtifact(first, deviceId, bundleId, deps) {
       ...deps.attachOnly === true ? { attachOnly: true } : {}
     });
   } finally {
-    release();
+    release2();
   }
   const probe = deps.probe ?? probeFastRunnerLivenessDetailed;
   const rebuilt = await probe();
@@ -31187,8 +31187,8 @@ async function runFlowParked(run, opts = {}) {
   const stale = opts.markCdpStale ?? markCdpStale;
   try {
     if (opts.platform === "android") {
-      const release = opts.releaseAndroidSlot ?? releaseAndroidInteractionSlot;
-      await release({ deviceId: opts.deviceId });
+      const release2 = opts.releaseAndroidSlot ?? releaseAndroidInteractionSlot;
+      await release2({ deviceId: opts.deviceId });
     } else {
       await (opts.stopFastRunner ?? stopFastRunner)(opts.deviceId);
     }
@@ -35391,12 +35391,12 @@ ensureJavaEnv();
 ensureCwd();
 
 // packages/rn-dev-agent-core/dist/index.js
-import { createHash as createHash20, createHmac as createHmac5, randomUUID as randomUUID8 } from "node:crypto";
-import { readFileSync as readFileSync40, rmSync as rmSync11 } from "node:fs";
+import { createHash as createHash21, createHmac as createHmac5, randomUUID as randomUUID9 } from "node:crypto";
+import { readFileSync as readFileSync41, rmSync as rmSync11 } from "node:fs";
 import { execFile as execFile26 } from "node:child_process";
 import { promisify as promisify28 } from "node:util";
-import { fileURLToPath as fileURLToPath6 } from "node:url";
-import { dirname as dirname22, join as join54 } from "node:path";
+import { fileURLToPath as fileURLToPath7 } from "node:url";
+import { dirname as dirname23, join as join55 } from "node:path";
 
 // node_modules/zod/v3/external.js
 var external_exports = {};
@@ -79392,8 +79392,398 @@ function instrumentTool(toolName, handler) {
   };
 }
 
+// packages/rn-dev-agent-core/dist/experience/evidence.js
+import { createHash as createHash17, randomUUID as randomUUID8 } from "node:crypto";
+import { chmodSync as chmodSync5, existsSync as existsSync35, mkdirSync as mkdirSync20, readFileSync as readFileSync33, renameSync as renameSync8, unlinkSync as unlinkSync12, writeFileSync as writeFileSync19 } from "node:fs";
+import { homedir as homedir11, platform as hostPlatform, release } from "node:os";
+import { dirname as dirname19, join as join44 } from "node:path";
+import { fileURLToPath as fileURLToPath5 } from "node:url";
+var UNKNOWN_CLASSIFICATION = "UNKNOWN";
+var DEFAULT_MAX_RECORDS = 500;
+var DEFAULT_RETENTION_DAYS = 14;
+var MAX_EVIDENCE_POINTERS = 3;
+var EXPERIENCE_DIRECTORY = join44(homedir11(), ".claude", "rn-agent", "experience");
+var EXPERIENCE_STORE_NAME = "patterns.jsonl";
+var DAY_MS = 24 * 60 * 60 * 1e3;
+var REDACTION_FAILED = "[REDACTION_FAILED]";
+var REDACTION_RULES = [
+  [/(sk|pk|api|key|token|secret|password|auth)[-_]?[A-Za-z0-9_-]{20,}/gi, "[REDACTED_SECRET]"],
+  [/Bearer [A-Za-z0-9_./+=-]{20,}/g, "Bearer [REDACTED]"],
+  [/ghp_[A-Za-z0-9_]{36}/g, "[REDACTED_GH_TOKEN]"],
+  [/eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g, "[REDACTED_JWT]"],
+  [/AKIA[0-9A-Z]{16}/g, "[REDACTED_AWS]"],
+  [/xox[baprs]-[A-Za-z0-9-]+/g, "[REDACTED_SLACK]"],
+  [/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, "[EMAIL_REDACTED]"],
+  [
+    /(^|[^0-9])(192|10|172|169)\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}([^0-9]|$)/g,
+    "$1[IP_REDACTED]$3"
+  ],
+  [/(^|[^0-9])[0-9]{1,3}(?:\.[0-9]{1,3}){3}([^0-9]|$)/g, "$1[IP_REDACTED]$2"],
+  [
+    /(?:https?:\/\/)?(?:localhost|127\.0\.0\.1)(?::[0-9]{2,5})?(?:\/[^\s]*)?/gi,
+    "[LOOPBACK_ENDPOINT_REDACTED]"
+  ],
+  [/"(metroPort|observePort|port)"\s*:\s*[0-9]+/g, '"$1":"[PORT_REDACTED]"'],
+  [/\bport\s*[:=]?\s*[0-9]{2,5}\b/gi, "[PORT_REDACTED]"],
+  [/:([0-9]{2,5})(?=\/|\s|$)/g, ":[PORT_REDACTED]"],
+  [/~\/[A-Za-z0-9_./-]+/g, "[PATH_REDACTED]"],
+  [/\/(Users|home|opt|var|tmp|etc|private|Volumes)\/[A-Za-z0-9_./-]+/g, "[PATH_REDACTED]"],
+  [/(com|org|io|dev|net)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_.-]+/g, "[BUNDLE_REDACTED]"]
+];
+var KEYED_SECRET = /((?:token|secret|password|auth|api[_-]?key)\s*[:=]\s*)[^\s,;}]{6,}/gi;
+function sanitizeString(value, redact2 = applyRedactionRules) {
+  try {
+    return redact2(value);
+  } catch {
+    return REDACTION_FAILED;
+  }
+}
+function sanitizeForEvidence(value, redact2) {
+  if (value === null || value === void 0 || typeof value === "boolean" || typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "string")
+    return sanitizeString(value, redact2);
+  if (Array.isArray(value))
+    return value.map((item) => sanitizeForEvidence(item, redact2));
+  if (typeof value === "object") {
+    const sanitized = {};
+    for (const [key, nested] of Object.entries(value)) {
+      sanitized[key] = sanitizeForEvidence(nested, redact2);
+    }
+    return sanitized;
+  }
+  return REDACTION_FAILED;
+}
+function applyRedactionRules(value) {
+  let result = value.replaceAll(homedir11(), "~").replace(KEYED_SECRET, "$1[REDACTED_SECRET]");
+  for (const [pattern, replacement] of REDACTION_RULES) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}
+var ExperienceRecorder = class {
+  directory;
+  path;
+  candidate;
+  environment;
+  maxRecords;
+  retentionMs;
+  now;
+  schedule;
+  previousFailure = null;
+  constructor(options) {
+    this.directory = options.directory ?? process.env.RN_DEV_AGENT_EXPERIENCE_DIR ?? EXPERIENCE_DIRECTORY;
+    this.path = join44(this.directory, EXPERIENCE_STORE_NAME);
+    this.candidate = {
+      pluginVersion: options.pluginVersion ?? null,
+      coreVersion: options.coreVersion
+    };
+    this.environment = { os: `${hostPlatform()} ${release()}`, node: process.version };
+    this.maxRecords = options.maxRecords ?? DEFAULT_MAX_RECORDS;
+    this.retentionMs = (options.retentionDays ?? DEFAULT_RETENTION_DAYS) * DAY_MS;
+    this.now = options.now ?? (() => /* @__PURE__ */ new Date());
+    this.schedule = options.schedule ?? ((work) => setImmediate(work));
+  }
+  /** Queue only: persistence never executes in the observed tool's call stack. */
+  observe(event) {
+    try {
+      this.schedule(() => this.recordNonLoadBearing(event));
+    } catch {
+    }
+  }
+  /** Test and CLI support; returns a sanitized, deduplicated view. */
+  read() {
+    return readExperienceStore(this.path);
+  }
+  recordNonLoadBearing(event) {
+    try {
+      this.record(event);
+    } catch {
+    }
+  }
+  record(event) {
+    if (!event || typeof event.tool !== "string") {
+      this.previousFailure = null;
+      return;
+    }
+    if (event.status === "PASS") {
+      const recovery = this.previousFailure;
+      this.previousFailure = null;
+      if (recovery?.tool === event.tool)
+        this.persistRecovery(recovery.signature, event.tool);
+      return;
+    }
+    if (event.status !== "FAIL" && event.status !== "ERROR") {
+      this.previousFailure = null;
+      return;
+    }
+    const record2 = this.buildFailureRecord(event);
+    this.persistFailure(record2);
+    this.previousFailure = event.status === "FAIL" ? { tool: event.tool, signature: record2.signature } : null;
+  }
+  buildFailureRecord(event) {
+    const now = this.now().toISOString();
+    const tool = sanitizeString(event.tool);
+    const symptom = sanitizeString(extractSymptom(event));
+    const platform = sanitizeNullable(extractScalar(event, ["platform"]));
+    const deviceName = extractScalar(event, ["deviceName", "deviceModel", "model"]);
+    const hasDeviceId = extractScalar(event, ["deviceId", "udid"]) !== null;
+    const device = sanitizeNullable(deviceName ?? (hasDeviceId ? "identified-device" : null));
+    const runtime = sanitizeNullable(extractScalar(event, ["runtime", "engine"]));
+    const classification = classifyExperience(symptom, tool, platform);
+    const normalizedSymptomShape = normalizeSymptomShape(symptom);
+    const signature = experienceSignature({
+      classification,
+      tool,
+      normalizedSymptomShape,
+      platform
+    });
+    const unknownReasons = {};
+    if (this.candidate.pluginVersion === null) {
+      unknownReasons["candidate.pluginVersion"] = "plugin manifest was not available to the core runtime";
+    }
+    if (platform === null)
+      unknownReasons.platform = "tool event did not expose a platform";
+    if (device === null)
+      unknownReasons.device = "tool event did not expose a device name or identifier";
+    if (runtime === null)
+      unknownReasons.runtime = "tool event did not expose a runtime";
+    unknownReasons.maskingCondition = "not derivable from a single tool event";
+    unknownReasons.recovery = "no immediate successful retry has been observed";
+    unknownReasons.cleanup = "tool events do not report cleanup actions";
+    const raw = {
+      signature,
+      candidate: this.candidate,
+      environment: this.environment,
+      platform,
+      device,
+      runtime,
+      phase: "tool",
+      trigger: `${event.status} reported by ${tool}`,
+      maskingCondition: null,
+      symptom,
+      recovery: null,
+      cleanup: null,
+      classification,
+      evidencePointers: [`event:${randomUUID8()}`],
+      tool,
+      status: event.status === "ERROR" ? "ERROR" : "FAIL",
+      normalizedSymptomShape,
+      count: 1,
+      recoveryCount: 0,
+      firstSeen: now,
+      lastSeen: now,
+      lastRecoveredAt: null,
+      unknownReasons
+    };
+    return sanitizeForEvidence(raw);
+  }
+  persistFailure(incoming) {
+    const records = readExperienceStore(this.path, true);
+    const existing = records.find((record2) => record2.signature === incoming.signature);
+    if (existing) {
+      existing.count += 1;
+      existing.lastSeen = incoming.lastSeen;
+      existing.status = incoming.status;
+      existing.symptom = incoming.symptom;
+      existing.candidate = incoming.candidate;
+      existing.environment = incoming.environment;
+      existing.evidencePointers = boundedPointers(existing.evidencePointers, incoming.evidencePointers);
+    } else {
+      records.push(incoming);
+    }
+    this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
+  }
+  persistRecovery(signature, tool) {
+    const records = readExperienceStore(this.path, true);
+    const existing = records.find((record2) => record2.signature === signature);
+    if (!existing)
+      return;
+    const now = this.now().toISOString();
+    existing.recovery = sanitizeString(`PASS immediately followed FAIL for ${tool}`);
+    existing.recoveryCount += 1;
+    existing.lastRecoveredAt = now;
+    delete existing.unknownReasons.recovery;
+    existing.evidencePointers = boundedPointers(existing.evidencePointers, [
+      `event:${randomUUID8()}`
+    ]);
+    this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
+  }
+  write(records) {
+    mkdirSync20(this.directory, { recursive: true, mode: 448 });
+    const temp = join44(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID8()}`);
+    try {
+      const sanitized = records.map((record2) => sanitizeForEvidence(record2));
+      const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
+      writeFileSync19(temp, contents.length > 0 ? `${contents}
+` : "", {
+        encoding: "utf8",
+        flag: "wx",
+        mode: 384
+      });
+      renameSync8(temp, this.path);
+      chmodSync5(this.path, 384);
+    } catch (error2) {
+      try {
+        unlinkSync12(temp);
+      } catch {
+      }
+      throw error2;
+    }
+  }
+};
+function discoverPluginVersion(fromUrl = import.meta.url) {
+  if (process.env.RN_DEV_AGENT_PLUGIN_VERSION)
+    return process.env.RN_DEV_AGENT_PLUGIN_VERSION;
+  const start = dirname19(fileURLToPath5(fromUrl));
+  const candidates = [
+    join44(start, "..", "..", ".claude-plugin", "plugin.json"),
+    join44(start, "..", "..", ".codex-plugin", "plugin.json"),
+    join44(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
+    join44(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
+  ];
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(readFileSync33(candidate, "utf8"));
+      if (typeof parsed.version === "string")
+        return sanitizeString(parsed.version);
+    } catch {
+    }
+  }
+  return null;
+}
+function readExperienceStore(path, allowMissing = false) {
+  if (!existsSync35(path)) {
+    if (allowMissing)
+      return [];
+    return [];
+  }
+  const contents = readFileSync33(path, "utf8");
+  if (!contents.trim())
+    return [];
+  return contents.split("\n").filter((line) => line.trim().length > 0).map((line) => JSON.parse(line));
+}
+function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, retentionMs = DEFAULT_RETENTION_DAYS * DAY_MS) {
+  const cutoff = now.getTime() - retentionMs;
+  return records.filter((record2) => {
+    const lastSeen = Date.parse(record2.lastSeen);
+    return Number.isFinite(lastSeen) && lastSeen >= cutoff;
+  }).sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen) || a.signature.localeCompare(b.signature)).slice(0, Math.max(0, maxRecords)).sort((a, b) => a.signature.localeCompare(b.signature));
+}
+function experienceSignature(input) {
+  return createHash17("sha256").update(JSON.stringify([
+    input.classification,
+    input.tool,
+    input.normalizedSymptomShape,
+    input.platform ?? "unknown"
+  ])).digest("hex");
+}
+function normalizeSymptomShape(symptom) {
+  return symptom.toLowerCase().replace(/[0-9a-f]{8}-[0-9a-f-]{27,}/gi, "<id>").replace(/\b0x[0-9a-f]+\b/gi, "<hex>").replace(/\b(?=[a-z0-9_-]{12,}\b)(?=[a-z0-9_-]*\d)[a-z0-9_-]+\b/gi, "<id>").replace(/\b\d+\b/g, "#").replace(/\s+/g, " ").trim();
+}
+function classifyExperience(symptom, tool, platform) {
+  const haystack = `${tool} ${platform ?? ""} ${symptom}`.toLowerCase();
+  const rules = [
+    ["FF_REDBOX", /redbox|logbox|error overlay|hasredbox/],
+    ["FF_DEBUGGER_PAUSED", /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
+    [
+      "FF_STALE_CDP",
+      /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/
+    ],
+    ["FF_FAST_REFRESH_STALE", /fast refresh|ui unchanged|old exports|old module path/],
+    ["FF_METRO_CACHE", /metro.*(?:stale|cache)|config change not reflected/],
+    [
+      "FF_BINARY_MISMATCH",
+      /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/
+    ],
+    ["FF_EXPO_DIALOG", /open-in-app|system confirmation dialog/],
+    [
+      "FF_DEV_CLIENT_PICKER",
+      /no hermes target|development servers|devclientlauncher|server picker/
+    ],
+    ["FF_KEYBOARD_OVERLAY", /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
+    ["FF_MAESTRO_GRPC_ANDROID", /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
+    [
+      "FF_ANDROID_TEXT_INPUT_CRASH",
+      /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/
+    ],
+    [
+      "FF_AUTH_GATE",
+      /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/
+    ],
+    [
+      "FF_PERMISSION_ALREADY_GRANTED",
+      /permission already granted|prompt (?:was )?not shown|flow completes instantly/
+    ],
+    ["EG_EXPO_GO_SDK_MISMATCH", /incompatible with this version of expo go|expo go sdk.*mismatch/],
+    ["EG_NATIVEWIND_JSX_SOURCE", /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
+    ["EG_EXPO_GO_NATIVE_MODULES", /expo go.*custom native module/],
+    ["EG_DEV_CLIENT_CLEARSTATE", /clearstate.*(?:dev client|metro connection|launcher)/],
+    ["EG_MSW_HERMES", /msw.*(?:hermes|react native|initialize)/],
+    ["EG_EXPO_ROUTER_DEEP_LINK", /expo router.*deep link|deep link.*confirmation dialog/],
+    ["EG_DEV_MENU_INTERFERENCE", /dev menu.*(?:overlay|recording|blocking)/],
+    ["EG_NEW_ARCH_CDP_TARGET", /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
+    ["PQ_IOS_RECORDVIDEO_CODEC", /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
+    ["PQ_ANDROID_SCREENRECORD_LIMIT", /screenrecord.*180|screenrecord.*3 minute/],
+    ["PQ_ANDROID_BOOT_DELAY", /sys\.boot_completed|emulator.*grpc.*ready/],
+    ["PQ_ANDROID_PLAY_PROTECT", /play protect.*(?:block|apk|install)/]
+  ];
+  return rules.find(([, pattern]) => pattern.test(haystack))?.[0] ?? UNKNOWN_CLASSIFICATION;
+}
+function extractSymptom(event) {
+  if (typeof event.error === "string" && event.error.length > 0)
+    return event.error;
+  if (event.result && typeof event.result === "object") {
+    const envelope = event.result;
+    if (typeof envelope.error === "string")
+      return envelope.error;
+    const content = envelope.content;
+    if (Array.isArray(content)) {
+      const first = content[0];
+      if (typeof first?.text === "string")
+        return first.text;
+    }
+  }
+  return `${event.tool} reported ${event.status} without an error message`;
+}
+function extractScalar(event, keys) {
+  const sources = [event.params, event.result];
+  for (const source of sources) {
+    const value = findScalar(source, keys, 0);
+    if (value !== null)
+      return value;
+  }
+  return null;
+}
+function findScalar(value, keys, depth) {
+  if (!value || typeof value !== "object" || depth > 3)
+    return null;
+  const object3 = value;
+  for (const key of keys) {
+    const candidate = object3[key];
+    if (typeof candidate === "string" && candidate.length > 0)
+      return candidate;
+  }
+  for (const nested of Object.values(object3)) {
+    if (nested && typeof nested === "object") {
+      const found = findScalar(nested, keys, depth + 1);
+      if (found !== null)
+        return found;
+    }
+  }
+  return null;
+}
+function sanitizeNullable(value) {
+  return value === null ? null : sanitizeString(value);
+}
+function boundedPointers(existing, incoming) {
+  return [.../* @__PURE__ */ new Set([...existing, ...incoming])].slice(-MAX_EVIDENCE_POINTERS);
+}
+
 // packages/rn-dev-agent-core/dist/observability/live-device.js
-import { join as join44 } from "node:path";
+import { join as join45 } from "node:path";
 import { tmpdir as tmpdir13 } from "node:os";
 function isStateMutating(tool, args) {
   if (FLOW_MUTATION_TOOLS.has(tool))
@@ -79545,7 +79935,7 @@ function buildLiveDeps(input) {
     // iterable" when invoked as deps.pushLive(...). The live device gate caught
     // this — the unit fakes used standalone arrows and missed it.
     pushLive: (frame) => input.recorder.pushLive(frame),
-    tmpPath: () => join44(tmpdir13(), `rn-observe-live-${process.pid}.jpg`),
+    tmpPath: () => join45(tmpdir13(), `rn-observe-live-${process.pid}.jpg`),
     isMirrorActive: input.isMirrorActive
   };
 }
@@ -79559,9 +79949,9 @@ init_utils();
 
 // packages/rn-dev-agent-core/dist/observability/server.js
 import { createServer as createServer3 } from "node:http";
-import { readFileSync as readFileSync33 } from "node:fs";
-import { fileURLToPath as fileURLToPath5 } from "node:url";
-import { dirname as dirname19, join as join45 } from "node:path";
+import { readFileSync as readFileSync34 } from "node:fs";
+import { fileURLToPath as fileURLToPath6 } from "node:url";
+import { dirname as dirname20, join as join46 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/observability/e2e-csrf.js
 import { randomBytes as randomBytes6, timingSafeEqual as timingSafeEqual6 } from "node:crypto";
@@ -79594,7 +79984,7 @@ function isPostAllowed(req, token2) {
 // packages/rn-dev-agent-core/dist/observability/server.js
 init_logger();
 var HOST = "127.0.0.1";
-var __dir = dirname19(fileURLToPath5(import.meta.url));
+var __dir = dirname20(fileURLToPath6(import.meta.url));
 var ObservabilityServer = class {
   recorder;
   e2e;
@@ -79826,7 +80216,7 @@ var ObservabilityServer = class {
   }
   index(res) {
     try {
-      let html = readFileSync33(join45(__dir, "web-dist", "index.html"), "utf8");
+      let html = readFileSync34(join46(__dir, "web-dist", "index.html"), "utf8");
       if (this.e2e) {
         const tokenJs = JSON.stringify(this.e2e.token).replace(/</g, "\\u003c");
         html = html.replace("</head>", `<script>window.__E2E_CSRF__=${tokenJs}</script></head>`);
@@ -80010,10 +80400,10 @@ init_project_config();
 // packages/rn-dev-agent-core/dist/observability/observe-state.js
 init_secure_state_file();
 init_storage();
-import { join as join46 } from "node:path";
+import { join as join47 } from "node:path";
 function observeStatePath(projectRoot) {
   const safe = projectRoot.replace(/[^A-Za-z0-9._-]/g, "_");
-  return join46(getStateDir(), "observe", `${safe}.json`);
+  return join47(getStateDir(), "observe", `${safe}.json`);
 }
 function writeObserveState(url, port, projectRoot = findProjectRoot(), now = () => /* @__PURE__ */ new Date()) {
   try {
@@ -80239,7 +80629,7 @@ init_project_config();
 import { spawn as spawn9, execFile as execFile25 } from "node:child_process";
 import { readFile as readFile2, unlink } from "node:fs/promises";
 import { tmpdir as tmpdir14 } from "node:os";
-import { join as join47 } from "node:path";
+import { join as join48 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/observability/mirror/jpeg-stream.js
 var MAX_FRAME_BYTES = 8e6;
@@ -80402,7 +80792,7 @@ var IosSimctlLoopSource = class {
     this.gate = new RestartGate(3, 1e4, opts.now ?? Date.now);
     this.idleDelayMs = opts.idleDelayMs ?? 25;
     this.failurePauseMs = opts.failurePauseMs ?? 500;
-    this.tmpPath = opts.tmpPath ?? (() => join47(tmpdir14(), "rn-mirror-simctl-" + process.pid + ".jpg"));
+    this.tmpPath = opts.tmpPath ?? (() => join48(tmpdir14(), "rn-mirror-simctl-" + process.pid + ".jpg"));
     this.degradedHint = opts.degradedHint ?? SIMCTL_HINT;
   }
   start(sink) {
@@ -80842,20 +81232,20 @@ function buildMirrorTargetResolver(deps) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/lock-e2e-test.js
-import { readFileSync as readFileSync36 } from "node:fs";
+import { readFileSync as readFileSync37 } from "node:fs";
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
-import { dirname as dirname20, join as join48 } from "node:path";
-import { mkdirSync as mkdirSync20, writeFileSync as writeFileSync19, renameSync as renameSync8, readFileSync as readFileSync34, readdirSync as readdirSync12, existsSync as existsSync35 } from "node:fs";
-import { createHash as createHash17 } from "node:crypto";
+import { dirname as dirname21, join as join49 } from "node:path";
+import { mkdirSync as mkdirSync21, writeFileSync as writeFileSync20, renameSync as renameSync9, readFileSync as readFileSync35, readdirSync as readdirSync12, existsSync as existsSync36 } from "node:fs";
+import { createHash as createHash18 } from "node:crypto";
 var FLOW_SENTINEL = "# e2e-locked-flow-below";
 function e2eDirFor(projectRoot) {
-  return join48(projectRoot, ".rn-agent", "e2e");
+  return join49(projectRoot, ".rn-agent", "e2e");
 }
 function e2ePathFor(projectRoot, id) {
   assertValidActionId(id, "e2ePathFor");
   const dir = e2eDirFor(projectRoot);
-  const file = join48(dir, `${id}.yaml`);
+  const file = join49(dir, `${id}.yaml`);
   assertWithinDir(file, dir);
   return file;
 }
@@ -80879,11 +81269,11 @@ function serializeLockedTest(meta) {
 ${meta.flow}`;
 }
 function hashBody(s) {
-  return createHash17("sha256").update(s).digest("hex");
+  return createHash18("sha256").update(s).digest("hex");
 }
 function freezeLockedTest(projectRoot, source, ctx) {
   const filePath = e2ePathFor(projectRoot, source.id);
-  mkdirSync20(dirname20(filePath), { recursive: true });
+  mkdirSync21(dirname21(filePath), { recursive: true });
   const meta = {
     id: source.id,
     intent: source.intent,
@@ -80897,19 +81287,19 @@ function freezeLockedTest(projectRoot, source, ctx) {
     flow: source.flow
   };
   const tmp = `${filePath}.tmp`;
-  writeFileSync19(tmp, serializeLockedTest(meta), "utf8");
-  renameSync8(tmp, filePath);
+  writeFileSync20(tmp, serializeLockedTest(meta), "utf8");
+  renameSync9(tmp, filePath);
   return { ...meta, filePath };
 }
 function loadLockedTest(projectRoot, id) {
   const filePath = e2ePathFor(projectRoot, id);
-  if (!existsSync35(filePath))
+  if (!existsSync36(filePath))
     return null;
-  return parseLockedTest(readFileSync34(filePath, "utf8"), filePath);
+  return parseLockedTest(readFileSync35(filePath, "utf8"), filePath);
 }
 function discoverLockedTests(projectRoot) {
   const dir = e2eDirFor(projectRoot);
-  if (!existsSync35(dir))
+  if (!existsSync36(dir))
     return [];
   return readdirSync12(dir).filter((f) => f.endsWith(".yaml")).map((f) => f.replace(/\.yaml$/, "")).sort();
 }
@@ -80948,12 +81338,12 @@ function parseLockedTest(text, filePath) {
 }
 
 // packages/rn-dev-agent-core/dist/domain/e2e-config.js
-import { readFileSync as readFileSync35 } from "node:fs";
-import { join as join49 } from "node:path";
+import { readFileSync as readFileSync36 } from "node:fs";
+import { join as join50 } from "node:path";
 function loadE2eConfig(projectRoot) {
-  const filePath = join49(projectRoot, ".rn-agent", "e2e.config.json");
+  const filePath = join50(projectRoot, ".rn-agent", "e2e.config.json");
   try {
-    const raw = readFileSync35(filePath, "utf8");
+    const raw = readFileSync36(filePath, "utf8");
     return JSON.parse(raw);
   } catch {
     return {};
@@ -81021,7 +81411,7 @@ function readPassed(result) {
 async function lockE2eTestCore(args, deps = {}) {
   const projectRoot = args.projectRoot ?? findProjectRoot() ?? process.cwd();
   const load = deps.loadAction ?? loadAction;
-  const readFile3 = deps.readActionFile ?? ((p) => readFileSync36(p, "utf8"));
+  const readFile3 = deps.readActionFile ?? ((p) => readFileSync37(p, "utf8"));
   const getGit = deps.getGitInfo ?? getGitInfo;
   const getSession = deps.getSession ?? getActiveSession;
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
@@ -81084,8 +81474,8 @@ function createLockE2eTestHandler(deps = {}) {
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
 init_maestro_error_parser();
-import { join as join50 } from "node:path";
-import { mkdirSync as mkdirSync21, writeFileSync as writeFileSync20, renameSync as renameSync9, readFileSync as readFileSync37, existsSync as existsSync36 } from "node:fs";
+import { join as join51 } from "node:path";
+import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync21, renameSync as renameSync10, readFileSync as readFileSync38, existsSync as existsSync37 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
     return {
@@ -81140,20 +81530,20 @@ function diffNewlyFailing(current, previousGreen) {
 }
 var INDEX_MAX = 100;
 function e2eRunsDirFor(projectRoot) {
-  return join50(sessionStateDirectory(projectRoot), "e2e-runs");
+  return join51(sessionStateDirectory(projectRoot), "e2e-runs");
 }
 function writeJsonAtomic(file, value) {
-  mkdirSync21(join50(file, ".."), { recursive: true });
+  mkdirSync22(join51(file, ".."), { recursive: true });
   const tmp = `${file}.tmp`;
-  writeFileSync20(tmp, JSON.stringify(value, null, 2), "utf8");
-  renameSync9(tmp, file);
+  writeFileSync21(tmp, JSON.stringify(value, null, 2), "utf8");
+  renameSync10(tmp, file);
 }
 function loadIndex(projectRoot) {
-  const file = join50(e2eRunsDirFor(projectRoot), "index.json");
-  if (!existsSync36(file))
+  const file = join51(e2eRunsDirFor(projectRoot), "index.json");
+  if (!existsSync37(file))
     return [];
   try {
-    const parsed = JSON.parse(readFileSync37(file, "utf8"));
+    const parsed = JSON.parse(readFileSync38(file, "utf8"));
     return Array.isArray(parsed) ? parsed : [];
   } catch {
     return [];
@@ -81162,7 +81552,7 @@ function loadIndex(projectRoot) {
 function writeRunRecord(projectRoot, rec) {
   assertValidActionId(rec.runId, "writeRunRecord");
   const dir = e2eRunsDirFor(projectRoot);
-  writeJsonAtomic(join50(dir, `${rec.runId}.json`), rec);
+  writeJsonAtomic(join51(dir, `${rec.runId}.json`), rec);
   const entry = {
     runId: rec.runId,
     finishedAt: rec.finishedAt,
@@ -81170,15 +81560,15 @@ function writeRunRecord(projectRoot, rec) {
     totals: rec.totals
   };
   const next = [entry, ...loadIndex(projectRoot).filter((e) => e.runId !== rec.runId)].slice(0, INDEX_MAX);
-  writeJsonAtomic(join50(dir, "index.json"), next);
+  writeJsonAtomic(join51(dir, "index.json"), next);
 }
 function loadRunRecord(projectRoot, runId) {
   assertValidActionId(runId, "loadRunRecord");
-  const file = join50(e2eRunsDirFor(projectRoot), `${runId}.json`);
-  if (!existsSync36(file))
+  const file = join51(e2eRunsDirFor(projectRoot), `${runId}.json`);
+  if (!existsSync37(file))
     return null;
   try {
-    return JSON.parse(readFileSync37(file, "utf8"));
+    return JSON.parse(readFileSync38(file, "utf8"));
   } catch {
     return null;
   }
@@ -81194,8 +81584,8 @@ init_storage();
 init_utils();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
-import { join as join51 } from "node:path";
-import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync21, renameSync as renameSync10, readFileSync as readFileSync38, readdirSync as readdirSync13, existsSync as existsSync37 } from "node:fs";
+import { join as join52 } from "node:path";
+import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync22, renameSync as renameSync11, readFileSync as readFileSync39, readdirSync as readdirSync13, existsSync as existsSync38 } from "node:fs";
 var TERMINAL_STATUSES = /* @__PURE__ */ new Set([
   "done",
   "failed",
@@ -81203,25 +81593,25 @@ var TERMINAL_STATUSES = /* @__PURE__ */ new Set([
   "interrupted"
 ]);
 function requestsDir(projectRoot) {
-  return join51(e2eRunsDirFor(projectRoot), "requests");
+  return join52(e2eRunsDirFor(projectRoot), "requests");
 }
 function requestPath(projectRoot, runId) {
   assertValidActionId(runId, "e2e-run-request");
-  return join51(requestsDir(projectRoot), `${runId}.json`);
+  return join52(requestsDir(projectRoot), `${runId}.json`);
 }
 function writeRequest(projectRoot, req) {
   const file = requestPath(projectRoot, req.runId);
-  mkdirSync22(requestsDir(projectRoot), { recursive: true });
+  mkdirSync23(requestsDir(projectRoot), { recursive: true });
   const tmp = `${file}.tmp`;
-  writeFileSync21(tmp, JSON.stringify(req, null, 2), "utf8");
-  renameSync10(tmp, file);
+  writeFileSync22(tmp, JSON.stringify(req, null, 2), "utf8");
+  renameSync11(tmp, file);
 }
 function loadRequest(projectRoot, runId) {
   const file = requestPath(projectRoot, runId);
-  if (!existsSync37(file))
+  if (!existsSync38(file))
     return null;
   try {
-    return JSON.parse(readFileSync38(file, "utf8"));
+    return JSON.parse(readFileSync39(file, "utf8"));
   } catch {
     return null;
   }
@@ -81236,7 +81626,7 @@ function updateRequest(projectRoot, runId, patch) {
 }
 function listRequests(projectRoot) {
   const dir = requestsDir(projectRoot);
-  if (!existsSync37(dir))
+  if (!existsSync38(dir))
     return [];
   const out = [];
   for (const f of readdirSync13(dir)) {
@@ -81527,9 +81917,9 @@ init_storage();
 
 // packages/rn-dev-agent-core/dist/domain/action-inventory.js
 import { readdirSync as readdirSync14 } from "node:fs";
-import { join as join52 } from "node:path";
+import { join as join53 } from "node:path";
 async function listActions(projectRoot) {
-  const actionsDir = join52(projectRoot, ".rn-agent", "actions");
+  const actionsDir = join53(projectRoot, ".rn-agent", "actions");
   let files;
   try {
     files = readdirSync14(actionsDir);
@@ -81634,20 +82024,20 @@ init_discovery();
 init_metro_cwd();
 init_install_authority();
 import { execFileSync as execFileSync17 } from "node:child_process";
-import { createHash as createHash19 } from "node:crypto";
+import { createHash as createHash20 } from "node:crypto";
 init_metro_binding();
 init_process_birth();
 init_registry();
 
 // packages/rn-dev-agent-core/dist/session/source-identity.js
 init_metro_cwd();
-import { createHash as createHash18, createHmac as createHmac4, randomBytes as randomBytes7, timingSafeEqual as timingSafeEqual7 } from "node:crypto";
+import { createHash as createHash19, createHmac as createHmac4, randomBytes as randomBytes7, timingSafeEqual as timingSafeEqual7 } from "node:crypto";
 import { execFileSync as execFileSync16 } from "node:child_process";
-import { closeSync as closeSync10, constants as constants6, existsSync as existsSync38, fstatSync as fstatSync6, lstatSync as lstatSync12, openSync as openSync10, readdirSync as readdirSync15, readFileSync as readFileSync39, readlinkSync as readlinkSync3, readSync as readSync4, realpathSync as realpathSync10 } from "node:fs";
-import { dirname as dirname21, isAbsolute as isAbsolute8, join as join53, relative as relative5, resolve as resolve10 } from "node:path";
+import { closeSync as closeSync10, constants as constants6, existsSync as existsSync39, fstatSync as fstatSync6, lstatSync as lstatSync12, openSync as openSync10, readdirSync as readdirSync15, readFileSync as readFileSync40, readlinkSync as readlinkSync3, readSync as readSync4, realpathSync as realpathSync10 } from "node:fs";
+import { dirname as dirname22, isAbsolute as isAbsolute8, join as join54, relative as relative5, resolve as resolve10 } from "node:path";
 init_declared_source_contract();
 function digest2(parts) {
-  const hash = createHash18("sha256");
+  const hash = createHash19("sha256");
   for (const part of parts) {
     hash.update(part);
     hash.update("\0");
@@ -81754,7 +82144,7 @@ function updateFramedFile(hash, path, maximumBytes) {
   return updateStableFile(hash, path, maximumBytes, true);
 }
 function fileDigest(path) {
-  const hash = createHash18("sha256");
+  const hash = createHash19("sha256");
   updateStableFile(hash, path, MAX_STRICT_PROOF_DEPENDENCY_FILE_BYTES, false);
   return hash.digest("hex");
 }
@@ -81800,7 +82190,7 @@ function updateDependencyPath(hash, path, label, state) {
       updateFramed(hash, "directory");
       for (const entry of readdirSync15(current.path).sort().reverse()) {
         pending2.push({
-          path: join53(current.path, entry),
+          path: join54(current.path, entry),
           label: `${current.label}/${entry}`,
           depth: current.depth + 1
         });
@@ -81830,10 +82220,10 @@ function isExcludedRuntimePath(root, candidate) {
   return EXCLUDED_RUNTIME_DIRECTORIES.some((excluded) => entry === excluded || entry.startsWith(`${excluded}/`) || entry.endsWith(`/${excluded}`) || entry.includes(`/${excluded}/`));
 }
 function assertFinalMetroIntegration(identity2) {
-  const candidates = ["metro.config.js", "metro.config.cjs"].map((entry) => join53(identity2.appRoot, entry)).filter(existsSync38);
+  const candidates = ["metro.config.js", "metro.config.cjs"].map((entry) => join54(identity2.appRoot, entry)).filter(existsSync39);
   if (candidates.length === 0)
     return;
-  const source = readFileSync39(candidates[0], "utf8");
+  const source = readFileSync40(candidates[0], "utf8");
   const start = source.indexOf(METRO_INTEGRATION_START);
   const end = source.indexOf(METRO_INTEGRATION_END);
   if (start < 0 || end < start || source.indexOf(METRO_INTEGRATION_START, start + METRO_INTEGRATION_START.length) >= 0 || source.indexOf(METRO_INTEGRATION_END, end + METRO_INTEGRATION_END.length) >= 0 || source.slice(start, end + METRO_INTEGRATION_END.length) !== METRO_INTEGRATION_BLOCK || source.slice(end + METRO_INTEGRATION_END.length).trim()) {
@@ -81843,7 +82233,7 @@ function assertFinalMetroIntegration(identity2) {
 function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntimeEnforcement) {
   if (!authority)
     return { paths: [], semantics: [] };
-  const raw = readFileSync39(join53(identity2.appRoot, METRO_RUNTIME_POLICY2), "utf8");
+  const raw = readFileSync40(join54(identity2.appRoot, METRO_RUNTIME_POLICY2), "utf8");
   const receipt2 = JSON.parse(raw);
   const payload = {
     version: receipt2.version,
@@ -81876,7 +82266,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
     platform: process.platform,
     appRoot: identity2.appRoot,
     sourceRoot: identity2.contentRoot,
-    runtimeRoot: dirname21(authority.evidencePath),
+    runtimeRoot: dirname22(authority.evidencePath),
     nodeExecutable: runtimeManifest.nodeExecutable,
     nodeVersion: runtimeManifest.nodeVersion,
     commandExecutable: runtimeManifest.executable,
@@ -81905,7 +82295,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
     if (!runtimeLoadsStat.isFile() || runtimeLoadsStat.size > MAX_STRICT_PROOF_FILE_BYTES) {
       throw new Error("runtime load evidence is not a bounded regular file");
     }
-    runtimeLoadsRaw = readFileSync39(runtimeLoadsPath, "utf8");
+    runtimeLoadsRaw = readFileSync40(runtimeLoadsPath, "utf8");
   } catch (error2) {
     throw new Error("STRICT_PROOF_UNVERIFIED_METRO_POLICY: runtime load evidence is invalid", {
       cause: error2
@@ -81984,7 +82374,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
         throw new Error("STRICT_PROOF_UNVERIFIED_METRO_POLICY: runtime semantics are unbounded");
       }
       runtimeSemantics.add(load.value);
-      runtimeSemanticsByDigest.set(createHash18("sha256").update(load.value).digest("hex"), load.value);
+      runtimeSemanticsByDigest.set(createHash19("sha256").update(load.value).digest("hex"), load.value);
       orderedRuntimeSemantics.push(load.value);
       continue;
     }
@@ -82134,8 +82524,8 @@ function dependencyStoreRoots(identity2, git, pathExists) {
     ...DEPENDENCY_STORE_PATHS
   ]).split("\0").filter(Boolean);
   for (const candidate of [
-    join53(identity2.contentRoot, "node_modules"),
-    join53(identity2.appRoot, "node_modules")
+    join54(identity2.contentRoot, "node_modules"),
+    join54(identity2.appRoot, "node_modules")
   ]) {
     if (pathExists(candidate))
       entries.push(relative5(identity2.contentRoot, candidate));
@@ -82146,21 +82536,21 @@ function dependencyStoreRoots(identity2, git, pathExists) {
     pnpRoots.push(pnpRoot);
     if (pnpRoot === identity2.contentRoot)
       break;
-    const parent = dirname21(pnpRoot);
+    const parent = dirname22(pnpRoot);
     if (parent === pnpRoot || !isContained(identity2.contentRoot, parent))
       break;
     pnpRoot = parent;
   }
-  const pnpLoaders = [...new Set(pnpRoots)].flatMap((root) => [".pnp.js", ".pnp.cjs", ".pnp.loader.mjs"].map((entry) => join53(root, entry)).filter(pathExists));
+  const pnpLoaders = [...new Set(pnpRoots)].flatMap((root) => [".pnp.js", ".pnp.cjs", ".pnp.loader.mjs"].map((entry) => join54(root, entry)).filter(pathExists));
   if (pnpLoaders.length > 0) {
     throw new Error("STRICT_PROOF_UNVERIFIED_DEPENDENCY_LAYOUT: Plug\u2019n\u2019Play dependency resolution is unsupported");
   }
-  let ancestor = dirname21(identity2.contentRoot);
+  let ancestor = dirname22(identity2.contentRoot);
   while (true) {
-    if (pathExists(join53(ancestor, "node_modules"))) {
+    if (pathExists(join54(ancestor, "node_modules"))) {
       throw new Error("STRICT_PROOF_UNVERIFIED_DEPENDENCY_LAYOUT: ancestor node_modules resolves outside the content root");
     }
-    const parent = dirname21(ancestor);
+    const parent = dirname22(ancestor);
     if (parent === ancestor)
       break;
     ancestor = parent;
@@ -82212,7 +82602,7 @@ function resolveDeclaredIdentity(appRoot, dependencies, canonicalize) {
   if (!dependencies.declaredManifests?.length) {
     throw new Error(missingDeclaredManifestListMessage());
   }
-  const pathExists = dependencies.exists ?? existsSync38;
+  const pathExists = dependencies.exists ?? existsSync39;
   const contentRoot = canonicalize(resolve10(dependencies.declaredRoot));
   assertContained(contentRoot, appRoot, "NON_GIT_ROOT_MISMATCH");
   const manifestParts = [];
@@ -82222,7 +82612,7 @@ function resolveDeclaredIdentity(appRoot, dependencies, canonicalize) {
       throw new Error(missingDeclaredManifestMessage(entry));
     const manifest = canonicalize(declared);
     assertContained(contentRoot, manifest, "NON_GIT_MANIFEST_OUTSIDE_ROOT");
-    manifestParts.push(relative5(contentRoot, manifest), readFileSync39(manifest));
+    manifestParts.push(relative5(contentRoot, manifest), readFileSync40(manifest));
   }
   const manifestDigest = digest2(manifestParts);
   const appRelative = relative5(contentRoot, appRoot) || ".";
@@ -82245,7 +82635,7 @@ function resolveSourceIdentity(inputRoot, dependencies = {}) {
     const contentRoot = canonicalize(git(appRoot, ["rev-parse", "--show-toplevel"]));
     assertContained(contentRoot, appRoot, "APP_ROOT_OUTSIDE_WORKTREE");
     const commonRaw = git(appRoot, ["rev-parse", "--git-common-dir"]);
-    const commonDirectory = canonicalize(isAbsolute8(commonRaw) ? commonRaw : join53(appRoot, commonRaw));
+    const commonDirectory = canonicalize(isAbsolute8(commonRaw) ? commonRaw : join54(appRoot, commonRaw));
     const head = git(appRoot, ["rev-parse", "HEAD"]);
     const appRelative = relative5(contentRoot, appRoot) || ".";
     return {
@@ -82271,7 +82661,7 @@ function strictProofSourceIdentity(identity2, dependencies = {}) {
     throw new Error("STRICT_PROOF_GIT_REQUIRED: accepted strict proof requires a Git worktree");
   }
   const git = dependencies.git ?? defaultGit;
-  const pathExists = dependencies.exists ?? existsSync38;
+  const pathExists = dependencies.exists ?? existsSync39;
   assertFinalMetroIntegration(identity2);
   const evidenceHeadReader = dependencies.readMetroEvidenceHead ?? readMetroEvidenceHead;
   const runtimeEnforcementVerifier = dependencies.verifyMetroRuntimeEnforcement ?? verifyManagedMetroEnforcementReceipt;
@@ -82305,7 +82695,7 @@ function strictProofSourceIdentity(identity2, dependencies = {}) {
       throw new Error(`STRICT_PROOF_DIRTY_SUBMODULE: ${entry} contains source changes outside the parent digest`);
     }
   }
-  const dirtyHash = createHash18("sha256");
+  const dirtyHash = createHash19("sha256");
   updateFramed(dirtyHash, "git-dirty-v3");
   updateFramed(dirtyHash, diff);
   for (const semantics of runtimeInputs.semantics) {
@@ -82377,7 +82767,7 @@ function strictProofSourceIdentity(identity2, dependencies = {}) {
 
 // packages/rn-dev-agent-core/dist/session/local-authority-probe.js
 function identity(value) {
-  return createHash19("sha256").update(JSON.stringify(value)).digest("hex");
+  return createHash20("sha256").update(JSON.stringify(value)).digest("hex");
 }
 function objectBinding(status, name) {
   const value = status.bindings[name];
@@ -83170,8 +83560,8 @@ async function connectExactSessionTarget(input, timeoutMs, dependencies) {
 }
 
 // packages/rn-dev-agent-core/dist/index.js
-var pkgPath = join54(dirname22(fileURLToPath6(import.meta.url)), "..", "package.json");
-var pkgVersion = JSON.parse(readFileSync40(pkgPath, "utf8")).version;
+var pkgPath = join55(dirname23(fileURLToPath7(import.meta.url)), "..", "package.json");
+var pkgVersion = JSON.parse(readFileSync41(pkgPath, "utf8")).version;
 var lockfile = null;
 var diagnosticContractProbe = process.argv.includes("--diagnostic-contract-probe");
 var noLock = diagnosticContractProbe || process.argv.includes("--no-lock");
@@ -83274,8 +83664,13 @@ var server2 = new McpServer({
   version: pkgVersion
 });
 var strictProofMonitor = new StrictProofMonitor();
+var experienceRecorder = new ExperienceRecorder({
+  coreVersion: pkgVersion,
+  pluginVersion: discoverPluginVersion()
+});
 addToolObserver((o) => recorder.record(o));
 addToolObserver((o) => strictProofMonitor.record(o));
+addToolObserver((o) => experienceRecorder.observe(o));
 var authorityRuntime = getWorkerAuthorityRuntime();
 setSnapshotAuthorityProvider({
   current: () => {
@@ -83300,7 +83695,7 @@ setSnapshotAuthorityProvider({
       runnerInstanceId: runner?.instanceId,
       runnerPid: runner?.pid,
       runnerProcessBirth: runner?.processBirth,
-      runnerCapabilityHash: typeof runner?.capability === "string" ? createHash20("sha256").update(runner.capability).digest("hex") : void 0,
+      runnerCapabilityHash: typeof runner?.capability === "string" ? createHash21("sha256").update(runner.capability).digest("hex") : void 0,
       runnerPort: runner?.port,
       runnerClaim: status.claims.find((claim) => claim.type === "runner")?.key,
       deviceClaim: status.claims.find((claim) => claim.type === "device")?.key
@@ -83491,7 +83886,7 @@ setObserveAuthorityDeps({
       authority: {
         sessionId: status.sessionId,
         claimEpoch: status.claimEpoch,
-        instanceId: randomUUID8(),
+        instanceId: randomUUID9(),
         capability: secret.observeCapability
       }
     };
@@ -83575,7 +83970,7 @@ var liveDeps = buildLiveDeps({
   readRoute: (c) => readLiveRoute(c),
   readShotFile: (path) => {
     try {
-      const buf = readFileSync40(path);
+      const buf = readFileSync41(path);
       const isPng = buf.length >= 4 && buf[0] === 137 && buf[1] === 80 && buf[2] === 78 && buf[3] === 71;
       return { buf, contentType: isPng ? "image/png" : "image/jpeg" };
     } catch {
@@ -83899,7 +84294,7 @@ var getSessionSignerCapability = (sessionId) => {
     return null;
   if (sessionId && !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(sessionId))
     return null;
-  const secretPath = sessionId ? join54(dirname22(dirname22(currentSecretPath)), sessionId, "secret.json") : currentSecretPath;
+  const secretPath = sessionId ? join55(dirname23(dirname23(currentSecretPath)), sessionId, "secret.json") : currentSecretPath;
   return readJsonStateFile(secretPath)?.signerCapability ?? null;
 };
 var spawningSupervisorPid = process.ppid;
@@ -84458,7 +84853,7 @@ var proofReadiness = async () => {
       connectedAt: current.connectedAt
     }),
     errorCount: errors.length,
-    errorSha256: createHash20("sha256").update(errorBytes).digest("hex"),
+    errorSha256: createHash21("sha256").update(errorBytes).digest("hex"),
     device: identity2.device,
     runtime: identity2.runtime
   };

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -81855,17 +81855,25 @@ function applyRedactionRules(value) {
 }
 function readAppIdentity() {
   const root = process.env.RN_PROJECT_ROOT ?? process.env.CLAUDE_USER_CWD ?? process.cwd();
-  if (appIdentityCache?.root === root)
-    return appIdentityCache.identity;
+  if (appIdentityCache?.root !== root) {
+    appIdentityCache = { root, identity: loadAppIdentity(root) };
+  }
+  if (appIdentityCache.identity === null) {
+    throw new Error("app identity could not be read for redaction");
+  }
+  return appIdentityCache.identity;
+}
+function loadAppIdentity(root) {
   const manifest = join47(root, "app.json");
-  let identity2 = { name: null, slug: null };
-  if (existsSync36(manifest)) {
+  try {
+    if (!existsSync36(manifest))
+      return { name: null, slug: null };
     const parsed = JSON.parse(readFileSync34(manifest, "utf8"));
     const expo = parsed.expo ?? parsed;
-    identity2 = { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
+    return { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
+  } catch {
+    return null;
   }
-  appIdentityCache = { root, identity: identity2 };
-  return identity2;
 }
 function usableIdentity(value) {
   return typeof value === "string" && value.trim().length > 2 ? value : null;
@@ -81906,7 +81914,6 @@ function readExperienceStore(path) {
     } catch {
       continue;
     }
-    SANITIZED_RECORDS.add(parsed);
     records.push(parsed);
   }
   return records;
@@ -81994,7 +82001,7 @@ function adoptLateFact(existing, incoming, field2) {
 function boundedPointers(existing, incoming) {
   return [.../* @__PURE__ */ new Set([...existing, ...incoming])].slice(-MAX_EVIDENCE_POINTERS);
 }
-var UNKNOWN_CLASSIFICATION, DEFAULT_MAX_RECORDS, DEFAULT_RETENTION_DAYS, MAX_EVIDENCE_POINTERS, EXPERIENCE_DIRECTORY, EXPERIENCE_STORE_NAME, MAX_SYMPTOM_LENGTH, DAY_MS, REDACTION_FAILED, SYMPTOM_TRUNCATED, REDACTION_RULES, KEYED_SECRET, SANITIZED_RECORDS, appIdentityCache, ExperienceRecorder, CLASSIFICATION_RULES, EXPERIENCE_FAMILY_IDS;
+var UNKNOWN_CLASSIFICATION, DEFAULT_MAX_RECORDS, DEFAULT_RETENTION_DAYS, MAX_EVIDENCE_POINTERS, EXPERIENCE_DIRECTORY, EXPERIENCE_STORE_NAME, MAX_SYMPTOM_LENGTH, DAY_MS, REDACTION_FAILED, SYMPTOM_TRUNCATED, REDACTION_RULES, KEYED_SECRET, REDACTION_RULES_VERSION, appIdentityCache, ExperienceRecorder, CLASSIFICATION_RULES, EXPERIENCE_FAMILY_IDS;
 var init_evidence = __esm({
   "packages/rn-dev-agent-core/dist/experience/evidence.js"() {
     "use strict";
@@ -82033,7 +82040,7 @@ var init_evidence = __esm({
       [/(com|org|io|dev|net)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_.-]+/g, "[BUNDLE_REDACTED]"]
     ];
     KEYED_SECRET = /((?:token|secret|password|auth|api[_-]?key)\s*[:=]\s*)[^\s,;}]{6,}/gi;
-    SANITIZED_RECORDS = /* @__PURE__ */ new WeakSet();
+    REDACTION_RULES_VERSION = 1;
     appIdentityCache = null;
     ExperienceRecorder = class {
       directory;
@@ -82148,11 +82155,10 @@ var init_evidence = __esm({
           firstSeen: now,
           lastSeen: now,
           lastRecoveredAt: null,
-          unknownReasons
+          unknownReasons,
+          redactionVersion: REDACTION_RULES_VERSION
         };
-        const sanitized = sanitizeForEvidence(raw);
-        SANITIZED_RECORDS.add(sanitized);
-        return sanitized;
+        return sanitizeForEvidence(raw);
       }
       persistFailure(incoming) {
         const records = readExperienceStore(this.path);
@@ -82167,7 +82173,6 @@ var init_evidence = __esm({
           existing.symptom = incoming.symptom;
           existing.candidate = incoming.candidate;
           existing.environment = incoming.environment;
-          adoptLateFact(existing, incoming, "platform");
           adoptLateFact(existing, incoming, "device");
           adoptLateFact(existing, incoming, "runtime");
           existing.evidencePointers = boundedPointers(existing.evidencePointers, incoming.evidencePointers);
@@ -82195,7 +82200,10 @@ var init_evidence = __esm({
         mkdirSync20(this.directory, { recursive: true, mode: 448 });
         const temp = join47(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID9()}`);
         try {
-          const sanitized = records.map((record2) => SANITIZED_RECORDS.has(record2) ? record2 : sanitizeForEvidence(record2));
+          const sanitized = records.map((record2) => record2.redactionVersion === REDACTION_RULES_VERSION ? record2 : {
+            ...sanitizeForEvidence(record2),
+            redactionVersion: REDACTION_RULES_VERSION
+          });
           const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
           writeFileSync19(temp, contents.length > 0 ? `${contents}
 ` : "", {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -24410,7 +24410,7 @@ async function rebuildStaleRunnerArtifact(first, deviceId, bundleId, deps) {
       message: "another session is rebuilding the shared runner artifact \u2014 retry this open in a few minutes."
     };
   }
-  const release = deps.releaseBuildLock ?? releaseRunnerRebuildLock;
+  const release2 = deps.releaseBuildLock ?? releaseRunnerRebuildLock;
   try {
     const reap = deps.reap ?? reapStaleFastRunner;
     await reap();
@@ -24424,7 +24424,7 @@ async function rebuildStaleRunnerArtifact(first, deviceId, bundleId, deps) {
       ...deps.attachOnly === true ? { attachOnly: true } : {}
     });
   } finally {
-    release();
+    release2();
   }
   const probe = deps.probe ?? probeFastRunnerLivenessDetailed;
   const rebuilt = await probe();
@@ -28085,8 +28085,8 @@ async function runFlowParked(run, opts = {}) {
   const stale = opts.markCdpStale ?? markCdpStale;
   try {
     if (opts.platform === "android") {
-      const release = opts.releaseAndroidSlot ?? releaseAndroidInteractionSlot;
-      await release({ deviceId: opts.deviceId });
+      const release2 = opts.releaseAndroidSlot ?? releaseAndroidInteractionSlot;
+      await release2({ deviceId: opts.deviceId });
     } else {
       await (opts.stopFastRunner ?? stopFastRunner)(opts.deviceId);
     }
@@ -33114,13 +33114,13 @@ function consumePendingAndroidUpgradeNote() {
   pendingUpgradeNote = void 0;
   return note;
 }
-async function reapMismatchedAndroidRunner(state, release, verify, signal) {
+async function reapMismatchedAndroidRunner(state, release2, verify, signal) {
   signal?.throwIfAborted();
   const deviceId = state?.deviceId;
   if (!deviceId) {
     throw new Error("RUNNER_CLEANUP_UNCONFIRMED: stale Android runner has no recorded device identity");
   }
-  const releaseSlot = release ?? (async (opts) => {
+  const releaseSlot = release2 ?? (async (opts) => {
     const { releaseAndroidInteractionSlot: releaseAndroidInteractionSlot2 } = await Promise.resolve().then(() => (init_release_android_slot(), release_android_slot_exports));
     return releaseAndroidInteractionSlot2({ ...opts, signal });
   });
@@ -33134,7 +33134,7 @@ async function reapMismatchedAndroidRunner(state, release, verify, signal) {
   if (!receipt2.stoppedOwnRunner || missingPackages.length > 0) {
     throw new Error(`RUNNER_CLEANUP_UNCONFIRMED: stale Android runner cleanup failed for ${deviceId}`);
   }
-  const verifyReleased = verify ?? (release ? async () => {
+  const verifyReleased = verify ?? (release2 ? async () => {
   } : async (expected) => {
     const forwards = String((await execFileAsync2("adb", ["forward", "--list"], {
       timeout: ADB_CLEANUP_TIMEOUT_MS,
@@ -33322,7 +33322,7 @@ async function runBoundedAndroidRunnerRebuild(error2, rebuild, cleanup, dependen
   const heartbeat = dependencies.heartbeat ?? heartbeatAndroidRunnerRebuildLock;
   const complete = dependencies.complete ?? completeAndroidRunnerRebuildLock;
   const beginCleanup = dependencies.beginCleanup ?? beginAndroidRunnerRebuildCleanup;
-  const release = dependencies.release ?? releaseAndroidRunnerRebuildLock;
+  const release2 = dependencies.release ?? releaseAndroidRunnerRebuildLock;
   const markCleanupUnverified = dependencies.markCleanupUnverified ?? markAndroidRunnerRebuildCleanupUnverified;
   const controller = new AbortController();
   let cleanupController;
@@ -33418,7 +33418,7 @@ async function runBoundedAndroidRunnerRebuild(error2, rebuild, cleanup, dependen
     }
     clearTimeout(cleanupTimer);
     cleanupController = void 0;
-    const terminalPersisted = await persistTransition(cleanupVerified ? release : markCleanupUnverified);
+    const terminalPersisted = await persistTransition(cleanupVerified ? release2 : markCleanupUnverified);
     clearInterval(heartbeatTimer2);
     if (!terminalPersisted) {
       throw leaseAuthorityLost ? controller.signal.reason : androidRebuildRefusal(error2, "runner artifact failure state was not durable");
@@ -58697,7 +58697,7 @@ var require_websocket = __commonJS({
     var http = __require("http");
     var net = __require("net");
     var tls = __require("tls");
-    var { randomBytes: randomBytes9, createHash: createHash23 } = __require("crypto");
+    var { randomBytes: randomBytes9, createHash: createHash24 } = __require("crypto");
     var { Duplex, Readable } = __require("stream");
     var { URL: URL2 } = __require("url");
     var PerMessageDeflate2 = require_permessage_deflate();
@@ -59365,7 +59365,7 @@ var require_websocket = __commonJS({
           abortHandshake(websocket, socket, "Invalid Upgrade header");
           return;
         }
-        const digest3 = createHash23("sha1").update(key + GUID).digest("base64");
+        const digest3 = createHash24("sha1").update(key + GUID).digest("base64");
         if (res.headers["sec-websocket-accept"] !== digest3) {
           abortHandshake(websocket, socket, "Invalid Sec-WebSocket-Accept header");
           return;
@@ -59734,7 +59734,7 @@ var require_websocket_server = __commonJS({
     var EventEmitter = __require("events");
     var http = __require("http");
     var { Duplex } = __require("stream");
-    var { createHash: createHash23 } = __require("crypto");
+    var { createHash: createHash24 } = __require("crypto");
     var extension2 = require_extension();
     var PerMessageDeflate2 = require_permessage_deflate();
     var subprotocol2 = require_subprotocol();
@@ -60041,7 +60041,7 @@ var require_websocket_server = __commonJS({
           );
         }
         if (this._state > RUNNING) return abortHandshake(socket, 503);
-        const digest3 = createHash23("sha1").update(key + GUID).digest("base64");
+        const digest3 = createHash24("sha1").update(key + GUID).digest("base64");
         const headers = [
           "HTTP/1.1 101 Switching Protocols",
           "Upgrade: websocket",
@@ -81810,8 +81810,404 @@ var init_instrumentation = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/experience/evidence.js
+import { createHash as createHash20, randomUUID as randomUUID9 } from "node:crypto";
+import { chmodSync as chmodSync5, existsSync as existsSync36, mkdirSync as mkdirSync20, readFileSync as readFileSync34, renameSync as renameSync8, unlinkSync as unlinkSync12, writeFileSync as writeFileSync19 } from "node:fs";
+import { homedir as homedir11, platform as hostPlatform, release } from "node:os";
+import { dirname as dirname21, join as join47 } from "node:path";
+import { fileURLToPath as fileURLToPath5 } from "node:url";
+function sanitizeString(value, redact2 = applyRedactionRules) {
+  try {
+    return redact2(value);
+  } catch {
+    return REDACTION_FAILED;
+  }
+}
+function sanitizeForEvidence(value, redact2) {
+  if (value === null || value === void 0 || typeof value === "boolean" || typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "string")
+    return sanitizeString(value, redact2);
+  if (Array.isArray(value))
+    return value.map((item) => sanitizeForEvidence(item, redact2));
+  if (typeof value === "object") {
+    const sanitized = {};
+    for (const [key, nested] of Object.entries(value)) {
+      sanitized[key] = sanitizeForEvidence(nested, redact2);
+    }
+    return sanitized;
+  }
+  return REDACTION_FAILED;
+}
+function applyRedactionRules(value) {
+  let result = value.replaceAll(homedir11(), "~").replace(KEYED_SECRET, "$1[REDACTED_SECRET]");
+  for (const [pattern, replacement] of REDACTION_RULES) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}
+function discoverPluginVersion(fromUrl = import.meta.url) {
+  if (process.env.RN_DEV_AGENT_PLUGIN_VERSION)
+    return process.env.RN_DEV_AGENT_PLUGIN_VERSION;
+  const start = dirname21(fileURLToPath5(fromUrl));
+  const candidates = [
+    join47(start, "..", "..", ".claude-plugin", "plugin.json"),
+    join47(start, "..", "..", ".codex-plugin", "plugin.json"),
+    join47(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
+    join47(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
+  ];
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(readFileSync34(candidate, "utf8"));
+      if (typeof parsed.version === "string")
+        return sanitizeString(parsed.version);
+    } catch {
+    }
+  }
+  return null;
+}
+function readExperienceStore(path, allowMissing = false) {
+  if (!existsSync36(path)) {
+    if (allowMissing)
+      return [];
+    return [];
+  }
+  const contents = readFileSync34(path, "utf8");
+  if (!contents.trim())
+    return [];
+  return contents.split("\n").filter((line) => line.trim().length > 0).map((line) => JSON.parse(line));
+}
+function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, retentionMs = DEFAULT_RETENTION_DAYS * DAY_MS) {
+  const cutoff = now.getTime() - retentionMs;
+  return records.filter((record2) => {
+    const lastSeen = Date.parse(record2.lastSeen);
+    return Number.isFinite(lastSeen) && lastSeen >= cutoff;
+  }).sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen) || a.signature.localeCompare(b.signature)).slice(0, Math.max(0, maxRecords)).sort((a, b) => a.signature.localeCompare(b.signature));
+}
+function experienceSignature(input) {
+  return createHash20("sha256").update(JSON.stringify([
+    input.classification,
+    input.tool,
+    input.normalizedSymptomShape,
+    input.platform ?? "unknown"
+  ])).digest("hex");
+}
+function normalizeSymptomShape(symptom) {
+  return symptom.toLowerCase().replace(/[0-9a-f]{8}-[0-9a-f-]{27,}/gi, "<id>").replace(/\b0x[0-9a-f]+\b/gi, "<hex>").replace(/\b(?=[a-z0-9_-]{12,}\b)(?=[a-z0-9_-]*\d)[a-z0-9_-]+\b/gi, "<id>").replace(/\b\d+\b/g, "#").replace(/\s+/g, " ").trim();
+}
+function classifyExperience(symptom, tool, platform) {
+  const haystack = `${tool} ${platform ?? ""} ${symptom}`.toLowerCase();
+  const rules = [
+    ["FF_REDBOX", /redbox|logbox|error overlay|hasredbox/],
+    ["FF_DEBUGGER_PAUSED", /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
+    [
+      "FF_STALE_CDP",
+      /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/
+    ],
+    ["FF_FAST_REFRESH_STALE", /fast refresh|ui unchanged|old exports|old module path/],
+    ["FF_METRO_CACHE", /metro.*(?:stale|cache)|config change not reflected/],
+    [
+      "FF_BINARY_MISMATCH",
+      /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/
+    ],
+    ["FF_EXPO_DIALOG", /open-in-app|system confirmation dialog/],
+    [
+      "FF_DEV_CLIENT_PICKER",
+      /no hermes target|development servers|devclientlauncher|server picker/
+    ],
+    ["FF_KEYBOARD_OVERLAY", /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
+    ["FF_MAESTRO_GRPC_ANDROID", /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
+    [
+      "FF_ANDROID_TEXT_INPUT_CRASH",
+      /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/
+    ],
+    [
+      "FF_AUTH_GATE",
+      /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/
+    ],
+    [
+      "FF_PERMISSION_ALREADY_GRANTED",
+      /permission already granted|prompt (?:was )?not shown|flow completes instantly/
+    ],
+    ["EG_EXPO_GO_SDK_MISMATCH", /incompatible with this version of expo go|expo go sdk.*mismatch/],
+    ["EG_NATIVEWIND_JSX_SOURCE", /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
+    ["EG_EXPO_GO_NATIVE_MODULES", /expo go.*custom native module/],
+    ["EG_DEV_CLIENT_CLEARSTATE", /clearstate.*(?:dev client|metro connection|launcher)/],
+    ["EG_MSW_HERMES", /msw.*(?:hermes|react native|initialize)/],
+    ["EG_EXPO_ROUTER_DEEP_LINK", /expo router.*deep link|deep link.*confirmation dialog/],
+    ["EG_DEV_MENU_INTERFERENCE", /dev menu.*(?:overlay|recording|blocking)/],
+    ["EG_NEW_ARCH_CDP_TARGET", /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
+    ["PQ_IOS_RECORDVIDEO_CODEC", /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
+    ["PQ_ANDROID_SCREENRECORD_LIMIT", /screenrecord.*180|screenrecord.*3 minute/],
+    ["PQ_ANDROID_BOOT_DELAY", /sys\.boot_completed|emulator.*grpc.*ready/],
+    ["PQ_ANDROID_PLAY_PROTECT", /play protect.*(?:block|apk|install)/]
+  ];
+  return rules.find(([, pattern]) => pattern.test(haystack))?.[0] ?? UNKNOWN_CLASSIFICATION;
+}
+function extractSymptom(event) {
+  if (typeof event.error === "string" && event.error.length > 0)
+    return event.error;
+  if (event.result && typeof event.result === "object") {
+    const envelope = event.result;
+    if (typeof envelope.error === "string")
+      return envelope.error;
+    const content = envelope.content;
+    if (Array.isArray(content)) {
+      const first = content[0];
+      if (typeof first?.text === "string")
+        return first.text;
+    }
+  }
+  return `${event.tool} reported ${event.status} without an error message`;
+}
+function extractScalar(event, keys) {
+  const sources = [event.params, event.result];
+  for (const source of sources) {
+    const value = findScalar(source, keys, 0);
+    if (value !== null)
+      return value;
+  }
+  return null;
+}
+function findScalar(value, keys, depth) {
+  if (!value || typeof value !== "object" || depth > 3)
+    return null;
+  const object3 = value;
+  for (const key of keys) {
+    const candidate = object3[key];
+    if (typeof candidate === "string" && candidate.length > 0)
+      return candidate;
+  }
+  for (const nested of Object.values(object3)) {
+    if (nested && typeof nested === "object") {
+      const found = findScalar(nested, keys, depth + 1);
+      if (found !== null)
+        return found;
+    }
+  }
+  return null;
+}
+function sanitizeNullable(value) {
+  return value === null ? null : sanitizeString(value);
+}
+function boundedPointers(existing, incoming) {
+  return [.../* @__PURE__ */ new Set([...existing, ...incoming])].slice(-MAX_EVIDENCE_POINTERS);
+}
+var UNKNOWN_CLASSIFICATION, DEFAULT_MAX_RECORDS, DEFAULT_RETENTION_DAYS, MAX_EVIDENCE_POINTERS, EXPERIENCE_DIRECTORY, EXPERIENCE_STORE_NAME, DAY_MS, REDACTION_FAILED, REDACTION_RULES, KEYED_SECRET, ExperienceRecorder;
+var init_evidence = __esm({
+  "packages/rn-dev-agent-core/dist/experience/evidence.js"() {
+    "use strict";
+    UNKNOWN_CLASSIFICATION = "UNKNOWN";
+    DEFAULT_MAX_RECORDS = 500;
+    DEFAULT_RETENTION_DAYS = 14;
+    MAX_EVIDENCE_POINTERS = 3;
+    EXPERIENCE_DIRECTORY = join47(homedir11(), ".claude", "rn-agent", "experience");
+    EXPERIENCE_STORE_NAME = "patterns.jsonl";
+    DAY_MS = 24 * 60 * 60 * 1e3;
+    REDACTION_FAILED = "[REDACTION_FAILED]";
+    REDACTION_RULES = [
+      [/(sk|pk|api|key|token|secret|password|auth)[-_]?[A-Za-z0-9_-]{20,}/gi, "[REDACTED_SECRET]"],
+      [/Bearer [A-Za-z0-9_./+=-]{20,}/g, "Bearer [REDACTED]"],
+      [/ghp_[A-Za-z0-9_]{36}/g, "[REDACTED_GH_TOKEN]"],
+      [/eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g, "[REDACTED_JWT]"],
+      [/AKIA[0-9A-Z]{16}/g, "[REDACTED_AWS]"],
+      [/xox[baprs]-[A-Za-z0-9-]+/g, "[REDACTED_SLACK]"],
+      [/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, "[EMAIL_REDACTED]"],
+      [
+        /(^|[^0-9])(192|10|172|169)\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}([^0-9]|$)/g,
+        "$1[IP_REDACTED]$3"
+      ],
+      [/(^|[^0-9])[0-9]{1,3}(?:\.[0-9]{1,3}){3}([^0-9]|$)/g, "$1[IP_REDACTED]$2"],
+      [
+        /(?:https?:\/\/)?(?:localhost|127\.0\.0\.1)(?::[0-9]{2,5})?(?:\/[^\s]*)?/gi,
+        "[LOOPBACK_ENDPOINT_REDACTED]"
+      ],
+      [/"(metroPort|observePort|port)"\s*:\s*[0-9]+/g, '"$1":"[PORT_REDACTED]"'],
+      [/\bport\s*[:=]?\s*[0-9]{2,5}\b/gi, "[PORT_REDACTED]"],
+      [/:([0-9]{2,5})(?=\/|\s|$)/g, ":[PORT_REDACTED]"],
+      [/~\/[A-Za-z0-9_./-]+/g, "[PATH_REDACTED]"],
+      [/\/(Users|home|opt|var|tmp|etc|private|Volumes)\/[A-Za-z0-9_./-]+/g, "[PATH_REDACTED]"],
+      [/(com|org|io|dev|net)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_.-]+/g, "[BUNDLE_REDACTED]"]
+    ];
+    KEYED_SECRET = /((?:token|secret|password|auth|api[_-]?key)\s*[:=]\s*)[^\s,;}]{6,}/gi;
+    ExperienceRecorder = class {
+      directory;
+      path;
+      candidate;
+      environment;
+      maxRecords;
+      retentionMs;
+      now;
+      schedule;
+      previousFailure = null;
+      constructor(options) {
+        this.directory = options.directory ?? process.env.RN_DEV_AGENT_EXPERIENCE_DIR ?? EXPERIENCE_DIRECTORY;
+        this.path = join47(this.directory, EXPERIENCE_STORE_NAME);
+        this.candidate = {
+          pluginVersion: options.pluginVersion ?? null,
+          coreVersion: options.coreVersion
+        };
+        this.environment = { os: `${hostPlatform()} ${release()}`, node: process.version };
+        this.maxRecords = options.maxRecords ?? DEFAULT_MAX_RECORDS;
+        this.retentionMs = (options.retentionDays ?? DEFAULT_RETENTION_DAYS) * DAY_MS;
+        this.now = options.now ?? (() => /* @__PURE__ */ new Date());
+        this.schedule = options.schedule ?? ((work) => setImmediate(work));
+      }
+      /** Queue only: persistence never executes in the observed tool's call stack. */
+      observe(event) {
+        try {
+          this.schedule(() => this.recordNonLoadBearing(event));
+        } catch {
+        }
+      }
+      /** Test and CLI support; returns a sanitized, deduplicated view. */
+      read() {
+        return readExperienceStore(this.path);
+      }
+      recordNonLoadBearing(event) {
+        try {
+          this.record(event);
+        } catch {
+        }
+      }
+      record(event) {
+        if (!event || typeof event.tool !== "string") {
+          this.previousFailure = null;
+          return;
+        }
+        if (event.status === "PASS") {
+          const recovery = this.previousFailure;
+          this.previousFailure = null;
+          if (recovery?.tool === event.tool)
+            this.persistRecovery(recovery.signature, event.tool);
+          return;
+        }
+        if (event.status !== "FAIL" && event.status !== "ERROR") {
+          this.previousFailure = null;
+          return;
+        }
+        const record2 = this.buildFailureRecord(event);
+        this.persistFailure(record2);
+        this.previousFailure = event.status === "FAIL" ? { tool: event.tool, signature: record2.signature } : null;
+      }
+      buildFailureRecord(event) {
+        const now = this.now().toISOString();
+        const tool = sanitizeString(event.tool);
+        const symptom = sanitizeString(extractSymptom(event));
+        const platform = sanitizeNullable(extractScalar(event, ["platform"]));
+        const deviceName = extractScalar(event, ["deviceName", "deviceModel", "model"]);
+        const hasDeviceId = extractScalar(event, ["deviceId", "udid"]) !== null;
+        const device = sanitizeNullable(deviceName ?? (hasDeviceId ? "identified-device" : null));
+        const runtime = sanitizeNullable(extractScalar(event, ["runtime", "engine"]));
+        const classification = classifyExperience(symptom, tool, platform);
+        const normalizedSymptomShape = normalizeSymptomShape(symptom);
+        const signature = experienceSignature({
+          classification,
+          tool,
+          normalizedSymptomShape,
+          platform
+        });
+        const unknownReasons = {};
+        if (this.candidate.pluginVersion === null) {
+          unknownReasons["candidate.pluginVersion"] = "plugin manifest was not available to the core runtime";
+        }
+        if (platform === null)
+          unknownReasons.platform = "tool event did not expose a platform";
+        if (device === null)
+          unknownReasons.device = "tool event did not expose a device name or identifier";
+        if (runtime === null)
+          unknownReasons.runtime = "tool event did not expose a runtime";
+        unknownReasons.maskingCondition = "not derivable from a single tool event";
+        unknownReasons.recovery = "no immediate successful retry has been observed";
+        unknownReasons.cleanup = "tool events do not report cleanup actions";
+        const raw = {
+          signature,
+          candidate: this.candidate,
+          environment: this.environment,
+          platform,
+          device,
+          runtime,
+          phase: "tool",
+          trigger: `${event.status} reported by ${tool}`,
+          maskingCondition: null,
+          symptom,
+          recovery: null,
+          cleanup: null,
+          classification,
+          evidencePointers: [`event:${randomUUID9()}`],
+          tool,
+          status: event.status === "ERROR" ? "ERROR" : "FAIL",
+          normalizedSymptomShape,
+          count: 1,
+          recoveryCount: 0,
+          firstSeen: now,
+          lastSeen: now,
+          lastRecoveredAt: null,
+          unknownReasons
+        };
+        return sanitizeForEvidence(raw);
+      }
+      persistFailure(incoming) {
+        const records = readExperienceStore(this.path, true);
+        const existing = records.find((record2) => record2.signature === incoming.signature);
+        if (existing) {
+          existing.count += 1;
+          existing.lastSeen = incoming.lastSeen;
+          existing.status = incoming.status;
+          existing.symptom = incoming.symptom;
+          existing.candidate = incoming.candidate;
+          existing.environment = incoming.environment;
+          existing.evidencePointers = boundedPointers(existing.evidencePointers, incoming.evidencePointers);
+        } else {
+          records.push(incoming);
+        }
+        this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
+      }
+      persistRecovery(signature, tool) {
+        const records = readExperienceStore(this.path, true);
+        const existing = records.find((record2) => record2.signature === signature);
+        if (!existing)
+          return;
+        const now = this.now().toISOString();
+        existing.recovery = sanitizeString(`PASS immediately followed FAIL for ${tool}`);
+        existing.recoveryCount += 1;
+        existing.lastRecoveredAt = now;
+        delete existing.unknownReasons.recovery;
+        existing.evidencePointers = boundedPointers(existing.evidencePointers, [
+          `event:${randomUUID9()}`
+        ]);
+        this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
+      }
+      write(records) {
+        mkdirSync20(this.directory, { recursive: true, mode: 448 });
+        const temp = join47(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID9()}`);
+        try {
+          const sanitized = records.map((record2) => sanitizeForEvidence(record2));
+          const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
+          writeFileSync19(temp, contents.length > 0 ? `${contents}
+` : "", {
+            encoding: "utf8",
+            flag: "wx",
+            mode: 384
+          });
+          renameSync8(temp, this.path);
+          chmodSync5(this.path, 384);
+        } catch (error2) {
+          try {
+            unlinkSync12(temp);
+          } catch {
+          }
+          throw error2;
+        }
+      }
+    };
+  }
+});
+
 // packages/rn-dev-agent-core/dist/observability/live-device.js
-import { join as join47 } from "node:path";
+import { join as join48 } from "node:path";
 import { tmpdir as tmpdir13 } from "node:os";
 function isStateMutating(tool, args) {
   if (FLOW_MUTATION_TOOLS.has(tool))
@@ -81915,7 +82311,7 @@ function buildLiveDeps(input) {
     // iterable" when invoked as deps.pushLive(...). The live device gate caught
     // this — the unit fakes used standalone arrows and missed it.
     pushLive: (frame) => input.recorder.pushLive(frame),
-    tmpPath: () => join47(tmpdir13(), `rn-observe-live-${process.pid}.jpg`),
+    tmpPath: () => join48(tmpdir13(), `rn-observe-live-${process.pid}.jpg`),
     isMirrorActive: input.isMirrorActive
   };
 }
@@ -82010,9 +82406,9 @@ var init_e2e_csrf = __esm({
 
 // packages/rn-dev-agent-core/dist/observability/server.js
 import { createServer as createServer3 } from "node:http";
-import { readFileSync as readFileSync34 } from "node:fs";
-import { fileURLToPath as fileURLToPath5 } from "node:url";
-import { dirname as dirname21, join as join48 } from "node:path";
+import { readFileSync as readFileSync35 } from "node:fs";
+import { fileURLToPath as fileURLToPath6 } from "node:url";
+import { dirname as dirname22, join as join49 } from "node:path";
 function listen(server3, port) {
   return new Promise((resolve11, reject) => {
     const onErr = (e) => {
@@ -82034,7 +82430,7 @@ var init_server3 = __esm({
     init_e2e_csrf();
     init_logger();
     HOST = "127.0.0.1";
-    __dir = dirname21(fileURLToPath5(import.meta.url));
+    __dir = dirname22(fileURLToPath6(import.meta.url));
     ObservabilityServer = class {
       recorder;
       e2e;
@@ -82266,7 +82662,7 @@ var init_server3 = __esm({
       }
       index(res) {
         try {
-          let html = readFileSync34(join48(__dir, "web-dist", "index.html"), "utf8");
+          let html = readFileSync35(join49(__dir, "web-dist", "index.html"), "utf8");
           if (this.e2e) {
             const tokenJs = JSON.stringify(this.e2e.token).replace(/</g, "\\u003c");
             html = html.replace("</head>", `<script>window.__E2E_CSRF__=${tokenJs}</script></head>`);
@@ -82433,10 +82829,10 @@ var init_server3 = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/observability/observe-state.js
-import { join as join49 } from "node:path";
+import { join as join50 } from "node:path";
 function observeStatePath(projectRoot) {
   const safe = projectRoot.replace(/[^A-Za-z0-9._-]/g, "_");
-  return join49(getStateDir(), "observe", `${safe}.json`);
+  return join50(getStateDir(), "observe", `${safe}.json`);
 }
 function writeObserveState(url, port, projectRoot = findProjectRoot(), now = () => /* @__PURE__ */ new Date()) {
   try {
@@ -82721,7 +83117,7 @@ var init_jpeg_stream = __esm({
 import { spawn as spawn9, execFile as execFile25 } from "node:child_process";
 import { readFile as readFile2, unlink } from "node:fs/promises";
 import { tmpdir as tmpdir14 } from "node:os";
-import { join as join50 } from "node:path";
+import { join as join51 } from "node:path";
 async function probeIdbClient(execFileFn = execFile25) {
   return new Promise((resolve11) => {
     execFileFn("idb", ["--help"], { timeout: 3e3 }, (err) => {
@@ -82888,7 +83284,7 @@ var init_sources = __esm({
         this.gate = new RestartGate(3, 1e4, opts.now ?? Date.now);
         this.idleDelayMs = opts.idleDelayMs ?? 25;
         this.failurePauseMs = opts.failurePauseMs ?? 500;
-        this.tmpPath = opts.tmpPath ?? (() => join50(tmpdir14(), "rn-mirror-simctl-" + process.pid + ".jpg"));
+        this.tmpPath = opts.tmpPath ?? (() => join51(tmpdir14(), "rn-mirror-simctl-" + process.pid + ".jpg"));
         this.degradedHint = opts.degradedHint ?? SIMCTL_HINT;
       }
       start(sink) {
@@ -83311,16 +83707,16 @@ var init_target = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
-import { dirname as dirname22, join as join51 } from "node:path";
-import { mkdirSync as mkdirSync20, writeFileSync as writeFileSync19, renameSync as renameSync8, readFileSync as readFileSync35, readdirSync as readdirSync13, existsSync as existsSync36 } from "node:fs";
-import { createHash as createHash20 } from "node:crypto";
+import { dirname as dirname23, join as join52 } from "node:path";
+import { mkdirSync as mkdirSync21, writeFileSync as writeFileSync20, renameSync as renameSync9, readFileSync as readFileSync36, readdirSync as readdirSync13, existsSync as existsSync37 } from "node:fs";
+import { createHash as createHash21 } from "node:crypto";
 function e2eDirFor(projectRoot) {
-  return join51(projectRoot, ".rn-agent", "e2e");
+  return join52(projectRoot, ".rn-agent", "e2e");
 }
 function e2ePathFor(projectRoot, id) {
   assertValidActionId(id, "e2ePathFor");
   const dir = e2eDirFor(projectRoot);
-  const file = join51(dir, `${id}.yaml`);
+  const file = join52(dir, `${id}.yaml`);
   assertWithinDir(file, dir);
   return file;
 }
@@ -83344,11 +83740,11 @@ function serializeLockedTest(meta) {
 ${meta.flow}`;
 }
 function hashBody(s) {
-  return createHash20("sha256").update(s).digest("hex");
+  return createHash21("sha256").update(s).digest("hex");
 }
 function freezeLockedTest(projectRoot, source, ctx) {
   const filePath = e2ePathFor(projectRoot, source.id);
-  mkdirSync20(dirname22(filePath), { recursive: true });
+  mkdirSync21(dirname23(filePath), { recursive: true });
   const meta = {
     id: source.id,
     intent: source.intent,
@@ -83362,19 +83758,19 @@ function freezeLockedTest(projectRoot, source, ctx) {
     flow: source.flow
   };
   const tmp = `${filePath}.tmp`;
-  writeFileSync19(tmp, serializeLockedTest(meta), "utf8");
-  renameSync8(tmp, filePath);
+  writeFileSync20(tmp, serializeLockedTest(meta), "utf8");
+  renameSync9(tmp, filePath);
   return { ...meta, filePath };
 }
 function loadLockedTest(projectRoot, id) {
   const filePath = e2ePathFor(projectRoot, id);
-  if (!existsSync36(filePath))
+  if (!existsSync37(filePath))
     return null;
-  return parseLockedTest(readFileSync35(filePath, "utf8"), filePath);
+  return parseLockedTest(readFileSync36(filePath, "utf8"), filePath);
 }
 function discoverLockedTests(projectRoot) {
   const dir = e2eDirFor(projectRoot);
-  if (!existsSync36(dir))
+  if (!existsSync37(dir))
     return [];
   return readdirSync13(dir).filter((f) => f.endsWith(".yaml")).map((f) => f.replace(/\.yaml$/, "")).sort();
 }
@@ -83421,12 +83817,12 @@ var init_e2e_test = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/e2e-config.js
-import { readFileSync as readFileSync36 } from "node:fs";
-import { join as join52 } from "node:path";
+import { readFileSync as readFileSync37 } from "node:fs";
+import { join as join53 } from "node:path";
 function loadE2eConfig(projectRoot) {
-  const filePath = join52(projectRoot, ".rn-agent", "e2e.config.json");
+  const filePath = join53(projectRoot, ".rn-agent", "e2e.config.json");
   try {
-    const raw = readFileSync36(filePath, "utf8");
+    const raw = readFileSync37(filePath, "utf8");
     return JSON.parse(raw);
   } catch {
     return {};
@@ -83487,7 +83883,7 @@ var init_git_info = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/lock-e2e-test.js
-import { readFileSync as readFileSync37 } from "node:fs";
+import { readFileSync as readFileSync38 } from "node:fs";
 function readPassed(result) {
   try {
     const env = JSON.parse(result.content[0].text);
@@ -83502,7 +83898,7 @@ function readPassed(result) {
 async function lockE2eTestCore(args, deps = {}) {
   const projectRoot = args.projectRoot ?? findProjectRoot() ?? process.cwd();
   const load = deps.loadAction ?? loadAction;
-  const readFile3 = deps.readActionFile ?? ((p) => readFileSync37(p, "utf8"));
+  const readFile3 = deps.readActionFile ?? ((p) => readFileSync38(p, "utf8"));
   const getGit = deps.getGitInfo ?? getGitInfo;
   const getSession = deps.getSession ?? getActiveSession;
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
@@ -83577,8 +83973,8 @@ var init_lock_e2e_test = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
-import { join as join53 } from "node:path";
-import { mkdirSync as mkdirSync21, writeFileSync as writeFileSync20, renameSync as renameSync9, readFileSync as readFileSync38, existsSync as existsSync37 } from "node:fs";
+import { join as join54 } from "node:path";
+import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync21, renameSync as renameSync10, readFileSync as readFileSync39, existsSync as existsSync38 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
     return {
@@ -83632,20 +84028,20 @@ function diffNewlyFailing(current, previousGreen) {
   return current.results.filter((r) => !r.passed && r.classification !== "skipped" && (previousGreen === null || wasPassing.has(r.testId))).map((r) => r.testId);
 }
 function e2eRunsDirFor(projectRoot) {
-  return join53(sessionStateDirectory(projectRoot), "e2e-runs");
+  return join54(sessionStateDirectory(projectRoot), "e2e-runs");
 }
 function writeJsonAtomic(file, value) {
-  mkdirSync21(join53(file, ".."), { recursive: true });
+  mkdirSync22(join54(file, ".."), { recursive: true });
   const tmp = `${file}.tmp`;
-  writeFileSync20(tmp, JSON.stringify(value, null, 2), "utf8");
-  renameSync9(tmp, file);
+  writeFileSync21(tmp, JSON.stringify(value, null, 2), "utf8");
+  renameSync10(tmp, file);
 }
 function loadIndex(projectRoot) {
-  const file = join53(e2eRunsDirFor(projectRoot), "index.json");
-  if (!existsSync37(file))
+  const file = join54(e2eRunsDirFor(projectRoot), "index.json");
+  if (!existsSync38(file))
     return [];
   try {
-    const parsed = JSON.parse(readFileSync38(file, "utf8"));
+    const parsed = JSON.parse(readFileSync39(file, "utf8"));
     return Array.isArray(parsed) ? parsed : [];
   } catch {
     return [];
@@ -83654,7 +84050,7 @@ function loadIndex(projectRoot) {
 function writeRunRecord(projectRoot, rec) {
   assertValidActionId(rec.runId, "writeRunRecord");
   const dir = e2eRunsDirFor(projectRoot);
-  writeJsonAtomic(join53(dir, `${rec.runId}.json`), rec);
+  writeJsonAtomic(join54(dir, `${rec.runId}.json`), rec);
   const entry = {
     runId: rec.runId,
     finishedAt: rec.finishedAt,
@@ -83662,15 +84058,15 @@ function writeRunRecord(projectRoot, rec) {
     totals: rec.totals
   };
   const next = [entry, ...loadIndex(projectRoot).filter((e) => e.runId !== rec.runId)].slice(0, INDEX_MAX);
-  writeJsonAtomic(join53(dir, "index.json"), next);
+  writeJsonAtomic(join54(dir, "index.json"), next);
 }
 function loadRunRecord(projectRoot, runId) {
   assertValidActionId(runId, "loadRunRecord");
-  const file = join53(e2eRunsDirFor(projectRoot), `${runId}.json`);
-  if (!existsSync37(file))
+  const file = join54(e2eRunsDirFor(projectRoot), `${runId}.json`);
+  if (!existsSync38(file))
     return null;
   try {
-    return JSON.parse(readFileSync38(file, "utf8"));
+    return JSON.parse(readFileSync39(file, "utf8"));
   } catch {
     return null;
   }
@@ -83690,28 +84086,28 @@ var init_e2e_run = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
-import { join as join54 } from "node:path";
-import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync21, renameSync as renameSync10, readFileSync as readFileSync39, readdirSync as readdirSync14, existsSync as existsSync38 } from "node:fs";
+import { join as join55 } from "node:path";
+import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync22, renameSync as renameSync11, readFileSync as readFileSync40, readdirSync as readdirSync14, existsSync as existsSync39 } from "node:fs";
 function requestsDir(projectRoot) {
-  return join54(e2eRunsDirFor(projectRoot), "requests");
+  return join55(e2eRunsDirFor(projectRoot), "requests");
 }
 function requestPath(projectRoot, runId) {
   assertValidActionId(runId, "e2e-run-request");
-  return join54(requestsDir(projectRoot), `${runId}.json`);
+  return join55(requestsDir(projectRoot), `${runId}.json`);
 }
 function writeRequest(projectRoot, req) {
   const file = requestPath(projectRoot, req.runId);
-  mkdirSync22(requestsDir(projectRoot), { recursive: true });
+  mkdirSync23(requestsDir(projectRoot), { recursive: true });
   const tmp = `${file}.tmp`;
-  writeFileSync21(tmp, JSON.stringify(req, null, 2), "utf8");
-  renameSync10(tmp, file);
+  writeFileSync22(tmp, JSON.stringify(req, null, 2), "utf8");
+  renameSync11(tmp, file);
 }
 function loadRequest(projectRoot, runId) {
   const file = requestPath(projectRoot, runId);
-  if (!existsSync38(file))
+  if (!existsSync39(file))
     return null;
   try {
-    return JSON.parse(readFileSync39(file, "utf8"));
+    return JSON.parse(readFileSync40(file, "utf8"));
   } catch {
     return null;
   }
@@ -83726,7 +84122,7 @@ function updateRequest(projectRoot, runId, patch) {
 }
 function listRequests(projectRoot) {
   const dir = requestsDir(projectRoot);
-  if (!existsSync38(dir))
+  if (!existsSync39(dir))
     return [];
   const out = [];
   for (const f of readdirSync14(dir)) {
@@ -84046,9 +84442,9 @@ var init_preflight = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/action-inventory.js
 import { readdirSync as readdirSync15 } from "node:fs";
-import { join as join55 } from "node:path";
+import { join as join56 } from "node:path";
 async function listActions(projectRoot) {
-  const actionsDir = join55(projectRoot, ".rn-agent", "actions");
+  const actionsDir = join56(projectRoot, ".rn-agent", "actions");
   let files;
   try {
     files = readdirSync15(actionsDir);
@@ -84159,9 +84555,9 @@ var init_runner_binding = __esm({
 
 // packages/rn-dev-agent-core/dist/session/local-authority-probe.js
 import { execFileSync as execFileSync17 } from "node:child_process";
-import { createHash as createHash21 } from "node:crypto";
+import { createHash as createHash22 } from "node:crypto";
 function identity(value) {
-  return createHash21("sha256").update(JSON.stringify(value)).digest("hex");
+  return createHash22("sha256").update(JSON.stringify(value)).digest("hex");
 }
 function objectBinding(status, name) {
   const value = status.bindings[name];
@@ -84998,12 +85394,12 @@ var index_exports = {};
 __export(index_exports, {
   strictProofMonitor: () => strictProofMonitor
 });
-import { createHash as createHash22, createHmac as createHmac5, randomUUID as randomUUID9 } from "node:crypto";
-import { readFileSync as readFileSync40, rmSync as rmSync11 } from "node:fs";
+import { createHash as createHash23, createHmac as createHmac5, randomUUID as randomUUID10 } from "node:crypto";
+import { readFileSync as readFileSync41, rmSync as rmSync11 } from "node:fs";
 import { execFile as execFile26 } from "node:child_process";
 import { promisify as promisify28 } from "node:util";
-import { fileURLToPath as fileURLToPath6 } from "node:url";
-import { dirname as dirname23, join as join56 } from "node:path";
+import { fileURLToPath as fileURLToPath7 } from "node:url";
+import { dirname as dirname24, join as join57 } from "node:path";
 function trackedTool(name, desc, schema, handler) {
   registeredToolNames.push(name);
   const base = instrumentTool(name, authorityGate.wrap(name, arbiterWrap(name, handler)));
@@ -85455,7 +85851,7 @@ async function main() {
     });
   }
 }
-var pkgPath, pkgVersion, lockfile, diagnosticContractProbe, noLock, client, getClient, configureClientLifecycle, setClient, publishClient, createClient, execFileP, mustOk, makeReplayDeps, server2, strictProofMonitor, authorityRuntime, createRuntimeAuthorityProbe, localAuthorityProbe, authorityGate, blindProbeContext, mirrorCfg, mirrorManager2, liveEnabled, liveDeps, registeredToolNames, persistedAuthorityStatus, getSessionSignerCapability, spawningSupervisorPid, requestWorkerRecycle, sessionHandler, disconnectClientHandler, connectBoundSession, resolveNativeProofDevice, proofReadiness, proofCaptureHandler, e2ePreflight, e2eReload, e2eSuiteHandler, e2eCsrfToken, projectRootFor, triggerE2eRun, runActionHandler, observeRunActionHandler, observeTriggerRun, gatedObserveState, shutdown, stopParentWatch;
+var pkgPath, pkgVersion, lockfile, diagnosticContractProbe, noLock, client, getClient, configureClientLifecycle, setClient, publishClient, createClient, execFileP, mustOk, makeReplayDeps, server2, strictProofMonitor, experienceRecorder, authorityRuntime, createRuntimeAuthorityProbe, localAuthorityProbe, authorityGate, blindProbeContext, mirrorCfg, mirrorManager2, liveEnabled, liveDeps, registeredToolNames, persistedAuthorityStatus, getSessionSignerCapability, spawningSupervisorPid, requestWorkerRecycle, sessionHandler, disconnectClientHandler, connectBoundSession, resolveNativeProofDevice, proofReadiness, proofCaptureHandler, e2ePreflight, e2eReload, e2eSuiteHandler, e2eCsrfToken, projectRootFor, triggerE2eRun, runActionHandler, observeRunActionHandler, observeTriggerRun, gatedObserveState, shutdown, stopParentWatch;
 var init_index = __esm({
   "packages/rn-dev-agent-core/dist/index.js"() {
     "use strict";
@@ -85534,6 +85930,7 @@ var init_index = __esm({
     init_process_birth();
     init_ensure_single_runner();
     init_instrumentation();
+    init_evidence();
     init_recorder();
     init_proof_capture();
     init_live_device();
@@ -85575,8 +85972,8 @@ var init_index = __esm({
     init_source_identity();
     init_managed_metro();
     init_process_cleanup();
-    pkgPath = join56(dirname23(fileURLToPath6(import.meta.url)), "..", "package.json");
-    pkgVersion = JSON.parse(readFileSync40(pkgPath, "utf8")).version;
+    pkgPath = join57(dirname24(fileURLToPath7(import.meta.url)), "..", "package.json");
+    pkgVersion = JSON.parse(readFileSync41(pkgPath, "utf8")).version;
     lockfile = null;
     diagnosticContractProbe = process.argv.includes("--diagnostic-contract-probe");
     noLock = diagnosticContractProbe || process.argv.includes("--no-lock");
@@ -85678,8 +86075,13 @@ var init_index = __esm({
       version: pkgVersion
     });
     strictProofMonitor = new StrictProofMonitor();
+    experienceRecorder = new ExperienceRecorder({
+      coreVersion: pkgVersion,
+      pluginVersion: discoverPluginVersion()
+    });
     addToolObserver((o) => recorder.record(o));
     addToolObserver((o) => strictProofMonitor.record(o));
+    addToolObserver((o) => experienceRecorder.observe(o));
     authorityRuntime = getWorkerAuthorityRuntime();
     setSnapshotAuthorityProvider({
       current: () => {
@@ -85704,7 +86106,7 @@ var init_index = __esm({
           runnerInstanceId: runner?.instanceId,
           runnerPid: runner?.pid,
           runnerProcessBirth: runner?.processBirth,
-          runnerCapabilityHash: typeof runner?.capability === "string" ? createHash22("sha256").update(runner.capability).digest("hex") : void 0,
+          runnerCapabilityHash: typeof runner?.capability === "string" ? createHash23("sha256").update(runner.capability).digest("hex") : void 0,
           runnerPort: runner?.port,
           runnerClaim: status.claims.find((claim) => claim.type === "runner")?.key,
           deviceClaim: status.claims.find((claim) => claim.type === "device")?.key
@@ -85895,7 +86297,7 @@ var init_index = __esm({
           authority: {
             sessionId: status.sessionId,
             claimEpoch: status.claimEpoch,
-            instanceId: randomUUID9(),
+            instanceId: randomUUID10(),
             capability: secret.observeCapability
           }
         };
@@ -85979,7 +86381,7 @@ var init_index = __esm({
       readRoute: (c) => readLiveRoute(c),
       readShotFile: (path) => {
         try {
-          const buf = readFileSync40(path);
+          const buf = readFileSync41(path);
           const isPng = buf.length >= 4 && buf[0] === 137 && buf[1] === 80 && buf[2] === 78 && buf[3] === 71;
           return { buf, contentType: isPng ? "image/png" : "image/jpeg" };
         } catch {
@@ -85999,7 +86401,7 @@ var init_index = __esm({
         return null;
       if (sessionId && !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(sessionId))
         return null;
-      const secretPath = sessionId ? join56(dirname23(dirname23(currentSecretPath)), sessionId, "secret.json") : currentSecretPath;
+      const secretPath = sessionId ? join57(dirname24(dirname24(currentSecretPath)), sessionId, "secret.json") : currentSecretPath;
       return readJsonStateFile(secretPath)?.signerCapability ?? null;
     };
     spawningSupervisorPid = process.ppid;
@@ -86539,7 +86941,7 @@ var init_index = __esm({
           connectedAt: current.connectedAt
         }),
         errorCount: errors.length,
-        errorSha256: createHash22("sha256").update(errorBytes).digest("hex"),
+        errorSha256: createHash23("sha256").update(errorBytes).digest("hex"),
         device: identity2.device,
         runtime: identity2.runtime
       };
@@ -87032,11 +87434,11 @@ var init_index = __esm({
 // packages/rn-dev-agent-core/dist/supervisor.js
 init_lockfile();
 init_parent_watch();
-import { randomUUID as randomUUID10 } from "node:crypto";
+import { randomUUID as randomUUID11 } from "node:crypto";
 import { spawn as spawn10 } from "node:child_process";
-import { readFileSync as readFileSync41 } from "node:fs";
-import { dirname as dirname24, join as join57 } from "node:path";
-import { fileURLToPath as fileURLToPath7 } from "node:url";
+import { readFileSync as readFileSync42 } from "node:fs";
+import { dirname as dirname25, join as join58 } from "node:path";
+import { fileURLToPath as fileURLToPath8 } from "node:url";
 
 // packages/rn-dev-agent-core/dist/lifecycle/stdio-frames.js
 var LineSplitter = class {
@@ -87521,8 +87923,8 @@ function supervisorRelaunchArgs(supervisorPath, sqliteWarningFilterPath2, versio
 }
 
 // packages/rn-dev-agent-core/dist/supervisor.js
-var here = dirname24(fileURLToPath7(import.meta.url));
-var sqliteWarningFilterPath = join57(here, "sqlite-warning-filter.js");
+var here = dirname25(fileURLToPath8(import.meta.url));
+var sqliteWarningFilterPath = join58(here, "sqlite-warning-filter.js");
 var unsupportedNode = unsupportedNodeVersionMessage();
 if (unsupportedNode) {
   process.stderr.write(`${unsupportedNode}
@@ -87531,7 +87933,7 @@ if (unsupportedNode) {
 }
 var supervisorFlag = sqliteFlagForNode();
 if (supervisorFlag.length > 0 && !process.execArgv.includes("--experimental-sqlite") && process.env.RN_DEV_AGENT_SQLITE_RELAUNCHED !== "1") {
-  const child = spawn10(process.execPath, supervisorRelaunchArgs(fileURLToPath7(import.meta.url), sqliteWarningFilterPath, void 0, process.argv.slice(2)), {
+  const child = spawn10(process.execPath, supervisorRelaunchArgs(fileURLToPath8(import.meta.url), sqliteWarningFilterPath, void 0, process.argv.slice(2)), {
     stdio: "inherit",
     env: { ...process.env, RN_DEV_AGENT_SQLITE_RELAUNCHED: "1" }
   });
@@ -87572,13 +87974,13 @@ if (process.env.RN_BRIDGE_SUPERVISOR === "0") {
 `);
   }, spawnWorker2 = function() {
     resolveAuthorityForSpawn2();
-    const workerInstance = randomUUID10();
+    const workerInstance = randomUUID11();
     const child = spawn10(process.execPath, workerSpawnArgs(workerPath, sqliteWarningFilterPath, void 0, process.argv.slice(2)), {
       stdio: ["pipe", "pipe", "inherit"],
       env: {
         ...process.env,
         RN_BRIDGE_SUPERVISED: "1",
-        RN_DEV_AGENT_SESSION_CLI: join57(here, "rn-session.js"),
+        RN_DEV_AGENT_SESSION_CLI: join58(here, "rn-session.js"),
         RN_BRIDGE_RESTARTS: String(core.restartCount),
         ...core.lastExit ? { RN_BRIDGE_LAST_EXIT: core.lastExit } : {},
         ...authority ? authority.workerEnvironment(workerInstance) : { RN_DEV_AGENT_AUTHORITY_ERROR: authorityError ?? "AUTHORITY_STORE_UNAVAILABLE" }
@@ -87642,12 +88044,12 @@ if (process.env.RN_BRIDGE_SUPERVISOR === "0") {
     force.unref();
   };
   apply = apply2, resolveAuthorityForSpawn = resolveAuthorityForSpawn2, spawnWorker = spawnWorker2, closeAuthorityAndExit = closeAuthorityAndExit2, beginShutdown = beginShutdown2;
-  const workerPath = process.env.RN_BRIDGE_WORKER_PATH ?? join57(here, "index.js");
+  const workerPath = process.env.RN_BRIDGE_WORKER_PATH ?? join58(here, "index.js");
   const noLock2 = process.argv.includes("--no-lock");
   const diagnosticContractProbe2 = process.argv.includes("--diagnostic-contract-probe");
   let lockfile2 = null;
   if (!noLock2) {
-    const pkg = JSON.parse(readFileSync41(join57(here, "..", "package.json"), "utf8"));
+    const pkg = JSON.parse(readFileSync42(join58(here, "..", "package.json"), "utf8"));
     lockfile2 = new Lockfile({ version: pkg.version });
     const lockResult = lockfile2.acquire();
     if (lockResult.status === "conflict") {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -81846,7 +81846,29 @@ function applyRedactionRules(value) {
     pattern.lastIndex = 0;
     result = result.replace(pattern, replacement);
   }
+  const identity2 = readAppIdentity();
+  if (identity2.name)
+    result = result.replaceAll(identity2.name, "[APP_NAME_REDACTED]");
+  if (identity2.slug)
+    result = result.replaceAll(identity2.slug, "[APP_SLUG_REDACTED]");
   return result;
+}
+function readAppIdentity() {
+  const root = process.env.RN_PROJECT_ROOT ?? process.env.CLAUDE_USER_CWD ?? process.cwd();
+  if (appIdentityCache?.root === root)
+    return appIdentityCache.identity;
+  const manifest = join47(root, "app.json");
+  let identity2 = { name: null, slug: null };
+  if (existsSync36(manifest)) {
+    const parsed = JSON.parse(readFileSync34(manifest, "utf8"));
+    const expo = parsed.expo ?? parsed;
+    identity2 = { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
+  }
+  appIdentityCache = { root, identity: identity2 };
+  return identity2;
+}
+function usableIdentity(value) {
+  return typeof value === "string" && value.trim().length > 2 ? value : null;
 }
 function discoverPluginVersion(fromUrl = import.meta.url) {
   if (process.env.RN_DEV_AGENT_PLUGIN_VERSION)
@@ -81868,16 +81890,26 @@ function discoverPluginVersion(fromUrl = import.meta.url) {
   }
   return null;
 }
-function readExperienceStore(path, allowMissing = false) {
-  if (!existsSync36(path)) {
-    if (allowMissing)
-      return [];
+function readExperienceStore(path) {
+  if (!existsSync36(path))
     return [];
-  }
   const contents = readFileSync34(path, "utf8");
   if (!contents.trim())
     return [];
-  return contents.split("\n").filter((line) => line.trim().length > 0).map((line) => JSON.parse(line));
+  const records = [];
+  for (const line of contents.split("\n")) {
+    if (line.trim().length === 0)
+      continue;
+    let parsed;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    SANITIZED_RECORDS.add(parsed);
+    records.push(parsed);
+  }
+  return records;
 }
 function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, retentionMs = DEFAULT_RETENTION_DAYS * DAY_MS) {
   const cutoff = now.getTime() - retentionMs;
@@ -81899,52 +81931,7 @@ function normalizeSymptomShape(symptom) {
 }
 function classifyExperience(symptom, tool, platform) {
   const haystack = `${tool} ${platform ?? ""} ${symptom}`.toLowerCase();
-  const rules = [
-    ["FF_REDBOX", /redbox|logbox|error overlay|hasredbox/],
-    ["FF_DEBUGGER_PAUSED", /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
-    [
-      "FF_STALE_CDP",
-      /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/
-    ],
-    ["FF_FAST_REFRESH_STALE", /fast refresh|ui unchanged|old exports|old module path/],
-    ["FF_METRO_CACHE", /metro.*(?:stale|cache)|config change not reflected/],
-    [
-      "FF_BINARY_MISMATCH",
-      /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/
-    ],
-    ["FF_EXPO_DIALOG", /open-in-app|system confirmation dialog/],
-    [
-      "FF_DEV_CLIENT_PICKER",
-      /no hermes target|development servers|devclientlauncher|server picker/
-    ],
-    ["FF_KEYBOARD_OVERLAY", /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
-    ["FF_MAESTRO_GRPC_ANDROID", /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
-    [
-      "FF_ANDROID_TEXT_INPUT_CRASH",
-      /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/
-    ],
-    [
-      "FF_AUTH_GATE",
-      /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/
-    ],
-    [
-      "FF_PERMISSION_ALREADY_GRANTED",
-      /permission already granted|prompt (?:was )?not shown|flow completes instantly/
-    ],
-    ["EG_EXPO_GO_SDK_MISMATCH", /incompatible with this version of expo go|expo go sdk.*mismatch/],
-    ["EG_NATIVEWIND_JSX_SOURCE", /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
-    ["EG_EXPO_GO_NATIVE_MODULES", /expo go.*custom native module/],
-    ["EG_DEV_CLIENT_CLEARSTATE", /clearstate.*(?:dev client|metro connection|launcher)/],
-    ["EG_MSW_HERMES", /msw.*(?:hermes|react native|initialize)/],
-    ["EG_EXPO_ROUTER_DEEP_LINK", /expo router.*deep link|deep link.*confirmation dialog/],
-    ["EG_DEV_MENU_INTERFERENCE", /dev menu.*(?:overlay|recording|blocking)/],
-    ["EG_NEW_ARCH_CDP_TARGET", /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
-    ["PQ_IOS_RECORDVIDEO_CODEC", /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
-    ["PQ_ANDROID_SCREENRECORD_LIMIT", /screenrecord.*180|screenrecord.*3 minute/],
-    ["PQ_ANDROID_BOOT_DELAY", /sys\.boot_completed|emulator.*grpc.*ready/],
-    ["PQ_ANDROID_PLAY_PROTECT", /play protect.*(?:block|apk|install)/]
-  ];
-  return rules.find(([, pattern]) => pattern.test(haystack))?.[0] ?? UNKNOWN_CLASSIFICATION;
+  return CLASSIFICATION_RULES.find(([, pattern]) => pattern.test(haystack))?.[0] ?? UNKNOWN_CLASSIFICATION;
 }
 function extractSymptom(event) {
   if (typeof event.error === "string" && event.error.length > 0)
@@ -81961,6 +81948,12 @@ function extractSymptom(event) {
     }
   }
   return `${event.tool} reported ${event.status} without an error message`;
+}
+function boundSymptom(symptom) {
+  if (symptom.length <= MAX_SYMPTOM_LENGTH)
+    return symptom;
+  const head = symptom.slice(0, MAX_SYMPTOM_LENGTH).replace(/\S+$/, "");
+  return `${head}${SYMPTOM_TRUNCATED}`;
 }
 function extractScalar(event, keys) {
   const sources = [event.params, event.result];
@@ -81992,10 +81985,16 @@ function findScalar(value, keys, depth) {
 function sanitizeNullable(value) {
   return value === null ? null : sanitizeString(value);
 }
+function adoptLateFact(existing, incoming, field2) {
+  if (existing[field2] !== null || incoming[field2] === null)
+    return;
+  existing[field2] = incoming[field2];
+  delete existing.unknownReasons[field2];
+}
 function boundedPointers(existing, incoming) {
   return [.../* @__PURE__ */ new Set([...existing, ...incoming])].slice(-MAX_EVIDENCE_POINTERS);
 }
-var UNKNOWN_CLASSIFICATION, DEFAULT_MAX_RECORDS, DEFAULT_RETENTION_DAYS, MAX_EVIDENCE_POINTERS, EXPERIENCE_DIRECTORY, EXPERIENCE_STORE_NAME, DAY_MS, REDACTION_FAILED, REDACTION_RULES, KEYED_SECRET, ExperienceRecorder;
+var UNKNOWN_CLASSIFICATION, DEFAULT_MAX_RECORDS, DEFAULT_RETENTION_DAYS, MAX_EVIDENCE_POINTERS, EXPERIENCE_DIRECTORY, EXPERIENCE_STORE_NAME, MAX_SYMPTOM_LENGTH, DAY_MS, REDACTION_FAILED, SYMPTOM_TRUNCATED, REDACTION_RULES, KEYED_SECRET, SANITIZED_RECORDS, appIdentityCache, ExperienceRecorder, CLASSIFICATION_RULES, EXPERIENCE_FAMILY_IDS;
 var init_evidence = __esm({
   "packages/rn-dev-agent-core/dist/experience/evidence.js"() {
     "use strict";
@@ -82005,8 +82004,10 @@ var init_evidence = __esm({
     MAX_EVIDENCE_POINTERS = 3;
     EXPERIENCE_DIRECTORY = join47(homedir11(), ".claude", "rn-agent", "experience");
     EXPERIENCE_STORE_NAME = "patterns.jsonl";
+    MAX_SYMPTOM_LENGTH = 2048;
     DAY_MS = 24 * 60 * 60 * 1e3;
     REDACTION_FAILED = "[REDACTION_FAILED]";
+    SYMPTOM_TRUNCATED = "[TRUNCATED]";
     REDACTION_RULES = [
       [/(sk|pk|api|key|token|secret|password|auth)[-_]?[A-Za-z0-9_-]{20,}/gi, "[REDACTED_SECRET]"],
       [/Bearer [A-Za-z0-9_./+=-]{20,}/g, "Bearer [REDACTED]"],
@@ -82032,6 +82033,8 @@ var init_evidence = __esm({
       [/(com|org|io|dev|net)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_.-]+/g, "[BUNDLE_REDACTED]"]
     ];
     KEYED_SECRET = /((?:token|secret|password|auth|api[_-]?key)\s*[:=]\s*)[^\s,;}]{6,}/gi;
+    SANITIZED_RECORDS = /* @__PURE__ */ new WeakSet();
+    appIdentityCache = null;
     ExperienceRecorder = class {
       directory;
       path;
@@ -82095,7 +82098,7 @@ var init_evidence = __esm({
       buildFailureRecord(event) {
         const now = this.now().toISOString();
         const tool = sanitizeString(event.tool);
-        const symptom = sanitizeString(extractSymptom(event));
+        const symptom = sanitizeString(boundSymptom(extractSymptom(event)));
         const platform = sanitizeNullable(extractScalar(event, ["platform"]));
         const deviceName = extractScalar(event, ["deviceName", "deviceModel", "model"]);
         const hasDeviceId = extractScalar(event, ["deviceId", "udid"]) !== null;
@@ -82147,18 +82150,26 @@ var init_evidence = __esm({
           lastRecoveredAt: null,
           unknownReasons
         };
-        return sanitizeForEvidence(raw);
+        const sanitized = sanitizeForEvidence(raw);
+        SANITIZED_RECORDS.add(sanitized);
+        return sanitized;
       }
       persistFailure(incoming) {
-        const records = readExperienceStore(this.path, true);
+        const records = readExperienceStore(this.path);
         const existing = records.find((record2) => record2.signature === incoming.signature);
         if (existing) {
           existing.count += 1;
           existing.lastSeen = incoming.lastSeen;
-          existing.status = incoming.status;
+          if (incoming.status === "ERROR" && existing.status !== "ERROR") {
+            existing.status = "ERROR";
+            existing.trigger = incoming.trigger;
+          }
           existing.symptom = incoming.symptom;
           existing.candidate = incoming.candidate;
           existing.environment = incoming.environment;
+          adoptLateFact(existing, incoming, "platform");
+          adoptLateFact(existing, incoming, "device");
+          adoptLateFact(existing, incoming, "runtime");
           existing.evidencePointers = boundedPointers(existing.evidencePointers, incoming.evidencePointers);
         } else {
           records.push(incoming);
@@ -82166,7 +82177,7 @@ var init_evidence = __esm({
         this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
       }
       persistRecovery(signature, tool) {
-        const records = readExperienceStore(this.path, true);
+        const records = readExperienceStore(this.path);
         const existing = records.find((record2) => record2.signature === signature);
         if (!existing)
           return;
@@ -82184,7 +82195,7 @@ var init_evidence = __esm({
         mkdirSync20(this.directory, { recursive: true, mode: 448 });
         const temp = join47(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID9()}`);
         try {
-          const sanitized = records.map((record2) => sanitizeForEvidence(record2));
+          const sanitized = records.map((record2) => SANITIZED_RECORDS.has(record2) ? record2 : sanitizeForEvidence(record2));
           const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
           writeFileSync19(temp, contents.length > 0 ? `${contents}
 ` : "", {
@@ -82203,6 +82214,46 @@ var init_evidence = __esm({
         }
       }
     };
+    CLASSIFICATION_RULES = [
+      ["FF_REDBOX", /redbox|logbox|error overlay|hasredbox/],
+      ["FF_DEBUGGER_PAUSED", /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
+      [
+        "FF_STALE_CDP",
+        /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/
+      ],
+      ["FF_FAST_REFRESH_STALE", /fast refresh|ui unchanged|old exports|old module path/],
+      ["FF_METRO_CACHE", /metro.*(?:stale|cache)|config change not reflected/],
+      [
+        "FF_BINARY_MISMATCH",
+        /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/
+      ],
+      ["FF_EXPO_DIALOG", /open-in-app|system confirmation dialog/],
+      ["FF_DEV_CLIENT_PICKER", /no hermes target|development servers|devclientlauncher|server picker/],
+      ["FF_KEYBOARD_OVERLAY", /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
+      ["FF_MAESTRO_GRPC_ANDROID", /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
+      [
+        "FF_ANDROID_TEXT_INPUT_CRASH",
+        /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/
+      ],
+      ["FF_AUTH_GATE", /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/],
+      [
+        "FF_PERMISSION_ALREADY_GRANTED",
+        /permission already granted|prompt (?:was )?not shown|flow completes instantly/
+      ],
+      ["EG_EXPO_GO_SDK_MISMATCH", /incompatible with this version of expo go|expo go sdk.*mismatch/],
+      ["EG_NATIVEWIND_JSX_SOURCE", /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
+      ["EG_EXPO_GO_NATIVE_MODULES", /expo go.*custom native module/],
+      ["EG_DEV_CLIENT_CLEARSTATE", /clearstate.*(?:dev client|metro connection|launcher)/],
+      ["EG_MSW_HERMES", /msw.*(?:hermes|react native|initialize)/],
+      ["EG_EXPO_ROUTER_DEEP_LINK", /expo router.*deep link|deep link.*confirmation dialog/],
+      ["EG_DEV_MENU_INTERFERENCE", /dev menu.*(?:overlay|recording|blocking)/],
+      ["EG_NEW_ARCH_CDP_TARGET", /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
+      ["PQ_IOS_RECORDVIDEO_CODEC", /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
+      ["PQ_ANDROID_SCREENRECORD_LIMIT", /screenrecord.*180|screenrecord.*3 minute/],
+      ["PQ_ANDROID_BOOT_DELAY", /sys\.boot_completed|emulator.*grpc.*ready/],
+      ["PQ_ANDROID_PLAY_PROTECT", /play protect.*(?:block|apk|install)/]
+    ];
+    EXPERIENCE_FAMILY_IDS = CLASSIFICATION_RULES.map(([id]) => id);
   }
 });
 

--- a/packages/codex-plugin/rn-dev-agent-core/dist/experience-trends.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/experience-trends.js
@@ -11,17 +11,68 @@ import { dirname, join } from "node:path";
 var EXPERIENCE_DIRECTORY = join(homedir(), ".claude", "rn-agent", "experience");
 var EXPERIENCE_STORE_NAME = "patterns.jsonl";
 var DAY_MS = 24 * 60 * 60 * 1e3;
-function readExperienceStore(path, allowMissing = false) {
-  if (!existsSync(path)) {
-    if (allowMissing)
-      return [];
+var SANITIZED_RECORDS = /* @__PURE__ */ new WeakSet();
+function readExperienceStore(path) {
+  if (!existsSync(path))
     return [];
-  }
   const contents = readFileSync(path, "utf8");
   if (!contents.trim())
     return [];
-  return contents.split("\n").filter((line) => line.trim().length > 0).map((line) => JSON.parse(line));
+  const records = [];
+  for (const line of contents.split("\n")) {
+    if (line.trim().length === 0)
+      continue;
+    let parsed;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    SANITIZED_RECORDS.add(parsed);
+    records.push(parsed);
+  }
+  return records;
 }
+var CLASSIFICATION_RULES = [
+  ["FF_REDBOX", /redbox|logbox|error overlay|hasredbox/],
+  ["FF_DEBUGGER_PAUSED", /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
+  [
+    "FF_STALE_CDP",
+    /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/
+  ],
+  ["FF_FAST_REFRESH_STALE", /fast refresh|ui unchanged|old exports|old module path/],
+  ["FF_METRO_CACHE", /metro.*(?:stale|cache)|config change not reflected/],
+  [
+    "FF_BINARY_MISMATCH",
+    /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/
+  ],
+  ["FF_EXPO_DIALOG", /open-in-app|system confirmation dialog/],
+  ["FF_DEV_CLIENT_PICKER", /no hermes target|development servers|devclientlauncher|server picker/],
+  ["FF_KEYBOARD_OVERLAY", /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
+  ["FF_MAESTRO_GRPC_ANDROID", /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
+  [
+    "FF_ANDROID_TEXT_INPUT_CRASH",
+    /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/
+  ],
+  ["FF_AUTH_GATE", /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/],
+  [
+    "FF_PERMISSION_ALREADY_GRANTED",
+    /permission already granted|prompt (?:was )?not shown|flow completes instantly/
+  ],
+  ["EG_EXPO_GO_SDK_MISMATCH", /incompatible with this version of expo go|expo go sdk.*mismatch/],
+  ["EG_NATIVEWIND_JSX_SOURCE", /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
+  ["EG_EXPO_GO_NATIVE_MODULES", /expo go.*custom native module/],
+  ["EG_DEV_CLIENT_CLEARSTATE", /clearstate.*(?:dev client|metro connection|launcher)/],
+  ["EG_MSW_HERMES", /msw.*(?:hermes|react native|initialize)/],
+  ["EG_EXPO_ROUTER_DEEP_LINK", /expo router.*deep link|deep link.*confirmation dialog/],
+  ["EG_DEV_MENU_INTERFERENCE", /dev menu.*(?:overlay|recording|blocking)/],
+  ["EG_NEW_ARCH_CDP_TARGET", /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
+  ["PQ_IOS_RECORDVIDEO_CODEC", /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
+  ["PQ_ANDROID_SCREENRECORD_LIMIT", /screenrecord.*180|screenrecord.*3 minute/],
+  ["PQ_ANDROID_BOOT_DELAY", /sys\.boot_completed|emulator.*grpc.*ready/],
+  ["PQ_ANDROID_PLAY_PROTECT", /play protect.*(?:block|apk|install)/]
+];
+var EXPERIENCE_FAMILY_IDS = CLASSIFICATION_RULES.map(([id]) => id);
 
 // packages/rn-dev-agent-core/dist/experience/trends.js
 function buildExperienceTrendReport(records, since2, now = /* @__PURE__ */ new Date()) {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/experience-trends.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/experience-trends.js
@@ -11,7 +11,6 @@ import { dirname, join } from "node:path";
 var EXPERIENCE_DIRECTORY = join(homedir(), ".claude", "rn-agent", "experience");
 var EXPERIENCE_STORE_NAME = "patterns.jsonl";
 var DAY_MS = 24 * 60 * 60 * 1e3;
-var SANITIZED_RECORDS = /* @__PURE__ */ new WeakSet();
 function readExperienceStore(path) {
   if (!existsSync(path))
     return [];
@@ -28,7 +27,6 @@ function readExperienceStore(path) {
     } catch {
       continue;
     }
-    SANITIZED_RECORDS.add(parsed);
     records.push(parsed);
   }
   return records;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/experience-trends.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/experience-trends.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+import { createRequire as __rnCreateRequire } from "node:module"; const require = __rnCreateRequire(import.meta.url);
+
+// packages/rn-dev-agent-core/dist/experience/trends.js
+import { join as join2 } from "node:path";
+
+// packages/rn-dev-agent-core/dist/experience/evidence.js
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir, platform as hostPlatform, release } from "node:os";
+import { dirname, join } from "node:path";
+var EXPERIENCE_DIRECTORY = join(homedir(), ".claude", "rn-agent", "experience");
+var EXPERIENCE_STORE_NAME = "patterns.jsonl";
+var DAY_MS = 24 * 60 * 60 * 1e3;
+function readExperienceStore(path, allowMissing = false) {
+  if (!existsSync(path)) {
+    if (allowMissing)
+      return [];
+    return [];
+  }
+  const contents = readFileSync(path, "utf8");
+  if (!contents.trim())
+    return [];
+  return contents.split("\n").filter((line) => line.trim().length > 0).map((line) => JSON.parse(line));
+}
+
+// packages/rn-dev-agent-core/dist/experience/trends.js
+function buildExperienceTrendReport(records, since2, now = /* @__PURE__ */ new Date()) {
+  const families = /* @__PURE__ */ new Map();
+  for (const record of records) {
+    const aggregate = families.get(record.classification) ?? { count: 0, patterns: 0 };
+    aggregate.count += record.count;
+    aggregate.patterns += 1;
+    families.set(record.classification, aggregate);
+  }
+  const project = (record) => ({
+    signature: record.signature,
+    classification: record.classification,
+    tool: record.tool,
+    count: record.count,
+    firstSeen: record.firstSeen,
+    lastSeen: record.lastSeen
+  });
+  const sortPatterns = (a, b) => b.count - a.count || a.classification.localeCompare(b.classification) || a.signature.localeCompare(b.signature);
+  return {
+    generatedAt: now.toISOString(),
+    since: since2.toISOString(),
+    families: [...families.entries()].map(([classification, value]) => ({ classification, ...value })).sort((a, b) => b.count - a.count || a.classification.localeCompare(b.classification)),
+    newSincePreviousReport: records.filter((record) => Date.parse(record.firstSeen) >= since2.getTime()).map(project).sort(sortPatterns),
+    recurring: records.filter((record) => record.count > 1).map(project).sort(sortPatterns)
+  };
+}
+function readExperienceTrendReport(options) {
+  const directory = options.directory ?? process.env.RN_DEV_AGENT_EXPERIENCE_DIR ?? EXPERIENCE_DIRECTORY;
+  return buildExperienceTrendReport(readExperienceStore(join2(directory, EXPERIENCE_STORE_NAME)), options.since);
+}
+
+// packages/rn-dev-agent-core/dist/experience-trends.js
+function usage() {
+  process.stderr.write("Usage: rn-experience-trends [--since <ISO timestamp>] [--json]\n  --since is the generated-at timestamp printed by the previous report (default: 24 hours ago).\n  This command only reads ~/.claude/rn-agent/experience/patterns.jsonl.\n");
+  process.exit(2);
+}
+var since = new Date(Date.now() - 24 * 60 * 60 * 1e3);
+var json = false;
+for (let index = 2; index < process.argv.length; index += 1) {
+  const argument = process.argv[index];
+  if (argument === "--json") {
+    json = true;
+  } else if (argument === "--since") {
+    const value = process.argv[++index];
+    const parsed = value ? new Date(value) : new Date(Number.NaN);
+    if (!Number.isFinite(parsed.getTime()))
+      usage();
+    since = parsed;
+  } else if (argument === "--help" || argument === "-h") {
+    usage();
+  } else {
+    usage();
+  }
+}
+try {
+  const report = readExperienceTrendReport({ since });
+  if (json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}
+`);
+  } else {
+    process.stdout.write(`Experience trends (new since ${report.since})
+`);
+    process.stdout.write(`Report generated at ${report.generatedAt}; pass this value to --since next time.
+`);
+    process.stdout.write("\nFamilies by frequency\n");
+    if (report.families.length === 0)
+      process.stdout.write("  none\n");
+    for (const family of report.families) {
+      process.stdout.write(`  ${family.classification}: ${family.count} occurrence(s), ${family.patterns} pattern(s)
+`);
+    }
+    process.stdout.write("\nNew since previous report\n");
+    if (report.newSincePreviousReport.length === 0)
+      process.stdout.write("  none\n");
+    for (const item of report.newSincePreviousReport) {
+      process.stdout.write(`  ${item.classification} ${item.tool}: ${item.count} (${item.signature.slice(0, 12)})
+`);
+    }
+    process.stdout.write("\nRecurring\n");
+    if (report.recurring.length === 0)
+      process.stdout.write("  none\n");
+    for (const item of report.recurring) {
+      process.stdout.write(`  ${item.classification} ${item.tool}: ${item.count} (${item.signature.slice(0, 12)})
+`);
+    }
+  }
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`rn-experience-trends: could not read the local evidence store: ${message}
+`);
+  process.exitCode = 1;
+}

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -79433,7 +79433,7 @@ var REDACTION_RULES = [
   [/(com|org|io|dev|net)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_.-]+/g, "[BUNDLE_REDACTED]"]
 ];
 var KEYED_SECRET = /((?:token|secret|password|auth|api[_-]?key)\s*[:=]\s*)[^\s,;}]{6,}/gi;
-var SANITIZED_RECORDS = /* @__PURE__ */ new WeakSet();
+var REDACTION_RULES_VERSION = 1;
 function sanitizeString(value, redact2 = applyRedactionRules) {
   try {
     return redact2(value);
@@ -79474,17 +79474,25 @@ function applyRedactionRules(value) {
 var appIdentityCache = null;
 function readAppIdentity() {
   const root = process.env.RN_PROJECT_ROOT ?? process.env.CLAUDE_USER_CWD ?? process.cwd();
-  if (appIdentityCache?.root === root)
-    return appIdentityCache.identity;
+  if (appIdentityCache?.root !== root) {
+    appIdentityCache = { root, identity: loadAppIdentity(root) };
+  }
+  if (appIdentityCache.identity === null) {
+    throw new Error("app identity could not be read for redaction");
+  }
+  return appIdentityCache.identity;
+}
+function loadAppIdentity(root) {
   const manifest = join44(root, "app.json");
-  let identity2 = { name: null, slug: null };
-  if (existsSync35(manifest)) {
+  try {
+    if (!existsSync35(manifest))
+      return { name: null, slug: null };
     const parsed = JSON.parse(readFileSync33(manifest, "utf8"));
     const expo = parsed.expo ?? parsed;
-    identity2 = { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
+    return { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
+  } catch {
+    return null;
   }
-  appIdentityCache = { root, identity: identity2 };
-  return identity2;
 }
 function usableIdentity(value) {
   return typeof value === "string" && value.trim().length > 2 ? value : null;
@@ -79602,11 +79610,10 @@ var ExperienceRecorder = class {
       firstSeen: now,
       lastSeen: now,
       lastRecoveredAt: null,
-      unknownReasons
+      unknownReasons,
+      redactionVersion: REDACTION_RULES_VERSION
     };
-    const sanitized = sanitizeForEvidence(raw);
-    SANITIZED_RECORDS.add(sanitized);
-    return sanitized;
+    return sanitizeForEvidence(raw);
   }
   persistFailure(incoming) {
     const records = readExperienceStore(this.path);
@@ -79621,7 +79628,6 @@ var ExperienceRecorder = class {
       existing.symptom = incoming.symptom;
       existing.candidate = incoming.candidate;
       existing.environment = incoming.environment;
-      adoptLateFact(existing, incoming, "platform");
       adoptLateFact(existing, incoming, "device");
       adoptLateFact(existing, incoming, "runtime");
       existing.evidencePointers = boundedPointers(existing.evidencePointers, incoming.evidencePointers);
@@ -79649,7 +79655,10 @@ var ExperienceRecorder = class {
     mkdirSync20(this.directory, { recursive: true, mode: 448 });
     const temp = join44(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID8()}`);
     try {
-      const sanitized = records.map((record2) => SANITIZED_RECORDS.has(record2) ? record2 : sanitizeForEvidence(record2));
+      const sanitized = records.map((record2) => record2.redactionVersion === REDACTION_RULES_VERSION ? record2 : {
+        ...sanitizeForEvidence(record2),
+        redactionVersion: REDACTION_RULES_VERSION
+      });
       const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
       writeFileSync19(temp, contents.length > 0 ? `${contents}
 ` : "", {
@@ -79704,7 +79713,6 @@ function readExperienceStore(path) {
     } catch {
       continue;
     }
-    SANITIZED_RECORDS.add(parsed);
     records.push(parsed);
   }
   return records;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -79404,8 +79404,10 @@ var DEFAULT_RETENTION_DAYS = 14;
 var MAX_EVIDENCE_POINTERS = 3;
 var EXPERIENCE_DIRECTORY = join44(homedir11(), ".claude", "rn-agent", "experience");
 var EXPERIENCE_STORE_NAME = "patterns.jsonl";
+var MAX_SYMPTOM_LENGTH = 2048;
 var DAY_MS = 24 * 60 * 60 * 1e3;
 var REDACTION_FAILED = "[REDACTION_FAILED]";
+var SYMPTOM_TRUNCATED = "[TRUNCATED]";
 var REDACTION_RULES = [
   [/(sk|pk|api|key|token|secret|password|auth)[-_]?[A-Za-z0-9_-]{20,}/gi, "[REDACTED_SECRET]"],
   [/Bearer [A-Za-z0-9_./+=-]{20,}/g, "Bearer [REDACTED]"],
@@ -79431,6 +79433,7 @@ var REDACTION_RULES = [
   [/(com|org|io|dev|net)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_.-]+/g, "[BUNDLE_REDACTED]"]
 ];
 var KEYED_SECRET = /((?:token|secret|password|auth|api[_-]?key)\s*[:=]\s*)[^\s,;}]{6,}/gi;
+var SANITIZED_RECORDS = /* @__PURE__ */ new WeakSet();
 function sanitizeString(value, redact2 = applyRedactionRules) {
   try {
     return redact2(value);
@@ -79461,7 +79464,30 @@ function applyRedactionRules(value) {
     pattern.lastIndex = 0;
     result = result.replace(pattern, replacement);
   }
+  const identity2 = readAppIdentity();
+  if (identity2.name)
+    result = result.replaceAll(identity2.name, "[APP_NAME_REDACTED]");
+  if (identity2.slug)
+    result = result.replaceAll(identity2.slug, "[APP_SLUG_REDACTED]");
   return result;
+}
+var appIdentityCache = null;
+function readAppIdentity() {
+  const root = process.env.RN_PROJECT_ROOT ?? process.env.CLAUDE_USER_CWD ?? process.cwd();
+  if (appIdentityCache?.root === root)
+    return appIdentityCache.identity;
+  const manifest = join44(root, "app.json");
+  let identity2 = { name: null, slug: null };
+  if (existsSync35(manifest)) {
+    const parsed = JSON.parse(readFileSync33(manifest, "utf8"));
+    const expo = parsed.expo ?? parsed;
+    identity2 = { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
+  }
+  appIdentityCache = { root, identity: identity2 };
+  return identity2;
+}
+function usableIdentity(value) {
+  return typeof value === "string" && value.trim().length > 2 ? value : null;
 }
 var ExperienceRecorder = class {
   directory;
@@ -79526,7 +79552,7 @@ var ExperienceRecorder = class {
   buildFailureRecord(event) {
     const now = this.now().toISOString();
     const tool = sanitizeString(event.tool);
-    const symptom = sanitizeString(extractSymptom(event));
+    const symptom = sanitizeString(boundSymptom(extractSymptom(event)));
     const platform = sanitizeNullable(extractScalar(event, ["platform"]));
     const deviceName = extractScalar(event, ["deviceName", "deviceModel", "model"]);
     const hasDeviceId = extractScalar(event, ["deviceId", "udid"]) !== null;
@@ -79578,18 +79604,26 @@ var ExperienceRecorder = class {
       lastRecoveredAt: null,
       unknownReasons
     };
-    return sanitizeForEvidence(raw);
+    const sanitized = sanitizeForEvidence(raw);
+    SANITIZED_RECORDS.add(sanitized);
+    return sanitized;
   }
   persistFailure(incoming) {
-    const records = readExperienceStore(this.path, true);
+    const records = readExperienceStore(this.path);
     const existing = records.find((record2) => record2.signature === incoming.signature);
     if (existing) {
       existing.count += 1;
       existing.lastSeen = incoming.lastSeen;
-      existing.status = incoming.status;
+      if (incoming.status === "ERROR" && existing.status !== "ERROR") {
+        existing.status = "ERROR";
+        existing.trigger = incoming.trigger;
+      }
       existing.symptom = incoming.symptom;
       existing.candidate = incoming.candidate;
       existing.environment = incoming.environment;
+      adoptLateFact(existing, incoming, "platform");
+      adoptLateFact(existing, incoming, "device");
+      adoptLateFact(existing, incoming, "runtime");
       existing.evidencePointers = boundedPointers(existing.evidencePointers, incoming.evidencePointers);
     } else {
       records.push(incoming);
@@ -79597,7 +79631,7 @@ var ExperienceRecorder = class {
     this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
   }
   persistRecovery(signature, tool) {
-    const records = readExperienceStore(this.path, true);
+    const records = readExperienceStore(this.path);
     const existing = records.find((record2) => record2.signature === signature);
     if (!existing)
       return;
@@ -79615,7 +79649,7 @@ var ExperienceRecorder = class {
     mkdirSync20(this.directory, { recursive: true, mode: 448 });
     const temp = join44(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID8()}`);
     try {
-      const sanitized = records.map((record2) => sanitizeForEvidence(record2));
+      const sanitized = records.map((record2) => SANITIZED_RECORDS.has(record2) ? record2 : sanitizeForEvidence(record2));
       const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
       writeFileSync19(temp, contents.length > 0 ? `${contents}
 ` : "", {
@@ -79654,16 +79688,26 @@ function discoverPluginVersion(fromUrl = import.meta.url) {
   }
   return null;
 }
-function readExperienceStore(path, allowMissing = false) {
-  if (!existsSync35(path)) {
-    if (allowMissing)
-      return [];
+function readExperienceStore(path) {
+  if (!existsSync35(path))
     return [];
-  }
   const contents = readFileSync33(path, "utf8");
   if (!contents.trim())
     return [];
-  return contents.split("\n").filter((line) => line.trim().length > 0).map((line) => JSON.parse(line));
+  const records = [];
+  for (const line of contents.split("\n")) {
+    if (line.trim().length === 0)
+      continue;
+    let parsed;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    SANITIZED_RECORDS.add(parsed);
+    records.push(parsed);
+  }
+  return records;
 }
 function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, retentionMs = DEFAULT_RETENTION_DAYS * DAY_MS) {
   const cutoff = now.getTime() - retentionMs;
@@ -79683,54 +79727,49 @@ function experienceSignature(input) {
 function normalizeSymptomShape(symptom) {
   return symptom.toLowerCase().replace(/[0-9a-f]{8}-[0-9a-f-]{27,}/gi, "<id>").replace(/\b0x[0-9a-f]+\b/gi, "<hex>").replace(/\b(?=[a-z0-9_-]{12,}\b)(?=[a-z0-9_-]*\d)[a-z0-9_-]+\b/gi, "<id>").replace(/\b\d+\b/g, "#").replace(/\s+/g, " ").trim();
 }
+var CLASSIFICATION_RULES = [
+  ["FF_REDBOX", /redbox|logbox|error overlay|hasredbox/],
+  ["FF_DEBUGGER_PAUSED", /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
+  [
+    "FF_STALE_CDP",
+    /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/
+  ],
+  ["FF_FAST_REFRESH_STALE", /fast refresh|ui unchanged|old exports|old module path/],
+  ["FF_METRO_CACHE", /metro.*(?:stale|cache)|config change not reflected/],
+  [
+    "FF_BINARY_MISMATCH",
+    /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/
+  ],
+  ["FF_EXPO_DIALOG", /open-in-app|system confirmation dialog/],
+  ["FF_DEV_CLIENT_PICKER", /no hermes target|development servers|devclientlauncher|server picker/],
+  ["FF_KEYBOARD_OVERLAY", /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
+  ["FF_MAESTRO_GRPC_ANDROID", /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
+  [
+    "FF_ANDROID_TEXT_INPUT_CRASH",
+    /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/
+  ],
+  ["FF_AUTH_GATE", /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/],
+  [
+    "FF_PERMISSION_ALREADY_GRANTED",
+    /permission already granted|prompt (?:was )?not shown|flow completes instantly/
+  ],
+  ["EG_EXPO_GO_SDK_MISMATCH", /incompatible with this version of expo go|expo go sdk.*mismatch/],
+  ["EG_NATIVEWIND_JSX_SOURCE", /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
+  ["EG_EXPO_GO_NATIVE_MODULES", /expo go.*custom native module/],
+  ["EG_DEV_CLIENT_CLEARSTATE", /clearstate.*(?:dev client|metro connection|launcher)/],
+  ["EG_MSW_HERMES", /msw.*(?:hermes|react native|initialize)/],
+  ["EG_EXPO_ROUTER_DEEP_LINK", /expo router.*deep link|deep link.*confirmation dialog/],
+  ["EG_DEV_MENU_INTERFERENCE", /dev menu.*(?:overlay|recording|blocking)/],
+  ["EG_NEW_ARCH_CDP_TARGET", /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
+  ["PQ_IOS_RECORDVIDEO_CODEC", /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
+  ["PQ_ANDROID_SCREENRECORD_LIMIT", /screenrecord.*180|screenrecord.*3 minute/],
+  ["PQ_ANDROID_BOOT_DELAY", /sys\.boot_completed|emulator.*grpc.*ready/],
+  ["PQ_ANDROID_PLAY_PROTECT", /play protect.*(?:block|apk|install)/]
+];
+var EXPERIENCE_FAMILY_IDS = CLASSIFICATION_RULES.map(([id]) => id);
 function classifyExperience(symptom, tool, platform) {
   const haystack = `${tool} ${platform ?? ""} ${symptom}`.toLowerCase();
-  const rules = [
-    ["FF_REDBOX", /redbox|logbox|error overlay|hasredbox/],
-    ["FF_DEBUGGER_PAUSED", /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
-    [
-      "FF_STALE_CDP",
-      /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/
-    ],
-    ["FF_FAST_REFRESH_STALE", /fast refresh|ui unchanged|old exports|old module path/],
-    ["FF_METRO_CACHE", /metro.*(?:stale|cache)|config change not reflected/],
-    [
-      "FF_BINARY_MISMATCH",
-      /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/
-    ],
-    ["FF_EXPO_DIALOG", /open-in-app|system confirmation dialog/],
-    [
-      "FF_DEV_CLIENT_PICKER",
-      /no hermes target|development servers|devclientlauncher|server picker/
-    ],
-    ["FF_KEYBOARD_OVERLAY", /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
-    ["FF_MAESTRO_GRPC_ANDROID", /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
-    [
-      "FF_ANDROID_TEXT_INPUT_CRASH",
-      /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/
-    ],
-    [
-      "FF_AUTH_GATE",
-      /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/
-    ],
-    [
-      "FF_PERMISSION_ALREADY_GRANTED",
-      /permission already granted|prompt (?:was )?not shown|flow completes instantly/
-    ],
-    ["EG_EXPO_GO_SDK_MISMATCH", /incompatible with this version of expo go|expo go sdk.*mismatch/],
-    ["EG_NATIVEWIND_JSX_SOURCE", /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
-    ["EG_EXPO_GO_NATIVE_MODULES", /expo go.*custom native module/],
-    ["EG_DEV_CLIENT_CLEARSTATE", /clearstate.*(?:dev client|metro connection|launcher)/],
-    ["EG_MSW_HERMES", /msw.*(?:hermes|react native|initialize)/],
-    ["EG_EXPO_ROUTER_DEEP_LINK", /expo router.*deep link|deep link.*confirmation dialog/],
-    ["EG_DEV_MENU_INTERFERENCE", /dev menu.*(?:overlay|recording|blocking)/],
-    ["EG_NEW_ARCH_CDP_TARGET", /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
-    ["PQ_IOS_RECORDVIDEO_CODEC", /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
-    ["PQ_ANDROID_SCREENRECORD_LIMIT", /screenrecord.*180|screenrecord.*3 minute/],
-    ["PQ_ANDROID_BOOT_DELAY", /sys\.boot_completed|emulator.*grpc.*ready/],
-    ["PQ_ANDROID_PLAY_PROTECT", /play protect.*(?:block|apk|install)/]
-  ];
-  return rules.find(([, pattern]) => pattern.test(haystack))?.[0] ?? UNKNOWN_CLASSIFICATION;
+  return CLASSIFICATION_RULES.find(([, pattern]) => pattern.test(haystack))?.[0] ?? UNKNOWN_CLASSIFICATION;
 }
 function extractSymptom(event) {
   if (typeof event.error === "string" && event.error.length > 0)
@@ -79747,6 +79786,12 @@ function extractSymptom(event) {
     }
   }
   return `${event.tool} reported ${event.status} without an error message`;
+}
+function boundSymptom(symptom) {
+  if (symptom.length <= MAX_SYMPTOM_LENGTH)
+    return symptom;
+  const head = symptom.slice(0, MAX_SYMPTOM_LENGTH).replace(/\S+$/, "");
+  return `${head}${SYMPTOM_TRUNCATED}`;
 }
 function extractScalar(event, keys) {
   const sources = [event.params, event.result];
@@ -79777,6 +79822,12 @@ function findScalar(value, keys, depth) {
 }
 function sanitizeNullable(value) {
   return value === null ? null : sanitizeString(value);
+}
+function adoptLateFact(existing, incoming, field2) {
+  if (existing[field2] !== null || incoming[field2] === null)
+    return;
+  existing[field2] = incoming[field2];
+  delete existing.unknownReasons[field2];
 }
 function boundedPointers(existing, incoming) {
   return [.../* @__PURE__ */ new Set([...existing, ...incoming])].slice(-MAX_EVIDENCE_POINTERS);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -9244,7 +9244,7 @@ var require_websocket = __commonJS({
     var http = __require("http");
     var net = __require("net");
     var tls = __require("tls");
-    var { randomBytes: randomBytes8, createHash: createHash21 } = __require("crypto");
+    var { randomBytes: randomBytes8, createHash: createHash22 } = __require("crypto");
     var { Duplex, Readable } = __require("stream");
     var { URL: URL2 } = __require("url");
     var PerMessageDeflate2 = require_permessage_deflate();
@@ -9912,7 +9912,7 @@ var require_websocket = __commonJS({
           abortHandshake(websocket, socket, "Invalid Upgrade header");
           return;
         }
-        const digest3 = createHash21("sha1").update(key + GUID).digest("base64");
+        const digest3 = createHash22("sha1").update(key + GUID).digest("base64");
         if (res.headers["sec-websocket-accept"] !== digest3) {
           abortHandshake(websocket, socket, "Invalid Sec-WebSocket-Accept header");
           return;
@@ -10281,7 +10281,7 @@ var require_websocket_server = __commonJS({
     var EventEmitter = __require("events");
     var http = __require("http");
     var { Duplex } = __require("stream");
-    var { createHash: createHash21 } = __require("crypto");
+    var { createHash: createHash22 } = __require("crypto");
     var extension2 = require_extension();
     var PerMessageDeflate2 = require_permessage_deflate();
     var subprotocol2 = require_subprotocol();
@@ -10588,7 +10588,7 @@ var require_websocket_server = __commonJS({
           );
         }
         if (this._state > RUNNING) return abortHandshake(socket, 503);
-        const digest3 = createHash21("sha1").update(key + GUID).digest("base64");
+        const digest3 = createHash22("sha1").update(key + GUID).digest("base64");
         const headers = [
           "HTTP/1.1 101 Switching Protocols",
           "Upgrade: websocket",
@@ -26328,13 +26328,13 @@ function consumePendingAndroidUpgradeNote() {
   pendingUpgradeNote = void 0;
   return note;
 }
-async function reapMismatchedAndroidRunner(state, release, verify, signal) {
+async function reapMismatchedAndroidRunner(state, release2, verify, signal) {
   signal?.throwIfAborted();
   const deviceId = state?.deviceId;
   if (!deviceId) {
     throw new Error("RUNNER_CLEANUP_UNCONFIRMED: stale Android runner has no recorded device identity");
   }
-  const releaseSlot = release ?? (async (opts) => {
+  const releaseSlot = release2 ?? (async (opts) => {
     const { releaseAndroidInteractionSlot: releaseAndroidInteractionSlot2 } = await Promise.resolve().then(() => (init_release_android_slot(), release_android_slot_exports));
     return releaseAndroidInteractionSlot2({ ...opts, signal });
   });
@@ -26348,7 +26348,7 @@ async function reapMismatchedAndroidRunner(state, release, verify, signal) {
   if (!receipt2.stoppedOwnRunner || missingPackages.length > 0) {
     throw new Error(`RUNNER_CLEANUP_UNCONFIRMED: stale Android runner cleanup failed for ${deviceId}`);
   }
-  const verifyReleased = verify ?? (release ? async () => {
+  const verifyReleased = verify ?? (release2 ? async () => {
   } : async (expected) => {
     const forwards = String((await execFileAsync2("adb", ["forward", "--list"], {
       timeout: ADB_CLEANUP_TIMEOUT_MS,
@@ -26536,7 +26536,7 @@ async function runBoundedAndroidRunnerRebuild(error2, rebuild, cleanup, dependen
   const heartbeat = dependencies.heartbeat ?? heartbeatAndroidRunnerRebuildLock;
   const complete = dependencies.complete ?? completeAndroidRunnerRebuildLock;
   const beginCleanup = dependencies.beginCleanup ?? beginAndroidRunnerRebuildCleanup;
-  const release = dependencies.release ?? releaseAndroidRunnerRebuildLock;
+  const release2 = dependencies.release ?? releaseAndroidRunnerRebuildLock;
   const markCleanupUnverified = dependencies.markCleanupUnverified ?? markAndroidRunnerRebuildCleanupUnverified;
   const controller = new AbortController();
   let cleanupController;
@@ -26632,7 +26632,7 @@ async function runBoundedAndroidRunnerRebuild(error2, rebuild, cleanup, dependen
     }
     clearTimeout(cleanupTimer);
     cleanupController = void 0;
-    const terminalPersisted = await persistTransition(cleanupVerified ? release : markCleanupUnverified);
+    const terminalPersisted = await persistTransition(cleanupVerified ? release2 : markCleanupUnverified);
     clearInterval(heartbeatTimer2);
     if (!terminalPersisted) {
       throw leaseAuthorityLost ? controller.signal.reason : androidRebuildRefusal(error2, "runner artifact failure state was not durable");
@@ -27847,7 +27847,7 @@ async function rebuildStaleRunnerArtifact(first, deviceId, bundleId, deps) {
       message: "another session is rebuilding the shared runner artifact \u2014 retry this open in a few minutes."
     };
   }
-  const release = deps.releaseBuildLock ?? releaseRunnerRebuildLock;
+  const release2 = deps.releaseBuildLock ?? releaseRunnerRebuildLock;
   try {
     const reap = deps.reap ?? reapStaleFastRunner;
     await reap();
@@ -27861,7 +27861,7 @@ async function rebuildStaleRunnerArtifact(first, deviceId, bundleId, deps) {
       ...deps.attachOnly === true ? { attachOnly: true } : {}
     });
   } finally {
-    release();
+    release2();
   }
   const probe = deps.probe ?? probeFastRunnerLivenessDetailed;
   const rebuilt = await probe();
@@ -31187,8 +31187,8 @@ async function runFlowParked(run, opts = {}) {
   const stale = opts.markCdpStale ?? markCdpStale;
   try {
     if (opts.platform === "android") {
-      const release = opts.releaseAndroidSlot ?? releaseAndroidInteractionSlot;
-      await release({ deviceId: opts.deviceId });
+      const release2 = opts.releaseAndroidSlot ?? releaseAndroidInteractionSlot;
+      await release2({ deviceId: opts.deviceId });
     } else {
       await (opts.stopFastRunner ?? stopFastRunner)(opts.deviceId);
     }
@@ -35391,12 +35391,12 @@ ensureJavaEnv();
 ensureCwd();
 
 // packages/rn-dev-agent-core/dist/index.js
-import { createHash as createHash20, createHmac as createHmac5, randomUUID as randomUUID8 } from "node:crypto";
-import { readFileSync as readFileSync40, rmSync as rmSync11 } from "node:fs";
+import { createHash as createHash21, createHmac as createHmac5, randomUUID as randomUUID9 } from "node:crypto";
+import { readFileSync as readFileSync41, rmSync as rmSync11 } from "node:fs";
 import { execFile as execFile26 } from "node:child_process";
 import { promisify as promisify28 } from "node:util";
-import { fileURLToPath as fileURLToPath6 } from "node:url";
-import { dirname as dirname22, join as join54 } from "node:path";
+import { fileURLToPath as fileURLToPath7 } from "node:url";
+import { dirname as dirname23, join as join55 } from "node:path";
 
 // node_modules/zod/v3/external.js
 var external_exports = {};
@@ -79392,8 +79392,398 @@ function instrumentTool(toolName, handler) {
   };
 }
 
+// packages/rn-dev-agent-core/dist/experience/evidence.js
+import { createHash as createHash17, randomUUID as randomUUID8 } from "node:crypto";
+import { chmodSync as chmodSync5, existsSync as existsSync35, mkdirSync as mkdirSync20, readFileSync as readFileSync33, renameSync as renameSync8, unlinkSync as unlinkSync12, writeFileSync as writeFileSync19 } from "node:fs";
+import { homedir as homedir11, platform as hostPlatform, release } from "node:os";
+import { dirname as dirname19, join as join44 } from "node:path";
+import { fileURLToPath as fileURLToPath5 } from "node:url";
+var UNKNOWN_CLASSIFICATION = "UNKNOWN";
+var DEFAULT_MAX_RECORDS = 500;
+var DEFAULT_RETENTION_DAYS = 14;
+var MAX_EVIDENCE_POINTERS = 3;
+var EXPERIENCE_DIRECTORY = join44(homedir11(), ".claude", "rn-agent", "experience");
+var EXPERIENCE_STORE_NAME = "patterns.jsonl";
+var DAY_MS = 24 * 60 * 60 * 1e3;
+var REDACTION_FAILED = "[REDACTION_FAILED]";
+var REDACTION_RULES = [
+  [/(sk|pk|api|key|token|secret|password|auth)[-_]?[A-Za-z0-9_-]{20,}/gi, "[REDACTED_SECRET]"],
+  [/Bearer [A-Za-z0-9_./+=-]{20,}/g, "Bearer [REDACTED]"],
+  [/ghp_[A-Za-z0-9_]{36}/g, "[REDACTED_GH_TOKEN]"],
+  [/eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g, "[REDACTED_JWT]"],
+  [/AKIA[0-9A-Z]{16}/g, "[REDACTED_AWS]"],
+  [/xox[baprs]-[A-Za-z0-9-]+/g, "[REDACTED_SLACK]"],
+  [/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, "[EMAIL_REDACTED]"],
+  [
+    /(^|[^0-9])(192|10|172|169)\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}([^0-9]|$)/g,
+    "$1[IP_REDACTED]$3"
+  ],
+  [/(^|[^0-9])[0-9]{1,3}(?:\.[0-9]{1,3}){3}([^0-9]|$)/g, "$1[IP_REDACTED]$2"],
+  [
+    /(?:https?:\/\/)?(?:localhost|127\.0\.0\.1)(?::[0-9]{2,5})?(?:\/[^\s]*)?/gi,
+    "[LOOPBACK_ENDPOINT_REDACTED]"
+  ],
+  [/"(metroPort|observePort|port)"\s*:\s*[0-9]+/g, '"$1":"[PORT_REDACTED]"'],
+  [/\bport\s*[:=]?\s*[0-9]{2,5}\b/gi, "[PORT_REDACTED]"],
+  [/:([0-9]{2,5})(?=\/|\s|$)/g, ":[PORT_REDACTED]"],
+  [/~\/[A-Za-z0-9_./-]+/g, "[PATH_REDACTED]"],
+  [/\/(Users|home|opt|var|tmp|etc|private|Volumes)\/[A-Za-z0-9_./-]+/g, "[PATH_REDACTED]"],
+  [/(com|org|io|dev|net)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_.-]+/g, "[BUNDLE_REDACTED]"]
+];
+var KEYED_SECRET = /((?:token|secret|password|auth|api[_-]?key)\s*[:=]\s*)[^\s,;}]{6,}/gi;
+function sanitizeString(value, redact2 = applyRedactionRules) {
+  try {
+    return redact2(value);
+  } catch {
+    return REDACTION_FAILED;
+  }
+}
+function sanitizeForEvidence(value, redact2) {
+  if (value === null || value === void 0 || typeof value === "boolean" || typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "string")
+    return sanitizeString(value, redact2);
+  if (Array.isArray(value))
+    return value.map((item) => sanitizeForEvidence(item, redact2));
+  if (typeof value === "object") {
+    const sanitized = {};
+    for (const [key, nested] of Object.entries(value)) {
+      sanitized[key] = sanitizeForEvidence(nested, redact2);
+    }
+    return sanitized;
+  }
+  return REDACTION_FAILED;
+}
+function applyRedactionRules(value) {
+  let result = value.replaceAll(homedir11(), "~").replace(KEYED_SECRET, "$1[REDACTED_SECRET]");
+  for (const [pattern, replacement] of REDACTION_RULES) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}
+var ExperienceRecorder = class {
+  directory;
+  path;
+  candidate;
+  environment;
+  maxRecords;
+  retentionMs;
+  now;
+  schedule;
+  previousFailure = null;
+  constructor(options) {
+    this.directory = options.directory ?? process.env.RN_DEV_AGENT_EXPERIENCE_DIR ?? EXPERIENCE_DIRECTORY;
+    this.path = join44(this.directory, EXPERIENCE_STORE_NAME);
+    this.candidate = {
+      pluginVersion: options.pluginVersion ?? null,
+      coreVersion: options.coreVersion
+    };
+    this.environment = { os: `${hostPlatform()} ${release()}`, node: process.version };
+    this.maxRecords = options.maxRecords ?? DEFAULT_MAX_RECORDS;
+    this.retentionMs = (options.retentionDays ?? DEFAULT_RETENTION_DAYS) * DAY_MS;
+    this.now = options.now ?? (() => /* @__PURE__ */ new Date());
+    this.schedule = options.schedule ?? ((work) => setImmediate(work));
+  }
+  /** Queue only: persistence never executes in the observed tool's call stack. */
+  observe(event) {
+    try {
+      this.schedule(() => this.recordNonLoadBearing(event));
+    } catch {
+    }
+  }
+  /** Test and CLI support; returns a sanitized, deduplicated view. */
+  read() {
+    return readExperienceStore(this.path);
+  }
+  recordNonLoadBearing(event) {
+    try {
+      this.record(event);
+    } catch {
+    }
+  }
+  record(event) {
+    if (!event || typeof event.tool !== "string") {
+      this.previousFailure = null;
+      return;
+    }
+    if (event.status === "PASS") {
+      const recovery = this.previousFailure;
+      this.previousFailure = null;
+      if (recovery?.tool === event.tool)
+        this.persistRecovery(recovery.signature, event.tool);
+      return;
+    }
+    if (event.status !== "FAIL" && event.status !== "ERROR") {
+      this.previousFailure = null;
+      return;
+    }
+    const record2 = this.buildFailureRecord(event);
+    this.persistFailure(record2);
+    this.previousFailure = event.status === "FAIL" ? { tool: event.tool, signature: record2.signature } : null;
+  }
+  buildFailureRecord(event) {
+    const now = this.now().toISOString();
+    const tool = sanitizeString(event.tool);
+    const symptom = sanitizeString(extractSymptom(event));
+    const platform = sanitizeNullable(extractScalar(event, ["platform"]));
+    const deviceName = extractScalar(event, ["deviceName", "deviceModel", "model"]);
+    const hasDeviceId = extractScalar(event, ["deviceId", "udid"]) !== null;
+    const device = sanitizeNullable(deviceName ?? (hasDeviceId ? "identified-device" : null));
+    const runtime = sanitizeNullable(extractScalar(event, ["runtime", "engine"]));
+    const classification = classifyExperience(symptom, tool, platform);
+    const normalizedSymptomShape = normalizeSymptomShape(symptom);
+    const signature = experienceSignature({
+      classification,
+      tool,
+      normalizedSymptomShape,
+      platform
+    });
+    const unknownReasons = {};
+    if (this.candidate.pluginVersion === null) {
+      unknownReasons["candidate.pluginVersion"] = "plugin manifest was not available to the core runtime";
+    }
+    if (platform === null)
+      unknownReasons.platform = "tool event did not expose a platform";
+    if (device === null)
+      unknownReasons.device = "tool event did not expose a device name or identifier";
+    if (runtime === null)
+      unknownReasons.runtime = "tool event did not expose a runtime";
+    unknownReasons.maskingCondition = "not derivable from a single tool event";
+    unknownReasons.recovery = "no immediate successful retry has been observed";
+    unknownReasons.cleanup = "tool events do not report cleanup actions";
+    const raw = {
+      signature,
+      candidate: this.candidate,
+      environment: this.environment,
+      platform,
+      device,
+      runtime,
+      phase: "tool",
+      trigger: `${event.status} reported by ${tool}`,
+      maskingCondition: null,
+      symptom,
+      recovery: null,
+      cleanup: null,
+      classification,
+      evidencePointers: [`event:${randomUUID8()}`],
+      tool,
+      status: event.status === "ERROR" ? "ERROR" : "FAIL",
+      normalizedSymptomShape,
+      count: 1,
+      recoveryCount: 0,
+      firstSeen: now,
+      lastSeen: now,
+      lastRecoveredAt: null,
+      unknownReasons
+    };
+    return sanitizeForEvidence(raw);
+  }
+  persistFailure(incoming) {
+    const records = readExperienceStore(this.path, true);
+    const existing = records.find((record2) => record2.signature === incoming.signature);
+    if (existing) {
+      existing.count += 1;
+      existing.lastSeen = incoming.lastSeen;
+      existing.status = incoming.status;
+      existing.symptom = incoming.symptom;
+      existing.candidate = incoming.candidate;
+      existing.environment = incoming.environment;
+      existing.evidencePointers = boundedPointers(existing.evidencePointers, incoming.evidencePointers);
+    } else {
+      records.push(incoming);
+    }
+    this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
+  }
+  persistRecovery(signature, tool) {
+    const records = readExperienceStore(this.path, true);
+    const existing = records.find((record2) => record2.signature === signature);
+    if (!existing)
+      return;
+    const now = this.now().toISOString();
+    existing.recovery = sanitizeString(`PASS immediately followed FAIL for ${tool}`);
+    existing.recoveryCount += 1;
+    existing.lastRecoveredAt = now;
+    delete existing.unknownReasons.recovery;
+    existing.evidencePointers = boundedPointers(existing.evidencePointers, [
+      `event:${randomUUID8()}`
+    ]);
+    this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
+  }
+  write(records) {
+    mkdirSync20(this.directory, { recursive: true, mode: 448 });
+    const temp = join44(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID8()}`);
+    try {
+      const sanitized = records.map((record2) => sanitizeForEvidence(record2));
+      const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
+      writeFileSync19(temp, contents.length > 0 ? `${contents}
+` : "", {
+        encoding: "utf8",
+        flag: "wx",
+        mode: 384
+      });
+      renameSync8(temp, this.path);
+      chmodSync5(this.path, 384);
+    } catch (error2) {
+      try {
+        unlinkSync12(temp);
+      } catch {
+      }
+      throw error2;
+    }
+  }
+};
+function discoverPluginVersion(fromUrl = import.meta.url) {
+  if (process.env.RN_DEV_AGENT_PLUGIN_VERSION)
+    return process.env.RN_DEV_AGENT_PLUGIN_VERSION;
+  const start = dirname19(fileURLToPath5(fromUrl));
+  const candidates = [
+    join44(start, "..", "..", ".claude-plugin", "plugin.json"),
+    join44(start, "..", "..", ".codex-plugin", "plugin.json"),
+    join44(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
+    join44(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
+  ];
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(readFileSync33(candidate, "utf8"));
+      if (typeof parsed.version === "string")
+        return sanitizeString(parsed.version);
+    } catch {
+    }
+  }
+  return null;
+}
+function readExperienceStore(path, allowMissing = false) {
+  if (!existsSync35(path)) {
+    if (allowMissing)
+      return [];
+    return [];
+  }
+  const contents = readFileSync33(path, "utf8");
+  if (!contents.trim())
+    return [];
+  return contents.split("\n").filter((line) => line.trim().length > 0).map((line) => JSON.parse(line));
+}
+function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, retentionMs = DEFAULT_RETENTION_DAYS * DAY_MS) {
+  const cutoff = now.getTime() - retentionMs;
+  return records.filter((record2) => {
+    const lastSeen = Date.parse(record2.lastSeen);
+    return Number.isFinite(lastSeen) && lastSeen >= cutoff;
+  }).sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen) || a.signature.localeCompare(b.signature)).slice(0, Math.max(0, maxRecords)).sort((a, b) => a.signature.localeCompare(b.signature));
+}
+function experienceSignature(input) {
+  return createHash17("sha256").update(JSON.stringify([
+    input.classification,
+    input.tool,
+    input.normalizedSymptomShape,
+    input.platform ?? "unknown"
+  ])).digest("hex");
+}
+function normalizeSymptomShape(symptom) {
+  return symptom.toLowerCase().replace(/[0-9a-f]{8}-[0-9a-f-]{27,}/gi, "<id>").replace(/\b0x[0-9a-f]+\b/gi, "<hex>").replace(/\b(?=[a-z0-9_-]{12,}\b)(?=[a-z0-9_-]*\d)[a-z0-9_-]+\b/gi, "<id>").replace(/\b\d+\b/g, "#").replace(/\s+/g, " ").trim();
+}
+function classifyExperience(symptom, tool, platform) {
+  const haystack = `${tool} ${platform ?? ""} ${symptom}`.toLowerCase();
+  const rules = [
+    ["FF_REDBOX", /redbox|logbox|error overlay|hasredbox/],
+    ["FF_DEBUGGER_PAUSED", /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
+    [
+      "FF_STALE_CDP",
+      /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/
+    ],
+    ["FF_FAST_REFRESH_STALE", /fast refresh|ui unchanged|old exports|old module path/],
+    ["FF_METRO_CACHE", /metro.*(?:stale|cache)|config change not reflected/],
+    [
+      "FF_BINARY_MISMATCH",
+      /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/
+    ],
+    ["FF_EXPO_DIALOG", /open-in-app|system confirmation dialog/],
+    [
+      "FF_DEV_CLIENT_PICKER",
+      /no hermes target|development servers|devclientlauncher|server picker/
+    ],
+    ["FF_KEYBOARD_OVERLAY", /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
+    ["FF_MAESTRO_GRPC_ANDROID", /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
+    [
+      "FF_ANDROID_TEXT_INPUT_CRASH",
+      /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/
+    ],
+    [
+      "FF_AUTH_GATE",
+      /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/
+    ],
+    [
+      "FF_PERMISSION_ALREADY_GRANTED",
+      /permission already granted|prompt (?:was )?not shown|flow completes instantly/
+    ],
+    ["EG_EXPO_GO_SDK_MISMATCH", /incompatible with this version of expo go|expo go sdk.*mismatch/],
+    ["EG_NATIVEWIND_JSX_SOURCE", /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
+    ["EG_EXPO_GO_NATIVE_MODULES", /expo go.*custom native module/],
+    ["EG_DEV_CLIENT_CLEARSTATE", /clearstate.*(?:dev client|metro connection|launcher)/],
+    ["EG_MSW_HERMES", /msw.*(?:hermes|react native|initialize)/],
+    ["EG_EXPO_ROUTER_DEEP_LINK", /expo router.*deep link|deep link.*confirmation dialog/],
+    ["EG_DEV_MENU_INTERFERENCE", /dev menu.*(?:overlay|recording|blocking)/],
+    ["EG_NEW_ARCH_CDP_TARGET", /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
+    ["PQ_IOS_RECORDVIDEO_CODEC", /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
+    ["PQ_ANDROID_SCREENRECORD_LIMIT", /screenrecord.*180|screenrecord.*3 minute/],
+    ["PQ_ANDROID_BOOT_DELAY", /sys\.boot_completed|emulator.*grpc.*ready/],
+    ["PQ_ANDROID_PLAY_PROTECT", /play protect.*(?:block|apk|install)/]
+  ];
+  return rules.find(([, pattern]) => pattern.test(haystack))?.[0] ?? UNKNOWN_CLASSIFICATION;
+}
+function extractSymptom(event) {
+  if (typeof event.error === "string" && event.error.length > 0)
+    return event.error;
+  if (event.result && typeof event.result === "object") {
+    const envelope = event.result;
+    if (typeof envelope.error === "string")
+      return envelope.error;
+    const content = envelope.content;
+    if (Array.isArray(content)) {
+      const first = content[0];
+      if (typeof first?.text === "string")
+        return first.text;
+    }
+  }
+  return `${event.tool} reported ${event.status} without an error message`;
+}
+function extractScalar(event, keys) {
+  const sources = [event.params, event.result];
+  for (const source of sources) {
+    const value = findScalar(source, keys, 0);
+    if (value !== null)
+      return value;
+  }
+  return null;
+}
+function findScalar(value, keys, depth) {
+  if (!value || typeof value !== "object" || depth > 3)
+    return null;
+  const object3 = value;
+  for (const key of keys) {
+    const candidate = object3[key];
+    if (typeof candidate === "string" && candidate.length > 0)
+      return candidate;
+  }
+  for (const nested of Object.values(object3)) {
+    if (nested && typeof nested === "object") {
+      const found = findScalar(nested, keys, depth + 1);
+      if (found !== null)
+        return found;
+    }
+  }
+  return null;
+}
+function sanitizeNullable(value) {
+  return value === null ? null : sanitizeString(value);
+}
+function boundedPointers(existing, incoming) {
+  return [.../* @__PURE__ */ new Set([...existing, ...incoming])].slice(-MAX_EVIDENCE_POINTERS);
+}
+
 // packages/rn-dev-agent-core/dist/observability/live-device.js
-import { join as join44 } from "node:path";
+import { join as join45 } from "node:path";
 import { tmpdir as tmpdir13 } from "node:os";
 function isStateMutating(tool, args) {
   if (FLOW_MUTATION_TOOLS.has(tool))
@@ -79545,7 +79935,7 @@ function buildLiveDeps(input) {
     // iterable" when invoked as deps.pushLive(...). The live device gate caught
     // this — the unit fakes used standalone arrows and missed it.
     pushLive: (frame) => input.recorder.pushLive(frame),
-    tmpPath: () => join44(tmpdir13(), `rn-observe-live-${process.pid}.jpg`),
+    tmpPath: () => join45(tmpdir13(), `rn-observe-live-${process.pid}.jpg`),
     isMirrorActive: input.isMirrorActive
   };
 }
@@ -79559,9 +79949,9 @@ init_utils();
 
 // packages/rn-dev-agent-core/dist/observability/server.js
 import { createServer as createServer3 } from "node:http";
-import { readFileSync as readFileSync33 } from "node:fs";
-import { fileURLToPath as fileURLToPath5 } from "node:url";
-import { dirname as dirname19, join as join45 } from "node:path";
+import { readFileSync as readFileSync34 } from "node:fs";
+import { fileURLToPath as fileURLToPath6 } from "node:url";
+import { dirname as dirname20, join as join46 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/observability/e2e-csrf.js
 import { randomBytes as randomBytes6, timingSafeEqual as timingSafeEqual6 } from "node:crypto";
@@ -79594,7 +79984,7 @@ function isPostAllowed(req, token2) {
 // packages/rn-dev-agent-core/dist/observability/server.js
 init_logger();
 var HOST = "127.0.0.1";
-var __dir = dirname19(fileURLToPath5(import.meta.url));
+var __dir = dirname20(fileURLToPath6(import.meta.url));
 var ObservabilityServer = class {
   recorder;
   e2e;
@@ -79826,7 +80216,7 @@ var ObservabilityServer = class {
   }
   index(res) {
     try {
-      let html = readFileSync33(join45(__dir, "web-dist", "index.html"), "utf8");
+      let html = readFileSync34(join46(__dir, "web-dist", "index.html"), "utf8");
       if (this.e2e) {
         const tokenJs = JSON.stringify(this.e2e.token).replace(/</g, "\\u003c");
         html = html.replace("</head>", `<script>window.__E2E_CSRF__=${tokenJs}</script></head>`);
@@ -80010,10 +80400,10 @@ init_project_config();
 // packages/rn-dev-agent-core/dist/observability/observe-state.js
 init_secure_state_file();
 init_storage();
-import { join as join46 } from "node:path";
+import { join as join47 } from "node:path";
 function observeStatePath(projectRoot) {
   const safe = projectRoot.replace(/[^A-Za-z0-9._-]/g, "_");
-  return join46(getStateDir(), "observe", `${safe}.json`);
+  return join47(getStateDir(), "observe", `${safe}.json`);
 }
 function writeObserveState(url, port, projectRoot = findProjectRoot(), now = () => /* @__PURE__ */ new Date()) {
   try {
@@ -80239,7 +80629,7 @@ init_project_config();
 import { spawn as spawn9, execFile as execFile25 } from "node:child_process";
 import { readFile as readFile2, unlink } from "node:fs/promises";
 import { tmpdir as tmpdir14 } from "node:os";
-import { join as join47 } from "node:path";
+import { join as join48 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/observability/mirror/jpeg-stream.js
 var MAX_FRAME_BYTES = 8e6;
@@ -80402,7 +80792,7 @@ var IosSimctlLoopSource = class {
     this.gate = new RestartGate(3, 1e4, opts.now ?? Date.now);
     this.idleDelayMs = opts.idleDelayMs ?? 25;
     this.failurePauseMs = opts.failurePauseMs ?? 500;
-    this.tmpPath = opts.tmpPath ?? (() => join47(tmpdir14(), "rn-mirror-simctl-" + process.pid + ".jpg"));
+    this.tmpPath = opts.tmpPath ?? (() => join48(tmpdir14(), "rn-mirror-simctl-" + process.pid + ".jpg"));
     this.degradedHint = opts.degradedHint ?? SIMCTL_HINT;
   }
   start(sink) {
@@ -80842,20 +81232,20 @@ function buildMirrorTargetResolver(deps) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/lock-e2e-test.js
-import { readFileSync as readFileSync36 } from "node:fs";
+import { readFileSync as readFileSync37 } from "node:fs";
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
-import { dirname as dirname20, join as join48 } from "node:path";
-import { mkdirSync as mkdirSync20, writeFileSync as writeFileSync19, renameSync as renameSync8, readFileSync as readFileSync34, readdirSync as readdirSync12, existsSync as existsSync35 } from "node:fs";
-import { createHash as createHash17 } from "node:crypto";
+import { dirname as dirname21, join as join49 } from "node:path";
+import { mkdirSync as mkdirSync21, writeFileSync as writeFileSync20, renameSync as renameSync9, readFileSync as readFileSync35, readdirSync as readdirSync12, existsSync as existsSync36 } from "node:fs";
+import { createHash as createHash18 } from "node:crypto";
 var FLOW_SENTINEL = "# e2e-locked-flow-below";
 function e2eDirFor(projectRoot) {
-  return join48(projectRoot, ".rn-agent", "e2e");
+  return join49(projectRoot, ".rn-agent", "e2e");
 }
 function e2ePathFor(projectRoot, id) {
   assertValidActionId(id, "e2ePathFor");
   const dir = e2eDirFor(projectRoot);
-  const file = join48(dir, `${id}.yaml`);
+  const file = join49(dir, `${id}.yaml`);
   assertWithinDir(file, dir);
   return file;
 }
@@ -80879,11 +81269,11 @@ function serializeLockedTest(meta) {
 ${meta.flow}`;
 }
 function hashBody(s) {
-  return createHash17("sha256").update(s).digest("hex");
+  return createHash18("sha256").update(s).digest("hex");
 }
 function freezeLockedTest(projectRoot, source, ctx) {
   const filePath = e2ePathFor(projectRoot, source.id);
-  mkdirSync20(dirname20(filePath), { recursive: true });
+  mkdirSync21(dirname21(filePath), { recursive: true });
   const meta = {
     id: source.id,
     intent: source.intent,
@@ -80897,19 +81287,19 @@ function freezeLockedTest(projectRoot, source, ctx) {
     flow: source.flow
   };
   const tmp = `${filePath}.tmp`;
-  writeFileSync19(tmp, serializeLockedTest(meta), "utf8");
-  renameSync8(tmp, filePath);
+  writeFileSync20(tmp, serializeLockedTest(meta), "utf8");
+  renameSync9(tmp, filePath);
   return { ...meta, filePath };
 }
 function loadLockedTest(projectRoot, id) {
   const filePath = e2ePathFor(projectRoot, id);
-  if (!existsSync35(filePath))
+  if (!existsSync36(filePath))
     return null;
-  return parseLockedTest(readFileSync34(filePath, "utf8"), filePath);
+  return parseLockedTest(readFileSync35(filePath, "utf8"), filePath);
 }
 function discoverLockedTests(projectRoot) {
   const dir = e2eDirFor(projectRoot);
-  if (!existsSync35(dir))
+  if (!existsSync36(dir))
     return [];
   return readdirSync12(dir).filter((f) => f.endsWith(".yaml")).map((f) => f.replace(/\.yaml$/, "")).sort();
 }
@@ -80948,12 +81338,12 @@ function parseLockedTest(text, filePath) {
 }
 
 // packages/rn-dev-agent-core/dist/domain/e2e-config.js
-import { readFileSync as readFileSync35 } from "node:fs";
-import { join as join49 } from "node:path";
+import { readFileSync as readFileSync36 } from "node:fs";
+import { join as join50 } from "node:path";
 function loadE2eConfig(projectRoot) {
-  const filePath = join49(projectRoot, ".rn-agent", "e2e.config.json");
+  const filePath = join50(projectRoot, ".rn-agent", "e2e.config.json");
   try {
-    const raw = readFileSync35(filePath, "utf8");
+    const raw = readFileSync36(filePath, "utf8");
     return JSON.parse(raw);
   } catch {
     return {};
@@ -81021,7 +81411,7 @@ function readPassed(result) {
 async function lockE2eTestCore(args, deps = {}) {
   const projectRoot = args.projectRoot ?? findProjectRoot() ?? process.cwd();
   const load = deps.loadAction ?? loadAction;
-  const readFile3 = deps.readActionFile ?? ((p) => readFileSync36(p, "utf8"));
+  const readFile3 = deps.readActionFile ?? ((p) => readFileSync37(p, "utf8"));
   const getGit = deps.getGitInfo ?? getGitInfo;
   const getSession = deps.getSession ?? getActiveSession;
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
@@ -81084,8 +81474,8 @@ function createLockE2eTestHandler(deps = {}) {
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
 init_maestro_error_parser();
-import { join as join50 } from "node:path";
-import { mkdirSync as mkdirSync21, writeFileSync as writeFileSync20, renameSync as renameSync9, readFileSync as readFileSync37, existsSync as existsSync36 } from "node:fs";
+import { join as join51 } from "node:path";
+import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync21, renameSync as renameSync10, readFileSync as readFileSync38, existsSync as existsSync37 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
     return {
@@ -81140,20 +81530,20 @@ function diffNewlyFailing(current, previousGreen) {
 }
 var INDEX_MAX = 100;
 function e2eRunsDirFor(projectRoot) {
-  return join50(sessionStateDirectory(projectRoot), "e2e-runs");
+  return join51(sessionStateDirectory(projectRoot), "e2e-runs");
 }
 function writeJsonAtomic(file, value) {
-  mkdirSync21(join50(file, ".."), { recursive: true });
+  mkdirSync22(join51(file, ".."), { recursive: true });
   const tmp = `${file}.tmp`;
-  writeFileSync20(tmp, JSON.stringify(value, null, 2), "utf8");
-  renameSync9(tmp, file);
+  writeFileSync21(tmp, JSON.stringify(value, null, 2), "utf8");
+  renameSync10(tmp, file);
 }
 function loadIndex(projectRoot) {
-  const file = join50(e2eRunsDirFor(projectRoot), "index.json");
-  if (!existsSync36(file))
+  const file = join51(e2eRunsDirFor(projectRoot), "index.json");
+  if (!existsSync37(file))
     return [];
   try {
-    const parsed = JSON.parse(readFileSync37(file, "utf8"));
+    const parsed = JSON.parse(readFileSync38(file, "utf8"));
     return Array.isArray(parsed) ? parsed : [];
   } catch {
     return [];
@@ -81162,7 +81552,7 @@ function loadIndex(projectRoot) {
 function writeRunRecord(projectRoot, rec) {
   assertValidActionId(rec.runId, "writeRunRecord");
   const dir = e2eRunsDirFor(projectRoot);
-  writeJsonAtomic(join50(dir, `${rec.runId}.json`), rec);
+  writeJsonAtomic(join51(dir, `${rec.runId}.json`), rec);
   const entry = {
     runId: rec.runId,
     finishedAt: rec.finishedAt,
@@ -81170,15 +81560,15 @@ function writeRunRecord(projectRoot, rec) {
     totals: rec.totals
   };
   const next = [entry, ...loadIndex(projectRoot).filter((e) => e.runId !== rec.runId)].slice(0, INDEX_MAX);
-  writeJsonAtomic(join50(dir, "index.json"), next);
+  writeJsonAtomic(join51(dir, "index.json"), next);
 }
 function loadRunRecord(projectRoot, runId) {
   assertValidActionId(runId, "loadRunRecord");
-  const file = join50(e2eRunsDirFor(projectRoot), `${runId}.json`);
-  if (!existsSync36(file))
+  const file = join51(e2eRunsDirFor(projectRoot), `${runId}.json`);
+  if (!existsSync37(file))
     return null;
   try {
-    return JSON.parse(readFileSync37(file, "utf8"));
+    return JSON.parse(readFileSync38(file, "utf8"));
   } catch {
     return null;
   }
@@ -81194,8 +81584,8 @@ init_storage();
 init_utils();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
-import { join as join51 } from "node:path";
-import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync21, renameSync as renameSync10, readFileSync as readFileSync38, readdirSync as readdirSync13, existsSync as existsSync37 } from "node:fs";
+import { join as join52 } from "node:path";
+import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync22, renameSync as renameSync11, readFileSync as readFileSync39, readdirSync as readdirSync13, existsSync as existsSync38 } from "node:fs";
 var TERMINAL_STATUSES = /* @__PURE__ */ new Set([
   "done",
   "failed",
@@ -81203,25 +81593,25 @@ var TERMINAL_STATUSES = /* @__PURE__ */ new Set([
   "interrupted"
 ]);
 function requestsDir(projectRoot) {
-  return join51(e2eRunsDirFor(projectRoot), "requests");
+  return join52(e2eRunsDirFor(projectRoot), "requests");
 }
 function requestPath(projectRoot, runId) {
   assertValidActionId(runId, "e2e-run-request");
-  return join51(requestsDir(projectRoot), `${runId}.json`);
+  return join52(requestsDir(projectRoot), `${runId}.json`);
 }
 function writeRequest(projectRoot, req) {
   const file = requestPath(projectRoot, req.runId);
-  mkdirSync22(requestsDir(projectRoot), { recursive: true });
+  mkdirSync23(requestsDir(projectRoot), { recursive: true });
   const tmp = `${file}.tmp`;
-  writeFileSync21(tmp, JSON.stringify(req, null, 2), "utf8");
-  renameSync10(tmp, file);
+  writeFileSync22(tmp, JSON.stringify(req, null, 2), "utf8");
+  renameSync11(tmp, file);
 }
 function loadRequest(projectRoot, runId) {
   const file = requestPath(projectRoot, runId);
-  if (!existsSync37(file))
+  if (!existsSync38(file))
     return null;
   try {
-    return JSON.parse(readFileSync38(file, "utf8"));
+    return JSON.parse(readFileSync39(file, "utf8"));
   } catch {
     return null;
   }
@@ -81236,7 +81626,7 @@ function updateRequest(projectRoot, runId, patch) {
 }
 function listRequests(projectRoot) {
   const dir = requestsDir(projectRoot);
-  if (!existsSync37(dir))
+  if (!existsSync38(dir))
     return [];
   const out = [];
   for (const f of readdirSync13(dir)) {
@@ -81527,9 +81917,9 @@ init_storage();
 
 // packages/rn-dev-agent-core/dist/domain/action-inventory.js
 import { readdirSync as readdirSync14 } from "node:fs";
-import { join as join52 } from "node:path";
+import { join as join53 } from "node:path";
 async function listActions(projectRoot) {
-  const actionsDir = join52(projectRoot, ".rn-agent", "actions");
+  const actionsDir = join53(projectRoot, ".rn-agent", "actions");
   let files;
   try {
     files = readdirSync14(actionsDir);
@@ -81634,20 +82024,20 @@ init_discovery();
 init_metro_cwd();
 init_install_authority();
 import { execFileSync as execFileSync17 } from "node:child_process";
-import { createHash as createHash19 } from "node:crypto";
+import { createHash as createHash20 } from "node:crypto";
 init_metro_binding();
 init_process_birth();
 init_registry();
 
 // packages/rn-dev-agent-core/dist/session/source-identity.js
 init_metro_cwd();
-import { createHash as createHash18, createHmac as createHmac4, randomBytes as randomBytes7, timingSafeEqual as timingSafeEqual7 } from "node:crypto";
+import { createHash as createHash19, createHmac as createHmac4, randomBytes as randomBytes7, timingSafeEqual as timingSafeEqual7 } from "node:crypto";
 import { execFileSync as execFileSync16 } from "node:child_process";
-import { closeSync as closeSync10, constants as constants6, existsSync as existsSync38, fstatSync as fstatSync6, lstatSync as lstatSync12, openSync as openSync10, readdirSync as readdirSync15, readFileSync as readFileSync39, readlinkSync as readlinkSync3, readSync as readSync4, realpathSync as realpathSync10 } from "node:fs";
-import { dirname as dirname21, isAbsolute as isAbsolute8, join as join53, relative as relative5, resolve as resolve10 } from "node:path";
+import { closeSync as closeSync10, constants as constants6, existsSync as existsSync39, fstatSync as fstatSync6, lstatSync as lstatSync12, openSync as openSync10, readdirSync as readdirSync15, readFileSync as readFileSync40, readlinkSync as readlinkSync3, readSync as readSync4, realpathSync as realpathSync10 } from "node:fs";
+import { dirname as dirname22, isAbsolute as isAbsolute8, join as join54, relative as relative5, resolve as resolve10 } from "node:path";
 init_declared_source_contract();
 function digest2(parts) {
-  const hash = createHash18("sha256");
+  const hash = createHash19("sha256");
   for (const part of parts) {
     hash.update(part);
     hash.update("\0");
@@ -81754,7 +82144,7 @@ function updateFramedFile(hash, path, maximumBytes) {
   return updateStableFile(hash, path, maximumBytes, true);
 }
 function fileDigest(path) {
-  const hash = createHash18("sha256");
+  const hash = createHash19("sha256");
   updateStableFile(hash, path, MAX_STRICT_PROOF_DEPENDENCY_FILE_BYTES, false);
   return hash.digest("hex");
 }
@@ -81800,7 +82190,7 @@ function updateDependencyPath(hash, path, label, state) {
       updateFramed(hash, "directory");
       for (const entry of readdirSync15(current.path).sort().reverse()) {
         pending2.push({
-          path: join53(current.path, entry),
+          path: join54(current.path, entry),
           label: `${current.label}/${entry}`,
           depth: current.depth + 1
         });
@@ -81830,10 +82220,10 @@ function isExcludedRuntimePath(root, candidate) {
   return EXCLUDED_RUNTIME_DIRECTORIES.some((excluded) => entry === excluded || entry.startsWith(`${excluded}/`) || entry.endsWith(`/${excluded}`) || entry.includes(`/${excluded}/`));
 }
 function assertFinalMetroIntegration(identity2) {
-  const candidates = ["metro.config.js", "metro.config.cjs"].map((entry) => join53(identity2.appRoot, entry)).filter(existsSync38);
+  const candidates = ["metro.config.js", "metro.config.cjs"].map((entry) => join54(identity2.appRoot, entry)).filter(existsSync39);
   if (candidates.length === 0)
     return;
-  const source = readFileSync39(candidates[0], "utf8");
+  const source = readFileSync40(candidates[0], "utf8");
   const start = source.indexOf(METRO_INTEGRATION_START);
   const end = source.indexOf(METRO_INTEGRATION_END);
   if (start < 0 || end < start || source.indexOf(METRO_INTEGRATION_START, start + METRO_INTEGRATION_START.length) >= 0 || source.indexOf(METRO_INTEGRATION_END, end + METRO_INTEGRATION_END.length) >= 0 || source.slice(start, end + METRO_INTEGRATION_END.length) !== METRO_INTEGRATION_BLOCK || source.slice(end + METRO_INTEGRATION_END.length).trim()) {
@@ -81843,7 +82233,7 @@ function assertFinalMetroIntegration(identity2) {
 function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntimeEnforcement) {
   if (!authority)
     return { paths: [], semantics: [] };
-  const raw = readFileSync39(join53(identity2.appRoot, METRO_RUNTIME_POLICY2), "utf8");
+  const raw = readFileSync40(join54(identity2.appRoot, METRO_RUNTIME_POLICY2), "utf8");
   const receipt2 = JSON.parse(raw);
   const payload = {
     version: receipt2.version,
@@ -81876,7 +82266,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
     platform: process.platform,
     appRoot: identity2.appRoot,
     sourceRoot: identity2.contentRoot,
-    runtimeRoot: dirname21(authority.evidencePath),
+    runtimeRoot: dirname22(authority.evidencePath),
     nodeExecutable: runtimeManifest.nodeExecutable,
     nodeVersion: runtimeManifest.nodeVersion,
     commandExecutable: runtimeManifest.executable,
@@ -81905,7 +82295,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
     if (!runtimeLoadsStat.isFile() || runtimeLoadsStat.size > MAX_STRICT_PROOF_FILE_BYTES) {
       throw new Error("runtime load evidence is not a bounded regular file");
     }
-    runtimeLoadsRaw = readFileSync39(runtimeLoadsPath, "utf8");
+    runtimeLoadsRaw = readFileSync40(runtimeLoadsPath, "utf8");
   } catch (error2) {
     throw new Error("STRICT_PROOF_UNVERIFIED_METRO_POLICY: runtime load evidence is invalid", {
       cause: error2
@@ -81984,7 +82374,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
         throw new Error("STRICT_PROOF_UNVERIFIED_METRO_POLICY: runtime semantics are unbounded");
       }
       runtimeSemantics.add(load.value);
-      runtimeSemanticsByDigest.set(createHash18("sha256").update(load.value).digest("hex"), load.value);
+      runtimeSemanticsByDigest.set(createHash19("sha256").update(load.value).digest("hex"), load.value);
       orderedRuntimeSemantics.push(load.value);
       continue;
     }
@@ -82134,8 +82524,8 @@ function dependencyStoreRoots(identity2, git, pathExists) {
     ...DEPENDENCY_STORE_PATHS
   ]).split("\0").filter(Boolean);
   for (const candidate of [
-    join53(identity2.contentRoot, "node_modules"),
-    join53(identity2.appRoot, "node_modules")
+    join54(identity2.contentRoot, "node_modules"),
+    join54(identity2.appRoot, "node_modules")
   ]) {
     if (pathExists(candidate))
       entries.push(relative5(identity2.contentRoot, candidate));
@@ -82146,21 +82536,21 @@ function dependencyStoreRoots(identity2, git, pathExists) {
     pnpRoots.push(pnpRoot);
     if (pnpRoot === identity2.contentRoot)
       break;
-    const parent = dirname21(pnpRoot);
+    const parent = dirname22(pnpRoot);
     if (parent === pnpRoot || !isContained(identity2.contentRoot, parent))
       break;
     pnpRoot = parent;
   }
-  const pnpLoaders = [...new Set(pnpRoots)].flatMap((root) => [".pnp.js", ".pnp.cjs", ".pnp.loader.mjs"].map((entry) => join53(root, entry)).filter(pathExists));
+  const pnpLoaders = [...new Set(pnpRoots)].flatMap((root) => [".pnp.js", ".pnp.cjs", ".pnp.loader.mjs"].map((entry) => join54(root, entry)).filter(pathExists));
   if (pnpLoaders.length > 0) {
     throw new Error("STRICT_PROOF_UNVERIFIED_DEPENDENCY_LAYOUT: Plug\u2019n\u2019Play dependency resolution is unsupported");
   }
-  let ancestor = dirname21(identity2.contentRoot);
+  let ancestor = dirname22(identity2.contentRoot);
   while (true) {
-    if (pathExists(join53(ancestor, "node_modules"))) {
+    if (pathExists(join54(ancestor, "node_modules"))) {
       throw new Error("STRICT_PROOF_UNVERIFIED_DEPENDENCY_LAYOUT: ancestor node_modules resolves outside the content root");
     }
-    const parent = dirname21(ancestor);
+    const parent = dirname22(ancestor);
     if (parent === ancestor)
       break;
     ancestor = parent;
@@ -82212,7 +82602,7 @@ function resolveDeclaredIdentity(appRoot, dependencies, canonicalize) {
   if (!dependencies.declaredManifests?.length) {
     throw new Error(missingDeclaredManifestListMessage());
   }
-  const pathExists = dependencies.exists ?? existsSync38;
+  const pathExists = dependencies.exists ?? existsSync39;
   const contentRoot = canonicalize(resolve10(dependencies.declaredRoot));
   assertContained(contentRoot, appRoot, "NON_GIT_ROOT_MISMATCH");
   const manifestParts = [];
@@ -82222,7 +82612,7 @@ function resolveDeclaredIdentity(appRoot, dependencies, canonicalize) {
       throw new Error(missingDeclaredManifestMessage(entry));
     const manifest = canonicalize(declared);
     assertContained(contentRoot, manifest, "NON_GIT_MANIFEST_OUTSIDE_ROOT");
-    manifestParts.push(relative5(contentRoot, manifest), readFileSync39(manifest));
+    manifestParts.push(relative5(contentRoot, manifest), readFileSync40(manifest));
   }
   const manifestDigest = digest2(manifestParts);
   const appRelative = relative5(contentRoot, appRoot) || ".";
@@ -82245,7 +82635,7 @@ function resolveSourceIdentity(inputRoot, dependencies = {}) {
     const contentRoot = canonicalize(git(appRoot, ["rev-parse", "--show-toplevel"]));
     assertContained(contentRoot, appRoot, "APP_ROOT_OUTSIDE_WORKTREE");
     const commonRaw = git(appRoot, ["rev-parse", "--git-common-dir"]);
-    const commonDirectory = canonicalize(isAbsolute8(commonRaw) ? commonRaw : join53(appRoot, commonRaw));
+    const commonDirectory = canonicalize(isAbsolute8(commonRaw) ? commonRaw : join54(appRoot, commonRaw));
     const head = git(appRoot, ["rev-parse", "HEAD"]);
     const appRelative = relative5(contentRoot, appRoot) || ".";
     return {
@@ -82271,7 +82661,7 @@ function strictProofSourceIdentity(identity2, dependencies = {}) {
     throw new Error("STRICT_PROOF_GIT_REQUIRED: accepted strict proof requires a Git worktree");
   }
   const git = dependencies.git ?? defaultGit;
-  const pathExists = dependencies.exists ?? existsSync38;
+  const pathExists = dependencies.exists ?? existsSync39;
   assertFinalMetroIntegration(identity2);
   const evidenceHeadReader = dependencies.readMetroEvidenceHead ?? readMetroEvidenceHead;
   const runtimeEnforcementVerifier = dependencies.verifyMetroRuntimeEnforcement ?? verifyManagedMetroEnforcementReceipt;
@@ -82305,7 +82695,7 @@ function strictProofSourceIdentity(identity2, dependencies = {}) {
       throw new Error(`STRICT_PROOF_DIRTY_SUBMODULE: ${entry} contains source changes outside the parent digest`);
     }
   }
-  const dirtyHash = createHash18("sha256");
+  const dirtyHash = createHash19("sha256");
   updateFramed(dirtyHash, "git-dirty-v3");
   updateFramed(dirtyHash, diff);
   for (const semantics of runtimeInputs.semantics) {
@@ -82377,7 +82767,7 @@ function strictProofSourceIdentity(identity2, dependencies = {}) {
 
 // packages/rn-dev-agent-core/dist/session/local-authority-probe.js
 function identity(value) {
-  return createHash19("sha256").update(JSON.stringify(value)).digest("hex");
+  return createHash20("sha256").update(JSON.stringify(value)).digest("hex");
 }
 function objectBinding(status, name) {
   const value = status.bindings[name];
@@ -83170,8 +83560,8 @@ async function connectExactSessionTarget(input, timeoutMs, dependencies) {
 }
 
 // packages/rn-dev-agent-core/dist/index.js
-var pkgPath = join54(dirname22(fileURLToPath6(import.meta.url)), "..", "package.json");
-var pkgVersion = JSON.parse(readFileSync40(pkgPath, "utf8")).version;
+var pkgPath = join55(dirname23(fileURLToPath7(import.meta.url)), "..", "package.json");
+var pkgVersion = JSON.parse(readFileSync41(pkgPath, "utf8")).version;
 var lockfile = null;
 var diagnosticContractProbe = process.argv.includes("--diagnostic-contract-probe");
 var noLock = diagnosticContractProbe || process.argv.includes("--no-lock");
@@ -83274,8 +83664,13 @@ var server2 = new McpServer({
   version: pkgVersion
 });
 var strictProofMonitor = new StrictProofMonitor();
+var experienceRecorder = new ExperienceRecorder({
+  coreVersion: pkgVersion,
+  pluginVersion: discoverPluginVersion()
+});
 addToolObserver((o) => recorder.record(o));
 addToolObserver((o) => strictProofMonitor.record(o));
+addToolObserver((o) => experienceRecorder.observe(o));
 var authorityRuntime = getWorkerAuthorityRuntime();
 setSnapshotAuthorityProvider({
   current: () => {
@@ -83300,7 +83695,7 @@ setSnapshotAuthorityProvider({
       runnerInstanceId: runner?.instanceId,
       runnerPid: runner?.pid,
       runnerProcessBirth: runner?.processBirth,
-      runnerCapabilityHash: typeof runner?.capability === "string" ? createHash20("sha256").update(runner.capability).digest("hex") : void 0,
+      runnerCapabilityHash: typeof runner?.capability === "string" ? createHash21("sha256").update(runner.capability).digest("hex") : void 0,
       runnerPort: runner?.port,
       runnerClaim: status.claims.find((claim) => claim.type === "runner")?.key,
       deviceClaim: status.claims.find((claim) => claim.type === "device")?.key
@@ -83491,7 +83886,7 @@ setObserveAuthorityDeps({
       authority: {
         sessionId: status.sessionId,
         claimEpoch: status.claimEpoch,
-        instanceId: randomUUID8(),
+        instanceId: randomUUID9(),
         capability: secret.observeCapability
       }
     };
@@ -83575,7 +83970,7 @@ var liveDeps = buildLiveDeps({
   readRoute: (c) => readLiveRoute(c),
   readShotFile: (path) => {
     try {
-      const buf = readFileSync40(path);
+      const buf = readFileSync41(path);
       const isPng = buf.length >= 4 && buf[0] === 137 && buf[1] === 80 && buf[2] === 78 && buf[3] === 71;
       return { buf, contentType: isPng ? "image/png" : "image/jpeg" };
     } catch {
@@ -83899,7 +84294,7 @@ var getSessionSignerCapability = (sessionId) => {
     return null;
   if (sessionId && !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(sessionId))
     return null;
-  const secretPath = sessionId ? join54(dirname22(dirname22(currentSecretPath)), sessionId, "secret.json") : currentSecretPath;
+  const secretPath = sessionId ? join55(dirname23(dirname23(currentSecretPath)), sessionId, "secret.json") : currentSecretPath;
   return readJsonStateFile(secretPath)?.signerCapability ?? null;
 };
 var spawningSupervisorPid = process.ppid;
@@ -84458,7 +84853,7 @@ var proofReadiness = async () => {
       connectedAt: current.connectedAt
     }),
     errorCount: errors.length,
-    errorSha256: createHash20("sha256").update(errorBytes).digest("hex"),
+    errorSha256: createHash21("sha256").update(errorBytes).digest("hex"),
     device: identity2.device,
     runtime: identity2.runtime
   };

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -81855,17 +81855,25 @@ function applyRedactionRules(value) {
 }
 function readAppIdentity() {
   const root = process.env.RN_PROJECT_ROOT ?? process.env.CLAUDE_USER_CWD ?? process.cwd();
-  if (appIdentityCache?.root === root)
-    return appIdentityCache.identity;
+  if (appIdentityCache?.root !== root) {
+    appIdentityCache = { root, identity: loadAppIdentity(root) };
+  }
+  if (appIdentityCache.identity === null) {
+    throw new Error("app identity could not be read for redaction");
+  }
+  return appIdentityCache.identity;
+}
+function loadAppIdentity(root) {
   const manifest = join47(root, "app.json");
-  let identity2 = { name: null, slug: null };
-  if (existsSync36(manifest)) {
+  try {
+    if (!existsSync36(manifest))
+      return { name: null, slug: null };
     const parsed = JSON.parse(readFileSync34(manifest, "utf8"));
     const expo = parsed.expo ?? parsed;
-    identity2 = { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
+    return { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
+  } catch {
+    return null;
   }
-  appIdentityCache = { root, identity: identity2 };
-  return identity2;
 }
 function usableIdentity(value) {
   return typeof value === "string" && value.trim().length > 2 ? value : null;
@@ -81906,7 +81914,6 @@ function readExperienceStore(path) {
     } catch {
       continue;
     }
-    SANITIZED_RECORDS.add(parsed);
     records.push(parsed);
   }
   return records;
@@ -81994,7 +82001,7 @@ function adoptLateFact(existing, incoming, field2) {
 function boundedPointers(existing, incoming) {
   return [.../* @__PURE__ */ new Set([...existing, ...incoming])].slice(-MAX_EVIDENCE_POINTERS);
 }
-var UNKNOWN_CLASSIFICATION, DEFAULT_MAX_RECORDS, DEFAULT_RETENTION_DAYS, MAX_EVIDENCE_POINTERS, EXPERIENCE_DIRECTORY, EXPERIENCE_STORE_NAME, MAX_SYMPTOM_LENGTH, DAY_MS, REDACTION_FAILED, SYMPTOM_TRUNCATED, REDACTION_RULES, KEYED_SECRET, SANITIZED_RECORDS, appIdentityCache, ExperienceRecorder, CLASSIFICATION_RULES, EXPERIENCE_FAMILY_IDS;
+var UNKNOWN_CLASSIFICATION, DEFAULT_MAX_RECORDS, DEFAULT_RETENTION_DAYS, MAX_EVIDENCE_POINTERS, EXPERIENCE_DIRECTORY, EXPERIENCE_STORE_NAME, MAX_SYMPTOM_LENGTH, DAY_MS, REDACTION_FAILED, SYMPTOM_TRUNCATED, REDACTION_RULES, KEYED_SECRET, REDACTION_RULES_VERSION, appIdentityCache, ExperienceRecorder, CLASSIFICATION_RULES, EXPERIENCE_FAMILY_IDS;
 var init_evidence = __esm({
   "packages/rn-dev-agent-core/dist/experience/evidence.js"() {
     "use strict";
@@ -82033,7 +82040,7 @@ var init_evidence = __esm({
       [/(com|org|io|dev|net)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_.-]+/g, "[BUNDLE_REDACTED]"]
     ];
     KEYED_SECRET = /((?:token|secret|password|auth|api[_-]?key)\s*[:=]\s*)[^\s,;}]{6,}/gi;
-    SANITIZED_RECORDS = /* @__PURE__ */ new WeakSet();
+    REDACTION_RULES_VERSION = 1;
     appIdentityCache = null;
     ExperienceRecorder = class {
       directory;
@@ -82148,11 +82155,10 @@ var init_evidence = __esm({
           firstSeen: now,
           lastSeen: now,
           lastRecoveredAt: null,
-          unknownReasons
+          unknownReasons,
+          redactionVersion: REDACTION_RULES_VERSION
         };
-        const sanitized = sanitizeForEvidence(raw);
-        SANITIZED_RECORDS.add(sanitized);
-        return sanitized;
+        return sanitizeForEvidence(raw);
       }
       persistFailure(incoming) {
         const records = readExperienceStore(this.path);
@@ -82167,7 +82173,6 @@ var init_evidence = __esm({
           existing.symptom = incoming.symptom;
           existing.candidate = incoming.candidate;
           existing.environment = incoming.environment;
-          adoptLateFact(existing, incoming, "platform");
           adoptLateFact(existing, incoming, "device");
           adoptLateFact(existing, incoming, "runtime");
           existing.evidencePointers = boundedPointers(existing.evidencePointers, incoming.evidencePointers);
@@ -82195,7 +82200,10 @@ var init_evidence = __esm({
         mkdirSync20(this.directory, { recursive: true, mode: 448 });
         const temp = join47(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID9()}`);
         try {
-          const sanitized = records.map((record2) => SANITIZED_RECORDS.has(record2) ? record2 : sanitizeForEvidence(record2));
+          const sanitized = records.map((record2) => record2.redactionVersion === REDACTION_RULES_VERSION ? record2 : {
+            ...sanitizeForEvidence(record2),
+            redactionVersion: REDACTION_RULES_VERSION
+          });
           const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
           writeFileSync19(temp, contents.length > 0 ? `${contents}
 ` : "", {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -24410,7 +24410,7 @@ async function rebuildStaleRunnerArtifact(first, deviceId, bundleId, deps) {
       message: "another session is rebuilding the shared runner artifact \u2014 retry this open in a few minutes."
     };
   }
-  const release = deps.releaseBuildLock ?? releaseRunnerRebuildLock;
+  const release2 = deps.releaseBuildLock ?? releaseRunnerRebuildLock;
   try {
     const reap = deps.reap ?? reapStaleFastRunner;
     await reap();
@@ -24424,7 +24424,7 @@ async function rebuildStaleRunnerArtifact(first, deviceId, bundleId, deps) {
       ...deps.attachOnly === true ? { attachOnly: true } : {}
     });
   } finally {
-    release();
+    release2();
   }
   const probe = deps.probe ?? probeFastRunnerLivenessDetailed;
   const rebuilt = await probe();
@@ -28085,8 +28085,8 @@ async function runFlowParked(run, opts = {}) {
   const stale = opts.markCdpStale ?? markCdpStale;
   try {
     if (opts.platform === "android") {
-      const release = opts.releaseAndroidSlot ?? releaseAndroidInteractionSlot;
-      await release({ deviceId: opts.deviceId });
+      const release2 = opts.releaseAndroidSlot ?? releaseAndroidInteractionSlot;
+      await release2({ deviceId: opts.deviceId });
     } else {
       await (opts.stopFastRunner ?? stopFastRunner)(opts.deviceId);
     }
@@ -33114,13 +33114,13 @@ function consumePendingAndroidUpgradeNote() {
   pendingUpgradeNote = void 0;
   return note;
 }
-async function reapMismatchedAndroidRunner(state, release, verify, signal) {
+async function reapMismatchedAndroidRunner(state, release2, verify, signal) {
   signal?.throwIfAborted();
   const deviceId = state?.deviceId;
   if (!deviceId) {
     throw new Error("RUNNER_CLEANUP_UNCONFIRMED: stale Android runner has no recorded device identity");
   }
-  const releaseSlot = release ?? (async (opts) => {
+  const releaseSlot = release2 ?? (async (opts) => {
     const { releaseAndroidInteractionSlot: releaseAndroidInteractionSlot2 } = await Promise.resolve().then(() => (init_release_android_slot(), release_android_slot_exports));
     return releaseAndroidInteractionSlot2({ ...opts, signal });
   });
@@ -33134,7 +33134,7 @@ async function reapMismatchedAndroidRunner(state, release, verify, signal) {
   if (!receipt2.stoppedOwnRunner || missingPackages.length > 0) {
     throw new Error(`RUNNER_CLEANUP_UNCONFIRMED: stale Android runner cleanup failed for ${deviceId}`);
   }
-  const verifyReleased = verify ?? (release ? async () => {
+  const verifyReleased = verify ?? (release2 ? async () => {
   } : async (expected) => {
     const forwards = String((await execFileAsync2("adb", ["forward", "--list"], {
       timeout: ADB_CLEANUP_TIMEOUT_MS,
@@ -33322,7 +33322,7 @@ async function runBoundedAndroidRunnerRebuild(error2, rebuild, cleanup, dependen
   const heartbeat = dependencies.heartbeat ?? heartbeatAndroidRunnerRebuildLock;
   const complete = dependencies.complete ?? completeAndroidRunnerRebuildLock;
   const beginCleanup = dependencies.beginCleanup ?? beginAndroidRunnerRebuildCleanup;
-  const release = dependencies.release ?? releaseAndroidRunnerRebuildLock;
+  const release2 = dependencies.release ?? releaseAndroidRunnerRebuildLock;
   const markCleanupUnverified = dependencies.markCleanupUnverified ?? markAndroidRunnerRebuildCleanupUnverified;
   const controller = new AbortController();
   let cleanupController;
@@ -33418,7 +33418,7 @@ async function runBoundedAndroidRunnerRebuild(error2, rebuild, cleanup, dependen
     }
     clearTimeout(cleanupTimer);
     cleanupController = void 0;
-    const terminalPersisted = await persistTransition(cleanupVerified ? release : markCleanupUnverified);
+    const terminalPersisted = await persistTransition(cleanupVerified ? release2 : markCleanupUnverified);
     clearInterval(heartbeatTimer2);
     if (!terminalPersisted) {
       throw leaseAuthorityLost ? controller.signal.reason : androidRebuildRefusal(error2, "runner artifact failure state was not durable");
@@ -58697,7 +58697,7 @@ var require_websocket = __commonJS({
     var http = __require("http");
     var net = __require("net");
     var tls = __require("tls");
-    var { randomBytes: randomBytes9, createHash: createHash23 } = __require("crypto");
+    var { randomBytes: randomBytes9, createHash: createHash24 } = __require("crypto");
     var { Duplex, Readable } = __require("stream");
     var { URL: URL2 } = __require("url");
     var PerMessageDeflate2 = require_permessage_deflate();
@@ -59365,7 +59365,7 @@ var require_websocket = __commonJS({
           abortHandshake(websocket, socket, "Invalid Upgrade header");
           return;
         }
-        const digest3 = createHash23("sha1").update(key + GUID).digest("base64");
+        const digest3 = createHash24("sha1").update(key + GUID).digest("base64");
         if (res.headers["sec-websocket-accept"] !== digest3) {
           abortHandshake(websocket, socket, "Invalid Sec-WebSocket-Accept header");
           return;
@@ -59734,7 +59734,7 @@ var require_websocket_server = __commonJS({
     var EventEmitter = __require("events");
     var http = __require("http");
     var { Duplex } = __require("stream");
-    var { createHash: createHash23 } = __require("crypto");
+    var { createHash: createHash24 } = __require("crypto");
     var extension2 = require_extension();
     var PerMessageDeflate2 = require_permessage_deflate();
     var subprotocol2 = require_subprotocol();
@@ -60041,7 +60041,7 @@ var require_websocket_server = __commonJS({
           );
         }
         if (this._state > RUNNING) return abortHandshake(socket, 503);
-        const digest3 = createHash23("sha1").update(key + GUID).digest("base64");
+        const digest3 = createHash24("sha1").update(key + GUID).digest("base64");
         const headers = [
           "HTTP/1.1 101 Switching Protocols",
           "Upgrade: websocket",
@@ -81810,8 +81810,404 @@ var init_instrumentation = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/experience/evidence.js
+import { createHash as createHash20, randomUUID as randomUUID9 } from "node:crypto";
+import { chmodSync as chmodSync5, existsSync as existsSync36, mkdirSync as mkdirSync20, readFileSync as readFileSync34, renameSync as renameSync8, unlinkSync as unlinkSync12, writeFileSync as writeFileSync19 } from "node:fs";
+import { homedir as homedir11, platform as hostPlatform, release } from "node:os";
+import { dirname as dirname21, join as join47 } from "node:path";
+import { fileURLToPath as fileURLToPath5 } from "node:url";
+function sanitizeString(value, redact2 = applyRedactionRules) {
+  try {
+    return redact2(value);
+  } catch {
+    return REDACTION_FAILED;
+  }
+}
+function sanitizeForEvidence(value, redact2) {
+  if (value === null || value === void 0 || typeof value === "boolean" || typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "string")
+    return sanitizeString(value, redact2);
+  if (Array.isArray(value))
+    return value.map((item) => sanitizeForEvidence(item, redact2));
+  if (typeof value === "object") {
+    const sanitized = {};
+    for (const [key, nested] of Object.entries(value)) {
+      sanitized[key] = sanitizeForEvidence(nested, redact2);
+    }
+    return sanitized;
+  }
+  return REDACTION_FAILED;
+}
+function applyRedactionRules(value) {
+  let result = value.replaceAll(homedir11(), "~").replace(KEYED_SECRET, "$1[REDACTED_SECRET]");
+  for (const [pattern, replacement] of REDACTION_RULES) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}
+function discoverPluginVersion(fromUrl = import.meta.url) {
+  if (process.env.RN_DEV_AGENT_PLUGIN_VERSION)
+    return process.env.RN_DEV_AGENT_PLUGIN_VERSION;
+  const start = dirname21(fileURLToPath5(fromUrl));
+  const candidates = [
+    join47(start, "..", "..", ".claude-plugin", "plugin.json"),
+    join47(start, "..", "..", ".codex-plugin", "plugin.json"),
+    join47(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
+    join47(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
+  ];
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(readFileSync34(candidate, "utf8"));
+      if (typeof parsed.version === "string")
+        return sanitizeString(parsed.version);
+    } catch {
+    }
+  }
+  return null;
+}
+function readExperienceStore(path, allowMissing = false) {
+  if (!existsSync36(path)) {
+    if (allowMissing)
+      return [];
+    return [];
+  }
+  const contents = readFileSync34(path, "utf8");
+  if (!contents.trim())
+    return [];
+  return contents.split("\n").filter((line) => line.trim().length > 0).map((line) => JSON.parse(line));
+}
+function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, retentionMs = DEFAULT_RETENTION_DAYS * DAY_MS) {
+  const cutoff = now.getTime() - retentionMs;
+  return records.filter((record2) => {
+    const lastSeen = Date.parse(record2.lastSeen);
+    return Number.isFinite(lastSeen) && lastSeen >= cutoff;
+  }).sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen) || a.signature.localeCompare(b.signature)).slice(0, Math.max(0, maxRecords)).sort((a, b) => a.signature.localeCompare(b.signature));
+}
+function experienceSignature(input) {
+  return createHash20("sha256").update(JSON.stringify([
+    input.classification,
+    input.tool,
+    input.normalizedSymptomShape,
+    input.platform ?? "unknown"
+  ])).digest("hex");
+}
+function normalizeSymptomShape(symptom) {
+  return symptom.toLowerCase().replace(/[0-9a-f]{8}-[0-9a-f-]{27,}/gi, "<id>").replace(/\b0x[0-9a-f]+\b/gi, "<hex>").replace(/\b(?=[a-z0-9_-]{12,}\b)(?=[a-z0-9_-]*\d)[a-z0-9_-]+\b/gi, "<id>").replace(/\b\d+\b/g, "#").replace(/\s+/g, " ").trim();
+}
+function classifyExperience(symptom, tool, platform) {
+  const haystack = `${tool} ${platform ?? ""} ${symptom}`.toLowerCase();
+  const rules = [
+    ["FF_REDBOX", /redbox|logbox|error overlay|hasredbox/],
+    ["FF_DEBUGGER_PAUSED", /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
+    [
+      "FF_STALE_CDP",
+      /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/
+    ],
+    ["FF_FAST_REFRESH_STALE", /fast refresh|ui unchanged|old exports|old module path/],
+    ["FF_METRO_CACHE", /metro.*(?:stale|cache)|config change not reflected/],
+    [
+      "FF_BINARY_MISMATCH",
+      /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/
+    ],
+    ["FF_EXPO_DIALOG", /open-in-app|system confirmation dialog/],
+    [
+      "FF_DEV_CLIENT_PICKER",
+      /no hermes target|development servers|devclientlauncher|server picker/
+    ],
+    ["FF_KEYBOARD_OVERLAY", /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
+    ["FF_MAESTRO_GRPC_ANDROID", /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
+    [
+      "FF_ANDROID_TEXT_INPUT_CRASH",
+      /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/
+    ],
+    [
+      "FF_AUTH_GATE",
+      /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/
+    ],
+    [
+      "FF_PERMISSION_ALREADY_GRANTED",
+      /permission already granted|prompt (?:was )?not shown|flow completes instantly/
+    ],
+    ["EG_EXPO_GO_SDK_MISMATCH", /incompatible with this version of expo go|expo go sdk.*mismatch/],
+    ["EG_NATIVEWIND_JSX_SOURCE", /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
+    ["EG_EXPO_GO_NATIVE_MODULES", /expo go.*custom native module/],
+    ["EG_DEV_CLIENT_CLEARSTATE", /clearstate.*(?:dev client|metro connection|launcher)/],
+    ["EG_MSW_HERMES", /msw.*(?:hermes|react native|initialize)/],
+    ["EG_EXPO_ROUTER_DEEP_LINK", /expo router.*deep link|deep link.*confirmation dialog/],
+    ["EG_DEV_MENU_INTERFERENCE", /dev menu.*(?:overlay|recording|blocking)/],
+    ["EG_NEW_ARCH_CDP_TARGET", /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
+    ["PQ_IOS_RECORDVIDEO_CODEC", /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
+    ["PQ_ANDROID_SCREENRECORD_LIMIT", /screenrecord.*180|screenrecord.*3 minute/],
+    ["PQ_ANDROID_BOOT_DELAY", /sys\.boot_completed|emulator.*grpc.*ready/],
+    ["PQ_ANDROID_PLAY_PROTECT", /play protect.*(?:block|apk|install)/]
+  ];
+  return rules.find(([, pattern]) => pattern.test(haystack))?.[0] ?? UNKNOWN_CLASSIFICATION;
+}
+function extractSymptom(event) {
+  if (typeof event.error === "string" && event.error.length > 0)
+    return event.error;
+  if (event.result && typeof event.result === "object") {
+    const envelope = event.result;
+    if (typeof envelope.error === "string")
+      return envelope.error;
+    const content = envelope.content;
+    if (Array.isArray(content)) {
+      const first = content[0];
+      if (typeof first?.text === "string")
+        return first.text;
+    }
+  }
+  return `${event.tool} reported ${event.status} without an error message`;
+}
+function extractScalar(event, keys) {
+  const sources = [event.params, event.result];
+  for (const source of sources) {
+    const value = findScalar(source, keys, 0);
+    if (value !== null)
+      return value;
+  }
+  return null;
+}
+function findScalar(value, keys, depth) {
+  if (!value || typeof value !== "object" || depth > 3)
+    return null;
+  const object3 = value;
+  for (const key of keys) {
+    const candidate = object3[key];
+    if (typeof candidate === "string" && candidate.length > 0)
+      return candidate;
+  }
+  for (const nested of Object.values(object3)) {
+    if (nested && typeof nested === "object") {
+      const found = findScalar(nested, keys, depth + 1);
+      if (found !== null)
+        return found;
+    }
+  }
+  return null;
+}
+function sanitizeNullable(value) {
+  return value === null ? null : sanitizeString(value);
+}
+function boundedPointers(existing, incoming) {
+  return [.../* @__PURE__ */ new Set([...existing, ...incoming])].slice(-MAX_EVIDENCE_POINTERS);
+}
+var UNKNOWN_CLASSIFICATION, DEFAULT_MAX_RECORDS, DEFAULT_RETENTION_DAYS, MAX_EVIDENCE_POINTERS, EXPERIENCE_DIRECTORY, EXPERIENCE_STORE_NAME, DAY_MS, REDACTION_FAILED, REDACTION_RULES, KEYED_SECRET, ExperienceRecorder;
+var init_evidence = __esm({
+  "packages/rn-dev-agent-core/dist/experience/evidence.js"() {
+    "use strict";
+    UNKNOWN_CLASSIFICATION = "UNKNOWN";
+    DEFAULT_MAX_RECORDS = 500;
+    DEFAULT_RETENTION_DAYS = 14;
+    MAX_EVIDENCE_POINTERS = 3;
+    EXPERIENCE_DIRECTORY = join47(homedir11(), ".claude", "rn-agent", "experience");
+    EXPERIENCE_STORE_NAME = "patterns.jsonl";
+    DAY_MS = 24 * 60 * 60 * 1e3;
+    REDACTION_FAILED = "[REDACTION_FAILED]";
+    REDACTION_RULES = [
+      [/(sk|pk|api|key|token|secret|password|auth)[-_]?[A-Za-z0-9_-]{20,}/gi, "[REDACTED_SECRET]"],
+      [/Bearer [A-Za-z0-9_./+=-]{20,}/g, "Bearer [REDACTED]"],
+      [/ghp_[A-Za-z0-9_]{36}/g, "[REDACTED_GH_TOKEN]"],
+      [/eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g, "[REDACTED_JWT]"],
+      [/AKIA[0-9A-Z]{16}/g, "[REDACTED_AWS]"],
+      [/xox[baprs]-[A-Za-z0-9-]+/g, "[REDACTED_SLACK]"],
+      [/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, "[EMAIL_REDACTED]"],
+      [
+        /(^|[^0-9])(192|10|172|169)\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}([^0-9]|$)/g,
+        "$1[IP_REDACTED]$3"
+      ],
+      [/(^|[^0-9])[0-9]{1,3}(?:\.[0-9]{1,3}){3}([^0-9]|$)/g, "$1[IP_REDACTED]$2"],
+      [
+        /(?:https?:\/\/)?(?:localhost|127\.0\.0\.1)(?::[0-9]{2,5})?(?:\/[^\s]*)?/gi,
+        "[LOOPBACK_ENDPOINT_REDACTED]"
+      ],
+      [/"(metroPort|observePort|port)"\s*:\s*[0-9]+/g, '"$1":"[PORT_REDACTED]"'],
+      [/\bport\s*[:=]?\s*[0-9]{2,5}\b/gi, "[PORT_REDACTED]"],
+      [/:([0-9]{2,5})(?=\/|\s|$)/g, ":[PORT_REDACTED]"],
+      [/~\/[A-Za-z0-9_./-]+/g, "[PATH_REDACTED]"],
+      [/\/(Users|home|opt|var|tmp|etc|private|Volumes)\/[A-Za-z0-9_./-]+/g, "[PATH_REDACTED]"],
+      [/(com|org|io|dev|net)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_.-]+/g, "[BUNDLE_REDACTED]"]
+    ];
+    KEYED_SECRET = /((?:token|secret|password|auth|api[_-]?key)\s*[:=]\s*)[^\s,;}]{6,}/gi;
+    ExperienceRecorder = class {
+      directory;
+      path;
+      candidate;
+      environment;
+      maxRecords;
+      retentionMs;
+      now;
+      schedule;
+      previousFailure = null;
+      constructor(options) {
+        this.directory = options.directory ?? process.env.RN_DEV_AGENT_EXPERIENCE_DIR ?? EXPERIENCE_DIRECTORY;
+        this.path = join47(this.directory, EXPERIENCE_STORE_NAME);
+        this.candidate = {
+          pluginVersion: options.pluginVersion ?? null,
+          coreVersion: options.coreVersion
+        };
+        this.environment = { os: `${hostPlatform()} ${release()}`, node: process.version };
+        this.maxRecords = options.maxRecords ?? DEFAULT_MAX_RECORDS;
+        this.retentionMs = (options.retentionDays ?? DEFAULT_RETENTION_DAYS) * DAY_MS;
+        this.now = options.now ?? (() => /* @__PURE__ */ new Date());
+        this.schedule = options.schedule ?? ((work) => setImmediate(work));
+      }
+      /** Queue only: persistence never executes in the observed tool's call stack. */
+      observe(event) {
+        try {
+          this.schedule(() => this.recordNonLoadBearing(event));
+        } catch {
+        }
+      }
+      /** Test and CLI support; returns a sanitized, deduplicated view. */
+      read() {
+        return readExperienceStore(this.path);
+      }
+      recordNonLoadBearing(event) {
+        try {
+          this.record(event);
+        } catch {
+        }
+      }
+      record(event) {
+        if (!event || typeof event.tool !== "string") {
+          this.previousFailure = null;
+          return;
+        }
+        if (event.status === "PASS") {
+          const recovery = this.previousFailure;
+          this.previousFailure = null;
+          if (recovery?.tool === event.tool)
+            this.persistRecovery(recovery.signature, event.tool);
+          return;
+        }
+        if (event.status !== "FAIL" && event.status !== "ERROR") {
+          this.previousFailure = null;
+          return;
+        }
+        const record2 = this.buildFailureRecord(event);
+        this.persistFailure(record2);
+        this.previousFailure = event.status === "FAIL" ? { tool: event.tool, signature: record2.signature } : null;
+      }
+      buildFailureRecord(event) {
+        const now = this.now().toISOString();
+        const tool = sanitizeString(event.tool);
+        const symptom = sanitizeString(extractSymptom(event));
+        const platform = sanitizeNullable(extractScalar(event, ["platform"]));
+        const deviceName = extractScalar(event, ["deviceName", "deviceModel", "model"]);
+        const hasDeviceId = extractScalar(event, ["deviceId", "udid"]) !== null;
+        const device = sanitizeNullable(deviceName ?? (hasDeviceId ? "identified-device" : null));
+        const runtime = sanitizeNullable(extractScalar(event, ["runtime", "engine"]));
+        const classification = classifyExperience(symptom, tool, platform);
+        const normalizedSymptomShape = normalizeSymptomShape(symptom);
+        const signature = experienceSignature({
+          classification,
+          tool,
+          normalizedSymptomShape,
+          platform
+        });
+        const unknownReasons = {};
+        if (this.candidate.pluginVersion === null) {
+          unknownReasons["candidate.pluginVersion"] = "plugin manifest was not available to the core runtime";
+        }
+        if (platform === null)
+          unknownReasons.platform = "tool event did not expose a platform";
+        if (device === null)
+          unknownReasons.device = "tool event did not expose a device name or identifier";
+        if (runtime === null)
+          unknownReasons.runtime = "tool event did not expose a runtime";
+        unknownReasons.maskingCondition = "not derivable from a single tool event";
+        unknownReasons.recovery = "no immediate successful retry has been observed";
+        unknownReasons.cleanup = "tool events do not report cleanup actions";
+        const raw = {
+          signature,
+          candidate: this.candidate,
+          environment: this.environment,
+          platform,
+          device,
+          runtime,
+          phase: "tool",
+          trigger: `${event.status} reported by ${tool}`,
+          maskingCondition: null,
+          symptom,
+          recovery: null,
+          cleanup: null,
+          classification,
+          evidencePointers: [`event:${randomUUID9()}`],
+          tool,
+          status: event.status === "ERROR" ? "ERROR" : "FAIL",
+          normalizedSymptomShape,
+          count: 1,
+          recoveryCount: 0,
+          firstSeen: now,
+          lastSeen: now,
+          lastRecoveredAt: null,
+          unknownReasons
+        };
+        return sanitizeForEvidence(raw);
+      }
+      persistFailure(incoming) {
+        const records = readExperienceStore(this.path, true);
+        const existing = records.find((record2) => record2.signature === incoming.signature);
+        if (existing) {
+          existing.count += 1;
+          existing.lastSeen = incoming.lastSeen;
+          existing.status = incoming.status;
+          existing.symptom = incoming.symptom;
+          existing.candidate = incoming.candidate;
+          existing.environment = incoming.environment;
+          existing.evidencePointers = boundedPointers(existing.evidencePointers, incoming.evidencePointers);
+        } else {
+          records.push(incoming);
+        }
+        this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
+      }
+      persistRecovery(signature, tool) {
+        const records = readExperienceStore(this.path, true);
+        const existing = records.find((record2) => record2.signature === signature);
+        if (!existing)
+          return;
+        const now = this.now().toISOString();
+        existing.recovery = sanitizeString(`PASS immediately followed FAIL for ${tool}`);
+        existing.recoveryCount += 1;
+        existing.lastRecoveredAt = now;
+        delete existing.unknownReasons.recovery;
+        existing.evidencePointers = boundedPointers(existing.evidencePointers, [
+          `event:${randomUUID9()}`
+        ]);
+        this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
+      }
+      write(records) {
+        mkdirSync20(this.directory, { recursive: true, mode: 448 });
+        const temp = join47(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID9()}`);
+        try {
+          const sanitized = records.map((record2) => sanitizeForEvidence(record2));
+          const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
+          writeFileSync19(temp, contents.length > 0 ? `${contents}
+` : "", {
+            encoding: "utf8",
+            flag: "wx",
+            mode: 384
+          });
+          renameSync8(temp, this.path);
+          chmodSync5(this.path, 384);
+        } catch (error2) {
+          try {
+            unlinkSync12(temp);
+          } catch {
+          }
+          throw error2;
+        }
+      }
+    };
+  }
+});
+
 // packages/rn-dev-agent-core/dist/observability/live-device.js
-import { join as join47 } from "node:path";
+import { join as join48 } from "node:path";
 import { tmpdir as tmpdir13 } from "node:os";
 function isStateMutating(tool, args) {
   if (FLOW_MUTATION_TOOLS.has(tool))
@@ -81915,7 +82311,7 @@ function buildLiveDeps(input) {
     // iterable" when invoked as deps.pushLive(...). The live device gate caught
     // this — the unit fakes used standalone arrows and missed it.
     pushLive: (frame) => input.recorder.pushLive(frame),
-    tmpPath: () => join47(tmpdir13(), `rn-observe-live-${process.pid}.jpg`),
+    tmpPath: () => join48(tmpdir13(), `rn-observe-live-${process.pid}.jpg`),
     isMirrorActive: input.isMirrorActive
   };
 }
@@ -82010,9 +82406,9 @@ var init_e2e_csrf = __esm({
 
 // packages/rn-dev-agent-core/dist/observability/server.js
 import { createServer as createServer3 } from "node:http";
-import { readFileSync as readFileSync34 } from "node:fs";
-import { fileURLToPath as fileURLToPath5 } from "node:url";
-import { dirname as dirname21, join as join48 } from "node:path";
+import { readFileSync as readFileSync35 } from "node:fs";
+import { fileURLToPath as fileURLToPath6 } from "node:url";
+import { dirname as dirname22, join as join49 } from "node:path";
 function listen(server3, port) {
   return new Promise((resolve11, reject) => {
     const onErr = (e) => {
@@ -82034,7 +82430,7 @@ var init_server3 = __esm({
     init_e2e_csrf();
     init_logger();
     HOST = "127.0.0.1";
-    __dir = dirname21(fileURLToPath5(import.meta.url));
+    __dir = dirname22(fileURLToPath6(import.meta.url));
     ObservabilityServer = class {
       recorder;
       e2e;
@@ -82266,7 +82662,7 @@ var init_server3 = __esm({
       }
       index(res) {
         try {
-          let html = readFileSync34(join48(__dir, "web-dist", "index.html"), "utf8");
+          let html = readFileSync35(join49(__dir, "web-dist", "index.html"), "utf8");
           if (this.e2e) {
             const tokenJs = JSON.stringify(this.e2e.token).replace(/</g, "\\u003c");
             html = html.replace("</head>", `<script>window.__E2E_CSRF__=${tokenJs}</script></head>`);
@@ -82433,10 +82829,10 @@ var init_server3 = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/observability/observe-state.js
-import { join as join49 } from "node:path";
+import { join as join50 } from "node:path";
 function observeStatePath(projectRoot) {
   const safe = projectRoot.replace(/[^A-Za-z0-9._-]/g, "_");
-  return join49(getStateDir(), "observe", `${safe}.json`);
+  return join50(getStateDir(), "observe", `${safe}.json`);
 }
 function writeObserveState(url, port, projectRoot = findProjectRoot(), now = () => /* @__PURE__ */ new Date()) {
   try {
@@ -82721,7 +83117,7 @@ var init_jpeg_stream = __esm({
 import { spawn as spawn9, execFile as execFile25 } from "node:child_process";
 import { readFile as readFile2, unlink } from "node:fs/promises";
 import { tmpdir as tmpdir14 } from "node:os";
-import { join as join50 } from "node:path";
+import { join as join51 } from "node:path";
 async function probeIdbClient(execFileFn = execFile25) {
   return new Promise((resolve11) => {
     execFileFn("idb", ["--help"], { timeout: 3e3 }, (err) => {
@@ -82888,7 +83284,7 @@ var init_sources = __esm({
         this.gate = new RestartGate(3, 1e4, opts.now ?? Date.now);
         this.idleDelayMs = opts.idleDelayMs ?? 25;
         this.failurePauseMs = opts.failurePauseMs ?? 500;
-        this.tmpPath = opts.tmpPath ?? (() => join50(tmpdir14(), "rn-mirror-simctl-" + process.pid + ".jpg"));
+        this.tmpPath = opts.tmpPath ?? (() => join51(tmpdir14(), "rn-mirror-simctl-" + process.pid + ".jpg"));
         this.degradedHint = opts.degradedHint ?? SIMCTL_HINT;
       }
       start(sink) {
@@ -83311,16 +83707,16 @@ var init_target = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
-import { dirname as dirname22, join as join51 } from "node:path";
-import { mkdirSync as mkdirSync20, writeFileSync as writeFileSync19, renameSync as renameSync8, readFileSync as readFileSync35, readdirSync as readdirSync13, existsSync as existsSync36 } from "node:fs";
-import { createHash as createHash20 } from "node:crypto";
+import { dirname as dirname23, join as join52 } from "node:path";
+import { mkdirSync as mkdirSync21, writeFileSync as writeFileSync20, renameSync as renameSync9, readFileSync as readFileSync36, readdirSync as readdirSync13, existsSync as existsSync37 } from "node:fs";
+import { createHash as createHash21 } from "node:crypto";
 function e2eDirFor(projectRoot) {
-  return join51(projectRoot, ".rn-agent", "e2e");
+  return join52(projectRoot, ".rn-agent", "e2e");
 }
 function e2ePathFor(projectRoot, id) {
   assertValidActionId(id, "e2ePathFor");
   const dir = e2eDirFor(projectRoot);
-  const file = join51(dir, `${id}.yaml`);
+  const file = join52(dir, `${id}.yaml`);
   assertWithinDir(file, dir);
   return file;
 }
@@ -83344,11 +83740,11 @@ function serializeLockedTest(meta) {
 ${meta.flow}`;
 }
 function hashBody(s) {
-  return createHash20("sha256").update(s).digest("hex");
+  return createHash21("sha256").update(s).digest("hex");
 }
 function freezeLockedTest(projectRoot, source, ctx) {
   const filePath = e2ePathFor(projectRoot, source.id);
-  mkdirSync20(dirname22(filePath), { recursive: true });
+  mkdirSync21(dirname23(filePath), { recursive: true });
   const meta = {
     id: source.id,
     intent: source.intent,
@@ -83362,19 +83758,19 @@ function freezeLockedTest(projectRoot, source, ctx) {
     flow: source.flow
   };
   const tmp = `${filePath}.tmp`;
-  writeFileSync19(tmp, serializeLockedTest(meta), "utf8");
-  renameSync8(tmp, filePath);
+  writeFileSync20(tmp, serializeLockedTest(meta), "utf8");
+  renameSync9(tmp, filePath);
   return { ...meta, filePath };
 }
 function loadLockedTest(projectRoot, id) {
   const filePath = e2ePathFor(projectRoot, id);
-  if (!existsSync36(filePath))
+  if (!existsSync37(filePath))
     return null;
-  return parseLockedTest(readFileSync35(filePath, "utf8"), filePath);
+  return parseLockedTest(readFileSync36(filePath, "utf8"), filePath);
 }
 function discoverLockedTests(projectRoot) {
   const dir = e2eDirFor(projectRoot);
-  if (!existsSync36(dir))
+  if (!existsSync37(dir))
     return [];
   return readdirSync13(dir).filter((f) => f.endsWith(".yaml")).map((f) => f.replace(/\.yaml$/, "")).sort();
 }
@@ -83421,12 +83817,12 @@ var init_e2e_test = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/e2e-config.js
-import { readFileSync as readFileSync36 } from "node:fs";
-import { join as join52 } from "node:path";
+import { readFileSync as readFileSync37 } from "node:fs";
+import { join as join53 } from "node:path";
 function loadE2eConfig(projectRoot) {
-  const filePath = join52(projectRoot, ".rn-agent", "e2e.config.json");
+  const filePath = join53(projectRoot, ".rn-agent", "e2e.config.json");
   try {
-    const raw = readFileSync36(filePath, "utf8");
+    const raw = readFileSync37(filePath, "utf8");
     return JSON.parse(raw);
   } catch {
     return {};
@@ -83487,7 +83883,7 @@ var init_git_info = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/lock-e2e-test.js
-import { readFileSync as readFileSync37 } from "node:fs";
+import { readFileSync as readFileSync38 } from "node:fs";
 function readPassed(result) {
   try {
     const env = JSON.parse(result.content[0].text);
@@ -83502,7 +83898,7 @@ function readPassed(result) {
 async function lockE2eTestCore(args, deps = {}) {
   const projectRoot = args.projectRoot ?? findProjectRoot() ?? process.cwd();
   const load = deps.loadAction ?? loadAction;
-  const readFile3 = deps.readActionFile ?? ((p) => readFileSync37(p, "utf8"));
+  const readFile3 = deps.readActionFile ?? ((p) => readFileSync38(p, "utf8"));
   const getGit = deps.getGitInfo ?? getGitInfo;
   const getSession = deps.getSession ?? getActiveSession;
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
@@ -83577,8 +83973,8 @@ var init_lock_e2e_test = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
-import { join as join53 } from "node:path";
-import { mkdirSync as mkdirSync21, writeFileSync as writeFileSync20, renameSync as renameSync9, readFileSync as readFileSync38, existsSync as existsSync37 } from "node:fs";
+import { join as join54 } from "node:path";
+import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync21, renameSync as renameSync10, readFileSync as readFileSync39, existsSync as existsSync38 } from "node:fs";
 function classifyFlowResult(input) {
   if (input.passed) {
     return {
@@ -83632,20 +84028,20 @@ function diffNewlyFailing(current, previousGreen) {
   return current.results.filter((r) => !r.passed && r.classification !== "skipped" && (previousGreen === null || wasPassing.has(r.testId))).map((r) => r.testId);
 }
 function e2eRunsDirFor(projectRoot) {
-  return join53(sessionStateDirectory(projectRoot), "e2e-runs");
+  return join54(sessionStateDirectory(projectRoot), "e2e-runs");
 }
 function writeJsonAtomic(file, value) {
-  mkdirSync21(join53(file, ".."), { recursive: true });
+  mkdirSync22(join54(file, ".."), { recursive: true });
   const tmp = `${file}.tmp`;
-  writeFileSync20(tmp, JSON.stringify(value, null, 2), "utf8");
-  renameSync9(tmp, file);
+  writeFileSync21(tmp, JSON.stringify(value, null, 2), "utf8");
+  renameSync10(tmp, file);
 }
 function loadIndex(projectRoot) {
-  const file = join53(e2eRunsDirFor(projectRoot), "index.json");
-  if (!existsSync37(file))
+  const file = join54(e2eRunsDirFor(projectRoot), "index.json");
+  if (!existsSync38(file))
     return [];
   try {
-    const parsed = JSON.parse(readFileSync38(file, "utf8"));
+    const parsed = JSON.parse(readFileSync39(file, "utf8"));
     return Array.isArray(parsed) ? parsed : [];
   } catch {
     return [];
@@ -83654,7 +84050,7 @@ function loadIndex(projectRoot) {
 function writeRunRecord(projectRoot, rec) {
   assertValidActionId(rec.runId, "writeRunRecord");
   const dir = e2eRunsDirFor(projectRoot);
-  writeJsonAtomic(join53(dir, `${rec.runId}.json`), rec);
+  writeJsonAtomic(join54(dir, `${rec.runId}.json`), rec);
   const entry = {
     runId: rec.runId,
     finishedAt: rec.finishedAt,
@@ -83662,15 +84058,15 @@ function writeRunRecord(projectRoot, rec) {
     totals: rec.totals
   };
   const next = [entry, ...loadIndex(projectRoot).filter((e) => e.runId !== rec.runId)].slice(0, INDEX_MAX);
-  writeJsonAtomic(join53(dir, "index.json"), next);
+  writeJsonAtomic(join54(dir, "index.json"), next);
 }
 function loadRunRecord(projectRoot, runId) {
   assertValidActionId(runId, "loadRunRecord");
-  const file = join53(e2eRunsDirFor(projectRoot), `${runId}.json`);
-  if (!existsSync37(file))
+  const file = join54(e2eRunsDirFor(projectRoot), `${runId}.json`);
+  if (!existsSync38(file))
     return null;
   try {
-    return JSON.parse(readFileSync38(file, "utf8"));
+    return JSON.parse(readFileSync39(file, "utf8"));
   } catch {
     return null;
   }
@@ -83690,28 +84086,28 @@ var init_e2e_run = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run-request.js
-import { join as join54 } from "node:path";
-import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync21, renameSync as renameSync10, readFileSync as readFileSync39, readdirSync as readdirSync14, existsSync as existsSync38 } from "node:fs";
+import { join as join55 } from "node:path";
+import { mkdirSync as mkdirSync23, writeFileSync as writeFileSync22, renameSync as renameSync11, readFileSync as readFileSync40, readdirSync as readdirSync14, existsSync as existsSync39 } from "node:fs";
 function requestsDir(projectRoot) {
-  return join54(e2eRunsDirFor(projectRoot), "requests");
+  return join55(e2eRunsDirFor(projectRoot), "requests");
 }
 function requestPath(projectRoot, runId) {
   assertValidActionId(runId, "e2e-run-request");
-  return join54(requestsDir(projectRoot), `${runId}.json`);
+  return join55(requestsDir(projectRoot), `${runId}.json`);
 }
 function writeRequest(projectRoot, req) {
   const file = requestPath(projectRoot, req.runId);
-  mkdirSync22(requestsDir(projectRoot), { recursive: true });
+  mkdirSync23(requestsDir(projectRoot), { recursive: true });
   const tmp = `${file}.tmp`;
-  writeFileSync21(tmp, JSON.stringify(req, null, 2), "utf8");
-  renameSync10(tmp, file);
+  writeFileSync22(tmp, JSON.stringify(req, null, 2), "utf8");
+  renameSync11(tmp, file);
 }
 function loadRequest(projectRoot, runId) {
   const file = requestPath(projectRoot, runId);
-  if (!existsSync38(file))
+  if (!existsSync39(file))
     return null;
   try {
-    return JSON.parse(readFileSync39(file, "utf8"));
+    return JSON.parse(readFileSync40(file, "utf8"));
   } catch {
     return null;
   }
@@ -83726,7 +84122,7 @@ function updateRequest(projectRoot, runId, patch) {
 }
 function listRequests(projectRoot) {
   const dir = requestsDir(projectRoot);
-  if (!existsSync38(dir))
+  if (!existsSync39(dir))
     return [];
   const out = [];
   for (const f of readdirSync14(dir)) {
@@ -84046,9 +84442,9 @@ var init_preflight = __esm({
 
 // packages/rn-dev-agent-core/dist/domain/action-inventory.js
 import { readdirSync as readdirSync15 } from "node:fs";
-import { join as join55 } from "node:path";
+import { join as join56 } from "node:path";
 async function listActions(projectRoot) {
-  const actionsDir = join55(projectRoot, ".rn-agent", "actions");
+  const actionsDir = join56(projectRoot, ".rn-agent", "actions");
   let files;
   try {
     files = readdirSync15(actionsDir);
@@ -84159,9 +84555,9 @@ var init_runner_binding = __esm({
 
 // packages/rn-dev-agent-core/dist/session/local-authority-probe.js
 import { execFileSync as execFileSync17 } from "node:child_process";
-import { createHash as createHash21 } from "node:crypto";
+import { createHash as createHash22 } from "node:crypto";
 function identity(value) {
-  return createHash21("sha256").update(JSON.stringify(value)).digest("hex");
+  return createHash22("sha256").update(JSON.stringify(value)).digest("hex");
 }
 function objectBinding(status, name) {
   const value = status.bindings[name];
@@ -84998,12 +85394,12 @@ var index_exports = {};
 __export(index_exports, {
   strictProofMonitor: () => strictProofMonitor
 });
-import { createHash as createHash22, createHmac as createHmac5, randomUUID as randomUUID9 } from "node:crypto";
-import { readFileSync as readFileSync40, rmSync as rmSync11 } from "node:fs";
+import { createHash as createHash23, createHmac as createHmac5, randomUUID as randomUUID10 } from "node:crypto";
+import { readFileSync as readFileSync41, rmSync as rmSync11 } from "node:fs";
 import { execFile as execFile26 } from "node:child_process";
 import { promisify as promisify28 } from "node:util";
-import { fileURLToPath as fileURLToPath6 } from "node:url";
-import { dirname as dirname23, join as join56 } from "node:path";
+import { fileURLToPath as fileURLToPath7 } from "node:url";
+import { dirname as dirname24, join as join57 } from "node:path";
 function trackedTool(name, desc, schema, handler) {
   registeredToolNames.push(name);
   const base = instrumentTool(name, authorityGate.wrap(name, arbiterWrap(name, handler)));
@@ -85455,7 +85851,7 @@ async function main() {
     });
   }
 }
-var pkgPath, pkgVersion, lockfile, diagnosticContractProbe, noLock, client, getClient, configureClientLifecycle, setClient, publishClient, createClient, execFileP, mustOk, makeReplayDeps, server2, strictProofMonitor, authorityRuntime, createRuntimeAuthorityProbe, localAuthorityProbe, authorityGate, blindProbeContext, mirrorCfg, mirrorManager2, liveEnabled, liveDeps, registeredToolNames, persistedAuthorityStatus, getSessionSignerCapability, spawningSupervisorPid, requestWorkerRecycle, sessionHandler, disconnectClientHandler, connectBoundSession, resolveNativeProofDevice, proofReadiness, proofCaptureHandler, e2ePreflight, e2eReload, e2eSuiteHandler, e2eCsrfToken, projectRootFor, triggerE2eRun, runActionHandler, observeRunActionHandler, observeTriggerRun, gatedObserveState, shutdown, stopParentWatch;
+var pkgPath, pkgVersion, lockfile, diagnosticContractProbe, noLock, client, getClient, configureClientLifecycle, setClient, publishClient, createClient, execFileP, mustOk, makeReplayDeps, server2, strictProofMonitor, experienceRecorder, authorityRuntime, createRuntimeAuthorityProbe, localAuthorityProbe, authorityGate, blindProbeContext, mirrorCfg, mirrorManager2, liveEnabled, liveDeps, registeredToolNames, persistedAuthorityStatus, getSessionSignerCapability, spawningSupervisorPid, requestWorkerRecycle, sessionHandler, disconnectClientHandler, connectBoundSession, resolveNativeProofDevice, proofReadiness, proofCaptureHandler, e2ePreflight, e2eReload, e2eSuiteHandler, e2eCsrfToken, projectRootFor, triggerE2eRun, runActionHandler, observeRunActionHandler, observeTriggerRun, gatedObserveState, shutdown, stopParentWatch;
 var init_index = __esm({
   "packages/rn-dev-agent-core/dist/index.js"() {
     "use strict";
@@ -85534,6 +85930,7 @@ var init_index = __esm({
     init_process_birth();
     init_ensure_single_runner();
     init_instrumentation();
+    init_evidence();
     init_recorder();
     init_proof_capture();
     init_live_device();
@@ -85575,8 +85972,8 @@ var init_index = __esm({
     init_source_identity();
     init_managed_metro();
     init_process_cleanup();
-    pkgPath = join56(dirname23(fileURLToPath6(import.meta.url)), "..", "package.json");
-    pkgVersion = JSON.parse(readFileSync40(pkgPath, "utf8")).version;
+    pkgPath = join57(dirname24(fileURLToPath7(import.meta.url)), "..", "package.json");
+    pkgVersion = JSON.parse(readFileSync41(pkgPath, "utf8")).version;
     lockfile = null;
     diagnosticContractProbe = process.argv.includes("--diagnostic-contract-probe");
     noLock = diagnosticContractProbe || process.argv.includes("--no-lock");
@@ -85678,8 +86075,13 @@ var init_index = __esm({
       version: pkgVersion
     });
     strictProofMonitor = new StrictProofMonitor();
+    experienceRecorder = new ExperienceRecorder({
+      coreVersion: pkgVersion,
+      pluginVersion: discoverPluginVersion()
+    });
     addToolObserver((o) => recorder.record(o));
     addToolObserver((o) => strictProofMonitor.record(o));
+    addToolObserver((o) => experienceRecorder.observe(o));
     authorityRuntime = getWorkerAuthorityRuntime();
     setSnapshotAuthorityProvider({
       current: () => {
@@ -85704,7 +86106,7 @@ var init_index = __esm({
           runnerInstanceId: runner?.instanceId,
           runnerPid: runner?.pid,
           runnerProcessBirth: runner?.processBirth,
-          runnerCapabilityHash: typeof runner?.capability === "string" ? createHash22("sha256").update(runner.capability).digest("hex") : void 0,
+          runnerCapabilityHash: typeof runner?.capability === "string" ? createHash23("sha256").update(runner.capability).digest("hex") : void 0,
           runnerPort: runner?.port,
           runnerClaim: status.claims.find((claim) => claim.type === "runner")?.key,
           deviceClaim: status.claims.find((claim) => claim.type === "device")?.key
@@ -85895,7 +86297,7 @@ var init_index = __esm({
           authority: {
             sessionId: status.sessionId,
             claimEpoch: status.claimEpoch,
-            instanceId: randomUUID9(),
+            instanceId: randomUUID10(),
             capability: secret.observeCapability
           }
         };
@@ -85979,7 +86381,7 @@ var init_index = __esm({
       readRoute: (c) => readLiveRoute(c),
       readShotFile: (path) => {
         try {
-          const buf = readFileSync40(path);
+          const buf = readFileSync41(path);
           const isPng = buf.length >= 4 && buf[0] === 137 && buf[1] === 80 && buf[2] === 78 && buf[3] === 71;
           return { buf, contentType: isPng ? "image/png" : "image/jpeg" };
         } catch {
@@ -85999,7 +86401,7 @@ var init_index = __esm({
         return null;
       if (sessionId && !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(sessionId))
         return null;
-      const secretPath = sessionId ? join56(dirname23(dirname23(currentSecretPath)), sessionId, "secret.json") : currentSecretPath;
+      const secretPath = sessionId ? join57(dirname24(dirname24(currentSecretPath)), sessionId, "secret.json") : currentSecretPath;
       return readJsonStateFile(secretPath)?.signerCapability ?? null;
     };
     spawningSupervisorPid = process.ppid;
@@ -86539,7 +86941,7 @@ var init_index = __esm({
           connectedAt: current.connectedAt
         }),
         errorCount: errors.length,
-        errorSha256: createHash22("sha256").update(errorBytes).digest("hex"),
+        errorSha256: createHash23("sha256").update(errorBytes).digest("hex"),
         device: identity2.device,
         runtime: identity2.runtime
       };
@@ -87032,11 +87434,11 @@ var init_index = __esm({
 // packages/rn-dev-agent-core/dist/supervisor.js
 init_lockfile();
 init_parent_watch();
-import { randomUUID as randomUUID10 } from "node:crypto";
+import { randomUUID as randomUUID11 } from "node:crypto";
 import { spawn as spawn10 } from "node:child_process";
-import { readFileSync as readFileSync41 } from "node:fs";
-import { dirname as dirname24, join as join57 } from "node:path";
-import { fileURLToPath as fileURLToPath7 } from "node:url";
+import { readFileSync as readFileSync42 } from "node:fs";
+import { dirname as dirname25, join as join58 } from "node:path";
+import { fileURLToPath as fileURLToPath8 } from "node:url";
 
 // packages/rn-dev-agent-core/dist/lifecycle/stdio-frames.js
 var LineSplitter = class {
@@ -87521,8 +87923,8 @@ function supervisorRelaunchArgs(supervisorPath, sqliteWarningFilterPath2, versio
 }
 
 // packages/rn-dev-agent-core/dist/supervisor.js
-var here = dirname24(fileURLToPath7(import.meta.url));
-var sqliteWarningFilterPath = join57(here, "sqlite-warning-filter.js");
+var here = dirname25(fileURLToPath8(import.meta.url));
+var sqliteWarningFilterPath = join58(here, "sqlite-warning-filter.js");
 var unsupportedNode = unsupportedNodeVersionMessage();
 if (unsupportedNode) {
   process.stderr.write(`${unsupportedNode}
@@ -87531,7 +87933,7 @@ if (unsupportedNode) {
 }
 var supervisorFlag = sqliteFlagForNode();
 if (supervisorFlag.length > 0 && !process.execArgv.includes("--experimental-sqlite") && process.env.RN_DEV_AGENT_SQLITE_RELAUNCHED !== "1") {
-  const child = spawn10(process.execPath, supervisorRelaunchArgs(fileURLToPath7(import.meta.url), sqliteWarningFilterPath, void 0, process.argv.slice(2)), {
+  const child = spawn10(process.execPath, supervisorRelaunchArgs(fileURLToPath8(import.meta.url), sqliteWarningFilterPath, void 0, process.argv.slice(2)), {
     stdio: "inherit",
     env: { ...process.env, RN_DEV_AGENT_SQLITE_RELAUNCHED: "1" }
   });
@@ -87572,13 +87974,13 @@ if (process.env.RN_BRIDGE_SUPERVISOR === "0") {
 `);
   }, spawnWorker2 = function() {
     resolveAuthorityForSpawn2();
-    const workerInstance = randomUUID10();
+    const workerInstance = randomUUID11();
     const child = spawn10(process.execPath, workerSpawnArgs(workerPath, sqliteWarningFilterPath, void 0, process.argv.slice(2)), {
       stdio: ["pipe", "pipe", "inherit"],
       env: {
         ...process.env,
         RN_BRIDGE_SUPERVISED: "1",
-        RN_DEV_AGENT_SESSION_CLI: join57(here, "rn-session.js"),
+        RN_DEV_AGENT_SESSION_CLI: join58(here, "rn-session.js"),
         RN_BRIDGE_RESTARTS: String(core.restartCount),
         ...core.lastExit ? { RN_BRIDGE_LAST_EXIT: core.lastExit } : {},
         ...authority ? authority.workerEnvironment(workerInstance) : { RN_DEV_AGENT_AUTHORITY_ERROR: authorityError ?? "AUTHORITY_STORE_UNAVAILABLE" }
@@ -87642,12 +88044,12 @@ if (process.env.RN_BRIDGE_SUPERVISOR === "0") {
     force.unref();
   };
   apply = apply2, resolveAuthorityForSpawn = resolveAuthorityForSpawn2, spawnWorker = spawnWorker2, closeAuthorityAndExit = closeAuthorityAndExit2, beginShutdown = beginShutdown2;
-  const workerPath = process.env.RN_BRIDGE_WORKER_PATH ?? join57(here, "index.js");
+  const workerPath = process.env.RN_BRIDGE_WORKER_PATH ?? join58(here, "index.js");
   const noLock2 = process.argv.includes("--no-lock");
   const diagnosticContractProbe2 = process.argv.includes("--diagnostic-contract-probe");
   let lockfile2 = null;
   if (!noLock2) {
-    const pkg = JSON.parse(readFileSync41(join57(here, "..", "package.json"), "utf8"));
+    const pkg = JSON.parse(readFileSync42(join58(here, "..", "package.json"), "utf8"));
     lockfile2 = new Lockfile({ version: pkg.version });
     const lockResult = lockfile2.acquire();
     if (lockResult.status === "conflict") {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -81846,7 +81846,29 @@ function applyRedactionRules(value) {
     pattern.lastIndex = 0;
     result = result.replace(pattern, replacement);
   }
+  const identity2 = readAppIdentity();
+  if (identity2.name)
+    result = result.replaceAll(identity2.name, "[APP_NAME_REDACTED]");
+  if (identity2.slug)
+    result = result.replaceAll(identity2.slug, "[APP_SLUG_REDACTED]");
   return result;
+}
+function readAppIdentity() {
+  const root = process.env.RN_PROJECT_ROOT ?? process.env.CLAUDE_USER_CWD ?? process.cwd();
+  if (appIdentityCache?.root === root)
+    return appIdentityCache.identity;
+  const manifest = join47(root, "app.json");
+  let identity2 = { name: null, slug: null };
+  if (existsSync36(manifest)) {
+    const parsed = JSON.parse(readFileSync34(manifest, "utf8"));
+    const expo = parsed.expo ?? parsed;
+    identity2 = { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
+  }
+  appIdentityCache = { root, identity: identity2 };
+  return identity2;
+}
+function usableIdentity(value) {
+  return typeof value === "string" && value.trim().length > 2 ? value : null;
 }
 function discoverPluginVersion(fromUrl = import.meta.url) {
   if (process.env.RN_DEV_AGENT_PLUGIN_VERSION)
@@ -81868,16 +81890,26 @@ function discoverPluginVersion(fromUrl = import.meta.url) {
   }
   return null;
 }
-function readExperienceStore(path, allowMissing = false) {
-  if (!existsSync36(path)) {
-    if (allowMissing)
-      return [];
+function readExperienceStore(path) {
+  if (!existsSync36(path))
     return [];
-  }
   const contents = readFileSync34(path, "utf8");
   if (!contents.trim())
     return [];
-  return contents.split("\n").filter((line) => line.trim().length > 0).map((line) => JSON.parse(line));
+  const records = [];
+  for (const line of contents.split("\n")) {
+    if (line.trim().length === 0)
+      continue;
+    let parsed;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    SANITIZED_RECORDS.add(parsed);
+    records.push(parsed);
+  }
+  return records;
 }
 function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, retentionMs = DEFAULT_RETENTION_DAYS * DAY_MS) {
   const cutoff = now.getTime() - retentionMs;
@@ -81899,52 +81931,7 @@ function normalizeSymptomShape(symptom) {
 }
 function classifyExperience(symptom, tool, platform) {
   const haystack = `${tool} ${platform ?? ""} ${symptom}`.toLowerCase();
-  const rules = [
-    ["FF_REDBOX", /redbox|logbox|error overlay|hasredbox/],
-    ["FF_DEBUGGER_PAUSED", /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
-    [
-      "FF_STALE_CDP",
-      /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/
-    ],
-    ["FF_FAST_REFRESH_STALE", /fast refresh|ui unchanged|old exports|old module path/],
-    ["FF_METRO_CACHE", /metro.*(?:stale|cache)|config change not reflected/],
-    [
-      "FF_BINARY_MISMATCH",
-      /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/
-    ],
-    ["FF_EXPO_DIALOG", /open-in-app|system confirmation dialog/],
-    [
-      "FF_DEV_CLIENT_PICKER",
-      /no hermes target|development servers|devclientlauncher|server picker/
-    ],
-    ["FF_KEYBOARD_OVERLAY", /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
-    ["FF_MAESTRO_GRPC_ANDROID", /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
-    [
-      "FF_ANDROID_TEXT_INPUT_CRASH",
-      /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/
-    ],
-    [
-      "FF_AUTH_GATE",
-      /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/
-    ],
-    [
-      "FF_PERMISSION_ALREADY_GRANTED",
-      /permission already granted|prompt (?:was )?not shown|flow completes instantly/
-    ],
-    ["EG_EXPO_GO_SDK_MISMATCH", /incompatible with this version of expo go|expo go sdk.*mismatch/],
-    ["EG_NATIVEWIND_JSX_SOURCE", /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
-    ["EG_EXPO_GO_NATIVE_MODULES", /expo go.*custom native module/],
-    ["EG_DEV_CLIENT_CLEARSTATE", /clearstate.*(?:dev client|metro connection|launcher)/],
-    ["EG_MSW_HERMES", /msw.*(?:hermes|react native|initialize)/],
-    ["EG_EXPO_ROUTER_DEEP_LINK", /expo router.*deep link|deep link.*confirmation dialog/],
-    ["EG_DEV_MENU_INTERFERENCE", /dev menu.*(?:overlay|recording|blocking)/],
-    ["EG_NEW_ARCH_CDP_TARGET", /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
-    ["PQ_IOS_RECORDVIDEO_CODEC", /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
-    ["PQ_ANDROID_SCREENRECORD_LIMIT", /screenrecord.*180|screenrecord.*3 minute/],
-    ["PQ_ANDROID_BOOT_DELAY", /sys\.boot_completed|emulator.*grpc.*ready/],
-    ["PQ_ANDROID_PLAY_PROTECT", /play protect.*(?:block|apk|install)/]
-  ];
-  return rules.find(([, pattern]) => pattern.test(haystack))?.[0] ?? UNKNOWN_CLASSIFICATION;
+  return CLASSIFICATION_RULES.find(([, pattern]) => pattern.test(haystack))?.[0] ?? UNKNOWN_CLASSIFICATION;
 }
 function extractSymptom(event) {
   if (typeof event.error === "string" && event.error.length > 0)
@@ -81961,6 +81948,12 @@ function extractSymptom(event) {
     }
   }
   return `${event.tool} reported ${event.status} without an error message`;
+}
+function boundSymptom(symptom) {
+  if (symptom.length <= MAX_SYMPTOM_LENGTH)
+    return symptom;
+  const head = symptom.slice(0, MAX_SYMPTOM_LENGTH).replace(/\S+$/, "");
+  return `${head}${SYMPTOM_TRUNCATED}`;
 }
 function extractScalar(event, keys) {
   const sources = [event.params, event.result];
@@ -81992,10 +81985,16 @@ function findScalar(value, keys, depth) {
 function sanitizeNullable(value) {
   return value === null ? null : sanitizeString(value);
 }
+function adoptLateFact(existing, incoming, field2) {
+  if (existing[field2] !== null || incoming[field2] === null)
+    return;
+  existing[field2] = incoming[field2];
+  delete existing.unknownReasons[field2];
+}
 function boundedPointers(existing, incoming) {
   return [.../* @__PURE__ */ new Set([...existing, ...incoming])].slice(-MAX_EVIDENCE_POINTERS);
 }
-var UNKNOWN_CLASSIFICATION, DEFAULT_MAX_RECORDS, DEFAULT_RETENTION_DAYS, MAX_EVIDENCE_POINTERS, EXPERIENCE_DIRECTORY, EXPERIENCE_STORE_NAME, DAY_MS, REDACTION_FAILED, REDACTION_RULES, KEYED_SECRET, ExperienceRecorder;
+var UNKNOWN_CLASSIFICATION, DEFAULT_MAX_RECORDS, DEFAULT_RETENTION_DAYS, MAX_EVIDENCE_POINTERS, EXPERIENCE_DIRECTORY, EXPERIENCE_STORE_NAME, MAX_SYMPTOM_LENGTH, DAY_MS, REDACTION_FAILED, SYMPTOM_TRUNCATED, REDACTION_RULES, KEYED_SECRET, SANITIZED_RECORDS, appIdentityCache, ExperienceRecorder, CLASSIFICATION_RULES, EXPERIENCE_FAMILY_IDS;
 var init_evidence = __esm({
   "packages/rn-dev-agent-core/dist/experience/evidence.js"() {
     "use strict";
@@ -82005,8 +82004,10 @@ var init_evidence = __esm({
     MAX_EVIDENCE_POINTERS = 3;
     EXPERIENCE_DIRECTORY = join47(homedir11(), ".claude", "rn-agent", "experience");
     EXPERIENCE_STORE_NAME = "patterns.jsonl";
+    MAX_SYMPTOM_LENGTH = 2048;
     DAY_MS = 24 * 60 * 60 * 1e3;
     REDACTION_FAILED = "[REDACTION_FAILED]";
+    SYMPTOM_TRUNCATED = "[TRUNCATED]";
     REDACTION_RULES = [
       [/(sk|pk|api|key|token|secret|password|auth)[-_]?[A-Za-z0-9_-]{20,}/gi, "[REDACTED_SECRET]"],
       [/Bearer [A-Za-z0-9_./+=-]{20,}/g, "Bearer [REDACTED]"],
@@ -82032,6 +82033,8 @@ var init_evidence = __esm({
       [/(com|org|io|dev|net)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_.-]+/g, "[BUNDLE_REDACTED]"]
     ];
     KEYED_SECRET = /((?:token|secret|password|auth|api[_-]?key)\s*[:=]\s*)[^\s,;}]{6,}/gi;
+    SANITIZED_RECORDS = /* @__PURE__ */ new WeakSet();
+    appIdentityCache = null;
     ExperienceRecorder = class {
       directory;
       path;
@@ -82095,7 +82098,7 @@ var init_evidence = __esm({
       buildFailureRecord(event) {
         const now = this.now().toISOString();
         const tool = sanitizeString(event.tool);
-        const symptom = sanitizeString(extractSymptom(event));
+        const symptom = sanitizeString(boundSymptom(extractSymptom(event)));
         const platform = sanitizeNullable(extractScalar(event, ["platform"]));
         const deviceName = extractScalar(event, ["deviceName", "deviceModel", "model"]);
         const hasDeviceId = extractScalar(event, ["deviceId", "udid"]) !== null;
@@ -82147,18 +82150,26 @@ var init_evidence = __esm({
           lastRecoveredAt: null,
           unknownReasons
         };
-        return sanitizeForEvidence(raw);
+        const sanitized = sanitizeForEvidence(raw);
+        SANITIZED_RECORDS.add(sanitized);
+        return sanitized;
       }
       persistFailure(incoming) {
-        const records = readExperienceStore(this.path, true);
+        const records = readExperienceStore(this.path);
         const existing = records.find((record2) => record2.signature === incoming.signature);
         if (existing) {
           existing.count += 1;
           existing.lastSeen = incoming.lastSeen;
-          existing.status = incoming.status;
+          if (incoming.status === "ERROR" && existing.status !== "ERROR") {
+            existing.status = "ERROR";
+            existing.trigger = incoming.trigger;
+          }
           existing.symptom = incoming.symptom;
           existing.candidate = incoming.candidate;
           existing.environment = incoming.environment;
+          adoptLateFact(existing, incoming, "platform");
+          adoptLateFact(existing, incoming, "device");
+          adoptLateFact(existing, incoming, "runtime");
           existing.evidencePointers = boundedPointers(existing.evidencePointers, incoming.evidencePointers);
         } else {
           records.push(incoming);
@@ -82166,7 +82177,7 @@ var init_evidence = __esm({
         this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
       }
       persistRecovery(signature, tool) {
-        const records = readExperienceStore(this.path, true);
+        const records = readExperienceStore(this.path);
         const existing = records.find((record2) => record2.signature === signature);
         if (!existing)
           return;
@@ -82184,7 +82195,7 @@ var init_evidence = __esm({
         mkdirSync20(this.directory, { recursive: true, mode: 448 });
         const temp = join47(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID9()}`);
         try {
-          const sanitized = records.map((record2) => sanitizeForEvidence(record2));
+          const sanitized = records.map((record2) => SANITIZED_RECORDS.has(record2) ? record2 : sanitizeForEvidence(record2));
           const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
           writeFileSync19(temp, contents.length > 0 ? `${contents}
 ` : "", {
@@ -82203,6 +82214,46 @@ var init_evidence = __esm({
         }
       }
     };
+    CLASSIFICATION_RULES = [
+      ["FF_REDBOX", /redbox|logbox|error overlay|hasredbox/],
+      ["FF_DEBUGGER_PAUSED", /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
+      [
+        "FF_STALE_CDP",
+        /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/
+      ],
+      ["FF_FAST_REFRESH_STALE", /fast refresh|ui unchanged|old exports|old module path/],
+      ["FF_METRO_CACHE", /metro.*(?:stale|cache)|config change not reflected/],
+      [
+        "FF_BINARY_MISMATCH",
+        /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/
+      ],
+      ["FF_EXPO_DIALOG", /open-in-app|system confirmation dialog/],
+      ["FF_DEV_CLIENT_PICKER", /no hermes target|development servers|devclientlauncher|server picker/],
+      ["FF_KEYBOARD_OVERLAY", /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
+      ["FF_MAESTRO_GRPC_ANDROID", /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
+      [
+        "FF_ANDROID_TEXT_INPUT_CRASH",
+        /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/
+      ],
+      ["FF_AUTH_GATE", /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/],
+      [
+        "FF_PERMISSION_ALREADY_GRANTED",
+        /permission already granted|prompt (?:was )?not shown|flow completes instantly/
+      ],
+      ["EG_EXPO_GO_SDK_MISMATCH", /incompatible with this version of expo go|expo go sdk.*mismatch/],
+      ["EG_NATIVEWIND_JSX_SOURCE", /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
+      ["EG_EXPO_GO_NATIVE_MODULES", /expo go.*custom native module/],
+      ["EG_DEV_CLIENT_CLEARSTATE", /clearstate.*(?:dev client|metro connection|launcher)/],
+      ["EG_MSW_HERMES", /msw.*(?:hermes|react native|initialize)/],
+      ["EG_EXPO_ROUTER_DEEP_LINK", /expo router.*deep link|deep link.*confirmation dialog/],
+      ["EG_DEV_MENU_INTERFERENCE", /dev menu.*(?:overlay|recording|blocking)/],
+      ["EG_NEW_ARCH_CDP_TARGET", /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
+      ["PQ_IOS_RECORDVIDEO_CODEC", /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
+      ["PQ_ANDROID_SCREENRECORD_LIMIT", /screenrecord.*180|screenrecord.*3 minute/],
+      ["PQ_ANDROID_BOOT_DELAY", /sys\.boot_completed|emulator.*grpc.*ready/],
+      ["PQ_ANDROID_PLAY_PROTECT", /play protect.*(?:block|apk|install)/]
+    ];
+    EXPERIENCE_FAMILY_IDS = CLASSIFICATION_RULES.map(([id]) => id);
   }
 });
 

--- a/packages/rn-dev-agent-core/dist/experience-trends.js
+++ b/packages/rn-dev-agent-core/dist/experience-trends.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+import { readExperienceTrendReport } from './experience/trends.js';
+function usage() {
+    process.stderr.write('Usage: rn-experience-trends [--since <ISO timestamp>] [--json]\n' +
+        '  --since is the generated-at timestamp printed by the previous report (default: 24 hours ago).\n' +
+        '  This command only reads ~/.claude/rn-agent/experience/patterns.jsonl.\n');
+    process.exit(2);
+}
+let since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+let json = false;
+for (let index = 2; index < process.argv.length; index += 1) {
+    const argument = process.argv[index];
+    if (argument === '--json') {
+        json = true;
+    }
+    else if (argument === '--since') {
+        const value = process.argv[++index];
+        const parsed = value ? new Date(value) : new Date(Number.NaN);
+        if (!Number.isFinite(parsed.getTime()))
+            usage();
+        since = parsed;
+    }
+    else if (argument === '--help' || argument === '-h') {
+        usage();
+    }
+    else {
+        usage();
+    }
+}
+try {
+    const report = readExperienceTrendReport({ since });
+    if (json) {
+        process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    }
+    else {
+        process.stdout.write(`Experience trends (new since ${report.since})\n`);
+        process.stdout.write(`Report generated at ${report.generatedAt}; pass this value to --since next time.\n`);
+        process.stdout.write('\nFamilies by frequency\n');
+        if (report.families.length === 0)
+            process.stdout.write('  none\n');
+        for (const family of report.families) {
+            process.stdout.write(`  ${family.classification}: ${family.count} occurrence(s), ${family.patterns} pattern(s)\n`);
+        }
+        process.stdout.write('\nNew since previous report\n');
+        if (report.newSincePreviousReport.length === 0)
+            process.stdout.write('  none\n');
+        for (const item of report.newSincePreviousReport) {
+            process.stdout.write(`  ${item.classification} ${item.tool}: ${item.count} (${item.signature.slice(0, 12)})\n`);
+        }
+        process.stdout.write('\nRecurring\n');
+        if (report.recurring.length === 0)
+            process.stdout.write('  none\n');
+        for (const item of report.recurring) {
+            process.stdout.write(`  ${item.classification} ${item.tool}: ${item.count} (${item.signature.slice(0, 12)})\n`);
+        }
+    }
+}
+catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`rn-experience-trends: could not read the local evidence store: ${message}\n`);
+    process.exitCode = 1;
+}

--- a/packages/rn-dev-agent-core/dist/experience/evidence.js
+++ b/packages/rn-dev-agent-core/dist/experience/evidence.js
@@ -1,0 +1,426 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync, } from 'node:fs';
+import { homedir, platform as hostPlatform, release } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+export const UNKNOWN_CLASSIFICATION = 'UNKNOWN';
+export const DEFAULT_MAX_RECORDS = 500;
+export const DEFAULT_RETENTION_DAYS = 14;
+export const MAX_EVIDENCE_POINTERS = 3;
+export const EXPERIENCE_DIRECTORY = join(homedir(), '.claude', 'rn-agent', 'experience');
+export const EXPERIENCE_STORE_NAME = 'patterns.jsonl';
+const DAY_MS = 24 * 60 * 60 * 1000;
+const REDACTION_FAILED = '[REDACTION_FAILED]';
+// Keep this list aligned with scripts/collect-feedback.sh. That collector is the
+// public sanitization contract; this in-process form exists so private tool
+// payloads never have to cross a process boundary.
+const REDACTION_RULES = [
+    [/(sk|pk|api|key|token|secret|password|auth)[-_]?[A-Za-z0-9_-]{20,}/gi, '[REDACTED_SECRET]'],
+    [/Bearer [A-Za-z0-9_./+=-]{20,}/g, 'Bearer [REDACTED]'],
+    [/ghp_[A-Za-z0-9_]{36}/g, '[REDACTED_GH_TOKEN]'],
+    [/eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g, '[REDACTED_JWT]'],
+    [/AKIA[0-9A-Z]{16}/g, '[REDACTED_AWS]'],
+    [/xox[baprs]-[A-Za-z0-9-]+/g, '[REDACTED_SLACK]'],
+    [/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, '[EMAIL_REDACTED]'],
+    [
+        /(^|[^0-9])(192|10|172|169)\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}([^0-9]|$)/g,
+        '$1[IP_REDACTED]$3',
+    ],
+    [/(^|[^0-9])[0-9]{1,3}(?:\.[0-9]{1,3}){3}([^0-9]|$)/g, '$1[IP_REDACTED]$2'],
+    [
+        /(?:https?:\/\/)?(?:localhost|127\.0\.0\.1)(?::[0-9]{2,5})?(?:\/[^\s]*)?/gi,
+        '[LOOPBACK_ENDPOINT_REDACTED]',
+    ],
+    [/"(metroPort|observePort|port)"\s*:\s*[0-9]+/g, '"$1":"[PORT_REDACTED]"'],
+    [/\bport\s*[:=]?\s*[0-9]{2,5}\b/gi, '[PORT_REDACTED]'],
+    [/:([0-9]{2,5})(?=\/|\s|$)/g, ':[PORT_REDACTED]'],
+    [/~\/[A-Za-z0-9_./-]+/g, '[PATH_REDACTED]'],
+    [/\/(Users|home|opt|var|tmp|etc|private|Volumes)\/[A-Za-z0-9_./-]+/g, '[PATH_REDACTED]'],
+    [/(com|org|io|dev|net)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_.-]+/g, '[BUNDLE_REDACTED]'],
+];
+// The shell contract catches keyword-adjacent values. Structured tool errors
+// commonly use `token=...`, so retain the same secret vocabulary while also
+// handling the separator explicitly.
+const KEYED_SECRET = /((?:token|secret|password|auth|api[_-]?key)\s*[:=]\s*)[^\s,;}]{6,}/gi;
+export function sanitizeString(value, redact = applyRedactionRules) {
+    try {
+        return redact(value);
+    }
+    catch {
+        return REDACTION_FAILED;
+    }
+}
+export function sanitizeForEvidence(value, redact) {
+    if (value === null ||
+        value === undefined ||
+        typeof value === 'boolean' ||
+        typeof value === 'number') {
+        return value;
+    }
+    if (typeof value === 'string')
+        return sanitizeString(value, redact);
+    if (Array.isArray(value))
+        return value.map((item) => sanitizeForEvidence(item, redact));
+    if (typeof value === 'object') {
+        const sanitized = {};
+        for (const [key, nested] of Object.entries(value)) {
+            sanitized[key] = sanitizeForEvidence(nested, redact);
+        }
+        return sanitized;
+    }
+    return REDACTION_FAILED;
+}
+function applyRedactionRules(value) {
+    let result = value.replaceAll(homedir(), '~').replace(KEYED_SECRET, '$1[REDACTED_SECRET]');
+    for (const [pattern, replacement] of REDACTION_RULES) {
+        pattern.lastIndex = 0;
+        result = result.replace(pattern, replacement);
+    }
+    return result;
+}
+export class ExperienceRecorder {
+    directory;
+    path;
+    candidate;
+    environment;
+    maxRecords;
+    retentionMs;
+    now;
+    schedule;
+    previousFailure = null;
+    constructor(options) {
+        this.directory =
+            options.directory ?? process.env.RN_DEV_AGENT_EXPERIENCE_DIR ?? EXPERIENCE_DIRECTORY;
+        this.path = join(this.directory, EXPERIENCE_STORE_NAME);
+        this.candidate = {
+            pluginVersion: options.pluginVersion ?? null,
+            coreVersion: options.coreVersion,
+        };
+        this.environment = { os: `${hostPlatform()} ${release()}`, node: process.version };
+        this.maxRecords = options.maxRecords ?? DEFAULT_MAX_RECORDS;
+        this.retentionMs = (options.retentionDays ?? DEFAULT_RETENTION_DAYS) * DAY_MS;
+        this.now = options.now ?? (() => new Date());
+        this.schedule = options.schedule ?? ((work) => setImmediate(work));
+    }
+    /** Queue only: persistence never executes in the observed tool's call stack. */
+    observe(event) {
+        try {
+            this.schedule(() => this.recordNonLoadBearing(event));
+        }
+        catch {
+            /* experience evidence is non-load-bearing */
+        }
+    }
+    /** Test and CLI support; returns a sanitized, deduplicated view. */
+    read() {
+        return readExperienceStore(this.path);
+    }
+    recordNonLoadBearing(event) {
+        try {
+            this.record(event);
+        }
+        catch {
+            /* an unwritable/corrupt store must never affect tool behavior */
+        }
+    }
+    record(event) {
+        if (!event || typeof event.tool !== 'string') {
+            this.previousFailure = null;
+            return;
+        }
+        if (event.status === 'PASS') {
+            const recovery = this.previousFailure;
+            this.previousFailure = null;
+            if (recovery?.tool === event.tool)
+                this.persistRecovery(recovery.signature, event.tool);
+            return;
+        }
+        if (event.status !== 'FAIL' && event.status !== 'ERROR') {
+            this.previousFailure = null;
+            return;
+        }
+        const record = this.buildFailureRecord(event);
+        this.persistFailure(record);
+        this.previousFailure =
+            event.status === 'FAIL' ? { tool: event.tool, signature: record.signature } : null;
+    }
+    buildFailureRecord(event) {
+        const now = this.now().toISOString();
+        const tool = sanitizeString(event.tool);
+        const symptom = sanitizeString(extractSymptom(event));
+        const platform = sanitizeNullable(extractScalar(event, ['platform']));
+        const deviceName = extractScalar(event, ['deviceName', 'deviceModel', 'model']);
+        const hasDeviceId = extractScalar(event, ['deviceId', 'udid']) !== null;
+        const device = sanitizeNullable(deviceName ?? (hasDeviceId ? 'identified-device' : null));
+        const runtime = sanitizeNullable(extractScalar(event, ['runtime', 'engine']));
+        const classification = classifyExperience(symptom, tool, platform);
+        const normalizedSymptomShape = normalizeSymptomShape(symptom);
+        const signature = experienceSignature({
+            classification,
+            tool,
+            normalizedSymptomShape,
+            platform,
+        });
+        const unknownReasons = {};
+        if (this.candidate.pluginVersion === null) {
+            unknownReasons['candidate.pluginVersion'] =
+                'plugin manifest was not available to the core runtime';
+        }
+        if (platform === null)
+            unknownReasons.platform = 'tool event did not expose a platform';
+        if (device === null)
+            unknownReasons.device = 'tool event did not expose a device name or identifier';
+        if (runtime === null)
+            unknownReasons.runtime = 'tool event did not expose a runtime';
+        unknownReasons.maskingCondition = 'not derivable from a single tool event';
+        unknownReasons.recovery = 'no immediate successful retry has been observed';
+        unknownReasons.cleanup = 'tool events do not report cleanup actions';
+        const raw = {
+            signature,
+            candidate: this.candidate,
+            environment: this.environment,
+            platform,
+            device,
+            runtime,
+            phase: 'tool',
+            trigger: `${event.status} reported by ${tool}`,
+            maskingCondition: null,
+            symptom,
+            recovery: null,
+            cleanup: null,
+            classification,
+            evidencePointers: [`event:${randomUUID()}`],
+            tool,
+            status: event.status === 'ERROR' ? 'ERROR' : 'FAIL',
+            normalizedSymptomShape,
+            count: 1,
+            recoveryCount: 0,
+            firstSeen: now,
+            lastSeen: now,
+            lastRecoveredAt: null,
+            unknownReasons,
+        };
+        return sanitizeForEvidence(raw);
+    }
+    persistFailure(incoming) {
+        const records = readExperienceStore(this.path, true);
+        const existing = records.find((record) => record.signature === incoming.signature);
+        if (existing) {
+            existing.count += 1;
+            existing.lastSeen = incoming.lastSeen;
+            existing.status = incoming.status;
+            existing.symptom = incoming.symptom;
+            existing.candidate = incoming.candidate;
+            existing.environment = incoming.environment;
+            existing.evidencePointers = boundedPointers(existing.evidencePointers, incoming.evidencePointers);
+        }
+        else {
+            records.push(incoming);
+        }
+        this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
+    }
+    persistRecovery(signature, tool) {
+        const records = readExperienceStore(this.path, true);
+        const existing = records.find((record) => record.signature === signature);
+        if (!existing)
+            return;
+        const now = this.now().toISOString();
+        existing.recovery = sanitizeString(`PASS immediately followed FAIL for ${tool}`);
+        existing.recoveryCount += 1;
+        existing.lastRecoveredAt = now;
+        delete existing.unknownReasons.recovery;
+        existing.evidencePointers = boundedPointers(existing.evidencePointers, [
+            `event:${randomUUID()}`,
+        ]);
+        this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
+    }
+    write(records) {
+        mkdirSync(this.directory, { recursive: true, mode: 0o700 });
+        const temp = join(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID()}`);
+        try {
+            const sanitized = records.map((record) => sanitizeForEvidence(record));
+            const contents = sanitized.map((record) => JSON.stringify(record)).join('\n');
+            writeFileSync(temp, contents.length > 0 ? `${contents}\n` : '', {
+                encoding: 'utf8',
+                flag: 'wx',
+                mode: 0o600,
+            });
+            renameSync(temp, this.path);
+            chmodSync(this.path, 0o600);
+        }
+        catch (error) {
+            try {
+                unlinkSync(temp);
+            }
+            catch {
+                /* nothing to clean */
+            }
+            throw error;
+        }
+    }
+}
+export function discoverPluginVersion(fromUrl = import.meta.url) {
+    if (process.env.RN_DEV_AGENT_PLUGIN_VERSION)
+        return process.env.RN_DEV_AGENT_PLUGIN_VERSION;
+    const start = dirname(fileURLToPath(fromUrl));
+    const candidates = [
+        join(start, '..', '..', '.claude-plugin', 'plugin.json'),
+        join(start, '..', '..', '.codex-plugin', 'plugin.json'),
+        join(start, '..', '..', '..', 'claude-plugin', '.claude-plugin', 'plugin.json'),
+        join(start, '..', '..', '..', 'codex-plugin', '.codex-plugin', 'plugin.json'),
+    ];
+    for (const candidate of candidates) {
+        try {
+            const parsed = JSON.parse(readFileSync(candidate, 'utf8'));
+            if (typeof parsed.version === 'string')
+                return sanitizeString(parsed.version);
+        }
+        catch {
+            /* try the next installed/source layout */
+        }
+    }
+    return null;
+}
+export function readExperienceStore(path, allowMissing = false) {
+    if (!existsSync(path)) {
+        if (allowMissing)
+            return [];
+        return [];
+    }
+    const contents = readFileSync(path, 'utf8');
+    if (!contents.trim())
+        return [];
+    return contents
+        .split('\n')
+        .filter((line) => line.trim().length > 0)
+        .map((line) => JSON.parse(line));
+}
+export function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, retentionMs = DEFAULT_RETENTION_DAYS * DAY_MS) {
+    const cutoff = now.getTime() - retentionMs;
+    return records
+        .filter((record) => {
+        const lastSeen = Date.parse(record.lastSeen);
+        return Number.isFinite(lastSeen) && lastSeen >= cutoff;
+    })
+        .sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen) || a.signature.localeCompare(b.signature))
+        .slice(0, Math.max(0, maxRecords))
+        .sort((a, b) => a.signature.localeCompare(b.signature));
+}
+export function experienceSignature(input) {
+    return createHash('sha256')
+        .update(JSON.stringify([
+        input.classification,
+        input.tool,
+        input.normalizedSymptomShape,
+        input.platform ?? 'unknown',
+    ]))
+        .digest('hex');
+}
+export function normalizeSymptomShape(symptom) {
+    return symptom
+        .toLowerCase()
+        .replace(/[0-9a-f]{8}-[0-9a-f-]{27,}/gi, '<id>')
+        .replace(/\b0x[0-9a-f]+\b/gi, '<hex>')
+        .replace(/\b(?=[a-z0-9_-]{12,}\b)(?=[a-z0-9_-]*\d)[a-z0-9_-]+\b/gi, '<id>')
+        .replace(/\b\d+\b/g, '#')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+export function classifyExperience(symptom, tool, platform) {
+    const haystack = `${tool} ${platform ?? ''} ${symptom}`.toLowerCase();
+    const rules = [
+        ['FF_REDBOX', /redbox|logbox|error overlay|hasredbox/],
+        ['FF_DEBUGGER_PAUSED', /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
+        [
+            'FF_STALE_CDP',
+            /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/,
+        ],
+        ['FF_FAST_REFRESH_STALE', /fast refresh|ui unchanged|old exports|old module path/],
+        ['FF_METRO_CACHE', /metro.*(?:stale|cache)|config change not reflected/],
+        [
+            'FF_BINARY_MISMATCH',
+            /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/,
+        ],
+        ['FF_EXPO_DIALOG', /open-in-app|system confirmation dialog/],
+        [
+            'FF_DEV_CLIENT_PICKER',
+            /no hermes target|development servers|devclientlauncher|server picker/,
+        ],
+        ['FF_KEYBOARD_OVERLAY', /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
+        ['FF_MAESTRO_GRPC_ANDROID', /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
+        [
+            'FF_ANDROID_TEXT_INPUT_CRASH',
+            /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/,
+        ],
+        [
+            'FF_AUTH_GATE',
+            /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/,
+        ],
+        [
+            'FF_PERMISSION_ALREADY_GRANTED',
+            /permission already granted|prompt (?:was )?not shown|flow completes instantly/,
+        ],
+        ['EG_EXPO_GO_SDK_MISMATCH', /incompatible with this version of expo go|expo go sdk.*mismatch/],
+        ['EG_NATIVEWIND_JSX_SOURCE', /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
+        ['EG_EXPO_GO_NATIVE_MODULES', /expo go.*custom native module/],
+        ['EG_DEV_CLIENT_CLEARSTATE', /clearstate.*(?:dev client|metro connection|launcher)/],
+        ['EG_MSW_HERMES', /msw.*(?:hermes|react native|initialize)/],
+        ['EG_EXPO_ROUTER_DEEP_LINK', /expo router.*deep link|deep link.*confirmation dialog/],
+        ['EG_DEV_MENU_INTERFERENCE', /dev menu.*(?:overlay|recording|blocking)/],
+        ['EG_NEW_ARCH_CDP_TARGET', /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
+        ['PQ_IOS_RECORDVIDEO_CODEC', /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
+        ['PQ_ANDROID_SCREENRECORD_LIMIT', /screenrecord.*180|screenrecord.*3 minute/],
+        ['PQ_ANDROID_BOOT_DELAY', /sys\.boot_completed|emulator.*grpc.*ready/],
+        ['PQ_ANDROID_PLAY_PROTECT', /play protect.*(?:block|apk|install)/],
+    ];
+    return rules.find(([, pattern]) => pattern.test(haystack))?.[0] ?? UNKNOWN_CLASSIFICATION;
+}
+function extractSymptom(event) {
+    if (typeof event.error === 'string' && event.error.length > 0)
+        return event.error;
+    if (event.result && typeof event.result === 'object') {
+        const envelope = event.result;
+        if (typeof envelope.error === 'string')
+            return envelope.error;
+        const content = envelope.content;
+        if (Array.isArray(content)) {
+            const first = content[0];
+            if (typeof first?.text === 'string')
+                return first.text;
+        }
+    }
+    return `${event.tool} reported ${event.status} without an error message`;
+}
+function extractScalar(event, keys) {
+    const sources = [event.params, event.result];
+    for (const source of sources) {
+        const value = findScalar(source, keys, 0);
+        if (value !== null)
+            return value;
+    }
+    return null;
+}
+function findScalar(value, keys, depth) {
+    if (!value || typeof value !== 'object' || depth > 3)
+        return null;
+    const object = value;
+    for (const key of keys) {
+        const candidate = object[key];
+        if (typeof candidate === 'string' && candidate.length > 0)
+            return candidate;
+    }
+    for (const nested of Object.values(object)) {
+        if (nested && typeof nested === 'object') {
+            const found = findScalar(nested, keys, depth + 1);
+            if (found !== null)
+                return found;
+        }
+    }
+    return null;
+}
+function sanitizeNullable(value) {
+    return value === null ? null : sanitizeString(value);
+}
+function boundedPointers(existing, incoming) {
+    return [...new Set([...existing, ...incoming])].slice(-MAX_EVIDENCE_POINTERS);
+}

--- a/packages/rn-dev-agent-core/dist/experience/evidence.js
+++ b/packages/rn-dev-agent-core/dist/experience/evidence.js
@@ -44,9 +44,9 @@ const REDACTION_RULES = [
 // commonly use `token=...`, so retain the same secret vocabulary while also
 // handling the separator explicitly.
 const KEYED_SECRET = /((?:token|secret|password|auth|api[_-]?key)\s*[:=]\s*)[^\s,;}]{6,}/gi;
-// Records are sanitized on construction and again before they reach disk, so a
-// record read back from the store never needs a second full-tree pass.
-const SANITIZED_RECORDS = new WeakSet();
+// Bump whenever a redaction rule changes: stored records stamped with an older
+// version are re-sanitized under the current rules before the next rewrite.
+export const REDACTION_RULES_VERSION = 1;
 export function sanitizeString(value, redact = applyRedactionRules) {
     try {
         return redact(value);
@@ -89,21 +89,30 @@ function applyRedactionRules(value) {
     return result;
 }
 let appIdentityCache = null;
-// Mirrors the app.json stage of scripts/collect-feedback.sh. A malformed
+// Mirrors the app.json stage of scripts/collect-feedback.sh. An unreadable
 // manifest throws, so sanitizeString fails closed instead of shipping the name.
 function readAppIdentity() {
     const root = process.env.RN_PROJECT_ROOT ?? process.env.CLAUDE_USER_CWD ?? process.cwd();
-    if (appIdentityCache?.root === root)
-        return appIdentityCache.identity;
+    if (appIdentityCache?.root !== root) {
+        appIdentityCache = { root, identity: loadAppIdentity(root) };
+    }
+    if (appIdentityCache.identity === null) {
+        throw new Error('app identity could not be read for redaction');
+    }
+    return appIdentityCache.identity;
+}
+function loadAppIdentity(root) {
     const manifest = join(root, 'app.json');
-    let identity = { name: null, slug: null };
-    if (existsSync(manifest)) {
+    try {
+        if (!existsSync(manifest))
+            return { name: null, slug: null };
         const parsed = JSON.parse(readFileSync(manifest, 'utf8'));
         const expo = parsed.expo ?? parsed;
-        identity = { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
+        return { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
     }
-    appIdentityCache = { root, identity };
-    return identity;
+    catch {
+        return null;
+    }
 }
 function usableIdentity(value) {
     return typeof value === 'string' && value.trim().length > 2 ? value : null;
@@ -229,10 +238,9 @@ export class ExperienceRecorder {
             lastSeen: now,
             lastRecoveredAt: null,
             unknownReasons,
+            redactionVersion: REDACTION_RULES_VERSION,
         };
-        const sanitized = sanitizeForEvidence(raw);
-        SANITIZED_RECORDS.add(sanitized);
-        return sanitized;
+        return sanitizeForEvidence(raw);
     }
     persistFailure(incoming) {
         const records = readExperienceStore(this.path);
@@ -247,7 +255,6 @@ export class ExperienceRecorder {
             existing.symptom = incoming.symptom;
             existing.candidate = incoming.candidate;
             existing.environment = incoming.environment;
-            adoptLateFact(existing, incoming, 'platform');
             adoptLateFact(existing, incoming, 'device');
             adoptLateFact(existing, incoming, 'runtime');
             existing.evidencePointers = boundedPointers(existing.evidencePointers, incoming.evidencePointers);
@@ -276,7 +283,12 @@ export class ExperienceRecorder {
         mkdirSync(this.directory, { recursive: true, mode: 0o700 });
         const temp = join(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID()}`);
         try {
-            const sanitized = records.map((record) => SANITIZED_RECORDS.has(record) ? record : sanitizeForEvidence(record));
+            const sanitized = records.map((record) => record.redactionVersion === REDACTION_RULES_VERSION
+                ? record
+                : {
+                    ...sanitizeForEvidence(record),
+                    redactionVersion: REDACTION_RULES_VERSION,
+                });
             const contents = sanitized.map((record) => JSON.stringify(record)).join('\n');
             writeFileSync(temp, contents.length > 0 ? `${contents}\n` : '', {
                 encoding: 'utf8',
@@ -336,7 +348,6 @@ export function readExperienceStore(path) {
         catch {
             continue;
         }
-        SANITIZED_RECORDS.add(parsed);
         records.push(parsed);
     }
     return records;

--- a/packages/rn-dev-agent-core/dist/experience/evidence.js
+++ b/packages/rn-dev-agent-core/dist/experience/evidence.js
@@ -9,8 +9,10 @@ export const DEFAULT_RETENTION_DAYS = 14;
 export const MAX_EVIDENCE_POINTERS = 3;
 export const EXPERIENCE_DIRECTORY = join(homedir(), '.claude', 'rn-agent', 'experience');
 export const EXPERIENCE_STORE_NAME = 'patterns.jsonl';
+export const MAX_SYMPTOM_LENGTH = 2048;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const REDACTION_FAILED = '[REDACTION_FAILED]';
+const SYMPTOM_TRUNCATED = '[TRUNCATED]';
 // Keep this list aligned with scripts/collect-feedback.sh. That collector is the
 // public sanitization contract; this in-process form exists so private tool
 // payloads never have to cross a process boundary.
@@ -42,6 +44,9 @@ const REDACTION_RULES = [
 // commonly use `token=...`, so retain the same secret vocabulary while also
 // handling the separator explicitly.
 const KEYED_SECRET = /((?:token|secret|password|auth|api[_-]?key)\s*[:=]\s*)[^\s,;}]{6,}/gi;
+// Records are sanitized on construction and again before they reach disk, so a
+// record read back from the store never needs a second full-tree pass.
+const SANITIZED_RECORDS = new WeakSet();
 export function sanitizeString(value, redact = applyRedactionRules) {
     try {
         return redact(value);
@@ -76,7 +81,32 @@ function applyRedactionRules(value) {
         pattern.lastIndex = 0;
         result = result.replace(pattern, replacement);
     }
+    const identity = readAppIdentity();
+    if (identity.name)
+        result = result.replaceAll(identity.name, '[APP_NAME_REDACTED]');
+    if (identity.slug)
+        result = result.replaceAll(identity.slug, '[APP_SLUG_REDACTED]');
     return result;
+}
+let appIdentityCache = null;
+// Mirrors the app.json stage of scripts/collect-feedback.sh. A malformed
+// manifest throws, so sanitizeString fails closed instead of shipping the name.
+function readAppIdentity() {
+    const root = process.env.RN_PROJECT_ROOT ?? process.env.CLAUDE_USER_CWD ?? process.cwd();
+    if (appIdentityCache?.root === root)
+        return appIdentityCache.identity;
+    const manifest = join(root, 'app.json');
+    let identity = { name: null, slug: null };
+    if (existsSync(manifest)) {
+        const parsed = JSON.parse(readFileSync(manifest, 'utf8'));
+        const expo = parsed.expo ?? parsed;
+        identity = { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
+    }
+    appIdentityCache = { root, identity };
+    return identity;
+}
+function usableIdentity(value) {
+    return typeof value === 'string' && value.trim().length > 2 ? value : null;
 }
 export class ExperienceRecorder {
     directory;
@@ -147,7 +177,7 @@ export class ExperienceRecorder {
     buildFailureRecord(event) {
         const now = this.now().toISOString();
         const tool = sanitizeString(event.tool);
-        const symptom = sanitizeString(extractSymptom(event));
+        const symptom = sanitizeString(boundSymptom(extractSymptom(event)));
         const platform = sanitizeNullable(extractScalar(event, ['platform']));
         const deviceName = extractScalar(event, ['deviceName', 'deviceModel', 'model']);
         const hasDeviceId = extractScalar(event, ['deviceId', 'udid']) !== null;
@@ -200,18 +230,26 @@ export class ExperienceRecorder {
             lastRecoveredAt: null,
             unknownReasons,
         };
-        return sanitizeForEvidence(raw);
+        const sanitized = sanitizeForEvidence(raw);
+        SANITIZED_RECORDS.add(sanitized);
+        return sanitized;
     }
     persistFailure(incoming) {
-        const records = readExperienceStore(this.path, true);
+        const records = readExperienceStore(this.path);
         const existing = records.find((record) => record.signature === incoming.signature);
         if (existing) {
             existing.count += 1;
             existing.lastSeen = incoming.lastSeen;
-            existing.status = incoming.status;
+            if (incoming.status === 'ERROR' && existing.status !== 'ERROR') {
+                existing.status = 'ERROR';
+                existing.trigger = incoming.trigger;
+            }
             existing.symptom = incoming.symptom;
             existing.candidate = incoming.candidate;
             existing.environment = incoming.environment;
+            adoptLateFact(existing, incoming, 'platform');
+            adoptLateFact(existing, incoming, 'device');
+            adoptLateFact(existing, incoming, 'runtime');
             existing.evidencePointers = boundedPointers(existing.evidencePointers, incoming.evidencePointers);
         }
         else {
@@ -220,7 +258,7 @@ export class ExperienceRecorder {
         this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
     }
     persistRecovery(signature, tool) {
-        const records = readExperienceStore(this.path, true);
+        const records = readExperienceStore(this.path);
         const existing = records.find((record) => record.signature === signature);
         if (!existing)
             return;
@@ -238,7 +276,7 @@ export class ExperienceRecorder {
         mkdirSync(this.directory, { recursive: true, mode: 0o700 });
         const temp = join(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID()}`);
         try {
-            const sanitized = records.map((record) => sanitizeForEvidence(record));
+            const sanitized = records.map((record) => SANITIZED_RECORDS.has(record) ? record : sanitizeForEvidence(record));
             const contents = sanitized.map((record) => JSON.stringify(record)).join('\n');
             writeFileSync(temp, contents.length > 0 ? `${contents}\n` : '', {
                 encoding: 'utf8',
@@ -281,19 +319,27 @@ export function discoverPluginVersion(fromUrl = import.meta.url) {
     }
     return null;
 }
-export function readExperienceStore(path, allowMissing = false) {
-    if (!existsSync(path)) {
-        if (allowMissing)
-            return [];
+export function readExperienceStore(path) {
+    if (!existsSync(path))
         return [];
-    }
     const contents = readFileSync(path, 'utf8');
     if (!contents.trim())
         return [];
-    return contents
-        .split('\n')
-        .filter((line) => line.trim().length > 0)
-        .map((line) => JSON.parse(line));
+    const records = [];
+    for (const line of contents.split('\n')) {
+        if (line.trim().length === 0)
+            continue;
+        let parsed;
+        try {
+            parsed = JSON.parse(line);
+        }
+        catch {
+            continue;
+        }
+        SANITIZED_RECORDS.add(parsed);
+        records.push(parsed);
+    }
+    return records;
 }
 export function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, retentionMs = DEFAULT_RETENTION_DAYS * DAY_MS) {
     const cutoff = now.getTime() - retentionMs;
@@ -326,54 +372,50 @@ export function normalizeSymptomShape(symptom) {
         .replace(/\s+/g, ' ')
         .trim();
 }
+const CLASSIFICATION_RULES = [
+    ['FF_REDBOX', /redbox|logbox|error overlay|hasredbox/],
+    ['FF_DEBUGGER_PAUSED', /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
+    [
+        'FF_STALE_CDP',
+        /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/,
+    ],
+    ['FF_FAST_REFRESH_STALE', /fast refresh|ui unchanged|old exports|old module path/],
+    ['FF_METRO_CACHE', /metro.*(?:stale|cache)|config change not reflected/],
+    [
+        'FF_BINARY_MISMATCH',
+        /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/,
+    ],
+    ['FF_EXPO_DIALOG', /open-in-app|system confirmation dialog/],
+    ['FF_DEV_CLIENT_PICKER', /no hermes target|development servers|devclientlauncher|server picker/],
+    ['FF_KEYBOARD_OVERLAY', /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
+    ['FF_MAESTRO_GRPC_ANDROID', /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
+    [
+        'FF_ANDROID_TEXT_INPUT_CRASH',
+        /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/,
+    ],
+    ['FF_AUTH_GATE', /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/],
+    [
+        'FF_PERMISSION_ALREADY_GRANTED',
+        /permission already granted|prompt (?:was )?not shown|flow completes instantly/,
+    ],
+    ['EG_EXPO_GO_SDK_MISMATCH', /incompatible with this version of expo go|expo go sdk.*mismatch/],
+    ['EG_NATIVEWIND_JSX_SOURCE', /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
+    ['EG_EXPO_GO_NATIVE_MODULES', /expo go.*custom native module/],
+    ['EG_DEV_CLIENT_CLEARSTATE', /clearstate.*(?:dev client|metro connection|launcher)/],
+    ['EG_MSW_HERMES', /msw.*(?:hermes|react native|initialize)/],
+    ['EG_EXPO_ROUTER_DEEP_LINK', /expo router.*deep link|deep link.*confirmation dialog/],
+    ['EG_DEV_MENU_INTERFERENCE', /dev menu.*(?:overlay|recording|blocking)/],
+    ['EG_NEW_ARCH_CDP_TARGET', /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
+    ['PQ_IOS_RECORDVIDEO_CODEC', /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
+    ['PQ_ANDROID_SCREENRECORD_LIMIT', /screenrecord.*180|screenrecord.*3 minute/],
+    ['PQ_ANDROID_BOOT_DELAY', /sys\.boot_completed|emulator.*grpc.*ready/],
+    ['PQ_ANDROID_PLAY_PROTECT', /play protect.*(?:block|apk|install)/],
+];
+export const EXPERIENCE_FAMILY_IDS = CLASSIFICATION_RULES.map(([id]) => id);
 export function classifyExperience(symptom, tool, platform) {
     const haystack = `${tool} ${platform ?? ''} ${symptom}`.toLowerCase();
-    const rules = [
-        ['FF_REDBOX', /redbox|logbox|error overlay|hasredbox/],
-        ['FF_DEBUGGER_PAUSED', /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
-        [
-            'FF_STALE_CDP',
-            /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/,
-        ],
-        ['FF_FAST_REFRESH_STALE', /fast refresh|ui unchanged|old exports|old module path/],
-        ['FF_METRO_CACHE', /metro.*(?:stale|cache)|config change not reflected/],
-        [
-            'FF_BINARY_MISMATCH',
-            /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/,
-        ],
-        ['FF_EXPO_DIALOG', /open-in-app|system confirmation dialog/],
-        [
-            'FF_DEV_CLIENT_PICKER',
-            /no hermes target|development servers|devclientlauncher|server picker/,
-        ],
-        ['FF_KEYBOARD_OVERLAY', /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
-        ['FF_MAESTRO_GRPC_ANDROID', /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
-        [
-            'FF_ANDROID_TEXT_INPUT_CRASH',
-            /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/,
-        ],
-        [
-            'FF_AUTH_GATE',
-            /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/,
-        ],
-        [
-            'FF_PERMISSION_ALREADY_GRANTED',
-            /permission already granted|prompt (?:was )?not shown|flow completes instantly/,
-        ],
-        ['EG_EXPO_GO_SDK_MISMATCH', /incompatible with this version of expo go|expo go sdk.*mismatch/],
-        ['EG_NATIVEWIND_JSX_SOURCE', /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
-        ['EG_EXPO_GO_NATIVE_MODULES', /expo go.*custom native module/],
-        ['EG_DEV_CLIENT_CLEARSTATE', /clearstate.*(?:dev client|metro connection|launcher)/],
-        ['EG_MSW_HERMES', /msw.*(?:hermes|react native|initialize)/],
-        ['EG_EXPO_ROUTER_DEEP_LINK', /expo router.*deep link|deep link.*confirmation dialog/],
-        ['EG_DEV_MENU_INTERFERENCE', /dev menu.*(?:overlay|recording|blocking)/],
-        ['EG_NEW_ARCH_CDP_TARGET', /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
-        ['PQ_IOS_RECORDVIDEO_CODEC', /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
-        ['PQ_ANDROID_SCREENRECORD_LIMIT', /screenrecord.*180|screenrecord.*3 minute/],
-        ['PQ_ANDROID_BOOT_DELAY', /sys\.boot_completed|emulator.*grpc.*ready/],
-        ['PQ_ANDROID_PLAY_PROTECT', /play protect.*(?:block|apk|install)/],
-    ];
-    return rules.find(([, pattern]) => pattern.test(haystack))?.[0] ?? UNKNOWN_CLASSIFICATION;
+    return (CLASSIFICATION_RULES.find(([, pattern]) => pattern.test(haystack))?.[0] ??
+        UNKNOWN_CLASSIFICATION);
 }
 function extractSymptom(event) {
     if (typeof event.error === 'string' && event.error.length > 0)
@@ -390,6 +432,15 @@ function extractSymptom(event) {
         }
     }
     return `${event.tool} reported ${event.status} without an error message`;
+}
+// Bounding happens before redaction so the regex pass stays linear on huge
+// payloads; the trailing partial token goes too, so nothing can survive the cut
+// as a half-redacted secret.
+function boundSymptom(symptom) {
+    if (symptom.length <= MAX_SYMPTOM_LENGTH)
+        return symptom;
+    const head = symptom.slice(0, MAX_SYMPTOM_LENGTH).replace(/\S+$/, '');
+    return `${head}${SYMPTOM_TRUNCATED}`;
 }
 function extractScalar(event, keys) {
     const sources = [event.params, event.result];
@@ -420,6 +471,12 @@ function findScalar(value, keys, depth) {
 }
 function sanitizeNullable(value) {
     return value === null ? null : sanitizeString(value);
+}
+function adoptLateFact(existing, incoming, field) {
+    if (existing[field] !== null || incoming[field] === null)
+        return;
+    existing[field] = incoming[field];
+    delete existing.unknownReasons[field];
 }
 function boundedPointers(existing, incoming) {
     return [...new Set([...existing, ...incoming])].slice(-MAX_EVIDENCE_POINTERS);

--- a/packages/rn-dev-agent-core/dist/experience/trends.js
+++ b/packages/rn-dev-agent-core/dist/experience/trends.js
@@ -1,0 +1,41 @@
+import { join } from 'node:path';
+import { EXPERIENCE_DIRECTORY, EXPERIENCE_STORE_NAME, readExperienceStore, } from './evidence.js';
+export function buildExperienceTrendReport(records, since, now = new Date()) {
+    const families = new Map();
+    for (const record of records) {
+        const aggregate = families.get(record.classification) ?? { count: 0, patterns: 0 };
+        aggregate.count += record.count;
+        aggregate.patterns += 1;
+        families.set(record.classification, aggregate);
+    }
+    const project = (record) => ({
+        signature: record.signature,
+        classification: record.classification,
+        tool: record.tool,
+        count: record.count,
+        firstSeen: record.firstSeen,
+        lastSeen: record.lastSeen,
+    });
+    const sortPatterns = (a, b) => b.count - a.count ||
+        a.classification.localeCompare(b.classification) ||
+        a.signature.localeCompare(b.signature);
+    return {
+        generatedAt: now.toISOString(),
+        since: since.toISOString(),
+        families: [...families.entries()]
+            .map(([classification, value]) => ({ classification, ...value }))
+            .sort((a, b) => b.count - a.count || a.classification.localeCompare(b.classification)),
+        newSincePreviousReport: records
+            .filter((record) => Date.parse(record.firstSeen) >= since.getTime())
+            .map(project)
+            .sort(sortPatterns),
+        recurring: records
+            .filter((record) => record.count > 1)
+            .map(project)
+            .sort(sortPatterns),
+    };
+}
+export function readExperienceTrendReport(options) {
+    const directory = options.directory ?? process.env.RN_DEV_AGENT_EXPERIENCE_DIR ?? EXPERIENCE_DIRECTORY;
+    return buildExperienceTrendReport(readExperienceStore(join(directory, EXPERIENCE_STORE_NAME)), options.since);
+}

--- a/packages/rn-dev-agent-core/dist/index.js
+++ b/packages/rn-dev-agent-core/dist/index.js
@@ -79,6 +79,7 @@ import { captureInstalledArtifact, captureInstallGeneration, verifyInstalledArti
 import { readProcessBirth } from './session/process-birth.js';
 import { ensureSingleRunner } from './runners/ensure-single-runner.js';
 import { addToolObserver, instrumentTool } from './observability/instrumentation.js';
+import { discoverPluginVersion, ExperienceRecorder } from './experience/evidence.js';
 import { recorder } from './observability/recorder.js';
 import { hashProofValue, StrictProofMonitor } from './domain/proof-capture.js';
 import { maybeCaptureLiveFrame, isStateMutating, mayTriggerLiveCapture, resolveSnapshotInvalidationPlatform, toolInvalidatesSnapshotCache, toolInvalidatesRetryBaseline, buildLiveDeps, } from './observability/live-device.js';
@@ -256,8 +257,13 @@ const server = new McpServer({
     version: pkgVersion,
 });
 export const strictProofMonitor = new StrictProofMonitor();
+const experienceRecorder = new ExperienceRecorder({
+    coreVersion: pkgVersion,
+    pluginVersion: discoverPluginVersion(),
+});
 addToolObserver((o) => recorder.record(o));
 addToolObserver((o) => strictProofMonitor.record(o));
+addToolObserver((o) => experienceRecorder.observe(o));
 const authorityRuntime = getWorkerAuthorityRuntime();
 setSnapshotAuthorityProvider({
     current: () => {

--- a/packages/rn-dev-agent-core/package.json
+++ b/packages/rn-dev-agent-core/package.json
@@ -3,7 +3,10 @@
   "version": "0.70.3",
   "type": "module",
   "main": "dist/index.js",
-  "bin": "./dist/supervisor.js",
+  "bin": {
+    "rn-dev-agent-core": "./dist/supervisor.js",
+    "rn-experience-trends": "./dist/experience-trends.js"
+  },
   "scripts": {
     "build": "tsc",
     "build:web": "cd src/observability/web && npm install && npm run build",

--- a/packages/rn-dev-agent-core/src/experience-trends.ts
+++ b/packages/rn-dev-agent-core/src/experience-trends.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import { readExperienceTrendReport } from './experience/trends.js';
+
+function usage(): never {
+  process.stderr.write(
+    'Usage: rn-experience-trends [--since <ISO timestamp>] [--json]\n' +
+      '  --since is the generated-at timestamp printed by the previous report (default: 24 hours ago).\n' +
+      '  This command only reads ~/.claude/rn-agent/experience/patterns.jsonl.\n',
+  );
+  process.exit(2);
+}
+
+let since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+let json = false;
+for (let index = 2; index < process.argv.length; index += 1) {
+  const argument = process.argv[index];
+  if (argument === '--json') {
+    json = true;
+  } else if (argument === '--since') {
+    const value = process.argv[++index];
+    const parsed = value ? new Date(value) : new Date(Number.NaN);
+    if (!Number.isFinite(parsed.getTime())) usage();
+    since = parsed;
+  } else if (argument === '--help' || argument === '-h') {
+    usage();
+  } else {
+    usage();
+  }
+}
+
+try {
+  const report = readExperienceTrendReport({ since });
+  if (json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    process.stdout.write(`Experience trends (new since ${report.since})\n`);
+    process.stdout.write(
+      `Report generated at ${report.generatedAt}; pass this value to --since next time.\n`,
+    );
+    process.stdout.write('\nFamilies by frequency\n');
+    if (report.families.length === 0) process.stdout.write('  none\n');
+    for (const family of report.families) {
+      process.stdout.write(
+        `  ${family.classification}: ${family.count} occurrence(s), ${family.patterns} pattern(s)\n`,
+      );
+    }
+    process.stdout.write('\nNew since previous report\n');
+    if (report.newSincePreviousReport.length === 0) process.stdout.write('  none\n');
+    for (const item of report.newSincePreviousReport) {
+      process.stdout.write(
+        `  ${item.classification} ${item.tool}: ${item.count} (${item.signature.slice(0, 12)})\n`,
+      );
+    }
+    process.stdout.write('\nRecurring\n');
+    if (report.recurring.length === 0) process.stdout.write('  none\n');
+    for (const item of report.recurring) {
+      process.stdout.write(
+        `  ${item.classification} ${item.tool}: ${item.count} (${item.signature.slice(0, 12)})\n`,
+      );
+    }
+  }
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(
+    `rn-experience-trends: could not read the local evidence store: ${message}\n`,
+  );
+  process.exitCode = 1;
+}

--- a/packages/rn-dev-agent-core/src/experience/evidence.ts
+++ b/packages/rn-dev-agent-core/src/experience/evidence.ts
@@ -1,0 +1,511 @@
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir, platform as hostPlatform, release } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { ToolObserverInput } from '../observability/instrumentation.js';
+
+export const UNKNOWN_CLASSIFICATION = 'UNKNOWN';
+export const DEFAULT_MAX_RECORDS = 500;
+export const DEFAULT_RETENTION_DAYS = 14;
+export const MAX_EVIDENCE_POINTERS = 3;
+export const EXPERIENCE_DIRECTORY = join(homedir(), '.claude', 'rn-agent', 'experience');
+export const EXPERIENCE_STORE_NAME = 'patterns.jsonl';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const REDACTION_FAILED = '[REDACTION_FAILED]';
+
+// Keep this list aligned with scripts/collect-feedback.sh. That collector is the
+// public sanitization contract; this in-process form exists so private tool
+// payloads never have to cross a process boundary.
+const REDACTION_RULES: ReadonlyArray<[RegExp, string]> = [
+  [/(sk|pk|api|key|token|secret|password|auth)[-_]?[A-Za-z0-9_-]{20,}/gi, '[REDACTED_SECRET]'],
+  [/Bearer [A-Za-z0-9_./+=-]{20,}/g, 'Bearer [REDACTED]'],
+  [/ghp_[A-Za-z0-9_]{36}/g, '[REDACTED_GH_TOKEN]'],
+  [/eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+/g, '[REDACTED_JWT]'],
+  [/AKIA[0-9A-Z]{16}/g, '[REDACTED_AWS]'],
+  [/xox[baprs]-[A-Za-z0-9-]+/g, '[REDACTED_SLACK]'],
+  [/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, '[EMAIL_REDACTED]'],
+  [
+    /(^|[^0-9])(192|10|172|169)\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}([^0-9]|$)/g,
+    '$1[IP_REDACTED]$3',
+  ],
+  [/(^|[^0-9])[0-9]{1,3}(?:\.[0-9]{1,3}){3}([^0-9]|$)/g, '$1[IP_REDACTED]$2'],
+  [
+    /(?:https?:\/\/)?(?:localhost|127\.0\.0\.1)(?::[0-9]{2,5})?(?:\/[^\s]*)?/gi,
+    '[LOOPBACK_ENDPOINT_REDACTED]',
+  ],
+  [/"(metroPort|observePort|port)"\s*:\s*[0-9]+/g, '"$1":"[PORT_REDACTED]"'],
+  [/\bport\s*[:=]?\s*[0-9]{2,5}\b/gi, '[PORT_REDACTED]'],
+  [/:([0-9]{2,5})(?=\/|\s|$)/g, ':[PORT_REDACTED]'],
+  [/~\/[A-Za-z0-9_./-]+/g, '[PATH_REDACTED]'],
+  [/\/(Users|home|opt|var|tmp|etc|private|Volumes)\/[A-Za-z0-9_./-]+/g, '[PATH_REDACTED]'],
+  [/(com|org|io|dev|net)\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_.-]+/g, '[BUNDLE_REDACTED]'],
+];
+
+// The shell contract catches keyword-adjacent values. Structured tool errors
+// commonly use `token=...`, so retain the same secret vocabulary while also
+// handling the separator explicitly.
+const KEYED_SECRET = /((?:token|secret|password|auth|api[_-]?key)\s*[:=]\s*)[^\s,;}]{6,}/gi;
+
+export type RedactString = (value: string) => string;
+
+export function sanitizeString(value: string, redact: RedactString = applyRedactionRules): string {
+  try {
+    return redact(value);
+  } catch {
+    return REDACTION_FAILED;
+  }
+}
+
+export function sanitizeForEvidence(value: unknown, redact?: RedactString): unknown {
+  if (
+    value === null ||
+    value === undefined ||
+    typeof value === 'boolean' ||
+    typeof value === 'number'
+  ) {
+    return value;
+  }
+  if (typeof value === 'string') return sanitizeString(value, redact);
+  if (Array.isArray(value)) return value.map((item) => sanitizeForEvidence(item, redact));
+  if (typeof value === 'object') {
+    const sanitized: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      sanitized[key] = sanitizeForEvidence(nested, redact);
+    }
+    return sanitized;
+  }
+  return REDACTION_FAILED;
+}
+
+function applyRedactionRules(value: string): string {
+  let result = value.replaceAll(homedir(), '~').replace(KEYED_SECRET, '$1[REDACTED_SECRET]');
+  for (const [pattern, replacement] of REDACTION_RULES) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}
+
+interface Candidate {
+  pluginVersion: string | null;
+  coreVersion: string;
+}
+
+interface Environment {
+  os: string;
+  node: string;
+}
+
+export interface ExperienceRecord {
+  signature: string;
+  candidate: Candidate;
+  environment: Environment;
+  platform: string | null;
+  device: string | null;
+  runtime: string | null;
+  phase: 'tool';
+  trigger: string;
+  maskingCondition: string | null;
+  symptom: string;
+  recovery: string | null;
+  cleanup: string | null;
+  classification: string;
+  evidencePointers: string[];
+  tool: string;
+  status: 'FAIL' | 'ERROR';
+  normalizedSymptomShape: string;
+  count: number;
+  recoveryCount: number;
+  firstSeen: string;
+  lastSeen: string;
+  lastRecoveredAt: string | null;
+  unknownReasons: Record<string, string>;
+}
+
+export interface ExperienceStoreOptions {
+  directory?: string;
+  coreVersion: string;
+  pluginVersion?: string | null;
+  maxRecords?: number;
+  retentionDays?: number;
+  now?: () => Date;
+  schedule?: (work: () => void) => void;
+}
+
+export class ExperienceRecorder {
+  private readonly directory: string;
+  private readonly path: string;
+  private readonly candidate: Candidate;
+  private readonly environment: Environment;
+  private readonly maxRecords: number;
+  private readonly retentionMs: number;
+  private readonly now: () => Date;
+  private readonly schedule: (work: () => void) => void;
+  private previousFailure: { tool: string; signature: string } | null = null;
+
+  constructor(options: ExperienceStoreOptions) {
+    this.directory =
+      options.directory ?? process.env.RN_DEV_AGENT_EXPERIENCE_DIR ?? EXPERIENCE_DIRECTORY;
+    this.path = join(this.directory, EXPERIENCE_STORE_NAME);
+    this.candidate = {
+      pluginVersion: options.pluginVersion ?? null,
+      coreVersion: options.coreVersion,
+    };
+    this.environment = { os: `${hostPlatform()} ${release()}`, node: process.version };
+    this.maxRecords = options.maxRecords ?? DEFAULT_MAX_RECORDS;
+    this.retentionMs = (options.retentionDays ?? DEFAULT_RETENTION_DAYS) * DAY_MS;
+    this.now = options.now ?? (() => new Date());
+    this.schedule = options.schedule ?? ((work) => setImmediate(work));
+  }
+
+  /** Queue only: persistence never executes in the observed tool's call stack. */
+  observe(event: ToolObserverInput): void {
+    try {
+      this.schedule(() => this.recordNonLoadBearing(event));
+    } catch {
+      /* experience evidence is non-load-bearing */
+    }
+  }
+
+  /** Test and CLI support; returns a sanitized, deduplicated view. */
+  read(): ExperienceRecord[] {
+    return readExperienceStore(this.path);
+  }
+
+  private recordNonLoadBearing(event: ToolObserverInput): void {
+    try {
+      this.record(event);
+    } catch {
+      /* an unwritable/corrupt store must never affect tool behavior */
+    }
+  }
+
+  private record(event: ToolObserverInput): void {
+    if (!event || typeof event.tool !== 'string') {
+      this.previousFailure = null;
+      return;
+    }
+
+    if (event.status === 'PASS') {
+      const recovery = this.previousFailure;
+      this.previousFailure = null;
+      if (recovery?.tool === event.tool) this.persistRecovery(recovery.signature, event.tool);
+      return;
+    }
+
+    if (event.status !== 'FAIL' && event.status !== 'ERROR') {
+      this.previousFailure = null;
+      return;
+    }
+
+    const record = this.buildFailureRecord(event);
+    this.persistFailure(record);
+    this.previousFailure =
+      event.status === 'FAIL' ? { tool: event.tool, signature: record.signature } : null;
+  }
+
+  private buildFailureRecord(event: ToolObserverInput): ExperienceRecord {
+    const now = this.now().toISOString();
+    const tool = sanitizeString(event.tool);
+    const symptom = sanitizeString(extractSymptom(event));
+    const platform = sanitizeNullable(extractScalar(event, ['platform']));
+    const deviceName = extractScalar(event, ['deviceName', 'deviceModel', 'model']);
+    const hasDeviceId = extractScalar(event, ['deviceId', 'udid']) !== null;
+    const device = sanitizeNullable(deviceName ?? (hasDeviceId ? 'identified-device' : null));
+    const runtime = sanitizeNullable(extractScalar(event, ['runtime', 'engine']));
+    const classification = classifyExperience(symptom, tool, platform);
+    const normalizedSymptomShape = normalizeSymptomShape(symptom);
+    const signature = experienceSignature({
+      classification,
+      tool,
+      normalizedSymptomShape,
+      platform,
+    });
+    const unknownReasons: Record<string, string> = {};
+    if (this.candidate.pluginVersion === null) {
+      unknownReasons['candidate.pluginVersion'] =
+        'plugin manifest was not available to the core runtime';
+    }
+    if (platform === null) unknownReasons.platform = 'tool event did not expose a platform';
+    if (device === null)
+      unknownReasons.device = 'tool event did not expose a device name or identifier';
+    if (runtime === null) unknownReasons.runtime = 'tool event did not expose a runtime';
+    unknownReasons.maskingCondition = 'not derivable from a single tool event';
+    unknownReasons.recovery = 'no immediate successful retry has been observed';
+    unknownReasons.cleanup = 'tool events do not report cleanup actions';
+
+    const raw: ExperienceRecord = {
+      signature,
+      candidate: this.candidate,
+      environment: this.environment,
+      platform,
+      device,
+      runtime,
+      phase: 'tool',
+      trigger: `${event.status} reported by ${tool}`,
+      maskingCondition: null,
+      symptom,
+      recovery: null,
+      cleanup: null,
+      classification,
+      evidencePointers: [`event:${randomUUID()}`],
+      tool,
+      status: event.status === 'ERROR' ? 'ERROR' : 'FAIL',
+      normalizedSymptomShape,
+      count: 1,
+      recoveryCount: 0,
+      firstSeen: now,
+      lastSeen: now,
+      lastRecoveredAt: null,
+      unknownReasons,
+    };
+    return sanitizeForEvidence(raw) as ExperienceRecord;
+  }
+
+  private persistFailure(incoming: ExperienceRecord): void {
+    const records = readExperienceStore(this.path, true);
+    const existing = records.find((record) => record.signature === incoming.signature);
+    if (existing) {
+      existing.count += 1;
+      existing.lastSeen = incoming.lastSeen;
+      existing.status = incoming.status;
+      existing.symptom = incoming.symptom;
+      existing.candidate = incoming.candidate;
+      existing.environment = incoming.environment;
+      existing.evidencePointers = boundedPointers(
+        existing.evidencePointers,
+        incoming.evidencePointers,
+      );
+    } else {
+      records.push(incoming);
+    }
+    this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
+  }
+
+  private persistRecovery(signature: string, tool: string): void {
+    const records = readExperienceStore(this.path, true);
+    const existing = records.find((record) => record.signature === signature);
+    if (!existing) return;
+    const now = this.now().toISOString();
+    existing.recovery = sanitizeString(`PASS immediately followed FAIL for ${tool}`);
+    existing.recoveryCount += 1;
+    existing.lastRecoveredAt = now;
+    delete existing.unknownReasons.recovery;
+    existing.evidencePointers = boundedPointers(existing.evidencePointers, [
+      `event:${randomUUID()}`,
+    ]);
+    this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
+  }
+
+  private write(records: ExperienceRecord[]): void {
+    mkdirSync(this.directory, { recursive: true, mode: 0o700 });
+    const temp = join(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID()}`);
+    try {
+      const sanitized = records.map((record) => sanitizeForEvidence(record) as ExperienceRecord);
+      const contents = sanitized.map((record) => JSON.stringify(record)).join('\n');
+      writeFileSync(temp, contents.length > 0 ? `${contents}\n` : '', {
+        encoding: 'utf8',
+        flag: 'wx',
+        mode: 0o600,
+      });
+      renameSync(temp, this.path);
+      chmodSync(this.path, 0o600);
+    } catch (error) {
+      try {
+        unlinkSync(temp);
+      } catch {
+        /* nothing to clean */
+      }
+      throw error;
+    }
+  }
+}
+
+export function discoverPluginVersion(fromUrl: string = import.meta.url): string | null {
+  if (process.env.RN_DEV_AGENT_PLUGIN_VERSION) return process.env.RN_DEV_AGENT_PLUGIN_VERSION;
+  const start = dirname(fileURLToPath(fromUrl));
+  const candidates = [
+    join(start, '..', '..', '.claude-plugin', 'plugin.json'),
+    join(start, '..', '..', '.codex-plugin', 'plugin.json'),
+    join(start, '..', '..', '..', 'claude-plugin', '.claude-plugin', 'plugin.json'),
+    join(start, '..', '..', '..', 'codex-plugin', '.codex-plugin', 'plugin.json'),
+  ];
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(readFileSync(candidate, 'utf8')) as { version?: unknown };
+      if (typeof parsed.version === 'string') return sanitizeString(parsed.version);
+    } catch {
+      /* try the next installed/source layout */
+    }
+  }
+  return null;
+}
+
+export function readExperienceStore(path: string, allowMissing = false): ExperienceRecord[] {
+  if (!existsSync(path)) {
+    if (allowMissing) return [];
+    return [];
+  }
+  const contents = readFileSync(path, 'utf8');
+  if (!contents.trim()) return [];
+  return contents
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as ExperienceRecord);
+}
+
+export function pruneExperienceRecords(
+  records: ExperienceRecord[],
+  now: Date,
+  maxRecords = DEFAULT_MAX_RECORDS,
+  retentionMs = DEFAULT_RETENTION_DAYS * DAY_MS,
+): ExperienceRecord[] {
+  const cutoff = now.getTime() - retentionMs;
+  return records
+    .filter((record) => {
+      const lastSeen = Date.parse(record.lastSeen);
+      return Number.isFinite(lastSeen) && lastSeen >= cutoff;
+    })
+    .sort(
+      (a, b) =>
+        Date.parse(b.lastSeen) - Date.parse(a.lastSeen) || a.signature.localeCompare(b.signature),
+    )
+    .slice(0, Math.max(0, maxRecords))
+    .sort((a, b) => a.signature.localeCompare(b.signature));
+}
+
+export function experienceSignature(input: {
+  classification: string;
+  tool: string;
+  normalizedSymptomShape: string;
+  platform: string | null;
+}): string {
+  return createHash('sha256')
+    .update(
+      JSON.stringify([
+        input.classification,
+        input.tool,
+        input.normalizedSymptomShape,
+        input.platform ?? 'unknown',
+      ]),
+    )
+    .digest('hex');
+}
+
+export function normalizeSymptomShape(symptom: string): string {
+  return symptom
+    .toLowerCase()
+    .replace(/[0-9a-f]{8}-[0-9a-f-]{27,}/gi, '<id>')
+    .replace(/\b0x[0-9a-f]+\b/gi, '<hex>')
+    .replace(/\b(?=[a-z0-9_-]{12,}\b)(?=[a-z0-9_-]*\d)[a-z0-9_-]+\b/gi, '<id>')
+    .replace(/\b\d+\b/g, '#')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function classifyExperience(symptom: string, tool: string, platform: string | null): string {
+  const haystack = `${tool} ${platform ?? ''} ${symptom}`.toLowerCase();
+  const rules: ReadonlyArray<[string, RegExp]> = [
+    ['FF_REDBOX', /redbox|logbox|error overlay|hasredbox/],
+    ['FF_DEBUGGER_PAUSED', /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
+    [
+      'FF_STALE_CDP',
+      /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/,
+    ],
+    ['FF_FAST_REFRESH_STALE', /fast refresh|ui unchanged|old exports|old module path/],
+    ['FF_METRO_CACHE', /metro.*(?:stale|cache)|config change not reflected/],
+    [
+      'FF_BINARY_MISMATCH',
+      /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/,
+    ],
+    ['FF_EXPO_DIALOG', /open-in-app|system confirmation dialog/],
+    [
+      'FF_DEV_CLIENT_PICKER',
+      /no hermes target|development servers|devclientlauncher|server picker/,
+    ],
+    ['FF_KEYBOARD_OVERLAY', /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
+    ['FF_MAESTRO_GRPC_ANDROID', /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
+    [
+      'FF_ANDROID_TEXT_INPUT_CRASH',
+      /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/,
+    ],
+    [
+      'FF_AUTH_GATE',
+      /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/,
+    ],
+    [
+      'FF_PERMISSION_ALREADY_GRANTED',
+      /permission already granted|prompt (?:was )?not shown|flow completes instantly/,
+    ],
+    ['EG_EXPO_GO_SDK_MISMATCH', /incompatible with this version of expo go|expo go sdk.*mismatch/],
+    ['EG_NATIVEWIND_JSX_SOURCE', /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
+    ['EG_EXPO_GO_NATIVE_MODULES', /expo go.*custom native module/],
+    ['EG_DEV_CLIENT_CLEARSTATE', /clearstate.*(?:dev client|metro connection|launcher)/],
+    ['EG_MSW_HERMES', /msw.*(?:hermes|react native|initialize)/],
+    ['EG_EXPO_ROUTER_DEEP_LINK', /expo router.*deep link|deep link.*confirmation dialog/],
+    ['EG_DEV_MENU_INTERFERENCE', /dev menu.*(?:overlay|recording|blocking)/],
+    ['EG_NEW_ARCH_CDP_TARGET', /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
+    ['PQ_IOS_RECORDVIDEO_CODEC', /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
+    ['PQ_ANDROID_SCREENRECORD_LIMIT', /screenrecord.*180|screenrecord.*3 minute/],
+    ['PQ_ANDROID_BOOT_DELAY', /sys\.boot_completed|emulator.*grpc.*ready/],
+    ['PQ_ANDROID_PLAY_PROTECT', /play protect.*(?:block|apk|install)/],
+  ];
+  return rules.find(([, pattern]) => pattern.test(haystack))?.[0] ?? UNKNOWN_CLASSIFICATION;
+}
+
+function extractSymptom(event: ToolObserverInput): string {
+  if (typeof event.error === 'string' && event.error.length > 0) return event.error;
+  if (event.result && typeof event.result === 'object') {
+    const envelope = event.result as Record<string, unknown>;
+    if (typeof envelope.error === 'string') return envelope.error;
+    const content = envelope.content;
+    if (Array.isArray(content)) {
+      const first = content[0] as Record<string, unknown> | undefined;
+      if (typeof first?.text === 'string') return first.text;
+    }
+  }
+  return `${event.tool} reported ${event.status} without an error message`;
+}
+
+function extractScalar(event: ToolObserverInput, keys: string[]): string | null {
+  const sources: unknown[] = [event.params, event.result];
+  for (const source of sources) {
+    const value = findScalar(source, keys, 0);
+    if (value !== null) return value;
+  }
+  return null;
+}
+
+function findScalar(value: unknown, keys: string[], depth: number): string | null {
+  if (!value || typeof value !== 'object' || depth > 3) return null;
+  const object = value as Record<string, unknown>;
+  for (const key of keys) {
+    const candidate = object[key];
+    if (typeof candidate === 'string' && candidate.length > 0) return candidate;
+  }
+  for (const nested of Object.values(object)) {
+    if (nested && typeof nested === 'object') {
+      const found = findScalar(nested, keys, depth + 1);
+      if (found !== null) return found;
+    }
+  }
+  return null;
+}
+
+function sanitizeNullable(value: string | null): string | null {
+  return value === null ? null : sanitizeString(value);
+}
+
+function boundedPointers(existing: string[], incoming: string[]): string[] {
+  return [...new Set([...existing, ...incoming])].slice(-MAX_EVIDENCE_POINTERS);
+}

--- a/packages/rn-dev-agent-core/src/experience/evidence.ts
+++ b/packages/rn-dev-agent-core/src/experience/evidence.ts
@@ -19,9 +19,11 @@ export const DEFAULT_RETENTION_DAYS = 14;
 export const MAX_EVIDENCE_POINTERS = 3;
 export const EXPERIENCE_DIRECTORY = join(homedir(), '.claude', 'rn-agent', 'experience');
 export const EXPERIENCE_STORE_NAME = 'patterns.jsonl';
+export const MAX_SYMPTOM_LENGTH = 2048;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const REDACTION_FAILED = '[REDACTION_FAILED]';
+const SYMPTOM_TRUNCATED = '[TRUNCATED]';
 
 // Keep this list aligned with scripts/collect-feedback.sh. That collector is the
 // public sanitization contract; this in-process form exists so private tool
@@ -58,6 +60,10 @@ const KEYED_SECRET = /((?:token|secret|password|auth|api[_-]?key)\s*[:=]\s*)[^\s
 
 export type RedactString = (value: string) => string;
 
+// Records are sanitized on construction and again before they reach disk, so a
+// record read back from the store never needs a second full-tree pass.
+const SANITIZED_RECORDS = new WeakSet<ExperienceRecord>();
+
 export function sanitizeString(value: string, redact: RedactString = applyRedactionRules): string {
   try {
     return redact(value);
@@ -93,7 +99,37 @@ function applyRedactionRules(value: string): string {
     pattern.lastIndex = 0;
     result = result.replace(pattern, replacement);
   }
+  const identity = readAppIdentity();
+  if (identity.name) result = result.replaceAll(identity.name, '[APP_NAME_REDACTED]');
+  if (identity.slug) result = result.replaceAll(identity.slug, '[APP_SLUG_REDACTED]');
   return result;
+}
+
+interface AppIdentity {
+  name: string | null;
+  slug: string | null;
+}
+
+let appIdentityCache: { root: string; identity: AppIdentity } | null = null;
+
+// Mirrors the app.json stage of scripts/collect-feedback.sh. A malformed
+// manifest throws, so sanitizeString fails closed instead of shipping the name.
+function readAppIdentity(): AppIdentity {
+  const root = process.env.RN_PROJECT_ROOT ?? process.env.CLAUDE_USER_CWD ?? process.cwd();
+  if (appIdentityCache?.root === root) return appIdentityCache.identity;
+  const manifest = join(root, 'app.json');
+  let identity: AppIdentity = { name: null, slug: null };
+  if (existsSync(manifest)) {
+    const parsed = JSON.parse(readFileSync(manifest, 'utf8')) as Record<string, unknown>;
+    const expo = (parsed.expo as Record<string, unknown> | undefined) ?? parsed;
+    identity = { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
+  }
+  appIdentityCache = { root, identity };
+  return identity;
+}
+
+function usableIdentity(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 2 ? value : null;
 }
 
 interface Candidate {
@@ -217,7 +253,7 @@ export class ExperienceRecorder {
   private buildFailureRecord(event: ToolObserverInput): ExperienceRecord {
     const now = this.now().toISOString();
     const tool = sanitizeString(event.tool);
-    const symptom = sanitizeString(extractSymptom(event));
+    const symptom = sanitizeString(boundSymptom(extractSymptom(event)));
     const platform = sanitizeNullable(extractScalar(event, ['platform']));
     const deviceName = extractScalar(event, ['deviceName', 'deviceModel', 'model']);
     const hasDeviceId = extractScalar(event, ['deviceId', 'udid']) !== null;
@@ -269,19 +305,27 @@ export class ExperienceRecorder {
       lastRecoveredAt: null,
       unknownReasons,
     };
-    return sanitizeForEvidence(raw) as ExperienceRecord;
+    const sanitized = sanitizeForEvidence(raw) as ExperienceRecord;
+    SANITIZED_RECORDS.add(sanitized);
+    return sanitized;
   }
 
   private persistFailure(incoming: ExperienceRecord): void {
-    const records = readExperienceStore(this.path, true);
+    const records = readExperienceStore(this.path);
     const existing = records.find((record) => record.signature === incoming.signature);
     if (existing) {
       existing.count += 1;
       existing.lastSeen = incoming.lastSeen;
-      existing.status = incoming.status;
+      if (incoming.status === 'ERROR' && existing.status !== 'ERROR') {
+        existing.status = 'ERROR';
+        existing.trigger = incoming.trigger;
+      }
       existing.symptom = incoming.symptom;
       existing.candidate = incoming.candidate;
       existing.environment = incoming.environment;
+      adoptLateFact(existing, incoming, 'platform');
+      adoptLateFact(existing, incoming, 'device');
+      adoptLateFact(existing, incoming, 'runtime');
       existing.evidencePointers = boundedPointers(
         existing.evidencePointers,
         incoming.evidencePointers,
@@ -293,7 +337,7 @@ export class ExperienceRecorder {
   }
 
   private persistRecovery(signature: string, tool: string): void {
-    const records = readExperienceStore(this.path, true);
+    const records = readExperienceStore(this.path);
     const existing = records.find((record) => record.signature === signature);
     if (!existing) return;
     const now = this.now().toISOString();
@@ -311,7 +355,9 @@ export class ExperienceRecorder {
     mkdirSync(this.directory, { recursive: true, mode: 0o700 });
     const temp = join(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID()}`);
     try {
-      const sanitized = records.map((record) => sanitizeForEvidence(record) as ExperienceRecord);
+      const sanitized = records.map((record) =>
+        SANITIZED_RECORDS.has(record) ? record : (sanitizeForEvidence(record) as ExperienceRecord),
+      );
       const contents = sanitized.map((record) => JSON.stringify(record)).join('\n');
       writeFileSync(temp, contents.length > 0 ? `${contents}\n` : '', {
         encoding: 'utf8',
@@ -351,17 +397,23 @@ export function discoverPluginVersion(fromUrl: string = import.meta.url): string
   return null;
 }
 
-export function readExperienceStore(path: string, allowMissing = false): ExperienceRecord[] {
-  if (!existsSync(path)) {
-    if (allowMissing) return [];
-    return [];
-  }
+export function readExperienceStore(path: string): ExperienceRecord[] {
+  if (!existsSync(path)) return [];
   const contents = readFileSync(path, 'utf8');
   if (!contents.trim()) return [];
-  return contents
-    .split('\n')
-    .filter((line) => line.trim().length > 0)
-    .map((line) => JSON.parse(line) as ExperienceRecord);
+  const records: ExperienceRecord[] = [];
+  for (const line of contents.split('\n')) {
+    if (line.trim().length === 0) continue;
+    let parsed: ExperienceRecord;
+    try {
+      parsed = JSON.parse(line) as ExperienceRecord;
+    } catch {
+      continue;
+    }
+    SANITIZED_RECORDS.add(parsed);
+    records.push(parsed);
+  }
+  return records;
 }
 
 export function pruneExperienceRecords(
@@ -413,54 +465,54 @@ export function normalizeSymptomShape(symptom: string): string {
     .trim();
 }
 
+const CLASSIFICATION_RULES: ReadonlyArray<[string, RegExp]> = [
+  ['FF_REDBOX', /redbox|logbox|error overlay|hasredbox/],
+  ['FF_DEBUGGER_PAUSED', /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
+  [
+    'FF_STALE_CDP',
+    /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/,
+  ],
+  ['FF_FAST_REFRESH_STALE', /fast refresh|ui unchanged|old exports|old module path/],
+  ['FF_METRO_CACHE', /metro.*(?:stale|cache)|config change not reflected/],
+  [
+    'FF_BINARY_MISMATCH',
+    /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/,
+  ],
+  ['FF_EXPO_DIALOG', /open-in-app|system confirmation dialog/],
+  ['FF_DEV_CLIENT_PICKER', /no hermes target|development servers|devclientlauncher|server picker/],
+  ['FF_KEYBOARD_OVERLAY', /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
+  ['FF_MAESTRO_GRPC_ANDROID', /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
+  [
+    'FF_ANDROID_TEXT_INPUT_CRASH',
+    /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/,
+  ],
+  ['FF_AUTH_GATE', /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/],
+  [
+    'FF_PERMISSION_ALREADY_GRANTED',
+    /permission already granted|prompt (?:was )?not shown|flow completes instantly/,
+  ],
+  ['EG_EXPO_GO_SDK_MISMATCH', /incompatible with this version of expo go|expo go sdk.*mismatch/],
+  ['EG_NATIVEWIND_JSX_SOURCE', /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
+  ['EG_EXPO_GO_NATIVE_MODULES', /expo go.*custom native module/],
+  ['EG_DEV_CLIENT_CLEARSTATE', /clearstate.*(?:dev client|metro connection|launcher)/],
+  ['EG_MSW_HERMES', /msw.*(?:hermes|react native|initialize)/],
+  ['EG_EXPO_ROUTER_DEEP_LINK', /expo router.*deep link|deep link.*confirmation dialog/],
+  ['EG_DEV_MENU_INTERFERENCE', /dev menu.*(?:overlay|recording|blocking)/],
+  ['EG_NEW_ARCH_CDP_TARGET', /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
+  ['PQ_IOS_RECORDVIDEO_CODEC', /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
+  ['PQ_ANDROID_SCREENRECORD_LIMIT', /screenrecord.*180|screenrecord.*3 minute/],
+  ['PQ_ANDROID_BOOT_DELAY', /sys\.boot_completed|emulator.*grpc.*ready/],
+  ['PQ_ANDROID_PLAY_PROTECT', /play protect.*(?:block|apk|install)/],
+];
+
+export const EXPERIENCE_FAMILY_IDS: readonly string[] = CLASSIFICATION_RULES.map(([id]) => id);
+
 export function classifyExperience(symptom: string, tool: string, platform: string | null): string {
   const haystack = `${tool} ${platform ?? ''} ${symptom}`.toLowerCase();
-  const rules: ReadonlyArray<[string, RegExp]> = [
-    ['FF_REDBOX', /redbox|logbox|error overlay|hasredbox/],
-    ['FF_DEBUGGER_PAUSED', /debugger paused|ispaused\s*[=:]\s*true|execution (?:is )?halted/],
-    [
-      'FF_STALE_CDP',
-      /websocket (?:close )?1006|target not found|cdp_status.*time(?:d)?out|not connected/,
-    ],
-    ['FF_FAST_REFRESH_STALE', /fast refresh|ui unchanged|old exports|old module path/],
-    ['FF_METRO_CACHE', /metro.*(?:stale|cache)|config change not reflected/],
-    [
-      'FF_BINARY_MISMATCH',
-      /turbomoduleregistry|getenforcing|native module (?:cannot be null|mismatch|not found)/,
-    ],
-    ['FF_EXPO_DIALOG', /open-in-app|system confirmation dialog/],
-    [
-      'FF_DEV_CLIENT_PICKER',
-      /no hermes target|development servers|devclientlauncher|server picker/,
-    ],
-    ['FF_KEYBOARD_OVERLAY', /keyboard.*(?:obscur|behind|cover)|element behind keyboard/],
-    ['FF_MAESTRO_GRPC_ANDROID', /unavailable:\s*io exception|androiddriver.*grpc|maestro.*grpc/],
-    [
-      'FF_ANDROID_TEXT_INPUT_CRASH',
-      /(?:text input|mobile_type_keys|adb.*input text).*(?:crash|anr|home screen|disappear)/,
-    ],
-    [
-      'FF_AUTH_GATE',
-      /(?:stuck|blocked|remains?).*(?:login|welcome|register|auth) (?:screen|route)/,
-    ],
-    [
-      'FF_PERMISSION_ALREADY_GRANTED',
-      /permission already granted|prompt (?:was )?not shown|flow completes instantly/,
-    ],
-    ['EG_EXPO_GO_SDK_MISMATCH', /incompatible with this version of expo go|expo go sdk.*mismatch/],
-    ['EG_NATIVEWIND_JSX_SOURCE', /nativewind.*jsximportsource|styles.*(?:unstyled|don.t apply)/],
-    ['EG_EXPO_GO_NATIVE_MODULES', /expo go.*custom native module/],
-    ['EG_DEV_CLIENT_CLEARSTATE', /clearstate.*(?:dev client|metro connection|launcher)/],
-    ['EG_MSW_HERMES', /msw.*(?:hermes|react native|initialize)/],
-    ['EG_EXPO_ROUTER_DEEP_LINK', /expo router.*deep link|deep link.*confirmation dialog/],
-    ['EG_DEV_MENU_INTERFERENCE', /dev menu.*(?:overlay|recording|blocking)/],
-    ['EG_NEW_ARCH_CDP_TARGET', /bridgeless.*(?:target|app\.dev)|new architecture.*cdp target/],
-    ['PQ_IOS_RECORDVIDEO_CODEC', /simctl recordvideo.*codec.*fail|recordvideo.*h264/],
-    ['PQ_ANDROID_SCREENRECORD_LIMIT', /screenrecord.*180|screenrecord.*3 minute/],
-    ['PQ_ANDROID_BOOT_DELAY', /sys\.boot_completed|emulator.*grpc.*ready/],
-    ['PQ_ANDROID_PLAY_PROTECT', /play protect.*(?:block|apk|install)/],
-  ];
-  return rules.find(([, pattern]) => pattern.test(haystack))?.[0] ?? UNKNOWN_CLASSIFICATION;
+  return (
+    CLASSIFICATION_RULES.find(([, pattern]) => pattern.test(haystack))?.[0] ??
+    UNKNOWN_CLASSIFICATION
+  );
 }
 
 function extractSymptom(event: ToolObserverInput): string {
@@ -475,6 +527,15 @@ function extractSymptom(event: ToolObserverInput): string {
     }
   }
   return `${event.tool} reported ${event.status} without an error message`;
+}
+
+// Bounding happens before redaction so the regex pass stays linear on huge
+// payloads; the trailing partial token goes too, so nothing can survive the cut
+// as a half-redacted secret.
+function boundSymptom(symptom: string): string {
+  if (symptom.length <= MAX_SYMPTOM_LENGTH) return symptom;
+  const head = symptom.slice(0, MAX_SYMPTOM_LENGTH).replace(/\S+$/, '');
+  return `${head}${SYMPTOM_TRUNCATED}`;
 }
 
 function extractScalar(event: ToolObserverInput, keys: string[]): string | null {
@@ -504,6 +565,16 @@ function findScalar(value: unknown, keys: string[], depth: number): string | nul
 
 function sanitizeNullable(value: string | null): string | null {
   return value === null ? null : sanitizeString(value);
+}
+
+function adoptLateFact(
+  existing: ExperienceRecord,
+  incoming: ExperienceRecord,
+  field: 'platform' | 'device' | 'runtime',
+): void {
+  if (existing[field] !== null || incoming[field] === null) return;
+  existing[field] = incoming[field];
+  delete existing.unknownReasons[field];
 }
 
 function boundedPointers(existing: string[], incoming: string[]): string[] {

--- a/packages/rn-dev-agent-core/src/experience/evidence.ts
+++ b/packages/rn-dev-agent-core/src/experience/evidence.ts
@@ -60,9 +60,9 @@ const KEYED_SECRET = /((?:token|secret|password|auth|api[_-]?key)\s*[:=]\s*)[^\s
 
 export type RedactString = (value: string) => string;
 
-// Records are sanitized on construction and again before they reach disk, so a
-// record read back from the store never needs a second full-tree pass.
-const SANITIZED_RECORDS = new WeakSet<ExperienceRecord>();
+// Bump whenever a redaction rule changes: stored records stamped with an older
+// version are re-sanitized under the current rules before the next rewrite.
+export const REDACTION_RULES_VERSION = 1;
 
 export function sanitizeString(value: string, redact: RedactString = applyRedactionRules): string {
   try {
@@ -110,22 +110,31 @@ interface AppIdentity {
   slug: string | null;
 }
 
-let appIdentityCache: { root: string; identity: AppIdentity } | null = null;
+let appIdentityCache: { root: string; identity: AppIdentity | null } | null = null;
 
-// Mirrors the app.json stage of scripts/collect-feedback.sh. A malformed
+// Mirrors the app.json stage of scripts/collect-feedback.sh. An unreadable
 // manifest throws, so sanitizeString fails closed instead of shipping the name.
 function readAppIdentity(): AppIdentity {
   const root = process.env.RN_PROJECT_ROOT ?? process.env.CLAUDE_USER_CWD ?? process.cwd();
-  if (appIdentityCache?.root === root) return appIdentityCache.identity;
+  if (appIdentityCache?.root !== root) {
+    appIdentityCache = { root, identity: loadAppIdentity(root) };
+  }
+  if (appIdentityCache.identity === null) {
+    throw new Error('app identity could not be read for redaction');
+  }
+  return appIdentityCache.identity;
+}
+
+function loadAppIdentity(root: string): AppIdentity | null {
   const manifest = join(root, 'app.json');
-  let identity: AppIdentity = { name: null, slug: null };
-  if (existsSync(manifest)) {
+  try {
+    if (!existsSync(manifest)) return { name: null, slug: null };
     const parsed = JSON.parse(readFileSync(manifest, 'utf8')) as Record<string, unknown>;
     const expo = (parsed.expo as Record<string, unknown> | undefined) ?? parsed;
-    identity = { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
+    return { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
+  } catch {
+    return null;
   }
-  appIdentityCache = { root, identity };
-  return identity;
 }
 
 function usableIdentity(value: unknown): string | null {
@@ -166,6 +175,7 @@ export interface ExperienceRecord {
   lastSeen: string;
   lastRecoveredAt: string | null;
   unknownReasons: Record<string, string>;
+  redactionVersion: number;
 }
 
 export interface ExperienceStoreOptions {
@@ -304,10 +314,9 @@ export class ExperienceRecorder {
       lastSeen: now,
       lastRecoveredAt: null,
       unknownReasons,
+      redactionVersion: REDACTION_RULES_VERSION,
     };
-    const sanitized = sanitizeForEvidence(raw) as ExperienceRecord;
-    SANITIZED_RECORDS.add(sanitized);
-    return sanitized;
+    return sanitizeForEvidence(raw) as ExperienceRecord;
   }
 
   private persistFailure(incoming: ExperienceRecord): void {
@@ -323,7 +332,6 @@ export class ExperienceRecorder {
       existing.symptom = incoming.symptom;
       existing.candidate = incoming.candidate;
       existing.environment = incoming.environment;
-      adoptLateFact(existing, incoming, 'platform');
       adoptLateFact(existing, incoming, 'device');
       adoptLateFact(existing, incoming, 'runtime');
       existing.evidencePointers = boundedPointers(
@@ -356,7 +364,12 @@ export class ExperienceRecorder {
     const temp = join(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID()}`);
     try {
       const sanitized = records.map((record) =>
-        SANITIZED_RECORDS.has(record) ? record : (sanitizeForEvidence(record) as ExperienceRecord),
+        record.redactionVersion === REDACTION_RULES_VERSION
+          ? record
+          : {
+              ...(sanitizeForEvidence(record) as ExperienceRecord),
+              redactionVersion: REDACTION_RULES_VERSION,
+            },
       );
       const contents = sanitized.map((record) => JSON.stringify(record)).join('\n');
       writeFileSync(temp, contents.length > 0 ? `${contents}\n` : '', {
@@ -410,7 +423,6 @@ export function readExperienceStore(path: string): ExperienceRecord[] {
     } catch {
       continue;
     }
-    SANITIZED_RECORDS.add(parsed);
     records.push(parsed);
   }
   return records;
@@ -570,7 +582,7 @@ function sanitizeNullable(value: string | null): string | null {
 function adoptLateFact(
   existing: ExperienceRecord,
   incoming: ExperienceRecord,
-  field: 'platform' | 'device' | 'runtime',
+  field: 'device' | 'runtime',
 ): void {
   if (existing[field] !== null || incoming[field] === null) return;
   existing[field] = incoming[field];

--- a/packages/rn-dev-agent-core/src/experience/trends.ts
+++ b/packages/rn-dev-agent-core/src/experience/trends.ts
@@ -1,0 +1,85 @@
+import { join } from 'node:path';
+import {
+  EXPERIENCE_DIRECTORY,
+  EXPERIENCE_STORE_NAME,
+  readExperienceStore,
+  type ExperienceRecord,
+} from './evidence.js';
+
+export interface FamilyTrend {
+  classification: string;
+  count: number;
+  patterns: number;
+}
+
+export interface RecurringTrend {
+  signature: string;
+  classification: string;
+  tool: string;
+  count: number;
+  firstSeen: string;
+  lastSeen: string;
+}
+
+export interface ExperienceTrendReport {
+  generatedAt: string;
+  since: string;
+  families: FamilyTrend[];
+  newSincePreviousReport: RecurringTrend[];
+  recurring: RecurringTrend[];
+}
+
+export function buildExperienceTrendReport(
+  records: ExperienceRecord[],
+  since: Date,
+  now: Date = new Date(),
+): ExperienceTrendReport {
+  const families = new Map<string, { count: number; patterns: number }>();
+  for (const record of records) {
+    const aggregate = families.get(record.classification) ?? { count: 0, patterns: 0 };
+    aggregate.count += record.count;
+    aggregate.patterns += 1;
+    families.set(record.classification, aggregate);
+  }
+
+  const project = (record: ExperienceRecord): RecurringTrend => ({
+    signature: record.signature,
+    classification: record.classification,
+    tool: record.tool,
+    count: record.count,
+    firstSeen: record.firstSeen,
+    lastSeen: record.lastSeen,
+  });
+  const sortPatterns = (a: RecurringTrend, b: RecurringTrend) =>
+    b.count - a.count ||
+    a.classification.localeCompare(b.classification) ||
+    a.signature.localeCompare(b.signature);
+
+  return {
+    generatedAt: now.toISOString(),
+    since: since.toISOString(),
+    families: [...families.entries()]
+      .map(([classification, value]) => ({ classification, ...value }))
+      .sort((a, b) => b.count - a.count || a.classification.localeCompare(b.classification)),
+    newSincePreviousReport: records
+      .filter((record) => Date.parse(record.firstSeen) >= since.getTime())
+      .map(project)
+      .sort(sortPatterns),
+    recurring: records
+      .filter((record) => record.count > 1)
+      .map(project)
+      .sort(sortPatterns),
+  };
+}
+
+export function readExperienceTrendReport(options: {
+  since: Date;
+  directory?: string;
+}): ExperienceTrendReport {
+  const directory =
+    options.directory ?? process.env.RN_DEV_AGENT_EXPERIENCE_DIR ?? EXPERIENCE_DIRECTORY;
+  return buildExperienceTrendReport(
+    readExperienceStore(join(directory, EXPERIENCE_STORE_NAME)),
+    options.since,
+  );
+}

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -149,6 +149,7 @@ import {
 import { readProcessBirth } from './session/process-birth.js';
 import { ensureSingleRunner } from './runners/ensure-single-runner.js';
 import { addToolObserver, instrumentTool } from './observability/instrumentation.js';
+import { discoverPluginVersion, ExperienceRecorder } from './experience/evidence.js';
 import { recorder } from './observability/recorder.js';
 import { hashProofValue, StrictProofMonitor } from './domain/proof-capture.js';
 import type { ProofAuthority } from './domain/proof-receipt.js';
@@ -378,8 +379,13 @@ const server = new McpServer({
 });
 
 export const strictProofMonitor = new StrictProofMonitor();
+const experienceRecorder = new ExperienceRecorder({
+  coreVersion: pkgVersion,
+  pluginVersion: discoverPluginVersion(),
+});
 addToolObserver((o) => recorder.record(o));
 addToolObserver((o) => strictProofMonitor.record(o));
+addToolObserver((o) => experienceRecorder.observe(o));
 
 const authorityRuntime = getWorkerAuthorityRuntime();
 setSnapshotAuthorityProvider({

--- a/packages/rn-dev-agent-core/test/unit/experience-evidence.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/experience-evidence.test.ts
@@ -7,7 +7,9 @@ import { fileURLToPath } from 'node:url';
 import { parse } from 'yaml';
 import {
   ExperienceRecorder,
+  EXPERIENCE_FAMILY_IDS,
   EXPERIENCE_STORE_NAME,
+  MAX_SYMPTOM_LENGTH,
   classifyExperience,
   experienceSignature,
   normalizeSymptomShape,
@@ -119,6 +121,112 @@ test('a meaningful failure writes exactly one fully sanitized structured record'
   assert.match(serialized, /REDACTED/);
 });
 
+test('a bare app display name and slug from app.json are redacted', (t) => {
+  const projectRoot = tempDirectory();
+  writeFileSync(
+    join(projectRoot, 'app.json'),
+    JSON.stringify({ expo: { name: 'AcmeBanking', slug: 'acme-banking-private' } }),
+  );
+  const previousRoot = process.env.RN_PROJECT_ROOT;
+  process.env.RN_PROJECT_ROOT = projectRoot;
+  t.after(() => {
+    if (previousRoot === undefined) delete process.env.RN_PROJECT_ROOT;
+    else process.env.RN_PROJECT_ROOT = previousRoot;
+  });
+
+  const directory = tempDirectory();
+  const recorder = synchronousRecorder(directory);
+  recorder.observe(fail('launchApp', 'Failed to launch AcmeBanking (acme-banking-private)'));
+
+  const serialized = readFileSync(join(directory, EXPERIENCE_STORE_NAME), 'utf8');
+  assert.doesNotMatch(serialized, /AcmeBanking|acme-banking-private/);
+  assert.match(serialized, /\[APP_NAME_REDACTED\]/);
+  assert.match(serialized, /\[APP_SLUG_REDACTED\]/);
+});
+
+test('a malformed app.json fails closed instead of shipping raw symptoms', (t) => {
+  const projectRoot = tempDirectory();
+  writeFileSync(join(projectRoot, 'app.json'), '{ not valid json');
+  const previousRoot = process.env.RN_PROJECT_ROOT;
+  process.env.RN_PROJECT_ROOT = projectRoot;
+  t.after(() => {
+    if (previousRoot === undefined) delete process.env.RN_PROJECT_ROOT;
+    else process.env.RN_PROJECT_ROOT = previousRoot;
+  });
+
+  const directory = tempDirectory();
+  const recorder = synchronousRecorder(directory);
+  recorder.observe(fail('launchApp', 'Failed to launch AcmeBanking'));
+
+  const serialized = readFileSync(join(directory, EXPERIENCE_STORE_NAME), 'utf8');
+  assert.doesNotMatch(serialized, /AcmeBanking/);
+  assert.deepEqual(recorder.read(), []);
+});
+
+test('a payload-heavy symptom is bounded before it reaches the store', { timeout: 10_000 }, () => {
+  const directory = tempDirectory();
+  const recorder = synchronousRecorder(directory);
+  recorder.observe(fail('device_snapshot', `hierarchy ${'x'.repeat(200_000)}`));
+
+  const record = recorder.read()[0];
+  assert.ok(record.symptom.length <= MAX_SYMPTOM_LENGTH + '[TRUNCATED]'.length);
+  assert.match(record.symptom, /\[TRUNCATED\]$/);
+  assert.ok(readFileSync(join(directory, EXPERIENCE_STORE_NAME), 'utf8').length < 10_000);
+});
+
+test('a corrupt store line is dropped instead of disabling recording forever', () => {
+  const directory = tempDirectory();
+  const path = join(directory, EXPERIENCE_STORE_NAME);
+  const recorder = synchronousRecorder(directory);
+  recorder.observe(fail('cdp_status', 'WebSocket close 1006', { platform: 'ios' }));
+  writeFileSync(path, `${readFileSync(path, 'utf8')}{"signature":"truncated`);
+
+  recorder.observe(fail('device_find', 'unrecognized failure', { platform: 'android' }));
+
+  const records = recorder.read();
+  assert.equal(records.length, 2);
+  assert.doesNotMatch(readFileSync(path, 'utf8'), /truncated/);
+});
+
+test('a later event fills a previously unknown device without losing the record', () => {
+  const directory = tempDirectory();
+  const recorder = synchronousRecorder(directory);
+  recorder.observe(fail('cdp_status', 'WebSocket close 1006', { platform: 'ios' }));
+  recorder.observe(
+    fail('cdp_status', 'WebSocket close 1006', {
+      platform: 'ios',
+      deviceName: 'iPhone 17',
+      runtime: 'Hermes',
+    }),
+  );
+
+  const records = recorder.read();
+  assert.equal(records.length, 1);
+  assert.equal(records[0].count, 2);
+  assert.equal(records[0].device, 'iPhone 17');
+  assert.equal(records[0].runtime, 'Hermes');
+  assert.equal(records[0].unknownReasons.device, undefined);
+  assert.equal(records[0].unknownReasons.runtime, undefined);
+});
+
+test('an ERROR occurrence is not downgraded by a later FAIL with the same shape', () => {
+  const directory = tempDirectory();
+  const recorder = synchronousRecorder(directory);
+  recorder.observe({
+    tool: 'cdp_status',
+    params: { platform: 'ios' },
+    status: 'ERROR',
+    latencyMs: 3,
+    error: 'WebSocket close 1006',
+  });
+  recorder.observe(fail('cdp_status', 'WebSocket close 1006', { platform: 'ios' }));
+
+  const records = recorder.read();
+  assert.equal(records.length, 1);
+  assert.equal(records[0].status, 'ERROR');
+  assert.match(records[0].trigger, /^ERROR reported by/);
+});
+
 test('a thrown-tool ERROR writes one meaningful record', () => {
   const directory = tempDirectory();
   const recorder = synchronousRecorder(directory);
@@ -179,7 +287,10 @@ test('classification only emits ids that exist in real seed-experience YAML', ()
     'android',
   );
   assert.equal(classification, 'FF_MAESTRO_GRPC_ANDROID');
-  assert.ok(ids.has(classification));
+  assert.deepEqual(
+    EXPERIENCE_FAMILY_IDS.filter((id) => !ids.has(id)),
+    [],
+  );
   assert.equal(classifyExperience('unrecognized private failure', 'custom_tool', null), 'UNKNOWN');
 });
 

--- a/packages/rn-dev-agent-core/test/unit/experience-evidence.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/experience-evidence.test.ts
@@ -10,6 +10,7 @@ import {
   EXPERIENCE_FAMILY_IDS,
   EXPERIENCE_STORE_NAME,
   MAX_SYMPTOM_LENGTH,
+  REDACTION_RULES_VERSION,
   classifyExperience,
   experienceSignature,
   normalizeSymptomShape,
@@ -72,6 +73,7 @@ function recordFixture(overrides: Partial<ExperienceRecord>): ExperienceRecord {
     lastSeen: '2026-06-01T00:00:00.000Z',
     lastRecoveredAt: null,
     unknownReasons: {},
+    redactionVersion: REDACTION_RULES_VERSION,
     ...overrides,
   };
 }
@@ -186,6 +188,39 @@ test('a corrupt store line is dropped instead of disabling recording forever', (
   const records = recorder.read();
   assert.equal(records.length, 2);
   assert.doesNotMatch(readFileSync(path, 'utf8'), /truncated/);
+});
+
+test('a record stored under older redaction rules is re-sanitized before rewrite', (t) => {
+  const projectRoot = tempDirectory();
+  writeFileSync(
+    join(projectRoot, 'app.json'),
+    JSON.stringify({ expo: { name: 'AcmeBanking', slug: 'acme-banking-private' } }),
+  );
+  const previousRoot = process.env.RN_PROJECT_ROOT;
+  process.env.RN_PROJECT_ROOT = projectRoot;
+  t.after(() => {
+    if (previousRoot === undefined) delete process.env.RN_PROJECT_ROOT;
+    else process.env.RN_PROJECT_ROOT = previousRoot;
+  });
+
+  const directory = tempDirectory();
+  const path = join(directory, EXPERIENCE_STORE_NAME);
+  const legacy = recordFixture({
+    signature: 'legacy',
+    symptom: 'Failed to launch AcmeBanking for owner@example.com',
+    lastSeen: '2026-06-09T00:00:00.000Z',
+    redactionVersion: REDACTION_RULES_VERSION - 1,
+  });
+  writeFileSync(path, `${JSON.stringify(legacy)}\n`);
+
+  const recorder = synchronousRecorder(directory);
+  recorder.observe(fail('device_find', 'unrecognized failure', { platform: 'android' }));
+
+  const stored = recorder.read().find((record) => record.signature === 'legacy');
+  assert.ok(stored);
+  assert.doesNotMatch(readFileSync(path, 'utf8'), /AcmeBanking|owner@example\.com/);
+  assert.match(stored.symptom, /\[APP_NAME_REDACTED\]/);
+  assert.equal(stored.redactionVersion, REDACTION_RULES_VERSION);
 });
 
 test('a later event fills a previously unknown device without losing the record', () => {

--- a/packages/rn-dev-agent-core/test/unit/experience-evidence.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/experience-evidence.test.ts
@@ -1,0 +1,338 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'yaml';
+import {
+  ExperienceRecorder,
+  EXPERIENCE_STORE_NAME,
+  classifyExperience,
+  experienceSignature,
+  normalizeSymptomShape,
+  pruneExperienceRecords,
+  sanitizeForEvidence,
+  type ExperienceRecord,
+} from '../../dist/experience/evidence.js';
+import {
+  buildExperienceTrendReport,
+  readExperienceTrendReport,
+} from '../../dist/experience/trends.js';
+import { addToolObserver, instrumentTool } from '../../dist/observability/instrumentation.js';
+
+const NOW = new Date('2026-06-10T12:00:00.000Z');
+
+function tempDirectory(): string {
+  return mkdtempSync(join(tmpdir(), 'rn-experience-test-'));
+}
+
+function synchronousRecorder(
+  directory: string,
+  overrides: Partial<ConstructorParameters<typeof ExperienceRecorder>[0]> = {},
+) {
+  return new ExperienceRecorder({
+    directory,
+    coreVersion: '0.70.3',
+    pluginVersion: '0.75.3',
+    now: () => NOW,
+    schedule: (work) => work(),
+    ...overrides,
+  });
+}
+
+function fail(tool: string, error: string, params: Record<string, unknown> = {}) {
+  return { tool, params, status: 'FAIL' as const, latencyMs: 12, error };
+}
+
+function recordFixture(overrides: Partial<ExperienceRecord>): ExperienceRecord {
+  return {
+    signature: 'a',
+    candidate: { pluginVersion: '1.0.0', coreVersion: '1.0.0' },
+    environment: { os: 'darwin', node: 'v24' },
+    platform: 'ios',
+    device: null,
+    runtime: null,
+    phase: 'tool',
+    trigger: 'FAIL reported by cdp_status',
+    maskingCondition: null,
+    symptom: 'failure',
+    recovery: null,
+    cleanup: null,
+    classification: 'UNKNOWN',
+    evidencePointers: ['event:1'],
+    tool: 'cdp_status',
+    status: 'FAIL',
+    normalizedSymptomShape: 'failure',
+    count: 1,
+    recoveryCount: 0,
+    firstSeen: '2026-06-01T00:00:00.000Z',
+    lastSeen: '2026-06-01T00:00:00.000Z',
+    lastRecoveredAt: null,
+    unknownReasons: {},
+    ...overrides,
+  };
+}
+
+test('a meaningful failure writes exactly one fully sanitized structured record', () => {
+  const directory = tempDirectory();
+  const recorder = synchronousRecorder(directory);
+  const secret = 'ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ';
+  recorder.observe(
+    fail(
+      'cdp_status',
+      `WebSocket close 1006 for ${secret} user@example.com at 192.168.1.20 and 8.8.8.8, localhost:8081, https://example.test:9090/path, ${homedir()}/private/project.ts, /Users/private/project/very-long-file.ts, com.example.privateapp`,
+      { platform: 'ios', deviceId: 'PRIVATE-UDID', runtime: 'Hermes', port: 8081 },
+    ),
+  );
+
+  const records = recorder.read();
+  assert.equal(records.length, 1);
+  const record = records[0];
+  assert.equal(record.classification, 'FF_STALE_CDP');
+  assert.equal(record.platform, 'ios');
+  assert.equal(record.device, 'identified-device');
+  assert.equal(record.runtime, 'Hermes');
+  assert.equal(record.maskingCondition, null);
+  assert.match(record.unknownReasons.maskingCondition, /not derivable/);
+
+  const serialized = readFileSync(join(directory, EXPERIENCE_STORE_NAME), 'utf8');
+  for (const privateValue of [
+    secret,
+    'user@example.com',
+    '192.168.1.20',
+    '8.8.8.8',
+    'localhost:8081',
+    '8081',
+    '9090',
+    `${homedir()}/private/project.ts`,
+    '~/private/project.ts',
+    '/Users/private/project/very-long-file.ts',
+    'com.example.privateapp',
+    'PRIVATE-UDID',
+  ]) {
+    assert.doesNotMatch(
+      serialized,
+      new RegExp(privateValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+    );
+  }
+  assert.match(serialized, /REDACTED/);
+});
+
+test('a thrown-tool ERROR writes one meaningful record', () => {
+  const directory = tempDirectory();
+  const recorder = synchronousRecorder(directory);
+  recorder.observe({
+    tool: 'device_find',
+    params: {},
+    status: 'ERROR',
+    latencyMs: 4,
+    error: 'unexpected device transport error',
+  });
+
+  const records = recorder.read();
+  assert.equal(records.length, 1);
+  assert.equal(records[0].status, 'ERROR');
+  assert.equal(records[0].classification, 'UNKNOWN');
+});
+
+test('redaction failures fail closed with a placeholder, never raw content', () => {
+  const raw = { symptom: 'token-super-secret-private-value', nested: ['private@example.com'] };
+  const sanitized = sanitizeForEvidence(raw, () => {
+    throw new Error('redactor unavailable');
+  });
+  assert.deepEqual(sanitized, { symptom: '[REDACTION_FAILED]', nested: ['[REDACTION_FAILED]'] });
+  assert.doesNotMatch(JSON.stringify(sanitized), /super-secret|private@example/);
+});
+
+test('classification only emits ids that exist in real seed-experience YAML', () => {
+  const seedRoot = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    '..',
+    '..',
+    '..',
+    '..',
+    'seed-experience',
+  );
+  const ids = new Set<string>();
+  for (const file of [
+    'common-failures.yaml',
+    'expo-gotchas.yaml',
+    'platform-quirks.yaml',
+    'recovery-playbook.yaml',
+  ]) {
+    const value = parse(readFileSync(join(seedRoot, file), 'utf8')) as Record<string, unknown>;
+    const visit = (node: unknown): void => {
+      if (Array.isArray(node)) for (const item of node) visit(item);
+      else if (node && typeof node === 'object') {
+        const object = node as Record<string, unknown>;
+        if (typeof object.id === 'string') ids.add(object.id);
+        for (const nested of Object.values(object)) visit(nested);
+      }
+    };
+    visit(value);
+  }
+
+  const classification = classifyExperience(
+    'UNAVAILABLE: io exception in AndroidDriver gRPC',
+    'maestro_run',
+    'android',
+  );
+  assert.equal(classification, 'FF_MAESTRO_GRPC_ANDROID');
+  assert.ok(ids.has(classification));
+  assert.equal(classifyExperience('unrecognized private failure', 'custom_tool', null), 'UNKNOWN');
+});
+
+test('FAIL then immediate PASS on the same tool updates the failure as a recovery', () => {
+  const directory = tempDirectory();
+  const recorder = synchronousRecorder(directory);
+  recorder.observe(fail('cdp_status', 'WebSocket close 1006', { platform: 'ios' }));
+  recorder.observe({
+    tool: 'cdp_status',
+    params: { platform: 'ios' },
+    status: 'PASS',
+    latencyMs: 2,
+  });
+
+  const records = recorder.read();
+  assert.equal(records.length, 1);
+  assert.equal(records[0].count, 1);
+  assert.equal(records[0].recoveryCount, 1);
+  assert.match(records[0].recovery ?? '', /PASS immediately followed FAIL/);
+  assert.equal(records[0].unknownReasons.recovery, undefined);
+});
+
+test('ordinary PASS and a non-immediate PASS are not recorded as recoveries', () => {
+  const directory = tempDirectory();
+  const recorder = synchronousRecorder(directory);
+  recorder.observe({ tool: 'cdp_status', params: {}, status: 'PASS', latencyMs: 1 });
+  assert.deepEqual(recorder.read(), []);
+
+  recorder.observe(fail('cdp_status', 'WebSocket close 1006'));
+  recorder.observe({ tool: 'device_find', params: {}, status: 'PASS', latencyMs: 1 });
+  recorder.observe({ tool: 'cdp_status', params: {}, status: 'PASS', latencyMs: 1 });
+  assert.equal(recorder.read()[0].recoveryCount, 0);
+});
+
+test('dedupe signature is stable across runs, paths, ports, timestamps, and ids', () => {
+  const directory = tempDirectory();
+  const first = synchronousRecorder(directory);
+  first.observe(
+    fail(
+      'cdp_status',
+      `WebSocket close 1006 at localhost:8081 ${homedir()}/first/private-file.ts run ABCDEF1234567890`,
+      { platform: 'ios' },
+    ),
+  );
+  const firstSignature = first.read()[0].signature;
+
+  const second = synchronousRecorder(directory);
+  second.observe(
+    fail(
+      'cdp_status',
+      `WebSocket close 1006 at localhost:9090 ${homedir()}/second/another-file.ts run FEDCBA0987654321`,
+      { platform: 'ios' },
+    ),
+  );
+  const records = second.read();
+
+  assert.equal(records.length, 1);
+  assert.equal(records[0].count, 2);
+  assert.equal(records[0].signature, firstSignature);
+  assert.equal(
+    experienceSignature({
+      classification: 'FF_STALE_CDP',
+      tool: 'cdp_status',
+      normalizedSymptomShape: normalizeSymptomShape(records[0].symptom),
+      platform: 'ios',
+    }),
+    firstSignature,
+  );
+});
+
+test('a throwing or arbitrarily slow recorder is outside the tool path', async (t) => {
+  const directory = tempDirectory();
+  const blockedDirectory = join(directory, 'not-a-directory');
+  writeFileSync(blockedDirectory, 'occupied');
+  let queued: (() => void) | undefined;
+  const recorder = new ExperienceRecorder({
+    directory: blockedDirectory,
+    coreVersion: '1.0.0',
+    pluginVersion: '1.0.0',
+    schedule: (work) => {
+      queued = work;
+    },
+  });
+  const detach = addToolObserver((event) => recorder.observe(event));
+  t.after(detach);
+  const expected = { ok: false, error: 'failure stays unchanged' };
+
+  const result = await instrumentTool('cdp_status', async () => expected)({});
+
+  assert.strictEqual(result, expected);
+  assert.ok(queued, 'slow persistence was queued rather than awaited');
+  assert.equal(existsStore(blockedDirectory), false);
+  assert.doesNotThrow(() => queued?.(), 'an unwritable store is swallowed outside the tool path');
+});
+
+test('pruning is deterministic by age, recency, then signature', () => {
+  const records = [
+    recordFixture({ signature: 'old', lastSeen: '2026-05-01T00:00:00.000Z' }),
+    recordFixture({ signature: 'b', lastSeen: '2026-06-09T00:00:00.000Z' }),
+    recordFixture({ signature: 'a', lastSeen: '2026-06-09T00:00:00.000Z' }),
+    recordFixture({ signature: 'newest', lastSeen: '2026-06-10T00:00:00.000Z' }),
+  ];
+  const pruned = pruneExperienceRecords(records, NOW, 2, 14 * 24 * 60 * 60 * 1000);
+  assert.deepEqual(
+    pruned.map((record) => record.signature),
+    ['a', 'newest'],
+  );
+  assert.deepEqual(
+    pruneExperienceRecords([...records].reverse(), NOW, 2, 14 * 24 * 60 * 60 * 1000),
+    pruned,
+  );
+});
+
+test('trend report is read-only and exposes frequency, new, and recurring patterns', () => {
+  const directory = tempDirectory();
+  const recorder = synchronousRecorder(directory);
+  recorder.observe(fail('cdp_status', 'WebSocket close 1006', { platform: 'ios' }));
+  recorder.observe(fail('cdp_status', 'WebSocket close 1006', { platform: 'ios' }));
+  recorder.observe(fail('device_find', 'unrecognized failure', { platform: 'android' }));
+  const path = join(directory, EXPERIENCE_STORE_NAME);
+  const before = readFileSync(path, 'utf8');
+  const beforeStat = statSync(path);
+
+  const report = readExperienceTrendReport({
+    directory,
+    since: new Date('2026-06-10T00:00:00.000Z'),
+  });
+
+  assert.deepEqual(
+    report.families.map(({ classification, count }) => ({ classification, count })),
+    [
+      { classification: 'FF_STALE_CDP', count: 2 },
+      { classification: 'UNKNOWN', count: 1 },
+    ],
+  );
+  assert.equal(report.newSincePreviousReport.length, 2);
+  assert.equal(report.recurring.length, 1);
+  assert.equal(report.recurring[0].count, 2);
+  assert.equal(readFileSync(path, 'utf8'), before);
+  assert.equal(statSync(path).mtimeMs, beforeStat.mtimeMs);
+
+  assert.deepEqual(
+    buildExperienceTrendReport(recorder.read(), new Date('2026-06-11T00:00:00.000Z'))
+      .newSincePreviousReport,
+    [],
+  );
+});
+
+function existsStore(directory: string): boolean {
+  try {
+    readFileSync(join(directory, EXPERIENCE_STORE_NAME));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/scripts/build-host-runtimes.ts
+++ b/scripts/build-host-runtimes.ts
@@ -84,6 +84,7 @@ const RUNTIME_ENTRIES = [
   'startup-integrity-loader.js',
   'startup-integrity-register.js',
   'rn-session.js',
+  'experience-trends.js',
   'worktree-inheritance.js',
   'workflow-check.js',
 ];
@@ -119,6 +120,7 @@ for (const file of RUNTIME_ENTRIES) {
   }
 }
 chmodSync(join(coreRoot, 'dist', 'supervisor.js'), 0o755);
+chmodSync(join(coreRoot, 'dist', 'experience-trends.js'), 0o755);
 
 if (!existsSync(observeWebDistSource)) {
   console.error(`build-host-runtimes: missing observe web bundle at ${observeWebDistSource}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8324,6 +8324,7 @@ __metadata:
     zod-to-json-schema: "npm:3.25.2"
   bin:
     rn-dev-agent-core: ./dist/supervisor.js
+    rn-experience-trends: ./dist/experience-trends.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Intent

Build the smallest durable sanitized evidence loop for rn-dev-agent as a stabilization-supporting first slice, using the existing addToolObserver capture point without adding instrumentation call sites. Capture only meaningful FAIL and ERROR tool events plus an immediate PASS after a FAIL of the same tool as a linked recovery; never retain ordinary PASS traffic. Sanitize every persisted field fail-closed using the collect-feedback.sh contract for secrets/tokens/JWTs, emails, IPs, loopback endpoints, ports, absolute paths, bundle ids, and app-identifying data, with placeholders or dropped data on any redaction failure and no raw fallback. Persist honest structured local records containing candidate plugin/core version, sanitized OS/node environment, platform/device/runtime, phase, trigger, masking condition, symptom, recovery, cleanup, a real seed-experience family id or explicit unknown bucket, and bounded evidence ids/relative pointers; unsupported fields must be explicitly null with documented reasons and never guessed. Deduplicate with a stable signature over classification, tool, normalized symptom shape, and platform that remains stable across runs and contains no timestamps, ids, ports, or paths; retain count, first/last seen, and bounded evidence samples. Provide one read-only trend command reporting family frequency, items new since the previous report, and recurring patterns without mutating the store. Bound and deterministically prune the local sibling store under ~/.claude/rn-agent/ alongside the existing telemetry convention. Preserve observability as non-load-bearing: throwing, slow, corrupt, or unwritable recording must never change or materially delay tool behavior. Keep the plugin build/start happy path working. Add hermetic unit tests for sensitive redaction and fail-closed failure, classification against real seed ids, signature stability, recovery pairing, meaningful-only capture, non-load-bearing behavior, read-only trends, and deterministic pruning. Include required changesets/generated host runtimes.

Strict non-goals: no mutation of code, rules, tests, runbooks, seed YAML, or configuration based on evidence; no promotion pipeline; no network calls, upload, issue filing, external posting, or GitHub interaction from the loop; no ownership, authority, claim, lock, or session-authority changes; no learned-actions.ts changes; no ingestion of existing private ~/.claude/rn-agent/telemetry history; no journey rerun/resolution marking; no cross-machine aggregation. Defer promotion proposals, journey rerun/resolution marking, and cross-machine aggregation explicitly in the PR description. This PR observes and reports only and must stop after the smallest working end-to-end slice.

## What Changed

- Added `experience/evidence.ts`, which hooks the existing `addToolObserver` capture point (no new instrumentation call sites) to record only meaningful FAIL/ERROR tool events plus an immediately following PASS of the same tool as a linked recovery. Every persisted field is sanitized fail-closed (secrets/tokens/JWTs, emails, IPs, loopback endpoints, ports, absolute paths, bundle ids, and the project's app.json name/slug) with no raw fallback; records carry explicit `null` plus a documented reason for anything the event does not expose, are deduplicated by a timestamp/id/port/path-free signature over classification, tool, normalized symptom shape and platform, and are bounded (truncated symptoms, capped evidence samples, deterministic pruning) in a local sibling store under `~/.claude/rn-agent/experience/`. Recording is non-load-bearing — throwing, slow, corrupt, or unwritable recording never changes tool behavior (measured 0.0044 ms/call overhead on 200 instrumented PASS calls). Records are stamped with a redaction-rules version so stored data is re-sanitized when the rule set changes.
- Added `experience/trends.ts` and a read-only `experience-trends` command (exposed as the `rn-experience-trends` bin) reporting family frequency, items new since a `--since` timestamp, and recurring patterns without mutating the store, plus 17 hermetic unit tests covering redaction, fail-closed failure, classification against real seed-experience family ids, signature stability, recovery pairing, meaningful-only capture, non-load-bearing behavior, read-only trends, and pruning.
- Wired the recorder through `src/index.ts`, regenerated the claude-plugin and codex-plugin host runtimes via `scripts/build-host-runtimes.ts`, and added the changeset and README section documenting the store and the trend command.

Deferred explicitly and out of scope here: promotion proposals (nothing in this loop mutates code, rules, tests, runbooks, seed YAML, or configuration), journey rerun/resolution marking, and cross-machine aggregation. The loop makes no network calls and ingests no existing telemetry history — it observes and reports only.

## Risk Assessment

✅ Low: All previously accepted findings are resolved with hermetic tests and fresh, in-sync generated artifacts, the loop remains off the tool execution path, and the single remaining item is a maintainability guard on a local-only store rather than a reachable defect.

## Testing

Built the package, ran the focused hermetic suite (17/17 pass), then drove the loop end-to-end through the real instrumentTool/addToolObserver path with a secret-laden RedBox failure, two same-shape maestro failures, a thrown ERROR and 202 ordinary PASS calls: only the three meaningful events persisted, every sensitive category (GitHub token, JWT, email, private IP, loopback URL, port, absolute path, bundle id) came out as a placeholder, the two maestro failures deduped into a single signature with count 2, and the FAIL→PASS pair was recorded as a linked recovery. The shipped rn-experience-trends CLI (from both the package dist and the generated claude-plugin host runtime) printed family frequency, new-since and recurring patterns while leaving the store byte-identical, and 200 instrumented calls averaged 0.0044 ms with the recorder installed, confirming observability stays non-load-bearing. This change has no rendered UI surface — it is a background recorder plus a terminal command — so the reviewer-visible evidence is the CLI transcript and the sanitized persisted records rather than a screenshot. Everything passed and the worktree is clean.

<details>
<summary>Evidence: Sanitized persisted evidence records (patterns.jsonl, pretty-printed)</summary>

<code>{&#10;&#34;signature&#34;: &#34;22e56f4da6888b7ec64a2bb6ad4c5e22ffd582122cdb50d6ac7f1267625bd8c0&#34;,&#10;&#34;candidate&#34;: { &#34;pluginVersion&#34;: &#34;0.75.3&#34;, &#34;coreVersion&#34;: &#34;0.70.3&#34; },&#10;&#34;environment&#34;: { &#34;os&#34;: &#34;darwin 25.5.0&#34;, &#34;node&#34;: &#34;v24.14.0&#34; },&#10;&#34;platform&#34;: &#34;ios&#34;, &#34;device&#34;: &#34;iPhone 17 Pro&#34;, &#34;runtime&#34;: null, &#34;phase&#34;: &#34;tool&#34;,&#10;&#34;trigger&#34;: &#34;FAIL reported by cdp_connect&#34;,&#10;&#34;symptom&#34;: &#34;RedBox visible: TypeError: undefined is not an object at [LOOPBACK_ENDPOINT_REDACTED] (source [PATH_REDACTED]) session token=[REDACTED_SECRET] jwt [REDACTED_JWT] reporter [EMAIL_REDACTED] device [IP_REDACTED]:[PORT_REDACTED] app [BUNDLE_REDACTED]&#34;,&#10;&#34;recovery&#34;: &#34;PASS immediately followed FAIL for cdp_connect&#34;,&#10;&#34;classification&#34;: &#34;FF_REDBOX&#34;, &#34;count&#34;: 1, &#34;recoveryCount&#34;: 1,&#10;&#34;unknownReasons&#34;: { &#34;runtime&#34;: &#34;tool event did not expose a runtime&#34;, &#34;maskingCondition&#34;: &#34;not derivable from a single tool event&#34;, &#34;cleanup&#34;: &#34;tool events do not report cleanup actions&#34; },&#10;&#34;redactionVersion&#34;: 1&#10;}&#10;... (maestro_run record: classification FF_MAESTRO_GRPC_ANDROID, count 2 from two runs differing only in uuid and port; cdp_evaluate record: classification FF_STALE_CDP, status ERROR)</code>

```text
records: 3
{
  "signature": "22e56f4da6888b7ec64a2bb6ad4c5e22ffd582122cdb50d6ac7f1267625bd8c0",
  "candidate": {
    "pluginVersion": "0.75.3",
    "coreVersion": "0.70.3"
  },
  "environment": {
    "os": "darwin 25.5.0",
    "node": "v24.14.0"
  },
  "platform": "ios",
  "device": "iPhone 17 Pro",
  "runtime": null,
  "phase": "tool",
  "trigger": "FAIL reported by cdp_connect",
  "maskingCondition": null,
  "symptom": "RedBox visible: TypeError: undefined is not an object at [LOOPBACK_ENDPOINT_REDACTED] (source [PATH_REDACTED]) session token=[REDACTED_SECRET] jwt [REDACTED_JWT] reporter [EMAIL_REDACTED] device [IP_REDACTED]:[PORT_REDACTED] app [BUNDLE_REDACTED]",
  "recovery": "PASS immediately followed FAIL for cdp_connect",
  "cleanup": null,
  "classification": "FF_REDBOX",
  "evidencePointers": [
    "event:3b24ae86-7225-4db4-9ba1-eb4db9879c3b",
    "event:dc2df4f6-a982-4e88-b13e-1c8a2ea2ae8e"
  ],
  "tool": "cdp_connect",
  "status": "FAIL",
  "normalizedSymptomShape": "redbox visible: typeerror: undefined is not an object at [loopback_endpoint_redacted] (source [path_redacted]) session token=[REDACTED_SECRET] jwt [redacted_jwt] reporter [email_redacted] device [ip_redacted]:[port_redacted] app [bundle_redacted]",
  "count": 1,
  "recoveryCount": 1,
  "firstSeen": "2026-08-09T15:00:07.495Z",
  "lastSeen": "2026-08-09T15:00:07.495Z",
  "lastRecoveredAt": "2026-08-09T15:00:07.498Z",
  "unknownReasons": {
    "runtime": "tool event did not expose a runtime",
    "maskingCondition": "not derivable from a single tool event",
    "cleanup": "tool events do not report cleanup actions"
  },
  "redactionVersion": 1
}
{
  "signature": "394c9c7e72d947aa121b98a8c13b7c56eecdf3333db8d9646092161506db825f",
  "candidate": {
    "pluginVersion": "0.75.3",
    "coreVersion": "0.70.3"
  },
  "environment": {
    "os": "darwin 25.5.0",
    "node": "v24.14.0"
  },
  "platform": "ios",
  "device": null,
  "runtime": null,
  "phase": "tool",
  "trigger": "ERROR reported by cdp_evaluate",
  "maskingCondition": null,
  "symptom": "CDP websocket close 1006 for target not found at ws://[LOOPBACK_ENDPOINT_REDACTED]",
  "recovery": null,
  "cleanup": null,
  "classification": "FF_STALE_CDP",
  "evidencePointers": [
    "event:c070e55f-64d3-4415-8145-d97b8a6d32a9"
  ],
  "tool": "cdp_evaluate",
  "status": "ERROR",
  "normalizedSymptomShape": "cdp websocket close # for target not found at ws://[loopback_endpoint_redacted]",
  "count": 1,
  "recoveryCount": 0,
  "firstSeen": "2026-08-09T15:00:07.507Z",
  "lastSeen": "2026-08-09T15:00:07.507Z",
  "lastRecoveredAt": null,
  "unknownReasons": {
    "device": "tool event did not expose a device name or identifier",
    "runtime": "tool event did not expose a runtime",
    "maskingCondition": "not derivable from a single tool event",
    "recovery": "no immediate successful retry has been observed",
    "cleanup": "tool events do not report cleanup actions"
  },
  "redactionVersion": 1
}
{
  "signature": "c89b52747b490b0b47232369c088bd66fa399e093d85defffc6cab88a1c52049",
  "candidate": {
    "pluginVersion": "0.75.3",
    "coreVersion": "0.70.3"
  },
  "environment": {
    "os": "darwin 25.5.0",
    "node": "v24.14.0"
  },
  "platform": "android",
  "device": "Pixel_9_API_36",
  "runtime": null,
  "phase": "tool",
  "trigger": "FAIL reported by maestro_run",
  "maskingCondition": null,
  "symptom": "UNAVAILABLE: io exception on AndroidDriver grpc channel run-99887766-aaaa-bbbb-cccc-ddddeeeeffff at [IP_REDACTED]:[PORT_REDACTED]",
  "recovery": null,
  "cleanup": null,
  "classification": "FF_MAESTRO_GRPC_ANDROID",
  "evidencePointers": [
    "event:61389b06-3ad0-4c98-87b9-0ebe2fdd2efe",
    "event:2c1f769e-b0bb-4515-821d-bbd9ee8387d4"
  ],
  "tool": "maestro_run",
  "status": "FAIL",
  "normalizedSymptomShape": "unavailable: io exception on androiddriver grpc channel run-<id> at [ip_redacted]:[port_redacted]",
  "count": 2,
  "recoveryCount": 0,
  "firstSeen": "2026-08-09T15:00:07.498Z",
  "lastSeen": "2026-08-09T15:00:07.506Z",
  "lastRecoveredAt": null,
  "unknownReasons": {
    "runtime": "tool event did not expose a runtime",
    "maskingCondition": "not derivable from a single tool event",
    "recovery": "no immediate successful retry has been observed",
    "cleanup": "tool events do not report cleanup actions"
  },
  "redactionVersion": 1
}
```
</details>
<details>
<summary>Evidence: rn-experience-trends CLI transcript (read-only, store checksum unchanged)</summary>

<code>$ rn-experience-trends&#10;Experience trends (new since 2026-08-08T15:00:22.654Z)&#10;Report generated at 2026-08-09T15:00:22.654Z; pass this value to --since next time.&#10;&#10;Families by frequency&#10;FF_MAESTRO_GRPC_ANDROID: 2 occurrence(s), 1 pattern(s)&#10;FF_REDBOX: 1 occurrence(s), 1 pattern(s)&#10;FF_STALE_CDP: 1 occurrence(s), 1 pattern(s)&#10;&#10;New since previous report&#10;FF_MAESTRO_GRPC_ANDROID maestro_run: 2 (c89b52747b49)&#10;FF_REDBOX cdp_connect: 1 (22e56f4da688)&#10;FF_STALE_CDP cdp_evaluate: 1 (394c9c7e72d9)&#10;&#10;Recurring&#10;FF_MAESTRO_GRPC_ANDROID maestro_run: 2 (c89b52747b49)&#10;&#10;$ rn-experience-trends --since 2030-01-01T00:00:00Z&#10;...&#10;New since previous report&#10;none&#10;&#10;Recurring&#10;FF_MAESTRO_GRPC_ANDROID maestro_run: 2 (c89b52747b49)&#10;&#10;store unchanged by trend command: f6ff87fe00f71604542e5d1232e6634c8a8e29b9 store/patterns.jsonl</code>

```text
$ rn-experience-trends
Experience trends (new since 2026-08-08T15:00:22.654Z)
Report generated at 2026-08-09T15:00:22.654Z; pass this value to --since next time.

Families by frequency
  FF_MAESTRO_GRPC_ANDROID: 2 occurrence(s), 1 pattern(s)
  FF_REDBOX: 1 occurrence(s), 1 pattern(s)
  FF_STALE_CDP: 1 occurrence(s), 1 pattern(s)

New since previous report
  FF_MAESTRO_GRPC_ANDROID maestro_run: 2 (c89b52747b49)
  FF_REDBOX cdp_connect: 1 (22e56f4da688)
  FF_STALE_CDP cdp_evaluate: 1 (394c9c7e72d9)

Recurring
  FF_MAESTRO_GRPC_ANDROID maestro_run: 2 (c89b52747b49)

$ rn-experience-trends --since 2030-01-01T00:00:00Z
Experience trends (new since 2030-01-01T00:00:00.000Z)
Report generated at 2026-08-09T15:00:22.708Z; pass this value to --since next time.

Families by frequency
  FF_MAESTRO_GRPC_ANDROID: 2 occurrence(s), 1 pattern(s)
  FF_REDBOX: 1 occurrence(s), 1 pattern(s)
  FF_STALE_CDP: 1 occurrence(s), 1 pattern(s)

New since previous report
  none

Recurring
  FF_MAESTRO_GRPC_ANDROID maestro_run: 2 (c89b52747b49)
store unchanged by trend command: f6ff87fe00f71604542e5d1232e6634c8a8e29b9  store/patterns.jsonl
```
</details>
<details>
<summary>Evidence: End-to-end driver script (real addToolObserver capture point)</summary>

```text
import { addToolObserver, instrumentTool } from '/Users/antonlykhoyda/.no-mistakes/worktrees/355948388e7d/01KZKF4S4RXMAEC59ZXHZK44JW/packages/rn-dev-agent-core/dist/observability/instrumentation.js';
import { ExperienceRecorder, discoverPluginVersion } from '/Users/antonlykhoyda/.no-mistakes/worktrees/355948388e7d/01KZKF4S4RXMAEC59ZXHZK44JW/packages/rn-dev-agent-core/dist/experience/evidence.js';

const recorder = new ExperienceRecorder({
  coreVersion: '0.70.3',
  pluginVersion: discoverPluginVersion(),
});
addToolObserver((o) => recorder.observe(o));

const failResult = (text) => ({ isError: true, content: [{ type: 'text', text }] });

const redbox = failResult(JSON.stringify({
  ok: false,
  error:
    "RedBox visible: TypeError: undefined is not an object at http://localhost:8081/index.bundle?platform=ios " +
    "(source /Users/antonlykhoyda/dev/acme-wallet/src/screens/Home.tsx) " +
    "session token=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 " +
    "jwt eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk " +
    "reporter anton.lykhoyda@example.com device 192.168.1.42:8081 app com.acme.walletapp",
}));

const cdpConnect = instrumentTool('cdp_connect', async (p) => {
  if (p.attempt === 1) return redbox;
  return { ok: true, content: [{ type: 'text', text: '{"ok":true}' }] };
});

const maestroRun = instrumentTool('maestro_run', async (p) =>
  failResult(JSON.stringify({
    ok: false,
    error: `UNAVAILABLE: io exception on AndroidDriver grpc channel run-${p.runId} at 127.0.0.1:${p.port}`,
  })),
);

const devicePress = instrumentTool('device_press', async () => ({
  ok: true,
  content: [{ type: 'text', text: '{"ok":true}' }],
}));

const cdpEvaluate = instrumentTool('cdp_evaluate', async () => {
  throw new Error('CDP websocket close 1006 for target not found at ws://localhost:9222/devtools');
});

await cdpConnect({ attempt: 1, platform: 'ios', deviceName: 'iPhone 17 Pro' });
await cdpConnect({ attempt: 2, platform: 'ios', deviceName: 'iPhone 17 Pro' });
await maestroRun({ platform: 'android', runId: 'a1b2c3d4-1111-2222-3333-444455556666', port: 7001, deviceName: 'Pixel_9_API_36' });
await maestroRun({ platform: 'android', runId: '99887766-aaaa-bbbb-cccc-ddddeeeeffff', port: 7442, deviceName: 'Pixel_9_API_36' });
await devicePress({ platform: 'ios' });
await cdpEvaluate({ platform: 'ios' }).catch(() => {});

// latency proof: 200 instrumented PASS calls with the recorder installed
const t0 = performance.now();
for (let i = 0; i < 200; i += 1) await devicePress({ platform: 'ios' });
console.log(`instrumented tool latency with recorder installed: ${((performance.now() - t0) / 200).toFixed(4)} ms/call`);

await new Promise((r) => setTimeout(r, 300));
```
</details>
<details>
<summary>Evidence: Run summary incl. non-load-bearing latency measurement</summary>

<code>events emitted: 202 PASS (cdp_connect recovery + 201 device_press), 3 FAIL (1 redbox, 2 maestro grpc), 1 thrown ERROR&#10;records retained: 3 (no ordinary PASS traffic persisted)&#10;instrumented tool latency with recorder installed: 0.0044 ms/call</code>

```text
== end-to-end run through the real addToolObserver capture point ==
events emitted: 202 PASS (cdp_connect recovery + 201 device_press), 3 FAIL (1 redbox, 2 maestro grpc), 1 thrown ERROR
records retained: 3 (no ordinary PASS traffic persisted)
instrumented tool latency with recorder installed: 0.0044 ms/call

$ rn-experience-trends
Experience trends (new since 2026-08-08T15:00:22.654Z)
Report generated at 2026-08-09T15:00:22.654Z; pass this value to --since next time.

Families by frequency
  FF_MAESTRO_GRPC_ANDROID: 2 occurrence(s), 1 pattern(s)
  FF_REDBOX: 1 occurrence(s), 1 pattern(s)
  FF_STALE_CDP: 1 occurrence(s), 1 pattern(s)

New since previous report
  FF_MAESTRO_GRPC_ANDROID maestro_run: 2 (c89b52747b49)
  FF_REDBOX cdp_connect: 1 (22e56f4da688)
  FF_STALE_CDP cdp_evaluate: 1 (394c9c7e72d9)

Recurring
  FF_MAESTRO_GRPC_ANDROID maestro_run: 2 (c89b52747b49)

$ rn-experience-trends --since 2030-01-01T00:00:00Z
Experience trends (new since 2030-01-01T00:00:00.000Z)
Report generated at 2026-08-09T15:00:22.708Z; pass this value to --since next time.

Families by frequency
  FF_MAESTRO_GRPC_ANDROID: 2 occurrence(s), 1 pattern(s)
  FF_REDBOX: 1 occurrence(s), 1 pattern(s)
  FF_STALE_CDP: 1 occurrence(s), 1 pattern(s)

New since previous report
  none

Recurring
  FF_MAESTRO_GRPC_ANDROID maestro_run: 2 (c89b52747b49)
store unchanged by trend command: f6ff87fe00f71604542e5d1232e6634c8a8e29b9  store/patterns.jsonl
```
</details>
<details>
<summary>Evidence: Resulting local evidence store</summary>

```text
{"signature":"22e56f4da6888b7ec64a2bb6ad4c5e22ffd582122cdb50d6ac7f1267625bd8c0","candidate":{"pluginVersion":"0.75.3","coreVersion":"0.70.3"},"environment":{"os":"darwin 25.5.0","node":"v24.14.0"},"platform":"ios","device":"iPhone 17 Pro","runtime":null,"phase":"tool","trigger":"FAIL reported by cdp_connect","maskingCondition":null,"symptom":"RedBox visible: TypeError: undefined is not an object at [LOOPBACK_ENDPOINT_REDACTED] (source [PATH_REDACTED]) session token=[REDACTED_SECRET] jwt [REDACTED_JWT] reporter [EMAIL_REDACTED] device [IP_REDACTED]:[PORT_REDACTED] app [BUNDLE_REDACTED]","recovery":"PASS immediately followed FAIL for cdp_connect","cleanup":null,"classification":"FF_REDBOX","evidencePointers":["event:3b24ae86-7225-4db4-9ba1-eb4db9879c3b","event:dc2df4f6-a982-4e88-b13e-1c8a2ea2ae8e"],"tool":"cdp_connect","status":"FAIL","normalizedSymptomShape":"redbox visible: typeerror: undefined is not an object at [loopback_endpoint_redacted] (source [path_redacted]) session token=[REDACTED_SECRET] jwt [redacted_jwt] reporter [email_redacted] device [ip_redacted]:[port_redacted] app [bundle_redacted]","count":1,"recoveryCount":1,"firstSeen":"2026-08-09T15:00:07.495Z","lastSeen":"2026-08-09T15:00:07.495Z","lastRecoveredAt":"2026-08-09T15:00:07.498Z","unknownReasons":{"runtime":"tool event did not expose a runtime","maskingCondition":"not derivable from a single tool event","cleanup":"tool events do not report cleanup actions"},"redactionVersion":1}
{"signature":"394c9c7e72d947aa121b98a8c13b7c56eecdf3333db8d9646092161506db825f","candidate":{"pluginVersion":"0.75.3","coreVersion":"0.70.3"},"environment":{"os":"darwin 25.5.0","node":"v24.14.0"},"platform":"ios","device":null,"runtime":null,"phase":"tool","trigger":"ERROR reported by cdp_evaluate","maskingCondition":null,"symptom":"CDP websocket close 1006 for target not found at ws://[LOOPBACK_ENDPOINT_REDACTED]","recovery":null,"cleanup":null,"classification":"FF_STALE_CDP","evidencePointers":["event:c070e55f-64d3-4415-8145-d97b8a6d32a9"],"tool":"cdp_evaluate","status":"ERROR","normalizedSymptomShape":"cdp websocket close # for target not found at ws://[loopback_endpoint_redacted]","count":1,"recoveryCount":0,"firstSeen":"2026-08-09T15:00:07.507Z","lastSeen":"2026-08-09T15:00:07.507Z","lastRecoveredAt":null,"unknownReasons":{"device":"tool event did not expose a device name or identifier","runtime":"tool event did not expose a runtime","maskingCondition":"not derivable from a single tool event","recovery":"no immediate successful retry has been observed","cleanup":"tool events do not report cleanup actions"},"redactionVersion":1}
{"signature":"c89b52747b490b0b47232369c088bd66fa399e093d85defffc6cab88a1c52049","candidate":{"pluginVersion":"0.75.3","coreVersion":"0.70.3"},"environment":{"os":"darwin 25.5.0","node":"v24.14.0"},"platform":"android","device":"Pixel_9_API_36","runtime":null,"phase":"tool","trigger":"FAIL reported by maestro_run","maskingCondition":null,"symptom":"UNAVAILABLE: io exception on AndroidDriver grpc channel run-99887766-aaaa-bbbb-cccc-ddddeeeeffff at [IP_REDACTED]:[PORT_REDACTED]","recovery":null,"cleanup":null,"classification":"FF_MAESTRO_GRPC_ANDROID","evidencePointers":["event:61389b06-3ad0-4c98-87b9-0ebe2fdd2efe","event:2c1f769e-b0bb-4515-821d-bbd9ee8387d4"],"tool":"maestro_run","status":"FAIL","normalizedSymptomShape":"unavailable: io exception on androiddriver grpc channel run-<id> at [ip_redacted]:[port_redacted]","count":2,"recoveryCount":0,"firstSeen":"2026-08-09T15:00:07.498Z","lastSeen":"2026-08-09T15:00:07.506Z","lastRecoveredAt":null,"unknownReasons":{"runtime":"tool event did not expose a runtime","maskingCondition":"not derivable from a single tool event","recovery":"no immediate successful retry has been observed","cleanup":"tool events do not report cleanup actions"},"redactionVersion":1}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `packages/rn-dev-agent-core/src/experience/evidence.ts:90` - Intent requires sanitizing &#34;app-identifying data&#34; &#34;using the collect-feedback.sh contract&#34;. applyRedactionRules mirrors only the sed regex stage (collect-feedback.sh:24-35); it omits that script&#39;s second stage (collect-feedback.sh:43-48) which substitutes the project&#39;s app.json `name` and `slug` with [APP_NAME_REDACTED]/[APP_SLUG_REDACTED]. Bundle ids like com.example.app are caught by the BUNDLE rule, but a bare app display name is not: a FAIL from e.g. launchApp/device_press whose error text reads &#34;Failed to launch AcmeBanking&#34; persists the app identity verbatim into ~/.claude/rn-agent/experience/patterns.jsonl. Add the app-name/slug stage (fail-closed like the rest) or state explicitly why it is out of scope for this slice.
- ⚠️ `packages/rn-dev-agent-core/src/experience/evidence.ts:466` - extractSymptom returns the full `event.error` or `result.content[0].text` with no length cap, and both `symptom` and `normalizedSymptomShape` are persisted verbatim. A FAIL envelope from a payload-heavy tool (device_snapshot hierarchy, cdp_network_body, a base64-bearing result) can be tens/hundreds of KB. Because persistFailure re-reads the whole store and write() re-runs all 17 global regexes over every string of every record on every failure event, store size and per-event CPU both grow unbounded despite the 500-record cap — contradicting &#34;bounded ... local sibling store&#34; and risking a multi-second event-loop stall shared by all concurrent MCP tools. Truncate the symptom (e.g. first 2 KB) before sanitizing/normalizing, and skip re-sanitizing records that were already sanitized on write.
- ⚠️ `packages/rn-dev-agent-core/src/experience/evidence.ts:364` - readExperienceStore JSON.parses every line and throws on the first malformed one. persistFailure/persistRecovery call it inside recordNonLoadBearing&#39;s catch-all, so a single bad line (truncated write from SIGKILL, hand-edit, disk error) silently kills all future recording forever with no self-heal path, and the trends CLI degrades to an error. Tool behavior is unaffected as intended, but the loop is dead. Filter out unparsable lines instead of throwing (and drop them on the next write).
- ℹ️ `packages/rn-dev-agent-core/src/experience/evidence.ts:280` - On a dedupe hit persistFailure refreshes count/lastSeen/status/symptom/candidate/environment but not platform/device/runtime or unknownReasons. device and runtime are not part of the signature, so a record first captured from an event without a deviceName keeps `device: null` plus unknownReasons.device &#34;tool event did not expose a device name or identifier&#34; even after later matching events do expose one — the record&#39;s explicit-null honesty contract becomes inaccurate. Relatedly, status is overwritten so a FAIL and an ERROR that normalize to the same shape collapse into one record whose status reflects only the last occurrence.
- ℹ️ `packages/rn-dev-agent-core/src/experience/evidence.ts:354` - readExperienceStore&#39;s `allowMissing` parameter has no effect — both branches of the !existsSync check return []. Every call site passes it (`true` from the recorder, default from trends) implying a behavioral difference that does not exist. Remove the parameter and the redundant branch.
- ℹ️ `packages/rn-dev-agent-core/test/unit/experience-evidence.test.ts:176` - The test builds the complete set of seed-experience ids but then asserts membership for only FF_MAESTRO_GRPC_ANDROID out of the 25 ids in classifyExperience&#39;s rule table. All 25 currently do exist in seed-experience/*.yaml, but a future typo or renamed seed entry would make the recorder emit a non-existent family id without failing this test. Export the family-id list from evidence.ts and assert the whole table is a subset of the seed ids.
- ℹ️ `packages/rn-dev-agent-core/src/experience/evidence.ts:154` - previousFailure is a single global slot, so with concurrently executing tools an interleaved FAIL(A), FAIL(B), PASS(A) sequence drops A&#39;s recovery pairing; likewise two MCP server processes sharing ~/.claude do read-modify-write with last-writer-wins and can lose counts. Both only under-count an observability signal and never affect tool behavior, so this is acceptable for the smallest slice — noting it so the trend report&#39;s recovery numbers are read as a lower bound.

🔧 Fix: redact app identity and bound experience evidence records
5 issues (1 warning, 4 infos) still open:
- ⚠️ `packages/rn-dev-agent-core/src/experience/evidence.ts:413` - readExperienceStore adds every record parsed off disk to SANITIZED_RECORDS, and write() then skips sanitizeForEvidence for those records. Previously every write re-sanitized the whole store, which meant a rule-set change retroactively cleaned already-stored records. Concrete path: a store written before this round&#39;s app-name/slug stage existed keeps &#39;AcmeBanking&#39; in its symptom, is re-read, marked sanitized, and rewritten verbatim on the next failure — the same class of leak just fixed persists indefinitely, and the same will apply to any future rule addition. Impact today is limited because the feature is new so no legacy stores exist in the wild. Suggest stamping each record with a redaction-rules version and re-sanitizing on mismatch, which preserves the performance win now that symptoms are bounded.
- ℹ️ `packages/rn-dev-agent-core/src/experience/evidence.ts:127` - readAppIdentity assigns appIdentityCache only after JSON.parse succeeds, so a malformed app.json throws before caching. applyRedactionRules calls it per string, meaning every sanitizeString on a failure event re-runs existsSync + readFileSync + JSON.parse (roughly 20 syscalls per recorded event, repeated for every event) while still returning the same fail-closed placeholder. Cache the failure outcome (e.g. a sentinel that rethrows) so the manifest is read at most once per project root.
- ℹ️ `packages/rn-dev-agent-core/src/experience/evidence.ts:326` - adoptLateFact(existing, incoming, &#39;platform&#39;) can effectively never fire: experienceSignature hashes `input.platform ?? &#39;unknown&#39;`, so a signature match implies the two records already agree on platform (the only exception is an event whose platform literally sanitizes to the string &#39;unknown&#39;). device and runtime are genuinely adoptable because they are not in the signature; the platform call is dead and the accompanying test only exercises device/runtime. Drop the platform call or add a comment explaining the &#39;unknown&#39; collision case it actually covers.
- ℹ️ `packages/rn-dev-agent-core/src/experience/evidence.ts:305` - When redaction fails, the record is not dropped by an explicit guard — every string including lastSeen becomes [REDACTION_FAILED], and pruneExperienceRecords&#39; Number.isFinite(Date.parse(record.lastSeen)) filter is what discards it (this is what makes the &#39;malformed app.json&#39; test&#39;s assert.deepEqual(recorder.read(), []) pass). The behavior satisfies the intent&#39;s &#34;dropped data on any redaction failure&#34; today, but it is emergent: exempting ISO timestamps from sanitization, an obvious future optimization, would silently turn the drop into an all-placeholder record being persisted. An explicit check for REDACTION_FAILED in required fields before persisting would make the contract self-documenting.
- ℹ️ `packages/rn-dev-agent-core/src/experience/evidence.ts:535` - boundSymptom strips the trailing partial token with .replace(/\S+$/, &#39;&#39;), so a symptom whose first 2048 characters contain no whitespace (a single long base64 blob or an unbroken JSON string) reduces to exactly &#39;[TRUNCATED]&#39;. Every such failure for a given tool and platform then normalizes to the same shape and collapses into one signature with classification UNKNOWN. The discarded content was unusable anyway, so this is an acceptable tradeoff for the smallest slice — noting it so a future reader does not mistake the collapsed record for a genuine recurring pattern.

🔧 Fix: version-stamp redaction and cache app identity loads
1 info still open:
- ℹ️ `packages/rn-dev-agent-core/src/experience/evidence.ts:65` - REDACTION_RULES_VERSION is a hand-maintained constant guarded only by the comment &#34;Bump whenever a redaction rule changes&#34;. Nothing ties it to REDACTION_RULES, KEYED_SECRET, or the app-identity stage, so a future rule addition landed without a bump leaves every already-stored record stamped as current and rewritten verbatim — reintroducing exactly the stale-redaction leak this stamp was added to close, silently and with no failing test. Concrete precedent: this branch&#39;s own app-name/slug stage was added in a later commit than the rules array it sits next to. Derive the version from a hash of the rule sources (e.g. createHash over REDACTION_RULES.map(String) + KEYED_SECRET.source), or add a test asserting a checksum of the rule table equals a constant that must be updated alongside the version.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx tsc -p tsconfig.json` in packages/rn-dev-agent-core (build happy path)</code>
- <code>`node --test test/unit/experience-evidence.test.ts` — 17/17 pass</code>
- <code>End-to-end driver through the real capture point: `RN_DEV_AGENT_EXPERIENCE_DIR=... RN_PROJECT_ROOT=... node drive-experience-loop.mjs` using `instrumentTool` + `addToolObserver` + `new ExperienceRecorder(...)` exactly as src/index.ts wires it; emitted 202 PASS, 3 FAIL (RedBox with token/JWT/email/IP/path/bundle, two maestro gRPC failures differing only in uuid and port) and 1 thrown ERROR</code>
- <code>Inspected the persisted `patterns.jsonl` to confirm redaction placeholders, dedup count 2 on one signature, recovery linkage, real seed family ids (FF_REDBOX, FF_STALE_CDP, FF_MAESTRO_GRPC_ANDROID), and explicit null fields with documented unknownReasons</code>
- <code>`node dist/experience-trends.js` and `node dist/experience-trends.js --since 2030-01-01T00:00:00Z`, with a shasum of the store taken before and after to prove read-only</code>
- <code>`node packages/claude-plugin/rn-dev-agent-core/dist/experience-trends.js` against the same store (generated host runtime)</code>
- <code>`node --input-type=module --check` on the generated claude-plugin index.js and codex-plugin supervisor.js, plus grep confirming ExperienceRecorder wiring is bundled</code>
- `Latency measurement: 200 instrumented PASS calls with the recorder installed → 0.0044 ms/call`
- <code>`git status --porcelain` to confirm no transient build artifacts left in the worktree</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
