### PR TITLE
fix(core): preserve Unicode in Android text entry

### DIFF
--- a/.changeset/gh-635-android-unicode-text.md
+++ b/.changeset/gh-635-android-unicode-text.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-core": patch
+"rn-dev-agent-plugin": patch
+---
+
+Preserve arbitrary Unicode text in Android runner commands by declaring the JSON request body as UTF-8 before NanoHTTPD decodes it.

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -14994,7 +14994,7 @@ async function sendCommandOnce2(hostPort, body, timeoutMs) {
     resp = await fetchImpl2(`http://127.0.0.1:${hostPort}/command`, {
       method: "POST",
       headers: {
-        "content-type": "application/json",
+        "content-type": "application/json; charset=UTF-8",
         authorization: `Bearer ${capability}`
       },
       body: JSON.stringify(body),

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -36551,7 +36551,7 @@ async function sendCommandOnce2(hostPort, body, timeoutMs) {
     resp = await fetchImpl2(`http://127.0.0.1:${hostPort}/command`, {
       method: "POST",
       headers: {
-        "content-type": "application/json",
+        "content-type": "application/json; charset=UTF-8",
         authorization: `Bearer ${capability}`
       },
       body: JSON.stringify(body),

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -14994,7 +14994,7 @@ async function sendCommandOnce2(hostPort, body, timeoutMs) {
     resp = await fetchImpl2(`http://127.0.0.1:${hostPort}/command`, {
       method: "POST",
       headers: {
-        "content-type": "application/json",
+        "content-type": "application/json; charset=UTF-8",
         authorization: `Bearer ${capability}`
       },
       body: JSON.stringify(body),

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -36551,7 +36551,7 @@ async function sendCommandOnce2(hostPort, body, timeoutMs) {
     resp = await fetchImpl2(`http://127.0.0.1:${hostPort}/command`, {
       method: "POST",
       headers: {
-        "content-type": "application/json",
+        "content-type": "application/json; charset=UTF-8",
         authorization: `Bearer ${capability}`
       },
       body: JSON.stringify(body),

--- a/packages/rn-dev-agent-core/dist/runners/rn-android-runner-client.js
+++ b/packages/rn-dev-agent-core/dist/runners/rn-android-runner-client.js
@@ -1216,7 +1216,7 @@ async function sendCommandOnce(hostPort, body, timeoutMs) {
         resp = await fetchImpl(`http://127.0.0.1:${hostPort}/command`, {
             method: 'POST',
             headers: {
-                'content-type': 'application/json',
+                'content-type': 'application/json; charset=UTF-8',
                 authorization: `Bearer ${capability}`,
             },
             body: JSON.stringify(body),

--- a/packages/rn-dev-agent-core/src/runners/rn-android-runner-client.ts
+++ b/packages/rn-dev-agent-core/src/runners/rn-android-runner-client.ts
@@ -1722,7 +1722,7 @@ async function sendCommandOnce(
     resp = await fetchImpl(`http://127.0.0.1:${hostPort}/command`, {
       method: 'POST',
       headers: {
-        'content-type': 'application/json',
+        'content-type': 'application/json; charset=UTF-8',
         authorization: `Bearer ${capability}`,
       },
       body: JSON.stringify(body),

--- a/packages/rn-dev-agent-core/test/unit/gh-635-android-unicode-transport.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-635-android-unicode-transport.test.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import {
+  _setAndroidRunnerStateForTest,
+  _setFetchForTest,
+  runAndroid,
+} from '../../dist/runners/rn-android-runner-client.js';
+import {
+  REQUIRED_ANDROID_COMMANDS,
+  REQUIRED_ANDROID_FEATURES,
+} from '../../dist/runners/protocol.js';
+
+const TEXT_SAMPLES = ['Friedrichstraße', '東京 👋🏽', 'quote: " slash: \\ newline:\n tab:\t', ''];
+
+function setRunnerState(): void {
+  _setAndroidRunnerStateForTest({
+    schemaVersion: 1,
+    hostPort: 22089,
+    devicePort: 22089,
+    pid: process.pid,
+    deviceId: 'emulator-635',
+    bundleId: 'dev.test',
+    startedAt: new Date(0).toISOString(),
+    protocolVersion: 2,
+  });
+}
+
+function healthResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      protocolVersion: 2,
+      commands: [...REQUIRED_ANDROID_COMMANDS],
+      capabilities: [...REQUIRED_ANDROID_FEATURES],
+    }),
+  );
+}
+
+afterEach(() => {
+  _setAndroidRunnerStateForTest(null);
+  _setFetchForTest(globalThis.fetch);
+});
+
+test('Android runner transport declares UTF-8 and preserves arbitrary JSON text exactly', async () => {
+  const received: string[] = [];
+  setRunnerState();
+  _setFetchForTest(async (url, init) => {
+    if (String(url).endsWith('/health')) return healthResponse();
+
+    const headers = new Headers(init?.headers);
+    assert.equal(headers.get('content-type'), 'application/json; charset=UTF-8');
+    const body = JSON.parse(String(init?.body)) as { text: string };
+    received.push(body.text);
+    return new Response(JSON.stringify({ ok: true, data: { typed: true } }));
+  });
+
+  for (const text of TEXT_SAMPLES) {
+    const result = await runAndroid({
+      command: 'fill',
+      bundleId: 'dev.test',
+      text,
+      snapshotIdentifier: 'address-input',
+      snapshotElementType: 'android.widget.EditText',
+    });
+    assert.equal(result.isError, undefined);
+  }
+
+  assert.deepEqual(received, TEXT_SAMPLES);
+});
+
+test('Android runner transport refuses a failed Unicode fill once without disclosing its text', async () => {
+  const secret = 'Friedrichstraße "東京" 👋🏽';
+  const diagnostics: string[] = [];
+  const originalError = console.error;
+  const originalWarn = console.warn;
+  let commandPosts = 0;
+  console.error = (...args: unknown[]) => diagnostics.push(args.map(String).join(' '));
+  console.warn = (...args: unknown[]) => diagnostics.push(args.map(String).join(' '));
+  setRunnerState();
+  _setFetchForTest(async (url) => {
+    if (String(url).endsWith('/health')) return healthResponse();
+    commandPosts += 1;
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error: {
+          code: 'SET_TEXT_REJECTED',
+          message: 'Bound field ignored ACTION_SET_TEXT.',
+          mutation: 'none',
+        },
+      }),
+    );
+  });
+
+  try {
+    const result = await runAndroid({
+      command: 'fill',
+      bundleId: 'dev.test',
+      text: secret,
+      snapshotIdentifier: 'address-input',
+      snapshotElementType: 'android.widget.EditText',
+    });
+
+    assert.equal(result.isError, true);
+    assert.equal(commandPosts, 1);
+    assert.doesNotMatch(result.content[0]!.text, new RegExp(secret));
+    assert.doesNotMatch(diagnostics.join('\n'), new RegExp(secret));
+  } finally {
+    console.error = originalError;
+    console.warn = originalWarn;
+  }
+});


### PR DESCRIPTION
## Intent

Fix and ship GitHub issue 635 from the exact current origin/main: reproduce and isolate the Android UIAutomator text-entry failure where Friedrichstraße became Friedrichstra??e, separating the initiating text-entry path, any environment or keyboard masking condition, and visible field corruption; compare the failing non-ASCII path with a proven ASCII path, inspect encoding boundaries and relevant history, run the smallest counterfactual distinguishing transport, shell quoting, UIAutomator, and app-side causes, actively seek disconfirming evidence, and treat autocomplete matching corrupted text as masking rather than success. Preserve arbitrary Unicode exactly through the supported Android text-entry path, including ß and at least one multi-byte non-Latin or emoji case at the proven boundary. Do not weaken selector authority, target freshness, secret redaction, replay protection, or field verification. Do not assume a UTF-8 fallback before identifying the earliest failing boundary; use the smallest correction explaining both failing and proven paths. Add behavioral regressions that fail before the fix and cover quoting, empty and special text, failure or refusal behavior, and non-disclosure of field contents in logs. Update generated artifacts only through repository-authoritative generators, include required one-sentence changesets, and keep the branch single-story. The bounded task-owned rn-qa live-proof attempts are exhausted: native control refused because install authority was not proven, and private-server instrumentation could not see the leased device; the lease and all owned infrastructure were fully cleaned. Do not retry or alter shared device infrastructure, do not present hermetic coverage as live proof, and explicitly disclose that no faithful Android device proof was obtained so independent follow-up QA can perform it. If validation requires a product-contract decision or device evidence, escalate; otherwise carry a green PR to completion. Never merge.

## What Changed

- Declare Android runner JSON command bodies as UTF-8 so Unicode text is preserved during text entry.
- Add regressions covering German, non-Latin, emoji, quoted, escaped, and empty text values, plus single-attempt refusal and content redaction on failure.
- Refresh generated core and host runtimes and add patch changesets for the core and plugin packages.

## Risk Assessment

✅ Low: The narrowly scoped charset declaration fixes NanoHTTPD’s verified US-ASCII decoding default at the shared command boundary without altering authority, replay, selector, verification, or redaction behavior.

## Testing

No baseline commands were supplied as already run; after repairing the isolated worktree with an immutable install, the core build, focused transport/fill-truth/authority/replay tests, targeted native text-recipe test, and real NanoHTTPD counterfactual all passed, with a reviewer-visible transcript captured, but no screenshot or faithful live Android field proof was possible because the authoritative intent forbids retrying the exhausted device infrastructure.

<details>
<summary>Evidence: NanoHTTPD transport-boundary transcript</summary>

```text
GH-635 NanoHTTPD 2.3.1 transport-boundary evidence
Boundary: public runAndroid(fill) -> HTTP JSON -> real NanoHTTPD parseBody(postData)
No Android device/UIAutomator/app field is exercised by this hermetic check.

LEGACY  ASCII                exact=true  charset="application/json" replacements=0 sent="Friedrichstrasse" received="Friedrichstrasse"
LEGACY  German sharp-s       exact=false charset="application/json" replacements=2 sent="Friedrichstraße" received="Friedrichstra��e"
LEGACY  Japanese plus emoji  exact=false charset="application/json" replacements=14 sent="東京 👋🏽" received="������ ��������"

FIXED   ASCII                exact=true  charset="application/json; charset=UTF-8" replacements=0 sent="Friedrichstrasse" received="Friedrichstrasse"
FIXED   German sharp-s       exact=true  charset="application/json; charset=UTF-8" replacements=0 sent="Friedrichstraße" received="Friedrichstraße"
FIXED   Japanese plus emoji  exact=true  charset="application/json; charset=UTF-8" replacements=0 sent="東京 👋🏽" received="東京 👋🏽"
FIXED   JSON special text    exact=true  charset="application/json; charset=UTF-8" replacements=0 sent="quote: \" slash: \\ newline:\n tab:\t" received="quote: \" slash: \\ newline:\n tab:\t"
FIXED   Empty clear          exact=true  charset="application/json; charset=UTF-8" replacements=0 sent="" received=""

RESULT: legacy ASCII survives, legacy Unicode corrupts at NanoHTTPD decoding,
        and the supported runAndroid(fill) path preserves every sample exactly.
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (6m3s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2a3c94a677e1778fea50ece251023b982f053992","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ No faithful Android-device proof was obtained, and the exhausted shared-device paths were not retried as required. The evidence reaches the real NanoHTTPD decoder and proves the earliest corruption boundary, but it does not visibly fill and read back an Android app field; independent QA should verify Friedrichstraße and 東京 👋🏽 through device_fill on an authoritative device.
- <code>`corepack yarn build:core` (initially could not start because the isolated worktree lacked Yarn install-state)</code>
- `corepack yarn install --immutable`
- `corepack yarn build:core`
- `node --test packages/rn-dev-agent-core/test/unit/gh-635-android-unicode-transport.test.ts`
- `node --test --test-name-pattern='wrapper binds its inner input|final verification uses the fill operation token|duplicate wrapper mapping rejects|empty text is a verified clear|observed SET_TEXT_REJECTED requires independent verification|android parity|no envelope ever echoes' packages/rn-dev-agent-core/test/unit/gh-581-fill-truth.test.ts`
- `node --test packages/rn-dev-agent-core/test/unit/story-14-android-recovery.test.ts packages/rn-dev-agent-core/test/unit/session/runner-capability.test.ts`
- <code>Compiled `NanoBoundaryServer.java` against NanoHTTPD 2.3.1 and ran `verify-nano-boundary.mjs` against the production Android runner client</code>
- `./gradlew :app:testDebugUnitTest --tests 'dev.lykhoyda.rndevagent.androidrunner.TextInputRecipeTest' --no-daemon`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ The required disclosure that no faithful Android device proof was obtained belongs in the future PR, outside this phase; include it so independent Android QA can follow up.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
