### PR TITLE
test(rn-fast-runner): assert runner foreground before the B155 snapshot dispatch

### DIFF
--- a/.changeset/b155-regression-foreground-wait.md
+++ b/.changeset/b155-regression-foreground-wait.md
@@ -1,0 +1,5 @@
+---
+"rn-dev-agent-plugin": patch
+---
+
+Make the iOS B155 snapshot regression test wait for the runner to actually reach the foreground before dispatching the snapshot, so a failed or delayed re-activation fails the test instead of letting it pass vacuously.

--- a/packages/claude-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/SnapshotForegroundRegressionTest.swift
+++ b/packages/claude-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/SnapshotForegroundRegressionTest.swift
@@ -64,10 +64,21 @@ final class SnapshotForegroundRegressionTest: RnFastRunnerTests {
       "test-app \(Self.testAppBundleId) must be installed and launchable for this regression to be meaningful"
     )
     // Put runner foreground AGAIN so the dispatcher starts from the broken state.
+    // waitForExistence passes for a backgrounded app, so wait on state itself (GH #765).
     app.activate()
-    XCTAssertTrue(
-      app.waitForExistence(timeout: 5),
-      "runner must be foreground before the snapshot dispatch (B155 setup)"
+    let runnerForeground = XCTNSPredicateExpectation(
+      predicate: NSPredicate(format: "state == %d", XCUIApplication.State.runningForeground.rawValue),
+      object: app
+    )
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [runnerForeground], timeout: 10),
+      .completed,
+      "runner must be foreground before the snapshot dispatch (B155 setup); state=\(app.state.rawValue)"
+    )
+    XCTAssertEqual(
+      app.state,
+      .runningForeground,
+      "runner app should be foreground before the snapshot dispatch"
     )
     currentApp = app
     currentBundleId = nil

--- a/packages/codex-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/SnapshotForegroundRegressionTest.swift
+++ b/packages/codex-plugin/scripts/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/SnapshotForegroundRegressionTest.swift
@@ -64,10 +64,21 @@ final class SnapshotForegroundRegressionTest: RnFastRunnerTests {
       "test-app \(Self.testAppBundleId) must be installed and launchable for this regression to be meaningful"
     )
     // Put runner foreground AGAIN so the dispatcher starts from the broken state.
+    // waitForExistence passes for a backgrounded app, so wait on state itself (GH #765).
     app.activate()
-    XCTAssertTrue(
-      app.waitForExistence(timeout: 5),
-      "runner must be foreground before the snapshot dispatch (B155 setup)"
+    let runnerForeground = XCTNSPredicateExpectation(
+      predicate: NSPredicate(format: "state == %d", XCUIApplication.State.runningForeground.rawValue),
+      object: app
+    )
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [runnerForeground], timeout: 10),
+      .completed,
+      "runner must be foreground before the snapshot dispatch (B155 setup); state=\(app.state.rawValue)"
+    )
+    XCTAssertEqual(
+      app.state,
+      .runningForeground,
+      "runner app should be foreground before the snapshot dispatch"
     )
     currentApp = app
     currentBundleId = nil

--- a/packages/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/SnapshotForegroundRegressionTest.swift
+++ b/packages/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/SnapshotForegroundRegressionTest.swift
@@ -64,10 +64,21 @@ final class SnapshotForegroundRegressionTest: RnFastRunnerTests {
       "test-app \(Self.testAppBundleId) must be installed and launchable for this regression to be meaningful"
     )
     // Put runner foreground AGAIN so the dispatcher starts from the broken state.
+    // waitForExistence passes for a backgrounded app, so wait on state itself (GH #765).
     app.activate()
-    XCTAssertTrue(
-      app.waitForExistence(timeout: 5),
-      "runner must be foreground before the snapshot dispatch (B155 setup)"
+    let runnerForeground = XCTNSPredicateExpectation(
+      predicate: NSPredicate(format: "state == %d", XCUIApplication.State.runningForeground.rawValue),
+      object: app
+    )
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [runnerForeground], timeout: 10),
+      .completed,
+      "runner must be foreground before the snapshot dispatch (B155 setup); state=\(app.state.rawValue)"
+    )
+    XCTAssertEqual(
+      app.state,
+      .runningForeground,
+      "runner app should be foreground before the snapshot dispatch"
     )
     currentApp = app
     currentBundleId = nil


### PR DESCRIPTION
## Intent

