### PR TITLE
fix(release): correct the phantom 0.70.5 changelog entry and block changeset-only PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,10 @@ corepack yarn build:docs
 
 ## Changesets And Versions
 
+- A changeset must land in the same PR as the change it describes. A
+  changeset-only PR is rejected by `scripts/require-changeset.sh` (phantom
+  0.70.5 post-mortem: a merged release declaration produced a changelog claim
+  with no shipped code).
 - Changes under `packages/rn-dev-agent-core/src/` are shippable source changes.
   They require a changeset that bumps `rn-dev-agent-plugin` so marketplace
   installs receive the updated bundled runtime. Usually bump

--- a/apps/docs-site/src/content/docs/changelog.md
+++ b/apps/docs-site/src/content/docs/changelog.md
@@ -345,7 +345,7 @@ description: "Release history for rn-dev-agent"
 
 #### Patch Changes
 
-- fddcfae: On Python 3.14 with an installed-but-crashing fb-idb, ensure-idb reports the interpreter incompatibility and recommends reinstalling fb-idb under Python 3.13, and stops retrying once the incompatible-Python verdict is reached.
+- fddcfae: Release-record correction: this entry originally claimed the ensure-idb Python 3.14 incompatibility fix, but only the release-declaring changeset merged (#601) — no corresponding code shipped in 0.70.5. The fix shipped in 0.76.0 (#578, see the 6c1533f entry).
 
 ### 0.70.4
 

--- a/docs/CONTRIBUTING-VERSIONS.md
+++ b/docs/CONTRIBUTING-VERSIONS.md
@@ -102,8 +102,13 @@ You can add one after the fact:
 corepack yarn changeset
 ```
 
-…and amend it into your PR (or push as a follow-up commit). If you
-genuinely have no user-facing change (e.g. fixing a typo in a comment),
+…and push it to the same PR as the change it describes. Do **not** open a
+separate changeset-only PR: `scripts/require-changeset.sh` rejects a PR that
+adds a changeset while changing nothing outside `.changeset/`, because such a
+changeset mints a CHANGELOG entry for code that never shipped (the phantom
+0.70.5 entry). Deleting or rewording a pending changeset is still allowed.
+
+If you genuinely have no user-facing change (e.g. fixing a typo in a comment),
 you can ship a PR with no changeset — `changeset version` will simply
 not bump anything for that PR.
 

--- a/packages/claude-plugin/CHANGELOG.md
+++ b/packages/claude-plugin/CHANGELOG.md
@@ -370,7 +370,7 @@
 
 ### Patch Changes
 
-- fddcfae: On Python 3.14 with an installed-but-crashing fb-idb, ensure-idb reports the interpreter incompatibility and recommends reinstalling fb-idb under Python 3.13, and stops retrying once the incompatible-Python verdict is reached.
+- fddcfae: Release-record correction: this entry originally claimed the ensure-idb Python 3.14 incompatibility fix, but only the release-declaring changeset merged (#601) — no corresponding code shipped in 0.70.5. The fix shipped in 0.76.0 (#578, see the 6c1533f entry).
 
 ## 0.70.4
 

--- a/scripts/require-changeset.sh
+++ b/scripts/require-changeset.sh
@@ -8,6 +8,7 @@
 #
 # Test seams (scripts/test/require-changeset.test.sh):
 #   CHANGED_FILES  newline-separated changed paths (overrides git diff)
+#   ADDED_FILES    newline-separated added paths (used with CHANGED_FILES)
 #   REPO_ROOT      where to look for .changeset/ (default: repo root)
 #   BASE_REF       git diff base when CHANGED_FILES is unset (default origin/main)
 set -uo pipefail
@@ -25,6 +26,34 @@ if [ -n "${CHANGED_FILES+x}" ]; then
   changed="$CHANGED_FILES"
 else
   changed="$(git -C "$ROOT" diff --name-only "${BASE_REF}...HEAD")"
+fi
+
+# Inverse guard (GH #578 phantom-0.70.5 post-mortem): a PR that ADDS a changeset
+# while changing nothing outside .changeset/ declares a release claim with no
+# shipped change — `changeset version` then mints a changelog entry for behavior
+# that never landed (the fddcfae/#601 changeset-only merge made 0.70.5 claim the
+# ensure-idb Python 3.14 fix 11 releases before the code shipped in 0.76.0).
+# Deleting or rewording a pending changeset stays allowed (Version Packages bot).
+if [ -n "${CHANGED_FILES+x}" ]; then
+  added="${ADDED_FILES-}"
+else
+  added="$(git -C "$ROOT" diff --diff-filter=A --name-only "${BASE_REF}...HEAD" -- '.changeset')"
+fi
+non_changeset_changed="$(printf '%s\n' "$changed" | grep -v '^\.changeset/' | grep -v '^$' || true)"
+added_changesets="$(printf '%s\n' "$added" | grep -E '^\.changeset/[^/]+\.md$' | grep -vE '^\.changeset/README\.md$' || true)"
+if [ -z "$non_changeset_changed" ] && [ -n "$added_changesets" ]; then
+  echo "ERROR: this PR adds a changeset but changes nothing outside .changeset/:" >&2
+  printf '%s\n' "$added_changesets" | sed 's/^/  /' >&2
+  cat >&2 <<'MSG'
+
+A changeset that merges without the change it describes becomes a phantom
+changelog entry at the next `changeset version` (GH #578 post-mortem: the
+fddcfae/#601 changeset-only merge made 0.70.5 claim the ensure-idb
+Python 3.14 fix 11 releases before the code shipped in 0.76.0).
+
+Fix: land the changeset in the same PR as the change it describes.
+MSG
+  exit 1
 fi
 
 src_changed="$(printf '%s\n' "$changed" | grep -E "$WATCHED" || true)"

--- a/scripts/require-changeset.sh
+++ b/scripts/require-changeset.sh
@@ -24,8 +24,9 @@ WATCHED='^packages/rn-dev-agent-core/src/|^packages/(claude-plugin|codex-plugin|
 
 if [ -n "${CHANGED_FILES+x}" ]; then
   changed="$CHANGED_FILES"
-else
-  changed="$(git -C "$ROOT" diff --name-only "${BASE_REF}...HEAD")"
+elif ! changed="$(git -C "$ROOT" diff --name-only "${BASE_REF}...HEAD")"; then
+  echo "ERROR: require-changeset: git diff against ${BASE_REF} failed — refusing to pass without a changed-file list." >&2
+  exit 1
 fi
 
 # Inverse guard (GH #578 phantom-0.70.5 post-mortem): a PR that ADDS a changeset
@@ -36,8 +37,9 @@ fi
 # Deleting or rewording a pending changeset stays allowed (Version Packages bot).
 if [ -n "${CHANGED_FILES+x}" ]; then
   added="${ADDED_FILES-}"
-else
-  added="$(git -C "$ROOT" diff --diff-filter=A --name-only "${BASE_REF}...HEAD" -- '.changeset')"
+elif ! added="$(git -C "$ROOT" diff --diff-filter=A --name-only "${BASE_REF}...HEAD" -- '.changeset')"; then
+  echo "ERROR: require-changeset: git diff against ${BASE_REF} failed — refusing to pass without an added-file list." >&2
+  exit 1
 fi
 non_changeset_changed="$(printf '%s\n' "$changed" | grep -v '^\.changeset/' | grep -v '^$' || true)"
 added_changesets="$(printf '%s\n' "$added" | grep -E '^\.changeset/[^/]+\.md$' | grep -vE '^\.changeset/README\.md$' || true)"

--- a/scripts/require-changeset.sh
+++ b/scripts/require-changeset.sh
@@ -37,7 +37,7 @@ fi
 # Deleting or rewording a pending changeset stays allowed (Version Packages bot).
 if [ -n "${CHANGED_FILES+x}" ]; then
   added="${ADDED_FILES-}"
-elif ! added="$(git -C "$ROOT" diff --diff-filter=A --name-only "${BASE_REF}...HEAD" -- '.changeset')"; then
+elif ! added="$(git -C "$ROOT" diff --no-renames --diff-filter=A --name-only "${BASE_REF}...HEAD" -- '.changeset')"; then
   echo "ERROR: require-changeset: git diff against ${BASE_REF} failed — refusing to pass without an added-file list." >&2
   exit 1
 fi

--- a/scripts/test/require-changeset.test.sh
+++ b/scripts/test/require-changeset.test.sh
@@ -142,4 +142,9 @@ CHANGED_FILES=$'.changeset/one.md\n.changeset/two.md' ADDED_FILES=$'.changeset/o
   REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
 check "multi-changeset-only addition fails" 1 $?
 
+# 6. git-mode diff failure ($tmp is not a git repo) -> MUST fail closed instead
+# of passing on an empty changed-file list.
+env -u CHANGED_FILES -u ADDED_FILES REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "git diff failure fails closed" 1 $?
+
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; exit 1; fi

--- a/scripts/test/require-changeset.test.sh
+++ b/scripts/test/require-changeset.test.sh
@@ -142,9 +142,52 @@ CHANGED_FILES=$'.changeset/one.md\n.changeset/two.md' ADDED_FILES=$'.changeset/o
   REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
 check "multi-changeset-only addition fails" 1 $?
 
+# 5e. a regenerated changeset arrives as a rename pair (old deleted, new added):
+# with git's default rename detection the addition would be invisible and the
+# phantom claim would merge. Seam form of the git-mode case below.
+CHANGED_FILES=$'.changeset/old-claims.md\n.changeset/new-claims.md' ADDED_FILES=$'.changeset/new-claims.md' \
+  REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "renamed changeset-only addition fails" 1 $?
+
 # 6. git-mode diff failure ($tmp is not a git repo) -> MUST fail closed instead
 # of passing on an empty changed-file list.
 env -u CHANGED_FILES -u ADDED_FILES REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
 check "git diff failure fails closed" 1 $?
+
+# 7. git mode, real repo: a changeset-only PR that RENAMES a pending changeset
+# still declares a fresh release claim with no shipped code. git pairs it as
+# `R old -> new` by default, so the guard must disable rename detection to see
+# the addition.
+gitrepo="$(mktemp -d)"
+trap 'rm -rf "$tmp" "$gitrepo"' EXIT
+(
+  set -e
+  cd "$gitrepo"
+  git init -q -b main .
+  git config user.email test@example.com
+  git config user.name test
+  mkdir .changeset
+  echo "# changesets readme" > .changeset/README.md
+  printf -- '---\n"rn-dev-agent-plugin": patch\n---\nclaim\n' > .changeset/old-name.md
+  git add -A
+  git commit -qm base
+  git checkout -qb feature
+  git mv .changeset/old-name.md .changeset/new-name.md
+  git commit -qam regenerate
+) >/dev/null 2>&1
+env -u CHANGED_FILES -u ADDED_FILES REPO_ROOT="$gitrepo" BASE_REF=main bash "$GUARD" >/dev/null 2>&1
+check "git-mode renamed changeset-only PR fails" 1 $?
+
+# 7b. git mode: deleting a pending changeset (Version Packages bot) still passes.
+(
+  set -e
+  cd "$gitrepo"
+  git checkout -q main
+  git checkout -qb consume
+  git rm -q .changeset/new-name.md 2>/dev/null || git rm -q .changeset/old-name.md
+  git commit -qm consume
+) >/dev/null 2>&1
+env -u CHANGED_FILES -u ADDED_FILES REPO_ROOT="$gitrepo" BASE_REF=main bash "$GUARD" >/dev/null 2>&1
+check "git-mode changeset deletion passes" 0 $?
 
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; exit 1; fi

--- a/scripts/test/require-changeset.test.sh
+++ b/scripts/test/require-changeset.test.sh
@@ -114,4 +114,32 @@ check "manifest/CHANGELOG/mirror-only change without changeset passes" 0 $?
 CHANGED_FILES="" REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
 check "empty diff passes" 0 $?
 
+# 5. changeset-only PR (adds a changeset, changes nothing else) -> MUST fail.
+# GH #578 phantom-0.70.5 post-mortem: the fddcfae/#601 changeset-only merge made
+# `changeset version` mint a 0.70.5 changelog entry for the ensure-idb Python
+# 3.14 fix 11 releases before the code shipped (0.76.0).
+CHANGED_FILES=$'.changeset/lone-claims.md' ADDED_FILES=$'.changeset/lone-claims.md' \
+  REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "changeset-only addition fails (phantom 0.70.5 class)" 1 $?
+
+# 5b. changeset deletion/reword-only (nothing ADDED) -> passes — the Version
+# Packages bot deletes consumed changesets, and pending-changeset text edits
+# describe already-merged code.
+CHANGED_FILES=$'.changeset/stale-entry.md' ADDED_FILES='' \
+  REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "changeset deletion/reword-only passes" 0 $?
+
+# 5c. changeset ADDED alongside the change it describes -> passes
+printf -- '---\n"rn-dev-agent-plugin": patch\n---\nship\n' > "$tmp/.changeset/paired-claims.md"
+CHANGED_FILES=$'.changeset/paired-claims.md\npackages/rn-dev-agent-core/src/index.ts' \
+  ADDED_FILES=$'.changeset/paired-claims.md' \
+  REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "changeset addition alongside code passes" 0 $?
+rm -f "$tmp/.changeset/paired-claims.md"
+
+# 5d. multiple changesets added, still nothing outside .changeset/ -> MUST fail
+CHANGED_FILES=$'.changeset/one.md\n.changeset/two.md' ADDED_FILES=$'.changeset/one.md\n.changeset/two.md' \
+  REPO_ROOT="$tmp" bash "$GUARD" >/dev/null 2>&1
+check "multi-changeset-only addition fails" 1 $?
+
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; exit 1; fi


### PR DESCRIPTION
## Intent

Investigate and fix the phantom release-history claim discovered while resolving issue #578: the 0.70.5 CHANGELOG entry in packages/claude-plugin/CHANGELOG.md credited changeset fddcfae with shipping the ensure-idb Python 3.14 incompatibility fix (the brief called it the 'IndexedDB fix'; the actual subject is fb-idb), but the corresponding code did not land. Treat it as a release-truthfulness defect, not wording cleanup. Established causal mechanism with commit evidence: commit fddcfae8 (issue #601, a 'trusted prerequisite: Plugin release changeset' step of story #578) merged ONLY .changeset/idb-python-314-compat.md with no code; the Version Packages bot (PR #602, commit 2f4a2a44) consumed it ~3 minutes later and minted the 0.70.5 changelog claim; v0.70.5's tree provably lacks all three claimed behaviors; the real fix shipped 19 days later in 0.76.0 (#578/#725, changelog entry 6c1533f). Deliverables chosen: (1) Correct the public changelog record - the 0.70.5 entry is deliberately rewritten in place as a release-record correction stating the fix did not ship there and pointing to 0.76.0; this intentional hand-edit of a historical changesets-generated section is mandated by the task acceptance ('no longer claims an unshipped fix') while preserving the version section, immutable tags, and all other history - do not flag the historical rewrite as a defect. (2) The phantom class is still reproducible on current tooling (CI only guarded code-without-changeset and changeset name validity), so the smallest direct guard was added at the authoritative PR gate: scripts/require-changeset.sh now rejects a PR that ADDS a changeset while changing nothing outside .changeset/; deleting or rewording pending changesets stays allowed so the Version Packages bot PR is unaffected. (3) Executable regressions in scripts/test/require-changeset.test.sh: phantom addition fails, multi-changeset-only fails, deletion/reword-only passes, paired addition passes; the guard replayed in git mode rejects historical fddcfae8. (4) After per-edit Codex review, both git diff invocations in the guard now fail closed with explicit errors when git cannot produce a file list (previously an empty diff on git failure silently passed), with a regression test driving the git path against a non-repo root. (5) Bounded audit: only three changeset-only commits exist in history; dd95747b (#361) and 33db4bee are proven legitimate backfills of already-merged code and were deliberately left untouched - no unbounded release-history rewrite. (6) One doctrine bullet added to AGENTS.md under Changesets And Versions. Deliberately ruled out as out-of-scope pre-existing design: expanding the WATCHED shippable-surface allowlist (GH #439 decision; would false-positive on legitimate releases like 0.70.6's ensure-ffmpeg.sh fix outside WATCHED), tightening the existence-only changeset match to per-PR changesets, and requiring a shippable-surface change alongside every added changeset. No changeset was added for this PR itself: CI-guard/docs/test-only per repo doctrine, CHANGELOG is excluded from the shippable surface. Legitimate changelog entries, package versioning, and generated release conventions preserved.

## What Changed

- Rewrote the `fddcfae` entry in the 0.70.5 section of `packages/claude-plugin/CHANGELOG.md` and the docs-site changelog mirror as an explicit release-record correction: the ensure-idb Python 3.14 fix never shipped in 0.70.5 (only the release-declaring changeset from #601 merged) and the entry now points to 0.76.0 (#578) where the code actually landed. Version sections and all other history are untouched.
- Added an inverse guard to `scripts/require-changeset.sh`: a PR that ADDS a `.changeset/*.md` file while changing nothing outside `.changeset/` now fails with a post-mortem explanation, while deleting or rewording pending changesets still passes so the Version Packages bot PR is unaffected. Rename detection is disabled on the added-file diff so a regenerated changeset can't slip through as a rename pair, and both `git diff` invocations now fail closed with an explicit error instead of passing on an empty file list.
- Extended `scripts/test/require-changeset.test.sh` with regressions for the new guard (single and multi changeset-only additions fail, renamed changeset-only addition fails, deletion/reword-only passes, changeset paired with code passes, git-diff failure fails closed) including two git-mode cases against a real throwaway repo; documented the rule in `AGENTS.md` and `docs/CONTRIBUTING-VERSIONS.md`.

## Risk Assessment

✅ Low: The change is confined to a CI-only shell guard with matching executable regressions, a documented historical changelog correction, and a docs bullet — no product or runtime code is touched, the new rejection path is narrowly scoped (adds a changeset AND changes nothing outside .changeset/), the Version Packages bot path is provably unaffected, and both git-diff invocations now fail closed rather than passing on an empty list.

## Testing

I reproduced the defect against the real commit that caused it: replayed the guard from the base commit and from this branch against fddcfae8 (#601), the changeset-only merge that minted the phantom 0.70.5 entry — the old guard passes it, the new guard rejects it with the phantom-claim message, and the Version Packages bot release commit plus this branch's own diff still pass, so the release path is not disturbed. I then verified the changelog correction is factually true rather than merely reworded by running the current ensure-idb contract test against ensure-idb.sh as it shipped at the 0.70.5 release commit: the broken-client and Python-3.14 assertions fail there and pass on this branch, confirming 0.70.5 lacked the behavior it credited and that the fix landed where the corrected entry now points (0.76.0, 6c1533f). The full require-changeset and ensure-idb unit suites pass and the worktree is clean. No visual evidence applies — the change touches a CI shell guard, a generated CHANGELOG, and repo doctrine, with no rendered user surface; the CLI transcripts are the end-user-facing artifact.

<details>
<summary>Evidence: Guard replayed against the historical phantom commit fddcfae8 (before/after + bot non-regression)</summary>

<code>$ git show fddcfae8:.changeset/idb-python-314-compat.md&#10;---&#10;&#34;rn-dev-agent-plugin&#34;: patch&#10;---&#10;On Python 3.14 with an installed-but-crashing fb-idb, ensure-idb reports the interpreter incompatibility ...&#10;&#10;BEFORE (guard at base commit 800e5502) — the phantom claim merges:&#10;$ BASE_REF=fddcfae8^ bash scripts/require-changeset.sh # @fddcfae8&#10;require-changeset: no shippable src changes — changeset not required.&#10;exit=0&#10;&#10;AFTER (guard on this branch) — the phantom claim is rejected:&#10;$ BASE_REF=fddcfae8^ bash scripts/require-changeset.sh # @fddcfae8&#10;ERROR: this PR adds a changeset but changes nothing outside .changeset/:&#10;.changeset/idb-python-314-compat.md&#10;&#10;A changeset that merges without the change it describes becomes a phantom&#10;changelog entry at the next `changeset version` (GH #578 post-mortem: the&#10;fddcfae/#601 changeset-only merge made 0.70.5 claim the ensure-idb&#10;Python 3.14 fix 11 releases before the code shipped in 0.76.0).&#10;&#10;Fix: land the changeset in the same PR as the change it describes.&#10;exit=1&#10;&#10;NON-REGRESSION — the Version Packages bot PR (2f4a2a44, #602) still passes:&#10;$ BASE_REF=2f4a2a44^ bash scripts/require-changeset.sh # @2f4a2a44&#10;require-changeset: no shippable src changes — changeset not required.&#10;exit=0</code>

```text
########################################################################
# Historical replay: commit fddcfae8 (#601) — the changeset-only merge
# that minted the phantom 0.70.5 changelog claim.
########################################################################

$ git show --stat fddcfae8
fddcfae8 chore: declare rn-dev-agent-plugin patch release for idb Python 3.14 fix (#601)


 .changeset/idb-python-314-compat.md | 5 +++++
 1 file changed, 5 insertions(+)
$ git show fddcfae8:.changeset/idb-python-314-compat.md
---
"rn-dev-agent-plugin": patch
---

On Python 3.14 with an installed-but-crashing fb-idb, ensure-idb reports the interpreter incompatibility and recommends reinstalling fb-idb under Python 3.13, and stops retrying once the incompatible-Python verdict is reached.

------------------------------------------------------------------------
BEFORE (guard at base commit 800e5502) — the phantom claim merges:
$ BASE_REF=fddcfae8^ bash scripts/require-changeset.sh   # @fddcfae8
require-changeset: no shippable src changes — changeset not required.
exit=0

AFTER (guard on this branch) — the phantom claim is rejected:
$ BASE_REF=fddcfae8^ bash scripts/require-changeset.sh   # @fddcfae8
ERROR: this PR adds a changeset but changes nothing outside .changeset/:
  .changeset/idb-python-314-compat.md

A changeset that merges without the change it describes becomes a phantom
changelog entry at the next `changeset version` (GH #578 post-mortem: the
fddcfae/#601 changeset-only merge made 0.70.5 claim the ensure-idb
Python 3.14 fix 11 releases before the code shipped in 0.76.0).

Fix: land the changeset in the same PR as the change it describes.
exit=1

------------------------------------------------------------------------
NON-REGRESSION — the Version Packages bot PR (2f4a2a44, #602) still passes:
$ BASE_REF=2f4a2a44^ bash scripts/require-changeset.sh   # @2f4a2a44
require-changeset: no shippable src changes — changeset not required.
exit=0
```
</details>
<details>
<summary>Evidence: Release-truthfulness proof: 0.70.5&#39;s shipped ensure-idb.sh fails the behavior its changelog credited</summary>

<code>$ bash scripts/test/ensure-idb.test.sh # against 0.70.5&#39;s ensure-idb.sh (release commit 2f4a2a44)&#10;FAIL: broken-client: expected present-but-unusable notice, got: idb client on PATH is broken (crashes on invocation) — the background worker will replace or remove it (B269)&#10;FAIL: broken-client: expected the Python 3.14 explanation, got: idb client on PATH is broken (crashes on invocation) ...&#10;FAIL: broken-client: printed the known-broken unpinned install command&#10;FAIL: worker: expected incompatible marker, got: failed 1786746474&#10;&#10;-&gt; 0.70.5&#39;s tree does NOT implement the behavior its changelog credited.&#10;&#10;$ bash scripts/test/ensure-idb.test.sh # against this branch (post-0.76.0)&#10;ok: broken-client: reports present-but-unusable&#10;ok: broken-client: names the actual incompatibility&#10;ok: broken-client: not described as missing&#10;ok: broken-client: no unpinned install command&#10;&#10;-&gt; the behavior exists today (shipped in 0.76.0, entry 6c1533f), which is exactly&#10;what the corrected 0.70.5 changelog entry now points readers to.&#10;&#10;## 0.70.5&#10;&#10;### Patch Changes&#10;&#10;- fddcfae: Release-record correction: this entry originally claimed the ensure-idb Python 3.14 incompatibility fix, but only the release-declaring changeset merged (#601) — no corresponding code shipped in 0.70.5. The fix shipped in 0.76.0 (#578, see the 6c1533f entry).</code>

```text
#############################################################################
# Release-truthfulness proof: was the ensure-idb Python 3.14 fix really in
# 0.70.5? Run the CURRENT ensure-idb contract test against the ensure-idb.sh
# AS SHIPPED at the 0.70.5 release commit (2f4a2a44).
#############################################################################

$ bash scripts/test/ensure-idb.test.sh   # against 0.70.5's ensure-idb.sh
FAIL: broken-client: expected present-but-unusable notice, got: idb client on PATH is broken (crashes on invocation) — the background worker will replace or remove it (B269)
FAIL: broken-client: expected the Python 3.14 explanation, got: idb client on PATH is broken (crashes on invocation) — the background worker will replace or remove it (B269)
FAIL: broken-client: still described as missing (states 1 and 3 collapsed)
FAIL: broken-client: printed the known-broken unpinned install command
ok: broken-client: spawns repair worker
FAIL: worker: expected pinned install, got: uninstall fb-idb
FAIL: worker: expected incompatible marker, got: failed 1786746474
FAIL: worker: expected fingerprint in marker, got: failed 1786746474
FAIL: worker: expected crash explanation, got: fb-idb installed but the client crashes on invocation (incompatible Python?) — uninstalled; the mirror stays on the simctl tier
ok: repair-notice: backoff still blocks the spawn
ok: repair-notice: silent when no worker is spawned
FAIL: repair-notice: dropped the broken-client explanation, got: idb client on PATH is broken (crashes on invocation) — the background worker will replace or remove it (B269)

-> 0.70.5's tree does NOT implement the behavior its changelog credited.

$ bash scripts/test/ensure-idb.test.sh   # against this branch (post-0.76.0)
ok: broken-client: reports present-but-unusable
ok: broken-client: names the actual incompatibility
ok: broken-client: not described as missing
ok: broken-client: no unpinned install command
ok: broken-client: spawns repair worker

-> the behavior exists today (shipped in 0.76.0, entry 6c1533f), which is
   exactly what the corrected 0.70.5 changelog entry now points readers to.

#############################################################################
# Corrected public record, packages/claude-plugin/CHANGELOG.md
#############################################################################
## 0.70.5

### Patch Changes

- fddcfae: Release-record correction: this entry originally claimed the ensure-idb Python 3.14 incompatibility fix, but only the release-declaring changeset merged (#601) — no corresponding code shipped in 0.70.5. The fix shipped in 0.76.0 (#578, see the 6c1533f entry).
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"52896bf7f3ec08132b58d97eb348b65d13620e68","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 4 infos</summary>

- ⚠️ `scripts/require-changeset.sh:40` - The added-changeset detection uses `git diff --diff-filter=A` with git&#39;s default rename detection ON (`diff.renames=true` since git 2.9), so a changeset that arrives as a *rename* is never classified as an addition and the phantom guard silently passes. Failing sequence: a changeset-only PR that regenerates a pending changeset (`changeset` CLI emits a new random filename; old file deleted, new file added with ≥50%-similar body) is paired by git as `R .changeset/old.md -&gt; .changeset/new.md`; `added` comes back empty, `added_changesets` is empty, the `-z non_changeset_changed &amp;&amp; -n added_changesets` condition is false, and the release claim merges with no shipped code — the exact class the guard was added to close. Verified on this repo&#39;s own history: `git diff --name-status &lt;c&gt;^ &lt;c&gt;` on commit 2be74a2e reports 2 `R` entries while `git diff --diff-filter=A --name-only` on the same range reports none of them. Fix: add `--no-renames` (or `--find-renames=100%`) to the `--diff-filter=A` invocation at line 40 so a rewritten-and-renamed changeset counts as an addition, and add a test case whose ADDED_FILES/CHANGED_FILES model the rename pair.
- ℹ️ `scripts/test/require-changeset.test.sh:147` - Test case 6 (&#34;git diff failure fails closed&#34;) only exercises the first fail-closed branch: with `$tmp` not a git repo, the changed-file `git diff` at line 27 fails and exits before the added-file `git diff` at line 40 is ever reached, so the second error path (lines 40-43) has no executing coverage. It is also unreachable in practice, since any condition that breaks the second diff breaks the first. Not a defect — noting that the intent&#39;s &#34;both git diff invocations ... with a regression test&#34; is verified for one of the two paths.
- ℹ️ `scripts/require-changeset.sh:46` - The new guard categorically rejects changeset-only PRs, which also blocks the legitimate backfill class the intent itself documents as valid (dd95747b/#361 and 33db4bee backfilled changesets for already-merged code). There is no documented escape hatch (no override label/env, and `--no-verify` does not apply to a CI job), so a future legitimate backfill must be merged by disabling the check. This is a deliberate, stated tradeoff in the intent — recorded here only so the operational cost is visible, not as a blocker.

🔧 Fix: disable rename detection in added-changeset guard diff
4 infos still open:
- ℹ️ `apps/docs-site/src/content/docs/changelog.md:348` - The committed, generated public copy of the changelog still carries the uncorrected phantom text (&#34;On Python 3.14 with an installed-but-crashing fb-idb, ensure-idb reports the interpreter incompatibility...&#34;) under `### 0.70.5`, while `packages/claude-plugin/CHANGELOG.md:373` now carries the release-record correction. Not a defect: this file is regenerated by `apps/docs-site/scripts/generate-tool-docs.mjs` (CHANGELOG_SOURCES copies the package CHANGELOGs verbatim), and `.github/workflows/deploy-docs.yml` triggers on `packages/*/CHANGELOG.md`, so merging this PR regenerates and republishes the corrected entry. The committed copy is already lagging independently of this change (it stops at 0.76.3 while the package changelog is at 0.76.5), so regenerating it here would pull in unrelated drift. Recorded only so it is visible that the in-repo generated artifact keeps the phantom sentence until the next regeneration commit.
- ℹ️ `scripts/test/require-changeset.test.sh:145` - Case 5e&#39;s comment claims it covers the rename pair (&#34;with git&#39;s default rename detection the addition would be invisible&#34;), but it drives the CHANGED_FILES/ADDED_FILES seam, which bypasses `git diff` entirely — it would pass identically with `--no-renames` removed from scripts/require-changeset.sh:40, and is semantically the same assertion as 5d (changeset-only additions fail). The actual rename regression is case 7, which does exercise git. Suggest rewording the 5e comment to state it is the seam-level shape of the rename outcome and that case 7 is the test that pins rename detection off, so a future reader does not treat 5e as the guard against re-enabling renames.
- ℹ️ `scripts/test/require-changeset.test.sh:163` - The case-7 fixture subshell runs `set -e` under `&gt;/dev/null 2&gt;&amp;1` and its exit status is never checked. If any setup step fails on a developer machine (e.g. a global `core.hooksPath`, `commit.gpgsign=true`, or a git older than 2.28 rejecting `git init -b main`), `$gitrepo` is not a usable repo, the guard then exits 1 via the *fail-closed* git-diff path, and case 7 reports `ok` for the wrong reason — its expected exit (1) is satisfied by any failure mode, not specifically by the rename being seen. Case 7b (expects exit 0) does catch a broken fixture, but only as a confusing unrelated failure. Suggest asserting the setup subshell succeeded (`|| { echo &#39;FAIL: fixture setup&#39;; exit 1; }`) and using `git commit --no-verify` so the fixture is insulated from host git configuration.
- ℹ️ `scripts/require-changeset.sh:40` - `--no-renames` is the correct conservative choice — it is what makes a regenerated changeset (old deleted, new random filename added with a materially different claim) count as an addition. The accepted cost is that a PR which *only* renames a pending changeset without changing its body is now rejected too, even though it declares no new claim; that sits slightly outside the guard&#39;s stated allowance that &#34;deleting or rewording pending changesets stays allowed&#34;. The Version Packages bot is unaffected (it deletes changesets while also touching CHANGELOG/package.json, so `non_changeset_changed` is non-empty), and a pure rename-only changeset PR is not a workflow this repo produces. Noted as a deliberate tradeoff of the requested fix, not a defect.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash scripts/test/require-changeset.test.sh` — 21/21 pass, including the new phantom-addition, multi-changeset-only, deletion/reword, paired-addition, rename-pair, and git-diff-fails-closed cases</code>
- <code>Historical replay in a scratch clone: base-commit guard vs branch guard run with `BASE_REF=fddcfae8^` at commit `fddcfae8` (#601) — before: exit 0, after: exit 1</code>
- <code>Non-regression replay of the Version Packages bot release commit: `BASE_REF=2f4a2a44^ bash scripts/require-changeset.sh` → exit 0</code>
- <code>Branch-level gate as CI invokes it: `BASE_REF=800e5502 bash scripts/require-changeset.sh` → exit 0</code>
- <code>`bash scripts/test/ensure-idb.test.sh` run against `scripts/ensure-idb.sh` extracted from the 0.70.5 release commit 2f4a2a44 (broken-client / Python-3.14 assertions FAIL) and against the branch tree (all pass)</code>
- <code>`bash scripts/validate-changeset-names.sh` → exit 0</code>
- <code>`git status --porcelain` → clean; scratch clone and extracted scripts removed after capture</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `apps/docs-site/src/content/docs/changelog.md:8` - Pre-existing drift, unrelated to this change: the generated docs-site changelog mirror is missing the 0.76.4 and 0.76.5 plugin sections and the 0.71.4/0.71.5 core sections. Running `node apps/docs-site/scripts/generate-tool-docs.mjs` regenerates them, but that would add ~50 lines of unrelated release notes to this diff, so I applied only the scoped 0.70.5 record correction. Follow-up: regenerate the docs site content (or wire the generator into CI as a drift check) in a separate change.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
