### PR TITLE
fix(core): target auto-login to the bound device

### DIFF
--- a/.changeset/quiet-device-compasses.md
+++ b/.changeset/quiet-device-compasses.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-core": patch
+"rn-dev-agent-plugin": patch
+---
+
+Route auto-login through the exact bound device and refuse unbound ambient device selection with an executable authority remedy.

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -85670,7 +85670,15 @@ function autoLoginToolResult(result) {
   if (result.code) {
     return failResult(result.reason, result.code, result.nextAction ? { nextAction: result.nextAction } : void 0);
   }
-  return failResult(result.reason);
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({ ok: false, error: result.reason, data: result })
+      }
+    ],
+    isError: true
+  };
 }
 
 // packages/rn-dev-agent-core/dist/tools/proof-step.js

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -85375,6 +85375,8 @@ function createNavGraphHandler(getClient2) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/auto-login.js
+init_utils();
+init_agent_device_wrapper();
 init_storage();
 init_project_config();
 init_maestro_validator();
@@ -85519,17 +85521,21 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
   if (!onAuth) {
     return { loggedIn: false, reason: "App is not on an auth screen" };
   }
-  const platform = opts.platform;
+  const session2 = (deps.getSession ?? getActiveSession)();
+  const platform = opts.platform ?? session2?.platform;
   if (platform !== "ios" && platform !== "android") {
     return {
       loggedIn: false,
       reason: 'Cannot determine platform. Pass platform="ios" or platform="android" explicitly, or open a device session first.'
     };
   }
-  if (!opts.deviceId) {
+  const deviceId = opts.deviceId ?? (session2?.platform === platform ? session2.deviceId : void 0);
+  if (!deviceId) {
     return {
       loggedIn: false,
-      reason: `Auto-login requires an owned ${platform} session bound to one exact device.`
+      reason: `Auto-login requires an owned ${platform} session bound to one exact device.`,
+      code: "DEVICE_AUTHORITY_MISMATCH",
+      nextAction: 'Run rn_session with action "status" and repair the device authority binding, then retry cdp_auto_login.'
     };
   }
   const boundProjectRoot = (deps.boundProjectRoot ?? boundSessionProjectRoot)();
@@ -85625,7 +85631,7 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
   const replay = await maestroRun({
     inlineYaml: wrapperContent,
     platform,
-    deviceId: opts.deviceId,
+    deviceId,
     timeoutMs: 12e4,
     ...managedAuthority
   });
@@ -85655,6 +85661,16 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
     reason: "Auto-login via Maestro subflow succeeded",
     flow: flowPath
   };
+}
+function autoLoginToolResult(result) {
+  if (result === null)
+    return failResult("CDP not connected or helpers not injected");
+  if (result.loggedIn || result.reason.includes("not on an auth screen"))
+    return okResult(result);
+  if (result.code) {
+    return failResult(result.reason, result.code, result.nextAction ? { nextAction: result.nextAction } : void 0);
+  }
+  return failResult(result.reason);
 }
 
 // packages/rn-dev-agent-core/dist/tools/proof-step.js
