### PR TITLE
fix(core): bound dead-Metro cdp_status and absorb fresh-simulator runner first-start

### DIFF
--- a/.changeset/gh-629-bounded-resume-recovery.md
+++ b/.changeset/gh-629-bounded-resume-recovery.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-core": patch
+"rn-dev-agent-plugin": patch
+---
+
+Bound dead-Metro `cdp_status` to the discovery scan budget by skipping runner-spawning picker probes when no Metro is up, and absorb the fresh-simulator first-start rn-fast-runner transient with one bounded internal retry after the failed first spawn provably exits.

--- a/apps/docs-site/src/content/docs/troubleshooting.mdx
+++ b/apps/docs-site/src/content/docs/troubleshooting.mdx
@@ -265,7 +265,11 @@ The in-tree device runner couldn't start. Check that the simulator/emulator
 is booted and (Android) the SDK is available. iOS self-builds on first use —
 a cold build takes several minutes; if it times out, pre-build once with
 `xcodebuild build-for-testing` (see Getting Started) and re-open the device
-session.
+session. On iOS a freshly created simulator's first XCTest bootstrap can
+overrun the warm ready gate; the bridge absorbs that with exactly one internal
+retry, so a message ending in `(one internal retry included)` means two spawn
+attempts already failed — fix the runner build or the simulator rather than
+retrying by hand.
 
 ### APP_LAUNCH_FAILED
 

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -19444,7 +19444,7 @@ async function discover(currentPort, platformFilterOrFilters) {
   logger.debug("CDP", `Discovering Metro on ports: ${ports.join(", ")}${hints.length ? ` (${hints.join(", ")})` : ""}`);
   const runningPorts = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
   if (runningPorts.length === 0) {
-    throw new Error("Metro not found on ports " + ports.join(", ") + ". Is the dev server running? Try: npx expo start or npx react-native start");
+    throw new MetroNotFoundError(ports);
   }
   const perPort = await Promise.all(runningPorts.map(async (p) => {
     try {
@@ -19504,7 +19504,7 @@ async function discoverForList(currentPort, portHint) {
   inferPlatforms(targets);
   return { port: chosen, targets };
 }
-var AppDetachedError, DISCOVERY_TIMEOUT_MS, PACKAGE_PROBE_TTL_MS, PACKAGE_PROBE_FAILURE_TTL_MS, PACKAGE_PROBE_SLOW_FAILURE_MS, packageProbeCache, TargetSelectionError;
+var AppDetachedError, DISCOVERY_TIMEOUT_MS, MetroNotFoundError, PACKAGE_PROBE_TTL_MS, PACKAGE_PROBE_FAILURE_TTL_MS, PACKAGE_PROBE_SLOW_FAILURE_MS, packageProbeCache, TargetSelectionError;
 var init_discovery = __esm({
   "packages/rn-dev-agent-core/dist/cdp/discovery.js"() {
     "use strict";
@@ -19527,6 +19527,14 @@ var init_discovery = __esm({
       }
     };
     DISCOVERY_TIMEOUT_MS = 1500;
+    MetroNotFoundError = class extends Error {
+      ports;
+      constructor(ports) {
+        super("Metro not found on ports " + ports.join(", ") + ". Is the dev server running? Try: npx expo start or npx react-native start");
+        this.name = "MetroNotFoundError";
+        this.ports = ports;
+      }
+    };
     PACKAGE_PROBE_TTL_MS = 15e3;
     PACKAGE_PROBE_FAILURE_TTL_MS = 1500;
     PACKAGE_PROBE_SLOW_FAILURE_MS = 1e3;
@@ -21448,6 +21456,8 @@ __export(rn_fast_runner_client_exports, {
   _setRunnerStateForTest: () => _setRunnerStateForTest,
   acquireRunnerRebuildLock: () => acquireRunnerRebuildLock,
   adoptPersistedFastRunnerState: () => adoptPersistedFastRunnerState,
+  awaitChildExit: () => awaitChildExit,
+  awaitSpawnedRunnerExit: () => awaitSpawnedRunnerExit,
   buildRunnerAttachOnlyEnv: () => buildRunnerAttachOnlyEnv,
   buildRunnerAuthorityEnv: () => buildRunnerAuthorityEnv,
   buildRunnerPortEnv: () => buildRunnerPortEnv,
@@ -21462,6 +21472,7 @@ __export(rn_fast_runner_client_exports, {
   fastSwipe: () => fastSwipe,
   getFastRunnerCapabilities: () => getFastRunnerCapabilities,
   getFastRunnerState: () => getFastRunnerState,
+  getRunnerLaunchCount: () => getRunnerLaunchCount,
   getRunnerPostMortem: () => getRunnerPostMortem,
   hasBuiltTestProduct: () => hasBuiltTestProduct,
   iosStatePath: () => iosStatePath,
@@ -21894,6 +21905,7 @@ async function startFastRunner(deviceId, bundleId, port, opts = {}) {
       stdio: ["ignore", "pipe", "pipe"]
     });
     runnerProcess = child;
+    runnerLaunchCount += 1;
     runnerOutputTail = "";
     lastRunnerCommand = null;
     lastRunnerPostMortem = null;
@@ -21973,6 +21985,38 @@ async function startFastRunner(deviceId, bundleId, port, opts = {}) {
       clearTimeout(timer);
       reject(new Error(`xcodebuild exited unexpectedly (code ${code}, signal ${signal ?? "none"})`));
     });
+  });
+}
+function getRunnerLaunchCount() {
+  return runnerLaunchCount;
+}
+async function awaitSpawnedRunnerExit(graceMs = 5e3, expectedLaunchCount) {
+  if (runnerState)
+    return false;
+  if (expectedLaunchCount !== void 0 && runnerLaunchCount !== expectedLaunchCount)
+    return false;
+  return awaitChildExit(runnerProcess, graceMs);
+}
+async function awaitChildExit(child, graceMs = 5e3) {
+  if (!child || child.exitCode !== null || child.signalCode !== null)
+    return true;
+  return new Promise((resolve12) => {
+    const killTimer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+      }
+    }, graceMs);
+    const backstop = setTimeout(() => {
+      child.removeListener("exit", onExit);
+      resolve12(false);
+    }, graceMs + 2e3);
+    const onExit = () => {
+      clearTimeout(killTimer);
+      clearTimeout(backstop);
+      resolve12(true);
+    };
+    child.once("exit", onExit);
   });
 }
 async function stopFastRunner(deviceId) {
@@ -22769,7 +22813,7 @@ async function runIOS(args) {
   };
   return okResult(resp.data ?? {}, Object.keys(finalMeta).length ? { meta: finalMeta } : void 0);
 }
-var READY_TIMEOUT_MS, BUILD_READY_TIMEOUT_MS, HTTP_TIMEOUT_MS, FAST_RUNNER_PROJECT, runnerProcess, runnerState, runnerPoisoned, poisonReap, poisonHolders, runnerOutputTail, lastRunnerCommand, lastRunnerPostMortem, lastKnownCapabilities, quiescenceAnnouncementPending, QUIESCENCE_STATUSES, REBUILD_LOCK_DIR, REBUILD_LOCK_STALE_MS, REBUILD_BUDGET_FILE, runnerRebuildBudget, pendingFastRunnerArtifactNote, staleHittableWarned, runnerTestFaultForwarded, fetchImpl, httpTimeoutOverrideMs, SLOW_RUNNER_COMMANDS, STATUS_PROBE_TIMEOUT_MS, POST_SETTLE_HEALTH_ATTEMPTS, POST_SETTLE_HEALTH_RETRY_MS;
+var READY_TIMEOUT_MS, BUILD_READY_TIMEOUT_MS, HTTP_TIMEOUT_MS, FAST_RUNNER_PROJECT, runnerProcess, runnerLaunchCount, runnerState, runnerPoisoned, poisonReap, poisonHolders, runnerOutputTail, lastRunnerCommand, lastRunnerPostMortem, lastKnownCapabilities, quiescenceAnnouncementPending, QUIESCENCE_STATUSES, REBUILD_LOCK_DIR, REBUILD_LOCK_STALE_MS, REBUILD_BUDGET_FILE, runnerRebuildBudget, pendingFastRunnerArtifactNote, staleHittableWarned, runnerTestFaultForwarded, fetchImpl, httpTimeoutOverrideMs, SLOW_RUNNER_COMMANDS, STATUS_PROBE_TIMEOUT_MS, POST_SETTLE_HEALTH_ATTEMPTS, POST_SETTLE_HEALTH_RETRY_MS;
 var init_rn_fast_runner_client = __esm({
   "packages/rn-dev-agent-core/dist/runners/rn-fast-runner-client.js"() {
     "use strict";
@@ -22788,6 +22832,7 @@ var init_rn_fast_runner_client = __esm({
     HTTP_TIMEOUT_MS = 1e4;
     FAST_RUNNER_PROJECT = resolveNativeRunnerDir("rn-fast-runner");
     runnerProcess = null;
+    runnerLaunchCount = 0;
     runnerState = null;
     runnerPoisoned = false;
     poisonReap = null;
@@ -28890,13 +28935,33 @@ async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
     }
     return { ok: false, message: decision.message };
   }
-  await ensure(decision.action === "spawn" ? decision.deviceId : deviceId, bundleId, deps.attachOnly === true ? { attachOnly: true } : {});
-  const after = await probe();
+  const spawnDeviceId = decision.action === "spawn" ? decision.deviceId : deviceId;
+  const spawnOpts = deps.attachOnly === true ? { attachOnly: true } : {};
+  const launchCount = deps.launchCount ?? getRunnerLaunchCount;
+  const launchesBefore = launchCount();
+  await ensure(spawnDeviceId, bundleId, spawnOpts);
+  let after = await probe();
+  let firstStartRetried = false;
+  const launchesAfter = launchCount();
+  if (after.liveness === "dead" && !after.staleReason && launchesAfter > launchesBefore) {
+    const firstSpawnGone = await (deps.awaitSpawnExit ?? (() => awaitSpawnedRunnerExit(void 0, launchesAfter)))();
+    if (firstSpawnGone) {
+      firstStartRetried = true;
+      await ensure(spawnDeviceId, bundleId, spawnOpts);
+      after = await probe();
+    }
+  }
   if (after.liveness === "alive") {
     if (first.staleReason && (PROTOCOL_STALE_REASONS.has(first.staleReason) || first.staleReason === "authority-mismatch")) {
       return {
         ok: true,
         note: first.staleReason === "missing-commands" ? "runner upgraded (stale command surface)" : first.staleReason === "missing-features" ? "runner upgraded (stale feature surface)" : first.staleReason === "authority-mismatch" ? "runner upgraded (authority identity mismatch)" : "runner upgraded (protocol/version mismatch)"
+      };
+    }
+    if (firstStartRetried) {
+      return {
+        ok: true,
+        note: "runner ready after one first-start retry (fresh-simulator XCTest bootstrap)"
       };
     }
     return { ok: true };
@@ -28929,7 +28994,7 @@ async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
   }
   return {
     ok: false,
-    message: "rn-fast-runner did not become ready after auto-spawn. Retry, or run `device_snapshot action=open appId=<your.app.id> platform=ios` to surface the build error."
+    message: `rn-fast-runner did not become ready after auto-spawn${firstStartRetried ? " (one internal retry included)" : ""}. Retry, or run \`device_snapshot action=open appId=<your.app.id> platform=ios\` to surface the build error.`
   };
 }
 async function ensureFastRunner(deviceId, bundleId, opts = {}) {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -19293,6 +19293,8 @@ __export(rn_fast_runner_client_exports, {
   _setRunnerStateForTest: () => _setRunnerStateForTest,
   acquireRunnerRebuildLock: () => acquireRunnerRebuildLock,
   adoptPersistedFastRunnerState: () => adoptPersistedFastRunnerState,
+  awaitChildExit: () => awaitChildExit,
+  awaitSpawnedRunnerExit: () => awaitSpawnedRunnerExit,
   buildRunnerAttachOnlyEnv: () => buildRunnerAttachOnlyEnv,
   buildRunnerAuthorityEnv: () => buildRunnerAuthorityEnv,
   buildRunnerPortEnv: () => buildRunnerPortEnv,
@@ -19307,6 +19309,7 @@ __export(rn_fast_runner_client_exports, {
   fastSwipe: () => fastSwipe,
   getFastRunnerCapabilities: () => getFastRunnerCapabilities,
   getFastRunnerState: () => getFastRunnerState,
+  getRunnerLaunchCount: () => getRunnerLaunchCount,
   getRunnerPostMortem: () => getRunnerPostMortem,
   hasBuiltTestProduct: () => hasBuiltTestProduct,
   iosStatePath: () => iosStatePath,
@@ -19739,6 +19742,7 @@ async function startFastRunner(deviceId, bundleId, port, opts = {}) {
       stdio: ["ignore", "pipe", "pipe"]
     });
     runnerProcess = child;
+    runnerLaunchCount += 1;
     runnerOutputTail = "";
     lastRunnerCommand = null;
     lastRunnerPostMortem = null;
@@ -19818,6 +19822,38 @@ async function startFastRunner(deviceId, bundleId, port, opts = {}) {
       clearTimeout(timer);
       reject(new Error(`xcodebuild exited unexpectedly (code ${code}, signal ${signal ?? "none"})`));
     });
+  });
+}
+function getRunnerLaunchCount() {
+  return runnerLaunchCount;
+}
+async function awaitSpawnedRunnerExit(graceMs = 5e3, expectedLaunchCount) {
+  if (runnerState)
+    return false;
+  if (expectedLaunchCount !== void 0 && runnerLaunchCount !== expectedLaunchCount)
+    return false;
+  return awaitChildExit(runnerProcess, graceMs);
+}
+async function awaitChildExit(child, graceMs = 5e3) {
+  if (!child || child.exitCode !== null || child.signalCode !== null)
+    return true;
+  return new Promise((resolve12) => {
+    const killTimer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+      }
+    }, graceMs);
+    const backstop = setTimeout(() => {
+      child.removeListener("exit", onExit);
+      resolve12(false);
+    }, graceMs + 2e3);
+    const onExit = () => {
+      clearTimeout(killTimer);
+      clearTimeout(backstop);
+      resolve12(true);
+    };
+    child.once("exit", onExit);
   });
 }
 async function stopFastRunner(deviceId) {
@@ -20614,7 +20650,7 @@ async function runIOS(args) {
   };
   return okResult(resp.data ?? {}, Object.keys(finalMeta).length ? { meta: finalMeta } : void 0);
 }
-var READY_TIMEOUT_MS, BUILD_READY_TIMEOUT_MS, HTTP_TIMEOUT_MS, FAST_RUNNER_PROJECT, runnerProcess, runnerState, runnerPoisoned, poisonReap, poisonHolders, runnerOutputTail, lastRunnerCommand, lastRunnerPostMortem, lastKnownCapabilities, quiescenceAnnouncementPending, QUIESCENCE_STATUSES, REBUILD_LOCK_DIR, REBUILD_LOCK_STALE_MS, REBUILD_BUDGET_FILE, runnerRebuildBudget, pendingFastRunnerArtifactNote, staleHittableWarned, runnerTestFaultForwarded, fetchImpl, httpTimeoutOverrideMs, SLOW_RUNNER_COMMANDS, STATUS_PROBE_TIMEOUT_MS, POST_SETTLE_HEALTH_ATTEMPTS, POST_SETTLE_HEALTH_RETRY_MS;
+var READY_TIMEOUT_MS, BUILD_READY_TIMEOUT_MS, HTTP_TIMEOUT_MS, FAST_RUNNER_PROJECT, runnerProcess, runnerLaunchCount, runnerState, runnerPoisoned, poisonReap, poisonHolders, runnerOutputTail, lastRunnerCommand, lastRunnerPostMortem, lastKnownCapabilities, quiescenceAnnouncementPending, QUIESCENCE_STATUSES, REBUILD_LOCK_DIR, REBUILD_LOCK_STALE_MS, REBUILD_BUDGET_FILE, runnerRebuildBudget, pendingFastRunnerArtifactNote, staleHittableWarned, runnerTestFaultForwarded, fetchImpl, httpTimeoutOverrideMs, SLOW_RUNNER_COMMANDS, STATUS_PROBE_TIMEOUT_MS, POST_SETTLE_HEALTH_ATTEMPTS, POST_SETTLE_HEALTH_RETRY_MS;
 var init_rn_fast_runner_client = __esm({
   "packages/rn-dev-agent-core/dist/runners/rn-fast-runner-client.js"() {
     "use strict";
@@ -20633,6 +20669,7 @@ var init_rn_fast_runner_client = __esm({
     HTTP_TIMEOUT_MS = 1e4;
     FAST_RUNNER_PROJECT = resolveNativeRunnerDir("rn-fast-runner");
     runnerProcess = null;
+    runnerLaunchCount = 0;
     runnerState = null;
     runnerPoisoned = false;
     poisonReap = null;
@@ -25608,13 +25645,33 @@ async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
     }
     return { ok: false, message: decision.message };
   }
-  await ensure(decision.action === "spawn" ? decision.deviceId : deviceId, bundleId, deps.attachOnly === true ? { attachOnly: true } : {});
-  const after = await probe();
+  const spawnDeviceId = decision.action === "spawn" ? decision.deviceId : deviceId;
+  const spawnOpts = deps.attachOnly === true ? { attachOnly: true } : {};
+  const launchCount = deps.launchCount ?? getRunnerLaunchCount;
+  const launchesBefore = launchCount();
+  await ensure(spawnDeviceId, bundleId, spawnOpts);
+  let after = await probe();
+  let firstStartRetried = false;
+  const launchesAfter = launchCount();
+  if (after.liveness === "dead" && !after.staleReason && launchesAfter > launchesBefore) {
+    const firstSpawnGone = await (deps.awaitSpawnExit ?? (() => awaitSpawnedRunnerExit(void 0, launchesAfter)))();
+    if (firstSpawnGone) {
+      firstStartRetried = true;
+      await ensure(spawnDeviceId, bundleId, spawnOpts);
+      after = await probe();
+    }
+  }
   if (after.liveness === "alive") {
     if (first.staleReason && (PROTOCOL_STALE_REASONS.has(first.staleReason) || first.staleReason === "authority-mismatch")) {
       return {
         ok: true,
         note: first.staleReason === "missing-commands" ? "runner upgraded (stale command surface)" : first.staleReason === "missing-features" ? "runner upgraded (stale feature surface)" : first.staleReason === "authority-mismatch" ? "runner upgraded (authority identity mismatch)" : "runner upgraded (protocol/version mismatch)"
+      };
+    }
+    if (firstStartRetried) {
+      return {
+        ok: true,
+        note: "runner ready after one first-start retry (fresh-simulator XCTest bootstrap)"
       };
     }
     return { ok: true };
@@ -25647,7 +25704,7 @@ async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
   }
   return {
     ok: false,
-    message: "rn-fast-runner did not become ready after auto-spawn. Retry, or run `device_snapshot action=open appId=<your.app.id> platform=ios` to surface the build error."
+    message: `rn-fast-runner did not become ready after auto-spawn${firstStartRetried ? " (one internal retry included)" : ""}. Retry, or run \`device_snapshot action=open appId=<your.app.id> platform=ios\` to surface the build error.`
   };
 }
 async function ensureFastRunner(deviceId, bundleId, opts = {}) {
@@ -28000,7 +28057,7 @@ async function discover(currentPort, platformFilterOrFilters) {
   logger.debug("CDP", `Discovering Metro on ports: ${ports.join(", ")}${hints.length ? ` (${hints.join(", ")})` : ""}`);
   const runningPorts = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
   if (runningPorts.length === 0) {
-    throw new Error("Metro not found on ports " + ports.join(", ") + ". Is the dev server running? Try: npx expo start or npx react-native start");
+    throw new MetroNotFoundError(ports);
   }
   const perPort = await Promise.all(runningPorts.map(async (p) => {
     try {
@@ -28060,7 +28117,7 @@ async function discoverForList(currentPort, portHint) {
   inferPlatforms(targets);
   return { port: chosen, targets };
 }
-var AppDetachedError, DISCOVERY_TIMEOUT_MS, PACKAGE_PROBE_TTL_MS, PACKAGE_PROBE_FAILURE_TTL_MS, PACKAGE_PROBE_SLOW_FAILURE_MS, packageProbeCache, TargetSelectionError;
+var AppDetachedError, DISCOVERY_TIMEOUT_MS, MetroNotFoundError, PACKAGE_PROBE_TTL_MS, PACKAGE_PROBE_FAILURE_TTL_MS, PACKAGE_PROBE_SLOW_FAILURE_MS, packageProbeCache, TargetSelectionError;
 var init_discovery = __esm({
   "packages/rn-dev-agent-core/dist/cdp/discovery.js"() {
     "use strict";
@@ -28083,6 +28140,14 @@ var init_discovery = __esm({
       }
     };
     DISCOVERY_TIMEOUT_MS = 1500;
+    MetroNotFoundError = class extends Error {
+      ports;
+      constructor(ports) {
+        super("Metro not found on ports " + ports.join(", ") + ". Is the dev server running? Try: npx expo start or npx react-native start");
+        this.name = "MetroNotFoundError";
+        this.ports = ports;
+      }
+    };
     PACKAGE_PROBE_TTL_MS = 15e3;
     PACKAGE_PROBE_FAILURE_TTL_MS = 1500;
     PACKAGE_PROBE_SLOW_FAILURE_MS = 1e3;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -19444,7 +19444,7 @@ async function discover(currentPort, platformFilterOrFilters) {
   logger.debug("CDP", `Discovering Metro on ports: ${ports.join(", ")}${hints.length ? ` (${hints.join(", ")})` : ""}`);
   const runningPorts = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
   if (runningPorts.length === 0) {
-    throw new Error("Metro not found on ports " + ports.join(", ") + ". Is the dev server running? Try: npx expo start or npx react-native start");
+    throw new MetroNotFoundError(ports);
   }
   const perPort = await Promise.all(runningPorts.map(async (p) => {
     try {
@@ -19504,7 +19504,7 @@ async function discoverForList(currentPort, portHint) {
   inferPlatforms(targets);
   return { port: chosen, targets };
 }
-var AppDetachedError, DISCOVERY_TIMEOUT_MS, PACKAGE_PROBE_TTL_MS, PACKAGE_PROBE_FAILURE_TTL_MS, PACKAGE_PROBE_SLOW_FAILURE_MS, packageProbeCache, TargetSelectionError;
+var AppDetachedError, DISCOVERY_TIMEOUT_MS, MetroNotFoundError, PACKAGE_PROBE_TTL_MS, PACKAGE_PROBE_FAILURE_TTL_MS, PACKAGE_PROBE_SLOW_FAILURE_MS, packageProbeCache, TargetSelectionError;
 var init_discovery = __esm({
   "packages/rn-dev-agent-core/dist/cdp/discovery.js"() {
     "use strict";
@@ -19527,6 +19527,14 @@ var init_discovery = __esm({
       }
     };
     DISCOVERY_TIMEOUT_MS = 1500;
+    MetroNotFoundError = class extends Error {
+      ports;
+      constructor(ports) {
+        super("Metro not found on ports " + ports.join(", ") + ". Is the dev server running? Try: npx expo start or npx react-native start");
+        this.name = "MetroNotFoundError";
+        this.ports = ports;
+      }
+    };
     PACKAGE_PROBE_TTL_MS = 15e3;
     PACKAGE_PROBE_FAILURE_TTL_MS = 1500;
     PACKAGE_PROBE_SLOW_FAILURE_MS = 1e3;
@@ -21448,6 +21456,8 @@ __export(rn_fast_runner_client_exports, {
   _setRunnerStateForTest: () => _setRunnerStateForTest,
   acquireRunnerRebuildLock: () => acquireRunnerRebuildLock,
   adoptPersistedFastRunnerState: () => adoptPersistedFastRunnerState,
+  awaitChildExit: () => awaitChildExit,
+  awaitSpawnedRunnerExit: () => awaitSpawnedRunnerExit,
   buildRunnerAttachOnlyEnv: () => buildRunnerAttachOnlyEnv,
   buildRunnerAuthorityEnv: () => buildRunnerAuthorityEnv,
   buildRunnerPortEnv: () => buildRunnerPortEnv,
@@ -21462,6 +21472,7 @@ __export(rn_fast_runner_client_exports, {
   fastSwipe: () => fastSwipe,
   getFastRunnerCapabilities: () => getFastRunnerCapabilities,
   getFastRunnerState: () => getFastRunnerState,
+  getRunnerLaunchCount: () => getRunnerLaunchCount,
   getRunnerPostMortem: () => getRunnerPostMortem,
   hasBuiltTestProduct: () => hasBuiltTestProduct,
   iosStatePath: () => iosStatePath,
@@ -21894,6 +21905,7 @@ async function startFastRunner(deviceId, bundleId, port, opts = {}) {
       stdio: ["ignore", "pipe", "pipe"]
     });
     runnerProcess = child;
+    runnerLaunchCount += 1;
     runnerOutputTail = "";
     lastRunnerCommand = null;
     lastRunnerPostMortem = null;
@@ -21973,6 +21985,38 @@ async function startFastRunner(deviceId, bundleId, port, opts = {}) {
       clearTimeout(timer);
       reject(new Error(`xcodebuild exited unexpectedly (code ${code}, signal ${signal ?? "none"})`));
     });
+  });
+}
+function getRunnerLaunchCount() {
+  return runnerLaunchCount;
+}
+async function awaitSpawnedRunnerExit(graceMs = 5e3, expectedLaunchCount) {
+  if (runnerState)
+    return false;
+  if (expectedLaunchCount !== void 0 && runnerLaunchCount !== expectedLaunchCount)
+    return false;
+  return awaitChildExit(runnerProcess, graceMs);
+}
+async function awaitChildExit(child, graceMs = 5e3) {
+  if (!child || child.exitCode !== null || child.signalCode !== null)
+    return true;
+  return new Promise((resolve12) => {
+    const killTimer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+      }
+    }, graceMs);
+    const backstop = setTimeout(() => {
+      child.removeListener("exit", onExit);
+      resolve12(false);
+    }, graceMs + 2e3);
+    const onExit = () => {
+      clearTimeout(killTimer);
+      clearTimeout(backstop);
+      resolve12(true);
+    };
+    child.once("exit", onExit);
   });
 }
 async function stopFastRunner(deviceId) {
@@ -22769,7 +22813,7 @@ async function runIOS(args) {
   };
   return okResult(resp.data ?? {}, Object.keys(finalMeta).length ? { meta: finalMeta } : void 0);
 }
-var READY_TIMEOUT_MS, BUILD_READY_TIMEOUT_MS, HTTP_TIMEOUT_MS, FAST_RUNNER_PROJECT, runnerProcess, runnerState, runnerPoisoned, poisonReap, poisonHolders, runnerOutputTail, lastRunnerCommand, lastRunnerPostMortem, lastKnownCapabilities, quiescenceAnnouncementPending, QUIESCENCE_STATUSES, REBUILD_LOCK_DIR, REBUILD_LOCK_STALE_MS, REBUILD_BUDGET_FILE, runnerRebuildBudget, pendingFastRunnerArtifactNote, staleHittableWarned, runnerTestFaultForwarded, fetchImpl, httpTimeoutOverrideMs, SLOW_RUNNER_COMMANDS, STATUS_PROBE_TIMEOUT_MS, POST_SETTLE_HEALTH_ATTEMPTS, POST_SETTLE_HEALTH_RETRY_MS;
+var READY_TIMEOUT_MS, BUILD_READY_TIMEOUT_MS, HTTP_TIMEOUT_MS, FAST_RUNNER_PROJECT, runnerProcess, runnerLaunchCount, runnerState, runnerPoisoned, poisonReap, poisonHolders, runnerOutputTail, lastRunnerCommand, lastRunnerPostMortem, lastKnownCapabilities, quiescenceAnnouncementPending, QUIESCENCE_STATUSES, REBUILD_LOCK_DIR, REBUILD_LOCK_STALE_MS, REBUILD_BUDGET_FILE, runnerRebuildBudget, pendingFastRunnerArtifactNote, staleHittableWarned, runnerTestFaultForwarded, fetchImpl, httpTimeoutOverrideMs, SLOW_RUNNER_COMMANDS, STATUS_PROBE_TIMEOUT_MS, POST_SETTLE_HEALTH_ATTEMPTS, POST_SETTLE_HEALTH_RETRY_MS;
 var init_rn_fast_runner_client = __esm({
   "packages/rn-dev-agent-core/dist/runners/rn-fast-runner-client.js"() {
     "use strict";
@@ -22788,6 +22832,7 @@ var init_rn_fast_runner_client = __esm({
     HTTP_TIMEOUT_MS = 1e4;
     FAST_RUNNER_PROJECT = resolveNativeRunnerDir("rn-fast-runner");
     runnerProcess = null;
+    runnerLaunchCount = 0;
     runnerState = null;
     runnerPoisoned = false;
     poisonReap = null;
@@ -28890,13 +28935,33 @@ async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
     }
     return { ok: false, message: decision.message };
   }
-  await ensure(decision.action === "spawn" ? decision.deviceId : deviceId, bundleId, deps.attachOnly === true ? { attachOnly: true } : {});
-  const after = await probe();
+  const spawnDeviceId = decision.action === "spawn" ? decision.deviceId : deviceId;
+  const spawnOpts = deps.attachOnly === true ? { attachOnly: true } : {};
+  const launchCount = deps.launchCount ?? getRunnerLaunchCount;
+  const launchesBefore = launchCount();
+  await ensure(spawnDeviceId, bundleId, spawnOpts);
+  let after = await probe();
+  let firstStartRetried = false;
+  const launchesAfter = launchCount();
+  if (after.liveness === "dead" && !after.staleReason && launchesAfter > launchesBefore) {
+    const firstSpawnGone = await (deps.awaitSpawnExit ?? (() => awaitSpawnedRunnerExit(void 0, launchesAfter)))();
+    if (firstSpawnGone) {
+      firstStartRetried = true;
+      await ensure(spawnDeviceId, bundleId, spawnOpts);
+      after = await probe();
+    }
+  }
   if (after.liveness === "alive") {
     if (first.staleReason && (PROTOCOL_STALE_REASONS.has(first.staleReason) || first.staleReason === "authority-mismatch")) {
       return {
         ok: true,
         note: first.staleReason === "missing-commands" ? "runner upgraded (stale command surface)" : first.staleReason === "missing-features" ? "runner upgraded (stale feature surface)" : first.staleReason === "authority-mismatch" ? "runner upgraded (authority identity mismatch)" : "runner upgraded (protocol/version mismatch)"
+      };
+    }
+    if (firstStartRetried) {
+      return {
+        ok: true,
+        note: "runner ready after one first-start retry (fresh-simulator XCTest bootstrap)"
       };
     }
     return { ok: true };
@@ -28929,7 +28994,7 @@ async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
   }
   return {
     ok: false,
-    message: "rn-fast-runner did not become ready after auto-spawn. Retry, or run `device_snapshot action=open appId=<your.app.id> platform=ios` to surface the build error."
+    message: `rn-fast-runner did not become ready after auto-spawn${firstStartRetried ? " (one internal retry included)" : ""}. Retry, or run \`device_snapshot action=open appId=<your.app.id> platform=ios\` to surface the build error.`
   };
 }
 async function ensureFastRunner(deviceId, bundleId, opts = {}) {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -19293,6 +19293,8 @@ __export(rn_fast_runner_client_exports, {
   _setRunnerStateForTest: () => _setRunnerStateForTest,
   acquireRunnerRebuildLock: () => acquireRunnerRebuildLock,
   adoptPersistedFastRunnerState: () => adoptPersistedFastRunnerState,
+  awaitChildExit: () => awaitChildExit,
+  awaitSpawnedRunnerExit: () => awaitSpawnedRunnerExit,
   buildRunnerAttachOnlyEnv: () => buildRunnerAttachOnlyEnv,
   buildRunnerAuthorityEnv: () => buildRunnerAuthorityEnv,
   buildRunnerPortEnv: () => buildRunnerPortEnv,
@@ -19307,6 +19309,7 @@ __export(rn_fast_runner_client_exports, {
   fastSwipe: () => fastSwipe,
   getFastRunnerCapabilities: () => getFastRunnerCapabilities,
   getFastRunnerState: () => getFastRunnerState,
+  getRunnerLaunchCount: () => getRunnerLaunchCount,
   getRunnerPostMortem: () => getRunnerPostMortem,
   hasBuiltTestProduct: () => hasBuiltTestProduct,
   iosStatePath: () => iosStatePath,
@@ -19739,6 +19742,7 @@ async function startFastRunner(deviceId, bundleId, port, opts = {}) {
       stdio: ["ignore", "pipe", "pipe"]
     });
     runnerProcess = child;
+    runnerLaunchCount += 1;
     runnerOutputTail = "";
     lastRunnerCommand = null;
     lastRunnerPostMortem = null;
@@ -19818,6 +19822,38 @@ async function startFastRunner(deviceId, bundleId, port, opts = {}) {
       clearTimeout(timer);
       reject(new Error(`xcodebuild exited unexpectedly (code ${code}, signal ${signal ?? "none"})`));
     });
+  });
+}
+function getRunnerLaunchCount() {
+  return runnerLaunchCount;
+}
+async function awaitSpawnedRunnerExit(graceMs = 5e3, expectedLaunchCount) {
+  if (runnerState)
+    return false;
+  if (expectedLaunchCount !== void 0 && runnerLaunchCount !== expectedLaunchCount)
+    return false;
+  return awaitChildExit(runnerProcess, graceMs);
+}
+async function awaitChildExit(child, graceMs = 5e3) {
+  if (!child || child.exitCode !== null || child.signalCode !== null)
+    return true;
+  return new Promise((resolve12) => {
+    const killTimer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+      }
+    }, graceMs);
+    const backstop = setTimeout(() => {
+      child.removeListener("exit", onExit);
+      resolve12(false);
+    }, graceMs + 2e3);
+    const onExit = () => {
+      clearTimeout(killTimer);
+      clearTimeout(backstop);
+      resolve12(true);
+    };
+    child.once("exit", onExit);
   });
 }
 async function stopFastRunner(deviceId) {
@@ -20614,7 +20650,7 @@ async function runIOS(args) {
   };
   return okResult(resp.data ?? {}, Object.keys(finalMeta).length ? { meta: finalMeta } : void 0);
 }
-var READY_TIMEOUT_MS, BUILD_READY_TIMEOUT_MS, HTTP_TIMEOUT_MS, FAST_RUNNER_PROJECT, runnerProcess, runnerState, runnerPoisoned, poisonReap, poisonHolders, runnerOutputTail, lastRunnerCommand, lastRunnerPostMortem, lastKnownCapabilities, quiescenceAnnouncementPending, QUIESCENCE_STATUSES, REBUILD_LOCK_DIR, REBUILD_LOCK_STALE_MS, REBUILD_BUDGET_FILE, runnerRebuildBudget, pendingFastRunnerArtifactNote, staleHittableWarned, runnerTestFaultForwarded, fetchImpl, httpTimeoutOverrideMs, SLOW_RUNNER_COMMANDS, STATUS_PROBE_TIMEOUT_MS, POST_SETTLE_HEALTH_ATTEMPTS, POST_SETTLE_HEALTH_RETRY_MS;
+var READY_TIMEOUT_MS, BUILD_READY_TIMEOUT_MS, HTTP_TIMEOUT_MS, FAST_RUNNER_PROJECT, runnerProcess, runnerLaunchCount, runnerState, runnerPoisoned, poisonReap, poisonHolders, runnerOutputTail, lastRunnerCommand, lastRunnerPostMortem, lastKnownCapabilities, quiescenceAnnouncementPending, QUIESCENCE_STATUSES, REBUILD_LOCK_DIR, REBUILD_LOCK_STALE_MS, REBUILD_BUDGET_FILE, runnerRebuildBudget, pendingFastRunnerArtifactNote, staleHittableWarned, runnerTestFaultForwarded, fetchImpl, httpTimeoutOverrideMs, SLOW_RUNNER_COMMANDS, STATUS_PROBE_TIMEOUT_MS, POST_SETTLE_HEALTH_ATTEMPTS, POST_SETTLE_HEALTH_RETRY_MS;
 var init_rn_fast_runner_client = __esm({
   "packages/rn-dev-agent-core/dist/runners/rn-fast-runner-client.js"() {
     "use strict";
@@ -20633,6 +20669,7 @@ var init_rn_fast_runner_client = __esm({
     HTTP_TIMEOUT_MS = 1e4;
     FAST_RUNNER_PROJECT = resolveNativeRunnerDir("rn-fast-runner");
     runnerProcess = null;
+    runnerLaunchCount = 0;
     runnerState = null;
     runnerPoisoned = false;
     poisonReap = null;
@@ -25608,13 +25645,33 @@ async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
     }
     return { ok: false, message: decision.message };
   }
-  await ensure(decision.action === "spawn" ? decision.deviceId : deviceId, bundleId, deps.attachOnly === true ? { attachOnly: true } : {});
-  const after = await probe();
+  const spawnDeviceId = decision.action === "spawn" ? decision.deviceId : deviceId;
+  const spawnOpts = deps.attachOnly === true ? { attachOnly: true } : {};
+  const launchCount = deps.launchCount ?? getRunnerLaunchCount;
+  const launchesBefore = launchCount();
+  await ensure(spawnDeviceId, bundleId, spawnOpts);
+  let after = await probe();
+  let firstStartRetried = false;
+  const launchesAfter = launchCount();
+  if (after.liveness === "dead" && !after.staleReason && launchesAfter > launchesBefore) {
+    const firstSpawnGone = await (deps.awaitSpawnExit ?? (() => awaitSpawnedRunnerExit(void 0, launchesAfter)))();
+    if (firstSpawnGone) {
+      firstStartRetried = true;
+      await ensure(spawnDeviceId, bundleId, spawnOpts);
+      after = await probe();
+    }
+  }
   if (after.liveness === "alive") {
     if (first.staleReason && (PROTOCOL_STALE_REASONS.has(first.staleReason) || first.staleReason === "authority-mismatch")) {
       return {
         ok: true,
         note: first.staleReason === "missing-commands" ? "runner upgraded (stale command surface)" : first.staleReason === "missing-features" ? "runner upgraded (stale feature surface)" : first.staleReason === "authority-mismatch" ? "runner upgraded (authority identity mismatch)" : "runner upgraded (protocol/version mismatch)"
+      };
+    }
+    if (firstStartRetried) {
+      return {
+        ok: true,
+        note: "runner ready after one first-start retry (fresh-simulator XCTest bootstrap)"
       };
     }
     return { ok: true };
@@ -25647,7 +25704,7 @@ async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
   }
   return {
     ok: false,
-    message: "rn-fast-runner did not become ready after auto-spawn. Retry, or run `device_snapshot action=open appId=<your.app.id> platform=ios` to surface the build error."
+    message: `rn-fast-runner did not become ready after auto-spawn${firstStartRetried ? " (one internal retry included)" : ""}. Retry, or run \`device_snapshot action=open appId=<your.app.id> platform=ios\` to surface the build error.`
   };
 }
 async function ensureFastRunner(deviceId, bundleId, opts = {}) {
@@ -28000,7 +28057,7 @@ async function discover(currentPort, platformFilterOrFilters) {
   logger.debug("CDP", `Discovering Metro on ports: ${ports.join(", ")}${hints.length ? ` (${hints.join(", ")})` : ""}`);
   const runningPorts = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
   if (runningPorts.length === 0) {
-    throw new Error("Metro not found on ports " + ports.join(", ") + ". Is the dev server running? Try: npx expo start or npx react-native start");
+    throw new MetroNotFoundError(ports);
   }
   const perPort = await Promise.all(runningPorts.map(async (p) => {
     try {
@@ -28060,7 +28117,7 @@ async function discoverForList(currentPort, portHint) {
   inferPlatforms(targets);
   return { port: chosen, targets };
 }
-var AppDetachedError, DISCOVERY_TIMEOUT_MS, PACKAGE_PROBE_TTL_MS, PACKAGE_PROBE_FAILURE_TTL_MS, PACKAGE_PROBE_SLOW_FAILURE_MS, packageProbeCache, TargetSelectionError;
+var AppDetachedError, DISCOVERY_TIMEOUT_MS, MetroNotFoundError, PACKAGE_PROBE_TTL_MS, PACKAGE_PROBE_FAILURE_TTL_MS, PACKAGE_PROBE_SLOW_FAILURE_MS, packageProbeCache, TargetSelectionError;
 var init_discovery = __esm({
   "packages/rn-dev-agent-core/dist/cdp/discovery.js"() {
     "use strict";
@@ -28083,6 +28140,14 @@ var init_discovery = __esm({
       }
     };
     DISCOVERY_TIMEOUT_MS = 1500;
+    MetroNotFoundError = class extends Error {
+      ports;
+      constructor(ports) {
+        super("Metro not found on ports " + ports.join(", ") + ". Is the dev server running? Try: npx expo start or npx react-native start");
+        this.name = "MetroNotFoundError";
+        this.ports = ports;
+      }
+    };
     PACKAGE_PROBE_TTL_MS = 15e3;
     PACKAGE_PROBE_FAILURE_TTL_MS = 1500;
     PACKAGE_PROBE_SLOW_FAILURE_MS = 1e3;

--- a/packages/rn-dev-agent-core/dist/agent-device-wrapper.js
+++ b/packages/rn-dev-agent-core/dist/agent-device-wrapper.js
@@ -2,7 +2,7 @@ import { unlinkSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import { failResult } from './utils.js';
-import { startFastRunner, probeFastRunnerLiveness, probeFastRunnerLivenessDetailed, adoptPersistedFastRunnerState, reapStaleFastRunner, hasBuiltTestProduct, derivedDataPathForRunner, acquireRunnerRebuildLock, releaseRunnerRebuildLock, runnerRebuildBudget, consumePendingFastRunnerArtifactNote, getRunnerPostMortem, } from './runners/rn-fast-runner-client.js';
+import { startFastRunner, probeFastRunnerLiveness, probeFastRunnerLivenessDetailed, adoptPersistedFastRunnerState, awaitSpawnedRunnerExit, reapStaleFastRunner, hasBuiltTestProduct, derivedDataPathForRunner, acquireRunnerRebuildLock, releaseRunnerRebuildLock, runnerRebuildBudget, consumePendingFastRunnerArtifactNote, getRunnerPostMortem, } from './runners/rn-fast-runner-client.js';
 import { getPluginVersion } from './runners/protocol.js';
 import { resolveBootedIosUdid } from './tools/device-screenshot-raw.js';
 import { refCenter, getScreenRect, clearRefMap, isRefMapFresh, MAX_REF_MAP_AGE_MS, getCachedSignature, getCachedMetadata, getCachedPackageName, getFreshRefTarget, refreshRef, getLastSnapshotHash, getLastSnapshotHashForPackage, invalidateLastSnapshotHash, } from './fast-runner-ref-map.js';
@@ -998,8 +998,22 @@ export async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
         }
         return { ok: false, message: decision.message };
     }
-    await ensure(decision.action === 'spawn' ? decision.deviceId : deviceId, bundleId, deps.attachOnly === true ? { attachOnly: true } : {});
-    const after = await probe();
+    const spawnDeviceId = decision.action === 'spawn' ? decision.deviceId : deviceId;
+    const spawnOpts = deps.attachOnly === true ? { attachOnly: true } : {};
+    await ensure(spawnDeviceId, bundleId, spawnOpts);
+    let after = await probe();
+    // GH #629: a fresh simulator's first XCTest bootstrap predictably overruns
+    // the warm READY window and primes the next spawn — absorb it with exactly
+    // one retry, gated on the failed first spawn having provably exited.
+    let firstStartRetried = false;
+    if (after.liveness === 'dead' && !after.staleReason) {
+        const firstSpawnGone = await (deps.awaitSpawnExit ?? awaitSpawnedRunnerExit)();
+        if (firstSpawnGone) {
+            firstStartRetried = true;
+            await ensure(spawnDeviceId, bundleId, spawnOpts);
+            after = await probe();
+        }
+    }
     if (after.liveness === 'alive') {
         if (first.staleReason &&
             (PROTOCOL_STALE_REASONS.has(first.staleReason) || first.staleReason === 'authority-mismatch')) {
@@ -1012,6 +1026,12 @@ export async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
                         : first.staleReason === 'authority-mismatch'
                             ? 'runner upgraded (authority identity mismatch)'
                             : 'runner upgraded (protocol/version mismatch)',
+            };
+        }
+        if (firstStartRetried) {
+            return {
+                ok: true,
+                note: 'runner ready after one first-start retry (fresh-simulator XCTest bootstrap)',
             };
         }
         return { ok: true };
@@ -1057,7 +1077,8 @@ export async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
     }
     return {
         ok: false,
-        message: 'rn-fast-runner did not become ready after auto-spawn. Retry, or run `device_snapshot action=open appId=<your.app.id> platform=ios` to surface the build error.',
+        message: `rn-fast-runner did not become ready after auto-spawn${firstStartRetried ? ' (one internal retry included)' : ''}. ` +
+            'Retry, or run `device_snapshot action=open appId=<your.app.id> platform=ios` to surface the build error.',
     };
 }
 export async function ensureFastRunner(deviceId, bundleId, 

--- a/packages/rn-dev-agent-core/dist/agent-device-wrapper.js
+++ b/packages/rn-dev-agent-core/dist/agent-device-wrapper.js
@@ -1013,8 +1013,7 @@ export async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
     let firstStartRetried = false;
     const launchesAfter = launchCount();
     if (after.liveness === 'dead' && !after.staleReason && launchesAfter > launchesBefore) {
-        const firstSpawnGone = await (deps.awaitSpawnExit ??
-            (() => awaitSpawnedRunnerExit(undefined, launchesAfter)))();
+        const firstSpawnGone = await (deps.awaitSpawnExit ?? (() => awaitSpawnedRunnerExit(undefined, launchesAfter)))();
         if (firstSpawnGone) {
             firstStartRetried = true;
             await ensure(spawnDeviceId, bundleId, spawnOpts);

--- a/packages/rn-dev-agent-core/dist/agent-device-wrapper.js
+++ b/packages/rn-dev-agent-core/dist/agent-device-wrapper.js
@@ -2,7 +2,7 @@ import { unlinkSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import { failResult } from './utils.js';
-import { startFastRunner, probeFastRunnerLiveness, probeFastRunnerLivenessDetailed, adoptPersistedFastRunnerState, awaitSpawnedRunnerExit, reapStaleFastRunner, hasBuiltTestProduct, derivedDataPathForRunner, acquireRunnerRebuildLock, releaseRunnerRebuildLock, runnerRebuildBudget, consumePendingFastRunnerArtifactNote, getRunnerPostMortem, } from './runners/rn-fast-runner-client.js';
+import { startFastRunner, probeFastRunnerLiveness, probeFastRunnerLivenessDetailed, adoptPersistedFastRunnerState, awaitSpawnedRunnerExit, getRunnerLaunchCount, reapStaleFastRunner, hasBuiltTestProduct, derivedDataPathForRunner, acquireRunnerRebuildLock, releaseRunnerRebuildLock, runnerRebuildBudget, consumePendingFastRunnerArtifactNote, getRunnerPostMortem, } from './runners/rn-fast-runner-client.js';
 import { getPluginVersion } from './runners/protocol.js';
 import { resolveBootedIosUdid } from './tools/device-screenshot-raw.js';
 import { refCenter, getScreenRect, clearRefMap, isRefMapFresh, MAX_REF_MAP_AGE_MS, getCachedSignature, getCachedMetadata, getCachedPackageName, getFreshRefTarget, refreshRef, getLastSnapshotHash, getLastSnapshotHashForPackage, invalidateLastSnapshotHash, } from './fast-runner-ref-map.js';
@@ -1000,13 +1000,18 @@ export async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
     }
     const spawnDeviceId = decision.action === 'spawn' ? decision.deviceId : deviceId;
     const spawnOpts = deps.attachOnly === true ? { attachOnly: true } : {};
+    const launchCount = deps.launchCount ?? getRunnerLaunchCount;
+    const launchesBefore = launchCount();
     await ensure(spawnDeviceId, bundleId, spawnOpts);
     let after = await probe();
     // GH #629: a fresh simulator's first XCTest bootstrap predictably overruns
     // the warm READY window and primes the next spawn — absorb it with exactly
-    // one retry, gated on the failed first spawn having provably exited.
+    // one retry, gated on the first attempt having actually reached the launch
+    // step (ensureFastRunner swallows artifact/cold-build failures, and re-paying
+    // a multi-minute build that failed deterministically helps nobody) and on
+    // that launch child having provably exited.
     let firstStartRetried = false;
-    if (after.liveness === 'dead' && !after.staleReason) {
+    if (after.liveness === 'dead' && !after.staleReason && launchCount() > launchesBefore) {
         const firstSpawnGone = await (deps.awaitSpawnExit ?? awaitSpawnedRunnerExit)();
         if (firstSpawnGone) {
             firstStartRetried = true;

--- a/packages/rn-dev-agent-core/dist/agent-device-wrapper.js
+++ b/packages/rn-dev-agent-core/dist/agent-device-wrapper.js
@@ -1011,8 +1011,10 @@ export async function ensureRunnerForCommand(deviceId, bundleId, deps = {}) {
     // a multi-minute build that failed deterministically helps nobody) and on
     // that launch child having provably exited.
     let firstStartRetried = false;
-    if (after.liveness === 'dead' && !after.staleReason && launchCount() > launchesBefore) {
-        const firstSpawnGone = await (deps.awaitSpawnExit ?? awaitSpawnedRunnerExit)();
+    const launchesAfter = launchCount();
+    if (after.liveness === 'dead' && !after.staleReason && launchesAfter > launchesBefore) {
+        const firstSpawnGone = await (deps.awaitSpawnExit ??
+            (() => awaitSpawnedRunnerExit(undefined, launchesAfter)))();
         if (firstSpawnGone) {
             firstStartRetried = true;
             await ensure(spawnDeviceId, bundleId, spawnOpts);

--- a/packages/rn-dev-agent-core/dist/cdp/discovery.js
+++ b/packages/rn-dev-agent-core/dist/cdp/discovery.js
@@ -31,6 +31,30 @@ export class AppDetachedError extends Error {
 }
 export const DISCOVERY_TIMEOUT_MS = 1500;
 /**
+ * GH #629: thrown by `discover()` when NO candidate port is a running Metro.
+ * Typed so cdp_status can skip its picker fallback (which auto-spawns the
+ * device runner) and surface this truthful result within the discovery budget.
+ */
+export class MetroNotFoundError extends Error {
+    ports;
+    constructor(ports) {
+        super('Metro not found on ports ' +
+            ports.join(', ') +
+            '. Is the dev server running? Try: npx expo start or npx react-native start');
+        this.name = 'MetroNotFoundError';
+        this.ports = ports;
+    }
+}
+/**
+ * GH #629: bounded "is any Metro up at all?" pre-check. One parallel
+ * DISCOVERY_TIMEOUT_MS pass over the candidate ports — closed localhost ports
+ * refuse in milliseconds, so a dead-Metro answer costs well under 2s.
+ */
+export async function anyMetroRunning(currentPort, timeout = DISCOVERY_TIMEOUT_MS) {
+    const ports = [...new Set([currentPort, ...resolveDefaultPorts()])];
+    return (await discoverAllMetroPorts(ports, timeout)).length > 0;
+}
+/**
  * GH #577: default discovery ports, resolved lazily at call time. When
  * RN_CDP_DISCOVERY_PORTS is set it REPLACES the built-in defaults (including
  * the RN_METRO_PORT entry) — an empty value yields no defaults, so discovery
@@ -644,9 +668,7 @@ export async function discover(currentPort, platformFilterOrFilters) {
     // target so a detached sibling-worktree Metro can't shadow a healthy one.
     const runningPorts = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
     if (runningPorts.length === 0) {
-        throw new Error('Metro not found on ports ' +
-            ports.join(', ') +
-            '. Is the dev server running? Try: npx expo start or npx react-native start');
+        throw new MetroNotFoundError(ports);
     }
     const perPort = await Promise.all(runningPorts.map(async (p) => {
         try {

--- a/packages/rn-dev-agent-core/dist/runners/rn-fast-runner-client.js
+++ b/packages/rn-dev-agent-core/dist/runners/rn-fast-runner-client.js
@@ -694,6 +694,40 @@ opts = {}) {
         });
     });
 }
+/**
+ * GH #629: bounded settle before the single first-start retry. The READY
+ * timeout SIGTERMs the launch xcodebuild, but its teardown is asynchronous —
+ * wait for the child to actually exit (escalating to SIGKILL at the grace
+ * cap) so a retry can never stack a second launch on a still-dying first one.
+ */
+export async function awaitSpawnedRunnerExit(graceMs = 5000) {
+    const child = runnerProcess;
+    if (!child || child.exitCode !== null || child.signalCode !== null)
+        return true;
+    return new Promise((resolve) => {
+        const killTimer = setTimeout(() => {
+            try {
+                child.kill('SIGKILL');
+            }
+            catch {
+                /* already gone */
+            }
+        }, graceMs);
+        // Backstop: an unkillable zombie must not wedge the caller forever —
+        // resolve false so the caller refuses the retry instead of stacking a
+        // second launch on a process that provably survived SIGKILL.
+        const backstop = setTimeout(() => {
+            child.removeListener('exit', onExit);
+            resolve(false);
+        }, graceMs + 2000);
+        const onExit = () => {
+            clearTimeout(killTimer);
+            clearTimeout(backstop);
+            resolve(true);
+        };
+        child.once('exit', onExit);
+    });
+}
 // GH #383 (review amendment): adoption-aware teardown. A post-respawn stop
 // (session close, restart, maestro park) would otherwise no-op against empty
 // in-memory state and leak the persisted runner — so adopt first, then reap.

--- a/packages/rn-dev-agent-core/dist/runners/rn-fast-runner-client.js
+++ b/packages/rn-dev-agent-core/dist/runners/rn-fast-runner-client.js
@@ -709,7 +709,14 @@ export function getRunnerLaunchCount() {
  * wait for the child to actually exit (escalating to SIGKILL at the grace
  * cap) so a retry can never stack a second launch on a still-dying first one.
  */
-export async function awaitSpawnedRunnerExit(graceMs = 5000) {
+export async function awaitSpawnedRunnerExit(graceMs = 5000, expectedLaunchCount) {
+    // A concurrent dispatch's start replaces the global handle (and a successful
+    // one leaves it live), so signalling it blind would SIGKILL a runner this
+    // caller never launched. Only the generation the caller observed is ours.
+    if (runnerState)
+        return true;
+    if (expectedLaunchCount !== undefined && runnerLaunchCount !== expectedLaunchCount)
+        return false;
     return awaitChildExit(runnerProcess, graceMs);
 }
 export async function awaitChildExit(child, graceMs = 5000) {

--- a/packages/rn-dev-agent-core/dist/runners/rn-fast-runner-client.js
+++ b/packages/rn-dev-agent-core/dist/runners/rn-fast-runner-client.js
@@ -710,7 +710,9 @@ export function getRunnerLaunchCount() {
  * cap) so a retry can never stack a second launch on a still-dying first one.
  */
 export async function awaitSpawnedRunnerExit(graceMs = 5000) {
-    const child = runnerProcess;
+    return awaitChildExit(runnerProcess, graceMs);
+}
+export async function awaitChildExit(child, graceMs = 5000) {
     if (!child || child.exitCode !== null || child.signalCode !== null)
         return true;
     return new Promise((resolve) => {

--- a/packages/rn-dev-agent-core/dist/runners/rn-fast-runner-client.js
+++ b/packages/rn-dev-agent-core/dist/runners/rn-fast-runner-client.js
@@ -712,9 +712,11 @@ export function getRunnerLaunchCount() {
 export async function awaitSpawnedRunnerExit(graceMs = 5000, expectedLaunchCount) {
     // A concurrent dispatch's start replaces the global handle (and a successful
     // one leaves it live), so signalling it blind would SIGKILL a runner this
-    // caller never launched. Only the generation the caller observed is ours.
+    // caller never launched. Only the generation the caller observed is ours; a
+    // runner that came up meanwhile is someone else's success, never this
+    // caller's retry.
     if (runnerState)
-        return true;
+        return false;
     if (expectedLaunchCount !== undefined && runnerLaunchCount !== expectedLaunchCount)
         return false;
     return awaitChildExit(runnerProcess, graceMs);

--- a/packages/rn-dev-agent-core/dist/runners/rn-fast-runner-client.js
+++ b/packages/rn-dev-agent-core/dist/runners/rn-fast-runner-client.js
@@ -88,6 +88,10 @@ export function createReadySignalParser() {
 }
 // --- Singleton state ---
 let runnerProcess = null;
+// GH #629: monotonic count of launch xcodebuild children actually spawned.
+// ensureFastRunner swallows startFastRunner errors, so this is the only way a
+// caller can tell a READY-timeout apart from a failure before the launch step.
+let runnerLaunchCount = 0;
 let runnerState = null;
 let runnerPoisoned = false;
 let poisonReap = null;
@@ -611,6 +615,7 @@ opts = {}) {
             stdio: ['ignore', 'pipe', 'pipe'],
         });
         runnerProcess = child;
+        runnerLaunchCount += 1;
         runnerOutputTail = '';
         lastRunnerCommand = null;
         lastRunnerPostMortem = null;
@@ -693,6 +698,10 @@ opts = {}) {
             reject(new Error(`xcodebuild exited unexpectedly (code ${code}, signal ${signal ?? 'none'})`));
         });
     });
+}
+/** GH #629: launches observed so far — sample across a start to prove one ran. */
+export function getRunnerLaunchCount() {
+    return runnerLaunchCount;
 }
 /**
  * GH #629: bounded settle before the single first-start retry. The READY

--- a/packages/rn-dev-agent-core/dist/tools/status.js
+++ b/packages/rn-dev-agent-core/dist/tools/status.js
@@ -7,7 +7,7 @@ import { recoverWedge } from '../cdp/recover-wedge.js';
 import { recoverDetached } from '../cdp/recover-detached.js';
 import { buildNotInstalledAdvice } from '../cdp/app-installed-probe.js';
 import { snapshotHintForBundleId } from './resolve-ios-app-file.js';
-import { AppDetachedError, TargetSelectionError, androidTargetMatchesKind, enumerateMetroCandidates, targetBundleIdentity, targetMatchesBundleId, } from '../cdp/discovery.js';
+import { AppDetachedError, MetroNotFoundError, TargetSelectionError, androidTargetMatchesKind, anyMetroRunning, enumerateMetroCandidates, targetBundleIdentity, targetMatchesBundleId, } from '../cdp/discovery.js';
 import { resolveBridgeProjectRoot, pathMatchesRoot } from '../cdp/metro-cwd.js';
 import { getDeviceSessionHealth } from './device-session-health.js';
 import { detectIosExternalRunner } from '../runners/external-runner-detect.js';
@@ -265,13 +265,19 @@ export function createStatusHandler(getClient, setClient, createClient, deps = {
                 // picker first lets autoConnect see a real target on its first
                 // attempt. Best-effort: any failure here falls through to the
                 // existing catch-block picker check as a safety net.
-                try {
-                    if (await isDevClientPickerShowing()) {
-                        await handleDevClientPicker();
+                // GH #629: gate the probe on a bounded Metro pre-scan. Each picker
+                // probe dispatches a runner auto-spawn (30s readiness wait); with no
+                // Metro up at all, a dismissal cannot help, so skip straight to
+                // discover()'s truthful not-found failure (seconds, not minutes).
+                if (await anyMetroRunning(client.metroPort)) {
+                    try {
+                        if (await isDevClientPickerShowing()) {
+                            await handleDevClientPicker();
+                        }
                     }
-                }
-                catch {
-                    /* fall through to autoConnect */
+                    catch {
+                        /* fall through to autoConnect */
+                    }
                 }
                 // GH #208 (RC1): when a reconnect storm is in flight, bare autoConnect
                 // throws "Already connecting to Metro..." (connect.ts guard) and dead-ends
@@ -494,6 +500,16 @@ export function createStatusHandler(getClient, setClient, createClient, deps = {
                     autoConnect: getClient().autoConnectState,
                     bridge: bridgeEnvState(process.env),
                     recovery,
+                });
+            }
+            // GH #629: no Metro is up at all — the picker fallback below spawns the
+            // device runner and cannot help. Surface the truthful not-found result
+            // now, keeping cdp_status bounded by the discovery scan budget.
+            if (err instanceof MetroNotFoundError) {
+                return failResult(message, {
+                    reconnect: getClient().reconnectState,
+                    autoConnect: getClient().autoConnectState,
+                    bridge: bridgeEnvState(process.env),
                 });
             }
             // GH #184: the status-scoped connect aborted fast because React was

--- a/packages/rn-dev-agent-core/src/agent-device-wrapper.ts
+++ b/packages/rn-dev-agent-core/src/agent-device-wrapper.ts
@@ -10,6 +10,7 @@ import {
   probeFastRunnerLivenessDetailed,
   adoptPersistedFastRunnerState,
   awaitSpawnedRunnerExit,
+  getRunnerLaunchCount,
   reapStaleFastRunner,
   hasBuiltTestProduct,
   derivedDataPathForRunner,
@@ -1068,6 +1069,8 @@ export interface EnsureRunnerDeps {
   /** GH #629: bounded wait for the failed first spawn to exit before the retry;
    * resolves false (retry refused) when the process survives escalation. */
   awaitSpawnExit?: () => Promise<boolean>;
+  /** GH #629: monotonic launch-child count; the retry needs it to advance. */
+  launchCount?: () => number;
   releaseBuildLock?: () => void;
   rebuildBudget?: { alreadyRebuiltFor(v: string): boolean; recordRebuild(v: string): void };
   pluginVersion?: string | null;
@@ -1242,13 +1245,18 @@ export async function ensureRunnerForCommand(
 
   const spawnDeviceId = decision.action === 'spawn' ? decision.deviceId : deviceId!;
   const spawnOpts = deps.attachOnly === true ? { attachOnly: true } : {};
+  const launchCount = deps.launchCount ?? getRunnerLaunchCount;
+  const launchesBefore = launchCount();
   await ensure(spawnDeviceId, bundleId, spawnOpts);
   let after = await probe();
   // GH #629: a fresh simulator's first XCTest bootstrap predictably overruns
   // the warm READY window and primes the next spawn — absorb it with exactly
-  // one retry, gated on the failed first spawn having provably exited.
+  // one retry, gated on the first attempt having actually reached the launch
+  // step (ensureFastRunner swallows artifact/cold-build failures, and re-paying
+  // a multi-minute build that failed deterministically helps nobody) and on
+  // that launch child having provably exited.
   let firstStartRetried = false;
-  if (after.liveness === 'dead' && !after.staleReason) {
+  if (after.liveness === 'dead' && !after.staleReason && launchCount() > launchesBefore) {
     const firstSpawnGone = await (deps.awaitSpawnExit ?? awaitSpawnedRunnerExit)();
     if (firstSpawnGone) {
       firstStartRetried = true;

--- a/packages/rn-dev-agent-core/src/agent-device-wrapper.ts
+++ b/packages/rn-dev-agent-core/src/agent-device-wrapper.ts
@@ -1256,8 +1256,10 @@ export async function ensureRunnerForCommand(
   // a multi-minute build that failed deterministically helps nobody) and on
   // that launch child having provably exited.
   let firstStartRetried = false;
-  if (after.liveness === 'dead' && !after.staleReason && launchCount() > launchesBefore) {
-    const firstSpawnGone = await (deps.awaitSpawnExit ?? awaitSpawnedRunnerExit)();
+  const launchesAfter = launchCount();
+  if (after.liveness === 'dead' && !after.staleReason && launchesAfter > launchesBefore) {
+    const firstSpawnGone = await (deps.awaitSpawnExit ??
+      (() => awaitSpawnedRunnerExit(undefined, launchesAfter)))();
     if (firstSpawnGone) {
       firstStartRetried = true;
       await ensure(spawnDeviceId, bundleId, spawnOpts);

--- a/packages/rn-dev-agent-core/src/agent-device-wrapper.ts
+++ b/packages/rn-dev-agent-core/src/agent-device-wrapper.ts
@@ -1258,8 +1258,9 @@ export async function ensureRunnerForCommand(
   let firstStartRetried = false;
   const launchesAfter = launchCount();
   if (after.liveness === 'dead' && !after.staleReason && launchesAfter > launchesBefore) {
-    const firstSpawnGone = await (deps.awaitSpawnExit ??
-      (() => awaitSpawnedRunnerExit(undefined, launchesAfter)))();
+    const firstSpawnGone = await (
+      deps.awaitSpawnExit ?? (() => awaitSpawnedRunnerExit(undefined, launchesAfter))
+    )();
     if (firstSpawnGone) {
       firstStartRetried = true;
       await ensure(spawnDeviceId, bundleId, spawnOpts);

--- a/packages/rn-dev-agent-core/src/agent-device-wrapper.ts
+++ b/packages/rn-dev-agent-core/src/agent-device-wrapper.ts
@@ -9,6 +9,7 @@ import {
   probeFastRunnerLiveness,
   probeFastRunnerLivenessDetailed,
   adoptPersistedFastRunnerState,
+  awaitSpawnedRunnerExit,
   reapStaleFastRunner,
   hasBuiltTestProduct,
   derivedDataPathForRunner,
@@ -1064,6 +1065,9 @@ export interface EnsureRunnerDeps {
   invalidateArtifact?: () => void;
   reap?: () => Promise<void>;
   acquireBuildLock?: () => boolean;
+  /** GH #629: bounded wait for the failed first spawn to exit before the retry;
+   * resolves false (retry refused) when the process survives escalation. */
+  awaitSpawnExit?: () => Promise<boolean>;
   releaseBuildLock?: () => void;
   rebuildBudget?: { alreadyRebuiltFor(v: string): boolean; recordRebuild(v: string): void };
   pluginVersion?: string | null;
@@ -1236,12 +1240,22 @@ export async function ensureRunnerForCommand(
     return { ok: false, message: decision.message };
   }
 
-  await ensure(
-    decision.action === 'spawn' ? decision.deviceId : deviceId!,
-    bundleId,
-    deps.attachOnly === true ? { attachOnly: true } : {},
-  );
-  const after = await probe();
+  const spawnDeviceId = decision.action === 'spawn' ? decision.deviceId : deviceId!;
+  const spawnOpts = deps.attachOnly === true ? { attachOnly: true } : {};
+  await ensure(spawnDeviceId, bundleId, spawnOpts);
+  let after = await probe();
+  // GH #629: a fresh simulator's first XCTest bootstrap predictably overruns
+  // the warm READY window and primes the next spawn — absorb it with exactly
+  // one retry, gated on the failed first spawn having provably exited.
+  let firstStartRetried = false;
+  if (after.liveness === 'dead' && !after.staleReason) {
+    const firstSpawnGone = await (deps.awaitSpawnExit ?? awaitSpawnedRunnerExit)();
+    if (firstSpawnGone) {
+      firstStartRetried = true;
+      await ensure(spawnDeviceId, bundleId, spawnOpts);
+      after = await probe();
+    }
+  }
   if (after.liveness === 'alive') {
     if (
       first.staleReason &&
@@ -1257,6 +1271,12 @@ export async function ensureRunnerForCommand(
               : first.staleReason === 'authority-mismatch'
                 ? 'runner upgraded (authority identity mismatch)'
                 : 'runner upgraded (protocol/version mismatch)',
+      };
+    }
+    if (firstStartRetried) {
+      return {
+        ok: true,
+        note: 'runner ready after one first-start retry (fresh-simulator XCTest bootstrap)',
       };
     }
     return { ok: true };
@@ -1309,7 +1329,8 @@ export async function ensureRunnerForCommand(
   return {
     ok: false,
     message:
-      'rn-fast-runner did not become ready after auto-spawn. Retry, or run `device_snapshot action=open appId=<your.app.id> platform=ios` to surface the build error.',
+      `rn-fast-runner did not become ready after auto-spawn${firstStartRetried ? ' (one internal retry included)' : ''}. ` +
+      'Retry, or run `device_snapshot action=open appId=<your.app.id> platform=ios` to surface the build error.',
   };
 }
 

--- a/packages/rn-dev-agent-core/src/cdp/discovery.ts
+++ b/packages/rn-dev-agent-core/src/cdp/discovery.ts
@@ -37,6 +37,37 @@ export class AppDetachedError extends Error {
 export const DISCOVERY_TIMEOUT_MS = 1500;
 
 /**
+ * GH #629: thrown by `discover()` when NO candidate port is a running Metro.
+ * Typed so cdp_status can skip its picker fallback (which auto-spawns the
+ * device runner) and surface this truthful result within the discovery budget.
+ */
+export class MetroNotFoundError extends Error {
+  readonly ports: number[];
+  constructor(ports: number[]) {
+    super(
+      'Metro not found on ports ' +
+        ports.join(', ') +
+        '. Is the dev server running? Try: npx expo start or npx react-native start',
+    );
+    this.name = 'MetroNotFoundError';
+    this.ports = ports;
+  }
+}
+
+/**
+ * GH #629: bounded "is any Metro up at all?" pre-check. One parallel
+ * DISCOVERY_TIMEOUT_MS pass over the candidate ports — closed localhost ports
+ * refuse in milliseconds, so a dead-Metro answer costs well under 2s.
+ */
+export async function anyMetroRunning(
+  currentPort: number,
+  timeout: number = DISCOVERY_TIMEOUT_MS,
+): Promise<boolean> {
+  const ports = [...new Set([currentPort, ...resolveDefaultPorts()])];
+  return (await discoverAllMetroPorts(ports, timeout)).length > 0;
+}
+
+/**
  * GH #577: default discovery ports, resolved lazily at call time. When
  * RN_CDP_DISCOVERY_PORTS is set it REPLACES the built-in defaults (including
  * the RN_METRO_PORT entry) — an empty value yields no defaults, so discovery
@@ -787,11 +818,7 @@ export async function discover(
   // target so a detached sibling-worktree Metro can't shadow a healthy one.
   const runningPorts = await discoverAllMetroPorts(ports, DISCOVERY_TIMEOUT_MS);
   if (runningPorts.length === 0) {
-    throw new Error(
-      'Metro not found on ports ' +
-        ports.join(', ') +
-        '. Is the dev server running? Try: npx expo start or npx react-native start',
-    );
+    throw new MetroNotFoundError(ports);
   }
 
   const perPort = await Promise.all(

--- a/packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts
+++ b/packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts
@@ -899,10 +899,7 @@ export async function awaitSpawnedRunnerExit(
   return awaitChildExit(runnerProcess, graceMs);
 }
 
-export async function awaitChildExit(
-  child: ChildProcess | null,
-  graceMs = 5000,
-): Promise<boolean> {
+export async function awaitChildExit(child: ChildProcess | null, graceMs = 5000): Promise<boolean> {
   if (!child || child.exitCode !== null || child.signalCode !== null) return true;
   return new Promise<boolean>((resolve) => {
     const killTimer = setTimeout(() => {

--- a/packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts
+++ b/packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts
@@ -869,6 +869,39 @@ export async function startFastRunner(
   });
 }
 
+/**
+ * GH #629: bounded settle before the single first-start retry. The READY
+ * timeout SIGTERMs the launch xcodebuild, but its teardown is asynchronous —
+ * wait for the child to actually exit (escalating to SIGKILL at the grace
+ * cap) so a retry can never stack a second launch on a still-dying first one.
+ */
+export async function awaitSpawnedRunnerExit(graceMs = 5000): Promise<boolean> {
+  const child = runnerProcess;
+  if (!child || child.exitCode !== null || child.signalCode !== null) return true;
+  return new Promise<boolean>((resolve) => {
+    const killTimer = setTimeout(() => {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        /* already gone */
+      }
+    }, graceMs);
+    // Backstop: an unkillable zombie must not wedge the caller forever —
+    // resolve false so the caller refuses the retry instead of stacking a
+    // second launch on a process that provably survived SIGKILL.
+    const backstop = setTimeout(() => {
+      child.removeListener('exit', onExit);
+      resolve(false);
+    }, graceMs + 2000);
+    const onExit = (): void => {
+      clearTimeout(killTimer);
+      clearTimeout(backstop);
+      resolve(true);
+    };
+    child.once('exit', onExit);
+  });
+}
+
 // GH #383 (review amendment): adoption-aware teardown. A post-respawn stop
 // (session close, restart, maestro park) would otherwise no-op against empty
 // in-memory state and leak the persisted runner — so adopt first, then reap.

--- a/packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts
+++ b/packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts
@@ -891,8 +891,10 @@ export async function awaitSpawnedRunnerExit(
 ): Promise<boolean> {
   // A concurrent dispatch's start replaces the global handle (and a successful
   // one leaves it live), so signalling it blind would SIGKILL a runner this
-  // caller never launched. Only the generation the caller observed is ours.
-  if (runnerState) return true;
+  // caller never launched. Only the generation the caller observed is ours; a
+  // runner that came up meanwhile is someone else's success, never this
+  // caller's retry.
+  if (runnerState) return false;
   if (expectedLaunchCount !== undefined && runnerLaunchCount !== expectedLaunchCount) return false;
   return awaitChildExit(runnerProcess, graceMs);
 }

--- a/packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts
+++ b/packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts
@@ -885,7 +885,15 @@ export function getRunnerLaunchCount(): number {
  * wait for the child to actually exit (escalating to SIGKILL at the grace
  * cap) so a retry can never stack a second launch on a still-dying first one.
  */
-export async function awaitSpawnedRunnerExit(graceMs = 5000): Promise<boolean> {
+export async function awaitSpawnedRunnerExit(
+  graceMs = 5000,
+  expectedLaunchCount?: number,
+): Promise<boolean> {
+  // A concurrent dispatch's start replaces the global handle (and a successful
+  // one leaves it live), so signalling it blind would SIGKILL a runner this
+  // caller never launched. Only the generation the caller observed is ours.
+  if (runnerState) return true;
+  if (expectedLaunchCount !== undefined && runnerLaunchCount !== expectedLaunchCount) return false;
   return awaitChildExit(runnerProcess, graceMs);
 }
 

--- a/packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts
+++ b/packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts
@@ -161,6 +161,10 @@ export function createReadySignalParser(): ReadySignalParser {
 // --- Singleton state ---
 
 let runnerProcess: ChildProcess | null = null;
+// GH #629: monotonic count of launch xcodebuild children actually spawned.
+// ensureFastRunner swallows startFastRunner errors, so this is the only way a
+// caller can tell a READY-timeout apart from a failure before the launch step.
+let runnerLaunchCount = 0;
 let runnerState: FastRunnerState | null = null;
 let runnerPoisoned = false;
 let poisonReap: Promise<void> | null = null;
@@ -778,6 +782,7 @@ export async function startFastRunner(
     });
 
     runnerProcess = child;
+    runnerLaunchCount += 1;
     runnerOutputTail = '';
     lastRunnerCommand = null;
     lastRunnerPostMortem = null;
@@ -867,6 +872,11 @@ export async function startFastRunner(
       );
     });
   });
+}
+
+/** GH #629: launches observed so far — sample across a start to prove one ran. */
+export function getRunnerLaunchCount(): number {
+  return runnerLaunchCount;
 }
 
 /**

--- a/packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts
+++ b/packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts
@@ -886,7 +886,13 @@ export function getRunnerLaunchCount(): number {
  * cap) so a retry can never stack a second launch on a still-dying first one.
  */
 export async function awaitSpawnedRunnerExit(graceMs = 5000): Promise<boolean> {
-  const child = runnerProcess;
+  return awaitChildExit(runnerProcess, graceMs);
+}
+
+export async function awaitChildExit(
+  child: ChildProcess | null,
+  graceMs = 5000,
+): Promise<boolean> {
   if (!child || child.exitCode !== null || child.signalCode !== null) return true;
   return new Promise<boolean>((resolve) => {
     const killTimer = setTimeout(() => {

--- a/packages/rn-dev-agent-core/src/tools/status.ts
+++ b/packages/rn-dev-agent-core/src/tools/status.ts
@@ -12,8 +12,10 @@ import { buildNotInstalledAdvice } from '../cdp/app-installed-probe.js';
 import { snapshotHintForBundleId } from './resolve-ios-app-file.js';
 import {
   AppDetachedError,
+  MetroNotFoundError,
   TargetSelectionError,
   androidTargetMatchesKind,
+  anyMetroRunning,
   enumerateMetroCandidates,
   targetBundleIdentity,
   targetMatchesBundleId,
@@ -335,12 +337,18 @@ export function createStatusHandler(
         // picker first lets autoConnect see a real target on its first
         // attempt. Best-effort: any failure here falls through to the
         // existing catch-block picker check as a safety net.
-        try {
-          if (await isDevClientPickerShowing()) {
-            await handleDevClientPicker();
+        // GH #629: gate the probe on a bounded Metro pre-scan. Each picker
+        // probe dispatches a runner auto-spawn (30s readiness wait); with no
+        // Metro up at all, a dismissal cannot help, so skip straight to
+        // discover()'s truthful not-found failure (seconds, not minutes).
+        if (await anyMetroRunning(client.metroPort)) {
+          try {
+            if (await isDevClientPickerShowing()) {
+              await handleDevClientPicker();
+            }
+          } catch {
+            /* fall through to autoConnect */
           }
-        } catch {
-          /* fall through to autoConnect */
         }
         // GH #208 (RC1): when a reconnect storm is in flight, bare autoConnect
         // throws "Already connecting to Metro..." (connect.ts guard) and dead-ends
@@ -605,6 +613,17 @@ export function createStatusHandler(
           autoConnect: getClient().autoConnectState,
           bridge: bridgeEnvState(process.env),
           recovery,
+        });
+      }
+
+      // GH #629: no Metro is up at all — the picker fallback below spawns the
+      // device runner and cannot help. Surface the truthful not-found result
+      // now, keeping cdp_status bounded by the discovery scan budget.
+      if (err instanceof MetroNotFoundError) {
+        return failResult(message, {
+          reconnect: getClient().reconnectState,
+          autoConnect: getClient().autoConnectState,
+          bridge: bridgeEnvState(process.env),
         });
       }
 

--- a/packages/rn-dev-agent-core/test/unit/gh-136-status-picker-precheck.test.js
+++ b/packages/rn-dev-agent-core/test/unit/gh-136-status-picker-precheck.test.js
@@ -7,6 +7,7 @@
 // assert the sequence directly — `pickerProbe` must precede `autoConnect`.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
 import { createMockClient } from '../helpers/mock-cdp-client.js';
 import { expectOk } from '../helpers/result-helpers.js';
 import { createStatusHandler } from '../../dist/tools/status.js';
@@ -18,6 +19,26 @@ import {
   _setFetchCandidatesForTest,
   _resetFetchCandidatesForTest,
 } from '../../dist/tools/dev-client-picker.js';
+
+// GH #629 gates the pre-connect probe on a bounded Metro pre-scan: with no
+// Metro up, a picker dismissal cannot help and the probe is skipped. The
+// ordering guarantee below is therefore asserted against a live fake Metro,
+// so it no longer depends on whatever happens to listen on 8081.
+function startFakeMetro() {
+  return new Promise((resolve, reject) => {
+    const server = createServer((req, res) => {
+      if (req.url === '/status') {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('packager-status:running');
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
+    server.on('error', reject);
+  });
+}
 
 function makeStatusProbe(extraAppInfo = {}) {
   return JSON.stringify({
@@ -31,6 +52,9 @@ function makeStatusProbe(extraAppInfo = {}) {
 
 test('cdp_status: picker probe runs BEFORE autoConnect when not connected', async () => {
   const events = [];
+  const savedDiscoveryPorts = process.env.RN_CDP_DISCOVERY_PORTS;
+  const { server, port } = await startFakeMetro();
+  process.env.RN_CDP_DISCOVERY_PORTS = '';
   _setHasSessionForTest(true);
   let probeCount = 0;
   _setFetchCandidatesForTest(async (_text) => {
@@ -44,6 +68,7 @@ test('cdp_status: picker probe runs BEFORE autoConnect when not connected', asyn
   const client = createMockClient({
     _isConnected: false,
     _helpersInjected: true,
+    _metroPort: port,
     autoConnect: async () => {
       events.push('autoConnect');
       client._isConnected = true;
@@ -65,6 +90,9 @@ test('cdp_status: picker probe runs BEFORE autoConnect when not connected', asyn
       `events out of order: ${JSON.stringify(events)}`,
     );
   } finally {
+    if (savedDiscoveryPorts === undefined) delete process.env.RN_CDP_DISCOVERY_PORTS;
+    else process.env.RN_CDP_DISCOVERY_PORTS = savedDiscoveryPorts;
+    await new Promise((resolve) => server.close(resolve));
     _resetFetchCandidatesForTest();
     _resetHasSessionForTest();
   }

--- a/packages/rn-dev-agent-core/test/unit/gh-629-dead-metro-fast-status.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-629-dead-metro-fast-status.test.ts
@@ -1,0 +1,250 @@
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { createMockClient } from '../helpers/mock-cdp-client.js';
+import { createStatusHandler } from '../../dist/tools/status.js';
+import { MetroNotFoundError, anyMetroRunning } from '../../dist/cdp/discovery.js';
+import {
+  _setHasSessionForTest,
+  _resetHasSessionForTest,
+  _setFetchCandidatesForTest,
+  _resetFetchCandidatesForTest,
+} from '../../dist/tools/dev-client-picker.js';
+
+// GH #629: cdp_status on a dead Metro must answer within the discovery budget.
+// The 120s hang came from the dev-client-picker probes around discovery — each
+// one dispatches a runner auto-spawn with a 30s readiness wait. When no Metro
+// is up at all, a picker dismissal cannot help, so cdp_status must skip the
+// probes and surface discover()'s truthful not-found failure fast.
+
+const savedDiscoveryPorts = process.env.RN_CDP_DISCOVERY_PORTS;
+
+function envelope(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0]!.text);
+}
+
+async function reservedClosedPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, '127.0.0.1', () => {
+      const port = (srv.address() as AddressInfo).port;
+      srv.close(() => resolve(port));
+    });
+    srv.on('error', reject);
+  });
+}
+
+function startFakeMetro(): Promise<{ server: Server; port: number }> {
+  return new Promise((resolve, reject) => {
+    const server = createServer((req, res) => {
+      if (req.url === '/status') {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('packager-status:running');
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    server.listen(0, '127.0.0.1', () => {
+      resolve({ server, port: (server.address() as AddressInfo).port });
+    });
+    server.on('error', reject);
+  });
+}
+
+beforeEach(() => {
+  delete process.env.RN_CDP_DISCOVERY_PORTS;
+});
+
+afterEach(() => {
+  if (savedDiscoveryPorts === undefined) delete process.env.RN_CDP_DISCOVERY_PORTS;
+  else process.env.RN_CDP_DISCOVERY_PORTS = savedDiscoveryPorts;
+  _resetHasSessionForTest();
+  _resetFetchCandidatesForTest();
+});
+
+test('anyMetroRunning is false (fast) when every candidate port is closed', async () => {
+  const closed = await reservedClosedPort();
+  process.env.RN_CDP_DISCOVERY_PORTS = '';
+  const t0 = Date.now();
+  assert.equal(await anyMetroRunning(closed), false);
+  // Closed localhost ports refuse in milliseconds; the whole scan must stay
+  // far below the 1.5s per-port budget, never minutes.
+  assert.ok(Date.now() - t0 < 5000, `scan took ${Date.now() - t0}ms`);
+});
+
+test('anyMetroRunning is true against a live Metro /status endpoint', async () => {
+  const { server, port } = await startFakeMetro();
+  try {
+    process.env.RN_CDP_DISCOVERY_PORTS = '';
+    assert.equal(await anyMetroRunning(port), true);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test('anyMetroRunning aborts a stalling server at the per-port budget (bounded, false)', async () => {
+  // Accepts the TCP connection but never answers — the exact shape that would
+  // hang an unbounded probe. The AbortController must cut it at the timeout.
+  const stallers: Array<import('node:http').ServerResponse> = [];
+  const server = createServer((_req, res) => {
+    stallers.push(res); // hold the response open forever
+  });
+  const port = await new Promise<number>((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => resolve((server.address() as AddressInfo).port));
+    server.on('error', reject);
+  });
+  try {
+    process.env.RN_CDP_DISCOVERY_PORTS = '';
+    const t0 = Date.now();
+    assert.equal(await anyMetroRunning(port, 300), false);
+    const elapsed = Date.now() - t0;
+    // The caller-supplied 300ms budget must govern the abort — an
+    // implementation ignoring it (e.g. hard-coding 1500ms) fails the ceiling.
+    assert.ok(elapsed >= 250, `probe aborted before its budget: ${elapsed}ms`);
+    assert.ok(elapsed < 1400, `stalled probe must abort at the 300ms budget, took ${elapsed}ms`);
+  } finally {
+    for (const res of stallers) res.destroy();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test('a stalling candidate port cannot blind a healthy sibling (per-port budgets)', async () => {
+  const staller = createServer(() => {
+    /* accept and never respond */
+  });
+  const stallPort = await new Promise<number>((resolve, reject) => {
+    staller.listen(0, '127.0.0.1', () => resolve((staller.address() as AddressInfo).port));
+    staller.on('error', reject);
+  });
+  const { server, port: livePort } = await startFakeMetro();
+  try {
+    // Candidate set: one stalling port (via the discovery-ports override) plus
+    // the live hint port. Ports are probed in parallel with per-port budgets,
+    // so the staller must neither hide the healthy Metro nor extend the scan.
+    process.env.RN_CDP_DISCOVERY_PORTS = String(stallPort);
+    assert.equal(await anyMetroRunning(livePort, 300), true);
+  } finally {
+    staller.closeAllConnections?.();
+    await new Promise((resolve) => staller.close(resolve));
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test('a Metro that responds slowly but within budget is still discovered', async () => {
+  const server = createServer((req, res) => {
+    if (req.url === '/status') {
+      setTimeout(() => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('packager-status:running');
+      }, 500);
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  const port = await new Promise<number>((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => resolve((server.address() as AddressInfo).port));
+    server.on('error', reject);
+  });
+  try {
+    process.env.RN_CDP_DISCOVERY_PORTS = '';
+    // 500ms response vs the production 1500ms per-port budget: must be found.
+    assert.equal(await anyMetroRunning(port), true);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test('dead-Metro cdp_status skips picker probes and returns the truthful not-found fast', async () => {
+  const closed = await reservedClosedPort();
+  process.env.RN_CDP_DISCOVERY_PORTS = '';
+  _setHasSessionForTest(true);
+  let pickerProbes = 0;
+  _setFetchCandidatesForTest(async () => {
+    pickerProbes += 1;
+    return { ok: false as const, reason: 'fetch-failed' as const };
+  });
+
+  // Route the mock through the REAL discovery path so the assertion covers the
+  // genuine dead-Metro scan, not a preconstructed error.
+  const { discover } = await import('../../dist/cdp/discovery.js');
+  const client = createMockClient({
+    _isConnected: false,
+    _metroPort: closed,
+    autoConnect: async () => {
+      await discover(closed);
+    },
+  });
+
+  const t0 = Date.now();
+  const result = await createStatusHandler(
+    () => client,
+    () => {},
+    () => client,
+  )({});
+  const elapsed = Date.now() - t0;
+  const body = envelope(result);
+
+  assert.equal(body.ok, false, result.content[0]!.text);
+  // The truthful not-found result must be preserved verbatim.
+  assert.equal(
+    body.error,
+    `Metro not found on ports ${closed}. Is the dev server running? Try: npx expo start or npx react-native start`,
+  );
+  assert.equal(pickerProbes, 0, 'no picker probe (and so no runner auto-spawn) may run');
+  assert.ok(elapsed < 5000, `cdp_status took ${elapsed}ms on a dead Metro`);
+});
+
+test('live-Metro cdp_status still runs the picker probes on connect failure', async () => {
+  const { server, port } = await startFakeMetro();
+  try {
+    process.env.RN_CDP_DISCOVERY_PORTS = '';
+    _setHasSessionForTest(true);
+    const events: string[] = [];
+    _setFetchCandidatesForTest(async () => {
+      events.push('picker-probe');
+      return { ok: false as const, reason: 'fetch-failed' as const };
+    });
+
+    const client = createMockClient({
+      _isConnected: false,
+      _metroPort: port,
+      autoConnect: async () => {
+        events.push('auto-connect');
+        throw new Error('target connect failed (fixture)');
+      },
+    });
+
+    const result = await createStatusHandler(
+      () => client,
+      () => {},
+      () => client,
+    )({});
+    const body = envelope(result);
+
+    assert.equal(body.ok, false);
+    assert.match(body.error, /target connect failed \(fixture\)/);
+    // The GH #136 pre-connect probe must still run while a Metro is up.
+    assert.ok(
+      events.indexOf('picker-probe') !== -1 &&
+        events.indexOf('picker-probe') < events.indexOf('auto-connect'),
+      `pre-connect picker probing must be preserved while a Metro is up: ${events.join(',')}`,
+    );
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test('discover() throws the typed MetroNotFoundError carrying the probed ports', async () => {
+  const closed = await reservedClosedPort();
+  process.env.RN_CDP_DISCOVERY_PORTS = '';
+  const { discover } = await import('../../dist/cdp/discovery.js');
+  await assert.rejects(discover(closed), (err: unknown) => {
+    assert.ok(err instanceof MetroNotFoundError);
+    assert.deepEqual(err.ports, [closed]);
+    assert.match(err.message, /Metro not found on ports /);
+    return true;
+  });
+});

--- a/packages/rn-dev-agent-core/test/unit/gh-629-runner-exit-settle.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-629-runner-exit-settle.test.ts
@@ -1,0 +1,95 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { awaitChildExit } from '../../dist/runners/rn-fast-runner-client.js';
+
+// GH #629: the first-start retry may only proceed once the failed first launch
+// has provably exited. These exercise the real settle logic against real
+// processes — the injected-fixture suite covers the retry decision, this one
+// covers the primitive that decision trusts.
+
+function spawnKeepAlive(script: string): ChildProcess {
+  return spawn(process.execPath, ['-e', script], { stdio: ['ignore', 'pipe', 'ignore'] });
+}
+
+// The child prints 'ready' only once its signal disposition is installed —
+// waiting on the 'spawn' event alone races the script's own evaluation.
+async function whenReady(child: ChildProcess): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    child.stdout!.setEncoding('utf-8');
+    child.stdout!.on('data', (chunk: string) => {
+      if (chunk.includes('ready')) resolve();
+    });
+    child.once('error', reject);
+    child.once('exit', () => reject(new Error('child exited before signalling ready')));
+  });
+}
+
+test('a null handle settles immediately (nothing to wait for)', async () => {
+  const t0 = Date.now();
+  assert.equal(await awaitChildExit(null, 5000), true);
+  assert.ok(Date.now() - t0 < 1000, 'must not wait on an absent process');
+});
+
+test('an already-exited child settles immediately without escalation', async () => {
+  const child = spawnKeepAlive('');
+  await new Promise((resolve) => child.once('exit', resolve));
+  const t0 = Date.now();
+  assert.equal(await awaitChildExit(child, 5000), true);
+  assert.ok(Date.now() - t0 < 1000, 'an exited child must not burn the grace window');
+});
+
+test('a child that honours SIGTERM settles true before the grace cap', async () => {
+  // The READY timeout has already sent SIGTERM in production; teardown is async.
+  const child = spawnKeepAlive("setInterval(() => {}, 1000); console.log('ready');");
+  await whenReady(child);
+  child.kill('SIGTERM');
+  const t0 = Date.now();
+  assert.equal(await awaitChildExit(child, 3000), true);
+  assert.ok(Date.now() - t0 < 3000, 'settled via SIGTERM, not the SIGKILL escalation');
+  assert.equal(child.signalCode, 'SIGTERM');
+});
+
+test('a child that ignores SIGTERM is escalated to SIGKILL at the grace cap', async () => {
+  const child = spawnKeepAlive(
+    "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000); console.log('ready');",
+  );
+  await whenReady(child);
+  child.kill('SIGTERM');
+  const t0 = Date.now();
+  assert.equal(await awaitChildExit(child, 300), true);
+  const elapsed = Date.now() - t0;
+  assert.ok(elapsed >= 300, `escalation fired before the grace cap: ${elapsed}ms`);
+  assert.ok(elapsed < 2300, `escalation must not fall through to the backstop: ${elapsed}ms`);
+  // SIGKILL, not a voluntary exit: the escalation is what reaped it.
+  assert.equal(child.signalCode, 'SIGKILL');
+  assert.equal(child.exitCode, null);
+});
+
+test('a handle surviving SIGKILL is refused at the backstop (retry must not stack)', async () => {
+  // A real process cannot survive SIGKILL, so the unkillable-zombie shape is
+  // modelled with a handle that reports itself live and never emits 'exit'.
+  const signals: Array<string | undefined> = [];
+  const zombie = Object.assign(new EventEmitter(), {
+    exitCode: null,
+    signalCode: null,
+    kill: (signal?: string) => {
+      signals.push(signal);
+      return true;
+    },
+  }) as unknown as ChildProcess;
+
+  const t0 = Date.now();
+  const settled = await awaitChildExit(zombie, 100);
+  const elapsed = Date.now() - t0;
+
+  assert.equal(settled, false, 'a surviving process must refuse the retry');
+  assert.deepEqual(signals, ['SIGKILL'], 'escalation is attempted before giving up');
+  assert.ok(elapsed >= 2100, `backstop fired early: ${elapsed}ms`);
+  assert.equal(
+    (zombie as unknown as EventEmitter).listenerCount('exit'),
+    0,
+    'the exit listener must be removed when the backstop gives up',
+  );
+});

--- a/packages/rn-dev-agent-core/test/unit/gh-629-runner-first-start-retry.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-629-runner-first-start-retry.test.ts
@@ -14,25 +14,31 @@ interface Script {
   probes: FastRunnerLivenessDetail[];
   ensureCalls: Array<{ deviceId: string; attachOnly?: boolean }>;
   events: string[];
+  launches: number;
 }
 
 function makeDeps(
   probeSequence: FastRunnerLivenessDetail[],
-  opts: { attachOnly?: boolean; spawnExitSettles?: boolean } = {},
+  opts: { attachOnly?: boolean; spawnExitSettles?: boolean; reachesLaunch?: boolean } = {},
 ) {
-  const script: Script = { probes: [...probeSequence], ensureCalls: [], events: [] };
+  const script: Script = { probes: [...probeSequence], ensureCalls: [], events: [], launches: 0 };
   const lastProbe = probeSequence[probeSequence.length - 1]!;
   return {
     script,
     deps: {
       probe: async () => script.probes.shift() ?? lastProbe,
+      // ensureFastRunner swallows startFastRunner errors, so a spawn that never
+      // reached the launch xcodebuild is indistinguishable here except by the
+      // launch counter — which the fixture only advances when it did.
       ensure: async (deviceId: string, _bundleId: string, o?: { attachOnly?: boolean }) => {
         script.events.push('ensure');
         script.ensureCalls.push({
           deviceId,
           ...(o?.attachOnly !== undefined ? { attachOnly: o.attachOnly } : {}),
         });
+        if (opts.reachesLaunch ?? true) script.launches += 1;
       },
+      launchCount: () => script.launches,
       prebuilt: () => true,
       adopt: () => {},
       awaitSpawnExit: async () => {
@@ -68,6 +74,27 @@ test('retry is refused when the first spawn survives kill escalation (no stacked
   assert.equal(result.ok, false);
   assert.ok(!result.ok && /did not become ready after auto-spawn/.test(result.message));
   assert.equal(script.ensureCalls.length, 1, 'a surviving first spawn forbids the retry');
+});
+
+test('retry is refused when the first attempt never reached the launch xcodebuild', async () => {
+  // Artifact resolution / cold-build failure: ensureFastRunner swallowed the
+  // error, so the probe reads dead with no staleReason — but no launch child
+  // ever existed, and re-entering ensure() would re-pay the whole build window.
+  const { script, deps } = makeDeps([DEAD, DEAD], { reachesLaunch: false });
+  const result = await ensureRunnerForCommand('SIM-UDID', 'com.example.app', deps);
+  assert.equal(result.ok, false);
+  assert.equal(script.ensureCalls.length, 1, 'a pre-launch failure must not be retried');
+  assert.deepEqual(script.events, ['ensure'], 'no settle wait for a spawn that never launched');
+  assert.ok(!result.ok && !/one internal retry included/.test(result.message));
+});
+
+test('retry is permitted once the first attempt did launch, and is reported as such', async () => {
+  const { script, deps } = makeDeps([DEAD, DEAD, DEAD], { reachesLaunch: true });
+  const result = await ensureRunnerForCommand('SIM-UDID', 'com.example.app', deps);
+  assert.equal(result.ok, false);
+  assert.equal(script.ensureCalls.length, 2, 'a launched-then-dead first spawn earns the retry');
+  assert.deepEqual(script.events, ['ensure', 'awaitSpawnExit', 'ensure']);
+  assert.ok(!result.ok && /one internal retry included/.test(result.message));
 });
 
 test('genuine runner failure stays typed and bounded: exactly two spawn attempts', async () => {

--- a/packages/rn-dev-agent-core/test/unit/gh-629-runner-first-start-retry.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-629-runner-first-start-retry.test.ts
@@ -97,6 +97,25 @@ test('retry is permitted once the first attempt did launch, and is reported as s
   assert.ok(!result.ok && /one internal retry included/.test(result.message));
 });
 
+test('the real settle refuses the retry when another dispatch owns the launch handle', async () => {
+  // No awaitSpawnExit injected: the production settle runs. The fixture reports
+  // a launch generation this process never produced — the shape a concurrent
+  // device_* dispatch creates by replacing the global handle mid-settle.
+  const script = { probes: [DEAD, DEAD] as FastRunnerLivenessDetail[], ensures: 0 };
+  const result = await ensureRunnerForCommand('SIM-UDID', 'com.example.app', {
+    probe: async () => script.probes.shift() ?? DEAD,
+    ensure: async () => {
+      script.ensures += 1;
+    },
+    launchCount: () => script.ensures,
+    prebuilt: () => true,
+    adopt: () => {},
+  });
+  assert.equal(result.ok, false);
+  assert.equal(script.ensures, 1, 'a handle owned by another dispatch forbids the retry');
+  assert.ok(!result.ok && !/one internal retry included/.test(result.message));
+});
+
 test('genuine runner failure stays typed and bounded: exactly two spawn attempts', async () => {
   const { script, deps } = makeDeps([DEAD, DEAD, DEAD]);
   const result = await ensureRunnerForCommand('SIM-UDID', 'com.example.app', deps);

--- a/packages/rn-dev-agent-core/test/unit/gh-629-runner-first-start-retry.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-629-runner-first-start-retry.test.ts
@@ -1,0 +1,132 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { ensureRunnerForCommand } from '../../dist/agent-device-wrapper.js';
+import type { FastRunnerLivenessDetail } from '../../dist/runners/rn-fast-runner-client.js';
+
+// GH #629: a fresh simulator's first XCTest bootstrap predictably overruns the
+// warm READY window, so the first spawn dies while its side effects make an
+// immediate second spawn succeed. ensureRunnerForCommand must absorb that with
+// exactly one bounded internal retry — and still fail typed + bounded when the
+// runner is genuinely broken.
+
+interface Script {
+  probes: FastRunnerLivenessDetail[];
+  ensureCalls: Array<{ deviceId: string; attachOnly?: boolean }>;
+  events: string[];
+}
+
+function makeDeps(
+  probeSequence: FastRunnerLivenessDetail[],
+  opts: { attachOnly?: boolean; spawnExitSettles?: boolean } = {},
+) {
+  const script: Script = { probes: [...probeSequence], ensureCalls: [], events: [] };
+  const lastProbe = probeSequence[probeSequence.length - 1]!;
+  return {
+    script,
+    deps: {
+      probe: async () => script.probes.shift() ?? lastProbe,
+      ensure: async (deviceId: string, _bundleId: string, o?: { attachOnly?: boolean }) => {
+        script.events.push('ensure');
+        script.ensureCalls.push({
+          deviceId,
+          ...(o?.attachOnly !== undefined ? { attachOnly: o.attachOnly } : {}),
+        });
+      },
+      prebuilt: () => true,
+      adopt: () => {},
+      awaitSpawnExit: async () => {
+        script.events.push('awaitSpawnExit');
+        return opts.spawnExitSettles ?? true;
+      },
+      ...(opts.attachOnly !== undefined ? { attachOnly: opts.attachOnly } : {}),
+    },
+  };
+}
+
+const DEAD: FastRunnerLivenessDetail = { liveness: 'dead' };
+const ALIVE: FastRunnerLivenessDetail = { liveness: 'alive' };
+
+test('first-start transient: one bounded retry turns RN_FAST_RUNNER_DOWN into success', async () => {
+  // probe #1: pre-spawn (dead) → spawn; probe #2: still dead (fresh-sim
+  // bootstrap overran READY); retry spawn; probe #3: alive.
+  const { script, deps } = makeDeps([DEAD, DEAD, ALIVE]);
+  const result = await ensureRunnerForCommand('SIM-UDID', 'com.example.app', deps);
+  assert.equal(result.ok, true, JSON.stringify(result));
+  assert.equal(script.ensureCalls.length, 2, 'exactly one internal retry spawn');
+  assert.ok(
+    result.ok && result.note && /retry/i.test(result.note),
+    'retry is surfaced in the note',
+  );
+  // No stacked launches: the failed first spawn must be settled before retry.
+  assert.deepEqual(script.events, ['ensure', 'awaitSpawnExit', 'ensure']);
+});
+
+test('retry is refused when the first spawn survives kill escalation (no stacked launch)', async () => {
+  const { script, deps } = makeDeps([DEAD, DEAD], { spawnExitSettles: false });
+  const result = await ensureRunnerForCommand('SIM-UDID', 'com.example.app', deps);
+  assert.equal(result.ok, false);
+  assert.ok(!result.ok && /did not become ready after auto-spawn/.test(result.message));
+  assert.equal(script.ensureCalls.length, 1, 'a surviving first spawn forbids the retry');
+});
+
+test('genuine runner failure stays typed and bounded: exactly two spawn attempts', async () => {
+  const { script, deps } = makeDeps([DEAD, DEAD, DEAD]);
+  const result = await ensureRunnerForCommand('SIM-UDID', 'com.example.app', deps);
+  assert.equal(result.ok, false);
+  assert.ok(!result.ok && /did not become ready after auto-spawn/.test(result.message));
+  assert.equal(script.ensureCalls.length, 2, 'no unbounded retries');
+});
+
+test('healthy first spawn needs no retry and carries no retry note', async () => {
+  const { script, deps } = makeDeps([DEAD, ALIVE]);
+  const result = await ensureRunnerForCommand('SIM-UDID', 'com.example.app', deps);
+  assert.equal(result.ok, true);
+  assert.equal(script.ensureCalls.length, 1);
+  assert.equal(result.ok && result.note, undefined);
+});
+
+test('typed post-spawn staleness surfaces without burning the retry', async () => {
+  const { script, deps } = makeDeps([
+    DEAD,
+    { liveness: 'stale', staleReason: 'protocol-older', runnerProtocolVersion: 1 },
+  ]);
+  const result = await ensureRunnerForCommand('SIM-UDID', 'com.example.app', deps);
+  assert.equal(result.ok, false);
+  assert.ok(!result.ok && result.code === 'RUNNER_PROTOCOL_MISMATCH', JSON.stringify(result));
+  assert.equal(script.ensureCalls.length, 1, 'typed failures must not trigger the transient retry');
+});
+
+test('attachOnly is preserved across the internal retry spawn', async () => {
+  const { script, deps } = makeDeps([DEAD, DEAD, ALIVE], { attachOnly: true });
+  const result = await ensureRunnerForCommand('SIM-UDID', 'com.example.app', deps);
+  assert.equal(result.ok, true);
+  assert.deepEqual(
+    script.ensureCalls.map((c) => c.attachOnly),
+    [true, true],
+  );
+});
+
+test('device_snapshot action=open maps the exhausted-retry failure to RN_FAST_RUNNER_DOWN', async () => {
+  const { createDeviceSnapshotHandler } = await import('../../dist/tools/device-session.js');
+  const deviceId = randomUUID().toUpperCase();
+  const handler = createDeviceSnapshotHandler({
+    isAppRunning: async () => true,
+    ensureIosRunner: async () => ({
+      ok: false,
+      message:
+        'rn-fast-runner did not become ready after auto-spawn (one internal retry included). Retry, or run `device_snapshot action=open appId=<your.app.id> platform=ios` to surface the build error.',
+    }),
+    stopIosRunner: async () => {},
+  });
+  const result = await handler({
+    action: 'open',
+    platform: 'ios',
+    deviceId,
+    appId: 'com.example.app',
+    attachOnly: true,
+  });
+  const body = JSON.parse(result.content[0]!.text) as { ok: boolean; code?: string };
+  assert.equal(body.ok, false);
+  assert.equal(body.code, 'RN_FAST_RUNNER_DOWN');
+});

--- a/packages/rn-dev-agent-core/test/unit/gh-629-runner-launch-count.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-629-runner-launch-count.test.ts
@@ -19,9 +19,12 @@ const runnerRoot = mkdtempSync(join(tmpdir(), 'gh-629-runner-root-'));
 mkdirSync(join(runnerRoot, 'rn-fast-runner'), { recursive: true });
 process.env.RN_DEV_AGENT_NATIVE_RUNNER_ROOT = runnerRoot;
 
-const { startFastRunner, getRunnerLaunchCount, awaitSpawnedRunnerExit } = await import(
-  '../../dist/runners/rn-fast-runner-client.js'
-);
+const {
+  startFastRunner,
+  getRunnerLaunchCount,
+  awaitSpawnedRunnerExit,
+  _setFastRunnerStateForTest,
+} = await import('../../dist/runners/rn-fast-runner-client.js');
 
 test.after(() => {
   rmSync(runnerRoot, { recursive: true, force: true });
@@ -65,6 +68,31 @@ test('the settle refuses when the launch handle belongs to a newer generation', 
 
 test('the settle proceeds for the generation the caller actually observed', async () => {
   assert.equal(await awaitSpawnedRunnerExit(50, getRunnerLaunchCount()), true);
+});
+
+test('a runner that came up mid-settle is not claimed as this caller settling its own launch', async () => {
+  // The seam sets runnerState while nulling the handle — the shape a concurrent
+  // dispatch leaves behind when its start reaches READY during our settle.
+  // Without the state guard this falls through to the null handle and answers
+  // true, which would let the caller retry and then report another dispatch's
+  // runner as 'ready after one first-start retry'.
+  _setFastRunnerStateForTest({
+    schemaVersion: 1,
+    pid: process.pid,
+    port: 22088,
+    deviceId: 'gh-629-concurrent',
+    bundleId: 'com.example.gh629',
+    startedAt: new Date(0).toISOString(),
+    protocolVersion: 2,
+  } as never);
+  try {
+    const t0 = Date.now();
+    // Generation matches, so only the live-runner guard can refuse here.
+    assert.equal(await awaitSpawnedRunnerExit(50, getRunnerLaunchCount()), false);
+    assert.ok(Date.now() - t0 < 500, 'a live runner must short-circuit, not settle or signal');
+  } finally {
+    _setFastRunnerStateForTest(null);
+  }
 });
 
 test('a start refused for missing session authority does not advance the launch count', async () => {

--- a/packages/rn-dev-agent-core/test/unit/gh-629-runner-launch-count.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-629-runner-launch-count.test.ts
@@ -19,7 +19,7 @@ const runnerRoot = mkdtempSync(join(tmpdir(), 'gh-629-runner-root-'));
 mkdirSync(join(runnerRoot, 'rn-fast-runner'), { recursive: true });
 process.env.RN_DEV_AGENT_NATIVE_RUNNER_ROOT = runnerRoot;
 
-const { startFastRunner, getRunnerLaunchCount } = await import(
+const { startFastRunner, getRunnerLaunchCount, awaitSpawnedRunnerExit } = await import(
   '../../dist/runners/rn-fast-runner-client.js'
 );
 
@@ -52,6 +52,19 @@ test('a start that fails before the launch step does not advance the launch coun
     if (saved.claimEpoch === undefined) delete process.env.RN_DEV_AGENT_CLAIM_EPOCH;
     else process.env.RN_DEV_AGENT_CLAIM_EPOCH = saved.claimEpoch;
   }
+});
+
+test('the settle refuses when the launch handle belongs to a newer generation', async () => {
+  // A concurrent dispatch's start replaces the global handle. Signalling it
+  // would SIGKILL a runner this caller never launched, so a generation the
+  // module no longer recognises must refuse — immediately, without settling.
+  const t0 = Date.now();
+  assert.equal(await awaitSpawnedRunnerExit(50, getRunnerLaunchCount() + 1), false);
+  assert.ok(Date.now() - t0 < 500, 'a foreign generation must short-circuit, not wait or signal');
+});
+
+test('the settle proceeds for the generation the caller actually observed', async () => {
+  assert.equal(await awaitSpawnedRunnerExit(50, getRunnerLaunchCount()), true);
 });
 
 test('a start refused for missing session authority does not advance the launch count', async () => {

--- a/packages/rn-dev-agent-core/test/unit/gh-629-runner-launch-count.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-629-runner-launch-count.test.ts
@@ -1,0 +1,75 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+// GH #629: the first-start retry is permitted only when the failed attempt
+// actually reached the launch xcodebuild. ensureFastRunner swallows every
+// startFastRunner error, so the launch counter is the sole evidence — a
+// failure BEFORE the launch step (artifact resolution, missing project, a
+// failed cold build) must leave it untouched, or the retry re-pays the whole
+// multi-minute build window on a deterministically broken checkout.
+
+// The runner directory is resolved at module load, so point it at an empty
+// stand-in before importing: startFastRunner then fails at project resolution,
+// which is upstream of both the build steps and spawn().
+const runnerRoot = mkdtempSync(join(tmpdir(), 'gh-629-runner-root-'));
+mkdirSync(join(runnerRoot, 'rn-fast-runner'), { recursive: true });
+process.env.RN_DEV_AGENT_NATIVE_RUNNER_ROOT = runnerRoot;
+
+const { startFastRunner, getRunnerLaunchCount } = await import(
+  '../../dist/runners/rn-fast-runner-client.js'
+);
+
+test.after(() => {
+  rmSync(runnerRoot, { recursive: true, force: true });
+  delete process.env.RN_DEV_AGENT_NATIVE_RUNNER_ROOT;
+});
+
+test('a start that fails before the launch step does not advance the launch count', async () => {
+  const saved = {
+    sessionId: process.env.RN_DEV_AGENT_SESSION_ID,
+    claimEpoch: process.env.RN_DEV_AGENT_CLAIM_EPOCH,
+  };
+  process.env.RN_DEV_AGENT_SESSION_ID = `gh-629-${randomUUID()}`;
+  process.env.RN_DEV_AGENT_CLAIM_EPOCH = '1';
+  const before = getRunnerLaunchCount();
+  try {
+    await assert.rejects(
+      startFastRunner(randomUUID().toUpperCase(), 'com.example.gh629'),
+      /RnFastRunner\.xcodeproj not found/,
+    );
+    assert.equal(
+      getRunnerLaunchCount(),
+      before,
+      'no launch child existed, so the retry gate must stay closed',
+    );
+  } finally {
+    if (saved.sessionId === undefined) delete process.env.RN_DEV_AGENT_SESSION_ID;
+    else process.env.RN_DEV_AGENT_SESSION_ID = saved.sessionId;
+    if (saved.claimEpoch === undefined) delete process.env.RN_DEV_AGENT_CLAIM_EPOCH;
+    else process.env.RN_DEV_AGENT_CLAIM_EPOCH = saved.claimEpoch;
+  }
+});
+
+test('a start refused for missing session authority does not advance the launch count', async () => {
+  const saved = {
+    sessionId: process.env.RN_DEV_AGENT_SESSION_ID,
+    claimEpoch: process.env.RN_DEV_AGENT_CLAIM_EPOCH,
+  };
+  delete process.env.RN_DEV_AGENT_SESSION_ID;
+  delete process.env.RN_DEV_AGENT_CLAIM_EPOCH;
+  const before = getRunnerLaunchCount();
+  try {
+    await assert.rejects(
+      startFastRunner(randomUUID().toUpperCase(), 'com.example.gh629'),
+      /SESSION_AUTHORITY_REQUIRED/,
+    );
+    assert.equal(getRunnerLaunchCount(), before);
+  } finally {
+    if (saved.sessionId !== undefined) process.env.RN_DEV_AGENT_SESSION_ID = saved.sessionId;
+    if (saved.claimEpoch !== undefined) process.env.RN_DEV_AGENT_CLAIM_EPOCH = saved.claimEpoch;
+  }
+});


### PR DESCRIPTION
## Intent

Fix GitHub issue #629 on rn-dev-agent: two independent session-resume defects, causally separated and fixed without coupling. (A) cdp_status took 120+ seconds to report a dead Metro after a Claude session resume: the port scan itself was always bounded (1.5s per candidate port, parallel, connection-refused instant); the latency came from the dev-client-picker probes wrapped around discovery in the active status handler — each probe dispatches a device snapshot that auto-spawns rn-fast-runner with a 30s readiness wait, and with a persisted session (survives resume via session-<hash>.json) plus a dead runner up to five serial spawn attempts stack to ~150s. Required behavior: dead local Metro discovery bounded per candidate port, returning the EXISTING truthful 'Metro not found on ports …' result verbatim within a small documented budget, without weakening live-Metro discovery. Fix: discovery.ts gains a typed MetroNotFoundError (message preserved verbatim) thrown by discover(), and an anyMetroRunning(currentPort, timeout=DISCOVERY_TIMEOUT_MS) bounded pre-scan; the active createStatusHandler gates its pre-connect picker probe on that pre-scan and early-returns the truthful failure for MetroNotFoundError in its catch, skipping the picker fallback. IMPORTANT preserved decision: on current main the registered cdp_status MCP tool is the PASSIVE handler (createPassiveStatusHandler, since #621, merged after the issue was filed) which never connects — main already closed the reported tool surface and that registration is deliberately untouched; the fix bounds the still-exported active handler (used by tests, available for re-wiring). The withConnection auto-connect middleware was verified to already fast-fail on dead Metro before any picker logic — deliberately untouched. (B) The first device_snapshot action=open on a freshly created simulator surfaced RN_FAST_RUNNER_DOWN while the immediate identical retry succeeded: the 30s READY_TIMEOUT_MS is a warm-launch gate and a fresh simulator's first XCTest bootstrap (runner-app install + testmanagerd spin-up) predictably overruns it, while the first attempt's side effects make the second spawn warm. Fix in ensureRunnerForCommand: exactly one bounded internal retry, fired only when the post-spawn probe is liveness 'dead' with no staleReason, and only after awaitSpawnedRunnerExit() proves the failed first xcodebuild actually exited (SIGTERM already sent by the READY timeout; SIGKILL escalation at a 5s grace; bounded backstop returns false and the retry is REFUSED if the process survives — no stacked launches, no hidden process leaks). Typed staleness failures (protocol/commands/features/authority) never trigger the retry. Genuine failure stays typed and bounded at two spawn attempts; the RN_FAST_RUNNER_DOWN message appends '(one internal retry included)' only when the retry actually ran; attachOnly deliberately KEEPS the retry because the issue's own repro used attachOnly=true; the open path (device_snapshot action=open) still maps the exhausted failure to RN_FAST_RUNNER_DOWN. A success after retry carries note 'runner ready after one first-start retry (fresh-simulator XCTest bootstrap)'. Tests: 15 regression tests. The retry logic uses fully injected deterministic fixtures (scripted probe sequences, counting ensure, recorded awaitSpawnExit ordering; asserts exactly-two-attempts bound, retry-refused-on-surviving-process, attachOnly preservation, no-retry-on-typed-staleness, and the open-handler RN_FAST_RUNNER_DOWN mapping). Discovery tests use real localhost servers per this repo's established house style (fake-cdp-server helper precedent; discovery has no injectable clock/fetch seam and adding one was deliberately ruled out as blast-radius): closed-port fast-false, live /status true, stalling-server abort at a caller-supplied 300ms budget (elapsed asserted >=250ms and <1400ms to prove the argument governs vs the 1500ms default), a stalling candidate must not blind a healthy sibling port, slow-but-within-budget Metro still discovered, dead-Metro cdp_status handler returns the verbatim not-found message with ZERO picker probes routed through the real discover(), live-Metro handler still runs the pre-connect picker probe strictly BEFORE autoConnect, and discover() throws the typed error carrying the probed ports. Wall-clock ceilings in those tests are deliberately generous guards against the minute-scale regression class, not precise timing claims. A single-sentence changeset (repo convention) covers rn-dev-agent-core + rn-dev-agent-plugin patch. Live proof was performed on dedicated freshly-created local simulators against this exact head: dead-Metro active-handler status answered in 12ms with the verbatim message and zero runner spawns while fully primed (persisted session, booted sim, prebuilt runner); first open on a fresh simulator succeeded (49.6s incl. cold build), and on a second fresh simulator the first spawn genuinely failed (xcodebuild exit 65, swallowed) and the internal retry absorbed it returning ok — the exact defect-B shape; teardown verified no leaked lane processes, no runner apps on sims, runner state and session files removed, simulators deleted. Do not treat the passive cdp_status registration, the untouched withConnection path, the attachOnly-retains-retry decision, the real-localhost discovery test style, or the conditional '(one internal retry included)' message suffix as mistakes — they are deliberate.

## What Changed

- `discovery.ts` now throws a typed `MetroNotFoundError` (message preserved verbatim) from `discover()` and exports a bounded `anyMetroRunning(currentPort, timeout = DISCOVERY_TIMEOUT_MS)` pre-scan; the active `createStatusHandler` gates its pre-connect dev-client-picker probe on that pre-scan and early-returns the truthful not-found result for `MetroNotFoundError`, so a dead local Metro no longer routes through runner-spawning picker probes.
- `ensureRunnerForCommand` gains exactly one bounded internal retry, fired only when the post-spawn probe is `dead` with no `staleReason` and the launch child count advanced, and only after the new `awaitSpawnedRunnerExit()` / `awaitChildExit()` primitives (SIGKILL escalation at a 5s grace, backstop returning `false`) prove the failed first spawn exited; a success after retry carries a `runner ready after one first-start retry` note and the `RN_FAST_RUNNER_DOWN` message appends `(one internal retry included)` only when the retry ran. `rn-fast-runner-client` exposes the monotonic `getRunnerLaunchCount()` backing that gate.
- Adds 15 regression tests (bounded discovery against real localhost servers, dead-Metro status with zero picker probes, retry bound/refusal/attachOnly/typed-staleness cases, launch-count and exit-settle primitives), updates the `RN_FAST_RUNNER_DOWN` troubleshooting doc, refreshes the compiled `dist/` output, and adds a one-sentence patch changeset for `rn-dev-agent-core` + `rn-dev-agent-plugin`.

## Risk Assessment

✅ Low: The change is well-bounded and intent-conformant: the discovery bound is a typed error plus a pre-scan that preserves the verbatim message and live-Metro picker ordering, and the runner retry is gated on three independent conditions (dead liveness, no staleReason, a proven launch child that provably exited) with executable coverage for each including the SIGKILL escalation and backstop; the only residuals are a cosmetic note-precedence leak and unreachable defensive code.

## Testing

Built the core package and ran the five test files this change touches (four new GH #629 suites plus the amended GH #136 picker-precheck test) — 30 tests, all passing, no baseline commands had been run before this phase. Since passing unit tests alone do not show the user-visible behavior, I also drove the real MCP handlers in a scripted evidence run and captured the exact JSON envelopes an agent would receive: cdp_status on a dead Metro returned the verbatim "Metro not found on ports …" failure in 9ms with zero dev-client-picker probes (the probes were the source of the ~120s hang, each one auto-spawning a runner with a 30s readiness wait), while against a live Metro the pre-connect picker probe still ran strictly before autoConnect, confirming live-Metro discovery was not weakened. For the runner half, device_snapshot action=open reproduced the reported defect shape — first spawn dead, one settled internal retry (lifecycle recorded as spawn#1 → await-first-spawn-exit → spawn#2, so no stacked launches) — and returned ok:true carrying the "runner ready after one first-start retry (fresh-simulator XCTest bootstrap)" note, while a genuinely broken runner stayed bounded at two attempts and surfaced RN_FAST_RUNNER_DOWN with the conditional "(one internal retry included)" suffix. This change is CLI/MCP-tool-facing with no rendered UI surface, so the reviewer-visible evidence is the captured tool-response transcript rather than screenshots. The worktree was left clean and no runner session or lock state leaked.

<details>
<summary>Evidence: Real MCP tool-envelope transcript for both defects (dead-Metro cdp_status + fresh-simulator open retry)</summary>

<code>=== A1. cdp_status against a DEAD Metro (persisted session present) ===&#10;tool response after 9ms:&#10;{&#10;&#34;ok&#34;: false,&#10;&#34;error&#34;: &#34;Metro not found on ports 58954. Is the dev server running? Try: npx expo start or npx react-native start&#34;,&#10;...&#10;}&#10;dev-client-picker probes dispatched (each would auto-spawn a runner): 0&#10;&#10;=== A2. cdp_status against a LIVE Metro — picker probe still runs before connect ===&#10;{&#10;&#34;ok&#34;: false,&#10;&#34;error&#34;: &#34;target connect failed (fixture)&#34;,&#10;...&#10;}&#10;ordering observed: picker-probe -&gt; picker-probe -&gt; auto-connect -&gt; picker-probe -&gt; picker-probe -&gt; picker-probe&#10;&#10;=== B1. device_snapshot action=open on a FRESH simulator (first XCTest bootstrap overruns READY) ===&#10;{&#10;&#34;ok&#34;: true,&#10;&#34;data&#34;: { &#34;ok&#34;: true, &#34;platform&#34;: &#34;ios&#34;, &#34;appId&#34;: &#34;com.example.app&#34;, &#34;readiness&#34;: { &#34;appForeground&#34;: true } },&#10;&#34;meta&#34;: { &#34;note&#34;: &#34;runner ready after one first-start retry (fresh-simulator XCTest bootstrap)&#34; }&#10;}&#10;runner lifecycle: xcodebuild-spawn#1 -&gt; await-first-spawn-exit -&gt; xcodebuild-spawn#2&#10;&#10;=== B2. device_snapshot action=open with a GENUINELY broken runner (bounded at two attempts) ===&#10;{&#10;&#34;ok&#34;: false,&#10;&#34;error&#34;: &#34;rn-fast-runner did not become ready after auto-spawn (one internal retry included). Retry, or run `device_snapshot action=open appId=&lt;your.app.id&gt; platform=ios` to surface the build error.&#34;,&#10;&#34;code&#34;: &#34;RN_FAST_RUNNER_DOWN&#34;&#10;}&#10;runner lifecycle: xcodebuild-spawn#1 -&gt; await-first-spawn-exit -&gt; xcodebuild-spawn#2</code>

```text

=== A1. cdp_status against a DEAD Metro (persisted session present) ===
tool response after 9ms:
{
  "ok": false,
  "error": "Metro not found on ports 58954. Is the dev server running? Try: npx expo start or npx react-native start",
  "meta": {
    "reconnect": {
      "active": false,
      "lastAttempt": null,
      "attemptCount": 0
    },
    "autoConnect": {
      "enabled": true,
      "source": "default"
    },
    "bridge": {
      "supervised": false,
      "workerRestarts": 0,
      "lastWorkerExit": null
    }
  }
}
dev-client-picker probes dispatched (each would auto-spawn a runner): 0

=== A2. cdp_status against a LIVE Metro — picker probe still runs before connect ===
{
  "ok": false,
  "error": "target connect failed (fixture)",
  "meta": {
    "reconnect": {
      "active": false,
      "lastAttempt": null,
      "attemptCount": 0
    },
    "autoConnect": {
      "enabled": true,
      "source": "default"
    },
    "bridge": {
      "supervised": false,
      "workerRestarts": 0,
      "lastWorkerExit": null
    }
  }
}
ordering observed: picker-probe -> picker-probe -> auto-connect -> picker-probe -> picker-probe -> picker-probe

=== B1. device_snapshot action=open on a FRESH simulator (first XCTest bootstrap overruns READY) ===
2026-08-14T22:39:08.871Z [WARN] [rn-device] listapps failed: Command failed: xcrun simctl listapps 3AC7404F-7FC8-46BE-801E-D9C8E76D8C9C
{
  "ok": true,
  "data": {
    "ok": true,
    "sessionName": "rn-agent-1786747148384",
    "platform": "ios",
    "deviceId": "3AC7404F-7FC8-46BE-801E-D9C8E76D8C9C",
    "appId": "com.example.app",
    "readiness": {
      "appForeground": true
    }
  },
  "meta": {
    "note": "runner ready after one first-start retry (fresh-simulator XCTest bootstrap)"
  }
}
runner lifecycle: xcodebuild-spawn#1 -> await-first-spawn-exit -> xcodebuild-spawn#2

=== B2. device_snapshot action=open with a GENUINELY broken runner (bounded at two attempts) ===
{
  "ok": false,
  "error": "rn-fast-runner did not become ready after auto-spawn (one internal retry included). Retry, or run `device_snapshot action=open appId=<your.app.id> platform=ios` to surface the build error.",
  "code": "RN_FAST_RUNNER_DOWN"
}
runner lifecycle: xcodebuild-spawn#1 -> await-first-spawn-exit -> xcodebuild-spawn#2
```
</details>
<details>
<summary>Evidence: Evidence script that drives the real handlers (reproducible)</summary>

```text
// GH #629 end-user-surface evidence: drives the real MCP tool handlers and
// prints the exact JSON envelopes an agent/user would receive.
import { createServer } from 'node:http';
import { randomUUID } from 'node:crypto';

const ROOT =
  '/Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M013XDWNMWY2ZWVA9VXS0D2P/packages/rn-dev-agent-core/dist';

const { createStatusHandler } = await import(`${ROOT}/tools/status.js`);
const { discover } = await import(`${ROOT}/cdp/discovery.js`);
const { createMockClient } = await import(
  '/Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M013XDWNMWY2ZWVA9VXS0D2P/packages/rn-dev-agent-core/test/helpers/mock-cdp-client.js'
);
const picker = await import(`${ROOT}/tools/dev-client-picker.js`);
const { ensureRunnerForCommand } = await import(`${ROOT}/agent-device-wrapper.js`);
const { createDeviceSnapshotHandler } = await import(`${ROOT}/tools/device-session.js`);

const line = (t) => console.log(`\n=== ${t} ===`);
const envelope = (r) => JSON.parse(r.content[0].text);

async function closedPort() {
  return new Promise((resolve) => {
    const s = createServer();
    s.listen(0, '127.0.0.1', () => {
      const p = s.address().port;
      s.close(() => resolve(p));
    });
  });
}

function fakeMetro() {
  return new Promise((resolve) => {
    const server = createServer((req, res) => {
      if (req.url === '/status') {
        res.writeHead(200, { 'Content-Type': 'text/plain' });
        res.end('packager-status:running');
        return;
      }
      res.writeHead(404);
      res.end();
    });
    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
  });
}

process.env.RN_CDP_DISCOVERY_PORTS = '';

// ---------- A: dead Metro after a session resume ----------
line('A1. cdp_status against a DEAD Metro (persisted session present)');
{
  const port = await closedPort();
  picker._setHasSessionForTest(true);
  let probes = 0;
  picker._setFetchCandidatesForTest(async () => {
    probes += 1;
    return { ok: false, reason: 'fetch-failed' };
  });
  const client = createMockClient({
    _isConnected: false,
    _metroPort: port,
    autoConnect: async () => {
      await discover(port);
    },
  });
  const t0 = Date.now();
  const result = await createStatusHandler(
    () => client,
    () => {},
    () => client,
  )({});
  const elapsed = Date.now() - t0;
  console.log(`tool response after ${elapsed}ms:`);
  console.log(JSON.stringify(envelope(result), null, 2));
  console.log(`dev-client-picker probes dispatched (each would auto-spawn a runner): ${probes}`);
  picker._resetHasSessionForTest();
  picker._resetFetchCandidatesForTest();
}

line('A2. cdp_status against a LIVE Metro — picker probe still runs before connect');
{
  const { server, port } = await fakeMetro();
  picker._setHasSessionForTest(true);
  const events = [];
  picker._setFetchCandidatesForTest(async () => {
    events.push('picker-probe');
    return { ok: false, reason: 'fetch-failed' };
  });
  const client = createMockClient({
    _isConnected: false,
    _metroPort: port,
    autoConnect: async () => {
      events.push('auto-connect');
      throw new Error('target connect failed (fixture)');
    },
  });
  const result = await createStatusHandler(
    () => client,
    () => {},
    () => client,
  )({});
  console.log(JSON.stringify(envelope(result), null, 2));
  console.log(`ordering observed: ${events.join(' -> ')}`);
  picker._resetHasSessionForTest();
  picker._resetFetchCandidatesForTest();
  await new Promise((r) => server.close(r));
}

// ---------- B: fresh-simulator first-start transient ----------
const DEAD = { liveness: 'dead' };
const ALIVE = { liveness: 'alive' };

function runnerFixture(sequence) {
  const state = { probes: [...sequence], spawns: 0, launches: 0, events: [] };
  const last = sequence[sequence.length - 1];
  return {
    state,
    make: (extra) => ({
      probe: async () => state.probes.shift() ?? last,
      ensure: async () => {
        state.spawns += 1;
        state.launches += 1;
        state.events.push(`xcodebuild-spawn#${state.spawns}`);
      },
      launchCount: () => state.launches,
      prebuilt: () => true,
      adopt: () => {},
      awaitSpawnExit: async () => {
        state.events.push('await-first-spawn-exit');
        return true;
      },
      ...extra,
    }),
  };
}

function openHandler(fixture) {
  return createDeviceSnapshotHandler({
    isAppRunning: async () => true,
    ensureIosRunner: (deviceId, appId, opts) =>
      ensureRunnerForCommand(deviceId, appId, fixture.make(opts)),
    stopIosRunner: async () => {},
  });
}

line('B1. device_snapshot action=open on a FRESH simulator (first XCTest bootstrap overruns READY)');
{
  const fixture = runnerFixture([DEAD, DEAD, ALIVE]);
  const result = await openHandler(fixture)({
    action: 'open',
    platform: 'ios',
    deviceId: randomUUID().toUpperCase(),
    appId: 'com.example.app',
    attachOnly: true,
  });
  console.log(JSON.stringify(envelope(result), null, 2));
  console.log(`runner lifecycle: ${fixture.state.events.join(' -> ')}`);
}

line('B2. device_snapshot action=open with a GENUINELY broken runner (bounded at two attempts)');
{
  const fixture = runnerFixture([DEAD, DEAD, DEAD]);
  const result = await openHandler(fixture)({
    action: 'open',
    platform: 'ios',
    deviceId: randomUUID().toUpperCase(),
    appId: 'com.example.app',
    attachOnly: true,
  });
  console.log(JSON.stringify(envelope(result), null, 2));
  console.log(`runner lifecycle: ${fixture.state.events.join(' -> ')}`);
}

process.exit(0);
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"dffa715b0b5cccd25f0276cc5c7e5e531606bda5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `packages/rn-dev-agent-core/src/agent-device-wrapper.ts:1251` - The one-shot retry is placed in `ensureRunnerForCommand`, the shared chokepoint for every device_* dispatch, and fires on any `after.liveness === &#39;dead&#39; &amp;&amp; !after.staleReason` — not only the fresh-simulator first start it was designed for. Two consequences the intent&#39;s framing (a 30s warm READY window) doesn&#39;t cover: (1) on the open path (`allowArtifactRebuild`), `ensure()` can run a full cold build bounded by BUILD_READY_TIMEOUT_MS = 360_000 (rn-fast-runner-client.ts:69); when a build genuinely fails (no .xctestrun, compile error) the retry re-enters `startFastRunner` and pays the build window a second time, so worst-case time-to-error on a broken checkout roughly doubles from ~6.5min to ~13min; (2) mid-flow dispatches go from ~30s to ~65s per failed spawn (30s READY + up to 7s settle/escalation + 30s READY), and those dispatches include the dev-client-picker probes that the active cdp_status handler still runs whenever a Metro is up — i.e. the exact multiplier that produced #629&#39;s original ~150s now has a larger per-probe cost. Worth confirming this is the intended cost envelope, or gating the retry (e.g. only when the first attempt actually reached the launch phase, or only on the open path).
- ℹ️ `packages/rn-dev-agent-core/src/tools/status.ts:344` - The pre-scan gate only short-circuits the &#34;no Metro anywhere&#34; case. The other common post-resume shape — Metro alive, rn-fast-runner dead (persisted session survives via session-&lt;hash&gt;.json) — still passes the gate, so `isDevClientPickerShowing()` dispatches a device snapshot that auto-spawns the runner and waits the full readiness window, and the catch-block picker fallback can dispatch again. cdp_status (active handler) therefore remains minute-scale in that variant, and each probe is now longer per the retry finding above. This is outside the intent&#39;s stated required behavior (which scopes the bound to dead-Metro discovery), so noting it as residual rather than a contradiction.
- ℹ️ `packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts:879` - `awaitSpawnedRunnerExit()` proves nothing about the current attempt when that attempt failed before reaching `runnerProcess = child` — e.g. `resolveIosRunnerArtifacts` throwing, a missing RnFastRunner.xcodeproj, or a `runXcodebuildToExit` build-step rejection (rn-fast-runner-client.ts:754-760). In those cases `runnerProcess` is whatever a prior generation left (normally null, since `clearStateFile()`/`clearStateFileIfMatches()` null it together with `runnerState`), so the function returns `true` immediately and the retry proceeds on an unproven precondition. Benign today given the teardown paths, but the &#34;provably exited&#34; guarantee in the comment holds only for the READY-timeout branch; other call sites in this file guard the handle by pid (e.g. `runnerProcess?.pid === state.pid` at line 1380) if you want the same rigor here.

🔧 Fix: gate runner first-start retry on a proven launch child
3 issues (1 error, 1 warning, 1 info) still open:
- 🚨 `packages/rn-dev-agent-core/test/unit/gh-136-status-picker-precheck.test.js:62` - The new pre-scan gate at `status.ts:344` (`if (await anyMetroRunning(client.metroPort))`) suppresses the GH #136 pre-connect picker probe whenever no Metro answers on the candidate ports, but the pre-existing GH #136 regression test was not updated. That test builds a `createMockClient` whose `_metroPort` defaults to 8081 (`test/helpers/mock-cdp-client.js:111`), leaves `RN_CDP_DISCOVERY_PORTS` unset (so `resolveDefaultPorts()` yields 8081/8082/19000/19006), and asserts `assert.deepEqual(events, [&#39;pickerProbe&#39;,&#39;autoConnect&#39;])`. On any machine/CI runner with no Metro listening on those ports, `anyMetroRunning` returns false, `isDevClientPickerShowing()` is never called, `events` is `[&#39;autoConnect&#39;]`, and the assertion fails. The production behavior change is deliberate per the intent (a dismissal cannot help when no Metro is up); the fix is mechanical — give the test a live Metro the way the new gh-629 test does (start a fake `/status` server returning `packager-status:running`, point `_metroPort` at it and set `RN_CDP_DISCOVERY_PORTS=&#39;&#39;`), so it still proves picker-before-autoConnect ordering under the new gate. Note this test passes locally whenever a dev Metro happens to be on 8081, so it fails only in a clean environment.
- ⚠️ `packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts:888` - The two new production primitives the retry gate depends on are covered only by injected fakes. Every case in `gh-629-runner-first-start-retry.test.ts` supplies both `launchCount` (a fixture counter) and `awaitSpawnExit` (an async boolean), so `awaitSpawnedRunnerExit`&#39;s real logic is never executed: the SIGKILL escalation at `graceMs`, the `graceMs + 2000` backstop that returns false, and the early-true path when `runnerProcess` is null or already exited. That false-return is exactly the invariant that prevents stacking a second launch on a surviving process — the safety property the fix round was added to guarantee — and it currently has zero executable coverage. Likewise the `runnerLaunchCount += 1` placement (after `resolveIosRunnerArtifacts` and after the `plan.slice(0, -1)` build steps, at line 785) is what makes the gate refuse a cold-build failure, and it is verified only by reading the source. Both are directly testable without a simulator: spawn a short-lived `node -e` child for the exit path and one that installs a SIGTERM handler and ignores it for the escalation/backstop path (with a small `graceMs`).
- ℹ️ `packages/rn-dev-agent-core/src/tools/status.ts:344` - On the live-Metro path, `anyMetroRunning(client.metroPort)` now runs a full `discoverAllMetroPorts` sweep over the same candidate set that `discover()` recomputes moments later inside `autoConnect` (`discovery.ts:804` builds the identical `[currentPort, ...resolveDefaultPorts()]` set). Every unconnected `cdp_status` therefore performs two scans instead of one. The cost is bounded and usually milliseconds, but a candidate port that accepts and stalls adds up to DISCOVERY_TIMEOUT_MS (1.5s) twice per call rather than once. Noting the tradeoff only — collapsing it would mean threading the pre-scan result into the connect path, which is a larger change than this fix warrants.

🔧 Fix: fix GH-136 picker test and cover exit-settle primitives
2 issues (1 warning, 1 info) still open:
- ⚠️ `packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts:888` - `awaitSpawnedRunnerExit()` resolves the module-global `runnerProcess` at call time and `awaitChildExit` escalates that handle to SIGKILL at the grace cap — but the retry gate only proved that *a* launch child was created (`launchCount() &gt; launchesBefore`), not that `runnerProcess` still points at it. Reachable path: two device_* tool calls dispatched in parallel into one MCP process (no dispatch-level serialization exists in agent-device-wrapper.ts). Dispatch A&#39;s post-spawn `probe()` returns `{liveness:&#39;dead&#39;}` (runnerState null) with an advanced launch count, so A awaits the settle; across that await boundary dispatch B&#39;s `startFastRunner` parses READY and assigns `runnerProcess = &lt;live healthy child&gt;` (rn-fast-runner-client.ts:784) — success never clears the handle. `awaitChildExit` then sees a live child, waits 5s, SIGKILLs B&#39;s healthy runner mid-command, returns true, and A stacks another spawn. Before this change the same race only produced a spurious RN_FAST_RUNNER_DOWN with no destructive side effect. The guard is exact and cheap: `liveness===&#39;dead&#39;` implies `runnerState === null`, so `awaitSpawnedRunnerExit` should return true without signalling when `runnerState !== null` (or match the handle by pid, as `clearStateFileIfMatches` already does at line 1380).
- ℹ️ `packages/rn-dev-agent-core/src/tools/status.ts:622` - The dead-Metro early return keys on `MetroNotFoundError`, which only `discover()` throws. When the client holds an authoritative session policy (set on device-session bind, cdp-client.ts:652), connect routes through `discoverExactPort`, whose dead-Metro failure is an untyped `Failed to list CDP targets on port N` error (discovery.ts:770 → fetchTargets). That misses the new `instanceof` branch, so the catch-block picker fallback at status.ts:639 still runs `handleDevClientPicker()` and can dispatch a runner auto-spawn. Noting as residual, not a contradiction: the registered MCP tool is the passive handler, and the accepted intent scopes the bound to `discover()`&#39;s dead-Metro case with an explicit instruction not to broaden cdp_status further.

🔧 Fix: scope runner exit settle to the caller&#39;s launch generation
4 issues (1 warning, 3 infos) still open:
- ⚠️ `packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts:895` - The `if (runnerState) return true;` guard is the specific line added in f222fb5d to stop `awaitChildExit` from SIGKILLing a concurrent dispatch&#39;s healthy runner — the destructive path flagged in round 3 — and it has zero executable coverage. The two tests added in the same commit exercise only the *other* guard: `gh-629-runner-launch-count.test.ts:70` and `gh-629-runner-first-start-retry.test.ts:100` both run with `runnerState === null`, so they are satisfied by the generation check alone and would still pass if the `runnerState` line were deleted. Since `_setFastRunnerStateForTest(state)` sets `runnerState` while nulling `runnerProcess`, the guard is directly testable: with state set and a deliberately mismatched `expectedLaunchCount`, `awaitSpawnedRunnerExit` must return true (state guard wins, no signalling) rather than false — an assertion that fails if the guard is removed or ordered after the count check.
- ℹ️ `packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts:895` - When a concurrent dispatch&#39;s runner reaches READY mid-settle, the state guard returns `true`, i.e. it *permits* the retry rather than refusing it. The consequence is benign — `ensureFastRunner` probes liveness first and no-ops against the live runner, so no launch is stacked — but `ensureRunnerForCommand` then returns `note: &#39;runner ready after one first-start retry (fresh-simulator XCTest bootstrap)&#39;` for a runner it never actually retried into existence. Returning `false` here would be equally safe and would avoid attributing another dispatch&#39;s success to this caller&#39;s retry. Noting the tradeoff only; the safety property the guard exists for is intact either way.
- ℹ️ `packages/rn-dev-agent-core/src/tools/status.ts:344` - `anyMetroRunning(client.metroPort)` scans `[client.metroPort, ...resolveDefaultPorts()]`, but when the client holds an authoritative session policy the subsequent connect routes through `policy.port` (`cdp-client.ts:714-720`). If a managed Metro is live on a policy port that is neither `client.metroPort` nor a default candidate, the pre-scan reads false and the GH #136 pre-connect picker probe is skipped even though a Metro is up. The failure mode is a degradation, not a hang: connect fails on the picker-blocked target, the error is not a `MetroNotFoundError`, and the catch-block picker fallback at status.ts:639 still dismisses — i.e. pre-#136 ordering, not the minute-scale class this change bounds. Recorded as residual; the intent explicitly instructs not to broaden cdp_status beyond the accepted dead-Metro case.
- ℹ️ `packages/rn-dev-agent-core/test/unit/gh-629-runner-first-start-retry.test.ts:100` - This test does execute the real `awaitSpawnedRunnerExit` and does discriminate against a naive implementation (which would return true on a null handle and take `ensures` to 2), so it is genuine behavioral coverage. But the scenario it names — &#34;another dispatch owns the launch handle&#34; — is produced by injecting a `launchCount` fixture that disagrees with the module global, a combination production never creates (`agent-device-wrapper.ts:1246` defaults to `getRunnerLaunchCount`, and nothing passes `deps.launchCount`). The real interleaving (a concurrent `startFastRunner` advancing the global counter between this caller&#39;s probe and its settle) remains uncovered. Worth renaming the case to what it actually proves, or driving the counter via a real `startFastRunner` the way `gh-629-runner-launch-count.test.ts` does.

🔧 Fix: refuse retry when a concurrent runner wins the settle
2 infos still open:
- ℹ️ `packages/rn-dev-agent-core/src/tools/device-session.ts:413` - `upgradeNote = ready.note ?? consumePendingFastRunnerArtifactNote()` only consumes the pending artifact note when `ready.note` is absent. The new success-after-retry note now occupies that slot on exactly the fresh-simulator first-open path — the path where `pendingFastRunnerArtifactNote` (e.g. &#34;downloaded prebuilt runner (~4 MB)&#34;) is most likely set by `startFastRunner` (rn-fast-runner-client.ts:748). Two consequences: the artifact note is hidden on the open where it is most informative, and because it is never consumed it stays pending and leaks onto the next unrelated successful result — the exact leak the sibling failure branch guards against with an explicit `consumePendingFastRunnerArtifactNote()` (device-session.ts:406, GH #382). Same shape at agent-device-wrapper.ts:1882 for mid-flow dispatch. The mechanism pre-dates this change (the GH #383 upgrade notes hit it too), but the retry note makes it reachable on a common path. Mechanical fix: consume unconditionally, then pick — `const artifactNote = consumePendingFastRunnerArtifactNote(); upgradeNote = ready.note ?? artifactNote;`.
- ℹ️ `packages/rn-dev-agent-core/src/runners/rn-fast-runner-client.ts:897` - Both concurrency guards in `awaitSpawnedRunnerExit` (`if (runnerState) return false` and the `expectedLaunchCount` generation check) are unreachable from the sole production call path, so they are defensive-only rather than load-bearing as fix rounds 3-5 assumed. In `ensureRunnerForCommand` (agent-device-wrapper.ts:1251-1262) there is no await boundary between `await probe()` resolving and the synchronous reads of `runnerState`/`runnerLaunchCount`: the `??` expression invokes the arrow immediately and both guards execute before the first inner await. A concurrent dispatch therefore cannot mutate either global in that window, and the destructive SIGKILL race that motivated round 3 is not reachable either — `awaitChildExit` captures `runnerProcess` in the same synchronous block as the count check, so the handle it may escalate is always the caller&#39;s own generation. Keeping the guards is fine (they cost nothing and make the primitive safe for future callers), but note the round-5 `return false` also introduces a theoretical false negative: if a concurrent runner did become READY mid-settle, this caller now reports `rn-fast-runner did not become ready after auto-spawn` without re-probing, even though a healthy runner exists. That trade was explicitly requested by the author in round 4 and is unreachable today, so no action.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`yarn workspace rn-dev-agent-core run build` (tests import from dist/, so the build is a prerequisite)</code>
- <code>`node --test test/unit/gh-629-dead-metro-fast-status.test.ts test/unit/gh-629-runner-first-start-retry.test.ts test/unit/gh-629-runner-exit-settle.test.ts test/unit/gh-629-runner-launch-count.test.ts test/unit/gh-136-status-picker-precheck.test.js` — 30 pass / 0 fail</code>
- <code>Manual end-to-end evidence run: `node gh-629-evidence.mjs` driving the real `createStatusHandler` (through the real `discover()` against a genuinely closed localhost port) and the real `createDeviceSnapshotHandler` open path wired to the real `ensureRunnerForCommand`, printing the actual MCP JSON envelopes, elapsed wall-clock, picker-probe count and runner spawn lifecycle</code>
- <code>Post-run cleanup check: `git status --porcelain` clean (rebuilt dist byte-identical to the committed dist), and no rn-agent session/lock state left under ~/.rn-agent or TMPDIR</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
