### PR TITLE
fix(core): do not treat a partial renderer scan as mounting evidence (#789)

### DIFF
--- a/.changeset/gh-789-partial-root-scan-mounting.md
+++ b/.changeset/gh-789-partial-root-scan-mounting.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-core": patch
+"rn-dev-agent-plugin": patch
+---
+
+An incomplete renderer-root scan (missing or malformed DevTools `renderers` registry plus the empty-ID early-exit) is no longer treated as proof the app is still mounting, so a live root on a sparse renderer ID above 5 keeps the legacy no-navigation result instead of `mounting: true`.

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -53149,7 +53149,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 43;
+var HELPERS_VERSION = 45;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -53196,7 +53196,10 @@ var INJECTED_HELPERS = `
 
   // Reset by every root-iteration pass; only valid when read synchronously
   // after the pass that produced the tree (many helpers share the iterators).
-  var lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+  // complete is true only when the renderer-ID loop finished without the
+  // empty-streak early-exit \u2014 empty roots are mounting evidence only then
+  // (GH #789).
+  var lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
 
   function computeUnscannedRendererIds() {
     try {
@@ -53234,7 +53237,7 @@ var INJECTED_HELPERS = `
   }
 
   function findActiveRenderer() {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
     var rendererIds = getRegisteredRendererIds(hook);
@@ -53260,6 +53263,7 @@ var INJECTED_HELPERS = `
         lastRootScan.rendererErrors++;
       }
     }
+    lastRootScan.complete = true;
     return null;
   }
 
@@ -53276,7 +53280,7 @@ var INJECTED_HELPERS = `
   // native renderer loop so user-registered portals stay lower priority
   // than React's own registry.
   function iterateAllRoots(cb) {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (hook && typeof hook.getFiberRoots === 'function') {
       var rendererIds = getRegisteredRendererIds(hook);
@@ -53285,6 +53289,7 @@ var INJECTED_HELPERS = `
         if (rendererIds.indexOf(fallbackId) === -1) rendererIds.push(fallbackId);
       }
       var emptyStreak = 0;
+      var abortedEarly = false;
       for (var rii = 0; rii < rendererIds.length; rii++) {
         var ri = rendererIds[rii];
         if (ri > lastRootScan.probedUpTo) lastRootScan.probedUpTo = ri;
@@ -53302,13 +53307,17 @@ var INJECTED_HELPERS = `
             }
           } else if (!usingRegisteredIds) {
             emptyStreak++;
-            if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && ri >= 5) break;
+            if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && ri >= 5) {
+              abortedEarly = true;
+              break;
+            }
           }
         } catch (_) {
           if (!usingRegisteredIds) emptyStreak++;
           lastRootScan.rendererErrors++;
         }
       }
+      lastRootScan.complete = !abortedEarly;
     }
     // GH #126 Gap B \u2014 extra-roots step. Runs AFTER the native renderer
     // loop (above) so user-registered portals are lower priority than
