### PR TITLE
test(core): expand ffmpeg exit contract receipts

### DIFF
--- a/packages/rn-dev-agent-core/test/integration/ensure-ffmpeg-exit-contract.test.ts
+++ b/packages/rn-dev-agent-core/test/integration/ensure-ffmpeg-exit-contract.test.ts
@@ -22,15 +22,50 @@ for (const [label, helper] of [
     const receipt = JSON.parse(stdout.trim()) as {
       status: string;
       helper: string;
-      cases: Array<{ case: string; expectedExit: number; actualExit: number }>;
+      cases: Array<{
+        case: string;
+        initiatingCondition: string;
+        pathMasking: string;
+        expectedExit: number;
+        actualExit: number;
+        skipGuidanceOnStderr: boolean;
+      }>;
     };
     assert.equal(receipt.status, 'passed');
     assert.equal(receipt.helper, label);
     assert.deepEqual(receipt.cases, [
-      { case: 'pre-installed', expectedExit: 0, actualExit: 0 },
-      { case: 'homebrew-install-success', expectedExit: 0, actualExit: 0 },
-      { case: 'homebrew-install-failure', expectedExit: 1, actualExit: 1 },
-      { case: 'homebrew-absent', expectedExit: 1, actualExit: 1 },
+      {
+        case: 'pre-installed',
+        initiatingCondition: 'ffmpeg already installed',
+        pathMasking: 'host ffmpeg and brew masked; ffmpeg stub exposed',
+        expectedExit: 0,
+        actualExit: 0,
+        skipGuidanceOnStderr: false,
+      },
+      {
+        case: 'homebrew-install-success',
+        initiatingCondition: 'ffmpeg absent; Homebrew install succeeds',
+        pathMasking: 'host ffmpeg and brew masked; brew stub exposed',
+        expectedExit: 0,
+        actualExit: 0,
+        skipGuidanceOnStderr: false,
+      },
+      {
+        case: 'homebrew-install-failure',
+        initiatingCondition: 'ffmpeg absent; Homebrew install fails',
+        pathMasking: 'host ffmpeg and brew masked; failing brew stub exposed',
+        expectedExit: 1,
+        actualExit: 1,
+        skipGuidanceOnStderr: true,
+      },
+      {
+        case: 'homebrew-absent',
+        initiatingCondition: 'ffmpeg and Homebrew absent',
+        pathMasking: 'host ffmpeg and brew masked; no command stubs exposed',
+        expectedExit: 1,
+        actualExit: 1,
+        skipGuidanceOnStderr: true,
+      },
     ]);
   });
 }

