### PR TITLE
fix(rn-fast-runner): key the splash precondition on a stable identifier

### DIFF
--- a/.changeset/runner-splash-identifier-contract.md
+++ b/.changeset/runner-splash-identifier-contract.md
@@ -1,0 +1,5 @@
+---
+"rn-dev-agent-plugin": patch
+---
+
+Expose a stable `runner-splash-title` accessibility identifier on the iOS fast runner's splash screen so launch checks no longer depend on display copy.

--- a/packages/claude-plugin/scripts/rn-fast-runner/IMPORT_NOTES.md
+++ b/packages/claude-plugin/scripts/rn-fast-runner/IMPORT_NOTES.md
@@ -30,6 +30,10 @@ namespace as a single import-time sweep. Final names:
 | Bundle id | `dev.lykhoyda.rndevagent.fastrunner` |
 | Splash text | `rn-dev-agent fast runner` |
 
+Post-import: the splash was later split into `rn-dev-agent` / `fast runner`
+lines, and the title now carries the stable `runner-splash-title`
+accessibility identifier that launch-contract tests key on.
+
 ## Dropped at import time
 
 - `RunnerTests+ScreenRecorder.swift` — our `device_record` uses `xcrun simctl io recordVideo` directly

--- a/packages/claude-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunner/ContentView.swift
+++ b/packages/claude-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunner/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
             Text("rn-dev-agent")
                 .font(.title2)
                 .fontWeight(.semibold)
+                .accessibilityIdentifier("runner-splash-title")
             Text("fast runner")
                 .font(.body)
                 .foregroundStyle(.secondary)

--- a/packages/claude-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RunnerSplashContract.swift
+++ b/packages/claude-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RunnerSplashContract.swift
@@ -1,0 +1,10 @@
+//
+//  RunnerSplashContract.swift
+//  RnFastRunnerUITests
+//
+
+// Stable splash-title identifier set in ContentView.swift — tests key on it
+// instead of display copy so branding edits cannot break preconditions.
+enum RunnerSplashContract {
+  static let titleIdentifier = "runner-splash-title"
+}

--- a/packages/claude-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RunnerSplashContractTests.swift
+++ b/packages/claude-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RunnerSplashContractTests.swift
@@ -1,0 +1,25 @@
+//
+//  RunnerSplashContractTests.swift
+//  RnFastRunnerUITests
+//
+//  CI-run pin for the splash-identifier launch contract SnapshotForegroundRegressionTest's precondition depends on.
+//
+
+import XCTest
+
+final class RunnerSplashContractTests: XCTestCase {
+  @MainActor
+  func testLaunchedRunnerExposesSplashIdentifier() {
+    let app = XCUIApplication()
+    app.launch()
+    XCTAssertEqual(
+      app.state,
+      .runningForeground,
+      "runner app should be foreground after launch"
+    )
+    XCTAssertTrue(
+      app.staticTexts[RunnerSplashContract.titleIdentifier].waitForExistence(timeout: 10),
+      "launched runner must expose splash identifier \"\(RunnerSplashContract.titleIdentifier)\""
+    )
+  }
+}

