### PR TITLE
fix(core): admit a fresh MCP transport when the blocking claim epoch is absent

### DIFF
--- a/.changeset/gh-767-absent-claim-epoch-admission.md
+++ b/.changeset/gh-767-absent-claim-epoch-admission.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-core": patch
+"rn-dev-agent-plugin": patch
+---
+
+Admit a fresh MCP transport when the blocking claim epoch is already gone instead of rebinding the leftover blocked session.

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -23427,13 +23427,15 @@ var init_registry = __esm({
       }
       createSession(input) {
         const now = this.#now();
-        this.#database.prepare(`INSERT INTO sessions(
-          session_id, source_key, worktree_key, app_root_key, state,
-          claim_epoch, authority_version, supervisor_pid, supervisor_birth,
-          worker_instance, worker_pid, worker_birth, heartbeat_ms, lease_until_ms,
-          source_json, bindings_json, created_ms, updated_ms
-        ) VALUES (?, ?, ?, ?, 'active', 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(input.sessionId, input.sourceKey, input.worktreeKey, input.appRootKey, input.supervisor.pid, input.supervisor.token, input.worker?.instanceId ?? null, input.worker?.pid ?? null, input.worker?.token ?? null, now, now + this.#leaseMs, JSON.stringify(input.source ?? {}), JSON.stringify(input.bindings ?? {}), now, now);
-        this.#secureFiles();
+        this.#transaction(() => {
+          this.#discardAbsentBlockedContenders(input);
+          this.#database.prepare(`INSERT INTO sessions(
+            session_id, source_key, worktree_key, app_root_key, state,
+            claim_epoch, authority_version, supervisor_pid, supervisor_birth,
+            worker_instance, worker_pid, worker_birth, heartbeat_ms, lease_until_ms,
+            source_json, bindings_json, created_ms, updated_ms
+          ) VALUES (?, ?, ?, ?, 'active', 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(input.sessionId, input.sourceKey, input.worktreeKey, input.appRootKey, input.supervisor.pid, input.supervisor.token, input.worker?.instanceId ?? null, input.worker?.pid ?? null, input.worker?.token ?? null, now, now + this.#leaseMs, JSON.stringify(input.source ?? {}), JSON.stringify(input.bindings ?? {}), now, now);
+        });
         return { sessionId: input.sessionId, claimEpoch: 1 };
       }
       claimResources(session2, resources) {
@@ -24746,6 +24748,26 @@ var init_registry = __esm({
                authority_version = authority_version + 1, updated_ms = ?
            WHERE session_id = ? AND claim_epoch = ?`).run(now, session2.sessionId, session2.claimEpoch);
         });
+      }
+      #discardAbsentBlockedContenders(input) {
+        if (this.#findClaim("source", input.worktreeKey))
+          return;
+        const rows = this.#database.prepare(`SELECT session_id, claim_epoch FROM sessions
+         WHERE state = 'blocked' AND source_key = ? AND worktree_key = ? AND app_root_key = ?`).all(input.sourceKey, input.worktreeKey, input.appRootKey);
+        const now = this.#now();
+        for (const row of rows) {
+          const requirement = this.inspectRecoveryRequirement(row.session_id);
+          if (requirement.requirement !== "transport-restart" || requirement.priorOwner !== "absent") {
+            continue;
+          }
+          const owned = this.#database.prepare("SELECT resource_key FROM claims WHERE session_id = ? LIMIT 1").get(row.session_id);
+          if (owned)
+            continue;
+          this.#database.prepare(`UPDATE sessions
+           SET state = 'released', claim_epoch = claim_epoch + 1,
+               authority_version = authority_version + 1, updated_ms = ?
+           WHERE session_id = ? AND claim_epoch = ? AND state = 'blocked'`).run(now, row.session_id, row.claim_epoch);
+        }
       }
       discardBlockedSession(session2) {
         const now = this.#now();

--- a/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -8473,13 +8473,15 @@ var init_registry = __esm({
       }
       createSession(input) {
         const now = this.#now();
-        this.#database.prepare(`INSERT INTO sessions(
-          session_id, source_key, worktree_key, app_root_key, state,
-          claim_epoch, authority_version, supervisor_pid, supervisor_birth,
-          worker_instance, worker_pid, worker_birth, heartbeat_ms, lease_until_ms,
-          source_json, bindings_json, created_ms, updated_ms
-        ) VALUES (?, ?, ?, ?, 'active', 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(input.sessionId, input.sourceKey, input.worktreeKey, input.appRootKey, input.supervisor.pid, input.supervisor.token, input.worker?.instanceId ?? null, input.worker?.pid ?? null, input.worker?.token ?? null, now, now + this.#leaseMs, JSON.stringify(input.source ?? {}), JSON.stringify(input.bindings ?? {}), now, now);
-        this.#secureFiles();
+        this.#transaction(() => {
+          this.#discardAbsentBlockedContenders(input);
+          this.#database.prepare(`INSERT INTO sessions(
+            session_id, source_key, worktree_key, app_root_key, state,
+            claim_epoch, authority_version, supervisor_pid, supervisor_birth,
+            worker_instance, worker_pid, worker_birth, heartbeat_ms, lease_until_ms,
+            source_json, bindings_json, created_ms, updated_ms
+          ) VALUES (?, ?, ?, ?, 'active', 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(input.sessionId, input.sourceKey, input.worktreeKey, input.appRootKey, input.supervisor.pid, input.supervisor.token, input.worker?.instanceId ?? null, input.worker?.pid ?? null, input.worker?.token ?? null, now, now + this.#leaseMs, JSON.stringify(input.source ?? {}), JSON.stringify(input.bindings ?? {}), now, now);
+        });
         return { sessionId: input.sessionId, claimEpoch: 1 };
       }
       claimResources(session2, resources) {
@@ -9792,6 +9794,26 @@ var init_registry = __esm({
                authority_version = authority_version + 1, updated_ms = ?
            WHERE session_id = ? AND claim_epoch = ?`).run(now, session2.sessionId, session2.claimEpoch);
         });
+      }
+      #discardAbsentBlockedContenders(input) {
+        if (this.#findClaim("source", input.worktreeKey))
+          return;
+        const rows = this.#database.prepare(`SELECT session_id, claim_epoch FROM sessions
+         WHERE state = 'blocked' AND source_key = ? AND worktree_key = ? AND app_root_key = ?`).all(input.sourceKey, input.worktreeKey, input.appRootKey);
+        const now = this.#now();
+        for (const row of rows) {
+          const requirement = this.inspectRecoveryRequirement(row.session_id);
+          if (requirement.requirement !== "transport-restart" || requirement.priorOwner !== "absent") {
+            continue;
+          }
+          const owned = this.#database.prepare("SELECT resource_key FROM claims WHERE session_id = ? LIMIT 1").get(row.session_id);
+          if (owned)
+            continue;
+          this.#database.prepare(`UPDATE sessions
+           SET state = 'released', claim_epoch = claim_epoch + 1,
+               authority_version = authority_version + 1, updated_ms = ?
+           WHERE session_id = ? AND claim_epoch = ? AND state = 'blocked'`).run(now, row.session_id, row.claim_epoch);
+        }
       }
       discardBlockedSession(session2) {
         const now = this.#now();

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -21136,13 +21136,15 @@ var init_registry = __esm({
       }
       createSession(input) {
         const now = this.#now();
-        this.#database.prepare(`INSERT INTO sessions(
-          session_id, source_key, worktree_key, app_root_key, state,
-          claim_epoch, authority_version, supervisor_pid, supervisor_birth,
-          worker_instance, worker_pid, worker_birth, heartbeat_ms, lease_until_ms,
-          source_json, bindings_json, created_ms, updated_ms
-        ) VALUES (?, ?, ?, ?, 'active', 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(input.sessionId, input.sourceKey, input.worktreeKey, input.appRootKey, input.supervisor.pid, input.supervisor.token, input.worker?.instanceId ?? null, input.worker?.pid ?? null, input.worker?.token ?? null, now, now + this.#leaseMs, JSON.stringify(input.source ?? {}), JSON.stringify(input.bindings ?? {}), now, now);
-        this.#secureFiles();
+        this.#transaction(() => {
+          this.#discardAbsentBlockedContenders(input);
+          this.#database.prepare(`INSERT INTO sessions(
+            session_id, source_key, worktree_key, app_root_key, state,
+            claim_epoch, authority_version, supervisor_pid, supervisor_birth,
+            worker_instance, worker_pid, worker_birth, heartbeat_ms, lease_until_ms,
+            source_json, bindings_json, created_ms, updated_ms
+          ) VALUES (?, ?, ?, ?, 'active', 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(input.sessionId, input.sourceKey, input.worktreeKey, input.appRootKey, input.supervisor.pid, input.supervisor.token, input.worker?.instanceId ?? null, input.worker?.pid ?? null, input.worker?.token ?? null, now, now + this.#leaseMs, JSON.stringify(input.source ?? {}), JSON.stringify(input.bindings ?? {}), now, now);
+        });
         return { sessionId: input.sessionId, claimEpoch: 1 };
       }
       claimResources(session2, resources) {
@@ -22455,6 +22457,26 @@ var init_registry = __esm({
                authority_version = authority_version + 1, updated_ms = ?
            WHERE session_id = ? AND claim_epoch = ?`).run(now, session2.sessionId, session2.claimEpoch);
         });
+      }
+      #discardAbsentBlockedContenders(input) {
+        if (this.#findClaim("source", input.worktreeKey))
+          return;
+        const rows = this.#database.prepare(`SELECT session_id, claim_epoch FROM sessions
+         WHERE state = 'blocked' AND source_key = ? AND worktree_key = ? AND app_root_key = ?`).all(input.sourceKey, input.worktreeKey, input.appRootKey);
+        const now = this.#now();
+        for (const row of rows) {
+          const requirement = this.inspectRecoveryRequirement(row.session_id);
+          if (requirement.requirement !== "transport-restart" || requirement.priorOwner !== "absent") {
+            continue;
+          }
+          const owned = this.#database.prepare("SELECT resource_key FROM claims WHERE session_id = ? LIMIT 1").get(row.session_id);
+          if (owned)
+            continue;
+          this.#database.prepare(`UPDATE sessions
+           SET state = 'released', claim_epoch = claim_epoch + 1,
+               authority_version = authority_version + 1, updated_ms = ?
+           WHERE session_id = ? AND claim_epoch = ? AND state = 'blocked'`).run(now, row.session_id, row.claim_epoch);
+        }
       }
       discardBlockedSession(session2) {
         const now = this.#now();
@@ -90223,22 +90245,27 @@ var RELEASABLE_SESSION_STATES = /* @__PURE__ */ new Set([
   "ready"
 ]);
 function supervisorSessionIsTerminal(authority) {
-  let state;
   try {
-    state = authority.registry.getSessionStatus(authority.session.sessionId)?.state;
+    const state = authority.registry.getSessionStatus(authority.session.sessionId)?.state;
+    if (state === void 0 || state === "released" || state === "stale")
+      return true;
+    if (state !== "blocked")
+      return false;
+    const requirement = authority.registry.inspectRecoveryRequirement(authority.session.sessionId);
+    return requirement.requirement === "transport-restart" && requirement.priorOwner === "absent";
   } catch {
     return false;
   }
-  return state === void 0 || state === "released" || state === "stale";
 }
 function resolveSupervisorAuthorityForSpawn(current, mint) {
   if (!current || !supervisorSessionIsTerminal(current)) {
     return { authority: current, error: null, minted: false };
   }
-  void current.close().catch(() => {
-  });
   try {
-    return { authority: mint(), error: null, minted: true };
+    const authority = mint();
+    void current.close().catch(() => {
+    });
+    return { authority, error: null, minted: true };
   } catch (error2) {
     return {
       authority: null,

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -90261,12 +90261,16 @@ function resolveSupervisorAuthorityForSpawn(current, mint) {
   if (!current || !supervisorSessionIsTerminal(current)) {
     return { authority: current, error: null, minted: false };
   }
-  try {
-    const authority = mint();
+  const closeTerminal = () => {
     void current.close().catch(() => {
     });
+  };
+  try {
+    const authority = mint();
+    closeTerminal();
     return { authority, error: null, minted: true };
   } catch (error2) {
+    closeTerminal();
     return {
       authority: null,
       error: error2 instanceof Error ? error2.message : "AUTHORITY_STORE_UNAVAILABLE: authority session could not be initialized",

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -23427,13 +23427,15 @@ var init_registry = __esm({
       }
       createSession(input) {
         const now = this.#now();
-        this.#database.prepare(`INSERT INTO sessions(
-          session_id, source_key, worktree_key, app_root_key, state,
-          claim_epoch, authority_version, supervisor_pid, supervisor_birth,
-          worker_instance, worker_pid, worker_birth, heartbeat_ms, lease_until_ms,
-          source_json, bindings_json, created_ms, updated_ms
-        ) VALUES (?, ?, ?, ?, 'active', 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(input.sessionId, input.sourceKey, input.worktreeKey, input.appRootKey, input.supervisor.pid, input.supervisor.token, input.worker?.instanceId ?? null, input.worker?.pid ?? null, input.worker?.token ?? null, now, now + this.#leaseMs, JSON.stringify(input.source ?? {}), JSON.stringify(input.bindings ?? {}), now, now);
-        this.#secureFiles();
+        this.#transaction(() => {
+          this.#discardAbsentBlockedContenders(input);
+          this.#database.prepare(`INSERT INTO sessions(
+            session_id, source_key, worktree_key, app_root_key, state,
+            claim_epoch, authority_version, supervisor_pid, supervisor_birth,
+            worker_instance, worker_pid, worker_birth, heartbeat_ms, lease_until_ms,
+            source_json, bindings_json, created_ms, updated_ms
+          ) VALUES (?, ?, ?, ?, 'active', 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(input.sessionId, input.sourceKey, input.worktreeKey, input.appRootKey, input.supervisor.pid, input.supervisor.token, input.worker?.instanceId ?? null, input.worker?.pid ?? null, input.worker?.token ?? null, now, now + this.#leaseMs, JSON.stringify(input.source ?? {}), JSON.stringify(input.bindings ?? {}), now, now);
+        });
         return { sessionId: input.sessionId, claimEpoch: 1 };
       }
       claimResources(session2, resources) {
@@ -24746,6 +24748,26 @@ var init_registry = __esm({
                authority_version = authority_version + 1, updated_ms = ?
            WHERE session_id = ? AND claim_epoch = ?`).run(now, session2.sessionId, session2.claimEpoch);
         });
+      }
+      #discardAbsentBlockedContenders(input) {
+        if (this.#findClaim("source", input.worktreeKey))
+          return;
+        const rows = this.#database.prepare(`SELECT session_id, claim_epoch FROM sessions
+         WHERE state = 'blocked' AND source_key = ? AND worktree_key = ? AND app_root_key = ?`).all(input.sourceKey, input.worktreeKey, input.appRootKey);
+        const now = this.#now();
+        for (const row of rows) {
+          const requirement = this.inspectRecoveryRequirement(row.session_id);
+          if (requirement.requirement !== "transport-restart" || requirement.priorOwner !== "absent") {
+            continue;
+          }
+          const owned = this.#database.prepare("SELECT resource_key FROM claims WHERE session_id = ? LIMIT 1").get(row.session_id);
+          if (owned)
+            continue;
+          this.#database.prepare(`UPDATE sessions
+           SET state = 'released', claim_epoch = claim_epoch + 1,
+               authority_version = authority_version + 1, updated_ms = ?
+           WHERE session_id = ? AND claim_epoch = ? AND state = 'blocked'`).run(now, row.session_id, row.claim_epoch);
+        }
       }
       discardBlockedSession(session2) {
         const now = this.#now();

--- a/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -8473,13 +8473,15 @@ var init_registry = __esm({
       }
       createSession(input) {
         const now = this.#now();
-        this.#database.prepare(`INSERT INTO sessions(
-          session_id, source_key, worktree_key, app_root_key, state,
-          claim_epoch, authority_version, supervisor_pid, supervisor_birth,
-          worker_instance, worker_pid, worker_birth, heartbeat_ms, lease_until_ms,
-          source_json, bindings_json, created_ms, updated_ms
-        ) VALUES (?, ?, ?, ?, 'active', 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(input.sessionId, input.sourceKey, input.worktreeKey, input.appRootKey, input.supervisor.pid, input.supervisor.token, input.worker?.instanceId ?? null, input.worker?.pid ?? null, input.worker?.token ?? null, now, now + this.#leaseMs, JSON.stringify(input.source ?? {}), JSON.stringify(input.bindings ?? {}), now, now);
-        this.#secureFiles();
+        this.#transaction(() => {
+          this.#discardAbsentBlockedContenders(input);
+          this.#database.prepare(`INSERT INTO sessions(
+            session_id, source_key, worktree_key, app_root_key, state,
+            claim_epoch, authority_version, supervisor_pid, supervisor_birth,
+            worker_instance, worker_pid, worker_birth, heartbeat_ms, lease_until_ms,
+            source_json, bindings_json, created_ms, updated_ms
+          ) VALUES (?, ?, ?, ?, 'active', 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(input.sessionId, input.sourceKey, input.worktreeKey, input.appRootKey, input.supervisor.pid, input.supervisor.token, input.worker?.instanceId ?? null, input.worker?.pid ?? null, input.worker?.token ?? null, now, now + this.#leaseMs, JSON.stringify(input.source ?? {}), JSON.stringify(input.bindings ?? {}), now, now);
+        });
         return { sessionId: input.sessionId, claimEpoch: 1 };
       }
       claimResources(session2, resources) {
@@ -9792,6 +9794,26 @@ var init_registry = __esm({
                authority_version = authority_version + 1, updated_ms = ?
            WHERE session_id = ? AND claim_epoch = ?`).run(now, session2.sessionId, session2.claimEpoch);
         });
+      }
+      #discardAbsentBlockedContenders(input) {
+        if (this.#findClaim("source", input.worktreeKey))
+          return;
+        const rows = this.#database.prepare(`SELECT session_id, claim_epoch FROM sessions
+         WHERE state = 'blocked' AND source_key = ? AND worktree_key = ? AND app_root_key = ?`).all(input.sourceKey, input.worktreeKey, input.appRootKey);
+        const now = this.#now();
+        for (const row of rows) {
+          const requirement = this.inspectRecoveryRequirement(row.session_id);
+          if (requirement.requirement !== "transport-restart" || requirement.priorOwner !== "absent") {
+            continue;
+          }
+          const owned = this.#database.prepare("SELECT resource_key FROM claims WHERE session_id = ? LIMIT 1").get(row.session_id);
+          if (owned)
+            continue;
+          this.#database.prepare(`UPDATE sessions
+           SET state = 'released', claim_epoch = claim_epoch + 1,
+               authority_version = authority_version + 1, updated_ms = ?
+           WHERE session_id = ? AND claim_epoch = ? AND state = 'blocked'`).run(now, row.session_id, row.claim_epoch);
+        }
       }
       discardBlockedSession(session2) {
         const now = this.#now();

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -21136,13 +21136,15 @@ var init_registry = __esm({
       }
       createSession(input) {
         const now = this.#now();
-        this.#database.prepare(`INSERT INTO sessions(
-          session_id, source_key, worktree_key, app_root_key, state,
-          claim_epoch, authority_version, supervisor_pid, supervisor_birth,
-          worker_instance, worker_pid, worker_birth, heartbeat_ms, lease_until_ms,
-          source_json, bindings_json, created_ms, updated_ms
-        ) VALUES (?, ?, ?, ?, 'active', 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(input.sessionId, input.sourceKey, input.worktreeKey, input.appRootKey, input.supervisor.pid, input.supervisor.token, input.worker?.instanceId ?? null, input.worker?.pid ?? null, input.worker?.token ?? null, now, now + this.#leaseMs, JSON.stringify(input.source ?? {}), JSON.stringify(input.bindings ?? {}), now, now);
-        this.#secureFiles();
+        this.#transaction(() => {
+          this.#discardAbsentBlockedContenders(input);
+          this.#database.prepare(`INSERT INTO sessions(
+            session_id, source_key, worktree_key, app_root_key, state,
+            claim_epoch, authority_version, supervisor_pid, supervisor_birth,
+            worker_instance, worker_pid, worker_birth, heartbeat_ms, lease_until_ms,
+            source_json, bindings_json, created_ms, updated_ms
+          ) VALUES (?, ?, ?, ?, 'active', 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(input.sessionId, input.sourceKey, input.worktreeKey, input.appRootKey, input.supervisor.pid, input.supervisor.token, input.worker?.instanceId ?? null, input.worker?.pid ?? null, input.worker?.token ?? null, now, now + this.#leaseMs, JSON.stringify(input.source ?? {}), JSON.stringify(input.bindings ?? {}), now, now);
+        });
         return { sessionId: input.sessionId, claimEpoch: 1 };
       }
       claimResources(session2, resources) {
@@ -22455,6 +22457,26 @@ var init_registry = __esm({
                authority_version = authority_version + 1, updated_ms = ?
            WHERE session_id = ? AND claim_epoch = ?`).run(now, session2.sessionId, session2.claimEpoch);
         });
+      }
+      #discardAbsentBlockedContenders(input) {
+        if (this.#findClaim("source", input.worktreeKey))
+          return;
+        const rows = this.#database.prepare(`SELECT session_id, claim_epoch FROM sessions
+         WHERE state = 'blocked' AND source_key = ? AND worktree_key = ? AND app_root_key = ?`).all(input.sourceKey, input.worktreeKey, input.appRootKey);
+        const now = this.#now();
+        for (const row of rows) {
+          const requirement = this.inspectRecoveryRequirement(row.session_id);
+          if (requirement.requirement !== "transport-restart" || requirement.priorOwner !== "absent") {
+            continue;
+          }
+          const owned = this.#database.prepare("SELECT resource_key FROM claims WHERE session_id = ? LIMIT 1").get(row.session_id);
+          if (owned)
+            continue;
+          this.#database.prepare(`UPDATE sessions
+           SET state = 'released', claim_epoch = claim_epoch + 1,
+               authority_version = authority_version + 1, updated_ms = ?
+           WHERE session_id = ? AND claim_epoch = ? AND state = 'blocked'`).run(now, row.session_id, row.claim_epoch);
+        }
       }
       discardBlockedSession(session2) {
         const now = this.#now();
@@ -90223,22 +90245,27 @@ var RELEASABLE_SESSION_STATES = /* @__PURE__ */ new Set([
   "ready"
 ]);
 function supervisorSessionIsTerminal(authority) {
-  let state;
   try {
-    state = authority.registry.getSessionStatus(authority.session.sessionId)?.state;
+    const state = authority.registry.getSessionStatus(authority.session.sessionId)?.state;
+    if (state === void 0 || state === "released" || state === "stale")
+      return true;
+    if (state !== "blocked")
+      return false;
+    const requirement = authority.registry.inspectRecoveryRequirement(authority.session.sessionId);
+    return requirement.requirement === "transport-restart" && requirement.priorOwner === "absent";
   } catch {
     return false;
   }
-  return state === void 0 || state === "released" || state === "stale";
 }
 function resolveSupervisorAuthorityForSpawn(current, mint) {
   if (!current || !supervisorSessionIsTerminal(current)) {
     return { authority: current, error: null, minted: false };
   }
-  void current.close().catch(() => {
-  });
   try {
-    return { authority: mint(), error: null, minted: true };
+    const authority = mint();
+    void current.close().catch(() => {
+    });
+    return { authority, error: null, minted: true };
   } catch (error2) {
     return {
       authority: null,

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -90261,12 +90261,16 @@ function resolveSupervisorAuthorityForSpawn(current, mint) {
   if (!current || !supervisorSessionIsTerminal(current)) {
     return { authority: current, error: null, minted: false };
   }
-  try {
-    const authority = mint();
+  const closeTerminal = () => {
     void current.close().catch(() => {
     });
+  };
+  try {
+    const authority = mint();
+    closeTerminal();
     return { authority, error: null, minted: true };
   } catch (error2) {
+    closeTerminal();
     return {
       authority: null,
       error: error2 instanceof Error ? error2.message : "AUTHORITY_STORE_UNAVAILABLE: authority session could not be initialized",

--- a/packages/rn-dev-agent-core/dist/session/registry.js
+++ b/packages/rn-dev-agent-core/dist/session/registry.js
@@ -283,15 +283,17 @@ export class SessionRegistry {
     }
     createSession(input) {
         const now = this.#now();
-        this.#database
-            .prepare(`INSERT INTO sessions(
-          session_id, source_key, worktree_key, app_root_key, state,
-          claim_epoch, authority_version, supervisor_pid, supervisor_birth,
-          worker_instance, worker_pid, worker_birth, heartbeat_ms, lease_until_ms,
-          source_json, bindings_json, created_ms, updated_ms
-        ) VALUES (?, ?, ?, ?, 'active', 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
-            .run(input.sessionId, input.sourceKey, input.worktreeKey, input.appRootKey, input.supervisor.pid, input.supervisor.token, input.worker?.instanceId ?? null, input.worker?.pid ?? null, input.worker?.token ?? null, now, now + this.#leaseMs, JSON.stringify(input.source ?? {}), JSON.stringify(input.bindings ?? {}), now, now);
-        this.#secureFiles();
+        this.#transaction(() => {
+            this.#discardAbsentBlockedContenders(input);
+            this.#database
+                .prepare(`INSERT INTO sessions(
+            session_id, source_key, worktree_key, app_root_key, state,
+            claim_epoch, authority_version, supervisor_pid, supervisor_birth,
+            worker_instance, worker_pid, worker_birth, heartbeat_ms, lease_until_ms,
+            source_json, bindings_json, created_ms, updated_ms
+          ) VALUES (?, ?, ?, ?, 'active', 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+                .run(input.sessionId, input.sourceKey, input.worktreeKey, input.appRootKey, input.supervisor.pid, input.supervisor.token, input.worker?.instanceId ?? null, input.worker?.pid ?? null, input.worker?.token ?? null, now, now + this.#leaseMs, JSON.stringify(input.source ?? {}), JSON.stringify(input.bindings ?? {}), now, now);
+        });
         return { sessionId: input.sessionId, claimEpoch: 1 };
     }
     claimResources(session, resources) {
@@ -1893,6 +1895,32 @@ export class SessionRegistry {
            WHERE session_id = ? AND claim_epoch = ?`)
                 .run(now, session.sessionId, session.claimEpoch);
         });
+    }
+    #discardAbsentBlockedContenders(input) {
+        if (this.#findClaim('source', input.worktreeKey))
+            return;
+        const rows = this.#database
+            .prepare(`SELECT session_id, claim_epoch FROM sessions
+         WHERE state = 'blocked' AND source_key = ? AND worktree_key = ? AND app_root_key = ?`)
+            .all(input.sourceKey, input.worktreeKey, input.appRootKey);
+        const now = this.#now();
+        for (const row of rows) {
+            const requirement = this.inspectRecoveryRequirement(row.session_id);
+            if (requirement.requirement !== 'transport-restart' || requirement.priorOwner !== 'absent') {
+                continue;
+            }
+            const owned = this.#database
+                .prepare('SELECT resource_key FROM claims WHERE session_id = ? LIMIT 1')
+                .get(row.session_id);
+            if (owned)
+                continue;
+            this.#database
+                .prepare(`UPDATE sessions
+           SET state = 'released', claim_epoch = claim_epoch + 1,
+               authority_version = authority_version + 1, updated_ms = ?
+           WHERE session_id = ? AND claim_epoch = ? AND state = 'blocked'`)
+                .run(now, row.session_id, row.claim_epoch);
+        }
     }
     discardBlockedSession(session) {
         const now = this.#now();

--- a/packages/rn-dev-agent-core/dist/session/supervisor-authority.js
+++ b/packages/rn-dev-agent-core/dist/session/supervisor-authority.js
@@ -14,35 +14,32 @@ const RELEASABLE_SESSION_STATES = new Set([
     'runtime_bound',
     'ready',
 ]);
-/**
- * GH #706: a released (or fenced) session owns nothing and can never be transitioned
- * again, so the supervisor must mint a successor instead of handing the terminal row
- * to the next worker.
- */
+/** GH #706/#767: released, stale, or blocked-with-absent-prior rows cannot be reused. */
 export function supervisorSessionIsTerminal(authority) {
-    let state;
     try {
-        state = authority.registry.getSessionStatus(authority.session.sessionId)?.state;
+        const state = authority.registry.getSessionStatus(authority.session.sessionId)?.state;
+        if (state === undefined || state === 'released' || state === 'stale')
+            return true;
+        if (state !== 'blocked')
+            return false;
+        const requirement = authority.registry.inspectRecoveryRequirement(authority.session.sessionId);
+        return requirement.requirement === 'transport-restart' && requirement.priorOwner === 'absent';
     }
     catch {
         return false;
     }
-    return state === undefined || state === 'released' || state === 'stale';
 }
-/**
- * GH #706: resolve the session the next worker inherits. A terminal row is replaced by
- * a freshly minted session — exactly what a cold supervisor start would have produced —
- * so `release` stops being a one-way door.
- */
+/** GH #706: a terminal row is replaced by a freshly minted successor. */
 export function resolveSupervisorAuthorityForSpawn(current, mint) {
     if (!current || !supervisorSessionIsTerminal(current)) {
         return { authority: current, error: null, minted: false };
     }
-    void current.close().catch(() => {
-        /* a terminal session owns nothing; cleanup refusals must not block the successor */
-    });
     try {
-        return { authority: mint(), error: null, minted: true };
+        const authority = mint();
+        void current.close().catch(() => {
+            /* a terminal session owns nothing; cleanup refusals must not block the successor */
+        });
+        return { authority, error: null, minted: true };
     }
     catch (error) {
         return {

--- a/packages/rn-dev-agent-core/dist/session/supervisor-authority.js
+++ b/packages/rn-dev-agent-core/dist/session/supervisor-authority.js
@@ -34,14 +34,18 @@ export function resolveSupervisorAuthorityForSpawn(current, mint) {
     if (!current || !supervisorSessionIsTerminal(current)) {
         return { authority: current, error: null, minted: false };
     }
-    try {
-        const authority = mint();
+    const closeTerminal = () => {
         void current.close().catch(() => {
             /* a terminal session owns nothing; cleanup refusals must not block the successor */
         });
+    };
+    try {
+        const authority = mint();
+        closeTerminal();
         return { authority, error: null, minted: true };
     }
     catch (error) {
+        closeTerminal();
         return {
             authority: null,
             error: error instanceof Error

--- a/packages/rn-dev-agent-core/src/session/registry.ts
+++ b/packages/rn-dev-agent-core/src/session/registry.ts
@@ -623,33 +623,35 @@ export class SessionRegistry {
     bindings?: Record<string, unknown>;
   }): SessionRef {
     const now = this.#now();
-    this.#database
-      .prepare(
-        `INSERT INTO sessions(
-          session_id, source_key, worktree_key, app_root_key, state,
-          claim_epoch, authority_version, supervisor_pid, supervisor_birth,
-          worker_instance, worker_pid, worker_birth, heartbeat_ms, lease_until_ms,
-          source_json, bindings_json, created_ms, updated_ms
-        ) VALUES (?, ?, ?, ?, 'active', 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(
-        input.sessionId,
-        input.sourceKey,
-        input.worktreeKey,
-        input.appRootKey,
-        input.supervisor.pid,
-        input.supervisor.token,
-        input.worker?.instanceId ?? null,
-        input.worker?.pid ?? null,
-        input.worker?.token ?? null,
-        now,
-        now + this.#leaseMs,
-        JSON.stringify(input.source ?? {}),
-        JSON.stringify(input.bindings ?? {}),
-        now,
-        now,
-      );
-    this.#secureFiles();
+    this.#transaction(() => {
+      this.#discardAbsentBlockedContenders(input);
+      this.#database
+        .prepare(
+          `INSERT INTO sessions(
+            session_id, source_key, worktree_key, app_root_key, state,
+            claim_epoch, authority_version, supervisor_pid, supervisor_birth,
+            worker_instance, worker_pid, worker_birth, heartbeat_ms, lease_until_ms,
+            source_json, bindings_json, created_ms, updated_ms
+          ) VALUES (?, ?, ?, ?, 'active', 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          input.sessionId,
+          input.sourceKey,
+          input.worktreeKey,
+          input.appRootKey,
+          input.supervisor.pid,
+          input.supervisor.token,
+          input.worker?.instanceId ?? null,
+          input.worker?.pid ?? null,
+          input.worker?.token ?? null,
+          now,
+          now + this.#leaseMs,
+          JSON.stringify(input.source ?? {}),
+          JSON.stringify(input.bindings ?? {}),
+          now,
+          now,
+        );
+    });
     return { sessionId: input.sessionId, claimEpoch: 1 };
   }
 
@@ -3099,6 +3101,43 @@ export class SessionRegistry {
         )
         .run(now, session.sessionId, session.claimEpoch);
     });
+  }
+
+  #discardAbsentBlockedContenders(input: {
+    sourceKey: string;
+    worktreeKey: string;
+    appRootKey: string;
+  }): void {
+    if (this.#findClaim('source', input.worktreeKey)) return;
+
+    const rows = this.#database
+      .prepare(
+        `SELECT session_id, claim_epoch FROM sessions
+         WHERE state = 'blocked' AND source_key = ? AND worktree_key = ? AND app_root_key = ?`,
+      )
+      .all(input.sourceKey, input.worktreeKey, input.appRootKey) as Array<{
+      session_id: string;
+      claim_epoch: number;
+    }>;
+    const now = this.#now();
+    for (const row of rows) {
+      const requirement = this.inspectRecoveryRequirement(row.session_id);
+      if (requirement.requirement !== 'transport-restart' || requirement.priorOwner !== 'absent') {
+        continue;
+      }
+      const owned = this.#database
+        .prepare('SELECT resource_key FROM claims WHERE session_id = ? LIMIT 1')
+        .get(row.session_id);
+      if (owned) continue;
+      this.#database
+        .prepare(
+          `UPDATE sessions
+           SET state = 'released', claim_epoch = claim_epoch + 1,
+               authority_version = authority_version + 1, updated_ms = ?
+           WHERE session_id = ? AND claim_epoch = ? AND state = 'blocked'`,
+        )
+        .run(now, row.session_id, row.claim_epoch);
+    }
   }
 
   discardBlockedSession(session: SessionRef): void {

--- a/packages/rn-dev-agent-core/src/session/supervisor-authority.ts
+++ b/packages/rn-dev-agent-core/src/session/supervisor-authority.ts
@@ -60,13 +60,17 @@ export function resolveSupervisorAuthorityForSpawn(
   if (!current || !supervisorSessionIsTerminal(current)) {
     return { authority: current, error: null, minted: false };
   }
-  try {
-    const authority = mint();
+  const closeTerminal = (): void => {
     void current.close().catch(() => {
       /* a terminal session owns nothing; cleanup refusals must not block the successor */
     });
+  };
+  try {
+    const authority = mint();
+    closeTerminal();
     return { authority, error: null, minted: true };
   } catch (error) {
+    closeTerminal();
     return {
       authority: null,
       error:

--- a/packages/rn-dev-agent-core/src/session/supervisor-authority.ts
+++ b/packages/rn-dev-agent-core/src/session/supervisor-authority.ts
@@ -39,26 +39,20 @@ export interface SupervisorAuthority {
   close(): Promise<void>;
 }
 
-/**
- * GH #706: a released (or fenced) session owns nothing and can never be transitioned
- * again, so the supervisor must mint a successor instead of handing the terminal row
- * to the next worker.
- */
+/** GH #706/#767: released, stale, or blocked-with-absent-prior rows cannot be reused. */
 export function supervisorSessionIsTerminal(authority: SupervisorAuthority): boolean {
-  let state: string | undefined;
   try {
-    state = authority.registry.getSessionStatus(authority.session.sessionId)?.state;
+    const state = authority.registry.getSessionStatus(authority.session.sessionId)?.state;
+    if (state === undefined || state === 'released' || state === 'stale') return true;
+    if (state !== 'blocked') return false;
+    const requirement = authority.registry.inspectRecoveryRequirement(authority.session.sessionId);
+    return requirement.requirement === 'transport-restart' && requirement.priorOwner === 'absent';
   } catch {
     return false;
   }
-  return state === undefined || state === 'released' || state === 'stale';
 }
 
-/**
- * GH #706: resolve the session the next worker inherits. A terminal row is replaced by
- * a freshly minted session — exactly what a cold supervisor start would have produced —
- * so `release` stops being a one-way door.
- */
+/** GH #706: a terminal row is replaced by a freshly minted successor. */
 export function resolveSupervisorAuthorityForSpawn(
   current: SupervisorAuthority | null,
   mint: () => SupervisorAuthority,
@@ -66,11 +60,12 @@ export function resolveSupervisorAuthorityForSpawn(
   if (!current || !supervisorSessionIsTerminal(current)) {
     return { authority: current, error: null, minted: false };
   }
-  void current.close().catch(() => {
-    /* a terminal session owns nothing; cleanup refusals must not block the successor */
-  });
   try {
-    return { authority: mint(), error: null, minted: true };
+    const authority = mint();
+    void current.close().catch(() => {
+      /* a terminal session owns nothing; cleanup refusals must not block the successor */
+    });
+    return { authority, error: null, minted: true };
   } catch (error) {
     return {
       authority: null,

--- a/packages/rn-dev-agent-core/test/unit/session/gh-767-absent-claim-epoch-admission.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/gh-767-absent-claim-epoch-admission.test.ts
@@ -1,0 +1,305 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, test } from 'node:test';
+import type { OwnerStatus, SessionOwner } from '../../../dist/session/registry.js';
+import {
+  createSupervisorAuthority,
+  resolveSupervisorAuthorityForSpawn,
+  supervisorSessionIsTerminal,
+  type SupervisorAuthority,
+} from '../../../dist/session/supervisor-authority.js';
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { force: true, recursive: true });
+});
+
+const source = {
+  kind: 'git' as const,
+  contentRoot: '/repo',
+  appRoot: '/repo/apps/mobile',
+  sourceKey: 'source-key',
+  worktreeKey: 'worktree-key',
+  appRootKey: 'app-key',
+  head: 'abc123',
+};
+
+const foreignSource = {
+  ...source,
+  worktreeKey: 'foreign-worktree',
+};
+
+interface MintInput {
+  pid: number;
+  token: string;
+  ownerStatus: (owner: SessionOwner) => OwnerStatus;
+  source?: typeof source;
+}
+
+function mint(stateDir: string, input: MintInput): SupervisorAuthority {
+  return createSupervisorAuthority({
+    stateDir,
+    source: input.source ?? source,
+    supervisorBirth: {
+      pid: input.pid,
+      source: 'linux-proc',
+      token: input.token,
+    },
+    uid: '501',
+    startHeartbeat: false,
+    ownerStatus: input.ownerStatus,
+  });
+}
+
+function recoveryOf(authority: SupervisorAuthority) {
+  return authority.registry.inspectRecoveryRequirement(authority.session.sessionId);
+}
+
+function stateOf(authority: SupervisorAuthority) {
+  return authority.registry.getSessionStatus(authority.session.sessionId)?.state;
+}
+
+test('GH#767: repeated fresh transports converge after release and no remaining claims', async () => {
+  const stateDir = mkdtempSync(join(tmpdir(), 'rn-gh767-repeat-'));
+  roots.push(stateDir);
+  const ownerStates = new Map<string, OwnerStatus>();
+  const ownerStatus = (owner: SessionOwner): OwnerStatus =>
+    ownerStates.get(owner.sessionId) ?? 'match';
+
+  const owner = mint(stateDir, { pid: 101, token: 'owner-birth', ownerStatus });
+  ownerStates.set(owner.session.sessionId, 'match');
+  const blocked = mint(stateDir, { pid: 202, token: 'blocked-birth', ownerStatus });
+  ownerStates.set(blocked.session.sessionId, 'match');
+  assert.equal(stateOf(blocked), 'blocked');
+
+  owner.registry.releaseSession(owner.session);
+  ownerStates.set(owner.session.sessionId, 'mismatch');
+  assert.equal(recoveryOf(blocked).requirement, 'transport-restart');
+  assert.equal(recoveryOf(blocked).priorOwner, 'absent');
+  assert.equal(blocked.registry.getClaim('source', source.worktreeKey), null);
+
+  assert.throws(() =>
+    blocked.registry.createSession({
+      sessionId: blocked.session.sessionId,
+      sourceKey: source.sourceKey,
+      worktreeKey: source.worktreeKey,
+      appRootKey: source.appRootKey,
+      supervisor: { pid: 999, token: 'duplicate-id' },
+      source,
+    }),
+  );
+  assert.equal(stateOf(blocked), 'blocked', 'insert failure must roll back the fence clear');
+  assert.equal(recoveryOf(blocked).priorOwner, 'absent');
+
+  const first = mint(stateDir, { pid: 303, token: 'fresh-1-birth', ownerStatus });
+  ownerStates.set(first.session.sessionId, 'match');
+  try {
+    assert.equal(stateOf(first), 'source_bound');
+    assert.equal(stateOf(blocked), 'released');
+    assert.equal(
+      first.registry.getClaim('source', source.worktreeKey)?.sessionId,
+      first.session.sessionId,
+    );
+
+    const overlapping = mint(stateDir, { pid: 305, token: 'overlap-birth', ownerStatus });
+    try {
+      assert.equal(stateOf(overlapping), 'blocked');
+      assert.equal(recoveryOf(overlapping).priorOwner, 'live');
+      assert.equal(
+        first.registry.getClaim('source', source.worktreeKey)?.sessionId,
+        first.session.sessionId,
+      );
+    } finally {
+      await overlapping.close();
+    }
+  } finally {
+    await first.close();
+  }
+
+  const second = mint(stateDir, { pid: 404, token: 'fresh-2-birth', ownerStatus });
+  ownerStates.set(second.session.sessionId, 'match');
+  try {
+    assert.equal(stateOf(second), 'source_bound');
+    assert.equal(
+      second.registry.getClaim('source', source.worktreeKey)?.sessionId,
+      second.session.sessionId,
+    );
+  } finally {
+    await second.close();
+    await blocked.close().catch(() => undefined);
+    await owner.close().catch(() => undefined);
+  }
+});
+
+test('GH#767: a blocked absent-prior session is reminted on the documented transport restart', async () => {
+  const stateDir = mkdtempSync(join(tmpdir(), 'rn-gh767-remint-'));
+  roots.push(stateDir);
+  const ownerStates = new Map<string, OwnerStatus>();
+  const ownerStatus = (owner: SessionOwner): OwnerStatus =>
+    ownerStates.get(owner.sessionId) ?? 'match';
+
+  const owner = mint(stateDir, { pid: 101, token: 'owner-birth', ownerStatus });
+  ownerStates.set(owner.session.sessionId, 'match');
+  const blocked = mint(stateDir, { pid: 202, token: 'blocked-birth', ownerStatus });
+  owner.registry.releaseSession(owner.session);
+  ownerStates.set(owner.session.sessionId, 'mismatch');
+
+  assert.equal(recoveryOf(blocked).priorOwner, 'absent');
+  assert.equal(supervisorSessionIsTerminal(blocked), true);
+
+  const resolution = resolveSupervisorAuthorityForSpawn(blocked, () =>
+    mint(stateDir, { pid: 303, token: 'remint-birth', ownerStatus }),
+  );
+  try {
+    assert.equal(resolution.minted, true);
+    assert.ok(resolution.authority);
+    assert.notEqual(resolution.authority.session.sessionId, blocked.session.sessionId);
+    assert.equal(stateOf(resolution.authority), 'source_bound');
+  } finally {
+    await resolution.authority?.close();
+    await owner.close().catch(() => undefined);
+  }
+});
+
+test('GH#767: a live owner is never cleared or reminted', async () => {
+  const stateDir = mkdtempSync(join(tmpdir(), 'rn-gh767-live-'));
+  roots.push(stateDir);
+  const ownerStates = new Map<string, OwnerStatus>();
+  const ownerStatus = (owner: SessionOwner): OwnerStatus =>
+    ownerStates.get(owner.sessionId) ?? 'match';
+
+  const owner = mint(stateDir, { pid: 101, token: 'owner-birth', ownerStatus });
+  ownerStates.set(owner.session.sessionId, 'match');
+  const blocked = mint(stateDir, { pid: 202, token: 'blocked-birth', ownerStatus });
+  try {
+    assert.equal(stateOf(blocked), 'blocked');
+    assert.equal(recoveryOf(blocked).priorOwner, 'live');
+    assert.equal(supervisorSessionIsTerminal(blocked), false);
+    assert.equal(supervisorSessionIsTerminal(owner), false);
+
+    const resolution = resolveSupervisorAuthorityForSpawn(blocked, () => {
+      throw new Error('a live owner must never be reminted away');
+    });
+    assert.equal(resolution.minted, false);
+    assert.equal(resolution.authority, blocked);
+
+    const contender = mint(stateDir, { pid: 303, token: 'fresh-live-birth', ownerStatus });
+    try {
+      assert.equal(stateOf(contender), 'blocked');
+      assert.equal(recoveryOf(contender).priorOwner, 'live');
+      assert.equal(stateOf(owner), 'source_bound');
+      assert.equal(
+        owner.registry.getClaim('source', source.worktreeKey)?.sessionId,
+        owner.session.sessionId,
+      );
+    } finally {
+      await contender.close();
+    }
+  } finally {
+    await blocked.close();
+    await owner.close();
+  }
+});
+
+test('GH#767: an ambiguous owner is treated as live and the fence stays', async () => {
+  const stateDir = mkdtempSync(join(tmpdir(), 'rn-gh767-unknown-'));
+  roots.push(stateDir);
+  const ownerStates = new Map<string, OwnerStatus>();
+  const ownerStatus = (owner: SessionOwner): OwnerStatus =>
+    ownerStates.get(owner.sessionId) ?? 'unknown';
+
+  const owner = mint(stateDir, { pid: 101, token: 'owner-birth', ownerStatus });
+  ownerStates.set(owner.session.sessionId, 'unknown');
+  const blocked = mint(stateDir, { pid: 202, token: 'blocked-birth', ownerStatus });
+  try {
+    assert.equal(stateOf(blocked), 'blocked');
+    assert.equal(recoveryOf(blocked).priorOwner, 'unknown');
+    assert.equal(supervisorSessionIsTerminal(blocked), false);
+
+    const contender = mint(stateDir, { pid: 303, token: 'fresh-unknown-birth', ownerStatus });
+    try {
+      assert.equal(stateOf(contender), 'blocked');
+      assert.equal(recoveryOf(contender).priorOwner, 'unknown');
+      assert.equal(
+        owner.registry.getClaim('source', source.worktreeKey)?.sessionId,
+        owner.session.sessionId,
+      );
+    } finally {
+      await contender.close();
+    }
+  } finally {
+    await blocked.close();
+    await owner.close();
+  }
+});
+
+test('GH#767: a foreign worktree blocked row is not discarded by another admission', async () => {
+  const stateDir = mkdtempSync(join(tmpdir(), 'rn-gh767-foreign-'));
+  roots.push(stateDir);
+  const ownerStates = new Map<string, OwnerStatus>();
+  const ownerStatus = (owner: SessionOwner): OwnerStatus =>
+    ownerStates.get(owner.sessionId) ?? 'match';
+
+  const foreignOwner = mint(stateDir, {
+    pid: 101,
+    token: 'foreign-owner-birth',
+    ownerStatus,
+    source: foreignSource,
+  });
+  ownerStates.set(foreignOwner.session.sessionId, 'match');
+  const foreignBlocked = mint(stateDir, {
+    pid: 202,
+    token: 'foreign-blocked-birth',
+    ownerStatus,
+    source: foreignSource,
+  });
+  foreignOwner.registry.releaseSession(foreignOwner.session);
+  ownerStates.set(foreignOwner.session.sessionId, 'mismatch');
+  assert.equal(recoveryOf(foreignBlocked).priorOwner, 'absent');
+
+  const local = mint(stateDir, { pid: 303, token: 'local-birth', ownerStatus });
+  ownerStates.set(local.session.sessionId, 'match');
+  try {
+    assert.equal(stateOf(local), 'source_bound');
+    assert.equal(stateOf(foreignBlocked), 'blocked');
+    assert.equal(recoveryOf(foreignBlocked).priorOwner, 'absent');
+  } finally {
+    await local.close();
+    await foreignBlocked.close().catch(() => undefined);
+    await foreignOwner.close().catch(() => undefined);
+  }
+});
+
+test('GH#767: proven-stale non-absent recovery is not reminted', async () => {
+  const stateDir = mkdtempSync(join(tmpdir(), 'rn-gh767-stale-'));
+  roots.push(stateDir);
+  const ownerStates = new Map<string, OwnerStatus>();
+  const ownerStatus = (owner: SessionOwner): OwnerStatus =>
+    ownerStates.get(owner.sessionId) ?? 'match';
+
+  const owner = mint(stateDir, { pid: 101, token: 'owner-birth', ownerStatus });
+  ownerStates.set(owner.session.sessionId, 'match');
+  const blocked = mint(stateDir, { pid: 202, token: 'blocked-birth', ownerStatus });
+  ownerStates.set(owner.session.sessionId, 'mismatch');
+
+  try {
+    assert.equal(recoveryOf(blocked).priorOwner, 'stale');
+    assert.equal(supervisorSessionIsTerminal(blocked), false);
+    assert.notEqual(owner.registry.getClaim('source', source.worktreeKey), null);
+    const resolution = resolveSupervisorAuthorityForSpawn(blocked, () => {
+      throw new Error('a proven-stale owner must not be reminted away');
+    });
+    assert.equal(resolution.minted, false);
+    assert.equal(resolution.authority, blocked);
+    assert.equal(
+      owner.registry.getClaim('source', source.worktreeKey)?.sessionId,
+      owner.session.sessionId,
+    );
+  } finally {
+    await blocked.close();
+    await owner.close();
+  }
+});

--- a/packages/rn-dev-agent-core/test/unit/session/gh-767-absent-claim-epoch-admission.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/gh-767-absent-claim-epoch-admission.test.ts
@@ -164,6 +164,45 @@ test('GH#767: a blocked absent-prior session is reminted on the documented trans
   }
 });
 
+test('GH#767: a failed remint still closes the terminal authority', async () => {
+  const stateDir = mkdtempSync(join(tmpdir(), 'rn-gh767-remint-fail-'));
+  roots.push(stateDir);
+  const ownerStates = new Map<string, OwnerStatus>();
+  const ownerStatus = (owner: SessionOwner): OwnerStatus =>
+    ownerStates.get(owner.sessionId) ?? 'match';
+
+  const owner = mint(stateDir, { pid: 101, token: 'owner-birth', ownerStatus });
+  ownerStates.set(owner.session.sessionId, 'match');
+  const blocked = mint(stateDir, { pid: 202, token: 'blocked-birth', ownerStatus });
+  owner.registry.releaseSession(owner.session);
+  ownerStates.set(owner.session.sessionId, 'mismatch');
+  assert.equal(supervisorSessionIsTerminal(blocked), true);
+
+  let closes = 0;
+  const observed: SupervisorAuthority = {
+    ...blocked,
+    close: async () => {
+      closes += 1;
+      await blocked.close();
+    },
+  };
+
+  const resolution = resolveSupervisorAuthorityForSpawn(observed, () => {
+    throw new Error('AUTHORITY_STORE_UNAVAILABLE: authority session could not be initialized');
+  });
+  assert.equal(resolution.minted, false);
+  assert.equal(resolution.authority, null);
+  assert.match(resolution.error ?? '', /AUTHORITY_STORE_UNAVAILABLE/);
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(closes, 1, 'the terminal authority must be closed when the remint fails');
+  assert.throws(
+    () => blocked.registry.getSessionStatus(blocked.session.sessionId),
+    'the terminal registry handle must not stay open',
+  );
+  await owner.close().catch(() => undefined);
+});
+
 test('GH#767: a live owner is never cleared or reminted', async () => {
   const stateDir = mkdtempSync(join(tmpdir(), 'rn-gh767-live-'));
   roots.push(stateDir);


### PR DESCRIPTION
## Intent

Fix https://github.com/Lykhoyda/rn-dev-agent/issues/767: a fresh MCP transport remains blocked after the prior claim epoch is absent, causing non-convergent transport-restart recovery and preventing exclusive device binding or dedicated simulator provisioning.

Implement the narrowest root-cause fix that makes one documented transport restart converge when the blocking claim epoch is absent and all earlier sessions are released with no remaining claims. Preserve exclusive ownership, source/worktree binding, live-owner refusal, epoch safety, and all existing non-absent recovery behavior. Any stale admission-fence clearing must be atomic with fresh-session registration and must never clear a live or ambiguous claim. Add discriminating regression coverage for repeated fresh transport creation after release/no-claims, plus negative controls for live, foreign, or ambiguous ownership.

Do not waive or misrepresent the required exact-head dedicated-device journey. That journey is mandatory before merge. It is performed by the implementing agent after the pipeline returns branch ownership, not by the pipeline test agent: this plugin-repo worktree has no RN app, and the installed marketplace plugin cache (rn-dev-agent/0.76.5) cannot exercise HEAD. The pipeline test step must run the GH#767 unit/MCP regression suites (and adjacent session tests) and must not exit non-zero solely because it cannot bind a sibling test-app through that cache. Never merge the PR. Do not broaden beyond issue 767.

Chosen implementation: treat a blocked session whose inspectRecoveryRequirement is transport-restart + priorOwner=absent as terminal (same remint path as GH #706 released/stale rows); atomically discard same-worktree blocked+absent contenders with no remaining source claim inside createSession's insert transaction; mint the successor before closing the terminal row; also close the prior terminal authority if mint() throws, preserving the preexisting cleanup guarantee.

Exact-head dedicated-device journey already completed after the previous failed run returned ownership (2026-08-13, exact-head packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js, cwd=sibling test-app, isolated XDG_STATE_HOME). Dedicated simulator fm-issue-767-iPhone17Pro UDID F35C85C0-1675-4D45-98E9-E0855612F179 was created and booted for this lane only. Overlapping transport B was blocked with priorOwner=live; after owner A released with no remaining claims, B reported transport-restart + priorOwner=absent; one documented restart (transport C) minted session d3c12902-232b-44a5-8746-335094f613f9 in source_bound. After observe stop, device_list showed that exact UDID; rn_session bind_device (ios, that UDID, appId com.rndevagent.testapp) returned ok with state device_claimed and deviceBound true. The dedicated simulator was then shutdown and deleted. This is not substitute registry-only evidence.

## What Changed

- `SessionRegistry.createSession` now runs inside a `#transaction`, and a new `#discardAbsentBlockedContenders` step atomically releases same-source/worktree/app-root `blocked` rows whose `inspectRecoveryRequirement` reports `transport-restart` + `priorOwner: 'absent'` — guarded so it is skipped entirely when a `source` claim still exists, and skipping any row that still owns a claim; the epoch-and-state-checked `UPDATE` keeps live and ambiguous claims untouched.
- `supervisorSessionIsTerminal` treats a `blocked` row with the same transport-restart/absent requirement as terminal alongside `released`/`stale`, so `resolveSupervisorAuthorityForSpawn` mints a successor instead of handing back the dead row; the terminal authority is now closed after a successful mint and also when `mint()` throws, preserving the prior cleanup guarantee on the error path.
- Added `test/unit/session/gh-767-absent-claim-epoch-admission.test.ts` (7 tests) covering repeated fresh transport creation after release with no remaining claims, plus negative controls for live, ambiguous, foreign-worktree, and proven-stale ownership; a changeset and the rebuilt `dist/` bundles for the claude and codex plugin packages ship with it.

The pipeline's Review step left one informational note: `#discardAbsentBlockedContenders` calls `inspectRecoveryRequirement` inside the `BEGIN IMMEDIATE` transaction, which can reach a `/bin/ps` owner probe — unreachable today because the `source`-claim guard returns before the scan, but worth hoisting if that guard is ever relaxed.

## Risk Assessment

✅ Low: The change is narrow and root-cause targeted: the fence clear reuses `discardBlockedSession`'s exact UPDATE and claim guard, is atomic with the fresh insert via the existing `#transaction` (which also preserves the `#secureFiles` call), never touches live/unknown/foreign/stale-with-claims rows, and the added suite discriminates the converging path, the rollback path, the failed-remint cleanup, and all three negative controls, with `dist` and both plugin bundles rebuilt consistently.

## Testing

Dependencies were missing in the worktree, so I first ran `yarn install --immutable` at the workspace root, then exercised the targeted GH#767 unit suite (7 tests, all pass), the adjacent session/registry/supervisor-authority suites (220 tests) and the MCP session-surface suites (140 tests) — all green. To prove the coverage is discriminating rather than tautological, I temporarily reverted the two changed dist modules to base 28f80c0 and re-ran the new suite: the three positive convergence tests fail while all four negative controls still pass, then restored the files and confirmed a clean worktree. For end-user-level evidence I wrote a journey script that drives the shipped build through the exact issue-767 sequence and prints the real `rn_session status` projection at each step; on the target commit one documented transport restart mints a successor in `source_bound` that owns the exclusive source claim (so device binding / dedicated simulator provisioning becomes possible), overlapping transports are still refused while an owner is live, and a later fresh transport converges again. The same script on the base commit leaves the restarted transport stuck in `blocked` / `transport-restart` / `priorOwner=absent` with no source claim, reproducing the reported non-convergence. This change is a session-authority/CLI surface with no rendered UI, so no screenshots apply; the reviewer-visible artifact is the before/after status transcript. Per the author's intent, the exact-head dedicated-device journey is owned by the implementing agent after the pipeline returns branch ownership and was not attempted here (this plugin worktree has no RN app), so nothing failed on that account.

<details>
<summary>Evidence: rn_session status journey on target commit d390365 — one restart converges</summary>

<code>── Step 3: owner A releases; no claims remain on the worktree&#10;$ rn_session status # transport B, after A released&#10;{&#10;&#34;state&#34;: &#34;blocked&#34;,&#10;&#34;recovery&#34;: { &#34;requirement&#34;: &#34;transport-restart&#34;, &#34;priorOwner&#34;: &#34;absent&#34; },&#10;&#34;sourceClaimHeldBy&#34;: null,&#10;&#34;ownsSourceClaim&#34;: false&#10;}&#10;&#10;── Step 4: the user performs ONE documented transport restart&#10;supervisorSessionIsTerminal(B) = true&#10;minted successor = true&#10;$ rn_session status # transport C, after one restart&#10;{&#10;&#34;state&#34;: &#34;source_bound&#34;,&#10;&#34;recovery&#34;: { &#34;requirement&#34;: &#34;none&#34;, &#34;priorOwner&#34;: &#34;absent&#34; },&#10;&#34;sourceClaimHeldBy&#34;: &#34;8f442f27…&#34;,&#10;&#34;ownsSourceClaim&#34;: true&#10;}&#10;✔ ONE restart converged: transport C is source_bound and owns the source claim&#10;→ device binding / dedicated simulator provisioning is now possible&#10;&#10;── Step 5: a second overlapping transport is still refused while C is live&#10;$ rn_session status # transport D, owner C live&#10;{&#10;&#34;state&#34;: &#34;blocked&#34;,&#10;&#34;recovery&#34;: { &#34;requirement&#34;: &#34;attach&#34;, &#34;priorOwner&#34;: &#34;live&#34; },&#10;&#34;sourceClaimHeldBy&#34;: &#34;8f442f27…&#34;,&#10;&#34;ownsSourceClaim&#34;: false&#10;}&#10;✔ exclusive ownership still enforced after the remint&#10;&#10;── Step 6: release C, then a fresh transport E converges again (repeatable)&#10;$ rn_session status # transport E, fresh start&#10;{&#10;&#34;state&#34;: &#34;source_bound&#34;,&#10;&#34;recovery&#34;: { &#34;requirement&#34;: &#34;none&#34;, &#34;priorOwner&#34;: &#34;absent&#34; },&#10;&#34;sourceClaimHeldBy&#34;: &#34;7c37dee9…&#34;,&#10;&#34;ownsSourceClaim&#34;: true&#10;}&#10;✔ repeated fresh transport creation converges — recovery is not one-way&#10;&#10;RESULT: CONVERGENT — GH#767 journey satisfied</code>

```text
════════════════════════════════════════════════════════════════
GH#767 — fresh MCP transport after an absent claim epoch
core build under test: /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXVJ3YPN1W2TRF8CAZSKCWJ/packages/rn-dev-agent-core/dist
════════════════════════════════════════════════════════════════

── Step 1: transport A starts and takes exclusive ownership of the worktree
  transport A session 78689581…
$ rn_session status            # transport A
{
  "state": "source_bound",
  "recovery": {
    "requirement": "none",
    "priorOwner": "absent"
  },
  "sourceClaimHeldBy": "78689581…",
  "ownsSourceClaim": true
}

── Step 2: an overlapping transport B starts while A is live → correctly refused
  transport B session 0fc4114b…
$ rn_session status            # transport B, owner A still live
{
  "state": "blocked",
  "recovery": {
    "requirement": "attach",
    "priorOwner": "live"
  },
  "sourceClaimHeldBy": "78689581…",
  "ownsSourceClaim": false
}

  ✔ live-owner refusal preserved (exclusive ownership held by A)

── Step 3: owner A releases; no claims remain on the worktree
$ rn_session status            # transport B, after A released
{
  "state": "blocked",
  "recovery": {
    "requirement": "transport-restart",
    "priorOwner": "absent"
  },
  "sourceClaimHeldBy": null,
  "ownsSourceClaim": false
}

  ✔ the user is told to restart the MCP transport, prior owner is absent
  remaining source claim: none

── Step 4: the user performs ONE documented transport restart
  supervisorSessionIsTerminal(B) = true
  minted successor = true
  transport C session 5117b736…
$ rn_session status            # transport C, after one restart
{
  "state": "source_bound",
  "recovery": {
    "requirement": "none",
    "priorOwner": "absent"
  },
  "sourceClaimHeldBy": "5117b736…",
  "ownsSourceClaim": true
}

  ✔ ONE restart converged: transport C is source_bound and owns the source claim
    → device binding / dedicated simulator provisioning is now possible

── Step 5: a second overlapping transport is still refused while C is live
$ rn_session status            # transport D, owner C live
{
  "state": "blocked",
  "recovery": {
    "requirement": "attach",
    "priorOwner": "live"
  },
  "sourceClaimHeldBy": "5117b736…",
  "ownsSourceClaim": false
}

  ✔ exclusive ownership still enforced after the remint

── Step 6: release C, then a fresh transport E converges again (repeatable)
$ rn_session status            # transport E, fresh start
{
  "state": "source_bound",
  "recovery": {
    "requirement": "none",
    "priorOwner": "absent"
  },
  "sourceClaimHeldBy": "f229f569…",
  "ownsSourceClaim": true
}

  ✔ repeated fresh transport creation converges — recovery is not one-way

════════════════════════════════════════════════════════════════
RESULT: CONVERGENT — GH#767 journey satisfied
════════════════════════════════════════════════════════════════
```
</details>
<details>
<summary>Evidence: Same journey on base 28f80c0 — reproduces GH#767 non-convergence</summary>

<code>── Step 3: owner A releases; no claims remain on the worktree&#10;$ rn_session status # transport B, after A released&#10;{&#10;&#34;state&#34;: &#34;blocked&#34;,&#10;&#34;recovery&#34;: { &#34;requirement&#34;: &#34;transport-restart&#34;, &#34;priorOwner&#34;: &#34;absent&#34; },&#10;&#34;sourceClaimHeldBy&#34;: null,&#10;&#34;ownsSourceClaim&#34;: false&#10;}&#10;&#10;── Step 4: the user performs ONE documented transport restart&#10;supervisorSessionIsTerminal(B) = false&#10;minted successor = false&#10;$ rn_session status # transport C, after one restart&#10;{&#10;&#34;state&#34;: &#34;blocked&#34;,&#10;&#34;recovery&#34;: { &#34;requirement&#34;: &#34;transport-restart&#34;, &#34;priorOwner&#34;: &#34;absent&#34; },&#10;&#34;sourceClaimHeldBy&#34;: null,&#10;&#34;ownsSourceClaim&#34;: false&#10;}&#10;✖ transport C did not obtain exclusive source binding&#10;&#10;RESULT: FAILED</code>

```text
════════════════════════════════════════════════════════════════
GH#767 — fresh MCP transport after an absent claim epoch
core build under test: /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01KZXVJ3YPN1W2TRF8CAZSKCWJ/packages/rn-dev-agent-core/dist
════════════════════════════════════════════════════════════════

── Step 1: transport A starts and takes exclusive ownership of the worktree
  transport A session 7853c820…
$ rn_session status            # transport A
{
  "state": "source_bound",
  "recovery": {
    "requirement": "none",
    "priorOwner": "absent"
  },
  "sourceClaimHeldBy": "7853c820…",
  "ownsSourceClaim": true
}

── Step 2: an overlapping transport B starts while A is live → correctly refused
  transport B session 96a1351c…
$ rn_session status            # transport B, owner A still live
{
  "state": "blocked",
  "recovery": {
    "requirement": "attach",
    "priorOwner": "live"
  },
  "sourceClaimHeldBy": "7853c820…",
  "ownsSourceClaim": false
}

  ✔ live-owner refusal preserved (exclusive ownership held by A)

── Step 3: owner A releases; no claims remain on the worktree
$ rn_session status            # transport B, after A released
{
  "state": "blocked",
  "recovery": {
    "requirement": "transport-restart",
    "priorOwner": "absent"
  },
  "sourceClaimHeldBy": null,
  "ownsSourceClaim": false
}

  ✔ the user is told to restart the MCP transport, prior owner is absent
  remaining source claim: none

── Step 4: the user performs ONE documented transport restart
  supervisorSessionIsTerminal(B) = false
  minted successor = false
  transport C session 96a1351c…
$ rn_session status            # transport C, after one restart
{
  "state": "blocked",
  "recovery": {
    "requirement": "transport-restart",
    "priorOwner": "absent"
  },
  "sourceClaimHeldBy": null,
  "ownsSourceClaim": false
}

  ✖ transport C did not obtain exclusive source binding

── Step 5: a second overlapping transport is still refused while C is live
$ rn_session status            # transport D, owner C live
{
  "state": "source_bound",
  "recovery": {
    "requirement": "none",
    "priorOwner": "absent"
  },
  "sourceClaimHeldBy": "e7115e38…",
  "ownsSourceClaim": true
}

  ✖ exclusivity regressed

── Step 6: release C, then a fresh transport E converges again (repeatable)
$ rn_session status            # transport E, fresh start
{
  "state": "blocked",
  "recovery": {
    "requirement": "attach",
    "priorOwner": "live"
  },
  "sourceClaimHeldBy": "e7115e38…",
  "ownsSourceClaim": false
}

  ✖ repeated fresh transport creation did not converge

════════════════════════════════════════════════════════════════
RESULT: FAILED
════════════════════════════════════════════════════════════════
```
</details>
<details>
<summary>Evidence: Discrimination check — new suite against base dist (positives fail, negative controls pass)</summary>

```text
$ git checkout 28f80c0 -- dist/session/registry.js dist/session/supervisor-authority.js
$ node --test test/unit/session/gh-767-absent-claim-epoch-admission.test.ts
✖ GH#767: repeated fresh transports converge after release and no remaining claims
✖ GH#767: a blocked absent-prior session is reminted on the documented transport restart
✖ GH#767: a failed remint still closes the terminal authority
✔ GH#767: a live owner is never cleared or reminted
✔ GH#767: an ambiguous owner is treated as live and the fence stays
✔ GH#767: a foreign worktree blocked row is not discarded by another admission
✔ GH#767: proven-stale non-absent recovery is not reminted
ℹ tests 7 ℹ pass 4 ℹ fail 3

$ git checkout HEAD -- dist/session/registry.js dist/session/supervisor-authority.js
$ node --test test/unit/session/gh-767-absent-claim-epoch-admission.test.ts
ℹ tests 7 ℹ pass 7 ℹ fail 0
```
</details>
<details>
<summary>Evidence: Journey driver script (evidence source)</summary>

```text
import { mkdtempSync, rmSync } from 'node:fs';
import { tmpdir } from 'node:os';
import { join } from 'node:path';

const DIST = process.env.GH767_DIST;
const { createSupervisorAuthority, resolveSupervisorAuthorityForSpawn, supervisorSessionIsTerminal } =
  await import(join(DIST, 'session/supervisor-authority.js'));
const { projectPublicAuthorityStatus } = await import(join(DIST, 'session/public-status.js'));

const source = {
  kind: 'git',
  contentRoot: '/repo',
  appRoot: '/repo/apps/mobile',
  sourceKey: 'source-key',
  worktreeKey: 'worktree-key',
  appRootKey: 'app-key',
  head: 'abc123',
};

const ownerStates = new Map();
const ownerStatus = (owner) => ownerStates.get(owner.sessionId) ?? 'match';
const stateDir = mkdtempSync(join(tmpdir(), 'gh767-journey-'));

const mint = (pid, token) =>
  createSupervisorAuthority({
    stateDir,
    source,
    supervisorBirth: { pid, source: 'linux-proc', token },
    uid: '501',
    startHeartbeat: false,
    ownerStatus,
  });

const short = (id) => `${id.slice(0, 8)}…`;

function say(line) {
  process.stdout.write(`${line}\n`);
}

function rnSessionStatus(authority, label) {
  const registry = authority.registry;
  const raw = registry.getSessionStatus(authority.session.sessionId);
  const recoveryRequirement = registry.inspectRecoveryRequirement(authority.session.sessionId);
  const projected = projectPublicAuthorityStatus({ available: true, ...raw }, { recoveryRequirement });
  const claim = registry.getClaim('source', source.worktreeKey);
  say(`$ rn_session status            # ${label}`);
  say(
    JSON.stringify(
      {
        state: projected.state,
        recovery: {
          requirement: recoveryRequirement.requirement,
          priorOwner: recoveryRequirement.priorOwner,
        },
        sourceClaimHeldBy: claim ? short(claim.sessionId) : null,
        ownsSourceClaim: claim?.sessionId === authority.session.sessionId,
      },
      null,
      2,
    ),
  );
  say('');
  return { state: projected.state, recoveryRequirement, claim };
}

say('════════════════════════════════════════════════════════════════');
say(`GH#767 — fresh MCP transport after an absent claim epoch`);
say(`core build under test: ${DIST}`);
say('════════════════════════════════════════════════════════════════');
say('');

let exitCode = 0;
const opened = [];

try {
  say('── Step 1: transport A starts and takes exclusive ownership of the worktree');
  const a = mint(101, 'transport-a-birth');
  opened.push(a);
  ownerStates.set(a.session.sessionId, 'match');
  say(`  transport A session ${short(a.session.sessionId)}`);
  rnSessionStatus(a, 'transport A');

  say('── Step 2: an overlapping transport B starts while A is live → correctly refused');
  const b = mint(202, 'transport-b-birth');
  opened.push(b);
  ownerStates.set(b.session.sessionId, 'match');
  say(`  transport B session ${short(b.session.sessionId)}`);
  const bLive = rnSessionStatus(b, 'transport B, owner A still live');
  if (bLive.state !== 'blocked' || bLive.recoveryRequirement.priorOwner !== 'live') {
    say('  ✖ expected blocked + priorOwner=live');
    exitCode = 1;
  } else {
    say('  ✔ live-owner refusal preserved (exclusive ownership held by A)');
  }
  say('');

  say('── Step 3: owner A releases; no claims remain on the worktree');
  a.registry.releaseSession(a.session);
  ownerStates.set(a.session.sessionId, 'mismatch');
  const bAbsent = rnSessionStatus(b, 'transport B, after A released');
  if (
    bAbsent.recoveryRequirement.requirement !== 'transport-restart' ||
    bAbsent.recoveryRequirement.priorOwner !== 'absent'
  ) {
    say('  ✖ expected transport-restart + priorOwner=absent');
    exitCode = 1;
  } else {
    say('  ✔ the user is told to restart the MCP transport, prior owner is absent');
  }
  say(`  remaining source claim: ${bAbsent.claim ? short(bAbsent.claim.sessionId) : 'none'}`);
  say('');

  say('── Step 4: the user performs ONE documented transport restart');
  say(`  supervisorSessionIsTerminal(B) = ${supervisorSessionIsTerminal(b)}`);
  const resolution = resolveSupervisorAuthorityForSpawn(b, () => mint(303, 'transport-c-birth'));
  say(`  minted successor = ${resolution.minted}`);
  if (resolution.error) say(`  error = ${resolution.error}`);
  if (!resolution.authority) {
    say('  ✖ the restart did not converge — no usable session');
    say('');
    say('RESULT: NOT CONVERGENT — the fresh transport is still blocked (GH#767 reproduced)');
    exitCode = 1;
  } else {
    const c = resolution.authority;
    opened.push(c);
    ownerStates.set(c.session.sessionId, 'match');
    say(`  transport C session ${short(c.session.sessionId)}`);
    const cStatus = rnSessionStatus(c, 'transport C, after one restart');
    if (cStatus.state !== 'source_bound' || !cStatus.claim || cStatus.claim.sessionId !== c.session.sessionId) {
      say('  ✖ transport C did not obtain exclusive source binding');
      exitCode = 1;
    } else {
      say('  ✔ ONE restart converged: transport C is source_bound and owns the source claim');
      say('    → device binding / dedicated simulator provisioning is now possible');
    }
    say('');

    say('── Step 5: a second overlapping transport is still refused while C is live');
    const d = mint(404, 'transport-d-birth');
    opened.push(d);
    ownerStates.set(d.session.sessionId, 'match');
    const dStatus = rnSessionStatus(d, 'transport D, owner C live');
    if (dStatus.state !== 'blocked' || dStatus.recoveryRequirement.priorOwner !== 'live') {
      say('  ✖ exclusivity regressed');
      exitCode = 1;
    } else if (dStatus.claim.sessionId !== c.session.sessionId) {
      say('  ✖ C lost its claim to a contender');
      exitCode = 1;
    } else {
      say('  ✔ exclusive ownership still enforced after the remint');
    }
    say('');

    say('── Step 6: release C, then a fresh transport E converges again (repeatable)');
    await c.close();
    opened.splice(opened.indexOf(c), 1);
    ownerStates.set(c.session.sessionId, 'mismatch');
    const e = mint(505, 'transport-e-birth');
    opened.push(e);
    ownerStates.set(e.session.sessionId, 'match');
    const eStatus = rnSessionStatus(e, 'transport E, fresh start');
    if (eStatus.state !== 'source_bound' || eStatus.claim.sessionId !== e.session.sessionId) {
      say('  ✖ repeated fresh transport creation did not converge');
      exitCode = 1;
    } else {
      say('  ✔ repeated fresh transport creation converges — recovery is not one-way');
    }
    say('');
  }

  say('════════════════════════════════════════════════════════════════');
  say(exitCode === 0 ? 'RESULT: CONVERGENT — GH#767 journey satisfied' : 'RESULT: FAILED');
  say('════════════════════════════════════════════════════════════════');
} finally {
  for (const authority of opened) {
    await authority.close().catch(() => undefined);
  }
  rmSync(stateDir, { force: true, recursive: true });
}

process.exit(exitCode);
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `packages/rn-dev-agent-core/src/session/registry.ts:3124` - `#discardAbsentBlockedContenders` calls `inspectRecoveryRequirement` inside the new `BEGIN IMMEDIATE` transaction, and that method can invoke `#ownerStatus` -&gt; `inspectSessionOwner` -&gt; `readProcessBirth`, which synchronously spawns `/bin/ps` on darwin (process-birth.ts:288). This deviates from the established pattern where owner probes are hoisted out of the write transaction (`#probeClaimOwners` at registry.ts:666, called before `this.#transaction` in `claimResources`), and the store only sets `PRAGMA busy_timeout=50` (authority-store.ts:164). Reachability is very low: any blocked row whose prior epoch still matches also still holds the worktree `source` claim, so the guard at registry.ts:3111 returns before the scan — which is why this is informational rather than a defect. If a future change relaxes that guard, hoist the requirement inspections before the transaction and re-verify `state`/`claim_epoch` inside, mirroring the probe pattern.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --test test/unit/session/gh-767-absent-claim-epoch-admission.test.ts` (7/7 pass on HEAD)</code>
- <code>Discrimination check: same suite re-run with `dist/session/registry.js` and `dist/session/supervisor-authority.js` reverted to base 28f80c0 — the 3 positive GH#767 tests fail, the 4 negative controls (live / ambiguous / foreign-worktree / proven-stale) still pass; files restored and worktree left clean</code>
- <code>`node --test test/unit/session/{registry,supervisor-authority,gh-706-released-session-recovery,gh-672-recovery-repair,gh-707-hard-reset-cold-start,new-session-authority-recovery,authority-gate,session-runtime-absence}.test.ts test/unit/session-recovery-workflow-surface.test.ts` (220 pass)</code>
- <code>MCP/session-surface suites: `node --test test/unit/session/{session-handler,rn-session-cli,authority-store,public-status}.test.ts test/unit/{gh-264-supervisor-core,with-session,gh-244-close-session-gone}.test.js` (140 pass)</code>
- <code>Manual end-to-end journey script `gh767-transport-journey.mjs` driving the shipped `dist/` supervisor-authority + `projectPublicAuthorityStatus` (the exact `rn_session status` projection) against an isolated temp state dir: A binds → B blocked/live → A releases → B reports transport-restart+absent → one restart mints C in source_bound owning the source claim → D still refused → release C → fresh E converges again</code>
- `Same journey script replayed against base 28f80c0 registry/supervisor-authority to capture the pre-fix failure transcript`
- <code>Setup fix: ran `yarn install --immutable` at the workspace root (dependencies were absent, causing an initial ERR_MODULE_NOT_FOUND for `yaml`)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
