### PR TITLE
fix(core): harden Observe request body handling

### DIFF
--- a/.changeset/observe-body-utf8-413.md
+++ b/.changeset/observe-body-utf8-413.md
@@ -1,0 +1,6 @@
+---
+"rn-dev-agent-core": patch
+"rn-dev-agent-plugin": patch
+---
+
+Fix Observe HTTP request-body handling (GH #818): decode bodies with a streaming StringDecoder so a multi-byte UTF-8 code point split across TCP chunks survives intact instead of becoming replacement characters, and stop destroying the request socket when the 64 KiB byte limit is exceeded — oversized bodies are now drained to completion so callers receive the parseable JSON 413 over a usable keep-alive connection without the action/run handlers being invoked. Adds raw-socket regressions for both affected e2e endpoints.

--- a/.changeset/observe-body-utf8-413.md
+++ b/.changeset/observe-body-utf8-413.md
@@ -3,4 +3,4 @@
 "rn-dev-agent-plugin": patch
 ---
 
-Fix Observe HTTP request-body handling (GH #818): decode bodies with a streaming StringDecoder so a multi-byte UTF-8 code point split across TCP chunks survives intact instead of becoming replacement characters, and stop destroying the request socket when the 64 KiB byte limit is exceeded — oversized bodies are now drained to completion so callers receive the parseable JSON 413 over a usable keep-alive connection without the action/run handlers being invoked. Adds raw-socket regressions for both affected e2e endpoints.
+Fix Observe HTTP request-body handling by preserving multi-byte UTF-8 code points split across TCP chunks and draining oversized bodies while returning parseable JSON 413 responses over usable keep-alive connections.

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -89364,15 +89364,7 @@ var ObservabilityServer = class {
       res.end("SPA bundle not built \u2014 run npm run build:web");
     }
   }
-  // Bounded body read that can never become an unhandled rejection —
-  // handle() fire-and-forgets the async routes, so a rejecting await here
-  // would crash the process on an oversized/aborted request (GH #438 review).
-  // GH #818: decode with a streaming StringDecoder so a multi-byte UTF-8
-  // code point split across TCP chunks survives intact (per-chunk
-  // toString() corrupts split points), and never destroy() the request —
-  // an oversized body is drained to its 'end' so the JSON 413 response can
-  // still be delivered over a usable connection. The 64 KiB limit stays
-  // byte-based; accumulation stops there, so memory remains bounded.
+  // Bounded body read that settles safely while handle() fire-and-forgets async routes.
   readBody(req) {
     return new Promise((resolve20) => {
       const decoder = new StringDecoder("utf8");
@@ -89385,6 +89377,7 @@ var ObservabilityServer = class {
         bytes += chunk.length;
         if (bytes > 65536) {
           oversized = true;
+          resolve20(null);
           return;
         }
         body += decoder.write(chunk);

--- a/packages/claude-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/index.js
@@ -89015,6 +89015,7 @@ init_utils();
 
 // packages/rn-dev-agent-core/dist/observability/server.js
 import { createServer as createServer3 } from "node:http";
+import { StringDecoder } from "node:string_decoder";
 import { readFileSync as readFileSync38 } from "node:fs";
 import { fileURLToPath as fileURLToPath6 } from "node:url";
 import { dirname as dirname29, join as join54 } from "node:path";
@@ -89366,20 +89367,29 @@ var ObservabilityServer = class {
   // Bounded body read that can never become an unhandled rejection —
   // handle() fire-and-forgets the async routes, so a rejecting await here
   // would crash the process on an oversized/aborted request (GH #438 review).
+  // GH #818: decode with a streaming StringDecoder so a multi-byte UTF-8
+  // code point split across TCP chunks survives intact (per-chunk
+  // toString() corrupts split points), and never destroy() the request —
+  // an oversized body is drained to its 'end' so the JSON 413 response can
+  // still be delivered over a usable connection. The 64 KiB limit stays
+  // byte-based; accumulation stops there, so memory remains bounded.
   readBody(req) {
     return new Promise((resolve20) => {
+      const decoder = new StringDecoder("utf8");
       let body = "";
       let bytes = 0;
+      let oversized = false;
       req.on("data", (chunk) => {
+        if (oversized)
+          return;
         bytes += chunk.length;
         if (bytes > 65536) {
-          req.destroy();
-          resolve20(null);
+          oversized = true;
           return;
         }
-        body += chunk.toString();
+        body += decoder.write(chunk);
       });
-      req.on("end", () => resolve20(body));
+      req.on("end", () => resolve20(oversized ? null : body + decoder.end()));
       req.on("error", () => resolve20(null));
     });
   }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -90944,6 +90944,7 @@ var init_observe_project_root = __esm({
 
 // packages/rn-dev-agent-core/dist/observability/server.js
 import { createServer as createServer3 } from "node:http";
+import { StringDecoder } from "node:string_decoder";
 import { readFileSync as readFileSync38 } from "node:fs";
 import { fileURLToPath as fileURLToPath6 } from "node:url";
 import { dirname as dirname31, join as join55 } from "node:path";
@@ -91231,20 +91232,29 @@ var init_server3 = __esm({
       // Bounded body read that can never become an unhandled rejection —
       // handle() fire-and-forgets the async routes, so a rejecting await here
       // would crash the process on an oversized/aborted request (GH #438 review).
+      // GH #818: decode with a streaming StringDecoder so a multi-byte UTF-8
+      // code point split across TCP chunks survives intact (per-chunk
+      // toString() corrupts split points), and never destroy() the request —
+      // an oversized body is drained to its 'end' so the JSON 413 response can
+      // still be delivered over a usable connection. The 64 KiB limit stays
+      // byte-based; accumulation stops there, so memory remains bounded.
       readBody(req) {
         return new Promise((resolve21) => {
+          const decoder = new StringDecoder("utf8");
           let body = "";
           let bytes = 0;
+          let oversized = false;
           req.on("data", (chunk) => {
+            if (oversized)
+              return;
             bytes += chunk.length;
             if (bytes > 65536) {
-              req.destroy();
-              resolve21(null);
+              oversized = true;
               return;
             }
-            body += chunk.toString();
+            body += decoder.write(chunk);
           });
-          req.on("end", () => resolve21(body));
+          req.on("end", () => resolve21(oversized ? null : body + decoder.end()));
           req.on("error", () => resolve21(null));
         });
       }

--- a/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -91229,15 +91229,7 @@ var init_server3 = __esm({
           res.end("SPA bundle not built \u2014 run npm run build:web");
         }
       }
-      // Bounded body read that can never become an unhandled rejection —
-      // handle() fire-and-forgets the async routes, so a rejecting await here
-      // would crash the process on an oversized/aborted request (GH #438 review).
-      // GH #818: decode with a streaming StringDecoder so a multi-byte UTF-8
-      // code point split across TCP chunks survives intact (per-chunk
-      // toString() corrupts split points), and never destroy() the request —
-      // an oversized body is drained to its 'end' so the JSON 413 response can
-      // still be delivered over a usable connection. The 64 KiB limit stays
-      // byte-based; accumulation stops there, so memory remains bounded.
+      // Bounded body read that settles safely while handle() fire-and-forgets async routes.
       readBody(req) {
         return new Promise((resolve21) => {
           const decoder = new StringDecoder("utf8");
@@ -91250,6 +91242,7 @@ var init_server3 = __esm({
             bytes += chunk.length;
             if (bytes > 65536) {
               oversized = true;
+              resolve21(null);
               return;
             }
             body += decoder.write(chunk);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -89364,15 +89364,7 @@ var ObservabilityServer = class {
       res.end("SPA bundle not built \u2014 run npm run build:web");
     }
   }
-  // Bounded body read that can never become an unhandled rejection —
-  // handle() fire-and-forgets the async routes, so a rejecting await here
-  // would crash the process on an oversized/aborted request (GH #438 review).
-  // GH #818: decode with a streaming StringDecoder so a multi-byte UTF-8
-  // code point split across TCP chunks survives intact (per-chunk
-  // toString() corrupts split points), and never destroy() the request —
-  // an oversized body is drained to its 'end' so the JSON 413 response can
-  // still be delivered over a usable connection. The 64 KiB limit stays
-  // byte-based; accumulation stops there, so memory remains bounded.
+  // Bounded body read that settles safely while handle() fire-and-forgets async routes.
   readBody(req) {
     return new Promise((resolve20) => {
       const decoder = new StringDecoder("utf8");
@@ -89385,6 +89377,7 @@ var ObservabilityServer = class {
         bytes += chunk.length;
         if (bytes > 65536) {
           oversized = true;
+          resolve20(null);
           return;
         }
         body += decoder.write(chunk);

--- a/packages/codex-plugin/rn-dev-agent-core/dist/index.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/index.js
@@ -89015,6 +89015,7 @@ init_utils();
 
 // packages/rn-dev-agent-core/dist/observability/server.js
 import { createServer as createServer3 } from "node:http";
+import { StringDecoder } from "node:string_decoder";
 import { readFileSync as readFileSync38 } from "node:fs";
 import { fileURLToPath as fileURLToPath6 } from "node:url";
 import { dirname as dirname29, join as join54 } from "node:path";
@@ -89366,20 +89367,29 @@ var ObservabilityServer = class {
   // Bounded body read that can never become an unhandled rejection —
   // handle() fire-and-forgets the async routes, so a rejecting await here
   // would crash the process on an oversized/aborted request (GH #438 review).
+  // GH #818: decode with a streaming StringDecoder so a multi-byte UTF-8
+  // code point split across TCP chunks survives intact (per-chunk
+  // toString() corrupts split points), and never destroy() the request —
+  // an oversized body is drained to its 'end' so the JSON 413 response can
+  // still be delivered over a usable connection. The 64 KiB limit stays
+  // byte-based; accumulation stops there, so memory remains bounded.
   readBody(req) {
     return new Promise((resolve20) => {
+      const decoder = new StringDecoder("utf8");
       let body = "";
       let bytes = 0;
+      let oversized = false;
       req.on("data", (chunk) => {
+        if (oversized)
+          return;
         bytes += chunk.length;
         if (bytes > 65536) {
-          req.destroy();
-          resolve20(null);
+          oversized = true;
           return;
         }
-        body += chunk.toString();
+        body += decoder.write(chunk);
       });
-      req.on("end", () => resolve20(body));
+      req.on("end", () => resolve20(oversized ? null : body + decoder.end()));
       req.on("error", () => resolve20(null));
     });
   }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -90944,6 +90944,7 @@ var init_observe_project_root = __esm({
 
 // packages/rn-dev-agent-core/dist/observability/server.js
 import { createServer as createServer3 } from "node:http";
+import { StringDecoder } from "node:string_decoder";
 import { readFileSync as readFileSync38 } from "node:fs";
 import { fileURLToPath as fileURLToPath6 } from "node:url";
 import { dirname as dirname31, join as join55 } from "node:path";
@@ -91231,20 +91232,29 @@ var init_server3 = __esm({
       // Bounded body read that can never become an unhandled rejection —
       // handle() fire-and-forgets the async routes, so a rejecting await here
       // would crash the process on an oversized/aborted request (GH #438 review).
+      // GH #818: decode with a streaming StringDecoder so a multi-byte UTF-8
+      // code point split across TCP chunks survives intact (per-chunk
+      // toString() corrupts split points), and never destroy() the request —
+      // an oversized body is drained to its 'end' so the JSON 413 response can
+      // still be delivered over a usable connection. The 64 KiB limit stays
+      // byte-based; accumulation stops there, so memory remains bounded.
       readBody(req) {
         return new Promise((resolve21) => {
+          const decoder = new StringDecoder("utf8");
           let body = "";
           let bytes = 0;
+          let oversized = false;
           req.on("data", (chunk) => {
+            if (oversized)
+              return;
             bytes += chunk.length;
             if (bytes > 65536) {
-              req.destroy();
-              resolve21(null);
+              oversized = true;
               return;
             }
-            body += chunk.toString();
+            body += decoder.write(chunk);
           });
-          req.on("end", () => resolve21(body));
+          req.on("end", () => resolve21(oversized ? null : body + decoder.end()));
           req.on("error", () => resolve21(null));
         });
       }

--- a/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
+++ b/packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js
@@ -91229,15 +91229,7 @@ var init_server3 = __esm({
           res.end("SPA bundle not built \u2014 run npm run build:web");
         }
       }
-      // Bounded body read that can never become an unhandled rejection —
-      // handle() fire-and-forgets the async routes, so a rejecting await here
-      // would crash the process on an oversized/aborted request (GH #438 review).
-      // GH #818: decode with a streaming StringDecoder so a multi-byte UTF-8
-      // code point split across TCP chunks survives intact (per-chunk
-      // toString() corrupts split points), and never destroy() the request —
-      // an oversized body is drained to its 'end' so the JSON 413 response can
-      // still be delivered over a usable connection. The 64 KiB limit stays
-      // byte-based; accumulation stops there, so memory remains bounded.
+      // Bounded body read that settles safely while handle() fire-and-forgets async routes.
       readBody(req) {
         return new Promise((resolve21) => {
           const decoder = new StringDecoder("utf8");
@@ -91250,6 +91242,7 @@ var init_server3 = __esm({
             bytes += chunk.length;
             if (bytes > 65536) {
               oversized = true;
+              resolve21(null);
               return;
             }
             body += decoder.write(chunk);

--- a/packages/rn-dev-agent-core/src/observability/server.ts
+++ b/packages/rn-dev-agent-core/src/observability/server.ts
@@ -322,15 +322,7 @@ export class ObservabilityServer {
     }
   }
 
-  // Bounded body read that can never become an unhandled rejection —
-  // handle() fire-and-forgets the async routes, so a rejecting await here
-  // would crash the process on an oversized/aborted request (GH #438 review).
-  // GH #818: decode with a streaming StringDecoder so a multi-byte UTF-8
-  // code point split across TCP chunks survives intact (per-chunk
-  // toString() corrupts split points), and never destroy() the request —
-  // an oversized body is drained to its 'end' so the JSON 413 response can
-  // still be delivered over a usable connection. The 64 KiB limit stays
-  // byte-based; accumulation stops there, so memory remains bounded.
+  // Bounded body read that settles safely while handle() fire-and-forgets async routes.
   private readBody(req: IncomingMessage): Promise<string | null> {
     return new Promise((resolve) => {
       const decoder = new StringDecoder('utf8');
@@ -342,6 +334,7 @@ export class ObservabilityServer {
         bytes += chunk.length;
         if (bytes > 65536) {
           oversized = true;
+          resolve(null);
           return;
         }
         body += decoder.write(chunk);

--- a/packages/rn-dev-agent-core/src/observability/server.ts
+++ b/packages/rn-dev-agent-core/src/observability/server.ts
@@ -1,4 +1,5 @@
 import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'node:http';
+import { StringDecoder } from 'node:string_decoder';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -324,20 +325,28 @@ export class ObservabilityServer {
   // Bounded body read that can never become an unhandled rejection —
   // handle() fire-and-forgets the async routes, so a rejecting await here
   // would crash the process on an oversized/aborted request (GH #438 review).
+  // GH #818: decode with a streaming StringDecoder so a multi-byte UTF-8
+  // code point split across TCP chunks survives intact (per-chunk
+  // toString() corrupts split points), and never destroy() the request —
+  // an oversized body is drained to its 'end' so the JSON 413 response can
+  // still be delivered over a usable connection. The 64 KiB limit stays
+  // byte-based; accumulation stops there, so memory remains bounded.
   private readBody(req: IncomingMessage): Promise<string | null> {
     return new Promise((resolve) => {
+      const decoder = new StringDecoder('utf8');
       let body = '';
       let bytes = 0;
+      let oversized = false;
       req.on('data', (chunk: Buffer) => {
+        if (oversized) return; // drain without accumulating
         bytes += chunk.length;
         if (bytes > 65536) {
-          req.destroy();
-          resolve(null);
+          oversized = true;
           return;
         }
-        body += chunk.toString();
+        body += decoder.write(chunk);
       });
-      req.on('end', () => resolve(body));
+      req.on('end', () => resolve(oversized ? null : body + decoder.end()));
       req.on('error', () => resolve(null));
     });
   }

--- a/packages/rn-dev-agent-core/test/unit/observability/request-body-utf8-and-413.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/observability/request-body-utf8-and-413.test.ts
@@ -1,0 +1,375 @@
+import assert from 'node:assert/strict';
+import net from 'node:net';
+import { test } from 'node:test';
+import { ObservabilityServer, type E2eServerDeps } from '../../../dist/observability/server.js';
+import { recorder } from '../../../dist/observability/recorder.js';
+
+// GH #818 regressions, driven through the real HTTP server over a raw TCP
+// socket so the test controls chunk boundaries exactly:
+//
+//   Defect 1 (initiating trigger): readBody() decoded each Buffer with
+//   per-chunk toString(); the emoji split across writes became U+FFFD
+//   replacement characters. (Masking condition: ASCII-only payloads and
+//   chunk-aligned multi-byte sequences decode fine, so small bodies in a
+//   single TCP segment hid it. Visible symptom: multilingual learned-action
+//   parameters arrive mangled.) Smallest counterfactual — decode with a
+//   streaming StringDecoder and the emoji survives.
+//
+//   Defect 2 (initiating trigger): readBody() called req.destroy() on the
+//   64 KiB overflow before its callers emitted JSON 413, so clients saw a
+//   connection reset instead of the structured error. (Masking condition:
+//   fetch reports a generic network error that looks like any other
+//   transport failure. Visible symptom: no parseable 413 reaches callers.)
+//   Disconfirming evidence checked before committing to this cause: CSRF
+//   (403), malformed-JSON (400), and ASCII paths all behaved correctly on
+//   the same build, and the server itself stayed alive after an oversized
+//   request — only the request socket was destroyed.
+
+const EMOJI = '\u{1F600}'; // U+1F600 = F0 9F 98 80
+
+function e2eDeps(): { deps: E2eServerDeps; calls: { run: number; action: number } } {
+  const calls = { run: 0, action: 0 };
+  return {
+    calls,
+    deps: {
+      token: 'tok1',
+      triggerRun: async (pattern) => {
+        calls.run += 1;
+        return { ok: true, data: { pattern } };
+      },
+      listRuns: async () => [],
+      loadRun: async () => null,
+      listActions: async () => [],
+      runAction: async (actionId, params) => {
+        calls.action += 1;
+        return { ok: true, actionId, params };
+      },
+    },
+  };
+}
+
+interface SocketTarget {
+  host: string;
+  port: number;
+}
+
+function socketTarget(url: string): SocketTarget {
+  const u = new URL(url);
+  return { host: u.hostname, port: Number(u.port) };
+}
+
+/** Raw-socket POST whose body arrives as two TCP segments. */
+function rawPost(
+  target: SocketTarget,
+  firstSegment: Buffer,
+  secondSegment: Buffer,
+): Promise<Buffer | null> {
+  return new Promise((resolve) => {
+    const sock = net.connect(target.port, target.host);
+    // Disable Nagle so the first segment goes out immediately and cannot
+    // coalesce with the second — the split must survive server-side.
+    sock.setNoDelay(true);
+    const chunks: Buffer[] = [];
+    let settled = false;
+    const done = (v: Buffer | null) => {
+      if (!settled) {
+        settled = true;
+        resolve(v);
+      }
+    };
+    sock.on('connect', () => {
+      sock.write(firstSegment);
+      setTimeout(() => {
+        sock.write(secondSegment);
+        sock.end();
+      }, 50);
+    });
+    sock.on('data', (c) => chunks.push(c));
+    sock.on('close', () => done(chunks.length ? Buffer.concat(chunks) : null));
+    sock.on('error', () => done(chunks.length ? Buffer.concat(chunks) : null));
+    setTimeout(() => done(chunks.length ? Buffer.concat(chunks) : null), 5_000);
+  });
+}
+
+/**
+ * Two sequential HTTP/1.1 keep-alive requests on ONE raw socket. Request 1's
+ * body arrives as two TCP segments (with Nagle disabled); once its response
+ * completes, request 2 (a full raw request buffer) is sent on the same
+ * connection. Resolves with each response's raw bytes.
+ */
+function rawTwoRequests(
+  target: SocketTarget,
+  firstSegment: Buffer,
+  secondSegment: Buffer,
+  secondRawRequest: Buffer,
+): Promise<[Buffer | null, Buffer | null]> {
+  return new Promise((resolve) => {
+    const sock = net.connect(target.port, target.host);
+    sock.setNoDelay(true);
+    const chunks: Buffer[] = [];
+    let firstDone = false;
+    let settled = false;
+    const done = (v: [Buffer | null, Buffer | null]) => {
+      if (!settled) {
+        settled = true;
+        resolve(v);
+      }
+    };
+    const all = (): Buffer => Buffer.concat(chunks);
+    const responses = (): [Buffer, Buffer] | [Buffer] => {
+      const buf = all();
+      // Split at the start of the second response's status line.
+      const marker = buf.indexOf('\r\nHTTP/1.1');
+      if (marker < 0) return [buf];
+      return [buf.subarray(0, marker), buf.subarray(marker + 2)];
+    };
+    sock.on('connect', () => {
+      sock.write(firstSegment);
+      setTimeout(() => sock.write(secondSegment), 50);
+    });
+    let responsesComplete = false;
+    sock.on('data', (c) => {
+      chunks.push(c);
+      const text = all().toString('utf8');
+      if (!firstDone && text.endsWith('\r\n0\r\n\r\n')) {
+        firstDone = true;
+        sock.write(secondRawRequest);
+      } else if (firstDone && text.endsWith('\r\n0\r\n\r\n')) {
+        // Both keep-alive responses are in; finish without waiting out the
+        // server's idle keep-alive window.
+        if (!responsesComplete) {
+          responsesComplete = true;
+          sock.end();
+        }
+      }
+    });
+    sock.on('close', () => {
+      const parts = responses();
+      done(parts.length === 2 ? [parts[0], parts[1]] : [parts[0], null]);
+    });
+    sock.on('error', () => {
+      const parts = responses();
+      done(parts.length === 2 ? [parts[0], parts[1]] : [chunks.length ? parts[0] : null, null]);
+    });
+    setTimeout(() => {
+      const parts = responses();
+      done(parts.length === 2 ? [parts[0], parts[1]] : [chunks.length ? parts[0] : null, null]);
+    }, 5_000);
+  });
+}
+
+/** Split an HTTP/1.1 response into status line + de-chunked JSON body. */
+function parseResponse(buf: Buffer | null): { statusLine: string; json: unknown } {
+  if (!buf) return { statusLine: '<no response: socket reset>', json: null };
+  const text = buf.toString('utf8');
+  const [head, ...rest] = text.split('\r\n\r\n');
+  const statusLine = head.split('\r\n')[0];
+  let bodyStr = rest.join('\r\n\r\n');
+  if (/transfer-encoding:\s*chunked/i.test(head)) {
+    let out = Buffer.alloc(0);
+    let raw = Buffer.from(bodyStr, 'utf8');
+    for (;;) {
+      const nl = raw.indexOf('\r\n');
+      if (nl < 0) break;
+      const size = parseInt(raw.subarray(0, nl).toString().split(';')[0], 16);
+      if (!Number.isFinite(size) || size === 0) break;
+      out = Buffer.concat([out, raw.subarray(nl + 2, nl + 2 + size)]);
+      raw = raw.subarray(nl + 2 + size + 2);
+    }
+    bodyStr = out.toString('utf8');
+  }
+  try {
+    return { statusLine, json: JSON.parse(bodyStr) };
+  } catch {
+    return { statusLine, json: null };
+  }
+}
+
+async function withServer(
+  deps: E2eServerDeps,
+  fn: (url: string, target: SocketTarget) => Promise<void>,
+): Promise<void> {
+  const server = new ObservabilityServer(recorder, deps);
+  const { url } = await server.start();
+  try {
+    await fn(url, socketTarget(url));
+  } finally {
+    await server.stop();
+  }
+}
+
+test('split emoji survives on POST /api/e2e/actions/run (GH #818)', async () => {
+  const { deps, calls } = e2eDeps();
+  await withServer(deps, async (_url, target) => {
+    // Body: {"actionId":"a1","params":{"q":"😀"}} with the emoji's four
+    // UTF-8 bytes split across two TCP segments after byte two.
+    const prefix = Buffer.from(`{"actionId":"a1","params":{"q":"`, 'utf8');
+    const suffix = Buffer.from(`"}}`, 'utf8');
+    const body = Buffer.concat([prefix, Buffer.from(EMOJI, 'utf8'), suffix]);
+    assert.equal(body.length, prefix.length + 4 + suffix.length);
+
+    const res = parseResponse(
+      await rawPost(
+        target,
+        Buffer.concat([
+          Buffer.from(
+            `POST /api/e2e/actions/run HTTP/1.1\r\nHost: 127.0.0.1:${target.port}\r\n` +
+              `Content-Type: application/json\r\nx-csrf-token: tok1\r\n` +
+              `Content-Length: ${body.length}\r\n\r\n`,
+            'utf8',
+          ),
+          prefix,
+          Buffer.from([0xf0, 0x9f]),
+        ]),
+        Buffer.concat([Buffer.from([0x98, 0x80]), suffix]),
+      ),
+    );
+    assert.match(res.statusLine, /200/);
+    assert.deepEqual(res.json, { ok: true, actionId: 'a1', params: { q: EMOJI } });
+    assert.equal(calls.action, 1);
+  });
+});
+
+test('split emoji survives on POST /api/e2e/run (GH #818)', async () => {
+  const { deps, calls } = e2eDeps();
+  await withServer(deps, async (_url, target) => {
+    const prefix = Buffer.from(`{"pattern":"`, 'utf8');
+    const suffix = Buffer.from(`"}`, 'utf8');
+    const body = Buffer.concat([prefix, Buffer.from(EMOJI, 'utf8'), suffix]);
+
+    const res = parseResponse(
+      await rawPost(
+        target,
+        Buffer.concat([
+          Buffer.from(
+            `POST /api/e2e/run HTTP/1.1\r\nHost: 127.0.0.1:${target.port}\r\n` +
+              `Content-Type: application/json\r\nx-csrf-token: tok1\r\n` +
+              `Content-Length: ${body.length}\r\n\r\n`,
+            'utf8',
+          ),
+          prefix,
+          Buffer.from([0xf0, 0x9f]),
+        ]),
+        Buffer.concat([Buffer.from([0x98, 0x80]), suffix]),
+      ),
+    );
+    assert.match(res.statusLine, /200/);
+    assert.deepEqual(res.json, { ok: true, data: { pattern: EMOJI } });
+    assert.equal(calls.run, 1);
+  });
+});
+
+test('65537-byte body to POST /api/e2e/actions/run returns JSON 413 without running the action', async () => {
+  const { deps, calls } = e2eDeps();
+  await withServer(deps, async (_url, target) => {
+    const prefix = Buffer.from(`{"actionId":"a1","pad":"`, 'utf8');
+    const suffix = Buffer.from(`"}`, 'utf8');
+    const pad = Buffer.alloc(65_537 - prefix.length - suffix.length, 0x61);
+    const body = Buffer.concat([prefix, pad, suffix]);
+    assert.equal(body.length, 65_537); // exactly one byte over the 64 KiB limit
+
+    const res = parseResponse(
+      await rawPost(
+        target,
+        Buffer.from(
+          `POST /api/e2e/actions/run HTTP/1.1\r\nHost: 127.0.0.1:${target.port}\r\n` +
+            `Content-Type: application/json\r\nx-csrf-token: tok1\r\n` +
+            `Content-Length: ${body.length}\r\n\r\n`,
+          'utf8',
+        ),
+        body,
+      ),
+    );
+    assert.match(res.statusLine, /413/);
+    assert.deepEqual(res.json, { error: 'body too large' });
+    assert.equal(calls.action, 0, 'run handler must not be invoked for oversized bodies');
+  });
+});
+
+test('65537-byte body to POST /api/e2e/run returns JSON 413 without triggering a run', async () => {
+  const { deps, calls } = e2eDeps();
+  await withServer(deps, async (url, target) => {
+    const prefix = Buffer.from(`{"pattern":"`, 'utf8');
+    const suffix = Buffer.from(`"}`, 'utf8');
+    const pad = Buffer.alloc(65_537 - prefix.length - suffix.length, 0x61);
+    const body = Buffer.concat([prefix, pad, suffix]);
+    assert.equal(body.length, 65_537);
+
+    const res = parseResponse(
+      await rawPost(
+        target,
+        Buffer.from(
+          `POST /api/e2e/run HTTP/1.1\r\nHost: 127.0.0.1:${target.port}\r\n` +
+            `Content-Type: application/json\r\nx-csrf-token: tok1\r\n` +
+            `Content-Length: ${body.length}\r\n\r\n`,
+          'utf8',
+        ),
+        body,
+      ),
+    );
+    assert.match(res.statusLine, /413/);
+    assert.deepEqual(res.json, { error: 'body too large' });
+    assert.equal(calls.run, 0, 'run handler must not be invoked for oversized bodies');
+
+    // The SAME connection stays usable for a subsequent request (keep-alive).
+    const [, followUp] = await rawTwoRequests(
+      target,
+      Buffer.from(
+        `POST /api/e2e/run HTTP/1.1\r\nHost: 127.0.0.1:${target.port}\r\n` +
+          `Content-Type: application/json\r\nx-csrf-token: tok1\r\n` +
+          `Content-Length: ${body.length}\r\n\r\n`,
+        'utf8',
+      ),
+      body,
+      Buffer.from(
+        `POST /api/e2e/run HTTP/1.1\r\nHost: 127.0.0.1:${target.port}\r\n` +
+          `Content-Type: application/json\r\nx-csrf-token: tok1\r\n` +
+          `Content-Length: 18\r\n\r\n{"pattern":"next"}`,
+        'utf8',
+      ),
+    );
+    const followUpParsed = parseResponse(followUp);
+    assert.match(
+      followUpParsed.statusLine,
+      /200/,
+      'follow-up request on the same socket must succeed',
+    );
+    assert.deepEqual(followUpParsed.json, { ok: true, data: { pattern: 'next' } });
+  });
+});
+
+test('ASCII bodies still work end-to-end after the GH #818 change', async () => {
+  const { deps, calls } = e2eDeps();
+  await withServer(deps, async (url) => {
+    const r = await fetch(`${url}/api/e2e/run`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-csrf-token': 'tok1' },
+      body: '{"pattern":"smoke"}',
+    });
+    assert.equal(r.status, 200);
+    assert.deepEqual(await r.json(), { ok: true, data: { pattern: 'smoke' } });
+    assert.equal(calls.run, 1);
+  });
+});
+
+test('oversized-but-valid requests keep CSRF and malformed-JSON behavior unchanged', async () => {
+  const { deps } = e2eDeps();
+  await withServer(deps, async (url) => {
+    // No CSRF token → 403 regardless of body size.
+    const csrf = await fetch(`${url}/api/e2e/run`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+    assert.equal(csrf.status, 403);
+
+    // Valid-size malformed JSON → 400.
+    const bad = await fetch(`${url}/api/e2e/run`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-csrf-token': 'tok1' },
+      body: '{not json',
+    });
+    assert.equal(bad.status, 400);
+    assert.deepEqual(await bad.json(), { error: 'invalid json body' });
+  });
+});

--- a/packages/rn-dev-agent-core/test/unit/observability/request-body-utf8-and-413.test.ts
+++ b/packages/rn-dev-agent-core/test/unit/observability/request-body-utf8-and-413.test.ts
@@ -4,27 +4,6 @@ import { test } from 'node:test';
 import { ObservabilityServer, type E2eServerDeps } from '../../../dist/observability/server.js';
 import { recorder } from '../../../dist/observability/recorder.js';
 
-// GH #818 regressions, driven through the real HTTP server over a raw TCP
-// socket so the test controls chunk boundaries exactly:
-//
-//   Defect 1 (initiating trigger): readBody() decoded each Buffer with
-//   per-chunk toString(); the emoji split across writes became U+FFFD
-//   replacement characters. (Masking condition: ASCII-only payloads and
-//   chunk-aligned multi-byte sequences decode fine, so small bodies in a
-//   single TCP segment hid it. Visible symptom: multilingual learned-action
-//   parameters arrive mangled.) Smallest counterfactual — decode with a
-//   streaming StringDecoder and the emoji survives.
-//
-//   Defect 2 (initiating trigger): readBody() called req.destroy() on the
-//   64 KiB overflow before its callers emitted JSON 413, so clients saw a
-//   connection reset instead of the structured error. (Masking condition:
-//   fetch reports a generic network error that looks like any other
-//   transport failure. Visible symptom: no parseable 413 reaches callers.)
-//   Disconfirming evidence checked before committing to this cause: CSRF
-//   (403), malformed-JSON (400), and ASCII paths all behaved correctly on
-//   the same build, and the server itself stayed alive after an oversized
-//   request — only the request socket was destroyed.
-
 const EMOJI = '\u{1F600}'; // U+1F600 = F0 9F 98 80
 
 function e2eDeps(): { deps: E2eServerDeps; calls: { run: number; action: number } } {
@@ -58,7 +37,6 @@ function socketTarget(url: string): SocketTarget {
   return { host: u.hostname, port: Number(u.port) };
 }
 
-/** Raw-socket POST whose body arrives as two TCP segments. */
 function rawPost(
   target: SocketTarget,
   firstSegment: Buffer,
@@ -66,8 +44,6 @@ function rawPost(
 ): Promise<Buffer | null> {
   return new Promise((resolve) => {
     const sock = net.connect(target.port, target.host);
-    // Disable Nagle so the first segment goes out immediately and cannot
-    // coalesce with the second — the split must survive server-side.
     sock.setNoDelay(true);
     const chunks: Buffer[] = [];
     let settled = false;
@@ -91,12 +67,6 @@ function rawPost(
   });
 }
 
-/**
- * Two sequential HTTP/1.1 keep-alive requests on ONE raw socket. Request 1's
- * body arrives as two TCP segments (with Nagle disabled); once its response
- * completes, request 2 (a full raw request buffer) is sent on the same
- * connection. Resolves with each response's raw bytes.
- */
 function rawTwoRequests(
   target: SocketTarget,
   firstSegment: Buffer,
@@ -118,7 +88,6 @@ function rawTwoRequests(
     const all = (): Buffer => Buffer.concat(chunks);
     const responses = (): [Buffer, Buffer] | [Buffer] => {
       const buf = all();
-      // Split at the start of the second response's status line.
       const marker = buf.indexOf('\r\nHTTP/1.1');
       if (marker < 0) return [buf];
       return [buf.subarray(0, marker), buf.subarray(marker + 2)];
@@ -135,8 +104,6 @@ function rawTwoRequests(
         firstDone = true;
         sock.write(secondRawRequest);
       } else if (firstDone && text.endsWith('\r\n0\r\n\r\n')) {
-        // Both keep-alive responses are in; finish without waiting out the
-        // server's idle keep-alive window.
         if (!responsesComplete) {
           responsesComplete = true;
           sock.end();
@@ -158,7 +125,29 @@ function rawTwoRequests(
   });
 }
 
-/** Split an HTTP/1.1 response into status line + de-chunked JSON body. */
+function rawStalledPost(target: SocketTarget, request: Buffer): Promise<Buffer | null> {
+  return new Promise((resolve) => {
+    const sock = net.connect(target.port, target.host);
+    const chunks: Buffer[] = [];
+    let settled = false;
+    const done = (value: Buffer | null) => {
+      if (settled) return;
+      settled = true;
+      sock.destroy();
+      resolve(value);
+    };
+    sock.on('connect', () => sock.write(request));
+    sock.on('data', (chunk) => {
+      chunks.push(chunk);
+      const response = Buffer.concat(chunks);
+      if (response.includes('\r\n0\r\n\r\n')) done(response);
+    });
+    sock.on('close', () => done(chunks.length ? Buffer.concat(chunks) : null));
+    sock.on('error', () => done(chunks.length ? Buffer.concat(chunks) : null));
+    setTimeout(() => done(chunks.length ? Buffer.concat(chunks) : null), 1_000);
+  });
+}
+
 function parseResponse(buf: Buffer | null): { statusLine: string; json: unknown } {
   if (!buf) return { statusLine: '<no response: socket reset>', json: null };
   const text = buf.toString('utf8');
@@ -338,6 +327,30 @@ test('65537-byte body to POST /api/e2e/run returns JSON 413 without triggering a
   });
 });
 
+test('over-limit POST returns JSON 413 before a stalled request ends', async () => {
+  const { deps, calls } = e2eDeps();
+  await withServer(deps, async (_url, target) => {
+    const body = Buffer.alloc(65_537, 0x61);
+    const response = await rawStalledPost(
+      target,
+      Buffer.concat([
+        Buffer.from(
+          `POST /api/e2e/run HTTP/1.1\r\nHost: 127.0.0.1:${target.port}\r\n` +
+            `Content-Type: application/json\r\nx-csrf-token: tok1\r\n` +
+            `Content-Length: ${body.length + 1}\r\n\r\n`,
+          'utf8',
+        ),
+        body,
+      ]),
+    );
+
+    const parsed = parseResponse(response);
+    assert.match(parsed.statusLine, /413/);
+    assert.deepEqual(parsed.json, { error: 'body too large' });
+    assert.equal(calls.run, 0);
+  });
+});
+
 test('ASCII bodies still work end-to-end after the GH #818 change', async () => {
   const { deps, calls } = e2eDeps();
   await withServer(deps, async (url) => {
@@ -355,7 +368,6 @@ test('ASCII bodies still work end-to-end after the GH #818 change', async () => 
 test('oversized-but-valid requests keep CSRF and malformed-JSON behavior unchanged', async () => {
   const { deps } = e2eDeps();
   await withServer(deps, async (url) => {
-    // No CSRF token → 403 regardless of body size.
     const csrf = await fetch(`${url}/api/e2e/run`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -363,7 +375,6 @@ test('oversized-but-valid requests keep CSRF and malformed-JSON behavior unchang
     });
     assert.equal(csrf.status, 403);
 
-    // Valid-size malformed JSON → 400.
     const bad = await fetch(`${url}/api/e2e/run`, {
       method: 'POST',
       headers: { 'content-type': 'application/json', 'x-csrf-token': 'tok1' },


### PR DESCRIPTION
## Intent

Fix GitHub issue Lykhoyda/rn-dev-agent#818: Observe HTTP request bodies corrupted UTF-8 code points split across TCP chunks, and oversized bodies destroyed the socket before callers could read the structured JSON 413. Requirements accepted from the issue and captain: (1) decode request bodies with a streaming decoder so a multi-byte UTF-8 code point split across chunks survives intact; keep the 64 KiB limit BYTE-based, never character-based; (2) once the byte limit is exceeded, stop accumulating, drain the request safely, and return parseable JSON HTTP 413 without invoking action/run handlers; (3) the connection and server must remain usable for a subsequent request; (4) regressions must go through the real HTTP/raw-socket interface against the real ObservabilityServer — an emoji split across two raw socket writes and exactly 65,537-byte bodies submitted to both affected endpoints POST /api/e2e/run and POST /api/e2e/actions/run; (5) preserve ASCII behavior, CSRF handling (403), malformed-JSON responses (400), existing response schemas, and memory bounds; (6) reuse only the existing readBody and endpoint mechanisms — no parallel server, no new authority path, no generalized streaming framework, no unrelated cleanup; (7) changes under core src require a changeset bumping rn-dev-agent-plugin (and rn-dev-agent-core), and committed host plugin bundles must be regenerated via build:host-runtimes. Deliberate decisions already made and approved by firstmate/captain: the fix is committed as 2851014b on branch fm/issue-818 including refreshed host bundle artifacts; codex-pair review ran manually via codex CLI (Pi ask-llm plugin not installed in this session) and its two MEDIUM findings were addressed by disabling Nagle in test helpers for deterministic chunk splits and adding a same-socket keep-alive recovery assertion; the six full-suite failures in migrateLearnedActions/save-as-action tests are pre-existing environment flakiness (file-lock timeouts under this disposable worktree's filesystem) that also fail on the clean base tree — do not treat them as regressions of this change unless the pipeline independently verifies otherwise, and do not skip or weaken any tests to pass them; no simulator/device QA is performed in this run (independent rn-dev-agent-qa verifies on a real simulator after CI green); never use paid credits or another model.

## What Changed

- Decode Observe request bodies with a streaming UTF-8 decoder while retaining the 64 KiB byte-based limit.
- Drain oversized requests without accumulating further data, returning parseable JSON 413 responses promptly without invoking handlers and keeping connections usable.
- Add raw-socket regression coverage for both affected endpoints, plus patch changesets and regenerated Claude/Codex host bundles.

## Risk Assessment

✅ Low: The change is narrowly scoped and satisfies the required streaming UTF-8 decoding, byte-based limit, prompt parseable 413 response, safe draining, handler suppression, keep-alive recovery, changeset, and regenerated host-bundle invariants.

## Testing

No baseline test commands were supplied; targeted regressions and compatibility tests passed, direct raw HTTP evidence demonstrated the required behavior, and regenerated host bundles matched the commit exactly. Simulator/device QA was intentionally excluded per the supplied acceptance scope.

<details>
<summary>Evidence: Real ObservabilityServer raw HTTP evidence</summary>

```text
{
  "server": "real ObservabilityServer over TCP/HTTP",
  "splitUtf8": {
    "splitBoundary": "emoji bytes F0 9F | 98 80 across two socket writes",
    "actionsRun": {
      "requestBodyBytes": 42,
      "status": "HTTP/1.1 200 OK",
      "body": {
        "ok": true,
        "actionId": "proof",
        "params": {
          "q": "😀"
        }
      }
    },
    "e2eRun": {
      "requestBodyBytes": 18,
      "status": "HTTP/1.1 200 OK",
      "body": {
        "ok": true,
        "data": {
          "pattern": "😀"
        }
      }
    }
  },
  "exact65537ByteBodies": {
    "actionsRun": {
      "requestBodyBytes": 65537,
      "status": "HTTP/1.1 413 Payload Too Large",
      "body": {
        "error": "body too large"
      },
      "handlerCallsBefore": 1,
      "handlerCallsAfter": 1
    },
    "e2eRun": {
      "requestBodyBytes": 65537,
      "status": "HTTP/1.1 413 Payload Too Large",
      "body": {
        "error": "body too large"
      },
      "handlerCallsBefore": 1,
      "handlerCallsAfter": 1
    }
  },
  "sameSocketKeepAlive": {
    "firstResponse": {
      "status": "HTTP/1.1 413 Payload Too Large",
      "body": {
        "error": "body too large"
      }
    },
    "subsequentResponse": {
      "status": "HTTP/1.1 200 OK",
      "body": {
        "ok": true,
        "data": {
          "pattern": "same-socket-next"
        }
      }
    }
  },
  "stalledUpload": {
    "declaredBytes": 65538,
    "sentBytes": 65537,
    "responseBeforeRequestEnd": {
      "status": "HTTP/1.1 413 Payload Too Large",
      "body": {
        "error": "body too large"
      }
    },
    "elapsedMs": 2,
    "handlerCallsBefore": 2,
    "handlerCallsAfter": 2
  },
  "compatibility": {
    "ascii": {
      "status": 200,
      "body": {
        "ok": true,
        "data": {
          "pattern": "ascii-smoke"
        }
      }
    },
    "missingCsrf": {
      "status": 403,
      "body": {
        "error": "bad csrf token"
      }
    },
    "malformedJson": {
      "status": 400,
      "body": {
        "error": "invalid json body"
      }
    }
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"249082cc9604d37626a54d220eb8a7602c037f06","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `packages/rn-dev-agent-core/src/observability/server.ts:349` - The 413 is resolved only on `end`. Because `requestTimeout` is disabled, a client can declare a very large body, send 65,537 bytes, then stall indefinitely; the server neither returns 413 nor releases the connection. Resolve as soon as overflow is detected while continuing to drain the request, preserving keep-alive.
- ⚠️ `.changeset/observe-body-utf8-413.md:6` - The changeset body contains two sentences, while this repository requires changesets to be a single sentence because they feed the published changelog. Fold the final test note into the first sentence or remove it.

🔧 Fix: Return stalled oversized-body 413 responses promptly
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `corepack yarn build:core`
- `node --test packages/rn-dev-agent-core/test/unit/observability/request-body-utf8-and-413.test.ts`
- <code>Ran a raw-socket/HTTP evidence harness against the real rebuilt `ObservabilityServer`, covering split UTF-8, exact 65,537-byte bodies on both endpoints, handler suppression, stalled-upload response, and same-socket recovery.</code>
- `node --test packages/rn-dev-agent-core/test/unit/e2e-server-routes.test.js packages/rn-dev-agent-core/test/unit/e2e-server-actions.test.js`
- <code>`corepack yarn build:host-runtimes` followed by `git diff --exit-code` on the four committed Claude/Codex runtime bundles</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR hardens Observe request-body handling while preserving the byte-based 64 KiB limit.
- Uses a streaming UTF-8 decoder so code points split across TCP chunks remain intact.
- Drains oversized requests and returns structured 413 responses without invoking run or action handlers.
- Adds raw-socket coverage for split UTF-8, exact-limit overflow, stalled uploads, and same-connection recovery.
- Adds patch changesets and refreshes the Claude and Codex host runtime bundles.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The changed implementation preserves byte-based limits, safely reconstructs split UTF-8 sequences, suppresses handlers for oversized bodies, and exercises prompt 413 delivery plus same-socket recovery through the real server interface.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/rn-dev-agent-core/src/observability/server.ts | Replaces per-chunk UTF-8 conversion and socket destruction with streaming decoding, byte-based overflow detection, prompt null settlement, and continued draining. |
| packages/rn-dev-agent-core/test/unit/observability/request-body-utf8-and-413.test.ts | Adds real-server raw-socket regressions for split code points, oversized bodies on both endpoints, handler suppression, prompt stalled-upload responses, and keep-alive recovery. |
| .changeset/observe-body-utf8-413.md | Adds patch releases for the core and plugin packages with a concise description of the request-body fix. |
| packages/claude-plugin/rn-dev-agent-core/dist/index.js | Refreshes the committed Claude host runtime bundle to include the core change. |
| packages/claude-plugin/rn-dev-agent-core/dist/supervisor.js | Refreshes the committed Claude supervisor runtime artifact. |
| packages/codex-plugin/rn-dev-agent-core/dist/index.js | Refreshes the committed Codex host runtime bundle to include the core change. |
| packages/codex-plugin/rn-dev-agent-core/dist/supervisor.js | Refreshes the committed Codex supervisor runtime artifact. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Receive request chunk] --> B{Already oversized?}
  B -- Yes --> C[Discard chunk while draining]
  B -- No --> D[Add chunk byte length]
  D --> E{Bytes exceed 65536?}
  E -- Yes --> F[Mark oversized and resolve null]
  F --> G[Endpoint returns JSON 413]
  E -- No --> H[Decode through StringDecoder]
  H --> I{Request ended?}
  I -- No --> A
  I -- Yes --> J[Flush decoder and return body]
  C --> K{Request ended?}
  K -- No --> A
  K -- Yes --> L[Connection remains reusable]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["no-mistakes(review): Return stalled over..."](https://github.com/lykhoyda/rn-dev-agent/commit/249082cc9604d37626a54d220eb8a7602c037f06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56963003)</sub>

<!-- /greptile_comment -->