Fix GitHub issue #765 in Lykhoyda/rn-dev-agent: in SnapshotForegroundRegressionTest.testForegroundSnapshotReturnsTestAppTree (iOS rn-fast-runner), the step-2 re-foregrounding after the test-app detour used app.activate() followed only by app.waitForExistence(timeout: 5). waitForExistence passes for a backgrounded app, so a failed or delayed activation could leave the test-app foreground when the snapshot dispatches; the dispatcher then returns the test-app tree without exercising the B155 activation transition and the test passes vacuously. The accepted fix: immediately before the step-2 snapshot dispatch, wait for and assert app.state == .runningForeground with a bounded XCTest expectation (XCTNSPredicateExpectation + XCTWaiter, 10s, matching neighboring waits), mirroring the established step-1 post-launch state assertion contract, plus a direct XCTAssertEqual on state. A failed/delayed activation must now fail the regression rather than pass vacuously. Deliberate decisions: test-only change — no product/dispatcher behavior changes; the existence check was replaced (foreground implies existence); the change is mirrored into both host-package copies (packages/claude-plugin and packages/codex-plugin scripts/rn-fast-runner) via corepack yarn build:host-runtimes, per repo convention; a one-sentence changeset patch-bumps rn-dev-agent-plugin because host packages ship the runner sources (same precedent as PR #764). Validation already performed: format/lint/sync/dist-fresh/ts-only checks green, corepack yarn test 4913/4913, corepack yarn test:native:ios 85/85 (compiles the modified UITests target; SnapshotForegroundRegressionTest itself is skipped there by design), plus a dedicated live simulator run of SnapshotForegroundRegressionTest at exact head 4b10b16d on a dedicated iPhone 17 Pro (iOS 26.4) sim with com.rndevagent.testapp installed and Metro serving: passed in 8.35s with B155_REGRESSION_OK markers_found=home-welcome,home-search-btn,tab-home,tab-tasks node_count=71. Constraints: never merge the PR; PR must be green before handoff.

## What Changed

- In `SnapshotForegroundRegressionTest.testForegroundSnapshotReturnsTestAppTree`, the step-2 re-activation after the test-app detour no longer relies on `app.waitForExistence(timeout: 5)` (which also passes for a backgrounded app). It now waits on the app state itself via `XCTNSPredicateExpectation` + `XCTWaiter` (10s, matching neighboring waits) for `state == .runningForeground`, plus a direct `XCTAssertEqual(app.state, .runningForeground)`, so a failed or delayed activation fails the regression instead of letting it pass vacuously against the test-app tree.
- The same change is mirrored into both host-package copies of the runner sources under `packages/claude-plugin` and `packages/codex-plugin` (`scripts/rn-fast-runner/...`), per repo convention.
- Adds a one-sentence changeset patch-bumping `rn-dev-agent-plugin`, since the host packages ship these runner sources. Test-only change — no dispatcher or product behavior was modified.

## Risk Assessment

✅ Low: Test-only, tightly scoped change that replaces a weaker existence check with a bounded foreground-state wait matching the file's existing step-1 contract and the neighboring XCTWaiter idiom, mirrored byte-identically into both host-package copies with a correct one-sentence patch changeset.

## Testing

On a live iPhone 17 Pro (iOS 26.4) simulator I ran a temporary XCUITest harness that puts the runner in exactly the failure state from issue #765 — foreground stolen by another app, re-activation not landed — and evaluated both gates: the pre-fix `app.waitForExistence(timeout:)` returned PASSED while `state == 3` (.runningBackground), and the shipped `XCTNSPredicateExpectation` + `XCTWaiter` wait TIMED OUT, i.e. it now fails the setup instead of letting the snapshot dispatch proceed vacuously; after a genuine `app.activate()` the shipped gate completed with `state == 4` (.runningForeground). Simulator screenshots captured at each point show Settings foreground while the old gate still claimed success, which is the reviewer-visible proof of the vacuity. The same xcodebuild invocation compiled the modified SnapshotForegroundRegressionTest.swift, and the three host-package copies are byte-identical. The real SnapshotForegroundRegressionTest itself could not be run end-to-end here because no simulator has com.rndevagent.testapp installed and that fixture app lives outside this repository (the author documented a passing live run at this exact head); the harness above proves the changed gate's behavior directly instead. Temporary test file and xcresult/DerivedData output were deleted and the worktree is clean.

