### PR TITLE
fix(core): skip corrupt inventory entries and avoid refused-run reports

### DIFF
--- a/.changeset/clean-action-reports.md
+++ b/.changeset/clean-action-reports.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-plugin": patch
+"rn-dev-agent-core": patch
+---
+
+Keep valid action inventory entries available around corrupt files with typed warnings and avoid allocating Maestro report directories before preflight passes.

--- a/apps/docs-site/src/content/docs/actions/index.mdx
+++ b/apps/docs-site/src/content/docs/actions/index.mdx
@@ -127,6 +127,8 @@ You can hand-edit actions, but consider that self-repair refuses to touch hand-e
 /rn-dev-agent:list-learned-actions task
 ```
 
+Programmatic action inventories keep valid actions available when one action file is corrupt and emit an `ACTION_INVENTORY_ENTRY_SKIPPED` warning naming that file. A corpus that changes or becomes refused during inventory remains a terminal integrity error.
+
 [`/rn-dev-agent:run-action`](../commands/run-action/) replays one by name:
 
 ```

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -26924,6 +26924,9 @@ function assertStableReadableCorpus(projectRoot, expected) {
     throw new Error(`Refusing replaced learned-action corpus symlink at ${actionsDir}.`);
   }
 }
+function assertReadableActionLoadContextStable(context) {
+  assertStableReadableCorpus(context.projectRoot, context.corpus);
+}
 function lstatIfPresent2(path) {
   try {
     return lstatSync9(path);
@@ -34342,12 +34345,6 @@ function createMaestroRunHandler(deps = {}) {
         paramArgs.push("-e", `${key}=${value}`);
       }
     }
-    const runnerReportDir = createRunnerReportDir(dispatch.runner, "rn-maestro-report");
-    const finalArgs = assembleMaestroArgs(baseArgs, [
-      ...runnerReportArgs(runnerReportDir),
-      ...paramArgs
-    ]);
-    const directRunnerEvidence = (output) => collectDirectRunnerEvidence(runnerReportDir, output);
     const releaseAndroidSlot = deps.releaseAndroidSlot ?? releaseAndroidInteractionSlot;
     const androidSlotReleaseWarnings = [];
     let releasedAndroidDeviceId;
@@ -34414,6 +34411,12 @@ function createMaestroRunHandler(deps = {}) {
         });
       }
     }