@@ -92171,22 +92187,7 @@ trackedTool("cdp_auto_login", "Explicit legacy navigation helper that detects an
   appId: external_exports.string().optional().describe("App bundle ID override (auto-detected from app.json if omitted)"),
   platform: external_exports.enum(["ios", "android"]).optional().describe("Platform override (auto-detected from session if omitted)")
 }, withConnection(getClient, async (args, client2) => {
-  const result = await handleAutoLogin(client2, args);
-  if (result === null)
-    return failResult("CDP not connected or helpers not injected");
-  if (result.loggedIn)
-    return okResult(result);
-  if (result.reason.includes("not on an auth screen"))
-    return okResult(result);
-  return {
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify({ ok: false, error: result.reason, data: result })
-      }
-    ],
-    isError: true
-  };
+  return autoLoginToolResult(await handleAutoLogin(client2, args));
 }));
 trackedTool("proof_step", "Atomic proof capture step: navigate to a screen (optional), wait for settlement, verify an element (optional), and take a screenshot. Combines 3-4 tool calls into one. Use in proof flows to reduce tool-call overhead.", {
   screen: external_exports.string().optional().describe("Screen to navigate to (omit to stay on current screen)"),

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -87719,7 +87719,15 @@ function autoLoginToolResult(result) {
   if (result.code) {
     return failResult(result.reason, result.code, result.nextAction ? { nextAction: result.nextAction } : void 0);
   }
-  return failResult(result.reason);
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({ ok: false, error: result.reason, data: result })
+      }
+    ],
+    isError: true
+  };
 }
 var AUTH_ROUTE_PATTERNS, LOGIN_FLOW_PRIORITY;
 var init_auto_login = __esm({

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -87570,17 +87570,21 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
   if (!onAuth) {
     return { loggedIn: false, reason: "App is not on an auth screen" };
   }
-  const platform = opts.platform;
+  const session2 = (deps.getSession ?? getActiveSession)();
+  const platform = opts.platform ?? session2?.platform;
   if (platform !== "ios" && platform !== "android") {
     return {
       loggedIn: false,
       reason: 'Cannot determine platform. Pass platform="ios" or platform="android" explicitly, or open a device session first.'
     };
   }
-  if (!opts.deviceId) {
+  const deviceId = opts.deviceId ?? (session2?.platform === platform ? session2.deviceId : void 0);
+  if (!deviceId) {
     return {
       loggedIn: false,
-      reason: `Auto-login requires an owned ${platform} session bound to one exact device.`
+      reason: `Auto-login requires an owned ${platform} session bound to one exact device.`,
+      code: "DEVICE_AUTHORITY_MISMATCH",
+      nextAction: 'Run rn_session with action "status" and repair the device authority binding, then retry cdp_auto_login.'
     };
   }
   const boundProjectRoot = (deps.boundProjectRoot ?? boundSessionProjectRoot)();
@@ -87676,7 +87680,7 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
   const replay = await maestroRun({
     inlineYaml: wrapperContent,
     platform,
-    deviceId: opts.deviceId,
+    deviceId,
     timeoutMs: 12e4,
     ...managedAuthority
   });
@@ -87707,10 +87711,22 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
     flow: flowPath
   };
 }
+function autoLoginToolResult(result) {
+  if (result === null)
+    return failResult("CDP not connected or helpers not injected");
+  if (result.loggedIn || result.reason.includes("not on an auth screen"))
+    return okResult(result);
+  if (result.code) {
+    return failResult(result.reason, result.code, result.nextAction ? { nextAction: result.nextAction } : void 0);
+  }
+  return failResult(result.reason);
+}
 var AUTH_ROUTE_PATTERNS, LOGIN_FLOW_PRIORITY;
 var init_auto_login = __esm({
   "packages/rn-dev-agent-core/dist/tools/auto-login.js"() {
     "use strict";
+    init_utils();
+    init_agent_device_wrapper();
     init_storage();
     init_project_config();
     init_maestro_validator();
@@ -94297,22 +94313,7 @@ var init_index = __esm({
       appId: external_exports.string().optional().describe("App bundle ID override (auto-detected from app.json if omitted)"),
       platform: external_exports.enum(["ios", "android"]).optional().describe("Platform override (auto-detected from session if omitted)")
     }, withConnection(getClient, async (args, client2) => {
-      const result = await handleAutoLogin(client2, args);
-      if (result === null)
-        return failResult("CDP not connected or helpers not injected");
-      if (result.loggedIn)
-        return okResult(result);
-      if (result.reason.includes("not on an auth screen"))
-        return okResult(result);
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify({ ok: false, error: result.reason, data: result })
-          }
-        ],
-        isError: true
-      };
+      return autoLoginToolResult(await handleAutoLogin(client2, args));
     }));
     trackedTool("proof_step", "Atomic proof capture step: navigate to a screen (optional), wait for settlement, verify an element (optional), and take a screenshot. Combines 3-4 tool calls into one. Use in proof flows to reduce tool-call overhead.", {
       screen: external_exports.string().optional().describe("Screen to navigate to (omit to stay on current screen)"),

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -85670,7 +85670,15 @@ function autoLoginToolResult(result) {
   if (result.code) {
     return failResult(result.reason, result.code, result.nextAction ? { nextAction: result.nextAction } : void 0);
   }
-  return failResult(result.reason);
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({ ok: false, error: result.reason, data: result })
+      }
+    ],
+    isError: true
+  };
 }
 
 // packages/rn-dev-agent-core/dist/tools/proof-step.js

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -85375,6 +85375,8 @@ function createNavGraphHandler(getClient2) {
 }
 
 // packages/rn-dev-agent-core/dist/tools/auto-login.js
+init_utils();
+init_agent_device_wrapper();
 init_storage();
 init_project_config();
 init_maestro_validator();
@@ -85519,17 +85521,21 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
   if (!onAuth) {
     return { loggedIn: false, reason: "App is not on an auth screen" };
   }
-  const platform = opts.platform;
+  const session2 = (deps.getSession ?? getActiveSession)();
+  const platform = opts.platform ?? session2?.platform;
   if (platform !== "ios" && platform !== "android") {
     return {
       loggedIn: false,
       reason: 'Cannot determine platform. Pass platform="ios" or platform="android" explicitly, or open a device session first.'
     };
   }