@@ -54023,14 +54032,17 @@ var INJECTED_HELPERS = `
       var mountHook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
       var mountHookUsable = !!(mountHook && typeof mountHook.getFiberRoots === 'function');
       var mountRoots = mountHookUsable ? findAllRootFibers() : [];
-      // Only a CLEAN scan is mounting evidence (throwing renderers can hide roots).
-      var mountScanClean = mountHookUsable && lastRootScan.rendererErrors === 0;
+      // Only a complete, clean scan is mounting evidence.
+      var mountScanClean = mountHookUsable && lastRootScan.complete && lastRootScan.rendererErrors === 0;
       if (mountScanClean && mountRoots.length === 0) {
         return JSON.stringify({
           error: 'App is still mounting \u2014 no React fiber roots exist yet (the bundle is likely still loading). Retry in ~2s.',
           mounting: true,
           retryInMs: 2000
         });
+      }
+      if (mountHookUsable && !lastRootScan.complete && mountRoots.length === 0) {
+        return JSON.stringify({ error: 'Navigation state not found. Is React Navigation or Expo Router installed?' });
       }
       var navFw = navDetectBundledFramework();
       if (navFw) {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -64343,7 +64343,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 43;
+    HELPERS_VERSION = 45;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -64390,7 +64390,10 @@ var init_injected_helpers = __esm({
 
   // Reset by every root-iteration pass; only valid when read synchronously
   // after the pass that produced the tree (many helpers share the iterators).
-  var lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+  // complete is true only when the renderer-ID loop finished without the
+  // empty-streak early-exit \u2014 empty roots are mounting evidence only then
+  // (GH #789).
+  var lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
 
   function computeUnscannedRendererIds() {
     try {
@@ -64428,7 +64431,7 @@ var init_injected_helpers = __esm({
   }
 
   function findActiveRenderer() {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
     var rendererIds = getRegisteredRendererIds(hook);
@@ -64454,6 +64457,7 @@ var init_injected_helpers = __esm({
         lastRootScan.rendererErrors++;
       }
     }
+    lastRootScan.complete = true;
     return null;
   }
 
@@ -64470,7 +64474,7 @@ var init_injected_helpers = __esm({
   // native renderer loop so user-registered portals stay lower priority
   // than React's own registry.
   function iterateAllRoots(cb) {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (hook && typeof hook.getFiberRoots === 'function') {
       var rendererIds = getRegisteredRendererIds(hook);
@@ -64479,6 +64483,7 @@ var init_injected_helpers = __esm({
         if (rendererIds.indexOf(fallbackId) === -1) rendererIds.push(fallbackId);
       }
       var emptyStreak = 0;
+      var abortedEarly = false;
       for (var rii = 0; rii < rendererIds.length; rii++) {
         var ri = rendererIds[rii];
         if (ri > lastRootScan.probedUpTo) lastRootScan.probedUpTo = ri;
@@ -64496,13 +64501,17 @@ var init_injected_helpers = __esm({
             }
           } else if (!usingRegisteredIds) {
             emptyStreak++;
-            if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && ri >= 5) break;
+            if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && ri >= 5) {
+              abortedEarly = true;
+              break;
+            }
           }
         } catch (_) {
           if (!usingRegisteredIds) emptyStreak++;
           lastRootScan.rendererErrors++;
         }
       }
+      lastRootScan.complete = !abortedEarly;
     }
     // GH #126 Gap B \u2014 extra-roots step. Runs AFTER the native renderer
     // loop (above) so user-registered portals are lower priority than
@@ -65217,14 +65226,17 @@ var init_injected_helpers = __esm({
       var mountHook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
       var mountHookUsable = !!(mountHook && typeof mountHook.getFiberRoots === 'function');
       var mountRoots = mountHookUsable ? findAllRootFibers() : [];
-      // Only a CLEAN scan is mounting evidence (throwing renderers can hide roots).
-      var mountScanClean = mountHookUsable && lastRootScan.rendererErrors === 0;
+      // Only a complete, clean scan is mounting evidence.
+      var mountScanClean = mountHookUsable && lastRootScan.complete && lastRootScan.rendererErrors === 0;
       if (mountScanClean && mountRoots.length === 0) {
         return JSON.stringify({
           error: 'App is still mounting \u2014 no React fiber roots exist yet (the bundle is likely still loading). Retry in ~2s.',
           mounting: true,
           retryInMs: 2000
         });
+      }
+      if (mountHookUsable && !lastRootScan.complete && mountRoots.length === 0) {
+        return JSON.stringify({ error: 'Navigation state not found. Is React Navigation or Expo Router installed?' });
       }
       var navFw = navDetectBundledFramework();
       if (navFw) {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -53149,7 +53149,7 @@ async function detectBridge(client2, evaluate = (expression) => client2.evaluate
 init_logger();
 
 // packages/rn-dev-agent-core/dist/injected-helpers.js
-var HELPERS_VERSION = 43;
+var HELPERS_VERSION = 45;
 var INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -53196,7 +53196,10 @@ var INJECTED_HELPERS = `
 
   // Reset by every root-iteration pass; only valid when read synchronously
   // after the pass that produced the tree (many helpers share the iterators).