+    const runnerReportDir = (deps.createReportDir ?? createRunnerReportDir)(dispatch.runner, "rn-maestro-report");
+    const finalArgs = assembleMaestroArgs(baseArgs, [
+      ...runnerReportArgs(runnerReportDir),
+      ...paramArgs
+    ]);
+    const directRunnerEvidence = (output) => collectDirectRunnerEvidence(runnerReportDir, output);
     try {
       const managedAuthority = nestedMaestroAuthorityCallbacks(args);
       const claimOrigin = args.claimNativeOrigin ?? deps.claimNativeOrigin ?? managedAuthority.claimNativeOrigin;
@@ -79186,6 +79189,12 @@ async function persistRun(actionId, projectRoot, record2) {
 
 // packages/rn-dev-agent-core/dist/domain/action-inventory.js
 init_action_store();
+function emitInventoryWarning(warning) {
+  process.emitWarning(warning.message, {
+    type: "ActionInventoryWarning",
+    code: warning.code
+  });
+}
 async function listActions(projectRoot, dependencies = {}) {
   const context = openReadableActionLoadContext(projectRoot);
   if (!context)
@@ -79196,9 +79205,27 @@ async function listActions(projectRoot, dependencies = {}) {
   for (const id of new Set(yamlFiles.map((file) => file.replace(/\.ya?ml$/, "")))) {
     if (yamlFiles.includes(`${id}.yaml`) && yamlFiles.includes(`${id}.yml`))
       continue;
-    const action = load(context, id);
-    if (!action)
+    const file = yamlFiles.includes(`${id}.yaml`) ? `${id}.yaml` : `${id}.yml`;
+    let action;
+    let failure;
+    try {
+      action = load(context, id);
+      if (!action)
+        failure = new Error("missing or invalid action metadata");
+    } catch (error2) {
+      failure = error2;
+      action = null;
+    }
+    if (!action) {
+      assertReadableActionLoadContextStable(context);
+      const message = `Skipped corrupt action inventory entry ${file}: ${failure instanceof Error ? failure.message : String(failure)}`;
+      (dependencies.onWarning ?? emitInventoryWarning)({
+        code: "ACTION_INVENTORY_ENTRY_SKIPPED",
+        file,
+        message
+      });
       continue;
+    }
     const { metadata } = action;
     const summary = {
       id: metadata.id,

--- a/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -14218,12 +14218,6 @@ function createMaestroRunHandler(deps = {}) {
         paramArgs.push("-e", `${key}=${value}`);
       }
     }
-    const runnerReportDir = createRunnerReportDir(dispatch.runner, "rn-maestro-report");
-    const finalArgs = assembleMaestroArgs(baseArgs, [
-      ...runnerReportArgs(runnerReportDir),
-      ...paramArgs
-    ]);
-    const directRunnerEvidence = (output) => collectDirectRunnerEvidence(runnerReportDir, output);
     const releaseAndroidSlot = deps.releaseAndroidSlot ?? releaseAndroidInteractionSlot;
     const androidSlotReleaseWarnings = [];
     let releasedAndroidDeviceId;
@@ -14290,6 +14284,12 @@ function createMaestroRunHandler(deps = {}) {
         });
       }
     }
+    const runnerReportDir = (deps.createReportDir ?? createRunnerReportDir)(dispatch.runner, "rn-maestro-report");
+    const finalArgs = assembleMaestroArgs(baseArgs, [
+      ...runnerReportArgs(runnerReportDir),
+      ...paramArgs
+    ]);
+    const directRunnerEvidence = (output) => collectDirectRunnerEvidence(runnerReportDir, output);
     try {
       const managedAuthority = nestedMaestroAuthorityCallbacks(args);
       const claimOrigin = args.claimNativeOrigin ?? deps.claimNativeOrigin ?? managedAuthority.claimNativeOrigin;

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -29852,6 +29852,9 @@ function assertStableReadableCorpus(projectRoot, expected) {
     throw new Error(`Refusing replaced learned-action corpus symlink at ${actionsDir}.`);
   }
 }
+function assertReadableActionLoadContextStable(context) {
+  assertStableReadableCorpus(context.projectRoot, context.corpus);
+}
 function lstatIfPresent2(path) {
   try {
     return lstatSync13(path);
@@ -34497,12 +34500,6 @@ function createMaestroRunHandler(deps = {}) {
         paramArgs.push("-e", `${key}=${value}`);
       }
     }
-    const runnerReportDir = createRunnerReportDir(dispatch.runner, "rn-maestro-report");
-    const finalArgs = assembleMaestroArgs(baseArgs, [
-      ...runnerReportArgs(runnerReportDir),
-      ...paramArgs
-    ]);
-    const directRunnerEvidence = (output) => collectDirectRunnerEvidence(runnerReportDir, output);
     const releaseAndroidSlot = deps.releaseAndroidSlot ?? releaseAndroidInteractionSlot;
     const androidSlotReleaseWarnings = [];
     let releasedAndroidDeviceId;
@@ -34569,6 +34566,12 @@ function createMaestroRunHandler(deps = {}) {
         });
       }
     }