--- a/packages/claude-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/SnapshotForegroundRegressionTest.swift
+++ b/packages/claude-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/SnapshotForegroundRegressionTest.swift
@@ -14,7 +14,7 @@ import XCTest
 
 final class SnapshotForegroundRegressionTest: RnFastRunnerTests {
   private static let testAppBundleId = "com.rndevagent.testapp"
-  private static let runnerSplashText = "rn-dev-agent fast runner"
+  private static let runnerSplashIdentifier = RunnerSplashContract.titleIdentifier
   private static let expectedTestAppMarkers: [String] = [
     "home-welcome",
     "home-search-btn",
@@ -46,11 +46,12 @@ final class SnapshotForegroundRegressionTest: RnFastRunnerTests {
 
     // Sanity-check that the runner's splash UI is actually visible — if this
     // fails the regression test is meaningless because we cannot prove the
-    // dispatcher had to activate a different target.
-    let runnerSplash = app.staticTexts[Self.runnerSplashText]
+    // dispatcher had to activate a different target. Keyed on the stable
+    // splash identifier, not display copy.
+    let runnerSplash = app.staticTexts[Self.runnerSplashIdentifier]
     XCTAssertTrue(
-      runnerSplash.waitForExistence(timeout: 5),
-      "runner splash UI (\"\(Self.runnerSplashText)\") should be visible before the snapshot call"
+      runnerSplash.waitForExistence(timeout: 10),
+      "runner splash UI (identifier \"\(Self.runnerSplashIdentifier)\") should be visible before the snapshot call"
     )
 
     // Step 2: Verify the test-app is installed on this simulator. The test
@@ -125,12 +126,12 @@ final class SnapshotForegroundRegressionTest: RnFastRunnerTests {
       ].joined(separator: "|")
     }.joined(separator: "\n")
 
-    // Step 5: The response must NOT contain the runner's splash text — if it
-    // does, the dispatcher read the runner's UI instead of the test-app's
-    // (the original B155 bug).
+    // Step 5: The response must NOT contain the runner's splash identifier —
+    // if it does, the dispatcher read the runner's UI instead of the
+    // test-app's (the original B155 bug).
     XCTAssertFalse(
-      nodeBlob.contains(Self.runnerSplashText),
-      "B155 regression: snapshot returned the runner's UI (\"\(Self.runnerSplashText)\") instead of the test-app's tree.\nnodes:\n\(nodeBlob.prefix(2000))"
+      nodeBlob.contains(Self.runnerSplashIdentifier),
+      "B155 regression: snapshot returned the runner's UI (identifier \"\(Self.runnerSplashIdentifier)\") instead of the test-app's tree.\nnodes:\n\(nodeBlob.prefix(2000))"
     )
 
     // Step 6: The response MUST contain at least one test-app marker — proves

--- a/packages/codex-plugin/scripts/rn-fast-runner/IMPORT_NOTES.md
+++ b/packages/codex-plugin/scripts/rn-fast-runner/IMPORT_NOTES.md
@@ -30,6 +30,10 @@ namespace as a single import-time sweep. Final names:
 | Bundle id | `dev.lykhoyda.rndevagent.fastrunner` |
 | Splash text | `rn-dev-agent fast runner` |
 
+Post-import: the splash was later split into `rn-dev-agent` / `fast runner`
+lines, and the title now carries the stable `runner-splash-title`
+accessibility identifier that launch-contract tests key on.
+
 ## Dropped at import time
 
 - `RunnerTests+ScreenRecorder.swift` — our `device_record` uses `xcrun simctl io recordVideo` directly

--- a/packages/codex-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunner/ContentView.swift
+++ b/packages/codex-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunner/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
             Text("rn-dev-agent")
                 .font(.title2)
                 .fontWeight(.semibold)
+                .accessibilityIdentifier("runner-splash-title")
             Text("fast runner")
                 .font(.body)
                 .foregroundStyle(.secondary)

--- a/packages/codex-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RunnerSplashContract.swift
+++ b/packages/codex-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RunnerSplashContract.swift
@@ -1,0 +1,10 @@
+//
+//  RunnerSplashContract.swift
+//  RnFastRunnerUITests
+//
+
+// Stable splash-title identifier set in ContentView.swift — tests key on it
+// instead of display copy so branding edits cannot break preconditions.
+enum RunnerSplashContract {
+  static let titleIdentifier = "runner-splash-title"
+}

--- a/packages/codex-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RunnerSplashContractTests.swift
+++ b/packages/codex-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RunnerSplashContractTests.swift
@@ -1,0 +1,25 @@
+//
+//  RunnerSplashContractTests.swift
+//  RnFastRunnerUITests
+//
+//  CI-run pin for the splash-identifier launch contract SnapshotForegroundRegressionTest's precondition depends on.
+//
+
+import XCTest
+
+final class RunnerSplashContractTests: XCTestCase {
+  @MainActor
+  func testLaunchedRunnerExposesSplashIdentifier() {
+    let app = XCUIApplication()
+    app.launch()
+    XCTAssertEqual(
+      app.state,
+      .runningForeground,
+      "runner app should be foreground after launch"
+    )
+    XCTAssertTrue(
+      app.staticTexts[RunnerSplashContract.titleIdentifier].waitForExistence(timeout: 10),
+      "launched runner must expose splash identifier \"\(RunnerSplashContract.titleIdentifier)\""
+    )
+  }
+}

--- a/packages/codex-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/SnapshotForegroundRegressionTest.swift
+++ b/packages/codex-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/SnapshotForegroundRegressionTest.swift
@@ -14,7 +14,7 @@ import XCTest
 
 final class SnapshotForegroundRegressionTest: RnFastRunnerTests {
   private static let testAppBundleId = "com.rndevagent.testapp"
-  private static let runnerSplashText = "rn-dev-agent fast runner"
+  private static let runnerSplashIdentifier = RunnerSplashContract.titleIdentifier
   private static let expectedTestAppMarkers: [String] = [
     "home-welcome",
     "home-search-btn",
@@ -46,11 +46,12 @@ final class SnapshotForegroundRegressionTest: RnFastRunnerTests {
 
     // Sanity-check that the runner's splash UI is actually visible — if this
     // fails the regression test is meaningless because we cannot prove the
-    // dispatcher had to activate a different target.
-    let runnerSplash = app.staticTexts[Self.runnerSplashText]
+    // dispatcher had to activate a different target. Keyed on the stable
+    // splash identifier, not display copy.
+    let runnerSplash = app.staticTexts[Self.runnerSplashIdentifier]
     XCTAssertTrue(
-      runnerSplash.waitForExistence(timeout: 5),
-      "runner splash UI (\"\(Self.runnerSplashText)\") should be visible before the snapshot call"
+      runnerSplash.waitForExistence(timeout: 10),
+      "runner splash UI (identifier \"\(Self.runnerSplashIdentifier)\") should be visible before the snapshot call"
     )
 
     // Step 2: Verify the test-app is installed on this simulator. The test
@@ -125,12 +126,12 @@ final class SnapshotForegroundRegressionTest: RnFastRunnerTests {
       ].joined(separator: "|")
     }.joined(separator: "\n")
 
-    // Step 5: The response must NOT contain the runner's splash text — if it
-    // does, the dispatcher read the runner's UI instead of the test-app's
-    // (the original B155 bug).
+    // Step 5: The response must NOT contain the runner's splash identifier —
+    // if it does, the dispatcher read the runner's UI instead of the
+    // test-app's (the original B155 bug).
     XCTAssertFalse(
-      nodeBlob.contains(Self.runnerSplashText),
-      "B155 regression: snapshot returned the runner's UI (\"\(Self.runnerSplashText)\") instead of the test-app's tree.\nnodes:\n\(nodeBlob.prefix(2000))"
+      nodeBlob.contains(Self.runnerSplashIdentifier),
+      "B155 regression: snapshot returned the runner's UI (identifier \"\(Self.runnerSplashIdentifier)\") instead of the test-app's tree.\nnodes:\n\(nodeBlob.prefix(2000))"
     )
 
     // Step 6: The response MUST contain at least one test-app marker — proves

--- a/packages/rn-fast-runner/IMPORT_NOTES.md
+++ b/packages/rn-fast-runner/IMPORT_NOTES.md
@@ -30,6 +30,10 @@ namespace as a single import-time sweep. Final names:
 | Bundle id | `dev.lykhoyda.rndevagent.fastrunner` |
 | Splash text | `rn-dev-agent fast runner` |
 
+Post-import: the splash was later split into `rn-dev-agent` / `fast runner`
+lines, and the title now carries the stable `runner-splash-title`
+accessibility identifier that launch-contract tests key on.
+
 ## Dropped at import time
 
 - `RunnerTests+ScreenRecorder.swift` — our `device_record` uses `xcrun simctl io recordVideo` directly

--- a/packages/rn-fast-runner/RnFastRunner/RnFastRunner/ContentView.swift
+++ b/packages/rn-fast-runner/RnFastRunner/RnFastRunner/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
             Text("rn-dev-agent")
                 .font(.title2)
                 .fontWeight(.semibold)
+                .accessibilityIdentifier("runner-splash-title")
             Text("fast runner")
                 .font(.body)
                 .foregroundStyle(.secondary)

--- a/packages/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RunnerSplashContract.swift
+++ b/packages/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RunnerSplashContract.swift
@@ -1,0 +1,10 @@
+//
+//  RunnerSplashContract.swift
+//  RnFastRunnerUITests
+//
+
+// Stable splash-title identifier set in ContentView.swift — tests key on it
+// instead of display copy so branding edits cannot break preconditions.
+enum RunnerSplashContract {
+  static let titleIdentifier = "runner-splash-title"
+}

--- a/packages/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RunnerSplashContractTests.swift
+++ b/packages/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/RunnerSplashContractTests.swift
@@ -1,0 +1,25 @@
+//
+//  RunnerSplashContractTests.swift
+//  RnFastRunnerUITests
+//
+//  CI-run pin for the splash-identifier launch contract SnapshotForegroundRegressionTest's precondition depends on.
+//
+
+import XCTest
+
+final class RunnerSplashContractTests: XCTestCase {
+  @MainActor
+  func testLaunchedRunnerExposesSplashIdentifier() {
+    let app = XCUIApplication()
+    app.launch()
+    XCTAssertEqual(
+      app.state,
+      .runningForeground,
+      "runner app should be foreground after launch"
+    )
+    XCTAssertTrue(
+      app.staticTexts[RunnerSplashContract.titleIdentifier].waitForExistence(timeout: 10),
+      "launched runner must expose splash identifier \"\(RunnerSplashContract.titleIdentifier)\""
+    )
+  }
+}

--- a/packages/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/SnapshotForegroundRegressionTest.swift
+++ b/packages/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/SnapshotForegroundRegressionTest.swift
@@ -14,7 +14,7 @@ import XCTest
 
 final class SnapshotForegroundRegressionTest: RnFastRunnerTests {
   private static let testAppBundleId = "com.rndevagent.testapp"
-  private static let runnerSplashText = "rn-dev-agent fast runner"
+  private static let runnerSplashIdentifier = RunnerSplashContract.titleIdentifier
   private static let expectedTestAppMarkers: [String] = [
     "home-welcome",
     "home-search-btn",
@@ -46,11 +46,12 @@ final class SnapshotForegroundRegressionTest: RnFastRunnerTests {
 
     // Sanity-check that the runner's splash UI is actually visible — if this
     // fails the regression test is meaningless because we cannot prove the
-    // dispatcher had to activate a different target.
-    let runnerSplash = app.staticTexts[Self.runnerSplashText]
+    // dispatcher had to activate a different target. Keyed on the stable
+    // splash identifier, not display copy.
+    let runnerSplash = app.staticTexts[Self.runnerSplashIdentifier]
     XCTAssertTrue(
-      runnerSplash.waitForExistence(timeout: 5),
-      "runner splash UI (\"\(Self.runnerSplashText)\") should be visible before the snapshot call"
+      runnerSplash.waitForExistence(timeout: 10),
+      "runner splash UI (identifier \"\(Self.runnerSplashIdentifier)\") should be visible before the snapshot call"
     )
 
     // Step 2: Verify the test-app is installed on this simulator. The test
@@ -125,12 +126,12 @@ final class SnapshotForegroundRegressionTest: RnFastRunnerTests {
       ].joined(separator: "|")
     }.joined(separator: "\n")
 
-    // Step 5: The response must NOT contain the runner's splash text — if it
-    // does, the dispatcher read the runner's UI instead of the test-app's
-    // (the original B155 bug).
+    // Step 5: The response must NOT contain the runner's splash identifier —
+    // if it does, the dispatcher read the runner's UI instead of the
+    // test-app's (the original B155 bug).
     XCTAssertFalse(
-      nodeBlob.contains(Self.runnerSplashText),
-      "B155 regression: snapshot returned the runner's UI (\"\(Self.runnerSplashText)\") instead of the test-app's tree.\nnodes:\n\(nodeBlob.prefix(2000))"
+      nodeBlob.contains(Self.runnerSplashIdentifier),
+      "B155 regression: snapshot returned the runner's UI (identifier \"\(Self.runnerSplashIdentifier)\") instead of the test-app's tree.\nnodes:\n\(nodeBlob.prefix(2000))"
     )
 
     // Step 6: The response MUST contain at least one test-app marker — proves


### PR DESCRIPTION
## Intent

Fix GitHub issue #404: SnapshotForegroundRegressionTest.testForegroundSnapshotReturnsTestAppTree had a broken splash-visibility sanity precondition (reported on iPhone 16 Pro / iOS 18.5) even though the B155 foreground-snapshot behavior itself passes. Task required diagnostic rigor: reproduce the real XCTest path, separate launch trigger / OS masking / visible assertion, compare against a proven path or history, test the smallest counterfactual, and seek disconfirming evidence before assigning cause; issue evidence proved the failure deterministic 3/3 with RN_QUIESCENCE_FORCE_UNAVAILABLE=1 so the #384 quiescence swizzle must not be blamed. Diagnosis outcome: the issue's 'iOS 18.5 accessibility masking' hypothesis is disproven — commit 8345f4b6 (2026-05-15, branding strip) split the single Text("rn-dev-agent fast runner") splash into two Text views ('rn-dev-agent' / 'fast runner') three hours after the B155 test landed asserting the combined staticText, and only verified a compile, so the precondition has failed on every OS since; reproduced byte-identically on iOS 26.4 (no iOS 18.5 runtime exists on this host — stated limitation, not equivalent live evidence for 18.5). Fix (deliberate decisions): make the narrowest robust correction WITHOUT weakening the B155 contract — prefer a stable observable contract over static splash-text accessibility. ContentView.swift now exposes a stable 'runner-splash-title' accessibilityIdentifier on the splash title (shipped runner behavior, hence a one-sentence changeset bumping rn-dev-agent-plugin only; core is untouched). The regression test's precondition keys on that identifier with the wait window deliberately widened 5s->10s per the issue's fix direction, and still asserts app.state == runningForeground so it fails meaningfully when launch truly fails. Step 5's negative B155 assertion had become vacuous (it searched the snapshot blob for the removed combined label) and now keys on the identifier, restoring its discriminating power; step 6's positive marker check is unchanged. New CI-run RunnerSplashContractTests pins the launch/splash-identifier contract with no test-app dependency (test-native-ios.sh is a skip-list so the new class runs automatically in CI); this is the discriminating regression coverage the repo infrastructure permits. RunnerSplashContract constant is deliberately test-target-owned while ContentView carries the literal, so identifier drift on either side fails the test. IMPORT_NOTES.md keeps the historical import-time splash entry and documents the split + identifier as an explicit post-import note (provenance accuracy). Host-package runner copies under packages/claude-plugin and packages/codex-plugin are regenerated via build:host-runtimes as required — large mirrored diff is expected. Full B155 end-to-end (steps 2-6) could not be run locally because com.rndevagent.testapp has no prebuilt binary on this host; the issue's own device matrix already proved the B155 core green and the dispatcher is untouched. Validation already run: new contract test passes on iOS 26.4 sim, regression-test precondition now passes (only the environmental test-app-missing failure remains, which is why CI skips that class), unit suite 4906/4906, format:check, lint, check-agent-package-sync, check-typescript-only, check-dist-fresh all green. Per repo convention no AI-attribution footers in commits/PR bodies, changeset is a single consumer-facing sentence, no tracker IDs in source comments, no multiline comment narration.

## What Changed

- `ContentView.swift` now sets a stable `runner-splash-title` accessibility identifier on the splash title, so launch checks no longer depend on display copy — the branding split into separate `rn-dev-agent` / `fast runner` `Text` views had silently broken the old combined-string lookup.
- `SnapshotForegroundRegressionTest` keys its step-1 splash precondition on that identifier (wait window widened 5s → 10s) while still asserting `app.state == .runningForeground`, and step 5's negative B155 assertion — which had become vacuous by searching the snapshot blob for the removed combined label — now keys on the identifier too, restoring its discriminating power.
- Added a test-target-owned `RunnerSplashContract` constant plus a new `RunnerSplashContractTests` class that pins the launch/splash-identifier contract with no test-app dependency, so it runs in CI (`test-native-ios.sh` is a skip list); `IMPORT_NOTES.md` records the splash split and identifier as a post-import note, and the host-package runner copies under `packages/claude-plugin` and `packages/codex-plugin` are regenerated via `build:host-runtimes`.

The pipeline's Review note is accurate: CI pins only the new contract test, since the repaired precondition lives in a class CI skips for lack of a prebuilt `com.rndevagent.testapp`. Full B155 steps 2–6 could not run locally for the same reason; the dispatcher itself is untouched.

## Risk Assessment

✅ Low: Narrow, additive change — one accessibility identifier on the runner splash plus test-side rekeying and a new CI-run contract test — with the negative B155 assertion verified discriminating again against the snapshot serializer, no other consumers of the old splash copy, and host mirrors and changeset scope in sync.

## Testing

Ran the new RunnerSplashContractTests plus a temporary counterfactual XCUITest on a booted iPhone 17 simulator (iOS 26.4; no iOS 18.5 runtime exists on this host, so 18.5 is not directly re-proven): the counterfactual confirms the old combined "rn-dev-agent fast runner" staticText is genuinely absent — the real cause of #404 — while the new runner-splash-title identifier is present with the app in runningForeground. Also executed the full SnapshotForegroundRegressionTest, where the previously broken step-1 precondition now clears in about a second and the only remaining failure is the expected environmental "Failed to launch com.rndevagent.testapp" (no prebuilt test app locally, which is why CI skips that class). Captured a simulator screenshot of the rendered splash showing the two-line branding that broke the old lookup, verified step 5's negative assertion is non-vacuous because the snapshot node blob includes node.identifier, and confirmed the claude-plugin/codex-plugin runner mirrors are byte-identical to the source package. Transient build output, the temp test file, and the installed app were removed and the simulator shut down; the worktree is clean.

- Evidence: iOS simulator screenshot: runner splash with two-line branding (local file: <code>/var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/no-mistakes-evidence/01KZXJF22M65RDAK7XBXJN1YJT/runner-splash.png</code>)
<details>
<summary>Evidence: Splash-contract test + counterfactual evidence</summary>

<code>Test Case &#39;-[RnFastRunnerUITests.RunnerSplashContractTests testLaunchedRunnerExposesSplashIdentifier]&#39; passed (22.925 seconds).&#10;EVIDENCE old-combined-staticText-exists=false&#10;EVIDENCE identifier-staticText-exists=true&#10;EVIDENCE app-state-runningForeground=true&#10;EVIDENCE visible-staticTexts:&#10;id=runner-splash-title label=rn-dev-agent&#10;id= label=fast runner&#10;id= label=XCUITest bridge&#10;Test Case &#39;-[RnFastRunnerUITests.TempSplashEvidenceTests testCounterfactualOldSplashTextVersusIdentifier]&#39; passed (10.350 seconds).</code>

```text
== RunnerSplashContractTests + counterfactual (iPhone 17 sim, iOS 26.4) ==
Test Case '-[RnFastRunnerUITests.RunnerSplashContractTests testLaunchedRunnerExposesSplashIdentifier]' passed (22.925 seconds).
EVIDENCE old-combined-staticText-exists=false
EVIDENCE identifier-staticText-exists=true
EVIDENCE app-state-runningForeground=true
EVIDENCE visible-staticTexts:
Test Case '-[RnFastRunnerUITests.TempSplashEvidenceTests testCounterfactualOldSplashTextVersusIdentifier]' passed (10.350 seconds).

== SnapshotForegroundRegressionTest: precondition now passes, only test-app-missing remains ==
2026-08-13 14:54:56.680 xcodebuild[42332:215372429] [MT] IDELaunchParametersSnapshot: no debugger version
    t =     4.29s         Setting up automation session
    t =     6.46s Waiting 10.0s for "runner-splash-title" StaticText to exist
    t =     7.50s     Checking `Expect predicate `existsNoRetry == 1` for object "runner-splash-title" StaticText`
    t =     7.50s         Checking existence of `"runner-splash-title" StaticText`
    t =     7.56s Open com.rndevagent.testapp
    t =     7.56s     Launch com.rndevagent.testapp
<unknown>:0: error: -[RnFastRunnerUITests.SnapshotForegroundRegressionTest testForegroundSnapshotReturnsTestAppTree] : Failed to launch com.rndevagent.testapp: The request to open "com.rndevagent.testapp" failed. (Underlying Error: The operation couldn’t be completed. Application info provider (FBSApplicationLibrary) returned nil for "com.rndevagent.testapp")
    t =     7.62s Tear Down
Test Case '-[RnFastRunnerUITests.SnapshotForegroundRegressionTest testForegroundSnapshotReturnsTestAppTree]' failed (7.825 seconds).
```
</details>
<details>
<summary>Evidence: SnapshotForegroundRegressionTest: precondition passes, only test-app-missing remains</summary>

<code>t = 6.46s Waiting 10.0s for &#34;runner-splash-title&#34; StaticText to exist&#10;t = 7.50s Checking existence of `&#34;runner-splash-title&#34; StaticText`&#10;t = 7.56s Open com.rndevagent.testapp&#10;&lt;unknown&gt;:0: error: ... Failed to launch com.rndevagent.testapp: Application info provider (FBSApplicationLibrary) returned nil</code>

```text
Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild test -project RnFastRunner.xcodeproj -scheme RnFastRunner -destination id=4542C5DB-AFBA-4B3C-95CD-D6702A718BB6 -derivedDataPath ../build/DerivedData-native-tests CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=YES "SWIFT_ACTIVE_COMPILATION_CONDITIONS=DEBUG RN_FAST_RUNNER_TEST_FAULTS" "-only-testing:RnFastRunnerUITests/SnapshotForegroundRegressionTest"

Build settings from command line:
    CODE_SIGN_IDENTITY = 
    CODE_SIGNING_ALLOWED = NO
    CODE_SIGNING_REQUIRED = NO
    ONLY_ACTIVE_ARCH = YES
    SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG RN_FAST_RUNNER_TEST_FAULTS

note: Using codesigning identity override: 
ComputePackagePrebuildTargetDependencyGraph

Prepare packages

CreateBuildRequest

SendProjectDescription

CreateBuildOperation

ComputeTargetDependencyGraph
note: Building targets in dependency order
note: Target dependency graph (2 targets)
    Target 'RnFastRunnerUITests' in project 'RnFastRunner'
        ➜ Explicit dependency on target 'RnFastRunner' in project 'RnFastRunner'
    Target 'RnFastRunner' in project 'RnFastRunner' (no dependencies)

GatherProvisioningInputs

CreateBuildDescription

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/usr/bin/actool --print-asset-tag-combinations --output-format xml1 /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/RnFastRunner/RnFastRunner/Assets.xcassets

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -v -E -dM -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.4.sdk -x c -c /dev/null

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -v -E -dM -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.4.sdk -x objective-c -c /dev/null

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -v -E -dM -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.4.sdk -x c -c /dev/null

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/usr/bin/actool --version --output-format xml1

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld -version_details

Build description signature: 7cc480610ef4f8ab79c62c0426629a8a
Build description path: /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex/XCBuildData/7cc480610ef4f8ab79c62c0426629a8a.xcbuilddata
ClangStatCache /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.4.sdk /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/SDKStatCaches.noindex/iphonesimulator26.4-23E237-686eebb5dc1d8ecb277353a59184f4aa.sdkstatcache
    cd /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/RnFastRunner/RnFastRunner.xcodeproj
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.4.sdk -o /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/SDKStatCaches.noindex/iphonesimulator26.4-23E237-686eebb5dc1d8ecb277353a59184f4aa.sdkstatcache

ProcessInfoPlistFile /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunner.app/Info.plist /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex/RnFastRunner.build/Debug-iphonesimulator/RnFastRunner.build/empty-RnFastRunner.plist (in target 'RnFastRunner' from project 'RnFastRunner')
    cd /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/RnFastRunner
    builtin-infoPlistUtility /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex/RnFastRunner.build/Debug-iphonesimulator/RnFastRunner.build/empty-RnFastRunner.plist -producttype com.apple.product-type.application -genpkginfo /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunner.app/PkgInfo -expandbuildsettings -format binary -platform iphonesimulator -additionalcontentfile /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex/RnFastRunner.build/Debug-iphonesimulator/RnFastRunner.build/assetcatalog_generated_info.plist -o /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunner.app/Info.plist

CopySwiftLibs /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunner.app (in target 'RnFastRunner' from project 'RnFastRunner')
    cd /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/RnFastRunner
    builtin-swiftStdLibTool --copy --verbose --scan-executable /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunner.app/RnFastRunner.debug.dylib --scan-folder /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunner.app/Frameworks --scan-folder /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunner.app/PlugIns --scan-folder /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunner.app/SystemExtensions --scan-folder /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunner.app/Extensions --platform iphonesimulator --toolchain /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain --destination /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunner.app/Frameworks --strip-bitcode --strip-bitcode-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/bitcode_strip --emit-dependency-info /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex/RnFastRunner.build/Debug-iphonesimulator/RnFastRunner.build/SwiftStdLibToolInputDependenc

... [187 bytes truncated] ...

YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunnerUITests-Runner.app/PlugIns/RnFastRunnerUITests.xctest/Info.plist /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex/RnFastRunner.build/Debug-iphonesimulator/RnFastRunnerUITests.build/empty-RnFastRunnerUITests.plist (in target 'RnFastRunnerUITests' from project 'RnFastRunner')
    cd /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/RnFastRunner
    builtin-infoPlistUtility /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex/RnFastRunner.build/Debug-iphonesimulator/RnFastRunnerUITests.build/empty-RnFastRunnerUITests.plist -producttype com.apple.product-type.bundle.ui-testing -expandbuildsettings -format binary -platform iphonesimulator -additionalcontentfile /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex/RnFastRunner.build/Debug-iphonesimulator/RnFastRunnerUITests.build/assetcatalog_generated_info.plist -additionalcontentfile /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex/RnFastRunner.build/Debug-iphonesimulator/RnFastRunnerUITests.build/ProductTypeInfoPlistAdditions.plist -o /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunnerUITests-Runner.app/PlugIns/RnFastRunnerUITests.xctest/Info.plist

CopySwiftLibs /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunnerUITests-Runner.app/PlugIns/RnFastRunnerUITests.xctest (in target 'RnFastRunnerUITests' from project 'RnFastRunner')
    cd /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/RnFastRunner
    builtin-swiftStdLibTool --copy --verbose --scan-executable /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunnerUITests-Runner.app/PlugIns/RnFastRunnerUITests.xctest/RnFastRunnerUITests --scan-folder /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunnerUITests-Runner.app/PlugIns/RnFastRunnerUITests.xctest/Frameworks --scan-folder /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunnerUITests-Runner.app/PlugIns/RnFastRunnerUITests.xctest/PlugIns --scan-folder /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunnerUITests-Runner.app/PlugIns/RnFastRunnerUITests.xctest/SystemExtensions --scan-folder /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunnerUITests-Runner.app/PlugIns/RnFastRunnerUITests.xctest/Extensions --platform iphonesimulator --toolchain /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain --destination /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunnerUITests-Runner.app/PlugIns/RnFastRunnerUITests.xctest/Frameworks --strip-bitcode --scan-executable /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/usr/lib/libXCTestSwiftSupport.dylib --strip-bitcode-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/bitcode_strip --emit-dependency-info /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex/RnFastRunner.build/Debug-iphonesimulator/RnFastRunnerUITests.build/SwiftStdLibToolInputDependencies.dep --filter-for-swift-os
Ignoring --strip-bitcode because --sign was not passed

2026-08-13 14:54:51.083614+0200 RnFastRunnerUITests-Runner[47893:215381864] [Default] Running tests...
    t =      nans Interface orientation changed to Portrait
Test Suite 'Selected tests' started at 2026-08-13 14:54:55.232.
Test Suite 'RnFastRunnerUITests.xctest' started at 2026-08-13 14:54:55.233.
Test Suite 'SnapshotForegroundRegressionTest' started at 2026-08-13 14:54:55.233.
Test Case '-[RnFastRunnerUITests.SnapshotForegroundRegressionTest testCommand]' started.
    t =     0.00s Start Test at 2026-08-13 14:54:55.235
    t =     0.04s Set Up
    t =     0.04s Tear Down
Test Case '-[RnFastRunnerUITests.SnapshotForegroundRegressionTest testCommand]' passed (0.037 seconds).
Test Case '-[RnFastRunnerUITests.SnapshotForegroundRegressionTest testForegroundSnapshotReturnsTestAppTree]' started.
    t =     0.00s Start Test at 2026-08-13 14:54:55.272
    t =     0.02s Set Up
    t =     0.02s Open dev.lykhoyda.rndevagent.fastrunner
    t =     0.03s     Launch dev.lykhoyda.rndevagent.fastrunner
    t =     0.03s         Terminate dev.lykhoyda.rndevagent.fastrunner:18662
2026-08-13 14:54:56.680 xcodebuild[42332:215372429] [MT] IDELaunchParametersSnapshot: The operation couldn’t be completed. (DebuggerLLDB.DebuggerVersionStore.StoreError error 0.)
2026-08-13 14:54:56.680 xcodebuild[42332:215372429] [MT] IDELaunchParametersSnapshot: no debugger version
    t =     4.29s         Setting up automation session
    t =     6.46s Waiting 10.0s for "runner-splash-title" StaticText to exist
    t =     7.50s     Checking `Expect predicate `existsNoRetry == 1` for object "runner-splash-title" StaticText`
    t =     7.50s         Checking existence of `"runner-splash-title" StaticText`
    t =     7.56s Open com.rndevagent.testapp
    t =     7.56s     Launch com.rndevagent.testapp
<unknown>:0: error: -[RnFastRunnerUITests.SnapshotForegroundRegressionTest testForegroundSnapshotReturnsTestAppTree] : Failed to launch com.rndevagent.testapp: The request to open "com.rndevagent.testapp" failed. (Underlying Error: The operation couldn’t be completed. Application info provider (FBSApplicationLibrary) returned nil for "com.rndevagent.testapp")
    t =     7.62s Tear Down
Test Case '-[RnFastRunnerUITests.SnapshotForegroundRegressionTest testForegroundSnapshotReturnsTestAppTree]' failed (7.825 seconds).
Test Suite 'SnapshotForegroundRegressionTest' failed at 2026-08-13 14:55:03.097.
	 Executed 2 tests, with 1 failure (0 unexpected) in 7.862 (7.864) seconds
Test Suite 'RnFastRunnerUITests.xctest' failed at 2026-08-13 14:55:03.097.
	 Executed 2 tests, with 1 failure (0 unexpected) in 7.862 (7.864) seconds
Test Suite 'Selected tests' failed at 2026-08-13 14:55:03.098.
	 Executed 2 tests, with 1 failure (0 unexpected) in 7.862 (7.865) seconds
2026-08-13 14:55:25.780 xcodebuild[42332:215372429] [MT] IDETestOperationsObserverDebug: 40.824 elapsed -- Testing started completed.
2026-08-13 14:55:25.780 xcodebuild[42332:215372429] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
2026-08-13 14:55:25.780 xcodebuild[42332:215372429] [MT] IDETestOperationsObserverDebug: 40.824 sec, +40.824 sec -- end

Test session results, code coverage, and logs:
	/Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXJF22M65RDAK7XBXJN1YJT/packages/rn-fast-runner/build/DerivedData-native-tests/Logs/Test/Test-RnFastRunner-2026.08.13_14-54-37-+0200.xcresult

** TEST FAILED **

Testing started
```
</details>
- Evidence: Full xcodebuild log for the splash-contract test run (local file: <code>/var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/no-mistakes-evidence/01KZXJF22M65RDAK7XBXJN1YJT/xcodebuild-splash-tests.log</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `packages/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/SnapshotForegroundRegressionTest.swift:51` - The repaired precondition lives in SnapshotForegroundRegressionTest, which test-native-ios.sh skips in CI (needs com.rndevagent.testapp), so CI pins only the splash-identifier contract via the new RunnerSplashContractTests, not the full B155 dispatcher flow. The intent states this limitation explicitly and it matches what the repo infrastructure permits; noting it as residual coverage context, not a defect.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`xcodebuild test -only-testing:RnFastRunnerUITests/RunnerSplashContractTests` on iPhone 17 sim (iOS 26.4) — passed</code>
- <code>Temporary counterfactual XCUITest asserting `app.staticTexts[&#34;rn-dev-agent fast runner&#34;]` does NOT exist and `app.staticTexts[&#34;runner-splash-title&#34;]` does — passed, then removed</code>
- <code>`xcodebuild test -only-testing:RnFastRunnerUITests/SnapshotForegroundRegressionTest` — step-1 splash precondition resolves in ~1s; run fails only at step 2 `Failed to launch com.rndevagent.testapp` (no prebuilt test app on this host)</code>
- <code>`xcrun simctl install/launch dev.lykhoyda.rndevagent.fastrunner` + `xcrun simctl io screenshot` — captured the rendered splash screen</code>
- <code>`diff -r packages/rn-fast-runner/RnFastRunner/RnFastRunnerUITests packages/{claude-plugin,codex-plugin}/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests` — identical</code>
- <code>Inspected `nodeBlob` construction to confirm step 5&#39;s negative assertion keys on a field (`node.identifier`) actually present in snapshot output</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