--- a/scripts/test/ensure-ffmpeg.test.sh
+++ b/scripts/test/ensure-ffmpeg.test.sh
@@ -25,10 +25,12 @@ make_stub() {
 
 run_case() {
   local name="$1"
-  local expected_status="$2"
-  local ffmpeg_body="$3"
-  local brew_body="$4"
-  local expect_skip="$5"
+  local initiating_condition="$2"
+  local path_masking="$3"
+  local expected_status="$4"
+  local ffmpeg_body="$5"
+  local brew_body="$6"
+  local expect_skip="$7"
   local stubs="$TMP/$name/stubs"
   local stdout="$TMP/$name/stdout"
   local stderr="$TMP/$name/stderr"
@@ -58,15 +60,15 @@ run_case() {
     fail "$name: unexpected skip-GIF guidance"
   fi
 
-  CASE_RECEIPTS="${CASE_RECEIPTS}${CASE_RECEIPTS:+,}{\"case\":\"$name\",\"expectedExit\":$expected_status,\"actualExit\":$actual_status}"
+  CASE_RECEIPTS="${CASE_RECEIPTS}${CASE_RECEIPTS:+,}{\"case\":\"$name\",\"initiatingCondition\":\"$initiating_condition\",\"pathMasking\":\"$path_masking\",\"expectedExit\":$expected_status,\"actualExit\":$actual_status,\"skipGuidanceOnStderr\":$expect_skip}"
 }
 
 [ -f "$SCRIPT" ] || fail "helper not found: $SCRIPT"
 
 CASE_RECEIPTS=""
-run_case "pre-installed" 0 'echo "ffmpeg version test"; exit 0' '' false
-run_case "homebrew-install-success" 0 '' '[ "$1" = install ] && [ "$2" = ffmpeg ]; exit $?' false
-run_case "homebrew-install-failure" 1 '' 'exit 42' true
-run_case "homebrew-absent" 1 '' '' true
+run_case "pre-installed" "ffmpeg already installed" "host ffmpeg and brew masked; ffmpeg stub exposed" 0 'echo "ffmpeg version test"; exit 0' '' false
+run_case "homebrew-install-success" "ffmpeg absent; Homebrew install succeeds" "host ffmpeg and brew masked; brew stub exposed" 0 '' '[ "$1" = install ] && [ "$2" = ffmpeg ]; exit $?' false
+run_case "homebrew-install-failure" "ffmpeg absent; Homebrew install fails" "host ffmpeg and brew masked; failing brew stub exposed" 1 '' 'exit 42' true
+run_case "homebrew-absent" "ffmpeg and Homebrew absent" "host ffmpeg and brew masked; no command stubs exposed" 1 '' '' true
 
 printf '{"status":"passed","helper":"%s","cases":[%s]}\n' "$LABEL" "$CASE_RECEIPTS"


### PR DESCRIPTION
## Intent

Fix GitHub issue 598 so ensure-ffmpeg exits 0 when ffmpeg is already available or Homebrew installs it successfully, and returns one consistent non-zero status when Homebrew installation fails or Homebrew is absent, while preserving the GIF conversion will be skipped stderr guidance. Cover all four branches deterministically in an isolated executable shell regression test that masks host ffmpeg and Homebrew, and explicitly reports the initiating condition, PATH masking, exit code, and stderr guidance. Preserve existing caller behavior and make no unrelated changes. Deliver through a green pull request.

## What Changed

- Expand the isolated ffmpeg regression receipt with each branch’s initiating condition, PATH masking, expected and actual exit code, and stderr guidance result.
- Assert the complete four-branch receipt for both source and packaged helpers.

## Risk Assessment

✅ Low: The test-only change is well-bounded and accurately reports all four executable helper outcomes while preserving the existing caller contract.

## Testing

No baseline results were supplied; the focused Node integration test and direct isolated-PATH shell runs passed for both helper copies, JSON receipts captured every condition, exit code, PATH mask, and stderr-guidance result, and the same harness reproduced the historical exit-0 defect.

<details>
<summary>Evidence: Source helper four-branch receipt</summary>

```text
{"status":"passed","helper":"source","cases":[{"case":"pre-installed","initiatingCondition":"ffmpeg already installed","pathMasking":"host ffmpeg and brew masked; ffmpeg stub exposed","expectedExit":0,"actualExit":0,"skipGuidanceOnStderr":false},{"case":"homebrew-install-success","initiatingCondition":"ffmpeg absent; Homebrew install succeeds","pathMasking":"host ffmpeg and brew masked; brew stub exposed","expectedExit":0,"actualExit":0,"skipGuidanceOnStderr":false},{"case":"homebrew-install-failure","initiatingCondition":"ffmpeg absent; Homebrew install fails","pathMasking":"host ffmpeg and brew masked; failing brew stub exposed","expectedExit":1,"actualExit":1,"skipGuidanceOnStderr":true},{"case":"homebrew-absent","initiatingCondition":"ffmpeg and Homebrew absent","pathMasking":"host ffmpeg and brew masked; no command stubs exposed","expectedExit":1,"actualExit":1,"skipGuidanceOnStderr":true}]}
```
</details>
<details>
<summary>Evidence: Packaged helper four-branch receipt</summary>

```text
{"status":"passed","helper":"packaged","cases":[{"case":"pre-installed","initiatingCondition":"ffmpeg already installed","pathMasking":"host ffmpeg and brew masked; ffmpeg stub exposed","expectedExit":0,"actualExit":0,"skipGuidanceOnStderr":false},{"case":"homebrew-install-success","initiatingCondition":"ffmpeg absent; Homebrew install succeeds","pathMasking":"host ffmpeg and brew masked; brew stub exposed","expectedExit":0,"actualExit":0,"skipGuidanceOnStderr":false},{"case":"homebrew-install-failure","initiatingCondition":"ffmpeg absent; Homebrew install fails","pathMasking":"host ffmpeg and brew masked; failing brew stub exposed","expectedExit":1,"actualExit":1,"skipGuidanceOnStderr":true},{"case":"homebrew-absent","initiatingCondition":"ffmpeg and Homebrew absent","pathMasking":"host ffmpeg and brew masked; no command stubs exposed","expectedExit":1,"actualExit":1,"skipGuidanceOnStderr":true}]}
```
</details>
<details>
<summary>Evidence: Historical regression reproduction</summary>

<code>Historical pre-fix contract run&#10;Harness exit: 1 (expected failure)&#10;FAIL: homebrew-absent: expected exit 1, got 0; stderr: Warning: ffmpeg not found and Homebrew not available. GIF conversion will be skipped.&#10;Install manually: brew install ffmpeg</code>

```text
Historical pre-fix contract run
Harness exit: 1 (expected failure)
FAIL: homebrew-absent: expected exit 1, got 0; stderr: Warning: ffmpeg not found and Homebrew not available. GIF conversion will be skipped.
Install manually: brew install ffmpeg
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f2d1c983befb221344555112fc46a8644d0ce2f8","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --test test/integration/ensure-ffmpeg-exit-contract.test.ts` from `packages/rn-dev-agent-core`</code>
- `bash scripts/test/ensure-ffmpeg.test.sh scripts/ensure-ffmpeg.sh source`
- `bash scripts/test/ensure-ffmpeg.test.sh packages/claude-plugin/scripts/ensure-ffmpeg.sh packaged`
- <code>Historical regression reproduction using `bash scripts/test/ensure-ffmpeg.test.sh &lt;pre-fix-helper&gt; pre-fix`</code>
- <code>Inspected `git diff --name-status a06eebb338d57d42dfd138ae39dd6271a80627ba..f2d1c983befb221344555112fc46a8644d0ce2f8` and confirmed only the focused regression tests changed</code>
- <code>Verified `git status --short` remained clean after testing</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
