### PR TITLE
fix(core): fence ambient adb inference whenever an authority session is present

### DIFF
--- a/.changeset/gh-777-fence-authority-without-device.md
+++ b/.changeset/gh-777-fence-authority-without-device.md
@@ -3,4 +3,4 @@
 "rn-dev-agent-plugin": patch
 ---
 
-Fence `adb` reads whenever an authority session is present, so an available authority with no device binding — or a registry lookup that throws — no longer falls back to ambient `adb devices`; only a genuinely absent authority runtime keeps the legacy ambient read.
+Fence `adb` reads for exact-connect device/platform inference whenever an authority session is present, so an available authority with no device binding — or a registry lookup that throws — no longer falls back to ambient `adb devices`; only a genuinely absent authority runtime keeps the legacy ambient read, and raw `device_*` tools are unaffected.

--- a/.changeset/gh-777-fence-authority-without-device.md
+++ b/.changeset/gh-777-fence-authority-without-device.md
@@ -3,4 +3,4 @@
 "rn-dev-agent-plugin": patch
 ---
 
-Fence `adb` reads for exact-connect device/platform inference whenever an authority session is present, so an available authority with no device binding — or a registry lookup that throws — no longer falls back to ambient `adb devices`; only a genuinely absent authority runtime keeps the legacy ambient read, and raw `device_*` tools are unaffected.
+Fence `adb` reads for exact-connect device/platform inference whenever an authority session is present, so an available authority with no device binding, a registry lookup that throws, or an initialized runtime whose session is lost (`SESSION_OWNER_LOST`) no longer falls back to ambient `adb devices`; only a runtime that was never initialized keeps the legacy ambient read, and raw `device_*` tools are unaffected.

--- a/.changeset/gh-777-fence-authority-without-device.md
+++ b/.changeset/gh-777-fence-authority-without-device.md
@@ -3,4 +3,4 @@
 "rn-dev-agent-plugin": patch
 ---
 
-Fence `adb` reads for exact-connect device/platform inference whenever an authority session is present, so an available authority with no device binding, a registry lookup that throws, or an initialized runtime whose session is lost (`SESSION_OWNER_LOST`) no longer falls back to ambient `adb devices`; only a runtime that was never initialized keeps the legacy ambient read, and raw `device_*` tools are unaffected.
+Fence `adb` reads for exact-connect device/platform inference whenever an authority session is present, so an available authority with no device binding, a registry lookup that throws, or an unavailable runtime whose code is not `SESSION_NOT_INITIALIZED` (`SESSION_OWNER_LOST`, `PROCESS_BIRTH_UNAVAILABLE`, `AUTHORITY_STORE_UNAVAILABLE`) no longer falls back to ambient `adb devices`; only a runtime that was never initialized keeps the legacy ambient read, and raw `device_*` tools are unaffected.

--- a/.changeset/gh-777-fence-authority-without-device.md
+++ b/.changeset/gh-777-fence-authority-without-device.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-core": patch
+"rn-dev-agent-plugin": patch
+---
+
+Fence `adb` reads whenever an authority session is present, so an available authority with no device binding — or a registry lookup that throws — no longer falls back to ambient `adb devices`; only a genuinely absent authority runtime keeps the legacy ambient read.

--- a/apps/docs-site/src/content/docs/troubleshooting.mdx
+++ b/apps/docs-site/src/content/docs/troubleshooting.mdx
@@ -252,9 +252,11 @@ that carries no platform token — a custom simulator name such as `rn-qa` —
 is proven against the live device inventory (booted `simctl` simulator names
 and, only when the session authority binds that exact Android serial, that one
 device's `adb` model — any other initialized authority, including one that binds
-no device at all, one whose session owner was lost, or one whose binding cannot
-be read, fences `adb` entirely and an ambient adb device is never queried; only
-a runtime that was never initialized keeps the legacy ambient read); a name that
+no device at all, one whose session owner was lost, one whose worker birth or
+authority store failed to open, or one whose binding cannot be read, fences
+`adb` entirely and an ambient adb device is never queried; only a runtime that
+was never initialized (`SESSION_NOT_INITIALIZED`) keeps the legacy ambient
+read); a name that
 matches both inventories, or neither, stays on the fail-closed bundle inference.
 The refusal lists the candidate targets with their inference confidence. Run
 `cdp_targets` only to diagnose the mismatch, relaunch the authority-bound app,

--- a/apps/docs-site/src/content/docs/troubleshooting.mdx
+++ b/apps/docs-site/src/content/docs/troubleshooting.mdx
@@ -251,7 +251,8 @@ or ambiguous platform guess never satisfies a platform filter. A `deviceName`
 that carries no platform token — a custom simulator name such as `rn-qa` —
 is proven against the live device inventory (booted `simctl` simulator names
 and, only when the session authority binds that exact Android serial, that one
-device's `adb` model — any other bound session, including a stale one, fences
+device's `adb` model — any other live authority, including one that binds no
+device at all, a stale one, or one whose binding cannot be read, fences
 `adb` entirely and an ambient adb device is never queried); a name that matches both
 inventories, or neither, stays on the fail-closed bundle inference. The refusal lists the candidate
 targets with their inference confidence. Run

--- a/apps/docs-site/src/content/docs/troubleshooting.mdx
+++ b/apps/docs-site/src/content/docs/troubleshooting.mdx
@@ -251,11 +251,12 @@ or ambiguous platform guess never satisfies a platform filter. A `deviceName`
 that carries no platform token — a custom simulator name such as `rn-qa` —
 is proven against the live device inventory (booted `simctl` simulator names
 and, only when the session authority binds that exact Android serial, that one
-device's `adb` model — any other live authority, including one that binds no
-device at all, a stale one, or one whose binding cannot be read, fences
-`adb` entirely and an ambient adb device is never queried); a name that matches both
-inventories, or neither, stays on the fail-closed bundle inference. The refusal lists the candidate
-targets with their inference confidence. Run
+device's `adb` model — any other initialized authority, including one that binds
+no device at all, one whose session owner was lost, or one whose binding cannot
+be read, fences `adb` entirely and an ambient adb device is never queried; only
+a runtime that was never initialized keeps the legacy ambient read); a name that
+matches both inventories, or neither, stays on the fail-closed bundle inference.
+The refusal lists the candidate targets with their inference confidence. Run
 `cdp_targets` only to diagnose the mismatch, relaunch the authority-bound app,
 and call `cdp_connect` again. Omitted values come only from the fenced session;
 no-filter or explicit ambient-target selection is diagnostic legacy behavior,

--- a/apps/docs-site/src/content/docs/troubleshooting.mdx
+++ b/apps/docs-site/src/content/docs/troubleshooting.mdx
@@ -256,8 +256,8 @@ no device at all, one whose session owner was lost, one whose worker birth or
 authority store failed to open, or one whose binding cannot be read, fences
 `adb` entirely and an ambient adb device is never queried; only a runtime that
 was never initialized (`SESSION_NOT_INITIALIZED`) keeps the legacy ambient