- Evidence: Simulator at the moment the OLD gate passed: runner backgrounded, Settings foreground (local file: <code>/var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/no-mistakes-evidence/01M0132ZQ39SQBFZPG6PA23BDB/screenshots/02-runner-backgrounded-activation-did-not-land.png</code>)
- Evidence: Simulator after a real activation: runner foreground, shipped gate completed (local file: <code>/var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/no-mistakes-evidence/01M0132ZQ39SQBFZPG6PA23BDB/screenshots/03-runner-foreground-after-real-activation.png</code>)
- Evidence: Runner foreground right after launch (baseline) (local file: <code>/var/folders/wy/khrzvmhd0ss969ydn32ghccm0000gn/T/no-mistakes-evidence/01M0132ZQ39SQBFZPG6PA23BDB/screenshots/01-runner-foreground-after-launch.png</code>)
<details>
<summary>Evidence: Live gate-comparison test output (old gate vs shipped gate)</summary>

<code>GH765_EVIDENCE phase=failed_activation runner_state=3 old_gate_waitForExistence=PASSED(vacuous) new_gate_waitForForeground=TIMED_OUT(caught)&#10;GH765_EVIDENCE phase=successful_activation runner_state=4 new_gate_waitForForeground=completed&#10;Test Case &#39;-[RnFastRunnerUITests.GH765GateEvidenceTests testOldGatePassesVacuouslyWhileNewGateCatchesFailedActivation]&#39; passed (38.686 seconds).&#10;** TEST SUCCEEDED **</code>

```text
Test Case '-[RnFastRunnerUITests.GH765GateEvidenceTests testCommand]' started.
Test Case '-[RnFastRunnerUITests.GH765GateEvidenceTests testCommand]' passed (0.052 seconds).
Test Case '-[RnFastRunnerUITests.GH765GateEvidenceTests testOldGatePassesVacuouslyWhileNewGateCatchesFailedActivation]' started.
2026-08-14 23:39:07.603555+0200 RnFastRunnerUITests-Runner[53842:2656221] GH765_EVIDENCE phase=failed_activation runner_state=3 old_gate_waitForExistence=PASSED(vacuous) new_gate_waitForForeground=TIMED_OUT(caught)
2026-08-14 23:39:08.899001+0200 RnFastRunnerUITests-Runner[53842:2656221] GH765_EVIDENCE phase=successful_activation runner_state=4 new_gate_waitForForeground=completed
Test Case '-[RnFastRunnerUITests.GH765GateEvidenceTests testOldGatePassesVacuouslyWhileNewGateCatchesFailedActivation]' passed (38.686 seconds).
	 Executed 2 tests, with 0 failures (0 unexpected) in 38.737 (38.740) seconds
	 Executed 2 tests, with 0 failures (0 unexpected) in 38.737 (38.743) seconds
	 Executed 2 tests, with 0 failures (0 unexpected) in 38.737 (38.746) seconds
** TEST SUCCEEDED **
```
</details>
<details>
<summary>Evidence: Full xcodebuild log for the gate-comparison run</summary>