-  if (!opts.deviceId) {
+  const deviceId = opts.deviceId ?? (session2?.platform === platform ? session2.deviceId : void 0);
+  if (!deviceId) {
     return {
       loggedIn: false,
-      reason: `Auto-login requires an owned ${platform} session bound to one exact device.`
+      reason: `Auto-login requires an owned ${platform} session bound to one exact device.`,
+      code: "DEVICE_AUTHORITY_MISMATCH",
+      nextAction: 'Run rn_session with action "status" and repair the device authority binding, then retry cdp_auto_login.'
     };
   }
   const boundProjectRoot = (deps.boundProjectRoot ?? boundSessionProjectRoot)();
@@ -85625,7 +85631,7 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
   const replay = await maestroRun({
     inlineYaml: wrapperContent,
     platform,
-    deviceId: opts.deviceId,
+    deviceId,
     timeoutMs: 12e4,
     ...managedAuthority
   });
@@ -85655,6 +85661,16 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
     reason: "Auto-login via Maestro subflow succeeded",
     flow: flowPath
   };
+}
+function autoLoginToolResult(result) {
+  if (result === null)
+    return failResult("CDP not connected or helpers not injected");
+  if (result.loggedIn || result.reason.includes("not on an auth screen"))
+    return okResult(result);
+  if (result.code) {
+    return failResult(result.reason, result.code, result.nextAction ? { nextAction: result.nextAction } : void 0);
+  }
+  return failResult(result.reason);
 }
 
 // packages/rn-dev-agent-core/dist/tools/proof-step.js