-read); a name that
-matches both inventories, or neither, stays on the fail-closed bundle inference.
+read); a name that matches both inventories, or neither, stays on the
+fail-closed bundle inference. Raw `device_*` tools are not fenced by this rule.
 The refusal lists the candidate targets with their inference confidence. Run
 `cdp_targets` only to diagnose the mismatch, relaunch the authority-bound app,
 and call `cdp_connect` again. Omitted values come only from the fenced session;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -37103,11 +37103,7 @@ function setRegistryDeviceBindingProvider(provider) {
 function registryDeviceBinding() {
   if (!registryDeviceBindingProvider)
     return null;
-  try {
-    return registryDeviceBindingProvider() ?? null;
-  } catch {
-    return null;
-  }
+  return registryDeviceBindingProvider() ?? null;
 }
 function runAdbSync(file, args) {
   return execFileSync8(file, args, {
@@ -37117,7 +37113,12 @@ function runAdbSync(file, args) {
   });
 }
 function androidAdbScope(deps = {}) {
-  const registry2 = (deps.getRegistryBinding ?? registryDeviceBinding)();
+  let registry2;
+  try {
+    registry2 = (deps.getRegistryBinding ?? registryDeviceBinding)();
+  } catch {
+    registry2 = {};
+  }
   const session2 = (deps.getSession ?? getActiveSession)();
   if (!registry2 && !session2)
     return { kind: "ambient" };
@@ -86485,7 +86486,7 @@ setRegistryDeviceBindingProvider(() => {
     return null;
   const device = status.bindings.device;
   if (!device)
-    return null;
+    return {};
   return {
     platform: typeof device.platform === "string" ? device.platform : void 0,
     deviceId: typeof device.deviceId === "string" ? device.deviceId : void 0

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -37097,6 +37097,19 @@ function cachedPackageProbe(key, probe, clock = Date.now) {
   });
   return value;
 }
+function mapRegistryDeviceBinding(status) {
+  if (!status.available)
+    return null;
+  const device = status.bindings.device;
+  if (!device)
+    return {};
+  const mapped = {};
+  if (typeof device.platform === "string")
+    mapped.platform = device.platform;
+  if (typeof device.deviceId === "string")
+    mapped.deviceId = device.deviceId;
+  return mapped;
+}
 function setRegistryDeviceBindingProvider(provider) {
   registryDeviceBindingProvider = provider;
 }
@@ -86480,18 +86493,7 @@ addToolObserver((o) => recorder.record(o));
 addToolObserver((o) => strictProofMonitor.record(o));
 addToolObserver((o) => experienceRecorder.observe(o));
 var authorityRuntime = getWorkerAuthorityRuntime();
-setRegistryDeviceBindingProvider(() => {
-  const status = authorityRuntime.status();
-  if (!status.available)
-    return null;
-  const device = status.bindings.device;
-  if (!device)
-    return {};
-  return {
-    platform: typeof device.platform === "string" ? device.platform : void 0,
-    deviceId: typeof device.deviceId === "string" ? device.deviceId : void 0
-  };
-});
+setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(authorityRuntime.status()));
 setSnapshotAuthorityProvider({
   current: () => {
     const status = authorityRuntime.status();

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -37097,9 +37097,10 @@ function cachedPackageProbe(key, probe, clock = Date.now) {
   });
   return value;
 }
-function mapRegistryDeviceBinding(status) {
-  if (!status.available)
-    return null;
+function mapRegistryDeviceBinding(status, runtimeInitialized = false) {
+  if (!status.available) {
+    return runtimeInitialized || status.code === "SESSION_OWNER_LOST" ? {} : null;
+  }
   const device = status.bindings.device;
   if (!device)
     return {};
@@ -86493,7 +86494,7 @@ addToolObserver((o) => recorder.record(o));
 addToolObserver((o) => strictProofMonitor.record(o));
 addToolObserver((o) => experienceRecorder.observe(o));
 var authorityRuntime = getWorkerAuthorityRuntime();
-setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(authorityRuntime.status()));
+setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(authorityRuntime.status(), authorityRuntime.available));
 setSnapshotAuthorityProvider({
   current: () => {
     const status = authorityRuntime.status();

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -37099,7 +37099,8 @@ function cachedPackageProbe(key, probe, clock = Date.now) {
 }
 function mapRegistryDeviceBinding(status, runtimeInitialized = false) {
   if (!status.available) {
-    return runtimeInitialized || status.code === "SESSION_OWNER_LOST" ? {} : null;
+    const neverInitialized = !runtimeInitialized && (status.code === void 0 || status.code === "SESSION_NOT_INITIALIZED");
+    return neverInitialized ? null : {};
   }
   const device = status.bindings.device;
   if (!device)

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -27799,11 +27799,7 @@ function setRegistryDeviceBindingProvider(provider) {
 function registryDeviceBinding() {
   if (!registryDeviceBindingProvider)
     return null;
-  try {
-    return registryDeviceBindingProvider() ?? null;
-  } catch {
-    return null;
-  }
+  return registryDeviceBindingProvider() ?? null;
 }
 function runAdbSync(file, args) {
   return execFileSync11(file, args, {
@@ -27813,7 +27809,12 @@ function runAdbSync(file, args) {
   });
 }
 function androidAdbScope(deps = {}) {
-  const registry2 = (deps.getRegistryBinding ?? registryDeviceBinding)();
+  let registry2;
+  try {
+    registry2 = (deps.getRegistryBinding ?? registryDeviceBinding)();
+  } catch {
+    registry2 = {};
+  }
   const session2 = (deps.getSession ?? getActiveSession)();
   if (!registry2 && !session2)
     return { kind: "ambient" };
@@ -88925,7 +88926,7 @@ var init_index = __esm({
         return null;
       const device = status.bindings.device;
       if (!device)
-        return null;
+        return {};
       return {
         platform: typeof device.platform === "string" ? device.platform : void 0,
         deviceId: typeof device.deviceId === "string" ? device.deviceId : void 0

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -27793,9 +27793,10 @@ function cachedPackageProbe(key, probe, clock = Date.now) {
   });
   return value;
 }
-function mapRegistryDeviceBinding(status) {
-  if (!status.available)
-    return null;
+function mapRegistryDeviceBinding(status, runtimeInitialized = false) {
+  if (!status.available) {
+    return runtimeInitialized || status.code === "SESSION_OWNER_LOST" ? {} : null;
+  }
   const device = status.bindings.device;
   if (!device)
     return {};
@@ -88933,7 +88934,7 @@ var init_index = __esm({
     addToolObserver((o) => strictProofMonitor.record(o));
     addToolObserver((o) => experienceRecorder.observe(o));
     authorityRuntime = getWorkerAuthorityRuntime();
-    setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(authorityRuntime.status()));
+    setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(authorityRuntime.status(), authorityRuntime.available));
     setSnapshotAuthorityProvider({
       current: () => {
         const status = authorityRuntime.status();

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -27793,6 +27793,19 @@ function cachedPackageProbe(key, probe, clock = Date.now) {
   });
   return value;
 }
+function mapRegistryDeviceBinding(status) {
+  if (!status.available)
+    return null;
+  const device = status.bindings.device;
+  if (!device)
+    return {};
+  const mapped = {};
+  if (typeof device.platform === "string")
+    mapped.platform = device.platform;
+  if (typeof device.deviceId === "string")
+    mapped.deviceId = device.deviceId;
+  return mapped;
+}
 function setRegistryDeviceBindingProvider(provider) {
   registryDeviceBindingProvider = provider;
 }
@@ -88920,18 +88933,7 @@ var init_index = __esm({
     addToolObserver((o) => strictProofMonitor.record(o));
     addToolObserver((o) => experienceRecorder.observe(o));
     authorityRuntime = getWorkerAuthorityRuntime();
-    setRegistryDeviceBindingProvider(() => {
-      const status = authorityRuntime.status();
-      if (!status.available)
-        return null;
-      const device = status.bindings.device;
-      if (!device)
-        return {};
-      return {
-        platform: typeof device.platform === "string" ? device.platform : void 0,
-        deviceId: typeof device.deviceId === "string" ? device.deviceId : void 0
-      };
-    });
+    setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(authorityRuntime.status()));
     setSnapshotAuthorityProvider({
       current: () => {
         const status = authorityRuntime.status();

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -27795,7 +27795,8 @@ function cachedPackageProbe(key, probe, clock = Date.now) {
 }
 function mapRegistryDeviceBinding(status, runtimeInitialized = false) {
   if (!status.available) {
-    return runtimeInitialized || status.code === "SESSION_OWNER_LOST" ? {} : null;
+    const neverInitialized = !runtimeInitialized && (status.code === void 0 || status.code === "SESSION_NOT_INITIALIZED");
+    return neverInitialized ? null : {};
   }
   const device = status.bindings.device;
   if (!device)

--- a/packages/claude-plugin/scripts/record_proof.sh
+++ b/packages/claude-plugin/scripts/record_proof.sh
@@ -936,6 +936,11 @@ is_zombie() {
   [[ "${state//[[:space:]]/}" == Z* ]]
 }
 
+is_present() {
+  local pid="$1"
+  is_alive "$pid" && ! is_zombie "$pid"
+}
+
 hash_process_identity() {
   {
     local index=0
@@ -1018,14 +1023,14 @@ probe_local_process() {
   LOCAL_PROCESS_STATE="unknown"
   LOCAL_PROCESS_BIRTH=""
   LOCAL_PROCESS_MARKER_MATCH="false"
-  if ! is_alive "$pid" || is_zombie "$pid"; then
+  if ! is_present "$pid"; then
     LOCAL_PROCESS_STATE="absent"
     return 0
   fi
 
   local command
   command="$(ps -ww -p "$pid" -o command= 2>/dev/null)" || {
-    is_alive "$pid" || {
+    is_present "$pid" || {
       LOCAL_PROCESS_STATE="absent"
       return 0
     }
@@ -1050,7 +1055,7 @@ probe_local_process() {
       return 1
     }
     info="$(darwin_process_birth_info "$helper" "$pid" "$requirement" 2>/dev/null)" || {
-      is_alive "$pid" || {
+      is_present "$pid" || {
         LOCAL_PROCESS_STATE="absent"
         return 0
       }
@@ -1069,7 +1074,7 @@ probe_local_process() {
     local stat_after
     local boot_id
     stat_before="$(cat "/proc/$pid/stat" 2>/dev/null)" || {
-      [[ ! -e "/proc/$pid" ]] && {
+      { [[ ! -e "/proc/$pid" ]] || is_zombie "$pid"; } && {
         LOCAL_PROCESS_STATE="absent"
         return 0
       }
@@ -1081,7 +1086,7 @@ probe_local_process() {
       return 1
     }
     stat_after="$(cat "/proc/$pid/stat" 2>/dev/null)" || {
-      [[ ! -e "/proc/$pid" ]] && {
+      { [[ ! -e "/proc/$pid" ]] || is_zombie "$pid"; } && {
         LOCAL_PROCESS_STATE="absent"
         return 0
       }
@@ -1106,7 +1111,7 @@ probe_local_process() {
 
   local command_after
   command_after="$(ps -ww -p "$pid" -o command= 2>/dev/null)" || {
-    is_alive "$pid" || {
+    is_present "$pid" || {
       LOCAL_PROCESS_STATE="absent"
       return 0
     }

--- a/packages/claude-plugin/scripts/record_proof.sh
+++ b/packages/claude-plugin/scripts/record_proof.sh
@@ -926,6 +926,16 @@ is_alive() {
   kill -0 "$pid" 2>/dev/null
 }
 
+# GH#707: an unreaped zombie has already terminated — it runs no code and its
+# pid cannot be reused until the parent reaps it, so it must read as absent
+# instead of as a live process whose command identity suddenly changed.
+is_zombie() {
+  local pid="$1"
+  local state
+  state="$(ps -p "$pid" -o state= 2>/dev/null)" || return 1
+  [[ "${state//[[:space:]]/}" == Z* ]]
+}
+
 hash_process_identity() {
   {
     local index=0
@@ -1008,7 +1018,7 @@ probe_local_process() {
   LOCAL_PROCESS_STATE="unknown"
   LOCAL_PROCESS_BIRTH=""
   LOCAL_PROCESS_MARKER_MATCH="false"
-  if ! is_alive "$pid"; then
+  if ! is_alive "$pid" || is_zombie "$pid"; then
     LOCAL_PROCESS_STATE="absent"
     return 0
   fi
@@ -1104,6 +1114,10 @@ probe_local_process() {
     return 1
   }
   [[ "$command_after" == *"$marker"* ]] || LOCAL_PROCESS_MARKER_MATCH="false"
+  if is_zombie "$pid"; then
+    LOCAL_PROCESS_STATE="absent"
+    return 0
+  fi
   [[ "$LOCAL_PROCESS_BIRTH" =~ ^[a-f0-9]{64}$ ]] || {
     echo "Error: recorder process birth token is invalid" >&2
     return 1
@@ -2420,14 +2434,16 @@ PYEOF
   echo "Labeled video: $output ($size bytes)"
 }
 
-trap cleanup_pending_pull EXIT
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  trap cleanup_pending_pull EXIT
 
-case "${1:-}" in
-  start)       shift; cmd_start "$@" ;;
-  abort)       shift; cmd_abort "$@" ;;
-  stop)        shift; cmd_stop "$@" ;;
-  status)      shift; cmd_status "$@" ;;
-  convert-gif) shift; cmd_convert_gif "$@" ;;
-  label)       shift; cmd_label "$@" ;;
-  *)           usage ;;
-esac
+  case "${1:-}" in
+    start)       shift; cmd_start "$@" ;;
+    abort)       shift; cmd_abort "$@" ;;
+    stop)        shift; cmd_stop "$@" ;;
+    status)      shift; cmd_status "$@" ;;
+    convert-gif) shift; cmd_convert_gif "$@" ;;
+    label)       shift; cmd_label "$@" ;;
+    *)           usage ;;
+  esac
+fi

--- a/packages/claude-plugin/scripts/snapshot_state.sh
+++ b/packages/claude-plugin/scripts/snapshot_state.sh
@@ -60,16 +60,32 @@ if [ -z "$DEVICE_ID" ]; then
   exit 1
 fi
 
+DEVICE_LISTING=""
+
+# A listing that could not be produced is an unknown state, not a verdict:
+# retry before reporting the device absent, so one transient spawn failure
+# cannot masquerade as "not booted".
+probe_device_listing() {
+  local attempt=1
+  while [ "$attempt" -le 3 ]; do
+    DEVICE_LISTING=$("$@" 2>/dev/null) && return 0
+    attempt=$((attempt + 1))
+  done
+  DEVICE_LISTING=""
+  return 1
+}
+
 ios_device_is_booted() {
-  local devices
-  devices=$(xcrun simctl list devices booted 2>/dev/null) || return 1
-  printf '%s\n' "$devices" | grep -Fq "($DEVICE_ID) (Booted)"
+  probe_device_listing xcrun simctl list devices booted || return 1
+  case "$DEVICE_LISTING" in
+    *"($DEVICE_ID) (Booted)"*) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 android_device_is_connected() {
-  local devices
-  devices=$(adb devices 2>/dev/null) || return 1
-  printf '%s\n' "$devices" | awk -v id="$DEVICE_ID" '$1 == id && $2 == "device" { found = 1 } END { exit !found }'
+  probe_device_listing adb devices || return 1
+  printf '%s\n' "$DEVICE_LISTING" | awk -v id="$DEVICE_ID" '$1 == id && $2 == "device" { found = 1 } END { exit !found }'
 }
 
 if [ "$PLATFORM" = "auto" ]; then

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -37103,11 +37103,7 @@ function setRegistryDeviceBindingProvider(provider) {
 function registryDeviceBinding() {
   if (!registryDeviceBindingProvider)
     return null;
-  try {
-    return registryDeviceBindingProvider() ?? null;
-  } catch {
-    return null;
-  }
+  return registryDeviceBindingProvider() ?? null;
 }
 function runAdbSync(file, args) {
   return execFileSync8(file, args, {
@@ -37117,7 +37113,12 @@ function runAdbSync(file, args) {
   });
 }
 function androidAdbScope(deps = {}) {
-  const registry2 = (deps.getRegistryBinding ?? registryDeviceBinding)();
+  let registry2;
+  try {
+    registry2 = (deps.getRegistryBinding ?? registryDeviceBinding)();
+  } catch {
+    registry2 = {};
+  }
   const session2 = (deps.getSession ?? getActiveSession)();
   if (!registry2 && !session2)
     return { kind: "ambient" };
@@ -86485,7 +86486,7 @@ setRegistryDeviceBindingProvider(() => {
     return null;
   const device = status.bindings.device;
   if (!device)
-    return null;
+    return {};
   return {
     platform: typeof device.platform === "string" ? device.platform : void 0,
     deviceId: typeof device.deviceId === "string" ? device.deviceId : void 0

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -37097,6 +37097,19 @@ function cachedPackageProbe(key, probe, clock = Date.now) {
   });
   return value;
 }
+function mapRegistryDeviceBinding(status) {
+  if (!status.available)
+    return null;
+  const device = status.bindings.device;
+  if (!device)
+    return {};
+  const mapped = {};
+  if (typeof device.platform === "string")
+    mapped.platform = device.platform;
+  if (typeof device.deviceId === "string")
+    mapped.deviceId = device.deviceId;
+  return mapped;
+}
 function setRegistryDeviceBindingProvider(provider) {
   registryDeviceBindingProvider = provider;
 }
@@ -86480,18 +86493,7 @@ addToolObserver((o) => recorder.record(o));
 addToolObserver((o) => strictProofMonitor.record(o));
 addToolObserver((o) => experienceRecorder.observe(o));
 var authorityRuntime = getWorkerAuthorityRuntime();
-setRegistryDeviceBindingProvider(() => {
-  const status = authorityRuntime.status();
-  if (!status.available)
-    return null;
-  const device = status.bindings.device;
-  if (!device)
-    return {};
-  return {
-    platform: typeof device.platform === "string" ? device.platform : void 0,
-    deviceId: typeof device.deviceId === "string" ? device.deviceId : void 0
-  };
-});
+setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(authorityRuntime.status()));
 setSnapshotAuthorityProvider({
   current: () => {
     const status = authorityRuntime.status();

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -37097,9 +37097,10 @@ function cachedPackageProbe(key, probe, clock = Date.now) {
   });
   return value;
 }
-function mapRegistryDeviceBinding(status) {
-  if (!status.available)
-    return null;
+function mapRegistryDeviceBinding(status, runtimeInitialized = false) {
+  if (!status.available) {
+    return runtimeInitialized || status.code === "SESSION_OWNER_LOST" ? {} : null;
+  }
   const device = status.bindings.device;
   if (!device)
     return {};
@@ -86493,7 +86494,7 @@ addToolObserver((o) => recorder.record(o));
 addToolObserver((o) => strictProofMonitor.record(o));
 addToolObserver((o) => experienceRecorder.observe(o));
 var authorityRuntime = getWorkerAuthorityRuntime();
-setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(authorityRuntime.status()));
+setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(authorityRuntime.status(), authorityRuntime.available));
 setSnapshotAuthorityProvider({
   current: () => {
     const status = authorityRuntime.status();

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -37099,7 +37099,8 @@ function cachedPackageProbe(key, probe, clock = Date.now) {
 }
 function mapRegistryDeviceBinding(status, runtimeInitialized = false) {
   if (!status.available) {
-    return runtimeInitialized || status.code === "SESSION_OWNER_LOST" ? {} : null;
+    const neverInitialized = !runtimeInitialized && (status.code === void 0 || status.code === "SESSION_NOT_INITIALIZED");
+    return neverInitialized ? null : {};
   }
   const device = status.bindings.device;
   if (!device)

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -27799,11 +27799,7 @@ function setRegistryDeviceBindingProvider(provider) {
 function registryDeviceBinding() {
   if (!registryDeviceBindingProvider)
     return null;
-  try {
-    return registryDeviceBindingProvider() ?? null;
-  } catch {
-    return null;
-  }
+  return registryDeviceBindingProvider() ?? null;
 }
 function runAdbSync(file, args) {
   return execFileSync11(file, args, {
@@ -27813,7 +27809,12 @@ function runAdbSync(file, args) {
   });
 }
 function androidAdbScope(deps = {}) {
-  const registry2 = (deps.getRegistryBinding ?? registryDeviceBinding)();
+  let registry2;
+  try {
+    registry2 = (deps.getRegistryBinding ?? registryDeviceBinding)();
+  } catch {
+    registry2 = {};
+  }
   const session2 = (deps.getSession ?? getActiveSession)();
   if (!registry2 && !session2)
     return { kind: "ambient" };
@@ -88925,7 +88926,7 @@ var init_index = __esm({
         return null;
       const device = status.bindings.device;
       if (!device)
-        return null;
+        return {};
       return {
         platform: typeof device.platform === "string" ? device.platform : void 0,
         deviceId: typeof device.deviceId === "string" ? device.deviceId : void 0

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -27793,9 +27793,10 @@ function cachedPackageProbe(key, probe, clock = Date.now) {
   });
   return value;
 }
-function mapRegistryDeviceBinding(status) {
-  if (!status.available)
-    return null;
+function mapRegistryDeviceBinding(status, runtimeInitialized = false) {
+  if (!status.available) {
+    return runtimeInitialized || status.code === "SESSION_OWNER_LOST" ? {} : null;
+  }
   const device = status.bindings.device;
   if (!device)
     return {};
@@ -88933,7 +88934,7 @@ var init_index = __esm({
     addToolObserver((o) => strictProofMonitor.record(o));
     addToolObserver((o) => experienceRecorder.observe(o));
     authorityRuntime = getWorkerAuthorityRuntime();
-    setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(authorityRuntime.status()));
+    setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(authorityRuntime.status(), authorityRuntime.available));
     setSnapshotAuthorityProvider({
       current: () => {
         const status = authorityRuntime.status();

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -27793,6 +27793,19 @@ function cachedPackageProbe(key, probe, clock = Date.now) {
   });
   return value;
 }
+function mapRegistryDeviceBinding(status) {
+  if (!status.available)
+    return null;
+  const device = status.bindings.device;
+  if (!device)
+    return {};
+  const mapped = {};
+  if (typeof device.platform === "string")
+    mapped.platform = device.platform;
+  if (typeof device.deviceId === "string")
+    mapped.deviceId = device.deviceId;
+  return mapped;
+}
 function setRegistryDeviceBindingProvider(provider) {
   registryDeviceBindingProvider = provider;
 }
@@ -88920,18 +88933,7 @@ var init_index = __esm({
     addToolObserver((o) => strictProofMonitor.record(o));
     addToolObserver((o) => experienceRecorder.observe(o));
     authorityRuntime = getWorkerAuthorityRuntime();
-    setRegistryDeviceBindingProvider(() => {
-      const status = authorityRuntime.status();
-      if (!status.available)
-        return null;
-      const device = status.bindings.device;
-      if (!device)
-        return {};
-      return {
-        platform: typeof device.platform === "string" ? device.platform : void 0,
-        deviceId: typeof device.deviceId === "string" ? device.deviceId : void 0
-      };
-    });
+    setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(authorityRuntime.status()));
     setSnapshotAuthorityProvider({
       current: () => {
         const status = authorityRuntime.status();

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -27795,7 +27795,8 @@ function cachedPackageProbe(key, probe, clock = Date.now) {
 }
 function mapRegistryDeviceBinding(status, runtimeInitialized = false) {
   if (!status.available) {
-    return runtimeInitialized || status.code === "SESSION_OWNER_LOST" ? {} : null;
+    const neverInitialized = !runtimeInitialized && (status.code === void 0 || status.code === "SESSION_NOT_INITIALIZED");
+    return neverInitialized ? null : {};
   }
   const device = status.bindings.device;
   if (!device)

--- a/packages/codex-plugin/scripts/record_proof.sh
+++ b/packages/codex-plugin/scripts/record_proof.sh
@@ -936,6 +936,11 @@ is_zombie() {
   [[ "${state//[[:space:]]/}" == Z* ]]
 }
 
+is_present() {
+  local pid="$1"
+  is_alive "$pid" && ! is_zombie "$pid"
+}
+
 hash_process_identity() {
   {
     local index=0
@@ -1018,14 +1023,14 @@ probe_local_process() {
   LOCAL_PROCESS_STATE="unknown"
   LOCAL_PROCESS_BIRTH=""
   LOCAL_PROCESS_MARKER_MATCH="false"
-  if ! is_alive "$pid" || is_zombie "$pid"; then
+  if ! is_present "$pid"; then
     LOCAL_PROCESS_STATE="absent"
     return 0
   fi
 
   local command
   command="$(ps -ww -p "$pid" -o command= 2>/dev/null)" || {
-    is_alive "$pid" || {
+    is_present "$pid" || {
       LOCAL_PROCESS_STATE="absent"
       return 0
     }
@@ -1050,7 +1055,7 @@ probe_local_process() {
       return 1
     }
     info="$(darwin_process_birth_info "$helper" "$pid" "$requirement" 2>/dev/null)" || {
-      is_alive "$pid" || {
+      is_present "$pid" || {
         LOCAL_PROCESS_STATE="absent"
         return 0
       }
@@ -1069,7 +1074,7 @@ probe_local_process() {
     local stat_after
     local boot_id
     stat_before="$(cat "/proc/$pid/stat" 2>/dev/null)" || {
-      [[ ! -e "/proc/$pid" ]] && {
+      { [[ ! -e "/proc/$pid" ]] || is_zombie "$pid"; } && {
         LOCAL_PROCESS_STATE="absent"
         return 0
       }
@@ -1081,7 +1086,7 @@ probe_local_process() {
       return 1
     }
     stat_after="$(cat "/proc/$pid/stat" 2>/dev/null)" || {
-      [[ ! -e "/proc/$pid" ]] && {
+      { [[ ! -e "/proc/$pid" ]] || is_zombie "$pid"; } && {
         LOCAL_PROCESS_STATE="absent"
         return 0
       }
@@ -1106,7 +1111,7 @@ probe_local_process() {
 
   local command_after
   command_after="$(ps -ww -p "$pid" -o command= 2>/dev/null)" || {
-    is_alive "$pid" || {
+    is_present "$pid" || {
       LOCAL_PROCESS_STATE="absent"
       return 0
     }

--- a/packages/codex-plugin/scripts/record_proof.sh
+++ b/packages/codex-plugin/scripts/record_proof.sh
@@ -926,6 +926,16 @@ is_alive() {
   kill -0 "$pid" 2>/dev/null
 }
 
+# GH#707: an unreaped zombie has already terminated — it runs no code and its
+# pid cannot be reused until the parent reaps it, so it must read as absent
+# instead of as a live process whose command identity suddenly changed.
+is_zombie() {
+  local pid="$1"
+  local state
+  state="$(ps -p "$pid" -o state= 2>/dev/null)" || return 1
+  [[ "${state//[[:space:]]/}" == Z* ]]
+}
+
 hash_process_identity() {
   {
     local index=0
@@ -1008,7 +1018,7 @@ probe_local_process() {
   LOCAL_PROCESS_STATE="unknown"
   LOCAL_PROCESS_BIRTH=""
   LOCAL_PROCESS_MARKER_MATCH="false"
-  if ! is_alive "$pid"; then
+  if ! is_alive "$pid" || is_zombie "$pid"; then
     LOCAL_PROCESS_STATE="absent"
     return 0
   fi
@@ -1104,6 +1114,10 @@ probe_local_process() {
     return 1
   }
   [[ "$command_after" == *"$marker"* ]] || LOCAL_PROCESS_MARKER_MATCH="false"
+  if is_zombie "$pid"; then
+    LOCAL_PROCESS_STATE="absent"
+    return 0
+  fi
   [[ "$LOCAL_PROCESS_BIRTH" =~ ^[a-f0-9]{64}$ ]] || {
     echo "Error: recorder process birth token is invalid" >&2
     return 1
@@ -2420,14 +2434,16 @@ PYEOF
   echo "Labeled video: $output ($size bytes)"
 }
 
-trap cleanup_pending_pull EXIT
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  trap cleanup_pending_pull EXIT
 
-case "${1:-}" in
-  start)       shift; cmd_start "$@" ;;
-  abort)       shift; cmd_abort "$@" ;;
-  stop)        shift; cmd_stop "$@" ;;
-  status)      shift; cmd_status "$@" ;;
-  convert-gif) shift; cmd_convert_gif "$@" ;;
-  label)       shift; cmd_label "$@" ;;
-  *)           usage ;;
-esac
+  case "${1:-}" in
+    start)       shift; cmd_start "$@" ;;
+    abort)       shift; cmd_abort "$@" ;;
+    stop)        shift; cmd_stop "$@" ;;
+    status)      shift; cmd_status "$@" ;;
+    convert-gif) shift; cmd_convert_gif "$@" ;;
+    label)       shift; cmd_label "$@" ;;
+    *)           usage ;;
+  esac
+fi

--- a/packages/codex-plugin/scripts/snapshot_state.sh
+++ b/packages/codex-plugin/scripts/snapshot_state.sh
@@ -60,16 +60,32 @@ if [ -z "$DEVICE_ID" ]; then
   exit 1
 fi
 
+DEVICE_LISTING=""
+
+# A listing that could not be produced is an unknown state, not a verdict:
+# retry before reporting the device absent, so one transient spawn failure
+# cannot masquerade as "not booted".
+probe_device_listing() {
+  local attempt=1
+  while [ "$attempt" -le 3 ]; do
+    DEVICE_LISTING=$("$@" 2>/dev/null) && return 0
+    attempt=$((attempt + 1))
+  done
+  DEVICE_LISTING=""
+  return 1
+}
+
 ios_device_is_booted() {
-  local devices
-  devices=$(xcrun simctl list devices booted 2>/dev/null) || return 1
-  printf '%s\n' "$devices" | grep -Fq "($DEVICE_ID) (Booted)"
+  probe_device_listing xcrun simctl list devices booted || return 1
+  case "$DEVICE_LISTING" in
+    *"($DEVICE_ID) (Booted)"*) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 android_device_is_connected() {
-  local devices
-  devices=$(adb devices 2>/dev/null) || return 1
-  printf '%s\n' "$devices" | awk -v id="$DEVICE_ID" '$1 == id && $2 == "device" { found = 1 } END { exit !found }'
+  probe_device_listing adb devices || return 1
+  printf '%s\n' "$DEVICE_LISTING" | awk -v id="$DEVICE_ID" '$1 == id && $2 == "device" { found = 1 } END { exit !found }'
 }
 
 if [ "$PLATFORM" = "auto" ]; then

--- a/packages/rn-dev-agent-core/dist/cdp/discovery.js
+++ b/packages/rn-dev-agent-core/dist/cdp/discovery.js
@@ -217,6 +217,22 @@ export function cachedPackageProbe(key, probe, clock = Date.now) {
 export function clearPackageProbeCache() {
     packageProbeCache.clear();
 }
+// Pure producer for the three-state fence. Unavailable authority is null
+// (legacy ambient may apply). An available authority with no device binding
+// is the {} sentinel (fences adb). A present device copies only string fields.
+export function mapRegistryDeviceBinding(status) {
+    if (!status.available)
+        return null;
+    const device = status.bindings.device;
+    if (!device)
+        return {};
+    const mapped = {};
+    if (typeof device.platform === 'string')
+        mapped.platform = device.platform;
+    if (typeof device.deviceId === 'string')
+        mapped.deviceId = device.deviceId;
+    return mapped;
+}
 let registryDeviceBindingProvider = null;
 export function setRegistryDeviceBindingProvider(provider) {
     registryDeviceBindingProvider = provider;

--- a/packages/rn-dev-agent-core/dist/cdp/discovery.js
+++ b/packages/rn-dev-agent-core/dist/cdp/discovery.js
@@ -217,12 +217,15 @@ export function cachedPackageProbe(key, probe, clock = Date.now) {
 export function clearPackageProbeCache() {
     packageProbeCache.clear();
 }
-// Pure producer for the three-state fence. Unavailable authority is null
-// (legacy ambient may apply). An available authority with no device binding
-// is the {} sentinel (fences adb). A present device copies only string fields.
-export function mapRegistryDeviceBinding(status) {
-    if (!status.available)
-        return null;
+// Pure producer for the three-state fence. A runtime that was never
+// initialized maps to null (legacy ambient may apply). An initialized runtime
+// whose status is unavailable (SESSION_OWNER_LOST) is the {} sentinel, as is
+// an available authority with no device binding. A present device copies only
+// string fields.
+export function mapRegistryDeviceBinding(status, runtimeInitialized = false) {
+    if (!status.available) {
+        return runtimeInitialized || status.code === 'SESSION_OWNER_LOST' ? {} : null;
+    }
     const device = status.bindings.device;
     if (!device)
         return {};

--- a/packages/rn-dev-agent-core/dist/cdp/discovery.js
+++ b/packages/rn-dev-agent-core/dist/cdp/discovery.js
@@ -217,14 +217,17 @@ export function cachedPackageProbe(key, probe, clock = Date.now) {
 export function clearPackageProbeCache() {
     packageProbeCache.clear();
 }
-// Pure producer for the three-state fence. A runtime that was never
-// initialized maps to null (legacy ambient may apply). An initialized runtime
-// whose status is unavailable (SESSION_OWNER_LOST) is the {} sentinel, as is
-// an available authority with no device binding. A present device copies only
-// string fields.
+// Pure producer for the three-state fence. Only SESSION_NOT_INITIALIZED (or an
+// unavailable status with no code) maps to null — legacy ambient may apply.
+// Any other unavailable code is a present-but-failed authority
+// (SESSION_OWNER_LOST, PROCESS_BIRTH_UNAVAILABLE, AUTHORITY_STORE_UNAVAILABLE,
+// …) and must return the {} sentinel. An available authority with no device
+// binding is also {}. A present device copies only string fields.
 export function mapRegistryDeviceBinding(status, runtimeInitialized = false) {
     if (!status.available) {
-        return runtimeInitialized || status.code === 'SESSION_OWNER_LOST' ? {} : null;
+        const neverInitialized = !runtimeInitialized &&
+            (status.code === undefined || status.code === 'SESSION_NOT_INITIALIZED');
+        return neverInitialized ? null : {};
     }
     const device = status.bindings.device;
     if (!device)

--- a/packages/rn-dev-agent-core/dist/cdp/discovery.js
+++ b/packages/rn-dev-agent-core/dist/cdp/discovery.js
@@ -221,16 +221,14 @@ let registryDeviceBindingProvider = null;
 export function setRegistryDeviceBindingProvider(provider) {
     registryDeviceBindingProvider = provider;
 }
-// An unavailable registry lookup is an absence of authorization, never a grant.
+// Null means NO authority session exists in this worker (provider uninstalled
+// or the runtime reports unavailable) — only then may legacy ambient behavior
+// apply. An installed provider reporting an available authority with no device
+// binding returns the {} sentinel instead, which fences adb downstream.
 function registryDeviceBinding() {
     if (!registryDeviceBindingProvider)
         return null;
-    try {
-        return registryDeviceBindingProvider() ?? null;
-    }
-    catch {
-        return null;
-    }
+    return registryDeviceBindingProvider() ?? null;
 }
 function runAdbSync(file, args) {
     return execFileSync(file, args, {
@@ -243,7 +241,14 @@ function runAdbSync(file, args) {
 // device-wrapper session (including its disk-rehydrated state) can only revoke.
 // Only a flow with both stores empty keeps the pre-existing single ambient read.
 function androidAdbScope(deps = {}) {
-    const registry = (deps.getRegistryBinding ?? registryDeviceBinding)();
+    let registry;
+    try {
+        registry = (deps.getRegistryBinding ?? registryDeviceBinding)();
+    }
+    catch {
+        // A failing authority lookup is an unknown state, never ambient license.
+        registry = {};
+    }
     const session = (deps.getSession ?? getActiveSession)();
     if (!registry && !session)
         return { kind: 'ambient' };

--- a/packages/rn-dev-agent-core/dist/index.js
+++ b/packages/rn-dev-agent-core/dist/index.js
@@ -115,7 +115,7 @@ import { bindNativeRunner, unbindNativeRunner } from './session/runner-binding.j
 import { claimOptionalBundleAuthority, createAuthorityGate, } from './session/authority-gate.js';
 import { createLocalAuthorityProbe } from './session/local-authority-probe.js';
 import { createForeignMetroOriginScanner } from './session/metro-origin.js';
-import { DISCOVERY_TIMEOUT_MS, discoverAllMetroPorts, resolveDefaultPorts, setRegistryDeviceBindingProvider, } from './cdp/discovery.js';
+import { DISCOVERY_TIMEOUT_MS, discoverAllMetroPorts, resolveDefaultPorts, mapRegistryDeviceBinding, setRegistryDeviceBindingProvider, } from './cdp/discovery.js';
 import { assertAuthorityProfilesExhaustive } from './session/tool-profiles.js';
 import { readJsonStateFile } from './util/secure-state-file.js';
 import { buildBundleAuthorityBinding, pinExactDevClient, reconcileAuthoritativeBundle, } from './session/dev-client-authority.js';
@@ -270,20 +270,7 @@ addToolObserver((o) => recorder.record(o));
 addToolObserver((o) => strictProofMonitor.record(o));
 addToolObserver((o) => experienceRecorder.observe(o));
 const authorityRuntime = getWorkerAuthorityRuntime();
-setRegistryDeviceBindingProvider(() => {
-    const status = authorityRuntime.status();
-    if (!status.available)
-        return null;
-    const device = status.bindings.device;
-    // An available authority with no device binding (e.g. source/Metro bound
-    // before bind_device) is authority-present: the {} sentinel fences adb.
-    if (!device)
-        return {};
-    return {
-        platform: typeof device.platform === 'string' ? device.platform : undefined,
-        deviceId: typeof device.deviceId === 'string' ? device.deviceId : undefined,
-    };
-});
+setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(authorityRuntime.status()));
 setSnapshotAuthorityProvider({
     current: () => {
         const status = authorityRuntime.status();

--- a/packages/rn-dev-agent-core/dist/index.js
+++ b/packages/rn-dev-agent-core/dist/index.js
@@ -270,7 +270,7 @@ addToolObserver((o) => recorder.record(o));
 addToolObserver((o) => strictProofMonitor.record(o));
 addToolObserver((o) => experienceRecorder.observe(o));
 const authorityRuntime = getWorkerAuthorityRuntime();
-setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(authorityRuntime.status()));
+setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(authorityRuntime.status(), authorityRuntime.available));
 setSnapshotAuthorityProvider({
     current: () => {
         const status = authorityRuntime.status();

--- a/packages/rn-dev-agent-core/dist/index.js
+++ b/packages/rn-dev-agent-core/dist/index.js
@@ -275,8 +275,10 @@ setRegistryDeviceBindingProvider(() => {
     if (!status.available)
         return null;
     const device = status.bindings.device;
+    // An available authority with no device binding (e.g. source/Metro bound
+    // before bind_device) is authority-present: the {} sentinel fences adb.
     if (!device)
-        return null;
+        return {};
     return {
         platform: typeof device.platform === 'string' ? device.platform : undefined,
         deviceId: typeof device.deviceId === 'string' ? device.deviceId : undefined,

--- a/packages/rn-dev-agent-core/src/cdp/discovery.ts
+++ b/packages/rn-dev-agent-core/src/cdp/discovery.ts
@@ -270,14 +270,13 @@ export function setRegistryDeviceBindingProvider(
   registryDeviceBindingProvider = provider;
 }
 
-// An unavailable registry lookup is an absence of authorization, never a grant.
+// Null means NO authority session exists in this worker (provider uninstalled
+// or the runtime reports unavailable) — only then may legacy ambient behavior
+// apply. An installed provider reporting an available authority with no device
+// binding returns the {} sentinel instead, which fences adb downstream.
 function registryDeviceBinding(): SessionDeviceBinding | null {
   if (!registryDeviceBindingProvider) return null;
-  try {
-    return registryDeviceBindingProvider() ?? null;
-  } catch {
-    return null;
-  }
+  return registryDeviceBindingProvider() ?? null;
 }
 
 function runAdbSync(file: string, args: string[]): string {
@@ -297,7 +296,13 @@ type AndroidAdbScope =
 // device-wrapper session (including its disk-rehydrated state) can only revoke.
 // Only a flow with both stores empty keeps the pre-existing single ambient read.
 function androidAdbScope(deps: AndroidInventoryDependencies = {}): AndroidAdbScope {
-  const registry = (deps.getRegistryBinding ?? registryDeviceBinding)();
+  let registry: SessionDeviceBinding | null;
+  try {
+    registry = (deps.getRegistryBinding ?? registryDeviceBinding)();
+  } catch {
+    // A failing authority lookup is an unknown state, never ambient license.
+    registry = {};
+  }
   const session = (deps.getSession ?? getActiveSession)();
   if (!registry && !session) return { kind: 'ambient' };
   const authorized =

--- a/packages/rn-dev-agent-core/src/cdp/discovery.ts
+++ b/packages/rn-dev-agent-core/src/cdp/discovery.ts
@@ -256,13 +256,20 @@ export interface SessionDeviceBinding {
   deviceId?: string;
 }
 
-// Pure producer for the three-state fence. Unavailable authority is null
-// (legacy ambient may apply). An available authority with no device binding
-// is the {} sentinel (fences adb). A present device copies only string fields.
+// Pure producer for the three-state fence. A runtime that was never
+// initialized maps to null (legacy ambient may apply). An initialized runtime
+// whose status is unavailable (SESSION_OWNER_LOST) is the {} sentinel, as is
+// an available authority with no device binding. A present device copies only
+// string fields.
 export function mapRegistryDeviceBinding(
-  status: { available: false } | { available: true; bindings: Record<string, unknown> },
+  status:
+    | { available: false; code?: string }
+    | { available: true; bindings: Record<string, unknown> },
+  runtimeInitialized = false,
 ): SessionDeviceBinding | null {
-  if (!status.available) return null;
+  if (!status.available) {
+    return runtimeInitialized || status.code === 'SESSION_OWNER_LOST' ? {} : null;
+  }
   const device = status.bindings.device as { platform?: unknown; deviceId?: unknown } | undefined;
   if (!device) return {};
   const mapped: SessionDeviceBinding = {};

--- a/packages/rn-dev-agent-core/src/cdp/discovery.ts
+++ b/packages/rn-dev-agent-core/src/cdp/discovery.ts
@@ -256,6 +256,21 @@ export interface SessionDeviceBinding {
   deviceId?: string;
 }
 
+// Pure producer for the three-state fence. Unavailable authority is null
+// (legacy ambient may apply). An available authority with no device binding
+// is the {} sentinel (fences adb). A present device copies only string fields.
+export function mapRegistryDeviceBinding(
+  status: { available: false } | { available: true; bindings: Record<string, unknown> },
+): SessionDeviceBinding | null {
+  if (!status.available) return null;
+  const device = status.bindings.device as { platform?: unknown; deviceId?: unknown } | undefined;
+  if (!device) return {};
+  const mapped: SessionDeviceBinding = {};
+  if (typeof device.platform === 'string') mapped.platform = device.platform;
+  if (typeof device.deviceId === 'string') mapped.deviceId = device.deviceId;
+  return mapped;
+}
+
 export interface AndroidInventoryDependencies {
   execute?: (file: string, args: string[]) => string;
   getSession?: () => SessionDeviceBinding | null;

--- a/packages/rn-dev-agent-core/src/cdp/discovery.ts
+++ b/packages/rn-dev-agent-core/src/cdp/discovery.ts
@@ -256,11 +256,12 @@ export interface SessionDeviceBinding {
   deviceId?: string;
 }
 
-// Pure producer for the three-state fence. A runtime that was never
-// initialized maps to null (legacy ambient may apply). An initialized runtime
-// whose status is unavailable (SESSION_OWNER_LOST) is the {} sentinel, as is
-// an available authority with no device binding. A present device copies only
-// string fields.
+// Pure producer for the three-state fence. Only SESSION_NOT_INITIALIZED (or an
+// unavailable status with no code) maps to null — legacy ambient may apply.
+// Any other unavailable code is a present-but-failed authority
+// (SESSION_OWNER_LOST, PROCESS_BIRTH_UNAVAILABLE, AUTHORITY_STORE_UNAVAILABLE,
+// …) and must return the {} sentinel. An available authority with no device
+// binding is also {}. A present device copies only string fields.
 export function mapRegistryDeviceBinding(
   status:
     | { available: false; code?: string }
@@ -268,7 +269,10 @@ export function mapRegistryDeviceBinding(
   runtimeInitialized = false,
 ): SessionDeviceBinding | null {
   if (!status.available) {
-    return runtimeInitialized || status.code === 'SESSION_OWNER_LOST' ? {} : null;
+    const neverInitialized =
+      !runtimeInitialized &&
+      (status.code === undefined || status.code === 'SESSION_NOT_INITIALIZED');
+    return neverInitialized ? null : {};
   }
   const device = status.bindings.device as { platform?: unknown; deviceId?: unknown } | undefined;
   if (!device) return {};

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -418,7 +418,9 @@ addToolObserver((o) => strictProofMonitor.record(o));
 addToolObserver((o) => experienceRecorder.observe(o));
 
 const authorityRuntime = getWorkerAuthorityRuntime();
-setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(authorityRuntime.status()));
+setRegistryDeviceBindingProvider(() =>
+  mapRegistryDeviceBinding(authorityRuntime.status(), authorityRuntime.available),
+);
 setSnapshotAuthorityProvider({
   current: () => {
     const status = authorityRuntime.status();

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -421,7 +421,9 @@ setRegistryDeviceBindingProvider(() => {
   const status = authorityRuntime.status();
   if (!status.available) return null;
   const device = status.bindings.device as { platform?: unknown; deviceId?: unknown } | undefined;
-  if (!device) return null;
+  // An available authority with no device binding (e.g. source/Metro bound
+  // before bind_device) is authority-present: the {} sentinel fences adb.
+  if (!device) return {};
   return {
     platform: typeof device.platform === 'string' ? device.platform : undefined,
     deviceId: typeof device.deviceId === 'string' ? device.deviceId : undefined,

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -228,6 +228,7 @@ import {
   DISCOVERY_TIMEOUT_MS,
   discoverAllMetroPorts,
   resolveDefaultPorts,
+  mapRegistryDeviceBinding,
   setRegistryDeviceBindingProvider,
 } from './cdp/discovery.js';
 import { assertAuthorityProfilesExhaustive } from './session/tool-profiles.js';
@@ -417,18 +418,7 @@ addToolObserver((o) => strictProofMonitor.record(o));
 addToolObserver((o) => experienceRecorder.observe(o));
 
 const authorityRuntime = getWorkerAuthorityRuntime();
-setRegistryDeviceBindingProvider(() => {
-  const status = authorityRuntime.status();
-  if (!status.available) return null;
-  const device = status.bindings.device as { platform?: unknown; deviceId?: unknown } | undefined;
-  // An available authority with no device binding (e.g. source/Metro bound
-  // before bind_device) is authority-present: the {} sentinel fences adb.
-  if (!device) return {};
-  return {
-    platform: typeof device.platform === 'string' ? device.platform : undefined,
-    deviceId: typeof device.deviceId === 'string' ? device.deviceId : undefined,
-  };
-});
+setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(authorityRuntime.status()));
 setSnapshotAuthorityProvider({
   current: () => {
     const status = authorityRuntime.status();

--- a/packages/rn-dev-agent-core/test/unit/gh-575-snapshot-helper.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-575-snapshot-helper.test.ts
@@ -209,6 +209,69 @@ exit 1
   }
 });
 
+// A device listing that could not be produced is an unknown state, never the
+// verdict "this device is absent" — a single failed probe spawn once reported a
+// booted simulator as not booted and failed the run.
+test('GH-575 snapshot retries a failed device listing instead of reporting the device absent', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'rn-agent-snapshot-probe-'));
+  const bin = join(root, 'bin');
+  const output = join(root, 'output');
+  const attempts = join(root, 'attempts');
+  const udid = 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE';
+  await mkdir(bin);
+  await mkdir(output, { mode: 0o700 });
+  await executable(
+    join(bin, 'xcrun'),
+    `#!/bin/sh
+if [ "$1 $2 $3" = "simctl list devices" ]; then
+  printf 'x' >> "$ATTEMPTS"
+  if [ "$(wc -c < "$ATTEMPTS")" -le 1 ]; then
+    exit 137
+  fi
+  printf '    iPhone One (%s) (Booted)\n' '${udid}'
+  exit 0
+fi
+printf 'jpeg\n' > "$6"
+`,
+  );
+  try {
+    const { stdout } = await pexecFile(
+      'bash',
+      [snapshotHelper, 'ios', '--device-id', udid, '--output-dir', output],
+      { env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, ATTEMPTS: attempts } },
+    );
+    const result = stdout.trim();
+    assert.match(result, /\/snapshot-ios-[A-Za-z0-9]+$/);
+    assert.equal(await readFile(join(result, 'screenshot.jpg'), 'utf8'), 'jpeg\n');
+    assert.equal((await readFile(attempts, 'utf8')).length, 2);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('GH-575 snapshot still reports a device that every listing omits', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'rn-agent-snapshot-absent-'));
+  const bin = join(root, 'bin');
+  const udid = 'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE';
+  await mkdir(bin);
+  await executable(
+    join(bin, 'xcrun'),
+    `#!/bin/sh
+printf '    iPhone Other (11111111-2222-3333-4444-555555555555) (Booted)\n'
+`,
+  );
+  try {
+    await assert.rejects(
+      pexecFile('bash', [snapshotHelper, 'ios', '--device-id', udid], {
+        env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, TMPDIR: root },
+      }),
+      /is not booted/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test('GH-575 snapshot cleans caller-owned staging when either Android artifact fails', async () => {
   const root = await mkdtemp(join(tmpdir(), 'rn-agent-snapshot-android-failure-'));
   const bin = join(root, 'bin');

--- a/packages/rn-dev-agent-core/test/unit/record-proof-local-authority.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/record-proof-local-authority.test.ts
@@ -340,7 +340,7 @@ done
   childPid = 0;
 });
 
-test('an unreaped recorder process reads as absent, not as changed command identity', async (t) => {
+async function createUnreapedPid(registerCleanup: (cleanup: () => void) => void): Promise<number> {
   const parent = spawn(
     'python3',
     [
@@ -355,7 +355,7 @@ test('an unreaped recorder process reads as absent, not as changed command ident
     ],
     { stdio: ['ignore', 'pipe', 'ignore'] },
   );
-  t.after(() => {
+  registerCleanup(() => {
     try {
       parent.kill('SIGKILL');
     } catch {}
@@ -378,15 +378,21 @@ test('an unreaped recorder process reads as absent, not as changed command ident
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   assert.equal(probeProcessPresence(zombiePid), 'absent');
+  return zombiePid;
+}
 
+function probeLocalProcess(
+  pid: number,
+  preamble = '',
+): { status: number | null; state: string; stderr: string } {
   const probe = spawnSync(
     'bash',
     [
       '-c',
-      'source "$1"; probe_local_process "$2" "$3"; printf \'%s\\n\' "$LOCAL_PROCESS_STATE"',
+      `source "$1"; ${preamble} probe_local_process "$2" "$3"; printf '%s\\n' "$LOCAL_PROCESS_STATE"`,
       'probe',
       sourceScript,
-      String(zombiePid),
+      String(pid),
       'marker-that-a-defunct-process-cannot-carry',
     ],
     {
@@ -399,8 +405,32 @@ test('an unreaped recorder process reads as absent, not as changed command ident
       },
     },
   );
+  return { status: probe.status, state: probe.stdout.trim(), stderr: probe.stderr };
+}
+
+test('an unreaped recorder process reads as absent, not as changed command identity', async (t) => {
+  const zombiePid = await createUnreapedPid((cleanup) => t.after(cleanup));
+
+  const probe = probeLocalProcess(zombiePid);
   assert.equal(probe.status, 0, probe.stderr);
-  assert.equal(probe.stdout.trim(), 'absent');
+  assert.equal(probe.state, 'absent');
+});
+
+test('a recorder that becomes unreaped mid-probe still reads as absent', async (t) => {
+  const zombiePid = await createUnreapedPid((cleanup) => t.after(cleanup));
+
+  const probe = probeLocalProcess(
+    zombiePid,
+    [
+      '__entry_checked=0;',
+      'is_present() {',
+      '  if (( __entry_checked == 0 )); then __entry_checked=1; return 0; fi;',
+      '  is_alive "$1" && ! is_zombie "$1";',
+      '};',
+    ].join(' '),
+  );
+  assert.equal(probe.status, 0, probe.stderr);
+  assert.equal(probe.state, 'absent');
 });
 
 test('recording stop delegates signals to the authenticated supervisor', () => {

--- a/packages/rn-dev-agent-core/test/unit/record-proof-local-authority.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/record-proof-local-authority.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { execFile, spawnSync } from 'node:child_process';
+import { execFile, spawn, spawnSync } from 'node:child_process';
 import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -338,6 +338,69 @@ done
   assert.equal(existsSync(`${prefix}-${scope}.pid`), false);
   supervisorPid = 0;
   childPid = 0;
+});
+
+test('an unreaped recorder process reads as absent, not as changed command identity', async (t) => {
+  const parent = spawn(
+    'python3',
+    [
+      '-c',
+      [
+        'import subprocess, sys, time',
+        'child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(600)"])',
+        'child.kill()',
+        'print(child.pid, flush=True)',
+        'time.sleep(600)',
+      ].join('\n'),
+    ],
+    { stdio: ['ignore', 'pipe', 'ignore'] },
+  );
+  t.after(() => {
+    try {
+      parent.kill('SIGKILL');
+    } catch {}
+  });
+
+  const zombiePid = await new Promise<number>((resolve, reject) => {
+    let buffered = '';
+    parent.stdout.setEncoding('utf8');
+    parent.stdout.on('data', (chunk: string) => {
+      buffered += chunk;
+      const line = buffered.split('\n')[0];
+      if (buffered.includes('\n')) resolve(Number(line.trim()));
+    });
+    parent.once('error', reject);
+    parent.once('exit', () => reject(new Error('zombie parent exited early')));
+  });
+
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (probeProcessPresence(zombiePid) === 'absent') break;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  assert.equal(probeProcessPresence(zombiePid), 'absent');
+
+  const probe = spawnSync(
+    'bash',
+    [
+      '-c',
+      'source "$1"; probe_local_process "$2" "$3"; printf \'%s\\n\' "$LOCAL_PROCESS_STATE"',
+      'probe',
+      sourceScript,
+      String(zombiePid),
+      'marker-that-a-defunct-process-cannot-carry',
+    ],
+    {
+      encoding: 'utf8',
+      timeout: 10_000,
+      env: {
+        ...process.env,
+        RN_DEV_AGENT_PROCESS_BIRTH_HELPER: processBirthHelper,
+        RN_DEV_AGENT_PROCESS_BIRTH_REQUIREMENT: darwinProcessBirthRequirement(),
+      },
+    },
+  );
+  assert.equal(probe.status, 0, probe.stderr);
+  assert.equal(probe.stdout.trim(), 'absent');
 });
 
 test('recording stop delegates signals to the authenticated supervisor', () => {

--- a/packages/rn-dev-agent-core/test/unit/session/gh-777-exact-target-device-inventory.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/gh-777-exact-target-device-inventory.test.ts
@@ -257,9 +257,10 @@ test('gh-777-qa: both stores empty keeps the single pre-existing baseline read',
 
 // P1 (PR #782 / #786 review): the provider mapping is a pure three-state seam —
 // never-initialized => null, available with no/null device => {}, device present =>
-// {platform,deviceId}. SESSION_OWNER_LOST on an initialized runtime is {}, never
-// null. The consumer tests below still prove the {} sentinel fences adb, and a
-// throwing lookup never becomes ambient.
+// {platform,deviceId}. Any unavailable code other than SESSION_NOT_INITIALIZED
+// (SESSION_OWNER_LOST, PROCESS_BIRTH_UNAVAILABLE, AUTHORITY_STORE_UNAVAILABLE)
+// is {}, never null. The consumer tests below still prove the {} sentinel
+// fences adb, and a throwing lookup never becomes ambient.
 test('gh-777-qa: provider mapping — unavailable authority is null', () => {
   assert.equal(mapRegistryDeviceBinding({ available: false }), null);
   assert.equal(
@@ -272,6 +273,24 @@ test('gh-777-qa: provider mapping — SESSION_OWNER_LOST from an initialized run
   assert.deepEqual(mapRegistryDeviceBinding({ available: false, code: 'SESSION_OWNER_LOST' }), {});
   assert.deepEqual(
     mapRegistryDeviceBinding({ available: false, code: 'SESSION_OWNER_LOST' }, true),
+    {},
+  );
+});
+
+test('gh-777-qa: provider mapping — supervisor-present init failures are the fence sentinel', () => {
+  // Discriminating vs a5d7a4a9: that head fenced only SESSION_OWNER_LOST, so
+  // PROCESS_BIRTH_UNAVAILABLE / AUTHORITY_STORE_UNAVAILABLE collapsed to null
+  // (ambient) even though the supervisor had already supplied a session context.
+  assert.notEqual(
+    mapRegistryDeviceBinding({ available: false, code: 'PROCESS_BIRTH_UNAVAILABLE' }),
+    null,
+  );
+  assert.deepEqual(
+    mapRegistryDeviceBinding({ available: false, code: 'PROCESS_BIRTH_UNAVAILABLE' }),
+    {},
+  );
+  assert.deepEqual(
+    mapRegistryDeviceBinding({ available: false, code: 'AUTHORITY_STORE_UNAVAILABLE' }),
     {},
   );
 });

--- a/packages/rn-dev-agent-core/test/unit/session/gh-777-exact-target-device-inventory.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/gh-777-exact-target-device-inventory.test.ts
@@ -8,6 +8,7 @@ import {
   clearPackageProbeCache,
   discoverExactPort,
   inferPlatforms,
+  mapRegistryDeviceBinding,
   probeAndroidDeviceModels,
   probeAndroidPackages,
 } from '../../../dist/cdp/discovery.js';
@@ -254,9 +255,56 @@ test('gh-777-qa: both stores empty keeps the single pre-existing baseline read',
   assert.deepEqual(spy.calls, [['adb', 'shell', 'pm', 'list', 'packages']]);
 });
 
-// P1 (PR #782 review): an available authority runtime with NO device binding
-// reports the {} sentinel, never null — a source/Metro-bound worker must not
-// collapse to the ambient legacy read when the wrapper session is also empty.
+// P1 (PR #782 review): the provider mapping is a pure three-state seam —
+// unavailable => null, available with no/null device => {}, device present =>
+// {platform,deviceId}. The consumer tests below still prove the {} sentinel
+// fences adb, and a throwing lookup never becomes ambient.
+test('gh-777-qa: provider mapping — unavailable authority is null', () => {
+  assert.equal(mapRegistryDeviceBinding({ available: false }), null);
+});
+
+test('gh-777-qa: provider mapping — available with no device is the fence sentinel', () => {
+  const missing = mapRegistryDeviceBinding({ available: true, bindings: {} });
+  const unbound = mapRegistryDeviceBinding({ available: true, bindings: { device: null } });
+  assert.notEqual(missing, null);
+  assert.deepEqual(missing, {});
+  assert.notEqual(unbound, null);
+  assert.deepEqual(unbound, {});
+});
+
+test('gh-777-qa: provider mapping — available with a device copies string fields only', () => {
+  assert.deepEqual(
+    mapRegistryDeviceBinding({
+      available: true,
+      bindings: {
+        device: { platform: 'android', deviceId: boundSerial, appId },
+      },
+    }),
+    { platform: 'android', deviceId: boundSerial },
+  );
+  assert.deepEqual(
+    mapRegistryDeviceBinding({
+      available: true,
+      bindings: { device: { platform: 'ios', deviceId: simulatorUdid } },
+    }),
+    { platform: 'ios', deviceId: simulatorUdid },
+  );
+  assert.deepEqual(
+    mapRegistryDeviceBinding({
+      available: true,
+      bindings: { device: { platform: 1, deviceId: false, appId } },
+    }),
+    {},
+  );
+  assert.deepEqual(
+    mapRegistryDeviceBinding({
+      available: true,
+      bindings: { device: { platform: 'android', deviceId: 99 } },
+    }),
+    { platform: 'android' },
+  );
+});
+
 test('gh-777-qa: source/Metro-bound authority with no device binding fences adb entirely', () => {
   const spy = execSpy();
   const stores = {

--- a/packages/rn-dev-agent-core/test/unit/session/gh-777-exact-target-device-inventory.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/gh-777-exact-target-device-inventory.test.ts
@@ -254,6 +254,35 @@ test('gh-777-qa: both stores empty keeps the single pre-existing baseline read',
   assert.deepEqual(spy.calls, [['adb', 'shell', 'pm', 'list', 'packages']]);
 });
 
+// P1 (PR #782 review): an available authority runtime with NO device binding
+// reports the {} sentinel, never null — a source/Metro-bound worker must not
+// collapse to the ambient legacy read when the wrapper session is also empty.
+test('gh-777-qa: source/Metro-bound authority with no device binding fences adb entirely', () => {
+  const spy = execSpy();
+  const stores = {
+    getSession: () => null,
+    getRegistryBinding: () => ({}),
+  };
+  assert.equal(authorizedAndroidSerial(stores), null);
+  assert.equal(probeAndroidDeviceModels({ execute: spy.execute, ...stores }), null);
+  assert.equal(probeAndroidPackages({ execute: spy.execute, ...stores }), null);
+  assert.deepEqual(spy.calls, []);
+});
+
+test('gh-777-qa: a throwing registry lookup is fenced, never ambient', () => {
+  const spy = execSpy();
+  const stores = {
+    getSession: () => null,
+    getRegistryBinding: () => {
+      throw new Error('authority runtime unavailable');
+    },
+  };
+  assert.equal(authorizedAndroidSerial(stores), null);
+  assert.equal(probeAndroidDeviceModels({ execute: spy.execute, ...stores }), null);
+  assert.equal(probeAndroidPackages({ execute: spy.execute, ...stores }), null);
+  assert.deepEqual(spy.calls, []);
+});
+
 function iosExactFixture(listedTargets: unknown[]) {
   let now = 0;
   const client = {

--- a/packages/rn-dev-agent-core/test/unit/session/gh-777-exact-target-device-inventory.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/gh-777-exact-target-device-inventory.test.ts
@@ -255,12 +255,25 @@ test('gh-777-qa: both stores empty keeps the single pre-existing baseline read',
   assert.deepEqual(spy.calls, [['adb', 'shell', 'pm', 'list', 'packages']]);
 });
 
-// P1 (PR #782 review): the provider mapping is a pure three-state seam —
-// unavailable => null, available with no/null device => {}, device present =>
-// {platform,deviceId}. The consumer tests below still prove the {} sentinel
-// fences adb, and a throwing lookup never becomes ambient.
+// P1 (PR #782 / #786 review): the provider mapping is a pure three-state seam —
+// never-initialized => null, available with no/null device => {}, device present =>
+// {platform,deviceId}. SESSION_OWNER_LOST on an initialized runtime is {}, never
+// null. The consumer tests below still prove the {} sentinel fences adb, and a
+// throwing lookup never becomes ambient.
 test('gh-777-qa: provider mapping — unavailable authority is null', () => {
   assert.equal(mapRegistryDeviceBinding({ available: false }), null);
+  assert.equal(
+    mapRegistryDeviceBinding({ available: false, code: 'SESSION_NOT_INITIALIZED' }),
+    null,
+  );
+});
+
+test('gh-777-qa: provider mapping — SESSION_OWNER_LOST from an initialized runtime is the fence sentinel', () => {
+  assert.deepEqual(mapRegistryDeviceBinding({ available: false, code: 'SESSION_OWNER_LOST' }), {});
+  assert.deepEqual(
+    mapRegistryDeviceBinding({ available: false, code: 'SESSION_OWNER_LOST' }, true),
+    {},
+  );
 });
 
 test('gh-777-qa: provider mapping — available with no device is the fence sentinel', () => {

--- a/scripts/record_proof.sh
+++ b/scripts/record_proof.sh
@@ -936,6 +936,11 @@ is_zombie() {
   [[ "${state//[[:space:]]/}" == Z* ]]
 }
 
+is_present() {
+  local pid="$1"
+  is_alive "$pid" && ! is_zombie "$pid"
+}
+
 hash_process_identity() {
   {
     local index=0
@@ -1018,14 +1023,14 @@ probe_local_process() {
   LOCAL_PROCESS_STATE="unknown"
   LOCAL_PROCESS_BIRTH=""
   LOCAL_PROCESS_MARKER_MATCH="false"
-  if ! is_alive "$pid" || is_zombie "$pid"; then
+  if ! is_present "$pid"; then
     LOCAL_PROCESS_STATE="absent"
     return 0
   fi
 
   local command
   command="$(ps -ww -p "$pid" -o command= 2>/dev/null)" || {
-    is_alive "$pid" || {
+    is_present "$pid" || {
       LOCAL_PROCESS_STATE="absent"
       return 0
     }
@@ -1050,7 +1055,7 @@ probe_local_process() {
       return 1
     }
     info="$(darwin_process_birth_info "$helper" "$pid" "$requirement" 2>/dev/null)" || {
-      is_alive "$pid" || {
+      is_present "$pid" || {
         LOCAL_PROCESS_STATE="absent"
         return 0
       }
@@ -1069,7 +1074,7 @@ probe_local_process() {
     local stat_after
     local boot_id
     stat_before="$(cat "/proc/$pid/stat" 2>/dev/null)" || {
-      [[ ! -e "/proc/$pid" ]] && {
+      { [[ ! -e "/proc/$pid" ]] || is_zombie "$pid"; } && {
         LOCAL_PROCESS_STATE="absent"
         return 0
       }
@@ -1081,7 +1086,7 @@ probe_local_process() {
       return 1
     }
     stat_after="$(cat "/proc/$pid/stat" 2>/dev/null)" || {
-      [[ ! -e "/proc/$pid" ]] && {
+      { [[ ! -e "/proc/$pid" ]] || is_zombie "$pid"; } && {
         LOCAL_PROCESS_STATE="absent"
         return 0
       }
@@ -1106,7 +1111,7 @@ probe_local_process() {
 
   local command_after
   command_after="$(ps -ww -p "$pid" -o command= 2>/dev/null)" || {
-    is_alive "$pid" || {
+    is_present "$pid" || {
       LOCAL_PROCESS_STATE="absent"
       return 0
     }

--- a/scripts/record_proof.sh
+++ b/scripts/record_proof.sh
@@ -926,6 +926,16 @@ is_alive() {
   kill -0 "$pid" 2>/dev/null
 }
 
+# GH#707: an unreaped zombie has already terminated — it runs no code and its
+# pid cannot be reused until the parent reaps it, so it must read as absent
+# instead of as a live process whose command identity suddenly changed.
+is_zombie() {
+  local pid="$1"
+  local state
+  state="$(ps -p "$pid" -o state= 2>/dev/null)" || return 1
+  [[ "${state//[[:space:]]/}" == Z* ]]
+}
+
 hash_process_identity() {
   {
     local index=0
@@ -1008,7 +1018,7 @@ probe_local_process() {
   LOCAL_PROCESS_STATE="unknown"
   LOCAL_PROCESS_BIRTH=""
   LOCAL_PROCESS_MARKER_MATCH="false"
-  if ! is_alive "$pid"; then
+  if ! is_alive "$pid" || is_zombie "$pid"; then
     LOCAL_PROCESS_STATE="absent"
     return 0
   fi
@@ -1104,6 +1114,10 @@ probe_local_process() {
     return 1
   }
   [[ "$command_after" == *"$marker"* ]] || LOCAL_PROCESS_MARKER_MATCH="false"
+  if is_zombie "$pid"; then
+    LOCAL_PROCESS_STATE="absent"
+    return 0
+  fi
   [[ "$LOCAL_PROCESS_BIRTH" =~ ^[a-f0-9]{64}$ ]] || {
     echo "Error: recorder process birth token is invalid" >&2
     return 1
@@ -2420,14 +2434,16 @@ PYEOF
   echo "Labeled video: $output ($size bytes)"
 }
 
-trap cleanup_pending_pull EXIT
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  trap cleanup_pending_pull EXIT
 
-case "${1:-}" in
-  start)       shift; cmd_start "$@" ;;
-  abort)       shift; cmd_abort "$@" ;;
-  stop)        shift; cmd_stop "$@" ;;
-  status)      shift; cmd_status "$@" ;;
-  convert-gif) shift; cmd_convert_gif "$@" ;;
-  label)       shift; cmd_label "$@" ;;
-  *)           usage ;;
-esac
+  case "${1:-}" in
+    start)       shift; cmd_start "$@" ;;
+    abort)       shift; cmd_abort "$@" ;;
+    stop)        shift; cmd_stop "$@" ;;
+    status)      shift; cmd_status "$@" ;;
+    convert-gif) shift; cmd_convert_gif "$@" ;;
+    label)       shift; cmd_label "$@" ;;
+    *)           usage ;;
+  esac
+fi

--- a/scripts/snapshot_state.sh
+++ b/scripts/snapshot_state.sh
@@ -60,16 +60,32 @@ if [ -z "$DEVICE_ID" ]; then
   exit 1
 fi
 
+DEVICE_LISTING=""
+
+# A listing that could not be produced is an unknown state, not a verdict:
+# retry before reporting the device absent, so one transient spawn failure
+# cannot masquerade as "not booted".
+probe_device_listing() {
+  local attempt=1
+  while [ "$attempt" -le 3 ]; do
+    DEVICE_LISTING=$("$@" 2>/dev/null) && return 0
+    attempt=$((attempt + 1))
+  done
+  DEVICE_LISTING=""
+  return 1
+}
+
 ios_device_is_booted() {
-  local devices
-  devices=$(xcrun simctl list devices booted 2>/dev/null) || return 1
-  printf '%s\n' "$devices" | grep -Fq "($DEVICE_ID) (Booted)"
+  probe_device_listing xcrun simctl list devices booted || return 1
+  case "$DEVICE_LISTING" in
+    *"($DEVICE_ID) (Booted)"*) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 android_device_is_connected() {
-  local devices
-  devices=$(adb devices 2>/dev/null) || return 1
-  printf '%s\n' "$devices" | awk -v id="$DEVICE_ID" '$1 == id && $2 == "device" { found = 1 } END { exit !found }'
+  probe_device_listing adb devices || return 1
+  printf '%s\n' "$DEVICE_LISTING" | awk -v id="$DEVICE_ID" '$1 == id && $2 == "device" { found = 1 } END { exit !found }'
 }
 
 if [ "$PLATFORM" = "auto" ]; then


### PR DESCRIPTION
## Intent

Fix GitHub issue #777 follow-up on PR 786: exact-connect device/platform inference must not fall back to ambient adb whenever an authority session is present. Null (legacy ambient) is only for a runtime that was never initialized (SESSION_NOT_INITIALIZED / no unavailable code). The {} fence sentinel applies to an available authority with no device binding, a throwing registry lookup, SESSION_OWNER_LOST, and supervisor-present init failures (PROCESS_BIRTH_UNAVAILABLE, AUTHORITY_STORE_UNAVAILABLE) — createWorkerAuthorityRuntime already received a complete supervisor context in those cases, but at a5d7a4a9 the mapper still returned null and reopened ambient adb (live Codex P1 on discovery.ts:271). Keep raw device_* tools unfenced. Discriminating producer test must fail at a5d7a4a9 (PROCESS_BIRTH maps to null) and pass at this head ({}). Pipeline CI auto-fixes already on this branch (snapshot_state.sh listing retry; record_proof.sh unreaped zombie reads as absent) stay; do not revert them. Sol IMPORTANT finding that exhausted listing probes still classify as device-absent / can flip auto platform selection is a pre-existing diagnostic uniqueness residual — escalate, do not expand this PR to change auto-detect product behavior. Leave pre-existing docs changelog drift out. Do not merge.

## What Changed

- Extracted the registry device-binding mapper into a pure `mapRegistryDeviceBinding` in `packages/rn-dev-agent-core/src/cdp/discovery.ts` and wired `src/index.ts` to it: only a runtime that was never initialized (unavailable with no code or `SESSION_NOT_INITIALIZED`) still returns `null` and keeps the legacy ambient `adb` read, while an available authority with no device binding and every other unavailable code (`SESSION_OWNER_LOST`, `PROCESS_BIRTH_UNAVAILABLE`, `AUTHORITY_STORE_UNAVAILABLE`) now returns the `{}` fence sentinel. Raw `device_*` tools stay unfenced.
- Moved the try/catch off the provider call and into `androidAdbScope`, so a throwing registry lookup resolves to `{}` (unknown state) instead of `null` (ambient license); added a changeset and reflowed the `troubleshooting.mdx` adb-fence paragraph to match.
- Shell helpers (root plus the claude/codex plugin copies): `snapshot_state.sh` retries a failed device listing up to three times before declaring the device absent, and `record_proof.sh` adds `is_zombie`/`is_present` so an unreaped recorder reads as absent in every probe branch, with its dispatch guarded by a `BASH_SOURCE` check so tests can source it. Unit tests cover the new mapper, the snapshot retry, and the zombie handling.

## Risk Assessment

✅ Low: The core fence is a small, well-tested pure-function seam whose three-state mapping I verified against the actual codes WorkerAuthorityRuntime emits, raw device_* paths are demonstrably untouched, the prior round's zombie finding is fully closed with no remaining zombie-reachable error return, and all plugin script copies plus dist artifacts are in sync.

## Testing

<code>Installed workspace deps and built rn-dev-agent-core (clean tsc; the committed dist/ rebuilt byte-identically, which matters because the tests import from dist/). The targeted suite test/unit/session/gh-777-exact-target-device-inventory.test.ts passes 29/29 at head. To prove the regression rather than just green tests, I checked out a5d7a4a9&#39;s src/, rebuilt, and ran the head test file against it: the discriminating producer test fails there with actual null where {} is required, then passes again after restoring head — the fail-before/pass-after property the intent demands. For product-level evidence I drove the exact provider wiring src/index.ts installs and recorded every adb command actually executed across seven authority-runtime states at both commits: the only behavioral delta is PROCESS_BIRTH_UNAVAILABLE and AUTHORITY_STORE_UNAVAILABLE, which ran `adb shell pm list packages` against an ambient device before and now run nothing. SESSION_NOT_INITIALIZED still permits legacy ambient, SESSION_OWNER_LOST and unbound/iOS authorities stay fenced, and an android-bound authority still issues only its `-s &lt;serial&gt;`-scoped getprop and package reads with no `adb devices` enumeration. I also ran the two suites covering the branch&#39;s pipeline auto-fixes (17/17) and the discovery regression guard (38/38), and confirmed by grep that the fenced probes have no callers outside cdp/discovery.ts so raw device_* tools remain unfenced. No visual artifacts apply — this is a CLI/MCP-layer authority fence with no rendered UI surface; the adb-command transcript is the end-user-visible behavior. Tracked files are unchanged after testing (only gitignored node_modules/install state added).</code>

<details>
<summary>Evidence: Before/after adb fence matrix through the production provider seam (head)</summary>

<code>AUTHORITY RUNTIME STATE | MAPPED BINDING | ADB COMMANDS ACTUALLY RUN&#10;------------------------------------------------------------------------------------------------------------------------&#10;runtime never initialized (SESSION_NOT_INITIALIZED)| null (legacy ambient) | adb shell pm list packages&#10;authority session, PROCESS_BIRTH_UNAVAILABLE | {} | NONE — adb fenced&#10;authority session, AUTHORITY_STORE_UNAVAILABLE| {} | NONE — adb fenced&#10;authority session, SESSION_OWNER_LOST | {} | NONE — adb fenced&#10;available authority, no device binding | {} | NONE — adb fenced&#10;available authority bound to iOS simulator | {&#34;platform&#34;:&#34;ios&#34;,&#34;deviceId&#34;:&#34;59FBC743-4090-4D45-8FDC-AD13CFCB6196&#34;}| NONE — adb fenced&#10;available authority bound to android 1A2B3C4D | {&#34;platform&#34;:&#34;android&#34;,&#34;deviceId&#34;:&#34;1A2B3C4D&#34;}| adb -s 1A2B3C4D shell getprop ro.product.model ; adb -s 1A2B3C4D shell pm list packages&#10;| authorized serial | 1A2B3C4D</code>

```text
AUTHORITY RUNTIME STATE                       | MAPPED BINDING            | ADB COMMANDS ACTUALLY RUN
------------------------------------------------------------------------------------------------------------------------
runtime never initialized (SESSION_NOT_INITIALIZED)| null (legacy ambient)     | adb shell pm list packages
authority session, PROCESS_BIRTH_UNAVAILABLE  | {}                        | NONE — adb fenced
authority session, AUTHORITY_STORE_UNAVAILABLE| {}                        | NONE — adb fenced
authority session, SESSION_OWNER_LOST         | {}                        | NONE — adb fenced
available authority, no device binding        | {}                        | NONE — adb fenced
available authority bound to iOS simulator    | {"platform":"ios","deviceId":"59FBC743-4090-4D45-8FDC-AD13CFCB6196"}| NONE — adb fenced
available authority bound to android 1A2B3C4D | {"platform":"android","deviceId":"1A2B3C4D"}| adb -s 1A2B3C4D shell getprop ro.product.model ; adb -s 1A2B3C4D shell pm list packages
                                              |   authorized serial       | 1A2B3C4D
```
</details>
<details>
<summary>Evidence: Same matrix at a5d7a4a9 — ambient adb reopened for the two init-failure codes (the live P1)</summary>

<code>AUTHORITY RUNTIME STATE | MAPPED BINDING | ADB COMMANDS ACTUALLY RUN&#10;------------------------------------------------------------------------------------------------------------------------&#10;runtime never initialized (SESSION_NOT_INITIALIZED)| null (legacy ambient) | adb shell pm list packages&#10;authority session, PROCESS_BIRTH_UNAVAILABLE | null (legacy ambient) | adb shell pm list packages&#10;authority session, AUTHORITY_STORE_UNAVAILABLE| null (legacy ambient) | adb shell pm list packages&#10;authority session, SESSION_OWNER_LOST | {} | NONE — adb fenced&#10;available authority, no device binding | {} | NONE — adb fenced&#10;available authority bound to iOS simulator | {&#34;platform&#34;:&#34;ios&#34;,&#34;deviceId&#34;:&#34;59FBC743-4090-4D45-8FDC-AD13CFCB6196&#34;}| NONE — adb fenced&#10;available authority bound to android 1A2B3C4D | {&#34;platform&#34;:&#34;android&#34;,&#34;deviceId&#34;:&#34;1A2B3C4D&#34;}| adb -s 1A2B3C4D shell getprop ro.product.model ; adb -s 1A2B3C4D shell pm list packages</code>

```text
AUTHORITY RUNTIME STATE                       | MAPPED BINDING            | ADB COMMANDS ACTUALLY RUN
------------------------------------------------------------------------------------------------------------------------
runtime never initialized (SESSION_NOT_INITIALIZED)| null (legacy ambient)     | adb shell pm list packages
authority session, PROCESS_BIRTH_UNAVAILABLE  | null (legacy ambient)     | adb shell pm list packages
authority session, AUTHORITY_STORE_UNAVAILABLE| null (legacy ambient)     | adb shell pm list packages
authority session, SESSION_OWNER_LOST         | {}                        | NONE — adb fenced
available authority, no device binding        | {}                        | NONE — adb fenced
available authority bound to iOS simulator    | {"platform":"ios","deviceId":"59FBC743-4090-4D45-8FDC-AD13CFCB6196"}| NONE — adb fenced
available authority bound to android 1A2B3C4D | {"platform":"android","deviceId":"1A2B3C4D"}| adb -s 1A2B3C4D shell getprop ro.product.model ; adb -s 1A2B3C4D shell pm list packages
                                              |   authorized serial       | 1A2B3C4D
```
</details>
<details>
<summary>Evidence: Discriminating test fails at a5d7a4a9 (fail-before evidence)</summary>

<code>✖ gh-777-qa: provider mapping — supervisor-present init failures are the fence sentinel&#10;ℹ tests 29 ℹ pass 28 ℹ fail 1&#10;&#10;test at test/unit/session/gh-777-exact-target-device-inventory.test.ts:280:1&#10;AssertionError [ERR_ASSERTION]: Expected &#34;actual&#34; to be strictly unequal to: null&#10;actual: null,&#10;operator: &#39;notStrictEqual&#39;&#10;&#10;(at head f28b78ad the same file reports: ℹ tests 29 ℹ pass 29 ℹ fail 0)</code>

```text
✔ gh-777: custom-named booted simulator with a dual-installed bundle is proven ios (0.784792ms)
✔ gh-777: custom Android model deviceName with a dual-installed bundle is proven android (0.19925ms)
✔ gh-777: a name present in both inventories stays with the fail-closed bundle inference (0.189209ms)
✔ gh-777: iOS inventory match with Android tooling unavailable stays proven ios (0.074166ms)
✔ gh-777: Android inventory match with simctl unavailable stays proven android (0.080584ms)
✔ gh-777: unavailable device inventory preserves the ambiguous fail-close (0.103625ms)
✔ gh-777: targets without a deviceName never consult the device inventory (0.071167ms)
✔ gh-777-qa: no bound session at all — the models probe never runs adb (0.397375ms)
✔ gh-777-qa: iOS registry binding before any device_snapshot open fences adb entirely (0.120209ms)
✔ gh-777-qa: iOS device-wrapper session — no adb read runs, ambient phone untouched (0.202917ms)
✔ gh-777-qa: a stale persisted android session with no registry binding is fenced (0.095958ms)
✔ gh-777-qa: a stale android session disagreeing with the registry binding is fenced (0.111042ms)
✔ gh-777-qa: registry-bound android device — exactly one getprop scoped to that serial (0.161791ms)
✔ gh-777-qa: registry-bound android device — package probe is scoped with -s (0.083ms)
✔ gh-777-qa: both stores empty keeps the single pre-existing baseline read (0.12375ms)
✔ gh-777-qa: provider mapping — unavailable authority is null (0.052791ms)
✔ gh-777-qa: provider mapping — SESSION_OWNER_LOST from an initialized runtime is the fence sentinel (0.047666ms)
✖ gh-777-qa: provider mapping — supervisor-present init failures are the fence sentinel (0.3445ms)
✔ gh-777-qa: provider mapping — available with no device is the fence sentinel (0.039625ms)
✔ gh-777-qa: provider mapping — available with a device copies string fields only (0.056292ms)
✔ gh-777-qa: source/Metro-bound authority with no device binding fences adb entirely (0.047959ms)
✔ gh-777-qa: a throwing registry lookup is fenced, never ambient (0.062166ms)
✔ gh-777: unproven-platform exclusion is named instead of a false "found 0" (0.728584ms)
✔ gh-777: app-identity exclusion is named as the failing stage (0.142542ms)
✔ gh-777: duplicate booted simulator names keep refusing the exact-device bind (0.207375ms)
✔ gh-777: the real discovery path proves a custom-named simulator target (22.825958ms)
✔ gh-777: device-association exclusion names the mismatched deviceName (0.300541ms)
✔ gh-777: empty Metro target list keeps the no-targets refusal (0.119542ms)
✔ gh-777: the sole custom-named exact-device target connects (0.211208ms)
ℹ tests 29
ℹ suites 0
ℹ pass 28
ℹ fail 1
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 222.68675

✖ failing tests:

test at test/unit/session/gh-777-exact-target-device-inventory.test.ts:280:1
✖ gh-777-qa: provider mapping — supervisor-present init failures are the fence sentinel (0.3445ms)
  AssertionError [ERR_ASSERTION]: Expected "actual" to be strictly unequal to: null
      at TestContext.<anonymous> (file:///Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M08SGRJ01VH6WKD69WVPP2XP/packages/rn-dev-agent-core/test/unit/session/gh-777-exact-target-device-inventory.test.ts:284:10)
      at Test.runInAsyncScope (node:async_hooks:228:14)
      at Test.run (node:internal/test_runner/test:1118:25)
      at Test.processPendingSubtests (node:internal/test_runner/test:787:18)
      at Test.postRun (node:internal/test_runner/test:1247:19)
      at Test.run (node:internal/test_runner/test:1175:12)
      at async Test.processPendingSubtests (node:internal/test_runner/test:787:7) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: null,
    expected: null,
    operator: 'notStrictEqual',
    diff: 'simple'
  }
```
</details>
<details>
<summary>Evidence: Demo driver script used for the adb-command matrix</summary>

```text
// Drives the PRODUCTION provider seam: exactly the wiring packages/rn-dev-agent-core/src/index.ts
// installs (setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(runtime.status(), runtime.available))),
// then runs the real Android inventory probes and records every adb command actually executed.
import {
  mapRegistryDeviceBinding,
  setRegistryDeviceBindingProvider,
  probeAndroidPackages,
  probeAndroidDeviceModels,
  authorizedAndroidSerial,
} from 'file:///Users/antonlykhoyda/.no-mistakes/worktrees/6368e539b7ff/01M08SGRJ01VH6WKD69WVPP2XP/packages/rn-dev-agent-core/dist/cdp/discovery.js';

const scenarios = [
  ['runtime never initialized (SESSION_NOT_INITIALIZED)', { available: false, code: 'SESSION_NOT_INITIALIZED' }, false],
  ['authority session, PROCESS_BIRTH_UNAVAILABLE',        { available: false, code: 'PROCESS_BIRTH_UNAVAILABLE' }, false],
  ['authority session, AUTHORITY_STORE_UNAVAILABLE',      { available: false, code: 'AUTHORITY_STORE_UNAVAILABLE' }, false],
  ['authority session, SESSION_OWNER_LOST',               { available: false, code: 'SESSION_OWNER_LOST' }, false],
  ['available authority, no device binding',              { available: true, bindings: {} }, true],
  ['available authority bound to iOS simulator',          { available: true, bindings: { device: { platform: 'ios', deviceId: '59FBC743-4090-4D45-8FDC-AD13CFCB6196' } } }, true],
  ['available authority bound to android 1A2B3C4D',       { available: true, bindings: { device: { platform: 'android', deviceId: '1A2B3C4D' } } }, true],
];

const row = (a, b, c) => `${a.padEnd(46)}| ${b.padEnd(26)}| ${c}`;
console.log(row('AUTHORITY RUNTIME STATE', 'MAPPED BINDING', 'ADB COMMANDS ACTUALLY RUN'));
console.log('-'.repeat(120));

for (const [label, status, available] of scenarios) {
  setRegistryDeviceBindingProvider(() => mapRegistryDeviceBinding(status, available));
  const calls = [];
  const execute = (file, args) => {
    calls.push([file, ...args].join(' '));
    return args.includes('getprop') ? 'be2013\n' : 'package:com.rndevagent.testapp\n';
  };
  const deps = { execute, getSession: () => null };
  const serial = authorizedAndroidSerial(deps);
  probeAndroidDeviceModels(deps);
  probeAndroidPackages(deps);
  const mapped = mapRegistryDeviceBinding(status, available);
  console.log(row(label, mapped === null ? 'null (legacy ambient)' : JSON.stringify(mapped),
    calls.length === 0 ? 'NONE — adb fenced' : calls.join(' ; ')));
  if (serial) console.log(row('', '  authorized serial', serial));
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"67ff58871c2aca3da5769e9b778766a1a5f5502a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `scripts/record_proof.sh:1117` - The unreaped-process fix guards only the entry check (line 1021) and the point after command re-capture (line 1117), but the four absence-recovery branches inside probe_local_process (lines 1027, 1053, 1076, 1085, 1107) still use bare `is_alive`, which returns true for a zombie. If a recorder is SIGKILLed mid-probe and stays unreaped, and the Darwin birth helper or `ps` fails for that defunct pid, the function returns 1 with &#34;recorder process birth is unavailable&#34; instead of the LOCAL_PROCESS_STATE=absent the commit claims to produce. The new test never reaches that window (its zombie is already caught by the entry check), so the mid-probe path is unproven. Consider a single `is_present() { is_alive &#34;$1&#34; &amp;&amp; ! is_zombie &#34;$1&#34;; }` used by every absence branch.
- ℹ️ `scripts/snapshot_state.sh:69` - probe_device_listing retries three times with no delay between attempts, so it only smooths a failure that clears within microseconds (e.g. a single fork/EAGAIN). A transient simctl/adb stall lasting even tens of milliseconds still exhausts all three attempts and falls through to the device-absent verdict. A short sleep between attempts would make the retry cover the failure class it targets. (The device-absent classification on exhaustion itself is the pre-existing residual the intent says to escalate rather than change here.)
- ℹ️ `packages/rn-dev-agent-core/src/cdp/discovery.ts:270` - The `runtimeInitialized` parameter can never change an outcome at the only production call site. WorkerAuthorityRuntime.status() returns code SESSION_NOT_INITIALIZED only when registry/session are null, in which case `available` is false; when `available` is true the only unavailable code it can emit is SESSION_OWNER_LOST, which maps to {} regardless of the flag. It is harmless defense-in-depth, but the fence is fully determined by the status code alone.
- ℹ️ `.changeset/gh-777-fence-authority-without-device.md:6` - The two shipped-script behavior fixes on this branch (snapshot_state.sh listing retry, record_proof.sh unreaped-process reads as absent) are not described in any changeset, so the published rn-dev-agent-plugin CHANGELOG will attribute this patch release solely to the adb fence. The existing patch bump covers versioning; only the user-visible description is missing.

🔧 Fix: read unreaped recorder as absent in all probe branches
1 info still open:
- ℹ️ `scripts/record_proof.sh:1077` - The Linux additions `{ [[ ! -e &#34;/proc/$pid&#34; ]] || is_zombie &#34;$pid&#34;; }` at lines 1077 and 1089 are unreachable defense: /proc/&lt;pid&gt;/stat stays readable for an unreaped zombie, so a failed `cat` already implies the pid is gone and the existing `[[ ! -e /proc/$pid ]]` test covers it. Correspondingly the new &#39;becomes unreaped mid-probe&#39; test only discriminates on Darwin (where it exercises the real fix at line 1058 via the birth-helper failure); on Linux it would pass even with the is_present change reverted, because it exits through the pre-existing is_zombie check at line 1122. Harmless — the Darwin path it does prove is the one that was actually broken.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`yarn install` + `yarn build` in packages/rn-dev-agent-core — clean tsc build, committed dist/ byte-identical to source</code>
- <code>`node --test test/unit/session/gh-777-exact-target-device-inventory.test.ts` at head — 29/29 pass</code>
- <code>Regression discrimination: `git checkout a5d7a4a9 -- packages/rn-dev-agent-core/src &amp;&amp; yarn build`, then re-ran the head test file — `gh-777-qa: provider mapping — supervisor-present init failures are the fence sentinel` FAILS (actual null, expected {}), 28/29; source restored and rebuilt, worktree clean</code>
- <code>Manual end-to-end demo driving the production provider seam (`setRegistryDeviceBindingProvider(() =&gt; mapRegistryDeviceBinding(status, available))` exactly as src/index.ts wires it) through `authorizedAndroidSerial` / `probeAndroidDeviceModels` / `probeAndroidPackages`, logging every adb command executed across 7 authority-runtime states; captured at both a5d7a4a9 and head</code>
- <code>`node --test test/unit/gh-575-snapshot-helper.test.ts test/unit/record-proof-local-authority.test.ts` — 17/17 pass (branch&#39;s snapshot_state.sh listing retry + record_proof.sh unreaped-recorder auto-fixes)</code>
- <code>`node --test test/unit/cdp-discovery.test.js` — 38/38 pass (platform-inference regression guard)</code>
- <code>Scope check: `grep -rn &#39;probeAndroidDeviceModels|probeAndroidPackages|authorizedAndroidSerial&#39; src --include=&#39;*.ts&#39;` returns no callers outside cdp/discovery.ts, confirming raw device_* tools stay unfenced</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `scripts/snapshot_state.sh:65` - The probe_device_listing comment claims a listing that could not be produced is &#34;an unknown state, not a verdict&#34; so a transient failure &#34;cannot masquerade as &#39;not booted&#39;&#34;, but after three exhausted attempts the helper returns 1 and both ios_device_is_booted/android_device_is_connected propagate that as device-absent, which can flip auto platform selection. This is the escalated Sol IMPORTANT residual; per the intent the auto-detect product behavior must not change in this PR, so the comment&#39;s overstated guarantee is left as-is pending that follow-up. Same comment is mirrored in the two synced plugin copies.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