+    const runnerReportDir = (deps.createReportDir ?? createRunnerReportDir)(dispatch.runner, "rn-maestro-report");
+    const finalArgs = assembleMaestroArgs(baseArgs, [
+      ...runnerReportArgs(runnerReportDir),
+      ...paramArgs
+    ]);
+    const directRunnerEvidence = (output) => collectDirectRunnerEvidence(runnerReportDir, output);
     try {
       const managedAuthority = nestedMaestroAuthorityCallbacks(args);
       const claimOrigin = args.claimNativeOrigin ?? deps.claimNativeOrigin ?? managedAuthority.claimNativeOrigin;
@@ -81129,6 +81132,12 @@ var init_run_action = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/action-inventory.js
+function emitInventoryWarning(warning) {
+  process.emitWarning(warning.message, {
+    type: "ActionInventoryWarning",
+    code: warning.code
+  });
+}
 async function listActions(projectRoot, dependencies = {}) {
   const context = openReadableActionLoadContext(projectRoot);
   if (!context)
@@ -81139,9 +81148,27 @@ async function listActions(projectRoot, dependencies = {}) {
   for (const id of new Set(yamlFiles.map((file) => file.replace(/\.ya?ml$/, "")))) {
     if (yamlFiles.includes(`${id}.yaml`) && yamlFiles.includes(`${id}.yml`))
       continue;
-    const action = load(context, id);
-    if (!action)
+    const file = yamlFiles.includes(`${id}.yaml`) ? `${id}.yaml` : `${id}.yml`;
+    let action;
+    let failure;
+    try {
+      action = load(context, id);
+      if (!action)
+        failure = new Error("missing or invalid action metadata");
+    } catch (error2) {
+      failure = error2;
+      action = null;
+    }
+    if (!action) {
+      assertReadableActionLoadContextStable(context);
+      const message = `Skipped corrupt action inventory entry ${file}: ${failure instanceof Error ? failure.message : String(failure)}`;
+      (dependencies.onWarning ?? emitInventoryWarning)({
+        code: "ACTION_INVENTORY_ENTRY_SKIPPED",
+        file,
+        message
+      });
       continue;
+    }
     const { metadata } = action;
     const summary = {
       id: metadata.id,

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -26924,6 +26924,9 @@ function assertStableReadableCorpus(projectRoot, expected) {
     throw new Error(`Refusing replaced learned-action corpus symlink at ${actionsDir}.`);
   }
 }
+function assertReadableActionLoadContextStable(context) {
+  assertStableReadableCorpus(context.projectRoot, context.corpus);
+}
 function lstatIfPresent2(path) {
   try {
     return lstatSync9(path);
@@ -34342,12 +34345,6 @@ function createMaestroRunHandler(deps = {}) {
         paramArgs.push("-e", `${key}=${value}`);
       }
     }
-    const runnerReportDir = createRunnerReportDir(dispatch.runner, "rn-maestro-report");
-    const finalArgs = assembleMaestroArgs(baseArgs, [
-      ...runnerReportArgs(runnerReportDir),
-      ...paramArgs
-    ]);
-    const directRunnerEvidence = (output) => collectDirectRunnerEvidence(runnerReportDir, output);
     const releaseAndroidSlot = deps.releaseAndroidSlot ?? releaseAndroidInteractionSlot;
     const androidSlotReleaseWarnings = [];
     let releasedAndroidDeviceId;
@@ -34414,6 +34411,12 @@ function createMaestroRunHandler(deps = {}) {
         });
       }
     }
+    const runnerReportDir = (deps.createReportDir ?? createRunnerReportDir)(dispatch.runner, "rn-maestro-report");
+    const finalArgs = assembleMaestroArgs(baseArgs, [
+      ...runnerReportArgs(runnerReportDir),
+      ...paramArgs
+    ]);
+    const directRunnerEvidence = (output) => collectDirectRunnerEvidence(runnerReportDir, output);
     try {
       const managedAuthority = nestedMaestroAuthorityCallbacks(args);
       const claimOrigin = args.claimNativeOrigin ?? deps.claimNativeOrigin ?? managedAuthority.claimNativeOrigin;
@@ -79186,6 +79189,12 @@ async function persistRun(actionId, projectRoot, record2) {
 
 // packages/rn-dev-agent-core/dist/domain/action-inventory.js
 init_action_store();
+function emitInventoryWarning(warning) {
+  process.emitWarning(warning.message, {
+    type: "ActionInventoryWarning",
+    code: warning.code
+  });
+}
 async function listActions(projectRoot, dependencies = {}) {
   const context = openReadableActionLoadContext(projectRoot);
   if (!context)
@@ -79196,9 +79205,27 @@ async function listActions(projectRoot, dependencies = {}) {
   for (const id of new Set(yamlFiles.map((file) => file.replace(/\.ya?ml$/, "")))) {
     if (yamlFiles.includes(`${id}.yaml`) && yamlFiles.includes(`${id}.yml`))
       continue;
-    const action = load(context, id);
-    if (!action)
+    const file = yamlFiles.includes(`${id}.yaml`) ? `${id}.yaml` : `${id}.yml`;
+    let action;
+    let failure;
+    try {
+      action = load(context, id);
+      if (!action)
+        failure = new Error("missing or invalid action metadata");
+    } catch (error2) {
+      failure = error2;
+      action = null;
+    }
+    if (!action) {
+      assertReadableActionLoadContextStable(context);
+      const message = `Skipped corrupt action inventory entry ${file}: ${failure instanceof Error ? failure.message : String(failure)}`;
+      (dependencies.onWarning ?? emitInventoryWarning)({
+        code: "ACTION_INVENTORY_ENTRY_SKIPPED",
+        file,
+        message
+      });
       continue;
+    }
     const { metadata } = action;
     const summary = {
       id: metadata.id,

--- a/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/maestro-runner-pin.js
@@ -14218,12 +14218,6 @@ function createMaestroRunHandler(deps = {}) {
         paramArgs.push("-e", `${key}=${value}`);
       }
     }
-    const runnerReportDir = createRunnerReportDir(dispatch.runner, "rn-maestro-report");
-    const finalArgs = assembleMaestroArgs(baseArgs, [
-      ...runnerReportArgs(runnerReportDir),
-      ...paramArgs
-    ]);
-    const directRunnerEvidence = (output) => collectDirectRunnerEvidence(runnerReportDir, output);
     const releaseAndroidSlot = deps.releaseAndroidSlot ?? releaseAndroidInteractionSlot;
     const androidSlotReleaseWarnings = [];
     let releasedAndroidDeviceId;
@@ -14290,6 +14284,12 @@ function createMaestroRunHandler(deps = {}) {
         });
       }
     }
+    const runnerReportDir = (deps.createReportDir ?? createRunnerReportDir)(dispatch.runner, "rn-maestro-report");
+    const finalArgs = assembleMaestroArgs(baseArgs, [
+      ...runnerReportArgs(runnerReportDir),
+      ...paramArgs
+    ]);
+    const directRunnerEvidence = (output) => collectDirectRunnerEvidence(runnerReportDir, output);
     try {
       const managedAuthority = nestedMaestroAuthorityCallbacks(args);
       const claimOrigin = args.claimNativeOrigin ?? deps.claimNativeOrigin ?? managedAuthority.claimNativeOrigin;

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -29852,6 +29852,9 @@ function assertStableReadableCorpus(projectRoot, expected) {
     throw new Error(`Refusing replaced learned-action corpus symlink at ${actionsDir}.`);
   }
 }
+function assertReadableActionLoadContextStable(context) {
+  assertStableReadableCorpus(context.projectRoot, context.corpus);
+}
 function lstatIfPresent2(path) {
   try {
     return lstatSync13(path);
@@ -34497,12 +34500,6 @@ function createMaestroRunHandler(deps = {}) {
         paramArgs.push("-e", `${key}=${value}`);
       }
     }
-    const runnerReportDir = createRunnerReportDir(dispatch.runner, "rn-maestro-report");
-    const finalArgs = assembleMaestroArgs(baseArgs, [
-      ...runnerReportArgs(runnerReportDir),
-      ...paramArgs
-    ]);
-    const directRunnerEvidence = (output) => collectDirectRunnerEvidence(runnerReportDir, output);
     const releaseAndroidSlot = deps.releaseAndroidSlot ?? releaseAndroidInteractionSlot;
     const androidSlotReleaseWarnings = [];
     let releasedAndroidDeviceId;
@@ -34569,6 +34566,12 @@ function createMaestroRunHandler(deps = {}) {
         });
       }
     }
+    const runnerReportDir = (deps.createReportDir ?? createRunnerReportDir)(dispatch.runner, "rn-maestro-report");
+    const finalArgs = assembleMaestroArgs(baseArgs, [
+      ...runnerReportArgs(runnerReportDir),
+      ...paramArgs
+    ]);
+    const directRunnerEvidence = (output) => collectDirectRunnerEvidence(runnerReportDir, output);
     try {
       const managedAuthority = nestedMaestroAuthorityCallbacks(args);
       const claimOrigin = args.claimNativeOrigin ?? deps.claimNativeOrigin ?? managedAuthority.claimNativeOrigin;
@@ -81129,6 +81132,12 @@ var init_run_action = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/domain/action-inventory.js
+function emitInventoryWarning(warning) {
+  process.emitWarning(warning.message, {
+    type: "ActionInventoryWarning",
+    code: warning.code
+  });
+}
 async function listActions(projectRoot, dependencies = {}) {
   const context = openReadableActionLoadContext(projectRoot);
   if (!context)
@@ -81139,9 +81148,27 @@ async function listActions(projectRoot, dependencies = {}) {
   for (const id of new Set(yamlFiles.map((file) => file.replace(/\.ya?ml$/, "")))) {
     if (yamlFiles.includes(`${id}.yaml`) && yamlFiles.includes(`${id}.yml`))
       continue;
-    const action = load(context, id);
-    if (!action)
+    const file = yamlFiles.includes(`${id}.yaml`) ? `${id}.yaml` : `${id}.yml`;
+    let action;
+    let failure;
+    try {
+      action = load(context, id);
+      if (!action)
+        failure = new Error("missing or invalid action metadata");
+    } catch (error2) {
+      failure = error2;
+      action = null;
+    }
+    if (!action) {
+      assertReadableActionLoadContextStable(context);
+      const message = `Skipped corrupt action inventory entry ${file}: ${failure instanceof Error ? failure.message : String(failure)}`;
+      (dependencies.onWarning ?? emitInventoryWarning)({
+        code: "ACTION_INVENTORY_ENTRY_SKIPPED",
+        file,
+        message
+      });
       continue;
+    }
     const { metadata } = action;
     const summary = {
       id: metadata.id,

--- a/packages/rn-dev-agent-core/dist/domain/action-inventory.js
+++ b/packages/rn-dev-agent-core/dist/domain/action-inventory.js
@@ -1,4 +1,10 @@
-import { loadActionFromContext, openReadableActionLoadContext, } from './action-store.js';
+import { assertReadableActionLoadContextStable, loadActionFromContext, openReadableActionLoadContext, } from './action-store.js';
+function emitInventoryWarning(warning) {
+    process.emitWarning(warning.message, {
+        type: 'ActionInventoryWarning',
+        code: warning.code,
+    });
+}
 export async function listActions(projectRoot, dependencies = {}) {
     const context = openReadableActionLoadContext(projectRoot);
     if (!context)
@@ -10,9 +16,28 @@ export async function listActions(projectRoot, dependencies = {}) {
         // Inventory omits yaml/yml twins; resolveActionPath still refuses replay.
         if (yamlFiles.includes(`${id}.yaml`) && yamlFiles.includes(`${id}.yml`))
             continue;
-        const action = load(context, id);
-        if (!action)
+        const file = yamlFiles.includes(`${id}.yaml`) ? `${id}.yaml` : `${id}.yml`;
+        let action;
+        let failure;
+        try {
+            action = load(context, id);
+            if (!action)
+                failure = new Error('missing or invalid action metadata');
+        }
+        catch (error) {
+            failure = error;
+            action = null;
+        }
+        if (!action) {
+            assertReadableActionLoadContextStable(context);
+            const message = `Skipped corrupt action inventory entry ${file}: ${failure instanceof Error ? failure.message : String(failure)}`;
+            (dependencies.onWarning ?? emitInventoryWarning)({
+                code: 'ACTION_INVENTORY_ENTRY_SKIPPED',
+                file,
+                message,
+            });
             continue;
+        }
         const { metadata } = action;
         const summary = {
             id: metadata.id,

--- a/packages/rn-dev-agent-core/dist/domain/action-store.js
+++ b/packages/rn-dev-agent-core/dist/domain/action-store.js
@@ -55,6 +55,9 @@ function assertStableReadableCorpus(projectRoot, expected) {
         throw new Error(`Refusing replaced learned-action corpus symlink at ${actionsDir}.`);
     }
 }
+export function assertReadableActionLoadContextStable(context) {
+    assertStableReadableCorpus(context.projectRoot, context.corpus);
+}
 function lstatIfPresent(path) {
     try {
         return lstatSync(path);

--- a/packages/rn-dev-agent-core/dist/tools/maestro-run.js
+++ b/packages/rn-dev-agent-core/dist/tools/maestro-run.js
@@ -418,14 +418,6 @@ export function createMaestroRunHandler(deps = {}) {
                 paramArgs.push('-e', `${key}=${value}`);
             }
         }
-        // A unique flattened report gives us maestro-runner's direct selected-device
-        // and WDA target log. Never infer execution identity from requested argv.
-        const runnerReportDir = createRunnerReportDir(dispatch.runner, 'rn-maestro-report');
-        const finalArgs = assembleMaestroArgs(baseArgs, [
-            ...runnerReportArgs(runnerReportDir),
-            ...paramArgs,
-        ]);
-        const directRunnerEvidence = (output) => collectDirectRunnerEvidence(runnerReportDir, output);
         const releaseAndroidSlot = deps.releaseAndroidSlot ?? defaultReleaseAndroidSlot;
         const androidSlotReleaseWarnings = [];
         let releasedAndroidDeviceId;
@@ -506,6 +498,13 @@ export function createMaestroRunHandler(deps = {}) {
                 });
             }
         }
+        // Allocate report evidence only after preflight so refusal leaves no scratch tree.
+        const runnerReportDir = (deps.createReportDir ?? createRunnerReportDir)(dispatch.runner, 'rn-maestro-report');
+        const finalArgs = assembleMaestroArgs(baseArgs, [
+            ...runnerReportArgs(runnerReportDir),
+            ...paramArgs,
+        ]);
+        const directRunnerEvidence = (output) => collectDirectRunnerEvidence(runnerReportDir, output);
         try {
             // 10MB buffer: a multi-step flow with screenshots + app console/network
             // logs routinely exceeds Node's 1MB execFile default, which would kill

--- a/packages/rn-dev-agent-core/src/domain/action-inventory.ts
+++ b/packages/rn-dev-agent-core/src/domain/action-inventory.ts
@@ -1,4 +1,5 @@
 import {
+  assertReadableActionLoadContextStable,
   loadActionFromContext,
   openReadableActionLoadContext,
   type ReadableActionLoadContext,
@@ -10,11 +11,25 @@ import type { ActionSummary } from '../observability/wire-types.js';
 // the observe SPA).
 export type { ActionSummary } from '../observability/wire-types.js';
 
+export interface ActionInventoryWarning {
+  code: 'ACTION_INVENTORY_ENTRY_SKIPPED';
+  file: string;
+  message: string;
+}
+
 export interface ActionInventoryDependencies {
   loadAction?: (
     context: ReadableActionLoadContext,
     actionId: string,
   ) => ReturnType<typeof loadActionFromContext>;
+  onWarning?: (warning: ActionInventoryWarning) => void;
+}
+
+function emitInventoryWarning(warning: ActionInventoryWarning): void {
+  process.emitWarning(warning.message, {
+    type: 'ActionInventoryWarning',
+    code: warning.code,
+  });
 }
 
 export async function listActions(
@@ -29,8 +44,28 @@ export async function listActions(
   for (const id of new Set(yamlFiles.map((file) => file.replace(/\.ya?ml$/, '')))) {
     // Inventory omits yaml/yml twins; resolveActionPath still refuses replay.
     if (yamlFiles.includes(`${id}.yaml`) && yamlFiles.includes(`${id}.yml`)) continue;
-    const action = load(context, id);
-    if (!action) continue;
+    const file = yamlFiles.includes(`${id}.yaml`) ? `${id}.yaml` : `${id}.yml`;
+    let action: ReturnType<typeof loadActionFromContext>;
+    let failure: unknown;
+    try {
+      action = load(context, id);
+      if (!action) failure = new Error('missing or invalid action metadata');
+    } catch (error) {
+      failure = error;
+      action = null;
+    }
+    if (!action) {
+      assertReadableActionLoadContextStable(context);
+      const message = `Skipped corrupt action inventory entry ${file}: ${
+        failure instanceof Error ? failure.message : String(failure)
+      }`;
+      (dependencies.onWarning ?? emitInventoryWarning)({
+        code: 'ACTION_INVENTORY_ENTRY_SKIPPED',
+        file,
+        message,
+      });
+      continue;
+    }
     const { metadata } = action;
     const summary: ActionSummary = {
       id: metadata.id,

--- a/packages/rn-dev-agent-core/src/domain/action-store.ts
+++ b/packages/rn-dev-agent-core/src/domain/action-store.ts
@@ -79,6 +79,10 @@ function assertStableReadableCorpus(
   }
 }
 
+export function assertReadableActionLoadContextStable(context: ReadableActionLoadContext): void {
+  assertStableReadableCorpus(context.projectRoot, context.corpus);
+}
+
 function lstatIfPresent(path: string): ReturnType<typeof lstatSync> | null {
   try {
     return lstatSync(path);

--- a/packages/rn-dev-agent-core/src/tools/maestro-run.ts
+++ b/packages/rn-dev-agent-core/src/tools/maestro-run.ts
@@ -361,6 +361,7 @@ export interface MaestroRunDeps {
   /** GH #741: null = unknown (probe failure fails open, never refuses). */
   probeAndroidApiLevel?: (deviceId: string) => Promise<number | null>;
   resolveEngineStatus?: () => Promise<ReplayEngineStatus | null>;
+  createReportDir?: typeof createRunnerReportDir;
 }
 
 async function defaultProbeAndroidApiLevel(deviceId: string): Promise<number | null> {
@@ -648,15 +649,6 @@ export function createMaestroRunHandler(
         paramArgs.push('-e', `${key}=${value}`);
       }
     }
-    // A unique flattened report gives us maestro-runner's direct selected-device
-    // and WDA target log. Never infer execution identity from requested argv.
-    const runnerReportDir = createRunnerReportDir(dispatch.runner, 'rn-maestro-report');
-    const finalArgs = assembleMaestroArgs(baseArgs, [
-      ...runnerReportArgs(runnerReportDir),
-      ...paramArgs,
-    ]);
-    const directRunnerEvidence = (output: string) =>
-      collectDirectRunnerEvidence(runnerReportDir, output);
     const releaseAndroidSlot = deps.releaseAndroidSlot ?? defaultReleaseAndroidSlot;
     const androidSlotReleaseWarnings: string[] = [];
     let releasedAndroidDeviceId: string | undefined;
@@ -740,6 +732,18 @@ export function createMaestroRunHandler(
         });
       }
     }
+
+    // Allocate report evidence only after preflight so refusal leaves no scratch tree.
+    const runnerReportDir = (deps.createReportDir ?? createRunnerReportDir)(
+      dispatch.runner,
+      'rn-maestro-report',
+    );
+    const finalArgs = assembleMaestroArgs(baseArgs, [
+      ...runnerReportArgs(runnerReportDir),
+      ...paramArgs,
+    ]);
+    const directRunnerEvidence = (output: string) =>
+      collectDirectRunnerEvidence(runnerReportDir, output);
 
     try {
       // 10MB buffer: a multi-step flow with screenshots + app console/network

--- a/packages/rn-dev-agent-core/test/unit/action-inventory.test.js
+++ b/packages/rn-dev-agent-core/test/unit/action-inventory.test.js
@@ -4,6 +4,7 @@ import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { listActions } from '../../dist/domain/action-inventory.js';
+import { loadAction } from '../../dist/domain/action-store.js';
 
 function makeProject() {
   const root = join(
@@ -51,17 +52,27 @@ test('listActions returns correct summaries sorted by id', async () => {
   }
 });
 
-test('listActions skips unparseable files and continues', async () => {
+test('listActions skips one corrupt file with one typed warning and keeps valid actions usable', async () => {
   const root = makeProject();
   try {
     writeAction(root, 'good-action');
     writeFileSync(
       join(root, '.rn-agent', 'actions', 'bad-action.yaml'),
-      'not: yaml: with: no: m7: header\n',
+      '# id: renamed-action\n# intent: Broken identity\n# status: active\n- launchApp\n',
     );
-    const result = await listActions(root);
+    const warnings = [];
+    const result = await listActions(root, { onWarning: (warning) => warnings.push(warning) });
     assert.equal(result.length, 1);
     assert.equal(result[0].id, 'good-action');
+    assert.deepEqual(warnings, [
+      {
+        code: 'ACTION_INVENTORY_ENTRY_SKIPPED',
+        file: 'bad-action.yaml',
+        message:
+          'Skipped corrupt action inventory entry bad-action.yaml: Action metadata id renamed-action does not match filename identity bad-action.',
+      },
+    ]);
+    assert.equal(loadAction(root, 'good-action')?.metadata.id, 'good-action');
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/rn-dev-agent-core/test/unit/gh-588-runner-report-cleanup.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-588-runner-report-cleanup.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, test } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createMaestroRunHandler } from '../../dist/tools/maestro-run.js';
@@ -140,6 +140,41 @@ test('a non-zero runner exit still deletes its temporary report tree', async () 
   assert.equal(body.meta.deviceAuthority.reportedDeviceId, EXACT);
   assert.equal(body.meta.runnerReportDir, undefined);
   assert.equal(existsSync(seen.dir!), false, 'report tree must be removed on the failure path');
+});
+
+test('runner preflight refusal leaves no report directory tree', async () => {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'rn-maestro-report-refusal-fixture-'));
+  let execCalls = 0;
+  try {
+    const handler = createMaestroRunHandler({
+      getActiveSession: () => ({
+        name: 'exact',
+        platform: 'ios',
+        deviceId: EXACT,
+        appId: APP_ID,
+        openedAt: new Date(0).toISOString(),
+      }),
+      chooseDispatch: () => fakeRunnerDispatch(),
+      resolveEngineStatus: async () => buildReplayEngineStatus('drift-older', '1.1.23', false),
+      createReportDir: () => mkdtempSync(join(fixtureRoot, 'rn-maestro-report-')),
+      execFile: async () => {
+        execCalls += 1;
+        return { stdout: '', stderr: '' };
+      },
+    });
+
+    const result = await handler({
+      inlineYaml: '- launchApp',
+      platform: 'ios',
+      appId: APP_ID,
+    });
+    const body = JSON.parse(result.content[0].text);
+    assert.equal(body.code, 'ENGINE_PIN_MISMATCH');
+    assert.equal(execCalls, 0, 'preflight refusal must not execute the runner');
+    assert.deepEqual(readdirSync(fixtureRoot), [], 'report directory tree must remain clean');
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
 });
 
 test('structured report identity survives scalar and alternate device key spellings', () => {


### PR DESCRIPTION
## Intent

Implement only the captain-approved corpus/report hygiene split from simplified issue #812: when action inventory contains one corrupt entry, list every valid action, emit exactly one typed warning naming the corrupt file, and succeed; add one corrupt-fixture behavioral regression proving valid actions remain usable and the warning is emitted once; when Maestro preflight refuses before runner execution, leave no rn-maestro-report-* directory and add one regression asserting the report tree is clean; preserve terminal corpus-change and refusal behavior when the corpus itself changes during inventory; keep generated runtimes and documentation synchronized where affected; ship one focused PR. Exclude generalized diagnostics, duplicate corpus classifiers, installer or cache behavior, auto-login device work, runner-floor wording, instruction-delivery tests, unrelated action semantics, and obsolete fm/issue-812-p2 history. A bounded identical-command comparison against clean current origin/main reproduced the same five unrelated action-migration failures and one overwrite-lock timeout, so retain that baseline evidence, use the scoped hygiene regressions as the task signal, and do not fix those unrelated failures.

## What Changed

- Keep valid actions available when an inventory entry is corrupt, emitting one typed warning with the skipped filename while preserving terminal corpus-integrity failures.
- Defer Maestro report-directory creation until preflight succeeds so refusals leave no `rn-maestro-report-*` tree.
- Add focused regressions and documentation, and synchronize the generated Claude and Codex runtimes.

## Risk Assessment

✅ Low: The changes are narrowly scoped and preserve the required corpus-integrity and report-cleanup invariants, with synchronized runtimes, documentation, changeset, and behavioral regressions.

## Testing

After restoring the isolated worktree’s Yarn state, the focused core build and scoped hygiene/integrity regressions passed. Executable JSON evidence demonstrates the valid action remains listed and loadable alongside exactly one typed corrupt-file warning, while Maestro preflight refusal executes no runner, allocates no report directory, and leaves the report tree empty. The supplied origin/main baseline containing five unrelated action-migration failures and one overwrite-lock timeout was retained as context and not treated as task signal. No screenshot was captured because this is a non-UI protocol/filesystem change; the JSON response and persisted filesystem-state evidence are the relevant user-facing artifacts.

<details>
<summary>Evidence: Corpus and report hygiene evidence</summary>

`Shows one typed warning for bad-action.yaml, good-action remaining loadable, ENGINE_PIN_MISMATCH before runner execution, zero report-directory allocations, and an empty report tree.`

```text
{
  "corruptCorpusExperience": {
    "inventorySucceeded": true,
    "listedActions": [
      {
        "id": "good-action",
        "intent": "Run the valid flow",
        "status": "active"
      }
    ],
    "warningCount": 1,
    "warnings": [
      {
        "type": "ActionInventoryWarning",
        "code": "ACTION_INVENTORY_ENTRY_SKIPPED",
        "message": "Skipped corrupt action inventory entry bad-action.yaml: Action metadata id renamed-action does not match filename identity bad-action."
      }
    ],
    "validActionStillLoads": true
  },
  "maestroPreflightExperience": {
    "response": {
      "ok": false,
      "code": "ENGINE_PIN_MISMATCH"
    },
    "runnerExecutions": 0,
    "createReportDirCalls": 0,
    "reportTreeEntries": []
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6860010c2e2dd0223da11927852f5ff3c86e9ec6","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`corepack yarn build:core` (initially exposed missing Yarn install state; passed after local dependency recovery)</code>
- `corepack yarn install --immutable`
- `node --test packages/rn-dev-agent-core/test/unit/action-inventory.test.js`
- `node --test --test-name-pattern='runner preflight refusal leaves no report directory tree|a passing runner flow consumes then deletes its temporary report tree|a non-zero runner exit still deletes its temporary report tree' packages/rn-dev-agent-core/test/unit/gh-588-runner-report-cleanup.test.ts`
- `node --test --test-name-pattern='inventory stays bound to its original corpus snapshot|follow-all-symlinks would accept a foreign corpus that the allowlist refuses' packages/rn-dev-agent-core/test/unit/gh-812-inherited-action-corpus.test.ts`
- `node /Users/antonlykhoyda/.no-mistakes/evidence/01M0QVT7HDBWGHQ8XSW0PTD3FQ/hygiene-evidence.mjs`
- <code>Verified `git status --short` remained clean after removing testing-created `node_modules`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