-  var lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+  // complete is true only when the renderer-ID loop finished without the
+  // empty-streak early-exit \u2014 empty roots are mounting evidence only then
+  // (GH #789).
+  var lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
 
   function computeUnscannedRendererIds() {
     try {
@@ -53234,7 +53237,7 @@ var INJECTED_HELPERS = `
   }
 
   function findActiveRenderer() {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
     var rendererIds = getRegisteredRendererIds(hook);
@@ -53260,6 +53263,7 @@ var INJECTED_HELPERS = `
         lastRootScan.rendererErrors++;
       }
     }
+    lastRootScan.complete = true;
     return null;
   }
 
@@ -53276,7 +53280,7 @@ var INJECTED_HELPERS = `
   // native renderer loop so user-registered portals stay lower priority
   // than React's own registry.
   function iterateAllRoots(cb) {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (hook && typeof hook.getFiberRoots === 'function') {
       var rendererIds = getRegisteredRendererIds(hook);
@@ -53285,6 +53289,7 @@ var INJECTED_HELPERS = `
         if (rendererIds.indexOf(fallbackId) === -1) rendererIds.push(fallbackId);
       }
       var emptyStreak = 0;
+      var abortedEarly = false;
       for (var rii = 0; rii < rendererIds.length; rii++) {
         var ri = rendererIds[rii];
         if (ri > lastRootScan.probedUpTo) lastRootScan.probedUpTo = ri;
@@ -53302,13 +53307,17 @@ var INJECTED_HELPERS = `
             }
           } else if (!usingRegisteredIds) {
             emptyStreak++;
-            if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && ri >= 5) break;
+            if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && ri >= 5) {
+              abortedEarly = true;
+              break;
+            }
           }
         } catch (_) {
           if (!usingRegisteredIds) emptyStreak++;
           lastRootScan.rendererErrors++;
         }
       }
+      lastRootScan.complete = !abortedEarly;
     }
     // GH #126 Gap B \u2014 extra-roots step. Runs AFTER the native renderer
     // loop (above) so user-registered portals are lower priority than
@@ -54023,14 +54032,17 @@ var INJECTED_HELPERS = `
       var mountHook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
       var mountHookUsable = !!(mountHook && typeof mountHook.getFiberRoots === 'function');
       var mountRoots = mountHookUsable ? findAllRootFibers() : [];
-      // Only a CLEAN scan is mounting evidence (throwing renderers can hide roots).
-      var mountScanClean = mountHookUsable && lastRootScan.rendererErrors === 0;
+      // Only a complete, clean scan is mounting evidence.
+      var mountScanClean = mountHookUsable && lastRootScan.complete && lastRootScan.rendererErrors === 0;
       if (mountScanClean && mountRoots.length === 0) {
         return JSON.stringify({
           error: 'App is still mounting \u2014 no React fiber roots exist yet (the bundle is likely still loading). Retry in ~2s.',
           mounting: true,
           retryInMs: 2000
         });
+      }
+      if (mountHookUsable && !lastRootScan.complete && mountRoots.length === 0) {
+        return JSON.stringify({ error: 'Navigation state not found. Is React Navigation or Expo Router installed?' });
       }
       var navFw = navDetectBundledFramework();
       if (navFw) {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -64343,7 +64343,7 @@ var HELPERS_VERSION, INJECTED_HELPERS, NETWORK_HOOK_SCRIPT, NETWORK_CB_BUFFERED_
 var init_injected_helpers = __esm({
   "packages/rn-dev-agent-core/dist/injected-helpers.js"() {
     "use strict";
-    HELPERS_VERSION = 43;
+    HELPERS_VERSION = 45;
     INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -64390,7 +64390,10 @@ var init_injected_helpers = __esm({
 
   // Reset by every root-iteration pass; only valid when read synchronously
   // after the pass that produced the tree (many helpers share the iterators).
-  var lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+  // complete is true only when the renderer-ID loop finished without the
+  // empty-streak early-exit \u2014 empty roots are mounting evidence only then
+  // (GH #789).
+  var lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
 
   function computeUnscannedRendererIds() {
     try {
@@ -64428,7 +64431,7 @@ var init_injected_helpers = __esm({
   }
 
   function findActiveRenderer() {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
     var rendererIds = getRegisteredRendererIds(hook);
@@ -64454,6 +64457,7 @@ var init_injected_helpers = __esm({
         lastRootScan.rendererErrors++;
       }
     }
+    lastRootScan.complete = true;
     return null;
   }
 
@@ -64470,7 +64474,7 @@ var init_injected_helpers = __esm({
   // native renderer loop so user-registered portals stay lower priority
   // than React's own registry.
   function iterateAllRoots(cb) {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (hook && typeof hook.getFiberRoots === 'function') {
       var rendererIds = getRegisteredRendererIds(hook);
@@ -64479,6 +64483,7 @@ var init_injected_helpers = __esm({
         if (rendererIds.indexOf(fallbackId) === -1) rendererIds.push(fallbackId);
       }
       var emptyStreak = 0;
+      var abortedEarly = false;
       for (var rii = 0; rii < rendererIds.length; rii++) {
         var ri = rendererIds[rii];
         if (ri > lastRootScan.probedUpTo) lastRootScan.probedUpTo = ri;
@@ -64496,13 +64501,17 @@ var init_injected_helpers = __esm({
             }
           } else if (!usingRegisteredIds) {
             emptyStreak++;
-            if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && ri >= 5) break;
+            if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && ri >= 5) {
+              abortedEarly = true;
+              break;
+            }
           }
         } catch (_) {
           if (!usingRegisteredIds) emptyStreak++;
           lastRootScan.rendererErrors++;
         }
       }
+      lastRootScan.complete = !abortedEarly;
     }
     // GH #126 Gap B \u2014 extra-roots step. Runs AFTER the native renderer
     // loop (above) so user-registered portals are lower priority than
@@ -65217,14 +65226,17 @@ var init_injected_helpers = __esm({
       var mountHook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
       var mountHookUsable = !!(mountHook && typeof mountHook.getFiberRoots === 'function');
       var mountRoots = mountHookUsable ? findAllRootFibers() : [];
-      // Only a CLEAN scan is mounting evidence (throwing renderers can hide roots).
-      var mountScanClean = mountHookUsable && lastRootScan.rendererErrors === 0;
+      // Only a complete, clean scan is mounting evidence.
+      var mountScanClean = mountHookUsable && lastRootScan.complete && lastRootScan.rendererErrors === 0;
       if (mountScanClean && mountRoots.length === 0) {
         return JSON.stringify({
           error: 'App is still mounting \u2014 no React fiber roots exist yet (the bundle is likely still loading). Retry in ~2s.',
           mounting: true,
           retryInMs: 2000
         });
+      }
+      if (mountHookUsable && !lastRootScan.complete && mountRoots.length === 0) {
+        return JSON.stringify({ error: 'Navigation state not found. Is React Navigation or Expo Router installed?' });
       }
       var navFw = navDetectBundledFramework();
       if (navFw) {

--- a/packages/rn-dev-agent-core/dist/injected-helpers.js
+++ b/packages/rn-dev-agent-core/dist/injected-helpers.js
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 43;
+export const HELPERS_VERSION = 45;
 export const INJECTED_HELPERS = `
 (function() {
   var __HELPERS_VERSION__ = ${HELPERS_VERSION};
@@ -49,7 +49,10 @@ export const INJECTED_HELPERS = `
 
   // Reset by every root-iteration pass; only valid when read synchronously
   // after the pass that produced the tree (many helpers share the iterators).
-  var lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+  // complete is true only when the renderer-ID loop finished without the
+  // empty-streak early-exit — empty roots are mounting evidence only then
+  // (GH #789).
+  var lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
 
   function computeUnscannedRendererIds() {
     try {
@@ -87,7 +90,7 @@ export const INJECTED_HELPERS = `
   }
 
   function findActiveRenderer() {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
     var rendererIds = getRegisteredRendererIds(hook);
@@ -113,6 +116,7 @@ export const INJECTED_HELPERS = `
         lastRootScan.rendererErrors++;
       }
     }
+    lastRootScan.complete = true;
     return null;
   }
 
@@ -129,7 +133,7 @@ export const INJECTED_HELPERS = `
   // native renderer loop so user-registered portals stay lower priority
   // than React's own registry.
   function iterateAllRoots(cb) {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (hook && typeof hook.getFiberRoots === 'function') {
       var rendererIds = getRegisteredRendererIds(hook);
@@ -138,6 +142,7 @@ export const INJECTED_HELPERS = `
         if (rendererIds.indexOf(fallbackId) === -1) rendererIds.push(fallbackId);
       }
       var emptyStreak = 0;
+      var abortedEarly = false;
       for (var rii = 0; rii < rendererIds.length; rii++) {
         var ri = rendererIds[rii];
         if (ri > lastRootScan.probedUpTo) lastRootScan.probedUpTo = ri;
@@ -155,13 +160,17 @@ export const INJECTED_HELPERS = `
             }
           } else if (!usingRegisteredIds) {
             emptyStreak++;
-            if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && ri >= 5) break;
+            if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && ri >= 5) {
+              abortedEarly = true;
+              break;
+            }
           }
         } catch (_) {
           if (!usingRegisteredIds) emptyStreak++;
           lastRootScan.rendererErrors++;
         }
       }
+      lastRootScan.complete = !abortedEarly;
     }
     // GH #126 Gap B — extra-roots step. Runs AFTER the native renderer
     // loop (above) so user-registered portals are lower priority than
@@ -876,14 +885,17 @@ export const INJECTED_HELPERS = `
       var mountHook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
       var mountHookUsable = !!(mountHook && typeof mountHook.getFiberRoots === 'function');
       var mountRoots = mountHookUsable ? findAllRootFibers() : [];
-      // Only a CLEAN scan is mounting evidence (throwing renderers can hide roots).
-      var mountScanClean = mountHookUsable && lastRootScan.rendererErrors === 0;
+      // Only a complete, clean scan is mounting evidence.
+      var mountScanClean = mountHookUsable && lastRootScan.complete && lastRootScan.rendererErrors === 0;
       if (mountScanClean && mountRoots.length === 0) {
         return JSON.stringify({
           error: 'App is still mounting — no React fiber roots exist yet (the bundle is likely still loading). Retry in ~2s.',
           mounting: true,
           retryInMs: 2000
         });
+      }
+      if (mountHookUsable && !lastRootScan.complete && mountRoots.length === 0) {
+        return JSON.stringify({ error: 'Navigation state not found. Is React Navigation or Expo Router installed?' });
       }
       var navFw = navDetectBundledFramework();
       if (navFw) {

--- a/packages/rn-dev-agent-core/src/injected-helpers.ts
+++ b/packages/rn-dev-agent-core/src/injected-helpers.ts
@@ -2,7 +2,7 @@
 // whenever the injected surface changes; it flows into the IIFE's freshness
 // check (__RN_AGENT.__v) AND the post-injection log line, so they can never
 // drift (the log previously hard-coded a stale "v11").
-export const HELPERS_VERSION = 43;
+export const HELPERS_VERSION = 45;
 
 export const INJECTED_HELPERS = `
 (function() {
@@ -50,7 +50,10 @@ export const INJECTED_HELPERS = `
 
   // Reset by every root-iteration pass; only valid when read synchronously
   // after the pass that produced the tree (many helpers share the iterators).
-  var lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+  // complete is true only when the renderer-ID loop finished without the
+  // empty-streak early-exit — empty roots are mounting evidence only then
+  // (GH #789).
+  var lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
 
   function computeUnscannedRendererIds() {
     try {
@@ -88,7 +91,7 @@ export const INJECTED_HELPERS = `
   }
 
   function findActiveRenderer() {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (!hook || typeof hook.getFiberRoots !== 'function') return null;
     var rendererIds = getRegisteredRendererIds(hook);
@@ -114,6 +117,7 @@ export const INJECTED_HELPERS = `
         lastRootScan.rendererErrors++;
       }
     }
+    lastRootScan.complete = true;
     return null;
   }
 
@@ -130,7 +134,7 @@ export const INJECTED_HELPERS = `
   // native renderer loop so user-registered portals stay lower priority
   // than React's own registry.
   function iterateAllRoots(cb) {
-    lastRootScan = { rendererErrors: 0, probedUpTo: 0 };
+    lastRootScan = { rendererErrors: 0, probedUpTo: 0, complete: false };
     var hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
     if (hook && typeof hook.getFiberRoots === 'function') {
       var rendererIds = getRegisteredRendererIds(hook);
@@ -139,6 +143,7 @@ export const INJECTED_HELPERS = `
         if (rendererIds.indexOf(fallbackId) === -1) rendererIds.push(fallbackId);
       }
       var emptyStreak = 0;
+      var abortedEarly = false;
       for (var rii = 0; rii < rendererIds.length; rii++) {
         var ri = rendererIds[rii];
         if (ri > lastRootScan.probedUpTo) lastRootScan.probedUpTo = ri;
@@ -156,13 +161,17 @@ export const INJECTED_HELPERS = `
             }
           } else if (!usingRegisteredIds) {
             emptyStreak++;
-            if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && ri >= 5) break;
+            if (emptyStreak >= EARLY_EXIT_EMPTY_STREAK && ri >= 5) {
+              abortedEarly = true;
+              break;
+            }
           }
         } catch (_) {
           if (!usingRegisteredIds) emptyStreak++;
           lastRootScan.rendererErrors++;
         }
       }
+      lastRootScan.complete = !abortedEarly;
     }
     // GH #126 Gap B — extra-roots step. Runs AFTER the native renderer
     // loop (above) so user-registered portals are lower priority than
@@ -877,14 +886,17 @@ export const INJECTED_HELPERS = `
       var mountHook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
       var mountHookUsable = !!(mountHook && typeof mountHook.getFiberRoots === 'function');
       var mountRoots = mountHookUsable ? findAllRootFibers() : [];
-      // Only a CLEAN scan is mounting evidence (throwing renderers can hide roots).
-      var mountScanClean = mountHookUsable && lastRootScan.rendererErrors === 0;
+      // Only a complete, clean scan is mounting evidence.
+      var mountScanClean = mountHookUsable && lastRootScan.complete && lastRootScan.rendererErrors === 0;
       if (mountScanClean && mountRoots.length === 0) {
         return JSON.stringify({
           error: 'App is still mounting — no React fiber roots exist yet (the bundle is likely still loading). Retry in ~2s.',
           mounting: true,
           retryInMs: 2000
         });
+      }
+      if (mountHookUsable && !lastRootScan.complete && mountRoots.length === 0) {
+        return JSON.stringify({ error: 'Navigation state not found. Is React Navigation or Expo Router installed?' });
       }
       var navFw = navDetectBundledFramework();
       if (navFw) {

--- a/packages/rn-dev-agent-core/test/unit/gh-789-partial-root-scan-mounting.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-789-partial-root-scan-mounting.test.ts
@@ -1,0 +1,130 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import vm from 'node:vm';
+import { INJECTED_HELPERS } from '../../dist/injected-helpers.js';
+
+const LEGACY_MESSAGE = 'Navigation state not found. Is React Navigation or Expo Router installed?';
+const SPARSE_RENDERER_ID = 7;
+
+type Fiber = {
+  type?: { displayName?: string };
+  memoizedState?: unknown;
+  child?: Fiber | null;
+  sibling?: Fiber | null;
+};
+
+type NavState = {
+  routes: Array<{ name: string; params?: Record<string, unknown> }>;
+  index: number;
+};
+
+function mountedNavFiber(): Fiber {
+  const state: NavState = {
+    routes: [{ name: 'Home', params: {} }],
+    index: 0,
+  };
+  return {
+    type: { displayName: 'NavigationContainer' },
+    memoizedState: { memoizedState: state, next: null },
+    child: null,
+    sibling: null,
+  };
+}
+
+function createSandbox(hook: object | undefined, metroRegistry?: unknown) {
+  const sandbox: Record<string, unknown> = {
+    Array,
+    Object,
+    JSON,
+    Map,
+    Set,
+    WeakSet,
+    Error,
+    Date,
+    parseInt,
+    parseFloat,
+    String,
+    Number,
+    Boolean,
+    RegExp,
+    Symbol,
+    Promise,
+    setTimeout,
+    clearTimeout,
+    console: { log() {}, error() {}, warn() {}, info() {}, debug() {} },
+  };
+  sandbox.globalThis = sandbox;
+  if (hook !== undefined) sandbox.__REACT_DEVTOOLS_GLOBAL_HOOK__ = hook;
+  if (metroRegistry !== undefined) sandbox.__r = { getModules: () => metroRegistry };
+  vm.createContext(sandbox);
+  vm.runInContext(INJECTED_HELPERS, sandbox);
+  return sandbox as Record<string, any>;
+}
+
+function hookWithSparseRoot(opts: { renderers?: unknown }) {
+  const fiber = mountedNavFiber();
+  const hook: Record<string, unknown> = {
+    getFiberRoots: (rendererId: number) =>
+      rendererId === SPARSE_RENDERER_ID ? new Set([{ current: fiber }]) : new Set(),
+  };
+  if ('renderers' in opts) hook.renderers = opts.renderers;
+  return hook;
+}
+
+function parseNavState(sandbox: Record<string, any>) {
+  return JSON.parse(sandbox.__RN_AGENT.getNavState());
+}
+
+test('#789 malformed renderers registry + sparse root >5: legacy no-nav, never mounting', () => {
+  const sandbox = createSandbox(hookWithSparseRoot({ renderers: { keys: 1 } }));
+  const result = parseNavState(sandbox);
+  assert.equal(result.error, LEGACY_MESSAGE);
+  assert.notEqual(result.mounting, true);
+});
+
+test('#789 incomplete sparse scan ignores Metro navigation evidence', () => {
+  const sandbox = createSandbox(
+    hookWithSparseRoot({ renderers: { keys: 1 } }),
+    new Map([
+      [0, { verboseName: 'node_modules/react-native/index.js' }],
+      [1, { verboseName: 'node_modules/@react-navigation/native/lib/module/index.js' }],
+    ]),
+  );
+  const result = parseNavState(sandbox);
+  assert.equal(result.error, LEGACY_MESSAGE);
+  assert.notEqual(result.mounting, true);
+  assert.equal(result.frameworkDetected, undefined);
+});
+
+test('#789 missing renderers registry + sparse root >5: legacy no-nav, never mounting', () => {
+  const sandbox = createSandbox(hookWithSparseRoot({}));
+  const result = parseNavState(sandbox);
+  assert.equal(result.error, LEGACY_MESSAGE);
+  assert.notEqual(result.mounting, true);
+});
+
+test('#789 complete empty scan with a usable registry still reports mounting', () => {
+  const sandbox = createSandbox({
+    renderers: new Map([[1, {}]]),
+    getFiberRoots: () => new Set(),
+  });
+  const result = parseNavState(sandbox);
+  assert.match(result.error, /App is still mounting[\s\S]*[Rr]etry in ~2s/);
+  assert.equal(result.mounting, true);
+  assert.doesNotMatch(result.error, /Is React Navigation or Expo Router installed/);
+});
+
+test('#789 usable registry still discovers a sparse renderer ID above 5', () => {
+  const sandbox = createSandbox(
+    hookWithSparseRoot({
+      renderers: new Map([
+        [1, {}],
+        [SPARSE_RENDERER_ID, {}],
+      ]),
+    }),
+  );
+  const result = parseNavState(sandbox);
+  assert.equal(result.error, undefined);
+  assert.equal(result.routeName, 'Home');
+  assert.notEqual(result.mounting, true);
+});


### PR DESCRIPTION
## Summary
- Incomplete DevTools renderer-root scans (missing or malformed `renderers` registry plus the empty-ID early-exit) no longer count as proof the app is still mounting.
- `getNavState` returns the legacy no-navigation result before framework detection when the bounded scan did not complete and found no roots, including with Metro evidence for `@react-navigation`.
- Genuine mounting after a complete empty scan, and ordinary sparse-ID discovery with a usable registry, are unchanged.

Fixes https://github.com/Lykhoyda/rn-dev-agent/issues/789

## Test plan
- [x] Sandbox regression: malformed/missing registry + live root on renderer 7 returns the legacy message, never `mounting: true`
- [x] Same scenario with Metro `@react-navigation` bundle evidence still returns the legacy message
- [x] Complete empty scan with a usable registry still reports mounting
- [x] Usable registry still discovers a sparse renderer ID above 5
- [x] GH #525 mounting and GH #597 multi-renderer suites still pass (41/41 focused)