### PR TITLE
fix(core): handle SQLite relaunch spawn failures

### DIFF
--- a/.changeset/sqlite-relaunch-spawn-error.md
+++ b/.changeset/sqlite-relaunch-spawn-error.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-core": patch
+"rn-dev-agent-plugin": patch
+---
+
+Settle SQLite supervisor relaunch spawn failures on error or exit once, with a diagnostic and no hanging promise.

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -95906,13 +95906,76 @@ var init_index = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/supervisor.js
-init_lockfile();
-init_parent_watch();
 import { randomUUID as randomUUID13 } from "node:crypto";
 import { spawn as spawn10 } from "node:child_process";
 import { lstatSync as lstatSync20, readFileSync as readFileSync43 } from "node:fs";
 import { dirname as dirname33, join as join61, resolve as resolve20 } from "node:path";
 import { fileURLToPath as fileURLToPath8 } from "node:url";
+
+// packages/rn-dev-agent-core/dist/lifecycle/child-error-or-exit.js
+var SQLITE_RELAUNCH_SIGNALS = ["SIGTERM", "SIGINT", "SIGHUP", "SIGUSR2"];
+function processSqliteRelaunchIo() {
+  return {
+    writeErrorLine: (line) => {
+      process.stderr.write(`${line}
+`);
+    },
+    exit: (code) => {
+      process.exit(code);
+    },
+    killSelf: (signal) => {
+      process.kill(process.pid, signal);
+    },
+    removeSignalListeners: (signal) => {
+      process.removeAllListeners(signal);
+    },
+    onSignal: (signal, handler) => {
+      process.on(signal, handler);
+    }
+  };
+}
+function awaitChildErrorOrExit(child) {
+  return new Promise((resolve21) => {
+    let settled = false;
+    const settle = (outcome) => {
+      if (settled)
+        return;
+      settled = true;
+      resolve21(outcome);
+    };
+    child.on("error", (err) => settle({
+      code: null,
+      signal: null,
+      error: err instanceof Error ? err : new Error(String(err))
+    }));
+    child.on("exit", (code, signal) => settle({ code, signal, error: null }));
+  });
+}
+async function completeSqliteRelaunch(child, io = processSqliteRelaunchIo()) {
+  for (const signal of SQLITE_RELAUNCH_SIGNALS) {
+    io.onSignal(signal, () => {
+      try {
+        child.kill?.(signal);
+      } catch {
+      }
+    });
+  }
+  const outcome = await awaitChildErrorOrExit(child);
+  if (outcome.error) {
+    io.writeErrorLine(`rn-bridge-supervisor: sqlite relaunch spawn failed: ${outcome.error.message}`);
+    io.exit(1);
+    return;
+  }
+  if (outcome.signal) {
+    io.removeSignalListeners(outcome.signal);
+    io.killSelf(outcome.signal);
+  }
+  io.exit(outcome.code ?? 1);
+}
+
+// packages/rn-dev-agent-core/dist/supervisor.js
+init_lockfile();
+init_parent_watch();
 
 // packages/rn-dev-agent-core/dist/lifecycle/stdio-frames.js
 var LineSplitter = class {
@@ -96249,15 +96312,7 @@ if (supervisorFlag.length > 0 && !process.execArgv.includes("--experimental-sqli
     stdio: "inherit",
     env: { ...process.env, RN_DEV_AGENT_SQLITE_RELAUNCHED: "1" }
   });
-  for (const signal of ["SIGTERM", "SIGINT", "SIGHUP", "SIGUSR2"]) {
-    process.on(signal, () => child.kill(signal));
-  }
-  const outcome = await new Promise((resolve21) => child.on("exit", (code, signal) => resolve21({ code, signal })));
-  if (outcome.signal) {
-    process.removeAllListeners(outcome.signal);
-    process.kill(process.pid, outcome.signal);
-  }
-  process.exit(outcome.code ?? 1);
+  await completeSqliteRelaunch(child);
 }
 function legacyRepairArtifactPresent(cwd) {
   try {
@@ -96355,7 +96410,7 @@ if (process.env.RN_BRIDGE_SUPERVISOR === "0") {
     };
     child.stdin?.on("error", () => {
     });
-    child.on("error", (err) => onDeath(null, null, `spawn failed: ${err.message}`));
+    void awaitChildErrorOrExit(child).then((outcome) => onDeath(outcome.code, outcome.signal, outcome.error ? `spawn failed: ${outcome.error.message}` : ""));
     if (child.stdout) {
       child.stdout.setEncoding("utf8");
       const childLines = new LineSplitter();
@@ -96366,7 +96421,6 @@ if (process.env.RN_BRIDGE_SUPERVISOR === "0") {
           apply2(core.onWorkerLine(line));
       });
     }
-    child.on("exit", (code, signal) => onDeath(code, signal, ""));
   }, closeAuthorityAndExit2 = function(exitCode = 0) {
     void authority?.close().then(() => process.exit(exitCode)).catch((error2) => {
       process.stderr.write(`rn-bridge-supervisor: authority cleanup failed: ${error2 instanceof Error ? error2.message : String(error2)}

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -95906,13 +95906,76 @@ var init_index = __esm({
 });
 
 // packages/rn-dev-agent-core/dist/supervisor.js
-init_lockfile();
-init_parent_watch();
 import { randomUUID as randomUUID13 } from "node:crypto";
 import { spawn as spawn10 } from "node:child_process";
 import { lstatSync as lstatSync20, readFileSync as readFileSync43 } from "node:fs";
 import { dirname as dirname33, join as join61, resolve as resolve20 } from "node:path";
 import { fileURLToPath as fileURLToPath8 } from "node:url";
+
+// packages/rn-dev-agent-core/dist/lifecycle/child-error-or-exit.js
+var SQLITE_RELAUNCH_SIGNALS = ["SIGTERM", "SIGINT", "SIGHUP", "SIGUSR2"];
+function processSqliteRelaunchIo() {
+  return {
+    writeErrorLine: (line) => {
+      process.stderr.write(`${line}
+`);
+    },
+    exit: (code) => {
+      process.exit(code);
+    },
+    killSelf: (signal) => {
+      process.kill(process.pid, signal);
+    },
+    removeSignalListeners: (signal) => {
+      process.removeAllListeners(signal);
+    },
+    onSignal: (signal, handler) => {
+      process.on(signal, handler);
+    }
+  };
+}
+function awaitChildErrorOrExit(child) {
+  return new Promise((resolve21) => {
+    let settled = false;
+    const settle = (outcome) => {
+      if (settled)
+        return;
+      settled = true;
+      resolve21(outcome);
+    };
+    child.on("error", (err) => settle({
+      code: null,
+      signal: null,
+      error: err instanceof Error ? err : new Error(String(err))
+    }));
+    child.on("exit", (code, signal) => settle({ code, signal, error: null }));
+  });
+}
+async function completeSqliteRelaunch(child, io = processSqliteRelaunchIo()) {
+  for (const signal of SQLITE_RELAUNCH_SIGNALS) {
+    io.onSignal(signal, () => {
+      try {
+        child.kill?.(signal);
+      } catch {
+      }
+    });
+  }
+  const outcome = await awaitChildErrorOrExit(child);
+  if (outcome.error) {
+    io.writeErrorLine(`rn-bridge-supervisor: sqlite relaunch spawn failed: ${outcome.error.message}`);
+    io.exit(1);
+    return;
+  }
+  if (outcome.signal) {
+    io.removeSignalListeners(outcome.signal);
+    io.killSelf(outcome.signal);
+  }
+  io.exit(outcome.code ?? 1);
+}
+
+// packages/rn-dev-agent-core/dist/supervisor.js
+init_lockfile();
+init_parent_watch();
 
 // packages/rn-dev-agent-core/dist/lifecycle/stdio-frames.js
 var LineSplitter = class {
@@ -96249,15 +96312,7 @@ if (supervisorFlag.length > 0 && !process.execArgv.includes("--experimental-sqli
     stdio: "inherit",
     env: { ...process.env, RN_DEV_AGENT_SQLITE_RELAUNCHED: "1" }
   });
-  for (const signal of ["SIGTERM", "SIGINT", "SIGHUP", "SIGUSR2"]) {
-    process.on(signal, () => child.kill(signal));
-  }
-  const outcome = await new Promise((resolve21) => child.on("exit", (code, signal) => resolve21({ code, signal })));
-  if (outcome.signal) {
-    process.removeAllListeners(outcome.signal);
-    process.kill(process.pid, outcome.signal);
-  }
-  process.exit(outcome.code ?? 1);
+  await completeSqliteRelaunch(child);
 }
 function legacyRepairArtifactPresent(cwd) {
   try {
@@ -96355,7 +96410,7 @@ if (process.env.RN_BRIDGE_SUPERVISOR === "0") {
     };
     child.stdin?.on("error", () => {
     });
-    child.on("error", (err) => onDeath(null, null, `spawn failed: ${err.message}`));
+    void awaitChildErrorOrExit(child).then((outcome) => onDeath(outcome.code, outcome.signal, outcome.error ? `spawn failed: ${outcome.error.message}` : ""));
     if (child.stdout) {
       child.stdout.setEncoding("utf8");
       const childLines = new LineSplitter();
@@ -96366,7 +96421,6 @@ if (process.env.RN_BRIDGE_SUPERVISOR === "0") {
           apply2(core.onWorkerLine(line));
       });
     }
-    child.on("exit", (code, signal) => onDeath(code, signal, ""));
   }, closeAuthorityAndExit2 = function(exitCode = 0) {
     void authority?.close().then(() => process.exit(exitCode)).catch((error2) => {
       process.stderr.write(`rn-bridge-supervisor: authority cleanup failed: ${error2 instanceof Error ? error2.message : String(error2)}

--- a/packages/rn-dev-agent-core/src/lifecycle/child-error-or-exit.ts
+++ b/packages/rn-dev-agent-core/src/lifecycle/child-error-or-exit.ts
@@ -43,11 +43,7 @@ export function processSqliteRelaunchIo(): SqliteRelaunchIo {
   };
 }
 
-/**
- * Same once-only funnel the worker spawn path uses: `error` and `exit` can
- * both fire, or only `error` (ENOENT / EAGAIN / EMFILE), and a later event
- * must not settle twice.
- */
+/** Settles once when a child emits `error`, `exit`, or both. */
 export function awaitChildErrorOrExit(
   child: ChildErrorOrExitHandle,
 ): Promise<ChildErrorOrExitOutcome> {

--- a/packages/rn-dev-agent-core/src/lifecycle/child-error-or-exit.ts
+++ b/packages/rn-dev-agent-core/src/lifecycle/child-error-or-exit.ts
@@ -1,0 +1,98 @@
+export const SQLITE_RELAUNCH_SIGNALS = ['SIGTERM', 'SIGINT', 'SIGHUP', 'SIGUSR2'] as const;
+
+export interface ChildErrorOrExitOutcome {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  error: Error | null;
+}
+
+export interface ChildErrorOrExitHandle {
+  on(event: 'error', listener: (err: Error) => void): unknown;
+  on(
+    event: 'exit',
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+  ): unknown;
+  kill?(signal?: NodeJS.Signals): boolean | void;
+}
+
+export interface SqliteRelaunchIo {
+  writeErrorLine: (line: string) => void;
+  exit: (code: number) => void;
+  killSelf: (signal: NodeJS.Signals) => void;
+  removeSignalListeners: (signal: NodeJS.Signals) => void;
+  onSignal: (signal: NodeJS.Signals, handler: () => void) => void;
+}
+
+export function processSqliteRelaunchIo(): SqliteRelaunchIo {
+  return {
+    writeErrorLine: (line) => {
+      process.stderr.write(`${line}\n`);
+    },
+    exit: (code) => {
+      process.exit(code);
+    },
+    killSelf: (signal) => {
+      process.kill(process.pid, signal);
+    },
+    removeSignalListeners: (signal) => {
+      process.removeAllListeners(signal);
+    },
+    onSignal: (signal, handler) => {
+      process.on(signal, handler);
+    },
+  };
+}
+
+/**
+ * Same once-only funnel the worker spawn path uses: `error` and `exit` can
+ * both fire, or only `error` (ENOENT / EAGAIN / EMFILE), and a later event
+ * must not settle twice.
+ */
+export function awaitChildErrorOrExit(
+  child: ChildErrorOrExitHandle,
+): Promise<ChildErrorOrExitOutcome> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (outcome: ChildErrorOrExitOutcome): void => {
+      if (settled) return;
+      settled = true;
+      resolve(outcome);
+    };
+    child.on('error', (err) =>
+      settle({
+        code: null,
+        signal: null,
+        error: err instanceof Error ? err : new Error(String(err)),
+      }),
+    );
+    child.on('exit', (code, signal) => settle({ code, signal, error: null }));
+  });
+}
+
+export async function completeSqliteRelaunch(
+  child: ChildErrorOrExitHandle,
+  io: SqliteRelaunchIo = processSqliteRelaunchIo(),
+): Promise<void> {
+  for (const signal of SQLITE_RELAUNCH_SIGNALS) {
+    io.onSignal(signal, () => {
+      try {
+        child.kill?.(signal);
+      } catch {
+        /* already gone */
+      }
+    });
+  }
+  const outcome = await awaitChildErrorOrExit(child);
+  if (outcome.error) {
+    io.writeErrorLine(
+      `rn-bridge-supervisor: sqlite relaunch spawn failed: ${outcome.error.message}`,
+    );
+    io.exit(1);
+    return;
+  }
+  if (outcome.signal) {
+    io.removeSignalListeners(outcome.signal);
+    io.killSelf(outcome.signal);
+  }
+  io.exit(outcome.code ?? 1);
+}

--- a/packages/rn-dev-agent-core/src/supervisor.ts
+++ b/packages/rn-dev-agent-core/src/supervisor.ts
@@ -4,6 +4,7 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { lstatSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { awaitChildErrorOrExit, completeSqliteRelaunch } from './lifecycle/child-error-or-exit.js';
 import { Lockfile, formatLockConflictMessage } from './lifecycle/lockfile.js';
 import { startParentDeathWatch } from './lifecycle/parent-watch.js';
 import { LineSplitter } from './lifecycle/stdio-frames.js';
@@ -68,17 +69,7 @@ if (
       env: { ...process.env, RN_DEV_AGENT_SQLITE_RELAUNCHED: '1' },
     },
   );
-  for (const signal of ['SIGTERM', 'SIGINT', 'SIGHUP', 'SIGUSR2'] as const) {
-    process.on(signal, () => child.kill(signal));
-  }
-  const outcome = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
-    (resolve) => child.on('exit', (code, signal) => resolve({ code, signal })),
-  );
-  if (outcome.signal) {
-    process.removeAllListeners(outcome.signal);
-    process.kill(process.pid, outcome.signal);
-  }
-  process.exit(outcome.code ?? 1);
+  await completeSqliteRelaunch(child);
 }
 
 function legacyRepairArtifactPresent(cwd: string): boolean {
@@ -298,7 +289,13 @@ if (process.env.RN_BRIDGE_SUPERVISOR === '0') {
     child.stdin?.on('error', () => {
       /* EPIPE on a dying worker — exit handler covers it */
     });
-    child.on('error', (err) => onDeath(null, null, `spawn failed: ${err.message}`));
+    void awaitChildErrorOrExit(child).then((outcome) =>
+      onDeath(
+        outcome.code,
+        outcome.signal,
+        outcome.error ? `spawn failed: ${outcome.error.message}` : '',
+      ),
+    );
     if (child.stdout) {
       // setEncoding makes Node's StringDecoder hold partial UTF-8 sequences —
       // a multi-byte codepoint split across 'data' events must not corrupt
@@ -318,7 +315,6 @@ if (process.env.RN_BRIDGE_SUPERVISOR === '0') {
         for (const line of childLines.push(chunk)) apply(core.onWorkerLine(line));
       });
     }
-    child.on('exit', (code, signal) => onDeath(code, signal, ''));
   }
 
   function closeAuthorityAndExit(exitCode = 0): void {

--- a/packages/rn-dev-agent-core/test/unit/gh-819-sqlite-relaunch-spawn-error.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-819-sqlite-relaunch-spawn-error.test.ts
@@ -1,7 +1,5 @@
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { test } from 'node:test';
 import {
   SQLITE_RELAUNCH_SIGNALS,
@@ -189,14 +187,4 @@ test('signal forwarding is safe when the child is already gone', async () => {
   queueMicrotask(() => child.emit('exit', 0, null));
   await settleOrFail(pending, 'sqlite relaunch after dead-child signals');
   assert.deepEqual(rec.exits, [0]);
-});
-
-test('compiled supervisor relaunch reuses error-or-exit settlement instead of exit-only wait', () => {
-  const supervisorPath = fileURLToPath(new URL('../../dist/supervisor.js', import.meta.url));
-  const source = readFileSync(supervisorPath, 'utf8');
-  assert.match(source, /completeSqliteRelaunch/);
-  assert.doesNotMatch(
-    source,
-    /child\.on\('exit', \(code, signal\) => resolve\(\{ code, signal \}\)\)/,
-  );
 });

--- a/packages/rn-dev-agent-core/test/unit/gh-819-sqlite-relaunch-spawn-error.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-819-sqlite-relaunch-spawn-error.test.ts
@@ -1,0 +1,202 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import {
+  SQLITE_RELAUNCH_SIGNALS,
+  awaitChildErrorOrExit,
+  completeSqliteRelaunch,
+  type ChildErrorOrExitHandle,
+  type SqliteRelaunchIo,
+} from '../../dist/lifecycle/child-error-or-exit.js';
+
+function spawnErrno(code: string, message: string): Error & { code: string } {
+  const error = new Error(message) as Error & { code: string };
+  error.code = code;
+  return error;
+}
+
+function fakeChild(
+  kill: (signal?: NodeJS.Signals) => boolean = () => true,
+): EventEmitter & ChildErrorOrExitHandle {
+  const child = new EventEmitter() as EventEmitter & ChildErrorOrExitHandle;
+  child.kill = kill;
+  return child;
+}
+
+function recordingIo() {
+  const writes: string[] = [];
+  const exits: number[] = [];
+  const selfKills: NodeJS.Signals[] = [];
+  const removed: NodeJS.Signals[] = [];
+  const signalHandlers = new Map<NodeJS.Signals, Array<() => void>>();
+  const io: SqliteRelaunchIo = {
+    writeErrorLine: (line) => {
+      writes.push(line);
+    },
+    exit: (code) => {
+      exits.push(code);
+    },
+    killSelf: (signal) => {
+      selfKills.push(signal);
+    },
+    removeSignalListeners: (signal) => {
+      removed.push(signal);
+    },
+    onSignal: (signal, handler) => {
+      const list = signalHandlers.get(signal) ?? [];
+      list.push(handler);
+      signalHandlers.set(signal, list);
+    },
+  };
+  return { io, writes, exits, selfKills, removed, signalHandlers };
+}
+
+async function settleOrFail<T>(promise: Promise<T>, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} left a pending promise`)), 200),
+    ),
+  ]);
+}
+
+async function collectUncaught(run: () => Promise<void>): Promise<Error[]> {
+  const uncaught: Error[] = [];
+  const onUncaught = (error: Error) => {
+    uncaught.push(error);
+  };
+  process.on('uncaughtException', onUncaught);
+  try {
+    await run();
+    return uncaught;
+  } finally {
+    process.off('uncaughtException', onUncaught);
+  }
+}
+
+test('awaitChildErrorOrExit settles once on error-only EAGAIN', async () => {
+  const child = fakeChild();
+  const pending = awaitChildErrorOrExit(child);
+  queueMicrotask(() => child.emit('error', spawnErrno('EAGAIN', 'spawn EAGAIN')));
+  const outcome = await settleOrFail(pending, 'error-only EAGAIN');
+  assert.equal(outcome.error?.message, 'spawn EAGAIN');
+  assert.equal((outcome.error as (Error & { code?: string }) | null)?.code, 'EAGAIN');
+  assert.equal(outcome.code, null);
+  assert.equal(outcome.signal, null);
+  child.emit('exit', 0, null);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(outcome.error?.message, 'spawn EAGAIN');
+});
+
+test('awaitChildErrorOrExit settles once on exit', async () => {
+  const child = fakeChild();
+  const pending = awaitChildErrorOrExit(child);
+  queueMicrotask(() => child.emit('exit', 7, null));
+  const outcome = await settleOrFail(pending, 'exit-only');
+  assert.equal(outcome.code, 7);
+  assert.equal(outcome.signal, null);
+  assert.equal(outcome.error, null);
+});
+
+test('awaitChildErrorOrExit settles once when error is followed by exit', async () => {
+  const child = fakeChild();
+  const pending = awaitChildErrorOrExit(child);
+  let settleCount = 0;
+  const counted = pending.then((outcome) => {
+    settleCount += 1;
+    return outcome;
+  });
+  queueMicrotask(() => {
+    child.emit('error', spawnErrno('EAGAIN', 'spawn EAGAIN'));
+    child.emit('exit', 1, null);
+  });
+  const outcome = await settleOrFail(counted, 'error-plus-exit');
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(settleCount, 1);
+  assert.equal(outcome.error?.message, 'spawn EAGAIN');
+  assert.equal(outcome.code, null);
+});
+
+test('sqlite relaunch spawn failure emits one diagnostic, exits non-zero, and leaves no uncaught error', async () => {
+  const child = fakeChild();
+  const rec = recordingIo();
+  const uncaught = await collectUncaught(async () => {
+    const pending = completeSqliteRelaunch(child, rec.io);
+    queueMicrotask(() => child.emit('error', spawnErrno('EAGAIN', 'spawn EAGAIN')));
+    await settleOrFail(pending, 'sqlite relaunch EAGAIN');
+  });
+  assert.deepEqual(uncaught, []);
+  assert.deepEqual(rec.exits, [1]);
+  assert.equal(rec.writes.length, 1);
+  assert.equal(rec.writes[0], 'rn-bridge-supervisor: sqlite relaunch spawn failed: spawn EAGAIN');
+  child.emit('exit', 0, null);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(rec.exits, [1]);
+  assert.equal(rec.writes.length, 1);
+});
+
+test('sqlite relaunch error-plus-exit still exits once with one diagnostic', async () => {
+  const child = fakeChild();
+  const rec = recordingIo();
+  const pending = completeSqliteRelaunch(child, rec.io);
+  queueMicrotask(() => {
+    child.emit('error', spawnErrno('ENOENT', 'spawn ENOENT'));
+    child.emit('exit', 1, null);
+  });
+  await settleOrFail(pending, 'sqlite relaunch error-plus-exit');
+  assert.deepEqual(rec.exits, [1]);
+  assert.deepEqual(rec.writes, [
+    'rn-bridge-supervisor: sqlite relaunch spawn failed: spawn ENOENT',
+  ]);
+});
+
+test('sqlite relaunch successful exit code is unchanged', async () => {
+  const child = fakeChild();
+  const rec = recordingIo();
+  const pending = completeSqliteRelaunch(child, rec.io);
+  queueMicrotask(() => child.emit('exit', 0, null));
+  await settleOrFail(pending, 'sqlite relaunch exit 0');
+  assert.deepEqual(rec.exits, [0]);
+  assert.deepEqual(rec.writes, []);
+  assert.deepEqual(rec.selfKills, []);
+});
+
+test('sqlite relaunch successful signal propagation is unchanged', async () => {
+  const child = fakeChild();
+  const rec = recordingIo();
+  const pending = completeSqliteRelaunch(child, rec.io);
+  queueMicrotask(() => child.emit('exit', null, 'SIGTERM'));
+  await settleOrFail(pending, 'sqlite relaunch SIGTERM');
+  assert.deepEqual(rec.removed, ['SIGTERM']);
+  assert.deepEqual(rec.selfKills, ['SIGTERM']);
+  assert.deepEqual(rec.exits, [1]);
+  assert.deepEqual(rec.writes, []);
+});
+
+test('signal forwarding is safe when the child is already gone', async () => {
+  const child = fakeChild(() => {
+    throw Object.assign(new Error('kill ESRCH'), { code: 'ESRCH' });
+  });
+  const rec = recordingIo();
+  const pending = completeSqliteRelaunch(child, rec.io);
+  for (const signal of SQLITE_RELAUNCH_SIGNALS) {
+    const handlers = rec.signalHandlers.get(signal) ?? [];
+    assert.equal(handlers.length, 1, `${signal} must be forwarded`);
+    assert.doesNotThrow(() => handlers[0]?.());
+  }
+  queueMicrotask(() => child.emit('exit', 0, null));
+  await settleOrFail(pending, 'sqlite relaunch after dead-child signals');
+  assert.deepEqual(rec.exits, [0]);
+});
+
+test('compiled supervisor relaunch reuses error-or-exit settlement instead of exit-only wait', () => {
+  const supervisorPath = fileURLToPath(new URL('../../dist/supervisor.js', import.meta.url));
+  const source = readFileSync(supervisorPath, 'utf8');
+  assert.match(source, /completeSqliteRelaunch/);
+  assert.doesNotMatch(
+    source,
+    /child\.on\('exit', \(code, signal\) => resolve\(\{ code, signal \}\)\)/,
+  );
+});


### PR DESCRIPTION
## Intent

Fix https://github.com/Lykhoyda/rn-dev-agent/issues/819: handle SQLite-enabled supervisor relaunch spawn() failures without crashing or leaving a pending promise.

Start from the end-user behavior. Reproduce the unhandled child-process error or unresolved relaunch promise through the SQLite relaunch path, recording expected behavior, observed behavior, setup, inputs, and repeatability. Separate the initiating spawn() error, any masking timing or error-plus-exit ordering, and the visible process outcome. Compare the failing SQLite relaunch with the proven ordinary worker-spawn path, inspect relevant history, identify the earliest divergence, test the smallest counterfactual, and seek disconfirming evidence. Turn the faithful reproduction into behavioral regressions.

Acceptance criteria:
- SQLite relaunch settles exactly once for error, exit, and error followed by exit.
- Spawn failure emits one concise actionable diagnostic, exits non-zero, and leaves no uncaught-event stack or pending promise.
- Signal forwarding is safe when the child is already gone.
- Successful relaunch exit and signal propagation remain unchanged.
- Behavioral tests inject error-only and error-plus-exit fake children, including EAGAIN.
- Keep the correction narrow and reuse the existing proven error-or-exit settlement mechanism rather than adding a new supervisor abstraction.

Implementation decisions already made: extract the worker path's once-only error-or-exit funnel into awaitChildErrorOrExit/completeSqliteRelaunch (not a new supervisor abstraction); SQLite relaunch and worker spawn both use that helper; spawn failure writes one line `rn-bridge-supervisor: sqlite relaunch spawn failed: <message>` and exits 1; child.kill is try/caught so a gone child cannot crash signal forwarding; successful SIGTERM still does removeAllListeners + killSelf then exit(code ?? 1). Do not run /codex-pair. Sol review already completed with no high-confidence findings.

## What Changed

- Reuse a once-only child error-or-exit settlement helper for worker startup and SQLite supervisor relaunches.
- Report SQLite relaunch spawn failures with one actionable diagnostic, exit with code 1, and safely ignore failures when forwarding signals to an already-gone child.
- Add regressions for error-only and error-plus-exit failures, including `EAGAIN`, while preserving successful exit and signal propagation behavior.

## Risk Assessment

✅ Low: The change is narrow and preserves prior success semantics while settling SQLite relaunch errors once; generated Claude and Codex runtimes contain the fix, and the source-content-only test was removed.

## Testing

No prior baseline results were supplied. Focused regressions covered error-only EAGAIN, exit, error-plus-exit, dead-child signal forwarding, and successful exit/signal propagation; the ordinary worker respawn integration also passed. The base executable reproduced a 26-line uncaught ChildProcess stack, while the core and both packaged host runtimes each exited 1 with one concise diagnostic and no stack, timeout, or pending process across three real EAGAIN attempts. No visual artifact was applicable because this is a CLI process-lifecycle change.

<details>
<summary>Evidence: EAGAIN comparison summary</summary>

<code>Base: exit=1, 26 diagnostic lines, uncaught stack=true&#10;Core/Claude/Codex targets (3 attempts each): exit=1, one diagnostic line, timeout=false, uncaught stack=false</code>

```text
SQLite relaunch with real spawn() EAGAIN (RLIMIT_NPROC=1)
base: exit=1 signal=null timeout=false diagnosticLines=26 uncaughtStack=true
core-attempt-1: exit=1 signal=null timeout=false diagnosticLines=1 uncaughtStack=false
target diagnostic: rn-bridge-supervisor: sqlite relaunch spawn failed: spawn /Users/antonlykhoyda/.nvm/versions/node/v24.14.0/bin/node EAGAIN
core-attempt-2: exit=1 signal=null timeout=false diagnosticLines=1 uncaughtStack=false
core-attempt-3: exit=1 signal=null timeout=false diagnosticLines=1 uncaughtStack=false
claude-host-attempt-1: exit=1 signal=null timeout=false diagnosticLines=1 uncaughtStack=false
claude-host-attempt-2: exit=1 signal=null timeout=false diagnosticLines=1 uncaughtStack=false
claude-host-attempt-3: exit=1 signal=null timeout=false diagnosticLines=1 uncaughtStack=false
codex-host-attempt-1: exit=1 signal=null timeout=false diagnosticLines=1 uncaughtStack=false
codex-host-attempt-2: exit=1 signal=null timeout=false diagnosticLines=1 uncaughtStack=false
codex-host-attempt-3: exit=1 signal=null timeout=false diagnosticLines=1 uncaughtStack=false
```
</details>
<details>
<summary>Evidence: Complete before/after executable transcript</summary>

```text
[
  {
    "label": "base",
    "setup": "SQLite relaunch forced; RLIMIT_NPROC=1 makes the real spawn() return EAGAIN",
    "input": "/Users/antonlykhoyda/.no-mistakes/evidence/01M0TVADQ9A9TBD90C7FY526E3/force-sqlite-relaunch.mjs -> /Users/antonlykhoyda/.no-mistakes/evidence/01M0TVADQ9A9TBD90C7FY526E3/base-tree/packages/rn-dev-agent-core/dist/supervisor.js",
    "expected": "one concise sqlite relaunch diagnostic, exit 1, no uncaught-event stack, no timeout",
    "observed": {
      "code": 1,
      "signal": null,
      "timedOut": false,
      "elapsedMs": 166,
      "stdout": "",
      "stderr": "node:events:486\n      throw er; // Unhandled 'error' event\n      ^\n\nError: spawn /Users/antonlykhoyda/.nvm/versions/node/v24.14.0/bin/node EAGAIN\n    at ChildProcess._handle.onexit (node:internal/child_process:286:19)\n    at onErrorNT (node:internal/child_process:484:16)\n    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)\nEmitted 'error' event on ChildProcess instance at:\n    at ChildProcess._handle.onexit (node:internal/child_process:292:12)\n    at onErrorNT (node:internal/child_process:484:16)\n    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {\n  errno: -35,\n  code: 'EAGAIN',\n  syscall: 'spawn /Users/antonlykhoyda/.nvm/versions/node/v24.14.0/bin/node',\n  path: '/Users/antonlykhoyda/.nvm/versions/node/v24.14.0/bin/node',\n  spawnargs: [\n    '--experimental-sqlite',\n    '--import',\n    '/Users/antonlykhoyda/.no-mistakes/evidence/01M0TVADQ9A9TBD90C7FY526E3/base-tree/packages/rn-dev-agent-core/dist/sqlite-warning-filter.js',\n    '/Users/antonlykhoyda/.no-mistakes/evidence/01M0TVADQ9A9TBD90C7FY526E3/base-tree/packages/rn-dev-agent-core/dist/supervisor.js',\n    '--no-lock'\n  ]\n}\n\nNode.js v24.14.0\n",
      "diagnosticLines": 26,
      "hasUncaughtStack": true
    }
  },
  {
    "label": "core-attempt-1",
    "setup": "SQLite relaunch forced; RLIMIT_NPROC=1 makes the real spawn() return EAGAIN",
    "input": "/Users/antonlykhoyda/.no-mistakes/evidence/01M0TVADQ9A9TBD90C7FY526E3/force-sqlite-relaunch.mjs -> /Users/antonlykhoyda/.no-mistakes/worktrees/1eccd0b444be/01M0TVADQ9A9TBD90C7FY526E3/packages/rn-dev-agent-core/dist/supervisor.js",
    "expected": "one concise sqlite relaunch diagnostic, exit 1, no uncaught-event stack, no timeout",
    "observed": {
      "code": 1,
      "signal": null,
      "timedOut": false,
      "elapsedMs": 160,
      "stdout": "",
      "stderr": "rn-bridge-supervisor: sqlite relaunch spawn failed: spawn /Users/antonlykhoyda/.nvm/versions/node/v24.14.0/bin/node EAGAIN\n",
      "diagnosticLines": 1,
      "hasUncaughtStack": false
    }
  },
  {
    "label": "core-attempt-2",
    "setup": "SQLite relaunch forced; RLIMIT_NPROC=1 makes the real spawn() return EAGAIN",
    "input": "/Users/antonlykhoyda/.no-mistakes/evidence/01M0TVADQ9A9TBD90C7FY526E3/force-sqlite-relaunch.mjs -> /Users/antonlykhoyda/.no-mistakes/worktrees/1eccd0b444be/01M0TVADQ9A9TBD90C7FY526E3/packages/rn-dev-agent-core/dist/supervisor.js",
    "expected": "one concise sqlite relaunch diagnostic, exit 1, no uncaught-event stack, no timeout",
    "observed": {
      "code": 1,
      "signal": null,
      "timedOut": false,
      "elapsedMs": 129,
      "stdout": "",
      "stderr": "rn-bridge-supervisor: sqlite relaunch spawn failed: spawn /Users/antonlykhoyda/.nvm/versions/node/v24.14.0/bin/node EAGAIN\n",
      "diagnosticLines": 1,
      "hasUncaughtStack": false
    }
  },
  {
    "label": "core-attempt-3",
    "setup": "SQLite relaunch forced; RLIMIT_NPROC=1 makes the real spawn() return EAGAIN",
    "input": "/Users/antonlykhoyda/.no-mistakes/evidence/01M0TVADQ9A9TBD90C7FY526E3/force-sqlite-relaunch.mjs -> /Users/antonlykhoyda/.no-mistakes/worktrees/1eccd0b444be/01M0TVADQ9A9TBD90C7FY526E3/packages/rn-dev-agent-core/dist/supervisor.js",
    "expected": "one concise sqlite relaunch diagnostic, exit 1, no uncaught-event stack, no timeout",
    "observed": {
      "code": 1,
      "signal": null,
      "timedOut": false,
      "elapsedMs": 149,
      "stdout": "",
      "stderr": "rn-bridge-supervisor: sqlite relaunch spawn failed: spawn /Users/antonlykhoyda/.nvm/versions/node/v24.14.0/bin/node EAGAIN\n",
      "diagnosticLines": 1,
      "hasUncaughtStack": false
    }
  },
  {
    "label": "claude-host-attempt-1",
    "setup": "SQLite relaunch forced; RLIMIT_NPROC=1 makes the real spawn() return EAGAIN",
    "input": "/Users/antonlykhoyda/.no-mistakes/evidence/01M0TVADQ9A9TBD90C7FY526E3/force-sqlite-relaunch.mjs -> /Users/antonlykhoyda/.no-mistakes/worktrees/1eccd0b444be/01M0TVADQ9A9TBD90C7FY526E3/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js",
    "expected": "one concise sqlite relaunch diagnostic, exit 1, no uncaught-event stack, no timeout",
    "observed": {
      "code": 1,
      "signal": null,
      "timedOut": false,
      "elapsedMs": 154,
      "stdout": "",
      "stderr": "rn-bridge-supervisor: sqlite relaunch spawn failed: spawn /Users/antonlykhoyda/.nvm/versions/node/v24.14.0/bin/node EAGAIN\n",
      "diagnosticLines": 1,
      "hasUncaughtStack": false
    }
  },
  {
    "label": "claude-host-attempt-2",
    "setup": "SQLite relaunch forced; RLIMIT_NPROC=1 makes the real spawn() return EAGAIN",
    "input": "/Users/antonlykhoyda/.no-mistakes/evidence/01M0TVADQ9A9TBD90C7FY526E3/force-sqlite-relaunch.mjs -> /Users/antonlykhoyda/.no-mistakes/worktrees/1eccd0b444be/01M0TVADQ9A9TBD90C7FY526E3/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js",
    "expected": "one concise sqlite relaunch diagnostic, exit 1, no uncaught-event stack, no timeout",
    "observed": {
      "code": 1,
      "signal": null,
      "timedOut": false,
      "elapsedMs": 118,
      "stdout": "",
      "stderr": "rn-bridge-supervisor: sqlite relaunch spawn failed: spawn /Users/antonlykhoyda/.nvm/versions/node/v24.14.0/bin/node EAGAIN\n",
      "diagnosticLines": 1,
      "hasUncaughtStack": false
    }
  },
  {
    "label": "claude-host-attempt-3",
    "setup": "SQLite relaunch forced; RLIMIT_NPROC=1 makes the real spawn() return EAGAIN",
    "input": "/Users/antonlykhoyda/.no-mistakes/evidence/01M0TVADQ9A9TBD90C7FY526E3/force-sqlite-relaunch.mjs -> /Users/antonlykhoyda/.no-mistakes/worktrees/1eccd0b444be/01M0TVADQ9A9TBD90C7FY526E3/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js",
    "expected": "one concise sqlite relaunch diagnostic, exit 1, no uncaught-event stack, no timeout",
    "observed": {
      "code": 1,
      "signal": null,
      "timedOut": false,
      "elapsedMs": 105,
      "stdout": "",
      "stderr": "rn-bridge-supervisor: sqlite relaunch spawn failed: spawn /Users/antonlykhoyda/.nvm/versions/node/v24.14.0/bin/node EAGAIN\n",
      "diagnosticLines": 1,
      "hasUncaughtStack": false
    }
  },
  {
    "label": "codex-host-attempt-1",
    "setup": "SQLite relaunch forced; RLIMIT_NPROC=1 makes the real spawn() return EAGAIN",
    "input": "/Users/antonlykhoyda/.no-mistakes/evidence/01M0TVADQ9A9TBD90C7FY526E3/force-sqlite-relaunch.mjs -> /Users/antonlykhoyda/.no-mistakes/worktrees/1eccd0b444be/01M0TVADQ9A9TBD90C7FY526E3/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js",
    "expected": "one concise sqlite relaunch diagnostic, exit 1, no uncaught-event stack, no timeout",
    "observed": {
      "code": 1,
      "signal": null,
      "timedOut": false,
      "elapsedMs": 103,
      "stdout": "",
      "stderr": "rn-bridge-supervisor: sqlite relaunch spawn failed: spawn /Users/antonlykhoyda/.nvm/versions/node/v24.14.0/bin/node EAGAIN\n",
      "diagnosticLines": 1,
      "hasUncaughtStack": false
    }
  },
  {
    "label": "codex-host-attempt-2",
    "setup": "SQLite relaunch forced; RLIMIT_NPROC=1 makes the real spawn() return EAGAIN",
    "input": "/Users/antonlykhoyda/.no-mistakes/evidence/01M0TVADQ9A9TBD90C7FY526E3/force-sqlite-relaunch.mjs -> /Users/antonlykhoyda/.no-mistakes/worktrees/1eccd0b444be/01M0TVADQ9A9TBD90C7FY526E3/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js",
    "expected": "one concise sqlite relaunch diagnostic, exit 1, no uncaught-event stack, no timeout",
    "observed": {
      "code": 1,
      "signal": null,
      "timedOut": false,
      "elapsedMs": 103,
      "stdout": "",
      "stderr": "rn-bridge-supervisor: sqlite relaunch spawn failed: spawn /Users/antonlykhoyda/.nvm/versions/node/v24.14.0/bin/node EAGAIN\n",
      "diagnosticLines": 1,
      "hasUncaughtStack": false
    }
  },
  {
    "label": "codex-host-attempt-3",
    "setup": "SQLite relaunch forced; RLIMIT_NPROC=1 makes the real spawn() return EAGAIN",
    "input": "/Users/antonlykhoyda/.no-mistakes/evidence/01M0TVADQ9A9TBD90C7FY526E3/force-sqlite-relaunch.mjs -> /Users/antonlykhoyda/.no-mistakes/worktrees/1eccd0b444be/01M0TVADQ9A9TBD90C7FY526E3/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js",
    "expected": "one concise sqlite relaunch diagnostic, exit 1, no uncaught-event stack, no timeout",
    "observed": {
      "code": 1,
      "signal": null,
      "timedOut": false,
      "elapsedMs": 102,
      "stdout": "",
      "stderr": "rn-bridge-supervisor: sqlite relaunch spawn failed: spawn /Users/antonlykhoyda/.nvm/versions/node/v24.14.0/bin/node EAGAIN\n",
      "diagnosticLines": 1,
      "hasUncaughtStack": false
    }
  }
]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4eb8793298b6bb18659478719c197780f8a77464","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `packages/rn-dev-agent-core/src/supervisor.ts:72` - Marketplace installs execute the bundled Claude/Codex supervisor outputs, but neither was regenerated; both still use the original exit-only SQLite wait and unguarded signal forwarding. An EAGAIN spawn failure therefore remains reachable for plugin users. Run `corepack yarn build:host-runtimes` and include the generated host-runtime changes.
- 🚨 `packages/rn-dev-agent-core/test/unit/gh-819-sqlite-relaunch-spawn-error.test.ts:194` - This newly added test only reads compiled source and regex-matches an implementation name. It can pass when `completeSqliteRelaunch` remains merely imported but is no longer called, so it does not prove the supervisor behavior and violates the test-quality rule. Replace it with an executable integration boundary that observes relaunch settlement, diagnostics, and exit behavior.

🔧 Fix: Regenerate host runtimes and remove proxy test
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node --test packages/rn-dev-agent-core/test/unit/gh-819-sqlite-relaunch-spawn-error.test.ts`
- `node --test packages/rn-dev-agent-core/test/integration/gh-264-supervisor-respawn.test.js`
- `git archive 37c65e3a82bff4483ee8dc4fef2378d9e7538ae6 packages/rn-dev-agent-core/dist packages/rn-dev-agent-core/package.json | tar -x -C /Users/antonlykhoyda/.no-mistakes/evidence/01M0TVADQ9A9TBD90C7FY526E3/base-tree`
- <code>`node /Users/antonlykhoyda/.no-mistakes/evidence/01M0TVADQ9A9TBD90C7FY526E3/sqlite-relaunch-eagain-e2e.mjs &lt;base-runtime&gt; &lt;version-preload&gt; &lt;worktree&gt; core=&lt;core-runtime&gt; claude-host=&lt;claude-runtime&gt; codex-host=&lt;codex-runtime&gt;` with `RLIMIT_NPROC=1`, three attempts per target</code>
- `Validated the captured JSON invariants and confirmed no surviving test processes or worktree changes.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR extracts a shared once-only child error-or-exit settlement mechanism and applies it to SQLite relaunches and ordinary worker startup.
- SQLite relaunch spawn failures now produce one concise diagnostic and terminate non-zero without leaving an unresolved promise.
- Signal forwarding tolerates children that have already exited.
- Claude and Codex packaged supervisor runtimes include the regenerated behavior.
- Behavioral regressions cover error-only, error-plus-exit, successful exit, signal propagation, and dead-child forwarding.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/rn-dev-agent-core/src/lifecycle/child-error-or-exit.ts | Adds the shared once-only child settlement helper and SQLite relaunch completion behavior. |
| packages/rn-dev-agent-core/src/supervisor.ts | Reuses the settlement helper for worker startup and SQLite supervisor relaunches. |
| packages/rn-dev-agent-core/test/unit/gh-819-sqlite-relaunch-spawn-error.test.ts | Adds executable behavioral coverage for spawn errors, duplicate terminal events, diagnostics, exits, and signal forwarding. |
| packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js | Regenerates the Claude packaged supervisor with the SQLite relaunch fix. |
| packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js | Regenerates the Codex packaged supervisor with the SQLite relaunch fix. |

</details>

<sub>Reviews (2): Last reviewed commit: ["no-mistakes(document): Condense child se..."](https://github.com/lykhoyda/rn-dev-agent/commit/46271149b959d14bfb37051c9390af25fce11e69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56429473)</sub>

<!-- /greptile_comment -->