### PR TITLE
fix(codex-plugin): clarify supported Maestro Runner floor

### DIFF
--- a/packages/codex-plugin/skills/rn-testing/SKILL.md
+++ b/packages/codex-plugin/skills/rn-testing/SKILL.md
@@ -306,8 +306,8 @@ maestro_run(platform="android", deviceId="<exact emulator serial>", flowPath="fl
 
 ## Android-Specific Testing Rules (GH #7)
 
-1. **ALWAYS use rn-dev-agent replay tools on Android** — they enforce the exact
-   maestro-runner pin and the authority-bound device.
+1. **ALWAYS use rn-dev-agent replay tools on Android** — they enforce the
+   supported Maestro Runner floor `>= 1.1.24` and the authority-bound device.
 
 2. **Text input**: Use `device_fill` for text input on Android. It binds one
    exact input, types through the native runner, and succeeds only after stable

--- a/packages/rn-dev-agent-core/test/unit/gh-750-drift-regex-selector-refusal.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-750-drift-regex-selector-refusal.test.ts
@@ -72,6 +72,30 @@ test('gh-750: drifted runner refuses regex-selector flows with a typed message',
   assert.match(refusal, /\.\*Getsafe\.\*/);
 });
 
+test('gh-812: drifted runner refuses regex text in scrollUntilVisible.element', () => {
+  const drifted = buildReplayEngineStatus('drift-newer', '1.1.25', false);
+  const refusal = driftedRegexSelectorRefusal(drifted, [
+    { scrollUntilVisible: { element: 'Log.n', direction: 'DOWN' } },
+  ]);
+
+  assert.ok(refusal);
+  assert.match(refusal, /1\.1\.25/);
+  assert.match(refusal, /1\.1\.24/);
+  assert.match(refusal, /CONTAINS/);
+  assert.match(refusal, /Log\.n/);
+});
+
+test('gh-812: drifted runner refuses regex text in copyTextFrom', () => {
+  const drifted = buildReplayEngineStatus('drift-newer', '1.1.25', false);
+  const refusal = driftedRegexSelectorRefusal(drifted, [{ copyTextFrom: 'Order.*' }]);
+
+  assert.ok(refusal);
+  assert.match(refusal, /1\.1\.25/);
+  assert.match(refusal, /1\.1\.24/);
+  assert.match(refusal, /CONTAINS/);
+  assert.match(refusal, /Order\.\*/);
+});
+
 test('gh-750: pinned runner and literal-only flows replay without refusal', () => {
   const pinned = buildReplayEngineStatus('pinned-ok', '1.1.24', false);
   const drifted = buildReplayEngineStatus('drift-newer', '1.1.20', false);


### PR DESCRIPTION
## Intent

Complete only the captain-approved simplified runner-floor truthfulness scope for GitHub issue https://github.com/Lykhoyda/rn-dev-agent/issues/812. The inherited-action P1 already shipped in PR https://github.com/Lykhoyda/rn-dev-agent/pull/823; do not build on or cherry-pick the obsolete fm/issue-812-p2 branch or preserve its unrelated review machinery. Reuse the existing engine-pin text-selector classifier so a drifted runner refuses regex text selectors in scrollUntilVisible.element and copyTextFrom, without introducing a new classifier. Add one executable behavioral regression per position proving the same established refusal semantics. Change the Codex rn-testing skill wording to state the supported Maestro Runner floor >= 1.1.24. Keep generated artifacts synchronized where affected. Ship one focused validated PR referencing #812 and explain that it is the simplified runner-floor truthfulness completion. Exclude instruction-delivery test frameworks and source-text regex tests for the wording; action-corpus/report hygiene; auto-login device behavior; installer mutex/reclaim work; generalized diagnostics; new state machines; unrelated compatibility guarantees; and all migration, locking, corpus, and unrelated-test changes. The unchanged action-migration and overwrite-lock failures were reproduced exactly once on an immutable clean current-main control at base 6eb22eb9b4c456b4780a5bbf371bb91cd87ceaf2 and preserved in .worktrees/issue-812-baseline-logs/current-main-full-test.log and current-main-serial-failures.log. Treat those exact six failures as baseline evidence through the validation flow's supported path, not as candidate defects; stop on any candidate-only causal divergence.

## What Changed

- Update Codex React Native testing guidance to state the supported Maestro Runner floor of `>= 1.1.24`.
- Add behavioral regressions proving drifted runners reject regex text selectors in `scrollUntilVisible.element` and `copyTextFrom`, completing the simplified runner-floor truthfulness scope for #812.

## Risk Assessment

✅ Low: The focused test-and-documentation change satisfies the stated scope, exercises both required selector positions through the established classifier, and introduces no material source risk.

## Testing

The supplied immutable-base six-failure baseline was accepted without rerunning the broad suite; focused regressions and executable protocol checks confirmed both regex-selector positions refuse truthfully before any runner/UI mutation. This MCP/CLI-only change has no rendered UI surface to screenshot.

<details>
<summary>Evidence: Runner-floor truthfulness protocol evidence</summary>

```text
{
  "intent": "Runner-floor truthfulness for regex text selectors in both GH #812 command positions",
  "supportedFloor": "maestro-runner >= 1.1.24",
  "publicMaestroRunAtSupportedRunner": [
    {
      "position": "scrollUntilVisible.element",
      "selector": "Log.n",
      "ok": false,
      "code": "ENGINE_PIN_MISMATCH",
      "error": "Action uses regex text selectors (Log.n) which are not a validated maestro-runner 1.1.24 capability (GH #750 CONTAINS mistranslation). Rewrite as id or literal text selectors before replay. No UI mutation will run.",
      "runnerInvocations": 0
    },
    {
      "position": "copyTextFrom",
      "selector": "Order.*",
      "ok": false,
      "code": "ENGINE_PIN_MISMATCH",
      "error": "Action uses regex text selectors (Order.*) which are not a validated maestro-runner 1.1.24 capability (GH #750 CONTAINS mistranslation). Rewrite as id or literal text selectors before replay. No UI mutation will run.",
      "runnerInvocations": 0
    }
  ],
  "publicMaestroRunAtDriftedRunner": [
    {
      "position": "scrollUntilVisible.element",
      "selector": "Log.n",
      "ok": false,
      "code": "ENGINE_PIN_MISMATCH",
      "error": "maestro_run refused: Session maestro-runner 1.1.25 is newer than the attested default 1.1.24 and is not executed without attestation. Install attested 1.1.24 (floor >= 1.1.24) via bash ${CLAUDE_PLUGIN_ROOT:-${RN_DEV_AGENT_CODEX_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:?set it to the installed rn-dev-agent plugin root, then re-run}}}/scripts/ensure-maestro-runner.sh (session pin-cache; do not use PATH or brew maestro).",
      "runnerInvocations": 0
    },
    {
      "position": "copyTextFrom",
      "selector": "Order.*",
      "ok": false,
      "code": "ENGINE_PIN_MISMATCH",
      "error": "maestro_run refused: Session maestro-runner 1.1.25 is newer than the attested default 1.1.24 and is not executed without attestation. Install attested 1.1.24 (floor >= 1.1.24) via bash ${CLAUDE_PLUGIN_ROOT:-${RN_DEV_AGENT_CODEX_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:?set it to the installed rn-dev-agent plugin root, then re-run}}}/scripts/ensure-maestro-runner.sh (session pin-cache; do not use PATH or brew maestro).",
      "runnerInvocations": 0
    }
  ],
  "establishedDriftSelectorRefusal": [
    {
      "position": "scrollUntilVisible.element",
      "selector": "Log.n",
      "refusal": "maestro_run refused: maestro-runner 1.1.25 drifted from the tested pin 1.1.24 and the flow uses regex text selectors (Log.n). Drifted runners translate Maestro regex into a literal WDA CONTAINS predicate that can never match (B223-class, GH #750). Reinstall the pin via ensure-maestro-runner.sh, or rewrite the selectors as literal text or id selectors."
    },
    {
      "position": "copyTextFrom",
      "selector": "Order.*",
      "refusal": "maestro_run refused: maestro-runner 1.1.25 drifted from the tested pin 1.1.24 and the flow uses regex text selectors (Order.*). Drifted runners translate Maestro regex into a literal WDA CONTAINS predicate that can never match (B223-class, GH #750). Reinstall the pin via ensure-maestro-runner.sh, or rewrite the selectors as literal text or id selectors."
    }
  ]
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ea2306c9c7da7317247395318724bbae6a152769","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test packages/rn-dev-agent-core/test/unit/gh-750-drift-regex-selector-refusal.test.ts`
- <code>`corepack yarn install --immutable` to repair the isolated worktree’s missing dependencies after the initial protocol probe could not import `yaml`</code>
- <code>Executable `createMaestroRunHandler` probes for regex text in `scrollUntilVisible.element` and `copyTextFrom` under supported and drifted runner states; both returned `ENGINE_PIN_MISMATCH` with zero runner invocations</code>
- <code>Executable `driftedRegexSelectorRefusal` probes for both positions using maestro-runner 1.1.25 against the 1.1.24 floor</code>
- `Removed Yarn install artifacts created during testing and confirmed the worktree remained clean`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
