### PR TITLE
fix(core): keep shared-Metro reconnects bound to the pinned device (#625)

### DIFF
--- a/.changeset/gh-625-reconnect-device-affinity.md
+++ b/.changeset/gh-625-reconnect-device-affinity.md
@@ -1,0 +1,6 @@
+---
+'rn-dev-agent-plugin': patch
+'rn-dev-agent-core': patch
+---
+
+Reconnects now persist a pinned target's device and bundle identity so shared-Metro multi-simulator sessions re-bind the exact pinned device and fail closed with candidates listed instead of silently attaching to a sibling simulator.

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -19237,6 +19237,12 @@ function describeTarget(target) {
   const confidence = target.platformInference ?? "probed";
   return `${target.id} title="${target.title || "?"}" appId="${target.appId ?? "?"}" device="${target.deviceName ?? "?"}" description="${target.description ?? "?"}" platform=${target.platform ?? "?"} confidence=${confidence}`;
 }
+function metroDeviceConnectionId(id) {
+  if (!id)
+    return "";
+  const cut = id.lastIndexOf("-");
+  return cut > 0 ? id.slice(0, cut) : id;
+}
 function classifyAndroidDeviceKind(deviceName) {
   if (!deviceName)
     return "unknown";
@@ -19251,15 +19257,36 @@ function selectTarget(validTargets, filtersOrPlatform) {
   let filteredTargets = validTargets;
   const warnings = [];
   let warnNoPlatformFilter = false;
+  if (filters.deviceName) {
+    const pinnedDevice = filters.deviceName.trim();
+    const deviceMatched = filteredTargets.filter((target) => target.deviceName?.trim() === pinnedDevice);
+    if (deviceMatched.length === 0) {
+      return {
+        targets: [],
+        warning: `Pinned device "${pinnedDevice}" has no live CDP target on this Metro; refusing to silently bind a different device. Candidates: ${validTargets.map(describeTarget).join("; ")}. Relaunch the app on the pinned device, or re-pin deliberately via cdp_targets + cdp_connect targetId.`
+      };
+    }
+    const devicePrefixes = new Set(deviceMatched.map((t) => metroDeviceConnectionId(t.id)));
+    if (devicePrefixes.size > 1) {
+      return {
+        targets: [],
+        warning: `Pinned device name "${pinnedDevice}" matches ${devicePrefixes.size} live Metro device connections; refusing an ambiguous bind. Candidates: ${deviceMatched.map(describeTarget).join("; ")}. Re-pin deliberately via cdp_targets + cdp_connect targetId.`
+      };
+    }
+    filteredTargets = deviceMatched;
+  }
   if (filters.targetId) {
-    const idMatched = validTargets.filter((t) => t.id === filters.targetId);
-    if (idMatched.length === 0) {
+    const idMatched = filteredTargets.filter((t) => t.id === filters.targetId);
+    if (idMatched.length > 0) {
+      filteredTargets = idMatched;
+    } else if (!filters.deviceName) {
       return {
         targets: [],
         warning: `targetId "${filters.targetId}" not found. Available ids: ${validTargets.map((t) => t.id).join(", ")}`
       };
+    } else {
+      warnings.push(`Pinned targetId "${filters.targetId}" is stale (Metro page ids change on reload); re-resolving on pinned device "${filters.deviceName.trim()}".`);
     }
-    filteredTargets = idMatched;
   }
   if (filters.platform) {
     const platform = filters.platform.toLowerCase();
@@ -19273,7 +19300,7 @@ function selectTarget(validTargets, filtersOrPlatform) {
       };
     }
     filteredTargets = platformMatched;
-  } else if (validTargets.length > 0 && !filters.targetId && !filters.bundleId && !filters.deviceKind && !filters.preferredBundleId) {
+  } else if (validTargets.length > 0 && !filters.targetId && !filters.bundleId && !filters.deviceKind && !filters.preferredBundleId && !filters.deviceName) {
     warnNoPlatformFilter = true;
   }
   if (filters.deviceKind) {
@@ -19394,6 +19421,8 @@ async function discover(currentPort, platformFilterOrFilters) {
     hints.push(`bundleId=${filters.bundleId}`);
   if (filters.preferredBundleId)
     hints.push(`preferredBundleId=${filters.preferredBundleId}`);
+  if (filters.deviceName)
+    hints.push(`deviceName=${filters.deviceName}`);
   logger.debug("CDP", `Discovering Metro on ports: ${ports.join(", ")}${hints.length ? ` (${hints.join(", ")})` : ""}`);
   const runningPorts = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
   if (runningPorts.length === 0) {
@@ -55398,7 +55427,8 @@ async function discoverAndConnect(ctx, portHint, filters, discoverFn = discover,
     deviceKind: mergedFilters.deviceKind,
     targetId: mergedFilters.targetId,
     bundleId: mergedFilters.bundleId,
-    preferredBundleId: mergedFilters.preferredBundleId
+    preferredBundleId: mergedFilters.preferredBundleId,
+    deviceName: mergedFilters.deviceName
   };
   let result;
   try {
@@ -55457,6 +55487,9 @@ async function discoverAndConnect(ctx, portHint, filters, discoverFn = discover,
   const stickyFilters = stickyPlatformFilters(ctx.getConnectFilters(), connectedTarget.platform);
   if (stickyFilters)
     ctx.setConnectFilters(stickyFilters);
+  const pinnedDeviceFilters = stickyPinnedDeviceFilters(ctx.getConnectFilters(), connectedTarget);
+  if (pinnedDeviceFilters)
+    ctx.setConnectFilters(pinnedDeviceFilters);
   const msg3 = `Connected to ${connectedTarget.title} on port ${metroPort}`;
   return selectionWarning ? `${msg3}. WARNING: ${selectionWarning}` : msg3;
 }
@@ -55466,6 +55499,23 @@ function stickyPlatformFilters(current, resolvedPlatform) {
   if (!resolvedPlatform)
     return null;
   return { ...current, platform: resolvedPlatform };
+}
+function stickyPinnedDeviceFilters(current, connectedTarget) {
+  if (!current.targetId)
+    return null;
+  const deviceName = connectedTarget.deviceName?.trim();
+  if (!deviceName)
+    return null;
+  const bundleId = current.bundleId ?? targetBundleIdentity(connectedTarget) ?? void 0;
+  if (current.targetId === connectedTarget.id && current.deviceName === deviceName && current.bundleId === bundleId) {
+    return null;
+  }
+  return {
+    ...current,
+    targetId: connectedTarget.id,
+    deviceName,
+    ...bundleId ? { bundleId } : {}
+  };
 }
 function formatConnectFailureMessage(retries, attempts3, bundleHint, lastErrorMessage) {
   const allHandshakesSucceeded = attempts3.length > 0 && attempts3.every((a) => a.handshakeOk);
@@ -56079,6 +56129,10 @@ var CDPClient = class _CDPClient {
   _connectFilters = {};
   _reconnectDiscover;
   _exactDiscoveryPort;
+  /** GH #625: pinned device affinity, if an explicit targetId pin captured one. */
+  get pinnedDeviceName() {
+    return this._connectFilters.deviceName;
+  }
   createAuthoritativeDiscover(awaitWithinBoundary) {
     return async (_port, filtersOrPlatform) => {
       const policy = this._authoritativeSessionPolicy;
@@ -57011,6 +57065,7 @@ function captureClientState(client2) {
     port: client2.metroPort,
     platform: target?.platform,
     bundleId: target?.description ?? void 0,
+    deviceName: client2.pinnedDeviceName,
     proxyWasActive: client2.proxyDesired
   };
 }
@@ -57038,6 +57093,9 @@ async function forceReconnect(oldClient, setClient2, createClient2, captured, au
     const filters = {
       platform: authorityTarget?.platform ?? captured.platform,
       bundleId: authorityTarget?.appId ?? captured.bundleId,
+      // GH #625: without an exact authority target, the pinned device affinity
+      // is the only thing keeping recovery off a sibling simulator.
+      ...authorityTarget ? {} : { deviceName: captured.deviceName },
       ...authorityTarget && resolveExactTargetId ? { targetId: await resolveExactTargetId(newClient, captured, authorityTarget) } : {}
     };
     await raceWithTimeout(authorityTarget ? newClient.connectExact(captured.port, filters) : newClient.autoConnect(captured.port, filters), FORCE_FALLBACK_TIMEOUT_MS, "force_reconnect");
@@ -87027,9 +87085,11 @@ var e2eReload = async () => {
   const session2 = getActiveSession();
   if (!session2?.deviceId || !session2.appId)
     return false;
+  const sessionPlatform = session2.platform === "ios" || session2.platform === "android" ? session2.platform : void 0;
   try {
     const r = await createReloadHandler(getClient, setClient, createClient)({
       full: true,
+      ...sessionPlatform ? { platform: sessionPlatform } : {},
       deviceId: session2.deviceId,
       appId: session2.appId
     });

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -19243,6 +19243,13 @@ function metroDeviceConnectionId(id) {
   const cut = id.lastIndexOf("-");
   return cut > 0 ? id.slice(0, cut) : id;
 }
+function metroPageNumber(id) {
+  if (!id)
+    return 0;
+  const cut = id.lastIndexOf("-");
+  const page = cut > 0 ? Number.parseInt(id.slice(cut + 1), 10) : NaN;
+  return Number.isNaN(page) ? 0 : page;
+}
 function classifyAndroidDeviceKind(deviceName) {
   if (!deviceName)
     return "unknown";
@@ -19268,12 +19275,18 @@ function selectTarget(validTargets, filtersOrPlatform) {
     }
     const devicePrefixes = new Set(deviceMatched.map((t) => metroDeviceConnectionId(t.id)));
     if (devicePrefixes.size > 1) {
-      return {
-        targets: [],
-        warning: `Pinned device name "${pinnedDevice}" matches ${devicePrefixes.size} live Metro device connections; refusing an ambiguous bind. Candidates: ${deviceMatched.map(describeTarget).join("; ")}. Re-pin deliberately via cdp_targets + cdp_connect targetId.`
-      };
+      const bundleScoped = filters.bundleId ? deviceMatched.filter((target) => targetMatchesBundleId(target, filters.bundleId)) : [];
+      const bundleConnections = new Set(bundleScoped.map((t) => metroDeviceConnectionId(t.id)));
+      if (bundleConnections.size !== 1) {
+        return {
+          targets: [],
+          warning: `Pinned device name "${pinnedDevice}" matches ${devicePrefixes.size} live Metro device connections and ` + (filters.bundleId ? `pinned bundleId "${filters.bundleId}" narrows them to ${bundleConnections.size}` : `no proven bundle identity is pinned to narrow them`) + `; refusing an ambiguous bind. Candidates: ${deviceMatched.map(describeTarget).join("; ")}. Re-pin deliberately via cdp_targets + cdp_connect targetId.`
+        };
+      }
+      filteredTargets = bundleScoped;
+    } else {
+      filteredTargets = deviceMatched;
     }
-    filteredTargets = deviceMatched;
   }
   if (filters.targetId) {
     const idMatched = filteredTargets.filter((t) => t.id === filters.targetId);
@@ -19342,8 +19355,8 @@ function selectTarget(validTargets, filtersOrPlatform) {
     }
   }
   const sorted = [...filteredTargets].sort((a, b) => {
-    const aPage = parseInt(a.id?.split("-")[1] ?? "0", 10);
-    const bPage = parseInt(b.id?.split("-")[1] ?? "0", 10);
+    const aPage = metroPageNumber(a.id);
+    const bPage = metroPageNumber(b.id);
     if (aPage !== bPage)
       return bPage - aPage;
     if (prefLower) {
@@ -55698,7 +55711,8 @@ async function discoverAuthoritativeTarget(policy, requestedFilters, discoverFn 
     ...requestedFilters,
     ...policy.filters,
     targetId: void 0,
-    preferredBundleId: void 0
+    preferredBundleId: void 0,
+    deviceName: void 0
   });
   if (result.errorCode || result.targets.length === 0)
     return result;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -19284,6 +19284,11 @@ function selectTarget(validTargets, filtersOrPlatform) {
         targets: [],
         warning: `targetId "${filters.targetId}" not found. Available ids: ${validTargets.map((t) => t.id).join(", ")}`
       };
+    } else if (!filters.bundleId) {
+      return {
+        targets: [],
+        warning: `Pinned targetId "${filters.targetId}" is stale and no proven bundle identity is pinned; refusing to re-resolve on device "${filters.deviceName.trim()}" without app identity. Candidates: ${filteredTargets.map(describeTarget).join("; ")}. Re-pin deliberately via cdp_targets + cdp_connect targetId.`
+      };
     } else {
       warnings.push(`Pinned targetId "${filters.targetId}" is stale (Metro page ids change on reload); re-resolving on pinned device "${filters.deviceName.trim()}".`);
     }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -30799,6 +30799,13 @@ function metroDeviceConnectionId(id) {
   const cut = id.lastIndexOf("-");
   return cut > 0 ? id.slice(0, cut) : id;
 }
+function metroPageNumber(id) {
+  if (!id)
+    return 0;
+  const cut = id.lastIndexOf("-");
+  const page = cut > 0 ? Number.parseInt(id.slice(cut + 1), 10) : NaN;
+  return Number.isNaN(page) ? 0 : page;
+}
 function classifyAndroidDeviceKind(deviceName) {
   if (!deviceName)
     return "unknown";
@@ -30824,12 +30831,18 @@ function selectTarget(validTargets, filtersOrPlatform) {
     }
     const devicePrefixes = new Set(deviceMatched.map((t) => metroDeviceConnectionId(t.id)));
     if (devicePrefixes.size > 1) {
-      return {
-        targets: [],
-        warning: `Pinned device name "${pinnedDevice}" matches ${devicePrefixes.size} live Metro device connections; refusing an ambiguous bind. Candidates: ${deviceMatched.map(describeTarget).join("; ")}. Re-pin deliberately via cdp_targets + cdp_connect targetId.`
-      };
+      const bundleScoped = filters.bundleId ? deviceMatched.filter((target) => targetMatchesBundleId(target, filters.bundleId)) : [];
+      const bundleConnections = new Set(bundleScoped.map((t) => metroDeviceConnectionId(t.id)));
+      if (bundleConnections.size !== 1) {
+        return {
+          targets: [],
+          warning: `Pinned device name "${pinnedDevice}" matches ${devicePrefixes.size} live Metro device connections and ` + (filters.bundleId ? `pinned bundleId "${filters.bundleId}" narrows them to ${bundleConnections.size}` : `no proven bundle identity is pinned to narrow them`) + `; refusing an ambiguous bind. Candidates: ${deviceMatched.map(describeTarget).join("; ")}. Re-pin deliberately via cdp_targets + cdp_connect targetId.`
+        };
+      }
+      filteredTargets = bundleScoped;
+    } else {
+      filteredTargets = deviceMatched;
     }
-    filteredTargets = deviceMatched;
   }
   if (filters.targetId) {
     const idMatched = filteredTargets.filter((t) => t.id === filters.targetId);
@@ -30898,8 +30911,8 @@ function selectTarget(validTargets, filtersOrPlatform) {
     }
   }
   const sorted = [...filteredTargets].sort((a, b) => {
-    const aPage = parseInt(a.id?.split("-")[1] ?? "0", 10);
-    const bPage = parseInt(b.id?.split("-")[1] ?? "0", 10);
+    const aPage = metroPageNumber(a.id);
+    const bPage = metroPageNumber(b.id);
     if (aPage !== bPage)
       return bPage - aPage;
     if (prefLower) {
@@ -66505,7 +66518,8 @@ async function discoverAuthoritativeTarget(policy, requestedFilters, discoverFn 
     ...requestedFilters,
     ...policy.filters,
     targetId: void 0,
-    preferredBundleId: void 0
+    preferredBundleId: void 0,
+    deviceName: void 0
   });
   if (result.errorCode || result.targets.length === 0)
     return result;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -30840,6 +30840,11 @@ function selectTarget(validTargets, filtersOrPlatform) {
         targets: [],
         warning: `targetId "${filters.targetId}" not found. Available ids: ${validTargets.map((t) => t.id).join(", ")}`
       };
+    } else if (!filters.bundleId) {
+      return {
+        targets: [],
+        warning: `Pinned targetId "${filters.targetId}" is stale and no proven bundle identity is pinned; refusing to re-resolve on device "${filters.deviceName.trim()}" without app identity. Candidates: ${filteredTargets.map(describeTarget).join("; ")}. Re-pin deliberately via cdp_targets + cdp_connect targetId.`
+      };
     } else {
       warnings.push(`Pinned targetId "${filters.targetId}" is stale (Metro page ids change on reload); re-resolving on pinned device "${filters.deviceName.trim()}".`);
     }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -30793,6 +30793,12 @@ function describeTarget(target) {
   const confidence = target.platformInference ?? "probed";
   return `${target.id} title="${target.title || "?"}" appId="${target.appId ?? "?"}" device="${target.deviceName ?? "?"}" description="${target.description ?? "?"}" platform=${target.platform ?? "?"} confidence=${confidence}`;
 }
+function metroDeviceConnectionId(id) {
+  if (!id)
+    return "";
+  const cut = id.lastIndexOf("-");
+  return cut > 0 ? id.slice(0, cut) : id;
+}
 function classifyAndroidDeviceKind(deviceName) {
   if (!deviceName)
     return "unknown";
@@ -30807,15 +30813,36 @@ function selectTarget(validTargets, filtersOrPlatform) {
   let filteredTargets = validTargets;
   const warnings = [];
   let warnNoPlatformFilter = false;
+  if (filters.deviceName) {
+    const pinnedDevice = filters.deviceName.trim();
+    const deviceMatched = filteredTargets.filter((target) => target.deviceName?.trim() === pinnedDevice);
+    if (deviceMatched.length === 0) {
+      return {
+        targets: [],
+        warning: `Pinned device "${pinnedDevice}" has no live CDP target on this Metro; refusing to silently bind a different device. Candidates: ${validTargets.map(describeTarget).join("; ")}. Relaunch the app on the pinned device, or re-pin deliberately via cdp_targets + cdp_connect targetId.`
+      };
+    }
+    const devicePrefixes = new Set(deviceMatched.map((t) => metroDeviceConnectionId(t.id)));
+    if (devicePrefixes.size > 1) {
+      return {
+        targets: [],
+        warning: `Pinned device name "${pinnedDevice}" matches ${devicePrefixes.size} live Metro device connections; refusing an ambiguous bind. Candidates: ${deviceMatched.map(describeTarget).join("; ")}. Re-pin deliberately via cdp_targets + cdp_connect targetId.`
+      };
+    }
+    filteredTargets = deviceMatched;
+  }
   if (filters.targetId) {
-    const idMatched = validTargets.filter((t) => t.id === filters.targetId);
-    if (idMatched.length === 0) {
+    const idMatched = filteredTargets.filter((t) => t.id === filters.targetId);
+    if (idMatched.length > 0) {
+      filteredTargets = idMatched;
+    } else if (!filters.deviceName) {
       return {
         targets: [],
         warning: `targetId "${filters.targetId}" not found. Available ids: ${validTargets.map((t) => t.id).join(", ")}`
       };
+    } else {
+      warnings.push(`Pinned targetId "${filters.targetId}" is stale (Metro page ids change on reload); re-resolving on pinned device "${filters.deviceName.trim()}".`);
     }
-    filteredTargets = idMatched;
   }
   if (filters.platform) {
     const platform = filters.platform.toLowerCase();
@@ -30829,7 +30856,7 @@ function selectTarget(validTargets, filtersOrPlatform) {
       };
     }
     filteredTargets = platformMatched;
-  } else if (validTargets.length > 0 && !filters.targetId && !filters.bundleId && !filters.deviceKind && !filters.preferredBundleId) {
+  } else if (validTargets.length > 0 && !filters.targetId && !filters.bundleId && !filters.deviceKind && !filters.preferredBundleId && !filters.deviceName) {
     warnNoPlatformFilter = true;
   }
   if (filters.deviceKind) {
@@ -30950,6 +30977,8 @@ async function discover(currentPort, platformFilterOrFilters) {
     hints.push(`bundleId=${filters.bundleId}`);
   if (filters.preferredBundleId)
     hints.push(`preferredBundleId=${filters.preferredBundleId}`);
+  if (filters.deviceName)
+    hints.push(`deviceName=${filters.deviceName}`);
   logger.debug("CDP", `Discovering Metro on ports: ${ports.join(", ")}${hints.length ? ` (${hints.join(", ")})` : ""}`);
   const runningPorts = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
   if (runningPorts.length === 0) {
@@ -66168,7 +66197,8 @@ async function discoverAndConnect(ctx, portHint, filters, discoverFn = discover,
     deviceKind: mergedFilters.deviceKind,
     targetId: mergedFilters.targetId,
     bundleId: mergedFilters.bundleId,
-    preferredBundleId: mergedFilters.preferredBundleId
+    preferredBundleId: mergedFilters.preferredBundleId,
+    deviceName: mergedFilters.deviceName
   };
   let result;
   try {
@@ -66227,6 +66257,9 @@ async function discoverAndConnect(ctx, portHint, filters, discoverFn = discover,
   const stickyFilters = stickyPlatformFilters(ctx.getConnectFilters(), connectedTarget.platform);
   if (stickyFilters)
     ctx.setConnectFilters(stickyFilters);
+  const pinnedDeviceFilters = stickyPinnedDeviceFilters(ctx.getConnectFilters(), connectedTarget);
+  if (pinnedDeviceFilters)
+    ctx.setConnectFilters(pinnedDeviceFilters);
   const msg3 = `Connected to ${connectedTarget.title} on port ${metroPort}`;
   return selectionWarning ? `${msg3}. WARNING: ${selectionWarning}` : msg3;
 }
@@ -66236,6 +66269,23 @@ function stickyPlatformFilters(current, resolvedPlatform) {
   if (!resolvedPlatform)
     return null;
   return { ...current, platform: resolvedPlatform };
+}
+function stickyPinnedDeviceFilters(current, connectedTarget) {
+  if (!current.targetId)
+    return null;
+  const deviceName = connectedTarget.deviceName?.trim();
+  if (!deviceName)
+    return null;
+  const bundleId = current.bundleId ?? targetBundleIdentity(connectedTarget) ?? void 0;
+  if (current.targetId === connectedTarget.id && current.deviceName === deviceName && current.bundleId === bundleId) {
+    return null;
+  }
+  return {
+    ...current,
+    targetId: connectedTarget.id,
+    deviceName,
+    ...bundleId ? { bundleId } : {}
+  };
 }
 function formatConnectFailureMessage(retries, attempts3, bundleHint, lastErrorMessage) {
   const allHandshakesSucceeded = attempts3.length > 0 && attempts3.every((a) => a.handshakeOk);
@@ -66908,6 +66958,10 @@ var init_cdp_client = __esm({
       _connectFilters = {};
       _reconnectDiscover;
       _exactDiscoveryPort;
+      /** GH #625: pinned device affinity, if an explicit targetId pin captured one. */
+      get pinnedDeviceName() {
+        return this._connectFilters.deviceName;
+      }
       createAuthoritativeDiscover(awaitWithinBoundary) {
         return async (_port, filtersOrPlatform) => {
           const policy = this._authoritativeSessionPolicy;
@@ -67848,6 +67902,7 @@ function captureClientState(client2) {
     port: client2.metroPort,
     platform: target?.platform,
     bundleId: target?.description ?? void 0,
+    deviceName: client2.pinnedDeviceName,
     proxyWasActive: client2.proxyDesired
   };
 }
@@ -67875,6 +67930,9 @@ async function forceReconnect(oldClient, setClient2, createClient2, captured, au
     const filters = {
       platform: authorityTarget?.platform ?? captured.platform,
       bundleId: authorityTarget?.appId ?? captured.bundleId,
+      // GH #625: without an exact authority target, the pinned device affinity
+      // is the only thing keeping recovery off a sibling simulator.
+      ...authorityTarget ? {} : { deviceName: captured.deviceName },
       ...authorityTarget && resolveExactTargetId ? { targetId: await resolveExactTargetId(newClient, captured, authorityTarget) } : {}
     };
     await raceWithTimeout(authorityTarget ? newClient.connectExact(captured.port, filters) : newClient.autoConnect(captured.port, filters), FORCE_FALLBACK_TIMEOUT_MS, "force_reconnect");
@@ -89048,9 +89106,11 @@ var init_index = __esm({
       const session2 = getActiveSession();
       if (!session2?.deviceId || !session2.appId)
         return false;
+      const sessionPlatform = session2.platform === "ios" || session2.platform === "android" ? session2.platform : void 0;
       try {
         const r = await createReloadHandler(getClient, setClient, createClient)({
           full: true,
+          ...sessionPlatform ? { platform: sessionPlatform } : {},
           deviceId: session2.deviceId,
           appId: session2.appId
         });

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -19237,6 +19237,12 @@ function describeTarget(target) {
   const confidence = target.platformInference ?? "probed";
   return `${target.id} title="${target.title || "?"}" appId="${target.appId ?? "?"}" device="${target.deviceName ?? "?"}" description="${target.description ?? "?"}" platform=${target.platform ?? "?"} confidence=${confidence}`;
 }
+function metroDeviceConnectionId(id) {
+  if (!id)
+    return "";
+  const cut = id.lastIndexOf("-");
+  return cut > 0 ? id.slice(0, cut) : id;
+}
 function classifyAndroidDeviceKind(deviceName) {
   if (!deviceName)
     return "unknown";
@@ -19251,15 +19257,36 @@ function selectTarget(validTargets, filtersOrPlatform) {
   let filteredTargets = validTargets;
   const warnings = [];
   let warnNoPlatformFilter = false;
+  if (filters.deviceName) {
+    const pinnedDevice = filters.deviceName.trim();
+    const deviceMatched = filteredTargets.filter((target) => target.deviceName?.trim() === pinnedDevice);
+    if (deviceMatched.length === 0) {
+      return {
+        targets: [],
+        warning: `Pinned device "${pinnedDevice}" has no live CDP target on this Metro; refusing to silently bind a different device. Candidates: ${validTargets.map(describeTarget).join("; ")}. Relaunch the app on the pinned device, or re-pin deliberately via cdp_targets + cdp_connect targetId.`
+      };
+    }
+    const devicePrefixes = new Set(deviceMatched.map((t) => metroDeviceConnectionId(t.id)));
+    if (devicePrefixes.size > 1) {
+      return {
+        targets: [],
+        warning: `Pinned device name "${pinnedDevice}" matches ${devicePrefixes.size} live Metro device connections; refusing an ambiguous bind. Candidates: ${deviceMatched.map(describeTarget).join("; ")}. Re-pin deliberately via cdp_targets + cdp_connect targetId.`
+      };
+    }
+    filteredTargets = deviceMatched;
+  }
   if (filters.targetId) {
-    const idMatched = validTargets.filter((t) => t.id === filters.targetId);
-    if (idMatched.length === 0) {
+    const idMatched = filteredTargets.filter((t) => t.id === filters.targetId);
+    if (idMatched.length > 0) {
+      filteredTargets = idMatched;
+    } else if (!filters.deviceName) {
       return {
         targets: [],
         warning: `targetId "${filters.targetId}" not found. Available ids: ${validTargets.map((t) => t.id).join(", ")}`
       };
+    } else {
+      warnings.push(`Pinned targetId "${filters.targetId}" is stale (Metro page ids change on reload); re-resolving on pinned device "${filters.deviceName.trim()}".`);
     }
-    filteredTargets = idMatched;
   }
   if (filters.platform) {
     const platform = filters.platform.toLowerCase();
@@ -19273,7 +19300,7 @@ function selectTarget(validTargets, filtersOrPlatform) {
       };
     }
     filteredTargets = platformMatched;
-  } else if (validTargets.length > 0 && !filters.targetId && !filters.bundleId && !filters.deviceKind && !filters.preferredBundleId) {
+  } else if (validTargets.length > 0 && !filters.targetId && !filters.bundleId && !filters.deviceKind && !filters.preferredBundleId && !filters.deviceName) {
     warnNoPlatformFilter = true;
   }
   if (filters.deviceKind) {
@@ -19394,6 +19421,8 @@ async function discover(currentPort, platformFilterOrFilters) {
     hints.push(`bundleId=${filters.bundleId}`);
   if (filters.preferredBundleId)
     hints.push(`preferredBundleId=${filters.preferredBundleId}`);
+  if (filters.deviceName)
+    hints.push(`deviceName=${filters.deviceName}`);
   logger.debug("CDP", `Discovering Metro on ports: ${ports.join(", ")}${hints.length ? ` (${hints.join(", ")})` : ""}`);
   const runningPorts = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
   if (runningPorts.length === 0) {
@@ -55398,7 +55427,8 @@ async function discoverAndConnect(ctx, portHint, filters, discoverFn = discover,
     deviceKind: mergedFilters.deviceKind,
     targetId: mergedFilters.targetId,
     bundleId: mergedFilters.bundleId,
-    preferredBundleId: mergedFilters.preferredBundleId
+    preferredBundleId: mergedFilters.preferredBundleId,
+    deviceName: mergedFilters.deviceName
   };
   let result;
   try {
@@ -55457,6 +55487,9 @@ async function discoverAndConnect(ctx, portHint, filters, discoverFn = discover,
   const stickyFilters = stickyPlatformFilters(ctx.getConnectFilters(), connectedTarget.platform);
   if (stickyFilters)
     ctx.setConnectFilters(stickyFilters);
+  const pinnedDeviceFilters = stickyPinnedDeviceFilters(ctx.getConnectFilters(), connectedTarget);
+  if (pinnedDeviceFilters)
+    ctx.setConnectFilters(pinnedDeviceFilters);
   const msg3 = `Connected to ${connectedTarget.title} on port ${metroPort}`;
   return selectionWarning ? `${msg3}. WARNING: ${selectionWarning}` : msg3;
 }
@@ -55466,6 +55499,23 @@ function stickyPlatformFilters(current, resolvedPlatform) {
   if (!resolvedPlatform)
     return null;
   return { ...current, platform: resolvedPlatform };
+}
+function stickyPinnedDeviceFilters(current, connectedTarget) {
+  if (!current.targetId)
+    return null;
+  const deviceName = connectedTarget.deviceName?.trim();
+  if (!deviceName)
+    return null;
+  const bundleId = current.bundleId ?? targetBundleIdentity(connectedTarget) ?? void 0;
+  if (current.targetId === connectedTarget.id && current.deviceName === deviceName && current.bundleId === bundleId) {
+    return null;
+  }
+  return {
+    ...current,
+    targetId: connectedTarget.id,
+    deviceName,
+    ...bundleId ? { bundleId } : {}
+  };
 }
 function formatConnectFailureMessage(retries, attempts3, bundleHint, lastErrorMessage) {
   const allHandshakesSucceeded = attempts3.length > 0 && attempts3.every((a) => a.handshakeOk);
@@ -56079,6 +56129,10 @@ var CDPClient = class _CDPClient {
   _connectFilters = {};
   _reconnectDiscover;
   _exactDiscoveryPort;
+  /** GH #625: pinned device affinity, if an explicit targetId pin captured one. */
+  get pinnedDeviceName() {
+    return this._connectFilters.deviceName;
+  }
   createAuthoritativeDiscover(awaitWithinBoundary) {
     return async (_port, filtersOrPlatform) => {
       const policy = this._authoritativeSessionPolicy;
@@ -57011,6 +57065,7 @@ function captureClientState(client2) {
     port: client2.metroPort,
     platform: target?.platform,
     bundleId: target?.description ?? void 0,
+    deviceName: client2.pinnedDeviceName,
     proxyWasActive: client2.proxyDesired
   };
 }
@@ -57038,6 +57093,9 @@ async function forceReconnect(oldClient, setClient2, createClient2, captured, au
     const filters = {
       platform: authorityTarget?.platform ?? captured.platform,
       bundleId: authorityTarget?.appId ?? captured.bundleId,
+      // GH #625: without an exact authority target, the pinned device affinity
+      // is the only thing keeping recovery off a sibling simulator.
+      ...authorityTarget ? {} : { deviceName: captured.deviceName },
       ...authorityTarget && resolveExactTargetId ? { targetId: await resolveExactTargetId(newClient, captured, authorityTarget) } : {}
     };
     await raceWithTimeout(authorityTarget ? newClient.connectExact(captured.port, filters) : newClient.autoConnect(captured.port, filters), FORCE_FALLBACK_TIMEOUT_MS, "force_reconnect");
@@ -87027,9 +87085,11 @@ var e2eReload = async () => {
   const session2 = getActiveSession();
   if (!session2?.deviceId || !session2.appId)
     return false;
+  const sessionPlatform = session2.platform === "ios" || session2.platform === "android" ? session2.platform : void 0;
   try {
     const r = await createReloadHandler(getClient, setClient, createClient)({
       full: true,
+      ...sessionPlatform ? { platform: sessionPlatform } : {},
       deviceId: session2.deviceId,
       appId: session2.appId
     });

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -19243,6 +19243,13 @@ function metroDeviceConnectionId(id) {
   const cut = id.lastIndexOf("-");
   return cut > 0 ? id.slice(0, cut) : id;
 }
+function metroPageNumber(id) {
+  if (!id)
+    return 0;
+  const cut = id.lastIndexOf("-");
+  const page = cut > 0 ? Number.parseInt(id.slice(cut + 1), 10) : NaN;
+  return Number.isNaN(page) ? 0 : page;
+}
 function classifyAndroidDeviceKind(deviceName) {
   if (!deviceName)
     return "unknown";
@@ -19268,12 +19275,18 @@ function selectTarget(validTargets, filtersOrPlatform) {
     }
     const devicePrefixes = new Set(deviceMatched.map((t) => metroDeviceConnectionId(t.id)));
     if (devicePrefixes.size > 1) {
-      return {
-        targets: [],
-        warning: `Pinned device name "${pinnedDevice}" matches ${devicePrefixes.size} live Metro device connections; refusing an ambiguous bind. Candidates: ${deviceMatched.map(describeTarget).join("; ")}. Re-pin deliberately via cdp_targets + cdp_connect targetId.`
-      };
+      const bundleScoped = filters.bundleId ? deviceMatched.filter((target) => targetMatchesBundleId(target, filters.bundleId)) : [];
+      const bundleConnections = new Set(bundleScoped.map((t) => metroDeviceConnectionId(t.id)));
+      if (bundleConnections.size !== 1) {
+        return {
+          targets: [],
+          warning: `Pinned device name "${pinnedDevice}" matches ${devicePrefixes.size} live Metro device connections and ` + (filters.bundleId ? `pinned bundleId "${filters.bundleId}" narrows them to ${bundleConnections.size}` : `no proven bundle identity is pinned to narrow them`) + `; refusing an ambiguous bind. Candidates: ${deviceMatched.map(describeTarget).join("; ")}. Re-pin deliberately via cdp_targets + cdp_connect targetId.`
+        };
+      }
+      filteredTargets = bundleScoped;
+    } else {
+      filteredTargets = deviceMatched;
     }
-    filteredTargets = deviceMatched;
   }
   if (filters.targetId) {
     const idMatched = filteredTargets.filter((t) => t.id === filters.targetId);
@@ -19342,8 +19355,8 @@ function selectTarget(validTargets, filtersOrPlatform) {
     }
   }
   const sorted = [...filteredTargets].sort((a, b) => {
-    const aPage = parseInt(a.id?.split("-")[1] ?? "0", 10);
-    const bPage = parseInt(b.id?.split("-")[1] ?? "0", 10);
+    const aPage = metroPageNumber(a.id);
+    const bPage = metroPageNumber(b.id);
     if (aPage !== bPage)
       return bPage - aPage;
     if (prefLower) {
@@ -55698,7 +55711,8 @@ async function discoverAuthoritativeTarget(policy, requestedFilters, discoverFn 
     ...requestedFilters,
     ...policy.filters,
     targetId: void 0,
-    preferredBundleId: void 0
+    preferredBundleId: void 0,
+    deviceName: void 0
   });
   if (result.errorCode || result.targets.length === 0)
     return result;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -19284,6 +19284,11 @@ function selectTarget(validTargets, filtersOrPlatform) {
         targets: [],
         warning: `targetId "${filters.targetId}" not found. Available ids: ${validTargets.map((t) => t.id).join(", ")}`
       };
+    } else if (!filters.bundleId) {
+      return {
+        targets: [],
+        warning: `Pinned targetId "${filters.targetId}" is stale and no proven bundle identity is pinned; refusing to re-resolve on device "${filters.deviceName.trim()}" without app identity. Candidates: ${filteredTargets.map(describeTarget).join("; ")}. Re-pin deliberately via cdp_targets + cdp_connect targetId.`
+      };
     } else {
       warnings.push(`Pinned targetId "${filters.targetId}" is stale (Metro page ids change on reload); re-resolving on pinned device "${filters.deviceName.trim()}".`);
     }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -30799,6 +30799,13 @@ function metroDeviceConnectionId(id) {
   const cut = id.lastIndexOf("-");
   return cut > 0 ? id.slice(0, cut) : id;
 }
+function metroPageNumber(id) {
+  if (!id)
+    return 0;
+  const cut = id.lastIndexOf("-");
+  const page = cut > 0 ? Number.parseInt(id.slice(cut + 1), 10) : NaN;
+  return Number.isNaN(page) ? 0 : page;
+}
 function classifyAndroidDeviceKind(deviceName) {
   if (!deviceName)
     return "unknown";
@@ -30824,12 +30831,18 @@ function selectTarget(validTargets, filtersOrPlatform) {
     }
     const devicePrefixes = new Set(deviceMatched.map((t) => metroDeviceConnectionId(t.id)));
     if (devicePrefixes.size > 1) {
-      return {
-        targets: [],
-        warning: `Pinned device name "${pinnedDevice}" matches ${devicePrefixes.size} live Metro device connections; refusing an ambiguous bind. Candidates: ${deviceMatched.map(describeTarget).join("; ")}. Re-pin deliberately via cdp_targets + cdp_connect targetId.`
-      };
+      const bundleScoped = filters.bundleId ? deviceMatched.filter((target) => targetMatchesBundleId(target, filters.bundleId)) : [];
+      const bundleConnections = new Set(bundleScoped.map((t) => metroDeviceConnectionId(t.id)));
+      if (bundleConnections.size !== 1) {
+        return {
+          targets: [],
+          warning: `Pinned device name "${pinnedDevice}" matches ${devicePrefixes.size} live Metro device connections and ` + (filters.bundleId ? `pinned bundleId "${filters.bundleId}" narrows them to ${bundleConnections.size}` : `no proven bundle identity is pinned to narrow them`) + `; refusing an ambiguous bind. Candidates: ${deviceMatched.map(describeTarget).join("; ")}. Re-pin deliberately via cdp_targets + cdp_connect targetId.`
+        };
+      }
+      filteredTargets = bundleScoped;
+    } else {
+      filteredTargets = deviceMatched;
     }
-    filteredTargets = deviceMatched;
   }
   if (filters.targetId) {
     const idMatched = filteredTargets.filter((t) => t.id === filters.targetId);
@@ -30898,8 +30911,8 @@ function selectTarget(validTargets, filtersOrPlatform) {
     }
   }
   const sorted = [...filteredTargets].sort((a, b) => {
-    const aPage = parseInt(a.id?.split("-")[1] ?? "0", 10);
-    const bPage = parseInt(b.id?.split("-")[1] ?? "0", 10);
+    const aPage = metroPageNumber(a.id);
+    const bPage = metroPageNumber(b.id);
     if (aPage !== bPage)
       return bPage - aPage;
     if (prefLower) {
@@ -66505,7 +66518,8 @@ async function discoverAuthoritativeTarget(policy, requestedFilters, discoverFn 
     ...requestedFilters,
     ...policy.filters,
     targetId: void 0,
-    preferredBundleId: void 0
+    preferredBundleId: void 0,
+    deviceName: void 0
   });
   if (result.errorCode || result.targets.length === 0)
     return result;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -30840,6 +30840,11 @@ function selectTarget(validTargets, filtersOrPlatform) {
         targets: [],
         warning: `targetId "${filters.targetId}" not found. Available ids: ${validTargets.map((t) => t.id).join(", ")}`
       };
+    } else if (!filters.bundleId) {
+      return {
+        targets: [],
+        warning: `Pinned targetId "${filters.targetId}" is stale and no proven bundle identity is pinned; refusing to re-resolve on device "${filters.deviceName.trim()}" without app identity. Candidates: ${filteredTargets.map(describeTarget).join("; ")}. Re-pin deliberately via cdp_targets + cdp_connect targetId.`
+      };
     } else {
       warnings.push(`Pinned targetId "${filters.targetId}" is stale (Metro page ids change on reload); re-resolving on pinned device "${filters.deviceName.trim()}".`);
     }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -30793,6 +30793,12 @@ function describeTarget(target) {
   const confidence = target.platformInference ?? "probed";
   return `${target.id} title="${target.title || "?"}" appId="${target.appId ?? "?"}" device="${target.deviceName ?? "?"}" description="${target.description ?? "?"}" platform=${target.platform ?? "?"} confidence=${confidence}`;
 }
+function metroDeviceConnectionId(id) {
+  if (!id)
+    return "";
+  const cut = id.lastIndexOf("-");
+  return cut > 0 ? id.slice(0, cut) : id;
+}
 function classifyAndroidDeviceKind(deviceName) {
   if (!deviceName)
     return "unknown";
@@ -30807,15 +30813,36 @@ function selectTarget(validTargets, filtersOrPlatform) {
   let filteredTargets = validTargets;
   const warnings = [];
   let warnNoPlatformFilter = false;
+  if (filters.deviceName) {
+    const pinnedDevice = filters.deviceName.trim();
+    const deviceMatched = filteredTargets.filter((target) => target.deviceName?.trim() === pinnedDevice);
+    if (deviceMatched.length === 0) {
+      return {
+        targets: [],
+        warning: `Pinned device "${pinnedDevice}" has no live CDP target on this Metro; refusing to silently bind a different device. Candidates: ${validTargets.map(describeTarget).join("; ")}. Relaunch the app on the pinned device, or re-pin deliberately via cdp_targets + cdp_connect targetId.`
+      };
+    }
+    const devicePrefixes = new Set(deviceMatched.map((t) => metroDeviceConnectionId(t.id)));
+    if (devicePrefixes.size > 1) {
+      return {
+        targets: [],
+        warning: `Pinned device name "${pinnedDevice}" matches ${devicePrefixes.size} live Metro device connections; refusing an ambiguous bind. Candidates: ${deviceMatched.map(describeTarget).join("; ")}. Re-pin deliberately via cdp_targets + cdp_connect targetId.`
+      };
+    }
+    filteredTargets = deviceMatched;
+  }
   if (filters.targetId) {
-    const idMatched = validTargets.filter((t) => t.id === filters.targetId);
-    if (idMatched.length === 0) {
+    const idMatched = filteredTargets.filter((t) => t.id === filters.targetId);
+    if (idMatched.length > 0) {
+      filteredTargets = idMatched;
+    } else if (!filters.deviceName) {
       return {
         targets: [],
         warning: `targetId "${filters.targetId}" not found. Available ids: ${validTargets.map((t) => t.id).join(", ")}`
       };
+    } else {
+      warnings.push(`Pinned targetId "${filters.targetId}" is stale (Metro page ids change on reload); re-resolving on pinned device "${filters.deviceName.trim()}".`);
     }
-    filteredTargets = idMatched;
   }
   if (filters.platform) {
     const platform = filters.platform.toLowerCase();
@@ -30829,7 +30856,7 @@ function selectTarget(validTargets, filtersOrPlatform) {
       };
     }
     filteredTargets = platformMatched;
-  } else if (validTargets.length > 0 && !filters.targetId && !filters.bundleId && !filters.deviceKind && !filters.preferredBundleId) {
+  } else if (validTargets.length > 0 && !filters.targetId && !filters.bundleId && !filters.deviceKind && !filters.preferredBundleId && !filters.deviceName) {
     warnNoPlatformFilter = true;
   }
   if (filters.deviceKind) {
@@ -30950,6 +30977,8 @@ async function discover(currentPort, platformFilterOrFilters) {
     hints.push(`bundleId=${filters.bundleId}`);
   if (filters.preferredBundleId)
     hints.push(`preferredBundleId=${filters.preferredBundleId}`);
+  if (filters.deviceName)
+    hints.push(`deviceName=${filters.deviceName}`);
   logger.debug("CDP", `Discovering Metro on ports: ${ports.join(", ")}${hints.length ? ` (${hints.join(", ")})` : ""}`);
   const runningPorts = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
   if (runningPorts.length === 0) {
@@ -66168,7 +66197,8 @@ async function discoverAndConnect(ctx, portHint, filters, discoverFn = discover,
     deviceKind: mergedFilters.deviceKind,
     targetId: mergedFilters.targetId,
     bundleId: mergedFilters.bundleId,
-    preferredBundleId: mergedFilters.preferredBundleId
+    preferredBundleId: mergedFilters.preferredBundleId,
+    deviceName: mergedFilters.deviceName
   };
   let result;
   try {
@@ -66227,6 +66257,9 @@ async function discoverAndConnect(ctx, portHint, filters, discoverFn = discover,
   const stickyFilters = stickyPlatformFilters(ctx.getConnectFilters(), connectedTarget.platform);
   if (stickyFilters)
     ctx.setConnectFilters(stickyFilters);
+  const pinnedDeviceFilters = stickyPinnedDeviceFilters(ctx.getConnectFilters(), connectedTarget);
+  if (pinnedDeviceFilters)
+    ctx.setConnectFilters(pinnedDeviceFilters);
   const msg3 = `Connected to ${connectedTarget.title} on port ${metroPort}`;
   return selectionWarning ? `${msg3}. WARNING: ${selectionWarning}` : msg3;
 }
@@ -66236,6 +66269,23 @@ function stickyPlatformFilters(current, resolvedPlatform) {
   if (!resolvedPlatform)
     return null;
   return { ...current, platform: resolvedPlatform };
+}
+function stickyPinnedDeviceFilters(current, connectedTarget) {
+  if (!current.targetId)
+    return null;
+  const deviceName = connectedTarget.deviceName?.trim();
+  if (!deviceName)
+    return null;
+  const bundleId = current.bundleId ?? targetBundleIdentity(connectedTarget) ?? void 0;
+  if (current.targetId === connectedTarget.id && current.deviceName === deviceName && current.bundleId === bundleId) {
+    return null;
+  }
+  return {
+    ...current,
+    targetId: connectedTarget.id,
+    deviceName,
+    ...bundleId ? { bundleId } : {}
+  };
 }
 function formatConnectFailureMessage(retries, attempts3, bundleHint, lastErrorMessage) {
   const allHandshakesSucceeded = attempts3.length > 0 && attempts3.every((a) => a.handshakeOk);
@@ -66908,6 +66958,10 @@ var init_cdp_client = __esm({
       _connectFilters = {};
       _reconnectDiscover;
       _exactDiscoveryPort;
+      /** GH #625: pinned device affinity, if an explicit targetId pin captured one. */
+      get pinnedDeviceName() {
+        return this._connectFilters.deviceName;
+      }
       createAuthoritativeDiscover(awaitWithinBoundary) {
         return async (_port, filtersOrPlatform) => {
           const policy = this._authoritativeSessionPolicy;
@@ -67848,6 +67902,7 @@ function captureClientState(client2) {
     port: client2.metroPort,
     platform: target?.platform,
     bundleId: target?.description ?? void 0,
+    deviceName: client2.pinnedDeviceName,
     proxyWasActive: client2.proxyDesired
   };
 }
@@ -67875,6 +67930,9 @@ async function forceReconnect(oldClient, setClient2, createClient2, captured, au
     const filters = {
       platform: authorityTarget?.platform ?? captured.platform,
       bundleId: authorityTarget?.appId ?? captured.bundleId,
+      // GH #625: without an exact authority target, the pinned device affinity
+      // is the only thing keeping recovery off a sibling simulator.
+      ...authorityTarget ? {} : { deviceName: captured.deviceName },
       ...authorityTarget && resolveExactTargetId ? { targetId: await resolveExactTargetId(newClient, captured, authorityTarget) } : {}
     };
     await raceWithTimeout(authorityTarget ? newClient.connectExact(captured.port, filters) : newClient.autoConnect(captured.port, filters), FORCE_FALLBACK_TIMEOUT_MS, "force_reconnect");
@@ -89048,9 +89106,11 @@ var init_index = __esm({
       const session2 = getActiveSession();
       if (!session2?.deviceId || !session2.appId)
         return false;
+      const sessionPlatform = session2.platform === "ios" || session2.platform === "android" ? session2.platform : void 0;
       try {
         const r = await createReloadHandler(getClient, setClient, createClient)({
           full: true,
+          ...sessionPlatform ? { platform: sessionPlatform } : {},
           deviceId: session2.deviceId,
           appId: session2.appId
         });

--- a/packages/rn-dev-agent-core/dist/cdp-client.js
+++ b/packages/rn-dev-agent-core/dist/cdp-client.js
@@ -484,6 +484,10 @@ export class CDPClient {
     _connectFilters = {};
     _reconnectDiscover;
     _exactDiscoveryPort;
+    /** GH #625: pinned device affinity, if an explicit targetId pin captured one. */
+    get pinnedDeviceName() {
+        return this._connectFilters.deviceName;
+    }
     createAuthoritativeDiscover(awaitWithinBoundary) {
         return async (_port, filtersOrPlatform) => {
             const policy = this._authoritativeSessionPolicy;

--- a/packages/rn-dev-agent-core/dist/cdp-client.js
+++ b/packages/rn-dev-agent-core/dist/cdp-client.js
@@ -22,6 +22,7 @@ export async function discoverAuthoritativeTarget(policy, requestedFilters, disc
         ...policy.filters,
         targetId: undefined,
         preferredBundleId: undefined,
+        deviceName: undefined,
     });
     if (result.errorCode || result.targets.length === 0)
         return result;

--- a/packages/rn-dev-agent-core/dist/cdp/connect.js
+++ b/packages/rn-dev-agent-core/dist/cdp/connect.js
@@ -2,7 +2,7 @@ import WebSocket from 'ws';
 import { logger } from '../logger.js';
 import { metroOrigin } from '../ws-origin.js';
 import { resolveBundleId } from '../project-config.js';
-import { discover, TargetSelectionError } from './discovery.js';
+import { discover, targetBundleIdentity, TargetSelectionError } from './discovery.js';
 import { sleep } from './state.js';
 import { CDP_TIMEOUT_FAST } from './timeout-config.js';
 import { probeReactReachable } from './setup.js';
@@ -96,6 +96,7 @@ export async function discoverAndConnect(ctx, portHint, filters, discoverFn = di
         targetId: mergedFilters.targetId,
         bundleId: mergedFilters.bundleId,
         preferredBundleId: mergedFilters.preferredBundleId,
+        deviceName: mergedFilters.deviceName,
     };
     let result;
     try {
@@ -167,6 +168,12 @@ export async function discoverAndConnect(ctx, portHint, filters, discoverFn = di
     const stickyFilters = stickyPlatformFilters(ctx.getConnectFilters(), connectedTarget.platform);
     if (stickyFilters)
         ctx.setConnectFilters(stickyFilters);
+    // GH #625: an explicit targetId pin persists the connected target's durable
+    // device + bundle identity so reconnects re-resolve on the SAME device (page
+    // ids churn on reload) and fail closed instead of binding a sibling simulator.
+    const pinnedDeviceFilters = stickyPinnedDeviceFilters(ctx.getConnectFilters(), connectedTarget);
+    if (pinnedDeviceFilters)
+        ctx.setConnectFilters(pinnedDeviceFilters);
     const msg = `Connected to ${connectedTarget.title} on port ${metroPort}`;
     return selectionWarning ? `${msg}. WARNING: ${selectionWarning}` : msg;
 }
@@ -185,6 +192,31 @@ export function stickyPlatformFilters(current, resolvedPlatform) {
     if (!resolvedPlatform)
         return null;
     return { ...current, platform: resolvedPlatform };
+}
+/**
+ * GH #625: pure helper that persists the durable identity of an explicitly
+ * pinned target — deviceName plus proven bundle identity — and refreshes the
+ * volatile page-scoped targetId to the live one. Returns null when there is no
+ * pin, no durable identity to capture, or nothing changed.
+ */
+export function stickyPinnedDeviceFilters(current, connectedTarget) {
+    if (!current.targetId)
+        return null;
+    const deviceName = connectedTarget.deviceName?.trim();
+    if (!deviceName)
+        return null;
+    const bundleId = current.bundleId ?? targetBundleIdentity(connectedTarget) ?? undefined;
+    if (current.targetId === connectedTarget.id &&
+        current.deviceName === deviceName &&
+        current.bundleId === bundleId) {
+        return null;
+    }
+    return {
+        ...current,
+        targetId: connectedTarget.id,
+        deviceName,
+        ...(bundleId ? { bundleId } : {}),
+    };
 }
 /**
  * GH #105 / B154: pure helper. Decide which final error string to surface

--- a/packages/rn-dev-agent-core/dist/cdp/discovery.js
+++ b/packages/rn-dev-agent-core/dist/cdp/discovery.js
@@ -426,6 +426,16 @@ export function selectTarget(validTargets, filtersOrPlatform) {
                 warning: `targetId "${filters.targetId}" not found. Available ids: ${validTargets.map((t) => t.id).join(', ')}`,
             };
         }
+        else if (!filters.bundleId) {
+            // Device affinity without proven app identity cannot re-resolve a stale
+            // pin — a device can run several debuggable apps. Fail closed.
+            return {
+                targets: [],
+                warning: `Pinned targetId "${filters.targetId}" is stale and no proven bundle identity is pinned; refusing to re-resolve on device "${filters.deviceName.trim()}" without app identity. ` +
+                    `Candidates: ${filteredTargets.map(describeTarget).join('; ')}. ` +
+                    `Re-pin deliberately via cdp_targets + cdp_connect targetId.`,
+            };
+        }
         else {
             warnings.push(`Pinned targetId "${filters.targetId}" is stale (Metro page ids change on reload); re-resolving on pinned device "${filters.deviceName.trim()}".`);
         }

--- a/packages/rn-dev-agent-core/dist/cdp/discovery.js
+++ b/packages/rn-dev-agent-core/dist/cdp/discovery.js
@@ -343,6 +343,13 @@ function describeTarget(target) {
     const confidence = target.platformInference ?? 'probed';
     return `${target.id} title="${target.title || '?'}" appId="${target.appId ?? '?'}" device="${target.deviceName ?? '?'}" description="${target.description ?? '?'}" platform=${target.platform ?? '?'} confidence=${confidence}`;
 }
+/** Metro target ids are `<device>-<page>`; the device part may contain hyphens. */
+function metroDeviceConnectionId(id) {
+    if (!id)
+        return '';
+    const cut = id.lastIndexOf('-');
+    return cut > 0 ? id.slice(0, cut) : id;
+}
 export class TargetSelectionError extends Error {
     code;
     candidates;
@@ -374,17 +381,54 @@ export function selectTarget(validTargets, filtersOrPlatform) {
     let filteredTargets = validTargets;
     const warnings = [];
     let warnNoPlatformFilter = false;
-    // Selection precedence starts with an exact target id. It is exact identity,
-    // but it never overrides an explicit/session platform constraint.
+    // GH #625: device affinity outranks the page-scoped targetId. Metro page ids
+    // churn on reload and can be reused across devices after a Metro restart, so
+    // the pinned deviceName is the only durable identity. Fail closed when it
+    // cannot be re-proven — never silently bind a sibling simulator.
+    if (filters.deviceName) {
+        const pinnedDevice = filters.deviceName.trim();
+        const deviceMatched = filteredTargets.filter((target) => target.deviceName?.trim() === pinnedDevice);
+        if (deviceMatched.length === 0) {
+            return {
+                targets: [],
+                warning: `Pinned device "${pinnedDevice}" has no live CDP target on this Metro; refusing to silently bind a different device. ` +
+                    `Candidates: ${validTargets.map(describeTarget).join('; ')}. ` +
+                    `Relaunch the app on the pinned device, or re-pin deliberately via cdp_targets + cdp_connect targetId.`,
+            };
+        }
+        // The affinity must land on exactly ONE Metro device connection. Metro ids
+        // are `<device>-<page>` (device may itself contain hyphens), so multiple
+        // device prefixes under one deviceName mean two live devices share that
+        // name — indistinguishable from Metro metadata, and after a Metro restart
+        // even an exact page-id match cannot prove which clone owns it. Fail closed.
+        const devicePrefixes = new Set(deviceMatched.map((t) => metroDeviceConnectionId(t.id)));
+        if (devicePrefixes.size > 1) {
+            return {
+                targets: [],
+                warning: `Pinned device name "${pinnedDevice}" matches ${devicePrefixes.size} live Metro device connections; refusing an ambiguous bind. ` +
+                    `Candidates: ${deviceMatched.map(describeTarget).join('; ')}. ` +
+                    `Re-pin deliberately via cdp_targets + cdp_connect targetId.`,
+            };
+        }
+        filteredTargets = deviceMatched;
+    }
+    // Selection precedence continues with an exact target id. It is exact
+    // identity, but it never overrides an explicit/session platform constraint —
+    // and with a device affinity pinned it cannot escape that device.
     if (filters.targetId) {
-        const idMatched = validTargets.filter((t) => t.id === filters.targetId);
-        if (idMatched.length === 0) {
+        const idMatched = filteredTargets.filter((t) => t.id === filters.targetId);
+        if (idMatched.length > 0) {
+            filteredTargets = idMatched;
+        }
+        else if (!filters.deviceName) {
             return {
                 targets: [],
                 warning: `targetId "${filters.targetId}" not found. Available ids: ${validTargets.map((t) => t.id).join(', ')}`,
             };
         }
-        filteredTargets = idMatched;
+        else {
+            warnings.push(`Pinned targetId "${filters.targetId}" is stale (Metro page ids change on reload); re-resolving on pinned device "${filters.deviceName.trim()}".`);
+        }
     }
     if (filters.platform) {
         const platform = filters.platform.toLowerCase();
@@ -406,7 +450,8 @@ export function selectTarget(validTargets, filtersOrPlatform) {
         !filters.targetId &&
         !filters.bundleId &&
         !filters.deviceKind &&
-        !filters.preferredBundleId) {
+        !filters.preferredBundleId &&
+        !filters.deviceName) {
         warnNoPlatformFilter = true;
     }
     if (filters.deviceKind) {
@@ -560,6 +605,8 @@ export async function discover(currentPort, platformFilterOrFilters) {
         hints.push(`bundleId=${filters.bundleId}`);
     if (filters.preferredBundleId)
         hints.push(`preferredBundleId=${filters.preferredBundleId}`);
+    if (filters.deviceName)
+        hints.push(`deviceName=${filters.deviceName}`);
     logger.debug('CDP', `Discovering Metro on ports: ${ports.join(', ')}${hints.length ? ` (${hints.join(', ')})` : ''}`);
     // GH #303: probe ALL candidate ports, then prefer one with an attached Hermes
     // target so a detached sibling-worktree Metro can't shadow a healthy one.

--- a/packages/rn-dev-agent-core/dist/cdp/discovery.js
+++ b/packages/rn-dev-agent-core/dist/cdp/discovery.js
@@ -350,6 +350,13 @@ function metroDeviceConnectionId(id) {
     const cut = id.lastIndexOf('-');
     return cut > 0 ? id.slice(0, cut) : id;
 }
+function metroPageNumber(id) {
+    if (!id)
+        return 0;
+    const cut = id.lastIndexOf('-');
+    const page = cut > 0 ? Number.parseInt(id.slice(cut + 1), 10) : NaN;
+    return Number.isNaN(page) ? 0 : page;
+}
 export class TargetSelectionError extends Error {
     code;
     candidates;
@@ -397,20 +404,35 @@ export function selectTarget(validTargets, filtersOrPlatform) {
             };
         }
         // The affinity must land on exactly ONE Metro device connection. Metro ids
-        // are `<device>-<page>` (device may itself contain hyphens), so multiple
-        // device prefixes under one deviceName mean two live devices share that
-        // name — indistinguishable from Metro metadata, and after a Metro restart
-        // even an exact page-id match cannot prove which clone owns it. Fail closed.
+        // are `<device>-<page>` (device may itself contain hyphens). Metro opens a
+        // device connection per debuggable runtime, so several prefixes under one
+        // deviceName can be either one device running several apps — which the
+        // proven bundle identity disambiguates — or two same-named devices, which
+        // Metro metadata cannot tell apart even on an exact page-id match (ids are
+        // recycled across Metro restarts). Fail closed unless the bundle narrows it.
         const devicePrefixes = new Set(deviceMatched.map((t) => metroDeviceConnectionId(t.id)));
         if (devicePrefixes.size > 1) {
-            return {
-                targets: [],
-                warning: `Pinned device name "${pinnedDevice}" matches ${devicePrefixes.size} live Metro device connections; refusing an ambiguous bind. ` +
-                    `Candidates: ${deviceMatched.map(describeTarget).join('; ')}. ` +
-                    `Re-pin deliberately via cdp_targets + cdp_connect targetId.`,
-            };
+            const bundleScoped = filters.bundleId
+                ? deviceMatched.filter((target) => targetMatchesBundleId(target, filters.bundleId))
+                : [];
+            const bundleConnections = new Set(bundleScoped.map((t) => metroDeviceConnectionId(t.id)));
+            if (bundleConnections.size !== 1) {
+                return {
+                    targets: [],
+                    warning: `Pinned device name "${pinnedDevice}" matches ${devicePrefixes.size} live Metro device connections and ` +
+                        (filters.bundleId
+                            ? `pinned bundleId "${filters.bundleId}" narrows them to ${bundleConnections.size}`
+                            : `no proven bundle identity is pinned to narrow them`) +
+                        `; refusing an ambiguous bind. ` +
+                        `Candidates: ${deviceMatched.map(describeTarget).join('; ')}. ` +
+                        `Re-pin deliberately via cdp_targets + cdp_connect targetId.`,
+                };
+            }
+            filteredTargets = bundleScoped;
         }
-        filteredTargets = deviceMatched;
+        else {
+            filteredTargets = deviceMatched;
+        }
     }
     // Selection precedence continues with an exact target id. It is exact
     // identity, but it never overrides an explicit/session platform constraint —
@@ -510,8 +532,8 @@ export function selectTarget(validTargets, filtersOrPlatform) {
     // Tie-break 1: preferredBundleId-matched targets win.
     // Tie-break 2: lexicographic by full id (eliminates JS sort stability dependency).
     const sorted = [...filteredTargets].sort((a, b) => {
-        const aPage = parseInt(a.id?.split('-')[1] ?? '0', 10);
-        const bPage = parseInt(b.id?.split('-')[1] ?? '0', 10);
+        const aPage = metroPageNumber(a.id);
+        const bPage = metroPageNumber(b.id);
         if (aPage !== bPage)
             return bPage - aPage;
         if (prefLower) {

--- a/packages/rn-dev-agent-core/dist/index.js
+++ b/packages/rn-dev-agent-core/dist/index.js
@@ -2838,9 +2838,14 @@ const e2eReload = async () => {
     const session = getActiveSession();
     if (!session?.deviceId || !session.appId)
         return false;
+    // GH #625: recoverAfterFailedReconnect only engages exact-device recovery
+    // when platform+deviceId+appId are ALL present — omitting platform silently
+    // downgraded recovery to device-blind platform+bundle filters.
+    const sessionPlatform = session.platform === 'ios' || session.platform === 'android' ? session.platform : undefined;
     try {
         const r = await createReloadHandler(getClient, setClient, createClient)({
             full: true,
+            ...(sessionPlatform ? { platform: sessionPlatform } : {}),
             deviceId: session.deviceId,
             appId: session.appId,
         });

--- a/packages/rn-dev-agent-core/dist/tools/reload.js
+++ b/packages/rn-dev-agent-core/dist/tools/reload.js
@@ -20,6 +20,7 @@ export function captureClientState(client) {
         port: client.metroPort,
         platform: target?.platform,
         bundleId: target?.description ?? undefined,
+        deviceName: client.pinnedDeviceName,
         proxyWasActive: client.proxyDesired,
     };
 }
@@ -48,6 +49,9 @@ export async function forceReconnect(oldClient, setClient, createClient, capture
         const filters = {
             platform: authorityTarget?.platform ?? captured.platform,
             bundleId: authorityTarget?.appId ?? captured.bundleId,
+            // GH #625: without an exact authority target, the pinned device affinity
+            // is the only thing keeping recovery off a sibling simulator.
+            ...(authorityTarget ? {} : { deviceName: captured.deviceName }),
             ...(authorityTarget && resolveExactTargetId
                 ? { targetId: await resolveExactTargetId(newClient, captured, authorityTarget) }
                 : {}),

--- a/packages/rn-dev-agent-core/src/cdp-client.ts
+++ b/packages/rn-dev-agent-core/src/cdp-client.ts
@@ -684,6 +684,11 @@ export class CDPClient {
   private _reconnectDiscover: typeof discoverExactPort | undefined;
   private _exactDiscoveryPort: number | undefined;
 
+  /** GH #625: pinned device affinity, if an explicit targetId pin captured one. */
+  get pinnedDeviceName(): string | undefined {
+    return this._connectFilters.deviceName;
+  }
+
   private createAuthoritativeDiscover(
     awaitWithinBoundary?: AwaitWithinBoundary,
   ): typeof discoverExactPort {

--- a/packages/rn-dev-agent-core/src/cdp-client.ts
+++ b/packages/rn-dev-agent-core/src/cdp-client.ts
@@ -80,6 +80,7 @@ export async function discoverAuthoritativeTarget(
     ...policy.filters,
     targetId: undefined,
     preferredBundleId: undefined,
+    deviceName: undefined,
   });
   if (result.errorCode || result.targets.length === 0) return result;
   const resolveTargetId = () => policy.resolveTargetId(result.targets, awaitWithinBoundary);

--- a/packages/rn-dev-agent-core/src/cdp/connect.ts
+++ b/packages/rn-dev-agent-core/src/cdp/connect.ts
@@ -2,7 +2,7 @@ import WebSocket from 'ws';
 import { logger } from '../logger.js';
 import { metroOrigin } from '../ws-origin.js';
 import { resolveBundleId } from '../project-config.js';
-import { discover, TargetSelectionError } from './discovery.js';
+import { discover, targetBundleIdentity, TargetSelectionError } from './discovery.js';
 import type { SelectTargetFilters } from './discovery.js';
 import { sleep } from './state.js';
 import { CDP_TIMEOUT_FAST } from './timeout-config.js';
@@ -72,6 +72,8 @@ export interface ConnectFilters {
   targetId?: string;
   bundleId?: string;
   preferredBundleId?: string;
+  /** GH #625: durable device affinity captured when a targetId is pinned. */
+  deviceName?: string;
 }
 
 export interface ConnectContext {
@@ -164,6 +166,7 @@ export async function discoverAndConnect(
     targetId: mergedFilters.targetId,
     bundleId: mergedFilters.bundleId,
     preferredBundleId: mergedFilters.preferredBundleId,
+    deviceName: mergedFilters.deviceName,
   };
 
   let result;
@@ -248,6 +251,12 @@ export async function discoverAndConnect(
   const stickyFilters = stickyPlatformFilters(ctx.getConnectFilters(), connectedTarget!.platform);
   if (stickyFilters) ctx.setConnectFilters(stickyFilters);
 
+  // GH #625: an explicit targetId pin persists the connected target's durable
+  // device + bundle identity so reconnects re-resolve on the SAME device (page
+  // ids churn on reload) and fail closed instead of binding a sibling simulator.
+  const pinnedDeviceFilters = stickyPinnedDeviceFilters(ctx.getConnectFilters(), connectedTarget!);
+  if (pinnedDeviceFilters) ctx.setConnectFilters(pinnedDeviceFilters);
+
   const msg = `Connected to ${connectedTarget!.title} on port ${metroPort}`;
   return selectionWarning ? `${msg}. WARNING: ${selectionWarning}` : msg;
 }
@@ -268,6 +277,35 @@ export function stickyPlatformFilters(
   if (current.platform) return null;
   if (!resolvedPlatform) return null;
   return { ...current, platform: resolvedPlatform };
+}
+
+/**
+ * GH #625: pure helper that persists the durable identity of an explicitly
+ * pinned target — deviceName plus proven bundle identity — and refreshes the
+ * volatile page-scoped targetId to the live one. Returns null when there is no
+ * pin, no durable identity to capture, or nothing changed.
+ */
+export function stickyPinnedDeviceFilters(
+  current: ConnectFilters,
+  connectedTarget: HermesTarget,
+): ConnectFilters | null {
+  if (!current.targetId) return null;
+  const deviceName = connectedTarget.deviceName?.trim();
+  if (!deviceName) return null;
+  const bundleId = current.bundleId ?? targetBundleIdentity(connectedTarget) ?? undefined;
+  if (
+    current.targetId === connectedTarget.id &&
+    current.deviceName === deviceName &&
+    current.bundleId === bundleId
+  ) {
+    return null;
+  }
+  return {
+    ...current,
+    targetId: connectedTarget.id,
+    deviceName,
+    ...(bundleId ? { bundleId } : {}),
+  };
 }
 
 /**

--- a/packages/rn-dev-agent-core/src/cdp/discovery.ts
+++ b/packages/rn-dev-agent-core/src/cdp/discovery.ts
@@ -389,6 +389,13 @@ function describeTarget(target: HermesTarget): string {
   return `${target.id} title="${target.title || '?'}" appId="${target.appId ?? '?'}" device="${target.deviceName ?? '?'}" description="${target.description ?? '?'}" platform=${target.platform ?? '?'} confidence=${confidence}`;
 }
 
+/** Metro target ids are `<device>-<page>`; the device part may contain hyphens. */
+function metroDeviceConnectionId(id: string | undefined): string {
+  if (!id) return '';
+  const cut = id.lastIndexOf('-');
+  return cut > 0 ? id.slice(0, cut) : id;
+}
+
 export class TargetSelectionError extends Error {
   constructor(
     readonly code: 'PLATFORM_TARGET_NOT_FOUND' | 'TARGET_PLATFORM_CONFLICT',
@@ -431,6 +438,10 @@ export interface SelectTargetFilters {
   bundleId?: string;
   /** Preferred bundleId (auto-selection hint, non-hard-filter). Used to break ties. */
   preferredBundleId?: string;
+  /** GH #625: hard device affinity (exact deviceName). Internal reconnect pin:
+   * when set, a missing targetId re-resolves WITHIN this device instead of
+   * failing, since page ids churn on reload. Never exposed to tool callers. */
+  deviceName?: string;
 }
 
 export function selectTarget(
@@ -447,17 +458,59 @@ export function selectTarget(
   const warnings: string[] = [];
   let warnNoPlatformFilter = false;
 
-  // Selection precedence starts with an exact target id. It is exact identity,
-  // but it never overrides an explicit/session platform constraint.
+  // GH #625: device affinity outranks the page-scoped targetId. Metro page ids
+  // churn on reload and can be reused across devices after a Metro restart, so
+  // the pinned deviceName is the only durable identity. Fail closed when it
+  // cannot be re-proven — never silently bind a sibling simulator.
+  if (filters.deviceName) {
+    const pinnedDevice = filters.deviceName.trim();
+    const deviceMatched = filteredTargets.filter(
+      (target) => target.deviceName?.trim() === pinnedDevice,
+    );
+    if (deviceMatched.length === 0) {
+      return {
+        targets: [],
+        warning:
+          `Pinned device "${pinnedDevice}" has no live CDP target on this Metro; refusing to silently bind a different device. ` +
+          `Candidates: ${validTargets.map(describeTarget).join('; ')}. ` +
+          `Relaunch the app on the pinned device, or re-pin deliberately via cdp_targets + cdp_connect targetId.`,
+      };
+    }
+    // The affinity must land on exactly ONE Metro device connection. Metro ids
+    // are `<device>-<page>` (device may itself contain hyphens), so multiple
+    // device prefixes under one deviceName mean two live devices share that
+    // name — indistinguishable from Metro metadata, and after a Metro restart
+    // even an exact page-id match cannot prove which clone owns it. Fail closed.
+    const devicePrefixes = new Set(deviceMatched.map((t) => metroDeviceConnectionId(t.id)));
+    if (devicePrefixes.size > 1) {
+      return {
+        targets: [],
+        warning:
+          `Pinned device name "${pinnedDevice}" matches ${devicePrefixes.size} live Metro device connections; refusing an ambiguous bind. ` +
+          `Candidates: ${deviceMatched.map(describeTarget).join('; ')}. ` +
+          `Re-pin deliberately via cdp_targets + cdp_connect targetId.`,
+      };
+    }
+    filteredTargets = deviceMatched;
+  }
+
+  // Selection precedence continues with an exact target id. It is exact
+  // identity, but it never overrides an explicit/session platform constraint —
+  // and with a device affinity pinned it cannot escape that device.
   if (filters.targetId) {
-    const idMatched = validTargets.filter((t) => t.id === filters.targetId);
-    if (idMatched.length === 0) {
+    const idMatched = filteredTargets.filter((t) => t.id === filters.targetId);
+    if (idMatched.length > 0) {
+      filteredTargets = idMatched;
+    } else if (!filters.deviceName) {
       return {
         targets: [],
         warning: `targetId "${filters.targetId}" not found. Available ids: ${validTargets.map((t) => t.id).join(', ')}`,
       };
+    } else {
+      warnings.push(
+        `Pinned targetId "${filters.targetId}" is stale (Metro page ids change on reload); re-resolving on pinned device "${filters.deviceName.trim()}".`,
+      );
     }
-    filteredTargets = idMatched;
   }
 
   if (filters.platform) {
@@ -484,7 +537,8 @@ export function selectTarget(
     !filters.targetId &&
     !filters.bundleId &&
     !filters.deviceKind &&
-    !filters.preferredBundleId
+    !filters.preferredBundleId &&
+    !filters.deviceName
   ) {
     warnNoPlatformFilter = true;
   }
@@ -692,6 +746,7 @@ export async function discover(
   if (filters.targetId) hints.push(`targetId=${filters.targetId}`);
   if (filters.bundleId) hints.push(`bundleId=${filters.bundleId}`);
   if (filters.preferredBundleId) hints.push(`preferredBundleId=${filters.preferredBundleId}`);
+  if (filters.deviceName) hints.push(`deviceName=${filters.deviceName}`);
   logger.debug(
     'CDP',
     `Discovering Metro on ports: ${ports.join(', ')}${hints.length ? ` (${hints.join(', ')})` : ''}`,

--- a/packages/rn-dev-agent-core/src/cdp/discovery.ts
+++ b/packages/rn-dev-agent-core/src/cdp/discovery.ts
@@ -506,6 +506,16 @@ export function selectTarget(
         targets: [],
         warning: `targetId "${filters.targetId}" not found. Available ids: ${validTargets.map((t) => t.id).join(', ')}`,
       };
+    } else if (!filters.bundleId) {
+      // Device affinity without proven app identity cannot re-resolve a stale
+      // pin — a device can run several debuggable apps. Fail closed.
+      return {
+        targets: [],
+        warning:
+          `Pinned targetId "${filters.targetId}" is stale and no proven bundle identity is pinned; refusing to re-resolve on device "${filters.deviceName.trim()}" without app identity. ` +
+          `Candidates: ${filteredTargets.map(describeTarget).join('; ')}. ` +
+          `Re-pin deliberately via cdp_targets + cdp_connect targetId.`,
+      };
     } else {
       warnings.push(
         `Pinned targetId "${filters.targetId}" is stale (Metro page ids change on reload); re-resolving on pinned device "${filters.deviceName.trim()}".`,

--- a/packages/rn-dev-agent-core/src/cdp/discovery.ts
+++ b/packages/rn-dev-agent-core/src/cdp/discovery.ts
@@ -396,6 +396,13 @@ function metroDeviceConnectionId(id: string | undefined): string {
   return cut > 0 ? id.slice(0, cut) : id;
 }
 
+function metroPageNumber(id: string | undefined): number {
+  if (!id) return 0;
+  const cut = id.lastIndexOf('-');
+  const page = cut > 0 ? Number.parseInt(id.slice(cut + 1), 10) : NaN;
+  return Number.isNaN(page) ? 0 : page;
+}
+
 export class TargetSelectionError extends Error {
   constructor(
     readonly code: 'PLATFORM_TARGET_NOT_FOUND' | 'TARGET_PLATFORM_CONFLICT',
@@ -477,21 +484,35 @@ export function selectTarget(
       };
     }
     // The affinity must land on exactly ONE Metro device connection. Metro ids
-    // are `<device>-<page>` (device may itself contain hyphens), so multiple
-    // device prefixes under one deviceName mean two live devices share that
-    // name — indistinguishable from Metro metadata, and after a Metro restart
-    // even an exact page-id match cannot prove which clone owns it. Fail closed.
+    // are `<device>-<page>` (device may itself contain hyphens). Metro opens a
+    // device connection per debuggable runtime, so several prefixes under one
+    // deviceName can be either one device running several apps — which the
+    // proven bundle identity disambiguates — or two same-named devices, which
+    // Metro metadata cannot tell apart even on an exact page-id match (ids are
+    // recycled across Metro restarts). Fail closed unless the bundle narrows it.
     const devicePrefixes = new Set(deviceMatched.map((t) => metroDeviceConnectionId(t.id)));
     if (devicePrefixes.size > 1) {
-      return {
-        targets: [],
-        warning:
-          `Pinned device name "${pinnedDevice}" matches ${devicePrefixes.size} live Metro device connections; refusing an ambiguous bind. ` +
-          `Candidates: ${deviceMatched.map(describeTarget).join('; ')}. ` +
-          `Re-pin deliberately via cdp_targets + cdp_connect targetId.`,
-      };
+      const bundleScoped = filters.bundleId
+        ? deviceMatched.filter((target) => targetMatchesBundleId(target, filters.bundleId!))
+        : [];
+      const bundleConnections = new Set(bundleScoped.map((t) => metroDeviceConnectionId(t.id)));
+      if (bundleConnections.size !== 1) {
+        return {
+          targets: [],
+          warning:
+            `Pinned device name "${pinnedDevice}" matches ${devicePrefixes.size} live Metro device connections and ` +
+            (filters.bundleId
+              ? `pinned bundleId "${filters.bundleId}" narrows them to ${bundleConnections.size}`
+              : `no proven bundle identity is pinned to narrow them`) +
+            `; refusing an ambiguous bind. ` +
+            `Candidates: ${deviceMatched.map(describeTarget).join('; ')}. ` +
+            `Re-pin deliberately via cdp_targets + cdp_connect targetId.`,
+        };
+      }
+      filteredTargets = bundleScoped;
+    } else {
+      filteredTargets = deviceMatched;
     }
-    filteredTargets = deviceMatched;
   }
 
   // Selection precedence continues with an exact target id. It is exact
@@ -612,8 +633,8 @@ export function selectTarget(
   // Tie-break 1: preferredBundleId-matched targets win.
   // Tie-break 2: lexicographic by full id (eliminates JS sort stability dependency).
   const sorted = [...filteredTargets].sort((a, b) => {
-    const aPage = parseInt(a.id?.split('-')[1] ?? '0', 10);
-    const bPage = parseInt(b.id?.split('-')[1] ?? '0', 10);
+    const aPage = metroPageNumber(a.id);
+    const bPage = metroPageNumber(b.id);
     if (aPage !== bPage) return bPage - aPage;
     if (prefLower) {
       const aPref = targetMatchesBundleId(a, prefLower) ? 1 : 0;

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -3851,6 +3851,11 @@ const e2eReload = async (): Promise<boolean> => {
   if (!getClient().isConnected) return false;
   const session = getActiveSession();
   if (!session?.deviceId || !session.appId) return false;
+  // GH #625: recoverAfterFailedReconnect only engages exact-device recovery
+  // when platform+deviceId+appId are ALL present — omitting platform silently
+  // downgraded recovery to device-blind platform+bundle filters.
+  const sessionPlatform =
+    session.platform === 'ios' || session.platform === 'android' ? session.platform : undefined;
   try {
     const r = await createReloadHandler(
       getClient,
@@ -3858,6 +3863,7 @@ const e2eReload = async (): Promise<boolean> => {
       createClient,
     )({
       full: true,
+      ...(sessionPlatform ? { platform: sessionPlatform } : {}),
       deviceId: session.deviceId,
       appId: session.appId,
     });

--- a/packages/rn-dev-agent-core/src/tools/reload.ts
+++ b/packages/rn-dev-agent-core/src/tools/reload.ts
@@ -23,6 +23,8 @@ interface CapturedClientState {
   port: number;
   platform: 'ios' | 'android' | undefined;
   bundleId: string | undefined;
+  /** GH #625: pinned device affinity that must survive the recovery reconnect. */
+  deviceName: string | undefined;
   proxyWasActive: boolean;
 }
 
@@ -44,6 +46,7 @@ export function captureClientState(client: CDPClient): CapturedClientState {
     port: client.metroPort,
     platform: target?.platform,
     bundleId: target?.description ?? undefined,
+    deviceName: client.pinnedDeviceName,
     proxyWasActive: client.proxyDesired,
   };
 }
@@ -96,6 +99,9 @@ export async function forceReconnect(
     const filters = {
       platform: authorityTarget?.platform ?? captured.platform,
       bundleId: authorityTarget?.appId ?? captured.bundleId,
+      // GH #625: without an exact authority target, the pinned device affinity
+      // is the only thing keeping recovery off a sibling simulator.
+      ...(authorityTarget ? {} : { deviceName: captured.deviceName }),
       ...(authorityTarget && resolveExactTargetId
         ? { targetId: await resolveExactTargetId(newClient, captured, authorityTarget) }
         : {}),

--- a/packages/rn-dev-agent-core/test/unit/gh-625-shared-metro-device-affinity.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-625-shared-metro-device-affinity.test.ts
@@ -56,9 +56,22 @@ test('GH-625: a reused page id on the wrong device cannot escape the pinned devi
   const result = selectTarget([simA, simB], {
     targetId: '10-9', // matches sim A's live id, but the pin was on sim B
     deviceName: 'iPhone 17 Pro',
+    bundleId: 'com.example.app',
   });
   assert.equal(result.targets.length, 1);
   assert.equal(result.targets[0]!.deviceName, 'iPhone 17 Pro');
+});
+
+test('GH-625: a stale pin without proven bundle identity refuses instead of guessing the app', () => {
+  // A device can run several debuggable apps; deviceName alone must not
+  // re-resolve a stale pin onto whichever app happens to be newest.
+  const simB = simTarget('12-3', 'iPhone 17 Pro');
+  const result = selectTarget([simB], {
+    targetId: '3-1',
+    deviceName: 'iPhone 17 Pro',
+  });
+  assert.equal(result.targets.length, 0);
+  assert.match(result.warning ?? '', /bundle identity/i);
 });
 
 test('GH-625: truthful refusal when the pinned device has no live target', () => {
@@ -134,6 +147,7 @@ test('GH-625: multiple pages of one device connection stay resolvable after a st
   const result = selectTarget([pageA, pageB], {
     targetId: '3-1',
     deviceName: 'iPhone 17 Pro',
+    bundleId: 'com.example.app',
   });
   assert.equal(result.targets.length, 2, 'both same-device pages remain candidates');
   assert.equal(result.targets[0]!.id, '12-3', 'newest page first');
@@ -416,7 +430,9 @@ test('GH-625: reconnect refuses truthfully when only the sibling device remains'
       undefined,
       fakeDiscover([liveTarget('13-9', 'iPhone 16')]) as never,
     ),
-    /[Pp]inned device/,
-    'must surface the pinned-device refusal instead of binding the sibling',
+    // The propagated refusal must both name the pinned device AND disclose the
+    // live sibling candidate so the caller can re-pin deliberately.
+    /[Pp]inned device[\s\S]*iPhone 16/,
+    'must surface the pinned-device refusal with candidates instead of binding the sibling',
   );
 });

--- a/packages/rn-dev-agent-core/test/unit/gh-625-shared-metro-device-affinity.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-625-shared-metro-device-affinity.test.ts
@@ -1,0 +1,422 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { WebSocketServer } from 'ws';
+import { selectTarget } from '../../dist/cdp/discovery.js';
+import { discoverAndConnect, stickyPinnedDeviceFilters } from '../../dist/cdp/connect.js';
+import type { ConnectContext, ConnectFilters } from '../../dist/cdp/connect.js';
+import { captureClientState, forceReconnect } from '../../dist/tools/reload.js';
+import type { HermesTarget } from '../../dist/types.js';
+
+// GH #625: two simulators sharing one Metro port are indistinguishable under
+// platform+bundle filters, and the pinned targetId is a volatile Metro page id
+// that goes stale on every reload. Reconnect affinity must carry the pinned
+// target's device identity (deviceName) and fail closed when it cannot be
+// re-proven — never silently bind the sibling simulator.
+
+function simTarget(id: string, deviceName: string): HermesTarget {
+  return {
+    id,
+    title: `com.example.app (${deviceName})`,
+    vm: 'Hermes',
+    description: 'com.example.app',
+    appId: 'com.example.app',
+    deviceName,
+    platform: 'ios',
+    platformInference: 'probed',
+    webSocketDebuggerUrl: `ws://127.0.0.1:8082/inspector/debug?device=${id}`,
+  };
+}
+
+test('GH-625: stale pinned targetId re-resolves on the pinned device, never the sibling', () => {
+  // Sibling sim A carries the NEWER page id, so an affinity-blind fallback
+  // (drop stale pin → newest-page-first sort) would silently pick sim A.
+  const simA = simTarget('10-9', 'iPhone 16');
+  const simB = simTarget('12-3', 'iPhone 17 Pro');
+  const result = selectTarget([simA, simB], {
+    platform: 'ios',
+    bundleId: 'com.example.app',
+    targetId: '3-1',
+    deviceName: 'iPhone 17 Pro',
+  });
+  assert.equal(result.targets.length, 1, `expected exactly the pinned device's target`);
+  assert.equal(result.targets[0]!.deviceName, 'iPhone 17 Pro');
+  assert.match(
+    result.warning ?? '',
+    /stale/i,
+    'must disclose that the stale pin was re-resolved by device affinity',
+  );
+});
+
+test('GH-625: a reused page id on the wrong device cannot escape the pinned device', () => {
+  // Metro device numbering can reset (Metro restart), so a stale id may now
+  // belong to the SIBLING. Device affinity must outrank the id match.
+  const simA = simTarget('10-9', 'iPhone 16');
+  const simB = simTarget('12-3', 'iPhone 17 Pro');
+  const result = selectTarget([simA, simB], {
+    targetId: '10-9', // matches sim A's live id, but the pin was on sim B
+    deviceName: 'iPhone 17 Pro',
+  });
+  assert.equal(result.targets.length, 1);
+  assert.equal(result.targets[0]!.deviceName, 'iPhone 17 Pro');
+});
+
+test('GH-625: truthful refusal when the pinned device has no live target', () => {
+  const simA = simTarget('10-9', 'iPhone 16');
+  const result = selectTarget([simA], {
+    targetId: '3-1',
+    deviceName: 'iPhone 17 Pro',
+  });
+  assert.equal(result.targets.length, 0, 'must not bind the sibling device');
+  assert.match(result.warning ?? '', /pinned device/i, 'refusal must name the pinned device');
+  assert.match(
+    result.warning ?? '',
+    /iPhone 16/,
+    'refusal must list the live candidates so the caller can re-pin deliberately',
+  );
+});
+
+test('GH-625: valid pinned targetId on the pinned device still wins exact selection', () => {
+  const simA = simTarget('10-9', 'iPhone 16');
+  const simB1 = simTarget('12-3', 'iPhone 17 Pro');
+  const simB2 = simTarget('12-1', 'iPhone 17 Pro');
+  const result = selectTarget([simA, simB1, simB2], {
+    targetId: '12-1',
+    deviceName: 'iPhone 17 Pro',
+  });
+  assert.equal(result.targets.length, 1);
+  assert.equal(result.targets[0]!.id, '12-1');
+});
+
+test('GH-625: ambiguous same-name devices refuse a device-affinity fallback', () => {
+  // Two booted simulators can share a name; distinct live devices get distinct
+  // Metro id prefixes. A stale-pin fallback must not guess between them.
+  const cloneA = simTarget('12-3', 'iPhone 17 Pro');
+  const cloneB = simTarget('13-1', 'iPhone 17 Pro');
+  const result = selectTarget([cloneA, cloneB], {
+    targetId: '3-1',
+    deviceName: 'iPhone 17 Pro',
+  });
+  assert.equal(result.targets.length, 0);
+  assert.match(result.warning ?? '', /ambiguous/i);
+});
+
+test('GH-625: even a live id match refuses when same-name clones are indistinguishable', () => {
+  // After a Metro restart page-id counters reset, so a persisted id can
+  // collide with a sibling clone — an id match cannot prove device identity
+  // when two live devices share the pinned name.
+  const cloneA = simTarget('12-3', 'iPhone 17 Pro');
+  const cloneB = simTarget('13-1', 'iPhone 17 Pro');
+  const result = selectTarget([cloneA, cloneB], {
+    targetId: '12-3',
+    deviceName: 'iPhone 17 Pro',
+  });
+  assert.equal(result.targets.length, 0);
+  assert.match(result.warning ?? '', /ambiguous/i);
+});
+
+test('GH-625: hyphenated device ids still distinguish live device connections', () => {
+  const emulatorA = simTarget('emulator-5554-1', 'sdk_gphone64_arm64');
+  const emulatorB = simTarget('emulator-5556-2', 'sdk_gphone64_arm64');
+  const result = selectTarget([emulatorA, emulatorB], {
+    targetId: 'emulator-5554-9',
+    deviceName: 'sdk_gphone64_arm64',
+  });
+  assert.equal(result.targets.length, 0, 'two hyphenated device connections must stay ambiguous');
+  assert.match(result.warning ?? '', /ambiguous/i);
+});
+
+test('GH-625: multiple pages of one device connection stay resolvable after a stale pin', () => {
+  // Bridgeless apps expose several pages under ONE Metro device connection
+  // (shared id prefix) — that is normal re-resolution, not ambiguity.
+  const pageA = simTarget('12-1', 'iPhone 17 Pro');
+  const pageB = simTarget('12-3', 'iPhone 17 Pro');
+  const result = selectTarget([pageA, pageB], {
+    targetId: '3-1',
+    deviceName: 'iPhone 17 Pro',
+  });
+  assert.equal(result.targets.length, 2, 'both same-device pages remain candidates');
+  assert.equal(result.targets[0]!.id, '12-3', 'newest page first');
+});
+
+test('GH-625: behavior without device affinity is unchanged (stale pin still refuses)', () => {
+  const simA = simTarget('10-9', 'iPhone 16');
+  const result = selectTarget([simA], { targetId: '3-1' });
+  assert.equal(result.targets.length, 0);
+  assert.match(result.warning ?? '', /targetId "3-1" not found/);
+});
+
+test('GH-625: same-device different-app target cannot satisfy a pinned affinity', () => {
+  // A second RN app on the pinned simulator must not absorb a stale pin —
+  // bundle identity travels with the device affinity.
+  const otherApp: HermesTarget = {
+    ...simTarget('15-2', 'iPhone 17 Pro'),
+    title: 'com.other.app (iPhone 17 Pro)',
+    description: 'com.other.app',
+    appId: 'com.other.app',
+  };
+  const simA = simTarget('10-9', 'iPhone 16');
+  const result = selectTarget([simA, otherApp], {
+    targetId: '3-1',
+    deviceName: 'iPhone 17 Pro',
+    bundleId: 'com.example.app',
+  });
+  assert.equal(result.targets.length, 0, 'must refuse, not bind the other app');
+});
+
+test('GH-625: stickyPinnedDeviceFilters captures device + bundle identity for an explicit pin', () => {
+  const connected = simTarget('12-3', 'iPhone 17 Pro');
+  assert.deepEqual(
+    stickyPinnedDeviceFilters({ platform: 'ios', targetId: '12-3' }, connected),
+    {
+      platform: 'ios',
+      targetId: '12-3',
+      deviceName: 'iPhone 17 Pro',
+      bundleId: 'com.example.app',
+    },
+    'pinned connect must persist the durable device AND bundle identity',
+  );
+});
+
+test('GH-625: stickyPinnedDeviceFilters refreshes a stale pin to the live target id', () => {
+  const connected = simTarget('14-1', 'iPhone 17 Pro');
+  assert.deepEqual(
+    stickyPinnedDeviceFilters(
+      { platform: 'ios', targetId: '12-3', deviceName: 'iPhone 17 Pro' },
+      connected,
+    ),
+    {
+      platform: 'ios',
+      targetId: '14-1',
+      deviceName: 'iPhone 17 Pro',
+      bundleId: 'com.example.app',
+    },
+    'after a device-affinity re-resolve the persisted pin must track the live id',
+  );
+});
+
+test('GH-625: stickyPinnedDeviceFilters never overwrites an explicit bundleId', () => {
+  const connected = simTarget('12-3', 'iPhone 17 Pro');
+  const result = stickyPinnedDeviceFilters(
+    { platform: 'ios', targetId: '12-3', bundleId: 'com.pinned.app' },
+    connected,
+  );
+  assert.equal(result?.bundleId, 'com.pinned.app');
+});
+
+test('GH-625: stickyPinnedDeviceFilters is a no-op when nothing changed', () => {
+  const connected = simTarget('12-3', 'iPhone 17 Pro');
+  assert.equal(
+    stickyPinnedDeviceFilters(
+      {
+        platform: 'ios',
+        targetId: '12-3',
+        deviceName: 'iPhone 17 Pro',
+        bundleId: 'com.example.app',
+      },
+      connected,
+    ),
+    null,
+    'stable filters must not trigger redundant setConnectFilters churn',
+  );
+});
+
+test('GH-625: stickyPinnedDeviceFilters is a no-op without an explicit pin', () => {
+  const connected = simTarget('12-3', 'iPhone 17 Pro');
+  assert.equal(
+    stickyPinnedDeviceFilters({ platform: 'ios' }, connected),
+    null,
+    'un-pinned connects keep today’s free reconnect behavior',
+  );
+});
+
+test('GH-625: stickyPinnedDeviceFilters is a no-op when Metro exposes no deviceName', () => {
+  const connected: HermesTarget = {
+    ...simTarget('12-3', 'iPhone 17 Pro'),
+    deviceName: undefined,
+  };
+  assert.equal(
+    stickyPinnedDeviceFilters(
+      { platform: 'ios', targetId: '12-3', deviceName: undefined },
+      connected,
+    ),
+    null,
+    'no durable identity available — nothing to persist',
+  );
+});
+
+test('GH-625: captureClientState preserves the pinned device affinity for reload recovery', () => {
+  const fake = {
+    metroPort: 8082,
+    connectedTarget: simTarget('12-3', 'iPhone 17 Pro'),
+    proxyDesired: false,
+    pinnedDeviceName: 'iPhone 17 Pro',
+  };
+  const captured = captureClientState(fake as never);
+  assert.equal(captured.deviceName, 'iPhone 17 Pro');
+});
+
+test('GH-625: forceReconnect without an authority target keeps the pinned device affinity', async () => {
+  const seenFilters: ConnectFilters[] = [];
+  const newClient = {
+    autoConnect: async (_port: number, filters: ConnectFilters) => {
+      seenFilters.push(filters);
+      return 'connected';
+    },
+    disconnect: async () => {},
+    connectedTarget: { platform: 'ios' },
+  };
+  const oldClient = { disconnect: async () => {} };
+  const result = await forceReconnect(
+    oldClient as never,
+    () => {},
+    () => newClient as never,
+    {
+      port: 8082,
+      platform: 'ios',
+      bundleId: 'com.example.app',
+      deviceName: 'iPhone 17 Pro',
+      proxyWasActive: false,
+    },
+  );
+  assert.equal(result.ok, true);
+  assert.equal(
+    seenFilters[0]?.deviceName,
+    'iPhone 17 Pro',
+    'recovery must not silently drop the device pin and bind a sibling simulator',
+  );
+});
+
+// Connection-level regression: drive the REAL discoverAndConnect filter-merge
+// path (the one softReconnect and the handleClose reconnect loop use with
+// filters === undefined) against a live local WebSocket endpoint, so a
+// regression that wipes or ignores the persisted affinity cannot pass.
+const wss = new WebSocketServer({ port: 0 });
+const sockets: import('ws').WebSocket[] = [];
+wss.on('connection', (socket) => sockets.push(socket));
+before(async () => {
+  if (!wss.address()) await once(wss, 'listening');
+});
+after(
+  () =>
+    new Promise<void>((resolve) => {
+      for (const socket of sockets) socket.terminate();
+      wss.close(() => resolve());
+    }),
+);
+
+function wsUrl(): string {
+  const address = wss.address();
+  if (typeof address === 'string' || address === null) throw new Error('ws server not listening');
+  return `ws://127.0.0.1:${address.port}`;
+}
+
+function liveTarget(id: string, deviceName: string): HermesTarget {
+  return { ...simTarget(id, deviceName), webSocketDebuggerUrl: wsUrl() };
+}
+
+function fakeCtx() {
+  const state = {
+    filters: {} as ConnectFilters,
+    connected: null as HermesTarget | null,
+    ws: null as unknown,
+    port: 8082,
+    generation: 0,
+  };
+  const ctx: ConnectContext = {
+    isDisposed: () => false,
+    isReconnecting: () => false,
+    isSoftReconnectRequested: () => false,
+    getState: () => 'disconnected',
+    setState: () => {},
+    getPort: () => state.port,
+    setPort: (v: number) => {
+      state.port = v;
+    },
+    getConnectFilters: () => state.filters,
+    setConnectFilters: (v: ConnectFilters) => {
+      state.filters = v;
+    },
+    getWs: () => state.ws as never,
+    setWs: (ws: unknown) => {
+      state.ws = ws;
+    },
+    setHelpersInjected: () => {},
+    setConnectedTarget: (t: HermesTarget | null) => {
+      state.connected = t;
+    },
+    setConnectedAt: () => {},
+    now: () => Date.now(),
+    incrementConnectionGeneration: () => ++state.generation,
+    evaluate: async () => ({ value: true }),
+    sendWithTimeout: async () => ({}),
+    handleMessage: () => {},
+    handleClose: () => {},
+    rejectAllPending: () => {},
+    setup: async () => {},
+    getProxyUrl: () => null,
+  };
+  return { ctx, state };
+}
+
+function fakeDiscover(targets: HermesTarget[]) {
+  return async (port: number, filtersOrPlatform?: unknown) => {
+    const filters = typeof filtersOrPlatform === 'string' ? {} : (filtersOrPlatform ?? {});
+    const { targets: selected, warning, errorCode } = selectTarget(targets, filters);
+    return {
+      port,
+      targets: selected,
+      ...(warning ? { warning } : {}),
+      ...(errorCode ? { errorCode, candidates: targets } : {}),
+    };
+  };
+}
+
+test('GH-625: reconnect with preserved filters re-binds the pinned device after ids churn', async () => {
+  const { ctx, state } = fakeCtx();
+
+  await discoverAndConnect(
+    ctx,
+    8082,
+    { targetId: '12-3' },
+    fakeDiscover([liveTarget('10-9', 'iPhone 16'), liveTarget('12-3', 'iPhone 17 Pro')]) as never,
+  );
+  assert.equal(state.connected?.deviceName, 'iPhone 17 Pro');
+  assert.equal(state.filters.deviceName, 'iPhone 17 Pro', 'pin must persist device affinity');
+  assert.equal(state.filters.platform, 'ios', 'sticky platform must compose with the device pin');
+  assert.equal(state.filters.bundleId, 'com.example.app', 'bundle identity must persist too');
+
+  // App reloads: every page id changes and the SIBLING now has the newest id.
+  await discoverAndConnect(
+    ctx,
+    undefined,
+    undefined, // softReconnect semantics — persisted filters drive selection
+    fakeDiscover([liveTarget('13-9', 'iPhone 16'), liveTarget('14-1', 'iPhone 17 Pro')]) as never,
+  );
+  assert.equal(
+    state.connected?.deviceName,
+    'iPhone 17 Pro',
+    'reconnect must re-bind the pinned device, never the sibling simulator',
+  );
+  assert.equal(state.filters.targetId, '14-1', 'persisted pin must track the live id');
+});
+
+test('GH-625: reconnect refuses truthfully when only the sibling device remains', async () => {
+  const { ctx } = fakeCtx();
+  await discoverAndConnect(
+    ctx,
+    8082,
+    { targetId: '12-3' },
+    fakeDiscover([liveTarget('12-3', 'iPhone 17 Pro')]) as never,
+  );
+  await assert.rejects(
+    discoverAndConnect(
+      ctx,
+      undefined,
+      undefined,
+      fakeDiscover([liveTarget('13-9', 'iPhone 16')]) as never,
+    ),
+    /[Pp]inned device/,
+    'must surface the pinned-device refusal instead of binding the sibling',
+  );
+});

--- a/packages/rn-dev-agent-core/test/unit/gh-625-shared-metro-device-affinity.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-625-shared-metro-device-affinity.test.ts
@@ -28,6 +28,15 @@ function simTarget(id: string, deviceName: string): HermesTarget {
   };
 }
 
+function appTarget(id: string, deviceName: string, bundleId: string): HermesTarget {
+  return {
+    ...simTarget(id, deviceName),
+    title: `${bundleId} (${deviceName})`,
+    description: bundleId,
+    appId: bundleId,
+  };
+}
+
 test('GH-625: stale pinned targetId re-resolves on the pinned device, never the sibling', () => {
   // Sibling sim A carries the NEWER page id, so an affinity-blind fallback
   // (drop stale pin → newest-page-first sort) would silently pick sim A.
@@ -137,6 +146,45 @@ test('GH-625: hyphenated device ids still distinguish live device connections', 
   });
   assert.equal(result.targets.length, 0, 'two hyphenated device connections must stay ambiguous');
   assert.match(result.warning ?? '', /ambiguous/i);
+});
+
+test('GH-625: a second debuggable app on the pinned device is disambiguated by the pinned bundle', () => {
+  // Metro opens one device connection per debuggable runtime, so a dev client
+  // plus a second app on ONE simulator produce two prefixes under one name.
+  // The proven bundle identity resolves that without guessing a device.
+  const pinnedApp = simTarget('7-1', 'iPhone 17 Pro');
+  const otherApp = appTarget('9-2', 'iPhone 17 Pro', 'host.exp.Exponent');
+  const result = selectTarget([pinnedApp, otherApp], {
+    targetId: '7-1',
+    deviceName: 'iPhone 17 Pro',
+    bundleId: 'com.example.app',
+  });
+  assert.equal(result.targets.length, 1);
+  assert.equal(result.targets[0]!.id, '7-1');
+});
+
+test('GH-625: same-name clones running the pinned bundle still refuse an ambiguous bind', () => {
+  const cloneA = simTarget('12-3', 'iPhone 17 Pro');
+  const cloneB = simTarget('13-1', 'iPhone 17 Pro');
+  const result = selectTarget([cloneA, cloneB], {
+    targetId: '12-3',
+    deviceName: 'iPhone 17 Pro',
+    bundleId: 'com.example.app',
+  });
+  assert.equal(result.targets.length, 0, 'the pinned bundle cannot tell two clones apart');
+  assert.match(result.warning ?? '', /ambiguous/i);
+});
+
+test('GH-625: hyphenated device ids sort by numeric page, newest first', () => {
+  const stalePage = simTarget('emulator-5554-2', 'sdk_gphone64_arm64');
+  const freshPage = simTarget('emulator-5554-11', 'sdk_gphone64_arm64');
+  const result = selectTarget([stalePage, freshPage], {
+    targetId: 'emulator-5554-9',
+    deviceName: 'sdk_gphone64_arm64',
+    bundleId: 'com.example.app',
+  });
+  assert.equal(result.targets.length, 2);
+  assert.equal(result.targets[0]!.id, 'emulator-5554-11', 'page 11 is newer than page 2');
 });
 
 test('GH-625: multiple pages of one device connection stay resolvable after a stale pin', () => {

--- a/packages/rn-dev-agent-core/test/unit/session/exact-port-runtime-readiness.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/exact-port-runtime-readiness.test.ts
@@ -116,6 +116,7 @@ test('authoritative discovery re-resolves rotated target IDs from the managed po
       platform: 'ios',
       bundleId: 'com.example.app',
       preferredBundleId: undefined,
+      deviceName: undefined,
     },
   ]);
 });


### PR DESCRIPTION
## Intent

Fix GitHub issue #625 in Lykhoyda/rn-dev-agent: with two simulators attached to the same Metro port, auto-reconnect after cdp_reload/app restarts re-bound the WRONG device's Hermes target, silently discarding the explicitly pinned targetId (page-scoped Metro ids churn on every reload), and an explicit cdp_connect force=true re-pin raced the in-flight auto-reconnect. Acceptance: reconnect/bind must respect the session's pinned targetId or equivalent exact-device binding and never silently attach to the sibling simulator; causal regression tests covering the shared-Metro multi-simulator case; truthful refusal (candidates listed) when the pinned target is unavailable rather than a silent wrong-device bind. Constraints: smallest fix, no broad CDP redesign. Decisions made: the managed-session path is already exact-device via AuthoritativeSessionPolicy (simctl/adb proof), so the fix adds defense-in-depth for every filter-based reconnect window: an explicit targetId pin now persists the connected target's durable identity (deviceName + proven bundle identity) into the connect filters via a new stickyPinnedDeviceFilters helper; selectTarget gained an internal-only deviceName hard filter (never exposed on tool schemas) - a stale pinned targetId re-resolves ONLY within the pinned device AND only when a proven bundleId is pinned alongside, otherwise it refuses truthfully with candidates; same-name device ambiguity (multiple Metro device-connection id prefixes under one deviceName, hyphen-safe parse) refuses even on an exact id match because Metro restarts can recycle page ids; reload recovery carries the affinity through captureClientState/forceReconnect; cdp_run_e2e_suite reloads now pass the session platform so exact-device recovery actually engages. Deliberate choices a reviewer should not flag: refusals are warning-shaped with no new structured errorCode, matching the existing targetId-not-found contract; behavior without deviceName affinity is intentionally unchanged (old Metro without deviceName has no durable identity - matches pre-fix behavior); e2eReload omits platform when the session platform is missing/invalid rather than refusing, because those sessions are policy-protected. Includes a changeset bumping rn-dev-agent-plugin and rn-dev-agent-core (patch); dist and host-runtime artifacts are rebuilt and committed because unit tests import committed dist. 21 causal regression tests in gh-625-shared-metro-device-affinity.test.ts including a connection-level test driving the real discoverAndConnect filter-merge path against a live local WebSocket server.

## What Changed

- An explicit `targetId` pin now persists the connected target's durable identity (deviceName plus proven bundleId) into the connect filters via a new `stickyPinnedDeviceFilters` helper in `cdp-client.ts`/`connect.ts`, so every filter-based reconnect window keeps the session's device affinity instead of re-resolving freely across a shared Metro port.
- `selectTarget` gained an internal-only `deviceName` hard filter (never exposed on tool schemas): a stale pinned targetId re-resolves only within the pinned device and only when a proven bundleId is pinned alongside it; when the pinned device is absent, or a deviceName maps to multiple Metro device-connection id prefixes that the pinned bundle cannot disambiguate, discovery refuses truthfully with the candidate list rather than silently attaching to a sibling simulator. Metro id parsing is now hyphen-safe (device part split on the last hyphen).
- Reload recovery carries the affinity through `captureClientState`/`forceReconnect`, and `cdp_run_e2e_suite` reloads now pass the session platform so exact-device recovery actually engages; adds `gh-625-shared-metro-device-affinity.test.ts` (24 tests, including a connection-level test driving the real `discoverAndConnect` filter-merge path against a live local WebSocket server), a patch changeset for `rn-dev-agent-plugin` and `rn-dev-agent-core`, and the rebuilt dist/host-runtime artifacts the unit tests import.

Review left three informational notes, one still open: a single device can briefly expose two connections for the same bundle during an app restart, in which case the reconnect fail-closes with both candidates listed — the reload path's soft-reconnect attempts cover that transient window. Lint, tests, rebase, and push gates passed.

## Risk Assessment

✅ Low: The follow-up commit resolves all three prior findings without weakening the core safety property (same-named clones both running the pinned bundle still refuse), the page-id parse is now consistent with the documented hyphen-safe id format, dist artifacts match src, and three new causal tests pin the corrected behavior.

## Testing

Built the core package cleanly (worktree stayed clean, so the committed dist the tests import genuinely matches src), then ran the 24 causal GH-625 regression tests plus 93 tests across the neighboring discovery, connect and reload suites — all green with no regressions. For product-level evidence I drove the real code path (HTTP /json/list discovery, selectTarget, and a real WebSocket connect) against a fake Metro hosting two simulators on one port: pinning iPhone 17 Pro persisted deviceName + bundle identity, and after a reload churned every page id so the sibling iPhone 16 held the newest one, the pre-fix platform+bundle filters re-bound the WRONG device while the post-fix persisted pin re-bound iPhone 17 Pro with an explicit stale-pin warning; shutting down the pinned sim produced a truthful refusal listing the live sibling candidate, and same-name clones refused an ambiguous bind listing both connections. This change is CLI/MCP-tool-facing with no rendered UI surface, so the reviewer-visible artifact is a CLI transcript rather than a screenshot. The only gap: the e2eReload platform pass-through is a private closure in index.ts and is not directly unit-tested; I verified its necessity by inspecting the gate it feeds in reload.ts, whose downstream behavior the existing gh-523 tests cover.

<details>
<summary>Evidence: End-to-end shared-Metro reconnect transcript (pre-fix wrong-device bind vs post-fix pinned bind, plus both truthful refusals)</summary>

<code>Scenario: TWO simulators attached to ONE Metro port&#10;10-9 device=&#34;iPhone 16&#34; app=com.example.app&#10;12-3 device=&#34;iPhone 17 Pro&#34; app=com.example.app&#10;&#10;STEP 1 — cdp_connect { targetId: &#34;12-3&#34; } (pin iPhone 17 Pro)&#10;Connected to com.example.app (iPhone 17 Pro) on port 60569&#10;bound device : iPhone 17 Pro (target 12-3)&#10;session pin : {&#34;targetId&#34;:&#34;12-3&#34;,&#34;platform&#34;:&#34;ios&#34;,&#34;deviceName&#34;:&#34;iPhone 17 Pro&#34;,&#34;bundleId&#34;:&#34;com.example.app&#34;}&#10;&#10;STEP 2 — cdp_reload: page ids churn on BOTH sims&#10;13-9 device=&#34;iPhone 16&#34; app=com.example.app &lt;- sibling now holds the NEWEST page id&#10;14-1 device=&#34;iPhone 17 Pro&#34; app=com.example.app&#10;The pinned targetId &#34;12-3&#34; no longer exists.&#10;&#10;--- PRE-FIX (device affinity not persisted: platform+bundle only) ---&#10;re-bound to : iPhone 16 (target 13-9) &lt;-- WRONG DEVICE (issue #625)&#10;&#10;--- POST-FIX (auto-reconnect with the persisted session pin) ---&#10;Connected to com.example.app (iPhone 17 Pro) on port 60569. WARNING: Pinned targetId &#34;12-3&#34; is stale (Metro page ids change on reload); re-resolving on pinned device &#34;iPhone 17 Pro&#34;.&#10;re-bound to : iPhone 17 Pro (target 14-1) &lt;-- pinned device preserved&#10;session pin : {&#34;targetId&#34;:&#34;14-1&#34;,&#34;platform&#34;:&#34;ios&#34;,&#34;deviceName&#34;:&#34;iPhone 17 Pro&#34;,&#34;bundleId&#34;:&#34;com.example.app&#34;}&#10;&#10;STEP 3 — pinned simulator shut down; only the sibling remains (15-2 iPhone 16)&#10;Pinned device &#34;iPhone 17 Pro&#34; has no live CDP target on this Metro; refusing to silently bind a different device. Candidates: 15-2 title=&#34;com.example.app (iPhone 16)&#34; appId=&#34;com.example.app&#34; device=&#34;iPhone 16&#34; description=&#34;com.example.app&#34; platform=ios confidence=probed. Relaunch the app on the pinned device, or re-pin deliberately via cdp_targets + cdp_connect targetId.&#10;&#10;STEP 4 — same-name simulator clones (20-1 and 21-1, both &#34;iPhone 17 Pro&#34;)&#10;targets returned: 0&#10;Pinned device name &#34;iPhone 17 Pro&#34; matches 2 live Metro device connections and pinned bundleId &#34;com.example.app&#34; narrows them to 2; refusing an ambiguous bind. Candidates: 20-1 ...; 21-1 .... Re-pin deliberately via cdp_targets + cdp_connect targetId.</code>

```text

==============================================================================
Scenario: TWO simulators attached to ONE Metro port (fake Metro on 60569)
==============================================================================
Metro /json/list device connections:
  10-9   device="iPhone 16" app=com.example.app
  12-3   device="iPhone 17 Pro" app=com.example.app

==============================================================================
STEP 1 — user runs: cdp_connect { targetId: "12-3" }   (pin iPhone 17 Pro)
==============================================================================
Connected to com.example.app (iPhone 17 Pro) on port 60569
bound device : iPhone 17 Pro  (target 12-3)
session pin  : {"targetId":"12-3","platform":"ios","deviceName":"iPhone 17 Pro","bundleId":"com.example.app"}

==============================================================================
STEP 2 — cdp_reload: app restarts, Metro page ids churn on BOTH sims
==============================================================================
Metro /json/list after reload (sibling iPhone 16 now holds the NEWEST page id):
  13-9   device="iPhone 16" app=com.example.app
  14-1   device="iPhone 17 Pro" app=com.example.app
The pinned targetId "12-3" no longer exists.

--- PRE-FIX behavior (device affinity not persisted: platform+bundle only) ---
re-bound to  : iPhone 16  (target 13-9)  <-- WRONG DEVICE (issue #625)

--- POST-FIX behavior (auto-reconnect with the persisted session pin) ---
Connected to com.example.app (iPhone 17 Pro) on port 60569. WARNING: Pinned targetId "12-3" is stale (Metro page ids change on reload); re-resolving on pinned device "iPhone 17 Pro".
re-bound to  : iPhone 17 Pro  (target 14-1)  <-- pinned device preserved
session pin  : {"targetId":"14-1","platform":"ios","deviceName":"iPhone 17 Pro","bundleId":"com.example.app"}

==============================================================================
STEP 3 — pinned simulator is shut down; only the sibling remains
==============================================================================
Metro /json/list:
  15-2   device="iPhone 16" app=com.example.app

--- POST-FIX: auto-reconnect refuses truthfully instead of binding the sibling ---
Pinned device "iPhone 17 Pro" has no live CDP target on this Metro; refusing to silently bind a different device. Candidates: 15-2 title="com.example.app (iPhone 16)" appId="com.example.app" device="iPhone 16" description="com.example.app" platform=ios confidence=probed. Relaunch the app on the pinned device, or re-pin deliberately via cdp_targets + cdp_connect targetId.

==============================================================================
STEP 4 — same-name simulator clones (two Metro device connections, one name)
==============================================================================
  20-1   device="iPhone 17 Pro" app=com.example.app
  21-1   device="iPhone 17 Pro" app=com.example.app

targets returned: 0
Pinned device name "iPhone 17 Pro" matches 2 live Metro device connections and pinned bundleId "com.example.app" narrows them to 2; refusing an ambiguous bind. Candidates: 20-1 title="com.example.app (iPhone 17 Pro)" appId="com.example.app" device="iPhone 17 Pro" description="com.example.app" platform=ios confidence=probed; 21-1 title="com.example.app (iPhone 17 Pro)" appId="com.example.app" device="iPhone 17 Pro" description="com.example.app" platform=ios confidence=probed. Re-pin deliberately via cdp_targets + cdp_connect targetId.
```
</details>
<details>
<summary>Evidence: Demo driver script (fake Metro + real discoverExactPort/discoverAndConnect)</summary>

```text
// GH #625 end-to-end demo: two simulators on ONE Metro port.
// Drives the REAL discoverExactPort (HTTP /json/list fetch + selectTarget) and
// discoverAndConnect (real WebSocket handshake) against a fake Metro server.
import http from 'node:http';
import ws from '/Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZTG49ZB5Y1JCVETD0S72NFY/node_modules/ws/index.js';
const { WebSocketServer } = ws;
import { discoverExactPort } from '/Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZTG49ZB5Y1JCVETD0S72NFY/packages/rn-dev-agent-core/dist/cdp/discovery.js';
import { discoverAndConnect } from '/Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZTG49ZB5Y1JCVETD0S72NFY/packages/rn-dev-agent-core/dist/cdp/connect.js';

let PORT = 0;
let pages = [];

function target(id, deviceName, bundleId = 'com.example.app') {
  return {
    id,
    title: `${bundleId} (${deviceName})`,
    vm: 'Hermes',
    description: bundleId,
    appId: bundleId,
    deviceName,
    type: 'node',
    webSocketDebuggerUrl: `ws://127.0.0.1:${PORT}/inspector/debug?device=${id}`,
  };
}

const server = http.createServer((req, res) => {
  if (req.url?.startsWith('/json/list')) {
    res.setHeader('content-type', 'application/json');
    res.end(JSON.stringify(pages));
    return;
  }
  res.statusCode = 404;
  res.end('{}');
});
const wss = new WebSocketServer({ server });
const sockets = [];
wss.on('connection', (s) => sockets.push(s));

await new Promise((r) => server.listen(0, '127.0.0.1', r));
PORT = server.address().port;

function ctxFactory() {
  const state = { filters: {}, connected: null, ws: null, port: PORT, gen: 0 };
  const ctx = {
    isDisposed: () => false,
    isReconnecting: () => false,
    isSoftReconnectRequested: () => false,
    getState: () => 'disconnected',
    setState: () => {},
    getPort: () => state.port,
    setPort: (v) => (state.port = v),
    getConnectFilters: () => state.filters,
    setConnectFilters: (v) => (state.filters = v),
    getWs: () => state.ws,
    setWs: (ws) => (state.ws = ws),
    setHelpersInjected: () => {},
    setConnectedTarget: (t) => (state.connected = t),
    setConnectedAt: () => {},
    now: () => Date.now(),
    incrementConnectionGeneration: () => ++state.gen,
    evaluate: async () => ({ value: true }),
    sendWithTimeout: async () => ({}),
    handleMessage: () => {},
    handleClose: () => {},
    rejectAllPending: () => {},
    setup: async () => {},
    getProxyUrl: () => null,
  };
  return { ctx, state };
}

const line = (s = '') => console.log(s);
const hdr = (s) => {
  line();
  line('='.repeat(78));
  line(s);
  line('='.repeat(78));
};

hdr('Scenario: TWO simulators attached to ONE Metro port (fake Metro on ' + PORT + ')');
pages = [target('10-9', 'iPhone 16'), target('12-3', 'iPhone 17 Pro')];
line('Metro /json/list device connections:');
for (const p of pages) line(`  ${p.id.padEnd(6)} device="${p.deviceName}" app=${p.appId}`);

hdr('STEP 1 — user runs: cdp_connect { targetId: "12-3" }   (pin iPhone 17 Pro)');
const { ctx, state } = ctxFactory();
line(await discoverAndConnect(ctx, PORT, { targetId: '12-3' }, discoverExactPort));
line(`bound device : ${state.connected.deviceName}  (target ${state.connected.id})`);
line(`session pin  : ${JSON.stringify(state.filters)}`);

hdr('STEP 2 — cdp_reload: app restarts, Metro page ids churn on BOTH sims');
pages = [target('13-9', 'iPhone 16'), target('14-1', 'iPhone 17 Pro')];
line('Metro /json/list after reload (sibling iPhone 16 now holds the NEWEST page id):');
for (const p of pages) line(`  ${p.id.padEnd(6)} device="${p.deviceName}" app=${p.appId}`);
line('The pinned targetId "12-3" no longer exists.');

line();
line('--- PRE-FIX behavior (device affinity not persisted: platform+bundle only) ---');
const preFix = await discoverExactPort(PORT, { platform: 'ios', bundleId: 'com.example.app' });
line(`re-bound to  : ${preFix.targets[0].deviceName}  (target ${preFix.targets[0].id})  <-- WRONG DEVICE (issue #625)`);

line();
line('--- POST-FIX behavior (auto-reconnect with the persisted session pin) ---');
line(await discoverAndConnect(ctx, undefined, undefined, discoverExactPort));
line(`re-bound to  : ${state.connected.deviceName}  (target ${state.connected.id})  <-- pinned device preserved`);
line(`session pin  : ${JSON.stringify(state.filters)}`);

hdr('STEP 3 — pinned simulator is shut down; only the sibling remains');
pages = [target('15-2', 'iPhone 16')];
line('Metro /json/list:');
for (const p of pages) line(`  ${p.id.padEnd(6)} device="${p.deviceName}" app=${p.appId}`);
line();
line('--- POST-FIX: auto-reconnect refuses truthfully instead of binding the sibling ---');
try {
  await discoverAndConnect(ctx, undefined, undefined, discoverExactPort);
  line('!! connected anyway — REGRESSION');
} catch (err) {
  line(String(err.message ?? err));
}

hdr('STEP 4 — same-name simulator clones (two Metro device connections, one name)');
pages = [target('20-1', 'iPhone 17 Pro'), target('21-1', 'iPhone 17 Pro')];
for (const p of pages) line(`  ${p.id.padEnd(6)} device="${p.deviceName}" app=${p.appId}`);
line();
const ambiguous = await discoverExactPort(PORT, {
  targetId: '20-1',
  deviceName: 'iPhone 17 Pro',
  bundleId: 'com.example.app',
});
line(`targets returned: ${ambiguous.targets.length}`);
line(ambiguous.warning ?? '(no warning)');

line();
for (const s of sockets) s.terminate();
wss.close();
server.close();
process.exit(0);
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `packages/rn-dev-agent-core/src/cdp/discovery.ts:485` - The same-name ambiguity guard treats &#34;more than one Metro device-connection id prefix under one deviceName&#34; as &#34;two live devices share that name&#34;, but Metro&#39;s inspector proxy creates a device connection per runtime socket, not per physical device. One simulator running two debuggable apps (dev client + Expo Go, or a second RN app), or a simulator whose pre-restart device connection is still listed during the close window, produces two prefixes under a single deviceName. Failure scenario: session pinned to target `7-1` on &#34;iPhone 16 Pro&#34;; a second debuggable app on the same simulator registers device connection `9`; cdp_reload&#39;s recovery reconnect calls selectTarget with deviceName=&#34;iPhone 16 Pro&#34; and the still-live pinned id; devicePrefixes = {7, 9} so it returns targets: [] with &#34;matches 2 live Metro device connections&#34; and discoverAndConnect throws, even though the exact pinned targetId is live and the pinned bundleId would disambiguate. This is fail-closed (no sibling bind), but it converts a previously recoverable reload into a hard failure. The intent lists the ambiguity refusal as a deliberate decision, so confirm whether the single-device/multiple-apps case was in scope; a targeted relaxation would be to allow the bind when the pinned targetId is live AND the pinned bundleId matches exactly one of the ambiguous connections.
- ⚠️ `packages/rn-dev-agent-core/src/cdp/discovery.ts:615` - The new metroDeviceConnectionId helper documents that the device part of a Metro id may contain hyphens, but the candidate sort a few lines below still parses the page number with `id.split(&#39;-&#39;)[1]`. For a hyphenated device connection id the second segment is not the page number, so parseInt yields NaN for both operands, the page-desc ordering silently collapses, and selection falls through to lexicographic-ascending on the full id. Failure scenario: pinned device exposes ids `dev-abc-2` (stale page from before the reload) and `dev-abc-10` (fresh page); the stale pin re-resolves within the device (the path this PR newly enables) and the sort returns `dev-abc-10` before `dev-abc-2` only by luck of string compare - with `dev-abc-2` vs `dev-abc-11` it picks the stale page first. The __DEV__ probe loop usually falls through to the next candidate, so impact is a wasted connect attempt rather than a wrong bind, but the parse should match the helper: use `id.slice(id.lastIndexOf(&#39;-&#39;) + 1)`.
- ℹ️ `packages/rn-dev-agent-core/src/cdp-client.ts:81` - discoverAuthoritativeTarget deliberately clears targetId and preferredBundleId before delegating to discoverExactPort, because the policy&#39;s simctl/adb-proven resolver owns exact-device selection. The new deviceName filter is the same class of caller-supplied device hint but is not cleared, so it would hard-refuse inside selectTarget ahead of the authoritative resolver. Failure scenario is currently unreachable: policy sessions pass targetId: undefined through connectWithCurrentPolicy, so stickyPinnedDeviceFilters never captures a deviceName for a managed client and captured.deviceName is undefined in forceReconnect. Noting it as a latent inconsistency only - if a future path ever seeds deviceName on a policy-backed client, a stale or duplicated deviceName would refuse a connect the policy could have proven correct.

🔧 Fix: disambiguate same-name Metro connections and fix page-id parse
1 info still open:
- ℹ️ `packages/rn-dev-agent-core/src/cdp/discovery.ts:495` - The bundle-based disambiguation resolves the one-device/multiple-apps case, but a residual sub-case remains: when a single device briefly exposes two connections for the SAME bundle - the pre-restart device socket still listed by Metro alongside the newly-registered one - bundleScoped spans both prefixes, bundleConnections.size is 2, and the reconnect refuses. Concrete path: pinned session on &#34;iPhone 17 Pro&#34; with bundleId com.example.app; the app is force-quit and relaunched; during the window before Metro drops the closed socket, /json lists `7-1` (dead) and `9-1` (live), both com.example.app; forceReconnect&#39;s selectTarget call returns targets: [] with &#34;narrows them to 2&#34;. No action recommended: this is fail-closed with candidates listed, which is what the acceptance criteria ask for, Metro metadata genuinely cannot prove which connection is live, and the reload path&#39;s five soft-reconnect attempts across a 30s deadline (reload.ts SOFT_RECONNECT_ATTEMPTS / SOFT_RECONNECT_DEADLINE_MS) cover the transient window before forceReconnect runs. Recording it so the behavior is known rather than surprising.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx tsc` in packages/rn-dev-agent-core (clean build; worktree stayed clean, confirming committed dist matches src since tests import dist)</code>
- <code>`node --test test/unit/gh-625-shared-metro-device-affinity.test.ts` — 24/24 pass, including the live local-WebSocket connection-level test driving the real discoverAndConnect filter-merge path</code>
- <code>`node --test test/unit/cdp-discovery.test.js test/unit/cdp-connect.test.js test/unit/gh-59-5-sticky-platform.test.js test/unit/gh-588-ios-platform-affinity.test.ts test/unit/gh-584-registered-cdp-connect.test.ts test/unit/gh-589-android-session-replay.test.ts test/unit/reload-force-retry.test.js test/unit/gh-184-picker-blocking-probe.test.js` — 87/87 pass (neighboring discovery/connect/reload regression surface)</code>
- <code>`node --test test/unit/gh-523-reload-relaunch-chain.test.ts` — 6/6 pass (reload recovery / authority-target chain)</code>
- <code>Manual end-to-end demo: `node gh625-shared-metro-demo.mjs` — fake Metro HTTP `/json/list` + WebSocket server on one port hosting two simulators, driving the real `discoverExactPort` and `discoverAndConnect`; exercised pin → reload id churn → auto-reconnect (pre-fix vs post-fix), pinned device offline refusal, and same-name clone ambiguity refusal</code>
- <code>Code inspection of the e2eReload platform pass-through against its gate at `packages/rn-dev-agent-core/src/tools/reload.ts:409` (`args.platform &amp;&amp; args.deviceId &amp;&amp; args.appId`), confirming the omitted platform previously disabled exact-device recovery</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `apps/docs-site/src/content/docs/troubleshooting.mdx` - Judgment call, no edit made: the change adds new user-facing refusal texts (pinned device absent, same-name device ambiguity, stale pin without proven bundleId), but troubleshooting.mdx owns structured errorCode refusals only. Per the stated design these refusals are intentionally warning-shaped with no new errorCode and are self-describing (they list candidates and the exact next action: re-pin via cdp_targets + cdp_connect targetId), so adding a troubleshooting section would create a duplicate prose copy of the message rather than document an owned contract. Flagging so a maintainer can decide if a shared-Metro multi-simulator section is wanted later.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