@@ -92171,22 +92187,7 @@ trackedTool("cdp_auto_login", "Explicit legacy navigation helper that detects an
   appId: external_exports.string().optional().describe("App bundle ID override (auto-detected from app.json if omitted)"),
   platform: external_exports.enum(["ios", "android"]).optional().describe("Platform override (auto-detected from session if omitted)")
 }, withConnection(getClient, async (args, client2) => {
-  const result = await handleAutoLogin(client2, args);
-  if (result === null)
-    return failResult("CDP not connected or helpers not injected");
-  if (result.loggedIn)
-    return okResult(result);
-  if (result.reason.includes("not on an auth screen"))
-    return okResult(result);
-  return {
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify({ ok: false, error: result.reason, data: result })
-      }
-    ],
-    isError: true
-  };
+  return autoLoginToolResult(await handleAutoLogin(client2, args));
 }));
 trackedTool("proof_step", "Atomic proof capture step: navigate to a screen (optional), wait for settlement, verify an element (optional), and take a screenshot. Combines 3-4 tool calls into one. Use in proof flows to reduce tool-call overhead.", {
   screen: external_exports.string().optional().describe("Screen to navigate to (omit to stay on current screen)"),

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -87719,7 +87719,15 @@ function autoLoginToolResult(result) {
   if (result.code) {
     return failResult(result.reason, result.code, result.nextAction ? { nextAction: result.nextAction } : void 0);
   }
-  return failResult(result.reason);
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({ ok: false, error: result.reason, data: result })
+      }
+    ],
+    isError: true
+  };
 }
 var AUTH_ROUTE_PATTERNS, LOGIN_FLOW_PRIORITY;
 var init_auto_login = __esm({

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -87570,17 +87570,21 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
   if (!onAuth) {
     return { loggedIn: false, reason: "App is not on an auth screen" };
   }
-  const platform = opts.platform;
+  const session2 = (deps.getSession ?? getActiveSession)();
+  const platform = opts.platform ?? session2?.platform;
   if (platform !== "ios" && platform !== "android") {
     return {
       loggedIn: false,
       reason: 'Cannot determine platform. Pass platform="ios" or platform="android" explicitly, or open a device session first.'
     };
   }
-  if (!opts.deviceId) {
+  const deviceId = opts.deviceId ?? (session2?.platform === platform ? session2.deviceId : void 0);
+  if (!deviceId) {
     return {
       loggedIn: false,
-      reason: `Auto-login requires an owned ${platform} session bound to one exact device.`
+      reason: `Auto-login requires an owned ${platform} session bound to one exact device.`,
+      code: "DEVICE_AUTHORITY_MISMATCH",
+      nextAction: 'Run rn_session with action "status" and repair the device authority binding, then retry cdp_auto_login.'
     };
   }
   const boundProjectRoot = (deps.boundProjectRoot ?? boundSessionProjectRoot)();
@@ -87676,7 +87680,7 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
   const replay = await maestroRun({
     inlineYaml: wrapperContent,
     platform,
-    deviceId: opts.deviceId,
+    deviceId,
     timeoutMs: 12e4,
     ...managedAuthority
   });
@@ -87707,10 +87711,22 @@ async function handleAutoLogin(client2, opts = {}, deps = {}) {
     flow: flowPath
   };
 }
+function autoLoginToolResult(result) {
+  if (result === null)
+    return failResult("CDP not connected or helpers not injected");
+  if (result.loggedIn || result.reason.includes("not on an auth screen"))
+    return okResult(result);
+  if (result.code) {
+    return failResult(result.reason, result.code, result.nextAction ? { nextAction: result.nextAction } : void 0);
+  }
+  return failResult(result.reason);
+}
 var AUTH_ROUTE_PATTERNS, LOGIN_FLOW_PRIORITY;
 var init_auto_login = __esm({
   "packages/rn-dev-agent-core/dist/tools/auto-login.js"() {
     "use strict";
+    init_utils();
+    init_agent_device_wrapper();
     init_storage();
     init_project_config();
     init_maestro_validator();
@@ -94297,22 +94313,7 @@ var init_index = __esm({
       appId: external_exports.string().optional().describe("App bundle ID override (auto-detected from app.json if omitted)"),
       platform: external_exports.enum(["ios", "android"]).optional().describe("Platform override (auto-detected from session if omitted)")
     }, withConnection(getClient, async (args, client2) => {
-      const result = await handleAutoLogin(client2, args);
-      if (result === null)
-        return failResult("CDP not connected or helpers not injected");
-      if (result.loggedIn)
-        return okResult(result);
-      if (result.reason.includes("not on an auth screen"))
-        return okResult(result);
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify({ ok: false, error: result.reason, data: result })
-          }
-        ],
-        isError: true
-      };
+      return autoLoginToolResult(await handleAutoLogin(client2, args));
     }));
     trackedTool("proof_step", "Atomic proof capture step: navigate to a screen (optional), wait for settlement, verify an element (optional), and take a screenshot. Combines 3-4 tool calls into one. Use in proof flows to reduce tool-call overhead.", {
       screen: external_exports.string().optional().describe("Screen to navigate to (omit to stay on current screen)"),

--- a/packages/rn-dev-agent-core/dist/index.js
+++ b/packages/rn-dev-agent-core/dist/index.js
@@ -58,7 +58,7 @@ import { acceptDeeplinkOpenConfirmation, createDeviceAcceptSystemDialogHandler, 
 import { createDevicePickValueHandler, createDevicePickDateHandler, } from './tools/device-picker.js';
 import { createNavGraphHandler } from './tools/nav-graph.js';
 import { createDeviceBatchHandler } from './tools/device-batch.js';
-import { handleAutoLogin } from './tools/auto-login.js';
+import { autoLoginToolResult, handleAutoLogin } from './tools/auto-login.js';
 import { createProofStepHandler } from './tools/proof-step.js';
 import { createDisconnectHandler, createTargetsHandler } from './tools/connection.js';
 import { createRestartHandler } from './tools/restart.js';
@@ -2471,22 +2471,7 @@ trackedTool('cdp_auto_login', 'Explicit legacy navigation helper that detects an
         .optional()
         .describe('Platform override (auto-detected from session if omitted)'),
 }, withConnection(getClient, async (args, client) => {
-    const result = await handleAutoLogin(client, args);
-    if (result === null)
-        return failResult('CDP not connected or helpers not injected');
-    if (result.loggedIn)
-        return okResult(result);
-    if (result.reason.includes('not on an auth screen'))
-        return okResult(result);
-    return {
-        content: [
-            {
-                type: 'text',
-                text: JSON.stringify({ ok: false, error: result.reason, data: result }),
-            },
-        ],
-        isError: true,
-    };
+    return autoLoginToolResult(await handleAutoLogin(client, args));
 }));
 trackedTool('proof_step', 'Atomic proof capture step: navigate to a screen (optional), wait for settlement, verify an element (optional), and take a screenshot. Combines 3-4 tool calls into one. Use in proof flows to reduce tool-call overhead.', {
     screen: z

--- a/packages/rn-dev-agent-core/dist/tools/auto-login.js
+++ b/packages/rn-dev-agent-core/dist/tools/auto-login.js
@@ -1,5 +1,7 @@
 import { lstatSync, readFileSync, readdirSync, realpathSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
+import { failResult, okResult } from '../utils.js';
+import { getActiveSession } from '../agent-device-wrapper.js';
 import { findProjectRoot } from '../nav-graph/storage.js';
 import { readAppId } from '../project-config.js';
 import { buildMaestroFlow, parseAndValidateFlow, isValidBundleId, MaestroValidationError, } from '../domain/maestro-validator.js';
@@ -151,17 +153,21 @@ export async function handleAutoLogin(client, opts = {}, deps = {}) {
     if (!onAuth) {
         return { loggedIn: false, reason: 'App is not on an auth screen' };
     }
-    const platform = opts.platform;
+    const session = (deps.getSession ?? getActiveSession)();
+    const platform = opts.platform ?? session?.platform;
     if (platform !== 'ios' && platform !== 'android') {
         return {
             loggedIn: false,
             reason: 'Cannot determine platform. Pass platform="ios" or platform="android" explicitly, or open a device session first.',
         };
     }
-    if (!opts.deviceId) {
+    const deviceId = opts.deviceId ?? (session?.platform === platform ? session.deviceId : undefined);
+    if (!deviceId) {
         return {
             loggedIn: false,
             reason: `Auto-login requires an owned ${platform} session bound to one exact device.`,
+            code: 'DEVICE_AUTHORITY_MISMATCH',
+            nextAction: 'Run rn_session with action "status" and repair the device authority binding, then retry cdp_auto_login.',
         };
     }
     const boundProjectRoot = (deps.boundProjectRoot ?? boundSessionProjectRoot)();
@@ -269,7 +275,7 @@ export async function handleAutoLogin(client, opts = {}, deps = {}) {
     const replay = await maestroRun({
         inlineYaml: wrapperContent,
         platform,
-        deviceId: opts.deviceId,
+        deviceId,
         timeoutMs: 120_000,
         ...managedAuthority,
     });
@@ -281,8 +287,6 @@ export async function handleAutoLogin(client, opts = {}, deps = {}) {
             flow: flowPath,
         };
     }
-    // Poll for the auth screen to disappear instead of a blind 3s wait — returns
-    // as soon as login lands, and tolerates a slower transition.
     let stillOnAuth = true;
     const authDeadline = Date.now() + 5000;
     do {
@@ -301,4 +305,14 @@ export async function handleAutoLogin(client, opts = {}, deps = {}) {
         reason: 'Auto-login via Maestro subflow succeeded',
         flow: flowPath,
     };
+}
+export function autoLoginToolResult(result) {
+    if (result === null)
+        return failResult('CDP not connected or helpers not injected');
+    if (result.loggedIn || result.reason.includes('not on an auth screen'))
+        return okResult(result);
+    if (result.code) {
+        return failResult(result.reason, result.code, result.nextAction ? { nextAction: result.nextAction } : undefined);
+    }
+    return failResult(result.reason);
 }

--- a/packages/rn-dev-agent-core/dist/tools/auto-login.js
+++ b/packages/rn-dev-agent-core/dist/tools/auto-login.js
@@ -314,5 +314,13 @@ export function autoLoginToolResult(result) {
     if (result.code) {
         return failResult(result.reason, result.code, result.nextAction ? { nextAction: result.nextAction } : undefined);
     }
-    return failResult(result.reason);
+    return {
+        content: [
+            {
+                type: 'text',
+                text: JSON.stringify({ ok: false, error: result.reason, data: result }),
+            },
+        ],
+        isError: true,
+    };
 }

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -99,7 +99,7 @@ import {
 } from './tools/device-picker.js';
 import { createNavGraphHandler } from './tools/nav-graph.js';
 import { createDeviceBatchHandler } from './tools/device-batch.js';
-import { handleAutoLogin } from './tools/auto-login.js';
+import { autoLoginToolResult, handleAutoLogin } from './tools/auto-login.js';
 import { createProofStepHandler } from './tools/proof-step.js';
 import { createDisconnectHandler, createTargetsHandler } from './tools/connection.js';
 import { createRestartHandler } from './tools/restart.js';
@@ -3337,19 +3337,7 @@ trackedTool(
       .describe('Platform override (auto-detected from session if omitted)'),
   },
   withConnection(getClient, async (args: { appId?: string; platform?: string }, client) => {
-    const result = await handleAutoLogin(client, args);
-    if (result === null) return failResult('CDP not connected or helpers not injected');
-    if (result.loggedIn) return okResult(result);
-    if (result.reason.includes('not on an auth screen')) return okResult(result);
-    return {
-      content: [
-        {
-          type: 'text' as const,
-          text: JSON.stringify({ ok: false, error: result.reason, data: result }),
-        },
-      ],
-      isError: true as const,
-    };
+    return autoLoginToolResult(await handleAutoLogin(client, args));
   }),
 );
 

--- a/packages/rn-dev-agent-core/src/tools/auto-login.ts
+++ b/packages/rn-dev-agent-core/src/tools/auto-login.ts
@@ -1,7 +1,9 @@
 import { lstatSync, readFileSync, readdirSync, realpathSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import type { CDPClient } from '../cdp-client.js';
-import type { ToolResult } from '../utils.js';
+import { failResult, okResult, type ToolResult } from '../utils.js';
+import type { SessionState, ToolErrorCode } from '../types.js';
+import { getActiveSession } from '../agent-device-wrapper.js';
 import { findProjectRoot } from '../nav-graph/storage.js';
 import { readAppId } from '../project-config.js';
 import {
@@ -54,6 +56,8 @@ export interface AutoLoginResult {
   loggedIn: boolean;
   reason: string;
   flow?: string;
+  code?: ToolErrorCode;
+  nextAction?: string;
 }
 
 function matchesAuthPattern(routeName: string): boolean {
@@ -154,6 +158,7 @@ function containsClearState(value: unknown): boolean {
 interface AutoLoginDeps {
   boundProjectRoot?: () => string | null;
   projectRoot?: () => string | null;
+  getSession?: () => Pick<SessionState, 'platform' | 'deviceId'> | null;
   maestroRun?: (args: MaestroRunArgs) => Promise<ToolResult>;
 }
 
@@ -198,7 +203,8 @@ export async function handleAutoLogin(
     return { loggedIn: false, reason: 'App is not on an auth screen' };
   }
 
-  const platform = opts.platform;
+  const session = (deps.getSession ?? getActiveSession)();
+  const platform = opts.platform ?? session?.platform;
   if (platform !== 'ios' && platform !== 'android') {
     return {
       loggedIn: false,
@@ -206,10 +212,14 @@ export async function handleAutoLogin(
         'Cannot determine platform. Pass platform="ios" or platform="android" explicitly, or open a device session first.',
     };
   }
-  if (!opts.deviceId) {
+  const deviceId = opts.deviceId ?? (session?.platform === platform ? session.deviceId : undefined);
+  if (!deviceId) {
     return {
       loggedIn: false,
       reason: `Auto-login requires an owned ${platform} session bound to one exact device.`,
+      code: 'DEVICE_AUTHORITY_MISMATCH',
+      nextAction:
+        'Run rn_session with action "status" and repair the device authority binding, then retry cdp_auto_login.',
     };
   }
 
@@ -325,7 +335,7 @@ export async function handleAutoLogin(
   const replay = await maestroRun({
     inlineYaml: wrapperContent,
     platform,
-    deviceId: opts.deviceId,
+    deviceId,
     timeoutMs: 120_000,
     ...managedAuthority,
   });
@@ -338,8 +348,6 @@ export async function handleAutoLogin(
     };
   }
 
-  // Poll for the auth screen to disappear instead of a blind 3s wait — returns
-  // as soon as login lands, and tolerates a slower transition.
   let stillOnAuth = true;
   const authDeadline = Date.now() + 5000;
   do {
@@ -360,4 +368,17 @@ export async function handleAutoLogin(
     reason: 'Auto-login via Maestro subflow succeeded',
     flow: flowPath,
   };
+}
+
+export function autoLoginToolResult(result: AutoLoginResult | null): ToolResult {
+  if (result === null) return failResult('CDP not connected or helpers not injected');
+  if (result.loggedIn || result.reason.includes('not on an auth screen')) return okResult(result);
+  if (result.code) {
+    return failResult(
+      result.reason,
+      result.code,
+      result.nextAction ? { nextAction: result.nextAction } : undefined,
+    );
+  }
+  return failResult(result.reason);
 }

--- a/packages/rn-dev-agent-core/src/tools/auto-login.ts
+++ b/packages/rn-dev-agent-core/src/tools/auto-login.ts
@@ -380,5 +380,13 @@ export function autoLoginToolResult(result: AutoLoginResult | null): ToolResult 
       result.nextAction ? { nextAction: result.nextAction } : undefined,
     );
   }
-  return failResult(result.reason);
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({ ok: false, error: result.reason, data: result }),
+      },
+    ],
+    isError: true,
+  };
 }

--- a/packages/rn-dev-agent-core/test/unit/auto-login-authority.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/auto-login-authority.test.ts
@@ -85,6 +85,24 @@ test('cdp_auto_login refuses an unbound session without selecting an ambient dev
   assert.equal(replayed, false);
 });
 
+test('cdp_auto_login preserves the legacy envelope for ordinary login failures', () => {
+  const result = {
+    loggedIn: false,
+    reason: 'Maestro login flow failed: replay failed',
+    flow: '/project/.maestro/subflows/login.yaml',
+  };
+
+  const toolResult = autoLoginToolResult(result);
+  const envelope = JSON.parse(toolResult.content[0].text);
+
+  assert.deepEqual(envelope, {
+    ok: false,
+    error: result.reason,
+    data: result,
+  });
+  assert.equal(toolResult.isError, true);
+});
+
 test('cdp_auto_login refuses symlinked legacy flow ownership', async () => {
   const root = mkdtempSync(join(tmpdir(), 'rn-auto-login-symlink-'));
   const external = mkdtempSync(join(tmpdir(), 'rn-auto-login-external-'));

--- a/packages/rn-dev-agent-core/test/unit/auto-login-authority.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/auto-login-authority.test.ts
@@ -4,7 +4,7 @@ import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { CDPClient } from '../../dist/cdp-client.js';
-import { handleAutoLogin } from '../../dist/tools/auto-login.js';
+import { autoLoginToolResult, handleAutoLogin } from '../../dist/tools/auto-login.js';
 
 function authClient(): CDPClient {
   let reads = 0;
@@ -18,17 +18,24 @@ function authClient(): CDPClient {
   } as unknown as CDPClient;
 }
 
-test('cdp_auto_login delegates to maestro_run on the authority-bound device', async () => {
+test('cdp_auto_login targets only the bound serial when a second device is ambient', async (t) => {
   const root = mkdtempSync(join(tmpdir(), 'rn-auto-login-authority-'));
   const flowDir = join(root, '.maestro', 'subflows');
   mkdirSync(flowDir, { recursive: true });
   writeFileSync(join(flowDir, 'login.yaml'), '- tapOn:\n    id: "login"\n', 'utf8');
   let replayArgs: Record<string, unknown> | null = null;
+  const previousAndroidSerial = process.env.ANDROID_SERIAL;
+  process.env.ANDROID_SERIAL = 'AMBIENT-DEVICE';
+  t.after(() => {
+    if (previousAndroidSerial === undefined) delete process.env.ANDROID_SERIAL;
+    else process.env.ANDROID_SERIAL = previousAndroidSerial;
+  });
 
   const result = await handleAutoLogin(
     authClient(),
-    { appId: 'com.test.app', platform: 'ios', deviceId: 'SIM-AUTHORITY' },
+    { appId: 'com.test.app', platform: 'android' },
     {
+      getSession: () => ({ platform: 'android', deviceId: 'BOUND-DEVICE' }),
       projectRoot: () => root,
       boundProjectRoot: () => root,
       maestroRun: async (args) => {
@@ -39,20 +46,28 @@ test('cdp_auto_login delegates to maestro_run on the authority-bound device', as
   );
 
   assert.equal(result?.loggedIn, true);
-  assert.equal(replayArgs?.platform, 'ios');
-  assert.equal(replayArgs?.deviceId, 'SIM-AUTHORITY');
+  assert.equal(replayArgs?.platform, 'android');
+  assert.equal(replayArgs?.deviceId, 'BOUND-DEVICE');
+  assert.notEqual(replayArgs?.deviceId, 'AMBIENT-DEVICE');
   assert.equal(typeof replayArgs?.claimNativeOrigin, 'function');
   assert.equal(typeof replayArgs?.completeNativeOrigin, 'function');
   assert.equal(typeof replayArgs?.completeRunnerPark, 'function');
   assert.match(String(replayArgs?.inlineYaml), /id: login/);
 });
 
-test('cdp_auto_login refuses a platform without matching owned device authority', async () => {
+test('cdp_auto_login refuses an unbound session without selecting an ambient device', async (t) => {
   let replayed = false;
+  const previousAndroidSerial = process.env.ANDROID_SERIAL;
+  process.env.ANDROID_SERIAL = 'AMBIENT-DEVICE';
+  t.after(() => {
+    if (previousAndroidSerial === undefined) delete process.env.ANDROID_SERIAL;
+    else process.env.ANDROID_SERIAL = previousAndroidSerial;
+  });
   const result = await handleAutoLogin(
     authClient(),
     { platform: 'android' },
     {
+      getSession: () => null,
       maestroRun: async () => {
         replayed = true;
         return { content: [{ type: 'text', text: '{"ok":true,"data":{"passed":true}}' }] };
@@ -62,6 +77,11 @@ test('cdp_auto_login refuses a platform without matching owned device authority'
 
   assert.equal(result?.loggedIn, false);
   assert.match(String(result?.reason), /owned android session/);
+  assert.equal(result?.code, 'DEVICE_AUTHORITY_MISMATCH');
+  assert.match(String(result?.nextAction), /rn_session/);
+  const refusal = JSON.parse(autoLoginToolResult(result).content[0].text);
+  assert.equal(refusal.code, 'DEVICE_AUTHORITY_MISMATCH');
+  assert.match(String(refusal.meta?.nextAction), /rn_session/);
   assert.equal(replayed, false);
 });
 


### PR DESCRIPTION
## Intent

Implement only the captain-approved bound-device split from the simplified issue #812 follow-up. When a session has a bound device, cdp_auto_login must target exactly that device serial through the existing device/session authority path. When no device is bound, it must refuse with the existing suitable typed error and an executable remedy instead of selecting or mutating an ambient device. Add a two-device fixture proving only the bound serial is targeted and an unbound fixture proving typed refusal with zero ambient selection or mutation. Keep the single behavior owner in auto-login.ts; pass the resolved device explicitly without spreading or copying non-enumerable authority markers. Preserve existing login-helper behavior, authority, cleanup, and generated runtimes. Do not add a copied device-selection mechanism, a new authority layer, corpus/report hygiene, runner-cache or install work, a diagnostics framework, manual login, product-app access, or unrelated auto-login redesign. Do not use or cherry-pick the obsolete fm/issue-812-p2 pipeline-fix history; implement only this intended correction from clean current main. Ship one focused validated PR.

## What Changed

- Resolve auto-login’s device from the active session and target the exact bound serial through the existing authority path.
- Refuse unbound sessions with `DEVICE_AUTHORITY_MISMATCH` and an executable `rn_session` recovery action while preserving existing login-failure responses.
- Add bound-versus-ambient and unbound-device coverage, and regenerate the packaged host runtimes.

## Risk Assessment

✅ Low: The exact bound device remains enforced by the existing authority gate, unbound sessions fail closed with a typed remedy, and legacy login failure envelopes are preserved.

## Testing

No prior baseline results were supplied; focused auto-login, downstream Maestro authority, and registered authority-gate checks all passed, with JSON protocol evidence confirming exact bound targeting and zero ambient mutation on refusal. No screenshot was captured because this is a headless MCP protocol change and product-app access was explicitly out of scope.

<details>
<summary>Evidence: cdp_auto_login bound-device protocol evidence</summary>

`Bound replay targeted BOUND-DEVICE, not AMBIENT-DEVICE. Unbound calls performed zero replay/handler invocations, preserved the ambient serial, and returned DEVICE_AUTHORITY_MISMATCH with an rn_session remedy.`

```text
{
  "evidence": "cdp_auto_login bound-device protocol behavior",
  "bound_session_with_ambient_second_device": {
    "ambient_android_serial": "AMBIENT-DEVICE",
    "bound_session_serial": "BOUND-DEVICE",
    "replay_invocations": 1,
    "replay_platform": "android",
    "replay_device_id": "BOUND-DEVICE",
    "ambient_device_targeted": false,
    "managed_authority_callbacks_forwarded": true,
    "result": {
      "loggedIn": true,
      "reason": "Auto-login via Maestro subflow succeeded"
    }
  },
  "unbound_session_with_ambient_device": {
    "ambient_android_serial_before": "AMBIENT-DEVICE",
    "replay_invocations": 0,
    "ambient_android_serial_after": "AMBIENT-DEVICE",
    "tool_result_is_error": true,
    "tool_envelope": {
      "ok": false,
      "error": "Auto-login requires an owned android session bound to one exact device.",
      "code": "DEVICE_AUTHORITY_MISMATCH",
      "meta": {
        "nextAction": "Run rn_session with action \"status\" and repair the device authority binding, then retry cdp_auto_login."
      }
    }
  },
  "registered_authority_path_without_bound_device": {
    "ambient_android_serial_before": "AMBIENT-DEVICE",
    "handler_invocations": 0,
    "ambient_android_serial_after": "AMBIENT-DEVICE",
    "tool_result_is_error": true,
    "tool_envelope": {
      "ok": false,
      "error": "DEVICE_AUTHORITY_MISMATCH: D authority is not bound",
      "code": "DEVICE_AUTHORITY_MISMATCH",
      "meta": {
        "axis": "D",
        "nextAction": "Run rn_session with action \"status\" and repair the named authority axis."
      }
    }
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c7bce94c89451ed6f5bdce1cf258bd7bad82c0a3","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `packages/rn-dev-agent-core/src/tools/auto-login.ts:383` - The required criterion says “Preserve existing login-helper behavior.” Previously every ordinary failure returned `{ok:false,error,data:result}`; this fallback now calls `failResult(result.reason)`, dropping `data.loggedIn`, `data.reason`, and `data.flow` for existing cases such as Maestro replay failures. Preserve the legacy envelope for untyped failures and use the new typed envelope only for the authority refusal.

🔧 Fix: Preserve legacy auto-login failure envelopes
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test --test-reporter=spec test/unit/auto-login-authority.test.ts`
- `node --test --test-reporter=spec --test-name-pattern='exact active UDID is forwarded|real maestro_run path forwards active UDID' test/unit/gh-588-maestro-exact-device-authority.test.ts`
- `node --test --test-reporter=spec --test-name-pattern='hybrid execution separates required and optional bundle authority' test/unit/session/tool-profiles.test.ts`
- <code>`node --input-type=module` executable fixture against `dist/tools/auto-login.js`, with bound `BOUND-DEVICE` and ambient `ANDROID_SERIAL=AMBIENT-DEVICE`</code>
- <code>`node --input-type=module` registered `createAuthorityGate(...).wrap(&#39;cdp_auto_login&#39;, ...)` unbound-device refusal harness</code>
- <code>`git status --short` confirmed testing left the worktree unchanged</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
