### PR TITLE
fix(core): bound dialog waits and expose tool contracts

### DIFF
--- a/.changeset/dialog-presence-timeout.md
+++ b/.changeset/dialog-presence-timeout.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-core": patch
+"rn-dev-agent-plugin": patch
+---
+
+Bound the system-dialog fallback presence probe to a 15-second default (explicit caller timeouts through 120000ms remain accepted) so Android and session-less iOS calls with no dialog return typed DIALOG_NOT_FOUND promptly instead of appearing hung for two minutes, and teach the tool-docs generator to parse prettier-wrapped .describe() calls and wrapped zod chains so parameters such as timeoutMs and device_find.index are no longer published as undocumented unknowns.

--- a/apps/docs-site/scripts/generate-tool-docs.mjs
+++ b/apps/docs-site/scripts/generate-tool-docs.mjs
@@ -320,7 +320,9 @@ function escapeMdx(str) {
 }
 
 function escapeMdxTableCell(str) {
-  return escapeMdx(str).replace(/\r\n?|\n/g, '<br />').replace(/\|/g, '&#124;');
+  return escapeMdx(str)
+    .replace(/\r\n?|\n/g, '<br />')
+    .replace(/\|/g, '&#124;');
 }
 
 function escapeMdxCodeTableCell(str) {

--- a/apps/docs-site/scripts/generate-tool-docs.mjs
+++ b/apps/docs-site/scripts/generate-tool-docs.mjs
@@ -180,6 +180,39 @@ function parseZodType(def) {
   return 'unknown';
 }
 
+// Prettier wraps long zod chains across lines, so a param definition can span
+// several lines with the quote of .describe() on its own line (GH #816). The
+// chain's meaning is unaffected by whitespace outside string literals, so
+// collapse it once; string-literal contents (descriptions) are preserved byte
+// for byte.
+function collapseOuterWhitespace(def) {
+  let result = '';
+  let inString = false;
+  let stringChar = '';
+  for (let i = 0; i < def.length; i++) {
+    const ch = def[i];
+    if (inString) {
+      result += ch;
+      if (ch === '\\') {
+        // keep escapes intact inside literals
+        result += def[i + 1] ?? '';
+        i++;
+      } else if (ch === stringChar) {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      inString = true;
+      stringChar = ch;
+      result += ch;
+      continue;
+    }
+    if (!/\s/.test(ch)) result += ch;
+  }
+  return result;
+}
+
 function extractSchemaParams(schemaText) {
   const inner = schemaText.replace(/^\s*\{/, '').replace(/\}\s*$/, '');
   if (!inner.trim()) return [];
@@ -191,7 +224,7 @@ function extractSchemaParams(schemaText) {
     const colonIdx = line.indexOf(':');
     if (colonIdx === -1) continue;
     const name = line.slice(0, colonIdx).trim();
-    const def = line.slice(colonIdx + 1).trim();
+    const def = collapseOuterWhitespace(line.slice(colonIdx + 1).trim());
 
     const param = {
       name,
@@ -211,7 +244,10 @@ function extractSchemaParams(schemaText) {
       param.required = false;
     }
 
-    const descRe = /\.describe\((['"`])([\s\S]*?)\1\s*\)/g;
+    // Prettier may place the closing paren of a wrapped .describe() call after
+    // the argument (optionally with a trailing comma); accept both forms only —
+    // no widening beyond describe('…') / describe(\n '…',\n ).
+    const descRe = /\.describe\((['"`])([\s\S]*?)\1\s*,?\s*\)/g;
     let descMatch;
     let lastDesc = null;
     while ((descMatch = descRe.exec(def)) !== null) lastDesc = descMatch[2];

--- a/apps/docs-site/scripts/generate-tool-docs.mjs
+++ b/apps/docs-site/scripts/generate-tool-docs.mjs
@@ -323,6 +323,10 @@ function escapeMdxTableCell(str) {
   return escapeMdx(str).replace(/\r\n?|\n/g, '<br />').replace(/\|/g, '&#124;');
 }
 
+function escapeMdxCodeTableCell(str) {
+  return str.replace(/\|/g, '\\|');
+}
+
 function generateMdx(tool) {
   const isDeprecated = tool.description.toLowerCase().includes('deprecated');
   const sortIdx = SORT_ORDER.indexOf(tool.name);
@@ -333,7 +337,7 @@ function generateMdx(tool) {
       const constraints = p.constraints.length ? p.constraints.join(', ') : '';
       const def = p.defaultValue ?? '';
       const req = p.required ? 'Yes' : 'No';
-      return `| \`${p.name}\` | \`${p.type}\` | ${req} | ${def ? `\`${def}\`` : ''} | ${constraints} | ${escapeMdxTableCell(p.description)} |`;
+      return `| \`${p.name}\` | \`${escapeMdxCodeTableCell(p.type)}\` | ${req} | ${def ? `\`${def}\`` : ''} | ${constraints} | ${escapeMdxTableCell(p.description)} |`;
     })
     .join('\n');
 

--- a/apps/docs-site/scripts/generate-tool-docs.mjs
+++ b/apps/docs-site/scripts/generate-tool-docs.mjs
@@ -89,19 +89,26 @@ function parseStringLiteral(text, startPos) {
   let result = '';
   while (i < text.length) {
     if (text[i] === '\\') {
-      if (quote === "'" && text[i + 1] === "'") {
-        result += "'";
-        i += 2;
-        continue;
-      }
-      result += text[i + 1] ?? '';
+      if (i + 1 >= text.length) return null;
+      result += text.slice(i, i + 2);
       i += 2;
       continue;
     }
-    if (text[i] === quote) return { value: result, end: i + 1 };
+    if (text[i] === quote) {
+      return { value: decodeSupportedStringEscapes(result), end: i + 1 };
+    }
     result += text[i++];
   }
   return null;
+}
+
+export function decodeSupportedStringEscapes(value) {
+  return value.replace(/\\(?:u([\da-fA-F]{4})|([nt\\'"`]))/g, (_escape, unicode, simple) => {
+    if (unicode) return String.fromCharCode(Number.parseInt(unicode, 16));
+    if (simple === 'n') return '\n';
+    if (simple === 't') return '\t';
+    return simple;
+  });
 }
 
 function extractBalancedBraces(text, startIdx) {
@@ -180,11 +187,6 @@ function parseZodType(def) {
   return 'unknown';
 }
 
-// Prettier wraps long zod chains across lines, so a param definition can span
-// several lines with the quote of .describe() on its own line (GH #816). The
-// chain's meaning is unaffected by whitespace outside string literals, so
-// collapse it once; string-literal contents (descriptions) are preserved byte
-// for byte.
 function collapseOuterWhitespace(def) {
   let result = '';
   let inString = false;
@@ -194,7 +196,6 @@ function collapseOuterWhitespace(def) {
     if (inString) {
       result += ch;
       if (ch === '\\') {
-        // keep escapes intact inside literals
         result += def[i + 1] ?? '';
         i++;
       } else if (ch === stringChar) {
@@ -244,13 +245,16 @@ function extractSchemaParams(schemaText) {
       param.required = false;
     }
 
-    // Prettier may place the closing paren of a wrapped .describe() call after
-    // the argument (optionally with a trailing comma); accept both forms only —
-    // no widening beyond describe('…') / describe(\n '…',\n ).
-    const descRe = /\.describe\((['"`])([\s\S]*?)\1\s*,?\s*\)/g;
-    let descMatch;
     let lastDesc = null;
-    while ((descMatch = descRe.exec(def)) !== null) lastDesc = descMatch[2];
+    let describePos = 0;
+    while ((describePos = def.indexOf('.describe(', describePos)) !== -1) {
+      const argumentStart = describePos + '.describe('.length;
+      const parsed = parseStringLiteral(def, argumentStart);
+      if (parsed && (def[parsed.end] === ')' || def.slice(parsed.end, parsed.end + 2) === ',)')) {
+        lastDesc = parsed.value;
+      }
+      describePos = argumentStart;
+    }
     if (lastDesc) param.description = lastDesc;
 
     const minMatch = def.match(/\.min\(([^)]+)\)/);
@@ -355,7 +359,6 @@ ${usage}
 `;
 }
 
-// --- Main ---
 const source = readFileSync(INDEX_TS, 'utf8');
 const blocks = extractTrackedToolBlocks(source);
 const tools = blocks.map(blockToTool).filter(Boolean);
@@ -384,7 +387,6 @@ for (const tool of tools) {
   console.log(`  generated: tools/${category}/${tool.name}.mdx`);
 }
 
-// Copy package changelogs with frontmatter injection
 const CHANGELOG_SOURCES = [
   ['Claude plugin', resolve(ROOT, 'packages/claude-plugin/CHANGELOG.md')],
   ['Core MCP server', resolve(ROOT, 'packages/rn-dev-agent-core/CHANGELOG.md')],

--- a/apps/docs-site/scripts/generate-tool-docs.mjs
+++ b/apps/docs-site/scripts/generate-tool-docs.mjs
@@ -4,7 +4,9 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '../../..');
-const INDEX_TS = resolve(ROOT, 'packages/rn-dev-agent-core/src/index.ts');
+const INDEX_TS = process.env.RN_DEV_AGENT_DOCS_SOURCE
+  ? resolve(process.env.RN_DEV_AGENT_DOCS_SOURCE)
+  : resolve(ROOT, 'packages/rn-dev-agent-core/src/index.ts');
 // RN_DEV_AGENT_DOCS_OUT lets a regression run the real generator into a scratch
 // directory instead of overwriting the committed docs.
 const OUT_ROOT = process.env.RN_DEV_AGENT_DOCS_OUT
@@ -131,12 +133,17 @@ function splitTopLevel(text) {
   let stringChar = '';
   for (let i = 0; i < text.length; i++) {
     const ch = text[i];
-    if (!inString && (ch === '"' || ch === "'" || ch === '`')) {
+    if (inString) {
+      if (ch === '\\') {
+        current += ch;
+        if (i + 1 < text.length) current += text[++i];
+        continue;
+      }
+      if (ch === stringChar) inString = false;
+    } else if (ch === '"' || ch === "'" || ch === '`') {
       inString = true;
       stringChar = ch;
-    } else if (inString && ch === stringChar && text[i - 1] !== '\\') {
-      inString = false;
-    } else if (!inString) {
+    } else {
       if ('([{'.includes(ch)) depth++;
       else if (')]}'.includes(ch)) depth--;
       else if (ch === ',' && depth === 0) {
@@ -312,6 +319,10 @@ function escapeMdx(str) {
     .replace(/\}/g, '\\}');
 }
 
+function escapeMdxTableCell(str) {
+  return escapeMdx(str).replace(/\r\n?|\n/g, '<br />').replace(/\|/g, '&#124;');
+}
+
 function generateMdx(tool) {
   const isDeprecated = tool.description.toLowerCase().includes('deprecated');
   const sortIdx = SORT_ORDER.indexOf(tool.name);
@@ -322,7 +333,7 @@ function generateMdx(tool) {
       const constraints = p.constraints.length ? p.constraints.join(', ') : '';
       const def = p.defaultValue ?? '';
       const req = p.required ? 'Yes' : 'No';
-      return `| \`${p.name}\` | \`${p.type}\` | ${req} | ${def ? `\`${def}\`` : ''} | ${constraints} | ${escapeMdx(p.description)} |`;
+      return `| \`${p.name}\` | \`${p.type}\` | ${req} | ${def ? `\`${def}\`` : ''} | ${constraints} | ${escapeMdxTableCell(p.description)} |`;
     })
     .join('\n');
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_component_tree.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_component_tree.mdx
@@ -11,9 +11,9 @@ Get React component tree. Returns components with props, state, testIDs. Use fil
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `filter` | `unknown` | No |  |  |  |
+| `filter` | `string` | No |  |  | Case-insensitive substring match against component name, testID/nativeID, or accessibilityLabel (e.g. "CartBadge", "product-list", "Continue") |
 | `depth` | `number` | No | `4` | min: 1, max: 12, integer | Max depth (default 4, max 12) |
-| `interactiveOnly` | `unknown` | No |  |  |  |
+| `interactiveOnly` | `boolean` | No |  |  | Return a compact salient digest: only actionable nodes (Pressable/Button/TextInput/Switch/Link + accessibilityRole controls) with \{testID, role, text, label\}, dropping props/hookStates/nesting. Ignores filter/depth. Use to cheaply see what is tappable on the current screen. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_connect.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_connect.mdx
@@ -11,11 +11,11 @@ Connect only the exact app target on the authority-bound Metro and commit its si
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `metroPort` | `unknown` | No |  |  | Must equal the authority-bound Metro port; omitted uses that exact port |
-| `platform` | `unknown` | No |  |  |  |
-| `targetId` | `unknown` | No |  |  | Advisory; refuses only if it conflicts with the bound target |
-| `bundleId` | `unknown` | No |  |  |  |
-| `force` | `unknown` | No | `false` |  |  |
+| `metroPort` | `number` | No |  |  | Must equal the authority-bound Metro port; omitted uses that exact port |
+| `platform` | `string` | No |  |  | Filter target by platform (e.g. "ios", "android"). If already connected to a different platform, forces reconnection to the correct target. |
+| `targetId` | `string` | No |  |  | Advisory; refuses only if it conflicts with the bound target |
+| `bundleId` | `string` | No |  |  | App bundle id to match against target.description (e.g. "com.myapp.dev"). Filters out zombie Expo Go host pages when the real app target is present. B111/D635. |
+| `force` | `boolean` | No | `false` |  | Force disconnect and reconnect even if already connected. Use to switch targets or recover from stale connections. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_console_log.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_console_log.mdx
@@ -11,8 +11,8 @@ Get recent console output. Buffered in ring buffer so logs from between agent ca
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `level` | `unknown` | No | `'all'` |  | Filter by log level |
-| `limit` | `unknown` | No | `50` | min: 1, max: 200, integer | Max entries to return (default 50, max 200) |
+| `level` | `enum: all | log | warn | error | info | debug` | No | `'all'` |  | Filter by log level |
+| `limit` | `number` | No | `50` | min: 1, max: 200, integer | Max entries to return (default 50, max 200) |
 | `clear` | `boolean` | No | `false` |  | Clear console buffer instead of reading |
 
 ## Usage

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_console_log.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_console_log.mdx
@@ -11,7 +11,7 @@ Get recent console output. Buffered in ring buffer so logs from between agent ca
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `level` | `enum: all | log | warn | error | info | debug` | No | `'all'` |  | Filter by log level |
+| `level` | `enum: all \| log \| warn \| error \| info \| debug` | No | `'all'` |  | Filter by log level |
 | `limit` | `number` | No | `50` | min: 1, max: 200, integer | Max entries to return (default 50, max 200) |
 | `clear` | `boolean` | No | `false` |  | Clear console buffer instead of reading |
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_cpu_profile.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_cpu_profile.mdx
@@ -9,7 +9,7 @@ Record a CPU profile for a specified duration. Returns the top hot functions sor
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `durationMs` | `unknown` | No | `3000` | min: 500, max: 30000, integer | Profile duration in ms (default 3000, max 30000) |
+| `durationMs` | `number` | No | `3000` | min: 500, max: 30000, integer | Profile duration in ms (default 3000, max 30000) |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_dev_settings.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_dev_settings.mdx
@@ -11,7 +11,7 @@ Control React Native dev settings programmatically (no visual dev menu needed). 
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `action` | `enum: reload | toggleInspector | togglePerfMonitor | dismissRedBox | disableDevMenu | hideDevMenu` | Yes |  |  | Dev menu action to execute |
+| `action` | `enum: reload \| toggleInspector \| togglePerfMonitor \| dismissRedBox \| disableDevMenu \| hideDevMenu` | Yes |  |  | Dev menu action to execute |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_dev_settings.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_dev_settings.mdx
@@ -11,10 +11,10 @@ Control React Native dev settings programmatically (no visual dev menu needed). 
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `action` | `unknown` | Yes |  |  | Dev menu action to execute |
+| `action` | `enum: reload | toggleInspector | togglePerfMonitor | dismissRedBox | disableDevMenu | hideDevMenu` | Yes |  |  | Dev menu action to execute |
 
 ## Usage
 
 ```
-cdp_dev_settings(action: <unknown>)
+cdp_dev_settings(action: <enum: reload | toggleInspector | togglePerfMonitor | dismissRedBox | disableDevMenu | hideDevMenu>)
 ```

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_diagnostic_renderers.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_diagnostic_renderers.mdx
@@ -9,7 +9,7 @@ Diagnostic helper for "fiber root invisibility" bug reports (issue #126 follow-u
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `maxRendererId` | `unknown` | No |  | min: 1, max: 100, integer | How many renderer IDs to scan. Default 20 (matches IIFE MAX_RENDERER_IDS). |
+| `maxRendererId` | `number` | No |  | min: 1, max: 100, integer | How many renderer IDs to scan. Default 20 (matches IIFE MAX_RENDERER_IDS). |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_dismiss_dev_client_picker.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_dismiss_dev_client_picker.mdx
@@ -9,7 +9,7 @@ Dismiss the Expo Dev Client "Development servers" picker on demand. The picker i
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `platform` | `enum: ios \| android` | No |  |  | Authority-bound platform; conflicting values are refused |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_dismiss_dev_client_picker.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_dismiss_dev_client_picker.mdx
@@ -9,7 +9,7 @@ Dismiss the Expo Dev Client "Development servers" picker on demand. The picker i
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `platform` | `unknown` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_dispatch.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_dispatch.mdx
@@ -12,9 +12,9 @@ Dispatch a Redux action and optionally read state afterward — all in a single 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `action` | `string` | Yes |  |  | Redux action type (e.g. "tasks/softDelete", "cart/addItem") |
-| `payload` | `unknown` | No |  |  |  |
-| `payloadJson` | `unknown` | No |  |  |  |
-| `readPath` | `unknown` | No |  |  | Dot-path to read from store after dispatch (e.g. "tasks.pendingDelete") |
+| `payload` | `any` | No |  |  | Action payload. WARNING: JSON-RPC between LLM and MCP does not preserve the distinction between string "42" and number 42 — the LLM\\'s JSON encoder may serialize either way. For type-critical payloads (e.g. a string that happens to be numeric), use payloadJson instead. |
+| `payloadJson` | `string` | No |  |  | Stringified JSON payload with guaranteed type preservation. Takes precedence over `payload` when provided. Example: payloadJson=\\'"42"\\' dispatches the STRING "42"; payloadJson=\\'42\\' dispatches the NUMBER 42; payloadJson=\\'\{"id":"42","qty":5\}\\' dispatches an object. |
+| `readPath` | `string` | No |  |  | Dot-path to read from store after dispatch (e.g. "tasks.pendingDelete") |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_dispatch.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_dispatch.mdx
@@ -12,8 +12,8 @@ Dispatch a Redux action and optionally read state afterward — all in a single 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `action` | `string` | Yes |  |  | Redux action type (e.g. "tasks/softDelete", "cart/addItem") |
-| `payload` | `any` | No |  |  | Action payload. WARNING: JSON-RPC between LLM and MCP does not preserve the distinction between string "42" and number 42 — the LLM\\'s JSON encoder may serialize either way. For type-critical payloads (e.g. a string that happens to be numeric), use payloadJson instead. |
-| `payloadJson` | `string` | No |  |  | Stringified JSON payload with guaranteed type preservation. Takes precedence over `payload` when provided. Example: payloadJson=\\'"42"\\' dispatches the STRING "42"; payloadJson=\\'42\\' dispatches the NUMBER 42; payloadJson=\\'\{"id":"42","qty":5\}\\' dispatches an object. |
+| `payload` | `any` | No |  |  | Action payload. WARNING: JSON-RPC between LLM and MCP does not preserve the distinction between string "42" and number 42 — the LLM's JSON encoder may serialize either way. For type-critical payloads (e.g. a string that happens to be numeric), use payloadJson instead. |
+| `payloadJson` | `string` | No |  |  | Stringified JSON payload with guaranteed type preservation. Takes precedence over `payload` when provided. Example: payloadJson='"42"' dispatches the STRING "42"; payloadJson='42' dispatches the NUMBER 42; payloadJson='\{"id":"42","qty":5\}' dispatches an object. |
 | `readPath` | `string` | No |  |  | Dot-path to read from store after dispatch (e.g. "tasks.pendingDelete") |
 
 ## Usage

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_exception_breakpoint.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_exception_breakpoint.mdx
@@ -9,7 +9,7 @@ Set the debugger to pause on exceptions. With durationMs: records exceptions for
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `state` | `enum: none | uncaught | all` | No | `'uncaught'` |  | Exception pause mode: none (off), uncaught (default), all |
+| `state` | `enum: none \| uncaught \| all` | No | `'uncaught'` |  | Exception pause mode: none (off), uncaught (default), all |
 | `durationMs` | `number` | No |  | min: 1000, max: 30000, integer | Auto-capture duration in ms. If set, records exceptions then disables. |
 
 ## Usage

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_exception_breakpoint.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_exception_breakpoint.mdx
@@ -9,8 +9,8 @@ Set the debugger to pause on exceptions. With durationMs: records exceptions for
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `state` | `unknown` | No | `'uncaught'` |  | Exception pause mode: none (off), uncaught (default), all |
-| `durationMs` | `unknown` | No |  | min: 1000, max: 30000, integer | Auto-capture duration in ms. If set, records exceptions then disables. |
+| `state` | `enum: none | uncaught | all` | No | `'uncaught'` |  | Exception pause mode: none (off), uncaught (default), all |
+| `durationMs` | `number` | No |  | min: 1000, max: 30000, integer | Auto-capture duration in ms. If set, records exceptions then disables. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_interact.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_interact.mdx
@@ -11,7 +11,7 @@ Interact with React components by testID (preferred) or accessibilityLabel — p
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `action` | `enum: press | longPress | typeText | scroll | setFieldValue` | Yes |  |  | press: calls onPress (with `value` if provided, for radio/chip-style value-bearing controls). longPress: calls onLongPress. typeText: calls onChangeText. scroll: calls scrollTo or onScroll. setFieldValue: walks UP to nearest React Hook Form FormProvider and calls setValue(name, value, \{shouldValidate, shouldDirty\}). |
+| `action` | `enum: press \| longPress \| typeText \| scroll \| setFieldValue` | Yes |  |  | press: calls onPress (with `value` if provided, for radio/chip-style value-bearing controls). longPress: calls onLongPress. typeText: calls onChangeText. scroll: calls scrollTo or onScroll. setFieldValue: walks UP to nearest React Hook Form FormProvider and calls setValue(name, value, \{shouldValidate, shouldDirty\}). |
 | `testID` | `string` | No |  |  | testID prop of the target component (strict match — preferred). For setFieldValue, this is the testID anchor inside the form's subtree from which to walk up. |
 | `accessibilityLabel` | `string` | No |  |  | accessibilityLabel prop (used if testID not provided). Tiered match: exact → normalized (trim+lowercase) → substring. Returns Ambiguous error if &gt;1 component matches. |
 | `text` | `string` | No |  |  | For typeText: the text to enter. For the discovery ladder (no testID/accessibilityLabel, action:"press"): byText — match a host Text by its visible text content. |

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_interact.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_interact.mdx
@@ -11,25 +11,25 @@ Interact with React components by testID (preferred) or accessibilityLabel — p
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `action` | `unknown` | Yes |  |  |  |
-| `testID` | `unknown` | No |  |  |  |
-| `accessibilityLabel` | `unknown` | No |  |  |  |
-| `text` | `unknown` | No |  |  |  |
-| `role` | `unknown` | No |  |  |  |
-| `placeholder` | `unknown` | No |  |  | Discovery ladder (press-only): match a TextInput by its placeholder text. |
-| `exact` | `unknown` | No |  |  |  |
-| `includeHidden` | `unknown` | No |  |  | Discovery ladder: include accessibility-hidden elements (excluded by default). |
+| `action` | `enum: press | longPress | typeText | scroll | setFieldValue` | Yes |  |  | press: calls onPress (with `value` if provided, for radio/chip-style value-bearing controls). longPress: calls onLongPress. typeText: calls onChangeText. scroll: calls scrollTo or onScroll. setFieldValue: walks UP to nearest React Hook Form FormProvider and calls setValue(name, value, \{shouldValidate, shouldDirty\}). |
+| `testID` | `string` | No |  |  | testID prop of the target component (strict match — preferred). For setFieldValue, this is the testID anchor inside the form's subtree from which to walk up. |
+| `accessibilityLabel` | `string` | No |  |  | accessibilityLabel prop (used if testID not provided). Tiered match: exact → normalized (trim+lowercase) → substring. Returns Ambiguous error if &gt;1 component matches. |
+| `text` | `string` | No |  |  | For typeText: the text to enter. For the discovery ladder (no testID/accessibilityLabel, action:"press"): byText — match a host Text by its visible text content. |
+| `role` | `string` | No |  |  | Discovery ladder (press-only): match by accessibility role (e.g. button, tab, link). Combine with `name` for the accessible name. Needs an explicit accessibilityRole — Pressables without one resolve as role "none". |
+| `placeholder` | `string` | No |  |  | Discovery ladder (press-only): match a TextInput by its placeholder text. |
+| `exact` | `boolean` | No |  |  | Discovery ladder: require an exact (full-string) match for text/name/placeholder instead of case-insensitive substring. |
+| `includeHidden` | `boolean` | No |  |  | Discovery ladder: include accessibility-hidden elements (excluded by default). |
 | `scrollX` | `number` | No |  |  | For scroll: horizontal offset in pixels (default 0) |
 | `scrollY` | `number` | No |  |  | For scroll: vertical offset in pixels (default 300) |
 | `animated` | `boolean` | No | `true` |  | For scroll: whether to animate |
-| `name` | `unknown` | No |  |  |  |
-| `value` | `unknown` | No |  |  |  |
-| `shouldValidate` | `unknown` | No |  |  |  |
-| `shouldDirty` | `unknown` | No |  |  |  |
+| `name` | `string` | No |  |  | For setFieldValue: the React Hook Form field name (same string you passed to useController(\{name\}) or &lt;Controller name="..."&gt;). For the discovery ladder with `role`: the accessible name to match (e.g. role:"button" + name:"Save"). |
+| `value` | `unknown` | No |  |  | Value to set. For setFieldValue: passed to setValue (a digit-string is kept a string when the field currently holds a string — give string fields a "" default so this applies). For press: when provided, onPress receives this value instead of a synthetic event — use for radio/chip-style value-bearing controls. |
+| `shouldValidate` | `boolean` | No |  |  | For setFieldValue: pass-through to setValue's options.shouldValidate (default true). Set false to suppress synchronous validation. |
+| `shouldDirty` | `boolean` | No |  |  | For setFieldValue: pass-through to setValue's options.shouldDirty (default true). Set false to keep the field marked pristine. |
 | `walkUp` | `boolean` | No |  |  | Opt-in press-only nearest-pressable-ancestor walk |
 
 ## Usage
 
 ```
-cdp_interact(action: <unknown>)
+cdp_interact(action: <enum: press | longPress | typeText | scroll | setFieldValue>)
 ```

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_login_prologue.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_login_prologue.mdx
@@ -10,10 +10,10 @@ Fail-stop user-login helper: replay the exact action and require a fresh passing
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `projectRoot` | `string` | No |  |  | Override project root (default: process.cwd()). |
-| `platform` | `enum: ios | android` | No |  |  | Override the bound platform. |
+| `platform` | `enum: ios \| android` | No |  |  | Override the bound platform. |
 | `appFile` | `string` | No |  |  | iOS app artifact for clearState actions. |
 | `timeoutMs` | `number` | No |  |  | Saved-action timeout in milliseconds. |
-| `trigger` | `enum: agent | ci | human` | No |  |  | Run trigger; default agent. |
+| `trigger` | `enum: agent \| ci \| human` | No |  |  | Run trigger; default agent. |
 | `params` | `Record<string, unknown>` | No |  |  | String user-login bindings. |
 
 ## Usage

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_metro_events.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_metro_events.mdx
@@ -9,9 +9,9 @@ Read Metro reporter events (bundle_build_started, bundle_build_done, bundle_buil
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `limit` | `unknown` | No | `20` | min: 1, max: 100, integer | Max entries to return (default 20, max 100) |
+| `limit` | `number` | No | `20` | min: 1, max: 100, integer | Max entries to return (default 20, max 100) |
 | `type` | `string` | No |  |  | Filter by event type (e.g. "bundle_build_failed") |
-| `clearErrors` | `unknown` | No | `false` |  | Reset the build-error counter without reading events |
+| `clearErrors` | `boolean` | No | `false` |  | Reset the build-error counter without reading events |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_mmkv.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_mmkv.mdx
@@ -9,14 +9,14 @@ Read/write the app's MMKV storage from Hermes. Closes the iteration-loop gap whe
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `action` | `unknown` | Yes |  |  | MMKV action: get/set/delete/has by key, keys (list all), clear (wipe instance) |
+| `action` | `enum: get | set | delete | has | keys | clear` | Yes |  |  | MMKV action: get/set/delete/has by key, keys (list all), clear (wipe instance) |
 | `key` | `string` | No |  |  | Required for get/set/delete/has actions |
 | `value` | `unknown` | No |  |  | Required for set action. Combine with `type` to disambiguate (default: string) |
-| `type` | `unknown` | No |  |  | Value type for get/set (default: string) |
+| `type` | `enum: string | number | boolean` | No |  |  | Value type for get/set (default: string) |
 | `instanceId` | `string` | No |  |  | MMKV instance id (default: "mmkv.default") |
 
 ## Usage
 
 ```
-cdp_mmkv(action: <unknown>)
+cdp_mmkv(action: <enum: get | set | delete | has | keys | clear>)
 ```

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_mmkv.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_mmkv.mdx
@@ -9,10 +9,10 @@ Read/write the app's MMKV storage from Hermes. Closes the iteration-loop gap whe
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `action` | `enum: get | set | delete | has | keys | clear` | Yes |  |  | MMKV action: get/set/delete/has by key, keys (list all), clear (wipe instance) |
+| `action` | `enum: get \| set \| delete \| has \| keys \| clear` | Yes |  |  | MMKV action: get/set/delete/has by key, keys (list all), clear (wipe instance) |
 | `key` | `string` | No |  |  | Required for get/set/delete/has actions |
 | `value` | `unknown` | No |  |  | Required for set action. Combine with `type` to disambiguate (default: string) |
-| `type` | `enum: string | number | boolean` | No |  |  | Value type for get/set (default: string) |
+| `type` | `enum: string \| number \| boolean` | No |  |  | Value type for get/set (default: string) |
 | `instanceId` | `string` | No |  |  | MMKV instance id (default: "mmkv.default") |
 
 ## Usage

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_native_errors.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_native_errors.mdx
@@ -9,7 +9,7 @@ Read native-level errors from the exact authority-bound device. iOS uses simctl 
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `platform` | `enum: ios \| android` | No |  |  | Authority-bound platform; conflicting values are refused |
 | `deviceId` | `string` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
 | `sinceSeconds` | `number` | No |  | min: 5, max: 3600, integer | How far back to look (default 60s, max 3600) |
 | `limit` | `number` | No |  | min: 1, max: 100, integer | Max entries to return (default 10, max 100) |

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_native_errors.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_native_errors.mdx
@@ -9,10 +9,10 @@ Read native-level errors from the exact authority-bound device. iOS uses simctl 
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `platform` | `unknown` | No |  |  | Authority-bound platform; conflicting values are refused |
-| `deviceId` | `unknown` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
-| `sinceSeconds` | `unknown` | No |  | min: 5, max: 3600, integer | How far back to look (default 60s, max 3600) |
-| `limit` | `unknown` | No |  | min: 1, max: 100, integer | Max entries to return (default 10, max 100) |
+| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `deviceId` | `string` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
+| `sinceSeconds` | `number` | No |  | min: 5, max: 3600, integer | How far back to look (default 60s, max 3600) |
+| `limit` | `number` | No |  | min: 1, max: 100, integer | Max entries to return (default 10, max 100) |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_nav_graph.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_nav_graph.mdx
@@ -11,19 +11,19 @@ Navigation graph tool. PRIMARY: action="go" — navigates to any screen in ONE c
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `action` | `unknown` | Yes |  |  |  |
+| `action` | `enum: go | scan | read | navigate | record | staleness | playbook | heal` | Yes |  |  | go = navigate in one call (recommended). scan/read/navigate/record/staleness/playbook/heal for manual control |
 | `navigator_id` | `string` | No |  |  | (read) Filter to navigator subtree by id |
 | `screen` | `string` | No |  |  | (read/navigate/record/heal) Target screen name |
 | `from` | `string` | No |  |  | (navigate) Current screen. Omit to use active screen |
 | `force` | `boolean` | No | `false` |  | (scan) Force re-scan |
-| `method` | `unknown` | No |  |  | (record/heal) Navigation method |
+| `method` | `enum: programmatic | deep_link | ui_interaction` | No |  |  | (record/heal) Navigation method |
 | `success` | `boolean` | No |  |  | (record) Whether navigation succeeded |
 | `latency_ms` | `number` | No |  |  | (record) Navigation time in ms |
-| `platform` | `unknown` | No |  |  | (go/playbook/heal) Platform for playbook tips and heal advice |
-| `params` | `unknown` | No |  |  | (go) Screen params to pass (e.g. \{ id: "1" \}) |
+| `platform` | `enum: ios | android` | No |  |  | (go/playbook/heal) Platform for playbook tips and heal advice |
+| `params` | `Record<string, unknown>` | No |  |  | (go) Screen params to pass (e.g. \{ id: "1" \}) |
 
 ## Usage
 
 ```
-cdp_nav_graph(action: <unknown>)
+cdp_nav_graph(action: <enum: go | scan | read | navigate | record | staleness | playbook | heal>)
 ```

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_nav_graph.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_nav_graph.mdx
@@ -11,15 +11,15 @@ Navigation graph tool. PRIMARY: action="go" — navigates to any screen in ONE c
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `action` | `enum: go | scan | read | navigate | record | staleness | playbook | heal` | Yes |  |  | go = navigate in one call (recommended). scan/read/navigate/record/staleness/playbook/heal for manual control |
+| `action` | `enum: go \| scan \| read \| navigate \| record \| staleness \| playbook \| heal` | Yes |  |  | go = navigate in one call (recommended). scan/read/navigate/record/staleness/playbook/heal for manual control |
 | `navigator_id` | `string` | No |  |  | (read) Filter to navigator subtree by id |
 | `screen` | `string` | No |  |  | (read/navigate/record/heal) Target screen name |
 | `from` | `string` | No |  |  | (navigate) Current screen. Omit to use active screen |
 | `force` | `boolean` | No | `false` |  | (scan) Force re-scan |
-| `method` | `enum: programmatic | deep_link | ui_interaction` | No |  |  | (record/heal) Navigation method |
+| `method` | `enum: programmatic \| deep_link \| ui_interaction` | No |  |  | (record/heal) Navigation method |
 | `success` | `boolean` | No |  |  | (record) Whether navigation succeeded |
 | `latency_ms` | `number` | No |  |  | (record) Navigation time in ms |
-| `platform` | `enum: ios | android` | No |  |  | (go/playbook/heal) Platform for playbook tips and heal advice |
+| `platform` | `enum: ios \| android` | No |  |  | (go/playbook/heal) Platform for playbook tips and heal advice |
 | `params` | `Record<string, unknown>` | No |  |  | (go) Screen params to pass (e.g. \{ id: "1" \}) |
 
 ## Usage

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_navigate.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_navigate.mdx
@@ -11,11 +11,11 @@ Navigate to any screen by name, including nested stack screens that __NAV_REF__.
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `screen` | `unknown` | Yes |  |  | Screen name to navigate to (e.g. "AllTasks", "Dashboard", "ProfileEditModal") |
+| `screen` | `string` | Yes |  |  | Screen name to navigate to (e.g. "AllTasks", "Dashboard", "ProfileEditModal") |
 | `params` | `Record<string, unknown>` | No |  |  | Screen params (e.g. \{ id: "1" \}) |
 
 ## Usage
 
 ```
-cdp_navigate(screen: <unknown>)
+cdp_navigate(screen: <string>)
 ```

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_network_body.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_network_body.mdx
@@ -10,8 +10,8 @@ Get the actual response body for a network request by its requestId. Use cdp_net
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `requestId` | `string` | Yes |  |  | Request ID from cdp_network_log output |
-| `maxLength` | `unknown` | No | `10000` | min: 100, max: 100000, integer | Max body length to return (default 10000 chars). Truncated if longer. |
-| `device` | `unknown` | No |  |  |  |
+| `maxLength` | `number` | No | `10000` | min: 100, max: 100000, integer | Max body length to return (default 10000 chars). Truncated if longer. |
+| `device` | `string` | No |  |  | Device key to scope the lookup ("all" to search every device buffer). Defaults to the active device. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_network_log.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_network_log.mdx
@@ -11,12 +11,12 @@ Get recent network requests. Shows method, URL, status, duration. On RN 0.83+ us
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `limit` | `unknown` | No | `20` | min: 1, max: 100, integer | Max entries to return (default 20, max 100) |
+| `limit` | `number` | No | `20` | min: 1, max: 100, integer | Max entries to return (default 20, max 100) |
 | `filter` | `string` | No |  |  | Filter by URL substring (e.g. "/api/cart") |
-| `method` | `unknown` | No |  |  |  |
-| `since` | `unknown` | No |  |  |  |
+| `method` | `unknown` | No |  |  | Filter by HTTP method, case-insensitive (e.g. "POST" or ["POST","PUT"]). AND-combined with `filter`. Use to isolate mutations from follow-up GETs. |
+| `since` | `string` | No |  |  | ISO timestamp — drop entries with timestamp &lt; since before applying limit. Use to pin a checkpoint before an action and ask for everything since. |
 | `clear` | `boolean` | No | `false` |  | Clear network buffer instead of reading |
-| `device` | `unknown` | No |  |  |  |
+| `device` | `string` | No |  |  | Scope: a specific device key OR the literal "all" for a chronologically-merged view across every device. Defaults to the active device. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_object_inspect.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_object_inspect.mdx
@@ -10,8 +10,8 @@ Inspect a JS object by property path without flattening to JSON. Uses Runtime.ge
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `expression` | `string` | Yes |  |  | JS property path or primitive literal to inspect |
-| `depth` | `unknown` | No | `1` | min: 0, max: 3, integer | Property inspection depth (default 1, max 3) |
-| `maxProperties` | `unknown` | No | `20` | min: 1, max: 100, integer | Max properties per level (default 20) |
+| `depth` | `number` | No | `1` | min: 0, max: 3, integer | Property inspection depth (default 1, max 3) |
+| `maxProperties` | `number` | No | `20` | min: 1, max: 100, integer | Max properties per level (default 20) |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_record_test_generate.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_record_test_generate.mdx
@@ -9,14 +9,14 @@ Render the stored recording as replayable test code. Formats: maestro (YAML, pri
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `format` | `enum: maestro | detox | appium` | Yes |  |  | Output format |
+| `format` | `enum: maestro \| detox \| appium` | Yes |  |  | Output format |
 | `testName` | `string` | No |  |  | Name shown in describe()/comment header |
 | `bundleId` | `string` | No |  |  | App bundle ID for the Maestro appId header |
 | `id` | `string` | No |  |  | M7 action id (stable slug). When set, emitted as `# id: &lt;slug&gt;` header line. Default: filename without `.yaml`. |
 | `intent` | `string` | No |  |  | M7 one-line goal. When set, emitted as `# intent: &lt;intent&gt;` header line. |
 | `tags` | `array` | No |  |  | M7 filterable tags. When set, emitted as `# tags: [a, b, c]`. |
 | `mutates` | `boolean` | No |  |  | M7 side-effect flag. When set, emitted as `# mutates: true&#124;false`. |
-| `status` | `enum: experimental | active | deprecated` | No |  |  | M7 lifecycle status. When set, emitted as `# status: &lt;status&gt;`. |
+| `status` | `enum: experimental \| active \| deprecated` | No |  |  | M7 lifecycle status. When set, emitted as `# status: &lt;status&gt;`. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_record_test_generate.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_record_test_generate.mdx
@@ -15,7 +15,7 @@ Render the stored recording as replayable test code. Formats: maestro (YAML, pri
 | `id` | `string` | No |  |  | M7 action id (stable slug). When set, emitted as `# id: &lt;slug&gt;` header line. Default: filename without `.yaml`. |
 | `intent` | `string` | No |  |  | M7 one-line goal. When set, emitted as `# intent: &lt;intent&gt;` header line. |
 | `tags` | `array` | No |  |  | M7 filterable tags. When set, emitted as `# tags: [a, b, c]`. |
-| `mutates` | `boolean` | No |  |  | M7 side-effect flag. When set, emitted as `# mutates: true|false`. |
+| `mutates` | `boolean` | No |  |  | M7 side-effect flag. When set, emitted as `# mutates: true&#124;false`. |
 | `status` | `enum: experimental | active | deprecated` | No |  |  | M7 lifecycle status. When set, emitted as `# status: &lt;status&gt;`. |
 
 ## Usage

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_record_test_generate.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_record_test_generate.mdx
@@ -12,11 +12,11 @@ Render the stored recording as replayable test code. Formats: maestro (YAML, pri
 | `format` | `enum: maestro | detox | appium` | Yes |  |  | Output format |
 | `testName` | `string` | No |  |  | Name shown in describe()/comment header |
 | `bundleId` | `string` | No |  |  | App bundle ID for the Maestro appId header |
-| `id` | `unknown` | No |  |  |  |
-| `intent` | `unknown` | No |  |  | M7 one-line goal. When set, emitted as `# intent: &lt;intent&gt;` header line. |
-| `tags` | `unknown` | No |  |  | M7 filterable tags. When set, emitted as `# tags: [a, b, c]`. |
-| `mutates` | `unknown` | No |  |  | M7 side-effect flag. When set, emitted as `# mutates: true|false`. |
-| `status` | `unknown` | No |  |  | M7 lifecycle status. When set, emitted as `# status: &lt;status&gt;`. |
+| `id` | `string` | No |  |  | M7 action id (stable slug). When set, emitted as `# id: &lt;slug&gt;` header line. Default: filename without `.yaml`. |
+| `intent` | `string` | No |  |  | M7 one-line goal. When set, emitted as `# intent: &lt;intent&gt;` header line. |
+| `tags` | `array` | No |  |  | M7 filterable tags. When set, emitted as `# tags: [a, b, c]`. |
+| `mutates` | `boolean` | No |  |  | M7 side-effect flag. When set, emitted as `# mutates: true|false`. |
+| `status` | `enum: experimental | active | deprecated` | No |  |  | M7 lifecycle status. When set, emitted as `# status: &lt;status&gt;`. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_record_test_save_as_action.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_record_test_save_as_action.mdx
@@ -9,19 +9,19 @@ Promote the in-memory recording (started via cdp_record_test_start) into a first
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `id` | `unknown` | Yes |  |  |  |
-| `intent` | `unknown` | Yes |  |  | One-line goal — surfaced verbatim by /list-learned-actions. Required. |
-| `tags` | `unknown` | No |  |  |  |
-| `mutates` | `unknown` | No |  |  |  |
-| `status` | `unknown` | No |  |  |  |
-| `bundleId` | `unknown` | No |  |  |  |
+| `id` | `string` | Yes |  |  | Stable slug; becomes the filename and the M7 id field. Lower-case kebab-case (a-z, 0-9, hyphen). |
+| `intent` | `string` | Yes |  |  | One-line goal — surfaced verbatim by /list-learned-actions. Required. |
+| `tags` | `array` | No |  |  | Lower-case kebab-case keywords for filtering (e.g. ["tasks", "create", "regression"]). |
+| `mutates` | `boolean` | No |  |  | Does this flow leave persistent residue (created rows, toggled settings)? Required for /run-action safety pre-flight to know whether to confirm before replay. |
+| `status` | `enum: experimental | active | deprecated` | No |  |  | M7 lifecycle status. Default: experimental (auto-promotes on first clean replay). |
+| `bundleId` | `string` | No |  |  | App bundle ID for the Maestro appId header. Strongly recommended — /run-action uses it to refuse cross-app replays. |
 | `projectRoot` | `string` | No |  |  | Override project root (default: process.cwd()). |
-| `overwrite` | `unknown` | No |  |  |  |
-| `testName` | `unknown` | No |  |  |  |
-| `produces` | `unknown` | No |  |  |  |
+| `overwrite` | `boolean` | No |  |  | If an action with this id already exists, replace it. Default false (refuse with hint). |
+| `testName` | `string` | No |  |  | Optional one-line description shown as a comment above the M7 header. Falls back to intent. |
+| `produces` | `Record<string, unknown>` | No |  |  | D1209 — state postconditions this action establishes when it runs cleanly. Flat map of primitive values for hybrid composition (e.g. \{ authenticated: true, route: "home" \}). Optional. Values containing commas or newlines are not supported; use multiple keys instead. |
 
 ## Usage
 
 ```
-cdp_record_test_save_as_action(id: <unknown>, intent: <unknown>)
+cdp_record_test_save_as_action(id: <string>, intent: <string>)
 ```

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_record_test_save_as_action.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_record_test_save_as_action.mdx
@@ -13,7 +13,7 @@ Promote the in-memory recording (started via cdp_record_test_start) into a first
 | `intent` | `string` | Yes |  |  | One-line goal — surfaced verbatim by /list-learned-actions. Required. |
 | `tags` | `array` | No |  |  | Lower-case kebab-case keywords for filtering (e.g. ["tasks", "create", "regression"]). |
 | `mutates` | `boolean` | No |  |  | Does this flow leave persistent residue (created rows, toggled settings)? Required for /run-action safety pre-flight to know whether to confirm before replay. |
-| `status` | `enum: experimental | active | deprecated` | No |  |  | M7 lifecycle status. Default: experimental (auto-promotes on first clean replay). |
+| `status` | `enum: experimental \| active \| deprecated` | No |  |  | M7 lifecycle status. Default: experimental (auto-promotes on first clean replay). |
 | `bundleId` | `string` | No |  |  | App bundle ID for the Maestro appId header. Strongly recommended — /run-action uses it to refuse cross-app replays. |
 | `projectRoot` | `string` | No |  |  | Override project root (default: process.cwd()). |
 | `overwrite` | `boolean` | No |  |  | If an action with this id already exists, replace it. Default false (refuse with hint). |

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_reload.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_reload.mdx
@@ -11,7 +11,7 @@ Reload the authority-bound app and atomically replace its exact Hermes target cl
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `full` | `unknown` | No | `true` |  | Always performs a full reload via DevSettings.reload() |
+| `full` | `boolean` | No | `true` |  | Always performs a full reload via DevSettings.reload() |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_repair_action.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_repair_action.mdx
@@ -10,7 +10,7 @@ Repair a learned action using a fresh snapshot from the exact authority-bound de
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `actionId` | `string` | Yes |  |  | Owned action id; resolves one .yaml or .yml file. |
-| `failedSelector` | `string` | Yes |  |  | The testID that the prior maestro_run reported as missing. Parse it from stderr like "Element with id \\'X\\' not found" → X. |
+| `failedSelector` | `string` | Yes |  |  | The testID that the prior maestro_run reported as missing. Parse it from stderr like "Element with id 'X' not found" → X. |
 | `projectRoot` | `string` | No |  |  | Override project root (default: process.cwd()). |
 | `threshold` | `number` | No |  | min: 0, max: 1 | Fuzzy-match similarity threshold (0..1). Default 0.6. Lower if the screen has many similar testIDs and Levenshtein on the original is too strict. |
 | `dryRun` | `boolean` | No |  |  | Don't write changes — return the diff that WOULD be applied. Useful for previewing repairs before committing. |

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_repair_action.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_repair_action.mdx
@@ -10,17 +10,17 @@ Repair a learned action using a fresh snapshot from the exact authority-bound de
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `actionId` | `string` | Yes |  |  | Owned action id; resolves one .yaml or .yml file. |
-| `failedSelector` | `unknown` | Yes |  |  |  |
+| `failedSelector` | `string` | Yes |  |  | The testID that the prior maestro_run reported as missing. Parse it from stderr like "Element with id \\'X\\' not found" → X. |
 | `projectRoot` | `string` | No |  |  | Override project root (default: process.cwd()). |
-| `threshold` | `unknown` | No |  | min: 0, max: 1 |  |
-| `dryRun` | `unknown` | No |  |  |  |
-| `agentReasoning` | `unknown` | No |  |  |  |
-| `platform` | `unknown` | No |  |  | Authority-bound platform; conflicting values are refused |
-| `deviceId` | `unknown` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
-| `appId` | `unknown` | No |  |  | Authority-bound app identifier; normally injected by the session |
+| `threshold` | `number` | No |  | min: 0, max: 1 | Fuzzy-match similarity threshold (0..1). Default 0.6. Lower if the screen has many similar testIDs and Levenshtein on the original is too strict. |
+| `dryRun` | `boolean` | No |  |  | Don't write changes — return the diff that WOULD be applied. Useful for previewing repairs before committing. |
+| `agentReasoning` | `string` | No |  |  | Free-form one-liner the agent records in the RepairRecord. Helps audit "why did this repair happen". Max ~200 chars recommended. |
+| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `deviceId` | `string` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
+| `appId` | `string` | No |  |  | Authority-bound app identifier; normally injected by the session |
 
 ## Usage
 
 ```
-cdp_repair_action(actionId: <string>, failedSelector: <unknown>)
+cdp_repair_action(actionId: <string>, failedSelector: <string>)
 ```

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_repair_action.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_repair_action.mdx
@@ -15,7 +15,7 @@ Repair a learned action using a fresh snapshot from the exact authority-bound de
 | `threshold` | `number` | No |  | min: 0, max: 1 | Fuzzy-match similarity threshold (0..1). Default 0.6. Lower if the screen has many similar testIDs and Levenshtein on the original is too strict. |
 | `dryRun` | `boolean` | No |  |  | Don't write changes — return the diff that WOULD be applied. Useful for previewing repairs before committing. |
 | `agentReasoning` | `string` | No |  |  | Free-form one-liner the agent records in the RepairRecord. Helps audit "why did this repair happen". Max ~200 chars recommended. |
-| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `platform` | `enum: ios \| android` | No |  |  | Authority-bound platform; conflicting values are refused |
 | `deviceId` | `string` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
 | `appId` | `string` | No |  |  | Authority-bound app identifier; normally injected by the session |
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_restart.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_restart.mdx
@@ -10,7 +10,7 @@ Reset and reconnect the authority-bound Hermes client. hardReset relaunches only
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `metroPort` | `number` | No |  |  | Authority-bound Metro port; conflicting values are refused |
-| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `platform` | `enum: ios \| android` | No |  |  | Authority-bound platform; conflicting values are refused |
 | `deviceId` | `string` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
 | `appId` | `string` | No |  |  | Authority-bound exact app identifier; normally injected by the session |
 | `hardReset` | `boolean` | No |  |  | Relaunch the exact session app on its claimed iOS or Android device before reconnecting. |

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_restart.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_restart.mdx
@@ -9,12 +9,12 @@ Reset and reconnect the authority-bound Hermes client. hardReset relaunches only
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `metroPort` | `unknown` | No |  |  | Authority-bound Metro port; conflicting values are refused |
-| `platform` | `unknown` | No |  |  | Authority-bound platform; conflicting values are refused |
-| `deviceId` | `unknown` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
-| `appId` | `unknown` | No |  |  | Authority-bound exact app identifier; normally injected by the session |
-| `hardReset` | `unknown` | No |  |  |  |
-| `bundleId` | `unknown` | No |  |  |  |
+| `metroPort` | `number` | No |  |  | Authority-bound Metro port; conflicting values are refused |
+| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `deviceId` | `string` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
+| `appId` | `string` | No |  |  | Authority-bound exact app identifier; normally injected by the session |
+| `hardReset` | `boolean` | No |  |  | Relaunch the exact session app on its claimed iOS or Android device before reconnecting. |
+| `bundleId` | `string` | No |  |  | Compatibility alias for the authority-bound appId; conflicting values are refused. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_run_action.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_run_action.mdx
@@ -11,14 +11,14 @@ Replay a learned action by id with end-to-end auto-repair. Loads the action from
 |------|------|----------|---------|-------------|-------------|
 | `actionId` | `string` | Yes |  |  | Owned action id; resolves one .yaml or .yml file. |
 | `projectRoot` | `string` | No |  |  | Override project root (default: process.cwd()). |
-| `platform` | `enum: ios | android` | No |  |  | Force a specific platform; otherwise auto-detected from the active device session. |
+| `platform` | `enum: ios \| android` | No |  |  | Force a specific platform; otherwise auto-detected from the active device session. |
 | `appFile` | `string` | No |  |  | GH #705: path to the .app Maestro reinstalls from after a clearState uninstall. Normally omit it — an iOS clearState flow resolves the bundle from the session's attested install receipt, and the receipt is re-issued after the reinstall so later device_*/maestro_run calls keep working. |
 | `autoRepair` | `boolean` | No |  |  | Auto-repair on SELECTOR_NOT_FOUND failures. Default true. Pass false to disable (e.g. when investigating a failure manually). |
 | `timeoutMs` | `number` | No |  |  | Maestro execution timeout per attempt (ms). Default 120_000. |
-| `trigger` | `enum: agent | ci | human` | No |  |  | RunRecord trigger annotation. Default "agent". CI calls should pass "ci". |
+| `trigger` | `enum: agent \| ci \| human` | No |  |  | RunRecord trigger annotation. Default "agent". CI calls should pass "ci". |
 | `forceReload` | `boolean` | No |  |  | GH #173: when true (default), acknowledge any human edit to the YAML as the new baseline before running so downstream repair does not abort with STALE_TARGET. Pass false for the strict Phase 129 "respect external edits" behavior (useful for CI replays of fixed baselines). |
 | `proofReplay` | `boolean` | No |  |  | Read-only proof rehearsal mode. Requires autoRepair=false and forceReload=false; never writes action YAML, runtime sidecar, or DB state. |
-| `blindProbeMode` | `enum: inherit | allow | forbid` | No |  |  | Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged. |
+| `blindProbeMode` | `enum: inherit \| allow \| forbid` | No |  |  | Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged. |
 | `params` | `Record<string, unknown>` | No |  |  | Parameter bindings for the action's $\{VAR\} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run). |
 
 ## Usage

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_run_action.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_run_action.mdx
@@ -11,15 +11,15 @@ Replay a learned action by id with end-to-end auto-repair. Loads the action from
 |------|------|----------|---------|-------------|-------------|
 | `actionId` | `string` | Yes |  |  | Owned action id; resolves one .yaml or .yml file. |
 | `projectRoot` | `string` | No |  |  | Override project root (default: process.cwd()). |
-| `platform` | `unknown` | No |  |  |  |
-| `appFile` | `unknown` | No |  |  |  |
-| `autoRepair` | `unknown` | No |  |  |  |
-| `timeoutMs` | `unknown` | No |  |  | Maestro execution timeout per attempt (ms). Default 120_000. |
-| `trigger` | `unknown` | No |  |  | RunRecord trigger annotation. Default "agent". CI calls should pass "ci". |
-| `forceReload` | `unknown` | No |  |  |  |
-| `proofReplay` | `unknown` | No |  |  |  |
-| `blindProbeMode` | `unknown` | No |  |  |  |
-| `params` | `unknown` | No |  |  |  |
+| `platform` | `enum: ios | android` | No |  |  | Force a specific platform; otherwise auto-detected from the active device session. |
+| `appFile` | `string` | No |  |  | GH #705: path to the .app Maestro reinstalls from after a clearState uninstall. Normally omit it — an iOS clearState flow resolves the bundle from the session's attested install receipt, and the receipt is re-issued after the reinstall so later device_*/maestro_run calls keep working. |
+| `autoRepair` | `boolean` | No |  |  | Auto-repair on SELECTOR_NOT_FOUND failures. Default true. Pass false to disable (e.g. when investigating a failure manually). |
+| `timeoutMs` | `number` | No |  |  | Maestro execution timeout per attempt (ms). Default 120_000. |
+| `trigger` | `enum: agent | ci | human` | No |  |  | RunRecord trigger annotation. Default "agent". CI calls should pass "ci". |
+| `forceReload` | `boolean` | No |  |  | GH #173: when true (default), acknowledge any human edit to the YAML as the new baseline before running so downstream repair does not abort with STALE_TARGET. Pass false for the strict Phase 129 "respect external edits" behavior (useful for CI replays of fixed baselines). |
+| `proofReplay` | `boolean` | No |  |  | Read-only proof rehearsal mode. Requires autoRepair=false and forceReload=false; never writes action YAML, runtime sidecar, or DB state. |
+| `blindProbeMode` | `enum: inherit | allow | forbid` | No |  |  | Per-call proactive CDP/JS compatibility control. inherit (default) honors RN_BLIND_PROBE; allow explicitly enables the at-risk probe even when the process default is disabled; forbid keeps this call maestro-first. Reactive fallback behavior is unchanged. |
+| `params` | `Record<string, unknown>` | No |  |  | Parameter bindings for the action's $\{VAR\} placeholders, forwarded to maestro as -e KEY=VALUE on the first attempt AND the post-repair retry (GH #116). Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in maestro_run). |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_status.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_status.mdx
@@ -11,8 +11,8 @@ Passively report the current authority session, Metro client, and CDP target wit
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `metroPort` | `unknown` | No |  |  | Diagnostic comparison only; cdp_status never changes the active Metro port |
-| `platform` | `unknown` | No |  |  |  |
+| `metroPort` | `number` | No |  |  | Diagnostic comparison only; cdp_status never changes the active Metro port |
+| `platform` | `string` | No |  |  | Filter target by platform (e.g. "ios", "android") to avoid connecting to the wrong device in multi-simulator setups |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_store_state.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_store_state.mdx
@@ -12,7 +12,7 @@ Read app store state (Redux, Zustand, Jotai, React Query). Use path to query spe
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `path` | `string` | No |  |  | Dot-path into store state (e.g. "cart.items") |
-| `storeType` | `enum: redux | zustand | jotai | react-query` | No |  |  | Target a specific store type. Useful when app has both Redux and React Query. |
+| `storeType` | `enum: redux \| zustand \| jotai \| react-query` | No |  |  | Target a specific store type. Useful when app has both Redux and React Query. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_store_state.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_store_state.mdx
@@ -12,7 +12,7 @@ Read app store state (Redux, Zustand, Jotai, React Query). Use path to query spe
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `path` | `string` | No |  |  | Dot-path into store state (e.g. "cart.items") |
-| `storeType` | `unknown` | No |  |  | Target a specific store type. Useful when app has both Redux and React Query. |
+| `storeType` | `enum: redux | zustand | jotai | react-query` | No |  |  | Target a specific store type. Useful when app has both Redux and React Query. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cdp_wait_for_network.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cdp_wait_for_network.mdx
@@ -9,15 +9,15 @@ Block until a network request matching url_pattern (URL substring) and optional 
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `url_pattern` | `unknown` | Yes |  |  |  |
-| `method` | `unknown` | No |  |  |  |
-| `timeout_ms` | `unknown` | No | `5000` | min: 100, max: 60000, integer | Max wait in ms (default 5000, range 100-60000) |
-| `poll_interval_ms` | `unknown` | No | `100` | min: 50, max: 500, integer | Buffer poll cadence in ms (default 100, range 50-500) |
-| `since` | `unknown` | No |  |  |  |
+| `url_pattern` | `string` | Yes |  |  | URL substring to match (e.g. "/api/cart/add", "checkout"). Same matching semantics as cdp_network_log filter. |
+| `method` | `unknown` | No |  |  | HTTP method filter, case-insensitive (e.g. "POST" or ["POST","PUT"]). Omit to match any method. |
+| `timeout_ms` | `number` | No | `5000` | min: 100, max: 60000, integer | Max wait in ms (default 5000, range 100-60000) |
+| `poll_interval_ms` | `number` | No | `100` | min: 50, max: 500, integer | Buffer poll cadence in ms (default 100, range 50-500) |
+| `since` | `string` | No |  |  | ISO timestamp checkpoint — ignore entries older than this. Defaults to the moment the tool is called. Capture `new Date().toISOString()` before the trigger action to avoid missing the mutation in the transport window. |
 | `device` | `string` | No |  |  | Device key OR "all". Defaults to the active device. |
 
 ## Usage
 
 ```
-cdp_wait_for_network(url_pattern: <unknown>)
+cdp_wait_for_network(url_pattern: <string>)
 ```

--- a/apps/docs-site/src/content/docs/tools/cdp/collect_logs.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/collect_logs.mdx
@@ -11,12 +11,12 @@ Collect logs from multiple sources in parallel: JS console (Hermes ring buffer s
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `sources` | `unknown` | No | `['js_console']` |  | Log sources to collect from (default: js_console only) |
-| `durationMs` | `unknown` | No | `2000` | min: 0, max: 10000, integer |  |
-| `limit` | `unknown` | No | `100` | min: 1, max: 500, integer |  |
+| `sources` | `(js_console | native_ios | native_android)[]` | No | `['js_console']` |  | Log sources to collect from (default: js_console only) |
+| `durationMs` | `number` | No | `2000` | min: 0, max: 10000, integer | How long to stream native logs in ms (default 2000). JS console is a snapshot — durationMs only applies to native sources. |
+| `limit` | `number` | No | `100` | min: 1, max: 500, integer | Max entries to return (default 100, max 500). Returns most recent entries when truncated. |
 | `filter` | `string` | No |  |  | Substring filter applied to log text after collection |
-| `logLevel` | `unknown` | No | `'all'` |  | Filter by log level (default: all) |
-| `runnerDiagnosticsOutputPath` | `unknown` | No |  |  | New caller-named file for the newest sanitized runner diagnostics bundle |
+| `logLevel` | `enum: all | log | warn | error | info | debug` | No | `'all'` |  | Filter by log level (default: all) |
+| `runnerDiagnosticsOutputPath` | `string` | No |  |  | New caller-named file for the newest sanitized runner diagnostics bundle |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/collect_logs.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/collect_logs.mdx
@@ -11,11 +11,11 @@ Collect logs from multiple sources in parallel: JS console (Hermes ring buffer s
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `sources` | `(js_console | native_ios | native_android)[]` | No | `['js_console']` |  | Log sources to collect from (default: js_console only) |
+| `sources` | `(js_console \| native_ios \| native_android)[]` | No | `['js_console']` |  | Log sources to collect from (default: js_console only) |
 | `durationMs` | `number` | No | `2000` | min: 0, max: 10000, integer | How long to stream native logs in ms (default 2000). JS console is a snapshot — durationMs only applies to native sources. |
 | `limit` | `number` | No | `100` | min: 1, max: 500, integer | Max entries to return (default 100, max 500). Returns most recent entries when truncated. |
 | `filter` | `string` | No |  |  | Substring filter applied to log text after collection |
-| `logLevel` | `enum: all | log | warn | error | info | debug` | No | `'all'` |  | Filter by log level (default: all) |
+| `logLevel` | `enum: all \| log \| warn \| error \| info \| debug` | No | `'all'` |  | Filter by log level (default: all) |
 | `runnerDiagnosticsOutputPath` | `string` | No |  |  | New caller-named file for the newest sanitized runner diagnostics bundle |
 
 ## Usage

--- a/apps/docs-site/src/content/docs/tools/cdp/cross_platform_verify.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cross_platform_verify.mdx
@@ -9,9 +9,9 @@ Compare UI elements across iOS and Android. Reads cached accessibility snapshots
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `elements` | `unknown` | No |  |  |  |
-| `scanDir` | `unknown` | No |  |  |  |
-| `matchBy` | `unknown` | No | `'any'` |  |  |
+| `elements` | `array` | No |  |  | List of testIDs or labels to check on both platforms. Optional if scanDir is provided. |
+| `scanDir` | `string` | No |  |  | Directory to scan for testID="..." props in .tsx/.jsx/.ts/.js files. Auto-discovers elements. Merges with elements[] if both provided. |
+| `matchBy` | `enum: testID | label | any` | No | `'any'` |  | Match strategy: testID (exact identifier match), label (substring in accessibility label), any (try both) |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/cross_platform_verify.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/cross_platform_verify.mdx
@@ -11,7 +11,7 @@ Compare UI elements across iOS and Android. Reads cached accessibility snapshots
 |------|------|----------|---------|-------------|-------------|
 | `elements` | `array` | No |  |  | List of testIDs or labels to check on both platforms. Optional if scanDir is provided. |
 | `scanDir` | `string` | No |  |  | Directory to scan for testID="..." props in .tsx/.jsx/.ts/.js files. Auto-discovers elements. Merges with elements[] if both provided. |
-| `matchBy` | `enum: testID | label | any` | No | `'any'` |  | Match strategy: testID (exact identifier match), label (substring in accessibility label), any (try both) |
+| `matchBy` | `enum: testID \| label \| any` | No | `'any'` |  | Match strategy: testID (exact identifier match), label (substring in accessibility label), any (try both) |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/device_accept_system_dialog.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/device_accept_system_dialog.mdx
@@ -9,9 +9,9 @@ Tap an OS-level accept button on the exact session device. iOS prefers the capab
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `label` | `unknown` | No |  |  |  |
-| `platform` | `unknown` | No |  |  | Authority-bound platform; conflicting values are refused |
-| `timeoutMs` | `unknown` | No |  | min: 1000, max: 120000, integer |  |
+| `label` | `string` | No |  |  | Specific button label to tap. Omit to try common defaults (Allow, OK, Open, Continue, Yes, Accept). |
+| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `timeoutMs` | `number` | No |  | min: 1000, max: 120000, integer | Whole fallback Maestro timeout (default 15000ms; explicit values up to 120000 accepted). Native iOS runner path is preferred. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/device_accept_system_dialog.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/device_accept_system_dialog.mdx
@@ -10,7 +10,7 @@ Tap an OS-level accept button on the exact session device. iOS prefers the capab
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `label` | `string` | No |  |  | Specific button label to tap. Omit to try common defaults (Allow, OK, Open, Continue, Yes, Accept). |
-| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `platform` | `enum: ios \| android` | No |  |  | Authority-bound platform; conflicting values are refused |
 | `timeoutMs` | `number` | No |  | min: 1000, max: 120000, integer | Whole fallback Maestro timeout (default 15000ms; explicit values up to 120000 accepted). Native iOS runner path is preferred. |
 
 ## Usage

--- a/apps/docs-site/src/content/docs/tools/cdp/device_deeplink.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/device_deeplink.mdx
@@ -10,7 +10,7 @@ Open a deep link on the exact authority-bound iOS simulator or Android device. O
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `url` | `string` | Yes |  |  | URL to open, e.g. "myapp://claims/new" or "https://example.com/page". |
-| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `platform` | `enum: ios \| android` | No |  |  | Authority-bound platform; conflicting values are refused |
 | `deviceId` | `string` | No |  | min: 1, max: 256 | Authority-bound exact iOS simulator UDID or Android adb serial; normally injected by the session |
 | `metroPort` | `number` | No |  | min: 1, max: 65535, integer | Authority-bound Metro port used only for an exact picker row match |
 | `packageName` | `string` | No |  |  | (Android only) Explicit package/activity, e.g. "com.example/.MainActivity". Usually not needed — intent resolution picks the right app. |

--- a/apps/docs-site/src/content/docs/tools/cdp/device_deeplink.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/device_deeplink.mdx
@@ -9,14 +9,14 @@ Open a deep link on the exact authority-bound iOS simulator or Android device. O
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `url` | `unknown` | Yes |  |  | URL to open, e.g. "myapp://claims/new" or "https://example.com/page". |
-| `platform` | `unknown` | No |  |  | Authority-bound platform; conflicting values are refused |
-| `deviceId` | `unknown` | No |  | min: 1, max: 256 |  |
-| `metroPort` | `unknown` | No |  | min: 1, max: 65535, integer | Authority-bound Metro port used only for an exact picker row match |
-| `packageName` | `unknown` | No |  |  |  |
+| `url` | `string` | Yes |  |  | URL to open, e.g. "myapp://claims/new" or "https://example.com/page". |
+| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `deviceId` | `string` | No |  | min: 1, max: 256 | Authority-bound exact iOS simulator UDID or Android adb serial; normally injected by the session |
+| `metroPort` | `number` | No |  | min: 1, max: 65535, integer | Authority-bound Metro port used only for an exact picker row match |
+| `packageName` | `string` | No |  |  | (Android only) Explicit package/activity, e.g. "com.example/.MainActivity". Usually not needed — intent resolution picks the right app. |
 
 ## Usage
 
 ```
-device_deeplink(url: <unknown>)
+device_deeplink(url: <string>)
 ```

--- a/apps/docs-site/src/content/docs/tools/cdp/device_dismiss_system_dialog.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/device_dismiss_system_dialog.mdx
@@ -9,9 +9,9 @@ Tap an OS-level dismiss button through the capability-bound runner on the exact 
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `label` | `unknown` | No |  |  |  |
-| `platform` | `unknown` | No |  |  | Authority-bound platform; conflicting values are refused |
-| `timeoutMs` | `unknown` | No |  | min: 1000, max: 120000, integer |  |
+| `label` | `string` | No |  |  | Specific button label to tap. Omit to try common defaults (Cancel, Don\\u2019t Allow, Deny, No, Not Now). |
+| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `timeoutMs` | `number` | No |  | min: 1000, max: 120000, integer | Whole fallback Maestro timeout (default 15000ms; explicit values up to 120000 accepted). |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/device_dismiss_system_dialog.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/device_dismiss_system_dialog.mdx
@@ -9,7 +9,7 @@ Tap an OS-level dismiss button through the capability-bound runner on the exact 
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `label` | `string` | No |  |  | Specific button label to tap. Omit to try common defaults (Cancel, Don\\u2019t Allow, Deny, No, Not Now). |
+| `label` | `string` | No |  |  | Specific button label to tap. Omit to try common defaults (Cancel, Don’t Allow, Deny, No, Not Now). |
 | `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
 | `timeoutMs` | `number` | No |  | min: 1000, max: 120000, integer | Whole fallback Maestro timeout (default 15000ms; explicit values up to 120000 accepted). |
 

--- a/apps/docs-site/src/content/docs/tools/cdp/device_dismiss_system_dialog.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/device_dismiss_system_dialog.mdx
@@ -10,7 +10,7 @@ Tap an OS-level dismiss button through the capability-bound runner on the exact 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `label` | `string` | No |  |  | Specific button label to tap. Omit to try common defaults (Cancel, Don’t Allow, Deny, No, Not Now). |
-| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `platform` | `enum: ios \| android` | No |  |  | Authority-bound platform; conflicting values are refused |
 | `timeoutMs` | `number` | No |  | min: 1000, max: 120000, integer | Whole fallback Maestro timeout (default 15000ms; explicit values up to 120000 accepted). |
 
 ## Usage

--- a/apps/docs-site/src/content/docs/tools/cdp/device_pick_date.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/device_pick_date.mdx
@@ -13,7 +13,7 @@ Select a visible date in a UIDatePicker (wheels mode) / Android DatePicker with 
 | `openerTestId` | `string` | No |  |  | Optional testID of the control that opens the date picker. |
 | `pickerTestId` | `string` | No |  |  | Deprecated openerTestId alias retained for compatibility; it does not scope row taps. |
 | `pickerScopeTestId` | `string` | No |  |  | Optional picker-container testID used as childOf scope for month/day/year rows. |
-| `platform` | `enum: ios | android` | No |  |  | Force platform. Auto-detected if omitted. |
+| `platform` | `enum: ios \| android` | No |  |  | Force platform. Auto-detected if omitted. |
 | `timeoutMs` | `number` | No |  | min: 1000, max: 120000, integer | Whole Maestro flow timeout (default 120000ms; never divided by component count). |
 
 ## Usage

--- a/apps/docs-site/src/content/docs/tools/cdp/device_pick_date.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/device_pick_date.mdx
@@ -9,15 +9,15 @@ Select a visible date in a UIDatePicker (wheels mode) / Android DatePicker with 
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `date` | `unknown` | Yes |  |  | Target date — YYYY-MM-DD or full ISO 8601. Time component is ignored. |
-| `openerTestId` | `unknown` | No |  |  | Optional testID of the control that opens the date picker. |
-| `pickerTestId` | `unknown` | No |  |  |  |
-| `pickerScopeTestId` | `unknown` | No |  |  | Optional picker-container testID used as childOf scope for month/day/year rows. |
-| `platform` | `unknown` | No |  |  | Force platform. Auto-detected if omitted. |
-| `timeoutMs` | `unknown` | No |  | min: 1000, max: 120000, integer | Whole Maestro flow timeout (default 120000ms; never divided by component count). |
+| `date` | `string` | Yes |  |  | Target date — YYYY-MM-DD or full ISO 8601. Time component is ignored. |
+| `openerTestId` | `string` | No |  |  | Optional testID of the control that opens the date picker. |
+| `pickerTestId` | `string` | No |  |  | Deprecated openerTestId alias retained for compatibility; it does not scope row taps. |
+| `pickerScopeTestId` | `string` | No |  |  | Optional picker-container testID used as childOf scope for month/day/year rows. |
+| `platform` | `enum: ios | android` | No |  |  | Force platform. Auto-detected if omitted. |
+| `timeoutMs` | `number` | No |  | min: 1000, max: 120000, integer | Whole Maestro flow timeout (default 120000ms; never divided by component count). |
 
 ## Usage
 
 ```
-device_pick_date(date: <unknown>)
+device_pick_date(date: <string>)
 ```

--- a/apps/docs-site/src/content/docs/tools/cdp/device_pick_value.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/device_pick_value.mdx
@@ -9,13 +9,13 @@ Select a value in a UIPickerView / Android picker wheel by tapping the target ro
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `value` | `unknown` | Yes |  |  | The visible row label to select (e.g. "Claim damages", "Male", "USD") |
-| `pickerTestId` | `unknown` | No |  |  |  |
-| `platform` | `unknown` | No |  |  | Force platform. Auto-detected if omitted. |
-| `timeoutMs` | `unknown` | No |  | min: 1000, max: 120000, integer | Whole Maestro flow timeout (default 120000ms). |
+| `value` | `string` | Yes |  |  | The visible row label to select (e.g. "Claim damages", "Male", "USD") |
+| `pickerTestId` | `string` | No |  |  | Optional testID of the picker itself — tapped first to ensure the picker is open. |
+| `platform` | `enum: ios | android` | No |  |  | Force platform. Auto-detected if omitted. |
+| `timeoutMs` | `number` | No |  | min: 1000, max: 120000, integer | Whole Maestro flow timeout (default 120000ms). |
 
 ## Usage
 
 ```
-device_pick_value(value: <unknown>)
+device_pick_value(value: <string>)
 ```

--- a/apps/docs-site/src/content/docs/tools/cdp/device_pick_value.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/device_pick_value.mdx
@@ -11,7 +11,7 @@ Select a value in a UIPickerView / Android picker wheel by tapping the target ro
 |------|------|----------|---------|-------------|-------------|
 | `value` | `string` | Yes |  |  | The visible row label to select (e.g. "Claim damages", "Male", "USD") |
 | `pickerTestId` | `string` | No |  |  | Optional testID of the picker itself — tapped first to ensure the picker is open. |
-| `platform` | `enum: ios | android` | No |  |  | Force platform. Auto-detected if omitted. |
+| `platform` | `enum: ios \| android` | No |  |  | Force platform. Auto-detected if omitted. |
 | `timeoutMs` | `number` | No |  | min: 1000, max: 120000, integer | Whole Maestro flow timeout (default 120000ms). |
 
 ## Usage

--- a/apps/docs-site/src/content/docs/tools/cdp/device_record.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/device_record.mdx
@@ -9,8 +9,8 @@ Record the exact authority-bound device for proof capture. Start validates that 
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `action` | `enum: start | stop | status` | Yes |  |  | start: begin recording. stop: finalize and save (all active recordings). status: list active recordings. |
-| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `action` | `enum: start \| stop \| status` | Yes |  |  | start: begin recording. stop: finalize and save (all active recordings). status: list active recordings. |
+| `platform` | `enum: ios \| android` | No |  |  | Authority-bound platform; conflicting values are refused |
 | `outputPath` | `string` | No |  |  | (start only) Absolute output path. Defaults to /tmp/rn-dev-agent-proof-&lt;platform&gt;-&lt;timestamp&gt;.mp4. |
 | `deviceId` | `string` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
 | `gif` | `boolean` | No |  |  | (stop only) When true, also convert each saved recording to GIF via ffmpeg. |

--- a/apps/docs-site/src/content/docs/tools/cdp/device_record.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/device_record.mdx
@@ -9,15 +9,15 @@ Record the exact authority-bound device for proof capture. Start validates that 
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `action` | `unknown` | Yes |  |  |  |
-| `platform` | `unknown` | No |  |  | Authority-bound platform; conflicting values are refused |
-| `outputPath` | `unknown` | No |  |  |  |
-| `deviceId` | `unknown` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
-| `gif` | `unknown` | No |  |  | (stop only) When true, also convert each saved recording to GIF via ffmpeg. |
-| `gifPath` | `unknown` | No |  |  |  |
+| `action` | `enum: start | stop | status` | Yes |  |  | start: begin recording. stop: finalize and save (all active recordings). status: list active recordings. |
+| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `outputPath` | `string` | No |  |  | (start only) Absolute output path. Defaults to /tmp/rn-dev-agent-proof-&lt;platform&gt;-&lt;timestamp&gt;.mp4. |
+| `deviceId` | `string` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
+| `gif` | `boolean` | No |  |  | (stop only) When true, also convert each saved recording to GIF via ffmpeg. |
+| `gifPath` | `string` | No |  |  | (stop only) Override GIF output path. Defaults to the recording path with .gif extension. |
 
 ## Usage
 
 ```
-device_record(action: <unknown>)
+device_record(action: <enum: start | stop | status>)
 ```

--- a/apps/docs-site/src/content/docs/tools/cdp/device_reset_state.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/device_reset_state.mdx
@@ -10,7 +10,7 @@ Reset permissions/storage and relaunch the authority-bound app on its exact clai
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `appId` | `string` | No |  |  | Authority-bound app identifier; normally injected by the session |
-| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `platform` | `enum: ios \| android` | No |  |  | Authority-bound platform; conflicting values are refused |
 | `deviceId` | `string` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
 | `permissions` | `array` | No |  |  | Permissions to revoke/reset before relaunch. String shorthand defaults to revoke. Each entry is processed via device_permission. |
 | `storageKeys` | `array` | No |  |  | MMKV keys to delete before terminate (so the app reads cleared values on next launch). Skipped if CDP is not connected. |

--- a/apps/docs-site/src/content/docs/tools/cdp/device_reset_state.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/device_reset_state.mdx
@@ -9,15 +9,15 @@ Reset permissions/storage and relaunch the authority-bound app on its exact clai
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `appId` | `unknown` | No |  |  | Authority-bound app identifier; normally injected by the session |
-| `platform` | `unknown` | No |  |  | Authority-bound platform; conflicting values are refused |
-| `deviceId` | `unknown` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
-| `permissions` | `unknown` | No |  |  |  |
-| `storageKeys` | `unknown` | No |  |  |  |
-| `mmkvInstanceId` | `unknown` | No |  |  | Forwarded to cdp_mmkv. Defaults to mmkv.default. |
+| `appId` | `string` | No |  |  | Authority-bound app identifier; normally injected by the session |
+| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `deviceId` | `string` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
+| `permissions` | `array` | No |  |  | Permissions to revoke/reset before relaunch. String shorthand defaults to revoke. Each entry is processed via device_permission. |
+| `storageKeys` | `array` | No |  |  | MMKV keys to delete before terminate (so the app reads cleared values on next launch). Skipped if CDP is not connected. |
+| `mmkvInstanceId` | `string` | No |  |  | Forwarded to cdp_mmkv. Defaults to mmkv.default. |
 | `relaunch` | `boolean` | No |  |  | Launch the app after terminate. Default true. |
-| `waitForReady` | `unknown` | No |  |  |  |
-| `waitForNavReady` | `unknown` | No |  |  |  |
+| `waitForReady` | `boolean` | No |  |  | After relaunch, wait for CDP reconnect + helpers injection. Default true. Set false to return immediately and let the caller poll. |
+| `waitForNavReady` | `boolean` | No |  |  | After helpers, also wait for globalThis.__NAV_REF__ to expose a non-empty navigation state. Default false. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/expect_redux.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/expect_redux.mdx
@@ -9,21 +9,21 @@ Assert against Redux/Zustand store state at a path. Returns ok when the assertio
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `path` | `unknown` | Yes |  |  | Dot-path into the store, e.g. "cart.items" or "auth.user.id". Required. |
-| `storeType` | `unknown` | No |  |  |  |
+| `path` | `string` | Yes |  |  | Dot-path into the store, e.g. "cart.items" or "auth.user.id". Required. |
+| `storeType` | `string` | No |  |  | Restrict to a specific store ("redux" | "zustand" | a Zustand store name). Default: auto-detect. |
 | `equals` | `unknown` | No |  |  | Deep-equal against this value. |
-| `exists` | `unknown` | No |  |  |  |
+| `exists` | `boolean` | No |  |  | When true, value must be defined and non-null. When false, value must be undefined or null. Implicit default if no other operator is supplied. |
 | `notExists` | `boolean` | No |  |  | Inverse of exists. |
-| `length` | `unknown` | No |  | integer | Asserts (Array | string).length === this number. |
+| `length` | `number` | No |  | integer | Asserts (Array | string).length === this number. |
 | `contains` | `unknown` | No |  |  | Asserts an array contains this element (deep-equal). |
 | `gt` | `number` | No |  |  | Asserts actual &gt; this number. |
 | `lt` | `number` | No |  |  | Asserts actual &lt; this number. |
 | `gte` | `number` | No |  |  | Asserts actual &gt;= this number. |
 | `lte` | `number` | No |  |  | Asserts actual &lt;= this number. |
-| `timeoutMs` | `unknown` | No |  | min: 0, integer | Polling timeout in ms (default 0 = no retry). Useful for async state updates. |
+| `timeoutMs` | `number` | No |  | min: 0, integer | Polling timeout in ms (default 0 = no retry). Useful for async state updates. |
 
 ## Usage
 
 ```
-expect_redux(path: <unknown>)
+expect_redux(path: <string>)
 ```

--- a/apps/docs-site/src/content/docs/tools/cdp/expect_redux.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/expect_redux.mdx
@@ -10,11 +10,11 @@ Assert against Redux/Zustand store state at a path. Returns ok when the assertio
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `path` | `string` | Yes |  |  | Dot-path into the store, e.g. "cart.items" or "auth.user.id". Required. |
-| `storeType` | `string` | No |  |  | Restrict to a specific store ("redux" | "zustand" | a Zustand store name). Default: auto-detect. |
+| `storeType` | `string` | No |  |  | Restrict to a specific store ("redux" &#124; "zustand" &#124; a Zustand store name). Default: auto-detect. |
 | `equals` | `unknown` | No |  |  | Deep-equal against this value. |
 | `exists` | `boolean` | No |  |  | When true, value must be defined and non-null. When false, value must be undefined or null. Implicit default if no other operator is supplied. |
 | `notExists` | `boolean` | No |  |  | Inverse of exists. |
-| `length` | `number` | No |  | integer | Asserts (Array | string).length === this number. |
+| `length` | `number` | No |  | integer | Asserts (Array &#124; string).length === this number. |
 | `contains` | `unknown` | No |  |  | Asserts an array contains this element (deep-equal). |
 | `gt` | `number` | No |  |  | Asserts actual &gt; this number. |
 | `lt` | `number` | No |  |  | Asserts actual &lt; this number. |

--- a/apps/docs-site/src/content/docs/tools/cdp/expect_route.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/expect_route.mdx
@@ -11,8 +11,8 @@ Assert against the navigation state — current route name, current route params
 |------|------|----------|---------|-------------|-------------|
 | `name` | `string` | No |  |  | Asserts the current top-of-stack route name === this. |
 | `paramsEquals` | `unknown` | No |  |  | Asserts deep-equal against the current route params object. |
-| `inStack` | `unknown` | No |  |  |  |
-| `timeoutMs` | `unknown` | No |  | min: 0, integer |  |
+| `inStack` | `string` | No |  |  | Asserts a route with this name exists somewhere in the stack (not necessarily current). |
+| `timeoutMs` | `number` | No |  | min: 0, integer | Polling timeout in ms (default 0). Use 1000-2000 to wait through navigation animations. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/expect_text.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/expect_text.mdx
@@ -10,8 +10,8 @@ Assert that visible text is (or is not) currently rendered in the device accessi
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `text` | `string` | Yes |  |  | The visible text to look for. |
-| `exact` | `unknown` | No |  |  | Default false (substring match). Pass true to require exact label equality. |
-| `exists` | `unknown` | No |  |  | Default true (assert visible). Pass false to assert NOT visible. |
+| `exact` | `boolean` | No |  |  | Default false (substring match). Pass true to require exact label equality. |
+| `exists` | `boolean` | No |  |  | Default true (assert visible). Pass false to assert NOT visible. |
 | `timeoutMs` | `number` | No |  | min: 0, integer | Polling timeout in ms (default 0). |
 
 ## Usage

--- a/apps/docs-site/src/content/docs/tools/cdp/expect_visible_by_testid.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/expect_visible_by_testid.mdx
@@ -10,8 +10,8 @@ Assert that an element with a given testID is (or is not) currently rendered in 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `testID` | `string` | Yes |  |  | The testID to look for in the accessibility tree. |
-| `exists` | `unknown` | No |  |  | Default true (assert visible). Pass false to assert NOT visible. |
-| `timeoutMs` | `unknown` | No |  | min: 0, integer | Polling timeout in ms (default 0). Use 1000-3000 for late-mounted elements. |
+| `exists` | `boolean` | No |  |  | Default true (assert visible). Pass false to assert NOT visible. |
+| `timeoutMs` | `number` | No |  | min: 0, integer | Polling timeout in ms (default 0). Use 1000-3000 for late-mounted elements. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/cdp/rn_session.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/rn_session.mdx
@@ -10,9 +10,9 @@ Inspect and transition the fenced rn-dev-agent authority session. Status reconci
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `action` | `enum: status | bind_source | bind_device | bind_metro | pin_dev_client | prepare_handoff | cancel_handoff | accept_handoff | adopt_stale | release_stale_device | recover_arbiter | preview_integration | apply_integration | restore_integration | stop_metro | release` | Yes |  |  |  |
-| `projectRoot` | `unknown` | No |  |  | bind_source: same-repo worktree to rebind; other actions refuse on mismatch |
-| `platform` | `unknown` | No |  |  | Required with deviceId for foreign transfer; omit both to resume own journal |
-| `deviceId` | `unknown` | No |  |  | Required with platform for foreign transfer; omit both to resume own journal |
+| `projectRoot` | `string` | No |  |  | bind_source: same-repo worktree to rebind; other actions refuse on mismatch |
+| `platform` | `enum: ios | android` | No |  |  | Required with deviceId for foreign transfer; omit both to resume own journal |
+| `deviceId` | `string` | No |  |  | Required with platform for foreign transfer; omit both to resume own journal |
 | `appId` | `string` | No |  |  |  |
 | `devClientUrl` | `string` | No |  |  |  |
 | `buildReceipt` | `Record<string, unknown>` | No |  |  |  |
@@ -26,7 +26,7 @@ Inspect and transition the fenced rn-dev-agent authority session. Status reconci
 | `handoffId` | `string` | No |  |  |  |
 | `token` | `string` | No |  |  |  |
 | `adoptionHandle` | `string` | No |  |  |  |
-| `releaseHandle` | `unknown` | No |  |  | Legacy release-offer capability; confirmed: true supersedes it |
+| `releaseHandle` | `string` | No |  |  | Legacy release-offer capability; confirmed: true supersedes it |
 | `confirmed` | `boolean` | No |  |  | Authorizes inline proven-dead device cleanup |
 | `force` | `boolean` | No |  |  |  |
 

--- a/apps/docs-site/src/content/docs/tools/cdp/rn_session.mdx
+++ b/apps/docs-site/src/content/docs/tools/cdp/rn_session.mdx
@@ -9,9 +9,9 @@ Inspect and transition the fenced rn-dev-agent authority session. Status reconci
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `action` | `enum: status | bind_source | bind_device | bind_metro | pin_dev_client | prepare_handoff | cancel_handoff | accept_handoff | adopt_stale | release_stale_device | recover_arbiter | preview_integration | apply_integration | restore_integration | stop_metro | release` | Yes |  |  |  |
+| `action` | `enum: status \| bind_source \| bind_device \| bind_metro \| pin_dev_client \| prepare_handoff \| cancel_handoff \| accept_handoff \| adopt_stale \| release_stale_device \| recover_arbiter \| preview_integration \| apply_integration \| restore_integration \| stop_metro \| release` | Yes |  |  |  |
 | `projectRoot` | `string` | No |  |  | bind_source: same-repo worktree to rebind; other actions refuse on mismatch |
-| `platform` | `enum: ios | android` | No |  |  | Required with deviceId for foreign transfer; omit both to resume own journal |
+| `platform` | `enum: ios \| android` | No |  |  | Required with deviceId for foreign transfer; omit both to resume own journal |
 | `deviceId` | `string` | No |  |  | Required with platform for foreign transfer; omit both to resume own journal |
 | `appId` | `string` | No |  |  |  |
 | `devClientUrl` | `string` | No |  |  |  |
@@ -20,7 +20,7 @@ Inspect and transition the fenced rn-dev-agent authority session. Status reconci
 | `metroPid` | `number` | No |  | integer |  |
 | `metroInstanceId` | `string` | No |  |  |  |
 | `buildGeneration` | `number` | No |  | integer |  |
-| `mode` | `enum: managed | external` | No |  |  |  |
+| `mode` | `enum: managed \| external` | No |  |  |  |
 | `targetHandle` | `string` | No |  |  |  |
 | `ttlMs` | `number` | No |  | min: 5_000, max: 300_000, integer |  |
 | `handoffId` | `string` | No |  |  |  |

--- a/apps/docs-site/src/content/docs/tools/device/device_batch.mdx
+++ b/apps/docs-site/src/content/docs/tools/device/device_batch.mdx
@@ -13,9 +13,9 @@ Execute a sequence of exact-device UI interactions in ONE tool call with the sam
 |------|------|----------|---------|-------------|-------------|
 | `steps` | `object[]` | No |  |  | Ordered list of UI interaction steps |
 | `delayMs` | `number` | No |  |  | Delay between steps in ms. Default: 0 while settle is on (settle waits for actual UI stability between steps), 300 when RN_SETTLE=0. Pass an explicit value to override either way. |
-| `screenshotOn` | `enum: none | failure | end | each` | No | `'failure'` |  | When to capture screenshots |
+| `screenshotOn` | `enum: none \| failure \| end \| each` | No | `'failure'` |  | When to capture screenshots |
 | `continueOnError` | `boolean` | No | `false` |  | When true, ordinary failed steps are recorded and the batch continues. A failed fill with observed or possible mutation always stops later steps. |
-| `finalSnapshot` | `enum: salient | full | none` | No | `'salient'` |  | Shape of the batch final_snapshot. salient (default): compact list of only actionable nodes (Button/TextField/Switch/etc) — far fewer tokens. full: complete node list (legacy). none: skip the implicit trailing snapshot entirely (~1,450 ms saved) for action-only batches you verify via expect_*/cdp_store_state. |
+| `finalSnapshot` | `enum: salient \| full \| none` | No | `'salient'` |  | Shape of the batch final_snapshot. salient (default): compact list of only actionable nodes (Button/TextField/Switch/etc) — far fewer tokens. full: complete node list (legacy). none: skip the implicit trailing snapshot entirely (~1,450 ms saved) for action-only batches you verify via expect_*/cdp_store_state. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/device/device_batch.mdx
+++ b/apps/docs-site/src/content/docs/tools/device/device_batch.mdx
@@ -11,11 +11,11 @@ Execute a sequence of exact-device UI interactions in ONE tool call with the sam
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `steps` | `unknown` | No |  |  | Ordered list of UI interaction steps |
-| `delayMs` | `unknown` | No |  |  |  |
-| `screenshotOn` | `unknown` | No | `'failure'` |  | When to capture screenshots |
-| `continueOnError` | `unknown` | No | `false` |  |  |
-| `finalSnapshot` | `unknown` | No | `'salient'` |  |  |
+| `steps` | `object[]` | No |  |  | Ordered list of UI interaction steps |
+| `delayMs` | `number` | No |  |  | Delay between steps in ms. Default: 0 while settle is on (settle waits for actual UI stability between steps), 300 when RN_SETTLE=0. Pass an explicit value to override either way. |
+| `screenshotOn` | `enum: none | failure | end | each` | No | `'failure'` |  | When to capture screenshots |
+| `continueOnError` | `boolean` | No | `false` |  | When true, ordinary failed steps are recorded and the batch continues. A failed fill with observed or possible mutation always stops later steps. |
+| `finalSnapshot` | `enum: salient | full | none` | No | `'salient'` |  | Shape of the batch final_snapshot. salient (default): compact list of only actionable nodes (Button/TextField/Switch/etc) — far fewer tokens. full: complete node list (legacy). none: skip the implicit trailing snapshot entirely (~1,450 ms saved) for action-only batches you verify via expect_*/cdp_store_state. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/device/device_fill.mdx
+++ b/apps/docs-site/src/content/docs/tools/device/device_fill.mdx
@@ -13,9 +13,9 @@ Type text into an input field by its @ref or testID from device_snapshot, bindin
 |------|------|----------|---------|-------------|-------------|
 | `ref` | `string` | Yes |  |  | Input ref from device_snapshot (for example "@e5"), or a testID |
 | `text` | `string` | Yes |  |  | Text to type into the field (empty string = verified clear) |
-| `waitForKeyboardMs` | `unknown` | No |  | min: 0, max: 5000, integer |  |
-| `testID` | `unknown` | No |  |  |  |
-| `settleTimeoutMs` | `unknown` | No |  | min: 500, max: 30000, integer |  |
+| `waitForKeyboardMs` | `number` | No |  | min: 0, max: 5000, integer | Bounded wait for the exact input to gain focus after the in-operation focus tap (default 1500). Bump to 3000-5000ms for slow keyboard animations on Pressable-wrapped TextInputs. |
+| `testID` | `string` | No |  |  | Explicit exact target identity. Otherwise device_fill uses the fresh snapshot ref's nonblank testID. |
+| `settleTimeoutMs` | `number` | No |  | min: 500, max: 30000, integer | Deprecated compatibility option. Exact owner-local read-back supplies the bounded stability check. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/device/device_find.mdx
+++ b/apps/docs-site/src/content/docs/tools/device/device_find.mdx
@@ -12,10 +12,10 @@ Find a UI element by visible text and optionally interact with it. Android match
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `text` | `string` | Yes |  |  | Visible text, accessibility label, or identifier to find |
-| `action` | `unknown` | No |  |  | Action to perform: "click" to tap, omit for search-only |
-| `exact` | `unknown` | No |  |  | Require exact label match (case-sensitive). Skips fuzzy matching entirely. |
-| `index` | `unknown` | No |  | min: 0, integer |  |
-| `includeSystemUi` | `unknown` | No |  |  | Include Android system UI in matching (default false; may leave the app). |
+| `action` | `string` | No |  |  | Action to perform: "click" to tap, omit for search-only |
+| `exact` | `boolean` | No |  |  | Require exact label match (case-sensitive). Skips fuzzy matching entirely. |
+| `index` | `number` | No |  | min: 0, integer | Pick the Nth candidate (0-based) when multiple elements match. Short-circuits AMBIGUOUS_MATCH. |
+| `includeSystemUi` | `boolean` | No |  |  | Include Android system UI in matching (default false; may leave the app). |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/device/device_longpress.mdx
+++ b/apps/docs-site/src/content/docs/tools/device/device_longpress.mdx
@@ -14,8 +14,8 @@ Long press on an element or coordinates. Use for context menus, drag initiation,
 | `ref` | `string` | No |  |  | Element ref from device_snapshot (uses press --hold-ms) |
 | `x` | `number` | No |  |  | X coordinate (use with y for coordinate-based long press) |
 | `y` | `number` | No |  |  | Y coordinate |
-| `durationMs` | `unknown` | No |  | min: 100, max: 10000, integer | Hold duration in ms (default 1000) |
-| `retryIfNoChange` | `unknown` | No |  |  |  |
+| `durationMs` | `number` | No |  | min: 100, max: 10000, integer | Hold duration in ms (default 1000) |
+| `retryIfNoChange` | `boolean` | No |  |  | Deprecated compatibility option. Interactions are never automatically replayed after a possible dispatch; uncertainty is reported from the first attempt. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/device/device_permission.mdx
+++ b/apps/docs-site/src/content/docs/tools/device/device_permission.mdx
@@ -11,10 +11,10 @@ Grant, revoke, reset, or query permissions for the authority-bound app on the ex
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `action` | `enum: grant | revoke | reset | query` | Yes |  |  | grant: allow. revoke: deny. reset: restore default. query: check current state (Android: granted/denied/not_declared, iOS: unknown). |
+| `action` | `enum: grant \| revoke \| reset \| query` | Yes |  |  | grant: allow. revoke: deny. reset: restore default. query: check current state (Android: granted/denied/not_declared, iOS: unknown). |
 | `permission` | `string` | Yes |  |  | Permission key: notifications, camera, microphone, location, location-always, photos, contacts, calendar, reminders, storage, all |
 | `appId` | `string` | No |  |  | Authority-bound app identifier; normally injected by the session |
-| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `platform` | `enum: ios \| android` | No |  |  | Authority-bound platform; conflicting values are refused |
 | `deviceId` | `string` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
 
 ## Usage

--- a/apps/docs-site/src/content/docs/tools/device/device_permission.mdx
+++ b/apps/docs-site/src/content/docs/tools/device/device_permission.mdx
@@ -11,14 +11,14 @@ Grant, revoke, reset, or query permissions for the authority-bound app on the ex
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `action` | `unknown` | Yes |  |  |  |
-| `permission` | `unknown` | Yes |  |  |  |
-| `appId` | `unknown` | No |  |  | Authority-bound app identifier; normally injected by the session |
-| `platform` | `unknown` | No |  |  | Authority-bound platform; conflicting values are refused |
-| `deviceId` | `unknown` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
+| `action` | `enum: grant | revoke | reset | query` | Yes |  |  | grant: allow. revoke: deny. reset: restore default. query: check current state (Android: granted/denied/not_declared, iOS: unknown). |
+| `permission` | `string` | Yes |  |  | Permission key: notifications, camera, microphone, location, location-always, photos, contacts, calendar, reminders, storage, all |
+| `appId` | `string` | No |  |  | Authority-bound app identifier; normally injected by the session |
+| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `deviceId` | `string` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
 
 ## Usage
 
 ```
-device_permission(action: <unknown>, permission: <unknown>)
+device_permission(action: <enum: grant | revoke | reset | query>, permission: <string>)
 ```

--- a/apps/docs-site/src/content/docs/tools/device/device_pinch.mdx
+++ b/apps/docs-site/src/content/docs/tools/device/device_pinch.mdx
@@ -11,12 +11,12 @@ Pinch/zoom gesture on the screen. scale &lt; 1 zooms out, scale &gt; 1 zooms in.
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `scale` | `unknown` | Yes |  | min: 0.1, max: 10 | Pinch scale factor (0.5 = zoom out 50%, 2.0 = zoom in 2x) |
+| `scale` | `number` | Yes |  | min: 0.1, max: 10 | Pinch scale factor (0.5 = zoom out 50%, 2.0 = zoom in 2x) |
 | `x` | `number` | No |  |  | Center X coordinate (default: screen center) |
 | `y` | `number` | No |  |  | Center Y coordinate (default: screen center) |
 
 ## Usage
 
 ```
-device_pinch(scale: <unknown>)
+device_pinch(scale: <number>)
 ```

--- a/apps/docs-site/src/content/docs/tools/device/device_press.mdx
+++ b/apps/docs-site/src/content/docs/tools/device/device_press.mdx
@@ -11,15 +11,15 @@ Tap a UI element by its @ref from device_snapshot, or at explicit raw x/y coordi
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `ref` | `unknown` | No |  |  | Element ref from device_snapshot (e.g. "e3" or "@e3"). Omit when using x/y. |
+| `ref` | `string` | No |  |  | Element ref from device_snapshot (e.g. "e3" or "@e3"). Omit when using x/y. |
 | `x` | `number` | No |  |  | Raw tap X coordinate; requires y and no ref |
 | `y` | `number` | No |  |  | Raw tap Y coordinate; requires x and no ref |
 | `doubleTap` | `boolean` | No |  |  | Use double-tap gesture |
-| `count` | `unknown` | No |  | min: 1, max: 50, integer | Repeat tap N times (for rapid-fire interactions) |
-| `holdMs` | `unknown` | No |  | min: 0, max: 10000, integer | Hold duration in ms (for long-press via ref) |
-| `waitForFocusMs` | `unknown` | No |  | min: 0, max: 5000, integer |  |
-| `settleTimeoutMs` | `unknown` | No |  | min: 500, max: 30000, integer |  |
-| `retryIfNoChange` | `unknown` | No |  |  |  |
+| `count` | `number` | No |  | min: 1, max: 50, integer | Repeat tap N times (for rapid-fire interactions) |
+| `holdMs` | `number` | No |  | min: 0, max: 10000, integer | Hold duration in ms (for long-press via ref) |
+| `waitForFocusMs` | `number` | No |  | min: 0, max: 5000, integer | Sleep this many ms after tap to let keyboard focus settle — useful in sequential press+fill flows where focus would otherwise not propagate. |
+| `settleTimeoutMs` | `number` | No |  | min: 500, max: 30000, integer | Override the post-action settle budget in ms (default 6000). Settle waits for the UI to stabilize after the action; see meta.settle in the result. Budget knob only — RN_SETTLE=0 disables settle. |
+| `retryIfNoChange` | `boolean` | No |  |  | Deprecated compatibility option. Interactions are never automatically replayed after a possible dispatch; uncertainty is reported from the first attempt. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/device/device_screenshot.mdx
+++ b/apps/docs-site/src/content/docs/tools/device/device_screenshot.mdx
@@ -12,8 +12,8 @@ Capture the exact authority-bound device screen with no cross-device retry. Raw 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `path` | `string` | No |  |  | Output file path (default: auto-generated in /tmp). Use .jpg extension for JPEG. |
-| `format` | `enum: jpeg | png` | No |  |  | Image format (default: auto-detect from path extension, or jpeg) |
-| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `format` | `enum: jpeg \| png` | No |  |  | Image format (default: auto-detect from path extension, or jpeg) |
+| `platform` | `enum: ios \| android` | No |  |  | Authority-bound platform; conflicting values are refused |
 | `deviceId` | `string` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
 | `maxWidth` | `number` | No |  | min: 0, integer | Downscale image so width does not exceed this many pixels. 0 disables resize. Default 800 (saves ~46% on iPhone 15/17 Pro screenshots without losing label readability). |
 | `quality` | `number` | No |  | min: 1, max: 100, integer | JPEG compression quality (1-100). Only applied to .jpg/.jpeg files. Default 85. |

--- a/apps/docs-site/src/content/docs/tools/device/device_screenshot.mdx
+++ b/apps/docs-site/src/content/docs/tools/device/device_screenshot.mdx
@@ -11,12 +11,12 @@ Capture the exact authority-bound device screen with no cross-device retry. Raw 
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `path` | `unknown` | No |  |  | Output file path (default: auto-generated in /tmp). Use .jpg extension for JPEG. |
-| `format` | `unknown` | No |  |  | Image format (default: auto-detect from path extension, or jpeg) |
-| `platform` | `unknown` | No |  |  | Authority-bound platform; conflicting values are refused |
-| `deviceId` | `unknown` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
-| `maxWidth` | `unknown` | No |  | min: 0, integer |  |
-| `quality` | `unknown` | No |  | min: 1, max: 100, integer | JPEG compression quality (1-100). Only applied to .jpg/.jpeg files. Default 85. |
+| `path` | `string` | No |  |  | Output file path (default: auto-generated in /tmp). Use .jpg extension for JPEG. |
+| `format` | `enum: jpeg | png` | No |  |  | Image format (default: auto-detect from path extension, or jpeg) |
+| `platform` | `enum: ios | android` | No |  |  | Authority-bound platform; conflicting values are refused |
+| `deviceId` | `string` | No |  |  | Authority-bound exact device identifier; normally injected by the session |
+| `maxWidth` | `number` | No |  | min: 0, integer | Downscale image so width does not exceed this many pixels. 0 disables resize. Default 800 (saves ~46% on iPhone 15/17 Pro screenshots without losing label readability). |
+| `quality` | `number` | No |  | min: 1, max: 100, integer | JPEG compression quality (1-100). Only applied to .jpg/.jpeg files. Default 85. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/device/device_scroll.mdx
+++ b/apps/docs-site/src/content/docs/tools/device/device_scroll.mdx
@@ -11,7 +11,7 @@ Scroll the screen in a direction. Smoother than device_swipe for list scrolling.
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `direction` | `enum: up | down | left | right` | Yes |  |  | Scroll direction |
+| `direction` | `enum: up \| down \| left \| right` | Yes |  |  | Scroll direction |
 | `amount` | `number` | No |  | min: 0, max: 1 | Scroll amount 0-1 (default ~0.5). 1 = full screen height/width. |
 
 ## Usage

--- a/apps/docs-site/src/content/docs/tools/device/device_scroll.mdx
+++ b/apps/docs-site/src/content/docs/tools/device/device_scroll.mdx
@@ -12,7 +12,7 @@ Scroll the screen in a direction. Smoother than device_swipe for list scrolling.
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `direction` | `enum: up | down | left | right` | Yes |  |  | Scroll direction |
-| `amount` | `unknown` | No |  | min: 0, max: 1 | Scroll amount 0-1 (default ~0.5). 1 = full screen height/width. |
+| `amount` | `number` | No |  | min: 0, max: 1 | Scroll amount 0-1 (default ~0.5). 1 = full screen height/width. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/device/device_snapshot.mdx
+++ b/apps/docs-site/src/content/docs/tools/device/device_snapshot.mdx
@@ -11,9 +11,9 @@ Manage exact device sessions and capture UI snapshots even when a Dev Client rem
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `action` | `enum: open | close | snapshot` | No | `'snapshot'` |  | open: start session for an app. snapshot: capture UI tree with element refs. close: end session. |
+| `action` | `enum: open \| close \| snapshot` | No | `'snapshot'` |  | open: start session for an app. snapshot: capture UI tree with element refs. close: end session. |
 | `appId` | `string` | No |  |  | App bundle ID — required for action=open (e.g. "com.example.app") |
-| `platform` | `enum: ios | android` | No |  |  | Target platform — used with action=open to select device |
+| `platform` | `enum: ios \| android` | No |  |  | Target platform — used with action=open to select device |
 | `deviceId` | `string` | No |  |  | Exact iOS simulator UDID or Android adb serial to use for action=open |
 | `sessionName` | `string` | No |  |  | Session name override (default: auto-generated) |
 | `attachOnly` | `boolean` | No |  |  | action=open only: skip launching the app. Requires the app to be already running. Use when connecting to an already-active dev session to avoid bundle-load races. |

--- a/apps/docs-site/src/content/docs/tools/device/device_snapshot.mdx
+++ b/apps/docs-site/src/content/docs/tools/device/device_snapshot.mdx
@@ -11,12 +11,12 @@ Manage exact device sessions and capture UI snapshots even when a Dev Client rem
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `action` | `unknown` | No | `'snapshot'` |  |  |
-| `appId` | `unknown` | No |  |  | App bundle ID — required for action=open (e.g. "com.example.app") |
-| `platform` | `unknown` | No |  |  | Target platform — used with action=open to select device |
-| `deviceId` | `unknown` | No |  |  | Exact iOS simulator UDID or Android adb serial to use for action=open |
+| `action` | `enum: open | close | snapshot` | No | `'snapshot'` |  | open: start session for an app. snapshot: capture UI tree with element refs. close: end session. |
+| `appId` | `string` | No |  |  | App bundle ID — required for action=open (e.g. "com.example.app") |
+| `platform` | `enum: ios | android` | No |  |  | Target platform — used with action=open to select device |
+| `deviceId` | `string` | No |  |  | Exact iOS simulator UDID or Android adb serial to use for action=open |
 | `sessionName` | `string` | No |  |  | Session name override (default: auto-generated) |
-| `attachOnly` | `unknown` | No |  |  |  |
+| `attachOnly` | `boolean` | No |  |  | action=open only: skip launching the app. Requires the app to be already running. Use when connecting to an already-active dev session to avoid bundle-load races. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/device/device_swipe.mdx
+++ b/apps/docs-site/src/content/docs/tools/device/device_swipe.mdx
@@ -11,14 +11,14 @@ Swipe on the device screen. Use direction for simple scrolling, or x1/y1/x2/y2 f
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `direction` | `enum: up | down | left | right` | No |  |  | Simple directional swipe (delegates to scroll) |
+| `direction` | `enum: up \| down \| left \| right` | No |  |  | Simple directional swipe (delegates to scroll) |
 | `x1` | `number` | No |  |  | Start X coordinate (use with y1, x2, y2 for precise swipes) |
 | `y1` | `number` | No |  |  | Start Y coordinate |
 | `x2` | `number` | No |  |  | End X coordinate |
 | `y2` | `number` | No |  |  | End Y coordinate |
 | `durationMs` | `number` | No |  | min: 50, max: 10000, integer | Swipe duration in ms (slower = more precise, default ~300). Note: the non-exact path may normalize/clamp very short durations — use exact: true for an unclamped duration. |
 | `count` | `number` | No |  | min: 1, max: 50, integer | Repeat swipe N times (incompatible with exact: true) |
-| `pattern` | `enum: one-way | ping-pong` | No |  |  | Repeat pattern: one-way (reset to start) or ping-pong (reverse direction). Incompatible with exact: true. |
+| `pattern` | `enum: one-way \| ping-pong` | No |  |  | Repeat pattern: one-way (reset to start) or ping-pong (reverse direction). Incompatible with exact: true. |
 | `exact` | `boolean` | No |  |  | B123: REQUIRE fast-runner (no daemon fallback). Preserves user-supplied durationMs verbatim — needed for slow precise swipes on UIDatePicker wheels and similar momentum-sensitive UIs. Fails with EXACT_REQUIRES_FAST_RUNNER if fast-runner unavailable instead of silently degrading. |
 
 ## Usage

--- a/apps/docs-site/src/content/docs/tools/device/device_swipe.mdx
+++ b/apps/docs-site/src/content/docs/tools/device/device_swipe.mdx
@@ -11,15 +11,15 @@ Swipe on the device screen. Use direction for simple scrolling, or x1/y1/x2/y2 f
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `direction` | `unknown` | No |  |  | Simple directional swipe (delegates to scroll) |
-| `x1` | `unknown` | No |  |  | Start X coordinate (use with y1, x2, y2 for precise swipes) |
+| `direction` | `enum: up | down | left | right` | No |  |  | Simple directional swipe (delegates to scroll) |
+| `x1` | `number` | No |  |  | Start X coordinate (use with y1, x2, y2 for precise swipes) |
 | `y1` | `number` | No |  |  | Start Y coordinate |
 | `x2` | `number` | No |  |  | End X coordinate |
 | `y2` | `number` | No |  |  | End Y coordinate |
-| `durationMs` | `unknown` | No |  | min: 50, max: 10000, integer |  |
-| `count` | `unknown` | No |  | min: 1, max: 50, integer | Repeat swipe N times (incompatible with exact: true) |
-| `pattern` | `unknown` | No |  |  |  |
-| `exact` | `unknown` | No |  |  |  |
+| `durationMs` | `number` | No |  | min: 50, max: 10000, integer | Swipe duration in ms (slower = more precise, default ~300). Note: the non-exact path may normalize/clamp very short durations — use exact: true for an unclamped duration. |
+| `count` | `number` | No |  | min: 1, max: 50, integer | Repeat swipe N times (incompatible with exact: true) |
+| `pattern` | `enum: one-way | ping-pong` | No |  |  | Repeat pattern: one-way (reset to start) or ping-pong (reverse direction). Incompatible with exact: true. |
+| `exact` | `boolean` | No |  |  | B123: REQUIRE fast-runner (no daemon fallback). Preserves user-supplied durationMs verbatim — needed for slow precise swipes on UIDatePicker wheels and similar momentum-sensitive UIs. Fails with EXACT_REQUIRES_FAST_RUNNER if fast-runner unavailable instead of silently degrading. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/testing/cdp_auto_login.mdx
+++ b/apps/docs-site/src/content/docs/tools/testing/cdp_auto_login.mdx
@@ -11,8 +11,8 @@ Explicit legacy navigation helper that detects an auth screen and runs one proje
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `appId` | `unknown` | No |  |  | App bundle ID override (auto-detected from app.json if omitted) |
-| `platform` | `unknown` | No |  |  | Platform override (auto-detected from session if omitted) |
+| `appId` | `string` | No |  |  | App bundle ID override (auto-detected from app.json if omitted) |
+| `platform` | `enum: ios | android` | No |  |  | Platform override (auto-detected from session if omitted) |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/testing/cdp_auto_login.mdx
+++ b/apps/docs-site/src/content/docs/tools/testing/cdp_auto_login.mdx
@@ -12,7 +12,7 @@ Explicit legacy navigation helper that detects an auth screen and runs one proje
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `appId` | `string` | No |  |  | App bundle ID override (auto-detected from app.json if omitted) |
-| `platform` | `enum: ios | android` | No |  |  | Platform override (auto-detected from session if omitted) |
+| `platform` | `enum: ios \| android` | No |  |  | Platform override (auto-detected from session if omitted) |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/testing/maestro_generate.mdx
+++ b/apps/docs-site/src/content/docs/tools/testing/maestro_generate.mdx
@@ -12,9 +12,9 @@ Generate a persistent Maestro YAML flow file from structured steps. Writes to .r
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `name` | `string` | Yes |  |  | Flow name (e.g. "add-to-cart", "profile-edit"). Becomes filename. |
-| `steps` | `unknown` | No |  |  | Ordered list of Maestro steps |
+| `steps` | `object[]` | No |  |  | Ordered list of Maestro steps |
 | `appId` | `string` | No |  |  | App bundle ID to include in YAML header |
-| `outputDir` | `unknown` | No |  |  |  |
+| `outputDir` | `string` | No |  |  | Output directory (default: &lt;project&gt;/.rn-agent/actions/). Pass an explicit path for non-default targets. |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/testing/maestro_run.mdx
+++ b/apps/docs-site/src/content/docs/tools/testing/maestro_run.mdx
@@ -13,7 +13,7 @@ Execute a Maestro flow through the pin-cache runner. The session requires maestr
 |------|------|----------|---------|-------------|-------------|
 | `flowPath` | `string` | No |  |  | Path to a .yaml flow file to execute |
 | `inlineYaml` | `string` | No |  |  | Inline YAML flow content (written to /tmp and executed) |
-| `platform` | `enum: ios | android` | No |  |  | Target platform (auto-detected from session) |
+| `platform` | `enum: ios \| android` | No |  |  | Target platform (auto-detected from session) |
 | `appId` | `string` | No |  |  | App bundle ID (auto-detected from app.json) |
 | `appFile` | `string` | No |  |  | iOS only — path to a built .app/.ipa for maestro-runner to reinstall on clearState. Auto-resolved from the flow appId when omitted (GH#201). |
 | `deviceId` | `string` | No |  | min: 1, max: 256 | Exact UDID or serial; defaults from session or Android ANDROID_SERIAL. |

--- a/apps/docs-site/src/content/docs/tools/testing/maestro_run.mdx
+++ b/apps/docs-site/src/content/docs/tools/testing/maestro_run.mdx
@@ -12,13 +12,13 @@ Execute a Maestro flow through the pin-cache runner. The session requires maestr
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
 | `flowPath` | `string` | No |  |  | Path to a .yaml flow file to execute |
-| `inlineYaml` | `unknown` | No |  |  | Inline YAML flow content (written to /tmp and executed) |
-| `platform` | `unknown` | No |  |  | Target platform (auto-detected from session) |
+| `inlineYaml` | `string` | No |  |  | Inline YAML flow content (written to /tmp and executed) |
+| `platform` | `enum: ios | android` | No |  |  | Target platform (auto-detected from session) |
 | `appId` | `string` | No |  |  | App bundle ID (auto-detected from app.json) |
-| `appFile` | `unknown` | No |  |  |  |
-| `deviceId` | `unknown` | No |  | min: 1, max: 256 | Exact UDID or serial; defaults from session or Android ANDROID_SERIAL. |
-| `timeoutMs` | `unknown` | No | `120000` | min: 5000, max: 300000, integer | Execution timeout in ms |
-| `params` | `unknown` | No |  |  |  |
+| `appFile` | `string` | No |  |  | iOS only — path to a built .app/.ipa for maestro-runner to reinstall on clearState. Auto-resolved from the flow appId when omitted (GH#201). |
+| `deviceId` | `string` | No |  | min: 1, max: 256 | Exact UDID or serial; defaults from session or Android ANDROID_SERIAL. |
+| `timeoutMs` | `number` | No | `120000` | min: 5000, max: 300000, integer | Execution timeout in ms |
+| `params` | `Record<string, unknown>` | No |  |  | GH #116: parameter bindings forwarded as -e KEY=VALUE for $\{KEY\} placeholders in the flow. Keys must match /^[A-Z_][A-Z0-9_]*$/ (validated in the handler). |
 
 ## Usage
 

--- a/apps/docs-site/src/content/docs/tools/testing/maestro_test_all.mdx
+++ b/apps/docs-site/src/content/docs/tools/testing/maestro_test_all.mdx
@@ -11,11 +11,11 @@ Discover and run all Maestro flows in .rn-agent/actions/ as a regression suite. 
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `platform` | `unknown` | No |  |  | Target platform (auto-detected from session) |
-| `deviceId` | `unknown` | No |  | min: 1, max: 256 |  |
-| `flowDir` | `unknown` | No |  |  | Directory to scan for .yaml flows (default: &lt;project&gt;/.rn-agent/actions/) |
-| `pattern` | `unknown` | No |  |  | Regex pattern to filter flow files (e.g. "cart|checkout") |
-| `timeoutPerFlow` | `unknown` | No | `120000` | min: 5000, max: 300000, integer | Timeout per flow in ms |
+| `platform` | `enum: ios | android` | No |  |  | Target platform (auto-detected from session) |
+| `deviceId` | `string` | No |  | min: 1, max: 256 | Exact simulator UDID / adb serial to run the suite on (defaults to the active session device). |
+| `flowDir` | `string` | No |  |  | Directory to scan for .yaml flows (default: &lt;project&gt;/.rn-agent/actions/) |
+| `pattern` | `string` | No |  |  | Regex pattern to filter flow files (e.g. "cart|checkout") |
+| `timeoutPerFlow` | `number` | No | `120000` | min: 5000, max: 300000, integer | Timeout per flow in ms |
 | `stopOnFailure` | `boolean` | No | `false` |  | Stop after first failure |
 
 ## Usage

--- a/apps/docs-site/src/content/docs/tools/testing/maestro_test_all.mdx
+++ b/apps/docs-site/src/content/docs/tools/testing/maestro_test_all.mdx
@@ -14,7 +14,7 @@ Discover and run all Maestro flows in .rn-agent/actions/ as a regression suite. 
 | `platform` | `enum: ios | android` | No |  |  | Target platform (auto-detected from session) |
 | `deviceId` | `string` | No |  | min: 1, max: 256 | Exact simulator UDID / adb serial to run the suite on (defaults to the active session device). |
 | `flowDir` | `string` | No |  |  | Directory to scan for .yaml flows (default: &lt;project&gt;/.rn-agent/actions/) |
-| `pattern` | `string` | No |  |  | Regex pattern to filter flow files (e.g. "cart|checkout") |
+| `pattern` | `string` | No |  |  | Regex pattern to filter flow files (e.g. "cart&#124;checkout") |
 | `timeoutPerFlow` | `number` | No | `120000` | min: 5000, max: 300000, integer | Timeout per flow in ms |
 | `stopOnFailure` | `boolean` | No | `false` |  | Stop after first failure |
 

--- a/apps/docs-site/src/content/docs/tools/testing/maestro_test_all.mdx
+++ b/apps/docs-site/src/content/docs/tools/testing/maestro_test_all.mdx
@@ -11,7 +11,7 @@ Discover and run all Maestro flows in .rn-agent/actions/ as a regression suite. 
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `platform` | `enum: ios | android` | No |  |  | Target platform (auto-detected from session) |
+| `platform` | `enum: ios \| android` | No |  |  | Target platform (auto-detected from session) |
 | `deviceId` | `string` | No |  | min: 1, max: 256 | Exact simulator UDID / adb serial to run the suite on (defaults to the active session device). |
 | `flowDir` | `string` | No |  |  | Directory to scan for .yaml flows (default: &lt;project&gt;/.rn-agent/actions/) |
 | `pattern` | `string` | No |  |  | Regex pattern to filter flow files (e.g. "cart&#124;checkout") |

--- a/apps/docs-site/src/content/docs/tools/testing/proof_step.mdx
+++ b/apps/docs-site/src/content/docs/tools/testing/proof_step.mdx
@@ -11,13 +11,13 @@ Atomic proof capture step: navigate to a screen (optional), wait for settlement,
 
 | Name | Type | Required | Default | Constraints | Description |
 |------|------|----------|---------|-------------|-------------|
-| `screen` | `unknown` | No |  |  | Screen to navigate to (omit to stay on current screen) |
+| `screen` | `string` | No |  |  | Screen to navigate to (omit to stay on current screen) |
 | `params` | `Record<string, unknown>` | No |  |  | Navigation params (e.g. \{ id: "1" \}) |
-| `waitMs` | `unknown` | No | `1500` | min: 0, max: 10000, integer | Settlement wait in ms (default 1500) |
-| `verifyText` | `unknown` | No |  |  | Visible text to verify on screen (uses device_find) |
-| `verifyTestID` | `unknown` | No |  |  | testID to verify in component tree (uses cdp_component_tree) |
-| `screenshotPath` | `unknown` | No |  |  | Output path for screenshot (default: auto-generated) |
-| `label` | `unknown` | No |  |  | Label for this proof step (e.g. "After adding item to cart") |
+| `waitMs` | `number` | No | `1500` | min: 0, max: 10000, integer | Settlement wait in ms (default 1500) |
+| `verifyText` | `string` | No |  |  | Visible text to verify on screen (uses device_find) |
+| `verifyTestID` | `string` | No |  |  | testID to verify in component tree (uses cdp_component_tree) |
+| `screenshotPath` | `string` | No |  |  | Output path for screenshot (default: auto-generated) |
+| `label` | `string` | No |  |  | Label for this proof step (e.g. "After adding item to cart") |
 
 ## Usage
 

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -82884,6 +82884,7 @@ var DISMISS_LABELS_ANDROID = ["Deny", "DENY", "Cancel", "CANCEL", "No", "Not now
 var realSleep2 = (ms) => new Promise((r) => setTimeout(r, ms));
 var fetchSnapshotNodesFn = fetchSnapshotNodes;
 var pressCandidateFn2 = pressCandidate;
+var runMaestroInlineFn = runMaestroInline;
 var sleepFn = realSleep2;
 var iosSessionActiveFn = () => hasActiveSession() && getActiveSession()?.platform === "ios";
 async function tapSystemDialogViaRunner(labels) {
@@ -82927,7 +82928,7 @@ async function acceptDeeplinkOpenConfirmation() {
   await sleepFn(OPEN_CONFIRMATION_RETRY_DELAY_MS);
   return tapSystemDialogViaRunner(OPEN_CONFIRMATION_LABELS);
 }
-var DEFAULT_DIALOG_TIMEOUT_MS = 12e4;
+var DEFAULT_DIALOG_TIMEOUT_MS = 15e3;
 function regexEscape(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -82935,7 +82936,7 @@ async function tapSystemDialog(labels, platform, totalTimeoutMs, slug, authority
   const selector = `^(?:${labels.map(regexEscape).join("|")})$`;
   const yaml2 = `- tapOn:
     text: "${yamlEscape(selector)}"`;
-  const result = await runMaestroInline(yaml2, {
+  const result = await runMaestroInlineFn(yaml2, {
     platform,
     timeoutMs: totalTimeoutMs,
     slug,
@@ -93082,12 +93083,12 @@ trackedTool("cdp_dismiss_dev_client_picker", 'Dismiss the Expo Dev Client "Devel
 trackedTool("device_accept_system_dialog", "Tap an OS-level accept button on the exact session device. iOS prefers the capability-bound native runner so SpringBoard-owned dialogs are reachable; DIALOG_BUTTON_NOT_FOUND returns availableButtons for an exact-label retry.", {
   label: external_exports.string().optional().describe("Specific button label to tap. Omit to try common defaults (Allow, OK, Open, Continue, Yes, Accept)."),
   platform: external_exports.enum(["ios", "android"]).optional().describe("Authority-bound platform; conflicting values are refused"),
-  timeoutMs: external_exports.number().int().min(1e3).max(12e4).optional().describe("Whole fallback Maestro timeout (default 120000ms; native iOS runner path is preferred).")
+  timeoutMs: external_exports.number().int().min(1e3).max(12e4).optional().describe("Whole fallback Maestro timeout (default 15000ms; explicit values up to 120000 accepted). Native iOS runner path is preferred.")
 }, createDeviceAcceptSystemDialogHandler());
 trackedTool("device_dismiss_system_dialog", "Tap an OS-level dismiss button through the capability-bound runner on the exact session device.", {
   label: external_exports.string().optional().describe("Specific button label to tap. Omit to try common defaults (Cancel, Don\u2019t Allow, Deny, No, Not Now)."),
   platform: external_exports.enum(["ios", "android"]).optional().describe("Authority-bound platform; conflicting values are refused"),
-  timeoutMs: external_exports.number().int().min(1e3).max(12e4).optional().describe("Whole fallback Maestro timeout (default 120000ms; native iOS runner path is preferred).")
+  timeoutMs: external_exports.number().int().min(1e3).max(12e4).optional().describe("Whole fallback Maestro timeout (default 15000ms; explicit values up to 120000 accepted).")
 }, createDeviceDismissSystemDialogHandler());
 var resolveNativeProofDevice = async () => {
   const session2 = getActiveSession();

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -84902,7 +84902,7 @@ async function tapSystemDialog(labels, platform, totalTimeoutMs, slug, authority
   const selector = `^(?:${labels.map(regexEscape).join("|")})$`;
   const yaml2 = `- tapOn:
     text: "${yamlEscape(selector)}"`;
-  const result = await runMaestroInline(yaml2, {
+  const result = await runMaestroInlineFn(yaml2, {
     platform,
     timeoutMs: totalTimeoutMs,
     slug,
@@ -84979,7 +84979,7 @@ function createDeviceAcceptSystemDialogHandler() {
 function createDeviceDismissSystemDialogHandler() {
   return async (args) => handleSystemDialog(args, DISMISS_LABELS_IOS, DISMISS_LABELS_ANDROID, "sys-dismiss");
 }
-var APOSTROPHE_ASCII, APOSTROPHE_CURLY, ACCEPT_LABELS_IOS, DISMISS_LABELS_IOS_BASE, DISMISS_LABELS_IOS, ACCEPT_LABELS_ANDROID, DISMISS_LABELS_ANDROID, realSleep2, fetchSnapshotNodesFn, pressCandidateFn2, sleepFn, iosSessionActiveFn, OPEN_CONFIRMATION_LABELS, OPEN_CONFIRMATION_RETRY_DELAY_MS, DEFAULT_DIALOG_TIMEOUT_MS;
+var APOSTROPHE_ASCII, APOSTROPHE_CURLY, ACCEPT_LABELS_IOS, DISMISS_LABELS_IOS_BASE, DISMISS_LABELS_IOS, ACCEPT_LABELS_ANDROID, DISMISS_LABELS_ANDROID, realSleep2, fetchSnapshotNodesFn, pressCandidateFn2, runMaestroInlineFn, sleepFn, iosSessionActiveFn, OPEN_CONFIRMATION_LABELS, OPEN_CONFIRMATION_RETRY_DELAY_MS, DEFAULT_DIALOG_TIMEOUT_MS;
 var init_device_system_dialog = __esm({
   "packages/rn-dev-agent-core/dist/tools/device-system-dialog.js"() {
     "use strict";
@@ -85021,11 +85021,12 @@ var init_device_system_dialog = __esm({
     realSleep2 = (ms) => new Promise((r) => setTimeout(r, ms));
     fetchSnapshotNodesFn = fetchSnapshotNodes;
     pressCandidateFn2 = pressCandidate;
+    runMaestroInlineFn = runMaestroInline;
     sleepFn = realSleep2;
     iosSessionActiveFn = () => hasActiveSession() && getActiveSession()?.platform === "ios";
     OPEN_CONFIRMATION_LABELS = ["Open"];
     OPEN_CONFIRMATION_RETRY_DELAY_MS = 750;
-    DEFAULT_DIALOG_TIMEOUT_MS = 12e4;
+    DEFAULT_DIALOG_TIMEOUT_MS = 15e3;
   }
 });
 
@@ -95291,12 +95292,12 @@ var init_index = __esm({
     trackedTool("device_accept_system_dialog", "Tap an OS-level accept button on the exact session device. iOS prefers the capability-bound native runner so SpringBoard-owned dialogs are reachable; DIALOG_BUTTON_NOT_FOUND returns availableButtons for an exact-label retry.", {
       label: external_exports.string().optional().describe("Specific button label to tap. Omit to try common defaults (Allow, OK, Open, Continue, Yes, Accept)."),
       platform: external_exports.enum(["ios", "android"]).optional().describe("Authority-bound platform; conflicting values are refused"),
-      timeoutMs: external_exports.number().int().min(1e3).max(12e4).optional().describe("Whole fallback Maestro timeout (default 120000ms; native iOS runner path is preferred).")
+      timeoutMs: external_exports.number().int().min(1e3).max(12e4).optional().describe("Whole fallback Maestro timeout (default 15000ms; explicit values up to 120000 accepted). Native iOS runner path is preferred.")
     }, createDeviceAcceptSystemDialogHandler());
     trackedTool("device_dismiss_system_dialog", "Tap an OS-level dismiss button through the capability-bound runner on the exact session device.", {
       label: external_exports.string().optional().describe("Specific button label to tap. Omit to try common defaults (Cancel, Don\u2019t Allow, Deny, No, Not Now)."),
       platform: external_exports.enum(["ios", "android"]).optional().describe("Authority-bound platform; conflicting values are refused"),
-      timeoutMs: external_exports.number().int().min(1e3).max(12e4).optional().describe("Whole fallback Maestro timeout (default 120000ms; native iOS runner path is preferred).")
+      timeoutMs: external_exports.number().int().min(1e3).max(12e4).optional().describe("Whole fallback Maestro timeout (default 15000ms; explicit values up to 120000 accepted).")
     }, createDeviceDismissSystemDialogHandler());
     resolveNativeProofDevice = async () => {
       const session2 = getActiveSession();

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -82884,6 +82884,7 @@ var DISMISS_LABELS_ANDROID = ["Deny", "DENY", "Cancel", "CANCEL", "No", "Not now
 var realSleep2 = (ms) => new Promise((r) => setTimeout(r, ms));
 var fetchSnapshotNodesFn = fetchSnapshotNodes;
 var pressCandidateFn2 = pressCandidate;
+var runMaestroInlineFn = runMaestroInline;
 var sleepFn = realSleep2;
 var iosSessionActiveFn = () => hasActiveSession() && getActiveSession()?.platform === "ios";
 async function tapSystemDialogViaRunner(labels) {
@@ -82927,7 +82928,7 @@ async function acceptDeeplinkOpenConfirmation() {
   await sleepFn(OPEN_CONFIRMATION_RETRY_DELAY_MS);
   return tapSystemDialogViaRunner(OPEN_CONFIRMATION_LABELS);
 }
-var DEFAULT_DIALOG_TIMEOUT_MS = 12e4;
+var DEFAULT_DIALOG_TIMEOUT_MS = 15e3;
 function regexEscape(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -82935,7 +82936,7 @@ async function tapSystemDialog(labels, platform, totalTimeoutMs, slug, authority
   const selector = `^(?:${labels.map(regexEscape).join("|")})$`;
   const yaml2 = `- tapOn:
     text: "${yamlEscape(selector)}"`;
-  const result = await runMaestroInline(yaml2, {
+  const result = await runMaestroInlineFn(yaml2, {
     platform,
     timeoutMs: totalTimeoutMs,
     slug,
@@ -93082,12 +93083,12 @@ trackedTool("cdp_dismiss_dev_client_picker", 'Dismiss the Expo Dev Client "Devel
 trackedTool("device_accept_system_dialog", "Tap an OS-level accept button on the exact session device. iOS prefers the capability-bound native runner so SpringBoard-owned dialogs are reachable; DIALOG_BUTTON_NOT_FOUND returns availableButtons for an exact-label retry.", {
   label: external_exports.string().optional().describe("Specific button label to tap. Omit to try common defaults (Allow, OK, Open, Continue, Yes, Accept)."),
   platform: external_exports.enum(["ios", "android"]).optional().describe("Authority-bound platform; conflicting values are refused"),
-  timeoutMs: external_exports.number().int().min(1e3).max(12e4).optional().describe("Whole fallback Maestro timeout (default 120000ms; native iOS runner path is preferred).")
+  timeoutMs: external_exports.number().int().min(1e3).max(12e4).optional().describe("Whole fallback Maestro timeout (default 15000ms; explicit values up to 120000 accepted). Native iOS runner path is preferred.")
 }, createDeviceAcceptSystemDialogHandler());
 trackedTool("device_dismiss_system_dialog", "Tap an OS-level dismiss button through the capability-bound runner on the exact session device.", {
   label: external_exports.string().optional().describe("Specific button label to tap. Omit to try common defaults (Cancel, Don\u2019t Allow, Deny, No, Not Now)."),
   platform: external_exports.enum(["ios", "android"]).optional().describe("Authority-bound platform; conflicting values are refused"),
-  timeoutMs: external_exports.number().int().min(1e3).max(12e4).optional().describe("Whole fallback Maestro timeout (default 120000ms; native iOS runner path is preferred).")
+  timeoutMs: external_exports.number().int().min(1e3).max(12e4).optional().describe("Whole fallback Maestro timeout (default 15000ms; explicit values up to 120000 accepted).")
 }, createDeviceDismissSystemDialogHandler());
 var resolveNativeProofDevice = async () => {
   const session2 = getActiveSession();

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -84902,7 +84902,7 @@ async function tapSystemDialog(labels, platform, totalTimeoutMs, slug, authority
   const selector = `^(?:${labels.map(regexEscape).join("|")})$`;
   const yaml2 = `- tapOn:
     text: "${yamlEscape(selector)}"`;
-  const result = await runMaestroInline(yaml2, {
+  const result = await runMaestroInlineFn(yaml2, {
     platform,
     timeoutMs: totalTimeoutMs,
     slug,
@@ -84979,7 +84979,7 @@ function createDeviceAcceptSystemDialogHandler() {
 function createDeviceDismissSystemDialogHandler() {
   return async (args) => handleSystemDialog(args, DISMISS_LABELS_IOS, DISMISS_LABELS_ANDROID, "sys-dismiss");
 }
-var APOSTROPHE_ASCII, APOSTROPHE_CURLY, ACCEPT_LABELS_IOS, DISMISS_LABELS_IOS_BASE, DISMISS_LABELS_IOS, ACCEPT_LABELS_ANDROID, DISMISS_LABELS_ANDROID, realSleep2, fetchSnapshotNodesFn, pressCandidateFn2, sleepFn, iosSessionActiveFn, OPEN_CONFIRMATION_LABELS, OPEN_CONFIRMATION_RETRY_DELAY_MS, DEFAULT_DIALOG_TIMEOUT_MS;
+var APOSTROPHE_ASCII, APOSTROPHE_CURLY, ACCEPT_LABELS_IOS, DISMISS_LABELS_IOS_BASE, DISMISS_LABELS_IOS, ACCEPT_LABELS_ANDROID, DISMISS_LABELS_ANDROID, realSleep2, fetchSnapshotNodesFn, pressCandidateFn2, runMaestroInlineFn, sleepFn, iosSessionActiveFn, OPEN_CONFIRMATION_LABELS, OPEN_CONFIRMATION_RETRY_DELAY_MS, DEFAULT_DIALOG_TIMEOUT_MS;
 var init_device_system_dialog = __esm({
   "packages/rn-dev-agent-core/dist/tools/device-system-dialog.js"() {
     "use strict";
@@ -85021,11 +85021,12 @@ var init_device_system_dialog = __esm({
     realSleep2 = (ms) => new Promise((r) => setTimeout(r, ms));
     fetchSnapshotNodesFn = fetchSnapshotNodes;
     pressCandidateFn2 = pressCandidate;
+    runMaestroInlineFn = runMaestroInline;
     sleepFn = realSleep2;
     iosSessionActiveFn = () => hasActiveSession() && getActiveSession()?.platform === "ios";
     OPEN_CONFIRMATION_LABELS = ["Open"];
     OPEN_CONFIRMATION_RETRY_DELAY_MS = 750;
-    DEFAULT_DIALOG_TIMEOUT_MS = 12e4;
+    DEFAULT_DIALOG_TIMEOUT_MS = 15e3;
   }
 });
 
@@ -95291,12 +95292,12 @@ var init_index = __esm({
     trackedTool("device_accept_system_dialog", "Tap an OS-level accept button on the exact session device. iOS prefers the capability-bound native runner so SpringBoard-owned dialogs are reachable; DIALOG_BUTTON_NOT_FOUND returns availableButtons for an exact-label retry.", {
       label: external_exports.string().optional().describe("Specific button label to tap. Omit to try common defaults (Allow, OK, Open, Continue, Yes, Accept)."),
       platform: external_exports.enum(["ios", "android"]).optional().describe("Authority-bound platform; conflicting values are refused"),
-      timeoutMs: external_exports.number().int().min(1e3).max(12e4).optional().describe("Whole fallback Maestro timeout (default 120000ms; native iOS runner path is preferred).")
+      timeoutMs: external_exports.number().int().min(1e3).max(12e4).optional().describe("Whole fallback Maestro timeout (default 15000ms; explicit values up to 120000 accepted). Native iOS runner path is preferred.")
     }, createDeviceAcceptSystemDialogHandler());
     trackedTool("device_dismiss_system_dialog", "Tap an OS-level dismiss button through the capability-bound runner on the exact session device.", {
       label: external_exports.string().optional().describe("Specific button label to tap. Omit to try common defaults (Cancel, Don\u2019t Allow, Deny, No, Not Now)."),
       platform: external_exports.enum(["ios", "android"]).optional().describe("Authority-bound platform; conflicting values are refused"),
-      timeoutMs: external_exports.number().int().min(1e3).max(12e4).optional().describe("Whole fallback Maestro timeout (default 120000ms; native iOS runner path is preferred).")
+      timeoutMs: external_exports.number().int().min(1e3).max(12e4).optional().describe("Whole fallback Maestro timeout (default 15000ms; explicit values up to 120000 accepted).")
     }, createDeviceDismissSystemDialogHandler());
     resolveNativeProofDevice = async () => {
       const session2 = getActiveSession();

--- a/packages/rn-dev-agent-core/src/index.ts
+++ b/packages/rn-dev-agent-core/src/index.ts
@@ -2847,7 +2847,7 @@ trackedTool(
       .max(120000)
       .optional()
       .describe(
-        'Whole fallback Maestro timeout (default 120000ms; native iOS runner path is preferred).',
+        'Whole fallback Maestro timeout (default 15000ms; explicit values up to 120000 accepted). Native iOS runner path is preferred.',
       ),
   },
   createDeviceAcceptSystemDialogHandler(),
@@ -2874,7 +2874,7 @@ trackedTool(
       .max(120000)
       .optional()
       .describe(
-        'Whole fallback Maestro timeout (default 120000ms; native iOS runner path is preferred).',
+        'Whole fallback Maestro timeout (default 15000ms; explicit values up to 120000 accepted).',
       ),
   },
   createDeviceDismissSystemDialogHandler(),

--- a/packages/rn-dev-agent-core/src/tools/device-system-dialog.ts
+++ b/packages/rn-dev-agent-core/src/tools/device-system-dialog.ts
@@ -164,11 +164,7 @@ export async function acceptDeeplinkOpenConfirmation(): Promise<RunnerDialogOutc
   return tapSystemDialogViaRunner(OPEN_CONFIRMATION_LABELS);
 }
 
-// GH #816: the Maestro fallback is a presence probe — when no dialog exists
-// (Android, or session-less iOS), waiting out the old 120 s default made every
-// call look hung before DIALOG_NOT_FOUND came back. A short default keeps the
-// no-dialog path bounded while explicit caller values up to 120 000 ms remain
-// accepted for slow-to-animate dialogs.
+// Keep the no-dialog fallback bounded while allowing longer explicit waits.
 const DEFAULT_DIALOG_TIMEOUT_MS = 15_000;
 
 function regexEscape(value: string): string {

--- a/packages/rn-dev-agent-core/src/tools/device-system-dialog.ts
+++ b/packages/rn-dev-agent-core/src/tools/device-system-dialog.ts
@@ -57,6 +57,7 @@ const realSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r
 
 let fetchSnapshotNodesFn: typeof fetchSnapshotNodes = fetchSnapshotNodes;
 let pressCandidateFn: typeof pressCandidate = pressCandidate;
+let runMaestroInlineFn: typeof runMaestroInline = runMaestroInline;
 let sleepFn: (ms: number) => Promise<void> = realSleep;
 let iosSessionActiveFn: () => boolean = () =>
   hasActiveSession() && getActiveSession()?.platform === 'ios';
@@ -78,6 +79,12 @@ export function _setPressCandidateForTest(fn: typeof pressCandidate): void {
 }
 export function _resetPressCandidateForTest(): void {
   pressCandidateFn = pressCandidate;
+}
+export function _setRunMaestroInlineForTest(fn: typeof runMaestroInline): void {
+  runMaestroInlineFn = fn;
+}
+export function _resetRunMaestroInlineForTest(): void {
+  runMaestroInlineFn = runMaestroInline;
 }
 export function _setIosSessionActiveForTest(value: boolean): void {
   iosSessionActiveFn = () => value;
@@ -157,7 +164,12 @@ export async function acceptDeeplinkOpenConfirmation(): Promise<RunnerDialogOutc
   return tapSystemDialogViaRunner(OPEN_CONFIRMATION_LABELS);
 }
 
-const DEFAULT_DIALOG_TIMEOUT_MS = 120_000;
+// GH #816: the Maestro fallback is a presence probe — when no dialog exists
+// (Android, or session-less iOS), waiting out the old 120 s default made every
+// call look hung before DIALOG_NOT_FOUND came back. A short default keeps the
+// no-dialog path bounded while explicit caller values up to 120 000 ms remain
+// accepted for slow-to-animate dialogs.
+const DEFAULT_DIALOG_TIMEOUT_MS = 15_000;
 
 function regexEscape(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -174,7 +186,7 @@ async function tapSystemDialog(
   // without paying a fresh iOS WDA cold start for every candidate label.
   const selector = `^(?:${labels.map(regexEscape).join('|')})$`;
   const yaml = `- tapOn:\n    text: "${yamlEscape(selector)}"`;
-  const result = await runMaestroInline(yaml, {
+  const result = await runMaestroInlineFn(yaml, {
     platform,
     timeoutMs: totalTimeoutMs,
     slug,

--- a/packages/rn-dev-agent-core/test/unit/gh-816-system-dialog-timeout.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-816-system-dialog-timeout.test.ts
@@ -1,11 +1,3 @@
-// GH #816: the Maestro fallback behind device_accept_system_dialog /
-// device_dismiss_system_dialog defaulted to a required 120 s wait whenever
-// the native runner path does not apply (Android, session-less iOS). With no
-// dialog present, every call looked hung for two minutes before returning
-// DIALOG_NOT_FOUND. Regression contract: the default presence timeout stays
-// at most 15 s, explicit caller values up to 120 000 ms still pass through,
-// and a no-dialog Android call returns the existing typed DIALOG_NOT_FOUND
-// result within that default bound.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
@@ -44,8 +36,7 @@ test('#816 accept dialog on Android with no dialog returns typed DIALOG_NOT_FOUN
   const handler = createDeviceAcceptSystemDialogHandler();
   try {
     const result = await handler({ platform: 'android' });
-    // The wait is bounded by the default, not by wall clock here — the seam
-    // records what the real Maestro flow would have waited out.
+    // The seam records the real Maestro timeout without a wall-clock wait.
     assert.ok(
       waitedMs > 0 && waitedMs <= 15_000,
       `default wait must be <= 15000ms, got ${waitedMs}`,

--- a/packages/rn-dev-agent-core/test/unit/gh-816-system-dialog-timeout.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-816-system-dialog-timeout.test.ts
@@ -1,0 +1,104 @@
+// GH #816: the Maestro fallback behind device_accept_system_dialog /
+// device_dismiss_system_dialog defaulted to a required 120 s wait whenever
+// the native runner path does not apply (Android, session-less iOS). With no
+// dialog present, every call looked hung for two minutes before returning
+// DIALOG_NOT_FOUND. Regression contract: the default presence timeout stays
+// at most 15 s, explicit caller values up to 120 000 ms still pass through,
+// and a no-dialog Android call returns the existing typed DIALOG_NOT_FOUND
+// result within that default bound.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createDeviceAcceptSystemDialogHandler,
+  createDeviceDismissSystemDialogHandler,
+  _setRunMaestroInlineForTest,
+  _resetRunMaestroInlineForTest,
+} from '../../dist/tools/device-system-dialog.js';
+
+interface RecordedCall {
+  yaml: string;
+  timeoutMs?: number;
+  slug?: string;
+}
+
+const MAESTRO_MISS = {
+  passed: false as const,
+  output: '',
+  flowFile: '',
+};
+
+function installRecordingMaestro(calls: RecordedCall[], sleepMs: (ms: number) => void) {
+  _setRunMaestroInlineForTest(async (_yaml, opts) => {
+    calls.push({ yaml: _yaml, timeoutMs: opts.timeoutMs, slug: opts.slug });
+    sleepMs(opts.timeoutMs ?? -1);
+    return MAESTRO_MISS;
+  });
+}
+
+test('#816 accept dialog on Android with no dialog returns typed DIALOG_NOT_FOUND inside the 15s default', async () => {
+  const calls: RecordedCall[] = [];
+  let waitedMs = 0;
+  installRecordingMaestro(calls, (ms) => {
+    waitedMs += ms;
+  });
+  const handler = createDeviceAcceptSystemDialogHandler();
+  try {
+    const result = await handler({ platform: 'android' });
+    // The wait is bounded by the default, not by wall clock here — the seam
+    // records what the real Maestro flow would have waited out.
+    assert.ok(
+      waitedMs > 0 && waitedMs <= 15_000,
+      `default wait must be <= 15000ms, got ${waitedMs}`,
+    );
+    assert.equal(
+      result.isError,
+      undefined,
+      'a missing dialog is a warning result, not a hard error',
+    );
+    const text = result.content?.map((c) => c.text).join('\n') ?? '';
+    const envelope = JSON.parse(text);
+    assert.equal(envelope.data?.tapped, false, 'no dialog was tapped');
+    assert.equal(envelope.data?.platform, 'android');
+    assert.equal(
+      envelope.meta?.code,
+      'DIALOG_NOT_FOUND',
+      'the typed DIALOG_NOT_FOUND code must surface in meta.code',
+    );
+    assert.match(text, /DIALOG_NOT_FOUND/);
+    assert.equal(calls.length, 1, 'exactly one combined-label Maestro probe runs');
+    assert.equal(calls[0].slug, 'sys-accept');
+  } finally {
+    _resetRunMaestroInlineForTest();
+  }
+});
+
+test('#816 dismiss dialog default timeout also stays within the 15s bound', async () => {
+  const calls: RecordedCall[] = [];
+  let waitedMs = 0;
+  installRecordingMaestro(calls, (ms) => {
+    waitedMs += ms;
+  });
+  const handler = createDeviceDismissSystemDialogHandler();
+  try {
+    await handler({ platform: 'android' });
+    assert.ok(waitedMs <= 15_000, `default dismiss wait must be <= 15000ms, got ${waitedMs}`);
+    assert.equal(calls[0].slug, 'sys-dismiss');
+  } finally {
+    _resetRunMaestroInlineForTest();
+  }
+});
+
+test('#816 an explicit caller timeout through 120000ms is passed to Maestro unchanged', async () => {
+  const calls: RecordedCall[] = [];
+  let waitedMs = 0;
+  installRecordingMaestro(calls, (ms) => {
+    waitedMs += ms;
+  });
+  const handler = createDeviceAcceptSystemDialogHandler();
+  try {
+    await handler({ platform: 'android', timeoutMs: 120_000 });
+    assert.equal(waitedMs, 120_000, 'explicit caller values up to 120000 must be honored');
+  } finally {
+    _resetRunMaestroInlineForTest();
+  }
+});

--- a/packages/rn-dev-agent-core/test/unit/gh-816-tool-docs-generator.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-816-tool-docs-generator.test.ts
@@ -1,0 +1,143 @@
+// GH #816: generate-tool-docs.mjs assumed unwrapped .describe() calls and
+// single-line zod chains. Prettier-wrapped declarations published params as
+// `unknown` with empty descriptions — hiding device_accept_system_dialog's
+// timeoutMs contract (the 15s default behind GH #816), device_find.index,
+// and many others. Regression contract: running the real generator over the
+// current src/index.ts must emit described, correctly typed rows for the GH
+// #816 acceptance set, and the committed docs must stay byte-fresh.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+const GENERATOR = join(REPO_ROOT, 'apps', 'docs-site', 'scripts', 'generate-tool-docs.mjs');
+const DOCS = join(REPO_ROOT, 'apps', 'docs-site', 'src', 'content', 'docs');
+
+function rowFor(mdx, param) {
+  const line = mdx.split('\n').find((l) => l.startsWith(`| \`${param}\``));
+  assert.ok(line, `params table must have a ${param} row`);
+  return line.split('|').map((c) => c.trim());
+}
+
+function runGenerator(outDir) {
+  execFileSync(process.execPath, [GENERATOR], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: { ...process.env, RN_DEV_AGENT_DOCS_OUT: outDir },
+  });
+  return join(outDir, 'tools');
+}
+
+test('#816 generated docs describe device_accept_system_dialog.timeoutMs as a number with its default', () => {
+  const out = fs.mkdtempSync(join(tmpdir(), 'gh816-docs-'));
+  try {
+    const tools = runGenerator(out);
+    const mdx = fs.readFileSync(join(tools, 'cdp', 'device_accept_system_dialog.mdx'), 'utf8');
+    const cells = rowFor(mdx, 'timeoutMs');
+    assert.equal(cells[2], '`number`', `timeoutMs must type as number, got ${cells[2]}`);
+    assert.match(
+      cells[6],
+      /default 15000ms/i,
+      'the timeout description must state the new default',
+    );
+    assert.match(cells[6], /120000/, 'explicit values up to 120000 remain documented');
+    const dismissed = fs.readFileSync(
+      join(tools, 'cdp', 'device_dismiss_system_dialog.mdx'),
+      'utf8',
+    );
+    const dismissCells = rowFor(dismissed, 'timeoutMs');
+    assert.equal(dismissCells[2], '`number`');
+    assert.match(dismissCells[6], /default 15000ms/i);
+  } finally {
+    fs.rmSync(out, { recursive: true, force: true });
+  }
+});
+
+test('#816 generated docs give device_find.index a real type and non-empty description', () => {
+  const out = fs.mkdtempSync(join(tmpdir(), 'gh816-docs-'));
+  try {
+    const tools = runGenerator(out);
+    const mdx = fs.readFileSync(join(tools, 'device', 'device_find.mdx'), 'utf8');
+    const cells = rowFor(mdx, 'index');
+    assert.equal(cells[2], '`number`', `index must type as number, got ${cells[2]}`);
+    assert.ok(cells[6].length > 0, 'index description must not be empty');
+    assert.match(cells[6], /AMBIGUOUS_MATCH|candidate/i);
+  } finally {
+    fs.rmSync(out, { recursive: true, force: true });
+  }
+});
+
+test('#816 cdp_run_action.actionId keeps its correct string type through regeneration', () => {
+  const out = fs.mkdtempSync(join(tmpdir(), 'gh816-docs-'));
+  try {
+    const tools = runGenerator(out);
+    const mdx = fs.readFileSync(join(tools, 'cdp', 'cdp_run_action.mdx'), 'utf8');
+    const cells = rowFor(mdx, 'actionId');
+    assert.equal(cells[2], '`string`', `actionId must type as string, got ${cells[2]}`);
+    assert.equal(cells[3], 'Yes', 'actionId is required');
+    assert.ok(cells[6].length > 0, 'actionId description must not be empty');
+  } finally {
+    fs.rmSync(out, { recursive: true, force: true });
+  }
+});
+
+test('#816 no generated tool page leaves a wrapped-zod param typed unknown with an empty description', () => {
+  // The parser may only widen to `unknown` for proven z.unknown()/z.any()
+  // forms; every such row must still carry a description (z.unknown() chains
+  // in index.ts are always described). A regenerated `unknown` + empty
+  // description cell is the exact GH #816 failure signature.
+  const out = fs.mkdtempSync(join(tmpdir(), 'gh816-docs-'));
+  try {
+    const tools = runGenerator(out);
+    const failures = [];
+    for (const category of fs.readdirSync(tools)) {
+      const dir = join(tools, category);
+      if (!fs.statSync(dir).isDirectory()) continue;
+      for (const file of fs.readdirSync(dir)) {
+        const mdx = fs.readFileSync(join(dir, file), 'utf8');
+        if (!mdx.includes('## Parameters')) continue;
+        for (const line of mdx.split('\n')) {
+          if (!line.startsWith('| `') || line.includes('Name | Type')) continue;
+          const cells = line.split('|').map((c) => c.trim());
+          if (cells[2] === '`unknown`' && cells[6] === '') {
+            failures.push(`${file}: ${cells[1]}`);
+          }
+        }
+      }
+    }
+    assert.deepEqual(
+      failures,
+      [],
+      `params regressed to undocumented unknown (GH #816 signature): ${failures.join(', ')}`,
+    );
+  } finally {
+    fs.rmSync(out, { recursive: true, force: true });
+  }
+});
+
+test('#816 committed tool docs are fresh against src/index.ts', () => {
+  const out = fs.mkdtempSync(join(tmpdir(), 'gh816-docs-'));
+  try {
+    const tools = runGenerator(out);
+    for (const [category, name] of [
+      ['cdp', 'device_accept_system_dialog'],
+      ['cdp', 'device_dismiss_system_dialog'],
+      ['device', 'device_find'],
+      ['cdp', 'cdp_run_action'],
+    ]) {
+      const generated = fs.readFileSync(join(tools, category, `${name}.mdx`), 'utf8');
+      assert.equal(
+        generated,
+        fs.readFileSync(join(DOCS, 'tools', category, `${name}.mdx`), 'utf8'),
+        `committed docs for ${name} are stale — rerun corepack yarn docs:generate`,
+      );
+    }
+  } finally {
+    fs.rmSync(out, { recursive: true, force: true });
+  }
+});

--- a/packages/rn-dev-agent-core/test/unit/gh-816-tool-docs-generator.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-816-tool-docs-generator.test.ts
@@ -1,10 +1,3 @@
-// GH #816: generate-tool-docs.mjs assumed unwrapped .describe() calls and
-// single-line zod chains. Prettier-wrapped declarations published params as
-// `unknown` with empty descriptions — hiding device_accept_system_dialog's
-// timeoutMs contract (the 15s default behind GH #816), device_find.index,
-// and many others. Regression contract: running the real generator over the
-// current src/index.ts must emit described, correctly typed rows for the GH
-// #816 acceptance set, and the committed docs must stay byte-fresh.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
@@ -119,7 +112,7 @@ test('#816 generated descriptions decode supported TypeScript string escapes', a
     );
     assert.equal(
       decodeSupportedStringEscapes(String.raw`line\ncolumn\tpath\\quote\'double\"tick\`\u2019`),
-      "line\ncolumn\tpath\\quote'double\"tick`’",
+      'line\ncolumn\tpath\\quote\'double"tick`’',
     );
     assert.equal(
       decodeSupportedStringEscapes(String.raw`keep\r\x41\u{2019}\q`),
@@ -188,10 +181,6 @@ trackedTool(
 });
 
 test('#816 no generated tool page leaves a wrapped-zod param typed unknown with an empty description', () => {
-  // The parser may only widen to `unknown` for proven z.unknown()/z.any()
-  // forms; every such row must still carry a description (z.unknown() chains
-  // in index.ts are always described). A regenerated `unknown` + empty
-  // description cell is the exact GH #816 failure signature.
   const out = fs.mkdtempSync(join(tmpdir(), 'gh816-docs-'));
   try {
     const tools = runGenerator(out);

--- a/packages/rn-dev-agent-core/test/unit/gh-816-tool-docs-generator.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-816-tool-docs-generator.test.ts
@@ -11,7 +11,7 @@ import fs from 'node:fs';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { resolve, dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
@@ -82,6 +82,41 @@ test('#816 cdp_run_action.actionId keeps its correct string type through regener
     assert.equal(cells[3], 'Yes', 'actionId is required');
     assert.ok(cells[6].length > 0, 'actionId description must not be empty');
   } finally {
+    fs.rmSync(out, { recursive: true, force: true });
+  }
+});
+
+test('#816 generated descriptions decode supported TypeScript string escapes', async () => {
+  const out = fs.mkdtempSync(join(tmpdir(), 'gh816-docs-'));
+  const previousOut = process.env.RN_DEV_AGENT_DOCS_OUT;
+  try {
+    process.env.RN_DEV_AGENT_DOCS_OUT = out;
+    const { decodeSupportedStringEscapes } = await import(
+      `${pathToFileURL(GENERATOR).href}?escape-regression`
+    );
+    assert.equal(
+      decodeSupportedStringEscapes(String.raw`line\ncolumn\tpath\\quote\'double\"tick\`\u2019`),
+      "line\ncolumn\tpath\\quote'double\"tick`’",
+    );
+    assert.equal(
+      decodeSupportedStringEscapes(String.raw`keep\r\x41\u{2019}\q`),
+      String.raw`keep\r\x41\u{2019}\q`,
+    );
+
+    const tools = join(out, 'tools');
+    const dismissed = fs.readFileSync(
+      join(tools, 'cdp', 'device_dismiss_system_dialog.mdx'),
+      'utf8',
+    );
+    assert.match(dismissed, /Cancel, Don’t Allow, Deny/);
+    assert.doesNotMatch(dismissed, /Don\\\\u2019t Allow/);
+
+    const dispatch = fs.readFileSync(join(tools, 'cdp', 'cdp_dispatch.mdx'), 'utf8');
+    assert.match(dispatch, /the LLM's JSON encoder/);
+    assert.doesNotMatch(dispatch, /LLM\\\\'s JSON encoder/);
+  } finally {
+    if (previousOut === undefined) delete process.env.RN_DEV_AGENT_DOCS_OUT;
+    else process.env.RN_DEV_AGENT_DOCS_OUT = previousOut;
     fs.rmSync(out, { recursive: true, force: true });
   }
 });

--- a/packages/rn-dev-agent-core/test/unit/gh-816-tool-docs-generator.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-816-tool-docs-generator.test.ts
@@ -18,10 +18,28 @@ const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
 const GENERATOR = join(REPO_ROOT, 'apps', 'docs-site', 'scripts', 'generate-tool-docs.mjs');
 const DOCS = join(REPO_ROOT, 'apps', 'docs-site', 'src', 'content', 'docs');
 
+function splitTableRow(line) {
+  const cells = [];
+  let current = '';
+  for (let index = 0; index < line.length; index++) {
+    if (line[index] === '\\' && line[index + 1] === '|') {
+      current += '\\|';
+      index++;
+    } else if (line[index] === '|') {
+      cells.push(current.trim());
+      current = '';
+    } else {
+      current += line[index];
+    }
+  }
+  cells.push(current.trim());
+  return cells;
+}
+
 function rowFor(mdx, param) {
   const line = mdx.split('\n').find((l) => l.startsWith(`| \`${param}\``));
   assert.ok(line, `params table must have a ${param} row`);
-  return line.split('|').map((c) => c.trim());
+  return splitTableRow(line);
 }
 
 function runGenerator(outDir, sourcePath) {
@@ -140,6 +158,12 @@ trackedTool(
   {
     path: z.string().describe('Path ends in \\'),
     structured: z.string().describe('First\nSecond\u007CTail'),
+    platform: z
+      .enum(['ios', 'android'])
+      .optional()
+      .describe(
+        'Wrapped enum type',
+      ),
   },
   () => {},
 );`,
@@ -151,10 +175,13 @@ trackedTool(
     const mdx = fs.readFileSync(join(tools, 'cdp', 'escape_fixture_0.mdx'), 'utf8');
     const pathCells = rowFor(mdx, 'path');
     const structuredCells = rowFor(mdx, 'structured');
+    const platformCells = rowFor(mdx, 'platform');
 
     assert.equal(pathCells[6], String.raw`Path ends in \\`);
     assert.equal(structuredCells.length, 8);
     assert.equal(structuredCells[6], 'First<br />Second&#124;Tail');
+    assert.equal(platformCells.length, 8);
+    assert.equal(platformCells[2], '`enum: ios \\| android`');
   } finally {
     fs.rmSync(out, { recursive: true, force: true });
   }
@@ -177,7 +204,7 @@ test('#816 no generated tool page leaves a wrapped-zod param typed unknown with 
         if (!mdx.includes('## Parameters')) continue;
         for (const line of mdx.split('\n')) {
           if (!line.startsWith('| `') || line.includes('Name | Type')) continue;
-          const cells = line.split('|').map((c) => c.trim());
+          const cells = splitTableRow(line);
           if (cells[2] === '`unknown`' && cells[6] === '') {
             failures.push(`${file}: ${cells[1]}`);
           }

--- a/packages/rn-dev-agent-core/test/unit/gh-816-tool-docs-generator.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/gh-816-tool-docs-generator.test.ts
@@ -24,11 +24,14 @@ function rowFor(mdx, param) {
   return line.split('|').map((c) => c.trim());
 }
 
-function runGenerator(outDir) {
+function runGenerator(outDir, sourcePath) {
+  const env = { ...process.env, RN_DEV_AGENT_DOCS_OUT: outDir };
+  if (sourcePath) env.RN_DEV_AGENT_DOCS_SOURCE = sourcePath;
+  else delete env.RN_DEV_AGENT_DOCS_SOURCE;
   execFileSync(process.execPath, [GENERATOR], {
     cwd: REPO_ROOT,
     encoding: 'utf8',
-    env: { ...process.env, RN_DEV_AGENT_DOCS_OUT: outDir },
+    env,
   });
   return join(outDir, 'tools');
 }
@@ -89,8 +92,10 @@ test('#816 cdp_run_action.actionId keeps its correct string type through regener
 test('#816 generated descriptions decode supported TypeScript string escapes', async () => {
   const out = fs.mkdtempSync(join(tmpdir(), 'gh816-docs-'));
   const previousOut = process.env.RN_DEV_AGENT_DOCS_OUT;
+  const previousSource = process.env.RN_DEV_AGENT_DOCS_SOURCE;
   try {
     process.env.RN_DEV_AGENT_DOCS_OUT = out;
+    delete process.env.RN_DEV_AGENT_DOCS_SOURCE;
     const { decodeSupportedStringEscapes } = await import(
       `${pathToFileURL(GENERATOR).href}?escape-regression`
     );
@@ -117,6 +122,40 @@ test('#816 generated descriptions decode supported TypeScript string escapes', a
   } finally {
     if (previousOut === undefined) delete process.env.RN_DEV_AGENT_DOCS_OUT;
     else process.env.RN_DEV_AGENT_DOCS_OUT = previousOut;
+    if (previousSource === undefined) delete process.env.RN_DEV_AGENT_DOCS_SOURCE;
+    else process.env.RN_DEV_AGENT_DOCS_SOURCE = previousSource;
+    fs.rmSync(out, { recursive: true, force: true });
+  }
+});
+
+test('#816 generated description rows preserve backslashes, line breaks, and delimiters', () => {
+  const out = fs.mkdtempSync(join(tmpdir(), 'gh816-docs-'));
+  const sourcePath = join(out, 'fixture-index.ts');
+  const source = Array.from(
+    { length: 38 },
+    (_, index) => String.raw`
+trackedTool(
+  'escape_fixture_${index}',
+  'Fixture tool',
+  {
+    path: z.string().describe('Path ends in \\'),
+    structured: z.string().describe('First\nSecond\u007CTail'),
+  },
+  () => {},
+);`,
+  ).join('\n');
+  fs.writeFileSync(sourcePath, source);
+
+  try {
+    const tools = runGenerator(out, sourcePath);
+    const mdx = fs.readFileSync(join(tools, 'cdp', 'escape_fixture_0.mdx'), 'utf8');
+    const pathCells = rowFor(mdx, 'path');
+    const structuredCells = rowFor(mdx, 'structured');
+
+    assert.equal(pathCells[6], String.raw`Path ends in \\`);
+    assert.equal(structuredCells.length, 8);
+    assert.equal(structuredCells[6], 'First<br />Second&#124;Tail');
+  } finally {
     fs.rmSync(out, { recursive: true, force: true });
   }
 });
@@ -164,6 +203,9 @@ test('#816 committed tool docs are fresh against src/index.ts', () => {
       ['cdp', 'device_dismiss_system_dialog'],
       ['device', 'device_find'],
       ['cdp', 'cdp_run_action'],
+      ['testing', 'maestro_test_all'],
+      ['cdp', 'cdp_record_test_generate'],
+      ['cdp', 'expect_redux'],
     ]) {
       const generated = fs.readFileSync(join(tools, category, `${name}.mdx`), 'utf8');
       assert.equal(


### PR DESCRIPTION
## Intent

Fix GitHub issue Lykhoyda/rn-dev-agent#816: system-dialog tools wait 120 seconds by default and generated docs hide the contract.

Requirements:
- device_accept_system_dialog and device_dismiss_system_dialog fall through to a required Maestro wait whose 120-second default makes Android or sessionless iOS with no dialog appear hung before the existing typed DIALOG_NOT_FOUND result.
- Make the default dialog-presence timeout at most 15 seconds while continuing to accept explicit caller values through 120 seconds.
- With no dialog on Android, return the existing typed DIALOG_NOT_FOUND within the default bound.
- Preserve all existing native fast paths; add no authority bypass, new authority mechanism, or new successful path.
- apps/docs-site/scripts/generate-tool-docs.mjs must handle prettier-wrapped .describe() calls and wrapped supported Zod expressions without widening parsing beyond proven forms.
- Regenerated MDX must contain a non-empty description for device_accept_system_dialog.timeoutMs, a non-empty description for device_find.index, and the correct type for cdp_run_action.actionId. Regenerating MDX intentionally also recovers descriptions/types for other previously-hidden params across tool docs - that is the same G4 defect class and in scope.
- Behavioral regression tests for both the timeout contract (via a test seam) and the docs generator are required.
- A supported rn-qa/rn-dev-agent runtime journey was completed on the NUC farm (no-dialog Android accept returned typed DIALOG_NOT_FOUND in 3.7s); no further device work is needed.
- Keep the change bounded to issue #816. Do not absorb unrelated findings.
- The committed changeset bumps rn-dev-agent-core and rn-dev-agent-plugin (patch). Host bundles under packages/claude-plugin and packages/codex-plugin are regenerated committed outputs of build:host-runtimes and must stay fresh (scripts/check-dist-fresh.sh).
- Known pre-existing environment failures NOT caused by this change (they reproduce identically at unmodified HEAD): six unit tests in action-engine-compat.test.ts and save-as-action-handler.test.js fail due to macOS /var vs /private/var tmpdir symlink resolution in migrateLearnedActions.

## What Changed

- Bound system-dialog fallback probes to a 15-second default while preserving explicit timeouts through 120 seconds and the existing typed `DIALOG_NOT_FOUND` result.
- Hardened tool-doc generation for wrapped Zod expressions and `.describe()` calls, then regenerated parameter types and descriptions across the affected docs.
- Added regression coverage for dialog timeout behavior and generated docs, plus refreshed host runtime bundles and patch changesets.

## Risk Assessment

✅ Low: The change is bounded and preserves native and authority paths while correctly limiting the shared Maestro fallback, recovering supported wrapped Zod documentation, and maintaining structurally valid generated tables.

## Testing

No baseline commands were supplied; after a local immutable install repaired missing setup, the two issue-specific regression suites, executable handler journey, and Astro docs build passed. The evidence shows Android no-dialog accept/dismiss forwarding a 15-second default and returning typed DIALOG_NOT_FOUND, explicit 120 seconds remaining accepted, and all three required documentation contracts rendering correctly. Screenshot capture was attempted but no browser was available, so actual rendered HTML was retained instead.

<details>
<summary>Evidence: Executable dialog-handler contract evidence</summary>

```text
{
  "acceptNoDialogAndroid": {
    "forwardedTimeoutMs": 15000,
    "result": {
      "ok": true,
      "data": {
        "tapped": false,
        "platform": "android",
        "triedLabels": [
          "Allow",
          "ALLOW",
          "While using the app",
          "Only this time",
          "OK",
          "Open",
          "Continue",
          "Yes"
        ],
        "attempts": [
          {
            "selector": "^(?:Allow|ALLOW|While using the app|Only this time|OK|Open|Continue|Yes)$"
          }
        ]
      },
      "meta": {
        "code": "DIALOG_NOT_FOUND",
        "warning": "No matching system dialog button found. The dialog may not be visible yet, or the button label differs from known variants. Call device_screenshot to verify the dialog is up, or pass a specific label."
      }
    }
  },
  "dismissNoDialogAndroid": {
    "forwardedTimeoutMs": 15000,
    "result": {
      "ok": true,
      "data": {
        "tapped": false,
        "platform": "android",
        "triedLabels": [
          "Deny",
          "DENY",
          "Cancel",
          "CANCEL",
          "No",
          "Not now"
        ],
        "attempts": [
          {
            "selector": "^(?:Deny|DENY|Cancel|CANCEL|No|Not now)$"
          }
        ]
      },
      "meta": {
        "code": "DIALOG_NOT_FOUND",
        "warning": "No matching system dialog button found. The dialog may not be visible yet, or the button label differs from known variants. Call device_screenshot to verify the dialog is up, or pass a specific label."
      }
    }
  },
  "explicitCallerTimeout": {
    "slug": "sys-accept",
    "platform": "android",
    "timeoutMs": 120000
  }
}
```
</details>
<details>
<summary>Evidence: Rendered device_accept_system_dialog documentation</summary>

```text
<!DOCTYPE html><html lang="en" dir="ltr" data-theme="dark" data-has-toc data-has-sidebar class="astro-tr7jhnh3"> <head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>device_accept_system_dialog | rn-dev-agent</title><link rel="canonical" href="https://lykhoyda.github.io/rn-dev-agent/tools/cdp/device_accept_system_dialog/"/><link rel="sitemap" href="/rn-dev-agent/sitemap-index.xml"/><script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareApplication","name":"rn-dev-agent","description":"Claude Code and Codex plugin for React Native development with 78 MCP tools for live app verification via Chrome DevTools Protocol.","applicationCategory":"DeveloperApplication","operatingSystem":"macOS, Linux","url":"https://lykhoyda.github.io/rn-dev-agent/","author":{"@type":"Person","name":"Anton Lykhoyda","url":"https://github.com/Lykhoyda"},"offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}</script><link rel="shortcut icon" href="/rn-dev-agent/favicon.svg" type="image/svg+xml"/><meta name="generator" content="Astro v6.4.8"/><meta name="generator" content="Starlight v0.38.5"/><meta property="og:title" content="device_accept_system_dialog"/><meta property="og:url" content="https://lykhoyda.github.io/rn-dev-agent/tools/cdp/device_accept_system_dialog/"/><meta property="og:locale" content="en"/><meta property="og:description" content="Tap an OS-level accept button on the exact session device"/><meta property="og:site_name" content="rn-dev-agent"/><meta name="description" content="Tap an OS-level accept button on the exact session device"/><meta name="keywords" content="react native, claude code, codex, plugin, mcp, chrome devtools protocol, expo, ios simulator, android emulator, ai testing, mobile development"/><meta property="og:image" content="https://lykhoyda.github.io/rn-dev-agent/og-image.png"/><meta property="og:type" content="website"/><meta name="twitter:card" content="summary_large_image"/><script>
	document.documentElement.dataset.theme = 'dark';
	try {
		localStorage.removeItem('starlight-theme');
	} catch {}
</script><link rel="stylesheet" href="_astro/print.DNXP8c50.css" media="print"><link rel="stylesheet" href="_astro/common.CbXEKOSo.css"><link rel="stylesheet" href="_astro/Code.CGHdpxzQ.css"><script type="module" src="_astro/page.B_tncCx8.js"></script></head> <body class="astro-tr7jhnh3"> <a href="#_top" class="astro-k5dwzo6t">Skip to content</a> <div class="page sl-flex astro-6godo7he"> <header class="header astro-6godo7he"><div class="header astro-lyyfhoxf"> <div class="title-wrapper sl-flex astro-lyyfhoxf"> <a href="/rn-dev-agent/" class="site-title sl-flex astro-fisvfjif">  <span class="astro-fisvfjif" translate="no"> rn-dev-agent </span> </a> </div> <div class="sl-flex print:hidden astro-lyyfhoxf"> <site-search class="astro-lyyfhoxf astro-m3qxhmob" data-translations="{&quot;placeholder&quot;:&quot;Search&quot;}"> <button data-open-modal disabled aria-label="Search" aria-keyshortcuts="Control+K" class="astro-m3qxhmob"> <svg aria-hidden="true" class="astro-m3qxhmob astro-xgpnebwa" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="--sl-icon-size: 1em;"><path d="M21.71 20.29 18 16.61A9 9 0 1 0 16.61 18l3.68 3.68a.999.999 0 0 0 1.42 0 1 1 0 0 0 0-1.39ZM11 18a7 7 0 1 1 0-14 7 7 0 0 1 0 14Z"/></svg> <span class="sl-hidden md:sl-block astro-m3qxhmob" aria-hidden="true">Search</span> <kbd class="sl-hidden md:sl-flex astro-m3qxhmob" style="display: none;"> <kbd class="astro-m3qxhmob">Ctrl</kbd><kbd class="astro-m3qxhmob">K</kbd> </kbd> </button> <dialog style="padding:0" aria-label="Search" class="astro-m3qxhmob"> <div class="dialog-frame sl-flex astro-m3qxhmob">  <button data-close-modal class="sl-flex md:sl-hidden astro-m3qxhmob"> Cancel </button> <div class="search-container astro-m3qxhmob"> <div id="starlight__search" class="astro-m3qxhmob"></div> </div> </div> </dialog> </site-search>  <script>
	(() => {
		const openBtn = document.querySelector('button[data-open-modal]');
		const shortcut = openBtn?.querySelector('kbd');
		if (!openBtn || !(shortcut instanceof HTMLElement)) return;
		const platformKey = shortcut.querySelector('kbd');
		if (platformKey && /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)) {
			platformKey.textContent = '⌘';
			openBtn.setAttribute('aria-keyshortcuts', 'Meta+K');
		}
		shortcut.style.display = '';
	})();
</script> <script type="module" src="_astro/Search.astro_astro_type_script_index_0_lang.CinqobZ0.js"></script>  </div> <div class="sl-hidden md:sl-flex print:hidden right-group astro-lyyfhoxf"> <div class="sl-flex social-icons astro-lyyfhoxf"> <a href="https://github.com/Lykhoyda/rn-dev-agent" rel="me" class="sl-flex astro-ej6vn57p"><span class="sr-only astro-ej6vn57p">GitHub</span><svg aria-hidden="true" class="astro-ej6vn57p astro-xgpnebwa" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="--sl-icon-size: 1em;"><path d="M12 .3a12 12 0 0 0-3.8 23.38c.6.12.83-.26.83-.57L9 21.07c-3.34.72-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.08-.74.09-.73.09-.73 1.2.09 1.83 1.24 1.83 1.24 1.08 1.83 2.81 1.3 3.5 1 .1-.78.42-1.31.76-1.61-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.14-.3-.54-1.52.1-3.18 0 0 1-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.28-1.55 3.29-1.23 3.29-1.23.64 1.66.24 2.88.12 3.18a4.65 4.65 0 0 1 1.23 3.22c0 4.61-2.8 5.63-5.48 5.92.42.36.81 1.1.81 2.22l-.01 3.29c0 .31.2.69.82.57A12 12 0 0 0 12 .3Z"/></svg></a> </div>  <script type="module">class s extends HTMLElement{constructor(){super();const e=this.querySelector("select");e&&(e.addEventListener("change",t=>{t.currentTarget instanceof HTMLSelectElement&&(window.location.pathname=t.currentTarget.value)}),window.addEventListener("pageshow",t=>{if(!t.persisted)return;const n=e.querySelector("option[selected]")?.index;n!==e.selectedIndex&&(e.selectedIndex=n??0)}))}}customElements.define("starlight-lang-select",s);</script> </div> </div></header> <nav class="sidebar print:hidden astro-6godo7he" aria-label="Main"> <starlight-menu-button class="print:hidden astro-qabje6pt"> <button aria-expanded="false" aria-label="Menu" aria-controls="starlight__sidebar" class="sl-flex md:sl-hidden astro-qabje6pt"> <svg aria-hidden="true" class="open-menu astro-qabje6pt astro-xgpnebwa" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="--sl-icon-size: 1em;"><path d="M3 8h18a1 1 0 1 0 0-2H3a1 1 0 0 0 0 2Zm18 8H3a1 1 0 0 0 0 2h18a1 1 0 0 0 0-2Zm0-5H3a1 1 0 0 0 0 2h18a1 1 0 0 0 0-2Z"/></svg> <svg aria-hidden="true" class="close-menu astro-qabje6pt astro-xgpnebwa" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="--sl-icon-size: 1em;"><path d="m13.41 12 6.3-6.29a1.004 1.004 0 1 0-1.42-1.42L12 10.59l-6.29-6.3a1.004 1.004 0 0 0-1.42 1.42l6.3 6.29-6.3 6.29a1 1 0 0 0 0 1.42.998.998 0 0 0 1.42 0l6.29-6.3 6.29 6.3a.999.999 0 0 0 1.42 0 1 1 0 0 0 0-1.42L13.41 12Z"/></svg> </button> </starlight-menu-button> <script type="module">class s extends HTMLElement{constructor(){super(),this.btn=this.querySelector("button"),this.btn.addEventListener("click",()=>this.toggleExpanded());const t=this.closest("nav");t&&t.addEventListener("keyup",e=>this.closeOnEscape(e))}setExpanded(t){this.setAttribute("aria-expanded",String(t)),document.body.toggleAttribute("data-mobile-menu-expanded",t)}toggleExpanded(){this.setExpanded(this.getAttribute("aria-expanded")!=="true")}closeOnEscape(t){t.code==="Escape"&&(this.setExpanded(!1),this.btn.focus())}}customElements.define("starlight-menu-button",s);</script>  <div id="starlight__sidebar" class="sidebar-pane astro-6godo7he"> <div class="sidebar-content sl-flex astro-6godo7he"> <sl-sidebar-state-persist data-hash="1uqna7r" class="astro-jmffp742"> <script aria-hidden="true">
		(() => {
			try {
				if (!matchMedia('(min-width: 50em)').matches) return;
				/** @type {HTMLElement | null} */
				const target = document.querySelector('sl-sidebar-state-persist');
				const state = JSON.parse(sessionStorage.getItem('sl-sidebar-state') || '0');
				if (!target || !state || target.dataset.hash !== state.hash) return;
				window._starlightScrollRestore = state.scroll;
				customElements

... [30021 bytes truncated] ...

Selector("sl-sidebar-restore"),r=parseInt(s?.dataset.index||"");isNaN(r)||l(!e.open,r)});addEventListener("visibilitychange",()=>{document.visibilityState==="hidden"&&d()});addEventListener("pageHide",d);</script> <div class="lg:sl-flex astro-yxrehrny"> <aside class="right-sidebar-container print:hidden astro-yxrehrny"> <div class="right-sidebar astro-yxrehrny"> <div class="lg:sl-hidden astro-hy3umtwt"><mobile-starlight-toc data-min-h="2" data-max-h="3" class="astro-vzpn72bm"><nav aria-labelledby="starlight__on-this-page--mobile" class="astro-vzpn72bm"><details id="starlight__mobile-toc" class="astro-vzpn72bm"><summary id="starlight__on-this-page--mobile" class="sl-flex astro-vzpn72bm"><span class="toggle sl-flex astro-vzpn72bm">On this page<svg aria-hidden="true" class="caret astro-vzpn72bm astro-xgpnebwa" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="--sl-icon-size: 1rem;"><path d="m14.83 11.29-4.24-4.24a1 1 0 1 0-1.42 1.41L12.71 12l-3.54 3.54a1 1 0 0 0 0 1.41 1 1 0 0 0 .71.29 1 1 0 0 0 .71-.29l4.24-4.24a1.002 1.002 0 0 0 0-1.42Z"/></svg></span><span class="display-current astro-vzpn72bm"></span></summary><div class="dropdown astro-vzpn72bm"><ul class="isMobile astro-x7byebxn" style="--depth: 0;"> <li class="astro-x7byebxn" style="--depth: 0;"> <a href="#_top" class="astro-x7byebxn" style="--depth: 0;"> <span class="astro-x7byebxn" style="--depth: 0;">Overview</span> </a>  </li><li class="astro-x7byebxn" style="--depth: 0;"> <a href="#parameters" class="astro-x7byebxn" style="--depth: 0;"> <span class="astro-x7byebxn" style="--depth: 0;">Parameters</span> </a>  </li><li class="astro-x7byebxn" style="--depth: 0;"> <a href="#usage" class="astro-x7byebxn" style="--depth: 0;"> <span class="astro-x7byebxn" style="--depth: 0;">Usage</span> </a>  </li> </ul></div></details></nav></mobile-starlight-toc><script type="module" src="_astro/MobileTableOfContents.astro_astro_type_script_index_0_lang.hwBsy0Mo.js"></script></div><div class="right-sidebar-panel sl-hidden lg:sl-block astro-hy3umtwt"><div class="sl-container astro-hy3umtwt"><starlight-toc data-min-h="2" data-max-h="3"><nav aria-labelledby="starlight__on-this-page"><h2 id="starlight__on-this-page">On this page</h2><ul class="astro-x7byebxn" style="--depth: 0;"> <li class="astro-x7byebxn" style="--depth: 0;"> <a href="#_top" class="astro-x7byebxn" style="--depth: 0;"> <span class="astro-x7byebxn" style="--depth: 0;">Overview</span> </a>  </li><li class="astro-x7byebxn" style="--depth: 0;"> <a href="#parameters" class="astro-x7byebxn" style="--depth: 0;"> <span class="astro-x7byebxn" style="--depth: 0;">Parameters</span> </a>  </li><li class="astro-x7byebxn" style="--depth: 0;"> <a href="#usage" class="astro-x7byebxn" style="--depth: 0;"> <span class="astro-x7byebxn" style="--depth: 0;">Usage</span> </a>  </li> </ul></nav></starlight-toc><script type="module" src="_astro/TableOfContents.astro_astro_type_script_index_0_lang.FuRcXuRY.js"></script></div></div> </div> </aside> <div class="main-pane astro-yxrehrny">  <main data-pagefind-body class="astro-tr7jhnh3" lang="en" dir="ltr">    <div class="content-panel astro-vd5l4jrn"> <div class="sl-container astro-vd5l4jrn"> <p class="page-kicker astro-guvttfii">Reference</p><h1 id="_top" class="astro-ai7cxo7a">device_accept_system_dialog</h1> </div> </div> <div class="content-panel astro-vd5l4jrn"> <div class="sl-container astro-vd5l4jrn"> <div class="sl-markdown-content"> <p>Tap an OS-level accept button on the exact session device. iOS prefers the capability-bound native runner so SpringBoard-owned dialogs are reachable; DIALOG_BUTTON_NOT_FOUND returns availableButtons for an exact-label retry.</p>
<div class="sl-heading-wrapper level-h2"><h2 id="parameters">Parameters</h2><a class="sl-anchor-link" href="#parameters"><span aria-hidden="true" class="sl-anchor-icon"><svg width="16" height="16" viewBox="0 0 24 24"><path fill="currentcolor" d="m12.11 15.39-3.88 3.88a2.52 2.52 0 0 1-3.5 0 2.47 2.47 0 0 1 0-3.5l3.88-3.88a1 1 0 0 0-1.42-1.42l-3.88 3.89a4.48 4.48 0 0 0 6.33 6.33l3.89-3.88a1 1 0 1 0-1.42-1.42Zm8.58-12.08a4.49 4.49 0 0 0-6.33 0l-3.89 3.88a1 1 0 0 0 1.42 1.42l3.88-3.88a2.52 2.52 0 0 1 3.5 0 2.47 2.47 0 0 1 0 3.5l-3.88 3.88a1 1 0 1 0 1.42 1.42l3.88-3.89a4.49 4.49 0 0 0 0-6.33ZM8.83 15.17a1 1 0 0 0 1.1.22 1 1 0 0 0 .32-.22l4.92-4.92a1 1 0 0 0-1.42-1.42l-4.92 4.92a1 1 0 0 0 0 1.42Z"></path></svg></span><span class="sr-only" data-pagefind-ignore>Section titled “Parameters”</span></a></div>





































<table><thead><tr><th>Name</th><th>Type</th><th>Required</th><th>Default</th><th>Constraints</th><th>Description</th></tr></thead><tbody><tr><td><code dir="auto">label</code></td><td><code dir="auto">string</code></td><td>No</td><td></td><td></td><td>Specific button label to tap. Omit to try common defaults (Allow, OK, Open, Continue, Yes, Accept).</td></tr><tr><td><code dir="auto">platform</code></td><td><code dir="auto">enum: ios | android</code></td><td>No</td><td></td><td></td><td>Authority-bound platform; conflicting values are refused</td></tr><tr><td><code dir="auto">timeoutMs</code></td><td><code dir="auto">number</code></td><td>No</td><td></td><td>min: 1000, max: 120000, integer</td><td>Whole fallback Maestro timeout (default 15000ms; explicit values up to 120000 accepted). Native iOS runner path is preferred.</td></tr></tbody></table>
<div class="sl-heading-wrapper level-h2"><h2 id="usage">Usage</h2><a class="sl-anchor-link" href="#usage"><span aria-hidden="true" class="sl-anchor-icon"><svg width="16" height="16" viewBox="0 0 24 24"><path fill="currentcolor" d="m12.11 15.39-3.88 3.88a2.52 2.52 0 0 1-3.5 0 2.47 2.47 0 0 1 0-3.5l3.88-3.88a1 1 0 0 0-1.42-1.42l-3.88 3.89a4.48 4.48 0 0 0 6.33 6.33l3.89-3.88a1 1 0 1 0-1.42-1.42Zm8.58-12.08a4.49 4.49 0 0 0-6.33 0l-3.89 3.88a1 1 0 0 0 1.42 1.42l3.88-3.88a2.52 2.52 0 0 1 3.5 0 2.47 2.47 0 0 1 0 3.5l-3.88 3.88a1 1 0 1 0 1.42 1.42l3.88-3.89a4.49 4.49 0 0 0 0-6.33ZM8.83 15.17a1 1 0 0 0 1.1.22 1 1 0 0 0 .32-.22l4.92-4.92a1 1 0 0 0-1.42-1.42l-4.92 4.92a1 1 0 0 0 0 1.42Z"></path></svg></span><span class="sr-only" data-pagefind-ignore>Section titled “Usage”</span></a></div>
<div class="expressive-code"><link rel="stylesheet" href="_astro/ec.wrlno.css"><script type="module" src="_astro/ec.0vx5m.js"></script><figure class="frame not-content"><figcaption class="header"></figcaption><pre data-language="plaintext"><code><div class="ec-line"><div class="code"><span style="--0:#e1e4e8">device_accept_system_dialog()</span></div></div></code></pre><div class="copy"><div aria-live="polite"></div><button title="Copy to clipboard" data-copied="Copied!" data-code="device_accept_system_dialog()"><div></div></button></div></figure></div> </div> <footer class="sl-flex astro-xfdhunca"> <div class="meta sl-flex astro-xfdhunca">   </div> <div class="pagination-links print:hidden astro-mkmkm45e" dir="ltr"> <a href="/rn-dev-agent/tools/cdp/cross_platform_verify/" rel="prev" class="astro-mkmkm45e"> <svg aria-hidden="true" class="astro-mkmkm45e astro-xgpnebwa" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="--sl-icon-size: 1.5rem;"><path d="M17 11H9.41l3.3-3.29a1.004 1.004 0 1 0-1.42-1.42l-5 5a1 1 0 0 0-.21.33 1 1 0 0 0 0 .76 1 1 0 0 0 .21.33l5 5a1.002 1.002 0 0 0 1.639-.325 1 1 0 0 0-.219-1.095L9.41 13H17a1 1 0 0 0 0-2Z"/></svg> <span class="astro-mkmkm45e"> Previous <br class="astro-mkmkm45e"> <span class="link-title astro-mkmkm45e">cross_platform_verify</span> </span> </a> <a href="/rn-dev-agent/tools/cdp/device_deeplink/" rel="next" class="astro-mkmkm45e"> <svg aria-hidden="true" class="astro-mkmkm45e astro-xgpnebwa" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="--sl-icon-size: 1.5rem;"><path d="M17.92 11.62a1.001 1.001 0 0 0-.21-.33l-5-5a1.003 1.003 0 1 0-1.42 1.42l3.3 3.29H7a1 1 0 0 0 0 2h7.59l-3.3 3.29a1.002 1.002 0 0 0 .325 1.639 1 1 0 0 0 1.095-.219l5-5a1 1 0 0 0 .21-.33 1 1 0 0 0 0-.76Z"/></svg> <span class="astro-mkmkm45e"> Next <br class="astro-mkmkm45e"> <span class="link-title astro-mkmkm45e">device_deeplink</span> </span> </a> </div>  </footer> </div> </div>  </main> </div> </div> </div> </div> </body></html>
```
</details>
- Evidence: Rendered device_find documentation (local file: <code>/Users/antonlykhoyda/.no-mistakes/evidence/01M0WYPJS8JX8K5EQV54ZZXJ76/docs-render/device_find.html</code>)
- Evidence: Rendered cdp_run_action documentation (local file: <code>/Users/antonlykhoyda/.no-mistakes/evidence/01M0WYPJS8JX8K5EQV54ZZXJ76/docs-render/cdp_run_action.html</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6e65fd748292f13d874d73831c0c34edae517fcd","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) ✅</summary>

- ⚠️ `apps/docs-site/scripts/generate-tool-docs.mjs:250` - Recovered descriptions are emitted as raw TypeScript literal text rather than their decoded values. For example, device_dismiss_system_dialog now publishes `Don\\u2019t Allow`, while cdp_dispatch and cdp_repair_action expose literal backslashes around apostrophes. Decode the proven string-literal escape forms when extracting `.describe()` arguments before passing descriptions to `escapeMdx`.

🔧 Fix: Decode supported tool description escapes
2 warnings still open:
- ⚠️ `apps/docs-site/scripts/generate-tool-docs.mjs:137` - `splitTopLevel` treats every quote preceded by `\` as escaped, without checking escape parity. A supported description such as `.describe(&#39;Path ends in \\&#39;)` therefore never closes during schema splitting and can merge subsequent parameters, so the decoder-only test passes while extraction still fails. Skip escape pairs or count consecutive preceding backslashes at this shared scanner boundary and exercise the real generator path.
- ⚠️ `apps/docs-site/scripts/generate-tool-docs.mjs:108` - Decoding `\n` or `\u007C` produces structural Markdown characters, but parameter descriptions are interpolated directly into a single table row. For example, `.describe(&#39;First\nSecond&#39;)` splits the row, while `.describe(&#39;A\u007CB&#39;)` adds a column, silently corrupting generated docs. Encode decoded line breaks and table delimiters at the MDX cell-rendering boundary.

🔧 Fix: Harden description parsing and table escaping
1 warning still open:
- ⚠️ `apps/docs-site/scripts/generate-tool-docs.mjs:336` - Recovered enum types are interpolated with raw `|` characters, which GFM treats as table delimiters even inside code spans. For example, `device_accept_system_dialog.platform` and `cdp_console_log.level` now split into extra columns instead of rendering a complete type. Escape pipes in `p.type` at the table-cell boundary and cover a generated wrapped-enum row through the real generator.

🔧 Fix: Escape enum unions in generated tables
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`corepack yarn install --immutable` — repaired the isolated worktree’s missing dependency state after the initial build attempt was blocked.</code>
- `corepack yarn build:core`
- `node --test packages/rn-dev-agent-core/test/unit/gh-816-system-dialog-timeout.test.ts packages/rn-dev-agent-core/test/unit/gh-816-tool-docs-generator.test.ts`
- <code>Executed the built dialog handlers through their test seam and recorded default accept/dismiss timeouts of 15000ms, typed `DIALOG_NOT_FOUND` responses, and an unchanged explicit 120000ms timeout.</code>
- <code>`corepack yarn build:docs` — regenerated and statically rendered the affected Astro documentation pages.</code>
- <code>Started `corepack yarn workspace rn-dev-agent-docs dev --host 127.0.0.1` and confirmed Astro served the generated site.</code>
- `Attempted browser-backed screenshot capture; browser discovery returned no available browser, so the actual emitted HTML pages were preserved as reviewer-visible evidence instead.`
- <code>Verified the evidence HTML contains the documented `timeoutMs: number`, `device_find.index: number`, and required `cdp_run_action.actionId: string` contracts.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR bounds system-dialog Maestro fallback waits while retaining explicit timeout values, and broadens the documentation generator to recover wrapped Zod contracts.
- Adds a 15-second default for accept/dismiss dialog fallback probes and regression coverage.
- Decodes supported description escapes, parses wrapped schema chains, and escapes generated table content.
- Regenerates tool-reference MDX and committed Claude/Codex host runtime bundles.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking generator hardening issue for escaped newlines in top-level tool descriptions.

The dialog timeout behavior and committed outputs align with the intended contract; only the newly supported escape decoder can emit an unescaped line break into YAML frontmatter under an additional description form.

**Files Needing Attention:** apps/docs-site/scripts/generate-tool-docs.mjs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/rn-dev-agent-core/src/tools/device-system-dialog.ts | Adds the bounded fallback default while preserving runner-first behavior and explicit timeout forwarding. |
| packages/rn-dev-agent-core/src/index.ts | Updates the public timeout schema descriptions without widening the accepted 120-second maximum. |
| apps/docs-site/scripts/generate-tool-docs.mjs | Recovers wrapped Zod metadata and safely escapes table content, but decoded newlines remain unsafe in YAML frontmatter descriptions. |
| packages/rn-dev-agent-core/test/unit/gh-816-system-dialog-timeout.test.ts | Covers omitted accept/dismiss timeouts and preservation of an explicit 120-second value. |
| packages/rn-dev-agent-core/test/unit/gh-816-tool-docs-generator.test.ts | Exercises wrapped expressions, decoded escape forms, and structural table escaping through the real generator. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Dialog tool call] --> B{Native iOS runner succeeds?}
  B -->|Yes| C[Return native result]
  B -->|No| D{timeoutMs supplied?}
  D -->|Yes| E[Forward caller timeout]
  D -->|No| F[Use 15000 ms default]
  E --> G[Maestro fallback]
  F --> G
  G --> H[Typed dialog result]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["no-mistakes(document): Polish dialog doc..."](https://github.com/lykhoyda/rn-dev-agent/commit/6e65fd748292f13d874d73831c0c34edae517fcd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56760660)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->