### PR TITLE
feat(core): add fail-stop login prologue guardrails

### DIFF
--- a/.changeset/tidy-login-prologue.md
+++ b/.changeset/tidy-login-prologue.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-core": patch
+"rn-dev-agent-plugin": patch
+---
+
+The login prologue now requires the exact user-login action to produce a fresh passing RunRecord, terminally gates session mutations on failure, and records auditable replay timings and supervisor overrides.

--- a/.changeset/tidy-login-prologue.md
+++ b/.changeset/tidy-login-prologue.md
@@ -3,4 +3,4 @@
 "rn-dev-agent-plugin": patch
 ---
 
-The login prologue remains a fail-stop navigation helper: it requires a fresh user-login RunRecord, terminally blocks credential fallbacks, and coexists with locked e2e login proof. A passing helper is not PR proof.
+The login prologue remains a fail-stop navigation helper that requires a fresh user-login RunRecord, terminally blocks credential fallbacks, and coexists with exact locked e2e login proof without serving as PR proof.

--- a/.changeset/tidy-login-prologue.md
+++ b/.changeset/tidy-login-prologue.md
@@ -3,4 +3,4 @@
 "rn-dev-agent-plugin": patch
 ---
 
-The login prologue now requires the exact user-login action to produce a fresh passing RunRecord, terminally gates session mutations on failure, and records auditable replay timings and supervisor overrides.
+The login prologue remains a fail-stop navigation helper: it requires a fresh user-login RunRecord, terminally blocks credential fallbacks, and coexists with locked e2e login proof. A passing helper is not PR proof.

--- a/CLAUDE-MD-TEMPLATE.md
+++ b/CLAUDE-MD-TEMPLATE.md
@@ -48,8 +48,8 @@ exist as YAML).
    `/rn-dev-agent:run-action <flow-name> [-e KEY=VALUE …]` — pre-flights
    mutates flag, appId match, parameter coverage, action engine pin, and
    selector compatibility; it resolves pin-cache maestro-runner `>= 1.1.24` from
-   rn-dev-agent's versioned pin-cache. A passing replay IS your evidence —
-   skip ahead to capturing proof.
+   rn-dev-agent's versioned pin-cache. For non-login actions, a passing replay
+   IS your evidence — skip ahead to capturing proof.
 3. **Only if no non-login match (or replay fails with a concrete error):** fall back to
    manual primitives (`device_press` / `device_fill` / `device_find`). When
    you do, **end the session by persisting the verified flow** as a new YAML
@@ -175,15 +175,14 @@ The artifact-first rule generalizes from "replay if exact match" to
    `produces: { authenticated: true, route: home }` is the right
    prologue when current state is `LoginScreen` and the user wants
    anything that requires auth — even if the user's task isn't "log in"
-   per se. Replay that action via `cdp_run_action`. Re-verify state.
-   Then continue with interactive `cdp_*` / `device_*` tools for the
-   novel part.
+   per se. Replay it through `cdp_login_prologue`. Re-verify state. Then
+   continue with interactive `cdp_*` / `device_*` tools for the novel part.
 
 3. **No false-binary fallbacks.** Never fall back to a fully-manual
    walk when a partial replay (login prologue, onboarding skip, locale
-   set) covers half the work. The cost of one failed replay attempt is
-   `cdp_run_action`'s auto-repair budget (3/24h); the cost of a fully
-   manual walk is 30s+ of context-burning device interaction.
+   set) covers half the work. For non-login gaps, one failed replay attempt
+   costs `cdp_run_action`'s auto-repair budget (3/24h); a login-prologue failure
+   is terminal. A fully manual walk costs 30s+ of context-burning interaction.
 
 **Example — user says "go to home and tap the cart badge":**
 

--- a/CLAUDE-MD-TEMPLATE.md
+++ b/CLAUDE-MD-TEMPLATE.md
@@ -50,11 +50,18 @@ exist as YAML).
    selector compatibility; it resolves pin-cache maestro-runner `>= 1.1.24` from
    rn-dev-agent's versioned pin-cache. A passing replay IS your evidence —
    skip ahead to capturing proof.
-3. **Only if no match (or replay fails with a concrete error):** fall back to
+3. **Only if no non-login match (or replay fails with a concrete error):** fall back to
    manual primitives (`device_press` / `device_fill` / `device_find`). When
    you do, **end the session by persisting the verified flow** as a new YAML
    under `<test-app>/.rn-agent/actions/<feature-slug>.yaml` so the next session
    starts at step 2, not step 3.
+
+Authentication is fail-stop: when login is required, call
+`cdp_login_prologue`. It inventories learned actions, resolves only the exact
+`user-login` action, and requires a fresh passing RunRecord. Any missing action,
+runner drift, selector failure, or timeout returns `LOGIN_PROLOGUE_BLOCKED`.
+Do not continue with credentials, ad-hoc Maestro, navigation shortcuts, or
+store mutation after that result.
 
 Manual walks are a fallback, not a default. Codified in
 `feedback_execute_artifacts_before_manual.md`. Enforced as Step 0 of
@@ -76,18 +83,19 @@ manual when state mismatches; never re-walk a flow you already have.
    relevant slice. Note any mismatch with the expected starting state.
 2. **Compose action + manual.** If current state ≠ expected start, scan
    `list-learned-actions` for an action whose `produces` covers the gap.
-   Replay via `cdp_run_action`. Re-verify state. Then continue
+   Replay via `cdp_run_action`; for authentication, use
+   `cdp_login_prologue`. Re-verify state. Then continue
    interactively for the novel part.
 3. **No fully-manual fallback when partial replay would cover half the work.**
-   Login is the cardinal example — if a saved login action exists, use it
-   as a prologue, never re-walk login interactively.
+   Login is the cardinal example — enter through `cdp_login_prologue` and
+   never re-walk login interactively if the exact action is absent or fails.
 
 **Worked example.** User: "tap the cart badge."
 
 - Agent: `cdp_navigation_state` → `LoginScreen` (mismatch with home)
 - Agent: `list-learned-actions` → finds `user-login` with
   `produces: { authenticated: true, route: home }`
-- Agent: `cdp_run_action({ id: "user-login", params: { EMAIL, PASSWORD } })`
+- Agent: `cdp_login_prologue({ params: { EMAIL, PASSWORD } })` → fresh passing RunRecord
 - Agent: `cdp_navigation_state` → `HomeScreen` (state delta closed)
 - Agent: `cdp_component_tree({ filter: "cart" })` → finds `cart-badge` ref
 - Agent: `device_press({ ref: "cart-badge" })`
@@ -182,8 +190,7 @@ The artifact-first rule generalizes from "replay if exact match" to
 2. /rn-dev-agent:list-learned-actions  (or read .rn-agent/actions/ directly)
                                     → finds `user-login` with
                                       produces: { authenticated: true, route: home }
-3. cdp_run_action({                 (deterministic prologue, ~4s)
-     id: "user-login",
+3. cdp_login_prologue({             (deterministic fail-stop prologue)
      params: { EMAIL, PASSWORD }
    })
 4. cdp_navigation_state             → returns "HomeScreen" (state delta closed)
@@ -564,10 +571,9 @@ the runner's settle engine.
 
 Before testing **auth-gated features:**
 1. `cdp_navigation_state` — check if on a login screen
-2. Scan `/rn-dev-agent:list-learned-actions login` — a saved login action with `produces: { authenticated: true }` is the preferred prologue (replay via `cdp_run_action`, ~4s; see Hybrid composition)
-3. If no compatible owned action exists, stop and report authentication as blocked. Do not use manual login, `.maestro` flows, ambient runners, or `cdp_auto_login` as an automatic fallback.
-4. Only when the user explicitly authorizes legacy per-call navigation recovery may `cdp_auto_login` run. It is never durable login authority or PR proof; create or migrate an owned compatible action before proof.
-5. `cdp_navigation_state` — verify arrival at home/target screen
+2. Call `cdp_login_prologue` — it inventories and resolves the exact `user-login` action itself
+3. Require `state: "passed"` plus a fresh passing `runRecord`; only then continue
+4. On `LOGIN_PROLOGUE_BLOCKED`, stop the journey; never fall through to manual credentials, `cdp_auto_login`, or ad-hoc Maestro
 
 Before testing **permission-gated features:**
 1. `device_permission(action="query", permission="<name>")` — check current state

--- a/CLAUDE-MD-TEMPLATE.md
+++ b/CLAUDE-MD-TEMPLATE.md
@@ -58,10 +58,12 @@ exist as YAML).
 
 Authentication is fail-stop: when login is required, call
 `cdp_login_prologue`. It inventories learned actions, resolves only the exact
-`user-login` action, and requires a fresh passing RunRecord. Any missing action,
-runner drift, selector failure, or timeout returns `LOGIN_PROLOGUE_BLOCKED`.
-Do not continue with credentials, ad-hoc Maestro, navigation shortcuts, or
-store mutation after that result.
+`user-login` action, and requires a fresh passing RunRecord. That result is a
+navigation helper, not PR proof. Any missing action, runner drift, selector
+failure, or timeout returns `LOGIN_PROLOGUE_BLOCKED`. Do not continue with
+credentials, ad-hoc Maestro, navigation shortcuts, or store mutation after
+that result. Formal login proof is `cdp_lock_e2e_test` / `cdp_run_e2e_suite` on
+the exact candidate; helper and locked tests coexist without sharing that proof.
 
 Manual walks are a fallback, not a default. Codified in
 `feedback_execute_artifacts_before_manual.md`. Enforced as Step 0 of
@@ -572,8 +574,9 @@ the runner's settle engine.
 Before testing **auth-gated features:**
 1. `cdp_navigation_state` — check if on a login screen
 2. Call `cdp_login_prologue` — it inventories and resolves the exact `user-login` action itself
-3. Require `state: "passed"` plus a fresh passing `runRecord`; only then continue
+3. Require `state: "passed"` plus a fresh passing `runRecord`; only then continue. Treat that pass as a navigation helper, not PR proof
 4. On `LOGIN_PROLOGUE_BLOCKED`, stop the journey; never fall through to manual credentials, `cdp_auto_login`, or ad-hoc Maestro
+5. Formal login proof is locking and running the login e2e on the exact candidate (`cdp_lock_e2e_test` / `cdp_run_e2e_suite`)
 
 Before testing **permission-gated features:**
 1. `device_permission(action="query", permission="<name>")` — check current state

--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ The plugin exposes MCP tools across six families ([full reference](https://lykho
 | **Session** | Fence one worktree, Metro, app, device, runner, Observe UI, and proof run | `rn_session` |
 | **CDP** | React internals via Chrome DevTools Protocol | `cdp_status`, `cdp_component_tree`, `cdp_store_state`, `cdp_evaluate`, `cdp_native_errors`, `cdp_navigate`, `collect_logs` |
 | **Device** | Native interaction with the simulator/emulator | `device_find`, `device_press`, `device_fill`, `device_screenshot`, `device_pick_date`, `device_batch` |
-| **Actions** | Record / replay / self-repair persistent flows | `cdp_run_action`, `cdp_repair_action`, `cdp_record_test_save_as_action`, `cdp_lock_e2e_test`, `cdp_run_e2e_suite` |
-| **Testing** | E2E replay and PR-ready proof | `proof_step`, `cross_platform_verify`, `maestro_run`, `maestro_test_all` (`cdp_auto_login` is legacy per-call recovery only, never PR proof) |
+| **Actions** | Record / replay / self-repair persistent flows, including fail-stop login | `cdp_login_prologue`, `cdp_run_action`, `cdp_repair_action`, `cdp_record_test_save_as_action`, `cdp_lock_e2e_test`, `cdp_run_e2e_suite` |
+| **Testing** | E2E replay and PR-ready proof | `proof_step`, `cross_platform_verify`, `maestro_run`, `maestro_test_all` (`cdp_auto_login` is legacy per-call recovery, not a blocked-journey fallback or PR proof) |
 | **Macro-Asserts** | State-assertive replays — internal state, not pixels | `expect_redux`, `expect_route`, `expect_visible_by_testid`, `expect_text` |
 
 The committed tool surface is asserted in CI against a golden registry (`packages/rn-dev-agent-core/test/fixtures/tool-registry.json`), so tool additions and removals can't silently drift.

--- a/apps/docs-site/src/content/docs/actions/index.mdx
+++ b/apps/docs-site/src/content/docs/actions/index.mdx
@@ -37,8 +37,8 @@ The agent never replays an entire job from a script — that would defeat the po
 A worked example. You ask: "tap the cart badge."
 
 - The agent reads the navigation state. The app is on `LoginScreen`, but the cart badge lives on `HomeScreen`.
-- It scans saved actions and finds `user-login`, whose recorded outcome is "logged-in home."
-- It runs `user-login` (~4 seconds), arrives at `HomeScreen`.
+- It enters through `cdp_login_prologue`, which resolves the exact saved `user-login` action.
+- The prologue requires a fresh passing RunRecord before it arrives at `HomeScreen`.
 - Then it discovers the cart badge interactively and taps it.
 
 ### Measured impact
@@ -59,12 +59,13 @@ Said another way: actions are the **memory** of the LLM loop. Every successful v
 
 ## Tool surface
 
-The hybrid is implemented across **four MCP tools** (one conceptual family, "Actions") and **two slash commands**.
+The hybrid is implemented across **five MCP tool groups** (one conceptual family, "Actions") and **two slash commands**.
 
 | Tool | Role |
 |---|---|
 | `cdp_record_test_save_as_action` | Convert a recorded interactive walk into a first-class `.rn-agent/actions/<id>.yaml` with metadata header and sidecar state file. Auto-promotes to `status: active` after the first clean replay. |
 | `cdp_run_action` | Replay an action by id with `params`. Orchestrates exact-active-device `maestro_run` + optional `cdp_repair_action` retry. Persists a `RunRecord` with `autoRepair` telemetry (passed / failed / refused / skipped, phase timings) so MTTR analysis can see which flows are stable. Maestro `deviceId` authority comes from direct runner evidence, not requested metadata; a runner/WDA mismatch fails closed. |
+| `cdp_login_prologue` | Enter authenticated journeys through the exact `user-login` action. Requires a fresh passing RunRecord and terminally blocks mutating fallbacks after failure; it is a navigation helper, not formal PR proof. |
 | `cdp_repair_action` | When a run fails with `SELECTOR_NOT_FOUND`, fuzzy-match the stale selector against the live snapshot, patch the YAML, retry. Refuses on human-edited files (`mtime` check), >3 repairs/24h, or snapshot infrastructure failure. |
 | `cdp_record_test_*` (start / stop / generate / annotate / save / load / list) | The recorder upstream of actions — captures device taps + CDP state assertions during interactive walks, before they get promoted to actions. |
 
@@ -77,7 +78,7 @@ The hybrid is implemented across **four MCP tools** (one conceptual family, "Act
 
 Both the `rn-tester` and `rn-debugger` agents are instructed (via `feedback_execute_artifacts_before_manual.md`) to scan saved actions **before** composing any new `device_*` primitives. Manual primitives are the **fallback**, not the default — that's the lever that keeps the LLM from paying full-walk latency on flows it has already verified once.
 
-In practice this means a session opens with `/list-learned-actions` (or its programmatic equivalent), confirms through `rn_session status` that replay authority is not blocked, routes through `/run-action` when a match exists, and only drops to interactive `device_press` / `device_fill` / `cdp_interact` when no action covers the intent. Discovery alone grants no replay authority; blocked sessions follow [parallel session authority](../session-authority/).
+In practice this means a session opens with `/list-learned-actions` (or its programmatic equivalent), confirms through `rn_session status` that replay authority is not blocked, routes non-login matches through `/run-action`, and uses `cdp_login_prologue` for authentication. It only drops to interactive `device_press` / `device_fill` / `cdp_interact` when no non-login action covers the intent. Discovery alone grants no replay authority; blocked sessions follow [parallel session authority](../session-authority/).
 
 ## Where actions live
 

--- a/apps/docs-site/src/content/docs/agents/rn-tester.mdx
+++ b/apps/docs-site/src/content/docs/agents/rn-tester.mdx
@@ -41,7 +41,7 @@ Writes a test plan before executing: starting state, steps to exercise, expected
 
 ### Step 2.5: Auth Pre-flight
 
-Checks `cdp_navigation_state` for auth-gated screens. If logged out, selects a compatible owned learned action and replays it through `cdp_run_action` on the authority-bound device. Missing or incompatible owned automation is terminal; `cdp_auto_login` requires explicit authorization for legacy per-call recovery and never counts as durable authority or PR proof.
+Checks `cdp_navigation_state` for auth-gated screens. If logged out, calls `cdp_login_prologue`, which resolves only the exact `user-login` action and requires a fresh passing RunRecord. `LOGIN_PROLOGUE_BLOCKED` ends the journey without credential or ad-hoc replay fallbacks. The helper is not PR proof; formal login proof locks and runs the exact login e2e candidate.
 
 ### Step 2.6: Permission Pre-flight
 

--- a/apps/docs-site/src/content/docs/architecture.mdx
+++ b/apps/docs-site/src/content/docs/architecture.mdx
@@ -40,7 +40,7 @@ The plugin is organized into three layers. Each one has a different job and gets
 
 On a known 3-step task-creation wizard, an interactive agent walk took **13 minutes 55 seconds**. The same wizard, replayed as a saved action, finished in **~4 seconds** — a ~210× speedup. That's the load-bearing data point behind the architecture: discovery tools are how the agent finds new ground; actions are how it replays known ground without paying that cost again.
 
-The agent doesn't choose all-or-nothing. If you're on the login screen and need to do something on home, the agent runs the saved login action as a prologue (4 seconds), then discovers the new work interactively. See [actions](actions/) for the full hybrid composition pattern.
+The agent doesn't choose all-or-nothing. If you're on the login screen and need to do something on home, the agent enters through `cdp_login_prologue`, which replays the exact saved `user-login` action, then discovers the new work interactively. See [actions](actions/) for the full hybrid composition pattern.
 
 ---
 

--- a/apps/docs-site/src/content/docs/commands/lock-e2e.mdx
+++ b/apps/docs-site/src/content/docs/commands/lock-e2e.mdx
@@ -5,7 +5,7 @@ description: Promote a verified action into a frozen, locked e2e regression test
 
 import { Aside } from '@astrojs/starlight/components';
 
-Freeze a passing [action](../../actions/) into a **locked e2e regression test**. A locked test is a copy of the action in `.rn-agent/e2e/<id>.yaml` that replays **strict** — self-repair is disabled, so any drift fails loudly instead of being absorbed. Locked tests are what [`cdp_run_e2e_suite`](../../tools/cdp/cdp_run_e2e_suite/) (and the observe UI's **E2E** tab) run as the project's regression suite.
+Freeze a passing [action](../../actions/) into a **locked e2e regression test**. A locked test is a copy of the action in `.rn-agent/e2e/<id>.yaml` that replays **strict** — self-repair is disabled, so any drift fails loudly instead of being absorbed. Locked tests are what [`cdp_run_e2e_suite`](../../tools/cdp/cdp_run_e2e_suite/) (and the observe UI's **E2E** tab) run as the project's regression suite. For login, this locked test on the exact candidate is the formal PR proof; [`cdp_login_prologue`](../../tools/cdp/cdp_login_prologue/) is the fail-stop navigation helper and is not that proof.
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/commands/run-action.mdx
+++ b/apps/docs-site/src/content/docs/commands/run-action.mdx
@@ -5,7 +5,7 @@ description: Replay a saved action by name. Self-repairs small UI drift; doesn't
 
 import { Aside } from '@astrojs/starlight/components';
 
-Replay a saved action — login, navigate to a screen, complete a multi-step flow — in seconds. Counterpart to [`/list-learned-actions`](../list-learned-actions/), which discovers what's available without granting replay authority.
+Replay a saved non-login action — navigate to a screen or complete a multi-step flow — in seconds. Counterpart to [`/list-learned-actions`](../list-learned-actions/), which discovers what's available without granting replay authority. Authenticated journeys enter through [`cdp_login_prologue`](../../tools/cdp/cdp_login_prologue/).
 
 ## Usage
 
@@ -17,7 +17,7 @@ Replay a saved action — login, navigate to a screen, complete a multi-step flo
 
 ```
 /rn-dev-agent:run-action wizard-create-task -e TITLE="Buy milk" -e PRIORITY=high
-/rn-dev-agent:run-action user-login --platform android
+/rn-dev-agent:run-action open-settings --platform android
 ```
 
 ## How match works

--- a/apps/docs-site/src/content/docs/skills/rn-testing.mdx
+++ b/apps/docs-site/src/content/docs/skills/rn-testing.mdx
@@ -53,7 +53,7 @@ Per-step timing with maestro-runner + JPEG: ~1.4s (2.2x faster than Maestro + PN
 
 ### Auth Pre-flight
 
-Before testing, check `cdp_navigation_state` for auth screens. If logged out, select a compatible owned learned action and replay it through `cdp_run_action` on the authority-bound device. Missing or incompatible owned automation is terminal. Never fall back to manual login or an unowned `.maestro` flow; use `cdp_auto_login` only when the user explicitly authorizes legacy per-call recovery, never as durable authority or PR proof.
+Before testing, check `cdp_navigation_state` for auth screens. If logged out, call `cdp_login_prologue`, which inventories and replays only the exact `user-login` action and requires a fresh passing RunRecord. `LOGIN_PROLOGUE_BLOCKED` is terminal: do not fall back to credentials, `cdp_auto_login`, ad-hoc Maestro, navigation shortcuts, or store mutation. The passing helper is not PR proof; lock and run the exact login e2e candidate for formal proof.
 
 ### Permission Pre-flight
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_login_prologue.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_login_prologue.mdx
@@ -1,20 +1,20 @@
 ---
 title: "cdp_login_prologue"
-description: "Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; not PR proof"
+description: "Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; failure blocks exploratory fallback mutations, and a pass is not PR proof"
 ---
 
-Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; not PR proof.
+Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; failure blocks exploratory fallback mutations, and a pass is not PR proof.
 
 ## Parameters
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `projectRoot` | `string` | No |  |  | Override project root (default: process.cwd()). |
-| `platform` | `unknown` | No |  |  | Force a platform; otherwise use the authority-bound device. |
-| `appFile` | `unknown` | No |  |  | iOS app artifact used only when the saved action contains clearState. |
+| `platform` | `enum: ios | android` | No |  |  | Override the bound platform. |
+| `appFile` | `string` | No |  |  | iOS app artifact for clearState actions. |
 | `timeoutMs` | `number` | No |  |  | Saved-action timeout in milliseconds. |
-| `trigger` | `unknown` | No |  |  | RunRecord trigger annotation. Default agent. |
-| `params` | `unknown` | No |  |  | Bindings for the exact user-login action placeholders. |
+| `trigger` | `enum: agent | ci | human` | No |  |  | Run trigger; default agent. |
+| `params` | `Record<string, unknown>` | No |  |  | String user-login bindings. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_login_prologue.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_login_prologue.mdx
@@ -1,9 +1,9 @@
 ---
 title: "cdp_login_prologue"
-description: "Inventory learned actions, replay the exact user-login action strictly, and require a fresh passing RunRecord before lifting the session login gate"
+description: "Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; not PR proof"
 ---
 
-Inventory learned actions, replay the exact user-login action strictly, and require a fresh passing RunRecord before lifting the session login gate.
+Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; not PR proof.
 
 ## Parameters
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_login_prologue.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_login_prologue.mdx
@@ -1,0 +1,23 @@
+---
+title: "cdp_login_prologue"
+description: "Inventory learned actions, replay the exact user-login action strictly, and require a fresh passing RunRecord before lifting the session login gate"
+---
+
+Inventory learned actions, replay the exact user-login action strictly, and require a fresh passing RunRecord before lifting the session login gate.
+
+## Parameters
+
+| Name | Type | Required | Default | Constraints | Description |
+|------|------|----------|---------|-------------|-------------|
+| `projectRoot` | `string` | No |  |  | Override project root (default: process.cwd()). |
+| `platform` | `unknown` | No |  |  | Force a platform; otherwise use the authority-bound device. |
+| `appFile` | `unknown` | No |  |  | iOS app artifact used only when the saved action contains clearState. |
+| `timeoutMs` | `number` | No |  |  | Saved-action timeout in milliseconds. |
+| `trigger` | `unknown` | No |  |  | RunRecord trigger annotation. Default agent. |
+| `params` | `unknown` | No |  |  | Bindings for the exact user-login action placeholders. |
+
+## Usage
+
+```
+cdp_login_prologue()
+```

--- a/apps/docs-site/src/content/docs/tools/index.mdx
+++ b/apps/docs-site/src/content/docs/tools/index.mdx
@@ -59,7 +59,7 @@ Native interaction. iOS routes through the in-tree `rn-fast-runner` `/command` e
 
 Record / replay / self-repair persistent flows. See the [**Actions concept guide**](../actions/) for why the LLM/pragmatic hybrid matters.
 
-**Replay & repair:** `cdp_run_action` (orchestrates `maestro_run` + auto-repair + retry; persists `RunRecord` with phase timings) → `cdp_repair_action` (fuzzy-patches stale `testID` against live snapshot; refuses on human edits, >3 repairs/24h)
+**Replay & repair:** `cdp_login_prologue` (exact fail-stop `user-login` helper; fresh passing RunRecord required) / `cdp_run_action` (orchestrates `maestro_run` + auto-repair + retry; persists `RunRecord` with phase timings) → `cdp_repair_action` (fuzzy-patches stale `testID` against live snapshot; refuses on human edits, >3 repairs/24h)
 
 **Recording → action promotion:** `cdp_record_test_start` → `cdp_record_test_annotate` (mid-recording state checks) → `cdp_record_test_stop` → `cdp_record_test_generate` (raw Maestro YAML) → `cdp_record_test_save` / `cdp_record_test_save_as_action` (promote to first-class action) → `cdp_record_test_list` / `cdp_record_test_load`
 
@@ -67,7 +67,7 @@ Record / replay / self-repair persistent flows. See the [**Actions concept guide
 
 E2E testing and proof capture — work even when the app is crashed or on native screens.
 
-`maestro_run` / `maestro_generate` → `maestro_test_all` → `proof_step` → `cross_platform_verify`. `cdp_auto_login` is available only for explicitly authorized legacy per-call recovery; it is not a default test step or PR proof.
+`maestro_run` / `maestro_generate` → `maestro_test_all` → `proof_step` → `cross_platform_verify`. `cdp_auto_login` remains a legacy per-call helper outside the guarded journey; it is not a fallback from `LOGIN_PROLOGUE_BLOCKED` or PR proof.
 
 ## Macro-Asserts
 

--- a/apps/docs-site/src/content/docs/tools/testing/cdp_auto_login.mdx
+++ b/apps/docs-site/src/content/docs/tools/testing/cdp_auto_login.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 33
 ---
 
-Explicit legacy navigation helper that detects an auth screen and runs one project login subflow through maestro_run on the authority-bound device. It is per-call recovery only, never durable login authority or PR proof; prefer a compatible owned learned action.
+Explicit legacy navigation helper that detects an auth screen and runs one project login subflow through maestro_run on the authority-bound device. It is never login authority or PR proof; use cdp_login_prologue for authenticated journeys.
 
 ## Parameters
 

--- a/packages/claude-plugin/CLAUDE-MD-TEMPLATE.md
+++ b/packages/claude-plugin/CLAUDE-MD-TEMPLATE.md
@@ -48,8 +48,8 @@ exist as YAML).
    `/rn-dev-agent:run-action <flow-name> [-e KEY=VALUE …]` — pre-flights
    mutates flag, appId match, parameter coverage, action engine pin, and
    selector compatibility; it resolves pin-cache maestro-runner `>= 1.1.24` from
-   rn-dev-agent's versioned pin-cache. A passing replay IS your evidence —
-   skip ahead to capturing proof.
+   rn-dev-agent's versioned pin-cache. For non-login actions, a passing replay
+   IS your evidence — skip ahead to capturing proof.
 3. **Only if no non-login match (or replay fails with a concrete error):** fall back to
    manual primitives (`device_press` / `device_fill` / `device_find`). When
    you do, **end the session by persisting the verified flow** as a new YAML
@@ -175,15 +175,14 @@ The artifact-first rule generalizes from "replay if exact match" to
    `produces: { authenticated: true, route: home }` is the right
    prologue when current state is `LoginScreen` and the user wants
    anything that requires auth — even if the user's task isn't "log in"
-   per se. Replay that action via `cdp_run_action`. Re-verify state.
-   Then continue with interactive `cdp_*` / `device_*` tools for the
-   novel part.
+   per se. Replay it through `cdp_login_prologue`. Re-verify state. Then
+   continue with interactive `cdp_*` / `device_*` tools for the novel part.
 
 3. **No false-binary fallbacks.** Never fall back to a fully-manual
    walk when a partial replay (login prologue, onboarding skip, locale
-   set) covers half the work. The cost of one failed replay attempt is
-   `cdp_run_action`'s auto-repair budget (3/24h); the cost of a fully
-   manual walk is 30s+ of context-burning device interaction.
+   set) covers half the work. For non-login gaps, one failed replay attempt
+   costs `cdp_run_action`'s auto-repair budget (3/24h); a login-prologue failure
+   is terminal. A fully manual walk costs 30s+ of context-burning interaction.
 
 **Example — user says "go to home and tap the cart badge":**
 

--- a/packages/claude-plugin/CLAUDE-MD-TEMPLATE.md
+++ b/packages/claude-plugin/CLAUDE-MD-TEMPLATE.md
@@ -50,11 +50,18 @@ exist as YAML).
    selector compatibility; it resolves pin-cache maestro-runner `>= 1.1.24` from
    rn-dev-agent's versioned pin-cache. A passing replay IS your evidence —
    skip ahead to capturing proof.
-3. **Only if no match (or replay fails with a concrete error):** fall back to
+3. **Only if no non-login match (or replay fails with a concrete error):** fall back to
    manual primitives (`device_press` / `device_fill` / `device_find`). When
    you do, **end the session by persisting the verified flow** as a new YAML
    under `<test-app>/.rn-agent/actions/<feature-slug>.yaml` so the next session
    starts at step 2, not step 3.
+
+Authentication is fail-stop: when login is required, call
+`cdp_login_prologue`. It inventories learned actions, resolves only the exact
+`user-login` action, and requires a fresh passing RunRecord. Any missing action,
+runner drift, selector failure, or timeout returns `LOGIN_PROLOGUE_BLOCKED`.
+Do not continue with credentials, ad-hoc Maestro, navigation shortcuts, or
+store mutation after that result.
 
 Manual walks are a fallback, not a default. Codified in
 `feedback_execute_artifacts_before_manual.md`. Enforced as Step 0 of
@@ -76,18 +83,19 @@ manual when state mismatches; never re-walk a flow you already have.
    relevant slice. Note any mismatch with the expected starting state.
 2. **Compose action + manual.** If current state ≠ expected start, scan
    `list-learned-actions` for an action whose `produces` covers the gap.
-   Replay via `cdp_run_action`. Re-verify state. Then continue
+   Replay via `cdp_run_action`; for authentication, use
+   `cdp_login_prologue`. Re-verify state. Then continue
    interactively for the novel part.
 3. **No fully-manual fallback when partial replay would cover half the work.**
-   Login is the cardinal example — if a saved login action exists, use it
-   as a prologue, never re-walk login interactively.
+   Login is the cardinal example — enter through `cdp_login_prologue` and
+   never re-walk login interactively if the exact action is absent or fails.
 
 **Worked example.** User: "tap the cart badge."
 
 - Agent: `cdp_navigation_state` → `LoginScreen` (mismatch with home)
 - Agent: `list-learned-actions` → finds `user-login` with
   `produces: { authenticated: true, route: home }`
-- Agent: `cdp_run_action({ id: "user-login", params: { EMAIL, PASSWORD } })`
+- Agent: `cdp_login_prologue({ params: { EMAIL, PASSWORD } })` → fresh passing RunRecord
 - Agent: `cdp_navigation_state` → `HomeScreen` (state delta closed)
 - Agent: `cdp_component_tree({ filter: "cart" })` → finds `cart-badge` ref
 - Agent: `device_press({ ref: "cart-badge" })`
@@ -182,8 +190,7 @@ The artifact-first rule generalizes from "replay if exact match" to
 2. /rn-dev-agent:list-learned-actions  (or read .rn-agent/actions/ directly)
                                     → finds `user-login` with
                                       produces: { authenticated: true, route: home }
-3. cdp_run_action({                 (deterministic prologue, ~4s)
-     id: "user-login",
+3. cdp_login_prologue({             (deterministic fail-stop prologue)
      params: { EMAIL, PASSWORD }
    })
 4. cdp_navigation_state             → returns "HomeScreen" (state delta closed)
@@ -564,10 +571,9 @@ the runner's settle engine.
 
 Before testing **auth-gated features:**
 1. `cdp_navigation_state` — check if on a login screen
-2. Scan `/rn-dev-agent:list-learned-actions login` — a saved login action with `produces: { authenticated: true }` is the preferred prologue (replay via `cdp_run_action`, ~4s; see Hybrid composition)
-3. If no compatible owned action exists, stop and report authentication as blocked. Do not use manual login, `.maestro` flows, ambient runners, or `cdp_auto_login` as an automatic fallback.
-4. Only when the user explicitly authorizes legacy per-call navigation recovery may `cdp_auto_login` run. It is never durable login authority or PR proof; create or migrate an owned compatible action before proof.
-5. `cdp_navigation_state` — verify arrival at home/target screen
+2. Call `cdp_login_prologue` — it inventories and resolves the exact `user-login` action itself
+3. Require `state: "passed"` plus a fresh passing `runRecord`; only then continue
+4. On `LOGIN_PROLOGUE_BLOCKED`, stop the journey; never fall through to manual credentials, `cdp_auto_login`, or ad-hoc Maestro
 
 Before testing **permission-gated features:**
 1. `device_permission(action="query", permission="<name>")` — check current state

--- a/packages/claude-plugin/CLAUDE-MD-TEMPLATE.md
+++ b/packages/claude-plugin/CLAUDE-MD-TEMPLATE.md
@@ -58,10 +58,12 @@ exist as YAML).
 
 Authentication is fail-stop: when login is required, call
 `cdp_login_prologue`. It inventories learned actions, resolves only the exact
-`user-login` action, and requires a fresh passing RunRecord. Any missing action,
-runner drift, selector failure, or timeout returns `LOGIN_PROLOGUE_BLOCKED`.
-Do not continue with credentials, ad-hoc Maestro, navigation shortcuts, or
-store mutation after that result.
+`user-login` action, and requires a fresh passing RunRecord. That result is a
+navigation helper, not PR proof. Any missing action, runner drift, selector
+failure, or timeout returns `LOGIN_PROLOGUE_BLOCKED`. Do not continue with
+credentials, ad-hoc Maestro, navigation shortcuts, or store mutation after
+that result. Formal login proof is `cdp_lock_e2e_test` / `cdp_run_e2e_suite` on
+the exact candidate; helper and locked tests coexist without sharing that proof.
 
 Manual walks are a fallback, not a default. Codified in
 `feedback_execute_artifacts_before_manual.md`. Enforced as Step 0 of
@@ -572,8 +574,9 @@ the runner's settle engine.
 Before testing **auth-gated features:**
 1. `cdp_navigation_state` — check if on a login screen
 2. Call `cdp_login_prologue` — it inventories and resolves the exact `user-login` action itself
-3. Require `state: "passed"` plus a fresh passing `runRecord`; only then continue
+3. Require `state: "passed"` plus a fresh passing `runRecord`; only then continue. Treat that pass as a navigation helper, not PR proof
 4. On `LOGIN_PROLOGUE_BLOCKED`, stop the journey; never fall through to manual credentials, `cdp_auto_login`, or ad-hoc Maestro
+5. Formal login proof is locking and running the login e2e on the exact candidate (`cdp_lock_e2e_test` / `cdp_run_e2e_suite`)
 
 Before testing **permission-gated features:**
 1. `device_permission(action="query", permission="<name>")` — check current state

--- a/packages/claude-plugin/agents/rn-tester.md
+++ b/packages/claude-plugin/agents/rn-tester.md
@@ -152,39 +152,20 @@ Write a brief test plan BEFORE executing:
 - Expected outcome at each step (UI + data)
 - Edge cases to verify
 
-### Step 2.5: Auth Pre-flight Check (GH #10)
+### Step 2.5: Deterministic Login Prologue
 
-Before navigating, check if the app is on an auth-gated screen (login,
-welcome, registration, onboarding). Authentication recovery must use a
-compatible action from the project's approved learned-action corpus.
-
-1. Call `cdp_navigation_state`. Check the current route name.
-2. If the navigation state is **empty or minimal**, the app may still
-   be loading (splash screen, token rehydration). Wait 3 seconds and
-   retry `cdp_navigation_state`. If the route remains unavailable, use a
-   device snapshot to distinguish the Dev Client picker from an auth screen;
-   passive `cdp_status` never dismisses UI.
-3. If the route suggests the user is logged out (common patterns:
-   `Login`, `Welcome`, `SignIn`, `Register`, `Onboarding`, `Auth`,
-   `Landing`):
-
-   a. Run `/rn-dev-agent:list-learned-actions login` and select one compatible
-      owned action whose metadata establishes authenticated state.
-   b. Replay it through `cdp_run_action` on the exact authority-bound device.
-      Any engine-pin, selector, or action-format incompatibility is terminal.
-   c. If no compatible owned action exists, stop and report authentication as
-      blocked. Do not use manual taps, `.maestro` flows, ambient runners, or
-      `cdp_auto_login` as an automatic fallback.
-   d. Only when the user explicitly authorizes legacy per-call navigation
-      recovery may `cdp_auto_login` run. It is never durable login authority or
-      PR proof; create or migrate an owned compatible action before proof.
-   e. **Verify arrival** at the home/main screen:
-      ```
-      cdp_navigation_state  → confirm route is NOT auth-related
-      ```
-
-4. If the route is a main app screen (home, dashboard, tabs, etc.),
-   skip this step — the user is already authenticated.
+1. Call `cdp_navigation_state` and distinguish a stable auth route from a
+    loading or Dev Client picker state. If navigation is empty or minimal,
+    wait 3 seconds and retry before concluding the app is signed out.
+2. If the app is signed out, call `cdp_login_prologue`. Do not inspect or
+    explore login controls first.
+3. Continue only with `state: "passed"` and a fresh passing `runRecord`.
+4. Treat `LOGIN_PROLOGUE_BLOCKED` as terminal. Do not enter credentials, run
+   ad-hoc Maestro, inject routes, mutate stores, or navigate to the story. Use
+   read-only diagnostics to repair the exact `user-login` action, then rerun
+   the prologue.
+5. A supervisor override is valid only when supplied out of band for one call;
+    never search for, infer, log, or persist its token.
 
 ### Step 2.6: Permission Pre-flight Check (GH #11)
 

--- a/packages/claude-plugin/agents/rn-tester.md
+++ b/packages/claude-plugin/agents/rn-tester.md
@@ -160,10 +160,13 @@ Write a brief test plan BEFORE executing:
 2. If the app is signed out, call `cdp_login_prologue`. Do not inspect or
     explore login controls first.
 3. Continue only with `state: "passed"` and a fresh passing `runRecord`.
+   That result is a navigation helper, not PR proof.
 4. Treat `LOGIN_PROLOGUE_BLOCKED` as terminal. Do not enter credentials, run
    ad-hoc Maestro, inject routes, mutate stores, or navigate to the story. Use
    read-only diagnostics to repair the exact `user-login` action, then rerun
-   the prologue.
+   the prologue. Locked e2e login proof (`cdp_lock_e2e_test` /
+   `cdp_run_e2e_suite` on the exact candidate) remains available and does not
+   lift or replace the helper gate.
 5. A supervisor override is valid only when supplied out of band for one call;
     never search for, infer, log, or persist its token.
 

--- a/packages/claude-plugin/commands/lock-e2e.md
+++ b/packages/claude-plugin/commands/lock-e2e.md
@@ -12,3 +12,4 @@ Steps:
 2. If it returns `STRICT_RUN_FAILED`, tell the user the action must pass a strict (no-repair) run first — offer to run `cdp_run_action` to repair it, then retry the lock.
 3. If it returns `PARAMS_UNSUPPORTED`, explain that v1 supports param-free tests only.
 4. On success, report the frozen file path and that it will now be included in `cdp_run_e2e_suite`.
+5. For login, this locked test is the formal PR proof on the exact candidate. `cdp_login_prologue` is only a navigation helper and must not be treated as that proof.

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -31930,22 +31930,20 @@ function tokenMatches(expected, supplied) {
   const suppliedHash = createHash7("sha256").update(supplied).digest();
   return timingSafeEqual3(expectedHash, suppliedHash);
 }
-function evaluateLoginPrologueGuard(input) {
+function inspectLoginPrologueGuard(input) {
   const outcome = readLoginPrologueOutcome(input.binding);
-  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation) {
-    return { allowed: true, override: false };
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args)) {
+    return { blocked: false };
   }
-  if (cleanupAllowed(input.tool, input.args))
-    return { allowed: true, override: false };
-  const supplied = typeof input.args.supervisorOverrideToken === "string" ? input.args.supervisorOverrideToken : void 0;
-  if (tokenMatches(input.expectedOverrideToken, supplied)) {
-    return {
-      allowed: true,
-      override: true,
-      audit: { tool: input.tool, usedAt: (input.now ?? (() => /* @__PURE__ */ new Date()))().toISOString() }
-    };
-  }
-  return { allowed: false, suppliedOverride: supplied !== void 0 };
+  return {
+    blocked: true,
+    suppliedOverride: typeof input.args.supervisorOverrideToken === "string" ? input.args.supervisorOverrideToken : void 0
+  };
+}
+function authorizeLoginSupervisorOverride(input) {
+  if (!tokenMatches(input.expectedOverrideToken, input.suppliedOverrideToken))
+    return null;
+  return { tool: input.tool, usedAt: (input.now ?? (() => /* @__PURE__ */ new Date()))().toISOString() };
 }
 function appendLoginOverrideAudit(outcome, audit) {
   return { ...outcome, overrides: [...outcome.overrides ?? [], audit].slice(-20) };
@@ -32925,22 +32923,22 @@ function createAuthorityGate(runtime, dependencies) {
         liveBundleProbe: tool === "proof_capture"
       } : baseProfile;
       const runtimeStatus = runtime.status();
-      const loginDecision = evaluateLoginPrologueGuard({
+      const loginGuard = inspectLoginPrologueGuard({
         binding: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
         tool,
         args,
-        mutation: profile.mutation,
-        expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.()
+        mutation: profile.mutation
       });
+      const pendingSupervisorOverrideToken = loginGuard.blocked ? loginGuard.suppliedOverride : void 0;
       delete args.supervisorOverrideToken;
-      if (!loginDecision.allowed) {
+      if (loginGuard.blocked && pendingSupervisorOverrideToken === void 0) {
         return failResult("LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.", "LOGIN_PROLOGUE_BLOCKED", {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
-          overrideRejected: loginDecision.suppliedOverride,
+          overrideRejected: false,
           nextAction: "Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call."
         });
       }
-      if (loginDecision.override && profile.kind === "transition") {
+      if (loginGuard.blocked && profile.kind === "transition") {
         return failResult("LOGIN_PROLOGUE_BLOCKED: supervisor overrides cannot authorize transition mutations.", "LOGIN_PROLOGUE_BLOCKED", {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
           transitionOverrideRejected: true,
@@ -33201,6 +33199,7 @@ function createAuthorityGate(runtime, dependencies) {
       let retainProofCleanupFence = false;
       let publishedProofFinalize = false;
       let stagedRuntimeRelaunch;
+      let loginPrologueAttemptOperationId = null;
       try {
         const available = runtime.requireAvailable();
         registry2 = available.registry;
@@ -33209,13 +33208,23 @@ function createAuthorityGate(runtime, dependencies) {
           throw new SessionAuthorityError(initialStatus.code, initialStatus.reason);
         }
         let status = initialStatus;
-        requireCompleteAxes(status, profile);
-        bindSessionArguments(status, profile, args, tool);
+        if (tool !== "cdp_login_prologue") {
+          requireCompleteAxes(status, profile);
+          bindSessionArguments(status, profile, args, tool);
+        }
         operation = registry2.beginOperation(available.session, {
           operationId: randomUUID4(),
           tool,
           profile: profile.axes.join("")
         });
+        if (tool === "cdp_login_prologue") {
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome());
+          operation = persisted.operation;
+          status = persisted.status;
+          loginPrologueAttemptOperationId = operation.operationId;
+          requireCompleteAxes(status, profile);
+          bindSessionArguments(status, profile, args, tool);
+        }
         const preflightRecovery = await reconcileRecoverableRuntime(runtime, dependencies, registry2, operation, status, profile, true);
         operation = preflightRecovery.operation;
         status = preflightRecovery.status;
@@ -33561,17 +33570,20 @@ function createAuthorityGate(runtime, dependencies) {
             }
           });
         }
-        if (loginDecision.override) {
+        if (pendingSupervisorOverrideToken !== void 0) {
           const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
           if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
             throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
           }
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, loginDecision.audit));
-          operation = persisted.operation;
-          status = persisted.status;
-        }
-        if (tool === "cdp_login_prologue") {
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome());
+          const audit = authorizeLoginSupervisorOverride({
+            expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
+            suppliedOverrideToken: pendingSupervisorOverrideToken,
+            tool
+          });
+          if (!audit) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the supervisor override token was rejected under the operation fence");
+          }
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, audit));
           operation = persisted.operation;
           status = persisted.status;
         }
@@ -33760,6 +33772,10 @@ function createAuthorityGate(runtime, dependencies) {
           registry2.commitPlatformAuthorityReceipts(operation);
         }
         if (operation && loginPrologueOutcome?.state === "passed") {
+          const pendingOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+          if (operation.operationId !== loginPrologueAttemptOperationId || pendingOutcome?.state !== LOGIN_PROLOGUE_BLOCKED || pendingOutcome.failure?.code !== "LOGIN_PROLOGUE_IN_PROGRESS") {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the passing login result does not match the active blocked attempt");
+          }
           const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
           operation = persisted.operation;
           status = persisted.status;
@@ -78134,6 +78150,14 @@ function getWorkerAuthorityRuntime() {
 init_resolve_ios_app_file();
 init_action_engine_compat();
 init_engine_pin();
+var strictRunActionPolicy = /* @__PURE__ */ Symbol("strictRunActionPolicy");
+function sealStrictRunAction(args) {
+  Object.defineProperty(args, strictRunActionPolicy, { value: true });
+  return args;
+}
+function usesStrictRunActionPolicy(args) {
+  return args[strictRunActionPolicy] === true;
+}
 function boundInstallReceipt() {
   try {
     const status = getWorkerAuthorityRuntime().status();
@@ -78391,9 +78415,9 @@ function createRunActionHandler(deps = {}) {
     });
     try {
       let atRisk = null;
-      const cdpFallbackForbidden = args.cdpFallbackMode === "forbid";
+      const strictExecutor = usesStrictRunActionPolicy(args);
       const inheritedBlindProbeDisabled = process.env.RN_BLIND_PROBE === "0" || process.env.RN_BLIND_PROBE === "false";
-      const blindProbeDisabled = cdpFallbackForbidden || args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
+      const blindProbeDisabled = strictExecutor || args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
       if (args.platform !== "android") {
         const ctx = await blindProbeContext2().catch(() => null);
         if (ctx) {
@@ -78579,7 +78603,7 @@ function createRunActionHandler(deps = {}) {
         }
       }
       let cdpJsFallback;
-      if (!cdpFallbackForbidden && (failure.kind === "SELECTOR_NOT_FOUND" || failure.kind === "UNKNOWN")) {
+      if (!strictExecutor && (failure.kind === "SELECTOR_NOT_FOUND" || failure.kind === "UNKNOWN")) {
         const candidate = getReplayDeps(args);
         const replayDeps = candidate && await claimBundleAuthority(args) ? candidate : null;
         const probe = !replayDeps ? null : failure.kind === "SELECTOR_NOT_FOUND" ? failure.selector : firstReplayTestId(cdpReplayYaml, args.params ?? {});
@@ -79032,9 +79056,9 @@ function createLoginPrologueHandler(deps) {
         forceReload: false,
         proofReplay: false,
         blindProbeMode: "forbid",
-        cdpFallbackMode: "forbid",
         trigger: args.trigger ?? "agent"
       });
+      sealStrictRunAction(replayArgs);
       let replayResult;
       try {
         replayResult = await measure("replay", () => deps.runAction(replayArgs));

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -32654,11 +32654,12 @@ function missingLoginPrologueOutcome() {
 }
 function persistLoginPrologueOutcome(runtime, registry2, operation, status, outcome) {
   const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+  const overrides = outcome.overrides ?? priorOutcome?.overrides;
   const nextOperation = registry2.replaceBindingsDuringOperation(operation, {
     bindings: {
       loginPrologue: {
         ...outcome,
-        ...priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}
+        ...overrides ? { overrides } : {}
       }
     }
   });
@@ -32906,7 +32907,7 @@ function createAuthorityGate(runtime, dependencies) {
         mutation: true,
         liveBundleProbe: tool === "proof_capture"
       } : baseProfile;
-      let runtimeStatus = runtime.status();
+      const runtimeStatus = runtime.status();
       const loginDecision = evaluateLoginPrologueGuard({
         binding: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
         tool,
@@ -32921,24 +32922,6 @@ function createAuthorityGate(runtime, dependencies) {
           overrideRejected: loginDecision.suppliedOverride,
           nextAction: "Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call."
         });
-      }
-      if (loginDecision.override) {
-        try {
-          const available = runtime.requireAvailable();
-          const current = runtime.status();
-          const outcome = current.available ? readLoginPrologueOutcome(current.bindings.loginPrologue) : null;
-          if (!outcome) {
-            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
-          }
-          available.registry.updateBindings(available.session, {
-            bindings: {
-              loginPrologue: appendLoginOverrideAudit(outcome, loginDecision.audit)
-            }
-          });
-          runtimeStatus = runtime.status();
-        } catch (error2) {
-          return authorityFailure(error2);
-        }
       }
       if (profile.kind === "diagnostic") {
         return addMeta2(await handler(...handlerArgs), { authoritative: false });
@@ -33554,6 +33537,15 @@ function createAuthorityGate(runtime, dependencies) {
             }
           });
         }
+        if (loginDecision.override) {
+          const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+          if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
+          }
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, loginDecision.audit));
+          operation = persisted.operation;
+          status = persisted.status;
+        }
         registry2.verifyOperation(operation);
         const snapshotCheckpoint = dependencies.snapshotCaptureCheckpoint?.();
         let result = await registry2.runWithOperation(operation, () => handler(...handlerArgs));
@@ -33689,11 +33681,6 @@ function createAuthorityGate(runtime, dependencies) {
           axes: [...runnerAwareReceiptProfile.axes, "M", "A"]
         } : runnerAwareReceiptProfile;
         const controllerGenerationAdvanced = operation.authorityVersion !== initialOperationAuthorityVersion;
-        if (loginPrologueOutcome?.state === "passed") {
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
-          operation = persisted.operation;
-          status = persisted.status;
-        }
         registry2.verifyOperation(operation);
         for (const observation of allBefore) {
           if (controllerGenerationAdvanced && observation.axis === "C")
@@ -33742,6 +33729,11 @@ function createAuthorityGate(runtime, dependencies) {
         }
         if (operation && receiptsCommittable) {
           registry2.commitPlatformAuthorityReceipts(operation);
+        }
+        if (operation && loginPrologueOutcome?.state === "passed") {
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
+          operation = persisted.operation;
+          status = persisted.status;
         }
         return addMeta2(result, {
           ...nativeOriginMeta(profile, nativeOriginProven),
@@ -78475,7 +78467,8 @@ function createRunActionHandler(deps = {}) {
       const firstFailureDetail = readMaestroFailureDetail(firstEnv, firstOutput);
       const firstDeviceAuthority = readMaestroDeviceAuthority(firstEnv);
       probeDeviceId = firstDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
-      if (firstEnv.code === "DEVICE_AUTHORITY_MISMATCH") {
+      if (firstEnv.code) {
+        const typedCode = firstEnv.code;
         const autoRepair2 = {
           attempted: false,
           outcome: args.autoRepair === false ? "refused" : "skipped",
@@ -78486,14 +78479,14 @@ function createRunActionHandler(deps = {}) {
           timestamp: (/* @__PURE__ */ new Date()).toISOString(),
           durationMs: Date.now() - t0,
           status: "fail",
-          failureCode: "DEVICE_AUTHORITY_MISMATCH",
+          failureCode: typedCode === "DEVICE_AUTHORITY_MISMATCH" ? "DEVICE_AUTHORITY_MISMATCH" : typedCode === "RECONNECT_TIMEOUT" ? "TIMEOUT" : "UNKNOWN",
           failureDetail: firstFailureDetail.slice(0, 1e3),
           trigger,
           autoRepair: autoRepair2
         });
-        return failResult(`cdp_run_action: ${args.actionId} refused replay authority: ${firstFailureDetail}`, "DEVICE_AUTHORITY_MISMATCH", {
+        return failResult(`cdp_run_action: ${args.actionId} refused replay: ${firstFailureDetail}`, typedCode, {
           actionId: args.actionId,
-          failureKind: "DEVICE_AUTHORITY_MISMATCH",
+          failureKind: typedCode,
           deviceAuthority: firstDeviceAuthority,
           autoRepair: autoRepair2,
           writes: writeDisclosure("none", persisted2)
@@ -78995,8 +78988,11 @@ function createLoginPrologueHandler(deps) {
     try {
       inventory = await measure("inventory", () => listActions(projectRoot));
       const action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
-      if (!action || !inventory.some((candidate) => candidate.id === LOGIN_PROLOGUE_ALIAS)) {
+      if (!action) {
         return blocked("LOGIN_ACTION_MISSING", `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
+      }
+      if (action.metadata.id !== LOGIN_PROLOGUE_ALIAS) {
+        return blocked("LOGIN_ACTION_ID_MISMATCH", `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
       }
       const priorRunIds = new Set(action.state.runHistory.map((record2) => record2.runId).filter((runId) => typeof runId === "string"));
       const replayArgs = Object.create(Object.getPrototypeOf(args), Object.getOwnPropertyDescriptors(args));

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -9244,7 +9244,7 @@ var require_websocket = __commonJS({
     var http = __require("http");
     var net = __require("net");
     var tls = __require("tls");
-    var { randomBytes: randomBytes8, createHash: createHash23 } = __require("crypto");
+    var { randomBytes: randomBytes8, createHash: createHash24 } = __require("crypto");
     var { Duplex, Readable } = __require("stream");
     var { URL: URL2 } = __require("url");
     var PerMessageDeflate2 = require_permessage_deflate();
@@ -9912,7 +9912,7 @@ var require_websocket = __commonJS({
           abortHandshake(websocket, socket, "Invalid Upgrade header");
           return;
         }
-        const digest3 = createHash23("sha1").update(key + GUID).digest("base64");
+        const digest3 = createHash24("sha1").update(key + GUID).digest("base64");
         if (res.headers["sec-websocket-accept"] !== digest3) {
           abortHandshake(websocket, socket, "Invalid Sec-WebSocket-Accept header");
           return;
@@ -10281,7 +10281,7 @@ var require_websocket_server = __commonJS({
     var EventEmitter = __require("events");
     var http = __require("http");
     var { Duplex } = __require("stream");
-    var { createHash: createHash23 } = __require("crypto");
+    var { createHash: createHash24 } = __require("crypto");
     var extension2 = require_extension();
     var PerMessageDeflate2 = require_permessage_deflate();
     var subprotocol2 = require_subprotocol();
@@ -10588,7 +10588,7 @@ var require_websocket_server = __commonJS({
           );
         }
         if (this._state > RUNNING) return abortHandshake(socket, 503);
-        const digest3 = createHash23("sha1").update(key + GUID).digest("base64");
+        const digest3 = createHash24("sha1").update(key + GUID).digest("base64");
         const headers = [
           "HTTP/1.1 101 Switching Protocols",
           "Upgrade: websocket",
@@ -30261,8 +30261,8 @@ var init_registry = __esm({
           const handoff = this.#database.prepare("SELECT token_hash, consumed_ms FROM handoffs WHERE handoff_id = ?").get(input.handoffId);
           const expected = Buffer.from(typeof handoff?.token_hash === "string" ? handoff.token_hash : "", "hex");
           const actual = createHash5("sha256").update(input.token).digest();
-          const tokenMatches = expected.length === actual.length && timingSafeEqual2(expected, actual);
-          if (!row || row.state !== "handoff_cleanup" || row.claim_epoch !== target.claimEpoch || row.worker_instance !== input.targetInstance || cleanup?.handoffId !== input.handoffId || cleanup?.targetSessionId !== target.sessionId || cleanup?.targetClaimEpoch !== target.claimEpoch || typeof handoff?.consumed_ms !== "number" || !tokenMatches) {
+          const tokenMatches2 = expected.length === actual.length && timingSafeEqual2(expected, actual);
+          if (!row || row.state !== "handoff_cleanup" || row.claim_epoch !== target.claimEpoch || row.worker_instance !== input.targetInstance || cleanup?.handoffId !== input.handoffId || cleanup?.targetSessionId !== target.sessionId || cleanup?.targetClaimEpoch !== target.claimEpoch || typeof handoff?.consumed_ms !== "number" || !tokenMatches2) {
             throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "handoff cleanup resumption requires the original handoff capability");
           }
         });
@@ -31896,6 +31896,69 @@ var init_install_reissue = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/login-prologue.js
+import { createHash as createHash7, timingSafeEqual as timingSafeEqual3 } from "node:crypto";
+function readLoginPrologueOutcome(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    return null;
+  const candidate = value;
+  if (candidate.schemaVersion !== 1 || candidate.alias !== LOGIN_PROLOGUE_ALIAS || candidate.state !== "passed" && candidate.state !== LOGIN_PROLOGUE_BLOCKED || typeof candidate.startedAt !== "string" || typeof candidate.endedAt !== "string" || typeof candidate.elapsedMs !== "number" || !Array.isArray(candidate.steps)) {
+    return null;
+  }
+  return candidate;
+}
+function cleanupAllowed(tool, args) {
+  if (tool === "cdp_login_prologue")
+    return true;
+  if (tool === "cdp_disconnect")
+    return true;
+  if (tool === "device_snapshot" && args.action === "close")
+    return true;
+  if (tool === "device_record" && (args.action === "stop" || args.action === "status"))
+    return true;
+  if (tool === "observe" && (args.action === "stop" || args.action === "status"))
+    return true;
+  if (tool === "proof_capture" && (args.action === "discard" || args.action === "status")) {
+    return true;
+  }
+  return tool === "rn_session" && (args.action === "release" || args.action === "stop_metro" || args.action === "cancel_handoff" || args.action === "status");
+}
+function tokenMatches(expected, supplied) {
+  if (!expected || expected.length < 16 || !supplied || supplied.length < 16)
+    return false;
+  const expectedHash = createHash7("sha256").update(expected).digest();
+  const suppliedHash = createHash7("sha256").update(supplied).digest();
+  return timingSafeEqual3(expectedHash, suppliedHash);
+}
+function evaluateLoginPrologueGuard(input) {
+  const outcome = readLoginPrologueOutcome(input.binding);
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation) {
+    return { allowed: true, override: false };
+  }
+  if (cleanupAllowed(input.tool, input.args))
+    return { allowed: true, override: false };
+  const supplied = typeof input.args.supervisorOverrideToken === "string" ? input.args.supervisorOverrideToken : void 0;
+  if (tokenMatches(input.expectedOverrideToken, supplied)) {
+    return {
+      allowed: true,
+      override: true,
+      audit: { tool: input.tool, usedAt: (input.now ?? (() => /* @__PURE__ */ new Date()))().toISOString() }
+    };
+  }
+  return { allowed: false, suppliedOverride: supplied !== void 0 };
+}
+function appendLoginOverrideAudit(outcome, audit) {
+  return { ...outcome, overrides: [...outcome.overrides ?? [], audit].slice(-20) };
+}
+var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED;
+var init_login_prologue = __esm({
+  "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
+    "use strict";
+    LOGIN_PROLOGUE_ALIAS = "user-login";
+    LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -32086,7 +32149,7 @@ var init_tool_profiles = __esm({
       "maestro_test_all"
     ];
     hybridMutation = ["cdp_auto_login", "cdp_run_e2e_suite"];
-    optionalHybridMutation = ["cdp_run_action"];
+    optionalHybridMutation = ["cdp_login_prologue", "cdp_run_action"];
     nativeDiagnostic = ["cdp_native_errors"];
     inlineMaestroMutation = /* @__PURE__ */ new Set([
       "device_accept_system_dialog",
@@ -32564,6 +32627,34 @@ function authorityFailure(error2) {
   const code = /^([A-Z][A-Z0-9_]+):/.exec(message)?.[1];
   return failResult(message, code ?? "AUTHORITY_LOST_DURING_OPERATION");
 }
+function parseLoginPrologueOutcome(result) {
+  try {
+    const envelope = JSON.parse(result.content?.[0]?.text ?? "{}");
+    return readLoginPrologueOutcome(envelope.data ?? envelope.meta?.loginPrologue);
+  } catch {
+    return null;
+  }
+}
+function missingLoginPrologueOutcome() {
+  const timestamp = (/* @__PURE__ */ new Date()).toISOString();
+  return {
+    schemaVersion: 1,
+    state: LOGIN_PROLOGUE_BLOCKED,
+    alias: LOGIN_PROLOGUE_ALIAS,
+    startedAt: timestamp,
+    endedAt: timestamp,
+    elapsedMs: 0,
+    steps: [],
+    inventory: { count: 0, actionIds: [] },
+    failure: {
+      code: "LOGIN_PROLOGUE_RESULT_INVALID",
+      detail: "The login prologue returned no valid terminal state."
+    }
+  };
+}
+function isActionReplayTool(tool) {
+  return tool === "cdp_run_action" || tool === "cdp_login_prologue";
+}
 function authorityErrorCode(error2) {
   return error2 instanceof SessionAuthorityError ? error2.code : /^([A-Z][A-Z0-9_]+):/.exec(error2 instanceof Error ? error2.message : String(error2))?.[1];
 }
@@ -32799,10 +32890,43 @@ function createAuthorityGate(runtime, dependencies) {
         mutation: true,
         liveBundleProbe: tool === "proof_capture"
       } : baseProfile;
+      let runtimeStatus = runtime.status();
+      const loginDecision = evaluateLoginPrologueGuard({
+        binding: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
+        tool,
+        args,
+        mutation: profile.mutation,
+        expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.()
+      });
+      delete args.supervisorOverrideToken;
+      if (!loginDecision.allowed) {
+        return failResult("LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.", "LOGIN_PROLOGUE_BLOCKED", {
+          loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
+          overrideRejected: loginDecision.suppliedOverride,
+          nextAction: "Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call."
+        });
+      }
+      if (loginDecision.override) {
+        try {
+          const available = runtime.requireAvailable();
+          const current = runtime.status();
+          const outcome = current.available ? readLoginPrologueOutcome(current.bindings.loginPrologue) : null;
+          if (!outcome) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
+          }
+          available.registry.updateBindings(available.session, {
+            bindings: {
+              loginPrologue: appendLoginOverrideAudit(outcome, loginDecision.audit)
+            }
+          });
+          runtimeStatus = runtime.status();
+        } catch (error2) {
+          return authorityFailure(error2);
+        }
+      }
       if (profile.kind === "diagnostic") {
         return addMeta2(await handler(...handlerArgs), { authoritative: false });
       }
-      const runtimeStatus = runtime.status();
       if (runtimeStatus.available && runtimeStatus.state === "blocked") {
         return authorityFailure(runtime.blockedContenderError());
       }
@@ -33416,7 +33540,15 @@ function createAuthorityGate(runtime, dependencies) {
         }
         registry2.verifyOperation(operation);
         const snapshotCheckpoint = dependencies.snapshotCaptureCheckpoint?.();
-        const result = await registry2.runWithOperation(operation, () => handler(...handlerArgs));
+        let result = await registry2.runWithOperation(operation, () => handler(...handlerArgs));
+        let loginPrologueOutcome = null;
+        if (tool === "cdp_login_prologue") {
+          loginPrologueOutcome = parseLoginPrologueOutcome(result);
+          if (!loginPrologueOutcome) {
+            loginPrologueOutcome = missingLoginPrologueOutcome();
+            result = failResult("Login prologue returned no valid terminal state.", "LOGIN_PROLOGUE_BLOCKED", { loginPrologue: loginPrologueOutcome });
+          }
+        }
         let runtimeTargetChanged = false;
         const postHandlerRecovery = await reconcileRecoverableRuntime(runtime, dependencies, registry2, operation, status, profile, resultSucceeded(result));
         operation = postHandlerRecovery.operation;
@@ -33439,7 +33571,7 @@ function createAuthorityGate(runtime, dependencies) {
         }
         publishedProofFinalize = tool === "proof_capture" && args.action === "finalize" && resultIsCanonicalSuccess(result);
         const directRuntimeReset = tool === "cdp_reload" || tool === "cdp_restart";
-        const nestedRuntimeReset = tool === "cdp_run_e2e_suite" || tool === "cdp_auto_login" || tool === "cdp_nav_graph" && args.action === "go" || tool === "cdp_run_action" && (optionalBundleClaimed || optionalBundleRecoveryFailed);
+        const nestedRuntimeReset = tool === "cdp_run_e2e_suite" || tool === "cdp_auto_login" || tool === "cdp_nav_graph" && args.action === "go" || isActionReplayTool(tool) && (optionalBundleClaimed || optionalBundleRecoveryFailed);
         const reconcilesRuntimeTarget = directRuntimeReset || nestedRuntimeReset;
         let authorityInvalidated = false;
         if (directRuntimeReset && !resultSucceeded(result)) {
@@ -33454,7 +33586,7 @@ function createAuthorityGate(runtime, dependencies) {
           const metro = status.bindings.metro;
           let bundle = null;
           try {
-            if (tool === "cdp_run_action" && optionalBundleRecoveryFailed) {
+            if (isActionReplayTool(tool) && optionalBundleRecoveryFailed) {
               throw new SessionAuthorityError("BUNDLE_HANDSHAKE_UNAVAILABLE", "reactive bundle authority did not verify");
             }
             if (!dependencies.refreshRuntimeBinding) {
@@ -33474,7 +33606,7 @@ function createAuthorityGate(runtime, dependencies) {
                 nextAction: 'Run rn_session action "pin_dev_client" before another CDP operation.'
               });
             }
-            if (tool === "cdp_run_action" && !optionalBundleClaimed) {
+            if (isActionReplayTool(tool) && !optionalBundleClaimed) {
               authorityInvalidated = true;
             } else {
               throw error2;
@@ -33536,6 +33668,22 @@ function createAuthorityGate(runtime, dependencies) {
           axes: [...runnerAwareReceiptProfile.axes, "M", "A"]
         } : runnerAwareReceiptProfile;
         const controllerGenerationAdvanced = operation.authorityVersion !== initialOperationAuthorityVersion;
+        if (loginPrologueOutcome) {
+          const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+          operation = registry2.replaceBindingsDuringOperation(operation, {
+            bindings: {
+              loginPrologue: {
+                ...loginPrologueOutcome,
+                ...priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}
+              }
+            }
+          });
+          const loginStatus = runtime.status();
+          if (!loginStatus.available) {
+            throw new SessionAuthorityError(loginStatus.code, loginStatus.reason);
+          }
+          status = loginStatus;
+        }
         registry2.verifyOperation(operation);
         for (const observation of allBefore) {
           if (controllerGenerationAdvanced && observation.axis === "C")
@@ -33633,6 +33781,7 @@ var init_authority_gate = __esm({
     init_registry();
     init_metro_origin();
     init_install_reissue();
+    init_login_prologue();
     init_tool_profiles();
     optionalBundleAdmission = /* @__PURE__ */ Symbol("optionalBundleAdmission");
     managedNativeOrigin = /* @__PURE__ */ Symbol("managedNativeOrigin");
@@ -38947,9 +39096,9 @@ var init_settle = __esm({
 // packages/rn-dev-agent-core/dist/agent-device-wrapper.js
 import { unlinkSync as unlinkSync13, rmSync as rmSync7 } from "node:fs";
 import { join as join30 } from "node:path";
-import { createHash as createHash7 } from "node:crypto";
+import { createHash as createHash8 } from "node:crypto";
 function getSessionFilePath() {
-  const projectId = createHash7("sha256").update(process.cwd()).digest("hex").slice(0, 12);
+  const projectId = createHash8("sha256").update(process.cwd()).digest("hex").slice(0, 12);
   return join30(getStateDir(), `session-${projectId}.json`);
 }
 function getActiveSession() {
@@ -40878,7 +41027,7 @@ ensureJavaEnv();
 ensureCwd();
 
 // packages/rn-dev-agent-core/dist/index.js
-import { createHash as createHash22, createHmac as createHmac5, randomUUID as randomUUID10 } from "node:crypto";
+import { createHash as createHash23, createHmac as createHmac5, randomUUID as randomUUID11 } from "node:crypto";
 import { readFileSync as readFileSync42, rmSync as rmSync12 } from "node:fs";
 import { execFile as execFile23 } from "node:child_process";
 import { promisify as promisify26 } from "node:util";
@@ -61792,7 +61941,7 @@ function inspectInstallIdentity(install, dependencies = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/session/migration-diagnostic.js
-import { createHash as createHash8 } from "node:crypto";
+import { createHash as createHash9 } from "node:crypto";
 import { existsSync as existsSync25, readFileSync as readFileSync26 } from "node:fs";
 import { join as join34 } from "node:path";
 
@@ -63670,7 +63819,7 @@ function inspectAuthorityMigration(status, dependencies = {}) {
   const integrationBinding = status.bindings.packageIntegration;
   let bindingDiagnostic = null;
   if (integrationBinding) {
-    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash8("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
+    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash9("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
     const manifestAvailable = manifestVerified(onDiskManifestText) || manifestVerified(integrationBinding.restoration?.phase === "started" ? integrationBinding.restoration.manifestSource : void 0) || manifestVerified(integrationBinding.installation?.phase === "started" ? integrationBinding.installation.manifestSource : void 0) || manifestVerified(integrationBinding.manifestSource);
     const effectiveOwnerSessionId = status.sessionId;
     const trustedDigestRecorded = typeof integrationBinding.manifestSha256 === "string" && /^[0-9a-f]{64}$/.test(integrationBinding.manifestSha256);
@@ -63709,6 +63858,7 @@ function inspectAuthorityMigration(status, dependencies = {}) {
 
 // packages/rn-dev-agent-core/dist/session/public-status.js
 init_registry();
+init_login_prologue();
 var SELECTED_STATES = /* @__PURE__ */ new Set(["active", "source_bound", "device_claimed", "metro_bound"]);
 var RUNNING_STATES = /* @__PURE__ */ new Set(["device_bound", "runtime_bound", "ready"]);
 function derivePublicPhase(state, buildPending) {
@@ -63785,6 +63935,7 @@ function projectPublicAuthorityStatus(status, options = {}) {
     observedAt: metroTerminal.observedAt
   } : void 0;
   const sandbox = metro?.runtimeEvidenceAuthority === "managed-sandbox-v1" ? "managed-sandbox-v1" : "unavailable";
+  const loginPrologue = readLoginPrologueOutcome(status.bindings.loginPrologue);
   const phase = derivePublicPhase(status.state, Boolean(status.bindings.pendingBuild));
   return {
     available: true,
@@ -63828,6 +63979,20 @@ function projectPublicAuthorityStatus(status, options = {}) {
     proof: Boolean(status.bindings.proof),
     // ADR §5.2 (L3): strict proof is an opt-in overlay outside the four groups, never a group.
     proofOverlay: { active: Boolean(status.bindings.proof) },
+    ...loginPrologue ? {
+      loginPrologue: {
+        state: loginPrologue.state,
+        alias: loginPrologue.alias,
+        actionId: loginPrologue.actionId,
+        startedAt: loginPrologue.startedAt,
+        endedAt: loginPrologue.endedAt,
+        elapsedMs: loginPrologue.elapsedMs,
+        failureCode: loginPrologue.failure?.code,
+        runId: loginPrologue.runRecord?.runId,
+        overrideCount: loginPrologue.overrides?.length ?? 0,
+        lastOverride: loginPrologue.overrides?.at(-1)
+      }
+    } : {},
     ...options.installIdentity ? { installIdentity: options.installIdentity.verdict } : {},
     // A live axis-I refusal means every gated tool refuses too — status must
     // not read `ready` while that is true. A pending re-issue reads ready only
@@ -63878,7 +64043,7 @@ init_registry();
 init_utils();
 
 // packages/rn-dev-agent-core/dist/session/build-receipt.js
-import { createHmac, timingSafeEqual as timingSafeEqual3 } from "node:crypto";
+import { createHmac, timingSafeEqual as timingSafeEqual4 } from "node:crypto";
 function serialize(payload) {
   return JSON.stringify(payload);
 }
@@ -63894,7 +64059,7 @@ function verifyBuildReceipt(receipt2, capability, expected) {
   }
   const expectedSignature = Buffer.from(sign(receipt2.payload, capability), "hex");
   const actualSignature = Buffer.from(receipt2.signature, "hex");
-  if (expectedSignature.length !== actualSignature.length || !timingSafeEqual3(expectedSignature, actualSignature)) {
+  if (expectedSignature.length !== actualSignature.length || !timingSafeEqual4(expectedSignature, actualSignature)) {
     throw new Error("BUILD_RECEIPT_INVALID: build receipt signature is invalid");
   }
   for (const [key, value] of Object.entries(expected)) {
@@ -64169,7 +64334,7 @@ function createBuildLaunchPlan(input) {
 
 // packages/rn-dev-agent-core/dist/session/managed-metro.js
 import { execFileSync as execFileSync10, spawn as spawn7 } from "node:child_process";
-import { createHash as createHash10, createHmac as createHmac2, timingSafeEqual as timingSafeEqual4 } from "node:crypto";
+import { createHash as createHash11, createHmac as createHmac2, timingSafeEqual as timingSafeEqual5 } from "node:crypto";
 import { closeSync as closeSync7, existsSync as existsSync27, fstatSync as fstatSync5, mkdirSync as mkdirSync17, openSync as openSync7, readFileSync as readFileSync28, readSync as readSync2, realpathSync as realpathSync11, rmSync as rmSync11 } from "node:fs";
 init_metro_binding();
 init_trusted_system_executable();
@@ -64267,13 +64432,13 @@ function canonicalAuthorityJson(value) {
 
 // packages/rn-dev-agent-core/dist/session/managed-metro-enforcement.js
 import { spawnSync as spawnSync2 } from "node:child_process";
-import { createHash as createHash9 } from "node:crypto";
+import { createHash as createHash10 } from "node:crypto";
 import { closeSync as closeSync6, constants as constants6, existsSync as existsSync26, mkdirSync as mkdirSync16, openSync as openSync6, readFileSync as readFileSync27, realpathSync as realpathSync10, rmSync as rmSync10, statSync as statSync12, symlinkSync as symlinkSync3, writeSync as writeSync2 } from "node:fs";
 import { dirname as dirname17, resolve as resolve10 } from "node:path";
 var DARWIN_SANDBOX_EXECUTABLE = "/usr/bin/sandbox-exec";
 var DARWIN_CODESIGN_EXECUTABLE = "/usr/bin/codesign";
 function sha256(value) {
-  return createHash9("sha256").update(value).digest("hex");
+  return createHash10("sha256").update(value).digest("hex");
 }
 function defaultRun2(command, args) {
   const result = spawnSync2(command, [...args], {
@@ -65778,7 +65943,7 @@ function verifyManagedMetroManagementProof(binding, input) {
   }, input.signerCapability);
   const expectedBuffer = Buffer.from(expected, "hex");
   const observedBuffer = Buffer.from(binding.managementProof, "hex");
-  return expectedBuffer.length === observedBuffer.length && timingSafeEqual4(expectedBuffer, observedBuffer);
+  return expectedBuffer.length === observedBuffer.length && timingSafeEqual5(expectedBuffer, observedBuffer);
 }
 function exactManagedProcessInspection(role, pid, birth, probe) {
   const prefix = role === "launcher" ? "METRO_LAUNCHER" : "METRO_LISTENER";
@@ -66040,7 +66205,7 @@ async function stopManagedMetro(binding, input, dependencies = {}) {
   ];
   if (!expectedProofs.some((expected) => {
     const expectedBuffer = Buffer.from(expected, "hex");
-    return expectedBuffer.length === observedBuffer.length && timingSafeEqual4(expectedBuffer, observedBuffer);
+    return expectedBuffer.length === observedBuffer.length && timingSafeEqual5(expectedBuffer, observedBuffer);
   })) {
     return false;
   }
@@ -66081,7 +66246,7 @@ import { closeSync as closeSync8, constants as constants7, fstatSync as fstatSyn
 import { basename as basename10, isAbsolute as isAbsolute7, join as join35, relative as relative6, resolve as resolve11, sep as sep8 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/metro-authority.js
-import { createHmac as createHmac3, createSecretKey, timingSafeEqual as timingSafeEqual5 } from "node:crypto";
+import { createHmac as createHmac3, createSecretKey, timingSafeEqual as timingSafeEqual6 } from "node:crypto";
 function serializePayload(payload) {
   return JSON.stringify(payload);
 }
@@ -66098,7 +66263,7 @@ function verifyMetroAuthorityMarker(marker, signerCapability, expected = {}) {
   }
   const signature = Buffer.from(marker.signature, "hex");
   const actual = Buffer.from(signPayload(marker.payload, signerCapability), "hex");
-  if (signature.length !== actual.length || !timingSafeEqual5(signature, actual)) {
+  if (signature.length !== actual.length || !timingSafeEqual6(signature, actual)) {
     throw mismatch();
   }
   for (const [key, value] of Object.entries(expected)) {
@@ -70310,17 +70475,17 @@ function restorePackageIntegrationFiles(input, dependencies = {}) {
 // packages/rn-dev-agent-core/dist/tools/session.js
 import { dirname as dirname19, isAbsolute as isAbsolute9, join as join39, resolve as resolve14 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { createHash as createHash13 } from "node:crypto";
+import { createHash as createHash14 } from "node:crypto";
 
 // packages/rn-dev-agent-core/dist/session/source-identity.js
 init_metro_cwd();
-import { createHash as createHash11, createHmac as createHmac4, randomBytes as randomBytes6, timingSafeEqual as timingSafeEqual6 } from "node:crypto";
+import { createHash as createHash12, createHmac as createHmac4, randomBytes as randomBytes6, timingSafeEqual as timingSafeEqual7 } from "node:crypto";
 import { execFileSync as execFileSync11 } from "node:child_process";
 import { closeSync as closeSync9, constants as constants8, existsSync as existsSync28, fstatSync as fstatSync7, lstatSync as lstatSync15, openSync as openSync9, readdirSync as readdirSync11, readFileSync as readFileSync30, readlinkSync as readlinkSync5, readSync as readSync3, realpathSync as realpathSync12 } from "node:fs";
 import { dirname as dirname18, isAbsolute as isAbsolute8, join as join36, relative as relative7, resolve as resolve12 } from "node:path";
 init_declared_source_contract();
 function digest2(parts) {
-  const hash = createHash11("sha256");
+  const hash = createHash12("sha256");
   for (const part of parts) {
     hash.update(part);
     hash.update("\0");
@@ -70427,7 +70592,7 @@ function updateFramedFile(hash, path, maximumBytes) {
   return updateStableFile(hash, path, maximumBytes, true);
 }
 function fileDigest(path) {
-  const hash = createHash11("sha256");
+  const hash = createHash12("sha256");
   updateStableFile(hash, path, MAX_STRICT_PROOF_DEPENDENCY_FILE_BYTES, false);
   return hash.digest("hex");
 }
@@ -70534,7 +70699,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
   const expected = createHmac4("sha256", authority.capability).update(canonicalAuthorityJson(payload)).digest();
   const observed = typeof receipt2.signature === "string" ? Buffer.from(receipt2.signature, "hex") : Buffer.alloc(0);
   const runtimeManifest = receipt2.runtimeManifest && typeof receipt2.runtimeManifest === "object" ? receipt2.runtimeManifest : null;
-  if (receipt2.version !== 1 || receipt2.runtimeEvidenceAuthority !== authority.evidenceAuthority || receipt2.sessionId !== authority.sessionId || receipt2.metroInstanceId !== authority.metroInstanceId || receipt2.contentRoot !== identity2.contentRoot || receipt2.appRoot !== identity2.appRoot || !runtimeManifest || runtimeManifest.version !== 1 || typeof runtimeManifest.executable !== "string" || typeof runtimeManifest.sourceExecutable !== "string" || typeof runtimeManifest.nodeExecutable !== "string" || typeof runtimeManifest.nodeVersion !== "string" || !Number.isSafeInteger(runtimeManifest.port) || runtimeManifest.port < 1 || runtimeManifest.port > 65535 || !Array.isArray(runtimeManifest.args) || runtimeManifest.args.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.commandProbeArguments) || runtimeManifest.commandProbeArguments.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.commandExecutableMappings) || runtimeManifest.commandExecutableMappings.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.commandChainInputs) || runtimeManifest.commandChainInputs.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.protectedRuntimeRoots) || runtimeManifest.protectedRuntimeRoots.some((entry) => typeof entry !== "string") || typeof runtimeManifest.nodeOptions !== "string" || typeof runtimeManifest.environmentDigest !== "string" || !/^[a-f0-9]{64}$/.test(runtimeManifest.environmentDigest) || runtimeManifest.contentRoot !== identity2.contentRoot || runtimeManifest.appRoot !== identity2.appRoot || typeof runtimeManifest.servingRoot !== "string" || !Number.isSafeInteger(runtimeManifest.buildGeneration) || !Array.isArray(runtimeManifest.packageInputs) || runtimeManifest.packageInputs.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.metroConfigInputs) || runtimeManifest.metroConfigInputs.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.dependencyRoots) || runtimeManifest.dependencyRoots.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.runtimeInputs) || runtimeManifest.runtimeInputs.some((entry) => typeof entry !== "string") || !runtimeManifest.descendantAuthority || typeof runtimeManifest.descendantAuthority !== "object" || !Array.isArray(receipt2.runtimeInputs) || receipt2.runtimeInputs.some((entry) => typeof entry !== "string") || canonicalAuthorityJson(runtimeManifest.runtimeInputs) !== canonicalAuthorityJson(receipt2.runtimeInputs) || !Array.isArray(receipt2.violations) || receipt2.violations.some((entry) => typeof entry !== "string") || observed.length !== expected.length || !timingSafeEqual6(observed, expected)) {
+  if (receipt2.version !== 1 || receipt2.runtimeEvidenceAuthority !== authority.evidenceAuthority || receipt2.sessionId !== authority.sessionId || receipt2.metroInstanceId !== authority.metroInstanceId || receipt2.contentRoot !== identity2.contentRoot || receipt2.appRoot !== identity2.appRoot || !runtimeManifest || runtimeManifest.version !== 1 || typeof runtimeManifest.executable !== "string" || typeof runtimeManifest.sourceExecutable !== "string" || typeof runtimeManifest.nodeExecutable !== "string" || typeof runtimeManifest.nodeVersion !== "string" || !Number.isSafeInteger(runtimeManifest.port) || runtimeManifest.port < 1 || runtimeManifest.port > 65535 || !Array.isArray(runtimeManifest.args) || runtimeManifest.args.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.commandProbeArguments) || runtimeManifest.commandProbeArguments.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.commandExecutableMappings) || runtimeManifest.commandExecutableMappings.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.commandChainInputs) || runtimeManifest.commandChainInputs.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.protectedRuntimeRoots) || runtimeManifest.protectedRuntimeRoots.some((entry) => typeof entry !== "string") || typeof runtimeManifest.nodeOptions !== "string" || typeof runtimeManifest.environmentDigest !== "string" || !/^[a-f0-9]{64}$/.test(runtimeManifest.environmentDigest) || runtimeManifest.contentRoot !== identity2.contentRoot || runtimeManifest.appRoot !== identity2.appRoot || typeof runtimeManifest.servingRoot !== "string" || !Number.isSafeInteger(runtimeManifest.buildGeneration) || !Array.isArray(runtimeManifest.packageInputs) || runtimeManifest.packageInputs.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.metroConfigInputs) || runtimeManifest.metroConfigInputs.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.dependencyRoots) || runtimeManifest.dependencyRoots.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.runtimeInputs) || runtimeManifest.runtimeInputs.some((entry) => typeof entry !== "string") || !runtimeManifest.descendantAuthority || typeof runtimeManifest.descendantAuthority !== "object" || !Array.isArray(receipt2.runtimeInputs) || receipt2.runtimeInputs.some((entry) => typeof entry !== "string") || canonicalAuthorityJson(runtimeManifest.runtimeInputs) !== canonicalAuthorityJson(receipt2.runtimeInputs) || !Array.isArray(receipt2.violations) || receipt2.violations.some((entry) => typeof entry !== "string") || observed.length !== expected.length || !timingSafeEqual7(observed, expected)) {
     throw new Error("STRICT_PROOF_UNVERIFIED_METRO_POLICY: runtime policy receipt is invalid");
   }
   if (!pathIsWithinRoot(runtimeManifest.servingRoot, identity2.contentRoot)) {
@@ -70619,7 +70784,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
     };
     const expectedLoad = createHmac4("sha256", authority.capability).update(canonicalAuthorityJson(loadPayload)).digest();
     const observedLoad = typeof load.signature === "string" ? Buffer.from(load.signature, "hex") : Buffer.alloc(0);
-    if (load.version !== 1 || load.runtimeEvidenceAuthority !== authority.evidenceAuthority || load.sessionId !== authority.sessionId || load.metroInstanceId !== authority.metroInstanceId || load.kind !== "input" && load.kind !== "violation" && load.kind !== "launch" && load.kind !== "attestation" && load.kind !== "semantics" && load.kind !== "pending" && load.kind !== "completion" && load.kind !== "stability" || typeof load.value !== "string" || !Number.isSafeInteger(load.sequence) || load.sequence !== evidenceSequence + 1 || load.previousSignature !== previousEvidenceSignature || (load.kind === "input" || load.kind === "stability" ? typeof load.digest !== "string" || !/^[a-f0-9]{64}$/.test(load.digest) : load.digest !== null) || observedLoad.length !== expectedLoad.length || !timingSafeEqual6(observedLoad, expectedLoad)) {
+    if (load.version !== 1 || load.runtimeEvidenceAuthority !== authority.evidenceAuthority || load.sessionId !== authority.sessionId || load.metroInstanceId !== authority.metroInstanceId || load.kind !== "input" && load.kind !== "violation" && load.kind !== "launch" && load.kind !== "attestation" && load.kind !== "semantics" && load.kind !== "pending" && load.kind !== "completion" && load.kind !== "stability" || typeof load.value !== "string" || !Number.isSafeInteger(load.sequence) || load.sequence !== evidenceSequence + 1 || load.previousSignature !== previousEvidenceSignature || (load.kind === "input" || load.kind === "stability" ? typeof load.digest !== "string" || !/^[a-f0-9]{64}$/.test(load.digest) : load.digest !== null) || observedLoad.length !== expectedLoad.length || !timingSafeEqual7(observedLoad, expectedLoad)) {
       throw new Error("STRICT_PROOF_UNVERIFIED_METRO_POLICY: runtime load evidence is invalid");
     }
     evidenceSequence = load.sequence;
@@ -70657,7 +70822,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
         throw new Error("STRICT_PROOF_UNVERIFIED_METRO_POLICY: runtime semantics are unbounded");
       }
       runtimeSemantics.add(load.value);
-      runtimeSemanticsByDigest.set(createHash11("sha256").update(load.value).digest("hex"), load.value);
+      runtimeSemanticsByDigest.set(createHash12("sha256").update(load.value).digest("hex"), load.value);
       orderedRuntimeSemantics.push(load.value);
       continue;
     }
@@ -70701,7 +70866,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
   };
   const expectedHead = createHmac4("sha256", authority.capability).update(canonicalAuthorityJson(headPayload)).digest();
   const observedHead = typeof head.signature === "string" ? Buffer.from(head.signature, "hex") : Buffer.alloc(0);
-  if (head.version !== 1 || head.runtimeEvidenceAuthority !== authority.evidenceAuthority || head.sessionId !== authority.sessionId || head.metroInstanceId !== authority.metroInstanceId || head.challenge !== challenge || head.sequence !== evidenceSequence || head.journalSignature !== previousEvidenceSignature || observedHead.length !== expectedHead.length || !timingSafeEqual6(observedHead, expectedHead)) {
+  if (head.version !== 1 || head.runtimeEvidenceAuthority !== authority.evidenceAuthority || head.sessionId !== authority.sessionId || head.metroInstanceId !== authority.metroInstanceId || head.challenge !== challenge || head.sequence !== evidenceSequence || head.journalSignature !== previousEvidenceSignature || observedHead.length !== expectedHead.length || !timingSafeEqual7(observedHead, expectedHead)) {
     throw new Error("STRICT_PROOF_UNVERIFIED_METRO_POLICY: runtime evidence head is invalid");
   }
   for (const launch of descendantLaunches.keys()) {
@@ -70978,7 +71143,7 @@ function strictProofSourceIdentity(identity2, dependencies = {}) {
       throw new Error(`STRICT_PROOF_DIRTY_SUBMODULE: ${entry} contains source changes outside the parent digest`);
     }
   }
-  const dirtyHash = createHash11("sha256");
+  const dirtyHash = createHash12("sha256");
   updateFramed(dirtyHash, "git-dirty-v3");
   updateFramed(dirtyHash, diff);
   for (const semantics of runtimeInputs.semantics) {
@@ -71093,7 +71258,7 @@ function inspectSessionOwner(owner, dependencies = {}) {
 
 // packages/rn-dev-agent-core/dist/session/startup-cleanup.js
 init_secure_state_file();
-import { createHash as createHash12 } from "node:crypto";
+import { createHash as createHash13 } from "node:crypto";
 import { join as join38 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/android-metro-reverse.js
@@ -71677,7 +71842,7 @@ function restoreDeadOwnerIntegration(input, prior, plan, dependencies) {
 function verifiedDeadOwnerManifestSource(appRoot, binding, manifestSha256) {
   if (!/^[0-9a-f]{64}$/.test(manifestSha256))
     return void 0;
-  const verified = (candidate) => typeof candidate === "string" && createHash12("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
+  const verified = (candidate) => typeof candidate === "string" && createHash13("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
   let liveManifest;
   try {
     liveManifest = readPackageIntegrationInputs(appRoot).manifest ?? void 0;
@@ -71783,7 +71948,7 @@ function sameMetroAuthority(current, next) {
 function verifiedManifestSource(candidate, manifestSha256) {
   if (typeof candidate !== "string" || typeof manifestSha256 !== "string")
     return void 0;
-  return createHash13("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
+  return createHash14("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
 }
 function durableBindingManifestSource(binding) {
   return verifiedManifestSource(binding?.manifestSource, binding?.manifestSha256);
@@ -72729,7 +72894,7 @@ function createSessionHandler(runtime, dependencies = {}) {
             });
           }
           assertPackageIntegrationInactive(status.bindings, input.action);
-          const manifestSha256 = createHash13("sha256").update(manifestSource ?? "").digest("hex");
+          const manifestSha256 = createHash14("sha256").update(manifestSource ?? "").digest("hex");
           if (integrationBinding?.version !== 1 || typeof integrationBinding.installedBySessionId !== "string" || integrationBinding.manifestSha256 !== manifestSha256) {
             throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "integration restoration requires the transferred manifest authority binding");
           }
@@ -72776,7 +72941,7 @@ function createSessionHandler(runtime, dependencies = {}) {
         }
         preview.manifest.metroConfig = metroConfigPath.slice(appRoot.length + 1);
         const expectedManifestSource = installationManifestSource ?? serializePackageIntegrationManifest(preview.manifest);
-        const expectedManifestSha256 = createHash13("sha256").update(expectedManifestSource).digest("hex");
+        const expectedManifestSha256 = createHash14("sha256").update(expectedManifestSource).digest("hex");
         if (installationManifestSource && (integrationBinding?.version !== 1 || integrationBinding.installedBySessionId !== session2.sessionId || integrationBinding.manifestSha256 !== expectedManifestSha256)) {
           throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "integration installation requires the original session manifest authority binding");
         }
@@ -72798,7 +72963,7 @@ function createSessionHandler(runtime, dependencies = {}) {
           if (!installedManifest) {
             throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: applied manifest is unavailable");
           }
-          if (createHash13("sha256").update(installedManifest).digest("hex") !== expectedManifestSha256) {
+          if (createHash14("sha256").update(installedManifest).digest("hex") !== expectedManifestSha256) {
             throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "applied integration manifest no longer matches its durable installation authority");
           }
           registry2.updateBindings(session2, {
@@ -74522,6 +74687,7 @@ var TESTING = /* @__PURE__ */ new Set([
   "maestro_run",
   "maestro_generate",
   "maestro_test_all",
+  "cdp_login_prologue",
   "cdp_run_action",
   "cdp_repair_action",
   "proof_step",
@@ -77399,6 +77565,7 @@ init_action_state_store();
 init_reusable_action();
 init_maestro_error_parser();
 init_maestro_run();
+import { randomUUID as randomUUID8 } from "node:crypto";
 init_path_safety();
 
 // packages/rn-dev-agent-core/dist/nav-graph/route-sequence.js
@@ -78143,6 +78310,23 @@ function createRunActionHandler(deps = {}) {
     const trigger = args.trigger ?? "agent";
     const timeoutMs = args.timeoutMs ?? 12e4;
     const t0 = Date.now();
+    const startedAt = new Date(t0).toISOString();
+    const runId = randomUUID8();
+    const timingSteps = [];
+    const measureStep = async (name, run) => {
+      const stepStartedMs = Date.now();
+      try {
+        return await run();
+      } finally {
+        const stepEndedMs = Date.now();
+        timingSteps.push({
+          name,
+          startedAt: new Date(stepStartedMs).toISOString(),
+          endedAt: new Date(stepEndedMs).toISOString(),
+          elapsedMs: Math.max(0, stepEndedMs - stepStartedMs)
+        });
+      }
+    };
     const activeTarget = targetContext();
     if (args.platform && activeTarget?.platform && activeTarget.platform !== args.platform) {
       return failResult(`cdp_run_action: requested ${args.platform}, but the active session is ${activeTarget.platform}; refusing cross-platform replay.`, "TARGET_SESSION_MISMATCH", { requestedPlatform: args.platform, activeSession: activeTarget });
@@ -78152,7 +78336,22 @@ function createRunActionHandler(deps = {}) {
     const appFile = args.appFile ?? (flowUsesClearState(replayYaml) && receipt2?.platform === "ios" && typeof receipt2.appId === "string" && typeof receipt2.deviceId === "string" ? resolveAppFile(receipt2.appId, receipt2.deviceId) ?? void 0 : void 0);
     let probeDeviceId = null;
     let observedDeviceId = maestroDeviceId ?? null;
-    const persistRunWithDevice = (record2) => proofReplay ? Promise.resolve({ promoted: false, promotionRefused: false }) : persistRun(args.actionId, projectRoot, probeDeviceId ? { ...record2, deviceId: probeDeviceId } : record2);
+    const persistRunWithDevice = (record2) => {
+      if (proofReplay)
+        return Promise.resolve({ promoted: false, promotionRefused: false });
+      const endedMs = Date.now();
+      const timedRecord = {
+        ...record2,
+        runId,
+        timing: {
+          startedAt,
+          endedAt: new Date(endedMs).toISOString(),
+          elapsedMs: Math.max(0, endedMs - t0),
+          steps: [...timingSteps]
+        }
+      };
+      return persistRun(args.actionId, projectRoot, probeDeviceId ? { ...timedRecord, deviceId: probeDeviceId } : timedRecord);
+    };
     const writeDisclosure = (actionYaml = "none", outcome) => ({
       actionYaml: actionYaml === "none" ? { written: false, reason: "repair-not-applied" } : actionYaml === "lifecycle-promotion-refused" ? { written: false, reason: "lifecycle-promotion-refused" } : { written: true, authorized: true, reason: actionYaml },
       runtimeState: proofReplay ? "none" : outcome?.runtimeStateRefused ? "refused-external-write" : "sidecar",
@@ -78183,11 +78382,11 @@ function createRunActionHandler(deps = {}) {
         const probe = replayDeps ? firstReplayTestId(cdpReplayYaml, args.params ?? {}) : null;
         if (replayDeps && probe) {
           const tProbe = Date.now();
-          const probeOutcome = await probeTreeWithRetry(replayDeps, probe, probeRetry);
+          const probeOutcome = await measureStep("proactive-probe", () => probeTreeWithRetry(replayDeps, probe, probeRetry));
           if (probeOutcome.found) {
             const tReplay = Date.now();
             try {
-              const replay = await runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps);
+              const replay = await measureStep("proactive-cdp-replay", () => runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps));
               const timings_ms = { probe: tReplay - tProbe, replay: Date.now() - tReplay };
               const blindProbe = { atRisk, skippedMaestro: true };
               const autoRepair2 = {
@@ -78242,7 +78441,7 @@ function createRunActionHandler(deps = {}) {
       }
       const tBeforeFirst = Date.now();
       probeDeviceId = null;
-      const firstResult = await maestroRun({
+      const firstResult = await measureStep("maestro-first-attempt", () => maestroRun({
         inlineYaml: replayYaml,
         actionMetadata: action.metadata,
         platform: args.platform,
@@ -78257,7 +78456,7 @@ function createRunActionHandler(deps = {}) {
         reproveManagedOrigin: () => reproveManagedOrigin(args),
         completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
         reissueInstallReceipt: () => reissueInstallReceipt(args)
-      });
+      }));
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, "maestro_run");
       const firstPassed = firstEnv.ok === true && firstEnv.data?.passed === true;
@@ -78355,7 +78554,7 @@ function createRunActionHandler(deps = {}) {
         } else if (!probe) {
           cdpJsFallback = { attempted: false, reason: "no-probe-testid" };
         } else {
-          const probeOutcome = await probeTreeWithRetry(replayDeps, probe, probeRetry);
+          const probeOutcome = await measureStep("fallback-probe", () => probeTreeWithRetry(replayDeps, probe, probeRetry));
           if (!probeOutcome.found) {
             cdpJsFallback = {
               attempted: false,
@@ -78370,9 +78569,9 @@ function createRunActionHandler(deps = {}) {
               firstAttemptOutput: boundedOutput(firstOutput)
             };
             try {
-              const replay = await runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps, {
+              const replay = await measureStep("fallback-cdp-replay", () => runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps, {
                 resumeAtSelector: failure.kind === "SELECTOR_NOT_FOUND" ? failure.selector : null
-              });
+              }));
               const status = replay.passed ? "pass" : "fail";
               const autoRepair2 = {
                 attempted: false,
@@ -78466,12 +78665,12 @@ function createRunActionHandler(deps = {}) {
         throw new Error("Internal: isAutoRepairable returned true for non-SELECTOR_NOT_FOUND failure");
       }
       const tBeforeRepair = Date.now();
-      const repairResult = await repairAction({
+      const repairResult = await measureStep("selector-repair", () => repairAction({
         actionId: args.actionId,
         failedSelector: failure.selector,
         projectRoot,
         agentReasoning: `auto-repair from cdp_run_action after maestro failure: ${failure.selector}`
-      });
+      }));
       const repairMs = Date.now() - tBeforeRepair;
       const repairEnv = parseEnvelope(repairResult, "cdp_repair_action");
       const repairPatched = repairEnv.ok === true && repairEnv.data?.patched === true;
@@ -78527,10 +78726,11 @@ function createRunActionHandler(deps = {}) {
       if (!reloadedAction.replay.ok) {
         return failResult(`cdp_run_action: repaired action is not valid Maestro YAML: ${reloadedAction.replay.error}`, "BAD_RECORDING", { actionId: args.actionId });
       }
+      const retryYaml = reloadedAction.replay.yamlText;
       const tBeforeRetry = Date.now();
       probeDeviceId = null;
-      const retryResult = await maestroRun({
-        inlineYaml: reloadedAction.replay.yamlText,
+      const retryResult = await measureStep("maestro-retry", () => maestroRun({
+        inlineYaml: retryYaml,
         actionMetadata: reloadedAction.metadata,
         platform: args.platform,
         appId: args.appId,
@@ -78544,7 +78744,7 @@ function createRunActionHandler(deps = {}) {
         reproveManagedOrigin: () => reproveManagedOrigin(args),
         completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
         reissueInstallReceipt: () => reissueInstallReceipt(args)
-      });
+      }));
       const retryMs = Date.now() - tBeforeRetry;
       const retryEnv = parseEnvelope(retryResult, "maestro_run");
       const retryPassed = retryEnv.ok === true && retryEnv.data?.passed === true;
@@ -78692,6 +78892,147 @@ async function persistRun(actionId, projectRoot, record2) {
     }
   }
   return { promoted: false, promotionRefused: false };
+}
+
+// packages/rn-dev-agent-core/dist/domain/action-inventory.js
+init_action_store();
+async function listActions(projectRoot, dependencies = {}) {
+  const context = openReadableActionLoadContext(projectRoot);
+  if (!context)
+    return [];
+  const load = dependencies.loadAction ?? loadActionFromContext;
+  const yamlFiles = context.files.filter((f) => /\.ya?ml$/.test(f)).sort();
+  const results = [];
+  for (const id of new Set(yamlFiles.map((file) => file.replace(/\.ya?ml$/, "")))) {
+    if (yamlFiles.includes(`${id}.yaml`) && yamlFiles.includes(`${id}.yml`))
+      continue;
+    const action = load(context, id);
+    if (!action)
+      continue;
+    const { metadata } = action;
+    const summary = {
+      id: metadata.id,
+      intent: metadata.intent,
+      status: metadata.status
+    };
+    if (metadata.params !== void 0)
+      summary.params = metadata.params;
+    if (metadata.mutates !== void 0)
+      summary.mutates = metadata.mutates;
+    if (metadata.appId !== void 0)
+      summary.appId = metadata.appId;
+    results.push(summary);
+  }
+  return results;
+}
+
+// packages/rn-dev-agent-core/dist/tools/login-prologue.js
+init_action_store();
+init_login_prologue();
+init_utils();
+function parseEnvelope2(result) {
+  try {
+    return JSON.parse(result.content[0]?.text ?? "{}");
+  } catch {
+    return { ok: false, code: "BAD_RESPONSE", error: "Action replay returned invalid JSON." };
+  }
+}
+function createLoginPrologueHandler(deps) {
+  const now = deps.now ?? (() => /* @__PURE__ */ new Date());
+  return async (args) => {
+    const projectRoot = args.projectRoot ?? process.cwd();
+    const prologueStarted = now();
+    const steps = [];
+    let inventory = [];
+    const measure = async (name, run) => {
+      const started = now();
+      try {
+        return await run();
+      } finally {
+        const ended = now();
+        steps.push({
+          name,
+          startedAt: started.toISOString(),
+          endedAt: ended.toISOString(),
+          elapsedMs: Math.max(0, ended.getTime() - started.getTime())
+        });
+      }
+    };
+    const finish = (state, extra) => {
+      const ended = now();
+      return {
+        schemaVersion: 1,
+        state,
+        alias: LOGIN_PROLOGUE_ALIAS,
+        startedAt: prologueStarted.toISOString(),
+        endedAt: ended.toISOString(),
+        elapsedMs: Math.max(0, ended.getTime() - prologueStarted.getTime()),
+        steps,
+        inventory: { count: inventory.length, actionIds: inventory.map((action) => action.id) },
+        ...extra
+      };
+    };
+    const blocked = (code, detail, extra = {}) => {
+      const outcome = finish(LOGIN_PROLOGUE_BLOCKED, {
+        failure: { code, detail },
+        ...extra
+      });
+      return failResult(`Login prologue blocked: ${detail}`, "LOGIN_PROLOGUE_BLOCKED", {
+        loginPrologue: outcome
+      });
+    };
+    try {
+      inventory = await measure("inventory", () => listActions(projectRoot));
+      const action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
+      if (!action || !inventory.some((candidate) => candidate.id === LOGIN_PROLOGUE_ALIAS)) {
+        return blocked("LOGIN_ACTION_MISSING", `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
+      }
+      const priorRunIds = new Set(action.state.runHistory.map((record2) => record2.runId).filter((runId) => typeof runId === "string"));
+      const replayArgs = {
+        ...args,
+        actionId: LOGIN_PROLOGUE_ALIAS,
+        autoRepair: false,
+        forceReload: false,
+        proofReplay: false,
+        blindProbeMode: "forbid",
+        trigger: args.trigger ?? "agent"
+      };
+      let replayResult;
+      try {
+        replayResult = await measure("replay", () => deps.runAction(replayArgs));
+      } catch (error2) {
+        const code = error2 && typeof error2 === "object" && "code" in error2 ? String(error2.code) : "ACTION_REPLAY_THROW";
+        return blocked(code, "The saved login action threw before producing a result.", {
+          actionId: LOGIN_PROLOGUE_ALIAS
+        });
+      }
+      const replay = parseEnvelope2(replayResult);
+      let freshRecord;
+      await measure("verify-run-record", async () => {
+        const reloaded = loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS);
+        freshRecord = reloaded?.state.runHistory.slice().reverse().find((record2) => typeof record2.runId === "string" && !priorRunIds.has(record2.runId));
+      });
+      if (replay.ok !== true || replay.data?.passed !== true) {
+        return blocked(replay.code ?? String(replay.data?.failureKind ?? "ACTION_REPLAY_FAILED"), "The saved login action did not pass; exploratory login is now terminally blocked.", { actionId: LOGIN_PROLOGUE_ALIAS, ...freshRecord ? { runRecord: freshRecord } : {} });
+      }
+      if (!freshRecord || freshRecord.status !== "pass") {
+        return blocked("AUTHORITATIVE_RUN_RECORD_MISSING", "The saved login action reported success without a fresh passing RunRecord.", { actionId: LOGIN_PROLOGUE_ALIAS });
+      }
+      const outcome = finish("passed", {
+        actionId: LOGIN_PROLOGUE_ALIAS,
+        runRecord: freshRecord,
+        actionResult: {
+          transport: replay.data.transport,
+          transportVersion: replay.data.transportVersion,
+          fallback: replay.data.fallback,
+          perStepReadback: replay.data.perStepReadback
+        }
+      });
+      return okResult(outcome);
+    } catch {
+      return blocked("LOGIN_PROLOGUE_INTERNAL_ERROR", "The login prologue failed before it could prove a passing replay.");
+    }
+  };
 }
 
 // packages/rn-dev-agent-core/dist/tools/dispatch.js
@@ -79108,7 +79449,7 @@ async function hideExpoDevMenu(client2, options = {}) {
       break;
     }
     if (attempt < retries)
-      await new Promise((resolve19) => setTimeout(resolve19, retryDelayMs));
+      await new Promise((resolve20) => setTimeout(resolve20, retryDelayMs));
   }
   return successfulCall ? { ...successfulCall, attempts: outcome.attempts } : outcome;
 }
@@ -79182,7 +79523,7 @@ function createDevSettingsHandler(getClient2, dependencies = {}) {
       const call = await hideExpoDevMenu(client2, { retries: 1 });
       if (!call.callSent)
         return failedHideResult(call, before);
-      await (dependencies.settleAfterHide?.() ?? new Promise((resolve19) => setTimeout(resolve19, 300)));
+      await (dependencies.settleAfterHide?.() ?? new Promise((resolve20) => setTimeout(resolve20, 300)));
       const after = probe ? await probe().catch(() => "unknown") : "unknown";
       if (before === "expo_dev_menu" && after === "app") {
         return okResult({
@@ -80957,7 +81298,7 @@ init_utils();
 init_path_safety();
 init_process_birth();
 import { execFile as execFile22 } from "node:child_process";
-import { createHash as createHash14 } from "node:crypto";
+import { createHash as createHash15 } from "node:crypto";
 import { existsSync as existsSync29 } from "node:fs";
 import { promisify as promisify23 } from "node:util";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
@@ -81109,7 +81450,7 @@ function parseStatusOutput(stdout) {
   return active;
 }
 function recordingScope(args) {
-  return createHash14("sha256").update(`${args.sessionId}\0${args.claimEpoch}\0${args.platform}\0${args.deviceId}`).digest("hex");
+  return createHash15("sha256").update(`${args.sessionId}\0${args.claimEpoch}\0${args.platform}\0${args.deviceId}`).digest("hex");
 }
 function bindRecorderSession(runtime, args) {
   const available = runtime.requireAvailable();
@@ -81378,7 +81719,7 @@ function createDeviceRecordHandler(deps = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
-import { createHash as createHash16, randomUUID as randomUUID8 } from "node:crypto";
+import { createHash as createHash17, randomUUID as randomUUID9 } from "node:crypto";
 import { execFileSync as execFileSync14 } from "node:child_process";
 import { chmodSync as chmodSync7, closeSync as closeSync11, existsSync as existsSync30, fsyncSync, lstatSync as lstatSync16, mkdirSync as mkdirSync19, openSync as openSync11, readFileSync as readFileSync31, realpathSync as realpathSync13, renameSync as renameSync8, unlinkSync as unlinkSync14, writeFileSync as writeFileSync14 } from "node:fs";
 import { basename as basename11, dirname as dirname22, extname, isAbsolute as isAbsolute11, join as join43, relative as relative8, resolve as resolve16, sep as sep9 } from "node:path";
@@ -81386,7 +81727,7 @@ import { fileURLToPath as fileURLToPath4 } from "node:url";
 init_action_store();
 
 // packages/rn-dev-agent-core/dist/domain/proof-capture.js
-import { createHash as createHash15 } from "node:crypto";
+import { createHash as createHash16 } from "node:crypto";
 var StrictProofMonitor = class {
   now;
   events = [];
@@ -81460,14 +81801,14 @@ function hashProofArgs(params) {
   return hashProofValue(redact(params));
 }
 function hashProofValue(value) {
-  return createHash15("sha256").update(JSON.stringify(canonicalizeProofValue(value))).digest("hex");
+  return createHash16("sha256").update(JSON.stringify(canonicalizeProofValue(value))).digest("hex");
 }
 function proofRuntimeAuthorityMarker(input) {
   return hashProofValue(input);
 }
 function hashObservedValue(value) {
   const bytes = JSON.stringify(value) ?? String(value);
-  return createHash15("sha256").update(bytes).digest("hex");
+  return createHash16("sha256").update(bytes).digest("hex");
 }
 function resultEnvelope(result) {
   if (!result || typeof result !== "object")
@@ -82029,7 +82370,7 @@ var readinessSchema = external_exports.object({
   runtime: proofRuntimeSchema
 }).strict();
 function hashBytes(bytes) {
-  return createHash16("sha256").update(bytes).digest("hex");
+  return createHash17("sha256").update(bytes).digest("hex");
 }
 function captureProofWorkerStartup(argv = process.argv, attestation = readStartupIntegrityAttestation()) {
   let executedEntrypointPath = null;
@@ -82255,7 +82596,7 @@ function readProofActionIdentity(appProjectRoot, actionId, dependencies = {}) {
     return {
       id: actionId,
       version: String(action.state.revision),
-      sha256: createHash16("sha256").update(action.yamlText).digest("hex")
+      sha256: createHash17("sha256").update(action.yamlText).digest("hex")
     };
   } catch {
     return null;
@@ -82456,7 +82797,7 @@ function readProofContractAt(moduleUrl = import.meta.url) {
 function writeProofReceiptAtomic(path, receipt2) {
   const directory = dirname22(path);
   mkdirSync19(directory, { recursive: true, mode: 448 });
-  const temporary = resolve16(directory, `.${randomUUID8()}.proof-receipt.tmp`);
+  const temporary = resolve16(directory, `.${randomUUID9()}.proof-receipt.tmp`);
   let descriptor = null;
   try {
     descriptor = openSync11(temporary, "wx", 384);
@@ -83257,7 +83598,7 @@ function createProofCaptureHandler(deps) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/proof-media.js
-import { createHash as createHash17 } from "node:crypto";
+import { createHash as createHash18 } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { mkdir as mkdir2, mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir as tmpdir11 } from "node:os";
@@ -83300,7 +83641,7 @@ async function hashAcceptedFile(path) {
   }
 }
 async function sha256File2(path) {
-  const hash = createHash17("sha256");
+  const hash = createHash18("sha256");
   const stream = createReadStream(path);
   for await (const chunk of stream)
     hash.update(chunk);
@@ -85429,7 +85770,7 @@ function buildGracefulShutdown(deps) {
 }
 
 // packages/rn-dev-agent-core/dist/lifecycle/lockfile.js
-import { createHash as createHash18 } from "node:crypto";
+import { createHash as createHash19 } from "node:crypto";
 import { execFileSync as execFileSync16 } from "node:child_process";
 import { closeSync as closeSync12, existsSync as existsSync31, mkdirSync as mkdirSync20, openSync as openSync12, readFileSync as readFileSync33, statSync as statSync14, unlinkSync as unlinkSync15, writeFileSync as writeFileSync15, writeSync as writeSync3 } from "node:fs";
 import { tmpdir as tmpdir12, userInfo as userInfo2 } from "node:os";
@@ -85482,7 +85823,7 @@ function defaultSelfPpid() {
   return typeof process.ppid === "number" ? process.ppid : 0;
 }
 function hashProjectRoot(projectRoot) {
-  return createHash18("md5").update(resolve18(projectRoot)).digest("hex").slice(0, 8);
+  return createHash19("md5").update(resolve18(projectRoot)).digest("hex").slice(0, 8);
 }
 var Lockfile = class {
   opts;
@@ -86580,7 +86921,7 @@ function instrumentTool(toolName, handler) {
 }
 
 // packages/rn-dev-agent-core/dist/experience/evidence.js
-import { createHash as createHash19, randomUUID as randomUUID9 } from "node:crypto";
+import { createHash as createHash20, randomUUID as randomUUID10 } from "node:crypto";
 import { chmodSync as chmodSync8, existsSync as existsSync33, mkdirSync as mkdirSync21, readFileSync as readFileSync36, renameSync as renameSync9, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
 import { dirname as dirname27, join as join50 } from "node:path";
@@ -86788,7 +87129,7 @@ var ExperienceRecorder = class {
       recovery: null,
       cleanup: null,
       classification,
-      evidencePointers: [`event:${randomUUID9()}`],
+      evidencePointers: [`event:${randomUUID10()}`],
       tool,
       status: event.status === "ERROR" ? "ERROR" : "FAIL",
       normalizedSymptomShape,
@@ -86834,13 +87175,13 @@ var ExperienceRecorder = class {
     existing.lastRecoveredAt = now;
     delete existing.unknownReasons.recovery;
     existing.evidencePointers = boundedPointers(existing.evidencePointers, [
-      `event:${randomUUID9()}`
+      `event:${randomUUID10()}`
     ]);
     this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
   }
   write(records) {
     mkdirSync21(this.directory, { recursive: true, mode: 448 });
-    const temp = join50(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID9()}`);
+    const temp = join50(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID10()}`);
     try {
       const sanitized = records.map((record2) => record2.redactionVersion === REDACTION_RULES_VERSION ? record2 : {
         ...sanitizeForEvidence(record2),
@@ -86912,7 +87253,7 @@ function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, 
   }).sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen) || a.signature.localeCompare(b.signature)).slice(0, Math.max(0, maxRecords)).sort((a, b) => a.signature.localeCompare(b.signature));
 }
 function experienceSignature(input) {
-  return createHash19("sha256").update(JSON.stringify([
+  return createHash20("sha256").update(JSON.stringify([
     input.classification,
     input.tool,
     input.normalizedSymptomShape,
@@ -87200,7 +87541,7 @@ import { fileURLToPath as fileURLToPath6 } from "node:url";
 import { dirname as dirname28, join as join52 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/observability/e2e-csrf.js
-import { randomBytes as randomBytes7, timingSafeEqual as timingSafeEqual7 } from "node:crypto";
+import { randomBytes as randomBytes7, timingSafeEqual as timingSafeEqual8 } from "node:crypto";
 function makeCsrfToken() {
   return randomBytes7(24).toString("hex");
 }
@@ -87213,7 +87554,7 @@ function isPostAllowed(req, token2) {
     const got = String(gotRaw);
     const a = Buffer.from(got);
     const b = Buffer.from(token2);
-    if (a.length !== b.length || !timingSafeEqual7(a, b)) {
+    if (a.length !== b.length || !timingSafeEqual8(a, b)) {
       return { ok: false, status: 403, reason: "bad csrf token" };
     }
   }
@@ -88419,7 +88760,7 @@ init_action_store();
 init_path_safety();
 import { dirname as dirname29, join as join54 } from "node:path";
 import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync10, readFileSync as readFileSync38, readdirSync as readdirSync15, existsSync as existsSync34 } from "node:fs";
-import { createHash as createHash20 } from "node:crypto";
+import { createHash as createHash21 } from "node:crypto";
 var FLOW_SENTINEL = "# e2e-locked-flow-below";
 function e2eDirFor(projectRoot) {
   return join54(projectRoot, ".rn-agent", "e2e");
@@ -88451,7 +88792,7 @@ function serializeLockedTest(meta) {
 ${meta.flow}`;
 }
 function hashBody(s) {
-  return createHash20("sha256").update(s).digest("hex");
+  return createHash21("sha256").update(s).digest("hex");
 }
 function freezeLockedTest(projectRoot, source, ctx) {
   const filePath = e2ePathFor(projectRoot, source.id);
@@ -89102,40 +89443,6 @@ function probeMetro(port, timeoutMs = 1500) {
 init_device_screenshot_raw();
 init_app_installed_probe();
 init_storage();
-
-// packages/rn-dev-agent-core/dist/domain/action-inventory.js
-init_action_store();
-async function listActions(projectRoot, dependencies = {}) {
-  const context = openReadableActionLoadContext(projectRoot);
-  if (!context)
-    return [];
-  const load = dependencies.loadAction ?? loadActionFromContext;
-  const yamlFiles = context.files.filter((f) => /\.ya?ml$/.test(f)).sort();
-  const results = [];
-  for (const id of new Set(yamlFiles.map((file) => file.replace(/\.ya?ml$/, "")))) {
-    if (yamlFiles.includes(`${id}.yaml`) && yamlFiles.includes(`${id}.yml`))
-      continue;
-    const action = load(context, id);
-    if (!action)
-      continue;
-    const { metadata } = action;
-    const summary = {
-      id: metadata.id,
-      intent: metadata.intent,
-      status: metadata.status
-    };
-    if (metadata.params !== void 0)
-      summary.params = metadata.params;
-    if (metadata.mutates !== void 0)
-      summary.mutates = metadata.mutates;
-    if (metadata.appId !== void 0)
-      summary.appId = metadata.appId;
-    results.push(summary);
-  }
-  return results;
-}
-
-// packages/rn-dev-agent-core/dist/index.js
 init_action_store();
 
 // packages/rn-dev-agent-core/dist/session/runner-binding.js
@@ -89207,7 +89514,7 @@ init_discovery();
 init_metro_cwd();
 init_install_authority();
 import { execFileSync as execFileSync18 } from "node:child_process";
-import { createHash as createHash21 } from "node:crypto";
+import { createHash as createHash22 } from "node:crypto";
 init_metro_origin();
 init_metro_binding();
 init_process_birth();
@@ -89215,7 +89522,7 @@ init_registry();
 init_target_device_authority();
 init_tool_profiles();
 function identity(value) {
-  return createHash21("sha256").update(JSON.stringify(value)).digest("hex");
+  return createHash22("sha256").update(JSON.stringify(value)).digest("hex");
 }
 function objectBinding(status, name) {
   const value = status.bindings[name];
@@ -90234,7 +90541,7 @@ setSnapshotAuthorityProvider({
       runnerInstanceId: runner?.instanceId,
       runnerPid: runner?.pid,
       runnerProcessBirth: runner?.processBirth,
-      runnerCapabilityHash: typeof runner?.capability === "string" ? createHash22("sha256").update(runner.capability).digest("hex") : void 0,
+      runnerCapabilityHash: typeof runner?.capability === "string" ? createHash23("sha256").update(runner.capability).digest("hex") : void 0,
       runnerPort: runner?.port,
       runnerClaim: status.claims.find((claim) => claim.type === "runner")?.key,
       deviceClaim: status.claims.find((claim) => claim.type === "device")?.key
@@ -90367,6 +90674,7 @@ var createRuntimeAuthorityProbe = (resolveClient) => createLocalAuthorityProbe({
 });
 var localAuthorityProbe = createRuntimeAuthorityProbe(getClient);
 var authorityGate = createAuthorityGate(authorityRuntime, {
+  loginSupervisorOverrideToken: () => process.env.RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN,
   probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
   recoverRuntimeConnection: async (status) => {
     const current = getClient();
@@ -90439,7 +90747,7 @@ setObserveAuthorityDeps({
       authority: {
         sessionId: status.sessionId,
         claimEpoch: status.claimEpoch,
-        instanceId: randomUUID10(),
+        instanceId: randomUUID11(),
         capability: secret.observeCapability
       }
     };
@@ -90576,7 +90884,10 @@ function trackedTool(name, desc, schema, handler) {
     }
     return result;
   };
-  server2.tool(name, desc, schema, wrapped);
+  server2.tool(name, desc, {
+    ...schema,
+    supervisorOverrideToken: external_exports.string().min(16).optional().describe("Supervisor token for one audited mutation after a blocked login prologue.")
+  }, wrapped);
 }
 async function pinSessionDevClient(status, options, commitBundle) {
   const device = status.bindings.device;
@@ -91479,7 +91790,7 @@ var proofReadiness = async () => {
       connectedAt: current.connectedAt
     }),
     errorCount: errors.length,
-    errorSha256: createHash22("sha256").update(errorBytes).digest("hex"),
+    errorSha256: createHash23("sha256").update(errorBytes).digest("hex"),
     device: identity2.device,
     runtime: identity2.runtime
   };
@@ -91830,34 +92141,34 @@ trackedTool("cdp_repair_action", "Repair a learned action using a fresh snapshot
   deviceId: external_exports.string().optional().describe("Authority-bound exact device identifier; normally injected by the session"),
   appId: external_exports.string().optional().describe("Authority-bound app identifier; normally injected by the session")
 }, createRepairActionHandler());
-trackedTool(
-  "cdp_run_action",
-  `Replay a learned action by id with end-to-end auto-repair. Loads the action from .rn-agent/actions/<actionId>.yaml or .yml, forwards the matching active session's exact device ID to Maestro, rejects mismatched direct runner/WDA evidence, and on a SELECTOR_NOT_FOUND failure automatically invokes cdp_repair_action and retries once. Appends a RunRecord to the sidecar with full auto-repair telemetry (passed/failed/refused/skipped + diff); its Maestro deviceId comes from direct runner evidence, never requested metadata. The repair attempt counts toward cdp_repair_action's 24h budget. Pass autoRepair=false to opt out of auto-repair (returns the raw maestro_run failure verbatim). forceReload defaults true: any human edit to the YAML since the agent's last write is acknowledged as the new baseline so downstream repair does not abort with STALE_TARGET (the right default for active composition). Pass forceReload=false for the strict "respect offline human edits" behavior: a successful replay still appends its RunRecord to the sidecar when only the tracked YAML mtime baseline is stale, while YAML-mutating promotion and repair stay refused. proofReplay=true is reserved for proof_capture rehearsal and requires autoRepair=false plus forceReload=false; it executes without RunRecord, promotion, YAML, sidecar, or DB persistence. The orchestrated home for the L3 self-healing loop \u2014 prefer this over invoking maestro_run + cdp_repair_action manually for any flow you intend to re-run on schedule. blindProbeMode provides per-call control of the proactive CDP/JS compatibility path: inherit (default) honors RN_BLIND_PROBE, allow explicitly enables it for this call, and forbid forces maestro-first for this call.`,
-  {
-    actionId: external_exports.string().describe("Owned action id; resolves one .yaml or .yml file."),
-    projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
-    platform: external_exports.enum(["ios", "android"]).optional().describe("Force a specific platform; otherwise auto-detected from the active device session."),
-    appFile: external_exports.string().optional().describe("GH #705: path to the .app Maestro reinstalls from after a clearState uninstall. Normally omit it \u2014 an iOS clearState flow resolves the bundle from the session's attested install receipt, and the receipt is re-issued after the reinstall so later device_*/maestro_run calls keep working."),
-    autoRepair: external_exports.boolean().optional().describe("Auto-repair on SELECTOR_NOT_FOUND failures. Default true. Pass false to disable (e.g. when investigating a failure manually)."),
-    timeoutMs: external_exports.number().optional().describe("Maestro execution timeout per attempt (ms). Default 120_000."),
-    trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe('RunRecord trigger annotation. Default "agent". CI calls should pass "ci".'),
-    forceReload: external_exports.boolean().optional().describe('GH #173: when true (default), acknowledge any human edit to the YAML as the new baseline before running so downstream repair does not abort with STALE_TARGET. Pass false for the strict Phase 129 "respect external edits" behavior (useful for CI replays of fixed baselines).'),
-    proofReplay: external_exports.boolean().optional().describe("Read-only proof rehearsal mode. Requires autoRepair=false and forceReload=false; never writes action YAML, runtime sidecar, or DB state."),
-    blindProbeMode: external_exports.enum(["inherit", "allow", "forbid"]).optional().describe("Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged."),
-    params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).")
-  },
-  // GH #186: supply a CDP-backed live-route reader so the route-drift guard is
-  // actually active. Without this the handler defaulted getLiveRoute to a no-op
-  // and the drift branch could never fire, silently routing screen-change
-  // failures into fuzzy selector repair.
-  createRunActionHandler({
-    getLiveRoute: () => readLiveRoute(getClient()),
-    replayDeps: makeReplayDeps,
-    blindProbeContext,
-    targetContext: getActiveSession,
-    claimBundleAuthority: claimOptionalBundleAuthority
-  })
-);
+var runActionHandler = createRunActionHandler({
+  getLiveRoute: () => readLiveRoute(getClient()),
+  replayDeps: makeReplayDeps,
+  blindProbeContext,
+  targetContext: getActiveSession,
+  claimBundleAuthority: claimOptionalBundleAuthority
+});
+trackedTool("cdp_run_action", `Replay a learned action by id with end-to-end auto-repair. Loads the action from .rn-agent/actions/<actionId>.yaml or .yml, forwards the matching active session's exact device ID to Maestro, rejects mismatched direct runner/WDA evidence, and on a SELECTOR_NOT_FOUND failure automatically invokes cdp_repair_action and retries once. Appends a RunRecord to the sidecar with full auto-repair telemetry (passed/failed/refused/skipped + diff); its Maestro deviceId comes from direct runner evidence, never requested metadata. The repair attempt counts toward cdp_repair_action's 24h budget. Pass autoRepair=false to opt out of auto-repair (returns the raw maestro_run failure verbatim). forceReload defaults true: any human edit to the YAML since the agent's last write is acknowledged as the new baseline so downstream repair does not abort with STALE_TARGET (the right default for active composition). Pass forceReload=false for the strict "respect offline human edits" behavior: a successful replay still appends its RunRecord to the sidecar when only the tracked YAML mtime baseline is stale, while YAML-mutating promotion and repair stay refused. proofReplay=true is reserved for proof_capture rehearsal and requires autoRepair=false plus forceReload=false; it executes without RunRecord, promotion, YAML, sidecar, or DB persistence. The orchestrated home for the L3 self-healing loop \u2014 prefer this over invoking maestro_run + cdp_repair_action manually for any flow you intend to re-run on schedule. blindProbeMode provides per-call control of the proactive CDP/JS compatibility path: inherit (default) honors RN_BLIND_PROBE, allow explicitly enables it for this call, and forbid forces maestro-first for this call.`, {
+  actionId: external_exports.string().describe("Owned action id; resolves one .yaml or .yml file."),
+  projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
+  platform: external_exports.enum(["ios", "android"]).optional().describe("Force a specific platform; otherwise auto-detected from the active device session."),
+  appFile: external_exports.string().optional().describe("GH #705: path to the .app Maestro reinstalls from after a clearState uninstall. Normally omit it \u2014 an iOS clearState flow resolves the bundle from the session's attested install receipt, and the receipt is re-issued after the reinstall so later device_*/maestro_run calls keep working."),
+  autoRepair: external_exports.boolean().optional().describe("Auto-repair on SELECTOR_NOT_FOUND failures. Default true. Pass false to disable (e.g. when investigating a failure manually)."),
+  timeoutMs: external_exports.number().optional().describe("Maestro execution timeout per attempt (ms). Default 120_000."),
+  trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe('RunRecord trigger annotation. Default "agent". CI calls should pass "ci".'),
+  forceReload: external_exports.boolean().optional().describe('GH #173: when true (default), acknowledge any human edit to the YAML as the new baseline before running so downstream repair does not abort with STALE_TARGET. Pass false for the strict Phase 129 "respect external edits" behavior (useful for CI replays of fixed baselines).'),
+  proofReplay: external_exports.boolean().optional().describe("Read-only proof rehearsal mode. Requires autoRepair=false and forceReload=false; never writes action YAML, runtime sidecar, or DB state."),
+  blindProbeMode: external_exports.enum(["inherit", "allow", "forbid"]).optional().describe("Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged."),
+  params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).")
+}, runActionHandler);
+trackedTool("cdp_login_prologue", "Inventory learned actions, replay the exact user-login action strictly, and require a fresh passing RunRecord before lifting the session login gate.", {
+  projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
+  platform: external_exports.enum(["ios", "android"]).optional().describe("Force a platform; otherwise use the authority-bound device."),
+  appFile: external_exports.string().optional().describe("iOS app artifact used only when the saved action contains clearState."),
+  timeoutMs: external_exports.number().optional().describe("Saved-action timeout in milliseconds."),
+  trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe("RunRecord trigger annotation. Default agent."),
+  params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Bindings for the exact user-login action placeholders.")
+}, createLoginPrologueHandler({ runAction: runActionHandler }));
 trackedTool("cdp_lock_e2e_test", "Promote a verified action into a frozen, locked e2e regression test. Runs the action once strict (no repair); freezes it only if it passes. v1 supports param-free actions only.", {
   actionId: external_exports.string().describe("The action id under .rn-agent/actions to lock"),
   relock: external_exports.boolean().optional().describe("Overwrite an existing locked test"),
@@ -91957,13 +92268,6 @@ var triggerE2eRun = async (args) => {
     arbiter.release(L.lease);
   }
 };
-var runActionHandler = createRunActionHandler({
-  getLiveRoute: () => readLiveRoute(getClient()),
-  replayDeps: makeReplayDeps,
-  blindProbeContext,
-  targetContext: getActiveSession,
-  claimBundleAuthority: claimOptionalBundleAuthority
-});
 var observeRunActionHandler = authorityGate.wrap("cdp_run_action", runActionHandler);
 var observeTriggerRun = authorityGate.wrap("cdp_run_e2e_suite", async (...raw) => {
   const args = raw[0] ?? {};

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -31939,7 +31939,7 @@ function cleanupAllowed(tool, args) {
   if (tool === "proof_capture" && (args.action === "discard" || args.action === "status")) {
     return true;
   }
-  return tool === "rn_session" && (args.action === "release" || args.action === "stop_metro" || args.action === "cancel_handoff" || args.action === "status");
+  return tool === "rn_session" && (args.action === "release" || args.action === "stop_metro" || args.action === "cancel_handoff" || args.action === "recover_arbiter" && args.confirmed === true || args.action === "status");
 }
 function tokenMatches(expected, supplied) {
   if (!expected || expected.length < 16 || !supplied || supplied.length < 16)

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -32039,6 +32039,9 @@ function loadLockedTest(projectRoot, id) {
   const locked = parseLockedTest(readFileSync19(filePath, "utf8"), filePath);
   return locked?.id === id ? locked : null;
 }
+function lockedTestFileExists(projectRoot, id) {
+  return existsSync20(e2ePathFor(projectRoot, id));
+}
 function discoverLockedTests(projectRoot) {
   const dir = e2eDirFor(projectRoot);
   if (!existsSync20(dir))
@@ -32056,11 +32059,13 @@ function resolveLockedTestIds(projectRoot, pattern, discover2 = discoverLockedTe
     return ids;
   }
 }
-function resolveLockedTestIdentityIds(projectRoot, pattern, discover2 = discoverLockedTests, load = loadLockedTest) {
-  return resolveLockedTestIds(projectRoot, pattern, discover2).filter((id) => {
+function resolveLockedTestSelection(projectRoot, pattern, discover2 = discoverLockedTests, load = loadLockedTest) {
+  const ids = resolveLockedTestIds(projectRoot, pattern, discover2);
+  const identitiesValid = ids.every((id) => {
     const locked = load(projectRoot, id);
     return locked?.id === id && locked.sourceActionId === id;
   });
+  return { ids, identitiesValid };
 }
 function setResolvedLockedTestIds(args, ids) {
   Object.defineProperty(args, resolvedLockedTestIds, {
@@ -33382,17 +33387,17 @@ function createAuthorityGate(runtime, dependencies) {
           bindSessionArguments(status, profile, args, tool);
         }
         if (pendingLockedE2eAdmission) {
-          const resolvedLockedTestIds2 = dependencies.resolveLockedE2eTestIds?.(args, status);
-          if (!resolvedLockedTestIds2 || inspectLoginPrologueGuard({
+          const resolvedSelection = dependencies.resolveLockedE2eTestIds?.(args, status);
+          if (!resolvedSelection?.identitiesValid || inspectLoginPrologueGuard({
             binding: status.bindings.loginPrologue,
             tool,
             args,
             mutation: profile.mutation,
-            resolvedLockedTestIds: resolvedLockedTestIds2
+            resolvedLockedTestIds: resolvedSelection.ids
           }).blocked) {
             throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the locked e2e suite did not resolve to the exact user-login candidate");
           }
-          setResolvedLockedTestIds(args, resolvedLockedTestIds2);
+          setResolvedLockedTestIds(args, resolvedSelection.ids);
         }
         operation = registry2.beginOperation(available.session, {
           operationId: randomUUID4(),
@@ -89154,7 +89159,7 @@ async function lockE2eTestCore(args, deps = {}) {
     }
     resolvedParams = resolved.params;
   }
-  if (!args.relock && loadLockedTest(projectRoot, args.actionId)) {
+  if (!args.relock && lockedTestFileExists(projectRoot, args.actionId)) {
     return failResult(`'${args.actionId}' is already locked \u2014 pass relock:true to re-lock`, "ALREADY_LOCKED");
   }
   const session2 = getSession();
@@ -90876,9 +90881,9 @@ var authorityGate = createAuthorityGate(authorityRuntime, {
   resolveLockedE2eTestIds: (args, status) => {
     const projectRoot = typeof args.projectRoot === "string" ? args.projectRoot : status.source.appRoot;
     if (typeof projectRoot !== "string")
-      return [];
+      return { ids: [], identitiesValid: false };
     args.projectRoot = projectRoot;
-    return resolveLockedTestIdentityIds(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
+    return resolveLockedTestSelection(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
   },
   probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
   recoverRuntimeConnection: async (status) => {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -32652,6 +32652,22 @@ function missingLoginPrologueOutcome() {
     }
   };
 }
+function persistLoginPrologueOutcome(runtime, registry2, operation, status, outcome) {
+  const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+  const nextOperation = registry2.replaceBindingsDuringOperation(operation, {
+    bindings: {
+      loginPrologue: {
+        ...outcome,
+        ...priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}
+      }
+    }
+  });
+  const nextStatus = runtime.status();
+  if (!nextStatus.available) {
+    throw new SessionAuthorityError(nextStatus.code, nextStatus.reason);
+  }
+  return { operation: nextOperation, status: nextStatus };
+}
 function isActionReplayTool(tool) {
   return tool === "cdp_run_action" || tool === "cdp_login_prologue";
 }
@@ -33548,6 +33564,11 @@ function createAuthorityGate(runtime, dependencies) {
             loginPrologueOutcome = missingLoginPrologueOutcome();
             result = failResult("Login prologue returned no valid terminal state.", "LOGIN_PROLOGUE_BLOCKED", { loginPrologue: loginPrologueOutcome });
           }
+          if (loginPrologueOutcome.state === LOGIN_PROLOGUE_BLOCKED) {
+            const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
+            operation = persisted.operation;
+            status = persisted.status;
+          }
         }
         let runtimeTargetChanged = false;
         const postHandlerRecovery = await reconcileRecoverableRuntime(runtime, dependencies, registry2, operation, status, profile, resultSucceeded(result));
@@ -33668,21 +33689,10 @@ function createAuthorityGate(runtime, dependencies) {
           axes: [...runnerAwareReceiptProfile.axes, "M", "A"]
         } : runnerAwareReceiptProfile;
         const controllerGenerationAdvanced = operation.authorityVersion !== initialOperationAuthorityVersion;
-        if (loginPrologueOutcome) {
-          const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
-          operation = registry2.replaceBindingsDuringOperation(operation, {
-            bindings: {
-              loginPrologue: {
-                ...loginPrologueOutcome,
-                ...priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}
-              }
-            }
-          });
-          const loginStatus = runtime.status();
-          if (!loginStatus.available) {
-            throw new SessionAuthorityError(loginStatus.code, loginStatus.reason);
-          }
-          status = loginStatus;
+        if (loginPrologueOutcome?.state === "passed") {
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
+          operation = persisted.operation;
+          status = persisted.status;
         }
         registry2.verifyOperation(operation);
         for (const observation of allBefore) {
@@ -35098,6 +35108,7 @@ var init_device_arbiter = __esm({
     FLOW_TOOLS = /* @__PURE__ */ new Set([
       "maestro_run",
       "maestro_test_all",
+      "cdp_login_prologue",
       "cdp_run_action",
       "cdp_auto_login",
       "cdp_reload",
@@ -78988,15 +78999,15 @@ function createLoginPrologueHandler(deps) {
         return blocked("LOGIN_ACTION_MISSING", `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
       }
       const priorRunIds = new Set(action.state.runHistory.map((record2) => record2.runId).filter((runId) => typeof runId === "string"));
-      const replayArgs = {
-        ...args,
+      const replayArgs = Object.create(Object.getPrototypeOf(args), Object.getOwnPropertyDescriptors(args));
+      Object.assign(replayArgs, {
         actionId: LOGIN_PROLOGUE_ALIAS,
         autoRepair: false,
         forceReload: false,
         proofReplay: false,
         blindProbeMode: "forbid",
         trigger: args.trigger ?? "agent"
-      };
+      });
       let replayResult;
       try {
         replayResult = await measure("replay", () => deps.runAction(replayArgs));

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -27320,7 +27320,7 @@ function assertWritableActionFile(filePath) {
 function assertActionMetadataIdentity(filePath, metadata) {
   const fileId = basename4(filePath).replace(/\.ya?ml$/i, "");
   if (metadata.id !== fileId) {
-    throw new ActionMetadataIdentityError(metadata.id, fileId);
+    throw new Error(`Action metadata id ${metadata.id} does not match filename identity ${fileId}.`);
   }
 }
 function withMetadata(action, metadata) {
@@ -27329,7 +27329,7 @@ function withMetadata(action, metadata) {
 function withBody(action, body) {
   return { ...action, body };
 }
-var SaveActionPreconditionError, ActionMetadataIdentityError;
+var SaveActionPreconditionError;
 var init_action_store = __esm({
   "packages/rn-dev-agent-core/dist/domain/action-store.js"() {
     "use strict";
@@ -27345,16 +27345,6 @@ var init_action_store = __esm({
       constructor(filePath) {
         super(`saveAction precondition violated: yaml at ${filePath} has been edited externally since the in-memory action was loaded. The caller must invoke actionWasEditedExternally() first and abort on true (or use saveActionWithCAS for atomic detection). GH #113 contract enforcement.`);
         this.name = "SaveActionPreconditionError";
-      }
-    };
-    ActionMetadataIdentityError = class extends Error {
-      metadataId;
-      fileId;
-      constructor(metadataId, fileId) {
-        super(`Action metadata id ${metadataId} does not match filename identity ${fileId}.`);
-        this.metadataId = metadataId;
-        this.fileId = fileId;
-        this.name = "ActionMetadataIdentityError";
       }
     };
   }
@@ -79228,9 +79218,6 @@ function parseEnvelope2(result) {
     return { ok: false, code: "BAD_RESPONSE", error: "Action replay returned invalid JSON." };
   }
 }
-function isLoginActionIdentityMismatch(error2) {
-  return error2 instanceof ActionMetadataIdentityError && (error2.fileId === LOGIN_PROLOGUE_ALIAS || error2.metadataId === LOGIN_PROLOGUE_ALIAS);
-}
 function createLoginPrologueHandler(deps) {
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
   return async (args) => {
@@ -79282,7 +79269,7 @@ function createLoginPrologueHandler(deps) {
         inventory = await measure("inventory", () => listActions(projectRoot));
         action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
       } catch (error2) {
-        if (isLoginActionIdentityMismatch(error2)) {
+        if (error2 instanceof Error && error2.message.includes("does not match filename identity") && error2.message.includes(LOGIN_PROLOGUE_ALIAS)) {
           return blocked("LOGIN_ACTION_ID_MISMATCH", `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
         }
         throw error2;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -27320,7 +27320,7 @@ function assertWritableActionFile(filePath) {
 function assertActionMetadataIdentity(filePath, metadata) {
   const fileId = basename4(filePath).replace(/\.ya?ml$/i, "");
   if (metadata.id !== fileId) {
-    throw new Error(`Action metadata id ${metadata.id} does not match filename identity ${fileId}.`);
+    throw new ActionMetadataIdentityError(metadata.id, fileId);
   }
 }
 function withMetadata(action, metadata) {
@@ -27329,7 +27329,7 @@ function withMetadata(action, metadata) {
 function withBody(action, body) {
   return { ...action, body };
 }
-var SaveActionPreconditionError;
+var SaveActionPreconditionError, ActionMetadataIdentityError;
 var init_action_store = __esm({
   "packages/rn-dev-agent-core/dist/domain/action-store.js"() {
     "use strict";
@@ -27345,6 +27345,16 @@ var init_action_store = __esm({
       constructor(filePath) {
         super(`saveAction precondition violated: yaml at ${filePath} has been edited externally since the in-memory action was loaded. The caller must invoke actionWasEditedExternally() first and abort on true (or use saveActionWithCAS for atomic detection). GH #113 contract enforcement.`);
         this.name = "SaveActionPreconditionError";
+      }
+    };
+    ActionMetadataIdentityError = class extends Error {
+      metadataId;
+      fileId;
+      constructor(metadataId, fileId) {
+        super(`Action metadata id ${metadataId} does not match filename identity ${fileId}.`);
+        this.metadataId = metadataId;
+        this.fileId = fileId;
+        this.name = "ActionMetadataIdentityError";
       }
     };
   }
@@ -31907,8 +31917,13 @@ function readLoginPrologueOutcome(value) {
   }
   return candidate;
 }
-function lockedE2eProofAllowed(tool) {
-  return LOCKED_E2E_LOGIN_TOOLS.includes(tool);
+function lockedE2eProofAllowed(tool, args) {
+  if (tool === "cdp_lock_e2e_test")
+    return args.actionId === LOGIN_PROLOGUE_ALIAS;
+  if (tool === "cdp_run_e2e_suite") {
+    return args.pattern === `^${LOGIN_PROLOGUE_ALIAS}$`;
+  }
+  return false;
 }
 function cleanupAllowed(tool, args) {
   if (tool === "cdp_login_prologue")
@@ -31935,7 +31950,7 @@ function tokenMatches(expected, supplied) {
 }
 function inspectLoginPrologueGuard(input) {
   const outcome = readLoginPrologueOutcome(input.binding);
-  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool)) {
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool, input.args)) {
     return { blocked: false };
   }
   return {
@@ -31951,14 +31966,13 @@ function authorizeLoginSupervisorOverride(input) {
 function appendLoginOverrideAudit(outcome, audit) {
   return { ...outcome, overrides: [...outcome.overrides ?? [], audit].slice(-20) };
 }
-var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, ACTION_LOGIN_HELPER, LOCKED_E2E_LOGIN_TOOLS;
+var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, ACTION_LOGIN_HELPER;
 var init_login_prologue = __esm({
   "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
     "use strict";
     LOGIN_PROLOGUE_ALIAS = "user-login";
     LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
     ACTION_LOGIN_HELPER = "ACTION_LOGIN_HELPER";
-    LOCKED_E2E_LOGIN_TOOLS = ["cdp_lock_e2e_test", "cdp_run_e2e_suite"];
   }
 });
 
@@ -79048,6 +79062,9 @@ function parseEnvelope2(result) {
     return { ok: false, code: "BAD_RESPONSE", error: "Action replay returned invalid JSON." };
   }
 }
+function isLoginActionIdentityMismatch(error2) {
+  return error2 instanceof ActionMetadataIdentityError && (error2.fileId === LOGIN_PROLOGUE_ALIAS || error2.metadataId === LOGIN_PROLOGUE_ALIAS);
+}
 function createLoginPrologueHandler(deps) {
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
   return async (args) => {
@@ -79094,8 +79111,16 @@ function createLoginPrologueHandler(deps) {
       });
     };
     try {
-      inventory = await measure("inventory", () => listActions(projectRoot));
-      const action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
+      let action;
+      try {
+        inventory = await measure("inventory", () => listActions(projectRoot));
+        action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
+      } catch (error2) {
+        if (isLoginActionIdentityMismatch(error2)) {
+          return blocked("LOGIN_ACTION_ID_MISMATCH", `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
+        }
+        throw error2;
+      }
       if (!action) {
         return blocked("LOGIN_ACTION_MISSING", `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
       }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -32650,12 +32650,13 @@ function missingLoginPrologueOutcome() {
     }
   };
 }
-function pendingLoginPrologueOutcome() {
+function pendingLoginPrologueOutcome(attemptId) {
   const timestamp = (/* @__PURE__ */ new Date()).toISOString();
   return {
     schemaVersion: 1,
     state: LOGIN_PROLOGUE_BLOCKED,
     alias: LOGIN_PROLOGUE_ALIAS,
+    attemptId,
     startedAt: timestamp,
     endedAt: timestamp,
     elapsedMs: 0,
@@ -32899,6 +32900,8 @@ function createAuthorityGate(runtime, dependencies) {
   return {
     wrap: (tool, handler) => async (...handlerArgs) => {
       const args = handlerArgs[0] && typeof handlerArgs[0] === "object" ? handlerArgs[0] : {};
+      const suppliedSupervisorOverrideToken = typeof args.supervisorOverrideToken === "string" ? args.supervisorOverrideToken : void 0;
+      delete args.supervisorOverrideToken;
       const baseProfile = authorityProfileFor(tool, args);
       let profile = tool === "rn_session" && (args.action === "status" || args.action === "preview_integration" || args.action === "accept_handoff" || args.action === "adopt_stale") ? {
         kind: "diagnostic",
@@ -32929,8 +32932,7 @@ function createAuthorityGate(runtime, dependencies) {
         args,
         mutation: profile.mutation
       });
-      const pendingSupervisorOverrideToken = loginGuard.blocked ? loginGuard.suppliedOverride : void 0;
-      delete args.supervisorOverrideToken;
+      const pendingSupervisorOverrideToken = loginGuard.blocked ? suppliedSupervisorOverrideToken : void 0;
       if (loginGuard.blocked && pendingSupervisorOverrideToken === void 0) {
         return failResult("LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.", "LOGIN_PROLOGUE_BLOCKED", {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
@@ -33208,7 +33210,8 @@ function createAuthorityGate(runtime, dependencies) {
           throw new SessionAuthorityError(initialStatus.code, initialStatus.reason);
         }
         let status = initialStatus;
-        if (tool !== "cdp_login_prologue") {
+        const deferredAdmissionChecks = tool === "cdp_login_prologue" || pendingSupervisorOverrideToken !== void 0;
+        if (!deferredAdmissionChecks) {
           requireCompleteAxes(status, profile);
           bindSessionArguments(status, profile, args, tool);
         }
@@ -33218,10 +33221,29 @@ function createAuthorityGate(runtime, dependencies) {
           profile: profile.axes.join("")
         });
         if (tool === "cdp_login_prologue") {
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome());
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome(operation.operationId));
           operation = persisted.operation;
           status = persisted.status;
           loginPrologueAttemptOperationId = operation.operationId;
+          requireCompleteAxes(status, profile);
+          bindSessionArguments(status, profile, args, tool);
+        }
+        if (pendingSupervisorOverrideToken !== void 0) {
+          const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+          if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
+          }
+          const audit = authorizeLoginSupervisorOverride({
+            expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
+            suppliedOverrideToken: pendingSupervisorOverrideToken,
+            tool
+          });
+          if (!audit) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the supervisor override token was rejected under the operation fence");
+          }
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, audit));
+          operation = persisted.operation;
+          status = persisted.status;
           requireCompleteAxes(status, profile);
           bindSessionArguments(status, profile, args, tool);
         }
@@ -33570,23 +33592,6 @@ function createAuthorityGate(runtime, dependencies) {
             }
           });
         }
-        if (pendingSupervisorOverrideToken !== void 0) {
-          const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
-          if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
-            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
-          }
-          const audit = authorizeLoginSupervisorOverride({
-            expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
-            suppliedOverrideToken: pendingSupervisorOverrideToken,
-            tool
-          });
-          if (!audit) {
-            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the supervisor override token was rejected under the operation fence");
-          }
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, audit));
-          operation = persisted.operation;
-          status = persisted.status;
-        }
         registry2.verifyOperation(operation);
         const snapshotCheckpoint = dependencies.snapshotCaptureCheckpoint?.();
         let result = await registry2.runWithOperation(operation, () => handler(...handlerArgs));
@@ -33773,7 +33778,7 @@ function createAuthorityGate(runtime, dependencies) {
         }
         if (operation && loginPrologueOutcome?.state === "passed") {
           const pendingOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
-          if (operation.operationId !== loginPrologueAttemptOperationId || pendingOutcome?.state !== LOGIN_PROLOGUE_BLOCKED || pendingOutcome.failure?.code !== "LOGIN_PROLOGUE_IN_PROGRESS") {
+          if (operation.operationId !== loginPrologueAttemptOperationId || pendingOutcome?.state !== LOGIN_PROLOGUE_BLOCKED || pendingOutcome.attemptId !== loginPrologueAttemptOperationId || pendingOutcome.failure?.code !== "LOGIN_PROLOGUE_IN_PROGRESS") {
             throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the passing login result does not match the active blocked attempt");
           }
           const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
@@ -74638,7 +74643,7 @@ var PII_PATTERNS = [
   /\b\d{3}[-.]\d{3}[-.]\d{4}\b/g,
   /\b\d{3}-\d{2}-\d{4}\b/g
 ];
-var AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
+var AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|supervisorOverrideToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
 var MAX_STRING_LENGTH = 2e3;
 function redactString(value) {
   let result = value.replace(HOME_RE, "~");
@@ -78184,6 +78189,11 @@ function classifyFailure(failure) {
       return { actionCode: "UNKNOWN", toolCode: void 0 };
   }
 }
+var PROVEN_ENGINE_PIN_DIVERGENCE = /* @__PURE__ */ new Set(["drift-newer", "drift-older", "checksum-mismatch"]);
+function strictEnginePinDivergence(env) {
+  const status = env.data?.enginePin?.status;
+  return typeof status === "string" && PROVEN_ENGINE_PIN_DIVERGENCE.has(status) ? status : null;
+}
 function parseEnvelope(toolResult, toolName) {
   try {
     return JSON.parse(toolResult.content?.[0]?.text ?? "{}");
@@ -78416,6 +78426,7 @@ function createRunActionHandler(deps = {}) {
     try {
       let atRisk = null;
       const strictExecutor = usesStrictRunActionPolicy(args);
+      const strictRunRecordMeta = (outcome) => strictExecutor && outcome.persistedRunId ? { strictRunRecordId: outcome.persistedRunId } : {};
       const inheritedBlindProbeDisabled = process.env.RN_BLIND_PROBE === "0" || process.env.RN_BLIND_PROBE === "false";
       const blindProbeDisabled = strictExecutor || args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
       if (args.platform !== "android") {
@@ -78516,11 +78527,37 @@ function createRunActionHandler(deps = {}) {
       }));
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, "maestro_run");
-      const firstPassed = firstEnv.ok === true && firstEnv.data?.passed === true;
       const firstOutput = readMaestroOutput(firstEnv);
       const firstFailureDetail = readMaestroFailureDetail(firstEnv, firstOutput);
       const firstDeviceAuthority = readMaestroDeviceAuthority(firstEnv);
       probeDeviceId = firstDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
+      const enginePinDivergence = strictExecutor ? strictEnginePinDivergence(firstEnv) : null;
+      if (enginePinDivergence) {
+        const autoRepair2 = {
+          attempted: false,
+          outcome: "refused",
+          refusedReason: "NOT_REPAIRABLE_KIND",
+          phases: { firstAttemptMs }
+        };
+        const persisted2 = await persistRunWithDevice({
+          timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+          durationMs: Date.now() - t0,
+          status: "fail",
+          failureCode: "UNKNOWN",
+          failureDetail: `Engine pin status ${enginePinDivergence}`,
+          trigger,
+          autoRepair: autoRepair2
+        });
+        return failResult(`cdp_run_action: ${args.actionId} refused strict replay because the engine pin status is ${enginePinDivergence}.`, "ENGINE_PIN_MISMATCH", {
+          actionId: args.actionId,
+          failureKind: "ENGINE_PIN_MISMATCH",
+          enginePin: firstEnv.data?.enginePin,
+          autoRepair: autoRepair2,
+          writes: writeDisclosure("none", persisted2),
+          ...strictRunRecordMeta(persisted2)
+        });
+      }
+      const firstPassed = firstEnv.ok === true && firstEnv.data?.passed === true;
       if (firstEnv.code) {
         const typedCode = firstEnv.code;
         const autoRepair2 = {
@@ -78543,7 +78580,8 @@ function createRunActionHandler(deps = {}) {
           failureKind: typedCode,
           deviceAuthority: firstDeviceAuthority,
           autoRepair: autoRepair2,
-          writes: writeDisclosure("none", persisted2)
+          writes: writeDisclosure("none", persisted2),
+          ...strictRunRecordMeta(persisted2)
         });
       }
       if (firstPassed) {
@@ -78559,9 +78597,17 @@ function createRunActionHandler(deps = {}) {
           trigger,
           autoRepair: autoRepair2
         });
+        if (strictExecutor && persisted2.persistedRunId !== runId) {
+          return failResult(`cdp_run_action: ${args.actionId} passed, but its authoritative RunRecord was not committed.`, "LOAD_FAILED", {
+            actionId: args.actionId,
+            failureKind: "AUTHORITATIVE_RUN_RECORD_MISSING",
+            writes: writeDisclosure("none", persisted2)
+          });
+        }
         return okResult({
           passed: true,
           actionId: args.actionId,
+          ...strictExecutor ? { strictRunRecordId: persisted2.persistedRunId } : {},
           ...proofReplay ? { proofReplay: true } : {},
           ...replaySuccessEvidence(firstEnv),
           repair: autoRepair2,
@@ -78691,7 +78737,7 @@ function createRunActionHandler(deps = {}) {
           phases: { firstAttemptMs }
         };
         const { actionCode, toolCode } = classifyFailure(failure);
-        await persistRunWithDevice({
+        const persisted2 = await persistRunWithDevice({
           timestamp: (/* @__PURE__ */ new Date()).toISOString(),
           durationMs: Date.now() - t0,
           status: "fail",
@@ -78711,7 +78757,8 @@ function createRunActionHandler(deps = {}) {
           firstAttemptOutput: boundedOutput(firstOutput),
           terminal: readMaestroTerminal(firstEnv),
           runnerResume: firstEnv.meta?.runnerResume,
-          ...cdpJsFallback ? { cdpJsFallback } : {}
+          ...cdpJsFallback ? { cdpJsFallback } : {},
+          ...strictRunRecordMeta(persisted2)
         };
         let message = failure.kind === "WDA_BOOTSTRAP_FAILED" ? `cdp_run_action: ${args.actionId} failed (WDA_BOOTSTRAP_FAILED) before the first replay step: ${failure.detail}. Re-run the replay (bootstrap retries itself); check network access; diagnose the pin-cache runner with ${PINNED_RUNNER_DIAGNOSE_HINT}. Supported correction: ${PINNED_RUNNER_INSTALL_HINT}. Never invoke PATH, ~/.maestro-runner, maestro-cli, or manual login. No preparation or cache mutation was attempted.` : `cdp_run_action: ${args.actionId} failed (${failure.kind})${autoRepairEnabled ? " \u2014 failure not auto-repairable" : " \u2014 auto-repair disabled"}: ${firstFailureDetail}`;
         if (cdpJsFallback?.reason === "cdp-unreachable") {
@@ -78937,7 +78984,7 @@ async function persistRun(actionId, projectRoot, record2) {
           path: fresh.filePath
         }
       });
-      return { promoted, promotionRefused: promotionRefused2 };
+      return { promoted, promotionRefused: promotionRefused2, persistedRunId: record2.runId };
     };
     const promotionRefused = promotes && !promoteActionRuntimeWithCAS(fresh, nextState).ok;
     if (promotes && !promotionRefused)
@@ -79048,7 +79095,6 @@ function createLoginPrologueHandler(deps) {
       if (action.metadata.id !== LOGIN_PROLOGUE_ALIAS) {
         return blocked("LOGIN_ACTION_ID_MISMATCH", `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
       }
-      const priorRunIds = new Set(action.state.runHistory.map((record2) => record2.runId).filter((runId) => typeof runId === "string"));
       const replayArgs = Object.create(Object.getPrototypeOf(args), Object.getOwnPropertyDescriptors(args));
       Object.assign(replayArgs, {
         actionId: LOGIN_PROLOGUE_ALIAS,
@@ -79069,15 +79115,17 @@ function createLoginPrologueHandler(deps) {
         });
       }
       const replay = parseEnvelope2(replayResult);
+      const strictRunRecordId = typeof replay.data?.strictRunRecordId === "string" ? replay.data.strictRunRecordId : typeof replay.meta?.strictRunRecordId === "string" ? replay.meta.strictRunRecordId : void 0;
       let freshRecord;
       await measure("verify-run-record", async () => {
         const reloaded = loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS);
-        freshRecord = reloaded?.state.runHistory.slice().reverse().find((record2) => typeof record2.runId === "string" && !priorRunIds.has(record2.runId));
+        freshRecord = strictRunRecordId ? reloaded?.state.runHistory.find((record2) => record2.runId === strictRunRecordId) : void 0;
       });
       if (replay.ok !== true || replay.data?.passed !== true) {
-        return blocked(replay.code ?? String(replay.data?.failureKind ?? "ACTION_REPLAY_FAILED"), "The saved login action did not pass; exploratory login is now terminally blocked.", { actionId: LOGIN_PROLOGUE_ALIAS, ...freshRecord ? { runRecord: freshRecord } : {} });
+        const metaFailureKind = replay.meta?.failureKind;
+        return blocked(replay.code ?? (typeof metaFailureKind === "string" ? metaFailureKind : freshRecord?.failureCode ?? "ACTION_REPLAY_FAILED"), "The saved login action did not pass; exploratory login is now terminally blocked.", { actionId: LOGIN_PROLOGUE_ALIAS, ...freshRecord ? { runRecord: freshRecord } : {} });
       }
-      if (!freshRecord || freshRecord.status !== "pass") {
+      if (!strictRunRecordId || !freshRecord || freshRecord.status !== "pass") {
         return blocked("AUTHORITATIVE_RUN_RECORD_MISSING", "The saved login action reported success without a fresh passing RunRecord.", { actionId: LOGIN_PROLOGUE_ALIAS });
       }
       const outcome = finish("passed", {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -32036,7 +32036,8 @@ function loadLockedTest(projectRoot, id) {
   const filePath = e2ePathFor(projectRoot, id);
   if (!existsSync20(filePath))
     return null;
-  return parseLockedTest(readFileSync19(filePath, "utf8"), filePath);
+  const locked = parseLockedTest(readFileSync19(filePath, "utf8"), filePath);
+  return locked?.id === id ? locked : null;
 }
 function discoverLockedTests(projectRoot) {
   const dir = e2eDirFor(projectRoot);
@@ -32054,6 +32055,12 @@ function resolveLockedTestIds(projectRoot, pattern, discover2 = discoverLockedTe
   } catch {
     return ids;
   }
+}
+function resolveLockedTestIdentityIds(projectRoot, pattern, discover2 = discoverLockedTests, load = loadLockedTest) {
+  return resolveLockedTestIds(projectRoot, pattern, discover2).filter((id) => {
+    const locked = load(projectRoot, id);
+    return locked?.id === id && locked.sourceActionId === id;
+  });
 }
 function setResolvedLockedTestIds(args, ids) {
   Object.defineProperty(args, resolvedLockedTestIds, {
@@ -32783,8 +32790,19 @@ function parseLoginPrologueOutcome(result) {
     return null;
   }
 }
-function missingLoginPrologueOutcome() {
+function missingLoginPrologueOutcome(result) {
   const timestamp = (/* @__PURE__ */ new Date()).toISOString();
+  let failure = {
+    code: "LOGIN_PROLOGUE_RESULT_INVALID",
+    detail: "The login prologue returned no valid terminal state."
+  };
+  try {
+    const envelope = JSON.parse(result.content?.[0]?.text ?? "{}");
+    if (envelope.code === "BUSY_FLOW_ACTIVE" && typeof envelope.error === "string") {
+      failure = { code: envelope.code, detail: envelope.error };
+    }
+  } catch {
+  }
   return {
     schemaVersion: 1,
     state: LOGIN_PROLOGUE_BLOCKED,
@@ -32794,10 +32812,7 @@ function missingLoginPrologueOutcome() {
     elapsedMs: 0,
     steps: [],
     inventory: { count: 0, actionIds: [] },
-    failure: {
-      code: "LOGIN_PROLOGUE_RESULT_INVALID",
-      detail: "The login prologue returned no valid terminal state."
-    }
+    failure
   };
 }
 function pendingLoginPrologueOutcome(attemptId) {
@@ -33763,8 +33778,8 @@ function createAuthorityGate(runtime, dependencies) {
         if (tool === "cdp_login_prologue") {
           loginPrologueOutcome = parseLoginPrologueOutcome(result);
           if (!loginPrologueOutcome) {
-            loginPrologueOutcome = missingLoginPrologueOutcome();
-            result = failResult("Login prologue returned no valid terminal state.", "LOGIN_PROLOGUE_BLOCKED", { loginPrologue: loginPrologueOutcome });
+            loginPrologueOutcome = missingLoginPrologueOutcome(result);
+            result = failResult(`Login prologue blocked: ${loginPrologueOutcome.failure?.detail ?? "The login prologue returned no valid terminal state."}`, "LOGIN_PROLOGUE_BLOCKED", { loginPrologue: loginPrologueOutcome });
           }
           if (loginPrologueOutcome.state === LOGIN_PROLOGUE_BLOCKED) {
             const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
@@ -90863,7 +90878,7 @@ var authorityGate = createAuthorityGate(authorityRuntime, {
     if (typeof projectRoot !== "string")
       return [];
     args.projectRoot = projectRoot;
-    return resolveLockedTestIds(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
+    return resolveLockedTestIdentityIds(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
   },
   probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
   recoverRuntimeConnection: async (status) => {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -31907,6 +31907,9 @@ function readLoginPrologueOutcome(value) {
   }
   return candidate;
 }
+function lockedE2eProofAllowed(tool) {
+  return LOCKED_E2E_LOGIN_TOOLS.includes(tool);
+}
 function cleanupAllowed(tool, args) {
   if (tool === "cdp_login_prologue")
     return true;
@@ -31932,7 +31935,7 @@ function tokenMatches(expected, supplied) {
 }
 function inspectLoginPrologueGuard(input) {
   const outcome = readLoginPrologueOutcome(input.binding);
-  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args)) {
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool)) {
     return { blocked: false };
   }
   return {
@@ -31948,12 +31951,14 @@ function authorizeLoginSupervisorOverride(input) {
 function appendLoginOverrideAudit(outcome, audit) {
   return { ...outcome, overrides: [...outcome.overrides ?? [], audit].slice(-20) };
 }
-var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED;
+var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, ACTION_LOGIN_HELPER, LOCKED_E2E_LOGIN_TOOLS;
 var init_login_prologue = __esm({
   "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
     "use strict";
     LOGIN_PROLOGUE_ALIAS = "user-login";
     LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
+    ACTION_LOGIN_HELPER = "ACTION_LOGIN_HELPER";
+    LOCKED_E2E_LOGIN_TOOLS = ["cdp_lock_e2e_test", "cdp_run_e2e_suite"];
   }
 });
 
@@ -64034,6 +64039,7 @@ function projectPublicAuthorityStatus(status, options = {}) {
     proofOverlay: { active: Boolean(status.bindings.proof) },
     ...loginPrologue ? {
       loginPrologue: {
+        role: ACTION_LOGIN_HELPER,
         state: loginPrologue.state,
         alias: loginPrologue.alias,
         actionId: loginPrologue.actionId,
@@ -79068,6 +79074,7 @@ function createLoginPrologueHandler(deps) {
       return {
         schemaVersion: 1,
         state,
+        role: ACTION_LOGIN_HELPER,
         alias: LOGIN_PROLOGUE_ALIAS,
         startedAt: prologueStarted.toISOString(),
         endedAt: ended.toISOString(),
@@ -92271,7 +92278,7 @@ trackedTool("cdp_run_action", `Replay a learned action by id with end-to-end aut
   blindProbeMode: external_exports.enum(["inherit", "allow", "forbid"]).optional().describe("Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged."),
   params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).")
 }, runActionHandler);
-trackedTool("cdp_login_prologue", "Inventory learned actions, replay the exact user-login action strictly, and require a fresh passing RunRecord before lifting the session login gate.", {
+trackedTool("cdp_login_prologue", "Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; not PR proof.", {
   projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
   platform: external_exports.enum(["ios", "android"]).optional().describe("Force a platform; otherwise use the authority-bound device."),
   appFile: external_exports.string().optional().describe("iOS app artifact used only when the saved action contains clearState."),

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -92171,7 +92171,7 @@ trackedTool("device_batch", "Execute a sequence of exact-device UI interactions 
   continueOnError: external_exports.boolean().default(false).describe("When true, ordinary failed steps are recorded and the batch continues. A failed fill with observed or possible mutation always stops later steps."),
   finalSnapshot: external_exports.enum(["salient", "full", "none"]).default("salient").describe("Shape of the batch final_snapshot. salient (default): compact list of only actionable nodes (Button/TextField/Switch/etc) \u2014 far fewer tokens. full: complete node list (legacy). none: skip the implicit trailing snapshot entirely (~1,450 ms saved) for action-only batches you verify via expect_*/cdp_store_state.")
 }, createDeviceBatchHandler(getClient));
-trackedTool("cdp_auto_login", "Explicit legacy navigation helper that detects an auth screen and runs one project login subflow through maestro_run on the authority-bound device. It is per-call recovery only, never durable login authority or PR proof; prefer a compatible owned learned action.", {
+trackedTool("cdp_auto_login", "Explicit legacy navigation helper that detects an auth screen and runs one project login subflow through maestro_run on the authority-bound device. It is never login authority or PR proof; use cdp_login_prologue for authenticated journeys.", {
   appId: external_exports.string().optional().describe("App bundle ID override (auto-detected from app.json if omitted)"),
   platform: external_exports.enum(["ios", "android"]).optional().describe("Platform override (auto-detected from session if omitted)")
 }, withConnection(getClient, async (args, client2) => {
@@ -92371,13 +92371,13 @@ trackedTool("cdp_run_action", `Replay a learned action by id with end-to-end aut
   blindProbeMode: external_exports.enum(["inherit", "allow", "forbid"]).optional().describe("Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged."),
   params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).")
 }, runActionHandler);
-trackedTool("cdp_login_prologue", "Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; not PR proof.", {
+trackedTool("cdp_login_prologue", "Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; failure blocks exploratory fallback mutations, and a pass is not PR proof.", {
   projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
-  platform: external_exports.enum(["ios", "android"]).optional().describe("Force a platform; otherwise use the authority-bound device."),
-  appFile: external_exports.string().optional().describe("iOS app artifact used only when the saved action contains clearState."),
+  platform: external_exports.enum(["ios", "android"]).optional().describe("Override the bound platform."),
+  appFile: external_exports.string().optional().describe("iOS app artifact for clearState actions."),
   timeoutMs: external_exports.number().optional().describe("Saved-action timeout in milliseconds."),
-  trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe("RunRecord trigger annotation. Default agent."),
-  params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Bindings for the exact user-login action placeholders.")
+  trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe("Run trigger; default agent."),
+  params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("String user-login bindings.")
 }, createLoginPrologueHandler({ runAction: runActionHandler }));
 trackedTool("cdp_lock_e2e_test", "Promote a verified action into a frozen, locked e2e regression test. Runs the action once strict (no repair); freezes it only if it passes. v1 supports param-free actions only.", {
   actionId: external_exports.string().describe("The action id under .rn-agent/actions to lock"),

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -31917,11 +31917,11 @@ function readLoginPrologueOutcome(value) {
   }
   return candidate;
 }
-function lockedE2eProofAllowed(tool, args) {
+function lockedE2eProofAllowed(tool, args, resolvedLockedTestIds2) {
   if (tool === "cdp_lock_e2e_test")
     return args.actionId === LOGIN_PROLOGUE_ALIAS;
   if (tool === "cdp_run_e2e_suite") {
-    return args.pattern === `^${LOGIN_PROLOGUE_ALIAS}$`;
+    return resolvedLockedTestIds2?.length === 1 && resolvedLockedTestIds2[0] === LOGIN_PROLOGUE_ALIAS;
   }
   return false;
 }
@@ -31950,7 +31950,7 @@ function tokenMatches(expected, supplied) {
 }
 function inspectLoginPrologueGuard(input) {
   const outcome = readLoginPrologueOutcome(input.binding);
-  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool, input.args)) {
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool, input.args, input.resolvedLockedTestIds)) {
     return { blocked: false };
   }
   return {
@@ -31973,6 +31973,137 @@ var init_login_prologue = __esm({
     LOGIN_PROLOGUE_ALIAS = "user-login";
     LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
     ACTION_LOGIN_HELPER = "ACTION_LOGIN_HELPER";
+  }
+});
+
+// packages/rn-dev-agent-core/dist/domain/e2e-test.js
+import { dirname as dirname15, join as join25 } from "node:path";
+import { mkdirSync as mkdirSync14, writeFileSync as writeFileSync9, renameSync as renameSync5, readFileSync as readFileSync19, readdirSync as readdirSync10, existsSync as existsSync20 } from "node:fs";
+import { createHash as createHash8 } from "node:crypto";
+function e2eDirFor(projectRoot) {
+  return join25(projectRoot, ".rn-agent", "e2e");
+}
+function e2ePathFor(projectRoot, id) {
+  assertValidActionId(id, "e2ePathFor");
+  const dir = e2eDirFor(projectRoot);
+  const file = join25(dir, `${id}.yaml`);
+  assertWithinDir(file, dir);
+  return file;
+}
+function serializeLockedTest(meta) {
+  const header = [
+    "# e2e-locked-test: true",
+    `# id: ${meta.id}`,
+    `# intent: ${meta.intent}`,
+    `# sourceActionId: ${meta.sourceActionId}`,
+    `# lockedAt: ${meta.lockedAt}`,
+    `# lockedGitSha: ${meta.lockedGitSha ?? ""}`,
+    `# sourceContentHash: ${meta.sourceContentHash}`,
+    "# status: locked"
+  ];
+  if (meta.appId)
+    header.push(`# appId: ${meta.appId}`);
+  if (meta.params?.length)
+    header.push(`# params: ${meta.params.join(", ")}`);
+  header.push(FLOW_SENTINEL);
+  return `${header.join("\n")}
+${meta.flow}`;
+}
+function hashBody(s) {
+  return createHash8("sha256").update(s).digest("hex");
+}
+function freezeLockedTest(projectRoot, source, ctx) {
+  const filePath = e2ePathFor(projectRoot, source.id);
+  mkdirSync14(dirname15(filePath), { recursive: true });
+  const meta = {
+    id: source.id,
+    intent: source.intent,
+    sourceActionId: source.sourceActionId,
+    lockedAt: ctx.now().toISOString(),
+    lockedGitSha: ctx.gitSha,
+    sourceContentHash: hashBody(source.flow),
+    status: "locked",
+    params: source.params,
+    appId: source.appId,
+    flow: source.flow
+  };
+  const tmp = `${filePath}.tmp`;
+  writeFileSync9(tmp, serializeLockedTest(meta), "utf8");
+  renameSync5(tmp, filePath);
+  return { ...meta, filePath };
+}
+function loadLockedTest(projectRoot, id) {
+  const filePath = e2ePathFor(projectRoot, id);
+  if (!existsSync20(filePath))
+    return null;
+  return parseLockedTest(readFileSync19(filePath, "utf8"), filePath);
+}
+function discoverLockedTests(projectRoot) {
+  const dir = e2eDirFor(projectRoot);
+  if (!existsSync20(dir))
+    return [];
+  return readdirSync10(dir).filter((f) => f.endsWith(".yaml")).map((f) => f.replace(/\.yaml$/, "")).sort();
+}
+function resolveLockedTestIds(projectRoot, pattern, discover2 = discoverLockedTests) {
+  const ids = discover2(projectRoot);
+  if (!pattern || pattern.length > 256)
+    return ids;
+  try {
+    const matcher = new RegExp(pattern, "i");
+    return ids.filter((id) => matcher.test(id));
+  } catch {
+    return ids;
+  }
+}
+function setResolvedLockedTestIds(args, ids) {
+  Object.defineProperty(args, resolvedLockedTestIds, {
+    value: Object.freeze([...ids]),
+    configurable: true
+  });
+}
+function getResolvedLockedTestIds(args) {
+  return args[resolvedLockedTestIds];
+}
+function parseLockedTest(text, filePath) {
+  if (!/^#\s*e2e-locked-test:\s*true\s*$/m.test(text))
+    return null;
+  const sentinelIdx = text.indexOf(FLOW_SENTINEL);
+  if (sentinelIdx < 0)
+    return null;
+  const headerText = text.slice(0, sentinelIdx);
+  const flowStart = text.indexOf("\n", sentinelIdx);
+  const flow = flowStart >= 0 ? text.slice(flowStart + 1) : "";
+  const field2 = (k) => {
+    const m = headerText.match(new RegExp(`^#\\s*${k}:\\s*(.*)$`, "m"));
+    const v = m?.[1]?.trim();
+    return v ? v : void 0;
+  };
+  const id = field2("id");
+  const intent = field2("intent");
+  if (!id || !intent)
+    return null;
+  const paramsRaw = field2("params");
+  return {
+    id,
+    intent,
+    sourceActionId: field2("sourceActionId") ?? id,
+    lockedAt: field2("lockedAt") ?? "",
+    lockedGitSha: field2("lockedGitSha") ?? null,
+    sourceContentHash: field2("sourceContentHash") ?? "",
+    status: "locked",
+    params: paramsRaw ? paramsRaw.split(",").map((s) => s.trim()).filter(Boolean) : void 0,
+    appId: field2("appId"),
+    flow,
+    filePath
+  };
+}
+var FLOW_SENTINEL, resolvedLockedTestIds;
+var init_e2e_test = __esm({
+  "packages/rn-dev-agent-core/dist/domain/e2e-test.js"() {
+    "use strict";
+    init_path_safety();
+    FLOW_SENTINEL = "# e2e-locked-flow-below";
+    resolvedLockedTestIds = /* @__PURE__ */ Symbol("resolvedLockedTestIds");
   }
 });
 
@@ -32952,7 +33083,8 @@ function createAuthorityGate(runtime, dependencies) {
         mutation: profile.mutation
       });
       const pendingSupervisorOverrideToken = loginGuard.blocked ? suppliedSupervisorOverrideToken : void 0;
-      if (loginGuard.blocked && pendingSupervisorOverrideToken === void 0) {
+      const pendingLockedE2eAdmission = loginGuard.blocked && tool === "cdp_run_e2e_suite" && pendingSupervisorOverrideToken === void 0;
+      if (loginGuard.blocked && pendingSupervisorOverrideToken === void 0 && !pendingLockedE2eAdmission) {
         return failResult("LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.", "LOGIN_PROLOGUE_BLOCKED", {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
           overrideRejected: false,
@@ -33233,6 +33365,19 @@ function createAuthorityGate(runtime, dependencies) {
         if (!deferredAdmissionChecks) {
           requireCompleteAxes(status, profile);
           bindSessionArguments(status, profile, args, tool);
+        }
+        if (pendingLockedE2eAdmission) {
+          const resolvedLockedTestIds2 = dependencies.resolveLockedE2eTestIds?.(args, status);
+          if (!resolvedLockedTestIds2 || inspectLoginPrologueGuard({
+            binding: status.bindings.loginPrologue,
+            tool,
+            args,
+            mutation: profile.mutation,
+            resolvedLockedTestIds: resolvedLockedTestIds2
+          }).blocked) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the locked e2e suite did not resolve to the exact user-login candidate");
+          }
+          setResolvedLockedTestIds(args, resolvedLockedTestIds2);
         }
         operation = registry2.beginOperation(available.session, {
           operationId: randomUUID4(),
@@ -33853,6 +33998,7 @@ var init_authority_gate = __esm({
     init_metro_origin();
     init_install_reissue();
     init_login_prologue();
+    init_e2e_test();
     init_tool_profiles();
     optionalBundleAdmission = /* @__PURE__ */ Symbol("optionalBundleAdmission");
     managedNativeOrigin = /* @__PURE__ */ Symbol("managedNativeOrigin");
@@ -33889,9 +34035,9 @@ var init_authority_gate = __esm({
 // packages/rn-dev-agent-core/dist/tools/maestro-run.js
 import { execFile as execFileCb3 } from "node:child_process";
 import { promisify as promisify4 } from "node:util";
-import { existsSync as existsSync20, readFileSync as readFileSync19, writeFileSync as writeFileSync9 } from "node:fs";
+import { existsSync as existsSync21, readFileSync as readFileSync20, writeFileSync as writeFileSync10 } from "node:fs";
 import { tmpdir as tmpdir7 } from "node:os";
-import { basename as basename7, join as join25, dirname as dirname15 } from "node:path";
+import { basename as basename7, join as join26, dirname as dirname16 } from "node:path";
 async function runFlowParked(run, opts = {}) {
   const stale = opts.markCdpStale ?? markCdpStale;
   try {
@@ -34132,11 +34278,11 @@ function createMaestroRunHandler(deps = {}) {
     } else if (args.inlineYaml) {
       rawYaml = args.inlineYaml;
     } else if (args.flowPath) {
-      if (!existsSync20(args.flowPath)) {
+      if (!existsSync21(args.flowPath)) {
         return failResult(`Flow file not found: ${args.flowPath}`);
       }
       try {
-        rawYaml = readFileSync19(args.flowPath, "utf-8");
+        rawYaml = readFileSync20(args.flowPath, "utf-8");
       } catch (err) {
         return failResult(`Failed to read flow file: ${err.message}`);
       }
@@ -34144,7 +34290,7 @@ function createMaestroRunHandler(deps = {}) {
       return failResult("Provide either flowPath or inlineYaml.");
     }
     try {
-      const runFlowOpts = args.flowPath && flowPathClassification === "outside" ? { flowDir: dirname15(args.flowPath), flowRoot: dirname15(args.flowPath) } : {};
+      const runFlowOpts = args.flowPath && flowPathClassification === "outside" ? { flowDir: dirname16(args.flowPath), flowRoot: dirname16(args.flowPath) } : {};
       const parsed = parseAndValidateFlow(rawYaml, runFlowOpts);
       planMaestroAuthorityStages(parsed.commands);
       validatedCommands = parsed.commands;
@@ -34152,8 +34298,8 @@ function createMaestroRunHandler(deps = {}) {
       const rawAppId = resolveAppId(args.appId, platform);
       headerAppId = resolveMaestroFlowAppId(rawAppId || void 0, parsed.appId);
       validatedContent = buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, parsed.commands);
-      flowFile = join25(tmpdir7(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
-      writeFileSync9(flowFile, validatedContent, "utf-8");
+      flowFile = join26(tmpdir7(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      writeFileSync10(flowFile, validatedContent, "utf-8");
     } catch (err) {
       if (err instanceof MaestroValidationError) {
         return failResult(`Refusing to run Maestro: ${err.message} (Phase 134.1)`);
@@ -34265,7 +34411,7 @@ function createMaestroRunHandler(deps = {}) {
       const relaunchManagedApp = args.relaunchManagedApp ?? deps.relaunchManagedApp ?? managedAuthority.relaunchManagedApp;
       const reproveManagedOrigin = args.reproveManagedOrigin ?? deps.reproveManagedOrigin ?? managedAuthority.reproveManagedOrigin;
       const stageResults = await parkFlow(() => executeMaestroAuthorityStages(validatedCommands, async (commands) => {
-        writeFileSync9(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
+        writeFileSync10(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
         const executeOnce = async (beforeDispatch) => {
           if (flowDeadline - now() <= 0) {
             const error2 = new Error("Maestro flow timeout exhausted before the next stage");
@@ -34508,7 +34654,7 @@ function createMaestroRunHandler(deps = {}) {
       return failResult(failAug.message, failAug.meta);
     } finally {
       try {
-        writeFileSync9(flowFile, validatedContent, "utf-8");
+        writeFileSync10(flowFile, validatedContent, "utf-8");
       } finally {
         disposeRunnerReportDir(runnerReportDir);
       }
@@ -34560,7 +34706,7 @@ var init_maestro_run = __esm({
 
 // packages/rn-dev-agent-core/dist/session/managed-automation.js
 import { spawn as spawn4 } from "node:child_process";
-import { readdirSync as readdirSync10, readFileSync as readFileSync20, unlinkSync as unlinkSync9 } from "node:fs";
+import { readdirSync as readdirSync11, readFileSync as readFileSync21, unlinkSync as unlinkSync9 } from "node:fs";
 function sleep4(ms) {
   return new Promise((resolve20) => setTimeout(resolve20, ms));
 }
@@ -34577,12 +34723,12 @@ function processGroupLiveness(pgid) {
   if (process.platform !== "linux")
     return "unknown";
   try {
-    for (const entry of readdirSync10("/proc", { withFileTypes: true })) {
+    for (const entry of readdirSync11("/proc", { withFileTypes: true })) {
       if (!entry.isDirectory() || !/^\d+$/.test(entry.name))
         continue;
       let stat2;
       try {
-        stat2 = readFileSync20(`/proc/${entry.name}/stat`, "utf8");
+        stat2 = readFileSync21(`/proc/${entry.name}/stat`, "utf8");
       } catch (error2) {
         if (error2.code === "ENOENT")
           continue;
@@ -35239,8 +35385,8 @@ var init_device_arbiter = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/maestro-invoke.js
-import { writeFileSync as writeFileSync10 } from "node:fs";
-import { join as join26 } from "node:path";
+import { writeFileSync as writeFileSync11 } from "node:fs";
+import { join as join27 } from "node:path";
 import { tmpdir as tmpdir8 } from "node:os";
 function yamlEscape(s) {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t");
@@ -35271,7 +35417,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     return { passed: false, output: "", flowFile: "", error: pinRefusal };
   }
   const rawAppId = opts.appId ?? resolveBundleId(opts.platform) ?? readExpoSlug() ?? "";
-  const flowFile = join26(tmpdir8(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+  const flowFile = join27(tmpdir8(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
   let content;
   let headerAppId;
   try {
@@ -35309,7 +35455,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     throw err;
   }
   try {
-    writeFileSync10(flowFile, content, "utf-8");
+    writeFileSync11(flowFile, content, "utf-8");
   } catch (err) {
     return {
       passed: false,
@@ -35681,9 +35827,9 @@ var init_app_lifecycle = __esm({
 
 // packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js
 import { execFileSync as execFileSync7 } from "node:child_process";
-import { existsSync as existsSync21, readFileSync as readFileSync21, unlinkSync as unlinkSync10 } from "node:fs";
+import { existsSync as existsSync22, readFileSync as readFileSync22, unlinkSync as unlinkSync10 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
-import { join as join27 } from "node:path";
+import { join as join28 } from "node:path";
 function selectInstalledLegacyApps(installed) {
   return LEGACY_BUNDLE_IDS.filter((id) => installed.has(id));
 }
@@ -35750,13 +35896,13 @@ function defaultDeps2() {
     },
     readDaemonPid: () => {
       try {
-        const parsed = JSON.parse(readFileSync21(DAEMON_JSON2, "utf8"));
+        const parsed = JSON.parse(readFileSync22(DAEMON_JSON2, "utf8"));
         return typeof parsed.pid === "number" ? parsed.pid : null;
       } catch {
         return null;
       }
     },
-    fileExists: (path) => existsSync21(path),
+    fileExists: (path) => existsSync22(path),
     removeFile: (path) => unlinkSync10(path),
     delay: (ms) => new Promise((resolve20) => setTimeout(resolve20, ms)),
     listApps: (udid) => execFileSync7("xcrun", ["simctl", "listapps", udid], {
@@ -35839,8 +35985,8 @@ var init_ensure_single_runner = __esm({
   "packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js"() {
     "use strict";
     init_discovery();
-    DAEMON_JSON2 = join27(homedir6(), ".agent-device", "daemon.json");
-    DAEMON_LOCK2 = join27(homedir6(), ".agent-device", "daemon.lock");
+    DAEMON_JSON2 = join28(homedir6(), ".agent-device", "daemon.json");
+    DAEMON_LOCK2 = join28(homedir6(), ".agent-device", "daemon.lock");
     DAEMON_FILES2 = [DAEMON_JSON2, DAEMON_LOCK2];
     SIGKILL_GRACE_MS2 = 500;
     LEGACY_BUNDLE_IDS = [
@@ -35967,9 +36113,9 @@ var init_recover_detached = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/lifecycle/device-lock.js
-import { existsSync as existsSync22, mkdirSync as mkdirSync14, openSync as openSync4, writeSync, closeSync as closeSync4, readFileSync as readFileSync22, unlinkSync as unlinkSync11, writeFileSync as writeFileSync11 } from "node:fs";
+import { existsSync as existsSync23, mkdirSync as mkdirSync15, openSync as openSync4, writeSync, closeSync as closeSync4, readFileSync as readFileSync23, unlinkSync as unlinkSync11, writeFileSync as writeFileSync12 } from "node:fs";
 import { tmpdir as tmpdir9, userInfo } from "node:os";
-import { join as join28 } from "node:path";
+import { join as join29 } from "node:path";
 function defaultProcessAlive3(pid) {
   try {
     process.kill(pid, 0);
@@ -36022,7 +36168,7 @@ var init_device_lock = __esm({
         this.clock = opts.clock ?? Date.now;
         this.processAlive = opts.processAlive ?? defaultProcessAlive3;
         this.staleMs = opts.staleMs ?? DEVICE_LOCK_STALE_MS;
-        this.lockPath = join28(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
+        this.lockPath = join29(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
       }
       acquire() {
         try {
@@ -36064,7 +36210,7 @@ var init_device_lock = __esm({
           return;
         holder.lastHeartbeat = this.clock();
         try {
-          writeFileSync11(this.lockPath, JSON.stringify(holder, null, 2), "utf8");
+          writeFileSync12(this.lockPath, JSON.stringify(holder, null, 2), "utf8");
         } catch {
         }
       }
@@ -36080,8 +36226,8 @@ var init_device_lock = __esm({
         this.acquired = false;
       }
       create() {
-        if (!existsSync22(this.tmpDir))
-          mkdirSync14(this.tmpDir, { recursive: true });
+        if (!existsSync23(this.tmpDir))
+          mkdirSync15(this.tmpDir, { recursive: true });
         const fd = openSync4(this.lockPath, "wx");
         try {
           const now = this.clock();
@@ -36103,7 +36249,7 @@ var init_device_lock = __esm({
       }
       readExisting() {
         try {
-          const parsed = JSON.parse(readFileSync22(this.lockPath, "utf8"));
+          const parsed = JSON.parse(readFileSync23(this.lockPath, "utf8"));
           if (!isValidBody(parsed))
             return null;
           if (parsed.deviceId !== this.deviceId || parsed.platform !== this.platform)
@@ -38701,8 +38847,8 @@ var init_utils = __esm({
 
 // packages/rn-dev-agent-core/dist/tools/device-screenshot-raw.js
 import { execFile as execFile13, spawn as spawn5 } from "node:child_process";
-import { createWriteStream as createWriteStream2, renameSync as renameSync5, statSync as statSync10, unlinkSync as unlinkSync12 } from "node:fs";
-import { basename as basename9, dirname as dirname16, join as join29 } from "node:path";
+import { createWriteStream as createWriteStream2, renameSync as renameSync6, statSync as statSync10, unlinkSync as unlinkSync12 } from "node:fs";
+import { basename as basename9, dirname as dirname17, join as join30 } from "node:path";
 import { promisify as promisify13 } from "node:util";
 function parseSimctlBootedAll(jsonText) {
   let data;
@@ -38855,7 +39001,7 @@ function resolveCaptureOutcome(streamFinished, procCode) {
   return procCode === 0 ? "success" : "failure";
 }
 function rawTempPath(finalPath, uniq) {
-  return join29(dirname16(finalPath), `.${basename9(finalPath)}.${uniq}.rawtmp`);
+  return join30(dirname17(finalPath), `.${basename9(finalPath)}.${uniq}.rawtmp`);
 }
 function nextCaptureSuffix() {
   captureCounter += 1;
@@ -38949,7 +39095,7 @@ var init_device_screenshot_raw = __esm({
           return;
         }
         try {
-          renameSync5(tmp, path);
+          renameSync6(tmp, path);
           settle(true);
         } catch {
           cleanupTemp();
@@ -39167,11 +39313,11 @@ var init_settle = __esm({
 
 // packages/rn-dev-agent-core/dist/agent-device-wrapper.js
 import { unlinkSync as unlinkSync13, rmSync as rmSync7 } from "node:fs";
-import { join as join30 } from "node:path";
-import { createHash as createHash8 } from "node:crypto";
+import { join as join31 } from "node:path";
+import { createHash as createHash9 } from "node:crypto";
 function getSessionFilePath() {
-  const projectId = createHash8("sha256").update(process.cwd()).digest("hex").slice(0, 12);
-  return join30(getStateDir(), `session-${projectId}.json`);
+  const projectId = createHash9("sha256").update(process.cwd()).digest("hex").slice(0, 12);
+  return join31(getStateDir(), `session-${projectId}.json`);
 }
 function getActiveSession() {
   return activeSession;
@@ -61564,8 +61710,8 @@ function annotateMutationAbsence(result, ctx) {
 
 // packages/rn-dev-agent-core/dist/verification/config.js
 init_storage();
-import { existsSync as existsSync23, readFileSync as readFileSync23 } from "node:fs";
-import { join as join31 } from "node:path";
+import { existsSync as existsSync24, readFileSync as readFileSync24 } from "node:fs";
+import { join as join32 } from "node:path";
 var MAX_PATTERN_LENGTH = 200;
 var _cachedProjectRoot;
 function getCachedProjectRoot() {
@@ -61621,14 +61767,14 @@ function loadVerificationConfig(projectRoot) {
   const cached2 = cache.get(projectRoot);
   if (cached2)
     return cached2;
-  const path = join31(projectRoot, ".rn-agent", "config.json");
-  if (!existsSync23(path)) {
+  const path = join32(projectRoot, ".rn-agent", "config.json");
+  if (!existsSync24(path)) {
     cache.set(projectRoot, DEFAULTS);
     return DEFAULTS;
   }
   let raw;
   try {
-    raw = JSON.parse(readFileSync23(path, "utf-8"));
+    raw = JSON.parse(readFileSync24(path, "utf-8"));
   } catch {
     cache.set(projectRoot, DEFAULTS);
     return DEFAULTS;
@@ -62013,28 +62159,28 @@ function inspectInstallIdentity(install, dependencies = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/session/migration-diagnostic.js
-import { createHash as createHash9 } from "node:crypto";
-import { existsSync as existsSync25, readFileSync as readFileSync26 } from "node:fs";
-import { join as join34 } from "node:path";
+import { createHash as createHash10 } from "node:crypto";
+import { existsSync as existsSync26, readFileSync as readFileSync27 } from "node:fs";
+import { join as join35 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/bound-directory.js
 import { spawn as spawn6 } from "node:child_process";
 import { randomUUID as randomUUID7 } from "node:crypto";
-import { closeSync as closeSync5, constants as constants5, existsSync as existsSync24, fstatSync as fstatSync4, lstatSync as lstatSync13, mkdtempSync as mkdtempSync2, openSync as openSync5, readFileSync as readFileSync25, realpathSync as realpathSync9, renameSync as renameSync7, rmSync as rmSync9, writeFileSync as writeFileSync13 } from "node:fs";
+import { closeSync as closeSync5, constants as constants5, existsSync as existsSync25, fstatSync as fstatSync4, lstatSync as lstatSync13, mkdtempSync as mkdtempSync2, openSync as openSync5, readFileSync as readFileSync26, realpathSync as realpathSync9, renameSync as renameSync8, rmSync as rmSync9, writeFileSync as writeFileSync14 } from "node:fs";
 import { tmpdir as tmpdir10 } from "node:os";
-import { join as join33 } from "node:path";
+import { join as join34 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/state-root.js
 init_secure_state_file();
 import { randomBytes as randomBytes5, randomUUID as randomUUID6 } from "node:crypto";
-import { chmodSync as chmodSync6, linkSync as linkSync2, lstatSync as lstatSync12, mkdirSync as mkdirSync15, readFileSync as readFileSync24, renameSync as renameSync6, rmSync as rmSync8, statSync as statSync11, writeFileSync as writeFileSync12 } from "node:fs";
-import { join as join32, resolve as resolve9 } from "node:path";
+import { chmodSync as chmodSync6, linkSync as linkSync2, lstatSync as lstatSync12, mkdirSync as mkdirSync16, readFileSync as readFileSync25, renameSync as renameSync7, rmSync as rmSync8, statSync as statSync11, writeFileSync as writeFileSync13 } from "node:fs";
+import { join as join33, resolve as resolve9 } from "node:path";
 function fail(code, detail) {
   throw new Error(`${code}: ${detail}`);
 }
 function ensurePrivateDirectory(path) {
   try {
-    mkdirSync15(path, { recursive: true, mode: 448 });
+    mkdirSync16(path, { recursive: true, mode: 448 });
     const link = lstatSync12(path);
     const stat2 = statSync11(path);
     if (link.isSymbolicLink() || !link.isDirectory() || typeof process.getuid === "function" && stat2.uid !== process.getuid()) {
@@ -62050,14 +62196,14 @@ function ensurePrivateDirectory(path) {
 }
 function authorityStateLayout(stateDir) {
   const resolvedStateDir = resolve9(stateDir);
-  const root = join32(resolvedStateDir, "v2");
+  const root = join33(resolvedStateDir, "v2");
   return {
     root,
-    registry: join32(root, "registry.sqlite3"),
-    sessions: join32(root, "sessions"),
-    runners: join32(root, "runner"),
-    observe: join32(root, "observe"),
-    migrations: join32(root, "migrations")
+    registry: join33(root, "registry.sqlite3"),
+    sessions: join33(root, "sessions"),
+    runners: join33(root, "runner"),
+    observe: join33(root, "observe"),
+    migrations: join33(root, "migrations")
   };
 }
 function createAuthorityStateLayout(stateDir = getStateDir()) {
@@ -62097,11 +62243,11 @@ function resolveAuthorityStateLayout(requestedStateHome) {
   return requestedStateHome ? openAuthorityStateLayout(requestedStateHome) : createAuthorityStateLayout();
 }
 function getBoundDirectoryJournalKey(layout = createAuthorityStateLayout()) {
-  const path = join32(layout.root, "bound-directory.key");
-  const temporary = join32(layout.root, `.bound-directory.${randomUUID6()}.key`);
+  const path = join33(layout.root, "bound-directory.key");
+  const temporary = join33(layout.root, `.bound-directory.${randomUUID6()}.key`);
   try {
     try {
-      writeFileSync12(temporary, randomBytes5(32), { flag: "wx", mode: 384, flush: true });
+      writeFileSync13(temporary, randomBytes5(32), { flag: "wx", mode: 384, flush: true });
       try {
         linkSync2(temporary, path);
       } catch (error2) {
@@ -62113,7 +62259,7 @@ function getBoundDirectoryJournalKey(layout = createAuthorityStateLayout()) {
     }
     const link = lstatSync12(path);
     const stat2 = statSync11(path);
-    const key = readFileSync24(path);
+    const key = readFileSync25(path);
     if (link.isSymbolicLink() || !link.isFile() || key.length !== 32 || typeof process.getuid === "function" && stat2.uid !== process.getuid()) {
       fail("AUTHORITY_STATE_ROOT_UNSAFE", "bound-directory journal key is invalid");
     }
@@ -63229,28 +63375,28 @@ function sameIdentity(left, right) {
 function waitForFile(path, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (existsSync24(path))
+    if (existsSync25(path))
       return true;
     Atomics.wait(WAIT_BUFFER, 0, 0, 5);
   }
-  return existsSync24(path);
+  return existsSync25(path);
 }
 function stopWorker(worker, signal = "SIGTERM") {
-  const stoppedPath = join33(worker.controlPath, "stopped");
+  const stoppedPath = join34(worker.controlPath, "stopped");
   if (signal === "SIGTERM") {
     try {
-      writeFileSync13(join33(worker.controlPath, "stop"), "", { flag: "wx", mode: 384 });
+      writeFileSync14(join34(worker.controlPath, "stop"), "", { flag: "wx", mode: 384 });
     } catch {
     }
     if (waitForFile(stoppedPath, 1e3)) {
-      if (!existsSync24(join33(worker.controlPath, "lock-retained"))) {
+      if (!existsSync25(join34(worker.controlPath, "lock-retained"))) {
         rmSync9(worker.controlPath, { force: true, recursive: true });
       }
       return;
     }
   }
   try {
-    writeFileSync13(join33(worker.controlPath, "terminate"), JSON.stringify({
+    writeFileSync14(join34(worker.controlPath, "terminate"), JSON.stringify({
       lifecycleCapability: worker.lifecycleCapability,
       signal: "SIGKILL"
     }), { flag: "wx", mode: 384 });
@@ -63259,7 +63405,7 @@ function stopWorker(worker, signal = "SIGTERM") {
   if (!waitForFile(stoppedPath, 1e4)) {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: bound-directory worker exit was not confirmed");
   }
-  if (!existsSync24(join33(worker.controlPath, "lock-retained"))) {
+  if (!existsSync25(join34(worker.controlPath, "lock-retained"))) {
     rmSync9(worker.controlPath, { force: true, recursive: true });
   }
 }
@@ -63281,13 +63427,13 @@ function bindWorker(controlPath, child, owner, childId, lifecycleCapability = ""
     }
     throw new Error(message);
   };
-  const readyPath = join33(controlPath, "ready");
+  const readyPath = join34(controlPath, "ready");
   if (!waitForFile(readyPath, WORKER_READY_TIMEOUT_MS)) {
     rejectWorker("SESSION_INTEGRATION_PATH_UNSAFE: bound-directory worker unavailable");
   }
   let ready = {};
   try {
-    ready = JSON.parse(readFileSync25(readyPath, "utf8"));
+    ready = JSON.parse(readFileSync26(readyPath, "utf8"));
   } catch {
     rejectWorker("SESSION_INTEGRATION_PATH_UNSAFE: bound-directory worker unavailable");
   }
@@ -63306,7 +63452,7 @@ function bindWorker(controlPath, child, owner, childId, lifecycleCapability = ""
   };
 }
 function startWorker(path, identity2, realPath) {
-  const controlPath = mkdtempSync2(join33(tmpdir10(), "rn-bound-directory-"));
+  const controlPath = mkdtempSync2(join34(tmpdir10(), "rn-bound-directory-"));
   const lifecycleCapability = randomUUID7();
   const binding = Buffer.from(JSON.stringify({
     dev: identity2.dev.toString(),
@@ -63336,7 +63482,7 @@ function startWorker(path, identity2, realPath) {
   return bindWorker(controlPath, child, void 0, void 0, lifecycleCapability);
 }
 function startSubdirectoryWorker(parent, name, expectedIdentity, expectedRealPath) {
-  const controlPath = mkdtempSync2(join33(tmpdir10(), "rn-bound-directory-"));
+  const controlPath = mkdtempSync2(join34(tmpdir10(), "rn-bound-directory-"));
   const childId = randomUUID7();
   const lifecycleCapability = randomUUID7();
   let worker;
@@ -63348,7 +63494,7 @@ function startSubdirectoryWorker(parent, name, expectedIdentity, expectedRealPat
       controlPath,
       lifecycleCapability,
       name,
-      publicPath: join33(parent.path, name),
+      publicPath: join34(parent.path, name),
       create: false,
       mode: 448
     });
@@ -63412,17 +63558,17 @@ function rebindDescendants(directory) {
 function sendOperation(directory, request2, timeoutMs) {
   const sequence = ++directory.worker.sequence;
   const prefix = String(sequence).padStart(8, "0");
-  const pendingPath = join33(directory.worker.controlPath, `${prefix}.pending`);
-  const requestPath2 = join33(directory.worker.controlPath, `${prefix}.request`);
-  const responsePath = join33(directory.worker.controlPath, `${prefix}.response`);
-  writeFileSync13(pendingPath, JSON.stringify(request2), { flag: "wx", mode: 384 });
-  renameSync7(pendingPath, requestPath2);
+  const pendingPath = join34(directory.worker.controlPath, `${prefix}.pending`);
+  const requestPath2 = join34(directory.worker.controlPath, `${prefix}.request`);
+  const responsePath = join34(directory.worker.controlPath, `${prefix}.response`);
+  writeFileSync14(pendingPath, JSON.stringify(request2), { flag: "wx", mode: 384 });
+  renameSync8(pendingPath, requestPath2);
   if (!waitForFile(responsePath, timeoutMs)) {
     throw new Error("SESSION_INTEGRATION_WORKER_TIMEOUT");
   }
   let result;
   try {
-    result = JSON.parse(readFileSync25(responsePath, "utf8"));
+    result = JSON.parse(readFileSync26(responsePath, "utf8"));
   } catch {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: bound-directory operation returned invalid output");
   } finally {
@@ -63676,7 +63822,7 @@ function assertBoundDirectoryCurrent(directory) {
   runBoundOperation(directory, { operation: "identity" });
 }
 function openBoundSubdirectoryInternal(parent, name, options = {}) {
-  const controlPath = mkdtempSync2(join33(tmpdir10(), "rn-bound-directory-"));
+  const controlPath = mkdtempSync2(join34(tmpdir10(), "rn-bound-directory-"));
   const childId = randomUUID7();
   const lifecycleCapability = randomUUID7();
   let worker;
@@ -63688,7 +63834,7 @@ function openBoundSubdirectoryInternal(parent, name, options = {}) {
       controlPath,
       lifecycleCapability,
       name,
-      publicPath: join33(parent.path, name),
+      publicPath: join34(parent.path, name),
       create: options.create ?? false,
       mode: options.mode ?? 448,
       optional: options.optional ?? false,
@@ -63712,7 +63858,7 @@ function openBoundSubdirectoryInternal(parent, name, options = {}) {
       },
       name,
       parent,
-      path: join33(parent.path, name),
+      path: join34(parent.path, name),
       pendingCleanups: /* @__PURE__ */ new Map(),
       realPath: result.directoryIdentity.realPath,
       worker,
@@ -63846,15 +63992,15 @@ function retryBoundDirectoryCleanup(directory, obligation, dependencies = {}) {
 // packages/rn-dev-agent-core/dist/session/migration-diagnostic.js
 init_registry();
 function readPackageIntegrationManifest(appRoot, dependencies) {
-  const manifestPath = join34(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
+  const manifestPath = join35(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
   if (dependencies.exists || dependencies.readText) {
-    const exists = dependencies.exists ?? existsSync25;
+    const exists = dependencies.exists ?? existsSync26;
     if (!exists(manifestPath))
       return void 0;
-    const readText = dependencies.readText ?? ((path) => readFileSync26(path, "utf8"));
+    const readText = dependencies.readText ?? ((path) => readFileSync27(path, "utf8"));
     return readText(manifestPath);
   }
-  const agent = openBoundDirectory(join34(appRoot, ".rn-agent"));
+  const agent = openBoundDirectory(join35(appRoot, ".rn-agent"));
   let integration;
   let primaryError;
   try {
@@ -63872,7 +64018,7 @@ function readPackageIntegrationManifest(appRoot, dependencies) {
   }
 }
 function inspectAuthorityMigration(status, dependencies = {}) {
-  const exists = dependencies.exists ?? existsSync25;
+  const exists = dependencies.exists ?? existsSync26;
   const appRoot = typeof status.source.appRoot === "string" ? status.source.appRoot : "";
   let packageIntegrationInstalled = false;
   let onDiskManifestText;
@@ -63891,7 +64037,7 @@ function inspectAuthorityMigration(status, dependencies = {}) {
   const integrationBinding = status.bindings.packageIntegration;
   let bindingDiagnostic = null;
   if (integrationBinding) {
-    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash9("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
+    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash10("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
     const manifestAvailable = manifestVerified(onDiskManifestText) || manifestVerified(integrationBinding.restoration?.phase === "started" ? integrationBinding.restoration.manifestSource : void 0) || manifestVerified(integrationBinding.installation?.phase === "started" ? integrationBinding.installation.manifestSource : void 0) || manifestVerified(integrationBinding.manifestSource);
     const effectiveOwnerSessionId = status.sessionId;
     const trustedDigestRecorded = typeof integrationBinding.manifestSha256 === "string" && /^[0-9a-f]{64}$/.test(integrationBinding.manifestSha256);
@@ -64407,8 +64553,8 @@ function createBuildLaunchPlan(input) {
 
 // packages/rn-dev-agent-core/dist/session/managed-metro.js
 import { execFileSync as execFileSync10, spawn as spawn7 } from "node:child_process";
-import { createHash as createHash11, createHmac as createHmac2, timingSafeEqual as timingSafeEqual5 } from "node:crypto";
-import { closeSync as closeSync7, existsSync as existsSync27, fstatSync as fstatSync5, mkdirSync as mkdirSync17, openSync as openSync7, readFileSync as readFileSync28, readSync as readSync2, realpathSync as realpathSync11, rmSync as rmSync11 } from "node:fs";
+import { createHash as createHash12, createHmac as createHmac2, timingSafeEqual as timingSafeEqual5 } from "node:crypto";
+import { closeSync as closeSync7, existsSync as existsSync28, fstatSync as fstatSync5, mkdirSync as mkdirSync18, openSync as openSync7, readFileSync as readFileSync29, readSync as readSync2, realpathSync as realpathSync11, rmSync as rmSync11 } from "node:fs";
 init_metro_binding();
 init_trusted_system_executable();
 init_process_birth();
@@ -64505,13 +64651,13 @@ function canonicalAuthorityJson(value) {
 
 // packages/rn-dev-agent-core/dist/session/managed-metro-enforcement.js
 import { spawnSync as spawnSync2 } from "node:child_process";
-import { createHash as createHash10 } from "node:crypto";
-import { closeSync as closeSync6, constants as constants6, existsSync as existsSync26, mkdirSync as mkdirSync16, openSync as openSync6, readFileSync as readFileSync27, realpathSync as realpathSync10, rmSync as rmSync10, statSync as statSync12, symlinkSync as symlinkSync3, writeSync as writeSync2 } from "node:fs";
-import { dirname as dirname17, resolve as resolve10 } from "node:path";
+import { createHash as createHash11 } from "node:crypto";
+import { closeSync as closeSync6, constants as constants6, existsSync as existsSync27, mkdirSync as mkdirSync17, openSync as openSync6, readFileSync as readFileSync28, realpathSync as realpathSync10, rmSync as rmSync10, statSync as statSync12, symlinkSync as symlinkSync3, writeSync as writeSync2 } from "node:fs";
+import { dirname as dirname18, resolve as resolve10 } from "node:path";
 var DARWIN_SANDBOX_EXECUTABLE = "/usr/bin/sandbox-exec";
 var DARWIN_CODESIGN_EXECUTABLE = "/usr/bin/codesign";
 function sha256(value) {
-  return createHash10("sha256").update(value).digest("hex");
+  return createHash11("sha256").update(value).digest("hex");
 }
 function defaultRun2(command, args) {
   const result = spawnSync2(command, [...args], {
@@ -64530,10 +64676,10 @@ function field(details, name) {
   return details.split("\n").find((line) => line.startsWith(prefix))?.slice(prefix.length).trim() ?? null;
 }
 function verifiedSandboxExecutable(dependencies) {
-  const exists = dependencies.exists ?? existsSync26;
+  const exists = dependencies.exists ?? existsSync27;
   const canonicalize = dependencies.canonicalize ?? realpathSync10;
   const stat2 = dependencies.stat ?? statSync12;
-  const readBytes = dependencies.readBytes ?? readFileSync27;
+  const readBytes = dependencies.readBytes ?? readFileSync28;
   const run = dependencies.run ?? defaultRun2;
   try {
     if (!exists(DARWIN_SANDBOX_EXECUTABLE))
@@ -64607,7 +64753,7 @@ function defaultRuntimeCache(exists) {
 function attestRuntimeFile(path, dependencies) {
   const canonicalize = dependencies.canonicalize ?? realpathSync10;
   const stat2 = dependencies.stat ?? statSync12;
-  const readBytes = dependencies.readBytes ?? readFileSync27;
+  const readBytes = dependencies.readBytes ?? readFileSync28;
   const run = dependencies.run ?? defaultRun2;
   const canonical2 = canonicalize(path);
   if (!stat2(canonical2).isFile())
@@ -64620,7 +64766,7 @@ function attestRuntimeFile(path, dependencies) {
 }
 function attestNodeRuntime(input, executableMappings, dependencies) {
   const run = dependencies.run ?? defaultRun2;
-  const exists = dependencies.exists ?? existsSync26;
+  const exists = dependencies.exists ?? existsSync27;
   const runtimeVersion = dependencies.runtimeVersion?.(input.nodeExecutable) ?? defaultRuntimeVersion(input.nodeExecutable, run);
   if (runtimeVersion !== input.nodeVersion)
     return null;
@@ -66080,7 +66226,7 @@ function inspectManagedMetroLifecycle(binding, input, dependencies = {}) {
       reason: "allocated managed Metro port is owned by a different process"
     };
   }
-  if (!(dependencies.exists ?? existsSync27)(binding.runtimeEvidenceSocket)) {
+  if (!(dependencies.exists ?? existsSync28)(binding.runtimeEvidenceSocket)) {
     return {
       status: "lost",
       code: "METRO_EVIDENCE_SOCKET_MISSING",
@@ -66178,7 +66324,7 @@ function inspectManagedMetroCleanupEvidence(binding, dependencies = {}) {
     } catch {
     }
   }
-  const evidenceSocket = managed ? cleanupSocketPresence(binding.runtimeEvidenceSocket, dependencies.exists ?? existsSync27) : "not-applicable";
+  const evidenceSocket = managed ? cleanupSocketPresence(binding.runtimeEvidenceSocket, dependencies.exists ?? existsSync28) : "not-applicable";
   const complete = launcher !== "present" && launcher !== "unknown" && listener === "absent" && port.status === "absent" && evidenceSocket !== "present" && evidenceSocket !== "unknown";
   return { complete, launcher, listener, port, evidenceSocket };
 }
@@ -66315,8 +66461,8 @@ async function stopManagedMetroWithEvidence(binding, input, dependencies = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/session/package-integration.js
-import { closeSync as closeSync8, constants as constants7, fstatSync as fstatSync6, lstatSync as lstatSync14, openSync as openSync8, readFileSync as readFileSync29 } from "node:fs";
-import { basename as basename10, isAbsolute as isAbsolute7, join as join35, relative as relative6, resolve as resolve11, sep as sep8 } from "node:path";
+import { closeSync as closeSync8, constants as constants7, fstatSync as fstatSync6, lstatSync as lstatSync14, openSync as openSync8, readFileSync as readFileSync30 } from "node:fs";
+import { basename as basename10, isAbsolute as isAbsolute7, join as join36, relative as relative6, resolve as resolve11, sep as sep8 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/metro-authority.js
 import { createHmac as createHmac3, createSecretKey, timingSafeEqual as timingSafeEqual6 } from "node:crypto";
@@ -70074,7 +70220,7 @@ function managedMetroProxyUrl(binding) {
 function snapshotBoundFiles(directory, directoryPath, names) {
   return readBoundDirectoryFiles(directory, names).map((snapshot) => ({
     ...snapshot,
-    path: join35(directoryPath, snapshot.name)
+    path: join36(directoryPath, snapshot.name)
   }));
 }
 function casReplaceBoundBatch(directory, writes, dependencies = {}) {
@@ -70099,7 +70245,7 @@ function assertNoSymlinkPath(root, candidate) {
   }
   let current = root;
   for (const component of [root, ...child.split(sep8).filter(Boolean)]) {
-    current = component === root ? root : join35(current, component);
+    current = component === root ? root : join36(current, component);
     try {
       if (lstatSync14(current).isSymbolicLink()) {
         throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: integration path is symlinked");
@@ -70128,7 +70274,7 @@ function readRegularFile(root, candidate) {
     if (!opened.isFile() || before.dev !== opened.dev || before.ino !== opened.ino || after.dev !== opened.dev || after.ino !== opened.ino) {
       throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: integration input changed while opening");
     }
-    return readFileSync29(descriptor, "utf8");
+    return readFileSync30(descriptor, "utf8");
   } finally {
     closeSync8(descriptor);
   }
@@ -70174,7 +70320,7 @@ function readPackageIntegrationInputs(appRootInput, dependencies = {}) {
       packageJson: packageSnapshot.contents.toString("utf8"),
       metroConfig: {
         contents: metroSnapshot.contents.toString("utf8"),
-        path: join35(appRoot, metroSnapshot.name)
+        path: join36(appRoot, metroSnapshot.name)
       },
       ...manifest ? { manifest: manifest.toString("utf8") } : {}
     };
@@ -70309,9 +70455,9 @@ function rollbackWrites(writes, dependencies) {
 }
 function applyPackageIntegration(input, dependencies = {}) {
   const appRoot = resolve11(input.appRoot);
-  const packagePath = join35(appRoot, "package.json");
+  const packagePath = join36(appRoot, "package.json");
   let metroConfigPath;
-  for (const path of ["metro.config.js", "metro.config.cjs"].map((name) => join35(appRoot, name))) {
+  for (const path of ["metro.config.js", "metro.config.cjs"].map((name) => join36(appRoot, name))) {
     if (readOptionalRegularFileNoFollow(appRoot, path) !== void 0) {
       metroConfigPath = path;
       break;
@@ -70444,7 +70590,7 @@ function applyPackageIntegration(input, dependencies = {}) {
 }
 function restorePackageIntegrationFiles(input, dependencies = {}) {
   const appRoot = resolve11(input.appRoot);
-  const packagePath = join35(appRoot, "package.json");
+  const packagePath = join36(appRoot, "package.json");
   const directories = openIntegrationDirectories(appRoot);
   const generatedNames = [
     "rn-session-integration.json",
@@ -70472,7 +70618,7 @@ function restorePackageIntegrationFiles(input, dependencies = {}) {
     if (metroConfig !== "metro.config.js" && metroConfig !== "metro.config.cjs") {
       throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: manifest Metro config is not an expected app-root config");
     }
-    const metroConfigPath = join35(appRoot, metroConfig);
+    const metroConfigPath = join36(appRoot, metroConfig);
     const [packageSnapshot, metroSnapshot] = snapshotBoundFiles(directories.app, appRoot, [
       basename10(packagePath),
       basename10(metroConfigPath)
@@ -70546,19 +70692,19 @@ function restorePackageIntegrationFiles(input, dependencies = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/session.js
-import { dirname as dirname19, isAbsolute as isAbsolute9, join as join39, resolve as resolve14 } from "node:path";
+import { dirname as dirname20, isAbsolute as isAbsolute9, join as join40, resolve as resolve14 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { createHash as createHash14 } from "node:crypto";
+import { createHash as createHash15 } from "node:crypto";
 
 // packages/rn-dev-agent-core/dist/session/source-identity.js
 init_metro_cwd();
-import { createHash as createHash12, createHmac as createHmac4, randomBytes as randomBytes6, timingSafeEqual as timingSafeEqual7 } from "node:crypto";
+import { createHash as createHash13, createHmac as createHmac4, randomBytes as randomBytes6, timingSafeEqual as timingSafeEqual7 } from "node:crypto";
 import { execFileSync as execFileSync11 } from "node:child_process";
-import { closeSync as closeSync9, constants as constants8, existsSync as existsSync28, fstatSync as fstatSync7, lstatSync as lstatSync15, openSync as openSync9, readdirSync as readdirSync11, readFileSync as readFileSync30, readlinkSync as readlinkSync5, readSync as readSync3, realpathSync as realpathSync12 } from "node:fs";
-import { dirname as dirname18, isAbsolute as isAbsolute8, join as join36, relative as relative7, resolve as resolve12 } from "node:path";
+import { closeSync as closeSync9, constants as constants8, existsSync as existsSync29, fstatSync as fstatSync7, lstatSync as lstatSync15, openSync as openSync9, readdirSync as readdirSync12, readFileSync as readFileSync31, readlinkSync as readlinkSync5, readSync as readSync3, realpathSync as realpathSync12 } from "node:fs";
+import { dirname as dirname19, isAbsolute as isAbsolute8, join as join37, relative as relative7, resolve as resolve12 } from "node:path";
 init_declared_source_contract();
 function digest2(parts) {
-  const hash = createHash12("sha256");
+  const hash = createHash13("sha256");
   for (const part of parts) {
     hash.update(part);
     hash.update("\0");
@@ -70665,7 +70811,7 @@ function updateFramedFile(hash, path, maximumBytes) {
   return updateStableFile(hash, path, maximumBytes, true);
 }
 function fileDigest(path) {
-  const hash = createHash12("sha256");
+  const hash = createHash13("sha256");
   updateStableFile(hash, path, MAX_STRICT_PROOF_DEPENDENCY_FILE_BYTES, false);
   return hash.digest("hex");
 }
@@ -70709,9 +70855,9 @@ function updateDependencyPath(hash, path, label, state) {
       }
       state.visitedDirectories.add(canonical2);
       updateFramed(hash, "directory");
-      for (const entry of readdirSync11(current.path).sort().reverse()) {
+      for (const entry of readdirSync12(current.path).sort().reverse()) {
         pending2.push({
-          path: join36(current.path, entry),
+          path: join37(current.path, entry),
           label: `${current.label}/${entry}`,
           depth: current.depth + 1
         });
@@ -70741,10 +70887,10 @@ function isExcludedRuntimePath(root, candidate) {
   return EXCLUDED_RUNTIME_DIRECTORIES.some((excluded) => entry === excluded || entry.startsWith(`${excluded}/`) || entry.endsWith(`/${excluded}`) || entry.includes(`/${excluded}/`));
 }
 function assertFinalMetroIntegration(identity2) {
-  const candidates = ["metro.config.js", "metro.config.cjs"].map((entry) => join36(identity2.appRoot, entry)).filter(existsSync28);
+  const candidates = ["metro.config.js", "metro.config.cjs"].map((entry) => join37(identity2.appRoot, entry)).filter(existsSync29);
   if (candidates.length === 0)
     return;
-  const source = readFileSync30(candidates[0], "utf8");
+  const source = readFileSync31(candidates[0], "utf8");
   const start = source.indexOf(METRO_INTEGRATION_START);
   const end = source.indexOf(METRO_INTEGRATION_END);
   if (start < 0 || end < start || source.indexOf(METRO_INTEGRATION_START, start + METRO_INTEGRATION_START.length) >= 0 || source.indexOf(METRO_INTEGRATION_END, end + METRO_INTEGRATION_END.length) >= 0 || source.slice(start, end + METRO_INTEGRATION_END.length) !== METRO_INTEGRATION_BLOCK || source.slice(end + METRO_INTEGRATION_END.length).trim()) {
@@ -70754,7 +70900,7 @@ function assertFinalMetroIntegration(identity2) {
 function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntimeEnforcement) {
   if (!authority)
     return { paths: [], semantics: [] };
-  const raw = readFileSync30(join36(identity2.appRoot, METRO_RUNTIME_POLICY2), "utf8");
+  const raw = readFileSync31(join37(identity2.appRoot, METRO_RUNTIME_POLICY2), "utf8");
   const receipt2 = JSON.parse(raw);
   const payload = {
     version: receipt2.version,
@@ -70787,7 +70933,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
     platform: process.platform,
     appRoot: identity2.appRoot,
     sourceRoot: identity2.contentRoot,
-    runtimeRoot: dirname18(authority.evidencePath),
+    runtimeRoot: dirname19(authority.evidencePath),
     nodeExecutable: runtimeManifest.nodeExecutable,
     nodeVersion: runtimeManifest.nodeVersion,
     commandExecutable: runtimeManifest.executable,
@@ -70816,7 +70962,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
     if (!runtimeLoadsStat.isFile() || runtimeLoadsStat.size > MAX_STRICT_PROOF_FILE_BYTES) {
       throw new Error("runtime load evidence is not a bounded regular file");
     }
-    runtimeLoadsRaw = readFileSync30(runtimeLoadsPath, "utf8");
+    runtimeLoadsRaw = readFileSync31(runtimeLoadsPath, "utf8");
   } catch (error2) {
     throw new Error("STRICT_PROOF_UNVERIFIED_METRO_POLICY: runtime load evidence is invalid", {
       cause: error2
@@ -70895,7 +71041,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
         throw new Error("STRICT_PROOF_UNVERIFIED_METRO_POLICY: runtime semantics are unbounded");
       }
       runtimeSemantics.add(load.value);
-      runtimeSemanticsByDigest.set(createHash12("sha256").update(load.value).digest("hex"), load.value);
+      runtimeSemanticsByDigest.set(createHash13("sha256").update(load.value).digest("hex"), load.value);
       orderedRuntimeSemantics.push(load.value);
       continue;
     }
@@ -71045,8 +71191,8 @@ function dependencyStoreRoots(identity2, git2, pathExists) {
     ...DEPENDENCY_STORE_PATHS
   ]).split("\0").filter(Boolean);
   for (const candidate of [
-    join36(identity2.contentRoot, "node_modules"),
-    join36(identity2.appRoot, "node_modules")
+    join37(identity2.contentRoot, "node_modules"),
+    join37(identity2.appRoot, "node_modules")
   ]) {
     if (pathExists(candidate))
       entries.push(relative7(identity2.contentRoot, candidate));
@@ -71057,21 +71203,21 @@ function dependencyStoreRoots(identity2, git2, pathExists) {
     pnpRoots.push(pnpRoot);
     if (pnpRoot === identity2.contentRoot)
       break;
-    const parent = dirname18(pnpRoot);
+    const parent = dirname19(pnpRoot);
     if (parent === pnpRoot || !isContained(identity2.contentRoot, parent))
       break;
     pnpRoot = parent;
   }
-  const pnpLoaders = [...new Set(pnpRoots)].flatMap((root) => [".pnp.js", ".pnp.cjs", ".pnp.loader.mjs"].map((entry) => join36(root, entry)).filter(pathExists));
+  const pnpLoaders = [...new Set(pnpRoots)].flatMap((root) => [".pnp.js", ".pnp.cjs", ".pnp.loader.mjs"].map((entry) => join37(root, entry)).filter(pathExists));
   if (pnpLoaders.length > 0) {
     throw new Error("STRICT_PROOF_UNVERIFIED_DEPENDENCY_LAYOUT: Plug\u2019n\u2019Play dependency resolution is unsupported");
   }
-  let ancestor = dirname18(identity2.contentRoot);
+  let ancestor = dirname19(identity2.contentRoot);
   while (true) {
-    if (pathExists(join36(ancestor, "node_modules"))) {
+    if (pathExists(join37(ancestor, "node_modules"))) {
       throw new Error("STRICT_PROOF_UNVERIFIED_DEPENDENCY_LAYOUT: ancestor node_modules resolves outside the content root");
     }
-    const parent = dirname18(ancestor);
+    const parent = dirname19(ancestor);
     if (parent === ancestor)
       break;
     ancestor = parent;
@@ -71123,7 +71269,7 @@ function resolveDeclaredIdentity(appRoot, dependencies, canonicalize) {
   if (!dependencies.declaredManifests?.length) {
     throw new Error(missingDeclaredManifestListMessage());
   }
-  const pathExists = dependencies.exists ?? existsSync28;
+  const pathExists = dependencies.exists ?? existsSync29;
   const contentRoot = canonicalize(resolve12(dependencies.declaredRoot));
   assertContained(contentRoot, appRoot, "NON_GIT_ROOT_MISMATCH");
   const manifestParts = [];
@@ -71133,7 +71279,7 @@ function resolveDeclaredIdentity(appRoot, dependencies, canonicalize) {
       throw new Error(missingDeclaredManifestMessage(entry));
     const manifest = canonicalize(declared);
     assertContained(contentRoot, manifest, "NON_GIT_MANIFEST_OUTSIDE_ROOT");
-    manifestParts.push(relative7(contentRoot, manifest), readFileSync30(manifest));
+    manifestParts.push(relative7(contentRoot, manifest), readFileSync31(manifest));
   }
   const manifestDigest = digest2(manifestParts);
   const appRelative = relative7(contentRoot, appRoot) || ".";
@@ -71156,7 +71302,7 @@ function resolveSourceIdentity(inputRoot, dependencies = {}) {
     const contentRoot = canonicalize(git2(appRoot, ["rev-parse", "--show-toplevel"]));
     assertContained(contentRoot, appRoot, "APP_ROOT_OUTSIDE_WORKTREE");
     const commonRaw = git2(appRoot, ["rev-parse", "--git-common-dir"]);
-    const commonDirectory = canonicalize(isAbsolute8(commonRaw) ? commonRaw : join36(appRoot, commonRaw));
+    const commonDirectory = canonicalize(isAbsolute8(commonRaw) ? commonRaw : join37(appRoot, commonRaw));
     const head = git2(appRoot, ["rev-parse", "HEAD"]);
     const appRelative = relative7(contentRoot, appRoot) || ".";
     return {
@@ -71182,7 +71328,7 @@ function strictProofSourceIdentity(identity2, dependencies = {}) {
     throw new Error("STRICT_PROOF_GIT_REQUIRED: accepted strict proof requires a Git worktree");
   }
   const git2 = dependencies.git ?? defaultGit;
-  const pathExists = dependencies.exists ?? existsSync28;
+  const pathExists = dependencies.exists ?? existsSync29;
   assertFinalMetroIntegration(identity2);
   const evidenceHeadReader = dependencies.readMetroEvidenceHead ?? readMetroEvidenceHead;
   const runtimeEnforcementVerifier = dependencies.verifyMetroRuntimeEnforcement ?? verifyManagedMetroEnforcementReceipt;
@@ -71216,7 +71362,7 @@ function strictProofSourceIdentity(identity2, dependencies = {}) {
       throw new Error(`STRICT_PROOF_DIRTY_SUBMODULE: ${entry} contains source changes outside the parent digest`);
     }
   }
-  const dirtyHash = createHash12("sha256");
+  const dirtyHash = createHash13("sha256");
   updateFramed(dirtyHash, "git-dirty-v3");
   updateFramed(dirtyHash, diff);
   for (const semantics of runtimeInputs.semantics) {
@@ -71288,10 +71434,10 @@ function strictProofSourceIdentity(identity2, dependencies = {}) {
 
 // packages/rn-dev-agent-core/dist/session/successor-source.js
 init_secure_state_file();
-import { join as join37, resolve as resolve13 } from "node:path";
+import { join as join38, resolve as resolve13 } from "node:path";
 var DECLARATION_FILE = "successor-source.json";
 function successorSourceDeclarationPath(runtimeRoot) {
-  return join37(runtimeRoot, DECLARATION_FILE);
+  return join38(runtimeRoot, DECLARATION_FILE);
 }
 function writeSuccessorSourceDeclaration(runtimeRoot, declaration) {
   writeJsonStateFileAtomic(successorSourceDeclarationPath(runtimeRoot), declaration);
@@ -71331,8 +71477,8 @@ function inspectSessionOwner(owner, dependencies = {}) {
 
 // packages/rn-dev-agent-core/dist/session/startup-cleanup.js
 init_secure_state_file();
-import { createHash as createHash13 } from "node:crypto";
-import { join as join38 } from "node:path";
+import { createHash as createHash14 } from "node:crypto";
+import { join as join39 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/android-metro-reverse.js
 import { execFileSync as execFileSync12 } from "node:child_process";
@@ -71856,7 +72002,7 @@ async function runStartupCleanupForSource(input) {
       appRootKey: input.source.appRootKey,
       appRoot: input.source.appRoot
     }, {
-      readSessionSecret: (sessionId) => readJsonStateFile(join38(layout.sessions, sessionId, "secret.json"))
+      readSessionSecret: (sessionId) => readJsonStateFile(join39(layout.sessions, sessionId, "secret.json"))
     });
   } finally {
     registry2.close();
@@ -71915,7 +72061,7 @@ function restoreDeadOwnerIntegration(input, prior, plan, dependencies) {
 function verifiedDeadOwnerManifestSource(appRoot, binding, manifestSha256) {
   if (!/^[0-9a-f]{64}$/.test(manifestSha256))
     return void 0;
-  const verified = (candidate) => typeof candidate === "string" && createHash13("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
+  const verified = (candidate) => typeof candidate === "string" && createHash14("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
   let liveManifest;
   try {
     liveManifest = readPackageIntegrationInputs(appRoot).manifest ?? void 0;
@@ -72021,7 +72167,7 @@ function sameMetroAuthority(current, next) {
 function verifiedManifestSource(candidate, manifestSha256) {
   if (typeof candidate !== "string" || typeof manifestSha256 !== "string")
     return void 0;
-  return createHash14("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
+  return createHash15("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
 }
 function durableBindingManifestSource(binding) {
   return verifiedManifestSource(binding?.manifestSource, binding?.manifestSha256);
@@ -72935,9 +73081,9 @@ function createSessionHandler(runtime, dependencies = {}) {
         if (input.action !== "restore_integration") {
           assertDeclaredProjectRootMatches(status, input.projectRoot, sessionSourceResolver(status, dependencies));
         }
-        const packagePath = join39(appRoot, "package.json");
+        const packagePath = join40(appRoot, "package.json");
         const integrationInputs = readPackageIntegrationInputs(appRoot);
-        const manifestPath = join39(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
+        const manifestPath = join40(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
         const packageJson = JSON.parse(integrationInputs.packageJson);
         const integrationBinding = status.bindings.packageIntegration;
         const installationManifestSource = integrationBinding?.installation?.phase === "started" && typeof integrationBinding.installation.manifestSource === "string" ? integrationBinding.installation.manifestSource : void 0;
@@ -72950,7 +73096,7 @@ function createSessionHandler(runtime, dependencies = {}) {
           if (!(error2 instanceof SyntaxError))
             throw error2;
         }
-        const sessionCli = process.env.RN_DEV_AGENT_SESSION_CLI ?? join39(dirname19(fileURLToPath2(import.meta.url)), "..", "rn-session.js");
+        const sessionCli = process.env.RN_DEV_AGENT_SESSION_CLI ?? join40(dirname20(fileURLToPath2(import.meta.url)), "..", "rn-session.js");
         const stateDir = process.env.RN_DEV_AGENT_STATE_DIR;
         if (input.action === "restore_integration") {
           if (input.confirmed !== true) {
@@ -72967,7 +73113,7 @@ function createSessionHandler(runtime, dependencies = {}) {
             });
           }
           assertPackageIntegrationInactive(status.bindings, input.action);
-          const manifestSha256 = createHash14("sha256").update(manifestSource ?? "").digest("hex");
+          const manifestSha256 = createHash15("sha256").update(manifestSource ?? "").digest("hex");
           if (integrationBinding?.version !== 1 || typeof integrationBinding.installedBySessionId !== "string" || integrationBinding.manifestSha256 !== manifestSha256) {
             throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "integration restoration requires the transferred manifest authority binding");
           }
@@ -73014,7 +73160,7 @@ function createSessionHandler(runtime, dependencies = {}) {
         }
         preview.manifest.metroConfig = metroConfigPath.slice(appRoot.length + 1);
         const expectedManifestSource = installationManifestSource ?? serializePackageIntegrationManifest(preview.manifest);
-        const expectedManifestSha256 = createHash14("sha256").update(expectedManifestSource).digest("hex");
+        const expectedManifestSha256 = createHash15("sha256").update(expectedManifestSource).digest("hex");
         if (installationManifestSource && (integrationBinding?.version !== 1 || integrationBinding.installedBySessionId !== session2.sessionId || integrationBinding.manifestSha256 !== expectedManifestSha256)) {
           throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "integration installation requires the original session manifest authority binding");
         }
@@ -73036,7 +73182,7 @@ function createSessionHandler(runtime, dependencies = {}) {
           if (!installedManifest) {
             throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: applied manifest is unavailable");
           }
-          if (createHash14("sha256").update(installedManifest).digest("hex") !== expectedManifestSha256) {
+          if (createHash15("sha256").update(installedManifest).digest("hex") !== expectedManifestSha256) {
             throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "applied integration manifest no longer matches its durable installation authority");
           }
           registry2.updateBindings(session2, {
@@ -74526,10 +74672,10 @@ init_keyboard_guard();
 // packages/rn-dev-agent-core/dist/tools/device-list.js
 init_agent_device_wrapper();
 init_utils();
-import { mkdirSync as mkdirSync18 } from "node:fs";
+import { mkdirSync as mkdirSync19 } from "node:fs";
 import { execFile as execFile17 } from "node:child_process";
 import { promisify as promisify18 } from "node:util";
-import { dirname as dirname20, join as join40, resolve as resolve15 } from "node:path";
+import { dirname as dirname21, join as join41, resolve as resolve15 } from "node:path";
 import { homedir as homedir8 } from "node:os";
 
 // packages/rn-dev-agent-core/dist/tools/device-screenshot-resize.js
@@ -75137,7 +75283,7 @@ function deriveScreenshotPath(args, now = Date.now, rand = Math.random) {
   }
   if (args.path?.startsWith("~")) {
     if (args.path.startsWith("~/"))
-      return join40(homedir8(), args.path.slice(2));
+      return join41(homedir8(), args.path.slice(2));
     throw new TildeScreenshotPathError(`Screenshot path "${args.path}" starts with '~' which the bridge cannot expand (only a leading '~/' is expanded to the home directory). Pass an absolute path instead.`);
   }
   if (args.path)
@@ -75148,7 +75294,7 @@ function deriveScreenshotPath(args, now = Date.now, rand = Math.random) {
 }
 function ensureScreenshotDir(path) {
   try {
-    mkdirSync18(dirname20(path), { recursive: true });
+    mkdirSync19(dirname21(path), { recursive: true });
     return { ok: true };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
@@ -76535,7 +76681,7 @@ init_utils();
 init_storage();
 init_runtime_paths2();
 import { mkdir, readdir, readFile as readFile2, writeFile } from "node:fs/promises";
-import { join as join41 } from "node:path";
+import { join as join42 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/cdp/test-recorder-helpers.js
 var DEV_CHECK_JS = `(typeof __DEV__ !== 'undefined' && __DEV__ === true)`;
@@ -77484,7 +77630,7 @@ function createRecordTestSaveHandler(getClient2) {
     if (!safe) {
       return failResult("Filename is empty after sanitization", "BAD_FILENAME");
     }
-    const filePath = join41(dir, `${safe}.json`);
+    const filePath = join42(dir, `${safe}.json`);
     const payload = { savedAt: (/* @__PURE__ */ new Date()).toISOString(), events: storedEvents };
     await writeFile(filePath, JSON.stringify(payload, null, 2), "utf8");
     return okResult({
@@ -77505,7 +77651,7 @@ function createRecordTestLoadHandler(getClient2) {
     if (!safe) {
       return failResult("Filename is empty after sanitization", "BAD_FILENAME");
     }
-    const filePath = join41(dir, `${safe}.json`);
+    const filePath = join42(dir, `${safe}.json`);
     let raw;
     try {
       raw = await readFile2(filePath, "utf8");
@@ -81440,11 +81586,11 @@ init_utils();
 init_path_safety();
 init_process_birth();
 import { execFile as execFile22 } from "node:child_process";
-import { createHash as createHash15 } from "node:crypto";
-import { existsSync as existsSync29 } from "node:fs";
+import { createHash as createHash16 } from "node:crypto";
+import { existsSync as existsSync30 } from "node:fs";
 import { promisify as promisify23 } from "node:util";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
-import { dirname as dirname21, join as join42 } from "node:path";
+import { dirname as dirname22, join as join43 } from "node:path";
 var execFileAsync5 = promisify23(execFile22);
 var START_TIMEOUT_MS = 1e4;
 var STATUS_TIMEOUT_MS = 5e3;
@@ -81527,28 +81673,28 @@ function compactUnique2(paths) {
   }
   return out;
 }
-function candidateRecordScripts(baseDir = dirname21(fileURLToPath3(import.meta.url))) {
+function candidateRecordScripts(baseDir = dirname22(fileURLToPath3(import.meta.url))) {
   const codexPluginRoot = process.env.RN_DEV_AGENT_CODEX_PLUGIN_ROOT;
   const claudePluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
   return compactUnique2([
     process.env.RN_DEV_AGENT_RECORD_PROOF_SCRIPT,
-    codexPluginRoot ? join42(codexPluginRoot, "scripts", "record_proof.sh") : void 0,
-    claudePluginRoot ? join42(claudePluginRoot, "scripts", "record_proof.sh") : void 0,
-    claudePluginRoot ? join42(claudePluginRoot, "..", "..", "scripts", "record_proof.sh") : void 0,
+    codexPluginRoot ? join43(codexPluginRoot, "scripts", "record_proof.sh") : void 0,
+    claudePluginRoot ? join43(claudePluginRoot, "scripts", "record_proof.sh") : void 0,
+    claudePluginRoot ? join43(claudePluginRoot, "..", "..", "scripts", "record_proof.sh") : void 0,
     // Bundled Codex runtime: <plugin>/rn-dev-agent-core/dist.
-    join42(baseDir, "..", "..", "scripts", "record_proof.sh"),
+    join43(baseDir, "..", "..", "scripts", "record_proof.sh"),
     // Source core bundle: packages/rn-dev-agent-core/dist/supervisor.js.
-    join42(baseDir, "..", "..", "..", "scripts", "record_proof.sh"),
+    join43(baseDir, "..", "..", "..", "scripts", "record_proof.sh"),
     // Source module build: packages/rn-dev-agent-core/dist/tools/device-record.js.
-    join42(baseDir, "..", "..", "..", "..", "scripts", "record_proof.sh")
+    join43(baseDir, "..", "..", "..", "..", "scripts", "record_proof.sh")
   ]);
 }
-function resolveRecordScript(baseDir = dirname21(fileURLToPath3(import.meta.url))) {
+function resolveRecordScript(baseDir = dirname22(fileURLToPath3(import.meta.url))) {
   if (process.env.RN_DEV_AGENT_RECORD_PROOF_SCRIPT) {
     return process.env.RN_DEV_AGENT_RECORD_PROOF_SCRIPT;
   }
   const candidates = candidateRecordScripts(baseDir);
-  return candidates.find((path) => existsSync29(path)) ?? candidates[0];
+  return candidates.find((path) => existsSync30(path)) ?? candidates[0];
 }
 function getRecordScript() {
   return resolveRecordScript();
@@ -81592,7 +81738,7 @@ function parseStatusOutput(stdout) {
   return active;
 }
 function recordingScope(args) {
-  return createHash15("sha256").update(`${args.sessionId}\0${args.claimEpoch}\0${args.platform}\0${args.deviceId}`).digest("hex");
+  return createHash16("sha256").update(`${args.sessionId}\0${args.claimEpoch}\0${args.platform}\0${args.deviceId}`).digest("hex");
 }
 function bindRecorderSession(runtime, args) {
   const available = runtime.requireAvailable();
@@ -81861,15 +82007,15 @@ function createDeviceRecordHandler(deps = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
-import { createHash as createHash17, randomUUID as randomUUID9 } from "node:crypto";
+import { createHash as createHash18, randomUUID as randomUUID9 } from "node:crypto";
 import { execFileSync as execFileSync14 } from "node:child_process";
-import { chmodSync as chmodSync7, closeSync as closeSync11, existsSync as existsSync30, fsyncSync, lstatSync as lstatSync16, mkdirSync as mkdirSync19, openSync as openSync11, readFileSync as readFileSync31, realpathSync as realpathSync13, renameSync as renameSync8, unlinkSync as unlinkSync14, writeFileSync as writeFileSync14 } from "node:fs";
-import { basename as basename11, dirname as dirname22, extname, isAbsolute as isAbsolute11, join as join43, relative as relative8, resolve as resolve16, sep as sep9 } from "node:path";
+import { chmodSync as chmodSync7, closeSync as closeSync11, existsSync as existsSync31, fsyncSync, lstatSync as lstatSync16, mkdirSync as mkdirSync20, openSync as openSync11, readFileSync as readFileSync32, realpathSync as realpathSync13, renameSync as renameSync9, unlinkSync as unlinkSync14, writeFileSync as writeFileSync15 } from "node:fs";
+import { basename as basename11, dirname as dirname23, extname, isAbsolute as isAbsolute11, join as join44, relative as relative8, resolve as resolve16, sep as sep9 } from "node:path";
 import { fileURLToPath as fileURLToPath4 } from "node:url";
 init_action_store();
 
 // packages/rn-dev-agent-core/dist/domain/proof-capture.js
-import { createHash as createHash16 } from "node:crypto";
+import { createHash as createHash17 } from "node:crypto";
 var StrictProofMonitor = class {
   now;
   events = [];
@@ -81943,14 +82089,14 @@ function hashProofArgs(params) {
   return hashProofValue(redact(params));
 }
 function hashProofValue(value) {
-  return createHash16("sha256").update(JSON.stringify(canonicalizeProofValue(value))).digest("hex");
+  return createHash17("sha256").update(JSON.stringify(canonicalizeProofValue(value))).digest("hex");
 }
 function proofRuntimeAuthorityMarker(input) {
   return hashProofValue(input);
 }
 function hashObservedValue(value) {
   const bytes = JSON.stringify(value) ?? String(value);
-  return createHash16("sha256").update(bytes).digest("hex");
+  return createHash17("sha256").update(bytes).digest("hex");
 }
 function resultEnvelope(result) {
   if (!result || typeof result !== "object")
@@ -82512,7 +82658,7 @@ var readinessSchema = external_exports.object({
   runtime: proofRuntimeSchema
 }).strict();
 function hashBytes(bytes) {
-  return createHash17("sha256").update(bytes).digest("hex");
+  return createHash18("sha256").update(bytes).digest("hex");
 }
 function captureProofWorkerStartup(argv = process.argv, attestation = readStartupIntegrityAttestation()) {
   let executedEntrypointPath = null;
@@ -82566,9 +82712,9 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
     return null;
   }
   for (const host of ["claude-plugin", "codex-plugin"]) {
-    const hostRoot = join43(root, "packages", host);
-    const coreIndex = realpathOrSelf(join43(hostRoot, "rn-dev-agent-core", "dist", "index.js"));
-    const coreSupervisor = realpathOrSelf(join43(hostRoot, "rn-dev-agent-core", "dist", "supervisor.js"));
+    const hostRoot = join44(root, "packages", host);
+    const coreIndex = realpathOrSelf(join44(hostRoot, "rn-dev-agent-core", "dist", "index.js"));
+    const coreSupervisor = realpathOrSelf(join44(hostRoot, "rn-dev-agent-core", "dist", "supervisor.js"));
     if (arg === coreIndex) {
       return {
         host,
@@ -82587,8 +82733,8 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
         kind: "core-supervisor"
       };
     }
-    if (host === "codex-plugin" && arg === realpathOrSelf(join43(hostRoot, "bin", "cdp-supervisor.js"))) {
-      if (!existsSync30(coreIndex) || !existsSync30(coreSupervisor))
+    if (host === "codex-plugin" && arg === realpathOrSelf(join44(hostRoot, "bin", "cdp-supervisor.js"))) {
+      if (!existsSync31(coreIndex) || !existsSync31(coreSupervisor))
         return null;
       return {
         host,
@@ -82622,7 +82768,7 @@ function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
   }
   if (supervisorOverride && supervisorOverride !== entrypoint.coreSupervisor)
     return false;
-  if (coreRootOverride && join43(coreRootOverride, "dist", "supervisor.js") !== entrypoint.coreSupervisor) {
+  if (coreRootOverride && join44(coreRootOverride, "dist", "supervisor.js") !== entrypoint.coreSupervisor) {
     return false;
   }
   if (workerOverride && workerOverride !== entrypoint.coreBundle)
@@ -82653,7 +82799,7 @@ function readProofCandidateHeadArtifacts(candidateRoot, artifactPaths) {
       const headBytes = execFileSync14("git", ["-C", root, "show", `HEAD:${artifactRelativePath}`], {
         maxBuffer: 128 * 1024 * 1024
       });
-      const artifactBytes = readFileSync31(resolvedArtifactPath);
+      const artifactBytes = readFileSync32(resolvedArtifactPath);
       if (hashBytes(artifactBytes) !== hashBytes(headBytes))
         return null;
       verifiedBytes.push(artifactBytes);
@@ -82680,7 +82826,7 @@ function readProofCandidateRuntime(candidateRoot, startup = proofWorkerStartup) 
     throw new Error("CANDIDATE_MCP_PROCESS_MISMATCH");
   }
   const { host, coreBundle } = entrypoint;
-  const runnerManifest = join43(root, "packages", host, "runner-manifest.json");
+  const runnerManifest = join44(root, "packages", host, "runner-manifest.json");
   const artifacts = readProofCandidateHeadArtifacts(root, [coreBundle, runnerManifest]);
   if (!artifacts) {
     throw new Error("CANDIDATE_CHECKOUT_NOT_CLEAN");
@@ -82738,7 +82884,7 @@ function readProofActionIdentity(appProjectRoot, actionId, dependencies = {}) {
     return {
       id: actionId,
       version: String(action.state.revision),
-      sha256: createHash17("sha256").update(action.yamlText).digest("hex")
+      sha256: createHash18("sha256").update(action.yamlText).digest("hex")
     };
   } catch {
     return null;
@@ -82775,7 +82921,7 @@ function validCaptureContext(args, expectedRoot) {
   ];
   if (proofTools.some((tool) => normalizeTool(tool) === "cdp_auto_login"))
     return false;
-  const proofRoot = join43(expectedRoot, "docs", "proof", args.runId);
+  const proofRoot = join44(expectedRoot, "docs", "proof", args.runId);
   const screenshots = args.storyboard.steps.map((step) => step.screenshotPath);
   const destinations = [args.receiptPath, args.videoPath, args.contactSheetPath, ...screenshots];
   if (destinations.some((path) => !isNormalizedDescendant(proofRoot, path) || hasExistingSymlink(expectedRoot, path)) || new Set(destinations).size !== destinations.length) {
@@ -82789,7 +82935,7 @@ function validCaptureContext(args, expectedRoot) {
   }));
 }
 function proofRootExists(args) {
-  const proofRoot = join43(args.projectRoot, "docs", "proof", args.runId);
+  const proofRoot = join44(args.projectRoot, "docs", "proof", args.runId);
   try {
     lstatSync16(proofRoot);
     return true;
@@ -82922,14 +83068,14 @@ function traceFor(storyboard, events) {
   return validateTrace([...required3, ...allowedExtras], events);
 }
 function readProofContractAt(moduleUrl = import.meta.url) {
-  const moduleDir = dirname22(fileURLToPath4(moduleUrl));
+  const moduleDir = dirname23(fileURLToPath4(moduleUrl));
   const candidates = [
     resolve16(moduleDir, "../../schemas/proof-receipt.schema.json"),
     resolve16(moduleDir, "../schemas/proof-receipt.schema.json")
   ];
   for (const path of candidates) {
     try {
-      const bytes = readFileSync31(path, "utf8");
+      const bytes = readFileSync32(path, "utf8");
       return { schema: JSON.parse(bytes), bytes, sha256: hashBytes(bytes) };
     } catch {
     }
@@ -82937,18 +83083,18 @@ function readProofContractAt(moduleUrl = import.meta.url) {
   throw new Error("PROOF_CONTRACT_MISSING");
 }
 function writeProofReceiptAtomic(path, receipt2) {
-  const directory = dirname22(path);
-  mkdirSync19(directory, { recursive: true, mode: 448 });
+  const directory = dirname23(path);
+  mkdirSync20(directory, { recursive: true, mode: 448 });
   const temporary = resolve16(directory, `.${randomUUID9()}.proof-receipt.tmp`);
   let descriptor = null;
   try {
     descriptor = openSync11(temporary, "wx", 384);
-    writeFileSync14(descriptor, `${JSON.stringify(receipt2, null, 2)}
+    writeFileSync15(descriptor, `${JSON.stringify(receipt2, null, 2)}
 `, "utf8");
     fsyncSync(descriptor);
     closeSync11(descriptor);
     descriptor = null;
-    renameSync8(temporary, path);
+    renameSync9(temporary, path);
     chmodSync7(path, 384);
   } catch (error2) {
     if (descriptor !== null)
@@ -83274,7 +83420,7 @@ function createProofCaptureHandler(deps) {
         return proofFailure(["PROOF_ACTION_IDENTITY_MISMATCH"], "idle");
       }
       try {
-        const proofRoot = join43(args.projectRoot, "docs", "proof", args.runId);
+        const proofRoot = join44(args.projectRoot, "docs", "proof", args.runId);
         if (deps.proofRootTracked(args.projectRoot, proofRoot)) {
           return proofFailure(["PROOF_ROOT_TRACKED"], "idle");
         }
@@ -83740,11 +83886,11 @@ function createProofCaptureHandler(deps) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/proof-media.js
-import { createHash as createHash18 } from "node:crypto";
+import { createHash as createHash19 } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { mkdir as mkdir2, mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir as tmpdir11 } from "node:os";
-import { dirname as dirname23, join as join44 } from "node:path";
+import { dirname as dirname24, join as join45 } from "node:path";
 var MediaFailure = class extends Error {
   reason;
   constructor(reason) {
@@ -83783,7 +83929,7 @@ async function hashAcceptedFile(path) {
   }
 }
 async function sha256File2(path) {
-  const hash = createHash18("sha256");
+  const hash = createHash19("sha256");
   const stream = createReadStream(path);
   for await (const chunk of stream)
     hash.update(chunk);
@@ -83881,7 +84027,7 @@ async function matchScreenshotAt(process3, input) {
   if (input.videoDurationMs !== void 0 && (!Number.isFinite(input.videoDurationMs) || input.videoDurationMs <= 0)) {
     fail2("INVALID_MEDIA_INPUT");
   }
-  const normalizedScreenshotPath = join44(input.scratchDir, `screenshot-${index}.png`);
+  const normalizedScreenshotPath = join45(input.scratchDir, `screenshot-${index}.png`);
   await rm(normalizedScreenshotPath, { force: true });
   await runFrameProcess(process3, [
     "-y",
@@ -83906,7 +84052,7 @@ async function matchScreenshotAt(process3, input) {
   let best = null;
   let decodedFrameCount = 0;
   for (const [sampleIndex, timestampMs] of sampleTimestamps.entries()) {
-    const framePath = join44(input.scratchDir, `frame-${index}-${sampleIndex}.jpg`);
+    const framePath = join45(input.scratchDir, `frame-${index}-${sampleIndex}.jpg`);
     await rm(framePath, { force: true });
     try {
       await runFrameProcess(process3, [
@@ -83978,7 +84124,7 @@ async function buildContactSheet(process3, selectedFramePaths, contactSheetPath)
     await requireNonEmptyFile(path, "FRAME_PROCESS_FAILED", "FRAME_PROCESS_FAILED");
   }
   try {
-    await mkdir2(dirname23(contactSheetPath), { recursive: true });
+    await mkdir2(dirname24(contactSheetPath), { recursive: true });
     await rm(contactSheetPath, { force: true });
   } catch {
     fail2("MEDIA_IO_FAILED");
@@ -84030,7 +84176,7 @@ async function validateMedia(process3, input) {
     const scratchRoot = input.scratchRoot ?? tmpdir11();
     try {
       await mkdir2(scratchRoot, { recursive: true });
-      scratchDir = await mkdtemp(join44(scratchRoot, "proof-media-"));
+      scratchDir = await mkdtemp(join45(scratchRoot, "proof-media-"));
     } catch {
       fail2("MEDIA_IO_FAILED");
     }
@@ -85218,8 +85364,8 @@ init_project_config();
 init_maestro_validator();
 init_maestro_run();
 init_action_engine_compat();
-import { lstatSync as lstatSync17, readFileSync as readFileSync32, readdirSync as readdirSync12, realpathSync as realpathSync14 } from "node:fs";
-import { dirname as dirname24, join as join45, resolve as resolve17 } from "node:path";
+import { lstatSync as lstatSync17, readFileSync as readFileSync33, readdirSync as readdirSync13, realpathSync as realpathSync14 } from "node:fs";
+import { dirname as dirname25, join as join46, resolve as resolve17 } from "node:path";
 var AUTH_ROUTE_PATTERNS = [
   "login",
   "signin",
@@ -85279,8 +85425,8 @@ async function isOnAuthScreen(client2) {
   }
 }
 function findLoginFlow(projectRoot) {
-  const maestroDir = join45(projectRoot, ".maestro");
-  const searchDirs = [join45(maestroDir, "subflows"), maestroDir];
+  const maestroDir = join46(projectRoot, ".maestro");
+  const searchDirs = [join46(maestroDir, "subflows"), maestroDir];
   for (const dir of searchDirs) {
     let files;
     try {
@@ -85291,7 +85437,7 @@ function findLoginFlow(projectRoot) {
       }
       if (!maestroStat.isDirectory() || !dirStat.isDirectory())
         continue;
-      files = readdirSync12(dir);
+      files = readdirSync13(dir);
     } catch (err) {
       if (err.code !== "ENOENT")
         throw err;
@@ -85299,12 +85445,12 @@ function findLoginFlow(projectRoot) {
     }
     for (const candidate of LOGIN_FLOW_PRIORITY) {
       if (files.includes(candidate)) {
-        return assertLegacyLoginFlow(projectRoot, join45(dir, candidate));
+        return assertLegacyLoginFlow(projectRoot, join46(dir, candidate));
       }
     }
     const authFile = files.find((f) => /\.(ya?ml)$/.test(f) && AUTH_ROUTE_PATTERNS.some((p) => f.toLowerCase().includes(p)));
     if (authFile)
-      return assertLegacyLoginFlow(projectRoot, join45(dir, authFile));
+      return assertLegacyLoginFlow(projectRoot, join46(dir, authFile));
   }
   return null;
 }
@@ -85411,12 +85557,12 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
     };
   }
   const rawAppId = opts.appId ?? projectAppId ?? "";
-  const originalContent = readFileSync32(flowPath, "utf-8");
+  const originalContent = readFileSync33(flowPath, "utf-8");
   let validatedCommands;
   try {
     const parsed = parseAndValidateFlow(originalContent, {
-      flowDir: dirname24(flowPath),
-      flowRoot: join45(projectRoot, ".maestro")
+      flowDir: dirname25(flowPath),
+      flowRoot: join46(projectRoot, ".maestro")
     });
     validatedCommands = parsed.commands;
     if (containsClearState(validatedCommands)) {
@@ -85912,11 +86058,11 @@ function buildGracefulShutdown(deps) {
 }
 
 // packages/rn-dev-agent-core/dist/lifecycle/lockfile.js
-import { createHash as createHash19 } from "node:crypto";
+import { createHash as createHash20 } from "node:crypto";
 import { execFileSync as execFileSync16 } from "node:child_process";
-import { closeSync as closeSync12, existsSync as existsSync31, mkdirSync as mkdirSync20, openSync as openSync12, readFileSync as readFileSync33, statSync as statSync14, unlinkSync as unlinkSync15, writeFileSync as writeFileSync15, writeSync as writeSync3 } from "node:fs";
+import { closeSync as closeSync12, existsSync as existsSync32, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync34, statSync as statSync14, unlinkSync as unlinkSync15, writeFileSync as writeFileSync16, writeSync as writeSync3 } from "node:fs";
 import { tmpdir as tmpdir12, userInfo as userInfo2 } from "node:os";
-import { join as join46, resolve as resolve18 } from "node:path";
+import { join as join47, resolve as resolve18 } from "node:path";
 var DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
 var DEFAULT_PROCESS_NAME_NEEDLE = "cdp-bridge";
 var PROCESS_IDENTITY_MARKERS = ["cdp-bridge", "rn-dev-agent", "supervisor.js"];
@@ -85965,7 +86111,7 @@ function defaultSelfPpid() {
   return typeof process.ppid === "number" ? process.ppid : 0;
 }
 function hashProjectRoot(projectRoot) {
-  return createHash19("md5").update(resolve18(projectRoot)).digest("hex").slice(0, 8);
+  return createHash20("md5").update(resolve18(projectRoot)).digest("hex").slice(0, 8);
 }
 var Lockfile = class {
   opts;
@@ -85992,7 +86138,7 @@ var Lockfile = class {
       processIdentity: opts.processIdentity ?? defaultProcessIdentity(),
       staleMs: opts.staleMs ?? DEFAULT_STALE_MS
     };
-    this.lockPath = join46(tmpDir, `rn-dev-agent-cdp-${uid}-${hash}.lock`);
+    this.lockPath = join47(tmpDir, `rn-dev-agent-cdp-${uid}-${hash}.lock`);
   }
   // GH#251: acquire via atomic exclusive-create (same pattern as DeviceLock).
   // The previous read-then-writeFileSync let two bridges starting in the same
@@ -86049,7 +86195,7 @@ var Lockfile = class {
     if (!this.acquired)
       return;
     try {
-      if (existsSync31(this.lockPath)) {
+      if (existsSync32(this.lockPath)) {
         const body = this.readExisting();
         if (body?.pid === this.opts.pid) {
           unlinkSync15(this.lockPath);
@@ -86077,16 +86223,16 @@ var Lockfile = class {
       return false;
     body.lastHeartbeat = this.opts.clock();
     try {
-      writeFileSync15(this.lockPath, JSON.stringify(body, null, 2), { encoding: "utf8" });
+      writeFileSync16(this.lockPath, JSON.stringify(body, null, 2), { encoding: "utf8" });
     } catch {
     }
     return true;
   }
   readExisting() {
-    if (!existsSync31(this.lockPath))
+    if (!existsSync32(this.lockPath))
       return null;
     try {
-      const raw = readFileSync33(this.lockPath, "utf8");
+      const raw = readFileSync34(this.lockPath, "utf8");
       const parsed = JSON.parse(raw);
       if (!isValidLockBody(parsed))
         return null;
@@ -86156,8 +86302,8 @@ var Lockfile = class {
       version: this.opts.version || void 0
     };
     const dir = this.opts.tmpDir;
-    if (!existsSync31(dir)) {
-      mkdirSync20(dir, { recursive: true });
+    if (!existsSync32(dir)) {
+      mkdirSync21(dir, { recursive: true });
     }
     const fd = openSync12(this.lockPath, "wx");
     try {
@@ -86237,7 +86383,7 @@ init_action_engine_compat();
 init_action_store();
 init_reusable_action();
 init_path_safety();
-import { basename as basename12, dirname as dirname25, join as join47 } from "node:path";
+import { basename as basename12, dirname as dirname26, join as join48 } from "node:path";
 function stepToMaestroCommands(step) {
   const ALLOWED_DIRECTIONS = /* @__PURE__ */ new Set(["up", "down", "left", "right"]);
   switch (step.action) {
@@ -86296,7 +86442,7 @@ function createMaestroGenerateHandler() {
       return failResult("Flow name contains an unsafe control character or is too long.");
     }
     const root = findProjectRoot();
-    const outputDir = args.outputDir ?? (root ? join47(root, ".rn-agent", "actions") : null);
+    const outputDir = args.outputDir ?? (root ? join48(root, ".rn-agent", "actions") : null);
     if (!outputDir) {
       return failResult("Cannot determine project root. Pass outputDir explicitly.");
     }
@@ -86305,7 +86451,7 @@ function createMaestroGenerateHandler() {
       return failResult("Flow name must produce an action id that starts with a letter or number and is at most 64 characters.");
     }
     const fileName = `${sanitizedName}.yaml`;
-    const learnedProjectRoot = basename12(outputDir) === "actions" && basename12(dirname25(outputDir)) === ".rn-agent" ? dirname25(dirname25(outputDir)) : null;
+    const learnedProjectRoot = basename12(outputDir) === "actions" && basename12(dirname26(outputDir)) === ".rn-agent" ? dirname26(dirname26(outputDir)) : null;
     if (!learnedProjectRoot) {
       return failResult("Generated actions must be written to an owned .rn-agent/actions corpus.");
     }
@@ -86380,8 +86526,8 @@ init_maestro_runner_report();
 init_registry();
 import { execFile as execFileCb19 } from "node:child_process";
 import { promisify as promisify25 } from "node:util";
-import { existsSync as existsSync32, readdirSync as readdirSync13, readFileSync as readFileSync34, writeFileSync as writeFileSync16 } from "node:fs";
-import { basename as basename13, dirname as dirname26, join as join48, resolve as resolve19 } from "node:path";
+import { existsSync as existsSync33, readdirSync as readdirSync14, readFileSync as readFileSync35, writeFileSync as writeFileSync17 } from "node:fs";
+import { basename as basename13, dirname as dirname27, join as join49, resolve as resolve19 } from "node:path";
 import { tmpdir as tmpdir13 } from "node:os";
 var defaultExecFile4 = promisify25(execFileCb19);
 function filterFlows(yamls, pattern) {
@@ -86399,9 +86545,9 @@ function filterFlows(yamls, pattern) {
   return yamls;
 }
 function discoverFlows(dir, pattern) {
-  if (!existsSync32(dir))
+  if (!existsSync33(dir))
     return [];
-  const yamls = readdirSync13(dir, { recursive: true }).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).map((f) => join48(dir, f)).sort();
+  const yamls = readdirSync14(dir, { recursive: true }).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).map((f) => join49(dir, f)).sort();
   return filterFlows(yamls, pattern);
 }
 function createMaestroTestAllHandler(deps = {}) {
@@ -86433,17 +86579,17 @@ function createMaestroTestAllHandler(deps = {}) {
     if (pinRefusal)
       return failResult(pinRefusal);
     const root = findProjectRoot();
-    const flowDir = args.flowDir ?? (root ? join48(root, ".rn-agent", "actions") : null);
+    const flowDir = args.flowDir ?? (root ? join49(root, ".rn-agent", "actions") : null);
     if (!flowDir) {
       return failResult("Cannot determine project root. Pass flowDir explicitly.");
     }
     const resolvedFlowDir = resolve19(flowDir);
-    const flowDirClassification = classifyLearnedActionPath(join48(resolvedFlowDir, "__action__.yaml"));
+    const flowDirClassification = classifyLearnedActionPath(join49(resolvedFlowDir, "__action__.yaml"));
     if (flowDirClassification === "descendant") {
       return failResult(`Refusing to execute learned-action descendants from ${resolvedFlowDir} as standalone flows.`);
     }
     const learnedCorpus = flowDirClassification === "action";
-    const learnedProjectRoot = learnedCorpus ? dirname26(dirname26(resolvedFlowDir)) : null;
+    const learnedProjectRoot = learnedCorpus ? dirname27(dirname27(resolvedFlowDir)) : null;
     let learnedContext = null;
     if (learnedProjectRoot) {
       try {
@@ -86455,7 +86601,7 @@ function createMaestroTestAllHandler(deps = {}) {
     if (learnedCorpus && !learnedContext) {
       return failResult(`Refusing learned-action corpus without an approved load context: ${resolvedFlowDir}.`);
     }
-    const flows = learnedContext ? filterFlows(learnedContext.files.filter((file) => /\.ya?ml$/i.test(file)).map((file) => join48(flowDir, file)).sort(), args.pattern) : discoverFlows(flowDir, args.pattern);
+    const flows = learnedContext ? filterFlows(learnedContext.files.filter((file) => /\.ya?ml$/i.test(file)).map((file) => join49(flowDir, file)).sort(), args.pattern) : discoverFlows(flowDir, args.pattern);
     if (flows.length === 0) {
       return failResult(`No Maestro flows found in ${flowDir}. Generate flows with maestro_generate first.`);
     }
@@ -86482,9 +86628,9 @@ function createMaestroTestAllHandler(deps = {}) {
           meta = action.metadata;
           requireEnginePin = true;
         } else {
-          const yamlText = readFileSync34(flow, "utf-8");
+          const yamlText = readFileSync35(flow, "utf-8");
           const parsed = parseAndValidateFlow(yamlText, {
-            flowDir: dirname26(flow),
+            flowDir: dirname27(flow),
             flowRoot: flowDir
           });
           const flowId = name.replace(/\.ya?ml$/i, "");
@@ -86554,8 +86700,8 @@ function createMaestroTestAllHandler(deps = {}) {
     for (const prepared of preparedFlows) {
       const { name } = prepared;
       const start = now();
-      const safeFlowFile = join48(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
-      writeFileSync16(safeFlowFile, prepared.canonical, "utf-8");
+      const safeFlowFile = join49(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      writeFileSync17(safeFlowFile, prepared.canonical, "utf-8");
       const parsedCommands = prepared.commands;
       const parsedAppId = prepared.appId;
       const appFile = prepared.appFile;
@@ -86578,7 +86724,7 @@ function createMaestroTestAllHandler(deps = {}) {
             Object.assign(error2, { code: "ETIMEDOUT" });
             throw error2;
           }
-          writeFileSync16(safeFlowFile, buildMaestroFlow(parsedAppId !== void 0 ? { appId: parsedAppId } : {}, [
+          writeFileSync17(safeFlowFile, buildMaestroFlow(parsedAppId !== void 0 ? { appId: parsedAppId } : {}, [
             ...commands
           ]), "utf-8");
           const executeRunner = (runnerPath, prefixArgs = []) => {
@@ -86704,8 +86850,8 @@ function createMaestroTestAllHandler(deps = {}) {
 init_agent_device_wrapper();
 init_utils();
 init_path_safety();
-import { readFileSync as readFileSync35, readdirSync as readdirSync14, lstatSync as lstatSync18 } from "node:fs";
-import { join as join49, extname as extname2 } from "node:path";
+import { readFileSync as readFileSync36, readdirSync as readdirSync15, lstatSync as lstatSync18 } from "node:fs";
+import { join as join50, extname as extname2 } from "node:path";
 function findElement(nodes, query, matchBy) {
   const q = query.toLowerCase();
   return nodes.some((n) => {
@@ -86723,14 +86869,14 @@ function discoverTestIDs(dir) {
   function walk(d) {
     let entries;
     try {
-      entries = readdirSync14(d);
+      entries = readdirSync15(d);
     } catch {
       return;
     }
     for (const entry of entries) {
       if (entry === "node_modules" || entry.startsWith("."))
         continue;
-      const full = join49(d, entry);
+      const full = join50(d, entry);
       try {
         const st = lstatSync18(full);
         if (st.isSymbolicLink())
@@ -86741,7 +86887,7 @@ function discoverTestIDs(dir) {
         }
         if (!SCAN_EXTENSIONS.has(extname2(entry)))
           continue;
-        const src = readFileSync35(full, "utf8");
+        const src = readFileSync36(full, "utf8");
         for (const m of src.matchAll(TESTID_RE)) {
           const id = m[1] ?? m[2] ?? m[3];
           if (id)
@@ -87063,16 +87209,16 @@ function instrumentTool(toolName, handler) {
 }
 
 // packages/rn-dev-agent-core/dist/experience/evidence.js
-import { createHash as createHash20, randomUUID as randomUUID10 } from "node:crypto";
-import { chmodSync as chmodSync8, existsSync as existsSync33, mkdirSync as mkdirSync21, readFileSync as readFileSync36, renameSync as renameSync9, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17 } from "node:fs";
+import { createHash as createHash21, randomUUID as randomUUID10 } from "node:crypto";
+import { chmodSync as chmodSync8, existsSync as existsSync34, mkdirSync as mkdirSync22, readFileSync as readFileSync37, renameSync as renameSync10, unlinkSync as unlinkSync16, writeFileSync as writeFileSync18 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
-import { dirname as dirname27, join as join50 } from "node:path";
+import { dirname as dirname28, join as join51 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 var UNKNOWN_CLASSIFICATION = "UNKNOWN";
 var DEFAULT_MAX_RECORDS = 500;
 var DEFAULT_RETENTION_DAYS = 14;
 var MAX_EVIDENCE_POINTERS = 3;
-var EXPERIENCE_DIRECTORY = join50(homedir9(), ".claude", "rn-agent", "experience");
+var EXPERIENCE_DIRECTORY = join51(homedir9(), ".claude", "rn-agent", "experience");
 var EXPERIENCE_STORE_NAME = "patterns.jsonl";
 var MAX_SYMPTOM_LENGTH = 2048;
 var DAY_MS = 24 * 60 * 60 * 1e3;
@@ -87153,11 +87299,11 @@ function readAppIdentity() {
   return appIdentityCache.identity;
 }
 function loadAppIdentity(root) {
-  const manifest = join50(root, "app.json");
+  const manifest = join51(root, "app.json");
   try {
-    if (!existsSync33(manifest))
+    if (!existsSync34(manifest))
       return { name: null, slug: null };
-    const parsed = JSON.parse(readFileSync36(manifest, "utf8"));
+    const parsed = JSON.parse(readFileSync37(manifest, "utf8"));
     const expo = parsed.expo ?? parsed;
     return { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
   } catch {
@@ -87179,7 +87325,7 @@ var ExperienceRecorder = class {
   previousFailure = null;
   constructor(options) {
     this.directory = options.directory ?? process.env.RN_DEV_AGENT_EXPERIENCE_DIR ?? EXPERIENCE_DIRECTORY;
-    this.path = join50(this.directory, EXPERIENCE_STORE_NAME);
+    this.path = join51(this.directory, EXPERIENCE_STORE_NAME);
     this.candidate = {
       pluginVersion: options.pluginVersion ?? null,
       coreVersion: options.coreVersion
@@ -87322,21 +87468,21 @@ var ExperienceRecorder = class {
     this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
   }
   write(records) {
-    mkdirSync21(this.directory, { recursive: true, mode: 448 });
-    const temp = join50(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID10()}`);
+    mkdirSync22(this.directory, { recursive: true, mode: 448 });
+    const temp = join51(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID10()}`);
     try {
       const sanitized = records.map((record2) => record2.redactionVersion === REDACTION_RULES_VERSION ? record2 : {
         ...sanitizeForEvidence(record2),
         redactionVersion: REDACTION_RULES_VERSION
       });
       const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
-      writeFileSync17(temp, contents.length > 0 ? `${contents}
+      writeFileSync18(temp, contents.length > 0 ? `${contents}
 ` : "", {
         encoding: "utf8",
         flag: "wx",
         mode: 384
       });
-      renameSync9(temp, this.path);
+      renameSync10(temp, this.path);
       chmodSync8(this.path, 384);
     } catch (error2) {
       try {
@@ -87350,16 +87496,16 @@ var ExperienceRecorder = class {
 function discoverPluginVersion(fromUrl = import.meta.url) {
   if (process.env.RN_DEV_AGENT_PLUGIN_VERSION)
     return process.env.RN_DEV_AGENT_PLUGIN_VERSION;
-  const start = dirname27(fileURLToPath5(fromUrl));
+  const start = dirname28(fileURLToPath5(fromUrl));
   const candidates = [
-    join50(start, "..", "..", ".claude-plugin", "plugin.json"),
-    join50(start, "..", "..", ".codex-plugin", "plugin.json"),
-    join50(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
-    join50(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
+    join51(start, "..", "..", ".claude-plugin", "plugin.json"),
+    join51(start, "..", "..", ".codex-plugin", "plugin.json"),
+    join51(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
+    join51(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
   ];
   for (const candidate of candidates) {
     try {
-      const parsed = JSON.parse(readFileSync36(candidate, "utf8"));
+      const parsed = JSON.parse(readFileSync37(candidate, "utf8"));
       if (typeof parsed.version === "string")
         return sanitizeString(parsed.version);
     } catch {
@@ -87368,9 +87514,9 @@ function discoverPluginVersion(fromUrl = import.meta.url) {
   return null;
 }
 function readExperienceStore(path) {
-  if (!existsSync33(path))
+  if (!existsSync34(path))
     return [];
-  const contents = readFileSync36(path, "utf8");
+  const contents = readFileSync37(path, "utf8");
   if (!contents.trim())
     return [];
   const records = [];
@@ -87395,7 +87541,7 @@ function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, 
   }).sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen) || a.signature.localeCompare(b.signature)).slice(0, Math.max(0, maxRecords)).sort((a, b) => a.signature.localeCompare(b.signature));
 }
 function experienceSignature(input) {
-  return createHash20("sha256").update(JSON.stringify([
+  return createHash21("sha256").update(JSON.stringify([
     input.classification,
     input.tool,
     input.normalizedSymptomShape,
@@ -87512,7 +87658,7 @@ function boundedPointers(existing, incoming) {
 }
 
 // packages/rn-dev-agent-core/dist/observability/live-device.js
-import { join as join51 } from "node:path";
+import { join as join52 } from "node:path";
 import { tmpdir as tmpdir14 } from "node:os";
 function isStateMutating(tool, args) {
   if (FLOW_MUTATION_TOOLS.has(tool))
@@ -87664,7 +87810,7 @@ function buildLiveDeps(input) {
     // iterable" when invoked as deps.pushLive(...). The live device gate caught
     // this — the unit fakes used standalone arrows and missed it.
     pushLive: (frame) => input.recorder.pushLive(frame),
-    tmpPath: () => join51(tmpdir14(), `rn-observe-live-${process.pid}.jpg`),
+    tmpPath: () => join52(tmpdir14(), `rn-observe-live-${process.pid}.jpg`),
     isMirrorActive: input.isMirrorActive
   };
 }
@@ -87678,9 +87824,9 @@ init_utils();
 
 // packages/rn-dev-agent-core/dist/observability/server.js
 import { createServer as createServer3 } from "node:http";
-import { readFileSync as readFileSync37 } from "node:fs";
+import { readFileSync as readFileSync38 } from "node:fs";
 import { fileURLToPath as fileURLToPath6 } from "node:url";
-import { dirname as dirname28, join as join52 } from "node:path";
+import { dirname as dirname29, join as join53 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/observability/e2e-csrf.js
 import { randomBytes as randomBytes7, timingSafeEqual as timingSafeEqual8 } from "node:crypto";
@@ -87767,7 +87913,7 @@ function createObserveRootResolver(deps) {
 // packages/rn-dev-agent-core/dist/observability/server.js
 init_logger();
 var HOST = "127.0.0.1";
-var __dir = dirname28(fileURLToPath6(import.meta.url));
+var __dir = dirname29(fileURLToPath6(import.meta.url));
 var ObservabilityServer = class {
   recorder;
   e2e;
@@ -88010,7 +88156,7 @@ var ObservabilityServer = class {
   }
   index(res) {
     try {
-      let html = readFileSync37(join52(__dir, "web-dist", "index.html"), "utf8");
+      let html = readFileSync38(join53(__dir, "web-dist", "index.html"), "utf8");
       if (this.e2e) {
         const tokenJs = JSON.stringify(this.e2e.token).replace(/</g, "\\u003c");
         html = html.replace("</head>", `<script>window.__E2E_CSRF__=${tokenJs}</script></head>`);
@@ -88211,10 +88357,10 @@ init_project_config();
 // packages/rn-dev-agent-core/dist/observability/observe-state.js
 init_secure_state_file();
 init_storage();
-import { join as join53 } from "node:path";
+import { join as join54 } from "node:path";
 function observeStatePath(projectRoot) {
   const safe = projectRoot.replace(/[^A-Za-z0-9._-]/g, "_");
-  return join53(getStateDir(), "observe", `${safe}.json`);
+  return join54(getStateDir(), "observe", `${safe}.json`);
 }
 function writeObserveState(url, port, projectRoot = findProjectRoot(), now = () => /* @__PURE__ */ new Date()) {
   try {
@@ -88897,110 +89043,7 @@ init_sources();
 
 // packages/rn-dev-agent-core/dist/tools/lock-e2e-test.js
 init_action_store();
-
-// packages/rn-dev-agent-core/dist/domain/e2e-test.js
-init_path_safety();
-import { dirname as dirname29, join as join54 } from "node:path";
-import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync10, readFileSync as readFileSync38, readdirSync as readdirSync15, existsSync as existsSync34 } from "node:fs";
-import { createHash as createHash21 } from "node:crypto";
-var FLOW_SENTINEL = "# e2e-locked-flow-below";
-function e2eDirFor(projectRoot) {
-  return join54(projectRoot, ".rn-agent", "e2e");
-}
-function e2ePathFor(projectRoot, id) {
-  assertValidActionId(id, "e2ePathFor");
-  const dir = e2eDirFor(projectRoot);
-  const file = join54(dir, `${id}.yaml`);
-  assertWithinDir(file, dir);
-  return file;
-}
-function serializeLockedTest(meta) {
-  const header = [
-    "# e2e-locked-test: true",
-    `# id: ${meta.id}`,
-    `# intent: ${meta.intent}`,
-    `# sourceActionId: ${meta.sourceActionId}`,
-    `# lockedAt: ${meta.lockedAt}`,
-    `# lockedGitSha: ${meta.lockedGitSha ?? ""}`,
-    `# sourceContentHash: ${meta.sourceContentHash}`,
-    "# status: locked"
-  ];
-  if (meta.appId)
-    header.push(`# appId: ${meta.appId}`);
-  if (meta.params?.length)
-    header.push(`# params: ${meta.params.join(", ")}`);
-  header.push(FLOW_SENTINEL);
-  return `${header.join("\n")}
-${meta.flow}`;
-}
-function hashBody(s) {
-  return createHash21("sha256").update(s).digest("hex");
-}
-function freezeLockedTest(projectRoot, source, ctx) {
-  const filePath = e2ePathFor(projectRoot, source.id);
-  mkdirSync22(dirname29(filePath), { recursive: true });
-  const meta = {
-    id: source.id,
-    intent: source.intent,
-    sourceActionId: source.sourceActionId,
-    lockedAt: ctx.now().toISOString(),
-    lockedGitSha: ctx.gitSha,
-    sourceContentHash: hashBody(source.flow),
-    status: "locked",
-    params: source.params,
-    appId: source.appId,
-    flow: source.flow
-  };
-  const tmp = `${filePath}.tmp`;
-  writeFileSync18(tmp, serializeLockedTest(meta), "utf8");
-  renameSync10(tmp, filePath);
-  return { ...meta, filePath };
-}
-function loadLockedTest(projectRoot, id) {
-  const filePath = e2ePathFor(projectRoot, id);
-  if (!existsSync34(filePath))
-    return null;
-  return parseLockedTest(readFileSync38(filePath, "utf8"), filePath);
-}
-function discoverLockedTests(projectRoot) {
-  const dir = e2eDirFor(projectRoot);
-  if (!existsSync34(dir))
-    return [];
-  return readdirSync15(dir).filter((f) => f.endsWith(".yaml")).map((f) => f.replace(/\.yaml$/, "")).sort();
-}
-function parseLockedTest(text, filePath) {
-  if (!/^#\s*e2e-locked-test:\s*true\s*$/m.test(text))
-    return null;
-  const sentinelIdx = text.indexOf(FLOW_SENTINEL);
-  if (sentinelIdx < 0)
-    return null;
-  const headerText = text.slice(0, sentinelIdx);
-  const flowStart = text.indexOf("\n", sentinelIdx);
-  const flow = flowStart >= 0 ? text.slice(flowStart + 1) : "";
-  const field2 = (k) => {
-    const m = headerText.match(new RegExp(`^#\\s*${k}:\\s*(.*)$`, "m"));
-    const v = m?.[1]?.trim();
-    return v ? v : void 0;
-  };
-  const id = field2("id");
-  const intent = field2("intent");
-  if (!id || !intent)
-    return null;
-  const paramsRaw = field2("params");
-  return {
-    id,
-    intent,
-    sourceActionId: field2("sourceActionId") ?? id,
-    lockedAt: field2("lockedAt") ?? "",
-    lockedGitSha: field2("lockedGitSha") ?? null,
-    sourceContentHash: field2("sourceContentHash") ?? "",
-    status: "locked",
-    params: paramsRaw ? paramsRaw.split(",").map((s) => s.trim()).filter(Boolean) : void 0,
-    appId: field2("appId"),
-    flow,
-    filePath
-  };
-}
+init_e2e_test();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-config.js
 import { readFileSync as readFileSync39 } from "node:fs";
@@ -89139,6 +89182,9 @@ async function lockE2eTestCore(args, deps = {}) {
 function createLockE2eTestHandler(deps = {}) {
   return (args) => lockE2eTestCore(args, deps);
 }
+
+// packages/rn-dev-agent-core/dist/tools/run-e2e-suite.js
+init_e2e_test();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
 init_maestro_error_parser();
@@ -89340,16 +89386,6 @@ function readMaestro(result) {
     return { passed: false, output: "unparseable maestro result" };
   }
 }
-function filterByPattern(ids, pattern) {
-  if (!pattern || pattern.length > 256)
-    return ids;
-  try {
-    const re = new RegExp(pattern, "i");
-    return ids.filter((id) => re.test(id));
-  } catch {
-    return ids;
-  }
-}
 async function runE2eSuiteCore(args, deps = {}) {
   const projectRoot = args.projectRoot ?? findProjectRoot() ?? process.cwd();
   const discover2 = deps.discover ?? discoverLockedTests;
@@ -89360,7 +89396,9 @@ async function runE2eSuiteCore(args, deps = {}) {
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
   const mkRunId = deps.makeRunId ?? makeRunId;
   const rand = () => Math.random().toString(36).slice(2, 8);
-  const ids = filterByPattern(discover2(projectRoot), args.pattern);
+  const ids = [
+    ...getResolvedLockedTestIds(args) ?? resolveLockedTestIds(projectRoot, args.pattern, discover2)
+  ];
   if (ids.length === 0) {
     return warnResult({
       runId: null,
@@ -89539,6 +89577,9 @@ function createRunE2eSuiteHandler(deps = {}) {
     }
   };
 }
+
+// packages/rn-dev-agent-core/dist/index.js
+init_e2e_test();
 
 // packages/rn-dev-agent-core/dist/e2e/preflight.js
 import { request } from "node:http";
@@ -90817,6 +90858,13 @@ var createRuntimeAuthorityProbe = (resolveClient) => createLocalAuthorityProbe({
 var localAuthorityProbe = createRuntimeAuthorityProbe(getClient);
 var authorityGate = createAuthorityGate(authorityRuntime, {
   loginSupervisorOverrideToken: () => process.env.RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN,
+  resolveLockedE2eTestIds: (args, status) => {
+    const projectRoot = typeof args.projectRoot === "string" ? args.projectRoot : status.source.appRoot;
+    if (typeof projectRoot !== "string")
+      return [];
+    args.projectRoot = projectRoot;
+    return resolveLockedTestIds(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
+  },
   probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
   recoverRuntimeConnection: async (status) => {
     const current = getClient();

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -32652,6 +32652,23 @@ function missingLoginPrologueOutcome() {
     }
   };
 }
+function pendingLoginPrologueOutcome() {
+  const timestamp = (/* @__PURE__ */ new Date()).toISOString();
+  return {
+    schemaVersion: 1,
+    state: LOGIN_PROLOGUE_BLOCKED,
+    alias: LOGIN_PROLOGUE_ALIAS,
+    startedAt: timestamp,
+    endedAt: timestamp,
+    elapsedMs: 0,
+    steps: [],
+    inventory: { count: 0, actionIds: [] },
+    failure: {
+      code: "LOGIN_PROLOGUE_IN_PROGRESS",
+      detail: "The login prologue has not completed authoritative validation."
+    }
+  };
+}
 function persistLoginPrologueOutcome(runtime, registry2, operation, status, outcome) {
   const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
   const overrides = outcome.overrides ?? priorOutcome?.overrides;
@@ -32921,6 +32938,13 @@ function createAuthorityGate(runtime, dependencies) {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
           overrideRejected: loginDecision.suppliedOverride,
           nextAction: "Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call."
+        });
+      }
+      if (loginDecision.override && profile.kind === "transition") {
+        return failResult("LOGIN_PROLOGUE_BLOCKED: supervisor overrides cannot authorize transition mutations.", "LOGIN_PROLOGUE_BLOCKED", {
+          loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
+          transitionOverrideRejected: true,
+          nextAction: "Repair the exact user-login action and rerun cdp_login_prologue before this transition."
         });
       }
       if (profile.kind === "diagnostic") {
@@ -33543,6 +33567,11 @@ function createAuthorityGate(runtime, dependencies) {
             throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
           }
           const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, loginDecision.audit));
+          operation = persisted.operation;
+          status = persisted.status;
+        }
+        if (tool === "cdp_login_prologue") {
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome());
           operation = persisted.operation;
           status = persisted.status;
         }
@@ -78362,8 +78391,9 @@ function createRunActionHandler(deps = {}) {
     });
     try {
       let atRisk = null;
+      const cdpFallbackForbidden = args.cdpFallbackMode === "forbid";
       const inheritedBlindProbeDisabled = process.env.RN_BLIND_PROBE === "0" || process.env.RN_BLIND_PROBE === "false";
-      const blindProbeDisabled = args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
+      const blindProbeDisabled = cdpFallbackForbidden || args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
       if (args.platform !== "android") {
         const ctx = await blindProbeContext2().catch(() => null);
         if (ctx) {
@@ -78549,7 +78579,7 @@ function createRunActionHandler(deps = {}) {
         }
       }
       let cdpJsFallback;
-      if (failure.kind === "SELECTOR_NOT_FOUND" || failure.kind === "UNKNOWN") {
+      if (!cdpFallbackForbidden && (failure.kind === "SELECTOR_NOT_FOUND" || failure.kind === "UNKNOWN")) {
         const candidate = getReplayDeps(args);
         const replayDeps = candidate && await claimBundleAuthority(args) ? candidate : null;
         const probe = !replayDeps ? null : failure.kind === "SELECTOR_NOT_FOUND" ? failure.selector : firstReplayTestId(cdpReplayYaml, args.params ?? {});
@@ -79002,6 +79032,7 @@ function createLoginPrologueHandler(deps) {
         forceReload: false,
         proofReplay: false,
         blindProbeMode: "forbid",
+        cdpFallbackMode: "forbid",
         trigger: args.trigger ?? "agent"
       });
       let replayResult;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -13032,6 +13032,14 @@ var init_login_prologue = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/e2e-test.js
+var init_e2e_test = __esm({
+  "packages/rn-dev-agent-core/dist/domain/e2e-test.js"() {
+    "use strict";
+    init_path_safety();
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -13320,6 +13328,7 @@ var init_authority_gate = __esm({
     init_metro_origin();
     init_install_reissue();
     init_login_prologue();
+    init_e2e_test();
     init_tool_profiles();
     managedNativeOrigin = /* @__PURE__ */ Symbol("managedNativeOrigin");
     managedRunnerPark = /* @__PURE__ */ Symbol("managedRunnerPark");

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -10902,10 +10902,10 @@ function assertWritableActionFile(filePath) {
 function assertActionMetadataIdentity(filePath, metadata) {
   const fileId = basename4(filePath).replace(/\.ya?ml$/i, "");
   if (metadata.id !== fileId) {
-    throw new Error(`Action metadata id ${metadata.id} does not match filename identity ${fileId}.`);
+    throw new ActionMetadataIdentityError(metadata.id, fileId);
   }
 }
-var migrationPathIdentities;
+var migrationPathIdentities, ActionMetadataIdentityError;
 var init_action_store = __esm({
   "packages/rn-dev-agent-core/dist/domain/action-store.js"() {
     "use strict";
@@ -10918,6 +10918,16 @@ var init_action_store = __esm({
     init_action_state_store();
     init_worktree_inheritance();
     migrationPathIdentities = /* @__PURE__ */ new WeakMap();
+    ActionMetadataIdentityError = class extends Error {
+      metadataId;
+      fileId;
+      constructor(metadataId, fileId) {
+        super(`Action metadata id ${metadataId} does not match filename identity ${fileId}.`);
+        this.metadataId = metadataId;
+        this.fileId = fileId;
+        this.name = "ActionMetadataIdentityError";
+      }
+    };
   }
 });
 

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -13015,6 +13015,13 @@ var init_install_reissue = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/login-prologue.js
+var init_login_prologue = __esm({
+  "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
+    "use strict";
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -13087,7 +13094,7 @@ var init_tool_profiles = __esm({
       "maestro_test_all"
     ];
     hybridMutation = ["cdp_auto_login", "cdp_run_e2e_suite"];
-    optionalHybridMutation = ["cdp_run_action"];
+    optionalHybridMutation = ["cdp_login_prologue", "cdp_run_action"];
     nativeDiagnostic = ["cdp_native_errors"];
     cdpRead = [
       "cdp_component_state",
@@ -13302,6 +13309,7 @@ var init_authority_gate = __esm({
     init_registry();
     init_metro_origin();
     init_install_reissue();
+    init_login_prologue();
     init_tool_profiles();
     managedNativeOrigin = /* @__PURE__ */ Symbol("managedNativeOrigin");
     managedRunnerPark = /* @__PURE__ */ Symbol("managedRunnerPark");

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -10902,10 +10902,10 @@ function assertWritableActionFile(filePath) {
 function assertActionMetadataIdentity(filePath, metadata) {
   const fileId = basename4(filePath).replace(/\.ya?ml$/i, "");
   if (metadata.id !== fileId) {
-    throw new ActionMetadataIdentityError(metadata.id, fileId);
+    throw new Error(`Action metadata id ${metadata.id} does not match filename identity ${fileId}.`);
   }
 }
-var migrationPathIdentities, ActionMetadataIdentityError;
+var migrationPathIdentities;
 var init_action_store = __esm({
   "packages/rn-dev-agent-core/dist/domain/action-store.js"() {
     "use strict";
@@ -10918,16 +10918,6 @@ var init_action_store = __esm({
     init_action_state_store();
     init_worktree_inheritance();
     migrationPathIdentities = /* @__PURE__ */ new WeakMap();
-    ActionMetadataIdentityError = class extends Error {
-      metadataId;
-      fileId;
-      constructor(metadataId, fileId) {
-        super(`Action metadata id ${metadataId} does not match filename identity ${fileId}.`);
-        this.metadataId = metadataId;
-        this.fileId = fileId;
-        this.name = "ActionMetadataIdentityError";
-      }
-    };
   }
 });
 

--- a/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -11970,6 +11970,14 @@ var init_install_reissue = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/e2e-test.js
+var init_e2e_test = __esm({
+  "packages/rn-dev-agent-core/dist/domain/e2e-test.js"() {
+    "use strict";
+    init_path_safety();
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -12212,6 +12220,7 @@ var init_authority_gate = __esm({
     init_metro_origin();
     init_install_reissue();
     init_login_prologue();
+    init_e2e_test();
     init_tool_profiles();
   }
 });

--- a/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -11390,12 +11390,13 @@ function readLoginPrologueOutcome(value) {
   }
   return candidate;
 }
-var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED;
+var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, ACTION_LOGIN_HELPER;
 var init_login_prologue = __esm({
   "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
     "use strict";
     LOGIN_PROLOGUE_ALIAS = "user-login";
     LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
+    ACTION_LOGIN_HELPER = "ACTION_LOGIN_HELPER";
   }
 });
 
@@ -17753,6 +17754,7 @@ function projectPublicAuthorityStatus(status, options = {}) {
     proofOverlay: { active: Boolean(status.bindings.proof) },
     ...loginPrologue ? {
       loginPrologue: {
+        role: ACTION_LOGIN_HELPER,
         state: loginPrologue.state,
         alias: loginPrologue.alias,
         actionId: loginPrologue.actionId,

--- a/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -11380,6 +11380,25 @@ var init_secure_state_file = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/login-prologue.js
+function readLoginPrologueOutcome(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    return null;
+  const candidate = value;
+  if (candidate.schemaVersion !== 1 || candidate.alias !== LOGIN_PROLOGUE_ALIAS || candidate.state !== "passed" && candidate.state !== LOGIN_PROLOGUE_BLOCKED || typeof candidate.startedAt !== "string" || typeof candidate.endedAt !== "string" || typeof candidate.elapsedMs !== "number" || !Array.isArray(candidate.steps)) {
+    return null;
+  }
+  return candidate;
+}
+var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED;
+var init_login_prologue = __esm({
+  "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
+    "use strict";
+    LOGIN_PROLOGUE_ALIAS = "user-login";
+    LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
+  }
+});
+
 // packages/rn-dev-agent-core/dist/lifecycle/settle-hash.js
 var init_settle_hash = __esm({
   "packages/rn-dev-agent-core/dist/lifecycle/settle-hash.js"() {
@@ -12022,7 +12041,7 @@ var init_tool_profiles = __esm({
       "maestro_test_all"
     ];
     hybridMutation = ["cdp_auto_login", "cdp_run_e2e_suite"];
-    optionalHybridMutation = ["cdp_run_action"];
+    optionalHybridMutation = ["cdp_login_prologue", "cdp_run_action"];
     nativeDiagnostic = ["cdp_native_errors"];
     cdpRead = [
       "cdp_component_state",
@@ -12191,6 +12210,7 @@ var init_authority_gate = __esm({
     init_registry();
     init_metro_origin();
     init_install_reissue();
+    init_login_prologue();
     init_tool_profiles();
   }
 });
@@ -17610,6 +17630,7 @@ function inspectAuthorityMigration(status, dependencies = {}) {
 
 // packages/rn-dev-agent-core/dist/session/public-status.js
 init_registry();
+init_login_prologue();
 var SELECTED_STATES = /* @__PURE__ */ new Set(["active", "source_bound", "device_claimed", "metro_bound"]);
 var RUNNING_STATES = /* @__PURE__ */ new Set(["device_bound", "runtime_bound", "ready"]);
 function derivePublicPhase(state, buildPending) {
@@ -17686,6 +17707,7 @@ function projectPublicAuthorityStatus(status, options = {}) {
     observedAt: metroTerminal.observedAt
   } : void 0;
   const sandbox = metro?.runtimeEvidenceAuthority === "managed-sandbox-v1" ? "managed-sandbox-v1" : "unavailable";
+  const loginPrologue = readLoginPrologueOutcome(status.bindings.loginPrologue);
   const phase = derivePublicPhase(status.state, Boolean(status.bindings.pendingBuild));
   return {
     available: true,
@@ -17729,6 +17751,20 @@ function projectPublicAuthorityStatus(status, options = {}) {
     proof: Boolean(status.bindings.proof),
     // ADR §5.2 (L3): strict proof is an opt-in overlay outside the four groups, never a group.
     proofOverlay: { active: Boolean(status.bindings.proof) },
+    ...loginPrologue ? {
+      loginPrologue: {
+        state: loginPrologue.state,
+        alias: loginPrologue.alias,
+        actionId: loginPrologue.actionId,
+        startedAt: loginPrologue.startedAt,
+        endedAt: loginPrologue.endedAt,
+        elapsedMs: loginPrologue.elapsedMs,
+        failureCode: loginPrologue.failure?.code,
+        runId: loginPrologue.runRecord?.runId,
+        overrideCount: loginPrologue.overrides?.length ?? 0,
+        lastOverride: loginPrologue.overrides?.at(-1)
+      }
+    } : {},
     ...options.installIdentity ? { installIdentity: options.installIdentity.verdict } : {},
     // A live axis-I refusal means every gated tool refuses too — status must
     // not read `ready` while that is true. A pending re-issue reads ready only

--- a/packages/claude-plugin/rn-dev-agent-core/dist/session-doctor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/session-doctor.js
@@ -11655,6 +11655,14 @@ var init_login_prologue = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/e2e-test.js
+var init_e2e_test = __esm({
+  "packages/rn-dev-agent-core/dist/domain/e2e-test.js"() {
+    "use strict";
+    init_path_safety();
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -11897,6 +11905,7 @@ var init_authority_gate = __esm({
     init_metro_origin();
     init_install_reissue();
     init_login_prologue();
+    init_e2e_test();
     init_tool_profiles();
   }
 });

--- a/packages/claude-plugin/rn-dev-agent-core/dist/session-doctor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/session-doctor.js
@@ -11648,6 +11648,13 @@ var init_install_reissue = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/login-prologue.js
+var init_login_prologue = __esm({
+  "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
+    "use strict";
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -11720,7 +11727,7 @@ var init_tool_profiles = __esm({
       "maestro_test_all"
     ];
     hybridMutation = ["cdp_auto_login", "cdp_run_e2e_suite"];
-    optionalHybridMutation = ["cdp_run_action"];
+    optionalHybridMutation = ["cdp_login_prologue", "cdp_run_action"];
     nativeDiagnostic = ["cdp_native_errors"];
     cdpRead = [
       "cdp_component_state",
@@ -11889,6 +11896,7 @@ var init_authority_gate = __esm({
     init_registry();
     init_metro_origin();
     init_install_reissue();
+    init_login_prologue();
     init_tool_profiles();
   }
 });

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -30239,7 +30239,7 @@ function assertWritableActionFile(filePath) {
 function assertActionMetadataIdentity(filePath, metadata) {
   const fileId = basename7(filePath).replace(/\.ya?ml$/i, "");
   if (metadata.id !== fileId) {
-    throw new Error(`Action metadata id ${metadata.id} does not match filename identity ${fileId}.`);
+    throw new ActionMetadataIdentityError(metadata.id, fileId);
   }
 }
 function withMetadata(action, metadata) {
@@ -30248,7 +30248,7 @@ function withMetadata(action, metadata) {
 function withBody(action, body) {
   return { ...action, body };
 }
-var SaveActionPreconditionError;
+var SaveActionPreconditionError, ActionMetadataIdentityError;
 var init_action_store = __esm({
   "packages/rn-dev-agent-core/dist/domain/action-store.js"() {
     "use strict";
@@ -30264,6 +30264,16 @@ var init_action_store = __esm({
       constructor(filePath) {
         super(`saveAction precondition violated: yaml at ${filePath} has been edited externally since the in-memory action was loaded. The caller must invoke actionWasEditedExternally() first and abort on true (or use saveActionWithCAS for atomic detection). GH #113 contract enforcement.`);
         this.name = "SaveActionPreconditionError";
+      }
+    };
+    ActionMetadataIdentityError = class extends Error {
+      metadataId;
+      fileId;
+      constructor(metadataId, fileId) {
+        super(`Action metadata id ${metadataId} does not match filename identity ${fileId}.`);
+        this.metadataId = metadataId;
+        this.fileId = fileId;
+        this.name = "ActionMetadataIdentityError";
       }
     };
   }
@@ -32053,8 +32063,13 @@ function readLoginPrologueOutcome(value) {
   }
   return candidate;
 }
-function lockedE2eProofAllowed(tool) {
-  return LOCKED_E2E_LOGIN_TOOLS.includes(tool);
+function lockedE2eProofAllowed(tool, args) {
+  if (tool === "cdp_lock_e2e_test")
+    return args.actionId === LOGIN_PROLOGUE_ALIAS;
+  if (tool === "cdp_run_e2e_suite") {
+    return args.pattern === `^${LOGIN_PROLOGUE_ALIAS}$`;
+  }
+  return false;
 }
 function cleanupAllowed(tool, args) {
   if (tool === "cdp_login_prologue")
@@ -32081,7 +32096,7 @@ function tokenMatches(expected, supplied) {
 }
 function inspectLoginPrologueGuard(input) {
   const outcome = readLoginPrologueOutcome(input.binding);
-  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool)) {
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool, input.args)) {
     return { blocked: false };
   }
   return {
@@ -32097,14 +32112,13 @@ function authorizeLoginSupervisorOverride(input) {
 function appendLoginOverrideAudit(outcome, audit) {
   return { ...outcome, overrides: [...outcome.overrides ?? [], audit].slice(-20) };
 }
-var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, ACTION_LOGIN_HELPER, LOCKED_E2E_LOGIN_TOOLS;
+var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, ACTION_LOGIN_HELPER;
 var init_login_prologue = __esm({
   "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
     "use strict";
     LOGIN_PROLOGUE_ALIAS = "user-login";
     LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
     ACTION_LOGIN_HELPER = "ACTION_LOGIN_HELPER";
-    LOCKED_E2E_LOGIN_TOOLS = ["cdp_lock_e2e_test", "cdp_run_e2e_suite"];
   }
 });
 
@@ -80994,6 +81008,9 @@ function parseEnvelope2(result) {
     return { ok: false, code: "BAD_RESPONSE", error: "Action replay returned invalid JSON." };
   }
 }
+function isLoginActionIdentityMismatch(error2) {
+  return error2 instanceof ActionMetadataIdentityError && (error2.fileId === LOGIN_PROLOGUE_ALIAS || error2.metadataId === LOGIN_PROLOGUE_ALIAS);
+}
 function createLoginPrologueHandler(deps) {
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
   return async (args) => {
@@ -81040,8 +81057,16 @@ function createLoginPrologueHandler(deps) {
       });
     };
     try {
-      inventory = await measure("inventory", () => listActions(projectRoot));
-      const action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
+      let action;
+      try {
+        inventory = await measure("inventory", () => listActions(projectRoot));
+        action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
+      } catch (error2) {
+        if (isLoginActionIdentityMismatch(error2)) {
+          return blocked("LOGIN_ACTION_ID_MISMATCH", `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
+        }
+        throw error2;
+      }
       if (!action) {
         return blocked("LOGIN_ACTION_MISSING", `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
       }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32182,7 +32182,8 @@ function loadLockedTest(projectRoot, id) {
   const filePath = e2ePathFor(projectRoot, id);
   if (!existsSync22(filePath))
     return null;
-  return parseLockedTest(readFileSync24(filePath, "utf8"), filePath);
+  const locked = parseLockedTest(readFileSync24(filePath, "utf8"), filePath);
+  return locked?.id === id ? locked : null;
 }
 function discoverLockedTests(projectRoot) {
   const dir = e2eDirFor(projectRoot);
@@ -32200,6 +32201,12 @@ function resolveLockedTestIds(projectRoot, pattern, discover2 = discoverLockedTe
   } catch {
     return ids;
   }
+}
+function resolveLockedTestIdentityIds(projectRoot, pattern, discover2 = discoverLockedTests, load = loadLockedTest) {
+  return resolveLockedTestIds(projectRoot, pattern, discover2).filter((id) => {
+    const locked = load(projectRoot, id);
+    return locked?.id === id && locked.sourceActionId === id;
+  });
 }
 function setResolvedLockedTestIds(args, ids) {
   Object.defineProperty(args, resolvedLockedTestIds, {
@@ -32929,8 +32936,19 @@ function parseLoginPrologueOutcome(result) {
     return null;
   }
 }
-function missingLoginPrologueOutcome() {
+function missingLoginPrologueOutcome(result) {
   const timestamp = (/* @__PURE__ */ new Date()).toISOString();
+  let failure = {
+    code: "LOGIN_PROLOGUE_RESULT_INVALID",
+    detail: "The login prologue returned no valid terminal state."
+  };
+  try {
+    const envelope = JSON.parse(result.content?.[0]?.text ?? "{}");
+    if (envelope.code === "BUSY_FLOW_ACTIVE" && typeof envelope.error === "string") {
+      failure = { code: envelope.code, detail: envelope.error };
+    }
+  } catch {
+  }
   return {
     schemaVersion: 1,
     state: LOGIN_PROLOGUE_BLOCKED,
@@ -32940,10 +32958,7 @@ function missingLoginPrologueOutcome() {
     elapsedMs: 0,
     steps: [],
     inventory: { count: 0, actionIds: [] },
-    failure: {
-      code: "LOGIN_PROLOGUE_RESULT_INVALID",
-      detail: "The login prologue returned no valid terminal state."
-    }
+    failure
   };
 }
 function pendingLoginPrologueOutcome(attemptId) {
@@ -33909,8 +33924,8 @@ function createAuthorityGate(runtime, dependencies) {
         if (tool === "cdp_login_prologue") {
           loginPrologueOutcome = parseLoginPrologueOutcome(result);
           if (!loginPrologueOutcome) {
-            loginPrologueOutcome = missingLoginPrologueOutcome();
-            result = failResult("Login prologue returned no valid terminal state.", "LOGIN_PROLOGUE_BLOCKED", { loginPrologue: loginPrologueOutcome });
+            loginPrologueOutcome = missingLoginPrologueOutcome(result);
+            result = failResult(`Login prologue blocked: ${loginPrologueOutcome.failure?.detail ?? "The login prologue returned no valid terminal state."}`, "LOGIN_PROLOGUE_BLOCKED", { loginPrologue: loginPrologueOutcome });
           }
           if (loginPrologueOutcome.state === LOGIN_PROLOGUE_BLOCKED) {
             const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
@@ -93423,7 +93438,7 @@ var init_index = __esm({
         if (typeof projectRoot !== "string")
           return [];
         args.projectRoot = projectRoot;
-        return resolveLockedTestIds(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
+        return resolveLockedTestIdentityIds(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
       },
       probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
       recoverRuntimeConnection: async (status) => {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32798,6 +32798,23 @@ function missingLoginPrologueOutcome() {
     }
   };
 }
+function pendingLoginPrologueOutcome() {
+  const timestamp = (/* @__PURE__ */ new Date()).toISOString();
+  return {
+    schemaVersion: 1,
+    state: LOGIN_PROLOGUE_BLOCKED,
+    alias: LOGIN_PROLOGUE_ALIAS,
+    startedAt: timestamp,
+    endedAt: timestamp,
+    elapsedMs: 0,
+    steps: [],
+    inventory: { count: 0, actionIds: [] },
+    failure: {
+      code: "LOGIN_PROLOGUE_IN_PROGRESS",
+      detail: "The login prologue has not completed authoritative validation."
+    }
+  };
+}
 function persistLoginPrologueOutcome(runtime, registry2, operation, status, outcome) {
   const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
   const overrides = outcome.overrides ?? priorOutcome?.overrides;
@@ -33067,6 +33084,13 @@ function createAuthorityGate(runtime, dependencies) {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
           overrideRejected: loginDecision.suppliedOverride,
           nextAction: "Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call."
+        });
+      }
+      if (loginDecision.override && profile.kind === "transition") {
+        return failResult("LOGIN_PROLOGUE_BLOCKED: supervisor overrides cannot authorize transition mutations.", "LOGIN_PROLOGUE_BLOCKED", {
+          loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
+          transitionOverrideRejected: true,
+          nextAction: "Repair the exact user-login action and rerun cdp_login_prologue before this transition."
         });
       }
       if (profile.kind === "diagnostic") {
@@ -33689,6 +33713,11 @@ function createAuthorityGate(runtime, dependencies) {
             throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
           }
           const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, loginDecision.audit));
+          operation = persisted.operation;
+          status = persisted.status;
+        }
+        if (tool === "cdp_login_prologue") {
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome());
           operation = persisted.operation;
           status = persisted.status;
         }
@@ -80280,8 +80309,9 @@ function createRunActionHandler(deps = {}) {
     });
     try {
       let atRisk = null;
+      const cdpFallbackForbidden = args.cdpFallbackMode === "forbid";
       const inheritedBlindProbeDisabled = process.env.RN_BLIND_PROBE === "0" || process.env.RN_BLIND_PROBE === "false";
-      const blindProbeDisabled = args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
+      const blindProbeDisabled = cdpFallbackForbidden || args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
       if (args.platform !== "android") {
         const ctx = await blindProbeContext2().catch(() => null);
         if (ctx) {
@@ -80467,7 +80497,7 @@ function createRunActionHandler(deps = {}) {
         }
       }
       let cdpJsFallback;
-      if (failure.kind === "SELECTOR_NOT_FOUND" || failure.kind === "UNKNOWN") {
+      if (!cdpFallbackForbidden && (failure.kind === "SELECTOR_NOT_FOUND" || failure.kind === "UNKNOWN")) {
         const candidate = getReplayDeps(args);
         const replayDeps = candidate && await claimBundleAuthority(args) ? candidate : null;
         const probe = !replayDeps ? null : failure.kind === "SELECTOR_NOT_FOUND" ? failure.selector : firstReplayTestId(cdpReplayYaml, args.params ?? {});
@@ -80948,6 +80978,7 @@ function createLoginPrologueHandler(deps) {
         forceReload: false,
         proofReplay: false,
         blindProbeMode: "forbid",
+        cdpFallbackMode: "forbid",
         trigger: args.trigger ?? "agent"
       });
       let replayResult;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32796,12 +32796,13 @@ function missingLoginPrologueOutcome() {
     }
   };
 }
-function pendingLoginPrologueOutcome() {
+function pendingLoginPrologueOutcome(attemptId) {
   const timestamp = (/* @__PURE__ */ new Date()).toISOString();
   return {
     schemaVersion: 1,
     state: LOGIN_PROLOGUE_BLOCKED,
     alias: LOGIN_PROLOGUE_ALIAS,
+    attemptId,
     startedAt: timestamp,
     endedAt: timestamp,
     elapsedMs: 0,
@@ -33045,6 +33046,8 @@ function createAuthorityGate(runtime, dependencies) {
   return {
     wrap: (tool, handler) => async (...handlerArgs) => {
       const args = handlerArgs[0] && typeof handlerArgs[0] === "object" ? handlerArgs[0] : {};
+      const suppliedSupervisorOverrideToken = typeof args.supervisorOverrideToken === "string" ? args.supervisorOverrideToken : void 0;
+      delete args.supervisorOverrideToken;
       const baseProfile = authorityProfileFor(tool, args);
       let profile = tool === "rn_session" && (args.action === "status" || args.action === "preview_integration" || args.action === "accept_handoff" || args.action === "adopt_stale") ? {
         kind: "diagnostic",
@@ -33075,8 +33078,7 @@ function createAuthorityGate(runtime, dependencies) {
         args,
         mutation: profile.mutation
       });
-      const pendingSupervisorOverrideToken = loginGuard.blocked ? loginGuard.suppliedOverride : void 0;
-      delete args.supervisorOverrideToken;
+      const pendingSupervisorOverrideToken = loginGuard.blocked ? suppliedSupervisorOverrideToken : void 0;
       if (loginGuard.blocked && pendingSupervisorOverrideToken === void 0) {
         return failResult("LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.", "LOGIN_PROLOGUE_BLOCKED", {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
@@ -33354,7 +33356,8 @@ function createAuthorityGate(runtime, dependencies) {
           throw new SessionAuthorityError(initialStatus.code, initialStatus.reason);
         }
         let status = initialStatus;
-        if (tool !== "cdp_login_prologue") {
+        const deferredAdmissionChecks = tool === "cdp_login_prologue" || pendingSupervisorOverrideToken !== void 0;
+        if (!deferredAdmissionChecks) {
           requireCompleteAxes(status, profile);
           bindSessionArguments(status, profile, args, tool);
         }
@@ -33364,10 +33367,29 @@ function createAuthorityGate(runtime, dependencies) {
           profile: profile.axes.join("")
         });
         if (tool === "cdp_login_prologue") {
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome());
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome(operation.operationId));
           operation = persisted.operation;
           status = persisted.status;
           loginPrologueAttemptOperationId = operation.operationId;
+          requireCompleteAxes(status, profile);
+          bindSessionArguments(status, profile, args, tool);
+        }
+        if (pendingSupervisorOverrideToken !== void 0) {
+          const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+          if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
+          }
+          const audit = authorizeLoginSupervisorOverride({
+            expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
+            suppliedOverrideToken: pendingSupervisorOverrideToken,
+            tool
+          });
+          if (!audit) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the supervisor override token was rejected under the operation fence");
+          }
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, audit));
+          operation = persisted.operation;
+          status = persisted.status;
           requireCompleteAxes(status, profile);
           bindSessionArguments(status, profile, args, tool);
         }
@@ -33716,23 +33738,6 @@ function createAuthorityGate(runtime, dependencies) {
             }
           });
         }
-        if (pendingSupervisorOverrideToken !== void 0) {
-          const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
-          if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
-            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
-          }
-          const audit = authorizeLoginSupervisorOverride({
-            expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
-            suppliedOverrideToken: pendingSupervisorOverrideToken,
-            tool
-          });
-          if (!audit) {
-            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the supervisor override token was rejected under the operation fence");
-          }
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, audit));
-          operation = persisted.operation;
-          status = persisted.status;
-        }
         registry2.verifyOperation(operation);
         const snapshotCheckpoint = dependencies.snapshotCaptureCheckpoint?.();
         let result = await registry2.runWithOperation(operation, () => handler(...handlerArgs));
@@ -33919,7 +33924,7 @@ function createAuthorityGate(runtime, dependencies) {
         }
         if (operation && loginPrologueOutcome?.state === "passed") {
           const pendingOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
-          if (operation.operationId !== loginPrologueAttemptOperationId || pendingOutcome?.state !== LOGIN_PROLOGUE_BLOCKED || pendingOutcome.failure?.code !== "LOGIN_PROLOGUE_IN_PROGRESS") {
+          if (operation.operationId !== loginPrologueAttemptOperationId || pendingOutcome?.state !== LOGIN_PROLOGUE_BLOCKED || pendingOutcome.attemptId !== loginPrologueAttemptOperationId || pendingOutcome.failure?.code !== "LOGIN_PROLOGUE_IN_PROGRESS") {
             throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the passing login result does not match the active blocked attempt");
           }
           const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
@@ -76497,7 +76502,7 @@ var init_redact = __esm({
       /\b\d{3}[-.]\d{3}[-.]\d{4}\b/g,
       /\b\d{3}-\d{2}-\d{4}\b/g
     ];
-    AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
+    AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|supervisorOverrideToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
     MAX_STRING_LENGTH = 2e3;
   }
 });
@@ -80103,6 +80108,10 @@ function classifyFailure(failure) {
       return { actionCode: "UNKNOWN", toolCode: void 0 };
   }
 }
+function strictEnginePinDivergence(env) {
+  const status = env.data?.enginePin?.status;
+  return typeof status === "string" && PROVEN_ENGINE_PIN_DIVERGENCE.has(status) ? status : null;
+}
 function parseEnvelope(toolResult, toolName) {
   try {
     return JSON.parse(toolResult.content?.[0]?.text ?? "{}");
@@ -80333,6 +80342,7 @@ function createRunActionHandler(deps = {}) {
     try {
       let atRisk = null;
       const strictExecutor = usesStrictRunActionPolicy(args);
+      const strictRunRecordMeta = (outcome) => strictExecutor && outcome.persistedRunId ? { strictRunRecordId: outcome.persistedRunId } : {};
       const inheritedBlindProbeDisabled = process.env.RN_BLIND_PROBE === "0" || process.env.RN_BLIND_PROBE === "false";
       const blindProbeDisabled = strictExecutor || args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
       if (args.platform !== "android") {
@@ -80433,11 +80443,37 @@ function createRunActionHandler(deps = {}) {
       }));
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, "maestro_run");
-      const firstPassed = firstEnv.ok === true && firstEnv.data?.passed === true;
       const firstOutput = readMaestroOutput(firstEnv);
       const firstFailureDetail = readMaestroFailureDetail(firstEnv, firstOutput);
       const firstDeviceAuthority = readMaestroDeviceAuthority(firstEnv);
       probeDeviceId = firstDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
+      const enginePinDivergence = strictExecutor ? strictEnginePinDivergence(firstEnv) : null;
+      if (enginePinDivergence) {
+        const autoRepair2 = {
+          attempted: false,
+          outcome: "refused",
+          refusedReason: "NOT_REPAIRABLE_KIND",
+          phases: { firstAttemptMs }
+        };
+        const persisted2 = await persistRunWithDevice({
+          timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+          durationMs: Date.now() - t0,
+          status: "fail",
+          failureCode: "UNKNOWN",
+          failureDetail: `Engine pin status ${enginePinDivergence}`,
+          trigger,
+          autoRepair: autoRepair2
+        });
+        return failResult(`cdp_run_action: ${args.actionId} refused strict replay because the engine pin status is ${enginePinDivergence}.`, "ENGINE_PIN_MISMATCH", {
+          actionId: args.actionId,
+          failureKind: "ENGINE_PIN_MISMATCH",
+          enginePin: firstEnv.data?.enginePin,
+          autoRepair: autoRepair2,
+          writes: writeDisclosure("none", persisted2),
+          ...strictRunRecordMeta(persisted2)
+        });
+      }
+      const firstPassed = firstEnv.ok === true && firstEnv.data?.passed === true;
       if (firstEnv.code) {
         const typedCode = firstEnv.code;
         const autoRepair2 = {
@@ -80460,7 +80496,8 @@ function createRunActionHandler(deps = {}) {
           failureKind: typedCode,
           deviceAuthority: firstDeviceAuthority,
           autoRepair: autoRepair2,
-          writes: writeDisclosure("none", persisted2)
+          writes: writeDisclosure("none", persisted2),
+          ...strictRunRecordMeta(persisted2)
         });
       }
       if (firstPassed) {
@@ -80476,9 +80513,17 @@ function createRunActionHandler(deps = {}) {
           trigger,
           autoRepair: autoRepair2
         });
+        if (strictExecutor && persisted2.persistedRunId !== runId) {
+          return failResult(`cdp_run_action: ${args.actionId} passed, but its authoritative RunRecord was not committed.`, "LOAD_FAILED", {
+            actionId: args.actionId,
+            failureKind: "AUTHORITATIVE_RUN_RECORD_MISSING",
+            writes: writeDisclosure("none", persisted2)
+          });
+        }
         return okResult({
           passed: true,
           actionId: args.actionId,
+          ...strictExecutor ? { strictRunRecordId: persisted2.persistedRunId } : {},
           ...proofReplay ? { proofReplay: true } : {},
           ...replaySuccessEvidence(firstEnv),
           repair: autoRepair2,
@@ -80608,7 +80653,7 @@ function createRunActionHandler(deps = {}) {
           phases: { firstAttemptMs }
         };
         const { actionCode, toolCode } = classifyFailure(failure);
-        await persistRunWithDevice({
+        const persisted2 = await persistRunWithDevice({
           timestamp: (/* @__PURE__ */ new Date()).toISOString(),
           durationMs: Date.now() - t0,
           status: "fail",
@@ -80628,7 +80673,8 @@ function createRunActionHandler(deps = {}) {
           firstAttemptOutput: boundedOutput(firstOutput),
           terminal: readMaestroTerminal(firstEnv),
           runnerResume: firstEnv.meta?.runnerResume,
-          ...cdpJsFallback ? { cdpJsFallback } : {}
+          ...cdpJsFallback ? { cdpJsFallback } : {},
+          ...strictRunRecordMeta(persisted2)
         };
         let message = failure.kind === "WDA_BOOTSTRAP_FAILED" ? `cdp_run_action: ${args.actionId} failed (WDA_BOOTSTRAP_FAILED) before the first replay step: ${failure.detail}. Re-run the replay (bootstrap retries itself); check network access; diagnose the pin-cache runner with ${PINNED_RUNNER_DIAGNOSE_HINT}. Supported correction: ${PINNED_RUNNER_INSTALL_HINT}. Never invoke PATH, ~/.maestro-runner, maestro-cli, or manual login. No preparation or cache mutation was attempted.` : `cdp_run_action: ${args.actionId} failed (${failure.kind})${autoRepairEnabled ? " \u2014 failure not auto-repairable" : " \u2014 auto-repair disabled"}: ${firstFailureDetail}`;
         if (cdpJsFallback?.reason === "cdp-unreachable") {
@@ -80854,7 +80900,7 @@ async function persistRun(actionId, projectRoot, record2) {
           path: fresh.filePath
         }
       });
-      return { promoted, promotionRefused: promotionRefused2 };
+      return { promoted, promotionRefused: promotionRefused2, persistedRunId: record2.runId };
     };
     const promotionRefused = promotes && !promoteActionRuntimeWithCAS(fresh, nextState).ok;
     if (promotes && !promotionRefused)
@@ -80868,7 +80914,7 @@ async function persistRun(actionId, projectRoot, record2) {
   }
   return { promoted: false, promotionRefused: false };
 }
-var strictRunActionPolicy, OUTPUT_BUDGET, OUTPUT_ELISION;
+var strictRunActionPolicy, PROVEN_ENGINE_PIN_DIVERGENCE, OUTPUT_BUDGET, OUTPUT_ELISION;
 var init_run_action = __esm({
   "packages/rn-dev-agent-core/dist/tools/run-action.js"() {
     "use strict";
@@ -80891,6 +80937,7 @@ var init_run_action = __esm({
     init_action_engine_compat();
     init_engine_pin();
     strictRunActionPolicy = /* @__PURE__ */ Symbol("strictRunActionPolicy");
+    PROVEN_ENGINE_PIN_DIVERGENCE = /* @__PURE__ */ new Set(["drift-newer", "drift-older", "checksum-mismatch"]);
     OUTPUT_BUDGET = 500;
     OUTPUT_ELISION = "\n\u2026\n";
   }
@@ -80994,7 +81041,6 @@ function createLoginPrologueHandler(deps) {
       if (action.metadata.id !== LOGIN_PROLOGUE_ALIAS) {
         return blocked("LOGIN_ACTION_ID_MISMATCH", `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
       }
-      const priorRunIds = new Set(action.state.runHistory.map((record2) => record2.runId).filter((runId) => typeof runId === "string"));
       const replayArgs = Object.create(Object.getPrototypeOf(args), Object.getOwnPropertyDescriptors(args));
       Object.assign(replayArgs, {
         actionId: LOGIN_PROLOGUE_ALIAS,
@@ -81015,15 +81061,17 @@ function createLoginPrologueHandler(deps) {
         });
       }
       const replay = parseEnvelope2(replayResult);
+      const strictRunRecordId = typeof replay.data?.strictRunRecordId === "string" ? replay.data.strictRunRecordId : typeof replay.meta?.strictRunRecordId === "string" ? replay.meta.strictRunRecordId : void 0;
       let freshRecord;
       await measure("verify-run-record", async () => {
         const reloaded = loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS);
-        freshRecord = reloaded?.state.runHistory.slice().reverse().find((record2) => typeof record2.runId === "string" && !priorRunIds.has(record2.runId));
+        freshRecord = strictRunRecordId ? reloaded?.state.runHistory.find((record2) => record2.runId === strictRunRecordId) : void 0;
       });
       if (replay.ok !== true || replay.data?.passed !== true) {
-        return blocked(replay.code ?? String(replay.data?.failureKind ?? "ACTION_REPLAY_FAILED"), "The saved login action did not pass; exploratory login is now terminally blocked.", { actionId: LOGIN_PROLOGUE_ALIAS, ...freshRecord ? { runRecord: freshRecord } : {} });
+        const metaFailureKind = replay.meta?.failureKind;
+        return blocked(replay.code ?? (typeof metaFailureKind === "string" ? metaFailureKind : freshRecord?.failureCode ?? "ACTION_REPLAY_FAILED"), "The saved login action did not pass; exploratory login is now terminally blocked.", { actionId: LOGIN_PROLOGUE_ALIAS, ...freshRecord ? { runRecord: freshRecord } : {} });
       }
-      if (!freshRecord || freshRecord.status !== "pass") {
+      if (!strictRunRecordId || !freshRecord || freshRecord.status !== "pass") {
         return blocked("AUTHORITATIVE_RUN_RECORD_MISSING", "The saved login action reported success without a fresh passing RunRecord.", { actionId: LOGIN_PROLOGUE_ALIAS });
       }
       const outcome = finish("passed", {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32053,6 +32053,9 @@ function readLoginPrologueOutcome(value) {
   }
   return candidate;
 }
+function lockedE2eProofAllowed(tool) {
+  return LOCKED_E2E_LOGIN_TOOLS.includes(tool);
+}
 function cleanupAllowed(tool, args) {
   if (tool === "cdp_login_prologue")
     return true;
@@ -32078,7 +32081,7 @@ function tokenMatches(expected, supplied) {
 }
 function inspectLoginPrologueGuard(input) {
   const outcome = readLoginPrologueOutcome(input.binding);
-  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args)) {
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool)) {
     return { blocked: false };
   }
   return {
@@ -32094,12 +32097,14 @@ function authorizeLoginSupervisorOverride(input) {
 function appendLoginOverrideAudit(outcome, audit) {
   return { ...outcome, overrides: [...outcome.overrides ?? [], audit].slice(-20) };
 }
-var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED;
+var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, ACTION_LOGIN_HELPER, LOCKED_E2E_LOGIN_TOOLS;
 var init_login_prologue = __esm({
   "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
     "use strict";
     LOGIN_PROLOGUE_ALIAS = "user-login";
     LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
+    ACTION_LOGIN_HELPER = "ACTION_LOGIN_HELPER";
+    LOCKED_E2E_LOGIN_TOOLS = ["cdp_lock_e2e_test", "cdp_run_e2e_suite"];
   }
 });
 
@@ -73546,6 +73551,7 @@ function projectPublicAuthorityStatus(status, options = {}) {
     proofOverlay: { active: Boolean(status.bindings.proof) },
     ...loginPrologue ? {
       loginPrologue: {
+        role: ACTION_LOGIN_HELPER,
         state: loginPrologue.state,
         alias: loginPrologue.alias,
         actionId: loginPrologue.actionId,
@@ -81014,6 +81020,7 @@ function createLoginPrologueHandler(deps) {
       return {
         schemaVersion: 1,
         state,
+        role: ACTION_LOGIN_HELPER,
         alias: LOGIN_PROLOGUE_ALIAS,
         startedAt: prologueStarted.toISOString(),
         endedAt: ended.toISOString(),
@@ -94409,7 +94416,7 @@ var init_index = __esm({
       blindProbeMode: external_exports.enum(["inherit", "allow", "forbid"]).optional().describe("Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged."),
       params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).")
     }, runActionHandler);
-    trackedTool("cdp_login_prologue", "Inventory learned actions, replay the exact user-login action strictly, and require a fresh passing RunRecord before lifting the session login gate.", {
+    trackedTool("cdp_login_prologue", "Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; not PR proof.", {
       projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
       platform: external_exports.enum(["ios", "android"]).optional().describe("Force a platform; otherwise use the authority-bound device."),
       appFile: external_exports.string().optional().describe("iOS app artifact used only when the saved action contains clearState."),

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32076,22 +32076,20 @@ function tokenMatches(expected, supplied) {
   const suppliedHash = createHash12("sha256").update(supplied).digest();
   return timingSafeEqual5(expectedHash, suppliedHash);
 }
-function evaluateLoginPrologueGuard(input) {
+function inspectLoginPrologueGuard(input) {
   const outcome = readLoginPrologueOutcome(input.binding);
-  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation) {
-    return { allowed: true, override: false };
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args)) {
+    return { blocked: false };
   }
-  if (cleanupAllowed(input.tool, input.args))
-    return { allowed: true, override: false };
-  const supplied = typeof input.args.supervisorOverrideToken === "string" ? input.args.supervisorOverrideToken : void 0;
-  if (tokenMatches(input.expectedOverrideToken, supplied)) {
-    return {
-      allowed: true,
-      override: true,
-      audit: { tool: input.tool, usedAt: (input.now ?? (() => /* @__PURE__ */ new Date()))().toISOString() }
-    };
-  }
-  return { allowed: false, suppliedOverride: supplied !== void 0 };
+  return {
+    blocked: true,
+    suppliedOverride: typeof input.args.supervisorOverrideToken === "string" ? input.args.supervisorOverrideToken : void 0
+  };
+}
+function authorizeLoginSupervisorOverride(input) {
+  if (!tokenMatches(input.expectedOverrideToken, input.suppliedOverrideToken))
+    return null;
+  return { tool: input.tool, usedAt: (input.now ?? (() => /* @__PURE__ */ new Date()))().toISOString() };
 }
 function appendLoginOverrideAudit(outcome, audit) {
   return { ...outcome, overrides: [...outcome.overrides ?? [], audit].slice(-20) };
@@ -33071,22 +33069,22 @@ function createAuthorityGate(runtime, dependencies) {
         liveBundleProbe: tool === "proof_capture"
       } : baseProfile;
       const runtimeStatus = runtime.status();
-      const loginDecision = evaluateLoginPrologueGuard({
+      const loginGuard = inspectLoginPrologueGuard({
         binding: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
         tool,
         args,
-        mutation: profile.mutation,
-        expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.()
+        mutation: profile.mutation
       });
+      const pendingSupervisorOverrideToken = loginGuard.blocked ? loginGuard.suppliedOverride : void 0;
       delete args.supervisorOverrideToken;
-      if (!loginDecision.allowed) {
+      if (loginGuard.blocked && pendingSupervisorOverrideToken === void 0) {
         return failResult("LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.", "LOGIN_PROLOGUE_BLOCKED", {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
-          overrideRejected: loginDecision.suppliedOverride,
+          overrideRejected: false,
           nextAction: "Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call."
         });
       }
-      if (loginDecision.override && profile.kind === "transition") {
+      if (loginGuard.blocked && profile.kind === "transition") {
         return failResult("LOGIN_PROLOGUE_BLOCKED: supervisor overrides cannot authorize transition mutations.", "LOGIN_PROLOGUE_BLOCKED", {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
           transitionOverrideRejected: true,
@@ -33347,6 +33345,7 @@ function createAuthorityGate(runtime, dependencies) {
       let retainProofCleanupFence = false;
       let publishedProofFinalize = false;
       let stagedRuntimeRelaunch;
+      let loginPrologueAttemptOperationId = null;
       try {
         const available = runtime.requireAvailable();
         registry2 = available.registry;
@@ -33355,13 +33354,23 @@ function createAuthorityGate(runtime, dependencies) {
           throw new SessionAuthorityError(initialStatus.code, initialStatus.reason);
         }
         let status = initialStatus;
-        requireCompleteAxes(status, profile);
-        bindSessionArguments(status, profile, args, tool);
+        if (tool !== "cdp_login_prologue") {
+          requireCompleteAxes(status, profile);
+          bindSessionArguments(status, profile, args, tool);
+        }
         operation = registry2.beginOperation(available.session, {
           operationId: randomUUID5(),
           tool,
           profile: profile.axes.join("")
         });
+        if (tool === "cdp_login_prologue") {
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome());
+          operation = persisted.operation;
+          status = persisted.status;
+          loginPrologueAttemptOperationId = operation.operationId;
+          requireCompleteAxes(status, profile);
+          bindSessionArguments(status, profile, args, tool);
+        }
         const preflightRecovery = await reconcileRecoverableRuntime(runtime, dependencies, registry2, operation, status, profile, true);
         operation = preflightRecovery.operation;
         status = preflightRecovery.status;
@@ -33707,17 +33716,20 @@ function createAuthorityGate(runtime, dependencies) {
             }
           });
         }
-        if (loginDecision.override) {
+        if (pendingSupervisorOverrideToken !== void 0) {
           const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
           if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
             throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
           }
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, loginDecision.audit));
-          operation = persisted.operation;
-          status = persisted.status;
-        }
-        if (tool === "cdp_login_prologue") {
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome());
+          const audit = authorizeLoginSupervisorOverride({
+            expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
+            suppliedOverrideToken: pendingSupervisorOverrideToken,
+            tool
+          });
+          if (!audit) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the supervisor override token was rejected under the operation fence");
+          }
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, audit));
           operation = persisted.operation;
           status = persisted.status;
         }
@@ -33906,6 +33918,10 @@ function createAuthorityGate(runtime, dependencies) {
           registry2.commitPlatformAuthorityReceipts(operation);
         }
         if (operation && loginPrologueOutcome?.state === "passed") {
+          const pendingOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+          if (operation.operationId !== loginPrologueAttemptOperationId || pendingOutcome?.state !== LOGIN_PROLOGUE_BLOCKED || pendingOutcome.failure?.code !== "LOGIN_PROLOGUE_IN_PROGRESS") {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the passing login result does not match the active blocked attempt");
+          }
           const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
           operation = persisted.operation;
           status = persisted.status;
@@ -80054,6 +80070,13 @@ var init_runtime = __esm({
 
 // packages/rn-dev-agent-core/dist/tools/run-action.js
 import { randomUUID as randomUUID9 } from "node:crypto";
+function sealStrictRunAction(args) {
+  Object.defineProperty(args, strictRunActionPolicy, { value: true });
+  return args;
+}
+function usesStrictRunActionPolicy(args) {
+  return args[strictRunActionPolicy] === true;
+}
 function boundInstallReceipt() {
   try {
     const status = getWorkerAuthorityRuntime().status();
@@ -80309,9 +80332,9 @@ function createRunActionHandler(deps = {}) {
     });
     try {
       let atRisk = null;
-      const cdpFallbackForbidden = args.cdpFallbackMode === "forbid";
+      const strictExecutor = usesStrictRunActionPolicy(args);
       const inheritedBlindProbeDisabled = process.env.RN_BLIND_PROBE === "0" || process.env.RN_BLIND_PROBE === "false";
-      const blindProbeDisabled = cdpFallbackForbidden || args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
+      const blindProbeDisabled = strictExecutor || args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
       if (args.platform !== "android") {
         const ctx = await blindProbeContext2().catch(() => null);
         if (ctx) {
@@ -80497,7 +80520,7 @@ function createRunActionHandler(deps = {}) {
         }
       }
       let cdpJsFallback;
-      if (!cdpFallbackForbidden && (failure.kind === "SELECTOR_NOT_FOUND" || failure.kind === "UNKNOWN")) {
+      if (!strictExecutor && (failure.kind === "SELECTOR_NOT_FOUND" || failure.kind === "UNKNOWN")) {
         const candidate = getReplayDeps(args);
         const replayDeps = candidate && await claimBundleAuthority(args) ? candidate : null;
         const probe = !replayDeps ? null : failure.kind === "SELECTOR_NOT_FOUND" ? failure.selector : firstReplayTestId(cdpReplayYaml, args.params ?? {});
@@ -80845,7 +80868,7 @@ async function persistRun(actionId, projectRoot, record2) {
   }
   return { promoted: false, promotionRefused: false };
 }
-var OUTPUT_BUDGET, OUTPUT_ELISION;
+var strictRunActionPolicy, OUTPUT_BUDGET, OUTPUT_ELISION;
 var init_run_action = __esm({
   "packages/rn-dev-agent-core/dist/tools/run-action.js"() {
     "use strict";
@@ -80867,6 +80890,7 @@ var init_run_action = __esm({
     init_resolve_ios_app_file();
     init_action_engine_compat();
     init_engine_pin();
+    strictRunActionPolicy = /* @__PURE__ */ Symbol("strictRunActionPolicy");
     OUTPUT_BUDGET = 500;
     OUTPUT_ELISION = "\n\u2026\n";
   }
@@ -80978,9 +81002,9 @@ function createLoginPrologueHandler(deps) {
         forceReload: false,
         proofReplay: false,
         blindProbeMode: "forbid",
-        cdpFallbackMode: "forbid",
         trigger: args.trigger ?? "agent"
       });
+      sealStrictRunAction(replayArgs);
       let replayResult;
       try {
         replayResult = await measure("replay", () => deps.runAction(replayArgs));
@@ -81025,6 +81049,7 @@ var init_login_prologue2 = __esm({
     init_action_store();
     init_login_prologue();
     init_utils();
+    init_run_action();
   }
 });
 

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32085,7 +32085,7 @@ function cleanupAllowed(tool, args) {
   if (tool === "proof_capture" && (args.action === "discard" || args.action === "status")) {
     return true;
   }
-  return tool === "rn_session" && (args.action === "release" || args.action === "stop_metro" || args.action === "cancel_handoff" || args.action === "status");
+  return tool === "rn_session" && (args.action === "release" || args.action === "stop_metro" || args.action === "cancel_handoff" || args.action === "recover_arbiter" && args.confirmed === true || args.action === "status");
 }
 function tokenMatches(expected, supplied) {
   if (!expected || expected.length < 16 || !supplied || supplied.length < 16)

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -23988,8 +23988,8 @@ var init_registry = __esm({
           const handoff = this.#database.prepare("SELECT token_hash, consumed_ms FROM handoffs WHERE handoff_id = ?").get(input.handoffId);
           const expected = Buffer.from(typeof handoff?.token_hash === "string" ? handoff.token_hash : "", "hex");
           const actual = createHash8("sha256").update(input.token).digest();
-          const tokenMatches = expected.length === actual.length && timingSafeEqual4(expected, actual);
-          if (!row || row.state !== "handoff_cleanup" || row.claim_epoch !== target.claimEpoch || row.worker_instance !== input.targetInstance || cleanup?.handoffId !== input.handoffId || cleanup?.targetSessionId !== target.sessionId || cleanup?.targetClaimEpoch !== target.claimEpoch || typeof handoff?.consumed_ms !== "number" || !tokenMatches) {
+          const tokenMatches2 = expected.length === actual.length && timingSafeEqual4(expected, actual);
+          if (!row || row.state !== "handoff_cleanup" || row.claim_epoch !== target.claimEpoch || row.worker_instance !== input.targetInstance || cleanup?.handoffId !== input.handoffId || cleanup?.targetSessionId !== target.sessionId || cleanup?.targetClaimEpoch !== target.claimEpoch || typeof handoff?.consumed_ms !== "number" || !tokenMatches2) {
             throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "handoff cleanup resumption requires the original handoff capability");
           }
         });
@@ -32042,6 +32042,69 @@ var init_install_reissue = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/login-prologue.js
+import { createHash as createHash12, timingSafeEqual as timingSafeEqual5 } from "node:crypto";
+function readLoginPrologueOutcome(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    return null;
+  const candidate = value;
+  if (candidate.schemaVersion !== 1 || candidate.alias !== LOGIN_PROLOGUE_ALIAS || candidate.state !== "passed" && candidate.state !== LOGIN_PROLOGUE_BLOCKED || typeof candidate.startedAt !== "string" || typeof candidate.endedAt !== "string" || typeof candidate.elapsedMs !== "number" || !Array.isArray(candidate.steps)) {
+    return null;
+  }
+  return candidate;
+}
+function cleanupAllowed(tool, args) {
+  if (tool === "cdp_login_prologue")
+    return true;
+  if (tool === "cdp_disconnect")
+    return true;
+  if (tool === "device_snapshot" && args.action === "close")
+    return true;
+  if (tool === "device_record" && (args.action === "stop" || args.action === "status"))
+    return true;
+  if (tool === "observe" && (args.action === "stop" || args.action === "status"))
+    return true;
+  if (tool === "proof_capture" && (args.action === "discard" || args.action === "status")) {
+    return true;
+  }
+  return tool === "rn_session" && (args.action === "release" || args.action === "stop_metro" || args.action === "cancel_handoff" || args.action === "status");
+}
+function tokenMatches(expected, supplied) {
+  if (!expected || expected.length < 16 || !supplied || supplied.length < 16)
+    return false;
+  const expectedHash = createHash12("sha256").update(expected).digest();
+  const suppliedHash = createHash12("sha256").update(supplied).digest();
+  return timingSafeEqual5(expectedHash, suppliedHash);
+}
+function evaluateLoginPrologueGuard(input) {
+  const outcome = readLoginPrologueOutcome(input.binding);
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation) {
+    return { allowed: true, override: false };
+  }
+  if (cleanupAllowed(input.tool, input.args))
+    return { allowed: true, override: false };
+  const supplied = typeof input.args.supervisorOverrideToken === "string" ? input.args.supervisorOverrideToken : void 0;
+  if (tokenMatches(input.expectedOverrideToken, supplied)) {
+    return {
+      allowed: true,
+      override: true,
+      audit: { tool: input.tool, usedAt: (input.now ?? (() => /* @__PURE__ */ new Date()))().toISOString() }
+    };
+  }
+  return { allowed: false, suppliedOverride: supplied !== void 0 };
+}
+function appendLoginOverrideAudit(outcome, audit) {
+  return { ...outcome, overrides: [...outcome.overrides ?? [], audit].slice(-20) };
+}
+var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED;
+var init_login_prologue = __esm({
+  "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
+    "use strict";
+    LOGIN_PROLOGUE_ALIAS = "user-login";
+    LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -32232,7 +32295,7 @@ var init_tool_profiles = __esm({
       "maestro_test_all"
     ];
     hybridMutation = ["cdp_auto_login", "cdp_run_e2e_suite"];
-    optionalHybridMutation = ["cdp_run_action"];
+    optionalHybridMutation = ["cdp_login_prologue", "cdp_run_action"];
     nativeDiagnostic = ["cdp_native_errors"];
     inlineMaestroMutation = /* @__PURE__ */ new Set([
       "device_accept_system_dialog",
@@ -32710,6 +32773,34 @@ function authorityFailure(error2) {
   const code = /^([A-Z][A-Z0-9_]+):/.exec(message)?.[1];
   return failResult(message, code ?? "AUTHORITY_LOST_DURING_OPERATION");
 }
+function parseLoginPrologueOutcome(result) {
+  try {
+    const envelope = JSON.parse(result.content?.[0]?.text ?? "{}");
+    return readLoginPrologueOutcome(envelope.data ?? envelope.meta?.loginPrologue);
+  } catch {
+    return null;
+  }
+}
+function missingLoginPrologueOutcome() {
+  const timestamp = (/* @__PURE__ */ new Date()).toISOString();
+  return {
+    schemaVersion: 1,
+    state: LOGIN_PROLOGUE_BLOCKED,
+    alias: LOGIN_PROLOGUE_ALIAS,
+    startedAt: timestamp,
+    endedAt: timestamp,
+    elapsedMs: 0,
+    steps: [],
+    inventory: { count: 0, actionIds: [] },
+    failure: {
+      code: "LOGIN_PROLOGUE_RESULT_INVALID",
+      detail: "The login prologue returned no valid terminal state."
+    }
+  };
+}
+function isActionReplayTool(tool) {
+  return tool === "cdp_run_action" || tool === "cdp_login_prologue";
+}
 function authorityErrorCode(error2) {
   return error2 instanceof SessionAuthorityError ? error2.code : /^([A-Z][A-Z0-9_]+):/.exec(error2 instanceof Error ? error2.message : String(error2))?.[1];
 }
@@ -32945,10 +33036,43 @@ function createAuthorityGate(runtime, dependencies) {
         mutation: true,
         liveBundleProbe: tool === "proof_capture"
       } : baseProfile;
+      let runtimeStatus = runtime.status();
+      const loginDecision = evaluateLoginPrologueGuard({
+        binding: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
+        tool,
+        args,
+        mutation: profile.mutation,
+        expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.()
+      });
+      delete args.supervisorOverrideToken;
+      if (!loginDecision.allowed) {
+        return failResult("LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.", "LOGIN_PROLOGUE_BLOCKED", {
+          loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
+          overrideRejected: loginDecision.suppliedOverride,
+          nextAction: "Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call."
+        });
+      }
+      if (loginDecision.override) {
+        try {
+          const available = runtime.requireAvailable();
+          const current = runtime.status();
+          const outcome = current.available ? readLoginPrologueOutcome(current.bindings.loginPrologue) : null;
+          if (!outcome) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
+          }
+          available.registry.updateBindings(available.session, {
+            bindings: {
+              loginPrologue: appendLoginOverrideAudit(outcome, loginDecision.audit)
+            }
+          });
+          runtimeStatus = runtime.status();
+        } catch (error2) {
+          return authorityFailure(error2);
+        }
+      }
       if (profile.kind === "diagnostic") {
         return addMeta(await handler(...handlerArgs), { authoritative: false });
       }
-      const runtimeStatus = runtime.status();
       if (runtimeStatus.available && runtimeStatus.state === "blocked") {
         return authorityFailure(runtime.blockedContenderError());
       }
@@ -33562,7 +33686,15 @@ function createAuthorityGate(runtime, dependencies) {
         }
         registry2.verifyOperation(operation);
         const snapshotCheckpoint = dependencies.snapshotCaptureCheckpoint?.();
-        const result = await registry2.runWithOperation(operation, () => handler(...handlerArgs));
+        let result = await registry2.runWithOperation(operation, () => handler(...handlerArgs));
+        let loginPrologueOutcome = null;
+        if (tool === "cdp_login_prologue") {
+          loginPrologueOutcome = parseLoginPrologueOutcome(result);
+          if (!loginPrologueOutcome) {
+            loginPrologueOutcome = missingLoginPrologueOutcome();
+            result = failResult("Login prologue returned no valid terminal state.", "LOGIN_PROLOGUE_BLOCKED", { loginPrologue: loginPrologueOutcome });
+          }
+        }
         let runtimeTargetChanged = false;
         const postHandlerRecovery = await reconcileRecoverableRuntime(runtime, dependencies, registry2, operation, status, profile, resultSucceeded(result));
         operation = postHandlerRecovery.operation;
@@ -33585,7 +33717,7 @@ function createAuthorityGate(runtime, dependencies) {
         }
         publishedProofFinalize = tool === "proof_capture" && args.action === "finalize" && resultIsCanonicalSuccess(result);
         const directRuntimeReset = tool === "cdp_reload" || tool === "cdp_restart";
-        const nestedRuntimeReset = tool === "cdp_run_e2e_suite" || tool === "cdp_auto_login" || tool === "cdp_nav_graph" && args.action === "go" || tool === "cdp_run_action" && (optionalBundleClaimed || optionalBundleRecoveryFailed);
+        const nestedRuntimeReset = tool === "cdp_run_e2e_suite" || tool === "cdp_auto_login" || tool === "cdp_nav_graph" && args.action === "go" || isActionReplayTool(tool) && (optionalBundleClaimed || optionalBundleRecoveryFailed);
         const reconcilesRuntimeTarget = directRuntimeReset || nestedRuntimeReset;
         let authorityInvalidated = false;
         if (directRuntimeReset && !resultSucceeded(result)) {
@@ -33600,7 +33732,7 @@ function createAuthorityGate(runtime, dependencies) {
           const metro = status.bindings.metro;
           let bundle = null;
           try {
-            if (tool === "cdp_run_action" && optionalBundleRecoveryFailed) {
+            if (isActionReplayTool(tool) && optionalBundleRecoveryFailed) {
               throw new SessionAuthorityError("BUNDLE_HANDSHAKE_UNAVAILABLE", "reactive bundle authority did not verify");
             }
             if (!dependencies.refreshRuntimeBinding) {
@@ -33620,7 +33752,7 @@ function createAuthorityGate(runtime, dependencies) {
                 nextAction: 'Run rn_session action "pin_dev_client" before another CDP operation.'
               });
             }
-            if (tool === "cdp_run_action" && !optionalBundleClaimed) {
+            if (isActionReplayTool(tool) && !optionalBundleClaimed) {
               authorityInvalidated = true;
             } else {
               throw error2;
@@ -33682,6 +33814,22 @@ function createAuthorityGate(runtime, dependencies) {
           axes: [...runnerAwareReceiptProfile.axes, "M", "A"]
         } : runnerAwareReceiptProfile;
         const controllerGenerationAdvanced = operation.authorityVersion !== initialOperationAuthorityVersion;
+        if (loginPrologueOutcome) {
+          const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+          operation = registry2.replaceBindingsDuringOperation(operation, {
+            bindings: {
+              loginPrologue: {
+                ...loginPrologueOutcome,
+                ...priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}
+              }
+            }
+          });
+          const loginStatus = runtime.status();
+          if (!loginStatus.available) {
+            throw new SessionAuthorityError(loginStatus.code, loginStatus.reason);
+          }
+          status = loginStatus;
+        }
         registry2.verifyOperation(operation);
         for (const observation of allBefore) {
           if (controllerGenerationAdvanced && observation.axis === "C")
@@ -33779,6 +33927,7 @@ var init_authority_gate = __esm({
     init_registry();
     init_metro_origin();
     init_install_reissue();
+    init_login_prologue();
     init_tool_profiles();
     optionalBundleAdmission = /* @__PURE__ */ Symbol("optionalBundleAdmission");
     managedNativeOrigin = /* @__PURE__ */ Symbol("managedNativeOrigin");
@@ -40472,7 +40621,7 @@ var init_process_cleanup = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/session/startup-cleanup.js
-import { createHash as createHash12 } from "node:crypto";
+import { createHash as createHash13 } from "node:crypto";
 import { join as join35 } from "node:path";
 function startupCleanupFailureMessage() {
   return "rn-dev-agent startup cleanup failed: STARTUP_CLEANUP_FAILED\n";
@@ -40583,7 +40732,7 @@ function restoreDeadOwnerIntegration(input, prior, plan, dependencies) {
 function verifiedDeadOwnerManifestSource(appRoot, binding, manifestSha256) {
   if (!/^[0-9a-f]{64}$/.test(manifestSha256))
     return void 0;
-  const verified = (candidate) => typeof candidate === "string" && createHash12("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
+  const verified = (candidate) => typeof candidate === "string" && createHash13("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
   let liveManifest;
   try {
     liveManifest = readPackageIntegrationInputs(appRoot).manifest ?? void 0;
@@ -64872,7 +65021,7 @@ var require_websocket = __commonJS({
     var http = __require("http");
     var net = __require("net");
     var tls = __require("tls");
-    var { randomBytes: randomBytes9, createHash: createHash24 } = __require("crypto");
+    var { randomBytes: randomBytes9, createHash: createHash25 } = __require("crypto");
     var { Duplex, Readable } = __require("stream");
     var { URL: URL2 } = __require("url");
     var PerMessageDeflate2 = require_permessage_deflate();
@@ -65540,7 +65689,7 @@ var require_websocket = __commonJS({
           abortHandshake(websocket, socket, "Invalid Upgrade header");
           return;
         }
-        const digest3 = createHash24("sha1").update(key + GUID).digest("base64");
+        const digest3 = createHash25("sha1").update(key + GUID).digest("base64");
         if (res.headers["sec-websocket-accept"] !== digest3) {
           abortHandshake(websocket, socket, "Invalid Sec-WebSocket-Accept header");
           return;
@@ -65909,7 +66058,7 @@ var require_websocket_server = __commonJS({
     var EventEmitter = __require("events");
     var http = __require("http");
     var { Duplex } = __require("stream");
-    var { createHash: createHash24 } = __require("crypto");
+    var { createHash: createHash25 } = __require("crypto");
     var extension2 = require_extension();
     var PerMessageDeflate2 = require_permessage_deflate();
     var subprotocol2 = require_subprotocol();
@@ -66216,7 +66365,7 @@ var require_websocket_server = __commonJS({
           );
         }
         if (this._state > RUNNING) return abortHandshake(socket, 503);
-        const digest3 = createHash24("sha1").update(key + GUID).digest("base64");
+        const digest3 = createHash25("sha1").update(key + GUID).digest("base64");
         const headers = [
           "HTTP/1.1 101 Switching Protocols",
           "Upgrade: websocket",
@@ -66996,7 +67145,7 @@ var init_events_client = __esm({
 
 // packages/rn-dev-agent-core/dist/cdp/multiplexer.js
 import { createServer as createServer2 } from "node:http";
-import { randomBytes as randomBytes7, timingSafeEqual as timingSafeEqual5 } from "node:crypto";
+import { randomBytes as randomBytes7, timingSafeEqual as timingSafeEqual6 } from "node:crypto";
 import { Buffer as Buffer2 } from "node:buffer";
 function generateCapabilityToken() {
   return randomBytes7(32).toString("base64url");
@@ -67015,7 +67164,7 @@ function verifyConsumerPath(reqUrl, expectedToken) {
   const b = Buffer2.from(expectedToken);
   if (a.length !== b.length)
     return false;
-  return timingSafeEqual5(a, b);
+  return timingSafeEqual6(a, b);
 }
 function parseRNVersion(raw) {
   if (raw === null || raw === void 0)
@@ -73130,7 +73279,7 @@ var init_install_identity_inspection = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/session/migration-diagnostic.js
-import { createHash as createHash14 } from "node:crypto";
+import { createHash as createHash15 } from "node:crypto";
 import { existsSync as existsSync29, readFileSync as readFileSync31 } from "node:fs";
 import { join as join40 } from "node:path";
 function readPackageIntegrationManifest(appRoot, dependencies) {
@@ -73179,7 +73328,7 @@ function inspectAuthorityMigration(status, dependencies = {}) {
   const integrationBinding = status.bindings.packageIntegration;
   let bindingDiagnostic = null;
   if (integrationBinding) {
-    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash14("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
+    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash15("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
     const manifestAvailable = manifestVerified(onDiskManifestText) || manifestVerified(integrationBinding.restoration?.phase === "started" ? integrationBinding.restoration.manifestSource : void 0) || manifestVerified(integrationBinding.installation?.phase === "started" ? integrationBinding.installation.manifestSource : void 0) || manifestVerified(integrationBinding.manifestSource);
     const effectiveOwnerSessionId = status.sessionId;
     const trustedDigestRecorded = typeof integrationBinding.manifestSha256 === "string" && /^[0-9a-f]{64}$/.test(integrationBinding.manifestSha256);
@@ -73298,6 +73447,7 @@ function projectPublicAuthorityStatus(status, options = {}) {
     observedAt: metroTerminal.observedAt
   } : void 0;
   const sandbox = metro?.runtimeEvidenceAuthority === "managed-sandbox-v1" ? "managed-sandbox-v1" : "unavailable";
+  const loginPrologue = readLoginPrologueOutcome(status.bindings.loginPrologue);
   const phase = derivePublicPhase(status.state, Boolean(status.bindings.pendingBuild));
   return {
     available: true,
@@ -73341,6 +73491,20 @@ function projectPublicAuthorityStatus(status, options = {}) {
     proof: Boolean(status.bindings.proof),
     // ADR §5.2 (L3): strict proof is an opt-in overlay outside the four groups, never a group.
     proofOverlay: { active: Boolean(status.bindings.proof) },
+    ...loginPrologue ? {
+      loginPrologue: {
+        state: loginPrologue.state,
+        alias: loginPrologue.alias,
+        actionId: loginPrologue.actionId,
+        startedAt: loginPrologue.startedAt,
+        endedAt: loginPrologue.endedAt,
+        elapsedMs: loginPrologue.elapsedMs,
+        failureCode: loginPrologue.failure?.code,
+        runId: loginPrologue.runRecord?.runId,
+        overrideCount: loginPrologue.overrides?.length ?? 0,
+        lastOverride: loginPrologue.overrides?.at(-1)
+      }
+    } : {},
     ...options.installIdentity ? { installIdentity: options.installIdentity.verdict } : {},
     // A live axis-I refusal means every gated tool refuses too — status must
     // not read `ready` while that is true. A pending re-issue reads ready only
@@ -73391,13 +73555,14 @@ var init_public_status = __esm({
     "use strict";
     init_migration_diagnostic();
     init_registry();
+    init_login_prologue();
     SELECTED_STATES = /* @__PURE__ */ new Set(["active", "source_bound", "device_claimed", "metro_bound"]);
     RUNNING_STATES = /* @__PURE__ */ new Set(["device_bound", "runtime_bound", "ready"]);
   }
 });
 
 // packages/rn-dev-agent-core/dist/session/build-receipt.js
-import { createHmac as createHmac4, timingSafeEqual as timingSafeEqual6 } from "node:crypto";
+import { createHmac as createHmac4, timingSafeEqual as timingSafeEqual7 } from "node:crypto";
 function serialize(payload) {
   return JSON.stringify(payload);
 }
@@ -73413,7 +73578,7 @@ function verifyBuildReceipt(receipt2, capability, expected) {
   }
   const expectedSignature = Buffer.from(sign(receipt2.payload, capability), "hex");
   const actualSignature = Buffer.from(receipt2.signature, "hex");
-  if (expectedSignature.length !== actualSignature.length || !timingSafeEqual6(expectedSignature, actualSignature)) {
+  if (expectedSignature.length !== actualSignature.length || !timingSafeEqual7(expectedSignature, actualSignature)) {
     throw new Error("BUILD_RECEIPT_INVALID: build receipt signature is invalid");
   }
   for (const [key, value] of Object.entries(expected)) {
@@ -73457,7 +73622,7 @@ var init_device_existence = __esm({
 // packages/rn-dev-agent-core/dist/tools/session.js
 import { dirname as dirname21, isAbsolute as isAbsolute9, join as join41, resolve as resolve15 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { createHash as createHash15 } from "node:crypto";
+import { createHash as createHash16 } from "node:crypto";
 function sameAndroidMetroReverse(current, next) {
   if (!current || !next)
     return current === next;
@@ -73470,7 +73635,7 @@ function sameMetroAuthority(current, next) {
 function verifiedManifestSource(candidate, manifestSha256) {
   if (typeof candidate !== "string" || typeof manifestSha256 !== "string")
     return void 0;
-  return createHash15("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
+  return createHash16("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
 }
 function durableBindingManifestSource(binding) {
   return verifiedManifestSource(binding?.manifestSource, binding?.manifestSha256);
@@ -74413,7 +74578,7 @@ function createSessionHandler(runtime, dependencies = {}) {
             });
           }
           assertPackageIntegrationInactive(status.bindings, input.action);
-          const manifestSha256 = createHash15("sha256").update(manifestSource ?? "").digest("hex");
+          const manifestSha256 = createHash16("sha256").update(manifestSource ?? "").digest("hex");
           if (integrationBinding?.version !== 1 || typeof integrationBinding.installedBySessionId !== "string" || integrationBinding.manifestSha256 !== manifestSha256) {
             throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "integration restoration requires the transferred manifest authority binding");
           }
@@ -74460,7 +74625,7 @@ function createSessionHandler(runtime, dependencies = {}) {
         }
         preview.manifest.metroConfig = metroConfigPath.slice(appRoot.length + 1);
         const expectedManifestSource = installationManifestSource ?? serializePackageIntegrationManifest(preview.manifest);
-        const expectedManifestSha256 = createHash15("sha256").update(expectedManifestSource).digest("hex");
+        const expectedManifestSha256 = createHash16("sha256").update(expectedManifestSource).digest("hex");
         if (installationManifestSource && (integrationBinding?.version !== 1 || integrationBinding.installedBySessionId !== session2.sessionId || integrationBinding.manifestSha256 !== expectedManifestSha256)) {
           throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "integration installation requires the original session manifest authority binding");
         }
@@ -74482,7 +74647,7 @@ function createSessionHandler(runtime, dependencies = {}) {
           if (!installedManifest) {
             throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: applied manifest is unavailable");
           }
-          if (createHash15("sha256").update(installedManifest).digest("hex") !== expectedManifestSha256) {
+          if (createHash16("sha256").update(installedManifest).digest("hex") !== expectedManifestSha256) {
             throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "applied integration manifest no longer matches its durable installation authority");
           }
           registry2.updateBindings(session2, {
@@ -76489,6 +76654,7 @@ var init_events = __esm({
       "maestro_run",
       "maestro_generate",
       "maestro_test_all",
+      "cdp_login_prologue",
       "cdp_run_action",
       "cdp_repair_action",
       "proof_step",
@@ -79855,6 +80021,7 @@ var init_runtime = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/run-action.js
+import { randomUUID as randomUUID9 } from "node:crypto";
 function boundInstallReceipt() {
   try {
     const status = getWorkerAuthorityRuntime().status();
@@ -80061,6 +80228,23 @@ function createRunActionHandler(deps = {}) {
     const trigger = args.trigger ?? "agent";
     const timeoutMs = args.timeoutMs ?? 12e4;
     const t0 = Date.now();
+    const startedAt = new Date(t0).toISOString();
+    const runId = randomUUID9();
+    const timingSteps = [];
+    const measureStep = async (name, run) => {
+      const stepStartedMs = Date.now();
+      try {
+        return await run();
+      } finally {
+        const stepEndedMs = Date.now();
+        timingSteps.push({
+          name,
+          startedAt: new Date(stepStartedMs).toISOString(),
+          endedAt: new Date(stepEndedMs).toISOString(),
+          elapsedMs: Math.max(0, stepEndedMs - stepStartedMs)
+        });
+      }
+    };
     const activeTarget = targetContext();
     if (args.platform && activeTarget?.platform && activeTarget.platform !== args.platform) {
       return failResult(`cdp_run_action: requested ${args.platform}, but the active session is ${activeTarget.platform}; refusing cross-platform replay.`, "TARGET_SESSION_MISMATCH", { requestedPlatform: args.platform, activeSession: activeTarget });
@@ -80070,7 +80254,22 @@ function createRunActionHandler(deps = {}) {
     const appFile = args.appFile ?? (flowUsesClearState(replayYaml) && receipt2?.platform === "ios" && typeof receipt2.appId === "string" && typeof receipt2.deviceId === "string" ? resolveAppFile(receipt2.appId, receipt2.deviceId) ?? void 0 : void 0);
     let probeDeviceId = null;
     let observedDeviceId = maestroDeviceId ?? null;
-    const persistRunWithDevice = (record2) => proofReplay ? Promise.resolve({ promoted: false, promotionRefused: false }) : persistRun(args.actionId, projectRoot, probeDeviceId ? { ...record2, deviceId: probeDeviceId } : record2);
+    const persistRunWithDevice = (record2) => {
+      if (proofReplay)
+        return Promise.resolve({ promoted: false, promotionRefused: false });
+      const endedMs = Date.now();
+      const timedRecord = {
+        ...record2,
+        runId,
+        timing: {
+          startedAt,
+          endedAt: new Date(endedMs).toISOString(),
+          elapsedMs: Math.max(0, endedMs - t0),
+          steps: [...timingSteps]
+        }
+      };
+      return persistRun(args.actionId, projectRoot, probeDeviceId ? { ...timedRecord, deviceId: probeDeviceId } : timedRecord);
+    };
     const writeDisclosure = (actionYaml = "none", outcome) => ({
       actionYaml: actionYaml === "none" ? { written: false, reason: "repair-not-applied" } : actionYaml === "lifecycle-promotion-refused" ? { written: false, reason: "lifecycle-promotion-refused" } : { written: true, authorized: true, reason: actionYaml },
       runtimeState: proofReplay ? "none" : outcome?.runtimeStateRefused ? "refused-external-write" : "sidecar",
@@ -80101,11 +80300,11 @@ function createRunActionHandler(deps = {}) {
         const probe = replayDeps ? firstReplayTestId(cdpReplayYaml, args.params ?? {}) : null;
         if (replayDeps && probe) {
           const tProbe = Date.now();
-          const probeOutcome = await probeTreeWithRetry(replayDeps, probe, probeRetry);
+          const probeOutcome = await measureStep("proactive-probe", () => probeTreeWithRetry(replayDeps, probe, probeRetry));
           if (probeOutcome.found) {
             const tReplay = Date.now();
             try {
-              const replay = await runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps);
+              const replay = await measureStep("proactive-cdp-replay", () => runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps));
               const timings_ms = { probe: tReplay - tProbe, replay: Date.now() - tReplay };
               const blindProbe = { atRisk, skippedMaestro: true };
               const autoRepair2 = {
@@ -80160,7 +80359,7 @@ function createRunActionHandler(deps = {}) {
       }
       const tBeforeFirst = Date.now();
       probeDeviceId = null;
-      const firstResult = await maestroRun({
+      const firstResult = await measureStep("maestro-first-attempt", () => maestroRun({
         inlineYaml: replayYaml,
         actionMetadata: action.metadata,
         platform: args.platform,
@@ -80175,7 +80374,7 @@ function createRunActionHandler(deps = {}) {
         reproveManagedOrigin: () => reproveManagedOrigin(args),
         completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
         reissueInstallReceipt: () => reissueInstallReceipt(args)
-      });
+      }));
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, "maestro_run");
       const firstPassed = firstEnv.ok === true && firstEnv.data?.passed === true;
@@ -80273,7 +80472,7 @@ function createRunActionHandler(deps = {}) {
         } else if (!probe) {
           cdpJsFallback = { attempted: false, reason: "no-probe-testid" };
         } else {
-          const probeOutcome = await probeTreeWithRetry(replayDeps, probe, probeRetry);
+          const probeOutcome = await measureStep("fallback-probe", () => probeTreeWithRetry(replayDeps, probe, probeRetry));
           if (!probeOutcome.found) {
             cdpJsFallback = {
               attempted: false,
@@ -80288,9 +80487,9 @@ function createRunActionHandler(deps = {}) {
               firstAttemptOutput: boundedOutput(firstOutput)
             };
             try {
-              const replay = await runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps, {
+              const replay = await measureStep("fallback-cdp-replay", () => runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps, {
                 resumeAtSelector: failure.kind === "SELECTOR_NOT_FOUND" ? failure.selector : null
-              });
+              }));
               const status = replay.passed ? "pass" : "fail";
               const autoRepair2 = {
                 attempted: false,
@@ -80384,12 +80583,12 @@ function createRunActionHandler(deps = {}) {
         throw new Error("Internal: isAutoRepairable returned true for non-SELECTOR_NOT_FOUND failure");
       }
       const tBeforeRepair = Date.now();
-      const repairResult = await repairAction({
+      const repairResult = await measureStep("selector-repair", () => repairAction({
         actionId: args.actionId,
         failedSelector: failure.selector,
         projectRoot,
         agentReasoning: `auto-repair from cdp_run_action after maestro failure: ${failure.selector}`
-      });
+      }));
       const repairMs = Date.now() - tBeforeRepair;
       const repairEnv = parseEnvelope(repairResult, "cdp_repair_action");
       const repairPatched = repairEnv.ok === true && repairEnv.data?.patched === true;
@@ -80445,10 +80644,11 @@ function createRunActionHandler(deps = {}) {
       if (!reloadedAction.replay.ok) {
         return failResult(`cdp_run_action: repaired action is not valid Maestro YAML: ${reloadedAction.replay.error}`, "BAD_RECORDING", { actionId: args.actionId });
       }
+      const retryYaml = reloadedAction.replay.yamlText;
       const tBeforeRetry = Date.now();
       probeDeviceId = null;
-      const retryResult = await maestroRun({
-        inlineYaml: reloadedAction.replay.yamlText,
+      const retryResult = await measureStep("maestro-retry", () => maestroRun({
+        inlineYaml: retryYaml,
         actionMetadata: reloadedAction.metadata,
         platform: args.platform,
         appId: args.appId,
@@ -80462,7 +80662,7 @@ function createRunActionHandler(deps = {}) {
         reproveManagedOrigin: () => reproveManagedOrigin(args),
         completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
         reissueInstallReceipt: () => reissueInstallReceipt(args)
-      });
+      }));
       const retryMs = Date.now() - tBeforeRetry;
       const retryEnv = parseEnvelope(retryResult, "maestro_run");
       const retryPassed = retryEnv.ok === true && retryEnv.data?.passed === true;
@@ -80635,6 +80835,158 @@ var init_run_action = __esm({
     init_engine_pin();
     OUTPUT_BUDGET = 500;
     OUTPUT_ELISION = "\n\u2026\n";
+  }
+});
+
+// packages/rn-dev-agent-core/dist/domain/action-inventory.js
+async function listActions(projectRoot, dependencies = {}) {
+  const context = openReadableActionLoadContext(projectRoot);
+  if (!context)
+    return [];
+  const load = dependencies.loadAction ?? loadActionFromContext;
+  const yamlFiles = context.files.filter((f) => /\.ya?ml$/.test(f)).sort();
+  const results = [];
+  for (const id of new Set(yamlFiles.map((file) => file.replace(/\.ya?ml$/, "")))) {
+    if (yamlFiles.includes(`${id}.yaml`) && yamlFiles.includes(`${id}.yml`))
+      continue;
+    const action = load(context, id);
+    if (!action)
+      continue;
+    const { metadata } = action;
+    const summary = {
+      id: metadata.id,
+      intent: metadata.intent,
+      status: metadata.status
+    };
+    if (metadata.params !== void 0)
+      summary.params = metadata.params;
+    if (metadata.mutates !== void 0)
+      summary.mutates = metadata.mutates;
+    if (metadata.appId !== void 0)
+      summary.appId = metadata.appId;
+    results.push(summary);
+  }
+  return results;
+}
+var init_action_inventory = __esm({
+  "packages/rn-dev-agent-core/dist/domain/action-inventory.js"() {
+    "use strict";
+    init_action_store();
+  }
+});
+
+// packages/rn-dev-agent-core/dist/tools/login-prologue.js
+function parseEnvelope2(result) {
+  try {
+    return JSON.parse(result.content[0]?.text ?? "{}");
+  } catch {
+    return { ok: false, code: "BAD_RESPONSE", error: "Action replay returned invalid JSON." };
+  }
+}
+function createLoginPrologueHandler(deps) {
+  const now = deps.now ?? (() => /* @__PURE__ */ new Date());
+  return async (args) => {
+    const projectRoot = args.projectRoot ?? process.cwd();
+    const prologueStarted = now();
+    const steps = [];
+    let inventory = [];
+    const measure = async (name, run) => {
+      const started = now();
+      try {
+        return await run();
+      } finally {
+        const ended = now();
+        steps.push({
+          name,
+          startedAt: started.toISOString(),
+          endedAt: ended.toISOString(),
+          elapsedMs: Math.max(0, ended.getTime() - started.getTime())
+        });
+      }
+    };
+    const finish = (state, extra) => {
+      const ended = now();
+      return {
+        schemaVersion: 1,
+        state,
+        alias: LOGIN_PROLOGUE_ALIAS,
+        startedAt: prologueStarted.toISOString(),
+        endedAt: ended.toISOString(),
+        elapsedMs: Math.max(0, ended.getTime() - prologueStarted.getTime()),
+        steps,
+        inventory: { count: inventory.length, actionIds: inventory.map((action) => action.id) },
+        ...extra
+      };
+    };
+    const blocked = (code, detail, extra = {}) => {
+      const outcome = finish(LOGIN_PROLOGUE_BLOCKED, {
+        failure: { code, detail },
+        ...extra
+      });
+      return failResult(`Login prologue blocked: ${detail}`, "LOGIN_PROLOGUE_BLOCKED", {
+        loginPrologue: outcome
+      });
+    };
+    try {
+      inventory = await measure("inventory", () => listActions(projectRoot));
+      const action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
+      if (!action || !inventory.some((candidate) => candidate.id === LOGIN_PROLOGUE_ALIAS)) {
+        return blocked("LOGIN_ACTION_MISSING", `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
+      }
+      const priorRunIds = new Set(action.state.runHistory.map((record2) => record2.runId).filter((runId) => typeof runId === "string"));
+      const replayArgs = {
+        ...args,
+        actionId: LOGIN_PROLOGUE_ALIAS,
+        autoRepair: false,
+        forceReload: false,
+        proofReplay: false,
+        blindProbeMode: "forbid",
+        trigger: args.trigger ?? "agent"
+      };
+      let replayResult;
+      try {
+        replayResult = await measure("replay", () => deps.runAction(replayArgs));
+      } catch (error2) {
+        const code = error2 && typeof error2 === "object" && "code" in error2 ? String(error2.code) : "ACTION_REPLAY_THROW";
+        return blocked(code, "The saved login action threw before producing a result.", {
+          actionId: LOGIN_PROLOGUE_ALIAS
+        });
+      }
+      const replay = parseEnvelope2(replayResult);
+      let freshRecord;
+      await measure("verify-run-record", async () => {
+        const reloaded = loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS);
+        freshRecord = reloaded?.state.runHistory.slice().reverse().find((record2) => typeof record2.runId === "string" && !priorRunIds.has(record2.runId));
+      });
+      if (replay.ok !== true || replay.data?.passed !== true) {
+        return blocked(replay.code ?? String(replay.data?.failureKind ?? "ACTION_REPLAY_FAILED"), "The saved login action did not pass; exploratory login is now terminally blocked.", { actionId: LOGIN_PROLOGUE_ALIAS, ...freshRecord ? { runRecord: freshRecord } : {} });
+      }
+      if (!freshRecord || freshRecord.status !== "pass") {
+        return blocked("AUTHORITATIVE_RUN_RECORD_MISSING", "The saved login action reported success without a fresh passing RunRecord.", { actionId: LOGIN_PROLOGUE_ALIAS });
+      }
+      const outcome = finish("passed", {
+        actionId: LOGIN_PROLOGUE_ALIAS,
+        runRecord: freshRecord,
+        actionResult: {
+          transport: replay.data.transport,
+          transportVersion: replay.data.transportVersion,
+          fallback: replay.data.fallback,
+          perStepReadback: replay.data.perStepReadback
+        }
+      });
+      return okResult(outcome);
+    } catch {
+      return blocked("LOGIN_PROLOGUE_INTERNAL_ERROR", "The login prologue failed before it could prove a passing replay.");
+    }
+  };
+}
+var init_login_prologue2 = __esm({
+  "packages/rn-dev-agent-core/dist/tools/login-prologue.js"() {
+    "use strict";
+    init_action_inventory();
+    init_action_store();
+    init_login_prologue();
+    init_utils();
   }
 });
 
@@ -80995,7 +81347,7 @@ async function hideExpoDevMenu(client2, options = {}) {
       break;
     }
     if (attempt < retries)
-      await new Promise((resolve20) => setTimeout(resolve20, retryDelayMs));
+      await new Promise((resolve21) => setTimeout(resolve21, retryDelayMs));
   }
   return successfulCall ? { ...successfulCall, attempts: outcome.attempts } : outcome;
 }
@@ -81109,7 +81461,7 @@ function createDevSettingsHandler(getClient2, dependencies = {}) {
       const call = await hideExpoDevMenu(client2, { retries: 1 });
       if (!call.callSent)
         return failedHideResult(call, before);
-      await (dependencies.settleAfterHide?.() ?? new Promise((resolve20) => setTimeout(resolve20, 300)));
+      await (dependencies.settleAfterHide?.() ?? new Promise((resolve21) => setTimeout(resolve21, 300)));
       const after = probe ? await probe().catch(() => "unknown") : "unknown";
       if (before === "expo_dev_menu" && after === "app") {
         return okResult({
@@ -82963,7 +83315,7 @@ var init_device_deeplink = __esm({
 
 // packages/rn-dev-agent-core/dist/tools/device-record.js
 import { execFile as execFile22 } from "node:child_process";
-import { createHash as createHash16 } from "node:crypto";
+import { createHash as createHash17 } from "node:crypto";
 import { existsSync as existsSync30 } from "node:fs";
 import { promisify as promisify23 } from "node:util";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
@@ -83111,7 +83463,7 @@ function parseStatusOutput(stdout) {
   return active;
 }
 function recordingScope(args) {
-  return createHash16("sha256").update(`${args.sessionId}\0${args.claimEpoch}\0${args.platform}\0${args.deviceId}`).digest("hex");
+  return createHash17("sha256").update(`${args.sessionId}\0${args.claimEpoch}\0${args.platform}\0${args.deviceId}`).digest("hex");
 }
 function bindRecorderSession(runtime, args) {
   const available = runtime.requireAvailable();
@@ -83395,7 +83747,7 @@ var init_device_record = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/proof-capture.js
-import { createHash as createHash17 } from "node:crypto";
+import { createHash as createHash18 } from "node:crypto";
 function canonicalizeProofValue(value) {
   if (Array.isArray(value))
     return value.map(canonicalizeProofValue);
@@ -83407,14 +83759,14 @@ function hashProofArgs(params) {
   return hashProofValue(redact(params));
 }
 function hashProofValue(value) {
-  return createHash17("sha256").update(JSON.stringify(canonicalizeProofValue(value))).digest("hex");
+  return createHash18("sha256").update(JSON.stringify(canonicalizeProofValue(value))).digest("hex");
 }
 function proofRuntimeAuthorityMarker(input) {
   return hashProofValue(input);
 }
 function hashObservedValue(value) {
   const bytes = JSON.stringify(value) ?? String(value);
-  return createHash17("sha256").update(bytes).digest("hex");
+  return createHash18("sha256").update(bytes).digest("hex");
 }
 function resultEnvelope(result) {
   if (!result || typeof result !== "object")
@@ -83937,7 +84289,7 @@ var init_startup_integrity = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
-import { createHash as createHash18, randomUUID as randomUUID9 } from "node:crypto";
+import { createHash as createHash19, randomUUID as randomUUID10 } from "node:crypto";
 import { execFileSync as execFileSync15 } from "node:child_process";
 import { chmodSync as chmodSync7, closeSync as closeSync12, existsSync as existsSync31, fsyncSync, lstatSync as lstatSync16, mkdirSync as mkdirSync20, openSync as openSync12, readFileSync as readFileSync32, realpathSync as realpathSync14, renameSync as renameSync8, unlinkSync as unlinkSync15, writeFileSync as writeFileSync15 } from "node:fs";
 import { basename as basename11, dirname as dirname24, extname, isAbsolute as isAbsolute11, join as join45, relative as relative8, resolve as resolve17, sep as sep9 } from "node:path";
@@ -83973,7 +84325,7 @@ function evidenceTimingReasons(timestamps, videoDurationMs, steps) {
   return reasons;
 }
 function hashBytes(bytes) {
-  return createHash18("sha256").update(bytes).digest("hex");
+  return createHash19("sha256").update(bytes).digest("hex");
 }
 function captureProofWorkerStartup(argv = process.argv, attestation = readStartupIntegrityAttestation()) {
   let executedEntrypointPath = null;
@@ -84198,7 +84550,7 @@ function readProofActionIdentity(appProjectRoot, actionId, dependencies = {}) {
     return {
       id: actionId,
       version: String(action.state.revision),
-      sha256: createHash18("sha256").update(action.yamlText).digest("hex")
+      sha256: createHash19("sha256").update(action.yamlText).digest("hex")
     };
   } catch {
     return null;
@@ -84399,7 +84751,7 @@ function readProofContractAt(moduleUrl = import.meta.url) {
 function writeProofReceiptAtomic(path, receipt2) {
   const directory = dirname24(path);
   mkdirSync20(directory, { recursive: true, mode: 448 });
-  const temporary = resolve17(directory, `.${randomUUID9()}.proof-receipt.tmp`);
+  const temporary = resolve17(directory, `.${randomUUID10()}.proof-receipt.tmp`);
   let descriptor = null;
   try {
     descriptor = openSync12(temporary, "wx", 384);
@@ -85300,7 +85652,7 @@ var init_proof_capture2 = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/proof-media.js
-import { createHash as createHash19 } from "node:crypto";
+import { createHash as createHash20 } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { mkdir as mkdir2, mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir as tmpdir12 } from "node:os";
@@ -85335,7 +85687,7 @@ async function hashAcceptedFile(path) {
   }
 }
 async function sha256File2(path) {
-  const hash = createHash19("sha256");
+  const hash = createHash20("sha256");
   const stream = createReadStream(path);
   for await (const chunk of stream)
     hash.update(chunk);
@@ -88399,7 +88751,7 @@ var init_instrumentation = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/experience/evidence.js
-import { createHash as createHash20, randomUUID as randomUUID10 } from "node:crypto";
+import { createHash as createHash21, randomUUID as randomUUID11 } from "node:crypto";
 import { chmodSync as chmodSync8, existsSync as existsSync33, mkdirSync as mkdirSync21, readFileSync as readFileSync36, renameSync as renameSync9, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
 import { dirname as dirname29, join as join51 } from "node:path";
@@ -88514,7 +88866,7 @@ function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, 
   }).sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen) || a.signature.localeCompare(b.signature)).slice(0, Math.max(0, maxRecords)).sort((a, b) => a.signature.localeCompare(b.signature));
 }
 function experienceSignature(input) {
-  return createHash20("sha256").update(JSON.stringify([
+  return createHash21("sha256").update(JSON.stringify([
     input.classification,
     input.tool,
     input.normalizedSymptomShape,
@@ -88734,7 +89086,7 @@ var init_evidence = __esm({
           recovery: null,
           cleanup: null,
           classification,
-          evidencePointers: [`event:${randomUUID10()}`],
+          evidencePointers: [`event:${randomUUID11()}`],
           tool,
           status: event.status === "ERROR" ? "ERROR" : "FAIL",
           normalizedSymptomShape,
@@ -88780,13 +89132,13 @@ var init_evidence = __esm({
         existing.lastRecoveredAt = now;
         delete existing.unknownReasons.recovery;
         existing.evidencePointers = boundedPointers(existing.evidencePointers, [
-          `event:${randomUUID10()}`
+          `event:${randomUUID11()}`
         ]);
         this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
       }
       write(records) {
         mkdirSync21(this.directory, { recursive: true, mode: 448 });
-        const temp = join51(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID10()}`);
+        const temp = join51(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID11()}`);
         try {
           const sanitized = records.map((record2) => record2.redactionVersion === REDACTION_RULES_VERSION ? record2 : {
             ...sanitizeForEvidence(record2),
@@ -89019,7 +89371,7 @@ var init_live_device = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/observability/e2e-csrf.js
-import { randomBytes as randomBytes8, timingSafeEqual as timingSafeEqual7 } from "node:crypto";
+import { randomBytes as randomBytes8, timingSafeEqual as timingSafeEqual8 } from "node:crypto";
 function makeCsrfToken() {
   return randomBytes8(24).toString("hex");
 }
@@ -89032,7 +89384,7 @@ function isPostAllowed(req, token2) {
     const got = String(gotRaw);
     const a = Buffer.from(got);
     const b = Buffer.from(token2);
-    if (a.length !== b.length || !timingSafeEqual7(a, b)) {
+    if (a.length !== b.length || !timingSafeEqual8(a, b)) {
       return { ok: false, status: 403, reason: "bad csrf token" };
     }
   }
@@ -90283,7 +90635,7 @@ var init_target = __esm({
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
 import { dirname as dirname31, join as join55 } from "node:path";
 import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync10, readFileSync as readFileSync38, readdirSync as readdirSync15, existsSync as existsSync34 } from "node:fs";
-import { createHash as createHash21 } from "node:crypto";
+import { createHash as createHash22 } from "node:crypto";
 function e2eDirFor(projectRoot) {
   return join55(projectRoot, ".rn-agent", "e2e");
 }
@@ -90314,7 +90666,7 @@ function serializeLockedTest(meta) {
 ${meta.flow}`;
 }
 function hashBody(s) {
-  return createHash21("sha256").update(s).digest("hex");
+  return createHash22("sha256").update(s).digest("hex");
 }
 function freezeLockedTest(projectRoot, source, ctx) {
   const filePath = e2ePathFor(projectRoot, source.id);
@@ -91016,43 +91368,6 @@ var init_preflight = __esm({
   }
 });
 
-// packages/rn-dev-agent-core/dist/domain/action-inventory.js
-async function listActions(projectRoot, dependencies = {}) {
-  const context = openReadableActionLoadContext(projectRoot);
-  if (!context)
-    return [];
-  const load = dependencies.loadAction ?? loadActionFromContext;
-  const yamlFiles = context.files.filter((f) => /\.ya?ml$/.test(f)).sort();
-  const results = [];
-  for (const id of new Set(yamlFiles.map((file) => file.replace(/\.ya?ml$/, "")))) {
-    if (yamlFiles.includes(`${id}.yaml`) && yamlFiles.includes(`${id}.yml`))
-      continue;
-    const action = load(context, id);
-    if (!action)
-      continue;
-    const { metadata } = action;
-    const summary = {
-      id: metadata.id,
-      intent: metadata.intent,
-      status: metadata.status
-    };
-    if (metadata.params !== void 0)
-      summary.params = metadata.params;
-    if (metadata.mutates !== void 0)
-      summary.mutates = metadata.mutates;
-    if (metadata.appId !== void 0)
-      summary.appId = metadata.appId;
-    results.push(summary);
-  }
-  return results;
-}
-var init_action_inventory = __esm({
-  "packages/rn-dev-agent-core/dist/domain/action-inventory.js"() {
-    "use strict";
-    init_action_store();
-  }
-});
-
 // packages/rn-dev-agent-core/dist/session/runner-binding.js
 function bindNativeRunner(runtime, target) {
   const { registry: registry2, session: session2 } = runtime.requireAvailable();
@@ -91122,9 +91437,9 @@ var init_runner_binding = __esm({
 
 // packages/rn-dev-agent-core/dist/session/local-authority-probe.js
 import { execFileSync as execFileSync18 } from "node:child_process";
-import { createHash as createHash22 } from "node:crypto";
+import { createHash as createHash23 } from "node:crypto";
 function identity(value) {
-  return createHash22("sha256").update(JSON.stringify(value)).digest("hex");
+  return createHash23("sha256").update(JSON.stringify(value)).digest("hex");
 }
 function objectBinding(status, name) {
   const value = status.bindings[name];
@@ -92038,7 +92353,7 @@ var index_exports = {};
 __export(index_exports, {
   strictProofMonitor: () => strictProofMonitor
 });
-import { createHash as createHash23, createHmac as createHmac5, randomUUID as randomUUID11 } from "node:crypto";
+import { createHash as createHash24, createHmac as createHmac5, randomUUID as randomUUID12 } from "node:crypto";
 import { readFileSync as readFileSync42, rmSync as rmSync12 } from "node:fs";
 import { execFile as execFile23 } from "node:child_process";
 import { promisify as promisify26 } from "node:util";
@@ -92068,7 +92383,10 @@ function trackedTool(name, desc, schema, handler) {
     }
     return result;
   };
-  server2.tool(name, desc, schema, wrapped);
+  server2.tool(name, desc, {
+    ...schema,
+    supervisorOverrideToken: external_exports.string().min(16).optional().describe("Supervisor token for one audited mutation after a blocked login prologue.")
+  }, wrapped);
 }
 async function pinSessionDevClient(status, options, commitBundle) {
   const device = status.bindings.device;
@@ -92521,7 +92839,7 @@ async function main() {
     });
   }
 }
-var pkgPath, pkgVersion, lockfile, diagnosticContractProbe, noLock, client, getClient, configureClientLifecycle, setClient, publishClient, createClient, execFileP, mustOk, makeReplayDeps, server2, strictProofMonitor, experienceRecorder, authorityRuntime, probeForegroundSurface, foreignMetroOriginScanner, createRuntimeAuthorityProbe, localAuthorityProbe, authorityGate, blindProbeContext, mirrorCfg, mirrorManager2, liveEnabled, liveDeps, registeredToolNames, isSessionRuntimeAbsent, persistedAuthorityStatus, getSessionSignerCapability, spawningSupervisorPid, requestWorkerRecycle, sessionHandler, disconnectClientHandler, connectBoundSession, resolveNativeProofDevice, proofReadiness, proofCaptureHandler, e2ePreflight, e2eReload, e2eSuiteHandler, e2eCsrfToken, observeRootResolver, projectRootFor, triggerE2eRun, runActionHandler, observeRunActionHandler, observeTriggerRun, gatedObserveState, shutdown, stopParentWatch;
+var pkgPath, pkgVersion, lockfile, diagnosticContractProbe, noLock, client, getClient, configureClientLifecycle, setClient, publishClient, createClient, execFileP, mustOk, makeReplayDeps, server2, strictProofMonitor, experienceRecorder, authorityRuntime, probeForegroundSurface, foreignMetroOriginScanner, createRuntimeAuthorityProbe, localAuthorityProbe, authorityGate, blindProbeContext, mirrorCfg, mirrorManager2, liveEnabled, liveDeps, registeredToolNames, isSessionRuntimeAbsent, persistedAuthorityStatus, getSessionSignerCapability, spawningSupervisorPid, requestWorkerRecycle, sessionHandler, disconnectClientHandler, connectBoundSession, resolveNativeProofDevice, proofReadiness, proofCaptureHandler, runActionHandler, e2ePreflight, e2eReload, e2eSuiteHandler, e2eCsrfToken, observeRootResolver, projectRootFor, triggerE2eRun, observeRunActionHandler, observeTriggerRun, gatedObserveState, shutdown, stopParentWatch;
 var init_index = __esm({
   "packages/rn-dev-agent-core/dist/index.js"() {
     "use strict";
@@ -92554,6 +92872,7 @@ var init_index = __esm({
     init_repair_action();
     init_save_as_action();
     init_run_action();
+    init_login_prologue2();
     init_cdp_replay_dispatch();
     init_dispatch();
     init_mmkv();
@@ -92793,7 +93112,7 @@ var init_index = __esm({
           runnerInstanceId: runner?.instanceId,
           runnerPid: runner?.pid,
           runnerProcessBirth: runner?.processBirth,
-          runnerCapabilityHash: typeof runner?.capability === "string" ? createHash23("sha256").update(runner.capability).digest("hex") : void 0,
+          runnerCapabilityHash: typeof runner?.capability === "string" ? createHash24("sha256").update(runner.capability).digest("hex") : void 0,
           runnerPort: runner?.port,
           runnerClaim: status.claims.find((claim) => claim.type === "runner")?.key,
           deviceClaim: status.claims.find((claim) => claim.type === "device")?.key
@@ -92926,6 +93245,7 @@ var init_index = __esm({
     });
     localAuthorityProbe = createRuntimeAuthorityProbe(getClient);
     authorityGate = createAuthorityGate(authorityRuntime, {
+      loginSupervisorOverrideToken: () => process.env.RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN,
       probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
       recoverRuntimeConnection: async (status) => {
         const current = getClient();
@@ -92998,7 +93318,7 @@ var init_index = __esm({
           authority: {
             sessionId: status.sessionId,
             claimEpoch: status.claimEpoch,
-            instanceId: randomUUID11(),
+            instanceId: randomUUID12(),
             capability: secret.observeCapability
           }
         };
@@ -93691,7 +94011,7 @@ var init_index = __esm({
           connectedAt: current.connectedAt
         }),
         errorCount: errors.length,
-        errorSha256: createHash23("sha256").update(errorBytes).digest("hex"),
+        errorSha256: createHash24("sha256").update(errorBytes).digest("hex"),
         device: identity2.device,
         runtime: identity2.runtime
       };
@@ -93958,34 +94278,34 @@ var init_index = __esm({
       deviceId: external_exports.string().optional().describe("Authority-bound exact device identifier; normally injected by the session"),
       appId: external_exports.string().optional().describe("Authority-bound app identifier; normally injected by the session")
     }, createRepairActionHandler());
-    trackedTool(
-      "cdp_run_action",
-      `Replay a learned action by id with end-to-end auto-repair. Loads the action from .rn-agent/actions/<actionId>.yaml or .yml, forwards the matching active session's exact device ID to Maestro, rejects mismatched direct runner/WDA evidence, and on a SELECTOR_NOT_FOUND failure automatically invokes cdp_repair_action and retries once. Appends a RunRecord to the sidecar with full auto-repair telemetry (passed/failed/refused/skipped + diff); its Maestro deviceId comes from direct runner evidence, never requested metadata. The repair attempt counts toward cdp_repair_action's 24h budget. Pass autoRepair=false to opt out of auto-repair (returns the raw maestro_run failure verbatim). forceReload defaults true: any human edit to the YAML since the agent's last write is acknowledged as the new baseline so downstream repair does not abort with STALE_TARGET (the right default for active composition). Pass forceReload=false for the strict "respect offline human edits" behavior: a successful replay still appends its RunRecord to the sidecar when only the tracked YAML mtime baseline is stale, while YAML-mutating promotion and repair stay refused. proofReplay=true is reserved for proof_capture rehearsal and requires autoRepair=false plus forceReload=false; it executes without RunRecord, promotion, YAML, sidecar, or DB persistence. The orchestrated home for the L3 self-healing loop \u2014 prefer this over invoking maestro_run + cdp_repair_action manually for any flow you intend to re-run on schedule. blindProbeMode provides per-call control of the proactive CDP/JS compatibility path: inherit (default) honors RN_BLIND_PROBE, allow explicitly enables it for this call, and forbid forces maestro-first for this call.`,
-      {
-        actionId: external_exports.string().describe("Owned action id; resolves one .yaml or .yml file."),
-        projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
-        platform: external_exports.enum(["ios", "android"]).optional().describe("Force a specific platform; otherwise auto-detected from the active device session."),
-        appFile: external_exports.string().optional().describe("GH #705: path to the .app Maestro reinstalls from after a clearState uninstall. Normally omit it \u2014 an iOS clearState flow resolves the bundle from the session's attested install receipt, and the receipt is re-issued after the reinstall so later device_*/maestro_run calls keep working."),
-        autoRepair: external_exports.boolean().optional().describe("Auto-repair on SELECTOR_NOT_FOUND failures. Default true. Pass false to disable (e.g. when investigating a failure manually)."),
-        timeoutMs: external_exports.number().optional().describe("Maestro execution timeout per attempt (ms). Default 120_000."),
-        trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe('RunRecord trigger annotation. Default "agent". CI calls should pass "ci".'),
-        forceReload: external_exports.boolean().optional().describe('GH #173: when true (default), acknowledge any human edit to the YAML as the new baseline before running so downstream repair does not abort with STALE_TARGET. Pass false for the strict Phase 129 "respect external edits" behavior (useful for CI replays of fixed baselines).'),
-        proofReplay: external_exports.boolean().optional().describe("Read-only proof rehearsal mode. Requires autoRepair=false and forceReload=false; never writes action YAML, runtime sidecar, or DB state."),
-        blindProbeMode: external_exports.enum(["inherit", "allow", "forbid"]).optional().describe("Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged."),
-        params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).")
-      },
-      // GH #186: supply a CDP-backed live-route reader so the route-drift guard is
-      // actually active. Without this the handler defaulted getLiveRoute to a no-op
-      // and the drift branch could never fire, silently routing screen-change
-      // failures into fuzzy selector repair.
-      createRunActionHandler({
-        getLiveRoute: () => readLiveRoute(getClient()),
-        replayDeps: makeReplayDeps,
-        blindProbeContext,
-        targetContext: getActiveSession,
-        claimBundleAuthority: claimOptionalBundleAuthority
-      })
-    );
+    runActionHandler = createRunActionHandler({
+      getLiveRoute: () => readLiveRoute(getClient()),
+      replayDeps: makeReplayDeps,
+      blindProbeContext,
+      targetContext: getActiveSession,
+      claimBundleAuthority: claimOptionalBundleAuthority
+    });
+    trackedTool("cdp_run_action", `Replay a learned action by id with end-to-end auto-repair. Loads the action from .rn-agent/actions/<actionId>.yaml or .yml, forwards the matching active session's exact device ID to Maestro, rejects mismatched direct runner/WDA evidence, and on a SELECTOR_NOT_FOUND failure automatically invokes cdp_repair_action and retries once. Appends a RunRecord to the sidecar with full auto-repair telemetry (passed/failed/refused/skipped + diff); its Maestro deviceId comes from direct runner evidence, never requested metadata. The repair attempt counts toward cdp_repair_action's 24h budget. Pass autoRepair=false to opt out of auto-repair (returns the raw maestro_run failure verbatim). forceReload defaults true: any human edit to the YAML since the agent's last write is acknowledged as the new baseline so downstream repair does not abort with STALE_TARGET (the right default for active composition). Pass forceReload=false for the strict "respect offline human edits" behavior: a successful replay still appends its RunRecord to the sidecar when only the tracked YAML mtime baseline is stale, while YAML-mutating promotion and repair stay refused. proofReplay=true is reserved for proof_capture rehearsal and requires autoRepair=false plus forceReload=false; it executes without RunRecord, promotion, YAML, sidecar, or DB persistence. The orchestrated home for the L3 self-healing loop \u2014 prefer this over invoking maestro_run + cdp_repair_action manually for any flow you intend to re-run on schedule. blindProbeMode provides per-call control of the proactive CDP/JS compatibility path: inherit (default) honors RN_BLIND_PROBE, allow explicitly enables it for this call, and forbid forces maestro-first for this call.`, {
+      actionId: external_exports.string().describe("Owned action id; resolves one .yaml or .yml file."),
+      projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
+      platform: external_exports.enum(["ios", "android"]).optional().describe("Force a specific platform; otherwise auto-detected from the active device session."),
+      appFile: external_exports.string().optional().describe("GH #705: path to the .app Maestro reinstalls from after a clearState uninstall. Normally omit it \u2014 an iOS clearState flow resolves the bundle from the session's attested install receipt, and the receipt is re-issued after the reinstall so later device_*/maestro_run calls keep working."),
+      autoRepair: external_exports.boolean().optional().describe("Auto-repair on SELECTOR_NOT_FOUND failures. Default true. Pass false to disable (e.g. when investigating a failure manually)."),
+      timeoutMs: external_exports.number().optional().describe("Maestro execution timeout per attempt (ms). Default 120_000."),
+      trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe('RunRecord trigger annotation. Default "agent". CI calls should pass "ci".'),
+      forceReload: external_exports.boolean().optional().describe('GH #173: when true (default), acknowledge any human edit to the YAML as the new baseline before running so downstream repair does not abort with STALE_TARGET. Pass false for the strict Phase 129 "respect external edits" behavior (useful for CI replays of fixed baselines).'),
+      proofReplay: external_exports.boolean().optional().describe("Read-only proof rehearsal mode. Requires autoRepair=false and forceReload=false; never writes action YAML, runtime sidecar, or DB state."),
+      blindProbeMode: external_exports.enum(["inherit", "allow", "forbid"]).optional().describe("Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged."),
+      params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).")
+    }, runActionHandler);
+    trackedTool("cdp_login_prologue", "Inventory learned actions, replay the exact user-login action strictly, and require a fresh passing RunRecord before lifting the session login gate.", {
+      projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
+      platform: external_exports.enum(["ios", "android"]).optional().describe("Force a platform; otherwise use the authority-bound device."),
+      appFile: external_exports.string().optional().describe("iOS app artifact used only when the saved action contains clearState."),
+      timeoutMs: external_exports.number().optional().describe("Saved-action timeout in milliseconds."),
+      trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe("RunRecord trigger annotation. Default agent."),
+      params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Bindings for the exact user-login action placeholders.")
+    }, createLoginPrologueHandler({ runAction: runActionHandler }));
     trackedTool("cdp_lock_e2e_test", "Promote a verified action into a frozen, locked e2e regression test. Runs the action once strict (no repair); freezes it only if it passes. v1 supports param-free actions only.", {
       actionId: external_exports.string().describe("The action id under .rn-agent/actions to lock"),
       relock: external_exports.boolean().optional().describe("Overwrite an existing locked test"),
@@ -94085,13 +94405,6 @@ var init_index = __esm({
         arbiter.release(L.lease);
       }
     };
-    runActionHandler = createRunActionHandler({
-      getLiveRoute: () => readLiveRoute(getClient()),
-      replayDeps: makeReplayDeps,
-      blindProbeContext,
-      targetContext: getActiveSession,
-      claimBundleAuthority: claimOptionalBundleAuthority
-    });
     observeRunActionHandler = authorityGate.wrap("cdp_run_action", runActionHandler);
     observeTriggerRun = authorityGate.wrap("cdp_run_e2e_suite", async (...raw) => {
       const args = raw[0] ?? {};
@@ -94241,7 +94554,7 @@ var init_index = __esm({
 // packages/rn-dev-agent-core/dist/supervisor.js
 init_lockfile();
 init_parent_watch();
-import { randomUUID as randomUUID12 } from "node:crypto";
+import { randomUUID as randomUUID13 } from "node:crypto";
 import { spawn as spawn10 } from "node:child_process";
 import { lstatSync as lstatSync19, readFileSync as readFileSync43 } from "node:fs";
 import { dirname as dirname33, join as join60, resolve as resolve20 } from "node:path";
@@ -94280,7 +94593,7 @@ init_registry();
 init_managed_metro();
 init_android_metro_reverse();
 init_state_root();
-import { createHash as createHash13, randomBytes as randomBytes6, randomUUID as randomUUID8 } from "node:crypto";
+import { createHash as createHash14, randomBytes as randomBytes6, randomUUID as randomUUID8 } from "node:crypto";
 import { dirname as dirname19 } from "node:path";
 var RELEASABLE_SESSION_STATES = /* @__PURE__ */ new Set([
   "active",
@@ -94410,7 +94723,7 @@ function createSupervisorAuthority(input, dependencies = {}) {
       metroPort,
       observePort,
       ...adoptionRequired ? {
-        recoveryCapabilityHash: createHash13("sha256").update(recoveryCapability).digest("hex"),
+        recoveryCapabilityHash: createHash14("sha256").update(recoveryCapability).digest("hex"),
         adoptionRequired: {
           sessionId: adoptionRequired.sessionId,
           claimEpoch: adoptionRequired.claimEpoch
@@ -94632,7 +94945,7 @@ if (process.env.RN_BRIDGE_SUPERVISOR === "0") {
 `);
   }, spawnWorker2 = function() {
     resolveAuthorityForSpawn2();
-    const workerInstance = randomUUID12();
+    const workerInstance = randomUUID13();
     let workerCwd = process.cwd();
     let spawnAuthorityError = null;
     try {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32798,6 +32798,22 @@ function missingLoginPrologueOutcome() {
     }
   };
 }
+function persistLoginPrologueOutcome(runtime, registry2, operation, status, outcome) {
+  const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+  const nextOperation = registry2.replaceBindingsDuringOperation(operation, {
+    bindings: {
+      loginPrologue: {
+        ...outcome,
+        ...priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}
+      }
+    }
+  });
+  const nextStatus = runtime.status();
+  if (!nextStatus.available) {
+    throw new SessionAuthorityError(nextStatus.code, nextStatus.reason);
+  }
+  return { operation: nextOperation, status: nextStatus };
+}
 function isActionReplayTool(tool) {
   return tool === "cdp_run_action" || tool === "cdp_login_prologue";
 }
@@ -33694,6 +33710,11 @@ function createAuthorityGate(runtime, dependencies) {
             loginPrologueOutcome = missingLoginPrologueOutcome();
             result = failResult("Login prologue returned no valid terminal state.", "LOGIN_PROLOGUE_BLOCKED", { loginPrologue: loginPrologueOutcome });
           }
+          if (loginPrologueOutcome.state === LOGIN_PROLOGUE_BLOCKED) {
+            const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
+            operation = persisted.operation;
+            status = persisted.status;
+          }
         }
         let runtimeTargetChanged = false;
         const postHandlerRecovery = await reconcileRecoverableRuntime(runtime, dependencies, registry2, operation, status, profile, resultSucceeded(result));
@@ -33814,21 +33835,10 @@ function createAuthorityGate(runtime, dependencies) {
           axes: [...runnerAwareReceiptProfile.axes, "M", "A"]
         } : runnerAwareReceiptProfile;
         const controllerGenerationAdvanced = operation.authorityVersion !== initialOperationAuthorityVersion;
-        if (loginPrologueOutcome) {
-          const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
-          operation = registry2.replaceBindingsDuringOperation(operation, {
-            bindings: {
-              loginPrologue: {
-                ...loginPrologueOutcome,
-                ...priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}
-              }
-            }
-          });
-          const loginStatus = runtime.status();
-          if (!loginStatus.available) {
-            throw new SessionAuthorityError(loginStatus.code, loginStatus.reason);
-          }
-          status = loginStatus;
+        if (loginPrologueOutcome?.state === "passed") {
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
+          operation = persisted.operation;
+          status = persisted.status;
         }
         registry2.verifyOperation(operation);
         for (const observation of allBefore) {
@@ -35203,6 +35213,7 @@ var init_device_arbiter = __esm({
     FLOW_TOOLS = /* @__PURE__ */ new Set([
       "maestro_run",
       "maestro_test_all",
+      "cdp_login_prologue",
       "cdp_run_action",
       "cdp_auto_login",
       "cdp_reload",
@@ -80934,15 +80945,15 @@ function createLoginPrologueHandler(deps) {
         return blocked("LOGIN_ACTION_MISSING", `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
       }
       const priorRunIds = new Set(action.state.runHistory.map((record2) => record2.runId).filter((runId) => typeof runId === "string"));
-      const replayArgs = {
-        ...args,
+      const replayArgs = Object.create(Object.getPrototypeOf(args), Object.getOwnPropertyDescriptors(args));
+      Object.assign(replayArgs, {
         actionId: LOGIN_PROLOGUE_ALIAS,
         autoRepair: false,
         forceReload: false,
         proofReplay: false,
         blindProbeMode: "forbid",
         trigger: args.trigger ?? "agent"
-      };
+      });
       let replayResult;
       try {
         replayResult = await measure("replay", () => deps.runAction(replayArgs));

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32185,6 +32185,9 @@ function loadLockedTest(projectRoot, id) {
   const locked = parseLockedTest(readFileSync24(filePath, "utf8"), filePath);
   return locked?.id === id ? locked : null;
 }
+function lockedTestFileExists(projectRoot, id) {
+  return existsSync22(e2ePathFor(projectRoot, id));
+}
 function discoverLockedTests(projectRoot) {
   const dir = e2eDirFor(projectRoot);
   if (!existsSync22(dir))
@@ -32202,11 +32205,13 @@ function resolveLockedTestIds(projectRoot, pattern, discover2 = discoverLockedTe
     return ids;
   }
 }
-function resolveLockedTestIdentityIds(projectRoot, pattern, discover2 = discoverLockedTests, load = loadLockedTest) {
-  return resolveLockedTestIds(projectRoot, pattern, discover2).filter((id) => {
+function resolveLockedTestSelection(projectRoot, pattern, discover2 = discoverLockedTests, load = loadLockedTest) {
+  const ids = resolveLockedTestIds(projectRoot, pattern, discover2);
+  const identitiesValid = ids.every((id) => {
     const locked = load(projectRoot, id);
     return locked?.id === id && locked.sourceActionId === id;
   });
+  return { ids, identitiesValid };
 }
 function setResolvedLockedTestIds(args, ids) {
   Object.defineProperty(args, resolvedLockedTestIds, {
@@ -33528,17 +33533,17 @@ function createAuthorityGate(runtime, dependencies) {
           bindSessionArguments(status, profile, args, tool);
         }
         if (pendingLockedE2eAdmission) {
-          const resolvedLockedTestIds2 = dependencies.resolveLockedE2eTestIds?.(args, status);
-          if (!resolvedLockedTestIds2 || inspectLoginPrologueGuard({
+          const resolvedSelection = dependencies.resolveLockedE2eTestIds?.(args, status);
+          if (!resolvedSelection?.identitiesValid || inspectLoginPrologueGuard({
             binding: status.bindings.loginPrologue,
             tool,
             args,
             mutation: profile.mutation,
-            resolvedLockedTestIds: resolvedLockedTestIds2
+            resolvedLockedTestIds: resolvedSelection.ids
           }).blocked) {
             throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the locked e2e suite did not resolve to the exact user-login candidate");
           }
-          setResolvedLockedTestIds(args, resolvedLockedTestIds2);
+          setResolvedLockedTestIds(args, resolvedSelection.ids);
         }
         operation = registry2.beginOperation(available.session, {
           operationId: randomUUID5(),
@@ -91037,7 +91042,7 @@ async function lockE2eTestCore(args, deps = {}) {
     }
     resolvedParams = resolved.params;
   }
-  if (!args.relock && loadLockedTest(projectRoot, args.actionId)) {
+  if (!args.relock && lockedTestFileExists(projectRoot, args.actionId)) {
     return failResult(`'${args.actionId}' is already locked \u2014 pass relock:true to re-lock`, "ALREADY_LOCKED");
   }
   const session2 = getSession();
@@ -93436,9 +93441,9 @@ var init_index = __esm({
       resolveLockedE2eTestIds: (args, status) => {
         const projectRoot = typeof args.projectRoot === "string" ? args.projectRoot : status.source.appRoot;
         if (typeof projectRoot !== "string")
-          return [];
+          return { ids: [], identitiesValid: false };
         args.projectRoot = projectRoot;
-        return resolveLockedTestIdentityIds(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
+        return resolveLockedTestSelection(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
       },
       probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
       recoverRuntimeConnection: async (status) => {

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -94297,7 +94297,7 @@ var init_index = __esm({
       continueOnError: external_exports.boolean().default(false).describe("When true, ordinary failed steps are recorded and the batch continues. A failed fill with observed or possible mutation always stops later steps."),
       finalSnapshot: external_exports.enum(["salient", "full", "none"]).default("salient").describe("Shape of the batch final_snapshot. salient (default): compact list of only actionable nodes (Button/TextField/Switch/etc) \u2014 far fewer tokens. full: complete node list (legacy). none: skip the implicit trailing snapshot entirely (~1,450 ms saved) for action-only batches you verify via expect_*/cdp_store_state.")
     }, createDeviceBatchHandler(getClient));
-    trackedTool("cdp_auto_login", "Explicit legacy navigation helper that detects an auth screen and runs one project login subflow through maestro_run on the authority-bound device. It is per-call recovery only, never durable login authority or PR proof; prefer a compatible owned learned action.", {
+    trackedTool("cdp_auto_login", "Explicit legacy navigation helper that detects an auth screen and runs one project login subflow through maestro_run on the authority-bound device. It is never login authority or PR proof; use cdp_login_prologue for authenticated journeys.", {
       appId: external_exports.string().optional().describe("App bundle ID override (auto-detected from app.json if omitted)"),
       platform: external_exports.enum(["ios", "android"]).optional().describe("Platform override (auto-detected from session if omitted)")
     }, withConnection(getClient, async (args, client2) => {
@@ -94497,13 +94497,13 @@ var init_index = __esm({
       blindProbeMode: external_exports.enum(["inherit", "allow", "forbid"]).optional().describe("Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged."),
       params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).")
     }, runActionHandler);
-    trackedTool("cdp_login_prologue", "Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; not PR proof.", {
+    trackedTool("cdp_login_prologue", "Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; failure blocks exploratory fallback mutations, and a pass is not PR proof.", {
       projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
-      platform: external_exports.enum(["ios", "android"]).optional().describe("Force a platform; otherwise use the authority-bound device."),
-      appFile: external_exports.string().optional().describe("iOS app artifact used only when the saved action contains clearState."),
+      platform: external_exports.enum(["ios", "android"]).optional().describe("Override the bound platform."),
+      appFile: external_exports.string().optional().describe("iOS app artifact for clearState actions."),
       timeoutMs: external_exports.number().optional().describe("Saved-action timeout in milliseconds."),
-      trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe("RunRecord trigger annotation. Default agent."),
-      params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Bindings for the exact user-login action placeholders.")
+      trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe("Run trigger; default agent."),
+      params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("String user-login bindings.")
     }, createLoginPrologueHandler({ runAction: runActionHandler }));
     trackedTool("cdp_lock_e2e_test", "Promote a verified action into a frozen, locked e2e regression test. Runs the action once strict (no repair); freezes it only if it passes. v1 supports param-free actions only.", {
       actionId: external_exports.string().describe("The action id under .rn-agent/actions to lock"),

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32800,11 +32800,12 @@ function missingLoginPrologueOutcome() {
 }
 function persistLoginPrologueOutcome(runtime, registry2, operation, status, outcome) {
   const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+  const overrides = outcome.overrides ?? priorOutcome?.overrides;
   const nextOperation = registry2.replaceBindingsDuringOperation(operation, {
     bindings: {
       loginPrologue: {
         ...outcome,
-        ...priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}
+        ...overrides ? { overrides } : {}
       }
     }
   });
@@ -33052,7 +33053,7 @@ function createAuthorityGate(runtime, dependencies) {
         mutation: true,
         liveBundleProbe: tool === "proof_capture"
       } : baseProfile;
-      let runtimeStatus = runtime.status();
+      const runtimeStatus = runtime.status();
       const loginDecision = evaluateLoginPrologueGuard({
         binding: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
         tool,
@@ -33067,24 +33068,6 @@ function createAuthorityGate(runtime, dependencies) {
           overrideRejected: loginDecision.suppliedOverride,
           nextAction: "Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call."
         });
-      }
-      if (loginDecision.override) {
-        try {
-          const available = runtime.requireAvailable();
-          const current = runtime.status();
-          const outcome = current.available ? readLoginPrologueOutcome(current.bindings.loginPrologue) : null;
-          if (!outcome) {
-            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
-          }
-          available.registry.updateBindings(available.session, {
-            bindings: {
-              loginPrologue: appendLoginOverrideAudit(outcome, loginDecision.audit)
-            }
-          });
-          runtimeStatus = runtime.status();
-        } catch (error2) {
-          return authorityFailure(error2);
-        }
       }
       if (profile.kind === "diagnostic") {
         return addMeta(await handler(...handlerArgs), { authoritative: false });
@@ -33700,6 +33683,15 @@ function createAuthorityGate(runtime, dependencies) {
             }
           });
         }
+        if (loginDecision.override) {
+          const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+          if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
+          }
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, loginDecision.audit));
+          operation = persisted.operation;
+          status = persisted.status;
+        }
         registry2.verifyOperation(operation);
         const snapshotCheckpoint = dependencies.snapshotCaptureCheckpoint?.();
         let result = await registry2.runWithOperation(operation, () => handler(...handlerArgs));
@@ -33835,11 +33827,6 @@ function createAuthorityGate(runtime, dependencies) {
           axes: [...runnerAwareReceiptProfile.axes, "M", "A"]
         } : runnerAwareReceiptProfile;
         const controllerGenerationAdvanced = operation.authorityVersion !== initialOperationAuthorityVersion;
-        if (loginPrologueOutcome?.state === "passed") {
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
-          operation = persisted.operation;
-          status = persisted.status;
-        }
         registry2.verifyOperation(operation);
         for (const observation of allBefore) {
           if (controllerGenerationAdvanced && observation.axis === "C")
@@ -33888,6 +33875,11 @@ function createAuthorityGate(runtime, dependencies) {
         }
         if (operation && receiptsCommittable) {
           registry2.commitPlatformAuthorityReceipts(operation);
+        }
+        if (operation && loginPrologueOutcome?.state === "passed") {
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
+          operation = persisted.operation;
+          status = persisted.status;
         }
         return addMeta(result, {
           ...nativeOriginMeta(profile, nativeOriginProven),
@@ -80393,7 +80385,8 @@ function createRunActionHandler(deps = {}) {
       const firstFailureDetail = readMaestroFailureDetail(firstEnv, firstOutput);
       const firstDeviceAuthority = readMaestroDeviceAuthority(firstEnv);
       probeDeviceId = firstDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
-      if (firstEnv.code === "DEVICE_AUTHORITY_MISMATCH") {
+      if (firstEnv.code) {
+        const typedCode = firstEnv.code;
         const autoRepair2 = {
           attempted: false,
           outcome: args.autoRepair === false ? "refused" : "skipped",
@@ -80404,14 +80397,14 @@ function createRunActionHandler(deps = {}) {
           timestamp: (/* @__PURE__ */ new Date()).toISOString(),
           durationMs: Date.now() - t0,
           status: "fail",
-          failureCode: "DEVICE_AUTHORITY_MISMATCH",
+          failureCode: typedCode === "DEVICE_AUTHORITY_MISMATCH" ? "DEVICE_AUTHORITY_MISMATCH" : typedCode === "RECONNECT_TIMEOUT" ? "TIMEOUT" : "UNKNOWN",
           failureDetail: firstFailureDetail.slice(0, 1e3),
           trigger,
           autoRepair: autoRepair2
         });
-        return failResult(`cdp_run_action: ${args.actionId} refused replay authority: ${firstFailureDetail}`, "DEVICE_AUTHORITY_MISMATCH", {
+        return failResult(`cdp_run_action: ${args.actionId} refused replay: ${firstFailureDetail}`, typedCode, {
           actionId: args.actionId,
-          failureKind: "DEVICE_AUTHORITY_MISMATCH",
+          failureKind: typedCode,
           deviceAuthority: firstDeviceAuthority,
           autoRepair: autoRepair2,
           writes: writeDisclosure("none", persisted2)
@@ -80941,8 +80934,11 @@ function createLoginPrologueHandler(deps) {
     try {
       inventory = await measure("inventory", () => listActions(projectRoot));
       const action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
-      if (!action || !inventory.some((candidate) => candidate.id === LOGIN_PROLOGUE_ALIAS)) {
+      if (!action) {
         return blocked("LOGIN_ACTION_MISSING", `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
+      }
+      if (action.metadata.id !== LOGIN_PROLOGUE_ALIAS) {
+        return blocked("LOGIN_ACTION_ID_MISMATCH", `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
       }
       const priorRunIds = new Set(action.state.runHistory.map((record2) => record2.runId).filter((runId) => typeof runId === "string"));
       const replayArgs = Object.create(Object.getPrototypeOf(args), Object.getOwnPropertyDescriptors(args));

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32063,11 +32063,11 @@ function readLoginPrologueOutcome(value) {
   }
   return candidate;
 }
-function lockedE2eProofAllowed(tool, args) {
+function lockedE2eProofAllowed(tool, args, resolvedLockedTestIds2) {
   if (tool === "cdp_lock_e2e_test")
     return args.actionId === LOGIN_PROLOGUE_ALIAS;
   if (tool === "cdp_run_e2e_suite") {
-    return args.pattern === `^${LOGIN_PROLOGUE_ALIAS}$`;
+    return resolvedLockedTestIds2?.length === 1 && resolvedLockedTestIds2[0] === LOGIN_PROLOGUE_ALIAS;
   }
   return false;
 }
@@ -32096,7 +32096,7 @@ function tokenMatches(expected, supplied) {
 }
 function inspectLoginPrologueGuard(input) {
   const outcome = readLoginPrologueOutcome(input.binding);
-  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool, input.args)) {
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool, input.args, input.resolvedLockedTestIds)) {
     return { blocked: false };
   }
   return {
@@ -32119,6 +32119,137 @@ var init_login_prologue = __esm({
     LOGIN_PROLOGUE_ALIAS = "user-login";
     LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
     ACTION_LOGIN_HELPER = "ACTION_LOGIN_HELPER";
+  }
+});
+
+// packages/rn-dev-agent-core/dist/domain/e2e-test.js
+import { dirname as dirname18, join as join29 } from "node:path";
+import { mkdirSync as mkdirSync18, writeFileSync as writeFileSync10, renameSync as renameSync8, readFileSync as readFileSync24, readdirSync as readdirSync11, existsSync as existsSync22 } from "node:fs";
+import { createHash as createHash13 } from "node:crypto";
+function e2eDirFor(projectRoot) {
+  return join29(projectRoot, ".rn-agent", "e2e");
+}
+function e2ePathFor(projectRoot, id) {
+  assertValidActionId(id, "e2ePathFor");
+  const dir = e2eDirFor(projectRoot);
+  const file = join29(dir, `${id}.yaml`);
+  assertWithinDir(file, dir);
+  return file;
+}
+function serializeLockedTest(meta) {
+  const header = [
+    "# e2e-locked-test: true",
+    `# id: ${meta.id}`,
+    `# intent: ${meta.intent}`,
+    `# sourceActionId: ${meta.sourceActionId}`,
+    `# lockedAt: ${meta.lockedAt}`,
+    `# lockedGitSha: ${meta.lockedGitSha ?? ""}`,
+    `# sourceContentHash: ${meta.sourceContentHash}`,
+    "# status: locked"
+  ];
+  if (meta.appId)
+    header.push(`# appId: ${meta.appId}`);
+  if (meta.params?.length)
+    header.push(`# params: ${meta.params.join(", ")}`);
+  header.push(FLOW_SENTINEL);
+  return `${header.join("\n")}
+${meta.flow}`;
+}
+function hashBody(s) {
+  return createHash13("sha256").update(s).digest("hex");
+}
+function freezeLockedTest(projectRoot, source, ctx) {
+  const filePath = e2ePathFor(projectRoot, source.id);
+  mkdirSync18(dirname18(filePath), { recursive: true });
+  const meta = {
+    id: source.id,
+    intent: source.intent,
+    sourceActionId: source.sourceActionId,
+    lockedAt: ctx.now().toISOString(),
+    lockedGitSha: ctx.gitSha,
+    sourceContentHash: hashBody(source.flow),
+    status: "locked",
+    params: source.params,
+    appId: source.appId,
+    flow: source.flow
+  };
+  const tmp = `${filePath}.tmp`;
+  writeFileSync10(tmp, serializeLockedTest(meta), "utf8");
+  renameSync8(tmp, filePath);
+  return { ...meta, filePath };
+}
+function loadLockedTest(projectRoot, id) {
+  const filePath = e2ePathFor(projectRoot, id);
+  if (!existsSync22(filePath))
+    return null;
+  return parseLockedTest(readFileSync24(filePath, "utf8"), filePath);
+}
+function discoverLockedTests(projectRoot) {
+  const dir = e2eDirFor(projectRoot);
+  if (!existsSync22(dir))
+    return [];
+  return readdirSync11(dir).filter((f) => f.endsWith(".yaml")).map((f) => f.replace(/\.yaml$/, "")).sort();
+}
+function resolveLockedTestIds(projectRoot, pattern, discover2 = discoverLockedTests) {
+  const ids = discover2(projectRoot);
+  if (!pattern || pattern.length > 256)
+    return ids;
+  try {
+    const matcher = new RegExp(pattern, "i");
+    return ids.filter((id) => matcher.test(id));
+  } catch {
+    return ids;
+  }
+}
+function setResolvedLockedTestIds(args, ids) {
+  Object.defineProperty(args, resolvedLockedTestIds, {
+    value: Object.freeze([...ids]),
+    configurable: true
+  });
+}
+function getResolvedLockedTestIds(args) {
+  return args[resolvedLockedTestIds];
+}
+function parseLockedTest(text, filePath) {
+  if (!/^#\s*e2e-locked-test:\s*true\s*$/m.test(text))
+    return null;
+  const sentinelIdx = text.indexOf(FLOW_SENTINEL);
+  if (sentinelIdx < 0)
+    return null;
+  const headerText = text.slice(0, sentinelIdx);
+  const flowStart = text.indexOf("\n", sentinelIdx);
+  const flow = flowStart >= 0 ? text.slice(flowStart + 1) : "";
+  const field2 = (k) => {
+    const m = headerText.match(new RegExp(`^#\\s*${k}:\\s*(.*)$`, "m"));
+    const v = m?.[1]?.trim();
+    return v ? v : void 0;
+  };
+  const id = field2("id");
+  const intent = field2("intent");
+  if (!id || !intent)
+    return null;
+  const paramsRaw = field2("params");
+  return {
+    id,
+    intent,
+    sourceActionId: field2("sourceActionId") ?? id,
+    lockedAt: field2("lockedAt") ?? "",
+    lockedGitSha: field2("lockedGitSha") ?? null,
+    sourceContentHash: field2("sourceContentHash") ?? "",
+    status: "locked",
+    params: paramsRaw ? paramsRaw.split(",").map((s) => s.trim()).filter(Boolean) : void 0,
+    appId: field2("appId"),
+    flow,
+    filePath
+  };
+}
+var FLOW_SENTINEL, resolvedLockedTestIds;
+var init_e2e_test = __esm({
+  "packages/rn-dev-agent-core/dist/domain/e2e-test.js"() {
+    "use strict";
+    init_path_safety();
+    FLOW_SENTINEL = "# e2e-locked-flow-below";
+    resolvedLockedTestIds = /* @__PURE__ */ Symbol("resolvedLockedTestIds");
   }
 });
 
@@ -33098,7 +33229,8 @@ function createAuthorityGate(runtime, dependencies) {
         mutation: profile.mutation
       });
       const pendingSupervisorOverrideToken = loginGuard.blocked ? suppliedSupervisorOverrideToken : void 0;
-      if (loginGuard.blocked && pendingSupervisorOverrideToken === void 0) {
+      const pendingLockedE2eAdmission = loginGuard.blocked && tool === "cdp_run_e2e_suite" && pendingSupervisorOverrideToken === void 0;
+      if (loginGuard.blocked && pendingSupervisorOverrideToken === void 0 && !pendingLockedE2eAdmission) {
         return failResult("LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.", "LOGIN_PROLOGUE_BLOCKED", {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
           overrideRejected: false,
@@ -33379,6 +33511,19 @@ function createAuthorityGate(runtime, dependencies) {
         if (!deferredAdmissionChecks) {
           requireCompleteAxes(status, profile);
           bindSessionArguments(status, profile, args, tool);
+        }
+        if (pendingLockedE2eAdmission) {
+          const resolvedLockedTestIds2 = dependencies.resolveLockedE2eTestIds?.(args, status);
+          if (!resolvedLockedTestIds2 || inspectLoginPrologueGuard({
+            binding: status.bindings.loginPrologue,
+            tool,
+            args,
+            mutation: profile.mutation,
+            resolvedLockedTestIds: resolvedLockedTestIds2
+          }).blocked) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the locked e2e suite did not resolve to the exact user-login candidate");
+          }
+          setResolvedLockedTestIds(args, resolvedLockedTestIds2);
         }
         operation = registry2.beginOperation(available.session, {
           operationId: randomUUID5(),
@@ -33999,6 +34144,7 @@ var init_authority_gate = __esm({
     init_metro_origin();
     init_install_reissue();
     init_login_prologue();
+    init_e2e_test();
     init_tool_profiles();
     optionalBundleAdmission = /* @__PURE__ */ Symbol("optionalBundleAdmission");
     managedNativeOrigin = /* @__PURE__ */ Symbol("managedNativeOrigin");
@@ -34035,9 +34181,9 @@ var init_authority_gate = __esm({
 // packages/rn-dev-agent-core/dist/tools/maestro-run.js
 import { execFile as execFileCb2 } from "node:child_process";
 import { promisify as promisify3 } from "node:util";
-import { existsSync as existsSync22, readFileSync as readFileSync24, writeFileSync as writeFileSync10 } from "node:fs";
+import { existsSync as existsSync23, readFileSync as readFileSync25, writeFileSync as writeFileSync11 } from "node:fs";
 import { tmpdir as tmpdir7 } from "node:os";
-import { basename as basename10, join as join29, dirname as dirname18 } from "node:path";
+import { basename as basename10, join as join30, dirname as dirname19 } from "node:path";
 async function runFlowParked(run, opts = {}) {
   const stale = opts.markCdpStale ?? markCdpStale;
   try {
@@ -34278,11 +34424,11 @@ function createMaestroRunHandler(deps = {}) {
     } else if (args.inlineYaml) {
       rawYaml = args.inlineYaml;
     } else if (args.flowPath) {
-      if (!existsSync22(args.flowPath)) {
+      if (!existsSync23(args.flowPath)) {
         return failResult(`Flow file not found: ${args.flowPath}`);
       }
       try {
-        rawYaml = readFileSync24(args.flowPath, "utf-8");
+        rawYaml = readFileSync25(args.flowPath, "utf-8");
       } catch (err) {
         return failResult(`Failed to read flow file: ${err.message}`);
       }
@@ -34290,7 +34436,7 @@ function createMaestroRunHandler(deps = {}) {
       return failResult("Provide either flowPath or inlineYaml.");
     }
     try {
-      const runFlowOpts = args.flowPath && flowPathClassification === "outside" ? { flowDir: dirname18(args.flowPath), flowRoot: dirname18(args.flowPath) } : {};
+      const runFlowOpts = args.flowPath && flowPathClassification === "outside" ? { flowDir: dirname19(args.flowPath), flowRoot: dirname19(args.flowPath) } : {};
       const parsed = parseAndValidateFlow(rawYaml, runFlowOpts);
       planMaestroAuthorityStages(parsed.commands);
       validatedCommands = parsed.commands;
@@ -34298,8 +34444,8 @@ function createMaestroRunHandler(deps = {}) {
       const rawAppId = resolveAppId(args.appId, platform);
       headerAppId = resolveMaestroFlowAppId(rawAppId || void 0, parsed.appId);
       validatedContent = buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, parsed.commands);
-      flowFile = join29(tmpdir7(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
-      writeFileSync10(flowFile, validatedContent, "utf-8");
+      flowFile = join30(tmpdir7(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      writeFileSync11(flowFile, validatedContent, "utf-8");
     } catch (err) {
       if (err instanceof MaestroValidationError) {
         return failResult(`Refusing to run Maestro: ${err.message} (Phase 134.1)`);
@@ -34411,7 +34557,7 @@ function createMaestroRunHandler(deps = {}) {
       const relaunchManagedApp = args.relaunchManagedApp ?? deps.relaunchManagedApp ?? managedAuthority.relaunchManagedApp;
       const reproveManagedOrigin = args.reproveManagedOrigin ?? deps.reproveManagedOrigin ?? managedAuthority.reproveManagedOrigin;
       const stageResults = await parkFlow(() => executeMaestroAuthorityStages(validatedCommands, async (commands) => {
-        writeFileSync10(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
+        writeFileSync11(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
         const executeOnce = async (beforeDispatch) => {
           if (flowDeadline - now() <= 0) {
             const error2 = new Error("Maestro flow timeout exhausted before the next stage");
@@ -34654,7 +34800,7 @@ function createMaestroRunHandler(deps = {}) {
       return failResult(failAug.message, failAug.meta);
     } finally {
       try {
-        writeFileSync10(flowFile, validatedContent, "utf-8");
+        writeFileSync11(flowFile, validatedContent, "utf-8");
       } finally {
         disposeRunnerReportDir(runnerReportDir);
       }
@@ -34706,7 +34852,7 @@ var init_maestro_run = __esm({
 
 // packages/rn-dev-agent-core/dist/session/managed-automation.js
 import { spawn as spawn6 } from "node:child_process";
-import { readdirSync as readdirSync11, readFileSync as readFileSync25, unlinkSync as unlinkSync10 } from "node:fs";
+import { readdirSync as readdirSync12, readFileSync as readFileSync26, unlinkSync as unlinkSync10 } from "node:fs";
 function sleep3(ms) {
   return new Promise((resolve21) => setTimeout(resolve21, ms));
 }
@@ -34723,12 +34869,12 @@ function processGroupLiveness(pgid) {
   if (process.platform !== "linux")
     return "unknown";
   try {
-    for (const entry of readdirSync11("/proc", { withFileTypes: true })) {
+    for (const entry of readdirSync12("/proc", { withFileTypes: true })) {
       if (!entry.isDirectory() || !/^\d+$/.test(entry.name))
         continue;
       let stat2;
       try {
-        stat2 = readFileSync25(`/proc/${entry.name}/stat`, "utf8");
+        stat2 = readFileSync26(`/proc/${entry.name}/stat`, "utf8");
       } catch (error2) {
         if (error2.code === "ENOENT")
           continue;
@@ -35344,8 +35490,8 @@ var init_device_arbiter = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/maestro-invoke.js
-import { writeFileSync as writeFileSync11 } from "node:fs";
-import { join as join30 } from "node:path";
+import { writeFileSync as writeFileSync12 } from "node:fs";
+import { join as join31 } from "node:path";
 import { tmpdir as tmpdir8 } from "node:os";
 function yamlEscape(s) {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t");
@@ -35376,7 +35522,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     return { passed: false, output: "", flowFile: "", error: pinRefusal };
   }
   const rawAppId = opts.appId ?? resolveBundleId(opts.platform) ?? readExpoSlug() ?? "";
-  const flowFile = join30(tmpdir8(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+  const flowFile = join31(tmpdir8(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
   let content;
   let headerAppId;
   try {
@@ -35414,7 +35560,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     throw err;
   }
   try {
-    writeFileSync11(flowFile, content, "utf-8");
+    writeFileSync12(flowFile, content, "utf-8");
   } catch (err) {
     return {
       passed: false,
@@ -35786,9 +35932,9 @@ var init_app_lifecycle = __esm({
 
 // packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js
 import { execFileSync as execFileSync13 } from "node:child_process";
-import { existsSync as existsSync23, readFileSync as readFileSync26, unlinkSync as unlinkSync11 } from "node:fs";
+import { existsSync as existsSync24, readFileSync as readFileSync27, unlinkSync as unlinkSync11 } from "node:fs";
 import { homedir as homedir5 } from "node:os";
-import { join as join31 } from "node:path";
+import { join as join32 } from "node:path";
 function selectInstalledLegacyApps(installed) {
   return LEGACY_BUNDLE_IDS.filter((id) => installed.has(id));
 }
@@ -35855,13 +36001,13 @@ function defaultDeps() {
     },
     readDaemonPid: () => {
       try {
-        const parsed = JSON.parse(readFileSync26(DAEMON_JSON, "utf8"));
+        const parsed = JSON.parse(readFileSync27(DAEMON_JSON, "utf8"));
         return typeof parsed.pid === "number" ? parsed.pid : null;
       } catch {
         return null;
       }
     },
-    fileExists: (path) => existsSync23(path),
+    fileExists: (path) => existsSync24(path),
     removeFile: (path) => unlinkSync11(path),
     delay: (ms) => new Promise((resolve21) => setTimeout(resolve21, ms)),
     listApps: (udid) => execFileSync13("xcrun", ["simctl", "listapps", udid], {
@@ -35944,8 +36090,8 @@ var init_ensure_single_runner = __esm({
   "packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js"() {
     "use strict";
     init_discovery();
-    DAEMON_JSON = join31(homedir5(), ".agent-device", "daemon.json");
-    DAEMON_LOCK = join31(homedir5(), ".agent-device", "daemon.lock");
+    DAEMON_JSON = join32(homedir5(), ".agent-device", "daemon.json");
+    DAEMON_LOCK = join32(homedir5(), ".agent-device", "daemon.lock");
     DAEMON_FILES = [DAEMON_JSON, DAEMON_LOCK];
     SIGKILL_GRACE_MS = 500;
     LEGACY_BUNDLE_IDS = [
@@ -36072,9 +36218,9 @@ var init_recover_detached = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/lifecycle/device-lock.js
-import { existsSync as existsSync24, mkdirSync as mkdirSync18, openSync as openSync10, writeSync as writeSync3, closeSync as closeSync10, readFileSync as readFileSync27, unlinkSync as unlinkSync12, writeFileSync as writeFileSync12 } from "node:fs";
+import { existsSync as existsSync25, mkdirSync as mkdirSync19, openSync as openSync10, writeSync as writeSync3, closeSync as closeSync10, readFileSync as readFileSync28, unlinkSync as unlinkSync12, writeFileSync as writeFileSync13 } from "node:fs";
 import { tmpdir as tmpdir9, userInfo as userInfo2 } from "node:os";
-import { join as join32 } from "node:path";
+import { join as join33 } from "node:path";
 function defaultProcessAlive3(pid) {
   try {
     process.kill(pid, 0);
@@ -36127,7 +36273,7 @@ var init_device_lock = __esm({
         this.clock = opts.clock ?? Date.now;
         this.processAlive = opts.processAlive ?? defaultProcessAlive3;
         this.staleMs = opts.staleMs ?? DEVICE_LOCK_STALE_MS;
-        this.lockPath = join32(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
+        this.lockPath = join33(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
       }
       acquire() {
         try {
@@ -36169,7 +36315,7 @@ var init_device_lock = __esm({
           return;
         holder.lastHeartbeat = this.clock();
         try {
-          writeFileSync12(this.lockPath, JSON.stringify(holder, null, 2), "utf8");
+          writeFileSync13(this.lockPath, JSON.stringify(holder, null, 2), "utf8");
         } catch {
         }
       }
@@ -36185,8 +36331,8 @@ var init_device_lock = __esm({
         this.acquired = false;
       }
       create() {
-        if (!existsSync24(this.tmpDir))
-          mkdirSync18(this.tmpDir, { recursive: true });
+        if (!existsSync25(this.tmpDir))
+          mkdirSync19(this.tmpDir, { recursive: true });
         const fd = openSync10(this.lockPath, "wx");
         try {
           const now = this.clock();
@@ -36208,7 +36354,7 @@ var init_device_lock = __esm({
       }
       readExisting() {
         try {
-          const parsed = JSON.parse(readFileSync27(this.lockPath, "utf8"));
+          const parsed = JSON.parse(readFileSync28(this.lockPath, "utf8"));
           if (!isValidBody(parsed))
             return null;
           if (parsed.deviceId !== this.deviceId || parsed.platform !== this.platform)
@@ -38892,10 +39038,10 @@ __export(rn_android_runner_client_exports, {
 });
 import { spawn as spawn7, execFile as execFile12 } from "node:child_process";
 import { promisify as promisify12 } from "node:util";
-import { existsSync as existsSync25, rmSync as rmSync11, writeFileSync as writeFileSync13 } from "node:fs";
+import { existsSync as existsSync26, rmSync as rmSync11, writeFileSync as writeFileSync14 } from "node:fs";
 import { tmpdir as tmpdir10 } from "node:os";
 import { randomBytes as randomBytes5, randomUUID as randomUUID7 } from "node:crypto";
-import { join as join33 } from "node:path";
+import { join as join34 } from "node:path";
 function getAndroidRunnerState() {
   return runnerState2;
 }
@@ -39098,7 +39244,7 @@ async function ensureAndroidRunnerInstalled(deviceId, opts = {}) {
     pendingUpgradeNote = artifacts.note;
   const action = resolveAndroidInstallAction({
     instrumentationRegistered: !opts.forceReinstall && isInstrumentationRegistered(pmOut, INSTRUMENTATION),
-    apksExist: existsSync25(artifacts.appApk) && existsSync25(artifacts.testApk)
+    apksExist: existsSync26(artifacts.appApk) && existsSync26(artifacts.testApk)
   });
   if (action === "reuse")
     return provenance;
@@ -39555,7 +39701,7 @@ function androidRetryCleanupContext(state, error2) {
   return state ?? (error2.deviceId ? { deviceId: error2.deviceId } : null);
 }
 function androidRunnerApksExist() {
-  return RUNNER_APK_PATHS.every((p) => existsSync25(p));
+  return RUNNER_APK_PATHS.every((p) => existsSync26(p));
 }
 function _androidRunnerApkPathsForTest() {
   return RUNNER_APK_PATHS;
@@ -40099,8 +40245,8 @@ async function runAndroid(args) {
     const data = resp.data;
     if (!data?.pngBase64)
       return failResult("Android runner screenshot response did not include pngBase64", "SCREENSHOT_FAILED", recovery ? { transportRecovery: recovery } : void 0);
-    const outPath = args.outPath ?? join33(tmpdir10(), `rn-android-screenshot-${Date.now()}.png`);
-    writeFileSync13(outPath, Buffer.from(data.pngBase64, "base64"));
+    const outPath = args.outPath ?? join34(tmpdir10(), `rn-android-screenshot-${Date.now()}.png`);
+    writeFileSync14(outPath, Buffer.from(data.pngBase64, "base64"));
     return okResult({ path: outPath }, Object.keys(recoveryMeta).length ? { meta: recoveryMeta } : void 0);
   }
   return okResult(resp.data ?? {}, Object.keys(recoveryMeta).length ? { meta: recoveryMeta } : void 0);
@@ -40134,11 +40280,11 @@ var init_rn_android_runner_client = __esm({
     HEALTH_POLL_INTERVAL_MS = 150;
     HEALTH_PROBE_TIMEOUT_MS = 1e3;
     RN_ANDROID_RUNNER_DIR = resolveNativeRunnerDir("rn-android-runner");
-    GRADLEW = join33(RN_ANDROID_RUNNER_DIR, "gradlew");
-    APK_APP = join33(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "debug", "app-debug.apk");
-    APK_TEST = join33(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "androidTest", "debug", "app-debug-androidTest.apk");
-    ANDROID_REBUILD_ROOT = join33(RN_ANDROID_RUNNER_DIR, "app", "build");
-    ANDROID_REBUILD_LOCK_DATABASE = join33(ANDROID_REBUILD_ROOT, ".authority-rebuild", "lock.sqlite");
+    GRADLEW = join34(RN_ANDROID_RUNNER_DIR, "gradlew");
+    APK_APP = join34(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "debug", "app-debug.apk");
+    APK_TEST = join34(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "androidTest", "debug", "app-debug-androidTest.apk");
+    ANDROID_REBUILD_ROOT = join34(RN_ANDROID_RUNNER_DIR, "app", "build");
+    ANDROID_REBUILD_LOCK_DATABASE = join34(ANDROID_REBUILD_ROOT, ".authority-rebuild", "lock.sqlite");
     ANDROID_REBUILD_LOCK_STALE_MS = 15 * 6e4;
     ANDROID_REBUILD_HEARTBEAT_MS = 6e4;
     ANDROID_REBUILD_COMPLETION_RETRY_MS = 1e3;
@@ -40185,9 +40331,9 @@ __export(release_android_slot_exports, {
 });
 import { execFile as execFileCb10 } from "node:child_process";
 import { promisify as promisify13 } from "node:util";
-import { existsSync as existsSync26, readFileSync as readFileSync28, unlinkSync as unlinkSync13 } from "node:fs";
+import { existsSync as existsSync27, readFileSync as readFileSync29, unlinkSync as unlinkSync13 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
-import { join as join34 } from "node:path";
+import { join as join35 } from "node:path";
 function isProtectedPid(pid, selfPid, parentPid) {
   return pid === selfPid || pid === parentPid;
 }
@@ -40204,7 +40350,7 @@ function defaultDeps3() {
     resolveSerial: (deviceId) => deviceId ? ["-s", deviceId] : getAdbSerial(),
     readDaemonPid: () => {
       try {
-        const parsed = JSON.parse(readFileSync28(DAEMON_JSON2, "utf8"));
+        const parsed = JSON.parse(readFileSync29(DAEMON_JSON2, "utf8"));
         return typeof parsed.pid === "number" ? parsed.pid : null;
       } catch {
         return null;
@@ -40220,7 +40366,7 @@ function defaultDeps3() {
     },
     protectedPids: () => ({ selfPid: process.pid, parentPid: process.ppid }),
     kill: (pid, sig) => process.kill(pid, sig),
-    fileExists: (p) => existsSync26(p),
+    fileExists: (p) => existsSync27(p),
     removeFile: (p) => unlinkSync13(p),
     delay: (ms) => new Promise((resolve21) => setTimeout(resolve21, ms)),
     killLegacy: () => process.env.RN_DEVICE_KILL_LEGACY !== "0",
@@ -40334,8 +40480,8 @@ var init_release_android_slot = __esm({
     init_rn_android_runner_client();
     init_agent_device_wrapper();
     execFile13 = promisify13(execFileCb10);
-    DAEMON_JSON2 = join34(homedir6(), ".agent-device", "daemon.json");
-    DAEMON_LOCK2 = join34(homedir6(), ".agent-device", "daemon.lock");
+    DAEMON_JSON2 = join35(homedir6(), ".agent-device", "daemon.json");
+    DAEMON_LOCK2 = join35(homedir6(), ".agent-device", "daemon.lock");
     DAEMON_FILES2 = [DAEMON_JSON2, DAEMON_LOCK2];
     SIGKILL_GRACE_MS2 = 500;
     ADB_TIMEOUT_MS = 5e3;
@@ -40693,8 +40839,8 @@ var init_process_cleanup = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/session/startup-cleanup.js
-import { createHash as createHash13 } from "node:crypto";
-import { join as join35 } from "node:path";
+import { createHash as createHash14 } from "node:crypto";
+import { join as join36 } from "node:path";
 function startupCleanupFailureMessage() {
   return "rn-dev-agent startup cleanup failed: STARTUP_CLEANUP_FAILED\n";
 }
@@ -40745,7 +40891,7 @@ async function runStartupCleanupForSource(input) {
       appRootKey: input.source.appRootKey,
       appRoot: input.source.appRoot
     }, {
-      readSessionSecret: (sessionId) => readJsonStateFile(join35(layout.sessions, sessionId, "secret.json"))
+      readSessionSecret: (sessionId) => readJsonStateFile(join36(layout.sessions, sessionId, "secret.json"))
     });
   } finally {
     registry2.close();
@@ -40804,7 +40950,7 @@ function restoreDeadOwnerIntegration(input, prior, plan, dependencies) {
 function verifiedDeadOwnerManifestSource(appRoot, binding, manifestSha256) {
   if (!/^[0-9a-f]{64}$/.test(manifestSha256))
     return void 0;
-  const verified = (candidate) => typeof candidate === "string" && createHash13("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
+  const verified = (candidate) => typeof candidate === "string" && createHash14("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
   let liveManifest;
   try {
     liveManifest = readPackageIntegrationInputs(appRoot).manifest ?? void 0;
@@ -40894,8 +41040,8 @@ var init_startup_cleanup = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/env-setup.js
-import { existsSync as existsSync27, readFileSync as readFileSync29 } from "node:fs";
-import { join as join37 } from "node:path";
+import { existsSync as existsSync28, readFileSync as readFileSync30 } from "node:fs";
+import { join as join38 } from "node:path";
 function ensureAndroidEnv() {
   if (!process.env.ANDROID_HOME) {
     if (process.env.ANDROID_SDK_ROOT) {
@@ -40903,12 +41049,12 @@ function ensureAndroidEnv() {
     } else {
       const home = process.env.HOME ?? "";
       const candidates = [
-        join37(home, "Library/Android/sdk"),
-        join37(home, "Android/Sdk"),
+        join38(home, "Library/Android/sdk"),
+        join38(home, "Android/Sdk"),
         "/opt/android-sdk"
       ];
       for (const c of candidates) {
-        if (existsSync27(c)) {
+        if (existsSync28(c)) {
           process.env.ANDROID_HOME = c;
           break;
         }
@@ -40916,8 +41062,8 @@ function ensureAndroidEnv() {
     }
   }
   if (process.env.ANDROID_HOME) {
-    const pt = join37(process.env.ANDROID_HOME, "platform-tools");
-    const emu = join37(process.env.ANDROID_HOME, "emulator");
+    const pt = join38(process.env.ANDROID_HOME, "platform-tools");
+    const emu = join38(process.env.ANDROID_HOME, "emulator");
     const path = process.env.PATH ?? "";
     if (!path.includes(pt))
       process.env.PATH = `${pt}:${path}`;
@@ -40925,19 +41071,19 @@ function ensureAndroidEnv() {
       process.env.PATH = `${emu}:${process.env.PATH}`;
   }
   if (!process.env.ANDROID_SERIAL) {
-    const serialFile = join37(process.env.TMPDIR ?? "/tmp", "rn-dev-agent-android-serial");
-    if (existsSync27(serialFile)) {
-      process.env.ANDROID_SERIAL = readFileSync29(serialFile, "utf8").trim();
+    const serialFile = join38(process.env.TMPDIR ?? "/tmp", "rn-dev-agent-android-serial");
+    if (existsSync28(serialFile)) {
+      process.env.ANDROID_SERIAL = readFileSync30(serialFile, "utf8").trim();
     }
   }
 }
 function ensureJavaEnv() {
   const path = process.env.PATH ?? "";
-  if (path.split(":").some((p) => existsSync27(join37(p, "java"))))
+  if (path.split(":").some((p) => existsSync28(join38(p, "java"))))
     return;
   const candidates = ["/opt/homebrew/opt/openjdk@17", "/opt/homebrew/opt/openjdk"];
   for (const jdk of candidates) {
-    if (existsSync27(join37(jdk, "bin/java"))) {
+    if (existsSync28(join38(jdk, "bin/java"))) {
       process.env.JAVA_HOME = jdk;
       process.env.PATH = `${jdk}/bin:${process.env.PATH}`;
       break;
@@ -66785,9 +66931,9 @@ var init_ws_origin = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/cdp/state.js
-import { writeFileSync as writeFileSync14, unlinkSync as unlinkSync14 } from "node:fs";
+import { writeFileSync as writeFileSync15, unlinkSync as unlinkSync14 } from "node:fs";
 import { tmpdir as tmpdir11 } from "node:os";
-import { join as join38 } from "node:path";
+import { join as join39 } from "node:path";
 function resetState(s) {
   s.setState("disconnected");
   s.setHelpersInjected(false);
@@ -66802,11 +66948,11 @@ function resetState(s) {
 }
 function setActiveFlag(port, target) {
   try {
-    writeFileSync14(CDP_ACTIVE_FLAG, String(process.pid));
+    writeFileSync15(CDP_ACTIVE_FLAG, String(process.pid));
   } catch {
   }
   try {
-    writeFileSync14(CDP_SESSION_FILE, JSON.stringify({
+    writeFileSync15(CDP_SESSION_FILE, JSON.stringify({
       port,
       platform: target?.platform ?? null,
       target: target?.title ?? null,
@@ -66833,8 +66979,8 @@ var CDP_ACTIVE_FLAG, CDP_SESSION_FILE;
 var init_state = __esm({
   "packages/rn-dev-agent-core/dist/cdp/state.js"() {
     "use strict";
-    CDP_ACTIVE_FLAG = join38(tmpdir11(), "rn-dev-agent-cdp-active");
-    CDP_SESSION_FILE = join38(tmpdir11(), "rn-dev-agent-cdp-session.json");
+    CDP_ACTIVE_FLAG = join39(tmpdir11(), "rn-dev-agent-cdp-active");
+    CDP_SESSION_FILE = join39(tmpdir11(), "rn-dev-agent-cdp-session.json");
   }
 });
 
@@ -72899,8 +73045,8 @@ var init_mutation_absence = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/verification/config.js
-import { existsSync as existsSync28, readFileSync as readFileSync30 } from "node:fs";
-import { join as join39 } from "node:path";
+import { existsSync as existsSync29, readFileSync as readFileSync31 } from "node:fs";
+import { join as join40 } from "node:path";
 function getCachedProjectRoot() {
   if (_cachedProjectRoot === void 0) {
     _cachedProjectRoot = findProjectRoot();
@@ -72952,14 +73098,14 @@ function loadVerificationConfig(projectRoot) {
   const cached2 = cache.get(projectRoot);
   if (cached2)
     return cached2;
-  const path = join39(projectRoot, ".rn-agent", "config.json");
-  if (!existsSync28(path)) {
+  const path = join40(projectRoot, ".rn-agent", "config.json");
+  if (!existsSync29(path)) {
     cache.set(projectRoot, DEFAULTS);
     return DEFAULTS;
   }
   let raw;
   try {
-    raw = JSON.parse(readFileSync30(path, "utf-8"));
+    raw = JSON.parse(readFileSync31(path, "utf-8"));
   } catch {
     cache.set(projectRoot, DEFAULTS);
     return DEFAULTS;
@@ -73351,19 +73497,19 @@ var init_install_identity_inspection = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/session/migration-diagnostic.js
-import { createHash as createHash15 } from "node:crypto";
-import { existsSync as existsSync29, readFileSync as readFileSync31 } from "node:fs";
-import { join as join40 } from "node:path";
+import { createHash as createHash16 } from "node:crypto";
+import { existsSync as existsSync30, readFileSync as readFileSync32 } from "node:fs";
+import { join as join41 } from "node:path";
 function readPackageIntegrationManifest(appRoot, dependencies) {
-  const manifestPath = join40(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
+  const manifestPath = join41(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
   if (dependencies.exists || dependencies.readText) {
-    const exists = dependencies.exists ?? existsSync29;
+    const exists = dependencies.exists ?? existsSync30;
     if (!exists(manifestPath))
       return void 0;
-    const readText = dependencies.readText ?? ((path) => readFileSync31(path, "utf8"));
+    const readText = dependencies.readText ?? ((path) => readFileSync32(path, "utf8"));
     return readText(manifestPath);
   }
-  const agent = openBoundDirectory(join40(appRoot, ".rn-agent"));
+  const agent = openBoundDirectory(join41(appRoot, ".rn-agent"));
   let integration;
   let primaryError;
   try {
@@ -73381,7 +73527,7 @@ function readPackageIntegrationManifest(appRoot, dependencies) {
   }
 }
 function inspectAuthorityMigration(status, dependencies = {}) {
-  const exists = dependencies.exists ?? existsSync29;
+  const exists = dependencies.exists ?? existsSync30;
   const appRoot = typeof status.source.appRoot === "string" ? status.source.appRoot : "";
   let packageIntegrationInstalled = false;
   let onDiskManifestText;
@@ -73400,7 +73546,7 @@ function inspectAuthorityMigration(status, dependencies = {}) {
   const integrationBinding = status.bindings.packageIntegration;
   let bindingDiagnostic = null;
   if (integrationBinding) {
-    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash15("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
+    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash16("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
     const manifestAvailable = manifestVerified(onDiskManifestText) || manifestVerified(integrationBinding.restoration?.phase === "started" ? integrationBinding.restoration.manifestSource : void 0) || manifestVerified(integrationBinding.installation?.phase === "started" ? integrationBinding.installation.manifestSource : void 0) || manifestVerified(integrationBinding.manifestSource);
     const effectiveOwnerSessionId = status.sessionId;
     const trustedDigestRecorded = typeof integrationBinding.manifestSha256 === "string" && /^[0-9a-f]{64}$/.test(integrationBinding.manifestSha256);
@@ -73693,9 +73839,9 @@ var init_device_existence = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/session.js
-import { dirname as dirname21, isAbsolute as isAbsolute9, join as join41, resolve as resolve15 } from "node:path";
+import { dirname as dirname22, isAbsolute as isAbsolute9, join as join42, resolve as resolve15 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { createHash as createHash16 } from "node:crypto";
+import { createHash as createHash17 } from "node:crypto";
 function sameAndroidMetroReverse(current, next) {
   if (!current || !next)
     return current === next;
@@ -73708,7 +73854,7 @@ function sameMetroAuthority(current, next) {
 function verifiedManifestSource(candidate, manifestSha256) {
   if (typeof candidate !== "string" || typeof manifestSha256 !== "string")
     return void 0;
-  return createHash16("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
+  return createHash17("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
 }
 function durableBindingManifestSource(binding) {
   return verifiedManifestSource(binding?.manifestSource, binding?.manifestSha256);
@@ -74619,9 +74765,9 @@ function createSessionHandler(runtime, dependencies = {}) {
         if (input.action !== "restore_integration") {
           assertDeclaredProjectRootMatches(status, input.projectRoot, sessionSourceResolver(status, dependencies));
         }
-        const packagePath = join41(appRoot, "package.json");
+        const packagePath = join42(appRoot, "package.json");
         const integrationInputs = readPackageIntegrationInputs(appRoot);
-        const manifestPath = join41(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
+        const manifestPath = join42(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
         const packageJson = JSON.parse(integrationInputs.packageJson);
         const integrationBinding = status.bindings.packageIntegration;
         const installationManifestSource = integrationBinding?.installation?.phase === "started" && typeof integrationBinding.installation.manifestSource === "string" ? integrationBinding.installation.manifestSource : void 0;
@@ -74634,7 +74780,7 @@ function createSessionHandler(runtime, dependencies = {}) {
           if (!(error2 instanceof SyntaxError))
             throw error2;
         }
-        const sessionCli = process.env.RN_DEV_AGENT_SESSION_CLI ?? join41(dirname21(fileURLToPath2(import.meta.url)), "..", "rn-session.js");
+        const sessionCli = process.env.RN_DEV_AGENT_SESSION_CLI ?? join42(dirname22(fileURLToPath2(import.meta.url)), "..", "rn-session.js");
         const stateDir = process.env.RN_DEV_AGENT_STATE_DIR;
         if (input.action === "restore_integration") {
           if (input.confirmed !== true) {
@@ -74651,7 +74797,7 @@ function createSessionHandler(runtime, dependencies = {}) {
             });
           }
           assertPackageIntegrationInactive(status.bindings, input.action);
-          const manifestSha256 = createHash16("sha256").update(manifestSource ?? "").digest("hex");
+          const manifestSha256 = createHash17("sha256").update(manifestSource ?? "").digest("hex");
           if (integrationBinding?.version !== 1 || typeof integrationBinding.installedBySessionId !== "string" || integrationBinding.manifestSha256 !== manifestSha256) {
             throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "integration restoration requires the transferred manifest authority binding");
           }
@@ -74698,7 +74844,7 @@ function createSessionHandler(runtime, dependencies = {}) {
         }
         preview.manifest.metroConfig = metroConfigPath.slice(appRoot.length + 1);
         const expectedManifestSource = installationManifestSource ?? serializePackageIntegrationManifest(preview.manifest);
-        const expectedManifestSha256 = createHash16("sha256").update(expectedManifestSource).digest("hex");
+        const expectedManifestSha256 = createHash17("sha256").update(expectedManifestSource).digest("hex");
         if (installationManifestSource && (integrationBinding?.version !== 1 || integrationBinding.installedBySessionId !== session2.sessionId || integrationBinding.manifestSha256 !== expectedManifestSha256)) {
           throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "integration installation requires the original session manifest authority binding");
         }
@@ -74720,7 +74866,7 @@ function createSessionHandler(runtime, dependencies = {}) {
           if (!installedManifest) {
             throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: applied manifest is unavailable");
           }
-          if (createHash16("sha256").update(installedManifest).digest("hex") !== expectedManifestSha256) {
+          if (createHash17("sha256").update(installedManifest).digest("hex") !== expectedManifestSha256) {
             throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "applied integration manifest no longer matches its durable installation authority");
           }
           registry2.updateBindings(session2, {
@@ -76925,10 +77071,10 @@ var init_recorder = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/device-list.js
-import { mkdirSync as mkdirSync19 } from "node:fs";
+import { mkdirSync as mkdirSync20 } from "node:fs";
 import { execFile as execFile17 } from "node:child_process";
 import { promisify as promisify18 } from "node:util";
-import { dirname as dirname22, join as join42, resolve as resolve16 } from "node:path";
+import { dirname as dirname23, join as join43, resolve as resolve16 } from "node:path";
 import { homedir as homedir8 } from "node:os";
 function parseSimctlDevicesAll(jsonText) {
   try {
@@ -76972,7 +77118,7 @@ function deriveScreenshotPath(args, now = Date.now, rand = Math.random) {
   }
   if (args.path?.startsWith("~")) {
     if (args.path.startsWith("~/"))
-      return join42(homedir8(), args.path.slice(2));
+      return join43(homedir8(), args.path.slice(2));
     throw new TildeScreenshotPathError(`Screenshot path "${args.path}" starts with '~' which the bridge cannot expand (only a leading '~/' is expanded to the home directory). Pass an absolute path instead.`);
   }
   if (args.path)
@@ -76983,7 +77129,7 @@ function deriveScreenshotPath(args, now = Date.now, rand = Math.random) {
 }
 function ensureScreenshotDir(path) {
   try {
-    mkdirSync19(dirname22(path), { recursive: true });
+    mkdirSync20(dirname23(path), { recursive: true });
     return { ok: true };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
@@ -79186,7 +79332,7 @@ var init_test_recorder_generators = __esm({
 
 // packages/rn-dev-agent-core/dist/tools/test-recorder.js
 import { mkdir, readdir, readFile as readFile2, writeFile } from "node:fs/promises";
-import { join as join43 } from "node:path";
+import { join as join44 } from "node:path";
 function deduplicateEvents(events) {
   const out = [];
   for (let i = 0; i < events.length; i++) {
@@ -79369,7 +79515,7 @@ function createRecordTestSaveHandler(getClient2) {
     if (!safe) {
       return failResult("Filename is empty after sanitization", "BAD_FILENAME");
     }
-    const filePath = join43(dir, `${safe}.json`);
+    const filePath = join44(dir, `${safe}.json`);
     const payload = { savedAt: (/* @__PURE__ */ new Date()).toISOString(), events: storedEvents };
     await writeFile(filePath, JSON.stringify(payload, null, 2), "utf8");
     return okResult({
@@ -79390,7 +79536,7 @@ function createRecordTestLoadHandler(getClient2) {
     if (!safe) {
       return failResult("Filename is empty after sanitization", "BAD_FILENAME");
     }
-    const filePath = join43(dir, `${safe}.json`);
+    const filePath = join44(dir, `${safe}.json`);
     let raw;
     try {
       raw = await readFile2(filePath, "utf8");
@@ -83458,11 +83604,11 @@ var init_device_deeplink = __esm({
 
 // packages/rn-dev-agent-core/dist/tools/device-record.js
 import { execFile as execFile22 } from "node:child_process";
-import { createHash as createHash17 } from "node:crypto";
-import { existsSync as existsSync30 } from "node:fs";
+import { createHash as createHash18 } from "node:crypto";
+import { existsSync as existsSync31 } from "node:fs";
 import { promisify as promisify23 } from "node:util";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
-import { dirname as dirname23, join as join44 } from "node:path";
+import { dirname as dirname24, join as join45 } from "node:path";
 function parseAllBootedIosDevices(jsonText) {
   let data;
   try {
@@ -83541,28 +83687,28 @@ function compactUnique2(paths) {
   }
   return out;
 }
-function candidateRecordScripts(baseDir = dirname23(fileURLToPath3(import.meta.url))) {
+function candidateRecordScripts(baseDir = dirname24(fileURLToPath3(import.meta.url))) {
   const codexPluginRoot = process.env.RN_DEV_AGENT_CODEX_PLUGIN_ROOT;
   const claudePluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
   return compactUnique2([
     process.env.RN_DEV_AGENT_RECORD_PROOF_SCRIPT,
-    codexPluginRoot ? join44(codexPluginRoot, "scripts", "record_proof.sh") : void 0,
-    claudePluginRoot ? join44(claudePluginRoot, "scripts", "record_proof.sh") : void 0,
-    claudePluginRoot ? join44(claudePluginRoot, "..", "..", "scripts", "record_proof.sh") : void 0,
+    codexPluginRoot ? join45(codexPluginRoot, "scripts", "record_proof.sh") : void 0,
+    claudePluginRoot ? join45(claudePluginRoot, "scripts", "record_proof.sh") : void 0,
+    claudePluginRoot ? join45(claudePluginRoot, "..", "..", "scripts", "record_proof.sh") : void 0,
     // Bundled Codex runtime: <plugin>/rn-dev-agent-core/dist.
-    join44(baseDir, "..", "..", "scripts", "record_proof.sh"),
+    join45(baseDir, "..", "..", "scripts", "record_proof.sh"),
     // Source core bundle: packages/rn-dev-agent-core/dist/supervisor.js.
-    join44(baseDir, "..", "..", "..", "scripts", "record_proof.sh"),
+    join45(baseDir, "..", "..", "..", "scripts", "record_proof.sh"),
     // Source module build: packages/rn-dev-agent-core/dist/tools/device-record.js.
-    join44(baseDir, "..", "..", "..", "..", "scripts", "record_proof.sh")
+    join45(baseDir, "..", "..", "..", "..", "scripts", "record_proof.sh")
   ]);
 }
-function resolveRecordScript(baseDir = dirname23(fileURLToPath3(import.meta.url))) {
+function resolveRecordScript(baseDir = dirname24(fileURLToPath3(import.meta.url))) {
   if (process.env.RN_DEV_AGENT_RECORD_PROOF_SCRIPT) {
     return process.env.RN_DEV_AGENT_RECORD_PROOF_SCRIPT;
   }
   const candidates = candidateRecordScripts(baseDir);
-  return candidates.find((path) => existsSync30(path)) ?? candidates[0];
+  return candidates.find((path) => existsSync31(path)) ?? candidates[0];
 }
 function getRecordScript() {
   return resolveRecordScript();
@@ -83606,7 +83752,7 @@ function parseStatusOutput(stdout) {
   return active;
 }
 function recordingScope(args) {
-  return createHash17("sha256").update(`${args.sessionId}\0${args.claimEpoch}\0${args.platform}\0${args.deviceId}`).digest("hex");
+  return createHash18("sha256").update(`${args.sessionId}\0${args.claimEpoch}\0${args.platform}\0${args.deviceId}`).digest("hex");
 }
 function bindRecorderSession(runtime, args) {
   const available = runtime.requireAvailable();
@@ -83890,7 +84036,7 @@ var init_device_record = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/proof-capture.js
-import { createHash as createHash18 } from "node:crypto";
+import { createHash as createHash19 } from "node:crypto";
 function canonicalizeProofValue(value) {
   if (Array.isArray(value))
     return value.map(canonicalizeProofValue);
@@ -83902,14 +84048,14 @@ function hashProofArgs(params) {
   return hashProofValue(redact(params));
 }
 function hashProofValue(value) {
-  return createHash18("sha256").update(JSON.stringify(canonicalizeProofValue(value))).digest("hex");
+  return createHash19("sha256").update(JSON.stringify(canonicalizeProofValue(value))).digest("hex");
 }
 function proofRuntimeAuthorityMarker(input) {
   return hashProofValue(input);
 }
 function hashObservedValue(value) {
   const bytes = JSON.stringify(value) ?? String(value);
-  return createHash18("sha256").update(bytes).digest("hex");
+  return createHash19("sha256").update(bytes).digest("hex");
 }
 function resultEnvelope(result) {
   if (!result || typeof result !== "object")
@@ -84432,10 +84578,10 @@ var init_startup_integrity = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
-import { createHash as createHash19, randomUUID as randomUUID10 } from "node:crypto";
+import { createHash as createHash20, randomUUID as randomUUID10 } from "node:crypto";
 import { execFileSync as execFileSync15 } from "node:child_process";
-import { chmodSync as chmodSync7, closeSync as closeSync12, existsSync as existsSync31, fsyncSync, lstatSync as lstatSync16, mkdirSync as mkdirSync20, openSync as openSync12, readFileSync as readFileSync32, realpathSync as realpathSync14, renameSync as renameSync8, unlinkSync as unlinkSync15, writeFileSync as writeFileSync15 } from "node:fs";
-import { basename as basename11, dirname as dirname24, extname, isAbsolute as isAbsolute11, join as join45, relative as relative8, resolve as resolve17, sep as sep9 } from "node:path";
+import { chmodSync as chmodSync7, closeSync as closeSync12, existsSync as existsSync32, fsyncSync, lstatSync as lstatSync16, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync33, realpathSync as realpathSync14, renameSync as renameSync9, unlinkSync as unlinkSync15, writeFileSync as writeFileSync16 } from "node:fs";
+import { basename as basename11, dirname as dirname25, extname, isAbsolute as isAbsolute11, join as join46, relative as relative8, resolve as resolve17, sep as sep9 } from "node:path";
 import { fileURLToPath as fileURLToPath4 } from "node:url";
 function proofActionPayload(unparsedArgs) {
   if (!unparsedArgs || typeof unparsedArgs !== "object" || Array.isArray(unparsedArgs)) {
@@ -84468,7 +84614,7 @@ function evidenceTimingReasons(timestamps, videoDurationMs, steps) {
   return reasons;
 }
 function hashBytes(bytes) {
-  return createHash19("sha256").update(bytes).digest("hex");
+  return createHash20("sha256").update(bytes).digest("hex");
 }
 function captureProofWorkerStartup(argv = process.argv, attestation = readStartupIntegrityAttestation()) {
   let executedEntrypointPath = null;
@@ -84521,9 +84667,9 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
     return null;
   }
   for (const host of ["claude-plugin", "codex-plugin"]) {
-    const hostRoot = join45(root, "packages", host);
-    const coreIndex = realpathOrSelf(join45(hostRoot, "rn-dev-agent-core", "dist", "index.js"));
-    const coreSupervisor = realpathOrSelf(join45(hostRoot, "rn-dev-agent-core", "dist", "supervisor.js"));
+    const hostRoot = join46(root, "packages", host);
+    const coreIndex = realpathOrSelf(join46(hostRoot, "rn-dev-agent-core", "dist", "index.js"));
+    const coreSupervisor = realpathOrSelf(join46(hostRoot, "rn-dev-agent-core", "dist", "supervisor.js"));
     if (arg === coreIndex) {
       return {
         host,
@@ -84542,8 +84688,8 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
         kind: "core-supervisor"
       };
     }
-    if (host === "codex-plugin" && arg === realpathOrSelf(join45(hostRoot, "bin", "cdp-supervisor.js"))) {
-      if (!existsSync31(coreIndex) || !existsSync31(coreSupervisor))
+    if (host === "codex-plugin" && arg === realpathOrSelf(join46(hostRoot, "bin", "cdp-supervisor.js"))) {
+      if (!existsSync32(coreIndex) || !existsSync32(coreSupervisor))
         return null;
       return {
         host,
@@ -84577,7 +84723,7 @@ function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
   }
   if (supervisorOverride && supervisorOverride !== entrypoint.coreSupervisor)
     return false;
-  if (coreRootOverride && join45(coreRootOverride, "dist", "supervisor.js") !== entrypoint.coreSupervisor) {
+  if (coreRootOverride && join46(coreRootOverride, "dist", "supervisor.js") !== entrypoint.coreSupervisor) {
     return false;
   }
   if (workerOverride && workerOverride !== entrypoint.coreBundle)
@@ -84608,7 +84754,7 @@ function readProofCandidateHeadArtifacts(candidateRoot, artifactPaths) {
       const headBytes = execFileSync15("git", ["-C", root, "show", `HEAD:${artifactRelativePath}`], {
         maxBuffer: 128 * 1024 * 1024
       });
-      const artifactBytes = readFileSync32(resolvedArtifactPath);
+      const artifactBytes = readFileSync33(resolvedArtifactPath);
       if (hashBytes(artifactBytes) !== hashBytes(headBytes))
         return null;
       verifiedBytes.push(artifactBytes);
@@ -84635,7 +84781,7 @@ function readProofCandidateRuntime(candidateRoot, startup = proofWorkerStartup) 
     throw new Error("CANDIDATE_MCP_PROCESS_MISMATCH");
   }
   const { host, coreBundle } = entrypoint;
-  const runnerManifest = join45(root, "packages", host, "runner-manifest.json");
+  const runnerManifest = join46(root, "packages", host, "runner-manifest.json");
   const artifacts = readProofCandidateHeadArtifacts(root, [coreBundle, runnerManifest]);
   if (!artifacts) {
     throw new Error("CANDIDATE_CHECKOUT_NOT_CLEAN");
@@ -84693,7 +84839,7 @@ function readProofActionIdentity(appProjectRoot, actionId, dependencies = {}) {
     return {
       id: actionId,
       version: String(action.state.revision),
-      sha256: createHash19("sha256").update(action.yamlText).digest("hex")
+      sha256: createHash20("sha256").update(action.yamlText).digest("hex")
     };
   } catch {
     return null;
@@ -84730,7 +84876,7 @@ function validCaptureContext(args, expectedRoot) {
   ];
   if (proofTools.some((tool) => normalizeTool(tool) === "cdp_auto_login"))
     return false;
-  const proofRoot = join45(expectedRoot, "docs", "proof", args.runId);
+  const proofRoot = join46(expectedRoot, "docs", "proof", args.runId);
   const screenshots = args.storyboard.steps.map((step) => step.screenshotPath);
   const destinations = [args.receiptPath, args.videoPath, args.contactSheetPath, ...screenshots];
   if (destinations.some((path) => !isNormalizedDescendant(proofRoot, path) || hasExistingSymlink(expectedRoot, path)) || new Set(destinations).size !== destinations.length) {
@@ -84744,7 +84890,7 @@ function validCaptureContext(args, expectedRoot) {
   }));
 }
 function proofRootExists(args) {
-  const proofRoot = join45(args.projectRoot, "docs", "proof", args.runId);
+  const proofRoot = join46(args.projectRoot, "docs", "proof", args.runId);
   try {
     lstatSync16(proofRoot);
     return true;
@@ -84877,14 +85023,14 @@ function traceFor(storyboard, events) {
   return validateTrace([...required3, ...allowedExtras], events);
 }
 function readProofContractAt(moduleUrl = import.meta.url) {
-  const moduleDir = dirname24(fileURLToPath4(moduleUrl));
+  const moduleDir = dirname25(fileURLToPath4(moduleUrl));
   const candidates = [
     resolve17(moduleDir, "../../schemas/proof-receipt.schema.json"),
     resolve17(moduleDir, "../schemas/proof-receipt.schema.json")
   ];
   for (const path of candidates) {
     try {
-      const bytes = readFileSync32(path, "utf8");
+      const bytes = readFileSync33(path, "utf8");
       return { schema: JSON.parse(bytes), bytes, sha256: hashBytes(bytes) };
     } catch {
     }
@@ -84892,18 +85038,18 @@ function readProofContractAt(moduleUrl = import.meta.url) {
   throw new Error("PROOF_CONTRACT_MISSING");
 }
 function writeProofReceiptAtomic(path, receipt2) {
-  const directory = dirname24(path);
-  mkdirSync20(directory, { recursive: true, mode: 448 });
+  const directory = dirname25(path);
+  mkdirSync21(directory, { recursive: true, mode: 448 });
   const temporary = resolve17(directory, `.${randomUUID10()}.proof-receipt.tmp`);
   let descriptor = null;
   try {
     descriptor = openSync12(temporary, "wx", 384);
-    writeFileSync15(descriptor, `${JSON.stringify(receipt2, null, 2)}
+    writeFileSync16(descriptor, `${JSON.stringify(receipt2, null, 2)}
 `, "utf8");
     fsyncSync(descriptor);
     closeSync12(descriptor);
     descriptor = null;
-    renameSync8(temporary, path);
+    renameSync9(temporary, path);
     chmodSync7(path, 384);
   } catch (error2) {
     if (descriptor !== null)
@@ -85229,7 +85375,7 @@ function createProofCaptureHandler(deps) {
         return proofFailure(["PROOF_ACTION_IDENTITY_MISMATCH"], "idle");
       }
       try {
-        const proofRoot = join45(args.projectRoot, "docs", "proof", args.runId);
+        const proofRoot = join46(args.projectRoot, "docs", "proof", args.runId);
         if (deps.proofRootTracked(args.projectRoot, proofRoot)) {
           return proofFailure(["PROOF_ROOT_TRACKED"], "idle");
         }
@@ -85795,11 +85941,11 @@ var init_proof_capture2 = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/proof-media.js
-import { createHash as createHash20 } from "node:crypto";
+import { createHash as createHash21 } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { mkdir as mkdir2, mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir as tmpdir12 } from "node:os";
-import { dirname as dirname25, join as join46 } from "node:path";
+import { dirname as dirname26, join as join47 } from "node:path";
 function fail2(reason) {
   throw new MediaFailure(reason);
 }
@@ -85830,7 +85976,7 @@ async function hashAcceptedFile(path) {
   }
 }
 async function sha256File2(path) {
-  const hash = createHash20("sha256");
+  const hash = createHash21("sha256");
   const stream = createReadStream(path);
   for await (const chunk of stream)
     hash.update(chunk);
@@ -85928,7 +86074,7 @@ async function matchScreenshotAt(process3, input) {
   if (input.videoDurationMs !== void 0 && (!Number.isFinite(input.videoDurationMs) || input.videoDurationMs <= 0)) {
     fail2("INVALID_MEDIA_INPUT");
   }
-  const normalizedScreenshotPath = join46(input.scratchDir, `screenshot-${index}.png`);
+  const normalizedScreenshotPath = join47(input.scratchDir, `screenshot-${index}.png`);
   await rm(normalizedScreenshotPath, { force: true });
   await runFrameProcess(process3, [
     "-y",
@@ -85953,7 +86099,7 @@ async function matchScreenshotAt(process3, input) {
   let best = null;
   let decodedFrameCount = 0;
   for (const [sampleIndex, timestampMs] of sampleTimestamps.entries()) {
-    const framePath = join46(input.scratchDir, `frame-${index}-${sampleIndex}.jpg`);
+    const framePath = join47(input.scratchDir, `frame-${index}-${sampleIndex}.jpg`);
     await rm(framePath, { force: true });
     try {
       await runFrameProcess(process3, [
@@ -86025,7 +86171,7 @@ async function buildContactSheet(process3, selectedFramePaths, contactSheetPath)
     await requireNonEmptyFile(path, "FRAME_PROCESS_FAILED", "FRAME_PROCESS_FAILED");
   }
   try {
-    await mkdir2(dirname25(contactSheetPath), { recursive: true });
+    await mkdir2(dirname26(contactSheetPath), { recursive: true });
     await rm(contactSheetPath, { force: true });
   } catch {
     fail2("MEDIA_IO_FAILED");
@@ -86077,7 +86223,7 @@ async function validateMedia(process3, input) {
     const scratchRoot = input.scratchRoot ?? tmpdir12();
     try {
       await mkdir2(scratchRoot, { recursive: true });
-      scratchDir = await mkdtemp(join46(scratchRoot, "proof-media-"));
+      scratchDir = await mkdtemp(join47(scratchRoot, "proof-media-"));
     } catch {
       fail2("MEDIA_IO_FAILED");
     }
@@ -87299,8 +87445,8 @@ var init_nav_graph = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/auto-login.js
-import { lstatSync as lstatSync17, readFileSync as readFileSync33, readdirSync as readdirSync12, realpathSync as realpathSync15 } from "node:fs";
-import { dirname as dirname26, join as join47, resolve as resolve18 } from "node:path";
+import { lstatSync as lstatSync17, readFileSync as readFileSync34, readdirSync as readdirSync13, realpathSync as realpathSync15 } from "node:fs";
+import { dirname as dirname27, join as join48, resolve as resolve18 } from "node:path";
 function matchesAuthPattern(routeName) {
   const lower = routeName.toLowerCase();
   return AUTH_ROUTE_PATTERNS.some((p) => lower.includes(p));
@@ -87330,8 +87476,8 @@ async function isOnAuthScreen(client2) {
   }
 }
 function findLoginFlow(projectRoot) {
-  const maestroDir = join47(projectRoot, ".maestro");
-  const searchDirs = [join47(maestroDir, "subflows"), maestroDir];
+  const maestroDir = join48(projectRoot, ".maestro");
+  const searchDirs = [join48(maestroDir, "subflows"), maestroDir];
   for (const dir of searchDirs) {
     let files;
     try {
@@ -87342,7 +87488,7 @@ function findLoginFlow(projectRoot) {
       }
       if (!maestroStat.isDirectory() || !dirStat.isDirectory())
         continue;
-      files = readdirSync12(dir);
+      files = readdirSync13(dir);
     } catch (err) {
       if (err.code !== "ENOENT")
         throw err;
@@ -87350,12 +87496,12 @@ function findLoginFlow(projectRoot) {
     }
     for (const candidate of LOGIN_FLOW_PRIORITY) {
       if (files.includes(candidate)) {
-        return assertLegacyLoginFlow(projectRoot, join47(dir, candidate));
+        return assertLegacyLoginFlow(projectRoot, join48(dir, candidate));
       }
     }
     const authFile = files.find((f) => /\.(ya?ml)$/.test(f) && AUTH_ROUTE_PATTERNS.some((p) => f.toLowerCase().includes(p)));
     if (authFile)
-      return assertLegacyLoginFlow(projectRoot, join47(dir, authFile));
+      return assertLegacyLoginFlow(projectRoot, join48(dir, authFile));
   }
   return null;
 }
@@ -87462,12 +87608,12 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
     };
   }
   const rawAppId = opts.appId ?? projectAppId ?? "";
-  const originalContent = readFileSync33(flowPath, "utf-8");
+  const originalContent = readFileSync34(flowPath, "utf-8");
   let validatedCommands;
   try {
     const parsed = parseAndValidateFlow(originalContent, {
-      flowDir: dirname26(flowPath),
-      flowRoot: join47(projectRoot, ".maestro")
+      flowDir: dirname27(flowPath),
+      flowRoot: join48(projectRoot, ".maestro")
     });
     validatedCommands = parsed.commands;
     if (containsClearState(validatedCommands)) {
@@ -88032,7 +88178,7 @@ var init_graceful_shutdown = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/maestro-generate.js
-import { basename as basename12, dirname as dirname27, join as join48 } from "node:path";
+import { basename as basename12, dirname as dirname28, join as join49 } from "node:path";
 function stepToMaestroCommands(step) {
   const ALLOWED_DIRECTIONS = /* @__PURE__ */ new Set(["up", "down", "left", "right"]);
   switch (step.action) {
@@ -88091,7 +88237,7 @@ function createMaestroGenerateHandler() {
       return failResult("Flow name contains an unsafe control character or is too long.");
     }
     const root = findProjectRoot();
-    const outputDir = args.outputDir ?? (root ? join48(root, ".rn-agent", "actions") : null);
+    const outputDir = args.outputDir ?? (root ? join49(root, ".rn-agent", "actions") : null);
     if (!outputDir) {
       return failResult("Cannot determine project root. Pass outputDir explicitly.");
     }
@@ -88100,7 +88246,7 @@ function createMaestroGenerateHandler() {
       return failResult("Flow name must produce an action id that starts with a letter or number and is at most 64 characters.");
     }
     const fileName = `${sanitizedName}.yaml`;
-    const learnedProjectRoot = basename12(outputDir) === "actions" && basename12(dirname27(outputDir)) === ".rn-agent" ? dirname27(dirname27(outputDir)) : null;
+    const learnedProjectRoot = basename12(outputDir) === "actions" && basename12(dirname28(outputDir)) === ".rn-agent" ? dirname28(dirname28(outputDir)) : null;
     if (!learnedProjectRoot) {
       return failResult("Generated actions must be written to an owned .rn-agent/actions corpus.");
     }
@@ -88173,8 +88319,8 @@ var init_maestro_generate = __esm({
 // packages/rn-dev-agent-core/dist/tools/maestro-test-all.js
 import { execFile as execFileCb19 } from "node:child_process";
 import { promisify as promisify25 } from "node:util";
-import { existsSync as existsSync32, readdirSync as readdirSync13, readFileSync as readFileSync34, writeFileSync as writeFileSync16 } from "node:fs";
-import { basename as basename13, dirname as dirname28, join as join49, resolve as resolve19 } from "node:path";
+import { existsSync as existsSync33, readdirSync as readdirSync14, readFileSync as readFileSync35, writeFileSync as writeFileSync17 } from "node:fs";
+import { basename as basename13, dirname as dirname29, join as join50, resolve as resolve19 } from "node:path";
 import { tmpdir as tmpdir13 } from "node:os";
 function filterFlows(yamls, pattern) {
   if (pattern) {
@@ -88191,9 +88337,9 @@ function filterFlows(yamls, pattern) {
   return yamls;
 }
 function discoverFlows(dir, pattern) {
-  if (!existsSync32(dir))
+  if (!existsSync33(dir))
     return [];
-  const yamls = readdirSync13(dir, { recursive: true }).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).map((f) => join49(dir, f)).sort();
+  const yamls = readdirSync14(dir, { recursive: true }).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).map((f) => join50(dir, f)).sort();
   return filterFlows(yamls, pattern);
 }
 function createMaestroTestAllHandler(deps = {}) {
@@ -88225,17 +88371,17 @@ function createMaestroTestAllHandler(deps = {}) {
     if (pinRefusal)
       return failResult(pinRefusal);
     const root = findProjectRoot();
-    const flowDir = args.flowDir ?? (root ? join49(root, ".rn-agent", "actions") : null);
+    const flowDir = args.flowDir ?? (root ? join50(root, ".rn-agent", "actions") : null);
     if (!flowDir) {
       return failResult("Cannot determine project root. Pass flowDir explicitly.");
     }
     const resolvedFlowDir = resolve19(flowDir);
-    const flowDirClassification = classifyLearnedActionPath(join49(resolvedFlowDir, "__action__.yaml"));
+    const flowDirClassification = classifyLearnedActionPath(join50(resolvedFlowDir, "__action__.yaml"));
     if (flowDirClassification === "descendant") {
       return failResult(`Refusing to execute learned-action descendants from ${resolvedFlowDir} as standalone flows.`);
     }
     const learnedCorpus = flowDirClassification === "action";
-    const learnedProjectRoot = learnedCorpus ? dirname28(dirname28(resolvedFlowDir)) : null;
+    const learnedProjectRoot = learnedCorpus ? dirname29(dirname29(resolvedFlowDir)) : null;
     let learnedContext = null;
     if (learnedProjectRoot) {
       try {
@@ -88247,7 +88393,7 @@ function createMaestroTestAllHandler(deps = {}) {
     if (learnedCorpus && !learnedContext) {
       return failResult(`Refusing learned-action corpus without an approved load context: ${resolvedFlowDir}.`);
     }
-    const flows = learnedContext ? filterFlows(learnedContext.files.filter((file) => /\.ya?ml$/i.test(file)).map((file) => join49(flowDir, file)).sort(), args.pattern) : discoverFlows(flowDir, args.pattern);
+    const flows = learnedContext ? filterFlows(learnedContext.files.filter((file) => /\.ya?ml$/i.test(file)).map((file) => join50(flowDir, file)).sort(), args.pattern) : discoverFlows(flowDir, args.pattern);
     if (flows.length === 0) {
       return failResult(`No Maestro flows found in ${flowDir}. Generate flows with maestro_generate first.`);
     }
@@ -88274,9 +88420,9 @@ function createMaestroTestAllHandler(deps = {}) {
           meta = action.metadata;
           requireEnginePin = true;
         } else {
-          const yamlText = readFileSync34(flow, "utf-8");
+          const yamlText = readFileSync35(flow, "utf-8");
           const parsed = parseAndValidateFlow(yamlText, {
-            flowDir: dirname28(flow),
+            flowDir: dirname29(flow),
             flowRoot: flowDir
           });
           const flowId = name.replace(/\.ya?ml$/i, "");
@@ -88346,8 +88492,8 @@ function createMaestroTestAllHandler(deps = {}) {
     for (const prepared of preparedFlows) {
       const { name } = prepared;
       const start = now();
-      const safeFlowFile = join49(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
-      writeFileSync16(safeFlowFile, prepared.canonical, "utf-8");
+      const safeFlowFile = join50(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      writeFileSync17(safeFlowFile, prepared.canonical, "utf-8");
       const parsedCommands = prepared.commands;
       const parsedAppId = prepared.appId;
       const appFile = prepared.appFile;
@@ -88370,7 +88516,7 @@ function createMaestroTestAllHandler(deps = {}) {
             Object.assign(error2, { code: "ETIMEDOUT" });
             throw error2;
           }
-          writeFileSync16(safeFlowFile, buildMaestroFlow(parsedAppId !== void 0 ? { appId: parsedAppId } : {}, [
+          writeFileSync17(safeFlowFile, buildMaestroFlow(parsedAppId !== void 0 ? { appId: parsedAppId } : {}, [
             ...commands
           ]), "utf-8");
           const executeRunner = (runnerPath, prefixArgs = []) => {
@@ -88515,8 +88661,8 @@ var init_maestro_test_all = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/cross-platform-verify.js
-import { readFileSync as readFileSync35, readdirSync as readdirSync14, lstatSync as lstatSync18 } from "node:fs";
-import { join as join50, extname as extname2 } from "node:path";
+import { readFileSync as readFileSync36, readdirSync as readdirSync15, lstatSync as lstatSync18 } from "node:fs";
+import { join as join51, extname as extname2 } from "node:path";
 function findElement(nodes, query, matchBy) {
   const q = query.toLowerCase();
   return nodes.some((n) => {
@@ -88532,14 +88678,14 @@ function discoverTestIDs(dir) {
   function walk(d) {
     let entries;
     try {
-      entries = readdirSync14(d);
+      entries = readdirSync15(d);
     } catch {
       return;
     }
     for (const entry of entries) {
       if (entry === "node_modules" || entry.startsWith("."))
         continue;
-      const full = join50(d, entry);
+      const full = join51(d, entry);
       try {
         const st = lstatSync18(full);
         if (st.isSymbolicLink())
@@ -88550,7 +88696,7 @@ function discoverTestIDs(dir) {
         }
         if (!SCAN_EXTENSIONS.has(extname2(entry)))
           continue;
-        const src = readFileSync35(full, "utf8");
+        const src = readFileSync36(full, "utf8");
         for (const m of src.matchAll(TESTID_RE)) {
           const id = m[1] ?? m[2] ?? m[3];
           if (id)
@@ -88894,10 +89040,10 @@ var init_instrumentation = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/experience/evidence.js
-import { createHash as createHash21, randomUUID as randomUUID11 } from "node:crypto";
-import { chmodSync as chmodSync8, existsSync as existsSync33, mkdirSync as mkdirSync21, readFileSync as readFileSync36, renameSync as renameSync9, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17 } from "node:fs";
+import { createHash as createHash22, randomUUID as randomUUID11 } from "node:crypto";
+import { chmodSync as chmodSync8, existsSync as existsSync34, mkdirSync as mkdirSync22, readFileSync as readFileSync37, renameSync as renameSync10, unlinkSync as unlinkSync16, writeFileSync as writeFileSync18 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
-import { dirname as dirname29, join as join51 } from "node:path";
+import { dirname as dirname30, join as join52 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 function sanitizeString(value, redact2 = applyRedactionRules) {
   try {
@@ -88947,11 +89093,11 @@ function readAppIdentity() {
   return appIdentityCache.identity;
 }
 function loadAppIdentity(root) {
-  const manifest = join51(root, "app.json");
+  const manifest = join52(root, "app.json");
   try {
-    if (!existsSync33(manifest))
+    if (!existsSync34(manifest))
       return { name: null, slug: null };
-    const parsed = JSON.parse(readFileSync36(manifest, "utf8"));
+    const parsed = JSON.parse(readFileSync37(manifest, "utf8"));
     const expo = parsed.expo ?? parsed;
     return { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
   } catch {
@@ -88964,16 +89110,16 @@ function usableIdentity(value) {
 function discoverPluginVersion(fromUrl = import.meta.url) {
   if (process.env.RN_DEV_AGENT_PLUGIN_VERSION)
     return process.env.RN_DEV_AGENT_PLUGIN_VERSION;
-  const start = dirname29(fileURLToPath5(fromUrl));
+  const start = dirname30(fileURLToPath5(fromUrl));
   const candidates = [
-    join51(start, "..", "..", ".claude-plugin", "plugin.json"),
-    join51(start, "..", "..", ".codex-plugin", "plugin.json"),
-    join51(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
-    join51(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
+    join52(start, "..", "..", ".claude-plugin", "plugin.json"),
+    join52(start, "..", "..", ".codex-plugin", "plugin.json"),
+    join52(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
+    join52(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
   ];
   for (const candidate of candidates) {
     try {
-      const parsed = JSON.parse(readFileSync36(candidate, "utf8"));
+      const parsed = JSON.parse(readFileSync37(candidate, "utf8"));
       if (typeof parsed.version === "string")
         return sanitizeString(parsed.version);
     } catch {
@@ -88982,9 +89128,9 @@ function discoverPluginVersion(fromUrl = import.meta.url) {
   return null;
 }
 function readExperienceStore(path) {
-  if (!existsSync33(path))
+  if (!existsSync34(path))
     return [];
-  const contents = readFileSync36(path, "utf8");
+  const contents = readFileSync37(path, "utf8");
   if (!contents.trim())
     return [];
   const records = [];
@@ -89009,7 +89155,7 @@ function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, 
   }).sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen) || a.signature.localeCompare(b.signature)).slice(0, Math.max(0, maxRecords)).sort((a, b) => a.signature.localeCompare(b.signature));
 }
 function experienceSignature(input) {
-  return createHash21("sha256").update(JSON.stringify([
+  return createHash22("sha256").update(JSON.stringify([
     input.classification,
     input.tool,
     input.normalizedSymptomShape,
@@ -89092,7 +89238,7 @@ var init_evidence = __esm({
     DEFAULT_MAX_RECORDS = 500;
     DEFAULT_RETENTION_DAYS = 14;
     MAX_EVIDENCE_POINTERS = 3;
-    EXPERIENCE_DIRECTORY = join51(homedir9(), ".claude", "rn-agent", "experience");
+    EXPERIENCE_DIRECTORY = join52(homedir9(), ".claude", "rn-agent", "experience");
     EXPERIENCE_STORE_NAME = "patterns.jsonl";
     MAX_SYMPTOM_LENGTH = 2048;
     DAY_MS = 24 * 60 * 60 * 1e3;
@@ -89137,7 +89283,7 @@ var init_evidence = __esm({
       previousFailure = null;
       constructor(options) {
         this.directory = options.directory ?? process.env.RN_DEV_AGENT_EXPERIENCE_DIR ?? EXPERIENCE_DIRECTORY;
-        this.path = join51(this.directory, EXPERIENCE_STORE_NAME);
+        this.path = join52(this.directory, EXPERIENCE_STORE_NAME);
         this.candidate = {
           pluginVersion: options.pluginVersion ?? null,
           coreVersion: options.coreVersion
@@ -89280,21 +89426,21 @@ var init_evidence = __esm({
         this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
       }
       write(records) {
-        mkdirSync21(this.directory, { recursive: true, mode: 448 });
-        const temp = join51(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID11()}`);
+        mkdirSync22(this.directory, { recursive: true, mode: 448 });
+        const temp = join52(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID11()}`);
         try {
           const sanitized = records.map((record2) => record2.redactionVersion === REDACTION_RULES_VERSION ? record2 : {
             ...sanitizeForEvidence(record2),
             redactionVersion: REDACTION_RULES_VERSION
           });
           const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
-          writeFileSync17(temp, contents.length > 0 ? `${contents}
+          writeFileSync18(temp, contents.length > 0 ? `${contents}
 ` : "", {
             encoding: "utf8",
             flag: "wx",
             mode: 384
           });
-          renameSync9(temp, this.path);
+          renameSync10(temp, this.path);
           chmodSync8(this.path, 384);
         } catch (error2) {
           try {
@@ -89349,7 +89495,7 @@ var init_evidence = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/observability/live-device.js
-import { join as join52 } from "node:path";
+import { join as join53 } from "node:path";
 import { tmpdir as tmpdir14 } from "node:os";
 function isStateMutating(tool, args) {
   if (FLOW_MUTATION_TOOLS.has(tool))
@@ -89453,7 +89599,7 @@ function buildLiveDeps(input) {
     // iterable" when invoked as deps.pushLive(...). The live device gate caught
     // this — the unit fakes used standalone arrows and missed it.
     pushLive: (frame) => input.recorder.pushLive(frame),
-    tmpPath: () => join52(tmpdir14(), `rn-observe-live-${process.pid}.jpg`),
+    tmpPath: () => join53(tmpdir14(), `rn-observe-live-${process.pid}.jpg`),
     isMirrorActive: input.isMirrorActive
   };
 }
@@ -89608,9 +89754,9 @@ var init_observe_project_root = __esm({
 
 // packages/rn-dev-agent-core/dist/observability/server.js
 import { createServer as createServer3 } from "node:http";
-import { readFileSync as readFileSync37 } from "node:fs";
+import { readFileSync as readFileSync38 } from "node:fs";
 import { fileURLToPath as fileURLToPath6 } from "node:url";
-import { dirname as dirname30, join as join53 } from "node:path";
+import { dirname as dirname31, join as join54 } from "node:path";
 function listen(server3, port) {
   return new Promise((resolve21, reject) => {
     const onErr = (e) => {
@@ -89633,7 +89779,7 @@ var init_server3 = __esm({
     init_observe_project_root();
     init_logger();
     HOST = "127.0.0.1";
-    __dir = dirname30(fileURLToPath6(import.meta.url));
+    __dir = dirname31(fileURLToPath6(import.meta.url));
     ObservabilityServer = class {
       recorder;
       e2e;
@@ -89876,7 +90022,7 @@ var init_server3 = __esm({
       }
       index(res) {
         try {
-          let html = readFileSync37(join53(__dir, "web-dist", "index.html"), "utf8");
+          let html = readFileSync38(join54(__dir, "web-dist", "index.html"), "utf8");
           if (this.e2e) {
             const tokenJs = JSON.stringify(this.e2e.token).replace(/</g, "\\u003c");
             html = html.replace("</head>", `<script>window.__E2E_CSRF__=${tokenJs}</script></head>`);
@@ -90060,10 +90206,10 @@ var init_server3 = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/observability/observe-state.js
-import { join as join54 } from "node:path";
+import { join as join55 } from "node:path";
 function observeStatePath(projectRoot) {
   const safe = projectRoot.replace(/[^A-Za-z0-9._-]/g, "_");
-  return join54(getStateDir(), "observe", `${safe}.json`);
+  return join55(getStateDir(), "observe", `${safe}.json`);
 }
 function writeObserveState(url, port, projectRoot = findProjectRoot(), now = () => /* @__PURE__ */ new Date()) {
   try {
@@ -90775,116 +90921,6 @@ var init_target = __esm({
   }
 });
 
-// packages/rn-dev-agent-core/dist/domain/e2e-test.js
-import { dirname as dirname31, join as join55 } from "node:path";
-import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync10, readFileSync as readFileSync38, readdirSync as readdirSync15, existsSync as existsSync34 } from "node:fs";
-import { createHash as createHash22 } from "node:crypto";
-function e2eDirFor(projectRoot) {
-  return join55(projectRoot, ".rn-agent", "e2e");
-}
-function e2ePathFor(projectRoot, id) {
-  assertValidActionId(id, "e2ePathFor");
-  const dir = e2eDirFor(projectRoot);
-  const file = join55(dir, `${id}.yaml`);
-  assertWithinDir(file, dir);
-  return file;
-}
-function serializeLockedTest(meta) {
-  const header = [
-    "# e2e-locked-test: true",
-    `# id: ${meta.id}`,
-    `# intent: ${meta.intent}`,
-    `# sourceActionId: ${meta.sourceActionId}`,
-    `# lockedAt: ${meta.lockedAt}`,
-    `# lockedGitSha: ${meta.lockedGitSha ?? ""}`,
-    `# sourceContentHash: ${meta.sourceContentHash}`,
-    "# status: locked"
-  ];
-  if (meta.appId)
-    header.push(`# appId: ${meta.appId}`);
-  if (meta.params?.length)
-    header.push(`# params: ${meta.params.join(", ")}`);
-  header.push(FLOW_SENTINEL);
-  return `${header.join("\n")}
-${meta.flow}`;
-}
-function hashBody(s) {
-  return createHash22("sha256").update(s).digest("hex");
-}
-function freezeLockedTest(projectRoot, source, ctx) {
-  const filePath = e2ePathFor(projectRoot, source.id);
-  mkdirSync22(dirname31(filePath), { recursive: true });
-  const meta = {
-    id: source.id,
-    intent: source.intent,
-    sourceActionId: source.sourceActionId,
-    lockedAt: ctx.now().toISOString(),
-    lockedGitSha: ctx.gitSha,
-    sourceContentHash: hashBody(source.flow),
-    status: "locked",
-    params: source.params,
-    appId: source.appId,
-    flow: source.flow
-  };
-  const tmp = `${filePath}.tmp`;
-  writeFileSync18(tmp, serializeLockedTest(meta), "utf8");
-  renameSync10(tmp, filePath);
-  return { ...meta, filePath };
-}
-function loadLockedTest(projectRoot, id) {
-  const filePath = e2ePathFor(projectRoot, id);
-  if (!existsSync34(filePath))
-    return null;
-  return parseLockedTest(readFileSync38(filePath, "utf8"), filePath);
-}
-function discoverLockedTests(projectRoot) {
-  const dir = e2eDirFor(projectRoot);
-  if (!existsSync34(dir))
-    return [];
-  return readdirSync15(dir).filter((f) => f.endsWith(".yaml")).map((f) => f.replace(/\.yaml$/, "")).sort();
-}
-function parseLockedTest(text, filePath) {
-  if (!/^#\s*e2e-locked-test:\s*true\s*$/m.test(text))
-    return null;
-  const sentinelIdx = text.indexOf(FLOW_SENTINEL);
-  if (sentinelIdx < 0)
-    return null;
-  const headerText = text.slice(0, sentinelIdx);
-  const flowStart = text.indexOf("\n", sentinelIdx);
-  const flow = flowStart >= 0 ? text.slice(flowStart + 1) : "";
-  const field2 = (k) => {
-    const m = headerText.match(new RegExp(`^#\\s*${k}:\\s*(.*)$`, "m"));
-    const v = m?.[1]?.trim();
-    return v ? v : void 0;
-  };
-  const id = field2("id");
-  const intent = field2("intent");
-  if (!id || !intent)
-    return null;
-  const paramsRaw = field2("params");
-  return {
-    id,
-    intent,
-    sourceActionId: field2("sourceActionId") ?? id,
-    lockedAt: field2("lockedAt") ?? "",
-    lockedGitSha: field2("lockedGitSha") ?? null,
-    sourceContentHash: field2("sourceContentHash") ?? "",
-    status: "locked",
-    params: paramsRaw ? paramsRaw.split(",").map((s) => s.trim()).filter(Boolean) : void 0,
-    appId: field2("appId"),
-    flow,
-    filePath
-  };
-}
-var FLOW_SENTINEL;
-var init_e2e_test = __esm({
-  "packages/rn-dev-agent-core/dist/domain/e2e-test.js"() {
-    "use strict";
-    init_path_safety();
-    FLOW_SENTINEL = "# e2e-locked-flow-below";
-  }
-});
-
 // packages/rn-dev-agent-core/dist/domain/e2e-config.js
 import { readFileSync as readFileSync39 } from "node:fs";
 import { join as join56 } from "node:path";
@@ -91250,16 +91286,6 @@ function readMaestro(result) {
     return { passed: false, output: "unparseable maestro result" };
   }
 }
-function filterByPattern(ids, pattern) {
-  if (!pattern || pattern.length > 256)
-    return ids;
-  try {
-    const re = new RegExp(pattern, "i");
-    return ids.filter((id) => re.test(id));
-  } catch {
-    return ids;
-  }
-}
 async function runE2eSuiteCore(args, deps = {}) {
   const projectRoot = args.projectRoot ?? findProjectRoot() ?? process.cwd();
   const discover2 = deps.discover ?? discoverLockedTests;
@@ -91270,7 +91296,9 @@ async function runE2eSuiteCore(args, deps = {}) {
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
   const mkRunId = deps.makeRunId ?? makeRunId;
   const rand = () => Math.random().toString(36).slice(2, 8);
-  const ids = filterByPattern(discover2(projectRoot), args.pattern);
+  const ids = [
+    ...getResolvedLockedTestIds(args) ?? resolveLockedTestIds(projectRoot, args.pattern, discover2)
+  ];
   if (ids.length === 0) {
     return warnResult({
       runId: null,
@@ -93081,6 +93109,7 @@ var init_index = __esm({
     init_device_record();
     init_lock_e2e_test();
     init_run_e2e_suite();
+    init_e2e_test();
     init_e2e_run_request();
     init_preflight();
     init_device_screenshot_raw();
@@ -93389,6 +93418,13 @@ var init_index = __esm({
     localAuthorityProbe = createRuntimeAuthorityProbe(getClient);
     authorityGate = createAuthorityGate(authorityRuntime, {
       loginSupervisorOverrideToken: () => process.env.RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN,
+      resolveLockedE2eTestIds: (args, status) => {
+        const projectRoot = typeof args.projectRoot === "string" ? args.projectRoot : status.source.appRoot;
+        if (typeof projectRoot !== "string")
+          return [];
+        args.projectRoot = projectRoot;
+        return resolveLockedTestIds(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
+      },
       probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
       recoverRuntimeConnection: async (status) => {
         const current = getClient();
@@ -94736,8 +94772,8 @@ init_registry();
 init_managed_metro();
 init_android_metro_reverse();
 init_state_root();
-import { createHash as createHash14, randomBytes as randomBytes6, randomUUID as randomUUID8 } from "node:crypto";
-import { dirname as dirname19 } from "node:path";
+import { createHash as createHash15, randomBytes as randomBytes6, randomUUID as randomUUID8 } from "node:crypto";
+import { dirname as dirname20 } from "node:path";
 var RELEASABLE_SESSION_STATES = /* @__PURE__ */ new Set([
   "active",
   "source_bound",
@@ -94866,7 +94902,7 @@ function createSupervisorAuthority(input, dependencies = {}) {
       metroPort,
       observePort,
       ...adoptionRequired ? {
-        recoveryCapabilityHash: createHash14("sha256").update(recoveryCapability).digest("hex"),
+        recoveryCapabilityHash: createHash15("sha256").update(recoveryCapability).digest("hex"),
         adoptionRequired: {
           sessionId: adoptionRequired.sessionId,
           claimEpoch: adoptionRequired.claimEpoch
@@ -94910,7 +94946,7 @@ function createSupervisorAuthority(input, dependencies = {}) {
       RN_DEV_AGENT_SESSION_ID: session2.sessionId,
       RN_DEV_AGENT_CLAIM_EPOCH: String(session2.claimEpoch),
       RN_DEV_AGENT_REGISTRY_PATH: layout.registry,
-      RN_DEV_AGENT_STATE_DIR: dirname19(layout.root),
+      RN_DEV_AGENT_STATE_DIR: dirname20(layout.root),
       RN_DEV_AGENT_SESSION_SECRET_PATH: secretPath,
       RN_DEV_AGENT_SESSION_RUNTIME_ROOT: sessionRuntimeDirectory(layout, sessionId),
       RN_DEV_AGENT_WORKER_INSTANCE: workerInstance,
@@ -94981,7 +95017,7 @@ function createSupervisorAuthority(input, dependencies = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/supervisor-args.js
-import { dirname as dirname20, join as join36 } from "node:path";
+import { dirname as dirname21, join as join37 } from "node:path";
 function sqliteFlagForNode(version2) {
   const v = version2 ?? process.versions.node;
   const [majorStr, minorStr] = v.split(".");
@@ -95007,7 +95043,7 @@ function workerSpawnArgs(workerPath, sqliteWarningFilterPath2, version2, forward
     "--import",
     sqliteWarningFilterPath2,
     "--import",
-    join36(dirname20(sqliteWarningFilterPath2), "startup-integrity-register.js"),
+    join37(dirname21(sqliteWarningFilterPath2), "startup-integrity-register.js"),
     workerPath,
     "--no-lock",
     ...diagnosticArgs

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -30239,7 +30239,7 @@ function assertWritableActionFile(filePath) {
 function assertActionMetadataIdentity(filePath, metadata) {
   const fileId = basename7(filePath).replace(/\.ya?ml$/i, "");
   if (metadata.id !== fileId) {
-    throw new ActionMetadataIdentityError(metadata.id, fileId);
+    throw new Error(`Action metadata id ${metadata.id} does not match filename identity ${fileId}.`);
   }
 }
 function withMetadata(action, metadata) {
@@ -30248,7 +30248,7 @@ function withMetadata(action, metadata) {
 function withBody(action, body) {
   return { ...action, body };
 }
-var SaveActionPreconditionError, ActionMetadataIdentityError;
+var SaveActionPreconditionError;
 var init_action_store = __esm({
   "packages/rn-dev-agent-core/dist/domain/action-store.js"() {
     "use strict";
@@ -30264,16 +30264,6 @@ var init_action_store = __esm({
       constructor(filePath) {
         super(`saveAction precondition violated: yaml at ${filePath} has been edited externally since the in-memory action was loaded. The caller must invoke actionWasEditedExternally() first and abort on true (or use saveActionWithCAS for atomic detection). GH #113 contract enforcement.`);
         this.name = "SaveActionPreconditionError";
-      }
-    };
-    ActionMetadataIdentityError = class extends Error {
-      metadataId;
-      fileId;
-      constructor(metadataId, fileId) {
-        super(`Action metadata id ${metadataId} does not match filename identity ${fileId}.`);
-        this.metadataId = metadataId;
-        this.fileId = fileId;
-        this.name = "ActionMetadataIdentityError";
       }
     };
   }
@@ -81174,9 +81164,6 @@ function parseEnvelope2(result) {
     return { ok: false, code: "BAD_RESPONSE", error: "Action replay returned invalid JSON." };
   }
 }
-function isLoginActionIdentityMismatch(error2) {
-  return error2 instanceof ActionMetadataIdentityError && (error2.fileId === LOGIN_PROLOGUE_ALIAS || error2.metadataId === LOGIN_PROLOGUE_ALIAS);
-}
 function createLoginPrologueHandler(deps) {
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
   return async (args) => {
@@ -81228,7 +81215,7 @@ function createLoginPrologueHandler(deps) {
         inventory = await measure("inventory", () => listActions(projectRoot));
         action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
       } catch (error2) {
-        if (isLoginActionIdentityMismatch(error2)) {
+        if (error2 instanceof Error && error2.message.includes("does not match filename identity") && error2.message.includes(LOGIN_PROLOGUE_ALIAS)) {
           return blocked("LOGIN_ACTION_ID_MISMATCH", `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
         }
         throw error2;

--- a/packages/claude-plugin/skills/rn-testing/SKILL.md
+++ b/packages/claude-plugin/skills/rn-testing/SKILL.md
@@ -60,7 +60,7 @@ Do not silently take the cheaper path. The user reviewing your output cannot tel
 
 ### When shortcuts are legitimate
 
-- **Auth pre-flight** (`cdp_login_prologue` with a passing RunRecord) — bootstrap, not verification surface
+- **Auth pre-flight** (`cdp_login_prologue` with a passing RunRecord) — bootstrap helper, not PR proof or a durable authority capability
 - **Permission pre-flight** (granting via `device_permission`) — platform setup, declared upfront
 - **Test data seeding** (via app's test-only fixtures) — declared in the test plan
 - **Explicit user instruction** ("just deep-link to the details screen and check the layout") — user-sanctioned scope
@@ -332,7 +332,12 @@ and replays it with conservative runner and selector safety checks.
 
 Continue only when the result has `state: "passed"` and a fresh passing
 `runRecord`. The returned prologue and RunRecord timing fields separate
-inventory, resolution, replay, verification, and transport time.
+inventory, resolution, replay, verification, and transport time. Treat that
+pass as a navigation helper only: it is not PR proof and must not be used as
+a durable authority capability. Formal login proof is locking and running
+the login e2e on the exact candidate (`cdp_lock_e2e_test` /
+`cdp_run_e2e_suite`). Helper replay and locked e2e coexist without sharing
+that proof or rewriting each other's artifacts.
 
 `LOGIN_PROLOGUE_BLOCKED` is a terminal journey boundary. A missing action,
 runner drift, selector failure, timeout, or missing fresh RunRecord must not

--- a/packages/claude-plugin/skills/rn-testing/SKILL.md
+++ b/packages/claude-plugin/skills/rn-testing/SKILL.md
@@ -60,7 +60,7 @@ Do not silently take the cheaper path. The user reviewing your output cannot tel
 
 ### When shortcuts are legitimate
 
-- **Auth pre-flight** (compatible owned action; explicitly authorized legacy helper only when needed) — bootstrap, not verification surface
+- **Auth pre-flight** (`cdp_login_prologue` with a passing RunRecord) — bootstrap, not verification surface
 - **Permission pre-flight** (granting via `device_permission`) — platform setup, declared upfront
 - **Test data seeding** (via app's test-only fixtures) — declared in the test plan
 - **Explicit user instruction** ("just deep-link to the details screen and check the layout") — user-sanctioned scope
@@ -322,52 +322,32 @@ maestro_run(platform="android", deviceId="<exact emulator serial>", flowPath="fl
 
 ---
 
-## Auth Pre-flight: Approved Learned Actions (GH #10)
+## Auth Pre-flight: Deterministic Login Prologue
 
-Before testing features that require authentication, check if the app is
-on a login/auth screen. If so, authentication recovery must use a compatible
-action from the project's approved learned-action corpus.
+Before testing an authenticated feature, read the route with
+`cdp_navigation_state`. If the app is signed out, call
+`cdp_login_prologue` before any exploratory login interaction. The tool
+inventories learned actions, resolves only `.rn-agent/actions/user-login.yaml`,
+and replays it with conservative runner and selector safety checks.
 
-### Detection
+Continue only when the result has `state: "passed"` and a fresh passing
+`runRecord`. The returned prologue and RunRecord timing fields separate
+inventory, resolution, replay, verification, and transport time.
 
-Call `cdp_navigation_state` and check the route name. Auth-related routes
-typically match: `Login`, `Welcome`, `SignIn`, `Register`, `Onboarding`,
-`Auth`, `Landing`.
+`LOGIN_PROLOGUE_BLOCKED` is a terminal journey boundary. A missing action,
+runner drift, selector failure, timeout, or missing fresh RunRecord must not
+fall through to manual credential entry, `cdp_auto_login`, raw or ad-hoc
+Maestro, route injection, navigation shortcuts, or store mutation. Read-only
+diagnostics and cleanup remain available; repair the exact saved action and
+rerun the prologue.
 
-**Caution**: An empty navigation state may be a splash screen (loading) or
-the Dev Client picker (GH #9), not necessarily auth. Wait 3 seconds and
-retry before concluding the app is logged out.
+An empty navigation state may be a splash screen or Dev Client picker, not
+necessarily auth. Wait 3 seconds and retry before concluding the app is logged
+out.
 
-### Discovery and execution
-
-1. Run `/rn-dev-agent:list-learned-actions login`.
-2. Select one compatible owned action whose metadata establishes authenticated
-   state.
-3. Replay it through `cdp_run_action` on the exact authority-bound device.
-4. Treat any engine-pin, selector, or action-format incompatibility as terminal.
-5. If no compatible owned action exists, stop and report authentication as
-   blocked. Do not use manual taps, `.maestro` flows, ambient runners, or
-   `cdp_auto_login` as an automatic fallback.
-
-Only when the user explicitly authorizes legacy per-call navigation recovery may
-`cdp_auto_login` run. It is never durable login authority or PR proof; create or
-migrate an owned compatible action before proof.
-
-### Verification
-
-After replay completes, verify arrival at the main app:
-```
-cdp_navigation_state → route should be a main screen (Home, Dashboard, Tabs)
-```
-
-### Rules
-
-- **NEVER** fall back to manual login or an unowned replay flow
-- **ALWAYS** use `cdp_run_action` for the owned authentication action
-- **Skip** the notification `permissions` config if testing notification
-  permission flows (preserve undetermined state)
-- If no compatible owned login action exists, stop and report that
-  authentication cannot proceed through an authorized reusable flow
+A supervisor may authorize one otherwise-blocked mutation only with an
+out-of-band token configured as `RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN` and supplied
+as `supervisorOverrideToken`. Never infer, discover, log, or persist that token.
 
 ---
 

--- a/packages/claude-plugin/skills/using-rn-dev-agent/SKILL.md
+++ b/packages/claude-plugin/skills/using-rn-dev-agent/SKILL.md
@@ -106,7 +106,8 @@ What is the user asking for?
 ├── FREEZE a verified action into a locked regression test
 │   └─► /rn-dev-agent:lock-e2e <action-name>
 │       (Strict no-repair run via cdp_lock_e2e_test, freezes to .rn-agent/e2e/;
-│        the frozen suite runs via cdp_run_e2e_suite)
+│        the frozen suite runs via cdp_run_e2e_suite. For login, this is the
+│        formal PR proof on the exact candidate; cdp_login_prologue is not.)
 │
 ├── Watch tool activity live in a browser ("observability UI")
 │   └─► /rn-dev-agent:observe
@@ -160,7 +161,7 @@ These apply to every RN task:
 5. **Filter `cdp_component_tree` queries** — never dump the full tree (10K+ tokens wasted)
 6. **Stop at the first red flag** from the agent's red flags list
 7. **Run `/rn-dev-agent:list-learned-actions` BEFORE composing any `device_*` sequence.** If a saved action already covers the request, replay it via `cdp_run_action` (or `/rn-dev-agent:run-action`) first — that path runs the mutates/appId/param pre-flights and auto-repair; reserve raw `maestro_run` for non-action YAML flows. Manual primitives are a fallback, not a default. (Codified in `feedback_execute_artifacts_before_manual.md`. The original failure case: a 7-minute / 11-tool-call manual walk that an existing 23-second Maestro flow would have covered.)
-8. **Enter authenticated journeys through `cdp_login_prologue`.** It resolves only the exact `user-login` action and requires a fresh passing RunRecord. `LOGIN_PROLOGUE_BLOCKED` is terminal for the journey: do not use manual credentials, ad-hoc Maestro, navigation shortcuts, or store mutation afterward.
+8. **Enter authenticated journeys through `cdp_login_prologue`.** It resolves only the exact `user-login` action and requires a fresh passing RunRecord. That result is a navigation helper, not PR proof. `LOGIN_PROLOGUE_BLOCKED` is terminal for the journey: do not use manual credentials, ad-hoc Maestro, navigation shortcuts, or store mutation afterward. Formal login proof is `cdp_lock_e2e_test` / `cdp_run_e2e_suite` on the exact candidate; helper and locked tests coexist without sharing that proof.
 
 ### Ask First
 - Adding new dependencies to the user's project

--- a/packages/claude-plugin/skills/using-rn-dev-agent/SKILL.md
+++ b/packages/claude-plugin/skills/using-rn-dev-agent/SKILL.md
@@ -160,6 +160,7 @@ These apply to every RN task:
 5. **Filter `cdp_component_tree` queries** — never dump the full tree (10K+ tokens wasted)
 6. **Stop at the first red flag** from the agent's red flags list
 7. **Run `/rn-dev-agent:list-learned-actions` BEFORE composing any `device_*` sequence.** If a saved action already covers the request, replay it via `cdp_run_action` (or `/rn-dev-agent:run-action`) first — that path runs the mutates/appId/param pre-flights and auto-repair; reserve raw `maestro_run` for non-action YAML flows. Manual primitives are a fallback, not a default. (Codified in `feedback_execute_artifacts_before_manual.md`. The original failure case: a 7-minute / 11-tool-call manual walk that an existing 23-second Maestro flow would have covered.)
+8. **Enter authenticated journeys through `cdp_login_prologue`.** It resolves only the exact `user-login` action and requires a fresh passing RunRecord. `LOGIN_PROLOGUE_BLOCKED` is terminal for the journey: do not use manual credentials, ad-hoc Maestro, navigation shortcuts, or store mutation afterward.
 
 ### Ask First
 - Adding new dependencies to the user's project

--- a/packages/claude-plugin/templates/rn-agent/README.md
+++ b/packages/claude-plugin/templates/rn-agent/README.md
@@ -9,7 +9,8 @@ your project.
 If your project also has a `.maestro/` folder for hand-authored E2E tests,
 that's yours alone. Authentication prologues resolve the exact
 `.rn-agent/actions/user-login.yaml` learned action and never infer a login flow
-from `.maestro/` filenames.
+from `.maestro/` filenames. `cdp_login_prologue` is a navigation helper, not PR
+proof; lock and run the login e2e on the exact candidate for formal proof.
 
 ## Layout
 

--- a/packages/claude-plugin/templates/rn-agent/README.md
+++ b/packages/claude-plugin/templates/rn-agent/README.md
@@ -6,11 +6,10 @@ plugin for Claude Code and Codex. One folder, one doctrine — the plugin's
 entire footprint is `.rn-agent/` and it does not read or write anywhere else in
 your project.
 
-If your project also has a `.maestro/` folder for hand-authored E2E
-tests, that's yours alone. Those files are never learned-action authority or an
-automatic authentication fallback. The explicit legacy `cdp_auto_login` helper
-may inspect one only when the user authorizes that per-call navigation recovery;
-its result is never durable login authority or PR proof.
+If your project also has a `.maestro/` folder for hand-authored E2E tests,
+that's yours alone. Authentication prologues resolve the exact
+`.rn-agent/actions/user-login.yaml` learned action and never infer a login flow
+from `.maestro/` filenames.
 
 ## Layout
 

--- a/packages/codex-plugin/CLAUDE-MD-TEMPLATE.md
+++ b/packages/codex-plugin/CLAUDE-MD-TEMPLATE.md
@@ -48,8 +48,8 @@ exist as YAML).
    `/rn-dev-agent:run-action <flow-name> [-e KEY=VALUE …]` — pre-flights
    mutates flag, appId match, parameter coverage, action engine pin, and
    selector compatibility; it resolves pin-cache maestro-runner `>= 1.1.24` from
-   rn-dev-agent's versioned pin-cache. A passing replay IS your evidence —
-   skip ahead to capturing proof.
+   rn-dev-agent's versioned pin-cache. For non-login actions, a passing replay
+   IS your evidence — skip ahead to capturing proof.
 3. **Only if no non-login match (or replay fails with a concrete error):** fall back to
    manual primitives (`device_press` / `device_fill` / `device_find`). When
    you do, **end the session by persisting the verified flow** as a new YAML
@@ -175,15 +175,14 @@ The artifact-first rule generalizes from "replay if exact match" to
    `produces: { authenticated: true, route: home }` is the right
    prologue when current state is `LoginScreen` and the user wants
    anything that requires auth — even if the user's task isn't "log in"
-   per se. Replay that action via `cdp_run_action`. Re-verify state.
-   Then continue with interactive `cdp_*` / `device_*` tools for the
-   novel part.
+   per se. Replay it through `cdp_login_prologue`. Re-verify state. Then
+   continue with interactive `cdp_*` / `device_*` tools for the novel part.
 
 3. **No false-binary fallbacks.** Never fall back to a fully-manual
    walk when a partial replay (login prologue, onboarding skip, locale
-   set) covers half the work. The cost of one failed replay attempt is
-   `cdp_run_action`'s auto-repair budget (3/24h); the cost of a fully
-   manual walk is 30s+ of context-burning device interaction.
+   set) covers half the work. For non-login gaps, one failed replay attempt
+   costs `cdp_run_action`'s auto-repair budget (3/24h); a login-prologue failure
+   is terminal. A fully manual walk costs 30s+ of context-burning interaction.
 
 **Example — user says "go to home and tap the cart badge":**
 

--- a/packages/codex-plugin/CLAUDE-MD-TEMPLATE.md
+++ b/packages/codex-plugin/CLAUDE-MD-TEMPLATE.md
@@ -50,11 +50,18 @@ exist as YAML).
    selector compatibility; it resolves pin-cache maestro-runner `>= 1.1.24` from
    rn-dev-agent's versioned pin-cache. A passing replay IS your evidence —
    skip ahead to capturing proof.
-3. **Only if no match (or replay fails with a concrete error):** fall back to
+3. **Only if no non-login match (or replay fails with a concrete error):** fall back to
    manual primitives (`device_press` / `device_fill` / `device_find`). When
    you do, **end the session by persisting the verified flow** as a new YAML
    under `<test-app>/.rn-agent/actions/<feature-slug>.yaml` so the next session
    starts at step 2, not step 3.
+
+Authentication is fail-stop: when login is required, call
+`cdp_login_prologue`. It inventories learned actions, resolves only the exact
+`user-login` action, and requires a fresh passing RunRecord. Any missing action,
+runner drift, selector failure, or timeout returns `LOGIN_PROLOGUE_BLOCKED`.
+Do not continue with credentials, ad-hoc Maestro, navigation shortcuts, or
+store mutation after that result.
 
 Manual walks are a fallback, not a default. Codified in
 `feedback_execute_artifacts_before_manual.md`. Enforced as Step 0 of
@@ -76,18 +83,19 @@ manual when state mismatches; never re-walk a flow you already have.
    relevant slice. Note any mismatch with the expected starting state.
 2. **Compose action + manual.** If current state ≠ expected start, scan
    `list-learned-actions` for an action whose `produces` covers the gap.
-   Replay via `cdp_run_action`. Re-verify state. Then continue
+   Replay via `cdp_run_action`; for authentication, use
+   `cdp_login_prologue`. Re-verify state. Then continue
    interactively for the novel part.
 3. **No fully-manual fallback when partial replay would cover half the work.**
-   Login is the cardinal example — if a saved login action exists, use it
-   as a prologue, never re-walk login interactively.
+   Login is the cardinal example — enter through `cdp_login_prologue` and
+   never re-walk login interactively if the exact action is absent or fails.
 
 **Worked example.** User: "tap the cart badge."
 
 - Agent: `cdp_navigation_state` → `LoginScreen` (mismatch with home)
 - Agent: `list-learned-actions` → finds `user-login` with
   `produces: { authenticated: true, route: home }`
-- Agent: `cdp_run_action({ id: "user-login", params: { EMAIL, PASSWORD } })`
+- Agent: `cdp_login_prologue({ params: { EMAIL, PASSWORD } })` → fresh passing RunRecord
 - Agent: `cdp_navigation_state` → `HomeScreen` (state delta closed)
 - Agent: `cdp_component_tree({ filter: "cart" })` → finds `cart-badge` ref
 - Agent: `device_press({ ref: "cart-badge" })`
@@ -182,8 +190,7 @@ The artifact-first rule generalizes from "replay if exact match" to
 2. /rn-dev-agent:list-learned-actions  (or read .rn-agent/actions/ directly)
                                     → finds `user-login` with
                                       produces: { authenticated: true, route: home }
-3. cdp_run_action({                 (deterministic prologue, ~4s)
-     id: "user-login",
+3. cdp_login_prologue({             (deterministic fail-stop prologue)
      params: { EMAIL, PASSWORD }
    })
 4. cdp_navigation_state             → returns "HomeScreen" (state delta closed)
@@ -564,10 +571,9 @@ the runner's settle engine.
 
 Before testing **auth-gated features:**
 1. `cdp_navigation_state` — check if on a login screen
-2. Scan `/rn-dev-agent:list-learned-actions login` — a saved login action with `produces: { authenticated: true }` is the preferred prologue (replay via `cdp_run_action`, ~4s; see Hybrid composition)
-3. If no compatible owned action exists, stop and report authentication as blocked. Do not use manual login, `.maestro` flows, ambient runners, or `cdp_auto_login` as an automatic fallback.
-4. Only when the user explicitly authorizes legacy per-call navigation recovery may `cdp_auto_login` run. It is never durable login authority or PR proof; create or migrate an owned compatible action before proof.
-5. `cdp_navigation_state` — verify arrival at home/target screen
+2. Call `cdp_login_prologue` — it inventories and resolves the exact `user-login` action itself
+3. Require `state: "passed"` plus a fresh passing `runRecord`; only then continue
+4. On `LOGIN_PROLOGUE_BLOCKED`, stop the journey; never fall through to manual credentials, `cdp_auto_login`, or ad-hoc Maestro
 
 Before testing **permission-gated features:**
 1. `device_permission(action="query", permission="<name>")` — check current state

--- a/packages/codex-plugin/CLAUDE-MD-TEMPLATE.md
+++ b/packages/codex-plugin/CLAUDE-MD-TEMPLATE.md
@@ -58,10 +58,12 @@ exist as YAML).
 
 Authentication is fail-stop: when login is required, call
 `cdp_login_prologue`. It inventories learned actions, resolves only the exact
-`user-login` action, and requires a fresh passing RunRecord. Any missing action,
-runner drift, selector failure, or timeout returns `LOGIN_PROLOGUE_BLOCKED`.
-Do not continue with credentials, ad-hoc Maestro, navigation shortcuts, or
-store mutation after that result.
+`user-login` action, and requires a fresh passing RunRecord. That result is a
+navigation helper, not PR proof. Any missing action, runner drift, selector
+failure, or timeout returns `LOGIN_PROLOGUE_BLOCKED`. Do not continue with
+credentials, ad-hoc Maestro, navigation shortcuts, or store mutation after
+that result. Formal login proof is `cdp_lock_e2e_test` / `cdp_run_e2e_suite` on
+the exact candidate; helper and locked tests coexist without sharing that proof.
 
 Manual walks are a fallback, not a default. Codified in
 `feedback_execute_artifacts_before_manual.md`. Enforced as Step 0 of
@@ -572,8 +574,9 @@ the runner's settle engine.
 Before testing **auth-gated features:**
 1. `cdp_navigation_state` — check if on a login screen
 2. Call `cdp_login_prologue` — it inventories and resolves the exact `user-login` action itself
-3. Require `state: "passed"` plus a fresh passing `runRecord`; only then continue
+3. Require `state: "passed"` plus a fresh passing `runRecord`; only then continue. Treat that pass as a navigation helper, not PR proof
 4. On `LOGIN_PROLOGUE_BLOCKED`, stop the journey; never fall through to manual credentials, `cdp_auto_login`, or ad-hoc Maestro
+5. Formal login proof is locking and running the login e2e on the exact candidate (`cdp_lock_e2e_test` / `cdp_run_e2e_suite`)
 
 Before testing **permission-gated features:**
 1. `device_permission(action="query", permission="<name>")` — check current state

--- a/packages/codex-plugin/agents/rn-tester.md
+++ b/packages/codex-plugin/agents/rn-tester.md
@@ -161,39 +161,20 @@ Write a brief test plan BEFORE executing:
 - Expected outcome at each step (UI + data)
 - Edge cases to verify
 
-### Step 2.5: Auth Pre-flight Check (GH #10)
+### Step 2.5: Deterministic Login Prologue
 
-Before navigating, check if the app is on an auth-gated screen (login,
-welcome, registration, onboarding). Authentication recovery must use a
-compatible action from the project's approved learned-action corpus.
-
-1. Call `cdp_navigation_state`. Check the current route name.
-2. If the navigation state is **empty or minimal**, the app may still
-   be loading (splash screen, token rehydration). Wait 3 seconds and
-   retry `cdp_navigation_state`. If the route remains unavailable, use a
-   device snapshot to distinguish the Dev Client picker from an auth screen;
-   passive `cdp_status` never dismisses UI.
-3. If the route suggests the user is logged out (common patterns:
-   `Login`, `Welcome`, `SignIn`, `Register`, `Onboarding`, `Auth`,
-   `Landing`):
-
-   a. Run `$rn-dev-agent:list-learned-actions login` and select one compatible
-      owned action whose metadata establishes authenticated state.
-   b. Replay it through `cdp_run_action` on the exact authority-bound device.
-      Any engine-pin, selector, or action-format incompatibility is terminal.
-   c. If no compatible owned action exists, stop and report authentication as
-      blocked. Do not use manual taps, `.maestro` flows, ambient runners, or
-      `cdp_auto_login` as an automatic fallback.
-   d. Only when the user explicitly authorizes legacy per-call navigation
-      recovery may `cdp_auto_login` run. It is never durable login authority or
-      PR proof; create or migrate an owned compatible action before proof.
-   e. **Verify arrival** at the home/main screen:
-      ```
-      cdp_navigation_state  → confirm route is NOT auth-related
-      ```
-
-4. If the route is a main app screen (home, dashboard, tabs, etc.),
-   skip this step — the user is already authenticated.
+1. Call `cdp_navigation_state` and distinguish a stable auth route from a
+   loading or Dev Client picker state. If navigation is empty or minimal,
+   wait 3 seconds and retry before concluding the app is signed out.
+2. If the app is signed out, call `cdp_login_prologue`. Do not inspect or
+   explore login controls first.
+3. Continue only with `state: "passed"` and a fresh passing `runRecord`.
+4. Treat `LOGIN_PROLOGUE_BLOCKED` as terminal. Do not enter credentials, run
+   ad-hoc Maestro, inject routes, mutate stores, or navigate to the story. Use
+   read-only diagnostics to repair the exact `user-login` action, then rerun
+   the prologue.
+5. A supervisor override is valid only when supplied out of band for one call;
+   never search for, infer, log, or persist its token.
 
 ### Step 2.6: Permission Pre-flight Check (GH #11)
 

--- a/packages/codex-plugin/agents/rn-tester.md
+++ b/packages/codex-plugin/agents/rn-tester.md
@@ -169,10 +169,13 @@ Write a brief test plan BEFORE executing:
 2. If the app is signed out, call `cdp_login_prologue`. Do not inspect or
    explore login controls first.
 3. Continue only with `state: "passed"` and a fresh passing `runRecord`.
+   That result is a navigation helper, not PR proof.
 4. Treat `LOGIN_PROLOGUE_BLOCKED` as terminal. Do not enter credentials, run
    ad-hoc Maestro, inject routes, mutate stores, or navigate to the story. Use
    read-only diagnostics to repair the exact `user-login` action, then rerun
-   the prologue.
+   the prologue. Locked e2e login proof (`cdp_lock_e2e_test` /
+   `cdp_run_e2e_suite` on the exact candidate) remains available and does not
+   lift or replace the helper gate.
 5. A supervisor override is valid only when supplied out of band for one call;
    never search for, infer, log, or persist its token.
 

--- a/packages/codex-plugin/commands/lock-e2e.md
+++ b/packages/codex-plugin/commands/lock-e2e.md
@@ -20,6 +20,9 @@ read-only discovery diagnosis.
 3. On `PARAMS_UNSUPPORTED`, explain that this lock version supports param-free
    actions only.
 4. On success, report the frozen path and inclusion in `cdp_run_e2e_suite`.
+5. For login, this locked test is the formal PR proof on the exact candidate.
+   `cdp_login_prologue` is only a navigation helper and must not be treated as
+   that proof.
 
 Do not bypass strict replay, edit the frozen output directly, or substitute a
 raw Maestro result.

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -31930,22 +31930,20 @@ function tokenMatches(expected, supplied) {
   const suppliedHash = createHash7("sha256").update(supplied).digest();
   return timingSafeEqual3(expectedHash, suppliedHash);
 }
-function evaluateLoginPrologueGuard(input) {
+function inspectLoginPrologueGuard(input) {
   const outcome = readLoginPrologueOutcome(input.binding);
-  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation) {
-    return { allowed: true, override: false };
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args)) {
+    return { blocked: false };
   }
-  if (cleanupAllowed(input.tool, input.args))
-    return { allowed: true, override: false };
-  const supplied = typeof input.args.supervisorOverrideToken === "string" ? input.args.supervisorOverrideToken : void 0;
-  if (tokenMatches(input.expectedOverrideToken, supplied)) {
-    return {
-      allowed: true,
-      override: true,
-      audit: { tool: input.tool, usedAt: (input.now ?? (() => /* @__PURE__ */ new Date()))().toISOString() }
-    };
-  }
-  return { allowed: false, suppliedOverride: supplied !== void 0 };
+  return {
+    blocked: true,
+    suppliedOverride: typeof input.args.supervisorOverrideToken === "string" ? input.args.supervisorOverrideToken : void 0
+  };
+}
+function authorizeLoginSupervisorOverride(input) {
+  if (!tokenMatches(input.expectedOverrideToken, input.suppliedOverrideToken))
+    return null;
+  return { tool: input.tool, usedAt: (input.now ?? (() => /* @__PURE__ */ new Date()))().toISOString() };
 }
 function appendLoginOverrideAudit(outcome, audit) {
   return { ...outcome, overrides: [...outcome.overrides ?? [], audit].slice(-20) };
@@ -32925,22 +32923,22 @@ function createAuthorityGate(runtime, dependencies) {
         liveBundleProbe: tool === "proof_capture"
       } : baseProfile;
       const runtimeStatus = runtime.status();
-      const loginDecision = evaluateLoginPrologueGuard({
+      const loginGuard = inspectLoginPrologueGuard({
         binding: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
         tool,
         args,
-        mutation: profile.mutation,
-        expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.()
+        mutation: profile.mutation
       });
+      const pendingSupervisorOverrideToken = loginGuard.blocked ? loginGuard.suppliedOverride : void 0;
       delete args.supervisorOverrideToken;
-      if (!loginDecision.allowed) {
+      if (loginGuard.blocked && pendingSupervisorOverrideToken === void 0) {
         return failResult("LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.", "LOGIN_PROLOGUE_BLOCKED", {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
-          overrideRejected: loginDecision.suppliedOverride,
+          overrideRejected: false,
           nextAction: "Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call."
         });
       }
-      if (loginDecision.override && profile.kind === "transition") {
+      if (loginGuard.blocked && profile.kind === "transition") {
         return failResult("LOGIN_PROLOGUE_BLOCKED: supervisor overrides cannot authorize transition mutations.", "LOGIN_PROLOGUE_BLOCKED", {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
           transitionOverrideRejected: true,
@@ -33201,6 +33199,7 @@ function createAuthorityGate(runtime, dependencies) {
       let retainProofCleanupFence = false;
       let publishedProofFinalize = false;
       let stagedRuntimeRelaunch;
+      let loginPrologueAttemptOperationId = null;
       try {
         const available = runtime.requireAvailable();
         registry2 = available.registry;
@@ -33209,13 +33208,23 @@ function createAuthorityGate(runtime, dependencies) {
           throw new SessionAuthorityError(initialStatus.code, initialStatus.reason);
         }
         let status = initialStatus;
-        requireCompleteAxes(status, profile);
-        bindSessionArguments(status, profile, args, tool);
+        if (tool !== "cdp_login_prologue") {
+          requireCompleteAxes(status, profile);
+          bindSessionArguments(status, profile, args, tool);
+        }
         operation = registry2.beginOperation(available.session, {
           operationId: randomUUID4(),
           tool,
           profile: profile.axes.join("")
         });
+        if (tool === "cdp_login_prologue") {
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome());
+          operation = persisted.operation;
+          status = persisted.status;
+          loginPrologueAttemptOperationId = operation.operationId;
+          requireCompleteAxes(status, profile);
+          bindSessionArguments(status, profile, args, tool);
+        }
         const preflightRecovery = await reconcileRecoverableRuntime(runtime, dependencies, registry2, operation, status, profile, true);
         operation = preflightRecovery.operation;
         status = preflightRecovery.status;
@@ -33561,17 +33570,20 @@ function createAuthorityGate(runtime, dependencies) {
             }
           });
         }
-        if (loginDecision.override) {
+        if (pendingSupervisorOverrideToken !== void 0) {
           const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
           if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
             throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
           }
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, loginDecision.audit));
-          operation = persisted.operation;
-          status = persisted.status;
-        }
-        if (tool === "cdp_login_prologue") {
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome());
+          const audit = authorizeLoginSupervisorOverride({
+            expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
+            suppliedOverrideToken: pendingSupervisorOverrideToken,
+            tool
+          });
+          if (!audit) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the supervisor override token was rejected under the operation fence");
+          }
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, audit));
           operation = persisted.operation;
           status = persisted.status;
         }
@@ -33760,6 +33772,10 @@ function createAuthorityGate(runtime, dependencies) {
           registry2.commitPlatformAuthorityReceipts(operation);
         }
         if (operation && loginPrologueOutcome?.state === "passed") {
+          const pendingOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+          if (operation.operationId !== loginPrologueAttemptOperationId || pendingOutcome?.state !== LOGIN_PROLOGUE_BLOCKED || pendingOutcome.failure?.code !== "LOGIN_PROLOGUE_IN_PROGRESS") {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the passing login result does not match the active blocked attempt");
+          }
           const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
           operation = persisted.operation;
           status = persisted.status;
@@ -78134,6 +78150,14 @@ function getWorkerAuthorityRuntime() {
 init_resolve_ios_app_file();
 init_action_engine_compat();
 init_engine_pin();
+var strictRunActionPolicy = /* @__PURE__ */ Symbol("strictRunActionPolicy");
+function sealStrictRunAction(args) {
+  Object.defineProperty(args, strictRunActionPolicy, { value: true });
+  return args;
+}
+function usesStrictRunActionPolicy(args) {
+  return args[strictRunActionPolicy] === true;
+}
 function boundInstallReceipt() {
   try {
     const status = getWorkerAuthorityRuntime().status();
@@ -78391,9 +78415,9 @@ function createRunActionHandler(deps = {}) {
     });
     try {
       let atRisk = null;
-      const cdpFallbackForbidden = args.cdpFallbackMode === "forbid";
+      const strictExecutor = usesStrictRunActionPolicy(args);
       const inheritedBlindProbeDisabled = process.env.RN_BLIND_PROBE === "0" || process.env.RN_BLIND_PROBE === "false";
-      const blindProbeDisabled = cdpFallbackForbidden || args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
+      const blindProbeDisabled = strictExecutor || args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
       if (args.platform !== "android") {
         const ctx = await blindProbeContext2().catch(() => null);
         if (ctx) {
@@ -78579,7 +78603,7 @@ function createRunActionHandler(deps = {}) {
         }
       }
       let cdpJsFallback;
-      if (!cdpFallbackForbidden && (failure.kind === "SELECTOR_NOT_FOUND" || failure.kind === "UNKNOWN")) {
+      if (!strictExecutor && (failure.kind === "SELECTOR_NOT_FOUND" || failure.kind === "UNKNOWN")) {
         const candidate = getReplayDeps(args);
         const replayDeps = candidate && await claimBundleAuthority(args) ? candidate : null;
         const probe = !replayDeps ? null : failure.kind === "SELECTOR_NOT_FOUND" ? failure.selector : firstReplayTestId(cdpReplayYaml, args.params ?? {});
@@ -79032,9 +79056,9 @@ function createLoginPrologueHandler(deps) {
         forceReload: false,
         proofReplay: false,
         blindProbeMode: "forbid",
-        cdpFallbackMode: "forbid",
         trigger: args.trigger ?? "agent"
       });
+      sealStrictRunAction(replayArgs);
       let replayResult;
       try {
         replayResult = await measure("replay", () => deps.runAction(replayArgs));

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -32654,11 +32654,12 @@ function missingLoginPrologueOutcome() {
 }
 function persistLoginPrologueOutcome(runtime, registry2, operation, status, outcome) {
   const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+  const overrides = outcome.overrides ?? priorOutcome?.overrides;
   const nextOperation = registry2.replaceBindingsDuringOperation(operation, {
     bindings: {
       loginPrologue: {
         ...outcome,
-        ...priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}
+        ...overrides ? { overrides } : {}
       }
     }
   });
@@ -32906,7 +32907,7 @@ function createAuthorityGate(runtime, dependencies) {
         mutation: true,
         liveBundleProbe: tool === "proof_capture"
       } : baseProfile;
-      let runtimeStatus = runtime.status();
+      const runtimeStatus = runtime.status();
       const loginDecision = evaluateLoginPrologueGuard({
         binding: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
         tool,
@@ -32921,24 +32922,6 @@ function createAuthorityGate(runtime, dependencies) {
           overrideRejected: loginDecision.suppliedOverride,
           nextAction: "Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call."
         });
-      }
-      if (loginDecision.override) {
-        try {
-          const available = runtime.requireAvailable();
-          const current = runtime.status();
-          const outcome = current.available ? readLoginPrologueOutcome(current.bindings.loginPrologue) : null;
-          if (!outcome) {
-            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
-          }
-          available.registry.updateBindings(available.session, {
-            bindings: {
-              loginPrologue: appendLoginOverrideAudit(outcome, loginDecision.audit)
-            }
-          });
-          runtimeStatus = runtime.status();
-        } catch (error2) {
-          return authorityFailure(error2);
-        }
       }
       if (profile.kind === "diagnostic") {
         return addMeta2(await handler(...handlerArgs), { authoritative: false });
@@ -33554,6 +33537,15 @@ function createAuthorityGate(runtime, dependencies) {
             }
           });
         }
+        if (loginDecision.override) {
+          const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+          if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
+          }
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, loginDecision.audit));
+          operation = persisted.operation;
+          status = persisted.status;
+        }
         registry2.verifyOperation(operation);
         const snapshotCheckpoint = dependencies.snapshotCaptureCheckpoint?.();
         let result = await registry2.runWithOperation(operation, () => handler(...handlerArgs));
@@ -33689,11 +33681,6 @@ function createAuthorityGate(runtime, dependencies) {
           axes: [...runnerAwareReceiptProfile.axes, "M", "A"]
         } : runnerAwareReceiptProfile;
         const controllerGenerationAdvanced = operation.authorityVersion !== initialOperationAuthorityVersion;
-        if (loginPrologueOutcome?.state === "passed") {
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
-          operation = persisted.operation;
-          status = persisted.status;
-        }
         registry2.verifyOperation(operation);
         for (const observation of allBefore) {
           if (controllerGenerationAdvanced && observation.axis === "C")
@@ -33742,6 +33729,11 @@ function createAuthorityGate(runtime, dependencies) {
         }
         if (operation && receiptsCommittable) {
           registry2.commitPlatformAuthorityReceipts(operation);
+        }
+        if (operation && loginPrologueOutcome?.state === "passed") {
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
+          operation = persisted.operation;
+          status = persisted.status;
         }
         return addMeta2(result, {
           ...nativeOriginMeta(profile, nativeOriginProven),
@@ -78475,7 +78467,8 @@ function createRunActionHandler(deps = {}) {
       const firstFailureDetail = readMaestroFailureDetail(firstEnv, firstOutput);
       const firstDeviceAuthority = readMaestroDeviceAuthority(firstEnv);
       probeDeviceId = firstDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
-      if (firstEnv.code === "DEVICE_AUTHORITY_MISMATCH") {
+      if (firstEnv.code) {
+        const typedCode = firstEnv.code;
         const autoRepair2 = {
           attempted: false,
           outcome: args.autoRepair === false ? "refused" : "skipped",
@@ -78486,14 +78479,14 @@ function createRunActionHandler(deps = {}) {
           timestamp: (/* @__PURE__ */ new Date()).toISOString(),
           durationMs: Date.now() - t0,
           status: "fail",
-          failureCode: "DEVICE_AUTHORITY_MISMATCH",
+          failureCode: typedCode === "DEVICE_AUTHORITY_MISMATCH" ? "DEVICE_AUTHORITY_MISMATCH" : typedCode === "RECONNECT_TIMEOUT" ? "TIMEOUT" : "UNKNOWN",
           failureDetail: firstFailureDetail.slice(0, 1e3),
           trigger,
           autoRepair: autoRepair2
         });
-        return failResult(`cdp_run_action: ${args.actionId} refused replay authority: ${firstFailureDetail}`, "DEVICE_AUTHORITY_MISMATCH", {
+        return failResult(`cdp_run_action: ${args.actionId} refused replay: ${firstFailureDetail}`, typedCode, {
           actionId: args.actionId,
-          failureKind: "DEVICE_AUTHORITY_MISMATCH",
+          failureKind: typedCode,
           deviceAuthority: firstDeviceAuthority,
           autoRepair: autoRepair2,
           writes: writeDisclosure("none", persisted2)
@@ -78995,8 +78988,11 @@ function createLoginPrologueHandler(deps) {
     try {
       inventory = await measure("inventory", () => listActions(projectRoot));
       const action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
-      if (!action || !inventory.some((candidate) => candidate.id === LOGIN_PROLOGUE_ALIAS)) {
+      if (!action) {
         return blocked("LOGIN_ACTION_MISSING", `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
+      }
+      if (action.metadata.id !== LOGIN_PROLOGUE_ALIAS) {
+        return blocked("LOGIN_ACTION_ID_MISMATCH", `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
       }
       const priorRunIds = new Set(action.state.runHistory.map((record2) => record2.runId).filter((runId) => typeof runId === "string"));
       const replayArgs = Object.create(Object.getPrototypeOf(args), Object.getOwnPropertyDescriptors(args));

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -9244,7 +9244,7 @@ var require_websocket = __commonJS({
     var http = __require("http");
     var net = __require("net");
     var tls = __require("tls");
-    var { randomBytes: randomBytes8, createHash: createHash23 } = __require("crypto");
+    var { randomBytes: randomBytes8, createHash: createHash24 } = __require("crypto");
     var { Duplex, Readable } = __require("stream");
     var { URL: URL2 } = __require("url");
     var PerMessageDeflate2 = require_permessage_deflate();
@@ -9912,7 +9912,7 @@ var require_websocket = __commonJS({
           abortHandshake(websocket, socket, "Invalid Upgrade header");
           return;
         }
-        const digest3 = createHash23("sha1").update(key + GUID).digest("base64");
+        const digest3 = createHash24("sha1").update(key + GUID).digest("base64");
         if (res.headers["sec-websocket-accept"] !== digest3) {
           abortHandshake(websocket, socket, "Invalid Sec-WebSocket-Accept header");
           return;
@@ -10281,7 +10281,7 @@ var require_websocket_server = __commonJS({
     var EventEmitter = __require("events");
     var http = __require("http");
     var { Duplex } = __require("stream");
-    var { createHash: createHash23 } = __require("crypto");
+    var { createHash: createHash24 } = __require("crypto");
     var extension2 = require_extension();
     var PerMessageDeflate2 = require_permessage_deflate();
     var subprotocol2 = require_subprotocol();
@@ -10588,7 +10588,7 @@ var require_websocket_server = __commonJS({
           );
         }
         if (this._state > RUNNING) return abortHandshake(socket, 503);
-        const digest3 = createHash23("sha1").update(key + GUID).digest("base64");
+        const digest3 = createHash24("sha1").update(key + GUID).digest("base64");
         const headers = [
           "HTTP/1.1 101 Switching Protocols",
           "Upgrade: websocket",
@@ -30261,8 +30261,8 @@ var init_registry = __esm({
           const handoff = this.#database.prepare("SELECT token_hash, consumed_ms FROM handoffs WHERE handoff_id = ?").get(input.handoffId);
           const expected = Buffer.from(typeof handoff?.token_hash === "string" ? handoff.token_hash : "", "hex");
           const actual = createHash5("sha256").update(input.token).digest();
-          const tokenMatches = expected.length === actual.length && timingSafeEqual2(expected, actual);
-          if (!row || row.state !== "handoff_cleanup" || row.claim_epoch !== target.claimEpoch || row.worker_instance !== input.targetInstance || cleanup?.handoffId !== input.handoffId || cleanup?.targetSessionId !== target.sessionId || cleanup?.targetClaimEpoch !== target.claimEpoch || typeof handoff?.consumed_ms !== "number" || !tokenMatches) {
+          const tokenMatches2 = expected.length === actual.length && timingSafeEqual2(expected, actual);
+          if (!row || row.state !== "handoff_cleanup" || row.claim_epoch !== target.claimEpoch || row.worker_instance !== input.targetInstance || cleanup?.handoffId !== input.handoffId || cleanup?.targetSessionId !== target.sessionId || cleanup?.targetClaimEpoch !== target.claimEpoch || typeof handoff?.consumed_ms !== "number" || !tokenMatches2) {
             throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "handoff cleanup resumption requires the original handoff capability");
           }
         });
@@ -31896,6 +31896,69 @@ var init_install_reissue = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/login-prologue.js
+import { createHash as createHash7, timingSafeEqual as timingSafeEqual3 } from "node:crypto";
+function readLoginPrologueOutcome(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    return null;
+  const candidate = value;
+  if (candidate.schemaVersion !== 1 || candidate.alias !== LOGIN_PROLOGUE_ALIAS || candidate.state !== "passed" && candidate.state !== LOGIN_PROLOGUE_BLOCKED || typeof candidate.startedAt !== "string" || typeof candidate.endedAt !== "string" || typeof candidate.elapsedMs !== "number" || !Array.isArray(candidate.steps)) {
+    return null;
+  }
+  return candidate;
+}
+function cleanupAllowed(tool, args) {
+  if (tool === "cdp_login_prologue")
+    return true;
+  if (tool === "cdp_disconnect")
+    return true;
+  if (tool === "device_snapshot" && args.action === "close")
+    return true;
+  if (tool === "device_record" && (args.action === "stop" || args.action === "status"))
+    return true;
+  if (tool === "observe" && (args.action === "stop" || args.action === "status"))
+    return true;
+  if (tool === "proof_capture" && (args.action === "discard" || args.action === "status")) {
+    return true;
+  }
+  return tool === "rn_session" && (args.action === "release" || args.action === "stop_metro" || args.action === "cancel_handoff" || args.action === "status");
+}
+function tokenMatches(expected, supplied) {
+  if (!expected || expected.length < 16 || !supplied || supplied.length < 16)
+    return false;
+  const expectedHash = createHash7("sha256").update(expected).digest();
+  const suppliedHash = createHash7("sha256").update(supplied).digest();
+  return timingSafeEqual3(expectedHash, suppliedHash);
+}
+function evaluateLoginPrologueGuard(input) {
+  const outcome = readLoginPrologueOutcome(input.binding);
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation) {
+    return { allowed: true, override: false };
+  }
+  if (cleanupAllowed(input.tool, input.args))
+    return { allowed: true, override: false };
+  const supplied = typeof input.args.supervisorOverrideToken === "string" ? input.args.supervisorOverrideToken : void 0;
+  if (tokenMatches(input.expectedOverrideToken, supplied)) {
+    return {
+      allowed: true,
+      override: true,
+      audit: { tool: input.tool, usedAt: (input.now ?? (() => /* @__PURE__ */ new Date()))().toISOString() }
+    };
+  }
+  return { allowed: false, suppliedOverride: supplied !== void 0 };
+}
+function appendLoginOverrideAudit(outcome, audit) {
+  return { ...outcome, overrides: [...outcome.overrides ?? [], audit].slice(-20) };
+}
+var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED;
+var init_login_prologue = __esm({
+  "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
+    "use strict";
+    LOGIN_PROLOGUE_ALIAS = "user-login";
+    LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -32086,7 +32149,7 @@ var init_tool_profiles = __esm({
       "maestro_test_all"
     ];
     hybridMutation = ["cdp_auto_login", "cdp_run_e2e_suite"];
-    optionalHybridMutation = ["cdp_run_action"];
+    optionalHybridMutation = ["cdp_login_prologue", "cdp_run_action"];
     nativeDiagnostic = ["cdp_native_errors"];
     inlineMaestroMutation = /* @__PURE__ */ new Set([
       "device_accept_system_dialog",
@@ -32564,6 +32627,34 @@ function authorityFailure(error2) {
   const code = /^([A-Z][A-Z0-9_]+):/.exec(message)?.[1];
   return failResult(message, code ?? "AUTHORITY_LOST_DURING_OPERATION");
 }
+function parseLoginPrologueOutcome(result) {
+  try {
+    const envelope = JSON.parse(result.content?.[0]?.text ?? "{}");
+    return readLoginPrologueOutcome(envelope.data ?? envelope.meta?.loginPrologue);
+  } catch {
+    return null;
+  }
+}
+function missingLoginPrologueOutcome() {
+  const timestamp = (/* @__PURE__ */ new Date()).toISOString();
+  return {
+    schemaVersion: 1,
+    state: LOGIN_PROLOGUE_BLOCKED,
+    alias: LOGIN_PROLOGUE_ALIAS,
+    startedAt: timestamp,
+    endedAt: timestamp,
+    elapsedMs: 0,
+    steps: [],
+    inventory: { count: 0, actionIds: [] },
+    failure: {
+      code: "LOGIN_PROLOGUE_RESULT_INVALID",
+      detail: "The login prologue returned no valid terminal state."
+    }
+  };
+}
+function isActionReplayTool(tool) {
+  return tool === "cdp_run_action" || tool === "cdp_login_prologue";
+}
 function authorityErrorCode(error2) {
   return error2 instanceof SessionAuthorityError ? error2.code : /^([A-Z][A-Z0-9_]+):/.exec(error2 instanceof Error ? error2.message : String(error2))?.[1];
 }
@@ -32799,10 +32890,43 @@ function createAuthorityGate(runtime, dependencies) {
         mutation: true,
         liveBundleProbe: tool === "proof_capture"
       } : baseProfile;
+      let runtimeStatus = runtime.status();
+      const loginDecision = evaluateLoginPrologueGuard({
+        binding: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
+        tool,
+        args,
+        mutation: profile.mutation,
+        expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.()
+      });
+      delete args.supervisorOverrideToken;
+      if (!loginDecision.allowed) {
+        return failResult("LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.", "LOGIN_PROLOGUE_BLOCKED", {
+          loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
+          overrideRejected: loginDecision.suppliedOverride,
+          nextAction: "Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call."
+        });
+      }
+      if (loginDecision.override) {
+        try {
+          const available = runtime.requireAvailable();
+          const current = runtime.status();
+          const outcome = current.available ? readLoginPrologueOutcome(current.bindings.loginPrologue) : null;
+          if (!outcome) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
+          }
+          available.registry.updateBindings(available.session, {
+            bindings: {
+              loginPrologue: appendLoginOverrideAudit(outcome, loginDecision.audit)
+            }
+          });
+          runtimeStatus = runtime.status();
+        } catch (error2) {
+          return authorityFailure(error2);
+        }
+      }
       if (profile.kind === "diagnostic") {
         return addMeta2(await handler(...handlerArgs), { authoritative: false });
       }
-      const runtimeStatus = runtime.status();
       if (runtimeStatus.available && runtimeStatus.state === "blocked") {
         return authorityFailure(runtime.blockedContenderError());
       }
@@ -33416,7 +33540,15 @@ function createAuthorityGate(runtime, dependencies) {
         }
         registry2.verifyOperation(operation);
         const snapshotCheckpoint = dependencies.snapshotCaptureCheckpoint?.();
-        const result = await registry2.runWithOperation(operation, () => handler(...handlerArgs));
+        let result = await registry2.runWithOperation(operation, () => handler(...handlerArgs));
+        let loginPrologueOutcome = null;
+        if (tool === "cdp_login_prologue") {
+          loginPrologueOutcome = parseLoginPrologueOutcome(result);
+          if (!loginPrologueOutcome) {
+            loginPrologueOutcome = missingLoginPrologueOutcome();
+            result = failResult("Login prologue returned no valid terminal state.", "LOGIN_PROLOGUE_BLOCKED", { loginPrologue: loginPrologueOutcome });
+          }
+        }
         let runtimeTargetChanged = false;
         const postHandlerRecovery = await reconcileRecoverableRuntime(runtime, dependencies, registry2, operation, status, profile, resultSucceeded(result));
         operation = postHandlerRecovery.operation;
@@ -33439,7 +33571,7 @@ function createAuthorityGate(runtime, dependencies) {
         }
         publishedProofFinalize = tool === "proof_capture" && args.action === "finalize" && resultIsCanonicalSuccess(result);
         const directRuntimeReset = tool === "cdp_reload" || tool === "cdp_restart";
-        const nestedRuntimeReset = tool === "cdp_run_e2e_suite" || tool === "cdp_auto_login" || tool === "cdp_nav_graph" && args.action === "go" || tool === "cdp_run_action" && (optionalBundleClaimed || optionalBundleRecoveryFailed);
+        const nestedRuntimeReset = tool === "cdp_run_e2e_suite" || tool === "cdp_auto_login" || tool === "cdp_nav_graph" && args.action === "go" || isActionReplayTool(tool) && (optionalBundleClaimed || optionalBundleRecoveryFailed);
         const reconcilesRuntimeTarget = directRuntimeReset || nestedRuntimeReset;
         let authorityInvalidated = false;
         if (directRuntimeReset && !resultSucceeded(result)) {
@@ -33454,7 +33586,7 @@ function createAuthorityGate(runtime, dependencies) {
           const metro = status.bindings.metro;
           let bundle = null;
           try {
-            if (tool === "cdp_run_action" && optionalBundleRecoveryFailed) {
+            if (isActionReplayTool(tool) && optionalBundleRecoveryFailed) {
               throw new SessionAuthorityError("BUNDLE_HANDSHAKE_UNAVAILABLE", "reactive bundle authority did not verify");
             }
             if (!dependencies.refreshRuntimeBinding) {
@@ -33474,7 +33606,7 @@ function createAuthorityGate(runtime, dependencies) {
                 nextAction: 'Run rn_session action "pin_dev_client" before another CDP operation.'
               });
             }
-            if (tool === "cdp_run_action" && !optionalBundleClaimed) {
+            if (isActionReplayTool(tool) && !optionalBundleClaimed) {
               authorityInvalidated = true;
             } else {
               throw error2;
@@ -33536,6 +33668,22 @@ function createAuthorityGate(runtime, dependencies) {
           axes: [...runnerAwareReceiptProfile.axes, "M", "A"]
         } : runnerAwareReceiptProfile;
         const controllerGenerationAdvanced = operation.authorityVersion !== initialOperationAuthorityVersion;
+        if (loginPrologueOutcome) {
+          const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+          operation = registry2.replaceBindingsDuringOperation(operation, {
+            bindings: {
+              loginPrologue: {
+                ...loginPrologueOutcome,
+                ...priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}
+              }
+            }
+          });
+          const loginStatus = runtime.status();
+          if (!loginStatus.available) {
+            throw new SessionAuthorityError(loginStatus.code, loginStatus.reason);
+          }
+          status = loginStatus;
+        }
         registry2.verifyOperation(operation);
         for (const observation of allBefore) {
           if (controllerGenerationAdvanced && observation.axis === "C")
@@ -33633,6 +33781,7 @@ var init_authority_gate = __esm({
     init_registry();
     init_metro_origin();
     init_install_reissue();
+    init_login_prologue();
     init_tool_profiles();
     optionalBundleAdmission = /* @__PURE__ */ Symbol("optionalBundleAdmission");
     managedNativeOrigin = /* @__PURE__ */ Symbol("managedNativeOrigin");
@@ -38947,9 +39096,9 @@ var init_settle = __esm({
 // packages/rn-dev-agent-core/dist/agent-device-wrapper.js
 import { unlinkSync as unlinkSync13, rmSync as rmSync7 } from "node:fs";
 import { join as join30 } from "node:path";
-import { createHash as createHash7 } from "node:crypto";
+import { createHash as createHash8 } from "node:crypto";
 function getSessionFilePath() {
-  const projectId = createHash7("sha256").update(process.cwd()).digest("hex").slice(0, 12);
+  const projectId = createHash8("sha256").update(process.cwd()).digest("hex").slice(0, 12);
   return join30(getStateDir(), `session-${projectId}.json`);
 }
 function getActiveSession() {
@@ -40878,7 +41027,7 @@ ensureJavaEnv();
 ensureCwd();
 
 // packages/rn-dev-agent-core/dist/index.js
-import { createHash as createHash22, createHmac as createHmac5, randomUUID as randomUUID10 } from "node:crypto";
+import { createHash as createHash23, createHmac as createHmac5, randomUUID as randomUUID11 } from "node:crypto";
 import { readFileSync as readFileSync42, rmSync as rmSync12 } from "node:fs";
 import { execFile as execFile23 } from "node:child_process";
 import { promisify as promisify26 } from "node:util";
@@ -61792,7 +61941,7 @@ function inspectInstallIdentity(install, dependencies = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/session/migration-diagnostic.js
-import { createHash as createHash8 } from "node:crypto";
+import { createHash as createHash9 } from "node:crypto";
 import { existsSync as existsSync25, readFileSync as readFileSync26 } from "node:fs";
 import { join as join34 } from "node:path";
 
@@ -63670,7 +63819,7 @@ function inspectAuthorityMigration(status, dependencies = {}) {
   const integrationBinding = status.bindings.packageIntegration;
   let bindingDiagnostic = null;
   if (integrationBinding) {
-    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash8("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
+    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash9("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
     const manifestAvailable = manifestVerified(onDiskManifestText) || manifestVerified(integrationBinding.restoration?.phase === "started" ? integrationBinding.restoration.manifestSource : void 0) || manifestVerified(integrationBinding.installation?.phase === "started" ? integrationBinding.installation.manifestSource : void 0) || manifestVerified(integrationBinding.manifestSource);
     const effectiveOwnerSessionId = status.sessionId;
     const trustedDigestRecorded = typeof integrationBinding.manifestSha256 === "string" && /^[0-9a-f]{64}$/.test(integrationBinding.manifestSha256);
@@ -63709,6 +63858,7 @@ function inspectAuthorityMigration(status, dependencies = {}) {
 
 // packages/rn-dev-agent-core/dist/session/public-status.js
 init_registry();
+init_login_prologue();
 var SELECTED_STATES = /* @__PURE__ */ new Set(["active", "source_bound", "device_claimed", "metro_bound"]);
 var RUNNING_STATES = /* @__PURE__ */ new Set(["device_bound", "runtime_bound", "ready"]);
 function derivePublicPhase(state, buildPending) {
@@ -63785,6 +63935,7 @@ function projectPublicAuthorityStatus(status, options = {}) {
     observedAt: metroTerminal.observedAt
   } : void 0;
   const sandbox = metro?.runtimeEvidenceAuthority === "managed-sandbox-v1" ? "managed-sandbox-v1" : "unavailable";
+  const loginPrologue = readLoginPrologueOutcome(status.bindings.loginPrologue);
   const phase = derivePublicPhase(status.state, Boolean(status.bindings.pendingBuild));
   return {
     available: true,
@@ -63828,6 +63979,20 @@ function projectPublicAuthorityStatus(status, options = {}) {
     proof: Boolean(status.bindings.proof),
     // ADR §5.2 (L3): strict proof is an opt-in overlay outside the four groups, never a group.
     proofOverlay: { active: Boolean(status.bindings.proof) },
+    ...loginPrologue ? {
+      loginPrologue: {
+        state: loginPrologue.state,
+        alias: loginPrologue.alias,
+        actionId: loginPrologue.actionId,
+        startedAt: loginPrologue.startedAt,
+        endedAt: loginPrologue.endedAt,
+        elapsedMs: loginPrologue.elapsedMs,
+        failureCode: loginPrologue.failure?.code,
+        runId: loginPrologue.runRecord?.runId,
+        overrideCount: loginPrologue.overrides?.length ?? 0,
+        lastOverride: loginPrologue.overrides?.at(-1)
+      }
+    } : {},
     ...options.installIdentity ? { installIdentity: options.installIdentity.verdict } : {},
     // A live axis-I refusal means every gated tool refuses too — status must
     // not read `ready` while that is true. A pending re-issue reads ready only
@@ -63878,7 +64043,7 @@ init_registry();
 init_utils();
 
 // packages/rn-dev-agent-core/dist/session/build-receipt.js
-import { createHmac, timingSafeEqual as timingSafeEqual3 } from "node:crypto";
+import { createHmac, timingSafeEqual as timingSafeEqual4 } from "node:crypto";
 function serialize(payload) {
   return JSON.stringify(payload);
 }
@@ -63894,7 +64059,7 @@ function verifyBuildReceipt(receipt2, capability, expected) {
   }
   const expectedSignature = Buffer.from(sign(receipt2.payload, capability), "hex");
   const actualSignature = Buffer.from(receipt2.signature, "hex");
-  if (expectedSignature.length !== actualSignature.length || !timingSafeEqual3(expectedSignature, actualSignature)) {
+  if (expectedSignature.length !== actualSignature.length || !timingSafeEqual4(expectedSignature, actualSignature)) {
     throw new Error("BUILD_RECEIPT_INVALID: build receipt signature is invalid");
   }
   for (const [key, value] of Object.entries(expected)) {
@@ -64169,7 +64334,7 @@ function createBuildLaunchPlan(input) {
 
 // packages/rn-dev-agent-core/dist/session/managed-metro.js
 import { execFileSync as execFileSync10, spawn as spawn7 } from "node:child_process";
-import { createHash as createHash10, createHmac as createHmac2, timingSafeEqual as timingSafeEqual4 } from "node:crypto";
+import { createHash as createHash11, createHmac as createHmac2, timingSafeEqual as timingSafeEqual5 } from "node:crypto";
 import { closeSync as closeSync7, existsSync as existsSync27, fstatSync as fstatSync5, mkdirSync as mkdirSync17, openSync as openSync7, readFileSync as readFileSync28, readSync as readSync2, realpathSync as realpathSync11, rmSync as rmSync11 } from "node:fs";
 init_metro_binding();
 init_trusted_system_executable();
@@ -64267,13 +64432,13 @@ function canonicalAuthorityJson(value) {
 
 // packages/rn-dev-agent-core/dist/session/managed-metro-enforcement.js
 import { spawnSync as spawnSync2 } from "node:child_process";
-import { createHash as createHash9 } from "node:crypto";
+import { createHash as createHash10 } from "node:crypto";
 import { closeSync as closeSync6, constants as constants6, existsSync as existsSync26, mkdirSync as mkdirSync16, openSync as openSync6, readFileSync as readFileSync27, realpathSync as realpathSync10, rmSync as rmSync10, statSync as statSync12, symlinkSync as symlinkSync3, writeSync as writeSync2 } from "node:fs";
 import { dirname as dirname17, resolve as resolve10 } from "node:path";
 var DARWIN_SANDBOX_EXECUTABLE = "/usr/bin/sandbox-exec";
 var DARWIN_CODESIGN_EXECUTABLE = "/usr/bin/codesign";
 function sha256(value) {
-  return createHash9("sha256").update(value).digest("hex");
+  return createHash10("sha256").update(value).digest("hex");
 }
 function defaultRun2(command, args) {
   const result = spawnSync2(command, [...args], {
@@ -65778,7 +65943,7 @@ function verifyManagedMetroManagementProof(binding, input) {
   }, input.signerCapability);
   const expectedBuffer = Buffer.from(expected, "hex");
   const observedBuffer = Buffer.from(binding.managementProof, "hex");
-  return expectedBuffer.length === observedBuffer.length && timingSafeEqual4(expectedBuffer, observedBuffer);
+  return expectedBuffer.length === observedBuffer.length && timingSafeEqual5(expectedBuffer, observedBuffer);
 }
 function exactManagedProcessInspection(role, pid, birth, probe) {
   const prefix = role === "launcher" ? "METRO_LAUNCHER" : "METRO_LISTENER";
@@ -66040,7 +66205,7 @@ async function stopManagedMetro(binding, input, dependencies = {}) {
   ];
   if (!expectedProofs.some((expected) => {
     const expectedBuffer = Buffer.from(expected, "hex");
-    return expectedBuffer.length === observedBuffer.length && timingSafeEqual4(expectedBuffer, observedBuffer);
+    return expectedBuffer.length === observedBuffer.length && timingSafeEqual5(expectedBuffer, observedBuffer);
   })) {
     return false;
   }
@@ -66081,7 +66246,7 @@ import { closeSync as closeSync8, constants as constants7, fstatSync as fstatSyn
 import { basename as basename10, isAbsolute as isAbsolute7, join as join35, relative as relative6, resolve as resolve11, sep as sep8 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/metro-authority.js
-import { createHmac as createHmac3, createSecretKey, timingSafeEqual as timingSafeEqual5 } from "node:crypto";
+import { createHmac as createHmac3, createSecretKey, timingSafeEqual as timingSafeEqual6 } from "node:crypto";
 function serializePayload(payload) {
   return JSON.stringify(payload);
 }
@@ -66098,7 +66263,7 @@ function verifyMetroAuthorityMarker(marker, signerCapability, expected = {}) {
   }
   const signature = Buffer.from(marker.signature, "hex");
   const actual = Buffer.from(signPayload(marker.payload, signerCapability), "hex");
-  if (signature.length !== actual.length || !timingSafeEqual5(signature, actual)) {
+  if (signature.length !== actual.length || !timingSafeEqual6(signature, actual)) {
     throw mismatch();
   }
   for (const [key, value] of Object.entries(expected)) {
@@ -70310,17 +70475,17 @@ function restorePackageIntegrationFiles(input, dependencies = {}) {
 // packages/rn-dev-agent-core/dist/tools/session.js
 import { dirname as dirname19, isAbsolute as isAbsolute9, join as join39, resolve as resolve14 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { createHash as createHash13 } from "node:crypto";
+import { createHash as createHash14 } from "node:crypto";
 
 // packages/rn-dev-agent-core/dist/session/source-identity.js
 init_metro_cwd();
-import { createHash as createHash11, createHmac as createHmac4, randomBytes as randomBytes6, timingSafeEqual as timingSafeEqual6 } from "node:crypto";
+import { createHash as createHash12, createHmac as createHmac4, randomBytes as randomBytes6, timingSafeEqual as timingSafeEqual7 } from "node:crypto";
 import { execFileSync as execFileSync11 } from "node:child_process";
 import { closeSync as closeSync9, constants as constants8, existsSync as existsSync28, fstatSync as fstatSync7, lstatSync as lstatSync15, openSync as openSync9, readdirSync as readdirSync11, readFileSync as readFileSync30, readlinkSync as readlinkSync5, readSync as readSync3, realpathSync as realpathSync12 } from "node:fs";
 import { dirname as dirname18, isAbsolute as isAbsolute8, join as join36, relative as relative7, resolve as resolve12 } from "node:path";
 init_declared_source_contract();
 function digest2(parts) {
-  const hash = createHash11("sha256");
+  const hash = createHash12("sha256");
   for (const part of parts) {
     hash.update(part);
     hash.update("\0");
@@ -70427,7 +70592,7 @@ function updateFramedFile(hash, path, maximumBytes) {
   return updateStableFile(hash, path, maximumBytes, true);
 }
 function fileDigest(path) {
-  const hash = createHash11("sha256");
+  const hash = createHash12("sha256");
   updateStableFile(hash, path, MAX_STRICT_PROOF_DEPENDENCY_FILE_BYTES, false);
   return hash.digest("hex");
 }
@@ -70534,7 +70699,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
   const expected = createHmac4("sha256", authority.capability).update(canonicalAuthorityJson(payload)).digest();
   const observed = typeof receipt2.signature === "string" ? Buffer.from(receipt2.signature, "hex") : Buffer.alloc(0);
   const runtimeManifest = receipt2.runtimeManifest && typeof receipt2.runtimeManifest === "object" ? receipt2.runtimeManifest : null;
-  if (receipt2.version !== 1 || receipt2.runtimeEvidenceAuthority !== authority.evidenceAuthority || receipt2.sessionId !== authority.sessionId || receipt2.metroInstanceId !== authority.metroInstanceId || receipt2.contentRoot !== identity2.contentRoot || receipt2.appRoot !== identity2.appRoot || !runtimeManifest || runtimeManifest.version !== 1 || typeof runtimeManifest.executable !== "string" || typeof runtimeManifest.sourceExecutable !== "string" || typeof runtimeManifest.nodeExecutable !== "string" || typeof runtimeManifest.nodeVersion !== "string" || !Number.isSafeInteger(runtimeManifest.port) || runtimeManifest.port < 1 || runtimeManifest.port > 65535 || !Array.isArray(runtimeManifest.args) || runtimeManifest.args.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.commandProbeArguments) || runtimeManifest.commandProbeArguments.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.commandExecutableMappings) || runtimeManifest.commandExecutableMappings.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.commandChainInputs) || runtimeManifest.commandChainInputs.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.protectedRuntimeRoots) || runtimeManifest.protectedRuntimeRoots.some((entry) => typeof entry !== "string") || typeof runtimeManifest.nodeOptions !== "string" || typeof runtimeManifest.environmentDigest !== "string" || !/^[a-f0-9]{64}$/.test(runtimeManifest.environmentDigest) || runtimeManifest.contentRoot !== identity2.contentRoot || runtimeManifest.appRoot !== identity2.appRoot || typeof runtimeManifest.servingRoot !== "string" || !Number.isSafeInteger(runtimeManifest.buildGeneration) || !Array.isArray(runtimeManifest.packageInputs) || runtimeManifest.packageInputs.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.metroConfigInputs) || runtimeManifest.metroConfigInputs.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.dependencyRoots) || runtimeManifest.dependencyRoots.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.runtimeInputs) || runtimeManifest.runtimeInputs.some((entry) => typeof entry !== "string") || !runtimeManifest.descendantAuthority || typeof runtimeManifest.descendantAuthority !== "object" || !Array.isArray(receipt2.runtimeInputs) || receipt2.runtimeInputs.some((entry) => typeof entry !== "string") || canonicalAuthorityJson(runtimeManifest.runtimeInputs) !== canonicalAuthorityJson(receipt2.runtimeInputs) || !Array.isArray(receipt2.violations) || receipt2.violations.some((entry) => typeof entry !== "string") || observed.length !== expected.length || !timingSafeEqual6(observed, expected)) {
+  if (receipt2.version !== 1 || receipt2.runtimeEvidenceAuthority !== authority.evidenceAuthority || receipt2.sessionId !== authority.sessionId || receipt2.metroInstanceId !== authority.metroInstanceId || receipt2.contentRoot !== identity2.contentRoot || receipt2.appRoot !== identity2.appRoot || !runtimeManifest || runtimeManifest.version !== 1 || typeof runtimeManifest.executable !== "string" || typeof runtimeManifest.sourceExecutable !== "string" || typeof runtimeManifest.nodeExecutable !== "string" || typeof runtimeManifest.nodeVersion !== "string" || !Number.isSafeInteger(runtimeManifest.port) || runtimeManifest.port < 1 || runtimeManifest.port > 65535 || !Array.isArray(runtimeManifest.args) || runtimeManifest.args.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.commandProbeArguments) || runtimeManifest.commandProbeArguments.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.commandExecutableMappings) || runtimeManifest.commandExecutableMappings.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.commandChainInputs) || runtimeManifest.commandChainInputs.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.protectedRuntimeRoots) || runtimeManifest.protectedRuntimeRoots.some((entry) => typeof entry !== "string") || typeof runtimeManifest.nodeOptions !== "string" || typeof runtimeManifest.environmentDigest !== "string" || !/^[a-f0-9]{64}$/.test(runtimeManifest.environmentDigest) || runtimeManifest.contentRoot !== identity2.contentRoot || runtimeManifest.appRoot !== identity2.appRoot || typeof runtimeManifest.servingRoot !== "string" || !Number.isSafeInteger(runtimeManifest.buildGeneration) || !Array.isArray(runtimeManifest.packageInputs) || runtimeManifest.packageInputs.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.metroConfigInputs) || runtimeManifest.metroConfigInputs.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.dependencyRoots) || runtimeManifest.dependencyRoots.some((entry) => typeof entry !== "string") || !Array.isArray(runtimeManifest.runtimeInputs) || runtimeManifest.runtimeInputs.some((entry) => typeof entry !== "string") || !runtimeManifest.descendantAuthority || typeof runtimeManifest.descendantAuthority !== "object" || !Array.isArray(receipt2.runtimeInputs) || receipt2.runtimeInputs.some((entry) => typeof entry !== "string") || canonicalAuthorityJson(runtimeManifest.runtimeInputs) !== canonicalAuthorityJson(receipt2.runtimeInputs) || !Array.isArray(receipt2.violations) || receipt2.violations.some((entry) => typeof entry !== "string") || observed.length !== expected.length || !timingSafeEqual7(observed, expected)) {
     throw new Error("STRICT_PROOF_UNVERIFIED_METRO_POLICY: runtime policy receipt is invalid");
   }
   if (!pathIsWithinRoot(runtimeManifest.servingRoot, identity2.contentRoot)) {
@@ -70619,7 +70784,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
     };
     const expectedLoad = createHmac4("sha256", authority.capability).update(canonicalAuthorityJson(loadPayload)).digest();
     const observedLoad = typeof load.signature === "string" ? Buffer.from(load.signature, "hex") : Buffer.alloc(0);
-    if (load.version !== 1 || load.runtimeEvidenceAuthority !== authority.evidenceAuthority || load.sessionId !== authority.sessionId || load.metroInstanceId !== authority.metroInstanceId || load.kind !== "input" && load.kind !== "violation" && load.kind !== "launch" && load.kind !== "attestation" && load.kind !== "semantics" && load.kind !== "pending" && load.kind !== "completion" && load.kind !== "stability" || typeof load.value !== "string" || !Number.isSafeInteger(load.sequence) || load.sequence !== evidenceSequence + 1 || load.previousSignature !== previousEvidenceSignature || (load.kind === "input" || load.kind === "stability" ? typeof load.digest !== "string" || !/^[a-f0-9]{64}$/.test(load.digest) : load.digest !== null) || observedLoad.length !== expectedLoad.length || !timingSafeEqual6(observedLoad, expectedLoad)) {
+    if (load.version !== 1 || load.runtimeEvidenceAuthority !== authority.evidenceAuthority || load.sessionId !== authority.sessionId || load.metroInstanceId !== authority.metroInstanceId || load.kind !== "input" && load.kind !== "violation" && load.kind !== "launch" && load.kind !== "attestation" && load.kind !== "semantics" && load.kind !== "pending" && load.kind !== "completion" && load.kind !== "stability" || typeof load.value !== "string" || !Number.isSafeInteger(load.sequence) || load.sequence !== evidenceSequence + 1 || load.previousSignature !== previousEvidenceSignature || (load.kind === "input" || load.kind === "stability" ? typeof load.digest !== "string" || !/^[a-f0-9]{64}$/.test(load.digest) : load.digest !== null) || observedLoad.length !== expectedLoad.length || !timingSafeEqual7(observedLoad, expectedLoad)) {
       throw new Error("STRICT_PROOF_UNVERIFIED_METRO_POLICY: runtime load evidence is invalid");
     }
     evidenceSequence = load.sequence;
@@ -70657,7 +70822,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
         throw new Error("STRICT_PROOF_UNVERIFIED_METRO_POLICY: runtime semantics are unbounded");
       }
       runtimeSemantics.add(load.value);
-      runtimeSemanticsByDigest.set(createHash11("sha256").update(load.value).digest("hex"), load.value);
+      runtimeSemanticsByDigest.set(createHash12("sha256").update(load.value).digest("hex"), load.value);
       orderedRuntimeSemantics.push(load.value);
       continue;
     }
@@ -70701,7 +70866,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
   };
   const expectedHead = createHmac4("sha256", authority.capability).update(canonicalAuthorityJson(headPayload)).digest();
   const observedHead = typeof head.signature === "string" ? Buffer.from(head.signature, "hex") : Buffer.alloc(0);
-  if (head.version !== 1 || head.runtimeEvidenceAuthority !== authority.evidenceAuthority || head.sessionId !== authority.sessionId || head.metroInstanceId !== authority.metroInstanceId || head.challenge !== challenge || head.sequence !== evidenceSequence || head.journalSignature !== previousEvidenceSignature || observedHead.length !== expectedHead.length || !timingSafeEqual6(observedHead, expectedHead)) {
+  if (head.version !== 1 || head.runtimeEvidenceAuthority !== authority.evidenceAuthority || head.sessionId !== authority.sessionId || head.metroInstanceId !== authority.metroInstanceId || head.challenge !== challenge || head.sequence !== evidenceSequence || head.journalSignature !== previousEvidenceSignature || observedHead.length !== expectedHead.length || !timingSafeEqual7(observedHead, expectedHead)) {
     throw new Error("STRICT_PROOF_UNVERIFIED_METRO_POLICY: runtime evidence head is invalid");
   }
   for (const launch of descendantLaunches.keys()) {
@@ -70978,7 +71143,7 @@ function strictProofSourceIdentity(identity2, dependencies = {}) {
       throw new Error(`STRICT_PROOF_DIRTY_SUBMODULE: ${entry} contains source changes outside the parent digest`);
     }
   }
-  const dirtyHash = createHash11("sha256");
+  const dirtyHash = createHash12("sha256");
   updateFramed(dirtyHash, "git-dirty-v3");
   updateFramed(dirtyHash, diff);
   for (const semantics of runtimeInputs.semantics) {
@@ -71093,7 +71258,7 @@ function inspectSessionOwner(owner, dependencies = {}) {
 
 // packages/rn-dev-agent-core/dist/session/startup-cleanup.js
 init_secure_state_file();
-import { createHash as createHash12 } from "node:crypto";
+import { createHash as createHash13 } from "node:crypto";
 import { join as join38 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/android-metro-reverse.js
@@ -71677,7 +71842,7 @@ function restoreDeadOwnerIntegration(input, prior, plan, dependencies) {
 function verifiedDeadOwnerManifestSource(appRoot, binding, manifestSha256) {
   if (!/^[0-9a-f]{64}$/.test(manifestSha256))
     return void 0;
-  const verified = (candidate) => typeof candidate === "string" && createHash12("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
+  const verified = (candidate) => typeof candidate === "string" && createHash13("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
   let liveManifest;
   try {
     liveManifest = readPackageIntegrationInputs(appRoot).manifest ?? void 0;
@@ -71783,7 +71948,7 @@ function sameMetroAuthority(current, next) {
 function verifiedManifestSource(candidate, manifestSha256) {
   if (typeof candidate !== "string" || typeof manifestSha256 !== "string")
     return void 0;
-  return createHash13("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
+  return createHash14("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
 }
 function durableBindingManifestSource(binding) {
   return verifiedManifestSource(binding?.manifestSource, binding?.manifestSha256);
@@ -72729,7 +72894,7 @@ function createSessionHandler(runtime, dependencies = {}) {
             });
           }
           assertPackageIntegrationInactive(status.bindings, input.action);
-          const manifestSha256 = createHash13("sha256").update(manifestSource ?? "").digest("hex");
+          const manifestSha256 = createHash14("sha256").update(manifestSource ?? "").digest("hex");
           if (integrationBinding?.version !== 1 || typeof integrationBinding.installedBySessionId !== "string" || integrationBinding.manifestSha256 !== manifestSha256) {
             throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "integration restoration requires the transferred manifest authority binding");
           }
@@ -72776,7 +72941,7 @@ function createSessionHandler(runtime, dependencies = {}) {
         }
         preview.manifest.metroConfig = metroConfigPath.slice(appRoot.length + 1);
         const expectedManifestSource = installationManifestSource ?? serializePackageIntegrationManifest(preview.manifest);
-        const expectedManifestSha256 = createHash13("sha256").update(expectedManifestSource).digest("hex");
+        const expectedManifestSha256 = createHash14("sha256").update(expectedManifestSource).digest("hex");
         if (installationManifestSource && (integrationBinding?.version !== 1 || integrationBinding.installedBySessionId !== session2.sessionId || integrationBinding.manifestSha256 !== expectedManifestSha256)) {
           throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "integration installation requires the original session manifest authority binding");
         }
@@ -72798,7 +72963,7 @@ function createSessionHandler(runtime, dependencies = {}) {
           if (!installedManifest) {
             throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: applied manifest is unavailable");
           }
-          if (createHash13("sha256").update(installedManifest).digest("hex") !== expectedManifestSha256) {
+          if (createHash14("sha256").update(installedManifest).digest("hex") !== expectedManifestSha256) {
             throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "applied integration manifest no longer matches its durable installation authority");
           }
           registry2.updateBindings(session2, {
@@ -74522,6 +74687,7 @@ var TESTING = /* @__PURE__ */ new Set([
   "maestro_run",
   "maestro_generate",
   "maestro_test_all",
+  "cdp_login_prologue",
   "cdp_run_action",
   "cdp_repair_action",
   "proof_step",
@@ -77399,6 +77565,7 @@ init_action_state_store();
 init_reusable_action();
 init_maestro_error_parser();
 init_maestro_run();
+import { randomUUID as randomUUID8 } from "node:crypto";
 init_path_safety();
 
 // packages/rn-dev-agent-core/dist/nav-graph/route-sequence.js
@@ -78143,6 +78310,23 @@ function createRunActionHandler(deps = {}) {
     const trigger = args.trigger ?? "agent";
     const timeoutMs = args.timeoutMs ?? 12e4;
     const t0 = Date.now();
+    const startedAt = new Date(t0).toISOString();
+    const runId = randomUUID8();
+    const timingSteps = [];
+    const measureStep = async (name, run) => {
+      const stepStartedMs = Date.now();
+      try {
+        return await run();
+      } finally {
+        const stepEndedMs = Date.now();
+        timingSteps.push({
+          name,
+          startedAt: new Date(stepStartedMs).toISOString(),
+          endedAt: new Date(stepEndedMs).toISOString(),
+          elapsedMs: Math.max(0, stepEndedMs - stepStartedMs)
+        });
+      }
+    };
     const activeTarget = targetContext();
     if (args.platform && activeTarget?.platform && activeTarget.platform !== args.platform) {
       return failResult(`cdp_run_action: requested ${args.platform}, but the active session is ${activeTarget.platform}; refusing cross-platform replay.`, "TARGET_SESSION_MISMATCH", { requestedPlatform: args.platform, activeSession: activeTarget });
@@ -78152,7 +78336,22 @@ function createRunActionHandler(deps = {}) {
     const appFile = args.appFile ?? (flowUsesClearState(replayYaml) && receipt2?.platform === "ios" && typeof receipt2.appId === "string" && typeof receipt2.deviceId === "string" ? resolveAppFile(receipt2.appId, receipt2.deviceId) ?? void 0 : void 0);
     let probeDeviceId = null;
     let observedDeviceId = maestroDeviceId ?? null;
-    const persistRunWithDevice = (record2) => proofReplay ? Promise.resolve({ promoted: false, promotionRefused: false }) : persistRun(args.actionId, projectRoot, probeDeviceId ? { ...record2, deviceId: probeDeviceId } : record2);
+    const persistRunWithDevice = (record2) => {
+      if (proofReplay)
+        return Promise.resolve({ promoted: false, promotionRefused: false });
+      const endedMs = Date.now();
+      const timedRecord = {
+        ...record2,
+        runId,
+        timing: {
+          startedAt,
+          endedAt: new Date(endedMs).toISOString(),
+          elapsedMs: Math.max(0, endedMs - t0),
+          steps: [...timingSteps]
+        }
+      };
+      return persistRun(args.actionId, projectRoot, probeDeviceId ? { ...timedRecord, deviceId: probeDeviceId } : timedRecord);
+    };
     const writeDisclosure = (actionYaml = "none", outcome) => ({
       actionYaml: actionYaml === "none" ? { written: false, reason: "repair-not-applied" } : actionYaml === "lifecycle-promotion-refused" ? { written: false, reason: "lifecycle-promotion-refused" } : { written: true, authorized: true, reason: actionYaml },
       runtimeState: proofReplay ? "none" : outcome?.runtimeStateRefused ? "refused-external-write" : "sidecar",
@@ -78183,11 +78382,11 @@ function createRunActionHandler(deps = {}) {
         const probe = replayDeps ? firstReplayTestId(cdpReplayYaml, args.params ?? {}) : null;
         if (replayDeps && probe) {
           const tProbe = Date.now();
-          const probeOutcome = await probeTreeWithRetry(replayDeps, probe, probeRetry);
+          const probeOutcome = await measureStep("proactive-probe", () => probeTreeWithRetry(replayDeps, probe, probeRetry));
           if (probeOutcome.found) {
             const tReplay = Date.now();
             try {
-              const replay = await runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps);
+              const replay = await measureStep("proactive-cdp-replay", () => runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps));
               const timings_ms = { probe: tReplay - tProbe, replay: Date.now() - tReplay };
               const blindProbe = { atRisk, skippedMaestro: true };
               const autoRepair2 = {
@@ -78242,7 +78441,7 @@ function createRunActionHandler(deps = {}) {
       }
       const tBeforeFirst = Date.now();
       probeDeviceId = null;
-      const firstResult = await maestroRun({
+      const firstResult = await measureStep("maestro-first-attempt", () => maestroRun({
         inlineYaml: replayYaml,
         actionMetadata: action.metadata,
         platform: args.platform,
@@ -78257,7 +78456,7 @@ function createRunActionHandler(deps = {}) {
         reproveManagedOrigin: () => reproveManagedOrigin(args),
         completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
         reissueInstallReceipt: () => reissueInstallReceipt(args)
-      });
+      }));
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, "maestro_run");
       const firstPassed = firstEnv.ok === true && firstEnv.data?.passed === true;
@@ -78355,7 +78554,7 @@ function createRunActionHandler(deps = {}) {
         } else if (!probe) {
           cdpJsFallback = { attempted: false, reason: "no-probe-testid" };
         } else {
-          const probeOutcome = await probeTreeWithRetry(replayDeps, probe, probeRetry);
+          const probeOutcome = await measureStep("fallback-probe", () => probeTreeWithRetry(replayDeps, probe, probeRetry));
           if (!probeOutcome.found) {
             cdpJsFallback = {
               attempted: false,
@@ -78370,9 +78569,9 @@ function createRunActionHandler(deps = {}) {
               firstAttemptOutput: boundedOutput(firstOutput)
             };
             try {
-              const replay = await runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps, {
+              const replay = await measureStep("fallback-cdp-replay", () => runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps, {
                 resumeAtSelector: failure.kind === "SELECTOR_NOT_FOUND" ? failure.selector : null
-              });
+              }));
               const status = replay.passed ? "pass" : "fail";
               const autoRepair2 = {
                 attempted: false,
@@ -78466,12 +78665,12 @@ function createRunActionHandler(deps = {}) {
         throw new Error("Internal: isAutoRepairable returned true for non-SELECTOR_NOT_FOUND failure");
       }
       const tBeforeRepair = Date.now();
-      const repairResult = await repairAction({
+      const repairResult = await measureStep("selector-repair", () => repairAction({
         actionId: args.actionId,
         failedSelector: failure.selector,
         projectRoot,
         agentReasoning: `auto-repair from cdp_run_action after maestro failure: ${failure.selector}`
-      });
+      }));
       const repairMs = Date.now() - tBeforeRepair;
       const repairEnv = parseEnvelope(repairResult, "cdp_repair_action");
       const repairPatched = repairEnv.ok === true && repairEnv.data?.patched === true;
@@ -78527,10 +78726,11 @@ function createRunActionHandler(deps = {}) {
       if (!reloadedAction.replay.ok) {
         return failResult(`cdp_run_action: repaired action is not valid Maestro YAML: ${reloadedAction.replay.error}`, "BAD_RECORDING", { actionId: args.actionId });
       }
+      const retryYaml = reloadedAction.replay.yamlText;
       const tBeforeRetry = Date.now();
       probeDeviceId = null;
-      const retryResult = await maestroRun({
-        inlineYaml: reloadedAction.replay.yamlText,
+      const retryResult = await measureStep("maestro-retry", () => maestroRun({
+        inlineYaml: retryYaml,
         actionMetadata: reloadedAction.metadata,
         platform: args.platform,
         appId: args.appId,
@@ -78544,7 +78744,7 @@ function createRunActionHandler(deps = {}) {
         reproveManagedOrigin: () => reproveManagedOrigin(args),
         completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
         reissueInstallReceipt: () => reissueInstallReceipt(args)
-      });
+      }));
       const retryMs = Date.now() - tBeforeRetry;
       const retryEnv = parseEnvelope(retryResult, "maestro_run");
       const retryPassed = retryEnv.ok === true && retryEnv.data?.passed === true;
@@ -78692,6 +78892,147 @@ async function persistRun(actionId, projectRoot, record2) {
     }
   }
   return { promoted: false, promotionRefused: false };
+}
+
+// packages/rn-dev-agent-core/dist/domain/action-inventory.js
+init_action_store();
+async function listActions(projectRoot, dependencies = {}) {
+  const context = openReadableActionLoadContext(projectRoot);
+  if (!context)
+    return [];
+  const load = dependencies.loadAction ?? loadActionFromContext;
+  const yamlFiles = context.files.filter((f) => /\.ya?ml$/.test(f)).sort();
+  const results = [];
+  for (const id of new Set(yamlFiles.map((file) => file.replace(/\.ya?ml$/, "")))) {
+    if (yamlFiles.includes(`${id}.yaml`) && yamlFiles.includes(`${id}.yml`))
+      continue;
+    const action = load(context, id);
+    if (!action)
+      continue;
+    const { metadata } = action;
+    const summary = {
+      id: metadata.id,
+      intent: metadata.intent,
+      status: metadata.status
+    };
+    if (metadata.params !== void 0)
+      summary.params = metadata.params;
+    if (metadata.mutates !== void 0)
+      summary.mutates = metadata.mutates;
+    if (metadata.appId !== void 0)
+      summary.appId = metadata.appId;
+    results.push(summary);
+  }
+  return results;
+}
+
+// packages/rn-dev-agent-core/dist/tools/login-prologue.js
+init_action_store();
+init_login_prologue();
+init_utils();
+function parseEnvelope2(result) {
+  try {
+    return JSON.parse(result.content[0]?.text ?? "{}");
+  } catch {
+    return { ok: false, code: "BAD_RESPONSE", error: "Action replay returned invalid JSON." };
+  }
+}
+function createLoginPrologueHandler(deps) {
+  const now = deps.now ?? (() => /* @__PURE__ */ new Date());
+  return async (args) => {
+    const projectRoot = args.projectRoot ?? process.cwd();
+    const prologueStarted = now();
+    const steps = [];
+    let inventory = [];
+    const measure = async (name, run) => {
+      const started = now();
+      try {
+        return await run();
+      } finally {
+        const ended = now();
+        steps.push({
+          name,
+          startedAt: started.toISOString(),
+          endedAt: ended.toISOString(),
+          elapsedMs: Math.max(0, ended.getTime() - started.getTime())
+        });
+      }
+    };
+    const finish = (state, extra) => {
+      const ended = now();
+      return {
+        schemaVersion: 1,
+        state,
+        alias: LOGIN_PROLOGUE_ALIAS,
+        startedAt: prologueStarted.toISOString(),
+        endedAt: ended.toISOString(),
+        elapsedMs: Math.max(0, ended.getTime() - prologueStarted.getTime()),
+        steps,
+        inventory: { count: inventory.length, actionIds: inventory.map((action) => action.id) },
+        ...extra
+      };
+    };
+    const blocked = (code, detail, extra = {}) => {
+      const outcome = finish(LOGIN_PROLOGUE_BLOCKED, {
+        failure: { code, detail },
+        ...extra
+      });
+      return failResult(`Login prologue blocked: ${detail}`, "LOGIN_PROLOGUE_BLOCKED", {
+        loginPrologue: outcome
+      });
+    };
+    try {
+      inventory = await measure("inventory", () => listActions(projectRoot));
+      const action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
+      if (!action || !inventory.some((candidate) => candidate.id === LOGIN_PROLOGUE_ALIAS)) {
+        return blocked("LOGIN_ACTION_MISSING", `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
+      }
+      const priorRunIds = new Set(action.state.runHistory.map((record2) => record2.runId).filter((runId) => typeof runId === "string"));
+      const replayArgs = {
+        ...args,
+        actionId: LOGIN_PROLOGUE_ALIAS,
+        autoRepair: false,
+        forceReload: false,
+        proofReplay: false,
+        blindProbeMode: "forbid",
+        trigger: args.trigger ?? "agent"
+      };
+      let replayResult;
+      try {
+        replayResult = await measure("replay", () => deps.runAction(replayArgs));
+      } catch (error2) {
+        const code = error2 && typeof error2 === "object" && "code" in error2 ? String(error2.code) : "ACTION_REPLAY_THROW";
+        return blocked(code, "The saved login action threw before producing a result.", {
+          actionId: LOGIN_PROLOGUE_ALIAS
+        });
+      }
+      const replay = parseEnvelope2(replayResult);
+      let freshRecord;
+      await measure("verify-run-record", async () => {
+        const reloaded = loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS);
+        freshRecord = reloaded?.state.runHistory.slice().reverse().find((record2) => typeof record2.runId === "string" && !priorRunIds.has(record2.runId));
+      });
+      if (replay.ok !== true || replay.data?.passed !== true) {
+        return blocked(replay.code ?? String(replay.data?.failureKind ?? "ACTION_REPLAY_FAILED"), "The saved login action did not pass; exploratory login is now terminally blocked.", { actionId: LOGIN_PROLOGUE_ALIAS, ...freshRecord ? { runRecord: freshRecord } : {} });
+      }
+      if (!freshRecord || freshRecord.status !== "pass") {
+        return blocked("AUTHORITATIVE_RUN_RECORD_MISSING", "The saved login action reported success without a fresh passing RunRecord.", { actionId: LOGIN_PROLOGUE_ALIAS });
+      }
+      const outcome = finish("passed", {
+        actionId: LOGIN_PROLOGUE_ALIAS,
+        runRecord: freshRecord,
+        actionResult: {
+          transport: replay.data.transport,
+          transportVersion: replay.data.transportVersion,
+          fallback: replay.data.fallback,
+          perStepReadback: replay.data.perStepReadback
+        }
+      });
+      return okResult(outcome);
+    } catch {
+      return blocked("LOGIN_PROLOGUE_INTERNAL_ERROR", "The login prologue failed before it could prove a passing replay.");
+    }
+  };
 }
 
 // packages/rn-dev-agent-core/dist/tools/dispatch.js
@@ -79108,7 +79449,7 @@ async function hideExpoDevMenu(client2, options = {}) {
       break;
     }
     if (attempt < retries)
-      await new Promise((resolve19) => setTimeout(resolve19, retryDelayMs));
+      await new Promise((resolve20) => setTimeout(resolve20, retryDelayMs));
   }
   return successfulCall ? { ...successfulCall, attempts: outcome.attempts } : outcome;
 }
@@ -79182,7 +79523,7 @@ function createDevSettingsHandler(getClient2, dependencies = {}) {
       const call = await hideExpoDevMenu(client2, { retries: 1 });
       if (!call.callSent)
         return failedHideResult(call, before);
-      await (dependencies.settleAfterHide?.() ?? new Promise((resolve19) => setTimeout(resolve19, 300)));
+      await (dependencies.settleAfterHide?.() ?? new Promise((resolve20) => setTimeout(resolve20, 300)));
       const after = probe ? await probe().catch(() => "unknown") : "unknown";
       if (before === "expo_dev_menu" && after === "app") {
         return okResult({
@@ -80957,7 +81298,7 @@ init_utils();
 init_path_safety();
 init_process_birth();
 import { execFile as execFile22 } from "node:child_process";
-import { createHash as createHash14 } from "node:crypto";
+import { createHash as createHash15 } from "node:crypto";
 import { existsSync as existsSync29 } from "node:fs";
 import { promisify as promisify23 } from "node:util";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
@@ -81109,7 +81450,7 @@ function parseStatusOutput(stdout) {
   return active;
 }
 function recordingScope(args) {
-  return createHash14("sha256").update(`${args.sessionId}\0${args.claimEpoch}\0${args.platform}\0${args.deviceId}`).digest("hex");
+  return createHash15("sha256").update(`${args.sessionId}\0${args.claimEpoch}\0${args.platform}\0${args.deviceId}`).digest("hex");
 }
 function bindRecorderSession(runtime, args) {
   const available = runtime.requireAvailable();
@@ -81378,7 +81719,7 @@ function createDeviceRecordHandler(deps = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
-import { createHash as createHash16, randomUUID as randomUUID8 } from "node:crypto";
+import { createHash as createHash17, randomUUID as randomUUID9 } from "node:crypto";
 import { execFileSync as execFileSync14 } from "node:child_process";
 import { chmodSync as chmodSync7, closeSync as closeSync11, existsSync as existsSync30, fsyncSync, lstatSync as lstatSync16, mkdirSync as mkdirSync19, openSync as openSync11, readFileSync as readFileSync31, realpathSync as realpathSync13, renameSync as renameSync8, unlinkSync as unlinkSync14, writeFileSync as writeFileSync14 } from "node:fs";
 import { basename as basename11, dirname as dirname22, extname, isAbsolute as isAbsolute11, join as join43, relative as relative8, resolve as resolve16, sep as sep9 } from "node:path";
@@ -81386,7 +81727,7 @@ import { fileURLToPath as fileURLToPath4 } from "node:url";
 init_action_store();
 
 // packages/rn-dev-agent-core/dist/domain/proof-capture.js
-import { createHash as createHash15 } from "node:crypto";
+import { createHash as createHash16 } from "node:crypto";
 var StrictProofMonitor = class {
   now;
   events = [];
@@ -81460,14 +81801,14 @@ function hashProofArgs(params) {
   return hashProofValue(redact(params));
 }
 function hashProofValue(value) {
-  return createHash15("sha256").update(JSON.stringify(canonicalizeProofValue(value))).digest("hex");
+  return createHash16("sha256").update(JSON.stringify(canonicalizeProofValue(value))).digest("hex");
 }
 function proofRuntimeAuthorityMarker(input) {
   return hashProofValue(input);
 }
 function hashObservedValue(value) {
   const bytes = JSON.stringify(value) ?? String(value);
-  return createHash15("sha256").update(bytes).digest("hex");
+  return createHash16("sha256").update(bytes).digest("hex");
 }
 function resultEnvelope(result) {
   if (!result || typeof result !== "object")
@@ -82029,7 +82370,7 @@ var readinessSchema = external_exports.object({
   runtime: proofRuntimeSchema
 }).strict();
 function hashBytes(bytes) {
-  return createHash16("sha256").update(bytes).digest("hex");
+  return createHash17("sha256").update(bytes).digest("hex");
 }
 function captureProofWorkerStartup(argv = process.argv, attestation = readStartupIntegrityAttestation()) {
   let executedEntrypointPath = null;
@@ -82255,7 +82596,7 @@ function readProofActionIdentity(appProjectRoot, actionId, dependencies = {}) {
     return {
       id: actionId,
       version: String(action.state.revision),
-      sha256: createHash16("sha256").update(action.yamlText).digest("hex")
+      sha256: createHash17("sha256").update(action.yamlText).digest("hex")
     };
   } catch {
     return null;
@@ -82456,7 +82797,7 @@ function readProofContractAt(moduleUrl = import.meta.url) {
 function writeProofReceiptAtomic(path, receipt2) {
   const directory = dirname22(path);
   mkdirSync19(directory, { recursive: true, mode: 448 });
-  const temporary = resolve16(directory, `.${randomUUID8()}.proof-receipt.tmp`);
+  const temporary = resolve16(directory, `.${randomUUID9()}.proof-receipt.tmp`);
   let descriptor = null;
   try {
     descriptor = openSync11(temporary, "wx", 384);
@@ -83257,7 +83598,7 @@ function createProofCaptureHandler(deps) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/proof-media.js
-import { createHash as createHash17 } from "node:crypto";
+import { createHash as createHash18 } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { mkdir as mkdir2, mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir as tmpdir11 } from "node:os";
@@ -83300,7 +83641,7 @@ async function hashAcceptedFile(path) {
   }
 }
 async function sha256File2(path) {
-  const hash = createHash17("sha256");
+  const hash = createHash18("sha256");
   const stream = createReadStream(path);
   for await (const chunk of stream)
     hash.update(chunk);
@@ -85429,7 +85770,7 @@ function buildGracefulShutdown(deps) {
 }
 
 // packages/rn-dev-agent-core/dist/lifecycle/lockfile.js
-import { createHash as createHash18 } from "node:crypto";
+import { createHash as createHash19 } from "node:crypto";
 import { execFileSync as execFileSync16 } from "node:child_process";
 import { closeSync as closeSync12, existsSync as existsSync31, mkdirSync as mkdirSync20, openSync as openSync12, readFileSync as readFileSync33, statSync as statSync14, unlinkSync as unlinkSync15, writeFileSync as writeFileSync15, writeSync as writeSync3 } from "node:fs";
 import { tmpdir as tmpdir12, userInfo as userInfo2 } from "node:os";
@@ -85482,7 +85823,7 @@ function defaultSelfPpid() {
   return typeof process.ppid === "number" ? process.ppid : 0;
 }
 function hashProjectRoot(projectRoot) {
-  return createHash18("md5").update(resolve18(projectRoot)).digest("hex").slice(0, 8);
+  return createHash19("md5").update(resolve18(projectRoot)).digest("hex").slice(0, 8);
 }
 var Lockfile = class {
   opts;
@@ -86580,7 +86921,7 @@ function instrumentTool(toolName, handler) {
 }
 
 // packages/rn-dev-agent-core/dist/experience/evidence.js
-import { createHash as createHash19, randomUUID as randomUUID9 } from "node:crypto";
+import { createHash as createHash20, randomUUID as randomUUID10 } from "node:crypto";
 import { chmodSync as chmodSync8, existsSync as existsSync33, mkdirSync as mkdirSync21, readFileSync as readFileSync36, renameSync as renameSync9, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
 import { dirname as dirname27, join as join50 } from "node:path";
@@ -86788,7 +87129,7 @@ var ExperienceRecorder = class {
       recovery: null,
       cleanup: null,
       classification,
-      evidencePointers: [`event:${randomUUID9()}`],
+      evidencePointers: [`event:${randomUUID10()}`],
       tool,
       status: event.status === "ERROR" ? "ERROR" : "FAIL",
       normalizedSymptomShape,
@@ -86834,13 +87175,13 @@ var ExperienceRecorder = class {
     existing.lastRecoveredAt = now;
     delete existing.unknownReasons.recovery;
     existing.evidencePointers = boundedPointers(existing.evidencePointers, [
-      `event:${randomUUID9()}`
+      `event:${randomUUID10()}`
     ]);
     this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
   }
   write(records) {
     mkdirSync21(this.directory, { recursive: true, mode: 448 });
-    const temp = join50(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID9()}`);
+    const temp = join50(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID10()}`);
     try {
       const sanitized = records.map((record2) => record2.redactionVersion === REDACTION_RULES_VERSION ? record2 : {
         ...sanitizeForEvidence(record2),
@@ -86912,7 +87253,7 @@ function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, 
   }).sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen) || a.signature.localeCompare(b.signature)).slice(0, Math.max(0, maxRecords)).sort((a, b) => a.signature.localeCompare(b.signature));
 }
 function experienceSignature(input) {
-  return createHash19("sha256").update(JSON.stringify([
+  return createHash20("sha256").update(JSON.stringify([
     input.classification,
     input.tool,
     input.normalizedSymptomShape,
@@ -87200,7 +87541,7 @@ import { fileURLToPath as fileURLToPath6 } from "node:url";
 import { dirname as dirname28, join as join52 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/observability/e2e-csrf.js
-import { randomBytes as randomBytes7, timingSafeEqual as timingSafeEqual7 } from "node:crypto";
+import { randomBytes as randomBytes7, timingSafeEqual as timingSafeEqual8 } from "node:crypto";
 function makeCsrfToken() {
   return randomBytes7(24).toString("hex");
 }
@@ -87213,7 +87554,7 @@ function isPostAllowed(req, token2) {
     const got = String(gotRaw);
     const a = Buffer.from(got);
     const b = Buffer.from(token2);
-    if (a.length !== b.length || !timingSafeEqual7(a, b)) {
+    if (a.length !== b.length || !timingSafeEqual8(a, b)) {
       return { ok: false, status: 403, reason: "bad csrf token" };
     }
   }
@@ -88419,7 +88760,7 @@ init_action_store();
 init_path_safety();
 import { dirname as dirname29, join as join54 } from "node:path";
 import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync10, readFileSync as readFileSync38, readdirSync as readdirSync15, existsSync as existsSync34 } from "node:fs";
-import { createHash as createHash20 } from "node:crypto";
+import { createHash as createHash21 } from "node:crypto";
 var FLOW_SENTINEL = "# e2e-locked-flow-below";
 function e2eDirFor(projectRoot) {
   return join54(projectRoot, ".rn-agent", "e2e");
@@ -88451,7 +88792,7 @@ function serializeLockedTest(meta) {
 ${meta.flow}`;
 }
 function hashBody(s) {
-  return createHash20("sha256").update(s).digest("hex");
+  return createHash21("sha256").update(s).digest("hex");
 }
 function freezeLockedTest(projectRoot, source, ctx) {
   const filePath = e2ePathFor(projectRoot, source.id);
@@ -89102,40 +89443,6 @@ function probeMetro(port, timeoutMs = 1500) {
 init_device_screenshot_raw();
 init_app_installed_probe();
 init_storage();
-
-// packages/rn-dev-agent-core/dist/domain/action-inventory.js
-init_action_store();
-async function listActions(projectRoot, dependencies = {}) {
-  const context = openReadableActionLoadContext(projectRoot);
-  if (!context)
-    return [];
-  const load = dependencies.loadAction ?? loadActionFromContext;
-  const yamlFiles = context.files.filter((f) => /\.ya?ml$/.test(f)).sort();
-  const results = [];
-  for (const id of new Set(yamlFiles.map((file) => file.replace(/\.ya?ml$/, "")))) {
-    if (yamlFiles.includes(`${id}.yaml`) && yamlFiles.includes(`${id}.yml`))
-      continue;
-    const action = load(context, id);
-    if (!action)
-      continue;
-    const { metadata } = action;
-    const summary = {
-      id: metadata.id,
-      intent: metadata.intent,
-      status: metadata.status
-    };
-    if (metadata.params !== void 0)
-      summary.params = metadata.params;
-    if (metadata.mutates !== void 0)
-      summary.mutates = metadata.mutates;
-    if (metadata.appId !== void 0)
-      summary.appId = metadata.appId;
-    results.push(summary);
-  }
-  return results;
-}
-
-// packages/rn-dev-agent-core/dist/index.js
 init_action_store();
 
 // packages/rn-dev-agent-core/dist/session/runner-binding.js
@@ -89207,7 +89514,7 @@ init_discovery();
 init_metro_cwd();
 init_install_authority();
 import { execFileSync as execFileSync18 } from "node:child_process";
-import { createHash as createHash21 } from "node:crypto";
+import { createHash as createHash22 } from "node:crypto";
 init_metro_origin();
 init_metro_binding();
 init_process_birth();
@@ -89215,7 +89522,7 @@ init_registry();
 init_target_device_authority();
 init_tool_profiles();
 function identity(value) {
-  return createHash21("sha256").update(JSON.stringify(value)).digest("hex");
+  return createHash22("sha256").update(JSON.stringify(value)).digest("hex");
 }
 function objectBinding(status, name) {
   const value = status.bindings[name];
@@ -90234,7 +90541,7 @@ setSnapshotAuthorityProvider({
       runnerInstanceId: runner?.instanceId,
       runnerPid: runner?.pid,
       runnerProcessBirth: runner?.processBirth,
-      runnerCapabilityHash: typeof runner?.capability === "string" ? createHash22("sha256").update(runner.capability).digest("hex") : void 0,
+      runnerCapabilityHash: typeof runner?.capability === "string" ? createHash23("sha256").update(runner.capability).digest("hex") : void 0,
       runnerPort: runner?.port,
       runnerClaim: status.claims.find((claim) => claim.type === "runner")?.key,
       deviceClaim: status.claims.find((claim) => claim.type === "device")?.key
@@ -90367,6 +90674,7 @@ var createRuntimeAuthorityProbe = (resolveClient) => createLocalAuthorityProbe({
 });
 var localAuthorityProbe = createRuntimeAuthorityProbe(getClient);
 var authorityGate = createAuthorityGate(authorityRuntime, {
+  loginSupervisorOverrideToken: () => process.env.RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN,
   probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
   recoverRuntimeConnection: async (status) => {
     const current = getClient();
@@ -90439,7 +90747,7 @@ setObserveAuthorityDeps({
       authority: {
         sessionId: status.sessionId,
         claimEpoch: status.claimEpoch,
-        instanceId: randomUUID10(),
+        instanceId: randomUUID11(),
         capability: secret.observeCapability
       }
     };
@@ -90576,7 +90884,10 @@ function trackedTool(name, desc, schema, handler) {
     }
     return result;
   };
-  server2.tool(name, desc, schema, wrapped);
+  server2.tool(name, desc, {
+    ...schema,
+    supervisorOverrideToken: external_exports.string().min(16).optional().describe("Supervisor token for one audited mutation after a blocked login prologue.")
+  }, wrapped);
 }
 async function pinSessionDevClient(status, options, commitBundle) {
   const device = status.bindings.device;
@@ -91479,7 +91790,7 @@ var proofReadiness = async () => {
       connectedAt: current.connectedAt
     }),
     errorCount: errors.length,
-    errorSha256: createHash22("sha256").update(errorBytes).digest("hex"),
+    errorSha256: createHash23("sha256").update(errorBytes).digest("hex"),
     device: identity2.device,
     runtime: identity2.runtime
   };
@@ -91830,34 +92141,34 @@ trackedTool("cdp_repair_action", "Repair a learned action using a fresh snapshot
   deviceId: external_exports.string().optional().describe("Authority-bound exact device identifier; normally injected by the session"),
   appId: external_exports.string().optional().describe("Authority-bound app identifier; normally injected by the session")
 }, createRepairActionHandler());
-trackedTool(
-  "cdp_run_action",
-  `Replay a learned action by id with end-to-end auto-repair. Loads the action from .rn-agent/actions/<actionId>.yaml or .yml, forwards the matching active session's exact device ID to Maestro, rejects mismatched direct runner/WDA evidence, and on a SELECTOR_NOT_FOUND failure automatically invokes cdp_repair_action and retries once. Appends a RunRecord to the sidecar with full auto-repair telemetry (passed/failed/refused/skipped + diff); its Maestro deviceId comes from direct runner evidence, never requested metadata. The repair attempt counts toward cdp_repair_action's 24h budget. Pass autoRepair=false to opt out of auto-repair (returns the raw maestro_run failure verbatim). forceReload defaults true: any human edit to the YAML since the agent's last write is acknowledged as the new baseline so downstream repair does not abort with STALE_TARGET (the right default for active composition). Pass forceReload=false for the strict "respect offline human edits" behavior: a successful replay still appends its RunRecord to the sidecar when only the tracked YAML mtime baseline is stale, while YAML-mutating promotion and repair stay refused. proofReplay=true is reserved for proof_capture rehearsal and requires autoRepair=false plus forceReload=false; it executes without RunRecord, promotion, YAML, sidecar, or DB persistence. The orchestrated home for the L3 self-healing loop \u2014 prefer this over invoking maestro_run + cdp_repair_action manually for any flow you intend to re-run on schedule. blindProbeMode provides per-call control of the proactive CDP/JS compatibility path: inherit (default) honors RN_BLIND_PROBE, allow explicitly enables it for this call, and forbid forces maestro-first for this call.`,
-  {
-    actionId: external_exports.string().describe("Owned action id; resolves one .yaml or .yml file."),
-    projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
-    platform: external_exports.enum(["ios", "android"]).optional().describe("Force a specific platform; otherwise auto-detected from the active device session."),
-    appFile: external_exports.string().optional().describe("GH #705: path to the .app Maestro reinstalls from after a clearState uninstall. Normally omit it \u2014 an iOS clearState flow resolves the bundle from the session's attested install receipt, and the receipt is re-issued after the reinstall so later device_*/maestro_run calls keep working."),
-    autoRepair: external_exports.boolean().optional().describe("Auto-repair on SELECTOR_NOT_FOUND failures. Default true. Pass false to disable (e.g. when investigating a failure manually)."),
-    timeoutMs: external_exports.number().optional().describe("Maestro execution timeout per attempt (ms). Default 120_000."),
-    trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe('RunRecord trigger annotation. Default "agent". CI calls should pass "ci".'),
-    forceReload: external_exports.boolean().optional().describe('GH #173: when true (default), acknowledge any human edit to the YAML as the new baseline before running so downstream repair does not abort with STALE_TARGET. Pass false for the strict Phase 129 "respect external edits" behavior (useful for CI replays of fixed baselines).'),
-    proofReplay: external_exports.boolean().optional().describe("Read-only proof rehearsal mode. Requires autoRepair=false and forceReload=false; never writes action YAML, runtime sidecar, or DB state."),
-    blindProbeMode: external_exports.enum(["inherit", "allow", "forbid"]).optional().describe("Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged."),
-    params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).")
-  },
-  // GH #186: supply a CDP-backed live-route reader so the route-drift guard is
-  // actually active. Without this the handler defaulted getLiveRoute to a no-op
-  // and the drift branch could never fire, silently routing screen-change
-  // failures into fuzzy selector repair.
-  createRunActionHandler({
-    getLiveRoute: () => readLiveRoute(getClient()),
-    replayDeps: makeReplayDeps,
-    blindProbeContext,
-    targetContext: getActiveSession,
-    claimBundleAuthority: claimOptionalBundleAuthority
-  })
-);
+var runActionHandler = createRunActionHandler({
+  getLiveRoute: () => readLiveRoute(getClient()),
+  replayDeps: makeReplayDeps,
+  blindProbeContext,
+  targetContext: getActiveSession,
+  claimBundleAuthority: claimOptionalBundleAuthority
+});
+trackedTool("cdp_run_action", `Replay a learned action by id with end-to-end auto-repair. Loads the action from .rn-agent/actions/<actionId>.yaml or .yml, forwards the matching active session's exact device ID to Maestro, rejects mismatched direct runner/WDA evidence, and on a SELECTOR_NOT_FOUND failure automatically invokes cdp_repair_action and retries once. Appends a RunRecord to the sidecar with full auto-repair telemetry (passed/failed/refused/skipped + diff); its Maestro deviceId comes from direct runner evidence, never requested metadata. The repair attempt counts toward cdp_repair_action's 24h budget. Pass autoRepair=false to opt out of auto-repair (returns the raw maestro_run failure verbatim). forceReload defaults true: any human edit to the YAML since the agent's last write is acknowledged as the new baseline so downstream repair does not abort with STALE_TARGET (the right default for active composition). Pass forceReload=false for the strict "respect offline human edits" behavior: a successful replay still appends its RunRecord to the sidecar when only the tracked YAML mtime baseline is stale, while YAML-mutating promotion and repair stay refused. proofReplay=true is reserved for proof_capture rehearsal and requires autoRepair=false plus forceReload=false; it executes without RunRecord, promotion, YAML, sidecar, or DB persistence. The orchestrated home for the L3 self-healing loop \u2014 prefer this over invoking maestro_run + cdp_repair_action manually for any flow you intend to re-run on schedule. blindProbeMode provides per-call control of the proactive CDP/JS compatibility path: inherit (default) honors RN_BLIND_PROBE, allow explicitly enables it for this call, and forbid forces maestro-first for this call.`, {
+  actionId: external_exports.string().describe("Owned action id; resolves one .yaml or .yml file."),
+  projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
+  platform: external_exports.enum(["ios", "android"]).optional().describe("Force a specific platform; otherwise auto-detected from the active device session."),
+  appFile: external_exports.string().optional().describe("GH #705: path to the .app Maestro reinstalls from after a clearState uninstall. Normally omit it \u2014 an iOS clearState flow resolves the bundle from the session's attested install receipt, and the receipt is re-issued after the reinstall so later device_*/maestro_run calls keep working."),
+  autoRepair: external_exports.boolean().optional().describe("Auto-repair on SELECTOR_NOT_FOUND failures. Default true. Pass false to disable (e.g. when investigating a failure manually)."),
+  timeoutMs: external_exports.number().optional().describe("Maestro execution timeout per attempt (ms). Default 120_000."),
+  trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe('RunRecord trigger annotation. Default "agent". CI calls should pass "ci".'),
+  forceReload: external_exports.boolean().optional().describe('GH #173: when true (default), acknowledge any human edit to the YAML as the new baseline before running so downstream repair does not abort with STALE_TARGET. Pass false for the strict Phase 129 "respect external edits" behavior (useful for CI replays of fixed baselines).'),
+  proofReplay: external_exports.boolean().optional().describe("Read-only proof rehearsal mode. Requires autoRepair=false and forceReload=false; never writes action YAML, runtime sidecar, or DB state."),
+  blindProbeMode: external_exports.enum(["inherit", "allow", "forbid"]).optional().describe("Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged."),
+  params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).")
+}, runActionHandler);
+trackedTool("cdp_login_prologue", "Inventory learned actions, replay the exact user-login action strictly, and require a fresh passing RunRecord before lifting the session login gate.", {
+  projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
+  platform: external_exports.enum(["ios", "android"]).optional().describe("Force a platform; otherwise use the authority-bound device."),
+  appFile: external_exports.string().optional().describe("iOS app artifact used only when the saved action contains clearState."),
+  timeoutMs: external_exports.number().optional().describe("Saved-action timeout in milliseconds."),
+  trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe("RunRecord trigger annotation. Default agent."),
+  params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Bindings for the exact user-login action placeholders.")
+}, createLoginPrologueHandler({ runAction: runActionHandler }));
 trackedTool("cdp_lock_e2e_test", "Promote a verified action into a frozen, locked e2e regression test. Runs the action once strict (no repair); freezes it only if it passes. v1 supports param-free actions only.", {
   actionId: external_exports.string().describe("The action id under .rn-agent/actions to lock"),
   relock: external_exports.boolean().optional().describe("Overwrite an existing locked test"),
@@ -91957,13 +92268,6 @@ var triggerE2eRun = async (args) => {
     arbiter.release(L.lease);
   }
 };
-var runActionHandler = createRunActionHandler({
-  getLiveRoute: () => readLiveRoute(getClient()),
-  replayDeps: makeReplayDeps,
-  blindProbeContext,
-  targetContext: getActiveSession,
-  claimBundleAuthority: claimOptionalBundleAuthority
-});
 var observeRunActionHandler = authorityGate.wrap("cdp_run_action", runActionHandler);
 var observeTriggerRun = authorityGate.wrap("cdp_run_e2e_suite", async (...raw) => {
   const args = raw[0] ?? {};

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -31939,7 +31939,7 @@ function cleanupAllowed(tool, args) {
   if (tool === "proof_capture" && (args.action === "discard" || args.action === "status")) {
     return true;
   }
-  return tool === "rn_session" && (args.action === "release" || args.action === "stop_metro" || args.action === "cancel_handoff" || args.action === "status");
+  return tool === "rn_session" && (args.action === "release" || args.action === "stop_metro" || args.action === "cancel_handoff" || args.action === "recover_arbiter" && args.confirmed === true || args.action === "status");
 }
 function tokenMatches(expected, supplied) {
   if (!expected || expected.length < 16 || !supplied || supplied.length < 16)

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -32039,6 +32039,9 @@ function loadLockedTest(projectRoot, id) {
   const locked = parseLockedTest(readFileSync19(filePath, "utf8"), filePath);
   return locked?.id === id ? locked : null;
 }
+function lockedTestFileExists(projectRoot, id) {
+  return existsSync20(e2ePathFor(projectRoot, id));
+}
 function discoverLockedTests(projectRoot) {
   const dir = e2eDirFor(projectRoot);
   if (!existsSync20(dir))
@@ -32056,11 +32059,13 @@ function resolveLockedTestIds(projectRoot, pattern, discover2 = discoverLockedTe
     return ids;
   }
 }
-function resolveLockedTestIdentityIds(projectRoot, pattern, discover2 = discoverLockedTests, load = loadLockedTest) {
-  return resolveLockedTestIds(projectRoot, pattern, discover2).filter((id) => {
+function resolveLockedTestSelection(projectRoot, pattern, discover2 = discoverLockedTests, load = loadLockedTest) {
+  const ids = resolveLockedTestIds(projectRoot, pattern, discover2);
+  const identitiesValid = ids.every((id) => {
     const locked = load(projectRoot, id);
     return locked?.id === id && locked.sourceActionId === id;
   });
+  return { ids, identitiesValid };
 }
 function setResolvedLockedTestIds(args, ids) {
   Object.defineProperty(args, resolvedLockedTestIds, {
@@ -33382,17 +33387,17 @@ function createAuthorityGate(runtime, dependencies) {
           bindSessionArguments(status, profile, args, tool);
         }
         if (pendingLockedE2eAdmission) {
-          const resolvedLockedTestIds2 = dependencies.resolveLockedE2eTestIds?.(args, status);
-          if (!resolvedLockedTestIds2 || inspectLoginPrologueGuard({
+          const resolvedSelection = dependencies.resolveLockedE2eTestIds?.(args, status);
+          if (!resolvedSelection?.identitiesValid || inspectLoginPrologueGuard({
             binding: status.bindings.loginPrologue,
             tool,
             args,
             mutation: profile.mutation,
-            resolvedLockedTestIds: resolvedLockedTestIds2
+            resolvedLockedTestIds: resolvedSelection.ids
           }).blocked) {
             throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the locked e2e suite did not resolve to the exact user-login candidate");
           }
-          setResolvedLockedTestIds(args, resolvedLockedTestIds2);
+          setResolvedLockedTestIds(args, resolvedSelection.ids);
         }
         operation = registry2.beginOperation(available.session, {
           operationId: randomUUID4(),
@@ -89154,7 +89159,7 @@ async function lockE2eTestCore(args, deps = {}) {
     }
     resolvedParams = resolved.params;
   }
-  if (!args.relock && loadLockedTest(projectRoot, args.actionId)) {
+  if (!args.relock && lockedTestFileExists(projectRoot, args.actionId)) {
     return failResult(`'${args.actionId}' is already locked \u2014 pass relock:true to re-lock`, "ALREADY_LOCKED");
   }
   const session2 = getSession();
@@ -90876,9 +90881,9 @@ var authorityGate = createAuthorityGate(authorityRuntime, {
   resolveLockedE2eTestIds: (args, status) => {
     const projectRoot = typeof args.projectRoot === "string" ? args.projectRoot : status.source.appRoot;
     if (typeof projectRoot !== "string")
-      return [];
+      return { ids: [], identitiesValid: false };
     args.projectRoot = projectRoot;
-    return resolveLockedTestIdentityIds(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
+    return resolveLockedTestSelection(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
   },
   probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
   recoverRuntimeConnection: async (status) => {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -32652,6 +32652,22 @@ function missingLoginPrologueOutcome() {
     }
   };
 }
+function persistLoginPrologueOutcome(runtime, registry2, operation, status, outcome) {
+  const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+  const nextOperation = registry2.replaceBindingsDuringOperation(operation, {
+    bindings: {
+      loginPrologue: {
+        ...outcome,
+        ...priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}
+      }
+    }
+  });
+  const nextStatus = runtime.status();
+  if (!nextStatus.available) {
+    throw new SessionAuthorityError(nextStatus.code, nextStatus.reason);
+  }
+  return { operation: nextOperation, status: nextStatus };
+}
 function isActionReplayTool(tool) {
   return tool === "cdp_run_action" || tool === "cdp_login_prologue";
 }
@@ -33548,6 +33564,11 @@ function createAuthorityGate(runtime, dependencies) {
             loginPrologueOutcome = missingLoginPrologueOutcome();
             result = failResult("Login prologue returned no valid terminal state.", "LOGIN_PROLOGUE_BLOCKED", { loginPrologue: loginPrologueOutcome });
           }
+          if (loginPrologueOutcome.state === LOGIN_PROLOGUE_BLOCKED) {
+            const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
+            operation = persisted.operation;
+            status = persisted.status;
+          }
         }
         let runtimeTargetChanged = false;
         const postHandlerRecovery = await reconcileRecoverableRuntime(runtime, dependencies, registry2, operation, status, profile, resultSucceeded(result));
@@ -33668,21 +33689,10 @@ function createAuthorityGate(runtime, dependencies) {
           axes: [...runnerAwareReceiptProfile.axes, "M", "A"]
         } : runnerAwareReceiptProfile;
         const controllerGenerationAdvanced = operation.authorityVersion !== initialOperationAuthorityVersion;
-        if (loginPrologueOutcome) {
-          const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
-          operation = registry2.replaceBindingsDuringOperation(operation, {
-            bindings: {
-              loginPrologue: {
-                ...loginPrologueOutcome,
-                ...priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}
-              }
-            }
-          });
-          const loginStatus = runtime.status();
-          if (!loginStatus.available) {
-            throw new SessionAuthorityError(loginStatus.code, loginStatus.reason);
-          }
-          status = loginStatus;
+        if (loginPrologueOutcome?.state === "passed") {
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
+          operation = persisted.operation;
+          status = persisted.status;
         }
         registry2.verifyOperation(operation);
         for (const observation of allBefore) {
@@ -35098,6 +35108,7 @@ var init_device_arbiter = __esm({
     FLOW_TOOLS = /* @__PURE__ */ new Set([
       "maestro_run",
       "maestro_test_all",
+      "cdp_login_prologue",
       "cdp_run_action",
       "cdp_auto_login",
       "cdp_reload",
@@ -78988,15 +78999,15 @@ function createLoginPrologueHandler(deps) {
         return blocked("LOGIN_ACTION_MISSING", `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
       }
       const priorRunIds = new Set(action.state.runHistory.map((record2) => record2.runId).filter((runId) => typeof runId === "string"));
-      const replayArgs = {
-        ...args,
+      const replayArgs = Object.create(Object.getPrototypeOf(args), Object.getOwnPropertyDescriptors(args));
+      Object.assign(replayArgs, {
         actionId: LOGIN_PROLOGUE_ALIAS,
         autoRepair: false,
         forceReload: false,
         proofReplay: false,
         blindProbeMode: "forbid",
         trigger: args.trigger ?? "agent"
-      };
+      });
       let replayResult;
       try {
         replayResult = await measure("replay", () => deps.runAction(replayArgs));

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -27320,7 +27320,7 @@ function assertWritableActionFile(filePath) {
 function assertActionMetadataIdentity(filePath, metadata) {
   const fileId = basename4(filePath).replace(/\.ya?ml$/i, "");
   if (metadata.id !== fileId) {
-    throw new ActionMetadataIdentityError(metadata.id, fileId);
+    throw new Error(`Action metadata id ${metadata.id} does not match filename identity ${fileId}.`);
   }
 }
 function withMetadata(action, metadata) {
@@ -27329,7 +27329,7 @@ function withMetadata(action, metadata) {
 function withBody(action, body) {
   return { ...action, body };
 }
-var SaveActionPreconditionError, ActionMetadataIdentityError;
+var SaveActionPreconditionError;
 var init_action_store = __esm({
   "packages/rn-dev-agent-core/dist/domain/action-store.js"() {
     "use strict";
@@ -27345,16 +27345,6 @@ var init_action_store = __esm({
       constructor(filePath) {
         super(`saveAction precondition violated: yaml at ${filePath} has been edited externally since the in-memory action was loaded. The caller must invoke actionWasEditedExternally() first and abort on true (or use saveActionWithCAS for atomic detection). GH #113 contract enforcement.`);
         this.name = "SaveActionPreconditionError";
-      }
-    };
-    ActionMetadataIdentityError = class extends Error {
-      metadataId;
-      fileId;
-      constructor(metadataId, fileId) {
-        super(`Action metadata id ${metadataId} does not match filename identity ${fileId}.`);
-        this.metadataId = metadataId;
-        this.fileId = fileId;
-        this.name = "ActionMetadataIdentityError";
       }
     };
   }
@@ -79228,9 +79218,6 @@ function parseEnvelope2(result) {
     return { ok: false, code: "BAD_RESPONSE", error: "Action replay returned invalid JSON." };
   }
 }
-function isLoginActionIdentityMismatch(error2) {
-  return error2 instanceof ActionMetadataIdentityError && (error2.fileId === LOGIN_PROLOGUE_ALIAS || error2.metadataId === LOGIN_PROLOGUE_ALIAS);
-}
 function createLoginPrologueHandler(deps) {
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
   return async (args) => {
@@ -79282,7 +79269,7 @@ function createLoginPrologueHandler(deps) {
         inventory = await measure("inventory", () => listActions(projectRoot));
         action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
       } catch (error2) {
-        if (isLoginActionIdentityMismatch(error2)) {
+        if (error2 instanceof Error && error2.message.includes("does not match filename identity") && error2.message.includes(LOGIN_PROLOGUE_ALIAS)) {
           return blocked("LOGIN_ACTION_ID_MISMATCH", `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
         }
         throw error2;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -27320,7 +27320,7 @@ function assertWritableActionFile(filePath) {
 function assertActionMetadataIdentity(filePath, metadata) {
   const fileId = basename4(filePath).replace(/\.ya?ml$/i, "");
   if (metadata.id !== fileId) {
-    throw new Error(`Action metadata id ${metadata.id} does not match filename identity ${fileId}.`);
+    throw new ActionMetadataIdentityError(metadata.id, fileId);
   }
 }
 function withMetadata(action, metadata) {
@@ -27329,7 +27329,7 @@ function withMetadata(action, metadata) {
 function withBody(action, body) {
   return { ...action, body };
 }
-var SaveActionPreconditionError;
+var SaveActionPreconditionError, ActionMetadataIdentityError;
 var init_action_store = __esm({
   "packages/rn-dev-agent-core/dist/domain/action-store.js"() {
     "use strict";
@@ -27345,6 +27345,16 @@ var init_action_store = __esm({
       constructor(filePath) {
         super(`saveAction precondition violated: yaml at ${filePath} has been edited externally since the in-memory action was loaded. The caller must invoke actionWasEditedExternally() first and abort on true (or use saveActionWithCAS for atomic detection). GH #113 contract enforcement.`);
         this.name = "SaveActionPreconditionError";
+      }
+    };
+    ActionMetadataIdentityError = class extends Error {
+      metadataId;
+      fileId;
+      constructor(metadataId, fileId) {
+        super(`Action metadata id ${metadataId} does not match filename identity ${fileId}.`);
+        this.metadataId = metadataId;
+        this.fileId = fileId;
+        this.name = "ActionMetadataIdentityError";
       }
     };
   }
@@ -31907,8 +31917,13 @@ function readLoginPrologueOutcome(value) {
   }
   return candidate;
 }
-function lockedE2eProofAllowed(tool) {
-  return LOCKED_E2E_LOGIN_TOOLS.includes(tool);
+function lockedE2eProofAllowed(tool, args) {
+  if (tool === "cdp_lock_e2e_test")
+    return args.actionId === LOGIN_PROLOGUE_ALIAS;
+  if (tool === "cdp_run_e2e_suite") {
+    return args.pattern === `^${LOGIN_PROLOGUE_ALIAS}$`;
+  }
+  return false;
 }
 function cleanupAllowed(tool, args) {
   if (tool === "cdp_login_prologue")
@@ -31935,7 +31950,7 @@ function tokenMatches(expected, supplied) {
 }
 function inspectLoginPrologueGuard(input) {
   const outcome = readLoginPrologueOutcome(input.binding);
-  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool)) {
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool, input.args)) {
     return { blocked: false };
   }
   return {
@@ -31951,14 +31966,13 @@ function authorizeLoginSupervisorOverride(input) {
 function appendLoginOverrideAudit(outcome, audit) {
   return { ...outcome, overrides: [...outcome.overrides ?? [], audit].slice(-20) };
 }
-var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, ACTION_LOGIN_HELPER, LOCKED_E2E_LOGIN_TOOLS;
+var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, ACTION_LOGIN_HELPER;
 var init_login_prologue = __esm({
   "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
     "use strict";
     LOGIN_PROLOGUE_ALIAS = "user-login";
     LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
     ACTION_LOGIN_HELPER = "ACTION_LOGIN_HELPER";
-    LOCKED_E2E_LOGIN_TOOLS = ["cdp_lock_e2e_test", "cdp_run_e2e_suite"];
   }
 });
 
@@ -79048,6 +79062,9 @@ function parseEnvelope2(result) {
     return { ok: false, code: "BAD_RESPONSE", error: "Action replay returned invalid JSON." };
   }
 }
+function isLoginActionIdentityMismatch(error2) {
+  return error2 instanceof ActionMetadataIdentityError && (error2.fileId === LOGIN_PROLOGUE_ALIAS || error2.metadataId === LOGIN_PROLOGUE_ALIAS);
+}
 function createLoginPrologueHandler(deps) {
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
   return async (args) => {
@@ -79094,8 +79111,16 @@ function createLoginPrologueHandler(deps) {
       });
     };
     try {
-      inventory = await measure("inventory", () => listActions(projectRoot));
-      const action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
+      let action;
+      try {
+        inventory = await measure("inventory", () => listActions(projectRoot));
+        action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
+      } catch (error2) {
+        if (isLoginActionIdentityMismatch(error2)) {
+          return blocked("LOGIN_ACTION_ID_MISMATCH", `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
+        }
+        throw error2;
+      }
       if (!action) {
         return blocked("LOGIN_ACTION_MISSING", `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
       }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -32650,12 +32650,13 @@ function missingLoginPrologueOutcome() {
     }
   };
 }
-function pendingLoginPrologueOutcome() {
+function pendingLoginPrologueOutcome(attemptId) {
   const timestamp = (/* @__PURE__ */ new Date()).toISOString();
   return {
     schemaVersion: 1,
     state: LOGIN_PROLOGUE_BLOCKED,
     alias: LOGIN_PROLOGUE_ALIAS,
+    attemptId,
     startedAt: timestamp,
     endedAt: timestamp,
     elapsedMs: 0,
@@ -32899,6 +32900,8 @@ function createAuthorityGate(runtime, dependencies) {
   return {
     wrap: (tool, handler) => async (...handlerArgs) => {
       const args = handlerArgs[0] && typeof handlerArgs[0] === "object" ? handlerArgs[0] : {};
+      const suppliedSupervisorOverrideToken = typeof args.supervisorOverrideToken === "string" ? args.supervisorOverrideToken : void 0;
+      delete args.supervisorOverrideToken;
       const baseProfile = authorityProfileFor(tool, args);
       let profile = tool === "rn_session" && (args.action === "status" || args.action === "preview_integration" || args.action === "accept_handoff" || args.action === "adopt_stale") ? {
         kind: "diagnostic",
@@ -32929,8 +32932,7 @@ function createAuthorityGate(runtime, dependencies) {
         args,
         mutation: profile.mutation
       });
-      const pendingSupervisorOverrideToken = loginGuard.blocked ? loginGuard.suppliedOverride : void 0;
-      delete args.supervisorOverrideToken;
+      const pendingSupervisorOverrideToken = loginGuard.blocked ? suppliedSupervisorOverrideToken : void 0;
       if (loginGuard.blocked && pendingSupervisorOverrideToken === void 0) {
         return failResult("LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.", "LOGIN_PROLOGUE_BLOCKED", {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
@@ -33208,7 +33210,8 @@ function createAuthorityGate(runtime, dependencies) {
           throw new SessionAuthorityError(initialStatus.code, initialStatus.reason);
         }
         let status = initialStatus;
-        if (tool !== "cdp_login_prologue") {
+        const deferredAdmissionChecks = tool === "cdp_login_prologue" || pendingSupervisorOverrideToken !== void 0;
+        if (!deferredAdmissionChecks) {
           requireCompleteAxes(status, profile);
           bindSessionArguments(status, profile, args, tool);
         }
@@ -33218,10 +33221,29 @@ function createAuthorityGate(runtime, dependencies) {
           profile: profile.axes.join("")
         });
         if (tool === "cdp_login_prologue") {
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome());
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome(operation.operationId));
           operation = persisted.operation;
           status = persisted.status;
           loginPrologueAttemptOperationId = operation.operationId;
+          requireCompleteAxes(status, profile);
+          bindSessionArguments(status, profile, args, tool);
+        }
+        if (pendingSupervisorOverrideToken !== void 0) {
+          const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+          if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
+          }
+          const audit = authorizeLoginSupervisorOverride({
+            expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
+            suppliedOverrideToken: pendingSupervisorOverrideToken,
+            tool
+          });
+          if (!audit) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the supervisor override token was rejected under the operation fence");
+          }
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, audit));
+          operation = persisted.operation;
+          status = persisted.status;
           requireCompleteAxes(status, profile);
           bindSessionArguments(status, profile, args, tool);
         }
@@ -33570,23 +33592,6 @@ function createAuthorityGate(runtime, dependencies) {
             }
           });
         }
-        if (pendingSupervisorOverrideToken !== void 0) {
-          const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
-          if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
-            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
-          }
-          const audit = authorizeLoginSupervisorOverride({
-            expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
-            suppliedOverrideToken: pendingSupervisorOverrideToken,
-            tool
-          });
-          if (!audit) {
-            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the supervisor override token was rejected under the operation fence");
-          }
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, audit));
-          operation = persisted.operation;
-          status = persisted.status;
-        }
         registry2.verifyOperation(operation);
         const snapshotCheckpoint = dependencies.snapshotCaptureCheckpoint?.();
         let result = await registry2.runWithOperation(operation, () => handler(...handlerArgs));
@@ -33773,7 +33778,7 @@ function createAuthorityGate(runtime, dependencies) {
         }
         if (operation && loginPrologueOutcome?.state === "passed") {
           const pendingOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
-          if (operation.operationId !== loginPrologueAttemptOperationId || pendingOutcome?.state !== LOGIN_PROLOGUE_BLOCKED || pendingOutcome.failure?.code !== "LOGIN_PROLOGUE_IN_PROGRESS") {
+          if (operation.operationId !== loginPrologueAttemptOperationId || pendingOutcome?.state !== LOGIN_PROLOGUE_BLOCKED || pendingOutcome.attemptId !== loginPrologueAttemptOperationId || pendingOutcome.failure?.code !== "LOGIN_PROLOGUE_IN_PROGRESS") {
             throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the passing login result does not match the active blocked attempt");
           }
           const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
@@ -74638,7 +74643,7 @@ var PII_PATTERNS = [
   /\b\d{3}[-.]\d{3}[-.]\d{4}\b/g,
   /\b\d{3}-\d{2}-\d{4}\b/g
 ];
-var AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
+var AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|supervisorOverrideToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
 var MAX_STRING_LENGTH = 2e3;
 function redactString(value) {
   let result = value.replace(HOME_RE, "~");
@@ -78184,6 +78189,11 @@ function classifyFailure(failure) {
       return { actionCode: "UNKNOWN", toolCode: void 0 };
   }
 }
+var PROVEN_ENGINE_PIN_DIVERGENCE = /* @__PURE__ */ new Set(["drift-newer", "drift-older", "checksum-mismatch"]);
+function strictEnginePinDivergence(env) {
+  const status = env.data?.enginePin?.status;
+  return typeof status === "string" && PROVEN_ENGINE_PIN_DIVERGENCE.has(status) ? status : null;
+}
 function parseEnvelope(toolResult, toolName) {
   try {
     return JSON.parse(toolResult.content?.[0]?.text ?? "{}");
@@ -78416,6 +78426,7 @@ function createRunActionHandler(deps = {}) {
     try {
       let atRisk = null;
       const strictExecutor = usesStrictRunActionPolicy(args);
+      const strictRunRecordMeta = (outcome) => strictExecutor && outcome.persistedRunId ? { strictRunRecordId: outcome.persistedRunId } : {};
       const inheritedBlindProbeDisabled = process.env.RN_BLIND_PROBE === "0" || process.env.RN_BLIND_PROBE === "false";
       const blindProbeDisabled = strictExecutor || args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
       if (args.platform !== "android") {
@@ -78516,11 +78527,37 @@ function createRunActionHandler(deps = {}) {
       }));
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, "maestro_run");
-      const firstPassed = firstEnv.ok === true && firstEnv.data?.passed === true;
       const firstOutput = readMaestroOutput(firstEnv);
       const firstFailureDetail = readMaestroFailureDetail(firstEnv, firstOutput);
       const firstDeviceAuthority = readMaestroDeviceAuthority(firstEnv);
       probeDeviceId = firstDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
+      const enginePinDivergence = strictExecutor ? strictEnginePinDivergence(firstEnv) : null;
+      if (enginePinDivergence) {
+        const autoRepair2 = {
+          attempted: false,
+          outcome: "refused",
+          refusedReason: "NOT_REPAIRABLE_KIND",
+          phases: { firstAttemptMs }
+        };
+        const persisted2 = await persistRunWithDevice({
+          timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+          durationMs: Date.now() - t0,
+          status: "fail",
+          failureCode: "UNKNOWN",
+          failureDetail: `Engine pin status ${enginePinDivergence}`,
+          trigger,
+          autoRepair: autoRepair2
+        });
+        return failResult(`cdp_run_action: ${args.actionId} refused strict replay because the engine pin status is ${enginePinDivergence}.`, "ENGINE_PIN_MISMATCH", {
+          actionId: args.actionId,
+          failureKind: "ENGINE_PIN_MISMATCH",
+          enginePin: firstEnv.data?.enginePin,
+          autoRepair: autoRepair2,
+          writes: writeDisclosure("none", persisted2),
+          ...strictRunRecordMeta(persisted2)
+        });
+      }
+      const firstPassed = firstEnv.ok === true && firstEnv.data?.passed === true;
       if (firstEnv.code) {
         const typedCode = firstEnv.code;
         const autoRepair2 = {
@@ -78543,7 +78580,8 @@ function createRunActionHandler(deps = {}) {
           failureKind: typedCode,
           deviceAuthority: firstDeviceAuthority,
           autoRepair: autoRepair2,
-          writes: writeDisclosure("none", persisted2)
+          writes: writeDisclosure("none", persisted2),
+          ...strictRunRecordMeta(persisted2)
         });
       }
       if (firstPassed) {
@@ -78559,9 +78597,17 @@ function createRunActionHandler(deps = {}) {
           trigger,
           autoRepair: autoRepair2
         });
+        if (strictExecutor && persisted2.persistedRunId !== runId) {
+          return failResult(`cdp_run_action: ${args.actionId} passed, but its authoritative RunRecord was not committed.`, "LOAD_FAILED", {
+            actionId: args.actionId,
+            failureKind: "AUTHORITATIVE_RUN_RECORD_MISSING",
+            writes: writeDisclosure("none", persisted2)
+          });
+        }
         return okResult({
           passed: true,
           actionId: args.actionId,
+          ...strictExecutor ? { strictRunRecordId: persisted2.persistedRunId } : {},
           ...proofReplay ? { proofReplay: true } : {},
           ...replaySuccessEvidence(firstEnv),
           repair: autoRepair2,
@@ -78691,7 +78737,7 @@ function createRunActionHandler(deps = {}) {
           phases: { firstAttemptMs }
         };
         const { actionCode, toolCode } = classifyFailure(failure);
-        await persistRunWithDevice({
+        const persisted2 = await persistRunWithDevice({
           timestamp: (/* @__PURE__ */ new Date()).toISOString(),
           durationMs: Date.now() - t0,
           status: "fail",
@@ -78711,7 +78757,8 @@ function createRunActionHandler(deps = {}) {
           firstAttemptOutput: boundedOutput(firstOutput),
           terminal: readMaestroTerminal(firstEnv),
           runnerResume: firstEnv.meta?.runnerResume,
-          ...cdpJsFallback ? { cdpJsFallback } : {}
+          ...cdpJsFallback ? { cdpJsFallback } : {},
+          ...strictRunRecordMeta(persisted2)
         };
         let message = failure.kind === "WDA_BOOTSTRAP_FAILED" ? `cdp_run_action: ${args.actionId} failed (WDA_BOOTSTRAP_FAILED) before the first replay step: ${failure.detail}. Re-run the replay (bootstrap retries itself); check network access; diagnose the pin-cache runner with ${PINNED_RUNNER_DIAGNOSE_HINT}. Supported correction: ${PINNED_RUNNER_INSTALL_HINT}. Never invoke PATH, ~/.maestro-runner, maestro-cli, or manual login. No preparation or cache mutation was attempted.` : `cdp_run_action: ${args.actionId} failed (${failure.kind})${autoRepairEnabled ? " \u2014 failure not auto-repairable" : " \u2014 auto-repair disabled"}: ${firstFailureDetail}`;
         if (cdpJsFallback?.reason === "cdp-unreachable") {
@@ -78937,7 +78984,7 @@ async function persistRun(actionId, projectRoot, record2) {
           path: fresh.filePath
         }
       });
-      return { promoted, promotionRefused: promotionRefused2 };
+      return { promoted, promotionRefused: promotionRefused2, persistedRunId: record2.runId };
     };
     const promotionRefused = promotes && !promoteActionRuntimeWithCAS(fresh, nextState).ok;
     if (promotes && !promotionRefused)
@@ -79048,7 +79095,6 @@ function createLoginPrologueHandler(deps) {
       if (action.metadata.id !== LOGIN_PROLOGUE_ALIAS) {
         return blocked("LOGIN_ACTION_ID_MISMATCH", `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
       }
-      const priorRunIds = new Set(action.state.runHistory.map((record2) => record2.runId).filter((runId) => typeof runId === "string"));
       const replayArgs = Object.create(Object.getPrototypeOf(args), Object.getOwnPropertyDescriptors(args));
       Object.assign(replayArgs, {
         actionId: LOGIN_PROLOGUE_ALIAS,
@@ -79069,15 +79115,17 @@ function createLoginPrologueHandler(deps) {
         });
       }
       const replay = parseEnvelope2(replayResult);
+      const strictRunRecordId = typeof replay.data?.strictRunRecordId === "string" ? replay.data.strictRunRecordId : typeof replay.meta?.strictRunRecordId === "string" ? replay.meta.strictRunRecordId : void 0;
       let freshRecord;
       await measure("verify-run-record", async () => {
         const reloaded = loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS);
-        freshRecord = reloaded?.state.runHistory.slice().reverse().find((record2) => typeof record2.runId === "string" && !priorRunIds.has(record2.runId));
+        freshRecord = strictRunRecordId ? reloaded?.state.runHistory.find((record2) => record2.runId === strictRunRecordId) : void 0;
       });
       if (replay.ok !== true || replay.data?.passed !== true) {
-        return blocked(replay.code ?? String(replay.data?.failureKind ?? "ACTION_REPLAY_FAILED"), "The saved login action did not pass; exploratory login is now terminally blocked.", { actionId: LOGIN_PROLOGUE_ALIAS, ...freshRecord ? { runRecord: freshRecord } : {} });
+        const metaFailureKind = replay.meta?.failureKind;
+        return blocked(replay.code ?? (typeof metaFailureKind === "string" ? metaFailureKind : freshRecord?.failureCode ?? "ACTION_REPLAY_FAILED"), "The saved login action did not pass; exploratory login is now terminally blocked.", { actionId: LOGIN_PROLOGUE_ALIAS, ...freshRecord ? { runRecord: freshRecord } : {} });
       }
-      if (!freshRecord || freshRecord.status !== "pass") {
+      if (!strictRunRecordId || !freshRecord || freshRecord.status !== "pass") {
         return blocked("AUTHORITATIVE_RUN_RECORD_MISSING", "The saved login action reported success without a fresh passing RunRecord.", { actionId: LOGIN_PROLOGUE_ALIAS });
       }
       const outcome = finish("passed", {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -32036,7 +32036,8 @@ function loadLockedTest(projectRoot, id) {
   const filePath = e2ePathFor(projectRoot, id);
   if (!existsSync20(filePath))
     return null;
-  return parseLockedTest(readFileSync19(filePath, "utf8"), filePath);
+  const locked = parseLockedTest(readFileSync19(filePath, "utf8"), filePath);
+  return locked?.id === id ? locked : null;
 }
 function discoverLockedTests(projectRoot) {
   const dir = e2eDirFor(projectRoot);
@@ -32054,6 +32055,12 @@ function resolveLockedTestIds(projectRoot, pattern, discover2 = discoverLockedTe
   } catch {
     return ids;
   }
+}
+function resolveLockedTestIdentityIds(projectRoot, pattern, discover2 = discoverLockedTests, load = loadLockedTest) {
+  return resolveLockedTestIds(projectRoot, pattern, discover2).filter((id) => {
+    const locked = load(projectRoot, id);
+    return locked?.id === id && locked.sourceActionId === id;
+  });
 }
 function setResolvedLockedTestIds(args, ids) {
   Object.defineProperty(args, resolvedLockedTestIds, {
@@ -32783,8 +32790,19 @@ function parseLoginPrologueOutcome(result) {
     return null;
   }
 }
-function missingLoginPrologueOutcome() {
+function missingLoginPrologueOutcome(result) {
   const timestamp = (/* @__PURE__ */ new Date()).toISOString();
+  let failure = {
+    code: "LOGIN_PROLOGUE_RESULT_INVALID",
+    detail: "The login prologue returned no valid terminal state."
+  };
+  try {
+    const envelope = JSON.parse(result.content?.[0]?.text ?? "{}");
+    if (envelope.code === "BUSY_FLOW_ACTIVE" && typeof envelope.error === "string") {
+      failure = { code: envelope.code, detail: envelope.error };
+    }
+  } catch {
+  }
   return {
     schemaVersion: 1,
     state: LOGIN_PROLOGUE_BLOCKED,
@@ -32794,10 +32812,7 @@ function missingLoginPrologueOutcome() {
     elapsedMs: 0,
     steps: [],
     inventory: { count: 0, actionIds: [] },
-    failure: {
-      code: "LOGIN_PROLOGUE_RESULT_INVALID",
-      detail: "The login prologue returned no valid terminal state."
-    }
+    failure
   };
 }
 function pendingLoginPrologueOutcome(attemptId) {
@@ -33763,8 +33778,8 @@ function createAuthorityGate(runtime, dependencies) {
         if (tool === "cdp_login_prologue") {
           loginPrologueOutcome = parseLoginPrologueOutcome(result);
           if (!loginPrologueOutcome) {
-            loginPrologueOutcome = missingLoginPrologueOutcome();
-            result = failResult("Login prologue returned no valid terminal state.", "LOGIN_PROLOGUE_BLOCKED", { loginPrologue: loginPrologueOutcome });
+            loginPrologueOutcome = missingLoginPrologueOutcome(result);
+            result = failResult(`Login prologue blocked: ${loginPrologueOutcome.failure?.detail ?? "The login prologue returned no valid terminal state."}`, "LOGIN_PROLOGUE_BLOCKED", { loginPrologue: loginPrologueOutcome });
           }
           if (loginPrologueOutcome.state === LOGIN_PROLOGUE_BLOCKED) {
             const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
@@ -90863,7 +90878,7 @@ var authorityGate = createAuthorityGate(authorityRuntime, {
     if (typeof projectRoot !== "string")
       return [];
     args.projectRoot = projectRoot;
-    return resolveLockedTestIds(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
+    return resolveLockedTestIdentityIds(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
   },
   probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
   recoverRuntimeConnection: async (status) => {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -31907,6 +31907,9 @@ function readLoginPrologueOutcome(value) {
   }
   return candidate;
 }
+function lockedE2eProofAllowed(tool) {
+  return LOCKED_E2E_LOGIN_TOOLS.includes(tool);
+}
 function cleanupAllowed(tool, args) {
   if (tool === "cdp_login_prologue")
     return true;
@@ -31932,7 +31935,7 @@ function tokenMatches(expected, supplied) {
 }
 function inspectLoginPrologueGuard(input) {
   const outcome = readLoginPrologueOutcome(input.binding);
-  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args)) {
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool)) {
     return { blocked: false };
   }
   return {
@@ -31948,12 +31951,14 @@ function authorizeLoginSupervisorOverride(input) {
 function appendLoginOverrideAudit(outcome, audit) {
   return { ...outcome, overrides: [...outcome.overrides ?? [], audit].slice(-20) };
 }
-var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED;
+var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, ACTION_LOGIN_HELPER, LOCKED_E2E_LOGIN_TOOLS;
 var init_login_prologue = __esm({
   "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
     "use strict";
     LOGIN_PROLOGUE_ALIAS = "user-login";
     LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
+    ACTION_LOGIN_HELPER = "ACTION_LOGIN_HELPER";
+    LOCKED_E2E_LOGIN_TOOLS = ["cdp_lock_e2e_test", "cdp_run_e2e_suite"];
   }
 });
 
@@ -64034,6 +64039,7 @@ function projectPublicAuthorityStatus(status, options = {}) {
     proofOverlay: { active: Boolean(status.bindings.proof) },
     ...loginPrologue ? {
       loginPrologue: {
+        role: ACTION_LOGIN_HELPER,
         state: loginPrologue.state,
         alias: loginPrologue.alias,
         actionId: loginPrologue.actionId,
@@ -79068,6 +79074,7 @@ function createLoginPrologueHandler(deps) {
       return {
         schemaVersion: 1,
         state,
+        role: ACTION_LOGIN_HELPER,
         alias: LOGIN_PROLOGUE_ALIAS,
         startedAt: prologueStarted.toISOString(),
         endedAt: ended.toISOString(),
@@ -92271,7 +92278,7 @@ trackedTool("cdp_run_action", `Replay a learned action by id with end-to-end aut
   blindProbeMode: external_exports.enum(["inherit", "allow", "forbid"]).optional().describe("Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged."),
   params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).")
 }, runActionHandler);
-trackedTool("cdp_login_prologue", "Inventory learned actions, replay the exact user-login action strictly, and require a fresh passing RunRecord before lifting the session login gate.", {
+trackedTool("cdp_login_prologue", "Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; not PR proof.", {
   projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
   platform: external_exports.enum(["ios", "android"]).optional().describe("Force a platform; otherwise use the authority-bound device."),
   appFile: external_exports.string().optional().describe("iOS app artifact used only when the saved action contains clearState."),

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -92171,7 +92171,7 @@ trackedTool("device_batch", "Execute a sequence of exact-device UI interactions 
   continueOnError: external_exports.boolean().default(false).describe("When true, ordinary failed steps are recorded and the batch continues. A failed fill with observed or possible mutation always stops later steps."),
   finalSnapshot: external_exports.enum(["salient", "full", "none"]).default("salient").describe("Shape of the batch final_snapshot. salient (default): compact list of only actionable nodes (Button/TextField/Switch/etc) \u2014 far fewer tokens. full: complete node list (legacy). none: skip the implicit trailing snapshot entirely (~1,450 ms saved) for action-only batches you verify via expect_*/cdp_store_state.")
 }, createDeviceBatchHandler(getClient));
-trackedTool("cdp_auto_login", "Explicit legacy navigation helper that detects an auth screen and runs one project login subflow through maestro_run on the authority-bound device. It is per-call recovery only, never durable login authority or PR proof; prefer a compatible owned learned action.", {
+trackedTool("cdp_auto_login", "Explicit legacy navigation helper that detects an auth screen and runs one project login subflow through maestro_run on the authority-bound device. It is never login authority or PR proof; use cdp_login_prologue for authenticated journeys.", {
   appId: external_exports.string().optional().describe("App bundle ID override (auto-detected from app.json if omitted)"),
   platform: external_exports.enum(["ios", "android"]).optional().describe("Platform override (auto-detected from session if omitted)")
 }, withConnection(getClient, async (args, client2) => {
@@ -92371,13 +92371,13 @@ trackedTool("cdp_run_action", `Replay a learned action by id with end-to-end aut
   blindProbeMode: external_exports.enum(["inherit", "allow", "forbid"]).optional().describe("Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged."),
   params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).")
 }, runActionHandler);
-trackedTool("cdp_login_prologue", "Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; not PR proof.", {
+trackedTool("cdp_login_prologue", "Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; failure blocks exploratory fallback mutations, and a pass is not PR proof.", {
   projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
-  platform: external_exports.enum(["ios", "android"]).optional().describe("Force a platform; otherwise use the authority-bound device."),
-  appFile: external_exports.string().optional().describe("iOS app artifact used only when the saved action contains clearState."),
+  platform: external_exports.enum(["ios", "android"]).optional().describe("Override the bound platform."),
+  appFile: external_exports.string().optional().describe("iOS app artifact for clearState actions."),
   timeoutMs: external_exports.number().optional().describe("Saved-action timeout in milliseconds."),
-  trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe("RunRecord trigger annotation. Default agent."),
-  params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Bindings for the exact user-login action placeholders.")
+  trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe("Run trigger; default agent."),
+  params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("String user-login bindings.")
 }, createLoginPrologueHandler({ runAction: runActionHandler }));
 trackedTool("cdp_lock_e2e_test", "Promote a verified action into a frozen, locked e2e regression test. Runs the action once strict (no repair); freezes it only if it passes. v1 supports param-free actions only.", {
   actionId: external_exports.string().describe("The action id under .rn-agent/actions to lock"),

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -31917,11 +31917,11 @@ function readLoginPrologueOutcome(value) {
   }
   return candidate;
 }
-function lockedE2eProofAllowed(tool, args) {
+function lockedE2eProofAllowed(tool, args, resolvedLockedTestIds2) {
   if (tool === "cdp_lock_e2e_test")
     return args.actionId === LOGIN_PROLOGUE_ALIAS;
   if (tool === "cdp_run_e2e_suite") {
-    return args.pattern === `^${LOGIN_PROLOGUE_ALIAS}$`;
+    return resolvedLockedTestIds2?.length === 1 && resolvedLockedTestIds2[0] === LOGIN_PROLOGUE_ALIAS;
   }
   return false;
 }
@@ -31950,7 +31950,7 @@ function tokenMatches(expected, supplied) {
 }
 function inspectLoginPrologueGuard(input) {
   const outcome = readLoginPrologueOutcome(input.binding);
-  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool, input.args)) {
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool, input.args, input.resolvedLockedTestIds)) {
     return { blocked: false };
   }
   return {
@@ -31973,6 +31973,137 @@ var init_login_prologue = __esm({
     LOGIN_PROLOGUE_ALIAS = "user-login";
     LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
     ACTION_LOGIN_HELPER = "ACTION_LOGIN_HELPER";
+  }
+});
+
+// packages/rn-dev-agent-core/dist/domain/e2e-test.js
+import { dirname as dirname15, join as join25 } from "node:path";
+import { mkdirSync as mkdirSync14, writeFileSync as writeFileSync9, renameSync as renameSync5, readFileSync as readFileSync19, readdirSync as readdirSync10, existsSync as existsSync20 } from "node:fs";
+import { createHash as createHash8 } from "node:crypto";
+function e2eDirFor(projectRoot) {
+  return join25(projectRoot, ".rn-agent", "e2e");
+}
+function e2ePathFor(projectRoot, id) {
+  assertValidActionId(id, "e2ePathFor");
+  const dir = e2eDirFor(projectRoot);
+  const file = join25(dir, `${id}.yaml`);
+  assertWithinDir(file, dir);
+  return file;
+}
+function serializeLockedTest(meta) {
+  const header = [
+    "# e2e-locked-test: true",
+    `# id: ${meta.id}`,
+    `# intent: ${meta.intent}`,
+    `# sourceActionId: ${meta.sourceActionId}`,
+    `# lockedAt: ${meta.lockedAt}`,
+    `# lockedGitSha: ${meta.lockedGitSha ?? ""}`,
+    `# sourceContentHash: ${meta.sourceContentHash}`,
+    "# status: locked"
+  ];
+  if (meta.appId)
+    header.push(`# appId: ${meta.appId}`);
+  if (meta.params?.length)
+    header.push(`# params: ${meta.params.join(", ")}`);
+  header.push(FLOW_SENTINEL);
+  return `${header.join("\n")}
+${meta.flow}`;
+}
+function hashBody(s) {
+  return createHash8("sha256").update(s).digest("hex");
+}
+function freezeLockedTest(projectRoot, source, ctx) {
+  const filePath = e2ePathFor(projectRoot, source.id);
+  mkdirSync14(dirname15(filePath), { recursive: true });
+  const meta = {
+    id: source.id,
+    intent: source.intent,
+    sourceActionId: source.sourceActionId,
+    lockedAt: ctx.now().toISOString(),
+    lockedGitSha: ctx.gitSha,
+    sourceContentHash: hashBody(source.flow),
+    status: "locked",
+    params: source.params,
+    appId: source.appId,
+    flow: source.flow
+  };
+  const tmp = `${filePath}.tmp`;
+  writeFileSync9(tmp, serializeLockedTest(meta), "utf8");
+  renameSync5(tmp, filePath);
+  return { ...meta, filePath };
+}
+function loadLockedTest(projectRoot, id) {
+  const filePath = e2ePathFor(projectRoot, id);
+  if (!existsSync20(filePath))
+    return null;
+  return parseLockedTest(readFileSync19(filePath, "utf8"), filePath);
+}
+function discoverLockedTests(projectRoot) {
+  const dir = e2eDirFor(projectRoot);
+  if (!existsSync20(dir))
+    return [];
+  return readdirSync10(dir).filter((f) => f.endsWith(".yaml")).map((f) => f.replace(/\.yaml$/, "")).sort();
+}
+function resolveLockedTestIds(projectRoot, pattern, discover2 = discoverLockedTests) {
+  const ids = discover2(projectRoot);
+  if (!pattern || pattern.length > 256)
+    return ids;
+  try {
+    const matcher = new RegExp(pattern, "i");
+    return ids.filter((id) => matcher.test(id));
+  } catch {
+    return ids;
+  }
+}
+function setResolvedLockedTestIds(args, ids) {
+  Object.defineProperty(args, resolvedLockedTestIds, {
+    value: Object.freeze([...ids]),
+    configurable: true
+  });
+}
+function getResolvedLockedTestIds(args) {
+  return args[resolvedLockedTestIds];
+}
+function parseLockedTest(text, filePath) {
+  if (!/^#\s*e2e-locked-test:\s*true\s*$/m.test(text))
+    return null;
+  const sentinelIdx = text.indexOf(FLOW_SENTINEL);
+  if (sentinelIdx < 0)
+    return null;
+  const headerText = text.slice(0, sentinelIdx);
+  const flowStart = text.indexOf("\n", sentinelIdx);
+  const flow = flowStart >= 0 ? text.slice(flowStart + 1) : "";
+  const field2 = (k) => {
+    const m = headerText.match(new RegExp(`^#\\s*${k}:\\s*(.*)$`, "m"));
+    const v = m?.[1]?.trim();
+    return v ? v : void 0;
+  };
+  const id = field2("id");
+  const intent = field2("intent");
+  if (!id || !intent)
+    return null;
+  const paramsRaw = field2("params");
+  return {
+    id,
+    intent,
+    sourceActionId: field2("sourceActionId") ?? id,
+    lockedAt: field2("lockedAt") ?? "",
+    lockedGitSha: field2("lockedGitSha") ?? null,
+    sourceContentHash: field2("sourceContentHash") ?? "",
+    status: "locked",
+    params: paramsRaw ? paramsRaw.split(",").map((s) => s.trim()).filter(Boolean) : void 0,
+    appId: field2("appId"),
+    flow,
+    filePath
+  };
+}
+var FLOW_SENTINEL, resolvedLockedTestIds;
+var init_e2e_test = __esm({
+  "packages/rn-dev-agent-core/dist/domain/e2e-test.js"() {
+    "use strict";
+    init_path_safety();
+    FLOW_SENTINEL = "# e2e-locked-flow-below";
+    resolvedLockedTestIds = /* @__PURE__ */ Symbol("resolvedLockedTestIds");
   }
 });
 
@@ -32952,7 +33083,8 @@ function createAuthorityGate(runtime, dependencies) {
         mutation: profile.mutation
       });
       const pendingSupervisorOverrideToken = loginGuard.blocked ? suppliedSupervisorOverrideToken : void 0;
-      if (loginGuard.blocked && pendingSupervisorOverrideToken === void 0) {
+      const pendingLockedE2eAdmission = loginGuard.blocked && tool === "cdp_run_e2e_suite" && pendingSupervisorOverrideToken === void 0;
+      if (loginGuard.blocked && pendingSupervisorOverrideToken === void 0 && !pendingLockedE2eAdmission) {
         return failResult("LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.", "LOGIN_PROLOGUE_BLOCKED", {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
           overrideRejected: false,
@@ -33233,6 +33365,19 @@ function createAuthorityGate(runtime, dependencies) {
         if (!deferredAdmissionChecks) {
           requireCompleteAxes(status, profile);
           bindSessionArguments(status, profile, args, tool);
+        }
+        if (pendingLockedE2eAdmission) {
+          const resolvedLockedTestIds2 = dependencies.resolveLockedE2eTestIds?.(args, status);
+          if (!resolvedLockedTestIds2 || inspectLoginPrologueGuard({
+            binding: status.bindings.loginPrologue,
+            tool,
+            args,
+            mutation: profile.mutation,
+            resolvedLockedTestIds: resolvedLockedTestIds2
+          }).blocked) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the locked e2e suite did not resolve to the exact user-login candidate");
+          }
+          setResolvedLockedTestIds(args, resolvedLockedTestIds2);
         }
         operation = registry2.beginOperation(available.session, {
           operationId: randomUUID4(),
@@ -33853,6 +33998,7 @@ var init_authority_gate = __esm({
     init_metro_origin();
     init_install_reissue();
     init_login_prologue();
+    init_e2e_test();
     init_tool_profiles();
     optionalBundleAdmission = /* @__PURE__ */ Symbol("optionalBundleAdmission");
     managedNativeOrigin = /* @__PURE__ */ Symbol("managedNativeOrigin");
@@ -33889,9 +34035,9 @@ var init_authority_gate = __esm({
 // packages/rn-dev-agent-core/dist/tools/maestro-run.js
 import { execFile as execFileCb3 } from "node:child_process";
 import { promisify as promisify4 } from "node:util";
-import { existsSync as existsSync20, readFileSync as readFileSync19, writeFileSync as writeFileSync9 } from "node:fs";
+import { existsSync as existsSync21, readFileSync as readFileSync20, writeFileSync as writeFileSync10 } from "node:fs";
 import { tmpdir as tmpdir7 } from "node:os";
-import { basename as basename7, join as join25, dirname as dirname15 } from "node:path";
+import { basename as basename7, join as join26, dirname as dirname16 } from "node:path";
 async function runFlowParked(run, opts = {}) {
   const stale = opts.markCdpStale ?? markCdpStale;
   try {
@@ -34132,11 +34278,11 @@ function createMaestroRunHandler(deps = {}) {
     } else if (args.inlineYaml) {
       rawYaml = args.inlineYaml;
     } else if (args.flowPath) {
-      if (!existsSync20(args.flowPath)) {
+      if (!existsSync21(args.flowPath)) {
         return failResult(`Flow file not found: ${args.flowPath}`);
       }
       try {
-        rawYaml = readFileSync19(args.flowPath, "utf-8");
+        rawYaml = readFileSync20(args.flowPath, "utf-8");
       } catch (err) {
         return failResult(`Failed to read flow file: ${err.message}`);
       }
@@ -34144,7 +34290,7 @@ function createMaestroRunHandler(deps = {}) {
       return failResult("Provide either flowPath or inlineYaml.");
     }
     try {
-      const runFlowOpts = args.flowPath && flowPathClassification === "outside" ? { flowDir: dirname15(args.flowPath), flowRoot: dirname15(args.flowPath) } : {};
+      const runFlowOpts = args.flowPath && flowPathClassification === "outside" ? { flowDir: dirname16(args.flowPath), flowRoot: dirname16(args.flowPath) } : {};
       const parsed = parseAndValidateFlow(rawYaml, runFlowOpts);
       planMaestroAuthorityStages(parsed.commands);
       validatedCommands = parsed.commands;
@@ -34152,8 +34298,8 @@ function createMaestroRunHandler(deps = {}) {
       const rawAppId = resolveAppId(args.appId, platform);
       headerAppId = resolveMaestroFlowAppId(rawAppId || void 0, parsed.appId);
       validatedContent = buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, parsed.commands);
-      flowFile = join25(tmpdir7(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
-      writeFileSync9(flowFile, validatedContent, "utf-8");
+      flowFile = join26(tmpdir7(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      writeFileSync10(flowFile, validatedContent, "utf-8");
     } catch (err) {
       if (err instanceof MaestroValidationError) {
         return failResult(`Refusing to run Maestro: ${err.message} (Phase 134.1)`);
@@ -34265,7 +34411,7 @@ function createMaestroRunHandler(deps = {}) {
       const relaunchManagedApp = args.relaunchManagedApp ?? deps.relaunchManagedApp ?? managedAuthority.relaunchManagedApp;
       const reproveManagedOrigin = args.reproveManagedOrigin ?? deps.reproveManagedOrigin ?? managedAuthority.reproveManagedOrigin;
       const stageResults = await parkFlow(() => executeMaestroAuthorityStages(validatedCommands, async (commands) => {
-        writeFileSync9(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
+        writeFileSync10(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
         const executeOnce = async (beforeDispatch) => {
           if (flowDeadline - now() <= 0) {
             const error2 = new Error("Maestro flow timeout exhausted before the next stage");
@@ -34508,7 +34654,7 @@ function createMaestroRunHandler(deps = {}) {
       return failResult(failAug.message, failAug.meta);
     } finally {
       try {
-        writeFileSync9(flowFile, validatedContent, "utf-8");
+        writeFileSync10(flowFile, validatedContent, "utf-8");
       } finally {
         disposeRunnerReportDir(runnerReportDir);
       }
@@ -34560,7 +34706,7 @@ var init_maestro_run = __esm({
 
 // packages/rn-dev-agent-core/dist/session/managed-automation.js
 import { spawn as spawn4 } from "node:child_process";
-import { readdirSync as readdirSync10, readFileSync as readFileSync20, unlinkSync as unlinkSync9 } from "node:fs";
+import { readdirSync as readdirSync11, readFileSync as readFileSync21, unlinkSync as unlinkSync9 } from "node:fs";
 function sleep4(ms) {
   return new Promise((resolve20) => setTimeout(resolve20, ms));
 }
@@ -34577,12 +34723,12 @@ function processGroupLiveness(pgid) {
   if (process.platform !== "linux")
     return "unknown";
   try {
-    for (const entry of readdirSync10("/proc", { withFileTypes: true })) {
+    for (const entry of readdirSync11("/proc", { withFileTypes: true })) {
       if (!entry.isDirectory() || !/^\d+$/.test(entry.name))
         continue;
       let stat2;
       try {
-        stat2 = readFileSync20(`/proc/${entry.name}/stat`, "utf8");
+        stat2 = readFileSync21(`/proc/${entry.name}/stat`, "utf8");
       } catch (error2) {
         if (error2.code === "ENOENT")
           continue;
@@ -35239,8 +35385,8 @@ var init_device_arbiter = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/maestro-invoke.js
-import { writeFileSync as writeFileSync10 } from "node:fs";
-import { join as join26 } from "node:path";
+import { writeFileSync as writeFileSync11 } from "node:fs";
+import { join as join27 } from "node:path";
 import { tmpdir as tmpdir8 } from "node:os";
 function yamlEscape(s) {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t");
@@ -35271,7 +35417,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     return { passed: false, output: "", flowFile: "", error: pinRefusal };
   }
   const rawAppId = opts.appId ?? resolveBundleId(opts.platform) ?? readExpoSlug() ?? "";
-  const flowFile = join26(tmpdir8(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+  const flowFile = join27(tmpdir8(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
   let content;
   let headerAppId;
   try {
@@ -35309,7 +35455,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     throw err;
   }
   try {
-    writeFileSync10(flowFile, content, "utf-8");
+    writeFileSync11(flowFile, content, "utf-8");
   } catch (err) {
     return {
       passed: false,
@@ -35681,9 +35827,9 @@ var init_app_lifecycle = __esm({
 
 // packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js
 import { execFileSync as execFileSync7 } from "node:child_process";
-import { existsSync as existsSync21, readFileSync as readFileSync21, unlinkSync as unlinkSync10 } from "node:fs";
+import { existsSync as existsSync22, readFileSync as readFileSync22, unlinkSync as unlinkSync10 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
-import { join as join27 } from "node:path";
+import { join as join28 } from "node:path";
 function selectInstalledLegacyApps(installed) {
   return LEGACY_BUNDLE_IDS.filter((id) => installed.has(id));
 }
@@ -35750,13 +35896,13 @@ function defaultDeps2() {
     },
     readDaemonPid: () => {
       try {
-        const parsed = JSON.parse(readFileSync21(DAEMON_JSON2, "utf8"));
+        const parsed = JSON.parse(readFileSync22(DAEMON_JSON2, "utf8"));
         return typeof parsed.pid === "number" ? parsed.pid : null;
       } catch {
         return null;
       }
     },
-    fileExists: (path) => existsSync21(path),
+    fileExists: (path) => existsSync22(path),
     removeFile: (path) => unlinkSync10(path),
     delay: (ms) => new Promise((resolve20) => setTimeout(resolve20, ms)),
     listApps: (udid) => execFileSync7("xcrun", ["simctl", "listapps", udid], {
@@ -35839,8 +35985,8 @@ var init_ensure_single_runner = __esm({
   "packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js"() {
     "use strict";
     init_discovery();
-    DAEMON_JSON2 = join27(homedir6(), ".agent-device", "daemon.json");
-    DAEMON_LOCK2 = join27(homedir6(), ".agent-device", "daemon.lock");
+    DAEMON_JSON2 = join28(homedir6(), ".agent-device", "daemon.json");
+    DAEMON_LOCK2 = join28(homedir6(), ".agent-device", "daemon.lock");
     DAEMON_FILES2 = [DAEMON_JSON2, DAEMON_LOCK2];
     SIGKILL_GRACE_MS2 = 500;
     LEGACY_BUNDLE_IDS = [
@@ -35967,9 +36113,9 @@ var init_recover_detached = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/lifecycle/device-lock.js
-import { existsSync as existsSync22, mkdirSync as mkdirSync14, openSync as openSync4, writeSync, closeSync as closeSync4, readFileSync as readFileSync22, unlinkSync as unlinkSync11, writeFileSync as writeFileSync11 } from "node:fs";
+import { existsSync as existsSync23, mkdirSync as mkdirSync15, openSync as openSync4, writeSync, closeSync as closeSync4, readFileSync as readFileSync23, unlinkSync as unlinkSync11, writeFileSync as writeFileSync12 } from "node:fs";
 import { tmpdir as tmpdir9, userInfo } from "node:os";
-import { join as join28 } from "node:path";
+import { join as join29 } from "node:path";
 function defaultProcessAlive3(pid) {
   try {
     process.kill(pid, 0);
@@ -36022,7 +36168,7 @@ var init_device_lock = __esm({
         this.clock = opts.clock ?? Date.now;
         this.processAlive = opts.processAlive ?? defaultProcessAlive3;
         this.staleMs = opts.staleMs ?? DEVICE_LOCK_STALE_MS;
-        this.lockPath = join28(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
+        this.lockPath = join29(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
       }
       acquire() {
         try {
@@ -36064,7 +36210,7 @@ var init_device_lock = __esm({
           return;
         holder.lastHeartbeat = this.clock();
         try {
-          writeFileSync11(this.lockPath, JSON.stringify(holder, null, 2), "utf8");
+          writeFileSync12(this.lockPath, JSON.stringify(holder, null, 2), "utf8");
         } catch {
         }
       }
@@ -36080,8 +36226,8 @@ var init_device_lock = __esm({
         this.acquired = false;
       }
       create() {
-        if (!existsSync22(this.tmpDir))
-          mkdirSync14(this.tmpDir, { recursive: true });
+        if (!existsSync23(this.tmpDir))
+          mkdirSync15(this.tmpDir, { recursive: true });
         const fd = openSync4(this.lockPath, "wx");
         try {
           const now = this.clock();
@@ -36103,7 +36249,7 @@ var init_device_lock = __esm({
       }
       readExisting() {
         try {
-          const parsed = JSON.parse(readFileSync22(this.lockPath, "utf8"));
+          const parsed = JSON.parse(readFileSync23(this.lockPath, "utf8"));
           if (!isValidBody(parsed))
             return null;
           if (parsed.deviceId !== this.deviceId || parsed.platform !== this.platform)
@@ -38701,8 +38847,8 @@ var init_utils = __esm({
 
 // packages/rn-dev-agent-core/dist/tools/device-screenshot-raw.js
 import { execFile as execFile13, spawn as spawn5 } from "node:child_process";
-import { createWriteStream as createWriteStream2, renameSync as renameSync5, statSync as statSync10, unlinkSync as unlinkSync12 } from "node:fs";
-import { basename as basename9, dirname as dirname16, join as join29 } from "node:path";
+import { createWriteStream as createWriteStream2, renameSync as renameSync6, statSync as statSync10, unlinkSync as unlinkSync12 } from "node:fs";
+import { basename as basename9, dirname as dirname17, join as join30 } from "node:path";
 import { promisify as promisify13 } from "node:util";
 function parseSimctlBootedAll(jsonText) {
   let data;
@@ -38855,7 +39001,7 @@ function resolveCaptureOutcome(streamFinished, procCode) {
   return procCode === 0 ? "success" : "failure";
 }
 function rawTempPath(finalPath, uniq) {
-  return join29(dirname16(finalPath), `.${basename9(finalPath)}.${uniq}.rawtmp`);
+  return join30(dirname17(finalPath), `.${basename9(finalPath)}.${uniq}.rawtmp`);
 }
 function nextCaptureSuffix() {
   captureCounter += 1;
@@ -38949,7 +39095,7 @@ var init_device_screenshot_raw = __esm({
           return;
         }
         try {
-          renameSync5(tmp, path);
+          renameSync6(tmp, path);
           settle(true);
         } catch {
           cleanupTemp();
@@ -39167,11 +39313,11 @@ var init_settle = __esm({
 
 // packages/rn-dev-agent-core/dist/agent-device-wrapper.js
 import { unlinkSync as unlinkSync13, rmSync as rmSync7 } from "node:fs";
-import { join as join30 } from "node:path";
-import { createHash as createHash8 } from "node:crypto";
+import { join as join31 } from "node:path";
+import { createHash as createHash9 } from "node:crypto";
 function getSessionFilePath() {
-  const projectId = createHash8("sha256").update(process.cwd()).digest("hex").slice(0, 12);
-  return join30(getStateDir(), `session-${projectId}.json`);
+  const projectId = createHash9("sha256").update(process.cwd()).digest("hex").slice(0, 12);
+  return join31(getStateDir(), `session-${projectId}.json`);
 }
 function getActiveSession() {
   return activeSession;
@@ -61564,8 +61710,8 @@ function annotateMutationAbsence(result, ctx) {
 
 // packages/rn-dev-agent-core/dist/verification/config.js
 init_storage();
-import { existsSync as existsSync23, readFileSync as readFileSync23 } from "node:fs";
-import { join as join31 } from "node:path";
+import { existsSync as existsSync24, readFileSync as readFileSync24 } from "node:fs";
+import { join as join32 } from "node:path";
 var MAX_PATTERN_LENGTH = 200;
 var _cachedProjectRoot;
 function getCachedProjectRoot() {
@@ -61621,14 +61767,14 @@ function loadVerificationConfig(projectRoot) {
   const cached2 = cache.get(projectRoot);
   if (cached2)
     return cached2;
-  const path = join31(projectRoot, ".rn-agent", "config.json");
-  if (!existsSync23(path)) {
+  const path = join32(projectRoot, ".rn-agent", "config.json");
+  if (!existsSync24(path)) {
     cache.set(projectRoot, DEFAULTS);
     return DEFAULTS;
   }
   let raw;
   try {
-    raw = JSON.parse(readFileSync23(path, "utf-8"));
+    raw = JSON.parse(readFileSync24(path, "utf-8"));
   } catch {
     cache.set(projectRoot, DEFAULTS);
     return DEFAULTS;
@@ -62013,28 +62159,28 @@ function inspectInstallIdentity(install, dependencies = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/session/migration-diagnostic.js
-import { createHash as createHash9 } from "node:crypto";
-import { existsSync as existsSync25, readFileSync as readFileSync26 } from "node:fs";
-import { join as join34 } from "node:path";
+import { createHash as createHash10 } from "node:crypto";
+import { existsSync as existsSync26, readFileSync as readFileSync27 } from "node:fs";
+import { join as join35 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/bound-directory.js
 import { spawn as spawn6 } from "node:child_process";
 import { randomUUID as randomUUID7 } from "node:crypto";
-import { closeSync as closeSync5, constants as constants5, existsSync as existsSync24, fstatSync as fstatSync4, lstatSync as lstatSync13, mkdtempSync as mkdtempSync2, openSync as openSync5, readFileSync as readFileSync25, realpathSync as realpathSync9, renameSync as renameSync7, rmSync as rmSync9, writeFileSync as writeFileSync13 } from "node:fs";
+import { closeSync as closeSync5, constants as constants5, existsSync as existsSync25, fstatSync as fstatSync4, lstatSync as lstatSync13, mkdtempSync as mkdtempSync2, openSync as openSync5, readFileSync as readFileSync26, realpathSync as realpathSync9, renameSync as renameSync8, rmSync as rmSync9, writeFileSync as writeFileSync14 } from "node:fs";
 import { tmpdir as tmpdir10 } from "node:os";
-import { join as join33 } from "node:path";
+import { join as join34 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/state-root.js
 init_secure_state_file();
 import { randomBytes as randomBytes5, randomUUID as randomUUID6 } from "node:crypto";
-import { chmodSync as chmodSync6, linkSync as linkSync2, lstatSync as lstatSync12, mkdirSync as mkdirSync15, readFileSync as readFileSync24, renameSync as renameSync6, rmSync as rmSync8, statSync as statSync11, writeFileSync as writeFileSync12 } from "node:fs";
-import { join as join32, resolve as resolve9 } from "node:path";
+import { chmodSync as chmodSync6, linkSync as linkSync2, lstatSync as lstatSync12, mkdirSync as mkdirSync16, readFileSync as readFileSync25, renameSync as renameSync7, rmSync as rmSync8, statSync as statSync11, writeFileSync as writeFileSync13 } from "node:fs";
+import { join as join33, resolve as resolve9 } from "node:path";
 function fail(code, detail) {
   throw new Error(`${code}: ${detail}`);
 }
 function ensurePrivateDirectory(path) {
   try {
-    mkdirSync15(path, { recursive: true, mode: 448 });
+    mkdirSync16(path, { recursive: true, mode: 448 });
     const link = lstatSync12(path);
     const stat2 = statSync11(path);
     if (link.isSymbolicLink() || !link.isDirectory() || typeof process.getuid === "function" && stat2.uid !== process.getuid()) {
@@ -62050,14 +62196,14 @@ function ensurePrivateDirectory(path) {
 }
 function authorityStateLayout(stateDir) {
   const resolvedStateDir = resolve9(stateDir);
-  const root = join32(resolvedStateDir, "v2");
+  const root = join33(resolvedStateDir, "v2");
   return {
     root,
-    registry: join32(root, "registry.sqlite3"),
-    sessions: join32(root, "sessions"),
-    runners: join32(root, "runner"),
-    observe: join32(root, "observe"),
-    migrations: join32(root, "migrations")
+    registry: join33(root, "registry.sqlite3"),
+    sessions: join33(root, "sessions"),
+    runners: join33(root, "runner"),
+    observe: join33(root, "observe"),
+    migrations: join33(root, "migrations")
   };
 }
 function createAuthorityStateLayout(stateDir = getStateDir()) {
@@ -62097,11 +62243,11 @@ function resolveAuthorityStateLayout(requestedStateHome) {
   return requestedStateHome ? openAuthorityStateLayout(requestedStateHome) : createAuthorityStateLayout();
 }
 function getBoundDirectoryJournalKey(layout = createAuthorityStateLayout()) {
-  const path = join32(layout.root, "bound-directory.key");
-  const temporary = join32(layout.root, `.bound-directory.${randomUUID6()}.key`);
+  const path = join33(layout.root, "bound-directory.key");
+  const temporary = join33(layout.root, `.bound-directory.${randomUUID6()}.key`);
   try {
     try {
-      writeFileSync12(temporary, randomBytes5(32), { flag: "wx", mode: 384, flush: true });
+      writeFileSync13(temporary, randomBytes5(32), { flag: "wx", mode: 384, flush: true });
       try {
         linkSync2(temporary, path);
       } catch (error2) {
@@ -62113,7 +62259,7 @@ function getBoundDirectoryJournalKey(layout = createAuthorityStateLayout()) {
     }
     const link = lstatSync12(path);
     const stat2 = statSync11(path);
-    const key = readFileSync24(path);
+    const key = readFileSync25(path);
     if (link.isSymbolicLink() || !link.isFile() || key.length !== 32 || typeof process.getuid === "function" && stat2.uid !== process.getuid()) {
       fail("AUTHORITY_STATE_ROOT_UNSAFE", "bound-directory journal key is invalid");
     }
@@ -63229,28 +63375,28 @@ function sameIdentity(left, right) {
 function waitForFile(path, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (existsSync24(path))
+    if (existsSync25(path))
       return true;
     Atomics.wait(WAIT_BUFFER, 0, 0, 5);
   }
-  return existsSync24(path);
+  return existsSync25(path);
 }
 function stopWorker(worker, signal = "SIGTERM") {
-  const stoppedPath = join33(worker.controlPath, "stopped");
+  const stoppedPath = join34(worker.controlPath, "stopped");
   if (signal === "SIGTERM") {
     try {
-      writeFileSync13(join33(worker.controlPath, "stop"), "", { flag: "wx", mode: 384 });
+      writeFileSync14(join34(worker.controlPath, "stop"), "", { flag: "wx", mode: 384 });
     } catch {
     }
     if (waitForFile(stoppedPath, 1e3)) {
-      if (!existsSync24(join33(worker.controlPath, "lock-retained"))) {
+      if (!existsSync25(join34(worker.controlPath, "lock-retained"))) {
         rmSync9(worker.controlPath, { force: true, recursive: true });
       }
       return;
     }
   }
   try {
-    writeFileSync13(join33(worker.controlPath, "terminate"), JSON.stringify({
+    writeFileSync14(join34(worker.controlPath, "terminate"), JSON.stringify({
       lifecycleCapability: worker.lifecycleCapability,
       signal: "SIGKILL"
     }), { flag: "wx", mode: 384 });
@@ -63259,7 +63405,7 @@ function stopWorker(worker, signal = "SIGTERM") {
   if (!waitForFile(stoppedPath, 1e4)) {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: bound-directory worker exit was not confirmed");
   }
-  if (!existsSync24(join33(worker.controlPath, "lock-retained"))) {
+  if (!existsSync25(join34(worker.controlPath, "lock-retained"))) {
     rmSync9(worker.controlPath, { force: true, recursive: true });
   }
 }
@@ -63281,13 +63427,13 @@ function bindWorker(controlPath, child, owner, childId, lifecycleCapability = ""
     }
     throw new Error(message);
   };
-  const readyPath = join33(controlPath, "ready");
+  const readyPath = join34(controlPath, "ready");
   if (!waitForFile(readyPath, WORKER_READY_TIMEOUT_MS)) {
     rejectWorker("SESSION_INTEGRATION_PATH_UNSAFE: bound-directory worker unavailable");
   }
   let ready = {};
   try {
-    ready = JSON.parse(readFileSync25(readyPath, "utf8"));
+    ready = JSON.parse(readFileSync26(readyPath, "utf8"));
   } catch {
     rejectWorker("SESSION_INTEGRATION_PATH_UNSAFE: bound-directory worker unavailable");
   }
@@ -63306,7 +63452,7 @@ function bindWorker(controlPath, child, owner, childId, lifecycleCapability = ""
   };
 }
 function startWorker(path, identity2, realPath) {
-  const controlPath = mkdtempSync2(join33(tmpdir10(), "rn-bound-directory-"));
+  const controlPath = mkdtempSync2(join34(tmpdir10(), "rn-bound-directory-"));
   const lifecycleCapability = randomUUID7();
   const binding = Buffer.from(JSON.stringify({
     dev: identity2.dev.toString(),
@@ -63336,7 +63482,7 @@ function startWorker(path, identity2, realPath) {
   return bindWorker(controlPath, child, void 0, void 0, lifecycleCapability);
 }
 function startSubdirectoryWorker(parent, name, expectedIdentity, expectedRealPath) {
-  const controlPath = mkdtempSync2(join33(tmpdir10(), "rn-bound-directory-"));
+  const controlPath = mkdtempSync2(join34(tmpdir10(), "rn-bound-directory-"));
   const childId = randomUUID7();
   const lifecycleCapability = randomUUID7();
   let worker;
@@ -63348,7 +63494,7 @@ function startSubdirectoryWorker(parent, name, expectedIdentity, expectedRealPat
       controlPath,
       lifecycleCapability,
       name,
-      publicPath: join33(parent.path, name),
+      publicPath: join34(parent.path, name),
       create: false,
       mode: 448
     });
@@ -63412,17 +63558,17 @@ function rebindDescendants(directory) {
 function sendOperation(directory, request2, timeoutMs) {
   const sequence = ++directory.worker.sequence;
   const prefix = String(sequence).padStart(8, "0");
-  const pendingPath = join33(directory.worker.controlPath, `${prefix}.pending`);
-  const requestPath2 = join33(directory.worker.controlPath, `${prefix}.request`);
-  const responsePath = join33(directory.worker.controlPath, `${prefix}.response`);
-  writeFileSync13(pendingPath, JSON.stringify(request2), { flag: "wx", mode: 384 });
-  renameSync7(pendingPath, requestPath2);
+  const pendingPath = join34(directory.worker.controlPath, `${prefix}.pending`);
+  const requestPath2 = join34(directory.worker.controlPath, `${prefix}.request`);
+  const responsePath = join34(directory.worker.controlPath, `${prefix}.response`);
+  writeFileSync14(pendingPath, JSON.stringify(request2), { flag: "wx", mode: 384 });
+  renameSync8(pendingPath, requestPath2);
   if (!waitForFile(responsePath, timeoutMs)) {
     throw new Error("SESSION_INTEGRATION_WORKER_TIMEOUT");
   }
   let result;
   try {
-    result = JSON.parse(readFileSync25(responsePath, "utf8"));
+    result = JSON.parse(readFileSync26(responsePath, "utf8"));
   } catch {
     throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: bound-directory operation returned invalid output");
   } finally {
@@ -63676,7 +63822,7 @@ function assertBoundDirectoryCurrent(directory) {
   runBoundOperation(directory, { operation: "identity" });
 }
 function openBoundSubdirectoryInternal(parent, name, options = {}) {
-  const controlPath = mkdtempSync2(join33(tmpdir10(), "rn-bound-directory-"));
+  const controlPath = mkdtempSync2(join34(tmpdir10(), "rn-bound-directory-"));
   const childId = randomUUID7();
   const lifecycleCapability = randomUUID7();
   let worker;
@@ -63688,7 +63834,7 @@ function openBoundSubdirectoryInternal(parent, name, options = {}) {
       controlPath,
       lifecycleCapability,
       name,
-      publicPath: join33(parent.path, name),
+      publicPath: join34(parent.path, name),
       create: options.create ?? false,
       mode: options.mode ?? 448,
       optional: options.optional ?? false,
@@ -63712,7 +63858,7 @@ function openBoundSubdirectoryInternal(parent, name, options = {}) {
       },
       name,
       parent,
-      path: join33(parent.path, name),
+      path: join34(parent.path, name),
       pendingCleanups: /* @__PURE__ */ new Map(),
       realPath: result.directoryIdentity.realPath,
       worker,
@@ -63846,15 +63992,15 @@ function retryBoundDirectoryCleanup(directory, obligation, dependencies = {}) {
 // packages/rn-dev-agent-core/dist/session/migration-diagnostic.js
 init_registry();
 function readPackageIntegrationManifest(appRoot, dependencies) {
-  const manifestPath = join34(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
+  const manifestPath = join35(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
   if (dependencies.exists || dependencies.readText) {
-    const exists = dependencies.exists ?? existsSync25;
+    const exists = dependencies.exists ?? existsSync26;
     if (!exists(manifestPath))
       return void 0;
-    const readText = dependencies.readText ?? ((path) => readFileSync26(path, "utf8"));
+    const readText = dependencies.readText ?? ((path) => readFileSync27(path, "utf8"));
     return readText(manifestPath);
   }
-  const agent = openBoundDirectory(join34(appRoot, ".rn-agent"));
+  const agent = openBoundDirectory(join35(appRoot, ".rn-agent"));
   let integration;
   let primaryError;
   try {
@@ -63872,7 +64018,7 @@ function readPackageIntegrationManifest(appRoot, dependencies) {
   }
 }
 function inspectAuthorityMigration(status, dependencies = {}) {
-  const exists = dependencies.exists ?? existsSync25;
+  const exists = dependencies.exists ?? existsSync26;
   const appRoot = typeof status.source.appRoot === "string" ? status.source.appRoot : "";
   let packageIntegrationInstalled = false;
   let onDiskManifestText;
@@ -63891,7 +64037,7 @@ function inspectAuthorityMigration(status, dependencies = {}) {
   const integrationBinding = status.bindings.packageIntegration;
   let bindingDiagnostic = null;
   if (integrationBinding) {
-    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash9("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
+    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash10("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
     const manifestAvailable = manifestVerified(onDiskManifestText) || manifestVerified(integrationBinding.restoration?.phase === "started" ? integrationBinding.restoration.manifestSource : void 0) || manifestVerified(integrationBinding.installation?.phase === "started" ? integrationBinding.installation.manifestSource : void 0) || manifestVerified(integrationBinding.manifestSource);
     const effectiveOwnerSessionId = status.sessionId;
     const trustedDigestRecorded = typeof integrationBinding.manifestSha256 === "string" && /^[0-9a-f]{64}$/.test(integrationBinding.manifestSha256);
@@ -64407,8 +64553,8 @@ function createBuildLaunchPlan(input) {
 
 // packages/rn-dev-agent-core/dist/session/managed-metro.js
 import { execFileSync as execFileSync10, spawn as spawn7 } from "node:child_process";
-import { createHash as createHash11, createHmac as createHmac2, timingSafeEqual as timingSafeEqual5 } from "node:crypto";
-import { closeSync as closeSync7, existsSync as existsSync27, fstatSync as fstatSync5, mkdirSync as mkdirSync17, openSync as openSync7, readFileSync as readFileSync28, readSync as readSync2, realpathSync as realpathSync11, rmSync as rmSync11 } from "node:fs";
+import { createHash as createHash12, createHmac as createHmac2, timingSafeEqual as timingSafeEqual5 } from "node:crypto";
+import { closeSync as closeSync7, existsSync as existsSync28, fstatSync as fstatSync5, mkdirSync as mkdirSync18, openSync as openSync7, readFileSync as readFileSync29, readSync as readSync2, realpathSync as realpathSync11, rmSync as rmSync11 } from "node:fs";
 init_metro_binding();
 init_trusted_system_executable();
 init_process_birth();
@@ -64505,13 +64651,13 @@ function canonicalAuthorityJson(value) {
 
 // packages/rn-dev-agent-core/dist/session/managed-metro-enforcement.js
 import { spawnSync as spawnSync2 } from "node:child_process";
-import { createHash as createHash10 } from "node:crypto";
-import { closeSync as closeSync6, constants as constants6, existsSync as existsSync26, mkdirSync as mkdirSync16, openSync as openSync6, readFileSync as readFileSync27, realpathSync as realpathSync10, rmSync as rmSync10, statSync as statSync12, symlinkSync as symlinkSync3, writeSync as writeSync2 } from "node:fs";
-import { dirname as dirname17, resolve as resolve10 } from "node:path";
+import { createHash as createHash11 } from "node:crypto";
+import { closeSync as closeSync6, constants as constants6, existsSync as existsSync27, mkdirSync as mkdirSync17, openSync as openSync6, readFileSync as readFileSync28, realpathSync as realpathSync10, rmSync as rmSync10, statSync as statSync12, symlinkSync as symlinkSync3, writeSync as writeSync2 } from "node:fs";
+import { dirname as dirname18, resolve as resolve10 } from "node:path";
 var DARWIN_SANDBOX_EXECUTABLE = "/usr/bin/sandbox-exec";
 var DARWIN_CODESIGN_EXECUTABLE = "/usr/bin/codesign";
 function sha256(value) {
-  return createHash10("sha256").update(value).digest("hex");
+  return createHash11("sha256").update(value).digest("hex");
 }
 function defaultRun2(command, args) {
   const result = spawnSync2(command, [...args], {
@@ -64530,10 +64676,10 @@ function field(details, name) {
   return details.split("\n").find((line) => line.startsWith(prefix))?.slice(prefix.length).trim() ?? null;
 }
 function verifiedSandboxExecutable(dependencies) {
-  const exists = dependencies.exists ?? existsSync26;
+  const exists = dependencies.exists ?? existsSync27;
   const canonicalize = dependencies.canonicalize ?? realpathSync10;
   const stat2 = dependencies.stat ?? statSync12;
-  const readBytes = dependencies.readBytes ?? readFileSync27;
+  const readBytes = dependencies.readBytes ?? readFileSync28;
   const run = dependencies.run ?? defaultRun2;
   try {
     if (!exists(DARWIN_SANDBOX_EXECUTABLE))
@@ -64607,7 +64753,7 @@ function defaultRuntimeCache(exists) {
 function attestRuntimeFile(path, dependencies) {
   const canonicalize = dependencies.canonicalize ?? realpathSync10;
   const stat2 = dependencies.stat ?? statSync12;
-  const readBytes = dependencies.readBytes ?? readFileSync27;
+  const readBytes = dependencies.readBytes ?? readFileSync28;
   const run = dependencies.run ?? defaultRun2;
   const canonical2 = canonicalize(path);
   if (!stat2(canonical2).isFile())
@@ -64620,7 +64766,7 @@ function attestRuntimeFile(path, dependencies) {
 }
 function attestNodeRuntime(input, executableMappings, dependencies) {
   const run = dependencies.run ?? defaultRun2;
-  const exists = dependencies.exists ?? existsSync26;
+  const exists = dependencies.exists ?? existsSync27;
   const runtimeVersion = dependencies.runtimeVersion?.(input.nodeExecutable) ?? defaultRuntimeVersion(input.nodeExecutable, run);
   if (runtimeVersion !== input.nodeVersion)
     return null;
@@ -66080,7 +66226,7 @@ function inspectManagedMetroLifecycle(binding, input, dependencies = {}) {
       reason: "allocated managed Metro port is owned by a different process"
     };
   }
-  if (!(dependencies.exists ?? existsSync27)(binding.runtimeEvidenceSocket)) {
+  if (!(dependencies.exists ?? existsSync28)(binding.runtimeEvidenceSocket)) {
     return {
       status: "lost",
       code: "METRO_EVIDENCE_SOCKET_MISSING",
@@ -66178,7 +66324,7 @@ function inspectManagedMetroCleanupEvidence(binding, dependencies = {}) {
     } catch {
     }
   }
-  const evidenceSocket = managed ? cleanupSocketPresence(binding.runtimeEvidenceSocket, dependencies.exists ?? existsSync27) : "not-applicable";
+  const evidenceSocket = managed ? cleanupSocketPresence(binding.runtimeEvidenceSocket, dependencies.exists ?? existsSync28) : "not-applicable";
   const complete = launcher !== "present" && launcher !== "unknown" && listener === "absent" && port.status === "absent" && evidenceSocket !== "present" && evidenceSocket !== "unknown";
   return { complete, launcher, listener, port, evidenceSocket };
 }
@@ -66315,8 +66461,8 @@ async function stopManagedMetroWithEvidence(binding, input, dependencies = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/session/package-integration.js
-import { closeSync as closeSync8, constants as constants7, fstatSync as fstatSync6, lstatSync as lstatSync14, openSync as openSync8, readFileSync as readFileSync29 } from "node:fs";
-import { basename as basename10, isAbsolute as isAbsolute7, join as join35, relative as relative6, resolve as resolve11, sep as sep8 } from "node:path";
+import { closeSync as closeSync8, constants as constants7, fstatSync as fstatSync6, lstatSync as lstatSync14, openSync as openSync8, readFileSync as readFileSync30 } from "node:fs";
+import { basename as basename10, isAbsolute as isAbsolute7, join as join36, relative as relative6, resolve as resolve11, sep as sep8 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/metro-authority.js
 import { createHmac as createHmac3, createSecretKey, timingSafeEqual as timingSafeEqual6 } from "node:crypto";
@@ -70074,7 +70220,7 @@ function managedMetroProxyUrl(binding) {
 function snapshotBoundFiles(directory, directoryPath, names) {
   return readBoundDirectoryFiles(directory, names).map((snapshot) => ({
     ...snapshot,
-    path: join35(directoryPath, snapshot.name)
+    path: join36(directoryPath, snapshot.name)
   }));
 }
 function casReplaceBoundBatch(directory, writes, dependencies = {}) {
@@ -70099,7 +70245,7 @@ function assertNoSymlinkPath(root, candidate) {
   }
   let current = root;
   for (const component of [root, ...child.split(sep8).filter(Boolean)]) {
-    current = component === root ? root : join35(current, component);
+    current = component === root ? root : join36(current, component);
     try {
       if (lstatSync14(current).isSymbolicLink()) {
         throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: integration path is symlinked");
@@ -70128,7 +70274,7 @@ function readRegularFile(root, candidate) {
     if (!opened.isFile() || before.dev !== opened.dev || before.ino !== opened.ino || after.dev !== opened.dev || after.ino !== opened.ino) {
       throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: integration input changed while opening");
     }
-    return readFileSync29(descriptor, "utf8");
+    return readFileSync30(descriptor, "utf8");
   } finally {
     closeSync8(descriptor);
   }
@@ -70174,7 +70320,7 @@ function readPackageIntegrationInputs(appRootInput, dependencies = {}) {
       packageJson: packageSnapshot.contents.toString("utf8"),
       metroConfig: {
         contents: metroSnapshot.contents.toString("utf8"),
-        path: join35(appRoot, metroSnapshot.name)
+        path: join36(appRoot, metroSnapshot.name)
       },
       ...manifest ? { manifest: manifest.toString("utf8") } : {}
     };
@@ -70309,9 +70455,9 @@ function rollbackWrites(writes, dependencies) {
 }
 function applyPackageIntegration(input, dependencies = {}) {
   const appRoot = resolve11(input.appRoot);
-  const packagePath = join35(appRoot, "package.json");
+  const packagePath = join36(appRoot, "package.json");
   let metroConfigPath;
-  for (const path of ["metro.config.js", "metro.config.cjs"].map((name) => join35(appRoot, name))) {
+  for (const path of ["metro.config.js", "metro.config.cjs"].map((name) => join36(appRoot, name))) {
     if (readOptionalRegularFileNoFollow(appRoot, path) !== void 0) {
       metroConfigPath = path;
       break;
@@ -70444,7 +70590,7 @@ function applyPackageIntegration(input, dependencies = {}) {
 }
 function restorePackageIntegrationFiles(input, dependencies = {}) {
   const appRoot = resolve11(input.appRoot);
-  const packagePath = join35(appRoot, "package.json");
+  const packagePath = join36(appRoot, "package.json");
   const directories = openIntegrationDirectories(appRoot);
   const generatedNames = [
     "rn-session-integration.json",
@@ -70472,7 +70618,7 @@ function restorePackageIntegrationFiles(input, dependencies = {}) {
     if (metroConfig !== "metro.config.js" && metroConfig !== "metro.config.cjs") {
       throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: manifest Metro config is not an expected app-root config");
     }
-    const metroConfigPath = join35(appRoot, metroConfig);
+    const metroConfigPath = join36(appRoot, metroConfig);
     const [packageSnapshot, metroSnapshot] = snapshotBoundFiles(directories.app, appRoot, [
       basename10(packagePath),
       basename10(metroConfigPath)
@@ -70546,19 +70692,19 @@ function restorePackageIntegrationFiles(input, dependencies = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/session.js
-import { dirname as dirname19, isAbsolute as isAbsolute9, join as join39, resolve as resolve14 } from "node:path";
+import { dirname as dirname20, isAbsolute as isAbsolute9, join as join40, resolve as resolve14 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { createHash as createHash14 } from "node:crypto";
+import { createHash as createHash15 } from "node:crypto";
 
 // packages/rn-dev-agent-core/dist/session/source-identity.js
 init_metro_cwd();
-import { createHash as createHash12, createHmac as createHmac4, randomBytes as randomBytes6, timingSafeEqual as timingSafeEqual7 } from "node:crypto";
+import { createHash as createHash13, createHmac as createHmac4, randomBytes as randomBytes6, timingSafeEqual as timingSafeEqual7 } from "node:crypto";
 import { execFileSync as execFileSync11 } from "node:child_process";
-import { closeSync as closeSync9, constants as constants8, existsSync as existsSync28, fstatSync as fstatSync7, lstatSync as lstatSync15, openSync as openSync9, readdirSync as readdirSync11, readFileSync as readFileSync30, readlinkSync as readlinkSync5, readSync as readSync3, realpathSync as realpathSync12 } from "node:fs";
-import { dirname as dirname18, isAbsolute as isAbsolute8, join as join36, relative as relative7, resolve as resolve12 } from "node:path";
+import { closeSync as closeSync9, constants as constants8, existsSync as existsSync29, fstatSync as fstatSync7, lstatSync as lstatSync15, openSync as openSync9, readdirSync as readdirSync12, readFileSync as readFileSync31, readlinkSync as readlinkSync5, readSync as readSync3, realpathSync as realpathSync12 } from "node:fs";
+import { dirname as dirname19, isAbsolute as isAbsolute8, join as join37, relative as relative7, resolve as resolve12 } from "node:path";
 init_declared_source_contract();
 function digest2(parts) {
-  const hash = createHash12("sha256");
+  const hash = createHash13("sha256");
   for (const part of parts) {
     hash.update(part);
     hash.update("\0");
@@ -70665,7 +70811,7 @@ function updateFramedFile(hash, path, maximumBytes) {
   return updateStableFile(hash, path, maximumBytes, true);
 }
 function fileDigest(path) {
-  const hash = createHash12("sha256");
+  const hash = createHash13("sha256");
   updateStableFile(hash, path, MAX_STRICT_PROOF_DEPENDENCY_FILE_BYTES, false);
   return hash.digest("hex");
 }
@@ -70709,9 +70855,9 @@ function updateDependencyPath(hash, path, label, state) {
       }
       state.visitedDirectories.add(canonical2);
       updateFramed(hash, "directory");
-      for (const entry of readdirSync11(current.path).sort().reverse()) {
+      for (const entry of readdirSync12(current.path).sort().reverse()) {
         pending2.push({
-          path: join36(current.path, entry),
+          path: join37(current.path, entry),
           label: `${current.label}/${entry}`,
           depth: current.depth + 1
         });
@@ -70741,10 +70887,10 @@ function isExcludedRuntimePath(root, candidate) {
   return EXCLUDED_RUNTIME_DIRECTORIES.some((excluded) => entry === excluded || entry.startsWith(`${excluded}/`) || entry.endsWith(`/${excluded}`) || entry.includes(`/${excluded}/`));
 }
 function assertFinalMetroIntegration(identity2) {
-  const candidates = ["metro.config.js", "metro.config.cjs"].map((entry) => join36(identity2.appRoot, entry)).filter(existsSync28);
+  const candidates = ["metro.config.js", "metro.config.cjs"].map((entry) => join37(identity2.appRoot, entry)).filter(existsSync29);
   if (candidates.length === 0)
     return;
-  const source = readFileSync30(candidates[0], "utf8");
+  const source = readFileSync31(candidates[0], "utf8");
   const start = source.indexOf(METRO_INTEGRATION_START);
   const end = source.indexOf(METRO_INTEGRATION_END);
   if (start < 0 || end < start || source.indexOf(METRO_INTEGRATION_START, start + METRO_INTEGRATION_START.length) >= 0 || source.indexOf(METRO_INTEGRATION_END, end + METRO_INTEGRATION_END.length) >= 0 || source.slice(start, end + METRO_INTEGRATION_END.length) !== METRO_INTEGRATION_BLOCK || source.slice(end + METRO_INTEGRATION_END.length).trim()) {
@@ -70754,7 +70900,7 @@ function assertFinalMetroIntegration(identity2) {
 function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntimeEnforcement) {
   if (!authority)
     return { paths: [], semantics: [] };
-  const raw = readFileSync30(join36(identity2.appRoot, METRO_RUNTIME_POLICY2), "utf8");
+  const raw = readFileSync31(join37(identity2.appRoot, METRO_RUNTIME_POLICY2), "utf8");
   const receipt2 = JSON.parse(raw);
   const payload = {
     version: receipt2.version,
@@ -70787,7 +70933,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
     platform: process.platform,
     appRoot: identity2.appRoot,
     sourceRoot: identity2.contentRoot,
-    runtimeRoot: dirname18(authority.evidencePath),
+    runtimeRoot: dirname19(authority.evidencePath),
     nodeExecutable: runtimeManifest.nodeExecutable,
     nodeVersion: runtimeManifest.nodeVersion,
     commandExecutable: runtimeManifest.executable,
@@ -70816,7 +70962,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
     if (!runtimeLoadsStat.isFile() || runtimeLoadsStat.size > MAX_STRICT_PROOF_FILE_BYTES) {
       throw new Error("runtime load evidence is not a bounded regular file");
     }
-    runtimeLoadsRaw = readFileSync30(runtimeLoadsPath, "utf8");
+    runtimeLoadsRaw = readFileSync31(runtimeLoadsPath, "utf8");
   } catch (error2) {
     throw new Error("STRICT_PROOF_UNVERIFIED_METRO_POLICY: runtime load evidence is invalid", {
       cause: error2
@@ -70895,7 +71041,7 @@ function metroRuntimeInputs(identity2, authority, readEvidenceHead, verifyRuntim
         throw new Error("STRICT_PROOF_UNVERIFIED_METRO_POLICY: runtime semantics are unbounded");
       }
       runtimeSemantics.add(load.value);
-      runtimeSemanticsByDigest.set(createHash12("sha256").update(load.value).digest("hex"), load.value);
+      runtimeSemanticsByDigest.set(createHash13("sha256").update(load.value).digest("hex"), load.value);
       orderedRuntimeSemantics.push(load.value);
       continue;
     }
@@ -71045,8 +71191,8 @@ function dependencyStoreRoots(identity2, git2, pathExists) {
     ...DEPENDENCY_STORE_PATHS
   ]).split("\0").filter(Boolean);
   for (const candidate of [
-    join36(identity2.contentRoot, "node_modules"),
-    join36(identity2.appRoot, "node_modules")
+    join37(identity2.contentRoot, "node_modules"),
+    join37(identity2.appRoot, "node_modules")
   ]) {
     if (pathExists(candidate))
       entries.push(relative7(identity2.contentRoot, candidate));
@@ -71057,21 +71203,21 @@ function dependencyStoreRoots(identity2, git2, pathExists) {
     pnpRoots.push(pnpRoot);
     if (pnpRoot === identity2.contentRoot)
       break;
-    const parent = dirname18(pnpRoot);
+    const parent = dirname19(pnpRoot);
     if (parent === pnpRoot || !isContained(identity2.contentRoot, parent))
       break;
     pnpRoot = parent;
   }
-  const pnpLoaders = [...new Set(pnpRoots)].flatMap((root) => [".pnp.js", ".pnp.cjs", ".pnp.loader.mjs"].map((entry) => join36(root, entry)).filter(pathExists));
+  const pnpLoaders = [...new Set(pnpRoots)].flatMap((root) => [".pnp.js", ".pnp.cjs", ".pnp.loader.mjs"].map((entry) => join37(root, entry)).filter(pathExists));
   if (pnpLoaders.length > 0) {
     throw new Error("STRICT_PROOF_UNVERIFIED_DEPENDENCY_LAYOUT: Plug\u2019n\u2019Play dependency resolution is unsupported");
   }
-  let ancestor = dirname18(identity2.contentRoot);
+  let ancestor = dirname19(identity2.contentRoot);
   while (true) {
-    if (pathExists(join36(ancestor, "node_modules"))) {
+    if (pathExists(join37(ancestor, "node_modules"))) {
       throw new Error("STRICT_PROOF_UNVERIFIED_DEPENDENCY_LAYOUT: ancestor node_modules resolves outside the content root");
     }
-    const parent = dirname18(ancestor);
+    const parent = dirname19(ancestor);
     if (parent === ancestor)
       break;
     ancestor = parent;
@@ -71123,7 +71269,7 @@ function resolveDeclaredIdentity(appRoot, dependencies, canonicalize) {
   if (!dependencies.declaredManifests?.length) {
     throw new Error(missingDeclaredManifestListMessage());
   }
-  const pathExists = dependencies.exists ?? existsSync28;
+  const pathExists = dependencies.exists ?? existsSync29;
   const contentRoot = canonicalize(resolve12(dependencies.declaredRoot));
   assertContained(contentRoot, appRoot, "NON_GIT_ROOT_MISMATCH");
   const manifestParts = [];
@@ -71133,7 +71279,7 @@ function resolveDeclaredIdentity(appRoot, dependencies, canonicalize) {
       throw new Error(missingDeclaredManifestMessage(entry));
     const manifest = canonicalize(declared);
     assertContained(contentRoot, manifest, "NON_GIT_MANIFEST_OUTSIDE_ROOT");
-    manifestParts.push(relative7(contentRoot, manifest), readFileSync30(manifest));
+    manifestParts.push(relative7(contentRoot, manifest), readFileSync31(manifest));
   }
   const manifestDigest = digest2(manifestParts);
   const appRelative = relative7(contentRoot, appRoot) || ".";
@@ -71156,7 +71302,7 @@ function resolveSourceIdentity(inputRoot, dependencies = {}) {
     const contentRoot = canonicalize(git2(appRoot, ["rev-parse", "--show-toplevel"]));
     assertContained(contentRoot, appRoot, "APP_ROOT_OUTSIDE_WORKTREE");
     const commonRaw = git2(appRoot, ["rev-parse", "--git-common-dir"]);
-    const commonDirectory = canonicalize(isAbsolute8(commonRaw) ? commonRaw : join36(appRoot, commonRaw));
+    const commonDirectory = canonicalize(isAbsolute8(commonRaw) ? commonRaw : join37(appRoot, commonRaw));
     const head = git2(appRoot, ["rev-parse", "HEAD"]);
     const appRelative = relative7(contentRoot, appRoot) || ".";
     return {
@@ -71182,7 +71328,7 @@ function strictProofSourceIdentity(identity2, dependencies = {}) {
     throw new Error("STRICT_PROOF_GIT_REQUIRED: accepted strict proof requires a Git worktree");
   }
   const git2 = dependencies.git ?? defaultGit;
-  const pathExists = dependencies.exists ?? existsSync28;
+  const pathExists = dependencies.exists ?? existsSync29;
   assertFinalMetroIntegration(identity2);
   const evidenceHeadReader = dependencies.readMetroEvidenceHead ?? readMetroEvidenceHead;
   const runtimeEnforcementVerifier = dependencies.verifyMetroRuntimeEnforcement ?? verifyManagedMetroEnforcementReceipt;
@@ -71216,7 +71362,7 @@ function strictProofSourceIdentity(identity2, dependencies = {}) {
       throw new Error(`STRICT_PROOF_DIRTY_SUBMODULE: ${entry} contains source changes outside the parent digest`);
     }
   }
-  const dirtyHash = createHash12("sha256");
+  const dirtyHash = createHash13("sha256");
   updateFramed(dirtyHash, "git-dirty-v3");
   updateFramed(dirtyHash, diff);
   for (const semantics of runtimeInputs.semantics) {
@@ -71288,10 +71434,10 @@ function strictProofSourceIdentity(identity2, dependencies = {}) {
 
 // packages/rn-dev-agent-core/dist/session/successor-source.js
 init_secure_state_file();
-import { join as join37, resolve as resolve13 } from "node:path";
+import { join as join38, resolve as resolve13 } from "node:path";
 var DECLARATION_FILE = "successor-source.json";
 function successorSourceDeclarationPath(runtimeRoot) {
-  return join37(runtimeRoot, DECLARATION_FILE);
+  return join38(runtimeRoot, DECLARATION_FILE);
 }
 function writeSuccessorSourceDeclaration(runtimeRoot, declaration) {
   writeJsonStateFileAtomic(successorSourceDeclarationPath(runtimeRoot), declaration);
@@ -71331,8 +71477,8 @@ function inspectSessionOwner(owner, dependencies = {}) {
 
 // packages/rn-dev-agent-core/dist/session/startup-cleanup.js
 init_secure_state_file();
-import { createHash as createHash13 } from "node:crypto";
-import { join as join38 } from "node:path";
+import { createHash as createHash14 } from "node:crypto";
+import { join as join39 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/session/android-metro-reverse.js
 import { execFileSync as execFileSync12 } from "node:child_process";
@@ -71856,7 +72002,7 @@ async function runStartupCleanupForSource(input) {
       appRootKey: input.source.appRootKey,
       appRoot: input.source.appRoot
     }, {
-      readSessionSecret: (sessionId) => readJsonStateFile(join38(layout.sessions, sessionId, "secret.json"))
+      readSessionSecret: (sessionId) => readJsonStateFile(join39(layout.sessions, sessionId, "secret.json"))
     });
   } finally {
     registry2.close();
@@ -71915,7 +72061,7 @@ function restoreDeadOwnerIntegration(input, prior, plan, dependencies) {
 function verifiedDeadOwnerManifestSource(appRoot, binding, manifestSha256) {
   if (!/^[0-9a-f]{64}$/.test(manifestSha256))
     return void 0;
-  const verified = (candidate) => typeof candidate === "string" && createHash13("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
+  const verified = (candidate) => typeof candidate === "string" && createHash14("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
   let liveManifest;
   try {
     liveManifest = readPackageIntegrationInputs(appRoot).manifest ?? void 0;
@@ -72021,7 +72167,7 @@ function sameMetroAuthority(current, next) {
 function verifiedManifestSource(candidate, manifestSha256) {
   if (typeof candidate !== "string" || typeof manifestSha256 !== "string")
     return void 0;
-  return createHash14("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
+  return createHash15("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
 }
 function durableBindingManifestSource(binding) {
   return verifiedManifestSource(binding?.manifestSource, binding?.manifestSha256);
@@ -72935,9 +73081,9 @@ function createSessionHandler(runtime, dependencies = {}) {
         if (input.action !== "restore_integration") {
           assertDeclaredProjectRootMatches(status, input.projectRoot, sessionSourceResolver(status, dependencies));
         }
-        const packagePath = join39(appRoot, "package.json");
+        const packagePath = join40(appRoot, "package.json");
         const integrationInputs = readPackageIntegrationInputs(appRoot);
-        const manifestPath = join39(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
+        const manifestPath = join40(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
         const packageJson = JSON.parse(integrationInputs.packageJson);
         const integrationBinding = status.bindings.packageIntegration;
         const installationManifestSource = integrationBinding?.installation?.phase === "started" && typeof integrationBinding.installation.manifestSource === "string" ? integrationBinding.installation.manifestSource : void 0;
@@ -72950,7 +73096,7 @@ function createSessionHandler(runtime, dependencies = {}) {
           if (!(error2 instanceof SyntaxError))
             throw error2;
         }
-        const sessionCli = process.env.RN_DEV_AGENT_SESSION_CLI ?? join39(dirname19(fileURLToPath2(import.meta.url)), "..", "rn-session.js");
+        const sessionCli = process.env.RN_DEV_AGENT_SESSION_CLI ?? join40(dirname20(fileURLToPath2(import.meta.url)), "..", "rn-session.js");
         const stateDir = process.env.RN_DEV_AGENT_STATE_DIR;
         if (input.action === "restore_integration") {
           if (input.confirmed !== true) {
@@ -72967,7 +73113,7 @@ function createSessionHandler(runtime, dependencies = {}) {
             });
           }
           assertPackageIntegrationInactive(status.bindings, input.action);
-          const manifestSha256 = createHash14("sha256").update(manifestSource ?? "").digest("hex");
+          const manifestSha256 = createHash15("sha256").update(manifestSource ?? "").digest("hex");
           if (integrationBinding?.version !== 1 || typeof integrationBinding.installedBySessionId !== "string" || integrationBinding.manifestSha256 !== manifestSha256) {
             throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "integration restoration requires the transferred manifest authority binding");
           }
@@ -73014,7 +73160,7 @@ function createSessionHandler(runtime, dependencies = {}) {
         }
         preview.manifest.metroConfig = metroConfigPath.slice(appRoot.length + 1);
         const expectedManifestSource = installationManifestSource ?? serializePackageIntegrationManifest(preview.manifest);
-        const expectedManifestSha256 = createHash14("sha256").update(expectedManifestSource).digest("hex");
+        const expectedManifestSha256 = createHash15("sha256").update(expectedManifestSource).digest("hex");
         if (installationManifestSource && (integrationBinding?.version !== 1 || integrationBinding.installedBySessionId !== session2.sessionId || integrationBinding.manifestSha256 !== expectedManifestSha256)) {
           throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "integration installation requires the original session manifest authority binding");
         }
@@ -73036,7 +73182,7 @@ function createSessionHandler(runtime, dependencies = {}) {
           if (!installedManifest) {
             throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: applied manifest is unavailable");
           }
-          if (createHash14("sha256").update(installedManifest).digest("hex") !== expectedManifestSha256) {
+          if (createHash15("sha256").update(installedManifest).digest("hex") !== expectedManifestSha256) {
             throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "applied integration manifest no longer matches its durable installation authority");
           }
           registry2.updateBindings(session2, {
@@ -74526,10 +74672,10 @@ init_keyboard_guard();
 // packages/rn-dev-agent-core/dist/tools/device-list.js
 init_agent_device_wrapper();
 init_utils();
-import { mkdirSync as mkdirSync18 } from "node:fs";
+import { mkdirSync as mkdirSync19 } from "node:fs";
 import { execFile as execFile17 } from "node:child_process";
 import { promisify as promisify18 } from "node:util";
-import { dirname as dirname20, join as join40, resolve as resolve15 } from "node:path";
+import { dirname as dirname21, join as join41, resolve as resolve15 } from "node:path";
 import { homedir as homedir8 } from "node:os";
 
 // packages/rn-dev-agent-core/dist/tools/device-screenshot-resize.js
@@ -75137,7 +75283,7 @@ function deriveScreenshotPath(args, now = Date.now, rand = Math.random) {
   }
   if (args.path?.startsWith("~")) {
     if (args.path.startsWith("~/"))
-      return join40(homedir8(), args.path.slice(2));
+      return join41(homedir8(), args.path.slice(2));
     throw new TildeScreenshotPathError(`Screenshot path "${args.path}" starts with '~' which the bridge cannot expand (only a leading '~/' is expanded to the home directory). Pass an absolute path instead.`);
   }
   if (args.path)
@@ -75148,7 +75294,7 @@ function deriveScreenshotPath(args, now = Date.now, rand = Math.random) {
 }
 function ensureScreenshotDir(path) {
   try {
-    mkdirSync18(dirname20(path), { recursive: true });
+    mkdirSync19(dirname21(path), { recursive: true });
     return { ok: true };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
@@ -76535,7 +76681,7 @@ init_utils();
 init_storage();
 init_runtime_paths2();
 import { mkdir, readdir, readFile as readFile2, writeFile } from "node:fs/promises";
-import { join as join41 } from "node:path";
+import { join as join42 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/cdp/test-recorder-helpers.js
 var DEV_CHECK_JS = `(typeof __DEV__ !== 'undefined' && __DEV__ === true)`;
@@ -77484,7 +77630,7 @@ function createRecordTestSaveHandler(getClient2) {
     if (!safe) {
       return failResult("Filename is empty after sanitization", "BAD_FILENAME");
     }
-    const filePath = join41(dir, `${safe}.json`);
+    const filePath = join42(dir, `${safe}.json`);
     const payload = { savedAt: (/* @__PURE__ */ new Date()).toISOString(), events: storedEvents };
     await writeFile(filePath, JSON.stringify(payload, null, 2), "utf8");
     return okResult({
@@ -77505,7 +77651,7 @@ function createRecordTestLoadHandler(getClient2) {
     if (!safe) {
       return failResult("Filename is empty after sanitization", "BAD_FILENAME");
     }
-    const filePath = join41(dir, `${safe}.json`);
+    const filePath = join42(dir, `${safe}.json`);
     let raw;
     try {
       raw = await readFile2(filePath, "utf8");
@@ -81440,11 +81586,11 @@ init_utils();
 init_path_safety();
 init_process_birth();
 import { execFile as execFile22 } from "node:child_process";
-import { createHash as createHash15 } from "node:crypto";
-import { existsSync as existsSync29 } from "node:fs";
+import { createHash as createHash16 } from "node:crypto";
+import { existsSync as existsSync30 } from "node:fs";
 import { promisify as promisify23 } from "node:util";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
-import { dirname as dirname21, join as join42 } from "node:path";
+import { dirname as dirname22, join as join43 } from "node:path";
 var execFileAsync5 = promisify23(execFile22);
 var START_TIMEOUT_MS = 1e4;
 var STATUS_TIMEOUT_MS = 5e3;
@@ -81527,28 +81673,28 @@ function compactUnique2(paths) {
   }
   return out;
 }
-function candidateRecordScripts(baseDir = dirname21(fileURLToPath3(import.meta.url))) {
+function candidateRecordScripts(baseDir = dirname22(fileURLToPath3(import.meta.url))) {
   const codexPluginRoot = process.env.RN_DEV_AGENT_CODEX_PLUGIN_ROOT;
   const claudePluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
   return compactUnique2([
     process.env.RN_DEV_AGENT_RECORD_PROOF_SCRIPT,
-    codexPluginRoot ? join42(codexPluginRoot, "scripts", "record_proof.sh") : void 0,
-    claudePluginRoot ? join42(claudePluginRoot, "scripts", "record_proof.sh") : void 0,
-    claudePluginRoot ? join42(claudePluginRoot, "..", "..", "scripts", "record_proof.sh") : void 0,
+    codexPluginRoot ? join43(codexPluginRoot, "scripts", "record_proof.sh") : void 0,
+    claudePluginRoot ? join43(claudePluginRoot, "scripts", "record_proof.sh") : void 0,
+    claudePluginRoot ? join43(claudePluginRoot, "..", "..", "scripts", "record_proof.sh") : void 0,
     // Bundled Codex runtime: <plugin>/rn-dev-agent-core/dist.
-    join42(baseDir, "..", "..", "scripts", "record_proof.sh"),
+    join43(baseDir, "..", "..", "scripts", "record_proof.sh"),
     // Source core bundle: packages/rn-dev-agent-core/dist/supervisor.js.
-    join42(baseDir, "..", "..", "..", "scripts", "record_proof.sh"),
+    join43(baseDir, "..", "..", "..", "scripts", "record_proof.sh"),
     // Source module build: packages/rn-dev-agent-core/dist/tools/device-record.js.
-    join42(baseDir, "..", "..", "..", "..", "scripts", "record_proof.sh")
+    join43(baseDir, "..", "..", "..", "..", "scripts", "record_proof.sh")
   ]);
 }
-function resolveRecordScript(baseDir = dirname21(fileURLToPath3(import.meta.url))) {
+function resolveRecordScript(baseDir = dirname22(fileURLToPath3(import.meta.url))) {
   if (process.env.RN_DEV_AGENT_RECORD_PROOF_SCRIPT) {
     return process.env.RN_DEV_AGENT_RECORD_PROOF_SCRIPT;
   }
   const candidates = candidateRecordScripts(baseDir);
-  return candidates.find((path) => existsSync29(path)) ?? candidates[0];
+  return candidates.find((path) => existsSync30(path)) ?? candidates[0];
 }
 function getRecordScript() {
   return resolveRecordScript();
@@ -81592,7 +81738,7 @@ function parseStatusOutput(stdout) {
   return active;
 }
 function recordingScope(args) {
-  return createHash15("sha256").update(`${args.sessionId}\0${args.claimEpoch}\0${args.platform}\0${args.deviceId}`).digest("hex");
+  return createHash16("sha256").update(`${args.sessionId}\0${args.claimEpoch}\0${args.platform}\0${args.deviceId}`).digest("hex");
 }
 function bindRecorderSession(runtime, args) {
   const available = runtime.requireAvailable();
@@ -81861,15 +82007,15 @@ function createDeviceRecordHandler(deps = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
-import { createHash as createHash17, randomUUID as randomUUID9 } from "node:crypto";
+import { createHash as createHash18, randomUUID as randomUUID9 } from "node:crypto";
 import { execFileSync as execFileSync14 } from "node:child_process";
-import { chmodSync as chmodSync7, closeSync as closeSync11, existsSync as existsSync30, fsyncSync, lstatSync as lstatSync16, mkdirSync as mkdirSync19, openSync as openSync11, readFileSync as readFileSync31, realpathSync as realpathSync13, renameSync as renameSync8, unlinkSync as unlinkSync14, writeFileSync as writeFileSync14 } from "node:fs";
-import { basename as basename11, dirname as dirname22, extname, isAbsolute as isAbsolute11, join as join43, relative as relative8, resolve as resolve16, sep as sep9 } from "node:path";
+import { chmodSync as chmodSync7, closeSync as closeSync11, existsSync as existsSync31, fsyncSync, lstatSync as lstatSync16, mkdirSync as mkdirSync20, openSync as openSync11, readFileSync as readFileSync32, realpathSync as realpathSync13, renameSync as renameSync9, unlinkSync as unlinkSync14, writeFileSync as writeFileSync15 } from "node:fs";
+import { basename as basename11, dirname as dirname23, extname, isAbsolute as isAbsolute11, join as join44, relative as relative8, resolve as resolve16, sep as sep9 } from "node:path";
 import { fileURLToPath as fileURLToPath4 } from "node:url";
 init_action_store();
 
 // packages/rn-dev-agent-core/dist/domain/proof-capture.js
-import { createHash as createHash16 } from "node:crypto";
+import { createHash as createHash17 } from "node:crypto";
 var StrictProofMonitor = class {
   now;
   events = [];
@@ -81943,14 +82089,14 @@ function hashProofArgs(params) {
   return hashProofValue(redact(params));
 }
 function hashProofValue(value) {
-  return createHash16("sha256").update(JSON.stringify(canonicalizeProofValue(value))).digest("hex");
+  return createHash17("sha256").update(JSON.stringify(canonicalizeProofValue(value))).digest("hex");
 }
 function proofRuntimeAuthorityMarker(input) {
   return hashProofValue(input);
 }
 function hashObservedValue(value) {
   const bytes = JSON.stringify(value) ?? String(value);
-  return createHash16("sha256").update(bytes).digest("hex");
+  return createHash17("sha256").update(bytes).digest("hex");
 }
 function resultEnvelope(result) {
   if (!result || typeof result !== "object")
@@ -82512,7 +82658,7 @@ var readinessSchema = external_exports.object({
   runtime: proofRuntimeSchema
 }).strict();
 function hashBytes(bytes) {
-  return createHash17("sha256").update(bytes).digest("hex");
+  return createHash18("sha256").update(bytes).digest("hex");
 }
 function captureProofWorkerStartup(argv = process.argv, attestation = readStartupIntegrityAttestation()) {
   let executedEntrypointPath = null;
@@ -82566,9 +82712,9 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
     return null;
   }
   for (const host of ["claude-plugin", "codex-plugin"]) {
-    const hostRoot = join43(root, "packages", host);
-    const coreIndex = realpathOrSelf(join43(hostRoot, "rn-dev-agent-core", "dist", "index.js"));
-    const coreSupervisor = realpathOrSelf(join43(hostRoot, "rn-dev-agent-core", "dist", "supervisor.js"));
+    const hostRoot = join44(root, "packages", host);
+    const coreIndex = realpathOrSelf(join44(hostRoot, "rn-dev-agent-core", "dist", "index.js"));
+    const coreSupervisor = realpathOrSelf(join44(hostRoot, "rn-dev-agent-core", "dist", "supervisor.js"));
     if (arg === coreIndex) {
       return {
         host,
@@ -82587,8 +82733,8 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
         kind: "core-supervisor"
       };
     }
-    if (host === "codex-plugin" && arg === realpathOrSelf(join43(hostRoot, "bin", "cdp-supervisor.js"))) {
-      if (!existsSync30(coreIndex) || !existsSync30(coreSupervisor))
+    if (host === "codex-plugin" && arg === realpathOrSelf(join44(hostRoot, "bin", "cdp-supervisor.js"))) {
+      if (!existsSync31(coreIndex) || !existsSync31(coreSupervisor))
         return null;
       return {
         host,
@@ -82622,7 +82768,7 @@ function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
   }
   if (supervisorOverride && supervisorOverride !== entrypoint.coreSupervisor)
     return false;
-  if (coreRootOverride && join43(coreRootOverride, "dist", "supervisor.js") !== entrypoint.coreSupervisor) {
+  if (coreRootOverride && join44(coreRootOverride, "dist", "supervisor.js") !== entrypoint.coreSupervisor) {
     return false;
   }
   if (workerOverride && workerOverride !== entrypoint.coreBundle)
@@ -82653,7 +82799,7 @@ function readProofCandidateHeadArtifacts(candidateRoot, artifactPaths) {
       const headBytes = execFileSync14("git", ["-C", root, "show", `HEAD:${artifactRelativePath}`], {
         maxBuffer: 128 * 1024 * 1024
       });
-      const artifactBytes = readFileSync31(resolvedArtifactPath);
+      const artifactBytes = readFileSync32(resolvedArtifactPath);
       if (hashBytes(artifactBytes) !== hashBytes(headBytes))
         return null;
       verifiedBytes.push(artifactBytes);
@@ -82680,7 +82826,7 @@ function readProofCandidateRuntime(candidateRoot, startup = proofWorkerStartup) 
     throw new Error("CANDIDATE_MCP_PROCESS_MISMATCH");
   }
   const { host, coreBundle } = entrypoint;
-  const runnerManifest = join43(root, "packages", host, "runner-manifest.json");
+  const runnerManifest = join44(root, "packages", host, "runner-manifest.json");
   const artifacts = readProofCandidateHeadArtifacts(root, [coreBundle, runnerManifest]);
   if (!artifacts) {
     throw new Error("CANDIDATE_CHECKOUT_NOT_CLEAN");
@@ -82738,7 +82884,7 @@ function readProofActionIdentity(appProjectRoot, actionId, dependencies = {}) {
     return {
       id: actionId,
       version: String(action.state.revision),
-      sha256: createHash17("sha256").update(action.yamlText).digest("hex")
+      sha256: createHash18("sha256").update(action.yamlText).digest("hex")
     };
   } catch {
     return null;
@@ -82775,7 +82921,7 @@ function validCaptureContext(args, expectedRoot) {
   ];
   if (proofTools.some((tool) => normalizeTool(tool) === "cdp_auto_login"))
     return false;
-  const proofRoot = join43(expectedRoot, "docs", "proof", args.runId);
+  const proofRoot = join44(expectedRoot, "docs", "proof", args.runId);
   const screenshots = args.storyboard.steps.map((step) => step.screenshotPath);
   const destinations = [args.receiptPath, args.videoPath, args.contactSheetPath, ...screenshots];
   if (destinations.some((path) => !isNormalizedDescendant(proofRoot, path) || hasExistingSymlink(expectedRoot, path)) || new Set(destinations).size !== destinations.length) {
@@ -82789,7 +82935,7 @@ function validCaptureContext(args, expectedRoot) {
   }));
 }
 function proofRootExists(args) {
-  const proofRoot = join43(args.projectRoot, "docs", "proof", args.runId);
+  const proofRoot = join44(args.projectRoot, "docs", "proof", args.runId);
   try {
     lstatSync16(proofRoot);
     return true;
@@ -82922,14 +83068,14 @@ function traceFor(storyboard, events) {
   return validateTrace([...required3, ...allowedExtras], events);
 }
 function readProofContractAt(moduleUrl = import.meta.url) {
-  const moduleDir = dirname22(fileURLToPath4(moduleUrl));
+  const moduleDir = dirname23(fileURLToPath4(moduleUrl));
   const candidates = [
     resolve16(moduleDir, "../../schemas/proof-receipt.schema.json"),
     resolve16(moduleDir, "../schemas/proof-receipt.schema.json")
   ];
   for (const path of candidates) {
     try {
-      const bytes = readFileSync31(path, "utf8");
+      const bytes = readFileSync32(path, "utf8");
       return { schema: JSON.parse(bytes), bytes, sha256: hashBytes(bytes) };
     } catch {
     }
@@ -82937,18 +83083,18 @@ function readProofContractAt(moduleUrl = import.meta.url) {
   throw new Error("PROOF_CONTRACT_MISSING");
 }
 function writeProofReceiptAtomic(path, receipt2) {
-  const directory = dirname22(path);
-  mkdirSync19(directory, { recursive: true, mode: 448 });
+  const directory = dirname23(path);
+  mkdirSync20(directory, { recursive: true, mode: 448 });
   const temporary = resolve16(directory, `.${randomUUID9()}.proof-receipt.tmp`);
   let descriptor = null;
   try {
     descriptor = openSync11(temporary, "wx", 384);
-    writeFileSync14(descriptor, `${JSON.stringify(receipt2, null, 2)}
+    writeFileSync15(descriptor, `${JSON.stringify(receipt2, null, 2)}
 `, "utf8");
     fsyncSync(descriptor);
     closeSync11(descriptor);
     descriptor = null;
-    renameSync8(temporary, path);
+    renameSync9(temporary, path);
     chmodSync7(path, 384);
   } catch (error2) {
     if (descriptor !== null)
@@ -83274,7 +83420,7 @@ function createProofCaptureHandler(deps) {
         return proofFailure(["PROOF_ACTION_IDENTITY_MISMATCH"], "idle");
       }
       try {
-        const proofRoot = join43(args.projectRoot, "docs", "proof", args.runId);
+        const proofRoot = join44(args.projectRoot, "docs", "proof", args.runId);
         if (deps.proofRootTracked(args.projectRoot, proofRoot)) {
           return proofFailure(["PROOF_ROOT_TRACKED"], "idle");
         }
@@ -83740,11 +83886,11 @@ function createProofCaptureHandler(deps) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/proof-media.js
-import { createHash as createHash18 } from "node:crypto";
+import { createHash as createHash19 } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { mkdir as mkdir2, mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir as tmpdir11 } from "node:os";
-import { dirname as dirname23, join as join44 } from "node:path";
+import { dirname as dirname24, join as join45 } from "node:path";
 var MediaFailure = class extends Error {
   reason;
   constructor(reason) {
@@ -83783,7 +83929,7 @@ async function hashAcceptedFile(path) {
   }
 }
 async function sha256File2(path) {
-  const hash = createHash18("sha256");
+  const hash = createHash19("sha256");
   const stream = createReadStream(path);
   for await (const chunk of stream)
     hash.update(chunk);
@@ -83881,7 +84027,7 @@ async function matchScreenshotAt(process3, input) {
   if (input.videoDurationMs !== void 0 && (!Number.isFinite(input.videoDurationMs) || input.videoDurationMs <= 0)) {
     fail2("INVALID_MEDIA_INPUT");
   }
-  const normalizedScreenshotPath = join44(input.scratchDir, `screenshot-${index}.png`);
+  const normalizedScreenshotPath = join45(input.scratchDir, `screenshot-${index}.png`);
   await rm(normalizedScreenshotPath, { force: true });
   await runFrameProcess(process3, [
     "-y",
@@ -83906,7 +84052,7 @@ async function matchScreenshotAt(process3, input) {
   let best = null;
   let decodedFrameCount = 0;
   for (const [sampleIndex, timestampMs] of sampleTimestamps.entries()) {
-    const framePath = join44(input.scratchDir, `frame-${index}-${sampleIndex}.jpg`);
+    const framePath = join45(input.scratchDir, `frame-${index}-${sampleIndex}.jpg`);
     await rm(framePath, { force: true });
     try {
       await runFrameProcess(process3, [
@@ -83978,7 +84124,7 @@ async function buildContactSheet(process3, selectedFramePaths, contactSheetPath)
     await requireNonEmptyFile(path, "FRAME_PROCESS_FAILED", "FRAME_PROCESS_FAILED");
   }
   try {
-    await mkdir2(dirname23(contactSheetPath), { recursive: true });
+    await mkdir2(dirname24(contactSheetPath), { recursive: true });
     await rm(contactSheetPath, { force: true });
   } catch {
     fail2("MEDIA_IO_FAILED");
@@ -84030,7 +84176,7 @@ async function validateMedia(process3, input) {
     const scratchRoot = input.scratchRoot ?? tmpdir11();
     try {
       await mkdir2(scratchRoot, { recursive: true });
-      scratchDir = await mkdtemp(join44(scratchRoot, "proof-media-"));
+      scratchDir = await mkdtemp(join45(scratchRoot, "proof-media-"));
     } catch {
       fail2("MEDIA_IO_FAILED");
     }
@@ -85218,8 +85364,8 @@ init_project_config();
 init_maestro_validator();
 init_maestro_run();
 init_action_engine_compat();
-import { lstatSync as lstatSync17, readFileSync as readFileSync32, readdirSync as readdirSync12, realpathSync as realpathSync14 } from "node:fs";
-import { dirname as dirname24, join as join45, resolve as resolve17 } from "node:path";
+import { lstatSync as lstatSync17, readFileSync as readFileSync33, readdirSync as readdirSync13, realpathSync as realpathSync14 } from "node:fs";
+import { dirname as dirname25, join as join46, resolve as resolve17 } from "node:path";
 var AUTH_ROUTE_PATTERNS = [
   "login",
   "signin",
@@ -85279,8 +85425,8 @@ async function isOnAuthScreen(client2) {
   }
 }
 function findLoginFlow(projectRoot) {
-  const maestroDir = join45(projectRoot, ".maestro");
-  const searchDirs = [join45(maestroDir, "subflows"), maestroDir];
+  const maestroDir = join46(projectRoot, ".maestro");
+  const searchDirs = [join46(maestroDir, "subflows"), maestroDir];
   for (const dir of searchDirs) {
     let files;
     try {
@@ -85291,7 +85437,7 @@ function findLoginFlow(projectRoot) {
       }
       if (!maestroStat.isDirectory() || !dirStat.isDirectory())
         continue;
-      files = readdirSync12(dir);
+      files = readdirSync13(dir);
     } catch (err) {
       if (err.code !== "ENOENT")
         throw err;
@@ -85299,12 +85445,12 @@ function findLoginFlow(projectRoot) {
     }
     for (const candidate of LOGIN_FLOW_PRIORITY) {
       if (files.includes(candidate)) {
-        return assertLegacyLoginFlow(projectRoot, join45(dir, candidate));
+        return assertLegacyLoginFlow(projectRoot, join46(dir, candidate));
       }
     }
     const authFile = files.find((f) => /\.(ya?ml)$/.test(f) && AUTH_ROUTE_PATTERNS.some((p) => f.toLowerCase().includes(p)));
     if (authFile)
-      return assertLegacyLoginFlow(projectRoot, join45(dir, authFile));
+      return assertLegacyLoginFlow(projectRoot, join46(dir, authFile));
   }
   return null;
 }
@@ -85411,12 +85557,12 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
     };
   }
   const rawAppId = opts.appId ?? projectAppId ?? "";
-  const originalContent = readFileSync32(flowPath, "utf-8");
+  const originalContent = readFileSync33(flowPath, "utf-8");
   let validatedCommands;
   try {
     const parsed = parseAndValidateFlow(originalContent, {
-      flowDir: dirname24(flowPath),
-      flowRoot: join45(projectRoot, ".maestro")
+      flowDir: dirname25(flowPath),
+      flowRoot: join46(projectRoot, ".maestro")
     });
     validatedCommands = parsed.commands;
     if (containsClearState(validatedCommands)) {
@@ -85912,11 +86058,11 @@ function buildGracefulShutdown(deps) {
 }
 
 // packages/rn-dev-agent-core/dist/lifecycle/lockfile.js
-import { createHash as createHash19 } from "node:crypto";
+import { createHash as createHash20 } from "node:crypto";
 import { execFileSync as execFileSync16 } from "node:child_process";
-import { closeSync as closeSync12, existsSync as existsSync31, mkdirSync as mkdirSync20, openSync as openSync12, readFileSync as readFileSync33, statSync as statSync14, unlinkSync as unlinkSync15, writeFileSync as writeFileSync15, writeSync as writeSync3 } from "node:fs";
+import { closeSync as closeSync12, existsSync as existsSync32, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync34, statSync as statSync14, unlinkSync as unlinkSync15, writeFileSync as writeFileSync16, writeSync as writeSync3 } from "node:fs";
 import { tmpdir as tmpdir12, userInfo as userInfo2 } from "node:os";
-import { join as join46, resolve as resolve18 } from "node:path";
+import { join as join47, resolve as resolve18 } from "node:path";
 var DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1e3;
 var DEFAULT_PROCESS_NAME_NEEDLE = "cdp-bridge";
 var PROCESS_IDENTITY_MARKERS = ["cdp-bridge", "rn-dev-agent", "supervisor.js"];
@@ -85965,7 +86111,7 @@ function defaultSelfPpid() {
   return typeof process.ppid === "number" ? process.ppid : 0;
 }
 function hashProjectRoot(projectRoot) {
-  return createHash19("md5").update(resolve18(projectRoot)).digest("hex").slice(0, 8);
+  return createHash20("md5").update(resolve18(projectRoot)).digest("hex").slice(0, 8);
 }
 var Lockfile = class {
   opts;
@@ -85992,7 +86138,7 @@ var Lockfile = class {
       processIdentity: opts.processIdentity ?? defaultProcessIdentity(),
       staleMs: opts.staleMs ?? DEFAULT_STALE_MS
     };
-    this.lockPath = join46(tmpDir, `rn-dev-agent-cdp-${uid}-${hash}.lock`);
+    this.lockPath = join47(tmpDir, `rn-dev-agent-cdp-${uid}-${hash}.lock`);
   }
   // GH#251: acquire via atomic exclusive-create (same pattern as DeviceLock).
   // The previous read-then-writeFileSync let two bridges starting in the same
@@ -86049,7 +86195,7 @@ var Lockfile = class {
     if (!this.acquired)
       return;
     try {
-      if (existsSync31(this.lockPath)) {
+      if (existsSync32(this.lockPath)) {
         const body = this.readExisting();
         if (body?.pid === this.opts.pid) {
           unlinkSync15(this.lockPath);
@@ -86077,16 +86223,16 @@ var Lockfile = class {
       return false;
     body.lastHeartbeat = this.opts.clock();
     try {
-      writeFileSync15(this.lockPath, JSON.stringify(body, null, 2), { encoding: "utf8" });
+      writeFileSync16(this.lockPath, JSON.stringify(body, null, 2), { encoding: "utf8" });
     } catch {
     }
     return true;
   }
   readExisting() {
-    if (!existsSync31(this.lockPath))
+    if (!existsSync32(this.lockPath))
       return null;
     try {
-      const raw = readFileSync33(this.lockPath, "utf8");
+      const raw = readFileSync34(this.lockPath, "utf8");
       const parsed = JSON.parse(raw);
       if (!isValidLockBody(parsed))
         return null;
@@ -86156,8 +86302,8 @@ var Lockfile = class {
       version: this.opts.version || void 0
     };
     const dir = this.opts.tmpDir;
-    if (!existsSync31(dir)) {
-      mkdirSync20(dir, { recursive: true });
+    if (!existsSync32(dir)) {
+      mkdirSync21(dir, { recursive: true });
     }
     const fd = openSync12(this.lockPath, "wx");
     try {
@@ -86237,7 +86383,7 @@ init_action_engine_compat();
 init_action_store();
 init_reusable_action();
 init_path_safety();
-import { basename as basename12, dirname as dirname25, join as join47 } from "node:path";
+import { basename as basename12, dirname as dirname26, join as join48 } from "node:path";
 function stepToMaestroCommands(step) {
   const ALLOWED_DIRECTIONS = /* @__PURE__ */ new Set(["up", "down", "left", "right"]);
   switch (step.action) {
@@ -86296,7 +86442,7 @@ function createMaestroGenerateHandler() {
       return failResult("Flow name contains an unsafe control character or is too long.");
     }
     const root = findProjectRoot();
-    const outputDir = args.outputDir ?? (root ? join47(root, ".rn-agent", "actions") : null);
+    const outputDir = args.outputDir ?? (root ? join48(root, ".rn-agent", "actions") : null);
     if (!outputDir) {
       return failResult("Cannot determine project root. Pass outputDir explicitly.");
     }
@@ -86305,7 +86451,7 @@ function createMaestroGenerateHandler() {
       return failResult("Flow name must produce an action id that starts with a letter or number and is at most 64 characters.");
     }
     const fileName = `${sanitizedName}.yaml`;
-    const learnedProjectRoot = basename12(outputDir) === "actions" && basename12(dirname25(outputDir)) === ".rn-agent" ? dirname25(dirname25(outputDir)) : null;
+    const learnedProjectRoot = basename12(outputDir) === "actions" && basename12(dirname26(outputDir)) === ".rn-agent" ? dirname26(dirname26(outputDir)) : null;
     if (!learnedProjectRoot) {
       return failResult("Generated actions must be written to an owned .rn-agent/actions corpus.");
     }
@@ -86380,8 +86526,8 @@ init_maestro_runner_report();
 init_registry();
 import { execFile as execFileCb19 } from "node:child_process";
 import { promisify as promisify25 } from "node:util";
-import { existsSync as existsSync32, readdirSync as readdirSync13, readFileSync as readFileSync34, writeFileSync as writeFileSync16 } from "node:fs";
-import { basename as basename13, dirname as dirname26, join as join48, resolve as resolve19 } from "node:path";
+import { existsSync as existsSync33, readdirSync as readdirSync14, readFileSync as readFileSync35, writeFileSync as writeFileSync17 } from "node:fs";
+import { basename as basename13, dirname as dirname27, join as join49, resolve as resolve19 } from "node:path";
 import { tmpdir as tmpdir13 } from "node:os";
 var defaultExecFile4 = promisify25(execFileCb19);
 function filterFlows(yamls, pattern) {
@@ -86399,9 +86545,9 @@ function filterFlows(yamls, pattern) {
   return yamls;
 }
 function discoverFlows(dir, pattern) {
-  if (!existsSync32(dir))
+  if (!existsSync33(dir))
     return [];
-  const yamls = readdirSync13(dir, { recursive: true }).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).map((f) => join48(dir, f)).sort();
+  const yamls = readdirSync14(dir, { recursive: true }).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).map((f) => join49(dir, f)).sort();
   return filterFlows(yamls, pattern);
 }
 function createMaestroTestAllHandler(deps = {}) {
@@ -86433,17 +86579,17 @@ function createMaestroTestAllHandler(deps = {}) {
     if (pinRefusal)
       return failResult(pinRefusal);
     const root = findProjectRoot();
-    const flowDir = args.flowDir ?? (root ? join48(root, ".rn-agent", "actions") : null);
+    const flowDir = args.flowDir ?? (root ? join49(root, ".rn-agent", "actions") : null);
     if (!flowDir) {
       return failResult("Cannot determine project root. Pass flowDir explicitly.");
     }
     const resolvedFlowDir = resolve19(flowDir);
-    const flowDirClassification = classifyLearnedActionPath(join48(resolvedFlowDir, "__action__.yaml"));
+    const flowDirClassification = classifyLearnedActionPath(join49(resolvedFlowDir, "__action__.yaml"));
     if (flowDirClassification === "descendant") {
       return failResult(`Refusing to execute learned-action descendants from ${resolvedFlowDir} as standalone flows.`);
     }
     const learnedCorpus = flowDirClassification === "action";
-    const learnedProjectRoot = learnedCorpus ? dirname26(dirname26(resolvedFlowDir)) : null;
+    const learnedProjectRoot = learnedCorpus ? dirname27(dirname27(resolvedFlowDir)) : null;
     let learnedContext = null;
     if (learnedProjectRoot) {
       try {
@@ -86455,7 +86601,7 @@ function createMaestroTestAllHandler(deps = {}) {
     if (learnedCorpus && !learnedContext) {
       return failResult(`Refusing learned-action corpus without an approved load context: ${resolvedFlowDir}.`);
     }
-    const flows = learnedContext ? filterFlows(learnedContext.files.filter((file) => /\.ya?ml$/i.test(file)).map((file) => join48(flowDir, file)).sort(), args.pattern) : discoverFlows(flowDir, args.pattern);
+    const flows = learnedContext ? filterFlows(learnedContext.files.filter((file) => /\.ya?ml$/i.test(file)).map((file) => join49(flowDir, file)).sort(), args.pattern) : discoverFlows(flowDir, args.pattern);
     if (flows.length === 0) {
       return failResult(`No Maestro flows found in ${flowDir}. Generate flows with maestro_generate first.`);
     }
@@ -86482,9 +86628,9 @@ function createMaestroTestAllHandler(deps = {}) {
           meta = action.metadata;
           requireEnginePin = true;
         } else {
-          const yamlText = readFileSync34(flow, "utf-8");
+          const yamlText = readFileSync35(flow, "utf-8");
           const parsed = parseAndValidateFlow(yamlText, {
-            flowDir: dirname26(flow),
+            flowDir: dirname27(flow),
             flowRoot: flowDir
           });
           const flowId = name.replace(/\.ya?ml$/i, "");
@@ -86554,8 +86700,8 @@ function createMaestroTestAllHandler(deps = {}) {
     for (const prepared of preparedFlows) {
       const { name } = prepared;
       const start = now();
-      const safeFlowFile = join48(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
-      writeFileSync16(safeFlowFile, prepared.canonical, "utf-8");
+      const safeFlowFile = join49(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      writeFileSync17(safeFlowFile, prepared.canonical, "utf-8");
       const parsedCommands = prepared.commands;
       const parsedAppId = prepared.appId;
       const appFile = prepared.appFile;
@@ -86578,7 +86724,7 @@ function createMaestroTestAllHandler(deps = {}) {
             Object.assign(error2, { code: "ETIMEDOUT" });
             throw error2;
           }
-          writeFileSync16(safeFlowFile, buildMaestroFlow(parsedAppId !== void 0 ? { appId: parsedAppId } : {}, [
+          writeFileSync17(safeFlowFile, buildMaestroFlow(parsedAppId !== void 0 ? { appId: parsedAppId } : {}, [
             ...commands
           ]), "utf-8");
           const executeRunner = (runnerPath, prefixArgs = []) => {
@@ -86704,8 +86850,8 @@ function createMaestroTestAllHandler(deps = {}) {
 init_agent_device_wrapper();
 init_utils();
 init_path_safety();
-import { readFileSync as readFileSync35, readdirSync as readdirSync14, lstatSync as lstatSync18 } from "node:fs";
-import { join as join49, extname as extname2 } from "node:path";
+import { readFileSync as readFileSync36, readdirSync as readdirSync15, lstatSync as lstatSync18 } from "node:fs";
+import { join as join50, extname as extname2 } from "node:path";
 function findElement(nodes, query, matchBy) {
   const q = query.toLowerCase();
   return nodes.some((n) => {
@@ -86723,14 +86869,14 @@ function discoverTestIDs(dir) {
   function walk(d) {
     let entries;
     try {
-      entries = readdirSync14(d);
+      entries = readdirSync15(d);
     } catch {
       return;
     }
     for (const entry of entries) {
       if (entry === "node_modules" || entry.startsWith("."))
         continue;
-      const full = join49(d, entry);
+      const full = join50(d, entry);
       try {
         const st = lstatSync18(full);
         if (st.isSymbolicLink())
@@ -86741,7 +86887,7 @@ function discoverTestIDs(dir) {
         }
         if (!SCAN_EXTENSIONS.has(extname2(entry)))
           continue;
-        const src = readFileSync35(full, "utf8");
+        const src = readFileSync36(full, "utf8");
         for (const m of src.matchAll(TESTID_RE)) {
           const id = m[1] ?? m[2] ?? m[3];
           if (id)
@@ -87063,16 +87209,16 @@ function instrumentTool(toolName, handler) {
 }
 
 // packages/rn-dev-agent-core/dist/experience/evidence.js
-import { createHash as createHash20, randomUUID as randomUUID10 } from "node:crypto";
-import { chmodSync as chmodSync8, existsSync as existsSync33, mkdirSync as mkdirSync21, readFileSync as readFileSync36, renameSync as renameSync9, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17 } from "node:fs";
+import { createHash as createHash21, randomUUID as randomUUID10 } from "node:crypto";
+import { chmodSync as chmodSync8, existsSync as existsSync34, mkdirSync as mkdirSync22, readFileSync as readFileSync37, renameSync as renameSync10, unlinkSync as unlinkSync16, writeFileSync as writeFileSync18 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
-import { dirname as dirname27, join as join50 } from "node:path";
+import { dirname as dirname28, join as join51 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 var UNKNOWN_CLASSIFICATION = "UNKNOWN";
 var DEFAULT_MAX_RECORDS = 500;
 var DEFAULT_RETENTION_DAYS = 14;
 var MAX_EVIDENCE_POINTERS = 3;
-var EXPERIENCE_DIRECTORY = join50(homedir9(), ".claude", "rn-agent", "experience");
+var EXPERIENCE_DIRECTORY = join51(homedir9(), ".claude", "rn-agent", "experience");
 var EXPERIENCE_STORE_NAME = "patterns.jsonl";
 var MAX_SYMPTOM_LENGTH = 2048;
 var DAY_MS = 24 * 60 * 60 * 1e3;
@@ -87153,11 +87299,11 @@ function readAppIdentity() {
   return appIdentityCache.identity;
 }
 function loadAppIdentity(root) {
-  const manifest = join50(root, "app.json");
+  const manifest = join51(root, "app.json");
   try {
-    if (!existsSync33(manifest))
+    if (!existsSync34(manifest))
       return { name: null, slug: null };
-    const parsed = JSON.parse(readFileSync36(manifest, "utf8"));
+    const parsed = JSON.parse(readFileSync37(manifest, "utf8"));
     const expo = parsed.expo ?? parsed;
     return { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
   } catch {
@@ -87179,7 +87325,7 @@ var ExperienceRecorder = class {
   previousFailure = null;
   constructor(options) {
     this.directory = options.directory ?? process.env.RN_DEV_AGENT_EXPERIENCE_DIR ?? EXPERIENCE_DIRECTORY;
-    this.path = join50(this.directory, EXPERIENCE_STORE_NAME);
+    this.path = join51(this.directory, EXPERIENCE_STORE_NAME);
     this.candidate = {
       pluginVersion: options.pluginVersion ?? null,
       coreVersion: options.coreVersion
@@ -87322,21 +87468,21 @@ var ExperienceRecorder = class {
     this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
   }
   write(records) {
-    mkdirSync21(this.directory, { recursive: true, mode: 448 });
-    const temp = join50(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID10()}`);
+    mkdirSync22(this.directory, { recursive: true, mode: 448 });
+    const temp = join51(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID10()}`);
     try {
       const sanitized = records.map((record2) => record2.redactionVersion === REDACTION_RULES_VERSION ? record2 : {
         ...sanitizeForEvidence(record2),
         redactionVersion: REDACTION_RULES_VERSION
       });
       const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
-      writeFileSync17(temp, contents.length > 0 ? `${contents}
+      writeFileSync18(temp, contents.length > 0 ? `${contents}
 ` : "", {
         encoding: "utf8",
         flag: "wx",
         mode: 384
       });
-      renameSync9(temp, this.path);
+      renameSync10(temp, this.path);
       chmodSync8(this.path, 384);
     } catch (error2) {
       try {
@@ -87350,16 +87496,16 @@ var ExperienceRecorder = class {
 function discoverPluginVersion(fromUrl = import.meta.url) {
   if (process.env.RN_DEV_AGENT_PLUGIN_VERSION)
     return process.env.RN_DEV_AGENT_PLUGIN_VERSION;
-  const start = dirname27(fileURLToPath5(fromUrl));
+  const start = dirname28(fileURLToPath5(fromUrl));
   const candidates = [
-    join50(start, "..", "..", ".claude-plugin", "plugin.json"),
-    join50(start, "..", "..", ".codex-plugin", "plugin.json"),
-    join50(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
-    join50(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
+    join51(start, "..", "..", ".claude-plugin", "plugin.json"),
+    join51(start, "..", "..", ".codex-plugin", "plugin.json"),
+    join51(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
+    join51(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
   ];
   for (const candidate of candidates) {
     try {
-      const parsed = JSON.parse(readFileSync36(candidate, "utf8"));
+      const parsed = JSON.parse(readFileSync37(candidate, "utf8"));
       if (typeof parsed.version === "string")
         return sanitizeString(parsed.version);
     } catch {
@@ -87368,9 +87514,9 @@ function discoverPluginVersion(fromUrl = import.meta.url) {
   return null;
 }
 function readExperienceStore(path) {
-  if (!existsSync33(path))
+  if (!existsSync34(path))
     return [];
-  const contents = readFileSync36(path, "utf8");
+  const contents = readFileSync37(path, "utf8");
   if (!contents.trim())
     return [];
   const records = [];
@@ -87395,7 +87541,7 @@ function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, 
   }).sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen) || a.signature.localeCompare(b.signature)).slice(0, Math.max(0, maxRecords)).sort((a, b) => a.signature.localeCompare(b.signature));
 }
 function experienceSignature(input) {
-  return createHash20("sha256").update(JSON.stringify([
+  return createHash21("sha256").update(JSON.stringify([
     input.classification,
     input.tool,
     input.normalizedSymptomShape,
@@ -87512,7 +87658,7 @@ function boundedPointers(existing, incoming) {
 }
 
 // packages/rn-dev-agent-core/dist/observability/live-device.js
-import { join as join51 } from "node:path";
+import { join as join52 } from "node:path";
 import { tmpdir as tmpdir14 } from "node:os";
 function isStateMutating(tool, args) {
   if (FLOW_MUTATION_TOOLS.has(tool))
@@ -87664,7 +87810,7 @@ function buildLiveDeps(input) {
     // iterable" when invoked as deps.pushLive(...). The live device gate caught
     // this — the unit fakes used standalone arrows and missed it.
     pushLive: (frame) => input.recorder.pushLive(frame),
-    tmpPath: () => join51(tmpdir14(), `rn-observe-live-${process.pid}.jpg`),
+    tmpPath: () => join52(tmpdir14(), `rn-observe-live-${process.pid}.jpg`),
     isMirrorActive: input.isMirrorActive
   };
 }
@@ -87678,9 +87824,9 @@ init_utils();
 
 // packages/rn-dev-agent-core/dist/observability/server.js
 import { createServer as createServer3 } from "node:http";
-import { readFileSync as readFileSync37 } from "node:fs";
+import { readFileSync as readFileSync38 } from "node:fs";
 import { fileURLToPath as fileURLToPath6 } from "node:url";
-import { dirname as dirname28, join as join52 } from "node:path";
+import { dirname as dirname29, join as join53 } from "node:path";
 
 // packages/rn-dev-agent-core/dist/observability/e2e-csrf.js
 import { randomBytes as randomBytes7, timingSafeEqual as timingSafeEqual8 } from "node:crypto";
@@ -87767,7 +87913,7 @@ function createObserveRootResolver(deps) {
 // packages/rn-dev-agent-core/dist/observability/server.js
 init_logger();
 var HOST = "127.0.0.1";
-var __dir = dirname28(fileURLToPath6(import.meta.url));
+var __dir = dirname29(fileURLToPath6(import.meta.url));
 var ObservabilityServer = class {
   recorder;
   e2e;
@@ -88010,7 +88156,7 @@ var ObservabilityServer = class {
   }
   index(res) {
     try {
-      let html = readFileSync37(join52(__dir, "web-dist", "index.html"), "utf8");
+      let html = readFileSync38(join53(__dir, "web-dist", "index.html"), "utf8");
       if (this.e2e) {
         const tokenJs = JSON.stringify(this.e2e.token).replace(/</g, "\\u003c");
         html = html.replace("</head>", `<script>window.__E2E_CSRF__=${tokenJs}</script></head>`);
@@ -88211,10 +88357,10 @@ init_project_config();
 // packages/rn-dev-agent-core/dist/observability/observe-state.js
 init_secure_state_file();
 init_storage();
-import { join as join53 } from "node:path";
+import { join as join54 } from "node:path";
 function observeStatePath(projectRoot) {
   const safe = projectRoot.replace(/[^A-Za-z0-9._-]/g, "_");
-  return join53(getStateDir(), "observe", `${safe}.json`);
+  return join54(getStateDir(), "observe", `${safe}.json`);
 }
 function writeObserveState(url, port, projectRoot = findProjectRoot(), now = () => /* @__PURE__ */ new Date()) {
   try {
@@ -88897,110 +89043,7 @@ init_sources();
 
 // packages/rn-dev-agent-core/dist/tools/lock-e2e-test.js
 init_action_store();
-
-// packages/rn-dev-agent-core/dist/domain/e2e-test.js
-init_path_safety();
-import { dirname as dirname29, join as join54 } from "node:path";
-import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync10, readFileSync as readFileSync38, readdirSync as readdirSync15, existsSync as existsSync34 } from "node:fs";
-import { createHash as createHash21 } from "node:crypto";
-var FLOW_SENTINEL = "# e2e-locked-flow-below";
-function e2eDirFor(projectRoot) {
-  return join54(projectRoot, ".rn-agent", "e2e");
-}
-function e2ePathFor(projectRoot, id) {
-  assertValidActionId(id, "e2ePathFor");
-  const dir = e2eDirFor(projectRoot);
-  const file = join54(dir, `${id}.yaml`);
-  assertWithinDir(file, dir);
-  return file;
-}
-function serializeLockedTest(meta) {
-  const header = [
-    "# e2e-locked-test: true",
-    `# id: ${meta.id}`,
-    `# intent: ${meta.intent}`,
-    `# sourceActionId: ${meta.sourceActionId}`,
-    `# lockedAt: ${meta.lockedAt}`,
-    `# lockedGitSha: ${meta.lockedGitSha ?? ""}`,
-    `# sourceContentHash: ${meta.sourceContentHash}`,
-    "# status: locked"
-  ];
-  if (meta.appId)
-    header.push(`# appId: ${meta.appId}`);
-  if (meta.params?.length)
-    header.push(`# params: ${meta.params.join(", ")}`);
-  header.push(FLOW_SENTINEL);
-  return `${header.join("\n")}
-${meta.flow}`;
-}
-function hashBody(s) {
-  return createHash21("sha256").update(s).digest("hex");
-}
-function freezeLockedTest(projectRoot, source, ctx) {
-  const filePath = e2ePathFor(projectRoot, source.id);
-  mkdirSync22(dirname29(filePath), { recursive: true });
-  const meta = {
-    id: source.id,
-    intent: source.intent,
-    sourceActionId: source.sourceActionId,
-    lockedAt: ctx.now().toISOString(),
-    lockedGitSha: ctx.gitSha,
-    sourceContentHash: hashBody(source.flow),
-    status: "locked",
-    params: source.params,
-    appId: source.appId,
-    flow: source.flow
-  };
-  const tmp = `${filePath}.tmp`;
-  writeFileSync18(tmp, serializeLockedTest(meta), "utf8");
-  renameSync10(tmp, filePath);
-  return { ...meta, filePath };
-}
-function loadLockedTest(projectRoot, id) {
-  const filePath = e2ePathFor(projectRoot, id);
-  if (!existsSync34(filePath))
-    return null;
-  return parseLockedTest(readFileSync38(filePath, "utf8"), filePath);
-}
-function discoverLockedTests(projectRoot) {
-  const dir = e2eDirFor(projectRoot);
-  if (!existsSync34(dir))
-    return [];
-  return readdirSync15(dir).filter((f) => f.endsWith(".yaml")).map((f) => f.replace(/\.yaml$/, "")).sort();
-}
-function parseLockedTest(text, filePath) {
-  if (!/^#\s*e2e-locked-test:\s*true\s*$/m.test(text))
-    return null;
-  const sentinelIdx = text.indexOf(FLOW_SENTINEL);
-  if (sentinelIdx < 0)
-    return null;
-  const headerText = text.slice(0, sentinelIdx);
-  const flowStart = text.indexOf("\n", sentinelIdx);
-  const flow = flowStart >= 0 ? text.slice(flowStart + 1) : "";
-  const field2 = (k) => {
-    const m = headerText.match(new RegExp(`^#\\s*${k}:\\s*(.*)$`, "m"));
-    const v = m?.[1]?.trim();
-    return v ? v : void 0;
-  };
-  const id = field2("id");
-  const intent = field2("intent");
-  if (!id || !intent)
-    return null;
-  const paramsRaw = field2("params");
-  return {
-    id,
-    intent,
-    sourceActionId: field2("sourceActionId") ?? id,
-    lockedAt: field2("lockedAt") ?? "",
-    lockedGitSha: field2("lockedGitSha") ?? null,
-    sourceContentHash: field2("sourceContentHash") ?? "",
-    status: "locked",
-    params: paramsRaw ? paramsRaw.split(",").map((s) => s.trim()).filter(Boolean) : void 0,
-    appId: field2("appId"),
-    flow,
-    filePath
-  };
-}
+init_e2e_test();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-config.js
 import { readFileSync as readFileSync39 } from "node:fs";
@@ -89139,6 +89182,9 @@ async function lockE2eTestCore(args, deps = {}) {
 function createLockE2eTestHandler(deps = {}) {
   return (args) => lockE2eTestCore(args, deps);
 }
+
+// packages/rn-dev-agent-core/dist/tools/run-e2e-suite.js
+init_e2e_test();
 
 // packages/rn-dev-agent-core/dist/domain/e2e-run.js
 init_maestro_error_parser();
@@ -89340,16 +89386,6 @@ function readMaestro(result) {
     return { passed: false, output: "unparseable maestro result" };
   }
 }
-function filterByPattern(ids, pattern) {
-  if (!pattern || pattern.length > 256)
-    return ids;
-  try {
-    const re = new RegExp(pattern, "i");
-    return ids.filter((id) => re.test(id));
-  } catch {
-    return ids;
-  }
-}
 async function runE2eSuiteCore(args, deps = {}) {
   const projectRoot = args.projectRoot ?? findProjectRoot() ?? process.cwd();
   const discover2 = deps.discover ?? discoverLockedTests;
@@ -89360,7 +89396,9 @@ async function runE2eSuiteCore(args, deps = {}) {
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
   const mkRunId = deps.makeRunId ?? makeRunId;
   const rand = () => Math.random().toString(36).slice(2, 8);
-  const ids = filterByPattern(discover2(projectRoot), args.pattern);
+  const ids = [
+    ...getResolvedLockedTestIds(args) ?? resolveLockedTestIds(projectRoot, args.pattern, discover2)
+  ];
   if (ids.length === 0) {
     return warnResult({
       runId: null,
@@ -89539,6 +89577,9 @@ function createRunE2eSuiteHandler(deps = {}) {
     }
   };
 }
+
+// packages/rn-dev-agent-core/dist/index.js
+init_e2e_test();
 
 // packages/rn-dev-agent-core/dist/e2e/preflight.js
 import { request } from "node:http";
@@ -90817,6 +90858,13 @@ var createRuntimeAuthorityProbe = (resolveClient) => createLocalAuthorityProbe({
 var localAuthorityProbe = createRuntimeAuthorityProbe(getClient);
 var authorityGate = createAuthorityGate(authorityRuntime, {
   loginSupervisorOverrideToken: () => process.env.RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN,
+  resolveLockedE2eTestIds: (args, status) => {
+    const projectRoot = typeof args.projectRoot === "string" ? args.projectRoot : status.source.appRoot;
+    if (typeof projectRoot !== "string")
+      return [];
+    args.projectRoot = projectRoot;
+    return resolveLockedTestIds(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
+  },
   probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
   recoverRuntimeConnection: async (status) => {
     const current = getClient();

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -32652,6 +32652,23 @@ function missingLoginPrologueOutcome() {
     }
   };
 }
+function pendingLoginPrologueOutcome() {
+  const timestamp = (/* @__PURE__ */ new Date()).toISOString();
+  return {
+    schemaVersion: 1,
+    state: LOGIN_PROLOGUE_BLOCKED,
+    alias: LOGIN_PROLOGUE_ALIAS,
+    startedAt: timestamp,
+    endedAt: timestamp,
+    elapsedMs: 0,
+    steps: [],
+    inventory: { count: 0, actionIds: [] },
+    failure: {
+      code: "LOGIN_PROLOGUE_IN_PROGRESS",
+      detail: "The login prologue has not completed authoritative validation."
+    }
+  };
+}
 function persistLoginPrologueOutcome(runtime, registry2, operation, status, outcome) {
   const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
   const overrides = outcome.overrides ?? priorOutcome?.overrides;
@@ -32921,6 +32938,13 @@ function createAuthorityGate(runtime, dependencies) {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
           overrideRejected: loginDecision.suppliedOverride,
           nextAction: "Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call."
+        });
+      }
+      if (loginDecision.override && profile.kind === "transition") {
+        return failResult("LOGIN_PROLOGUE_BLOCKED: supervisor overrides cannot authorize transition mutations.", "LOGIN_PROLOGUE_BLOCKED", {
+          loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
+          transitionOverrideRejected: true,
+          nextAction: "Repair the exact user-login action and rerun cdp_login_prologue before this transition."
         });
       }
       if (profile.kind === "diagnostic") {
@@ -33543,6 +33567,11 @@ function createAuthorityGate(runtime, dependencies) {
             throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
           }
           const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, loginDecision.audit));
+          operation = persisted.operation;
+          status = persisted.status;
+        }
+        if (tool === "cdp_login_prologue") {
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome());
           operation = persisted.operation;
           status = persisted.status;
         }
@@ -78362,8 +78391,9 @@ function createRunActionHandler(deps = {}) {
     });
     try {
       let atRisk = null;
+      const cdpFallbackForbidden = args.cdpFallbackMode === "forbid";
       const inheritedBlindProbeDisabled = process.env.RN_BLIND_PROBE === "0" || process.env.RN_BLIND_PROBE === "false";
-      const blindProbeDisabled = args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
+      const blindProbeDisabled = cdpFallbackForbidden || args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
       if (args.platform !== "android") {
         const ctx = await blindProbeContext2().catch(() => null);
         if (ctx) {
@@ -78549,7 +78579,7 @@ function createRunActionHandler(deps = {}) {
         }
       }
       let cdpJsFallback;
-      if (failure.kind === "SELECTOR_NOT_FOUND" || failure.kind === "UNKNOWN") {
+      if (!cdpFallbackForbidden && (failure.kind === "SELECTOR_NOT_FOUND" || failure.kind === "UNKNOWN")) {
         const candidate = getReplayDeps(args);
         const replayDeps = candidate && await claimBundleAuthority(args) ? candidate : null;
         const probe = !replayDeps ? null : failure.kind === "SELECTOR_NOT_FOUND" ? failure.selector : firstReplayTestId(cdpReplayYaml, args.params ?? {});
@@ -79002,6 +79032,7 @@ function createLoginPrologueHandler(deps) {
         forceReload: false,
         proofReplay: false,
         blindProbeMode: "forbid",
+        cdpFallbackMode: "forbid",
         trigger: args.trigger ?? "agent"
       });
       let replayResult;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -13032,6 +13032,14 @@ var init_login_prologue = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/e2e-test.js
+var init_e2e_test = __esm({
+  "packages/rn-dev-agent-core/dist/domain/e2e-test.js"() {
+    "use strict";
+    init_path_safety();
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -13320,6 +13328,7 @@ var init_authority_gate = __esm({
     init_metro_origin();
     init_install_reissue();
     init_login_prologue();
+    init_e2e_test();
     init_tool_profiles();
     managedNativeOrigin = /* @__PURE__ */ Symbol("managedNativeOrigin");
     managedRunnerPark = /* @__PURE__ */ Symbol("managedRunnerPark");

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -10902,10 +10902,10 @@ function assertWritableActionFile(filePath) {
 function assertActionMetadataIdentity(filePath, metadata) {
   const fileId = basename4(filePath).replace(/\.ya?ml$/i, "");
   if (metadata.id !== fileId) {
-    throw new Error(`Action metadata id ${metadata.id} does not match filename identity ${fileId}.`);
+    throw new ActionMetadataIdentityError(metadata.id, fileId);
   }
 }
-var migrationPathIdentities;
+var migrationPathIdentities, ActionMetadataIdentityError;
 var init_action_store = __esm({
   "packages/rn-dev-agent-core/dist/domain/action-store.js"() {
     "use strict";
@@ -10918,6 +10918,16 @@ var init_action_store = __esm({
     init_action_state_store();
     init_worktree_inheritance();
     migrationPathIdentities = /* @__PURE__ */ new WeakMap();
+    ActionMetadataIdentityError = class extends Error {
+      metadataId;
+      fileId;
+      constructor(metadataId, fileId) {
+        super(`Action metadata id ${metadataId} does not match filename identity ${fileId}.`);
+        this.metadataId = metadataId;
+        this.fileId = fileId;
+        this.name = "ActionMetadataIdentityError";
+      }
+    };
   }
 });
 

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -13015,6 +13015,13 @@ var init_install_reissue = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/login-prologue.js
+var init_login_prologue = __esm({
+  "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
+    "use strict";
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -13087,7 +13094,7 @@ var init_tool_profiles = __esm({
       "maestro_test_all"
     ];
     hybridMutation = ["cdp_auto_login", "cdp_run_e2e_suite"];
-    optionalHybridMutation = ["cdp_run_action"];
+    optionalHybridMutation = ["cdp_login_prologue", "cdp_run_action"];
     nativeDiagnostic = ["cdp_native_errors"];
     cdpRead = [
       "cdp_component_state",
@@ -13302,6 +13309,7 @@ var init_authority_gate = __esm({
     init_registry();
     init_metro_origin();
     init_install_reissue();
+    init_login_prologue();
     init_tool_profiles();
     managedNativeOrigin = /* @__PURE__ */ Symbol("managedNativeOrigin");
     managedRunnerPark = /* @__PURE__ */ Symbol("managedRunnerPark");

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -10902,10 +10902,10 @@ function assertWritableActionFile(filePath) {
 function assertActionMetadataIdentity(filePath, metadata) {
   const fileId = basename4(filePath).replace(/\.ya?ml$/i, "");
   if (metadata.id !== fileId) {
-    throw new ActionMetadataIdentityError(metadata.id, fileId);
+    throw new Error(`Action metadata id ${metadata.id} does not match filename identity ${fileId}.`);
   }
 }
-var migrationPathIdentities, ActionMetadataIdentityError;
+var migrationPathIdentities;
 var init_action_store = __esm({
   "packages/rn-dev-agent-core/dist/domain/action-store.js"() {
     "use strict";
@@ -10918,16 +10918,6 @@ var init_action_store = __esm({
     init_action_state_store();
     init_worktree_inheritance();
     migrationPathIdentities = /* @__PURE__ */ new WeakMap();
-    ActionMetadataIdentityError = class extends Error {
-      metadataId;
-      fileId;
-      constructor(metadataId, fileId) {
-        super(`Action metadata id ${metadataId} does not match filename identity ${fileId}.`);
-        this.metadataId = metadataId;
-        this.fileId = fileId;
-        this.name = "ActionMetadataIdentityError";
-      }
-    };
   }
 });
 

--- a/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -11970,6 +11970,14 @@ var init_install_reissue = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/e2e-test.js
+var init_e2e_test = __esm({
+  "packages/rn-dev-agent-core/dist/domain/e2e-test.js"() {
+    "use strict";
+    init_path_safety();
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -12212,6 +12220,7 @@ var init_authority_gate = __esm({
     init_metro_origin();
     init_install_reissue();
     init_login_prologue();
+    init_e2e_test();
     init_tool_profiles();
   }
 });

--- a/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -11390,12 +11390,13 @@ function readLoginPrologueOutcome(value) {
   }
   return candidate;
 }
-var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED;
+var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, ACTION_LOGIN_HELPER;
 var init_login_prologue = __esm({
   "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
     "use strict";
     LOGIN_PROLOGUE_ALIAS = "user-login";
     LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
+    ACTION_LOGIN_HELPER = "ACTION_LOGIN_HELPER";
   }
 });
 
@@ -17753,6 +17754,7 @@ function projectPublicAuthorityStatus(status, options = {}) {
     proofOverlay: { active: Boolean(status.bindings.proof) },
     ...loginPrologue ? {
       loginPrologue: {
+        role: ACTION_LOGIN_HELPER,
         state: loginPrologue.state,
         alias: loginPrologue.alias,
         actionId: loginPrologue.actionId,

--- a/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/rn-session.js
@@ -11380,6 +11380,25 @@ var init_secure_state_file = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/login-prologue.js
+function readLoginPrologueOutcome(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    return null;
+  const candidate = value;
+  if (candidate.schemaVersion !== 1 || candidate.alias !== LOGIN_PROLOGUE_ALIAS || candidate.state !== "passed" && candidate.state !== LOGIN_PROLOGUE_BLOCKED || typeof candidate.startedAt !== "string" || typeof candidate.endedAt !== "string" || typeof candidate.elapsedMs !== "number" || !Array.isArray(candidate.steps)) {
+    return null;
+  }
+  return candidate;
+}
+var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED;
+var init_login_prologue = __esm({
+  "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
+    "use strict";
+    LOGIN_PROLOGUE_ALIAS = "user-login";
+    LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
+  }
+});
+
 // packages/rn-dev-agent-core/dist/lifecycle/settle-hash.js
 var init_settle_hash = __esm({
   "packages/rn-dev-agent-core/dist/lifecycle/settle-hash.js"() {
@@ -12022,7 +12041,7 @@ var init_tool_profiles = __esm({
       "maestro_test_all"
     ];
     hybridMutation = ["cdp_auto_login", "cdp_run_e2e_suite"];
-    optionalHybridMutation = ["cdp_run_action"];
+    optionalHybridMutation = ["cdp_login_prologue", "cdp_run_action"];
     nativeDiagnostic = ["cdp_native_errors"];
     cdpRead = [
       "cdp_component_state",
@@ -12191,6 +12210,7 @@ var init_authority_gate = __esm({
     init_registry();
     init_metro_origin();
     init_install_reissue();
+    init_login_prologue();
     init_tool_profiles();
   }
 });
@@ -17610,6 +17630,7 @@ function inspectAuthorityMigration(status, dependencies = {}) {
 
 // packages/rn-dev-agent-core/dist/session/public-status.js
 init_registry();
+init_login_prologue();
 var SELECTED_STATES = /* @__PURE__ */ new Set(["active", "source_bound", "device_claimed", "metro_bound"]);
 var RUNNING_STATES = /* @__PURE__ */ new Set(["device_bound", "runtime_bound", "ready"]);
 function derivePublicPhase(state, buildPending) {
@@ -17686,6 +17707,7 @@ function projectPublicAuthorityStatus(status, options = {}) {
     observedAt: metroTerminal.observedAt
   } : void 0;
   const sandbox = metro?.runtimeEvidenceAuthority === "managed-sandbox-v1" ? "managed-sandbox-v1" : "unavailable";
+  const loginPrologue = readLoginPrologueOutcome(status.bindings.loginPrologue);
   const phase = derivePublicPhase(status.state, Boolean(status.bindings.pendingBuild));
   return {
     available: true,
@@ -17729,6 +17751,20 @@ function projectPublicAuthorityStatus(status, options = {}) {
     proof: Boolean(status.bindings.proof),
     // ADR §5.2 (L3): strict proof is an opt-in overlay outside the four groups, never a group.
     proofOverlay: { active: Boolean(status.bindings.proof) },
+    ...loginPrologue ? {
+      loginPrologue: {
+        state: loginPrologue.state,
+        alias: loginPrologue.alias,
+        actionId: loginPrologue.actionId,
+        startedAt: loginPrologue.startedAt,
+        endedAt: loginPrologue.endedAt,
+        elapsedMs: loginPrologue.elapsedMs,
+        failureCode: loginPrologue.failure?.code,
+        runId: loginPrologue.runRecord?.runId,
+        overrideCount: loginPrologue.overrides?.length ?? 0,
+        lastOverride: loginPrologue.overrides?.at(-1)
+      }
+    } : {},
     ...options.installIdentity ? { installIdentity: options.installIdentity.verdict } : {},
     // A live axis-I refusal means every gated tool refuses too — status must
     // not read `ready` while that is true. A pending re-issue reads ready only

--- a/packages/codex-plugin/rn-dev-agent-core/dist/session-doctor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/session-doctor.js
@@ -11655,6 +11655,14 @@ var init_login_prologue = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/e2e-test.js
+var init_e2e_test = __esm({
+  "packages/rn-dev-agent-core/dist/domain/e2e-test.js"() {
+    "use strict";
+    init_path_safety();
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -11897,6 +11905,7 @@ var init_authority_gate = __esm({
     init_metro_origin();
     init_install_reissue();
     init_login_prologue();
+    init_e2e_test();
     init_tool_profiles();
   }
 });

--- a/packages/codex-plugin/rn-dev-agent-core/dist/session-doctor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/session-doctor.js
@@ -11648,6 +11648,13 @@ var init_install_reissue = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/login-prologue.js
+var init_login_prologue = __esm({
+  "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
+    "use strict";
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -11720,7 +11727,7 @@ var init_tool_profiles = __esm({
       "maestro_test_all"
     ];
     hybridMutation = ["cdp_auto_login", "cdp_run_e2e_suite"];
-    optionalHybridMutation = ["cdp_run_action"];
+    optionalHybridMutation = ["cdp_login_prologue", "cdp_run_action"];
     nativeDiagnostic = ["cdp_native_errors"];
     cdpRead = [
       "cdp_component_state",
@@ -11889,6 +11896,7 @@ var init_authority_gate = __esm({
     init_registry();
     init_metro_origin();
     init_install_reissue();
+    init_login_prologue();
     init_tool_profiles();
   }
 });

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -30239,7 +30239,7 @@ function assertWritableActionFile(filePath) {
 function assertActionMetadataIdentity(filePath, metadata) {
   const fileId = basename7(filePath).replace(/\.ya?ml$/i, "");
   if (metadata.id !== fileId) {
-    throw new Error(`Action metadata id ${metadata.id} does not match filename identity ${fileId}.`);
+    throw new ActionMetadataIdentityError(metadata.id, fileId);
   }
 }
 function withMetadata(action, metadata) {
@@ -30248,7 +30248,7 @@ function withMetadata(action, metadata) {
 function withBody(action, body) {
   return { ...action, body };
 }
-var SaveActionPreconditionError;
+var SaveActionPreconditionError, ActionMetadataIdentityError;
 var init_action_store = __esm({
   "packages/rn-dev-agent-core/dist/domain/action-store.js"() {
     "use strict";
@@ -30264,6 +30264,16 @@ var init_action_store = __esm({
       constructor(filePath) {
         super(`saveAction precondition violated: yaml at ${filePath} has been edited externally since the in-memory action was loaded. The caller must invoke actionWasEditedExternally() first and abort on true (or use saveActionWithCAS for atomic detection). GH #113 contract enforcement.`);
         this.name = "SaveActionPreconditionError";
+      }
+    };
+    ActionMetadataIdentityError = class extends Error {
+      metadataId;
+      fileId;
+      constructor(metadataId, fileId) {
+        super(`Action metadata id ${metadataId} does not match filename identity ${fileId}.`);
+        this.metadataId = metadataId;
+        this.fileId = fileId;
+        this.name = "ActionMetadataIdentityError";
       }
     };
   }
@@ -32053,8 +32063,13 @@ function readLoginPrologueOutcome(value) {
   }
   return candidate;
 }
-function lockedE2eProofAllowed(tool) {
-  return LOCKED_E2E_LOGIN_TOOLS.includes(tool);
+function lockedE2eProofAllowed(tool, args) {
+  if (tool === "cdp_lock_e2e_test")
+    return args.actionId === LOGIN_PROLOGUE_ALIAS;
+  if (tool === "cdp_run_e2e_suite") {
+    return args.pattern === `^${LOGIN_PROLOGUE_ALIAS}$`;
+  }
+  return false;
 }
 function cleanupAllowed(tool, args) {
   if (tool === "cdp_login_prologue")
@@ -32081,7 +32096,7 @@ function tokenMatches(expected, supplied) {
 }
 function inspectLoginPrologueGuard(input) {
   const outcome = readLoginPrologueOutcome(input.binding);
-  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool)) {
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool, input.args)) {
     return { blocked: false };
   }
   return {
@@ -32097,14 +32112,13 @@ function authorizeLoginSupervisorOverride(input) {
 function appendLoginOverrideAudit(outcome, audit) {
   return { ...outcome, overrides: [...outcome.overrides ?? [], audit].slice(-20) };
 }
-var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, ACTION_LOGIN_HELPER, LOCKED_E2E_LOGIN_TOOLS;
+var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, ACTION_LOGIN_HELPER;
 var init_login_prologue = __esm({
   "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
     "use strict";
     LOGIN_PROLOGUE_ALIAS = "user-login";
     LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
     ACTION_LOGIN_HELPER = "ACTION_LOGIN_HELPER";
-    LOCKED_E2E_LOGIN_TOOLS = ["cdp_lock_e2e_test", "cdp_run_e2e_suite"];
   }
 });
 
@@ -80994,6 +81008,9 @@ function parseEnvelope2(result) {
     return { ok: false, code: "BAD_RESPONSE", error: "Action replay returned invalid JSON." };
   }
 }
+function isLoginActionIdentityMismatch(error2) {
+  return error2 instanceof ActionMetadataIdentityError && (error2.fileId === LOGIN_PROLOGUE_ALIAS || error2.metadataId === LOGIN_PROLOGUE_ALIAS);
+}
 function createLoginPrologueHandler(deps) {
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
   return async (args) => {
@@ -81040,8 +81057,16 @@ function createLoginPrologueHandler(deps) {
       });
     };
     try {
-      inventory = await measure("inventory", () => listActions(projectRoot));
-      const action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
+      let action;
+      try {
+        inventory = await measure("inventory", () => listActions(projectRoot));
+        action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
+      } catch (error2) {
+        if (isLoginActionIdentityMismatch(error2)) {
+          return blocked("LOGIN_ACTION_ID_MISMATCH", `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
+        }
+        throw error2;
+      }
       if (!action) {
         return blocked("LOGIN_ACTION_MISSING", `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
       }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32182,7 +32182,8 @@ function loadLockedTest(projectRoot, id) {
   const filePath = e2ePathFor(projectRoot, id);
   if (!existsSync22(filePath))
     return null;
-  return parseLockedTest(readFileSync24(filePath, "utf8"), filePath);
+  const locked = parseLockedTest(readFileSync24(filePath, "utf8"), filePath);
+  return locked?.id === id ? locked : null;
 }
 function discoverLockedTests(projectRoot) {
   const dir = e2eDirFor(projectRoot);
@@ -32200,6 +32201,12 @@ function resolveLockedTestIds(projectRoot, pattern, discover2 = discoverLockedTe
   } catch {
     return ids;
   }
+}
+function resolveLockedTestIdentityIds(projectRoot, pattern, discover2 = discoverLockedTests, load = loadLockedTest) {
+  return resolveLockedTestIds(projectRoot, pattern, discover2).filter((id) => {
+    const locked = load(projectRoot, id);
+    return locked?.id === id && locked.sourceActionId === id;
+  });
 }
 function setResolvedLockedTestIds(args, ids) {
   Object.defineProperty(args, resolvedLockedTestIds, {
@@ -32929,8 +32936,19 @@ function parseLoginPrologueOutcome(result) {
     return null;
   }
 }
-function missingLoginPrologueOutcome() {
+function missingLoginPrologueOutcome(result) {
   const timestamp = (/* @__PURE__ */ new Date()).toISOString();
+  let failure = {
+    code: "LOGIN_PROLOGUE_RESULT_INVALID",
+    detail: "The login prologue returned no valid terminal state."
+  };
+  try {
+    const envelope = JSON.parse(result.content?.[0]?.text ?? "{}");
+    if (envelope.code === "BUSY_FLOW_ACTIVE" && typeof envelope.error === "string") {
+      failure = { code: envelope.code, detail: envelope.error };
+    }
+  } catch {
+  }
   return {
     schemaVersion: 1,
     state: LOGIN_PROLOGUE_BLOCKED,
@@ -32940,10 +32958,7 @@ function missingLoginPrologueOutcome() {
     elapsedMs: 0,
     steps: [],
     inventory: { count: 0, actionIds: [] },
-    failure: {
-      code: "LOGIN_PROLOGUE_RESULT_INVALID",
-      detail: "The login prologue returned no valid terminal state."
-    }
+    failure
   };
 }
 function pendingLoginPrologueOutcome(attemptId) {
@@ -33909,8 +33924,8 @@ function createAuthorityGate(runtime, dependencies) {
         if (tool === "cdp_login_prologue") {
           loginPrologueOutcome = parseLoginPrologueOutcome(result);
           if (!loginPrologueOutcome) {
-            loginPrologueOutcome = missingLoginPrologueOutcome();
-            result = failResult("Login prologue returned no valid terminal state.", "LOGIN_PROLOGUE_BLOCKED", { loginPrologue: loginPrologueOutcome });
+            loginPrologueOutcome = missingLoginPrologueOutcome(result);
+            result = failResult(`Login prologue blocked: ${loginPrologueOutcome.failure?.detail ?? "The login prologue returned no valid terminal state."}`, "LOGIN_PROLOGUE_BLOCKED", { loginPrologue: loginPrologueOutcome });
           }
           if (loginPrologueOutcome.state === LOGIN_PROLOGUE_BLOCKED) {
             const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
@@ -93423,7 +93438,7 @@ var init_index = __esm({
         if (typeof projectRoot !== "string")
           return [];
         args.projectRoot = projectRoot;
-        return resolveLockedTestIds(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
+        return resolveLockedTestIdentityIds(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
       },
       probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
       recoverRuntimeConnection: async (status) => {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32798,6 +32798,23 @@ function missingLoginPrologueOutcome() {
     }
   };
 }
+function pendingLoginPrologueOutcome() {
+  const timestamp = (/* @__PURE__ */ new Date()).toISOString();
+  return {
+    schemaVersion: 1,
+    state: LOGIN_PROLOGUE_BLOCKED,
+    alias: LOGIN_PROLOGUE_ALIAS,
+    startedAt: timestamp,
+    endedAt: timestamp,
+    elapsedMs: 0,
+    steps: [],
+    inventory: { count: 0, actionIds: [] },
+    failure: {
+      code: "LOGIN_PROLOGUE_IN_PROGRESS",
+      detail: "The login prologue has not completed authoritative validation."
+    }
+  };
+}
 function persistLoginPrologueOutcome(runtime, registry2, operation, status, outcome) {
   const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
   const overrides = outcome.overrides ?? priorOutcome?.overrides;
@@ -33067,6 +33084,13 @@ function createAuthorityGate(runtime, dependencies) {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
           overrideRejected: loginDecision.suppliedOverride,
           nextAction: "Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call."
+        });
+      }
+      if (loginDecision.override && profile.kind === "transition") {
+        return failResult("LOGIN_PROLOGUE_BLOCKED: supervisor overrides cannot authorize transition mutations.", "LOGIN_PROLOGUE_BLOCKED", {
+          loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
+          transitionOverrideRejected: true,
+          nextAction: "Repair the exact user-login action and rerun cdp_login_prologue before this transition."
         });
       }
       if (profile.kind === "diagnostic") {
@@ -33689,6 +33713,11 @@ function createAuthorityGate(runtime, dependencies) {
             throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
           }
           const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, loginDecision.audit));
+          operation = persisted.operation;
+          status = persisted.status;
+        }
+        if (tool === "cdp_login_prologue") {
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome());
           operation = persisted.operation;
           status = persisted.status;
         }
@@ -80280,8 +80309,9 @@ function createRunActionHandler(deps = {}) {
     });
     try {
       let atRisk = null;
+      const cdpFallbackForbidden = args.cdpFallbackMode === "forbid";
       const inheritedBlindProbeDisabled = process.env.RN_BLIND_PROBE === "0" || process.env.RN_BLIND_PROBE === "false";
-      const blindProbeDisabled = args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
+      const blindProbeDisabled = cdpFallbackForbidden || args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
       if (args.platform !== "android") {
         const ctx = await blindProbeContext2().catch(() => null);
         if (ctx) {
@@ -80467,7 +80497,7 @@ function createRunActionHandler(deps = {}) {
         }
       }
       let cdpJsFallback;
-      if (failure.kind === "SELECTOR_NOT_FOUND" || failure.kind === "UNKNOWN") {
+      if (!cdpFallbackForbidden && (failure.kind === "SELECTOR_NOT_FOUND" || failure.kind === "UNKNOWN")) {
         const candidate = getReplayDeps(args);
         const replayDeps = candidate && await claimBundleAuthority(args) ? candidate : null;
         const probe = !replayDeps ? null : failure.kind === "SELECTOR_NOT_FOUND" ? failure.selector : firstReplayTestId(cdpReplayYaml, args.params ?? {});
@@ -80948,6 +80978,7 @@ function createLoginPrologueHandler(deps) {
         forceReload: false,
         proofReplay: false,
         blindProbeMode: "forbid",
+        cdpFallbackMode: "forbid",
         trigger: args.trigger ?? "agent"
       });
       let replayResult;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32796,12 +32796,13 @@ function missingLoginPrologueOutcome() {
     }
   };
 }
-function pendingLoginPrologueOutcome() {
+function pendingLoginPrologueOutcome(attemptId) {
   const timestamp = (/* @__PURE__ */ new Date()).toISOString();
   return {
     schemaVersion: 1,
     state: LOGIN_PROLOGUE_BLOCKED,
     alias: LOGIN_PROLOGUE_ALIAS,
+    attemptId,
     startedAt: timestamp,
     endedAt: timestamp,
     elapsedMs: 0,
@@ -33045,6 +33046,8 @@ function createAuthorityGate(runtime, dependencies) {
   return {
     wrap: (tool, handler) => async (...handlerArgs) => {
       const args = handlerArgs[0] && typeof handlerArgs[0] === "object" ? handlerArgs[0] : {};
+      const suppliedSupervisorOverrideToken = typeof args.supervisorOverrideToken === "string" ? args.supervisorOverrideToken : void 0;
+      delete args.supervisorOverrideToken;
       const baseProfile = authorityProfileFor(tool, args);
       let profile = tool === "rn_session" && (args.action === "status" || args.action === "preview_integration" || args.action === "accept_handoff" || args.action === "adopt_stale") ? {
         kind: "diagnostic",
@@ -33075,8 +33078,7 @@ function createAuthorityGate(runtime, dependencies) {
         args,
         mutation: profile.mutation
       });
-      const pendingSupervisorOverrideToken = loginGuard.blocked ? loginGuard.suppliedOverride : void 0;
-      delete args.supervisorOverrideToken;
+      const pendingSupervisorOverrideToken = loginGuard.blocked ? suppliedSupervisorOverrideToken : void 0;
       if (loginGuard.blocked && pendingSupervisorOverrideToken === void 0) {
         return failResult("LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.", "LOGIN_PROLOGUE_BLOCKED", {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
@@ -33354,7 +33356,8 @@ function createAuthorityGate(runtime, dependencies) {
           throw new SessionAuthorityError(initialStatus.code, initialStatus.reason);
         }
         let status = initialStatus;
-        if (tool !== "cdp_login_prologue") {
+        const deferredAdmissionChecks = tool === "cdp_login_prologue" || pendingSupervisorOverrideToken !== void 0;
+        if (!deferredAdmissionChecks) {
           requireCompleteAxes(status, profile);
           bindSessionArguments(status, profile, args, tool);
         }
@@ -33364,10 +33367,29 @@ function createAuthorityGate(runtime, dependencies) {
           profile: profile.axes.join("")
         });
         if (tool === "cdp_login_prologue") {
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome());
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome(operation.operationId));
           operation = persisted.operation;
           status = persisted.status;
           loginPrologueAttemptOperationId = operation.operationId;
+          requireCompleteAxes(status, profile);
+          bindSessionArguments(status, profile, args, tool);
+        }
+        if (pendingSupervisorOverrideToken !== void 0) {
+          const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+          if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
+          }
+          const audit = authorizeLoginSupervisorOverride({
+            expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
+            suppliedOverrideToken: pendingSupervisorOverrideToken,
+            tool
+          });
+          if (!audit) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the supervisor override token was rejected under the operation fence");
+          }
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, audit));
+          operation = persisted.operation;
+          status = persisted.status;
           requireCompleteAxes(status, profile);
           bindSessionArguments(status, profile, args, tool);
         }
@@ -33716,23 +33738,6 @@ function createAuthorityGate(runtime, dependencies) {
             }
           });
         }
-        if (pendingSupervisorOverrideToken !== void 0) {
-          const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
-          if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
-            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
-          }
-          const audit = authorizeLoginSupervisorOverride({
-            expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
-            suppliedOverrideToken: pendingSupervisorOverrideToken,
-            tool
-          });
-          if (!audit) {
-            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the supervisor override token was rejected under the operation fence");
-          }
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, audit));
-          operation = persisted.operation;
-          status = persisted.status;
-        }
         registry2.verifyOperation(operation);
         const snapshotCheckpoint = dependencies.snapshotCaptureCheckpoint?.();
         let result = await registry2.runWithOperation(operation, () => handler(...handlerArgs));
@@ -33919,7 +33924,7 @@ function createAuthorityGate(runtime, dependencies) {
         }
         if (operation && loginPrologueOutcome?.state === "passed") {
           const pendingOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
-          if (operation.operationId !== loginPrologueAttemptOperationId || pendingOutcome?.state !== LOGIN_PROLOGUE_BLOCKED || pendingOutcome.failure?.code !== "LOGIN_PROLOGUE_IN_PROGRESS") {
+          if (operation.operationId !== loginPrologueAttemptOperationId || pendingOutcome?.state !== LOGIN_PROLOGUE_BLOCKED || pendingOutcome.attemptId !== loginPrologueAttemptOperationId || pendingOutcome.failure?.code !== "LOGIN_PROLOGUE_IN_PROGRESS") {
             throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the passing login result does not match the active blocked attempt");
           }
           const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
@@ -76497,7 +76502,7 @@ var init_redact = __esm({
       /\b\d{3}[-.]\d{3}[-.]\d{4}\b/g,
       /\b\d{3}-\d{2}-\d{4}\b/g
     ];
-    AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
+    AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|supervisorOverrideToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
     MAX_STRING_LENGTH = 2e3;
   }
 });
@@ -80103,6 +80108,10 @@ function classifyFailure(failure) {
       return { actionCode: "UNKNOWN", toolCode: void 0 };
   }
 }
+function strictEnginePinDivergence(env) {
+  const status = env.data?.enginePin?.status;
+  return typeof status === "string" && PROVEN_ENGINE_PIN_DIVERGENCE.has(status) ? status : null;
+}
 function parseEnvelope(toolResult, toolName) {
   try {
     return JSON.parse(toolResult.content?.[0]?.text ?? "{}");
@@ -80333,6 +80342,7 @@ function createRunActionHandler(deps = {}) {
     try {
       let atRisk = null;
       const strictExecutor = usesStrictRunActionPolicy(args);
+      const strictRunRecordMeta = (outcome) => strictExecutor && outcome.persistedRunId ? { strictRunRecordId: outcome.persistedRunId } : {};
       const inheritedBlindProbeDisabled = process.env.RN_BLIND_PROBE === "0" || process.env.RN_BLIND_PROBE === "false";
       const blindProbeDisabled = strictExecutor || args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
       if (args.platform !== "android") {
@@ -80433,11 +80443,37 @@ function createRunActionHandler(deps = {}) {
       }));
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, "maestro_run");
-      const firstPassed = firstEnv.ok === true && firstEnv.data?.passed === true;
       const firstOutput = readMaestroOutput(firstEnv);
       const firstFailureDetail = readMaestroFailureDetail(firstEnv, firstOutput);
       const firstDeviceAuthority = readMaestroDeviceAuthority(firstEnv);
       probeDeviceId = firstDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
+      const enginePinDivergence = strictExecutor ? strictEnginePinDivergence(firstEnv) : null;
+      if (enginePinDivergence) {
+        const autoRepair2 = {
+          attempted: false,
+          outcome: "refused",
+          refusedReason: "NOT_REPAIRABLE_KIND",
+          phases: { firstAttemptMs }
+        };
+        const persisted2 = await persistRunWithDevice({
+          timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+          durationMs: Date.now() - t0,
+          status: "fail",
+          failureCode: "UNKNOWN",
+          failureDetail: `Engine pin status ${enginePinDivergence}`,
+          trigger,
+          autoRepair: autoRepair2
+        });
+        return failResult(`cdp_run_action: ${args.actionId} refused strict replay because the engine pin status is ${enginePinDivergence}.`, "ENGINE_PIN_MISMATCH", {
+          actionId: args.actionId,
+          failureKind: "ENGINE_PIN_MISMATCH",
+          enginePin: firstEnv.data?.enginePin,
+          autoRepair: autoRepair2,
+          writes: writeDisclosure("none", persisted2),
+          ...strictRunRecordMeta(persisted2)
+        });
+      }
+      const firstPassed = firstEnv.ok === true && firstEnv.data?.passed === true;
       if (firstEnv.code) {
         const typedCode = firstEnv.code;
         const autoRepair2 = {
@@ -80460,7 +80496,8 @@ function createRunActionHandler(deps = {}) {
           failureKind: typedCode,
           deviceAuthority: firstDeviceAuthority,
           autoRepair: autoRepair2,
-          writes: writeDisclosure("none", persisted2)
+          writes: writeDisclosure("none", persisted2),
+          ...strictRunRecordMeta(persisted2)
         });
       }
       if (firstPassed) {
@@ -80476,9 +80513,17 @@ function createRunActionHandler(deps = {}) {
           trigger,
           autoRepair: autoRepair2
         });
+        if (strictExecutor && persisted2.persistedRunId !== runId) {
+          return failResult(`cdp_run_action: ${args.actionId} passed, but its authoritative RunRecord was not committed.`, "LOAD_FAILED", {
+            actionId: args.actionId,
+            failureKind: "AUTHORITATIVE_RUN_RECORD_MISSING",
+            writes: writeDisclosure("none", persisted2)
+          });
+        }
         return okResult({
           passed: true,
           actionId: args.actionId,
+          ...strictExecutor ? { strictRunRecordId: persisted2.persistedRunId } : {},
           ...proofReplay ? { proofReplay: true } : {},
           ...replaySuccessEvidence(firstEnv),
           repair: autoRepair2,
@@ -80608,7 +80653,7 @@ function createRunActionHandler(deps = {}) {
           phases: { firstAttemptMs }
         };
         const { actionCode, toolCode } = classifyFailure(failure);
-        await persistRunWithDevice({
+        const persisted2 = await persistRunWithDevice({
           timestamp: (/* @__PURE__ */ new Date()).toISOString(),
           durationMs: Date.now() - t0,
           status: "fail",
@@ -80628,7 +80673,8 @@ function createRunActionHandler(deps = {}) {
           firstAttemptOutput: boundedOutput(firstOutput),
           terminal: readMaestroTerminal(firstEnv),
           runnerResume: firstEnv.meta?.runnerResume,
-          ...cdpJsFallback ? { cdpJsFallback } : {}
+          ...cdpJsFallback ? { cdpJsFallback } : {},
+          ...strictRunRecordMeta(persisted2)
         };
         let message = failure.kind === "WDA_BOOTSTRAP_FAILED" ? `cdp_run_action: ${args.actionId} failed (WDA_BOOTSTRAP_FAILED) before the first replay step: ${failure.detail}. Re-run the replay (bootstrap retries itself); check network access; diagnose the pin-cache runner with ${PINNED_RUNNER_DIAGNOSE_HINT}. Supported correction: ${PINNED_RUNNER_INSTALL_HINT}. Never invoke PATH, ~/.maestro-runner, maestro-cli, or manual login. No preparation or cache mutation was attempted.` : `cdp_run_action: ${args.actionId} failed (${failure.kind})${autoRepairEnabled ? " \u2014 failure not auto-repairable" : " \u2014 auto-repair disabled"}: ${firstFailureDetail}`;
         if (cdpJsFallback?.reason === "cdp-unreachable") {
@@ -80854,7 +80900,7 @@ async function persistRun(actionId, projectRoot, record2) {
           path: fresh.filePath
         }
       });
-      return { promoted, promotionRefused: promotionRefused2 };
+      return { promoted, promotionRefused: promotionRefused2, persistedRunId: record2.runId };
     };
     const promotionRefused = promotes && !promoteActionRuntimeWithCAS(fresh, nextState).ok;
     if (promotes && !promotionRefused)
@@ -80868,7 +80914,7 @@ async function persistRun(actionId, projectRoot, record2) {
   }
   return { promoted: false, promotionRefused: false };
 }
-var strictRunActionPolicy, OUTPUT_BUDGET, OUTPUT_ELISION;
+var strictRunActionPolicy, PROVEN_ENGINE_PIN_DIVERGENCE, OUTPUT_BUDGET, OUTPUT_ELISION;
 var init_run_action = __esm({
   "packages/rn-dev-agent-core/dist/tools/run-action.js"() {
     "use strict";
@@ -80891,6 +80937,7 @@ var init_run_action = __esm({
     init_action_engine_compat();
     init_engine_pin();
     strictRunActionPolicy = /* @__PURE__ */ Symbol("strictRunActionPolicy");
+    PROVEN_ENGINE_PIN_DIVERGENCE = /* @__PURE__ */ new Set(["drift-newer", "drift-older", "checksum-mismatch"]);
     OUTPUT_BUDGET = 500;
     OUTPUT_ELISION = "\n\u2026\n";
   }
@@ -80994,7 +81041,6 @@ function createLoginPrologueHandler(deps) {
       if (action.metadata.id !== LOGIN_PROLOGUE_ALIAS) {
         return blocked("LOGIN_ACTION_ID_MISMATCH", `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
       }
-      const priorRunIds = new Set(action.state.runHistory.map((record2) => record2.runId).filter((runId) => typeof runId === "string"));
       const replayArgs = Object.create(Object.getPrototypeOf(args), Object.getOwnPropertyDescriptors(args));
       Object.assign(replayArgs, {
         actionId: LOGIN_PROLOGUE_ALIAS,
@@ -81015,15 +81061,17 @@ function createLoginPrologueHandler(deps) {
         });
       }
       const replay = parseEnvelope2(replayResult);
+      const strictRunRecordId = typeof replay.data?.strictRunRecordId === "string" ? replay.data.strictRunRecordId : typeof replay.meta?.strictRunRecordId === "string" ? replay.meta.strictRunRecordId : void 0;
       let freshRecord;
       await measure("verify-run-record", async () => {
         const reloaded = loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS);
-        freshRecord = reloaded?.state.runHistory.slice().reverse().find((record2) => typeof record2.runId === "string" && !priorRunIds.has(record2.runId));
+        freshRecord = strictRunRecordId ? reloaded?.state.runHistory.find((record2) => record2.runId === strictRunRecordId) : void 0;
       });
       if (replay.ok !== true || replay.data?.passed !== true) {
-        return blocked(replay.code ?? String(replay.data?.failureKind ?? "ACTION_REPLAY_FAILED"), "The saved login action did not pass; exploratory login is now terminally blocked.", { actionId: LOGIN_PROLOGUE_ALIAS, ...freshRecord ? { runRecord: freshRecord } : {} });
+        const metaFailureKind = replay.meta?.failureKind;
+        return blocked(replay.code ?? (typeof metaFailureKind === "string" ? metaFailureKind : freshRecord?.failureCode ?? "ACTION_REPLAY_FAILED"), "The saved login action did not pass; exploratory login is now terminally blocked.", { actionId: LOGIN_PROLOGUE_ALIAS, ...freshRecord ? { runRecord: freshRecord } : {} });
       }
-      if (!freshRecord || freshRecord.status !== "pass") {
+      if (!strictRunRecordId || !freshRecord || freshRecord.status !== "pass") {
         return blocked("AUTHORITATIVE_RUN_RECORD_MISSING", "The saved login action reported success without a fresh passing RunRecord.", { actionId: LOGIN_PROLOGUE_ALIAS });
       }
       const outcome = finish("passed", {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32053,6 +32053,9 @@ function readLoginPrologueOutcome(value) {
   }
   return candidate;
 }
+function lockedE2eProofAllowed(tool) {
+  return LOCKED_E2E_LOGIN_TOOLS.includes(tool);
+}
 function cleanupAllowed(tool, args) {
   if (tool === "cdp_login_prologue")
     return true;
@@ -32078,7 +32081,7 @@ function tokenMatches(expected, supplied) {
 }
 function inspectLoginPrologueGuard(input) {
   const outcome = readLoginPrologueOutcome(input.binding);
-  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args)) {
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool)) {
     return { blocked: false };
   }
   return {
@@ -32094,12 +32097,14 @@ function authorizeLoginSupervisorOverride(input) {
 function appendLoginOverrideAudit(outcome, audit) {
   return { ...outcome, overrides: [...outcome.overrides ?? [], audit].slice(-20) };
 }
-var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED;
+var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, ACTION_LOGIN_HELPER, LOCKED_E2E_LOGIN_TOOLS;
 var init_login_prologue = __esm({
   "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
     "use strict";
     LOGIN_PROLOGUE_ALIAS = "user-login";
     LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
+    ACTION_LOGIN_HELPER = "ACTION_LOGIN_HELPER";
+    LOCKED_E2E_LOGIN_TOOLS = ["cdp_lock_e2e_test", "cdp_run_e2e_suite"];
   }
 });
 
@@ -73546,6 +73551,7 @@ function projectPublicAuthorityStatus(status, options = {}) {
     proofOverlay: { active: Boolean(status.bindings.proof) },
     ...loginPrologue ? {
       loginPrologue: {
+        role: ACTION_LOGIN_HELPER,
         state: loginPrologue.state,
         alias: loginPrologue.alias,
         actionId: loginPrologue.actionId,
@@ -81014,6 +81020,7 @@ function createLoginPrologueHandler(deps) {
       return {
         schemaVersion: 1,
         state,
+        role: ACTION_LOGIN_HELPER,
         alias: LOGIN_PROLOGUE_ALIAS,
         startedAt: prologueStarted.toISOString(),
         endedAt: ended.toISOString(),
@@ -94409,7 +94416,7 @@ var init_index = __esm({
       blindProbeMode: external_exports.enum(["inherit", "allow", "forbid"]).optional().describe("Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged."),
       params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).")
     }, runActionHandler);
-    trackedTool("cdp_login_prologue", "Inventory learned actions, replay the exact user-login action strictly, and require a fresh passing RunRecord before lifting the session login gate.", {
+    trackedTool("cdp_login_prologue", "Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; not PR proof.", {
       projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
       platform: external_exports.enum(["ios", "android"]).optional().describe("Force a platform; otherwise use the authority-bound device."),
       appFile: external_exports.string().optional().describe("iOS app artifact used only when the saved action contains clearState."),

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32076,22 +32076,20 @@ function tokenMatches(expected, supplied) {
   const suppliedHash = createHash12("sha256").update(supplied).digest();
   return timingSafeEqual5(expectedHash, suppliedHash);
 }
-function evaluateLoginPrologueGuard(input) {
+function inspectLoginPrologueGuard(input) {
   const outcome = readLoginPrologueOutcome(input.binding);
-  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation) {
-    return { allowed: true, override: false };
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args)) {
+    return { blocked: false };
   }
-  if (cleanupAllowed(input.tool, input.args))
-    return { allowed: true, override: false };
-  const supplied = typeof input.args.supervisorOverrideToken === "string" ? input.args.supervisorOverrideToken : void 0;
-  if (tokenMatches(input.expectedOverrideToken, supplied)) {
-    return {
-      allowed: true,
-      override: true,
-      audit: { tool: input.tool, usedAt: (input.now ?? (() => /* @__PURE__ */ new Date()))().toISOString() }
-    };
-  }
-  return { allowed: false, suppliedOverride: supplied !== void 0 };
+  return {
+    blocked: true,
+    suppliedOverride: typeof input.args.supervisorOverrideToken === "string" ? input.args.supervisorOverrideToken : void 0
+  };
+}
+function authorizeLoginSupervisorOverride(input) {
+  if (!tokenMatches(input.expectedOverrideToken, input.suppliedOverrideToken))
+    return null;
+  return { tool: input.tool, usedAt: (input.now ?? (() => /* @__PURE__ */ new Date()))().toISOString() };
 }
 function appendLoginOverrideAudit(outcome, audit) {
   return { ...outcome, overrides: [...outcome.overrides ?? [], audit].slice(-20) };
@@ -33071,22 +33069,22 @@ function createAuthorityGate(runtime, dependencies) {
         liveBundleProbe: tool === "proof_capture"
       } : baseProfile;
       const runtimeStatus = runtime.status();
-      const loginDecision = evaluateLoginPrologueGuard({
+      const loginGuard = inspectLoginPrologueGuard({
         binding: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
         tool,
         args,
-        mutation: profile.mutation,
-        expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.()
+        mutation: profile.mutation
       });
+      const pendingSupervisorOverrideToken = loginGuard.blocked ? loginGuard.suppliedOverride : void 0;
       delete args.supervisorOverrideToken;
-      if (!loginDecision.allowed) {
+      if (loginGuard.blocked && pendingSupervisorOverrideToken === void 0) {
         return failResult("LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.", "LOGIN_PROLOGUE_BLOCKED", {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
-          overrideRejected: loginDecision.suppliedOverride,
+          overrideRejected: false,
           nextAction: "Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call."
         });
       }
-      if (loginDecision.override && profile.kind === "transition") {
+      if (loginGuard.blocked && profile.kind === "transition") {
         return failResult("LOGIN_PROLOGUE_BLOCKED: supervisor overrides cannot authorize transition mutations.", "LOGIN_PROLOGUE_BLOCKED", {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
           transitionOverrideRejected: true,
@@ -33347,6 +33345,7 @@ function createAuthorityGate(runtime, dependencies) {
       let retainProofCleanupFence = false;
       let publishedProofFinalize = false;
       let stagedRuntimeRelaunch;
+      let loginPrologueAttemptOperationId = null;
       try {
         const available = runtime.requireAvailable();
         registry2 = available.registry;
@@ -33355,13 +33354,23 @@ function createAuthorityGate(runtime, dependencies) {
           throw new SessionAuthorityError(initialStatus.code, initialStatus.reason);
         }
         let status = initialStatus;
-        requireCompleteAxes(status, profile);
-        bindSessionArguments(status, profile, args, tool);
+        if (tool !== "cdp_login_prologue") {
+          requireCompleteAxes(status, profile);
+          bindSessionArguments(status, profile, args, tool);
+        }
         operation = registry2.beginOperation(available.session, {
           operationId: randomUUID5(),
           tool,
           profile: profile.axes.join("")
         });
+        if (tool === "cdp_login_prologue") {
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome());
+          operation = persisted.operation;
+          status = persisted.status;
+          loginPrologueAttemptOperationId = operation.operationId;
+          requireCompleteAxes(status, profile);
+          bindSessionArguments(status, profile, args, tool);
+        }
         const preflightRecovery = await reconcileRecoverableRuntime(runtime, dependencies, registry2, operation, status, profile, true);
         operation = preflightRecovery.operation;
         status = preflightRecovery.status;
@@ -33707,17 +33716,20 @@ function createAuthorityGate(runtime, dependencies) {
             }
           });
         }
-        if (loginDecision.override) {
+        if (pendingSupervisorOverrideToken !== void 0) {
           const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
           if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
             throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
           }
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, loginDecision.audit));
-          operation = persisted.operation;
-          status = persisted.status;
-        }
-        if (tool === "cdp_login_prologue") {
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, pendingLoginPrologueOutcome());
+          const audit = authorizeLoginSupervisorOverride({
+            expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
+            suppliedOverrideToken: pendingSupervisorOverrideToken,
+            tool
+          });
+          if (!audit) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the supervisor override token was rejected under the operation fence");
+          }
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, audit));
           operation = persisted.operation;
           status = persisted.status;
         }
@@ -33906,6 +33918,10 @@ function createAuthorityGate(runtime, dependencies) {
           registry2.commitPlatformAuthorityReceipts(operation);
         }
         if (operation && loginPrologueOutcome?.state === "passed") {
+          const pendingOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+          if (operation.operationId !== loginPrologueAttemptOperationId || pendingOutcome?.state !== LOGIN_PROLOGUE_BLOCKED || pendingOutcome.failure?.code !== "LOGIN_PROLOGUE_IN_PROGRESS") {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the passing login result does not match the active blocked attempt");
+          }
           const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
           operation = persisted.operation;
           status = persisted.status;
@@ -80054,6 +80070,13 @@ var init_runtime = __esm({
 
 // packages/rn-dev-agent-core/dist/tools/run-action.js
 import { randomUUID as randomUUID9 } from "node:crypto";
+function sealStrictRunAction(args) {
+  Object.defineProperty(args, strictRunActionPolicy, { value: true });
+  return args;
+}
+function usesStrictRunActionPolicy(args) {
+  return args[strictRunActionPolicy] === true;
+}
 function boundInstallReceipt() {
   try {
     const status = getWorkerAuthorityRuntime().status();
@@ -80309,9 +80332,9 @@ function createRunActionHandler(deps = {}) {
     });
     try {
       let atRisk = null;
-      const cdpFallbackForbidden = args.cdpFallbackMode === "forbid";
+      const strictExecutor = usesStrictRunActionPolicy(args);
       const inheritedBlindProbeDisabled = process.env.RN_BLIND_PROBE === "0" || process.env.RN_BLIND_PROBE === "false";
-      const blindProbeDisabled = cdpFallbackForbidden || args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
+      const blindProbeDisabled = strictExecutor || args.blindProbeMode === "forbid" || args.blindProbeMode !== "allow" && inheritedBlindProbeDisabled;
       if (args.platform !== "android") {
         const ctx = await blindProbeContext2().catch(() => null);
         if (ctx) {
@@ -80497,7 +80520,7 @@ function createRunActionHandler(deps = {}) {
         }
       }
       let cdpJsFallback;
-      if (!cdpFallbackForbidden && (failure.kind === "SELECTOR_NOT_FOUND" || failure.kind === "UNKNOWN")) {
+      if (!strictExecutor && (failure.kind === "SELECTOR_NOT_FOUND" || failure.kind === "UNKNOWN")) {
         const candidate = getReplayDeps(args);
         const replayDeps = candidate && await claimBundleAuthority(args) ? candidate : null;
         const probe = !replayDeps ? null : failure.kind === "SELECTOR_NOT_FOUND" ? failure.selector : firstReplayTestId(cdpReplayYaml, args.params ?? {});
@@ -80845,7 +80868,7 @@ async function persistRun(actionId, projectRoot, record2) {
   }
   return { promoted: false, promotionRefused: false };
 }
-var OUTPUT_BUDGET, OUTPUT_ELISION;
+var strictRunActionPolicy, OUTPUT_BUDGET, OUTPUT_ELISION;
 var init_run_action = __esm({
   "packages/rn-dev-agent-core/dist/tools/run-action.js"() {
     "use strict";
@@ -80867,6 +80890,7 @@ var init_run_action = __esm({
     init_resolve_ios_app_file();
     init_action_engine_compat();
     init_engine_pin();
+    strictRunActionPolicy = /* @__PURE__ */ Symbol("strictRunActionPolicy");
     OUTPUT_BUDGET = 500;
     OUTPUT_ELISION = "\n\u2026\n";
   }
@@ -80978,9 +81002,9 @@ function createLoginPrologueHandler(deps) {
         forceReload: false,
         proofReplay: false,
         blindProbeMode: "forbid",
-        cdpFallbackMode: "forbid",
         trigger: args.trigger ?? "agent"
       });
+      sealStrictRunAction(replayArgs);
       let replayResult;
       try {
         replayResult = await measure("replay", () => deps.runAction(replayArgs));
@@ -81025,6 +81049,7 @@ var init_login_prologue2 = __esm({
     init_action_store();
     init_login_prologue();
     init_utils();
+    init_run_action();
   }
 });
 

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32085,7 +32085,7 @@ function cleanupAllowed(tool, args) {
   if (tool === "proof_capture" && (args.action === "discard" || args.action === "status")) {
     return true;
   }
-  return tool === "rn_session" && (args.action === "release" || args.action === "stop_metro" || args.action === "cancel_handoff" || args.action === "status");
+  return tool === "rn_session" && (args.action === "release" || args.action === "stop_metro" || args.action === "cancel_handoff" || args.action === "recover_arbiter" && args.confirmed === true || args.action === "status");
 }
 function tokenMatches(expected, supplied) {
   if (!expected || expected.length < 16 || !supplied || supplied.length < 16)

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -23988,8 +23988,8 @@ var init_registry = __esm({
           const handoff = this.#database.prepare("SELECT token_hash, consumed_ms FROM handoffs WHERE handoff_id = ?").get(input.handoffId);
           const expected = Buffer.from(typeof handoff?.token_hash === "string" ? handoff.token_hash : "", "hex");
           const actual = createHash8("sha256").update(input.token).digest();
-          const tokenMatches = expected.length === actual.length && timingSafeEqual4(expected, actual);
-          if (!row || row.state !== "handoff_cleanup" || row.claim_epoch !== target.claimEpoch || row.worker_instance !== input.targetInstance || cleanup?.handoffId !== input.handoffId || cleanup?.targetSessionId !== target.sessionId || cleanup?.targetClaimEpoch !== target.claimEpoch || typeof handoff?.consumed_ms !== "number" || !tokenMatches) {
+          const tokenMatches2 = expected.length === actual.length && timingSafeEqual4(expected, actual);
+          if (!row || row.state !== "handoff_cleanup" || row.claim_epoch !== target.claimEpoch || row.worker_instance !== input.targetInstance || cleanup?.handoffId !== input.handoffId || cleanup?.targetSessionId !== target.sessionId || cleanup?.targetClaimEpoch !== target.claimEpoch || typeof handoff?.consumed_ms !== "number" || !tokenMatches2) {
             throw new SessionAuthorityError("HANDOFF_NOT_AUTHORIZED", "handoff cleanup resumption requires the original handoff capability");
           }
         });
@@ -32042,6 +32042,69 @@ var init_install_reissue = __esm({
   }
 });
 
+// packages/rn-dev-agent-core/dist/domain/login-prologue.js
+import { createHash as createHash12, timingSafeEqual as timingSafeEqual5 } from "node:crypto";
+function readLoginPrologueOutcome(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    return null;
+  const candidate = value;
+  if (candidate.schemaVersion !== 1 || candidate.alias !== LOGIN_PROLOGUE_ALIAS || candidate.state !== "passed" && candidate.state !== LOGIN_PROLOGUE_BLOCKED || typeof candidate.startedAt !== "string" || typeof candidate.endedAt !== "string" || typeof candidate.elapsedMs !== "number" || !Array.isArray(candidate.steps)) {
+    return null;
+  }
+  return candidate;
+}
+function cleanupAllowed(tool, args) {
+  if (tool === "cdp_login_prologue")
+    return true;
+  if (tool === "cdp_disconnect")
+    return true;
+  if (tool === "device_snapshot" && args.action === "close")
+    return true;
+  if (tool === "device_record" && (args.action === "stop" || args.action === "status"))
+    return true;
+  if (tool === "observe" && (args.action === "stop" || args.action === "status"))
+    return true;
+  if (tool === "proof_capture" && (args.action === "discard" || args.action === "status")) {
+    return true;
+  }
+  return tool === "rn_session" && (args.action === "release" || args.action === "stop_metro" || args.action === "cancel_handoff" || args.action === "status");
+}
+function tokenMatches(expected, supplied) {
+  if (!expected || expected.length < 16 || !supplied || supplied.length < 16)
+    return false;
+  const expectedHash = createHash12("sha256").update(expected).digest();
+  const suppliedHash = createHash12("sha256").update(supplied).digest();
+  return timingSafeEqual5(expectedHash, suppliedHash);
+}
+function evaluateLoginPrologueGuard(input) {
+  const outcome = readLoginPrologueOutcome(input.binding);
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation) {
+    return { allowed: true, override: false };
+  }
+  if (cleanupAllowed(input.tool, input.args))
+    return { allowed: true, override: false };
+  const supplied = typeof input.args.supervisorOverrideToken === "string" ? input.args.supervisorOverrideToken : void 0;
+  if (tokenMatches(input.expectedOverrideToken, supplied)) {
+    return {
+      allowed: true,
+      override: true,
+      audit: { tool: input.tool, usedAt: (input.now ?? (() => /* @__PURE__ */ new Date()))().toISOString() }
+    };
+  }
+  return { allowed: false, suppliedOverride: supplied !== void 0 };
+}
+function appendLoginOverrideAudit(outcome, audit) {
+  return { ...outcome, overrides: [...outcome.overrides ?? [], audit].slice(-20) };
+}
+var LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED;
+var init_login_prologue = __esm({
+  "packages/rn-dev-agent-core/dist/domain/login-prologue.js"() {
+    "use strict";
+    LOGIN_PROLOGUE_ALIAS = "user-login";
+    LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
+  }
+});
+
 // packages/rn-dev-agent-core/dist/session/tool-profiles.js
 function facetsOf(groups, narrowing = {}) {
   const facets = new Set(groups.flatMap((group) => [...groupFacets[group]]));
@@ -32232,7 +32295,7 @@ var init_tool_profiles = __esm({
       "maestro_test_all"
     ];
     hybridMutation = ["cdp_auto_login", "cdp_run_e2e_suite"];
-    optionalHybridMutation = ["cdp_run_action"];
+    optionalHybridMutation = ["cdp_login_prologue", "cdp_run_action"];
     nativeDiagnostic = ["cdp_native_errors"];
     inlineMaestroMutation = /* @__PURE__ */ new Set([
       "device_accept_system_dialog",
@@ -32710,6 +32773,34 @@ function authorityFailure(error2) {
   const code = /^([A-Z][A-Z0-9_]+):/.exec(message)?.[1];
   return failResult(message, code ?? "AUTHORITY_LOST_DURING_OPERATION");
 }
+function parseLoginPrologueOutcome(result) {
+  try {
+    const envelope = JSON.parse(result.content?.[0]?.text ?? "{}");
+    return readLoginPrologueOutcome(envelope.data ?? envelope.meta?.loginPrologue);
+  } catch {
+    return null;
+  }
+}
+function missingLoginPrologueOutcome() {
+  const timestamp = (/* @__PURE__ */ new Date()).toISOString();
+  return {
+    schemaVersion: 1,
+    state: LOGIN_PROLOGUE_BLOCKED,
+    alias: LOGIN_PROLOGUE_ALIAS,
+    startedAt: timestamp,
+    endedAt: timestamp,
+    elapsedMs: 0,
+    steps: [],
+    inventory: { count: 0, actionIds: [] },
+    failure: {
+      code: "LOGIN_PROLOGUE_RESULT_INVALID",
+      detail: "The login prologue returned no valid terminal state."
+    }
+  };
+}
+function isActionReplayTool(tool) {
+  return tool === "cdp_run_action" || tool === "cdp_login_prologue";
+}
 function authorityErrorCode(error2) {
   return error2 instanceof SessionAuthorityError ? error2.code : /^([A-Z][A-Z0-9_]+):/.exec(error2 instanceof Error ? error2.message : String(error2))?.[1];
 }
@@ -32945,10 +33036,43 @@ function createAuthorityGate(runtime, dependencies) {
         mutation: true,
         liveBundleProbe: tool === "proof_capture"
       } : baseProfile;
+      let runtimeStatus = runtime.status();
+      const loginDecision = evaluateLoginPrologueGuard({
+        binding: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
+        tool,
+        args,
+        mutation: profile.mutation,
+        expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.()
+      });
+      delete args.supervisorOverrideToken;
+      if (!loginDecision.allowed) {
+        return failResult("LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.", "LOGIN_PROLOGUE_BLOCKED", {
+          loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
+          overrideRejected: loginDecision.suppliedOverride,
+          nextAction: "Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call."
+        });
+      }
+      if (loginDecision.override) {
+        try {
+          const available = runtime.requireAvailable();
+          const current = runtime.status();
+          const outcome = current.available ? readLoginPrologueOutcome(current.bindings.loginPrologue) : null;
+          if (!outcome) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
+          }
+          available.registry.updateBindings(available.session, {
+            bindings: {
+              loginPrologue: appendLoginOverrideAudit(outcome, loginDecision.audit)
+            }
+          });
+          runtimeStatus = runtime.status();
+        } catch (error2) {
+          return authorityFailure(error2);
+        }
+      }
       if (profile.kind === "diagnostic") {
         return addMeta(await handler(...handlerArgs), { authoritative: false });
       }
-      const runtimeStatus = runtime.status();
       if (runtimeStatus.available && runtimeStatus.state === "blocked") {
         return authorityFailure(runtime.blockedContenderError());
       }
@@ -33562,7 +33686,15 @@ function createAuthorityGate(runtime, dependencies) {
         }
         registry2.verifyOperation(operation);
         const snapshotCheckpoint = dependencies.snapshotCaptureCheckpoint?.();
-        const result = await registry2.runWithOperation(operation, () => handler(...handlerArgs));
+        let result = await registry2.runWithOperation(operation, () => handler(...handlerArgs));
+        let loginPrologueOutcome = null;
+        if (tool === "cdp_login_prologue") {
+          loginPrologueOutcome = parseLoginPrologueOutcome(result);
+          if (!loginPrologueOutcome) {
+            loginPrologueOutcome = missingLoginPrologueOutcome();
+            result = failResult("Login prologue returned no valid terminal state.", "LOGIN_PROLOGUE_BLOCKED", { loginPrologue: loginPrologueOutcome });
+          }
+        }
         let runtimeTargetChanged = false;
         const postHandlerRecovery = await reconcileRecoverableRuntime(runtime, dependencies, registry2, operation, status, profile, resultSucceeded(result));
         operation = postHandlerRecovery.operation;
@@ -33585,7 +33717,7 @@ function createAuthorityGate(runtime, dependencies) {
         }
         publishedProofFinalize = tool === "proof_capture" && args.action === "finalize" && resultIsCanonicalSuccess(result);
         const directRuntimeReset = tool === "cdp_reload" || tool === "cdp_restart";
-        const nestedRuntimeReset = tool === "cdp_run_e2e_suite" || tool === "cdp_auto_login" || tool === "cdp_nav_graph" && args.action === "go" || tool === "cdp_run_action" && (optionalBundleClaimed || optionalBundleRecoveryFailed);
+        const nestedRuntimeReset = tool === "cdp_run_e2e_suite" || tool === "cdp_auto_login" || tool === "cdp_nav_graph" && args.action === "go" || isActionReplayTool(tool) && (optionalBundleClaimed || optionalBundleRecoveryFailed);
         const reconcilesRuntimeTarget = directRuntimeReset || nestedRuntimeReset;
         let authorityInvalidated = false;
         if (directRuntimeReset && !resultSucceeded(result)) {
@@ -33600,7 +33732,7 @@ function createAuthorityGate(runtime, dependencies) {
           const metro = status.bindings.metro;
           let bundle = null;
           try {
-            if (tool === "cdp_run_action" && optionalBundleRecoveryFailed) {
+            if (isActionReplayTool(tool) && optionalBundleRecoveryFailed) {
               throw new SessionAuthorityError("BUNDLE_HANDSHAKE_UNAVAILABLE", "reactive bundle authority did not verify");
             }
             if (!dependencies.refreshRuntimeBinding) {
@@ -33620,7 +33752,7 @@ function createAuthorityGate(runtime, dependencies) {
                 nextAction: 'Run rn_session action "pin_dev_client" before another CDP operation.'
               });
             }
-            if (tool === "cdp_run_action" && !optionalBundleClaimed) {
+            if (isActionReplayTool(tool) && !optionalBundleClaimed) {
               authorityInvalidated = true;
             } else {
               throw error2;
@@ -33682,6 +33814,22 @@ function createAuthorityGate(runtime, dependencies) {
           axes: [...runnerAwareReceiptProfile.axes, "M", "A"]
         } : runnerAwareReceiptProfile;
         const controllerGenerationAdvanced = operation.authorityVersion !== initialOperationAuthorityVersion;
+        if (loginPrologueOutcome) {
+          const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+          operation = registry2.replaceBindingsDuringOperation(operation, {
+            bindings: {
+              loginPrologue: {
+                ...loginPrologueOutcome,
+                ...priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}
+              }
+            }
+          });
+          const loginStatus = runtime.status();
+          if (!loginStatus.available) {
+            throw new SessionAuthorityError(loginStatus.code, loginStatus.reason);
+          }
+          status = loginStatus;
+        }
         registry2.verifyOperation(operation);
         for (const observation of allBefore) {
           if (controllerGenerationAdvanced && observation.axis === "C")
@@ -33779,6 +33927,7 @@ var init_authority_gate = __esm({
     init_registry();
     init_metro_origin();
     init_install_reissue();
+    init_login_prologue();
     init_tool_profiles();
     optionalBundleAdmission = /* @__PURE__ */ Symbol("optionalBundleAdmission");
     managedNativeOrigin = /* @__PURE__ */ Symbol("managedNativeOrigin");
@@ -40472,7 +40621,7 @@ var init_process_cleanup = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/session/startup-cleanup.js
-import { createHash as createHash12 } from "node:crypto";
+import { createHash as createHash13 } from "node:crypto";
 import { join as join35 } from "node:path";
 function startupCleanupFailureMessage() {
   return "rn-dev-agent startup cleanup failed: STARTUP_CLEANUP_FAILED\n";
@@ -40583,7 +40732,7 @@ function restoreDeadOwnerIntegration(input, prior, plan, dependencies) {
 function verifiedDeadOwnerManifestSource(appRoot, binding, manifestSha256) {
   if (!/^[0-9a-f]{64}$/.test(manifestSha256))
     return void 0;
-  const verified = (candidate) => typeof candidate === "string" && createHash12("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
+  const verified = (candidate) => typeof candidate === "string" && createHash13("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
   let liveManifest;
   try {
     liveManifest = readPackageIntegrationInputs(appRoot).manifest ?? void 0;
@@ -64872,7 +65021,7 @@ var require_websocket = __commonJS({
     var http = __require("http");
     var net = __require("net");
     var tls = __require("tls");
-    var { randomBytes: randomBytes9, createHash: createHash24 } = __require("crypto");
+    var { randomBytes: randomBytes9, createHash: createHash25 } = __require("crypto");
     var { Duplex, Readable } = __require("stream");
     var { URL: URL2 } = __require("url");
     var PerMessageDeflate2 = require_permessage_deflate();
@@ -65540,7 +65689,7 @@ var require_websocket = __commonJS({
           abortHandshake(websocket, socket, "Invalid Upgrade header");
           return;
         }
-        const digest3 = createHash24("sha1").update(key + GUID).digest("base64");
+        const digest3 = createHash25("sha1").update(key + GUID).digest("base64");
         if (res.headers["sec-websocket-accept"] !== digest3) {
           abortHandshake(websocket, socket, "Invalid Sec-WebSocket-Accept header");
           return;
@@ -65909,7 +66058,7 @@ var require_websocket_server = __commonJS({
     var EventEmitter = __require("events");
     var http = __require("http");
     var { Duplex } = __require("stream");
-    var { createHash: createHash24 } = __require("crypto");
+    var { createHash: createHash25 } = __require("crypto");
     var extension2 = require_extension();
     var PerMessageDeflate2 = require_permessage_deflate();
     var subprotocol2 = require_subprotocol();
@@ -66216,7 +66365,7 @@ var require_websocket_server = __commonJS({
           );
         }
         if (this._state > RUNNING) return abortHandshake(socket, 503);
-        const digest3 = createHash24("sha1").update(key + GUID).digest("base64");
+        const digest3 = createHash25("sha1").update(key + GUID).digest("base64");
         const headers = [
           "HTTP/1.1 101 Switching Protocols",
           "Upgrade: websocket",
@@ -66996,7 +67145,7 @@ var init_events_client = __esm({
 
 // packages/rn-dev-agent-core/dist/cdp/multiplexer.js
 import { createServer as createServer2 } from "node:http";
-import { randomBytes as randomBytes7, timingSafeEqual as timingSafeEqual5 } from "node:crypto";
+import { randomBytes as randomBytes7, timingSafeEqual as timingSafeEqual6 } from "node:crypto";
 import { Buffer as Buffer2 } from "node:buffer";
 function generateCapabilityToken() {
   return randomBytes7(32).toString("base64url");
@@ -67015,7 +67164,7 @@ function verifyConsumerPath(reqUrl, expectedToken) {
   const b = Buffer2.from(expectedToken);
   if (a.length !== b.length)
     return false;
-  return timingSafeEqual5(a, b);
+  return timingSafeEqual6(a, b);
 }
 function parseRNVersion(raw) {
   if (raw === null || raw === void 0)
@@ -73130,7 +73279,7 @@ var init_install_identity_inspection = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/session/migration-diagnostic.js
-import { createHash as createHash14 } from "node:crypto";
+import { createHash as createHash15 } from "node:crypto";
 import { existsSync as existsSync29, readFileSync as readFileSync31 } from "node:fs";
 import { join as join40 } from "node:path";
 function readPackageIntegrationManifest(appRoot, dependencies) {
@@ -73179,7 +73328,7 @@ function inspectAuthorityMigration(status, dependencies = {}) {
   const integrationBinding = status.bindings.packageIntegration;
   let bindingDiagnostic = null;
   if (integrationBinding) {
-    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash14("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
+    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash15("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
     const manifestAvailable = manifestVerified(onDiskManifestText) || manifestVerified(integrationBinding.restoration?.phase === "started" ? integrationBinding.restoration.manifestSource : void 0) || manifestVerified(integrationBinding.installation?.phase === "started" ? integrationBinding.installation.manifestSource : void 0) || manifestVerified(integrationBinding.manifestSource);
     const effectiveOwnerSessionId = status.sessionId;
     const trustedDigestRecorded = typeof integrationBinding.manifestSha256 === "string" && /^[0-9a-f]{64}$/.test(integrationBinding.manifestSha256);
@@ -73298,6 +73447,7 @@ function projectPublicAuthorityStatus(status, options = {}) {
     observedAt: metroTerminal.observedAt
   } : void 0;
   const sandbox = metro?.runtimeEvidenceAuthority === "managed-sandbox-v1" ? "managed-sandbox-v1" : "unavailable";
+  const loginPrologue = readLoginPrologueOutcome(status.bindings.loginPrologue);
   const phase = derivePublicPhase(status.state, Boolean(status.bindings.pendingBuild));
   return {
     available: true,
@@ -73341,6 +73491,20 @@ function projectPublicAuthorityStatus(status, options = {}) {
     proof: Boolean(status.bindings.proof),
     // ADR §5.2 (L3): strict proof is an opt-in overlay outside the four groups, never a group.
     proofOverlay: { active: Boolean(status.bindings.proof) },
+    ...loginPrologue ? {
+      loginPrologue: {
+        state: loginPrologue.state,
+        alias: loginPrologue.alias,
+        actionId: loginPrologue.actionId,
+        startedAt: loginPrologue.startedAt,
+        endedAt: loginPrologue.endedAt,
+        elapsedMs: loginPrologue.elapsedMs,
+        failureCode: loginPrologue.failure?.code,
+        runId: loginPrologue.runRecord?.runId,
+        overrideCount: loginPrologue.overrides?.length ?? 0,
+        lastOverride: loginPrologue.overrides?.at(-1)
+      }
+    } : {},
     ...options.installIdentity ? { installIdentity: options.installIdentity.verdict } : {},
     // A live axis-I refusal means every gated tool refuses too — status must
     // not read `ready` while that is true. A pending re-issue reads ready only
@@ -73391,13 +73555,14 @@ var init_public_status = __esm({
     "use strict";
     init_migration_diagnostic();
     init_registry();
+    init_login_prologue();
     SELECTED_STATES = /* @__PURE__ */ new Set(["active", "source_bound", "device_claimed", "metro_bound"]);
     RUNNING_STATES = /* @__PURE__ */ new Set(["device_bound", "runtime_bound", "ready"]);
   }
 });
 
 // packages/rn-dev-agent-core/dist/session/build-receipt.js
-import { createHmac as createHmac4, timingSafeEqual as timingSafeEqual6 } from "node:crypto";
+import { createHmac as createHmac4, timingSafeEqual as timingSafeEqual7 } from "node:crypto";
 function serialize(payload) {
   return JSON.stringify(payload);
 }
@@ -73413,7 +73578,7 @@ function verifyBuildReceipt(receipt2, capability, expected) {
   }
   const expectedSignature = Buffer.from(sign(receipt2.payload, capability), "hex");
   const actualSignature = Buffer.from(receipt2.signature, "hex");
-  if (expectedSignature.length !== actualSignature.length || !timingSafeEqual6(expectedSignature, actualSignature)) {
+  if (expectedSignature.length !== actualSignature.length || !timingSafeEqual7(expectedSignature, actualSignature)) {
     throw new Error("BUILD_RECEIPT_INVALID: build receipt signature is invalid");
   }
   for (const [key, value] of Object.entries(expected)) {
@@ -73457,7 +73622,7 @@ var init_device_existence = __esm({
 // packages/rn-dev-agent-core/dist/tools/session.js
 import { dirname as dirname21, isAbsolute as isAbsolute9, join as join41, resolve as resolve15 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { createHash as createHash15 } from "node:crypto";
+import { createHash as createHash16 } from "node:crypto";
 function sameAndroidMetroReverse(current, next) {
   if (!current || !next)
     return current === next;
@@ -73470,7 +73635,7 @@ function sameMetroAuthority(current, next) {
 function verifiedManifestSource(candidate, manifestSha256) {
   if (typeof candidate !== "string" || typeof manifestSha256 !== "string")
     return void 0;
-  return createHash15("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
+  return createHash16("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
 }
 function durableBindingManifestSource(binding) {
   return verifiedManifestSource(binding?.manifestSource, binding?.manifestSha256);
@@ -74413,7 +74578,7 @@ function createSessionHandler(runtime, dependencies = {}) {
             });
           }
           assertPackageIntegrationInactive(status.bindings, input.action);
-          const manifestSha256 = createHash15("sha256").update(manifestSource ?? "").digest("hex");
+          const manifestSha256 = createHash16("sha256").update(manifestSource ?? "").digest("hex");
           if (integrationBinding?.version !== 1 || typeof integrationBinding.installedBySessionId !== "string" || integrationBinding.manifestSha256 !== manifestSha256) {
             throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "integration restoration requires the transferred manifest authority binding");
           }
@@ -74460,7 +74625,7 @@ function createSessionHandler(runtime, dependencies = {}) {
         }
         preview.manifest.metroConfig = metroConfigPath.slice(appRoot.length + 1);
         const expectedManifestSource = installationManifestSource ?? serializePackageIntegrationManifest(preview.manifest);
-        const expectedManifestSha256 = createHash15("sha256").update(expectedManifestSource).digest("hex");
+        const expectedManifestSha256 = createHash16("sha256").update(expectedManifestSource).digest("hex");
         if (installationManifestSource && (integrationBinding?.version !== 1 || integrationBinding.installedBySessionId !== session2.sessionId || integrationBinding.manifestSha256 !== expectedManifestSha256)) {
           throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "integration installation requires the original session manifest authority binding");
         }
@@ -74482,7 +74647,7 @@ function createSessionHandler(runtime, dependencies = {}) {
           if (!installedManifest) {
             throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: applied manifest is unavailable");
           }
-          if (createHash15("sha256").update(installedManifest).digest("hex") !== expectedManifestSha256) {
+          if (createHash16("sha256").update(installedManifest).digest("hex") !== expectedManifestSha256) {
             throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "applied integration manifest no longer matches its durable installation authority");
           }
           registry2.updateBindings(session2, {
@@ -76489,6 +76654,7 @@ var init_events = __esm({
       "maestro_run",
       "maestro_generate",
       "maestro_test_all",
+      "cdp_login_prologue",
       "cdp_run_action",
       "cdp_repair_action",
       "proof_step",
@@ -79855,6 +80021,7 @@ var init_runtime = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/run-action.js
+import { randomUUID as randomUUID9 } from "node:crypto";
 function boundInstallReceipt() {
   try {
     const status = getWorkerAuthorityRuntime().status();
@@ -80061,6 +80228,23 @@ function createRunActionHandler(deps = {}) {
     const trigger = args.trigger ?? "agent";
     const timeoutMs = args.timeoutMs ?? 12e4;
     const t0 = Date.now();
+    const startedAt = new Date(t0).toISOString();
+    const runId = randomUUID9();
+    const timingSteps = [];
+    const measureStep = async (name, run) => {
+      const stepStartedMs = Date.now();
+      try {
+        return await run();
+      } finally {
+        const stepEndedMs = Date.now();
+        timingSteps.push({
+          name,
+          startedAt: new Date(stepStartedMs).toISOString(),
+          endedAt: new Date(stepEndedMs).toISOString(),
+          elapsedMs: Math.max(0, stepEndedMs - stepStartedMs)
+        });
+      }
+    };
     const activeTarget = targetContext();
     if (args.platform && activeTarget?.platform && activeTarget.platform !== args.platform) {
       return failResult(`cdp_run_action: requested ${args.platform}, but the active session is ${activeTarget.platform}; refusing cross-platform replay.`, "TARGET_SESSION_MISMATCH", { requestedPlatform: args.platform, activeSession: activeTarget });
@@ -80070,7 +80254,22 @@ function createRunActionHandler(deps = {}) {
     const appFile = args.appFile ?? (flowUsesClearState(replayYaml) && receipt2?.platform === "ios" && typeof receipt2.appId === "string" && typeof receipt2.deviceId === "string" ? resolveAppFile(receipt2.appId, receipt2.deviceId) ?? void 0 : void 0);
     let probeDeviceId = null;
     let observedDeviceId = maestroDeviceId ?? null;
-    const persistRunWithDevice = (record2) => proofReplay ? Promise.resolve({ promoted: false, promotionRefused: false }) : persistRun(args.actionId, projectRoot, probeDeviceId ? { ...record2, deviceId: probeDeviceId } : record2);
+    const persistRunWithDevice = (record2) => {
+      if (proofReplay)
+        return Promise.resolve({ promoted: false, promotionRefused: false });
+      const endedMs = Date.now();
+      const timedRecord = {
+        ...record2,
+        runId,
+        timing: {
+          startedAt,
+          endedAt: new Date(endedMs).toISOString(),
+          elapsedMs: Math.max(0, endedMs - t0),
+          steps: [...timingSteps]
+        }
+      };
+      return persistRun(args.actionId, projectRoot, probeDeviceId ? { ...timedRecord, deviceId: probeDeviceId } : timedRecord);
+    };
     const writeDisclosure = (actionYaml = "none", outcome) => ({
       actionYaml: actionYaml === "none" ? { written: false, reason: "repair-not-applied" } : actionYaml === "lifecycle-promotion-refused" ? { written: false, reason: "lifecycle-promotion-refused" } : { written: true, authorized: true, reason: actionYaml },
       runtimeState: proofReplay ? "none" : outcome?.runtimeStateRefused ? "refused-external-write" : "sidecar",
@@ -80101,11 +80300,11 @@ function createRunActionHandler(deps = {}) {
         const probe = replayDeps ? firstReplayTestId(cdpReplayYaml, args.params ?? {}) : null;
         if (replayDeps && probe) {
           const tProbe = Date.now();
-          const probeOutcome = await probeTreeWithRetry(replayDeps, probe, probeRetry);
+          const probeOutcome = await measureStep("proactive-probe", () => probeTreeWithRetry(replayDeps, probe, probeRetry));
           if (probeOutcome.found) {
             const tReplay = Date.now();
             try {
-              const replay = await runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps);
+              const replay = await measureStep("proactive-cdp-replay", () => runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps));
               const timings_ms = { probe: tReplay - tProbe, replay: Date.now() - tReplay };
               const blindProbe = { atRisk, skippedMaestro: true };
               const autoRepair2 = {
@@ -80160,7 +80359,7 @@ function createRunActionHandler(deps = {}) {
       }
       const tBeforeFirst = Date.now();
       probeDeviceId = null;
-      const firstResult = await maestroRun({
+      const firstResult = await measureStep("maestro-first-attempt", () => maestroRun({
         inlineYaml: replayYaml,
         actionMetadata: action.metadata,
         platform: args.platform,
@@ -80175,7 +80374,7 @@ function createRunActionHandler(deps = {}) {
         reproveManagedOrigin: () => reproveManagedOrigin(args),
         completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
         reissueInstallReceipt: () => reissueInstallReceipt(args)
-      });
+      }));
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, "maestro_run");
       const firstPassed = firstEnv.ok === true && firstEnv.data?.passed === true;
@@ -80273,7 +80472,7 @@ function createRunActionHandler(deps = {}) {
         } else if (!probe) {
           cdpJsFallback = { attempted: false, reason: "no-probe-testid" };
         } else {
-          const probeOutcome = await probeTreeWithRetry(replayDeps, probe, probeRetry);
+          const probeOutcome = await measureStep("fallback-probe", () => probeTreeWithRetry(replayDeps, probe, probeRetry));
           if (!probeOutcome.found) {
             cdpJsFallback = {
               attempted: false,
@@ -80288,9 +80487,9 @@ function createRunActionHandler(deps = {}) {
               firstAttemptOutput: boundedOutput(firstOutput)
             };
             try {
-              const replay = await runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps, {
+              const replay = await measureStep("fallback-cdp-replay", () => runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps, {
                 resumeAtSelector: failure.kind === "SELECTOR_NOT_FOUND" ? failure.selector : null
-              });
+              }));
               const status = replay.passed ? "pass" : "fail";
               const autoRepair2 = {
                 attempted: false,
@@ -80384,12 +80583,12 @@ function createRunActionHandler(deps = {}) {
         throw new Error("Internal: isAutoRepairable returned true for non-SELECTOR_NOT_FOUND failure");
       }
       const tBeforeRepair = Date.now();
-      const repairResult = await repairAction({
+      const repairResult = await measureStep("selector-repair", () => repairAction({
         actionId: args.actionId,
         failedSelector: failure.selector,
         projectRoot,
         agentReasoning: `auto-repair from cdp_run_action after maestro failure: ${failure.selector}`
-      });
+      }));
       const repairMs = Date.now() - tBeforeRepair;
       const repairEnv = parseEnvelope(repairResult, "cdp_repair_action");
       const repairPatched = repairEnv.ok === true && repairEnv.data?.patched === true;
@@ -80445,10 +80644,11 @@ function createRunActionHandler(deps = {}) {
       if (!reloadedAction.replay.ok) {
         return failResult(`cdp_run_action: repaired action is not valid Maestro YAML: ${reloadedAction.replay.error}`, "BAD_RECORDING", { actionId: args.actionId });
       }
+      const retryYaml = reloadedAction.replay.yamlText;
       const tBeforeRetry = Date.now();
       probeDeviceId = null;
-      const retryResult = await maestroRun({
-        inlineYaml: reloadedAction.replay.yamlText,
+      const retryResult = await measureStep("maestro-retry", () => maestroRun({
+        inlineYaml: retryYaml,
         actionMetadata: reloadedAction.metadata,
         platform: args.platform,
         appId: args.appId,
@@ -80462,7 +80662,7 @@ function createRunActionHandler(deps = {}) {
         reproveManagedOrigin: () => reproveManagedOrigin(args),
         completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
         reissueInstallReceipt: () => reissueInstallReceipt(args)
-      });
+      }));
       const retryMs = Date.now() - tBeforeRetry;
       const retryEnv = parseEnvelope(retryResult, "maestro_run");
       const retryPassed = retryEnv.ok === true && retryEnv.data?.passed === true;
@@ -80635,6 +80835,158 @@ var init_run_action = __esm({
     init_engine_pin();
     OUTPUT_BUDGET = 500;
     OUTPUT_ELISION = "\n\u2026\n";
+  }
+});
+
+// packages/rn-dev-agent-core/dist/domain/action-inventory.js
+async function listActions(projectRoot, dependencies = {}) {
+  const context = openReadableActionLoadContext(projectRoot);
+  if (!context)
+    return [];
+  const load = dependencies.loadAction ?? loadActionFromContext;
+  const yamlFiles = context.files.filter((f) => /\.ya?ml$/.test(f)).sort();
+  const results = [];
+  for (const id of new Set(yamlFiles.map((file) => file.replace(/\.ya?ml$/, "")))) {
+    if (yamlFiles.includes(`${id}.yaml`) && yamlFiles.includes(`${id}.yml`))
+      continue;
+    const action = load(context, id);
+    if (!action)
+      continue;
+    const { metadata } = action;
+    const summary = {
+      id: metadata.id,
+      intent: metadata.intent,
+      status: metadata.status
+    };
+    if (metadata.params !== void 0)
+      summary.params = metadata.params;
+    if (metadata.mutates !== void 0)
+      summary.mutates = metadata.mutates;
+    if (metadata.appId !== void 0)
+      summary.appId = metadata.appId;
+    results.push(summary);
+  }
+  return results;
+}
+var init_action_inventory = __esm({
+  "packages/rn-dev-agent-core/dist/domain/action-inventory.js"() {
+    "use strict";
+    init_action_store();
+  }
+});
+
+// packages/rn-dev-agent-core/dist/tools/login-prologue.js
+function parseEnvelope2(result) {
+  try {
+    return JSON.parse(result.content[0]?.text ?? "{}");
+  } catch {
+    return { ok: false, code: "BAD_RESPONSE", error: "Action replay returned invalid JSON." };
+  }
+}
+function createLoginPrologueHandler(deps) {
+  const now = deps.now ?? (() => /* @__PURE__ */ new Date());
+  return async (args) => {
+    const projectRoot = args.projectRoot ?? process.cwd();
+    const prologueStarted = now();
+    const steps = [];
+    let inventory = [];
+    const measure = async (name, run) => {
+      const started = now();
+      try {
+        return await run();
+      } finally {
+        const ended = now();
+        steps.push({
+          name,
+          startedAt: started.toISOString(),
+          endedAt: ended.toISOString(),
+          elapsedMs: Math.max(0, ended.getTime() - started.getTime())
+        });
+      }
+    };
+    const finish = (state, extra) => {
+      const ended = now();
+      return {
+        schemaVersion: 1,
+        state,
+        alias: LOGIN_PROLOGUE_ALIAS,
+        startedAt: prologueStarted.toISOString(),
+        endedAt: ended.toISOString(),
+        elapsedMs: Math.max(0, ended.getTime() - prologueStarted.getTime()),
+        steps,
+        inventory: { count: inventory.length, actionIds: inventory.map((action) => action.id) },
+        ...extra
+      };
+    };
+    const blocked = (code, detail, extra = {}) => {
+      const outcome = finish(LOGIN_PROLOGUE_BLOCKED, {
+        failure: { code, detail },
+        ...extra
+      });
+      return failResult(`Login prologue blocked: ${detail}`, "LOGIN_PROLOGUE_BLOCKED", {
+        loginPrologue: outcome
+      });
+    };
+    try {
+      inventory = await measure("inventory", () => listActions(projectRoot));
+      const action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
+      if (!action || !inventory.some((candidate) => candidate.id === LOGIN_PROLOGUE_ALIAS)) {
+        return blocked("LOGIN_ACTION_MISSING", `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
+      }
+      const priorRunIds = new Set(action.state.runHistory.map((record2) => record2.runId).filter((runId) => typeof runId === "string"));
+      const replayArgs = {
+        ...args,
+        actionId: LOGIN_PROLOGUE_ALIAS,
+        autoRepair: false,
+        forceReload: false,
+        proofReplay: false,
+        blindProbeMode: "forbid",
+        trigger: args.trigger ?? "agent"
+      };
+      let replayResult;
+      try {
+        replayResult = await measure("replay", () => deps.runAction(replayArgs));
+      } catch (error2) {
+        const code = error2 && typeof error2 === "object" && "code" in error2 ? String(error2.code) : "ACTION_REPLAY_THROW";
+        return blocked(code, "The saved login action threw before producing a result.", {
+          actionId: LOGIN_PROLOGUE_ALIAS
+        });
+      }
+      const replay = parseEnvelope2(replayResult);
+      let freshRecord;
+      await measure("verify-run-record", async () => {
+        const reloaded = loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS);
+        freshRecord = reloaded?.state.runHistory.slice().reverse().find((record2) => typeof record2.runId === "string" && !priorRunIds.has(record2.runId));
+      });
+      if (replay.ok !== true || replay.data?.passed !== true) {
+        return blocked(replay.code ?? String(replay.data?.failureKind ?? "ACTION_REPLAY_FAILED"), "The saved login action did not pass; exploratory login is now terminally blocked.", { actionId: LOGIN_PROLOGUE_ALIAS, ...freshRecord ? { runRecord: freshRecord } : {} });
+      }
+      if (!freshRecord || freshRecord.status !== "pass") {
+        return blocked("AUTHORITATIVE_RUN_RECORD_MISSING", "The saved login action reported success without a fresh passing RunRecord.", { actionId: LOGIN_PROLOGUE_ALIAS });
+      }
+      const outcome = finish("passed", {
+        actionId: LOGIN_PROLOGUE_ALIAS,
+        runRecord: freshRecord,
+        actionResult: {
+          transport: replay.data.transport,
+          transportVersion: replay.data.transportVersion,
+          fallback: replay.data.fallback,
+          perStepReadback: replay.data.perStepReadback
+        }
+      });
+      return okResult(outcome);
+    } catch {
+      return blocked("LOGIN_PROLOGUE_INTERNAL_ERROR", "The login prologue failed before it could prove a passing replay.");
+    }
+  };
+}
+var init_login_prologue2 = __esm({
+  "packages/rn-dev-agent-core/dist/tools/login-prologue.js"() {
+    "use strict";
+    init_action_inventory();
+    init_action_store();
+    init_login_prologue();
+    init_utils();
   }
 });
 
@@ -80995,7 +81347,7 @@ async function hideExpoDevMenu(client2, options = {}) {
       break;
     }
     if (attempt < retries)
-      await new Promise((resolve20) => setTimeout(resolve20, retryDelayMs));
+      await new Promise((resolve21) => setTimeout(resolve21, retryDelayMs));
   }
   return successfulCall ? { ...successfulCall, attempts: outcome.attempts } : outcome;
 }
@@ -81109,7 +81461,7 @@ function createDevSettingsHandler(getClient2, dependencies = {}) {
       const call = await hideExpoDevMenu(client2, { retries: 1 });
       if (!call.callSent)
         return failedHideResult(call, before);
-      await (dependencies.settleAfterHide?.() ?? new Promise((resolve20) => setTimeout(resolve20, 300)));
+      await (dependencies.settleAfterHide?.() ?? new Promise((resolve21) => setTimeout(resolve21, 300)));
       const after = probe ? await probe().catch(() => "unknown") : "unknown";
       if (before === "expo_dev_menu" && after === "app") {
         return okResult({
@@ -82963,7 +83315,7 @@ var init_device_deeplink = __esm({
 
 // packages/rn-dev-agent-core/dist/tools/device-record.js
 import { execFile as execFile22 } from "node:child_process";
-import { createHash as createHash16 } from "node:crypto";
+import { createHash as createHash17 } from "node:crypto";
 import { existsSync as existsSync30 } from "node:fs";
 import { promisify as promisify23 } from "node:util";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
@@ -83111,7 +83463,7 @@ function parseStatusOutput(stdout) {
   return active;
 }
 function recordingScope(args) {
-  return createHash16("sha256").update(`${args.sessionId}\0${args.claimEpoch}\0${args.platform}\0${args.deviceId}`).digest("hex");
+  return createHash17("sha256").update(`${args.sessionId}\0${args.claimEpoch}\0${args.platform}\0${args.deviceId}`).digest("hex");
 }
 function bindRecorderSession(runtime, args) {
   const available = runtime.requireAvailable();
@@ -83395,7 +83747,7 @@ var init_device_record = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/proof-capture.js
-import { createHash as createHash17 } from "node:crypto";
+import { createHash as createHash18 } from "node:crypto";
 function canonicalizeProofValue(value) {
   if (Array.isArray(value))
     return value.map(canonicalizeProofValue);
@@ -83407,14 +83759,14 @@ function hashProofArgs(params) {
   return hashProofValue(redact(params));
 }
 function hashProofValue(value) {
-  return createHash17("sha256").update(JSON.stringify(canonicalizeProofValue(value))).digest("hex");
+  return createHash18("sha256").update(JSON.stringify(canonicalizeProofValue(value))).digest("hex");
 }
 function proofRuntimeAuthorityMarker(input) {
   return hashProofValue(input);
 }
 function hashObservedValue(value) {
   const bytes = JSON.stringify(value) ?? String(value);
-  return createHash17("sha256").update(bytes).digest("hex");
+  return createHash18("sha256").update(bytes).digest("hex");
 }
 function resultEnvelope(result) {
   if (!result || typeof result !== "object")
@@ -83937,7 +84289,7 @@ var init_startup_integrity = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
-import { createHash as createHash18, randomUUID as randomUUID9 } from "node:crypto";
+import { createHash as createHash19, randomUUID as randomUUID10 } from "node:crypto";
 import { execFileSync as execFileSync15 } from "node:child_process";
 import { chmodSync as chmodSync7, closeSync as closeSync12, existsSync as existsSync31, fsyncSync, lstatSync as lstatSync16, mkdirSync as mkdirSync20, openSync as openSync12, readFileSync as readFileSync32, realpathSync as realpathSync14, renameSync as renameSync8, unlinkSync as unlinkSync15, writeFileSync as writeFileSync15 } from "node:fs";
 import { basename as basename11, dirname as dirname24, extname, isAbsolute as isAbsolute11, join as join45, relative as relative8, resolve as resolve17, sep as sep9 } from "node:path";
@@ -83973,7 +84325,7 @@ function evidenceTimingReasons(timestamps, videoDurationMs, steps) {
   return reasons;
 }
 function hashBytes(bytes) {
-  return createHash18("sha256").update(bytes).digest("hex");
+  return createHash19("sha256").update(bytes).digest("hex");
 }
 function captureProofWorkerStartup(argv = process.argv, attestation = readStartupIntegrityAttestation()) {
   let executedEntrypointPath = null;
@@ -84198,7 +84550,7 @@ function readProofActionIdentity(appProjectRoot, actionId, dependencies = {}) {
     return {
       id: actionId,
       version: String(action.state.revision),
-      sha256: createHash18("sha256").update(action.yamlText).digest("hex")
+      sha256: createHash19("sha256").update(action.yamlText).digest("hex")
     };
   } catch {
     return null;
@@ -84399,7 +84751,7 @@ function readProofContractAt(moduleUrl = import.meta.url) {
 function writeProofReceiptAtomic(path, receipt2) {
   const directory = dirname24(path);
   mkdirSync20(directory, { recursive: true, mode: 448 });
-  const temporary = resolve17(directory, `.${randomUUID9()}.proof-receipt.tmp`);
+  const temporary = resolve17(directory, `.${randomUUID10()}.proof-receipt.tmp`);
   let descriptor = null;
   try {
     descriptor = openSync12(temporary, "wx", 384);
@@ -85300,7 +85652,7 @@ var init_proof_capture2 = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/proof-media.js
-import { createHash as createHash19 } from "node:crypto";
+import { createHash as createHash20 } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { mkdir as mkdir2, mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir as tmpdir12 } from "node:os";
@@ -85335,7 +85687,7 @@ async function hashAcceptedFile(path) {
   }
 }
 async function sha256File2(path) {
-  const hash = createHash19("sha256");
+  const hash = createHash20("sha256");
   const stream = createReadStream(path);
   for await (const chunk of stream)
     hash.update(chunk);
@@ -88399,7 +88751,7 @@ var init_instrumentation = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/experience/evidence.js
-import { createHash as createHash20, randomUUID as randomUUID10 } from "node:crypto";
+import { createHash as createHash21, randomUUID as randomUUID11 } from "node:crypto";
 import { chmodSync as chmodSync8, existsSync as existsSync33, mkdirSync as mkdirSync21, readFileSync as readFileSync36, renameSync as renameSync9, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
 import { dirname as dirname29, join as join51 } from "node:path";
@@ -88514,7 +88866,7 @@ function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, 
   }).sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen) || a.signature.localeCompare(b.signature)).slice(0, Math.max(0, maxRecords)).sort((a, b) => a.signature.localeCompare(b.signature));
 }
 function experienceSignature(input) {
-  return createHash20("sha256").update(JSON.stringify([
+  return createHash21("sha256").update(JSON.stringify([
     input.classification,
     input.tool,
     input.normalizedSymptomShape,
@@ -88734,7 +89086,7 @@ var init_evidence = __esm({
           recovery: null,
           cleanup: null,
           classification,
-          evidencePointers: [`event:${randomUUID10()}`],
+          evidencePointers: [`event:${randomUUID11()}`],
           tool,
           status: event.status === "ERROR" ? "ERROR" : "FAIL",
           normalizedSymptomShape,
@@ -88780,13 +89132,13 @@ var init_evidence = __esm({
         existing.lastRecoveredAt = now;
         delete existing.unknownReasons.recovery;
         existing.evidencePointers = boundedPointers(existing.evidencePointers, [
-          `event:${randomUUID10()}`
+          `event:${randomUUID11()}`
         ]);
         this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
       }
       write(records) {
         mkdirSync21(this.directory, { recursive: true, mode: 448 });
-        const temp = join51(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID10()}`);
+        const temp = join51(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID11()}`);
         try {
           const sanitized = records.map((record2) => record2.redactionVersion === REDACTION_RULES_VERSION ? record2 : {
             ...sanitizeForEvidence(record2),
@@ -89019,7 +89371,7 @@ var init_live_device = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/observability/e2e-csrf.js
-import { randomBytes as randomBytes8, timingSafeEqual as timingSafeEqual7 } from "node:crypto";
+import { randomBytes as randomBytes8, timingSafeEqual as timingSafeEqual8 } from "node:crypto";
 function makeCsrfToken() {
   return randomBytes8(24).toString("hex");
 }
@@ -89032,7 +89384,7 @@ function isPostAllowed(req, token2) {
     const got = String(gotRaw);
     const a = Buffer.from(got);
     const b = Buffer.from(token2);
-    if (a.length !== b.length || !timingSafeEqual7(a, b)) {
+    if (a.length !== b.length || !timingSafeEqual8(a, b)) {
       return { ok: false, status: 403, reason: "bad csrf token" };
     }
   }
@@ -90283,7 +90635,7 @@ var init_target = __esm({
 // packages/rn-dev-agent-core/dist/domain/e2e-test.js
 import { dirname as dirname31, join as join55 } from "node:path";
 import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync10, readFileSync as readFileSync38, readdirSync as readdirSync15, existsSync as existsSync34 } from "node:fs";
-import { createHash as createHash21 } from "node:crypto";
+import { createHash as createHash22 } from "node:crypto";
 function e2eDirFor(projectRoot) {
   return join55(projectRoot, ".rn-agent", "e2e");
 }
@@ -90314,7 +90666,7 @@ function serializeLockedTest(meta) {
 ${meta.flow}`;
 }
 function hashBody(s) {
-  return createHash21("sha256").update(s).digest("hex");
+  return createHash22("sha256").update(s).digest("hex");
 }
 function freezeLockedTest(projectRoot, source, ctx) {
   const filePath = e2ePathFor(projectRoot, source.id);
@@ -91016,43 +91368,6 @@ var init_preflight = __esm({
   }
 });
 
-// packages/rn-dev-agent-core/dist/domain/action-inventory.js
-async function listActions(projectRoot, dependencies = {}) {
-  const context = openReadableActionLoadContext(projectRoot);
-  if (!context)
-    return [];
-  const load = dependencies.loadAction ?? loadActionFromContext;
-  const yamlFiles = context.files.filter((f) => /\.ya?ml$/.test(f)).sort();
-  const results = [];
-  for (const id of new Set(yamlFiles.map((file) => file.replace(/\.ya?ml$/, "")))) {
-    if (yamlFiles.includes(`${id}.yaml`) && yamlFiles.includes(`${id}.yml`))
-      continue;
-    const action = load(context, id);
-    if (!action)
-      continue;
-    const { metadata } = action;
-    const summary = {
-      id: metadata.id,
-      intent: metadata.intent,
-      status: metadata.status
-    };
-    if (metadata.params !== void 0)
-      summary.params = metadata.params;
-    if (metadata.mutates !== void 0)
-      summary.mutates = metadata.mutates;
-    if (metadata.appId !== void 0)
-      summary.appId = metadata.appId;
-    results.push(summary);
-  }
-  return results;
-}
-var init_action_inventory = __esm({
-  "packages/rn-dev-agent-core/dist/domain/action-inventory.js"() {
-    "use strict";
-    init_action_store();
-  }
-});
-
 // packages/rn-dev-agent-core/dist/session/runner-binding.js
 function bindNativeRunner(runtime, target) {
   const { registry: registry2, session: session2 } = runtime.requireAvailable();
@@ -91122,9 +91437,9 @@ var init_runner_binding = __esm({
 
 // packages/rn-dev-agent-core/dist/session/local-authority-probe.js
 import { execFileSync as execFileSync18 } from "node:child_process";
-import { createHash as createHash22 } from "node:crypto";
+import { createHash as createHash23 } from "node:crypto";
 function identity(value) {
-  return createHash22("sha256").update(JSON.stringify(value)).digest("hex");
+  return createHash23("sha256").update(JSON.stringify(value)).digest("hex");
 }
 function objectBinding(status, name) {
   const value = status.bindings[name];
@@ -92038,7 +92353,7 @@ var index_exports = {};
 __export(index_exports, {
   strictProofMonitor: () => strictProofMonitor
 });
-import { createHash as createHash23, createHmac as createHmac5, randomUUID as randomUUID11 } from "node:crypto";
+import { createHash as createHash24, createHmac as createHmac5, randomUUID as randomUUID12 } from "node:crypto";
 import { readFileSync as readFileSync42, rmSync as rmSync12 } from "node:fs";
 import { execFile as execFile23 } from "node:child_process";
 import { promisify as promisify26 } from "node:util";
@@ -92068,7 +92383,10 @@ function trackedTool(name, desc, schema, handler) {
     }
     return result;
   };
-  server2.tool(name, desc, schema, wrapped);
+  server2.tool(name, desc, {
+    ...schema,
+    supervisorOverrideToken: external_exports.string().min(16).optional().describe("Supervisor token for one audited mutation after a blocked login prologue.")
+  }, wrapped);
 }
 async function pinSessionDevClient(status, options, commitBundle) {
   const device = status.bindings.device;
@@ -92521,7 +92839,7 @@ async function main() {
     });
   }
 }
-var pkgPath, pkgVersion, lockfile, diagnosticContractProbe, noLock, client, getClient, configureClientLifecycle, setClient, publishClient, createClient, execFileP, mustOk, makeReplayDeps, server2, strictProofMonitor, experienceRecorder, authorityRuntime, probeForegroundSurface, foreignMetroOriginScanner, createRuntimeAuthorityProbe, localAuthorityProbe, authorityGate, blindProbeContext, mirrorCfg, mirrorManager2, liveEnabled, liveDeps, registeredToolNames, isSessionRuntimeAbsent, persistedAuthorityStatus, getSessionSignerCapability, spawningSupervisorPid, requestWorkerRecycle, sessionHandler, disconnectClientHandler, connectBoundSession, resolveNativeProofDevice, proofReadiness, proofCaptureHandler, e2ePreflight, e2eReload, e2eSuiteHandler, e2eCsrfToken, observeRootResolver, projectRootFor, triggerE2eRun, runActionHandler, observeRunActionHandler, observeTriggerRun, gatedObserveState, shutdown, stopParentWatch;
+var pkgPath, pkgVersion, lockfile, diagnosticContractProbe, noLock, client, getClient, configureClientLifecycle, setClient, publishClient, createClient, execFileP, mustOk, makeReplayDeps, server2, strictProofMonitor, experienceRecorder, authorityRuntime, probeForegroundSurface, foreignMetroOriginScanner, createRuntimeAuthorityProbe, localAuthorityProbe, authorityGate, blindProbeContext, mirrorCfg, mirrorManager2, liveEnabled, liveDeps, registeredToolNames, isSessionRuntimeAbsent, persistedAuthorityStatus, getSessionSignerCapability, spawningSupervisorPid, requestWorkerRecycle, sessionHandler, disconnectClientHandler, connectBoundSession, resolveNativeProofDevice, proofReadiness, proofCaptureHandler, runActionHandler, e2ePreflight, e2eReload, e2eSuiteHandler, e2eCsrfToken, observeRootResolver, projectRootFor, triggerE2eRun, observeRunActionHandler, observeTriggerRun, gatedObserveState, shutdown, stopParentWatch;
 var init_index = __esm({
   "packages/rn-dev-agent-core/dist/index.js"() {
     "use strict";
@@ -92554,6 +92872,7 @@ var init_index = __esm({
     init_repair_action();
     init_save_as_action();
     init_run_action();
+    init_login_prologue2();
     init_cdp_replay_dispatch();
     init_dispatch();
     init_mmkv();
@@ -92793,7 +93112,7 @@ var init_index = __esm({
           runnerInstanceId: runner?.instanceId,
           runnerPid: runner?.pid,
           runnerProcessBirth: runner?.processBirth,
-          runnerCapabilityHash: typeof runner?.capability === "string" ? createHash23("sha256").update(runner.capability).digest("hex") : void 0,
+          runnerCapabilityHash: typeof runner?.capability === "string" ? createHash24("sha256").update(runner.capability).digest("hex") : void 0,
           runnerPort: runner?.port,
           runnerClaim: status.claims.find((claim) => claim.type === "runner")?.key,
           deviceClaim: status.claims.find((claim) => claim.type === "device")?.key
@@ -92926,6 +93245,7 @@ var init_index = __esm({
     });
     localAuthorityProbe = createRuntimeAuthorityProbe(getClient);
     authorityGate = createAuthorityGate(authorityRuntime, {
+      loginSupervisorOverrideToken: () => process.env.RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN,
       probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
       recoverRuntimeConnection: async (status) => {
         const current = getClient();
@@ -92998,7 +93318,7 @@ var init_index = __esm({
           authority: {
             sessionId: status.sessionId,
             claimEpoch: status.claimEpoch,
-            instanceId: randomUUID11(),
+            instanceId: randomUUID12(),
             capability: secret.observeCapability
           }
         };
@@ -93691,7 +94011,7 @@ var init_index = __esm({
           connectedAt: current.connectedAt
         }),
         errorCount: errors.length,
-        errorSha256: createHash23("sha256").update(errorBytes).digest("hex"),
+        errorSha256: createHash24("sha256").update(errorBytes).digest("hex"),
         device: identity2.device,
         runtime: identity2.runtime
       };
@@ -93958,34 +94278,34 @@ var init_index = __esm({
       deviceId: external_exports.string().optional().describe("Authority-bound exact device identifier; normally injected by the session"),
       appId: external_exports.string().optional().describe("Authority-bound app identifier; normally injected by the session")
     }, createRepairActionHandler());
-    trackedTool(
-      "cdp_run_action",
-      `Replay a learned action by id with end-to-end auto-repair. Loads the action from .rn-agent/actions/<actionId>.yaml or .yml, forwards the matching active session's exact device ID to Maestro, rejects mismatched direct runner/WDA evidence, and on a SELECTOR_NOT_FOUND failure automatically invokes cdp_repair_action and retries once. Appends a RunRecord to the sidecar with full auto-repair telemetry (passed/failed/refused/skipped + diff); its Maestro deviceId comes from direct runner evidence, never requested metadata. The repair attempt counts toward cdp_repair_action's 24h budget. Pass autoRepair=false to opt out of auto-repair (returns the raw maestro_run failure verbatim). forceReload defaults true: any human edit to the YAML since the agent's last write is acknowledged as the new baseline so downstream repair does not abort with STALE_TARGET (the right default for active composition). Pass forceReload=false for the strict "respect offline human edits" behavior: a successful replay still appends its RunRecord to the sidecar when only the tracked YAML mtime baseline is stale, while YAML-mutating promotion and repair stay refused. proofReplay=true is reserved for proof_capture rehearsal and requires autoRepair=false plus forceReload=false; it executes without RunRecord, promotion, YAML, sidecar, or DB persistence. The orchestrated home for the L3 self-healing loop \u2014 prefer this over invoking maestro_run + cdp_repair_action manually for any flow you intend to re-run on schedule. blindProbeMode provides per-call control of the proactive CDP/JS compatibility path: inherit (default) honors RN_BLIND_PROBE, allow explicitly enables it for this call, and forbid forces maestro-first for this call.`,
-      {
-        actionId: external_exports.string().describe("Owned action id; resolves one .yaml or .yml file."),
-        projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
-        platform: external_exports.enum(["ios", "android"]).optional().describe("Force a specific platform; otherwise auto-detected from the active device session."),
-        appFile: external_exports.string().optional().describe("GH #705: path to the .app Maestro reinstalls from after a clearState uninstall. Normally omit it \u2014 an iOS clearState flow resolves the bundle from the session's attested install receipt, and the receipt is re-issued after the reinstall so later device_*/maestro_run calls keep working."),
-        autoRepair: external_exports.boolean().optional().describe("Auto-repair on SELECTOR_NOT_FOUND failures. Default true. Pass false to disable (e.g. when investigating a failure manually)."),
-        timeoutMs: external_exports.number().optional().describe("Maestro execution timeout per attempt (ms). Default 120_000."),
-        trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe('RunRecord trigger annotation. Default "agent". CI calls should pass "ci".'),
-        forceReload: external_exports.boolean().optional().describe('GH #173: when true (default), acknowledge any human edit to the YAML as the new baseline before running so downstream repair does not abort with STALE_TARGET. Pass false for the strict Phase 129 "respect external edits" behavior (useful for CI replays of fixed baselines).'),
-        proofReplay: external_exports.boolean().optional().describe("Read-only proof rehearsal mode. Requires autoRepair=false and forceReload=false; never writes action YAML, runtime sidecar, or DB state."),
-        blindProbeMode: external_exports.enum(["inherit", "allow", "forbid"]).optional().describe("Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged."),
-        params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).")
-      },
-      // GH #186: supply a CDP-backed live-route reader so the route-drift guard is
-      // actually active. Without this the handler defaulted getLiveRoute to a no-op
-      // and the drift branch could never fire, silently routing screen-change
-      // failures into fuzzy selector repair.
-      createRunActionHandler({
-        getLiveRoute: () => readLiveRoute(getClient()),
-        replayDeps: makeReplayDeps,
-        blindProbeContext,
-        targetContext: getActiveSession,
-        claimBundleAuthority: claimOptionalBundleAuthority
-      })
-    );
+    runActionHandler = createRunActionHandler({
+      getLiveRoute: () => readLiveRoute(getClient()),
+      replayDeps: makeReplayDeps,
+      blindProbeContext,
+      targetContext: getActiveSession,
+      claimBundleAuthority: claimOptionalBundleAuthority
+    });
+    trackedTool("cdp_run_action", `Replay a learned action by id with end-to-end auto-repair. Loads the action from .rn-agent/actions/<actionId>.yaml or .yml, forwards the matching active session's exact device ID to Maestro, rejects mismatched direct runner/WDA evidence, and on a SELECTOR_NOT_FOUND failure automatically invokes cdp_repair_action and retries once. Appends a RunRecord to the sidecar with full auto-repair telemetry (passed/failed/refused/skipped + diff); its Maestro deviceId comes from direct runner evidence, never requested metadata. The repair attempt counts toward cdp_repair_action's 24h budget. Pass autoRepair=false to opt out of auto-repair (returns the raw maestro_run failure verbatim). forceReload defaults true: any human edit to the YAML since the agent's last write is acknowledged as the new baseline so downstream repair does not abort with STALE_TARGET (the right default for active composition). Pass forceReload=false for the strict "respect offline human edits" behavior: a successful replay still appends its RunRecord to the sidecar when only the tracked YAML mtime baseline is stale, while YAML-mutating promotion and repair stay refused. proofReplay=true is reserved for proof_capture rehearsal and requires autoRepair=false plus forceReload=false; it executes without RunRecord, promotion, YAML, sidecar, or DB persistence. The orchestrated home for the L3 self-healing loop \u2014 prefer this over invoking maestro_run + cdp_repair_action manually for any flow you intend to re-run on schedule. blindProbeMode provides per-call control of the proactive CDP/JS compatibility path: inherit (default) honors RN_BLIND_PROBE, allow explicitly enables it for this call, and forbid forces maestro-first for this call.`, {
+      actionId: external_exports.string().describe("Owned action id; resolves one .yaml or .yml file."),
+      projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
+      platform: external_exports.enum(["ios", "android"]).optional().describe("Force a specific platform; otherwise auto-detected from the active device session."),
+      appFile: external_exports.string().optional().describe("GH #705: path to the .app Maestro reinstalls from after a clearState uninstall. Normally omit it \u2014 an iOS clearState flow resolves the bundle from the session's attested install receipt, and the receipt is re-issued after the reinstall so later device_*/maestro_run calls keep working."),
+      autoRepair: external_exports.boolean().optional().describe("Auto-repair on SELECTOR_NOT_FOUND failures. Default true. Pass false to disable (e.g. when investigating a failure manually)."),
+      timeoutMs: external_exports.number().optional().describe("Maestro execution timeout per attempt (ms). Default 120_000."),
+      trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe('RunRecord trigger annotation. Default "agent". CI calls should pass "ci".'),
+      forceReload: external_exports.boolean().optional().describe('GH #173: when true (default), acknowledge any human edit to the YAML as the new baseline before running so downstream repair does not abort with STALE_TARGET. Pass false for the strict Phase 129 "respect external edits" behavior (useful for CI replays of fixed baselines).'),
+      proofReplay: external_exports.boolean().optional().describe("Read-only proof rehearsal mode. Requires autoRepair=false and forceReload=false; never writes action YAML, runtime sidecar, or DB state."),
+      blindProbeMode: external_exports.enum(["inherit", "allow", "forbid"]).optional().describe("Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged."),
+      params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).")
+    }, runActionHandler);
+    trackedTool("cdp_login_prologue", "Inventory learned actions, replay the exact user-login action strictly, and require a fresh passing RunRecord before lifting the session login gate.", {
+      projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
+      platform: external_exports.enum(["ios", "android"]).optional().describe("Force a platform; otherwise use the authority-bound device."),
+      appFile: external_exports.string().optional().describe("iOS app artifact used only when the saved action contains clearState."),
+      timeoutMs: external_exports.number().optional().describe("Saved-action timeout in milliseconds."),
+      trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe("RunRecord trigger annotation. Default agent."),
+      params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Bindings for the exact user-login action placeholders.")
+    }, createLoginPrologueHandler({ runAction: runActionHandler }));
     trackedTool("cdp_lock_e2e_test", "Promote a verified action into a frozen, locked e2e regression test. Runs the action once strict (no repair); freezes it only if it passes. v1 supports param-free actions only.", {
       actionId: external_exports.string().describe("The action id under .rn-agent/actions to lock"),
       relock: external_exports.boolean().optional().describe("Overwrite an existing locked test"),
@@ -94085,13 +94405,6 @@ var init_index = __esm({
         arbiter.release(L.lease);
       }
     };
-    runActionHandler = createRunActionHandler({
-      getLiveRoute: () => readLiveRoute(getClient()),
-      replayDeps: makeReplayDeps,
-      blindProbeContext,
-      targetContext: getActiveSession,
-      claimBundleAuthority: claimOptionalBundleAuthority
-    });
     observeRunActionHandler = authorityGate.wrap("cdp_run_action", runActionHandler);
     observeTriggerRun = authorityGate.wrap("cdp_run_e2e_suite", async (...raw) => {
       const args = raw[0] ?? {};
@@ -94241,7 +94554,7 @@ var init_index = __esm({
 // packages/rn-dev-agent-core/dist/supervisor.js
 init_lockfile();
 init_parent_watch();
-import { randomUUID as randomUUID12 } from "node:crypto";
+import { randomUUID as randomUUID13 } from "node:crypto";
 import { spawn as spawn10 } from "node:child_process";
 import { lstatSync as lstatSync19, readFileSync as readFileSync43 } from "node:fs";
 import { dirname as dirname33, join as join60, resolve as resolve20 } from "node:path";
@@ -94280,7 +94593,7 @@ init_registry();
 init_managed_metro();
 init_android_metro_reverse();
 init_state_root();
-import { createHash as createHash13, randomBytes as randomBytes6, randomUUID as randomUUID8 } from "node:crypto";
+import { createHash as createHash14, randomBytes as randomBytes6, randomUUID as randomUUID8 } from "node:crypto";
 import { dirname as dirname19 } from "node:path";
 var RELEASABLE_SESSION_STATES = /* @__PURE__ */ new Set([
   "active",
@@ -94410,7 +94723,7 @@ function createSupervisorAuthority(input, dependencies = {}) {
       metroPort,
       observePort,
       ...adoptionRequired ? {
-        recoveryCapabilityHash: createHash13("sha256").update(recoveryCapability).digest("hex"),
+        recoveryCapabilityHash: createHash14("sha256").update(recoveryCapability).digest("hex"),
         adoptionRequired: {
           sessionId: adoptionRequired.sessionId,
           claimEpoch: adoptionRequired.claimEpoch
@@ -94632,7 +94945,7 @@ if (process.env.RN_BRIDGE_SUPERVISOR === "0") {
 `);
   }, spawnWorker2 = function() {
     resolveAuthorityForSpawn2();
-    const workerInstance = randomUUID12();
+    const workerInstance = randomUUID13();
     let workerCwd = process.cwd();
     let spawnAuthorityError = null;
     try {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32798,6 +32798,22 @@ function missingLoginPrologueOutcome() {
     }
   };
 }
+function persistLoginPrologueOutcome(runtime, registry2, operation, status, outcome) {
+  const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+  const nextOperation = registry2.replaceBindingsDuringOperation(operation, {
+    bindings: {
+      loginPrologue: {
+        ...outcome,
+        ...priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}
+      }
+    }
+  });
+  const nextStatus = runtime.status();
+  if (!nextStatus.available) {
+    throw new SessionAuthorityError(nextStatus.code, nextStatus.reason);
+  }
+  return { operation: nextOperation, status: nextStatus };
+}
 function isActionReplayTool(tool) {
   return tool === "cdp_run_action" || tool === "cdp_login_prologue";
 }
@@ -33694,6 +33710,11 @@ function createAuthorityGate(runtime, dependencies) {
             loginPrologueOutcome = missingLoginPrologueOutcome();
             result = failResult("Login prologue returned no valid terminal state.", "LOGIN_PROLOGUE_BLOCKED", { loginPrologue: loginPrologueOutcome });
           }
+          if (loginPrologueOutcome.state === LOGIN_PROLOGUE_BLOCKED) {
+            const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
+            operation = persisted.operation;
+            status = persisted.status;
+          }
         }
         let runtimeTargetChanged = false;
         const postHandlerRecovery = await reconcileRecoverableRuntime(runtime, dependencies, registry2, operation, status, profile, resultSucceeded(result));
@@ -33814,21 +33835,10 @@ function createAuthorityGate(runtime, dependencies) {
           axes: [...runnerAwareReceiptProfile.axes, "M", "A"]
         } : runnerAwareReceiptProfile;
         const controllerGenerationAdvanced = operation.authorityVersion !== initialOperationAuthorityVersion;
-        if (loginPrologueOutcome) {
-          const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
-          operation = registry2.replaceBindingsDuringOperation(operation, {
-            bindings: {
-              loginPrologue: {
-                ...loginPrologueOutcome,
-                ...priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}
-              }
-            }
-          });
-          const loginStatus = runtime.status();
-          if (!loginStatus.available) {
-            throw new SessionAuthorityError(loginStatus.code, loginStatus.reason);
-          }
-          status = loginStatus;
+        if (loginPrologueOutcome?.state === "passed") {
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
+          operation = persisted.operation;
+          status = persisted.status;
         }
         registry2.verifyOperation(operation);
         for (const observation of allBefore) {
@@ -35203,6 +35213,7 @@ var init_device_arbiter = __esm({
     FLOW_TOOLS = /* @__PURE__ */ new Set([
       "maestro_run",
       "maestro_test_all",
+      "cdp_login_prologue",
       "cdp_run_action",
       "cdp_auto_login",
       "cdp_reload",
@@ -80934,15 +80945,15 @@ function createLoginPrologueHandler(deps) {
         return blocked("LOGIN_ACTION_MISSING", `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
       }
       const priorRunIds = new Set(action.state.runHistory.map((record2) => record2.runId).filter((runId) => typeof runId === "string"));
-      const replayArgs = {
-        ...args,
+      const replayArgs = Object.create(Object.getPrototypeOf(args), Object.getOwnPropertyDescriptors(args));
+      Object.assign(replayArgs, {
         actionId: LOGIN_PROLOGUE_ALIAS,
         autoRepair: false,
         forceReload: false,
         proofReplay: false,
         blindProbeMode: "forbid",
         trigger: args.trigger ?? "agent"
-      };
+      });
       let replayResult;
       try {
         replayResult = await measure("replay", () => deps.runAction(replayArgs));

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32185,6 +32185,9 @@ function loadLockedTest(projectRoot, id) {
   const locked = parseLockedTest(readFileSync24(filePath, "utf8"), filePath);
   return locked?.id === id ? locked : null;
 }
+function lockedTestFileExists(projectRoot, id) {
+  return existsSync22(e2ePathFor(projectRoot, id));
+}
 function discoverLockedTests(projectRoot) {
   const dir = e2eDirFor(projectRoot);
   if (!existsSync22(dir))
@@ -32202,11 +32205,13 @@ function resolveLockedTestIds(projectRoot, pattern, discover2 = discoverLockedTe
     return ids;
   }
 }
-function resolveLockedTestIdentityIds(projectRoot, pattern, discover2 = discoverLockedTests, load = loadLockedTest) {
-  return resolveLockedTestIds(projectRoot, pattern, discover2).filter((id) => {
+function resolveLockedTestSelection(projectRoot, pattern, discover2 = discoverLockedTests, load = loadLockedTest) {
+  const ids = resolveLockedTestIds(projectRoot, pattern, discover2);
+  const identitiesValid = ids.every((id) => {
     const locked = load(projectRoot, id);
     return locked?.id === id && locked.sourceActionId === id;
   });
+  return { ids, identitiesValid };
 }
 function setResolvedLockedTestIds(args, ids) {
   Object.defineProperty(args, resolvedLockedTestIds, {
@@ -33528,17 +33533,17 @@ function createAuthorityGate(runtime, dependencies) {
           bindSessionArguments(status, profile, args, tool);
         }
         if (pendingLockedE2eAdmission) {
-          const resolvedLockedTestIds2 = dependencies.resolveLockedE2eTestIds?.(args, status);
-          if (!resolvedLockedTestIds2 || inspectLoginPrologueGuard({
+          const resolvedSelection = dependencies.resolveLockedE2eTestIds?.(args, status);
+          if (!resolvedSelection?.identitiesValid || inspectLoginPrologueGuard({
             binding: status.bindings.loginPrologue,
             tool,
             args,
             mutation: profile.mutation,
-            resolvedLockedTestIds: resolvedLockedTestIds2
+            resolvedLockedTestIds: resolvedSelection.ids
           }).blocked) {
             throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the locked e2e suite did not resolve to the exact user-login candidate");
           }
-          setResolvedLockedTestIds(args, resolvedLockedTestIds2);
+          setResolvedLockedTestIds(args, resolvedSelection.ids);
         }
         operation = registry2.beginOperation(available.session, {
           operationId: randomUUID5(),
@@ -91037,7 +91042,7 @@ async function lockE2eTestCore(args, deps = {}) {
     }
     resolvedParams = resolved.params;
   }
-  if (!args.relock && loadLockedTest(projectRoot, args.actionId)) {
+  if (!args.relock && lockedTestFileExists(projectRoot, args.actionId)) {
     return failResult(`'${args.actionId}' is already locked \u2014 pass relock:true to re-lock`, "ALREADY_LOCKED");
   }
   const session2 = getSession();
@@ -93436,9 +93441,9 @@ var init_index = __esm({
       resolveLockedE2eTestIds: (args, status) => {
         const projectRoot = typeof args.projectRoot === "string" ? args.projectRoot : status.source.appRoot;
         if (typeof projectRoot !== "string")
-          return [];
+          return { ids: [], identitiesValid: false };
         args.projectRoot = projectRoot;
-        return resolveLockedTestIdentityIds(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
+        return resolveLockedTestSelection(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
       },
       probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
       recoverRuntimeConnection: async (status) => {

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -94297,7 +94297,7 @@ var init_index = __esm({
       continueOnError: external_exports.boolean().default(false).describe("When true, ordinary failed steps are recorded and the batch continues. A failed fill with observed or possible mutation always stops later steps."),
       finalSnapshot: external_exports.enum(["salient", "full", "none"]).default("salient").describe("Shape of the batch final_snapshot. salient (default): compact list of only actionable nodes (Button/TextField/Switch/etc) \u2014 far fewer tokens. full: complete node list (legacy). none: skip the implicit trailing snapshot entirely (~1,450 ms saved) for action-only batches you verify via expect_*/cdp_store_state.")
     }, createDeviceBatchHandler(getClient));
-    trackedTool("cdp_auto_login", "Explicit legacy navigation helper that detects an auth screen and runs one project login subflow through maestro_run on the authority-bound device. It is per-call recovery only, never durable login authority or PR proof; prefer a compatible owned learned action.", {
+    trackedTool("cdp_auto_login", "Explicit legacy navigation helper that detects an auth screen and runs one project login subflow through maestro_run on the authority-bound device. It is never login authority or PR proof; use cdp_login_prologue for authenticated journeys.", {
       appId: external_exports.string().optional().describe("App bundle ID override (auto-detected from app.json if omitted)"),
       platform: external_exports.enum(["ios", "android"]).optional().describe("Platform override (auto-detected from session if omitted)")
     }, withConnection(getClient, async (args, client2) => {
@@ -94497,13 +94497,13 @@ var init_index = __esm({
       blindProbeMode: external_exports.enum(["inherit", "allow", "forbid"]).optional().describe("Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged."),
       params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).")
     }, runActionHandler);
-    trackedTool("cdp_login_prologue", "Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; not PR proof.", {
+    trackedTool("cdp_login_prologue", "Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; failure blocks exploratory fallback mutations, and a pass is not PR proof.", {
       projectRoot: external_exports.string().optional().describe("Override project root (default: process.cwd())."),
-      platform: external_exports.enum(["ios", "android"]).optional().describe("Force a platform; otherwise use the authority-bound device."),
-      appFile: external_exports.string().optional().describe("iOS app artifact used only when the saved action contains clearState."),
+      platform: external_exports.enum(["ios", "android"]).optional().describe("Override the bound platform."),
+      appFile: external_exports.string().optional().describe("iOS app artifact for clearState actions."),
       timeoutMs: external_exports.number().optional().describe("Saved-action timeout in milliseconds."),
-      trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe("RunRecord trigger annotation. Default agent."),
-      params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("Bindings for the exact user-login action placeholders.")
+      trigger: external_exports.enum(["agent", "ci", "human"]).optional().describe("Run trigger; default agent."),
+      params: external_exports.record(external_exports.string(), external_exports.string()).optional().describe("String user-login bindings.")
     }, createLoginPrologueHandler({ runAction: runActionHandler }));
     trackedTool("cdp_lock_e2e_test", "Promote a verified action into a frozen, locked e2e regression test. Runs the action once strict (no repair); freezes it only if it passes. v1 supports param-free actions only.", {
       actionId: external_exports.string().describe("The action id under .rn-agent/actions to lock"),

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32800,11 +32800,12 @@ function missingLoginPrologueOutcome() {
 }
 function persistLoginPrologueOutcome(runtime, registry2, operation, status, outcome) {
   const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+  const overrides = outcome.overrides ?? priorOutcome?.overrides;
   const nextOperation = registry2.replaceBindingsDuringOperation(operation, {
     bindings: {
       loginPrologue: {
         ...outcome,
-        ...priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}
+        ...overrides ? { overrides } : {}
       }
     }
   });
@@ -33052,7 +33053,7 @@ function createAuthorityGate(runtime, dependencies) {
         mutation: true,
         liveBundleProbe: tool === "proof_capture"
       } : baseProfile;
-      let runtimeStatus = runtime.status();
+      const runtimeStatus = runtime.status();
       const loginDecision = evaluateLoginPrologueGuard({
         binding: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
         tool,
@@ -33067,24 +33068,6 @@ function createAuthorityGate(runtime, dependencies) {
           overrideRejected: loginDecision.suppliedOverride,
           nextAction: "Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call."
         });
-      }
-      if (loginDecision.override) {
-        try {
-          const available = runtime.requireAvailable();
-          const current = runtime.status();
-          const outcome = current.available ? readLoginPrologueOutcome(current.bindings.loginPrologue) : null;
-          if (!outcome) {
-            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
-          }
-          available.registry.updateBindings(available.session, {
-            bindings: {
-              loginPrologue: appendLoginOverrideAudit(outcome, loginDecision.audit)
-            }
-          });
-          runtimeStatus = runtime.status();
-        } catch (error2) {
-          return authorityFailure(error2);
-        }
       }
       if (profile.kind === "diagnostic") {
         return addMeta(await handler(...handlerArgs), { authoritative: false });
@@ -33700,6 +33683,15 @@ function createAuthorityGate(runtime, dependencies) {
             }
           });
         }
+        if (loginDecision.override) {
+          const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+          if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the blocked login prologue state disappeared before override audit");
+          }
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, appendLoginOverrideAudit(outcome, loginDecision.audit));
+          operation = persisted.operation;
+          status = persisted.status;
+        }
         registry2.verifyOperation(operation);
         const snapshotCheckpoint = dependencies.snapshotCaptureCheckpoint?.();
         let result = await registry2.runWithOperation(operation, () => handler(...handlerArgs));
@@ -33835,11 +33827,6 @@ function createAuthorityGate(runtime, dependencies) {
           axes: [...runnerAwareReceiptProfile.axes, "M", "A"]
         } : runnerAwareReceiptProfile;
         const controllerGenerationAdvanced = operation.authorityVersion !== initialOperationAuthorityVersion;
-        if (loginPrologueOutcome?.state === "passed") {
-          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
-          operation = persisted.operation;
-          status = persisted.status;
-        }
         registry2.verifyOperation(operation);
         for (const observation of allBefore) {
           if (controllerGenerationAdvanced && observation.axis === "C")
@@ -33888,6 +33875,11 @@ function createAuthorityGate(runtime, dependencies) {
         }
         if (operation && receiptsCommittable) {
           registry2.commitPlatformAuthorityReceipts(operation);
+        }
+        if (operation && loginPrologueOutcome?.state === "passed") {
+          const persisted = persistLoginPrologueOutcome(runtime, registry2, operation, status, loginPrologueOutcome);
+          operation = persisted.operation;
+          status = persisted.status;
         }
         return addMeta(result, {
           ...nativeOriginMeta(profile, nativeOriginProven),
@@ -80393,7 +80385,8 @@ function createRunActionHandler(deps = {}) {
       const firstFailureDetail = readMaestroFailureDetail(firstEnv, firstOutput);
       const firstDeviceAuthority = readMaestroDeviceAuthority(firstEnv);
       probeDeviceId = firstDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
-      if (firstEnv.code === "DEVICE_AUTHORITY_MISMATCH") {
+      if (firstEnv.code) {
+        const typedCode = firstEnv.code;
         const autoRepair2 = {
           attempted: false,
           outcome: args.autoRepair === false ? "refused" : "skipped",
@@ -80404,14 +80397,14 @@ function createRunActionHandler(deps = {}) {
           timestamp: (/* @__PURE__ */ new Date()).toISOString(),
           durationMs: Date.now() - t0,
           status: "fail",
-          failureCode: "DEVICE_AUTHORITY_MISMATCH",
+          failureCode: typedCode === "DEVICE_AUTHORITY_MISMATCH" ? "DEVICE_AUTHORITY_MISMATCH" : typedCode === "RECONNECT_TIMEOUT" ? "TIMEOUT" : "UNKNOWN",
           failureDetail: firstFailureDetail.slice(0, 1e3),
           trigger,
           autoRepair: autoRepair2
         });
-        return failResult(`cdp_run_action: ${args.actionId} refused replay authority: ${firstFailureDetail}`, "DEVICE_AUTHORITY_MISMATCH", {
+        return failResult(`cdp_run_action: ${args.actionId} refused replay: ${firstFailureDetail}`, typedCode, {
           actionId: args.actionId,
-          failureKind: "DEVICE_AUTHORITY_MISMATCH",
+          failureKind: typedCode,
           deviceAuthority: firstDeviceAuthority,
           autoRepair: autoRepair2,
           writes: writeDisclosure("none", persisted2)
@@ -80941,8 +80934,11 @@ function createLoginPrologueHandler(deps) {
     try {
       inventory = await measure("inventory", () => listActions(projectRoot));
       const action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
-      if (!action || !inventory.some((candidate) => candidate.id === LOGIN_PROLOGUE_ALIAS)) {
+      if (!action) {
         return blocked("LOGIN_ACTION_MISSING", `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
+      }
+      if (action.metadata.id !== LOGIN_PROLOGUE_ALIAS) {
+        return blocked("LOGIN_ACTION_ID_MISMATCH", `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
       }
       const priorRunIds = new Set(action.state.runHistory.map((record2) => record2.runId).filter((runId) => typeof runId === "string"));
       const replayArgs = Object.create(Object.getPrototypeOf(args), Object.getOwnPropertyDescriptors(args));

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -32063,11 +32063,11 @@ function readLoginPrologueOutcome(value) {
   }
   return candidate;
 }
-function lockedE2eProofAllowed(tool, args) {
+function lockedE2eProofAllowed(tool, args, resolvedLockedTestIds2) {
   if (tool === "cdp_lock_e2e_test")
     return args.actionId === LOGIN_PROLOGUE_ALIAS;
   if (tool === "cdp_run_e2e_suite") {
-    return args.pattern === `^${LOGIN_PROLOGUE_ALIAS}$`;
+    return resolvedLockedTestIds2?.length === 1 && resolvedLockedTestIds2[0] === LOGIN_PROLOGUE_ALIAS;
   }
   return false;
 }
@@ -32096,7 +32096,7 @@ function tokenMatches(expected, supplied) {
 }
 function inspectLoginPrologueGuard(input) {
   const outcome = readLoginPrologueOutcome(input.binding);
-  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool, input.args)) {
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation || cleanupAllowed(input.tool, input.args) || lockedE2eProofAllowed(input.tool, input.args, input.resolvedLockedTestIds)) {
     return { blocked: false };
   }
   return {
@@ -32119,6 +32119,137 @@ var init_login_prologue = __esm({
     LOGIN_PROLOGUE_ALIAS = "user-login";
     LOGIN_PROLOGUE_BLOCKED = "LOGIN_PROLOGUE_BLOCKED";
     ACTION_LOGIN_HELPER = "ACTION_LOGIN_HELPER";
+  }
+});
+
+// packages/rn-dev-agent-core/dist/domain/e2e-test.js
+import { dirname as dirname18, join as join29 } from "node:path";
+import { mkdirSync as mkdirSync18, writeFileSync as writeFileSync10, renameSync as renameSync8, readFileSync as readFileSync24, readdirSync as readdirSync11, existsSync as existsSync22 } from "node:fs";
+import { createHash as createHash13 } from "node:crypto";
+function e2eDirFor(projectRoot) {
+  return join29(projectRoot, ".rn-agent", "e2e");
+}
+function e2ePathFor(projectRoot, id) {
+  assertValidActionId(id, "e2ePathFor");
+  const dir = e2eDirFor(projectRoot);
+  const file = join29(dir, `${id}.yaml`);
+  assertWithinDir(file, dir);
+  return file;
+}
+function serializeLockedTest(meta) {
+  const header = [
+    "# e2e-locked-test: true",
+    `# id: ${meta.id}`,
+    `# intent: ${meta.intent}`,
+    `# sourceActionId: ${meta.sourceActionId}`,
+    `# lockedAt: ${meta.lockedAt}`,
+    `# lockedGitSha: ${meta.lockedGitSha ?? ""}`,
+    `# sourceContentHash: ${meta.sourceContentHash}`,
+    "# status: locked"
+  ];
+  if (meta.appId)
+    header.push(`# appId: ${meta.appId}`);
+  if (meta.params?.length)
+    header.push(`# params: ${meta.params.join(", ")}`);
+  header.push(FLOW_SENTINEL);
+  return `${header.join("\n")}
+${meta.flow}`;
+}
+function hashBody(s) {
+  return createHash13("sha256").update(s).digest("hex");
+}
+function freezeLockedTest(projectRoot, source, ctx) {
+  const filePath = e2ePathFor(projectRoot, source.id);
+  mkdirSync18(dirname18(filePath), { recursive: true });
+  const meta = {
+    id: source.id,
+    intent: source.intent,
+    sourceActionId: source.sourceActionId,
+    lockedAt: ctx.now().toISOString(),
+    lockedGitSha: ctx.gitSha,
+    sourceContentHash: hashBody(source.flow),
+    status: "locked",
+    params: source.params,
+    appId: source.appId,
+    flow: source.flow
+  };
+  const tmp = `${filePath}.tmp`;
+  writeFileSync10(tmp, serializeLockedTest(meta), "utf8");
+  renameSync8(tmp, filePath);
+  return { ...meta, filePath };
+}
+function loadLockedTest(projectRoot, id) {
+  const filePath = e2ePathFor(projectRoot, id);
+  if (!existsSync22(filePath))
+    return null;
+  return parseLockedTest(readFileSync24(filePath, "utf8"), filePath);
+}
+function discoverLockedTests(projectRoot) {
+  const dir = e2eDirFor(projectRoot);
+  if (!existsSync22(dir))
+    return [];
+  return readdirSync11(dir).filter((f) => f.endsWith(".yaml")).map((f) => f.replace(/\.yaml$/, "")).sort();
+}
+function resolveLockedTestIds(projectRoot, pattern, discover2 = discoverLockedTests) {
+  const ids = discover2(projectRoot);
+  if (!pattern || pattern.length > 256)
+    return ids;
+  try {
+    const matcher = new RegExp(pattern, "i");
+    return ids.filter((id) => matcher.test(id));
+  } catch {
+    return ids;
+  }
+}
+function setResolvedLockedTestIds(args, ids) {
+  Object.defineProperty(args, resolvedLockedTestIds, {
+    value: Object.freeze([...ids]),
+    configurable: true
+  });
+}
+function getResolvedLockedTestIds(args) {
+  return args[resolvedLockedTestIds];
+}
+function parseLockedTest(text, filePath) {
+  if (!/^#\s*e2e-locked-test:\s*true\s*$/m.test(text))
+    return null;
+  const sentinelIdx = text.indexOf(FLOW_SENTINEL);
+  if (sentinelIdx < 0)
+    return null;
+  const headerText = text.slice(0, sentinelIdx);
+  const flowStart = text.indexOf("\n", sentinelIdx);
+  const flow = flowStart >= 0 ? text.slice(flowStart + 1) : "";
+  const field2 = (k) => {
+    const m = headerText.match(new RegExp(`^#\\s*${k}:\\s*(.*)$`, "m"));
+    const v = m?.[1]?.trim();
+    return v ? v : void 0;
+  };
+  const id = field2("id");
+  const intent = field2("intent");
+  if (!id || !intent)
+    return null;
+  const paramsRaw = field2("params");
+  return {
+    id,
+    intent,
+    sourceActionId: field2("sourceActionId") ?? id,
+    lockedAt: field2("lockedAt") ?? "",
+    lockedGitSha: field2("lockedGitSha") ?? null,
+    sourceContentHash: field2("sourceContentHash") ?? "",
+    status: "locked",
+    params: paramsRaw ? paramsRaw.split(",").map((s) => s.trim()).filter(Boolean) : void 0,
+    appId: field2("appId"),
+    flow,
+    filePath
+  };
+}
+var FLOW_SENTINEL, resolvedLockedTestIds;
+var init_e2e_test = __esm({
+  "packages/rn-dev-agent-core/dist/domain/e2e-test.js"() {
+    "use strict";
+    init_path_safety();
+    FLOW_SENTINEL = "# e2e-locked-flow-below";
+    resolvedLockedTestIds = /* @__PURE__ */ Symbol("resolvedLockedTestIds");
   }
 });
 
@@ -33098,7 +33229,8 @@ function createAuthorityGate(runtime, dependencies) {
         mutation: profile.mutation
       });
       const pendingSupervisorOverrideToken = loginGuard.blocked ? suppliedSupervisorOverrideToken : void 0;
-      if (loginGuard.blocked && pendingSupervisorOverrideToken === void 0) {
+      const pendingLockedE2eAdmission = loginGuard.blocked && tool === "cdp_run_e2e_suite" && pendingSupervisorOverrideToken === void 0;
+      if (loginGuard.blocked && pendingSupervisorOverrideToken === void 0 && !pendingLockedE2eAdmission) {
         return failResult("LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.", "LOGIN_PROLOGUE_BLOCKED", {
           loginPrologue: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : void 0,
           overrideRejected: false,
@@ -33379,6 +33511,19 @@ function createAuthorityGate(runtime, dependencies) {
         if (!deferredAdmissionChecks) {
           requireCompleteAxes(status, profile);
           bindSessionArguments(status, profile, args, tool);
+        }
+        if (pendingLockedE2eAdmission) {
+          const resolvedLockedTestIds2 = dependencies.resolveLockedE2eTestIds?.(args, status);
+          if (!resolvedLockedTestIds2 || inspectLoginPrologueGuard({
+            binding: status.bindings.loginPrologue,
+            tool,
+            args,
+            mutation: profile.mutation,
+            resolvedLockedTestIds: resolvedLockedTestIds2
+          }).blocked) {
+            throw new SessionAuthorityError("LOGIN_PROLOGUE_BLOCKED", "the locked e2e suite did not resolve to the exact user-login candidate");
+          }
+          setResolvedLockedTestIds(args, resolvedLockedTestIds2);
         }
         operation = registry2.beginOperation(available.session, {
           operationId: randomUUID5(),
@@ -33999,6 +34144,7 @@ var init_authority_gate = __esm({
     init_metro_origin();
     init_install_reissue();
     init_login_prologue();
+    init_e2e_test();
     init_tool_profiles();
     optionalBundleAdmission = /* @__PURE__ */ Symbol("optionalBundleAdmission");
     managedNativeOrigin = /* @__PURE__ */ Symbol("managedNativeOrigin");
@@ -34035,9 +34181,9 @@ var init_authority_gate = __esm({
 // packages/rn-dev-agent-core/dist/tools/maestro-run.js
 import { execFile as execFileCb2 } from "node:child_process";
 import { promisify as promisify3 } from "node:util";
-import { existsSync as existsSync22, readFileSync as readFileSync24, writeFileSync as writeFileSync10 } from "node:fs";
+import { existsSync as existsSync23, readFileSync as readFileSync25, writeFileSync as writeFileSync11 } from "node:fs";
 import { tmpdir as tmpdir7 } from "node:os";
-import { basename as basename10, join as join29, dirname as dirname18 } from "node:path";
+import { basename as basename10, join as join30, dirname as dirname19 } from "node:path";
 async function runFlowParked(run, opts = {}) {
   const stale = opts.markCdpStale ?? markCdpStale;
   try {
@@ -34278,11 +34424,11 @@ function createMaestroRunHandler(deps = {}) {
     } else if (args.inlineYaml) {
       rawYaml = args.inlineYaml;
     } else if (args.flowPath) {
-      if (!existsSync22(args.flowPath)) {
+      if (!existsSync23(args.flowPath)) {
         return failResult(`Flow file not found: ${args.flowPath}`);
       }
       try {
-        rawYaml = readFileSync24(args.flowPath, "utf-8");
+        rawYaml = readFileSync25(args.flowPath, "utf-8");
       } catch (err) {
         return failResult(`Failed to read flow file: ${err.message}`);
       }
@@ -34290,7 +34436,7 @@ function createMaestroRunHandler(deps = {}) {
       return failResult("Provide either flowPath or inlineYaml.");
     }
     try {
-      const runFlowOpts = args.flowPath && flowPathClassification === "outside" ? { flowDir: dirname18(args.flowPath), flowRoot: dirname18(args.flowPath) } : {};
+      const runFlowOpts = args.flowPath && flowPathClassification === "outside" ? { flowDir: dirname19(args.flowPath), flowRoot: dirname19(args.flowPath) } : {};
       const parsed = parseAndValidateFlow(rawYaml, runFlowOpts);
       planMaestroAuthorityStages(parsed.commands);
       validatedCommands = parsed.commands;
@@ -34298,8 +34444,8 @@ function createMaestroRunHandler(deps = {}) {
       const rawAppId = resolveAppId(args.appId, platform);
       headerAppId = resolveMaestroFlowAppId(rawAppId || void 0, parsed.appId);
       validatedContent = buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, parsed.commands);
-      flowFile = join29(tmpdir7(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
-      writeFileSync10(flowFile, validatedContent, "utf-8");
+      flowFile = join30(tmpdir7(), `rn-maestro-run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      writeFileSync11(flowFile, validatedContent, "utf-8");
     } catch (err) {
       if (err instanceof MaestroValidationError) {
         return failResult(`Refusing to run Maestro: ${err.message} (Phase 134.1)`);
@@ -34411,7 +34557,7 @@ function createMaestroRunHandler(deps = {}) {
       const relaunchManagedApp = args.relaunchManagedApp ?? deps.relaunchManagedApp ?? managedAuthority.relaunchManagedApp;
       const reproveManagedOrigin = args.reproveManagedOrigin ?? deps.reproveManagedOrigin ?? managedAuthority.reproveManagedOrigin;
       const stageResults = await parkFlow(() => executeMaestroAuthorityStages(validatedCommands, async (commands) => {
-        writeFileSync10(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
+        writeFileSync11(flowFile, buildMaestroFlow(headerAppId ? { appId: headerAppId } : {}, [...commands]), "utf-8");
         const executeOnce = async (beforeDispatch) => {
           if (flowDeadline - now() <= 0) {
             const error2 = new Error("Maestro flow timeout exhausted before the next stage");
@@ -34654,7 +34800,7 @@ function createMaestroRunHandler(deps = {}) {
       return failResult(failAug.message, failAug.meta);
     } finally {
       try {
-        writeFileSync10(flowFile, validatedContent, "utf-8");
+        writeFileSync11(flowFile, validatedContent, "utf-8");
       } finally {
         disposeRunnerReportDir(runnerReportDir);
       }
@@ -34706,7 +34852,7 @@ var init_maestro_run = __esm({
 
 // packages/rn-dev-agent-core/dist/session/managed-automation.js
 import { spawn as spawn6 } from "node:child_process";
-import { readdirSync as readdirSync11, readFileSync as readFileSync25, unlinkSync as unlinkSync10 } from "node:fs";
+import { readdirSync as readdirSync12, readFileSync as readFileSync26, unlinkSync as unlinkSync10 } from "node:fs";
 function sleep3(ms) {
   return new Promise((resolve21) => setTimeout(resolve21, ms));
 }
@@ -34723,12 +34869,12 @@ function processGroupLiveness(pgid) {
   if (process.platform !== "linux")
     return "unknown";
   try {
-    for (const entry of readdirSync11("/proc", { withFileTypes: true })) {
+    for (const entry of readdirSync12("/proc", { withFileTypes: true })) {
       if (!entry.isDirectory() || !/^\d+$/.test(entry.name))
         continue;
       let stat2;
       try {
-        stat2 = readFileSync25(`/proc/${entry.name}/stat`, "utf8");
+        stat2 = readFileSync26(`/proc/${entry.name}/stat`, "utf8");
       } catch (error2) {
         if (error2.code === "ENOENT")
           continue;
@@ -35344,8 +35490,8 @@ var init_device_arbiter = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/maestro-invoke.js
-import { writeFileSync as writeFileSync11 } from "node:fs";
-import { join as join30 } from "node:path";
+import { writeFileSync as writeFileSync12 } from "node:fs";
+import { join as join31 } from "node:path";
 import { tmpdir as tmpdir8 } from "node:os";
 function yamlEscape(s) {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t");
@@ -35376,7 +35522,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     return { passed: false, output: "", flowFile: "", error: pinRefusal };
   }
   const rawAppId = opts.appId ?? resolveBundleId(opts.platform) ?? readExpoSlug() ?? "";
-  const flowFile = join30(tmpdir8(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+  const flowFile = join31(tmpdir8(), `rn-maestro-invoke-${opts.slug ?? "flow"}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
   let content;
   let headerAppId;
   try {
@@ -35414,7 +35560,7 @@ async function runMaestroInline(yaml2, opts, dependencies = {}) {
     throw err;
   }
   try {
-    writeFileSync11(flowFile, content, "utf-8");
+    writeFileSync12(flowFile, content, "utf-8");
   } catch (err) {
     return {
       passed: false,
@@ -35786,9 +35932,9 @@ var init_app_lifecycle = __esm({
 
 // packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js
 import { execFileSync as execFileSync13 } from "node:child_process";
-import { existsSync as existsSync23, readFileSync as readFileSync26, unlinkSync as unlinkSync11 } from "node:fs";
+import { existsSync as existsSync24, readFileSync as readFileSync27, unlinkSync as unlinkSync11 } from "node:fs";
 import { homedir as homedir5 } from "node:os";
-import { join as join31 } from "node:path";
+import { join as join32 } from "node:path";
 function selectInstalledLegacyApps(installed) {
   return LEGACY_BUNDLE_IDS.filter((id) => installed.has(id));
 }
@@ -35855,13 +36001,13 @@ function defaultDeps() {
     },
     readDaemonPid: () => {
       try {
-        const parsed = JSON.parse(readFileSync26(DAEMON_JSON, "utf8"));
+        const parsed = JSON.parse(readFileSync27(DAEMON_JSON, "utf8"));
         return typeof parsed.pid === "number" ? parsed.pid : null;
       } catch {
         return null;
       }
     },
-    fileExists: (path) => existsSync23(path),
+    fileExists: (path) => existsSync24(path),
     removeFile: (path) => unlinkSync11(path),
     delay: (ms) => new Promise((resolve21) => setTimeout(resolve21, ms)),
     listApps: (udid) => execFileSync13("xcrun", ["simctl", "listapps", udid], {
@@ -35944,8 +36090,8 @@ var init_ensure_single_runner = __esm({
   "packages/rn-dev-agent-core/dist/runners/ensure-single-runner.js"() {
     "use strict";
     init_discovery();
-    DAEMON_JSON = join31(homedir5(), ".agent-device", "daemon.json");
-    DAEMON_LOCK = join31(homedir5(), ".agent-device", "daemon.lock");
+    DAEMON_JSON = join32(homedir5(), ".agent-device", "daemon.json");
+    DAEMON_LOCK = join32(homedir5(), ".agent-device", "daemon.lock");
     DAEMON_FILES = [DAEMON_JSON, DAEMON_LOCK];
     SIGKILL_GRACE_MS = 500;
     LEGACY_BUNDLE_IDS = [
@@ -36072,9 +36218,9 @@ var init_recover_detached = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/lifecycle/device-lock.js
-import { existsSync as existsSync24, mkdirSync as mkdirSync18, openSync as openSync10, writeSync as writeSync3, closeSync as closeSync10, readFileSync as readFileSync27, unlinkSync as unlinkSync12, writeFileSync as writeFileSync12 } from "node:fs";
+import { existsSync as existsSync25, mkdirSync as mkdirSync19, openSync as openSync10, writeSync as writeSync3, closeSync as closeSync10, readFileSync as readFileSync28, unlinkSync as unlinkSync12, writeFileSync as writeFileSync13 } from "node:fs";
 import { tmpdir as tmpdir9, userInfo as userInfo2 } from "node:os";
-import { join as join32 } from "node:path";
+import { join as join33 } from "node:path";
 function defaultProcessAlive3(pid) {
   try {
     process.kill(pid, 0);
@@ -36127,7 +36273,7 @@ var init_device_lock = __esm({
         this.clock = opts.clock ?? Date.now;
         this.processAlive = opts.processAlive ?? defaultProcessAlive3;
         this.staleMs = opts.staleMs ?? DEVICE_LOCK_STALE_MS;
-        this.lockPath = join32(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
+        this.lockPath = join33(this.tmpDir, `rn-dev-agent-device-${uid}-${this.platform}-${this.deviceId}.lock`);
       }
       acquire() {
         try {
@@ -36169,7 +36315,7 @@ var init_device_lock = __esm({
           return;
         holder.lastHeartbeat = this.clock();
         try {
-          writeFileSync12(this.lockPath, JSON.stringify(holder, null, 2), "utf8");
+          writeFileSync13(this.lockPath, JSON.stringify(holder, null, 2), "utf8");
         } catch {
         }
       }
@@ -36185,8 +36331,8 @@ var init_device_lock = __esm({
         this.acquired = false;
       }
       create() {
-        if (!existsSync24(this.tmpDir))
-          mkdirSync18(this.tmpDir, { recursive: true });
+        if (!existsSync25(this.tmpDir))
+          mkdirSync19(this.tmpDir, { recursive: true });
         const fd = openSync10(this.lockPath, "wx");
         try {
           const now = this.clock();
@@ -36208,7 +36354,7 @@ var init_device_lock = __esm({
       }
       readExisting() {
         try {
-          const parsed = JSON.parse(readFileSync27(this.lockPath, "utf8"));
+          const parsed = JSON.parse(readFileSync28(this.lockPath, "utf8"));
           if (!isValidBody(parsed))
             return null;
           if (parsed.deviceId !== this.deviceId || parsed.platform !== this.platform)
@@ -38892,10 +39038,10 @@ __export(rn_android_runner_client_exports, {
 });
 import { spawn as spawn7, execFile as execFile12 } from "node:child_process";
 import { promisify as promisify12 } from "node:util";
-import { existsSync as existsSync25, rmSync as rmSync11, writeFileSync as writeFileSync13 } from "node:fs";
+import { existsSync as existsSync26, rmSync as rmSync11, writeFileSync as writeFileSync14 } from "node:fs";
 import { tmpdir as tmpdir10 } from "node:os";
 import { randomBytes as randomBytes5, randomUUID as randomUUID7 } from "node:crypto";
-import { join as join33 } from "node:path";
+import { join as join34 } from "node:path";
 function getAndroidRunnerState() {
   return runnerState2;
 }
@@ -39098,7 +39244,7 @@ async function ensureAndroidRunnerInstalled(deviceId, opts = {}) {
     pendingUpgradeNote = artifacts.note;
   const action = resolveAndroidInstallAction({
     instrumentationRegistered: !opts.forceReinstall && isInstrumentationRegistered(pmOut, INSTRUMENTATION),
-    apksExist: existsSync25(artifacts.appApk) && existsSync25(artifacts.testApk)
+    apksExist: existsSync26(artifacts.appApk) && existsSync26(artifacts.testApk)
   });
   if (action === "reuse")
     return provenance;
@@ -39555,7 +39701,7 @@ function androidRetryCleanupContext(state, error2) {
   return state ?? (error2.deviceId ? { deviceId: error2.deviceId } : null);
 }
 function androidRunnerApksExist() {
-  return RUNNER_APK_PATHS.every((p) => existsSync25(p));
+  return RUNNER_APK_PATHS.every((p) => existsSync26(p));
 }
 function _androidRunnerApkPathsForTest() {
   return RUNNER_APK_PATHS;
@@ -40099,8 +40245,8 @@ async function runAndroid(args) {
     const data = resp.data;
     if (!data?.pngBase64)
       return failResult("Android runner screenshot response did not include pngBase64", "SCREENSHOT_FAILED", recovery ? { transportRecovery: recovery } : void 0);
-    const outPath = args.outPath ?? join33(tmpdir10(), `rn-android-screenshot-${Date.now()}.png`);
-    writeFileSync13(outPath, Buffer.from(data.pngBase64, "base64"));
+    const outPath = args.outPath ?? join34(tmpdir10(), `rn-android-screenshot-${Date.now()}.png`);
+    writeFileSync14(outPath, Buffer.from(data.pngBase64, "base64"));
     return okResult({ path: outPath }, Object.keys(recoveryMeta).length ? { meta: recoveryMeta } : void 0);
   }
   return okResult(resp.data ?? {}, Object.keys(recoveryMeta).length ? { meta: recoveryMeta } : void 0);
@@ -40134,11 +40280,11 @@ var init_rn_android_runner_client = __esm({
     HEALTH_POLL_INTERVAL_MS = 150;
     HEALTH_PROBE_TIMEOUT_MS = 1e3;
     RN_ANDROID_RUNNER_DIR = resolveNativeRunnerDir("rn-android-runner");
-    GRADLEW = join33(RN_ANDROID_RUNNER_DIR, "gradlew");
-    APK_APP = join33(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "debug", "app-debug.apk");
-    APK_TEST = join33(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "androidTest", "debug", "app-debug-androidTest.apk");
-    ANDROID_REBUILD_ROOT = join33(RN_ANDROID_RUNNER_DIR, "app", "build");
-    ANDROID_REBUILD_LOCK_DATABASE = join33(ANDROID_REBUILD_ROOT, ".authority-rebuild", "lock.sqlite");
+    GRADLEW = join34(RN_ANDROID_RUNNER_DIR, "gradlew");
+    APK_APP = join34(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "debug", "app-debug.apk");
+    APK_TEST = join34(RN_ANDROID_RUNNER_DIR, "app", "build", "outputs", "apk", "androidTest", "debug", "app-debug-androidTest.apk");
+    ANDROID_REBUILD_ROOT = join34(RN_ANDROID_RUNNER_DIR, "app", "build");
+    ANDROID_REBUILD_LOCK_DATABASE = join34(ANDROID_REBUILD_ROOT, ".authority-rebuild", "lock.sqlite");
     ANDROID_REBUILD_LOCK_STALE_MS = 15 * 6e4;
     ANDROID_REBUILD_HEARTBEAT_MS = 6e4;
     ANDROID_REBUILD_COMPLETION_RETRY_MS = 1e3;
@@ -40185,9 +40331,9 @@ __export(release_android_slot_exports, {
 });
 import { execFile as execFileCb10 } from "node:child_process";
 import { promisify as promisify13 } from "node:util";
-import { existsSync as existsSync26, readFileSync as readFileSync28, unlinkSync as unlinkSync13 } from "node:fs";
+import { existsSync as existsSync27, readFileSync as readFileSync29, unlinkSync as unlinkSync13 } from "node:fs";
 import { homedir as homedir6 } from "node:os";
-import { join as join34 } from "node:path";
+import { join as join35 } from "node:path";
 function isProtectedPid(pid, selfPid, parentPid) {
   return pid === selfPid || pid === parentPid;
 }
@@ -40204,7 +40350,7 @@ function defaultDeps3() {
     resolveSerial: (deviceId) => deviceId ? ["-s", deviceId] : getAdbSerial(),
     readDaemonPid: () => {
       try {
-        const parsed = JSON.parse(readFileSync28(DAEMON_JSON2, "utf8"));
+        const parsed = JSON.parse(readFileSync29(DAEMON_JSON2, "utf8"));
         return typeof parsed.pid === "number" ? parsed.pid : null;
       } catch {
         return null;
@@ -40220,7 +40366,7 @@ function defaultDeps3() {
     },
     protectedPids: () => ({ selfPid: process.pid, parentPid: process.ppid }),
     kill: (pid, sig) => process.kill(pid, sig),
-    fileExists: (p) => existsSync26(p),
+    fileExists: (p) => existsSync27(p),
     removeFile: (p) => unlinkSync13(p),
     delay: (ms) => new Promise((resolve21) => setTimeout(resolve21, ms)),
     killLegacy: () => process.env.RN_DEVICE_KILL_LEGACY !== "0",
@@ -40334,8 +40480,8 @@ var init_release_android_slot = __esm({
     init_rn_android_runner_client();
     init_agent_device_wrapper();
     execFile13 = promisify13(execFileCb10);
-    DAEMON_JSON2 = join34(homedir6(), ".agent-device", "daemon.json");
-    DAEMON_LOCK2 = join34(homedir6(), ".agent-device", "daemon.lock");
+    DAEMON_JSON2 = join35(homedir6(), ".agent-device", "daemon.json");
+    DAEMON_LOCK2 = join35(homedir6(), ".agent-device", "daemon.lock");
     DAEMON_FILES2 = [DAEMON_JSON2, DAEMON_LOCK2];
     SIGKILL_GRACE_MS2 = 500;
     ADB_TIMEOUT_MS = 5e3;
@@ -40693,8 +40839,8 @@ var init_process_cleanup = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/session/startup-cleanup.js
-import { createHash as createHash13 } from "node:crypto";
-import { join as join35 } from "node:path";
+import { createHash as createHash14 } from "node:crypto";
+import { join as join36 } from "node:path";
 function startupCleanupFailureMessage() {
   return "rn-dev-agent startup cleanup failed: STARTUP_CLEANUP_FAILED\n";
 }
@@ -40745,7 +40891,7 @@ async function runStartupCleanupForSource(input) {
       appRootKey: input.source.appRootKey,
       appRoot: input.source.appRoot
     }, {
-      readSessionSecret: (sessionId) => readJsonStateFile(join35(layout.sessions, sessionId, "secret.json"))
+      readSessionSecret: (sessionId) => readJsonStateFile(join36(layout.sessions, sessionId, "secret.json"))
     });
   } finally {
     registry2.close();
@@ -40804,7 +40950,7 @@ function restoreDeadOwnerIntegration(input, prior, plan, dependencies) {
 function verifiedDeadOwnerManifestSource(appRoot, binding, manifestSha256) {
   if (!/^[0-9a-f]{64}$/.test(manifestSha256))
     return void 0;
-  const verified = (candidate) => typeof candidate === "string" && createHash13("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
+  const verified = (candidate) => typeof candidate === "string" && createHash14("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
   let liveManifest;
   try {
     liveManifest = readPackageIntegrationInputs(appRoot).manifest ?? void 0;
@@ -40894,8 +41040,8 @@ var init_startup_cleanup = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/env-setup.js
-import { existsSync as existsSync27, readFileSync as readFileSync29 } from "node:fs";
-import { join as join37 } from "node:path";
+import { existsSync as existsSync28, readFileSync as readFileSync30 } from "node:fs";
+import { join as join38 } from "node:path";
 function ensureAndroidEnv() {
   if (!process.env.ANDROID_HOME) {
     if (process.env.ANDROID_SDK_ROOT) {
@@ -40903,12 +41049,12 @@ function ensureAndroidEnv() {
     } else {
       const home = process.env.HOME ?? "";
       const candidates = [
-        join37(home, "Library/Android/sdk"),
-        join37(home, "Android/Sdk"),
+        join38(home, "Library/Android/sdk"),
+        join38(home, "Android/Sdk"),
         "/opt/android-sdk"
       ];
       for (const c of candidates) {
-        if (existsSync27(c)) {
+        if (existsSync28(c)) {
           process.env.ANDROID_HOME = c;
           break;
         }
@@ -40916,8 +41062,8 @@ function ensureAndroidEnv() {
     }
   }
   if (process.env.ANDROID_HOME) {
-    const pt = join37(process.env.ANDROID_HOME, "platform-tools");
-    const emu = join37(process.env.ANDROID_HOME, "emulator");
+    const pt = join38(process.env.ANDROID_HOME, "platform-tools");
+    const emu = join38(process.env.ANDROID_HOME, "emulator");
     const path = process.env.PATH ?? "";
     if (!path.includes(pt))
       process.env.PATH = `${pt}:${path}`;
@@ -40925,19 +41071,19 @@ function ensureAndroidEnv() {
       process.env.PATH = `${emu}:${process.env.PATH}`;
   }
   if (!process.env.ANDROID_SERIAL) {
-    const serialFile = join37(process.env.TMPDIR ?? "/tmp", "rn-dev-agent-android-serial");
-    if (existsSync27(serialFile)) {
-      process.env.ANDROID_SERIAL = readFileSync29(serialFile, "utf8").trim();
+    const serialFile = join38(process.env.TMPDIR ?? "/tmp", "rn-dev-agent-android-serial");
+    if (existsSync28(serialFile)) {
+      process.env.ANDROID_SERIAL = readFileSync30(serialFile, "utf8").trim();
     }
   }
 }
 function ensureJavaEnv() {
   const path = process.env.PATH ?? "";
-  if (path.split(":").some((p) => existsSync27(join37(p, "java"))))
+  if (path.split(":").some((p) => existsSync28(join38(p, "java"))))
     return;
   const candidates = ["/opt/homebrew/opt/openjdk@17", "/opt/homebrew/opt/openjdk"];
   for (const jdk of candidates) {
-    if (existsSync27(join37(jdk, "bin/java"))) {
+    if (existsSync28(join38(jdk, "bin/java"))) {
       process.env.JAVA_HOME = jdk;
       process.env.PATH = `${jdk}/bin:${process.env.PATH}`;
       break;
@@ -66785,9 +66931,9 @@ var init_ws_origin = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/cdp/state.js
-import { writeFileSync as writeFileSync14, unlinkSync as unlinkSync14 } from "node:fs";
+import { writeFileSync as writeFileSync15, unlinkSync as unlinkSync14 } from "node:fs";
 import { tmpdir as tmpdir11 } from "node:os";
-import { join as join38 } from "node:path";
+import { join as join39 } from "node:path";
 function resetState(s) {
   s.setState("disconnected");
   s.setHelpersInjected(false);
@@ -66802,11 +66948,11 @@ function resetState(s) {
 }
 function setActiveFlag(port, target) {
   try {
-    writeFileSync14(CDP_ACTIVE_FLAG, String(process.pid));
+    writeFileSync15(CDP_ACTIVE_FLAG, String(process.pid));
   } catch {
   }
   try {
-    writeFileSync14(CDP_SESSION_FILE, JSON.stringify({
+    writeFileSync15(CDP_SESSION_FILE, JSON.stringify({
       port,
       platform: target?.platform ?? null,
       target: target?.title ?? null,
@@ -66833,8 +66979,8 @@ var CDP_ACTIVE_FLAG, CDP_SESSION_FILE;
 var init_state = __esm({
   "packages/rn-dev-agent-core/dist/cdp/state.js"() {
     "use strict";
-    CDP_ACTIVE_FLAG = join38(tmpdir11(), "rn-dev-agent-cdp-active");
-    CDP_SESSION_FILE = join38(tmpdir11(), "rn-dev-agent-cdp-session.json");
+    CDP_ACTIVE_FLAG = join39(tmpdir11(), "rn-dev-agent-cdp-active");
+    CDP_SESSION_FILE = join39(tmpdir11(), "rn-dev-agent-cdp-session.json");
   }
 });
 
@@ -72899,8 +73045,8 @@ var init_mutation_absence = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/verification/config.js
-import { existsSync as existsSync28, readFileSync as readFileSync30 } from "node:fs";
-import { join as join39 } from "node:path";
+import { existsSync as existsSync29, readFileSync as readFileSync31 } from "node:fs";
+import { join as join40 } from "node:path";
 function getCachedProjectRoot() {
   if (_cachedProjectRoot === void 0) {
     _cachedProjectRoot = findProjectRoot();
@@ -72952,14 +73098,14 @@ function loadVerificationConfig(projectRoot) {
   const cached2 = cache.get(projectRoot);
   if (cached2)
     return cached2;
-  const path = join39(projectRoot, ".rn-agent", "config.json");
-  if (!existsSync28(path)) {
+  const path = join40(projectRoot, ".rn-agent", "config.json");
+  if (!existsSync29(path)) {
     cache.set(projectRoot, DEFAULTS);
     return DEFAULTS;
   }
   let raw;
   try {
-    raw = JSON.parse(readFileSync30(path, "utf-8"));
+    raw = JSON.parse(readFileSync31(path, "utf-8"));
   } catch {
     cache.set(projectRoot, DEFAULTS);
     return DEFAULTS;
@@ -73351,19 +73497,19 @@ var init_install_identity_inspection = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/session/migration-diagnostic.js
-import { createHash as createHash15 } from "node:crypto";
-import { existsSync as existsSync29, readFileSync as readFileSync31 } from "node:fs";
-import { join as join40 } from "node:path";
+import { createHash as createHash16 } from "node:crypto";
+import { existsSync as existsSync30, readFileSync as readFileSync32 } from "node:fs";
+import { join as join41 } from "node:path";
 function readPackageIntegrationManifest(appRoot, dependencies) {
-  const manifestPath = join40(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
+  const manifestPath = join41(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
   if (dependencies.exists || dependencies.readText) {
-    const exists = dependencies.exists ?? existsSync29;
+    const exists = dependencies.exists ?? existsSync30;
     if (!exists(manifestPath))
       return void 0;
-    const readText = dependencies.readText ?? ((path) => readFileSync31(path, "utf8"));
+    const readText = dependencies.readText ?? ((path) => readFileSync32(path, "utf8"));
     return readText(manifestPath);
   }
-  const agent = openBoundDirectory(join40(appRoot, ".rn-agent"));
+  const agent = openBoundDirectory(join41(appRoot, ".rn-agent"));
   let integration;
   let primaryError;
   try {
@@ -73381,7 +73527,7 @@ function readPackageIntegrationManifest(appRoot, dependencies) {
   }
 }
 function inspectAuthorityMigration(status, dependencies = {}) {
-  const exists = dependencies.exists ?? existsSync29;
+  const exists = dependencies.exists ?? existsSync30;
   const appRoot = typeof status.source.appRoot === "string" ? status.source.appRoot : "";
   let packageIntegrationInstalled = false;
   let onDiskManifestText;
@@ -73400,7 +73546,7 @@ function inspectAuthorityMigration(status, dependencies = {}) {
   const integrationBinding = status.bindings.packageIntegration;
   let bindingDiagnostic = null;
   if (integrationBinding) {
-    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash15("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
+    const manifestVerified = (candidate) => typeof candidate === "string" && typeof integrationBinding.manifestSha256 === "string" && createHash16("sha256").update(candidate).digest("hex") === integrationBinding.manifestSha256;
     const manifestAvailable = manifestVerified(onDiskManifestText) || manifestVerified(integrationBinding.restoration?.phase === "started" ? integrationBinding.restoration.manifestSource : void 0) || manifestVerified(integrationBinding.installation?.phase === "started" ? integrationBinding.installation.manifestSource : void 0) || manifestVerified(integrationBinding.manifestSource);
     const effectiveOwnerSessionId = status.sessionId;
     const trustedDigestRecorded = typeof integrationBinding.manifestSha256 === "string" && /^[0-9a-f]{64}$/.test(integrationBinding.manifestSha256);
@@ -73693,9 +73839,9 @@ var init_device_existence = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/session.js
-import { dirname as dirname21, isAbsolute as isAbsolute9, join as join41, resolve as resolve15 } from "node:path";
+import { dirname as dirname22, isAbsolute as isAbsolute9, join as join42, resolve as resolve15 } from "node:path";
 import { fileURLToPath as fileURLToPath2 } from "node:url";
-import { createHash as createHash16 } from "node:crypto";
+import { createHash as createHash17 } from "node:crypto";
 function sameAndroidMetroReverse(current, next) {
   if (!current || !next)
     return current === next;
@@ -73708,7 +73854,7 @@ function sameMetroAuthority(current, next) {
 function verifiedManifestSource(candidate, manifestSha256) {
   if (typeof candidate !== "string" || typeof manifestSha256 !== "string")
     return void 0;
-  return createHash16("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
+  return createHash17("sha256").update(candidate).digest("hex") === manifestSha256 ? candidate : void 0;
 }
 function durableBindingManifestSource(binding) {
   return verifiedManifestSource(binding?.manifestSource, binding?.manifestSha256);
@@ -74619,9 +74765,9 @@ function createSessionHandler(runtime, dependencies = {}) {
         if (input.action !== "restore_integration") {
           assertDeclaredProjectRootMatches(status, input.projectRoot, sessionSourceResolver(status, dependencies));
         }
-        const packagePath = join41(appRoot, "package.json");
+        const packagePath = join42(appRoot, "package.json");
         const integrationInputs = readPackageIntegrationInputs(appRoot);
-        const manifestPath = join41(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
+        const manifestPath = join42(appRoot, ".rn-agent", "integration", "rn-session-integration.json");
         const packageJson = JSON.parse(integrationInputs.packageJson);
         const integrationBinding = status.bindings.packageIntegration;
         const installationManifestSource = integrationBinding?.installation?.phase === "started" && typeof integrationBinding.installation.manifestSource === "string" ? integrationBinding.installation.manifestSource : void 0;
@@ -74634,7 +74780,7 @@ function createSessionHandler(runtime, dependencies = {}) {
           if (!(error2 instanceof SyntaxError))
             throw error2;
         }
-        const sessionCli = process.env.RN_DEV_AGENT_SESSION_CLI ?? join41(dirname21(fileURLToPath2(import.meta.url)), "..", "rn-session.js");
+        const sessionCli = process.env.RN_DEV_AGENT_SESSION_CLI ?? join42(dirname22(fileURLToPath2(import.meta.url)), "..", "rn-session.js");
         const stateDir = process.env.RN_DEV_AGENT_STATE_DIR;
         if (input.action === "restore_integration") {
           if (input.confirmed !== true) {
@@ -74651,7 +74797,7 @@ function createSessionHandler(runtime, dependencies = {}) {
             });
           }
           assertPackageIntegrationInactive(status.bindings, input.action);
-          const manifestSha256 = createHash16("sha256").update(manifestSource ?? "").digest("hex");
+          const manifestSha256 = createHash17("sha256").update(manifestSource ?? "").digest("hex");
           if (integrationBinding?.version !== 1 || typeof integrationBinding.installedBySessionId !== "string" || integrationBinding.manifestSha256 !== manifestSha256) {
             throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "integration restoration requires the transferred manifest authority binding");
           }
@@ -74698,7 +74844,7 @@ function createSessionHandler(runtime, dependencies = {}) {
         }
         preview.manifest.metroConfig = metroConfigPath.slice(appRoot.length + 1);
         const expectedManifestSource = installationManifestSource ?? serializePackageIntegrationManifest(preview.manifest);
-        const expectedManifestSha256 = createHash16("sha256").update(expectedManifestSource).digest("hex");
+        const expectedManifestSha256 = createHash17("sha256").update(expectedManifestSource).digest("hex");
         if (installationManifestSource && (integrationBinding?.version !== 1 || integrationBinding.installedBySessionId !== session2.sessionId || integrationBinding.manifestSha256 !== expectedManifestSha256)) {
           throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "integration installation requires the original session manifest authority binding");
         }
@@ -74720,7 +74866,7 @@ function createSessionHandler(runtime, dependencies = {}) {
           if (!installedManifest) {
             throw new Error("SESSION_INTEGRATION_PATH_UNSAFE: applied manifest is unavailable");
           }
-          if (createHash16("sha256").update(installedManifest).digest("hex") !== expectedManifestSha256) {
+          if (createHash17("sha256").update(installedManifest).digest("hex") !== expectedManifestSha256) {
             throw new SessionAuthorityError("SESSION_AUTHORITY_REQUIRED", "applied integration manifest no longer matches its durable installation authority");
           }
           registry2.updateBindings(session2, {
@@ -76925,10 +77071,10 @@ var init_recorder = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/device-list.js
-import { mkdirSync as mkdirSync19 } from "node:fs";
+import { mkdirSync as mkdirSync20 } from "node:fs";
 import { execFile as execFile17 } from "node:child_process";
 import { promisify as promisify18 } from "node:util";
-import { dirname as dirname22, join as join42, resolve as resolve16 } from "node:path";
+import { dirname as dirname23, join as join43, resolve as resolve16 } from "node:path";
 import { homedir as homedir8 } from "node:os";
 function parseSimctlDevicesAll(jsonText) {
   try {
@@ -76972,7 +77118,7 @@ function deriveScreenshotPath(args, now = Date.now, rand = Math.random) {
   }
   if (args.path?.startsWith("~")) {
     if (args.path.startsWith("~/"))
-      return join42(homedir8(), args.path.slice(2));
+      return join43(homedir8(), args.path.slice(2));
     throw new TildeScreenshotPathError(`Screenshot path "${args.path}" starts with '~' which the bridge cannot expand (only a leading '~/' is expanded to the home directory). Pass an absolute path instead.`);
   }
   if (args.path)
@@ -76983,7 +77129,7 @@ function deriveScreenshotPath(args, now = Date.now, rand = Math.random) {
 }
 function ensureScreenshotDir(path) {
   try {
-    mkdirSync19(dirname22(path), { recursive: true });
+    mkdirSync20(dirname23(path), { recursive: true });
     return { ok: true };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
@@ -79186,7 +79332,7 @@ var init_test_recorder_generators = __esm({
 
 // packages/rn-dev-agent-core/dist/tools/test-recorder.js
 import { mkdir, readdir, readFile as readFile2, writeFile } from "node:fs/promises";
-import { join as join43 } from "node:path";
+import { join as join44 } from "node:path";
 function deduplicateEvents(events) {
   const out = [];
   for (let i = 0; i < events.length; i++) {
@@ -79369,7 +79515,7 @@ function createRecordTestSaveHandler(getClient2) {
     if (!safe) {
       return failResult("Filename is empty after sanitization", "BAD_FILENAME");
     }
-    const filePath = join43(dir, `${safe}.json`);
+    const filePath = join44(dir, `${safe}.json`);
     const payload = { savedAt: (/* @__PURE__ */ new Date()).toISOString(), events: storedEvents };
     await writeFile(filePath, JSON.stringify(payload, null, 2), "utf8");
     return okResult({
@@ -79390,7 +79536,7 @@ function createRecordTestLoadHandler(getClient2) {
     if (!safe) {
       return failResult("Filename is empty after sanitization", "BAD_FILENAME");
     }
-    const filePath = join43(dir, `${safe}.json`);
+    const filePath = join44(dir, `${safe}.json`);
     let raw;
     try {
       raw = await readFile2(filePath, "utf8");
@@ -83458,11 +83604,11 @@ var init_device_deeplink = __esm({
 
 // packages/rn-dev-agent-core/dist/tools/device-record.js
 import { execFile as execFile22 } from "node:child_process";
-import { createHash as createHash17 } from "node:crypto";
-import { existsSync as existsSync30 } from "node:fs";
+import { createHash as createHash18 } from "node:crypto";
+import { existsSync as existsSync31 } from "node:fs";
 import { promisify as promisify23 } from "node:util";
 import { fileURLToPath as fileURLToPath3 } from "node:url";
-import { dirname as dirname23, join as join44 } from "node:path";
+import { dirname as dirname24, join as join45 } from "node:path";
 function parseAllBootedIosDevices(jsonText) {
   let data;
   try {
@@ -83541,28 +83687,28 @@ function compactUnique2(paths) {
   }
   return out;
 }
-function candidateRecordScripts(baseDir = dirname23(fileURLToPath3(import.meta.url))) {
+function candidateRecordScripts(baseDir = dirname24(fileURLToPath3(import.meta.url))) {
   const codexPluginRoot = process.env.RN_DEV_AGENT_CODEX_PLUGIN_ROOT;
   const claudePluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
   return compactUnique2([
     process.env.RN_DEV_AGENT_RECORD_PROOF_SCRIPT,
-    codexPluginRoot ? join44(codexPluginRoot, "scripts", "record_proof.sh") : void 0,
-    claudePluginRoot ? join44(claudePluginRoot, "scripts", "record_proof.sh") : void 0,
-    claudePluginRoot ? join44(claudePluginRoot, "..", "..", "scripts", "record_proof.sh") : void 0,
+    codexPluginRoot ? join45(codexPluginRoot, "scripts", "record_proof.sh") : void 0,
+    claudePluginRoot ? join45(claudePluginRoot, "scripts", "record_proof.sh") : void 0,
+    claudePluginRoot ? join45(claudePluginRoot, "..", "..", "scripts", "record_proof.sh") : void 0,
     // Bundled Codex runtime: <plugin>/rn-dev-agent-core/dist.
-    join44(baseDir, "..", "..", "scripts", "record_proof.sh"),
+    join45(baseDir, "..", "..", "scripts", "record_proof.sh"),
     // Source core bundle: packages/rn-dev-agent-core/dist/supervisor.js.
-    join44(baseDir, "..", "..", "..", "scripts", "record_proof.sh"),
+    join45(baseDir, "..", "..", "..", "scripts", "record_proof.sh"),
     // Source module build: packages/rn-dev-agent-core/dist/tools/device-record.js.
-    join44(baseDir, "..", "..", "..", "..", "scripts", "record_proof.sh")
+    join45(baseDir, "..", "..", "..", "..", "scripts", "record_proof.sh")
   ]);
 }
-function resolveRecordScript(baseDir = dirname23(fileURLToPath3(import.meta.url))) {
+function resolveRecordScript(baseDir = dirname24(fileURLToPath3(import.meta.url))) {
   if (process.env.RN_DEV_AGENT_RECORD_PROOF_SCRIPT) {
     return process.env.RN_DEV_AGENT_RECORD_PROOF_SCRIPT;
   }
   const candidates = candidateRecordScripts(baseDir);
-  return candidates.find((path) => existsSync30(path)) ?? candidates[0];
+  return candidates.find((path) => existsSync31(path)) ?? candidates[0];
 }
 function getRecordScript() {
   return resolveRecordScript();
@@ -83606,7 +83752,7 @@ function parseStatusOutput(stdout) {
   return active;
 }
 function recordingScope(args) {
-  return createHash17("sha256").update(`${args.sessionId}\0${args.claimEpoch}\0${args.platform}\0${args.deviceId}`).digest("hex");
+  return createHash18("sha256").update(`${args.sessionId}\0${args.claimEpoch}\0${args.platform}\0${args.deviceId}`).digest("hex");
 }
 function bindRecorderSession(runtime, args) {
   const available = runtime.requireAvailable();
@@ -83890,7 +84036,7 @@ var init_device_record = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/proof-capture.js
-import { createHash as createHash18 } from "node:crypto";
+import { createHash as createHash19 } from "node:crypto";
 function canonicalizeProofValue(value) {
   if (Array.isArray(value))
     return value.map(canonicalizeProofValue);
@@ -83902,14 +84048,14 @@ function hashProofArgs(params) {
   return hashProofValue(redact(params));
 }
 function hashProofValue(value) {
-  return createHash18("sha256").update(JSON.stringify(canonicalizeProofValue(value))).digest("hex");
+  return createHash19("sha256").update(JSON.stringify(canonicalizeProofValue(value))).digest("hex");
 }
 function proofRuntimeAuthorityMarker(input) {
   return hashProofValue(input);
 }
 function hashObservedValue(value) {
   const bytes = JSON.stringify(value) ?? String(value);
-  return createHash18("sha256").update(bytes).digest("hex");
+  return createHash19("sha256").update(bytes).digest("hex");
 }
 function resultEnvelope(result) {
   if (!result || typeof result !== "object")
@@ -84432,10 +84578,10 @@ var init_startup_integrity = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/proof-capture.js
-import { createHash as createHash19, randomUUID as randomUUID10 } from "node:crypto";
+import { createHash as createHash20, randomUUID as randomUUID10 } from "node:crypto";
 import { execFileSync as execFileSync15 } from "node:child_process";
-import { chmodSync as chmodSync7, closeSync as closeSync12, existsSync as existsSync31, fsyncSync, lstatSync as lstatSync16, mkdirSync as mkdirSync20, openSync as openSync12, readFileSync as readFileSync32, realpathSync as realpathSync14, renameSync as renameSync8, unlinkSync as unlinkSync15, writeFileSync as writeFileSync15 } from "node:fs";
-import { basename as basename11, dirname as dirname24, extname, isAbsolute as isAbsolute11, join as join45, relative as relative8, resolve as resolve17, sep as sep9 } from "node:path";
+import { chmodSync as chmodSync7, closeSync as closeSync12, existsSync as existsSync32, fsyncSync, lstatSync as lstatSync16, mkdirSync as mkdirSync21, openSync as openSync12, readFileSync as readFileSync33, realpathSync as realpathSync14, renameSync as renameSync9, unlinkSync as unlinkSync15, writeFileSync as writeFileSync16 } from "node:fs";
+import { basename as basename11, dirname as dirname25, extname, isAbsolute as isAbsolute11, join as join46, relative as relative8, resolve as resolve17, sep as sep9 } from "node:path";
 import { fileURLToPath as fileURLToPath4 } from "node:url";
 function proofActionPayload(unparsedArgs) {
   if (!unparsedArgs || typeof unparsedArgs !== "object" || Array.isArray(unparsedArgs)) {
@@ -84468,7 +84614,7 @@ function evidenceTimingReasons(timestamps, videoDurationMs, steps) {
   return reasons;
 }
 function hashBytes(bytes) {
-  return createHash19("sha256").update(bytes).digest("hex");
+  return createHash20("sha256").update(bytes).digest("hex");
 }
 function captureProofWorkerStartup(argv = process.argv, attestation = readStartupIntegrityAttestation()) {
   let executedEntrypointPath = null;
@@ -84521,9 +84667,9 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
     return null;
   }
   for (const host of ["claude-plugin", "codex-plugin"]) {
-    const hostRoot = join45(root, "packages", host);
-    const coreIndex = realpathOrSelf(join45(hostRoot, "rn-dev-agent-core", "dist", "index.js"));
-    const coreSupervisor = realpathOrSelf(join45(hostRoot, "rn-dev-agent-core", "dist", "supervisor.js"));
+    const hostRoot = join46(root, "packages", host);
+    const coreIndex = realpathOrSelf(join46(hostRoot, "rn-dev-agent-core", "dist", "index.js"));
+    const coreSupervisor = realpathOrSelf(join46(hostRoot, "rn-dev-agent-core", "dist", "supervisor.js"));
     if (arg === coreIndex) {
       return {
         host,
@@ -84542,8 +84688,8 @@ function resolveProofCandidateEntrypoint(candidateRoot, argv) {
         kind: "core-supervisor"
       };
     }
-    if (host === "codex-plugin" && arg === realpathOrSelf(join45(hostRoot, "bin", "cdp-supervisor.js"))) {
-      if (!existsSync31(coreIndex) || !existsSync31(coreSupervisor))
+    if (host === "codex-plugin" && arg === realpathOrSelf(join46(hostRoot, "bin", "cdp-supervisor.js"))) {
+      if (!existsSync32(coreIndex) || !existsSync32(coreSupervisor))
         return null;
       return {
         host,
@@ -84577,7 +84723,7 @@ function proofCandidateEntrypointEnvironmentMatches(entrypoint, env) {
   }
   if (supervisorOverride && supervisorOverride !== entrypoint.coreSupervisor)
     return false;
-  if (coreRootOverride && join45(coreRootOverride, "dist", "supervisor.js") !== entrypoint.coreSupervisor) {
+  if (coreRootOverride && join46(coreRootOverride, "dist", "supervisor.js") !== entrypoint.coreSupervisor) {
     return false;
   }
   if (workerOverride && workerOverride !== entrypoint.coreBundle)
@@ -84608,7 +84754,7 @@ function readProofCandidateHeadArtifacts(candidateRoot, artifactPaths) {
       const headBytes = execFileSync15("git", ["-C", root, "show", `HEAD:${artifactRelativePath}`], {
         maxBuffer: 128 * 1024 * 1024
       });
-      const artifactBytes = readFileSync32(resolvedArtifactPath);
+      const artifactBytes = readFileSync33(resolvedArtifactPath);
       if (hashBytes(artifactBytes) !== hashBytes(headBytes))
         return null;
       verifiedBytes.push(artifactBytes);
@@ -84635,7 +84781,7 @@ function readProofCandidateRuntime(candidateRoot, startup = proofWorkerStartup) 
     throw new Error("CANDIDATE_MCP_PROCESS_MISMATCH");
   }
   const { host, coreBundle } = entrypoint;
-  const runnerManifest = join45(root, "packages", host, "runner-manifest.json");
+  const runnerManifest = join46(root, "packages", host, "runner-manifest.json");
   const artifacts = readProofCandidateHeadArtifacts(root, [coreBundle, runnerManifest]);
   if (!artifacts) {
     throw new Error("CANDIDATE_CHECKOUT_NOT_CLEAN");
@@ -84693,7 +84839,7 @@ function readProofActionIdentity(appProjectRoot, actionId, dependencies = {}) {
     return {
       id: actionId,
       version: String(action.state.revision),
-      sha256: createHash19("sha256").update(action.yamlText).digest("hex")
+      sha256: createHash20("sha256").update(action.yamlText).digest("hex")
     };
   } catch {
     return null;
@@ -84730,7 +84876,7 @@ function validCaptureContext(args, expectedRoot) {
   ];
   if (proofTools.some((tool) => normalizeTool(tool) === "cdp_auto_login"))
     return false;
-  const proofRoot = join45(expectedRoot, "docs", "proof", args.runId);
+  const proofRoot = join46(expectedRoot, "docs", "proof", args.runId);
   const screenshots = args.storyboard.steps.map((step) => step.screenshotPath);
   const destinations = [args.receiptPath, args.videoPath, args.contactSheetPath, ...screenshots];
   if (destinations.some((path) => !isNormalizedDescendant(proofRoot, path) || hasExistingSymlink(expectedRoot, path)) || new Set(destinations).size !== destinations.length) {
@@ -84744,7 +84890,7 @@ function validCaptureContext(args, expectedRoot) {
   }));
 }
 function proofRootExists(args) {
-  const proofRoot = join45(args.projectRoot, "docs", "proof", args.runId);
+  const proofRoot = join46(args.projectRoot, "docs", "proof", args.runId);
   try {
     lstatSync16(proofRoot);
     return true;
@@ -84877,14 +85023,14 @@ function traceFor(storyboard, events) {
   return validateTrace([...required3, ...allowedExtras], events);
 }
 function readProofContractAt(moduleUrl = import.meta.url) {
-  const moduleDir = dirname24(fileURLToPath4(moduleUrl));
+  const moduleDir = dirname25(fileURLToPath4(moduleUrl));
   const candidates = [
     resolve17(moduleDir, "../../schemas/proof-receipt.schema.json"),
     resolve17(moduleDir, "../schemas/proof-receipt.schema.json")
   ];
   for (const path of candidates) {
     try {
-      const bytes = readFileSync32(path, "utf8");
+      const bytes = readFileSync33(path, "utf8");
       return { schema: JSON.parse(bytes), bytes, sha256: hashBytes(bytes) };
     } catch {
     }
@@ -84892,18 +85038,18 @@ function readProofContractAt(moduleUrl = import.meta.url) {
   throw new Error("PROOF_CONTRACT_MISSING");
 }
 function writeProofReceiptAtomic(path, receipt2) {
-  const directory = dirname24(path);
-  mkdirSync20(directory, { recursive: true, mode: 448 });
+  const directory = dirname25(path);
+  mkdirSync21(directory, { recursive: true, mode: 448 });
   const temporary = resolve17(directory, `.${randomUUID10()}.proof-receipt.tmp`);
   let descriptor = null;
   try {
     descriptor = openSync12(temporary, "wx", 384);
-    writeFileSync15(descriptor, `${JSON.stringify(receipt2, null, 2)}
+    writeFileSync16(descriptor, `${JSON.stringify(receipt2, null, 2)}
 `, "utf8");
     fsyncSync(descriptor);
     closeSync12(descriptor);
     descriptor = null;
-    renameSync8(temporary, path);
+    renameSync9(temporary, path);
     chmodSync7(path, 384);
   } catch (error2) {
     if (descriptor !== null)
@@ -85229,7 +85375,7 @@ function createProofCaptureHandler(deps) {
         return proofFailure(["PROOF_ACTION_IDENTITY_MISMATCH"], "idle");
       }
       try {
-        const proofRoot = join45(args.projectRoot, "docs", "proof", args.runId);
+        const proofRoot = join46(args.projectRoot, "docs", "proof", args.runId);
         if (deps.proofRootTracked(args.projectRoot, proofRoot)) {
           return proofFailure(["PROOF_ROOT_TRACKED"], "idle");
         }
@@ -85795,11 +85941,11 @@ var init_proof_capture2 = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/proof-media.js
-import { createHash as createHash20 } from "node:crypto";
+import { createHash as createHash21 } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { mkdir as mkdir2, mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir as tmpdir12 } from "node:os";
-import { dirname as dirname25, join as join46 } from "node:path";
+import { dirname as dirname26, join as join47 } from "node:path";
 function fail2(reason) {
   throw new MediaFailure(reason);
 }
@@ -85830,7 +85976,7 @@ async function hashAcceptedFile(path) {
   }
 }
 async function sha256File2(path) {
-  const hash = createHash20("sha256");
+  const hash = createHash21("sha256");
   const stream = createReadStream(path);
   for await (const chunk of stream)
     hash.update(chunk);
@@ -85928,7 +86074,7 @@ async function matchScreenshotAt(process3, input) {
   if (input.videoDurationMs !== void 0 && (!Number.isFinite(input.videoDurationMs) || input.videoDurationMs <= 0)) {
     fail2("INVALID_MEDIA_INPUT");
   }
-  const normalizedScreenshotPath = join46(input.scratchDir, `screenshot-${index}.png`);
+  const normalizedScreenshotPath = join47(input.scratchDir, `screenshot-${index}.png`);
   await rm(normalizedScreenshotPath, { force: true });
   await runFrameProcess(process3, [
     "-y",
@@ -85953,7 +86099,7 @@ async function matchScreenshotAt(process3, input) {
   let best = null;
   let decodedFrameCount = 0;
   for (const [sampleIndex, timestampMs] of sampleTimestamps.entries()) {
-    const framePath = join46(input.scratchDir, `frame-${index}-${sampleIndex}.jpg`);
+    const framePath = join47(input.scratchDir, `frame-${index}-${sampleIndex}.jpg`);
     await rm(framePath, { force: true });
     try {
       await runFrameProcess(process3, [
@@ -86025,7 +86171,7 @@ async function buildContactSheet(process3, selectedFramePaths, contactSheetPath)
     await requireNonEmptyFile(path, "FRAME_PROCESS_FAILED", "FRAME_PROCESS_FAILED");
   }
   try {
-    await mkdir2(dirname25(contactSheetPath), { recursive: true });
+    await mkdir2(dirname26(contactSheetPath), { recursive: true });
     await rm(contactSheetPath, { force: true });
   } catch {
     fail2("MEDIA_IO_FAILED");
@@ -86077,7 +86223,7 @@ async function validateMedia(process3, input) {
     const scratchRoot = input.scratchRoot ?? tmpdir12();
     try {
       await mkdir2(scratchRoot, { recursive: true });
-      scratchDir = await mkdtemp(join46(scratchRoot, "proof-media-"));
+      scratchDir = await mkdtemp(join47(scratchRoot, "proof-media-"));
     } catch {
       fail2("MEDIA_IO_FAILED");
     }
@@ -87299,8 +87445,8 @@ var init_nav_graph = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/auto-login.js
-import { lstatSync as lstatSync17, readFileSync as readFileSync33, readdirSync as readdirSync12, realpathSync as realpathSync15 } from "node:fs";
-import { dirname as dirname26, join as join47, resolve as resolve18 } from "node:path";
+import { lstatSync as lstatSync17, readFileSync as readFileSync34, readdirSync as readdirSync13, realpathSync as realpathSync15 } from "node:fs";
+import { dirname as dirname27, join as join48, resolve as resolve18 } from "node:path";
 function matchesAuthPattern(routeName) {
   const lower = routeName.toLowerCase();
   return AUTH_ROUTE_PATTERNS.some((p) => lower.includes(p));
@@ -87330,8 +87476,8 @@ async function isOnAuthScreen(client2) {
   }
 }
 function findLoginFlow(projectRoot) {
-  const maestroDir = join47(projectRoot, ".maestro");
-  const searchDirs = [join47(maestroDir, "subflows"), maestroDir];
+  const maestroDir = join48(projectRoot, ".maestro");
+  const searchDirs = [join48(maestroDir, "subflows"), maestroDir];
   for (const dir of searchDirs) {
     let files;
     try {
@@ -87342,7 +87488,7 @@ function findLoginFlow(projectRoot) {
       }
       if (!maestroStat.isDirectory() || !dirStat.isDirectory())
         continue;
-      files = readdirSync12(dir);
+      files = readdirSync13(dir);
     } catch (err) {
       if (err.code !== "ENOENT")
         throw err;
@@ -87350,12 +87496,12 @@ function findLoginFlow(projectRoot) {
     }
     for (const candidate of LOGIN_FLOW_PRIORITY) {
       if (files.includes(candidate)) {
-        return assertLegacyLoginFlow(projectRoot, join47(dir, candidate));
+        return assertLegacyLoginFlow(projectRoot, join48(dir, candidate));
       }
     }
     const authFile = files.find((f) => /\.(ya?ml)$/.test(f) && AUTH_ROUTE_PATTERNS.some((p) => f.toLowerCase().includes(p)));
     if (authFile)
-      return assertLegacyLoginFlow(projectRoot, join47(dir, authFile));
+      return assertLegacyLoginFlow(projectRoot, join48(dir, authFile));
   }
   return null;
 }
@@ -87462,12 +87608,12 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
     };
   }
   const rawAppId = opts.appId ?? projectAppId ?? "";
-  const originalContent = readFileSync33(flowPath, "utf-8");
+  const originalContent = readFileSync34(flowPath, "utf-8");
   let validatedCommands;
   try {
     const parsed = parseAndValidateFlow(originalContent, {
-      flowDir: dirname26(flowPath),
-      flowRoot: join47(projectRoot, ".maestro")
+      flowDir: dirname27(flowPath),
+      flowRoot: join48(projectRoot, ".maestro")
     });
     validatedCommands = parsed.commands;
     if (containsClearState(validatedCommands)) {
@@ -88032,7 +88178,7 @@ var init_graceful_shutdown = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/maestro-generate.js
-import { basename as basename12, dirname as dirname27, join as join48 } from "node:path";
+import { basename as basename12, dirname as dirname28, join as join49 } from "node:path";
 function stepToMaestroCommands(step) {
   const ALLOWED_DIRECTIONS = /* @__PURE__ */ new Set(["up", "down", "left", "right"]);
   switch (step.action) {
@@ -88091,7 +88237,7 @@ function createMaestroGenerateHandler() {
       return failResult("Flow name contains an unsafe control character or is too long.");
     }
     const root = findProjectRoot();
-    const outputDir = args.outputDir ?? (root ? join48(root, ".rn-agent", "actions") : null);
+    const outputDir = args.outputDir ?? (root ? join49(root, ".rn-agent", "actions") : null);
     if (!outputDir) {
       return failResult("Cannot determine project root. Pass outputDir explicitly.");
     }
@@ -88100,7 +88246,7 @@ function createMaestroGenerateHandler() {
       return failResult("Flow name must produce an action id that starts with a letter or number and is at most 64 characters.");
     }
     const fileName = `${sanitizedName}.yaml`;
-    const learnedProjectRoot = basename12(outputDir) === "actions" && basename12(dirname27(outputDir)) === ".rn-agent" ? dirname27(dirname27(outputDir)) : null;
+    const learnedProjectRoot = basename12(outputDir) === "actions" && basename12(dirname28(outputDir)) === ".rn-agent" ? dirname28(dirname28(outputDir)) : null;
     if (!learnedProjectRoot) {
       return failResult("Generated actions must be written to an owned .rn-agent/actions corpus.");
     }
@@ -88173,8 +88319,8 @@ var init_maestro_generate = __esm({
 // packages/rn-dev-agent-core/dist/tools/maestro-test-all.js
 import { execFile as execFileCb19 } from "node:child_process";
 import { promisify as promisify25 } from "node:util";
-import { existsSync as existsSync32, readdirSync as readdirSync13, readFileSync as readFileSync34, writeFileSync as writeFileSync16 } from "node:fs";
-import { basename as basename13, dirname as dirname28, join as join49, resolve as resolve19 } from "node:path";
+import { existsSync as existsSync33, readdirSync as readdirSync14, readFileSync as readFileSync35, writeFileSync as writeFileSync17 } from "node:fs";
+import { basename as basename13, dirname as dirname29, join as join50, resolve as resolve19 } from "node:path";
 import { tmpdir as tmpdir13 } from "node:os";
 function filterFlows(yamls, pattern) {
   if (pattern) {
@@ -88191,9 +88337,9 @@ function filterFlows(yamls, pattern) {
   return yamls;
 }
 function discoverFlows(dir, pattern) {
-  if (!existsSync32(dir))
+  if (!existsSync33(dir))
     return [];
-  const yamls = readdirSync13(dir, { recursive: true }).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).map((f) => join49(dir, f)).sort();
+  const yamls = readdirSync14(dir, { recursive: true }).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml")).map((f) => join50(dir, f)).sort();
   return filterFlows(yamls, pattern);
 }
 function createMaestroTestAllHandler(deps = {}) {
@@ -88225,17 +88371,17 @@ function createMaestroTestAllHandler(deps = {}) {
     if (pinRefusal)
       return failResult(pinRefusal);
     const root = findProjectRoot();
-    const flowDir = args.flowDir ?? (root ? join49(root, ".rn-agent", "actions") : null);
+    const flowDir = args.flowDir ?? (root ? join50(root, ".rn-agent", "actions") : null);
     if (!flowDir) {
       return failResult("Cannot determine project root. Pass flowDir explicitly.");
     }
     const resolvedFlowDir = resolve19(flowDir);
-    const flowDirClassification = classifyLearnedActionPath(join49(resolvedFlowDir, "__action__.yaml"));
+    const flowDirClassification = classifyLearnedActionPath(join50(resolvedFlowDir, "__action__.yaml"));
     if (flowDirClassification === "descendant") {
       return failResult(`Refusing to execute learned-action descendants from ${resolvedFlowDir} as standalone flows.`);
     }
     const learnedCorpus = flowDirClassification === "action";
-    const learnedProjectRoot = learnedCorpus ? dirname28(dirname28(resolvedFlowDir)) : null;
+    const learnedProjectRoot = learnedCorpus ? dirname29(dirname29(resolvedFlowDir)) : null;
     let learnedContext = null;
     if (learnedProjectRoot) {
       try {
@@ -88247,7 +88393,7 @@ function createMaestroTestAllHandler(deps = {}) {
     if (learnedCorpus && !learnedContext) {
       return failResult(`Refusing learned-action corpus without an approved load context: ${resolvedFlowDir}.`);
     }
-    const flows = learnedContext ? filterFlows(learnedContext.files.filter((file) => /\.ya?ml$/i.test(file)).map((file) => join49(flowDir, file)).sort(), args.pattern) : discoverFlows(flowDir, args.pattern);
+    const flows = learnedContext ? filterFlows(learnedContext.files.filter((file) => /\.ya?ml$/i.test(file)).map((file) => join50(flowDir, file)).sort(), args.pattern) : discoverFlows(flowDir, args.pattern);
     if (flows.length === 0) {
       return failResult(`No Maestro flows found in ${flowDir}. Generate flows with maestro_generate first.`);
     }
@@ -88274,9 +88420,9 @@ function createMaestroTestAllHandler(deps = {}) {
           meta = action.metadata;
           requireEnginePin = true;
         } else {
-          const yamlText = readFileSync34(flow, "utf-8");
+          const yamlText = readFileSync35(flow, "utf-8");
           const parsed = parseAndValidateFlow(yamlText, {
-            flowDir: dirname28(flow),
+            flowDir: dirname29(flow),
             flowRoot: flowDir
           });
           const flowId = name.replace(/\.ya?ml$/i, "");
@@ -88346,8 +88492,8 @@ function createMaestroTestAllHandler(deps = {}) {
     for (const prepared of preparedFlows) {
       const { name } = prepared;
       const start = now();
-      const safeFlowFile = join49(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
-      writeFileSync16(safeFlowFile, prepared.canonical, "utf-8");
+      const safeFlowFile = join50(tmpdir13(), `rn-maestro-validated-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.yaml`);
+      writeFileSync17(safeFlowFile, prepared.canonical, "utf-8");
       const parsedCommands = prepared.commands;
       const parsedAppId = prepared.appId;
       const appFile = prepared.appFile;
@@ -88370,7 +88516,7 @@ function createMaestroTestAllHandler(deps = {}) {
             Object.assign(error2, { code: "ETIMEDOUT" });
             throw error2;
           }
-          writeFileSync16(safeFlowFile, buildMaestroFlow(parsedAppId !== void 0 ? { appId: parsedAppId } : {}, [
+          writeFileSync17(safeFlowFile, buildMaestroFlow(parsedAppId !== void 0 ? { appId: parsedAppId } : {}, [
             ...commands
           ]), "utf-8");
           const executeRunner = (runnerPath, prefixArgs = []) => {
@@ -88515,8 +88661,8 @@ var init_maestro_test_all = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/tools/cross-platform-verify.js
-import { readFileSync as readFileSync35, readdirSync as readdirSync14, lstatSync as lstatSync18 } from "node:fs";
-import { join as join50, extname as extname2 } from "node:path";
+import { readFileSync as readFileSync36, readdirSync as readdirSync15, lstatSync as lstatSync18 } from "node:fs";
+import { join as join51, extname as extname2 } from "node:path";
 function findElement(nodes, query, matchBy) {
   const q = query.toLowerCase();
   return nodes.some((n) => {
@@ -88532,14 +88678,14 @@ function discoverTestIDs(dir) {
   function walk(d) {
     let entries;
     try {
-      entries = readdirSync14(d);
+      entries = readdirSync15(d);
     } catch {
       return;
     }
     for (const entry of entries) {
       if (entry === "node_modules" || entry.startsWith("."))
         continue;
-      const full = join50(d, entry);
+      const full = join51(d, entry);
       try {
         const st = lstatSync18(full);
         if (st.isSymbolicLink())
@@ -88550,7 +88696,7 @@ function discoverTestIDs(dir) {
         }
         if (!SCAN_EXTENSIONS.has(extname2(entry)))
           continue;
-        const src = readFileSync35(full, "utf8");
+        const src = readFileSync36(full, "utf8");
         for (const m of src.matchAll(TESTID_RE)) {
           const id = m[1] ?? m[2] ?? m[3];
           if (id)
@@ -88894,10 +89040,10 @@ var init_instrumentation = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/experience/evidence.js
-import { createHash as createHash21, randomUUID as randomUUID11 } from "node:crypto";
-import { chmodSync as chmodSync8, existsSync as existsSync33, mkdirSync as mkdirSync21, readFileSync as readFileSync36, renameSync as renameSync9, unlinkSync as unlinkSync16, writeFileSync as writeFileSync17 } from "node:fs";
+import { createHash as createHash22, randomUUID as randomUUID11 } from "node:crypto";
+import { chmodSync as chmodSync8, existsSync as existsSync34, mkdirSync as mkdirSync22, readFileSync as readFileSync37, renameSync as renameSync10, unlinkSync as unlinkSync16, writeFileSync as writeFileSync18 } from "node:fs";
 import { homedir as homedir9, platform as hostPlatform, release } from "node:os";
-import { dirname as dirname29, join as join51 } from "node:path";
+import { dirname as dirname30, join as join52 } from "node:path";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 function sanitizeString(value, redact2 = applyRedactionRules) {
   try {
@@ -88947,11 +89093,11 @@ function readAppIdentity() {
   return appIdentityCache.identity;
 }
 function loadAppIdentity(root) {
-  const manifest = join51(root, "app.json");
+  const manifest = join52(root, "app.json");
   try {
-    if (!existsSync33(manifest))
+    if (!existsSync34(manifest))
       return { name: null, slug: null };
-    const parsed = JSON.parse(readFileSync36(manifest, "utf8"));
+    const parsed = JSON.parse(readFileSync37(manifest, "utf8"));
     const expo = parsed.expo ?? parsed;
     return { name: usableIdentity(expo?.name), slug: usableIdentity(expo?.slug) };
   } catch {
@@ -88964,16 +89110,16 @@ function usableIdentity(value) {
 function discoverPluginVersion(fromUrl = import.meta.url) {
   if (process.env.RN_DEV_AGENT_PLUGIN_VERSION)
     return process.env.RN_DEV_AGENT_PLUGIN_VERSION;
-  const start = dirname29(fileURLToPath5(fromUrl));
+  const start = dirname30(fileURLToPath5(fromUrl));
   const candidates = [
-    join51(start, "..", "..", ".claude-plugin", "plugin.json"),
-    join51(start, "..", "..", ".codex-plugin", "plugin.json"),
-    join51(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
-    join51(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
+    join52(start, "..", "..", ".claude-plugin", "plugin.json"),
+    join52(start, "..", "..", ".codex-plugin", "plugin.json"),
+    join52(start, "..", "..", "..", "claude-plugin", ".claude-plugin", "plugin.json"),
+    join52(start, "..", "..", "..", "codex-plugin", ".codex-plugin", "plugin.json")
   ];
   for (const candidate of candidates) {
     try {
-      const parsed = JSON.parse(readFileSync36(candidate, "utf8"));
+      const parsed = JSON.parse(readFileSync37(candidate, "utf8"));
       if (typeof parsed.version === "string")
         return sanitizeString(parsed.version);
     } catch {
@@ -88982,9 +89128,9 @@ function discoverPluginVersion(fromUrl = import.meta.url) {
   return null;
 }
 function readExperienceStore(path) {
-  if (!existsSync33(path))
+  if (!existsSync34(path))
     return [];
-  const contents = readFileSync36(path, "utf8");
+  const contents = readFileSync37(path, "utf8");
   if (!contents.trim())
     return [];
   const records = [];
@@ -89009,7 +89155,7 @@ function pruneExperienceRecords(records, now, maxRecords = DEFAULT_MAX_RECORDS, 
   }).sort((a, b) => Date.parse(b.lastSeen) - Date.parse(a.lastSeen) || a.signature.localeCompare(b.signature)).slice(0, Math.max(0, maxRecords)).sort((a, b) => a.signature.localeCompare(b.signature));
 }
 function experienceSignature(input) {
-  return createHash21("sha256").update(JSON.stringify([
+  return createHash22("sha256").update(JSON.stringify([
     input.classification,
     input.tool,
     input.normalizedSymptomShape,
@@ -89092,7 +89238,7 @@ var init_evidence = __esm({
     DEFAULT_MAX_RECORDS = 500;
     DEFAULT_RETENTION_DAYS = 14;
     MAX_EVIDENCE_POINTERS = 3;
-    EXPERIENCE_DIRECTORY = join51(homedir9(), ".claude", "rn-agent", "experience");
+    EXPERIENCE_DIRECTORY = join52(homedir9(), ".claude", "rn-agent", "experience");
     EXPERIENCE_STORE_NAME = "patterns.jsonl";
     MAX_SYMPTOM_LENGTH = 2048;
     DAY_MS = 24 * 60 * 60 * 1e3;
@@ -89137,7 +89283,7 @@ var init_evidence = __esm({
       previousFailure = null;
       constructor(options) {
         this.directory = options.directory ?? process.env.RN_DEV_AGENT_EXPERIENCE_DIR ?? EXPERIENCE_DIRECTORY;
-        this.path = join51(this.directory, EXPERIENCE_STORE_NAME);
+        this.path = join52(this.directory, EXPERIENCE_STORE_NAME);
         this.candidate = {
           pluginVersion: options.pluginVersion ?? null,
           coreVersion: options.coreVersion
@@ -89280,21 +89426,21 @@ var init_evidence = __esm({
         this.write(pruneExperienceRecords(records, this.now(), this.maxRecords, this.retentionMs));
       }
       write(records) {
-        mkdirSync21(this.directory, { recursive: true, mode: 448 });
-        const temp = join51(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID11()}`);
+        mkdirSync22(this.directory, { recursive: true, mode: 448 });
+        const temp = join52(this.directory, `.${EXPERIENCE_STORE_NAME}.${process.pid}.${randomUUID11()}`);
         try {
           const sanitized = records.map((record2) => record2.redactionVersion === REDACTION_RULES_VERSION ? record2 : {
             ...sanitizeForEvidence(record2),
             redactionVersion: REDACTION_RULES_VERSION
           });
           const contents = sanitized.map((record2) => JSON.stringify(record2)).join("\n");
-          writeFileSync17(temp, contents.length > 0 ? `${contents}
+          writeFileSync18(temp, contents.length > 0 ? `${contents}
 ` : "", {
             encoding: "utf8",
             flag: "wx",
             mode: 384
           });
-          renameSync9(temp, this.path);
+          renameSync10(temp, this.path);
           chmodSync8(this.path, 384);
         } catch (error2) {
           try {
@@ -89349,7 +89495,7 @@ var init_evidence = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/observability/live-device.js
-import { join as join52 } from "node:path";
+import { join as join53 } from "node:path";
 import { tmpdir as tmpdir14 } from "node:os";
 function isStateMutating(tool, args) {
   if (FLOW_MUTATION_TOOLS.has(tool))
@@ -89453,7 +89599,7 @@ function buildLiveDeps(input) {
     // iterable" when invoked as deps.pushLive(...). The live device gate caught
     // this — the unit fakes used standalone arrows and missed it.
     pushLive: (frame) => input.recorder.pushLive(frame),
-    tmpPath: () => join52(tmpdir14(), `rn-observe-live-${process.pid}.jpg`),
+    tmpPath: () => join53(tmpdir14(), `rn-observe-live-${process.pid}.jpg`),
     isMirrorActive: input.isMirrorActive
   };
 }
@@ -89608,9 +89754,9 @@ var init_observe_project_root = __esm({
 
 // packages/rn-dev-agent-core/dist/observability/server.js
 import { createServer as createServer3 } from "node:http";
-import { readFileSync as readFileSync37 } from "node:fs";
+import { readFileSync as readFileSync38 } from "node:fs";
 import { fileURLToPath as fileURLToPath6 } from "node:url";
-import { dirname as dirname30, join as join53 } from "node:path";
+import { dirname as dirname31, join as join54 } from "node:path";
 function listen(server3, port) {
   return new Promise((resolve21, reject) => {
     const onErr = (e) => {
@@ -89633,7 +89779,7 @@ var init_server3 = __esm({
     init_observe_project_root();
     init_logger();
     HOST = "127.0.0.1";
-    __dir = dirname30(fileURLToPath6(import.meta.url));
+    __dir = dirname31(fileURLToPath6(import.meta.url));
     ObservabilityServer = class {
       recorder;
       e2e;
@@ -89876,7 +90022,7 @@ var init_server3 = __esm({
       }
       index(res) {
         try {
-          let html = readFileSync37(join53(__dir, "web-dist", "index.html"), "utf8");
+          let html = readFileSync38(join54(__dir, "web-dist", "index.html"), "utf8");
           if (this.e2e) {
             const tokenJs = JSON.stringify(this.e2e.token).replace(/</g, "\\u003c");
             html = html.replace("</head>", `<script>window.__E2E_CSRF__=${tokenJs}</script></head>`);
@@ -90060,10 +90206,10 @@ var init_server3 = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/observability/observe-state.js
-import { join as join54 } from "node:path";
+import { join as join55 } from "node:path";
 function observeStatePath(projectRoot) {
   const safe = projectRoot.replace(/[^A-Za-z0-9._-]/g, "_");
-  return join54(getStateDir(), "observe", `${safe}.json`);
+  return join55(getStateDir(), "observe", `${safe}.json`);
 }
 function writeObserveState(url, port, projectRoot = findProjectRoot(), now = () => /* @__PURE__ */ new Date()) {
   try {
@@ -90775,116 +90921,6 @@ var init_target = __esm({
   }
 });
 
-// packages/rn-dev-agent-core/dist/domain/e2e-test.js
-import { dirname as dirname31, join as join55 } from "node:path";
-import { mkdirSync as mkdirSync22, writeFileSync as writeFileSync18, renameSync as renameSync10, readFileSync as readFileSync38, readdirSync as readdirSync15, existsSync as existsSync34 } from "node:fs";
-import { createHash as createHash22 } from "node:crypto";
-function e2eDirFor(projectRoot) {
-  return join55(projectRoot, ".rn-agent", "e2e");
-}
-function e2ePathFor(projectRoot, id) {
-  assertValidActionId(id, "e2ePathFor");
-  const dir = e2eDirFor(projectRoot);
-  const file = join55(dir, `${id}.yaml`);
-  assertWithinDir(file, dir);
-  return file;
-}
-function serializeLockedTest(meta) {
-  const header = [
-    "# e2e-locked-test: true",
-    `# id: ${meta.id}`,
-    `# intent: ${meta.intent}`,
-    `# sourceActionId: ${meta.sourceActionId}`,
-    `# lockedAt: ${meta.lockedAt}`,
-    `# lockedGitSha: ${meta.lockedGitSha ?? ""}`,
-    `# sourceContentHash: ${meta.sourceContentHash}`,
-    "# status: locked"
-  ];
-  if (meta.appId)
-    header.push(`# appId: ${meta.appId}`);
-  if (meta.params?.length)
-    header.push(`# params: ${meta.params.join(", ")}`);
-  header.push(FLOW_SENTINEL);
-  return `${header.join("\n")}
-${meta.flow}`;
-}
-function hashBody(s) {
-  return createHash22("sha256").update(s).digest("hex");
-}
-function freezeLockedTest(projectRoot, source, ctx) {
-  const filePath = e2ePathFor(projectRoot, source.id);
-  mkdirSync22(dirname31(filePath), { recursive: true });
-  const meta = {
-    id: source.id,
-    intent: source.intent,
-    sourceActionId: source.sourceActionId,
-    lockedAt: ctx.now().toISOString(),
-    lockedGitSha: ctx.gitSha,
-    sourceContentHash: hashBody(source.flow),
-    status: "locked",
-    params: source.params,
-    appId: source.appId,
-    flow: source.flow
-  };
-  const tmp = `${filePath}.tmp`;
-  writeFileSync18(tmp, serializeLockedTest(meta), "utf8");
-  renameSync10(tmp, filePath);
-  return { ...meta, filePath };
-}
-function loadLockedTest(projectRoot, id) {
-  const filePath = e2ePathFor(projectRoot, id);
-  if (!existsSync34(filePath))
-    return null;
-  return parseLockedTest(readFileSync38(filePath, "utf8"), filePath);
-}
-function discoverLockedTests(projectRoot) {
-  const dir = e2eDirFor(projectRoot);
-  if (!existsSync34(dir))
-    return [];
-  return readdirSync15(dir).filter((f) => f.endsWith(".yaml")).map((f) => f.replace(/\.yaml$/, "")).sort();
-}
-function parseLockedTest(text, filePath) {
-  if (!/^#\s*e2e-locked-test:\s*true\s*$/m.test(text))
-    return null;
-  const sentinelIdx = text.indexOf(FLOW_SENTINEL);
-  if (sentinelIdx < 0)
-    return null;
-  const headerText = text.slice(0, sentinelIdx);
-  const flowStart = text.indexOf("\n", sentinelIdx);
-  const flow = flowStart >= 0 ? text.slice(flowStart + 1) : "";
-  const field2 = (k) => {
-    const m = headerText.match(new RegExp(`^#\\s*${k}:\\s*(.*)$`, "m"));
-    const v = m?.[1]?.trim();
-    return v ? v : void 0;
-  };
-  const id = field2("id");
-  const intent = field2("intent");
-  if (!id || !intent)
-    return null;
-  const paramsRaw = field2("params");
-  return {
-    id,
-    intent,
-    sourceActionId: field2("sourceActionId") ?? id,
-    lockedAt: field2("lockedAt") ?? "",
-    lockedGitSha: field2("lockedGitSha") ?? null,
-    sourceContentHash: field2("sourceContentHash") ?? "",
-    status: "locked",
-    params: paramsRaw ? paramsRaw.split(",").map((s) => s.trim()).filter(Boolean) : void 0,
-    appId: field2("appId"),
-    flow,
-    filePath
-  };
-}
-var FLOW_SENTINEL;
-var init_e2e_test = __esm({
-  "packages/rn-dev-agent-core/dist/domain/e2e-test.js"() {
-    "use strict";
-    init_path_safety();
-    FLOW_SENTINEL = "# e2e-locked-flow-below";
-  }
-});
-
 // packages/rn-dev-agent-core/dist/domain/e2e-config.js
 import { readFileSync as readFileSync39 } from "node:fs";
 import { join as join56 } from "node:path";
@@ -91250,16 +91286,6 @@ function readMaestro(result) {
     return { passed: false, output: "unparseable maestro result" };
   }
 }
-function filterByPattern(ids, pattern) {
-  if (!pattern || pattern.length > 256)
-    return ids;
-  try {
-    const re = new RegExp(pattern, "i");
-    return ids.filter((id) => re.test(id));
-  } catch {
-    return ids;
-  }
-}
 async function runE2eSuiteCore(args, deps = {}) {
   const projectRoot = args.projectRoot ?? findProjectRoot() ?? process.cwd();
   const discover2 = deps.discover ?? discoverLockedTests;
@@ -91270,7 +91296,9 @@ async function runE2eSuiteCore(args, deps = {}) {
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
   const mkRunId = deps.makeRunId ?? makeRunId;
   const rand = () => Math.random().toString(36).slice(2, 8);
-  const ids = filterByPattern(discover2(projectRoot), args.pattern);
+  const ids = [
+    ...getResolvedLockedTestIds(args) ?? resolveLockedTestIds(projectRoot, args.pattern, discover2)
+  ];
   if (ids.length === 0) {
     return warnResult({
       runId: null,
@@ -93081,6 +93109,7 @@ var init_index = __esm({
     init_device_record();
     init_lock_e2e_test();
     init_run_e2e_suite();
+    init_e2e_test();
     init_e2e_run_request();
     init_preflight();
     init_device_screenshot_raw();
@@ -93389,6 +93418,13 @@ var init_index = __esm({
     localAuthorityProbe = createRuntimeAuthorityProbe(getClient);
     authorityGate = createAuthorityGate(authorityRuntime, {
       loginSupervisorOverrideToken: () => process.env.RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN,
+      resolveLockedE2eTestIds: (args, status) => {
+        const projectRoot = typeof args.projectRoot === "string" ? args.projectRoot : status.source.appRoot;
+        if (typeof projectRoot !== "string")
+          return [];
+        args.projectRoot = projectRoot;
+        return resolveLockedTestIds(projectRoot, typeof args.pattern === "string" ? args.pattern : void 0);
+      },
       probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
       recoverRuntimeConnection: async (status) => {
         const current = getClient();
@@ -94736,8 +94772,8 @@ init_registry();
 init_managed_metro();
 init_android_metro_reverse();
 init_state_root();
-import { createHash as createHash14, randomBytes as randomBytes6, randomUUID as randomUUID8 } from "node:crypto";
-import { dirname as dirname19 } from "node:path";
+import { createHash as createHash15, randomBytes as randomBytes6, randomUUID as randomUUID8 } from "node:crypto";
+import { dirname as dirname20 } from "node:path";
 var RELEASABLE_SESSION_STATES = /* @__PURE__ */ new Set([
   "active",
   "source_bound",
@@ -94866,7 +94902,7 @@ function createSupervisorAuthority(input, dependencies = {}) {
       metroPort,
       observePort,
       ...adoptionRequired ? {
-        recoveryCapabilityHash: createHash14("sha256").update(recoveryCapability).digest("hex"),
+        recoveryCapabilityHash: createHash15("sha256").update(recoveryCapability).digest("hex"),
         adoptionRequired: {
           sessionId: adoptionRequired.sessionId,
           claimEpoch: adoptionRequired.claimEpoch
@@ -94910,7 +94946,7 @@ function createSupervisorAuthority(input, dependencies = {}) {
       RN_DEV_AGENT_SESSION_ID: session2.sessionId,
       RN_DEV_AGENT_CLAIM_EPOCH: String(session2.claimEpoch),
       RN_DEV_AGENT_REGISTRY_PATH: layout.registry,
-      RN_DEV_AGENT_STATE_DIR: dirname19(layout.root),
+      RN_DEV_AGENT_STATE_DIR: dirname20(layout.root),
       RN_DEV_AGENT_SESSION_SECRET_PATH: secretPath,
       RN_DEV_AGENT_SESSION_RUNTIME_ROOT: sessionRuntimeDirectory(layout, sessionId),
       RN_DEV_AGENT_WORKER_INSTANCE: workerInstance,
@@ -94981,7 +95017,7 @@ function createSupervisorAuthority(input, dependencies = {}) {
 }
 
 // packages/rn-dev-agent-core/dist/supervisor-args.js
-import { dirname as dirname20, join as join36 } from "node:path";
+import { dirname as dirname21, join as join37 } from "node:path";
 function sqliteFlagForNode(version2) {
   const v = version2 ?? process.versions.node;
   const [majorStr, minorStr] = v.split(".");
@@ -95007,7 +95043,7 @@ function workerSpawnArgs(workerPath, sqliteWarningFilterPath2, version2, forward
     "--import",
     sqliteWarningFilterPath2,
     "--import",
-    join36(dirname20(sqliteWarningFilterPath2), "startup-integrity-register.js"),
+    join37(dirname21(sqliteWarningFilterPath2), "startup-integrity-register.js"),
     workerPath,
     "--no-lock",
     ...diagnosticArgs

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -30239,7 +30239,7 @@ function assertWritableActionFile(filePath) {
 function assertActionMetadataIdentity(filePath, metadata) {
   const fileId = basename7(filePath).replace(/\.ya?ml$/i, "");
   if (metadata.id !== fileId) {
-    throw new ActionMetadataIdentityError(metadata.id, fileId);
+    throw new Error(`Action metadata id ${metadata.id} does not match filename identity ${fileId}.`);
   }
 }
 function withMetadata(action, metadata) {
@@ -30248,7 +30248,7 @@ function withMetadata(action, metadata) {
 function withBody(action, body) {
   return { ...action, body };
 }
-var SaveActionPreconditionError, ActionMetadataIdentityError;
+var SaveActionPreconditionError;
 var init_action_store = __esm({
   "packages/rn-dev-agent-core/dist/domain/action-store.js"() {
     "use strict";
@@ -30264,16 +30264,6 @@ var init_action_store = __esm({
       constructor(filePath) {
         super(`saveAction precondition violated: yaml at ${filePath} has been edited externally since the in-memory action was loaded. The caller must invoke actionWasEditedExternally() first and abort on true (or use saveActionWithCAS for atomic detection). GH #113 contract enforcement.`);
         this.name = "SaveActionPreconditionError";
-      }
-    };
-    ActionMetadataIdentityError = class extends Error {
-      metadataId;
-      fileId;
-      constructor(metadataId, fileId) {
-        super(`Action metadata id ${metadataId} does not match filename identity ${fileId}.`);
-        this.metadataId = metadataId;
-        this.fileId = fileId;
-        this.name = "ActionMetadataIdentityError";
       }
     };
   }
@@ -81174,9 +81164,6 @@ function parseEnvelope2(result) {
     return { ok: false, code: "BAD_RESPONSE", error: "Action replay returned invalid JSON." };
   }
 }
-function isLoginActionIdentityMismatch(error2) {
-  return error2 instanceof ActionMetadataIdentityError && (error2.fileId === LOGIN_PROLOGUE_ALIAS || error2.metadataId === LOGIN_PROLOGUE_ALIAS);
-}
 function createLoginPrologueHandler(deps) {
   const now = deps.now ?? (() => /* @__PURE__ */ new Date());
   return async (args) => {
@@ -81228,7 +81215,7 @@ function createLoginPrologueHandler(deps) {
         inventory = await measure("inventory", () => listActions(projectRoot));
         action = await measure("resolve", async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
       } catch (error2) {
-        if (isLoginActionIdentityMismatch(error2)) {
+        if (error2 instanceof Error && error2.message.includes("does not match filename identity") && error2.message.includes(LOGIN_PROLOGUE_ALIAS)) {
           return blocked("LOGIN_ACTION_ID_MISMATCH", `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
         }
         throw error2;

--- a/packages/codex-plugin/skills/rn-testing/SKILL.md
+++ b/packages/codex-plugin/skills/rn-testing/SKILL.md
@@ -60,7 +60,7 @@ Do not silently take the cheaper path. The user reviewing your output cannot tel
 
 ### When shortcuts are legitimate
 
-- **Auth pre-flight** (`cdp_login_prologue` with a passing RunRecord) — bootstrap, not verification surface
+- **Auth pre-flight** (`cdp_login_prologue` with a passing RunRecord) — bootstrap helper, not PR proof or a durable authority capability
 - **Permission pre-flight** (granting via `device_permission`) — platform setup, declared upfront
 - **Test data seeding** (via app's test-only fixtures) — declared in the test plan
 - **Explicit user instruction** ("just deep-link to the details screen and check the layout") — user-sanctioned scope
@@ -332,7 +332,12 @@ and replays it with conservative runner and selector safety checks.
 
 Continue only when the result has `state: "passed"` and a fresh passing
 `runRecord`. The returned prologue and RunRecord timing fields separate
-inventory, resolution, replay, verification, and transport time.
+inventory, resolution, replay, verification, and transport time. Treat that
+pass as a navigation helper only: it is not PR proof and must not be used as
+a durable authority capability. Formal login proof is locking and running
+the login e2e on the exact candidate (`cdp_lock_e2e_test` /
+`cdp_run_e2e_suite`). Helper replay and locked e2e coexist without sharing
+that proof or rewriting each other's artifacts.
 
 `LOGIN_PROLOGUE_BLOCKED` is a terminal journey boundary. A missing action,
 runner drift, selector failure, timeout, or missing fresh RunRecord must not

--- a/packages/codex-plugin/skills/rn-testing/SKILL.md
+++ b/packages/codex-plugin/skills/rn-testing/SKILL.md
@@ -60,7 +60,7 @@ Do not silently take the cheaper path. The user reviewing your output cannot tel
 
 ### When shortcuts are legitimate
 
-- **Auth pre-flight** (compatible owned action; explicitly authorized legacy helper only when needed) — bootstrap, not verification surface
+- **Auth pre-flight** (`cdp_login_prologue` with a passing RunRecord) — bootstrap, not verification surface
 - **Permission pre-flight** (granting via `device_permission`) — platform setup, declared upfront
 - **Test data seeding** (via app's test-only fixtures) — declared in the test plan
 - **Explicit user instruction** ("just deep-link to the details screen and check the layout") — user-sanctioned scope
@@ -322,52 +322,32 @@ maestro_run(platform="android", deviceId="<exact emulator serial>", flowPath="fl
 
 ---
 
-## Auth Pre-flight: Approved Learned Actions (GH #10)
+## Auth Pre-flight: Deterministic Login Prologue
 
-Before testing features that require authentication, check if the app is
-on a login/auth screen. If so, authentication recovery must use a compatible
-action from the project's approved learned-action corpus.
+Before testing an authenticated feature, read the route with
+`cdp_navigation_state`. If the app is signed out, call
+`cdp_login_prologue` before any exploratory login interaction. The tool
+inventories learned actions, resolves only `.rn-agent/actions/user-login.yaml`,
+and replays it with conservative runner and selector safety checks.
 
-### Detection
+Continue only when the result has `state: "passed"` and a fresh passing
+`runRecord`. The returned prologue and RunRecord timing fields separate
+inventory, resolution, replay, verification, and transport time.
 
-Call `cdp_navigation_state` and check the route name. Auth-related routes
-typically match: `Login`, `Welcome`, `SignIn`, `Register`, `Onboarding`,
-`Auth`, `Landing`.
+`LOGIN_PROLOGUE_BLOCKED` is a terminal journey boundary. A missing action,
+runner drift, selector failure, timeout, or missing fresh RunRecord must not
+fall through to manual credential entry, `cdp_auto_login`, raw or ad-hoc
+Maestro, route injection, navigation shortcuts, or store mutation. Read-only
+diagnostics and cleanup remain available; repair the exact saved action and
+rerun the prologue.
 
-**Caution**: An empty navigation state may be a splash screen (loading) or
-the Dev Client picker (GH #9), not necessarily auth. Wait 3 seconds and
-retry before concluding the app is logged out.
+An empty navigation state may be a splash screen or Dev Client picker, not
+necessarily auth. Wait 3 seconds and retry before concluding the app is logged
+out.
 
-### Discovery and execution
-
-1. Run `$rn-dev-agent:list-learned-actions login`.
-2. Select one compatible owned action whose metadata establishes authenticated
-   state.
-3. Replay it through `cdp_run_action` on the exact authority-bound device.
-4. Treat any engine-pin, selector, or action-format incompatibility as terminal.
-5. If no compatible owned action exists, stop and report authentication as
-   blocked. Do not use manual taps, `.maestro` flows, ambient runners, or
-   `cdp_auto_login` as an automatic fallback.
-
-Only when the user explicitly authorizes legacy per-call navigation recovery may
-`cdp_auto_login` run. It is never durable login authority or PR proof; create or
-migrate an owned compatible action before proof.
-
-### Verification
-
-After replay completes, verify arrival at the main app:
-```
-cdp_navigation_state → route should be a main screen (Home, Dashboard, Tabs)
-```
-
-### Rules
-
-- **NEVER** fall back to manual login or an unowned replay flow
-- **ALWAYS** use `cdp_run_action` for the owned authentication action
-- **Skip** the notification `permissions` config if testing notification
-  permission flows (preserve undetermined state)
-- If no compatible owned login action exists, stop and report that
-  authentication cannot proceed through an authorized reusable flow
+A supervisor may authorize one otherwise-blocked mutation only with an
+out-of-band token configured as `RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN` and supplied
+as `supervisorOverrideToken`. Never infer, discover, log, or persist that token.
 
 ---
 

--- a/packages/codex-plugin/skills/using-rn-dev-agent/SKILL.md
+++ b/packages/codex-plugin/skills/using-rn-dev-agent/SKILL.md
@@ -142,6 +142,7 @@ These apply to every RN task:
 5. **Filter `cdp_component_tree` queries** — never dump the full tree (10K+ tokens wasted)
 6. **Stop at the first red flag** from the agent's red flags list
 7. **Run `$rn-dev-agent:list-learned-actions` BEFORE composing any `device_*` sequence.** If a saved action already covers the request, replay it via `cdp_run_action` (or `$rn-dev-agent:run-action`) first — that path runs the mutates/appId/param pre-flights and auto-repair; reserve raw `maestro_run` for non-action YAML flows. Manual primitives are a fallback, not a default. (Codified in `feedback_execute_artifacts_before_manual.md`. The original failure case: a 7-minute / 11-tool-call manual walk that an existing 23-second Maestro flow would have covered.)
+8. **Enter authenticated journeys through `cdp_login_prologue`.** It resolves only the exact `user-login` action and requires a fresh passing RunRecord. `LOGIN_PROLOGUE_BLOCKED` is terminal for the journey: do not use manual credentials, ad-hoc Maestro, navigation shortcuts, or store mutation afterward.
 
 ### Ask First
 - Adding new dependencies to the user's project

--- a/packages/codex-plugin/skills/using-rn-dev-agent/SKILL.md
+++ b/packages/codex-plugin/skills/using-rn-dev-agent/SKILL.md
@@ -88,7 +88,8 @@ What is the user asking for?
 ├── FREEZE a verified action into a locked regression test
 │   └─► $rn-dev-agent:lock-e2e <action-name>
 │       (Strict no-repair run via cdp_lock_e2e_test, freezes to .rn-agent/e2e/;
-│        the frozen suite runs via cdp_run_e2e_suite)
+│        the frozen suite runs via cdp_run_e2e_suite. For login, this is the
+│        formal PR proof on the exact candidate; cdp_login_prologue is not.)
 │
 ├── Watch tool activity live in a browser ("observability UI")
 │   └─► $rn-dev-agent:observe
@@ -142,7 +143,7 @@ These apply to every RN task:
 5. **Filter `cdp_component_tree` queries** — never dump the full tree (10K+ tokens wasted)
 6. **Stop at the first red flag** from the agent's red flags list
 7. **Run `$rn-dev-agent:list-learned-actions` BEFORE composing any `device_*` sequence.** If a saved action already covers the request, replay it via `cdp_run_action` (or `$rn-dev-agent:run-action`) first — that path runs the mutates/appId/param pre-flights and auto-repair; reserve raw `maestro_run` for non-action YAML flows. Manual primitives are a fallback, not a default. (Codified in `feedback_execute_artifacts_before_manual.md`. The original failure case: a 7-minute / 11-tool-call manual walk that an existing 23-second Maestro flow would have covered.)
-8. **Enter authenticated journeys through `cdp_login_prologue`.** It resolves only the exact `user-login` action and requires a fresh passing RunRecord. `LOGIN_PROLOGUE_BLOCKED` is terminal for the journey: do not use manual credentials, ad-hoc Maestro, navigation shortcuts, or store mutation afterward.
+8. **Enter authenticated journeys through `cdp_login_prologue`.** It resolves only the exact `user-login` action and requires a fresh passing RunRecord. That result is a navigation helper, not PR proof. `LOGIN_PROLOGUE_BLOCKED` is terminal for the journey: do not use manual credentials, ad-hoc Maestro, navigation shortcuts, or store mutation afterward. Formal login proof is `cdp_lock_e2e_test` / `cdp_run_e2e_suite` on the exact candidate; helper and locked tests coexist without sharing that proof.
 
 ### Ask First
 - Adding new dependencies to the user's project

--- a/packages/codex-plugin/templates/rn-agent/README.md
+++ b/packages/codex-plugin/templates/rn-agent/README.md
@@ -9,7 +9,8 @@ your project.
 If your project also has a `.maestro/` folder for hand-authored E2E tests,
 that's yours alone. Authentication prologues resolve the exact
 `.rn-agent/actions/user-login.yaml` learned action and never infer a login flow
-from `.maestro/` filenames.
+from `.maestro/` filenames. `cdp_login_prologue` is a navigation helper, not PR
+proof; lock and run the login e2e on the exact candidate for formal proof.
 
 ## Layout
 

--- a/packages/codex-plugin/templates/rn-agent/README.md
+++ b/packages/codex-plugin/templates/rn-agent/README.md
@@ -6,11 +6,10 @@ plugin for Claude Code and Codex. One folder, one doctrine — the plugin's
 entire footprint is `.rn-agent/` and it does not read or write anywhere else in
 your project.
 
-If your project also has a `.maestro/` folder for hand-authored E2E
-tests, that's yours alone. Those files are never learned-action authority or an
-automatic authentication fallback. The explicit legacy `cdp_auto_login` helper
-may inspect one only when the user authorizes that per-call navigation recovery;
-its result is never durable login authority or PR proof.
+If your project also has a `.maestro/` folder for hand-authored E2E tests,
+that's yours alone. Authentication prologues resolve the exact
+`.rn-agent/actions/user-login.yaml` learned action and never infer a login flow
+from `.maestro/` filenames.
 
 ## Layout
 

--- a/packages/rn-dev-agent-core/dist/domain/action-store.js
+++ b/packages/rn-dev-agent-core/dist/domain/action-store.js
@@ -762,17 +762,7 @@ function assertWritableActionFile(filePath) {
 export function assertActionMetadataIdentity(filePath, metadata) {
     const fileId = basename(filePath).replace(/\.ya?ml$/i, '');
     if (metadata.id !== fileId) {
-        throw new ActionMetadataIdentityError(metadata.id, fileId);
-    }
-}
-export class ActionMetadataIdentityError extends Error {
-    metadataId;
-    fileId;
-    constructor(metadataId, fileId) {
-        super(`Action metadata id ${metadataId} does not match filename identity ${fileId}.`);
-        this.metadataId = metadataId;
-        this.fileId = fileId;
-        this.name = 'ActionMetadataIdentityError';
+        throw new Error(`Action metadata id ${metadata.id} does not match filename identity ${fileId}.`);
     }
 }
 /**

--- a/packages/rn-dev-agent-core/dist/domain/action-store.js
+++ b/packages/rn-dev-agent-core/dist/domain/action-store.js
@@ -762,7 +762,17 @@ function assertWritableActionFile(filePath) {
 export function assertActionMetadataIdentity(filePath, metadata) {
     const fileId = basename(filePath).replace(/\.ya?ml$/i, '');
     if (metadata.id !== fileId) {
-        throw new Error(`Action metadata id ${metadata.id} does not match filename identity ${fileId}.`);
+        throw new ActionMetadataIdentityError(metadata.id, fileId);
+    }
+}
+export class ActionMetadataIdentityError extends Error {
+    metadataId;
+    fileId;
+    constructor(metadataId, fileId) {
+        super(`Action metadata id ${metadataId} does not match filename identity ${fileId}.`);
+        this.metadataId = metadataId;
+        this.fileId = fileId;
+        this.name = 'ActionMetadataIdentityError';
     }
 }
 /**

--- a/packages/rn-dev-agent-core/dist/domain/e2e-test.js
+++ b/packages/rn-dev-agent-core/dist/domain/e2e-test.js
@@ -58,7 +58,8 @@ export function loadLockedTest(projectRoot, id) {
     const filePath = e2ePathFor(projectRoot, id);
     if (!existsSync(filePath))
         return null;
-    return parseLockedTest(readFileSync(filePath, 'utf8'), filePath);
+    const locked = parseLockedTest(readFileSync(filePath, 'utf8'), filePath);
+    return locked?.id === id ? locked : null;
 }
 export function discoverLockedTests(projectRoot) {
     const dir = e2eDirFor(projectRoot);
@@ -80,6 +81,12 @@ export function resolveLockedTestIds(projectRoot, pattern, discover = discoverLo
     catch {
         return ids;
     }
+}
+export function resolveLockedTestIdentityIds(projectRoot, pattern, discover = discoverLockedTests, load = loadLockedTest) {
+    return resolveLockedTestIds(projectRoot, pattern, discover).filter((id) => {
+        const locked = load(projectRoot, id);
+        return locked?.id === id && locked.sourceActionId === id;
+    });
 }
 const resolvedLockedTestIds = Symbol('resolvedLockedTestIds');
 export function setResolvedLockedTestIds(args, ids) {

--- a/packages/rn-dev-agent-core/dist/domain/e2e-test.js
+++ b/packages/rn-dev-agent-core/dist/domain/e2e-test.js
@@ -61,6 +61,9 @@ export function loadLockedTest(projectRoot, id) {
     const locked = parseLockedTest(readFileSync(filePath, 'utf8'), filePath);
     return locked?.id === id ? locked : null;
 }
+export function lockedTestFileExists(projectRoot, id) {
+    return existsSync(e2ePathFor(projectRoot, id));
+}
 export function discoverLockedTests(projectRoot) {
     const dir = e2eDirFor(projectRoot);
     if (!existsSync(dir))
@@ -82,11 +85,13 @@ export function resolveLockedTestIds(projectRoot, pattern, discover = discoverLo
         return ids;
     }
 }
-export function resolveLockedTestIdentityIds(projectRoot, pattern, discover = discoverLockedTests, load = loadLockedTest) {
-    return resolveLockedTestIds(projectRoot, pattern, discover).filter((id) => {
+export function resolveLockedTestSelection(projectRoot, pattern, discover = discoverLockedTests, load = loadLockedTest) {
+    const ids = resolveLockedTestIds(projectRoot, pattern, discover);
+    const identitiesValid = ids.every((id) => {
         const locked = load(projectRoot, id);
         return locked?.id === id && locked.sourceActionId === id;
     });
+    return { ids, identitiesValid };
 }
 const resolvedLockedTestIds = Symbol('resolvedLockedTestIds');
 export function setResolvedLockedTestIds(args, ids) {

--- a/packages/rn-dev-agent-core/dist/domain/e2e-test.js
+++ b/packages/rn-dev-agent-core/dist/domain/e2e-test.js
@@ -69,6 +69,28 @@ export function discoverLockedTests(projectRoot) {
         .map((f) => f.replace(/\.yaml$/, ''))
         .sort();
 }
+export function resolveLockedTestIds(projectRoot, pattern, discover = discoverLockedTests) {
+    const ids = discover(projectRoot);
+    if (!pattern || pattern.length > 256)
+        return ids;
+    try {
+        const matcher = new RegExp(pattern, 'i');
+        return ids.filter((id) => matcher.test(id));
+    }
+    catch {
+        return ids;
+    }
+}
+const resolvedLockedTestIds = Symbol('resolvedLockedTestIds');
+export function setResolvedLockedTestIds(args, ids) {
+    Object.defineProperty(args, resolvedLockedTestIds, {
+        value: Object.freeze([...ids]),
+        configurable: true,
+    });
+}
+export function getResolvedLockedTestIds(args) {
+    return args[resolvedLockedTestIds];
+}
 export function parseLockedTest(text, filePath) {
     if (!/^#\s*e2e-locked-test:\s*true\s*$/m.test(text))
         return null;

--- a/packages/rn-dev-agent-core/dist/domain/login-prologue.js
+++ b/packages/rn-dev-agent-core/dist/domain/login-prologue.js
@@ -18,11 +18,11 @@ export function readLoginPrologueOutcome(value) {
     }
     return candidate;
 }
-function lockedE2eProofAllowed(tool, args) {
+function lockedE2eProofAllowed(tool, args, resolvedLockedTestIds) {
     if (tool === 'cdp_lock_e2e_test')
         return args.actionId === LOGIN_PROLOGUE_ALIAS;
     if (tool === 'cdp_run_e2e_suite') {
-        return args.pattern === `^${LOGIN_PROLOGUE_ALIAS}$`;
+        return resolvedLockedTestIds?.length === 1 && resolvedLockedTestIds[0] === LOGIN_PROLOGUE_ALIAS;
     }
     return false;
 }
@@ -58,7 +58,7 @@ export function inspectLoginPrologueGuard(input) {
     if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED ||
         !input.mutation ||
         cleanupAllowed(input.tool, input.args) ||
-        lockedE2eProofAllowed(input.tool, input.args)) {
+        lockedE2eProofAllowed(input.tool, input.args, input.resolvedLockedTestIds)) {
         return { blocked: false };
     }
     return {

--- a/packages/rn-dev-agent-core/dist/domain/login-prologue.js
+++ b/packages/rn-dev-agent-core/dist/domain/login-prologue.js
@@ -1,0 +1,67 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+export const LOGIN_PROLOGUE_ALIAS = 'user-login';
+export const LOGIN_PROLOGUE_BLOCKED = 'LOGIN_PROLOGUE_BLOCKED';
+export function readLoginPrologueOutcome(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value))
+        return null;
+    const candidate = value;
+    if (candidate.schemaVersion !== 1 ||
+        candidate.alias !== LOGIN_PROLOGUE_ALIAS ||
+        (candidate.state !== 'passed' && candidate.state !== LOGIN_PROLOGUE_BLOCKED) ||
+        typeof candidate.startedAt !== 'string' ||
+        typeof candidate.endedAt !== 'string' ||
+        typeof candidate.elapsedMs !== 'number' ||
+        !Array.isArray(candidate.steps)) {
+        return null;
+    }
+    return candidate;
+}
+function cleanupAllowed(tool, args) {
+    if (tool === 'cdp_login_prologue')
+        return true;
+    if (tool === 'cdp_disconnect')
+        return true;
+    if (tool === 'device_snapshot' && args.action === 'close')
+        return true;
+    if (tool === 'device_record' && (args.action === 'stop' || args.action === 'status'))
+        return true;
+    if (tool === 'observe' && (args.action === 'stop' || args.action === 'status'))
+        return true;
+    if (tool === 'proof_capture' && (args.action === 'discard' || args.action === 'status')) {
+        return true;
+    }
+    return (tool === 'rn_session' &&
+        (args.action === 'release' ||
+            args.action === 'stop_metro' ||
+            args.action === 'cancel_handoff' ||
+            args.action === 'status'));
+}
+function tokenMatches(expected, supplied) {
+    if (!expected || expected.length < 16 || !supplied || supplied.length < 16)
+        return false;
+    const expectedHash = createHash('sha256').update(expected).digest();
+    const suppliedHash = createHash('sha256').update(supplied).digest();
+    return timingSafeEqual(expectedHash, suppliedHash);
+}
+export function evaluateLoginPrologueGuard(input) {
+    const outcome = readLoginPrologueOutcome(input.binding);
+    if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation) {
+        return { allowed: true, override: false };
+    }
+    if (cleanupAllowed(input.tool, input.args))
+        return { allowed: true, override: false };
+    const supplied = typeof input.args.supervisorOverrideToken === 'string'
+        ? input.args.supervisorOverrideToken
+        : undefined;
+    if (tokenMatches(input.expectedOverrideToken, supplied)) {
+        return {
+            allowed: true,
+            override: true,
+            audit: { tool: input.tool, usedAt: (input.now ?? (() => new Date()))().toISOString() },
+        };
+    }
+    return { allowed: false, suppliedOverride: supplied !== undefined };
+}
+export function appendLoginOverrideAudit(outcome, audit) {
+    return { ...outcome, overrides: [...(outcome.overrides ?? []), audit].slice(-20) };
+}

--- a/packages/rn-dev-agent-core/dist/domain/login-prologue.js
+++ b/packages/rn-dev-agent-core/dist/domain/login-prologue.js
@@ -43,24 +43,38 @@ function tokenMatches(expected, supplied) {
     const suppliedHash = createHash('sha256').update(supplied).digest();
     return timingSafeEqual(expectedHash, suppliedHash);
 }
-export function evaluateLoginPrologueGuard(input) {
+export function inspectLoginPrologueGuard(input) {
     const outcome = readLoginPrologueOutcome(input.binding);
-    if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation) {
-        return { allowed: true, override: false };
+    if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED ||
+        !input.mutation ||
+        cleanupAllowed(input.tool, input.args)) {
+        return { blocked: false };
     }
-    if (cleanupAllowed(input.tool, input.args))
+    return {
+        blocked: true,
+        suppliedOverride: typeof input.args.supervisorOverrideToken === 'string'
+            ? input.args.supervisorOverrideToken
+            : undefined,
+    };
+}
+export function authorizeLoginSupervisorOverride(input) {
+    if (!tokenMatches(input.expectedOverrideToken, input.suppliedOverrideToken))
+        return null;
+    return { tool: input.tool, usedAt: (input.now ?? (() => new Date()))().toISOString() };
+}
+export function evaluateLoginPrologueGuard(input) {
+    const inspection = inspectLoginPrologueGuard(input);
+    if (!inspection.blocked)
         return { allowed: true, override: false };
-    const supplied = typeof input.args.supervisorOverrideToken === 'string'
-        ? input.args.supervisorOverrideToken
-        : undefined;
-    if (tokenMatches(input.expectedOverrideToken, supplied)) {
-        return {
-            allowed: true,
-            override: true,
-            audit: { tool: input.tool, usedAt: (input.now ?? (() => new Date()))().toISOString() },
-        };
-    }
-    return { allowed: false, suppliedOverride: supplied !== undefined };
+    const audit = authorizeLoginSupervisorOverride({
+        expectedOverrideToken: input.expectedOverrideToken,
+        suppliedOverrideToken: inspection.suppliedOverride,
+        tool: input.tool,
+        now: input.now,
+    });
+    return audit
+        ? { allowed: true, override: true, audit }
+        : { allowed: false, suppliedOverride: inspection.suppliedOverride !== undefined };
 }
 export function appendLoginOverrideAudit(outcome, audit) {
     return { ...outcome, overrides: [...(outcome.overrides ?? []), audit].slice(-20) };

--- a/packages/rn-dev-agent-core/dist/domain/login-prologue.js
+++ b/packages/rn-dev-agent-core/dist/domain/login-prologue.js
@@ -44,6 +44,7 @@ function cleanupAllowed(tool, args) {
         (args.action === 'release' ||
             args.action === 'stop_metro' ||
             args.action === 'cancel_handoff' ||
+            (args.action === 'recover_arbiter' && args.confirmed === true) ||
             args.action === 'status'));
 }
 function tokenMatches(expected, supplied) {

--- a/packages/rn-dev-agent-core/dist/domain/login-prologue.js
+++ b/packages/rn-dev-agent-core/dist/domain/login-prologue.js
@@ -1,6 +1,8 @@
 import { createHash, timingSafeEqual } from 'node:crypto';
 export const LOGIN_PROLOGUE_ALIAS = 'user-login';
 export const LOGIN_PROLOGUE_BLOCKED = 'LOGIN_PROLOGUE_BLOCKED';
+export const ACTION_LOGIN_HELPER = 'ACTION_LOGIN_HELPER';
+export const LOCKED_E2E_LOGIN_TOOLS = ['cdp_lock_e2e_test', 'cdp_run_e2e_suite'];
 export function readLoginPrologueOutcome(value) {
     if (!value || typeof value !== 'object' || Array.isArray(value))
         return null;
@@ -15,6 +17,10 @@ export function readLoginPrologueOutcome(value) {
         return null;
     }
     return candidate;
+}
+function lockedE2eProofAllowed(tool) {
+    // Locked e2e is the formal PR-proof path and must coexist with the helper gate.
+    return LOCKED_E2E_LOGIN_TOOLS.includes(tool);
 }
 function cleanupAllowed(tool, args) {
     if (tool === 'cdp_login_prologue')
@@ -47,7 +53,8 @@ export function inspectLoginPrologueGuard(input) {
     const outcome = readLoginPrologueOutcome(input.binding);
     if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED ||
         !input.mutation ||
-        cleanupAllowed(input.tool, input.args)) {
+        cleanupAllowed(input.tool, input.args) ||
+        lockedE2eProofAllowed(input.tool)) {
         return { blocked: false };
     }
     return {

--- a/packages/rn-dev-agent-core/dist/domain/login-prologue.js
+++ b/packages/rn-dev-agent-core/dist/domain/login-prologue.js
@@ -18,9 +18,13 @@ export function readLoginPrologueOutcome(value) {
     }
     return candidate;
 }
-function lockedE2eProofAllowed(tool) {
-    // Locked e2e is the formal PR-proof path and must coexist with the helper gate.
-    return LOCKED_E2E_LOGIN_TOOLS.includes(tool);
+function lockedE2eProofAllowed(tool, args) {
+    if (tool === 'cdp_lock_e2e_test')
+        return args.actionId === LOGIN_PROLOGUE_ALIAS;
+    if (tool === 'cdp_run_e2e_suite') {
+        return args.pattern === `^${LOGIN_PROLOGUE_ALIAS}$`;
+    }
+    return false;
 }
 function cleanupAllowed(tool, args) {
     if (tool === 'cdp_login_prologue')
@@ -54,7 +58,7 @@ export function inspectLoginPrologueGuard(input) {
     if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED ||
         !input.mutation ||
         cleanupAllowed(input.tool, input.args) ||
-        lockedE2eProofAllowed(input.tool)) {
+        lockedE2eProofAllowed(input.tool, input.args)) {
         return { blocked: false };
     }
     return {

--- a/packages/rn-dev-agent-core/dist/index.js
+++ b/packages/rn-dev-agent-core/dist/index.js
@@ -33,6 +33,7 @@ import { createExpectReduxHandler, createExpectRouteHandler, createExpectVisible
 import { createRepairActionHandler } from './tools/repair-action.js';
 import { createSaveAsActionHandler } from './tools/save-as-action.js';
 import { createRunActionHandler } from './tools/run-action.js';
+import { createLoginPrologueHandler } from './tools/login-prologue.js';
 import { unwrapTree } from './tools/cdp-replay-dispatch.js';
 import { createDispatchHandler } from './tools/dispatch.js';
 import { createMmkvHandler } from './tools/mmkv.js';
@@ -461,6 +462,7 @@ const createRuntimeAuthorityProbe = (resolveClient) => createLocalAuthorityProbe
 });
 const localAuthorityProbe = createRuntimeAuthorityProbe(getClient);
 const authorityGate = createAuthorityGate(authorityRuntime, {
+    loginSupervisorOverrideToken: () => process.env.RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN,
     probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
     recoverRuntimeConnection: async (status) => {
         const current = getClient();
@@ -721,7 +723,14 @@ function trackedTool(name, desc, schema, handler) {
         }
         return result;
     };
-    server.tool(name, desc, schema, wrapped);
+    server.tool(name, desc, {
+        ...schema,
+        supervisorOverrideToken: z
+            .string()
+            .min(16)
+            .optional()
+            .describe('Supervisor token for one audited mutation after a blocked login prologue.'),
+    }, wrapped);
 }
 async function pinSessionDevClient(status, options, commitBundle) {
     const device = status.bindings.device;
@@ -2861,6 +2870,13 @@ trackedTool('cdp_repair_action', 'Repair a learned action using a fresh snapshot
 }, createRepairActionHandler());
 // Issue #104 — auto-repair-aware action replay. Wraps maestro_run with
 // stderr classification + cdp_repair_action retry on SELECTOR_NOT_FOUND.
+const runActionHandler = createRunActionHandler({
+    getLiveRoute: () => readLiveRoute(getClient()),
+    replayDeps: makeReplayDeps,
+    blindProbeContext,
+    targetContext: getActiveSession,
+    claimBundleAuthority: claimOptionalBundleAuthority,
+});
 trackedTool('cdp_run_action', "Replay a learned action by id with end-to-end auto-repair. Loads the action from .rn-agent/actions/<actionId>.yaml or .yml, forwards the matching active session's exact device ID to Maestro, rejects mismatched direct runner/WDA evidence, and on a SELECTOR_NOT_FOUND failure automatically invokes cdp_repair_action and retries once. Appends a RunRecord to the sidecar with full auto-repair telemetry (passed/failed/refused/skipped + diff); its Maestro deviceId comes from direct runner evidence, never requested metadata. The repair attempt counts toward cdp_repair_action's 24h budget. Pass autoRepair=false to opt out of auto-repair (returns the raw maestro_run failure verbatim). forceReload defaults true: any human edit to the YAML since the agent's last write is acknowledged as the new baseline so downstream repair does not abort with STALE_TARGET (the right default for active composition). Pass forceReload=false for the strict \"respect offline human edits\" behavior: a successful replay still appends its RunRecord to the sidecar when only the tracked YAML mtime baseline is stale, while YAML-mutating promotion and repair stay refused. proofReplay=true is reserved for proof_capture rehearsal and requires autoRepair=false plus forceReload=false; it executes without RunRecord, promotion, YAML, sidecar, or DB persistence. The orchestrated home for the L3 self-healing loop — prefer this over invoking maestro_run + cdp_repair_action manually for any flow you intend to re-run on schedule. blindProbeMode provides per-call control of the proactive CDP/JS compatibility path: inherit (default) honors RN_BLIND_PROBE, allow explicitly enables it for this call, and forbid forces maestro-first for this call.", {
     actionId: z.string().describe('Owned action id; resolves one .yaml or .yml file.'),
     projectRoot: z.string().optional().describe('Override project root (default: process.cwd()).'),
@@ -2900,18 +2916,27 @@ trackedTool('cdp_run_action', "Replay a learned action by id with end-to-end aut
         .record(z.string(), z.string())
         .optional()
         .describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run)."),
-}, 
-// GH #186: supply a CDP-backed live-route reader so the route-drift guard is
-// actually active. Without this the handler defaulted getLiveRoute to a no-op
-// and the drift branch could never fire, silently routing screen-change
-// failures into fuzzy selector repair.
-createRunActionHandler({
-    getLiveRoute: () => readLiveRoute(getClient()),
-    replayDeps: makeReplayDeps,
-    blindProbeContext,
-    targetContext: getActiveSession,
-    claimBundleAuthority: claimOptionalBundleAuthority,
-}));
+}, runActionHandler);
+trackedTool('cdp_login_prologue', 'Inventory learned actions, replay the exact user-login action strictly, and require a fresh passing RunRecord before lifting the session login gate.', {
+    projectRoot: z.string().optional().describe('Override project root (default: process.cwd()).'),
+    platform: z
+        .enum(['ios', 'android'])
+        .optional()
+        .describe('Force a platform; otherwise use the authority-bound device.'),
+    appFile: z
+        .string()
+        .optional()
+        .describe('iOS app artifact used only when the saved action contains clearState.'),
+    timeoutMs: z.number().optional().describe('Saved-action timeout in milliseconds.'),
+    trigger: z
+        .enum(['agent', 'ci', 'human'])
+        .optional()
+        .describe('RunRecord trigger annotation. Default agent.'),
+    params: z
+        .record(z.string(), z.string())
+        .optional()
+        .describe('Bindings for the exact user-login action placeholders.'),
+}, createLoginPrologueHandler({ runAction: runActionHandler }));
 trackedTool('cdp_lock_e2e_test', 'Promote a verified action into a frozen, locked e2e regression test. Runs the action once strict (no repair); freezes it only if it passes. v1 supports param-free actions only.', {
     actionId: z.string().describe('The action id under .rn-agent/actions to lock'),
     relock: z.boolean().optional().describe('Overwrite an existing locked test'),
@@ -3018,13 +3043,6 @@ const triggerE2eRun = async (args) => {
         arbiter.release(L.lease);
     }
 };
-const runActionHandler = createRunActionHandler({
-    getLiveRoute: () => readLiveRoute(getClient()),
-    replayDeps: makeReplayDeps,
-    blindProbeContext,
-    targetContext: getActiveSession,
-    claimBundleAuthority: claimOptionalBundleAuthority,
-});
 const observeRunActionHandler = authorityGate.wrap('cdp_run_action', runActionHandler);
 const observeTriggerRun = authorityGate.wrap('cdp_run_e2e_suite', async (...raw) => {
     const args = (raw[0] ?? {});

--- a/packages/rn-dev-agent-core/dist/index.js
+++ b/packages/rn-dev-agent-core/dist/index.js
@@ -99,7 +99,7 @@ import { createMirrorSource, IosSimctlLoopSource, idbDemotionHint, } from './obs
 import { parseAllAdbDevices } from './tools/device-record.js';
 import { createLockE2eTestHandler } from './tools/lock-e2e-test.js';
 import { createRunE2eSuiteHandler } from './tools/run-e2e-suite.js';
-import { resolveLockedTestIds } from './domain/e2e-test.js';
+import { resolveLockedTestIdentityIds } from './domain/e2e-test.js';
 import { recoverInterruptedRequests } from './domain/e2e-run-request.js';
 import { preflight, probeMetro } from './e2e/preflight.js';
 import { resolveIosUdid } from './tools/device-screenshot-raw.js';
@@ -469,7 +469,7 @@ const authorityGate = createAuthorityGate(authorityRuntime, {
         if (typeof projectRoot !== 'string')
             return [];
         args.projectRoot = projectRoot;
-        return resolveLockedTestIds(projectRoot, typeof args.pattern === 'string' ? args.pattern : undefined);
+        return resolveLockedTestIdentityIds(projectRoot, typeof args.pattern === 'string' ? args.pattern : undefined);
     },
     probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
     recoverRuntimeConnection: async (status) => {

--- a/packages/rn-dev-agent-core/dist/index.js
+++ b/packages/rn-dev-agent-core/dist/index.js
@@ -2461,7 +2461,7 @@ trackedTool('device_batch', 'Execute a sequence of exact-device UI interactions 
         .default('salient')
         .describe('Shape of the batch final_snapshot. salient (default): compact list of only actionable nodes (Button/TextField/Switch/etc) — far fewer tokens. full: complete node list (legacy). none: skip the implicit trailing snapshot entirely (~1,450 ms saved) for action-only batches you verify via expect_*/cdp_store_state.'),
 }, createDeviceBatchHandler(getClient));
-trackedTool('cdp_auto_login', 'Explicit legacy navigation helper that detects an auth screen and runs one project login subflow through maestro_run on the authority-bound device. It is per-call recovery only, never durable login authority or PR proof; prefer a compatible owned learned action.', {
+trackedTool('cdp_auto_login', 'Explicit legacy navigation helper that detects an auth screen and runs one project login subflow through maestro_run on the authority-bound device. It is never login authority or PR proof; use cdp_login_prologue for authenticated journeys.', {
     appId: z
         .string()
         .optional()
@@ -2925,25 +2925,13 @@ trackedTool('cdp_run_action', "Replay a learned action by id with end-to-end aut
         .optional()
         .describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run)."),
 }, runActionHandler);
-trackedTool('cdp_login_prologue', 'Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; not PR proof.', {
+trackedTool('cdp_login_prologue', 'Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; failure blocks exploratory fallback mutations, and a pass is not PR proof.', {
     projectRoot: z.string().optional().describe('Override project root (default: process.cwd()).'),
-    platform: z
-        .enum(['ios', 'android'])
-        .optional()
-        .describe('Force a platform; otherwise use the authority-bound device.'),
-    appFile: z
-        .string()
-        .optional()
-        .describe('iOS app artifact used only when the saved action contains clearState.'),
+    platform: z.enum(['ios', 'android']).optional().describe('Override the bound platform.'),
+    appFile: z.string().optional().describe('iOS app artifact for clearState actions.'),
     timeoutMs: z.number().optional().describe('Saved-action timeout in milliseconds.'),
-    trigger: z
-        .enum(['agent', 'ci', 'human'])
-        .optional()
-        .describe('RunRecord trigger annotation. Default agent.'),
-    params: z
-        .record(z.string(), z.string())
-        .optional()
-        .describe('Bindings for the exact user-login action placeholders.'),
+    trigger: z.enum(['agent', 'ci', 'human']).optional().describe('Run trigger; default agent.'),
+    params: z.record(z.string(), z.string()).optional().describe('String user-login bindings.'),
 }, createLoginPrologueHandler({ runAction: runActionHandler }));
 trackedTool('cdp_lock_e2e_test', 'Promote a verified action into a frozen, locked e2e regression test. Runs the action once strict (no repair); freezes it only if it passes. v1 supports param-free actions only.', {
     actionId: z.string().describe('The action id under .rn-agent/actions to lock'),

--- a/packages/rn-dev-agent-core/dist/index.js
+++ b/packages/rn-dev-agent-core/dist/index.js
@@ -2917,7 +2917,7 @@ trackedTool('cdp_run_action', "Replay a learned action by id with end-to-end aut
         .optional()
         .describe("Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run)."),
 }, runActionHandler);
-trackedTool('cdp_login_prologue', 'Inventory learned actions, replay the exact user-login action strictly, and require a fresh passing RunRecord before lifting the session login gate.', {
+trackedTool('cdp_login_prologue', 'Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; not PR proof.', {
     projectRoot: z.string().optional().describe('Override project root (default: process.cwd()).'),
     platform: z
         .enum(['ios', 'android'])

--- a/packages/rn-dev-agent-core/dist/index.js
+++ b/packages/rn-dev-agent-core/dist/index.js
@@ -99,7 +99,7 @@ import { createMirrorSource, IosSimctlLoopSource, idbDemotionHint, } from './obs
 import { parseAllAdbDevices } from './tools/device-record.js';
 import { createLockE2eTestHandler } from './tools/lock-e2e-test.js';
 import { createRunE2eSuiteHandler } from './tools/run-e2e-suite.js';
-import { resolveLockedTestIdentityIds } from './domain/e2e-test.js';
+import { resolveLockedTestSelection } from './domain/e2e-test.js';
 import { recoverInterruptedRequests } from './domain/e2e-run-request.js';
 import { preflight, probeMetro } from './e2e/preflight.js';
 import { resolveIosUdid } from './tools/device-screenshot-raw.js';
@@ -467,9 +467,9 @@ const authorityGate = createAuthorityGate(authorityRuntime, {
     resolveLockedE2eTestIds: (args, status) => {
         const projectRoot = typeof args.projectRoot === 'string' ? args.projectRoot : status.source.appRoot;
         if (typeof projectRoot !== 'string')
-            return [];
+            return { ids: [], identitiesValid: false };
         args.projectRoot = projectRoot;
-        return resolveLockedTestIdentityIds(projectRoot, typeof args.pattern === 'string' ? args.pattern : undefined);
+        return resolveLockedTestSelection(projectRoot, typeof args.pattern === 'string' ? args.pattern : undefined);
     },
     probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
     recoverRuntimeConnection: async (status) => {

--- a/packages/rn-dev-agent-core/dist/index.js
+++ b/packages/rn-dev-agent-core/dist/index.js
@@ -99,6 +99,7 @@ import { createMirrorSource, IosSimctlLoopSource, idbDemotionHint, } from './obs
 import { parseAllAdbDevices } from './tools/device-record.js';
 import { createLockE2eTestHandler } from './tools/lock-e2e-test.js';
 import { createRunE2eSuiteHandler } from './tools/run-e2e-suite.js';
+import { resolveLockedTestIds } from './domain/e2e-test.js';
 import { recoverInterruptedRequests } from './domain/e2e-run-request.js';
 import { preflight, probeMetro } from './e2e/preflight.js';
 import { resolveIosUdid } from './tools/device-screenshot-raw.js';
@@ -463,6 +464,13 @@ const createRuntimeAuthorityProbe = (resolveClient) => createLocalAuthorityProbe
 const localAuthorityProbe = createRuntimeAuthorityProbe(getClient);
 const authorityGate = createAuthorityGate(authorityRuntime, {
     loginSupervisorOverrideToken: () => process.env.RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN,
+    resolveLockedE2eTestIds: (args, status) => {
+        const projectRoot = typeof args.projectRoot === 'string' ? args.projectRoot : status.source.appRoot;
+        if (typeof projectRoot !== 'string')
+            return [];
+        args.projectRoot = projectRoot;
+        return resolveLockedTestIds(projectRoot, typeof args.pattern === 'string' ? args.pattern : undefined);
+    },
     probe: async ({ axis, phase, status, tool, args }) => localAuthorityProbe({ axis, phase, status, tool, args }),
     recoverRuntimeConnection: async (status) => {
         const current = getClient();

--- a/packages/rn-dev-agent-core/dist/lifecycle/device-arbiter.js
+++ b/packages/rn-dev-agent-core/dist/lifecycle/device-arbiter.js
@@ -125,6 +125,7 @@ export function promoteCurrentOperationToManagedFlow() {
 const FLOW_TOOLS = new Set([
     'maestro_run',
     'maestro_test_all',
+    'cdp_login_prologue',
     'cdp_run_action',
     'cdp_auto_login',
     'cdp_reload',

--- a/packages/rn-dev-agent-core/dist/observability/events.js
+++ b/packages/rn-dev-agent-core/dist/observability/events.js
@@ -49,6 +49,7 @@ const TESTING = new Set([
     'maestro_run',
     'maestro_generate',
     'maestro_test_all',
+    'cdp_login_prologue',
     'cdp_run_action',
     'cdp_repair_action',
     'proof_step',

--- a/packages/rn-dev-agent-core/dist/session/authority-gate.js
+++ b/packages/rn-dev-agent-core/dist/session/authority-gate.js
@@ -434,8 +434,19 @@ function parseLoginPrologueOutcome(result) {
         return null;
     }
 }
-function missingLoginPrologueOutcome() {
+function missingLoginPrologueOutcome(result) {
     const timestamp = new Date().toISOString();
+    let failure = {
+        code: 'LOGIN_PROLOGUE_RESULT_INVALID',
+        detail: 'The login prologue returned no valid terminal state.',
+    };
+    try {
+        const envelope = JSON.parse(result.content?.[0]?.text ?? '{}');
+        if (envelope.code === 'BUSY_FLOW_ACTIVE' && typeof envelope.error === 'string') {
+            failure = { code: envelope.code, detail: envelope.error };
+        }
+    }
+    catch { }
     return {
         schemaVersion: 1,
         state: LOGIN_PROLOGUE_BLOCKED,
@@ -445,10 +456,7 @@ function missingLoginPrologueOutcome() {
         elapsedMs: 0,
         steps: [],
         inventory: { count: 0, actionIds: [] },
-        failure: {
-            code: 'LOGIN_PROLOGUE_RESULT_INVALID',
-            detail: 'The login prologue returned no valid terminal state.',
-        },
+        failure,
     };
 }
 function pendingLoginPrologueOutcome(attemptId) {
@@ -1563,8 +1571,8 @@ export function createAuthorityGate(runtime, dependencies) {
                 if (tool === 'cdp_login_prologue') {
                     loginPrologueOutcome = parseLoginPrologueOutcome(result);
                     if (!loginPrologueOutcome) {
-                        loginPrologueOutcome = missingLoginPrologueOutcome();
-                        result = failResult('Login prologue returned no valid terminal state.', 'LOGIN_PROLOGUE_BLOCKED', { loginPrologue: loginPrologueOutcome });
+                        loginPrologueOutcome = missingLoginPrologueOutcome(result);
+                        result = failResult(`Login prologue blocked: ${loginPrologueOutcome.failure?.detail ?? 'The login prologue returned no valid terminal state.'}`, 'LOGIN_PROLOGUE_BLOCKED', { loginPrologue: loginPrologueOutcome });
                     }
                     if (loginPrologueOutcome.state === LOGIN_PROLOGUE_BLOCKED) {
                         const persisted = persistLoginPrologueOutcome(runtime, registry, operation, status, loginPrologueOutcome);

--- a/packages/rn-dev-agent-core/dist/session/authority-gate.js
+++ b/packages/rn-dev-agent-core/dist/session/authority-gate.js
@@ -5,6 +5,7 @@ import { failResult } from '../utils.js';
 import { authorityErrorMeta, SessionAuthorityError, shortAuthorityIdentity } from './registry.js';
 import { isProvenMetroOriginMismatch } from './metro-origin.js';
 import { reissueInstallBinding } from './install-reissue.js';
+import { LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, appendLoginOverrideAudit, evaluateLoginPrologueGuard, readLoginPrologueOutcome, } from '../domain/login-prologue.js';
 import { authorityProfileFor, requiresExactInstalledArtifact, } from './tool-profiles.js';
 const optionalBundleAdmission = Symbol('optionalBundleAdmission');
 const managedNativeOrigin = Symbol('managedNativeOrigin');
@@ -423,6 +424,35 @@ function authorityFailure(error) {
     const code = /^([A-Z][A-Z0-9_]+):/.exec(message)?.[1];
     return failResult(message, code ?? 'AUTHORITY_LOST_DURING_OPERATION');
 }
+function parseLoginPrologueOutcome(result) {
+    try {
+        const envelope = JSON.parse(result.content?.[0]?.text ?? '{}');
+        return readLoginPrologueOutcome(envelope.data ?? envelope.meta?.loginPrologue);
+    }
+    catch {
+        return null;
+    }
+}
+function missingLoginPrologueOutcome() {
+    const timestamp = new Date().toISOString();
+    return {
+        schemaVersion: 1,
+        state: LOGIN_PROLOGUE_BLOCKED,
+        alias: LOGIN_PROLOGUE_ALIAS,
+        startedAt: timestamp,
+        endedAt: timestamp,
+        elapsedMs: 0,
+        steps: [],
+        inventory: { count: 0, actionIds: [] },
+        failure: {
+            code: 'LOGIN_PROLOGUE_RESULT_INVALID',
+            detail: 'The login prologue returned no valid terminal state.',
+        },
+    };
+}
+function isActionReplayTool(tool) {
+    return tool === 'cdp_run_action' || tool === 'cdp_login_prologue';
+}
 function authorityErrorCode(error) {
     return error instanceof SessionAuthorityError
         ? error.code
@@ -735,10 +765,48 @@ export function createAuthorityGate(runtime, dependencies) {
                                 liveBundleProbe: tool === 'proof_capture',
                             }
                             : baseProfile;
+            let runtimeStatus = runtime.status();
+            const loginDecision = evaluateLoginPrologueGuard({
+                binding: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : undefined,
+                tool,
+                args,
+                mutation: profile.mutation,
+                expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
+            });
+            delete args.supervisorOverrideToken;
+            if (!loginDecision.allowed) {
+                return failResult('LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.', 'LOGIN_PROLOGUE_BLOCKED', {
+                    loginPrologue: runtimeStatus.available
+                        ? runtimeStatus.bindings.loginPrologue
+                        : undefined,
+                    overrideRejected: loginDecision.suppliedOverride,
+                    nextAction: 'Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call.',
+                });
+            }
+            if (loginDecision.override) {
+                try {
+                    const available = runtime.requireAvailable();
+                    const current = runtime.status();
+                    const outcome = current.available
+                        ? readLoginPrologueOutcome(current.bindings.loginPrologue)
+                        : null;
+                    if (!outcome) {
+                        throw new SessionAuthorityError('LOGIN_PROLOGUE_BLOCKED', 'the blocked login prologue state disappeared before override audit');
+                    }
+                    available.registry.updateBindings(available.session, {
+                        bindings: {
+                            loginPrologue: appendLoginOverrideAudit(outcome, loginDecision.audit),
+                        },
+                    });
+                    runtimeStatus = runtime.status();
+                }
+                catch (error) {
+                    return authorityFailure(error);
+                }
+            }
             if (profile.kind === 'diagnostic') {
                 return addMeta(await handler(...handlerArgs), { authoritative: false });
             }
-            const runtimeStatus = runtime.status();
             if (runtimeStatus.available && runtimeStatus.state === 'blocked') {
                 return authorityFailure(runtime.blockedContenderError());
             }
@@ -1411,7 +1479,15 @@ export function createAuthorityGate(runtime, dependencies) {
                 }
                 registry.verifyOperation(operation);
                 const snapshotCheckpoint = dependencies.snapshotCaptureCheckpoint?.();
-                const result = await registry.runWithOperation(operation, () => handler(...handlerArgs));
+                let result = await registry.runWithOperation(operation, () => handler(...handlerArgs));
+                let loginPrologueOutcome = null;
+                if (tool === 'cdp_login_prologue') {
+                    loginPrologueOutcome = parseLoginPrologueOutcome(result);
+                    if (!loginPrologueOutcome) {
+                        loginPrologueOutcome = missingLoginPrologueOutcome();
+                        result = failResult('Login prologue returned no valid terminal state.', 'LOGIN_PROLOGUE_BLOCKED', { loginPrologue: loginPrologueOutcome });
+                    }
+                }
                 let runtimeTargetChanged = false;
                 const postHandlerRecovery = await reconcileRecoverableRuntime(runtime, dependencies, registry, operation, status, profile, resultSucceeded(result));
                 operation = postHandlerRecovery.operation;
@@ -1440,7 +1516,7 @@ export function createAuthorityGate(runtime, dependencies) {
                 const nestedRuntimeReset = tool === 'cdp_run_e2e_suite' ||
                     tool === 'cdp_auto_login' ||
                     (tool === 'cdp_nav_graph' && args.action === 'go') ||
-                    (tool === 'cdp_run_action' && (optionalBundleClaimed || optionalBundleRecoveryFailed));
+                    (isActionReplayTool(tool) && (optionalBundleClaimed || optionalBundleRecoveryFailed));
                 const reconcilesRuntimeTarget = directRuntimeReset || nestedRuntimeReset;
                 let authorityInvalidated = false;
                 if (directRuntimeReset && !resultSucceeded(result)) {
@@ -1455,7 +1531,7 @@ export function createAuthorityGate(runtime, dependencies) {
                     const metro = status.bindings.metro;
                     let bundle = null;
                     try {
-                        if (tool === 'cdp_run_action' && optionalBundleRecoveryFailed) {
+                        if (isActionReplayTool(tool) && optionalBundleRecoveryFailed) {
                             throw new SessionAuthorityError('BUNDLE_HANDSHAKE_UNAVAILABLE', 'reactive bundle authority did not verify');
                         }
                         if (!dependencies.refreshRuntimeBinding) {
@@ -1476,7 +1552,7 @@ export function createAuthorityGate(runtime, dependencies) {
                                 nextAction: 'Run rn_session action "pin_dev_client" before another CDP operation.',
                             });
                         }
-                        if (tool === 'cdp_run_action' && !optionalBundleClaimed) {
+                        if (isActionReplayTool(tool) && !optionalBundleClaimed) {
                             authorityInvalidated = true;
                         }
                         else {
@@ -1561,6 +1637,22 @@ export function createAuthorityGate(runtime, dependencies) {
                 // Verify that exact advanced fence first, then tolerate only its C
                 // identity change. An external generation change still fails CAS.
                 const controllerGenerationAdvanced = operation.authorityVersion !== initialOperationAuthorityVersion;
+                if (loginPrologueOutcome) {
+                    const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+                    operation = registry.replaceBindingsDuringOperation(operation, {
+                        bindings: {
+                            loginPrologue: {
+                                ...loginPrologueOutcome,
+                                ...(priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}),
+                            },
+                        },
+                    });
+                    const loginStatus = runtime.status();
+                    if (!loginStatus.available) {
+                        throw new SessionAuthorityError(loginStatus.code, loginStatus.reason);
+                    }
+                    status = loginStatus;
+                }
                 registry.verifyOperation(operation);
                 for (const observation of allBefore) {
                     if (controllerGenerationAdvanced && observation.axis === 'C')

--- a/packages/rn-dev-agent-core/dist/session/authority-gate.js
+++ b/packages/rn-dev-agent-core/dist/session/authority-gate.js
@@ -452,11 +452,12 @@ function missingLoginPrologueOutcome() {
 }
 function persistLoginPrologueOutcome(runtime, registry, operation, status, outcome) {
     const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+    const overrides = outcome.overrides ?? priorOutcome?.overrides;
     const nextOperation = registry.replaceBindingsDuringOperation(operation, {
         bindings: {
             loginPrologue: {
                 ...outcome,
-                ...(priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}),
+                ...(overrides ? { overrides } : {}),
             },
         },
     });
@@ -781,7 +782,7 @@ export function createAuthorityGate(runtime, dependencies) {
                                 liveBundleProbe: tool === 'proof_capture',
                             }
                             : baseProfile;
-            let runtimeStatus = runtime.status();
+            const runtimeStatus = runtime.status();
             const loginDecision = evaluateLoginPrologueGuard({
                 binding: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : undefined,
                 tool,
@@ -798,27 +799,6 @@ export function createAuthorityGate(runtime, dependencies) {
                     overrideRejected: loginDecision.suppliedOverride,
                     nextAction: 'Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call.',
                 });
-            }
-            if (loginDecision.override) {
-                try {
-                    const available = runtime.requireAvailable();
-                    const current = runtime.status();
-                    const outcome = current.available
-                        ? readLoginPrologueOutcome(current.bindings.loginPrologue)
-                        : null;
-                    if (!outcome) {
-                        throw new SessionAuthorityError('LOGIN_PROLOGUE_BLOCKED', 'the blocked login prologue state disappeared before override audit');
-                    }
-                    available.registry.updateBindings(available.session, {
-                        bindings: {
-                            loginPrologue: appendLoginOverrideAudit(outcome, loginDecision.audit),
-                        },
-                    });
-                    runtimeStatus = runtime.status();
-                }
-                catch (error) {
-                    return authorityFailure(error);
-                }
             }
             if (profile.kind === 'diagnostic') {
                 return addMeta(await handler(...handlerArgs), { authoritative: false });
@@ -1493,6 +1473,15 @@ export function createAuthorityGate(runtime, dependencies) {
                         },
                     });
                 }
+                if (loginDecision.override) {
+                    const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+                    if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
+                        throw new SessionAuthorityError('LOGIN_PROLOGUE_BLOCKED', 'the blocked login prologue state disappeared before override audit');
+                    }
+                    const persisted = persistLoginPrologueOutcome(runtime, registry, operation, status, appendLoginOverrideAudit(outcome, loginDecision.audit));
+                    operation = persisted.operation;
+                    status = persisted.status;
+                }
                 registry.verifyOperation(operation);
                 const snapshotCheckpoint = dependencies.snapshotCaptureCheckpoint?.();
                 let result = await registry.runWithOperation(operation, () => handler(...handlerArgs));
@@ -1658,11 +1647,6 @@ export function createAuthorityGate(runtime, dependencies) {
                 // Verify that exact advanced fence first, then tolerate only its C
                 // identity change. An external generation change still fails CAS.
                 const controllerGenerationAdvanced = operation.authorityVersion !== initialOperationAuthorityVersion;
-                if (loginPrologueOutcome?.state === 'passed') {
-                    const persisted = persistLoginPrologueOutcome(runtime, registry, operation, status, loginPrologueOutcome);
-                    operation = persisted.operation;
-                    status = persisted.status;
-                }
                 registry.verifyOperation(operation);
                 for (const observation of allBefore) {
                     if (controllerGenerationAdvanced && observation.axis === 'C')
@@ -1724,6 +1708,11 @@ export function createAuthorityGate(runtime, dependencies) {
                 }
                 if (operation && receiptsCommittable) {
                     registry.commitPlatformAuthorityReceipts(operation);
+                }
+                if (operation && loginPrologueOutcome?.state === 'passed') {
+                    const persisted = persistLoginPrologueOutcome(runtime, registry, operation, status, loginPrologueOutcome);
+                    operation = persisted.operation;
+                    status = persisted.status;
                 }
                 return addMeta(result, {
                     ...nativeOriginMeta(profile, nativeOriginProven),

--- a/packages/rn-dev-agent-core/dist/session/authority-gate.js
+++ b/packages/rn-dev-agent-core/dist/session/authority-gate.js
@@ -5,7 +5,7 @@ import { failResult } from '../utils.js';
 import { authorityErrorMeta, SessionAuthorityError, shortAuthorityIdentity } from './registry.js';
 import { isProvenMetroOriginMismatch } from './metro-origin.js';
 import { reissueInstallBinding } from './install-reissue.js';
-import { LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, appendLoginOverrideAudit, evaluateLoginPrologueGuard, readLoginPrologueOutcome, } from '../domain/login-prologue.js';
+import { LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, appendLoginOverrideAudit, authorizeLoginSupervisorOverride, inspectLoginPrologueGuard, readLoginPrologueOutcome, } from '../domain/login-prologue.js';
 import { authorityProfileFor, requiresExactInstalledArtifact, } from './tool-profiles.js';
 const optionalBundleAdmission = Symbol('optionalBundleAdmission');
 const managedNativeOrigin = Symbol('managedNativeOrigin');
@@ -800,24 +800,26 @@ export function createAuthorityGate(runtime, dependencies) {
                             }
                             : baseProfile;
             const runtimeStatus = runtime.status();
-            const loginDecision = evaluateLoginPrologueGuard({
+            const loginGuard = inspectLoginPrologueGuard({
                 binding: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : undefined,
                 tool,
                 args,
                 mutation: profile.mutation,
-                expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
             });
+            const pendingSupervisorOverrideToken = loginGuard.blocked
+                ? loginGuard.suppliedOverride
+                : undefined;
             delete args.supervisorOverrideToken;
-            if (!loginDecision.allowed) {
+            if (loginGuard.blocked && pendingSupervisorOverrideToken === undefined) {
                 return failResult('LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.', 'LOGIN_PROLOGUE_BLOCKED', {
                     loginPrologue: runtimeStatus.available
                         ? runtimeStatus.bindings.loginPrologue
                         : undefined,
-                    overrideRejected: loginDecision.suppliedOverride,
+                    overrideRejected: false,
                     nextAction: 'Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call.',
                 });
             }
-            if (loginDecision.override && profile.kind === 'transition') {
+            if (loginGuard.blocked && profile.kind === 'transition') {
                 return failResult('LOGIN_PROLOGUE_BLOCKED: supervisor overrides cannot authorize transition mutations.', 'LOGIN_PROLOGUE_BLOCKED', {
                     loginPrologue: runtimeStatus.available
                         ? runtimeStatus.bindings.loginPrologue
@@ -1118,6 +1120,7 @@ export function createAuthorityGate(runtime, dependencies) {
             let retainProofCleanupFence = false;
             let publishedProofFinalize = false;
             let stagedRuntimeRelaunch;
+            let loginPrologueAttemptOperationId = null;
             try {
                 const available = runtime.requireAvailable();
                 registry = available.registry;
@@ -1126,13 +1129,23 @@ export function createAuthorityGate(runtime, dependencies) {
                     throw new SessionAuthorityError(initialStatus.code, initialStatus.reason);
                 }
                 let status = initialStatus;
-                requireCompleteAxes(status, profile);
-                bindSessionArguments(status, profile, args, tool);
+                if (tool !== 'cdp_login_prologue') {
+                    requireCompleteAxes(status, profile);
+                    bindSessionArguments(status, profile, args, tool);
+                }
                 operation = registry.beginOperation(available.session, {
                     operationId: randomUUID(),
                     tool,
                     profile: profile.axes.join(''),
                 });
+                if (tool === 'cdp_login_prologue') {
+                    const persisted = persistLoginPrologueOutcome(runtime, registry, operation, status, pendingLoginPrologueOutcome());
+                    operation = persisted.operation;
+                    status = persisted.status;
+                    loginPrologueAttemptOperationId = operation.operationId;
+                    requireCompleteAxes(status, profile);
+                    bindSessionArguments(status, profile, args, tool);
+                }
                 const preflightRecovery = await reconcileRecoverableRuntime(runtime, dependencies, registry, operation, status, profile, true);
                 operation = preflightRecovery.operation;
                 status = preflightRecovery.status;
@@ -1499,17 +1512,20 @@ export function createAuthorityGate(runtime, dependencies) {
                         },
                     });
                 }
-                if (loginDecision.override) {
+                if (pendingSupervisorOverrideToken !== undefined) {
                     const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
                     if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
                         throw new SessionAuthorityError('LOGIN_PROLOGUE_BLOCKED', 'the blocked login prologue state disappeared before override audit');
                     }
-                    const persisted = persistLoginPrologueOutcome(runtime, registry, operation, status, appendLoginOverrideAudit(outcome, loginDecision.audit));
-                    operation = persisted.operation;
-                    status = persisted.status;
-                }
-                if (tool === 'cdp_login_prologue') {
-                    const persisted = persistLoginPrologueOutcome(runtime, registry, operation, status, pendingLoginPrologueOutcome());
+                    const audit = authorizeLoginSupervisorOverride({
+                        expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
+                        suppliedOverrideToken: pendingSupervisorOverrideToken,
+                        tool,
+                    });
+                    if (!audit) {
+                        throw new SessionAuthorityError('LOGIN_PROLOGUE_BLOCKED', 'the supervisor override token was rejected under the operation fence');
+                    }
+                    const persisted = persistLoginPrologueOutcome(runtime, registry, operation, status, appendLoginOverrideAudit(outcome, audit));
                     operation = persisted.operation;
                     status = persisted.status;
                 }
@@ -1741,6 +1757,12 @@ export function createAuthorityGate(runtime, dependencies) {
                     registry.commitPlatformAuthorityReceipts(operation);
                 }
                 if (operation && loginPrologueOutcome?.state === 'passed') {
+                    const pendingOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+                    if (operation.operationId !== loginPrologueAttemptOperationId ||
+                        pendingOutcome?.state !== LOGIN_PROLOGUE_BLOCKED ||
+                        pendingOutcome.failure?.code !== 'LOGIN_PROLOGUE_IN_PROGRESS') {
+                        throw new SessionAuthorityError('LOGIN_PROLOGUE_BLOCKED', 'the passing login result does not match the active blocked attempt');
+                    }
                     const persisted = persistLoginPrologueOutcome(runtime, registry, operation, status, loginPrologueOutcome);
                     operation = persisted.operation;
                     status = persisted.status;

--- a/packages/rn-dev-agent-core/dist/session/authority-gate.js
+++ b/packages/rn-dev-agent-core/dist/session/authority-gate.js
@@ -450,12 +450,13 @@ function missingLoginPrologueOutcome() {
         },
     };
 }
-function pendingLoginPrologueOutcome() {
+function pendingLoginPrologueOutcome(attemptId) {
     const timestamp = new Date().toISOString();
     return {
         schemaVersion: 1,
         state: LOGIN_PROLOGUE_BLOCKED,
         alias: LOGIN_PROLOGUE_ALIAS,
+        attemptId,
         startedAt: timestamp,
         endedAt: timestamp,
         elapsedMs: 0,
@@ -752,6 +753,10 @@ export function createAuthorityGate(runtime, dependencies) {
             const args = handlerArgs[0] && typeof handlerArgs[0] === 'object'
                 ? handlerArgs[0]
                 : {};
+            const suppliedSupervisorOverrideToken = typeof args.supervisorOverrideToken === 'string'
+                ? args.supervisorOverrideToken
+                : undefined;
+            delete args.supervisorOverrideToken;
             const baseProfile = authorityProfileFor(tool, args);
             let profile = tool === 'rn_session' &&
                 (args.action === 'status' ||
@@ -807,9 +812,8 @@ export function createAuthorityGate(runtime, dependencies) {
                 mutation: profile.mutation,
             });
             const pendingSupervisorOverrideToken = loginGuard.blocked
-                ? loginGuard.suppliedOverride
+                ? suppliedSupervisorOverrideToken
                 : undefined;
-            delete args.supervisorOverrideToken;
             if (loginGuard.blocked && pendingSupervisorOverrideToken === undefined) {
                 return failResult('LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.', 'LOGIN_PROLOGUE_BLOCKED', {
                     loginPrologue: runtimeStatus.available
@@ -1129,7 +1133,8 @@ export function createAuthorityGate(runtime, dependencies) {
                     throw new SessionAuthorityError(initialStatus.code, initialStatus.reason);
                 }
                 let status = initialStatus;
-                if (tool !== 'cdp_login_prologue') {
+                const deferredAdmissionChecks = tool === 'cdp_login_prologue' || pendingSupervisorOverrideToken !== undefined;
+                if (!deferredAdmissionChecks) {
                     requireCompleteAxes(status, profile);
                     bindSessionArguments(status, profile, args, tool);
                 }
@@ -1139,10 +1144,29 @@ export function createAuthorityGate(runtime, dependencies) {
                     profile: profile.axes.join(''),
                 });
                 if (tool === 'cdp_login_prologue') {
-                    const persisted = persistLoginPrologueOutcome(runtime, registry, operation, status, pendingLoginPrologueOutcome());
+                    const persisted = persistLoginPrologueOutcome(runtime, registry, operation, status, pendingLoginPrologueOutcome(operation.operationId));
                     operation = persisted.operation;
                     status = persisted.status;
                     loginPrologueAttemptOperationId = operation.operationId;
+                    requireCompleteAxes(status, profile);
+                    bindSessionArguments(status, profile, args, tool);
+                }
+                if (pendingSupervisorOverrideToken !== undefined) {
+                    const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+                    if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
+                        throw new SessionAuthorityError('LOGIN_PROLOGUE_BLOCKED', 'the blocked login prologue state disappeared before override audit');
+                    }
+                    const audit = authorizeLoginSupervisorOverride({
+                        expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
+                        suppliedOverrideToken: pendingSupervisorOverrideToken,
+                        tool,
+                    });
+                    if (!audit) {
+                        throw new SessionAuthorityError('LOGIN_PROLOGUE_BLOCKED', 'the supervisor override token was rejected under the operation fence');
+                    }
+                    const persisted = persistLoginPrologueOutcome(runtime, registry, operation, status, appendLoginOverrideAudit(outcome, audit));
+                    operation = persisted.operation;
+                    status = persisted.status;
                     requireCompleteAxes(status, profile);
                     bindSessionArguments(status, profile, args, tool);
                 }
@@ -1512,23 +1536,6 @@ export function createAuthorityGate(runtime, dependencies) {
                         },
                     });
                 }
-                if (pendingSupervisorOverrideToken !== undefined) {
-                    const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
-                    if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
-                        throw new SessionAuthorityError('LOGIN_PROLOGUE_BLOCKED', 'the blocked login prologue state disappeared before override audit');
-                    }
-                    const audit = authorizeLoginSupervisorOverride({
-                        expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
-                        suppliedOverrideToken: pendingSupervisorOverrideToken,
-                        tool,
-                    });
-                    if (!audit) {
-                        throw new SessionAuthorityError('LOGIN_PROLOGUE_BLOCKED', 'the supervisor override token was rejected under the operation fence');
-                    }
-                    const persisted = persistLoginPrologueOutcome(runtime, registry, operation, status, appendLoginOverrideAudit(outcome, audit));
-                    operation = persisted.operation;
-                    status = persisted.status;
-                }
                 registry.verifyOperation(operation);
                 const snapshotCheckpoint = dependencies.snapshotCaptureCheckpoint?.();
                 let result = await registry.runWithOperation(operation, () => handler(...handlerArgs));
@@ -1760,6 +1767,7 @@ export function createAuthorityGate(runtime, dependencies) {
                     const pendingOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
                     if (operation.operationId !== loginPrologueAttemptOperationId ||
                         pendingOutcome?.state !== LOGIN_PROLOGUE_BLOCKED ||
+                        pendingOutcome.attemptId !== loginPrologueAttemptOperationId ||
                         pendingOutcome.failure?.code !== 'LOGIN_PROLOGUE_IN_PROGRESS') {
                         throw new SessionAuthorityError('LOGIN_PROLOGUE_BLOCKED', 'the passing login result does not match the active blocked attempt');
                     }

--- a/packages/rn-dev-agent-core/dist/session/authority-gate.js
+++ b/packages/rn-dev-agent-core/dist/session/authority-gate.js
@@ -450,6 +450,23 @@ function missingLoginPrologueOutcome() {
         },
     };
 }
+function pendingLoginPrologueOutcome() {
+    const timestamp = new Date().toISOString();
+    return {
+        schemaVersion: 1,
+        state: LOGIN_PROLOGUE_BLOCKED,
+        alias: LOGIN_PROLOGUE_ALIAS,
+        startedAt: timestamp,
+        endedAt: timestamp,
+        elapsedMs: 0,
+        steps: [],
+        inventory: { count: 0, actionIds: [] },
+        failure: {
+            code: 'LOGIN_PROLOGUE_IN_PROGRESS',
+            detail: 'The login prologue has not completed authoritative validation.',
+        },
+    };
+}
 function persistLoginPrologueOutcome(runtime, registry, operation, status, outcome) {
     const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
     const overrides = outcome.overrides ?? priorOutcome?.overrides;
@@ -798,6 +815,15 @@ export function createAuthorityGate(runtime, dependencies) {
                         : undefined,
                     overrideRejected: loginDecision.suppliedOverride,
                     nextAction: 'Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call.',
+                });
+            }
+            if (loginDecision.override && profile.kind === 'transition') {
+                return failResult('LOGIN_PROLOGUE_BLOCKED: supervisor overrides cannot authorize transition mutations.', 'LOGIN_PROLOGUE_BLOCKED', {
+                    loginPrologue: runtimeStatus.available
+                        ? runtimeStatus.bindings.loginPrologue
+                        : undefined,
+                    transitionOverrideRejected: true,
+                    nextAction: 'Repair the exact user-login action and rerun cdp_login_prologue before this transition.',
                 });
             }
             if (profile.kind === 'diagnostic') {
@@ -1479,6 +1505,11 @@ export function createAuthorityGate(runtime, dependencies) {
                         throw new SessionAuthorityError('LOGIN_PROLOGUE_BLOCKED', 'the blocked login prologue state disappeared before override audit');
                     }
                     const persisted = persistLoginPrologueOutcome(runtime, registry, operation, status, appendLoginOverrideAudit(outcome, loginDecision.audit));
+                    operation = persisted.operation;
+                    status = persisted.status;
+                }
+                if (tool === 'cdp_login_prologue') {
+                    const persisted = persistLoginPrologueOutcome(runtime, registry, operation, status, pendingLoginPrologueOutcome());
                     operation = persisted.operation;
                     status = persisted.status;
                 }

--- a/packages/rn-dev-agent-core/dist/session/authority-gate.js
+++ b/packages/rn-dev-agent-core/dist/session/authority-gate.js
@@ -1153,18 +1153,18 @@ export function createAuthorityGate(runtime, dependencies) {
                     bindSessionArguments(status, profile, args, tool);
                 }
                 if (pendingLockedE2eAdmission) {
-                    const resolvedLockedTestIds = dependencies.resolveLockedE2eTestIds?.(args, status);
-                    if (!resolvedLockedTestIds ||
+                    const resolvedSelection = dependencies.resolveLockedE2eTestIds?.(args, status);
+                    if (!resolvedSelection?.identitiesValid ||
                         inspectLoginPrologueGuard({
                             binding: status.bindings.loginPrologue,
                             tool,
                             args,
                             mutation: profile.mutation,
-                            resolvedLockedTestIds,
+                            resolvedLockedTestIds: resolvedSelection.ids,
                         }).blocked) {
                         throw new SessionAuthorityError('LOGIN_PROLOGUE_BLOCKED', 'the locked e2e suite did not resolve to the exact user-login candidate');
                     }
-                    setResolvedLockedTestIds(args, resolvedLockedTestIds);
+                    setResolvedLockedTestIds(args, resolvedSelection.ids);
                 }
                 operation = registry.beginOperation(available.session, {
                     operationId: randomUUID(),

--- a/packages/rn-dev-agent-core/dist/session/authority-gate.js
+++ b/packages/rn-dev-agent-core/dist/session/authority-gate.js
@@ -6,6 +6,7 @@ import { authorityErrorMeta, SessionAuthorityError, shortAuthorityIdentity } fro
 import { isProvenMetroOriginMismatch } from './metro-origin.js';
 import { reissueInstallBinding } from './install-reissue.js';
 import { LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, appendLoginOverrideAudit, authorizeLoginSupervisorOverride, inspectLoginPrologueGuard, readLoginPrologueOutcome, } from '../domain/login-prologue.js';
+import { setResolvedLockedTestIds } from '../domain/e2e-test.js';
 import { authorityProfileFor, requiresExactInstalledArtifact, } from './tool-profiles.js';
 const optionalBundleAdmission = Symbol('optionalBundleAdmission');
 const managedNativeOrigin = Symbol('managedNativeOrigin');
@@ -814,7 +815,12 @@ export function createAuthorityGate(runtime, dependencies) {
             const pendingSupervisorOverrideToken = loginGuard.blocked
                 ? suppliedSupervisorOverrideToken
                 : undefined;
-            if (loginGuard.blocked && pendingSupervisorOverrideToken === undefined) {
+            const pendingLockedE2eAdmission = loginGuard.blocked &&
+                tool === 'cdp_run_e2e_suite' &&
+                pendingSupervisorOverrideToken === undefined;
+            if (loginGuard.blocked &&
+                pendingSupervisorOverrideToken === undefined &&
+                !pendingLockedE2eAdmission) {
                 return failResult('LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.', 'LOGIN_PROLOGUE_BLOCKED', {
                     loginPrologue: runtimeStatus.available
                         ? runtimeStatus.bindings.loginPrologue
@@ -1137,6 +1143,20 @@ export function createAuthorityGate(runtime, dependencies) {
                 if (!deferredAdmissionChecks) {
                     requireCompleteAxes(status, profile);
                     bindSessionArguments(status, profile, args, tool);
+                }
+                if (pendingLockedE2eAdmission) {
+                    const resolvedLockedTestIds = dependencies.resolveLockedE2eTestIds?.(args, status);
+                    if (!resolvedLockedTestIds ||
+                        inspectLoginPrologueGuard({
+                            binding: status.bindings.loginPrologue,
+                            tool,
+                            args,
+                            mutation: profile.mutation,
+                            resolvedLockedTestIds,
+                        }).blocked) {
+                        throw new SessionAuthorityError('LOGIN_PROLOGUE_BLOCKED', 'the locked e2e suite did not resolve to the exact user-login candidate');
+                    }
+                    setResolvedLockedTestIds(args, resolvedLockedTestIds);
                 }
                 operation = registry.beginOperation(available.session, {
                     operationId: randomUUID(),

--- a/packages/rn-dev-agent-core/dist/session/authority-gate.js
+++ b/packages/rn-dev-agent-core/dist/session/authority-gate.js
@@ -450,6 +450,22 @@ function missingLoginPrologueOutcome() {
         },
     };
 }
+function persistLoginPrologueOutcome(runtime, registry, operation, status, outcome) {
+    const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+    const nextOperation = registry.replaceBindingsDuringOperation(operation, {
+        bindings: {
+            loginPrologue: {
+                ...outcome,
+                ...(priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}),
+            },
+        },
+    });
+    const nextStatus = runtime.status();
+    if (!nextStatus.available) {
+        throw new SessionAuthorityError(nextStatus.code, nextStatus.reason);
+    }
+    return { operation: nextOperation, status: nextStatus };
+}
 function isActionReplayTool(tool) {
     return tool === 'cdp_run_action' || tool === 'cdp_login_prologue';
 }
@@ -1487,6 +1503,11 @@ export function createAuthorityGate(runtime, dependencies) {
                         loginPrologueOutcome = missingLoginPrologueOutcome();
                         result = failResult('Login prologue returned no valid terminal state.', 'LOGIN_PROLOGUE_BLOCKED', { loginPrologue: loginPrologueOutcome });
                     }
+                    if (loginPrologueOutcome.state === LOGIN_PROLOGUE_BLOCKED) {
+                        const persisted = persistLoginPrologueOutcome(runtime, registry, operation, status, loginPrologueOutcome);
+                        operation = persisted.operation;
+                        status = persisted.status;
+                    }
                 }
                 let runtimeTargetChanged = false;
                 const postHandlerRecovery = await reconcileRecoverableRuntime(runtime, dependencies, registry, operation, status, profile, resultSucceeded(result));
@@ -1637,21 +1658,10 @@ export function createAuthorityGate(runtime, dependencies) {
                 // Verify that exact advanced fence first, then tolerate only its C
                 // identity change. An external generation change still fails CAS.
                 const controllerGenerationAdvanced = operation.authorityVersion !== initialOperationAuthorityVersion;
-                if (loginPrologueOutcome) {
-                    const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
-                    operation = registry.replaceBindingsDuringOperation(operation, {
-                        bindings: {
-                            loginPrologue: {
-                                ...loginPrologueOutcome,
-                                ...(priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}),
-                            },
-                        },
-                    });
-                    const loginStatus = runtime.status();
-                    if (!loginStatus.available) {
-                        throw new SessionAuthorityError(loginStatus.code, loginStatus.reason);
-                    }
-                    status = loginStatus;
+                if (loginPrologueOutcome?.state === 'passed') {
+                    const persisted = persistLoginPrologueOutcome(runtime, registry, operation, status, loginPrologueOutcome);
+                    operation = persisted.operation;
+                    status = persisted.status;
                 }
                 registry.verifyOperation(operation);
                 for (const observation of allBefore) {

--- a/packages/rn-dev-agent-core/dist/session/public-status.js
+++ b/packages/rn-dev-agent-core/dist/session/public-status.js
@@ -1,6 +1,6 @@
 import { inspectAuthorityMigration } from './migration-diagnostic.js';
 import { authorityRemedyNextAction } from './registry.js';
-import { readLoginPrologueOutcome } from '../domain/login-prologue.js';
+import { ACTION_LOGIN_HELPER, readLoginPrologueOutcome } from '../domain/login-prologue.js';
 const SELECTED_STATES = new Set(['active', 'source_bound', 'device_claimed', 'metro_bound']);
 const RUNNING_STATES = new Set(['device_bound', 'runtime_bound', 'ready']);
 // ADR §2.3 (L0): non-operational states keep only their internal name in `detail`.
@@ -148,6 +148,7 @@ export function projectPublicAuthorityStatus(status, options = {}) {
         ...(loginPrologue
             ? {
                 loginPrologue: {
+                    role: ACTION_LOGIN_HELPER,
                     state: loginPrologue.state,
                     alias: loginPrologue.alias,
                     actionId: loginPrologue.actionId,

--- a/packages/rn-dev-agent-core/dist/session/public-status.js
+++ b/packages/rn-dev-agent-core/dist/session/public-status.js
@@ -1,5 +1,6 @@
 import { inspectAuthorityMigration } from './migration-diagnostic.js';
 import { authorityRemedyNextAction } from './registry.js';
+import { readLoginPrologueOutcome } from '../domain/login-prologue.js';
 const SELECTED_STATES = new Set(['active', 'source_bound', 'device_claimed', 'metro_bound']);
 const RUNNING_STATES = new Set(['device_bound', 'runtime_bound', 'ready']);
 // ADR §2.3 (L0): non-operational states keep only their internal name in `detail`.
@@ -100,6 +101,7 @@ export function projectPublicAuthorityStatus(status, options = {}) {
         }
         : undefined;
     const sandbox = metro?.runtimeEvidenceAuthority === 'managed-sandbox-v1' ? 'managed-sandbox-v1' : 'unavailable';
+    const loginPrologue = readLoginPrologueOutcome(status.bindings.loginPrologue);
     const phase = derivePublicPhase(status.state, Boolean(status.bindings.pendingBuild));
     return {
         available: true,
@@ -143,6 +145,22 @@ export function projectPublicAuthorityStatus(status, options = {}) {
         proof: Boolean(status.bindings.proof),
         // ADR §5.2 (L3): strict proof is an opt-in overlay outside the four groups, never a group.
         proofOverlay: { active: Boolean(status.bindings.proof) },
+        ...(loginPrologue
+            ? {
+                loginPrologue: {
+                    state: loginPrologue.state,
+                    alias: loginPrologue.alias,
+                    actionId: loginPrologue.actionId,
+                    startedAt: loginPrologue.startedAt,
+                    endedAt: loginPrologue.endedAt,
+                    elapsedMs: loginPrologue.elapsedMs,
+                    failureCode: loginPrologue.failure?.code,
+                    runId: loginPrologue.runRecord?.runId,
+                    overrideCount: loginPrologue.overrides?.length ?? 0,
+                    lastOverride: loginPrologue.overrides?.at(-1),
+                },
+            }
+            : {}),
         ...(options.installIdentity ? { installIdentity: options.installIdentity.verdict } : {}),
         // A live axis-I refusal means every gated tool refuses too — status must
         // not read `ready` while that is true. A pending re-issue reads ready only

--- a/packages/rn-dev-agent-core/dist/session/tool-profiles.js
+++ b/packages/rn-dev-agent-core/dist/session/tool-profiles.js
@@ -59,7 +59,7 @@ const managedNativeMutation = [
     'maestro_test_all',
 ];
 const hybridMutation = ['cdp_auto_login', 'cdp_run_e2e_suite'];
-const optionalHybridMutation = ['cdp_run_action'];
+const optionalHybridMutation = ['cdp_login_prologue', 'cdp_run_action'];
 const nativeDiagnostic = ['cdp_native_errors'];
 const inlineMaestroMutation = new Set([
     'device_accept_system_dialog',

--- a/packages/rn-dev-agent-core/dist/tools/lock-e2e-test.js
+++ b/packages/rn-dev-agent-core/dist/tools/lock-e2e-test.js
@@ -1,5 +1,5 @@
 import { loadAction } from '../domain/action-store.js';
-import { freezeLockedTest, loadLockedTest } from '../domain/e2e-test.js';
+import { freezeLockedTest, lockedTestFileExists } from '../domain/e2e-test.js';
 import { loadE2eConfig, resolveParams, secretValuesFor, redactSecrets, } from '../domain/e2e-config.js';
 import { getGitInfo as realGetGitInfo } from '../e2e/git-info.js';
 import { getActiveSession } from '../agent-device-wrapper.js';
@@ -41,7 +41,7 @@ export async function lockE2eTestCore(args, deps = {}) {
         }
         resolvedParams = resolved.params;
     }
-    if (!args.relock && loadLockedTest(projectRoot, args.actionId)) {
+    if (!args.relock && lockedTestFileExists(projectRoot, args.actionId)) {
         return failResult(`'${args.actionId}' is already locked — pass relock:true to re-lock`, 'ALREADY_LOCKED');
     }
     const session = getSession();

--- a/packages/rn-dev-agent-core/dist/tools/login-prologue.js
+++ b/packages/rn-dev-agent-core/dist/tools/login-prologue.js
@@ -65,9 +65,6 @@ export function createLoginPrologueHandler(deps) {
             if (action.metadata.id !== LOGIN_PROLOGUE_ALIAS) {
                 return blocked('LOGIN_ACTION_ID_MISMATCH', `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
             }
-            const priorRunIds = new Set(action.state.runHistory
-                .map((record) => record.runId)
-                .filter((runId) => typeof runId === 'string'));
             const replayArgs = Object.create(Object.getPrototypeOf(args), Object.getOwnPropertyDescriptors(args));
             Object.assign(replayArgs, {
                 actionId: LOGIN_PROLOGUE_ALIAS,
@@ -91,18 +88,26 @@ export function createLoginPrologueHandler(deps) {
                 });
             }
             const replay = parseEnvelope(replayResult);
+            const strictRunRecordId = typeof replay.data?.strictRunRecordId === 'string'
+                ? replay.data.strictRunRecordId
+                : typeof replay.meta?.strictRunRecordId === 'string'
+                    ? replay.meta.strictRunRecordId
+                    : undefined;
             let freshRecord;
             await measure('verify-run-record', async () => {
                 const reloaded = loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS);
-                freshRecord = reloaded?.state.runHistory
-                    .slice()
-                    .reverse()
-                    .find((record) => typeof record.runId === 'string' && !priorRunIds.has(record.runId));
+                freshRecord = strictRunRecordId
+                    ? reloaded?.state.runHistory.find((record) => record.runId === strictRunRecordId)
+                    : undefined;
             });
             if (replay.ok !== true || replay.data?.passed !== true) {
-                return blocked(replay.code ?? String(replay.data?.failureKind ?? 'ACTION_REPLAY_FAILED'), 'The saved login action did not pass; exploratory login is now terminally blocked.', { actionId: LOGIN_PROLOGUE_ALIAS, ...(freshRecord ? { runRecord: freshRecord } : {}) });
+                const metaFailureKind = replay.meta?.failureKind;
+                return blocked(replay.code ??
+                    (typeof metaFailureKind === 'string'
+                        ? metaFailureKind
+                        : (freshRecord?.failureCode ?? 'ACTION_REPLAY_FAILED')), 'The saved login action did not pass; exploratory login is now terminally blocked.', { actionId: LOGIN_PROLOGUE_ALIAS, ...(freshRecord ? { runRecord: freshRecord } : {}) });
             }
-            if (!freshRecord || freshRecord.status !== 'pass') {
+            if (!strictRunRecordId || !freshRecord || freshRecord.status !== 'pass') {
                 return blocked('AUTHORITATIVE_RUN_RECORD_MISSING', 'The saved login action reported success without a fresh passing RunRecord.', { actionId: LOGIN_PROLOGUE_ALIAS });
             }
             const outcome = finish('passed', {

--- a/packages/rn-dev-agent-core/dist/tools/login-prologue.js
+++ b/packages/rn-dev-agent-core/dist/tools/login-prologue.js
@@ -1,5 +1,5 @@
 import { listActions } from '../domain/action-inventory.js';
-import { loadAction } from '../domain/action-store.js';
+import { ActionMetadataIdentityError, loadAction } from '../domain/action-store.js';
 import { ACTION_LOGIN_HELPER, LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, } from '../domain/login-prologue.js';
 import { failResult, okResult } from '../utils.js';
 import { sealStrictRunAction } from './run-action.js';
@@ -10,6 +10,10 @@ function parseEnvelope(result) {
     catch {
         return { ok: false, code: 'BAD_RESPONSE', error: 'Action replay returned invalid JSON.' };
     }
+}
+function isLoginActionIdentityMismatch(error) {
+    return (error instanceof ActionMetadataIdentityError &&
+        (error.fileId === LOGIN_PROLOGUE_ALIAS || error.metadataId === LOGIN_PROLOGUE_ALIAS));
 }
 export function createLoginPrologueHandler(deps) {
     const now = deps.now ?? (() => new Date());
@@ -58,8 +62,17 @@ export function createLoginPrologueHandler(deps) {
             });
         };
         try {
-            inventory = await measure('inventory', () => listActions(projectRoot));
-            const action = await measure('resolve', async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
+            let action;
+            try {
+                inventory = await measure('inventory', () => listActions(projectRoot));
+                action = await measure('resolve', async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
+            }
+            catch (error) {
+                if (isLoginActionIdentityMismatch(error)) {
+                    return blocked('LOGIN_ACTION_ID_MISMATCH', `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
+                }
+                throw error;
+            }
             if (!action) {
                 return blocked('LOGIN_ACTION_MISSING', `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
             }

--- a/packages/rn-dev-agent-core/dist/tools/login-prologue.js
+++ b/packages/rn-dev-agent-core/dist/tools/login-prologue.js
@@ -64,15 +64,15 @@ export function createLoginPrologueHandler(deps) {
             const priorRunIds = new Set(action.state.runHistory
                 .map((record) => record.runId)
                 .filter((runId) => typeof runId === 'string'));
-            const replayArgs = {
-                ...args,
+            const replayArgs = Object.create(Object.getPrototypeOf(args), Object.getOwnPropertyDescriptors(args));
+            Object.assign(replayArgs, {
                 actionId: LOGIN_PROLOGUE_ALIAS,
                 autoRepair: false,
                 forceReload: false,
                 proofReplay: false,
                 blindProbeMode: 'forbid',
                 trigger: args.trigger ?? 'agent',
-            };
+            });
             let replayResult;
             try {
                 replayResult = await measure('replay', () => deps.runAction(replayArgs));

--- a/packages/rn-dev-agent-core/dist/tools/login-prologue.js
+++ b/packages/rn-dev-agent-core/dist/tools/login-prologue.js
@@ -1,5 +1,5 @@
 import { listActions } from '../domain/action-inventory.js';
-import { ActionMetadataIdentityError, loadAction } from '../domain/action-store.js';
+import { loadAction } from '../domain/action-store.js';
 import { ACTION_LOGIN_HELPER, LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, } from '../domain/login-prologue.js';
 import { failResult, okResult } from '../utils.js';
 import { sealStrictRunAction } from './run-action.js';
@@ -10,10 +10,6 @@ function parseEnvelope(result) {
     catch {
         return { ok: false, code: 'BAD_RESPONSE', error: 'Action replay returned invalid JSON.' };
     }
-}
-function isLoginActionIdentityMismatch(error) {
-    return (error instanceof ActionMetadataIdentityError &&
-        (error.fileId === LOGIN_PROLOGUE_ALIAS || error.metadataId === LOGIN_PROLOGUE_ALIAS));
 }
 export function createLoginPrologueHandler(deps) {
     const now = deps.now ?? (() => new Date());
@@ -68,7 +64,9 @@ export function createLoginPrologueHandler(deps) {
                 action = await measure('resolve', async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
             }
             catch (error) {
-                if (isLoginActionIdentityMismatch(error)) {
+                if (error instanceof Error &&
+                    error.message.includes('does not match filename identity') &&
+                    error.message.includes(LOGIN_PROLOGUE_ALIAS)) {
                     return blocked('LOGIN_ACTION_ID_MISMATCH', `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
                 }
                 throw error;

--- a/packages/rn-dev-agent-core/dist/tools/login-prologue.js
+++ b/packages/rn-dev-agent-core/dist/tools/login-prologue.js
@@ -1,6 +1,6 @@
 import { listActions } from '../domain/action-inventory.js';
 import { loadAction } from '../domain/action-store.js';
-import { LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, } from '../domain/login-prologue.js';
+import { ACTION_LOGIN_HELPER, LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, } from '../domain/login-prologue.js';
 import { failResult, okResult } from '../utils.js';
 import { sealStrictRunAction } from './run-action.js';
 function parseEnvelope(result) {
@@ -38,6 +38,7 @@ export function createLoginPrologueHandler(deps) {
             return {
                 schemaVersion: 1,
                 state,
+                role: ACTION_LOGIN_HELPER,
                 alias: LOGIN_PROLOGUE_ALIAS,
                 startedAt: prologueStarted.toISOString(),
                 endedAt: ended.toISOString(),

--- a/packages/rn-dev-agent-core/dist/tools/login-prologue.js
+++ b/packages/rn-dev-agent-core/dist/tools/login-prologue.js
@@ -1,0 +1,119 @@
+import { listActions } from '../domain/action-inventory.js';
+import { loadAction } from '../domain/action-store.js';
+import { LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, } from '../domain/login-prologue.js';
+import { failResult, okResult } from '../utils.js';
+function parseEnvelope(result) {
+    try {
+        return JSON.parse(result.content[0]?.text ?? '{}');
+    }
+    catch {
+        return { ok: false, code: 'BAD_RESPONSE', error: 'Action replay returned invalid JSON.' };
+    }
+}
+export function createLoginPrologueHandler(deps) {
+    const now = deps.now ?? (() => new Date());
+    return async (args) => {
+        const projectRoot = args.projectRoot ?? process.cwd();
+        const prologueStarted = now();
+        const steps = [];
+        let inventory = [];
+        const measure = async (name, run) => {
+            const started = now();
+            try {
+                return await run();
+            }
+            finally {
+                const ended = now();
+                steps.push({
+                    name,
+                    startedAt: started.toISOString(),
+                    endedAt: ended.toISOString(),
+                    elapsedMs: Math.max(0, ended.getTime() - started.getTime()),
+                });
+            }
+        };
+        const finish = (state, extra) => {
+            const ended = now();
+            return {
+                schemaVersion: 1,
+                state,
+                alias: LOGIN_PROLOGUE_ALIAS,
+                startedAt: prologueStarted.toISOString(),
+                endedAt: ended.toISOString(),
+                elapsedMs: Math.max(0, ended.getTime() - prologueStarted.getTime()),
+                steps,
+                inventory: { count: inventory.length, actionIds: inventory.map((action) => action.id) },
+                ...extra,
+            };
+        };
+        const blocked = (code, detail, extra = {}) => {
+            const outcome = finish(LOGIN_PROLOGUE_BLOCKED, {
+                failure: { code, detail },
+                ...extra,
+            });
+            return failResult(`Login prologue blocked: ${detail}`, 'LOGIN_PROLOGUE_BLOCKED', {
+                loginPrologue: outcome,
+            });
+        };
+        try {
+            inventory = await measure('inventory', () => listActions(projectRoot));
+            const action = await measure('resolve', async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
+            if (!action || !inventory.some((candidate) => candidate.id === LOGIN_PROLOGUE_ALIAS)) {
+                return blocked('LOGIN_ACTION_MISSING', `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
+            }
+            const priorRunIds = new Set(action.state.runHistory
+                .map((record) => record.runId)
+                .filter((runId) => typeof runId === 'string'));
+            const replayArgs = {
+                ...args,
+                actionId: LOGIN_PROLOGUE_ALIAS,
+                autoRepair: false,
+                forceReload: false,
+                proofReplay: false,
+                blindProbeMode: 'forbid',
+                trigger: args.trigger ?? 'agent',
+            };
+            let replayResult;
+            try {
+                replayResult = await measure('replay', () => deps.runAction(replayArgs));
+            }
+            catch (error) {
+                const code = error && typeof error === 'object' && 'code' in error
+                    ? String(error.code)
+                    : 'ACTION_REPLAY_THROW';
+                return blocked(code, 'The saved login action threw before producing a result.', {
+                    actionId: LOGIN_PROLOGUE_ALIAS,
+                });
+            }
+            const replay = parseEnvelope(replayResult);
+            let freshRecord;
+            await measure('verify-run-record', async () => {
+                const reloaded = loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS);
+                freshRecord = reloaded?.state.runHistory
+                    .slice()
+                    .reverse()
+                    .find((record) => typeof record.runId === 'string' && !priorRunIds.has(record.runId));
+            });
+            if (replay.ok !== true || replay.data?.passed !== true) {
+                return blocked(replay.code ?? String(replay.data?.failureKind ?? 'ACTION_REPLAY_FAILED'), 'The saved login action did not pass; exploratory login is now terminally blocked.', { actionId: LOGIN_PROLOGUE_ALIAS, ...(freshRecord ? { runRecord: freshRecord } : {}) });
+            }
+            if (!freshRecord || freshRecord.status !== 'pass') {
+                return blocked('AUTHORITATIVE_RUN_RECORD_MISSING', 'The saved login action reported success without a fresh passing RunRecord.', { actionId: LOGIN_PROLOGUE_ALIAS });
+            }
+            const outcome = finish('passed', {
+                actionId: LOGIN_PROLOGUE_ALIAS,
+                runRecord: freshRecord,
+                actionResult: {
+                    transport: replay.data.transport,
+                    transportVersion: replay.data.transportVersion,
+                    fallback: replay.data.fallback,
+                    perStepReadback: replay.data.perStepReadback,
+                },
+            });
+            return okResult(outcome);
+        }
+        catch {
+            return blocked('LOGIN_PROLOGUE_INTERNAL_ERROR', 'The login prologue failed before it could prove a passing replay.');
+        }
+    };
+}

--- a/packages/rn-dev-agent-core/dist/tools/login-prologue.js
+++ b/packages/rn-dev-agent-core/dist/tools/login-prologue.js
@@ -2,6 +2,7 @@ import { listActions } from '../domain/action-inventory.js';
 import { loadAction } from '../domain/action-store.js';
 import { LOGIN_PROLOGUE_ALIAS, LOGIN_PROLOGUE_BLOCKED, } from '../domain/login-prologue.js';
 import { failResult, okResult } from '../utils.js';
+import { sealStrictRunAction } from './run-action.js';
 function parseEnvelope(result) {
     try {
         return JSON.parse(result.content[0]?.text ?? '{}');
@@ -74,9 +75,9 @@ export function createLoginPrologueHandler(deps) {
                 forceReload: false,
                 proofReplay: false,
                 blindProbeMode: 'forbid',
-                cdpFallbackMode: 'forbid',
                 trigger: args.trigger ?? 'agent',
             });
+            sealStrictRunAction(replayArgs);
             let replayResult;
             try {
                 replayResult = await measure('replay', () => deps.runAction(replayArgs));

--- a/packages/rn-dev-agent-core/dist/tools/login-prologue.js
+++ b/packages/rn-dev-agent-core/dist/tools/login-prologue.js
@@ -58,8 +58,11 @@ export function createLoginPrologueHandler(deps) {
         try {
             inventory = await measure('inventory', () => listActions(projectRoot));
             const action = await measure('resolve', async () => loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS));
-            if (!action || !inventory.some((candidate) => candidate.id === LOGIN_PROLOGUE_ALIAS)) {
+            if (!action) {
                 return blocked('LOGIN_ACTION_MISSING', `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`);
+            }
+            if (action.metadata.id !== LOGIN_PROLOGUE_ALIAS) {
+                return blocked('LOGIN_ACTION_ID_MISMATCH', `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`);
             }
             const priorRunIds = new Set(action.state.runHistory
                 .map((record) => record.runId)

--- a/packages/rn-dev-agent-core/dist/tools/login-prologue.js
+++ b/packages/rn-dev-agent-core/dist/tools/login-prologue.js
@@ -74,6 +74,7 @@ export function createLoginPrologueHandler(deps) {
                 forceReload: false,
                 proofReplay: false,
                 blindProbeMode: 'forbid',
+                cdpFallbackMode: 'forbid',
                 trigger: args.trigger ?? 'agent',
             });
             let replayResult;

--- a/packages/rn-dev-agent-core/dist/tools/run-action.js
+++ b/packages/rn-dev-agent-core/dist/tools/run-action.js
@@ -89,6 +89,11 @@ function classifyFailure(failure) {
             return { actionCode: 'UNKNOWN', toolCode: undefined };
     }
 }
+const PROVEN_ENGINE_PIN_DIVERGENCE = new Set(['drift-newer', 'drift-older', 'checksum-mismatch']);
+function strictEnginePinDivergence(env) {
+    const status = env.data?.enginePin?.status;
+    return typeof status === 'string' && PROVEN_ENGINE_PIN_DIVERGENCE.has(status) ? status : null;
+}
 function parseEnvelope(toolResult, toolName) {
     try {
         return JSON.parse(toolResult.content?.[0]?.text ?? '{}');
@@ -420,6 +425,9 @@ export function createRunActionHandler(deps = {}) {
             // Opt out globally with RN_BLIND_PROBE=0.
             let atRisk = null;
             const strictExecutor = usesStrictRunActionPolicy(args);
+            const strictRunRecordMeta = (outcome) => strictExecutor && outcome.persistedRunId
+                ? { strictRunRecordId: outcome.persistedRunId }
+                : {};
             const inheritedBlindProbeDisabled = process.env.RN_BLIND_PROBE === '0' || process.env.RN_BLIND_PROBE === 'false';
             const blindProbeDisabled = strictExecutor ||
                 args.blindProbeMode === 'forbid' ||
@@ -542,11 +550,37 @@ export function createRunActionHandler(deps = {}) {
             }));
             const firstAttemptMs = Date.now() - tBeforeFirst;
             const firstEnv = parseEnvelope(firstResult, 'maestro_run');
-            const firstPassed = firstEnv.ok === true && firstEnv.data?.passed === true;
             const firstOutput = readMaestroOutput(firstEnv);
             const firstFailureDetail = readMaestroFailureDetail(firstEnv, firstOutput);
             const firstDeviceAuthority = readMaestroDeviceAuthority(firstEnv);
             probeDeviceId = firstDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
+            const enginePinDivergence = strictExecutor ? strictEnginePinDivergence(firstEnv) : null;
+            if (enginePinDivergence) {
+                const autoRepair = {
+                    attempted: false,
+                    outcome: 'refused',
+                    refusedReason: 'NOT_REPAIRABLE_KIND',
+                    phases: { firstAttemptMs },
+                };
+                const persisted = await persistRunWithDevice({
+                    timestamp: new Date().toISOString(),
+                    durationMs: Date.now() - t0,
+                    status: 'fail',
+                    failureCode: 'UNKNOWN',
+                    failureDetail: `Engine pin status ${enginePinDivergence}`,
+                    trigger,
+                    autoRepair,
+                });
+                return failResult(`cdp_run_action: ${args.actionId} refused strict replay because the engine pin status is ${enginePinDivergence}.`, 'ENGINE_PIN_MISMATCH', {
+                    actionId: args.actionId,
+                    failureKind: 'ENGINE_PIN_MISMATCH',
+                    enginePin: firstEnv.data?.enginePin,
+                    autoRepair,
+                    writes: writeDisclosure('none', persisted),
+                    ...strictRunRecordMeta(persisted),
+                });
+            }
+            const firstPassed = firstEnv.ok === true && firstEnv.data?.passed === true;
             if (firstEnv.code) {
                 const typedCode = firstEnv.code;
                 const autoRepair = {
@@ -574,6 +608,7 @@ export function createRunActionHandler(deps = {}) {
                     deviceAuthority: firstDeviceAuthority,
                     autoRepair,
                     writes: writeDisclosure('none', persisted),
+                    ...strictRunRecordMeta(persisted),
                 });
             }
             if (firstPassed) {
@@ -590,9 +625,17 @@ export function createRunActionHandler(deps = {}) {
                     trigger,
                     autoRepair,
                 });
+                if (strictExecutor && persisted.persistedRunId !== runId) {
+                    return failResult(`cdp_run_action: ${args.actionId} passed, but its authoritative RunRecord was not committed.`, 'LOAD_FAILED', {
+                        actionId: args.actionId,
+                        failureKind: 'AUTHORITATIVE_RUN_RECORD_MISSING',
+                        writes: writeDisclosure('none', persisted),
+                    });
+                }
                 return okResult({
                     passed: true,
                     actionId: args.actionId,
+                    ...(strictExecutor ? { strictRunRecordId: persisted.persistedRunId } : {}),
                     ...(proofReplay ? { proofReplay: true } : {}),
                     ...replaySuccessEvidence(firstEnv),
                     repair: autoRepair,
@@ -764,7 +807,7 @@ export function createRunActionHandler(deps = {}) {
                         phases: { firstAttemptMs },
                     };
                 const { actionCode, toolCode } = classifyFailure(failure);
-                await persistRunWithDevice({
+                const persisted = await persistRunWithDevice({
                     timestamp: new Date().toISOString(),
                     durationMs: Date.now() - t0,
                     status: 'fail',
@@ -787,6 +830,7 @@ export function createRunActionHandler(deps = {}) {
                     terminal: readMaestroTerminal(firstEnv),
                     runnerResume: firstEnv.meta?.runnerResume,
                     ...(cdpJsFallback ? { cdpJsFallback } : {}),
+                    ...strictRunRecordMeta(persisted),
                 };
                 let message = failure.kind === 'WDA_BOOTSTRAP_FAILED'
                     ? `cdp_run_action: ${args.actionId} failed (WDA_BOOTSTRAP_FAILED) before the first replay step: ${failure.detail}. Re-run the replay (bootstrap retries itself); check network access; diagnose the pin-cache runner with ${PINNED_RUNNER_DIAGNOSE_HINT}. Supported correction: ${PINNED_RUNNER_INSTALL_HINT}. Never invoke PATH, ~/.maestro-runner, maestro-cli, or manual login. No preparation or cache mutation was attempted.`
@@ -1069,7 +1113,7 @@ async function persistRun(actionId, projectRoot, record) {
                     path: fresh.filePath,
                 },
             });
-            return { promoted, promotionRefused };
+            return { promoted, promotionRefused, persistedRunId: record.runId };
         };
         // A promotion refusal is deterministic (externally edited YAML, or a missing
         // `# status: experimental` marker) — retrying cannot clear it, so degrade to

--- a/packages/rn-dev-agent-core/dist/tools/run-action.js
+++ b/packages/rn-dev-agent-core/dist/tools/run-action.js
@@ -27,6 +27,7 @@
 //     intentionally NOT in scope for phase 1 (each repair attempt is a
 //     30s+ device snapshot; cascading retries would be slow and could
 //     mask underlying screen churn).
+import { randomUUID } from 'node:crypto';
 import { okResult, failResult } from '../utils.js';
 import { acknowledgeExternalEdit, loadAction, promoteActionRuntimeWithCAS, saveActionRuntimeWithCAS, } from '../domain/action-store.js';
 import { mirrorToDb } from '../domain/action-state-store.js';
@@ -325,6 +326,24 @@ export function createRunActionHandler(deps = {}) {
         const trigger = args.trigger ?? 'agent';
         const timeoutMs = args.timeoutMs ?? 120_000;
         const t0 = Date.now();
+        const startedAt = new Date(t0).toISOString();
+        const runId = randomUUID();
+        const timingSteps = [];
+        const measureStep = async (name, run) => {
+            const stepStartedMs = Date.now();
+            try {
+                return await run();
+            }
+            finally {
+                const stepEndedMs = Date.now();
+                timingSteps.push({
+                    name,
+                    startedAt: new Date(stepStartedMs).toISOString(),
+                    endedAt: new Date(stepEndedMs).toISOString(),
+                    elapsedMs: Math.max(0, stepEndedMs - stepStartedMs),
+                });
+            }
+        };
         const activeTarget = targetContext();
         if (args.platform && activeTarget?.platform && activeTarget.platform !== args.platform) {
             return failResult(`cdp_run_action: requested ${args.platform}, but the active session is ${activeTarget.platform}; refusing cross-platform replay.`, 'TARGET_SESSION_MISMATCH', { requestedPlatform: args.platform, activeSession: activeTarget });
@@ -351,9 +370,22 @@ export function createRunActionHandler(deps = {}) {
         // Maestro was pinned to). Used only when the dispatch produced no receipt,
         // so a clean pass can still clear a device-matched blind-probe latch.
         let observedDeviceId = maestroDeviceId ?? null;
-        const persistRunWithDevice = (record) => proofReplay
-            ? Promise.resolve({ promoted: false, promotionRefused: false })
-            : persistRun(args.actionId, projectRoot, probeDeviceId ? { ...record, deviceId: probeDeviceId } : record);
+        const persistRunWithDevice = (record) => {
+            if (proofReplay)
+                return Promise.resolve({ promoted: false, promotionRefused: false });
+            const endedMs = Date.now();
+            const timedRecord = {
+                ...record,
+                runId,
+                timing: {
+                    startedAt,
+                    endedAt: new Date(endedMs).toISOString(),
+                    elapsedMs: Math.max(0, endedMs - t0),
+                    steps: [...timingSteps],
+                },
+            };
+            return persistRun(args.actionId, projectRoot, probeDeviceId ? { ...timedRecord, deviceId: probeDeviceId } : timedRecord);
+        };
         const writeDisclosure = (actionYaml = 'none', outcome) => ({
             actionYaml: actionYaml === 'none'
                 ? { written: false, reason: 'repair-not-applied' }
@@ -407,11 +439,11 @@ export function createRunActionHandler(deps = {}) {
                 const probe = replayDeps ? firstReplayTestId(cdpReplayYaml, args.params ?? {}) : null;
                 if (replayDeps && probe) {
                     const tProbe = Date.now();
-                    const probeOutcome = await probeTreeWithRetry(replayDeps, probe, probeRetry);
+                    const probeOutcome = await measureStep('proactive-probe', () => probeTreeWithRetry(replayDeps, probe, probeRetry));
                     if (probeOutcome.found) {
                         const tReplay = Date.now();
                         try {
-                            const replay = await runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps);
+                            const replay = await measureStep('proactive-cdp-replay', () => runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps));
                             const timings_ms = { probe: tReplay - tProbe, replay: Date.now() - tReplay };
                             const blindProbe = { atRisk, skippedMaestro: true };
                             const autoRepair = {
@@ -482,7 +514,7 @@ export function createRunActionHandler(deps = {}) {
             // Requested/session metadata is not RunRecord authority. Clear it before
             // dispatch; only direct maestro-runner evidence may repopulate it.
             probeDeviceId = null;
-            const firstResult = await maestroRun({
+            const firstResult = await measureStep('maestro-first-attempt', () => maestroRun({
                 inlineYaml: replayYaml,
                 actionMetadata: action.metadata,
                 platform: args.platform,
@@ -497,7 +529,7 @@ export function createRunActionHandler(deps = {}) {
                 reproveManagedOrigin: () => reproveManagedOrigin(args),
                 completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
                 reissueInstallReceipt: () => reissueInstallReceipt(args),
-            });
+            }));
             const firstAttemptMs = Date.now() - tBeforeFirst;
             const firstEnv = parseEnvelope(firstResult, 'maestro_run');
             const firstPassed = firstEnv.ok === true && firstEnv.data?.passed === true;
@@ -620,7 +652,7 @@ export function createRunActionHandler(deps = {}) {
                     cdpJsFallback = { attempted: false, reason: 'no-probe-testid' };
                 }
                 else {
-                    const probeOutcome = await probeTreeWithRetry(replayDeps, probe, probeRetry);
+                    const probeOutcome = await measureStep('fallback-probe', () => probeTreeWithRetry(replayDeps, probe, probeRetry));
                     if (!probeOutcome.found) {
                         cdpJsFallback = {
                             attempted: false,
@@ -642,9 +674,9 @@ export function createRunActionHandler(deps = {}) {
                         try {
                             // GH #580: resume at the proven failed selector; UNKNOWN failed before
                             // any step, so it keeps start-at-zero.
-                            const replay = await runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps, {
+                            const replay = await measureStep('fallback-cdp-replay', () => runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps, {
                                 resumeAtSelector: failure.kind === 'SELECTOR_NOT_FOUND' ? failure.selector : null,
-                            });
+                            }));
                             const status = replay.passed ? 'pass' : 'fail';
                             const autoRepair = {
                                 attempted: false,
@@ -761,12 +793,12 @@ export function createRunActionHandler(deps = {}) {
                 throw new Error('Internal: isAutoRepairable returned true for non-SELECTOR_NOT_FOUND failure');
             }
             const tBeforeRepair = Date.now();
-            const repairResult = await repairAction({
+            const repairResult = await measureStep('selector-repair', () => repairAction({
                 actionId: args.actionId,
                 failedSelector: failure.selector,
                 projectRoot,
                 agentReasoning: `auto-repair from cdp_run_action after maestro failure: ${failure.selector}`,
-            });
+            }));
             const repairMs = Date.now() - tBeforeRepair;
             const repairEnv = parseEnvelope(repairResult, 'cdp_repair_action');
             const repairPatched = repairEnv.ok === true && repairEnv.data?.patched === true;
@@ -828,10 +860,11 @@ export function createRunActionHandler(deps = {}) {
             if (!reloadedAction.replay.ok) {
                 return failResult(`cdp_run_action: repaired action is not valid Maestro YAML: ${reloadedAction.replay.error}`, 'BAD_RECORDING', { actionId: args.actionId });
             }
+            const retryYaml = reloadedAction.replay.yamlText;
             const tBeforeRetry = Date.now();
             probeDeviceId = null;
-            const retryResult = await maestroRun({
-                inlineYaml: reloadedAction.replay.yamlText,
+            const retryResult = await measureStep('maestro-retry', () => maestroRun({
+                inlineYaml: retryYaml,
                 actionMetadata: reloadedAction.metadata,
                 platform: args.platform,
                 appId: args.appId,
@@ -845,7 +878,7 @@ export function createRunActionHandler(deps = {}) {
                 reproveManagedOrigin: () => reproveManagedOrigin(args),
                 completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
                 reissueInstallReceipt: () => reissueInstallReceipt(args),
-            });
+            }));
             const retryMs = Date.now() - tBeforeRetry;
             const retryEnv = parseEnvelope(retryResult, 'maestro_run');
             const retryPassed = retryEnv.ok === true && retryEnv.data?.passed === true;

--- a/packages/rn-dev-agent-core/dist/tools/run-action.js
+++ b/packages/rn-dev-agent-core/dist/tools/run-action.js
@@ -537,7 +537,8 @@ export function createRunActionHandler(deps = {}) {
             const firstFailureDetail = readMaestroFailureDetail(firstEnv, firstOutput);
             const firstDeviceAuthority = readMaestroDeviceAuthority(firstEnv);
             probeDeviceId = firstDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
-            if (firstEnv.code === 'DEVICE_AUTHORITY_MISMATCH') {
+            if (firstEnv.code) {
+                const typedCode = firstEnv.code;
                 const autoRepair = {
                     attempted: false,
                     outcome: args.autoRepair === false ? 'refused' : 'skipped',
@@ -548,14 +549,18 @@ export function createRunActionHandler(deps = {}) {
                     timestamp: new Date().toISOString(),
                     durationMs: Date.now() - t0,
                     status: 'fail',
-                    failureCode: 'DEVICE_AUTHORITY_MISMATCH',
+                    failureCode: typedCode === 'DEVICE_AUTHORITY_MISMATCH'
+                        ? 'DEVICE_AUTHORITY_MISMATCH'
+                        : typedCode === 'RECONNECT_TIMEOUT'
+                            ? 'TIMEOUT'
+                            : 'UNKNOWN',
                     failureDetail: firstFailureDetail.slice(0, 1000),
                     trigger,
                     autoRepair,
                 });
-                return failResult(`cdp_run_action: ${args.actionId} refused replay authority: ${firstFailureDetail}`, 'DEVICE_AUTHORITY_MISMATCH', {
+                return failResult(`cdp_run_action: ${args.actionId} refused replay: ${firstFailureDetail}`, typedCode, {
                     actionId: args.actionId,
-                    failureKind: 'DEVICE_AUTHORITY_MISMATCH',
+                    failureKind: typedCode,
                     deviceAuthority: firstDeviceAuthority,
                     autoRepair,
                     writes: writeDisclosure('none', persisted),

--- a/packages/rn-dev-agent-core/dist/tools/run-action.js
+++ b/packages/rn-dev-agent-core/dist/tools/run-action.js
@@ -411,8 +411,10 @@ export function createRunActionHandler(deps = {}) {
             // directly. Every branch fails open to the maestro-first path below.
             // Opt out globally with RN_BLIND_PROBE=0.
             let atRisk = null;
+            const cdpFallbackForbidden = args.cdpFallbackMode === 'forbid';
             const inheritedBlindProbeDisabled = process.env.RN_BLIND_PROBE === '0' || process.env.RN_BLIND_PROBE === 'false';
-            const blindProbeDisabled = args.blindProbeMode === 'forbid' ||
+            const blindProbeDisabled = cdpFallbackForbidden ||
+                args.blindProbeMode === 'forbid' ||
                 (args.blindProbeMode !== 'allow' && inheritedBlindProbeDisabled);
             if (args.platform !== 'android') {
                 // Resolve the device context even when the gate is opted out: a clean
@@ -642,7 +644,8 @@ export function createRunActionHandler(deps = {}) {
             // usually just relaunched the app), and every skip records its reason —
             // a silent skip surfaced in the field as an unexplained UNKNOWN.
             let cdpJsFallback;
-            if (failure.kind === 'SELECTOR_NOT_FOUND' || failure.kind === 'UNKNOWN') {
+            if (!cdpFallbackForbidden &&
+                (failure.kind === 'SELECTOR_NOT_FOUND' || failure.kind === 'UNKNOWN')) {
                 const candidate = getReplayDeps(args);
                 const replayDeps = candidate && (await claimBundleAuthority(args)) ? candidate : null;
                 const probe = !replayDeps

--- a/packages/rn-dev-agent-core/dist/tools/run-action.js
+++ b/packages/rn-dev-agent-core/dist/tools/run-action.js
@@ -46,6 +46,14 @@ import { getWorkerAuthorityRuntime } from '../session/runtime.js';
 import { flowUsesClearState, resolveIosAppFile } from './resolve-ios-app-file.js';
 import { actionReplayPreflight } from '../domain/action-engine-compat.js';
 import { getEngineStatus, PINNED_RUNNER_DIAGNOSE_HINT, PINNED_RUNNER_INSTALL_HINT, } from '../domain/engine-pin.js';
+const strictRunActionPolicy = Symbol('strictRunActionPolicy');
+export function sealStrictRunAction(args) {
+    Object.defineProperty(args, strictRunActionPolicy, { value: true });
+    return args;
+}
+function usesStrictRunActionPolicy(args) {
+    return args[strictRunActionPolicy] === true;
+}
 /** GH #705: the session's attested install receipt, or null outside a session. */
 function boundInstallReceipt() {
     try {
@@ -411,9 +419,9 @@ export function createRunActionHandler(deps = {}) {
             // directly. Every branch fails open to the maestro-first path below.
             // Opt out globally with RN_BLIND_PROBE=0.
             let atRisk = null;
-            const cdpFallbackForbidden = args.cdpFallbackMode === 'forbid';
+            const strictExecutor = usesStrictRunActionPolicy(args);
             const inheritedBlindProbeDisabled = process.env.RN_BLIND_PROBE === '0' || process.env.RN_BLIND_PROBE === 'false';
-            const blindProbeDisabled = cdpFallbackForbidden ||
+            const blindProbeDisabled = strictExecutor ||
                 args.blindProbeMode === 'forbid' ||
                 (args.blindProbeMode !== 'allow' && inheritedBlindProbeDisabled);
             if (args.platform !== 'android') {
@@ -644,7 +652,7 @@ export function createRunActionHandler(deps = {}) {
             // usually just relaunched the app), and every skip records its reason —
             // a silent skip surfaced in the field as an unexplained UNKNOWN.
             let cdpJsFallback;
-            if (!cdpFallbackForbidden &&
+            if (!strictExecutor &&
                 (failure.kind === 'SELECTOR_NOT_FOUND' || failure.kind === 'UNKNOWN')) {
                 const candidate = getReplayDeps(args);
                 const replayDeps = candidate && (await claimBundleAuthority(args)) ? candidate : null;

--- a/packages/rn-dev-agent-core/dist/tools/run-e2e-suite.js
+++ b/packages/rn-dev-agent-core/dist/tools/run-e2e-suite.js
@@ -1,4 +1,4 @@
-import { discoverLockedTests, loadLockedTest } from '../domain/e2e-test.js';
+import { discoverLockedTests, getResolvedLockedTestIds, loadLockedTest, resolveLockedTestIds, } from '../domain/e2e-test.js';
 import { classifyFlowResult, skippedResult, unloadableResult, computeVerdict, diffNewlyFailing, writeRunRecord, loadRunRecord, lastGreenRunId, } from '../domain/e2e-run.js';
 import { loadE2eConfig, resolveParams, secretValuesFor, redactSecrets, } from '../domain/e2e-config.js';
 import { getGitInfo as realGetGitInfo } from '../e2e/git-info.js';
@@ -22,17 +22,6 @@ function readMaestro(result) {
         return { passed: false, output: 'unparseable maestro result' };
     }
 }
-function filterByPattern(ids, pattern) {
-    if (!pattern || pattern.length > 256)
-        return ids;
-    try {
-        const re = new RegExp(pattern, 'i');
-        return ids.filter((id) => re.test(id));
-    }
-    catch {
-        return ids;
-    }
-}
 export async function runE2eSuiteCore(args, deps = {}) {
     const projectRoot = args.projectRoot ?? findProjectRoot() ?? process.cwd();
     const discover = deps.discover ?? discoverLockedTests;
@@ -43,7 +32,10 @@ export async function runE2eSuiteCore(args, deps = {}) {
     const now = deps.now ?? (() => new Date());
     const mkRunId = deps.makeRunId ?? makeRunId;
     const rand = () => Math.random().toString(36).slice(2, 8);
-    const ids = filterByPattern(discover(projectRoot), args.pattern);
+    const ids = [
+        ...(getResolvedLockedTestIds(args) ??
+            resolveLockedTestIds(projectRoot, args.pattern, discover)),
+    ];
     if (ids.length === 0) {
         return warnResult({
             runId: null,

--- a/packages/rn-dev-agent-core/dist/util/redact.js
+++ b/packages/rn-dev-agent-core/dist/util/redact.js
@@ -29,7 +29,7 @@ const PII_PATTERNS = [
     /\b\d{3}[-.]\d{3}[-.]\d{4}\b/g,
     /\b\d{3}-\d{2}-\d{4}\b/g,
 ];
-const AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
+const AUTH_PATHS = /\b(auth|authorization|session|token|accessToken|refreshToken|supervisorOverrideToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
 const MAX_STRING_LENGTH = 2000;
 function redactString(value) {
     // Redact BEFORE truncating. Truncation can sever a paired-delimiter secret —

--- a/packages/rn-dev-agent-core/src/domain/action-store.ts
+++ b/packages/rn-dev-agent-core/src/domain/action-store.ts
@@ -964,9 +964,17 @@ export function assertActionMetadataIdentity(
 ): void {
   const fileId = basename(filePath).replace(/\.ya?ml$/i, '');
   if (metadata.id !== fileId) {
-    throw new Error(
-      `Action metadata id ${metadata.id} does not match filename identity ${fileId}.`,
-    );
+    throw new ActionMetadataIdentityError(metadata.id, fileId);
+  }
+}
+
+export class ActionMetadataIdentityError extends Error {
+  constructor(
+    readonly metadataId: string,
+    readonly fileId: string,
+  ) {
+    super(`Action metadata id ${metadataId} does not match filename identity ${fileId}.`);
+    this.name = 'ActionMetadataIdentityError';
   }
 }
 

--- a/packages/rn-dev-agent-core/src/domain/action-store.ts
+++ b/packages/rn-dev-agent-core/src/domain/action-store.ts
@@ -964,17 +964,9 @@ export function assertActionMetadataIdentity(
 ): void {
   const fileId = basename(filePath).replace(/\.ya?ml$/i, '');
   if (metadata.id !== fileId) {
-    throw new ActionMetadataIdentityError(metadata.id, fileId);
-  }
-}
-
-export class ActionMetadataIdentityError extends Error {
-  constructor(
-    readonly metadataId: string,
-    readonly fileId: string,
-  ) {
-    super(`Action metadata id ${metadataId} does not match filename identity ${fileId}.`);
-    this.name = 'ActionMetadataIdentityError';
+    throw new Error(
+      `Action metadata id ${metadata.id} does not match filename identity ${fileId}.`,
+    );
   }
 }
 

--- a/packages/rn-dev-agent-core/src/domain/e2e-test.ts
+++ b/packages/rn-dev-agent-core/src/domain/e2e-test.ts
@@ -96,7 +96,8 @@ export function freezeLockedTest(
 export function loadLockedTest(projectRoot: string, id: string): LockedE2eTest | null {
   const filePath = e2ePathFor(projectRoot, id);
   if (!existsSync(filePath)) return null;
-  return parseLockedTest(readFileSync(filePath, 'utf8'), filePath);
+  const locked = parseLockedTest(readFileSync(filePath, 'utf8'), filePath);
+  return locked?.id === id ? locked : null;
 }
 
 export function discoverLockedTests(projectRoot: string): string[] {
@@ -121,6 +122,18 @@ export function resolveLockedTestIds(
   } catch {
     return ids;
   }
+}
+
+export function resolveLockedTestIdentityIds(
+  projectRoot: string,
+  pattern?: string,
+  discover: (root: string) => string[] = discoverLockedTests,
+  load: (root: string, id: string) => LockedE2eTest | null = loadLockedTest,
+): string[] {
+  return resolveLockedTestIds(projectRoot, pattern, discover).filter((id) => {
+    const locked = load(projectRoot, id);
+    return locked?.id === id && locked.sourceActionId === id;
+  });
 }
 
 const resolvedLockedTestIds = Symbol('resolvedLockedTestIds');

--- a/packages/rn-dev-agent-core/src/domain/e2e-test.ts
+++ b/packages/rn-dev-agent-core/src/domain/e2e-test.ts
@@ -100,6 +100,10 @@ export function loadLockedTest(projectRoot: string, id: string): LockedE2eTest |
   return locked?.id === id ? locked : null;
 }
 
+export function lockedTestFileExists(projectRoot: string, id: string): boolean {
+  return existsSync(e2ePathFor(projectRoot, id));
+}
+
 export function discoverLockedTests(projectRoot: string): string[] {
   const dir = e2eDirFor(projectRoot);
   if (!existsSync(dir)) return [];
@@ -124,16 +128,23 @@ export function resolveLockedTestIds(
   }
 }
 
-export function resolveLockedTestIdentityIds(
+export interface ResolvedLockedTestSelection {
+  ids: string[];
+  identitiesValid: boolean;
+}
+
+export function resolveLockedTestSelection(
   projectRoot: string,
   pattern?: string,
   discover: (root: string) => string[] = discoverLockedTests,
   load: (root: string, id: string) => LockedE2eTest | null = loadLockedTest,
-): string[] {
-  return resolveLockedTestIds(projectRoot, pattern, discover).filter((id) => {
+): ResolvedLockedTestSelection {
+  const ids = resolveLockedTestIds(projectRoot, pattern, discover);
+  const identitiesValid = ids.every((id) => {
     const locked = load(projectRoot, id);
     return locked?.id === id && locked.sourceActionId === id;
   });
+  return { ids, identitiesValid };
 }
 
 const resolvedLockedTestIds = Symbol('resolvedLockedTestIds');

--- a/packages/rn-dev-agent-core/src/domain/e2e-test.ts
+++ b/packages/rn-dev-agent-core/src/domain/e2e-test.ts
@@ -108,6 +108,38 @@ export function discoverLockedTests(projectRoot: string): string[] {
     .sort();
 }
 
+export function resolveLockedTestIds(
+  projectRoot: string,
+  pattern?: string,
+  discover: (root: string) => string[] = discoverLockedTests,
+): string[] {
+  const ids = discover(projectRoot);
+  if (!pattern || pattern.length > 256) return ids;
+  try {
+    const matcher = new RegExp(pattern, 'i');
+    return ids.filter((id) => matcher.test(id));
+  } catch {
+    return ids;
+  }
+}
+
+const resolvedLockedTestIds = Symbol('resolvedLockedTestIds');
+
+type ResolvedLockedTestArgs = Record<string | symbol, unknown> & {
+  [resolvedLockedTestIds]?: readonly string[];
+};
+
+export function setResolvedLockedTestIds(args: object, ids: readonly string[]): void {
+  Object.defineProperty(args, resolvedLockedTestIds, {
+    value: Object.freeze([...ids]),
+    configurable: true,
+  });
+}
+
+export function getResolvedLockedTestIds(args: object): readonly string[] | undefined {
+  return (args as ResolvedLockedTestArgs)[resolvedLockedTestIds];
+}
+
 export function parseLockedTest(text: string, filePath: string): LockedE2eTest | null {
   if (!/^#\s*e2e-locked-test:\s*true\s*$/m.test(text)) return null;
   const sentinelIdx = text.indexOf(FLOW_SENTINEL);

--- a/packages/rn-dev-agent-core/src/domain/login-prologue.ts
+++ b/packages/rn-dev-agent-core/src/domain/login-prologue.ts
@@ -3,6 +3,8 @@ import type { RunRecord } from './reusable-action.js';
 
 export const LOGIN_PROLOGUE_ALIAS = 'user-login';
 export const LOGIN_PROLOGUE_BLOCKED = 'LOGIN_PROLOGUE_BLOCKED';
+export const ACTION_LOGIN_HELPER = 'ACTION_LOGIN_HELPER';
+export const LOCKED_E2E_LOGIN_TOOLS = ['cdp_lock_e2e_test', 'cdp_run_e2e_suite'] as const;
 
 export interface LoginPrologueStepTiming {
   name: 'inventory' | 'resolve' | 'replay' | 'verify-run-record';
@@ -19,6 +21,7 @@ export interface LoginOverrideAudit {
 export interface LoginPrologueOutcome {
   schemaVersion: 1;
   state: 'passed' | typeof LOGIN_PROLOGUE_BLOCKED;
+  role?: typeof ACTION_LOGIN_HELPER;
   alias: typeof LOGIN_PROLOGUE_ALIAS;
   actionId?: string;
   attemptId?: string;
@@ -53,6 +56,11 @@ export function readLoginPrologueOutcome(value: unknown): LoginPrologueOutcome |
     return null;
   }
   return candidate as LoginPrologueOutcome;
+}
+
+function lockedE2eProofAllowed(tool: string): boolean {
+  // Locked e2e is the formal PR-proof path and must coexist with the helper gate.
+  return (LOCKED_E2E_LOGIN_TOOLS as readonly string[]).includes(tool);
 }
 
 function cleanupAllowed(tool: string, args: Record<string, unknown>): boolean {
@@ -99,7 +107,8 @@ export function inspectLoginPrologueGuard(input: {
   if (
     outcome?.state !== LOGIN_PROLOGUE_BLOCKED ||
     !input.mutation ||
-    cleanupAllowed(input.tool, input.args)
+    cleanupAllowed(input.tool, input.args) ||
+    lockedE2eProofAllowed(input.tool)
   ) {
     return { blocked: false };
   }

--- a/packages/rn-dev-agent-core/src/domain/login-prologue.ts
+++ b/packages/rn-dev-agent-core/src/domain/login-prologue.ts
@@ -58,10 +58,14 @@ export function readLoginPrologueOutcome(value: unknown): LoginPrologueOutcome |
   return candidate as LoginPrologueOutcome;
 }
 
-function lockedE2eProofAllowed(tool: string, args: Record<string, unknown>): boolean {
+function lockedE2eProofAllowed(
+  tool: string,
+  args: Record<string, unknown>,
+  resolvedLockedTestIds?: readonly string[],
+): boolean {
   if (tool === 'cdp_lock_e2e_test') return args.actionId === LOGIN_PROLOGUE_ALIAS;
   if (tool === 'cdp_run_e2e_suite') {
-    return args.pattern === `^${LOGIN_PROLOGUE_ALIAS}$`;
+    return resolvedLockedTestIds?.length === 1 && resolvedLockedTestIds[0] === LOGIN_PROLOGUE_ALIAS;
   }
   return false;
 }
@@ -105,13 +109,14 @@ export function inspectLoginPrologueGuard(input: {
   tool: string;
   args: Record<string, unknown>;
   mutation: boolean;
+  resolvedLockedTestIds?: readonly string[];
 }): LoginPrologueGuardInspection {
   const outcome = readLoginPrologueOutcome(input.binding);
   if (
     outcome?.state !== LOGIN_PROLOGUE_BLOCKED ||
     !input.mutation ||
     cleanupAllowed(input.tool, input.args) ||
-    lockedE2eProofAllowed(input.tool, input.args)
+    lockedE2eProofAllowed(input.tool, input.args, input.resolvedLockedTestIds)
   ) {
     return { blocked: false };
   }
@@ -139,6 +144,7 @@ export function evaluateLoginPrologueGuard(input: {
   tool: string;
   args: Record<string, unknown>;
   mutation: boolean;
+  resolvedLockedTestIds?: readonly string[];
   expectedOverrideToken?: string;
   now?: () => Date;
 }): LoginPrologueGuardDecision {

--- a/packages/rn-dev-agent-core/src/domain/login-prologue.ts
+++ b/packages/rn-dev-agent-core/src/domain/login-prologue.ts
@@ -58,9 +58,12 @@ export function readLoginPrologueOutcome(value: unknown): LoginPrologueOutcome |
   return candidate as LoginPrologueOutcome;
 }
 
-function lockedE2eProofAllowed(tool: string): boolean {
-  // Locked e2e is the formal PR-proof path and must coexist with the helper gate.
-  return (LOCKED_E2E_LOGIN_TOOLS as readonly string[]).includes(tool);
+function lockedE2eProofAllowed(tool: string, args: Record<string, unknown>): boolean {
+  if (tool === 'cdp_lock_e2e_test') return args.actionId === LOGIN_PROLOGUE_ALIAS;
+  if (tool === 'cdp_run_e2e_suite') {
+    return args.pattern === `^${LOGIN_PROLOGUE_ALIAS}$`;
+  }
+  return false;
 }
 
 function cleanupAllowed(tool: string, args: Record<string, unknown>): boolean {
@@ -108,7 +111,7 @@ export function inspectLoginPrologueGuard(input: {
     outcome?.state !== LOGIN_PROLOGUE_BLOCKED ||
     !input.mutation ||
     cleanupAllowed(input.tool, input.args) ||
-    lockedE2eProofAllowed(input.tool)
+    lockedE2eProofAllowed(input.tool, input.args)
   ) {
     return { blocked: false };
   }

--- a/packages/rn-dev-agent-core/src/domain/login-prologue.ts
+++ b/packages/rn-dev-agent-core/src/domain/login-prologue.ts
@@ -21,6 +21,7 @@ export interface LoginPrologueOutcome {
   state: 'passed' | typeof LOGIN_PROLOGUE_BLOCKED;
   alias: typeof LOGIN_PROLOGUE_ALIAS;
   actionId?: string;
+  attemptId?: string;
   startedAt: string;
   endedAt: string;
   elapsedMs: number;

--- a/packages/rn-dev-agent-core/src/domain/login-prologue.ts
+++ b/packages/rn-dev-agent-core/src/domain/login-prologue.ts
@@ -84,6 +84,7 @@ function cleanupAllowed(tool: string, args: Record<string, unknown>): boolean {
     (args.action === 'release' ||
       args.action === 'stop_metro' ||
       args.action === 'cancel_handoff' ||
+      (args.action === 'recover_arbiter' && args.confirmed === true) ||
       args.action === 'status')
   );
 }

--- a/packages/rn-dev-agent-core/src/domain/login-prologue.ts
+++ b/packages/rn-dev-agent-core/src/domain/login-prologue.ts
@@ -84,6 +84,43 @@ export type LoginPrologueGuardDecision =
   | { allowed: true; override: true; audit: LoginOverrideAudit }
   | { allowed: false; suppliedOverride: boolean };
 
+export type LoginPrologueGuardInspection =
+  | { blocked: false }
+  | { blocked: true; suppliedOverride: string | undefined };
+
+export function inspectLoginPrologueGuard(input: {
+  binding: unknown;
+  tool: string;
+  args: Record<string, unknown>;
+  mutation: boolean;
+}): LoginPrologueGuardInspection {
+  const outcome = readLoginPrologueOutcome(input.binding);
+  if (
+    outcome?.state !== LOGIN_PROLOGUE_BLOCKED ||
+    !input.mutation ||
+    cleanupAllowed(input.tool, input.args)
+  ) {
+    return { blocked: false };
+  }
+  return {
+    blocked: true,
+    suppliedOverride:
+      typeof input.args.supervisorOverrideToken === 'string'
+        ? input.args.supervisorOverrideToken
+        : undefined,
+  };
+}
+
+export function authorizeLoginSupervisorOverride(input: {
+  expectedOverrideToken?: string;
+  suppliedOverrideToken?: string;
+  tool: string;
+  now?: () => Date;
+}): LoginOverrideAudit | null {
+  if (!tokenMatches(input.expectedOverrideToken, input.suppliedOverrideToken)) return null;
+  return { tool: input.tool, usedAt: (input.now ?? (() => new Date()))().toISOString() };
+}
+
 export function evaluateLoginPrologueGuard(input: {
   binding: unknown;
   tool: string;
@@ -92,24 +129,17 @@ export function evaluateLoginPrologueGuard(input: {
   expectedOverrideToken?: string;
   now?: () => Date;
 }): LoginPrologueGuardDecision {
-  const outcome = readLoginPrologueOutcome(input.binding);
-  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation) {
-    return { allowed: true, override: false };
-  }
-  if (cleanupAllowed(input.tool, input.args)) return { allowed: true, override: false };
-
-  const supplied =
-    typeof input.args.supervisorOverrideToken === 'string'
-      ? input.args.supervisorOverrideToken
-      : undefined;
-  if (tokenMatches(input.expectedOverrideToken, supplied)) {
-    return {
-      allowed: true,
-      override: true,
-      audit: { tool: input.tool, usedAt: (input.now ?? (() => new Date()))().toISOString() },
-    };
-  }
-  return { allowed: false, suppliedOverride: supplied !== undefined };
+  const inspection = inspectLoginPrologueGuard(input);
+  if (!inspection.blocked) return { allowed: true, override: false };
+  const audit = authorizeLoginSupervisorOverride({
+    expectedOverrideToken: input.expectedOverrideToken,
+    suppliedOverrideToken: inspection.suppliedOverride,
+    tool: input.tool,
+    now: input.now,
+  });
+  return audit
+    ? { allowed: true, override: true, audit }
+    : { allowed: false, suppliedOverride: inspection.suppliedOverride !== undefined };
 }
 
 export function appendLoginOverrideAudit(

--- a/packages/rn-dev-agent-core/src/domain/login-prologue.ts
+++ b/packages/rn-dev-agent-core/src/domain/login-prologue.ts
@@ -1,0 +1,120 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import type { RunRecord } from './reusable-action.js';
+
+export const LOGIN_PROLOGUE_ALIAS = 'user-login';
+export const LOGIN_PROLOGUE_BLOCKED = 'LOGIN_PROLOGUE_BLOCKED';
+
+export interface LoginPrologueStepTiming {
+  name: 'inventory' | 'resolve' | 'replay' | 'verify-run-record';
+  startedAt: string;
+  endedAt: string;
+  elapsedMs: number;
+}
+
+export interface LoginOverrideAudit {
+  tool: string;
+  usedAt: string;
+}
+
+export interface LoginPrologueOutcome {
+  schemaVersion: 1;
+  state: 'passed' | typeof LOGIN_PROLOGUE_BLOCKED;
+  alias: typeof LOGIN_PROLOGUE_ALIAS;
+  actionId?: string;
+  startedAt: string;
+  endedAt: string;
+  elapsedMs: number;
+  steps: LoginPrologueStepTiming[];
+  inventory: { count: number; actionIds: string[] };
+  runRecord?: RunRecord;
+  actionResult?: {
+    transport?: unknown;
+    transportVersion?: unknown;
+    fallback?: unknown;
+    perStepReadback?: unknown;
+  };
+  failure?: { code: string; detail: string };
+  overrides?: LoginOverrideAudit[];
+}
+
+export function readLoginPrologueOutcome(value: unknown): LoginPrologueOutcome | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const candidate = value as Partial<LoginPrologueOutcome>;
+  if (
+    candidate.schemaVersion !== 1 ||
+    candidate.alias !== LOGIN_PROLOGUE_ALIAS ||
+    (candidate.state !== 'passed' && candidate.state !== LOGIN_PROLOGUE_BLOCKED) ||
+    typeof candidate.startedAt !== 'string' ||
+    typeof candidate.endedAt !== 'string' ||
+    typeof candidate.elapsedMs !== 'number' ||
+    !Array.isArray(candidate.steps)
+  ) {
+    return null;
+  }
+  return candidate as LoginPrologueOutcome;
+}
+
+function cleanupAllowed(tool: string, args: Record<string, unknown>): boolean {
+  if (tool === 'cdp_login_prologue') return true;
+  if (tool === 'cdp_disconnect') return true;
+  if (tool === 'device_snapshot' && args.action === 'close') return true;
+  if (tool === 'device_record' && (args.action === 'stop' || args.action === 'status')) return true;
+  if (tool === 'observe' && (args.action === 'stop' || args.action === 'status')) return true;
+  if (tool === 'proof_capture' && (args.action === 'discard' || args.action === 'status')) {
+    return true;
+  }
+  return (
+    tool === 'rn_session' &&
+    (args.action === 'release' ||
+      args.action === 'stop_metro' ||
+      args.action === 'cancel_handoff' ||
+      args.action === 'status')
+  );
+}
+
+function tokenMatches(expected: string | undefined, supplied: string | undefined): boolean {
+  if (!expected || expected.length < 16 || !supplied || supplied.length < 16) return false;
+  const expectedHash = createHash('sha256').update(expected).digest();
+  const suppliedHash = createHash('sha256').update(supplied).digest();
+  return timingSafeEqual(expectedHash, suppliedHash);
+}
+
+export type LoginPrologueGuardDecision =
+  | { allowed: true; override: false }
+  | { allowed: true; override: true; audit: LoginOverrideAudit }
+  | { allowed: false; suppliedOverride: boolean };
+
+export function evaluateLoginPrologueGuard(input: {
+  binding: unknown;
+  tool: string;
+  args: Record<string, unknown>;
+  mutation: boolean;
+  expectedOverrideToken?: string;
+  now?: () => Date;
+}): LoginPrologueGuardDecision {
+  const outcome = readLoginPrologueOutcome(input.binding);
+  if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED || !input.mutation) {
+    return { allowed: true, override: false };
+  }
+  if (cleanupAllowed(input.tool, input.args)) return { allowed: true, override: false };
+
+  const supplied =
+    typeof input.args.supervisorOverrideToken === 'string'
+      ? input.args.supervisorOverrideToken
+      : undefined;
+  if (tokenMatches(input.expectedOverrideToken, supplied)) {
+    return {
+      allowed: true,
+      override: true,
+      audit: { tool: input.tool, usedAt: (input.now ?? (() => new Date()))().toISOString() },
+    };
+  }
+  return { allowed: false, suppliedOverride: supplied !== undefined };
+}
+
+export function appendLoginOverrideAudit(
+  outcome: LoginPrologueOutcome,
+  audit: LoginOverrideAudit,
+): LoginPrologueOutcome {
+  return { ...outcome, overrides: [...(outcome.overrides ?? []), audit].slice(-20) };
+}

--- a/packages/rn-dev-agent-core/src/domain/reusable-action.ts
+++ b/packages/rn-dev-agent-core/src/domain/reusable-action.ts
@@ -257,6 +257,8 @@ export interface AutoRepairOutcome {
 
 /** A single replay attempt's outcome. Append-only; oldest dropped at limit. */
 export interface RunRecord {
+  /** Unique replay identity, used to prove that a prologue produced a fresh record. */
+  runId?: string;
   timestamp: string; // ISO
   durationMs: number;
   status: 'pass' | 'fail';
@@ -276,6 +278,18 @@ export interface RunRecord {
   deviceId?: string;
   /** GH #397 Phase 2: set when the proactive blind-probe routed this run. */
   blindProbe?: { atRisk: 'ios26' | 'prior-transport-blind'; skippedMaestro: boolean };
+  /** Wall-clock orchestration phases for separating agent overhead from replay time. */
+  timing?: {
+    startedAt: string;
+    endedAt: string;
+    elapsedMs: number;
+    steps: Array<{
+      name: string;
+      startedAt: string;
+      endedAt: string;
+      elapsedMs: number;
+    }>;
+  };
 }
 
 /** A single self-repair attempt (only emitted on successful repair). */

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -3325,7 +3325,7 @@ trackedTool(
 
 trackedTool(
   'cdp_auto_login',
-  'Explicit legacy navigation helper that detects an auth screen and runs one project login subflow through maestro_run on the authority-bound device. It is per-call recovery only, never durable login authority or PR proof; prefer a compatible owned learned action.',
+  'Explicit legacy navigation helper that detects an auth screen and runs one project login subflow through maestro_run on the authority-bound device. It is never login authority or PR proof; use cdp_login_prologue for authenticated journeys.',
   {
     appId: z
       .string()
@@ -3996,26 +3996,14 @@ trackedTool(
 
 trackedTool(
   'cdp_login_prologue',
-  'Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; not PR proof.',
+  'Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; failure blocks exploratory fallback mutations, and a pass is not PR proof.',
   {
     projectRoot: z.string().optional().describe('Override project root (default: process.cwd()).'),
-    platform: z
-      .enum(['ios', 'android'])
-      .optional()
-      .describe('Force a platform; otherwise use the authority-bound device.'),
-    appFile: z
-      .string()
-      .optional()
-      .describe('iOS app artifact used only when the saved action contains clearState.'),
+    platform: z.enum(['ios', 'android']).optional().describe('Override the bound platform.'),
+    appFile: z.string().optional().describe('iOS app artifact for clearState actions.'),
     timeoutMs: z.number().optional().describe('Saved-action timeout in milliseconds.'),
-    trigger: z
-      .enum(['agent', 'ci', 'human'])
-      .optional()
-      .describe('RunRecord trigger annotation. Default agent.'),
-    params: z
-      .record(z.string(), z.string())
-      .optional()
-      .describe('Bindings for the exact user-login action placeholders.'),
+    trigger: z.enum(['agent', 'ci', 'human']).optional().describe('Run trigger; default agent.'),
+    params: z.record(z.string(), z.string()).optional().describe('String user-login bindings.'),
   },
   createLoginPrologueHandler({ runAction: runActionHandler }),
 );

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -42,6 +42,7 @@ import {
 import { createRepairActionHandler } from './tools/repair-action.js';
 import { createSaveAsActionHandler } from './tools/save-as-action.js';
 import { createRunActionHandler } from './tools/run-action.js';
+import { createLoginPrologueHandler } from './tools/login-prologue.js';
 import { unwrapTree } from './tools/cdp-replay-dispatch.js';
 import type { CdpReplayDeps } from './tools/cdp-replay-dispatch.js';
 import { createDispatchHandler } from './tools/dispatch.js';
@@ -633,6 +634,7 @@ const createRuntimeAuthorityProbe = (resolveClient: () => CDPClient) =>
   });
 const localAuthorityProbe = createRuntimeAuthorityProbe(getClient);
 const authorityGate = createAuthorityGate(authorityRuntime, {
+  loginSupervisorOverrideToken: () => process.env.RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN,
   probe: async ({ axis, phase, status, tool, args }) =>
     localAuthorityProbe({ axis, phase, status, tool, args }),
   recoverRuntimeConnection: async (status) => {
@@ -936,7 +938,19 @@ function trackedTool(name: string, desc: string, schema: z.ZodRawShape, handler:
     }
     return result;
   };
-  server.tool(name, desc, schema, wrapped as typeof handler);
+  server.tool(
+    name,
+    desc,
+    {
+      ...schema,
+      supervisorOverrideToken: z
+        .string()
+        .min(16)
+        .optional()
+        .describe('Supervisor token for one audited mutation after a blocked login prologue.'),
+    },
+    wrapped as typeof handler,
+  );
 }
 
 async function pinSessionDevClient(
@@ -3901,6 +3915,14 @@ trackedTool(
 
 // Issue #104 — auto-repair-aware action replay. Wraps maestro_run with
 // stderr classification + cdp_repair_action retry on SELECTOR_NOT_FOUND.
+const runActionHandler = createRunActionHandler({
+  getLiveRoute: () => readLiveRoute(getClient()),
+  replayDeps: makeReplayDeps,
+  blindProbeContext,
+  targetContext: getActiveSession,
+  claimBundleAuthority: claimOptionalBundleAuthority,
+});
+
 trackedTool(
   'cdp_run_action',
   "Replay a learned action by id with end-to-end auto-repair. Loads the action from .rn-agent/actions/<actionId>.yaml or .yml, forwards the matching active session's exact device ID to Maestro, rejects mismatched direct runner/WDA evidence, and on a SELECTOR_NOT_FOUND failure automatically invokes cdp_repair_action and retries once. Appends a RunRecord to the sidecar with full auto-repair telemetry (passed/failed/refused/skipped + diff); its Maestro deviceId comes from direct runner evidence, never requested metadata. The repair attempt counts toward cdp_repair_action's 24h budget. Pass autoRepair=false to opt out of auto-repair (returns the raw maestro_run failure verbatim). forceReload defaults true: any human edit to the YAML since the agent's last write is acknowledged as the new baseline so downstream repair does not abort with STALE_TARGET (the right default for active composition). Pass forceReload=false for the strict \"respect offline human edits\" behavior: a successful replay still appends its RunRecord to the sidecar when only the tracked YAML mtime baseline is stale, while YAML-mutating promotion and repair stay refused. proofReplay=true is reserved for proof_capture rehearsal and requires autoRepair=false plus forceReload=false; it executes without RunRecord, promotion, YAML, sidecar, or DB persistence. The orchestrated home for the L3 self-healing loop — prefer this over invoking maestro_run + cdp_repair_action manually for any flow you intend to re-run on schedule. blindProbeMode provides per-call control of the proactive CDP/JS compatibility path: inherit (default) honors RN_BLIND_PROBE, allow explicitly enables it for this call, and forbid forces maestro-first for this call.",
@@ -3958,17 +3980,33 @@ trackedTool(
         "Parameter bindings for the action's ${VAR} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run).",
       ),
   },
-  // GH #186: supply a CDP-backed live-route reader so the route-drift guard is
-  // actually active. Without this the handler defaulted getLiveRoute to a no-op
-  // and the drift branch could never fire, silently routing screen-change
-  // failures into fuzzy selector repair.
-  createRunActionHandler({
-    getLiveRoute: () => readLiveRoute(getClient()),
-    replayDeps: makeReplayDeps,
-    blindProbeContext,
-    targetContext: getActiveSession,
-    claimBundleAuthority: claimOptionalBundleAuthority,
-  }),
+  runActionHandler,
+);
+
+trackedTool(
+  'cdp_login_prologue',
+  'Inventory learned actions, replay the exact user-login action strictly, and require a fresh passing RunRecord before lifting the session login gate.',
+  {
+    projectRoot: z.string().optional().describe('Override project root (default: process.cwd()).'),
+    platform: z
+      .enum(['ios', 'android'])
+      .optional()
+      .describe('Force a platform; otherwise use the authority-bound device.'),
+    appFile: z
+      .string()
+      .optional()
+      .describe('iOS app artifact used only when the saved action contains clearState.'),
+    timeoutMs: z.number().optional().describe('Saved-action timeout in milliseconds.'),
+    trigger: z
+      .enum(['agent', 'ci', 'human'])
+      .optional()
+      .describe('RunRecord trigger annotation. Default agent.'),
+    params: z
+      .record(z.string(), z.string())
+      .optional()
+      .describe('Bindings for the exact user-login action placeholders.'),
+  },
+  createLoginPrologueHandler({ runAction: runActionHandler }),
 );
 
 trackedTool(
@@ -4096,13 +4134,6 @@ const triggerE2eRun = async (args: RunE2eSuiteArgs): Promise<unknown> => {
   }
 };
 
-const runActionHandler = createRunActionHandler({
-  getLiveRoute: () => readLiveRoute(getClient()),
-  replayDeps: makeReplayDeps,
-  blindProbeContext,
-  targetContext: getActiveSession,
-  claimBundleAuthority: claimOptionalBundleAuthority,
-});
 const observeRunActionHandler = authorityGate.wrap(
   'cdp_run_action',
   runActionHandler as (...args: unknown[]) => Promise<unknown>,

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -193,7 +193,7 @@ import {
 import { parseAllAdbDevices } from './tools/device-record.js';
 import { createLockE2eTestHandler } from './tools/lock-e2e-test.js';
 import { createRunE2eSuiteHandler, type RunE2eSuiteArgs } from './tools/run-e2e-suite.js';
-import { resolveLockedTestIdentityIds } from './domain/e2e-test.js';
+import { resolveLockedTestSelection } from './domain/e2e-test.js';
 import { recoverInterruptedRequests } from './domain/e2e-run-request.js';
 import { preflight, probeMetro } from './e2e/preflight.js';
 import { resolveIosUdid } from './tools/device-screenshot-raw.js';
@@ -639,9 +639,9 @@ const authorityGate = createAuthorityGate(authorityRuntime, {
   resolveLockedE2eTestIds: (args, status) => {
     const projectRoot =
       typeof args.projectRoot === 'string' ? args.projectRoot : status.source.appRoot;
-    if (typeof projectRoot !== 'string') return [];
+    if (typeof projectRoot !== 'string') return { ids: [], identitiesValid: false };
     args.projectRoot = projectRoot;
-    return resolveLockedTestIdentityIds(
+    return resolveLockedTestSelection(
       projectRoot,
       typeof args.pattern === 'string' ? args.pattern : undefined,
     );

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -3985,7 +3985,7 @@ trackedTool(
 
 trackedTool(
   'cdp_login_prologue',
-  'Inventory learned actions, replay the exact user-login action strictly, and require a fresh passing RunRecord before lifting the session login gate.',
+  'Fail-stop user-login helper: replay the exact action and require a fresh passing RunRecord; not PR proof.',
   {
     projectRoot: z.string().optional().describe('Override project root (default: process.cwd()).'),
     platform: z

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -193,6 +193,7 @@ import {
 import { parseAllAdbDevices } from './tools/device-record.js';
 import { createLockE2eTestHandler } from './tools/lock-e2e-test.js';
 import { createRunE2eSuiteHandler, type RunE2eSuiteArgs } from './tools/run-e2e-suite.js';
+import { resolveLockedTestIds } from './domain/e2e-test.js';
 import { recoverInterruptedRequests } from './domain/e2e-run-request.js';
 import { preflight, probeMetro } from './e2e/preflight.js';
 import { resolveIosUdid } from './tools/device-screenshot-raw.js';
@@ -635,6 +636,16 @@ const createRuntimeAuthorityProbe = (resolveClient: () => CDPClient) =>
 const localAuthorityProbe = createRuntimeAuthorityProbe(getClient);
 const authorityGate = createAuthorityGate(authorityRuntime, {
   loginSupervisorOverrideToken: () => process.env.RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN,
+  resolveLockedE2eTestIds: (args, status) => {
+    const projectRoot =
+      typeof args.projectRoot === 'string' ? args.projectRoot : status.source.appRoot;
+    if (typeof projectRoot !== 'string') return [];
+    args.projectRoot = projectRoot;
+    return resolveLockedTestIds(
+      projectRoot,
+      typeof args.pattern === 'string' ? args.pattern : undefined,
+    );
+  },
   probe: async ({ axis, phase, status, tool, args }) =>
     localAuthorityProbe({ axis, phase, status, tool, args }),
   recoverRuntimeConnection: async (status) => {

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -193,7 +193,7 @@ import {
 import { parseAllAdbDevices } from './tools/device-record.js';
 import { createLockE2eTestHandler } from './tools/lock-e2e-test.js';
 import { createRunE2eSuiteHandler, type RunE2eSuiteArgs } from './tools/run-e2e-suite.js';
-import { resolveLockedTestIds } from './domain/e2e-test.js';
+import { resolveLockedTestIdentityIds } from './domain/e2e-test.js';
 import { recoverInterruptedRequests } from './domain/e2e-run-request.js';
 import { preflight, probeMetro } from './e2e/preflight.js';
 import { resolveIosUdid } from './tools/device-screenshot-raw.js';
@@ -641,7 +641,7 @@ const authorityGate = createAuthorityGate(authorityRuntime, {
       typeof args.projectRoot === 'string' ? args.projectRoot : status.source.appRoot;
     if (typeof projectRoot !== 'string') return [];
     args.projectRoot = projectRoot;
-    return resolveLockedTestIds(
+    return resolveLockedTestIdentityIds(
       projectRoot,
       typeof args.pattern === 'string' ? args.pattern : undefined,
     );

--- a/packages/rn-dev-agent-core/src/lifecycle/device-arbiter.ts
+++ b/packages/rn-dev-agent-core/src/lifecycle/device-arbiter.ts
@@ -180,6 +180,7 @@ export function promoteCurrentOperationToManagedFlow(): AcquireResult {
 const FLOW_TOOLS = new Set<string>([
   'maestro_run',
   'maestro_test_all',
+  'cdp_login_prologue',
   'cdp_run_action',
   'cdp_auto_login',
   'cdp_reload',

--- a/packages/rn-dev-agent-core/src/observability/events.ts
+++ b/packages/rn-dev-agent-core/src/observability/events.ts
@@ -60,6 +60,7 @@ const TESTING = new Set([
   'maestro_run',
   'maestro_generate',
   'maestro_test_all',
+  'cdp_login_prologue',
   'cdp_run_action',
   'cdp_repair_action',
   'proof_step',

--- a/packages/rn-dev-agent-core/src/session/authority-gate.ts
+++ b/packages/rn-dev-agent-core/src/session/authority-gate.ts
@@ -749,11 +749,12 @@ function persistLoginPrologueOutcome(
   outcome: LoginPrologueOutcome,
 ): { operation: OperationRef; status: SessionStatus } {
   const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+  const overrides = outcome.overrides ?? priorOutcome?.overrides;
   const nextOperation = registry.replaceBindingsDuringOperation(operation, {
     bindings: {
       loginPrologue: {
         ...outcome,
-        ...(priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}),
+        ...(overrides ? { overrides } : {}),
       },
     },
   });
@@ -1197,7 +1198,7 @@ export function createAuthorityGate(
                     }
                   : baseProfile;
 
-        let runtimeStatus = runtime.status();
+        const runtimeStatus = runtime.status();
         const loginDecision = evaluateLoginPrologueGuard({
           binding: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : undefined,
           tool,
@@ -1220,30 +1221,6 @@ export function createAuthorityGate(
             },
           );
         }
-        if (loginDecision.override) {
-          try {
-            const available = runtime.requireAvailable();
-            const current = runtime.status();
-            const outcome = current.available
-              ? readLoginPrologueOutcome(current.bindings.loginPrologue)
-              : null;
-            if (!outcome) {
-              throw new SessionAuthorityError(
-                'LOGIN_PROLOGUE_BLOCKED',
-                'the blocked login prologue state disappeared before override audit',
-              );
-            }
-            available.registry.updateBindings(available.session, {
-              bindings: {
-                loginPrologue: appendLoginOverrideAudit(outcome, loginDecision.audit),
-              },
-            });
-            runtimeStatus = runtime.status();
-          } catch (error) {
-            return authorityFailure(error);
-          }
-        }
-
         if (profile.kind === 'diagnostic') {
           return addMeta(await handler(...handlerArgs), { authoritative: false });
         }
@@ -2050,6 +2027,24 @@ export function createAuthorityGate(
               },
             });
           }
+          if (loginDecision.override) {
+            const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+            if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
+              throw new SessionAuthorityError(
+                'LOGIN_PROLOGUE_BLOCKED',
+                'the blocked login prologue state disappeared before override audit',
+              );
+            }
+            const persisted = persistLoginPrologueOutcome(
+              runtime,
+              registry,
+              operation,
+              status,
+              appendLoginOverrideAudit(outcome, loginDecision.audit),
+            );
+            operation = persisted.operation;
+            status = persisted.status;
+          }
           registry.verifyOperation(operation);
           const snapshotCheckpoint = dependencies.snapshotCaptureCheckpoint?.();
           let result = await registry.runWithOperation(operation, () => handler(...handlerArgs));
@@ -2270,17 +2265,6 @@ export function createAuthorityGate(
           // identity change. An external generation change still fails CAS.
           const controllerGenerationAdvanced =
             operation.authorityVersion !== initialOperationAuthorityVersion;
-          if (loginPrologueOutcome?.state === 'passed') {
-            const persisted = persistLoginPrologueOutcome(
-              runtime,
-              registry,
-              operation,
-              status,
-              loginPrologueOutcome,
-            );
-            operation = persisted.operation;
-            status = persisted.status;
-          }
           registry.verifyOperation(operation);
           for (const observation of allBefore) {
             if (controllerGenerationAdvanced && observation.axis === 'C') continue;
@@ -2357,6 +2341,17 @@ export function createAuthorityGate(
           }
           if (operation && receiptsCommittable) {
             registry.commitPlatformAuthorityReceipts(operation);
+          }
+          if (operation && loginPrologueOutcome?.state === 'passed') {
+            const persisted = persistLoginPrologueOutcome(
+              runtime,
+              registry,
+              operation,
+              status,
+              loginPrologueOutcome,
+            );
+            operation = persisted.operation;
+            status = persisted.status;
           }
           return addMeta(result, {
             ...nativeOriginMeta(profile, nativeOriginProven),

--- a/packages/rn-dev-agent-core/src/session/authority-gate.ts
+++ b/packages/rn-dev-agent-core/src/session/authority-gate.ts
@@ -741,6 +741,29 @@ function missingLoginPrologueOutcome(): LoginPrologueOutcome {
   };
 }
 
+function persistLoginPrologueOutcome(
+  runtime: AuthorityGateRuntime,
+  registry: SessionRegistry,
+  operation: OperationRef,
+  status: SessionStatus,
+  outcome: LoginPrologueOutcome,
+): { operation: OperationRef; status: SessionStatus } {
+  const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+  const nextOperation = registry.replaceBindingsDuringOperation(operation, {
+    bindings: {
+      loginPrologue: {
+        ...outcome,
+        ...(priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}),
+      },
+    },
+  });
+  const nextStatus = runtime.status();
+  if (!nextStatus.available) {
+    throw new SessionAuthorityError(nextStatus.code, nextStatus.reason);
+  }
+  return { operation: nextOperation, status: nextStatus };
+}
+
 function isActionReplayTool(tool: string): boolean {
   return tool === 'cdp_run_action' || tool === 'cdp_login_prologue';
 }
@@ -2041,6 +2064,17 @@ export function createAuthorityGate(
                 { loginPrologue: loginPrologueOutcome },
               );
             }
+            if (loginPrologueOutcome.state === LOGIN_PROLOGUE_BLOCKED) {
+              const persisted = persistLoginPrologueOutcome(
+                runtime,
+                registry,
+                operation,
+                status,
+                loginPrologueOutcome,
+              );
+              operation = persisted.operation;
+              status = persisted.status;
+            }
           }
           let runtimeTargetChanged = false;
           const postHandlerRecovery = await reconcileRecoverableRuntime(
@@ -2236,21 +2270,16 @@ export function createAuthorityGate(
           // identity change. An external generation change still fails CAS.
           const controllerGenerationAdvanced =
             operation.authorityVersion !== initialOperationAuthorityVersion;
-          if (loginPrologueOutcome) {
-            const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
-            operation = registry.replaceBindingsDuringOperation(operation, {
-              bindings: {
-                loginPrologue: {
-                  ...loginPrologueOutcome,
-                  ...(priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}),
-                },
-              },
-            });
-            const loginStatus = runtime.status();
-            if (!loginStatus.available) {
-              throw new SessionAuthorityError(loginStatus.code, loginStatus.reason);
-            }
-            status = loginStatus;
+          if (loginPrologueOutcome?.state === 'passed') {
+            const persisted = persistLoginPrologueOutcome(
+              runtime,
+              registry,
+              operation,
+              status,
+              loginPrologueOutcome,
+            );
+            operation = persisted.operation;
+            status = persisted.status;
           }
           registry.verifyOperation(operation);
           for (const observation of allBefore) {

--- a/packages/rn-dev-agent-core/src/session/authority-gate.ts
+++ b/packages/rn-dev-agent-core/src/session/authority-gate.ts
@@ -726,8 +726,21 @@ function parseLoginPrologueOutcome(result: unknown): LoginPrologueOutcome | null
   }
 }
 
-function missingLoginPrologueOutcome(): LoginPrologueOutcome {
+function missingLoginPrologueOutcome(result: unknown): LoginPrologueOutcome {
   const timestamp = new Date().toISOString();
+  let failure = {
+    code: 'LOGIN_PROLOGUE_RESULT_INVALID',
+    detail: 'The login prologue returned no valid terminal state.',
+  };
+  try {
+    const envelope = JSON.parse((result as ToolResult).content?.[0]?.text ?? '{}') as {
+      code?: unknown;
+      error?: unknown;
+    };
+    if (envelope.code === 'BUSY_FLOW_ACTIVE' && typeof envelope.error === 'string') {
+      failure = { code: envelope.code, detail: envelope.error };
+    }
+  } catch {}
   return {
     schemaVersion: 1,
     state: LOGIN_PROLOGUE_BLOCKED,
@@ -737,10 +750,7 @@ function missingLoginPrologueOutcome(): LoginPrologueOutcome {
     elapsedMs: 0,
     steps: [],
     inventory: { count: 0, actionIds: [] },
-    failure: {
-      code: 'LOGIN_PROLOGUE_RESULT_INVALID',
-      detail: 'The login prologue returned no valid terminal state.',
-    },
+    failure,
   };
 }
 
@@ -2153,9 +2163,9 @@ export function createAuthorityGate(
           if (tool === 'cdp_login_prologue') {
             loginPrologueOutcome = parseLoginPrologueOutcome(result);
             if (!loginPrologueOutcome) {
-              loginPrologueOutcome = missingLoginPrologueOutcome();
+              loginPrologueOutcome = missingLoginPrologueOutcome(result);
               result = failResult(
-                'Login prologue returned no valid terminal state.',
+                `Login prologue blocked: ${loginPrologueOutcome.failure?.detail ?? 'The login prologue returned no valid terminal state.'}`,
                 'LOGIN_PROLOGUE_BLOCKED',
                 { loginPrologue: loginPrologueOutcome },
               );

--- a/packages/rn-dev-agent-core/src/session/authority-gate.ts
+++ b/packages/rn-dev-agent-core/src/session/authority-gate.ts
@@ -12,7 +12,8 @@ import {
   LOGIN_PROLOGUE_ALIAS,
   LOGIN_PROLOGUE_BLOCKED,
   appendLoginOverrideAudit,
-  evaluateLoginPrologueGuard,
+  authorizeLoginSupervisorOverride,
+  inspectLoginPrologueGuard,
   readLoginPrologueOutcome,
   type LoginPrologueOutcome,
 } from '../domain/login-prologue.js';
@@ -1217,15 +1218,17 @@ export function createAuthorityGate(
                   : baseProfile;
 
         const runtimeStatus = runtime.status();
-        const loginDecision = evaluateLoginPrologueGuard({
+        const loginGuard = inspectLoginPrologueGuard({
           binding: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : undefined,
           tool,
           args,
           mutation: profile.mutation,
-          expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
         });
+        const pendingSupervisorOverrideToken = loginGuard.blocked
+          ? loginGuard.suppliedOverride
+          : undefined;
         delete args.supervisorOverrideToken;
-        if (!loginDecision.allowed) {
+        if (loginGuard.blocked && pendingSupervisorOverrideToken === undefined) {
           return failResult(
             'LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.',
             'LOGIN_PROLOGUE_BLOCKED',
@@ -1233,13 +1236,13 @@ export function createAuthorityGate(
               loginPrologue: runtimeStatus.available
                 ? runtimeStatus.bindings.loginPrologue
                 : undefined,
-              overrideRejected: loginDecision.suppliedOverride,
+              overrideRejected: false,
               nextAction:
                 'Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call.',
             },
           );
         }
-        if (loginDecision.override && profile.kind === 'transition') {
+        if (loginGuard.blocked && profile.kind === 'transition') {
           return failResult(
             'LOGIN_PROLOGUE_BLOCKED: supervisor overrides cannot authorize transition mutations.',
             'LOGIN_PROLOGUE_BLOCKED',
@@ -1619,6 +1622,7 @@ export function createAuthorityGate(
         let retainProofCleanupFence = false;
         let publishedProofFinalize = false;
         let stagedRuntimeRelaunch: StagedRuntimeRelaunch | undefined;
+        let loginPrologueAttemptOperationId: string | null = null;
         try {
           const available = runtime.requireAvailable();
           registry = available.registry;
@@ -1627,13 +1631,29 @@ export function createAuthorityGate(
             throw new SessionAuthorityError(initialStatus.code, initialStatus.reason);
           }
           let status: SessionStatus = initialStatus;
-          requireCompleteAxes(status, profile);
-          bindSessionArguments(status, profile, args, tool);
+          if (tool !== 'cdp_login_prologue') {
+            requireCompleteAxes(status, profile);
+            bindSessionArguments(status, profile, args, tool);
+          }
           operation = registry.beginOperation(available.session, {
             operationId: randomUUID(),
             tool,
             profile: profile.axes.join(''),
           });
+          if (tool === 'cdp_login_prologue') {
+            const persisted = persistLoginPrologueOutcome(
+              runtime,
+              registry,
+              operation,
+              status,
+              pendingLoginPrologueOutcome(),
+            );
+            operation = persisted.operation;
+            status = persisted.status;
+            loginPrologueAttemptOperationId = operation.operationId;
+            requireCompleteAxes(status, profile);
+            bindSessionArguments(status, profile, args, tool);
+          }
           const preflightRecovery = await reconcileRecoverableRuntime(
             runtime,
             dependencies,
@@ -2059,7 +2079,7 @@ export function createAuthorityGate(
               },
             });
           }
-          if (loginDecision.override) {
+          if (pendingSupervisorOverrideToken !== undefined) {
             const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
             if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
               throw new SessionAuthorityError(
@@ -2067,23 +2087,23 @@ export function createAuthorityGate(
                 'the blocked login prologue state disappeared before override audit',
               );
             }
+            const audit = authorizeLoginSupervisorOverride({
+              expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
+              suppliedOverrideToken: pendingSupervisorOverrideToken,
+              tool,
+            });
+            if (!audit) {
+              throw new SessionAuthorityError(
+                'LOGIN_PROLOGUE_BLOCKED',
+                'the supervisor override token was rejected under the operation fence',
+              );
+            }
             const persisted = persistLoginPrologueOutcome(
               runtime,
               registry,
               operation,
               status,
-              appendLoginOverrideAudit(outcome, loginDecision.audit),
-            );
-            operation = persisted.operation;
-            status = persisted.status;
-          }
-          if (tool === 'cdp_login_prologue') {
-            const persisted = persistLoginPrologueOutcome(
-              runtime,
-              registry,
-              operation,
-              status,
-              pendingLoginPrologueOutcome(),
+              appendLoginOverrideAudit(outcome, audit),
             );
             operation = persisted.operation;
             status = persisted.status;
@@ -2386,6 +2406,17 @@ export function createAuthorityGate(
             registry.commitPlatformAuthorityReceipts(operation);
           }
           if (operation && loginPrologueOutcome?.state === 'passed') {
+            const pendingOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+            if (
+              operation.operationId !== loginPrologueAttemptOperationId ||
+              pendingOutcome?.state !== LOGIN_PROLOGUE_BLOCKED ||
+              pendingOutcome.failure?.code !== 'LOGIN_PROLOGUE_IN_PROGRESS'
+            ) {
+              throw new SessionAuthorityError(
+                'LOGIN_PROLOGUE_BLOCKED',
+                'the passing login result does not match the active blocked attempt',
+              );
+            }
             const persisted = persistLoginPrologueOutcome(
               runtime,
               registry,

--- a/packages/rn-dev-agent-core/src/session/authority-gate.ts
+++ b/packages/rn-dev-agent-core/src/session/authority-gate.ts
@@ -741,6 +741,24 @@ function missingLoginPrologueOutcome(): LoginPrologueOutcome {
   };
 }
 
+function pendingLoginPrologueOutcome(): LoginPrologueOutcome {
+  const timestamp = new Date().toISOString();
+  return {
+    schemaVersion: 1,
+    state: LOGIN_PROLOGUE_BLOCKED,
+    alias: LOGIN_PROLOGUE_ALIAS,
+    startedAt: timestamp,
+    endedAt: timestamp,
+    elapsedMs: 0,
+    steps: [],
+    inventory: { count: 0, actionIds: [] },
+    failure: {
+      code: 'LOGIN_PROLOGUE_IN_PROGRESS',
+      detail: 'The login prologue has not completed authoritative validation.',
+    },
+  };
+}
+
 function persistLoginPrologueOutcome(
   runtime: AuthorityGateRuntime,
   registry: SessionRegistry,
@@ -1218,6 +1236,20 @@ export function createAuthorityGate(
               overrideRejected: loginDecision.suppliedOverride,
               nextAction:
                 'Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call.',
+            },
+          );
+        }
+        if (loginDecision.override && profile.kind === 'transition') {
+          return failResult(
+            'LOGIN_PROLOGUE_BLOCKED: supervisor overrides cannot authorize transition mutations.',
+            'LOGIN_PROLOGUE_BLOCKED',
+            {
+              loginPrologue: runtimeStatus.available
+                ? runtimeStatus.bindings.loginPrologue
+                : undefined,
+              transitionOverrideRejected: true,
+              nextAction:
+                'Repair the exact user-login action and rerun cdp_login_prologue before this transition.',
             },
           );
         }
@@ -2041,6 +2073,17 @@ export function createAuthorityGate(
               operation,
               status,
               appendLoginOverrideAudit(outcome, loginDecision.audit),
+            );
+            operation = persisted.operation;
+            status = persisted.status;
+          }
+          if (tool === 'cdp_login_prologue') {
+            const persisted = persistLoginPrologueOutcome(
+              runtime,
+              registry,
+              operation,
+              status,
+              pendingLoginPrologueOutcome(),
             );
             operation = persisted.operation;
             status = persisted.status;

--- a/packages/rn-dev-agent-core/src/session/authority-gate.ts
+++ b/packages/rn-dev-agent-core/src/session/authority-gate.ts
@@ -76,7 +76,10 @@ interface AuthorityGateDependencies {
     install: Record<string, unknown> | undefined,
   ): Record<string, unknown> | null;
   loginSupervisorOverrideToken?(): string | undefined;
-  resolveLockedE2eTestIds?(args: Record<string, unknown>, status: SessionStatus): string[];
+  resolveLockedE2eTestIds?(
+    args: Record<string, unknown>,
+    status: SessionStatus,
+  ): { ids: string[]; identitiesValid: boolean };
 }
 
 const optionalBundleAdmission = Symbol('optionalBundleAdmission');
@@ -1663,15 +1666,15 @@ export function createAuthorityGate(
             bindSessionArguments(status, profile, args, tool);
           }
           if (pendingLockedE2eAdmission) {
-            const resolvedLockedTestIds = dependencies.resolveLockedE2eTestIds?.(args, status);
+            const resolvedSelection = dependencies.resolveLockedE2eTestIds?.(args, status);
             if (
-              !resolvedLockedTestIds ||
+              !resolvedSelection?.identitiesValid ||
               inspectLoginPrologueGuard({
                 binding: status.bindings.loginPrologue,
                 tool,
                 args,
                 mutation: profile.mutation,
-                resolvedLockedTestIds,
+                resolvedLockedTestIds: resolvedSelection.ids,
               }).blocked
             ) {
               throw new SessionAuthorityError(
@@ -1679,7 +1682,7 @@ export function createAuthorityGate(
                 'the locked e2e suite did not resolve to the exact user-login candidate',
               );
             }
-            setResolvedLockedTestIds(args, resolvedLockedTestIds);
+            setResolvedLockedTestIds(args, resolvedSelection.ids);
           }
           operation = registry.beginOperation(available.session, {
             operationId: randomUUID(),

--- a/packages/rn-dev-agent-core/src/session/authority-gate.ts
+++ b/packages/rn-dev-agent-core/src/session/authority-gate.ts
@@ -9,6 +9,14 @@ import { isProvenMetroOriginMismatch } from './metro-origin.js';
 import { reissueInstallBinding } from './install-reissue.js';
 import type { WorkerAuthorityStatus } from './runtime.js';
 import {
+  LOGIN_PROLOGUE_ALIAS,
+  LOGIN_PROLOGUE_BLOCKED,
+  appendLoginOverrideAudit,
+  evaluateLoginPrologueGuard,
+  readLoginPrologueOutcome,
+  type LoginPrologueOutcome,
+} from '../domain/login-prologue.js';
+import {
   authorityProfileFor,
   requiresExactInstalledArtifact,
   type AuthorityAxis,
@@ -65,6 +73,7 @@ interface AuthorityGateDependencies {
   reissueInstallBinding?(
     install: Record<string, unknown> | undefined,
   ): Record<string, unknown> | null;
+  loginSupervisorOverrideToken?(): string | undefined;
 }
 
 const optionalBundleAdmission = Symbol('optionalBundleAdmission');
@@ -702,6 +711,40 @@ function authorityFailure(error: unknown): ToolResult {
   );
 }
 
+function parseLoginPrologueOutcome(result: unknown): LoginPrologueOutcome | null {
+  try {
+    const envelope = JSON.parse((result as ToolResult).content?.[0]?.text ?? '{}') as {
+      data?: unknown;
+      meta?: { loginPrologue?: unknown };
+    };
+    return readLoginPrologueOutcome(envelope.data ?? envelope.meta?.loginPrologue);
+  } catch {
+    return null;
+  }
+}
+
+function missingLoginPrologueOutcome(): LoginPrologueOutcome {
+  const timestamp = new Date().toISOString();
+  return {
+    schemaVersion: 1,
+    state: LOGIN_PROLOGUE_BLOCKED,
+    alias: LOGIN_PROLOGUE_ALIAS,
+    startedAt: timestamp,
+    endedAt: timestamp,
+    elapsedMs: 0,
+    steps: [],
+    inventory: { count: 0, actionIds: [] },
+    failure: {
+      code: 'LOGIN_PROLOGUE_RESULT_INVALID',
+      detail: 'The login prologue returned no valid terminal state.',
+    },
+  };
+}
+
+function isActionReplayTool(tool: string): boolean {
+  return tool === 'cdp_run_action' || tool === 'cdp_login_prologue';
+}
+
 function authorityErrorCode(error: unknown): string | undefined {
   return error instanceof SessionAuthorityError
     ? error.code
@@ -1131,10 +1174,56 @@ export function createAuthorityGate(
                     }
                   : baseProfile;
 
+        let runtimeStatus = runtime.status();
+        const loginDecision = evaluateLoginPrologueGuard({
+          binding: runtimeStatus.available ? runtimeStatus.bindings.loginPrologue : undefined,
+          tool,
+          args,
+          mutation: profile.mutation,
+          expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
+        });
+        delete args.supervisorOverrideToken;
+        if (!loginDecision.allowed) {
+          return failResult(
+            'LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.',
+            'LOGIN_PROLOGUE_BLOCKED',
+            {
+              loginPrologue: runtimeStatus.available
+                ? runtimeStatus.bindings.loginPrologue
+                : undefined,
+              overrideRejected: loginDecision.suppliedOverride,
+              nextAction:
+                'Repair the exact user-login action and rerun cdp_login_prologue, or supply a supervisorOverrideToken configured by RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN for this mutating call.',
+            },
+          );
+        }
+        if (loginDecision.override) {
+          try {
+            const available = runtime.requireAvailable();
+            const current = runtime.status();
+            const outcome = current.available
+              ? readLoginPrologueOutcome(current.bindings.loginPrologue)
+              : null;
+            if (!outcome) {
+              throw new SessionAuthorityError(
+                'LOGIN_PROLOGUE_BLOCKED',
+                'the blocked login prologue state disappeared before override audit',
+              );
+            }
+            available.registry.updateBindings(available.session, {
+              bindings: {
+                loginPrologue: appendLoginOverrideAudit(outcome, loginDecision.audit),
+              },
+            });
+            runtimeStatus = runtime.status();
+          } catch (error) {
+            return authorityFailure(error);
+          }
+        }
+
         if (profile.kind === 'diagnostic') {
           return addMeta(await handler(...handlerArgs), { authoritative: false });
         }
-        const runtimeStatus = runtime.status();
         if (runtimeStatus.available && runtimeStatus.state === 'blocked') {
           return authorityFailure(runtime.blockedContenderError());
         }
@@ -1940,7 +2029,19 @@ export function createAuthorityGate(
           }
           registry.verifyOperation(operation);
           const snapshotCheckpoint = dependencies.snapshotCaptureCheckpoint?.();
-          const result = await registry.runWithOperation(operation, () => handler(...handlerArgs));
+          let result = await registry.runWithOperation(operation, () => handler(...handlerArgs));
+          let loginPrologueOutcome: LoginPrologueOutcome | null = null;
+          if (tool === 'cdp_login_prologue') {
+            loginPrologueOutcome = parseLoginPrologueOutcome(result);
+            if (!loginPrologueOutcome) {
+              loginPrologueOutcome = missingLoginPrologueOutcome();
+              result = failResult(
+                'Login prologue returned no valid terminal state.',
+                'LOGIN_PROLOGUE_BLOCKED',
+                { loginPrologue: loginPrologueOutcome },
+              );
+            }
+          }
           let runtimeTargetChanged = false;
           const postHandlerRecovery = await reconcileRecoverableRuntime(
             runtime,
@@ -1983,7 +2084,7 @@ export function createAuthorityGate(
             tool === 'cdp_run_e2e_suite' ||
             tool === 'cdp_auto_login' ||
             (tool === 'cdp_nav_graph' && args.action === 'go') ||
-            (tool === 'cdp_run_action' && (optionalBundleClaimed || optionalBundleRecoveryFailed));
+            (isActionReplayTool(tool) && (optionalBundleClaimed || optionalBundleRecoveryFailed));
           const reconcilesRuntimeTarget = directRuntimeReset || nestedRuntimeReset;
           let authorityInvalidated = false;
           if (directRuntimeReset && !resultSucceeded(result)) {
@@ -2003,7 +2104,7 @@ export function createAuthorityGate(
             const metro = status.bindings.metro as Record<string, unknown> | undefined;
             let bundle: Record<string, unknown> | null = null;
             try {
-              if (tool === 'cdp_run_action' && optionalBundleRecoveryFailed) {
+              if (isActionReplayTool(tool) && optionalBundleRecoveryFailed) {
                 throw new SessionAuthorityError(
                   'BUNDLE_HANDSHAKE_UNAVAILABLE',
                   'reactive bundle authority did not verify',
@@ -2035,7 +2136,7 @@ export function createAuthorityGate(
                     'Run rn_session action "pin_dev_client" before another CDP operation.',
                 });
               }
-              if (tool === 'cdp_run_action' && !optionalBundleClaimed) {
+              if (isActionReplayTool(tool) && !optionalBundleClaimed) {
                 authorityInvalidated = true;
               } else {
                 throw error;
@@ -2135,6 +2236,22 @@ export function createAuthorityGate(
           // identity change. An external generation change still fails CAS.
           const controllerGenerationAdvanced =
             operation.authorityVersion !== initialOperationAuthorityVersion;
+          if (loginPrologueOutcome) {
+            const priorOutcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+            operation = registry.replaceBindingsDuringOperation(operation, {
+              bindings: {
+                loginPrologue: {
+                  ...loginPrologueOutcome,
+                  ...(priorOutcome?.overrides ? { overrides: priorOutcome.overrides } : {}),
+                },
+              },
+            });
+            const loginStatus = runtime.status();
+            if (!loginStatus.available) {
+              throw new SessionAuthorityError(loginStatus.code, loginStatus.reason);
+            }
+            status = loginStatus;
+          }
           registry.verifyOperation(operation);
           for (const observation of allBefore) {
             if (controllerGenerationAdvanced && observation.axis === 'C') continue;

--- a/packages/rn-dev-agent-core/src/session/authority-gate.ts
+++ b/packages/rn-dev-agent-core/src/session/authority-gate.ts
@@ -17,6 +17,7 @@ import {
   readLoginPrologueOutcome,
   type LoginPrologueOutcome,
 } from '../domain/login-prologue.js';
+import { setResolvedLockedTestIds } from '../domain/e2e-test.js';
 import {
   authorityProfileFor,
   requiresExactInstalledArtifact,
@@ -75,6 +76,7 @@ interface AuthorityGateDependencies {
     install: Record<string, unknown> | undefined,
   ): Record<string, unknown> | null;
   loginSupervisorOverrideToken?(): string | undefined;
+  resolveLockedE2eTestIds?(args: Record<string, unknown>, status: SessionStatus): string[];
 }
 
 const optionalBundleAdmission = Symbol('optionalBundleAdmission');
@@ -1233,7 +1235,15 @@ export function createAuthorityGate(
         const pendingSupervisorOverrideToken = loginGuard.blocked
           ? suppliedSupervisorOverrideToken
           : undefined;
-        if (loginGuard.blocked && pendingSupervisorOverrideToken === undefined) {
+        const pendingLockedE2eAdmission =
+          loginGuard.blocked &&
+          tool === 'cdp_run_e2e_suite' &&
+          pendingSupervisorOverrideToken === undefined;
+        if (
+          loginGuard.blocked &&
+          pendingSupervisorOverrideToken === undefined &&
+          !pendingLockedE2eAdmission
+        ) {
           return failResult(
             'LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.',
             'LOGIN_PROLOGUE_BLOCKED',
@@ -1641,6 +1651,25 @@ export function createAuthorityGate(
           if (!deferredAdmissionChecks) {
             requireCompleteAxes(status, profile);
             bindSessionArguments(status, profile, args, tool);
+          }
+          if (pendingLockedE2eAdmission) {
+            const resolvedLockedTestIds = dependencies.resolveLockedE2eTestIds?.(args, status);
+            if (
+              !resolvedLockedTestIds ||
+              inspectLoginPrologueGuard({
+                binding: status.bindings.loginPrologue,
+                tool,
+                args,
+                mutation: profile.mutation,
+                resolvedLockedTestIds,
+              }).blocked
+            ) {
+              throw new SessionAuthorityError(
+                'LOGIN_PROLOGUE_BLOCKED',
+                'the locked e2e suite did not resolve to the exact user-login candidate',
+              );
+            }
+            setResolvedLockedTestIds(args, resolvedLockedTestIds);
           }
           operation = registry.beginOperation(available.session, {
             operationId: randomUUID(),

--- a/packages/rn-dev-agent-core/src/session/authority-gate.ts
+++ b/packages/rn-dev-agent-core/src/session/authority-gate.ts
@@ -742,12 +742,13 @@ function missingLoginPrologueOutcome(): LoginPrologueOutcome {
   };
 }
 
-function pendingLoginPrologueOutcome(): LoginPrologueOutcome {
+function pendingLoginPrologueOutcome(attemptId: string): LoginPrologueOutcome {
   const timestamp = new Date().toISOString();
   return {
     schemaVersion: 1,
     state: LOGIN_PROLOGUE_BLOCKED,
     alias: LOGIN_PROLOGUE_ALIAS,
+    attemptId,
     startedAt: timestamp,
     endedAt: timestamp,
     elapsedMs: 0,
@@ -1166,6 +1167,11 @@ export function createAuthorityGate(
           handlerArgs[0] && typeof handlerArgs[0] === 'object'
             ? (handlerArgs[0] as Record<string, unknown>)
             : {};
+        const suppliedSupervisorOverrideToken =
+          typeof args.supervisorOverrideToken === 'string'
+            ? args.supervisorOverrideToken
+            : undefined;
+        delete args.supervisorOverrideToken;
         const baseProfile = authorityProfileFor(tool, args);
         let profile =
           tool === 'rn_session' &&
@@ -1225,9 +1231,8 @@ export function createAuthorityGate(
           mutation: profile.mutation,
         });
         const pendingSupervisorOverrideToken = loginGuard.blocked
-          ? loginGuard.suppliedOverride
+          ? suppliedSupervisorOverrideToken
           : undefined;
-        delete args.supervisorOverrideToken;
         if (loginGuard.blocked && pendingSupervisorOverrideToken === undefined) {
           return failResult(
             'LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.',
@@ -1631,7 +1636,9 @@ export function createAuthorityGate(
             throw new SessionAuthorityError(initialStatus.code, initialStatus.reason);
           }
           let status: SessionStatus = initialStatus;
-          if (tool !== 'cdp_login_prologue') {
+          const deferredAdmissionChecks =
+            tool === 'cdp_login_prologue' || pendingSupervisorOverrideToken !== undefined;
+          if (!deferredAdmissionChecks) {
             requireCompleteAxes(status, profile);
             bindSessionArguments(status, profile, args, tool);
           }
@@ -1646,11 +1653,42 @@ export function createAuthorityGate(
               registry,
               operation,
               status,
-              pendingLoginPrologueOutcome(),
+              pendingLoginPrologueOutcome(operation.operationId),
             );
             operation = persisted.operation;
             status = persisted.status;
             loginPrologueAttemptOperationId = operation.operationId;
+            requireCompleteAxes(status, profile);
+            bindSessionArguments(status, profile, args, tool);
+          }
+          if (pendingSupervisorOverrideToken !== undefined) {
+            const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
+            if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
+              throw new SessionAuthorityError(
+                'LOGIN_PROLOGUE_BLOCKED',
+                'the blocked login prologue state disappeared before override audit',
+              );
+            }
+            const audit = authorizeLoginSupervisorOverride({
+              expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
+              suppliedOverrideToken: pendingSupervisorOverrideToken,
+              tool,
+            });
+            if (!audit) {
+              throw new SessionAuthorityError(
+                'LOGIN_PROLOGUE_BLOCKED',
+                'the supervisor override token was rejected under the operation fence',
+              );
+            }
+            const persisted = persistLoginPrologueOutcome(
+              runtime,
+              registry,
+              operation,
+              status,
+              appendLoginOverrideAudit(outcome, audit),
+            );
+            operation = persisted.operation;
+            status = persisted.status;
             requireCompleteAxes(status, profile);
             bindSessionArguments(status, profile, args, tool);
           }
@@ -2079,35 +2117,6 @@ export function createAuthorityGate(
               },
             });
           }
-          if (pendingSupervisorOverrideToken !== undefined) {
-            const outcome = readLoginPrologueOutcome(status.bindings.loginPrologue);
-            if (outcome?.state !== LOGIN_PROLOGUE_BLOCKED) {
-              throw new SessionAuthorityError(
-                'LOGIN_PROLOGUE_BLOCKED',
-                'the blocked login prologue state disappeared before override audit',
-              );
-            }
-            const audit = authorizeLoginSupervisorOverride({
-              expectedOverrideToken: dependencies.loginSupervisorOverrideToken?.(),
-              suppliedOverrideToken: pendingSupervisorOverrideToken,
-              tool,
-            });
-            if (!audit) {
-              throw new SessionAuthorityError(
-                'LOGIN_PROLOGUE_BLOCKED',
-                'the supervisor override token was rejected under the operation fence',
-              );
-            }
-            const persisted = persistLoginPrologueOutcome(
-              runtime,
-              registry,
-              operation,
-              status,
-              appendLoginOverrideAudit(outcome, audit),
-            );
-            operation = persisted.operation;
-            status = persisted.status;
-          }
           registry.verifyOperation(operation);
           const snapshotCheckpoint = dependencies.snapshotCaptureCheckpoint?.();
           let result = await registry.runWithOperation(operation, () => handler(...handlerArgs));
@@ -2410,6 +2419,7 @@ export function createAuthorityGate(
             if (
               operation.operationId !== loginPrologueAttemptOperationId ||
               pendingOutcome?.state !== LOGIN_PROLOGUE_BLOCKED ||
+              pendingOutcome.attemptId !== loginPrologueAttemptOperationId ||
               pendingOutcome.failure?.code !== 'LOGIN_PROLOGUE_IN_PROGRESS'
             ) {
               throw new SessionAuthorityError(

--- a/packages/rn-dev-agent-core/src/session/public-status.ts
+++ b/packages/rn-dev-agent-core/src/session/public-status.ts
@@ -2,6 +2,7 @@ import type { InstallIdentityInspection } from './install-identity-inspection.js
 import { inspectAuthorityMigration } from './migration-diagnostic.js';
 import { authorityRemedyNextAction, type RecoveryRequirementInspection } from './registry.js';
 import type { WorkerAuthorityStatus } from './runtime.js';
+import { readLoginPrologueOutcome } from '../domain/login-prologue.js';
 
 interface BoundedHandle {
   token?: unknown;
@@ -148,6 +149,7 @@ export function projectPublicAuthorityStatus(
     : undefined;
   const sandbox =
     metro?.runtimeEvidenceAuthority === 'managed-sandbox-v1' ? 'managed-sandbox-v1' : 'unavailable';
+  const loginPrologue = readLoginPrologueOutcome(status.bindings.loginPrologue);
   const phase = derivePublicPhase(status.state, Boolean(status.bindings.pendingBuild));
   return {
     available: true,
@@ -191,6 +193,22 @@ export function projectPublicAuthorityStatus(
     proof: Boolean(status.bindings.proof),
     // ADR §5.2 (L3): strict proof is an opt-in overlay outside the four groups, never a group.
     proofOverlay: { active: Boolean(status.bindings.proof) },
+    ...(loginPrologue
+      ? {
+          loginPrologue: {
+            state: loginPrologue.state,
+            alias: loginPrologue.alias,
+            actionId: loginPrologue.actionId,
+            startedAt: loginPrologue.startedAt,
+            endedAt: loginPrologue.endedAt,
+            elapsedMs: loginPrologue.elapsedMs,
+            failureCode: loginPrologue.failure?.code,
+            runId: loginPrologue.runRecord?.runId,
+            overrideCount: loginPrologue.overrides?.length ?? 0,
+            lastOverride: loginPrologue.overrides?.at(-1),
+          },
+        }
+      : {}),
     ...(options.installIdentity ? { installIdentity: options.installIdentity.verdict } : {}),
     // A live axis-I refusal means every gated tool refuses too — status must
     // not read `ready` while that is true. A pending re-issue reads ready only

--- a/packages/rn-dev-agent-core/src/session/public-status.ts
+++ b/packages/rn-dev-agent-core/src/session/public-status.ts
@@ -2,7 +2,7 @@ import type { InstallIdentityInspection } from './install-identity-inspection.js
 import { inspectAuthorityMigration } from './migration-diagnostic.js';
 import { authorityRemedyNextAction, type RecoveryRequirementInspection } from './registry.js';
 import type { WorkerAuthorityStatus } from './runtime.js';
-import { readLoginPrologueOutcome } from '../domain/login-prologue.js';
+import { ACTION_LOGIN_HELPER, readLoginPrologueOutcome } from '../domain/login-prologue.js';
 
 interface BoundedHandle {
   token?: unknown;
@@ -196,6 +196,7 @@ export function projectPublicAuthorityStatus(
     ...(loginPrologue
       ? {
           loginPrologue: {
+            role: ACTION_LOGIN_HELPER,
             state: loginPrologue.state,
             alias: loginPrologue.alias,
             actionId: loginPrologue.actionId,

--- a/packages/rn-dev-agent-core/src/session/tool-profiles.ts
+++ b/packages/rn-dev-agent-core/src/session/tool-profiles.ts
@@ -89,7 +89,7 @@ const managedNativeMutation = [
 ] as const;
 
 const hybridMutation = ['cdp_auto_login', 'cdp_run_e2e_suite'] as const;
-const optionalHybridMutation = ['cdp_run_action'] as const;
+const optionalHybridMutation = ['cdp_login_prologue', 'cdp_run_action'] as const;
 const nativeDiagnostic = ['cdp_native_errors'] as const;
 const inlineMaestroMutation = new Set<string>([
   'device_accept_system_dialog',

--- a/packages/rn-dev-agent-core/src/tools/lock-e2e-test.ts
+++ b/packages/rn-dev-agent-core/src/tools/lock-e2e-test.ts
@@ -1,5 +1,5 @@
 import { loadAction } from '../domain/action-store.js';
-import { freezeLockedTest, loadLockedTest } from '../domain/e2e-test.js';
+import { freezeLockedTest, lockedTestFileExists } from '../domain/e2e-test.js';
 import {
   loadE2eConfig,
   resolveParams,
@@ -87,7 +87,7 @@ export async function lockE2eTestCore(
     resolvedParams = resolved.params;
   }
 
-  if (!args.relock && loadLockedTest(projectRoot, args.actionId)) {
+  if (!args.relock && lockedTestFileExists(projectRoot, args.actionId)) {
     return failResult(
       `'${args.actionId}' is already locked — pass relock:true to re-lock`,
       'ALREADY_LOCKED',

--- a/packages/rn-dev-agent-core/src/tools/login-prologue.ts
+++ b/packages/rn-dev-agent-core/src/tools/login-prologue.ts
@@ -1,5 +1,5 @@
 import { listActions } from '../domain/action-inventory.js';
-import { ActionMetadataIdentityError, loadAction } from '../domain/action-store.js';
+import { loadAction } from '../domain/action-store.js';
 import {
   ACTION_LOGIN_HELPER,
   LOGIN_PROLOGUE_ALIAS,
@@ -32,13 +32,6 @@ function parseEnvelope(result: ToolResult): ToolEnvelope {
   } catch {
     return { ok: false, code: 'BAD_RESPONSE', error: 'Action replay returned invalid JSON.' };
   }
-}
-
-function isLoginActionIdentityMismatch(error: unknown): error is ActionMetadataIdentityError {
-  return (
-    error instanceof ActionMetadataIdentityError &&
-    (error.fileId === LOGIN_PROLOGUE_ALIAS || error.metadataId === LOGIN_PROLOGUE_ALIAS)
-  );
 }
 
 export function createLoginPrologueHandler(deps: LoginPrologueDependencies) {
@@ -104,7 +97,11 @@ export function createLoginPrologueHandler(deps: LoginPrologueDependencies) {
           loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS),
         );
       } catch (error) {
-        if (isLoginActionIdentityMismatch(error)) {
+        if (
+          error instanceof Error &&
+          error.message.includes('does not match filename identity') &&
+          error.message.includes(LOGIN_PROLOGUE_ALIAS)
+        ) {
           return blocked(
             'LOGIN_ACTION_ID_MISMATCH',
             `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`,

--- a/packages/rn-dev-agent-core/src/tools/login-prologue.ts
+++ b/packages/rn-dev-agent-core/src/tools/login-prologue.ts
@@ -105,11 +105,6 @@ export function createLoginPrologueHandler(deps: LoginPrologueDependencies) {
         );
       }
 
-      const priorRunIds = new Set(
-        action.state.runHistory
-          .map((record) => record.runId)
-          .filter((runId): runId is string => typeof runId === 'string'),
-      );
       const replayArgs = Object.create(
         Object.getPrototypeOf(args),
         Object.getOwnPropertyDescriptors(args),
@@ -138,23 +133,32 @@ export function createLoginPrologueHandler(deps: LoginPrologueDependencies) {
       }
 
       const replay = parseEnvelope(replayResult);
+      const strictRunRecordId =
+        typeof replay.data?.strictRunRecordId === 'string'
+          ? replay.data.strictRunRecordId
+          : typeof replay.meta?.strictRunRecordId === 'string'
+            ? replay.meta.strictRunRecordId
+            : undefined;
       let freshRecord: RunRecord | undefined;
       await measure('verify-run-record', async () => {
         const reloaded = loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS);
-        freshRecord = reloaded?.state.runHistory
-          .slice()
-          .reverse()
-          .find((record) => typeof record.runId === 'string' && !priorRunIds.has(record.runId));
+        freshRecord = strictRunRecordId
+          ? reloaded?.state.runHistory.find((record) => record.runId === strictRunRecordId)
+          : undefined;
       });
 
       if (replay.ok !== true || replay.data?.passed !== true) {
+        const metaFailureKind = replay.meta?.failureKind;
         return blocked(
-          replay.code ?? String(replay.data?.failureKind ?? 'ACTION_REPLAY_FAILED'),
+          replay.code ??
+            (typeof metaFailureKind === 'string'
+              ? metaFailureKind
+              : (freshRecord?.failureCode ?? 'ACTION_REPLAY_FAILED')),
           'The saved login action did not pass; exploratory login is now terminally blocked.',
           { actionId: LOGIN_PROLOGUE_ALIAS, ...(freshRecord ? { runRecord: freshRecord } : {}) },
         );
       }
-      if (!freshRecord || freshRecord.status !== 'pass') {
+      if (!strictRunRecordId || !freshRecord || freshRecord.status !== 'pass') {
         return blocked(
           'AUTHORITATIVE_RUN_RECORD_MISSING',
           'The saved login action reported success without a fresh passing RunRecord.',

--- a/packages/rn-dev-agent-core/src/tools/login-prologue.ts
+++ b/packages/rn-dev-agent-core/src/tools/login-prologue.ts
@@ -104,15 +104,18 @@ export function createLoginPrologueHandler(deps: LoginPrologueDependencies) {
           .map((record) => record.runId)
           .filter((runId): runId is string => typeof runId === 'string'),
       );
-      const replayArgs: RunActionArgs = {
-        ...args,
+      const replayArgs = Object.create(
+        Object.getPrototypeOf(args),
+        Object.getOwnPropertyDescriptors(args),
+      ) as RunActionArgs;
+      Object.assign(replayArgs, {
         actionId: LOGIN_PROLOGUE_ALIAS,
         autoRepair: false,
         forceReload: false,
         proofReplay: false,
         blindProbeMode: 'forbid',
         trigger: args.trigger ?? 'agent',
-      };
+      });
 
       let replayResult: ToolResult;
       try {

--- a/packages/rn-dev-agent-core/src/tools/login-prologue.ts
+++ b/packages/rn-dev-agent-core/src/tools/login-prologue.ts
@@ -1,0 +1,173 @@
+import { listActions } from '../domain/action-inventory.js';
+import { loadAction } from '../domain/action-store.js';
+import {
+  LOGIN_PROLOGUE_ALIAS,
+  LOGIN_PROLOGUE_BLOCKED,
+  type LoginPrologueOutcome,
+  type LoginPrologueStepTiming,
+} from '../domain/login-prologue.js';
+import type { RunRecord } from '../domain/reusable-action.js';
+import { failResult, okResult, type ToolResult } from '../utils.js';
+import type { RunActionArgs } from './run-action.js';
+
+export type LoginPrologueArgs = Omit<RunActionArgs, 'actionId' | 'autoRepair' | 'forceReload'>;
+
+export interface LoginPrologueDependencies {
+  runAction: (args: RunActionArgs) => Promise<ToolResult>;
+  now?: () => Date;
+}
+
+interface ToolEnvelope {
+  ok?: boolean;
+  code?: string;
+  error?: string;
+  data?: Record<string, unknown>;
+  meta?: Record<string, unknown>;
+}
+
+function parseEnvelope(result: ToolResult): ToolEnvelope {
+  try {
+    return JSON.parse(result.content[0]?.text ?? '{}') as ToolEnvelope;
+  } catch {
+    return { ok: false, code: 'BAD_RESPONSE', error: 'Action replay returned invalid JSON.' };
+  }
+}
+
+export function createLoginPrologueHandler(deps: LoginPrologueDependencies) {
+  const now = deps.now ?? (() => new Date());
+  return async (args: LoginPrologueArgs): Promise<ToolResult> => {
+    const projectRoot = args.projectRoot ?? process.cwd();
+    const prologueStarted = now();
+    const steps: LoginPrologueStepTiming[] = [];
+    let inventory: Awaited<ReturnType<typeof listActions>> = [];
+
+    const measure = async <T>(
+      name: LoginPrologueStepTiming['name'],
+      run: () => Promise<T>,
+    ): Promise<T> => {
+      const started = now();
+      try {
+        return await run();
+      } finally {
+        const ended = now();
+        steps.push({
+          name,
+          startedAt: started.toISOString(),
+          endedAt: ended.toISOString(),
+          elapsedMs: Math.max(0, ended.getTime() - started.getTime()),
+        });
+      }
+    };
+
+    const finish = (
+      state: LoginPrologueOutcome['state'],
+      extra: Partial<LoginPrologueOutcome>,
+    ): LoginPrologueOutcome => {
+      const ended = now();
+      return {
+        schemaVersion: 1,
+        state,
+        alias: LOGIN_PROLOGUE_ALIAS,
+        startedAt: prologueStarted.toISOString(),
+        endedAt: ended.toISOString(),
+        elapsedMs: Math.max(0, ended.getTime() - prologueStarted.getTime()),
+        steps,
+        inventory: { count: inventory.length, actionIds: inventory.map((action) => action.id) },
+        ...extra,
+      };
+    };
+
+    const blocked = (code: string, detail: string, extra: Partial<LoginPrologueOutcome> = {}) => {
+      const outcome = finish(LOGIN_PROLOGUE_BLOCKED, {
+        failure: { code, detail },
+        ...extra,
+      });
+      return failResult(`Login prologue blocked: ${detail}`, 'LOGIN_PROLOGUE_BLOCKED', {
+        loginPrologue: outcome,
+      });
+    };
+
+    try {
+      inventory = await measure('inventory', () => listActions(projectRoot));
+      const action = await measure('resolve', async () =>
+        loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS),
+      );
+      if (!action || !inventory.some((candidate) => candidate.id === LOGIN_PROLOGUE_ALIAS)) {
+        return blocked(
+          'LOGIN_ACTION_MISSING',
+          `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`,
+        );
+      }
+
+      const priorRunIds = new Set(
+        action.state.runHistory
+          .map((record) => record.runId)
+          .filter((runId): runId is string => typeof runId === 'string'),
+      );
+      const replayArgs: RunActionArgs = {
+        ...args,
+        actionId: LOGIN_PROLOGUE_ALIAS,
+        autoRepair: false,
+        forceReload: false,
+        proofReplay: false,
+        blindProbeMode: 'forbid',
+        trigger: args.trigger ?? 'agent',
+      };
+
+      let replayResult: ToolResult;
+      try {
+        replayResult = await measure('replay', () => deps.runAction(replayArgs));
+      } catch (error) {
+        const code =
+          error && typeof error === 'object' && 'code' in error
+            ? String((error as { code?: unknown }).code)
+            : 'ACTION_REPLAY_THROW';
+        return blocked(code, 'The saved login action threw before producing a result.', {
+          actionId: LOGIN_PROLOGUE_ALIAS,
+        });
+      }
+
+      const replay = parseEnvelope(replayResult);
+      let freshRecord: RunRecord | undefined;
+      await measure('verify-run-record', async () => {
+        const reloaded = loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS);
+        freshRecord = reloaded?.state.runHistory
+          .slice()
+          .reverse()
+          .find((record) => typeof record.runId === 'string' && !priorRunIds.has(record.runId));
+      });
+
+      if (replay.ok !== true || replay.data?.passed !== true) {
+        return blocked(
+          replay.code ?? String(replay.data?.failureKind ?? 'ACTION_REPLAY_FAILED'),
+          'The saved login action did not pass; exploratory login is now terminally blocked.',
+          { actionId: LOGIN_PROLOGUE_ALIAS, ...(freshRecord ? { runRecord: freshRecord } : {}) },
+        );
+      }
+      if (!freshRecord || freshRecord.status !== 'pass') {
+        return blocked(
+          'AUTHORITATIVE_RUN_RECORD_MISSING',
+          'The saved login action reported success without a fresh passing RunRecord.',
+          { actionId: LOGIN_PROLOGUE_ALIAS },
+        );
+      }
+
+      const outcome = finish('passed', {
+        actionId: LOGIN_PROLOGUE_ALIAS,
+        runRecord: freshRecord,
+        actionResult: {
+          transport: replay.data.transport,
+          transportVersion: replay.data.transportVersion,
+          fallback: replay.data.fallback,
+          perStepReadback: replay.data.perStepReadback,
+        },
+      });
+      return okResult(outcome);
+    } catch {
+      return blocked(
+        'LOGIN_PROLOGUE_INTERNAL_ERROR',
+        'The login prologue failed before it could prove a passing replay.',
+      );
+    }
+  };
+}

--- a/packages/rn-dev-agent-core/src/tools/login-prologue.ts
+++ b/packages/rn-dev-agent-core/src/tools/login-prologue.ts
@@ -8,7 +8,7 @@ import {
 } from '../domain/login-prologue.js';
 import type { RunRecord } from '../domain/reusable-action.js';
 import { failResult, okResult, type ToolResult } from '../utils.js';
-import type { RunActionArgs } from './run-action.js';
+import { sealStrictRunAction, type RunActionArgs } from './run-action.js';
 
 export type LoginPrologueArgs = Omit<RunActionArgs, 'actionId' | 'autoRepair' | 'forceReload'>;
 
@@ -120,9 +120,9 @@ export function createLoginPrologueHandler(deps: LoginPrologueDependencies) {
         forceReload: false,
         proofReplay: false,
         blindProbeMode: 'forbid',
-        cdpFallbackMode: 'forbid',
         trigger: args.trigger ?? 'agent',
       });
+      sealStrictRunAction(replayArgs);
 
       let replayResult: ToolResult;
       try {

--- a/packages/rn-dev-agent-core/src/tools/login-prologue.ts
+++ b/packages/rn-dev-agent-core/src/tools/login-prologue.ts
@@ -1,6 +1,7 @@
 import { listActions } from '../domain/action-inventory.js';
 import { loadAction } from '../domain/action-store.js';
 import {
+  ACTION_LOGIN_HELPER,
   LOGIN_PROLOGUE_ALIAS,
   LOGIN_PROLOGUE_BLOCKED,
   type LoginPrologueOutcome,
@@ -67,6 +68,7 @@ export function createLoginPrologueHandler(deps: LoginPrologueDependencies) {
       return {
         schemaVersion: 1,
         state,
+        role: ACTION_LOGIN_HELPER,
         alias: LOGIN_PROLOGUE_ALIAS,
         startedAt: prologueStarted.toISOString(),
         endedAt: ended.toISOString(),

--- a/packages/rn-dev-agent-core/src/tools/login-prologue.ts
+++ b/packages/rn-dev-agent-core/src/tools/login-prologue.ts
@@ -120,6 +120,7 @@ export function createLoginPrologueHandler(deps: LoginPrologueDependencies) {
         forceReload: false,
         proofReplay: false,
         blindProbeMode: 'forbid',
+        cdpFallbackMode: 'forbid',
         trigger: args.trigger ?? 'agent',
       });
 

--- a/packages/rn-dev-agent-core/src/tools/login-prologue.ts
+++ b/packages/rn-dev-agent-core/src/tools/login-prologue.ts
@@ -92,10 +92,16 @@ export function createLoginPrologueHandler(deps: LoginPrologueDependencies) {
       const action = await measure('resolve', async () =>
         loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS),
       );
-      if (!action || !inventory.some((candidate) => candidate.id === LOGIN_PROLOGUE_ALIAS)) {
+      if (!action) {
         return blocked(
           'LOGIN_ACTION_MISSING',
           `No exact ${LOGIN_PROLOGUE_ALIAS} learned action was found. Auth-tag or intent inference is not permitted.`,
+        );
+      }
+      if (action.metadata.id !== LOGIN_PROLOGUE_ALIAS) {
+        return blocked(
+          'LOGIN_ACTION_ID_MISMATCH',
+          `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`,
         );
       }
 

--- a/packages/rn-dev-agent-core/src/tools/login-prologue.ts
+++ b/packages/rn-dev-agent-core/src/tools/login-prologue.ts
@@ -1,5 +1,5 @@
 import { listActions } from '../domain/action-inventory.js';
-import { loadAction } from '../domain/action-store.js';
+import { ActionMetadataIdentityError, loadAction } from '../domain/action-store.js';
 import {
   ACTION_LOGIN_HELPER,
   LOGIN_PROLOGUE_ALIAS,
@@ -32,6 +32,13 @@ function parseEnvelope(result: ToolResult): ToolEnvelope {
   } catch {
     return { ok: false, code: 'BAD_RESPONSE', error: 'Action replay returned invalid JSON.' };
   }
+}
+
+function isLoginActionIdentityMismatch(error: unknown): error is ActionMetadataIdentityError {
+  return (
+    error instanceof ActionMetadataIdentityError &&
+    (error.fileId === LOGIN_PROLOGUE_ALIAS || error.metadataId === LOGIN_PROLOGUE_ALIAS)
+  );
 }
 
 export function createLoginPrologueHandler(deps: LoginPrologueDependencies) {
@@ -90,10 +97,21 @@ export function createLoginPrologueHandler(deps: LoginPrologueDependencies) {
     };
 
     try {
-      inventory = await measure('inventory', () => listActions(projectRoot));
-      const action = await measure('resolve', async () =>
-        loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS),
-      );
+      let action;
+      try {
+        inventory = await measure('inventory', () => listActions(projectRoot));
+        action = await measure('resolve', async () =>
+          loadAction(projectRoot, LOGIN_PROLOGUE_ALIAS),
+        );
+      } catch (error) {
+        if (isLoginActionIdentityMismatch(error)) {
+          return blocked(
+            'LOGIN_ACTION_ID_MISMATCH',
+            `The ${LOGIN_PROLOGUE_ALIAS} action file declares a different action id.`,
+          );
+        }
+        throw error;
+      }
       if (!action) {
         return blocked(
           'LOGIN_ACTION_MISSING',

--- a/packages/rn-dev-agent-core/src/tools/run-action.ts
+++ b/packages/rn-dev-agent-core/src/tools/run-action.ts
@@ -29,7 +29,6 @@
 //     mask underlying screen churn).
 
 import { randomUUID } from 'node:crypto';
-import { dirname } from 'node:path';
 import { okResult, failResult } from '../utils.js';
 import type { ToolResult } from '../utils.js';
 import type { ToolErrorCode } from '../types.js';

--- a/packages/rn-dev-agent-core/src/tools/run-action.ts
+++ b/packages/rn-dev-agent-core/src/tools/run-action.ts
@@ -801,7 +801,8 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
       const firstDeviceAuthority = readMaestroDeviceAuthority(firstEnv);
       probeDeviceId = firstDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
 
-      if (firstEnv.code === 'DEVICE_AUTHORITY_MISMATCH') {
+      if (firstEnv.code) {
+        const typedCode = firstEnv.code as ToolErrorCode;
         const autoRepair: AutoRepairOutcome = {
           attempted: false,
           outcome: args.autoRepair === false ? 'refused' : 'skipped',
@@ -812,17 +813,22 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
           timestamp: new Date().toISOString(),
           durationMs: Date.now() - t0,
           status: 'fail',
-          failureCode: 'DEVICE_AUTHORITY_MISMATCH',
+          failureCode:
+            typedCode === 'DEVICE_AUTHORITY_MISMATCH'
+              ? 'DEVICE_AUTHORITY_MISMATCH'
+              : typedCode === 'RECONNECT_TIMEOUT'
+                ? 'TIMEOUT'
+                : 'UNKNOWN',
           failureDetail: firstFailureDetail.slice(0, 1000),
           trigger,
           autoRepair,
         });
         return failResult(
-          `cdp_run_action: ${args.actionId} refused replay authority: ${firstFailureDetail}`,
-          'DEVICE_AUTHORITY_MISMATCH',
+          `cdp_run_action: ${args.actionId} refused replay: ${firstFailureDetail}`,
+          typedCode,
           {
             actionId: args.actionId,
-            failureKind: 'DEVICE_AUTHORITY_MISMATCH',
+            failureKind: typedCode,
             deviceAuthority: firstDeviceAuthority,
             autoRepair,
             writes: writeDisclosure('none', persisted),

--- a/packages/rn-dev-agent-core/src/tools/run-action.ts
+++ b/packages/rn-dev-agent-core/src/tools/run-action.ts
@@ -184,6 +184,7 @@ export interface RunActionArgs {
    * unchanged.
    */
   blindProbeMode?: 'inherit' | 'allow' | 'forbid';
+  cdpFallbackMode?: 'allow' | 'forbid';
 }
 
 interface MaestroTerminal {
@@ -662,9 +663,11 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
       // directly. Every branch fails open to the maestro-first path below.
       // Opt out globally with RN_BLIND_PROBE=0.
       let atRisk: BlindProbeAtRisk | null = null;
+      const cdpFallbackForbidden = args.cdpFallbackMode === 'forbid';
       const inheritedBlindProbeDisabled =
         process.env.RN_BLIND_PROBE === '0' || process.env.RN_BLIND_PROBE === 'false';
       const blindProbeDisabled =
+        cdpFallbackForbidden ||
         args.blindProbeMode === 'forbid' ||
         (args.blindProbeMode !== 'allow' && inheritedBlindProbeDisabled);
       if (args.platform !== 'android') {
@@ -919,7 +922,10 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
       // usually just relaunched the app), and every skip records its reason —
       // a silent skip surfaced in the field as an unexplained UNKNOWN.
       let cdpJsFallback: CdpJsFallbackSkip | undefined;
-      if (failure.kind === 'SELECTOR_NOT_FOUND' || failure.kind === 'UNKNOWN') {
+      if (
+        !cdpFallbackForbidden &&
+        (failure.kind === 'SELECTOR_NOT_FOUND' || failure.kind === 'UNKNOWN')
+      ) {
         const candidate = getReplayDeps(args);
         const replayDeps = candidate && (await claimBundleAuthority(args)) ? candidate : null;
         const probe = !replayDeps

--- a/packages/rn-dev-agent-core/src/tools/run-action.ts
+++ b/packages/rn-dev-agent-core/src/tools/run-action.ts
@@ -86,6 +86,19 @@ import {
   type ReplayEngineStatus,
 } from '../domain/engine-pin.js';
 
+const strictRunActionPolicy = Symbol('strictRunActionPolicy');
+
+type StrictRunActionArgs = RunActionArgs & { [strictRunActionPolicy]?: true };
+
+export function sealStrictRunAction(args: RunActionArgs): RunActionArgs {
+  Object.defineProperty(args, strictRunActionPolicy, { value: true });
+  return args;
+}
+
+function usesStrictRunActionPolicy(args: RunActionArgs): boolean {
+  return (args as StrictRunActionArgs)[strictRunActionPolicy] === true;
+}
+
 /** GH #705: the session's attested install receipt, or null outside a session. */
 function boundInstallReceipt(): { platform?: unknown; deviceId?: unknown; appId?: unknown } | null {
   try {
@@ -184,7 +197,6 @@ export interface RunActionArgs {
    * unchanged.
    */
   blindProbeMode?: 'inherit' | 'allow' | 'forbid';
-  cdpFallbackMode?: 'allow' | 'forbid';
 }
 
 interface MaestroTerminal {
@@ -663,11 +675,11 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
       // directly. Every branch fails open to the maestro-first path below.
       // Opt out globally with RN_BLIND_PROBE=0.
       let atRisk: BlindProbeAtRisk | null = null;
-      const cdpFallbackForbidden = args.cdpFallbackMode === 'forbid';
+      const strictExecutor = usesStrictRunActionPolicy(args);
       const inheritedBlindProbeDisabled =
         process.env.RN_BLIND_PROBE === '0' || process.env.RN_BLIND_PROBE === 'false';
       const blindProbeDisabled =
-        cdpFallbackForbidden ||
+        strictExecutor ||
         args.blindProbeMode === 'forbid' ||
         (args.blindProbeMode !== 'allow' && inheritedBlindProbeDisabled);
       if (args.platform !== 'android') {
@@ -923,7 +935,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
       // a silent skip surfaced in the field as an unexplained UNKNOWN.
       let cdpJsFallback: CdpJsFallbackSkip | undefined;
       if (
-        !cdpFallbackForbidden &&
+        !strictExecutor &&
         (failure.kind === 'SELECTOR_NOT_FOUND' || failure.kind === 'UNKNOWN')
       ) {
         const candidate = getReplayDeps(args);

--- a/packages/rn-dev-agent-core/src/tools/run-action.ts
+++ b/packages/rn-dev-agent-core/src/tools/run-action.ts
@@ -221,6 +221,10 @@ interface MaestroEnvelope {
     transport?: string;
     transportVersion?: string | null;
     fallback?: string;
+    enginePin?: {
+      pinned?: string;
+      status?: string;
+    };
     deviceAuthority?: MaestroDeviceAuthority;
     steps?: Array<{
       index: number;
@@ -232,6 +236,13 @@ interface MaestroEnvelope {
   };
   error?: string;
   meta?: Record<string, unknown>;
+}
+
+const PROVEN_ENGINE_PIN_DIVERGENCE = new Set(['drift-newer', 'drift-older', 'checksum-mismatch']);
+
+function strictEnginePinDivergence(env: MaestroEnvelope): string | null {
+  const status = env.data?.enginePin?.status;
+  return typeof status === 'string' && PROVEN_ENGINE_PIN_DIVERGENCE.has(status) ? status : null;
 }
 
 function parseEnvelope(toolResult: ToolResult, toolName: string): MaestroEnvelope {
@@ -676,6 +687,10 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
       // Opt out globally with RN_BLIND_PROBE=0.
       let atRisk: BlindProbeAtRisk | null = null;
       const strictExecutor = usesStrictRunActionPolicy(args);
+      const strictRunRecordMeta = (outcome: PersistRunOutcome): Record<string, unknown> =>
+        strictExecutor && outcome.persistedRunId
+          ? { strictRunRecordId: outcome.persistedRunId }
+          : {};
       const inheritedBlindProbeDisabled =
         process.env.RN_BLIND_PROBE === '0' || process.env.RN_BLIND_PROBE === 'false';
       const blindProbeDisabled =
@@ -810,11 +825,43 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
       );
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, 'maestro_run');
-      const firstPassed = firstEnv.ok === true && firstEnv.data?.passed === true;
       const firstOutput = readMaestroOutput(firstEnv);
       const firstFailureDetail = readMaestroFailureDetail(firstEnv, firstOutput);
       const firstDeviceAuthority = readMaestroDeviceAuthority(firstEnv);
       probeDeviceId = firstDeviceAuthority?.reportedDeviceId ?? observedDeviceId;
+      const enginePinDivergence = strictExecutor ? strictEnginePinDivergence(firstEnv) : null;
+
+      if (enginePinDivergence) {
+        const autoRepair: AutoRepairOutcome = {
+          attempted: false,
+          outcome: 'refused',
+          refusedReason: 'NOT_REPAIRABLE_KIND',
+          phases: { firstAttemptMs },
+        };
+        const persisted = await persistRunWithDevice({
+          timestamp: new Date().toISOString(),
+          durationMs: Date.now() - t0,
+          status: 'fail',
+          failureCode: 'UNKNOWN',
+          failureDetail: `Engine pin status ${enginePinDivergence}`,
+          trigger,
+          autoRepair,
+        });
+        return failResult(
+          `cdp_run_action: ${args.actionId} refused strict replay because the engine pin status is ${enginePinDivergence}.`,
+          'ENGINE_PIN_MISMATCH',
+          {
+            actionId: args.actionId,
+            failureKind: 'ENGINE_PIN_MISMATCH',
+            enginePin: firstEnv.data?.enginePin,
+            autoRepair,
+            writes: writeDisclosure('none', persisted),
+            ...strictRunRecordMeta(persisted),
+          },
+        );
+      }
+
+      const firstPassed = firstEnv.ok === true && firstEnv.data?.passed === true;
 
       if (firstEnv.code) {
         const typedCode = firstEnv.code as ToolErrorCode;
@@ -847,6 +894,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
             deviceAuthority: firstDeviceAuthority,
             autoRepair,
             writes: writeDisclosure('none', persisted),
+            ...strictRunRecordMeta(persisted),
           },
         );
       }
@@ -865,9 +913,21 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
           trigger,
           autoRepair,
         });
+        if (strictExecutor && persisted.persistedRunId !== runId) {
+          return failResult(
+            `cdp_run_action: ${args.actionId} passed, but its authoritative RunRecord was not committed.`,
+            'LOAD_FAILED',
+            {
+              actionId: args.actionId,
+              failureKind: 'AUTHORITATIVE_RUN_RECORD_MISSING',
+              writes: writeDisclosure('none', persisted),
+            },
+          );
+        }
         return okResult({
           passed: true,
           actionId: args.actionId,
+          ...(strictExecutor ? { strictRunRecordId: persisted.persistedRunId } : {}),
           ...(proofReplay ? { proofReplay: true } : {}),
           ...replaySuccessEvidence(firstEnv),
           repair: autoRepair,
@@ -1058,7 +1118,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
               phases: { firstAttemptMs },
             };
         const { actionCode, toolCode } = classifyFailure(failure);
-        await persistRunWithDevice({
+        const persisted = await persistRunWithDevice({
           timestamp: new Date().toISOString(),
           durationMs: Date.now() - t0,
           status: 'fail',
@@ -1081,6 +1141,7 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
           terminal: readMaestroTerminal(firstEnv),
           runnerResume: (firstEnv.meta as { runnerResume?: unknown } | undefined)?.runnerResume,
           ...(cdpJsFallback ? { cdpJsFallback } : {}),
+          ...strictRunRecordMeta(persisted),
         };
         let message =
           failure.kind === 'WDA_BOOTSTRAP_FAILED'
@@ -1391,6 +1452,7 @@ interface PersistRunOutcome {
   promoted: boolean;
   promotionRefused: boolean;
   runtimeStateRefused?: boolean;
+  persistedRunId?: string;
 }
 
 type WriteDisclosureKind =
@@ -1440,7 +1502,7 @@ async function persistRun(
           path: fresh.filePath,
         },
       });
-      return { promoted, promotionRefused };
+      return { promoted, promotionRefused, persistedRunId: record.runId };
     };
     // A promotion refusal is deterministic (externally edited YAML, or a missing
     // `# status: experimental` marker) — retrying cannot clear it, so degrade to

--- a/packages/rn-dev-agent-core/src/tools/run-action.ts
+++ b/packages/rn-dev-agent-core/src/tools/run-action.ts
@@ -28,6 +28,8 @@
 //     30s+ device snapshot; cascading retries would be slow and could
 //     mask underlying screen churn).
 
+import { randomUUID } from 'node:crypto';
+import { dirname } from 'node:path';
 import { okResult, failResult } from '../utils.js';
 import type { ToolResult } from '../utils.js';
 import type { ToolErrorCode } from '../types.js';
@@ -560,6 +562,23 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
     const trigger: 'agent' | 'ci' | 'human' = args.trigger ?? 'agent';
     const timeoutMs = args.timeoutMs ?? 120_000;
     const t0 = Date.now();
+    const startedAt = new Date(t0).toISOString();
+    const runId = randomUUID();
+    const timingSteps: NonNullable<RunRecord['timing']>['steps'] = [];
+    const measureStep = async <T>(name: string, run: () => Promise<T>): Promise<T> => {
+      const stepStartedMs = Date.now();
+      try {
+        return await run();
+      } finally {
+        const stepEndedMs = Date.now();
+        timingSteps.push({
+          name,
+          startedAt: new Date(stepStartedMs).toISOString(),
+          endedAt: new Date(stepEndedMs).toISOString(),
+          elapsedMs: Math.max(0, stepEndedMs - stepStartedMs),
+        });
+      }
+    };
     const activeTarget = targetContext();
     if (args.platform && activeTarget?.platform && activeTarget.platform !== args.platform) {
       return failResult(
@@ -594,14 +613,25 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
     // Maestro was pinned to). Used only when the dispatch produced no receipt,
     // so a clean pass can still clear a device-matched blind-probe latch.
     let observedDeviceId: string | null = maestroDeviceId ?? null;
-    const persistRunWithDevice = (record: RunRecord): Promise<PersistRunOutcome> =>
-      proofReplay
-        ? Promise.resolve({ promoted: false, promotionRefused: false })
-        : persistRun(
-            args.actionId,
-            projectRoot,
-            probeDeviceId ? { ...record, deviceId: probeDeviceId } : record,
-          );
+    const persistRunWithDevice = (record: RunRecord): Promise<PersistRunOutcome> => {
+      if (proofReplay) return Promise.resolve({ promoted: false, promotionRefused: false });
+      const endedMs = Date.now();
+      const timedRecord: RunRecord = {
+        ...record,
+        runId,
+        timing: {
+          startedAt,
+          endedAt: new Date(endedMs).toISOString(),
+          elapsedMs: Math.max(0, endedMs - t0),
+          steps: [...timingSteps],
+        },
+      };
+      return persistRun(
+        args.actionId,
+        projectRoot,
+        probeDeviceId ? { ...timedRecord, deviceId: probeDeviceId } : timedRecord,
+      );
+    };
     const writeDisclosure = (
       actionYaml: WriteDisclosureKind = 'none',
       outcome?: PersistRunOutcome,
@@ -663,11 +693,15 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
         const probe = replayDeps ? firstReplayTestId(cdpReplayYaml, args.params ?? {}) : null;
         if (replayDeps && probe) {
           const tProbe = Date.now();
-          const probeOutcome = await probeTreeWithRetry(replayDeps, probe, probeRetry);
+          const probeOutcome = await measureStep('proactive-probe', () =>
+            probeTreeWithRetry(replayDeps, probe, probeRetry),
+          );
           if (probeOutcome.found) {
             const tReplay = Date.now();
             try {
-              const replay = await runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps);
+              const replay = await measureStep('proactive-cdp-replay', () =>
+                runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps),
+              );
               const timings_ms = { probe: tReplay - tProbe, replay: Date.now() - tReplay };
               const blindProbe = { atRisk, skippedMaestro: true };
               const autoRepair: AutoRepairOutcome = {
@@ -741,22 +775,24 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
       // Requested/session metadata is not RunRecord authority. Clear it before
       // dispatch; only direct maestro-runner evidence may repopulate it.
       probeDeviceId = null;
-      const firstResult = await maestroRun({
-        inlineYaml: replayYaml,
-        actionMetadata: action.metadata,
-        platform: args.platform,
-        appId: args.appId,
-        ...(appFile ? { appFile } : {}),
-        deviceId: maestroDeviceId,
-        timeoutMs,
-        params: args.params,
-        claimNativeOrigin: () => claimNativeOrigin(args),
-        completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
-        relaunchManagedApp: () => relaunchManagedApp(args),
-        reproveManagedOrigin: () => reproveManagedOrigin(args),
-        completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
-        reissueInstallReceipt: () => reissueInstallReceipt(args),
-      });
+      const firstResult = await measureStep('maestro-first-attempt', () =>
+        maestroRun({
+          inlineYaml: replayYaml,
+          actionMetadata: action.metadata,
+          platform: args.platform,
+          appId: args.appId,
+          ...(appFile ? { appFile } : {}),
+          deviceId: maestroDeviceId,
+          timeoutMs,
+          params: args.params,
+          claimNativeOrigin: () => claimNativeOrigin(args),
+          completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
+          relaunchManagedApp: () => relaunchManagedApp(args),
+          reproveManagedOrigin: () => reproveManagedOrigin(args),
+          completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+          reissueInstallReceipt: () => reissueInstallReceipt(args),
+        }),
+      );
       const firstAttemptMs = Date.now() - tBeforeFirst;
       const firstEnv = parseEnvelope(firstResult, 'maestro_run');
       const firstPassed = firstEnv.ok === true && firstEnv.data?.passed === true;
@@ -890,7 +926,9 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
         } else if (!probe) {
           cdpJsFallback = { attempted: false, reason: 'no-probe-testid' };
         } else {
-          const probeOutcome = await probeTreeWithRetry(replayDeps, probe, probeRetry);
+          const probeOutcome = await measureStep('fallback-probe', () =>
+            probeTreeWithRetry(replayDeps, probe, probeRetry),
+          );
           if (!probeOutcome.found) {
             cdpJsFallback = {
               attempted: false,
@@ -911,9 +949,11 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
             try {
               // GH #580: resume at the proven failed selector; UNKNOWN failed before
               // any step, so it keeps start-at-zero.
-              const replay = await runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps, {
-                resumeAtSelector: failure.kind === 'SELECTOR_NOT_FOUND' ? failure.selector : null,
-              });
+              const replay = await measureStep('fallback-cdp-replay', () =>
+                runCdpReplay(cdpReplayYaml, args.params ?? {}, replayDeps, {
+                  resumeAtSelector: failure.kind === 'SELECTOR_NOT_FOUND' ? failure.selector : null,
+                }),
+              );
               const status = replay.passed ? 'pass' : 'fail';
               const autoRepair: AutoRepairOutcome = {
                 attempted: false,
@@ -1044,12 +1084,14 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
       }
 
       const tBeforeRepair = Date.now();
-      const repairResult = await repairAction({
-        actionId: args.actionId,
-        failedSelector: failure.selector,
-        projectRoot,
-        agentReasoning: `auto-repair from cdp_run_action after maestro failure: ${failure.selector}`,
-      });
+      const repairResult = await measureStep('selector-repair', () =>
+        repairAction({
+          actionId: args.actionId,
+          failedSelector: failure.selector,
+          projectRoot,
+          agentReasoning: `auto-repair from cdp_run_action after maestro failure: ${failure.selector}`,
+        }),
+      );
       const repairMs = Date.now() - tBeforeRepair;
       const repairEnv = parseEnvelope(repairResult, 'cdp_repair_action');
       const repairPatched =
@@ -1132,25 +1174,28 @@ export function createRunActionHandler(deps: RunActionDeps = {}) {
           { actionId: args.actionId },
         );
       }
+      const retryYaml = reloadedAction.replay.yamlText;
 
       const tBeforeRetry = Date.now();
       probeDeviceId = null;
-      const retryResult = await maestroRun({
-        inlineYaml: reloadedAction.replay.yamlText,
-        actionMetadata: reloadedAction.metadata,
-        platform: args.platform,
-        appId: args.appId,
-        ...(appFile ? { appFile } : {}),
-        deviceId: maestroDeviceId,
-        timeoutMs,
-        params: args.params,
-        claimNativeOrigin: () => claimNativeOrigin(args),
-        completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
-        relaunchManagedApp: () => relaunchManagedApp(args),
-        reproveManagedOrigin: () => reproveManagedOrigin(args),
-        completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
-        reissueInstallReceipt: () => reissueInstallReceipt(args),
-      });
+      const retryResult = await measureStep('maestro-retry', () =>
+        maestroRun({
+          inlineYaml: retryYaml,
+          actionMetadata: reloadedAction.metadata,
+          platform: args.platform,
+          appId: args.appId,
+          ...(appFile ? { appFile } : {}),
+          deviceId: maestroDeviceId,
+          timeoutMs,
+          params: args.params,
+          claimNativeOrigin: () => claimNativeOrigin(args),
+          completeNativeOrigin: (targetExpected) => completeNativeOrigin(args, targetExpected),
+          relaunchManagedApp: () => relaunchManagedApp(args),
+          reproveManagedOrigin: () => reproveManagedOrigin(args),
+          completeRunnerPark: () => completeManagedRunnerParkAuthority(args),
+          reissueInstallReceipt: () => reissueInstallReceipt(args),
+        }),
+      );
       const retryMs = Date.now() - tBeforeRetry;
       const retryEnv = parseEnvelope(retryResult, 'maestro_run');
       const retryPassed = retryEnv.ok === true && retryEnv.data?.passed === true;

--- a/packages/rn-dev-agent-core/src/tools/run-e2e-suite.ts
+++ b/packages/rn-dev-agent-core/src/tools/run-e2e-suite.ts
@@ -1,4 +1,9 @@
-import { discoverLockedTests, loadLockedTest } from '../domain/e2e-test.js';
+import {
+  discoverLockedTests,
+  getResolvedLockedTestIds,
+  loadLockedTest,
+  resolveLockedTestIds,
+} from '../domain/e2e-test.js';
 import {
   classifyFlowResult,
   skippedResult,
@@ -76,16 +81,6 @@ function readMaestro(result: ToolResult): { passed: boolean; output: string } {
   }
 }
 
-function filterByPattern(ids: string[], pattern?: string): string[] {
-  if (!pattern || pattern.length > 256) return ids;
-  try {
-    const re = new RegExp(pattern, 'i');
-    return ids.filter((id) => re.test(id));
-  } catch {
-    return ids;
-  }
-}
-
 export async function runE2eSuiteCore(
   args: RunE2eSuiteArgs,
   deps: RunE2eSuiteDeps = {},
@@ -100,7 +95,10 @@ export async function runE2eSuiteCore(
   const mkRunId = deps.makeRunId ?? makeRunId;
   const rand = (): string => Math.random().toString(36).slice(2, 8);
 
-  const ids = filterByPattern(discover(projectRoot), args.pattern);
+  const ids = [
+    ...(getResolvedLockedTestIds(args) ??
+      resolveLockedTestIds(projectRoot, args.pattern, discover)),
+  ];
   if (ids.length === 0) {
     return warnResult(
       {

--- a/packages/rn-dev-agent-core/src/types.ts
+++ b/packages/rn-dev-agent-core/src/types.ts
@@ -346,6 +346,7 @@ export type ToolErrorCode =
   // GH #397 Phase 1: RN_ENGINE_PIN_STRICT=1 and the engine pin status is a
   // proven divergence (drift-newer / drift-older / checksum-mismatch).
   | 'ENGINE_PIN_MISMATCH'
+  | 'LOGIN_PROLOGUE_BLOCKED'
   // GH #105 / iOS-MVP §3.1: runIOS press/fill with a @ref no longer in the
   // ref-map (snapshot is stale / UI re-rendered). Caller must device_snapshot
   // to refresh refs, then retry.

--- a/packages/rn-dev-agent-core/src/util/redact.ts
+++ b/packages/rn-dev-agent-core/src/util/redact.ts
@@ -36,7 +36,7 @@ const PII_PATTERNS = [
 ];
 
 const AUTH_PATHS =
-  /\b(auth|authorization|session|token|accessToken|refreshToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
+  /\b(auth|authorization|session|token|accessToken|refreshToken|supervisorOverrideToken|credentials?|password|passwd|pwd|pass|secret|apiKey|api_key|cookie|set-cookie|clientSecret|client_secret)\b/i;
 
 const MAX_STRING_LENGTH = 2000;
 

--- a/packages/rn-dev-agent-core/test/fixtures/tool-registry.json
+++ b/packages/rn-dev-agent-core/test/fixtures/tool-registry.json
@@ -37,6 +37,7 @@
   "cdp_reload",
   "cdp_repair_action",
   "cdp_restart",
+  "cdp_login_prologue",
   "cdp_run_action",
   "cdp_run_e2e_suite",
   "cdp_set_shared_value",

--- a/packages/rn-dev-agent-core/test/integration/gh-575-diagnostic-contract.test.ts
+++ b/packages/rn-dev-agent-core/test/integration/gh-575-diagnostic-contract.test.ts
@@ -106,7 +106,7 @@ test(
           properties?: { action?: { enum?: string[] } };
         };
       }>;
-      assert.equal(tools.length, 80);
+      assert.equal(tools.length, 81);
       const proof = tools.find((tool) => tool.name === 'proof_capture');
       assert.ok(proof);
       assert.equal(proof.inputSchema.type, 'object');

--- a/packages/rn-dev-agent-core/test/integration/gh-575-plugin-health.test.ts
+++ b/packages/rn-dev-agent-core/test/integration/gh-575-plugin-health.test.ts
@@ -102,7 +102,7 @@ fi
       assert.equal(report.overall, 'healthy');
       assert.equal(report.materialization.status, 'EXACT_HEALTHY');
       assert.equal(report.mcpContractProbe.status, 'HEALTHY');
-      assert.equal(report.mcpContractProbe.toolCount, 80);
+      assert.equal(report.mcpContractProbe.toolCount, 81);
       assert.equal(report.directProofSchema.status, 'USABLE');
       assert.equal(existsSync(poisonMarker), false);
       assert.deepEqual(report.installation.matches, [

--- a/packages/rn-dev-agent-core/test/unit/audit-h1-redact-before-truncate.test.js
+++ b/packages/rn-dev-agent-core/test/unit/audit-h1-redact-before-truncate.test.js
@@ -40,3 +40,8 @@ test('H1: a long non-secret string is still truncated (ordering preserved)', () 
   assert.ok(out.blob.includes('[TRUNCATED:'), 'long benign strings still get a truncation marker');
   assert.ok(out.blob.length < 5000, 'output is clipped');
 });
+
+test('the supervisor override field is always redacted', () => {
+  const out = redact({ supervisorOverrideToken: 'supervisor-token-123456' });
+  assert.equal(out.supervisorOverrideToken, '[REDACTED:string]');
+});

--- a/packages/rn-dev-agent-core/test/unit/e2e-test-io.test.js
+++ b/packages/rn-dev-agent-core/test/unit/e2e-test-io.test.js
@@ -8,6 +8,8 @@ import {
   loadLockedTest,
   discoverLockedTests,
   hashBody,
+  resolveLockedTestIdentityIds,
+  serializeLockedTest,
 } from '../../dist/domain/e2e-test.js';
 
 const FLOW = 'appId: com.x\n---\n# id: login\n- launchApp\n';
@@ -41,6 +43,38 @@ test('discoverLockedTests lists .yaml ids sorted, ignores .yml; load null for mi
     writeFileSync(join(root, '.rn-agent', 'e2e', 'ccc.yml'), '# e2e-locked-test: true\n', 'utf8');
     assert.deepEqual(discoverLockedTests(root), ['aaa', 'bbb']);
     assert.equal(loadLockedTest(root, 'missing'), null);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('locked identity resolution rejects mismatched declared and source action ids', () => {
+  const root = mkdtempSync(join(tmpdir(), 'e2e-io-'));
+  try {
+    freezeLockedTest(root, { ...SRC, id: 'user-login', sourceActionId: 'other-login' }, CTX);
+    assert.deepEqual(resolveLockedTestIdentityIds(root, '^user-login$'), []);
+
+    const filePath = join(root, '.rn-agent', 'e2e', 'user-login.yaml');
+    writeFileSync(
+      filePath,
+      serializeLockedTest({
+        id: 'other-login',
+        intent: SRC.intent,
+        sourceActionId: 'user-login',
+        lockedAt: CTX.now().toISOString(),
+        lockedGitSha: CTX.gitSha,
+        sourceContentHash: hashBody(FLOW),
+        status: 'locked',
+        appId: SRC.appId,
+        flow: FLOW,
+      }),
+      'utf8',
+    );
+    assert.equal(loadLockedTest(root, 'user-login'), null);
+    assert.deepEqual(resolveLockedTestIdentityIds(root, '^user-login$'), []);
+
+    freezeLockedTest(root, { ...SRC, id: 'user-login', sourceActionId: 'user-login' }, CTX);
+    assert.deepEqual(resolveLockedTestIdentityIds(root, '^user-login$'), ['user-login']);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/rn-dev-agent-core/test/unit/e2e-test-io.test.js
+++ b/packages/rn-dev-agent-core/test/unit/e2e-test-io.test.js
@@ -8,7 +8,7 @@ import {
   loadLockedTest,
   discoverLockedTests,
   hashBody,
-  resolveLockedTestIdentityIds,
+  resolveLockedTestSelection,
   serializeLockedTest,
 } from '../../dist/domain/e2e-test.js';
 
@@ -52,7 +52,10 @@ test('locked identity resolution rejects mismatched declared and source action i
   const root = mkdtempSync(join(tmpdir(), 'e2e-io-'));
   try {
     freezeLockedTest(root, { ...SRC, id: 'user-login', sourceActionId: 'other-login' }, CTX);
-    assert.deepEqual(resolveLockedTestIdentityIds(root, '^user-login$'), []);
+    assert.deepEqual(resolveLockedTestSelection(root, '^user-login$'), {
+      ids: ['user-login'],
+      identitiesValid: false,
+    });
 
     const filePath = join(root, '.rn-agent', 'e2e', 'user-login.yaml');
     writeFileSync(
@@ -71,10 +74,22 @@ test('locked identity resolution rejects mismatched declared and source action i
       'utf8',
     );
     assert.equal(loadLockedTest(root, 'user-login'), null);
-    assert.deepEqual(resolveLockedTestIdentityIds(root, '^user-login$'), []);
+    assert.deepEqual(resolveLockedTestSelection(root, '^user-login$'), {
+      ids: ['user-login'],
+      identitiesValid: false,
+    });
 
     freezeLockedTest(root, { ...SRC, id: 'user-login', sourceActionId: 'user-login' }, CTX);
-    assert.deepEqual(resolveLockedTestIdentityIds(root, '^user-login$'), ['user-login']);
+    assert.deepEqual(resolveLockedTestSelection(root, '^user-login$'), {
+      ids: ['user-login'],
+      identitiesValid: true,
+    });
+
+    freezeLockedTest(root, { ...SRC, id: 'other-login', sourceActionId: 'wrong-login' }, CTX);
+    assert.deepEqual(resolveLockedTestSelection(root), {
+      ids: ['other-login', 'user-login'],
+      identitiesValid: false,
+    });
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/rn-dev-agent-core/test/unit/gh-584-inline-arbiter.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-584-inline-arbiter.test.ts
@@ -24,6 +24,45 @@ test('inline-capable tools receive lazy parking authority without static flow cl
   }
 });
 
+test('login prologue owns the flow plane for its entire replay', async () => {
+  const arbiter = new DeviceSessionArbiter(() => 20_000);
+  const noForeign = {
+    gate: { check: async () => ({ active: false, warning: null, scanMs: 0 }) },
+    getUdid: () => null,
+  };
+  let releaseReplay!: () => void;
+  const replayBlocked = new Promise<void>((resolve) => {
+    releaseReplay = resolve;
+  });
+  let replayStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    replayStarted = resolve;
+  });
+  const prologue = arbiterWrap(
+    'cdp_login_prologue',
+    async () => {
+      replayStarted();
+      await replayBlocked;
+      return { content: [{ type: 'text', text: '{"ok":true}' }] };
+    },
+    arbiter,
+    noForeign,
+  );
+  const running = prologue({});
+  await started;
+
+  const contender = arbiterWrap(
+    'device_press',
+    async () => ({ content: [{ type: 'text', text: '{"ok":true}' }] }),
+    arbiter,
+    noForeign,
+  );
+  assert.equal(body(await contender({})).code, 'BUSY_FLOW_ACTIVE');
+
+  releaseReplay();
+  assert.equal(body(await running).ok, true);
+});
+
 test('foreign automation refusal reuses the public sanitizer', async () => {
   const arbiter = new DeviceSessionArbiter(() => 20_000);
   const raw =

--- a/packages/rn-dev-agent-core/test/unit/lock-e2e-test.test.js
+++ b/packages/rn-dev-agent-core/test/unit/lock-e2e-test.test.js
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { lockE2eTestCore } from '../../dist/tools/lock-e2e-test.js';
+import { serializeLockedTest } from '../../dist/domain/e2e-test.js';
 
 function writeConfig(root, cfg) {
   const dir = join(root, '.rn-agent');
@@ -231,6 +232,50 @@ test('already locked → refused unless relock', async () => {
       ),
     );
     assert.equal(re.ok, true);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('malformed and mismatched locked files remain overwrite-protected', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'lock-'));
+  try {
+    seedAction(root, 'login');
+    const e2eDir = join(root, '.rn-agent', 'e2e');
+    const filePath = join(e2eDir, 'login.yaml');
+    mkdirSync(e2eDir, { recursive: true });
+    const existingFiles = [
+      'malformed locked test',
+      serializeLockedTest({
+        id: 'other-login',
+        intent: 'other login',
+        sourceActionId: 'other-login',
+        lockedAt: '2026-06-18T00:00:00.000Z',
+        lockedGitSha: 'sha1',
+        sourceContentHash: 'hash',
+        status: 'locked',
+        appId: 'com.x',
+        flow: 'appId: com.x\n---\n- launchApp\n',
+      }),
+    ];
+
+    for (const existing of existingFiles) {
+      writeFileSync(filePath, existing, 'utf8');
+      let maestroCalled = false;
+      const result = parse(
+        await lockE2eTestCore(
+          { actionId: 'login', projectRoot: root },
+          deps(async () => {
+            maestroCalled = true;
+            return okMaestro();
+          }),
+        ),
+      );
+
+      assert.equal(result.code, 'ALREADY_LOCKED');
+      assert.equal(maestroCalled, false);
+      assert.equal(readFileSync(filePath, 'utf8'), existing);
+    }
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
@@ -80,20 +80,32 @@ test('login prologue resolves the exact alias and requires a fresh passing RunRe
   }
 
   assert.deepEqual(
-    seenArgs.map(({ actionId, autoRepair, forceReload, proofReplay, blindProbeMode, trigger }) => ({
-      actionId,
-      autoRepair,
-      forceReload,
-      proofReplay,
-      blindProbeMode,
-      trigger,
-    })),
+    seenArgs.map(
+      ({
+        actionId,
+        autoRepair,
+        forceReload,
+        proofReplay,
+        blindProbeMode,
+        cdpFallbackMode,
+        trigger,
+      }) => ({
+        actionId,
+        autoRepair,
+        forceReload,
+        proofReplay,
+        blindProbeMode,
+        cdpFallbackMode,
+        trigger,
+      }),
+    ),
     [1, 2].map(() => ({
       actionId: 'user-login',
       autoRepair: false,
       forceReload: false,
       proofReplay: false,
       blindProbeMode: 'forbid',
+      cdpFallbackMode: 'forbid',
       trigger: 'agent',
     })),
   );

--- a/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
@@ -146,6 +146,34 @@ test('login prologue blocks when the exact user-login action is missing', async 
   assert.equal(dispatched, false);
 });
 
+test('login prologue rejects a filename and metadata id mismatch', async (t) => {
+  const project = createTmpProject();
+  t.after(() => project.cleanup());
+  project.seedAction(
+    'user-login',
+    fixtureYaml({ id: 'other-login', intent: 'wrong action identity' }),
+    null,
+  );
+  project.seedAction(
+    'decoy-login',
+    fixtureYaml({ id: 'user-login', intent: 'inventory identity decoy' }),
+    null,
+  );
+  let dispatched = false;
+  const handler = createLoginPrologueHandler({
+    now: deterministicClock(),
+    runAction: async () => {
+      dispatched = true;
+      return okResult({ passed: true });
+    },
+  });
+
+  const envelope = parse(await handler({ projectRoot: project.root }));
+  assert.equal(envelope.code, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(envelope.meta.loginPrologue.failure.code, 'LOGIN_ACTION_ID_MISMATCH');
+  assert.equal(dispatched, false);
+});
+
 for (const failure of [
   { name: 'runner drift', code: 'ENGINE_PIN_MISMATCH' },
   { name: 'selector failure', code: 'TESTID_NOT_FOUND' },

--- a/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
@@ -1,6 +1,12 @@
 import assert from 'node:assert/strict';
-import { writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { test } from 'node:test';
+import {
+  ACTION_LOGIN_HELPER,
+  evaluateLoginPrologueGuard,
+  LOGIN_PROLOGUE_BLOCKED,
+} from '../../dist/domain/login-prologue.js';
 import { createLoginPrologueHandler } from '../../dist/tools/login-prologue.js';
 import { createRunActionHandler } from '../../dist/tools/run-action.js';
 import { failResult, okResult } from '../../dist/utils.js';
@@ -66,6 +72,7 @@ test('login prologue resolves the exact alias and requires a fresh passing RunRe
     const envelope = parse(await handler({ projectRoot: project.root }));
     assert.equal(envelope.ok, true);
     assert.equal(envelope.data.state, 'passed');
+    assert.equal(envelope.data.role, ACTION_LOGIN_HELPER);
     assert.equal(envelope.data.actionId, 'user-login');
     assert.equal(envelope.data.runRecord.runId, expectedRunId);
     assert.deepEqual(
@@ -355,4 +362,82 @@ test('login prologue rejects transport success without a fresh passing RunRecord
   assert.equal(envelope.ok, false);
   assert.equal(envelope.code, 'LOGIN_PROLOGUE_BLOCKED');
   assert.equal(envelope.meta.loginPrologue.failure.code, 'AUTHORITATIVE_RUN_RECORD_MISSING');
+});
+
+function blockedBinding() {
+  return {
+    schemaVersion: 1,
+    state: LOGIN_PROLOGUE_BLOCKED,
+    role: ACTION_LOGIN_HELPER,
+    alias: 'user-login',
+    startedAt: '2026-08-21T10:00:00.000Z',
+    endedAt: '2026-08-21T10:00:00.100Z',
+    elapsedMs: 100,
+    steps: [],
+    inventory: { count: 1, actionIds: ['user-login'] },
+    failure: { code: 'ENGINE_PIN_MISMATCH', detail: 'runner drift' },
+  };
+}
+
+test('blocked helper still allows locked e2e proof without a supervisor override', () => {
+  const binding = blockedBinding();
+  for (const tool of ['cdp_lock_e2e_test', 'cdp_run_e2e_suite']) {
+    const decision = evaluateLoginPrologueGuard({
+      binding,
+      tool,
+      args: { actionId: 'user-login' },
+      mutation: true,
+    });
+    assert.deepEqual(decision, { allowed: true, override: false }, tool);
+  }
+});
+
+test('blocked helper still refuses credential and ad-hoc login mutations', () => {
+  const binding = blockedBinding();
+  for (const [tool, args] of [
+    ['device_fill', { text: 'secret' }],
+    ['cdp_evaluate', { expression: 'credential()' }],
+    ['cdp_interact', { action: 'press', testID: 'submit' }],
+    ['maestro_run', { yaml: '- tapOn: Login' }],
+  ]) {
+    const decision = evaluateLoginPrologueGuard({
+      binding,
+      tool,
+      args,
+      mutation: true,
+    });
+    assert.deepEqual(decision, { allowed: false, suppliedOverride: false }, tool);
+  }
+});
+
+test('login prologue does not freeze or rewrite locked e2e artifacts', async (t) => {
+  const project = createTmpProject();
+  t.after(() => project.cleanup());
+  seedLoginAction(project);
+  const e2eDir = join(project.root, '.rn-agent', 'e2e');
+  mkdirSync(e2eDir, { recursive: true });
+  const frozenPath = join(e2eDir, 'user-login.yaml');
+  writeFileSync(frozenPath, 'frozen-login-proof: true\n', 'utf8');
+  const handler = createLoginPrologueHandler({
+    now: deterministicClock(),
+    runAction: async () => {
+      appendRunRecordToSidecar(project.root, 'user-login', {
+        runId: 'login-run-helper',
+        timestamp: '2026-08-21T10:00:01.000Z',
+        durationMs: 125,
+        status: 'pass',
+        trigger: 'agent',
+      });
+      return okResult({
+        passed: true,
+        strictRunRecordId: 'login-run-helper',
+        transport: 'maestro',
+      });
+    },
+  });
+
+  const envelope = parse(await handler({ projectRoot: project.root }));
+  assert.equal(envelope.ok, true);
+  assert.equal(envelope.data.role, ACTION_LOGIN_HELPER);
+  assert.equal(readFileSync(frozenPath, 'utf8'), 'frozen-login-proof: true\n');
 });

--- a/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
@@ -99,6 +99,33 @@ test('login prologue resolves the exact alias and requires a fresh passing RunRe
   );
 });
 
+test('login prologue preserves non-enumerable replay authority', async (t) => {
+  const project = createTmpProject();
+  t.after(() => project.cleanup());
+  seedLoginAction(project);
+  const authority = Symbol('replay-authority');
+  const args = { projectRoot: project.root };
+  Object.defineProperty(args, authority, { value: 'retained' });
+  const handler = createLoginPrologueHandler({
+    now: deterministicClock(),
+    runAction: async (replayArgs) => {
+      assert.equal((replayArgs as Record<symbol, unknown>)[authority], 'retained');
+      appendRunRecordToSidecar(project.root, 'user-login', {
+        runId: 'login-run-authoritative',
+        timestamp: '2026-08-21T10:00:01.000Z',
+        durationMs: 125,
+        status: 'pass',
+        trigger: 'agent',
+      });
+      return okResult({ passed: true, transport: 'maestro' });
+    },
+  });
+
+  const envelope = parse(await handler(args));
+  assert.equal(envelope.ok, true);
+  assert.equal(envelope.data.runRecord.runId, 'login-run-authoritative');
+});
+
 test('login prologue blocks when the exact user-login action is missing', async (t) => {
   const project = createTmpProject();
   t.after(() => project.cleanup());

--- a/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createLoginPrologueHandler } from '../../dist/tools/login-prologue.js';
+import { failResult, okResult } from '../../dist/utils.js';
+import { appendRunRecordToSidecar } from '../helpers/action-state.ts';
+import { createTmpProject, fixtureYaml } from '../helpers/tmp-project.js';
+
+function parse(result: { content: Array<{ text?: string }> }) {
+  return JSON.parse(result.content[0]?.text ?? '{}');
+}
+
+function deterministicClock() {
+  let nowMs = Date.parse('2026-08-21T10:00:00.000Z');
+  return () => {
+    const value = new Date(nowMs);
+    nowMs += 10;
+    return value;
+  };
+}
+
+function seedLoginAction(project: ReturnType<typeof createTmpProject>) {
+  project.seedAction(
+    'user-login',
+    fixtureYaml({ id: 'user-login', intent: 'restore an authenticated fixture state' }),
+    null,
+  );
+}
+
+test('login prologue resolves the exact alias and requires a fresh passing RunRecord twice', async (t) => {
+  const project = createTmpProject();
+  t.after(() => project.cleanup());
+  seedLoginAction(project);
+  let runNumber = 0;
+  const seenArgs: Array<Record<string, unknown>> = [];
+  const handler = createLoginPrologueHandler({
+    now: deterministicClock(),
+    runAction: async (args) => {
+      runNumber += 1;
+      seenArgs.push({ ...args });
+      appendRunRecordToSidecar(project.root, 'user-login', {
+        runId: `login-run-${runNumber}`,
+        timestamp: `2026-08-21T10:00:0${runNumber}.000Z`,
+        durationMs: 125,
+        status: 'pass',
+        trigger: 'agent',
+        timing: {
+          startedAt: `2026-08-21T10:00:0${runNumber}.000Z`,
+          endedAt: `2026-08-21T10:00:0${runNumber}.125Z`,
+          elapsedMs: 125,
+          steps: [],
+        },
+      });
+      return okResult({
+        passed: true,
+        transport: 'maestro',
+        transportVersion: '1.0.9',
+        perStepReadback: { complete: true, steps: [] },
+      });
+    },
+  });
+
+  for (const expectedRunId of ['login-run-1', 'login-run-2']) {
+    const envelope = parse(await handler({ projectRoot: project.root }));
+    assert.equal(envelope.ok, true);
+    assert.equal(envelope.data.state, 'passed');
+    assert.equal(envelope.data.actionId, 'user-login');
+    assert.equal(envelope.data.runRecord.runId, expectedRunId);
+    assert.deepEqual(
+      envelope.data.steps.map((step: { name: string }) => step.name),
+      ['inventory', 'resolve', 'replay', 'verify-run-record'],
+    );
+    for (const step of envelope.data.steps) {
+      assert.equal(step.elapsedMs, Date.parse(step.endedAt) - Date.parse(step.startedAt));
+      assert.ok(step.elapsedMs >= 0);
+    }
+    assert.equal(
+      envelope.data.elapsedMs,
+      Date.parse(envelope.data.endedAt) - Date.parse(envelope.data.startedAt),
+    );
+  }
+
+  assert.deepEqual(
+    seenArgs.map(({ actionId, autoRepair, forceReload, proofReplay, blindProbeMode, trigger }) => ({
+      actionId,
+      autoRepair,
+      forceReload,
+      proofReplay,
+      blindProbeMode,
+      trigger,
+    })),
+    [1, 2].map(() => ({
+      actionId: 'user-login',
+      autoRepair: false,
+      forceReload: false,
+      proofReplay: false,
+      blindProbeMode: 'forbid',
+      trigger: 'agent',
+    })),
+  );
+});
+
+test('login prologue blocks when the exact user-login action is missing', async (t) => {
+  const project = createTmpProject();
+  t.after(() => project.cleanup());
+  project.seedAction('similar-login', fixtureYaml({ id: 'similar-login', tags: ['auth'] }), null);
+  let dispatched = false;
+  const handler = createLoginPrologueHandler({
+    now: deterministicClock(),
+    runAction: async () => {
+      dispatched = true;
+      return okResult({ passed: true });
+    },
+  });
+
+  const envelope = parse(await handler({ projectRoot: project.root }));
+  assert.equal(envelope.ok, false);
+  assert.equal(envelope.code, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(envelope.meta.loginPrologue.failure.code, 'LOGIN_ACTION_MISSING');
+  assert.equal(dispatched, false);
+});
+
+for (const failure of [
+  { name: 'runner drift', code: 'ENGINE_PIN_MISMATCH' },
+  { name: 'selector failure', code: 'TESTID_NOT_FOUND' },
+  { name: 'timeout', code: 'RECONNECT_TIMEOUT' },
+]) {
+  test(`login prologue terminally blocks on ${failure.name}`, async (t) => {
+    const project = createTmpProject();
+    t.after(() => project.cleanup());
+    seedLoginAction(project);
+    const handler = createLoginPrologueHandler({
+      now: deterministicClock(),
+      runAction: async (args) => {
+        appendRunRecordToSidecar(project.root, 'user-login', {
+          runId: `failed-${failure.code}`,
+          timestamp: '2026-08-21T10:00:01.000Z',
+          durationMs: 25,
+          status: 'fail',
+          failureCode: failure.code === 'TESTID_NOT_FOUND' ? 'SELECTOR_NOT_FOUND' : 'TIMEOUT',
+          trigger: args.trigger ?? 'agent',
+        });
+        return failResult(`injected ${failure.name}`, failure.code as 'ENGINE_PIN_MISMATCH');
+      },
+    });
+
+    const envelope = parse(await handler({ projectRoot: project.root }));
+    assert.equal(envelope.ok, false);
+    assert.equal(envelope.code, 'LOGIN_PROLOGUE_BLOCKED');
+    assert.equal(envelope.meta.loginPrologue.state, 'LOGIN_PROLOGUE_BLOCKED');
+    assert.equal(envelope.meta.loginPrologue.failure.code, failure.code);
+    assert.equal(envelope.meta.loginPrologue.runRecord.status, 'fail');
+    assert.ok(envelope.meta.loginPrologue.elapsedMs < 1_000);
+  });
+}
+
+test('login prologue rejects transport success without a fresh passing RunRecord', async (t) => {
+  const project = createTmpProject();
+  t.after(() => project.cleanup());
+  seedLoginAction(project);
+  const handler = createLoginPrologueHandler({
+    now: deterministicClock(),
+    runAction: async () => okResult({ passed: true, transport: 'maestro' }),
+  });
+
+  const envelope = parse(await handler({ projectRoot: project.root }));
+  assert.equal(envelope.ok, false);
+  assert.equal(envelope.code, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(envelope.meta.loginPrologue.failure.code, 'AUTHORITATIVE_RUN_RECORD_MISSING');
+});

--- a/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
@@ -383,13 +383,14 @@ test('blocked helper still allows locked e2e proof without a supervisor override
   const binding = blockedBinding();
   for (const [tool, args] of [
     ['cdp_lock_e2e_test', { actionId: 'user-login' }],
-    ['cdp_run_e2e_suite', { pattern: '^user-login$' }],
+    ['cdp_run_e2e_suite', { pattern: '.*' }],
   ] as const) {
     const decision = evaluateLoginPrologueGuard({
       binding,
       tool,
       args,
       mutation: true,
+      ...(tool === 'cdp_run_e2e_suite' ? { resolvedLockedTestIds: ['user-login'] } : {}),
     });
     assert.deepEqual(decision, { allowed: true, override: false }, tool);
   }
@@ -410,6 +411,25 @@ test('blocked helper refuses locked e2e requests outside the exact login candida
       mutation: true,
     });
     assert.deepEqual(decision, { allowed: false, suppliedOverride: false }, tool);
+  }
+});
+
+test('blocked helper requires case-sensitive exact resolved locked e2e ids', () => {
+  const binding = blockedBinding();
+  for (const resolvedLockedTestIds of [
+    [],
+    ['USER-LOGIN'],
+    ['user-login', 'USER-LOGIN'],
+    ['user-login', 'other-login'],
+  ]) {
+    const decision = evaluateLoginPrologueGuard({
+      binding,
+      tool: 'cdp_run_e2e_suite',
+      args: { pattern: '^user-login$' },
+      mutation: true,
+      resolvedLockedTestIds,
+    });
+    assert.deepEqual(decision, { allowed: false, suppliedOverride: false });
   }
 });
 

--- a/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
@@ -8,10 +8,13 @@ import {
   LOGIN_PROLOGUE_BLOCKED,
 } from '../../dist/domain/login-prologue.js';
 import { createLoginPrologueHandler } from '../../dist/tools/login-prologue.js';
-import { createRunActionHandler } from '../../dist/tools/run-action.js';
 import { failResult, okResult } from '../../dist/utils.js';
 import { appendRunRecordToSidecar } from '../helpers/action-state.ts';
-import { createTmpProject, fixtureYaml } from '../helpers/tmp-project.js';
+import {
+  createPinnedRunActionHandler,
+  createTmpProject,
+  fixtureYaml,
+} from '../helpers/tmp-project.js';
 
 function parse(result: { content: Array<{ text?: string }> }) {
   return JSON.parse(result.content[0]?.text ?? '{}');
@@ -145,7 +148,7 @@ test('login prologue seals selector replay against every CDP fallback', async (t
   t.after(() => project.cleanup());
   seedLoginAction(project);
   let replayDepsCalled = false;
-  const runAction = createRunActionHandler({
+  const runAction = createPinnedRunActionHandler({
     maestroRun: async () => ({
       content: [
         {
@@ -187,7 +190,7 @@ test('login prologue rejects a passing result from a divergent runner pin', asyn
   const project = createTmpProject();
   t.after(() => project.cleanup());
   seedLoginAction(project);
-  const runAction = createRunActionHandler({
+  const runAction = createPinnedRunActionHandler({
     maestroRun: async () =>
       okResult({
         passed: true,
@@ -236,7 +239,7 @@ test('strict replay refuses success when RunRecord persistence is not committed'
   const project = createTmpProject();
   t.after(() => project.cleanup());
   seedLoginAction(project);
-  const runAction = createRunActionHandler({
+  const runAction = createPinnedRunActionHandler({
     maestroRun: async () => {
       writeFileSync(project.sidecarPath('user-login'), '{invalid-sidecar', 'utf8');
       return okResult({ passed: true, transport: 'maestro-runner' });

--- a/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { writeFileSync } from 'node:fs';
 import { test } from 'node:test';
 import { createLoginPrologueHandler } from '../../dist/tools/login-prologue.js';
 import { createRunActionHandler } from '../../dist/tools/run-action.js';
@@ -53,6 +54,7 @@ test('login prologue resolves the exact alias and requires a fresh passing RunRe
       });
       return okResult({
         passed: true,
+        strictRunRecordId: `login-run-${runNumber}`,
         transport: 'maestro',
         transportVersion: '1.0.9',
         perStepReadback: { complete: true, steps: [] },
@@ -118,7 +120,11 @@ test('login prologue preserves non-enumerable replay authority', async (t) => {
         status: 'pass',
         trigger: 'agent',
       });
-      return okResult({ passed: true, transport: 'maestro' });
+      return okResult({
+        passed: true,
+        strictRunRecordId: 'login-run-authoritative',
+        transport: 'maestro',
+      });
     },
   });
 
@@ -168,6 +174,88 @@ test('login prologue seals selector replay against every CDP fallback', async (t
   assert.equal(envelope.code, 'LOGIN_PROLOGUE_BLOCKED');
   assert.equal(envelope.meta.loginPrologue.failure.code, 'TESTID_NOT_FOUND');
   assert.equal(replayDepsCalled, false);
+});
+
+test('login prologue rejects a passing result from a divergent runner pin', async (t) => {
+  const project = createTmpProject();
+  t.after(() => project.cleanup());
+  seedLoginAction(project);
+  const runAction = createRunActionHandler({
+    maestroRun: async () =>
+      okResult({
+        passed: true,
+        enginePin: { pinned: '1.0.9', status: 'checksum-mismatch' },
+        transport: 'maestro-runner',
+      }),
+  });
+  const handler = createLoginPrologueHandler({ now: deterministicClock(), runAction });
+
+  const envelope = parse(await handler({ projectRoot: project.root }));
+
+  assert.equal(envelope.code, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(envelope.meta.loginPrologue.failure.code, 'ENGINE_PIN_MISMATCH');
+  assert.equal(project.readSidecar('user-login').runHistory.at(-1).status, 'fail');
+});
+
+test('login prologue requires the strict executor persisted run identity', async (t) => {
+  const project = createTmpProject();
+  t.after(() => project.cleanup());
+  seedLoginAction(project);
+  const handler = createLoginPrologueHandler({
+    now: deterministicClock(),
+    runAction: async () => {
+      appendRunRecordToSidecar(project.root, 'user-login', {
+        runId: 'concurrent-login-run',
+        timestamp: '2026-08-21T10:00:01.000Z',
+        durationMs: 125,
+        status: 'pass',
+        trigger: 'agent',
+      });
+      return okResult({
+        passed: true,
+        strictRunRecordId: 'uncommitted-attempt-run',
+        transport: 'maestro',
+      });
+    },
+  });
+
+  const envelope = parse(await handler({ projectRoot: project.root }));
+
+  assert.equal(envelope.code, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(envelope.meta.loginPrologue.failure.code, 'AUTHORITATIVE_RUN_RECORD_MISSING');
+});
+
+test('strict replay refuses success when RunRecord persistence is not committed', async (t) => {
+  const project = createTmpProject();
+  t.after(() => project.cleanup());
+  seedLoginAction(project);
+  const runAction = createRunActionHandler({
+    maestroRun: async () => {
+      writeFileSync(project.sidecarPath('user-login'), '{invalid-sidecar', 'utf8');
+      return okResult({ passed: true, transport: 'maestro-runner' });
+    },
+  });
+  const handler = createLoginPrologueHandler({ now: deterministicClock(), runAction });
+
+  const envelope = parse(await handler({ projectRoot: project.root }));
+
+  assert.equal(envelope.code, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(envelope.meta.loginPrologue.failure.code, 'LOAD_FAILED');
+});
+
+test('login prologue preserves timeout classification from replay metadata', async (t) => {
+  const project = createTmpProject();
+  t.after(() => project.cleanup());
+  seedLoginAction(project);
+  const handler = createLoginPrologueHandler({
+    now: deterministicClock(),
+    runAction: async () => failResult('timed out', { failureKind: 'TIMEOUT' }),
+  });
+
+  const envelope = parse(await handler({ projectRoot: project.root }));
+
+  assert.equal(envelope.code, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(envelope.meta.loginPrologue.failure.code, 'TIMEOUT');
 });
 
 test('login prologue blocks when the exact user-login action is missing', async (t) => {
@@ -238,7 +326,9 @@ for (const failure of [
           failureCode: failure.code === 'TESTID_NOT_FOUND' ? 'SELECTOR_NOT_FOUND' : 'TIMEOUT',
           trigger: args.trigger ?? 'agent',
         });
-        return failResult(`injected ${failure.name}`, failure.code as 'ENGINE_PIN_MISMATCH');
+        return failResult(`injected ${failure.name}`, failure.code as 'ENGINE_PIN_MISMATCH', {
+          strictRunRecordId: `failed-${failure.code}`,
+        });
       },
     });
 

--- a/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
@@ -381,14 +381,35 @@ function blockedBinding() {
 
 test('blocked helper still allows locked e2e proof without a supervisor override', () => {
   const binding = blockedBinding();
-  for (const tool of ['cdp_lock_e2e_test', 'cdp_run_e2e_suite']) {
+  for (const [tool, args] of [
+    ['cdp_lock_e2e_test', { actionId: 'user-login' }],
+    ['cdp_run_e2e_suite', { pattern: '^user-login$' }],
+  ] as const) {
     const decision = evaluateLoginPrologueGuard({
       binding,
       tool,
-      args: { actionId: 'user-login' },
+      args,
       mutation: true,
     });
     assert.deepEqual(decision, { allowed: true, override: false }, tool);
+  }
+});
+
+test('blocked helper refuses locked e2e requests outside the exact login candidate', () => {
+  const binding = blockedBinding();
+  for (const [tool, args] of [
+    ['cdp_lock_e2e_test', { actionId: 'other-login' }],
+    ['cdp_run_e2e_suite', {}],
+    ['cdp_run_e2e_suite', { pattern: 'user-login' }],
+    ['cdp_run_e2e_suite', { pattern: '^user-login$|^other-login$' }],
+  ] as const) {
+    const decision = evaluateLoginPrologueGuard({
+      binding,
+      tool,
+      args,
+      mutation: true,
+    });
+    assert.deepEqual(decision, { allowed: false, suppliedOverride: false }, tool);
   }
 });
 

--- a/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/login-prologue.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { createLoginPrologueHandler } from '../../dist/tools/login-prologue.js';
+import { createRunActionHandler } from '../../dist/tools/run-action.js';
 import { failResult, okResult } from '../../dist/utils.js';
 import { appendRunRecordToSidecar } from '../helpers/action-state.ts';
 import { createTmpProject, fixtureYaml } from '../helpers/tmp-project.js';
@@ -80,32 +81,20 @@ test('login prologue resolves the exact alias and requires a fresh passing RunRe
   }
 
   assert.deepEqual(
-    seenArgs.map(
-      ({
-        actionId,
-        autoRepair,
-        forceReload,
-        proofReplay,
-        blindProbeMode,
-        cdpFallbackMode,
-        trigger,
-      }) => ({
-        actionId,
-        autoRepair,
-        forceReload,
-        proofReplay,
-        blindProbeMode,
-        cdpFallbackMode,
-        trigger,
-      }),
-    ),
+    seenArgs.map(({ actionId, autoRepair, forceReload, proofReplay, blindProbeMode, trigger }) => ({
+      actionId,
+      autoRepair,
+      forceReload,
+      proofReplay,
+      blindProbeMode,
+      trigger,
+    })),
     [1, 2].map(() => ({
       actionId: 'user-login',
       autoRepair: false,
       forceReload: false,
       proofReplay: false,
       blindProbeMode: 'forbid',
-      cdpFallbackMode: 'forbid',
       trigger: 'agent',
     })),
   );
@@ -136,6 +125,49 @@ test('login prologue preserves non-enumerable replay authority', async (t) => {
   const envelope = parse(await handler(args));
   assert.equal(envelope.ok, true);
   assert.equal(envelope.data.runRecord.runId, 'login-run-authoritative');
+});
+
+test('login prologue seals selector replay against every CDP fallback', async (t) => {
+  const project = createTmpProject();
+  t.after(() => project.cleanup());
+  seedLoginAction(project);
+  let replayDepsCalled = false;
+  const runAction = createRunActionHandler({
+    maestroRun: async () => ({
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            ok: false,
+            data: {
+              passed: false,
+              output: "Element with id 'fab-create-task' not found",
+              flowFile: 'user-login.yaml',
+              platform: 'ios',
+            },
+          }),
+        },
+      ],
+      isError: true,
+    }),
+    replayDeps: () => {
+      replayDepsCalled = true;
+      return {
+        treeFor: async () => ({ testID: 'fab-create-task', children: [] }),
+        pressByTestId: async () => {},
+        typeByTestId: async () => {},
+        launchApp: async () => {},
+        settle: async () => {},
+      };
+    },
+  });
+  const handler = createLoginPrologueHandler({ now: deterministicClock(), runAction });
+
+  const envelope = parse(await handler({ projectRoot: project.root }));
+
+  assert.equal(envelope.code, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(envelope.meta.loginPrologue.failure.code, 'TESTID_NOT_FOUND');
+  assert.equal(replayDepsCalled, false);
 });
 
 test('login prologue blocks when the exact user-login action is missing', async (t) => {

--- a/packages/rn-dev-agent-core/test/unit/run-action-handler.test.js
+++ b/packages/rn-dev-agent-core/test/unit/run-action-handler.test.js
@@ -172,6 +172,19 @@ test('run-action: first-attempt pass appends RunRecord with no auto-repair', asy
   assert.equal(sidecar.runHistory[0].autoRepair?.attempted, false);
   assert.equal(sidecar.runHistory[0].autoRepair?.outcome, 'skipped');
   assert.equal(typeof sidecar.runHistory[0].autoRepair?.phases?.firstAttemptMs, 'number');
+  assert.equal(typeof sidecar.runHistory[0].runId, 'string');
+  assert.equal(sidecar.runHistory[0].timing.steps.length, 1);
+  assert.equal(sidecar.runHistory[0].timing.steps[0].name, 'maestro-first-attempt');
+  assert.equal(
+    sidecar.runHistory[0].timing.elapsedMs,
+    Date.parse(sidecar.runHistory[0].timing.endedAt) -
+      Date.parse(sidecar.runHistory[0].timing.startedAt),
+  );
+  assert.equal(
+    sidecar.runHistory[0].timing.steps[0].elapsedMs,
+    Date.parse(sidecar.runHistory[0].timing.steps[0].endedAt) -
+      Date.parse(sidecar.runHistory[0].timing.steps[0].startedAt),
+  );
 });
 
 test('run-action: proofReplay pass on an experimental action discloses no lifecycle-promotion write', async () => {

--- a/packages/rn-dev-agent-core/test/unit/run-action-transport-blind.test.js
+++ b/packages/rn-dev-agent-core/test/unit/run-action-transport-blind.test.js
@@ -12,6 +12,7 @@ import {
   createPinnedRunActionHandler as createRunActionHandler,
   createTmpProject,
 } from '../helpers/tmp-project.js';
+import { sealStrictRunAction } from '../../dist/tools/run-action.js';
 
 let project;
 
@@ -306,12 +307,13 @@ test('strict replay blocks selector failure without reactive CDP fallback', asyn
     },
   });
 
-  const result = await handler({
-    actionId: 'demo',
-    projectRoot: project.root,
-    autoRepair: false,
-    cdpFallbackMode: 'forbid',
-  });
+  const result = await handler(
+    sealStrictRunAction({
+      actionId: 'demo',
+      projectRoot: project.root,
+      autoRepair: false,
+    }),
+  );
   const env = JSON.parse(result.content[0].text);
 
   assert.equal(env.code, 'TESTID_NOT_FOUND');

--- a/packages/rn-dev-agent-core/test/unit/run-action-transport-blind.test.js
+++ b/packages/rn-dev-agent-core/test/unit/run-action-transport-blind.test.js
@@ -289,6 +289,36 @@ test('typed runner refusal cannot be laundered through CDP fallback', async () =
   assert.equal(project.readSidecar('demo').runHistory[0].status, 'fail');
 });
 
+test('strict replay blocks selector failure without reactive CDP fallback', async () => {
+  project.seedAction('demo', replayFixtureYaml({ id: 'demo', selector: 'fab-create-task' }));
+  let replayDepsCalled = false;
+  const handler = createRunActionHandler({
+    maestroRun: fakeMaestroRun([FAIL_SELECTOR_ENV]),
+    replayDeps: () => {
+      replayDepsCalled = true;
+      return {
+        treeFor: async () => ({ testID: 'fab-create-task', children: [] }),
+        pressByTestId: async () => {},
+        typeByTestId: async () => {},
+        launchApp: async () => {},
+        settle: async () => {},
+      };
+    },
+  });
+
+  const result = await handler({
+    actionId: 'demo',
+    projectRoot: project.root,
+    autoRepair: false,
+    cdpFallbackMode: 'forbid',
+  });
+  const env = JSON.parse(result.content[0].text);
+
+  assert.equal(env.code, 'TESTID_NOT_FOUND');
+  assert.equal(replayDepsCalled, false);
+  assert.equal(project.readSidecar('demo').runHistory[0].status, 'fail');
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Test 4: a normal Maestro PASS exposes transport/readback but keeps legacy sidecar encoding
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/rn-dev-agent-core/test/unit/run-action-transport-blind.test.js
+++ b/packages/rn-dev-agent-core/test/unit/run-action-transport-blind.test.js
@@ -258,6 +258,37 @@ test('GH #317: UNKNOWN failure + first testID present → CDP/JS fallback fires;
   assert.equal(sidecar.runHistory[0].transport, 'cdp-js');
 });
 
+test('typed runner refusal cannot be laundered through CDP fallback', async () => {
+  project.seedAction('demo', replayFixtureYaml({ id: 'demo', selector: 'fab-create-task' }));
+  let replayDepsCalled = false;
+  const handler = createRunActionHandler({
+    maestroRun: fakeMaestroRun([
+      {
+        ok: false,
+        code: 'ENGINE_PIN_MISMATCH',
+        error: 'Pinned Maestro engine checksum does not match',
+      },
+    ]),
+    replayDeps: () => {
+      replayDepsCalled = true;
+      return {
+        treeFor: async () => ({ testID: 'fab-create-task', children: [] }),
+        pressByTestId: async () => {},
+        typeByTestId: async () => {},
+        launchApp: async () => {},
+        settle: async () => {},
+      };
+    },
+  });
+
+  const result = await handler({ actionId: 'demo', projectRoot: project.root });
+  const env = JSON.parse(result.content[0].text);
+
+  assert.equal(env.code, 'ENGINE_PIN_MISMATCH');
+  assert.equal(replayDepsCalled, false);
+  assert.equal(project.readSidecar('demo').runHistory[0].status, 'fail');
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Test 4: a normal Maestro PASS exposes transport/readback but keeps legacy sidecar encoding
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
@@ -6,6 +6,7 @@ import {
   completeManagedNativeOriginAuthority,
   claimOptionalBundleAuthority,
   createAuthorityGate,
+  reissueManagedInstallAuthority,
   relaunchManagedNativeOriginApp,
   reproveManagedNativeOrigin,
 } from '../../../dist/session/authority-gate.js';
@@ -1682,6 +1683,54 @@ test('bind_device can replace iOS authority with an exact Android device', async
   assert.equal(envelope.ok, true);
   assert.equal(dispatched?.platform, 'android');
   assert.equal(dispatched?.deviceId, 'emulator-5554');
+});
+
+test('accepted residual risk preserves a passing login helper across device and install replacement', async () => {
+  const passingLogin = loginOutcome('passed');
+
+  {
+    const { runtime, status } = fixture();
+    status.bindings.loginPrologue = structuredClone(passingLogin);
+    const gate = createAuthorityGate(runtime, {
+      probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
+    });
+
+    const result = await gate.wrap('rn_session', async (args) => {
+      status.bindings.device = {
+        platform: args.platform,
+        deviceId: args.deviceId,
+        appId: args.appId,
+      };
+      status.authorityVersion += 1;
+      return okResult({ rebound: true });
+    })({
+      action: 'bind_device',
+      platform: 'android',
+      deviceId: 'emulator-5554',
+      appId: 'dev.example',
+    });
+
+    assert.equal(JSON.parse(result.content[0].text).ok, true);
+    assert.deepEqual(status.bindings.loginPrologue, passingLogin);
+  }
+
+  {
+    const { runtime, status } = fixture();
+    status.bindings.loginPrologue = structuredClone(passingLogin);
+    const gate = createAuthorityGate(runtime, {
+      probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
+      reissueInstallBinding: (install) => ({ ...install, digest: 'install-reissued' }),
+    });
+
+    const result = await gate.wrap('maestro_run', async (args) => {
+      await reissueManagedInstallAuthority(args);
+      return okResult({ passed: true });
+    })({ platform: 'ios', deviceId: 'device', appId: 'dev.example' });
+
+    assert.equal(JSON.parse(result.content[0].text).ok, true);
+    assert.equal(status.bindings.install.digest, 'install-reissued');
+    assert.deepEqual(status.bindings.loginPrologue, passingLogin);
+  }
 });
 
 test('raw native control isolates the exact session and refuses a foreign device before mutation', async () => {

--- a/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
@@ -2723,7 +2723,26 @@ test('a passing login prologue remains blocked when postflight authority drifts'
 
   assert.equal(envelope.code, 'AUTHORITY_LOST_DURING_OPERATION');
   assert.equal(status.bindings.loginPrologue.state, 'LOGIN_PROLOGUE_BLOCKED');
-  assert.equal(status.bindings.loginPrologue.failure.code, 'RECONNECT_TIMEOUT');
+  assert.equal(status.bindings.loginPrologue.failure.code, 'LOGIN_PROLOGUE_IN_PROGRESS');
+});
+
+test('a login prologue transaction blocks before dispatch and stays blocked on throw', async () => {
+  const { runtime, status } = fixture();
+  status.bindings.loginPrologue = loginOutcome('passed');
+  const gate = createAuthorityGate(runtime, {
+    probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
+  });
+
+  const result = await gate.wrap('cdp_login_prologue', async () => {
+    assert.equal(status.bindings.loginPrologue.state, 'LOGIN_PROLOGUE_BLOCKED');
+    assert.equal(status.bindings.loginPrologue.failure.code, 'LOGIN_PROLOGUE_IN_PROGRESS');
+    throw new Error('replay crashed');
+  })({});
+  const envelope = JSON.parse(result.content[0].text);
+
+  assert.equal(envelope.ok, false);
+  assert.equal(status.bindings.loginPrologue.state, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(status.bindings.loginPrologue.failure.code, 'LOGIN_PROLOGUE_IN_PROGRESS');
 });
 
 test('a supervisor token authorizes one blocked mutation and records a redacted audit', async () => {
@@ -2814,6 +2833,63 @@ test('concurrent supervisor overrides cannot dispatch without a retained audit',
   assert.equal(envelopes.filter(({ ok }) => ok === true).length, 1);
   assert.equal(dispatchCount, 1);
   assert.equal(status.bindings.loginPrologue.overrides.length, 1);
+});
+
+test('blocked transition overrides are rejected while cleanup exits remain available', async () => {
+  const expectedToken = 'supervisor-token-123456';
+  for (const [tool, args] of [
+    ['observe', { action: 'start' }],
+    ['device_snapshot', { action: 'open' }],
+    ['proof_capture', { action: 'begin_rehearsal', runId: 'proof-new' }],
+    ['rn_session', { action: 'bind_source', projectRoot: process.cwd() }],
+    ['cdp_connect', {}],
+  ]) {
+    const { runtime, status } = fixture();
+    status.bindings.loginPrologue = loginOutcome('LOGIN_PROLOGUE_BLOCKED', {
+      code: 'TESTID_NOT_FOUND',
+      detail: 'selector drift',
+    });
+    let dispatched = false;
+    const gate = createAuthorityGate(runtime, {
+      probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
+      loginSupervisorOverrideToken: () => expectedToken,
+    });
+
+    const result = await gate.wrap(tool, async () => {
+      dispatched = true;
+      return okResult({});
+    })({ ...args, supervisorOverrideToken: expectedToken });
+    const envelope = JSON.parse(result.content[0].text);
+
+    assert.equal(envelope.code, 'LOGIN_PROLOGUE_BLOCKED', tool);
+    assert.equal(envelope.meta.transitionOverrideRejected, true, tool);
+    assert.equal(dispatched, false, tool);
+    assert.equal(status.bindings.loginPrologue.overrides, undefined, tool);
+  }
+
+  for (const [tool, args] of [
+    ['observe', { action: 'stop' }],
+    ['device_snapshot', { action: 'close' }],
+    ['cdp_disconnect', {}],
+    ['rn_session', { action: 'release' }],
+  ]) {
+    const { runtime, status } = fixture();
+    status.bindings.loginPrologue = loginOutcome('LOGIN_PROLOGUE_BLOCKED', {
+      code: 'TESTID_NOT_FOUND',
+      detail: 'selector drift',
+    });
+    const gate = createAuthorityGate(runtime, {
+      probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
+      loginSupervisorOverrideToken: () => expectedToken,
+    });
+
+    const result = await gate.wrap(tool, async () => {
+      return failResult('cleanup reached', 'START_FAILED');
+    })(args);
+    const envelope = JSON.parse(result.content[0].text);
+
+    assert.notEqual(envelope.code, 'LOGIN_PROLOGUE_BLOCKED', tool);
+  }
 });
 
 test('rerunning the exact login prologue discharges the terminal gate after a passing result', async () => {

--- a/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
@@ -120,6 +120,21 @@ function fixture() {
   return { calls, registry, runtime, status };
 }
 
+function loginOutcome(state, failure) {
+  return {
+    schemaVersion: 1,
+    state,
+    alias: 'user-login',
+    actionId: 'user-login',
+    startedAt: '2026-08-21T10:00:00.000Z',
+    endedAt: '2026-08-21T10:00:00.100Z',
+    elapsedMs: 100,
+    steps: [],
+    inventory: { count: 1, actionIds: ['user-login'] },
+    ...(failure ? { failure } : {}),
+  };
+}
+
 test('authoritative tools receive preflight/postflight receipts and an immediate CAS', async () => {
   const { calls, runtime } = fixture();
   const gate = createAuthorityGate(runtime, {
@@ -2606,4 +2621,114 @@ test('iOS hard reset returns a typed failure for conflicting session arguments',
 
   assert.equal(envelope.ok, false);
   assert.equal(envelope.code, 'DEVICE_AUTHORITY_MISMATCH');
+});
+
+test('a failed login prologue becomes a durable terminal mutation gate', async () => {
+  const { runtime, status } = fixture();
+  const blocked = loginOutcome('LOGIN_PROLOGUE_BLOCKED', {
+    code: 'ENGINE_PIN_MISMATCH',
+    detail: 'runner drift',
+  });
+  const gate = createAuthorityGate(runtime, {
+    probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
+  });
+
+  const prologueResult = await gate.wrap('cdp_login_prologue', async () =>
+    failResult('blocked', 'LOGIN_PROLOGUE_BLOCKED', { loginPrologue: blocked }),
+  )({});
+  assert.equal(JSON.parse(prologueResult.content[0].text).code, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(status.bindings.loginPrologue.state, 'LOGIN_PROLOGUE_BLOCKED');
+
+  for (const [tool, args] of [
+    ['cdp_evaluate', { expression: 'credential()' }],
+    ['cdp_interact', { action: 'press', testID: 'submit' }],
+    ['device_fill', { text: 'secret' }],
+    ['maestro_run', { yaml: '- tapOn: Login' }],
+    ['cdp_navigate', { route: 'Story' }],
+    ['cdp_mmkv', { action: 'set', key: 'auth', value: 'token' }],
+  ]) {
+    let dispatched = false;
+    const result = await gate.wrap(tool, async () => {
+      dispatched = true;
+      return okResult({});
+    })(args);
+    const envelope = JSON.parse(result.content[0].text);
+    assert.equal(envelope.code, 'LOGIN_PROLOGUE_BLOCKED', `${tool} must be blocked`);
+    assert.equal(dispatched, false, `${tool} must not dispatch`);
+  }
+
+  let readDispatched = false;
+  const readResult = await gate.wrap('cdp_component_tree', async () => {
+    readDispatched = true;
+    return okResult({ tree: [] });
+  })({});
+  assert.equal(JSON.parse(readResult.content[0].text).ok, true);
+  assert.equal(readDispatched, true);
+});
+
+test('a supervisor token authorizes one blocked mutation and records a redacted audit', async () => {
+  const { runtime, status } = fixture();
+  status.bindings.loginPrologue = loginOutcome('LOGIN_PROLOGUE_BLOCKED', {
+    code: 'TESTID_NOT_FOUND',
+    detail: 'selector drift',
+  });
+  const expectedToken = 'supervisor-token-123456';
+  const gate = createAuthorityGate(runtime, {
+    probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
+    loginSupervisorOverrideToken: () => expectedToken,
+  });
+
+  let invalidDispatched = false;
+  const invalid = await gate.wrap('cdp_evaluate', async () => {
+    invalidDispatched = true;
+    return okResult({});
+  })({ expression: 'mutate()', supervisorOverrideToken: 'incorrect-token-1234' });
+  assert.equal(JSON.parse(invalid.content[0].text).code, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(invalidDispatched, false);
+
+  let handlerArgs;
+  const allowed = await gate.wrap('cdp_evaluate', async (args) => {
+    handlerArgs = args;
+    return okResult({ allowed: true });
+  })({ expression: 'mutate()', supervisorOverrideToken: expectedToken });
+  assert.equal(JSON.parse(allowed.content[0].text).ok, true);
+  assert.equal(handlerArgs.supervisorOverrideToken, undefined);
+  assert.deepEqual(
+    status.bindings.loginPrologue.overrides.map(({ tool }) => tool),
+    ['cdp_evaluate'],
+  );
+  assert.equal(JSON.stringify(status.bindings.loginPrologue).includes(expectedToken), false);
+});
+
+test('rerunning the exact login prologue discharges the terminal gate after a passing result', async () => {
+  const { runtime, status } = fixture();
+  status.bindings.loginPrologue = loginOutcome('LOGIN_PROLOGUE_BLOCKED', {
+    code: 'RECONNECT_TIMEOUT',
+    detail: 'timeout',
+  });
+  const passed = {
+    ...loginOutcome('passed'),
+    runRecord: {
+      runId: 'fresh-login-run',
+      timestamp: '2026-08-21T10:00:00.100Z',
+      durationMs: 100,
+      status: 'pass',
+      trigger: 'agent',
+    },
+  };
+  const gate = createAuthorityGate(runtime, {
+    probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
+  });
+
+  const prologueResult = await gate.wrap('cdp_login_prologue', async () => okResult(passed))({});
+  assert.equal(JSON.parse(prologueResult.content[0].text).ok, true);
+  assert.equal(status.bindings.loginPrologue.state, 'passed');
+
+  let dispatched = false;
+  const mutationResult = await gate.wrap('cdp_evaluate', async () => {
+    dispatched = true;
+    return okResult({ allowed: true });
+  })({ expression: 'continueJourney()' });
+  assert.equal(JSON.parse(mutationResult.content[0].text).ok, true);
+  assert.equal(dispatched, true);
 });

--- a/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
@@ -2666,6 +2666,35 @@ test('a failed login prologue becomes a durable terminal mutation gate', async (
   assert.equal(readDispatched, true);
 });
 
+test('a failed login prologue persists before fallible postflight checks', async () => {
+  const { runtime, status } = fixture();
+  const blocked = loginOutcome('LOGIN_PROLOGUE_BLOCKED', {
+    code: 'RECONNECT_TIMEOUT',
+    detail: 'timeout',
+  });
+  const gate = createAuthorityGate(runtime, {
+    probe: async ({ axis, phase }) => {
+      if (phase === 'postflight') {
+        assert.equal(status.bindings.loginPrologue.state, 'LOGIN_PROLOGUE_BLOCKED');
+        throw new SessionAuthorityError(
+          'AUTHORITY_LOST_DURING_OPERATION',
+          'postflight authority changed',
+        );
+      }
+      return { axis, identity: `${axis}-identity` };
+    },
+  });
+
+  const result = await gate.wrap('cdp_login_prologue', async () =>
+    failResult('blocked', 'LOGIN_PROLOGUE_BLOCKED', { loginPrologue: blocked }),
+  )({});
+  const envelope = JSON.parse(result.content[0].text);
+
+  assert.equal(envelope.code, 'AUTHORITY_LOST_DURING_OPERATION');
+  assert.equal(status.bindings.loginPrologue.state, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(status.bindings.loginPrologue.failure.code, 'RECONNECT_TIMEOUT');
+});
+
 test('a supervisor token authorizes one blocked mutation and records a redacted audit', async () => {
   const { runtime, status } = fixture();
   status.bindings.loginPrologue = loginOutcome('LOGIN_PROLOGUE_BLOCKED', {

--- a/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
@@ -2680,6 +2680,7 @@ test('locked e2e proof coexists with a blocked login helper and does not rewrite
     const gate = createAuthorityGate(runtime, {
       probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
       refreshRuntimeBinding: async () => status.bindings.bundle,
+      resolveLockedE2eTestIds: () => ['user-login'],
     });
 
     const result = await gate.wrap(tool, async () => {
@@ -2688,11 +2689,7 @@ test('locked e2e proof coexists with a blocked login helper and does not rewrite
         locked: tool === 'cdp_lock_e2e_test',
         suite: tool === 'cdp_run_e2e_suite',
       });
-    })(
-      tool === 'cdp_lock_e2e_test'
-        ? { actionId: 'user-login' }
-        : { pattern: '^user-login$' },
-    );
+    })(tool === 'cdp_lock_e2e_test' ? { actionId: 'user-login' } : { pattern: '.*' });
     const envelope = JSON.parse(result.content[0].text);
     assert.equal(envelope.ok, true, `${tool}: ${envelope.code ?? envelope.error ?? 'ok'}`);
     assert.equal(dispatched, true, tool);
@@ -2711,6 +2708,27 @@ test('locked e2e proof coexists with a blocked login helper and does not rewrite
   })({ text: 'secret' });
   assert.equal(JSON.parse(fill.content[0].text).code, 'LOGIN_PROLOGUE_BLOCKED');
   assert.equal(fillDispatched, false);
+});
+
+test('blocked login helper rejects a case-insensitive multi-match after suite resolution', async () => {
+  const { runtime, status } = fixture();
+  status.bindings.loginPrologue = loginOutcome('LOGIN_PROLOGUE_BLOCKED', {
+    code: 'ENGINE_PIN_MISMATCH',
+    detail: 'runner drift',
+  });
+  let dispatched = false;
+  const gate = createAuthorityGate(runtime, {
+    probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
+    resolveLockedE2eTestIds: () => ['user-login', 'USER-LOGIN'],
+  });
+
+  const result = await gate.wrap('cdp_run_e2e_suite', async () => {
+    dispatched = true;
+    return okResult({});
+  })({ pattern: '^user-login$' });
+
+  assert.equal(JSON.parse(result.content[0].text).code, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(dispatched, false);
 });
 
 test('blocked login helper refuses non-exact locked e2e selections', async () => {

--- a/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
@@ -3021,12 +3021,19 @@ test('busy flow refusal leaves the login attempt blocked and releases its fence'
 
   const result = await gate.wrap('cdp_login_prologue', async () => {
     calls.push('arbiter-refusal');
-    return failResult('flow busy', 'BUSY_FLOW_ACTIVE');
+    return failResult(
+      'Refusing cdp_login_prologue: blocked by stale-flow; run rn_session({ action: "recover_arbiter", confirmed: true }).',
+      'BUSY_FLOW_ACTIVE',
+      { holder: { tool: 'stale-flow', plane: 'flow' } },
+    );
   })({});
   const envelope = JSON.parse(result.content[0].text);
 
   assert.equal(envelope.code, 'LOGIN_PROLOGUE_BLOCKED');
   assert.equal(status.bindings.loginPrologue.state, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(status.bindings.loginPrologue.failure.code, 'BUSY_FLOW_ACTIVE');
+  assert.match(status.bindings.loginPrologue.failure.detail, /recover_arbiter/);
+  assert.match(envelope.error, /recover_arbiter/);
   const firstPostflight = calls.findIndex((call) => call.startsWith('postflight:'));
   assert.ok(firstPostflight > calls.indexOf('arbiter-refusal'));
   assert.equal(calls.at(-1), 'end');

--- a/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
@@ -2666,6 +2666,49 @@ test('a failed login prologue becomes a durable terminal mutation gate', async (
   assert.equal(readDispatched, true);
 });
 
+test('locked e2e proof coexists with a blocked login helper and does not rewrite it', async () => {
+  const blocked = loginOutcome('LOGIN_PROLOGUE_BLOCKED', {
+    code: 'ENGINE_PIN_MISMATCH',
+    detail: 'runner drift',
+  });
+
+  for (const tool of ['cdp_lock_e2e_test', 'cdp_run_e2e_suite']) {
+    const { runtime, status } = fixture();
+    status.bindings.loginPrologue = structuredClone(blocked);
+    const frozenHelper = structuredClone(blocked);
+    let dispatched = false;
+    const gate = createAuthorityGate(runtime, {
+      probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
+      refreshRuntimeBinding: async () => status.bindings.bundle,
+    });
+
+    const result = await gate.wrap(tool, async () => {
+      dispatched = true;
+      return okResult({
+        locked: tool === 'cdp_lock_e2e_test',
+        suite: tool === 'cdp_run_e2e_suite',
+      });
+    })(tool === 'cdp_lock_e2e_test' ? { actionId: 'user-login' } : {});
+    const envelope = JSON.parse(result.content[0].text);
+    assert.equal(envelope.ok, true, `${tool}: ${envelope.code ?? envelope.error ?? 'ok'}`);
+    assert.equal(dispatched, true, tool);
+    assert.deepEqual(status.bindings.loginPrologue, frozenHelper, tool);
+  }
+
+  const { runtime, status } = fixture();
+  status.bindings.loginPrologue = structuredClone(blocked);
+  const gate = createAuthorityGate(runtime, {
+    probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
+  });
+  let fillDispatched = false;
+  const fill = await gate.wrap('device_fill', async () => {
+    fillDispatched = true;
+    return okResult({});
+  })({ text: 'secret' });
+  assert.equal(JSON.parse(fill.content[0].text).code, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(fillDispatched, false);
+});
+
 test('a failed login prologue persists before fallible postflight checks', async () => {
   const { runtime, status } = fixture();
   const blocked = loginOutcome('LOGIN_PROLOGUE_BLOCKED', {

--- a/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
@@ -2688,7 +2688,11 @@ test('locked e2e proof coexists with a blocked login helper and does not rewrite
         locked: tool === 'cdp_lock_e2e_test',
         suite: tool === 'cdp_run_e2e_suite',
       });
-    })(tool === 'cdp_lock_e2e_test' ? { actionId: 'user-login' } : {});
+    })(
+      tool === 'cdp_lock_e2e_test'
+        ? { actionId: 'user-login' }
+        : { pattern: '^user-login$' },
+    );
     const envelope = JSON.parse(result.content[0].text);
     assert.equal(envelope.ok, true, `${tool}: ${envelope.code ?? envelope.error ?? 'ok'}`);
     assert.equal(dispatched, true, tool);
@@ -2707,6 +2711,37 @@ test('locked e2e proof coexists with a blocked login helper and does not rewrite
   })({ text: 'secret' });
   assert.equal(JSON.parse(fill.content[0].text).code, 'LOGIN_PROLOGUE_BLOCKED');
   assert.equal(fillDispatched, false);
+});
+
+test('blocked login helper refuses non-exact locked e2e selections', async () => {
+  const blocked = loginOutcome('LOGIN_PROLOGUE_BLOCKED', {
+    code: 'ENGINE_PIN_MISMATCH',
+    detail: 'runner drift',
+  });
+
+  for (const [tool, args] of [
+    ['cdp_lock_e2e_test', { actionId: 'other-login' }],
+    ['cdp_run_e2e_suite', {}],
+    ['cdp_run_e2e_suite', { pattern: 'user-login' }],
+    ['cdp_run_e2e_suite', { pattern: '^other-login$' }],
+  ] as const) {
+    const { runtime, status } = fixture();
+    status.bindings.loginPrologue = structuredClone(blocked);
+    let dispatched = false;
+    const gate = createAuthorityGate(runtime, {
+      probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
+    });
+
+    const result = await gate.wrap(tool, async () => {
+      dispatched = true;
+      return okResult({});
+    })(args);
+    const envelope = JSON.parse(result.content[0].text);
+
+    assert.equal(envelope.code, 'LOGIN_PROLOGUE_BLOCKED', tool);
+    assert.equal(dispatched, false, tool);
+    assert.deepEqual(status.bindings.loginPrologue, blocked, tool);
+  }
 });
 
 test('a failed login prologue persists before fallible postflight checks', async () => {

--- a/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
@@ -3089,6 +3089,31 @@ test('blocked transition overrides are rejected while cleanup exits remain avail
   }
 });
 
+test('confirmed arbiter recovery remains reachable after a busy login prologue', async () => {
+  const { runtime, status } = fixture();
+  status.bindings.loginPrologue = loginOutcome('LOGIN_PROLOGUE_BLOCKED', {
+    code: 'BUSY_FLOW_ACTIVE',
+    detail: 'a stale flow lease is active',
+  });
+  const gate = createAuthorityGate(runtime, {
+    probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
+  });
+  let recoveryDispatched = false;
+  const recover = gate.wrap('rn_session', async () => {
+    recoveryDispatched = true;
+    return okResult({ recovered: true });
+  });
+
+  const refused = await recover({ action: 'recover_arbiter' });
+  assert.equal(JSON.parse(refused.content[0].text).code, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(recoveryDispatched, false);
+
+  const recovered = await recover({ action: 'recover_arbiter', confirmed: true });
+  assert.notEqual(JSON.parse(recovered.content[0].text).code, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(recoveryDispatched, true);
+  assert.equal(status.bindings.loginPrologue.state, 'LOGIN_PROLOGUE_BLOCKED');
+});
+
 test('rerunning the exact login prologue discharges the terminal gate after a passing result', async () => {
   const { runtime, status } = fixture();
   status.bindings.loginPrologue = loginOutcome('LOGIN_PROLOGUE_BLOCKED', {

--- a/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
@@ -2788,8 +2788,17 @@ test('a supervisor token authorizes one blocked mutation and records a redacted 
     detail: 'selector drift',
   });
   const expectedToken = 'supervisor-token-123456';
+  let recoveryCalls = 0;
+  let probeCalls = 0;
   const gate = createAuthorityGate(runtime, {
-    probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
+    recoverRuntimeConnection: async () => {
+      recoveryCalls += 1;
+      return false;
+    },
+    probe: async ({ axis }) => {
+      probeCalls += 1;
+      return { axis, identity: `${axis}-identity` };
+    },
     loginSupervisorOverrideToken: () => expectedToken,
   });
 
@@ -2800,6 +2809,8 @@ test('a supervisor token authorizes one blocked mutation and records a redacted 
   })({ expression: 'mutate()', supervisorOverrideToken: 'incorrect-token-1234' });
   assert.equal(JSON.parse(invalid.content[0].text).code, 'LOGIN_PROLOGUE_BLOCKED');
   assert.equal(invalidDispatched, false);
+  assert.equal(recoveryCalls, 0);
+  assert.equal(probeCalls, 0);
 
   let handlerArgs;
   const allowed = await gate.wrap('cdp_evaluate', async (args) => {
@@ -2832,24 +2843,8 @@ test('concurrent supervisor overrides cannot dispatch without a retained audit',
     }
     return replaceBindingsDuringOperation(operation, input);
   };
-  let releasePreflight!: () => void;
-  const preflightBarrier = new Promise<void>((resolve) => {
-    releasePreflight = resolve;
-  });
-  let preflightCount = 0;
-  let bothAtPreflight!: () => void;
-  const bothReady = new Promise<void>((resolve) => {
-    bothAtPreflight = resolve;
-  });
   const gate = createAuthorityGate(runtime, {
-    probe: async ({ axis, phase }) => {
-      if (phase === 'preflight' && axis === 'D') {
-        preflightCount += 1;
-        if (preflightCount === 2) bothAtPreflight();
-        await preflightBarrier;
-      }
-      return { axis, identity: `${axis}-identity` };
-    },
+    probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
     loginSupervisorOverrideToken: () => expectedToken,
   });
   let dispatchCount = 0;
@@ -2862,13 +2857,83 @@ test('concurrent supervisor overrides cannot dispatch without a retained audit',
     wrapped({ expression: 'mutateA()', supervisorOverrideToken: expectedToken }),
     wrapped({ expression: 'mutateB()', supervisorOverrideToken: expectedToken }),
   ];
-  await bothReady;
-  releasePreflight();
   const envelopes = (await Promise.all(calls)).map((result) => JSON.parse(result.content[0].text));
 
   assert.equal(envelopes.filter(({ ok }) => ok === true).length, 1);
   assert.equal(dispatchCount, 1);
   assert.equal(status.bindings.loginPrologue.overrides.length, 1);
+});
+
+test('supervisor tokens are removed before session status can fail', async () => {
+  const { runtime } = fixture();
+  runtime.status = () => {
+    throw new Error('status unavailable');
+  };
+  const gate = createAuthorityGate(runtime, {
+    probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
+  });
+  const args = {
+    expression: 'mutate()',
+    supervisorOverrideToken: 'supervisor-token-123456',
+  };
+
+  await assert.rejects(gate.wrap('cdp_evaluate', async () => okResult({}))(args));
+
+  assert.equal(args.supervisorOverrideToken, undefined);
+});
+
+test('login promotion rejects a different pending attempt generation', async () => {
+  const { runtime, status } = fixture();
+  status.bindings.loginPrologue = loginOutcome('passed');
+  const passed = {
+    ...loginOutcome('passed'),
+    runRecord: {
+      runId: 'fresh-login-run',
+      timestamp: '2026-08-21T10:00:00.100Z',
+      durationMs: 100,
+      status: 'pass',
+      trigger: 'agent',
+    },
+  };
+  const gate = createAuthorityGate(runtime, {
+    probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
+  });
+
+  const result = await gate.wrap('cdp_login_prologue', async () => {
+    status.bindings.loginPrologue = {
+      ...status.bindings.loginPrologue,
+      attemptId: 'different-attempt',
+    };
+    return okResult(passed);
+  })({});
+  const envelope = JSON.parse(result.content[0].text);
+
+  assert.equal(envelope.code, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(status.bindings.loginPrologue.state, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(status.bindings.loginPrologue.attemptId, 'different-attempt');
+});
+
+test('busy flow refusal leaves the login attempt blocked and releases its fence', async () => {
+  const { calls, runtime, status } = fixture();
+  status.bindings.loginPrologue = loginOutcome('passed');
+  const gate = createAuthorityGate(runtime, {
+    probe: async ({ axis, phase }) => {
+      calls.push(`${phase}:${axis}`);
+      return { axis, identity: `${axis}-identity` };
+    },
+  });
+
+  const result = await gate.wrap('cdp_login_prologue', async () => {
+    calls.push('arbiter-refusal');
+    return failResult('flow busy', 'BUSY_FLOW_ACTIVE');
+  })({});
+  const envelope = JSON.parse(result.content[0].text);
+
+  assert.equal(envelope.code, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(status.bindings.loginPrologue.state, 'LOGIN_PROLOGUE_BLOCKED');
+  const firstPostflight = calls.findIndex((call) => call.startsWith('postflight:'));
+  assert.ok(firstPostflight > calls.indexOf('arbiter-refusal'));
+  assert.equal(calls.at(-1), 'end');
 });
 
 test('blocked transition overrides are rejected while cleanup exits remain available', async () => {

--- a/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
@@ -2680,7 +2680,7 @@ test('locked e2e proof coexists with a blocked login helper and does not rewrite
     const gate = createAuthorityGate(runtime, {
       probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
       refreshRuntimeBinding: async () => status.bindings.bundle,
-      resolveLockedE2eTestIds: () => ['user-login'],
+      resolveLockedE2eTestIds: () => ({ ids: ['user-login'], identitiesValid: true }),
     });
 
     const result = await gate.wrap(tool, async () => {
@@ -2719,7 +2719,31 @@ test('blocked login helper rejects a case-insensitive multi-match after suite re
   let dispatched = false;
   const gate = createAuthorityGate(runtime, {
     probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
-    resolveLockedE2eTestIds: () => ['user-login', 'USER-LOGIN'],
+    resolveLockedE2eTestIds: () => ({
+      ids: ['user-login', 'USER-LOGIN'],
+      identitiesValid: true,
+    }),
+  });
+
+  const result = await gate.wrap('cdp_run_e2e_suite', async () => {
+    dispatched = true;
+    return okResult({});
+  })({ pattern: '^user-login$' });
+
+  assert.equal(JSON.parse(result.content[0].text).code, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(dispatched, false);
+});
+
+test('blocked login helper rejects an identity-invalid exact suite selection', async () => {
+  const { runtime, status } = fixture();
+  status.bindings.loginPrologue = loginOutcome('LOGIN_PROLOGUE_BLOCKED', {
+    code: 'ENGINE_PIN_MISMATCH',
+    detail: 'runner drift',
+  });
+  let dispatched = false;
+  const gate = createAuthorityGate(runtime, {
+    probe: async ({ axis }) => ({ axis, identity: `${axis}-identity` }),
+    resolveLockedE2eTestIds: () => ({ ids: ['user-login'], identitiesValid: false }),
   });
 
   const result = await gate.wrap('cdp_run_e2e_suite', async () => {

--- a/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
@@ -2695,6 +2695,37 @@ test('a failed login prologue persists before fallible postflight checks', async
   assert.equal(status.bindings.loginPrologue.failure.code, 'RECONNECT_TIMEOUT');
 });
 
+test('a passing login prologue remains blocked when postflight authority drifts', async () => {
+  const { runtime, status } = fixture();
+  status.bindings.loginPrologue = loginOutcome('LOGIN_PROLOGUE_BLOCKED', {
+    code: 'RECONNECT_TIMEOUT',
+    detail: 'timeout',
+  });
+  const passed = {
+    ...loginOutcome('passed'),
+    runRecord: {
+      runId: 'fresh-login-run',
+      timestamp: '2026-08-21T10:00:00.100Z',
+      durationMs: 100,
+      status: 'pass',
+      trigger: 'agent',
+    },
+  };
+  const gate = createAuthorityGate(runtime, {
+    probe: async ({ axis, phase }) => ({
+      axis,
+      identity: phase === 'postflight' && axis === 'D' ? 'foreign-device' : `${axis}-identity`,
+    }),
+  });
+
+  const result = await gate.wrap('cdp_login_prologue', async () => okResult(passed))({});
+  const envelope = JSON.parse(result.content[0].text);
+
+  assert.equal(envelope.code, 'AUTHORITY_LOST_DURING_OPERATION');
+  assert.equal(status.bindings.loginPrologue.state, 'LOGIN_PROLOGUE_BLOCKED');
+  assert.equal(status.bindings.loginPrologue.failure.code, 'RECONNECT_TIMEOUT');
+});
+
 test('a supervisor token authorizes one blocked mutation and records a redacted audit', async () => {
   const { runtime, status } = fixture();
   status.bindings.loginPrologue = loginOutcome('LOGIN_PROLOGUE_BLOCKED', {
@@ -2727,6 +2758,62 @@ test('a supervisor token authorizes one blocked mutation and records a redacted 
     ['cdp_evaluate'],
   );
   assert.equal(JSON.stringify(status.bindings.loginPrologue).includes(expectedToken), false);
+});
+
+test('concurrent supervisor overrides cannot dispatch without a retained audit', async () => {
+  const { runtime, registry, status } = fixture();
+  status.bindings.loginPrologue = loginOutcome('LOGIN_PROLOGUE_BLOCKED', {
+    code: 'TESTID_NOT_FOUND',
+    detail: 'selector drift',
+  });
+  const expectedToken = 'supervisor-token-123456';
+  const replaceBindingsDuringOperation = registry.replaceBindingsDuringOperation;
+  registry.replaceBindingsDuringOperation = (operation, input) => {
+    if (operation.authorityVersion !== status.authorityVersion) {
+      throw new SessionAuthorityError(
+        'AUTHORITY_LOST_DURING_OPERATION',
+        'override audit lost its operation fence',
+      );
+    }
+    return replaceBindingsDuringOperation(operation, input);
+  };
+  let releasePreflight!: () => void;
+  const preflightBarrier = new Promise<void>((resolve) => {
+    releasePreflight = resolve;
+  });
+  let preflightCount = 0;
+  let bothAtPreflight!: () => void;
+  const bothReady = new Promise<void>((resolve) => {
+    bothAtPreflight = resolve;
+  });
+  const gate = createAuthorityGate(runtime, {
+    probe: async ({ axis, phase }) => {
+      if (phase === 'preflight' && axis === 'D') {
+        preflightCount += 1;
+        if (preflightCount === 2) bothAtPreflight();
+        await preflightBarrier;
+      }
+      return { axis, identity: `${axis}-identity` };
+    },
+    loginSupervisorOverrideToken: () => expectedToken,
+  });
+  let dispatchCount = 0;
+  const wrapped = gate.wrap('cdp_evaluate', async () => {
+    dispatchCount += 1;
+    return okResult({ allowed: true });
+  });
+
+  const calls = [
+    wrapped({ expression: 'mutateA()', supervisorOverrideToken: expectedToken }),
+    wrapped({ expression: 'mutateB()', supervisorOverrideToken: expectedToken }),
+  ];
+  await bothReady;
+  releasePreflight();
+  const envelopes = (await Promise.all(calls)).map((result) => JSON.parse(result.content[0].text));
+
+  assert.equal(envelopes.filter(({ ok }) => ok === true).length, 1);
+  assert.equal(dispatchCount, 1);
+  assert.equal(status.bindings.loginPrologue.overrides.length, 1);
 });
 
 test('rerunning the exact login prologue discharges the terminal gate after a passing result', async () => {

--- a/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/authority-gate.test.ts
@@ -2745,6 +2745,42 @@ test('a login prologue transaction blocks before dispatch and stays blocked on t
   assert.equal(status.bindings.loginPrologue.failure.code, 'LOGIN_PROLOGUE_IN_PROGRESS');
 });
 
+test('login preflight failures replace stale passing authority before returning', async () => {
+  for (const failure of ['runner-drift', 'reconnect-timeout']) {
+    const { runtime, status } = fixture();
+    status.bindings.loginPrologue = loginOutcome('passed');
+    if (failure === 'runner-drift') status.bindings.runner = null;
+    let dispatched = false;
+    const gate = createAuthorityGate(runtime, {
+      probe: async ({ axis, phase }) => {
+        if (failure === 'reconnect-timeout' && phase === 'preflight' && axis === 'M') {
+          throw new SessionAuthorityError('RECONNECT_TIMEOUT', 'runtime did not reconnect');
+        }
+        return { axis, identity: `${axis}-identity` };
+      },
+    });
+
+    const result = await gate.wrap('cdp_login_prologue', async () => {
+      dispatched = true;
+      return okResult(loginOutcome('passed'));
+    })({});
+    const envelope = JSON.parse(result.content[0].text);
+
+    assert.equal(envelope.ok, false, failure);
+    assert.equal(dispatched, false, failure);
+    assert.equal(status.bindings.loginPrologue.state, 'LOGIN_PROLOGUE_BLOCKED', failure);
+    assert.equal(status.bindings.loginPrologue.failure.code, 'LOGIN_PROLOGUE_IN_PROGRESS', failure);
+
+    let mutationDispatched = false;
+    const mutation = await gate.wrap('cdp_evaluate', async () => {
+      mutationDispatched = true;
+      return okResult({});
+    })({ expression: 'mutate()' });
+    assert.equal(JSON.parse(mutation.content[0].text).code, 'LOGIN_PROLOGUE_BLOCKED', failure);
+    assert.equal(mutationDispatched, false, failure);
+  }
+});
+
 test('a supervisor token authorizes one blocked mutation and records a redacted audit', async () => {
   const { runtime, status } = fixture();
   status.bindings.loginPrologue = loginOutcome('LOGIN_PROLOGUE_BLOCKED', {

--- a/packages/rn-dev-agent-core/test/unit/session/public-status.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/public-status.test.ts
@@ -90,6 +90,51 @@ test('session status exposes the bounded managed-sandbox tier', () => {
   assert.equal(projectPublicAuthorityStatus({ ...base, bindings: {} }).sandbox, 'unavailable');
 });
 
+test('session status exposes bounded login-prologue evidence without action parameters', () => {
+  const projected = projectPublicAuthorityStatus({
+    ...operationalStatus('ready'),
+    bindings: {
+      loginPrologue: {
+        schemaVersion: 1,
+        state: 'LOGIN_PROLOGUE_BLOCKED',
+        alias: 'user-login',
+        actionId: 'user-login',
+        startedAt: '2026-08-21T10:00:00.000Z',
+        endedAt: '2026-08-21T10:00:00.100Z',
+        elapsedMs: 100,
+        steps: [],
+        inventory: { count: 1, actionIds: ['user-login'] },
+        failure: { code: 'ENGINE_PIN_MISMATCH', detail: 'private runner detail' },
+        runRecord: {
+          runId: 'login-run-1',
+          timestamp: '2026-08-21T10:00:00.100Z',
+          durationMs: 100,
+          status: 'fail',
+          trigger: 'agent',
+          failureDetail: 'private action output',
+        },
+        overrides: [{ tool: 'cdp_evaluate', usedAt: '2026-08-21T10:01:00.000Z' }],
+        params: { PASSWORD: 'secret' },
+      },
+    },
+  });
+
+  assert.deepEqual(projected.loginPrologue, {
+    state: 'LOGIN_PROLOGUE_BLOCKED',
+    alias: 'user-login',
+    actionId: 'user-login',
+    startedAt: '2026-08-21T10:00:00.000Z',
+    endedAt: '2026-08-21T10:00:00.100Z',
+    elapsedMs: 100,
+    failureCode: 'ENGINE_PIN_MISMATCH',
+    runId: 'login-run-1',
+    overrideCount: 1,
+    lastOverride: { tool: 'cdp_evaluate', usedAt: '2026-08-21T10:01:00.000Z' },
+  });
+  assert.equal(JSON.stringify(projected).includes('secret'), false);
+  assert.equal(JSON.stringify(projected).includes('private'), false);
+});
+
 function blockedStatus(expiresMs: number) {
   return {
     available: true as const,

--- a/packages/rn-dev-agent-core/test/unit/session/public-status.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/public-status.test.ts
@@ -120,6 +120,7 @@ test('session status exposes bounded login-prologue evidence without action para
   });
 
   assert.deepEqual(projected.loginPrologue, {
+    role: 'ACTION_LOGIN_HELPER',
     state: 'LOGIN_PROLOGUE_BLOCKED',
     alias: 'user-login',
     actionId: 'user-login',

--- a/packages/rn-dev-agent-core/test/unit/session/tool-profiles.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/session/tool-profiles.test.ts
@@ -247,6 +247,15 @@ const GOLDEN: Record<string, GoldenProfile> = {
     mutation: true,
     liveBundleProbe: true,
   },
+  cdp_login_prologue: {
+    kind: 'authoritative',
+    axes: 'CSIMDR',
+    optionalAxes: 'B',
+    managedOrigin: true,
+    managedRunnerPark: true,
+    mutation: true,
+    liveBundleProbe: true,
+  },
   cdp_run_e2e_suite: {
     kind: 'authoritative',
     axes: 'CSIMBDR',

--- a/packages/shared-agent-knowledge/agents/rn-tester.md
+++ b/packages/shared-agent-knowledge/agents/rn-tester.md
@@ -152,39 +152,20 @@ Write a brief test plan BEFORE executing:
 - Expected outcome at each step (UI + data)
 - Edge cases to verify
 
-### Step 2.5: Auth Pre-flight Check (GH #10)
+### Step 2.5: Deterministic Login Prologue
 
-Before navigating, check if the app is on an auth-gated screen (login,
-welcome, registration, onboarding). Authentication recovery must use a
-compatible action from the project's approved learned-action corpus.
-
-1. Call `cdp_navigation_state`. Check the current route name.
-2. If the navigation state is **empty or minimal**, the app may still
-   be loading (splash screen, token rehydration). Wait 3 seconds and
-   retry `cdp_navigation_state`. If the route remains unavailable, use a
-   device snapshot to distinguish the Dev Client picker from an auth screen;
-   passive `cdp_status` never dismisses UI.
-3. If the route suggests the user is logged out (common patterns:
-   `Login`, `Welcome`, `SignIn`, `Register`, `Onboarding`, `Auth`,
-   `Landing`):
-
-   a. Run `/rn-dev-agent:list-learned-actions login` and select one compatible
-      owned action whose metadata establishes authenticated state.
-   b. Replay it through `cdp_run_action` on the exact authority-bound device.
-      Any engine-pin, selector, or action-format incompatibility is terminal.
-   c. If no compatible owned action exists, stop and report authentication as
-      blocked. Do not use manual taps, `.maestro` flows, ambient runners, or
-      `cdp_auto_login` as an automatic fallback.
-   d. Only when the user explicitly authorizes legacy per-call navigation
-      recovery may `cdp_auto_login` run. It is never durable login authority or
-      PR proof; create or migrate an owned compatible action before proof.
-   e. **Verify arrival** at the home/main screen:
-      ```
-      cdp_navigation_state  → confirm route is NOT auth-related
-      ```
-
-4. If the route is a main app screen (home, dashboard, tabs, etc.),
-   skip this step — the user is already authenticated.
+1. Call `cdp_navigation_state` and distinguish a stable auth route from a
+    loading or Dev Client picker state. If navigation is empty or minimal,
+    wait 3 seconds and retry before concluding the app is signed out.
+2. If the app is signed out, call `cdp_login_prologue`. Do not inspect or
+    explore login controls first.
+3. Continue only with `state: "passed"` and a fresh passing `runRecord`.
+4. Treat `LOGIN_PROLOGUE_BLOCKED` as terminal. Do not enter credentials, run
+   ad-hoc Maestro, inject routes, mutate stores, or navigate to the story. Use
+   read-only diagnostics to repair the exact `user-login` action, then rerun
+   the prologue.
+5. A supervisor override is valid only when supplied out of band for one call;
+    never search for, infer, log, or persist its token.
 
 ### Step 2.6: Permission Pre-flight Check (GH #11)
 

--- a/packages/shared-agent-knowledge/agents/rn-tester.md
+++ b/packages/shared-agent-knowledge/agents/rn-tester.md
@@ -160,10 +160,13 @@ Write a brief test plan BEFORE executing:
 2. If the app is signed out, call `cdp_login_prologue`. Do not inspect or
     explore login controls first.
 3. Continue only with `state: "passed"` and a fresh passing `runRecord`.
+   That result is a navigation helper, not PR proof.
 4. Treat `LOGIN_PROLOGUE_BLOCKED` as terminal. Do not enter credentials, run
    ad-hoc Maestro, inject routes, mutate stores, or navigate to the story. Use
    read-only diagnostics to repair the exact `user-login` action, then rerun
-   the prologue.
+   the prologue. Locked e2e login proof (`cdp_lock_e2e_test` /
+   `cdp_run_e2e_suite` on the exact candidate) remains available and does not
+   lift or replace the helper gate.
 5. A supervisor override is valid only when supplied out of band for one call;
     never search for, infer, log, or persist its token.
 

--- a/packages/shared-agent-knowledge/commands/lock-e2e.md
+++ b/packages/shared-agent-knowledge/commands/lock-e2e.md
@@ -12,3 +12,4 @@ Steps:
 2. If it returns `STRICT_RUN_FAILED`, tell the user the action must pass a strict (no-repair) run first — offer to run `cdp_run_action` to repair it, then retry the lock.
 3. If it returns `PARAMS_UNSUPPORTED`, explain that v1 supports param-free tests only.
 4. On success, report the frozen file path and that it will now be included in `cdp_run_e2e_suite`.
+5. For login, this locked test is the formal PR proof on the exact candidate. `cdp_login_prologue` is only a navigation helper and must not be treated as that proof.

--- a/packages/shared-agent-knowledge/skills/rn-testing/SKILL.md
+++ b/packages/shared-agent-knowledge/skills/rn-testing/SKILL.md
@@ -60,7 +60,7 @@ Do not silently take the cheaper path. The user reviewing your output cannot tel
 
 ### When shortcuts are legitimate
 
-- **Auth pre-flight** (`cdp_login_prologue` with a passing RunRecord) — bootstrap, not verification surface
+- **Auth pre-flight** (`cdp_login_prologue` with a passing RunRecord) — bootstrap helper, not PR proof or a durable authority capability
 - **Permission pre-flight** (granting via `device_permission`) — platform setup, declared upfront
 - **Test data seeding** (via app's test-only fixtures) — declared in the test plan
 - **Explicit user instruction** ("just deep-link to the details screen and check the layout") — user-sanctioned scope
@@ -332,7 +332,12 @@ and replays it with conservative runner and selector safety checks.
 
 Continue only when the result has `state: "passed"` and a fresh passing
 `runRecord`. The returned prologue and RunRecord timing fields separate
-inventory, resolution, replay, verification, and transport time.
+inventory, resolution, replay, verification, and transport time. Treat that
+pass as a navigation helper only: it is not PR proof and must not be used as
+a durable authority capability. Formal login proof is locking and running
+the login e2e on the exact candidate (`cdp_lock_e2e_test` /
+`cdp_run_e2e_suite`). Helper replay and locked e2e coexist without sharing
+that proof or rewriting each other's artifacts.
 
 `LOGIN_PROLOGUE_BLOCKED` is a terminal journey boundary. A missing action,
 runner drift, selector failure, timeout, or missing fresh RunRecord must not

--- a/packages/shared-agent-knowledge/skills/rn-testing/SKILL.md
+++ b/packages/shared-agent-knowledge/skills/rn-testing/SKILL.md
@@ -60,7 +60,7 @@ Do not silently take the cheaper path. The user reviewing your output cannot tel
 
 ### When shortcuts are legitimate
 
-- **Auth pre-flight** (compatible owned action; explicitly authorized legacy helper only when needed) — bootstrap, not verification surface
+- **Auth pre-flight** (`cdp_login_prologue` with a passing RunRecord) — bootstrap, not verification surface
 - **Permission pre-flight** (granting via `device_permission`) — platform setup, declared upfront
 - **Test data seeding** (via app's test-only fixtures) — declared in the test plan
 - **Explicit user instruction** ("just deep-link to the details screen and check the layout") — user-sanctioned scope
@@ -322,52 +322,32 @@ maestro_run(platform="android", deviceId="<exact emulator serial>", flowPath="fl
 
 ---
 
-## Auth Pre-flight: Approved Learned Actions (GH #10)
+## Auth Pre-flight: Deterministic Login Prologue
 
-Before testing features that require authentication, check if the app is
-on a login/auth screen. If so, authentication recovery must use a compatible
-action from the project's approved learned-action corpus.
+Before testing an authenticated feature, read the route with
+`cdp_navigation_state`. If the app is signed out, call
+`cdp_login_prologue` before any exploratory login interaction. The tool
+inventories learned actions, resolves only `.rn-agent/actions/user-login.yaml`,
+and replays it with conservative runner and selector safety checks.
 
-### Detection
+Continue only when the result has `state: "passed"` and a fresh passing
+`runRecord`. The returned prologue and RunRecord timing fields separate
+inventory, resolution, replay, verification, and transport time.
 
-Call `cdp_navigation_state` and check the route name. Auth-related routes
-typically match: `Login`, `Welcome`, `SignIn`, `Register`, `Onboarding`,
-`Auth`, `Landing`.
+`LOGIN_PROLOGUE_BLOCKED` is a terminal journey boundary. A missing action,
+runner drift, selector failure, timeout, or missing fresh RunRecord must not
+fall through to manual credential entry, `cdp_auto_login`, raw or ad-hoc
+Maestro, route injection, navigation shortcuts, or store mutation. Read-only
+diagnostics and cleanup remain available; repair the exact saved action and
+rerun the prologue.
 
-**Caution**: An empty navigation state may be a splash screen (loading) or
-the Dev Client picker (GH #9), not necessarily auth. Wait 3 seconds and
-retry before concluding the app is logged out.
+An empty navigation state may be a splash screen or Dev Client picker, not
+necessarily auth. Wait 3 seconds and retry before concluding the app is logged
+out.
 
-### Discovery and execution
-
-1. Run `/rn-dev-agent:list-learned-actions login`.
-2. Select one compatible owned action whose metadata establishes authenticated
-   state.
-3. Replay it through `cdp_run_action` on the exact authority-bound device.
-4. Treat any engine-pin, selector, or action-format incompatibility as terminal.
-5. If no compatible owned action exists, stop and report authentication as
-   blocked. Do not use manual taps, `.maestro` flows, ambient runners, or
-   `cdp_auto_login` as an automatic fallback.
-
-Only when the user explicitly authorizes legacy per-call navigation recovery may
-`cdp_auto_login` run. It is never durable login authority or PR proof; create or
-migrate an owned compatible action before proof.
-
-### Verification
-
-After replay completes, verify arrival at the main app:
-```
-cdp_navigation_state → route should be a main screen (Home, Dashboard, Tabs)
-```
-
-### Rules
-
-- **NEVER** fall back to manual login or an unowned replay flow
-- **ALWAYS** use `cdp_run_action` for the owned authentication action
-- **Skip** the notification `permissions` config if testing notification
-  permission flows (preserve undetermined state)
-- If no compatible owned login action exists, stop and report that
-  authentication cannot proceed through an authorized reusable flow
+A supervisor may authorize one otherwise-blocked mutation only with an
+out-of-band token configured as `RN_LOGIN_PROLOGUE_OVERRIDE_TOKEN` and supplied
+as `supervisorOverrideToken`. Never infer, discover, log, or persist that token.
 
 ---
 

--- a/packages/shared-agent-knowledge/skills/using-rn-dev-agent/SKILL.md
+++ b/packages/shared-agent-knowledge/skills/using-rn-dev-agent/SKILL.md
@@ -106,7 +106,8 @@ What is the user asking for?
 ├── FREEZE a verified action into a locked regression test
 │   └─► /rn-dev-agent:lock-e2e <action-name>
 │       (Strict no-repair run via cdp_lock_e2e_test, freezes to .rn-agent/e2e/;
-│        the frozen suite runs via cdp_run_e2e_suite)
+│        the frozen suite runs via cdp_run_e2e_suite. For login, this is the
+│        formal PR proof on the exact candidate; cdp_login_prologue is not.)
 │
 ├── Watch tool activity live in a browser ("observability UI")
 │   └─► /rn-dev-agent:observe
@@ -160,7 +161,7 @@ These apply to every RN task:
 5. **Filter `cdp_component_tree` queries** — never dump the full tree (10K+ tokens wasted)
 6. **Stop at the first red flag** from the agent's red flags list
 7. **Run `/rn-dev-agent:list-learned-actions` BEFORE composing any `device_*` sequence.** If a saved action already covers the request, replay it via `cdp_run_action` (or `/rn-dev-agent:run-action`) first — that path runs the mutates/appId/param pre-flights and auto-repair; reserve raw `maestro_run` for non-action YAML flows. Manual primitives are a fallback, not a default. (Codified in `feedback_execute_artifacts_before_manual.md`. The original failure case: a 7-minute / 11-tool-call manual walk that an existing 23-second Maestro flow would have covered.)
-8. **Enter authenticated journeys through `cdp_login_prologue`.** It resolves only the exact `user-login` action and requires a fresh passing RunRecord. `LOGIN_PROLOGUE_BLOCKED` is terminal for the journey: do not use manual credentials, ad-hoc Maestro, navigation shortcuts, or store mutation afterward.
+8. **Enter authenticated journeys through `cdp_login_prologue`.** It resolves only the exact `user-login` action and requires a fresh passing RunRecord. That result is a navigation helper, not PR proof. `LOGIN_PROLOGUE_BLOCKED` is terminal for the journey: do not use manual credentials, ad-hoc Maestro, navigation shortcuts, or store mutation afterward. Formal login proof is `cdp_lock_e2e_test` / `cdp_run_e2e_suite` on the exact candidate; helper and locked tests coexist without sharing that proof.
 
 ### Ask First
 - Adding new dependencies to the user's project

--- a/packages/shared-agent-knowledge/skills/using-rn-dev-agent/SKILL.md
+++ b/packages/shared-agent-knowledge/skills/using-rn-dev-agent/SKILL.md
@@ -160,6 +160,7 @@ These apply to every RN task:
 5. **Filter `cdp_component_tree` queries** — never dump the full tree (10K+ tokens wasted)
 6. **Stop at the first red flag** from the agent's red flags list
 7. **Run `/rn-dev-agent:list-learned-actions` BEFORE composing any `device_*` sequence.** If a saved action already covers the request, replay it via `cdp_run_action` (or `/rn-dev-agent:run-action`) first — that path runs the mutates/appId/param pre-flights and auto-repair; reserve raw `maestro_run` for non-action YAML flows. Manual primitives are a fallback, not a default. (Codified in `feedback_execute_artifacts_before_manual.md`. The original failure case: a 7-minute / 11-tool-call manual walk that an existing 23-second Maestro flow would have covered.)
+8. **Enter authenticated journeys through `cdp_login_prologue`.** It resolves only the exact `user-login` action and requires a fresh passing RunRecord. `LOGIN_PROLOGUE_BLOCKED` is terminal for the journey: do not use manual credentials, ad-hoc Maestro, navigation shortcuts, or store mutation afterward.
 
 ### Ask First
 - Adding new dependencies to the user's project

--- a/packages/shared-agent-knowledge/templates/rn-agent/README.md
+++ b/packages/shared-agent-knowledge/templates/rn-agent/README.md
@@ -9,7 +9,8 @@ your project.
 If your project also has a `.maestro/` folder for hand-authored E2E tests,
 that's yours alone. Authentication prologues resolve the exact
 `.rn-agent/actions/user-login.yaml` learned action and never infer a login flow
-from `.maestro/` filenames.
+from `.maestro/` filenames. `cdp_login_prologue` is a navigation helper, not PR
+proof; lock and run the login e2e on the exact candidate for formal proof.
 
 ## Layout
 

--- a/packages/shared-agent-knowledge/templates/rn-agent/README.md
+++ b/packages/shared-agent-knowledge/templates/rn-agent/README.md
@@ -6,11 +6,10 @@ plugin for Claude Code and Codex. One folder, one doctrine — the plugin's
 entire footprint is `.rn-agent/` and it does not read or write anywhere else in
 your project.
 
-If your project also has a `.maestro/` folder for hand-authored E2E
-tests, that's yours alone. Those files are never learned-action authority or an
-automatic authentication fallback. The explicit legacy `cdp_auto_login` helper
-may inspect one only when the user authorizes that per-call navigation recovery;
-its result is never durable login authority or PR proof.
+If your project also has a `.maestro/` folder for hand-authored E2E tests,
+that's yours alone. Authentication prologues resolve the exact
+`.rn-agent/actions/user-login.yaml` learned action and never infer a login flow
+from `.maestro/` filenames.
 
 ## Layout
 


### PR DESCRIPTION
## Intent

Implement IX-3358/3359 login-prologue guardrails in rn-dev-agent only: a stable user-login entrypoint that inventories learned actions, replays the exact saved action, requires a fresh passing RunRecord, and terminally installs LOGIN_PROLOGUE_BLOCKED on missing action, pin drift, selector failure, or timeout so agents cannot fall through to exploratory login UI, credential fill/evaluate/interact, or ad-hoc Maestro login without an auditable supervisor override.

Captain-authorized revised design: cdp_login_prologue is ACTION_LOGIN_HELPER, a flexible deterministic navigation helper, not PR proof and not a durable authority capability. LOCKED_E2E_LOGIN (cdp_lock_e2e_test / cdp_run_e2e_suite on the exact candidate) is the formal deterministic proof and must coexist conflict-free with the helper, locked actions, sessions, devices, and Metro. Do not implement the declined F16 replacement-authority invalidation; a prior passing helper remaining valid after device/install replacement is accepted residual risk. Preserve session/device/Metro/CDP ownership, existing action safety checks, conservative runner-drift refusal, and ordinary non-login tool behavior. Never access react-native-app or other Getsafe product repositories, credentials, ambient sessions, or devices. Create a PR; do not merge.

Resume from preserved pipeline head edf0453e (rebased onto origin/main with F17/F18). Do not rewrite git history to remove Co-authored-by footers; history rewrite aborts this pipeline. Authorize locked-suite exemption only after resolved locked-test IDs are exactly ['user-login']. Do not expand persistRun.

## What Changed

- Add `cdp_login_prologue` to resolve and strictly replay the exact `user-login` learned action, requiring a fresh passing RunRecord.
- Persist `LOGIN_PROLOGUE_BLOCKED` after missing or mismatched actions, runner drift, replay failures, timeouts, or missing run evidence, gating subsequent mutations while preserving cleanup and audited overrides.
- Keep the helper separate from PR proof by admitting locked E2E operations only for the exact `user-login` candidate, with updated host guidance, runtimes, documentation, and coverage.

## Risk Assessment

🚨 High: Two reachable paths undermine the required exact, deterministic locked-login proof and should be resolved before merge.

## Testing

No inherited baseline results were supplied; targeted built-runtime tests, the added replacement regression test, and a public protocol evidence harness all passed, with no screenshot captured because this is a non-UI MCP surface and ambient device/product access was explicitly forbidden.

<details>
<summary>Evidence: Login-prologue protocol evidence</summary>

`Public handler transcript demonstrating a fresh passing RunRecord, terminal fallback blocking, exact locked-suite exemption, and expanded-suite refusal.`

```text
{
  "scope": "Built rn-dev-agent public handlers; no ambient session, device, credentials, or product repository accessed.",
  "loginSuccess": {
    "request": {
      "tool": "cdp_login_prologue",
      "args": {
        "projectRoot": "<isolated-fixture>"
      }
    },
    "response": {
      "ok": true,
      "data": {
        "state": "passed",
        "role": "ACTION_LOGIN_HELPER",
        "alias": "user-login",
        "actionId": "user-login",
        "runRecord": {
          "timestamp": "2026-08-22T22:18:37.113Z",
          "durationMs": 0,
          "status": "pass",
          "trigger": "agent",
          "autoRepair": {
            "attempted": false,
            "outcome": "skipped",
            "phases": {
              "firstAttemptMs": 0
            }
          },
          "runId": "cd0b6a92-1f0c-4876-aac0-5b6b85fb0be5",
          "timing": {
            "startedAt": "2026-08-22T22:18:37.113Z",
            "endedAt": "2026-08-22T22:18:37.113Z",
            "elapsedMs": 0,
            "steps": [
              {
                "name": "maestro-first-attempt",
                "startedAt": "2026-08-22T22:18:37.113Z",
                "endedAt": "2026-08-22T22:18:37.113Z",
                "elapsedMs": 0
              }
            ]
          }
        },
        "steps": [
          "inventory",
          "resolve",
          "replay",
          "verify-run-record"
        ],
        "inventory": {
          "count": 1,
          "actionIds": [
            "user-login"
          ]
        }
      }
    }
  },
  "missingExactAction": {
    "request": {
      "tool": "cdp_login_prologue",
      "args": {
        "projectRoot": "<isolated-fixture-without-user-login>"
      }
    },
    "response": {
      "ok": false,
      "code": "LOGIN_PROLOGUE_BLOCKED",
      "error": "Login prologue blocked: No exact user-login learned action was found. Auth-tag or intent inference is not permitted.",
      "loginPrologue": {
        "state": "LOGIN_PROLOGUE_BLOCKED",
        "role": "ACTION_LOGIN_HELPER",
        "alias": "user-login",
        "failure": {
          "code": "LOGIN_ACTION_MISSING",
          "detail": "No exact user-login learned action was found. Auth-tag or intent inference is not permitted."
        },
        "inventory": {
          "count": 0,
          "actionIds": []
        }
      }
    }
  },
  "terminalGuard": [
    {
      "tool": "device_fill",
      "response": {
        "ok": false,
        "code": "LOGIN_PROLOGUE_BLOCKED",
        "error": "LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.",
        "loginPrologue": {
          "state": "LOGIN_PROLOGUE_BLOCKED",
          "role": "ACTION_LOGIN_HELPER",
          "alias": "user-login",
          "failure": {
            "code": "LOGIN_ACTION_MISSING",
            "detail": "No exact user-login learned action was found. Auth-tag or intent inference is not permitted."
          },
          "inventory": {
            "count": 0,
            "actionIds": []
          }
        }
      },
      "handlerDispatched": false
    },
    {
      "tool": "cdp_evaluate",
      "response": {
        "ok": false,
        "code": "LOGIN_PROLOGUE_BLOCKED",
        "error": "LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.",
        "loginPrologue": {
          "state": "LOGIN_PROLOGUE_BLOCKED",
          "role": "ACTION_LOGIN_HELPER",
          "alias": "user-login",
          "failure": {
            "code": "LOGIN_ACTION_MISSING",
            "detail": "No exact user-login learned action was found. Auth-tag or intent inference is not permitted."
          },
          "inventory": {
            "count": 0,
            "actionIds": []
          }
        }
      },
      "handlerDispatched": false
    },
    {
      "tool": "cdp_interact",
      "response": {
        "ok": false,
        "code": "LOGIN_PROLOGUE_BLOCKED",
        "error": "LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.",
        "loginPrologue": {
          "state": "LOGIN_PROLOGUE_BLOCKED",
          "role": "ACTION_LOGIN_HELPER",
          "alias": "user-login",
          "failure": {
            "code": "LOGIN_ACTION_MISSING",
            "detail": "No exact user-login learned action was found. Auth-tag or intent inference is not permitted."
          },
          "inventory": {
            "count": 0,
            "actionIds": []
          }
        }
      },
      "handlerDispatched": false
    },
    {
      "tool": "maestro_run",
      "response": {
        "ok": false,
        "code": "LOGIN_PROLOGUE_BLOCKED",
        "error": "LOGIN_PROLOGUE_BLOCKED: the deterministic login action did not produce an authoritative passing RunRecord; mutating tools are disabled for this session.",
        "loginPrologue": {
          "state": "LOGIN_PROLOGUE_BLOCKED",
          "role": "ACTION_LOGIN_HELPER",
          "alias": "user-login",
          "failure": {
            "code": "LOGIN_ACTION_MISSING",
            "detail": "No exact user-login learned action was found. Auth-tag or intent inference is not permitted."
          },
          "inventory": {
            "count": 0,
            "actionIds": []
          }
        }
      },
      "handlerDispatched": false
    }
  ],
  "lockedE2eCoexistence": {
    "exactCandidate": {
      "request": {
        "tool": "cdp_run_e2e_suite",
        "args": {
          "pattern": "^user-login$"
        }
      },
      "resolvedLockedTestIds": [
        "user-login"
      ],
      "response": {
        "ok": true,
        "data": {
          "resolvedLockedTestIds": [
            "user-login"
          ],
          "passed": true
        }
      },
      "handlerDispatched": true,
      "helperBindingUnchanged": true
    },
    "expandedSelection": {
      "request": {
        "tool": "cdp_run_e2e_suite",
        "args": {
          "pattern": "^user-login$|^other-login$"
        }
      },
      "resolvedLockedTestIds": [
        "user-login",
        "other-login"
      ],
      "response": {
        "ok": false,
        "code": "LOGIN_PROLOGUE_BLOCKED",
        "error": "LOGIN_PROLOGUE_BLOCKED: the locked e2e suite did not resolve to the exact user-login candidate"
      },
      "handlerDispatched": false
    }
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c15126cabbd4863f22ad45ebc3dcb3f2af8db3e9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 errors</summary>

- 🚨 `packages/rn-dev-agent-core/src/domain/login-prologue.ts:64` - Intent requires “Authorize locked-suite exemption only after resolved locked-test IDs are exactly [&#39;user-login&#39;],” but this authorizes solely from the raw `args.pattern`. `runE2eSuiteCore` applies that pattern case-insensitively, so with locked IDs `[&#39;user-login&#39;, &#39;USER-LOGIN&#39;]`, `^user-login$` passes this gate and executes both. Authorize at the post-resolution boundary and require exact array equality.

🔧 Fix: Guard suites by exact resolved login ID
1 error still open:
- 🚨 `packages/rn-dev-agent-core/src/domain/login-prologue.ts:84` - A stale flow lease can make `cdp_login_prologue` return `BUSY_FLOW_ACTIVE`, which the gate converts into a terminal login block. The documented recovery, `rn_session({action:&#39;recover_arbiter&#39;, confirmed:true})`, is then rejected because it is absent from this cleanup whitelist and transition overrides are forbidden; rerunning the prologue remains busy, leaving session release as the only escape and violating the ownership-preservation requirement. Admit the confirmed arbiter recovery action at this cleanup boundary.

🔧 Fix: Admit confirmed arbiter recovery through login gate
2 issues (1 error, 1 warning) still open:
- 🚨 `packages/rn-dev-agent-core/src/domain/e2e-test.ts:120` - The required exemption is for the “exact candidate,” but resolution proves only filenames. A valid `user-login.yaml` whose locked header declares `id/sourceActionId: other-login` resolves as exactly `[&#39;user-login&#39;]`; `loadLockedTest` accepts that mismatch and the suite executes its non-login flow through the blocked gate. Validate locked-file identity at the load/resolution boundary before granting admission.
- ⚠️ `packages/rn-dev-agent-core/src/session/authority-gate.ts:2155` - A stale flow lease returns `BUSY_FLOW_ACTIVE` from the outer arbiter, but because that result lacks a prologue outcome this branch replaces it with `LOGIN_PROLOGUE_RESULT_INVALID`, discarding the holder and `recover_arbiter` guidance. Preserve the underlying refusal code/detail in the terminal blocked outcome so the newly admitted recovery path is discoverable.

🔧 Fix: Validate locked login identity and preserve busy recovery
3 errors still open:
- 🚨 `packages/rn-dev-agent-core/src/domain/e2e-test.ts:133` - Intent requires admission only when the resolved locked-test IDs are exactly `[&#39;user-login&#39;]`, but this filter silently removes invalid siblings. With an unfiltered selection of valid `user-login` plus identity-mismatched `other-login`, it returns only `[&#39;user-login&#39;]`, admits the request, and executes a narrowed suite. Preserve the raw resolved set and reject unless that set itself is exactly the login candidate.
- 🚨 `packages/rn-dev-agent-core/src/domain/e2e-test.ts:135` - The required declared identity is still not enforced: `parseLockedTest` substitutes the filename ID when `sourceActionId` is absent, so a `user-login.yaml` without that declaration satisfies this comparison and crosses the blocked helper gate. Require an explicitly present, case-sensitive `sourceActionId: user-login` at admission.
- 🚨 `packages/rn-dev-agent-core/src/domain/e2e-test.ts:100` - Returning null for an existing filename/metadata mismatch bypasses `lockE2eTestCore`&#39;s `ALREADY_LOCKED` guard. Calling `cdp_lock_e2e_test({actionId:&#39;user-login&#39;})` without `relock:true` can therefore overwrite that existing frozen file. Distinguish missing from malformed/mismatched files so every existing locked path remains overwrite-protected.

🔧 Fix: Preserve raw suite selection and locked-file overwrite guards
2 errors still open:
- 🚨 `packages/rn-dev-agent-core/src/domain/e2e-test.ts:100` - The required locked-login exemption is not stable through execution. After the gate validates `id/sourceActionId` and seals only `[&#39;user-login&#39;]`, async preflight leaves a window to replace the file with `id: user-login`, `sourceActionId: other-login`; this reload checks only `id`, so the replacement flow executes through `LOGIN_PROLOGUE_BLOCKED`. Execute a sealed validated candidate, with identity revalidated at the final dispatch boundary.
- 🚨 `apps/docs-site/src/content/docs/commands/lock-e2e.mdx:8` - Intent requires the exact locked `user-login` candidate to be formal deterministic proof, but parameterized actions lose their binding contract when frozen. Lock-time strict replay receives configured params, while the frozen file omits `action.metadata.params`; the suite then invokes Maestro without those bindings and does not replay the proven invocation. Preserve parameter names in the frozen locked-test header.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test --test-concurrency=2 test/unit/login-prologue.test.ts test/unit/gh-584-inline-arbiter.test.ts test/unit/run-action-handler.test.js test/unit/run-action-transport-blind.test.js test/unit/lock-e2e-test.test.js test/unit/e2e-test-io.test.js test/unit/session/public-status.test.ts test/unit/session/tool-profiles.test.ts`
- `node --test --test-concurrency=1 --test-name-pattern='accepted residual risk' test/unit/session/authority-gate.test.ts`
- `node --test --test-concurrency=1 --test-name-pattern='login prologue|login helper|login mutation|login attempt|login preflight|login promotion|login candidate|login transport|supervisor token|supervisor override|blocked transition|arbiter recovery|locked e2e|persistRun|accepted residual risk' test/unit/session/authority-gate.test.ts`
- <code>Inline Node ESM protocol harness invoking `createLoginPrologueHandler`, `createRunActionHandler`, and `createAuthorityGate`; generated `login-prologue-protocol.json`.</code>
- <code>Node assertions over the serialized protocol evidence verified the passing RunRecord, blocked mutations, exact `[&#39;user-login&#39;]` exemption, and expanded-suite refusal.</code>
- <code>`git diff --check` and `git status --short` confirmed no malformed diff or transient worktree artifacts.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