```text
Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild test -project RnFastRunner.xcodeproj -scheme RnFastRunner -destination id=7A6033C8-9291-4B0B-80B9-46024EEDF7D7 -derivedDataPath ../build/DerivedData-native-tests -resultBundlePath ../build/gh765.xcresult CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=YES "SWIFT_ACTIVE_COMPILATION_CONDITIONS=DEBUG RN_FAST_RUNNER_TEST_FAULTS" "-only-testing:RnFastRunnerUITests/GH765GateEvidenceTests"

Build settings from command line:
    CODE_SIGN_IDENTITY = 
    CODE_SIGNING_ALLOWED = NO
    CODE_SIGNING_REQUIRED = NO
    ONLY_ACTIVE_ARCH = YES
    SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG RN_FAST_RUNNER_TEST_FAULTS

Writing result bundle at path:
	/Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/gh765.xcresult

note: Using codesigning identity override: 
ComputePackagePrebuildTargetDependencyGraph

Prepare packages

CreateBuildRequest

SendProjectDescription

CreateBuildOperation

ComputeTargetDependencyGraph
note: Building targets in dependency order
note: Target dependency graph (2 targets)
    Target 'RnFastRunnerUITests' in project 'RnFastRunner'
        ➜ Explicit dependency on target 'RnFastRunner' in project 'RnFastRunner'
    Target 'RnFastRunner' in project 'RnFastRunner' (no dependencies)

GatherProvisioningInputs

CreateBuildDescription

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -v -E -dM -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.4.sdk -x c -c /dev/null

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/usr/bin/actool --print-asset-tag-combinations --output-format xml1 /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/RnFastRunner/RnFastRunner/Assets.xcassets

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -v -E -dM -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.4.sdk -x objective-c -c /dev/null

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -v -E -dM -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.4.sdk -x c -c /dev/null

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/usr/bin/actool --version --output-format xml1

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld -version_details

Build description signature: 0ac002dc6507d0791d76b996b6fd4b37
Build description path: /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex/XCBuildData/0ac002dc6507d0791d76b996b6fd4b37.xcbuilddata
ClangStatCache /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.4.sdk /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/SDKStatCaches.noindex/iphonesimulator26.4-23E237-686eebb5dc1d8ecb277353a59184f4aa.sdkstatcache
    cd /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/RnFastRunner/RnFastRunner.xcodeproj
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.4.sdk -o /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/SDKStatCaches.noindex/iphonesimulator26.4-23E237-686eebb5dc1d8ecb277353a59184f4aa.sdkstatcache

CreateBuildDirectory /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex
    cd /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/RnFastRunner/RnFastRunner.xcodeproj
    builtin-create-build-directory /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex

CreateBuildDirectory /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products
    cd /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/RnFastRunner/RnFastRunner.xcodeproj
    builtin-create-build-directory /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products

CreateBuildDirectory /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator
    cd /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/RnFastRunner/RnFastRunner.xcodeproj
    builtin-create-build-directory /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator

CreateBuildDirectory /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex/SwiftExplicitPrecompiledModules
    cd /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/RnFastRunner/RnFastRunner.xcodeproj
    builtin-create-build-directory /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex/SwiftExplicitPrecompiledModules

CreateBuildDirectory /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex/ExplicitPrecompiledModules
    cd /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/RnFastRunner/RnFastRunner.xcodeproj
    builtin-create-build-directory /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex/ExplicitPrecompiledModules

CreateBuildDirectory /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex/EagerLinkingTBDs/Debug-iphonesimulator
    cd /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/RnFastRunner/RnFastRunner.xcodeproj
    builtin-create-build-directory /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex/EagerLinkingTBDs/Debug-iphonesimulator

WriteAuxiliaryFile /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Intermediates.noindex/RnFastRunner.build/Debug-iphonesimulator/RnFastRunner-9de1c3e5d276b145f4a694780450ba1a-VFS-iphonesimulator/all-product-headers.yaml
    cd /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-

... [232748 bytes truncated] ...

s -exclude PrivateHeaders -exclude Modules -exclude \*.tbd -resolve-src-symlinks /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/Testing.framework /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunnerUITests-Runner.app/Frameworks

RegisterExecutionPolicyException /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunnerUITests-Runner.app/PlugIns/RnFastRunnerUITests.xctest (in target 'RnFastRunnerUITests' from project 'RnFastRunner')
    cd /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/RnFastRunner
    builtin-RegisterExecutionPolicyException /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunnerUITests-Runner.app/PlugIns/RnFastRunnerUITests.xctest

Touch /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunnerUITests-Runner.app/PlugIns/RnFastRunnerUITests.xctest (in target 'RnFastRunnerUITests' from project 'RnFastRunner')
    cd /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/RnFastRunner
    /usr/bin/touch -c /Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/DerivedData-native-tests/Build/Products/Debug-iphonesimulator/RnFastRunnerUITests-Runner.app/PlugIns/RnFastRunnerUITests.xctest

2026-08-14 23:38:26.037368+0200 RnFastRunnerUITests-Runner[53842:2656221] [Default] Running tests...
2026-08-14 23:38:26.066675+0200 RnFastRunnerUITests-Runner[53842:2658100] [General] Failed to send CA Event for app launch measurements for ca_event_type: 0 event_name: com.apple.app_launch_measurement.FirstFramePresentationMetric
2026-08-14 23:38:26.108751+0200 RnFastRunnerUITests-Runner[53842:2658115] [General] Failed to send CA Event for app launch measurements for ca_event_type: 1 event_name: com.apple.app_launch_measurement.ExtendedLaunchMetrics
    t =      nans Interface orientation changed to Portrait
Test Suite 'Selected tests' started at 2026-08-14 23:38:30.470.
Test Suite 'RnFastRunnerUITests.xctest' started at 2026-08-14 23:38:30.470.
Test Suite 'GH765GateEvidenceTests' started at 2026-08-14 23:38:30.471.
Test Case '-[RnFastRunnerUITests.GH765GateEvidenceTests testCommand]' started.
    t =     0.00s Start Test at 2026-08-14 23:38:30.471
    t =     0.05s Set Up
    t =     0.05s Tear Down
Test Case '-[RnFastRunnerUITests.GH765GateEvidenceTests testCommand]' passed (0.052 seconds).
Test Case '-[RnFastRunnerUITests.GH765GateEvidenceTests testOldGatePassesVacuouslyWhileNewGateCatchesFailedActivation]' started.
    t =     0.00s Start Test at 2026-08-14 23:38:30.524
    t =     0.03s Set Up
    t =     0.03s Open dev.lykhoyda.rndevagent.fastrunner
    t =     0.07s     Launch dev.lykhoyda.rndevagent.fastrunner
2026-08-14 23:38:46.789 xcodebuild[16228:2592125] [MT] IDELaunchParametersSnapshot: The operation couldn’t be completed. (DebuggerLLDB.DebuggerVersionStore.StoreError error 0.)
2026-08-14 23:38:46.800 xcodebuild[16228:2592125] [MT] IDELaunchParametersSnapshot: no debugger version
    t =    20.60s         Setting up automation session
    t =    22.64s Added attachment named '01-runner-foreground-after-launch'
    t =    22.64s Open com.apple.Preferences
    t =    22.65s     Launch com.apple.Preferences
    t =    22.77s         Setting up automation session
    t =    25.82s Checking `Expect predicate `state == 4` for object Application 'com.apple.Preferences'`
    t =    25.92s Added attachment named '02-runner-backgrounded-activation-did-not-land'
    t =    25.92s Waiting 5.0s for Target Application 'dev.lykhoyda.rndevagent.fastrunner' to exist
    t =    26.97s     Checking `Expect predicate `existsNoRetry == 1` for object Target Application 'dev.lykhoyda.rndevagent.fastrunner'`
    t =    26.97s         Checking existence of `Target Application 'dev.lykhoyda.rndevagent.fastrunner'`
    t =    28.10s Checking `Expect predicate `state == 4` for object Target Application 'dev.lykhoyda.rndevagent.fastrunner'`
    t =    28.11s     Capturing element debug description
    t =    29.14s Checking `Expect predicate `state == 4` for object Target Application 'dev.lykhoyda.rndevagent.fastrunner'`
    t =    29.14s     Capturing element debug description
    t =    30.11s Checking `Expect predicate `state == 4` for object Target Application 'dev.lykhoyda.rndevagent.fastrunner'`
    t =    30.11s     Capturing element debug description
    t =    31.13s Checking `Expect predicate `state == 4` for object Target Application 'dev.lykhoyda.rndevagent.fastrunner'`
    t =    31.13s     Capturing element debug description
    t =    32.17s Checking `Expect predicate `state == 4` for object Target Application 'dev.lykhoyda.rndevagent.fastrunner'`
    t =    32.17s     Capturing element debug description
    t =    33.10s Checking `Expect predicate `state == 4` for object Target Application 'dev.lykhoyda.rndevagent.fastrunner'`
    t =    33.10s     Capturing element debug description
    t =    34.14s Checking `Expect predicate `state == 4` for object Target Application 'dev.lykhoyda.rndevagent.fastrunner'`
    t =    34.14s     Capturing element debug description
    t =    35.08s Checking `Expect predicate `state == 4` for object Target Application 'dev.lykhoyda.rndevagent.fastrunner'`
    t =    35.08s     Capturing element debug description
    t =    36.13s Checking `Expect predicate `state == 4` for object Target Application 'dev.lykhoyda.rndevagent.fastrunner'`
    t =    36.13s     Capturing element debug description
    t =    37.07s Checking `Expect predicate `state == 4` for object Target Application 'dev.lykhoyda.rndevagent.fastrunner'`
    t =    37.08s     Capturing element debug description
2026-08-14 23:39:07.603555+0200 RnFastRunnerUITests-Runner[53842:2656221] GH765_EVIDENCE phase=failed_activation runner_state=3 old_gate_waitForExistence=PASSED(vacuous) new_gate_waitForForeground=TIMED_OUT(caught)
    t =    37.08s Open dev.lykhoyda.rndevagent.fastrunner
    t =    37.10s     Activate dev.lykhoyda.rndevagent.fastrunner
    t =    38.38s Checking `Expect predicate `state == 4` for object Target Application 'dev.lykhoyda.rndevagent.fastrunner'`
2026-08-14 23:39:08.899001+0200 RnFastRunnerUITests-Runner[53842:2656221] GH765_EVIDENCE phase=successful_activation runner_state=4 new_gate_waitForForeground=completed
    t =    38.48s Added attachment named '03-runner-foreground-after-real-activation'
    t =    38.48s Tear Down
Test Case '-[RnFastRunnerUITests.GH765GateEvidenceTests testOldGatePassesVacuouslyWhileNewGateCatchesFailedActivation]' passed (38.686 seconds).
Test Suite 'GH765GateEvidenceTests' passed at 2026-08-14 23:39:09.211.
	 Executed 2 tests, with 0 failures (0 unexpected) in 38.737 (38.740) seconds
Test Suite 'RnFastRunnerUITests.xctest' passed at 2026-08-14 23:39:09.213.
	 Executed 2 tests, with 0 failures (0 unexpected) in 38.737 (38.743) seconds
Test Suite 'Selected tests' passed at 2026-08-14 23:39:09.216.
	 Executed 2 tests, with 0 failures (0 unexpected) in 38.737 (38.746) seconds
2026-08-14 23:39:18.050 xcodebuild[16228:2592125] [MT] IDETestOperationsObserverDebug: 77.950 elapsed -- Testing started completed.
2026-08-14 23:39:18.052 xcodebuild[16228:2592125] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
2026-08-14 23:39:18.052 xcodebuild[16228:2592125] [MT] IDETestOperationsObserverDebug: 77.950 sec, +77.950 sec -- end

Test session results, code coverage, and logs:
	/Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M0132ZQ39SQBFZPG6PA23BDB/packages/rn-fast-runner/build/gh765.xcresult

** TEST SUCCEEDED **

Testing started
```
</details>
- Outcome: ⚠️ 1 info across 1 run (7m21s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4b10b16ddde75c7b2c78a74dd8ad6a74e4d39962","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `packages/rn-fast-runner/RnFastRunner/RnFastRunnerUITests/SnapshotForegroundRegressionTest.swift:161` - setUp sets continueAfterFailure = true (pre-existing, line 27), so when the new foreground assertion at line 73 fails the test does not abort — it proceeds through the snapshot dispatch and can still emit the NSLog &#34;B155_REGRESSION_OK markers_found=... node_count=...&#34; marker at line 161 even though the run failed. The xcodebuild result is correctly a failure, and nothing in the repo greps for that marker programmatically, but this workflow uses the marker as human-read proof evidence (the intent cites it verbatim), so a log-only reader could misread a failed activation as a pass. Optional hardening: return early after the foreground assertion, or fold the state check into the success condition guarding the NSLog.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ The real SnapshotForegroundRegressionTest could not be executed end-to-end in this environment: no simulator has com.rndevagent.testapp installed, and that fixture app&#39;s source/Metro project lives outside this repository, so its step-2 precondition cannot be satisfied here. The gate semantics were instead proven directly with a live XCUITest harness on a simulator; the author separately documented a passing live run at this exact head.
- <code>`xcodebuild test -project RnFastRunner.xcodeproj -scheme RnFastRunner -destination id=7A6033C8-... -only-testing:RnFastRunnerUITests/GH765GateEvidenceTests` (temporary live-simulator harness comparing the pre-fix `waitForExistence` gate against the shipped `XCTNSPredicateExpectation`/`XCTWaiter` foreground gate, both with a backgrounded runner and after a real `app.activate()`)</code>
- <code>Compilation of the modified `SnapshotForegroundRegressionTest.swift` as part of the `RnFastRunnerUITests` target in that same xcodebuild run</code>
- <code>XCTAttachment screenshots exported from the .xcresult via `xcrun xcresulttool export attachments` showing the simulator&#39;s actual foreground app at each gate check</code>
- <code>`cmp` of `packages/rn-fast-runner`, `packages/claude-plugin/scripts/rn-fast-runner`, and `packages/codex-plugin/scripts/rn-fast-runner` copies of SnapshotForegroundRegressionTest.swift (all identical)</code>
- <code>`git status --porcelain` after removing the temporary harness and build output (clean)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
